### PR TITLE
fix(cdc): support quoted Postgres table names

### DIFF
--- a/e2e_test/source_inline/cdc/postgres/postgres_quoted_table_wildcard.slt
+++ b/e2e_test/source_inline/cdc/postgres/postgres_quoted_table_wildcard.slt
@@ -1,0 +1,58 @@
+control substitution on
+
+statement ok
+drop table if exists quoted_note_auto_derived;
+
+statement ok
+drop source if exists quoted_note_source;
+
+system ok
+PGDATABASE=${PGDATABASE:-postgres} psql -c "
+    SELECT pg_drop_replication_slot(slot_name)
+    FROM pg_replication_slots
+    WHERE slot_name = 'quoted_table_wildcard_slot';
+    DROP PUBLICATION IF EXISTS quoted_table_wildcard_pub;
+    DROP TABLE IF EXISTS public.\"QuotedNoteE2e\" CASCADE;
+    CREATE TABLE public.\"QuotedNoteE2e\" (
+        \"id\" text NOT NULL,
+        \"authorId\" text NOT NULL,
+        \"content\" text NOT NULL,
+        CONSTRAINT \"QuotedNoteE2e_pkey\" PRIMARY KEY (\"id\")
+    );
+    INSERT INTO public.\"QuotedNoteE2e\" (\"id\", \"authorId\", \"content\") VALUES ('n1', 'a1', 'hello');
+    "
+
+statement ok
+create source quoted_note_source with (
+    connector = 'postgres-cdc',
+    hostname = '${PGHOST:localhost}',
+    port = '${PGPORT:5432}',
+    username = '${PGUSER:$USER}',
+    password = '${PGPASSWORD:}',
+    database.name = '${PGDATABASE:postgres}',
+    publication.name = 'quoted_table_wildcard_pub',
+    slot.name = 'quoted_table_wildcard_slot'
+);
+
+statement ok
+create table quoted_note_auto_derived (*)
+from quoted_note_source table 'public."QuotedNoteE2e"';
+
+query TTT retry 30 backoff 1s
+select id, "authorId", content from quoted_note_auto_derived order by id;
+----
+n1 a1 hello
+
+statement ok
+drop source quoted_note_source cascade;
+
+sleep 2s
+
+system ok
+PGDATABASE=${PGDATABASE:-postgres} psql -c "
+    SELECT pg_drop_replication_slot(slot_name)
+    FROM pg_replication_slots
+    WHERE slot_name = 'quoted_table_wildcard_slot';
+    DROP PUBLICATION IF EXISTS quoted_table_wildcard_pub;
+    DROP TABLE IF EXISTS public.\"QuotedNoteE2e\" CASCADE;
+    "

--- a/e2e_test/source_inline/cdc/postgres/postgres_quoted_table_wildcard.slt
+++ b/e2e_test/source_inline/cdc/postgres/postgres_quoted_table_wildcard.slt
@@ -8,6 +8,10 @@ drop source if exists quoted_note_source;
 
 system ok
 PGDATABASE=${PGDATABASE:-postgres} psql -c "
+    SELECT pg_terminate_backend(active_pid)
+    FROM pg_replication_slots
+    WHERE slot_name = 'quoted_table_wildcard_slot' AND active_pid IS NOT NULL;
+    SELECT pg_sleep(1);
     SELECT pg_drop_replication_slot(slot_name)
     FROM pg_replication_slots
     WHERE slot_name = 'quoted_table_wildcard_slot';
@@ -30,8 +34,10 @@ create source quoted_note_source with (
     username = '${PGUSER:$USER}',
     password = '${PGPASSWORD:}',
     database.name = '${PGDATABASE:postgres}',
+    schema.name = 'public',
     publication.name = 'quoted_table_wildcard_pub',
-    slot.name = 'quoted_table_wildcard_slot'
+    slot.name = 'quoted_table_wildcard_slot',
+    auto.schema.change = 'true'
 );
 
 statement ok
@@ -43,6 +49,29 @@ select id, "authorId", content from quoted_note_auto_derived order by id;
 ----
 n1 a1 hello
 
+system ok
+PGDATABASE=${PGDATABASE:-postgres} psql -c "
+    INSERT INTO public.\"QuotedNoteE2e\" (\"id\", \"authorId\", \"content\") VALUES ('n2', 'a2', 'stream');
+    "
+
+query TTT retry 30 backoff 1s
+select id, "authorId", content from quoted_note_auto_derived where id = 'n2';
+----
+n2 a2 stream
+
+sleep 2s
+
+system ok
+PGDATABASE=${PGDATABASE:-postgres} psql -c "
+    ALTER TABLE public.\"QuotedNoteE2e\" ADD COLUMN \"category\" varchar DEFAULT 'general';
+    INSERT INTO public.\"QuotedNoteE2e\" (\"id\", \"authorId\", \"content\", \"category\") VALUES ('n3', 'a3', 'schema-change', 'custom');
+    "
+
+query TTTT retry 30 backoff 1s
+select id, "authorId", content, category from quoted_note_auto_derived where id = 'n3';
+----
+n3 a3 schema-change custom
+
 statement ok
 drop source quoted_note_source cascade;
 
@@ -50,9 +79,107 @@ sleep 2s
 
 system ok
 PGDATABASE=${PGDATABASE:-postgres} psql -c "
+    SELECT pg_terminate_backend(active_pid)
+    FROM pg_replication_slots
+    WHERE slot_name = 'quoted_table_wildcard_slot' AND active_pid IS NOT NULL;
+    SELECT pg_sleep(1);
     SELECT pg_drop_replication_slot(slot_name)
     FROM pg_replication_slots
     WHERE slot_name = 'quoted_table_wildcard_slot';
     DROP PUBLICATION IF EXISTS quoted_table_wildcard_pub;
     DROP TABLE IF EXISTS public.\"QuotedNoteE2e\" CASCADE;
+    "
+
+statement ok
+drop table if exists pg_my_table_explicit;
+
+statement ok
+drop source if exists pg_my_table_source;
+
+system ok
+PGDATABASE=${PGDATABASE:-postgres} psql -c "
+    SELECT pg_terminate_backend(active_pid)
+    FROM pg_replication_slots
+    WHERE slot_name = 'quoted_table_explicit_slot' AND active_pid IS NOT NULL;
+    SELECT pg_sleep(1);
+    SELECT pg_drop_replication_slot(slot_name)
+    FROM pg_replication_slots
+    WHERE slot_name = 'quoted_table_explicit_slot';
+    DROP PUBLICATION IF EXISTS quoted_table_explicit_pub;
+    DROP TABLE IF EXISTS public.\"pg_my_table\" CASCADE;
+    CREATE TABLE public.\"pg_my_table\" (
+        id INT PRIMARY KEY,
+        \"name\" VARCHAR
+    );
+    INSERT INTO public.\"pg_my_table\" VALUES
+        (1, 'aa'), (2, 'bb'), (3, '33'), (4, '44'),
+        (5, '55'), (6, '66'), (7, '77'), (8, '88'),
+        (9, '99'), (10, '1010'), (11, '1111'), (12, '1212');
+    "
+
+statement ok
+create source pg_my_table_source with (
+    connector = 'postgres-cdc',
+    hostname = '${PGHOST:localhost}',
+    port = '${PGPORT:5432}',
+    username = '${PGUSER:$USER}',
+    password = '${PGPASSWORD:}',
+    database.name = '${PGDATABASE:postgres}',
+    schema.name = 'public',
+    publication.name = 'quoted_table_explicit_pub',
+    slot.name = 'quoted_table_explicit_slot',
+    auto.schema.change = 'true'
+);
+
+statement ok
+create table pg_my_table_explicit (
+    id INT PRIMARY KEY,
+    "name" VARCHAR
+)
+from pg_my_table_source table 'public."pg_my_table"';
+
+query I retry 30 backoff 1s
+select count(*) from pg_my_table_explicit;
+----
+12
+
+system ok
+PGDATABASE=${PGDATABASE:-postgres} psql -c "
+    INSERT INTO public.\"pg_my_table\" VALUES (1000, 'aa');
+    "
+
+query IT retry 30 backoff 1s
+select id, "name" from pg_my_table_explicit where id = 1000;
+----
+1000 aa
+
+sleep 2s
+
+system ok
+PGDATABASE=${PGDATABASE:-postgres} psql -c "
+    ALTER TABLE public.\"pg_my_table\" ADD COLUMN tag VARCHAR DEFAULT 'general';
+    INSERT INTO public.\"pg_my_table\" (id, \"name\", tag) VALUES (1001, 'bb', 'schema-change');
+    "
+
+query ITT retry 30 backoff 1s
+select id, "name", tag from pg_my_table_explicit where id = 1001;
+----
+1001 bb schema-change
+
+statement ok
+drop source pg_my_table_source cascade;
+
+sleep 2s
+
+system ok
+PGDATABASE=${PGDATABASE:-postgres} psql -c "
+    SELECT pg_terminate_backend(active_pid)
+    FROM pg_replication_slots
+    WHERE slot_name = 'quoted_table_explicit_slot' AND active_pid IS NOT NULL;
+    SELECT pg_sleep(1);
+    SELECT pg_drop_replication_slot(slot_name)
+    FROM pg_replication_slots
+    WHERE slot_name = 'quoted_table_explicit_slot';
+    DROP PUBLICATION IF EXISTS quoted_table_explicit_pub;
+    DROP TABLE IF EXISTS public.\"pg_my_table\" CASCADE;
     "

--- a/src/connector/src/connector_common/postgres.rs
+++ b/src/connector/src/connector_common/postgres.rs
@@ -38,11 +38,17 @@ use crate::sink::postgres::TcpKeepaliveConfig;
 
 /// SQL query to discover primary key columns directly from PostgreSQL system tables.
 /// This bypasses querying `information_schema.table_constraints` to avoid permission issues.
+/// Match `pg_class` and `pg_namespace` by exact catalog names instead of casting a
+/// constructed string to `regclass`, as unquoted `regclass` input folds mixed-case
+/// table names to lower case.
 const DISCOVER_PRIMARY_KEY_QUERY: &str = r#"
     SELECT a.attname as column_name
     FROM pg_index i
+    JOIN pg_class c ON c.oid = i.indrelid
+    JOIN pg_namespace n ON n.oid = c.relnamespace
     JOIN pg_attribute a ON a.attrelid = i.indrelid AND a.attnum = ANY(i.indkey)
-    WHERE i.indrelid = ($1 || '.' || $2)::regclass
+    WHERE n.nspname = $1
+      AND c.relname = $2
       AND i.indisprimary = true
     ORDER BY array_position(i.indkey, a.attnum)
 "#;

--- a/src/connector/src/source/cdc/mod.rs
+++ b/src/connector/src/source/cdc/mod.rs
@@ -69,6 +69,22 @@ pub fn build_cdc_table_id(source_id: SourceId, external_table_name: &str) -> Str
     format!("{}.{}", source_id, external_table_name)
 }
 
+pub fn normalize_simple_postgres_quoted_table_name(table_name: &str) -> Option<String> {
+    let (schema_name, table_name) = table_name.split_once('.')?;
+    let table_name = table_name.strip_prefix('"')?.strip_suffix('"')?;
+    if schema_name.is_empty()
+        || table_name.is_empty()
+        || table_name.contains('.')
+        || table_name.contains('"')
+        || table_name.contains('\\')
+        || schema_name.contains('"')
+    {
+        return None;
+    }
+
+    Some(format!("{schema_name}.{table_name}"))
+}
+
 pub trait CdcSourceTypeTrait: Send + Sync + Clone + std::fmt::Debug + 'static {
     const CDC_CONNECTOR_NAME: &'static str;
     fn source_type() -> CdcSourceType;
@@ -349,5 +365,38 @@ impl CdcScanOptions {
         !self.disable_backfill
             && self.backfill_num_rows_per_split > 0
             && self.backfill_parallelism > 0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_normalize_simple_postgres_quoted_table_name() {
+        assert_eq!(
+            normalize_simple_postgres_quoted_table_name(r#"public."TableName""#).as_deref(),
+            Some("public.TableName")
+        );
+        assert_eq!(
+            normalize_simple_postgres_quoted_table_name(r#"public."pg_my_table""#).as_deref(),
+            Some("public.pg_my_table")
+        );
+        assert_eq!(
+            normalize_simple_postgres_quoted_table_name("public.table"),
+            None
+        );
+        assert_eq!(
+            normalize_simple_postgres_quoted_table_name(r#""Mixed.Schema"."TableName""#),
+            None
+        );
+        assert_eq!(
+            normalize_simple_postgres_quoted_table_name(r#"public."table.name""#),
+            None
+        );
+        assert_eq!(
+            normalize_simple_postgres_quoted_table_name(r#"public."table\name""#),
+            None
+        );
     }
 }

--- a/src/frontend/src/handler/create_table.rs
+++ b/src/frontend/src/handler/create_table.rs
@@ -1021,13 +1021,12 @@ fn derive_with_options_for_cdc_table(
                 return Ok((with_options, external_table_name));
             }
             POSTGRES_CDC_CONNECTOR => {
-                let (schema_name, table_name) = external_table_name
-                    .split_once('.')
-                    .ok_or_else(|| anyhow!("The upstream table name must contain schema name prefix, e.g. 'public.table'"))?;
+                let (schema_name, table_name) =
+                    parse_postgres_cdc_external_table_name(&external_table_name)?;
 
                 // insert 'schema.name' into connect properties
-                with_options.insert(SCHEMA_NAME_KEY.into(), schema_name.into());
-                with_options.insert(TABLE_NAME_KEY.into(), table_name.into());
+                with_options.insert(SCHEMA_NAME_KEY.into(), schema_name);
+                with_options.insert(TABLE_NAME_KEY.into(), table_name);
                 // Return original external_table_name unchanged for Postgres
                 return Ok((with_options, external_table_name));
             }
@@ -1104,6 +1103,84 @@ fn derive_with_options_for_cdc_table(
         };
     }
     unreachable!("All valid CDC connectors should have returned by now")
+}
+
+/// Parse the schema/table name from the CDC `TABLE` clause.
+///
+/// Column names do not need the same parsing here: wildcard schema derivation reads
+/// them from PostgreSQL catalogs after the exact table has been identified.
+fn parse_postgres_cdc_external_table_name(external_table_name: &str) -> Result<(String, String)> {
+    let mut parts = vec![];
+    let mut current = String::new();
+    let mut chars = external_table_name.chars().peekable();
+    let mut in_quote = false;
+    let mut just_closed_quote = false;
+
+    while let Some(ch) = chars.next() {
+        if in_quote {
+            if ch == '"' {
+                if chars.peek() == Some(&'"') {
+                    current.push('"');
+                    chars.next();
+                } else {
+                    in_quote = false;
+                    just_closed_quote = true;
+                }
+            } else {
+                current.push(ch);
+            }
+        } else {
+            match ch {
+                '.' => {
+                    if current.is_empty() {
+                        return Err(anyhow!(
+                            "Invalid Postgres CDC table name '{}'. Expected 'schema.table'.",
+                            external_table_name
+                        )
+                        .into());
+                    }
+                    parts.push(std::mem::take(&mut current));
+                    just_closed_quote = false;
+                }
+                '"' if current.is_empty() => {
+                    in_quote = true;
+                }
+                '"' => {
+                    return Err(anyhow!(
+                        "Invalid Postgres CDC table name '{}'. Expected 'schema.table'.",
+                        external_table_name
+                    )
+                    .into());
+                }
+                _ if just_closed_quote => {
+                    return Err(anyhow!(
+                        "Invalid Postgres CDC table name '{}'. Expected 'schema.table'.",
+                        external_table_name
+                    )
+                    .into());
+                }
+                _ => current.push(ch),
+            }
+        }
+    }
+
+    if in_quote || current.is_empty() {
+        return Err(anyhow!(
+            "Invalid Postgres CDC table name '{}'. Expected 'schema.table'.",
+            external_table_name
+        )
+        .into());
+    }
+    parts.push(current);
+
+    if let [schema_name, table_name] = parts.as_slice() {
+        Ok((schema_name.clone(), table_name.clone()))
+    } else {
+        Err(
+            anyhow!("The upstream table name must contain schema name prefix, e.g. 'public.table'")
+                .into(),
+        )
+    }
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -2985,6 +3062,39 @@ mod tests {
                 .contains("only NULL column option is supported for webhook tables"),
             "{err:?}"
         );
+    }
+
+    #[test]
+    fn test_parse_postgres_cdc_external_table_name() {
+        for (input, expected) in [
+            ("public.Note", ("public", "Note")),
+            ("public.\"Note\"", ("public", "Note")),
+            (
+                "\"Mixed.Schema\".\"Note.Table\"",
+                ("Mixed.Schema", "Note.Table"),
+            ),
+            ("public.\"Note\"\"Archive\"", ("public", "Note\"Archive")),
+        ] {
+            assert_eq!(
+                parse_postgres_cdc_external_table_name(input).unwrap(),
+                (expected.0.to_owned(), expected.1.to_owned()),
+                "input: {input}"
+            );
+        }
+
+        for input in [
+            "Note",
+            "public.",
+            ".Note",
+            "public.\"Note",
+            "public.\"Note\"Archive",
+            "public.Note.Archive",
+        ] {
+            assert!(
+                parse_postgres_cdc_external_table_name(input).is_err(),
+                "input should be rejected: {input}"
+            );
+        }
     }
 
     #[test]

--- a/src/frontend/src/handler/create_table.rs
+++ b/src/frontend/src/handler/create_table.rs
@@ -36,10 +36,12 @@ use risingwave_common::util::sort_util::{ColumnOrder, OrderType};
 use risingwave_common::util::value_encoding::DatumToProtoExt;
 use risingwave_common::{bail, bail_not_implemented};
 use risingwave_connector::sink::decouple_checkpoint_log_sink::COMMIT_CHECKPOINT_INTERVAL;
-use risingwave_connector::source::cdc::build_cdc_table_id;
 use risingwave_connector::source::cdc::external::{
     DATABASE_NAME_KEY, ExternalCdcTableType, ExternalTableConfig, ExternalTableImpl,
     SCHEMA_NAME_KEY, TABLE_NAME_KEY,
+};
+use risingwave_connector::source::cdc::{
+    build_cdc_table_id, normalize_simple_postgres_quoted_table_name,
 };
 use risingwave_connector::{
     AUTO_SCHEMA_CHANGE_KEY, WithOptionsSecResolved, WithPropertiesExt, source,
@@ -943,7 +945,15 @@ pub(crate) fn gen_create_table_plan_for_cdc_table(
         vec![],
     );
 
-    let cdc_table_id = build_cdc_table_id(source.id, &external_table_name);
+    let cdc_table_id_external_table_name = if let ExternalCdcTableType::Postgres = cdc_table_type
+        && let Some(normalized_table_name) =
+            normalize_simple_postgres_quoted_table_name(&external_table_name)
+    {
+        normalized_table_name
+    } else {
+        external_table_name
+    };
+    let cdc_table_id = build_cdc_table_id(source.id, &cdc_table_id_external_table_name);
     let materialize = plan_root.gen_table_plan(
         context,
         resolved_table_name,

--- a/src/frontend/src/optimizer/plan_node/stream_cdc_table_scan.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_cdc_table_scan.rs
@@ -17,6 +17,7 @@ use pretty_xmlish::{Pretty, XmlNode};
 use risingwave_common::catalog::{ColumnCatalog, Field};
 use risingwave_common::types::DataType;
 use risingwave_common::util::sort_util::OrderType;
+use risingwave_connector::source::cdc::normalize_simple_postgres_quoted_table_name;
 use risingwave_pb::stream_plan::PbStreamNode;
 use risingwave_pb::stream_plan::stream_node::{PbNodeBody, PbStreamKind};
 
@@ -295,17 +296,42 @@ impl StreamCdcTableScan {
 
     // The filter node receive input chunks in `(payload, _rw_offset, _rw_table_name)` schema
     pub fn build_cdc_filter_expr(cdc_table_name: &str) -> ExprImpl {
-        // filter by the `_rw_table_name` column
-        FunctionCall::new(
-            ExprType::Equal,
-            vec![
-                InputRef::new(2, DataType::Varchar).into(),
-                ExprImpl::literal_varchar(cdc_table_name.into()),
-            ],
-        )
-        .unwrap()
-        .into()
+        let table_name_ref: ExprImpl = InputRef::new(2, DataType::Varchar).into();
+        let mut filter_expr = build_cdc_table_name_eq_expr(table_name_ref.clone(), cdc_table_name);
+
+        if let Some(compat_table_name) = normalize_simple_postgres_quoted_table_name(cdc_table_name)
+        {
+            // The left branch keeps matching the catalog/user-facing table name stored in
+            // `ExternalTableDesc`, e.g. `public."TableName"`. The right branch matches the
+            // Debezium runtime routing key carried in `_rw_table_name`, e.g. `public.TableName`.
+            // See `DbzChangeEventConsumer` for deriving the runtime table name from Debezium
+            // topics, and `DebeziumCdcMeta::extract_table_name` for how `_rw_table_name` is
+            // populated from that runtime name.
+            filter_expr = FunctionCall::new(
+                ExprType::Or,
+                vec![
+                    filter_expr,
+                    build_cdc_table_name_eq_expr(table_name_ref, &compat_table_name),
+                ],
+            )
+            .unwrap()
+            .into();
+        }
+
+        filter_expr
     }
+}
+
+fn build_cdc_table_name_eq_expr(table_name_ref: ExprImpl, cdc_table_name: &str) -> ExprImpl {
+    FunctionCall::new(
+        ExprType::Equal,
+        vec![
+            table_name_ref,
+            ExprImpl::literal_varchar(cdc_table_name.into()),
+        ],
+    )
+    .unwrap()
+    .into()
 }
 
 impl ExprRewritable<Stream> for StreamCdcTableScan {
@@ -372,5 +398,25 @@ mod tests {
             filter_expr.eval_row(&row3).await.unwrap(),
             Some(ScalarImpl::Bool(true))
         )
+    }
+
+    #[tokio::test]
+    async fn test_cdc_filter_expr_postgres_quoted_table_name_compat() {
+        let row_with_unquoted_schema_table =
+            OwnedRow::new(vec![None, None, Some("public.QuotedNoteE2e".into())]);
+        let row_with_other_table = OwnedRow::new(vec![None, None, Some("public.other".into())]);
+
+        let filter_expr = StreamCdcTableScan::build_cdc_filter_expr(r#"public."QuotedNoteE2e""#);
+        assert_eq!(
+            filter_expr
+                .eval_row(&row_with_unquoted_schema_table)
+                .await
+                .unwrap(),
+            Some(ScalarImpl::Bool(true))
+        );
+        assert_eq!(
+            filter_expr.eval_row(&row_with_other_table).await.unwrap(),
+            Some(ScalarImpl::Bool(false))
+        );
     }
 }


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

This PR fixes PostgreSQL CDC handling for upstream tables referenced with quoted PostgreSQL identifiers, for example:

```sql
CREATE TABLE note (*)
FROM pg_src TABLE 'public."Note"';
```

Previously the frontend split the Postgres CDC table path with `split_once('.')` and passed the quoted string `"Note"` as the connector `table.name`. Column discovery then looked for a PostgreSQL catalog table literally named `"Note"`, while primary-key discovery could still resolve the quoted name through `regclass`, producing `pk_names = ["id"]` without matching columns and failing with `column "id" named in key does not exist`.

This PR fixes that by:

- Parsing PostgreSQL CDC `TABLE` names with double-quoted identifier support for schema discovery.
- Storing exact PostgreSQL catalog names in `schema.name` and `table.name`.
- Changing PostgreSQL primary-key discovery to match `pg_namespace.nspname` and `pg_class.relname` exactly instead of relying on `regclass`, which can fold mixed-case identifiers.
- Keeping the external table name unchanged for validation/backfill SQL, while normalizing the CDC table id for simple `schema."TableName"` names so auto schema change can match Debezium's runtime table id.
- Making the CDC filter accept both the catalog/user-facing name, e.g. `public."TableName"`, and Debezium runtime `_rw_table_name`, e.g. `public.TableName`, for the narrow simple quoted Postgres table pattern.

Covered cases:

- Wildcard schema derivation from `public."QuotedNoteE2e"` with mixed-case column `"authorId"`.
- Streaming insert after `CREATE TABLE ... FROM ... TABLE 'public."QuotedNoteE2e"'`.
- Auto schema change after adding a new column on `public."QuotedNoteE2e"`.
- Explicit-column table creation from reviewer case `public."pg_my_table"` with `auto.schema.change = 'true'`.
- Streaming insert after explicit-column table creation for `public."pg_my_table"`.
- Auto schema change after adding a new column on `public."pg_my_table"`.

Local verification:

```text
cargo test -p risingwave_frontend test_cdc_filter_expr
cargo test -p risingwave_connector test_normalize_simple_postgres_quoted_table_name
./risedev slt-clean './e2e_test/source_inline/cdc/postgres/postgres_quoted_table_wildcard.slt' && ./risedev slt './e2e_test/source_inline/cdc/postgres/postgres_quoted_table_wildcard.slt'
cargo clippy --all-targets --all-features
```

`cargo clippy` only reports the existing `rquickjs-core` future-incompatibility note.

## Checklist

- [x] I have written necessary rustdoc comments.
- [x] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [x] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

PostgreSQL CDC tables can now derive schemas, consume streaming changes, and apply auto schema changes for upstream tables referenced with simple quoted PostgreSQL identifiers, such as `TABLE 'public."Note"'`.

</details>
