### PR TITLE
fix(iceberg): seperate iceberg snapshot expiration and compaction trigger

### DIFF
--- a/src/connector/src/connector_common/iceberg/compaction.rs
+++ b/src/connector/src/connector_common/iceberg/compaction.rs
@@ -17,5 +17,7 @@ use crate::sink::catalog::SinkId;
 pub struct IcebergSinkCompactionUpdate {
     // runtime event information
     pub sink_id: SinkId,
+    pub enable_compaction: bool,
+    pub enable_snapshot_expiration: bool,
     pub force_compaction: bool,
 }

--- a/src/connector/src/connector_common/iceberg/compaction.rs
+++ b/src/connector/src/connector_common/iceberg/compaction.rs
@@ -17,7 +17,5 @@ use crate::sink::catalog::SinkId;
 pub struct IcebergSinkCompactionUpdate {
     // runtime event information
     pub sink_id: SinkId,
-    pub enable_compaction: bool,
-    pub enable_snapshot_expiration: bool,
     pub force_compaction: bool,
 }

--- a/src/connector/src/sink/iceberg/commit.rs
+++ b/src/connector/src/sink/iceberg/commit.rs
@@ -616,10 +616,11 @@ impl IcebergSinkCommitter {
         tracing::debug!("Succeeded to commit to iceberg table in epoch {epoch}.");
 
         if let Some(iceberg_compact_stat_sender) = &self.iceberg_compact_stat_sender
-            && self.config.enable_compaction
             && iceberg_compact_stat_sender
                 .send(IcebergSinkCompactionUpdate {
                     sink_id: self.sink_id,
+                    enable_compaction: self.config.enable_compaction,
+                    enable_snapshot_expiration: self.config.enable_snapshot_expiration,
                     force_compaction: false,
                 })
                 .is_err()
@@ -867,6 +868,8 @@ impl IcebergSinkCommitter {
                     && iceberg_compact_stat_sender
                         .send(IcebergSinkCompactionUpdate {
                             sink_id: self.sink_id,
+                            enable_compaction: self.config.enable_compaction,
+                            enable_snapshot_expiration: self.config.enable_snapshot_expiration,
                             force_compaction: true,
                         })
                         .is_err()

--- a/src/connector/src/sink/iceberg/commit.rs
+++ b/src/connector/src/sink/iceberg/commit.rs
@@ -619,8 +619,6 @@ impl IcebergSinkCommitter {
             && iceberg_compact_stat_sender
                 .send(IcebergSinkCompactionUpdate {
                     sink_id: self.sink_id,
-                    enable_compaction: self.config.enable_compaction,
-                    enable_snapshot_expiration: self.config.enable_snapshot_expiration,
                     force_compaction: false,
                 })
                 .is_err()
@@ -868,8 +866,6 @@ impl IcebergSinkCommitter {
                     && iceberg_compact_stat_sender
                         .send(IcebergSinkCompactionUpdate {
                             sink_id: self.sink_id,
-                            enable_compaction: self.config.enable_compaction,
-                            enable_snapshot_expiration: self.config.enable_snapshot_expiration,
                             force_compaction: true,
                         })
                         .is_err()

--- a/src/meta/service/src/ddl_service.rs
+++ b/src/meta/service/src/ddl_service.rs
@@ -488,6 +488,8 @@ impl DdlService for DdlServiceImpl {
         self.sink_manager
             .stop_sink_coordinator(vec![SinkId::from(sink_id)])
             .await;
+        self.iceberg_compaction_manager
+            .clear_iceberg_maintenance_by_sink_id(SinkId::from(sink_id));
 
         Ok(Response::new(DropSinkResponse {
             status: None,

--- a/src/meta/src/manager/iceberg_compaction/gc.rs
+++ b/src/meta/src/manager/iceberg_compaction/gc.rs
@@ -57,7 +57,11 @@ impl IcebergCompactionManager {
     async fn perform_gc_operations(&self) -> MetaResult<()> {
         let sink_ids = {
             let guard = self.inner.read();
-            guard.sink_schedules.keys().cloned().collect::<Vec<_>>()
+            guard
+                .snapshot_expiration_sink_ids
+                .iter()
+                .cloned()
+                .collect::<Vec<_>>()
         };
 
         tracing::info!("Starting GC operations for {} tables", sink_ids.len());
@@ -78,6 +82,8 @@ impl IcebergCompactionManager {
 
         let iceberg_config = self.load_iceberg_config(sink_id).await?;
         if !iceberg_config.enable_snapshot_expiration {
+            let mut guard = self.inner.write();
+            guard.snapshot_expiration_sink_ids.remove(&sink_id);
             return Ok(());
         }
 

--- a/src/meta/src/manager/iceberg_compaction/mod.rs
+++ b/src/meta/src/manager/iceberg_compaction/mod.rs
@@ -17,7 +17,7 @@ mod manual;
 mod schedule;
 mod stream;
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -64,6 +64,7 @@ pub struct IcebergCompactionManager {
 
 struct IcebergCompactionManagerInner {
     sink_schedules: HashMap<SinkId, CompactionTrack>,
+    snapshot_expiration_sink_ids: HashSet<SinkId>,
     manual_task_waiters: HashMap<u64, ManualTaskWaiter>,
 }
 
@@ -89,6 +90,7 @@ impl IcebergCompactionManager {
                 env,
                 inner: Arc::new(RwLock::new(IcebergCompactionManagerInner {
                     sink_schedules: HashMap::default(),
+                    snapshot_expiration_sink_ids: HashSet::default(),
                     manual_task_waiters: HashMap::default(),
                 })),
                 metadata_manager,

--- a/src/meta/src/manager/iceberg_compaction/schedule.rs
+++ b/src/meta/src/manager/iceberg_compaction/schedule.rs
@@ -388,8 +388,6 @@ impl SinkUpdateKind {
 struct PreparedSinkUpdate {
     sink_id: SinkId,
     kind: SinkUpdateKind,
-    enable_compaction: bool,
-    enable_snapshot_expiration: bool,
     now: Instant,
     allow_track_initialization: bool,
     loaded_config: Option<IcebergConfig>,
@@ -436,8 +434,6 @@ impl IcebergCompactionManager {
     ) -> PreparedSinkUpdate {
         let IcebergSinkCompactionUpdate {
             sink_id,
-            enable_compaction,
-            enable_snapshot_expiration,
             force_compaction,
         } = msg;
         let kind = if force_compaction {
@@ -473,8 +469,6 @@ impl IcebergCompactionManager {
         PreparedSinkUpdate {
             sink_id,
             kind,
-            enable_compaction,
-            enable_snapshot_expiration,
             now,
             allow_track_initialization,
             loaded_config,
@@ -489,23 +483,23 @@ impl IcebergCompactionManager {
         let PreparedSinkUpdate {
             sink_id,
             kind,
-            enable_compaction,
-            enable_snapshot_expiration,
             now,
             allow_track_initialization,
             loaded_config,
         } = prepared_update;
         let refresh_interval = self.config_refresh_interval();
 
-        if enable_snapshot_expiration {
-            guard.snapshot_expiration_sink_ids.insert(sink_id);
-        } else {
-            guard.snapshot_expiration_sink_ids.remove(&sink_id);
-        }
+        if let Some(config) = loaded_config.as_ref() {
+            if config.enable_snapshot_expiration {
+                guard.snapshot_expiration_sink_ids.insert(sink_id);
+            } else {
+                guard.snapshot_expiration_sink_ids.remove(&sink_id);
+            }
 
-        if !enable_compaction {
-            guard.sink_schedules.remove(&sink_id);
-            return;
+            if !config.enable_compaction {
+                guard.sink_schedules.remove(&sink_id);
+                return;
+            }
         }
 
         match guard.sink_schedules.entry(sink_id) {

--- a/src/meta/src/manager/iceberg_compaction/schedule.rs
+++ b/src/meta/src/manager/iceberg_compaction/schedule.rs
@@ -388,6 +388,8 @@ impl SinkUpdateKind {
 struct PreparedSinkUpdate {
     sink_id: SinkId,
     kind: SinkUpdateKind,
+    enable_compaction: bool,
+    enable_snapshot_expiration: bool,
     now: Instant,
     allow_track_initialization: bool,
     loaded_config: Option<IcebergConfig>,
@@ -434,6 +436,8 @@ impl IcebergCompactionManager {
     ) -> PreparedSinkUpdate {
         let IcebergSinkCompactionUpdate {
             sink_id,
+            enable_compaction,
+            enable_snapshot_expiration,
             force_compaction,
         } = msg;
         let kind = if force_compaction {
@@ -469,6 +473,8 @@ impl IcebergCompactionManager {
         PreparedSinkUpdate {
             sink_id,
             kind,
+            enable_compaction,
+            enable_snapshot_expiration,
             now,
             allow_track_initialization,
             loaded_config,
@@ -483,11 +489,24 @@ impl IcebergCompactionManager {
         let PreparedSinkUpdate {
             sink_id,
             kind,
+            enable_compaction,
+            enable_snapshot_expiration,
             now,
             allow_track_initialization,
             loaded_config,
         } = prepared_update;
         let refresh_interval = self.config_refresh_interval();
+
+        if enable_snapshot_expiration {
+            guard.snapshot_expiration_sink_ids.insert(sink_id);
+        } else {
+            guard.snapshot_expiration_sink_ids.remove(&sink_id);
+        }
+
+        if !enable_compaction {
+            guard.sink_schedules.remove(&sink_id);
+            return;
+        }
 
         match guard.sink_schedules.entry(sink_id) {
             Entry::Occupied(entry) => {
@@ -600,9 +619,10 @@ impl IcebergCompactionManager {
             .collect()
     }
 
-    pub fn clear_iceberg_commits_by_sink_id(&self, sink_id: SinkId) {
+    pub fn clear_iceberg_maintenance_by_sink_id(&self, sink_id: SinkId) {
         let mut guard = self.inner.write();
         guard.sink_schedules.remove(&sink_id);
+        guard.snapshot_expiration_sink_ids.remove(&sink_id);
     }
 
     pub fn list_compaction_statuses(&self) -> Vec<IcebergCompactionScheduleStatus> {

--- a/src/meta/src/manager/iceberg_compaction/schedule/tests.rs
+++ b/src/meta/src/manager/iceberg_compaction/schedule/tests.rs
@@ -101,6 +101,7 @@ fn new_test_iceberg_config(
         }
         .to_owned(),
     );
+    values.insert("enable_compaction".to_owned(), "true".to_owned());
 
     IcebergConfig::from_btreemap(values).unwrap()
 }
@@ -391,8 +392,6 @@ async fn test_apply_sink_update_refreshes_existing_idle_track() {
         PreparedSinkUpdate {
             sink_id,
             kind: SinkUpdateKind::Commit,
-            enable_compaction: true,
-            enable_snapshot_expiration: false,
             now: refresh_at,
             allow_track_initialization: false,
             loaded_config: Some(config),
@@ -423,8 +422,6 @@ async fn test_update_iceberg_commit_info_skips_missing_track_on_load_failure() {
     manager
         .update_iceberg_commit_info(IcebergSinkCompactionUpdate {
             sink_id,
-            enable_compaction: true,
-            enable_snapshot_expiration: false,
             force_compaction: false,
         })
         .await;
@@ -446,8 +443,6 @@ async fn test_update_iceberg_commit_info_refresh_failure_keeps_refresh_deadline_
     manager
         .update_iceberg_commit_info(IcebergSinkCompactionUpdate {
             sink_id,
-            enable_compaction: true,
-            enable_snapshot_expiration: false,
             force_compaction: false,
         })
         .await;
@@ -477,8 +472,6 @@ async fn test_apply_sink_update_creates_missing_track() {
         PreparedSinkUpdate {
             sink_id,
             kind: SinkUpdateKind::Commit,
-            enable_compaction: true,
-            enable_snapshot_expiration: false,
             now,
             allow_track_initialization: true,
             loaded_config: Some(config),
@@ -492,6 +485,35 @@ async fn test_apply_sink_update_creates_missing_track() {
     assert_eq!(track.pending_commit_count, 1);
     assert_eq!(track.last_config_refresh_at, now);
     assert!(matches!(track.state, CompactionTrackState::Idle { .. }));
+}
+
+#[tokio::test]
+async fn test_apply_sink_update_tracks_snapshot_expiration_without_compaction() {
+    let manager = build_test_manager().await;
+    let sink_id = SinkId::new(144);
+    let now = Instant::now();
+    let mut config = new_test_iceberg_config(300, 3, CompactionType::SmallFiles);
+    config.enable_compaction = false;
+    config.enable_snapshot_expiration = true;
+    let mut guard = IcebergCompactionManagerInner {
+        sink_schedules: HashMap::new(),
+        snapshot_expiration_sink_ids: HashSet::new(),
+        manual_task_waiters: HashMap::new(),
+    };
+
+    manager.apply_sink_update(
+        &mut guard,
+        PreparedSinkUpdate {
+            sink_id,
+            kind: SinkUpdateKind::Commit,
+            now,
+            allow_track_initialization: true,
+            loaded_config: Some(config),
+        },
+    );
+
+    assert!(!guard.sink_schedules.contains_key(&sink_id));
+    assert!(guard.snapshot_expiration_sink_ids.contains(&sink_id));
 }
 
 #[tokio::test]
@@ -511,8 +533,6 @@ async fn test_apply_sink_update_does_not_resurrect_disappeared_track() {
         PreparedSinkUpdate {
             sink_id,
             kind: SinkUpdateKind::Commit,
-            enable_compaction: true,
-            enable_snapshot_expiration: false,
             now,
             allow_track_initialization: false,
             loaded_config: Some(config),

--- a/src/meta/src/manager/iceberg_compaction/schedule/tests.rs
+++ b/src/meta/src/manager/iceberg_compaction/schedule/tests.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::collections::{BTreeMap, HashMap};
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::sync::Arc;
 
 use prometheus::Registry;
@@ -391,6 +391,8 @@ async fn test_apply_sink_update_refreshes_existing_idle_track() {
         PreparedSinkUpdate {
             sink_id,
             kind: SinkUpdateKind::Commit,
+            enable_compaction: true,
+            enable_snapshot_expiration: false,
             now: refresh_at,
             allow_track_initialization: false,
             loaded_config: Some(config),
@@ -421,6 +423,8 @@ async fn test_update_iceberg_commit_info_skips_missing_track_on_load_failure() {
     manager
         .update_iceberg_commit_info(IcebergSinkCompactionUpdate {
             sink_id,
+            enable_compaction: true,
+            enable_snapshot_expiration: false,
             force_compaction: false,
         })
         .await;
@@ -442,6 +446,8 @@ async fn test_update_iceberg_commit_info_refresh_failure_keeps_refresh_deadline_
     manager
         .update_iceberg_commit_info(IcebergSinkCompactionUpdate {
             sink_id,
+            enable_compaction: true,
+            enable_snapshot_expiration: false,
             force_compaction: false,
         })
         .await;
@@ -462,6 +468,7 @@ async fn test_apply_sink_update_creates_missing_track() {
     let config = new_test_iceberg_config(300, 3, CompactionType::SmallFiles);
     let mut guard = IcebergCompactionManagerInner {
         sink_schedules: HashMap::new(),
+        snapshot_expiration_sink_ids: HashSet::new(),
         manual_task_waiters: HashMap::new(),
     };
 
@@ -470,6 +477,8 @@ async fn test_apply_sink_update_creates_missing_track() {
         PreparedSinkUpdate {
             sink_id,
             kind: SinkUpdateKind::Commit,
+            enable_compaction: true,
+            enable_snapshot_expiration: false,
             now,
             allow_track_initialization: true,
             loaded_config: Some(config),
@@ -493,6 +502,7 @@ async fn test_apply_sink_update_does_not_resurrect_disappeared_track() {
     let config = new_test_iceberg_config(300, 3, CompactionType::SmallFiles);
     let mut guard = IcebergCompactionManagerInner {
         sink_schedules: HashMap::new(),
+        snapshot_expiration_sink_ids: HashSet::new(),
         manual_task_waiters: HashMap::new(),
     };
 
@@ -501,6 +511,8 @@ async fn test_apply_sink_update_does_not_resurrect_disappeared_track() {
         PreparedSinkUpdate {
             sink_id,
             kind: SinkUpdateKind::Commit,
+            enable_compaction: true,
+            enable_snapshot_expiration: false,
             now,
             allow_track_initialization: false,
             loaded_config: Some(config),

--- a/src/meta/src/rpc/ddl_controller.rs
+++ b/src/meta/src/rpc/ddl_controller.rs
@@ -1426,7 +1426,7 @@ impl DdlController {
 
             for sink_id in iceberg_sink_ids {
                 self.iceberg_compaction_manager
-                    .clear_iceberg_commits_by_sink_id(sink_id);
+                    .clear_iceberg_maintenance_by_sink_id(sink_id);
             }
         }
 


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

- This pull request introduces enhancements to the management of Iceberg sink compaction and snapshot expiration. The changes add finer-grained control for enabling/disabling compaction and snapshot expiration per sink, improve the tracking of sinks requiring snapshot expiration, and ensure proper cleanup of related state when sinks are dropped. The update also includes changes to the internal data structures and tests to support these new features.


## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
