### PR TITLE
feat(sink): limit StarRocks stream load batch size

### DIFF
--- a/e2e_test/sink/starrocks_sink.slt
+++ b/e2e_test/sink/starrocks_sink.slt
@@ -42,7 +42,6 @@ FROM
     starrocks.password = '123456',
     starrocks.database = 'demo',
     starrocks.table = 'demo_bhv_table',
-    starrocks.max_batch_size_mb = '1',
     primary_key = 'v1'
 );
 

--- a/e2e_test/sink/starrocks_sink.slt
+++ b/e2e_test/sink/starrocks_sink.slt
@@ -42,6 +42,7 @@ FROM
     starrocks.password = '123456',
     starrocks.database = 'demo',
     starrocks.table = 'demo_bhv_table',
+    starrocks.max_batch_size_mb = '1',
     primary_key = 'v1'
 );
 

--- a/src/connector/src/allow_alter_on_fly_fields.rs
+++ b/src/connector/src/allow_alter_on_fly_fields.rs
@@ -305,7 +305,7 @@ pub static SINK_ALLOW_ALTER_ON_FLY_FIELDS: LazyLock<HashMap<String, HashSet<Stri
         [
             "starrocks.stream_load.http.timeout.ms".to_owned(),
             "commit_checkpoint_interval".to_owned(),
-            "starrocks.max_batch_size_mb".to_owned(),
+            "starrocks.max_batch_size_bytes".to_owned(),
         ].into_iter().collect(),
     ).unwrap();
     // TurbopufferConfig

--- a/src/connector/src/allow_alter_on_fly_fields.rs
+++ b/src/connector/src/allow_alter_on_fly_fields.rs
@@ -305,6 +305,7 @@ pub static SINK_ALLOW_ALTER_ON_FLY_FIELDS: LazyLock<HashMap<String, HashSet<Stri
         [
             "starrocks.stream_load.http.timeout.ms".to_owned(),
             "commit_checkpoint_interval".to_owned(),
+            "starrocks.max_batch_size_mb".to_owned(),
         ].into_iter().collect(),
     ).unwrap();
     // TurbopufferConfig

--- a/src/connector/src/sink/starrocks.rs
+++ b/src/connector/src/sink/starrocks.rs
@@ -52,6 +52,7 @@ pub const STARROCKS_SINK: &str = "starrocks";
 const STARROCK_MYSQL_PREFER_SOCKET: &str = "false";
 const STARROCK_MYSQL_MAX_ALLOWED_PACKET: usize = 1024;
 const STARROCK_MYSQL_WAIT_TIMEOUT: usize = 28800;
+const DEFAULT_STARROCKS_MAX_BATCH_SIZE_BYTES: u64 = 64 * 1024 * 1024;
 pub const fn _default_stream_load_http_timeout_ms() -> u64 {
     30 * 1000
 }
@@ -128,8 +129,11 @@ pub struct StarrocksConfig {
     pub partial_update: Option<String>,
 
     /// The maximum size in bytes for each `StarRocks` stream load request payload.
-    /// If unset, RisingWave does not split the request by payload size.
-    #[serde(rename = "starrocks.max_batch_size_bytes", default)]
+    /// Defaults to 64 MiB.
+    #[serde(
+        rename = "starrocks.max_batch_size_bytes",
+        default = "default_starrocks_max_batch_size_bytes"
+    )]
     #[serde_as(as = "Option<DisplayFromStr>")]
     #[with_option(allow_alter_on_fly)]
     pub max_batch_size_bytes: Option<u64>,
@@ -145,6 +149,10 @@ impl EnforceSecret for StarrocksConfig {
 
 fn default_commit_checkpoint_interval() -> u64 {
     DEFAULT_COMMIT_CHECKPOINT_INTERVAL_WITH_SINK_DECOUPLE
+}
+
+fn default_starrocks_max_batch_size_bytes() -> Option<u64> {
+    Some(DEFAULT_STARROCKS_MAX_BATCH_SIZE_BYTES)
 }
 
 impl StarrocksConfig {
@@ -172,6 +180,43 @@ impl StarrocksConfig {
         }
         Ok(config)
     }
+}
+
+#[derive(Debug, PartialEq, Eq)]
+struct LoadRequestSizeDecision {
+    finish_current_load: bool,
+    next_batch_size_bytes: u64,
+}
+
+fn decide_load_request_size(
+    current_batch_size_bytes: u64,
+    row_size: u64,
+    max_batch_size_bytes: u64,
+) -> Result<LoadRequestSizeDecision> {
+    if row_size > max_batch_size_bytes {
+        return Err(SinkError::Starrocks(format!(
+            "single row payload size {} bytes exceeds `starrocks.max_batch_size_bytes` limit {} bytes",
+            row_size, max_batch_size_bytes
+        )));
+    }
+
+    if current_batch_size_bytes > 0
+        && current_batch_size_bytes
+            .checked_add(row_size)
+            .is_none_or(|next_batch_size_bytes| next_batch_size_bytes > max_batch_size_bytes)
+    {
+        return Ok(LoadRequestSizeDecision {
+            finish_current_load: true,
+            next_batch_size_bytes: row_size,
+        });
+    }
+
+    Ok(LoadRequestSizeDecision {
+        finish_current_load: false,
+        next_batch_size_bytes: current_batch_size_bytes
+            .checked_add(row_size)
+            .expect("sum is checked against max_batch_size_bytes above"),
+    })
 }
 
 #[derive(Debug)]
@@ -491,10 +536,19 @@ impl StarrocksSinkWriter {
 
     async fn write_row_json(&mut self, row_json_string: String) -> Result<()> {
         let row_size = row_json_string.len() as u64;
-        if let Some(max_batch_size_bytes) = self.max_batch_size_bytes
-            && self.client.is_some()
-            && self.current_batch_size_bytes > 0
-            && self.current_batch_size_bytes + row_size > max_batch_size_bytes
+        let size_decision = self
+            .max_batch_size_bytes
+            .map(|max_batch_size_bytes| {
+                decide_load_request_size(
+                    self.current_batch_size_bytes,
+                    row_size,
+                    max_batch_size_bytes,
+                )
+            })
+            .transpose()?;
+        if size_decision
+            .as_ref()
+            .is_some_and(|decision| decision.finish_current_load)
         {
             self.finish_load_request().await?;
         }
@@ -504,8 +558,8 @@ impl StarrocksSinkWriter {
             .ok_or_else(|| SinkError::Starrocks("Can't find starrocks sink insert".to_owned()))?
             .write(row_json_string.into())
             .await?;
-        if self.max_batch_size_bytes.is_some() {
-            self.current_batch_size_bytes += row_size;
+        if let Some(size_decision) = size_decision {
+            self.current_batch_size_bytes = size_decision.next_batch_size_bytes;
         }
         Ok(())
     }
@@ -953,10 +1007,13 @@ mod tests {
     }
 
     #[test]
-    fn starrocks_max_batch_size_bytes_is_optional() {
+    fn starrocks_max_batch_size_bytes_uses_default() {
         let config = StarrocksConfig::from_btreemap(base_properties()).unwrap();
 
-        assert_eq!(config.max_batch_size_bytes, None);
+        assert_eq!(
+            config.max_batch_size_bytes,
+            Some(DEFAULT_STARROCKS_MAX_BATCH_SIZE_BYTES)
+        );
     }
 
     #[test]
@@ -979,6 +1036,48 @@ mod tests {
         assert!(
             err.to_string()
                 .contains("`starrocks.max_batch_size_bytes` must be greater than 0")
+        );
+    }
+
+    #[test]
+    fn starrocks_batch_size_allows_exact_limit() {
+        assert_eq!(
+            decide_load_request_size(3, 2, 5).unwrap(),
+            LoadRequestSizeDecision {
+                finish_current_load: false,
+                next_batch_size_bytes: 5,
+            }
+        );
+    }
+
+    #[test]
+    fn starrocks_batch_size_rolls_over_before_exceeding_limit() {
+        assert_eq!(
+            decide_load_request_size(4, 2, 5).unwrap(),
+            LoadRequestSizeDecision {
+                finish_current_load: true,
+                next_batch_size_bytes: 2,
+            }
+        );
+    }
+
+    #[test]
+    fn starrocks_batch_size_rejects_single_oversized_row() {
+        let err = decide_load_request_size(0, 6, 5).unwrap_err();
+
+        assert!(err.to_string().contains(
+            "single row payload size 6 bytes exceeds `starrocks.max_batch_size_bytes` limit 5 bytes"
+        ));
+    }
+
+    #[test]
+    fn starrocks_batch_size_rolls_over_on_u64_overflow() {
+        assert_eq!(
+            decide_load_request_size(u64::MAX, 1, u64::MAX).unwrap(),
+            LoadRequestSizeDecision {
+                finish_current_load: true,
+                next_batch_size_bytes: 1,
+            }
         );
     }
 }

--- a/src/connector/src/sink/starrocks.rs
+++ b/src/connector/src/sink/starrocks.rs
@@ -52,7 +52,7 @@ pub const STARROCKS_SINK: &str = "starrocks";
 const STARROCK_MYSQL_PREFER_SOCKET: &str = "false";
 const STARROCK_MYSQL_MAX_ALLOWED_PACKET: usize = 1024;
 const STARROCK_MYSQL_WAIT_TIMEOUT: usize = 28800;
-const BYTES_PER_MB: usize = 1024 * 1024;
+const BYTES_PER_MB: u64 = 1024 * 1024;
 
 pub const fn _default_stream_load_http_timeout_ms() -> u64 {
     30 * 1000
@@ -134,7 +134,7 @@ pub struct StarrocksConfig {
     #[serde(rename = "starrocks.max_batch_size_mb", default)]
     #[serde_as(as = "Option<DisplayFromStr>")]
     #[with_option(allow_alter_on_fly)]
-    pub max_batch_size_mb: Option<usize>,
+    pub max_batch_size_mb: Option<u64>,
 
     pub r#type: String, // accept "append-only" or "upsert"
 }
@@ -168,30 +168,33 @@ impl StarrocksConfig {
             )));
         }
         if let Some(max_batch_size_mb) = config.max_batch_size_mb {
-            if max_batch_size_mb == 0 {
-                return Err(SinkError::Config(anyhow!(
-                    "`starrocks.max_batch_size_mb` must be greater than 0"
-                )));
-            }
-            if max_batch_size_mb.checked_mul(BYTES_PER_MB).is_none() {
-                return Err(SinkError::Config(anyhow!(
-                    "`starrocks.max_batch_size_mb` is too large"
-                )));
-            }
+            max_batch_size_mb_to_bytes(max_batch_size_mb)?;
         }
         Ok(config)
     }
 
-    fn max_batch_size_bytes(&self) -> Option<usize> {
+    fn max_batch_size_bytes(&self) -> Result<Option<u64>> {
         self.max_batch_size_mb
-            .map(|max_batch_size_mb| max_batch_size_mb * BYTES_PER_MB)
+            .map(max_batch_size_mb_to_bytes)
+            .transpose()
     }
 }
 
+fn max_batch_size_mb_to_bytes(max_batch_size_mb: u64) -> Result<u64> {
+    if max_batch_size_mb == 0 {
+        return Err(SinkError::Config(anyhow!(
+            "`starrocks.max_batch_size_mb` must be greater than 0"
+        )));
+    }
+    max_batch_size_mb
+        .checked_mul(BYTES_PER_MB)
+        .ok_or_else(|| SinkError::Config(anyhow!("`starrocks.max_batch_size_mb` is too large")))
+}
+
 fn should_finish_current_load_before_row(
-    current_load_bytes: usize,
-    row_size: usize,
-    max_batch_size_bytes: usize,
+    current_load_bytes: u64,
+    row_size: u64,
+    max_batch_size_bytes: u64,
 ) -> bool {
     current_load_bytes > 0
         && current_load_bytes
@@ -418,7 +421,6 @@ impl Sink for StarrocksSink {
 }
 
 pub struct StarrocksSinkWriter {
-    pub config: StarrocksConfig,
     #[expect(dead_code)]
     schema: Schema,
     #[expect(dead_code)]
@@ -428,7 +430,8 @@ pub struct StarrocksSinkWriter {
     txn_client: Arc<StarrocksTxnClient>,
     row_encoder: JsonEncoder,
     curr_txn_label: Option<String>,
-    current_load_bytes: usize,
+    max_load_request_bytes: Option<u64>,
+    current_load_request_bytes: u64,
 }
 
 impl TryFrom<SinkParam> for StarrocksSink {
@@ -481,9 +484,9 @@ impl StarrocksSinkWriter {
         };
         let txn_request_builder =
             StarrocksTxnRequestBuilder::new(url, header, config.stream_load_http_timeout_ms)?;
+        let max_load_request_bytes = config.max_batch_size_bytes()?;
 
         Ok(Self {
-            config,
             schema: schema.clone(),
             pk_indices,
             is_append_only,
@@ -491,53 +494,73 @@ impl StarrocksSinkWriter {
             txn_client: Arc::new(StarrocksTxnClient::new(txn_request_builder)),
             row_encoder: JsonEncoder::new_with_starrocks(schema, None, time_zone),
             curr_txn_label: None,
-            current_load_bytes: 0,
+            max_load_request_bytes,
+            current_load_request_bytes: 0,
         })
     }
 
     async fn finish_load_request(&mut self) -> Result<()> {
         if let Some(client) = self.client.take() {
             client.finish().await?;
-            self.current_load_bytes = 0;
+            self.current_load_request_bytes = 0;
         }
         Ok(())
     }
 
-    async fn write_row_json(&mut self, row_json_string: String) -> Result<()> {
-        let row_size = row_json_string.len();
-        if let Some(max_batch_size_bytes) = self.config.max_batch_size_bytes() {
-            if row_size > max_batch_size_bytes {
+    async fn maybe_finish_load_before_row(&mut self, row_size: u64) -> Result<()> {
+        if let Some(max_load_request_bytes) = self.max_load_request_bytes {
+            if row_size > max_load_request_bytes {
                 return Err(SinkError::Starrocks(format!(
                     "single row payload size {} bytes exceeds `starrocks.max_batch_size_mb` limit {} bytes",
-                    row_size, max_batch_size_bytes
+                    row_size, max_load_request_bytes
                 )));
             }
             if self.client.is_some()
                 && should_finish_current_load_before_row(
-                    self.current_load_bytes,
+                    self.current_load_request_bytes,
                     row_size,
-                    max_batch_size_bytes,
+                    max_load_request_bytes,
                 )
             {
                 self.finish_load_request().await?;
             }
         }
+        Ok(())
+    }
 
+    async fn ensure_load_request(&mut self) -> Result<()> {
         if self.client.is_none() {
             let txn_label = self.curr_txn_label.clone().ok_or_else(|| {
                 SinkError::Starrocks("Can't find current starrocks transaction label".to_owned())
             })?;
-            self.client = Some(StarrocksClient::new(
-                self.txn_client.load(txn_label).await?,
-            ));
-            self.current_load_bytes = 0;
+            self.client = Some(StarrocksClient::new(self.txn_client.load(txn_label).await?));
+            self.current_load_request_bytes = 0;
         }
+        Ok(())
+    }
+
+    fn record_load_request_bytes(&mut self, row_size: u64) -> Result<()> {
+        if self.max_load_request_bytes.is_some() {
+            self.current_load_request_bytes = self
+                .current_load_request_bytes
+                .checked_add(row_size)
+                .ok_or_else(|| {
+                    SinkError::Starrocks("stream load payload size overflow".to_owned())
+                })?;
+        }
+        Ok(())
+    }
+
+    async fn write_row_json(&mut self, row_json_string: String) -> Result<()> {
+        let row_size = row_json_string.len() as u64;
+        self.maybe_finish_load_before_row(row_size).await?;
+        self.ensure_load_request().await?;
         self.client
             .as_mut()
             .ok_or_else(|| SinkError::Starrocks("Can't find starrocks sink insert".to_owned()))?
             .write(row_json_string.into())
             .await?;
-        self.current_load_bytes = self.current_load_bytes.saturating_add(row_size);
+        self.record_load_request_bytes(row_size)?;
         Ok(())
     }
 
@@ -988,7 +1011,7 @@ mod tests {
         let config = StarrocksConfig::from_btreemap(base_properties()).unwrap();
 
         assert_eq!(config.max_batch_size_mb, None);
-        assert_eq!(config.max_batch_size_bytes(), None);
+        assert_eq!(config.max_batch_size_bytes().unwrap(), None);
     }
 
     #[test]
@@ -999,7 +1022,10 @@ mod tests {
         let config = StarrocksConfig::from_btreemap(properties).unwrap();
 
         assert_eq!(config.max_batch_size_mb, Some(2));
-        assert_eq!(config.max_batch_size_bytes(), Some(2 * BYTES_PER_MB));
+        assert_eq!(
+            config.max_batch_size_bytes().unwrap(),
+            Some(2 * BYTES_PER_MB)
+        );
     }
 
     #[test]
@@ -1016,14 +1042,30 @@ mod tests {
     }
 
     #[test]
+    fn starrocks_max_batch_size_mb_rejects_too_large_value() {
+        let mut properties = base_properties();
+        properties.insert(
+            "starrocks.max_batch_size_mb".to_owned(),
+            (u64::MAX / BYTES_PER_MB + 1).to_string(),
+        );
+
+        let err = StarrocksConfig::from_btreemap(properties).unwrap_err();
+
+        assert!(
+            err.to_string()
+                .contains("`starrocks.max_batch_size_mb` is too large")
+        );
+    }
+
+    #[test]
     fn starrocks_batch_rollover_keeps_single_payload_within_limit() {
         assert!(!should_finish_current_load_before_row(0, 10, 10));
         assert!(!should_finish_current_load_before_row(4, 6, 10));
         assert!(should_finish_current_load_before_row(5, 6, 10));
         assert!(should_finish_current_load_before_row(
-            usize::MAX - 1,
+            u64::MAX - 1,
             10,
-            usize::MAX
+            u64::MAX
         ));
     }
 }

--- a/src/connector/src/sink/starrocks.rs
+++ b/src/connector/src/sink/starrocks.rs
@@ -52,6 +52,7 @@ pub const STARROCKS_SINK: &str = "starrocks";
 const STARROCK_MYSQL_PREFER_SOCKET: &str = "false";
 const STARROCK_MYSQL_MAX_ALLOWED_PACKET: usize = 1024;
 const STARROCK_MYSQL_WAIT_TIMEOUT: usize = 28800;
+const BYTES_PER_MB: usize = 1024 * 1024;
 
 pub const fn _default_stream_load_http_timeout_ms() -> u64 {
     30 * 1000
@@ -128,6 +129,13 @@ pub struct StarrocksConfig {
     #[serde(rename = "starrocks.partial_update")]
     pub partial_update: Option<String>,
 
+    /// The maximum size in MB for each StarRocks stream load request payload.
+    /// If unset, RisingWave does not split the request by payload size.
+    #[serde(rename = "starrocks.max_batch_size_mb", default)]
+    #[serde_as(as = "Option<DisplayFromStr>")]
+    #[with_option(allow_alter_on_fly)]
+    pub max_batch_size_mb: Option<usize>,
+
     pub r#type: String, // accept "append-only" or "upsert"
 }
 
@@ -159,8 +167,36 @@ impl StarrocksConfig {
                 "`commit_checkpoint_interval` must be greater than 0"
             )));
         }
+        if let Some(max_batch_size_mb) = config.max_batch_size_mb {
+            if max_batch_size_mb == 0 {
+                return Err(SinkError::Config(anyhow!(
+                    "`starrocks.max_batch_size_mb` must be greater than 0"
+                )));
+            }
+            if max_batch_size_mb.checked_mul(BYTES_PER_MB).is_none() {
+                return Err(SinkError::Config(anyhow!(
+                    "`starrocks.max_batch_size_mb` is too large"
+                )));
+            }
+        }
         Ok(config)
     }
+
+    fn max_batch_size_bytes(&self) -> Option<usize> {
+        self.max_batch_size_mb
+            .map(|max_batch_size_mb| max_batch_size_mb * BYTES_PER_MB)
+    }
+}
+
+fn should_finish_current_load_before_row(
+    current_load_bytes: usize,
+    row_size: usize,
+    max_batch_size_bytes: usize,
+) -> bool {
+    current_load_bytes > 0
+        && current_load_bytes
+            .checked_add(row_size)
+            .is_none_or(|next_load_bytes| next_load_bytes > max_batch_size_bytes)
 }
 
 #[derive(Debug)]
@@ -392,6 +428,7 @@ pub struct StarrocksSinkWriter {
     txn_client: Arc<StarrocksTxnClient>,
     row_encoder: JsonEncoder,
     curr_txn_label: Option<String>,
+    current_load_bytes: usize,
 }
 
 impl TryFrom<SinkParam> for StarrocksSink {
@@ -454,7 +491,54 @@ impl StarrocksSinkWriter {
             txn_client: Arc::new(StarrocksTxnClient::new(txn_request_builder)),
             row_encoder: JsonEncoder::new_with_starrocks(schema, None, time_zone),
             curr_txn_label: None,
+            current_load_bytes: 0,
         })
+    }
+
+    async fn finish_load_request(&mut self) -> Result<()> {
+        if let Some(client) = self.client.take() {
+            client.finish().await?;
+            self.current_load_bytes = 0;
+        }
+        Ok(())
+    }
+
+    async fn write_row_json(&mut self, row_json_string: String) -> Result<()> {
+        let row_size = row_json_string.len();
+        if let Some(max_batch_size_bytes) = self.config.max_batch_size_bytes() {
+            if row_size > max_batch_size_bytes {
+                return Err(SinkError::Starrocks(format!(
+                    "single row payload size {} bytes exceeds `starrocks.max_batch_size_mb` limit {} bytes",
+                    row_size, max_batch_size_bytes
+                )));
+            }
+            if self.client.is_some()
+                && should_finish_current_load_before_row(
+                    self.current_load_bytes,
+                    row_size,
+                    max_batch_size_bytes,
+                )
+            {
+                self.finish_load_request().await?;
+            }
+        }
+
+        if self.client.is_none() {
+            let txn_label = self.curr_txn_label.clone().ok_or_else(|| {
+                SinkError::Starrocks("Can't find current starrocks transaction label".to_owned())
+            })?;
+            self.client = Some(StarrocksClient::new(
+                self.txn_client.load(txn_label).await?,
+            ));
+            self.current_load_bytes = 0;
+        }
+        self.client
+            .as_mut()
+            .ok_or_else(|| SinkError::Starrocks("Can't find starrocks sink insert".to_owned()))?
+            .write(row_json_string.into())
+            .await?;
+        self.current_load_bytes = self.current_load_bytes.saturating_add(row_size);
+        Ok(())
     }
 
     async fn append_only(&mut self, chunk: StreamChunk) -> Result<()> {
@@ -463,11 +547,7 @@ impl StarrocksSinkWriter {
                 continue;
             }
             let row_json_string = Value::Object(self.row_encoder.encode(row)?).to_string();
-            self.client
-                .as_mut()
-                .ok_or_else(|| SinkError::Starrocks("Can't find starrocks sink insert".to_owned()))?
-                .write(row_json_string.into())
-                .await?;
+            self.write_row_json(row_json_string).await?;
         }
         Ok(())
     }
@@ -484,13 +564,7 @@ impl StarrocksSinkWriter {
                     let row_json_string = serde_json::to_string(&row_json_value).map_err(|e| {
                         SinkError::Starrocks(format!("Json derialize error: {}", e.as_report()))
                     })?;
-                    self.client
-                        .as_mut()
-                        .ok_or_else(|| {
-                            SinkError::Starrocks("Can't find starrocks sink insert".to_owned())
-                        })?
-                        .write(row_json_string.into())
-                        .await?;
+                    self.write_row_json(row_json_string).await?;
                 }
                 Op::Delete => {
                     let mut row_json_value = self.row_encoder.encode(row)?;
@@ -501,13 +575,7 @@ impl StarrocksSinkWriter {
                     let row_json_string = serde_json::to_string(&row_json_value).map_err(|e| {
                         SinkError::Starrocks(format!("Json derialize error: {}", e.as_report()))
                     })?;
-                    self.client
-                        .as_mut()
-                        .ok_or_else(|| {
-                            SinkError::Starrocks("Can't find starrocks sink insert".to_owned())
-                        })?
-                        .write(row_json_string.into())
-                        .await?;
+                    self.write_row_json(row_json_string).await?;
                 }
                 Op::UpdateDelete => {}
                 Op::UpdateInsert => {
@@ -519,13 +587,7 @@ impl StarrocksSinkWriter {
                     let row_json_string = serde_json::to_string(&row_json_value).map_err(|e| {
                         SinkError::Starrocks(format!("Json derialize error: {}", e.as_report()))
                     })?;
-                    self.client
-                        .as_mut()
-                        .ok_or_else(|| {
-                            SinkError::Starrocks("Can't find starrocks sink insert".to_owned())
-                        })?
-                        .write(row_json_string.into())
-                        .await?;
+                    self.write_row_json(row_json_string).await?;
                 }
             }
         }
@@ -600,13 +662,7 @@ impl SinkWriter for StarrocksSinkWriter {
                     txn_label, txn_label_res
                 )));
             }
-            self.curr_txn_label = Some(txn_label.clone());
-        }
-        if self.client.is_none() {
-            let txn_label = self.curr_txn_label.clone();
-            self.client = Some(StarrocksClient::new(
-                self.txn_client.load(txn_label.unwrap()).await?,
-            ));
+            self.curr_txn_label = Some(txn_label);
         }
         if self.is_append_only {
             self.append_only(chunk).await
@@ -616,14 +672,12 @@ impl SinkWriter for StarrocksSinkWriter {
     }
 
     async fn barrier(&mut self, is_checkpoint: bool) -> Result<()> {
-        if let Some(client) = self.client.take() {
-            // Here we finish the `/api/transaction/load` request when a barrier is received. Therefore,
-            // one or more load requests should be made within one commit_checkpoint_interval period.
-            // StarRocks will take care of merging those splits into a larger one during prepare transaction.
-            // Thus, only one version will be produced when the transaction is committed. See Stream Load
-            // transaction interface for more information.
-            client.finish().await?;
-        }
+        // Here we finish the `/api/transaction/load` request when a barrier is received. Therefore,
+        // one or more load requests should be made within one commit_checkpoint_interval period.
+        // StarRocks will take care of merging those splits into a larger one during prepare transaction.
+        // Thus, only one version will be produced when the transaction is committed. See Stream Load
+        // transaction interface for more information.
+        self.finish_load_request().await?;
 
         if is_checkpoint
             && let Some(txn_label) = self.curr_txn_label.take()
@@ -916,4 +970,60 @@ mod tests {
         }
     }
 
+    fn base_properties() -> BTreeMap<String, String> {
+        BTreeMap::from([
+            ("starrocks.host".to_owned(), "127.0.0.1".to_owned()),
+            ("starrocks.mysqlport".to_owned(), "9030".to_owned()),
+            ("starrocks.httpport".to_owned(), "8030".to_owned()),
+            ("starrocks.user".to_owned(), "root".to_owned()),
+            ("starrocks.password".to_owned(), "".to_owned()),
+            ("starrocks.database".to_owned(), "demo".to_owned()),
+            ("starrocks.table".to_owned(), "sink_table".to_owned()),
+            ("type".to_owned(), SINK_TYPE_APPEND_ONLY.to_owned()),
+        ])
+    }
+
+    #[test]
+    fn starrocks_max_batch_size_mb_is_optional() {
+        let config = StarrocksConfig::from_btreemap(base_properties()).unwrap();
+
+        assert_eq!(config.max_batch_size_mb, None);
+        assert_eq!(config.max_batch_size_bytes(), None);
+    }
+
+    #[test]
+    fn starrocks_max_batch_size_mb_parses_to_bytes() {
+        let mut properties = base_properties();
+        properties.insert("starrocks.max_batch_size_mb".to_owned(), "2".to_owned());
+
+        let config = StarrocksConfig::from_btreemap(properties).unwrap();
+
+        assert_eq!(config.max_batch_size_mb, Some(2));
+        assert_eq!(config.max_batch_size_bytes(), Some(2 * BYTES_PER_MB));
+    }
+
+    #[test]
+    fn starrocks_max_batch_size_mb_rejects_zero() {
+        let mut properties = base_properties();
+        properties.insert("starrocks.max_batch_size_mb".to_owned(), "0".to_owned());
+
+        let err = StarrocksConfig::from_btreemap(properties).unwrap_err();
+
+        assert!(
+            err.to_string()
+                .contains("`starrocks.max_batch_size_mb` must be greater than 0")
+        );
+    }
+
+    #[test]
+    fn starrocks_batch_rollover_keeps_single_payload_within_limit() {
+        assert!(!should_finish_current_load_before_row(0, 10, 10));
+        assert!(!should_finish_current_load_before_row(4, 6, 10));
+        assert!(should_finish_current_load_before_row(5, 6, 10));
+        assert!(should_finish_current_load_before_row(
+            usize::MAX - 1,
+            10,
+            usize::MAX
+        ));
+    }
 }

--- a/src/connector/src/sink/starrocks.rs
+++ b/src/connector/src/sink/starrocks.rs
@@ -52,8 +52,6 @@ pub const STARROCKS_SINK: &str = "starrocks";
 const STARROCK_MYSQL_PREFER_SOCKET: &str = "false";
 const STARROCK_MYSQL_MAX_ALLOWED_PACKET: usize = 1024;
 const STARROCK_MYSQL_WAIT_TIMEOUT: usize = 28800;
-const BYTES_PER_MB: u64 = 1024 * 1024;
-
 pub const fn _default_stream_load_http_timeout_ms() -> u64 {
     30 * 1000
 }
@@ -129,12 +127,12 @@ pub struct StarrocksConfig {
     #[serde(rename = "starrocks.partial_update")]
     pub partial_update: Option<String>,
 
-    /// The maximum size in MB for each `StarRocks` stream load request payload.
+    /// The maximum size in bytes for each `StarRocks` stream load request payload.
     /// If unset, RisingWave does not split the request by payload size.
-    #[serde(rename = "starrocks.max_batch_size_mb", default)]
+    #[serde(rename = "starrocks.max_batch_size_bytes", default)]
     #[serde_as(as = "Option<DisplayFromStr>")]
     #[with_option(allow_alter_on_fly)]
-    pub max_batch_size_mb: Option<u64>,
+    pub max_batch_size_bytes: Option<u64>,
 
     pub r#type: String, // accept "append-only" or "upsert"
 }
@@ -167,39 +165,13 @@ impl StarrocksConfig {
                 "`commit_checkpoint_interval` must be greater than 0"
             )));
         }
-        if let Some(max_batch_size_mb) = config.max_batch_size_mb {
-            max_batch_size_mb_to_bytes(max_batch_size_mb)?;
+        if let Some(0) = config.max_batch_size_bytes {
+            return Err(SinkError::Config(anyhow!(
+                "`starrocks.max_batch_size_bytes` must be greater than 0"
+            )));
         }
         Ok(config)
     }
-
-    fn max_batch_size_bytes(&self) -> Result<Option<u64>> {
-        self.max_batch_size_mb
-            .map(max_batch_size_mb_to_bytes)
-            .transpose()
-    }
-}
-
-fn max_batch_size_mb_to_bytes(max_batch_size_mb: u64) -> Result<u64> {
-    if max_batch_size_mb == 0 {
-        return Err(SinkError::Config(anyhow!(
-            "`starrocks.max_batch_size_mb` must be greater than 0"
-        )));
-    }
-    max_batch_size_mb
-        .checked_mul(BYTES_PER_MB)
-        .ok_or_else(|| SinkError::Config(anyhow!("`starrocks.max_batch_size_mb` is too large")))
-}
-
-fn should_finish_current_load_before_row(
-    current_load_bytes: u64,
-    row_size: u64,
-    max_batch_size_bytes: u64,
-) -> bool {
-    current_load_bytes > 0
-        && current_load_bytes
-            .checked_add(row_size)
-            .is_none_or(|next_load_bytes| next_load_bytes > max_batch_size_bytes)
 }
 
 #[derive(Debug)]
@@ -430,8 +402,8 @@ pub struct StarrocksSinkWriter {
     txn_client: Arc<StarrocksTxnClient>,
     row_encoder: JsonEncoder,
     curr_txn_label: Option<String>,
-    max_load_request_bytes: Option<u64>,
-    current_load_request_bytes: u64,
+    max_batch_size_bytes: Option<u64>,
+    current_batch_size_bytes: u64,
 }
 
 impl TryFrom<SinkParam> for StarrocksSink {
@@ -484,7 +456,6 @@ impl StarrocksSinkWriter {
         };
         let txn_request_builder =
             StarrocksTxnRequestBuilder::new(url, header, config.stream_load_http_timeout_ms)?;
-        let max_load_request_bytes = config.max_batch_size_bytes()?;
 
         Ok(Self {
             schema: schema.clone(),
@@ -494,36 +465,15 @@ impl StarrocksSinkWriter {
             txn_client: Arc::new(StarrocksTxnClient::new(txn_request_builder)),
             row_encoder: JsonEncoder::new_with_starrocks(schema, None, time_zone),
             curr_txn_label: None,
-            max_load_request_bytes,
-            current_load_request_bytes: 0,
+            max_batch_size_bytes: config.max_batch_size_bytes,
+            current_batch_size_bytes: 0,
         })
     }
 
     async fn finish_load_request(&mut self) -> Result<()> {
         if let Some(client) = self.client.take() {
             client.finish().await?;
-            self.current_load_request_bytes = 0;
-        }
-        Ok(())
-    }
-
-    async fn maybe_finish_load_before_row(&mut self, row_size: u64) -> Result<()> {
-        if let Some(max_load_request_bytes) = self.max_load_request_bytes {
-            if row_size > max_load_request_bytes {
-                return Err(SinkError::Starrocks(format!(
-                    "single row payload size {} bytes exceeds `starrocks.max_batch_size_mb` limit {} bytes",
-                    row_size, max_load_request_bytes
-                )));
-            }
-            if self.client.is_some()
-                && should_finish_current_load_before_row(
-                    self.current_load_request_bytes,
-                    row_size,
-                    max_load_request_bytes,
-                )
-            {
-                self.finish_load_request().await?;
-            }
+            self.current_batch_size_bytes = 0;
         }
         Ok(())
     }
@@ -534,33 +484,29 @@ impl StarrocksSinkWriter {
                 SinkError::Starrocks("Can't find current starrocks transaction label".to_owned())
             })?;
             self.client = Some(StarrocksClient::new(self.txn_client.load(txn_label).await?));
-            self.current_load_request_bytes = 0;
-        }
-        Ok(())
-    }
-
-    fn record_load_request_bytes(&mut self, row_size: u64) -> Result<()> {
-        if self.max_load_request_bytes.is_some() {
-            self.current_load_request_bytes = self
-                .current_load_request_bytes
-                .checked_add(row_size)
-                .ok_or_else(|| {
-                    SinkError::Starrocks("stream load payload size overflow".to_owned())
-                })?;
+            self.current_batch_size_bytes = 0;
         }
         Ok(())
     }
 
     async fn write_row_json(&mut self, row_json_string: String) -> Result<()> {
         let row_size = row_json_string.len() as u64;
-        self.maybe_finish_load_before_row(row_size).await?;
+        if let Some(max_batch_size_bytes) = self.max_batch_size_bytes
+            && self.client.is_some()
+            && self.current_batch_size_bytes > 0
+            && self.current_batch_size_bytes + row_size > max_batch_size_bytes
+        {
+            self.finish_load_request().await?;
+        }
         self.ensure_load_request().await?;
         self.client
             .as_mut()
             .ok_or_else(|| SinkError::Starrocks("Can't find starrocks sink insert".to_owned()))?
             .write(row_json_string.into())
             .await?;
-        self.record_load_request_bytes(row_size)?;
+        if self.max_batch_size_bytes.is_some() {
+            self.current_batch_size_bytes += row_size;
+        }
         Ok(())
     }
 
@@ -1007,65 +953,32 @@ mod tests {
     }
 
     #[test]
-    fn starrocks_max_batch_size_mb_is_optional() {
+    fn starrocks_max_batch_size_bytes_is_optional() {
         let config = StarrocksConfig::from_btreemap(base_properties()).unwrap();
 
-        assert_eq!(config.max_batch_size_mb, None);
-        assert_eq!(config.max_batch_size_bytes().unwrap(), None);
+        assert_eq!(config.max_batch_size_bytes, None);
     }
 
     #[test]
-    fn starrocks_max_batch_size_mb_parses_to_bytes() {
+    fn starrocks_max_batch_size_bytes_parses() {
         let mut properties = base_properties();
-        properties.insert("starrocks.max_batch_size_mb".to_owned(), "2".to_owned());
+        properties.insert("starrocks.max_batch_size_bytes".to_owned(), "2".to_owned());
 
         let config = StarrocksConfig::from_btreemap(properties).unwrap();
 
-        assert_eq!(config.max_batch_size_mb, Some(2));
-        assert_eq!(
-            config.max_batch_size_bytes().unwrap(),
-            Some(2 * BYTES_PER_MB)
-        );
+        assert_eq!(config.max_batch_size_bytes, Some(2));
     }
 
     #[test]
-    fn starrocks_max_batch_size_mb_rejects_zero() {
+    fn starrocks_max_batch_size_bytes_rejects_zero() {
         let mut properties = base_properties();
-        properties.insert("starrocks.max_batch_size_mb".to_owned(), "0".to_owned());
+        properties.insert("starrocks.max_batch_size_bytes".to_owned(), "0".to_owned());
 
         let err = StarrocksConfig::from_btreemap(properties).unwrap_err();
 
         assert!(
             err.to_string()
-                .contains("`starrocks.max_batch_size_mb` must be greater than 0")
+                .contains("`starrocks.max_batch_size_bytes` must be greater than 0")
         );
-    }
-
-    #[test]
-    fn starrocks_max_batch_size_mb_rejects_too_large_value() {
-        let mut properties = base_properties();
-        properties.insert(
-            "starrocks.max_batch_size_mb".to_owned(),
-            (u64::MAX / BYTES_PER_MB + 1).to_string(),
-        );
-
-        let err = StarrocksConfig::from_btreemap(properties).unwrap_err();
-
-        assert!(
-            err.to_string()
-                .contains("`starrocks.max_batch_size_mb` is too large")
-        );
-    }
-
-    #[test]
-    fn starrocks_batch_rollover_keeps_single_payload_within_limit() {
-        assert!(!should_finish_current_load_before_row(0, 10, 10));
-        assert!(!should_finish_current_load_before_row(4, 6, 10));
-        assert!(should_finish_current_load_before_row(5, 6, 10));
-        assert!(should_finish_current_load_before_row(
-            u64::MAX - 1,
-            10,
-            u64::MAX
-        ));
     }
 }

--- a/src/connector/src/sink/starrocks.rs
+++ b/src/connector/src/sink/starrocks.rs
@@ -52,7 +52,6 @@ pub const STARROCKS_SINK: &str = "starrocks";
 const STARROCK_MYSQL_PREFER_SOCKET: &str = "false";
 const STARROCK_MYSQL_MAX_ALLOWED_PACKET: usize = 1024;
 const STARROCK_MYSQL_WAIT_TIMEOUT: usize = 28800;
-const DEFAULT_STARROCKS_MAX_BATCH_SIZE_BYTES: u64 = 64 * 1024 * 1024;
 pub const fn _default_stream_load_http_timeout_ms() -> u64 {
     30 * 1000
 }
@@ -129,11 +128,8 @@ pub struct StarrocksConfig {
     pub partial_update: Option<String>,
 
     /// The maximum size in bytes for each `StarRocks` stream load request payload.
-    /// Defaults to 64 `MiB`.
-    #[serde(
-        rename = "starrocks.max_batch_size_bytes",
-        default = "default_starrocks_max_batch_size_bytes"
-    )]
+    /// Defaults to unlimited.
+    #[serde(rename = "starrocks.max_batch_size_bytes")]
     #[serde_as(as = "Option<DisplayFromStr>")]
     #[with_option(allow_alter_on_fly)]
     pub max_batch_size_bytes: Option<u64>,
@@ -149,10 +145,6 @@ impl EnforceSecret for StarrocksConfig {
 
 fn default_commit_checkpoint_interval() -> u64 {
     DEFAULT_COMMIT_CHECKPOINT_INTERVAL_WITH_SINK_DECOUPLE
-}
-
-fn default_starrocks_max_batch_size_bytes() -> Option<u64> {
-    Some(DEFAULT_STARROCKS_MAX_BATCH_SIZE_BYTES)
 }
 
 impl StarrocksConfig {
@@ -1007,13 +999,10 @@ mod tests {
     }
 
     #[test]
-    fn starrocks_max_batch_size_bytes_uses_default() {
+    fn starrocks_max_batch_size_bytes_defaults_to_none() {
         let config = StarrocksConfig::from_btreemap(base_properties()).unwrap();
 
-        assert_eq!(
-            config.max_batch_size_bytes,
-            Some(DEFAULT_STARROCKS_MAX_BATCH_SIZE_BYTES)
-        );
+        assert_eq!(config.max_batch_size_bytes, None);
     }
 
     #[test]

--- a/src/connector/src/sink/starrocks.rs
+++ b/src/connector/src/sink/starrocks.rs
@@ -585,7 +585,7 @@ impl StarrocksSinkWriter {
                         Value::String("0".to_owned()),
                     );
                     let row_json_string = serde_json::to_string(&row_json_value).map_err(|e| {
-                        SinkError::Starrocks(format!("Json derialize error: {}", e.as_report()))
+                        SinkError::Starrocks(format!("Json serialize error: {}", e.as_report()))
                     })?;
                     self.write_row_json(row_json_string).await?;
                 }
@@ -596,7 +596,7 @@ impl StarrocksSinkWriter {
                         Value::String("1".to_owned()),
                     );
                     let row_json_string = serde_json::to_string(&row_json_value).map_err(|e| {
-                        SinkError::Starrocks(format!("Json derialize error: {}", e.as_report()))
+                        SinkError::Starrocks(format!("Json serialize error: {}", e.as_report()))
                     })?;
                     self.write_row_json(row_json_string).await?;
                 }
@@ -608,7 +608,7 @@ impl StarrocksSinkWriter {
                         Value::String("0".to_owned()),
                     );
                     let row_json_string = serde_json::to_string(&row_json_value).map_err(|e| {
-                        SinkError::Starrocks(format!("Json derialize error: {}", e.as_report()))
+                        SinkError::Starrocks(format!("Json serialize error: {}", e.as_report()))
                     })?;
                     self.write_row_json(row_json_string).await?;
                 }

--- a/src/connector/src/sink/starrocks.rs
+++ b/src/connector/src/sink/starrocks.rs
@@ -129,7 +129,7 @@ pub struct StarrocksConfig {
     pub partial_update: Option<String>,
 
     /// The maximum size in bytes for each `StarRocks` stream load request payload.
-    /// Defaults to 64 MiB.
+    /// Defaults to 64 `MiB`.
     #[serde(
         rename = "starrocks.max_batch_size_bytes",
         default = "default_starrocks_max_batch_size_bytes"

--- a/src/connector/src/sink/starrocks.rs
+++ b/src/connector/src/sink/starrocks.rs
@@ -129,7 +129,7 @@ pub struct StarrocksConfig {
     #[serde(rename = "starrocks.partial_update")]
     pub partial_update: Option<String>,
 
-    /// The maximum size in MB for each StarRocks stream load request payload.
+    /// The maximum size in MB for each `StarRocks` stream load request payload.
     /// If unset, RisingWave does not split the request by payload size.
     #[serde(rename = "starrocks.max_batch_size_mb", default)]
     #[serde_as(as = "Option<DisplayFromStr>")]

--- a/src/connector/with_options_sink.yaml
+++ b/src/connector/with_options_sink.yaml
@@ -1869,9 +1869,9 @@ StarrocksConfig:
     field_type: u64
     comments: |-
       The maximum size in bytes for each `StarRocks` stream load request payload.
-      Defaults to 64 MiB.
+      Defaults to 64 `MiB`.
     required: false
-    default: Some(DEFAULT_STARROCKS_MAX_BATCH_SIZE_BYTES)
+    default: Some (DEFAULT_STARROCKS_MAX_BATCH_SIZE_BYTES)
     allow_alter_on_fly: true
   - name: r#type
     field_type: String

--- a/src/connector/with_options_sink.yaml
+++ b/src/connector/with_options_sink.yaml
@@ -1869,9 +1869,8 @@ StarrocksConfig:
     field_type: u64
     comments: |-
       The maximum size in bytes for each `StarRocks` stream load request payload.
-      Defaults to 64 `MiB`.
+      Defaults to unlimited.
     required: false
-    default: Some (DEFAULT_STARROCKS_MAX_BATCH_SIZE_BYTES)
     allow_alter_on_fly: true
   - name: r#type
     field_type: String

--- a/src/connector/with_options_sink.yaml
+++ b/src/connector/with_options_sink.yaml
@@ -1868,9 +1868,10 @@ StarrocksConfig:
   - name: starrocks.max_batch_size_mb
     field_type: u64
     comments: |-
-      The maximum size in MB for each StarRocks stream load request payload.
+      The maximum size in MB for each `StarRocks` stream load request payload.
       If unset, RisingWave does not split the request by payload size.
     required: false
+    default: Default::default
     allow_alter_on_fly: true
   - name: r#type
     field_type: String

--- a/src/connector/with_options_sink.yaml
+++ b/src/connector/with_options_sink.yaml
@@ -1869,9 +1869,9 @@ StarrocksConfig:
     field_type: u64
     comments: |-
       The maximum size in bytes for each `StarRocks` stream load request payload.
-      If unset, RisingWave does not split the request by payload size.
+      Defaults to 64 MiB.
     required: false
-    default: Default::default
+    default: Some(DEFAULT_STARROCKS_MAX_BATCH_SIZE_BYTES)
     allow_alter_on_fly: true
   - name: r#type
     field_type: String

--- a/src/connector/with_options_sink.yaml
+++ b/src/connector/with_options_sink.yaml
@@ -1865,6 +1865,13 @@ StarrocksConfig:
     field_type: String
     comments: Enable partial update
     required: false
+  - name: starrocks.max_batch_size_mb
+    field_type: usize
+    comments: |-
+      The maximum size in MB for each StarRocks stream load request payload.
+      If unset, RisingWave does not split the request by payload size.
+    required: false
+    allow_alter_on_fly: true
   - name: r#type
     field_type: String
     required: true

--- a/src/connector/with_options_sink.yaml
+++ b/src/connector/with_options_sink.yaml
@@ -1865,10 +1865,10 @@ StarrocksConfig:
     field_type: String
     comments: Enable partial update
     required: false
-  - name: starrocks.max_batch_size_mb
+  - name: starrocks.max_batch_size_bytes
     field_type: u64
     comments: |-
-      The maximum size in MB for each `StarRocks` stream load request payload.
+      The maximum size in bytes for each `StarRocks` stream load request payload.
       If unset, RisingWave does not split the request by payload size.
     required: false
     default: Default::default

--- a/src/connector/with_options_sink.yaml
+++ b/src/connector/with_options_sink.yaml
@@ -1866,7 +1866,7 @@ StarrocksConfig:
     comments: Enable partial update
     required: false
   - name: starrocks.max_batch_size_mb
-    field_type: usize
+    field_type: u64
     comments: |-
       The maximum size in MB for each StarRocks stream load request payload.
       If unset, RisingWave does not split the request by payload size.


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

This PR adds `starrocks.max_batch_size_bytes` for StarRocks sinks. It defaults to 64 MiB (67108864 bytes) and can be overridden with another positive byte value.

The StarRocks stream load writer splits requests by encoded JSON payload size before sending them to StarRocks. The option can be altered on the fly and is exposed in the generated sink options.

The intent is to prevent oversized stream load requests by default while still allowing users to tune the threshold.

## Checklist

- [ ] I have written necessary rustdoc comments.
- [x] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->

## Documentation

- [x] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

StarRocks sinks now limit stream load request size to 64 MiB by default with `starrocks.max_batch_size_bytes`, reducing the risk of oversized load requests. Users can tune the limit by setting another positive byte value.

</details>

## Testing

- `cargo fmt --check`
- `cargo test -p risingwave_connector --features sink-starrocks starrocks_max_batch_size --lib`
- `cargo test -p risingwave_connector --features sink-starrocks starrocks_batch_size --lib`
- `cargo test -p risingwave_connector --features sink-starrocks starrocks --lib`
- `cargo +nightly-2025-10-10 test -p risingwave_connector allow_alter_on_fly`
