### PR TITLE
chore(release): bump version to v3.0.0-rc.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4398,7 +4398,7 @@ dependencies = [
 
 [[package]]
 name = "delta_btree_map"
-version = "2.9.0-alpha"
+version = "3.0.0-rc.1"
 dependencies = [
  "educe",
  "enum-as-inner 0.7.0",
@@ -8989,7 +8989,7 @@ checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
 
 [[package]]
 name = "openai_embedding_service"
-version = "2.9.0-alpha"
+version = "3.0.0-rc.1"
 dependencies = [
  "async-openai",
  "axum",
@@ -9654,7 +9654,7 @@ dependencies = [
 
 [[package]]
 name = "pgwire"
-version = "2.9.0-alpha"
+version = "3.0.0-rc.1"
 dependencies = [
  "anyhow",
  "auto_enums",
@@ -11339,7 +11339,7 @@ dependencies = [
 
 [[package]]
 name = "risedev"
-version = "2.9.0-alpha"
+version = "3.0.0-rc.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -11371,7 +11371,7 @@ dependencies = [
 
 [[package]]
 name = "risedev-config"
-version = "2.9.0-alpha"
+version = "3.0.0-rc.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -11384,7 +11384,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave-fields-derive"
-version = "2.9.0-alpha"
+version = "3.0.0-rc.1"
 dependencies = [
  "expect-test",
  "indoc",
@@ -11396,7 +11396,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_backup"
-version = "2.9.0-alpha"
+version = "3.0.0-rc.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11417,7 +11417,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_batch"
-version = "2.9.0-alpha"
+version = "3.0.0-rc.1"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -11461,7 +11461,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_batch_executors"
-version = "2.9.0-alpha"
+version = "3.0.0-rc.1"
 dependencies = [
  "allocator-api2",
  "anyhow",
@@ -11506,7 +11506,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_bench"
-version = "2.9.0-alpha"
+version = "3.0.0-rc.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -11527,7 +11527,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_cmd"
-version = "2.9.0-alpha"
+version = "3.0.0-rc.1"
 dependencies = [
  "clap",
  "madsim-tokio",
@@ -11547,7 +11547,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_cmd_all"
-version = "2.9.0-alpha"
+version = "3.0.0-rc.1"
 dependencies = [
  "clap",
  "console",
@@ -11580,7 +11580,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_common"
-version = "2.9.0-alpha"
+version = "3.0.0-rc.1"
 dependencies = [
  "ahash 0.8.11",
  "allocator-api2",
@@ -11698,7 +11698,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_common_estimate_size"
-version = "2.9.0-alpha"
+version = "3.0.0-rc.1"
 dependencies = [
  "bytes",
  "educe",
@@ -11712,7 +11712,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_common_heap_profiling"
-version = "2.9.0-alpha"
+version = "3.0.0-rc.1"
 dependencies = [
  "chrono",
  "itertools 0.14.0",
@@ -11731,7 +11731,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_common_log"
-version = "2.9.0-alpha"
+version = "3.0.0-rc.1"
 dependencies = [
  "governor",
  "madsim-tokio",
@@ -11741,7 +11741,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_common_metrics"
-version = "2.9.0-alpha"
+version = "3.0.0-rc.1"
 dependencies = [
  "auto_impl",
  "bytes",
@@ -11775,7 +11775,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_common_proc_macro"
-version = "2.9.0-alpha"
+version = "3.0.0-rc.1"
 dependencies = [
  "bae",
  "itertools 0.14.0",
@@ -11787,7 +11787,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_common_rate_limit"
-version = "2.9.0-alpha"
+version = "3.0.0-rc.1"
 dependencies = [
  "arc-swap",
  "madsim-tokio",
@@ -11801,7 +11801,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_common_secret"
-version = "2.9.0-alpha"
+version = "3.0.0-rc.1"
 dependencies = [
  "anyhow",
  "aws-lc-rs",
@@ -11825,7 +11825,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_common_service"
-version = "2.9.0-alpha"
+version = "3.0.0-rc.1"
 dependencies = [
  "async-trait",
  "axum",
@@ -11849,7 +11849,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_compaction_test"
-version = "2.9.0-alpha"
+version = "3.0.0-rc.1"
 dependencies = [
  "anyhow",
  "bytes",
@@ -11870,7 +11870,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_compactor"
-version = "2.9.0-alpha"
+version = "3.0.0-rc.1"
 dependencies = [
  "async-trait",
  "await-tree",
@@ -11894,7 +11894,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_compute"
-version = "2.9.0-alpha"
+version = "3.0.0-rc.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11940,7 +11940,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_connector"
-version = "2.9.0-alpha"
+version = "3.0.0-rc.1"
 dependencies = [
  "adbc_core",
  "adbc_snowflake",
@@ -12077,7 +12077,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_connector_codec"
-version = "2.9.0-alpha"
+version = "3.0.0-rc.1"
 dependencies = [
  "anyhow",
  "apache-avro 0.21.0 (git+https://github.com/risingwavelabs/avro-rs?rev=1f2723802d4fb77b97fa084f7bb81e3b60b9e03f)",
@@ -12112,7 +12112,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_ctl"
-version = "2.9.0-alpha"
+version = "3.0.0-rc.1"
 dependencies = [
  "anyhow",
  "bytes",
@@ -12152,7 +12152,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_dml"
-version = "2.9.0-alpha"
+version = "3.0.0-rc.1"
 dependencies = [
  "assert_matches",
  "futures",
@@ -12170,7 +12170,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_e2e_extended_mode_test"
-version = "2.9.0-alpha"
+version = "3.0.0-rc.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -12185,7 +12185,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_error"
-version = "2.9.0-alpha"
+version = "3.0.0-rc.1"
 dependencies = [
  "anyhow",
  "bincode 1.3.3",
@@ -12201,7 +12201,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_expr"
-version = "2.9.0-alpha"
+version = "3.0.0-rc.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -12239,7 +12239,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_expr_impl"
-version = "2.9.0-alpha"
+version = "3.0.0-rc.1"
 dependencies = [
  "aho-corasick",
  "anyhow",
@@ -12309,7 +12309,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_frontend"
-version = "2.9.0-alpha"
+version = "3.0.0-rc.1"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -12408,7 +12408,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_frontend_macro"
-version = "2.9.0-alpha"
+version = "3.0.0-rc.1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -12417,7 +12417,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_hummock_sdk"
-version = "2.9.0-alpha"
+version = "3.0.0-rc.1"
 dependencies = [
  "bytes",
  "hex",
@@ -12432,7 +12432,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_hummock_test"
-version = "2.9.0-alpha"
+version = "3.0.0-rc.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -12464,7 +12464,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_hummock_trace"
-version = "2.9.0-alpha"
+version = "3.0.0-rc.1"
 dependencies = [
  "async-trait",
  "bincode 2.0.1",
@@ -12536,7 +12536,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_license"
-version = "2.9.0-alpha"
+version = "3.0.0-rc.1"
 dependencies = [
  "auto_enums",
  "expect-test",
@@ -12555,7 +12555,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_mem_table_spill_test"
-version = "2.9.0-alpha"
+version = "3.0.0-rc.1"
 dependencies = [
  "madsim-tokio",
  "risingwave_common",
@@ -12566,7 +12566,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_meta"
-version = "2.9.0-alpha"
+version = "3.0.0-rc.1"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -12645,7 +12645,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_meta_dashboard"
-version = "2.9.0-alpha"
+version = "3.0.0-rc.1"
 dependencies = [
  "anyhow",
  "axum",
@@ -12666,7 +12666,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_meta_model"
-version = "2.9.0-alpha"
+version = "3.0.0-rc.1"
 dependencies = [
  "prost 0.14.3",
  "risingwave_common",
@@ -12678,7 +12678,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_meta_model_migration"
-version = "2.9.0-alpha"
+version = "3.0.0-rc.1"
 dependencies = [
  "easy-ext",
  "madsim-tokio",
@@ -12694,7 +12694,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_meta_node"
-version = "2.9.0-alpha"
+version = "3.0.0-rc.1"
 dependencies = [
  "clap",
  "educe",
@@ -12721,7 +12721,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_meta_service"
-version = "2.9.0-alpha"
+version = "3.0.0-rc.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -12750,7 +12750,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_mysql_test"
-version = "2.9.0-alpha"
+version = "3.0.0-rc.1"
 dependencies = [
  "futures",
  "madsim-tokio",
@@ -12759,7 +12759,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_object_store"
-version = "2.9.0-alpha"
+version = "3.0.0-rc.1"
 dependencies = [
  "async-trait",
  "await-tree",
@@ -12790,7 +12790,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_pb"
-version = "2.9.0-alpha"
+version = "3.0.0-rc.1"
 dependencies = [
  "enum-as-inner 0.7.0",
  "fs-err",
@@ -12817,7 +12817,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_planner_test"
-version = "2.9.0-alpha"
+version = "3.0.0-rc.1"
 dependencies = [
  "anyhow",
  "expect-test",
@@ -12839,7 +12839,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_regress_test"
-version = "2.9.0-alpha"
+version = "3.0.0-rc.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -12853,7 +12853,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_rpc_client"
-version = "2.9.0-alpha"
+version = "3.0.0-rc.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -12884,7 +12884,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_rt"
-version = "2.9.0-alpha"
+version = "3.0.0-rc.1"
 dependencies = [
  "await-tree",
  "console",
@@ -12969,7 +12969,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_sqlparser"
-version = "2.9.0-alpha"
+version = "3.0.0-rc.1"
 dependencies = [
  "anyhow",
  "console",
@@ -12990,7 +12990,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_sqlsmith"
-version = "2.9.0-alpha"
+version = "3.0.0-rc.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -13021,7 +13021,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_state_cleaning_test"
-version = "2.9.0-alpha"
+version = "3.0.0-rc.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -13040,7 +13040,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_storage"
-version = "2.9.0-alpha"
+version = "3.0.0-rc.1"
 dependencies = [
  "ahash 0.8.11",
  "anyhow",
@@ -13111,7 +13111,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_stream"
-version = "2.9.0-alpha"
+version = "3.0.0-rc.1"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -13186,7 +13186,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_telemetry_event"
-version = "2.9.0-alpha"
+version = "3.0.0-rc.1"
 dependencies = [
  "jsonbb",
  "madsim-tokio",
@@ -13200,7 +13200,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_test_runner"
-version = "2.9.0-alpha"
+version = "3.0.0-rc.1"
 dependencies = [
  "fail",
  "sync-point",
@@ -13209,7 +13209,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_variables"
-version = "2.9.0-alpha"
+version = "3.0.0-rc.1"
 dependencies = [
  "chrono",
  "workspace-hack",
@@ -18009,7 +18009,7 @@ dependencies = [
 
 [[package]]
 name = "with_options"
-version = "2.9.0-alpha"
+version = "3.0.0-rc.1"
 dependencies = [
  "quote",
  "syn 2.0.117",
@@ -18029,7 +18029,7 @@ dependencies = [
 
 [[package]]
 name = "workspace-config"
-version = "2.9.0-alpha"
+version = "3.0.0-rc.1"
 dependencies = [
  "aws-lc-rs",
  "liblzma-sys",
@@ -18043,7 +18043,7 @@ dependencies = [
 
 [[package]]
 name = "workspace-hack"
-version = "2.9.0-alpha"
+version = "3.0.0-rc.1"
 
 [[package]]
 name = "wyz"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,7 +79,7 @@ exclude = [
 resolver = "2"
 
 [workspace.package]
-version = "2.9.0-alpha"
+version = "3.0.0-rc.1"
 edition = "2024"
 homepage = "https://github.com/risingwavelabs/risingwave"
 keywords = ["sql", "database", "streaming"]

--- a/docker/docker-compose-distributed.yml
+++ b/docker/docker-compose-distributed.yml
@@ -1,6 +1,6 @@
 ---
 x-image: &image
-  image: ${RW_IMAGE:-risingwavelabs/risingwave:v2.7.1}
+  image: ${RW_IMAGE:-risingwavelabs/risingwave:v3.0.0-rc.1}
 services:
   compactor-0:
     <<: *image

--- a/docker/docker-compose-with-azblob.yml
+++ b/docker/docker-compose-with-azblob.yml
@@ -1,6 +1,6 @@
 ---
 x-image: &image
-  image: ${RW_IMAGE:-risingwavelabs/risingwave:v2.7.1}
+  image: ${RW_IMAGE:-risingwavelabs/risingwave:v3.0.0-rc.1}
 services:
   risingwave-standalone:
     <<: *image

--- a/docker/docker-compose-with-gcs.yml
+++ b/docker/docker-compose-with-gcs.yml
@@ -1,6 +1,6 @@
 ---
 x-image: &image
-  image: ${RW_IMAGE:-risingwavelabs/risingwave:v2.7.1}
+  image: ${RW_IMAGE:-risingwavelabs/risingwave:v3.0.0-rc.1}
 services:
   risingwave-standalone:
     <<: *image

--- a/docker/docker-compose-with-lakekeeper.yml
+++ b/docker/docker-compose-with-lakekeeper.yml
@@ -1,6 +1,6 @@
 ---
 x-image: &image
-  image: ${RW_IMAGE:-risingwavelabs/risingwave:v2.7.1}
+  image: ${RW_IMAGE:-risingwavelabs/risingwave:v3.0.0-rc.1}
 
 x-lakekeeper-image: &lakekeeper-image
   image: ${LAKEKEEPER__SERVER_IMAGE:-quay.io/lakekeeper/catalog:latest-main}

--- a/docker/docker-compose-with-local-fs.yml
+++ b/docker/docker-compose-with-local-fs.yml
@@ -1,6 +1,6 @@
 ---
 x-image: &image
-  image: ${RW_IMAGE:-risingwavelabs/risingwave:v2.7.1}
+  image: ${RW_IMAGE:-risingwavelabs/risingwave:v3.0.0-rc.1}
 services:
   risingwave-standalone:
     <<: *image

--- a/docker/docker-compose-with-obs.yml
+++ b/docker/docker-compose-with-obs.yml
@@ -1,6 +1,6 @@
 ---
 x-image: &image
-  image: ${RW_IMAGE:-risingwavelabs/risingwave:v2.7.1}
+  image: ${RW_IMAGE:-risingwavelabs/risingwave:v3.0.0-rc.1}
 services:
   risingwave-standalone:
     <<: *image

--- a/docker/docker-compose-with-oss.yml
+++ b/docker/docker-compose-with-oss.yml
@@ -1,6 +1,6 @@
 ---
 x-image: &image
-  image: ${RW_IMAGE:-risingwavelabs/risingwave:v2.7.1}
+  image: ${RW_IMAGE:-risingwavelabs/risingwave:v3.0.0-rc.1}
 services:
   risingwave-standalone:
     <<: *image

--- a/docker/docker-compose-with-s3.yml
+++ b/docker/docker-compose-with-s3.yml
@@ -1,6 +1,6 @@
 ---
 x-image: &image
-  image: ${RW_IMAGE:-risingwavelabs/risingwave:v2.7.1}
+  image: ${RW_IMAGE:-risingwavelabs/risingwave:v3.0.0-rc.1}
 services:
   risingwave-standalone:
     <<: *image

--- a/docker/docker-compose-with-sqlite.yml
+++ b/docker/docker-compose-with-sqlite.yml
@@ -1,6 +1,6 @@
 ---
 x-image: &image
-  image: ${RW_IMAGE:-risingwavelabs/risingwave:v2.7.1}
+  image: ${RW_IMAGE:-risingwavelabs/risingwave:v3.0.0-rc.1}
 services:
   risingwave-standalone:
     <<: *image

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,6 +1,6 @@
 ---
 x-image: &image
-  image: ${RW_IMAGE:-risingwavelabs/risingwave:v2.7.1}
+  image: ${RW_IMAGE:-risingwavelabs/risingwave:v3.0.0-rc.1}
 services:
   risingwave-standalone:
     <<: *image


### PR DESCRIPTION
This PR bumps the version from v2.9.0-alpha to v3.0.0-rc.1 for the release.

## Changes

- Update Cargo.toml version to 3.0.0-rc.1
- Update Docker image tags to v3.0.0-rc.1
- Run cargo update -vv -w to update workspace dependencies

## Checklist

- [x] Version bumped in Cargo.toml
- [x] Docker image tags updated
- [x] Cargo.lock updated via cargo update

## Release Notes

See [CHANGELOG](https://github.com/risingwavelabs/risingwave/blob/release-3.0/CHANGELOG.md) for detailed changes in this release.

## Related

Release version: v3.0.0-rc.1
Base branch: release-3.0