### PR TITLE
fix(cdc): avoid aborting auto schema change on non-constant default expressions (#25431) [backport 2.8 patch]

### DIFF
--- a/e2e_test/source_legacy/cdc_inline/auto_schema_change_pg.slt
+++ b/e2e_test/source_legacy/cdc_inline/auto_schema_change_pg.slt
@@ -13,7 +13,7 @@ psql -c "
         v4 boolean DEFAULT false,
         v5 date DEFAULT '2020-01-01',
         v6 time DEFAULT '12:34:56',
-        v7 timestamp DEFAULT '2020-01-01 12:34:56',
+        v7 timestamp DEFAULT now(),
         v8 timestamptz DEFAULT '2020-01-01 12:34:56+00',
         v9 interval DEFAULT '1 day',
         v10 jsonb DEFAULT '{}',
@@ -61,12 +61,14 @@ distribution key id NULL NULL
 table description rw_test_schema_change NULL NULL
 
 
+# v7 defaults to `now()` upstream, so its value is non-deterministic;
+# use <slt:ignore> to skip matching those two tokens (date + time).
 query TTTTTTTTTTTTT retry 4 backoff 1s
 SELECT * from rw_test_schema_change order by id;
 ----
-1 name1 20 1.1 2.2 3.3 f 2020-01-01 12:34:56 2020-01-01 12:34:56 2020-01-01 12:34:56+00:00 1 day {}
-2 name2 21 1.1 2.2 3.3 f 2020-01-01 12:34:56 2020-01-01 12:34:56 2020-01-01 12:34:56+00:00 1 day {}
-3 name3 22 1.1 2.2 3.3 f 2020-01-01 12:34:56 2020-01-01 12:34:56 2020-01-01 12:34:56+00:00 1 day {}
+1 name1 20 1.1 2.2 3.3 f 2020-01-01 12:34:56 <slt:ignore> <slt:ignore> 2020-01-01 12:34:56+00:00 1 day {}
+2 name2 21 1.1 2.2 3.3 f 2020-01-01 12:34:56 <slt:ignore> <slt:ignore> 2020-01-01 12:34:56+00:00 1 day {}
+3 name3 22 1.1 2.2 3.3 f 2020-01-01 12:34:56 <slt:ignore> <slt:ignore> 2020-01-01 12:34:56+00:00 1 day {}
 
 sleep 3s
 
@@ -108,10 +110,10 @@ table description rw_test_schema_change NULL NULL
 query TTTTTTTTTTTTTTT retry 4 backoff 1s
 SELECT * from rw_test_schema_change order by id;
 ----
-1 name1 20 1.1 2.2 3.3 f 2020-01-01 12:34:56 2020-01-01 12:34:56 2020-01-01 12:34:56+00:00 1 day {} hello 1.2345
-2 name2 21 1.1 2.2 3.3 f 2020-01-01 12:34:56 2020-01-01 12:34:56 2020-01-01 12:34:56+00:00 1 day {} hello 1.2345
-3 name3 22 1.1 2.2 3.3 f 2020-01-01 12:34:56 2020-01-01 12:34:56 2020-01-01 12:34:56+00:00 1 day {} hello 1.2345
-11 aaa 11 1.1 2.2 3.3 f 2020-01-01 12:34:56 2020-01-01 12:34:56 2020-01-01 12:34:56+00:00 1 day {} hello 1.2345
+1 name1 20 1.1 2.2 3.3 f 2020-01-01 12:34:56 <slt:ignore> <slt:ignore> 2020-01-01 12:34:56+00:00 1 day {} hello 1.2345
+2 name2 21 1.1 2.2 3.3 f 2020-01-01 12:34:56 <slt:ignore> <slt:ignore> 2020-01-01 12:34:56+00:00 1 day {} hello 1.2345
+3 name3 22 1.1 2.2 3.3 f 2020-01-01 12:34:56 <slt:ignore> <slt:ignore> 2020-01-01 12:34:56+00:00 1 day {} hello 1.2345
+11 aaa 11 1.1 2.2 3.3 f 2020-01-01 12:34:56 <slt:ignore> <slt:ignore> 2020-01-01 12:34:56+00:00 1 day {} hello 1.2345
 
 
 system ok
@@ -153,11 +155,11 @@ table description rw_test_schema_change NULL NULL
 query TTTTTTTTTTTTTTT retry 4 backoff 1s
 SELECT * from rw_test_schema_change order by id;
 ----
-1 name1 20 3.3 f 2020-01-01 12:34:56 2020-01-01 12:34:56 2020-01-01 12:34:56+00:00 1 day {} hello 1.2345
-2 name2 21 3.3 f 2020-01-01 12:34:56 2020-01-01 12:34:56 2020-01-01 12:34:56+00:00 1 day {} hello 1.2345
-3 name3 22 3.3 f 2020-01-01 12:34:56 2020-01-01 12:34:56 2020-01-01 12:34:56+00:00 1 day {} hello 1.2345
-11 aaa 11 3.3 f 2020-01-01 12:34:56 2020-01-01 12:34:56 2020-01-01 12:34:56+00:00 1 day {} hello 1.2345
-12 bbb 12 3.3 f 2020-01-01 12:34:56 2020-01-01 12:34:56 2020-01-01 12:34:56+00:00 1 day {} hello 1.2345
+1 name1 20 3.3 f 2020-01-01 12:34:56 <slt:ignore> <slt:ignore> 2020-01-01 12:34:56+00:00 1 day {} hello 1.2345
+2 name2 21 3.3 f 2020-01-01 12:34:56 <slt:ignore> <slt:ignore> 2020-01-01 12:34:56+00:00 1 day {} hello 1.2345
+3 name3 22 3.3 f 2020-01-01 12:34:56 <slt:ignore> <slt:ignore> 2020-01-01 12:34:56+00:00 1 day {} hello 1.2345
+11 aaa 11 3.3 f 2020-01-01 12:34:56 <slt:ignore> <slt:ignore> 2020-01-01 12:34:56+00:00 1 day {} hello 1.2345
+12 bbb 12 3.3 f 2020-01-01 12:34:56 <slt:ignore> <slt:ignore> 2020-01-01 12:34:56+00:00 1 day {} hello 1.2345
 
 
 statement ok

--- a/src/connector/src/parser/unified/debezium.rs
+++ b/src/connector/src/parser/unified/debezium.rs
@@ -451,23 +451,49 @@ pub async fn parse_schema_change(
                                     }
                                 }
 
-                                let snapshot_value: Datum = if let Some(value_text) = value_text {
-                                    Some(ScalarImpl::from_text(value_text.as_str(), &data_type).map_err(
-                                        |err| {
-                                            tracing::error!(target: "auto_schema_change", error=%err.as_report(), "failed to parse default value expression");
-                                            AccessError::TypeError {
-                                                expected: "constant expression".into(),
-                                                got: data_type.to_string(),
-                                                value: value_text,
-                                            }
-                                        },
-                                    )?)
-                                } else {
-                                    None
-                                };
+                                // Handling default values during auto schema change is hard to get
+                                // completely right. The fundamental challenge is that we need to
+                                // accurately distinguish "literal constants" from "real expressions"
+                                // and evaluate each correctly. However, PostgreSQL / MySQL literal
+                                // grammar is quite complex (bit / hex / escape strings, arrays,
+                                // literals with casts, etc.), and `ScalarImpl::from_text` only
+                                // recognizes simple literals. Any function call (`now()`,
+                                // `gen_random_uuid()`) or unsupported literal form will fail here.
+                                //
+                                // Current strategy is fail-open: on parse failure we only emit a
+                                // warn log and add the column without a default, rather than
+                                // aborting the whole auto schema change. This is strictly better
+                                // than the previous hard-crash behavior — the pipeline stays
+                                // available, and the worst case is that existing rows are NULL in a
+                                // newly-added column (see the warn message below for details).
+                                //
+                                // TODO: the schema change event carries the **full** set of columns
+                                // of the table, so here we cannot tell "columns newly added by this
+                                // ALTER" from "columns that already existed". A better approach
+                                // would be to only process the delta columns that actually changed
+                                // in this event, which would let us precisely tell the user: which
+                                // columns have existing rows filled with NULL (needs attention),
+                                // and which ones are pre-existing columns merely surfaced by the
+                                // event (harmless, can be ignored silently).
+                                let snapshot_value: Datum = value_text.and_then(|value_text| {
+                                    ScalarImpl::from_text(value_text.as_str(), &data_type)
+                                        .inspect_err(|err| {
+                                            tracing::warn!(
+                                                target: "auto_schema_change",
+                                                error = %err.as_report(),
+                                                column = %name,
+                                                data_type = %data_type,
+                                                default_value_expression = default_val_expr_str,
+                                                upstream_ddl = %upstream_ddl,
+                                                "non-constant default expression, column added without default. \
+                                                 If this column is not newly added by this schema change, it is safe to ignore this warning. \
+                                                 If this column is newly added by this schema change, existing rows will be NULL in this column — consider using COALESCE in queries to provide a fallback value."
+                                            );
+                                        })
+                                        .ok()
+                                });
 
                                 if snapshot_value.is_none() {
-                                    tracing::warn!(target: "auto_schema_change", "failed to parse default value expression: {}", default_val_expr_str);
                                     ColumnDesc::named(name, ColumnId::placeholder(), data_type)
                                 } else {
                                     ColumnDesc::named_with_default_value(


### PR DESCRIPTION
Backport of #25431 onto the customer patch branch `v2.8-dynamic-http-double-quote` (2.8.3-based).

## Why

A customer on this 2.8.3 patch build sees repeated `AUTO_SCHEMA_CHANGE_FAIL` events:

```
Failed to parse schema change: Cannot parse value `CURRENT_TIMESTAMP` with type
`timestamp without time zone` into expected type `constant expression`, source: pg_source
```

On 2.8 the auto schema change path hard-aborts when a column default cannot be parsed
into a constant (e.g. `CURRENT_TIMESTAMP`). Because the schema-change event carries the
**full** column set of the table — not just the delta — this fires even for pre-existing
columns that were already backfilled, so it is harmless noise but surfaces as an error
event and aborts processing of that event.

#25431 (already in 3.0) changes this to **fail-open**: on parse failure it logs a warning
and adds the column without a default, instead of aborting the whole schema change.

## What

Clean cherry-pick of `4a4de64017` (#25431). No conflicts; identical to the merged commit.

## Impact

No behavior change for parseable constant defaults. For non-constant defaults
(`CURRENT_TIMESTAMP`, `now()`, `gen_random_uuid()`, sequences, etc.) the pipeline stays
available; worst case is a genuinely new column having NULL for existing rows.
