### PR TITLE
feat(compaction): support manual compact target level

### DIFF
--- a/proto/hummock.proto
+++ b/proto/hummock.proto
@@ -762,6 +762,7 @@ message TriggerManualCompactionRequest {
   uint32 level = 4;
   repeated uint64 sst_ids = 5;
   optional bool exclusive = 6;
+  optional uint32 target_level = 7;
 }
 
 message TriggerManualCompactionResponse {

--- a/src/ctl/src/cmd_impl/hummock/trigger_manual_compaction.rs
+++ b/src/ctl/src/cmd_impl/hummock/trigger_manual_compaction.rs
@@ -24,6 +24,7 @@ pub async fn trigger_manual_compaction(
     compaction_group_id: CompactionGroupId,
     table_id: JobId,
     levels: Vec<u32>,
+    target_level: Option<u32>,
     sst_ids: Vec<HummockSstableId>,
     exclusive: bool,
     retry_interval_ms: u64,
@@ -37,6 +38,7 @@ pub async fn trigger_manual_compaction(
                     compaction_group_id,
                     table_id,
                     level,
+                    target_level,
                     sst_ids.clone(),
                     exclusive,
                 )

--- a/src/ctl/src/lib.rs
+++ b/src/ctl/src/lib.rs
@@ -137,6 +137,9 @@ enum HummockCommands {
         #[clap(short, long = "level", value_delimiter = ',', default_values_t = vec![1u32])]
         levels: Vec<u32>,
 
+        #[clap(long = "target-level")]
+        target_level: Option<u32>,
+
         #[clap(short, long = "sst-ids", value_delimiter = ',')]
         sst_ids: Vec<HummockSstableId>,
 
@@ -656,6 +659,7 @@ async fn start_impl(opts: CliOpts, context: &CtlContext) -> Result<()> {
             compaction_group_id,
             table_id,
             levels,
+            target_level,
             sst_ids,
             exclusive,
             retry_interval_ms,
@@ -665,6 +669,7 @@ async fn start_impl(opts: CliOpts, context: &CtlContext) -> Result<()> {
                 compaction_group_id,
                 table_id.into(),
                 levels,
+                target_level,
                 sst_ids,
                 exclusive,
                 retry_interval_ms,

--- a/src/meta/service/src/hummock_service.rs
+++ b/src/meta/service/src/hummock_service.rs
@@ -185,6 +185,9 @@ impl HummockManagerService for HummockServiceImpl {
         let compaction_group_id = request.compaction_group_id;
         let mut option = ManualCompactionOption {
             level: request.level as usize,
+            target_level: request
+                .target_level
+                .map(|target_level| target_level as usize),
             sst_ids: request.sst_ids,
             exclusive: request.exclusive.unwrap_or(false),
             ..Default::default()

--- a/src/meta/src/hummock/compaction/picker/manual_compaction_picker.rs
+++ b/src/meta/src/hummock/compaction/picker/manual_compaction_picker.rs
@@ -1392,6 +1392,10 @@ pub mod tests {
                 )
                 .is_none()
         );
+        assert_eq!(
+            selector.validation_error(),
+            Some("target_level for L0 must be 3, got 4")
+        );
     }
 
     /// tests `DynamicLevelSelector::manual_pick_compaction`

--- a/src/meta/src/hummock/compaction/picker/manual_compaction_picker.rs
+++ b/src/meta/src/hummock/compaction/picker/manual_compaction_picker.rs
@@ -520,6 +520,7 @@ pub mod tests {
                     right_exclusive: false,
                 },
                 internal_table_id: HashSet::from([2.into()]),
+                target_level: None,
                 exclusive: false,
             };
 
@@ -687,6 +688,7 @@ pub mod tests {
                 right_exclusive: false,
             },
             internal_table_id: HashSet::default(),
+            target_level: None,
             exclusive: false,
         };
         let mut picker =
@@ -716,6 +718,7 @@ pub mod tests {
                 right_exclusive: false,
             },
             internal_table_id: HashSet::default(),
+            target_level: None,
             exclusive: false,
         };
         let mut picker = ManualCompactionPicker::new(
@@ -766,6 +769,7 @@ pub mod tests {
                 right_exclusive: false,
             },
             internal_table_id: HashSet::default(),
+            target_level: None,
             exclusive: false,
         };
         let mut picker =
@@ -818,6 +822,7 @@ pub mod tests {
                     right_exclusive: false,
                 },
                 internal_table_id: HashSet::default(),
+                target_level: None,
                 exclusive: false,
             };
             let mut picker = ManualCompactionPicker::new(
@@ -861,6 +866,7 @@ pub mod tests {
                 },
                 // No matching internal table id.
                 internal_table_id: HashSet::from([100.into()]),
+                target_level: None,
                 exclusive: false,
             };
             let mut picker = ManualCompactionPicker::new(
@@ -886,6 +892,7 @@ pub mod tests {
                 },
                 // Include all sub level's table ids
                 internal_table_id: HashSet::from([1.into(), 2.into(), 3.into()]),
+                target_level: None,
                 exclusive: false,
             };
             let mut picker = ManualCompactionPicker::new(
@@ -931,6 +938,7 @@ pub mod tests {
                 },
                 // Only include bottom sub level's table id
                 internal_table_id: HashSet::from([3.into()]),
+                target_level: None,
                 exclusive: false,
             };
             let mut picker = ManualCompactionPicker::new(
@@ -976,6 +984,7 @@ pub mod tests {
                 // Only include partial top sub level's table id, but the whole top sub level is
                 // picked.
                 internal_table_id: HashSet::from([1.into()]),
+                target_level: None,
                 exclusive: false,
             };
             let mut picker = ManualCompactionPicker::new(
@@ -1020,6 +1029,7 @@ pub mod tests {
                 },
                 // Only include bottom sub level's table id
                 internal_table_id: HashSet::from([3.into()]),
+                target_level: None,
                 exclusive: false,
             };
             let mut picker = ManualCompactionPicker::new(
@@ -1056,6 +1066,7 @@ pub mod tests {
                 },
                 // No matching internal table id.
                 internal_table_id: HashSet::from([100.into()]),
+                target_level: None,
                 exclusive: false,
             };
             let mut picker = ManualCompactionPicker::new(
@@ -1082,6 +1093,7 @@ pub mod tests {
                 },
                 // Only include partial input level's table id
                 internal_table_id: HashSet::from([1.into()]),
+                target_level: None,
                 exclusive: false,
             };
             let mut picker = ManualCompactionPicker::new(
@@ -1134,6 +1146,7 @@ pub mod tests {
                     right_exclusive: false,
                 },
                 internal_table_id: HashSet::default(),
+                target_level: None,
                 exclusive: false,
             };
             let mut picker = ManualCompactionPicker::new(
@@ -1181,6 +1194,7 @@ pub mod tests {
                     right_exclusive: false,
                 },
                 internal_table_id: HashSet::default(),
+                target_level: None,
                 exclusive: false,
             };
             let mut picker = ManualCompactionPicker::new(
@@ -1253,6 +1267,7 @@ pub mod tests {
                 },
                 internal_table_id: HashSet::default(),
                 level: 0,
+                target_level: None,
                 exclusive: false,
             };
             let mut selector = ManualCompactionSelector::new(option);
@@ -1296,6 +1311,7 @@ pub mod tests {
                 },
                 internal_table_id: HashSet::default(),
                 level: 0,
+                target_level: None,
                 exclusive: false,
             };
             let mut selector = ManualCompactionSelector::new(option);
@@ -1375,6 +1391,7 @@ pub mod tests {
                 },
                 internal_table_id: HashSet::default(),
                 level: 3,
+                target_level: None,
                 exclusive: false,
             };
             let mut selector = ManualCompactionSelector::new(option);
@@ -1409,6 +1426,52 @@ pub mod tests {
             }
         }
 
+        // pick l3 -> l3
+        {
+            let option = ManualCompactionOption {
+                sst_ids: [0, 1].iter().cloned().map(Into::into).collect(),
+                key_range: KeyRange {
+                    left: Bytes::default(),
+                    right: Bytes::default(),
+                    right_exclusive: false,
+                },
+                internal_table_id: HashSet::default(),
+                level: 3,
+                target_level: Some(3),
+                exclusive: false,
+            };
+            let mut selector = ManualCompactionSelector::new(option);
+            let task = selector
+                .pick_compaction(
+                    2,
+                    compaction_selector_context(
+                        &group_config,
+                        &levels,
+                        &BTreeSet::new(),
+                        &mut levels_handler,
+                        &mut local_stats,
+                        &HashMap::default(),
+                        Arc::new(CompactionDeveloperConfig::default()),
+                        &Default::default(),
+                        &HummockVersionStateTableInfo::empty(),
+                    ),
+                )
+                .unwrap();
+            assert_compaction_task(&task, &levels_handler);
+            assert_eq!(task.input.input_levels.len(), 2);
+            assert_eq!(task.input.input_levels[0].level_idx, 3);
+            assert_eq!(task.input.input_levels[0].table_infos.len(), 2);
+            assert_eq!(task.input.input_levels[1].level_idx, 3);
+            assert_eq!(task.input.input_levels[1].table_infos.len(), 0);
+            assert_eq!(task.input.target_level, 3);
+        }
+
+        for level_handler in &mut levels_handler {
+            for pending_task_id in &level_handler.pending_tasks_ids() {
+                level_handler.remove_task(*pending_task_id);
+            }
+        }
+
         // pick l4 -> l4
         {
             let option = ManualCompactionOption {
@@ -1420,6 +1483,7 @@ pub mod tests {
                 },
                 internal_table_id: HashSet::default(),
                 level: 4,
+                target_level: None,
                 exclusive: false,
             };
             let mut selector = ManualCompactionSelector::new(option);

--- a/src/meta/src/hummock/compaction/picker/manual_compaction_picker.rs
+++ b/src/meta/src/hummock/compaction/picker/manual_compaction_picker.rs
@@ -1340,6 +1340,60 @@ pub mod tests {
         }
     }
 
+    #[test]
+    fn test_manual_compaction_selector_rejects_l0_non_base_target_level() {
+        let config = CompactionConfigBuilder::new().max_level(4).build();
+        let group_config = CompactionGroup::new(1, config);
+        let l0 = generate_l0_nonoverlapping_sublevels(vec![
+            generate_table(0, 1, 0, 500, 1),
+            generate_table(1, 1, 0, 500, 1),
+        ]);
+        let levels = Levels {
+            levels: vec![
+                generate_level(1, vec![]),
+                generate_level(2, vec![]),
+                generate_level(3, vec![generate_table(2, 1, 0, 500, 1)]),
+                generate_level(4, vec![]),
+            ],
+            l0,
+            ..Default::default()
+        };
+        let mut levels_handler = (0..5).map(LevelHandler::new).collect_vec();
+        let mut local_stats = LocalSelectorStatistic::default();
+        let option = ManualCompactionOption {
+            sst_ids: vec![],
+            key_range: KeyRange {
+                left: Bytes::default(),
+                right: Bytes::default(),
+                right_exclusive: false,
+            },
+            internal_table_id: HashSet::default(),
+            level: 0,
+            target_level: Some(4),
+            exclusive: false,
+        };
+        let mut selector = ManualCompactionSelector::new(option);
+
+        assert!(
+            selector
+                .pick_compaction(
+                    1,
+                    compaction_selector_context(
+                        &group_config,
+                        &levels,
+                        &BTreeSet::new(),
+                        &mut levels_handler,
+                        &mut local_stats,
+                        &HashMap::default(),
+                        Arc::new(CompactionDeveloperConfig::default()),
+                        &Default::default(),
+                        &HummockVersionStateTableInfo::empty(),
+                    ),
+                )
+                .is_none()
+        );
+    }
+
     /// tests `DynamicLevelSelector::manual_pick_compaction`
     #[test]
     fn test_manual_compaction_selector() {

--- a/src/meta/src/hummock/compaction/selector/manual_selector.rs
+++ b/src/meta/src/hummock/compaction/selector/manual_selector.rs
@@ -42,6 +42,8 @@ pub struct ManualCompactionOption {
     pub internal_table_id: HashSet<StateTableId>,
     /// Input level.
     pub level: usize,
+    /// Output level. Defaults to the implicit manual compaction target if unset.
+    pub target_level: Option<usize>,
     /// When true, skip manual compaction if any task is pending in the compaction group.
     pub exclusive: bool,
 }
@@ -57,6 +59,7 @@ impl Default for ManualCompactionOption {
             },
             internal_table_id: HashSet::default(),
             level: 1,
+            target_level: None,
             exclusive: false,
         }
     }
@@ -100,13 +103,28 @@ impl CompactionSelector for ManualCompactionSelector {
         let overlap_strategy = create_overlap_strategy(group.compaction_config.compaction_mode());
         let ctx = dynamic_level_core.calculate_level_base_size(levels);
         let (mut picker, base_level) = {
-            let target_level = if self.option.level == 0 {
-                ctx.base_level
-            } else if self.option.level == group.compaction_config.max_level as usize {
-                self.option.level
-            } else {
-                self.option.level + 1
-            };
+            let max_level = group.compaction_config.max_level as usize;
+            if self.option.level > max_level {
+                return None;
+            }
+            let target_level = self.option.target_level.unwrap_or_else(|| {
+                if self.option.level == 0 {
+                    ctx.base_level
+                } else if self.option.level == group.compaction_config.max_level as usize {
+                    self.option.level
+                } else {
+                    self.option.level + 1
+                }
+            });
+            if target_level > max_level {
+                return None;
+            }
+            if self.option.level > 0
+                && target_level != self.option.level
+                && target_level != self.option.level + 1
+            {
+                return None;
+            }
             if self.option.level > 0 && self.option.level < ctx.base_level {
                 return None;
             }

--- a/src/meta/src/hummock/compaction/selector/manual_selector.rs
+++ b/src/meta/src/hummock/compaction/selector/manual_selector.rs
@@ -119,6 +119,9 @@ impl CompactionSelector for ManualCompactionSelector {
             if target_level > max_level {
                 return None;
             }
+            if self.option.level == 0 && target_level != ctx.base_level {
+                return None;
+            }
             if self.option.level > 0
                 && target_level != self.option.level
                 && target_level != self.option.level + 1

--- a/src/meta/src/hummock/compaction/selector/manual_selector.rs
+++ b/src/meta/src/hummock/compaction/selector/manual_selector.rs
@@ -68,6 +68,7 @@ impl Default for ManualCompactionOption {
 pub struct ManualCompactionSelector {
     option: ManualCompactionOption,
     blocked_by_pending: bool,
+    validation_error: Option<String>,
 }
 
 impl ManualCompactionSelector {
@@ -75,11 +76,16 @@ impl ManualCompactionSelector {
         Self {
             option,
             blocked_by_pending: false,
+            validation_error: None,
         }
     }
 
     pub fn blocked_by_pending(&self) -> bool {
         self.blocked_by_pending
+    }
+
+    pub fn validation_error(&self) -> Option<&str> {
+        self.validation_error.as_deref()
     }
 }
 
@@ -97,6 +103,7 @@ impl CompactionSelector for ManualCompactionSelector {
             ..
         } = context;
         self.blocked_by_pending = false;
+        self.validation_error = None;
 
         let dynamic_level_core =
             DynamicLevelSelectorCore::new(group.compaction_config.clone(), developer_config);
@@ -105,11 +112,19 @@ impl CompactionSelector for ManualCompactionSelector {
         let (mut picker, base_level) = {
             let max_level = group.compaction_config.max_level as usize;
             if self.option.level > max_level {
+                self.validation_error = Some(format!(
+                    "level {} exceeds max_level {}",
+                    self.option.level, max_level
+                ));
                 return None;
             }
             let target_level = self.option.target_level.unwrap_or_else(|| {
                 if self.option.level == 0 {
-                    ctx.base_level
+                    if self.option.sst_ids.is_empty() {
+                        ctx.base_level
+                    } else {
+                        0
+                    }
                 } else if self.option.level == group.compaction_config.max_level as usize {
                     self.option.level
                 } else {
@@ -117,15 +132,37 @@ impl CompactionSelector for ManualCompactionSelector {
                 }
             });
             if target_level > max_level {
+                self.validation_error = Some(format!(
+                    "target_level {} exceeds max_level {}",
+                    target_level, max_level
+                ));
                 return None;
             }
-            if self.option.level == 0 && target_level != ctx.base_level {
-                return None;
+            if self.option.level == 0 {
+                let expected_target_level = if self.option.sst_ids.is_empty() {
+                    ctx.base_level
+                } else {
+                    0
+                };
+                if target_level != expected_target_level {
+                    self.validation_error = Some(format!(
+                        "target_level for L0 must be {}, got {}",
+                        expected_target_level, target_level
+                    ));
+                    return None;
+                }
             }
             if self.option.level > 0
                 && target_level != self.option.level
                 && target_level != self.option.level + 1
             {
+                self.validation_error = Some(format!(
+                    "target_level for L{} must be {} or {}, got {}",
+                    self.option.level,
+                    self.option.level,
+                    self.option.level + 1,
+                    target_level
+                ));
                 return None;
             }
             if self.option.level > 0 && self.option.level < ctx.base_level {

--- a/src/meta/src/hummock/error.rs
+++ b/src/meta/src/hummock/error.rs
@@ -44,6 +44,8 @@ pub enum Error {
     CompactionGroup(String),
     #[error("SST {0} is invalid")]
     InvalidSst(HummockSstableObjectId),
+    #[error("invalid manual compaction option: {0}")]
+    InvalidManualCompactionOption(String),
     #[error("time travel")]
     TimeTravel(
         #[source]
@@ -78,6 +80,10 @@ impl From<sea_orm::DbErr> for Error {
 
 impl From<Error> for tonic::Status {
     fn from(err: Error) -> Self {
-        err.to_status(tonic::Code::Internal, "hummock")
+        let code = match &err {
+            Error::InvalidManualCompactionOption(_) => tonic::Code::InvalidArgument,
+            _ => tonic::Code::Internal,
+        };
+        err.to_status(code, "hummock")
     }
 }

--- a/src/meta/src/hummock/manager/compaction/mod.rs
+++ b/src/meta/src/hummock/manager/compaction/mod.rs
@@ -747,6 +747,9 @@ impl HummockManager {
         let task = self
             .get_compact_task(compaction_group_id, &mut selector)
             .await?;
+        if let Some(err) = selector.validation_error() {
+            return Err(Error::InvalidManualCompactionOption(err.to_owned()));
+        }
         Ok((task, selector.blocked_by_pending()))
     }
 
@@ -1047,6 +1050,9 @@ impl HummockManager {
             Ok((compact_task, blocked_by_pending)) => (compact_task, blocked_by_pending),
             Err(err) => {
                 tracing::warn!(error = %err.as_report(), "Failed to get compaction task");
+                if matches!(err, Error::InvalidManualCompactionOption(_)) {
+                    return Err(err);
+                }
 
                 return Err(anyhow::anyhow!(err)
                     .context(format!(

--- a/src/meta/src/hummock/manager/tests.rs
+++ b/src/meta/src/hummock/manager/tests.rs
@@ -1051,6 +1051,24 @@ async fn test_trigger_manual_compaction() {
     )
     .await;
     {
+        let option = ManualCompactionOption {
+            level: 0,
+            target_level: Some(0),
+            ..Default::default()
+        };
+        let result = hummock_manager
+            .trigger_manual_compaction(StaticCompactionGroupId::StateDefault, option)
+            .await;
+
+        assert!(
+            result
+                .err()
+                .unwrap()
+                .to_string()
+                .contains("invalid manual compaction option: target_level for L0 must be")
+        );
+    }
+    {
         // to check compactor send task fail
         drop(receiver);
         {

--- a/src/meta/src/hummock/mock_hummock_meta_client.rs
+++ b/src/meta/src/hummock/mock_hummock_meta_client.rs
@@ -230,6 +230,7 @@ impl HummockMetaClient for MockHummockMetaClient {
         _compaction_group_id: CompactionGroupId,
         _table_id: JobId,
         _level: u32,
+        _target_level: Option<u32>,
         _sst_ids: Vec<HummockSstableId>,
         _exclusive: bool,
     ) -> Result<bool> {

--- a/src/rpc_client/src/hummock_meta_client.rs
+++ b/src/rpc_client/src/hummock_meta_client.rs
@@ -59,6 +59,7 @@ pub trait HummockMetaClient: Send + Sync + 'static {
         compaction_group_id: CompactionGroupId,
         table_id: JobId,
         level: u32,
+        target_level: Option<u32>,
         sst_ids: Vec<HummockSstableId>,
         exclusive: bool,
     ) -> Result<bool>;

--- a/src/rpc_client/src/meta_client.rs
+++ b/src/rpc_client/src/meta_client.rs
@@ -2090,6 +2090,7 @@ impl HummockMetaClient for MetaClient {
         compaction_group_id: CompactionGroupId,
         table_id: JobId,
         level: u32,
+        target_level: Option<u32>,
         sst_ids: Vec<HummockSstableId>,
         exclusive: bool,
     ) -> Result<bool> {
@@ -2100,6 +2101,7 @@ impl HummockMetaClient for MetaClient {
             // if table_id not exist, manual_compaction will include all the sst
             // without check internal_table_id
             level,
+            target_level,
             sst_ids,
             exclusive: Some(exclusive),
             ..Default::default()

--- a/src/storage/src/hummock/hummock_meta_client.rs
+++ b/src/storage/src/hummock/hummock_meta_client.rs
@@ -83,11 +83,19 @@ impl HummockMetaClient for MonitoredHummockMetaClient {
         compaction_group_id: CompactionGroupId,
         table_id: JobId,
         level: u32,
+        target_level: Option<u32>,
         sst_ids: Vec<HummockSstableId>,
         exclusive: bool,
     ) -> Result<bool> {
         self.meta_client
-            .trigger_manual_compaction(compaction_group_id, table_id, level, sst_ids, exclusive)
+            .trigger_manual_compaction(
+                compaction_group_id,
+                table_id,
+                level,
+                target_level,
+                sst_ids,
+                exclusive,
+            )
             .await
     }
 


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

This PR adds an explicit target level to manual Hummock compaction.

- Adds optional `target_level` to `TriggerManualCompactionRequest` and wires it through `risectl hummock trigger-manual-compaction --target-level`, RPC client, storage wrapper, and meta service.
- Keeps the existing implicit target behavior when `target_level` is omitted: L0 compacts to the calculated base level, non-last Ln compacts to L(n+1), and the last level compacts into itself.
- Allows explicit intra-level manual compaction for a selected level, e.g. `--level 5 --target-level 5` for L5 -> L5.
- Keeps non-L0 target selection scoped to the shapes already supported by the picker: selected level -> selected level, or selected level -> next level.

## Checklist

- [ ] I have written necessary rustdoc comments.
- [x] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [x] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [x] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

`risectl hummock trigger-manual-compaction` now accepts `--target-level` so operators can compact a selected level into an explicit supported target level, including intra-level compaction such as L5 -> L5.

</details>
