### PR TITLE
feat(connector): support Confluent's known types beyond protobuf WKT

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10448,6 +10448,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "proto-src-confluent"
+version = "0.1.0+gc1e412b.v8.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4f58442516149764e913a2ba92fa50a1db1a50fd539e5c1874c3ce25911bdcc"
+
+[[package]]
+name = "proto-src-google-type"
+version = "0.1.0+g208f198.v2.71.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9380399e02f6d18b5aad0c5d47054a82c7aa346919a98f835fe7f590c7b4c123"
+
+[[package]]
 name = "protobuf"
 version = "3.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12096,6 +12108,8 @@ dependencies = [
  "prost-build 0.14.3",
  "prost-reflect",
  "prost-types 0.14.3",
+ "proto-src-confluent",
+ "proto-src-google-type",
  "protox",
  "reqwest 0.12.25",
  "risingwave_common",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10449,9 +10449,9 @@ dependencies = [
 
 [[package]]
 name = "proto-src-confluent"
-version = "0.1.0+gc1e412b.v8.2.1"
+version = "0.1.1+g6a3cfd9.v8.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4f58442516149764e913a2ba92fa50a1db1a50fd539e5c1874c3ce25911bdcc"
+checksum = "90f6b92ba20d060c49734f01d8565b79a6c1916a182143fd28a4c75a2dd2ccbd"
 
 [[package]]
 name = "proto-src-google-type"

--- a/src/connector/codec/Cargo.toml
+++ b/src/connector/codec/Cargo.toml
@@ -24,6 +24,8 @@ num-bigint = "0.4"
 prost = { workspace = true, features = ["no-recursion-limit"] }
 prost-reflect = { workspace = true }
 prost-types = { workspace = true }
+proto-src-confluent = "0.1"
+proto-src-google-type = "0.1"
 protox = "0.9.1"
 reqwest = { version = "0.12.2", features = ["json"] }
 risingwave_common = { workspace = true }

--- a/src/connector/codec/src/common/protobuf/compiler.rs
+++ b/src/connector/codec/src/common/protobuf/compiler.rs
@@ -48,11 +48,26 @@ pub fn compile_pb(
         }
     }
 
+    // Resolves imports from a static (import path, source) table — the bundled
+    // sets Confluent treats as ambient.
+    struct BundledFileResolver(&'static [(&'static str, &'static str)]);
+
+    impl FileResolver for BundledFileResolver {
+        fn open_file(&self, name: &str) -> Result<File, Error> {
+            let found = self.0.iter().find(|(path, _)| *path == name);
+            let (_, content) = found.ok_or_else(|| Error::file_not_found(name))?;
+            File::from_source(name, content)
+        }
+    }
+
     let main_file_name = main_file.0.clone();
 
+    // Confluent's Java / Go SDKs prioritize user overrides.
     let mut resolver = ChainFileResolver::new();
-    resolver.add(GoogleFileResolver::new());
     resolver.add(MyResolver::new(main_file, dependencies));
+    resolver.add(BundledFileResolver(proto_src_google_type::FILES));
+    resolver.add(BundledFileResolver(proto_src_confluent::FILES));
+    resolver.add(GoogleFileResolver::new());
 
     let fd = protox::Compiler::with_file_resolver(resolver)
         .include_imports(true)

--- a/src/connector/codec/tests/integration_tests/protobuf.rs
+++ b/src/connector/codec/tests/integration_tests/protobuf.rs
@@ -735,7 +735,7 @@ fn test_recursive() -> anyhow::Result<()> {
 // compile user protos importing `google/type/` and `confluent/type/` with zero
 // user-supplied dependencies.
 #[test]
-fn test_bundled_common_types() -> anyhow::Result<()> {
+fn test_bundled_ambient_types() -> anyhow::Result<()> {
     let main = r#"
         syntax = "proto3";
         package test;

--- a/src/connector/codec/tests/integration_tests/protobuf.rs
+++ b/src/connector/codec/tests/integration_tests/protobuf.rs
@@ -729,3 +729,59 @@ fn test_recursive() -> anyhow::Result<()> {
 
     Ok(())
 }
+
+// Confluent skips uploading `google/type/*` or `confluent/*` as references by
+// default, in addition to standard well-known types. This test ensures we can
+// compile user protos importing `google/type/` and `confluent/type/` with zero
+// user-supplied dependencies.
+#[test]
+fn test_bundled_common_types() -> anyhow::Result<()> {
+    let main = r#"
+        syntax = "proto3";
+        package test;
+        import "google/type/date.proto";
+        import "confluent/type/decimal.proto";
+
+        message Invoice {
+          google.type.Date issued_on = 1;
+          confluent.type.Decimal amount = 2;
+        }
+    "#;
+
+    let fd_set = compile_pb(("test.proto".to_owned(), main.to_owned()), [])?;
+    let pool = DescriptorPool::from_file_descriptor_set(fd_set)?;
+
+    // Bundled files should be present in the descriptor set (include_imports).
+    assert!(pool.get_file_by_name("google/type/date.proto").is_some());
+    assert!(
+        pool.get_file_by_name("confluent/type/decimal.proto")
+            .is_some()
+    );
+
+    // Resolved field types should point at the bundled message definitions.
+    let invoice = pool
+        .get_message_by_name("test.Invoice")
+        .context("Invoice not found")?;
+    assert_eq!(
+        invoice
+            .get_field_by_name("issued_on")
+            .unwrap()
+            .kind()
+            .as_message()
+            .unwrap()
+            .full_name(),
+        "google.type.Date"
+    );
+    assert_eq!(
+        invoice
+            .get_field_by_name("amount")
+            .unwrap()
+            .kind()
+            .as_message()
+            .unwrap()
+            .full_name(),
+        "confluent.type.Decimal"
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

RisingWave's protobuf schema compiler now resolves the types Confluent Schema Registry treats as built-in **"known" dependencies** — beyond the standard protobuf **well-known types** (`google/protobuf/*`).

Previously a protobuf schema importing these failed to compile unless the user uploaded them as Schema Registry references; they now resolve automatically during schema compilation. The `.proto` sources come from two new crates.io dependencies — `proto-src-google-type` and `proto-src-confluent` (`0.1`, Apache-2.0) — carrying the verbatim upstream files.

Covered by a new integration test, `test_bundled_ambient_types`.

Scope: tracks released upstream — `confluent/type/variant.proto` (only on unreleased Confluent main) is intentionally not bundled. Prior art: #13370.

- Closes #25657

## Checklist

- [ ] I have written necessary rustdoc comments.
- [x] I have added necessary unit tests and integration tests.
- [ ] I have added test labels as necessary.
- [ ] I have added fuzzing tests or opened an issue to track them.
- [ ] My PR contains breaking changes.
- [ ] My PR changes performance-critical code, so I will run (micro) benchmarks and present the results.
- [ ] I have checked the Release Timeline and Currently Supported Versions to determine which release branches I need to cherry-pick this PR into.

## Documentation

- [x] My PR needs documentation updates.

<details>
<summary><b>Release note</b></summary>

Protobuf source schemas can now import the types Confluent Schema Registry treats as built-in — `google/type/*` and `confluent/*` — without uploading them as Schema Registry references. They're resolved automatically during schema compilation, alongside the standard protobuf well-known types.

</details>