### PR TITLE
fix(binder): resolve conflicts between `FROM` relation names and `CTE` names

### DIFF
--- a/e2e_test/batch/basic/cte.slt.part
+++ b/e2e_test/batch/basic/cte.slt.part
@@ -53,13 +53,18 @@ create schema cte_conflict;
 statement ok
 create table cte_conflict.a(id int, b int);
 
-# resolved the conflict of relation name on addition context
+statement ok
+insert into cte_conflict.a values (1, 3);
+
+# resolve relation name conflicts in additional contexts
 # https://github.com/risingwavelabs/risingwave/issues/5176
 statement error table name "a" specified more than once
 with a(id, c) as (select 1, 2) select b, c from cte_conflict.a join a on cte_conflict.a.id = a.id;
 
-statement ok
-WITH a(id, c) AS (SELECT 1, 2) SELECT t.b, a.c FROM cte_conflict.a AS t JOIN a ON t.id = a.id;
+query II
+with a(id, c) as (select 1, 2) select t.b, a.c from cte_conflict.a as t join a on t.id = a.id;
+----
+3 2
 
 statement ok
 drop table cte_conflict.a;

--- a/e2e_test/batch/basic/cte.slt.part
+++ b/e2e_test/batch/basic/cte.slt.part
@@ -65,10 +65,19 @@ statement error table name "a" specified more than once
 with a(id, c) as (select 1, 2) select * from cte_conflict.a, a;
 
 statement error table name "a" specified more than once
+with a(id, c) as (select 1, 2) select * from a, cte_conflict.a;
+
+statement error table name "a" specified more than once
 with a(id, c) as (select 1, 2) select * from a join cte_conflict.a using (id);
 
 statement error table name "a" specified more than once
+with a(id, c) as (select 1, 2) select * from cte_conflict.a join a using (id);
+
+statement error table name "a" specified more than once
 with a(id, c) as (select 1, 2) select * from a, cte_conflict.a;
+
+statement error table name "a" specified more than once
+with a(id, c) as (select 1, 2) select * from cte_conflict.a, a;
 
 query II
 with a(id, c) as (select 1, 2) select t.b, a.c from cte_conflict.a as t join a on t.id = a.id;

--- a/e2e_test/batch/basic/cte.slt.part
+++ b/e2e_test/batch/basic/cte.slt.part
@@ -47,6 +47,26 @@ with t1 as (values(100, 200)) select * from public.t1;
 ----
 1 2
 
+statement ok
+create schema cte_conflict;
+
+statement ok
+create table cte_conflict.a(id int, b int);
+
+# resolved the conflict of relation name on addition context
+# https://github.com/risingwavelabs/risingwave/issues/5176
+statement error table name "a" specified more than once
+with a(id, c) as (select 1, 2) select b, c from cte_conflict.a join a on cte_conflict.a.id = a.id;
+
+statement ok
+WITH a(id, c) AS (SELECT 1, 2) SELECT t.b, a.c FROM cte_conflict.a AS t JOIN a ON t.id = a.id;
+
+statement ok
+drop table cte_conflict.a;
+
+statement ok
+drop schema cte_conflict;
+
 query I rowsort
 with c as (values(1)) select * from (with c as (values(2)) select * from c) foo union all select * from c order by 1;
 ----

--- a/e2e_test/batch/basic/cte.slt.part
+++ b/e2e_test/batch/basic/cte.slt.part
@@ -61,6 +61,15 @@ insert into cte_conflict.a values (1, 3);
 statement error table name "a" specified more than once
 with a(id, c) as (select 1, 2) select b, c from cte_conflict.a join a on cte_conflict.a.id = a.id;
 
+statement error table name "a" specified more than once
+with a(id, c) as (select 1, 2) select * from cte_conflict.a, a;
+
+statement error table name "a" specified more than once
+with a(id, c) as (select 1, 2) select * from a join cte_conflict.a using (id);
+
+statement error table name "a" specified more than once
+with a(id, c) as (select 1, 2) select * from a, cte_conflict.a;
+
 query II
 with a(id, c) as (select 1, 2) select t.b, a.c from cte_conflict.a as t join a on t.id = a.id;
 ----

--- a/src/frontend/src/binder/bind_context.rs
+++ b/src/frontend/src/binder/bind_context.rs
@@ -116,6 +116,8 @@ pub struct BindContext {
     /// Map the cte's name to its binding state.
     /// The `ShareId` in `BindingCte` of the value is used to help the planner identify the share plan.
     pub cte_to_relation: HashMap<String, Rc<RefCell<BindingCte>>>,
+    /// Exposed relation names of CTE references in the current FROM scope.
+    pub cte_relation_names: HashSet<String>,
     /// Current lambda functions's arguments
     pub lambda_args: Option<HashMap<String, (usize, DataType)>>,
     /// Whether the security invoker is set, currently only used for views.
@@ -264,6 +266,36 @@ impl BindContext {
         } else {
             Ok(columns.clone())
         }
+    }
+
+    pub fn check_catalog_name(&self, exposed_relation_name: &str) -> Result<()> {
+        if self.cte_relation_names.contains(exposed_relation_name) {
+            return Err(ErrorCode::DuplicateRelationName(format!(
+                "table name \"{}\" specified more than once",
+                exposed_relation_name
+            ))
+            .into());
+        }
+        Ok(())
+    }
+
+    pub fn check_cte_name(&self, exposed_relation_name: &str) -> Result<()> {
+        if self
+            .range_of
+            .keys()
+            .any(|(_, relation_name)| relation_name == exposed_relation_name)
+        {
+            return Err(ErrorCode::DuplicateRelationName(format!(
+                "table name \"{}\" specified more than once",
+                exposed_relation_name
+            ))
+            .into());
+        }
+        Ok(())
+    }
+
+    pub fn add_cte_name(&mut self, exposed_relation_name: String) {
+        self.cte_relation_names.insert(exposed_relation_name);
     }
 
     /// Identifies two columns as being in the same group. Additionally, possibly provides one of
@@ -453,6 +485,7 @@ impl BindContext {
                 }
             }
         }
+        self.cte_relation_names.extend(other.cte_relation_names);
         // To merge the column_group_contexts, we just need to offset RHS
         // with the next_group_id of LHS.
         let ColumnGroupContext {

--- a/src/frontend/src/binder/bind_context.rs
+++ b/src/frontend/src/binder/bind_context.rs
@@ -279,23 +279,39 @@ impl BindContext {
         Ok(())
     }
 
-    pub fn check_cte_name(&self, exposed_relation_name: &str) -> Result<()> {
-        if self
-            .range_of
+    pub fn add_cte_name(&mut self, exposed_relation_name: String) {
+        self.cte_relation_names.insert(exposed_relation_name);
+    }
+
+    fn has_relation_name(&self, relation_name: &str) -> bool {
+        self.range_of
             .keys()
-            .any(|(_, relation_name)| relation_name == exposed_relation_name)
-        {
+            .any(|(_, existing_name)| existing_name == relation_name)
+    }
+
+    pub fn check_relation_name_conflict(&self, relation_name: &str) -> Result<()> {
+        if self.has_relation_name(relation_name) {
             return Err(ErrorCode::DuplicateRelationName(format!(
                 "table name \"{}\" specified more than once",
-                exposed_relation_name
+                relation_name
             ))
             .into());
         }
         Ok(())
     }
 
-    pub fn add_cte_name(&mut self, exposed_relation_name: String) {
-        self.cte_relation_names.insert(exposed_relation_name);
+    fn check_cte_relation_name_conflict(&self, other: &Self) -> Result<()> {
+        // `self` may bind a CTE in a separate context, while `other` already has a catalog
+        // relation with the same exposed name.
+        for cte_relation_name in &self.cte_relation_names {
+            other.check_relation_name_conflict(cte_relation_name)?;
+        }
+        // `other` may bind a CTE in a separate context, while `self` already has a catalog
+        // relation with the same exposed name.
+        for cte_relation_name in &other.cte_relation_names {
+            self.check_relation_name_conflict(cte_relation_name)?;
+        }
+        Ok(())
     }
 
     /// Identifies two columns as being in the same group. Additionally, possibly provides one of
@@ -462,6 +478,8 @@ impl BindContext {
     /// Merges two `BindContext`s which are adjacent. For instance, the `BindContext` of two
     /// adjacent cross-joined tables.
     pub fn merge_context(&mut self, other: Self) -> Result<()> {
+        self.check_cte_relation_name_conflict(&other)?;
+
         let begin = self.columns.len();
         self.columns.extend(other.columns.into_iter().map(|mut c| {
             c.index += begin;

--- a/src/frontend/src/binder/relation/mod.rs
+++ b/src/frontend/src/binder/relation/mod.rs
@@ -465,7 +465,8 @@ impl Binder {
             }
 
             let exposed_table_name = original_alias.name.real_value();
-            self.context.check_cte_name(&exposed_table_name)?;
+            self.context
+                .check_relation_name_conflict(&exposed_table_name)?;
 
             match cte_state {
                 BindingCteState::Bound { query } => {

--- a/src/frontend/src/binder/relation/mod.rs
+++ b/src/frontend/src/binder/relation/mod.rs
@@ -464,6 +464,9 @@ impl Binder {
                     .collect();
             }
 
+            let exposed_table_name = original_alias.name.real_value();
+            self.context.check_cte_name(&exposed_table_name)?;
+
             match cte_state {
                 BindingCteState::Bound { query } => {
                     let input = BoundShareInput::Query(query);
@@ -473,6 +476,7 @@ impl Binder {
                         None,
                         Some(&original_alias),
                     )?;
+                    self.context.add_cte_name(exposed_table_name);
                     // we could always share the cte,
                     // no matter it's recursive or not.
                     Ok(Relation::Share(Box::new(BoundShare { share_id, input })))
@@ -485,10 +489,15 @@ impl Binder {
                         None,
                         Some(&original_alias),
                     )?;
+                    self.context.add_cte_name(exposed_table_name);
                     Ok(Relation::Share(Box::new(BoundShare { share_id, input })))
                 }
             }
         } else {
+            let exposed_table_name = alias
+                .map(|alias| alias.name.real_value())
+                .unwrap_or_else(|| table_name.clone());
+            self.context.check_catalog_name(&exposed_table_name)?;
             self.bind_catalog_relation_by_name(
                 db_name.as_deref(),
                 schema_name.as_deref(),


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

<!--

**Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

- Closes #5176

**Problem**:
The current binder phase does not check for conflicts between exposed relation names. Both CTE names and relations created under the default schema are stored in `BindContext` as `(None, relation_name)`, so the binder should prevent duplicate exposed names and ensure relation names remain unique within the binding scope.

For example:
```SQL
with a(id, c) as (select 1, 2)
select b, c from tmp.a join a on tmp.a.id = a.id;
```

Since `tmp.a` does not have an alias, its exposed relation name is `a`. The CTE `a` also exposes the relation name `a`, so `a` name conflict should be reported between them.

**Solution**:
Store `CTE` names during the binder phase so they can be checked during `FROM` clause binding.


```
dev=> create schema tmp;
CREATE_SCHEMA
dev=> create table tmp.a(id int, b int);
CREATE_TABLE
dev=> with a(id, c) as (select 1, 2) select b, c from tmp.a join a on tmp.a.id = a.id;
ERROR:  Failed to run the query

Caused by:
  Duplicate Relation Name: table name "a" specified more than once
```

## Checklist

- [ ] I have written necessary rustdoc comments.
- [x] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
