### PR TITLE
fix(ci): skip stale SST compat test for fixed versions

### DIFF
--- a/e2e_test/backwards-compat-tests/README.md
+++ b/e2e_test/backwards-compat-tests/README.md
@@ -19,4 +19,4 @@ We currently cover the following:
 5. TPC-H
 6. Kafka Source
 7. AsOf join
-8. Hummock stale SST table ids after dropping one table from a mixed-table SST (old version >= 2.8.0)
+8. Hummock stale SST table ids after dropping one table from a mixed-table SST (2.8.0 <= old version < 2.8.4)

--- a/e2e_test/backwards-compat-tests/scripts/utils.sh
+++ b/e2e_test/backwards-compat-tests/scripts/utils.sh
@@ -22,6 +22,9 @@ TEST_DIR=.risingwave/e2e_test/backwards-compat-tests/
 # Keep this case on recently verified releases. It relies on Hummock system tables and
 # risectl commands to build a mixed-table SST deterministically.
 HUMMOCK_STALE_TABLE_IDS_MIN_VERSION=2.8.0
+# v2.8.4 backported normalized compact task table ids, so old clusters at this
+# version and later already clean stale table ids from SST metadata.
+HUMMOCK_STALE_TABLE_IDS_FIXED_VERSION=2.8.4
 mkdir -p $TEST_DIR
 cp -r e2e_test/backwards-compat-tests/slt/* $TEST_DIR
 
@@ -121,7 +124,8 @@ seed_hummock_stale_table_ids() {
   rm -f "$TEST_DIR/hummock-stale-table-ids/enabled" \
     "$TEST_DIR/hummock-stale-table-ids/dropped_table_id"
 
-  if version_lt "$OLD_VERSION" "$HUMMOCK_STALE_TABLE_IDS_MIN_VERSION"; then
+  if version_lt "$OLD_VERSION" "$HUMMOCK_STALE_TABLE_IDS_MIN_VERSION" ||
+    version_le "$HUMMOCK_STALE_TABLE_IDS_FIXED_VERSION" "$OLD_VERSION"; then
     echo "--- HUMMOCK STALE TABLE IDS TEST: Skipped for old version ${OLD_VERSION}"
     return
   fi


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

- Bound the Hummock stale SST table ids backwards compatibility case to `2.8.0 <= OLD_VERSION < 2.8.4`.
- `v2.8.4` already backported normalized compact task table ids, so old clusters at `v2.8.4` and later are expected to clean stale table ids from SST metadata. The test should skip those fixed old versions instead of failing its own precondition.
- Updated the backwards compatibility test README to document the actual version range.

Related failure: https://buildkite.com/risingwavelabs/main-cron/builds/9363#019e514a-c4bb-4928-9efd-b91b9a0d9763

Local verification:
- `bash -n e2e_test/backwards-compat-tests/scripts/utils.sh`
- `git diff --check`
- Verified the gating logic maps `2.8.0` and `2.8.3` to run, and `2.8.4+` to skip.

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [x] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [x] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

No user-facing changes.

</details>
