### PR TITLE
fix(frontend): cancel subscription cursor fetch wait

### DIFF
--- a/src/batch/src/task/task_execution.rs
+++ b/src/batch/src/task/task_execution.rs
@@ -233,6 +233,7 @@ pub enum ShutdownMsg {
 }
 
 /// A token which can be used to signal a shutdown request.
+#[derive(Clone)]
 pub struct ShutdownSender(tokio::sync::watch::Sender<ShutdownMsg>);
 
 impl ShutdownSender {

--- a/src/frontend/src/handler/fetch_cursor.rs
+++ b/src/frontend/src/handler/fetch_cursor.rs
@@ -27,6 +27,7 @@ use super::util::convert_interval_to_u64_seconds;
 use crate::binder::BoundStatement;
 use crate::error::Result;
 use crate::handler::HandlerArgs;
+use crate::session::cursor_manager::FetchCursorCancelHandle;
 use crate::{Binder, PgResponseStream, WithOptions};
 
 pub async fn handle_fetch_cursor_execute(
@@ -75,16 +76,20 @@ pub async fn handle_fetch_cursor(
     }
 
     let cursor_manager = session.get_cursor_manager();
+    let mut cancel_handle = FetchCursorCancelHandle::new();
 
-    let (rows, pg_descs) = cursor_manager
+    let result = cursor_manager
         .get_rows_with_cursor(
             &cursor_name,
             stmt.count,
             handler_args,
             formats,
             timeout_seconds,
+            &mut cancel_handle,
         )
-        .await?;
+        .await;
+    session.clear_cancel_query_flag();
+    let (rows, pg_descs) = result?;
     Ok(build_fetch_cursor_response(rows, pg_descs))
 }
 

--- a/src/frontend/src/session.rs
+++ b/src/frontend/src/session.rs
@@ -1386,6 +1386,11 @@ impl SessionImpl {
         shutdown_rx
     }
 
+    pub fn set_cancel_query_flag(&self, shutdown_tx: ShutdownSender) {
+        let mut flag = self.current_query_cancel_flag.lock();
+        *flag = Some(shutdown_tx);
+    }
+
     pub fn cancel_current_query(&self) {
         let mut flag_guard = self.current_query_cancel_flag.lock();
         if let Some(sender) = flag_guard.take() {
@@ -1393,10 +1398,9 @@ impl SessionImpl {
             // Current running query is in local mode
             sender.cancel();
             info!("Cancel query request sent.");
-        } else {
-            info!("Trying to cancel query in distributed mode.");
-            self.env.query_manager().cancel_queries_in_session(self.id)
         }
+        info!("Trying to cancel query in distributed mode.");
+        self.env.query_manager().cancel_queries_in_session(self.id)
     }
 
     pub fn cancel_current_creating_job(&self) {

--- a/src/frontend/src/session/cursor_manager.rs
+++ b/src/frontend/src/session/cursor_manager.rs
@@ -26,6 +26,7 @@ use itertools::Itertools;
 use pgwire::pg_field_descriptor::PgFieldDescriptor;
 use pgwire::pg_response::StatementType;
 use pgwire::types::{Format, Row};
+use risingwave_batch::task::{ShutdownSender, ShutdownToken};
 use risingwave_common::catalog::{ColumnCatalog, Field};
 use risingwave_common::error::BoxedError;
 use risingwave_common::session_config::QueryMode;
@@ -49,7 +50,7 @@ use crate::monitor::{CursorMetrics, PeriodicCursorMetrics};
 use crate::optimizer::PlanRoot;
 use crate::optimizer::plan_node::{BatchFilter, BatchLogSeqScan, BatchSeqScan, generic};
 use crate::optimizer::property::{Order, RequiredDist};
-use crate::scheduler::{DistributedQueryStream, LocalQueryStream, ReadSnapshot};
+use crate::scheduler::{DistributedQueryStream, LocalQueryStream, ReadSnapshot, SchedulerError};
 use crate::utils::Condition;
 use crate::{OptimizerContext, OptimizerContextRef, PgResponseStream, TableCatalog};
 
@@ -57,6 +58,33 @@ pub enum CursorDataChunkStream {
     LocalDataChunk(Option<LocalQueryStream>),
     DistributedDataChunk(Option<DistributedQueryStream>),
     PgResponse(PgResponseStream),
+}
+
+pub struct FetchCursorCancelHandle {
+    cancel_tx: ShutdownSender,
+    cancel_rx: ShutdownToken,
+}
+
+impl FetchCursorCancelHandle {
+    pub fn new() -> Self {
+        let (cancel_tx, cancel_rx) = ShutdownToken::new();
+        Self {
+            cancel_tx,
+            cancel_rx,
+        }
+    }
+
+    fn register(&self, session: &SessionImpl) {
+        session.set_cancel_query_flag(self.cancel_tx.clone());
+    }
+
+    async fn cancelled(&mut self) {
+        self.cancel_rx.cancelled().await;
+    }
+
+    fn is_cancelled(&self) -> bool {
+        self.cancel_rx.is_cancelled()
+    }
 }
 
 impl CursorDataChunkStream {
@@ -113,10 +141,11 @@ impl Cursor {
         handler_args: HandlerArgs,
         formats: &Vec<Format>,
         timeout_seconds: Option<u64>,
+        cancel_handle: &mut FetchCursorCancelHandle,
     ) -> Result<(Vec<Row>, Vec<PgFieldDescriptor>)> {
         match self {
             Cursor::Subscription(cursor) => cursor
-                .next(count, handler_args, formats, timeout_seconds)
+                .next(count, handler_args, formats, timeout_seconds, cancel_handle)
                 .await
                 .inspect_err(|_| cursor.cursor_metrics.subscription_cursor_error_count.inc()),
             Cursor::Query(cursor) => {
@@ -607,6 +636,7 @@ impl SubscriptionCursor {
         handler_args: HandlerArgs,
         formats: &Vec<Format>,
         timeout_seconds: Option<u64>,
+        cancel_handle: &mut FetchCursorCancelHandle,
     ) -> Result<(Vec<Row>, Vec<PgFieldDescriptor>)> {
         let timeout_instant = timeout_seconds.map(|s| Instant::now() + Duration::from_secs(s));
         if Instant::now() > self.cursor_need_drop_time {
@@ -631,6 +661,9 @@ impl SubscriptionCursor {
             chunk_stream.init_row_stream(&fields, &fotmats, session.clone());
         }
         while cur < count {
+            if cancel_handle.is_cancelled() {
+                return Err(SchedulerError::QueryCancelled("Cancelled by user".to_owned()).into());
+            }
             let fetch_cursor_timer = Instant::now();
             let row = self.next_row(&handler_args, formats).await?;
             self.cursor_metrics
@@ -651,25 +684,39 @@ impl SubscriptionCursor {
                         // Triggered when previous next_row returns None while self.state is State::Fetch.
                         continue;
                     };
-                    // It's only blocked when there's no data
-                    // This method will only be called once, either to trigger a timeout or to get the return value in the next loop via `next_row`.
-                    match tokio::time::timeout(
-                        Duration::from_secs(timeout_seconds),
-                        session
+                    // This is the only point where subscription cursor fetch waits without an
+                    // inner query. Register the FETCH-level cancel token so CancelRequest can
+                    // interrupt this wait. The token also marks the whole FETCH as cancelled, so
+                    // we won't start another inner query after a cancellation.
+                    cancel_handle.register(session);
+                    let timeout = tokio::time::sleep(Duration::from_secs(timeout_seconds));
+                    tokio::pin!(timeout);
+                    tokio::select! {
+                        biased;
+                        _ = cancel_handle.cancelled() => {
+                            return Err(SchedulerError::QueryCancelled(
+                                "Cancelled by user".to_owned(),
+                            )
+                            .into());
+                        }
+                        result = session
                             .env
                             .hummock_snapshot_manager()
                             .wait_table_change_log_notification(
                                 self.dependent_table_id,
                                 *seek_timestamp,
-                            ),
-                    )
-                    .await
-                    {
-                        Ok(result) => result?,
-                        Err(_) => {
+                            ) => {
+                            result?;
+                        }
+                        _ = &mut timeout => {
                             tracing::debug!("Cursor wait next epoch timeout");
                             break;
                         }
+                    }
+                    if cancel_handle.is_cancelled() {
+                        return Err(
+                            SchedulerError::QueryCancelled("Cancelled by user".to_owned()).into(),
+                        );
                     }
                 }
             }
@@ -1142,10 +1189,11 @@ impl CursorManager {
         handler_args: HandlerArgs,
         formats: &Vec<Format>,
         timeout_seconds: Option<u64>,
+        cancel_handle: &mut FetchCursorCancelHandle,
     ) -> Result<(Vec<Row>, Vec<PgFieldDescriptor>)> {
         if let Some(cursor) = self.cursor_map.lock().await.get_mut(cursor_name) {
             cursor
-                .next(count, handler_args, formats, timeout_seconds)
+                .next(count, handler_args, formats, timeout_seconds, cancel_handle)
                 .await
         } else {
             Err(ErrorCode::InternalError(format!("Cannot find cursor `{}`", cursor_name)).into())

--- a/src/tests/e2e_extended_mode/Cargo.toml
+++ b/src/tests/e2e_extended_mode/Cargo.toml
@@ -16,7 +16,7 @@ rust_decimal = { version = "1.40", features = ["db-postgres"] }
 tokio = { workspace = true }
 tokio-postgres = { version = "0.7", features = ["with-chrono-0_4"] }
 tracing = "0.1"
-tracing-subscriber = "0.3.20"
+tracing-subscriber = { version = "0.3.20", features = ["env-filter"] }
 
 [[bin]]
 name = "risingwave_e2e_extended_mode_test"

--- a/src/tests/e2e_extended_mode/src/test.rs
+++ b/src/tests/e2e_extended_mode/src/test.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::time::Duration;
+
 use anyhow::anyhow;
 use chrono::{DateTime, NaiveDate, NaiveDateTime, NaiveTime, Utc};
 use pg_interval::Interval;
@@ -83,6 +85,8 @@ impl TestSuite {
         self.simple_cancel(true).await?;
         self.complex_cancel(false).await?;
         self.complex_cancel(true).await?;
+        self.subscription_fetch_cancel(false).await?;
+        self.subscription_fetch_cancel(true).await?;
         self.subquery_with_param().await?;
         self.create_mview_with_parameter().await?;
         Ok(())
@@ -580,6 +584,55 @@ impl TestSuite {
         new_client.execute("drop table t1", &[]).await?;
         new_client.execute("drop table t2", &[]).await?;
         new_client.execute("drop table t3", &[]).await?;
+        Ok(())
+    }
+
+    async fn subscription_fetch_cancel(&self, is_distributed: bool) -> anyhow::Result<()> {
+        let client = self.create_client(is_distributed).await?;
+        let suffix = if is_distributed { "dist" } else { "local" };
+        let table_name = format!("sub_cancel_t_{suffix}");
+        let subscription_name = format!("sub_cancel_{suffix}");
+
+        client
+            .execute(&format!("create table {table_name}(v int)"), &[])
+            .await?;
+        client
+            .execute(
+                &format!("create subscription {subscription_name} from {table_name} with(retention = '1D')"),
+                &[],
+            )
+            .await?;
+        client
+            .execute(
+                &format!("declare cur subscription cursor for {subscription_name} since now()"),
+                &[],
+            )
+            .await?;
+
+        let cancel_token = client.cancel_token();
+        let fetch_handle = tokio::spawn(async move {
+            client
+                .query("fetch 1 from cur with (timeout = '60s')", &[])
+                .await
+        });
+
+        tokio::time::sleep(Duration::from_secs(1)).await;
+        cancel_token.cancel_query(NoTls).await?;
+
+        let result = tokio::time::timeout(Duration::from_secs(10), fetch_handle).await??;
+        if result.is_ok() {
+            return Err(anyhow!(
+                "subscription cursor fetch should be cancelled by CancelRequest"
+            ));
+        }
+
+        let cleanup_client = self.create_client(is_distributed).await?;
+        cleanup_client
+            .execute(&format!("drop subscription {subscription_name}"), &[])
+            .await?;
+        cleanup_client
+            .execute(&format!("drop table {table_name}"), &[])
+            .await?;
         Ok(())
     }
 


### PR DESCRIPTION
## What
- Register a cancel token while subscription cursor FETCH waits for the next change-log notification.
- Race the wait against the FETCH timeout and PostgreSQL CancelRequest.
- Add e2e extended-mode coverage for cancelling subscription cursor FETCH in both local and distributed query modes.
- Enable tracing-subscriber env-filter feature for the e2e extended-mode test crate, matching its existing EnvFilter usage.

## Verification
- RUSTUP_TOOLCHAIN=nightly-2025-10-10 cargo check -p risingwave_frontend -p risingwave_e2e_extended_mode_test