### PR TITLE
fix(iceberg): fix iceberg glue iam assume role token expiration

### DIFF
--- a/java/connector-node/risingwave-sink-iceberg/src/main/java/com/risingwave/connector/catalog/GlueCredentialProvider.java
+++ b/java/connector-node/risingwave-sink-iceberg/src/main/java/com/risingwave/connector/catalog/GlueCredentialProvider.java
@@ -20,27 +20,38 @@ import java.util.Map;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.AwsCredentials;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
-import software.amazon.awssdk.auth.credentials.AwsSessionCredentials;
 import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.sts.StsClient;
 import software.amazon.awssdk.services.sts.StsClientBuilder;
+import software.amazon.awssdk.services.sts.auth.StsAssumeRoleCredentialsProvider;
 import software.amazon.awssdk.services.sts.model.AssumeRoleRequest;
-import software.amazon.awssdk.services.sts.model.Credentials;
+import software.amazon.awssdk.utils.SdkAutoCloseable;
 import software.amazon.awssdk.utils.StringUtils;
 import software.amazon.awssdk.utils.Validate;
 
 /** This class is used to provide a credential to glue catalog */
-public class GlueCredentialProvider implements AwsCredentialsProvider {
+public class GlueCredentialProvider implements AwsCredentialsProvider, SdkAutoCloseable {
     private static final String DEFAULT_SESSION_NAME = "risingwave-glue";
-    private final AwsCredentials credentials;
+    private final AwsCredentialsProvider credentialsProvider;
+    private final SdkAutoCloseable closeable;
 
-    private GlueCredentialProvider(AwsCredentials credentials) {
-        this.credentials =
-                (AwsCredentials)
+    private GlueCredentialProvider(AwsCredentialsProvider credentialsProvider) {
+        this(credentialsProvider, () -> {});
+    }
+
+    private GlueCredentialProvider(
+            AwsCredentialsProvider credentialsProvider, SdkAutoCloseable closeable) {
+        this.credentialsProvider =
+                (AwsCredentialsProvider)
                         Validate.notNull(
-                                credentials, "Credentials must not be null.", new Object[0]);
+                                credentialsProvider,
+                                "Credentials provider must not be null.",
+                                new Object[0]);
+        this.closeable =
+                (SdkAutoCloseable)
+                        Validate.notNull(closeable, "Closeable must not be null.", new Object[0]);
     }
 
     public static GlueCredentialProvider create(Map<String, String> config) {
@@ -52,63 +63,86 @@ public class GlueCredentialProvider implements AwsCredentialsProvider {
                         config.getOrDefault(
                                 "glue.use-default-credential-chain", Boolean.FALSE.toString()));
 
-        AwsCredentials baseCredentials =
-                resolveBaseCredentials(accessKey, secretKey, useDefaultChain);
+        AwsCredentialsProvider baseCredentialsProvider =
+                resolveBaseCredentialsProvider(accessKey, secretKey, useDefaultChain);
         String assumeRoleArn = config.get("glue.iam-role-arn");
         if (StringUtils.isBlank(assumeRoleArn)) {
-            return new GlueCredentialProvider(baseCredentials);
+            return new GlueCredentialProvider(baseCredentialsProvider);
         }
 
-        AwsCredentials assumed =
-                assumeRole(
-                        baseCredentials,
-                        assumeRoleArn,
-                        config.get("glue.iam-role-session-name"),
-                        config.get("glue.region"));
-        return new GlueCredentialProvider(assumed);
+        return assumeRole(
+                baseCredentialsProvider,
+                assumeRoleArn,
+                config.get("glue.iam-role-session-name"),
+                config.get("glue.region"));
     }
 
-    private static AwsCredentials resolveBaseCredentials(
+    private static AwsCredentialsProvider resolveBaseCredentialsProvider(
             String accessKey, String secretKey, boolean useDefaultChain) {
         if (!StringUtils.isBlank(accessKey) && !StringUtils.isBlank(secretKey)) {
-            return AwsBasicCredentials.create(accessKey, secretKey);
+            AwsCredentials credentials = AwsBasicCredentials.create(accessKey, secretKey);
+            return StaticCredentialsProvider.create(credentials);
         }
 
         if (useDefaultChain) {
-            AwsCredentialsProvider provider = DefaultCredentialsProvider.create();
-            return provider.resolveCredentials();
+            return DefaultCredentialsProvider.create();
         }
 
         Validate.notNull(accessKey, "Glue access key must not be null.", new Object[0]);
         Validate.notNull(secretKey, "Glue secret key must not be null.", new Object[0]);
-        return AwsBasicCredentials.create(accessKey, secretKey);
+        AwsCredentials credentials = AwsBasicCredentials.create(accessKey, secretKey);
+        return StaticCredentialsProvider.create(credentials);
     }
 
-    private static AwsCredentials assumeRole(
-            AwsCredentials baseCredentials, String roleArn, String sessionName, String region) {
-        StaticCredentialsProvider provider = StaticCredentialsProvider.create(baseCredentials);
-        StsClientBuilder builder = StsClient.builder().credentialsProvider(provider);
+    private static GlueCredentialProvider assumeRole(
+            AwsCredentialsProvider baseCredentialsProvider,
+            String roleArn,
+            String sessionName,
+            String region) {
+        StsClientBuilder builder = StsClient.builder().credentialsProvider(baseCredentialsProvider);
         if (!StringUtils.isBlank(region)) {
             builder = builder.region(Region.of(region));
         }
-        try (StsClient stsClient = builder.build()) {
-            AssumeRoleRequest request =
-                    AssumeRoleRequest.builder()
-                            .roleArn(roleArn)
-                            .roleSessionName(
-                                    StringUtils.isBlank(sessionName)
-                                            ? DEFAULT_SESSION_NAME
-                                            : sessionName)
-                            .build();
-            Credentials credentials = stsClient.assumeRole(request).credentials();
-            return AwsSessionCredentials.create(
-                    credentials.accessKeyId(),
-                    credentials.secretAccessKey(),
-                    credentials.sessionToken());
-        }
+        StsClient stsClient = builder.build();
+        AssumeRoleRequest request =
+                AssumeRoleRequest.builder()
+                        .roleArn(roleArn)
+                        .roleSessionName(
+                                StringUtils.isBlank(sessionName)
+                                        ? DEFAULT_SESSION_NAME
+                                        : sessionName)
+                        .build();
+        StsAssumeRoleCredentialsProvider assumedProvider =
+                StsAssumeRoleCredentialsProvider.builder()
+                        .stsClient(stsClient)
+                        .refreshRequest(request)
+                        .build();
+        return new GlueCredentialProvider(
+                assumedProvider,
+                () -> closeAssumeRoleResources(stsClient, baseCredentialsProvider));
     }
 
     public AwsCredentials resolveCredentials() {
-        return this.credentials;
+        return this.credentialsProvider.resolveCredentials();
+    }
+
+    AwsCredentialsProvider credentialsProviderForTest() {
+        return credentialsProvider;
+    }
+
+    private static void closeAssumeRoleResources(
+            StsClient stsClient, AwsCredentialsProvider baseCredentialsProvider) {
+        stsClient.close();
+        if (baseCredentialsProvider instanceof SdkAutoCloseable) {
+            ((SdkAutoCloseable) baseCredentialsProvider).close();
+        }
+    }
+
+    @Override
+    public void close() {
+        if (credentialsProvider instanceof SdkAutoCloseable) {
+            ((SdkAutoCloseable) credentialsProvider).close();
+        }
+        closeable.close();
     }
 }

--- a/java/connector-node/risingwave-sink-iceberg/src/main/java/com/risingwave/connector/catalog/S3FileIOAssumeRoleAwsClientFactory.java
+++ b/java/connector-node/risingwave-sink-iceberg/src/main/java/com/risingwave/connector/catalog/S3FileIOAssumeRoleAwsClientFactory.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright 2026 RisingWave Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.risingwave.connector.catalog;
+
+import java.util.Map;
+import org.apache.iceberg.aws.AwsClientProperties;
+import org.apache.iceberg.aws.HttpClientProperties;
+import org.apache.iceberg.aws.s3.S3FileIOAwsClientFactory;
+import org.apache.iceberg.aws.s3.S3FileIOProperties;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.AwsCredentials;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.AwsSessionCredentials;
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3AsyncClient;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.sts.StsClient;
+import software.amazon.awssdk.services.sts.StsClientBuilder;
+import software.amazon.awssdk.services.sts.auth.StsAssumeRoleCredentialsProvider;
+import software.amazon.awssdk.services.sts.model.AssumeRoleRequest;
+import software.amazon.awssdk.utils.StringUtils;
+
+public class S3FileIOAssumeRoleAwsClientFactory implements S3FileIOAwsClientFactory {
+    private static final String S3_IAM_ROLE_ARN = "s3.iam-role-arn";
+    private static final String S3_IAM_ROLE_SESSION_NAME = "s3.iam-role-session-name";
+    private static final String DEFAULT_SESSION_NAME = "risingwave-s3";
+
+    private S3FileIOProperties s3FileIOProperties;
+    private HttpClientProperties httpClientProperties;
+    private AwsClientProperties awsClientProperties;
+    private AwsCredentialsProvider credentialsProvider;
+
+    @Override
+    public void initialize(Map<String, String> properties) {
+        this.s3FileIOProperties = new S3FileIOProperties(properties);
+        this.httpClientProperties = new HttpClientProperties(properties);
+        this.awsClientProperties = new AwsClientProperties(properties);
+        this.credentialsProvider = createCredentialsProvider(properties);
+    }
+
+    @Override
+    public S3Client s3() {
+        return S3Client.builder()
+                .applyMutation(awsClientProperties::applyClientRegionConfiguration)
+                .applyMutation(awsClientProperties::applyLegacyMd5Plugin)
+                .applyMutation(httpClientProperties::applyHttpClientConfigurations)
+                .applyMutation(s3FileIOProperties::applyEndpointConfigurations)
+                .applyMutation(s3FileIOProperties::applyServiceConfigurations)
+                .credentialsProvider(credentialsProvider)
+                .applyMutation(s3FileIOProperties::applySignerConfiguration)
+                .applyMutation(s3FileIOProperties::applyS3AccessGrantsConfigurations)
+                .applyMutation(s3FileIOProperties::applyUserAgentConfigurations)
+                .applyMutation(s3FileIOProperties::applyRetryConfigurations)
+                .build();
+    }
+
+    @Override
+    public S3AsyncClient s3Async() {
+        if (s3FileIOProperties.isS3CRTEnabled()) {
+            return S3AsyncClient.crtBuilder()
+                    .applyMutation(awsClientProperties::applyClientRegionConfiguration)
+                    .credentialsProvider(credentialsProvider)
+                    .applyMutation(s3FileIOProperties::applyEndpointConfigurations)
+                    .applyMutation(s3FileIOProperties::applyS3CrtConfigurations)
+                    .build();
+        }
+        return S3AsyncClient.builder()
+                .applyMutation(awsClientProperties::applyClientRegionConfiguration)
+                .credentialsProvider(credentialsProvider)
+                .applyMutation(awsClientProperties::applyLegacyMd5Plugin)
+                .applyMutation(s3FileIOProperties::applyEndpointConfigurations)
+                .build();
+    }
+
+    AwsCredentialsProvider credentialsProviderForTest() {
+        return credentialsProvider;
+    }
+
+    private AwsCredentialsProvider createCredentialsProvider(Map<String, String> properties) {
+        AwsCredentialsProvider baseCredentialsProvider =
+                createBaseCredentialsProvider(
+                        s3FileIOProperties.accessKeyId(),
+                        s3FileIOProperties.secretAccessKey(),
+                        s3FileIOProperties.sessionToken());
+
+        String roleArn = properties.get(S3_IAM_ROLE_ARN);
+        if (StringUtils.isBlank(roleArn)) {
+            return baseCredentialsProvider;
+        }
+
+        StsClientBuilder stsClientBuilder =
+                StsClient.builder().credentialsProvider(baseCredentialsProvider);
+        String region = awsClientProperties.clientRegion();
+        if (!StringUtils.isBlank(region)) {
+            stsClientBuilder = stsClientBuilder.region(Region.of(region));
+        }
+        StsClient stsClient = stsClientBuilder.build();
+        String sessionName = properties.get(S3_IAM_ROLE_SESSION_NAME);
+        AssumeRoleRequest request =
+                AssumeRoleRequest.builder()
+                        .roleArn(roleArn)
+                        .roleSessionName(
+                                StringUtils.isBlank(sessionName)
+                                        ? DEFAULT_SESSION_NAME
+                                        : sessionName)
+                        .build();
+        return StsAssumeRoleCredentialsProvider.builder()
+                .stsClient(stsClient)
+                .refreshRequest(request)
+                .build();
+    }
+
+    private static AwsCredentialsProvider createBaseCredentialsProvider(
+            String accessKeyId, String secretAccessKey, String sessionToken) {
+        if (StringUtils.isBlank(accessKeyId) || StringUtils.isBlank(secretAccessKey)) {
+            return DefaultCredentialsProvider.create();
+        }
+
+        AwsCredentials credentials =
+                StringUtils.isBlank(sessionToken)
+                        ? AwsBasicCredentials.create(accessKeyId, secretAccessKey)
+                        : AwsSessionCredentials.create(accessKeyId, secretAccessKey, sessionToken);
+        return StaticCredentialsProvider.create(credentials);
+    }
+}

--- a/java/connector-node/risingwave-sink-iceberg/src/test/java/com/risingwave/connector/catalog/GlueCredentialProviderTest.java
+++ b/java/connector-node/risingwave-sink-iceberg/src/test/java/com/risingwave/connector/catalog/GlueCredentialProviderTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2026 RisingWave Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.risingwave.connector.catalog;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.Test;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.services.sts.auth.StsAssumeRoleCredentialsProvider;
+
+public class GlueCredentialProviderTest {
+    @Test
+    public void testStaticCredentialsWithoutAssumeRole() {
+        Map<String, String> config = new HashMap<>();
+        config.put("glue.access-key-id", "access-key");
+        config.put("glue.secret-access-key", "secret-key");
+
+        try (GlueCredentialProvider provider = GlueCredentialProvider.create(config)) {
+            assertThat(provider.resolveCredentials())
+                    .isEqualTo(AwsBasicCredentials.create("access-key", "secret-key"));
+        }
+    }
+
+    @Test
+    public void testAssumeRoleUsesRefreshableProvider() {
+        Map<String, String> config = new HashMap<>();
+        config.put("glue.access-key-id", "access-key");
+        config.put("glue.secret-access-key", "secret-key");
+        config.put("glue.iam-role-arn", "arn:aws:iam::123456789012:role/risingwave-glue");
+        config.put("glue.region", "us-east-1");
+
+        try (GlueCredentialProvider provider = GlueCredentialProvider.create(config)) {
+            assertThat(provider.credentialsProviderForTest())
+                    .isInstanceOf(StsAssumeRoleCredentialsProvider.class);
+        }
+    }
+}

--- a/java/connector-node/risingwave-sink-iceberg/src/test/java/com/risingwave/connector/catalog/S3FileIOAssumeRoleAwsClientFactoryTest.java
+++ b/java/connector-node/risingwave-sink-iceberg/src/test/java/com/risingwave/connector/catalog/S3FileIOAssumeRoleAwsClientFactoryTest.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2026 RisingWave Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.risingwave.connector.catalog;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.Test;
+import software.amazon.awssdk.services.sts.auth.StsAssumeRoleCredentialsProvider;
+
+public class S3FileIOAssumeRoleAwsClientFactoryTest {
+    @Test
+    public void testS3AssumeRoleUsesRefreshableProvider() {
+        Map<String, String> config = new HashMap<>();
+        config.put("client.region", "ap-southeast-2");
+        config.put("s3.access-key-id", "access-key");
+        config.put("s3.secret-access-key", "secret-key");
+        config.put("s3.iam-role-arn", "arn:aws:iam::123456789012:role/risingwave-s3");
+
+        S3FileIOAssumeRoleAwsClientFactory factory = new S3FileIOAssumeRoleAwsClientFactory();
+        factory.initialize(config);
+
+        assertThat(factory.credentialsProviderForTest())
+                .isInstanceOf(StsAssumeRoleCredentialsProvider.class);
+    }
+}

--- a/src/connector/src/connector_common/iceberg/mod.rs
+++ b/src/connector/src/connector_common/iceberg/mod.rs
@@ -678,26 +678,45 @@ impl IcebergCommon {
                     if let Some(glue_id) = self.glue_id.as_deref() {
                         java_catalog_configs.insert("glue.id".to_owned(), glue_id.to_owned());
                     }
+                    self.apply_java_s3_file_io_assume_role_configs(&mut java_catalog_configs);
                 }
                 "jdbc" => {
-                    if let Some(iam_role_arn) = &self.s3_iam_role_arn {
-                        java_catalog_configs
-                            .insert("client.assume-role.arn".to_owned(), iam_role_arn.clone());
-                        java_catalog_configs.insert(
-                            "client.factory".to_owned(),
-                            "org.apache.iceberg.aws.AssumeRoleAwsClientFactory".to_owned(),
-                        );
-                        if let Some(region) = &self.s3_region {
-                            java_catalog_configs
-                                .insert("client.assume-role.region".to_owned(), region.clone());
-                        }
-                    }
+                    self.apply_java_aws_client_assume_role_configs(&mut java_catalog_configs);
                 }
                 _ => {}
             }
         }
 
         Ok((file_io_props, java_catalog_configs))
+    }
+
+    fn apply_java_s3_file_io_assume_role_configs(
+        &self,
+        java_catalog_configs: &mut HashMap<String, String>,
+    ) {
+        if let Some(iam_role_arn) = &self.s3_iam_role_arn {
+            java_catalog_configs.insert(
+                "s3.client-factory-impl".to_owned(),
+                "com.risingwave.connector.catalog.S3FileIOAssumeRoleAwsClientFactory".to_owned(),
+            );
+            java_catalog_configs.insert("s3.iam-role-arn".to_owned(), iam_role_arn.clone());
+        }
+    }
+
+    fn apply_java_aws_client_assume_role_configs(
+        &self,
+        java_catalog_configs: &mut HashMap<String, String>,
+    ) {
+        if let Some(iam_role_arn) = &self.s3_iam_role_arn {
+            java_catalog_configs.insert("client.assume-role.arn".to_owned(), iam_role_arn.clone());
+            java_catalog_configs.insert(
+                "client.factory".to_owned(),
+                "org.apache.iceberg.aws.AssumeRoleAwsClientFactory".to_owned(),
+            );
+            if let Some(region) = &self.s3_region {
+                java_catalog_configs.insert("client.assume-role.region".to_owned(), region.clone());
+            }
+        }
     }
 }
 
@@ -946,7 +965,70 @@ pub async fn rebuild_table_with_shared_cache(table: Table) -> Table {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashMap;
+
     use super::*;
+
+    fn test_common(catalog_type: &str) -> IcebergCommon {
+        IcebergCommon {
+            catalog_type: Some(catalog_type.to_owned()),
+            s3_region: Some("ap-southeast-2".to_owned()),
+            s3_endpoint: None,
+            s3_access_key: None,
+            s3_secret_key: None,
+            s3_iam_role_arn: None,
+            glue_access_key: None,
+            glue_secret_key: None,
+            glue_iam_role_arn: None,
+            glue_region: None,
+            glue_id: None,
+            gcs_credential: None,
+            azblob_account_name: None,
+            azblob_account_key: None,
+            azblob_endpoint_url: None,
+            adlsgen2_account_name: None,
+            adlsgen2_account_key: None,
+            adlsgen2_endpoint: None,
+            warehouse_path: Some("s3://bucket/warehouse".to_owned()),
+            catalog_name: None,
+            catalog_uri: None,
+            catalog_credential: None,
+            catalog_token: None,
+            catalog_oauth2_server_uri: None,
+            catalog_scope: None,
+            rest_signing_region: None,
+            rest_signing_name: None,
+            rest_sigv4_enabled: None,
+            s3_path_style_access: None,
+            enable_config_load: None,
+            hosted_catalog: None,
+            catalog_header: None,
+            vended_credentials: None,
+            catalog_security: None,
+            gcp_auth_scopes: None,
+            catalog_io_impl: None,
+        }
+    }
+
+    #[test]
+    fn test_glue_jni_catalog_uses_s3_assume_role_for_file_io() {
+        let common = IcebergCommon {
+            s3_iam_role_arn: Some("arn:aws:iam::123456789012:role/risingwave-s3".to_owned()),
+            ..test_common("glue")
+        };
+
+        let (_, java_catalog_configs) = common.build_jni_catalog_configs(&HashMap::new()).unwrap();
+
+        assert_eq!(
+            java_catalog_configs.get("s3.client-factory-impl").unwrap(),
+            "com.risingwave.connector.catalog.S3FileIOAssumeRoleAwsClientFactory"
+        );
+        assert_eq!(
+            java_catalog_configs.get("s3.iam-role-arn").unwrap(),
+            "arn:aws:iam::123456789012:role/risingwave-s3"
+        );
+        assert!(!java_catalog_configs.contains_key("client.factory"));
+    }
 
     #[test]
     fn test_iceberg_table_identifier_validation() {


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

## What

Fix Iceberg Glue sink IAM role handling for long-running sinks and separate Glue/S3 assume-role paths.

This PR changes the Java Glue credential provider to keep refreshable AWS SDK credential providers instead of resolving credentials once at catalog initialization. It also adds a dedicated S3 FileIO client factory for Glue catalog metadata IO, so Glue and S3 can assume different roles.

## Why

There were two related issues:

1. `GlueCredentialProvider` called STS `AssumeRole` once and stored the returned session credentials. Long-running sinks could later fail Glue calls with expired STS tokens.

2. For `catalog.type = 'glue'`, Iceberg Java `S3FileIO` writes table metadata files such as `metadata/*.metadata.json`. That path used `s3.access.key` / `s3.secret.key` directly and did not honor `s3.iam_role_arn`, causing S3 `PutObject` failures when only the assumed role had bucket write permissions.

A global Iceberg `client.factory = AssumeRoleAwsClientFactory` is not sufficient here because it mixes Glue and S3 credentials. Glue and S3 need separate role assumptions.

## How

- Update `GlueCredentialProvider` to delegate to `AwsCredentialsProvider`.
- Use `StsAssumeRoleCredentialsProvider` for `glue.iam_role_arn`, allowing automatic STS credential refresh.
- Keep default credential chain as a provider instead of resolving it once.
- Add `S3FileIOAssumeRoleAwsClientFactory` for Java Iceberg `S3FileIO`.
- For Glue catalog with `s3.iam_role_arn`, configure:
  - `s3.client-factory-impl = com.risingwave.connector.catalog.S3FileIOAssumeRoleAwsClientFactory`
  - `s3.iam-role-arn = <s3.iam_role_arn>`
- Keep Glue API credentials independent via `GlueCredentialProvider`.

With this, Glue APIs use `glue.*` credentials/role, while S3 metadata IO uses `s3.*` credentials/role.



## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
