### PR TITLE
fix(storage): fallback on SST filter build failure

### DIFF
--- a/src/storage/src/hummock/sstable/builder.rs
+++ b/src/storage/src/hummock/sstable/builder.rs
@@ -27,6 +27,7 @@ use risingwave_hummock_sdk::sstable_info::{SstableInfo, SstableInfoInner, VnodeS
 use risingwave_hummock_sdk::table_stats::{TableStats, TableStatsMap};
 use risingwave_hummock_sdk::{HummockEpoch, HummockSstableObjectId, LocalSstableInfo};
 use risingwave_pb::hummock::{BloomFilterType, PbSstableFilterType};
+use thiserror_ext::AsReport;
 
 use super::utils::CompressionAlgorithm;
 use super::{
@@ -40,8 +41,8 @@ use crate::compaction_catalog_manager::{
 use crate::hummock::sstable::{FilterBuilder, utils};
 use crate::hummock::value::HummockValue;
 use crate::hummock::{
-    Block, BlockHolder, BlockIterator, HummockResult, MemoryLimiter, Xor16FilterBuilder,
-    try_shorten_block_smallest_key,
+    Block, BlockHolder, BlockIterator, HummockError, HummockResult, MemoryLimiter,
+    Xor16FilterBuilder, try_shorten_block_smallest_key,
 };
 use crate::monitor::CompactorMetrics;
 use crate::opts::StorageOpts;
@@ -134,7 +135,8 @@ pub struct SstableBuilder<W: SstableWriter, F: FilterBuilder> {
     /// by `finalize_last_table_stats`
     last_table_stats: TableStats,
 
-    filter_builder: F,
+    filter_builder: Option<F>,
+    filter_build_failed: bool,
 
     epoch_set: BTreeSet<u64>,
     memory_limiter: Option<Arc<MemoryLimiter>>,
@@ -199,7 +201,8 @@ impl<W: SstableWriter, F: FilterBuilder> SstableBuilder<W, F> {
                 restart_interval: options.restart_interval,
                 compression_algorithm: options.compression_algorithm,
             }),
-            filter_builder,
+            filter_builder: Some(filter_builder),
+            filter_build_failed: false,
             block_metas: Vec::with_capacity(options.capacity / options.block_capacity + 1),
             table_ids: BTreeSet::new(),
             last_table_id: None,
@@ -284,7 +287,9 @@ impl<W: SstableWriter, F: FilterBuilder> SstableBuilder<W, F> {
         );
         meta.offset = self.writer.data_len() as u32;
         self.block_metas.push(meta);
-        self.filter_builder.add_raw_data(filter_data);
+        if let Some(filter_builder) = &mut self.filter_builder {
+            filter_builder.add_raw_data(filter_data);
+        }
         let block_meta = self.block_metas.last_mut().unwrap();
         self.writer.write_block_bytes(buf, block_meta).await?;
 
@@ -406,9 +411,10 @@ impl<W: SstableWriter, F: FilterBuilder> SstableBuilder<W, F> {
             .compaction_catalog_agent_ref
             .extract(user_key(&self.raw_key));
         // Add SST filter check.
-        if !filter_key.is_empty() {
-            self.filter_builder
-                .add_key(filter_key, table_id.as_raw_id());
+        if !filter_key.is_empty()
+            && let Some(filter_builder) = &mut self.filter_builder
+        {
+            filter_builder.add_key(filter_key, table_id.as_raw_id());
         }
         // Use pre-encoded key to avoid redundant encoding
         self.block_builder.add(
@@ -469,17 +475,32 @@ impl<W: SstableWriter, F: FilterBuilder> SstableBuilder<W, F> {
         let right_exclusive = false;
         let meta_offset = self.writer.data_len() as u64;
 
-        let filter_data = self.filter_builder.finish(self.memory_limiter.clone());
-        let (bloom_filter_kind, filter_type) = if filter_data.is_empty() {
-            (
-                BloomFilterType::BloomFilterUnspecified,
-                PbSstableFilterType::SstableFilterNone,
-            )
-        } else if self.filter_builder.support_blocked_raw_data() {
-            (BloomFilterType::Blocked, self.filter_builder.filter_type())
+        let mut bloom_filter_kind = if self.filter_build_failed {
+            BloomFilterType::Sstable
         } else {
-            (BloomFilterType::Sstable, self.filter_builder.filter_type())
+            BloomFilterType::BloomFilterUnspecified
         };
+        let mut filter_type = PbSstableFilterType::SstableFilterNone;
+        let mut filter_data = Vec::new();
+        if let Some(filter_builder) = &mut self.filter_builder {
+            match filter_builder.finish(self.memory_limiter.clone()) {
+                Ok(filter) => {
+                    if !filter.is_empty() {
+                        bloom_filter_kind = if filter_builder.support_blocked_raw_data() {
+                            BloomFilterType::Blocked
+                        } else {
+                            BloomFilterType::Sstable
+                        };
+                        filter_type = filter_builder.filter_type();
+                    }
+                    filter_data = filter;
+                }
+                Err(err) => {
+                    bloom_filter_kind = BloomFilterType::Sstable;
+                    self.disable_filter_after_build_error(err);
+                }
+            }
+        }
 
         let total_key_count = self
             .block_metas
@@ -665,9 +686,11 @@ impl<W: SstableWriter, F: FilterBuilder> SstableBuilder<W, F> {
     }
 
     pub fn approximate_len(&self) -> usize {
-        self.writer.data_len()
-            + self.block_builder.approximate_len()
-            + self.filter_builder.approximate_len()
+        let filter_len = self
+            .filter_builder
+            .as_ref()
+            .map_or(0, |filter_builder| filter_builder.approximate_len());
+        self.writer.data_len() + self.block_builder.approximate_len() + filter_len
     }
 
     pub async fn build_block(&mut self) -> HummockResult<()> {
@@ -689,8 +712,6 @@ impl<W: SstableWriter, F: FilterBuilder> SstableBuilder<W, F> {
         let block = self.block_builder.build();
         self.writer.write_block(block, block_meta).await?;
         self.block_size_vec.push(block.len());
-        self.filter_builder
-            .switch_block(self.memory_limiter.clone());
         let data_len = utils::checked_into_u32(self.writer.data_len()).unwrap_or_else(|_| {
             panic!(
                 "WARN overflow can't convert writer_data_len {} into u32 table {:?}",
@@ -705,6 +726,14 @@ impl<W: SstableWriter, F: FilterBuilder> SstableBuilder<W, F> {
             )
         });
 
+        if let Some(err) = self.filter_builder.as_mut().and_then(|filter_builder| {
+            filter_builder
+                .switch_block(self.memory_limiter.clone())
+                .err()
+        }) {
+            self.disable_filter_after_build_error(err);
+        }
+
         if data_len as usize > self.options.capacity * 2 {
             tracing::warn!(
                 "WARN unexpected block size {} table {:?}",
@@ -715,6 +744,17 @@ impl<W: SstableWriter, F: FilterBuilder> SstableBuilder<W, F> {
 
         self.block_builder.clear();
         Ok(())
+    }
+
+    fn disable_filter_after_build_error(&mut self, err: HummockError) {
+        tracing::warn!(
+            error = %err.as_report(),
+            filter_type = ?self.filter_builder.as_ref().map(|filter_builder| filter_builder.filter_type()),
+            sst_object_id = self.sst_object_id.as_raw_id(),
+            "failed to build SST filter, falling back to no filter for this SST"
+        );
+        self.filter_build_failed = true;
+        self.filter_builder = None;
     }
 
     pub fn is_empty(&self) -> bool {
@@ -1296,6 +1336,102 @@ pub(super) mod tests {
             PbSstableFilterType::SstableFilterXor16,
         )
         .await;
+    }
+
+    struct FailingFilterBuilder<const FAIL_SWITCH_BLOCK: bool>;
+
+    impl<const FAIL_SWITCH_BLOCK: bool> FilterBuilder for FailingFilterBuilder<FAIL_SWITCH_BLOCK> {
+        fn add_key(&mut self, _dist_key: &[u8], _table_id: u32) {}
+
+        fn finish(
+            &mut self,
+            _memory_limiter: Option<Arc<MemoryLimiter>>,
+        ) -> HummockResult<Vec<u8>> {
+            if FAIL_SWITCH_BLOCK {
+                Ok(vec![1])
+            } else {
+                Err(HummockError::other("injected filter finish failure"))
+            }
+        }
+
+        fn approximate_len(&self) -> usize {
+            0
+        }
+
+        fn create(_capacity: usize) -> Self {
+            Self
+        }
+
+        fn switch_block(
+            &mut self,
+            _memory_limiter: Option<Arc<MemoryLimiter>>,
+        ) -> HummockResult<()> {
+            if FAIL_SWITCH_BLOCK {
+                Err(HummockError::other("injected filter switch-block failure"))
+            } else {
+                Ok(())
+            }
+        }
+
+        fn approximate_building_memory(&self) -> usize {
+            0
+        }
+
+        fn support_blocked_raw_data(&self) -> bool {
+            true
+        }
+
+        fn filter_type(&self) -> PbSstableFilterType {
+            PbSstableFilterType::SstableFilterXor8
+        }
+    }
+
+    async fn test_filter_failure_fallback_to_no_filter<F: FilterBuilder>() {
+        let opts = SstableBuilderOptions {
+            capacity: 0,
+            block_capacity: 4096,
+            restart_interval: 16,
+            bloom_false_positive: 0.01,
+            ..Default::default()
+        };
+
+        let sstable_store = mock_sstable_store().await;
+        let table_id_to_vnode = HashMap::from_iter(vec![(0, VirtualNode::COUNT_FOR_TEST)]);
+        let table_id_to_watermark_serde = HashMap::from_iter(vec![(0, None)]);
+        let sst_info = gen_test_sstable_impl::<Vec<u8>, F>(
+            opts,
+            0,
+            (0..TEST_KEYS_COUNT).map(|i| (test_key_of(i), HummockValue::put(test_value_of(i)))),
+            sstable_store.clone(),
+            CachePolicy::NotFill,
+            table_id_to_vnode,
+            table_id_to_watermark_serde,
+        )
+        .await;
+
+        assert_eq!(sst_info.bloom_filter_kind, BloomFilterType::Sstable);
+        assert_eq!(sst_info.filter_type, PbSstableFilterType::SstableFilterNone);
+
+        let table = sstable_store
+            .sstable(&sst_info, &mut StoreLocalStatistic::default())
+            .await
+            .unwrap();
+        assert!(!table.has_filter());
+
+        let full_key = test_key_of(0);
+        let hash = Sstable::hash_for_filter(full_key.user_key.encode().as_slice(), 0);
+        let key_ref = full_key.user_key.as_ref();
+        assert!(table.may_match_hash(&(Bound::Included(key_ref), Bound::Included(key_ref)), hash));
+    }
+
+    #[tokio::test]
+    async fn test_filter_finish_failure_fallbacks_to_no_filter() {
+        test_filter_failure_fallback_to_no_filter::<FailingFilterBuilder<false>>().await;
+    }
+
+    #[tokio::test]
+    async fn test_filter_switch_block_failure_fallbacks_to_no_filter() {
+        test_filter_failure_fallback_to_no_filter::<FailingFilterBuilder<true>>().await;
     }
 
     #[tokio::test]

--- a/src/storage/src/hummock/sstable/filter.rs
+++ b/src/storage/src/hummock/sstable/filter.rs
@@ -18,18 +18,20 @@ use std::sync::Arc;
 
 use risingwave_pb::hummock::PbSstableFilterType;
 
-use crate::hummock::MemoryLimiter;
+use crate::hummock::{HummockResult, MemoryLimiter};
 
 pub trait FilterBuilder: Send {
     /// add key which need to be filter for construct filter data.
     fn add_key(&mut self, dist_key: &[u8], table_id: u32);
     /// Builds SST filter from key hashes.
-    fn finish(&mut self, memory_limiter: Option<Arc<MemoryLimiter>>) -> Vec<u8>;
+    fn finish(&mut self, memory_limiter: Option<Arc<MemoryLimiter>>) -> HummockResult<Vec<u8>>;
     /// approximate memory of filter builder
     fn approximate_len(&self) -> usize;
 
     fn create(capacity: usize) -> Self;
-    fn switch_block(&mut self, _memory_limiter: Option<Arc<MemoryLimiter>>) {}
+    fn switch_block(&mut self, _memory_limiter: Option<Arc<MemoryLimiter>>) -> HummockResult<()> {
+        Ok(())
+    }
     /// approximate memory when finish filter
     fn approximate_building_memory(&self) -> usize;
 

--- a/src/storage/src/hummock/sstable/xor_filter.rs
+++ b/src/storage/src/hummock/sstable/xor_filter.rs
@@ -23,7 +23,7 @@ use risingwave_pb::hummock::PbSstableFilterType;
 use xorf::{Filter, Xor8, Xor16};
 
 use super::{FilterBuilder, Sstable};
-use crate::hummock::{BlockMeta, MemoryLimiter};
+use crate::hummock::{BlockMeta, HummockResult, MemoryLimiter};
 
 const FOOTER_XOR8: u8 = 254;
 const FOOTER_XOR16: u8 = 255;
@@ -93,7 +93,7 @@ impl FilterBuilder for Xor16FilterBuilder {
         self.key_hash_entries.len() * 4
     }
 
-    fn finish(&mut self, memory_limiter: Option<Arc<MemoryLimiter>>) -> Vec<u8> {
+    fn finish(&mut self, memory_limiter: Option<Arc<MemoryLimiter>>) -> HummockResult<Vec<u8>> {
         self.key_hash_entries.sort();
         self.key_hash_entries.dedup();
 
@@ -103,7 +103,7 @@ impl FilterBuilder for Xor16FilterBuilder {
 
         let xor_filter = Xor16::from(&self.key_hash_entries);
         self.key_hash_entries.clear();
-        Self::build_from_xor16(&xor_filter)
+        Ok(Self::build_from_xor16(&xor_filter))
     }
 
     fn create(capacity: usize) -> Self {
@@ -127,7 +127,7 @@ impl FilterBuilder for Xor8FilterBuilder {
             .push(Sstable::hash_for_filter(key, table_id));
     }
 
-    fn finish(&mut self, memory_limiter: Option<Arc<MemoryLimiter>>) -> Vec<u8> {
+    fn finish(&mut self, memory_limiter: Option<Arc<MemoryLimiter>>) -> HummockResult<Vec<u8>> {
         self.key_hash_entries.sort();
         self.key_hash_entries.dedup();
 
@@ -137,7 +137,7 @@ impl FilterBuilder for Xor8FilterBuilder {
 
         let xor_filter = Xor8::from(&self.key_hash_entries);
         self.key_hash_entries.clear();
-        Self::build_from_xor8(&xor_filter)
+        Ok(Self::build_from_xor8(&xor_filter))
     }
 
     fn approximate_len(&self) -> usize {
@@ -197,11 +197,11 @@ impl FilterBuilder for BlockedXor16FilterBuilder {
         self.current.add_key(key, table_id)
     }
 
-    fn finish(&mut self, _memory_limiter: Option<Arc<MemoryLimiter>>) -> Vec<u8> {
+    fn finish(&mut self, _memory_limiter: Option<Arc<MemoryLimiter>>) -> HummockResult<Vec<u8>> {
         // Add footer to tell which kind of filter.
         self.data.put_u32_le(self.block_count as u32);
         self.data.put_u8(FOOTER_BLOCKED_XOR16);
-        std::mem::take(&mut self.data)
+        Ok(std::mem::take(&mut self.data))
     }
 
     fn approximate_len(&self) -> usize {
@@ -212,11 +212,12 @@ impl FilterBuilder for BlockedXor16FilterBuilder {
         BlockedXor16FilterBuilder::new(capacity)
     }
 
-    fn switch_block(&mut self, memory_limiter: Option<Arc<MemoryLimiter>>) {
-        let block = self.current.finish(memory_limiter);
+    fn switch_block(&mut self, memory_limiter: Option<Arc<MemoryLimiter>>) -> HummockResult<()> {
+        let block = self.current.finish(memory_limiter)?;
         self.data.put_u32_le(block.len() as u32);
         self.data.extend(block);
         self.block_count += 1;
+        Ok(())
     }
 
     fn approximate_building_memory(&self) -> usize {
@@ -244,10 +245,10 @@ impl FilterBuilder for BlockedXor8FilterBuilder {
         self.current.add_key(key, table_id)
     }
 
-    fn finish(&mut self, _memory_limiter: Option<Arc<MemoryLimiter>>) -> Vec<u8> {
+    fn finish(&mut self, _memory_limiter: Option<Arc<MemoryLimiter>>) -> HummockResult<Vec<u8>> {
         self.data.put_u32_le(self.block_count as u32);
         self.data.put_u8(FOOTER_BLOCKED_XOR8);
-        std::mem::take(&mut self.data)
+        Ok(std::mem::take(&mut self.data))
     }
 
     fn approximate_len(&self) -> usize {
@@ -258,11 +259,12 @@ impl FilterBuilder for BlockedXor8FilterBuilder {
         BlockedXor8FilterBuilder::new(capacity)
     }
 
-    fn switch_block(&mut self, memory_limiter: Option<Arc<MemoryLimiter>>) {
-        let block = self.current.finish(memory_limiter);
+    fn switch_block(&mut self, memory_limiter: Option<Arc<MemoryLimiter>>) -> HummockResult<()> {
+        let block = self.current.finish(memory_limiter)?;
         self.data.put_u32_le(block.len() as u32);
         self.data.extend(block);
         self.block_count += 1;
+        Ok(())
     }
 
     fn approximate_building_memory(&self) -> usize {
@@ -695,7 +697,7 @@ mod tests {
         for i in 0..100 {
             xor8_builder.add_key(&test_user_key_of(i).encode(), 0);
         }
-        let xor8_bytes = xor8_builder.finish(None);
+        let xor8_bytes = xor8_builder.finish(None).unwrap();
         let xor8_reader = XorFilterReader::new(&xor8_bytes, &[]);
         let xor8_encoded = xor8_reader.encode_to_bytes();
         assert_eq!(
@@ -708,7 +710,7 @@ mod tests {
         for i in 0..100 {
             xor16_builder.add_key(&test_user_key_of(i).encode(), 0);
         }
-        let xor16_bytes = xor16_builder.finish(None);
+        let xor16_bytes = xor16_builder.finish(None).unwrap();
         let xor16_reader = XorFilterReader::new(&xor16_bytes, &[]);
         let xor16_encoded = xor16_reader.encode_to_bytes();
         assert_eq!(
@@ -740,9 +742,9 @@ mod tests {
                 let key_idx = block_idx * 50 + i;
                 blocked_xor8_builder.add_key(&test_user_key_of(key_idx).encode(), 0);
             }
-            blocked_xor8_builder.switch_block(None);
+            blocked_xor8_builder.switch_block(None).unwrap();
         }
-        let blocked_xor8_bytes = blocked_xor8_builder.finish(None);
+        let blocked_xor8_bytes = blocked_xor8_builder.finish(None).unwrap();
         let blocked_xor8_reader = XorFilterReader::new(&blocked_xor8_bytes, &block_metas);
         let blocked_xor8_encoded = blocked_xor8_reader.encode_to_bytes();
         assert_eq!(
@@ -757,9 +759,9 @@ mod tests {
                 let key_idx = block_idx * 50 + i;
                 blocked_xor16_builder.add_key(&test_user_key_of(key_idx).encode(), 0);
             }
-            blocked_xor16_builder.switch_block(None);
+            blocked_xor16_builder.switch_block(None).unwrap();
         }
-        let blocked_xor16_bytes = blocked_xor16_builder.finish(None);
+        let blocked_xor16_bytes = blocked_xor16_builder.finish(None).unwrap();
         let blocked_xor16_reader = XorFilterReader::new(&blocked_xor16_bytes, &block_metas);
         let blocked_xor16_encoded = blocked_xor16_reader.encode_to_bytes();
         assert_eq!(

--- a/src/storage/src/hummock/test_utils.rs
+++ b/src/storage/src/hummock/test_utils.rs
@@ -210,10 +210,10 @@ pub async fn put_sst(
     let bloom_filter = {
         let mut filter_builder = BlockedXor16FilterBuilder::new(100);
         for _ in &meta.block_metas {
-            filter_builder.switch_block(None);
+            filter_builder.switch_block(None)?;
         }
 
-        filter_builder.finish(None)
+        filter_builder.finish(None)?
     };
 
     meta.meta_offset = writer.data_len() as u64;


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

- Make `FilterBuilder::finish` and `FilterBuilder::switch_block` return `HummockResult`.
- Disable the SST filter for the current SST when filter construction fails, instead of panicking or aborting the whole build.
- Preserve the existing `bloom_false_positive` enable gate; this PR only changes error propagation and fallback behavior.
- Add unit coverage for finish-time and per-block switch-time failure fallback.

## Checklist

- [x] I have written necessary rustdoc comments.
- [x] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

</details>

## Local verification

- `cargo fmt --check && git diff --check`
- `cargo test -p risingwave_storage failure_fallback --lib`
- `cargo test -p risingwave_storage test_xor_filter_builder_and_reader --lib`
- `cargo test -p risingwave_storage test_bloom_filter --lib`