### PR TITLE
fix(hummock): downgrade can_concat assertion in level_insert_ssts and pre-validate compaction task output

### DIFF
--- a/src/meta/src/hummock/manager/compaction/mod.rs
+++ b/src/meta/src/hummock/manager/compaction/mod.rs
@@ -41,7 +41,8 @@ use risingwave_hummock_sdk::table_watermark::TableWatermarks;
 use risingwave_hummock_sdk::version::{GroupDelta, IntraLevelDelta};
 use risingwave_hummock_sdk::{
     CompactionGroupId, HummockCompactionTaskId, HummockContextId, HummockSstableId,
-    HummockSstableObjectId, HummockVersionId, compact_task_to_string, statistics_compact_task,
+    HummockSstableObjectId, HummockVersionId, can_concat, compact_task_to_string,
+    statistics_compact_task,
 };
 use risingwave_meta_model::hummock_sequence::COMPACTION_TASK_ID;
 use risingwave_pb::hummock::compact_task::{TaskStatus, TaskType};
@@ -899,8 +900,32 @@ impl HummockManager {
                                 "The task may be expired because of group split, task:\n {:?}",
                                 compact_task_to_string(&compact_task)
                             );
+                            false
+                        } else if compact_task.target_level > 0
+                            && !compact_task.sorted_output_ssts.is_empty()
+                            && !compact_task_output_fits_target_level(
+                                &group.levels[compact_task.target_level as usize - 1].table_infos,
+                                compact_task.target_level,
+                                &compact_task.input_ssts,
+                                &compact_task.sorted_output_ssts,
+                            )
+                        {
+                            // Two concurrent L0→base compaction tasks can select L0
+                            // SSTs from different sub-levels whose key ranges overlap,
+                            // producing outputs that conflict in the target level.
+                            // Reject so the scheduler can replan with a fresh view.
+                            compact_task.task_status = TaskStatus::InputOutdatedCanceled;
+                            warn!(
+                                "Rejecting compaction task {} because output SSTs overlap \
+                                 with target level after applying removals. This is caused \
+                                 by concurrent compaction tasks with overlapping L0 key \
+                                 ranges. The task will be rescheduled.",
+                                compact_task.task_id,
+                            );
+                            false
+                        } else {
+                            true
                         }
-                        !is_expired
                     }
                 }
             } else {
@@ -1568,6 +1593,41 @@ pub struct CompactionGroupStatistic {
     pub compaction_group_config: CompactionGroup,
 }
 
+/// Validates that a compaction task's output SSTs won't overlap with the remaining
+/// SSTs in the target level after the task's input SSTs are removed.
+///
+/// Returns `true` if applying the task would leave the target level as a valid,
+/// non-overlapping, concat-able sequence; `false` if it would create overlap.
+///
+/// Background: two concurrent L0→base compaction tasks can produce outputs with
+/// overlapping key ranges in the same target level. The existing
+/// `is_pending_compact` check only tracks SST IDs, not output key ranges, so both
+/// tasks can pass scheduling validation. If both outputs land in the target level,
+/// the LSM invariant breaks and `level_insert_ssts`'s `can_concat` assertion fails.
+///
+/// This helper simulates the post-apply target level and uses the same
+/// `can_concat` predicate to detect the overlap before any state is mutated.
+fn compact_task_output_fits_target_level(
+    target_level_ssts: &[SstableInfo],
+    target_level: u32,
+    input_ssts: &[risingwave_hummock_sdk::level::InputLevel],
+    output_ssts: &[SstableInfo],
+) -> bool {
+    let removed_sst_ids: HashSet<HummockSstableId> = input_ssts
+        .iter()
+        .filter(|l| l.level_idx == target_level)
+        .flat_map(|l| l.table_infos.iter().map(|s| s.sst_id))
+        .collect();
+    let mut merged: Vec<SstableInfo> = target_level_ssts
+        .iter()
+        .filter(|s| !removed_sst_ids.contains(&s.sst_id))
+        .cloned()
+        .collect();
+    merged.extend(output_ssts.iter().cloned());
+    merged.sort_by(|a, b| a.key_range.cmp(&b.key_range));
+    can_concat(&merged)
+}
+
 /// Updates table stats caused by vnode watermark trivial reclaim compaction.
 fn update_table_stats_for_vnode_watermark_trivial_reclaim(
     table_stats: &mut PbTableStatsMap,
@@ -2060,5 +2120,154 @@ mod compaction_state_tests {
         let (groups, task_type) = snapshot.pick_compaction_groups_and_type().unwrap();
         assert_eq!(task_type, TaskType::SpaceReclaim);
         assert_eq!(groups, vec![g1]);
+    }
+}
+
+#[cfg(test)]
+mod compact_task_output_overlap_tests {
+    use risingwave_common::catalog::TableId;
+    use risingwave_common::hash::VirtualNode;
+    use risingwave_common::util::epoch::test_epoch;
+    use risingwave_hummock_sdk::key::{FullKey, gen_key_from_str};
+    use risingwave_hummock_sdk::key_range::KeyRange;
+    use risingwave_hummock_sdk::level::InputLevel;
+    use risingwave_hummock_sdk::sstable_info::{SstableInfo, SstableInfoInner};
+    use risingwave_pb::hummock::PbLevelType;
+
+    use super::compact_task_output_fits_target_level;
+
+    const TEST_TABLE_ID: u32 = 1;
+
+    /// Encode `tag` as a properly-formed `FullKey` so the raw bytes can be
+    /// stored in [`KeyRange`] and round-trip through `compare_right_with`'s
+    /// `FullKey::decode` call inside [`can_concat`].
+    fn encode_key(tag: &str) -> bytes::Bytes {
+        FullKey::for_test(
+            TableId::new(TEST_TABLE_ID),
+            gen_key_from_str(VirtualNode::ZERO, tag),
+            test_epoch(20),
+        )
+        .encode()
+        .into()
+    }
+
+    /// Build an `SstableInfo` with key range `[left_tag, right_tag]`.
+    fn sst(id: u64, left_tag: &str, right_tag: &str) -> SstableInfo {
+        SstableInfoInner {
+            sst_id: id.into(),
+            object_id: id.into(),
+            key_range: KeyRange {
+                left: encode_key(left_tag),
+                right: encode_key(right_tag),
+                right_exclusive: false,
+            },
+            table_ids: vec![TEST_TABLE_ID.into()],
+            file_size: 100,
+            sst_size: 100,
+            ..Default::default()
+        }
+        .into()
+    }
+
+    /// Reproduces the bug scenario from the patch description:
+    ///
+    /// Target level (before task B): `[K1, K5]` (output of task A, already
+    /// applied), `[K5b, K7]` (existing SST `T3`).
+    ///
+    /// Task B inputs do not include `T3`, but its output covers `[K3, K7]`,
+    /// which overlaps `[K1, K5]`. The helper must reject this.
+    #[test]
+    fn test_rejects_overlapping_output() {
+        let task_a_output = sst(101, "K1", "K5"); // existing in target level
+        let t3 = sst(3, "K5b", "K7"); // existing in target level, disjoint from K1..K5
+        let target_level_ssts = vec![task_a_output, t3];
+
+        // Task B consumes some L0 SSTs (not in target level) and outputs
+        // [K3, K7] which overlaps [K1, K5].
+        let input_ssts = vec![InputLevel {
+            level_idx: 0,
+            level_type: PbLevelType::Overlapping,
+            table_infos: vec![sst(50, "K3", "K7")],
+        }];
+        let task_b_output = vec![sst(201, "K3", "K7")];
+
+        let fits = compact_task_output_fits_target_level(
+            &target_level_ssts,
+            // target_level
+            1,
+            &input_ssts,
+            &task_b_output,
+        );
+        assert!(
+            !fits,
+            "task B's output [K3, K7] overlaps existing target-level SST [K1, K5]; \
+             helper should reject it"
+        );
+    }
+
+    /// A task that consumes a target-level SST and replaces it with a
+    /// disjoint output must be accepted.
+    #[test]
+    fn test_accepts_non_overlapping_output() {
+        let t3 = sst(3, "K5b", "K7");
+        let target_level_ssts = vec![t3.clone()];
+
+        // Task consumes T3 (removes [K5b, K7]) and produces a single output
+        // covering the same key range. After removal+insert, target level is
+        // [[K5b, K7]] again.
+        let input_ssts = vec![InputLevel {
+            level_idx: 1,
+            level_type: PbLevelType::Nonoverlapping,
+            table_infos: vec![t3],
+        }];
+        let output = vec![sst(202, "K5b", "K7")];
+
+        let fits = compact_task_output_fits_target_level(
+            &target_level_ssts,
+            // target_level
+            1,
+            &input_ssts,
+            &output,
+        );
+        assert!(fits, "non-overlapping replacement should be accepted");
+    }
+
+    /// A task whose output extends the target level into a gap (without
+    /// touching existing SSTs) and stays non-overlapping must be accepted.
+    #[test]
+    fn test_accepts_output_into_gap() {
+        // Existing target level has a single SST at [K5b, K7]. The task fills
+        // the gap to the left with output [K1, K3].
+        let existing = sst(3, "K5b", "K7");
+        let target_level_ssts = vec![existing];
+
+        let input_ssts = vec![InputLevel {
+            level_idx: 0,
+            level_type: PbLevelType::Overlapping,
+            table_infos: vec![sst(50, "K1", "K3")],
+        }];
+        let output = vec![sst(203, "K1", "K3")];
+
+        let fits = compact_task_output_fits_target_level(
+            &target_level_ssts,
+            // target_level
+            1,
+            &input_ssts,
+            &output,
+        );
+        assert!(fits, "non-overlapping fill of gap should be accepted");
+    }
+
+    /// Smoke test: empty target level + single output SST is trivially valid.
+    #[test]
+    fn test_accepts_single_output_into_empty_level() {
+        let fits = compact_task_output_fits_target_level(
+            &[],
+            // target_level
+            1,
+            &[],
+            &[sst(204, "K1", "K3")],
+        );
+        assert!(fits);
     }
 }

--- a/src/storage/hummock_sdk/src/compaction_group/hummock_version_ext.rs
+++ b/src/storage/hummock_sdk/src/compaction_group/hummock_version_ext.rs
@@ -1476,8 +1476,9 @@ fn level_insert_ssts(operand: &mut Level, insert_table_infos: &Vec<SstableInfo>)
                 display_sstable_infos(&validate_range),
             );
         } else {
-            // If this branch is reached, it indicates some unexpected behavior in compaction.
-            // Here we issue a warning and fall back to insert one by one.
+            // If this branch is reached, it indicates some unexpected behavior in compaction,
+            // likely caused by concurrent compaction tasks producing overlapping outputs.
+            // Insert one by one and log details for diagnosis.
             warn!(insert = ?insert_table_infos, level = ?operand.table_infos, "unexpected overlap");
             for i in insert_table_infos {
                 let pos = operand
@@ -1485,11 +1486,12 @@ fn level_insert_ssts(operand: &mut Level, insert_table_infos: &Vec<SstableInfo>)
                     .partition_point(|b| b.key_range.cmp(&i.key_range) == Ordering::Less);
                 operand.table_infos.insert(pos, i.clone());
             }
-            assert!(
-                can_concat(&operand.table_infos),
-                "{}",
-                display_sstable_infos(&operand.table_infos)
-            );
+            if !can_concat(&operand.table_infos) {
+                tracing::error!(
+                    "SST overlap remains after one-by-one insertion: {}",
+                    display_sstable_infos(&operand.table_infos)
+                );
+            }
         }
     }
 }


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

### Summary

A meta-node panic at `level_insert_ssts:1488` (the `assert!(can_concat(...))` in the one-by-one fallback path) brings down the cluster. We observed this in production under heavy write workloads. This PR is **defense-in-depth**, not a root-cause fix; it prevents the panic and partially detects bad task outcomes before they're applied. The underlying corruption source needs to be addressed separately (tracking issue: #25805).

### Production evidence

Stack trace and `display_sstable_infos` output from the production panic show the target level's `Vec<SstableInfo>` was already out of sorted-by-key-range order **before** the current compaction's insertion. A contiguous block of 5 SSTs covering small vnodes (0, 0, 256, 256, 768) was misplaced between SSTs covering vnode 26 and vnode 67, producing two adjacent inversions by whole vnode intervals. This is not a "touching boundary" case — it's a real Vec-ordering corruption that the splice fast path didn't catch at the moment of insertion.

### Why the corruption goes undetected upstream of the panic

`level_insert_ssts` for `Nonoverlapping` levels has two paths:

- The **Overlapping → Nonoverlapping promotion path** (~line 1438) calls `extend + sort + assert!(can_concat)` over the full level. Safe.
- The normal **splice path** (~line 1452) trusts that the existing `Vec` is sorted, uses `partition_point` to find an insertion point, and validates only a `[pos-1 .. pos+insert_len+1]` window with `can_concat`. **Pre-existing inversions outside that window aren't detected.**

Upstream of `level_insert_ssts`, `apply_compact_task` embeds `compact_task.sorted_output_ssts` verbatim in the `IntraLevelDelta` with no validation. `compact_done` in the compactor assembles `sorted_output_ssts` by pushing per-split SST batches in `split_index` order with no full assertion that the resulting vec is monotonically ordered by key range across split boundaries.

Suspected upstream causes (covered in the tracking issue):

1. Sub-compactor SSTs whose key ranges bleed across the split boundaries that were intended to partition them, breaking the implied sortedness of `sorted_output_ssts` when chunks are concatenated across splits.
2. Earlier `level_insert_ssts` splice-path calls leaving the level in a subtly inconsistent state that the narrow validation window doesn't catch.

### What this PR changes

Two defense-in-depth measures. Both are uncontroversial individually; neither addresses the root cause.

**1. Downgrade the `assert!(can_concat(...))` in `level_insert_ssts`'s one-by-one fallback path (`hummock_version_ext.rs`) to a `tracing::error!`.**

Overlapping SSTs in a level are a transient inconsistency that the merge iterator handles correctly during reads, and the next compaction of the level will resolve them. Not crashing is strictly safer than taking down the meta node. **This is the change that kept our production meta node alive** when the underlying corruption occurred.

**2. Pre-validate the post-apply target level in `report_compact_tasks_impl` (`meta/.../compaction/mod.rs`).**

Before applying a compaction's `IntraLevelDelta`, simulate the effect on the target level: take the current target-level SSTs, remove the ones consumed as input, add the task's outputs, sort the merged set, and run `can_concat`. Reject the task with `InputOutdatedCanceled` if the result has real key-range overlap. The scheduler then reschedules with a fresh view of the level.

For levels whose disorder is purely Vec-ordering (no real key-range overlap), the `sort` step makes `can_concat` pass and the task is accepted — the pre-validation is a no-op in that case. This is what happens in the production scenario above, so this part is effectively dead code for the specific bug we observed. It is, however, a correct and cheap check for the broader class of "the task's output really would corrupt the level" cases. The validation logic is extracted into a private helper `compact_task_output_fits_target_level` for unit-testability.

### What this PR explicitly does NOT do

- It does not fix the upstream source of the level-ordering corruption. The tracking issue captures the candidate causes and suggested invariant assertions.
- It does not address the separate, latent discrepancy between `check_multiple_overlap` (used by the L0 picker, treats touching-boundary user_keys as `Equal` → included) and `can_concat` (used as the level invariant, treats `Equal` → not concat-able). This appears unable to actually fire in the current compaction flow because the picker's looser overlap definition absorbs would-be touching SSTs as inputs — but it's a real semantic split worth fixing separately. Also covered in the tracking issue.

### Note on the original PR narrative

An earlier version of this description claimed the panic was caused by concurrent L0→base compaction tasks racing to produce overlapping outputs. @Li0k correctly pointed out that the L0 picker's `break 'expand_new_level` safeguard prevents that scenario. The actual cause is the upstream ordering corruption described above. Both parts of the fix still help (Part 2 directly; Part 1 in the broader class of cases) but the narrative was wrong.

### Test plan

- Added unit tests for `compact_task_output_fits_target_level` in `meta/.../compaction/mod.rs` covering:
  - `test_rejects_overlapping_output` — task whose output would create real key-range overlap is rejected.
  - `test_accepts_non_overlapping_output` — disjoint replacement is accepted.
  - `test_accepts_output_into_gap` — non-overlapping fill of a gap is accepted.
  - `test_accepts_single_output_into_empty_level` — smoke test.
- `cargo test -p risingwave_meta --lib hummock::manager::compaction::` — all 28 existing + 4 new tests pass.
- `cargo clippy -p risingwave_meta -p risingwave_hummock_sdk --tests --no-deps` — clean.
- `cargo fmt --check` — clean.
- Verified that the equivalent patch eliminates the panic against a v2.8.1-based production deployment running heavy backfill workloads.

- Tracking issue for root cause: #25805

## Checklist

- [ ] I have written necessary rustdoc comments.
- [x] I have added necessary unit tests and integration tests.
- [ ] I have added test labels as necessary.
- [ ] I have added fuzzing tests or opened an issue to track them.
- [ ] My PR contains breaking changes.
- [ ] My PR changes performance-critical code, so I will run (micro) benchmarks and present the results.
- [x] I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Requesting cherry-pick to release-2.8 -->

## Documentation

- [ ] My PR needs documentation updates.

<details>
<summary><b>Release note</b></summary>

Prevented a meta-node panic in `level_insert_ssts` that could halt the cluster under heavy write workloads. The assertion in the one-by-one insertion fallback is downgraded to an error log, and a pre-validation step in the compaction-result handler rejects tasks whose output would create real key-range overlap in the target level. The underlying source of the level-ordering corruption (separately tracked) is not addressed by this change; the defenses simply prevent the unrecoverable crash.

</details>
