### PR TITLE
fix(meta): reject stale hummock deltas on restore

### DIFF
--- a/src/meta/src/backup_restore/restore_impl/v2.rs
+++ b/src/meta/src/backup_restore/restore_impl/v2.rs
@@ -106,6 +106,13 @@ impl Writer<MetadataV2> for WriterModelV2ToMetaStoreV2 {
         insert_models(metadata.version_stats.clone(), db).await?;
         insert_models(metadata.compaction_configs.clone(), db).await?;
         insert_models(metadata.hummock_sequences.clone(), db).await?;
+        // The snapshot restores a full Hummock version checkpoint, not version deltas.
+        // Reject leftover deltas in the metastore so they cannot be replayed after restore.
+        insert_models::<
+            risingwave_meta_model::hummock_version_delta::Model,
+            risingwave_meta_model::hummock_version_delta::ActiveModel,
+        >(std::iter::empty(), db)
+        .await?;
         insert_models(metadata.workers.clone(), db).await?;
         insert_models(metadata.worker_properties.clone(), db).await?;
         insert_models(metadata.users.clone(), db).await?;


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

This PR makes meta restore reject a non-empty `hummock_version_delta` table before writing restored metadata.

The backup snapshot restores a full Hummock version checkpoint to object storage. Any leftover version deltas in the SQL metastore are not part of the restored snapshot and can be replayed by meta startup after the checkpoint is loaded. Reusing the existing `insert_models` helper with an empty `hummock_version_delta` iterator gives this table the same non-empty guard as the model tables restored from the snapshot, without restoring any delta rows.

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [x] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [x] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

`restore-meta` now rejects restores when the SQL metastore still contains Hummock version delta rows. This prevents stale deltas from being replayed after restoring a snapshot that already contains a full Hummock version checkpoint.

</details>

## Local Verification

- `cargo check -p risingwave_meta`
- `cargo clippy --all-targets --all-features`
