### PR TITLE
fix(frontend): trim MV pk order key

### DIFF
--- a/src/frontend/planner_test/tests/testdata/input/distinct_on.yaml
+++ b/src/frontend/planner_test/tests/testdata/input/distinct_on.yaml
@@ -49,6 +49,13 @@
     select k, v, ts, id from mv_order_full;
   expected_outputs:
     - stream_plan
+- name: distinct on order by stops MV pk after stream key
+  sql: |
+    create table t (a int, b int, c int);
+    select distinct on (a) a, b, c from t order by a, b, c;
+  expected_outputs:
+    - stream_plan
+    - batch_plan
 - sql: |
     create table t (a int, b int, c int);
     select distinct on (foo, b) a as foo, b from t;

--- a/src/frontend/planner_test/tests/testdata/input/pk_derive.yaml
+++ b/src/frontend/planner_test/tests/testdata/input/pk_derive.yaml
@@ -74,3 +74,20 @@
   expected_outputs:
   - optimized_logical_plan_for_batch
   - stream_plan
+- name: MV pk stops after stream key in order by
+  sql: |
+    create table t (a int, b int, c int);
+    select
+        b,
+        min(a) as a,
+        min(c) as c
+    from
+        t
+    group by
+        b
+    order by
+        a,
+        b,
+        c;
+  expected_outputs:
+  - stream_plan

--- a/src/frontend/planner_test/tests/testdata/output/distinct_on.yaml
+++ b/src/frontend/planner_test/tests/testdata/output/distinct_on.yaml
@@ -44,7 +44,7 @@
         └─BatchExchange { order: [], dist: HashShard(t.a) }
           └─BatchScan { table: t, columns: [t.a, t.b], distribution: SomeShard }
   stream_plan: |-
-    StreamMaterialize { columns: [x, b], stream_key: [x], pk_columns: [x, b], pk_conflict: NoCheck }
+    StreamMaterialize { columns: [x, b], stream_key: [x], pk_columns: [x], pk_conflict: NoCheck }
     └─StreamProject { exprs: [t.a, t.b] }
       └─StreamGroupTopN { order: [t.a ASC, t.b ASC], limit: 1, offset: 0, group_key: [t.a] }
         └─StreamExchange { dist: HashShard(t.a) }
@@ -89,6 +89,22 @@
   stream_plan: |-
     StreamMaterialize { columns: [k, v, ts, id], stream_key: [k, ts, id], pk_columns: [k, ts, id], pk_conflict: NoCheck }
     └─StreamTableScan { table: mv_order_full, columns: [mv_order_full.k, mv_order_full.v, mv_order_full.ts, mv_order_full.id], stream_scan_type: SnapshotBackfill, stream_key: [mv_order_full.k, mv_order_full.ts, mv_order_full.id], pk: [k, ts, id], dist: UpstreamHashShard(mv_order_full.k) }
+- name: distinct on order by stops MV pk after stream key
+  sql: |
+    create table t (a int, b int, c int);
+    select distinct on (a) a, b, c from t order by a, b, c;
+  batch_plan: |-
+    BatchExchange { order: [t.a ASC, t.b ASC, t.c ASC], dist: Single }
+    └─BatchSort { order: [t.a ASC, t.b ASC, t.c ASC] }
+      └─BatchGroupTopN { order: [t.a ASC, t.b ASC, t.c ASC], limit: 1, offset: 0, group_key: [t.a] }
+        └─BatchExchange { order: [], dist: HashShard(t.a) }
+          └─BatchScan { table: t, columns: [t.a, t.b, t.c], distribution: SomeShard }
+  stream_plan: |-
+    StreamMaterialize { columns: [a, b, c], stream_key: [a], pk_columns: [a], pk_conflict: NoCheck }
+    └─StreamProject { exprs: [t.a, t.b, t.c] }
+      └─StreamGroupTopN { order: [t.a ASC, t.b ASC, t.c ASC], limit: 1, offset: 0, group_key: [t.a] }
+        └─StreamExchange { dist: HashShard(t.a) }
+          └─StreamTableScan { table: t, columns: [t.a, t.b, t.c, t._row_id], stream_scan_type: SnapshotBackfill, stream_key: [t._row_id], pk: [_row_id], dist: UpstreamHashShard(t._row_id) }
 - sql: |
     create table t (a int, b int, c int);
     select distinct on (foo, b) a as foo, b from t;

--- a/src/frontend/planner_test/tests/testdata/output/distinct_on.yaml
+++ b/src/frontend/planner_test/tests/testdata/output/distinct_on.yaml
@@ -62,13 +62,13 @@
     from t_probe
     left join mv_order on mv_order.k = t_probe.k;
   stream_plan: |-
-    StreamMaterialize { columns: [k, v, mv_order.k(hidden), mv_order.t_order.ts(hidden), mv_order.t_order.id(hidden)], stream_key: [k, mv_order.t_order.ts, mv_order.t_order.id], pk_columns: [k, mv_order.t_order.ts, mv_order.t_order.id], pk_conflict: NoCheck }
-    └─StreamExchange { dist: HashShard(t_probe.k, mv_order.t_order.ts, mv_order.t_order.id) }
-      └─StreamHashJoin { type: LeftOuter, predicate: t_probe.k = mv_order.k, output: [t_probe.k, mv_order.v, mv_order.k, mv_order.t_order.ts, mv_order.t_order.id] }
+    StreamMaterialize { columns: [k, v, mv_order.k(hidden)], stream_key: [k], pk_columns: [k], pk_conflict: NoCheck }
+    └─StreamExchange { dist: HashShard(t_probe.k) }
+      └─StreamHashJoin { type: LeftOuter, predicate: t_probe.k = mv_order.k, output: [t_probe.k, mv_order.v, mv_order.k] }
         ├─StreamExchange { dist: HashShard(t_probe.k) }
         │ └─StreamTableScan { table: t_probe, columns: [t_probe.k], stream_scan_type: SnapshotBackfill, stream_key: [t_probe.k], pk: [k], dist: UpstreamHashShard(t_probe.k) }
         └─StreamExchange { dist: HashShard(mv_order.k) }
-          └─StreamTableScan { table: mv_order, columns: [mv_order.k, mv_order.v, mv_order.t_order.ts, mv_order.t_order.id], stream_scan_type: SnapshotBackfill, stream_key: [mv_order.k, mv_order.t_order.ts, mv_order.t_order.id], pk: [k, t_order.ts, t_order.id], dist: UpstreamHashShard(mv_order.k) }
+          └─StreamTableScan { table: mv_order, columns: [mv_order.k, mv_order.v], stream_scan_type: SnapshotBackfill, stream_key: [mv_order.k], pk: [k], dist: UpstreamHashShard(mv_order.k) }
 - name: snapshot backfill keeps scan unchanged when stream key is already table pk
   sql: |
     set streaming_use_snapshot_backfill = true;
@@ -87,8 +87,8 @@
       order by k, ts desc, id desc;
     select k, v, ts, id from mv_order_full;
   stream_plan: |-
-    StreamMaterialize { columns: [k, v, ts, id], stream_key: [k, ts, id], pk_columns: [k, ts, id], pk_conflict: NoCheck }
-    └─StreamTableScan { table: mv_order_full, columns: [mv_order_full.k, mv_order_full.v, mv_order_full.ts, mv_order_full.id], stream_scan_type: SnapshotBackfill, stream_key: [mv_order_full.k, mv_order_full.ts, mv_order_full.id], pk: [k, ts, id], dist: UpstreamHashShard(mv_order_full.k) }
+    StreamMaterialize { columns: [k, v, ts, id], stream_key: [k], pk_columns: [k], pk_conflict: NoCheck }
+    └─StreamTableScan { table: mv_order_full, columns: [mv_order_full.k, mv_order_full.v, mv_order_full.ts, mv_order_full.id], stream_scan_type: SnapshotBackfill, stream_key: [mv_order_full.k], pk: [k], dist: UpstreamHashShard(mv_order_full.k) }
 - name: distinct on order by stops MV pk after stream key
   sql: |
     create table t (a int, b int, c int);

--- a/src/frontend/planner_test/tests/testdata/output/pk_derive.yaml
+++ b/src/frontend/planner_test/tests/testdata/output/pk_derive.yaml
@@ -103,3 +103,24 @@
     StreamMaterialize { columns: [v1, mv.v2(hidden), mv.v3(hidden)], stream_key: [v1, mv.v2, mv.v3], pk_columns: [v1, mv.v2, mv.v3], pk_conflict: NoCheck }
     └─StreamFilter { predicate: ((mv.v3 = 'world':Varchar) OR (mv.v3 = 'hello':Varchar)) }
       └─StreamTableScan { table: mv, columns: [mv.v1, mv.v2, mv.v3], stream_scan_type: SnapshotBackfill, stream_key: [mv.v1, mv.v2, mv.v3], pk: [v1, v2, v3], dist: UpstreamHashShard(mv.v1, mv.v2, mv.v3) }
+- name: MV pk stops after stream key in order by
+  sql: |
+    create table t (a int, b int, c int);
+    select
+        b,
+        min(a) as a,
+        min(c) as c
+    from
+        t
+    group by
+        b
+    order by
+        a,
+        b,
+        c;
+  stream_plan: |-
+    StreamMaterialize { columns: [b, a, c], stream_key: [b], pk_columns: [a, b], pk_conflict: NoCheck }
+    └─StreamProject { exprs: [t.b, min(t.a), min(t.c)] }
+      └─StreamHashAgg { group_key: [t.b], aggs: [min(t.a), min(t.c), count] }
+        └─StreamExchange { dist: HashShard(t.b) }
+          └─StreamTableScan { table: t, columns: [t.a, t.b, t.c, t._row_id], stream_scan_type: SnapshotBackfill, stream_key: [t._row_id], pk: [_row_id], dist: UpstreamHashShard(t._row_id) }

--- a/src/frontend/src/catalog/table_catalog.rs
+++ b/src/frontend/src/catalog/table_catalog.rs
@@ -71,8 +71,8 @@ use crate::user::UserId;
 ///
 /// - **Order Key**: the primary key for storage, used to sort and access data.
 ///
-///   For an MV, the columns in `ORDER BY` clause will be put at the beginning of the order key. And
-///   the remaining columns in pk will follow behind.
+///   For an MV, the columns in `ORDER BY` clause will be put at the beginning of the order key
+///   until the stream key is covered. The remaining stream-key columns will follow behind.
 ///
 ///   If there's no `ORDER BY` clause, the order key will be the same as pk.
 ///

--- a/src/frontend/src/optimizer/plan_node/derive.rs
+++ b/src/frontend/src/optimizer/plan_node/derive.rs
@@ -119,6 +119,8 @@ pub(crate) fn derive_pk(
 
     let mut in_order = FixedBitSet::with_capacity(schema.len());
     let mut pk = vec![];
+    let mut remaining_stream_key = stream_key.clone();
+    let stop_order_by_after_stream_key = !remaining_stream_key.is_empty();
 
     let func_dep = input.functional_dependency();
     let user_order_by = func_dep.minimize_order_key(
@@ -135,9 +137,18 @@ pub(crate) fn derive_pk(
         let idx = order.column_index;
         pk.push(*order);
         in_order.insert(idx);
+        if let Some(pos) = remaining_stream_key
+            .iter()
+            .position(|stream_key_idx| *stream_key_idx == idx)
+        {
+            remaining_stream_key.remove(pos);
+            if stop_order_by_after_stream_key && remaining_stream_key.is_empty() {
+                break;
+            }
+        }
     }
 
-    for &idx in &stream_key {
+    for &idx in &remaining_stream_key {
         if in_order.contains(idx) {
             continue;
         }

--- a/src/frontend/src/optimizer/plan_node/derive.rs
+++ b/src/frontend/src/optimizer/plan_node/derive.rs
@@ -102,8 +102,6 @@ pub(crate) fn derive_pk(
         }
     }
 
-    let schema = input.schema();
-
     // Assert the uniqueness of column names and IDs, including hidden columns.
     if let Some(name) = columns.iter().map(|c| c.name()).duplicates().next() {
         panic!("duplicated column name \"{name}\"");
@@ -117,7 +115,6 @@ pub(crate) fn derive_pk(
         input.schema().data_types()
     );
 
-    let mut in_order = FixedBitSet::with_capacity(schema.len());
     let mut pk = vec![];
     let mut remaining_stream_key = stream_key.clone();
     let stop_order_by_after_stream_key = !remaining_stream_key.is_empty();
@@ -136,7 +133,6 @@ pub(crate) fn derive_pk(
     for order in &user_order_by.column_orders {
         let idx = order.column_index;
         pk.push(*order);
-        in_order.insert(idx);
         if let Some(pos) = remaining_stream_key
             .iter()
             .position(|stream_key_idx| *stream_key_idx == idx)
@@ -149,11 +145,7 @@ pub(crate) fn derive_pk(
     }
 
     for &idx in &remaining_stream_key {
-        if in_order.contains(idx) {
-            continue;
-        }
         pk.push(ColumnOrder::new(idx, OrderType::ascending()));
-        in_order.insert(idx);
     }
 
     (pk, stream_key)


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

This PR trims the derived materialized view storage primary key when `ORDER BY` already covers the MV stream key.

Previously, MV PK derivation placed all minimized `ORDER BY` columns before appending any missing stream-key columns. For cases like `DISTINCT ON (a) ORDER BY a, b, c`, this made the MV PK `[a, b, c]` even though the stream key is already covered by `a`.

The new derivation:

- starts with the input stream key columns as the required uniqueness set,
- appends `ORDER BY` columns until all stream-key columns have appeared,
- stops consuming later `ORDER BY` columns once the stream key is covered,
- appends any stream-key columns that were not present in `ORDER BY`.

Planner coverage is added for:

- `DISTINCT ON (a) ORDER BY a, b, c`, expecting MV PK `[a]`,
- `GROUP BY b ORDER BY a, b, c`, expecting MV PK `[a, b]`,
- existing distinct-on snapshot-backfill planner expectations after regenerating outputs.

## Checklist

- [ ] I have written necessary rustdoc comments.
- [x] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [x] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

Not user-facing.

</details>
