### PR TITLE
cherry-pick fix(iceberg): support reading uuid/fixed columns as bytea (#25807) to patch-v2.8.4

### DIFF
--- a/e2e_test/source_inline/fs/parquet_fixed_size_binary.slt
+++ b/e2e_test/source_inline/fs/parquet_fixed_size_binary.slt
@@ -1,0 +1,51 @@
+# Regression test for reading Parquet `FixedSizeBinary` columns as `bytea`.
+#
+# Iceberg represents `uuid` as Arrow `FixedSizeBinary(16)` and `fixed[L]` as
+# Arrow `FixedSizeBinary(L)`. Before the fix, the Arrow -> RisingWave conversion
+# in `src/common/src/array/arrow/arrow_impl.rs` did not handle `FixedSizeBinary`,
+# so creating/reading such a source panicked the frontend with:
+#
+#     called `Result::unwrap()` on an `Err` value:
+#       FromArrow("unsupported arrow data type: FixedSizeBinary(16)")
+#
+# The Parquet file source shares the exact same conversion code path
+# (`is_parquet_schema_match_source_schema` + `IcebergArrowConvert::array_from_arrow_array`
+# in `src/connector/src/parser/parquet_parser.rs`), so this test reproduces the
+# bug without needing an external Iceberg catalog: pyarrow's `binary(16)` /
+# `binary(8)` produce real Parquet `FixedSizeBinary` columns.
+#
+# The Parquet file below was generated with pyarrow 23.0.1:
+#   id: int32      = [1, 2, 3]
+#   u:  binary(16) = [0x1234..f0, NULL, 0x0011..ff]
+#   f:  binary(8)  = [0x0011..77, 0x8899..ff, NULL]
+
+system ok
+bash -euo pipefail -c '
+  rm -rf /tmp/rw_parquet_fixed_size_binary
+  mkdir -p /tmp/rw_parquet_fixed_size_binary
+  printf "%s" "UEFSMRUEFRgVHEwVBhUAEgAADCwBAAAAAgAAAAMAAAAVABUUFRgsFQYVEBUGFQYcGAQDAAAAGAQBAAAAFgAoBAMAAAAYBAEAAAAREQAAAAokAgAAAAYBAgMkABUEFUAVOkwVBBUAEgAAIBwSNFZ4mrze8BEIPAARIjNEVWZ3iJmqu8zd7v8VABUSFRYsFQYVEBUGFQYcNgIoEBI0VniavN7wEjRWeJq83vAYEAARIjNEVWZ3iJmqu8zd7v8REQAAAAkgAgAAAAMFAQMCFQQVIBUkTBUEFQASAAAQPAARIjNEVWZ3iJmqu8zd7v8VABUSFRYsFQYVEBUGFQYcNgIoCIiZqrvM3e7/GAgAESIzRFVmdxERAAAACSACAAAAAwMBAwIVBBlMNQAYBnNjaGVtYRUGABUCJQIYAmlkABUOFSAVAhgBdQAVDhUQFQIYAWYAFgYZHBk8JgAcFQIZNQAGEBkYAmlkFQIWBhamARauASZAJggcGAQDAAAAGAQBAAAAFgAoBAMAAAAYBAEAAAAREQAZLBUEFQAVAgAVABUQFQIAPCkGGSYABgAAACYAHBUOGTUABhAZGAF1FQIWBhbkARbiASaMAia2ARw2AigQEjRWeJq83vASNFZ4mrze8BgQABEiM0RVZneImaq7zN3u/xERABksFQQVABUCABUAFRAVAgA8KQYZJgIEAAAAJgAcFQ4ZNQAGEBkYAWYVAhYGFqQBFqwBJtgDJpgDHDYCKAiImaq7zN3u/xgIABEiM0RVZncREQAZLBUEFQAVAgAVABUQFQIAPCkGGSYCBAAAABauBBYGJggWvAQAGRwYDEFSUk9XOnNjaGVtYRisAi8vLy8vOWdBQUFBUUFBQUFBQUFLQUF3QUJnQUZBQWdBQ2dBQUFBQUJCQUFNQUFBQUNBQUlBQUFBQkFBSUFBQUFCQUFBQUFNQUFBQndBQUFBTUFBQUFBUUFBQUNzLy8vL0FBQUJEeEFBQUFBVUFBQUFCQUFBQUFBQUFBQUJBQUFBWmdBQUFOci8vLzhJQUFBQTFQLy8vd0FBQVE4UUFBQUFHQUFBQUFRQUFBQUFBQUFBQVFBQUFIVUFCZ0FJQUFRQUJnQUFBQkFBQUFBUUFCUUFDQUFHQUFjQURBQUFBQkFBRUFBQUFBQUFBUUlRQUFBQUhBQUFBQVFBQUFBQUFBQUFBZ0FBQUdsa0FBQUlBQXdBQ0FBSEFBZ0FBQUFBQUFBQklBQUFBQUFBQUFBPQAYIHBhcnF1ZXQtY3BwLWFycm93IHZlcnNpb24gMjMuMC4xGTwcAAAcAAAcAAAAtgIAAFBBUjE=" \
+    | base64 -d > /tmp/rw_parquet_fixed_size_binary/data.parquet
+'
+
+statement ok
+CREATE TABLE parquet_fixed_size_binary (
+    id int,
+    u bytea,
+    f bytea
+) WITH (
+    connector = 'posix_fs',
+    posix_fs.root = '/tmp/rw_parquet_fixed_size_binary'
+) FORMAT PLAIN ENCODE PARQUET;
+
+query ITT retry 20 backoff 1s
+SELECT id, u, f FROM parquet_fixed_size_binary ORDER BY id;
+----
+1 \x123456789abcdef0123456789abcdef0 \x0011223344556677
+2 NULL \x8899aabbccddeeff
+3 \x00112233445566778899aabbccddeeff NULL
+
+statement ok
+DROP TABLE parquet_fixed_size_binary;
+
+system ok
+rm -rf /tmp/rw_parquet_fixed_size_binary

--- a/src/common/src/array/arrow/arrow_impl.rs
+++ b/src/common/src/array/arrow/arrow_impl.rs
@@ -564,6 +564,9 @@ pub trait FromArrow {
             Utf8 => DataType::Varchar,
             Utf8View => DataType::Varchar,
             Binary => DataType::Bytea,
+            // Iceberg `uuid` maps to `FixedSizeBinary(16)` and `fixed[L]` maps to
+            // `FixedSizeBinary(L)`. Both are represented as `Bytea` in RisingWave.
+            FixedSizeBinary(_) => self.from_fixed_size_binary()?,
             LargeUtf8 => self.from_large_utf8()?,
             LargeBinary => self.from_large_binary()?,
             List(field) => DataType::list(self.from_field(field)?),
@@ -589,6 +592,11 @@ pub trait FromArrow {
 
     /// Converts Arrow `LargeBinary` type to RisingWave data type.
     fn from_large_binary(&self) -> Result<DataType, ArrayError> {
+        Ok(DataType::Bytea)
+    }
+
+    /// Converts Arrow `FixedSizeBinary` type to RisingWave data type.
+    fn from_fixed_size_binary(&self) -> Result<DataType, ArrayError> {
         Ok(DataType::Bytea)
     }
 
@@ -689,6 +697,9 @@ pub trait FromArrow {
             Utf8 => self.from_utf8_array(array.as_any().downcast_ref().unwrap()),
             Utf8View => self.from_utf8_view_array(array.as_any().downcast_ref().unwrap()),
             Binary => self.from_binary_array(array.as_any().downcast_ref().unwrap()),
+            FixedSizeBinary(_) => {
+                self.from_fixed_size_binary_array(array.as_any().downcast_ref().unwrap())
+            }
             LargeUtf8 => self.from_large_utf8_array(array.as_any().downcast_ref().unwrap()),
             LargeBinary => self.from_large_binary_array(array.as_any().downcast_ref().unwrap()),
             List(_) => self.from_list_array(array.as_any().downcast_ref().unwrap()),
@@ -902,6 +913,13 @@ pub trait FromArrow {
         array: &arrow_array::LargeBinaryArray,
     ) -> Result<ArrayImpl, ArrayError> {
         Ok(ArrayImpl::Bytea(array.into()))
+    }
+
+    fn from_fixed_size_binary_array(
+        &self,
+        array: &arrow_array::FixedSizeBinaryArray,
+    ) -> Result<ArrayImpl, ArrayError> {
+        Ok(ArrayImpl::Bytea(array.iter().collect()))
     }
 
     fn from_list_array(&self, array: &arrow_array::ListArray) -> Result<ArrayImpl, ArrayError> {
@@ -1625,7 +1643,10 @@ pub fn is_parquet_schema_match_source_schema(
         | (ArrowType::Time32(_) | ArrowType::Time64(_), RwType::Time)
         | (ArrowType::Interval(arrow_schema::IntervalUnit::MonthDayNano), RwType::Interval)
         | (ArrowType::Utf8 | ArrowType::LargeUtf8, RwType::Varchar)
-        | (ArrowType::Binary | ArrowType::LargeBinary, RwType::Bytea) => true,
+        | (
+            ArrowType::Binary | ArrowType::LargeBinary | ArrowType::FixedSizeBinary(_),
+            RwType::Bytea,
+        ) => true,
 
         // Struct type recursive matching
         // Arrow's Struct matches RisingWave's Struct if all expected field names exist and types
@@ -2019,6 +2040,32 @@ mod tests {
         let array = BytesArray::from_iter([None, Some("array".as_bytes())]);
         let arrow = arrow_array::BinaryArray::from(&array);
         assert_eq!(BytesArray::from(&arrow), array);
+    }
+
+    #[test]
+    fn fixed_size_binary() {
+        struct Dummy;
+        impl FromArrow for Dummy {}
+
+        let uuid = [
+            0x12, 0x34, 0x56, 0x78, 0x9a, 0xbc, 0xde, 0xf0, 0x12, 0x34, 0x56, 0x78, 0x9a, 0xbc,
+            0xde, 0xf0,
+        ];
+        let arrow_array = arrow_array::FixedSizeBinaryArray::try_from_sparse_iter_with_size(
+            [None, Some(uuid)].into_iter(),
+            16,
+        )
+        .unwrap();
+        let field =
+            arrow_schema::Field::new("u", arrow_schema::DataType::FixedSizeBinary(16), true);
+
+        assert_eq!(Dummy.from_field(&field).unwrap(), DataType::Bytea);
+
+        let rw_array = Dummy
+            .from_array(&field, &(Arc::new(arrow_array) as arrow_array::ArrayRef))
+            .unwrap();
+        let expected = BytesArray::from_iter([None, Some(uuid.as_slice())]);
+        assert_eq!(rw_array.as_bytea(), &expected);
     }
 
     #[test]


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

Patch on top of the `v2.8.4` release tag (base branch `patch-v2.8.4`). Cherry-pick of #25807.

Reading an Iceberg table whose schema contains a `uuid` or `fixed[L]` column panicked the frontend:

```
FromArrow("unsupported arrow data type: FixedSizeBinary(16)")
```

Iceberg maps `uuid` to Arrow `FixedSizeBinary(16)` and `fixed[L]` to `FixedSizeBinary(L)`, but the Arrow → RisingWave conversion in `arrow_impl.rs` had no rule for `FixedSizeBinary`, so it hit the unsupported-type branch and was unwrapped into a panic.

This maps `FixedSizeBinary(_)` to `Bytea` in `from_field`, `from_array`, and `is_parquet_schema_match_source_schema`. `Bytea` is the lossless representation for both UUID bytes and arbitrary fixed-length payloads, matching how `Binary`/`LargeBinary` are already handled.

## Checklist

- [x] I have added necessary unit tests and integration tests.

## Documentation

- [ ] My PR needs documentation updates.
