### PR TITLE
chore: bump iceberg deps for token refresh

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6859,7 +6859,7 @@ dependencies = [
 [[package]]
 name = "iceberg"
 version = "0.8.0"
-source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=fb290e4c9473b1fb4b582e9ac88a8fe08d2265ef#fb290e4c9473b1fb4b582e9ac88a8fe08d2265ef"
+source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=8f7c952f66de9b2d65c1d168eccf32a3fe291a55#8f7c952f66de9b2d65c1d168eccf32a3fe291a55"
 dependencies = [
  "anyhow",
  "apache-avro 0.21.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -6887,6 +6887,7 @@ dependencies = [
  "flate2",
  "fnv",
  "futures",
+ "hashbrown 0.17.1",
  "itertools 0.13.0",
  "moka",
  "murmur3",
@@ -6917,7 +6918,7 @@ dependencies = [
 [[package]]
 name = "iceberg-catalog-glue"
 version = "0.8.0"
-source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=fb290e4c9473b1fb4b582e9ac88a8fe08d2265ef#fb290e4c9473b1fb4b582e9ac88a8fe08d2265ef"
+source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=8f7c952f66de9b2d65c1d168eccf32a3fe291a55#8f7c952f66de9b2d65c1d168eccf32a3fe291a55"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6932,7 +6933,7 @@ dependencies = [
 [[package]]
 name = "iceberg-catalog-rest"
 version = "0.8.0"
-source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=fb290e4c9473b1fb4b582e9ac88a8fe08d2265ef#fb290e4c9473b1fb4b582e9ac88a8fe08d2265ef"
+source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=8f7c952f66de9b2d65c1d168eccf32a3fe291a55#8f7c952f66de9b2d65c1d168eccf32a3fe291a55"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -6954,7 +6955,7 @@ dependencies = [
 [[package]]
 name = "iceberg-compaction-core"
 version = "0.1.0"
-source = "git+https://github.com/nimtable/iceberg-compaction.git?rev=a9ce53cc3a8401148b604897c1b586655a35a23e#a9ce53cc3a8401148b604897c1b586655a35a23e"
+source = "git+https://github.com/nimtable/iceberg-compaction.git?rev=001be834b30f8e7d9a6c16df7aa369ab21e31505#001be834b30f8e7d9a6c16df7aa369ab21e31505"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -6983,7 +6984,7 @@ dependencies = [
 [[package]]
 name = "iceberg-datafusion"
 version = "0.8.0"
-source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=fb290e4c9473b1fb4b582e9ac88a8fe08d2265ef#fb290e4c9473b1fb4b582e9ac88a8fe08d2265ef"
+source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=8f7c952f66de9b2d65c1d168eccf32a3fe291a55#8f7c952f66de9b2d65c1d168eccf32a3fe291a55"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -161,14 +161,14 @@ hashbrown0_15 = { package = "hashbrown", version = "0.15", features = [
 ] }
 hytra = "0.1"
 # branch dev_rebase_main_20251111
-iceberg = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "fb290e4c9473b1fb4b582e9ac88a8fe08d2265ef", features = [
+iceberg = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "8f7c952f66de9b2d65c1d168eccf32a3fe291a55", features = [
     "storage-s3",
     "storage-gcs",
     "storage-azblob",
     "storage-azdls",
 ] }
-iceberg-catalog-glue = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "fb290e4c9473b1fb4b582e9ac88a8fe08d2265ef" }
-iceberg-catalog-rest = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "fb290e4c9473b1fb4b582e9ac88a8fe08d2265ef" }
+iceberg-catalog-glue = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "8f7c952f66de9b2d65c1d168eccf32a3fe291a55" }
+iceberg-catalog-rest = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "8f7c952f66de9b2d65c1d168eccf32a3fe291a55" }
 
 adbc_core = { version = "0.23" }
 adbc_snowflake = { version = "0.23", default-features = false }

--- a/src/storage/Cargo.toml
+++ b/src/storage/Cargo.toml
@@ -33,7 +33,7 @@ futures = { version = "0.3", default-features = false, features = ["alloc"] }
 futures-async-stream = { workspace = true }
 hex = "0.4"
 iceberg = { workspace = true }
-iceberg-compaction-core = { git = "https://github.com/nimtable/iceberg-compaction.git", rev = "a9ce53cc3a8401148b604897c1b586655a35a23e" }
+iceberg-compaction-core = { git = "https://github.com/nimtable/iceberg-compaction.git", rev = "001be834b30f8e7d9a6c16df7aa369ab21e31505" }
 itertools = { workspace = true }
 libc = "0.2"
 lz4 = "1.28.0"


### PR DESCRIPTION
## Summary
- bump iceberg-rust git rev to 8f7c952f66de9b2d65c1d168eccf32a3fe291a55
- bump iceberg-compaction-core git rev to 001be834b30f8e7d9a6c16df7aa369ab21e31505
- refresh Cargo.lock for the Iceberg-related git dependencies

## Verification
- RUSTUP_TOOLCHAIN=nightly cargo metadata --locked --no-deps --format-version 1
- RUSTUP_TOOLCHAIN=nightly-2025-10-10 cargo check -p risingwave_storage --locked