### PR TITLE
fix(pg-cdc): make composite-to-string schema unconditionally optional

### DIFF
--- a/e2e_test/source_legacy/cdc/cdc.share_stream.slt
+++ b/e2e_test/source_legacy/cdc/cdc.share_stream.slt
@@ -838,6 +838,30 @@ order by id;
 2 KEEp (EUR,88.80) (EUR,99.90) (EUR,11.10) (bar,"(2,t,world)")
 3 QmFzZTY0P2J1dF9wbGFpbg== (JPY,1234.56) (JPY,2000.00) (JPY,765.44) (baz,"(3,f,delta)")
 
+# Regression: DELETE on a row whose composite column is declared NOT NULL upstream.
+# Under REPLICA IDENTITY DEFAULT, Debezium fills non-PK columns with null in the
+# delete before-image; if the composite converter inherits upstream NOT NULL into
+# the Connect schema, the DELETE event fails schema validation and stalls the
+# engine. The converter therefore registers the schema as unconditionally optional.
+system ok
+psql -c "DELETE FROM order_ledger_entries_composite WHERE id = 2;"
+
+query IITTTTT retry 8 backoff 1s
+select id, note_varchar, total, listed_price, listed_discount, complex_col
+from composite_text_schema_specified_shared
+order by id;
+----
+1 still_plain_text_1 (USD,66.66) (USD,20.00) (USD,7.66) (foo_updated,"(9,t,baz)")
+3 QmFzZTY0P2J1dF9wbGFpbg== (JPY,1234.56) (JPY,2000.00) (JPY,765.44) (baz,"(3,f,delta)")
+
+query IITTTTT retry 8 backoff 1s
+select id, note_varchar, total, listed_price, listed_discount, complex_col
+from composite_text_auto_derived_shared
+order by id;
+----
+1 still_plain_text_1 (USD,66.66) (USD,20.00) (USD,7.66) (foo_updated,"(9,t,baz)")
+3 QmFzZTY0P2J1dF9wbGFpbg== (JPY,1234.56) (JPY,2000.00) (JPY,765.44) (baz,"(3,f,delta)")
+
 statement ok
 CREATE TABLE test_pg_default_value (
     id int,

--- a/e2e_test/source_legacy/cdc/postgres_cdc.sql
+++ b/e2e_test/source_legacy/cdc/postgres_cdc.sql
@@ -64,7 +64,7 @@ CREATE TABLE order_ledger_entries_composite (
     note_varchar varchar,
     total money_type,
     listed_price money_type,
-    listed_discount money_type,
+    listed_discount money_type NOT NULL,
     complex_col outer_type
 );
 

--- a/java/connector-node/risingwave-source-cdc/src/main/java/com/risingwave/connector/cdc/debezium/converters/PgCompositeToStringConverter.java
+++ b/java/connector-node/risingwave-source-cdc/src/main/java/com/risingwave/connector/cdc/debezium/converters/PgCompositeToStringConverter.java
@@ -54,10 +54,9 @@ public class PgCompositeToStringConverter
             return;
         }
 
-        var schemaBuilder = SchemaBuilder.string();
-        if (column.isOptional()) {
-            schemaBuilder.optional();
-        }
+        // Always optional: PG DELETE before-image fills non-PK columns with null
+        // under REPLICA IDENTITY DEFAULT, regardless of upstream NOT NULL.
+        var schemaBuilder = SchemaBuilder.string().optional();
 
         registration.register(schemaBuilder, this::convertValue);
     }


### PR DESCRIPTION
## Summary

The composite-to-string converter added in #25153 registered the Kafka Connect schema as required whenever the upstream column was `NOT NULL`. Under `REPLICA IDENTITY DEFAULT`, the DELETE before-image fills non-PK columns with null, so emitting the DELETE failed schema validation:

```
DataException: Invalid value: null used for required field: "<col>", schema type: STRING
    at Envelope.delete(Envelope.java:334)
    at RelationalChangeRecordEmitter.emitDeleteRecord(...)
```

The embedded Debezium engine then terminated and restarted in a loop on the same LSN, stalling CDC for that table.

Make the schema unconditionally optional in the converter — downstream nullability is expressed by the RW table definition, not the emit-side Connect schema. The fix is a one-liner; the rest is an e2e regression.

## Test plan

- [x] Local repro before the fix: DELETE on a row whose composite column is upstream-`NOT NULL` triggers `DataException: Invalid value: null used for required field` and the engine terminates in a loop on the same LSN. After the fix, the DELETE flows through and the engine is quiet.
- [x] Added regression in `e2e_test/source_legacy/cdc/cdc.share_stream.slt`: `listed_discount money_type` is now declared `NOT NULL` in `postgres_cdc.sql`, and a DELETE is asserted to propagate to both schema-specified and auto-derived shared CDC tables.