### PR TITLE
fix(meta): finish recovered batch refresh jobs

### DIFF
--- a/e2e_test/streaming/batch_refresh_snapshot.slt
+++ b/e2e_test/streaming/batch_refresh_snapshot.slt
@@ -1,4 +1,7 @@
 statement ok
+SET RW_IMPLICIT_FLUSH TO true;
+
+statement ok
 DROP MATERIALIZED VIEW IF EXISTS mv_batch;
 
 statement ok

--- a/src/meta/src/barrier/context/recovery.rs
+++ b/src/meta/src/barrier/context/recovery.rs
@@ -38,7 +38,8 @@ use crate::barrier::DatabaseRuntimeInfoSnapshot;
 use crate::barrier::checkpoint::{
     BatchRefreshJobCheckpointControl, BatchRefreshLogicalFragments, BatchRefreshRenderResult,
 };
-use crate::barrier::context::GlobalBarrierWorkerContextImpl;
+use crate::barrier::context::{GlobalBarrierWorkerContext, GlobalBarrierWorkerContextImpl};
+use crate::barrier::progress::TrackingJob;
 use crate::barrier::rpc::to_partial_graph_id;
 use crate::controller::fragment::{InflightActorInfo, InflightFragmentInfo};
 use crate::controller::scale::{
@@ -310,6 +311,95 @@ fn build_stream_actors(
 }
 
 impl GlobalBarrierWorkerContextImpl {
+    fn resolve_job_committed_epoch(
+        job_id: JobId,
+        fragments: &HashMap<FragmentId, LoadedFragment>,
+        state_table_committed_epochs: &HashMap<TableId, u64>,
+    ) -> MetaResult<u64> {
+        let mut table_id_iter = fragments
+            .values()
+            .flat_map(|fragment| fragment.state_table_ids.iter().copied());
+        let Some(first_table_id) = table_id_iter.next() else {
+            bail!("job {} has no state table", job_id);
+        };
+        let committed_epoch = *state_table_committed_epochs
+            .get(&first_table_id)
+            .ok_or_else(|| anyhow!("cannot get committed epoch on table {}.", first_table_id))?;
+        for table_id in table_id_iter {
+            let table_committed_epoch = *state_table_committed_epochs
+                .get(&table_id)
+                .ok_or_else(|| anyhow!("cannot get committed epoch on table {}.", table_id))?;
+            if committed_epoch != table_committed_epoch {
+                bail!(
+                    "table {} has committed epoch {} different to other table {} with committed epoch {} in job {}",
+                    first_table_id,
+                    committed_epoch,
+                    table_id,
+                    table_committed_epoch,
+                    job_id
+                );
+            }
+        }
+
+        Ok(committed_epoch)
+    }
+
+    async fn finish_completed_batch_refresh_background_jobs(
+        &self,
+        recovery_context: &LoadedRecoveryContext,
+        state_table_committed_epochs: &HashMap<TableId, u64>,
+        background_jobs: &mut HashSet<JobId>,
+    ) -> MetaResult<()> {
+        let background_job_ids = background_jobs.iter().copied().collect_vec();
+        for job_id in background_job_ids {
+            let Some(job) = recovery_context.fragment_context.job_map.get(&job_id) else {
+                continue;
+            };
+            if job.refresh_interval_sec.is_none() {
+                continue;
+            }
+            let Some(fragments) = recovery_context.fragment_context.job_fragments.get(&job_id)
+            else {
+                continue;
+            };
+
+            let committed_epoch =
+                Self::resolve_job_committed_epoch(job_id, fragments, state_table_committed_epochs)?;
+            let snapshot_backfill_info = StreamFragmentGraph::collect_snapshot_backfill_info_impl(
+                fragments
+                    .values()
+                    .map(|fragment| (&fragment.nodes, fragment.fragment_type_mask)),
+            )?
+            .0
+            .ok_or_else(|| anyhow!("batch refresh job {} has no snapshot backfill info", job_id))?;
+            let snapshot_epoch = snapshot_backfill_info
+                .upstream_mv_table_id_to_backfill_epoch
+                .values()
+                .find_map(|e| *e)
+                .unwrap_or(committed_epoch);
+            if committed_epoch < snapshot_epoch {
+                continue;
+            }
+
+            info!(
+                %job_id,
+                committed_epoch,
+                snapshot_epoch,
+                "finish completed batch refresh background job during recovery"
+            );
+            self.finish_creating_job(TrackingJob::recovered_from_fragment_nodes(
+                job_id,
+                fragments
+                    .iter()
+                    .map(|(fragment_id, fragment)| (*fragment_id, &fragment.nodes)),
+            ))
+            .await?;
+            background_jobs.remove(&job_id);
+        }
+
+        Ok(())
+    }
+
     async fn apply_pre_applied_drop_cancel(
         &self,
         database_id: Option<DatabaseId>,
@@ -588,30 +678,8 @@ impl GlobalBarrierWorkerContextImpl {
         };
         let mut min_downstream_committed_epochs = HashMap::new();
         for (job_id, fragments) in background_jobs {
-            let job_committed_epoch = {
-                let mut table_id_iter = fragments
-                    .values()
-                    .flat_map(|fragment| fragment.state_table_ids.iter().copied());
-                let Some(first_table_id) = table_id_iter.next() else {
-                    bail!("job {} has no state table", job_id);
-                };
-                let job_committed_epoch = get_table_committed_epoch(first_table_id)?;
-                for table_id in table_id_iter {
-                    let table_committed_epoch = get_table_committed_epoch(table_id)?;
-                    if job_committed_epoch != table_committed_epoch {
-                        bail!(
-                            "table {} has committed epoch {} different to other table {} with committed epoch {} in job {}",
-                            first_table_id,
-                            job_committed_epoch,
-                            table_id,
-                            table_committed_epoch,
-                            job_id
-                        );
-                    }
-                }
-
-                job_committed_epoch
-            };
+            let job_committed_epoch =
+                Self::resolve_job_committed_epoch(job_id, fragments, &table_committed_epoch)?;
             if let (Some(snapshot_backfill_info), _) =
                 StreamFragmentGraph::collect_snapshot_backfill_info_impl(
                     fragments
@@ -715,7 +783,7 @@ impl GlobalBarrierWorkerContextImpl {
 
                     // Background job progress needs to be recovered.
                     tracing::info!("recovering background job progress");
-                    let initial_background_jobs = self
+                    let mut initial_background_jobs = self
                         .list_background_job_progress(None)
                         .await
                         .context("recover background job progress should not fail")?;
@@ -816,6 +884,13 @@ impl GlobalBarrierWorkerContextImpl {
                         })
                         .await?;
 
+                    self.finish_completed_batch_refresh_background_jobs(
+                        &recovery_context,
+                        &state_table_committed_epochs,
+                        &mut initial_background_jobs,
+                    )
+                    .await?;
+
                     let mv_depended_subscriptions = self
                         .metadata_manager
                         .get_mv_depended_subscriptions(None)
@@ -884,7 +959,7 @@ impl GlobalBarrierWorkerContextImpl {
             "recovering background job progress of database"
         );
 
-        let background_jobs = self
+        let mut background_jobs = self
             .list_background_job_progress(Some(database_id))
             .await
             .context("recover background job progress of database should not fail")?;
@@ -931,6 +1006,13 @@ impl GlobalBarrierWorkerContextImpl {
                 )
             })
             .await?;
+
+        self.finish_completed_batch_refresh_background_jobs(
+            &recovery_context,
+            &state_table_committed_epochs,
+            &mut background_jobs,
+        )
+        .await?;
 
         let mv_depended_subscriptions = self
             .metadata_manager

--- a/src/meta/src/barrier/progress.rs
+++ b/src/meta/src/barrier/progress.rs
@@ -19,6 +19,7 @@ use risingwave_common::catalog::{FragmentTypeFlag, TableId};
 use risingwave_common::id::JobId;
 use risingwave_common::util::epoch::Epoch;
 use risingwave_pb::hummock::HummockVersionStats;
+use risingwave_pb::stream_plan::StreamNode;
 use risingwave_pb::stream_service::barrier_complete_response::CreateMviewProgress;
 
 use crate::MetaResult;
@@ -336,11 +337,20 @@ impl TrackingJob {
         job_id: JobId,
         fragment_infos: &HashMap<FragmentId, InflightFragmentInfo>,
     ) -> Self {
-        let source_backfill_fragments = StreamJobFragments::source_backfill_fragments_impl(
+        Self::recovered_from_fragment_nodes(
+            job_id,
             fragment_infos
                 .iter()
                 .map(|(fragment_id, fragment)| (*fragment_id, &fragment.nodes)),
-        );
+        )
+    }
+
+    pub(crate) fn recovered_from_fragment_nodes<'a>(
+        job_id: JobId,
+        fragment_nodes: impl Iterator<Item = (FragmentId, &'a StreamNode)>,
+    ) -> Self {
+        let source_backfill_fragments =
+            StreamJobFragments::source_backfill_fragments_impl(fragment_nodes);
         let source_change = if source_backfill_fragments.is_empty() {
             None
         } else {


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

- Fixes recovery for batch-refresh materialized views whose initial snapshot checkpoint has already committed while the catalog job is still marked as creating.
- During runtime-info reload, completed background batch-refresh jobs are detected by comparing the job committed epoch with the snapshot epoch, then finalized through the existing `finish_creating_job` / `TrackingJob` path.
- Reuses the committed-epoch validation helper for recovery epoch resolution.

- Closes #25774

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [x] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

</details>
