### PR TITLE
feat(pg-cdc): support arrays of user-defined composite types

### DIFF
--- a/e2e_test/source_inline/cdc/postgres/postgres_corner_schema_change.slt
+++ b/e2e_test/source_inline/cdc/postgres/postgres_corner_schema_change.slt
@@ -1,17 +1,17 @@
 # Corner-case auto schema change tests for PG CDC.
 #
 # Focus: columns whose type is an *array of a user-defined type* (here
-# `mood_enum[]`). These are special because Debezium's schema-change event marks
-# them neither as enum (`enumValues`) nor as composite (`jdbcType == STRUCT`),
-# and their `_`-prefixed type name is not in the builtin whitelist. Without
-# dedicated handling, any schema change on such a table fails with
-# `unsupported data type _mood_enum`.
+# `mood_enum[]` and `corner_money[]`). These are special because Debezium's
+# schema-change event marks them neither as enum (`enumValues`) nor as composite
+# (`jdbcType == STRUCT`), and their `_`-prefixed type name is not in the builtin
+# whitelist. Without dedicated handling, any schema change on such a table fails
+# with `unsupported data type _mood_enum` or `unsupported data type _corner_money`.
 #
 # Two scenarios are covered:
-#  1. Existing column: an `mood_enum[]` column present before the schema change
-#     must NOT break an unrelated `ADD COLUMN`.
-#  2. New column: an `mood_enum[]` column added by the schema change itself must
-#     be derived as `varchar[]`.
+#  1. Existing columns: `mood_enum[]` and `corner_money[]` columns present before
+#     the schema change must NOT break an unrelated `ADD COLUMN`.
+#  2. New columns: `mood_enum[]` and `corner_money[]` columns added by the schema
+#     change itself must be derived as `varchar[]`.
 
 control substitution on
 
@@ -25,20 +25,26 @@ psql -c "
     FROM pg_replication_slots
     WHERE slot_name = 'corner_schema_change_slot';
     DROP TABLE IF EXISTS corner_enum_arr;
+    DROP TYPE IF EXISTS corner_money;
     DROP TYPE IF EXISTS mood_enum;
 "
 
 system ok
 psql -c "
     CREATE TYPE mood_enum AS ENUM ('happy', 'sad', 'neutral');
+    CREATE TYPE corner_money AS (
+        currency text,
+        amount numeric
+    );
     CREATE TABLE corner_enum_arr (
         id int PRIMARY KEY,
         tags mood_enum[] NOT NULL,
+        prices corner_money[] NOT NULL,
         note varchar
     );
-    INSERT INTO corner_enum_arr (id, tags, note) VALUES
-        (1, ARRAY['happy', 'sad']::mood_enum[], 'backfill_1'),
-        (2, ARRAY['neutral']::mood_enum[], 'backfill_2');
+    INSERT INTO corner_enum_arr (id, tags, prices, note) VALUES
+        (1, ARRAY['happy', 'sad']::mood_enum[], ARRAY[ROW('USD', 1)::corner_money]::corner_money[], 'backfill_1'),
+        (2, ARRAY['neutral']::mood_enum[], ARRAY[ROW('EUR', 2)::corner_money]::corner_money[], 'backfill_2');
 "
 
 statement ok
@@ -51,41 +57,43 @@ create source s with (
   database.name = '${PGDATABASE:postgres}',
   schema.name = 'public',
   slot.name = 'corner_schema_change_slot',
-  auto.schema.change = 'true'
+  auto.schema.change = 'true',
+  debezium.include.unknown.datatypes = 'true'
 );
 
-# The existing `mood_enum[]` column is derived as `varchar[]`.
+# The existing `mood_enum[]` and `corner_money[]` columns are derived as `varchar[]`.
 statement ok
 create table corner_enum_arr (*) from s table 'public.corner_enum_arr';
 
-query ITT retry 6 backoff 1s
-select id, tags, note from corner_enum_arr order by id;
+query ITTT retry 6 backoff 1s
+select id, tags, prices, note from corner_enum_arr order by id;
 ----
-1 {happy,sad} backfill_1
-2 {neutral} backfill_2
+1 {happy,sad} {"(USD,1)"} backfill_1
+2 {neutral} {"(EUR,2)"} backfill_2
 
 # Scenario 1: an unrelated `ADD COLUMN` must succeed even though the table
-# already has an `mood_enum[]` column (the original bug failed here).
+# already has user-defined array columns (the original bug failed here).
 system ok
 psql -c "
     ALTER TABLE corner_enum_arr ADD COLUMN extra int DEFAULT NULL;
-    INSERT INTO corner_enum_arr (id, tags, note, extra) VALUES
-        (3, ARRAY['neutral', 'happy']::mood_enum[], 'after_alter_1', 7);
+    INSERT INTO corner_enum_arr (id, tags, prices, note, extra) VALUES
+        (3, ARRAY['neutral', 'happy']::mood_enum[], ARRAY[ROW('GBP', 3)::corner_money]::corner_money[], 'after_alter_1', 7);
 "
 
-query ITTI retry 6 backoff 1s
-select id, tags, note, extra from corner_enum_arr order by id;
+query ITTTI retry 6 backoff 1s
+select id, tags, prices, note, extra from corner_enum_arr order by id;
 ----
-1 {happy,sad} backfill_1 NULL
-2 {neutral} backfill_2 NULL
-3 {neutral,happy} after_alter_1 7
+1 {happy,sad} {"(USD,1)"} backfill_1 NULL
+2 {neutral} {"(EUR,2)"} backfill_2 NULL
+3 {neutral,happy} {"(GBP,3)"} after_alter_1 7
 
-# The existing array-of-enum column stays `varchar[]` after the schema change.
+# The existing array-of-user-defined-type columns stay `varchar[]` after the schema change.
 query TTTT retry 6 backoff 1s
 describe corner_enum_arr;
 ----
 id integer false NULL
 tags character varying[] false NULL
+prices character varying[] false NULL
 note character varying false NULL
 extra integer false NULL
 _rw_timestamp timestamp with time zone true NULL
@@ -93,30 +101,33 @@ primary key id NULL NULL
 distribution key id NULL NULL
 table description corner_enum_arr NULL NULL
 
-# Scenario 2: a newly added `mood_enum[]` column is derived as `varchar[]`.
+# Scenario 2: newly added user-defined array columns are derived as `varchar[]`.
 system ok
 psql -c "
     ALTER TABLE corner_enum_arr ADD COLUMN moods mood_enum[] DEFAULT NULL;
-    INSERT INTO corner_enum_arr (id, tags, note, extra, moods) VALUES
-        (4, ARRAY['happy']::mood_enum[], 'after_alter_2', 8, ARRAY['sad', 'neutral']::mood_enum[]);
+    ALTER TABLE corner_enum_arr ADD COLUMN discounts corner_money[] DEFAULT NULL;
+    INSERT INTO corner_enum_arr (id, tags, prices, note, extra, moods, discounts) VALUES
+        (4, ARRAY['happy']::mood_enum[], ARRAY[ROW('JPY', 4)::corner_money]::corner_money[], 'after_alter_2', 8, ARRAY['sad', 'neutral']::mood_enum[], ARRAY[ROW('AUD', 5)::corner_money]::corner_money[]);
 "
 
-query ITTIT retry 6 backoff 1s
-select id, tags, note, extra, moods from corner_enum_arr order by id;
+query ITTTITT retry 6 backoff 1s
+select id, tags, prices, note, extra, moods, discounts from corner_enum_arr order by id;
 ----
-1 {happy,sad} backfill_1 NULL NULL
-2 {neutral} backfill_2 NULL NULL
-3 {neutral,happy} after_alter_1 7 NULL
-4 {happy} after_alter_2 8 {sad,neutral}
+1 {happy,sad} {"(USD,1)"} backfill_1 NULL NULL NULL
+2 {neutral} {"(EUR,2)"} backfill_2 NULL NULL NULL
+3 {neutral,happy} {"(GBP,3)"} after_alter_1 7 NULL NULL
+4 {happy} {"(JPY,4)"} after_alter_2 8 {sad,neutral} {"(AUD,5)"}
 
 query TTTT retry 6 backoff 1s
 describe corner_enum_arr;
 ----
 id integer false NULL
 tags character varying[] false NULL
+prices character varying[] false NULL
 note character varying false NULL
 extra integer false NULL
 moods character varying[] false NULL
+discounts character varying[] false NULL
 _rw_timestamp timestamp with time zone true NULL
 primary key id NULL NULL
 distribution key id NULL NULL
@@ -135,5 +146,6 @@ psql -c "
     FROM pg_replication_slots
     WHERE slot_name = 'corner_schema_change_slot';
     DROP TABLE IF EXISTS corner_enum_arr;
+    DROP TYPE IF EXISTS corner_money;
     DROP TYPE IF EXISTS mood_enum;
 "

--- a/e2e_test/source_inline/cdc/postgres/postgres_postgis_geometry.slt
+++ b/e2e_test/source_inline/cdc/postgres/postgres_postgis_geometry.slt
@@ -138,6 +138,124 @@ on ours.id = upstream.id;
 ----
 1 25 25 0101000020e610000000000000000000000000000000000000 0101000020e610000000000000000000000000000000000000 t
 
+# Test geometry[] -> bytea[] backfill and incremental events. The composite
+# custom converter must not intercept PostGIS arrays; Debezium should keep
+# emitting native geometry objects so RisingWave can decode EWKB bytes.
+system ok
+psql -c "
+    DROP TABLE IF EXISTS test_geo_array CASCADE;
+    CREATE TABLE test_geo_array (
+        id int PRIMARY KEY,
+        name varchar,
+        locations geometry(Point, 4326)[]
+    );
+    INSERT INTO test_geo_array VALUES
+        (
+            1,
+            'InitialRoute',
+            ARRAY[
+                ST_SetSRID(ST_MakePoint(-87.6298, 41.8781), 4326),
+                ST_SetSRID(ST_MakePoint(-74.0060, 40.7128), 4326)
+            ]::geometry(Point, 4326)[]
+        );
+"
+
+statement ok
+create table test_geo_array (
+    id int primary key,
+    name varchar,
+    locations bytea[]
+) from geo_source table 'public.test_geo_array';
+
+query IIITT retry 10 backoff 1s
+select
+  ours.id,
+  cardinality(ours.locations),
+  upstream.upstream_count,
+  encode(ours.locations[1], 'hex') = upstream.upstream_hex_1 as same_first,
+  encode(ours.locations[2], 'hex') = upstream.upstream_hex_2 as same_second
+from test_geo_array as ours
+join (
+  select * from postgres_query(
+    '${PGHOST:localhost}',
+    '${PGPORT:5432}',
+    '${PGUSER:$USER}',
+    '${PGPASSWORD:}',
+    '${PGDATABASE:postgres}',
+    'select id, array_length(locations, 1)::int as upstream_count, encode(locations[1], ''hex'') as upstream_hex_1, encode(locations[2], ''hex'') as upstream_hex_2 from test_geo_array where id = 1'
+  )
+) as upstream(id, upstream_count, upstream_hex_1, upstream_hex_2)
+on ours.id = upstream.id;
+----
+1 2 2 t t
+
+system ok
+psql -c "
+    INSERT INTO test_geo_array VALUES
+        (
+            2,
+            'InsertedRoute',
+            ARRAY[
+                ST_SetSRID(ST_MakePoint(-0.1278, 51.5074), 4326),
+                ST_SetSRID(ST_MakePoint(2.3522, 48.8566), 4326)
+            ]::geometry(Point, 4326)[]
+        );
+"
+
+query IIITT retry 10 backoff 1s
+select
+  ours.id,
+  cardinality(ours.locations),
+  upstream.upstream_count,
+  encode(ours.locations[1], 'hex') = upstream.upstream_hex_1 as same_first,
+  encode(ours.locations[2], 'hex') = upstream.upstream_hex_2 as same_second
+from test_geo_array as ours
+join (
+  select * from postgres_query(
+    '${PGHOST:localhost}',
+    '${PGPORT:5432}',
+    '${PGUSER:$USER}',
+    '${PGPASSWORD:}',
+    '${PGDATABASE:postgres}',
+    'select id, array_length(locations, 1)::int as upstream_count, encode(locations[1], ''hex'') as upstream_hex_1, encode(locations[2], ''hex'') as upstream_hex_2 from test_geo_array where id = 2'
+  )
+) as upstream(id, upstream_count, upstream_hex_1, upstream_hex_2)
+on ours.id = upstream.id;
+----
+2 2 2 t t
+
+system ok
+psql -c "
+    UPDATE test_geo_array
+    SET locations = ARRAY[
+            ST_SetSRID(ST_MakePoint(0, 0), 4326),
+            ST_SetSRID(ST_MakePoint(1, 1), 4326)
+        ]::geometry(Point, 4326)[]
+    WHERE id = 1;
+"
+
+query IIITT retry 10 backoff 1s
+select
+  ours.id,
+  cardinality(ours.locations),
+  upstream.upstream_count,
+  encode(ours.locations[1], 'hex') = upstream.upstream_hex_1 as same_first,
+  encode(ours.locations[2], 'hex') = upstream.upstream_hex_2 as same_second
+from test_geo_array as ours
+join (
+  select * from postgres_query(
+    '${PGHOST:localhost}',
+    '${PGPORT:5432}',
+    '${PGUSER:$USER}',
+    '${PGPASSWORD:}',
+    '${PGDATABASE:postgres}',
+    'select id, array_length(locations, 1)::int as upstream_count, encode(locations[1], ''hex'') as upstream_hex_1, encode(locations[2], ''hex'') as upstream_hex_2 from test_geo_array where id = 1'
+  )
+) as upstream(id, upstream_count, upstream_hex_1, upstream_hex_2)
+on ours.id = upstream.id;
+----
+1 2 2 t t
+
 # Test incremental DELETE
 system ok
 psql -c "DELETE FROM test_geo WHERE id = 2;"
@@ -218,6 +336,9 @@ statement ok
 drop table test_geo_line;
 
 statement ok
+drop table test_geo_array;
+
+statement ok
 drop table test_geo;
 
 statement ok
@@ -226,5 +347,6 @@ drop source geo_source;
 system ok
 psql -c "
     DROP TABLE IF EXISTS test_geo CASCADE;
+    DROP TABLE IF EXISTS test_geo_array CASCADE;
     DROP TABLE IF EXISTS test_geo_line CASCADE;
 "

--- a/e2e_test/source_legacy/cdc/cdc.check_new_rows.slt
+++ b/e2e_test/source_legacy/cdc/cdc.check_new_rows.slt
@@ -83,14 +83,14 @@ select id, my_num_2 from list_with_null_shared order by id;
 5 NULL
 6 NULL
 
-# Due to the bug in Debezium, if a enum list contains `NULL`, the list will be converted to `NULL`
+# Streaming user-defined arrays go through the PG custom converter and preserve NULL elements.
 query II
 select id, my_mood from list_with_null_shared order by id;
 ----
 1 NULL
 2 {happy,ok,sad}
-3 NULL
-4 NULL
+3 {NULL,sad,ok}
+4 {NULL,sad,ok}
 5 NULL
 6 NULL
 

--- a/e2e_test/source_legacy/cdc/cdc.check_new_rows.slt
+++ b/e2e_test/source_legacy/cdc/cdc.check_new_rows.slt
@@ -236,10 +236,10 @@ ORDER BY c_boolean, c_bigint, c_date;
 {}                            {}                                          {}
 NULL                          NULL                                        NULL
 {NULL,"{\"key\": \"value\"}"} {NULL,123e4567-e89b-12d3-a456-426614174000} NULL
-{"{}"}                        {bb488f9b-330d-4012-b849-12adeb49e57e}      NULL
+{"{}"}                        {bb488f9b-330d-4012-b849-12adeb49e57e}      {happy,ok,NULL}
 {}                            {}                                          {}
 NULL                          NULL                                        NULL
-{NULL,"{\"key\": \"value\"}"} {NULL,123e4567-e89b-12d3-a456-426614174000} NULL
+{NULL,"{\"key\": \"value\"}"} {NULL,123e4567-e89b-12d3-a456-426614174000} {NULL,happy}
 
 query TTT
 SELECT * FROM partitioned_timestamp_table_shared ORDER BY c_boolean, c_int;

--- a/e2e_test/source_legacy/cdc/cdc.share_stream.slt
+++ b/e2e_test/source_legacy/cdc/cdc.share_stream.slt
@@ -891,8 +891,8 @@ from composite_text_schema_specified_shared
 where id in (2, 4)
 order by id;
 ----
-2 true NULL false false false
-4 false 1 false true true
+2 t NULL f f f
+4 f 1 f t t
 
 query IBIBBB retry 8 backoff 1s
 select
@@ -906,8 +906,8 @@ from composite_text_auto_derived_shared
 where id in (2, 4)
 order by id;
 ----
-2 true NULL false false false
-4 false 1 false true true
+2 t NULL f f f
+4 f 1 f t t
 
 # Regression: DELETE on a row whose composite column is declared NOT NULL upstream.
 # Under REPLICA IDENTITY DEFAULT, Debezium fills non-PK columns with null in the

--- a/e2e_test/source_legacy/cdc/cdc.share_stream.slt
+++ b/e2e_test/source_legacy/cdc/cdc.share_stream.slt
@@ -924,6 +924,7 @@ order by id;
 ----
 1 still_plain_text_1 (USD,66.66) (USD,20.00) (USD,7.66) (foo_updated,"(9,t,baz)")
 3 QmFzZTY0P2J1dF9wbGFpbg== (JPY,1234.56) (JPY,2000.00) (JPY,765.44) (baz,"(3,f,delta)")
+4 toast_marker_update (AUD,4.40) (AUD,5.50) (AUD,1.10) (toast,"(4,t,large_array)")
 
 query IITTTTT retry 8 backoff 1s
 select id, note_varchar, total, listed_price, listed_discount, complex_col
@@ -932,6 +933,7 @@ order by id;
 ----
 1 still_plain_text_1 (USD,66.66) (USD,20.00) (USD,7.66) (foo_updated,"(9,t,baz)")
 3 QmFzZTY0P2J1dF9wbGFpbg== (JPY,1234.56) (JPY,2000.00) (JPY,765.44) (baz,"(3,f,delta)")
+4 toast_marker_update (AUD,4.40) (AUD,5.50) (AUD,1.10) (toast,"(4,t,large_array)")
 
 statement ok
 CREATE TABLE test_pg_default_value (

--- a/e2e_test/source_legacy/cdc/cdc.share_stream.slt
+++ b/e2e_test/source_legacy/cdc/cdc.share_stream.slt
@@ -814,6 +814,20 @@ INSERT INTO order_ledger_entries_composite VALUES
         ROW('JPY', 765.44)::money_type,
         ROW('baz', ROW(3, false, 'delta')::inner_type)::outer_type,
         ARRAY[ROW('CAD', 9.0)::money_type]::money_type[]
+    ),
+    (
+        4,
+        'toast_marker_initial',
+        ROW('AUD', 4.40)::money_type,
+        ROW('AUD', 5.50)::money_type,
+        ROW('AUD', 1.10)::money_type,
+        ROW('toast', ROW(4, true, 'large_array')::inner_type)::outer_type,
+        ARRAY[
+            ROW(
+                (SELECT string_agg(md5(i::text), '') FROM generate_series(1, 200) AS g(i)),
+                4.00
+            )::money_type
+        ]::money_type[]
     );
 UPDATE order_ledger_entries_composite
 SET note_varchar = 'still_plain_text_1',
@@ -821,6 +835,9 @@ SET note_varchar = 'still_plain_text_1',
     complex_col = ROW('foo_updated', ROW(9, true, 'baz')::inner_type)::outer_type,
     prices = ARRAY[ROW('GBP', 5)::money_type]::money_type[]
 WHERE id = 1;
+UPDATE order_ledger_entries_composite
+SET note_varchar = 'toast_marker_update'
+WHERE id = 4;
 "
 
 query IITTTTT retry 8 backoff 1s
@@ -831,6 +848,7 @@ order by id;
 1 still_plain_text_1 (USD,66.66) (USD,20.00) (USD,7.66) (foo_updated,"(9,t,baz)")
 2 KEEp (EUR,88.80) (EUR,99.90) (EUR,11.10) (bar,"(2,t,world)")
 3 QmFzZTY0P2J1dF9wbGFpbg== (JPY,1234.56) (JPY,2000.00) (JPY,765.44) (baz,"(3,f,delta)")
+4 toast_marker_update (AUD,4.40) (AUD,5.50) (AUD,1.10) (toast,"(4,t,large_array)")
 
 query IITTTTT retry 8 backoff 1s
 select id, note_varchar, total, listed_price, listed_discount, complex_col
@@ -840,22 +858,56 @@ order by id;
 1 still_plain_text_1 (USD,66.66) (USD,20.00) (USD,7.66) (foo_updated,"(9,t,baz)")
 2 KEEp (EUR,88.80) (EUR,99.90) (EUR,11.10) (bar,"(2,t,world)")
 3 QmFzZTY0P2J1dF9wbGFpbg== (JPY,1234.56) (JPY,2000.00) (JPY,765.44) (baz,"(3,f,delta)")
+4 toast_marker_update (AUD,4.40) (AUD,5.50) (AUD,1.10) (toast,"(4,t,large_array)")
 
 # Array of composite: backfill arrives as PG textual array form, streaming
 # INSERT/UPDATE preserves the same shape.
 query IT retry 8 backoff 1s
-select id, prices from composite_text_schema_specified_shared order by id;
+select id, prices from composite_text_schema_specified_shared where id < 4 order by id;
 ----
 1 {"(GBP,5)"}
-2 {"(JPY,100)"}
+2 NULL
 3 {"(CAD,9.0)"}
 
 query IT retry 8 backoff 1s
-select id, prices from composite_text_auto_derived_shared order by id;
+select id, prices from composite_text_auto_derived_shared where id < 4 order by id;
 ----
 1 {"(GBP,5)"}
-2 {"(JPY,100)"}
+2 NULL
 3 {"(CAD,9.0)"}
+
+# Regression: NULL composite arrays stay NULL during snapshot, while an
+# unchanged TOASTed composite array keeps its old value after updating another
+# column instead of being overwritten as an empty array.
+query IBIBBB retry 8 backoff 1s
+select
+    id,
+    prices is null,
+    cardinality(prices),
+    coalesce(prices[1] = '__debezium_unavailable_value', false),
+    coalesce(prices[1] like '(c4ca%', false),
+    coalesce(length(prices[1]) > 6000, false)
+from composite_text_schema_specified_shared
+where id in (2, 4)
+order by id;
+----
+2 true NULL false false false
+4 false 1 false true true
+
+query IBIBBB retry 8 backoff 1s
+select
+    id,
+    prices is null,
+    cardinality(prices),
+    coalesce(prices[1] = '__debezium_unavailable_value', false),
+    coalesce(prices[1] like '(c4ca%', false),
+    coalesce(length(prices[1]) > 6000, false)
+from composite_text_auto_derived_shared
+where id in (2, 4)
+order by id;
+----
+2 true NULL false false false
+4 false 1 false true true
 
 # Regression: DELETE on a row whose composite column is declared NOT NULL upstream.
 # Under REPLICA IDENTITY DEFAULT, Debezium fills non-PK columns with null in the

--- a/e2e_test/source_legacy/cdc/cdc.share_stream.slt
+++ b/e2e_test/source_legacy/cdc/cdc.share_stream.slt
@@ -780,6 +780,7 @@ CREATE TABLE composite_text_schema_specified_shared (
     listed_price varchar,
     listed_discount varchar,
     complex_col varchar,
+    prices varchar[],
     PRIMARY KEY (id)
 ) FROM pg_source TABLE 'public.order_ledger_entries_composite';
 
@@ -811,12 +812,14 @@ INSERT INTO order_ledger_entries_composite VALUES
         ROW('JPY', 1234.56)::money_type,
         ROW('JPY', 2000.00)::money_type,
         ROW('JPY', 765.44)::money_type,
-        ROW('baz', ROW(3, false, 'delta')::inner_type)::outer_type
+        ROW('baz', ROW(3, false, 'delta')::inner_type)::outer_type,
+        ARRAY[ROW('CAD', 9.0)::money_type]::money_type[]
     );
 UPDATE order_ledger_entries_composite
 SET note_varchar = 'still_plain_text_1',
     total = ROW('USD', 66.66)::money_type,
-    complex_col = ROW('foo_updated', ROW(9, true, 'baz')::inner_type)::outer_type
+    complex_col = ROW('foo_updated', ROW(9, true, 'baz')::inner_type)::outer_type,
+    prices = ARRAY[ROW('GBP', 5)::money_type]::money_type[]
 WHERE id = 1;
 "
 
@@ -837,6 +840,22 @@ order by id;
 1 still_plain_text_1 (USD,66.66) (USD,20.00) (USD,7.66) (foo_updated,"(9,t,baz)")
 2 KEEp (EUR,88.80) (EUR,99.90) (EUR,11.10) (bar,"(2,t,world)")
 3 QmFzZTY0P2J1dF9wbGFpbg== (JPY,1234.56) (JPY,2000.00) (JPY,765.44) (baz,"(3,f,delta)")
+
+# Array of composite: backfill arrives as PG textual array form, streaming
+# INSERT/UPDATE preserves the same shape.
+query IT retry 8 backoff 1s
+select id, prices from composite_text_schema_specified_shared order by id;
+----
+1 {"(GBP,5)"}
+2 {"(JPY,100)"}
+3 {"(CAD,9.0)"}
+
+query IT retry 8 backoff 1s
+select id, prices from composite_text_auto_derived_shared order by id;
+----
+1 {"(GBP,5)"}
+2 {"(JPY,100)"}
+3 {"(CAD,9.0)"}
 
 # Regression: DELETE on a row whose composite column is declared NOT NULL upstream.
 # Under REPLICA IDENTITY DEFAULT, Debezium fills non-PK columns with null in the

--- a/e2e_test/source_legacy/cdc/postgres_cdc.sql
+++ b/e2e_test/source_legacy/cdc/postgres_cdc.sql
@@ -65,7 +65,8 @@ CREATE TABLE order_ledger_entries_composite (
     total money_type,
     listed_price money_type,
     listed_discount money_type NOT NULL,
-    complex_col outer_type
+    complex_col outer_type,
+    prices money_type[]
 );
 
 INSERT INTO order_ledger_entries_composite VALUES
@@ -75,7 +76,8 @@ INSERT INTO order_ledger_entries_composite VALUES
         ROW('USD', 12.34)::money_type,
         ROW('USD', 20.00)::money_type,
         ROW('USD', 7.66)::money_type,
-        ROW('foo', ROW(1, false, 'hello')::inner_type)::outer_type
+        ROW('foo', ROW(1, false, 'hello')::inner_type)::outer_type,
+        ARRAY[ROW('USD', 1.00)::money_type, ROW('EUR', 2.00)::money_type]::money_type[]
     ),
     (
         2,
@@ -83,7 +85,8 @@ INSERT INTO order_ledger_entries_composite VALUES
         ROW('EUR', 88.80)::money_type,
         ROW('EUR', 99.90)::money_type,
         ROW('EUR', 11.10)::money_type,
-        ROW('bar', ROW(2, true, 'world')::inner_type)::outer_type
+        ROW('bar', ROW(2, true, 'world')::inner_type)::outer_type,
+        ARRAY[ROW('JPY', 100)::money_type]::money_type[]
     );
 
 CREATE TABLE IF NOT EXISTS postgres_all_types(
@@ -224,4 +227,3 @@ VALUES
   (2, '{}', '{}', ARRAY['{}'::json], ARRAY['{}'::jsonb]),
   (3, '{}', '{}', array[]::json[], array[]::jsonb[]),
   (4, NULL, NULL, NULL, NULL);
-

--- a/e2e_test/source_legacy/cdc/postgres_cdc.sql
+++ b/e2e_test/source_legacy/cdc/postgres_cdc.sql
@@ -68,6 +68,7 @@ CREATE TABLE order_ledger_entries_composite (
     complex_col outer_type,
     prices money_type[]
 );
+ALTER TABLE order_ledger_entries_composite ALTER COLUMN prices SET STORAGE EXTERNAL;
 
 INSERT INTO order_ledger_entries_composite VALUES
     (
@@ -86,7 +87,7 @@ INSERT INTO order_ledger_entries_composite VALUES
         ROW('EUR', 99.90)::money_type,
         ROW('EUR', 11.10)::money_type,
         ROW('bar', ROW(2, true, 'world')::inner_type)::outer_type,
-        ARRAY[ROW('JPY', 100)::money_type]::money_type[]
+        NULL
     );
 
 CREATE TABLE IF NOT EXISTS postgres_all_types(

--- a/java/connector-node/risingwave-source-cdc/src/main/java/com/risingwave/connector/cdc/debezium/converters/PgCompositeToStringConverter.java
+++ b/java/connector-node/risingwave-source-cdc/src/main/java/com/risingwave/connector/cdc/debezium/converters/PgCompositeToStringConverter.java
@@ -35,6 +35,10 @@ public class PgCompositeToStringConverter
     // through Debezium's standard handlers untouched.
     private static final int PG_FIRST_USER_OID = 16384;
 
+    // Must match `DEBEZIUM_UNAVAILABLE_VALUE` on the Rust side
+    // (src/common/src/types/mod.rs).
+    private static final String UNAVAILABLE_VALUE_PLACEHOLDER = "__debezium_unavailable_value";
+
     private boolean debug;
 
     @Override
@@ -77,7 +81,51 @@ public class PgCompositeToStringConverter
         // below PG_FIRST_USER_OID and are skipped. User-defined enum/domain
         // arrays will also match and get rendered as text — acceptable
         // since the downstream column is varchar[] anyway.
-        return column.jdbcType() == Types.ARRAY && column.nativeType() >= PG_FIRST_USER_OID;
+        //
+        // Do not intercept extension arrays that Debezium already knows how to
+        // encode with a native schema. For example, PostGIS geometry[] arrives
+        // as an array of geometry structs and RisingWave decodes each element
+        // as EWKB bytea. Re-registering it as array(string) would make the
+        // downstream bytea parser treat hex EWKB text as base64.
+        return column.jdbcType() == Types.ARRAY
+                && column.nativeType() >= PG_FIRST_USER_OID
+                && !isDebeziumNativeExtensionArray(column);
+    }
+
+    private static boolean isDebeziumNativeExtensionArray(RelationalColumn column) {
+        return isPostgresArrayOf(column, "geometry") || isPostgresArrayOf(column, "geography");
+    }
+
+    private static boolean isPostgresArrayOf(RelationalColumn column, String elementTypeName) {
+        return isPostgresArrayTypeName(column.typeName(), elementTypeName)
+                || isPostgresArrayTypeExpression(column.typeExpression(), elementTypeName);
+    }
+
+    private static boolean isPostgresArrayTypeName(String typeName, String elementTypeName) {
+        if (typeName == null) {
+            return false;
+        }
+        var normalized = unquoteAndUnqualify(typeName.toLowerCase());
+        return normalized.equals("_" + elementTypeName)
+                || normalized.equals(elementTypeName + "[]");
+    }
+
+    private static boolean isPostgresArrayTypeExpression(
+            String typeExpression, String elementTypeName) {
+        if (typeExpression == null) {
+            return false;
+        }
+        var normalized = typeExpression.toLowerCase().replace("\"", "").trim();
+        var unqualified = unquoteAndUnqualify(normalized);
+        return unqualified.equals("_" + elementTypeName)
+                || unqualified.equals(elementTypeName + "[]")
+                || (unqualified.startsWith(elementTypeName + "(") && unqualified.endsWith("[]"));
+    }
+
+    private static String unquoteAndUnqualify(String typeName) {
+        var unquoted = typeName.replace("\"", "").trim();
+        var dot = unquoted.lastIndexOf('.');
+        return dot >= 0 ? unquoted.substring(dot + 1) : unquoted;
     }
 
     private String convertScalar(Object value) {
@@ -104,6 +152,9 @@ public class PgCompositeToStringConverter
                 out.add(elementToString(el));
             }
             return out;
+        }
+        if (isDebeziumUnavailableValueObject(value)) {
+            return List.of(UNAVAILABLE_VALUE_PLACEHOLDER);
         }
         // Under include.unknown.datatypes=true, Debezium hands us the raw
         // PG textual array form `{"(a,b)","(c,d)"}` as bytes / string.
@@ -153,9 +204,19 @@ public class PgCompositeToStringConverter
         return out;
     }
 
+    private static boolean isDebeziumUnavailableValueObject(Object value) {
+        // Debezium's unchanged-TOAST sentinel for non-STRING schema columns is
+        // a bare java.lang.Object singleton. Normal composite array values
+        // arrive as concrete subclasses (byte[] / ByteBuffer / String / ...).
+        return value != null && value.getClass() == Object.class;
+    }
+
     private static String elementToString(Object el) {
         if (el == null) {
             return null;
+        }
+        if (isDebeziumUnavailableValueObject(el)) {
+            return UNAVAILABLE_VALUE_PLACEHOLDER;
         }
         if (el instanceof byte[] eb) {
             return new String(eb, StandardCharsets.UTF_8);

--- a/java/connector-node/risingwave-source-cdc/src/main/java/com/risingwave/connector/cdc/debezium/converters/PgCompositeToStringConverter.java
+++ b/java/connector-node/risingwave-source-cdc/src/main/java/com/risingwave/connector/cdc/debezium/converters/PgCompositeToStringConverter.java
@@ -21,12 +21,19 @@ import io.debezium.spi.converter.RelationalColumn;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.sql.Types;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Properties;
 import org.apache.kafka.connect.data.SchemaBuilder;
 
-/** Converts PostgreSQL composite values into plain strings. */
+/** Converts PostgreSQL composite values (and arrays of composites) into plain strings. */
 public class PgCompositeToStringConverter
         implements CustomConverter<SchemaBuilder, RelationalColumn> {
+
+    // PG FirstNormalObjectId: OIDs >= this are user-defined types.
+    // Built-in array types (e.g. _int4, _text) sit below this threshold and go
+    // through Debezium's standard handlers untouched.
+    private static final int PG_FIRST_USER_OID = 16384;
 
     private boolean debug;
 
@@ -50,22 +57,30 @@ public class PgCompositeToStringConverter
                     column.isOptional());
         }
 
-        if (!matches(column)) {
+        if (column.jdbcType() == Types.STRUCT) {
+            // Always optional: PG DELETE before-image fills non-PK columns
+            // with null under REPLICA IDENTITY DEFAULT, regardless of
+            // upstream NOT NULL.
+            registration.register(SchemaBuilder.string().optional(), this::convertScalar);
             return;
         }
-
-        // Always optional: PG DELETE before-image fills non-PK columns with null
-        // under REPLICA IDENTITY DEFAULT, regardless of upstream NOT NULL.
-        var schemaBuilder = SchemaBuilder.string().optional();
-
-        registration.register(schemaBuilder, this::convertValue);
+        if (isUserDefinedArray(column)) {
+            var elementSchema = SchemaBuilder.string().optional().build();
+            registration.register(
+                    SchemaBuilder.array(elementSchema).optional(), this::convertArray);
+        }
     }
 
-    private boolean matches(RelationalColumn column) {
-        return column.jdbcType() == Types.STRUCT;
+    private static boolean isUserDefinedArray(RelationalColumn column) {
+        // ARRAY columns whose element OID is user-defined are treated as
+        // arrays of composites. Built-in arrays (int[], text[], ...) have OIDs
+        // below PG_FIRST_USER_OID and are skipped. User-defined enum/domain
+        // arrays will also match and get rendered as text — acceptable
+        // since the downstream column is varchar[] anyway.
+        return column.jdbcType() == Types.ARRAY && column.nativeType() >= PG_FIRST_USER_OID;
     }
 
-    private String convertValue(Object value) {
+    private String convertScalar(Object value) {
         if (value == null) {
             return null;
         }
@@ -73,11 +88,88 @@ public class PgCompositeToStringConverter
             return new String(bytes, StandardCharsets.UTF_8);
         }
         if (value instanceof ByteBuffer buffer) {
-            var readOnly = buffer.asReadOnlyBuffer();
-            var bytes = new byte[readOnly.remaining()];
-            readOnly.get(bytes);
-            return new String(bytes, StandardCharsets.UTF_8);
+            return bufferToString(buffer);
         }
         return value.toString();
+    }
+
+    private List<String> convertArray(Object value) {
+        if (value == null) {
+            return null;
+        }
+        if (value instanceof List<?> list) {
+            // Pre-decoded form (rare for unknown composite arrays, but handle it).
+            var out = new ArrayList<String>(list.size());
+            for (Object el : list) {
+                out.add(elementToString(el));
+            }
+            return out;
+        }
+        // Under include.unknown.datatypes=true, Debezium hands us the raw
+        // PG textual array form `{"(a,b)","(c,d)"}` as bytes / string.
+        // Split it into individual element strings.
+        return parsePgTextArray(elementToString(value));
+    }
+
+    /**
+     * Minimal PG textual-array parser, sufficient for composite arrays. Recognizes the standard
+     * form {@code "{elem,elem,...}"} where each element is either NULL, a bare token, or a
+     * double-quoted string with {@code \\} and {@code \"} escapes.
+     */
+    private static List<String> parsePgTextArray(String s) {
+        if (s == null || s.length() < 2 || s.charAt(0) != '{' || s.charAt(s.length() - 1) != '}') {
+            return List.of();
+        }
+        var out = new ArrayList<String>();
+        int i = 1;
+        int end = s.length() - 1;
+        while (i < end) {
+            if (s.charAt(i) == '"') {
+                i++;
+                var sb = new StringBuilder();
+                while (i < end && s.charAt(i) != '"') {
+                    if (s.charAt(i) == '\\' && i + 1 < end) {
+                        sb.append(s.charAt(i + 1));
+                        i += 2;
+                    } else {
+                        sb.append(s.charAt(i));
+                        i++;
+                    }
+                }
+                i++; // consume closing "
+                out.add(sb.toString());
+            } else {
+                int start = i;
+                while (i < end && s.charAt(i) != ',') {
+                    i++;
+                }
+                var raw = s.substring(start, i);
+                out.add("NULL".equals(raw) ? null : raw);
+            }
+            if (i < end && s.charAt(i) == ',') {
+                i++;
+            }
+        }
+        return out;
+    }
+
+    private static String elementToString(Object el) {
+        if (el == null) {
+            return null;
+        }
+        if (el instanceof byte[] eb) {
+            return new String(eb, StandardCharsets.UTF_8);
+        }
+        if (el instanceof ByteBuffer ebb) {
+            return bufferToString(ebb);
+        }
+        return el.toString();
+    }
+
+    private static String bufferToString(ByteBuffer buffer) {
+        var readOnly = buffer.asReadOnlyBuffer();
+        var bytes = new byte[readOnly.remaining()];
+        readOnly.get(bytes);
+        return new String(bytes, StandardCharsets.UTF_8);
     }
 }

--- a/src/connector/src/parser/unified/debezium.rs
+++ b/src/connector/src/parser/unified/debezium.rs
@@ -119,15 +119,13 @@ async fn fetch_pgvector_dimensions_for_table(
 /// time.
 ///
 /// Right now the answer is "yes iff the array's element type is a user-defined
-/// enum". Debezium does not expose element enum metadata on the array column
-/// (the `enumValues` field is only set for scalar enum columns), so we ask the
-/// upstream catalog directly: follow the array type's `typelem` to its element
-/// type and check `typtype = 'e'`. Enum values are plain text, hence `varchar[]`.
-///
-/// TODO(composite): arrays of composite types (`typtype = 'c'`) should likewise
-/// map to `varchar[]`. That is deferred to a follow-up PR — the snapshot/streaming
-/// side for composite arrays is handled in #25818, and this predicate should be
-/// extended to `typtype IN ('e', 'c')` once that lands.
+/// enum or composite". Debezium does not expose element enum/composite metadata
+/// on the array column (the `enumValues` field is only set for scalar enum
+/// columns, and `jdbcType == STRUCT` is only set for scalar composite columns),
+/// so we ask the upstream catalog directly: follow the array type's `typelem`
+/// to its element type and check `typtype IN ('e', 'c')`. Enum values are plain
+/// text, and composite values are converted to text by our CustomConverter,
+/// hence `varchar[]`.
 async fn can_fallback_array_to_varchar(
     connector_props: &ConnectorProperties,
     array_type_name: &str,
@@ -147,7 +145,7 @@ async fn can_fallback_array_to_varchar(
 
     let row = client
         .query_opt(
-            "SELECT t_elem.typtype = 'e' \
+            "SELECT t_elem.typtype IN ('e', 'c') \
              FROM pg_type t \
              JOIN pg_type t_elem ON t.typelem = t_elem.oid \
              WHERE t.typname = $1 \

--- a/src/connector/src/parser/unified/debezium.rs
+++ b/src/connector/src/parser/unified/debezium.rs
@@ -124,7 +124,7 @@ async fn fetch_pgvector_dimensions_for_table(
 /// columns, and `jdbcType == STRUCT` is only set for scalar composite columns),
 /// so we ask the upstream catalog directly: follow the array type's `typelem`
 /// to its element type and check `typtype IN ('e', 'c')`. Enum values are plain
-/// text, and composite values are converted to text by our CustomConverter,
+/// text, and composite values are converted to text by our `CustomConverter`,
 /// hence `varchar[]`.
 async fn can_fallback_array_to_varchar(
     connector_props: &ConnectorProperties,

--- a/src/connector/src/source/cdc/external/postgres.rs
+++ b/src/connector/src/source/cdc/external/postgres.rs
@@ -242,23 +242,27 @@ impl PostgresExternalTableReader {
         // No TCP keepalive for CDC source
         let client = create_pg_client(&config.pg_connection_config()?, None).await?;
 
-        // Discover user-defined composite columns. tokio-postgres cannot decode
-        // composite values natively, so for these columns we cast to text in the
-        // snapshot SELECT to get the `(a,b,c)` textual representation. Other
-        // varchar columns stay as-is to preserve RW's own text rendering
-        // (e.g. numeric -> "NaN"/"POSITIVE_INFINITY").
+        // Discover user-defined composite columns and arrays of composites.
+        // tokio-postgres cannot decode composite values natively, so for these
+        // columns we cast to text in the snapshot SELECT. Scalar composites
+        // become `(a,b,c)`; arrays become `text[]` so tokio-postgres can
+        // decode them directly as `Vec<Option<String>>` matching the RW
+        // `List(Varchar)` column. Other varchar columns stay as-is to
+        // preserve RW's own text rendering (e.g. numeric -> "NaN").
         let composite_columns = client
             .query(
-                "SELECT a.attname \
+                "SELECT a.attname, (t.typcategory = 'A') AS is_array \
                  FROM pg_attribute a \
                  JOIN pg_class c ON a.attrelid = c.oid \
                  JOIN pg_namespace n ON c.relnamespace = n.oid \
                  JOIN pg_type t ON a.atttypid = t.oid \
+                 LEFT JOIN pg_type t_elem ON t.typelem = t_elem.oid \
                  WHERE n.nspname = $1 \
                    AND c.relname = $2 \
                    AND a.attnum > 0 \
                    AND NOT a.attisdropped \
-                   AND t.typtype = 'c'",
+                   AND (t.typtype = 'c' \
+                        OR (t.typcategory = 'A' AND t_elem.typtype = 'c'))",
                 &[
                     &schema_table_name.schema_name,
                     &schema_table_name.table_name,
@@ -267,8 +271,8 @@ impl PostgresExternalTableReader {
             .await
             .map(|rows| {
                 rows.into_iter()
-                    .map(|row| row.get::<_, String>(0))
-                    .collect::<std::collections::HashSet<_>>()
+                    .map(|row| (row.get::<_, String>(0), row.get::<_, bool>(1)))
+                    .collect::<std::collections::HashMap<_, _>>()
             })
             .unwrap_or_else(|err| {
                 tracing::warn!(
@@ -277,7 +281,7 @@ impl PostgresExternalTableReader {
                     table = %schema_table_name.table_name,
                     "failed to discover postgres composite columns; falling back to no text cast"
                 );
-                std::collections::HashSet::new()
+                std::collections::HashMap::new()
             });
 
         let field_names = rw_schema
@@ -285,10 +289,14 @@ impl PostgresExternalTableReader {
             .iter()
             .map(|f| {
                 let quoted = Self::quote_column(&f.name);
-                if matches!(f.data_type, DataType::Varchar) && composite_columns.contains(&f.name) {
-                    format!("{quoted}::text AS {quoted}")
-                } else {
-                    quoted
+                match composite_columns.get(&f.name) {
+                    Some(false) if matches!(f.data_type, DataType::Varchar) => {
+                        format!("{quoted}::text AS {quoted}")
+                    }
+                    Some(true) if matches!(f.data_type, DataType::List(_)) => {
+                        format!("ARRAY(SELECT t::text FROM unnest({quoted}) t)::text[] AS {quoted}")
+                    }
+                    _ => quoted,
                 }
             })
             .join(",");

--- a/src/connector/src/source/cdc/external/postgres.rs
+++ b/src/connector/src/source/cdc/external/postgres.rs
@@ -294,7 +294,11 @@ impl PostgresExternalTableReader {
                         format!("{quoted}::text AS {quoted}")
                     }
                     Some(true) if matches!(f.data_type, DataType::List(_)) => {
-                        format!("ARRAY(SELECT t::text FROM unnest({quoted}) t)::text[] AS {quoted}")
+                        format!(
+                            "CASE WHEN {quoted} IS NULL THEN NULL \
+                             ELSE ARRAY(SELECT t::text FROM unnest({quoted}) t)::text[] \
+                             END AS {quoted}"
+                        )
                     }
                     _ => quoted,
                 }


### PR DESCRIPTION
Follow-up to #25153. Extends the composite-to-text bridge to `<composite>[]` columns.

- **Snapshot**: catalog query detects arrays of composites via `typcategory='A' AND element typtype='c'`, and casts the column to `text[]` in the SELECT list.
- **Streaming**: `PgCompositeToStringConverter` registers an `array(string)` schema for user-defined ARRAY columns and parses Debezium's raw PG textual array into a `List<String>`.

Downstream column is `varchar[]` with elements in PG text form, e.g. `{"(USD,10)","(EUR,20)"}`.

## Test plan

- Local end-to-end script confirms backfill and streaming yield the same shape for both INSERT and UPDATE.
- e2e regression added in `e2e_test/source_legacy/cdc/cdc.share_stream.slt`.