### PR TITLE
fix(iceberg): avoid shared default AWS credentials provider in Iceberg sink

### DIFF
--- a/java/connector-node/risingwave-sink-iceberg/src/main/java/com/risingwave/connector/catalog/GlueCredentialProvider.java
+++ b/java/connector-node/risingwave-sink-iceberg/src/main/java/com/risingwave/connector/catalog/GlueCredentialProvider.java
@@ -85,7 +85,9 @@ public class GlueCredentialProvider implements AwsCredentialsProvider, SdkAutoCl
         }
 
         if (useDefaultChain) {
-            return DefaultCredentialsProvider.create();
+            // `create()` returns a JVM-wide singleton. Glue catalogs are closed independently, so
+            // use an owned provider to avoid one catalog closing credentials still used by another.
+            return DefaultCredentialsProvider.builder().build();
         }
 
         Validate.notNull(accessKey, "Glue access key must not be null.", new Object[0]);

--- a/java/connector-node/risingwave-sink-iceberg/src/main/java/com/risingwave/connector/catalog/S3FileIOAssumeRoleAwsClientFactory.java
+++ b/java/connector-node/risingwave-sink-iceberg/src/main/java/com/risingwave/connector/catalog/S3FileIOAssumeRoleAwsClientFactory.java
@@ -129,7 +129,9 @@ public class S3FileIOAssumeRoleAwsClientFactory implements S3FileIOAwsClientFact
     private static AwsCredentialsProvider createBaseCredentialsProvider(
             String accessKeyId, String secretAccessKey, String sessionToken) {
         if (StringUtils.isBlank(accessKeyId) || StringUtils.isBlank(secretAccessKey)) {
-            return DefaultCredentialsProvider.create();
+            // `create()` returns a JVM-wide singleton. FileIO factories are scoped to catalogs, so
+            // use an owned provider that can follow the factory/client lifecycle independently.
+            return DefaultCredentialsProvider.builder().build();
         }
 
         AwsCredentials credentials =

--- a/java/connector-node/risingwave-sink-iceberg/src/test/java/com/risingwave/connector/catalog/GlueCredentialProviderTest.java
+++ b/java/connector-node/risingwave-sink-iceberg/src/test/java/com/risingwave/connector/catalog/GlueCredentialProviderTest.java
@@ -22,6 +22,7 @@ import java.util.HashMap;
 import java.util.Map;
 import org.junit.Test;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
 import software.amazon.awssdk.services.sts.auth.StsAssumeRoleCredentialsProvider;
 
 public class GlueCredentialProviderTest {
@@ -48,6 +49,19 @@ public class GlueCredentialProviderTest {
         try (GlueCredentialProvider provider = GlueCredentialProvider.create(config)) {
             assertThat(provider.credentialsProviderForTest())
                     .isInstanceOf(StsAssumeRoleCredentialsProvider.class);
+        }
+    }
+
+    @Test
+    public void testDefaultCredentialChainDoesNotUseSharedSingleton() {
+        Map<String, String> config = new HashMap<>();
+        config.put("glue.use-default-credential-chain", "true");
+
+        try (GlueCredentialProvider first = GlueCredentialProvider.create(config);
+                GlueCredentialProvider second = GlueCredentialProvider.create(config)) {
+            assertThat(first.credentialsProviderForTest())
+                    .isInstanceOf(DefaultCredentialsProvider.class)
+                    .isNotSameAs(second.credentialsProviderForTest());
         }
     }
 }

--- a/java/connector-node/risingwave-sink-iceberg/src/test/java/com/risingwave/connector/catalog/S3FileIOAssumeRoleAwsClientFactoryTest.java
+++ b/java/connector-node/risingwave-sink-iceberg/src/test/java/com/risingwave/connector/catalog/S3FileIOAssumeRoleAwsClientFactoryTest.java
@@ -21,6 +21,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.util.HashMap;
 import java.util.Map;
 import org.junit.Test;
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
 import software.amazon.awssdk.services.sts.auth.StsAssumeRoleCredentialsProvider;
 
 public class S3FileIOAssumeRoleAwsClientFactoryTest {
@@ -37,5 +38,19 @@ public class S3FileIOAssumeRoleAwsClientFactoryTest {
 
         assertThat(factory.credentialsProviderForTest())
                 .isInstanceOf(StsAssumeRoleCredentialsProvider.class);
+    }
+
+    @Test
+    public void testDefaultCredentialChainDoesNotUseSharedSingleton() {
+        Map<String, String> config = new HashMap<>();
+
+        S3FileIOAssumeRoleAwsClientFactory first = new S3FileIOAssumeRoleAwsClientFactory();
+        first.initialize(config);
+        S3FileIOAssumeRoleAwsClientFactory second = new S3FileIOAssumeRoleAwsClientFactory();
+        second.initialize(config);
+
+        assertThat(first.credentialsProviderForTest())
+                .isInstanceOf(DefaultCredentialsProvider.class)
+                .isNotSameAs(second.credentialsProviderForTest());
     }
 }


### PR DESCRIPTION
## Summary

Fix Iceberg Glue/S3 credential provider lifecycle by avoiding `DefaultCredentialsProvider.create()`, which returns a JVM-wide singleton. Glue catalogs and S3 FileIO factories are scoped independently, so closing one catalog can otherwise close shared AWS credential-chain resources still used by another sink.

This uses `DefaultCredentialsProvider.builder().build()` for owned provider instances in:

- `GlueCredentialProvider`
- `S3FileIOAssumeRoleAwsClientFactory`

It also adds regression coverage that default credential-chain paths do not reuse the same provider instance across independently created providers/factories.

## Motivation

We saw Glue Iceberg sinks fail while checking namespace existence with:

```text
Failed to check namespace exists., source: Caught Java Exception: Connection pool shut down
```

The failing stack was in AWS credentials resolution for Glue catalog `namespaceExists`, after STS/Apache HTTP resources had already been closed by another catalog lifecycle.

## Testing

- `git diff --check`
- Not run: Maven test locally because this machine does not currently have Maven or a Java 21 runtime installed.
