### PR TITLE
fix: avoid shared default AWS credentials provider in Iceberg sink

### DIFF
--- a/java/connector-node/risingwave-sink-iceberg/src/main/java/com/risingwave/connector/catalog/GlueCredentialProvider.java
+++ b/java/connector-node/risingwave-sink-iceberg/src/main/java/com/risingwave/connector/catalog/GlueCredentialProvider.java
@@ -85,7 +85,9 @@ public class GlueCredentialProvider implements AwsCredentialsProvider, SdkAutoCl
         }
 
         if (useDefaultChain) {
-            return DefaultCredentialsProvider.create();
+            // `create()` returns a JVM-wide singleton. Glue catalogs are closed independently, so
+            // use an owned provider to avoid one catalog closing credentials still used by another.
+            return DefaultCredentialsProvider.builder().build();
         }
 
         Validate.notNull(accessKey, "Glue access key must not be null.", new Object[0]);

--- a/java/connector-node/risingwave-sink-iceberg/src/main/java/com/risingwave/connector/catalog/S3FileIOAssumeRoleAwsClientFactory.java
+++ b/java/connector-node/risingwave-sink-iceberg/src/main/java/com/risingwave/connector/catalog/S3FileIOAssumeRoleAwsClientFactory.java
@@ -129,7 +129,9 @@ public class S3FileIOAssumeRoleAwsClientFactory implements S3FileIOAwsClientFact
     private static AwsCredentialsProvider createBaseCredentialsProvider(
             String accessKeyId, String secretAccessKey, String sessionToken) {
         if (StringUtils.isBlank(accessKeyId) || StringUtils.isBlank(secretAccessKey)) {
-            return DefaultCredentialsProvider.create();
+            // `create()` returns a JVM-wide singleton. FileIO factories are scoped to catalogs, so
+            // use an owned provider that can follow the factory/client lifecycle independently.
+            return DefaultCredentialsProvider.builder().build();
         }
 
         AwsCredentials credentials =

--- a/java/connector-node/risingwave-sink-iceberg/src/test/java/com/risingwave/connector/catalog/GlueCredentialProviderTest.java
+++ b/java/connector-node/risingwave-sink-iceberg/src/test/java/com/risingwave/connector/catalog/GlueCredentialProviderTest.java
@@ -22,6 +22,7 @@ import java.util.HashMap;
 import java.util.Map;
 import org.junit.Test;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
 import software.amazon.awssdk.services.sts.auth.StsAssumeRoleCredentialsProvider;
 
 public class GlueCredentialProviderTest {
@@ -48,6 +49,19 @@ public class GlueCredentialProviderTest {
         try (GlueCredentialProvider provider = GlueCredentialProvider.create(config)) {
             assertThat(provider.credentialsProviderForTest())
                     .isInstanceOf(StsAssumeRoleCredentialsProvider.class);
+        }
+    }
+
+    @Test
+    public void testDefaultCredentialChainDoesNotUseSharedSingleton() {
+        Map<String, String> config = new HashMap<>();
+        config.put("glue.use-default-credential-chain", "true");
+
+        try (GlueCredentialProvider first = GlueCredentialProvider.create(config);
+                GlueCredentialProvider second = GlueCredentialProvider.create(config)) {
+            assertThat(first.credentialsProviderForTest())
+                    .isInstanceOf(DefaultCredentialsProvider.class)
+                    .isNotSameAs(second.credentialsProviderForTest());
         }
     }
 }

--- a/java/connector-node/risingwave-sink-iceberg/src/test/java/com/risingwave/connector/catalog/S3FileIOAssumeRoleAwsClientFactoryTest.java
+++ b/java/connector-node/risingwave-sink-iceberg/src/test/java/com/risingwave/connector/catalog/S3FileIOAssumeRoleAwsClientFactoryTest.java
@@ -21,6 +21,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.util.HashMap;
 import java.util.Map;
 import org.junit.Test;
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
 import software.amazon.awssdk.services.sts.auth.StsAssumeRoleCredentialsProvider;
 
 public class S3FileIOAssumeRoleAwsClientFactoryTest {
@@ -37,5 +38,19 @@ public class S3FileIOAssumeRoleAwsClientFactoryTest {
 
         assertThat(factory.credentialsProviderForTest())
                 .isInstanceOf(StsAssumeRoleCredentialsProvider.class);
+    }
+
+    @Test
+    public void testDefaultCredentialChainDoesNotUseSharedSingleton() {
+        Map<String, String> config = new HashMap<>();
+
+        S3FileIOAssumeRoleAwsClientFactory first = new S3FileIOAssumeRoleAwsClientFactory();
+        first.initialize(config);
+        S3FileIOAssumeRoleAwsClientFactory second = new S3FileIOAssumeRoleAwsClientFactory();
+        second.initialize(config);
+
+        assertThat(first.credentialsProviderForTest())
+                .isInstanceOf(DefaultCredentialsProvider.class)
+                .isNotSameAs(second.credentialsProviderForTest());
     }
 }


### PR DESCRIPTION
## Summary

Backport the Iceberg AWS credential provider lifecycle fix to `release-2.8`.

This avoids `DefaultCredentialsProvider.create()`, which returns a JVM-wide singleton, in the Iceberg Glue catalog and S3 FileIO assume-role paths. Each independently scoped Glue catalog / S3 FileIO factory now builds an owned default credential provider instead, so closing one catalog cannot close shared AWS credential-chain resources still used by another sink.

This is the release-2.8 patch for the Glue Iceberg sink failure observed around image/commit:

```text
v2.8.4--fix-iceberg-glue-token--d5ef992--copilot-release-2-8-fix-iceberg-glue-token-expiration
```

Related main-branch PR: #25829

## Testing

- `git show --check HEAD`
- Not run: Maven tests locally because this machine does not currently have Maven or a Java 17+ runtime installed.
