### PR TITLE
fix(connector): validate SQL Server sink targets and permissions

### DIFF
--- a/ci/scripts/e2e-sqlserver-sink-test.sh
+++ b/ci/scripts/e2e-sqlserver-sink-test.sh
@@ -76,9 +76,19 @@ else
   exit 1
 fi
 
-if [[ "${ENABLE_NATIVE_SQLSERVER_SINK_TEST:-}" == "1" ]]; then
-  echo "--- create native SQL Server sink table"
-  sqlcmd -S sqlserver-server -U SA -P SomeTestOnly@SA -Q "
+echo "--- create native SQL Server sink table"
+sqlcmd -S sqlserver-server -U SA -P SomeTestOnly@SA -Q "
+USE SinkTest;
+GO
+DROP USER IF EXISTS rw_sqlserver_readonly_user;
+GO
+USE master;
+GO
+IF EXISTS (SELECT 1 FROM sys.server_principals WHERE name = N'rw_sqlserver_readonly_login')
+  DROP LOGIN rw_sqlserver_readonly_login;
+GO
+CREATE LOGIN rw_sqlserver_readonly_login WITH PASSWORD = 'ReadOnlyOnly123!';
+GO
 USE SinkTest;
 GO
 DROP TABLE IF EXISTS test_schema.t_native_sink_pk_and_timestamptz;
@@ -97,13 +107,17 @@ CREATE TABLE test_schema.t_native_sink_pk_and_timestamptz (
 GO
 CREATE INDEX IX_t_native_sink_pk_and_timestamptz_EventDate
 ON test_schema.t_native_sink_pk_and_timestamptz (EventDate);
+GO
+CREATE USER rw_sqlserver_readonly_user FOR LOGIN rw_sqlserver_readonly_login;
+GO
+GRANT SELECT ON OBJECT::test_schema.t_native_sink_pk_and_timestamptz TO rw_sqlserver_readonly_user;
 GO"
 
-  echo "--- testing native SQL Server sink"
-  sqllogictest -p 4566 -d dev './e2e_test/sink/sqlserver_native_sink.slt'
+echo "--- testing native SQL Server sink"
+sqllogictest -p 4566 -d dev './e2e_test/sink/sqlserver_native_sink.slt'
 
-  native_check=$(
-    sqlcmd -S sqlserver-server -U SA -P SomeTestOnly@SA -h -1 -W -Q "
+native_check=$(
+  sqlcmd -S sqlserver-server -U SA -P SomeTestOnly@SA -h -1 -W -Q "
 SET NOCOUNT ON;
 SELECT CASE WHEN EXISTS (
   SELECT 1
@@ -118,14 +132,13 @@ SELECT CASE WHEN EXISTS (
     AND event_ts_tinyint = 123
 ) THEN 'ok' ELSE 'missing' END;
 GO" | tr -d '\r' | awk 'NF {print $1; exit}'
-  )
+)
 
-  if [[ "$native_check" == "ok" ]]; then
-    echo "Native SQL Server sink check passed"
-  else
-    echo "Native SQL Server sink check failed: $native_check"
-    exit 1
-  fi
+if [[ "$native_check" == "ok" ]]; then
+  echo "Native SQL Server sink check passed"
+else
+  echo "Native SQL Server sink check failed: $native_check"
+  exit 1
 fi
 
 echo "--- Kill cluster"

--- a/ci/scripts/e2e-sqlserver-sink-test.sh
+++ b/ci/scripts/e2e-sqlserver-sink-test.sh
@@ -76,5 +76,57 @@ else
   exit 1
 fi
 
+if [[ "${ENABLE_NATIVE_SQLSERVER_SINK_TEST:-}" == "1" ]]; then
+  echo "--- create native SQL Server sink table"
+  sqlcmd -S sqlserver-server -U SA -P SomeTestOnly@SA -Q "
+USE SinkTest;
+GO
+DROP TABLE IF EXISTS test_schema.t_native_sink_pk_and_timestamptz;
+GO
+CREATE TABLE test_schema.t_native_sink_pk_and_timestamptz (
+  EntityId nvarchar(100) NOT NULL,
+  EventDate date NOT NULL,
+  metric_value numeric(20,5) NULL,
+  event_ts_offset datetimeoffset(7) NULL,
+  event_ts_micros bigint NULL,
+  event_ts_int int NULL,
+  event_ts_smallint smallint NULL,
+  event_ts_tinyint tinyint NULL,
+  CONSTRAINT PK_t_native_sink_pk_and_timestamptz PRIMARY KEY CLUSTERED (EntityId, EventDate)
+);
+GO
+CREATE INDEX IX_t_native_sink_pk_and_timestamptz_EventDate
+ON test_schema.t_native_sink_pk_and_timestamptz (EventDate);
+GO"
+
+  echo "--- testing native SQL Server sink"
+  sqllogictest -p 4566 -d dev './e2e_test/sink/sqlserver_native_sink.slt'
+
+  native_check=$(
+    sqlcmd -S sqlserver-server -U SA -P SomeTestOnly@SA -h -1 -W -Q "
+SET NOCOUNT ON;
+SELECT CASE WHEN EXISTS (
+  SELECT 1
+  FROM SinkTest.test_schema.t_native_sink_pk_and_timestamptz
+  WHERE EntityId = N'entity-1'
+    AND EventDate = CONVERT(date, '2024-03-10')
+    AND metric_value = CONVERT(numeric(20,5), 123.45)
+    AND SWITCHOFFSET(event_ts_offset, '+00:00') = CONVERT(datetimeoffset(7), '2024-03-09T16:00:00+00:00')
+    AND event_ts_micros = 1710000000000000
+    AND event_ts_int = 123
+    AND event_ts_smallint = 123
+    AND event_ts_tinyint = 123
+) THEN 'ok' ELSE 'missing' END;
+GO" | tr -d '\r' | awk 'NF {print $1; exit}'
+  )
+
+  if [[ "$native_check" == "ok" ]]; then
+    echo "Native SQL Server sink check passed"
+  else
+    echo "Native SQL Server sink check failed: $native_check"
+    exit 1
+  fi
+fi
+
 echo "--- Kill cluster"
 risedev ci-kill

--- a/e2e_test/sink/sqlserver_native_sink.slt
+++ b/e2e_test/sink/sqlserver_native_sink.slt
@@ -13,6 +13,20 @@ create table t_native_sqlserver_sink_rw (
   event_ts_tinyint timestamptz
 );
 
+statement error lacks required write permission
+create sink s_native_sqlserver_sink_readonly from t_native_sqlserver_sink_rw with (
+  connector = 'sqlserver',
+  type = 'upsert',
+  sqlserver.host = 'sqlserver-server',
+  sqlserver.port = '1433',
+  sqlserver.user = 'rw_sqlserver_readonly_login',
+  sqlserver.password = 'ReadOnlyOnly123!',
+  sqlserver.database = 'SinkTest',
+  sqlserver.schema = 'test_schema',
+  sqlserver.table = 't_native_sink_pk_and_timestamptz',
+  primary_key = 'EntityId,EventDate'
+);
+
 statement ok
 create sink s_native_sqlserver_sink from t_native_sqlserver_sink_rw with (
   connector = 'sqlserver',

--- a/e2e_test/sink/sqlserver_native_sink.slt
+++ b/e2e_test/sink/sqlserver_native_sink.slt
@@ -1,0 +1,51 @@
+statement ok
+set sink_decouple = false;
+
+statement ok
+create table t_native_sqlserver_sink_rw (
+  "EntityId" varchar,
+  "EventDate" date,
+  metric_value numeric,
+  event_ts_offset timestamptz,
+  event_ts_micros timestamptz,
+  event_ts_int timestamptz,
+  event_ts_smallint timestamptz,
+  event_ts_tinyint timestamptz
+);
+
+statement ok
+create sink s_native_sqlserver_sink from t_native_sqlserver_sink_rw with (
+  connector = 'sqlserver',
+  type = 'upsert',
+  sqlserver.host = 'sqlserver-server',
+  sqlserver.port = '1433',
+  sqlserver.user = 'SA',
+  sqlserver.password = 'SomeTestOnly@SA',
+  sqlserver.database = 'SinkTest',
+  sqlserver.schema = 'test_schema',
+  sqlserver.table = 't_native_sink_pk_and_timestamptz',
+  primary_key = 'EntityId,EventDate'
+);
+
+statement ok
+insert into t_native_sqlserver_sink_rw values
+(
+  'entity-1',
+  date '2024-03-10',
+  123.45,
+  '2024-03-09 16:00:00Z'::timestamptz,
+  '2024-03-09 16:00:00Z'::timestamptz,
+  '1970-01-01 00:00:00.000123Z'::timestamptz,
+  '1970-01-01 00:00:00.000123Z'::timestamptz,
+  '1970-01-01 00:00:00.000123Z'::timestamptz
+);
+flush;
+
+statement ok
+FLUSH;
+
+statement ok
+DROP SINK s_native_sqlserver_sink;
+
+statement ok
+DROP TABLE t_native_sqlserver_sink_rw;

--- a/src/connector/src/sink/sqlserver.rs
+++ b/src/connector/src/sink/sqlserver.rs
@@ -108,6 +108,11 @@ pub struct SqlServerSink {
     is_append_only: bool,
 }
 
+struct SqlServerColumnMetadata {
+    is_pk: bool,
+    data_type: String,
+}
+
 impl EnforceSecret for SqlServerSink {
     fn enforce_secret<'a>(
         prop_iter: impl Iterator<Item = &'a str>,
@@ -180,54 +185,14 @@ impl Sink for SqlServerSink {
             check_data_type_compatibility(&f.data_type)?;
         }
 
-        // Query table metadata from SQL Server.
-        let mut sql_server_table_metadata = HashMap::new();
         let mut sql_client = SqlServerClient::new(&self.config).await?;
-        let query_table_metadata_error = || {
-            SinkError::SqlServer(anyhow!(format!(
-                "SQL Server table {} metadata error",
-                self.config.full_object_path()
-            )))
-        };
-        static QUERY_TABLE_METADATA: &str = r#"
-SELECT
-    col.name AS ColumnName,
-    pk.index_id AS PkIndex
-FROM
-    sys.columns col
-LEFT JOIN
-    sys.index_columns ic ON ic.object_id = col.object_id AND ic.column_id = col.column_id
-LEFT JOIN
-    sys.indexes pk ON pk.object_id = col.object_id AND pk.index_id = ic.index_id AND pk.is_primary_key = 1
-WHERE
-    col.object_id = OBJECT_ID(@P1)
-ORDER BY
-    col.column_id;"#;
-        let rows = sql_client
-            .inner_client
-            .query(QUERY_TABLE_METADATA, &[&self.config.full_object_path()])
-            .await?
-            .into_results()
-            .await?;
-        for row in rows.into_iter().flatten() {
-            let mut iter = row.into_iter();
-            let ColumnData::String(Some(col_name)) =
-                iter.next().ok_or_else(query_table_metadata_error)?
-            else {
-                return Err(query_table_metadata_error());
-            };
-            let ColumnData::I32(col_pk_index) =
-                iter.next().ok_or_else(query_table_metadata_error)?
-            else {
-                return Err(query_table_metadata_error());
-            };
-            sql_server_table_metadata.insert(col_name.into_owned(), col_pk_index.is_some());
-        }
+        let sql_server_table_metadata =
+            query_sql_server_table_metadata(&mut sql_client, &self.config).await?;
 
-        // Validate Column name and Primary Key
+        // Validate Column name, Primary Key and data type.
         for (idx, col) in self.schema.fields().iter().enumerate() {
             let rw_is_pk = self.pk_indices.contains(&idx);
-            match sql_server_table_metadata.get(&col.name) {
+            match sql_server_table_metadata.get(&normalize_sql_server_column_name(&col.name)) {
                 None => {
                     return Err(SinkError::SqlServer(anyhow!(format!(
                         "column {} not found in the downstream SQL Server table {}",
@@ -235,18 +200,23 @@ ORDER BY
                         self.config.full_object_path()
                     ))));
                 }
-                Some(sql_server_is_pk) => {
+                Some(sql_server_col) => {
+                    validate_data_type_compatibility(
+                        &col.name,
+                        &col.data_type,
+                        &sql_server_col.data_type,
+                    )?;
                     if self.is_append_only {
                         continue;
                     }
-                    if rw_is_pk && !*sql_server_is_pk {
+                    if rw_is_pk && !sql_server_col.is_pk {
                         return Err(SinkError::SqlServer(anyhow!(format!(
                             "column {} specified in primary_key mismatches with the downstream SQL Server table {} PK",
                             col.name,
                             self.config.full_object_path(),
                         ))));
                     }
-                    if !rw_is_pk && *sql_server_is_pk {
+                    if !rw_is_pk && sql_server_col.is_pk {
                         return Err(SinkError::SqlServer(anyhow!(format!(
                             "column {} unspecified in primary_key mismatches with the downstream SQL Server table {} PK",
                             col.name,
@@ -260,7 +230,7 @@ ORDER BY
         if !self.is_append_only {
             let sql_server_pk_count = sql_server_table_metadata
                 .values()
-                .filter(|is_pk| **is_pk)
+                .filter(|metadata| metadata.is_pk)
                 .count();
             if sql_server_pk_count != self.pk_indices.len() {
                 return Err(SinkError::SqlServer(anyhow!(format!(
@@ -298,6 +268,7 @@ pub struct SqlServerSinkWriter {
     schema: Schema,
     pk_indices: Vec<usize>,
     is_append_only: bool,
+    downstream_column_data_types: Vec<String>,
     sql_client: SqlServerClient,
     ops: Vec<SqlOp>,
 }
@@ -309,12 +280,15 @@ impl SqlServerSinkWriter {
         pk_indices: Vec<usize>,
         is_append_only: bool,
     ) -> Result<Self> {
-        let sql_client = SqlServerClient::new(&config).await?;
+        let mut sql_client = SqlServerClient::new(&config).await?;
+        let downstream_column_data_types =
+            query_downstream_column_data_types(&mut sql_client, &config, &schema).await?;
         let writer = Self {
             config,
             schema,
             pk_indices,
             is_append_only,
+            downstream_column_data_types,
             sql_client,
             ops: vec![],
         };
@@ -382,12 +356,17 @@ impl SqlServerSinkWriter {
             .collect::<Vec<_>>()
             .join(" AND ");
         let param_placeholders = |param_id: &mut usize| {
-            let params = (*param_id..(*param_id + col_num))
-                .map(|i| format!("@P{}", i))
+            (0..col_num)
+                .map(|idx| {
+                    param_placeholder(
+                        param_id,
+                        idx,
+                        &self.schema,
+                        &self.downstream_column_data_types,
+                    )
+                })
                 .collect::<Vec<_>>()
-                .join(",");
-            *param_id += col_num;
-            params
+                .join(",")
         };
         let set_all_source_col = non_pk_col_indices
             .iter()
@@ -438,9 +417,16 @@ impl SqlServerSinkWriter {
                         self.pk_indices
                             .iter()
                             .map(|idx| {
-                                let condition =
-                                    format!("[{}]=@P{}", self.schema[*idx].name, next_param_id);
-                                next_param_id += 1;
+                                let condition = format!(
+                                    "[{}]={}",
+                                    self.schema[*idx].name,
+                                    param_placeholder(
+                                        &mut next_param_id,
+                                        *idx,
+                                        &self.schema,
+                                        &self.downstream_column_data_types,
+                                    )
+                                );
                                 condition
                             })
                             .collect::<Vec<_>>()
@@ -455,16 +441,29 @@ impl SqlServerSinkWriter {
         for op in self.ops.drain(..) {
             match op {
                 SqlOp::Insert(row) => {
-                    bind_params(&mut query, row, &self.schema, 0..col_num)?;
+                    bind_params(
+                        &mut query,
+                        row,
+                        &self.schema,
+                        &self.downstream_column_data_types,
+                        0..col_num,
+                    )?;
                 }
                 SqlOp::Merge(row) => {
-                    bind_params(&mut query, row, &self.schema, 0..col_num)?;
+                    bind_params(
+                        &mut query,
+                        row,
+                        &self.schema,
+                        &self.downstream_column_data_types,
+                        0..col_num,
+                    )?;
                 }
                 SqlOp::Delete(row) => {
                     bind_params(
                         &mut query,
                         row,
                         &self.schema,
+                        &self.downstream_column_data_types,
                         self.pk_indices.iter().copied(),
                     )?;
                 }
@@ -566,10 +565,119 @@ impl SqlServerClient {
     }
 }
 
+async fn query_sql_server_table_metadata(
+    sql_client: &mut SqlServerClient,
+    config: &SqlServerConfig,
+) -> Result<HashMap<String, SqlServerColumnMetadata>> {
+    let mut sql_server_table_metadata = HashMap::new();
+    let query_table_metadata_error = || {
+        SinkError::SqlServer(anyhow!(format!(
+            "SQL Server table {} metadata error",
+            config.full_object_path()
+        )))
+    };
+    static QUERY_TABLE_METADATA: &str = r#"
+SELECT
+    col.name AS ColumnName,
+    CAST(CASE WHEN pk_col.column_id IS NULL THEN 0 ELSE 1 END AS int) AS IsPk,
+    typ.name AS DataType
+FROM
+    sys.columns col
+JOIN
+    sys.types typ ON typ.user_type_id = col.user_type_id
+LEFT JOIN
+    (
+        SELECT ic.object_id, ic.column_id
+        FROM sys.indexes pk
+        JOIN sys.index_columns ic ON ic.object_id = pk.object_id AND ic.index_id = pk.index_id
+        WHERE pk.is_primary_key = 1
+    ) pk_col ON pk_col.object_id = col.object_id AND pk_col.column_id = col.column_id
+WHERE
+    col.object_id = OBJECT_ID(@P1)
+ORDER BY
+    col.column_id;"#;
+    let rows = sql_client
+        .inner_client
+        .query(QUERY_TABLE_METADATA, &[&config.full_object_path()])
+        .await?
+        .into_results()
+        .await?;
+    for row in rows.into_iter().flatten() {
+        let mut iter = row.into_iter();
+        let ColumnData::String(Some(col_name)) =
+            iter.next().ok_or_else(query_table_metadata_error)?
+        else {
+            return Err(query_table_metadata_error());
+        };
+        let ColumnData::I32(Some(col_is_pk)) =
+            iter.next().ok_or_else(query_table_metadata_error)?
+        else {
+            return Err(query_table_metadata_error());
+        };
+        let ColumnData::String(Some(data_type)) =
+            iter.next().ok_or_else(query_table_metadata_error)?
+        else {
+            return Err(query_table_metadata_error());
+        };
+        sql_server_table_metadata.insert(
+            normalize_sql_server_column_name(&col_name),
+            SqlServerColumnMetadata {
+                is_pk: col_is_pk != 0,
+                data_type: normalize_sql_server_data_type(&data_type),
+            },
+        );
+    }
+    Ok(sql_server_table_metadata)
+}
+
+async fn query_downstream_column_data_types(
+    sql_client: &mut SqlServerClient,
+    config: &SqlServerConfig,
+    schema: &Schema,
+) -> Result<Vec<String>> {
+    let sql_server_table_metadata = query_sql_server_table_metadata(sql_client, config).await?;
+    schema
+        .fields()
+        .iter()
+        .map(|col| {
+            sql_server_table_metadata
+                .get(&normalize_sql_server_column_name(&col.name))
+                .map(|metadata| metadata.data_type.clone())
+                .ok_or_else(|| {
+                    SinkError::SqlServer(anyhow!(format!(
+                        "column {} not found in the downstream SQL Server table {}",
+                        col.name,
+                        config.full_object_path()
+                    )))
+                })
+        })
+        .collect()
+}
+
+fn param_placeholder(
+    param_id: &mut usize,
+    col_idx: usize,
+    schema: &Schema,
+    downstream_column_data_types: &[String],
+) -> String {
+    let placeholder = format!("@P{}", *param_id);
+    *param_id += 1;
+
+    if schema[col_idx].data_type != DataType::Timestamptz {
+        return placeholder;
+    }
+
+    match timestamptz_cast_type(&downstream_column_data_types[col_idx]) {
+        Some(cast_type) => format!("CAST({placeholder} AS {cast_type})"),
+        None => placeholder,
+    }
+}
+
 fn bind_params(
     query: &mut Query<'_>,
     row: impl Row,
     schema: &Schema,
+    downstream_column_data_types: &[String],
     col_indices: impl Iterator<Item = usize>,
 ) -> Result<()> {
     use risingwave_common::types::ScalarRefImpl;
@@ -596,7 +704,16 @@ fn bind_params(
                 },
                 ScalarRefImpl::Date(v) => query.bind(v.0),
                 ScalarRefImpl::Timestamp(v) => query.bind(v.0),
-                ScalarRefImpl::Timestamptz(v) => query.bind(v.timestamp_micros()),
+                ScalarRefImpl::Timestamptz(v) => {
+                    let downstream_data_type = &downstream_column_data_types[col_idx];
+                    if use_integer_micros_for_timestamptz(downstream_data_type) {
+                        query.bind(v.timestamp_micros());
+                    } else if use_datetimeoffset_for_timestamptz(downstream_data_type) {
+                        query.bind(v.to_datetime_utc().fixed_offset());
+                    } else {
+                        query.bind(v.to_datetime_utc().naive_utc());
+                    }
+                }
                 ScalarRefImpl::Time(v) => query.bind(v.0),
                 ScalarRefImpl::Bytea(v) => query.bind(v.to_vec()),
                 ScalarRefImpl::Interval(_) => return Err(data_type_not_supported("Interval")),
@@ -640,7 +757,14 @@ fn bind_params(
                     query.bind(None as Option<chrono::NaiveDateTime>);
                 }
                 DataType::Timestamptz => {
-                    query.bind(None as Option<i64>);
+                    let downstream_data_type = &downstream_column_data_types[col_idx];
+                    if use_integer_micros_for_timestamptz(downstream_data_type) {
+                        query.bind(None as Option<i64>);
+                    } else if use_datetimeoffset_for_timestamptz(downstream_data_type) {
+                        query.bind(None as Option<chrono::DateTime<chrono::FixedOffset>>);
+                    } else {
+                        query.bind(None as Option<chrono::NaiveDateTime>);
+                    }
                 }
                 DataType::Varchar => {
                     query.bind(None as Option<String>);
@@ -694,6 +818,100 @@ fn check_data_type_compatibility(data_type: &DataType) -> Result<()> {
     }
 }
 
+fn normalize_sql_server_column_name(column_name: &str) -> String {
+    column_name.to_lowercase()
+}
+
+fn normalize_sql_server_data_type(data_type: &str) -> String {
+    data_type.trim().to_ascii_lowercase()
+}
+
+fn timestamptz_cast_type(sql_server_data_type: &str) -> Option<&'static str> {
+    match normalize_sql_server_data_type(sql_server_data_type).as_str() {
+        "datetimeoffset" => Some("datetimeoffset"),
+        "datetime" => Some("datetime"),
+        "datetime2" => Some("datetime2"),
+        "smalldatetime" => Some("smalldatetime"),
+        "bigint" => Some("bigint"),
+        "int" => Some("int"),
+        "smallint" => Some("smallint"),
+        "tinyint" => Some("tinyint"),
+        _ => None,
+    }
+}
+
+fn use_datetimeoffset_for_timestamptz(sql_server_data_type: &str) -> bool {
+    normalize_sql_server_data_type(sql_server_data_type) == "datetimeoffset"
+}
+
+fn use_integer_micros_for_timestamptz(sql_server_data_type: &str) -> bool {
+    matches!(
+        normalize_sql_server_data_type(sql_server_data_type).as_str(),
+        "bigint" | "int" | "smallint" | "tinyint"
+    )
+}
+
+fn validate_data_type_compatibility(
+    column_name: &str,
+    rw_data_type: &DataType,
+    sql_server_data_type: &str,
+) -> Result<()> {
+    if sql_server_data_type_is_compatible(rw_data_type, sql_server_data_type) {
+        return Ok(());
+    }
+
+    Err(SinkError::SqlServer(anyhow!(format!(
+        "column {} data type {:?} is incompatible with downstream SQL Server type {}",
+        column_name, rw_data_type, sql_server_data_type
+    ))))
+}
+
+fn sql_server_data_type_is_compatible(rw_data_type: &DataType, sql_server_data_type: &str) -> bool {
+    let sql_server_data_type = normalize_sql_server_data_type(sql_server_data_type);
+    let sql_server_data_type = sql_server_data_type.as_str();
+    match rw_data_type {
+        DataType::Boolean => sql_server_data_type == "bit",
+        DataType::Int16 => matches!(sql_server_data_type, "smallint" | "int" | "bigint"),
+        DataType::Int32 => matches!(sql_server_data_type, "int" | "bigint"),
+        DataType::Int64 => sql_server_data_type == "bigint",
+        DataType::Float32 => matches!(sql_server_data_type, "real" | "float"),
+        DataType::Float64 => sql_server_data_type == "float",
+        DataType::Decimal => matches!(sql_server_data_type, "decimal" | "numeric"),
+        DataType::Date => sql_server_data_type == "date",
+        DataType::Varchar => matches!(
+            sql_server_data_type,
+            "char" | "nchar" | "varchar" | "nvarchar" | "text" | "ntext"
+        ),
+        DataType::Time => sql_server_data_type == "time",
+        DataType::Timestamp => {
+            matches!(
+                sql_server_data_type,
+                "datetime" | "datetime2" | "smalldatetime"
+            )
+        }
+        DataType::Timestamptz => matches!(
+            sql_server_data_type,
+            "datetimeoffset"
+                | "datetime"
+                | "datetime2"
+                | "smalldatetime"
+                | "bigint"
+                | "int"
+                | "smallint"
+                | "tinyint"
+        ),
+        DataType::Bytea => matches!(sql_server_data_type, "binary" | "varbinary" | "image"),
+        DataType::Interval
+        | DataType::Struct(_)
+        | DataType::List(_)
+        | DataType::Jsonb
+        | DataType::Serial
+        | DataType::Int256
+        | DataType::Map(_)
+        | DataType::Vector(_) => false,
+    }
+}
+
 /// The implementation is copied from tiberius crate.
 fn decimal_to_sql(decimal: &rust_decimal::Decimal) -> Numeric {
     let unpacked = decimal.unpack();
@@ -707,4 +925,84 @@ fn decimal_to_sql(decimal: &rust_decimal::Decimal) -> Numeric {
     }
 
     Numeric::new_with_scale(value, decimal.scale() as u8)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_normalize_sql_server_column_name() {
+        assert_eq!(normalize_sql_server_column_name("EventDate"), "eventdate");
+    }
+
+    #[test]
+    fn test_sql_server_data_type_compatibility() {
+        assert!(sql_server_data_type_is_compatible(
+            &DataType::Int16,
+            "smallint"
+        ));
+        assert!(sql_server_data_type_is_compatible(&DataType::Int16, "int"));
+        assert!(!sql_server_data_type_is_compatible(
+            &DataType::Int32,
+            "smallint"
+        ));
+
+        assert!(sql_server_data_type_is_compatible(
+            &DataType::Timestamp,
+            "datetime2"
+        ));
+        assert!(sql_server_data_type_is_compatible(
+            &DataType::Timestamptz,
+            "datetimeoffset"
+        ));
+        assert!(sql_server_data_type_is_compatible(
+            &DataType::Timestamptz,
+            "datetime2"
+        ));
+        assert!(sql_server_data_type_is_compatible(
+            &DataType::Timestamptz,
+            "bigint"
+        ));
+        assert!(sql_server_data_type_is_compatible(
+            &DataType::Timestamptz,
+            "int"
+        ));
+        assert!(!sql_server_data_type_is_compatible(
+            &DataType::Timestamp,
+            "datetimeoffset"
+        ));
+
+        assert!(sql_server_data_type_is_compatible(
+            &DataType::Varchar,
+            "nvarchar"
+        ));
+        assert!(!sql_server_data_type_is_compatible(
+            &DataType::Varchar,
+            "uniqueidentifier"
+        ));
+    }
+
+    #[test]
+    fn test_timestamptz_cast_type() {
+        assert_eq!(
+            timestamptz_cast_type("datetimeoffset"),
+            Some("datetimeoffset")
+        );
+        assert_eq!(timestamptz_cast_type("DATETIME2"), Some("datetime2"));
+        assert_eq!(
+            timestamptz_cast_type(" smalldatetime "),
+            Some("smalldatetime")
+        );
+        assert_eq!(timestamptz_cast_type("bigint"), Some("bigint"));
+        assert_eq!(timestamptz_cast_type("INT"), Some("int"));
+        assert_eq!(timestamptz_cast_type("date"), None);
+    }
+
+    #[test]
+    fn test_use_integer_micros_for_timestamptz() {
+        assert!(use_integer_micros_for_timestamptz("bigint"));
+        assert!(use_integer_micros_for_timestamptz(" int "));
+        assert!(!use_integer_micros_for_timestamptz("datetime2"));
+    }
 }

--- a/src/connector/src/sink/sqlserver.rs
+++ b/src/connector/src/sink/sqlserver.rs
@@ -186,6 +186,8 @@ impl Sink for SqlServerSink {
         }
 
         let mut sql_client = SqlServerClient::new(&self.config).await?;
+        validate_sql_server_write_permission(&mut sql_client, &self.config, self.is_append_only)
+            .await?;
         let sql_server_table_metadata =
             query_sql_server_table_metadata(&mut sql_client, &self.config).await?;
 
@@ -630,6 +632,84 @@ ORDER BY
     Ok(sql_server_table_metadata)
 }
 
+async fn validate_sql_server_write_permission(
+    sql_client: &mut SqlServerClient,
+    config: &SqlServerConfig,
+    is_append_only: bool,
+) -> Result<()> {
+    let permission_query_error = || {
+        SinkError::SqlServer(anyhow!(format!(
+            "SQL Server table {} permission metadata error",
+            config.full_object_path()
+        )))
+    };
+    static QUERY_WRITE_PERMISSION: &str = r#"
+SELECT
+    CAST(HAS_PERMS_BY_NAME(@P1, 'OBJECT', 'INSERT') AS int) AS CanInsert,
+    CAST(HAS_PERMS_BY_NAME(@P1, 'OBJECT', 'UPDATE') AS int) AS CanUpdate,
+    CAST(HAS_PERMS_BY_NAME(@P1, 'OBJECT', 'DELETE') AS int) AS CanDelete;"#;
+    let rows = sql_client
+        .inner_client
+        .query(QUERY_WRITE_PERMISSION, &[&config.full_object_path()])
+        .await?
+        .into_results()
+        .await?;
+    let mut rows = rows.into_iter().flatten();
+    let row = rows.next().ok_or_else(permission_query_error)?;
+    let mut iter = row.into_iter();
+    let ColumnData::I32(can_insert) = iter.next().ok_or_else(permission_query_error)? else {
+        return Err(permission_query_error());
+    };
+    let ColumnData::I32(can_update) = iter.next().ok_or_else(permission_query_error)? else {
+        return Err(permission_query_error());
+    };
+    let ColumnData::I32(can_delete) = iter.next().ok_or_else(permission_query_error)? else {
+        return Err(permission_query_error());
+    };
+
+    let missing_permissions = missing_sql_server_write_permissions(
+        is_append_only,
+        permission_is_granted(can_insert),
+        permission_is_granted(can_update),
+        permission_is_granted(can_delete),
+    );
+    if missing_permissions.is_empty() {
+        return Ok(());
+    }
+
+    Err(SinkError::SqlServer(anyhow!(format!(
+        "SQL Server user {} lacks required write permission(s) {} on table {}",
+        config.user,
+        missing_permissions.join(", "),
+        config.full_object_path()
+    ))))
+}
+
+fn permission_is_granted(permission_value: Option<i32>) -> bool {
+    permission_value == Some(1)
+}
+
+fn missing_sql_server_write_permissions(
+    is_append_only: bool,
+    can_insert: bool,
+    can_update: bool,
+    can_delete: bool,
+) -> Vec<&'static str> {
+    let mut missing_permissions = vec![];
+    if !can_insert {
+        missing_permissions.push("INSERT");
+    }
+    if !is_append_only {
+        if !can_update {
+            missing_permissions.push("UPDATE");
+        }
+        if !can_delete {
+            missing_permissions.push("DELETE");
+        }
+    }
+    missing_permissions
+}
+
 async fn query_downstream_column_data_types(
     sql_client: &mut SqlServerClient,
     config: &SqlServerConfig,
@@ -1004,5 +1084,23 @@ mod tests {
         assert!(use_integer_micros_for_timestamptz("bigint"));
         assert!(use_integer_micros_for_timestamptz(" int "));
         assert!(!use_integer_micros_for_timestamptz("datetime2"));
+    }
+
+    #[test]
+    fn test_missing_sql_server_write_permissions() {
+        assert_eq!(
+            missing_sql_server_write_permissions(true, false, false, false),
+            vec!["INSERT"]
+        );
+        assert!(missing_sql_server_write_permissions(true, true, false, false).is_empty());
+        assert_eq!(
+            missing_sql_server_write_permissions(false, false, false, false),
+            vec!["INSERT", "UPDATE", "DELETE"]
+        );
+        assert_eq!(
+            missing_sql_server_write_permissions(false, true, false, true),
+            vec!["UPDATE"]
+        );
+        assert!(missing_sql_server_write_permissions(false, true, true, true).is_empty());
     }
 }

--- a/src/connector/src/sink/sqlserver.rs
+++ b/src/connector/src/sink/sqlserver.rs
@@ -109,6 +109,7 @@ pub struct SqlServerSink {
 }
 
 struct SqlServerColumnMetadata {
+    name: String,
     is_pk: bool,
     data_type: String,
 }
@@ -190,6 +191,14 @@ impl Sink for SqlServerSink {
             .await?;
         let sql_server_table_metadata =
             query_sql_server_table_metadata(&mut sql_client, &self.config).await?;
+        let sql_server_pk_count = sql_server_table_metadata
+            .iter()
+            .filter(|metadata| metadata.is_pk)
+            .count();
+        let sql_server_table_metadata = sql_server_table_metadata
+            .into_iter()
+            .map(|metadata| (metadata.name.clone(), metadata))
+            .collect::<HashMap<_, _>>();
 
         // Validate Column name, Primary Key and data type.
         for (idx, col) in self.schema.fields().iter().enumerate() {
@@ -229,19 +238,27 @@ impl Sink for SqlServerSink {
             }
         }
 
-        if !self.is_append_only {
-            let sql_server_pk_count = sql_server_table_metadata
+        if !self.is_append_only && sql_server_pk_count != self.pk_indices.len() {
+            let sql_server_pk_columns = sql_server_table_metadata
                 .values()
                 .filter(|metadata| metadata.is_pk)
-                .count();
-            if sql_server_pk_count != self.pk_indices.len() {
-                return Err(SinkError::SqlServer(anyhow!(format!(
-                    "primary key does not match between RisingWave sink ({}) and SQL Server table {} ({})",
-                    self.pk_indices.len(),
-                    self.config.full_object_path(),
-                    sql_server_pk_count,
-                ))));
-            }
+                .map(|metadata| metadata.name.as_str())
+                .collect::<Vec<_>>()
+                .join(",");
+            let rw_pk_columns = self
+                .pk_indices
+                .iter()
+                .map(|idx| self.schema[*idx].name.as_str())
+                .collect::<Vec<_>>()
+                .join(",");
+            return Err(SinkError::SqlServer(anyhow!(format!(
+                "primary key does not match between RisingWave sink ({}: [{}]) and SQL Server table {} ({}: [{}])",
+                self.pk_indices.len(),
+                rw_pk_columns,
+                self.config.full_object_path(),
+                sql_server_pk_count,
+                sql_server_pk_columns,
+            ))));
         }
 
         Ok(())
@@ -284,7 +301,11 @@ impl SqlServerSinkWriter {
     ) -> Result<Self> {
         let mut sql_client = SqlServerClient::new(&config).await?;
         let downstream_column_data_types =
-            query_downstream_column_data_types(&mut sql_client, &config, &schema).await?;
+            query_downstream_column_metadata(&mut sql_client, &config, &schema)
+                .await?
+                .into_iter()
+                .map(|metadata| metadata.data_type)
+                .collect();
         let writer = Self {
             config,
             schema,
@@ -359,14 +380,7 @@ impl SqlServerSinkWriter {
             .join(" AND ");
         let param_placeholders = |param_id: &mut usize| {
             (0..col_num)
-                .map(|idx| {
-                    param_placeholder(
-                        param_id,
-                        idx,
-                        &self.schema,
-                        &self.downstream_column_data_types,
-                    )
-                })
+                .map(|_| param_placeholder(param_id))
                 .collect::<Vec<_>>()
                 .join(",")
         };
@@ -422,12 +436,7 @@ impl SqlServerSinkWriter {
                                 let condition = format!(
                                     "[{}]={}",
                                     self.schema[*idx].name,
-                                    param_placeholder(
-                                        &mut next_param_id,
-                                        *idx,
-                                        &self.schema,
-                                        &self.downstream_column_data_types,
-                                    )
+                                    param_placeholder(&mut next_param_id)
                                 );
                                 condition
                             })
@@ -570,14 +579,19 @@ impl SqlServerClient {
 async fn query_sql_server_table_metadata(
     sql_client: &mut SqlServerClient,
     config: &SqlServerConfig,
-) -> Result<HashMap<String, SqlServerColumnMetadata>> {
-    let mut sql_server_table_metadata = HashMap::new();
+) -> Result<Vec<SqlServerColumnMetadata>> {
+    let mut sql_server_table_metadata = Vec::new();
     let query_table_metadata_error = || {
         SinkError::SqlServer(anyhow!(format!(
             "SQL Server table {} metadata error",
             config.full_object_path()
         )))
     };
+    // Query primary-key membership through a subquery filtered by `pk.is_primary_key = 1`.
+    // A column can appear in both the primary-key index and secondary indexes, and a naive
+    // join from `sys.columns` to all `sys.index_columns` would emit extra index rows or mark
+    // secondary-index-only columns as PK columns. Keep the PK filter inside the subquery so
+    // each table column is returned once with `IsPk` set only by the primary-key index.
     static QUERY_TABLE_METADATA: &str = r#"
 SELECT
     col.name AS ColumnName,
@@ -621,13 +635,11 @@ ORDER BY
         else {
             return Err(query_table_metadata_error());
         };
-        sql_server_table_metadata.insert(
-            normalize_sql_server_column_name(&col_name),
-            SqlServerColumnMetadata {
-                is_pk: col_is_pk != 0,
-                data_type: normalize_sql_server_data_type(&data_type),
-            },
-        );
+        sql_server_table_metadata.push(SqlServerColumnMetadata {
+            name: normalize_sql_server_column_name(&col_name),
+            is_pk: col_is_pk != 0,
+            data_type: data_type.into_owned(),
+        });
     }
     Ok(sql_server_table_metadata)
 }
@@ -710,19 +722,27 @@ fn missing_sql_server_write_permissions(
     missing_permissions
 }
 
-async fn query_downstream_column_data_types(
+async fn query_downstream_column_metadata(
     sql_client: &mut SqlServerClient,
     config: &SqlServerConfig,
     schema: &Schema,
-) -> Result<Vec<String>> {
-    let sql_server_table_metadata = query_sql_server_table_metadata(sql_client, config).await?;
+) -> Result<Vec<SqlServerColumnMetadata>> {
+    let sql_server_table_metadata = query_sql_server_table_metadata(sql_client, config)
+        .await?
+        .into_iter()
+        .map(|metadata| (metadata.name.clone(), metadata))
+        .collect::<HashMap<_, _>>();
     schema
         .fields()
         .iter()
         .map(|col| {
             sql_server_table_metadata
                 .get(&normalize_sql_server_column_name(&col.name))
-                .map(|metadata| metadata.data_type.clone())
+                .map(|metadata| SqlServerColumnMetadata {
+                    name: metadata.name.clone(),
+                    is_pk: metadata.is_pk,
+                    data_type: metadata.data_type.clone(),
+                })
                 .ok_or_else(|| {
                     SinkError::SqlServer(anyhow!(format!(
                         "column {} not found in the downstream SQL Server table {}",
@@ -734,23 +754,10 @@ async fn query_downstream_column_data_types(
         .collect()
 }
 
-fn param_placeholder(
-    param_id: &mut usize,
-    col_idx: usize,
-    schema: &Schema,
-    downstream_column_data_types: &[String],
-) -> String {
+fn param_placeholder(param_id: &mut usize) -> String {
     let placeholder = format!("@P{}", *param_id);
     *param_id += 1;
-
-    if schema[col_idx].data_type != DataType::Timestamptz {
-        return placeholder;
-    }
-
-    match timestamptz_cast_type(&downstream_column_data_types[col_idx]) {
-        Some(cast_type) => format!("CAST({placeholder} AS {cast_type})"),
-        None => placeholder,
-    }
+    placeholder
 }
 
 fn bind_params(
@@ -786,13 +793,22 @@ fn bind_params(
                 ScalarRefImpl::Timestamp(v) => query.bind(v.0),
                 ScalarRefImpl::Timestamptz(v) => {
                     let downstream_data_type = &downstream_column_data_types[col_idx];
-                    if use_integer_micros_for_timestamptz(downstream_data_type) {
-                        query.bind(v.timestamp_micros());
-                    } else if use_datetimeoffset_for_timestamptz(downstream_data_type) {
-                        query.bind(v.to_datetime_utc().fixed_offset());
-                    } else {
-                        query.bind(v.to_datetime_utc().naive_utc());
-                    }
+                    match downstream_data_type.as_str() {
+                        "bigint" | "int" | "smallint" | "tinyint" => {
+                            query.bind(v.timestamp_micros());
+                        }
+                        "datetimeoffset" => {
+                            query.bind(v.to_datetime_utc().fixed_offset());
+                        }
+                        "datetime" | "datetime2" | "smalldatetime" => {
+                            query.bind(v.to_datetime_utc().naive_utc());
+                        }
+                        _ => {
+                            return Err(unexpected_downstream_timestamptz_type(
+                                downstream_data_type,
+                            ));
+                        }
+                    };
                 }
                 ScalarRefImpl::Time(v) => query.bind(v.0),
                 ScalarRefImpl::Bytea(v) => query.bind(v.to_vec()),
@@ -838,13 +854,22 @@ fn bind_params(
                 }
                 DataType::Timestamptz => {
                     let downstream_data_type = &downstream_column_data_types[col_idx];
-                    if use_integer_micros_for_timestamptz(downstream_data_type) {
-                        query.bind(None as Option<i64>);
-                    } else if use_datetimeoffset_for_timestamptz(downstream_data_type) {
-                        query.bind(None as Option<chrono::DateTime<chrono::FixedOffset>>);
-                    } else {
-                        query.bind(None as Option<chrono::NaiveDateTime>);
-                    }
+                    match downstream_data_type.as_str() {
+                        "bigint" | "int" | "smallint" | "tinyint" => {
+                            query.bind(None as Option<i64>);
+                        }
+                        "datetimeoffset" => {
+                            query.bind(None as Option<chrono::DateTime<chrono::FixedOffset>>);
+                        }
+                        "datetime" | "datetime2" | "smalldatetime" => {
+                            query.bind(None as Option<chrono::NaiveDateTime>);
+                        }
+                        _ => {
+                            return Err(unexpected_downstream_timestamptz_type(
+                                downstream_data_type,
+                            ));
+                        }
+                    };
                 }
                 DataType::Varchar => {
                     query.bind(None as Option<String>);
@@ -869,6 +894,12 @@ fn bind_params(
 fn data_type_not_supported(data_type_name: &str) -> SinkError {
     SinkError::SqlServer(anyhow!(format!(
         "{data_type_name} is not supported in SQL Server"
+    )))
+}
+
+fn unexpected_downstream_timestamptz_type(sql_server_data_type: &str) -> SinkError {
+    SinkError::SqlServer(anyhow!(format!(
+        "unexpected downstream SQL Server type {sql_server_data_type} for Timestamptz"
     )))
 }
 
@@ -899,36 +930,9 @@ fn check_data_type_compatibility(data_type: &DataType) -> Result<()> {
 }
 
 fn normalize_sql_server_column_name(column_name: &str) -> String {
+    // SQL Server identifiers are usually case-insensitive depending on database collation.
+    // Match metadata by a case-insensitive key so validation follows that common behavior.
     column_name.to_lowercase()
-}
-
-fn normalize_sql_server_data_type(data_type: &str) -> String {
-    data_type.trim().to_ascii_lowercase()
-}
-
-fn timestamptz_cast_type(sql_server_data_type: &str) -> Option<&'static str> {
-    match normalize_sql_server_data_type(sql_server_data_type).as_str() {
-        "datetimeoffset" => Some("datetimeoffset"),
-        "datetime" => Some("datetime"),
-        "datetime2" => Some("datetime2"),
-        "smalldatetime" => Some("smalldatetime"),
-        "bigint" => Some("bigint"),
-        "int" => Some("int"),
-        "smallint" => Some("smallint"),
-        "tinyint" => Some("tinyint"),
-        _ => None,
-    }
-}
-
-fn use_datetimeoffset_for_timestamptz(sql_server_data_type: &str) -> bool {
-    normalize_sql_server_data_type(sql_server_data_type) == "datetimeoffset"
-}
-
-fn use_integer_micros_for_timestamptz(sql_server_data_type: &str) -> bool {
-    matches!(
-        normalize_sql_server_data_type(sql_server_data_type).as_str(),
-        "bigint" | "int" | "smallint" | "tinyint"
-    )
 }
 
 fn validate_data_type_compatibility(
@@ -947,8 +951,6 @@ fn validate_data_type_compatibility(
 }
 
 fn sql_server_data_type_is_compatible(rw_data_type: &DataType, sql_server_data_type: &str) -> bool {
-    let sql_server_data_type = normalize_sql_server_data_type(sql_server_data_type);
-    let sql_server_data_type = sql_server_data_type.as_str();
     match rw_data_type {
         DataType::Boolean => sql_server_data_type == "bit",
         DataType::Int16 => matches!(sql_server_data_type, "smallint" | "int" | "bigint"),
@@ -1061,29 +1063,6 @@ mod tests {
             &DataType::Varchar,
             "uniqueidentifier"
         ));
-    }
-
-    #[test]
-    fn test_timestamptz_cast_type() {
-        assert_eq!(
-            timestamptz_cast_type("datetimeoffset"),
-            Some("datetimeoffset")
-        );
-        assert_eq!(timestamptz_cast_type("DATETIME2"), Some("datetime2"));
-        assert_eq!(
-            timestamptz_cast_type(" smalldatetime "),
-            Some("smalldatetime")
-        );
-        assert_eq!(timestamptz_cast_type("bigint"), Some("bigint"));
-        assert_eq!(timestamptz_cast_type("INT"), Some("int"));
-        assert_eq!(timestamptz_cast_type("date"), None);
-    }
-
-    #[test]
-    fn test_use_integer_micros_for_timestamptz() {
-        assert!(use_integer_micros_for_timestamptz("bigint"));
-        assert!(use_integer_micros_for_timestamptz(" int "));
-        assert!(!use_integer_micros_for_timestamptz("datetime2"));
     }
 
     #[test]


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

This PR fixes SQL Server sink target validation by choosing the `timestamptz` value representation from the downstream SQL Server column type and checking required write permissions during sink creation.

- Query downstream SQL Server column metadata once for validation and once for the writer.
- Keep legacy integer-backed `timestamptz` sinks compatible by binding microsecond epoch values for `bigint`, `int`, `smallint`, and `tinyint` targets.
- Bind `datetimeoffset` targets as offset-aware values, and bind `datetime`, `datetime2`, and `smalldatetime` targets as naive UTC datetime values.
- Validate sink schema fields against the downstream SQL Server column data types.
- Validate SQL Server sink write permissions during sink creation: append-only sinks require `INSERT`, and upsert sinks require `INSERT`, `UPDATE`, and `DELETE`.
- Add SQL Server sink e2e coverage for mixed-case PK columns, `datetimeoffset`, `bigint`, and non-overflowing integer timestamp targets with anonymized column names.
- Cover the SQL Server metadata case where a primary-key column is also present in a secondary index, so PK detection does not treat every indexed column as part of the primary key.
- Cover SQL Server write-permission validation in e2e with a read-only user that can inspect metadata but cannot create an upsert sink.

## Checklist

- [ ] I have written necessary rustdoc comments.
- [x] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [x] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Test coverage

| New change | Coverage | Evidence |
| --- | --- | --- |
| SQL Server sink validates required write permissions before creation. | New e2e negative case and new unit coverage. | `e2e_test/sink/sqlserver_native_sink.slt` creates an upsert sink with read-only credentials and expects `lacks required write permission`; `test_missing_sql_server_write_permissions` covers append-only vs upsert permission requirements. |
| Downstream table metadata now tracks normalized column names, PK membership, and SQL Server data types. | New unit coverage and new native SQL Server e2e sink creation. | `test_normalize_sql_server_column_name` covers case normalization; the new SLT uses mixed-case `"EntityId"` / `"EventDate"` columns and creates a sink against SQL Server columns `EntityId` / `EventDate`. |
| SQL Server downstream type compatibility is validated against the RisingWave sink schema. | New unit coverage and new e2e coverage for representative compatible types. | `test_sql_server_data_type_compatibility` covers accepted and rejected type pairs; the new SQL Server table uses `nvarchar`, `date`, `numeric`, `datetimeoffset`, `bigint`, `int`, `smallint`, and `tinyint`. |
| Writer stores downstream column data types and uses them while binding row values. | New native SQL Server e2e path. | `sqlserver_native_sink.slt` creates a native `connector = 'sqlserver'` upsert sink and inserts a row, exercising writer initialization and binding through the real SQL Server connector. |
| `timestamptz` binding chooses SQL Server datetime or integer representation from the target column type. | New SQL Server e2e result assertion plus compatibility unit coverage. | `test_sql_server_data_type_compatibility` covers supported downstream target types; `ci/scripts/e2e-sqlserver-sink-test.sh` verifies persisted `datetimeoffset`, `bigint`, `int`, `smallint`, and `tinyint` values. |
| Native SQL Server upsert with composite primary key is exercised. | New native SQL Server e2e coverage. | The CI script creates `PRIMARY KEY CLUSTERED (EntityId, EventDate)` and the SLT creates an upsert sink with `primary_key = 'EntityId,EventDate'`. |
| Existing SQL Server sink behavior remains covered. | Existing e2e coverage retained. | `ci/scripts/e2e-sqlserver-sink-test.sh` still runs `e2e_test/sink/sqlserver_sink.slt` and keeps the existing SQL Server output comparison. |
| The new SLT is selected by CI. | Static SLT coverage check and script invocation. | `ci/scripts/e2e-sqlserver-sink-test.sh` runs `e2e_test/sink/sqlserver_native_sink.slt`; `python3 e2e_test/check_slt_coverage.py -d` reports the SQL Server sink script covers two files. |

Local checks:

- `cargo test -p risingwave_connector sink::sqlserver::tests`
- `git diff --check origin/main...`
- `python3 e2e_test/check_slt_coverage.py -d`
- `cargo clippy --all-targets --all-features`

## Documentation

- [x] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

SQL Server sink now preserves compatibility for `timestamptz` columns based on the downstream SQL Server column type. Existing integer-backed sinks continue receiving microsecond epoch values, while datetime-like targets receive SQL Server datetime values compatible with their target type.

SQL Server sink creation also validates downstream write permissions earlier. Append-only sinks require `INSERT`, while upsert sinks require `INSERT`, `UPDATE`, and `DELETE`.

</details>
