### PR TITLE
refactor(meta): group diagnose actors by fragment

### DIFF
--- a/src/meta/src/manager/diagnose.rs
+++ b/src/meta/src/manager/diagnose.rs
@@ -1001,50 +1001,52 @@ impl DiagnoseCommand {
             let _ = writeln!(s, "{table}");
         }
 
-        let actors = self
+        let mut fragments = BTreeMap::new();
+        for (actor_id, fragment_id, job_id, schema_id, obj_type) in self
             .metadata_manager
             .catalog_controller
             .list_actor_info()
             .await?
-            .into_iter()
-            .map(|(actor_id, fragment_id, job_id, schema_id, obj_type)| {
-                (
-                    actor_id,
-                    (
-                        fragment_id,
-                        job_id,
-                        schema_id,
-                        obj_type,
-                        obj_id_to_name.get(&job_id).cloned().unwrap_or_default(),
-                    ),
-                )
-            })
-            .collect::<BTreeMap<_, _>>();
+        {
+            let entry = fragments
+                .entry(fragment_id)
+                .or_insert_with(|| (job_id, schema_id, obj_type, Vec::new()));
+            entry.3.push(actor_id);
+        }
 
         use comfy_table::{Row, Table};
         let mut table = Table::new();
         table.set_header({
             let mut row = Row::new();
-            row.add_cell("id".into());
             row.add_cell("fragment_id".into());
             row.add_cell("job_id".into());
             row.add_cell("schema_id".into());
             row.add_cell("type".into());
             row.add_cell("name".into());
+            row.add_cell("actor_count".into());
+            row.add_cell("actors".into());
             row
         });
-        for (actor_id, (fragment_id, job_id, schema_id, ddl_type, name)) in actors {
+        for (fragment_id, (job_id, schema_id, obj_type, mut actor_ids)) in fragments {
+            actor_ids.sort_unstable();
             let mut row = Row::new();
-            row.add_cell(actor_id.into());
             row.add_cell(fragment_id.into());
             row.add_cell(job_id.into());
             row.add_cell(schema_id.into());
-            row.add_cell(ddl_type.as_str().into());
-            row.add_cell(name.into());
+            row.add_cell(obj_type.as_str().into());
+            row.add_cell(
+                obj_id_to_name
+                    .get(&job_id)
+                    .cloned()
+                    .unwrap_or_default()
+                    .into(),
+            );
+            row.add_cell(actor_ids.len().into());
+            row.add_cell(actor_ids.iter().join(", ").into());
             table.add_row(row);
         }
         let _ = writeln!(s);
-        let _ = writeln!(s, "ACTOR");
+        let _ = writeln!(s, "FRAGMENT");
         let _ = writeln!(s, "{table}");
         Ok(())
     }


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

The `ACTOR` section of the diagnose report printed one row per actor. Since a fragment usually contains many actors that all share the same `fragment_id` / `job_id` / `schema_id` / `type` / `name`, the output was extremely long and repetitive (e.g. dozens of consecutive rows differing only by actor id).

This PR groups actors by fragment and renames the section from `ACTOR` to `FRAGMENT`. Each fragment now occupies a single row, with the actors listed in a single `actors` column (sorted, comma-separated) plus an `actor_count` column so the parallelism is visible at a glance.

Before:

```
ACTOR
| id   | fragment_id | job_id | schema_id | type  | name |
| 7435 | 667         | 1699   | 7         | table | imp_token_outputs |
| 7436 | 667         | 1699   | 7         | table | imp_token_outputs |
| 7437 | 667         | 1699   | 7         | table | imp_token_outputs |
... (one row per actor)
```

After:

```
FRAGMENT
| fragment_id | job_id | schema_id | type  | name | actor_count | actors         |
| 1           | 6      | 2         | table | t    | 4           | 0, 1, 2, 3     |
| 3           | 7      | 2         | table | mv1  | 4           | 12, 13, 14, 15 |
```

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [x] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

The meta diagnose report now presents streaming actors grouped by fragment under a `FRAGMENT` section (previously a per-actor `ACTOR` section), making the report much shorter and easier to read for high-parallelism jobs.

</details>
