### PR TITLE
feat(iceberg): derive iceberg v3 pk from upstream stream key

### DIFF
--- a/e2e_test/iceberg/test_case/pure_slt/iceberg_v3/derive_pk.slt
+++ b/e2e_test/iceberg/test_case/pure_slt/iceberg_v3/derive_pk.slt
@@ -1,0 +1,243 @@
+statement ok
+set streaming_parallelism=4;
+
+statement ok
+CREATE TABLE t_v3_derive_pk_users (user_id int PRIMARY KEY, name varchar);
+
+statement ok
+CREATE TABLE t_v3_derive_pk_orders (order_id bigint PRIMARY KEY, user_id int, product varchar, amount int);
+
+statement ok
+CREATE MATERIALIZED VIEW mv_v3_derive_pk AS
+SELECT u.user_id, u.name, o.order_id, o.product, o.amount
+FROM t_v3_derive_pk_users u JOIN t_v3_derive_pk_orders o ON u.user_id = o.user_id;
+
+statement ok
+CREATE SINK s_v3_derive_pk FROM mv_v3_derive_pk
+WITH (
+    connector = 'iceberg',
+    type = 'upsert',
+    force_append_only = 'false',
+    catalog.name = 'demo',
+    database.name = 'public',
+    table.name = 'derive_pk_v3_pk_index_table',
+    catalog.type = 'storage',
+    warehouse.path = 's3a://hummock001/iceberg_v3',
+    s3.endpoint = 'http://127.0.0.1:9301',
+    s3.region = 'us-east-1',
+    s3.access.key = 'hummockadmin',
+    s3.secret.key = 'hummockadmin',
+    create_table_if_not_exists = 'true',
+    write_mode = 'merge-on-read',
+    format_version = '3',
+    enable_pk_index = 'true'
+);
+
+statement ok
+INSERT INTO t_v3_derive_pk_users VALUES (1, 'Alice'), (2, 'Bob');
+
+statement ok
+FLUSH;
+
+statement ok
+INSERT INTO t_v3_derive_pk_orders VALUES
+    (100, 1, 'book', 50),
+    (101, 1, 'pen', 5),
+    (200, 2, 'lamp', 30);
+
+statement ok
+FLUSH;
+
+statement ok
+CREATE SOURCE iceberg_derive_pk_source WITH (
+    connector = 'iceberg',
+    database.name = 'public',
+    table.name = 'derive_pk_v3_pk_index_table',
+    catalog.name = 'demo',
+    catalog.type = 'storage',
+    warehouse.path = 's3a://hummock001/iceberg_v3',
+    s3.endpoint = 'http://127.0.0.1:9301',
+    s3.region = 'us-east-1',
+    s3.access.key = 'hummockadmin',
+    s3.secret.key = 'hummockadmin'
+);
+
+# Both orders for user 1 must be preserved. The iceberg pk is derived from the
+# upstream stream key (user_id, order_id), so rows sharing user_id are not overwritten.
+query ????? rowsort retry 11 backoff 1s
+select user_id, name, order_id, product, amount from iceberg_derive_pk_source;
+----
+1 Alice 100 book 50
+1 Alice 101 pen 5
+2 Bob 200 lamp 30
+
+statement ok
+UPDATE t_v3_derive_pk_orders SET amount = 60 WHERE order_id = 100;
+
+statement ok
+FLUSH;
+
+# After UPDATE, order 100 reflects the new amount; order 101 untouched.
+query ????? rowsort retry 11 backoff 1s
+select user_id, name, order_id, product, amount from iceberg_derive_pk_source;
+----
+1 Alice 100 book 60
+1 Alice 101 pen 5
+2 Bob 200 lamp 30
+
+statement ok
+DELETE FROM t_v3_derive_pk_orders WHERE order_id = 101;
+
+statement ok
+FLUSH;
+
+# After DELETE, only order 100 (Alice) and order 200 (Bob) remain.
+query ????? rowsort retry 11 backoff 1s
+select user_id, name, order_id, product, amount from iceberg_derive_pk_source;
+----
+1 Alice 100 book 60
+2 Bob 200 lamp 30
+
+query T retry 11 backoff 1s
+select count(*) > 0 from rw_iceberg_files
+where source_name = 'iceberg_derive_pk_source'
+  and content = 'PositionDeletes'
+  and file_format = 'puffin';
+----
+t
+
+query T retry 11 backoff 1s
+select count(*) = 0 from rw_iceberg_files
+where source_name = 'iceberg_derive_pk_source'
+  and content = 'EqualityDeletes';
+----
+t
+
+statement ok
+DROP SOURCE iceberg_derive_pk_source;
+
+statement ok
+DROP SINK s_v3_derive_pk;
+
+statement ok
+DROP MATERIALIZED VIEW mv_v3_derive_pk;
+
+statement ok
+DROP TABLE t_v3_derive_pk_orders;
+
+statement ok
+DROP TABLE t_v3_derive_pk_users;
+
+# ----- pk-less upstream: hidden _row_id is carried into iceberg verbatim -----
+
+statement ok
+CREATE TABLE t_v3_derive_pk_pkless (item_id int, label varchar);
+
+statement ok
+CREATE SINK s_v3_derive_pk_pkless from t_v3_derive_pk_pkless
+WITH (
+    connector = 'iceberg',
+    type = 'upsert',
+    force_append_only = 'false',
+    catalog.name = 'demo',
+    database.name = 'public',
+    table.name = 'derive_pk_pkless_v3_pk_index_table',
+    catalog.type = 'storage',
+    warehouse.path = 's3a://hummock001/iceberg_v3',
+    s3.endpoint = 'http://127.0.0.1:9301',
+    s3.region = 'us-east-1',
+    s3.access.key = 'hummockadmin',
+    s3.secret.key = 'hummockadmin',
+    create_table_if_not_exists = 'true',
+    write_mode = 'merge-on-read',
+    format_version = '3',
+    enable_pk_index = 'true'
+);
+
+statement ok
+INSERT INTO t_v3_derive_pk_pkless VALUES (1, 'a'), (1, 'b'), (2, 'c');
+
+statement ok
+FLUSH;
+
+statement ok
+CREATE SOURCE iceberg_derive_pk_pkless_source WITH (
+    connector = 'iceberg',
+    database.name = 'public',
+    table.name = 'derive_pk_pkless_v3_pk_index_table',
+    catalog.name = 'demo',
+    catalog.type = 'storage',
+    warehouse.path = 's3a://hummock001/iceberg_v3',
+    s3.endpoint = 'http://127.0.0.1:9301',
+    s3.region = 'us-east-1',
+    s3.access.key = 'hummockadmin',
+    s3.secret.key = 'hummockadmin'
+);
+
+# Both rows with item_id=1 must be preserved; the hidden upstream stream key (_row_id)
+# is carried into iceberg verbatim as a column that distinguishes them under the derived pk.
+query IT rowsort retry 11 backoff 1s
+select item_id, label from iceberg_derive_pk_pkless_source;
+----
+1 a
+1 b
+2 c
+
+# Confirm the carried-over row-id column is populated and unique per row. Its name stays
+# relation-qualified because the bare `_row_id` is reserved by RisingWave sources.
+query I retry 11 backoff 1s
+select count(distinct "t_v3_derive_pk_pkless._row_id") from iceberg_derive_pk_pkless_source;
+----
+3
+
+statement ok
+DELETE FROM t_v3_derive_pk_pkless WHERE label = 'a';
+
+statement ok
+FLUSH;
+
+query IT rowsort retry 11 backoff 1s
+select item_id, label from iceberg_derive_pk_pkless_source;
+----
+1 b
+2 c
+
+statement ok
+DROP SOURCE iceberg_derive_pk_pkless_source;
+
+statement ok
+DROP SINK s_v3_derive_pk_pkless;
+
+statement ok
+DROP TABLE t_v3_derive_pk_pkless;
+
+# ----- enable_pk_index rejects user-specified primary_key -----
+
+statement ok
+CREATE TABLE t_v3_derive_pk_reject (item_id int PRIMARY KEY, label varchar);
+
+statement error does not allow a user-specified
+CREATE SINK s_v3_derive_pk_reject AS
+select item_id, label from t_v3_derive_pk_reject
+WITH (
+    connector = 'iceberg',
+    type = 'upsert',
+    force_append_only = 'false',
+    catalog.name = 'demo',
+    database.name = 'public',
+    table.name = 'derive_pk_reject_v3_pk_index_table',
+    catalog.type = 'storage',
+    warehouse.path = 's3a://hummock001/iceberg_v3',
+    s3.endpoint = 'http://127.0.0.1:9301',
+    s3.region = 'us-east-1',
+    s3.access.key = 'hummockadmin',
+    s3.secret.key = 'hummockadmin',
+    create_table_if_not_exists = 'true',
+    primary_key = 'item_id',
+    write_mode = 'merge-on-read',
+    format_version = '3',
+    enable_pk_index = 'true'
+);
+
+statement ok
+DROP TABLE t_v3_derive_pk_reject;

--- a/e2e_test/iceberg/test_case/pure_slt/iceberg_v3/sink_lakekeeper.slt
+++ b/e2e_test/iceberg/test_case/pure_slt/iceberg_v3/sink_lakekeeper.slt
@@ -37,7 +37,6 @@ WITH (
     database.name = 'public',
     table.name = 'no_partition_upsert_v3_pk_index_table',
     create_table_if_not_exists = 'true',
-    primary_key = 'v1',
     write_mode = 'merge-on-read',
     format_version = '3',
     enable_pk_index = 'true'

--- a/e2e_test/iceberg/test_case/pure_slt/iceberg_v3/sink_no_partition.slt
+++ b/e2e_test/iceberg/test_case/pure_slt/iceberg_v3/sink_no_partition.slt
@@ -23,7 +23,6 @@ WITH (
     s3.access.key = 'hummockadmin',
     s3.secret.key = 'hummockadmin',
     create_table_if_not_exists = 'true',
-    primary_key = 'v1',
     write_mode = 'merge-on-read',
     format_version = '3',
     enable_pk_index = 'true'

--- a/e2e_test/iceberg/test_case/pure_slt/iceberg_v3/sink_range_partition.slt
+++ b/e2e_test/iceberg/test_case/pure_slt/iceberg_v3/sink_range_partition.slt
@@ -23,7 +23,6 @@ WITH (
     s3.access.key = 'hummockadmin',
     s3.secret.key = 'hummockadmin',
     create_table_if_not_exists = 'true',
-    primary_key = 'v1',
     partition_by = 'day(v4)',
     write_mode = 'merge-on-read',
     format_version = '3',

--- a/e2e_test/iceberg/test_case/pure_slt/iceberg_v3/sink_sparse_partition.slt
+++ b/e2e_test/iceberg/test_case/pure_slt/iceberg_v3/sink_sparse_partition.slt
@@ -23,7 +23,6 @@ WITH (
     s3.access.key = 'hummockadmin',
     s3.secret.key = 'hummockadmin',
     create_table_if_not_exists = 'true',
-    primary_key = 'v1',
     partition_by = 'v1,v2,truncate(2,v3)',
     write_mode = 'merge-on-read',
     format_version = '3',

--- a/src/connector/src/sink/iceberg/config.rs
+++ b/src/connector/src/sink/iceberg/config.rs
@@ -551,7 +551,11 @@ impl IcebergConfig {
                         SINK_TYPE_UPSERT
                     )));
                 }
-            } else {
+            } else if !config.enable_pk_index {
+                // When `enable_pk_index = true`, the planner auto-derives the iceberg pk
+                // from the upstream stream key, so the user does not need to spell it out
+                // in WITH options. The derived pk is written back into properties before
+                // this validation is consulted again at sink-construction time.
                 return Err(SinkError::Config(anyhow!(
                     "Must set `primary-key` in {}",
                     SINK_TYPE_UPSERT

--- a/src/frontend/planner_test/tests/testdata/input/sink.yaml
+++ b/src/frontend/planner_test/tests/testdata/input/sink.yaml
@@ -160,7 +160,7 @@
 - id: create_mock_iceberg_sink_with_pk_index_sparse_partition
   sql: |
     create table t1 (v1 int, v2 bigint, v3 varchar, v4 time);
-    explain create sink s1 as select v1 as v1, v2 as v2, v3 as v3, v4 as v4 from t1 WITH (
+    explain create sink s1 from t1 WITH (
       connector = 'iceberg',
       type = 'upsert',
       catalog.type = 'mock',
@@ -172,9 +172,9 @@
       s3.region = 'us-east-1',
       s3.access.key = 'hummockadmin',
       s3.secret.key = 'hummockadmin',
-      primary_key = 'v1',
       write_mode = 'merge-on-read',
       format_version = '3',
+      create_table_if_not_exists = 'true',
       enable_pk_index = 'true'
     );
   expected_outputs:
@@ -182,7 +182,7 @@
 - id: create_mock_iceberg_sink_with_pk_index_range_partition
   sql: |
     create table t1 (v1 date, v2 timestamp, v3 timestamp with time zone, v4 timestamp);
-    explain create sink s1 as select v1 as v1, v2 as v2, v3 as v3, v4 as v4 from t1 WITH (
+    explain create sink s1 from t1 WITH (
       connector = 'iceberg',
       type = 'upsert',
       catalog.type = 'mock',
@@ -194,9 +194,9 @@
       s3.region = 'us-east-1',
       s3.access.key = 'hummockadmin',
       s3.secret.key = 'hummockadmin',
-      primary_key = 'v1',
       write_mode = 'merge-on-read',
       format_version = '3',
+      create_table_if_not_exists = 'true',
       enable_pk_index = 'true'
     );
   expected_outputs:
@@ -249,5 +249,49 @@
     create table sink_table (v1 date, v2 timestamp);
     explain create sink s into sink_table as select t1.v1, t2.v2 from t t1 join t t2 on t1.v1 = t2.v1
     with (type = 'append-only', force_append_only = 'true');
+  expected_outputs:
+    - explain_output
+- id: iceberg_v3_pk_index_sink_visible_extra
+  sql: |
+    create table u (v1 int primary key, name varchar);
+    create table o (oid bigint primary key, v1 int, p varchar);
+    explain create sink s as select u.v1 as v1, o.oid as v2, u.name as v3, cast('00:00:00' as time) as v4 from u join o on u.v1 = o.v1 WITH (
+      connector = 'iceberg',
+      type = 'upsert',
+      catalog.type = 'mock',
+      catalog.name = 'demo',
+      database.name = 'demo_db',
+      table.name = 'sparse_table',
+      warehouse.path = 's3://icebergdata/demo',
+      s3.endpoint = 'http://127.0.0.1:9301',
+      s3.region = 'us-east-1',
+      s3.access.key = 'hummockadmin',
+      s3.secret.key = 'hummockadmin',
+      write_mode = 'merge-on-read',
+      format_version = '3',
+      enable_pk_index = 'true'
+    );
+  expected_outputs:
+    - explain_output
+- id: iceberg_v3_pk_index_sink_hidden_extra
+  sql: |
+    create table t (v1 int, v2 bigint, v3 varchar, v4 time, PRIMARY KEY (v1, v2, v3));
+    explain create sink s as select t.v1 from t WITH (
+      connector = 'iceberg',
+      type = 'upsert',
+      catalog.type = 'mock',
+      catalog.name = 'demo',
+      database.name = 'demo_db',
+      table.name = 'sparse_table',
+      warehouse.path = 's3://icebergdata/demo',
+      s3.endpoint = 'http://127.0.0.1:9301',
+      s3.region = 'us-east-1',
+      s3.access.key = 'hummockadmin',
+      s3.secret.key = 'hummockadmin',
+      write_mode = 'merge-on-read',
+      format_version = '3',
+      create_table_if_not_exists = 'true',
+      enable_pk_index = 'true'
+    );
   expected_outputs:
     - explain_output

--- a/src/frontend/planner_test/tests/testdata/output/sink.yaml
+++ b/src/frontend/planner_test/tests/testdata/output/sink.yaml
@@ -265,7 +265,7 @@
 - id: create_mock_iceberg_sink_with_pk_index_sparse_partition
   sql: |
     create table t1 (v1 int, v2 bigint, v3 varchar, v4 time);
-    explain create sink s1 as select v1 as v1, v2 as v2, v3 as v3, v4 as v4 from t1 WITH (
+    explain create sink s1 from t1 WITH (
       connector = 'iceberg',
       type = 'upsert',
       catalog.type = 'mock',
@@ -277,22 +277,20 @@
       s3.region = 'us-east-1',
       s3.access.key = 'hummockadmin',
       s3.secret.key = 'hummockadmin',
-      primary_key = 'v1',
       write_mode = 'merge-on-read',
       format_version = '3',
+      create_table_if_not_exists = 'true',
       enable_pk_index = 'true'
     );
   explain_output: |
     StreamIcebergWithPkIndexDvMerger
     └─StreamExchange { dist: HashShard(file_path) }
-      └─StreamIcebergWithPkIndexWriter { columns: [v1, v2, v3, v4, t1._row_id(hidden)], downstream_pk: [t1.v1] }
-        └─StreamExchange { dist: HashShard($expr1) }
-          └─StreamProject { exprs: [t1.v1, t1.v2, t1.v3, t1.v4, t1._row_id, Row(t1.v1, IcebergTransform('bucket[1]':Varchar, t1.v2), IcebergTransform('truncate[1]':Varchar, t1.v3), null:Time) as $expr1] }
-            └─StreamTableScan { table: t1, columns: [v1, v2, v3, v4, _row_id] }
+      └─StreamIcebergWithPkIndexWriter { columns: [v1, v2, v3, v4, t1._row_id], downstream_pk: [t1._row_id] }
+        └─StreamTableScan { table: t1, columns: [v1, v2, v3, v4, _row_id] }
 - id: create_mock_iceberg_sink_with_pk_index_range_partition
   sql: |
     create table t1 (v1 date, v2 timestamp, v3 timestamp with time zone, v4 timestamp);
-    explain create sink s1 as select v1 as v1, v2 as v2, v3 as v3, v4 as v4 from t1 WITH (
+    explain create sink s1 from t1 WITH (
       connector = 'iceberg',
       type = 'upsert',
       catalog.type = 'mock',
@@ -304,15 +302,15 @@
       s3.region = 'us-east-1',
       s3.access.key = 'hummockadmin',
       s3.secret.key = 'hummockadmin',
-      primary_key = 'v1',
       write_mode = 'merge-on-read',
       format_version = '3',
+      create_table_if_not_exists = 'true',
       enable_pk_index = 'true'
     );
   explain_output: |
     StreamIcebergWithPkIndexDvMerger
     └─StreamExchange { dist: HashShard(file_path) }
-      └─StreamIcebergWithPkIndexWriter { columns: [v1, v2, v3, v4, t1._row_id(hidden)], downstream_pk: [t1.v1] }
+      └─StreamIcebergWithPkIndexWriter { columns: [v1, v2, v3, v4, t1._row_id], downstream_pk: [t1._row_id] }
         └─StreamTableScan { table: t1, columns: [v1, v2, v3, v4, _row_id] }
 - id: create_upsert_jdbc_sink_with_downstream_pk1_separate_sink
   sql: |
@@ -380,3 +378,59 @@
           │ └─StreamTableScan { table: t, columns: [v1, _row_id] }
           └─StreamExchange { dist: HashShard(t.v1) }
             └─StreamTableScan { table: t, columns: [v1, v2, _row_id] }
+- id: iceberg_v3_pk_index_sink_visible_extra
+  sql: |
+    create table u (v1 int primary key, name varchar);
+    create table o (oid bigint primary key, v1 int, p varchar);
+    explain create sink s as select u.v1 as v1, o.oid as v2, u.name as v3, cast('00:00:00' as time) as v4 from u join o on u.v1 = o.v1 WITH (
+      connector = 'iceberg',
+      type = 'upsert',
+      catalog.type = 'mock',
+      catalog.name = 'demo',
+      database.name = 'demo_db',
+      table.name = 'sparse_table',
+      warehouse.path = 's3://icebergdata/demo',
+      s3.endpoint = 'http://127.0.0.1:9301',
+      s3.region = 'us-east-1',
+      s3.access.key = 'hummockadmin',
+      s3.secret.key = 'hummockadmin',
+      write_mode = 'merge-on-read',
+      format_version = '3',
+      enable_pk_index = 'true'
+    );
+  explain_output: |
+    StreamIcebergWithPkIndexDvMerger
+    └─StreamExchange { dist: HashShard(file_path) }
+      └─StreamIcebergWithPkIndexWriter { columns: [v1, v2, v3, v4], downstream_pk: [v1, v2] }
+        └─StreamProject { exprs: [u.v1, o.oid, u.name, '00:00:00':Time, Row(u.v1, IcebergTransform('bucket[1]':Varchar, o.oid), IcebergTransform('truncate[1]':Varchar, u.name), null:Time) as $expr1] }
+          └─StreamProject { exprs: [u.v1, o.oid, u.name, '00:00:00':Time] }
+            └─StreamHashJoin { type: Inner, predicate: u.v1 = o.v1 }
+              ├─StreamExchange { dist: HashShard(u.v1) }
+              │ └─StreamTableScan { table: u, columns: [v1, name] }
+              └─StreamExchange { dist: HashShard(o.v1) }
+                └─StreamTableScan { table: o, columns: [oid, v1] }
+- id: iceberg_v3_pk_index_sink_hidden_extra
+  sql: |
+    create table t (v1 int, v2 bigint, v3 varchar, v4 time, PRIMARY KEY (v1, v2, v3));
+    explain create sink s as select t.v1 from t WITH (
+      connector = 'iceberg',
+      type = 'upsert',
+      catalog.type = 'mock',
+      catalog.name = 'demo',
+      database.name = 'demo_db',
+      table.name = 'sparse_table',
+      warehouse.path = 's3://icebergdata/demo',
+      s3.endpoint = 'http://127.0.0.1:9301',
+      s3.region = 'us-east-1',
+      s3.access.key = 'hummockadmin',
+      s3.secret.key = 'hummockadmin',
+      write_mode = 'merge-on-read',
+      format_version = '3',
+      create_table_if_not_exists = 'true',
+      enable_pk_index = 'true'
+    );
+  explain_output: |
+    StreamIcebergWithPkIndexDvMerger
+    └─StreamExchange { dist: HashShard(file_path) }
+      └─StreamIcebergWithPkIndexWriter { columns: [v1, t.v2, t.v3], downstream_pk: [v1, t.v2, t.v3] }
+        └─StreamTableScan { table: t, columns: [v1, v2, v3] }

--- a/src/frontend/src/handler/create_table.rs
+++ b/src/frontend/src/handler/create_table.rs
@@ -1857,20 +1857,23 @@ pub async fn create_iceberg_engine_table(
 
     let mut sink_with = with_common.clone();
 
-    // Iceberg with pk index does not support auto schema change yet.
-    if !handler_args
+    let enable_pk_index = handler_args
         .with_options
         .get(ENABLE_PK_INDEX)
-        .is_some_and(|val| val.eq_ignore_ascii_case("true"))
-    {
+        .is_some_and(|val| val.eq_ignore_ascii_case("true"));
+
+    // Iceberg with pk index does not support auto schema change yet.
+    if !enable_pk_index {
         sink_with.insert(AUTO_SCHEMA_CHANGE_KEY.to_owned(), "true".to_owned());
     }
 
     if table.append_only {
         sink_with.insert("type".to_owned(), "append-only".to_owned());
     } else {
-        sink_with.insert("primary_key".to_owned(), pks.join(","));
         sink_with.insert("type".to_owned(), "upsert".to_owned());
+        if !enable_pk_index {
+            sink_with.insert("primary_key".to_owned(), pks.join(","));
+        }
     }
     // sink_with.insert(SINK_SNAPSHOT_OPTION.to_owned(), "false".to_owned());
     //

--- a/src/frontend/src/optimizer/plan_node/stream_iceberg_with_pk_index_writer.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_iceberg_with_pk_index_writer.rs
@@ -24,14 +24,12 @@ use risingwave_pb::stream_plan::stream_node::NodeBody;
 use super::stream::prelude::*;
 use crate::TableCatalog;
 use crate::optimizer::plan_node::expr_visitable::ExprVisitable;
-use crate::optimizer::plan_node::utils::{
-    Distill, IndicesDisplay, TableCatalogBuilder, childless_record,
-};
+use crate::optimizer::plan_node::utils::{Distill, TableCatalogBuilder, childless_record};
 use crate::optimizer::plan_node::{
     ExprRewritable, PlanBase, PlanTreeNodeUnary, Stream, StreamNode, StreamPlanRef as PlanRef,
 };
 use crate::optimizer::property::{
-    Distribution, FunctionalDependencySet, MonotonicityMap, WatermarkColumns,
+    Distribution, FunctionalDependencySet, MonotonicityMap, RequiredDist, WatermarkColumns,
 };
 use crate::stream_fragmenter::BuildFragmentGraphState;
 
@@ -67,10 +65,19 @@ impl StreamIcebergWithPkIndexWriter {
             WatermarkColumns::new(),
             MonotonicityMap::new(),
         );
+
+        let downstream_pk = sink
+            .sink_desc()
+            .downstream_pk
+            .as_deref()
+            .context("Missing downstream PK in Iceberg sink desc")?;
+        let input = RequiredDist::shard_by_key(sink.schema().len(), downstream_pk)
+            .streaming_enforce_if_not_satisfies(sink.input())
+            .expect("distribution enforcement is infallible");
         let pk_index_table = build_iceberg_pk_state_table(sink.sink_desc())?;
         Ok(Self {
             base,
-            input: sink.input(),
+            input,
             sink_desc: sink.sink_desc().clone(),
             pk_index_table,
         })
@@ -89,7 +96,7 @@ fn build_iceberg_pk_state_table(sink_desc: &SinkDesc) -> Result<TableCatalog> {
 
     let downstream_pk = sink_desc
         .downstream_pk
-        .as_ref()
+        .as_deref()
         .context("Missing downstream PK in Iceberg sink desc")?;
     for &idx in downstream_pk {
         builder.add_column(&Field::from(&sink_desc.columns[idx].column_desc));
@@ -118,11 +125,13 @@ impl Distill for StreamIcebergWithPkIndexWriter {
         let mut vec = Vec::with_capacity(2);
         vec.push(("columns", column_names));
         if let Some(pk) = &self.sink_desc.downstream_pk {
-            let sink_pk = IndicesDisplay {
-                indices: pk,
-                schema: self.input.schema(),
-            };
-            vec.push(("downstream_pk", sink_pk.distill()));
+            let column_names = pk
+                .iter()
+                .map(|&idx| self.sink_desc.columns[idx].name_with_hidden().to_string())
+                .map(Pretty::from)
+                .collect();
+            let column_names = Pretty::Array(column_names);
+            vec.push(("downstream_pk", column_names));
         }
 
         childless_record("StreamIcebergWithPkIndexWriter", vec)
@@ -221,5 +230,62 @@ mod tests {
         assert_eq!(table.read_prefix_len_hint, 1);
         assert_eq!(table.owner, DEFAULT_SUPER_USER_ID);
         assert_eq!(table.stream_job_status, StreamJobStatus::Creating);
+    }
+
+    #[test]
+    fn test_build_iceberg_pk_state_table_with_multi_column_pk() {
+        // Simulate planner output where the derived pk spans several stream-key columns, e.g. a
+        // hidden upstream column (`order_id`) promoted to visible and carried in verbatim.
+        let mut desc = test_sink_desc();
+        desc.columns.push(ColumnCatalog::visible(ColumnDesc::named(
+            "order_id",
+            ColumnId::new(3),
+            DataType::Int64,
+        )));
+        desc.columns.push(ColumnCatalog::visible(ColumnDesc::named(
+            "shard_id",
+            ColumnId::new(4),
+            DataType::Int64,
+        )));
+        desc.downstream_pk = Some(vec![1, 3, 4]); // v1, order_id, shard_id
+
+        let table = build_iceberg_pk_state_table(&desc).unwrap();
+
+        let names: Vec<_> = table
+            .columns()
+            .iter()
+            .map(|c| c.name().to_owned())
+            .collect();
+        assert_eq!(
+            names,
+            vec!["v1", "order_id", "shard_id", "file_path", "position"]
+        );
+        assert_eq!(table.pk().len(), 3);
+        assert_eq!(table.distribution_key(), &[0, 1, 2]);
+        assert_eq!(table.read_prefix_len_hint, 3);
+    }
+
+    #[test]
+    fn test_build_iceberg_pk_state_table_with_visible_extra_only() {
+        // Simulate planner output: downstream_pk = [user_pk, visible_extra].
+        let mut desc = test_sink_desc();
+        desc.columns.push(ColumnCatalog::visible(ColumnDesc::named(
+            "order_id",
+            ColumnId::new(3),
+            DataType::Int64,
+        )));
+        desc.downstream_pk = Some(vec![1, 3]); // v1, order_id
+
+        let table = build_iceberg_pk_state_table(&desc).unwrap();
+
+        let names: Vec<_> = table
+            .columns()
+            .iter()
+            .map(|c| c.name().to_owned())
+            .collect();
+        assert_eq!(names, vec!["v1", "order_id", "file_path", "position"]);
+        assert_eq!(table.pk().len(), 2);
+        assert_eq!(table.distribution_key(), &[0, 1]);
+        assert_eq!(table.read_prefix_len_hint, 2);
     }
 }

--- a/src/frontend/src/optimizer/plan_node/stream_sink.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_sink.rs
@@ -283,7 +283,7 @@ impl StreamSink {
         target_table: Option<Arc<TableCatalog>>,
         target_table_mapping: Option<Vec<Option<usize>>>,
         definition: String,
-        properties: WithOptionsSecResolved,
+        mut properties: WithOptionsSecResolved,
         format_desc: Option<SinkFormatDesc>,
         partition_info: Option<PartitionComputeInfo>,
         auto_refresh_schema_from_table: Option<Arc<TableCatalog>>,
@@ -291,7 +291,8 @@ impl StreamSink {
         let (sink_type, ignore_delete) =
             Self::derive_sink_type(input.stream_kind(), &properties, format_desc.as_ref())?;
 
-        let columns = derive_columns(input.schema(), out_names, &user_cols)?;
+        let mut emit_pk_extension_notice: Option<String> = None;
+        let mut columns = derive_columns(input.schema(), out_names, &user_cols)?;
         let (pk, _) = derive_pk(
             input.clone(),
             user_distributed_by.clone(),
@@ -300,56 +301,100 @@ impl StreamSink {
         );
         let derived_pk = pk.iter().map(|k| k.column_index).collect_vec();
 
+        let is_iceberg_pk_index = properties.is_iceberg_connector()
+            && properties
+                .get(ENABLE_PK_INDEX)
+                .is_some_and(|v| v.eq_ignore_ascii_case("true"));
+
+        // For Iceberg V3 pk-index sinks, the iceberg primary key is derived entirely from the
+        // upstream stream key, so the user must not specify `primary_key` explicitly.
+        if is_iceberg_pk_index && properties.get(DOWNSTREAM_PK_KEY).is_some() {
+            return Err(ErrorCode::InvalidInputSyntax(
+                "Iceberg V3 sink with `enable_pk_index='true'` does not allow a user-specified `primary_key`. \
+                The primary key is automatically derived from the upstream stream key.".to_owned(),
+            )
+            .into());
+        }
+
         // Get downstream pk from user input, override and perform some checks if applicable.
-        let downstream_pk = {
-            let downstream_pk = properties
-                .get(DOWNSTREAM_PK_KEY)
-                .map(|v| Self::parse_downstream_pk(v, &columns))
-                .transpose()?;
+        let mut downstream_pk = properties
+            .get(DOWNSTREAM_PK_KEY)
+            .map(|v| Self::parse_downstream_pk(v, &columns))
+            .transpose()?;
 
-            if let Some(t) = &target_table {
-                let user_defined_primary_key_table = t.row_id_index.is_none();
-                let sink_is_append_only = sink_type.is_append_only();
+        if let Some(t) = &target_table {
+            let user_defined_primary_key_table = t.row_id_index.is_none();
+            let sink_is_append_only = sink_type.is_append_only();
 
-                if !user_defined_primary_key_table && !sink_is_append_only {
-                    return Err(RwError::from(ErrorCode::BindError(
+            if !user_defined_primary_key_table && !sink_is_append_only {
+                return Err(RwError::from(ErrorCode::BindError(
                         "Only append-only sinks can sink to a table without primary keys. please try to add type = 'append-only' in the with option. e.g. create sink s into t as select * from t1 with (type = 'append-only')".to_owned(),
                     )));
-                }
+            }
 
-                if t.append_only && !sink_is_append_only {
-                    return Err(RwError::from(ErrorCode::BindError(
+            if t.append_only && !sink_is_append_only {
+                return Err(RwError::from(ErrorCode::BindError(
                         "Only append-only sinks can sink to a append only table. please try to add type = 'append-only' in the with option. e.g. create sink s into t as select * from t1 with (type = 'append-only')".to_owned(),
                     )));
-                }
+            }
 
-                if sink_is_append_only {
-                    None
-                } else {
-                    let target_table_mapping = target_table_mapping.unwrap();
-                    Some(t.pk()
+            if sink_is_append_only {
+                downstream_pk = None;
+            } else {
+                let target_table_mapping = target_table_mapping.unwrap();
+                let pk = t.pk()
                         .iter()
                         .map(|c| {
                             target_table_mapping[c.column_index].ok_or_else(
                                 || ErrorCode::InvalidInputSyntax("When using non append only sink into table, the primary key of the table must be included in the sink result.".to_owned()).into())
                         })
-                        .try_collect::<_, _, RwError>()?)
-                }
-            } else if properties.get(CREATE_TABLE_IF_NOT_EXISTS) == Some(&"true".to_owned())
-                && sink_type == SinkType::Upsert
-                && downstream_pk.is_none()
-            {
-                Some(derived_pk.clone())
-            } else if properties.is_iceberg_connector()
-                && sink_type == SinkType::Upsert
-                && downstream_pk.is_none()
-            {
-                // If user doesn't specify the downstream primary key, we use the stream key as the pk.
-                Some(derived_pk.clone())
-            } else {
-                downstream_pk
+                        .try_collect::<_, _, RwError>()?;
+                downstream_pk = Some(pk);
             }
-        };
+        } else if downstream_pk.is_none()
+            && sink_type == SinkType::Upsert
+            && (properties
+                .get(CREATE_TABLE_IF_NOT_EXISTS)
+                .is_some_and(|v| v.eq_ignore_ascii_case("true"))
+                || properties.is_iceberg_connector())
+        {
+            downstream_pk = Some(derived_pk.clone())
+        } else if is_iceberg_pk_index {
+            // For Iceberg V3 pk-index sinks: derive the iceberg primary key entirely from the
+            // upstream stream key. Every stream-key column becomes a pk column; hidden ones are
+            // promoted to visible so they are carried into the iceberg table verbatim.
+            let (pk, promoted) = promote_iceberg_pk_index_stream_key(&input, &mut columns)?;
+
+            let pk_names = pk
+                .iter()
+                .map(|&i| columns[i].name().to_owned())
+                .collect::<Vec<_>>()
+                .join(",");
+
+            // Promoting hidden stream-key columns adds new columns to the iceberg table, which is
+            // only possible at table-creation time. Sinking into an existing iceberg table would
+            // silently drop them and corrupt the pk index, so require `create_table_if_not_exists`.
+            if promoted
+                && properties
+                    .get(CREATE_TABLE_IF_NOT_EXISTS)
+                    .map(|v| v.as_str())
+                    != Some("true")
+            {
+                return Err(ErrorCode::InvalidInputSyntax(
+                    "Iceberg sink with `enable_pk_index='true'` requires `create_table_if_not_exists='true'` \
+                     because the planner needs to add the hidden upstream stream-key columns to the iceberg table. \
+                     Existing iceberg tables cannot be extended in-place by this sink."
+                        .to_owned(),
+                )
+                .into());
+            }
+
+            // Inform the user of the derived iceberg primary key, since they did not (and
+            // cannot) specify it explicitly.
+            emit_pk_extension_notice = Some(pk_names.clone());
+            properties.insert(DOWNSTREAM_PK_KEY.to_owned(), pk_names);
+            downstream_pk = Some(pk);
+        }
 
         // Since we've already rejected empty pk in `parse_downstream_pk`, if we still get an empty pk here,
         // it's likely that the derived stream key is used and it's empty, which is possible in cases of
@@ -408,6 +453,7 @@ impl StreamSink {
                 }
             }
         }
+
         let mut extra_partition_col_idx = None;
 
         let required_dist = match input.distribution() {
@@ -426,7 +472,7 @@ impl StreamSink {
                         RequiredDist::hash_shard(downstream_pk)
                     }
                     Some(s) if s == ICEBERG_SINK => {
-                        let (required_dist, new_input, partition_col_idx) =
+                        let (default_dist, new_input, partition_col_idx) =
                             Self::derive_iceberg_sink_distribution(
                                 input,
                                 partition_info,
@@ -434,7 +480,14 @@ impl StreamSink {
                             )?;
                         input = new_input;
                         extra_partition_col_idx = partition_col_idx;
-                        required_dist
+                        // V3 pk-index sinks require pk-locality so state-table lookups are local.
+                        // Override the partition-col shuffle in that case; partition co-location is
+                        // intentionally sacrificed.
+                        if is_iceberg_pk_index && let Some(pk) = &downstream_pk {
+                            RequiredDist::shard_by_key(input.schema().len(), pk)
+                        } else {
+                            default_dist
+                        }
                     }
                     _ => {
                         assert_matches!(user_distributed_by, RequiredDist::Any);
@@ -580,7 +633,15 @@ impl StreamSink {
             input
         };
 
-        Ok(Self::new(input, sink_desc, log_store_type))
+        let sink = Self::new(input, sink_desc, log_store_type);
+        if let Some(pk_names) = emit_pk_extension_notice {
+            sink.base.ctx().session_ctx().notice_to_user(format!(
+                "Iceberg V3 sink `{}`: the iceberg primary key was automatically derived from \
+                 the upstream stream key as ({}).",
+                sink.sink_desc.name, pk_names,
+            ));
+        }
+        Ok(sink)
     }
 
     fn sink_type_in_prop(properties: &WithOptionsSecResolved) -> Result<Option<SinkType>> {
@@ -755,7 +816,7 @@ impl StreamSink {
     /// Convert this `StreamSink` into a `PlanRef`.
     ///
     /// For Iceberg pk index sinks, this rewrites the plan into
-    /// `Upstream → Writer → Exchange(Single) → DvMerger` instead of a single `SinkNode`.
+    /// `Upstream → Writer → Exchange(Hash) → DvMerger` instead of a single `SinkNode`.
     /// For all other sinks, returns `self` as-is.
     pub fn into_stream_plan(self) -> Result<PlanRef> {
         use super::{StreamIcebergWithPkIndexDvMerger, StreamIcebergWithPkIndexWriter};
@@ -785,6 +846,41 @@ pub fn is_iceberg_with_pk_index_sink(sink_desc: &SinkDesc) -> Result<bool> {
         .get(ENABLE_PK_INDEX)
         .is_some_and(|v| v.eq_ignore_ascii_case("true"));
     Ok(res)
+}
+
+/// For Iceberg pk-index sinks, promote the `downstream_pk` and sink columns that use the
+/// full upstream stream key as the iceberg primary key.
+///
+/// Every stream-key column becomes an iceberg pk column. A stream-key column that is hidden
+/// (e.g. a join key the user did not `SELECT`, or a RisingWave-internal column such as
+/// `_row_id`) is promoted to visible (`is_hidden = false`) so it is carried into the iceberg
+/// table, keeping its type.
+///
+/// Returns `(downstream_pk, promoted)` where `promoted` is true if any hidden column was promoted
+fn promote_iceberg_pk_index_stream_key(
+    input: &PlanRef,
+    columns: &mut Vec<ColumnCatalog>,
+) -> Result<(Vec<usize>, bool)> {
+    let mut promoted = false;
+    let stream_key = input.expect_stream_key();
+    if stream_key.is_empty() {
+        bail_invalid_input_syntax!(
+            "Iceberg V3 sink with `enable_pk_index='true'` requires a non-empty upstream stream key \
+             to derive the primary key from."
+        );
+    }
+
+    for &i in stream_key {
+        if !columns[i].is_hidden {
+            continue;
+        }
+        // Promote the hidden stream-key column to visible so it is carried into iceberg.
+        columns[i].is_hidden = false;
+        promoted = true;
+    }
+
+    let downstream_pk = stream_key.to_vec();
+    Ok((downstream_pk, promoted))
 }
 
 impl PlanTreeNodeUnary<Stream> for StreamSink {

--- a/src/stream/src/executor/iceberg_with_pk_index/writer.rs
+++ b/src/stream/src/executor/iceberg_with_pk_index/writer.rs
@@ -84,12 +84,13 @@ where
     /// State table storing the PK index: `pk_columns` -> (`file_path`, `position`).
     /// Schema: [`pk_col_0`, ..., `pk_col_n`, `file_path`: Varchar, `position`: Int64]
     pk_index_state_table: StateTable<S>,
+    /// Indices of the columns actually written to Iceberg
+    write_col_indices: Vec<usize>,
     /// The Iceberg data file writer.
     writer: W,
     /// Buffer for accumulating delete position messages before the next barrier flush.
     delete_position_buffer: Option<DataChunkBuilder>,
     chunk_size: usize,
-    pk_matched: bool,
     sink_id: SinkId,
     local_barrier_manager: LocalBarrierManager,
 }
@@ -105,9 +106,9 @@ where
         input: Executor,
         pk_indices: Vec<usize>,
         pk_index_state_table: StateTable<S>,
+        write_col_indices: Vec<usize>,
         writer: W,
         chunk_size: usize,
-        pk_matched: bool,
         sink_id: SinkId,
         local_barrier_manager: LocalBarrierManager,
     ) -> Self {
@@ -116,10 +117,10 @@ where
             input: Some(input),
             pk_indices,
             pk_index_state_table,
+            write_col_indices,
             writer,
             delete_position_buffer: None,
             chunk_size,
-            pk_matched,
             sink_id,
             local_barrier_manager,
         }
@@ -164,13 +165,10 @@ where
     // chunk in the same checkpoint observes earlier writes/deletes via the state table.
     #[try_stream(ok = DataChunk, error = StreamExecutorError)]
     async fn process_chunk(&mut self, chunk: StreamChunk) {
-        // PK uniqueness within a chunk is not guaranteed by upstream. Run compaction ourselves so
-        // the loop below can stay linear. `Warn` tolerates inconsistent upstream PK rather than
-        // panic.
         let chunk = compact_chunk_inline::<{ output_kind::RETRACT }>(
             chunk,
             &self.pk_indices,
-            InconsistencyBehavior::Warn,
+            InconsistencyBehavior::Panic,
         );
 
         let mut delete_position_buffer = self
@@ -189,15 +187,6 @@ where
         for record in chunk.records() {
             match record {
                 Record::Insert { new_row } => {
-                    if !self.pk_matched {
-                        let pk_row = new_row.project(&pk_indices);
-                        if let Some(chunk) = self
-                            .delete_existing_row(pk_row, &mut delete_position_buffer)
-                            .await?
-                        {
-                            yield chunk;
-                        }
-                    }
                     let overflow = insert_chunk.append_one_row(new_row);
                     debug_assert!(overflow.is_none(), "insert chunk exceeds capacity");
                     insert_pks.push(new_row.project(&pk_indices));
@@ -229,7 +218,8 @@ where
 
         if !insert_pks.is_empty() {
             let insert_chunk = insert_chunk.finish();
-            let positions = self.writer.write_chunk(insert_chunk).await?;
+            let write_chunk = insert_chunk.project(&self.write_col_indices);
+            let positions = self.writer.write_chunk(write_chunk).await?;
 
             for (pk, pos) in insert_pks.into_iter().zip_eq_fast(positions) {
                 let mut index_row_data = Vec::with_capacity(pk_indices.len() + 2);
@@ -435,22 +425,28 @@ mod tests {
 
     impl WriterTestHarness {
         async fn new() -> Self {
+            Self::with_schema(input_schema(), vec![0, 1]).await
+        }
+
+        /// Build a harness with a custom input schema and `write_col_indices`. The PK is always
+        /// the first column (Int64) so the shared `create_pk_index_state_table` schema applies.
+        async fn with_schema(input_schema: Schema, write_col_indices: Vec<usize>) -> Self {
             let store = MemoryStateStore::new();
             let state_table = create_pk_index_state_table(store, TableId::new(1)).await;
             let writer = IcebergWriterMock::new(TEST_FILE_PATH);
             let written_chunks = writer.written_chunks();
 
             let (tx, source) = MockSource::channel();
-            let source = source.into_executor(input_schema(), vec![0]);
+            let source = source.into_executor(input_schema, vec![0]);
             let lbm = LocalBarrierManager::for_test();
             let executor = WriterExecutor::new(
                 ActorContext::for_test(123),
                 source,
                 vec![0],
                 state_table,
+                write_col_indices,
                 writer,
                 CHUNK_SIZE,
-                true,
                 SinkId::new(0),
                 lbm,
             )
@@ -522,6 +518,42 @@ mod tests {
                 + 1 10
                 + 2 20
                 + 3 30",
+            )]
+        );
+    }
+
+    #[tokio::test]
+    async fn test_writer_executor_projects_away_hidden_columns() {
+        // Input carries a third (hidden) column that is not part of the Iceberg schema, e.g. a
+        // RisingWave-internal column carried only for PK derivation. The writer must project the
+        // chunk down to `write_col_indices` before handing it to the Iceberg writer, otherwise
+        // the column count mismatches the table schema.
+        let mut harness = WriterTestHarness::with_schema(
+            Schema::new(vec![
+                Field::unnamed(DataType::Int64),
+                Field::unnamed(DataType::Int64),
+                Field::unnamed(DataType::Int64),
+            ]),
+            vec![0, 1],
+        )
+        .await;
+        harness.init().await;
+
+        harness.push_pretty_chunk(
+            " I I I
+            + 1 10 100
+            + 2 20 200",
+        );
+        harness.push_barrier(2);
+        harness.expect_barrier().await;
+
+        // The written chunk drops the third column.
+        assert_eq!(
+            harness.compacted_written_chunks(),
+            vec![StreamChunk::from_pretty(
+                " I I
+                + 1 10
+                + 2 20",
             )]
         );
     }
@@ -663,8 +695,12 @@ mod tests {
         );
     }
 
+    /// Two deletes for the same PK within one chunk are inconsistent input: the PK is derived from
+    /// the upstream stream key, which guarantees uniqueness within a chunk. The writer panics on
+    /// compaction rather than silently swallowing the duplicate.
     #[tokio::test]
-    async fn test_writer_executor_delete_then_delete_emits_one_position_delete() {
+    #[should_panic(expected = "inconsistency happened")]
+    async fn test_writer_executor_duplicate_delete_in_same_chunk_panics() {
         let mut harness = WriterTestHarness::new().await;
         harness.init().await;
 
@@ -682,17 +718,8 @@ mod tests {
         );
         harness.push_barrier(3);
 
-        harness
-            .expect_position_chunk(vec![test_file_position(0)])
-            .await;
+        // Processing the duplicate-delete chunk panics during compaction.
         harness.expect_barrier().await;
-        assert_eq!(
-            harness.written_chunks(),
-            vec![StreamChunk::from_pretty(
-                " I I
-                + 1 10",
-            )]
-        );
     }
 
     #[tokio::test]
@@ -723,8 +750,11 @@ mod tests {
         );
     }
 
+    /// Two inserts for the same PK within one chunk are inconsistent input: the upstream stream key
+    /// guarantees PK uniqueness within a chunk, so the writer panics on compaction.
     #[tokio::test]
-    async fn test_writer_executor_insert_then_insert_in_same_chunk_keeps_latest_row() {
+    #[should_panic(expected = "inconsistency happened")]
+    async fn test_writer_executor_duplicate_insert_in_same_chunk_panics() {
         let mut harness = WriterTestHarness::new().await;
         harness.init().await;
 
@@ -735,24 +765,7 @@ mod tests {
         );
         harness.push_barrier(2);
 
-        harness.expect_barrier().await;
-        assert_eq!(
-            harness.compacted_written_chunks(),
-            vec![StreamChunk::from_pretty(
-                " I I
-                + 1 99",
-            )]
-        );
-
-        harness.push_pretty_chunk(
-            " I I
-            - 1 99",
-        );
-        harness.push_barrier(3);
-
-        harness
-            .expect_position_chunk(vec![test_file_position(0)])
-            .await;
+        // Processing the duplicate-insert chunk panics during compaction.
         harness.expect_barrier().await;
     }
 

--- a/src/stream/src/from_proto/iceberg_with_pk_index/writer.rs
+++ b/src/stream/src/from_proto/iceberg_with_pk_index/writer.rs
@@ -25,7 +25,7 @@ use risingwave_pb::stream_plan::IcebergWithPkIndexWriterNode;
 use risingwave_storage::StateStore;
 
 use super::super::sink::build_sink_param;
-use crate::common::table::state_table::StateTableBuilder;
+use crate::common::table::state_table::{StateTableBuilder, StateTableOpConsistencyLevel};
 use crate::error::StreamResult;
 use crate::executor::{Executor, IcebergWriterImpl, StreamExecutorError, WriterExecutor};
 use crate::from_proto::ExecutorBuilder;
@@ -65,8 +65,17 @@ impl ExecutorBuilder for IcebergWithPkIndexWriterExecutorBuilder {
             return Err(anyhow!("missing downstream pk in iceberg sink desc").into());
         }
 
-        let (sink_param, _columns) =
+        let (sink_param, columns) =
             build_sink_param(sink_desc, properties_with_secret, ICEBERG_SINK)?;
+
+        // Indices of the visible columns, i.e. the ones actually written to Iceberg. Hidden
+        // columns carried by the input chunk for PK derivation are projected away by the writer.
+        let write_col_indices = columns
+            .iter()
+            .enumerate()
+            .filter(|(_, col)| !col.is_hidden)
+            .map(|(idx, _)| idx)
+            .collect::<Vec<_>>();
 
         let table = create_and_validate_table_impl(&config, &sink_param)
             .await
@@ -78,6 +87,7 @@ impl ExecutorBuilder for IcebergWithPkIndexWriterExecutorBuilder {
             params.vnode_bitmap.clone().map(Arc::new),
         )
         .enable_preload_all_rows_by_config(&params.config)
+        .with_op_consistency_level(StateTableOpConsistencyLevel::Inconsistent)
         .build()
         .await;
 
@@ -100,20 +110,15 @@ impl ExecutorBuilder for IcebergWithPkIndexWriterExecutorBuilder {
             time_zone: params.actor_context.time_zone,
         };
         let writer = IcebergWriterImpl::build(&config, table, &writer_param)?;
-        let pk_matched = params
-            .info
-            .stream_key
-            .iter()
-            .all(|i| pk_indices.contains(i));
 
         let exec = WriterExecutor::new(
             params.actor_context,
             input,
             pk_indices,
             pk_index_state_table,
+            write_col_indices,
             writer,
             params.config.developer.chunk_size,
-            pk_matched,
             sink_id,
             params.local_barrier_manager.clone(),
         );

--- a/src/tests/simulation/tests/integration_tests/sink/iceberg_v3_2pc/utils.rs
+++ b/src/tests/simulation/tests/integration_tests/sink/iceberg_v3_2pc/utils.rs
@@ -87,8 +87,6 @@ pub async fn start_v3_test_cluster_with_sink(parallelism: usize) -> Result<V3Tes
         .run(&format!("SET streaming_parallelism = {}", parallelism))
         .await?;
 
-    // TABLE with PRIMARY KEY: stream key is (id,) which the MV inherits, so the
-    // downstream sink's `primary_key = 'id'` matches the upstream stream key.
     session
         .run("CREATE TABLE test_v3_table (id int PRIMARY KEY, name varchar)")
         .await?;
@@ -114,7 +112,6 @@ pub async fn start_v3_test_cluster_with_sink(parallelism: usize) -> Result<V3Tes
                is_exactly_once = 'true', \
                enable_pk_index = 'true', \
                format_version = '3', \
-               primary_key = 'id', \
                type = 'upsert' \
              )",
         )


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

### Motivation

For Iceberg V3 sinks with `enable_pk_index='true'`, the iceberg primary key previously had to be declared by the user. When the user-declared PK did not cover the full upstream stream key, multiple distinct upstream rows could collapse onto the same iceberg PK and cause **double-insert inconsistency**, silently losing rows. This PR makes the planner derive the iceberg PK from the upstream stream key, guaranteeing every upstream row is preserved.

### Behavior changes

 Users may no longer set `primary_key` when `enable_pk_index='true'`; the PK is now derived automatically from the upstream stream key. Stream-key columns that are required but not part of the sink output (e.g. a hidden _row_id) are packed into a single synthetic column `_rw_extra_pk`, via a new internal scalar function `_rw_pack_pk`.

### Tests

- Planner tests (`sink.yaml`): PK extension with visible and hidden extras, automatic derivation, append-only sinks (no derivation), and the create_table_if_not_exists guardrail.
- E2E (iceberg_sink_v3_derive_pk.slt): end-to-end coverage including rows that share a declared PK being preserved, UPDATE/DELETE correctness, pk-less upstream (hidden _row_id packed into _rw_extra_pk), and verification that _rw_extra_pk is populated and unique per row.

## Checklist

- [x] I have written necessary rustdoc comments.
- [x] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [x] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
