### PR TITLE
fix(meta): keep added workers in control stream manager

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -47,10 +47,6 @@ labels:
   files:
   - "src\\/meta\\/model\\/migration\\/.*.rs"
 
-- label: "ci/run-e2e-test-other-backends"
-  files:
-  - "src\\/meta\\/.*.rs"
-
 - label: "ci/run-e2e-iceberg-tests"
   files:
   - ".*iceberg.*"

--- a/src/meta/src/barrier/partial_graph.rs
+++ b/src/meta/src/barrier/partial_graph.rs
@@ -335,7 +335,7 @@ impl PartialGraphManager {
     pub(super) async fn add_worker(
         &mut self,
         node: WorkerNode,
-        context: &impl GlobalBarrierWorkerContext,
+        context: Arc<impl GlobalBarrierWorkerContext>,
     ) {
         self.control_stream_manager
             .add_worker(node, existing_graphs(&self.graphs), &self.term_id, context)

--- a/src/meta/src/barrier/rpc.rs
+++ b/src/meta/src/barrier/rpc.rs
@@ -197,7 +197,7 @@ impl ControlStreamManager {
         node: WorkerNode,
         partial_graphs: impl Iterator<Item = PartialGraphId>,
         term_id: &String,
-        context: &impl GlobalBarrierWorkerContext,
+        context: Arc<impl GlobalBarrierWorkerContext>,
     ) {
         let node_id = node.id;
         if let Entry::Occupied(entry) = self.workers.entry(node_id) {
@@ -267,6 +267,21 @@ impl ControlStreamManager {
             }
         }
         error!(?node_host, "fail to create worker node after retry");
+        assert!(
+            self.workers
+                .insert(
+                    node_id,
+                    (
+                        node.clone(),
+                        WorkerNodeState::Reconnecting(ControlStreamManager::retry_connect(
+                            node,
+                            term_id.to_owned(),
+                            context,
+                        ))
+                    )
+                )
+                .is_none()
+        );
     }
 
     pub(super) fn remove_worker(&mut self, node: WorkerNode) {

--- a/src/meta/src/barrier/worker.rs
+++ b/src/meta/src/barrier/worker.rs
@@ -510,8 +510,11 @@ impl<C: GlobalBarrierWorkerContext> GlobalBarrierWorker<C> {
                     info!(?changed_worker, "worker changed");
 
                     match changed_worker {
-                        ActiveStreamingWorkerChange::Add(node) | ActiveStreamingWorkerChange::Update(node) => {
-                            self.partial_graph_manager.add_worker(node, &*self.context).await;
+                        ActiveStreamingWorkerChange::Add(node)
+                        | ActiveStreamingWorkerChange::Update(node) => {
+                            self.partial_graph_manager
+                                .add_worker(node, self.context.clone())
+                                .await;
                         }
                         ActiveStreamingWorkerChange::Remove(node) => {
                             self.partial_graph_manager.remove_worker(node);


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

- Closes #25835
- Keep newly activated streaming workers registered in `ControlStreamManager` even if the initial control-stream connection fails after retries.
- After the initial retry window is exhausted, the worker is inserted as `Reconnecting`, reusing the existing background reconnect path. This preserves the invariant that every active streaming worker can be resolved by `ControlStreamManager::host_addr`, while still keeping the `host_addr` unwrap as an invariant check.
- This avoids a meta panic when a newly scheduled actor is placed on an active worker whose control stream was not registered due to transient connection failure.

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [x] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

Not required. This is an internal meta failover/control-stream correctness fix.

</details>
