### PR TITLE
fix(iceberg): protect compaction snapshots from GC

### DIFF
--- a/src/connector/src/connector_common/iceberg/compaction.rs
+++ b/src/connector/src/connector_common/iceberg/compaction.rs
@@ -14,8 +14,17 @@
 
 use crate::sink::catalog::SinkId;
 
+#[derive(Debug, Clone)]
+pub struct IcebergCommittedSnapshot {
+    pub branch: String,
+    pub snapshot_id: i64,
+    pub timestamp_ms: i64,
+}
+
+#[derive(Debug, Clone)]
 pub struct IcebergSinkCompactionUpdate {
     // runtime event information
     pub sink_id: SinkId,
     pub force_compaction: bool,
+    pub observed_snapshot: IcebergCommittedSnapshot,
 }

--- a/src/connector/src/connector_common/mod.rs
+++ b/src/connector/src/connector_common/mod.rs
@@ -29,7 +29,7 @@ pub use connection::{
     ConfluentSchemaRegistryConnection, Connection, ElasticsearchConnection, IcebergConnection,
     KafkaConnection, SCHEMA_REGISTRY_CONNECTION_TYPE, read_kafka_log_level, validate_connection,
 };
-pub use iceberg::compaction::IcebergSinkCompactionUpdate;
+pub use iceberg::compaction::{IcebergCommittedSnapshot, IcebergSinkCompactionUpdate};
 
 mod iceberg;
 #[cfg(not(madsim))]

--- a/src/connector/src/sink/iceberg/commit.rs
+++ b/src/connector/src/sink/iceberg/commit.rs
@@ -40,7 +40,7 @@ use tokio_retry::strategy::{ExponentialBackoff, jitter};
 use tracing::warn;
 
 use super::{GLOBAL_SINK_METRICS, IcebergConfig, SinkError, commit_branch};
-use crate::connector_common::IcebergSinkCompactionUpdate;
+use crate::connector_common::{IcebergCommittedSnapshot, IcebergSinkCompactionUpdate};
 use crate::sink::catalog::SinkId;
 use crate::sink::{Result, SinglePhaseCommitCoordinator, SinkParam, TwoPhaseCommitCoordinator};
 
@@ -237,6 +237,54 @@ pub struct IcebergSinkCommitter {
 }
 
 impl IcebergSinkCommitter {
+    fn latest_observed_snapshot(&self) -> Option<IcebergCommittedSnapshot> {
+        let branch = commit_branch(self.config.r#type.as_str(), self.config.write_mode);
+        self.table
+            .metadata()
+            .snapshot_for_ref(&branch)
+            .map(|snapshot| IcebergCommittedSnapshot {
+                branch,
+                snapshot_id: snapshot.snapshot_id(),
+                timestamp_ms: snapshot.timestamp_ms(),
+            })
+    }
+
+    fn notify_iceberg_compaction_scheduler(&self, force_compaction: bool) {
+        let Some(iceberg_compact_stat_sender) = &self.iceberg_compact_stat_sender else {
+            return;
+        };
+
+        let Some(observed_snapshot) = self.latest_observed_snapshot() else {
+            warn!(
+                sink_id = %self.sink_id,
+                "skip iceberg compaction update because no observed snapshot is available"
+            );
+            return;
+        };
+
+        let observed_snapshot_id = observed_snapshot.snapshot_id;
+        let observed_snapshot_timestamp_ms = observed_snapshot.timestamp_ms;
+        let observed_snapshot_branch = observed_snapshot.branch.clone();
+
+        if iceberg_compact_stat_sender
+            .send(IcebergSinkCompactionUpdate {
+                sink_id: self.sink_id,
+                force_compaction,
+                observed_snapshot,
+            })
+            .is_err()
+        {
+            warn!(
+                sink_id = %self.sink_id,
+                force_compaction,
+                observed_snapshot_id,
+                observed_snapshot_timestamp_ms,
+                observed_snapshot_branch = %observed_snapshot_branch,
+                "failed to send iceberg compaction update"
+            );
+        }
+    }
+
     // Reload table and guarantee current schema_id and partition_spec_id matches
     // given `schema_id` and `partition_spec_id`
     async fn reload_table(
@@ -615,16 +663,7 @@ impl IcebergSinkCommitter {
 
         tracing::debug!("Succeeded to commit to iceberg table in epoch {epoch}.");
 
-        if let Some(iceberg_compact_stat_sender) = &self.iceberg_compact_stat_sender
-            && iceberg_compact_stat_sender
-                .send(IcebergSinkCompactionUpdate {
-                    sink_id: self.sink_id,
-                    force_compaction: false,
-                })
-                .is_err()
-        {
-            warn!("failed to send iceberg compaction stats");
-        }
+        self.notify_iceberg_compaction_scheduler(false);
 
         Ok(())
     }
@@ -862,21 +901,12 @@ impl IcebergSinkCommitter {
                     max_snapshots
                 );
 
-                if let Some(iceberg_compact_stat_sender) = &self.iceberg_compact_stat_sender
-                    && iceberg_compact_stat_sender
-                        .send(IcebergSinkCompactionUpdate {
-                            sink_id: self.sink_id,
-                            force_compaction: true,
-                        })
-                        .is_err()
-                {
-                    tracing::warn!("failed to send iceberg compaction stats");
-                }
+                self.notify_iceberg_compaction_scheduler(true);
 
                 // Wait for 30 seconds before checking again
                 tokio::time::sleep(Duration::from_secs(30)).await;
 
-                // Reload table to get latest snapshots
+                // Refresh table after the wait so the next check sees latest snapshots.
                 self.table = self.config.load_table().await?;
             }
         }

--- a/src/meta/src/manager/iceberg_compaction/gc.rs
+++ b/src/meta/src/manager/iceberg_compaction/gc.rs
@@ -22,6 +22,14 @@ use tokio::task::JoinHandle;
 
 use super::*;
 
+const MAX_SNAPSHOT_AGE_MS_DEFAULT: i64 = 24 * 60 * 60 * 1000;
+
+fn snapshot_expiration_cutoff_ms(iceberg_config: &IcebergConfig, now: i64) -> i64 {
+    iceberg_config
+        .snapshot_expiration_timestamp_ms(now)
+        .unwrap_or(now - MAX_SNAPSHOT_AGE_MS_DEFAULT)
+}
+
 impl IcebergCompactionManager {
     pub fn gc_loop(manager: Arc<Self>, interval_sec: u64) -> (JoinHandle<()>, Sender<()>) {
         assert!(
@@ -77,7 +85,6 @@ impl IcebergCompactionManager {
     }
 
     pub async fn check_and_expire_snapshots(&self, sink_id: SinkId) -> MetaResult<()> {
-        const MAX_SNAPSHOT_AGE_MS_DEFAULT: i64 = 24 * 60 * 60 * 1000;
         let now = chrono::Utc::now().timestamp_millis();
 
         let iceberg_config = self.load_iceberg_config(sink_id).await?;
@@ -85,6 +92,49 @@ impl IcebergCompactionManager {
             let mut guard = self.inner.write();
             guard.snapshot_expiration_sink_ids.remove(&sink_id);
             return Ok(());
+        }
+
+        let processing_gc_watermark_snapshot = {
+            let guard = self.inner.read();
+            guard
+                .sink_schedules
+                .get(&sink_id)
+                .and_then(|track| track.processing_gc_watermark_snapshot())
+                .map(|snapshot| snapshot.cloned())
+        };
+
+        let mut snapshot_expiration_timestamp_ms =
+            snapshot_expiration_cutoff_ms(&iceberg_config, now);
+
+        // Outer `None` means no active compaction task. Inner `None` means an
+        // active task exists without a safe snapshot watermark, so GC skips.
+        match processing_gc_watermark_snapshot {
+            None => {}
+            Some(None) => {
+                tracing::info!(
+                    catalog_name = iceberg_config.catalog_name(),
+                    table_name = iceberg_config.full_table_name()?.to_string(),
+                    %sink_id,
+                    "Skip snapshots expiration because an iceberg compaction task has no observed GC watermark",
+                );
+                return Ok(());
+            }
+            Some(Some(snapshot)) => {
+                // A running compaction task may still need snapshots up to its
+                // captured watermark, so GC must not expire newer snapshots.
+                snapshot_expiration_timestamp_ms =
+                    snapshot_expiration_timestamp_ms.min(snapshot.timestamp_ms);
+                tracing::info!(
+                    catalog_name = iceberg_config.catalog_name(),
+                    table_name = iceberg_config.full_table_name()?.to_string(),
+                    %sink_id,
+                    gc_watermark_branch = %snapshot.branch,
+                    gc_watermark_snapshot_id = snapshot.snapshot_id,
+                    gc_watermark_timestamp_ms = snapshot.timestamp_ms,
+                    protected_snapshot_expiration_timestamp_ms = snapshot_expiration_timestamp_ms,
+                    "Protect snapshots expiration with iceberg compaction GC watermark",
+                );
+            }
         }
 
         let catalog = iceberg_config.create_catalog().await?;
@@ -96,14 +146,6 @@ impl IcebergCompactionManager {
         let metadata = table.metadata();
         let mut snapshots = metadata.snapshots().collect_vec();
         snapshots.sort_by_key(|s| s.timestamp_ms());
-
-        let default_snapshot_expiration_timestamp_ms = now - MAX_SNAPSHOT_AGE_MS_DEFAULT;
-
-        let snapshot_expiration_timestamp_ms =
-            match iceberg_config.snapshot_expiration_timestamp_ms(now) {
-                Some(timestamp) => timestamp,
-                None => default_snapshot_expiration_timestamp_ms,
-            };
 
         if snapshots.is_empty()
             || snapshots.first().unwrap().timestamp_ms() > snapshot_expiration_timestamp_ms

--- a/src/meta/src/manager/iceberg_compaction/schedule.rs
+++ b/src/meta/src/manager/iceberg_compaction/schedule.rs
@@ -18,7 +18,9 @@ use std::time::{Duration, Instant};
 
 use itertools::Itertools;
 use parking_lot::RwLock;
-use risingwave_connector::connector_common::IcebergSinkCompactionUpdate;
+use risingwave_connector::connector_common::{
+    IcebergCommittedSnapshot, IcebergSinkCompactionUpdate,
+};
 use risingwave_connector::sink::SinkParam;
 use risingwave_connector::sink::catalog::{SinkCatalog, SinkId};
 use risingwave_connector::sink::iceberg::{
@@ -51,6 +53,7 @@ enum CompactionTrackState {
         task_type: TaskType,
         next_compaction_time_on_failure: Instant,
         pending_commit_count_at_dispatch: usize,
+        gc_watermark_snapshot: Option<IcebergCommittedSnapshot>,
     },
     /// Compaction task is in-flight. `report_deadline` acts as a lease; if it
     /// expires before a report arrives, the task becomes retryable.
@@ -59,6 +62,7 @@ enum CompactionTrackState {
         task_type: TaskType,
         pending_commit_count_at_dispatch: usize,
         report_deadline: Instant,
+        gc_watermark_snapshot: Option<IcebergCommittedSnapshot>,
     },
 }
 
@@ -78,6 +82,7 @@ pub(super) struct CompactionTrack {
     report_timeout: Duration,
     last_config_refresh_at: Instant,
     pending_commit_count: usize,
+    latest_observed_snapshot: Option<IcebergCommittedSnapshot>,
     /// Track lifecycle policy after a selected task finishes. Manual compaction
     /// uses `RemoveTrack` only while automatic compaction is disabled; a later
     /// config refresh can turn the temporary track into a normal schedule track.
@@ -100,6 +105,7 @@ impl CompactionTrack {
             report_timeout,
             last_config_refresh_at: now,
             pending_commit_count: 0,
+            latest_observed_snapshot: None,
             finish_action: CompactionTrackFinishAction::KeepTrack,
             state: CompactionTrackState::Idle {
                 next_compaction_time: now + Duration::from_secs(trigger_interval_sec),
@@ -134,6 +140,10 @@ impl CompactionTrack {
         let has_commits = self.pending_commit_count > 0;
 
         commit_ready || (time_ready && has_commits)
+    }
+
+    fn record_observed_snapshot(&mut self, observed_snapshot: IcebergCommittedSnapshot) {
+        self.latest_observed_snapshot = Some(observed_snapshot);
     }
 
     fn record_commit(&mut self) {
@@ -189,6 +199,7 @@ impl CompactionTrack {
                     task_type,
                     next_compaction_time_on_failure: *next_compaction_time,
                     pending_commit_count_at_dispatch: self.pending_commit_count,
+                    gc_watermark_snapshot: self.latest_observed_snapshot.clone(),
                 };
                 task_type
             }
@@ -200,12 +211,22 @@ impl CompactionTrack {
     }
 
     fn mark_dispatched(&mut self, task_id: u64, now: Instant) {
-        let (task_type, pending_commit_count_at_dispatch) = match &self.state {
+        let (task_type, pending_commit_count_at_dispatch, gc_watermark_snapshot) = match &mut self
+            .state
+        {
             CompactionTrackState::PendingDispatch {
                 task_type,
                 pending_commit_count_at_dispatch,
+                gc_watermark_snapshot,
                 ..
-            } => (*task_type, *pending_commit_count_at_dispatch),
+            } => {
+                let gc_watermark_snapshot = gc_watermark_snapshot.take();
+                (
+                    *task_type,
+                    *pending_commit_count_at_dispatch,
+                    gc_watermark_snapshot,
+                )
+            }
             CompactionTrackState::Idle { .. } => unreachable!("Cannot mark dispatched when idle"),
             CompactionTrackState::InFlight { .. } => {
                 unreachable!("Cannot mark dispatched when already in flight")
@@ -216,7 +237,24 @@ impl CompactionTrack {
             task_type,
             pending_commit_count_at_dispatch,
             report_deadline: now + self.report_timeout,
+            gc_watermark_snapshot,
         };
+    }
+
+    pub(super) fn processing_gc_watermark_snapshot(
+        &self,
+    ) -> Option<Option<&IcebergCommittedSnapshot>> {
+        match &self.state {
+            CompactionTrackState::PendingDispatch {
+                gc_watermark_snapshot,
+                ..
+            }
+            | CompactionTrackState::InFlight {
+                gc_watermark_snapshot,
+                ..
+            } => Some(gc_watermark_snapshot.as_ref()),
+            CompactionTrackState::Idle { .. } => None,
+        }
     }
 
     fn is_pending_dispatch(&self) -> bool {
@@ -436,13 +474,17 @@ impl Drop for IcebergCompactionHandle {
     }
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone)]
 enum SinkUpdateKind {
-    /// A normal sink commit. It only increases the pending snapshot count.
-    Commit,
+    /// A normal sink commit. It increases the pending snapshot count.
+    Commit {
+        observed_snapshot: IcebergCommittedSnapshot,
+    },
     /// A force signal from the sink update path. It triggers the configured
     /// compaction type and still follows the automatic-compaction config gate.
-    ForceCompaction,
+    ForceCompaction {
+        observed_snapshot: IcebergCommittedSnapshot,
+    },
     /// A user-triggered manual request. It can bypass disabled automatic
     /// compaction and supplies the task type selected for this request.
     ManualForceCompaction { task_type: TaskType },
@@ -451,15 +493,23 @@ enum SinkUpdateKind {
 impl SinkUpdateKind {
     fn apply_to_track(self, track: &mut CompactionTrack, now: Instant) {
         match self {
-            SinkUpdateKind::Commit => track.record_commit(),
-            SinkUpdateKind::ForceCompaction => track.record_force_compaction(now, None),
+            SinkUpdateKind::Commit { observed_snapshot } => {
+                track.record_observed_snapshot(observed_snapshot);
+                track.record_commit();
+            }
+            SinkUpdateKind::ForceCompaction { observed_snapshot } => {
+                if matches!(track.state, CompactionTrackState::Idle { .. }) {
+                    track.record_observed_snapshot(observed_snapshot);
+                }
+                track.record_force_compaction(now, None);
+            }
             SinkUpdateKind::ManualForceCompaction { task_type } => {
                 track.record_force_compaction(now, Some(task_type))
             }
         }
     }
 
-    fn allows_disabled_compaction(self) -> bool {
+    fn allows_disabled_compaction(&self) -> bool {
         matches!(self, SinkUpdateKind::ManualForceCompaction { .. })
     }
 }
@@ -525,11 +575,12 @@ impl IcebergCompactionManager {
         let IcebergSinkCompactionUpdate {
             sink_id,
             force_compaction,
+            observed_snapshot,
         } = msg;
         let kind = if force_compaction {
-            SinkUpdateKind::ForceCompaction
+            SinkUpdateKind::ForceCompaction { observed_snapshot }
         } else {
-            SinkUpdateKind::Commit
+            SinkUpdateKind::Commit { observed_snapshot }
         };
         let prepared_update = self
             .prepare_sink_update(sink_id, kind, Instant::now())

--- a/src/meta/src/manager/iceberg_compaction/schedule/tests.rs
+++ b/src/meta/src/manager/iceberg_compaction/schedule/tests.rs
@@ -55,6 +55,7 @@ fn new_track(
         report_timeout: Duration::from_secs(30 * 60),
         last_config_refresh_at: now,
         pending_commit_count,
+        latest_observed_snapshot: None,
         finish_action: CompactionTrackFinishAction::KeepTrack,
         state: CompactionTrackState::Idle {
             next_compaction_time: now + Duration::from_secs(trigger_interval_sec),
@@ -71,6 +72,34 @@ fn start_in_flight(track: &mut CompactionTrack, task_id: u64, now: Instant) {
 fn record_commits(track: &mut CompactionTrack, n: usize) {
     for _ in 0..n {
         track.record_commit();
+    }
+}
+
+fn committed_snapshot(snapshot_id: i64, timestamp_ms: i64) -> IcebergCommittedSnapshot {
+    IcebergCommittedSnapshot {
+        branch: "main".to_owned(),
+        snapshot_id,
+        timestamp_ms,
+    }
+}
+
+fn commit_update(snapshot_id: i64, timestamp_ms: i64) -> SinkUpdateKind {
+    SinkUpdateKind::Commit {
+        observed_snapshot: committed_snapshot(snapshot_id, timestamp_ms),
+    }
+}
+
+fn force_update(snapshot_id: i64, timestamp_ms: i64) -> SinkUpdateKind {
+    SinkUpdateKind::ForceCompaction {
+        observed_snapshot: committed_snapshot(snapshot_id, timestamp_ms),
+    }
+}
+
+fn empty_inner() -> IcebergCompactionManagerInner {
+    IcebergCompactionManagerInner {
+        sink_schedules: HashMap::new(),
+        snapshot_expiration_sink_ids: HashSet::new(),
+        manual_compaction_waiters: HashMap::new(),
     }
 }
 
@@ -149,6 +178,180 @@ fn test_record_force_compaction_bootstraps_or_preserves_backlog() {
         assert_eq!(track.pending_commit_count, expected_backlog);
         assert!(track.should_trigger(now));
     }
+}
+
+#[tokio::test]
+async fn test_commit_update_freezes_gc_watermark_after_task_start() {
+    let manager = build_test_manager().await;
+    let sink_id = SinkId::new(404);
+    let now = Instant::now();
+    let config = new_test_iceberg_config(300, 10, CompactionType::SmallFiles);
+    let mut guard = empty_inner();
+
+    let applied = manager.apply_sink_update(
+        &mut guard,
+        PreparedSinkUpdate {
+            sink_id,
+            kind: commit_update(10, 1000),
+            now,
+            allow_track_initialization: true,
+            loaded_config: Some(config),
+        },
+    );
+
+    assert!(applied);
+    guard
+        .sink_schedules
+        .get_mut(&sink_id)
+        .unwrap()
+        .start_processing();
+
+    let applied = manager.apply_sink_update(
+        &mut guard,
+        PreparedSinkUpdate {
+            sink_id,
+            kind: commit_update(11, 2000),
+            now,
+            allow_track_initialization: false,
+            loaded_config: None,
+        },
+    );
+
+    assert!(applied);
+    let track = guard.sink_schedules.get(&sink_id).unwrap();
+    assert_eq!(
+        track
+            .latest_observed_snapshot
+            .as_ref()
+            .map(|s| s.snapshot_id),
+        Some(11)
+    );
+    match track.processing_gc_watermark_snapshot() {
+        Some(Some(snapshot)) => assert_eq!(snapshot.snapshot_id, 10),
+        protection => panic!("unexpected gc watermark: {protection:?}"),
+    }
+
+    guard
+        .sink_schedules
+        .get_mut(&sink_id)
+        .unwrap()
+        .mark_dispatched(1, now);
+    let applied = manager.apply_sink_update(
+        &mut guard,
+        PreparedSinkUpdate {
+            sink_id,
+            kind: commit_update(12, 3000),
+            now,
+            allow_track_initialization: false,
+            loaded_config: None,
+        },
+    );
+    assert!(applied);
+    let applied = manager.apply_sink_update(
+        &mut guard,
+        PreparedSinkUpdate {
+            sink_id,
+            kind: force_update(13, 4000),
+            now,
+            allow_track_initialization: false,
+            loaded_config: None,
+        },
+    );
+    assert!(applied);
+
+    let track = guard.sink_schedules.get(&sink_id).unwrap();
+    assert_eq!(
+        track
+            .latest_observed_snapshot
+            .as_ref()
+            .map(|s| s.snapshot_id),
+        Some(12)
+    );
+    match track.processing_gc_watermark_snapshot() {
+        Some(Some(snapshot)) => assert_eq!(snapshot.snapshot_id, 10),
+        protection => panic!("unexpected gc watermark: {protection:?}"),
+    }
+}
+
+#[tokio::test]
+async fn test_force_update_records_observed_snapshot_only_for_idle_track() {
+    let manager = build_test_manager().await;
+    let idle_sink_id = SinkId::new(405);
+    let processing_sink_id = SinkId::new(406);
+    let now = Instant::now();
+    let config = new_test_iceberg_config(300, 10, CompactionType::SmallFiles);
+    let mut guard = empty_inner();
+
+    let applied = manager.apply_sink_update(
+        &mut guard,
+        PreparedSinkUpdate {
+            sink_id: idle_sink_id,
+            kind: force_update(10, 1000),
+            now,
+            allow_track_initialization: true,
+            loaded_config: Some(config),
+        },
+    );
+
+    assert!(applied);
+    let track = guard.sink_schedules.get_mut(&idle_sink_id).unwrap();
+    track.start_processing();
+    match track.processing_gc_watermark_snapshot() {
+        Some(Some(snapshot)) => assert_eq!(snapshot.snapshot_id, 10),
+        protection => panic!("unexpected gc watermark: {protection:?}"),
+    }
+
+    let mut track = new_track(now, 300, 10, 0);
+    track.record_observed_snapshot(committed_snapshot(20, 2000));
+    track.record_force_compaction(now, None);
+    track.start_processing();
+    guard.sink_schedules.insert(processing_sink_id, track);
+
+    let applied = manager.apply_sink_update(
+        &mut guard,
+        PreparedSinkUpdate {
+            sink_id: processing_sink_id,
+            kind: force_update(21, 3000),
+            now,
+            allow_track_initialization: false,
+            loaded_config: None,
+        },
+    );
+
+    assert!(applied);
+    let track = guard.sink_schedules.get(&processing_sink_id).unwrap();
+    assert_eq!(
+        track
+            .latest_observed_snapshot
+            .as_ref()
+            .map(|s| s.snapshot_id),
+        Some(20)
+    );
+    match track.processing_gc_watermark_snapshot() {
+        Some(Some(snapshot)) => assert_eq!(snapshot.snapshot_id, 20),
+        protection => panic!("unexpected gc watermark: {protection:?}"),
+    }
+}
+
+#[test]
+fn test_active_task_without_observed_snapshot_has_no_gc_watermark() {
+    let now = Instant::now();
+    let skip_sink_id = SinkId::new(42);
+    let mut skip_track = new_track(now, 300, 10, 0);
+    skip_track.record_force_compaction(now, None);
+    skip_track.start_processing();
+
+    let mut inner = empty_inner();
+    inner.sink_schedules.insert(skip_sink_id, skip_track);
+
+    assert!(matches!(
+        inner
+            .sink_schedules
+            .get(&skip_sink_id)
+            .unwrap()
+            .processing_gc_watermark_snapshot(),
+        Some(None)
+    ));
 }
 
 #[test]
@@ -404,7 +607,7 @@ async fn test_apply_sink_update_refreshes_existing_idle_track() {
         &mut guard,
         PreparedSinkUpdate {
             sink_id,
-            kind: SinkUpdateKind::Commit,
+            kind: commit_update(1, 1),
             now: refresh_at,
             allow_track_initialization: false,
             loaded_config: Some(config),
@@ -437,6 +640,7 @@ async fn test_update_iceberg_commit_info_skips_missing_track_on_load_failure() {
         .update_iceberg_commit_info(IcebergSinkCompactionUpdate {
             sink_id,
             force_compaction: false,
+            observed_snapshot: committed_snapshot(1, 1),
         })
         .await;
 
@@ -458,6 +662,7 @@ async fn test_update_iceberg_commit_info_refresh_failure_keeps_refresh_deadline_
         .update_iceberg_commit_info(IcebergSinkCompactionUpdate {
             sink_id,
             force_compaction: false,
+            observed_snapshot: committed_snapshot(1, 1),
         })
         .await;
 
@@ -475,17 +680,13 @@ async fn test_apply_sink_update_creates_missing_track() {
     let sink_id = SinkId::new(44);
     let now = Instant::now();
     let config = new_test_iceberg_config(300, 3, CompactionType::SmallFiles);
-    let mut guard = IcebergCompactionManagerInner {
-        sink_schedules: HashMap::new(),
-        snapshot_expiration_sink_ids: HashSet::new(),
-        manual_compaction_waiters: HashMap::new(),
-    };
+    let mut guard = empty_inner();
 
     manager.apply_sink_update(
         &mut guard,
         PreparedSinkUpdate {
             sink_id,
-            kind: SinkUpdateKind::Commit,
+            kind: commit_update(1, 1),
             now,
             allow_track_initialization: true,
             loaded_config: Some(config),
@@ -509,17 +710,13 @@ async fn test_apply_sink_update_tracks_snapshot_expiration_without_compaction() 
     let mut config = new_test_iceberg_config(300, 3, CompactionType::SmallFiles);
     config.enable_compaction = false;
     config.enable_snapshot_expiration = true;
-    let mut guard = IcebergCompactionManagerInner {
-        sink_schedules: HashMap::new(),
-        snapshot_expiration_sink_ids: HashSet::new(),
-        manual_compaction_waiters: HashMap::new(),
-    };
+    let mut guard = empty_inner();
 
     manager.apply_sink_update(
         &mut guard,
         PreparedSinkUpdate {
             sink_id,
-            kind: SinkUpdateKind::Commit,
+            kind: commit_update(1, 1),
             now,
             allow_track_initialization: true,
             loaded_config: Some(config),
@@ -537,11 +734,7 @@ async fn test_apply_manual_force_update_allows_disabled_compaction() {
     let now = Instant::now();
     let mut config = new_test_iceberg_config(300, 3, CompactionType::SmallFiles);
     config.enable_compaction = false;
-    let mut guard = IcebergCompactionManagerInner {
-        sink_schedules: HashMap::new(),
-        snapshot_expiration_sink_ids: HashSet::new(),
-        manual_compaction_waiters: HashMap::new(),
-    };
+    let mut guard = empty_inner();
 
     let applied = manager.apply_sink_update(
         &mut guard,
@@ -595,7 +788,7 @@ async fn test_manual_force_update_uses_selected_task_type_once() {
             &mut guard,
             PreparedSinkUpdate {
                 sink_id,
-                kind: SinkUpdateKind::ForceCompaction,
+                kind: force_update(1, 1),
                 now,
                 allow_track_initialization: false,
                 loaded_config: None,
@@ -625,17 +818,14 @@ async fn test_apply_sink_update_keeps_processing_track_when_compaction_is_disabl
     let mut track = new_track(now, 300, 3, 0);
     track.start_processing();
     track.mark_dispatched(task_id, now);
-    let mut guard = IcebergCompactionManagerInner {
-        sink_schedules: HashMap::from([(sink_id, track)]),
-        snapshot_expiration_sink_ids: HashSet::new(),
-        manual_compaction_waiters: HashMap::new(),
-    };
+    let mut guard = empty_inner();
+    guard.sink_schedules.insert(sink_id, track);
 
     manager.apply_sink_update(
         &mut guard,
         PreparedSinkUpdate {
             sink_id,
-            kind: SinkUpdateKind::Commit,
+            kind: commit_update(1, 1),
             now,
             allow_track_initialization: false,
             loaded_config: Some(config),
@@ -658,17 +848,15 @@ async fn test_apply_sink_update_keeps_temporary_manual_track_when_compaction_is_
     let mut track = new_track(now, 300, 3, 1);
     track.finish_action = CompactionTrackFinishAction::RemoveTrack;
     let (tx, _rx) = tokio::sync::oneshot::channel();
-    let mut guard = IcebergCompactionManagerInner {
-        sink_schedules: HashMap::from([(sink_id, track)]),
-        snapshot_expiration_sink_ids: HashSet::new(),
-        manual_compaction_waiters: HashMap::from([(sink_id, tx)]),
-    };
+    let mut guard = empty_inner();
+    guard.sink_schedules.insert(sink_id, track);
+    guard.manual_compaction_waiters.insert(sink_id, tx);
 
     let applied = manager.apply_sink_update(
         &mut guard,
         PreparedSinkUpdate {
             sink_id,
-            kind: SinkUpdateKind::Commit,
+            kind: commit_update(1, 1),
             now,
             allow_track_initialization: false,
             loaded_config: Some(config),
@@ -689,17 +877,14 @@ async fn test_apply_sink_update_rejects_temporary_manual_processing_track_withou
     let mut track = new_track(now, 300, 3, 1);
     track.finish_action = CompactionTrackFinishAction::RemoveTrack;
     start_in_flight(&mut track, task_id, now);
-    let mut guard = IcebergCompactionManagerInner {
-        sink_schedules: HashMap::from([(sink_id, track)]),
-        snapshot_expiration_sink_ids: HashSet::new(),
-        manual_compaction_waiters: HashMap::new(),
-    };
+    let mut guard = empty_inner();
+    guard.sink_schedules.insert(sink_id, track);
 
     let applied = manager.apply_sink_update(
         &mut guard,
         PreparedSinkUpdate {
             sink_id,
-            kind: SinkUpdateKind::Commit,
+            kind: commit_update(1, 1),
             now,
             allow_track_initialization: false,
             loaded_config: None,
@@ -733,7 +918,7 @@ async fn test_apply_sink_update_promotes_temporary_manual_track_when_compaction_
             &mut guard,
             PreparedSinkUpdate {
                 sink_id,
-                kind: SinkUpdateKind::Commit,
+                kind: commit_update(1, 1),
                 now,
                 allow_track_initialization: false,
                 loaded_config: Some(config),
@@ -766,17 +951,13 @@ async fn test_apply_sink_update_does_not_resurrect_disappeared_track() {
     let sink_id = SinkId::new(45);
     let now = Instant::now();
     let config = new_test_iceberg_config(300, 3, CompactionType::SmallFiles);
-    let mut guard = IcebergCompactionManagerInner {
-        sink_schedules: HashMap::new(),
-        snapshot_expiration_sink_ids: HashSet::new(),
-        manual_compaction_waiters: HashMap::new(),
-    };
+    let mut guard = empty_inner();
 
     manager.apply_sink_update(
         &mut guard,
         PreparedSinkUpdate {
             sink_id,
-            kind: SinkUpdateKind::Commit,
+            kind: commit_update(1, 1),
             now,
             allow_track_initialization: false,
             loaded_config: Some(config),


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

This PR prevents Iceberg snapshot expiration from deleting snapshots that may still be needed by active Iceberg compaction tasks.

- Carry the latest observed Iceberg snapshot from `IcebergSinkCommitter` to meta in `IcebergSinkCompactionUpdate`, using table metadata already available on the connector path.
- Use the current `IcebergSinkCommitter` table metadata for the existing `count_snapshots_since_rewrite() < max_snapshots` release check and the force-compaction watermark, then refresh the table after the wait before the next check.
- Track the latest observed snapshot per Iceberg compaction schedule and capture it when a task enters pending/in-flight processing.
- Protect snapshot expiration by capping the existing GC cutoff at the active compaction watermark; if an active task has no observed watermark, skip GC for that sink.
- Preserve the existing snapshot-expiration precheck and Iceberg expiration flow; only the cutoff timestamp is adjusted by the active compaction watermark.

Design notes:

- Manual compaction now reuses the unified scheduler track, so GC protection is derived only from `CompactionTrack::processing_gc_watermark_snapshot()`.
- There is no manual-specific GC watermark or task-id keyed manual GC state. `manual_compaction_waiters` only notifies the caller and does not participate in GC protection.
- Force compaction records the observed snapshot only when the track is idle and the force signal can actually trigger a task. Repeated force signals while a task is pending/in-flight remain no-ops.
- Connector force updates require an observed snapshot. Manual compaction can still run before any connector snapshot has been observed; if such a task is active, snapshot expiration skips that sink.

Limitations:

- The protection is in-memory only. It does not add persisted recovery for compaction tasks across meta restart.
- The watermark relies on the Iceberg branch retention used by RisingWave-managed branches. External changes to table branch retention may still affect how Iceberg `expire_older_than` retains snapshots.


## Checklist

- [ ] I have written necessary rustdoc comments.
- [x] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [x] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->

## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

Fixed Iceberg sink snapshot expiration so it does not remove snapshots still needed by active compaction tasks.

</details>
