### PR TITLE
fix(iceberg): resolve upsert sink primary key by index, not lower-cased name

### DIFF
--- a/src/connector/src/sink/iceberg/mod.rs
+++ b/src/connector/src/sink/iceberg/mod.rs
@@ -100,27 +100,21 @@ impl IcebergSink {
         }
 
         let unique_column_ids = if config.r#type == SINK_TYPE_UPSERT && !config.force_append_only {
-            if let Some(pk) = &config.primary_key {
-                let mut unique_column_ids = Vec::with_capacity(pk.len());
-                for col_name in pk {
-                    let id = param
-                        .columns
-                        .iter()
-                        .find(|col| col.name.as_str() == col_name)
-                        .ok_or_else(|| {
-                            SinkError::Config(anyhow!(
-                                "Primary key column {} not found in sink schema",
-                                col_name
-                            ))
-                        })?
-                        .column_id
-                        .get_id() as usize;
-                    unique_column_ids.push(id);
-                }
-                Some(unique_column_ids)
-            } else {
-                unreachable!()
-            }
+            // Use the pk indices resolved by the frontend instead of re-matching by name.
+            let pk_indices = param
+                .downstream_pk
+                .as_ref()
+                .filter(|pk| !pk.is_empty())
+                .ok_or_else(|| {
+                    SinkError::Config(anyhow!(
+                        "primary key must be specified for upsert iceberg sink"
+                    ))
+                })?;
+            let unique_column_ids = pk_indices
+                .iter()
+                .map(|&idx| param.columns[idx].column_id.get_id() as usize)
+                .collect();
+            Some(unique_column_ids)
         } else {
             None
         };

--- a/src/connector/src/sink/iceberg/test.rs
+++ b/src/connector/src/sink/iceberg/test.rs
@@ -906,3 +906,56 @@ fn test_upsert_accepts_copy_on_write() {
     let config = result.unwrap();
     assert_eq!(config.write_mode, IcebergWriteMode::CopyOnWrite);
 }
+
+// Regression: an upsert sink whose pk column has upper-case letters must resolve.
+// `primary_key` is lower-cased on deserialization, so re-matching it against the
+// (case-sensitive) column names would fail. The connector must instead use the pk
+// indices resolved by the frontend (`SinkParam::downstream_pk`).
+#[test]
+fn test_iceberg_sink_upper_case_primary_key() {
+    use risingwave_common::catalog::{ColumnDesc, ColumnId};
+    use risingwave_common::id::SinkId;
+
+    use crate::sink::SinkParam;
+    use crate::sink::catalog::SinkType;
+    use crate::sink::iceberg::IcebergSink;
+
+    let values = [
+        ("connector", "iceberg"),
+        ("type", "upsert"),
+        ("primary_key", "Key"),
+        ("warehouse.path", "s3://iceberg"),
+        ("s3.endpoint", "http://127.0.0.1:9301"),
+        ("s3.access.key", "hummockadmin"),
+        ("s3.secret.key", "hummockadmin"),
+        ("s3.region", "us-east-1"),
+        ("catalog.type", "storage"),
+        ("catalog.name", "demo"),
+        ("database.name", "demo_db"),
+        ("table.name", "demo_table"),
+    ]
+    .into_iter()
+    .map(|(k, v)| (k.to_owned(), v.to_owned()))
+    .collect();
+    let config = IcebergConfig::from_btreemap(values).unwrap();
+
+    let param = SinkParam {
+        sink_id: SinkId::from(1u32),
+        sink_name: "test_sink".to_owned(),
+        properties: BTreeMap::new(),
+        columns: vec![
+            ColumnDesc::named("Key", ColumnId::new(1), DataType::Int32),
+            ColumnDesc::named("Value", ColumnId::new(2), DataType::Int32),
+        ],
+        downstream_pk: Some(vec![0]),
+        sink_type: SinkType::Upsert,
+        ignore_delete: false,
+        format_desc: None,
+        db_name: "demo_db".to_owned(),
+        sink_from_name: "test_sink".to_owned(),
+    };
+
+    let sink = IcebergSink::new(config, param).unwrap();
+    // `unique_column_ids` is the `ColumnId` of the upper-case "Key" column.
+    assert_eq!(sink.unique_column_ids, Some(vec![1]));
+}


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

An upsert Iceberg sink could not reference a primary-key column whose name contains upper-case letters (e.g. a quoted identifier like `"Key"` / `"Timestamp"`). Such a sink failed at creation regardless of how the user quoted the `primary_key` option.

### Root cause

The `primary_key` for an Iceberg sink is resolved **twice**, by two paths that normalize the column name differently:

1. **Frontend** (`StreamSink::parse_downstream_pk`): splits on `,`, trims, then matches column names **case-sensitively** (no lower-casing, no quote stripping). The resolved indices are stored in `SinkParam::downstream_pk`.
2. **Connector** (`IcebergSink::new`): re-derives the pk from `config.primary_key`, but that option is **force-lower-cased** during deserialization (`deserialize_optional_string_seq_from_string`), and then matched against the (case-sensitive) column names again.

For a column named `Key`:
- `primary_key = 'Key,Timestamp'` → frontend matches `Key` ✓, but the connector lower-cases it to `key` and fails: `Primary key column key not found in sink schema`.
- `primary_key = '"Key","Timestamp"'` → neither path strips SQL identifier quotes, so the frontend already fails: `Sink primary key column not found: "Key"`.

So the two normalizations are mutually exclusive for any column whose name contains upper-case letters, making such a pk impossible to express.

### Fix

Stop re-resolving the pk by name in the connector. `IcebergSink::new` now derives `unique_column_ids` from the frontend-resolved `SinkParam::downstream_pk` indices, indexing directly into the sink columns. This keeps a single source of truth, removes the divergent lower-casing, and the value of `unique_column_ids` is unchanged for all previously-working sinks (still the pk columns' `ColumnId`).

`config.primary_key` is still validated as non-empty for upsert sinks; it is just no longer used for column resolution here.

### Note (out of scope)

This PR does not touch how `unique_column_ids` (an RW `ColumnId`) is later used as an Iceberg equality-delete field id. That mapping is correct for auto-created tables and freshly-created external tables, but can diverge for pre-existing external tables whose field ids don't equal `position + 1` (e.g. after schema evolution). That is a separate, pre-existing issue, tracked in #25847.

## Checklist

- [x] I have written necessary rustdoc comments.
- [x] I have added necessary unit tests and integration tests.

## Documentation

- [ ] My PR needs documentation updates.

<details>
<summary><b>Release note</b></summary>

Fixed a bug where an upsert Iceberg sink could not use a primary-key column whose name contains upper-case letters (e.g. `"Key"`). Such sinks can now be created without renaming or aliasing the column to lower case.

</details>
