### PR TITLE
fix(sink): add trailing slash to snowflake pipe stage path

### DIFF
--- a/src/connector/src/sink/snowflake_redshift/snowflake.rs
+++ b/src/connector/src/sink/snowflake_redshift/snowflake.rs
@@ -975,8 +975,10 @@ fn build_create_pipe_sql(
     target_table_name: &str,
 ) -> String {
     let pipe_name = format!(r#""{}"."{}"."{}""#, database, schema, pipe_name);
+    // Trailing slash is required: Snowflake matches stage paths by prefix, so `t` would
+    // also match sibling folders like `t_foo/`.
     let stage = format!(
-        r#""{}"."{}"."{}"/{}"#,
+        r#""{}"."{}"."{}"/{}/"#,
         database, schema, stage, target_table_name
     );
     let table_name = format!(r#""{}"."{}"."{}""#, database, schema, table_name);
@@ -1316,5 +1318,21 @@ BEGIN
     WHERE "__row_id" <= :max_row_id;
 END;"#;
         assert_eq!(normalize_sql(&task_sql), normalize_sql(expected));
+    }
+
+    #[test]
+    fn test_build_create_pipe_sql_stage_has_trailing_slash() {
+        let sql = build_create_pipe_sql(
+            "reservations_intermediate",
+            "test_db",
+            "test_schema",
+            "RW_S3_STAGE",
+            "reservations_pipe",
+            "reservations",
+        );
+        assert!(
+            sql.contains(r#"FROM @"test_db"."test_schema"."RW_S3_STAGE"/reservations/ "#),
+            "unexpected pipe sql: {sql}"
+        );
     }
 }


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

Fixes a production data-corruption bug in the `snowflake_v2` sink. Reported in #25849.

### The bug

`build_create_pipe_sql` builds each pipe's `COPY INTO ... FROM @<stage>/<target_table>` path **without a trailing slash**. Snowflake matches stage paths by **prefix**, not by directory boundary:

> "Snowflake treats the path value as a **prefix** and performs a **prefix match** against the file name in the external location." — [COPY INTO \<table\> docs](https://docs.snowflake.com/en/sql-reference/sql/copy-into-table)

The sink writes each table's files under `<stage>/<target_table>/<uuid>.json` (`build_opendal_writer_path`, which unconditionally appends `<target_table>/`). So a pipe with `FROM @<stage>/reservations` prefix-matches **every sibling whose name starts with `reservations`**:

- `reservations/` (intended)
- `reservations_channel_manager/`, `reservations_connector/`, `reservations_pms/`, `reservations_space_types/`, `reservations_spaces/` (swept in by mistake)

In production this MERGE'd hundreds of thousands of foreign rows into the wrong table and caused recurring `Number out of representable range` COPY aborts from schema mismatches.

### The fix

Append `/` to the stage path (`/{}` → `/{}/`) so the prefix match is scoped to the table's own folder. `reservations/` no longer prefix-matches `reservations_pms/` because the `/` delimiter is part of the prefix. Since written files are always under `<target_table>/`, scoping to `<target_table>/` never orphans the table's own files. Added a unit test that locks in the trailing slash.

Refer to: #25849
Hotfix for `release-2.8`: #25850

## Checklist

- [x] I have written necessary rustdoc comments.
- [x] I have added necessary unit tests and integration tests.
- [x] I have checked the Release Timeline and Currently Supported Versions to determine which release branches I need to cherry-pick this PR into.

## Documentation

- [ ] My PR needs documentation updates.

<details>
<summary><b>Release note</b></summary>

Fixes a data-corruption bug in the `snowflake_v2` sink where a sink for table `T` could also ingest the staged files of any sibling table whose name starts with `T` (e.g. `T_foo`), due to Snowflake's prefix matching on stage paths. The generated pipe now scopes the COPY path to the table's own folder.

</details>
