### PR TITLE
fix(iceberg): fix iceberg sink external table column id

### DIFF
--- a/e2e_test/iceberg/test_case/case_sensitive_column_upsert.toml
+++ b/e2e_test/iceberg/test_case/case_sensitive_column_upsert.toml
@@ -1,0 +1,26 @@
+init_sqls = [
+    'CREATE SCHEMA IF NOT EXISTS demo_db',
+    'DROP TABLE IF EXISTS demo_db.case_sensitive_column_upsert_table PURGE',
+    '''
+    CREATE TABLE demo_db.case_sensitive_column_upsert_table (
+    `Key` int,
+    `Value` int
+    ) USING iceberg
+    TBLPROPERTIES ('format-version'='2');
+    '''
+]
+
+slt = 'test_case/iceberg_sink_case_sensitive_column_upsert_table.slt'
+
+verify_schema = ['int','int']
+
+verify_sql = 'SELECT `Key`, `Value` FROM demo_db.case_sensitive_column_upsert_table ORDER BY `Key` ASC'
+
+verify_data = """
+1,600
+"""
+
+drop_sqls = [
+ 'DROP TABLE IF EXISTS demo_db.case_sensitive_column_upsert_table PURGE',
+ 'DROP SCHEMA IF EXISTS demo_db'
+]

--- a/e2e_test/iceberg/test_case/field_id_gap_upsert.toml
+++ b/e2e_test/iceberg/test_case/field_id_gap_upsert.toml
@@ -1,0 +1,28 @@
+init_sqls = [
+    'CREATE SCHEMA IF NOT EXISTS demo_db',
+    'DROP TABLE IF EXISTS demo_db.field_id_gap_upsert_table PURGE',
+    '''
+    CREATE TABLE demo_db.field_id_gap_upsert_table (
+    pad int,
+    k int,
+    b int
+    ) USING iceberg
+    TBLPROPERTIES ('format-version'='2');
+    ''',
+    'ALTER TABLE demo_db.field_id_gap_upsert_table DROP COLUMN pad'
+]
+
+slt = 'test_case/iceberg_sink_field_id_gap_upsert_table.slt'
+
+verify_schema = ['int','int']
+
+verify_sql = 'SELECT * FROM demo_db.field_id_gap_upsert_table ORDER BY k ASC'
+
+verify_data = """
+1,600
+"""
+
+drop_sqls = [
+ 'DROP TABLE IF EXISTS demo_db.field_id_gap_upsert_table PURGE',
+ 'DROP SCHEMA IF EXISTS demo_db'
+]

--- a/e2e_test/iceberg/test_case/iceberg_sink_case_sensitive_column_upsert_table.slt
+++ b/e2e_test/iceberg/test_case/iceberg_sink_case_sensitive_column_upsert_table.slt
@@ -2,6 +2,9 @@ statement ok
 set sink_decouple = false;
 
 statement ok
+set streaming_parallelism=4;
+
+statement ok
 DROP SINK IF EXISTS case_sensitive_column_sink;
 
 statement ok
@@ -40,11 +43,15 @@ INSERT INTO case_sensitive_column_t VALUES (1, 500);
 statement ok
 FLUSH;
 
+sleep 10s
+
 statement ok
 INSERT INTO case_sensitive_column_t VALUES (1, 600);
 
 statement ok
 FLUSH;
+
+sleep 10s
 
 query II
 SELECT "Key", "Value" FROM case_sensitive_column_t ORDER BY "Key";

--- a/e2e_test/iceberg/test_case/iceberg_sink_case_sensitive_column_upsert_table.slt
+++ b/e2e_test/iceberg/test_case/iceberg_sink_case_sensitive_column_upsert_table.slt
@@ -1,0 +1,61 @@
+statement ok
+set sink_decouple = false;
+
+statement ok
+DROP SINK IF EXISTS case_sensitive_column_sink;
+
+statement ok
+DROP MATERIALIZED VIEW IF EXISTS case_sensitive_column_mv;
+
+statement ok
+DROP TABLE IF EXISTS case_sensitive_column_t;
+
+statement ok
+CREATE TABLE case_sensitive_column_t ("Key" int, "Value" int, primary key ("Key"));
+
+statement ok
+CREATE MATERIALIZED VIEW case_sensitive_column_mv AS SELECT * FROM case_sensitive_column_t;
+
+statement ok
+CREATE SINK case_sensitive_column_sink AS SELECT "Key", "Value" FROM case_sensitive_column_mv WITH (
+    connector = 'iceberg',
+    type = 'upsert',
+    force_append_only = 'false',
+    primary_key = 'Key',
+    catalog.name = 'demo',
+    catalog.type = 'storage',
+    warehouse.path = 's3a://icebergdata/demo',
+    database.name = 'demo_db',
+    table.name = 'case_sensitive_column_upsert_table',
+    commit_checkpoint_interval = 1,
+    s3.endpoint = 'http://127.0.0.1:9301',
+    s3.region = 'us-east-1',
+    s3.access.key = 'hummockadmin',
+    s3.secret.key = 'hummockadmin'
+);
+
+statement ok
+INSERT INTO case_sensitive_column_t VALUES (1, 500);
+
+statement ok
+FLUSH;
+
+statement ok
+INSERT INTO case_sensitive_column_t VALUES (1, 600);
+
+statement ok
+FLUSH;
+
+query II
+SELECT "Key", "Value" FROM case_sensitive_column_t ORDER BY "Key";
+----
+1 600
+
+statement ok
+DROP SINK case_sensitive_column_sink;
+
+statement ok
+DROP MATERIALIZED VIEW case_sensitive_column_mv;
+
+statement ok
+DROP TABLE case_sensitive_column_t;

--- a/e2e_test/iceberg/test_case/iceberg_sink_field_id_gap_upsert_table.slt
+++ b/e2e_test/iceberg/test_case/iceberg_sink_field_id_gap_upsert_table.slt
@@ -2,6 +2,9 @@ statement ok
 set sink_decouple = false;
 
 statement ok
+set streaming_parallelism=4;
+
+statement ok
 DROP SINK IF EXISTS field_id_gap_sink;
 
 statement ok
@@ -40,11 +43,15 @@ INSERT INTO field_id_gap_t VALUES (1, 500);
 statement ok
 FLUSH;
 
+sleep 10s
+
 statement ok
 INSERT INTO field_id_gap_t VALUES (1, 600);
 
 statement ok
 FLUSH;
+
+sleep 10s
 
 query II
 SELECT * FROM field_id_gap_t ORDER BY k;

--- a/e2e_test/iceberg/test_case/iceberg_sink_field_id_gap_upsert_table.slt
+++ b/e2e_test/iceberg/test_case/iceberg_sink_field_id_gap_upsert_table.slt
@@ -1,0 +1,61 @@
+statement ok
+set sink_decouple = false;
+
+statement ok
+DROP SINK IF EXISTS field_id_gap_sink;
+
+statement ok
+DROP MATERIALIZED VIEW IF EXISTS field_id_gap_mv;
+
+statement ok
+DROP TABLE IF EXISTS field_id_gap_t;
+
+statement ok
+CREATE TABLE field_id_gap_t (k int, b int, primary key (k));
+
+statement ok
+CREATE MATERIALIZED VIEW field_id_gap_mv AS SELECT * FROM field_id_gap_t;
+
+statement ok
+CREATE SINK field_id_gap_sink AS SELECT k, b FROM field_id_gap_mv WITH (
+    connector = 'iceberg',
+    type = 'upsert',
+    force_append_only = 'false',
+    primary_key = 'k',
+    catalog.name = 'demo',
+    catalog.type = 'storage',
+    warehouse.path = 's3a://icebergdata/demo',
+    database.name = 'demo_db',
+    table.name = 'field_id_gap_upsert_table',
+    commit_checkpoint_interval = 1,
+    s3.endpoint = 'http://127.0.0.1:9301',
+    s3.region = 'us-east-1',
+    s3.access.key = 'hummockadmin',
+    s3.secret.key = 'hummockadmin'
+);
+
+statement ok
+INSERT INTO field_id_gap_t VALUES (1, 500);
+
+statement ok
+FLUSH;
+
+statement ok
+INSERT INTO field_id_gap_t VALUES (1, 600);
+
+statement ok
+FLUSH;
+
+query II
+SELECT * FROM field_id_gap_t ORDER BY k;
+----
+1 600
+
+statement ok
+DROP SINK field_id_gap_sink;
+
+statement ok
+DROP MATERIALIZED VIEW field_id_gap_mv;
+
+statement ok
+DROP TABLE field_id_gap_t;

--- a/src/connector/src/sink/iceberg/mod.rs
+++ b/src/connector/src/sink/iceberg/mod.rs
@@ -48,8 +48,8 @@ pub const ICEBERG_SINK: &str = "iceberg";
 pub struct IcebergSink {
     pub config: IcebergConfig,
     param: SinkParam,
-    // In upsert mode, it never be None and empty.
-    unique_column_ids: Option<Vec<usize>>,
+    // In upsert mode, it is never None or empty.
+    upsert_primary_key_column_names: Option<Vec<String>>,
 }
 
 impl EnforceSecret for IcebergSink {
@@ -99,29 +99,41 @@ impl IcebergSink {
             .map_err(SinkError::Config)?;
         }
 
-        let unique_column_ids = if config.r#type == SINK_TYPE_UPSERT && !config.force_append_only {
-            // Use the pk indices resolved by the frontend instead of re-matching by name.
-            let pk_indices = param
-                .downstream_pk
-                .as_ref()
-                .filter(|pk| !pk.is_empty())
-                .ok_or_else(|| {
-                    SinkError::Config(anyhow!(
-                        "primary key must be specified for upsert iceberg sink"
-                    ))
-                })?;
-            let unique_column_ids = pk_indices
-                .iter()
-                .map(|&idx| param.columns[idx].column_id.get_id() as usize)
-                .collect();
-            Some(unique_column_ids)
-        } else {
-            None
-        };
+        let upsert_primary_key_column_names =
+            if config.r#type == SINK_TYPE_UPSERT && !config.force_append_only {
+                let pk_indices = param
+                    .downstream_pk
+                    .as_ref()
+                    .filter(|pk| !pk.is_empty())
+                    .ok_or_else(|| {
+                        SinkError::Config(anyhow!(
+                            "primary key must be specified for upsert iceberg sink"
+                        ))
+                    })?;
+                Some(
+                    pk_indices
+                        .iter()
+                        .map(|&idx| {
+                            param
+                                .columns
+                                .get(idx)
+                                .map(|column| column.name.clone())
+                                .ok_or_else(|| {
+                                    SinkError::Config(anyhow!(
+                                        "primary key column index {} out of range in sink schema",
+                                        idx
+                                    ))
+                                })
+                        })
+                        .collect::<Result<Vec<_>>>()?,
+                )
+            } else {
+                None
+            };
         Ok(Self {
             config,
             param,
-            unique_column_ids,
+            upsert_primary_key_column_names,
         })
     }
 }
@@ -294,7 +306,7 @@ impl Sink for IcebergSink {
             self.config.clone(),
             self.param.clone(),
             writer_param.clone(),
-            self.unique_column_ids.clone(),
+            self.upsert_primary_key_column_names.clone(),
         );
 
         let commit_checkpoint_interval =

--- a/src/connector/src/sink/iceberg/test.rs
+++ b/src/connector/src/sink/iceberg/test.rs
@@ -56,7 +56,7 @@ fn test_resolve_equality_delete_field_ids_from_iceberg_schema() {
 }
 
 #[test]
-fn test_resolve_equality_delete_field_ids_case_insensitive() {
+fn test_resolve_equality_delete_field_ids_case_sensitive() {
     let iceberg_schema = IcebergSchema::builder()
         .with_fields(vec![
             NestedField::new(42, "Key", Type::Primitive(PrimitiveType::Int), true).into(),
@@ -66,10 +66,15 @@ fn test_resolve_equality_delete_field_ids_case_insensitive() {
         .unwrap();
 
     let field_ids =
-        super::writer::resolve_equality_delete_field_ids(&["key".to_owned()], &iceberg_schema)
+        super::writer::resolve_equality_delete_field_ids(&["Key".to_owned()], &iceberg_schema)
             .unwrap();
 
     assert_eq!(field_ids, vec![42]);
+
+    assert!(
+        super::writer::resolve_equality_delete_field_ids(&["key".to_owned()], &iceberg_schema)
+            .is_err()
+    );
 }
 
 #[test]

--- a/src/connector/src/sink/iceberg/test.rs
+++ b/src/connector/src/sink/iceberg/test.rs
@@ -56,6 +56,23 @@ fn test_resolve_equality_delete_field_ids_from_iceberg_schema() {
 }
 
 #[test]
+fn test_resolve_equality_delete_field_ids_case_insensitive() {
+    let iceberg_schema = IcebergSchema::builder()
+        .with_fields(vec![
+            NestedField::new(42, "Key", Type::Primitive(PrimitiveType::Int), true).into(),
+            NestedField::new(99, "Value", Type::Primitive(PrimitiveType::Int), true).into(),
+        ])
+        .build()
+        .unwrap();
+
+    let field_ids =
+        super::writer::resolve_equality_delete_field_ids(&["key".to_owned()], &iceberg_schema)
+            .unwrap();
+
+    assert_eq!(field_ids, vec![42]);
+}
+
+#[test]
 fn test_compatible_arrow_schema() {
     use super::*;
     let risingwave_schema = Schema::new(vec![

--- a/src/connector/src/sink/iceberg/test.rs
+++ b/src/connector/src/sink/iceberg/test.rs
@@ -14,7 +14,10 @@
 
 use std::collections::BTreeMap;
 
-use iceberg::spec::{FormatVersion, NullOrder, SortDirection};
+use iceberg::spec::{
+    FormatVersion, NestedField, NullOrder, PrimitiveType, Schema as IcebergSchema, SortDirection,
+    Type,
+};
 use risingwave_common::array::arrow::arrow_schema_iceberg::{
     DataType as ArrowDataType, Field as ArrowField, FieldRef as ArrowFieldRef,
     Fields as ArrowFields, Schema as ArrowSchema,
@@ -34,6 +37,23 @@ use crate::sink::iceberg::{
 };
 
 pub const DEFAULT_ICEBERG_COMPACTION_INTERVAL: u64 = 3600; // 1 hour
+
+#[test]
+fn test_resolve_equality_delete_field_ids_from_iceberg_schema() {
+    let iceberg_schema = IcebergSchema::builder()
+        .with_fields(vec![
+            NestedField::new(42, "k", Type::Primitive(PrimitiveType::Int), true).into(),
+            NestedField::new(99, "b", Type::Primitive(PrimitiveType::Int), true).into(),
+        ])
+        .build()
+        .unwrap();
+
+    let field_ids =
+        super::writer::resolve_equality_delete_field_ids(&["k".to_owned()], &iceberg_schema)
+            .unwrap();
+
+    assert_eq!(field_ids, vec![42]);
+}
 
 #[test]
 fn test_compatible_arrow_schema() {
@@ -956,6 +976,10 @@ fn test_iceberg_sink_upper_case_primary_key() {
     };
 
     let sink = IcebergSink::new(config, param).unwrap();
-    // `unique_column_ids` is the `ColumnId` of the upper-case "Key" column.
-    assert_eq!(sink.unique_column_ids, Some(vec![1]));
+    // Keep the case-preserving column name selected by the frontend so the writer can
+    // resolve the actual Iceberg field id after loading table metadata.
+    assert_eq!(
+        sink.upsert_primary_key_column_names,
+        Some(vec!["Key".to_owned()])
+    );
 }

--- a/src/connector/src/sink/iceberg/writer.rs
+++ b/src/connector/src/sink/iceberg/writer.rs
@@ -225,7 +225,7 @@ pub struct IcebergSinkWriterArgs {
     config: IcebergConfig,
     sink_param: SinkParam,
     writer_param: SinkWriterParam,
-    unique_column_ids: Option<Vec<usize>>,
+    upsert_primary_key_column_names: Option<Vec<String>>,
 }
 
 pub struct IcebergSinkWriterInner {
@@ -285,15 +285,32 @@ impl IcebergSinkWriter {
         config: IcebergConfig,
         sink_param: SinkParam,
         writer_param: SinkWriterParam,
-        unique_column_ids: Option<Vec<usize>>,
+        upsert_primary_key_column_names: Option<Vec<String>>,
     ) -> Self {
         Self::Created(IcebergSinkWriterArgs {
             config,
             sink_param,
             writer_param,
-            unique_column_ids,
+            upsert_primary_key_column_names,
         })
     }
+}
+
+pub(super) fn resolve_equality_delete_field_ids(
+    primary_key_column_names: &[String],
+    iceberg_schema: &iceberg::spec::Schema,
+) -> Result<Vec<i32>> {
+    primary_key_column_names
+        .iter()
+        .map(|column_name| {
+            iceberg_schema.field_id_by_name(column_name).ok_or_else(|| {
+                SinkError::Config(anyhow!(
+                    "Primary key column {} not found in Iceberg schema",
+                    column_name
+                ))
+            })
+        })
+        .collect()
 }
 
 impl IcebergSinkWriterInner {
@@ -403,7 +420,7 @@ impl IcebergSinkWriterInner {
     pub fn build_upsert(
         config: &IcebergConfig,
         table: Table,
-        unique_column_ids: Vec<usize>,
+        primary_key_column_names: Vec<String>,
         writer_param: &SinkWriterParam,
     ) -> Result<Self> {
         let SinkWriterParam {
@@ -418,7 +435,6 @@ impl IcebergSinkWriterInner {
             &sink_id.to_string(),
             sink_name.as_str(),
         ];
-        let unique_column_ids: Vec<_> = unique_column_ids.into_iter().map(|id| id as i32).collect();
 
         // Metrics
         let write_qps = GLOBAL_SINK_METRICS
@@ -438,6 +454,8 @@ impl IcebergSinkWriterInner {
 
         // Determine the schema id and partition spec id
         let schema = table.metadata().current_schema();
+        let unique_column_ids =
+            resolve_equality_delete_field_ids(&primary_key_column_names, schema)?;
         let partition_spec = table.metadata().default_partition_spec();
         let fanout_enabled = !partition_spec.fields().is_empty();
         let use_deletion_vectors = table.metadata().format_version() >= FormatVersion::V3;
@@ -802,11 +820,11 @@ impl SinkWriter for IcebergSinkWriter {
         };
 
         let table = create_and_validate_table_impl(&args.config, &args.sink_param).await?;
-        let inner = match &args.unique_column_ids {
-            Some(unique_column_ids) => IcebergSinkWriterInner::build_upsert(
+        let inner = match &args.upsert_primary_key_column_names {
+            Some(primary_key_column_names) => IcebergSinkWriterInner::build_upsert(
                 &args.config,
                 table,
-                unique_column_ids.clone(),
+                primary_key_column_names.clone(),
                 &args.writer_param,
             )?,
             None => {

--- a/src/connector/src/sink/iceberg/writer.rs
+++ b/src/connector/src/sink/iceberg/writer.rs
@@ -302,15 +302,37 @@ pub(super) fn resolve_equality_delete_field_ids(
 ) -> Result<Vec<i32>> {
     primary_key_column_names
         .iter()
-        .map(|column_name| {
-            iceberg_schema.field_id_by_name(column_name).ok_or_else(|| {
-                SinkError::Config(anyhow!(
-                    "Primary key column {} not found in Iceberg schema",
-                    column_name
-                ))
-            })
-        })
+        .map(|column_name| resolve_equality_delete_field_id(column_name, iceberg_schema))
         .collect()
+}
+
+fn resolve_equality_delete_field_id(
+    column_name: &str,
+    iceberg_schema: &iceberg::spec::Schema,
+) -> Result<i32> {
+    if let Some(field_id) = iceberg_schema.field_id_by_name(column_name) {
+        return Ok(field_id);
+    }
+
+    let lowercase_column_name = column_name.to_lowercase();
+    let matched_fields = iceberg_schema
+        .as_struct()
+        .fields()
+        .iter()
+        .filter(|field| field.name.to_lowercase() == lowercase_column_name)
+        .collect::<Vec<_>>();
+
+    match matched_fields.as_slice() {
+        [field] => Ok(field.id),
+        [] => Err(SinkError::Config(anyhow!(
+            "Primary key column {} not found in Iceberg schema",
+            column_name
+        ))),
+        _ => Err(SinkError::Config(anyhow!(
+            "Primary key column {} matches multiple columns in Iceberg schema ignoring case",
+            column_name
+        ))),
+    }
 }
 
 impl IcebergSinkWriterInner {

--- a/src/connector/src/sink/iceberg/writer.rs
+++ b/src/connector/src/sink/iceberg/writer.rs
@@ -302,37 +302,15 @@ pub(super) fn resolve_equality_delete_field_ids(
 ) -> Result<Vec<i32>> {
     primary_key_column_names
         .iter()
-        .map(|column_name| resolve_equality_delete_field_id(column_name, iceberg_schema))
+        .map(|column_name| {
+            iceberg_schema.field_id_by_name(column_name).ok_or_else(|| {
+                SinkError::Config(anyhow!(
+                    "Primary key column {} not found in Iceberg schema",
+                    column_name
+                ))
+            })
+        })
         .collect()
-}
-
-fn resolve_equality_delete_field_id(
-    column_name: &str,
-    iceberg_schema: &iceberg::spec::Schema,
-) -> Result<i32> {
-    if let Some(field_id) = iceberg_schema.field_id_by_name(column_name) {
-        return Ok(field_id);
-    }
-
-    let lowercase_column_name = column_name.to_lowercase();
-    let matched_fields = iceberg_schema
-        .as_struct()
-        .fields()
-        .iter()
-        .filter(|field| field.name.to_lowercase() == lowercase_column_name)
-        .collect::<Vec<_>>();
-
-    match matched_fields.as_slice() {
-        [field] => Ok(field.id),
-        [] => Err(SinkError::Config(anyhow!(
-            "Primary key column {} not found in Iceberg schema",
-            column_name
-        ))),
-        _ => Err(SinkError::Config(anyhow!(
-            "Primary key column {} matches multiple columns in Iceberg schema ignoring case",
-            column_name
-        ))),
-    }
 }
 
 impl IcebergSinkWriterInner {


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

## What's changed and what's your intention?

This PR fixes Iceberg upsert sink equality-delete field id resolution.

Previously, the Iceberg sink stored the RisingWave `ColumnId` selected by `downstream_pk` and passed it to Iceberg equality deletes. This is incorrect because Iceberg equality deletes require Iceberg schema field ids, which can diverge from RisingWave `ColumnId`s after Iceberg schema evolution, for example when a dropped column leaves a field-id gap.

The new flow is:

- keep using frontend-resolved `SinkParam::downstream_pk` to identify which sink output columns are primary keys;
- store the corresponding primary-key column names instead of RisingWave `ColumnId`s;
- after loading the target Iceberg table metadata, resolve those column names against the current Iceberg schema and use the real Iceberg field ids for equality deletes;
- preserve the case-sensitive primary-key behavior fixed by #25846 by keeping the case-preserving frontend column mapping, with a unique case-insensitive fallback when resolving against Iceberg schema names.

This fixes the field-id mismatch without regressing Iceberg table/column name case handling.

- Closes #25847
- Related to #25846

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
