### PR TITLE
refactor(meta): track manual iceberg compaction tasks

### DIFF
--- a/src/meta/src/manager/iceberg_compaction/manual.rs
+++ b/src/meta/src/manager/iceberg_compaction/manual.rs
@@ -12,106 +12,22 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::sync::Arc;
-
 use anyhow::anyhow;
 use risingwave_connector::sink::catalog::SinkId;
-use risingwave_pb::iceberg_compaction::IcebergCompactionTask;
-use risingwave_pb::iceberg_compaction::iceberg_compaction_task::TaskType;
 use risingwave_pb::iceberg_compaction::subscribe_iceberg_compaction_event_request::ReportTask as IcebergReportTask;
 use risingwave_pb::iceberg_compaction::subscribe_iceberg_compaction_event_request::report_task::Status as IcebergReportTaskStatus;
-use thiserror_ext::AsReport;
-use tokio::sync::oneshot;
 
 use super::*;
-use crate::hummock::sequence::next_compaction_task_id;
-
-struct ManualCompactionCancelGuard {
-    compactor: Arc<crate::hummock::IcebergCompactor>,
-    sink_id: SinkId,
-    task_id: u64,
-    armed: bool,
-}
-
-impl ManualCompactionCancelGuard {
-    fn new(
-        compactor: Arc<crate::hummock::IcebergCompactor>,
-        sink_id: SinkId,
-        task_id: u64,
-    ) -> Self {
-        Self {
-            compactor,
-            sink_id,
-            task_id,
-            armed: true,
-        }
-    }
-
-    fn disarm(&mut self) {
-        self.armed = false;
-    }
-}
-
-impl Drop for ManualCompactionCancelGuard {
-    fn drop(&mut self) {
-        if !self.armed {
-            return;
-        }
-
-        tracing::info!(
-            sink_id = %self.sink_id,
-            task_id = self.task_id,
-            "Cancelling manual iceberg compaction task",
-        );
-
-        if let Err(e) = self.compactor.cancel_task(self.task_id) {
-            tracing::warn!(
-                error = %e.as_report(),
-                sink_id = %self.sink_id,
-                task_id = self.task_id,
-                "Failed to cancel manual iceberg compaction task",
-            );
-        }
-    }
-}
 
 impl IcebergCompactionManager {
-    fn register_manual_task_waiter(
-        &self,
-        task_id: u64,
-    ) -> MetaResult<oneshot::Receiver<MetaResult<()>>> {
-        let (tx, rx) = oneshot::channel();
-        match self.inner.write().manual_task_waiters.entry(task_id) {
-            std::collections::hash_map::Entry::Vacant(entry) => {
-                entry.insert(tx);
-                Ok(rx)
-            }
-            std::collections::hash_map::Entry::Occupied(_) => Err(anyhow!(
-                "manual iceberg compaction waiter already exists for task_id={}",
-                task_id
-            )
-            .into()),
-        }
-    }
-
-    fn clear_manual_task_waiter(&self, task_id: u64) {
-        self.inner.write().manual_task_waiters.remove(&task_id);
-    }
-
-    pub(super) fn complete_manual_task_if_any(&self, report: &IcebergReportTask) -> bool {
-        let Some(waiter) = self
-            .inner
-            .write()
-            .manual_task_waiters
-            .remove(&report.task_id)
-        else {
-            return false;
-        };
-
+    pub(super) fn complete_manual_task_waiter(
+        waiter: ManualCompactionWaiter,
+        report: &IcebergReportTask,
+    ) {
         let status = IcebergReportTaskStatus::try_from(report.status)
             .unwrap_or(IcebergReportTaskStatus::Unspecified);
         let result = match status {
-            IcebergReportTaskStatus::Success => Ok(()),
+            IcebergReportTaskStatus::Success => Ok(report.task_id),
             IcebergReportTaskStatus::Failed | IcebergReportTaskStatus::Unspecified => {
                 let message = report
                     .error_message
@@ -128,77 +44,38 @@ impl IcebergCompactionManager {
         };
 
         let _ = waiter.send(result);
-        true
     }
 
     pub async fn trigger_manual_compaction(&self, sink_id: SinkId) -> MetaResult<u64> {
-        use risingwave_pb::iceberg_compaction::subscribe_iceberg_compaction_event_response::Event as IcebergResponseEvent;
-
-        let compactor = self
-            .iceberg_compactor_manager
-            .next_compactor()
-            .ok_or_else(|| anyhow!("No iceberg compactor available"))?;
-
-        let task_id = next_compaction_task_id(&self.env).await?;
-        let sink_param = self.get_sink_param(sink_id).await?;
-        let waiter = self.register_manual_task_waiter(task_id)?;
-
-        if let Err(error) =
-            compactor.send_event(IcebergResponseEvent::CompactTask(IcebergCompactionTask {
-                task_id,
-                sink_id: sink_id.as_raw_id(),
-                props: sink_param.properties,
-                task_type: TaskType::Full as i32,
-            }))
-        {
-            self.clear_manual_task_waiter(task_id);
-            return Err(error);
+        // Fast-fail before registering a waiter when no compactor can pull the
+        // scheduler task.
+        if self.iceberg_compactor_manager.compactor_num() == 0 {
+            return Err(anyhow!("No iceberg compactor available").into());
         }
 
-        // If the caller cancels the SQL command or this method exits before a
-        // completion report arrives, notify the compactor to stop the task.
-        let mut cancel_guard = ManualCompactionCancelGuard::new(compactor, sink_id, task_id);
+        let waiter = self.start_manual_compaction(sink_id).await?;
+        let cleanup_guard = scopeguard::guard(sink_id, |sink_id| {
+            self.cancel_manual_compaction_waiter(sink_id)
+        });
 
         tracing::info!(
-            "Manual compaction triggered for sink {} with task ID {}, waiting for completion...",
-            sink_id,
-            task_id
+            "Manual compaction requested for sink {}, waiting for completion...",
+            sink_id
         );
 
-        self.wait_for_compaction_completion(&sink_id, task_id, waiter, &mut cancel_guard)
-            .await?;
-
-        Ok(task_id)
-    }
-
-    async fn wait_for_compaction_completion(
-        &self,
-        sink_id: &SinkId,
-        task_id: u64,
-        waiter: oneshot::Receiver<MetaResult<()>>,
-        cancel_guard: &mut ManualCompactionCancelGuard,
-    ) -> MetaResult<()> {
-        let _cleanup_guard =
-            scopeguard::guard(task_id, |task_id| self.clear_manual_task_waiter(task_id));
-
-        match tokio::time::timeout(self.report_timeout(), waiter).await {
-            Ok(Ok(result)) => {
-                cancel_guard.disarm();
+        match waiter.await {
+            Ok(result) => {
+                let _ = scopeguard::ScopeGuard::into_inner(cleanup_guard);
                 result
             }
-            Ok(Err(_)) => Err(anyhow!(
-                "Manual iceberg compaction waiter dropped unexpectedly for sink {} (task_id={})",
-                sink_id,
-                task_id
-            )
-            .into()),
-            Err(_) => Err(anyhow!(
-                "Iceberg compaction did not report completion within {} seconds for sink {} (task_id={})",
-                self.report_timeout().as_secs(),
-                sink_id,
-                task_id
-            )
-            .into()),
+            Err(_) => {
+                let _ = scopeguard::ScopeGuard::into_inner(cleanup_guard);
+                Err(anyhow!(
+                    "Manual iceberg compaction waiter dropped unexpectedly for sink {}",
+                    sink_id,
+                )
+                .into())
+            }
         }
     }
 }

--- a/src/meta/src/manager/iceberg_compaction/mod.rs
+++ b/src/meta/src/manager/iceberg_compaction/mod.rs
@@ -45,7 +45,7 @@ pub(crate) type CompactorChangeTx =
 pub(crate) type CompactorChangeRx =
     UnboundedReceiver<(WorkerId, Streaming<SubscribeIcebergCompactionEventRequest>)>;
 
-type ManualTaskWaiter = tokio::sync::oneshot::Sender<MetaResult<()>>;
+type ManualCompactionWaiter = tokio::sync::oneshot::Sender<MetaResult<u64>>;
 
 use schedule::CompactionTrack;
 pub use schedule::IcebergCompactionScheduleStatus;
@@ -65,7 +65,7 @@ pub struct IcebergCompactionManager {
 struct IcebergCompactionManagerInner {
     sink_schedules: HashMap<SinkId, CompactionTrack>,
     snapshot_expiration_sink_ids: HashSet<SinkId>,
-    manual_task_waiters: HashMap<u64, ManualTaskWaiter>,
+    manual_compaction_waiters: HashMap<SinkId, ManualCompactionWaiter>,
 }
 
 impl IcebergCompactionManager {
@@ -91,7 +91,7 @@ impl IcebergCompactionManager {
                 inner: Arc::new(RwLock::new(IcebergCompactionManagerInner {
                     sink_schedules: HashMap::default(),
                     snapshot_expiration_sink_ids: HashSet::default(),
-                    manual_task_waiters: HashMap::default(),
+                    manual_compaction_waiters: HashMap::default(),
                 })),
                 metadata_manager,
                 iceberg_compactor_manager,

--- a/src/meta/src/manager/iceberg_compaction/schedule.rs
+++ b/src/meta/src/manager/iceberg_compaction/schedule.rs
@@ -29,16 +29,26 @@ use risingwave_pb::iceberg_compaction::iceberg_compaction_task::TaskType;
 use risingwave_pb::iceberg_compaction::subscribe_iceberg_compaction_event_request::ReportTask as IcebergReportTask;
 use risingwave_pb::iceberg_compaction::subscribe_iceberg_compaction_event_request::report_task::Status as IcebergReportTaskStatus;
 use thiserror_ext::AsReport;
+use tokio::sync::oneshot;
 
 use super::*;
 
 /// Compaction track states using type-safe state machine pattern
 #[derive(Debug, Clone)]
 enum CompactionTrackState {
-    /// Ready to accept commits and check for trigger conditions
-    Idle { next_compaction_time: Instant },
+    /// Ready to accept commits and check for trigger conditions.
+    ///
+    /// `Idle` is not an active task state. A manual request may leave a
+    /// one-shot task type override here for the next scheduler selection.
+    Idle {
+        next_compaction_time: Instant,
+        /// `None` uses the configured track task type; `Some` is consumed when
+        /// the next task enters `PendingDispatch`.
+        next_task_type_override: Option<TaskType>,
+    },
     /// Task has been selected locally but not yet accepted by a compactor.
     PendingDispatch {
+        task_type: TaskType,
         next_compaction_time_on_failure: Instant,
         pending_commit_count_at_dispatch: usize,
     },
@@ -46,9 +56,16 @@ enum CompactionTrackState {
     /// expires before a report arrives, the task becomes retryable.
     InFlight {
         task_id: u64,
+        task_type: TaskType,
         pending_commit_count_at_dispatch: usize,
         report_deadline: Instant,
     },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum CompactionTrackFinishAction {
+    KeepTrack,
+    RemoveTrack,
 }
 
 #[derive(Debug, Clone)]
@@ -61,6 +78,10 @@ pub(super) struct CompactionTrack {
     report_timeout: Duration,
     last_config_refresh_at: Instant,
     pending_commit_count: usize,
+    /// Track lifecycle policy after a selected task finishes. Manual compaction
+    /// uses `RemoveTrack` only while automatic compaction is disabled; a later
+    /// config refresh can turn the temporary track into a normal schedule track.
+    finish_action: CompactionTrackFinishAction,
     state: CompactionTrackState,
 }
 
@@ -79,8 +100,10 @@ impl CompactionTrack {
             report_timeout,
             last_config_refresh_at: now,
             pending_commit_count: 0,
+            finish_action: CompactionTrackFinishAction::KeepTrack,
             state: CompactionTrackState::Idle {
                 next_compaction_time: now + Duration::from_secs(trigger_interval_sec),
+                next_task_type_override: None,
             },
         }
     }
@@ -100,6 +123,7 @@ impl CompactionTrack {
         let next_compaction_time = match &self.state {
             CompactionTrackState::Idle {
                 next_compaction_time,
+                ..
             } => *next_compaction_time,
             CompactionTrackState::PendingDispatch { .. }
             | CompactionTrackState::InFlight { .. } => return false,
@@ -116,11 +140,15 @@ impl CompactionTrack {
         self.pending_commit_count = self.pending_commit_count.saturating_add(1);
     }
 
-    fn record_force_compaction(&mut self, now: Instant) {
+    fn record_force_compaction(&mut self, now: Instant, forced_task_type: Option<TaskType>) {
         if let CompactionTrackState::Idle {
             next_compaction_time,
+            next_task_type_override,
         } = &mut self.state
         {
+            if let Some(task_type) = forced_task_type {
+                *next_task_type_override = Some(task_type);
+            }
             *next_compaction_time = now;
             self.pending_commit_count = self.pending_commit_count.max(1);
         }
@@ -139,15 +167,30 @@ impl CompactionTrack {
         self.last_config_refresh_at = now;
     }
 
-    fn start_processing(&mut self) {
+    fn current_task_type(&self) -> TaskType {
         match &self.state {
             CompactionTrackState::Idle {
+                next_task_type_override,
+                ..
+            } => next_task_type_override.unwrap_or(self.task_type),
+            CompactionTrackState::PendingDispatch { task_type, .. }
+            | CompactionTrackState::InFlight { task_type, .. } => *task_type,
+        }
+    }
+
+    fn start_processing(&mut self) -> TaskType {
+        match &mut self.state {
+            CompactionTrackState::Idle {
                 next_compaction_time,
+                next_task_type_override,
             } => {
+                let task_type = next_task_type_override.take().unwrap_or(self.task_type);
                 self.state = CompactionTrackState::PendingDispatch {
+                    task_type,
                     next_compaction_time_on_failure: *next_compaction_time,
                     pending_commit_count_at_dispatch: self.pending_commit_count,
                 };
+                task_type
             }
             CompactionTrackState::PendingDispatch { .. }
             | CompactionTrackState::InFlight { .. } => {
@@ -157,11 +200,12 @@ impl CompactionTrack {
     }
 
     fn mark_dispatched(&mut self, task_id: u64, now: Instant) {
-        let pending_commit_count_at_dispatch = match &self.state {
+        let (task_type, pending_commit_count_at_dispatch) = match &self.state {
             CompactionTrackState::PendingDispatch {
+                task_type,
                 pending_commit_count_at_dispatch,
                 ..
-            } => *pending_commit_count_at_dispatch,
+            } => (*task_type, *pending_commit_count_at_dispatch),
             CompactionTrackState::Idle { .. } => unreachable!("Cannot mark dispatched when idle"),
             CompactionTrackState::InFlight { .. } => {
                 unreachable!("Cannot mark dispatched when already in flight")
@@ -169,6 +213,7 @@ impl CompactionTrack {
         };
         self.state = CompactionTrackState::InFlight {
             task_id,
+            task_type,
             pending_commit_count_at_dispatch,
             report_deadline: now + self.report_timeout,
         };
@@ -178,7 +223,11 @@ impl CompactionTrack {
         matches!(self.state, CompactionTrackState::PendingDispatch { .. })
     }
 
-    fn is_processing_task(&self, task_id: u64) -> bool {
+    fn removes_track_after_finish(&self) -> bool {
+        self.finish_action == CompactionTrackFinishAction::RemoveTrack
+    }
+
+    pub(super) fn is_processing_task(&self, task_id: u64) -> bool {
         matches!(
             &self.state,
             CompactionTrackState::InFlight {
@@ -198,7 +247,7 @@ impl CompactionTrack {
         )
     }
 
-    fn finish_success(&mut self, now: Instant) {
+    fn finish_success(&mut self, now: Instant) -> CompactionTrackFinishAction {
         match &self.state {
             CompactionTrackState::InFlight {
                 pending_commit_count_at_dispatch,
@@ -209,7 +258,9 @@ impl CompactionTrack {
                     .saturating_sub(*pending_commit_count_at_dispatch);
                 self.state = CompactionTrackState::Idle {
                     next_compaction_time: now + Duration::from_secs(self.trigger_interval_sec),
+                    next_task_type_override: None,
                 };
+                self.finish_action
             }
             CompactionTrackState::Idle { .. } => unreachable!("Cannot finish success when idle"),
             CompactionTrackState::PendingDispatch { .. } => {
@@ -218,12 +269,14 @@ impl CompactionTrack {
         }
     }
 
-    fn finish_failed(&mut self, now: Instant) {
+    fn finish_failed(&mut self, now: Instant) -> CompactionTrackFinishAction {
         match &self.state {
             CompactionTrackState::InFlight { .. } => {
                 self.state = CompactionTrackState::Idle {
                     next_compaction_time: now,
+                    next_task_type_override: None,
                 };
+                self.finish_action
             }
             CompactionTrackState::Idle { .. } => unreachable!("Cannot finish failed when idle"),
             CompactionTrackState::PendingDispatch { .. } => {
@@ -237,7 +290,7 @@ impl CompactionTrack {
     /// `pending_commit_count` is intentionally preserved so commits that arrive
     /// while the track is pending dispatch are not lost if task dispatch fails
     /// before the compactor accepts the task.
-    fn revert_pre_dispatch_failure(&mut self) {
+    fn revert_pre_dispatch_failure(&mut self) -> CompactionTrackFinishAction {
         match &self.state {
             CompactionTrackState::PendingDispatch {
                 next_compaction_time_on_failure,
@@ -245,7 +298,9 @@ impl CompactionTrack {
             } => {
                 self.state = CompactionTrackState::Idle {
                     next_compaction_time: *next_compaction_time_on_failure,
+                    next_task_type_override: None,
                 };
+                self.finish_action
             }
             CompactionTrackState::Idle { .. } => {
                 unreachable!("Cannot revert a pre-dispatch failure when idle")
@@ -266,6 +321,7 @@ impl CompactionTrack {
         match &mut self.state {
             CompactionTrackState::Idle {
                 next_compaction_time,
+                ..
             } => {
                 *next_compaction_time = now + Duration::from_secs(new_interval_sec);
             }
@@ -351,28 +407,60 @@ impl IcebergCompactionHandle {
 
 impl Drop for IcebergCompactionHandle {
     fn drop(&mut self) {
-        let mut guard = self.inner.write();
-        if !self.handle_success
-            && let Some(track) = guard.sink_schedules.get_mut(&self.sink_id)
-            && track.is_pending_dispatch()
-        {
-            track.revert_pre_dispatch_failure();
+        let waiter = {
+            let mut guard = self.inner.write();
+            if !self.handle_success
+                && let Some(track) = guard.sink_schedules.get_mut(&self.sink_id)
+                && track.is_pending_dispatch()
+            {
+                let finish_action = track.revert_pre_dispatch_failure();
+                let waiter = guard.manual_compaction_waiters.remove(&self.sink_id);
+                IcebergCompactionManager::apply_track_finish_action(
+                    &mut guard,
+                    self.sink_id,
+                    finish_action,
+                );
+                waiter
+            } else {
+                None
+            }
+        };
+
+        if let Some(waiter) = waiter {
+            let _ = waiter.send(Err(anyhow!(
+                "Iceberg compaction task failed before dispatch for sink {}",
+                self.sink_id
+            )
+            .into()));
         }
     }
 }
 
 #[derive(Debug, Clone, Copy)]
 enum SinkUpdateKind {
+    /// A normal sink commit. It only increases the pending snapshot count.
     Commit,
+    /// A force signal from the sink update path. It triggers the configured
+    /// compaction type and still follows the automatic-compaction config gate.
     ForceCompaction,
+    /// A user-triggered manual request. It can bypass disabled automatic
+    /// compaction and supplies the task type selected for this request.
+    ManualForceCompaction { task_type: TaskType },
 }
 
 impl SinkUpdateKind {
     fn apply_to_track(self, track: &mut CompactionTrack, now: Instant) {
         match self {
             SinkUpdateKind::Commit => track.record_commit(),
-            SinkUpdateKind::ForceCompaction => track.record_force_compaction(now),
+            SinkUpdateKind::ForceCompaction => track.record_force_compaction(now, None),
+            SinkUpdateKind::ManualForceCompaction { task_type } => {
+                track.record_force_compaction(now, Some(task_type))
+            }
         }
+    }
+
+    fn allows_disabled_compaction(self) -> bool {
+        matches!(self, SinkUpdateKind::ManualForceCompaction { .. })
     }
 }
 
@@ -406,7 +494,20 @@ pub struct IcebergCompactionScheduleStatus {
 }
 
 impl IcebergCompactionManager {
-    fn refresh_schedule_config(
+    fn apply_track_finish_action(
+        guard: &mut IcebergCompactionManagerInner,
+        sink_id: SinkId,
+        finish_action: CompactionTrackFinishAction,
+    ) {
+        match finish_action {
+            CompactionTrackFinishAction::KeepTrack => {}
+            CompactionTrackFinishAction::RemoveTrack => {
+                guard.sink_schedules.remove(&sink_id);
+            }
+        }
+    }
+
+    pub(super) fn refresh_schedule_config(
         &self,
         track: &mut CompactionTrack,
         iceberg_config: &IcebergConfig,
@@ -421,17 +522,6 @@ impl IcebergCompactionManager {
     }
 
     pub async fn update_iceberg_commit_info(&self, msg: IcebergSinkCompactionUpdate) {
-        let prepared_update = self.prepare_sink_update(msg, Instant::now()).await;
-
-        let mut guard = self.inner.write();
-        self.apply_sink_update(&mut guard, prepared_update);
-    }
-
-    async fn prepare_sink_update(
-        &self,
-        msg: IcebergSinkCompactionUpdate,
-        now: Instant,
-    ) -> PreparedSinkUpdate {
         let IcebergSinkCompactionUpdate {
             sink_id,
             force_compaction,
@@ -441,6 +531,20 @@ impl IcebergCompactionManager {
         } else {
             SinkUpdateKind::Commit
         };
+        let prepared_update = self
+            .prepare_sink_update(sink_id, kind, Instant::now())
+            .await;
+
+        let mut guard = self.inner.write();
+        self.apply_sink_update(&mut guard, prepared_update);
+    }
+
+    async fn prepare_sink_update(
+        &self,
+        sink_id: SinkId,
+        kind: SinkUpdateKind,
+        now: Instant,
+    ) -> PreparedSinkUpdate {
         let refresh_interval = self.config_refresh_interval();
         let (allow_track_initialization, should_refresh_config) = {
             let guard = self.inner.read();
@@ -479,7 +583,7 @@ impl IcebergCompactionManager {
         &self,
         guard: &mut IcebergCompactionManagerInner,
         prepared_update: PreparedSinkUpdate,
-    ) {
+    ) -> bool {
         let PreparedSinkUpdate {
             sink_id,
             kind,
@@ -496,22 +600,47 @@ impl IcebergCompactionManager {
                 guard.snapshot_expiration_sink_ids.remove(&sink_id);
             }
 
-            if !config.enable_compaction {
-                guard.sink_schedules.remove(&sink_id);
-                return;
+            if !config.enable_compaction && !kind.allows_disabled_compaction() {
+                if !guard.sink_schedules.get(&sink_id).is_some_and(|track| {
+                    matches!(
+                        &track.state,
+                        CompactionTrackState::PendingDispatch { .. }
+                            | CompactionTrackState::InFlight { .. }
+                    ) || track.removes_track_after_finish()
+                }) {
+                    guard.sink_schedules.remove(&sink_id);
+                }
+                return false;
             }
         }
 
         match guard.sink_schedules.entry(sink_id) {
             Entry::Occupied(entry) => {
                 let track = entry.into_mut();
+                if track.removes_track_after_finish()
+                    && !kind.allows_disabled_compaction()
+                    && !loaded_config
+                        .as_ref()
+                        .is_some_and(|config| config.enable_compaction)
+                {
+                    return false;
+                }
                 if track.should_refresh_config(now, refresh_interval)
                     && let Some(config) = loaded_config.as_ref()
                 {
                     self.refresh_schedule_config(track, config, now);
                 }
+                if let Some(config) = loaded_config.as_ref() {
+                    track.finish_action =
+                        if kind.allows_disabled_compaction() && !config.enable_compaction {
+                            CompactionTrackFinishAction::RemoveTrack
+                        } else {
+                            CompactionTrackFinishAction::KeepTrack
+                        };
+                }
 
                 kind.apply_to_track(track, now);
+                true
             }
             Entry::Vacant(entry) => {
                 if !allow_track_initialization {
@@ -519,7 +648,7 @@ impl IcebergCompactionManager {
                         sink_id = %sink_id,
                         "Ignoring iceberg compaction update because track disappeared before apply"
                     );
-                    return;
+                    return false;
                 }
 
                 let Some(config) = loaded_config.as_ref() else {
@@ -527,16 +656,23 @@ impl IcebergCompactionManager {
                         sink_id = %sink_id,
                         "Ignoring iceberg compaction update because sink config is unavailable"
                     );
-                    return;
+                    return false;
                 };
 
                 let track = entry.insert(self.create_compaction_track(config, now));
+                track.finish_action =
+                    if kind.allows_disabled_compaction() && !config.enable_compaction {
+                        CompactionTrackFinishAction::RemoveTrack
+                    } else {
+                        CompactionTrackFinishAction::KeepTrack
+                    };
                 kind.apply_to_track(track, now);
+                true
             }
         }
     }
 
-    fn create_compaction_track(
+    pub(super) fn create_compaction_track(
         &self,
         iceberg_config: &IcebergConfig,
         now: Instant,
@@ -570,53 +706,176 @@ impl IcebergCompactionManager {
         )
     }
 
+    pub(super) async fn start_manual_compaction(
+        &self,
+        sink_id: SinkId,
+    ) -> MetaResult<oneshot::Receiver<MetaResult<u64>>> {
+        let prepared_update = self
+            .prepare_sink_update(
+                sink_id,
+                SinkUpdateKind::ManualForceCompaction {
+                    task_type: TaskType::Full,
+                },
+                Instant::now(),
+            )
+            .await;
+        let mut guard = self.inner.write();
+        let now = Instant::now();
+        if guard.manual_compaction_waiters.contains_key(&sink_id) {
+            return Err(anyhow!(
+                "manual iceberg compaction is already waiting for sink {}",
+                sink_id
+            )
+            .into());
+        }
+
+        if let Some(track) = guard.sink_schedules.get(&sink_id) {
+            match &track.state {
+                CompactionTrackState::PendingDispatch {
+                    pending_commit_count_at_dispatch,
+                    ..
+                } => {
+                    return Err(anyhow!(
+                        "iceberg compaction task is already running for sink {} \
+                         (state=pending_dispatch, pending_commit_count_at_dispatch={}, \
+                         pending_commit_count={})",
+                        sink_id,
+                        pending_commit_count_at_dispatch,
+                        track.pending_commit_count
+                    )
+                    .into());
+                }
+                CompactionTrackState::InFlight {
+                    task_id,
+                    pending_commit_count_at_dispatch,
+                    report_deadline,
+                    ..
+                } => {
+                    return Err(anyhow!(
+                        "iceberg compaction task is already running for sink {} \
+                         (state=in_flight, task_id={}, pending_commit_count_at_dispatch={}, \
+                         pending_commit_count={}, report_timeout_after_sec={})",
+                        sink_id,
+                        task_id,
+                        pending_commit_count_at_dispatch,
+                        track.pending_commit_count,
+                        report_deadline.saturating_duration_since(now).as_secs()
+                    )
+                    .into());
+                }
+                CompactionTrackState::Idle { .. } => {}
+            }
+        }
+
+        if self.apply_sink_update(&mut guard, prepared_update) {
+            let (tx, rx) = oneshot::channel();
+            guard.manual_compaction_waiters.insert(sink_id, tx);
+            Ok(rx)
+        } else {
+            Err(anyhow!(
+                "failed to trigger manual iceberg compaction for sink {}",
+                sink_id
+            )
+            .into())
+        }
+    }
+
+    pub(super) fn cancel_manual_compaction_waiter(&self, sink_id: SinkId) {
+        self.inner
+            .write()
+            .manual_compaction_waiters
+            .remove(&sink_id);
+    }
+
+    fn finish_timed_out_compaction_tasks(
+        guard: &mut IcebergCompactionManagerInner,
+        now: Instant,
+    ) -> Vec<(SinkId, ManualCompactionWaiter)> {
+        let mut timed_out_tasks = Vec::new();
+        for (&sink_id, track) in &mut guard.sink_schedules {
+            if track.is_report_timed_out(now) {
+                tracing::warn!(sink_id = %sink_id, "Iceberg compaction task report timed out");
+                timed_out_tasks.push((sink_id, track.finish_failed(now)));
+            }
+        }
+
+        let mut timed_out_waiters = Vec::new();
+        for (sink_id, finish_action) in timed_out_tasks {
+            if let Some(waiter) = guard.manual_compaction_waiters.remove(&sink_id) {
+                timed_out_waiters.push((sink_id, waiter));
+            }
+            Self::apply_track_finish_action(guard, sink_id, finish_action);
+        }
+        timed_out_waiters
+    }
+
     pub(crate) fn get_top_n_iceberg_commit_sink_ids(
         &self,
         n: usize,
     ) -> Vec<IcebergCompactionHandle> {
         let now = Instant::now();
-        let mut guard = self.inner.write();
-        for (&sink_id, track) in &mut guard.sink_schedules {
-            if track.is_report_timed_out(now) {
-                tracing::warn!(sink_id = %sink_id, "Iceberg compaction task report timed out");
-                track.finish_failed(now);
+        let (handles, timed_out_waiters) = {
+            let mut guard = self.inner.write();
+            let timed_out_waiters = Self::finish_timed_out_compaction_tasks(&mut guard, now);
+
+            let mut candidates = Vec::new();
+            for (sink_id, track) in &guard.sink_schedules {
+                if track.should_trigger(now)
+                    && let CompactionTrackState::Idle {
+                        next_compaction_time,
+                        ..
+                    } = &track.state
+                {
+                    candidates.push((*sink_id, *next_compaction_time));
+                }
             }
+
+            candidates.sort_by(|a, b| a.1.cmp(&b.1));
+
+            let handles = candidates
+                .into_iter()
+                .take(n)
+                .filter_map(|(sink_id, _)| {
+                    let track = guard.sink_schedules.get_mut(&sink_id)?;
+                    let task_type = track.start_processing();
+
+                    Some(IcebergCompactionHandle::new(
+                        sink_id,
+                        task_type,
+                        self.inner.clone(),
+                        self.metadata_manager.clone(),
+                    ))
+                })
+                .collect();
+
+            (handles, timed_out_waiters)
+        };
+
+        for (sink_id, waiter) in timed_out_waiters {
+            let _ = waiter.send(Err(anyhow!(
+                "Iceberg compaction task report timed out for sink {}",
+                sink_id
+            )
+            .into()));
         }
 
-        let mut candidates = Vec::new();
-        for (sink_id, track) in &guard.sink_schedules {
-            if track.should_trigger(now)
-                && let CompactionTrackState::Idle {
-                    next_compaction_time,
-                } = &track.state
-            {
-                candidates.push((*sink_id, track.task_type, *next_compaction_time));
-            }
-        }
-
-        candidates.sort_by(|a, b| a.2.cmp(&b.2));
-
-        candidates
-            .into_iter()
-            .take(n)
-            .filter_map(|(sink_id, task_type, _)| {
-                let track = guard.sink_schedules.get_mut(&sink_id)?;
-                track.start_processing();
-
-                Some(IcebergCompactionHandle::new(
-                    sink_id,
-                    task_type,
-                    self.inner.clone(),
-                    self.metadata_manager.clone(),
-                ))
-            })
-            .collect()
+        handles
     }
 
     pub fn clear_iceberg_maintenance_by_sink_id(&self, sink_id: SinkId) {
-        let mut guard = self.inner.write();
-        guard.sink_schedules.remove(&sink_id);
-        guard.snapshot_expiration_sink_ids.remove(&sink_id);
+        let waiter = {
+            let mut guard = self.inner.write();
+            guard.sink_schedules.remove(&sink_id);
+            guard.snapshot_expiration_sink_ids.remove(&sink_id);
+            guard.manual_compaction_waiters.remove(&sink_id)
+        };
+        if let Some(waiter) = waiter {
+            let _ = waiter.send(Err(anyhow!(
+                "Iceberg compaction maintenance was cleared for sink {}",
+                sink_id
+            )
+            .into()));
+        }
     }
 
     pub fn list_compaction_statuses(&self) -> Vec<IcebergCompactionScheduleStatus> {
@@ -636,6 +895,7 @@ impl IcebergCompactionManager {
                 let next_compaction_after_sec = match &track.state {
                     CompactionTrackState::Idle {
                         next_compaction_time,
+                        ..
                     } => Some(
                         next_compaction_time
                             .saturating_duration_since(now)
@@ -648,7 +908,7 @@ impl IcebergCompactionManager {
 
                 IcebergCompactionScheduleStatus {
                     sink_id,
-                    task_type: track.task_type.as_str_name().to_ascii_lowercase(),
+                    task_type: track.current_task_type().as_str_name().to_ascii_lowercase(),
                     trigger_interval_sec: track.trigger_interval_sec,
                     trigger_snapshot_count: track.trigger_snapshot_count,
                     schedule_state: match track.state {
@@ -668,40 +928,47 @@ impl IcebergCompactionManager {
     }
 
     pub fn handle_report_task(&self, report: IcebergReportTask) {
-        if self.complete_manual_task_if_any(&report) {
-            return;
-        }
-
         let sink_id = SinkId::from(report.sink_id);
         let task_id = report.task_id;
         let status = IcebergReportTaskStatus::try_from(report.status)
             .unwrap_or(IcebergReportTaskStatus::Unspecified);
         let now = Instant::now();
 
-        let mut guard = self.inner.write();
-        let Some(track) = guard.sink_schedules.get_mut(&sink_id) else {
-            tracing::warn!(sink_id = %sink_id, task_id, "Received iceberg compaction report for unknown sink");
-            return;
+        let waiter = {
+            let mut guard = self.inner.write();
+            let mut waiter = None;
+
+            match guard.sink_schedules.get_mut(&sink_id) {
+                Some(track) if track.is_processing_task(task_id) => {
+                    let finish_action = match status {
+                        IcebergReportTaskStatus::Success => track.finish_success(now),
+                        IcebergReportTaskStatus::Failed | IcebergReportTaskStatus::Unspecified => {
+                            tracing::warn!(
+                                sink_id = %sink_id,
+                                task_id,
+                                error_message = report.error_message.clone().unwrap_or_default(),
+                                "Iceberg compaction task reported failure"
+                            );
+                            track.finish_failed(now)
+                        }
+                    };
+
+                    Self::apply_track_finish_action(&mut guard, sink_id, finish_action);
+                    waiter = guard.manual_compaction_waiters.remove(&sink_id);
+                }
+                Some(_) => {
+                    tracing::warn!(sink_id = %sink_id, task_id, "Ignoring stale iceberg compaction report");
+                }
+                None => {
+                    tracing::warn!(sink_id = %sink_id, task_id, "Received iceberg compaction report for unknown sink");
+                }
+            }
+
+            waiter
         };
 
-        if !track.is_processing_task(task_id) {
-            tracing::warn!(sink_id = %sink_id, task_id, "Ignoring stale iceberg compaction report");
-            return;
-        }
-
-        match status {
-            IcebergReportTaskStatus::Success => {
-                track.finish_success(now);
-            }
-            IcebergReportTaskStatus::Failed | IcebergReportTaskStatus::Unspecified => {
-                tracing::warn!(
-                    sink_id = %sink_id,
-                    task_id,
-                    error_message = report.error_message.unwrap_or_default(),
-                    "Iceberg compaction task reported failure"
-                );
-                track.finish_failed(now);
-            }
+        if let Some(waiter) = waiter {
+            Self::complete_manual_task_waiter(waiter, &report);
         }
     }
 }

--- a/src/meta/src/manager/iceberg_compaction/schedule/tests.rs
+++ b/src/meta/src/manager/iceberg_compaction/schedule/tests.rs
@@ -21,10 +21,13 @@ use super::*;
 use crate::controller::catalog::CatalogController;
 use crate::controller::cluster::ClusterController;
 use crate::hummock::IcebergCompactorManager;
+use crate::manager::MetaOpts;
 use crate::rpc::metrics::MetaMetrics;
 
 async fn build_test_manager() -> Arc<IcebergCompactionManager> {
-    let env = MetaSrvEnv::for_test().await;
+    let mut opts = MetaOpts::test(false);
+    opts.iceberg_compaction_report_timeout_sec = 30 * 60;
+    let env = MetaSrvEnv::for_test_opts(opts, |_| ()).await;
     let cluster_ctl = Arc::new(
         ClusterController::new(env.clone(), Duration::from_secs(1))
             .await
@@ -52,8 +55,10 @@ fn new_track(
         report_timeout: Duration::from_secs(30 * 60),
         last_config_refresh_at: now,
         pending_commit_count,
+        finish_action: CompactionTrackFinishAction::KeepTrack,
         state: CompactionTrackState::Idle {
             next_compaction_time: now + Duration::from_secs(trigger_interval_sec),
+            next_task_type_override: None,
         },
     }
 }
@@ -120,12 +125,14 @@ fn test_should_trigger_by_interval_only_with_pending_commits() {
     let mut track = new_track(now, 60, 10, 1);
     track.state = CompactionTrackState::Idle {
         next_compaction_time: now - Duration::from_secs(1),
+        next_task_type_override: None,
     };
     assert!(track.should_trigger(now));
 
     let mut empty_track = new_track(now, 60, 10, 0);
     empty_track.state = CompactionTrackState::Idle {
         next_compaction_time: now - Duration::from_secs(1),
+        next_task_type_override: None,
     };
     assert!(!empty_track.should_trigger(now));
 }
@@ -137,7 +144,7 @@ fn test_record_force_compaction_bootstraps_or_preserves_backlog() {
     for (initial_backlog, expected_backlog) in [(0, 1), (4, 4)] {
         let mut track = new_track(now, 300, 10, initial_backlog);
 
-        track.record_force_compaction(now);
+        track.record_force_compaction(now, None);
 
         assert_eq!(track.pending_commit_count, expected_backlog);
         assert!(track.should_trigger(now));
@@ -157,6 +164,7 @@ fn test_finish_success_clears_dispatched_baseline_and_starts_cooldown() {
     match track.state {
         CompactionTrackState::Idle {
             next_compaction_time,
+            ..
         } => assert!(next_compaction_time >= now + Duration::from_secs(120)),
         CompactionTrackState::PendingDispatch { .. } | CompactionTrackState::InFlight { .. } => {
             panic!("track should be idle")
@@ -177,6 +185,7 @@ fn test_finish_failed_preserves_backlog_and_allows_retry() {
     match track.state {
         CompactionTrackState::Idle {
             next_compaction_time,
+            ..
         } => assert!(next_compaction_time <= now),
         CompactionTrackState::PendingDispatch { .. } | CompactionTrackState::InFlight { .. } => {
             panic!("track should be idle")
@@ -216,6 +225,7 @@ fn test_revert_pre_dispatch_failure_restores_idle_without_losing_backlog() {
         match track.state {
             CompactionTrackState::Idle {
                 next_compaction_time,
+                ..
             } => assert_eq!(next_compaction_time, now + Duration::from_secs(120)),
             CompactionTrackState::PendingDispatch { .. }
             | CompactionTrackState::InFlight { .. } => {
@@ -243,7 +253,7 @@ fn test_force_compaction_does_not_make_processing_track_triggerable() {
     let mut track = new_track(now, 120, 10, 0);
     track.start_processing();
 
-    track.record_force_compaction(now);
+    track.record_force_compaction(now, None);
 
     assert!(!track.should_trigger(now));
 }
@@ -252,7 +262,7 @@ fn test_force_compaction_does_not_make_processing_track_triggerable() {
 fn test_finish_failed_after_force_keeps_force_backlog() {
     let now = Instant::now();
     let mut track = new_track(now, 120, 10, 0);
-    track.record_force_compaction(now);
+    track.record_force_compaction(now, None);
     start_in_flight(&mut track, 1, now);
 
     track.finish_failed(now);
@@ -265,7 +275,7 @@ fn test_finish_failed_after_force_keeps_force_backlog() {
 fn test_finish_success_after_force_consumes_force_backlog() {
     let now = Instant::now();
     let mut track = new_track(now, 120, 10, 0);
-    track.record_force_compaction(now);
+    track.record_force_compaction(now, None);
     start_in_flight(&mut track, 1, now);
 
     track.finish_success(now);
@@ -297,6 +307,7 @@ fn test_update_interval_resets_idle_deadline() {
     match track.state {
         CompactionTrackState::Idle {
             next_compaction_time,
+            ..
         } => assert_eq!(next_compaction_time, now + Duration::from_secs(300)),
         CompactionTrackState::PendingDispatch { .. } | CompactionTrackState::InFlight { .. } => {
             panic!("track should stay idle")
@@ -311,6 +322,7 @@ fn test_update_interval_same_value_keeps_existing_idle_deadline() {
     let original_deadline = match track.state {
         CompactionTrackState::Idle {
             next_compaction_time,
+            ..
         } => next_compaction_time,
         CompactionTrackState::PendingDispatch { .. } | CompactionTrackState::InFlight { .. } => {
             panic!("track should start idle")
@@ -322,6 +334,7 @@ fn test_update_interval_same_value_keeps_existing_idle_deadline() {
     match track.state {
         CompactionTrackState::Idle {
             next_compaction_time,
+            ..
         } => assert_eq!(next_compaction_time, original_deadline),
         CompactionTrackState::PendingDispatch { .. } | CompactionTrackState::InFlight { .. } => {
             panic!("track should stay idle")
@@ -407,6 +420,7 @@ async fn test_apply_sink_update_refreshes_existing_idle_track() {
     match track.state {
         CompactionTrackState::Idle {
             next_compaction_time,
+            ..
         } => assert_eq!(next_compaction_time, refresh_at + Duration::from_secs(300)),
         CompactionTrackState::PendingDispatch { .. } | CompactionTrackState::InFlight { .. } => {
             panic!("track should stay idle")
@@ -464,7 +478,7 @@ async fn test_apply_sink_update_creates_missing_track() {
     let mut guard = IcebergCompactionManagerInner {
         sink_schedules: HashMap::new(),
         snapshot_expiration_sink_ids: HashSet::new(),
-        manual_task_waiters: HashMap::new(),
+        manual_compaction_waiters: HashMap::new(),
     };
 
     manager.apply_sink_update(
@@ -498,7 +512,7 @@ async fn test_apply_sink_update_tracks_snapshot_expiration_without_compaction() 
     let mut guard = IcebergCompactionManagerInner {
         sink_schedules: HashMap::new(),
         snapshot_expiration_sink_ids: HashSet::new(),
-        manual_task_waiters: HashMap::new(),
+        manual_compaction_waiters: HashMap::new(),
     };
 
     manager.apply_sink_update(
@@ -517,6 +531,236 @@ async fn test_apply_sink_update_tracks_snapshot_expiration_without_compaction() 
 }
 
 #[tokio::test]
+async fn test_apply_manual_force_update_allows_disabled_compaction() {
+    let manager = build_test_manager().await;
+    let sink_id = SinkId::new(146);
+    let now = Instant::now();
+    let mut config = new_test_iceberg_config(300, 3, CompactionType::SmallFiles);
+    config.enable_compaction = false;
+    let mut guard = IcebergCompactionManagerInner {
+        sink_schedules: HashMap::new(),
+        snapshot_expiration_sink_ids: HashSet::new(),
+        manual_compaction_waiters: HashMap::new(),
+    };
+
+    let applied = manager.apply_sink_update(
+        &mut guard,
+        PreparedSinkUpdate {
+            sink_id,
+            kind: SinkUpdateKind::ManualForceCompaction {
+                task_type: TaskType::Full,
+            },
+            now,
+            allow_track_initialization: true,
+            loaded_config: Some(config),
+        },
+    );
+
+    assert!(applied);
+    let track = guard.sink_schedules.get(&sink_id).unwrap();
+    assert_eq!(track.pending_commit_count, 1);
+    assert!(track.should_trigger(now));
+    assert_eq!(
+        track.finish_action,
+        CompactionTrackFinishAction::RemoveTrack
+    );
+}
+
+#[tokio::test]
+async fn test_manual_force_update_uses_selected_task_type_once() {
+    let manager = build_test_manager().await;
+    let sink_id = SinkId::new(147);
+    let now = Instant::now();
+    let config = new_test_iceberg_config(300, 3, CompactionType::SmallFiles);
+    {
+        let mut guard = manager.inner.write();
+        let applied = manager.apply_sink_update(
+            &mut guard,
+            PreparedSinkUpdate {
+                sink_id,
+                kind: SinkUpdateKind::ManualForceCompaction {
+                    task_type: TaskType::FilesWithDelete,
+                },
+                now,
+                allow_track_initialization: true,
+                loaded_config: Some(config),
+            },
+        );
+
+        assert!(applied);
+        let track = guard.sink_schedules.get(&sink_id).unwrap();
+        assert_eq!(track.task_type, TaskType::SmallFiles);
+
+        let applied = manager.apply_sink_update(
+            &mut guard,
+            PreparedSinkUpdate {
+                sink_id,
+                kind: SinkUpdateKind::ForceCompaction,
+                now,
+                allow_track_initialization: false,
+                loaded_config: None,
+            },
+        );
+        assert!(applied);
+    }
+
+    let handles = manager.get_top_n_iceberg_commit_sink_ids(1);
+    assert_eq!(handles.len(), 1);
+    assert_eq!(handles[0].task_type, TaskType::FilesWithDelete);
+    drop(handles);
+
+    let handles = manager.get_top_n_iceberg_commit_sink_ids(1);
+    assert_eq!(handles.len(), 1);
+    assert_eq!(handles[0].task_type, TaskType::SmallFiles);
+}
+
+#[tokio::test]
+async fn test_apply_sink_update_keeps_processing_track_when_compaction_is_disabled() {
+    let manager = build_test_manager().await;
+    let sink_id = SinkId::new(145);
+    let task_id = 8;
+    let now = Instant::now();
+    let mut config = new_test_iceberg_config(300, 3, CompactionType::SmallFiles);
+    config.enable_compaction = false;
+    let mut track = new_track(now, 300, 3, 0);
+    track.start_processing();
+    track.mark_dispatched(task_id, now);
+    let mut guard = IcebergCompactionManagerInner {
+        sink_schedules: HashMap::from([(sink_id, track)]),
+        snapshot_expiration_sink_ids: HashSet::new(),
+        manual_compaction_waiters: HashMap::new(),
+    };
+
+    manager.apply_sink_update(
+        &mut guard,
+        PreparedSinkUpdate {
+            sink_id,
+            kind: SinkUpdateKind::Commit,
+            now,
+            allow_track_initialization: false,
+            loaded_config: Some(config),
+        },
+    );
+
+    assert!(matches!(
+        guard.sink_schedules.get(&sink_id).unwrap().state,
+        CompactionTrackState::InFlight { task_id: 8, .. }
+    ));
+}
+
+#[tokio::test]
+async fn test_apply_sink_update_keeps_temporary_manual_track_when_compaction_is_disabled() {
+    let manager = build_test_manager().await;
+    let sink_id = SinkId::new(148);
+    let now = Instant::now();
+    let mut config = new_test_iceberg_config(300, 3, CompactionType::SmallFiles);
+    config.enable_compaction = false;
+    let mut track = new_track(now, 300, 3, 1);
+    track.finish_action = CompactionTrackFinishAction::RemoveTrack;
+    let (tx, _rx) = tokio::sync::oneshot::channel();
+    let mut guard = IcebergCompactionManagerInner {
+        sink_schedules: HashMap::from([(sink_id, track)]),
+        snapshot_expiration_sink_ids: HashSet::new(),
+        manual_compaction_waiters: HashMap::from([(sink_id, tx)]),
+    };
+
+    let applied = manager.apply_sink_update(
+        &mut guard,
+        PreparedSinkUpdate {
+            sink_id,
+            kind: SinkUpdateKind::Commit,
+            now,
+            allow_track_initialization: false,
+            loaded_config: Some(config),
+        },
+    );
+
+    assert!(!applied);
+    assert!(guard.sink_schedules.contains_key(&sink_id));
+    assert!(guard.manual_compaction_waiters.contains_key(&sink_id));
+}
+
+#[tokio::test]
+async fn test_apply_sink_update_rejects_temporary_manual_processing_track_without_config() {
+    let manager = build_test_manager().await;
+    let sink_id = SinkId::new(149);
+    let task_id = 8;
+    let now = Instant::now();
+    let mut track = new_track(now, 300, 3, 1);
+    track.finish_action = CompactionTrackFinishAction::RemoveTrack;
+    start_in_flight(&mut track, task_id, now);
+    let mut guard = IcebergCompactionManagerInner {
+        sink_schedules: HashMap::from([(sink_id, track)]),
+        snapshot_expiration_sink_ids: HashSet::new(),
+        manual_compaction_waiters: HashMap::new(),
+    };
+
+    let applied = manager.apply_sink_update(
+        &mut guard,
+        PreparedSinkUpdate {
+            sink_id,
+            kind: SinkUpdateKind::Commit,
+            now,
+            allow_track_initialization: false,
+            loaded_config: None,
+        },
+    );
+
+    assert!(!applied);
+    let track = guard.sink_schedules.get(&sink_id).unwrap();
+    assert_eq!(track.pending_commit_count, 1);
+    assert!(matches!(
+        track.state,
+        CompactionTrackState::InFlight { task_id: 8, .. }
+    ));
+}
+
+#[tokio::test]
+async fn test_apply_sink_update_promotes_temporary_manual_track_when_compaction_enabled() {
+    let manager = build_test_manager().await;
+    let sink_id = SinkId::new(150);
+    let task_id = 9;
+    let now = Instant::now();
+    let mut track = new_track(now, 300, 3, 1);
+    track.finish_action = CompactionTrackFinishAction::RemoveTrack;
+    start_in_flight(&mut track, task_id, now);
+    let config = new_test_iceberg_config(300, 3, CompactionType::SmallFiles);
+    {
+        let mut guard = manager.inner.write();
+        guard.sink_schedules.insert(sink_id, track);
+
+        let applied = manager.apply_sink_update(
+            &mut guard,
+            PreparedSinkUpdate {
+                sink_id,
+                kind: SinkUpdateKind::Commit,
+                now,
+                allow_track_initialization: false,
+                loaded_config: Some(config),
+            },
+        );
+
+        assert!(applied);
+        let track = guard.sink_schedules.get(&sink_id).unwrap();
+        assert_eq!(track.pending_commit_count, 2);
+        assert_eq!(track.finish_action, CompactionTrackFinishAction::KeepTrack);
+    }
+
+    manager.handle_report_task(IcebergReportTask {
+        task_id,
+        sink_id: sink_id.as_raw_id(),
+        status: IcebergReportTaskStatus::Success as i32,
+        error_message: None,
+    });
+
+    let guard = manager.inner.read();
+    let track = guard.sink_schedules.get(&sink_id).unwrap();
+    assert_eq!(track.pending_commit_count, 1);
+    assert_eq!(track.finish_action, CompactionTrackFinishAction::KeepTrack);
+    assert!(matches!(track.state, CompactionTrackState::Idle { .. }));
+}
+
+#[tokio::test]
 async fn test_apply_sink_update_does_not_resurrect_disappeared_track() {
     let manager = build_test_manager().await;
     let sink_id = SinkId::new(45);
@@ -525,7 +769,7 @@ async fn test_apply_sink_update_does_not_resurrect_disappeared_track() {
     let mut guard = IcebergCompactionManagerInner {
         sink_schedules: HashMap::new(),
         snapshot_expiration_sink_ids: HashSet::new(),
-        manual_task_waiters: HashMap::new(),
+        manual_compaction_waiters: HashMap::new(),
     };
 
     manager.apply_sink_update(
@@ -550,6 +794,7 @@ async fn test_get_top_n_creates_pending_dispatch_handle_and_drop_restores_idle()
     let mut track = new_track(now, 120, 3, 3);
     track.state = CompactionTrackState::Idle {
         next_compaction_time: now - Duration::from_secs(1),
+        next_task_type_override: None,
     };
     manager.inner.write().sink_schedules.insert(sink_id, track);
 
@@ -570,6 +815,35 @@ async fn test_get_top_n_creates_pending_dispatch_handle_and_drop_restores_idle()
     let track = guard.sink_schedules.get(&sink_id).unwrap();
     assert_eq!(track.pending_commit_count, 3);
     assert!(matches!(track.state, CompactionTrackState::Idle { .. }));
+}
+
+#[tokio::test]
+async fn test_pre_dispatch_failure_notifies_manual_waiter_and_removes_temporary_track() {
+    let manager = build_test_manager().await;
+    let sink_id = SinkId::new(461);
+    let now = Instant::now();
+    let mut track = new_track(now, 120, 3, 1);
+    track.finish_action = CompactionTrackFinishAction::RemoveTrack;
+    track.start_processing();
+    let (tx, rx) = tokio::sync::oneshot::channel();
+    {
+        let mut guard = manager.inner.write();
+        guard.sink_schedules.insert(sink_id, track);
+        guard.manual_compaction_waiters.insert(sink_id, tx);
+    }
+
+    drop(IcebergCompactionHandle::new(
+        sink_id,
+        TaskType::Full,
+        manager.inner.clone(),
+        manager.metadata_manager.clone(),
+    ));
+
+    let error = rx.await.unwrap().unwrap_err();
+    assert!(error.to_string().contains("failed before dispatch"));
+    let guard = manager.inner.read();
+    assert!(!guard.sink_schedules.contains_key(&sink_id));
+    assert!(!guard.manual_compaction_waiters.contains_key(&sink_id));
 }
 
 #[tokio::test]
@@ -599,57 +873,382 @@ async fn test_handle_report_task_success_consumes_backlog_and_resets_to_idle() {
 async fn test_handle_report_task_completes_manual_waiter_on_success() {
     let manager = build_test_manager().await;
     let task_id = 42;
+    let sink_id = SinkId::new(47);
+    let now = Instant::now();
+    let mut track = new_track(now, 120, 10, 2);
+    track.start_processing();
+    track.mark_dispatched(task_id, now);
     let (tx, rx) = tokio::sync::oneshot::channel();
-    manager
-        .inner
-        .write()
-        .manual_task_waiters
-        .insert(task_id, tx);
+    {
+        let mut guard = manager.inner.write();
+        guard.sink_schedules.insert(sink_id, track);
+        guard.manual_compaction_waiters.insert(sink_id, tx);
+    }
 
     manager.handle_report_task(IcebergReportTask {
         task_id,
-        sink_id: SinkId::new(47).as_raw_id(),
+        sink_id: sink_id.as_raw_id(),
         status: IcebergReportTaskStatus::Success as i32,
         error_message: None,
     });
 
-    assert!(rx.await.unwrap().is_ok());
-    assert!(
-        !manager
-            .inner
-            .read()
-            .manual_task_waiters
-            .contains_key(&task_id)
-    );
+    assert_eq!(rx.await.unwrap().unwrap(), task_id);
+    let guard = manager.inner.read();
+    let track = guard.sink_schedules.get(&sink_id).unwrap();
+    assert_eq!(track.pending_commit_count, 0);
+    assert!(matches!(track.state, CompactionTrackState::Idle { .. }));
+    assert!(!guard.manual_compaction_waiters.contains_key(&sink_id));
 }
 
 #[tokio::test]
 async fn test_handle_report_task_completes_manual_waiter_on_failure() {
     let manager = build_test_manager().await;
     let task_id = 43;
+    let sink_id = SinkId::new(48);
+    let now = Instant::now();
+    let mut track = new_track(now, 120, 10, 2);
+    track.start_processing();
+    track.mark_dispatched(task_id, now);
     let (tx, rx) = tokio::sync::oneshot::channel();
-    manager
-        .inner
-        .write()
-        .manual_task_waiters
-        .insert(task_id, tx);
+    {
+        let mut guard = manager.inner.write();
+        guard.sink_schedules.insert(sink_id, track);
+        guard.manual_compaction_waiters.insert(sink_id, tx);
+    }
 
     manager.handle_report_task(IcebergReportTask {
         task_id,
-        sink_id: SinkId::new(48).as_raw_id(),
+        sink_id: sink_id.as_raw_id(),
         status: IcebergReportTaskStatus::Failed as i32,
         error_message: Some("boom".to_owned()),
     });
 
     let error = rx.await.unwrap().unwrap_err();
     assert!(error.to_string().contains("boom"));
+    let guard = manager.inner.read();
+    let track = guard.sink_schedules.get(&sink_id).unwrap();
+    assert_eq!(track.pending_commit_count, 2);
+    assert!(matches!(track.state, CompactionTrackState::Idle { .. }));
+    assert!(!guard.manual_compaction_waiters.contains_key(&sink_id));
+}
+
+#[tokio::test]
+async fn test_handle_report_task_removes_temporary_manual_track_on_success() {
+    let manager = build_test_manager().await;
+    let task_id = 44;
+    let sink_id = SinkId::new(49);
+    let now = Instant::now();
+    let mut track = new_track(now, 120, 10, 0);
+    track.finish_action = CompactionTrackFinishAction::RemoveTrack;
+    track.start_processing();
+    track.mark_dispatched(task_id, now);
+    let (tx, rx) = tokio::sync::oneshot::channel();
+    {
+        let mut guard = manager.inner.write();
+        guard.sink_schedules.insert(sink_id, track);
+        guard.manual_compaction_waiters.insert(sink_id, tx);
+    }
+
+    manager.handle_report_task(IcebergReportTask {
+        task_id,
+        sink_id: sink_id.as_raw_id(),
+        status: IcebergReportTaskStatus::Success as i32,
+        error_message: None,
+    });
+
+    assert_eq!(rx.await.unwrap().unwrap(), task_id);
+    let guard = manager.inner.read();
+    assert!(!guard.sink_schedules.contains_key(&sink_id));
+    assert!(!guard.manual_compaction_waiters.contains_key(&sink_id));
+}
+
+#[tokio::test]
+async fn test_handle_report_task_removes_temporary_manual_track_on_failure() {
+    let manager = build_test_manager().await;
+    let task_id = 45;
+    let sink_id = SinkId::new(149);
+    let now = Instant::now();
+    let mut track = new_track(now, 120, 10, 0);
+    track.finish_action = CompactionTrackFinishAction::RemoveTrack;
+    track.start_processing();
+    track.mark_dispatched(task_id, now);
+    let (tx, rx) = tokio::sync::oneshot::channel();
+    {
+        let mut guard = manager.inner.write();
+        guard.sink_schedules.insert(sink_id, track);
+        guard.manual_compaction_waiters.insert(sink_id, tx);
+    }
+
+    manager.handle_report_task(IcebergReportTask {
+        task_id,
+        sink_id: sink_id.as_raw_id(),
+        status: IcebergReportTaskStatus::Failed as i32,
+        error_message: Some("boom".to_owned()),
+    });
+
+    let error = rx.await.unwrap().unwrap_err();
+    assert!(error.to_string().contains("boom"));
+    let guard = manager.inner.read();
+    assert!(!guard.sink_schedules.contains_key(&sink_id));
+    assert!(!guard.manual_compaction_waiters.contains_key(&sink_id));
+}
+
+#[tokio::test]
+async fn test_cancel_manual_compaction_waiter_keeps_pending_track() {
+    let manager = build_test_manager().await;
+    let sink_id = SinkId::new(51);
+    let now = Instant::now();
+    let mut track = new_track(now, 120, 10, 2);
+    track.start_processing();
+    let (tx, rx) = tokio::sync::oneshot::channel();
+    {
+        let mut guard = manager.inner.write();
+        guard.sink_schedules.insert(sink_id, track);
+        guard.manual_compaction_waiters.insert(sink_id, tx);
+    }
+
+    manager.cancel_manual_compaction_waiter(sink_id);
+
+    assert!(rx.await.is_err());
+    let guard = manager.inner.read();
+    let track = guard.sink_schedules.get(&sink_id).unwrap();
+    assert_eq!(track.pending_commit_count, 2);
+    assert!(matches!(
+        track.state,
+        CompactionTrackState::PendingDispatch { .. }
+    ));
+    assert!(!guard.manual_compaction_waiters.contains_key(&sink_id));
+}
+
+#[tokio::test]
+async fn test_trigger_manual_compaction_does_not_register_waiter_during_config_load() {
+    let manager = build_test_manager().await;
+    let sink_id = SinkId::new(511);
+    let _compactor_rx = manager.iceberg_compactor_manager.add_compactor(1.into());
+    let catalog_write_guard = manager
+        .metadata_manager
+        .catalog_controller
+        .get_inner_write_guard()
+        .await;
+
+    let join_handle = {
+        let manager = manager.clone();
+        tokio::spawn(async move { manager.trigger_manual_compaction(sink_id).await })
+    };
+    for _ in 0..10 {
+        tokio::task::yield_now().await;
+    }
+
+    {
+        let guard = manager.inner.read();
+        assert!(!guard.manual_compaction_waiters.contains_key(&sink_id));
+        assert!(!guard.sink_schedules.contains_key(&sink_id));
+    }
+
+    join_handle.abort();
+    assert!(join_handle.await.unwrap_err().is_cancelled());
+    drop(catalog_write_guard);
+
+    let guard = manager.inner.read();
+    assert!(!guard.manual_compaction_waiters.contains_key(&sink_id));
+    assert!(!guard.sink_schedules.contains_key(&sink_id));
+}
+
+#[tokio::test]
+async fn test_manual_compaction_waiter_is_not_stolen_during_config_load() {
+    let manager = build_test_manager().await;
+    let sink_id = SinkId::new(512);
+    let task_id = 48;
+    let now = Instant::now();
+    let mut track = new_track(now, 120, 10, 1);
+    track.last_config_refresh_at = now - manager.config_refresh_interval();
+    manager.inner.write().sink_schedules.insert(sink_id, track);
+    let catalog_write_guard = manager
+        .metadata_manager
+        .catalog_controller
+        .get_inner_write_guard()
+        .await;
+
+    let join_handle = {
+        let manager = manager.clone();
+        tokio::spawn(async move { manager.start_manual_compaction(sink_id).await })
+    };
+    for _ in 0..10 {
+        tokio::task::yield_now().await;
+    }
+
+    {
+        let mut guard = manager.inner.write();
+        let track = guard.sink_schedules.get_mut(&sink_id).unwrap();
+        track.start_processing();
+        track.mark_dispatched(task_id, now);
+    }
+    manager.handle_report_task(IcebergReportTask {
+        task_id,
+        sink_id: sink_id.as_raw_id(),
+        status: IcebergReportTaskStatus::Success as i32,
+        error_message: None,
+    });
     assert!(
         !manager
             .inner
             .read()
-            .manual_task_waiters
-            .contains_key(&task_id)
+            .manual_compaction_waiters
+            .contains_key(&sink_id)
     );
+
+    drop(catalog_write_guard);
+    let waiter = join_handle.await.unwrap().unwrap();
+    assert!(
+        manager
+            .inner
+            .read()
+            .manual_compaction_waiters
+            .contains_key(&sink_id)
+    );
+    manager.cancel_manual_compaction_waiter(sink_id);
+    assert!(waiter.await.is_err());
+}
+
+#[tokio::test]
+async fn test_get_top_n_notifies_manual_waiter_on_report_timeout() {
+    let manager = build_test_manager().await;
+    let task_id = 46;
+    let sink_id = SinkId::new(52);
+    let now = Instant::now();
+    let mut track = new_track(now, 120, 10, 2);
+    track.report_timeout = Duration::from_secs(1);
+    start_in_flight(&mut track, task_id, now - Duration::from_secs(5));
+    let (tx, rx) = tokio::sync::oneshot::channel();
+    {
+        let mut guard = manager.inner.write();
+        guard.sink_schedules.insert(sink_id, track);
+        guard.manual_compaction_waiters.insert(sink_id, tx);
+    }
+
+    let handles = manager.get_top_n_iceberg_commit_sink_ids(1);
+
+    assert_eq!(handles.len(), 1);
+    let error = rx.await.unwrap().unwrap_err();
+    assert!(error.to_string().contains("timed out"));
+    let guard = manager.inner.read();
+    assert!(!guard.manual_compaction_waiters.contains_key(&sink_id));
+}
+
+#[tokio::test]
+async fn test_get_top_n_removes_temporary_manual_track_on_report_timeout() {
+    let manager = build_test_manager().await;
+    let task_id = 47;
+    let sink_id = SinkId::new(53);
+    let now = Instant::now();
+    let mut track = new_track(now, 120, 10, 0);
+    track.finish_action = CompactionTrackFinishAction::RemoveTrack;
+    track.report_timeout = Duration::from_secs(1);
+    start_in_flight(&mut track, task_id, now - Duration::from_secs(5));
+    let (tx, rx) = tokio::sync::oneshot::channel();
+    {
+        let mut guard = manager.inner.write();
+        guard.sink_schedules.insert(sink_id, track);
+        guard.manual_compaction_waiters.insert(sink_id, tx);
+    }
+
+    let handles = manager.get_top_n_iceberg_commit_sink_ids(1);
+
+    assert!(handles.is_empty());
+    let error = rx.await.unwrap().unwrap_err();
+    assert!(error.to_string().contains("timed out"));
+    let guard = manager.inner.read();
+    assert!(!guard.sink_schedules.contains_key(&sink_id));
+    assert!(!guard.manual_compaction_waiters.contains_key(&sink_id));
+}
+
+#[tokio::test]
+async fn test_clear_iceberg_maintenance_notifies_manual_waiter() {
+    let manager = build_test_manager().await;
+    let sink_id = SinkId::new(54);
+    let now = Instant::now();
+    let track = new_track(now, 120, 10, 1);
+    let (tx, rx) = tokio::sync::oneshot::channel();
+    {
+        let mut guard = manager.inner.write();
+        guard.sink_schedules.insert(sink_id, track);
+        guard.snapshot_expiration_sink_ids.insert(sink_id);
+        guard.manual_compaction_waiters.insert(sink_id, tx);
+    }
+
+    manager.clear_iceberg_maintenance_by_sink_id(sink_id);
+
+    let error = rx.await.unwrap().unwrap_err();
+    assert!(error.to_string().contains("was cleared"));
+    let guard = manager.inner.read();
+    assert!(!guard.sink_schedules.contains_key(&sink_id));
+    assert!(!guard.snapshot_expiration_sink_ids.contains(&sink_id));
+    assert!(!guard.manual_compaction_waiters.contains_key(&sink_id));
+}
+
+#[tokio::test]
+async fn test_trigger_manual_compaction_rejects_existing_task() {
+    let manager = build_test_manager().await;
+    let sink_id = SinkId::new(50);
+    let now = Instant::now();
+    let _compactor_rx = manager.iceberg_compactor_manager.add_compactor(1.into());
+    let mut track = new_track(now, 120, 10, 2);
+    start_in_flight(&mut track, 9, now);
+    manager.inner.write().sink_schedules.insert(sink_id, track);
+
+    let error = manager
+        .trigger_manual_compaction(sink_id)
+        .await
+        .unwrap_err();
+
+    let error = error.to_string();
+    assert!(error.contains("already running"));
+    assert!(error.contains("state=in_flight"));
+    assert!(error.contains("task_id=9"));
+    let guard = manager.inner.read();
+    assert!(!guard.manual_compaction_waiters.contains_key(&sink_id));
+    assert!(matches!(
+        guard.sink_schedules.get(&sink_id).unwrap().state,
+        CompactionTrackState::InFlight { task_id: 9, .. }
+    ));
+}
+
+#[tokio::test]
+async fn test_trigger_manual_compaction_rejects_without_compactor() {
+    let manager = build_test_manager().await;
+    let sink_id = SinkId::new(502);
+
+    let error = manager
+        .trigger_manual_compaction(sink_id)
+        .await
+        .unwrap_err();
+
+    assert!(error.to_string().contains("No iceberg compactor available"));
+    let guard = manager.inner.read();
+    assert!(!guard.manual_compaction_waiters.contains_key(&sink_id));
+    assert!(!guard.sink_schedules.contains_key(&sink_id));
+}
+
+#[tokio::test]
+async fn test_start_manual_compaction_rejects_existing_pending_task() {
+    let manager = build_test_manager().await;
+    let sink_id = SinkId::new(501);
+    let now = Instant::now();
+    let mut track = new_track(now, 120, 10, 2);
+    track.start_processing();
+    manager.inner.write().sink_schedules.insert(sink_id, track);
+
+    let error = manager.start_manual_compaction(sink_id).await.unwrap_err();
+
+    let error = error.to_string();
+    assert!(error.contains("already running"));
+    assert!(error.contains("state=pending_dispatch"));
+    let guard = manager.inner.read();
+    assert!(!guard.manual_compaction_waiters.contains_key(&sink_id));
+    assert!(matches!(
+        guard.sink_schedules.get(&sink_id).unwrap().state,
+        CompactionTrackState::PendingDispatch { .. }
+    ));
 }
 
 #[tokio::test]
@@ -682,7 +1281,12 @@ async fn test_handle_report_task_ignores_stale_task_id() {
     let now = Instant::now();
     let mut track = new_track(now, 120, 10, 2);
     start_in_flight(&mut track, 9, now);
-    manager.inner.write().sink_schedules.insert(sink_id, track);
+    let (tx, _rx) = tokio::sync::oneshot::channel();
+    {
+        let mut guard = manager.inner.write();
+        guard.sink_schedules.insert(sink_id, track);
+        guard.manual_compaction_waiters.insert(sink_id, tx);
+    }
 
     manager.handle_report_task(IcebergReportTask {
         task_id: 10,
@@ -698,6 +1302,7 @@ async fn test_handle_report_task_ignores_stale_task_id() {
         track.state,
         CompactionTrackState::InFlight { task_id: 9, .. }
     ));
+    assert!(guard.manual_compaction_waiters.contains_key(&sink_id));
 }
 
 #[tokio::test]


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

Refactor manual Iceberg compaction to reuse the existing per-sink scheduler track instead of dispatching a separate manual-only task path.

Main changes:

- Manual compaction now triggers the scheduler through `SinkUpdateKind::ManualForceCompaction { task_type: TaskType::Full }`.
- Manual waiters are keyed by sink and registered only after the scheduler update is accepted under the scheduler write lock.
- Existing `PendingDispatch` / `InFlight` tasks cause manual trigger to return immediately with current task state instead of attaching a waiter.
- Temporary manual tracks are supported when automatic compaction is disabled and are removed after report, report timeout, or pre-dispatch failure.
- Temporary manual tracks are promoted back to normal schedule tracks if auto compaction is re-enabled before the manual task finishes.

Manual compaction is now a thin trigger-and-wait API. The scheduler owns task selection, dispatch state, in-flight report timeout, report handling, and cleanup. Manual does not add a second caller-side timeout: the no-compactor fast path is preserved, and accepted tasks rely on scheduler report timeout.

Detailed design checkpoints and cross-review notes are archived in a PR comment.

## Checklist

- [ ] I have written necessary rustdoc comments.
- [x] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [x] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->

Tests run:

- `cargo test -p risingwave_meta manual --lib`
- `cargo test -p risingwave_meta iceberg_compaction --lib`
- `cargo fmt --check`
- `git diff --check`

Labels added: `type/refactor`, `A-meta`, `user-facing-changes`, `📖✗`, `ci/run-e2e-single-node-tests`, `ci/run-e2e-test-other-backends`, `ci/run-e2e-iceberg-tests`.

## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

Manual Iceberg compaction now shares the scheduled compaction lifecycle. If a sink already has a pending or in-flight Iceberg compaction task, a manual trigger returns the current task state instead of dispatching another task or waiting on the existing one.

</details>
