### PR TITLE
feat: guard DROP ... CASCADE behind session config

### DIFF
--- a/e2e_test/backfill/backfill_order_control.slt.part
+++ b/e2e_test/backfill/backfill_order_control.slt.part
@@ -1,4 +1,7 @@
 statement ok
+set allow_drop_cascade = true;
+
+statement ok
 SET RW_IMPLICIT_FLUSH TO TRUE;
 
 statement ok
@@ -140,3 +143,7 @@ drop table if exists car_info cascade;
 
 statement ok
 drop table if exists car_regions cascade;
+
+statement ok
+set allow_drop_cascade = false;
+

--- a/e2e_test/backfill/backfill_order_control_recovery.slt
+++ b/e2e_test/backfill/backfill_order_control_recovery.slt
@@ -1,3 +1,6 @@
+statement ok
+set allow_drop_cascade = true;
+
 # Test that after recovery, backfill order control can still allow the job to resume.
 statement ok
 SET RW_IMPLICIT_FLUSH TO TRUE;
@@ -82,3 +85,7 @@ drop table if exists t2 cascade;
 
 statement ok
 drop table if exists t3 cascade;
+
+statement ok
+set allow_drop_cascade = false;
+

--- a/e2e_test/backfill/backfill_order_control_recovery_progress.slt
+++ b/e2e_test/backfill/backfill_order_control_recovery_progress.slt
@@ -1,3 +1,6 @@
+statement ok
+set allow_drop_cascade = true;
+
 # Test that backfill order control maintains order after recovery
 # This test verifies:
 # 1. Backfill order is maintained with t1 -> t2
@@ -136,3 +139,7 @@ drop table t1 cascade;
 
 statement ok
 drop table t2 cascade;
+
+statement ok
+set allow_drop_cascade = false;
+

--- a/e2e_test/backfill/locality_backfill/shard_by_exact_key.slt
+++ b/e2e_test/backfill/locality_backfill/shard_by_exact_key.slt
@@ -1,4 +1,7 @@
 statement ok
+set allow_drop_cascade = true;
+
+statement ok
 set enable_locality_backfill=true;
 
 statement ok
@@ -41,3 +44,7 @@ flush;
 
 statement ok
 drop table t cascade;
+
+statement ok
+set allow_drop_cascade = false;
+

--- a/e2e_test/backfill/sink/test_sink_backfill_order_validation.slt
+++ b/e2e_test/backfill/sink/test_sink_backfill_order_validation.slt
@@ -1,4 +1,7 @@
 statement ok
+set allow_drop_cascade = true;
+
+statement ok
 SET RW_IMPLICIT_FLUSH TO TRUE;
 
 statement ok
@@ -85,3 +88,7 @@ drop table car_regions cascade;
 
 statement ok
 drop table t cascade;
+
+statement ok
+set allow_drop_cascade = false;
+

--- a/e2e_test/backfill/test_backfill_order_validation.slt
+++ b/e2e_test/backfill/test_backfill_order_validation.slt
@@ -1,4 +1,7 @@
 statement ok
+set allow_drop_cascade = true;
+
+statement ok
 SET RW_IMPLICIT_FLUSH TO TRUE;
 
 statement ok
@@ -97,3 +100,7 @@ drop table car_regions;
 
 statement ok
 drop table t;
+
+statement ok
+set allow_drop_cascade = false;
+

--- a/e2e_test/background_ddl/index.slt
+++ b/e2e_test/background_ddl/index.slt
@@ -1,4 +1,7 @@
 statement ok
+set allow_drop_cascade = true;
+
+statement ok
 SET RW_IMPLICIT_FLUSH TO true;
 
 statement ok
@@ -77,3 +80,7 @@ set backfill_rate_limit=default;
 
 statement ok
 set streaming_parallelism to default;
+
+statement ok
+set allow_drop_cascade = false;
+

--- a/e2e_test/background_ddl/sink.slt
+++ b/e2e_test/background_ddl/sink.slt
@@ -1,4 +1,7 @@
 statement ok
+set allow_drop_cascade = true;
+
+statement ok
 set streaming_parallelism=4;
 
 statement ok
@@ -101,3 +104,7 @@ set background_ddl=false;
 
 statement ok
 set backfill_rate_limit=default;
+
+statement ok
+set allow_drop_cascade = false;
+

--- a/e2e_test/backwards-compat-tests/slt/sink_into_table/validate_restart.slt
+++ b/e2e_test/backwards-compat-tests/slt/sink_into_table/validate_restart.slt
@@ -1,4 +1,7 @@
 statement ok
+set allow_drop_cascade = true;
+
+statement ok
 SET RW_IMPLICIT_FLUSH=true;
 
 statement ok
@@ -69,3 +72,7 @@ drop table sink_t3;
 
 statement ok
 drop table sink_t4;
+
+statement ok
+set allow_drop_cascade = false;
+

--- a/e2e_test/batch/basic/null_range_scan.slt.part
+++ b/e2e_test/batch/basic/null_range_scan.slt.part
@@ -1,4 +1,7 @@
 statement ok
+set allow_drop_cascade = true;
+
+statement ok
 SET RW_IMPLICIT_FLUSH TO true;
 
 statement ok
@@ -82,3 +85,7 @@ select * from rev_t where v > 15;
 
 statement ok
 drop table t cascade;
+
+statement ok
+set allow_drop_cascade = false;
+

--- a/e2e_test/batch/catalog/rw_depend.slt.part
+++ b/e2e_test/batch/catalog/rw_depend.slt.part
@@ -1,4 +1,7 @@
 statement ok
+set allow_drop_cascade = true;
+
+statement ok
 create table t1 (a int);
 
 statement ok
@@ -76,3 +79,7 @@ drop materialized view mv3;
 
 statement ok
 drop table t1;
+
+statement ok
+set allow_drop_cascade = false;
+

--- a/e2e_test/batch/duckdb/select/test_multi_column_reference.slt.part
+++ b/e2e_test/batch/duckdb/select/test_multi_column_reference.slt.part
@@ -1,3 +1,6 @@
+statement ok
+set allow_drop_cascade = true;
+
 # Copied from https://github.com/duckdb/duckdb (MIT licensed).
 # Copyright 2018-2022 Stichting DuckDB Foundation
 
@@ -250,3 +253,7 @@ DROP SCHEMA s1
 
 statement ok
 DROP SCHEMA s2
+
+statement ok
+set allow_drop_cascade = false;
+

--- a/e2e_test/batch/explain_analyze.slt
+++ b/e2e_test/batch/explain_analyze.slt
@@ -1,4 +1,7 @@
 statement ok
+set allow_drop_cascade = true;
+
+statement ok
 drop schema if exists explain_analyze_test cascade;
 
 statement ok
@@ -95,3 +98,7 @@ explain analyze (duration_secs 1) sink explain_analyze_test.s1;
 
 statement ok
 drop schema explain_analyze_test cascade;
+
+statement ok
+set allow_drop_cascade = false;
+

--- a/e2e_test/batch/types/jsonb_issue_23376.slt.part
+++ b/e2e_test/batch/types/jsonb_issue_23376.slt.part
@@ -1,3 +1,6 @@
+statement ok
+set allow_drop_cascade = true;
+
 # https://github.com/risingwavelabs/risingwave/issues/23376#issuecomment-3397462966
 
 statement ok
@@ -34,3 +37,7 @@ select * from mv;
 
 statement ok
 drop table t cascade;
+
+statement ok
+set allow_drop_cascade = false;
+

--- a/e2e_test/ddl/alter_resource_group.slt
+++ b/e2e_test/ddl/alter_resource_group.slt
@@ -1,4 +1,7 @@
 statement ok
+set allow_drop_cascade = true;
+
+statement ok
 create table t(v int);
 
 
@@ -50,3 +53,7 @@ alter system set license_key to default;
 
 statement ok
 drop table t cascade;
+
+statement ok
+set allow_drop_cascade = false;
+

--- a/e2e_test/ddl/alter_set_schema.slt
+++ b/e2e_test/ddl/alter_set_schema.slt
@@ -1,3 +1,6 @@
+statement ok
+set allow_drop_cascade = true;
+
 # ALTER CONNECTION SET SCHEMA is covered in `e2e_test/source_inline/connection/ddl.slt`
 
 statement ok
@@ -126,3 +129,7 @@ DROP TABLE test_schema.test_table cascade;
 
 statement ok
 DROP SCHEMA test_schema;
+
+statement ok
+set allow_drop_cascade = false;
+

--- a/e2e_test/ddl/alter_table_column.slt
+++ b/e2e_test/ddl/alter_table_column.slt
@@ -1,4 +1,7 @@
 statement ok
+set allow_drop_cascade = true;
+
+statement ok
 SET RW_IMPLICIT_FLUSH TO true;
 
 statement ok
@@ -241,3 +244,7 @@ select * from t where b = '1';
 
 statement ok
 drop table t;
+
+statement ok
+set allow_drop_cascade = false;
+

--- a/e2e_test/ddl/alter_table_column_type/basic.slt
+++ b/e2e_test/ddl/alter_table_column_type/basic.slt
@@ -1,4 +1,7 @@
 statement ok
+set allow_drop_cascade = true;
+
+statement ok
 SET RW_IMPLICIT_FLUSH TO true;
 
 statement ok
@@ -74,3 +77,7 @@ NULL
 
 statement ok
 drop table my_table cascade;
+
+statement ok
+set allow_drop_cascade = false;
+

--- a/e2e_test/ddl/alter_table_column_type/empty_struct.slt
+++ b/e2e_test/ddl/alter_table_column_type/empty_struct.slt
@@ -1,4 +1,7 @@
 statement ok
+set allow_drop_cascade = true;
+
+statement ok
 set RW_IMPLICIT_FLUSH to true;
 
 statement ok
@@ -67,3 +70,7 @@ NULL
 
 statement ok
 drop table t cascade;
+
+statement ok
+set allow_drop_cascade = false;
+

--- a/e2e_test/ddl/alter_table_column_type/with_downstream.slt
+++ b/e2e_test/ddl/alter_table_column_type/with_downstream.slt
@@ -1,4 +1,7 @@
 statement ok
+set allow_drop_cascade = true;
+
+statement ok
 set RW_IMPLICIT_FLUSH to true;
 
 statement ok
@@ -68,3 +71,7 @@ world   t       (t,world)
 
 statement ok
 drop table my_table cascade;
+
+statement ok
+set allow_drop_cascade = false;
+

--- a/e2e_test/ddl/alter_table_column_type/with_downstream_complex.slt
+++ b/e2e_test/ddl/alter_table_column_type/with_downstream_complex.slt
@@ -1,4 +1,7 @@
 statement ok
+set allow_drop_cascade = true;
+
+statement ok
 set RW_IMPLICIT_FLUSH to true;
 
 statement ok
@@ -29,3 +32,7 @@ world
 
 statement ok
 drop table my_table cascade;
+
+statement ok
+set allow_drop_cascade = false;
+

--- a/e2e_test/ddl/alter_table_column_type/with_index.slt
+++ b/e2e_test/ddl/alter_table_column_type/with_index.slt
@@ -1,4 +1,7 @@
 statement ok
+set allow_drop_cascade = true;
+
+statement ok
 set RW_IMPLICIT_FLUSH to true;
 
 statement ok
@@ -56,3 +59,7 @@ Field(v, 0:Int32)
 
 statement ok
 drop table my_table cascade;
+
+statement ok
+set allow_drop_cascade = false;
+

--- a/e2e_test/ddl/default_privilege.slt
+++ b/e2e_test/ddl/default_privilege.slt
@@ -1,4 +1,7 @@
 statement ok
+set allow_drop_cascade = true;
+
+statement ok
 CREATE USER john;
 
 statement ok
@@ -159,3 +162,7 @@ DROP SCHEMA test_schema CASCADE;
 
 statement ok
 DROP USER john;
+
+statement ok
+set allow_drop_cascade = false;
+

--- a/e2e_test/ddl/drop/drop_cascade_guard.slt
+++ b/e2e_test/ddl/drop/drop_cascade_guard.slt
@@ -1,0 +1,165 @@
+# Tests for the DROP CASCADE guard controlled by `allow_drop_cascade`.
+#
+# New clusters default to allow_drop_cascade = false (guard enabled).
+# Existing clusters default to allow_drop_cascade = true (backward-compatible).
+
+# Start with the guard explicitly enabled.
+statement ok
+set allow_drop_cascade = false;
+
+# --- Guard blocks CASCADE on table with dependents ---
+
+statement ok
+create table t_guard (a int);
+
+statement ok
+create view v_guard as select * from t_guard;
+
+statement ok
+create materialized view mv_guard as select * from v_guard;
+
+statement error DROP TABLE CASCADE is disabled
+drop table t_guard cascade;
+
+# Nothing should have been dropped.
+query I
+select count(*) from rw_tables where name = 't_guard';
+----
+1
+
+query I
+select count(*) from rw_views where name = 'v_guard';
+----
+1
+
+query I
+select count(*) from rw_materialized_views where name = 'mv_guard';
+----
+1
+
+# --- Guard blocks CASCADE even when the object has no dependents ---
+
+statement ok
+create table t_guard_nodep (a int);
+
+statement error DROP TABLE CASCADE is disabled
+drop table t_guard_nodep cascade;
+
+query I
+select count(*) from rw_tables where name = 't_guard_nodep';
+----
+1
+
+# --- RESTRICT drops are unaffected by the guard ---
+
+# RESTRICT fails when dependents exist (behavior unchanged).
+statement error
+drop table t_guard restrict;
+
+# RESTRICT succeeds when no dependents exist (behavior unchanged).
+statement ok
+drop table t_guard_nodep;
+
+# --- Enable allow_drop_cascade and verify CASCADE works ---
+
+statement ok
+set allow_drop_cascade = true;
+
+statement ok
+drop table t_guard cascade;
+
+query I
+select count(*) from rw_tables where name = 't_guard';
+----
+0
+
+query I
+select count(*) from rw_views where name = 'v_guard';
+----
+0
+
+query I
+select count(*) from rw_materialized_views where name = 'mv_guard';
+----
+0
+
+# --- CASCADE with allow_drop_cascade=true removes all dependents ---
+
+statement ok
+create table t_cascade_multi (a int);
+
+statement ok
+create materialized view mv_cascade_multi as select * from t_cascade_multi;
+
+statement ok
+create view v_cascade_multi as select * from mv_cascade_multi;
+
+statement ok
+create sink s_cascade_multi as select * from mv_cascade_multi with (connector = 'blackhole');
+
+statement ok
+drop table t_cascade_multi cascade;
+
+query I
+select count(*) from rw_tables where name = 't_cascade_multi';
+----
+0
+
+query I
+select count(*) from rw_materialized_views where name = 'mv_cascade_multi';
+----
+0
+
+query I
+select count(*) from rw_views where name = 'v_cascade_multi';
+----
+0
+
+query I
+select count(*) from rw_sinks where name = 's_cascade_multi';
+----
+0
+
+# --- Schema CASCADE with allow_drop_cascade=true ---
+
+statement ok
+create schema s_cascade_guard;
+
+statement ok
+create table s_cascade_guard.t1 (a int);
+
+statement ok
+create materialized view s_cascade_guard.mv1 as select * from s_cascade_guard.t1;
+
+statement ok
+drop schema s_cascade_guard cascade;
+
+query I
+select count(*) from rw_schemas where name = 's_cascade_guard';
+----
+0
+
+# --- Guard can be re-enabled per-session ---
+
+statement ok
+set allow_drop_cascade = false;
+
+statement ok
+create table t_retest (a int);
+
+statement ok
+create view v_retest as select * from t_retest;
+
+statement error DROP TABLE CASCADE is disabled
+drop table t_retest cascade;
+
+# Clean up
+statement ok
+drop view v_retest;
+
+statement ok
+drop table t_retest;
+
+# Reset to default.
+statement ok
+set allow_drop_cascade = false;

--- a/e2e_test/ddl/drop/drop_index_cascade.slt
+++ b/e2e_test/ddl/drop/drop_index_cascade.slt
@@ -1,4 +1,7 @@
 statement ok
+set allow_drop_cascade = true;
+
+statement ok
 set rw_streaming_enable_delta_join = true;
 
 statement ok
@@ -37,3 +40,6 @@ drop table b;
 
 statement ok
 set rw_streaming_enable_delta_join = false;
+
+statement ok
+set allow_drop_cascade = false;

--- a/e2e_test/ddl/drop/drop_mv_cascade.slt
+++ b/e2e_test/ddl/drop/drop_mv_cascade.slt
@@ -1,4 +1,7 @@
 statement ok
+set allow_drop_cascade = true;
+
+statement ok
 create materialized view mv as select 1 a
 
 statement ok
@@ -34,3 +37,6 @@ query T
 SELECT count(name) FROM rw_sinks WHERE name = 'my_sink';
 ----
 0
+
+statement ok
+set allow_drop_cascade = false;

--- a/e2e_test/ddl/drop/drop_schema_cascade.slt
+++ b/e2e_test/ddl/drop/drop_schema_cascade.slt
@@ -1,4 +1,7 @@
 statement ok
+set allow_drop_cascade = true;
+
+statement ok
 create schema schema1;
 
 statement ok
@@ -90,3 +93,6 @@ select count(name) FROM rw_sinks WHERE name = 's1' OR name = 's2';
 
 statement ok
 drop schema schema2 cascade;
+
+statement ok
+set allow_drop_cascade = false;

--- a/e2e_test/ddl/drop/drop_source_cascade.slt
+++ b/e2e_test/ddl/drop/drop_source_cascade.slt
@@ -1,4 +1,7 @@
 statement ok
+set allow_drop_cascade = true;
+
+statement ok
 create source my_source (a int, b int) with (
     connector = 'datagen',
     datagen.rows.per.second = '15',
@@ -38,4 +41,7 @@ query T
 SELECT count(name) FROM rw_sources WHERE name = 'my_source';
 ----
 0
+
+statement ok
+set allow_drop_cascade = false;
 

--- a/e2e_test/ddl/drop/drop_table_cascade.slt
+++ b/e2e_test/ddl/drop/drop_table_cascade.slt
@@ -1,4 +1,7 @@
 statement ok
+set allow_drop_cascade = true;
+
+statement ok
 create table t (a int, b int);
 
 statement ok
@@ -34,3 +37,6 @@ query T
 SELECT count(name) FROM rw_sinks WHERE name = 'my_sink';
 ----
 0
+
+statement ok
+set allow_drop_cascade = false;

--- a/e2e_test/ddl/drop/drop_view_cascade.slt
+++ b/e2e_test/ddl/drop/drop_view_cascade.slt
@@ -1,4 +1,7 @@
 statement ok
+set allow_drop_cascade = true;
+
+statement ok
 create view v as select 1;
 
 statement ok
@@ -26,4 +29,7 @@ query T
 SELECT count(name) FROM rw_materialized_views WHERE name = 'mv';
 ----
 0
+
+statement ok
+set allow_drop_cascade = false;
 

--- a/e2e_test/ddl/show.slt
+++ b/e2e_test/ddl/show.slt
@@ -1,4 +1,7 @@
 statement ok
+set allow_drop_cascade = true;
+
+statement ok
 create table if not exists t3 (v1 int, v2 int, v3 int) append only;
 
 statement ok
@@ -304,3 +307,7 @@ _rw_timestamp	timestamp with time zone	true	NULL
 
 statement ok
 drop table t5;
+
+statement ok
+set allow_drop_cascade = false;
+

--- a/e2e_test/error_ui/simple/recovery.slt
+++ b/e2e_test/error_ui/simple/recovery.slt
@@ -1,3 +1,6 @@
+statement ok
+set allow_drop_cascade = true;
+
 # TODO: the test triggers a recovery caused by a known issue: https://github.com/risingwavelabs/risingwave/issues/11915.
 # We should consider using a mechanism designed for testing recovery instead of depending on a bug.
 
@@ -33,3 +36,7 @@ ok
 
 statement ok
 drop table t cascade;
+
+statement ok
+set allow_drop_cascade = false;
+

--- a/e2e_test/iceberg/benches/predicate_pushdown.slt
+++ b/e2e_test/iceberg/benches/predicate_pushdown.slt
@@ -1,4 +1,7 @@
 statement ok
+set allow_drop_cascade = true;
+
+statement ok
 CREATE TABLE t_bench (i1 int, i2 varchar, i3 varchar);
 
 statement ok
@@ -63,3 +66,7 @@ DROP SOURCE iceberg_t_bench_source;
 
 statement ok
 DROP TABLE t_bench cascade;
+
+statement ok
+set allow_drop_cascade = false;
+

--- a/e2e_test/iceberg/test_case/iceberg_connection.slt
+++ b/e2e_test/iceberg/test_case/iceberg_connection.slt
@@ -1,4 +1,7 @@
 statement ok
+set allow_drop_cascade = true;
+
+statement ok
 set streaming_parallelism=4;
 
 statement ok
@@ -65,3 +68,7 @@ DROP TABLE s1 cascade;
 
 statement ok
 DROP CONNECTION conn;
+
+statement ok
+set allow_drop_cascade = false;
+

--- a/e2e_test/iceberg/test_case/iceberg_predicate_pushdown.slt
+++ b/e2e_test/iceberg/test_case/iceberg_predicate_pushdown.slt
@@ -1,4 +1,7 @@
 statement ok
+set allow_drop_cascade = true;
+
+statement ok
 set sink_decouple = false;
 
 statement ok
@@ -141,3 +144,7 @@ DROP SOURCE iceberg_t1_source;
 
 statement ok
 DROP TABLE s1 cascade;
+
+statement ok
+set allow_drop_cascade = false;
+

--- a/e2e_test/iceberg/test_case/iceberg_select_empty_table.slt
+++ b/e2e_test/iceberg/test_case/iceberg_select_empty_table.slt
@@ -1,4 +1,7 @@
 statement ok
+set allow_drop_cascade = true;
+
+statement ok
 set sink_decouple = false;
 
 statement ok
@@ -60,3 +63,7 @@ DROP SOURCE iceberg_t1_source;
 
 statement ok
 DROP TABLE s1 cascade;
+
+statement ok
+set allow_drop_cascade = false;
+

--- a/e2e_test/iceberg/test_case/iceberg_source_all_delete.slt
+++ b/e2e_test/iceberg/test_case/iceberg_source_all_delete.slt
@@ -1,3 +1,6 @@
+statement ok
+set allow_drop_cascade = true;
+
 # Deletions in a single commit are posistion delete, deletions across multiple commits are equail delete. sink_decouple = default(true), so we'll commit every 10s.
 statement ok
 set streaming_parallelism=4;
@@ -78,3 +81,7 @@ DROP SOURCE iceberg_t1_source;
 
 statement ok
 DROP TABLE s1 cascade;
+
+statement ok
+set allow_drop_cascade = false;
+

--- a/e2e_test/iceberg/test_case/iceberg_source_equality_delete.slt
+++ b/e2e_test/iceberg/test_case/iceberg_source_equality_delete.slt
@@ -1,3 +1,6 @@
+statement ok
+set allow_drop_cascade = true;
+
 # Deletions in a single commit are posistion delete, deletions across multiple commits are equail delete. sink_decouple = false, so we'll commit every 1s.
 statement ok
 set sink_decouple = false;
@@ -175,3 +178,7 @@ DROP SOURCE iceberg_s2_source;
 
 statement ok
 DROP TABLE s2 cascade;
+
+statement ok
+set allow_drop_cascade = false;
+

--- a/e2e_test/iceberg/test_case/iceberg_source_explain_for_delete.slt
+++ b/e2e_test/iceberg/test_case/iceberg_source_explain_for_delete.slt
@@ -1,3 +1,6 @@
+statement ok
+set allow_drop_cascade = true;
+
 # Deletions in a single commit are posistion delete, deletions across multiple commits are equail delete. sink_decouple = false, so we'll commit every 1s.
 statement ok
 set sink_decouple = false;
@@ -101,3 +104,7 @@ DROP SOURCE iceberg_t1_source;
 
 statement ok
 DROP TABLE s1 cascade;
+
+statement ok
+set allow_drop_cascade = false;
+

--- a/e2e_test/iceberg/test_case/iceberg_source_position_delete.slt
+++ b/e2e_test/iceberg/test_case/iceberg_source_position_delete.slt
@@ -1,3 +1,6 @@
+statement ok
+set allow_drop_cascade = true;
+
 # Deletions in a single commit are posistion delete, deletions across multiple commits are equail delete. sink_decouple = default(true), so we'll commit every 10s.
 statement ok
 set streaming_parallelism=4;
@@ -79,3 +82,7 @@ DROP SOURCE iceberg_t1_source;
 
 statement ok
 DROP TABLE s1 cascade;
+
+statement ok
+set allow_drop_cascade = false;
+

--- a/e2e_test/iceberg/test_case/iceberg_source_streaming.slt
+++ b/e2e_test/iceberg/test_case/iceberg_source_streaming.slt
@@ -1,4 +1,7 @@
 statement ok
+set allow_drop_cascade = true;
+
+statement ok
 SET RW_IMPLICIT_FLUSH = true;
 
 statement ok
@@ -231,3 +234,7 @@ DROP SOURCE iceberg_t1_source CASCADE;
 
 statement ok
 DROP TABLE s1 cascade;
+
+statement ok
+set allow_drop_cascade = false;
+

--- a/e2e_test/iceberg/test_case/pure_slt/iceberg_sink.slt
+++ b/e2e_test/iceberg/test_case/pure_slt/iceberg_sink.slt
@@ -1,3 +1,6 @@
+statement ok
+set allow_drop_cascade = true;
+
 system ok
 sparksql --e "
 DROP TABLE IF EXISTS demo.demo_db.e2e_demo_table PURGE;
@@ -168,3 +171,7 @@ sparksql --e "SELECT * FROM demo.demo_db.e2e_demo_table ORDER BY v1;" 2>/dev/nul
 
 system ok
 sparksql --e "drop table demo.demo_db.e2e_demo_table;"
+
+statement ok
+set allow_drop_cascade = false;
+

--- a/e2e_test/sink/bug_fixes/issue_24367.slt
+++ b/e2e_test/sink/bug_fixes/issue_24367.slt
@@ -1,3 +1,6 @@
+statement ok
+set allow_drop_cascade = true;
+
 # See https://github.com/risingwavelabs/risingwave/issues/24367
 
 control substitution on
@@ -41,3 +44,7 @@ select * from s;
 
 statement ok
 drop table s cascade;
+
+statement ok
+set allow_drop_cascade = false;
+

--- a/e2e_test/sink/kafka/protobuf.slt
+++ b/e2e_test/sink/kafka/protobuf.slt
@@ -1,4 +1,7 @@
 statement ok
+set allow_drop_cascade = true;
+
+statement ok
 set sink_decouple = false;
 
 system ok
@@ -252,3 +255,7 @@ rpk topic delete test-rw-sink-append-only-protobuf-csr-hi
 
 system ok
 rpk topic delete test-rw-sink-upsert-protobuf
+
+statement ok
+set allow_drop_cascade = false;
+

--- a/e2e_test/sink/postgres_sink.slt
+++ b/e2e_test/sink/postgres_sink.slt
@@ -1,5 +1,9 @@
 control substitution on
 
+statement ok
+set allow_drop_cascade = true;
+
+
 system ok
 PGDATABASE=postgres psql -c "DROP DATABASE IF EXISTS sink_test WITH (FORCE)"
 
@@ -652,3 +656,7 @@ PGDATABASE=sink_test psql -c "DROP TABLE pg_pk_only_table"
 
 system ok
 PGDATABASE=postgres psql -c "DROP DATABASE sink_test"
+
+statement ok
+set allow_drop_cascade = false;
+

--- a/e2e_test/sink/sink_into_table/alter_column.slt
+++ b/e2e_test/sink/sink_into_table/alter_column.slt
@@ -1,4 +1,7 @@
 statement ok
+set allow_drop_cascade = true;
+
+statement ok
 SET RW_IMPLICIT_FLUSH TO true;
 
 statement ok
@@ -669,3 +672,7 @@ drop table t_multi_c2;
 
 statement ok
 drop table m_multi_c;
+
+statement ok
+set allow_drop_cascade = false;
+

--- a/e2e_test/sink/sink_into_table/cascade_drop.slt
+++ b/e2e_test/sink/sink_into_table/cascade_drop.slt
@@ -1,4 +1,7 @@
 statement ok
+set allow_drop_cascade = true;
+
+statement ok
 SET RW_IMPLICIT_FLUSH TO true;
 
 statement ok
@@ -80,3 +83,7 @@ drop table t2;
 
 statement ok
 drop table t3;
+
+statement ok
+set allow_drop_cascade = false;
+

--- a/e2e_test/sink/sink_into_table/decoupled.slt
+++ b/e2e_test/sink/sink_into_table/decoupled.slt
@@ -1,4 +1,7 @@
 statement ok
+set allow_drop_cascade = true;
+
+statement ok
 DROP TABLE IF EXISTS s1_target cascade;
 
 statement ok
@@ -68,3 +71,7 @@ DROP TABLE fact cascade;
 
 statement ok
 DROP TABLE dim cascade;
+
+statement ok
+set allow_drop_cascade = false;
+

--- a/e2e_test/slow_tests/streaming/bug_fixes/issue_20342.slt.part
+++ b/e2e_test/slow_tests/streaming/bug_fixes/issue_20342.slt.part
@@ -1,4 +1,7 @@
 statement ok
+set allow_drop_cascade = true;
+
+statement ok
 set streaming_parallelism=1;
 
 # pk: [v1]
@@ -97,3 +100,7 @@ wait;
 
 statement ok
 drop table t cascade;
+
+statement ok
+set allow_drop_cascade = false;
+

--- a/e2e_test/source_inline/cdc/mongodb/mongodb_basic.slt
+++ b/e2e_test/source_inline/cdc/mongodb/mongodb_basic.slt
@@ -1,3 +1,6 @@
+statement ok
+set allow_drop_cascade = true;
+
 # CDC source basic test
 control substitution on
 
@@ -224,3 +227,7 @@ DROP TABLE phases;
 
 system ok
 mongosh 'mongodb://mongodb:27017' <<< 'db.all_types.drop();'
+
+statement ok
+set allow_drop_cascade = false;
+

--- a/e2e_test/source_inline/cdc/mysql/cdc_target.slt
+++ b/e2e_test/source_inline/cdc/mysql/cdc_target.slt
@@ -1,5 +1,9 @@
 control substitution on
 
+statement ok
+set allow_drop_cascade = true;
+
+
 # issue 21287
 system ok
 mysql -e "
@@ -65,3 +69,7 @@ drop table s;
 
 statement ok
 drop source mysql_source cascade;
+
+statement ok
+set allow_drop_cascade = false;
+

--- a/e2e_test/source_inline/cdc/mysql/mysql_create_drop.slt.serial
+++ b/e2e_test/source_inline/cdc/mysql/mysql_create_drop.slt.serial
@@ -1,3 +1,6 @@
+statement ok
+set allow_drop_cascade = true;
+
 # create and drop CDC mysql tables concurrently
 
 control substitution on
@@ -233,3 +236,7 @@ system ok
 mysql -e "
     SET GLOBAL time_zone = '+00:00';
 "
+
+statement ok
+set allow_drop_cascade = false;
+

--- a/e2e_test/source_inline/cdc/mysql/mysql_partition.slt
+++ b/e2e_test/source_inline/cdc/mysql/mysql_partition.slt
@@ -1,3 +1,6 @@
+statement ok
+set allow_drop_cascade = true;
+
 # Test MySQL CDC support for partitioned tables (both single-level and sub-partitioned tables)
 
 control substitution on
@@ -176,3 +179,7 @@ system ok
 mysql -e "
     SET GLOBAL time_zone = '+00:00';
 "
+
+statement ok
+set allow_drop_cascade = false;
+

--- a/e2e_test/source_inline/cdc/mysql/mysql_timestamptz_as_pk.slt
+++ b/e2e_test/source_inline/cdc/mysql/mysql_timestamptz_as_pk.slt
@@ -1,3 +1,6 @@
+statement ok
+set allow_drop_cascade = true;
+
 # Test MySQL CDC with TIMESTAMPTZ as primary key
 # This test verifies that TIMESTAMPTZ primary key works correctly in CDC backfill
 
@@ -139,3 +142,7 @@ mysql -e "
     USE risedev;
     DROP TABLE IF EXISTS ts_pk_test;
 "
+
+statement ok
+set allow_drop_cascade = false;
+

--- a/e2e_test/source_inline/cdc/mysql/mysql_watermark_ttl.slt
+++ b/e2e_test/source_inline/cdc/mysql/mysql_watermark_ttl.slt
@@ -1,6 +1,10 @@
 control substitution on
 
 statement ok
+set allow_drop_cascade = true;
+
+
+statement ok
 SET streaming_parallelism TO 1;
 
 system ok
@@ -92,3 +96,7 @@ mysql -e "
     USE risedev;
     DROP TABLE IF EXISTS mysql_cdc_watermark_ttl_test;
 "
+
+statement ok
+set allow_drop_cascade = false;
+

--- a/e2e_test/source_inline/cdc/mysql/test_unsigned_int.slt
+++ b/e2e_test/source_inline/cdc/mysql/test_unsigned_int.slt
@@ -1,3 +1,6 @@
+statement ok
+set allow_drop_cascade = true;
+
 # Test MySQL CDC with UNSIGNED BIGINT handling
 # This test verifies that UNSIGNED BIGINT values are handled correctly in CDC backfill
 # with debezium.bigint.unsigned.handling.mode='precise'
@@ -241,3 +244,7 @@ mysql -e "
     USE risedev;
     DROP TABLE IF EXISTS test_unsigned_int;
 "
+
+statement ok
+set allow_drop_cascade = false;
+

--- a/e2e_test/source_inline/cdc/postgres/postgres_publication_reuse.slt
+++ b/e2e_test/source_inline/cdc/postgres/postgres_publication_reuse.slt
@@ -1,3 +1,6 @@
+statement ok
+set allow_drop_cascade = true;
+
 # Test: Publication reuse causes column mismatch
 # This test requires PostgreSQL 15+ for partial publication support
 control substitution on
@@ -152,3 +155,7 @@ psql -c "
     DROP TABLE IF EXISTS users CASCADE;
     DROP PUBLICATION IF EXISTS rw_test_publication;
     "
+
+statement ok
+set allow_drop_cascade = false;
+

--- a/e2e_test/source_inline/cdc/postgres/postgres_schema_check_and_schema_change.slt
+++ b/e2e_test/source_inline/cdc/postgres/postgres_schema_check_and_schema_change.slt
@@ -1,5 +1,9 @@
 control substitution on
 
+statement ok
+set allow_drop_cascade = true;
+
+
 system ok
 psql -c "
     DROP TABLE IF EXISTS t;
@@ -431,3 +435,7 @@ psql -c "
     DROP EXTENSION IF EXISTS ltree;
     DROP EXTENSION IF EXISTS hstore;
 "
+
+statement ok
+set allow_drop_cascade = false;
+

--- a/e2e_test/source_inline/cdc/sql_server/sql_server_cdc.slt.serial
+++ b/e2e_test/source_inline/cdc/sql_server/sql_server_cdc.slt.serial
@@ -1,3 +1,6 @@
+statement ok
+set allow_drop_cascade = true;
+
 
 control substitution on
 
@@ -667,3 +670,7 @@ drop source upper_mssql_source cascade;
 
 statement ok
 drop source mssql_source cascade;
+
+statement ok
+set allow_drop_cascade = false;
+

--- a/e2e_test/source_inline/cdc/sql_server/sql_server_timestamp.slt.serial
+++ b/e2e_test/source_inline/cdc/sql_server/sql_server_timestamp.slt.serial
@@ -1,5 +1,9 @@
 control substitution on
 
+statement ok
+set allow_drop_cascade = true;
+
+
 # ------------ data prepare stage ------------
 system ok
 sqlcmd -C -d master -Q 'create database sqlserver_timestamp_db;' -b
@@ -73,3 +77,7 @@ select id, timestamp, time_col from timestamp_test order by id;
 # ------------ drop stage ------------
 statement ok
 drop source mssql_timestamp_source cascade;
+
+statement ok
+set allow_drop_cascade = false;
+

--- a/e2e_test/source_inline/connection/drop_connection_cascade.slt
+++ b/e2e_test/source_inline/connection/drop_connection_cascade.slt
@@ -2,6 +2,9 @@ control substitution on
 
 # Test DROP CONNECTION CASCADE functionality
 
+statement ok
+set allow_drop_cascade = true;
+
 # for non-shared source
 statement ok
 set streaming_use_shared_source to false;
@@ -137,3 +140,6 @@ select count(*) from rw_connections where name = 'conn_no_deps';
 
 statement ok
 set streaming_use_shared_source to true;
+
+statement ok
+set allow_drop_cascade = false;

--- a/e2e_test/source_inline/connection/drop_secret_cascade.slt
+++ b/e2e_test/source_inline/connection/drop_secret_cascade.slt
@@ -4,6 +4,9 @@
 
 control substitution on
 
+statement ok
+set allow_drop_cascade = true;
+
 # for non-shared source
 statement ok
 set streaming_use_shared_source to false;
@@ -154,3 +157,6 @@ DROP TABLE sink_table;
 
 statement ok
 set streaming_use_shared_source to true;
+
+statement ok
+set allow_drop_cascade = false;

--- a/e2e_test/source_inline/connection/issue-22513.slt
+++ b/e2e_test/source_inline/connection/issue-22513.slt
@@ -1,6 +1,10 @@
 control substitution on
 
 statement ok
+set allow_drop_cascade = true;
+
+
+statement ok
 create schema test_schema;
 
 statement ok
@@ -22,3 +26,7 @@ drop connection conn1;
 
 statement ok
 drop schema test_schema cascade;
+
+statement ok
+set allow_drop_cascade = false;
+

--- a/e2e_test/source_inline/kafka/alter/add_column_shared.slt
+++ b/e2e_test/source_inline/kafka/alter/add_column_shared.slt
@@ -1,5 +1,9 @@
 control substitution on
 
+statement ok
+set allow_drop_cascade = true;
+
+
 system ok
 rpk topic create shared_source_alter -p 4
 
@@ -211,3 +215,7 @@ drop source s cascade;
 
 system ok
 rpk topic delete shared_source_alter;
+
+statement ok
+set allow_drop_cascade = false;
+

--- a/e2e_test/source_inline/kafka/alter/alter_connector_props_non_shared_source.slt
+++ b/e2e_test/source_inline/kafka/alter/alter_connector_props_non_shared_source.slt
@@ -1,6 +1,10 @@
 control substitution on
 
 statement ok
+set allow_drop_cascade = true;
+
+
+statement ok
 create secret s1 with ( backend = 'meta' ) as '1000000000';
 
 
@@ -261,3 +265,7 @@ rpk topic delete test_alter_non_shared_source_conn -X brokers=message_queue_sasl
 
 statement ok
 set streaming_use_shared_source to true;
+
+statement ok
+set allow_drop_cascade = false;
+

--- a/e2e_test/source_inline/kafka/alter/alter_parallelism.slt
+++ b/e2e_test/source_inline/kafka/alter/alter_parallelism.slt
@@ -1,3 +1,6 @@
+statement ok
+set allow_drop_cascade = true;
+
 # Note: this test should use 4 parallelism, depending on the risedev profile.
 # TODO: test-specific risedev profile https://github.com/risingwavelabs/risingwave/issues/20525
 
@@ -197,3 +200,7 @@ Use `ALTER MATERIALIZED VIEW` to alter the materialized view using the source in
 
 system ok
 rpk topic delete alter_parallelism;
+
+statement ok
+set allow_drop_cascade = false;
+

--- a/e2e_test/source_inline/kafka/alter/rate_limit_source_kafka_shared.slt.serial
+++ b/e2e_test/source_inline/kafka/alter/rate_limit_source_kafka_shared.slt.serial
@@ -1,5 +1,9 @@
 control substitution on
 
+statement ok
+set allow_drop_cascade = true;
+
+
 system ok
 rpk topic delete test_rate_limit_shared || true
 
@@ -169,3 +173,7 @@ drop table kafka_seed_data cascade;
 
 system ok
 rpk topic delete test_rate_limit_shared || true
+
+statement ok
+set allow_drop_cascade = false;
+

--- a/e2e_test/source_inline/kafka/alter/source_rate_limit_inflight_sync.slt.serial
+++ b/e2e_test/source_inline/kafka/alter/source_rate_limit_inflight_sync.slt.serial
@@ -1,3 +1,6 @@
+statement ok
+set allow_drop_cascade = true;
+
 # Regression: `ALTER SOURCE source_rate_limit` updates DB and notifies running actors via
 # `Mutation::Throttle`, but historically did not refresh `database_info.fragment(..).nodes`.
 # A subsequent reschedule (e.g. `ALTER SOURCE SET PARALLELISM`) materialized fresh source
@@ -135,3 +138,7 @@ drop table seed;
 
 system ok
 rpk topic delete test_rl_inflight_sync || true
+
+statement ok
+set allow_drop_cascade = false;
+

--- a/e2e_test/source_inline/kafka/avro/alter_source.slt
+++ b/e2e_test/source_inline/kafka/avro/alter_source.slt
@@ -1,6 +1,10 @@
 control substitution on
 
 statement ok
+set allow_drop_cascade = true;
+
+
+statement ok
 SET streaming_use_shared_source TO false;
 
 # https://github.com/risingwavelabs/risingwave/issues/16486
@@ -77,3 +81,7 @@ drop source s cascade;
 
 statement ok
 SET streaming_use_shared_source TO true;
+
+statement ok
+set allow_drop_cascade = false;
+

--- a/e2e_test/source_inline/kafka/shared_source.slt.serial
+++ b/e2e_test/source_inline/kafka/shared_source.slt.serial
@@ -1,6 +1,10 @@
 control substitution on
 
 statement ok
+set allow_drop_cascade = true;
+
+
+statement ok
 SET streaming_use_shared_source TO true;
 
 system ok
@@ -322,3 +326,7 @@ drop source s_latest cascade;
 
 system ok
 rpk topic delete shared_source;
+
+statement ok
+set allow_drop_cascade = false;
+

--- a/e2e_test/source_inline/kafka/shared_source_latest.serial
+++ b/e2e_test/source_inline/kafka/shared_source_latest.serial
@@ -1,3 +1,6 @@
+statement ok
+set allow_drop_cascade = true;
+
 # Demonstrate that multiple MVs created from a shared source with `scan.startup.mode = 'latest'`
 # will use the same start offset resolved at the time when the source is created, no matter when
 # the MV is created.
@@ -85,3 +88,7 @@ rpk topic delete shared_source_latest
 
 statement ok
 SET streaming_use_shared_source TO DEFAULT;
+
+statement ok
+set allow_drop_cascade = false;
+

--- a/e2e_test/source_inline/refresh/refresh_table.slt
+++ b/e2e_test/source_inline/refresh/refresh_table.slt
@@ -1,3 +1,6 @@
+statement ok
+set allow_drop_cascade = true;
+
 # Test cases for refreshable table functionality using batch_posix_fs connector
 # This test validates the REFRESH TABLE command and covers insert, update, delete scenarios
 
@@ -358,3 +361,7 @@ DROP TABLE refresh_fs_t_on_conflict_ignore;
 
 system ok
 rm -rf ./e2e_test/source_inline/refresh/refresh_table_tmp
+
+statement ok
+set allow_drop_cascade = false;
+

--- a/e2e_test/source_legacy/cdc/cdc_share_stream_drop.slt
+++ b/e2e_test/source_legacy/cdc/cdc_share_stream_drop.slt
@@ -1,3 +1,6 @@
+statement ok
+set allow_drop_cascade = true;
+
 # drop relations created in cdc_share_stream.slt
 
 statement ok
@@ -8,3 +11,7 @@ drop materialized view products_test_cnt;
 
 statement error
 drop table products_test cascade;
+
+statement ok
+set allow_drop_cascade = false;
+

--- a/e2e_test/source_legacy/cdc_inline/alter/cdc_backfill_rate_limit.slt
+++ b/e2e_test/source_legacy/cdc_inline/alter/cdc_backfill_rate_limit.slt
@@ -1,5 +1,9 @@
 control substitution on
 
+statement ok
+set allow_drop_cascade = true;
+
+
 # mysql env vars will be read from the `.risingwave/config/risedev-env` file
 
 system ok
@@ -77,3 +81,7 @@ drop table my_orders;
 
 statement ok
 drop source mysql_source cascade;
+
+statement ok
+set allow_drop_cascade = false;
+

--- a/e2e_test/source_legacy/cdc_inline/alter/cdc_table_alter.slt
+++ b/e2e_test/source_legacy/cdc_inline/alter/cdc_table_alter.slt
@@ -1,5 +1,9 @@
 control substitution on
 
+statement ok
+set allow_drop_cascade = true;
+
+
 # mysql env vars will be read from the `.risingwave/config/risedev-env` file
 
 system ok
@@ -238,3 +242,7 @@ drop source mysql_source cascade;
 
 statement ok
 drop source pg_source cascade;
+
+statement ok
+set allow_drop_cascade = false;
+

--- a/e2e_test/source_legacy/cdc_inline/auto_schema_change_mysql.slt
+++ b/e2e_test/source_legacy/cdc_inline/auto_schema_change_mysql.slt
@@ -1,5 +1,9 @@
 control substitution on
 
+statement ok
+set allow_drop_cascade = true;
+
+
 system ok
 mysql -e "DROP DATABASE IF EXISTS mytest; CREATE DATABASE mytest;"
 
@@ -143,3 +147,7 @@ table description rw_customers NULL NULL
 
 statement ok
 drop source mysql_source cascade;
+
+statement ok
+set allow_drop_cascade = false;
+

--- a/e2e_test/source_legacy/cdc_inline/auto_schema_change_pg.slt
+++ b/e2e_test/source_legacy/cdc_inline/auto_schema_change_pg.slt
@@ -1,5 +1,9 @@
 control substitution on
 
+statement ok
+set allow_drop_cascade = true;
+
+
 system ok
 psql -c "
     DROP TABLE IF EXISTS test_schema_change;
@@ -284,3 +288,7 @@ SELECT id, name, description, new_col from rw_test_include_ts order by id;
 
 statement ok
 drop source pg_source_ts cascade;
+
+statement ok
+set allow_drop_cascade = false;
+

--- a/e2e_test/source_legacy/cdc_inline/auto_schema_map_mysql.slt
+++ b/e2e_test/source_legacy/cdc_inline/auto_schema_map_mysql.slt
@@ -1,5 +1,9 @@
 control substitution on
 
+statement ok
+set allow_drop_cascade = true;
+
+
 # test case need to cover all data types
 system ok
 mysql --protocol=tcp -u root -e "DROP DATABASE IF EXISTS mytest; CREATE DATABASE mytest;"
@@ -185,3 +189,7 @@ FROM rw_mysql_types_test order by c_boolean;
 
 statement ok
 drop source mysql_source cascade;
+
+statement ok
+set allow_drop_cascade = false;
+

--- a/e2e_test/source_legacy/cdc_inline/auto_schema_map_pg.slt
+++ b/e2e_test/source_legacy/cdc_inline/auto_schema_map_pg.slt
@@ -1,5 +1,9 @@
 control substitution on
 
+statement ok
+set allow_drop_cascade = true;
+
+
 # test case need to cover all data types
 system ok
 psql -c "
@@ -215,3 +219,7 @@ SELECT
 
 statement ok
 drop source pg_source cascade;
+
+statement ok
+set allow_drop_cascade = false;
+

--- a/e2e_test/streaming/aggregate/two_phase_approx_percentile_merge.slt
+++ b/e2e_test/streaming/aggregate/two_phase_approx_percentile_merge.slt
@@ -1,3 +1,6 @@
+statement ok
+set allow_drop_cascade = true;
+
 # Single phase approx percentile
 
 onlyif can-use-recover
@@ -121,3 +124,7 @@ drop materialized view m1;
 
 statement ok
 drop table t;
+
+statement ok
+set allow_drop_cascade = false;
+

--- a/e2e_test/streaming/aggregate/wrap_scalar.slt
+++ b/e2e_test/streaming/aggregate/wrap_scalar.slt
@@ -1,4 +1,7 @@
 statement ok
+set allow_drop_cascade = true;
+
+statement ok
 SET RW_IMPLICIT_FLUSH TO true;
 
 statement ok
@@ -60,3 +63,7 @@ select * from mv3 order by b;
 
 statement ok
 drop table t cascade;
+
+statement ok
+set allow_drop_cascade = false;
+

--- a/e2e_test/streaming/alter_mv/alter_mv_simple.slt
+++ b/e2e_test/streaming/alter_mv/alter_mv_simple.slt
@@ -1,4 +1,7 @@
 statement ok
+set allow_drop_cascade = true;
+
+statement ok
 SET RW_IMPLICIT_FLUSH TO true;
 
 statement ok
@@ -80,3 +83,7 @@ select * from mv_count;
 
 statement ok
 drop table t cascade;
+
+statement ok
+set allow_drop_cascade = false;
+

--- a/e2e_test/streaming/bug_fixes/issue_15302.slt
+++ b/e2e_test/streaming/bug_fixes/issue_15302.slt
@@ -1,3 +1,6 @@
+statement ok
+set allow_drop_cascade = true;
+
 # https://github.com/risingwavelabs/risingwave/issues/15302
 
 statement ok
@@ -42,3 +45,7 @@ drop materialized view test_last_ingestion_time cascade;
 
 statement ok
 drop materialized view test_records;
+
+statement ok
+set allow_drop_cascade = false;
+

--- a/e2e_test/streaming/cross_db_mv.slt
+++ b/e2e_test/streaming/cross_db_mv.slt
@@ -1,4 +1,7 @@
 statement ok
+set allow_drop_cascade = true;
+
+statement ok
 SET RW_IMPLICIT_FLUSH TO true;
 
 statement ok
@@ -97,3 +100,7 @@ drop database d2;
 connection other
 statement ok
 drop database d1;
+
+statement ok
+set allow_drop_cascade = false;
+

--- a/e2e_test/streaming/mv_on_index.slt
+++ b/e2e_test/streaming/mv_on_index.slt
@@ -1,4 +1,7 @@
 statement ok
+set allow_drop_cascade = true;
+
+statement ok
 set implicit_flush = true;
 
 statement ok
@@ -35,3 +38,7 @@ select * from mv;
 
 statement ok
 drop table t cascade;
+
+statement ok
+set allow_drop_cascade = false;
+

--- a/e2e_test/streaming/now_semi_join.slt
+++ b/e2e_test/streaming/now_semi_join.slt
@@ -1,4 +1,7 @@
 statement ok
+set allow_drop_cascade = true;
+
+statement ok
 set rw_implicit_flush to true;
 
 statement ok
@@ -68,3 +71,7 @@ flush;
 
 statement ok
 drop table t cascade;
+
+statement ok
+set allow_drop_cascade = false;
+

--- a/e2e_test/streaming/queryable_internal_state/group_agg.slt
+++ b/e2e_test/streaming/queryable_internal_state/group_agg.slt
@@ -1,3 +1,6 @@
+statement ok
+set allow_drop_cascade = true;
+
 # See https://github.com/risingwavelabs/risingwave/pull/20435 for the bug.
 
 control substitution on
@@ -59,3 +62,7 @@ count: 1
 
 statement ok
 drop table t cascade;
+
+statement ok
+set allow_drop_cascade = false;
+

--- a/e2e_test/streaming/row_id_cast.slt
+++ b/e2e_test/streaming/row_id_cast.slt
@@ -1,3 +1,6 @@
+statement ok
+set allow_drop_cascade = true;
+
 # Test that we can cast row id (both for pk and changelog) from serial type to timestamptz
 # to extract the timestamp from row id.
 
@@ -29,3 +32,7 @@ where abs(date_part('epoch', now() - _changelog_row_id::timestamptz)) < 60;
 
 statement ok
 drop table t cascade;
+
+statement ok
+set allow_drop_cascade = false;
+

--- a/e2e_test/streaming/sink_into_table_ignore_delete.slt
+++ b/e2e_test/streaming/sink_into_table_ignore_delete.slt
@@ -1,4 +1,7 @@
 statement ok
+set allow_drop_cascade = true;
+
+statement ok
 set implicit_flush = true;
 
 # Test `ignore_delete` for sink-into-table (non-append-only sink on non-append-only input).
@@ -55,3 +58,7 @@ drop table src cascade;
 
 statement ok
 drop table t cascade;
+
+statement ok
+set allow_drop_cascade = false;
+

--- a/e2e_test/streaming/sink_into_wide_table.slt
+++ b/e2e_test/streaming/sink_into_wide_table.slt
@@ -1,4 +1,7 @@
 statement ok
+set allow_drop_cascade = true;
+
+statement ok
 set implicit_flush = true;
 
 statement ok
@@ -57,3 +60,7 @@ select * from t order by k;
 
 statement ok
 drop table t cascade;
+
+statement ok
+set allow_drop_cascade = false;
+

--- a/e2e_test/streaming/temporal_join/append_only/temporal_join_watermark.slt
+++ b/e2e_test/streaming/temporal_join/append_only/temporal_join_watermark.slt
@@ -1,4 +1,7 @@
 statement ok
+set allow_drop_cascade = true;
+
+statement ok
 SET RW_IMPLICIT_FLUSH TO true;
 
 statement ok
@@ -63,3 +66,7 @@ drop table stream cascade;
 
 statement ok
 drop table version cascade;
+
+statement ok
+set allow_drop_cascade = false;
+

--- a/e2e_test/streaming/unaligned-join.slt
+++ b/e2e_test/streaming/unaligned-join.slt
@@ -1,4 +1,7 @@
 statement ok
+set allow_drop_cascade = true;
+
+statement ok
 DROP TABLE IF EXISTS fact;
 
 statement ok
@@ -55,3 +58,7 @@ DROP TABLE fact cascade;
 
 statement ok
 DROP TABLE dim cascade;
+
+statement ok
+set allow_drop_cascade = false;
+

--- a/e2e_test/streaming/watermark_ttl.slt
+++ b/e2e_test/streaming/watermark_ttl.slt
@@ -1,4 +1,7 @@
 statement ok
+set allow_drop_cascade = true;
+
+statement ok
 SET implicit_flush TO true;
 
 statement ok
@@ -300,3 +303,7 @@ SET streaming_parallelism TO DEFAULT;
 
 statement ok
 SET upsert_dml TO DEFAULT;
+
+statement ok
+set allow_drop_cascade = false;
+

--- a/e2e_test/streaming/watermark_ttl_append_only_rowid.slt
+++ b/e2e_test/streaming/watermark_ttl_append_only_rowid.slt
@@ -1,4 +1,7 @@
 statement ok
+set allow_drop_cascade = true;
+
+statement ok
 SET implicit_flush TO true;
 
 # Ensure deterministic behavior for watermark.
@@ -126,3 +129,7 @@ SET streaming_parallelism TO DEFAULT;
 
 statement ok
 SET implicit_flush TO DEFAULT;
+
+statement ok
+set allow_drop_cascade = false;
+

--- a/e2e_test/udf/tests/management/drop_function_cascade.slt
+++ b/e2e_test/udf/tests/management/drop_function_cascade.slt
@@ -1,3 +1,6 @@
+statement ok
+set allow_drop_cascade = true;
+
 # Test DROP FUNCTION CASCADE functionality
 # This test verifies that DROP FUNCTION CASCADE properly drops both the function
 # and any dependent objects like materialized views.
@@ -85,3 +88,7 @@ drop function subtract_udf;
 
 statement ok
 drop table t;
+
+statement ok
+set allow_drop_cascade = false;
+

--- a/proto/ddl_service.proto
+++ b/proto/ddl_service.proto
@@ -612,6 +612,21 @@ message DropConnectionResponse {
   WaitVersion version = 2;
 }
 
+message DropCascadeObjectCount {
+  common.ObjectType object_type = 1;
+  uint64 count = 2;
+}
+
+message PreviewDropCascadeRequest {
+  uint32 object_id = 1;
+  common.ObjectType object_type = 2;
+}
+
+message PreviewDropCascadeResponse {
+  uint64 total_count = 1;
+  repeated DropCascadeObjectCount object_counts = 2;
+}
+
 message GetTablesRequest {
   repeated uint32 table_ids = 1;
   bool include_dropped_tables = 2;
@@ -744,6 +759,7 @@ service DdlService {
   rpc CreateConnection(CreateConnectionRequest) returns (CreateConnectionResponse);
   rpc ListConnections(ListConnectionsRequest) returns (ListConnectionsResponse);
   rpc DropConnection(DropConnectionRequest) returns (DropConnectionResponse);
+  rpc PreviewDropCascade(PreviewDropCascadeRequest) returns (PreviewDropCascadeResponse);
   rpc GetTables(GetTablesRequest) returns (GetTablesResponse);
   rpc Wait(WaitRequest) returns (WaitResponse);
   rpc CommentOn(CommentOnRequest) returns (CommentOnResponse);

--- a/src/common/src/session_config/mod.rs
+++ b/src/common/src/session_config/mod.rs
@@ -483,6 +483,12 @@ pub struct SessionConfig {
     #[parameter(default = 30u32)]
     slow_ddl_notification_secs: u32,
 
+    /// Allow `DROP ... CASCADE` statements to execute.
+    /// When disabled, RisingWave rejects the statement after showing a summary of the objects that
+    /// would be removed.
+    #[parameter(default = false)]
+    allow_drop_cascade: bool,
+
     /// Unsafe: Enable storage retention for non-append-only tables.
     /// Enabling this can lead to streaming inconsistency and node panic
     /// if there is any row INSERT/UPDATE/DELETE operation corresponding to the ttled primary key.

--- a/src/frontend/src/handler/drop_cascade_guard.rs
+++ b/src/frontend/src/handler/drop_cascade_guard.rs
@@ -1,0 +1,133 @@
+// Copyright 2024 RisingWave Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use risingwave_pb::common::PbObjectType;
+use risingwave_pb::ddl_service::PreviewDropCascadeResponse;
+
+use crate::error::{ErrorCode, Result};
+use crate::session::SessionImpl;
+
+pub async fn guard_drop_cascade(
+    session: &SessionImpl,
+    statement_name: &str,
+    object_type: PbObjectType,
+    object_id: u32,
+) -> Result<()> {
+    let preview = session
+        .env()
+        .meta_client()
+        .preview_drop_cascade(object_id, object_type)
+        .await?;
+    let impact = format_drop_cascade_impact(&preview);
+
+    if !session.config().allow_drop_cascade() {
+        return Err(ErrorCode::NotSupported(
+            format!("{statement_name} CASCADE is disabled. {impact}"),
+            "SET allow_drop_cascade = true to enable DROP ... CASCADE in the current session, or ALTER SYSTEM SET allow_drop_cascade = true to change the default."
+                .to_owned(),
+        )
+        .into());
+    }
+
+    if preview.total_count > 1 {
+        session.notice_to_user(format!("{statement_name} CASCADE {impact}"));
+    }
+
+    Ok(())
+}
+
+fn format_drop_cascade_impact(preview: &PreviewDropCascadeResponse) -> String {
+    if preview.object_counts.is_empty() {
+        return format!("It would remove {} object(s).", preview.total_count);
+    }
+
+    let breakdown = preview
+        .object_counts
+        .iter()
+        .filter_map(|count| {
+            let object_type = PbObjectType::try_from(count.object_type).ok()?;
+            Some(format!(
+                "{} {}",
+                count.count,
+                format_object_type_name(object_type, count.count)
+            ))
+        })
+        .collect::<Vec<_>>()
+        .join(", ");
+
+    format!(
+        "It would remove {} object(s): {}.",
+        preview.total_count, breakdown
+    )
+}
+
+fn format_object_type_name(object_type: PbObjectType, count: u64) -> &'static str {
+    match (object_type, count == 1) {
+        (PbObjectType::Database, true) => "database",
+        (PbObjectType::Database, false) => "databases",
+        (PbObjectType::Schema, true) => "schema",
+        (PbObjectType::Schema, false) => "schemas",
+        (PbObjectType::Table, true) => "table",
+        (PbObjectType::Table, false) => "tables",
+        (PbObjectType::Mview, true) => "materialized view",
+        (PbObjectType::Mview, false) => "materialized views",
+        (PbObjectType::Source, true) => "source",
+        (PbObjectType::Source, false) => "sources",
+        (PbObjectType::Sink, true) => "sink",
+        (PbObjectType::Sink, false) => "sinks",
+        (PbObjectType::View, true) => "view",
+        (PbObjectType::View, false) => "views",
+        (PbObjectType::Index, true) => "index",
+        (PbObjectType::Index, false) => "indexes",
+        (PbObjectType::Function, true) => "function",
+        (PbObjectType::Function, false) => "functions",
+        (PbObjectType::Connection, true) => "connection",
+        (PbObjectType::Connection, false) => "connections",
+        (PbObjectType::Subscription, true) => "subscription",
+        (PbObjectType::Subscription, false) => "subscriptions",
+        (PbObjectType::Secret, true) => "secret",
+        (PbObjectType::Secret, false) => "secrets",
+        (PbObjectType::Unspecified, true) => "object",
+        (PbObjectType::Unspecified, false) => "objects",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use risingwave_pb::ddl_service::DropCascadeObjectCount;
+
+    use super::*;
+
+    #[test]
+    fn test_format_drop_cascade_impact() {
+        let preview = PreviewDropCascadeResponse {
+            total_count: 4,
+            object_counts: vec![
+                DropCascadeObjectCount {
+                    object_type: PbObjectType::Schema as i32,
+                    count: 1,
+                },
+                DropCascadeObjectCount {
+                    object_type: PbObjectType::Secret as i32,
+                    count: 3,
+                },
+            ],
+        };
+
+        assert_eq!(
+            format_drop_cascade_impact(&preview),
+            "It would remove 4 object(s): 1 schema, 3 secrets."
+        );
+    }
+}

--- a/src/frontend/src/handler/drop_connection.rs
+++ b/src/frontend/src/handler/drop_connection.rs
@@ -15,9 +15,11 @@
 use pgwire::pg_response::{PgResponse, StatementType};
 use risingwave_pb::catalog::connection::Info as ConnectionInfo;
 use risingwave_pb::catalog::connection_params::ConnectionType;
+use risingwave_pb::common::PbObjectType;
 use risingwave_sqlparser::ast::ObjectName;
 
 use super::RwPgResponse;
+use super::drop_cascade_guard::guard_drop_cascade;
 use crate::binder::Binder;
 use crate::catalog::root_catalog::SchemaPath;
 use crate::error::{ErrorCode, Result};
@@ -76,6 +78,16 @@ pub async fn handle_drop_connection(
             "Please drop dependent objects manually before dropping the Iceberg connection, or use DROP CONNECTION without CASCADE".to_owned(),
         )
         .into());
+    }
+
+    if cascade {
+        guard_drop_cascade(
+            &session,
+            "DROP CONNECTION",
+            PbObjectType::Connection,
+            connection_id.as_raw_id(),
+        )
+        .await?;
     }
 
     let catalog_writer = session.catalog_writer()?;

--- a/src/frontend/src/handler/drop_function.rs
+++ b/src/frontend/src/handler/drop_function.rs
@@ -12,6 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use risingwave_pb::common::PbObjectType;
+
+use super::drop_cascade_guard::guard_drop_cascade;
 use super::*;
 use crate::catalog::root_catalog::SchemaPath;
 use crate::{Binder, bind_data_type};
@@ -105,6 +108,21 @@ pub async fn handle_drop_function(
 
     let catalog_writer = session.catalog_writer()?;
     let cascade = matches!(option, Some(ReferentialAction::Cascade));
+
+    if cascade {
+        guard_drop_cascade(
+            &session,
+            if aggregate {
+                "DROP AGGREGATE"
+            } else {
+                "DROP FUNCTION"
+            },
+            PbObjectType::Function,
+            function_id.as_raw_id(),
+        )
+        .await?;
+    }
+
     catalog_writer.drop_function(function_id, cascade).await?;
 
     Ok(PgResponse::empty_result(stmt_type))

--- a/src/frontend/src/handler/drop_index.rs
+++ b/src/frontend/src/handler/drop_index.rs
@@ -14,10 +14,12 @@
 
 use pgwire::pg_response::{PgResponse, StatementType};
 use risingwave_common::catalog::StreamJobStatus;
+use risingwave_pb::common::PbObjectType;
 use risingwave_pb::meta::cancel_creating_jobs_request::{CreatingJobIds, PbJobs};
 use risingwave_sqlparser::ast::ObjectName;
 
 use super::RwPgResponse;
+use super::drop_cascade_guard::guard_drop_cascade;
 use super::util::{LongRunningNotificationAction, execute_with_long_running_notification};
 use crate::binder::Binder;
 use crate::catalog::CatalogError;
@@ -85,6 +87,16 @@ pub async fn handle_drop_index(
     };
 
     let index_id = index.id;
+
+    if cascade {
+        guard_drop_cascade(
+            &session,
+            "DROP INDEX",
+            PbObjectType::Index,
+            index_id.as_raw_id(),
+        )
+        .await?;
+    }
 
     // If the index is being created, use cancel RPC instead of normal drop
     if index.index_table().stream_job_status == StreamJobStatus::Creating {

--- a/src/frontend/src/handler/drop_mv.rs
+++ b/src/frontend/src/handler/drop_mv.rs
@@ -13,9 +13,11 @@
 // limitations under the License.
 
 use pgwire::pg_response::{PgResponse, StatementType};
+use risingwave_pb::common::PbObjectType;
 use risingwave_sqlparser::ast::ObjectName;
 
 use super::RwPgResponse;
+use super::drop_cascade_guard::guard_drop_cascade;
 use super::util::{LongRunningNotificationAction, execute_with_long_running_notification};
 use crate::binder::Binder;
 use crate::catalog::root_catalog::SchemaPath;
@@ -72,6 +74,16 @@ pub async fn handle_drop_mv(
 
         table.id()
     };
+
+    if cascade {
+        guard_drop_cascade(
+            &session,
+            "DROP MATERIALIZED VIEW",
+            PbObjectType::Mview,
+            table_id.as_raw_id(),
+        )
+        .await?;
+    }
 
     let catalog_writer = session.catalog_writer()?;
 

--- a/src/frontend/src/handler/drop_schema.rs
+++ b/src/frontend/src/handler/drop_schema.rs
@@ -14,9 +14,11 @@
 
 use pgwire::pg_response::{PgResponse, StatementType};
 use risingwave_common::catalog::is_system_schema;
+use risingwave_pb::common::PbObjectType;
 use risingwave_sqlparser::ast::ObjectName;
 
 use super::RwPgResponse;
+use super::drop_cascade_guard::guard_drop_cascade;
 use crate::binder::Binder;
 use crate::error::{ErrorCode, Result};
 use crate::handler::HandlerArgs;
@@ -63,6 +65,16 @@ pub async fn handle_drop_schema(
     // The check is done in meta `ensure_schema_empty`.
 
     session.check_privilege_for_drop_alter_db_schema(&schema)?;
+
+    if cascade {
+        guard_drop_cascade(
+            &session,
+            "DROP SCHEMA",
+            PbObjectType::Schema,
+            schema.id().as_raw_id(),
+        )
+        .await?;
+    }
 
     let catalog_writer = session.catalog_writer()?;
     catalog_writer.drop_schema(schema.id(), cascade).await?;

--- a/src/frontend/src/handler/drop_secret.rs
+++ b/src/frontend/src/handler/drop_secret.rs
@@ -16,8 +16,10 @@ use std::sync::Arc;
 
 use pgwire::pg_response::StatementType;
 use risingwave_common::license::Feature;
+use risingwave_pb::common::PbObjectType;
 use risingwave_sqlparser::ast::ObjectName;
 
+use super::drop_cascade_guard::guard_drop_cascade;
 use crate::Binder;
 use crate::catalog::root_catalog::SchemaPath;
 use crate::catalog::secret_catalog::SecretCatalog;
@@ -39,6 +41,16 @@ pub async fn handle_drop_secret(
     if let Some((secret_catalog, _, _)) =
         fetch_secret_catalog_with_db_schema_id(&session, &secret_name, if_exists)?
     {
+        if cascade {
+            guard_drop_cascade(
+                &session,
+                "DROP SECRET",
+                PbObjectType::Secret,
+                secret_catalog.id.as_raw_id(),
+            )
+            .await?;
+        }
+
         let catalog_writer = session.catalog_writer()?;
         catalog_writer
             .drop_secret(secret_catalog.id, cascade)

--- a/src/frontend/src/handler/drop_sink.rs
+++ b/src/frontend/src/handler/drop_sink.rs
@@ -14,9 +14,11 @@
 
 use pgwire::pg_response::{PgResponse, StatementType};
 use risingwave_common::catalog::ICEBERG_SINK_PREFIX;
+use risingwave_pb::common::PbObjectType;
 use risingwave_sqlparser::ast::ObjectName;
 
 use super::RwPgResponse;
+use super::drop_cascade_guard::guard_drop_cascade;
 use super::util::{LongRunningNotificationAction, execute_with_long_running_notification};
 use crate::binder::Binder;
 use crate::catalog::root_catalog::SchemaPath;
@@ -66,6 +68,16 @@ pub async fn handle_drop_sink(
     }
 
     let sink_id = sink.id;
+
+    if cascade {
+        guard_drop_cascade(
+            &session,
+            "DROP SINK",
+            PbObjectType::Sink,
+            sink_id.as_raw_id(),
+        )
+        .await?;
+    }
 
     let catalog_writer = session.catalog_writer()?;
     execute_with_long_running_notification(

--- a/src/frontend/src/handler/drop_source.rs
+++ b/src/frontend/src/handler/drop_source.rs
@@ -14,9 +14,11 @@
 
 use pgwire::pg_response::{PgResponse, StatementType};
 use risingwave_common::catalog::ICEBERG_SOURCE_PREFIX;
+use risingwave_pb::common::PbObjectType;
 use risingwave_sqlparser::ast::ObjectName;
 
 use super::RwPgResponse;
+use super::drop_cascade_guard::guard_drop_cascade;
 use super::util::{LongRunningNotificationAction, execute_with_long_running_notification};
 use crate::binder::Binder;
 use crate::catalog::root_catalog::SchemaPath;
@@ -78,6 +80,16 @@ pub async fn handle_drop_source(
     }
 
     session.check_privilege_for_drop_alter(schema_name, &*source)?;
+
+    if cascade {
+        guard_drop_cascade(
+            &session,
+            "DROP SOURCE",
+            PbObjectType::Source,
+            source.id.as_raw_id(),
+        )
+        .await?;
+    }
 
     let catalog_writer = session.catalog_writer()?;
     execute_with_long_running_notification(

--- a/src/frontend/src/handler/drop_subscription.rs
+++ b/src/frontend/src/handler/drop_subscription.rs
@@ -13,8 +13,10 @@
 // limitations under the License.
 
 use pgwire::pg_response::{PgResponse, StatementType};
+use risingwave_pb::common::PbObjectType;
 use risingwave_sqlparser::ast::ObjectName;
 
+use super::drop_cascade_guard::guard_drop_cascade;
 use super::util::{LongRunningNotificationAction, execute_with_long_running_notification};
 use super::{HandlerArgs, RwPgResponse};
 use crate::Binder;
@@ -61,6 +63,16 @@ pub async fn handle_drop_subscription(
     };
 
     let subscription_id = subscription.id;
+
+    if cascade {
+        guard_drop_cascade(
+            &session,
+            "DROP SUBSCRIPTION",
+            PbObjectType::Subscription,
+            subscription_id.as_raw_id(),
+        )
+        .await?;
+    }
 
     let catalog_writer = session.catalog_writer()?;
     execute_with_long_running_notification(

--- a/src/frontend/src/handler/drop_table.rs
+++ b/src/frontend/src/handler/drop_table.rs
@@ -13,9 +13,11 @@
 // limitations under the License.
 
 use pgwire::pg_response::{PgResponse, StatementType};
+use risingwave_pb::common::PbObjectType;
 use risingwave_sqlparser::ast::ObjectName;
 
 use super::RwPgResponse;
+use super::drop_cascade_guard::guard_drop_cascade;
 use super::util::{LongRunningNotificationAction, execute_with_long_running_notification};
 use crate::binder::Binder;
 use crate::catalog::root_catalog::SchemaPath;
@@ -60,6 +62,16 @@ pub async fn handle_drop_table(
         }
         (table.associated_source_id(), table.id())
     };
+
+    if cascade {
+        guard_drop_cascade(
+            &session,
+            "DROP TABLE",
+            PbObjectType::Table,
+            table_id.as_raw_id(),
+        )
+        .await?;
+    }
 
     let catalog_writer = session.catalog_writer()?;
     execute_with_long_running_notification(

--- a/src/frontend/src/handler/drop_view.rs
+++ b/src/frontend/src/handler/drop_view.rs
@@ -13,9 +13,11 @@
 // limitations under the License.
 
 use pgwire::pg_response::{PgResponse, StatementType};
+use risingwave_pb::common::PbObjectType;
 use risingwave_sqlparser::ast::ObjectName;
 
 use super::RwPgResponse;
+use super::drop_cascade_guard::guard_drop_cascade;
 use crate::binder::Binder;
 use crate::catalog::root_catalog::SchemaPath;
 use crate::error::Result;
@@ -55,6 +57,16 @@ pub async fn handle_drop_view(
 
         view.id
     };
+
+    if cascade {
+        guard_drop_cascade(
+            &session,
+            "DROP VIEW",
+            PbObjectType::View,
+            view_id.as_raw_id(),
+        )
+        .await?;
+    }
 
     let catalog_writer = session.catalog_writer()?;
     catalog_writer.drop_view(view_id, cascade).await?;

--- a/src/frontend/src/handler/mod.rs
+++ b/src/frontend/src/handler/mod.rs
@@ -91,6 +91,7 @@ pub mod declare_cursor;
 mod delete_meta_snapshot;
 pub mod describe;
 pub mod discard;
+mod drop_cascade_guard;
 mod drop_connection;
 mod drop_database;
 pub mod drop_function;

--- a/src/frontend/src/meta_client.rs
+++ b/src/frontend/src/meta_client.rs
@@ -25,7 +25,7 @@ use risingwave_hummock_sdk::{CompactionGroupId, HummockVersionId};
 use risingwave_pb::backup_service::{BackupJobStatus, MetaSnapshotMetadata};
 use risingwave_pb::catalog::Table;
 use risingwave_pb::common::WorkerNode;
-use risingwave_pb::ddl_service::DdlProgress;
+use risingwave_pb::ddl_service::{DdlProgress, PreviewDropCascadeResponse};
 use risingwave_pb::hummock::write_limits::WriteLimit;
 use risingwave_pb::hummock::{
     BranchedObject, CompactTaskAssignment, CompactTaskProgress, CompactionGroupInfo,
@@ -103,6 +103,12 @@ pub trait FrontendMetaClient: Send + Sync {
     async fn get_session_params(&self) -> Result<SessionConfig>;
 
     async fn set_session_param(&self, param: String, value: Option<String>) -> Result<String>;
+
+    async fn preview_drop_cascade(
+        &self,
+        object_id: u32,
+        object_type: risingwave_pb::common::PbObjectType,
+    ) -> Result<PreviewDropCascadeResponse>;
 
     async fn get_ddl_progress(&self) -> Result<Vec<DdlProgress>>;
 
@@ -327,6 +333,14 @@ impl FrontendMetaClient for FrontendMetaClientImpl {
 
     async fn set_session_param(&self, param: String, value: Option<String>) -> Result<String> {
         self.0.set_session_param(param, value).await
+    }
+
+    async fn preview_drop_cascade(
+        &self,
+        object_id: u32,
+        object_type: risingwave_pb::common::PbObjectType,
+    ) -> Result<PreviewDropCascadeResponse> {
+        self.0.preview_drop_cascade(object_id, object_type).await
     }
 
     async fn get_ddl_progress(&self) -> Result<Vec<DdlProgress>> {

--- a/src/frontend/src/test_utils.rs
+++ b/src/frontend/src/test_utils.rs
@@ -1218,6 +1218,14 @@ impl FrontendMetaClient for MockFrontendMetaClient {
         Ok("".to_owned())
     }
 
+    async fn preview_drop_cascade(
+        &self,
+        _object_id: u32,
+        _object_type: PbObjectType,
+    ) -> RpcResult<risingwave_pb::ddl_service::PreviewDropCascadeResponse> {
+        Ok(Default::default())
+    }
+
     async fn get_ddl_progress(&self) -> RpcResult<Vec<DdlProgress>> {
         Ok(vec![])
     }

--- a/src/meta/service/src/ddl_service.rs
+++ b/src/meta/service/src/ddl_service.rs
@@ -1025,6 +1025,30 @@ impl DdlService for DdlServiceImpl {
         }))
     }
 
+    async fn preview_drop_cascade(
+        &self,
+        request: Request<PreviewDropCascadeRequest>,
+    ) -> Result<Response<PreviewDropCascadeResponse>, Status> {
+        let req = request.into_inner();
+        let object_type = risingwave_meta_model::object::ObjectType::from(req.object_type());
+        let preview = self
+            .ddl_controller
+            .preview_drop_cascade(object_type, req.object_id)
+            .await?;
+
+        Ok(Response::new(PreviewDropCascadeResponse {
+            total_count: preview.total_count,
+            object_counts: preview
+                .object_counts
+                .into_iter()
+                .map(|count| ddl_service::DropCascadeObjectCount {
+                    object_type: count.object_type as i32,
+                    count: count.count,
+                })
+                .collect(),
+        }))
+    }
+
     async fn comment_on(
         &self,
         request: Request<CommentOnRequest>,

--- a/src/meta/src/controller/catalog/drop_op.rs
+++ b/src/meta/src/controller/catalog/drop_op.rs
@@ -529,7 +529,6 @@ async fn summarize_drop_preview(
     removed_objects: Vec<PartialObject>,
     txn: &DatabaseTransaction,
 ) -> MetaResult<DropObjectPreview> {
-    let total_count = removed_objects.len() as u64;
     let mut object_counts: BTreeMap<i32, u64> = BTreeMap::new();
     let mut table_ids = Vec::new();
 
@@ -563,15 +562,17 @@ async fn summarize_drop_preview(
             .all(txn)
             .await?;
         for (_, table_type) in table_types {
-            let pb_type = if table_type == TableType::MaterializedView {
-                PbObjectType::Mview
-            } else {
-                PbObjectType::Table
+            // Internal state tables are implementation details invisible to users; skip them.
+            let pb_type = match table_type {
+                TableType::Table => PbObjectType::Table,
+                TableType::MaterializedView => PbObjectType::Mview,
+                TableType::Internal | TableType::Index | TableType::VectorIndex => continue,
             };
             *object_counts.entry(pb_type as i32).or_default() += 1;
         }
     }
 
+    let total_count = object_counts.values().sum();
     Ok(DropObjectPreview {
         total_count,
         object_counts: object_counts

--- a/src/meta/src/controller/catalog/drop_op.rs
+++ b/src/meta/src/controller/catalog/drop_op.rs
@@ -12,14 +12,33 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::collections::{BTreeMap, HashMap, HashSet};
+
+use anyhow::anyhow;
 use risingwave_common::catalog::{ICEBERG_SINK_PREFIX, ICEBERG_SOURCE_PREFIX};
 use risingwave_pb::catalog::PbTable;
 use risingwave_pb::catalog::subscription::PbSubscriptionState;
+use risingwave_pb::common::PbObjectType;
 use risingwave_pb::telemetry::PbTelemetryDatabaseObject;
 use sea_orm::{ColumnTrait, DatabaseTransaction, EntityTrait, ModelTrait, QueryFilter};
 
 use super::*;
 impl CatalogController {
+    pub async fn preview_drop_cascade(
+        &self,
+        object_type: ObjectType,
+        object_id: impl Into<ObjectId>,
+    ) -> MetaResult<DropObjectPreview> {
+        let object_id = object_id.into();
+        let inner = self.inner.read().await;
+        let txn = inner.db.begin().await?;
+        let plan = self
+            .plan_drop_object(&txn, object_type, object_id, DropMode::Cascade)
+            .await?;
+
+        summarize_drop_preview(plan.removed_objects, &txn).await
+    }
+
     // Drop all kinds of objects including databases,
     // schemas, relations, connections, functions, etc.
     pub async fn drop_object(
@@ -31,178 +50,20 @@ impl CatalogController {
         let object_id = object_id.into();
         let mut inner = self.inner.write().await;
         let txn = inner.db.begin().await?;
-
-        let obj: PartialObject = Object::find_by_id(object_id)
-            .into_partial_model()
-            .one(&txn)
-            .await?
-            .ok_or_else(|| MetaError::catalog_id_not_found(object_type.as_str(), object_id))?;
-        assert_eq!(obj.obj_type, object_type);
-        let drop_database = object_type == ObjectType::Database;
-        let database_id = if object_type == ObjectType::Database {
-            object_id.as_database_id()
-        } else {
-            obj.database_id
-                .ok_or_else(|| anyhow!("dropped object should have database_id"))?
-        };
-
-        // Check the cross-db dependency info to see if the subscription can be dropped.
-        if obj.obj_type == ObjectType::Subscription {
-            validate_subscription_deletion(&txn, object_id.as_subscription_id()).await?;
-        }
-
-        let mut removed_objects = match drop_mode {
-            DropMode::Cascade => get_referring_objects_cascade(object_id, &txn).await?,
-            DropMode::Restrict => match object_type {
-                ObjectType::Database => unreachable!("database always be dropped in cascade mode"),
-                ObjectType::Schema => {
-                    ensure_schema_empty(object_id.as_schema_id(), &txn).await?;
-                    Default::default()
-                }
-                ObjectType::Table => {
-                    check_object_refer_for_drop(object_type, object_id, &txn).await?;
-                    let objects = get_referring_objects(object_id, &txn).await?;
-                    for obj in objects.iter().filter(|object| {
-                        object.obj_type == ObjectType::Source || object.obj_type == ObjectType::Sink
-                    }) {
-                        report_drop_object(obj.obj_type, obj.oid, &txn).await;
-                    }
-                    assert!(
-                        objects.iter().all(|obj| obj.obj_type == ObjectType::Index
-                            || obj.obj_type == ObjectType::Sink),
-                        "only index and iceberg sink could be dropped in restrict mode"
-                    );
-                    for obj in &objects {
-                        check_object_refer_for_drop(obj.obj_type, obj.oid, &txn).await?;
-                    }
-                    objects
-                }
-                object_type @ (ObjectType::Source | ObjectType::Sink) => {
-                    check_object_refer_for_drop(object_type, object_id, &txn).await?;
-                    report_drop_object(object_type, object_id, &txn).await;
-                    vec![]
-                }
-
-                ObjectType::View
-                | ObjectType::Index
-                | ObjectType::Function
-                | ObjectType::Connection
-                | ObjectType::Subscription
-                | ObjectType::Secret => {
-                    check_object_refer_for_drop(object_type, object_id, &txn).await?;
-                    vec![]
-                }
-            },
-        };
-
-        // check iceberg source.
-        if obj.obj_type == ObjectType::Table {
-            let table_name = Table::find_by_id(object_id.as_table_id())
-                .select_only()
-                .column(table::Column::Name)
-                .into_tuple::<String>()
-                .one(&txn)
-                .await?
-                .ok_or_else(|| MetaError::catalog_id_not_found("table", object_id))?;
-            let iceberg_source = Source::find()
-                .inner_join(Object)
-                .filter(
-                    object::Column::DatabaseId
-                        .eq(database_id)
-                        .and(object::Column::SchemaId.eq(obj.schema_id.unwrap()))
-                        .and(
-                            source::Column::Name
-                                .eq(format!("{}{}", ICEBERG_SOURCE_PREFIX, table_name)),
-                        ),
-                )
-                .into_partial_model()
-                .one(&txn)
-                .await?;
-            if let Some(iceberg_source) = iceberg_source {
-                removed_objects.push(iceberg_source);
-            }
-        }
-
-        removed_objects.push(obj);
-        let mut removed_object_ids: HashSet<_> =
-            removed_objects.iter().map(|obj| obj.oid).collect();
-
-        // TODO: record dependency info in object_dependency table for sink into table.
-        // Special handling for 'sink into table'.
-        let incoming_sink_ids: Vec<SinkId> = Sink::find()
-            .select_only()
-            .column(sink::Column::SinkId)
-            .filter(sink::Column::TargetTable.is_in(removed_object_ids.clone()))
-            .into_tuple()
-            .all(&txn)
+        let DropPlan {
+            database_id,
+            removed_objects,
+        } = self
+            .plan_drop_object(&txn, object_type, object_id, drop_mode)
             .await?;
-        if !incoming_sink_ids.is_empty() {
-            if self.env.opts.protect_drop_table_with_incoming_sink {
-                let sink_names: Vec<String> = Sink::find()
-                    .select_only()
-                    .column(sink::Column::Name)
-                    .filter(sink::Column::SinkId.is_in(incoming_sink_ids.clone()))
-                    .into_tuple()
-                    .all(&txn)
-                    .await?;
-
-                return Err(MetaError::permission_denied(format!(
-                    "Table used by incoming sinks: {:?}, please drop them manually",
-                    sink_names
-                )));
-            }
-
-            let removed_sink_objs: Vec<PartialObject> = Object::find()
-                .filter(object::Column::Oid.is_in(incoming_sink_ids))
-                .into_partial_model()
-                .all(&txn)
-                .await?;
-
-            removed_object_ids.extend(removed_sink_objs.iter().map(|obj| obj.oid));
-            removed_objects.extend(removed_sink_objs);
-        }
-
-        for obj in &removed_objects {
-            if obj.obj_type == ObjectType::Sink {
-                let sink = Sink::find_by_id(obj.oid.as_sink_id())
-                    .one(&txn)
-                    .await?
-                    .ok_or_else(|| MetaError::catalog_id_not_found("sink", obj.oid))?;
-
-                if let Some(target_table) = sink.target_table
-                    && !removed_object_ids.contains(&target_table.as_object_id())
-                    && !has_table_been_migrated(&txn, target_table).await?
-                {
-                    return Err(anyhow::anyhow!(
-                        "Dropping sink into table is not allowed for unmigrated table {}. Please migrate it first.",
-                        target_table
-                    ).into());
-                }
-            }
-        }
-
-        // 1. Detect when an Iceberg table is part of the dependencies.
-        // 2. Drop database with iceberg tables in it is not supported.
-        if object_type != ObjectType::Table || drop_database {
-            for obj in &removed_objects {
-                // if the obj is iceberg engine table, bail out
-                if obj.obj_type == ObjectType::Table {
-                    let table = Table::find_by_id(obj.oid.as_table_id())
-                        .one(&txn)
-                        .await?
-                        .ok_or_else(|| MetaError::catalog_id_not_found("table", obj.oid))?;
-                    if matches!(table.engine, Some(table::Engine::Iceberg)) {
-                        return Err(MetaError::permission_denied(format!(
-                            "Found iceberg table in dependency: {}, please drop it manually",
-                            table.name,
-                        )));
-                    }
-                }
-            }
-        }
+        let removed_objects: HashMap<_, _> = removed_objects
+            .into_iter()
+            .map(|obj| (obj.oid, obj))
+            .collect();
+        let removed_object_ids: HashSet<_> = removed_objects.keys().copied().collect();
 
         let removed_table_ids = removed_objects
-            .iter()
+            .values()
             .filter(|obj| obj.obj_type == ObjectType::Table || obj.obj_type == ObjectType::Index)
             .map(|obj| obj.oid.as_table_id());
 
@@ -222,104 +83,34 @@ impl CatalogController {
         let removed_streaming_job_ids: Vec<JobId> = StreamingJob::find()
             .select_only()
             .column(streaming_job::Column::JobId)
-            .filter(streaming_job::Column::JobId.is_in(removed_object_ids))
+            .filter(streaming_job::Column::JobId.is_in(removed_object_ids.clone()))
             .into_tuple()
             .all(&txn)
             .await?;
 
-        // Check if there are any streaming jobs that are creating.
-        if !removed_streaming_job_ids.is_empty() {
-            let creating = StreamingJob::find()
-                .filter(
-                    streaming_job::Column::JobStatus
-                        .ne(JobStatus::Created)
-                        .and(streaming_job::Column::JobId.is_in(removed_streaming_job_ids.clone())),
-                )
-                .count(&txn)
-                .await?;
-            if creating != 0 {
-                if creating == 1 && object_type == ObjectType::Sink {
-                    info!("dropping creating sink job, it will be cancelled");
-                } else {
-                    return Err(MetaError::permission_denied(format!(
-                        "can not drop {creating} creating streaming job, please cancel them firstly"
-                    )));
-                }
-            }
-        }
-
-        let mut removed_state_table_ids: HashSet<_> = removed_table_ids.clone().collect();
-
-        if !drop_database {
-            // Add associated sources.
-            let removed_source_ids: Vec<SourceId> = Table::find()
-                .select_only()
-                .column(table::Column::OptionalAssociatedSourceId)
-                .filter(
-                    table::Column::TableId
-                        .is_in(removed_table_ids)
-                        .and(table::Column::OptionalAssociatedSourceId.is_not_null()),
-                )
-                .into_tuple()
-                .all(&txn)
-                .await?;
-            let removed_source_objs: Vec<PartialObject> = Object::find()
-                .filter(object::Column::Oid.is_in(removed_source_ids))
-                .into_partial_model()
-                .all(&txn)
-                .await?;
-            removed_objects.extend(removed_source_objs);
-        }
+        let mut removed_state_table_ids: HashSet<_> = removed_table_ids.collect();
 
         let removed_source_ids: HashSet<_> = removed_objects
-            .iter()
+            .values()
             .filter(|obj| obj.obj_type == ObjectType::Source)
             .map(|obj| obj.oid.as_source_id())
             .collect();
 
         let removed_secret_ids = removed_objects
-            .iter()
+            .values()
             .filter(|obj| obj.obj_type == ObjectType::Secret)
             .map(|obj| obj.oid.as_secret_id())
             .collect();
 
         if !removed_streaming_job_ids.is_empty() {
-            let removed_internal_table_objs: Vec<PartialObject> = Object::find()
+            let internal_state_table_ids: Vec<TableId> = Table::find()
                 .select_only()
-                .columns([
-                    object::Column::Oid,
-                    object::Column::ObjType,
-                    object::Column::SchemaId,
-                    object::Column::DatabaseId,
-                ])
-                .join(JoinType::InnerJoin, object::Relation::Table.def())
+                .column(table::Column::TableId)
                 .filter(table::Column::BelongsToJobId.is_in(removed_streaming_job_ids.clone()))
-                .into_partial_model()
+                .into_tuple()
                 .all(&txn)
                 .await?;
-
-            removed_state_table_ids.extend(
-                removed_internal_table_objs
-                    .iter()
-                    .map(|obj| obj.oid.as_table_id()),
-            );
-            removed_objects.extend(removed_internal_table_objs);
-        }
-
-        let removed_objects: HashMap<_, _> = removed_objects
-            .into_iter()
-            .map(|obj| (obj.oid, obj))
-            .collect();
-
-        // TODO: Support drop cascade for cross-database query.
-        for obj in removed_objects.values() {
-            if let Some(obj_database_id) = obj.database_id
-                && obj_database_id != database_id
-            {
-                return Err(MetaError::permission_denied(format!(
-                    "Referenced by other objects in database {obj_database_id}, please drop them manually"
-                )));
-            }
+            removed_state_table_ids.extend(internal_state_table_ids);
         }
 
         let (removed_source_fragments, removed_sink_fragments, removed_fragments) =
@@ -466,6 +257,332 @@ impl CatalogController {
         txn.commit().await?;
         Ok(())
     }
+}
+
+struct DropPlan {
+    database_id: DatabaseId,
+    removed_objects: Vec<PartialObject>,
+}
+
+impl CatalogController {
+    async fn plan_drop_object(
+        &self,
+        txn: &DatabaseTransaction,
+        object_type: ObjectType,
+        object_id: ObjectId,
+        drop_mode: DropMode,
+    ) -> MetaResult<DropPlan> {
+        let obj: PartialObject = Object::find_by_id(object_id)
+            .into_partial_model()
+            .one(txn)
+            .await?
+            .ok_or_else(|| MetaError::catalog_id_not_found(object_type.as_str(), object_id))?;
+        assert_eq!(obj.obj_type, object_type);
+        let drop_database = object_type == ObjectType::Database;
+        let database_id = if drop_database {
+            object_id.as_database_id()
+        } else {
+            obj.database_id
+                .ok_or_else(|| anyhow!("dropped object should have database_id"))?
+        };
+
+        if obj.obj_type == ObjectType::Subscription {
+            validate_subscription_deletion(txn, object_id.as_subscription_id()).await?;
+        }
+
+        let mut removed_objects = match drop_mode {
+            DropMode::Cascade => get_referring_objects_cascade(object_id, txn).await?,
+            DropMode::Restrict => match object_type {
+                ObjectType::Database => unreachable!("database always be dropped in cascade mode"),
+                ObjectType::Schema => {
+                    ensure_schema_empty(object_id.as_schema_id(), txn).await?;
+                    Default::default()
+                }
+                ObjectType::Table => {
+                    check_object_refer_for_drop(object_type, object_id, txn).await?;
+                    let objects = get_referring_objects(object_id, txn).await?;
+                    for obj in objects.iter().filter(|object| {
+                        object.obj_type == ObjectType::Source || object.obj_type == ObjectType::Sink
+                    }) {
+                        report_drop_object(obj.obj_type, obj.oid, txn).await;
+                    }
+                    assert!(
+                        objects.iter().all(|obj| obj.obj_type == ObjectType::Index
+                            || obj.obj_type == ObjectType::Sink),
+                        "only index and iceberg sink could be dropped in restrict mode"
+                    );
+                    for obj in &objects {
+                        check_object_refer_for_drop(obj.obj_type, obj.oid, txn).await?;
+                    }
+                    objects
+                }
+                object_type @ (ObjectType::Source | ObjectType::Sink) => {
+                    check_object_refer_for_drop(object_type, object_id, txn).await?;
+                    report_drop_object(object_type, object_id, txn).await;
+                    vec![]
+                }
+                ObjectType::View
+                | ObjectType::Index
+                | ObjectType::Function
+                | ObjectType::Connection
+                | ObjectType::Subscription
+                | ObjectType::Secret => {
+                    check_object_refer_for_drop(object_type, object_id, txn).await?;
+                    vec![]
+                }
+            },
+        };
+
+        if obj.obj_type == ObjectType::Table {
+            let table_name = Table::find_by_id(object_id.as_table_id())
+                .select_only()
+                .column(table::Column::Name)
+                .into_tuple::<String>()
+                .one(txn)
+                .await?
+                .ok_or_else(|| MetaError::catalog_id_not_found("table", object_id))?;
+            let iceberg_source = Source::find()
+                .inner_join(Object)
+                .filter(
+                    object::Column::DatabaseId
+                        .eq(database_id)
+                        .and(object::Column::SchemaId.eq(obj.schema_id.unwrap()))
+                        .and(
+                            source::Column::Name
+                                .eq(format!("{}{}", ICEBERG_SOURCE_PREFIX, table_name)),
+                        ),
+                )
+                .into_partial_model()
+                .one(txn)
+                .await?;
+            if let Some(iceberg_source) = iceberg_source {
+                removed_objects.push(iceberg_source);
+            }
+        }
+
+        removed_objects.push(obj);
+        let mut removed_object_ids: HashSet<_> =
+            removed_objects.iter().map(|obj| obj.oid).collect();
+
+        let incoming_sink_ids: Vec<SinkId> = Sink::find()
+            .select_only()
+            .column(sink::Column::SinkId)
+            .filter(sink::Column::TargetTable.is_in(removed_object_ids.clone()))
+            .into_tuple()
+            .all(txn)
+            .await?;
+        if !incoming_sink_ids.is_empty() {
+            if self.env.opts.protect_drop_table_with_incoming_sink {
+                let sink_names: Vec<String> = Sink::find()
+                    .select_only()
+                    .column(sink::Column::Name)
+                    .filter(sink::Column::SinkId.is_in(incoming_sink_ids.clone()))
+                    .into_tuple()
+                    .all(txn)
+                    .await?;
+
+                return Err(MetaError::permission_denied(format!(
+                    "Table used by incoming sinks: {:?}, please drop them manually",
+                    sink_names
+                )));
+            }
+
+            let removed_sink_objs: Vec<PartialObject> = Object::find()
+                .filter(object::Column::Oid.is_in(incoming_sink_ids))
+                .into_partial_model()
+                .all(txn)
+                .await?;
+            removed_object_ids.extend(removed_sink_objs.iter().map(|obj| obj.oid));
+            removed_objects.extend(removed_sink_objs);
+        }
+
+        for obj in &removed_objects {
+            if obj.obj_type == ObjectType::Sink {
+                let sink = Sink::find_by_id(obj.oid.as_sink_id())
+                    .one(txn)
+                    .await?
+                    .ok_or_else(|| MetaError::catalog_id_not_found("sink", obj.oid))?;
+
+                if let Some(target_table) = sink.target_table
+                    && !removed_object_ids.contains(&target_table.as_object_id())
+                    && !has_table_been_migrated(txn, target_table).await?
+                {
+                    return Err(anyhow!(
+                        "Dropping sink into table is not allowed for unmigrated table {}. Please migrate it first.",
+                        target_table
+                    )
+                    .into());
+                }
+            }
+        }
+
+        if object_type != ObjectType::Table || drop_database {
+            for obj in &removed_objects {
+                if obj.obj_type == ObjectType::Table {
+                    let table = Table::find_by_id(obj.oid.as_table_id())
+                        .one(txn)
+                        .await?
+                        .ok_or_else(|| MetaError::catalog_id_not_found("table", obj.oid))?;
+                    if matches!(table.engine, Some(table::Engine::Iceberg)) {
+                        return Err(MetaError::permission_denied(format!(
+                            "Found iceberg table in dependency: {}, please drop it manually",
+                            table.name,
+                        )));
+                    }
+                }
+            }
+        }
+
+        let removed_table_ids = removed_objects
+            .iter()
+            .filter(|obj| obj.obj_type == ObjectType::Table || obj.obj_type == ObjectType::Index)
+            .map(|obj| obj.oid.as_table_id());
+
+        let removed_streaming_job_ids: Vec<JobId> = StreamingJob::find()
+            .select_only()
+            .column(streaming_job::Column::JobId)
+            .filter(streaming_job::Column::JobId.is_in(removed_object_ids))
+            .into_tuple()
+            .all(txn)
+            .await?;
+
+        if !removed_streaming_job_ids.is_empty() {
+            let creating = StreamingJob::find()
+                .filter(
+                    streaming_job::Column::JobStatus
+                        .ne(JobStatus::Created)
+                        .and(streaming_job::Column::JobId.is_in(removed_streaming_job_ids.clone())),
+                )
+                .count(txn)
+                .await?;
+            if creating != 0 {
+                if creating == 1 && object_type == ObjectType::Sink {
+                    info!("dropping creating sink job, it will be cancelled");
+                } else {
+                    return Err(MetaError::permission_denied(format!(
+                        "can not drop {creating} creating streaming job, please cancel them firstly"
+                    )));
+                }
+            }
+        }
+
+        if !drop_database {
+            let removed_source_ids: Vec<SourceId> = Table::find()
+                .select_only()
+                .column(table::Column::OptionalAssociatedSourceId)
+                .filter(
+                    table::Column::TableId
+                        .is_in(removed_table_ids)
+                        .and(table::Column::OptionalAssociatedSourceId.is_not_null()),
+                )
+                .into_tuple()
+                .all(txn)
+                .await?;
+            let removed_source_objs: Vec<PartialObject> = Object::find()
+                .filter(object::Column::Oid.is_in(removed_source_ids))
+                .into_partial_model()
+                .all(txn)
+                .await?;
+            removed_objects.extend(removed_source_objs);
+        }
+
+        if !removed_streaming_job_ids.is_empty() {
+            let removed_internal_table_objs: Vec<PartialObject> = Object::find()
+                .select_only()
+                .columns([
+                    object::Column::Oid,
+                    object::Column::ObjType,
+                    object::Column::SchemaId,
+                    object::Column::DatabaseId,
+                ])
+                .join(JoinType::InnerJoin, object::Relation::Table.def())
+                .filter(table::Column::BelongsToJobId.is_in(removed_streaming_job_ids))
+                .into_partial_model()
+                .all(txn)
+                .await?;
+            removed_objects.extend(removed_internal_table_objs);
+        }
+
+        let removed_objects: HashMap<_, _> = removed_objects
+            .into_iter()
+            .map(|obj| (obj.oid, obj))
+            .collect();
+
+        for obj in removed_objects.values() {
+            if let Some(obj_database_id) = obj.database_id
+                && obj_database_id != database_id
+            {
+                return Err(MetaError::permission_denied(format!(
+                    "Referenced by other objects in database {obj_database_id}, please drop them manually"
+                )));
+            }
+        }
+
+        Ok(DropPlan {
+            database_id,
+            removed_objects: removed_objects.into_values().collect(),
+        })
+    }
+}
+
+async fn summarize_drop_preview(
+    removed_objects: Vec<PartialObject>,
+    txn: &DatabaseTransaction,
+) -> MetaResult<DropObjectPreview> {
+    let total_count = removed_objects.len() as u64;
+    let mut object_counts: BTreeMap<i32, u64> = BTreeMap::new();
+    let mut table_ids = Vec::new();
+
+    for obj in &removed_objects {
+        if obj.obj_type == ObjectType::Table {
+            table_ids.push(obj.oid.as_table_id());
+        } else {
+            let pb_type = match obj.obj_type {
+                ObjectType::Database => PbObjectType::Database,
+                ObjectType::Schema => PbObjectType::Schema,
+                ObjectType::Source => PbObjectType::Source,
+                ObjectType::Sink => PbObjectType::Sink,
+                ObjectType::View => PbObjectType::View,
+                ObjectType::Index => PbObjectType::Index,
+                ObjectType::Function => PbObjectType::Function,
+                ObjectType::Connection => PbObjectType::Connection,
+                ObjectType::Subscription => PbObjectType::Subscription,
+                ObjectType::Secret => PbObjectType::Secret,
+                ObjectType::Table => unreachable!(),
+            };
+            *object_counts.entry(pb_type as i32).or_default() += 1;
+        }
+    }
+
+    if !table_ids.is_empty() {
+        let table_types: Vec<(TableId, TableType)> = Table::find()
+            .select_only()
+            .columns([table::Column::TableId, table::Column::TableType])
+            .filter(table::Column::TableId.is_in(table_ids))
+            .into_tuple()
+            .all(txn)
+            .await?;
+        for (_, table_type) in table_types {
+            let pb_type = if table_type == TableType::MaterializedView {
+                PbObjectType::Mview
+            } else {
+                PbObjectType::Table
+            };
+            *object_counts.entry(pb_type as i32).or_default() += 1;
+        }
+    }
+
+    Ok(DropObjectPreview {
+        total_count,
+        object_counts: object_counts
+            .into_iter()
+            .map(|(object_type, count)| DropCascadeObjectCount {
+                object_type: PbObjectType::try_from(object_type)
+                    .expect("preview object type should be valid"),
+                count,
+            })
+            .collect(),
+    })
 }
 
 async fn report_drop_object(

--- a/src/meta/src/controller/catalog/mod.rs
+++ b/src/meta/src/controller/catalog/mod.rs
@@ -54,6 +54,7 @@ use risingwave_pb::catalog::{
     PbComment, PbConnection, PbDatabase, PbFunction, PbIndex, PbSchema, PbSecret, PbSink, PbSource,
     PbSubscription, PbTable, PbView,
 };
+use risingwave_pb::common::PbObjectType;
 use risingwave_pb::meta::cancel_creating_jobs_request::PbCreatingJobInfo;
 use risingwave_pb::meta::object::PbObjectInfo;
 use risingwave_pb::meta::subscribe_response::{
@@ -118,6 +119,18 @@ pub struct DropTableConnectorContext {
     pub(crate) to_change_streaming_job_id: JobId,
     pub(crate) to_remove_state_table_id: TableId,
     pub(crate) to_remove_source_id: SourceId,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct DropCascadeObjectCount {
+    pub object_type: PbObjectType,
+    pub count: u64,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct DropObjectPreview {
+    pub total_count: u64,
+    pub object_counts: Vec<DropCascadeObjectCount>,
 }
 
 #[derive(Clone, Default, Debug)]

--- a/src/meta/src/controller/catalog/test.rs
+++ b/src/meta/src/controller/catalog/test.rs
@@ -17,6 +17,7 @@ mod tests {
     use risingwave_meta_model::table::HandleConflictBehavior;
     use risingwave_pb::catalog::StreamSourceInfo;
     use risingwave_pb::catalog::subscription::SubscriptionState;
+    use risingwave_pb::common::PbObjectType;
     use tokio::sync::oneshot;
 
     use crate::controller::catalog::*;
@@ -138,6 +139,62 @@ mod tests {
         assert_eq!(schema.name, "schema2");
         mgr.drop_object(ObjectType::Schema, schema_id, DropMode::Restrict)
             .await?;
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_preview_drop_schema_cascade_summary() -> MetaResult<()> {
+        let mgr = CatalogController::new(MetaSrvEnv::for_test().await).await?;
+        let inner = mgr.inner.write().await;
+        let txn = inner.db.begin().await?;
+
+        let mv_obj = CatalogController::create_object(
+            &txn,
+            ObjectType::Table,
+            TEST_OWNER_ID,
+            Some(TEST_DATABASE_ID),
+            Some(TEST_SCHEMA_ID),
+        )
+        .await?;
+        insert_test_table(
+            &txn,
+            mv_obj.oid.as_table_id(),
+            "mv_preview",
+            TableType::MaterializedView,
+            None,
+            "CREATE MATERIALIZED VIEW mv_preview AS SELECT 1",
+        )
+        .await?;
+
+        let _secret_obj = CatalogController::create_object(
+            &txn,
+            ObjectType::Secret,
+            TEST_OWNER_ID,
+            Some(TEST_DATABASE_ID),
+            Some(TEST_SCHEMA_ID),
+        )
+        .await?;
+        txn.commit().await?;
+        drop(inner);
+
+        let preview = mgr
+            .preview_drop_cascade(ObjectType::Schema, TEST_SCHEMA_ID)
+            .await?;
+
+        assert_eq!(preview.total_count, 3);
+        assert!(preview.object_counts.contains(&DropCascadeObjectCount {
+            object_type: PbObjectType::Schema,
+            count: 1,
+        }));
+        assert!(preview.object_counts.contains(&DropCascadeObjectCount {
+            object_type: PbObjectType::Mview,
+            count: 1,
+        }));
+        assert!(preview.object_counts.contains(&DropCascadeObjectCount {
+            object_type: PbObjectType::Secret,
+            count: 1,
+        }));
 
         Ok(())
     }

--- a/src/meta/src/manager/env.rs
+++ b/src/meta/src/manager/env.rs
@@ -32,7 +32,6 @@ use risingwave_rpc_client::{
 use risingwave_sqlparser::ast::RedactSqlOptionKeywordsRef;
 use sea_orm::EntityTrait;
 
-use crate::MetaResult;
 use crate::barrier::SharedActorInfos;
 use crate::controller::SqlMetaStore;
 use crate::controller::id::{
@@ -44,6 +43,7 @@ use crate::hummock::sequence::SequenceGenerator;
 use crate::manager::event_log::{EventLogManagerRef, start_event_log_manager};
 use crate::manager::{IdleManager, IdleManagerRef, NotificationManager, NotificationManagerRef};
 use crate::model::ClusterId;
+use crate::{MetaError, MetaResult};
 
 /// [`MetaSrvEnv`] is the global environment in Meta service. The instance will be shared by all
 /// kind of managers inside Meta.
@@ -427,7 +427,7 @@ impl MetaSrvEnv {
     pub async fn new(
         opts: MetaOpts,
         mut init_system_params: SystemParams,
-        init_session_config: SessionConfig,
+        mut init_session_config: SessionConfig,
         meta_store_impl: SqlMetaStore,
     ) -> MetaResult<Self> {
         let idle_manager = Arc::new(IdleManager::new(opts.max_idle_ms));
@@ -477,6 +477,9 @@ impl MetaSrvEnv {
         // For old clusters
         // - the prefix is ​​not divided for the sake of compatibility.
         init_system_params.use_new_object_prefix_strategy = Some(cluster_first_launch);
+        init_session_config
+            .set_allow_drop_cascade(!cluster_first_launch, &mut ())
+            .map_err(MetaError::from)?;
 
         let system_param_controller = Arc::new(
             SystemParamsController::new(

--- a/src/meta/src/rpc/ddl_controller.rs
+++ b/src/meta/src/rpc/ddl_controller.rs
@@ -71,7 +71,7 @@ use tokio::time::sleep;
 use tracing::Instrument;
 
 use crate::barrier::{BarrierManagerRef, Command};
-use crate::controller::catalog::{DropTableConnectorContext, ReleaseContext};
+use crate::controller::catalog::{DropObjectPreview, DropTableConnectorContext, ReleaseContext};
 use crate::controller::streaming_job::{FinishAutoRefreshSchemaSinkContext, SinkIntoTableContext};
 use crate::controller::utils::build_select_node_list;
 use crate::error::{MetaErrorInner, bail_invalid_parameter};
@@ -1430,6 +1430,17 @@ impl DdlController {
             LocalSecretManager::global().remove_secret(secret);
         }
         Ok(version)
+    }
+
+    pub async fn preview_drop_cascade(
+        &self,
+        object_type: ObjectType,
+        object_id: impl Into<ObjectId>,
+    ) -> MetaResult<DropObjectPreview> {
+        self.metadata_manager
+            .catalog_controller
+            .preview_drop_cascade(object_type, object_id)
+            .await
     }
 
     /// This is used for `ALTER TABLE ADD/DROP COLUMN` / `ALTER SOURCE ADD COLUMN`.

--- a/src/rpc_client/src/meta_client.rs
+++ b/src/rpc_client/src/meta_client.rs
@@ -250,6 +250,18 @@ impl MetaClient {
             .ok_or_else(|| anyhow!("wait version not set"))?)
     }
 
+    pub async fn preview_drop_cascade(
+        &self,
+        object_id: u32,
+        object_type: risingwave_pb::common::PbObjectType,
+    ) -> Result<risingwave_pb::ddl_service::PreviewDropCascadeResponse> {
+        let request = PreviewDropCascadeRequest {
+            object_id,
+            object_type: object_type as i32,
+        };
+        self.inner.preview_drop_cascade(request).await
+    }
+
     pub async fn drop_secret(&self, secret_id: SecretId, cascade: bool) -> Result<WaitVersion> {
         let request = DropSecretRequest { secret_id, cascade };
         let resp = self.inner.drop_secret(request).await?;
@@ -2710,6 +2722,7 @@ macro_rules! for_all_meta_rpc {
             ,{ ddl_client, create_connection, CreateConnectionRequest, CreateConnectionResponse }
             ,{ ddl_client, list_connections, ListConnectionsRequest, ListConnectionsResponse }
             ,{ ddl_client, drop_connection, DropConnectionRequest, DropConnectionResponse }
+            ,{ ddl_client, preview_drop_cascade, PreviewDropCascadeRequest, PreviewDropCascadeResponse }
             ,{ ddl_client, comment_on, CommentOnRequest, CommentOnResponse }
             ,{ ddl_client, get_tables, GetTablesRequest, GetTablesResponse }
             ,{ ddl_client, wait, WaitRequest, WaitResponse }


### PR DESCRIPTION
## Summary

Adds a safety guard that prevents `DROP ... CASCADE` from silently deleting large dependency graphs. On new clusters the guard is **enabled by default**; existing clusters default to **disabled** for backward compatibility.

### How it works

- New session config `allow_drop_cascade` (default `false` on new clusters, `true` on existing clusters).
- Before executing any `DROP ... CASCADE`, the frontend calls a new `PreviewDropCascade` RPC to count how many user-visible objects would be removed.
- If `allow_drop_cascade = false`: the statement is rejected with a human-readable impact summary and a hint to set the flag.
- If `allow_drop_cascade = true`: a notice is emitted when the cascade actually removes additional objects, then the drop proceeds.

### Changes

- **Proto**: new `PreviewDropCascadeRequest/Response` messages and `PreviewDropCascade` RPC on `DdlService`.
- **Frontend**: `drop_cascade_guard.rs` — shared guard called by all `handle_drop_*` handlers (table, mv, view, source, sink, schema, index, function, connection, subscription, secret).
- **Meta**: `plan_drop_object` extracted from `drop_object` so the preview can reuse the cascade planning logic without executing the drop. Internal state tables (`TableType::Internal/Index/VectorIndex`) are excluded from the user-facing count.
- **Cluster init**: `MetaSrvEnv::new` seeds `allow_drop_cascade = !cluster_first_launch`.

## Test plan

- [ ] Unit test: `test_preview_drop_schema_cascade_summary` verifies object counts and type breakdown.
- [ ] Manual: new cluster — `DROP TABLE t CASCADE` is rejected with impact message; `SET allow_drop_cascade = true` allows it.
- [ ] Manual: existing cluster (seeded `allow_drop_cascade = true`) — DROP CASCADE proceeds with notice when dependents exist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)