### PR TITLE
feat(pg-cdc): support TOAST unchanged-value placeholder for vector columns

### DIFF
--- a/e2e_test/source_legacy/cdc_inline/test_postgres_toast.slt
+++ b/e2e_test/source_legacy/cdc_inline/test_postgres_toast.slt
@@ -9,7 +9,7 @@ control substitution on
 
 # Step 1: Create table with TOAST-able columns in PostgreSQL
 system ok
-psql -c "DROP TABLE IF EXISTS test CASCADE; CREATE EXTENSION IF NOT EXISTS pgcrypto; CREATE TABLE test (id int PRIMARY KEY, v1 int, v2 jsonb, v3 varchar, v4 text, v5 bytea, v6 jsonb[], v7 varchar[], v8 text[], v9 bytea[], v100 int);"
+psql -c "DROP TABLE IF EXISTS test CASCADE; CREATE EXTENSION IF NOT EXISTS pgcrypto; CREATE EXTENSION IF NOT EXISTS vector; CREATE TABLE test (id int PRIMARY KEY, v1 int, v2 jsonb, v3 varchar, v4 text, v5 bytea, v6 jsonb[], v7 varchar[], v8 text[], v9 bytea[], v10 vector(2000), v100 int);"
 
 # Step 2: Create RisingWave source from PostgreSQL CDC
 statement ok
@@ -37,12 +37,12 @@ sleep 5s
 
 # Step 5: Insert large TOAST data (id=2) - all columns trigger TOAST
 system ok
-psql -c "INSERT INTO test (id, v1, v2, v3, v4, v5, v6, v7, v8, v9, v100) SELECT 2, 22, jsonb_build_object('large_data', (SELECT jsonb_agg(jsonb_build_object('id', i, 'random_string', encode(gen_random_bytes(20), 'hex'), 'timestamp', now() + (i || ' seconds')::interval)) FROM generate_series(1, 500) i), 'nested_object', jsonb_build_object('level1', jsonb_build_object('level2', jsonb_build_object('data', encode(gen_random_bytes(100), 'hex'))))), (SELECT string_agg(encode(gen_random_bytes(10), 'hex'), '') FROM generate_series(1, 1000)), (SELECT string_agg(encode(gen_random_bytes(15), 'hex'), '') FROM generate_series(1, 1000)), (SELECT string_agg(encode(gen_random_bytes(200), 'hex'), '')::bytea FROM generate_series(1, 5000)), (SELECT array_agg(jsonb_build_object('array_id', gs.i, 'nested_data', jsonb_build_object('level1', jsonb_build_object('level2', jsonb_build_object('random_values', (SELECT jsonb_agg(encode(gen_random_bytes(10), 'hex')) FROM generate_series(1, 50))))), 'metadata', jsonb_build_object('timestamp', now() + (gs.i || ' seconds')::interval, 'random_string', encode(gen_random_bytes(20), 'hex')))) FROM generate_series(1, 300) gs(i)), ARRAY['small_string', (SELECT string_agg(encode(gen_random_bytes(10), 'hex'), '') FROM generate_series(1, 2000))], (SELECT array_agg((SELECT string_agg(encode(gen_random_bytes(8), 'hex'), '') FROM generate_series(1, 150))) FROM generate_series(1, 400)), (SELECT array_agg((SELECT string_agg(encode(gen_random_bytes(50), 'hex'), '')::bytea FROM generate_series(1, 100))) FROM generate_series(1, 200)), 100;"
+psql -c "INSERT INTO test (id, v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v100) SELECT 2, 22, jsonb_build_object('large_data', (SELECT jsonb_agg(jsonb_build_object('id', i, 'random_string', encode(gen_random_bytes(20), 'hex'), 'timestamp', now() + (i || ' seconds')::interval)) FROM generate_series(1, 500) i), 'nested_object', jsonb_build_object('level1', jsonb_build_object('level2', jsonb_build_object('data', encode(gen_random_bytes(100), 'hex'))))), (SELECT string_agg(encode(gen_random_bytes(10), 'hex'), '') FROM generate_series(1, 1000)), (SELECT string_agg(encode(gen_random_bytes(15), 'hex'), '') FROM generate_series(1, 1000)), (SELECT string_agg(encode(gen_random_bytes(200), 'hex'), '')::bytea FROM generate_series(1, 5000)), (SELECT array_agg(jsonb_build_object('array_id', gs.i, 'nested_data', jsonb_build_object('level1', jsonb_build_object('level2', jsonb_build_object('random_values', (SELECT jsonb_agg(encode(gen_random_bytes(10), 'hex')) FROM generate_series(1, 50))))), 'metadata', jsonb_build_object('timestamp', now() + (gs.i || ' seconds')::interval, 'random_string', encode(gen_random_bytes(20), 'hex')))) FROM generate_series(1, 300) gs(i)), ARRAY['small_string', (SELECT string_agg(encode(gen_random_bytes(10), 'hex'), '') FROM generate_series(1, 2000))], (SELECT array_agg((SELECT string_agg(encode(gen_random_bytes(8), 'hex'), '') FROM generate_series(1, 150))) FROM generate_series(1, 400)), (SELECT array_agg((SELECT string_agg(encode(gen_random_bytes(50), 'hex'), '')::bytea FROM generate_series(1, 100))) FROM generate_series(1, 200)), array_fill(0.5::real, ARRAY[2000])::vector(2000), 100;"
 
 # Wait for data synchronization
 
 # Step 6: Verify initial TOAST data synchronization
-query TTTTTTTTTTTT retry 6 backoff 1s
+query TTTTTTTTTTTTT retry 6 backoff 1s
 select
     id,
     v1,
@@ -54,11 +54,12 @@ select
     case when octet_length(v7::text) > 30000 then 'toast-triggered' else 'small' end as v7_size_check,
     case when octet_length(v8::text) > 900000 then 'toast-triggered' else 'small' end as v8_size_check,
     case when octet_length(v9::text) > 3000000 then 'toast-triggered' else 'small' end as v9_size_check,
+    case when octet_length(v10::text) > 7000 then 'toast-triggered' else 'small' end as v10_size_check,
     v100
 from test
 where id = 2;
 ----
-2 22 toast-triggered toast-triggered toast-triggered toast-triggered toast-triggered toast-triggered toast-triggered toast-triggered 100
+2 22 toast-triggered toast-triggered toast-triggered toast-triggered toast-triggered toast-triggered toast-triggered toast-triggered toast-triggered 100
 
 # Step 7: Insert small data (id=3) - no TOAST triggered
 system ok
@@ -83,7 +84,7 @@ VALUES (
 # Wait for small data synchronization
 
 # Step 8: Verify small data synchronization
-query TTTTTTTTTTTT retry 4 backoff 1s
+query TTTTTTTTTTTTT retry 4 backoff 1s
 select
     id,
     v1,
@@ -95,11 +96,12 @@ select
     case when octet_length(v7::text) > 30000 then 'toast-triggered' else 'small' end as v7_size_check,
     case when octet_length(v8::text) > 900000 then 'toast-triggered' else 'small' end as v8_size_check,
     case when octet_length(v9::text) > 3000000 then 'toast-triggered' else 'small' end as v9_size_check,
+    case when v10 is null then 'null' else 'present' end as v10_check,
     v100
 from test
 where id = 3;
 ----
-3 33 small small small small small small small small 300
+3 33 small small small small small small small small null 300
 
 # Step 9: Update non-TOAST column v100 for both rows
 system ok
@@ -113,8 +115,11 @@ psql -c "UPDATE test SET v100 = 999 WHERE id = 3;"
 # Step 10: Verify TOAST columns are preserved after UPDATE (id=2)
 # After updating non-TOAST columns, the original TOAST columns should remain unchanged
 # instead of being replaced by placeholders. Check that TOAST column lengths are preserved.
-# Verify TOAST columns have reasonable sizes (not placeholder values)
-query TTTTTTTTTTTT retry 4 backoff 1s
+# Verify TOAST columns have reasonable sizes (not placeholder values).
+# For the vector column, also check that the first element is still `0.5` (the
+# original value), not the sentinel `f32::MAX` that the JSON parser materialises
+# for the Debezium unchanged-TOAST placeholder.
+query TTTTTTTTTTTTTT retry 4 backoff 1s
 select
     id,
     v1,
@@ -126,11 +131,13 @@ select
     case when octet_length(v7::text) > 30000 then 'toast-triggered' else 'small' end as v7_size_check,
     case when octet_length(v8::text) > 900000 then 'toast-triggered' else 'small' end as v8_size_check,
     case when octet_length(v9::text) > 3000000 then 'toast-triggered' else 'small' end as v9_size_check,
+    case when octet_length(v10::text) > 7000 then 'toast-triggered' else 'small' end as v10_size_check,
+    case when left(v10::text, 5) = '[0.5,' then 'preserved' else 'sentinel-leaked' end as v10_content_check,
     v100
 from test
 where id = 2;
 ----
-2 22 toast-triggered toast-triggered toast-triggered toast-triggered toast-triggered toast-triggered toast-triggered toast-triggered 999
+2 22 toast-triggered toast-triggered toast-triggered toast-triggered toast-triggered toast-triggered toast-triggered toast-triggered toast-triggered preserved 999
 
 # Step 11: Test DELETE with TOAST columns (id=2)
 system ok

--- a/java/connector-node/risingwave-connector-service/src/main/resources/postgres.properties
+++ b/java/connector-node/risingwave-connector-service/src/main/resources/postgres.properties
@@ -1,7 +1,8 @@
 # configs for postgres conneoctor
 connector.class=io.debezium.connector.postgresql.PostgresConnector
-converters=st2str
+converters=st2str,vec2str
 st2str.type=com.risingwave.connector.cdc.debezium.converters.PgCompositeToStringConverter
+vec2str.type=com.risingwave.connector.cdc.debezium.converters.PgVectorToStringConverter
 # default snapshot mode to initial
 snapshot.mode=${debezium.snapshot.mode:-initial}
 database.hostname=${hostname}

--- a/java/connector-node/risingwave-source-cdc/src/main/java/com/risingwave/connector/cdc/debezium/converters/PgVectorToStringConverter.java
+++ b/java/connector-node/risingwave-source-cdc/src/main/java/com/risingwave/connector/cdc/debezium/converters/PgVectorToStringConverter.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2026 RisingWave Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.risingwave.connector.cdc.debezium.converters;
+
+import io.debezium.spi.converter.CustomConverter;
+import io.debezium.spi.converter.RelationalColumn;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.Properties;
+import org.apache.kafka.connect.data.SchemaBuilder;
+
+/**
+ * Converts PostgreSQL pgvector values into plain strings.
+ *
+ * <p>Debezium's default handler maps the {@code vector} type to {@code
+ * io.debezium.data.DoubleVector}, a {@code Schema.Type.ARRAY} of {@code FLOAT64}. That schema
+ * cannot accept Debezium's unchanged-TOAST placeholder (a Java {@code String}), so a single UPDATE
+ * that leaves a TOAST'd vector column unchanged crashes {@code Struct.put} and kills the streaming
+ * coordinator.
+ *
+ * <p>This converter bypasses that path by registering an OPTIONAL STRING schema for the {@code
+ * vector} column and passing the raw value through unchanged — either the pgvector text form {@code
+ * "[a,b,...]"} or the placeholder {@code __debezium_unavailable_value}. The downstream RisingWave
+ * parser handles both cases and the TOAST replacement logic in the materialize executor takes over
+ * from there.
+ */
+public class PgVectorToStringConverter implements CustomConverter<SchemaBuilder, RelationalColumn> {
+
+    // Must match `DEBEZIUM_UNAVAILABLE_VALUE` on the Rust side
+    // (src/common/src/types/mod.rs). When a vector column is TOAST'd and the
+    // UPDATE does not touch it, Debezium hands us a bare `java.lang.Object`
+    // singleton instead of the usual placeholder string, because the default
+    // schema for vector is ARRAY (a String placeholder would fail schema
+    // validation). We translate that sentinel back to the canonical string so
+    // the downstream RisingWave parser + materialize executor handle it
+    // through the same path as varchar/jsonb/bytea TOAST columns.
+    private static final String UNAVAILABLE_VALUE_PLACEHOLDER = "__debezium_unavailable_value";
+
+    @Override
+    public void configure(Properties props) {}
+
+    @Override
+    public void converterFor(
+            RelationalColumn column, ConverterRegistration<SchemaBuilder> registration) {
+        // pgvector ships the `vector` type as an extension; the OID is assigned dynamically at
+        // CREATE EXTENSION time, so we match on the type name instead.
+        if ("vector".equalsIgnoreCase(column.typeName())) {
+            registration.register(SchemaBuilder.string().optional(), this::convertVector);
+        }
+    }
+
+    private String convertVector(Object value) {
+        if (value == null) {
+            return null;
+        }
+        // Debezium's unchanged-TOAST sentinel for non-STRING schema columns is a
+        // bare `java.lang.Object` singleton. Normal vector values arrive as a
+        // concrete subclass (String / byte[] / PGobject / ...), so a value whose
+        // runtime class is exactly Object can only be the sentinel.
+        if (value.getClass() == Object.class) {
+            return UNAVAILABLE_VALUE_PLACEHOLDER;
+        }
+        if (value instanceof byte[] bytes) {
+            return new String(bytes, StandardCharsets.UTF_8);
+        }
+        if (value instanceof ByteBuffer buffer) {
+            var readOnly = buffer.asReadOnlyBuffer();
+            var bytes = new byte[readOnly.remaining()];
+            readOnly.get(bytes);
+            return new String(bytes, StandardCharsets.UTF_8);
+        }
+        return value.toString();
+    }
+}

--- a/src/common/src/types/mod.rs
+++ b/src/common/src/types/mod.rs
@@ -117,6 +117,27 @@ pub static DEBEZIUM_UNAVAILABLE_JSON: std::sync::LazyLock<JsonbVal> =
         JsonbVal(builder.finish())
     });
 
+/// Magic per-element value used to build the Debezium unchanged-TOAST sentinel for
+/// pgvector columns. Picked because normal embeddings sit in a normalised range and
+/// having all elements simultaneously equal to `f32::MAX` is effectively impossible.
+pub const DEBEZIUM_UNAVAILABLE_VECTOR_ELEM: f32 = f32::MAX;
+
+/// Build a sentinel `VectorVal` of the given dimension to represent Debezium's
+/// unchanged-TOAST placeholder. The dimension must match the column's declared
+/// `vector(N)` size so it passes `check_datum_type` on the way through the
+/// `SourceStreamChunkBuilder`; the materialize executor recognises this sentinel
+/// by checking that every element equals `DEBEZIUM_UNAVAILABLE_VECTOR_ELEM`.
+pub fn debezium_unavailable_vector(size: usize) -> VectorVal {
+    VectorVal::from(
+        (0..size)
+            .map(|_| {
+                crate::array::Finite32::try_from(DEBEZIUM_UNAVAILABLE_VECTOR_ELEM)
+                    .expect("f32::MAX is finite")
+            })
+            .collect::<Vec<_>>(),
+    )
+}
+
 /// The set of datatypes that are supported in RisingWave.
 ///
 /// # Trait implementations

--- a/src/connector/src/parser/unified/json.rs
+++ b/src/connector/src/parser/unified/json.rs
@@ -22,8 +22,8 @@ use risingwave_common::array::{Finite32, ListValue, StructValue};
 use risingwave_common::cast::{i64_to_timestamp, i64_to_timestamptz, str_to_bytea};
 use risingwave_common::log::LogSuppressor;
 use risingwave_common::types::{
-    DataType, Date, Decimal, Int256, Interval, JsonbVal, ScalarImpl, Time, Timestamp, Timestamptz,
-    ToOwnedDatum, VectorVal,
+    DEBEZIUM_UNAVAILABLE_VALUE, DataType, Date, Decimal, Int256, Interval, JsonbVal, ScalarImpl,
+    Time, Timestamp, Timestamptz, ToOwnedDatum, VectorVal, debezium_unavailable_vector,
 };
 use risingwave_connector_codec::decoder::utils::scaled_bigint_to_rust_decimal;
 use simd_json::base::ValueAsObject;
@@ -715,6 +715,29 @@ impl JsonParseOptions {
                     elems.push(finite);
                 }
                 VectorVal::from(elems).into()
+            }
+            // Vector emitted as a string. Reached via the Java `PgVectorToStringConverter`,
+            // which downgrades the pgvector column from `DoubleVector` (ARRAY) to STRING so
+            // that the Debezium unchanged-TOAST placeholder can flow through without tripping
+            // Connect's schema validation. The value is either the pgvector text form
+            // `"[a,b,...]"` or the placeholder; the latter is mapped to a sentinel `VectorVal`
+            // that the materialize executor recognises and replaces with the old row value.
+            (DataType::Vector(size), ValueType::String) => {
+                let s = value.as_str().unwrap();
+                if self.handle_toast_columns
+                    && s.len() == DEBEZIUM_UNAVAILABLE_VALUE.len()
+                    && s == DEBEZIUM_UNAVAILABLE_VALUE
+                {
+                    // Build the sentinel at the declared dimension so it passes
+                    // `check_datum_type` in the chunk builder; the materialize
+                    // executor recognises it by checking that every element
+                    // equals `DEBEZIUM_UNAVAILABLE_VECTOR_ELEM`.
+                    debezium_unavailable_vector(*size).into()
+                } else {
+                    VectorVal::from_text(s, *size)
+                        .map_err(|_| create_error())?
+                        .into()
+                }
             }
 
             // ---- Bytea -----

--- a/src/stream/src/executor/mview/cache.rs
+++ b/src/stream/src/executor/mview/cache.rs
@@ -524,7 +524,6 @@ mod toast {
         new_row: &OwnedRow,
         toastable_indices: &[usize],
     ) -> OwnedRow {
-        println!("这里");
         let mut fixed_row_data = new_row.as_inner().to_vec();
 
         for &toast_idx in toastable_indices {

--- a/src/stream/src/executor/mview/cache.rs
+++ b/src/stream/src/executor/mview/cache.rs
@@ -450,7 +450,7 @@ fn versions_are_newer_or_equal(
 /// TOAST column handling for CDC tables with TOAST columns.
 mod toast {
     use risingwave_common::row::Row as _;
-    use risingwave_common::types::DEBEZIUM_UNAVAILABLE_VALUE;
+    use risingwave_common::types::{DEBEZIUM_UNAVAILABLE_VALUE, DEBEZIUM_UNAVAILABLE_VECTOR_ELEM};
 
     use super::*;
 
@@ -486,6 +486,19 @@ mod toast {
                     false
                 }
             }
+            Some(risingwave_common::types::ScalarRefImpl::Vector(vec_ref)) => {
+                // pgvector unchanged-TOAST sentinel: the JSON parser materialises an N-d
+                // vector whose every element equals `DEBEZIUM_UNAVAILABLE_VECTOR_ELEM`
+                // (currently `f32::MAX`). N matches the column's declared dimension so the
+                // value survives `check_datum_type` on its way in; the chance of a real
+                // embedding having every element simultaneously equal to that value is
+                // effectively zero.
+                let slice = vec_ref.as_slice();
+                !slice.is_empty()
+                    && slice
+                        .iter()
+                        .all(|f| f.0 == DEBEZIUM_UNAVAILABLE_VECTOR_ELEM)
+            }
             Some(risingwave_common::types::ScalarRefImpl::List(list_ref)) => {
                 // For list type, check if it contains exactly one element with the unavailable value
                 // This is because when any element in an array triggers TOAST, Debezium treats the entire
@@ -511,6 +524,7 @@ mod toast {
         new_row: &OwnedRow,
         toastable_indices: &[usize],
     ) -> OwnedRow {
+        println!("这里");
         let mut fixed_row_data = new_row.as_inner().to_vec();
 
         for &toast_idx in toastable_indices {

--- a/src/stream/src/executor/mview/materialize.rs
+++ b/src/stream/src/executor/mview/materialize.rs
@@ -249,13 +249,16 @@ impl<S: StateStore, SD: ValueRowSerde> MaterializeExecutor<S, SD> {
                     // - jsonb (DataType::Jsonb)
                     // - varchar (DataType::Varchar)
                     // - bytea (DataType::Bytea)
+                    // - pgvector (DataType::Vector)
                     // - One-dimensional arrays of the above types (DataType::List)
                     //   Note: Some array types may not be fully supported yet, see issue  https://github.com/risingwavelabs/risingwave/issues/22916 for details.
 
                     // For details on how TOAST values are handled, see comments in `is_debezium_unavailable_value`.
-                    DataType::Varchar | DataType::List(_) | DataType::Bytea | DataType::Jsonb => {
-                        Some(index)
-                    }
+                    DataType::Varchar
+                    | DataType::List(_)
+                    | DataType::Bytea
+                    | DataType::Jsonb
+                    | DataType::Vector(_) => Some(index),
                     _ => None,
                 })
                 .collect();


### PR DESCRIPTION
## Problem

When `REPLICA IDENTITY` is `DEFAULT` and a TOAST'd `vector` column is left untouched by an UPDATE, pgoutput marks the column as `u` (unchanged TOAST). Debezium then hands the value converter a bare `java.lang.Object` singleton, which does not fit the default `DoubleVector` (`ARRAY<FLOAT64>`) schema. `Struct.put` throws

```
DataException: Invalid Java object for schema "io.debezium.data.DoubleVector"
    with type ARRAY: class java.lang.String for field: "embedding"
```

the streaming coordinator exits, the CDC stream stops, and upstream WAL piles up.

#21577 added the downstream TOAST-placeholder path for `varchar` / `jsonb` / `bytea` / `List`. `vector` could not even reach the Rust side, so it never benefited from that path.

## Fix

Extend the same machinery to pgvector.

### Java

* New `PgVectorToStringConverter` registers an OPTIONAL STRING schema for any column whose `typeName == \"vector\"`, bypassing the default `DoubleVector` mapping.
* When the converter sees the bare `java.lang.Object` sentinel Debezium uses for non-STRING TOAST columns, it emits the canonical placeholder string `__debezium_unavailable_value`, so the column flows through the same downstream path as `varchar` / `jsonb` / `bytea`.

### Rust

* `debezium_unavailable_vector(N)` builds an N-dimensional `VectorVal` whose every element equals `f32::MAX`. Matching the declared dimension is required so the value survives `chunk_builder::check_datum_type`.
* `unified/json.rs` adds a `(Vector(N), String)` arm: the placeholder string materialises the sentinel above; a real pgvector text literal `\"[a,b,...]\"` goes through `VectorVal::from_text` as before.
* `materialize.rs` adds `DataType::Vector(_)` to the toastable column whitelist.
* `cache.rs::is_debezium_unavailable_value` recognises the sentinel by checking that every element equals `f32::MAX`. A real all-`f32::MAX` embedding cannot cause an incorrect replacement: the unchanged-TOAST path only fires when the column was not modified, so the value pulled from state equals the value the upstream still holds.

## Tested manually

CDC source on a table

```sql
CREATE TABLE vector_toast_test (
  id int PRIMARY KEY,
  embedding vector(1536) NOT NULL,
  metadata text,
  updated_at timestamp DEFAULT NOW()
);
ALTER TABLE vector_toast_test REPLICA IDENTITY DEFAULT;
```

with random 1536-d embeddings inserted in PG. An UPDATE that only changes `metadata`:

* Before this PR — connector node logs the DataException, streaming coordinator exits, stream stops.
* After this PR — UPDATE is delivered, downstream `metadata` is updated, and downstream `embedding` retains the value snapshotted during backfill.

## Cross-connector check

* MySQL has no TOAST semantics; MySQL `VECTOR` (9.0+) is unaffected.
* SQL Server / MongoDB do not yet support `vector` ingestion in RW.

This PR is scoped to Postgres CDC.

## Known limitation tracked separately

The `MaterializeExecutor` runtime optimization at `materialize.rs:485` demotes `ConflictBehavior::Overwrite` to `NoCheck` when there is no downstream subscriber, which bypasses `MaterializeCache` and therefore the TOAST replacement path entirely. Without a downstream MV, sentinel values currently land in state for all toastable types (not just `vector`). I will open a separate issue / fix to gate that demotion on `toastable_column_indices.is_none()`.