### PR TITLE
fix(cdc): keep TOAST replacement path active on tables without downstream

### DIFF
--- a/src/stream/src/executor/mview/materialize.rs
+++ b/src/stream/src/executor/mview/materialize.rs
@@ -94,6 +94,12 @@ pub struct MaterializeExecutor<S: StateStore, SD: ValueRowSerde> {
     /// The cache for conflict handling. `None` if conflict behavior is `NoCheck`.
     materialize_cache: Option<MaterializeCache>,
 
+    /// Indices of columns that may carry a Debezium unchanged-TOAST placeholder
+    /// (PostgreSQL CDC only). Mirrors the value passed into `MaterializeCache`.
+    /// Used at runtime to prevent the `Overwrite -> NoCheck` downgrade from
+    /// bypassing the placeholder replacement path.
+    toastable_column_indices: Option<Vec<usize>>,
+
     conflict_behavior: ConflictBehavior,
 
     /// Whether the table can clean itself by TTL watermark, i.e., is defined with `WATERMARK ... WITH TTL`.
@@ -338,9 +344,10 @@ impl<S: StateStore, SD: ValueRowSerde> MaterializeExecutor<S, SD> {
                 row_serde,
                 version_column_indices.clone(),
                 conflict_behavior,
-                toastable_column_indices,
+                toastable_column_indices.clone(),
                 cache_metrics,
             ),
+            toastable_column_indices,
             conflict_behavior,
             cleaned_by_ttl_watermark,
             version_column_indices,
@@ -471,11 +478,18 @@ impl<S: StateStore, SD: ValueRowSerde> MaterializeExecutor<S, SD> {
                                 // while outputting inconsistent changes to downstream which no one will subscribe to.
                                 // For tables with watermark TTL (indicated by `cleaned_by_ttl_watermark`), conflict check must be enabled.
                                 // TODO(ttl): differentiate between table consistency and downstream consistency.
+                                // When the table carries TOAST-able columns (PostgreSQL CDC), the
+                                // `MaterializeCache` is the only place where the Debezium
+                                // unchanged-TOAST placeholder is detected and swapped for the row's
+                                // previous value. Demoting to `NoCheck` here would skip the cache
+                                // entirely and let the placeholder land in state. Keep the original
+                                // `Overwrite` behavior in that case so the replacement path runs.
                                 let optimized_conflict_behavior = if let ConflictBehavior::Overwrite =
                                     self.conflict_behavior
                                     && !self.state_table.is_consistent_op()
                                     && !self.cleaned_by_ttl_watermark
                                     && self.version_column_indices.is_empty()
+                                    && self.toastable_column_indices.is_none()
                                 {
                                     ConflictBehavior::NoCheck
                                 } else {
@@ -1209,6 +1223,7 @@ impl<S: StateStore> MaterializeExecutor<S, BasicSerde> {
                 None,
                 cache_metrics,
             ),
+            toastable_column_indices: None,
             conflict_behavior,
             cleaned_by_ttl_watermark: false,
             version_column_indices: vec![],


### PR DESCRIPTION
## Problem

PR #21577 added the Debezium unchanged-TOAST placeholder replacement path inside `MaterializeCache::handle_inner`: when an UPDATE event for a PG CDC row carries the placeholder for an unchanged TOAST column (varchar / jsonb / bytea / List, and after #25863 also \`vector\`), the cache fetches the previous row from state and swaps the placeholder back.

However, `MaterializeExecutor::execute_inner` contains an *unrelated* performance optimization in [materialize.rs:481](src/stream/src/executor/mview/materialize.rs#L481):

```

let optimized_conflict_behavior = if let ConflictBehavior::Overwrite = self.conflict_behavior
    && !self.state_table.is_consistent_op()
    && !self.cleaned_by_ttl_watermark
    && self.version_column_indices.is_empty()
{
    ConflictBehavior::NoCheck   // skip MaterializeCache, write_chunk straight to state
} else {
    self.conflict_behavior
};

```

This runtime demotion skips \`MaterializeCache\` entirely and writes the chunk straight into the state table. For PG CDC tables **without a downstream subscriber**, all four conditions are satisfied, so:

* the placeholder bytes land in state untouched
* a subsequent \`SELECT\` returns \`__debezium_unavailable_value\` for varchar / jsonb / bytea, the all-\`f32::MAX\` sentinel for vector, and so on

The construction-time invariant inside [\`MaterializeCache::new\`](src/stream/src/executor/mview/cache.rs#L88):


```
ConflictBehavior::NoCheck => {
    assert!(toastable_column_indices.is_none(), \"when there are toastable columns, conflict handling must be enabled\");
    return None;
}

```

only sees the original \`conflict_behavior\` passed at construction; the runtime demotion lives one level up, so this assert can never fire on the affected tables and the gap stays silent.

## Fix

Mirror \`toastable_column_indices\` on \`MaterializeExecutor\` itself and add it to the demotion guard:

\`\`\`rust
let optimized_conflict_behavior = if let ConflictBehavior::Overwrite = self.conflict_behavior
    && !self.state_table.is_consistent_op()
    && !self.cleaned_by_ttl_watermark
    && self.version_column_indices.is_empty()
    && self.toastable_column_indices.is_none()   // new
{
    ConflictBehavior::NoCheck
} else {
    self.conflict_behavior
};
\`\`\`

## Why this is exact, no over-correction

\`toastable_column_indices\` is populated inside [materialize.rs:241](src/stream/src/executor/mview/materialize.rs#L241) only when:

1. \`table_catalog.cdc_table_type() == Postgres\`, **and**
2. the table has at least one column whose \`DataType\` is in the TOAST-able whitelist (\`Varchar | List(_) | Bytea | Jsonb | Vector(_)\`).

For every other table — non-CDC tables, MySQL / SQL Server / MongoDB CDC, PG CDC tables that only carry int / bool / numeric / etc. — the field is \`None\` and the demotion to \`NoCheck\` continues to fire unchanged. Only the narrow class \"PG CDC table with at least one TOAST-able column and no downstream subscriber\" stays on the cache path. Those tables exchange a per-row LRU lookup for correctness; they are typically metadata / config / embedding tables with modest update frequency, and after the initial \`fetch_keys\` batch the LRU absorbs repeated UPDATEs on the same key with no extra IO.

## Cross-connector check

* MySQL / SQL Server / MongoDB CDC: \`toastable_column_indices\` is always \`None\`, behavior unchanged.
* Non-CDC streaming tables / MVs: \`cdc_table_type\` is \`Unspecified\`, \`toastable_column_indices\` is \`None\`, behavior unchanged.

## Tested manually

PG CDC table

\`\`\`sql
CREATE TABLE t (id int PRIMARY KEY, payload jsonb, ts timestamp);
ALTER TABLE t REPLICA IDENTITY DEFAULT;
\`\`\`

with a large \`payload\` (forced into TOAST), no downstream MV on the RW side.

* Before this PR: \`UPDATE t SET ts = now() WHERE id = ...\` leaves \`payload = '__debezium_unavailable_value'\` in the downstream table.
* After this PR: the same UPDATE preserves the original payload in the downstream table.

## Related

* #21577 — wired in the placeholder replacement path for varchar / jsonb / bytea / List.
* #25863 — extended that path to \`vector\` (pgvector). Both PRs assumed the cache path was reached; this PR makes that assumption true on tables without a downstream.