### PR TITLE
fix(iceberg): reject sink column order mismatch to prevent silent data corruption

### DIFF
--- a/e2e_test/iceberg/test_case/column_order_validation.toml
+++ b/e2e_test/iceberg/test_case/column_order_validation.toml
@@ -1,0 +1,18 @@
+init_sqls = [
+    'CREATE SCHEMA IF NOT EXISTS demo_db',
+    'DROP TABLE IF EXISTS demo_db.column_order_validation_table PURGE',
+    '''
+    CREATE TABLE demo_db.column_order_validation_table (
+    col_a int,
+    col_b int
+    ) USING iceberg
+    TBLPROPERTIES ('format-version'='2');
+    '''
+]
+
+slt = 'test_case/iceberg_sink_column_order_validation.slt'
+
+drop_sqls = [
+ 'DROP TABLE IF EXISTS demo_db.column_order_validation_table PURGE',
+ 'DROP SCHEMA IF EXISTS demo_db'
+]

--- a/e2e_test/iceberg/test_case/iceberg_sink_column_order_validation.slt
+++ b/e2e_test/iceberg/test_case/iceberg_sink_column_order_validation.slt
@@ -1,0 +1,52 @@
+statement ok
+set sink_decouple = false;
+
+statement ok
+DROP TABLE IF EXISTS column_order_validation_t;
+
+statement ok
+CREATE TABLE column_order_validation_t (col_a int, col_b int);
+
+# The Iceberg table column order is (col_a, col_b). The sink writes columns by
+# position, so projecting in reverse order (col_b, col_a) must be rejected at
+# CREATE SINK time instead of silently writing to the wrong columns.
+statement error Column order mismatch
+CREATE SINK column_order_validation_sink AS SELECT col_b, col_a FROM column_order_validation_t WITH (
+    connector = 'iceberg',
+    type = 'append-only',
+    force_append_only = 'true',
+    catalog.name = 'demo',
+    catalog.type = 'storage',
+    warehouse.path = 's3a://icebergdata/demo',
+    database.name = 'demo_db',
+    table.name = 'column_order_validation_table',
+    commit_checkpoint_interval = 1,
+    s3.endpoint = 'http://127.0.0.1:9301',
+    s3.region = 'us-east-1',
+    s3.access.key = 'hummockadmin',
+    s3.secret.key = 'hummockadmin'
+);
+
+# Matching column order succeeds.
+statement ok
+CREATE SINK column_order_validation_sink AS SELECT col_a, col_b FROM column_order_validation_t WITH (
+    connector = 'iceberg',
+    type = 'append-only',
+    force_append_only = 'true',
+    catalog.name = 'demo',
+    catalog.type = 'storage',
+    warehouse.path = 's3a://icebergdata/demo',
+    database.name = 'demo_db',
+    table.name = 'column_order_validation_table',
+    commit_checkpoint_interval = 1,
+    s3.endpoint = 'http://127.0.0.1:9301',
+    s3.region = 'us-east-1',
+    s3.access.key = 'hummockadmin',
+    s3.secret.key = 'hummockadmin'
+);
+
+statement ok
+DROP SINK column_order_validation_sink;
+
+statement ok
+DROP TABLE column_order_validation_t;

--- a/src/connector/src/sink/iceberg/create_table.rs
+++ b/src/connector/src/sink/iceberg/create_table.rs
@@ -33,6 +33,7 @@ use risingwave_common::array::arrow::arrow_schema_iceberg::{
 use risingwave_common::array::arrow::{IcebergArrowConvert, IcebergCreateTableArrowConvert};
 use risingwave_common::bail;
 use risingwave_common::catalog::Schema;
+use risingwave_common::util::iter_util::ZipEqFast;
 use url::Url;
 
 use super::{IcebergConfig, PARTITION_DATA_ID_START, SinkError};
@@ -381,6 +382,29 @@ pub fn try_matches_arrow_schema(rw_schema: &Schema, arrow_schema: &ArrowSchema) 
     });
 
     check_compatibility(schema_fields, &arrow_schema.fields)?;
+
+    // The sink writes columns to the Iceberg table by position, so the column order
+    // must match. The check above only validates the name set and types.
+    for (idx, (rw_field, arrow_field)) in rw_schema
+        .fields
+        .iter()
+        .zip_eq_fast(arrow_schema.fields().iter())
+        .enumerate()
+    {
+        if rw_field.name.as_str() != arrow_field.name().as_str() {
+            bail!(
+                "Column order mismatch at position {}: the sink has column `{}` but the \
+                 Iceberg table has column `{}`. The Iceberg sink maps columns to the table \
+                 by position, so the sink's column order must match the Iceberg table \
+                 columns [{}].",
+                idx,
+                rw_field.name,
+                arrow_field.name(),
+                arrow_schema.fields().iter().map(|f| f.name()).join(", "),
+            );
+        }
+    }
+
     Ok(())
 }
 

--- a/src/connector/src/sink/iceberg/test.rs
+++ b/src/connector/src/sink/iceberg/test.rs
@@ -58,10 +58,10 @@ fn test_compatible_arrow_schema() {
         Field::with_name(DataType::Int32, "b"),
     ]);
     let arrow_schema = ArrowSchema::new(vec![
-        ArrowField::new("a", ArrowDataType::Int32, false),
-        ArrowField::new("b", ArrowDataType::Int32, false),
         ArrowField::new("d", ArrowDataType::Int32, false),
         ArrowField::new("c", ArrowDataType::Int32, false),
+        ArrowField::new("a", ArrowDataType::Int32, false),
+        ArrowField::new("b", ArrowDataType::Int32, false),
     ]);
     try_matches_arrow_schema(&risingwave_schema, &arrow_schema).unwrap();
 
@@ -186,6 +186,25 @@ fn test_compatible_arrow_schema() {
         ),
     ]);
     try_matches_arrow_schema(&risingwave_schema, &arrow_schema).unwrap();
+}
+
+#[test]
+fn test_arrow_schema_column_order_mismatch() {
+    use super::*;
+    // Same names and types but a different column order must be rejected.
+    let risingwave_schema = Schema::new(vec![
+        Field::with_name(DataType::Int32, "col_a"),
+        Field::with_name(DataType::Int32, "col_b"),
+    ]);
+    let arrow_schema = ArrowSchema::new(vec![
+        ArrowField::new("col_b", ArrowDataType::Int32, false),
+        ArrowField::new("col_a", ArrowDataType::Int32, false),
+    ]);
+    let err = try_matches_arrow_schema(&risingwave_schema, &arrow_schema).unwrap_err();
+    assert!(
+        err.to_string().contains("Column order mismatch"),
+        "unexpected error: {err}"
+    );
 }
 
 #[test]


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

<!--

**Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

- Closes #[ISSUE_NUMBER]

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
