### PR TITLE
refactor: ensure all meta store tables are empty during meta restore

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12651,6 +12651,7 @@ dependencies = [
  "sea-orm",
  "serde",
  "serde_json",
+ "syn 2.0.117",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12652,6 +12652,7 @@ dependencies = [
  "serde",
  "serde_json",
  "syn 2.0.117",
+ "thiserror-ext",
 ]
 
 [[package]]

--- a/src/meta/model/Cargo.toml
+++ b/src/meta/model/Cargo.toml
@@ -17,3 +17,4 @@ serde_json = "1"
 
 [dev-dependencies]
 syn = { version = "2", features = ["full"] }
+thiserror-ext = { workspace = true }

--- a/src/meta/model/Cargo.toml
+++ b/src/meta/model/Cargo.toml
@@ -14,3 +14,6 @@ risingwave_pb = { workspace = true }
 sea-orm = { workspace = true }
 serde = { workspace = true }
 serde_json = "1"
+
+[dev-dependencies]
+syn = { version = "2", features = ["full"] }

--- a/src/meta/model/src/lib.rs
+++ b/src/meta/model/src/lib.rs
@@ -73,6 +73,61 @@ pub mod view;
 pub mod worker;
 pub mod worker_property;
 
+#[macro_export]
+macro_rules! for_all_meta_model_entities {
+    ($macro:ident) => {
+        $macro! {
+            catalog_version,
+            cdc_table_snapshot_split,
+            cluster,
+            compaction_config,
+            compaction_status,
+            compaction_task,
+            connection,
+            database,
+            exactly_once_iceberg_sink,
+            fragment,
+            fragment_relation,
+            fragment_splits,
+            function,
+            hummock_epoch_to_version,
+            hummock_gc_history,
+            hummock_pinned_snapshot,
+            hummock_pinned_version,
+            hummock_sequence,
+            hummock_sstable_info,
+            hummock_table_change_log,
+            hummock_time_travel_delta,
+            hummock_time_travel_version,
+            hummock_version_delta,
+            hummock_version_stats,
+            iceberg_namespace_properties,
+            iceberg_tables,
+            index,
+            object,
+            object_dependency,
+            pending_sink_state,
+            refresh_job,
+            schema,
+            secret,
+            serde_seaql_migration,
+            session_parameter,
+            sink,
+            source,
+            streaming_job,
+            subscription,
+            system_parameter,
+            table,
+            user,
+            user_default_privilege,
+            user_privilege,
+            view,
+            worker,
+            worker_property
+        }
+    };
+}
+
 pub type TransactionId = i32;
 
 pub type PrivilegeId = i32;

--- a/src/meta/model/tests/meta_model_entities.rs
+++ b/src/meta/model/tests/meta_model_entities.rs
@@ -90,7 +90,11 @@ fn parse_table_names_in_src_tree() -> BTreeSet<String> {
             panic!("failed to read dir {}: {}", dir.display(), err.as_report())
         }) {
             let entry = entry.unwrap_or_else(|err| {
-                panic!("failed to read directory entry in {}: {}", dir.display(), err.as_report())
+                panic!(
+                    "failed to read directory entry in {}: {}",
+                    dir.display(),
+                    err.as_report()
+                )
             });
             let path = entry.path();
             if path.is_dir() {

--- a/src/meta/model/tests/meta_model_entities.rs
+++ b/src/meta/model/tests/meta_model_entities.rs
@@ -13,66 +13,89 @@
 // limitations under the License.
 
 use std::collections::BTreeSet;
+use std::path::PathBuf;
 
-fn parse_pub_mods(lib_rs: &str) -> BTreeSet<String> {
-    let mut mods = BTreeSet::new();
-    for line in lib_rs.lines() {
-        let line = line.trim();
-        let Some(rest) = line.strip_prefix("pub mod ") else {
-            continue;
-        };
-        let rest = rest.trim();
-        let Some(name) = rest.strip_suffix(';') else {
-            continue;
-        };
-        let name = name.trim();
-        if name.is_empty() {
-            continue;
-        }
-        if name.chars().all(|c| c.is_ascii_alphanumeric() || c == '_') {
-            mods.insert(name.to_owned());
-        }
-    }
-    mods
+fn parse_pub_mods_with_syn(lib_rs: &str) -> BTreeSet<String> {
+    syn::parse_file(lib_rs)
+        .expect("failed to parse src/lib.rs")
+        .items
+        .into_iter()
+        .filter_map(|item| match item {
+            syn::Item::Mod(module) if matches!(module.vis, syn::Visibility::Public(_)) => {
+                Some(module.ident.to_string())
+            }
+            _ => None,
+        })
+        .collect()
 }
 
-fn parse_models_in_for_all_meta_model_entities(lib_rs: &str) -> BTreeSet<String> {
-    let Some((_, after_macro_start)) =
-        lib_rs.split_once("macro_rules! for_all_meta_model_entities")
-    else {
-        panic!("for_all_meta_model_entities macro not found");
-    };
-    let Some((macro_body, _)) = after_macro_start.split_once("};\n}\n") else {
-        panic!("for_all_meta_model_entities macro end not found");
-    };
+macro_rules! collect_modules_in_for_all_meta_model_entities {
+    ($($module:ident),* $(,)?) => {{
+        [$(stringify!($module)),*]
+            .into_iter()
+            .map(ToOwned::to_owned)
+            .collect::<BTreeSet<String>>()
+    }};
+}
 
-    macro_body
-        .lines()
-        .map(str::trim)
-        .filter(|line| !line.is_empty())
-        .filter_map(|line| line.strip_suffix(','))
-        .filter(|line| line.chars().all(|c| c.is_ascii_alphanumeric() || c == '_'))
-        .map(ToOwned::to_owned)
+fn parse_table_names_with_syn(source: &str) -> BTreeSet<String> {
+    let mut table_names = BTreeSet::new();
+    let parsed = syn::parse_file(source).expect("failed to parse source file");
+    for item in parsed.items {
+        let syn::Item::Struct(item_struct) = item else {
+            continue;
+        };
+        for attr in item_struct.attrs {
+            if !attr.path().is_ident("sea_orm") {
+                continue;
+            }
+            attr.parse_nested_meta(|meta| {
+                if meta.path.is_ident("table_name") {
+                    let value = meta.value()?;
+                    table_names.insert(value.parse::<syn::LitStr>()?.value());
+                }
+                Ok(())
+            })
+            .expect("failed to parse #[sea_orm(...)] attribute");
+        }
+    }
+    table_names
+}
+
+fn parse_table_names_in_modules(modules: impl IntoIterator<Item = String>) -> BTreeSet<String> {
+    let model_src_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("src");
+    modules
+        .into_iter()
+        .flat_map(|module| {
+            let source = std::fs::read_to_string(model_src_dir.join(format!("{module}.rs")))
+                .unwrap_or_else(|err| panic!("failed to read {module}.rs: {err}"));
+            parse_table_names_with_syn(&source)
+        })
         .collect()
 }
 
 #[test]
-fn for_all_meta_model_entities_should_cover_all_entity_modules() {
+fn for_all_meta_model_entities_should_cover_all_entity_table_names() {
     let lib_rs = include_str!("../src/lib.rs");
 
-    let all_meta_model_modules = parse_pub_mods(lib_rs);
-    let expected: BTreeSet<String> = all_meta_model_modules
+    let expected = parse_table_names_in_modules(
+        parse_pub_mods_with_syn(lib_rs)
         .into_iter()
         .filter(|m| m != "prelude")
-        .collect();
-    let actual = parse_models_in_for_all_meta_model_entities(lib_rs);
+        .collect::<BTreeSet<_>>(),
+    );
+    let actual = parse_table_names_in_modules(
+        risingwave_meta_model::for_all_meta_model_entities!(
+            collect_modules_in_for_all_meta_model_entities
+        ),
+    );
 
     let missing: Vec<_> = expected.difference(&actual).cloned().collect();
     let unexpected: Vec<_> = actual.difference(&expected).cloned().collect();
 
     assert!(
         missing.is_empty() && unexpected.is_empty(),
-        "for_all_meta_model_entities is out of sync with risingwave_meta_model::lib.\n\
+        "for_all_meta_model_entities is out of sync with meta model sea_orm table_name definitions.\n\
 Missing in for_all_meta_model_entities: {missing:?}\n\
 Unexpected in for_all_meta_model_entities: {unexpected:?}"
     );

--- a/src/meta/model/tests/meta_model_entities.rs
+++ b/src/meta/model/tests/meta_model_entities.rs
@@ -1,0 +1,79 @@
+// Copyright 2026 RisingWave Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::BTreeSet;
+
+fn parse_pub_mods(lib_rs: &str) -> BTreeSet<String> {
+    let mut mods = BTreeSet::new();
+    for line in lib_rs.lines() {
+        let line = line.trim();
+        let Some(rest) = line.strip_prefix("pub mod ") else {
+            continue;
+        };
+        let rest = rest.trim();
+        let Some(name) = rest.strip_suffix(';') else {
+            continue;
+        };
+        let name = name.trim();
+        if name.is_empty() {
+            continue;
+        }
+        if name.chars().all(|c| c.is_ascii_alphanumeric() || c == '_') {
+            mods.insert(name.to_owned());
+        }
+    }
+    mods
+}
+
+fn parse_models_in_for_all_meta_model_entities(lib_rs: &str) -> BTreeSet<String> {
+    let Some((_, after_macro_start)) =
+        lib_rs.split_once("macro_rules! for_all_meta_model_entities")
+    else {
+        panic!("for_all_meta_model_entities macro not found");
+    };
+    let Some((macro_body, _)) = after_macro_start.split_once("};\n}\n") else {
+        panic!("for_all_meta_model_entities macro end not found");
+    };
+
+    macro_body
+        .lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty())
+        .filter_map(|line| line.strip_suffix(','))
+        .filter(|line| line.chars().all(|c| c.is_ascii_alphanumeric() || c == '_'))
+        .map(ToOwned::to_owned)
+        .collect()
+}
+
+#[test]
+fn for_all_meta_model_entities_should_cover_all_entity_modules() {
+    let lib_rs = include_str!("../src/lib.rs");
+
+    let all_meta_model_modules = parse_pub_mods(lib_rs);
+    let expected: BTreeSet<String> = all_meta_model_modules
+        .into_iter()
+        .filter(|m| m != "prelude")
+        .collect();
+    let actual = parse_models_in_for_all_meta_model_entities(lib_rs);
+
+    let missing: Vec<_> = expected.difference(&actual).cloned().collect();
+    let unexpected: Vec<_> = actual.difference(&expected).cloned().collect();
+
+    assert!(
+        missing.is_empty() && unexpected.is_empty(),
+        "for_all_meta_model_entities is out of sync with risingwave_meta_model::lib.\n\
+Missing in for_all_meta_model_entities: {missing:?}\n\
+Unexpected in for_all_meta_model_entities: {unexpected:?}"
+    );
+}

--- a/src/meta/model/tests/meta_model_entities.rs
+++ b/src/meta/model/tests/meta_model_entities.rs
@@ -17,7 +17,7 @@ use std::path::PathBuf;
 
 fn parse_pub_mods_with_syn(lib_rs: &str) -> BTreeSet<String> {
     syn::parse_file(lib_rs)
-        .expect("failed to parse src/lib.rs")
+        .expect("failed to parse lib.rs content")
         .items
         .into_iter()
         .filter_map(|item| match item {
@@ -38,26 +38,41 @@ macro_rules! collect_modules_in_for_all_meta_model_entities {
     }};
 }
 
-fn parse_table_names_with_syn(source: &str) -> BTreeSet<String> {
+fn parse_table_names_with_syn(source: &str, source_name: &str) -> BTreeSet<String> {
     let mut table_names = BTreeSet::new();
-    let parsed = syn::parse_file(source).expect("failed to parse source file");
+    let parsed = syn::parse_file(source)
+        .unwrap_or_else(|err| panic!("failed to parse {source_name}: {err}"));
     for item in parsed.items {
         let syn::Item::Struct(item_struct) = item else {
             continue;
         };
+        let mut saw_sea_orm_attr = false;
+        let mut saw_table_name = false;
         for attr in item_struct.attrs {
             if !attr.path().is_ident("sea_orm") {
                 continue;
             }
+            saw_sea_orm_attr = true;
             attr.parse_nested_meta(|meta| {
                 if meta.path.is_ident("table_name") {
                     let value = meta.value()?;
                     table_names.insert(value.parse::<syn::LitStr>()?.value());
+                    saw_table_name = true;
                 }
                 Ok(())
             })
-            .expect("failed to parse #[sea_orm(...)] attribute");
+            .unwrap_or_else(|err| {
+                panic!(
+                    "failed to parse #[sea_orm(...)] attribute on struct `{}` in {source_name}: {err}",
+                    item_struct.ident
+                )
+            });
         }
+        assert!(
+            !saw_sea_orm_attr || saw_table_name,
+            "struct `{}` has #[sea_orm(...)] but no table_name",
+            item_struct.ident
+        );
     }
     table_names
 }
@@ -67,9 +82,10 @@ fn parse_table_names_in_modules(modules: impl IntoIterator<Item = String>) -> BT
     modules
         .into_iter()
         .flat_map(|module| {
-            let source = std::fs::read_to_string(model_src_dir.join(format!("{module}.rs")))
-                .unwrap_or_else(|err| panic!("failed to read {module}.rs: {err}"));
-            parse_table_names_with_syn(&source)
+            let module_path = model_src_dir.join(format!("{module}.rs"));
+            let source = std::fs::read_to_string(&module_path)
+                .unwrap_or_else(|err| panic!("failed to read {}: {err}", module_path.display()));
+            parse_table_names_with_syn(&source, &module_path.display().to_string())
         })
         .collect()
 }

--- a/src/meta/model/tests/meta_model_entities.rs
+++ b/src/meta/model/tests/meta_model_entities.rs
@@ -17,20 +17,6 @@ use std::path::PathBuf;
 
 use thiserror_ext::AsReport;
 
-fn parse_pub_mods_with_syn(lib_rs: &str) -> BTreeSet<String> {
-    syn::parse_file(lib_rs)
-        .expect("failed to parse lib.rs content")
-        .items
-        .into_iter()
-        .filter_map(|item| match item {
-            syn::Item::Mod(module) if matches!(module.vis, syn::Visibility::Public(_)) => {
-                Some(module.ident.to_string())
-            }
-            _ => None,
-        })
-        .collect()
-}
-
 macro_rules! collect_modules_in_for_all_meta_model_entities {
     ($($module:ident),* $(,)?) => {{
         [$(stringify!($module)),*]
@@ -98,16 +84,41 @@ fn parse_table_names_in_modules(modules: impl IntoIterator<Item = String>) -> BT
         .collect()
 }
 
+fn parse_table_names_in_src_tree() -> BTreeSet<String> {
+    fn collect_rs_files(dir: &std::path::Path, out: &mut Vec<PathBuf>) {
+        for entry in std::fs::read_dir(dir).unwrap_or_else(|err| {
+            panic!("failed to read dir {}: {}", dir.display(), err.as_report())
+        }) {
+            let entry = entry.unwrap_or_else(|err| {
+                panic!("failed to read directory entry in {}: {}", dir.display(), err.as_report())
+            });
+            let path = entry.path();
+            if path.is_dir() {
+                collect_rs_files(&path, out);
+            } else if path.extension().is_some_and(|ext| ext == "rs") {
+                out.push(path);
+            }
+        }
+    }
+
+    let src_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("src");
+    let mut rs_files = Vec::new();
+    collect_rs_files(&src_dir, &mut rs_files);
+    rs_files.sort();
+    rs_files
+        .into_iter()
+        .flat_map(|path| {
+            let source = std::fs::read_to_string(&path).unwrap_or_else(|err| {
+                panic!("failed to read {}: {}", path.display(), err.as_report())
+            });
+            parse_table_names_with_syn(&source, &path.display().to_string())
+        })
+        .collect()
+}
+
 #[test]
 fn for_all_meta_model_entities_should_cover_all_entity_table_names() {
-    let lib_rs = include_str!("../src/lib.rs");
-
-    let expected = parse_table_names_in_modules(
-        parse_pub_mods_with_syn(lib_rs)
-            .into_iter()
-            .filter(|m| m != "prelude")
-            .collect::<BTreeSet<_>>(),
-    );
+    let expected = parse_table_names_in_src_tree();
     let actual = parse_table_names_in_modules(risingwave_meta_model::for_all_meta_model_entities!(
         collect_modules_in_for_all_meta_model_entities
     ));

--- a/src/meta/model/tests/meta_model_entities.rs
+++ b/src/meta/model/tests/meta_model_entities.rs
@@ -15,6 +15,8 @@
 use std::collections::BTreeSet;
 use std::path::PathBuf;
 
+use thiserror_ext::AsReport;
+
 fn parse_pub_mods_with_syn(lib_rs: &str) -> BTreeSet<String> {
     syn::parse_file(lib_rs)
         .expect("failed to parse lib.rs content")
@@ -41,7 +43,7 @@ macro_rules! collect_modules_in_for_all_meta_model_entities {
 fn parse_table_names_with_syn(source: &str, source_name: &str) -> BTreeSet<String> {
     let mut table_names = BTreeSet::new();
     let parsed = syn::parse_file(source)
-        .unwrap_or_else(|err| panic!("failed to parse {source_name}: {err}"));
+        .unwrap_or_else(|err| panic!("failed to parse {source_name}: {}", err.as_report()));
     for item in parsed.items {
         let syn::Item::Struct(item_struct) = item else {
             continue;
@@ -63,8 +65,9 @@ fn parse_table_names_with_syn(source: &str, source_name: &str) -> BTreeSet<Strin
             })
             .unwrap_or_else(|err| {
                 panic!(
-                    "failed to parse #[sea_orm(...)] attribute on struct `{}` in {source_name}: {err}",
-                    item_struct.ident
+                    "failed to parse #[sea_orm(...)] attribute on struct `{}` in {source_name}: {}",
+                    item_struct.ident,
+                    err.as_report()
                 )
             });
         }
@@ -83,8 +86,13 @@ fn parse_table_names_in_modules(modules: impl IntoIterator<Item = String>) -> BT
         .into_iter()
         .flat_map(|module| {
             let module_path = model_src_dir.join(format!("{module}.rs"));
-            let source = std::fs::read_to_string(&module_path)
-                .unwrap_or_else(|err| panic!("failed to read {}: {err}", module_path.display()));
+            let source = std::fs::read_to_string(&module_path).unwrap_or_else(|err| {
+                panic!(
+                    "failed to read {}: {}",
+                    module_path.display(),
+                    err.as_report()
+                )
+            });
             parse_table_names_with_syn(&source, &module_path.display().to_string())
         })
         .collect()
@@ -96,15 +104,13 @@ fn for_all_meta_model_entities_should_cover_all_entity_table_names() {
 
     let expected = parse_table_names_in_modules(
         parse_pub_mods_with_syn(lib_rs)
-        .into_iter()
-        .filter(|m| m != "prelude")
-        .collect::<BTreeSet<_>>(),
+            .into_iter()
+            .filter(|m| m != "prelude")
+            .collect::<BTreeSet<_>>(),
     );
-    let actual = parse_table_names_in_modules(
-        risingwave_meta_model::for_all_meta_model_entities!(
-            collect_modules_in_for_all_meta_model_entities
-        ),
-    );
+    let actual = parse_table_names_in_modules(risingwave_meta_model::for_all_meta_model_entities!(
+        collect_modules_in_for_all_meta_model_entities
+    ));
 
     let missing: Vec<_> = expected.difference(&actual).cloned().collect();
     let unexpected: Vec<_> = actual.difference(&expected).cloned().collect();

--- a/src/meta/src/backup_restore/restore_impl/v2.rs
+++ b/src/meta/src/backup_restore/restore_impl/v2.rs
@@ -101,6 +101,7 @@ impl Writer<MetadataV2> for WriterModelV2ToMetaStoreV2 {
     async fn write(&self, target_snapshot: MetaSnapshot<MetadataV2>) -> BackupResult<()> {
         let metadata = target_snapshot.metadata;
         let db = &self.meta_store.conn;
+        ensure_all_meta_store_tables_are_empty(db).await?;
         insert_models(metadata.seaql_migrations.clone(), db).await?;
         insert_models(metadata.clusters.clone(), db).await?;
         insert_models(metadata.version_stats.clone(), db).await?;
@@ -201,6 +202,28 @@ impl Writer<MetadataV2> for WriterModelV2ToMetaStoreV2 {
         }
         Ok(())
     }
+}
+
+async fn ensure_all_meta_store_tables_are_empty(
+    db: &impl sea_orm::ConnectionTrait,
+) -> BackupResult<()> {
+    macro_rules! ensure_entity_empty {
+        ($($entity_mod:ident),* $(,)?) => {
+            $(
+                if risingwave_meta_model::$entity_mod::Entity::find()
+                    .one(db)
+                    .await
+                    .map_err(map_db_err)?
+                    .is_some()
+                {
+                    return Err(BackupError::NonemptyMetaStorage);
+                }
+            )*
+        };
+    }
+
+    risingwave_meta_model::for_all_meta_model_entities!(ensure_entity_empty);
+    Ok(())
 }
 
 fn map_db_err(e: DbErr) -> BackupError {


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

Contributed by codex.

The correct enforcement point is a restore-time preflight over every meta-store table, not just the tables passed to `insert_models`.

- Implemented in `src/meta/src/backup_restore/restore_impl/v2.rs`: `write()` now calls `ensure_all_meta_store_tables_are_empty()` before the first insert. The helper walks all meta-store entities and returns `BackupError::NonemptyMetaStorage` if any table already has rows, including runtime hummock/compaction tables that are intentionally excluded from snapshots.
- Added a single source-of-truth macro `for_all_meta_model_entities!` in `src/meta/model/src/lib.rs` to avoid drift as new meta tables are added.
- Updated the guard test in `src/meta/model/tests/meta_model_entities.rs` to use `syn` for extracting `#[sea_orm(table_name = "...")]` from structs.
- Further updated the guard test to recursively scan all Rust files under `PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("src")`, so it does not assume model files must be colocated with `lib.rs`.
- Added test-only dev dependencies in `src/meta/model/Cargo.toml`: `syn` (for AST parsing) and `thiserror-ext` (for compliant error formatting in test diagnostics).

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwave-labs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

No user-facing behavior change. This refactor strengthens meta-restore safety checks and improves internal test coverage robustness for meta model entity registration.

</details>