### PR TITLE
feat: 6/10 route RBAC role membership through frontend

### DIFF
--- a/src/common/src/catalog/mod.rs
+++ b/src/common/src/catalog/mod.rs
@@ -89,6 +89,13 @@ pub fn is_reserved_admin_user(user_name: &str) -> bool {
     user_name == DEFAULT_SUPER_USER_FOR_ADMIN
 }
 
+pub fn is_default_super_user(user_name: &str) -> bool {
+    matches!(
+        user_name,
+        DEFAULT_SUPER_USER | DEFAULT_SUPER_USER_FOR_PG | DEFAULT_SUPER_USER_FOR_ADMIN
+    )
+}
+
 pub const RW_RESERVED_COLUMN_NAME_PREFIX: &str = "_rw_";
 
 /// When there is no primary key specified while creating source, will use

--- a/src/frontend/src/binder/mod.rs
+++ b/src/frontend/src/binder/mod.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::cell::RefCell;
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
@@ -72,6 +73,7 @@ use crate::catalog::root_catalog::SchemaPath;
 use crate::catalog::schema_catalog::SchemaCatalog;
 use crate::catalog::{CatalogResult, DatabaseId, SecretId, ViewId};
 use crate::error::ErrorCode;
+use crate::handler::privilege::ObjectCheckItem;
 use crate::session::{AuthContext, SessionImpl, StagingCatalogManager, TemporarySourceManager};
 use crate::user::user_service::UserInfoReadGuard;
 
@@ -129,6 +131,9 @@ pub struct Binder {
 
     /// The included relations while binding a query.
     included_relations: HashSet<ObjectId>,
+    /// The privilege checks performed during binding. Prepared statements re-run them at execute
+    /// time so revokes after parse/bind are not bypassed by stale bound plans.
+    included_privilege_checks: RefCell<Vec<ObjectCheckItem>>,
 
     /// The included user-defined functions while binding a query.
     included_udfs: HashSet<FunctionId>,
@@ -262,6 +267,7 @@ impl Binder {
             bind_for,
             shared_views: HashMap::new(),
             included_relations: HashSet::new(),
+            included_privilege_checks: RefCell::new(vec![]),
             included_udfs: HashSet::new(),
             included_secrets: HashSet::new(),
             param_types: ParameterTypes::new(vec![]),
@@ -328,6 +334,10 @@ impl Binder {
     /// optimised away.
     pub fn included_relations(&self) -> &HashSet<ObjectId> {
         &self.included_relations
+    }
+
+    pub fn included_privilege_checks_snapshot(&self) -> Vec<ObjectCheckItem> {
+        self.included_privilege_checks.borrow().clone()
     }
 
     /// Get included user-defined functions in the query after binding.

--- a/src/frontend/src/binder/relation/table_or_source.rs
+++ b/src/frontend/src/binder/relation/table_or_source.rs
@@ -320,6 +320,7 @@ impl Binder {
                 } else {
                     return Err(PermissionDenied("Session user is invalid".to_owned()).into());
                 }
+                self.included_privilege_checks.borrow_mut().push(item);
             }
             BindFor::Ddl | BindFor::System => {
                 // do nothing.

--- a/src/frontend/src/handler/alter_user.rs
+++ b/src/frontend/src/handler/alter_user.rs
@@ -15,7 +15,7 @@
 use std::collections::HashSet;
 
 use pgwire::pg_response::StatementType;
-use risingwave_common::catalog::{DEFAULT_SUPER_USER_FOR_ADMIN, is_reserved_admin_user};
+use risingwave_common::catalog::{is_default_super_user, is_reserved_admin_user};
 use risingwave_pb::user::UserInfo;
 use risingwave_pb::user::update_user_request::UpdateField;
 use risingwave_sqlparser::ast::{AlterUserStatement, ObjectName, UserOption, UserOptions};
@@ -26,6 +26,7 @@ use crate::catalog::CatalogError;
 use crate::error::ErrorCode::{self, InternalError, PermissionDenied};
 use crate::error::Result;
 use crate::handler::HandlerArgs;
+use crate::user::effective_privilege::{can_admin_role, role_memberships_snapshot};
 use crate::user::user_authentication::{
     OAUTH_ISSUER_KEY, OAUTH_JWKS_URL_KEY, build_oauth_info, encrypted_password,
 };
@@ -35,6 +36,7 @@ fn alter_prost_user_info(
     mut user_info: UserInfo,
     options: &UserOptions,
     session_user: &UserCatalog,
+    has_admin_option_on_target: bool,
 ) -> Result<(UserInfo, Vec<UpdateField>, Vec<String>)> {
     let change_self_password_only = session_user.id == user_info.id
         && options.0.len() == 1
@@ -42,6 +44,21 @@ fn alter_prost_user_info(
             &options.0[0],
             UserOption::EncryptedPassword(_) | UserOption::Password(_) | UserOption::OAuth(_)
         );
+    if !change_self_password_only && is_reserved_admin_user(&user_info.name) {
+        return Err(PermissionDenied(format!("{} cannot be altered", user_info.name)).into());
+    }
+    if is_default_super_user(&user_info.name)
+        && options
+            .0
+            .iter()
+            .any(|option| matches!(option, UserOption::NoSuperUser))
+    {
+        return Err(PermissionDenied(format!(
+            "{} cannot be downgraded from superuser",
+            user_info.name
+        ))
+        .into());
+    }
     let require_admin = user_info.is_admin
         || options
             .0
@@ -72,6 +89,14 @@ fn alter_prost_user_info(
         if !session_user.can_create_user && !change_self_password_only {
             return Err(PermissionDenied("permission denied to alter user".to_owned()).into());
         }
+
+        if !change_self_password_only && !has_admin_option_on_target {
+            return Err(PermissionDenied(format!(
+                "user {} does not have ADMIN OPTION for role {}",
+                session_user.name, user_info.name
+            ))
+            .into());
+        }
     }
 
     let mut update_fields = HashSet::new();
@@ -95,13 +120,21 @@ fn alter_prost_user_info(
                 user_info.can_create_db = false;
                 update_fields.insert(UpdateField::CreateDb);
             }
-            UserOption::CreateUser => {
+            UserOption::CreateRole | UserOption::CreateUser => {
                 user_info.can_create_user = true;
                 update_fields.insert(UpdateField::CreateUser);
             }
-            UserOption::NoCreateUser => {
+            UserOption::NoCreateRole | UserOption::NoCreateUser => {
                 user_info.can_create_user = false;
                 update_fields.insert(UpdateField::CreateUser);
+            }
+            UserOption::Inherit => {
+                user_info.can_inherit = Some(true);
+                update_fields.insert(UpdateField::Inherit);
+            }
+            UserOption::NoInherit => {
+                user_info.can_inherit = Some(false);
+                update_fields.insert(UpdateField::Inherit);
             }
             UserOption::Login => {
                 user_info.can_login = true;
@@ -118,15 +151,6 @@ fn alter_prost_user_info(
             UserOption::NoAdmin => {
                 user_info.is_admin = false;
                 update_fields.insert(UpdateField::Admin);
-            }
-            UserOption::CreateRole
-            | UserOption::NoCreateRole
-            | UserOption::Inherit
-            | UserOption::NoInherit => {
-                return Err(ErrorCode::InvalidParameterValue(
-                    "role options are not supported yet".to_owned(),
-                )
-                .into());
             }
             UserOption::EncryptedPassword(p) => {
                 if !p.0.is_empty() {
@@ -192,19 +216,11 @@ fn alter_rename_prost_user_info(
     }
 
     let new_name = Binder::resolve_user_name(new_name)?;
-    if is_reserved_admin_user(&new_name) {
-        return Err(PermissionDenied(format!(
-            "{} is reserved for admin",
-            DEFAULT_SUPER_USER_FOR_ADMIN
-        ))
-        .into());
+    if is_default_super_user(&new_name) {
+        return Err(PermissionDenied(format!("{} is a reserved default user", new_name)).into());
     }
-    if is_reserved_admin_user(&user_info.name) {
-        return Err(PermissionDenied(format!(
-            "{} cannot be renamed",
-            DEFAULT_SUPER_USER_FOR_ADMIN
-        ))
-        .into());
+    if is_default_super_user(&user_info.name) {
+        return Err(PermissionDenied(format!("{} cannot be renamed", user_info.name)).into());
     }
 
     user_info.name = new_name;
@@ -232,7 +248,11 @@ pub async fn handle_alter_user(
 
         match stmt.mode {
             risingwave_sqlparser::ast::AlterUserMode::Options(options) => {
-                alter_prost_user_info(old_info, &options, session_user)?
+                let role_memberships =
+                    role_memberships_snapshot(session.env().role_membership_info_reader());
+                let has_admin_option_on_target =
+                    can_admin_role(session_user.id, old_info.id, &role_memberships);
+                alter_prost_user_info(old_info, &options, session_user, has_admin_option_on_target)?
             }
             risingwave_sqlparser::ast::AlterUserMode::Rename(new_name) => {
                 let (user_info, fields) =
@@ -251,6 +271,13 @@ pub async fn handle_alter_user(
         response_builder = response_builder.notice(notice);
     }
     Ok(response_builder.into())
+}
+
+pub async fn handle_alter_role(
+    handler_args: HandlerArgs,
+    stmt: AlterUserStatement,
+) -> Result<RwPgResponse> {
+    handle_alter_user(handler_args, stmt).await
 }
 
 #[cfg(test)]
@@ -309,21 +336,41 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_alter_user_rejects_role_options() {
+    async fn test_alter_user_accepts_role_options() {
         let frontend = LocalFrontend::new(Default::default()).await;
+        let session = frontend.session_ref();
+        let user_info_reader = session.env().user_info_reader();
+
         frontend
             .run_sql("CREATE USER role_option_user")
             .await
             .unwrap();
 
-        for option in ["CREATEROLE", "NOCREATEROLE", "INHERIT", "NOINHERIT"] {
-            let err = frontend
-                .run_sql(&format!("ALTER USER role_option_user WITH {option}"))
-                .await
-                .unwrap_err()
-                .to_string();
-            assert!(err.contains("role options are not supported yet"), "{err}");
-        }
+        frontend
+            .run_sql("ALTER USER role_option_user WITH CREATEROLE NOINHERIT")
+            .await
+            .unwrap();
+
+        let user = user_info_reader
+            .read_guard()
+            .get_user_by_name("role_option_user")
+            .cloned()
+            .unwrap();
+        assert!(user.can_create_user);
+        assert!(!user.can_inherit);
+
+        frontend
+            .run_sql("ALTER USER role_option_user WITH NOCREATEROLE INHERIT")
+            .await
+            .unwrap();
+
+        let user = user_info_reader
+            .read_guard()
+            .get_user_by_name("role_option_user")
+            .cloned()
+            .unwrap();
+        assert!(!user.can_create_user);
+        assert!(user.can_inherit);
     }
 
     #[tokio::test]

--- a/src/frontend/src/handler/create_user.rs
+++ b/src/frontend/src/handler/create_user.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use pgwire::pg_response::StatementType;
+use risingwave_common::catalog::DEFAULT_SUPER_USER_ID;
 use risingwave_pb::user::grant_privilege::ActionWithGrantOption;
 use risingwave_pb::user::{Action, GrantPrivilege, UserInfo};
 use risingwave_sqlparser::ast::{CreateUserStatement, UserOption};
@@ -49,6 +50,7 @@ pub async fn handle_create_user(
         ..Default::default()
     };
     let mut notices = vec![];
+    let mut auto_admin_grant_member = None;
     {
         let user_reader = session.env().user_info_reader().read_guard();
         if user_reader.get_user_by_name(&user_name).is_some() {
@@ -74,6 +76,7 @@ pub async fn handle_create_user(
             if !session_user.can_create_user {
                 return Err(PermissionDenied("permission denied to create user".to_owned()).into());
             }
+            auto_admin_grant_member = Some(session_user.id);
         }
 
         // Admin users can only be created by other admin users
@@ -105,21 +108,16 @@ pub async fn handle_create_user(
                 UserOption::NoSuperUser => user_info.is_super = false,
                 UserOption::CreateDB => user_info.can_create_db = true,
                 UserOption::NoCreateDB => user_info.can_create_db = false,
-                UserOption::CreateUser => user_info.can_create_user = true,
-                UserOption::NoCreateUser => user_info.can_create_user = false,
+                UserOption::CreateRole | UserOption::CreateUser => user_info.can_create_user = true,
+                UserOption::NoCreateRole | UserOption::NoCreateUser => {
+                    user_info.can_create_user = false
+                }
+                UserOption::Inherit => user_info.can_inherit = Some(true),
+                UserOption::NoInherit => user_info.can_inherit = Some(false),
                 UserOption::Login => user_info.can_login = true,
                 UserOption::NoLogin => user_info.can_login = false,
                 UserOption::Admin => user_info.is_admin = true,
                 UserOption::NoAdmin => user_info.is_admin = false,
-                UserOption::CreateRole
-                | UserOption::NoCreateRole
-                | UserOption::Inherit
-                | UserOption::NoInherit => {
-                    return Err(ErrorCode::InvalidParameterValue(
-                        "role options are not supported yet".to_owned(),
-                    )
-                    .into());
-                }
                 UserOption::EncryptedPassword(password) => {
                     if !password.0.is_empty() {
                         user_info.auth_info = encrypted_password(&user_info.name, &password.0);
@@ -161,11 +159,49 @@ pub async fn handle_create_user(
 
     let user_info_writer = session.user_info_writer()?;
     user_info_writer.create_user(user_info).await?;
+    if let Some(member_id) = auto_admin_grant_member {
+        // Match PostgreSQL's CREATEROLE behavior: a non-superuser creator receives an
+        // automatic bootstrap-superuser grant with ADMIN TRUE, INHERIT FALSE and SET FALSE.
+        let created_user_id = session
+            .env()
+            .user_info_reader()
+            .read_guard()
+            .get_user_by_name(&user_name)
+            .ok_or_else(|| CatalogError::not_found("user", user_name.clone()))?
+            .id;
+        user_info_writer
+            .grant_role(
+                vec![created_user_id],
+                vec![member_id],
+                DEFAULT_SUPER_USER_ID,
+                DEFAULT_SUPER_USER_ID,
+                false,
+                Some(true),
+                Some(false),
+                Some(false),
+            )
+            .await?;
+    }
     let mut response_builder = RwPgResponse::builder(StatementType::CREATE_USER);
     for notice in notices {
         response_builder = response_builder.notice(notice);
     }
     Ok(response_builder.into())
+}
+
+pub async fn handle_create_role(
+    handler_args: HandlerArgs,
+    mut stmt: CreateUserStatement,
+) -> Result<RwPgResponse> {
+    let has_explicit_login = stmt
+        .with_options
+        .0
+        .iter()
+        .any(|option| matches!(option, UserOption::Login | UserOption::NoLogin));
+    if !has_explicit_login {
+        stmt.with_options.0.push(UserOption::NoLogin);
+    }
+    handle_create_user(handler_args, stmt).await
 }
 
 #[cfg(test)]
@@ -246,20 +282,36 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_create_user_rejects_role_options() {
+    async fn test_create_user_accepts_role_options() {
         let frontend = LocalFrontend::new(Default::default()).await;
+        let session = frontend.session_ref();
+        let user_info_reader = session.env().user_info_reader();
 
-        for (idx, option) in ["CREATEROLE", "NOCREATEROLE", "INHERIT", "NOINHERIT"]
-            .into_iter()
-            .enumerate()
-        {
-            let err = frontend
-                .run_sql(&format!("CREATE USER role_option_user_{idx} WITH {option}"))
-                .await
-                .unwrap_err()
-                .to_string();
-            assert!(err.contains("role options are not supported yet"), "{err}");
-        }
+        frontend
+            .run_sql("CREATE USER role_option_user WITH CREATEROLE NOINHERIT")
+            .await
+            .unwrap();
+
+        let user = user_info_reader
+            .read_guard()
+            .get_user_by_name("role_option_user")
+            .cloned()
+            .unwrap();
+        assert!(user.can_create_user);
+        assert!(!user.can_inherit);
+
+        frontend
+            .run_sql("CREATE USER role_option_user_default WITH NOCREATEROLE INHERIT")
+            .await
+            .unwrap();
+
+        let user = user_info_reader
+            .read_guard()
+            .get_user_by_name("role_option_user_default")
+            .cloned()
+            .unwrap();
+        assert!(!user.can_create_user);
+        assert!(user.can_inherit);
     }
 
     #[tokio::test]

--- a/src/frontend/src/handler/drop_user.rs
+++ b/src/frontend/src/handler/drop_user.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use pgwire::pg_response::{PgResponse, StatementType};
+use risingwave_common::catalog::is_default_super_user;
 use risingwave_sqlparser::ast::ObjectName;
 
 use super::RwPgResponse;
@@ -20,6 +21,7 @@ use crate::binder::Binder;
 use crate::catalog::CatalogError;
 use crate::error::{ErrorCode, Result};
 use crate::handler::HandlerArgs;
+use crate::user::effective_privilege::{can_admin_role, role_memberships_snapshot};
 
 pub async fn handle_drop_user(
     handler_args: HandlerArgs,
@@ -42,6 +44,13 @@ pub async fn handle_drop_user(
                 )
                 .into());
             }
+            if is_default_super_user(&user_name) {
+                return Err(ErrorCode::PermissionDenied(format!(
+                    "drop default super user {} is not allowed",
+                    user_name
+                ))
+                .into());
+            }
             if let Some(current_user) = user_info_reader
                 .read_guard()
                 .get_user_by_name(&session.user_name())
@@ -57,6 +66,15 @@ pub async fn handle_drop_user(
                         return Err(ErrorCode::PermissionDenied(
                             "permission denied to drop user".to_owned(),
                         )
+                        .into());
+                    }
+                    let role_memberships =
+                        role_memberships_snapshot(session.env().role_membership_info_reader());
+                    if !can_admin_role(session.user_id(), user_id, &role_memberships) {
+                        return Err(ErrorCode::PermissionDenied(format!(
+                            "user {} does not have ADMIN OPTION for role {}",
+                            current_user.name, user_name
+                        ))
                         .into());
                     }
                 }

--- a/src/frontend/src/handler/extended_handle.rs
+++ b/src/frontend/src/handler/extended_handle.rs
@@ -173,6 +173,7 @@ pub fn handle_bind(
                 bound,
                 param_types,
                 dependent_relations,
+                dependent_privilege_checks,
                 dependent_udfs,
                 dependent_secrets,
                 ..
@@ -185,6 +186,7 @@ pub fn handle_bind(
                 param_types,
                 parsed_params: Some(parsed_params),
                 dependent_relations,
+                dependent_privilege_checks,
                 dependent_udfs,
                 dependent_secrets,
                 bound: new_bound,

--- a/src/frontend/src/handler/fetch_cursor.rs
+++ b/src/frontend/src/handler/fetch_cursor.rs
@@ -120,6 +120,7 @@ pub async fn handle_parse(
             param_types: binder.export_param_types()?,
             parsed_params: None,
             dependent_relations: binder.included_relations().clone(),
+            dependent_privilege_checks: binder.included_privilege_checks_snapshot(),
             dependent_udfs: binder.included_udfs().clone(),
             dependent_secrets: binder.included_secrets().clone(),
         };

--- a/src/frontend/src/handler/handle_privilege.rs
+++ b/src/frontend/src/handler/handle_privilege.rs
@@ -26,7 +26,8 @@ use risingwave_pb::user::alter_default_privilege_request::{
 use risingwave_pb::user::grant_privilege::ActionWithGrantOption;
 use risingwave_pb::user::{PbAction, PbGrantPrivilege};
 use risingwave_sqlparser::ast::{
-    DefaultPrivilegeOperation, GrantObjects, Ident, PrivilegeObjectType, Privileges, Statement,
+    DefaultPrivilegeOperation, GrantObjects, Ident, PrivilegeObjectType, Privileges,
+    RoleOptionKind, RoleOptionSpec, Statement,
 };
 
 use super::RwPgResponse;
@@ -39,6 +40,7 @@ use crate::error::{ErrorCode, Result};
 use crate::handler::HandlerArgs;
 use crate::session::SessionImpl;
 use crate::user::UserId;
+use crate::user::effective_privilege::{can_set_role, role_memberships_snapshot};
 use crate::user::user_privilege::{
     available_privilege_actions, check_privilege_type, get_prost_action,
 };
@@ -47,6 +49,7 @@ fn make_prost_privilege(
     session: &SessionImpl,
     privileges: Privileges,
     objects: GrantObjects,
+    granted_by: UserId,
 ) -> Result<Vec<PbGrantPrivilege>> {
     check_privilege_type(&privileges, &objects)?;
 
@@ -358,7 +361,7 @@ fn make_prost_privilege(
         .into_iter()
         .map(|action| ActionWithGrantOption {
             action: action as i32,
-            granted_by: session.user_id(),
+            granted_by: granted_by as _,
             ..Default::default()
         })
         .collect::<Vec<_>>();
@@ -458,23 +461,11 @@ pub async fn handle_grant_privilege(
         return Err(ErrorCode::BindError("Invalid grant statement".to_owned()).into());
     };
     let users = bind_user_from_idents(&session, grantees)?;
-    if let Some(granted_by) = &granted_by {
-        let user_reader = session.env().user_info_reader();
-        let reader = user_reader.read_guard();
-
-        // We remark that the user name is always case-sensitive.
-        if reader.get_user_by_name(&granted_by.real_value()).is_none() {
-            return Err(ErrorCode::InvalidInputSyntax(format!(
-                "Grantor \"{granted_by}\" does not exist"
-            ))
-            .into());
-        }
-    }
-
-    let privileges = make_prost_privilege(&session, privileges, objects)?;
+    let granted_by = bind_object_granted_by(&session, granted_by)?;
+    let privileges = make_prost_privilege(&session, privileges, objects, granted_by)?;
     let user_info_writer = session.user_info_writer()?;
     user_info_writer
-        .grant_privilege(users, privileges, with_grant_option, session.user_id())
+        .grant_privilege(users, privileges, with_grant_option, granted_by)
         .await?;
     Ok(PgResponse::empty_result(StatementType::GRANT_PRIVILEGE))
 }
@@ -496,27 +487,14 @@ pub async fn handle_revoke_privilege(
         return Err(ErrorCode::BindError("Invalid revoke statement".to_owned()).into());
     };
     let users = bind_user_from_idents(&session, grantees)?;
-    let mut granted_by_id = None;
-    if let Some(granted_by) = &granted_by {
-        let user_reader = session.env().user_info_reader();
-        let reader = user_reader.read_guard();
-
-        if let Some(user) = reader.get_user_by_name(&granted_by.real_value()) {
-            granted_by_id = Some(user.id);
-        } else {
-            return Err(ErrorCode::InvalidInputSyntax(format!(
-                "Grantor \"{granted_by}\" does not exist"
-            ))
-            .into());
-        }
-    }
-    let privileges = make_prost_privilege(&session, privileges, objects)?;
+    let granted_by_id = bind_object_granted_by(&session, granted_by)?;
+    let privileges = make_prost_privilege(&session, privileges, objects, granted_by_id)?;
     let user_info_writer = session.user_info_writer()?;
     user_info_writer
         .revoke_privilege(
             users,
             privileges,
-            granted_by_id.unwrap_or(session.user_id()),
+            granted_by_id,
             session.user_id(),
             revoke_grant_option,
             cascade,
@@ -524,6 +502,165 @@ pub async fn handle_revoke_privilege(
         .await?;
 
     Ok(PgResponse::empty_result(StatementType::REVOKE_PRIVILEGE))
+}
+
+pub async fn handle_grant_role(handler_args: HandlerArgs, stmt: Statement) -> Result<RwPgResponse> {
+    let session = handler_args.session;
+    let Statement::GrantRole {
+        roles,
+        grantees,
+        role_options,
+        granted_by,
+    } = stmt
+    else {
+        return Err(ErrorCode::BindError("Invalid grant role statement".to_owned()).into());
+    };
+
+    let role_ids = bind_user_from_idents(&session, roles)?;
+    let member_ids = bind_user_from_idents(&session, grantees)?;
+    let granted_by = bind_role_granted_by(&session, granted_by)?;
+    let mut admin_option = None;
+    let mut inherit_option = None;
+    let mut set_option = None;
+    for RoleOptionSpec { kind, value } in role_options {
+        match kind {
+            RoleOptionKind::Admin => admin_option = Some(value),
+            RoleOptionKind::Inherit => inherit_option = Some(value),
+            RoleOptionKind::Set => set_option = Some(value),
+        }
+    }
+    let user_info_writer = session.user_info_writer()?;
+    user_info_writer
+        .grant_role(
+            role_ids,
+            member_ids,
+            granted_by.id,
+            session.user_id(),
+            granted_by.specified,
+            admin_option,
+            inherit_option,
+            set_option,
+        )
+        .await?;
+
+    Ok(PgResponse::empty_result(StatementType::GRANT_PRIVILEGE))
+}
+
+pub async fn handle_revoke_role(
+    handler_args: HandlerArgs,
+    stmt: Statement,
+) -> Result<RwPgResponse> {
+    let session = handler_args.session;
+    let Statement::RevokeRole {
+        roles,
+        grantees,
+        revoke_role_option,
+        granted_by,
+        cascade,
+    } = stmt
+    else {
+        return Err(ErrorCode::BindError("Invalid revoke role statement".to_owned()).into());
+    };
+
+    let revoke_admin_option = matches!(revoke_role_option, Some(RoleOptionKind::Admin));
+    let revoke_inherit_option = matches!(revoke_role_option, Some(RoleOptionKind::Inherit));
+    let revoke_set_option = matches!(revoke_role_option, Some(RoleOptionKind::Set));
+    let role_ids = bind_user_from_idents(&session, roles)?;
+    let member_ids = bind_user_from_idents(&session, grantees)?;
+    let granted_by = bind_role_granted_by(&session, granted_by)?;
+    let user_info_writer = session.user_info_writer()?;
+    user_info_writer
+        .revoke_role(
+            role_ids,
+            member_ids,
+            granted_by.id,
+            granted_by.specified,
+            session.user_id(),
+            revoke_admin_option,
+            revoke_inherit_option,
+            revoke_set_option,
+            cascade,
+        )
+        .await?;
+
+    Ok(PgResponse::empty_result(StatementType::REVOKE_PRIVILEGE))
+}
+
+struct ResolvedGrantor {
+    id: UserId,
+    specified: bool,
+}
+
+fn resolve_granted_by(session: &SessionImpl, granted_by: Option<Ident>) -> Result<ResolvedGrantor> {
+    let Some(granted_by) = granted_by else {
+        return Ok(ResolvedGrantor {
+            id: session.user_id(),
+            specified: false,
+        });
+    };
+    let granted_by_name = granted_by.real_value();
+    let resolved_grantor = if granted_by_name.eq_ignore_ascii_case("current_user")
+        || granted_by_name.eq_ignore_ascii_case("current_role")
+    {
+        session.user_name()
+    } else if granted_by_name.eq_ignore_ascii_case("session_user") {
+        session.session_user_name()
+    } else {
+        granted_by_name
+    };
+
+    let user_reader = session.env().user_info_reader();
+    let reader = user_reader.read_guard();
+    let user = reader.get_user_by_name(&resolved_grantor).ok_or_else(|| {
+        ErrorCode::InvalidInputSyntax(format!("User \"{}\" does not exist", resolved_grantor))
+    })?;
+    Ok(ResolvedGrantor {
+        id: user.id,
+        specified: true,
+    })
+}
+
+fn bind_object_granted_by(session: &SessionImpl, granted_by: Option<Ident>) -> Result<UserId> {
+    let requested_grantor = granted_by.as_ref().map(|ident| ident.real_value());
+    let granted_by = resolve_granted_by(session, granted_by)?;
+    if granted_by.id != session.user_id() {
+        let requested_grantor = requested_grantor.unwrap_or_else(|| granted_by.id.to_string());
+        return Err(ErrorCode::InvalidInputSyntax(format!(
+            "GRANTED BY {requested_grantor} must specify the current user \"{}\"",
+            session.user_name()
+        ))
+        .into());
+    }
+    Ok(granted_by.id)
+}
+
+fn bind_role_granted_by(
+    session: &SessionImpl,
+    granted_by: Option<Ident>,
+) -> Result<ResolvedGrantor> {
+    let granted_by = resolve_granted_by(session, granted_by)?;
+    if granted_by.id == session.user_id() {
+        return Ok(granted_by);
+    }
+    let user_reader = session.env().user_info_reader();
+    let reader = user_reader.read_guard();
+    if reader
+        .get_user_by_id(&session.user_id())
+        .map(|user| user.is_super)
+        .unwrap_or(false)
+    {
+        return Ok(granted_by);
+    }
+    drop(reader);
+    let memberships = role_memberships_snapshot(session.env().role_membership_info_reader());
+    if can_set_role(session.session_user_id(), granted_by.id, &memberships) {
+        return Ok(granted_by);
+    }
+    Err(ErrorCode::InvalidInputSyntax(format!(
+        "current user \"{}\" does not possess grantor role",
+        session.user_name()
+    ))
+    .into())
 }
 
 pub async fn handle_alter_default_privileges(
@@ -675,8 +812,18 @@ mod tests {
             .await
             .unwrap();
         frontend.run_sql("CREATE DATABASE db1").await.unwrap();
-        frontend
+        let grantor_err = frontend
             .run_sql("GRANT ALL ON DATABASE db1 TO user1 WITH GRANT OPTION GRANTED BY user")
+            .await
+            .unwrap_err()
+            .to_string();
+        assert!(
+            grantor_err.contains("GRANTED BY user must specify the current user \"root\""),
+            "{grantor_err}"
+        );
+
+        frontend
+            .run_sql("GRANT ALL ON DATABASE db1 TO user1 WITH GRANT OPTION GRANTED BY root")
             .await
             .unwrap();
 
@@ -727,7 +874,7 @@ mod tests {
         }
 
         frontend
-            .run_sql("REVOKE GRANT OPTION FOR ALL ON DATABASE db1 from user1 GRANTED BY user")
+            .run_sql("REVOKE GRANT OPTION FOR ALL ON DATABASE db1 from user1 GRANTED BY root")
             .await
             .unwrap();
         {
@@ -744,7 +891,7 @@ mod tests {
         }
 
         frontend
-            .run_sql("REVOKE ALL ON DATABASE db1 from user1 GRANTED BY user")
+            .run_sql("REVOKE ALL ON DATABASE db1 from user1 GRANTED BY root")
             .await
             .unwrap();
         {

--- a/src/frontend/src/handler/mod.rs
+++ b/src/frontend/src/handler/mod.rs
@@ -483,6 +483,7 @@ pub async fn handle(
                 .await
         }
         Statement::CreateUser(stmt) => create_user::handle_create_user(handler_args, stmt).await,
+        Statement::CreateRole(stmt) => create_user::handle_create_role(handler_args, stmt).await,
         Statement::DeclareCursor { stmt } => {
             declare_cursor::handle_declare_cursor(handler_args, stmt).await
         }
@@ -493,11 +494,18 @@ pub async fn handle(
             close_cursor::handle_close_cursor(handler_args, stmt).await
         }
         Statement::AlterUser(stmt) => alter_user::handle_alter_user(handler_args, stmt).await,
+        Statement::AlterRole(stmt) => alter_user::handle_alter_role(handler_args, stmt).await,
         Statement::Grant { .. } => {
             handle_privilege::handle_grant_privilege(handler_args, stmt).await
         }
+        Statement::GrantRole { .. } => {
+            handle_privilege::handle_grant_role(handler_args, stmt).await
+        }
         Statement::Revoke { .. } => {
             handle_privilege::handle_revoke_privilege(handler_args, stmt).await
+        }
+        Statement::RevokeRole { .. } => {
+            handle_privilege::handle_revoke_role(handler_args, stmt).await
         }
         Statement::Describe { name, kind } => match kind {
             DescribeKind::Fragments => {
@@ -537,7 +545,7 @@ pub async fn handle(
                     | ObjectType::Schema
                     | ObjectType::Connection
                     | ObjectType::Secret => true,
-                    ObjectType::Database | ObjectType::User | ObjectType::Role => {
+                    ObjectType::Database | ObjectType::Role | ObjectType::User => {
                         bail_not_implemented!("DROP CASCADE");
                     }
                 }
@@ -579,11 +587,8 @@ pub async fn handle(
                     drop_schema::handle_drop_schema(handler_args, object_name, if_exists, cascade)
                         .await
                 }
-                ObjectType::User => {
+                ObjectType::Role | ObjectType::User => {
                     drop_user::handle_drop_user(handler_args, object_name, if_exists).await
-                }
-                ObjectType::Role => {
-                    bail_not_implemented!("DROP ROLE")
                 }
                 ObjectType::View => {
                     drop_view::handle_drop_view(handler_args, object_name, if_exists, cascade).await
@@ -693,6 +698,11 @@ pub async fn handle(
         Statement::SetTimeZone { local: _, value } => {
             variable::handle_set_time_zone(handler_args, value)
         }
+        Statement::SetRole {
+            context_modifier,
+            role_name,
+        } => variable::handle_set_role(handler_args, context_modifier, role_name),
+        Statement::ResetRole => variable::handle_reset_role(handler_args),
         Statement::ShowVariable { variable } => variable::handle_show(handler_args, variable),
         Statement::CreateIndex {
             name,

--- a/src/frontend/src/handler/privilege.rs
+++ b/src/frontend/src/handler/privilege.rs
@@ -21,8 +21,9 @@ use crate::error::ErrorCode::PermissionDenied;
 use crate::error::Result;
 use crate::session::SessionImpl;
 use crate::user::UserId;
+use crate::user::effective_privilege::{role_memberships_snapshot, session_has_privilege};
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct ObjectCheckItem {
     pub(crate) owner: UserId,
     pub(crate) mode: AclMode,
@@ -69,21 +70,25 @@ impl SessionImpl {
         let user_reader = self.env().user_info_reader();
         let reader = user_reader.read_guard();
 
-        if let Some(user) = reader.get_user_by_name(&self.user_name()) {
-            if user.is_super {
-                return Ok(());
-            }
-            for item in items {
-                if item.owner == user.id {
-                    continue;
-                }
-                let has_privilege = user.has_privilege(item.object, item.mode);
-                if !has_privilege {
-                    return Err(PermissionDenied(item.error_message()).into());
-                }
-            }
-        } else {
+        if reader.get_user_by_name(&self.user_name()).is_none() {
             return Err(PermissionDenied("Session user is invalid".to_owned()).into());
+        }
+        drop(reader);
+
+        let auth_context = self.auth_context();
+        let memberships = role_memberships_snapshot(self.env().role_membership_info_reader());
+        for item in items {
+            let has_privilege = session_has_privilege(
+                user_reader,
+                &auth_context,
+                &memberships,
+                item.owner,
+                item.object,
+                item.mode,
+            );
+            if !has_privilege {
+                return Err(PermissionDenied(item.error_message()).into());
+            }
         }
 
         Ok(())
@@ -212,5 +217,204 @@ mod tests {
             .await
             .unwrap();
         assert!(&session.check_privileges(&check_items).is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_check_privileges_respects_active_role() {
+        let frontend = LocalFrontend::new(Default::default()).await;
+        let session = frontend.session_ref();
+        let catalog_reader = session.env().catalog_reader();
+        frontend.run_sql("CREATE SCHEMA role_schema").await.unwrap();
+
+        let schema = catalog_reader
+            .read_guard()
+            .get_schema_by_name(DEFAULT_DATABASE_NAME, "role_schema")
+            .unwrap()
+            .clone();
+        let check_items = vec![ObjectCheckItem::new(
+            DEFAULT_SUPER_USER_ID,
+            AclMode::Create,
+            "role_schema".to_owned(),
+            schema.id(),
+        )];
+
+        frontend.run_sql("CREATE ROLE role_a").await.unwrap();
+        frontend.run_sql("CREATE ROLE role_b").await.unwrap();
+        frontend
+            .run_sql(
+                "CREATE USER role_member WITH NOSUPERUSER PASSWORD 'md5827ccb0eea8a706c4c34a16891f84e7b'",
+            )
+            .await
+            .unwrap();
+        frontend
+            .run_sql("GRANT CREATE ON SCHEMA role_schema TO role_a")
+            .await
+            .unwrap();
+        frontend
+            .run_sql("GRANT role_a TO role_member")
+            .await
+            .unwrap();
+        frontend
+            .run_sql("GRANT role_b TO role_member")
+            .await
+            .unwrap();
+
+        let user_id = {
+            let user_reader = session.env().user_info_reader();
+            user_reader
+                .read_guard()
+                .get_user_by_name("role_member")
+                .unwrap()
+                .id
+        };
+        let member_session = frontend.session_user_ref(
+            DEFAULT_DATABASE_NAME.to_owned(),
+            "role_member".to_owned(),
+            user_id,
+        );
+
+        assert!(member_session.check_privileges(&check_items).is_ok());
+
+        frontend
+            .run_sql_with_session(member_session.clone(), "SET ROLE role_b")
+            .await
+            .unwrap();
+        assert!(member_session.check_privileges(&check_items).is_err());
+
+        frontend
+            .run_sql_with_session(member_session.clone(), "RESET ROLE")
+            .await
+            .unwrap();
+        assert!(member_session.check_privileges(&check_items).is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_check_privileges_does_not_inherit_superuser_attribute() {
+        let frontend = LocalFrontend::new(Default::default()).await;
+        let session = frontend.session_ref();
+        let catalog_reader = session.env().catalog_reader();
+        frontend
+            .run_sql("CREATE SCHEMA inherited_super_schema")
+            .await
+            .unwrap();
+
+        let schema = catalog_reader
+            .read_guard()
+            .get_schema_by_name(DEFAULT_DATABASE_NAME, "inherited_super_schema")
+            .unwrap()
+            .clone();
+        let check_items = vec![ObjectCheckItem::new(
+            DEFAULT_SUPER_USER_ID,
+            AclMode::Create,
+            "inherited_super_schema".to_owned(),
+            schema.id(),
+        )];
+
+        frontend
+            .run_sql("CREATE USER inherited_super WITH SUPERUSER PASSWORD ''")
+            .await
+            .unwrap();
+        frontend
+            .run_sql(
+                "CREATE USER inherited_super_member WITH NOSUPERUSER PASSWORD 'md5827ccb0eea8a706c4c34a16891f84e7b'",
+            )
+            .await
+            .unwrap();
+        frontend
+            .run_sql("GRANT inherited_super TO inherited_super_member")
+            .await
+            .unwrap();
+
+        let user_id = {
+            let user_reader = session.env().user_info_reader();
+            user_reader
+                .read_guard()
+                .get_user_by_name("inherited_super_member")
+                .unwrap()
+                .id
+        };
+        let member_session = frontend.session_user_ref(
+            DEFAULT_DATABASE_NAME.to_owned(),
+            "inherited_super_member".to_owned(),
+            user_id,
+        );
+
+        assert!(member_session.check_privileges(&check_items).is_err());
+
+        frontend
+            .run_sql_with_session(member_session.clone(), "SET ROLE inherited_super")
+            .await
+            .unwrap();
+        assert!(member_session.check_privileges(&check_items).is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_check_privileges_respects_noinherit_role() {
+        let frontend = LocalFrontend::new(Default::default()).await;
+        let session = frontend.session_ref();
+        let catalog_reader = session.env().catalog_reader();
+        frontend
+            .run_sql("CREATE SCHEMA noinherit_schema")
+            .await
+            .unwrap();
+
+        let schema = catalog_reader
+            .read_guard()
+            .get_schema_by_name(DEFAULT_DATABASE_NAME, "noinherit_schema")
+            .unwrap()
+            .clone();
+        let check_items = vec![ObjectCheckItem::new(
+            DEFAULT_SUPER_USER_ID,
+            AclMode::Create,
+            "noinherit_schema".to_owned(),
+            schema.id(),
+        )];
+
+        frontend
+            .run_sql("CREATE ROLE noinherit_role WITH NOINHERIT")
+            .await
+            .unwrap();
+        frontend
+            .run_sql(
+                "CREATE USER noinherit_member WITH NOSUPERUSER NOINHERIT PASSWORD 'md5827ccb0eea8a706c4c34a16891f84e7b'",
+            )
+            .await
+            .unwrap();
+        frontend
+            .run_sql("GRANT CREATE ON SCHEMA noinherit_schema TO noinherit_role")
+            .await
+            .unwrap();
+        frontend
+            .run_sql("GRANT noinherit_role TO noinherit_member")
+            .await
+            .unwrap();
+
+        let user_id = {
+            let user_reader = session.env().user_info_reader();
+            user_reader
+                .read_guard()
+                .get_user_by_name("noinherit_member")
+                .unwrap()
+                .id
+        };
+        let member_session = frontend.session_user_ref(
+            DEFAULT_DATABASE_NAME.to_owned(),
+            "noinherit_member".to_owned(),
+            user_id,
+        );
+
+        assert!(member_session.check_privileges(&check_items).is_err());
+
+        frontend
+            .run_sql_with_session(member_session.clone(), "SET ROLE noinherit_role")
+            .await
+            .unwrap();
+        assert!(member_session.check_privileges(&check_items).is_ok());
+
+        frontend
+            .run_sql_with_session(member_session.clone(), "RESET ROLE")
+            .await
+            .unwrap();
+        assert!(member_session.check_privileges(&check_items).is_err());
     }
 }

--- a/src/frontend/src/handler/query.rs
+++ b/src/frontend/src/handler/query.rs
@@ -36,6 +36,7 @@ use crate::datafusion::DfBatchQueryPlanResult;
 use crate::error::{ErrorCode, Result, RwError};
 use crate::handler::HandlerArgs;
 use crate::handler::flush::do_flush;
+use crate::handler::privilege::ObjectCheckItem;
 use crate::handler::util::{DataChunkToRowSetAdapter, to_pg_field};
 use crate::optimizer::plan_node::{BatchPlanRef, Explain};
 use crate::optimizer::{
@@ -157,6 +158,7 @@ pub async fn handle_execute(
         result_formats,
         statement,
     } = portal;
+    bound_result.recheck_privileges(&handler_args.session)?;
     match statement {
         Statement::Query(_)
         | Statement::Insert { .. }
@@ -204,7 +206,7 @@ pub async fn handle_execute(
                 bail_not_implemented!("CREATE OR REPLACE VIEW");
             }
 
-            // Hack: replace the `with_options` with the bounded ones.
+            // Use the options captured during binding so execution sees normalized options.
             let handler_args = HandlerArgs {
                 session: handler_args.session.clone(),
                 sql: handler_args.sql.clone(),
@@ -273,6 +275,7 @@ pub struct BoundResult {
     pub(crate) param_types: Vec<DataType>,
     pub(crate) parsed_params: Option<Vec<Datum>>,
     pub(crate) dependent_relations: HashSet<ObjectId>,
+    pub(crate) dependent_privilege_checks: Vec<ObjectCheckItem>,
     /// TODO(rc): merge with `dependent_relations`
     pub(crate) dependent_udfs: HashSet<FunctionId>,
     pub(crate) dependent_secrets: HashSet<SecretId>,
@@ -292,9 +295,16 @@ fn gen_bound(mut binder: Binder, stmt: Statement) -> Result<BoundResult> {
         param_types: binder.export_param_types()?,
         parsed_params: None,
         dependent_relations: binder.included_relations().clone(),
+        dependent_privilege_checks: binder.included_privilege_checks_snapshot(),
         dependent_udfs: binder.included_udfs().clone(),
         dependent_secrets: binder.included_secrets().clone(),
     })
+}
+
+impl BoundResult {
+    pub(crate) fn recheck_privileges(&self, session: &SessionImpl) -> Result<()> {
+        session.check_privileges(&self.dependent_privilege_checks)
+    }
 }
 
 pub struct RwBatchQueryPlanResult {

--- a/src/frontend/src/handler/variable.rs
+++ b/src/frontend/src/handler/variable.rs
@@ -20,11 +20,14 @@ use pgwire::pg_response::{PgResponse, StatementType};
 use risingwave_common::session_config::{ConfigReporter, SESSION_CONFIG_LIST_SEP};
 use risingwave_common::system_param::reader::SystemParamsRead;
 use risingwave_common::types::Fields;
-use risingwave_sqlparser::ast::{Ident, SetTimeZoneValue, SetVariableValue, Value};
+use risingwave_sqlparser::ast::{
+    Ident, RoleContextModifier, SetRoleSpec, SetTimeZoneValue, SetVariableValue, Value,
+};
 
 use super::{RwPgResponse, RwPgResponseBuilderExt, fields_to_descriptors};
-use crate::error::Result;
+use crate::error::{ErrorCode, Result};
 use crate::handler::HandlerArgs;
+use crate::user::effective_privilege::{can_set_role, role_memberships_snapshot};
 
 /// convert `SetVariableValue` to string while remove the quotes on literals.
 pub(crate) fn set_var_to_param_str(value: &SetVariableValue) -> Option<String> {
@@ -106,6 +109,75 @@ pub(super) fn handle_set_time_zone(
 
     handler_args.session.set_config("timezone", tz_info)?;
 
+    Ok(PgResponse::empty_result(StatementType::SET_VARIABLE))
+}
+
+pub(super) fn handle_set_role(
+    handler_args: HandlerArgs,
+    context_modifier: Option<RoleContextModifier>,
+    role_name: SetRoleSpec,
+) -> Result<RwPgResponse> {
+    let session = handler_args.session;
+    let is_local = matches!(context_modifier, Some(RoleContextModifier::Local));
+    if is_local && !session.is_explicit_transaction() {
+        session.notice_to_user(
+            "SET LOCAL ROLE can only be used in transaction blocks; statement has no effect.",
+        );
+        return Ok(PgResponse::empty_result(StatementType::SET_VARIABLE));
+    }
+    match role_name {
+        SetRoleSpec::None => {
+            if is_local {
+                session
+                    .set_local_current_user(session.session_user_name(), session.session_user_id());
+            } else {
+                session.clear_local_current_user();
+                session.reset_current_user();
+            }
+        }
+        SetRoleSpec::Name(role_name) => {
+            let user_reader = session.env().user_info_reader();
+            let reader = user_reader.read_guard();
+            let role = reader
+                .get_user_by_name(&role_name.real_value())
+                .cloned()
+                .ok_or_else(|| {
+                    ErrorCode::InvalidInputSyntax(format!(
+                        "Role \"{}\" does not exist",
+                        role_name.real_value()
+                    ))
+                })?;
+            let session_is_super = reader
+                .get_user_by_name(&session.session_user_name())
+                .map(|user| user.is_super)
+                .unwrap_or(false);
+            drop(reader);
+
+            let memberships =
+                role_memberships_snapshot(session.env().role_membership_info_reader());
+            if !session_is_super && !can_set_role(session.session_user_id(), role.id, &memberships)
+            {
+                return Err(ErrorCode::PermissionDenied(format!(
+                    "permission denied to set role \"{}\"",
+                    role.name
+                ))
+                .into());
+            }
+            if is_local {
+                session.set_local_current_user(role.name.clone(), role.id);
+            } else {
+                session.clear_local_current_user();
+                session.set_current_user(role.name.clone(), role.id);
+            }
+        }
+    }
+
+    Ok(PgResponse::empty_result(StatementType::SET_VARIABLE))
+}
+
+pub(super) fn handle_reset_role(handler_args: HandlerArgs) -> Result<RwPgResponse> {
+    handler_args.session.clear_local_current_user();
+    handler_args.session.reset_current_user();
     Ok(PgResponse::empty_result(StatementType::SET_VARIABLE))
 }
 

--- a/src/frontend/src/meta_client.rs
+++ b/src/frontend/src/meta_client.rs
@@ -15,7 +15,7 @@
 use std::collections::{BTreeMap, HashMap, HashSet};
 
 use anyhow::Context;
-use risingwave_common::id::{ConnectionId, JobId, SourceId, TableId, UserId, WorkerId};
+use risingwave_common::id::{ConnectionId, JobId, SourceId, TableId, WorkerId};
 use risingwave_common::session_config::SessionConfig;
 use risingwave_common::system_param::reader::SystemParamsReader;
 use risingwave_common::util::cluster_limit::ClusterLimit;
@@ -52,6 +52,7 @@ use risingwave_rpc_client::error::Result;
 use risingwave_rpc_client::{HummockMetaClient, MetaClient};
 
 use crate::catalog::{DatabaseId, FragmentId, SinkId};
+use crate::user::UserId;
 
 /// A wrapper around the `MetaClient` that only provides a minor set of meta rpc.
 /// Most of the rpc to meta are delegated by other separate structs like `CatalogWriter`,

--- a/src/frontend/src/observer/observer_manager.rs
+++ b/src/frontend/src/observer/observer_manager.rs
@@ -14,6 +14,8 @@
 
 use std::collections::HashMap;
 use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::Duration;
 
 use itertools::Itertools;
 use parking_lot::RwLock;
@@ -31,13 +33,44 @@ use risingwave_pb::hummock::{HummockVersionDeltas, HummockVersionStats};
 use risingwave_pb::meta::object::{ObjectInfo, PbObjectInfo};
 use risingwave_pb::meta::subscribe_response::{Info, Operation};
 use risingwave_pb::meta::{FragmentWorkerSlotMapping, MetaSnapshot, SubscribeResponse};
+use risingwave_pb::user::RoleMembership;
 use risingwave_rpc_client::ComputeClientPoolRef;
+use thiserror_ext::AsReport;
 use tokio::sync::watch::Sender;
+use tokio::time::sleep;
+use tracing::warn;
 
 use crate::catalog::FragmentId;
 use crate::catalog::root_catalog::Catalog;
+use crate::meta_client::FrontendMetaClient;
 use crate::scheduler::HummockSnapshotManagerRef;
 use crate::user::user_manager::UserInfoManager;
+
+fn publish_catalog_version_if_newer(
+    catalog_updated_tx: &Sender<CatalogVersion>,
+    version: CatalogVersion,
+) {
+    if *catalog_updated_tx.borrow() < version
+        && let Err(error) = catalog_updated_tx.send(version)
+    {
+        warn!(error = %error.as_report(), version, "failed to publish catalog version");
+    }
+}
+
+const ROLE_MEMBERSHIP_REFRESH_RETRY_DELAY: Duration = Duration::from_millis(100);
+const ROLE_MEMBERSHIP_REFRESH_RETRY_MAX_DELAY: Duration = Duration::from_secs(1);
+
+fn publish_catalog_version_if_current(
+    catalog_updated_tx: &Sender<CatalogVersion>,
+    latest_role_membership_refresh_version: &AtomicU64,
+    version: CatalogVersion,
+) -> bool {
+    if latest_role_membership_refresh_version.load(Ordering::Acquire) != version {
+        return false;
+    }
+    publish_catalog_version_if_newer(catalog_updated_tx, version);
+    true
+}
 
 pub struct FrontendObserverNode {
     worker_node_manager: WorkerNodeManagerRef,
@@ -45,6 +78,9 @@ pub struct FrontendObserverNode {
     catalog_updated_tx: Sender<CatalogVersion>,
     catalog: Arc<RwLock<Catalog>>,
     user_info_manager: Arc<RwLock<UserInfoManager>>,
+    role_memberships: Arc<RwLock<Vec<RoleMembership>>>,
+    latest_role_membership_refresh_version: Arc<AtomicU64>,
+    meta_client: Arc<dyn FrontendMetaClient>,
     hummock_snapshot_manager: HummockSnapshotManagerRef,
     system_params_manager: LocalSystemParamsManagerRef,
     session_params: Arc<RwLock<SessionConfig>>,
@@ -204,22 +240,74 @@ impl ObserverState for FrontendObserverNode {
 
         let snapshot_version = version.unwrap();
         self.version = snapshot_version.catalog_version;
-        self.catalog_updated_tx
-            .send(snapshot_version.catalog_version)
-            .unwrap();
         *self.session_params.write() =
             serde_json::from_str(&session_params.unwrap().params).unwrap();
         LocalSecretManager::global().init_secrets(secrets);
         LicenseManager::get().update_cluster_resource(cluster_resource.unwrap());
+        self.refresh_role_memberships_cache_and_publish(
+            snapshot_version.catalog_version,
+            "failed to refresh cached role memberships after observer initialization",
+        );
     }
 }
 
 impl FrontendObserverNode {
+    fn refresh_role_memberships_cache_and_publish(
+        &self,
+        version: CatalogVersion,
+        failure_context: &'static str,
+    ) {
+        self.latest_role_membership_refresh_version
+            .fetch_max(version, Ordering::AcqRel);
+        let role_memberships = self.role_memberships.clone();
+        let meta_client = self.meta_client.clone();
+        let catalog_updated_tx = self.catalog_updated_tx.clone();
+        let latest_role_membership_refresh_version =
+            self.latest_role_membership_refresh_version.clone();
+        tokio::spawn(async move {
+            let mut retry_delay = ROLE_MEMBERSHIP_REFRESH_RETRY_DELAY;
+            loop {
+                if latest_role_membership_refresh_version.load(Ordering::Acquire) != version {
+                    return;
+                }
+                match meta_client.list_all_role_memberships().await {
+                    Ok(memberships) => {
+                        let mut role_memberships = role_memberships.write();
+                        if latest_role_membership_refresh_version.load(Ordering::Acquire) != version
+                        {
+                            return;
+                        }
+                        *role_memberships = memberships;
+                        drop(role_memberships);
+                        publish_catalog_version_if_current(
+                            &catalog_updated_tx,
+                            &latest_role_membership_refresh_version,
+                            version,
+                        );
+                        return;
+                    }
+                    Err(error) => {
+                        warn!(error = %error.as_report(), failure_context, "failed to refresh cached role memberships");
+                        if latest_role_membership_refresh_version.load(Ordering::Acquire) != version
+                        {
+                            return;
+                        }
+                    }
+                }
+                sleep(retry_delay).await;
+                retry_delay =
+                    std::cmp::min(retry_delay * 2, ROLE_MEMBERSHIP_REFRESH_RETRY_MAX_DELAY);
+            }
+        });
+    }
+
     pub fn new(
         worker_node_manager: WorkerNodeManagerRef,
         catalog: Arc<RwLock<Catalog>>,
         catalog_updated_tx: Sender<CatalogVersion>,
         user_info_manager: Arc<RwLock<UserInfoManager>>,
+        role_memberships: Arc<RwLock<Vec<RoleMembership>>>,
+        meta_client: Arc<dyn FrontendMetaClient>,
         hummock_snapshot_manager: HummockSnapshotManagerRef,
         system_params_manager: LocalSystemParamsManagerRef,
         session_params: Arc<RwLock<SessionConfig>>,
@@ -231,6 +319,9 @@ impl FrontendObserverNode {
             catalog,
             catalog_updated_tx,
             user_info_manager,
+            role_memberships,
+            latest_role_membership_refresh_version: Arc::new(AtomicU64::new(0)),
+            meta_client,
             hummock_snapshot_manager,
             system_params_manager,
             session_params,
@@ -460,7 +551,10 @@ impl FrontendObserverNode {
             self.version
         );
         self.version = resp.version;
-        self.catalog_updated_tx.send(resp.version).unwrap();
+        self.refresh_role_memberships_cache_and_publish(
+            resp.version,
+            "failed to refresh cached role memberships after user notification",
+        );
     }
 
     fn handle_fragment_mapping_notification(&mut self, resp: SubscribeResponse) {
@@ -579,4 +673,47 @@ fn convert_worker_slot_mapping(
             },
         )
         .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use tokio::sync::watch;
+
+    use super::*;
+
+    #[test]
+    fn publish_catalog_version_if_newer_is_monotonic() {
+        let (tx, rx) = watch::channel(10);
+
+        publish_catalog_version_if_newer(&tx, 9);
+        assert_eq!(*rx.borrow(), 10);
+
+        publish_catalog_version_if_newer(&tx, 11);
+        assert_eq!(*rx.borrow(), 11);
+
+        publish_catalog_version_if_newer(&tx, 10);
+        assert_eq!(*rx.borrow(), 11);
+    }
+
+    #[test]
+    fn publish_catalog_version_if_current_requires_latest_role_membership_refresh() {
+        let (tx, rx) = watch::channel(1);
+        let latest_role_membership_refresh_version = AtomicU64::new(7);
+
+        assert!(publish_catalog_version_if_current(
+            &tx,
+            &latest_role_membership_refresh_version,
+            7,
+        ));
+        assert_eq!(*rx.borrow(), 7);
+
+        latest_role_membership_refresh_version.store(8, Ordering::Release);
+
+        assert!(!publish_catalog_version_if_current(
+            &tx,
+            &latest_role_membership_refresh_version,
+            7,
+        ));
+        assert_eq!(*rx.borrow(), 7);
+    }
 }

--- a/src/frontend/src/session.rs
+++ b/src/frontend/src/session.rs
@@ -79,7 +79,6 @@ use risingwave_pb::configured_monitor_service_server;
 use risingwave_pb::frontend_service::frontend_service_server::FrontendServiceServer;
 use risingwave_pb::health::health_server::HealthServer;
 use risingwave_pb::monitor_service::monitor_service_server::MonitorServiceServer;
-use risingwave_pb::user::RoleMembership;
 use risingwave_pb::user::auth_info::EncryptionType;
 use risingwave_rpc_client::{
     ComputeClientPool, ComputeClientPoolRef, FrontendClientPool, FrontendClientPoolRef, MetaClient,
@@ -134,7 +133,9 @@ use crate::telemetry::FrontendTelemetryCreator;
 use crate::user::UserId;
 use crate::user::user_authentication::md5_hash_with_salt;
 use crate::user::user_manager::UserInfoManager;
-use crate::user::user_service::{UserInfoReader, UserInfoWriter, UserInfoWriterImpl};
+use crate::user::user_service::{
+    RoleMembershipInfoReader, UserInfoReader, UserInfoWriter, UserInfoWriterImpl,
+};
 use crate::{FrontendOpts, PgResponseStream, TableCatalog};
 
 pub(crate) mod current;
@@ -151,6 +152,7 @@ pub(crate) struct FrontendEnv {
     catalog_reader: CatalogReader,
     user_info_writer: Arc<dyn UserInfoWriter>,
     user_info_reader: UserInfoReader,
+    role_membership_info_reader: RoleMembershipInfoReader,
     worker_node_manager: WorkerNodeManagerRef,
     query_manager: QueryManager,
     hummock_snapshot_manager: HummockSnapshotManagerRef,
@@ -222,7 +224,7 @@ impl FrontendEnv {
         use crate::test_utils::{MockCatalogWriter, MockFrontendMetaClient, MockUserInfoWriter};
 
         let catalog = Arc::new(RwLock::new(Catalog::default()));
-        let role_memberships = Arc::new(RwLock::new(Vec::<RoleMembership>::new()));
+        let role_memberships = Arc::new(RwLock::new(vec![]));
         let meta_client = Arc::new(MockFrontendMetaClient::new(role_memberships.clone()));
         let hummock_snapshot_manager = Arc::new(HummockSnapshotManager::new(meta_client.clone()));
         let catalog_writer = Arc::new(MockCatalogWriter::new(
@@ -233,9 +235,10 @@ impl FrontendEnv {
         let user_info_manager = Arc::new(RwLock::new(UserInfoManager::default()));
         let user_info_writer = Arc::new(MockUserInfoWriter::new(
             user_info_manager.clone(),
-            role_memberships,
+            role_memberships.clone(),
         ));
         let user_info_reader = UserInfoReader::new(user_info_manager);
+        let role_membership_info_reader = RoleMembershipInfoReader::new(role_memberships);
         let worker_node_manager = Arc::new(WorkerNodeManager::mock(vec![]));
         let system_params_manager = Arc::new(LocalSystemParamsManager::for_test());
         let compute_client_pool = Arc::new(ComputeClientPool::for_test());
@@ -275,6 +278,7 @@ impl FrontendEnv {
             catalog_reader,
             user_info_writer,
             user_info_reader,
+            role_membership_info_reader,
             worker_node_manager,
             query_manager,
             hummock_snapshot_manager,
@@ -395,8 +399,8 @@ impl FrontendEnv {
         let user_info_writer = Arc::new(UserInfoWriterImpl::new(
             meta_client.clone(),
             catalog_updated_rx,
-            role_memberships,
         ));
+        let role_membership_info_reader = RoleMembershipInfoReader::new(role_memberships.clone());
 
         let system_params_manager =
             Arc::new(LocalSystemParamsManager::new(system_params_reader.clone()));
@@ -417,6 +421,8 @@ impl FrontendEnv {
             catalog,
             catalog_updated_tx,
             user_info_manager,
+            role_memberships,
+            frontend_meta_client.clone(),
             hummock_snapshot_manager.clone(),
             system_params_manager.clone(),
             session_params.clone(),
@@ -565,6 +571,7 @@ impl FrontendEnv {
                 catalog_writer,
                 user_info_reader,
                 user_info_writer,
+                role_membership_info_reader,
                 worker_node_manager,
                 meta_client: frontend_meta_client,
                 query_manager,
@@ -623,6 +630,10 @@ impl FrontendEnv {
     /// Get a reference to the frontend env's user info reader.
     pub fn user_info_reader(&self) -> &UserInfoReader {
         &self.user_info_reader
+    }
+
+    pub fn role_membership_info_reader(&self) -> &RoleMembershipInfoReader {
+        &self.role_membership_info_reader
     }
 
     pub fn worker_node_manager_ref(&self) -> WorkerNodeManagerRef {
@@ -744,17 +755,57 @@ impl FrontendEnv {
 #[derive(Clone)]
 pub struct AuthContext {
     pub database: String,
+    pub session_user_name: String,
+    pub session_user_id: UserId,
     pub user_name: String,
     pub user_id: UserId,
 }
 
 impl AuthContext {
     pub fn new(database: String, user_name: String, user_id: UserId) -> Self {
+        Self::new_with_current(database, user_name.clone(), user_id, user_name, user_id)
+    }
+
+    pub fn new_with_current(
+        database: String,
+        session_user_name: String,
+        session_user_id: UserId,
+        current_user_name: String,
+        current_user_id: UserId,
+    ) -> Self {
         Self {
             database,
-            user_name,
-            user_id,
+            session_user_name,
+            session_user_id,
+            user_name: current_user_name,
+            user_id: current_user_id,
         }
+    }
+
+    pub fn session_user_name(&self) -> &str {
+        &self.session_user_name
+    }
+
+    pub fn session_user_id(&self) -> UserId {
+        self.session_user_id
+    }
+
+    pub fn current_user_name(&self) -> &str {
+        &self.user_name
+    }
+
+    pub fn current_user_id(&self) -> UserId {
+        self.user_id
+    }
+
+    pub fn set_current_user(&mut self, current_user_name: String, current_user_id: UserId) {
+        self.user_name = current_user_name;
+        self.user_id = current_user_id;
+    }
+
+    pub fn reset_current_user(&mut self) {
+        self.user_name = self.session_user_name.clone();
+        self.user_id = self.session_user_id;
     }
 }
 pub struct SessionImpl {
@@ -970,19 +1021,33 @@ impl SessionImpl {
     }
 
     pub fn user_name(&self) -> String {
-        self.auth_context.read().user_name.clone()
+        self.auth_context.read().current_user_name().to_owned()
     }
 
     pub fn user_id(&self) -> UserId {
-        self.auth_context.read().user_id
+        self.auth_context.read().current_user_id()
+    }
+
+    pub fn session_user_name(&self) -> String {
+        self.auth_context.read().session_user_name().to_owned()
     }
 
     pub fn session_user_id(&self) -> UserId {
-        self.user_id()
+        self.auth_context.read().session_user_id()
     }
 
     pub fn update_database(&self, database: String) {
         self.auth_context.write().database = database;
+    }
+
+    pub fn set_current_user(&self, current_user_name: String, current_user_id: UserId) {
+        self.auth_context
+            .write()
+            .set_current_user(current_user_name, current_user_id);
+    }
+
+    pub fn reset_current_user(&self) {
+        self.auth_context.write().reset_current_user();
     }
 
     pub fn shared_config(&self) -> Arc<RwLock<SessionConfig>> {
@@ -2045,5 +2110,26 @@ pub fn cancel_creating_jobs_in_session(session_id: SessionId, sessions_map: Sess
     } else {
         info!("Current session finished, ignoring cancel creating request");
         false
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::AuthContext;
+
+    #[test]
+    fn auth_context_tracks_session_and_current_user_separately() {
+        let ctx = AuthContext::new_with_current(
+            "dev".to_owned(),
+            "login_role".to_owned(),
+            1.into(),
+            "active_role".to_owned(),
+            2.into(),
+        );
+
+        assert_eq!(ctx.session_user_name(), "login_role");
+        assert_eq!(ctx.session_user_id(), 1);
+        assert_eq!(ctx.current_user_name(), "active_role");
+        assert_eq!(ctx.current_user_id(), 2);
     }
 }

--- a/src/frontend/src/session/transaction.rs
+++ b/src/frontend/src/session/transaction.rs
@@ -23,6 +23,7 @@ use super::SessionImpl;
 use crate::catalog::catalog_service::CatalogWriter;
 use crate::error::{ErrorCode, Result};
 use crate::scheduler::ReadSnapshot;
+use crate::user::UserId;
 use crate::user::user_service::UserInfoWriter;
 
 /// Globally unique transaction id in this frontend instance.
@@ -66,6 +67,10 @@ pub struct Context {
     /// The snapshot of the transaction, acquired lazily at the first read operation in the
     /// transaction.
     snapshot: Option<ReadSnapshot>,
+
+    /// Restores the effective current role when a `SET LOCAL ROLE` override expires at the end of
+    /// the transaction.
+    local_role_restore: Option<(String, crate::user::UserId)>,
 }
 
 /// Transaction state.
@@ -92,13 +97,21 @@ pub enum State {
 /// A guard that auto commits an implicit transaction when dropped. Do nothing if an explicit
 /// transaction is in progress.
 #[must_use]
-pub struct ImplicitAutoCommitGuard(Weak<Mutex<State>>);
+pub struct ImplicitAutoCommitGuard {
+    txn: Weak<Mutex<State>>,
+    auth_context: Weak<parking_lot::RwLock<super::AuthContext>>,
+}
 
 impl Drop for ImplicitAutoCommitGuard {
     fn drop(&mut self) {
-        if let Some(txn) = self.0.upgrade() {
+        if let Some(txn) = self.txn.upgrade() {
             let mut txn = txn.lock();
-            if let State::Implicit(_) = &*txn {
+            if let State::Implicit(ctx) = &mut *txn {
+                if let Some((user_name, user_id)) = ctx.local_role_restore.take()
+                    && let Some(auth_context) = self.auth_context.upgrade()
+                {
+                    auth_context.write().set_current_user(user_name, user_id);
+                }
                 *txn = State::Initial;
             }
         }
@@ -119,6 +132,7 @@ impl SessionImpl {
                     id: Id::new(),
                     access_mode: AccessMode::ReadWrite,
                     snapshot: Default::default(),
+                    local_role_restore: None,
                 })
             }
             State::Implicit(_) => unreachable!("implicit transaction is already in progress"),
@@ -126,7 +140,10 @@ impl SessionImpl {
                                       * progress */
         }
 
-        ImplicitAutoCommitGuard(Arc::downgrade(&self.txn))
+        ImplicitAutoCommitGuard {
+            txn: Arc::downgrade(&self.txn),
+            auth_context: Arc::downgrade(&self.auth_context),
+        }
     }
 
     /// Starts an explicit transaction with the specified access mode from `START TRANSACTION`.
@@ -147,6 +164,7 @@ impl SessionImpl {
                     id: ctx.id,
                     access_mode,
                     snapshot: ctx.snapshot.clone(),
+                    local_role_restore: None,
                 })
             }
             State::Explicit(_) => {
@@ -156,21 +174,30 @@ impl SessionImpl {
         }
     }
 
+    pub fn is_explicit_transaction(&self) -> bool {
+        matches!(*self.txn.lock(), State::Explicit(_))
+    }
+
     /// Commits an explicit transaction.
     // TODO: handle failed transaction
     pub fn txn_commit_explicit(&self) {
         let mut txn = self.txn.lock();
 
-        match &*txn {
+        match &mut *txn {
             State::Initial => unreachable!("no transaction in progress"),
             State::Implicit(_) => {
                 // TODO: should be warning
                 self.notice_to_user("there is no transaction in progress")
             }
-            State::Explicit(ctx) => match ctx.access_mode {
-                AccessMode::ReadWrite => unimplemented!(),
-                AccessMode::ReadOnly => *txn = State::Initial,
-            },
+            State::Explicit(ctx) => {
+                if let Some((user_name, user_id)) = ctx.local_role_restore.take() {
+                    self.set_current_user(user_name, user_id);
+                }
+                match ctx.access_mode {
+                    AccessMode::ReadWrite => unimplemented!(),
+                    AccessMode::ReadOnly => *txn = State::Initial,
+                }
+            }
         }
     }
 
@@ -179,16 +206,61 @@ impl SessionImpl {
     pub fn txn_rollback_explicit(&self) {
         let mut txn = self.txn.lock();
 
-        match &*txn {
+        match &mut *txn {
             State::Initial => unreachable!("no transaction in progress"),
             State::Implicit(_) => {
                 // TODO: should be warning
                 self.notice_to_user("there is no transaction in progress")
             }
-            State::Explicit(ctx) => match ctx.access_mode {
-                AccessMode::ReadWrite => unimplemented!(),
-                AccessMode::ReadOnly => *txn = State::Initial,
-            },
+            State::Explicit(ctx) => {
+                if let Some((user_name, user_id)) = ctx.local_role_restore.take() {
+                    self.set_current_user(user_name, user_id);
+                }
+                match ctx.access_mode {
+                    AccessMode::ReadWrite => unimplemented!(),
+                    AccessMode::ReadOnly => *txn = State::Initial,
+                }
+            }
+        }
+    }
+
+    pub fn set_local_current_user(
+        &self,
+        current_user_name: String,
+        current_user_id: UserId,
+    ) -> bool {
+        let previous = {
+            let auth_context = self.auth_context.read();
+            (
+                auth_context.current_user_name().to_owned(),
+                auth_context.current_user_id(),
+            )
+        };
+
+        let mut txn = self.txn.lock();
+        match &mut *txn {
+            State::Explicit(ctx) => {
+                ctx.local_role_restore.get_or_insert(previous);
+                drop(txn);
+                self.set_current_user(current_user_name, current_user_id);
+                true
+            }
+            State::Initial | State::Implicit(_) => {
+                self.notice_to_user(
+                    "SET LOCAL ROLE can only be used in transaction blocks; statement has no effect.",
+                );
+                false
+            }
+        }
+    }
+
+    pub fn clear_local_current_user(&self) {
+        let mut txn = self.txn.lock();
+        match &mut *txn {
+            State::Initial | State::Implicit(_) => {}
+            State::Explicit(ctx) => {
+                ctx.local_role_restore = None;
+            }
         }
     }
 

--- a/src/frontend/src/user/effective_privilege.rs
+++ b/src/frontend/src/user/effective_privilege.rs
@@ -1,0 +1,154 @@
+// Copyright 2026 RisingWave Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::{HashSet, VecDeque};
+
+use risingwave_common::acl::AclMode;
+use risingwave_pb::user::RoleMembership;
+
+use crate::session::AuthContext;
+use crate::user::UserId;
+use crate::user::user_catalog::UserCatalog;
+use crate::user::user_service::{RoleMembershipInfoReader, UserInfoReader};
+
+fn reachable_role_ids(
+    start_ids: impl IntoIterator<Item = UserId>,
+    memberships: &[RoleMembership],
+    edge_allowed: impl Fn(&RoleMembership) -> bool,
+) -> HashSet<UserId> {
+    let mut visited = HashSet::new();
+    let mut queue = VecDeque::new();
+    for start_id in start_ids {
+        queue.push_back(start_id);
+    }
+
+    while let Some(member_id) = queue.pop_front() {
+        for membership in memberships
+            .iter()
+            .filter(|membership| membership.member_id == member_id && edge_allowed(membership))
+        {
+            let role_id = membership.role_id;
+            if visited.insert(role_id) {
+                queue.push_back(role_id);
+            }
+        }
+    }
+
+    visited
+}
+
+pub fn can_set_role(
+    session_user_id: UserId,
+    target_role_id: UserId,
+    memberships: &[RoleMembership],
+) -> bool {
+    session_user_id == target_role_id
+        || reachable_role_ids([session_user_id], memberships, |membership| {
+            membership.set_option
+        })
+        .contains(&target_role_id)
+}
+
+pub fn can_admin_role(
+    actor_role_id: UserId,
+    target_role_id: UserId,
+    memberships: &[RoleMembership],
+) -> bool {
+    actor_role_id == target_role_id
+        || reachable_role_ids([actor_role_id], memberships, |membership| {
+            membership.admin_option
+        })
+        .contains(&target_role_id)
+}
+
+pub fn session_has_privilege(
+    user_info_reader: &UserInfoReader,
+    auth_context: &AuthContext,
+    memberships: &[RoleMembership],
+    owner: UserId,
+    object: impl Copy + Into<risingwave_pb::user::grant_privilege::Object>,
+    mode: AclMode,
+) -> bool {
+    let current_user_id = auth_context.current_user_id();
+    let reader = user_info_reader.read_guard();
+    if let Some(user) = reader.get_user_by_id(&current_user_id)
+        && has_direct_privilege_for_catalog_user(user, owner, object, mode)
+    {
+        return true;
+    }
+
+    for role_id in reachable_role_ids([current_user_id], memberships, |membership| {
+        membership.inherit_option
+    }) {
+        let Some(role) = reader.get_user_by_id(&role_id) else {
+            continue;
+        };
+        if has_inherited_privilege_for_catalog_user(role, owner, object, mode) {
+            return true;
+        }
+    }
+    false
+}
+
+#[allow(dead_code)]
+pub fn principal_has_privilege(
+    user_info_reader: &UserInfoReader,
+    memberships: &[RoleMembership],
+    principal: &UserCatalog,
+    owner: UserId,
+    object: impl Copy + Into<risingwave_pb::user::grant_privilege::Object>,
+    mode: AclMode,
+) -> bool {
+    let reader = user_info_reader.read_guard();
+    if has_direct_privilege_for_catalog_user(principal, owner, object, mode) {
+        return true;
+    }
+
+    for role_id in reachable_role_ids([principal.id], memberships, |membership| {
+        membership.inherit_option
+    }) {
+        let Some(role) = reader.get_user_by_id(&role_id) else {
+            continue;
+        };
+        if has_inherited_privilege_for_catalog_user(role, owner, object, mode) {
+            return true;
+        }
+    }
+
+    false
+}
+
+fn has_direct_privilege_for_catalog_user(
+    user: &UserCatalog,
+    owner: UserId,
+    object: impl Copy + Into<risingwave_pb::user::grant_privilege::Object>,
+    mode: AclMode,
+) -> bool {
+    user.is_super || has_inherited_privilege_for_catalog_user(user, owner, object, mode)
+}
+
+fn has_inherited_privilege_for_catalog_user(
+    user: &UserCatalog,
+    owner: UserId,
+    object: impl Copy + Into<risingwave_pb::user::grant_privilege::Object>,
+    mode: AclMode,
+) -> bool {
+    user.id == owner || user.has_privilege(object, mode)
+}
+
+pub fn role_memberships_snapshot(
+    role_membership_reader: &RoleMembershipInfoReader,
+) -> Vec<RoleMembership> {
+    role_membership_reader.read_guard().clone()
+}

--- a/src/frontend/src/user/mod.rs
+++ b/src/frontend/src/user/mod.rs
@@ -15,6 +15,7 @@
 use risingwave_common::id::{ObjectId, SchemaId};
 use user_catalog::UserCatalog;
 
+pub(crate) mod effective_privilege;
 pub(crate) mod user_authentication;
 pub(crate) mod user_catalog;
 pub(crate) mod user_manager;

--- a/src/frontend/src/user/user_service.rs
+++ b/src/frontend/src/user/user_service.rs
@@ -122,7 +122,6 @@ pub trait UserInfoWriter: Send + Sync {
 pub struct UserInfoWriterImpl {
     meta_client: MetaClient,
     user_updated_rx: Receiver<UserInfoVersion>,
-    role_memberships: Arc<RwLock<Vec<RoleMembership>>>,
 }
 
 #[async_trait::async_trait]
@@ -137,8 +136,7 @@ impl UserInfoWriter for UserInfoWriterImpl {
             .meta_client
             .drop_user(id, dropped_by, session_user)
             .await?;
-        self.wait_version(version).await?;
-        self.refresh_role_memberships().await
+        self.wait_version(version).await
     }
 
     async fn update_user(&self, user: UserInfo, update_fields: Vec<UpdateField>) -> Result<()> {
@@ -207,8 +205,7 @@ impl UserInfoWriter for UserInfoWriterImpl {
                 set_option,
             )
             .await?;
-        self.wait_version(version).await?;
-        self.refresh_role_memberships().await
+        self.wait_version(version).await
     }
 
     async fn revoke_role(
@@ -237,8 +234,7 @@ impl UserInfoWriter for UserInfoWriterImpl {
                 cascade,
             )
             .await?;
-        self.wait_version(version).await?;
-        self.refresh_role_memberships().await
+        self.wait_version(version).await
     }
 
     async fn alter_default_privilege(
@@ -257,15 +253,10 @@ impl UserInfoWriter for UserInfoWriterImpl {
 }
 
 impl UserInfoWriterImpl {
-    pub fn new(
-        meta_client: MetaClient,
-        user_updated_rx: Receiver<UserInfoVersion>,
-        role_memberships: Arc<RwLock<Vec<RoleMembership>>>,
-    ) -> Self {
+    pub fn new(meta_client: MetaClient, user_updated_rx: Receiver<UserInfoVersion>) -> Self {
         UserInfoWriterImpl {
             meta_client,
             user_updated_rx,
-            role_memberships,
         }
     }
 
@@ -274,11 +265,6 @@ impl UserInfoWriterImpl {
         while *rx.borrow_and_update() < version {
             rx.changed().await.map_err(|e| anyhow!(e))?;
         }
-        Ok(())
-    }
-
-    async fn refresh_role_memberships(&self) -> Result<()> {
-        *self.role_memberships.write() = self.meta_client.list_all_role_memberships().await?;
         Ok(())
     }
 }

--- a/src/meta/src/controller/user.rs
+++ b/src/meta/src/controller/user.rs
@@ -992,44 +992,68 @@ impl CatalogController {
             }
         }
 
-        // check whether grantor has the privilege to grant the privilege.
+        // Check whether the grantor can grant each privilege. Inherited roles can supply
+        // object ownership or WITH GRANT OPTION, matching PostgreSQL's effective privilege
+        // checks. Record the effective role as the grantor so dependency tracking remains
+        // attached to the privilege source.
         let user = User::find_by_id(grantor)
             .one(&txn)
             .await?
             .ok_or_else(|| MetaError::catalog_id_not_found("user", grantor))?;
-        let mut filtered_privileges = vec![];
-        if !user.is_super {
+        let filtered_privileges = if user.is_super {
+            privileges
+        } else {
+            let existing_memberships = UserRoleMembership::find().all(&txn).await?;
+            let inherit_graph = build_role_membership_graph(
+                &existing_memberships,
+                RoleMembershipGraphKind::Inherit,
+            );
+            let mut principals = vec![grantor];
+            principals.extend(closest_reachable_role_ids(&inherit_graph, grantor));
+
+            let mut filtered_privileges = vec![];
             for mut privilege in privileges {
-                if grantor == get_object_owner(*privilege.oid.as_ref(), &txn).await? {
+                let oid = *privilege.oid.as_ref();
+                let action = *privilege.action.as_ref();
+                let owner = get_object_owner(oid, &txn).await?;
+                if principals.contains(&owner) {
+                    privilege.granted_by = Set(owner);
                     filtered_privileges.push(privilege);
                     continue;
                 }
-                let filter = user_privilege::Column::UserId
-                    .eq(grantor)
-                    .and(user_privilege::Column::Oid.eq(*privilege.oid.as_ref()))
-                    .and(user_privilege::Column::Action.eq(*privilege.action.as_ref()))
-                    .and(user_privilege::Column::WithGrantOption.eq(true));
-                let privilege_id: Option<PrivilegeId> = UserPrivilege::find()
-                    .select_only()
-                    .column(user_privilege::Column::Id)
-                    .filter(filter)
-                    .into_tuple()
-                    .one(&txn)
-                    .await?;
-                let Some(privilege_id) = privilege_id else {
-                    tracing::warn!(
-                        "user {} don't have privilege {:?} or grant option",
-                        grantor,
-                        privilege.action
-                    );
-                    continue;
+
+                let mut grant_option = None;
+                for principal in &principals {
+                    let filter = user_privilege::Column::UserId
+                        .eq(*principal)
+                        .and(user_privilege::Column::Oid.eq(oid))
+                        .and(user_privilege::Column::Action.eq(action))
+                        .and(user_privilege::Column::WithGrantOption.eq(true));
+                    let privilege_id: Option<PrivilegeId> = UserPrivilege::find()
+                        .select_only()
+                        .column(user_privilege::Column::Id)
+                        .filter(filter)
+                        .into_tuple()
+                        .one(&txn)
+                        .await?;
+                    if let Some(privilege_id) = privilege_id {
+                        grant_option = Some((*principal, privilege_id));
+                        break;
+                    }
+                }
+
+                let Some((effective_grantor, privilege_id)) = grant_option else {
+                    return Err(MetaError::permission_denied(format!(
+                        "user {} does not have privilege {:?} with grant option on object {}",
+                        grantor, action, oid
+                    )));
                 };
+                privilege.granted_by = Set(effective_grantor);
                 privilege.dependent_id = Set(Some(privilege_id));
                 filtered_privileges.push(privilege);
             }
-        } else {
-            filtered_privileges = privileges;
-        }
+            filtered_privileges
+        };
 
         // insert privileges
         let user_privileges = user_ids
@@ -1144,55 +1168,75 @@ impl CatalogController {
             }
         }
 
-        let filter = if !revoke_user.is_super {
-            // ensure user have grant options or is owner of the object.
-            for (obj, actions) in &revoke_items {
-                if revoke_by == get_object_owner(*obj, &txn).await? {
-                    continue;
-                }
-                let owned_actions: HashSet<Action> = UserPrivilege::find()
-                    .select_only()
-                    .column(user_privilege::Column::Action)
-                    .filter(
-                        user_privilege::Column::UserId
-                            .eq(granted_by)
-                            .and(user_privilege::Column::Oid.eq(*obj))
-                            .and(user_privilege::Column::WithGrantOption.eq(true)),
-                    )
-                    .into_tuple::<Action>()
-                    .all(&txn)
-                    .await?
-                    .into_iter()
-                    .collect();
-                if actions.iter().any(|ac| !owned_actions.contains(ac)) {
-                    return Err(MetaError::permission_denied(format!(
-                        "user {} don't have privileges {:?} or grant option",
-                        revoke_user.name, actions,
-                    )));
+        let mut root_user_privileges: Vec<PartialUserPrivilege> = vec![];
+        if revoke_user.is_super {
+            let user_filter = user_privilege::Column::UserId.is_in(user_ids.clone());
+            for (obj, actions) in revoke_items {
+                root_user_privileges.extend(
+                    UserPrivilege::find()
+                        .select_only()
+                        .columns([user_privilege::Column::Id, user_privilege::Column::UserId])
+                        .filter(
+                            user_filter
+                                .clone()
+                                .and(user_privilege::Column::Oid.eq(obj))
+                                .and(user_privilege::Column::Action.is_in(actions)),
+                        )
+                        .into_partial_model()
+                        .all(&txn)
+                        .await?,
+                );
+            }
+        } else {
+            let existing_memberships = UserRoleMembership::find().all(&txn).await?;
+            let inherit_graph = build_role_membership_graph(
+                &existing_memberships,
+                RoleMembershipGraphKind::Inherit,
+            );
+            let mut principals = vec![revoke_by];
+            principals.extend(closest_reachable_role_ids(&inherit_graph, revoke_by));
+
+            for (obj, actions) in revoke_items {
+                let owner = get_object_owner(obj, &txn).await?;
+                for action in actions {
+                    let mut effective_grantors = HashSet::new();
+                    if principals.contains(&owner) {
+                        effective_grantors.insert(owner);
+                    }
+                    for principal in &principals {
+                        let exists = UserPrivilege::find()
+                            .filter(user_privilege::Column::UserId.eq(*principal))
+                            .filter(user_privilege::Column::Oid.eq(obj))
+                            .filter(user_privilege::Column::Action.eq(action))
+                            .filter(user_privilege::Column::WithGrantOption.eq(true))
+                            .one(&txn)
+                            .await?
+                            .is_some();
+                        if exists {
+                            effective_grantors.insert(*principal);
+                        }
+                    }
+                    if effective_grantors.is_empty() {
+                        return Err(MetaError::permission_denied(format!(
+                            "user {} does not have privilege {:?} with grant option on object {}",
+                            revoke_by, action, obj
+                        )));
+                    }
+
+                    root_user_privileges.extend(
+                        UserPrivilege::find()
+                            .select_only()
+                            .columns([user_privilege::Column::Id, user_privilege::Column::UserId])
+                            .filter(user_privilege::Column::GrantedBy.is_in(effective_grantors))
+                            .filter(user_privilege::Column::UserId.is_in(user_ids.clone()))
+                            .filter(user_privilege::Column::Oid.eq(obj))
+                            .filter(user_privilege::Column::Action.eq(action))
+                            .into_partial_model()
+                            .all(&txn)
+                            .await?,
+                    );
                 }
             }
-
-            user_privilege::Column::GrantedBy
-                .eq(granted_by)
-                .and(user_privilege::Column::UserId.is_in(user_ids.clone()))
-        } else {
-            user_privilege::Column::UserId.is_in(user_ids.clone())
-        };
-        let mut root_user_privileges: Vec<PartialUserPrivilege> = vec![];
-        for (obj, actions) in revoke_items {
-            let filter = filter
-                .clone()
-                .and(user_privilege::Column::Oid.eq(obj))
-                .and(user_privilege::Column::Action.is_in(actions));
-            root_user_privileges.extend(
-                UserPrivilege::find()
-                    .select_only()
-                    .columns([user_privilege::Column::Id, user_privilege::Column::UserId])
-                    .filter(filter)
-                    .into_partial_model()
-                    .all(&txn)
-                    .await?,
-            );
         }
         if root_user_privileges.is_empty() {
             tracing::warn!("no privilege to revoke, ignore it");


### PR DESCRIPTION
Part of the re-cut RBAC stack.

This slice routes role membership through frontend sessions:

- frontend privilege checks use effective role membership;
- SET ROLE / RESET ROLE session identity handling;
- frontend role grant/revoke handlers call the meta membership APIs;
- observer/session cache refresh for role memberships;
- fixes stale CREATEROLE/INHERIT tests by converting them to positive assertions once frontend support lands.

Local verification:
- `cargo fmt`
- `git diff --check origin/main ralph/rbac-v2-10-pg-catalog-compat`

No compile/build/e2e was run in this recut pass.
