### PR TITLE
test: 7/10 cover RBAC frontend runtime and e2e

### DIFF
--- a/e2e_test/ddl/role_membership.slt
+++ b/e2e_test/ddl/role_membership.slt
@@ -1,0 +1,110 @@
+# Core RBAC e2e coverage without role membership WITH OPTION syntax.
+# Follow-up PRs cover ADMIN/INHERIT/SET options and GRANTED BY.
+
+statement ok
+SET RW_IMPLICIT_FLUSH TO true;
+
+statement ok
+DROP TABLE IF EXISTS role_core_privilege_t;
+
+statement ok
+DROP ROLE IF EXISTS role_core_privilege_user;
+
+statement ok
+DROP ROLE IF EXISTS role_core_privilege_app;
+
+statement ok
+DROP ROLE IF EXISTS role_core_privilege_select;
+
+statement ok
+DROP ROLE IF EXISTS role_core_privilege_update;
+
+statement ok
+CREATE TABLE role_core_privilege_t (id int PRIMARY KEY, v int);
+
+statement ok
+INSERT INTO role_core_privilege_t VALUES (1, 10), (2, 20);
+
+statement ok
+CREATE ROLE role_core_privilege_select;
+
+statement ok
+CREATE ROLE role_core_privilege_update;
+
+statement ok
+CREATE ROLE role_core_privilege_app;
+
+statement ok
+CREATE USER role_core_privilege_user WITH PASSWORD 'secret';
+
+statement ok
+GRANT SELECT ON TABLE role_core_privilege_t TO role_core_privilege_select;
+
+statement ok
+GRANT UPDATE ON TABLE role_core_privilege_t TO role_core_privilege_update;
+
+statement ok
+GRANT role_core_privilege_select TO role_core_privilege_app;
+
+statement ok
+GRANT role_core_privilege_update TO role_core_privilege_app;
+
+statement ok
+GRANT role_core_privilege_app TO role_core_privilege_user;
+
+# SET ROLE should activate the simple role-membership graph.
+statement ok
+SET ROLE role_core_privilege_app;
+
+query II
+SELECT id, v FROM role_core_privilege_t ORDER BY id;
+----
+1 10
+2 20
+
+statement ok
+UPDATE role_core_privilege_t SET v = v + 1 WHERE id = 1;
+
+statement ok
+RESET ROLE;
+
+query II
+SELECT id, v FROM role_core_privilege_t ORDER BY id;
+----
+1 11
+2 20
+
+# A login user should inherit simple role memberships by default.
+system ok
+PGPASSWORD=secret psql -h "$SLT_HOST" -p "$SLT_PORT" -d "$SLT_DB" -U role_core_privilege_user -v ON_ERROR_STOP=1 -At -c "SELECT count(*) FROM role_core_privilege_t WHERE id = 1 AND v = 11;" | grep -qx "1"
+
+system ok
+PGPASSWORD=secret psql -h "$SLT_HOST" -p "$SLT_PORT" -d "$SLT_DB" -U role_core_privilege_user -v ON_ERROR_STOP=1 -c "SET RW_IMPLICIT_FLUSH TO true; UPDATE role_core_privilege_t SET v = v + 1 WHERE id = 2;"
+
+query II
+SELECT id, v FROM role_core_privilege_t ORDER BY id;
+----
+1 11
+2 21
+
+# Simple REVOKE should remove the inherited privilege.
+statement ok
+REVOKE role_core_privilege_app FROM role_core_privilege_user;
+
+system ok
+PGPASSWORD=secret psql -h "$SLT_HOST" -p "$SLT_PORT" -d "$SLT_DB" -U role_core_privilege_user -v ON_ERROR_STOP=1 -c "SELECT id, v FROM role_core_privilege_t ORDER BY id;" 2>&1 | grep -qi "permission denied"
+
+statement ok
+DROP TABLE role_core_privilege_t;
+
+statement ok
+DROP ROLE role_core_privilege_user;
+
+statement ok
+DROP ROLE role_core_privilege_app;
+
+statement ok
+DROP ROLE role_core_privilege_select;
+
+statement ok
+DROP ROLE role_core_privilege_update;

--- a/e2e_test/ddl/role_membership_options.slt
+++ b/e2e_test/ddl/role_membership_options.slt
@@ -1,0 +1,61 @@
+# Role-membership INHERIT/SET option coverage.
+
+statement ok
+SET RW_IMPLICIT_FLUSH TO true;
+
+statement ok
+DROP TABLE IF EXISTS role_option_privilege_t;
+
+statement ok
+DROP ROLE IF EXISTS role_option_user;
+
+statement ok
+DROP ROLE IF EXISTS role_option_reader;
+
+statement ok
+CREATE TABLE role_option_privilege_t (id int PRIMARY KEY, v int);
+
+statement ok
+INSERT INTO role_option_privilege_t VALUES (1, 10);
+
+statement ok
+CREATE ROLE role_option_reader;
+
+statement ok
+CREATE USER role_option_user WITH PASSWORD 'secret';
+
+statement ok
+GRANT SELECT ON TABLE role_option_privilege_t TO role_option_reader;
+
+statement ok
+GRANT role_option_reader TO role_option_user WITH INHERIT FALSE, SET FALSE;
+
+system ok
+PGPASSWORD=secret psql -h "$SLT_HOST" -p "$SLT_PORT" -d "$SLT_DB" -U role_option_user -v ON_ERROR_STOP=1 -c "SELECT * FROM role_option_privilege_t;" 2>&1 | grep -qi "permission denied"
+
+system ok
+PGPASSWORD=secret psql -h "$SLT_HOST" -p "$SLT_PORT" -d "$SLT_DB" -U role_option_user -v ON_ERROR_STOP=1 -c "SET ROLE role_option_reader;" 2>&1 | grep -q "permission denied to set role"
+
+statement ok
+GRANT role_option_reader TO role_option_user WITH INHERIT TRUE, SET TRUE;
+
+system ok
+PGPASSWORD=secret psql -h "$SLT_HOST" -p "$SLT_PORT" -d "$SLT_DB" -U role_option_user -v ON_ERROR_STOP=1 -At -c "SELECT count(*) FROM role_option_privilege_t WHERE id = 1 AND v = 10;" | grep -qx "1"
+
+system ok
+PGPASSWORD=secret psql -h "$SLT_HOST" -p "$SLT_PORT" -d "$SLT_DB" -U role_option_user -v ON_ERROR_STOP=1 -At -c "SET ROLE role_option_reader; SELECT count(*) FROM role_option_privilege_t WHERE id = 1 AND v = 10;" | grep -qx "1"
+
+statement ok
+REVOKE SET OPTION FOR role_option_reader FROM role_option_user;
+
+system ok
+PGPASSWORD=secret psql -h "$SLT_HOST" -p "$SLT_PORT" -d "$SLT_DB" -U role_option_user -v ON_ERROR_STOP=1 -c "SET ROLE role_option_reader;" 2>&1 | grep -q "permission denied to set role"
+
+statement ok
+DROP TABLE role_option_privilege_t;
+
+statement ok
+DROP ROLE role_option_user;
+
+statement ok
+DROP ROLE role_option_reader;

--- a/src/frontend/src/handler/alter_user.rs
+++ b/src/frontend/src/handler/alter_user.rs
@@ -374,6 +374,74 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_createrole_requires_admin_option_to_alter_other_roles() {
+        let frontend = LocalFrontend::new(Default::default()).await;
+
+        frontend
+            .run_sql("CREATE USER manager WITH CREATEROLE")
+            .await
+            .unwrap();
+        frontend.run_sql("CREATE USER target_user").await.unwrap();
+
+        let manager_id = frontend.user_by_name("manager").unwrap().id;
+        let database = DEFAULT_DATABASE_NAME.to_owned();
+        let manager_name = "manager".to_owned();
+
+        let err = frontend
+            .run_user_sql(
+                "ALTER USER target_user WITH PASSWORD 'new_password'",
+                database.clone(),
+                manager_name.clone(),
+                manager_id,
+            )
+            .await
+            .unwrap_err();
+        assert!(err.to_string().contains("ADMIN OPTION"));
+
+        frontend
+            .run_sql("GRANT target_user TO manager WITH ADMIN OPTION")
+            .await
+            .unwrap();
+        frontend
+            .run_user_sql(
+                "ALTER USER target_user WITH PASSWORD 'new_password'",
+                database,
+                manager_name,
+                manager_id,
+            )
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_reserved_default_users_cannot_be_downgraded_or_renamed() {
+        let frontend = LocalFrontend::new(Default::default()).await;
+
+        let err = frontend
+            .run_sql("ALTER USER root WITH NOSUPERUSER")
+            .await
+            .unwrap_err();
+        assert!(err.to_string().contains("cannot be downgraded"));
+
+        let err = frontend
+            .run_sql("ALTER USER rwadmin RENAME TO rwadmin_renamed")
+            .await
+            .unwrap_err();
+        assert!(err.to_string().contains("cannot be renamed"));
+
+        let err = frontend
+            .run_user_sql(
+                "ALTER USER rwadmin WITH NOADMIN NOSUPERUSER",
+                DEFAULT_DATABASE_NAME.to_owned(),
+                DEFAULT_SUPER_USER_FOR_ADMIN.to_owned(),
+                DEFAULT_SUPER_USER_FOR_ADMIN_ID,
+            )
+            .await
+            .unwrap_err();
+        assert!(err.to_string().contains("cannot be altered"));
+    }
+
+    #[tokio::test]
     async fn test_alter_admin_user() {
         let frontend = LocalFrontend::new(Default::default()).await;
         let session = frontend.session_ref();

--- a/src/frontend/src/handler/drop_user.rs
+++ b/src/frontend/src/handler/drop_user.rs
@@ -113,6 +113,8 @@ pub async fn handle_drop_user(
 
 #[cfg(test)]
 mod tests {
+    use risingwave_common::catalog::DEFAULT_DATABASE_NAME;
+
     use crate::test_utils::LocalFrontend;
 
     #[tokio::test]
@@ -136,5 +138,59 @@ mod tests {
                 .get_user_by_name("user")
                 .is_none()
         );
+    }
+
+    #[tokio::test]
+    async fn test_createrole_requires_admin_option_to_drop_other_roles() {
+        let frontend = LocalFrontend::new(Default::default()).await;
+        let session = frontend.session_ref();
+
+        frontend
+            .run_sql("CREATE USER manager WITH CREATEROLE")
+            .await
+            .unwrap();
+        frontend.run_sql("CREATE USER target_user").await.unwrap();
+
+        let manager_id = frontend.user_by_name("manager").unwrap().id;
+        let err = frontend
+            .run_user_sql(
+                "DROP USER target_user",
+                DEFAULT_DATABASE_NAME.to_owned(),
+                "manager".to_owned(),
+                manager_id,
+            )
+            .await
+            .unwrap_err();
+        assert!(err.to_string().contains("ADMIN OPTION"));
+
+        frontend
+            .run_sql("GRANT target_user TO manager WITH ADMIN OPTION")
+            .await
+            .unwrap();
+        frontend
+            .run_user_sql(
+                "DROP USER target_user",
+                DEFAULT_DATABASE_NAME.to_owned(),
+                "manager".to_owned(),
+                manager_id,
+            )
+            .await
+            .unwrap();
+        assert!(
+            session
+                .env()
+                .user_info_reader()
+                .read_guard()
+                .get_user_by_name("target_user")
+                .is_none()
+        );
+    }
+
+    #[tokio::test]
+    async fn test_drop_user_rejects_default_admin_user_in_frontend() {
+        let frontend = LocalFrontend::new(Default::default()).await;
+
+        let err = frontend.run_sql("DROP USER rwadmin").await.unwrap_err();
+        assert!(err.to_string().contains("drop default super user"));
     }
 }

--- a/src/frontend/src/test_utils.rs
+++ b/src/frontend/src/test_utils.rs
@@ -91,6 +91,7 @@ use crate::meta_client::FrontendMetaClient;
 use crate::scheduler::HummockSnapshotManagerRef;
 use crate::session::{AuthContext, FrontendEnv, SessionImpl};
 use crate::user::UserId;
+use crate::user::user_catalog::UserCatalog;
 use crate::user::user_manager::UserInfoManager;
 use crate::user::user_service::UserInfoWriter;
 
@@ -228,6 +229,22 @@ impl LocalFrontend {
             .into(),
             Default::default(),
         ))
+    }
+
+    pub fn user_by_name(&self, user_name: &str) -> Option<UserCatalog> {
+        self.env
+            .user_info_reader()
+            .read_guard()
+            .get_user_by_name(user_name)
+            .cloned()
+    }
+
+    pub async fn role_memberships(&self) -> Vec<RoleMembership> {
+        self.env
+            .meta_client()
+            .list_all_role_memberships()
+            .await
+            .unwrap()
     }
 }
 
@@ -1021,6 +1038,7 @@ impl MockCatalogWriter {
 pub struct MockUserInfoWriter {
     id: AtomicU32,
     user_info: Arc<RwLock<UserInfoManager>>,
+    role_memberships: Arc<RwLock<Vec<RoleMembership>>>,
 }
 
 #[async_trait::async_trait]
@@ -1032,8 +1050,19 @@ impl UserInfoWriter for MockUserInfoWriter {
         Ok(())
     }
 
-    async fn drop_user(&self, id: UserId) -> Result<()> {
+    async fn drop_user(
+        &self,
+        id: UserId,
+        _dropped_by: UserId,
+        _session_user: UserId,
+    ) -> Result<()> {
         self.user_info.write().drop_user(id);
+        let user_id = id.as_raw_id();
+        self.role_memberships.write().retain(|membership| {
+            membership.role_id != user_id
+                && membership.member_id != user_id
+                && membership.granted_by != user_id
+        });
         Ok(())
     }
 
@@ -1108,6 +1137,100 @@ impl UserInfoWriter for MockUserInfoWriter {
         Ok(())
     }
 
+    async fn grant_role(
+        &self,
+        role_ids: Vec<UserId>,
+        member_ids: Vec<UserId>,
+        granted_by: UserId,
+        _executed_by: UserId,
+        _granted_by_specified: bool,
+        admin_option: Option<bool>,
+        inherit_option: Option<bool>,
+        set_option: Option<bool>,
+    ) -> Result<()> {
+        let mut memberships = self.role_memberships.write();
+
+        for role_id in role_ids {
+            for member_id in &member_ids {
+                let member_inherit = self
+                    .user_info
+                    .read()
+                    .get_user_by_id(member_id)
+                    .map(|user| user.can_inherit)
+                    .unwrap_or(true);
+                if let Some(existing) = memberships.iter_mut().find(|membership| {
+                    membership.role_id == role_id
+                        && membership.member_id == *member_id
+                        && membership.granted_by == granted_by
+                }) {
+                    existing.admin_option = admin_option.unwrap_or(existing.admin_option);
+                    existing.inherit_option = inherit_option.unwrap_or(existing.inherit_option);
+                    existing.set_option = set_option.unwrap_or(existing.set_option);
+                } else {
+                    let id = memberships
+                        .iter()
+                        .map(|membership| membership.id)
+                        .max()
+                        .unwrap_or(0)
+                        + 1;
+                    memberships.push(RoleMembership {
+                        role_id,
+                        member_id: *member_id,
+                        granted_by,
+                        admin_option: admin_option.unwrap_or(false),
+                        inherit_option: inherit_option.unwrap_or(member_inherit),
+                        set_option: set_option.unwrap_or(true),
+                        id,
+                    });
+                }
+            }
+        }
+        Ok(())
+    }
+
+    async fn revoke_role(
+        &self,
+        role_ids: Vec<UserId>,
+        member_ids: Vec<UserId>,
+        granted_by: UserId,
+        _granted_by_specified: bool,
+        _revoked_by: UserId,
+        revoke_admin_option: bool,
+        revoke_inherit_option: bool,
+        revoke_set_option: bool,
+        _cascade: bool,
+    ) -> Result<()> {
+        let role_ids = role_ids.into_iter().collect::<HashSet<_>>();
+        let member_ids = member_ids.into_iter().collect::<HashSet<_>>();
+        let option_only = revoke_admin_option || revoke_inherit_option || revoke_set_option;
+        let mut memberships = self.role_memberships.write();
+
+        if option_only {
+            for membership in memberships.iter_mut().filter(|membership| {
+                membership.granted_by == granted_by
+                    && role_ids.contains(&membership.role_id)
+                    && member_ids.contains(&membership.member_id)
+            }) {
+                if revoke_admin_option {
+                    membership.admin_option = false;
+                }
+                if revoke_inherit_option {
+                    membership.inherit_option = false;
+                }
+                if revoke_set_option {
+                    membership.set_option = false;
+                }
+            }
+        } else {
+            memberships.retain(|membership| {
+                membership.granted_by != granted_by
+                    || !role_ids.contains(&membership.role_id)
+                    || !member_ids.contains(&membership.member_id)
+            });
+        }
+        Ok(())
+    }
+
     async fn alter_default_privilege(
         &self,
         _users: Vec<UserId>,
@@ -1121,7 +1244,10 @@ impl UserInfoWriter for MockUserInfoWriter {
 }
 
 impl MockUserInfoWriter {
-    pub fn new(user_info: Arc<RwLock<UserInfoManager>>) -> Self {
+    pub fn new(
+        user_info: Arc<RwLock<UserInfoManager>>,
+        role_memberships: Arc<RwLock<Vec<RoleMembership>>>,
+    ) -> Self {
         user_info.write().create_user(UserInfo {
             id: DEFAULT_SUPER_USER_ID,
             name: DEFAULT_SUPER_USER.to_owned(),
@@ -1146,6 +1272,7 @@ impl MockUserInfoWriter {
         Self {
             user_info,
             id: AtomicU32::new(NON_RESERVED_USER_ID.as_raw_id()),
+            role_memberships,
         }
     }
 
@@ -1154,7 +1281,15 @@ impl MockUserInfoWriter {
     }
 }
 
-pub struct MockFrontendMetaClient {}
+pub struct MockFrontendMetaClient {
+    role_memberships: Arc<RwLock<Vec<RoleMembership>>>,
+}
+
+impl MockFrontendMetaClient {
+    pub fn new(role_memberships: Arc<RwLock<Vec<RoleMembership>>>) -> Self {
+        Self { role_memberships }
+    }
+}
 
 #[async_trait::async_trait]
 impl FrontendMetaClient for MockFrontendMetaClient {
@@ -1394,13 +1529,23 @@ impl FrontendMetaClient for MockFrontendMetaClient {
 
     async fn list_role_memberships(
         &self,
-        _member_ids: Vec<UserId>,
+        member_ids: Vec<UserId>,
     ) -> RpcResult<Vec<RoleMembership>> {
-        Ok(vec![])
+        let memberships = self.role_memberships.read();
+        if member_ids.is_empty() {
+            return Ok(memberships.clone());
+        }
+
+        let member_ids = member_ids.into_iter().collect::<HashSet<_>>();
+        Ok(memberships
+            .iter()
+            .filter(|membership| member_ids.contains(&membership.member_id))
+            .cloned()
+            .collect())
     }
 
     async fn list_all_role_memberships(&self) -> RpcResult<Vec<RoleMembership>> {
-        Ok(vec![])
+        Ok(self.role_memberships.read().clone())
     }
 
     async fn list_iceberg_compaction_status(&self) -> RpcResult<Vec<IcebergCompactionStatus>> {

--- a/src/frontend/tests/role_dispatch.rs
+++ b/src/frontend/tests/role_dispatch.rs
@@ -1,0 +1,449 @@
+// Copyright 2026 RisingWave Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use risingwave_common::catalog::{DEFAULT_DATABASE_NAME, DEFAULT_SUPER_USER_FOR_PG};
+use risingwave_frontend::test_utils::LocalFrontend;
+
+#[tokio::test]
+async fn test_create_alter_drop_role_dispatches_attributes() {
+    let frontend = LocalFrontend::new(Default::default()).await;
+
+    frontend.run_sql("CREATE ROLE analytics").await.unwrap();
+    let analytics = frontend.user_by_name("analytics").unwrap();
+    assert!(
+        !analytics.can_login,
+        "CREATE ROLE should default to NOLOGIN"
+    );
+    assert!(!analytics.is_super);
+    assert!(!analytics.can_create_db);
+    assert!(!analytics.can_create_user);
+
+    frontend
+        .run_sql("CREATE ROLE login_role WITH LOGIN PASSWORD 'secret'")
+        .await
+        .unwrap();
+    assert!(frontend.user_by_name("login_role").unwrap().can_login);
+
+    frontend
+        .run_sql("CREATE ROLE inherited_role WITH NOINHERIT")
+        .await
+        .unwrap();
+    assert!(!frontend.user_by_name("inherited_role").unwrap().can_inherit);
+
+    frontend
+        .run_sql("ALTER ROLE inherited_role WITH INHERIT")
+        .await
+        .unwrap();
+    assert!(frontend.user_by_name("inherited_role").unwrap().can_inherit);
+
+    frontend
+        .run_sql("ALTER ROLE analytics RENAME TO reporting")
+        .await
+        .unwrap();
+    assert!(frontend.user_by_name("analytics").is_none());
+    assert!(!frontend.user_by_name("reporting").unwrap().can_login);
+
+    frontend.run_sql("CREATE ROLE doomed_role").await.unwrap();
+    assert!(frontend.user_by_name("doomed_role").is_some());
+
+    frontend.run_sql("DROP ROLE doomed_role").await.unwrap();
+    assert!(frontend.user_by_name("doomed_role").is_none());
+}
+
+#[tokio::test]
+async fn test_grant_revoke_role_dispatches() {
+    let frontend = LocalFrontend::new(Default::default()).await;
+
+    frontend.run_sql("CREATE ROLE role_a").await.unwrap();
+    frontend
+        .run_sql("CREATE USER user_b WITH PASSWORD 'secret'")
+        .await
+        .unwrap();
+
+    frontend
+        .run_sql("GRANT role_a TO user_b WITH ADMIN OPTION")
+        .await
+        .unwrap();
+
+    let role_a = frontend.user_by_name("role_a").unwrap();
+    let user_b = frontend.user_by_name("user_b").unwrap();
+    let memberships = frontend.role_memberships().await;
+    assert_eq!(memberships.len(), 1);
+    assert_eq!(memberships[0].role_id, role_a.id.as_raw_id());
+    assert_eq!(memberships[0].member_id, user_b.id.as_raw_id());
+    assert!(memberships[0].admin_option);
+
+    frontend
+        .run_sql("REVOKE ADMIN OPTION FOR role_a FROM user_b")
+        .await
+        .unwrap();
+
+    let memberships = frontend.role_memberships().await;
+    assert_eq!(memberships.len(), 1);
+    assert!(!memberships[0].admin_option);
+
+    frontend.run_sql("REVOKE role_a FROM user_b").await.unwrap();
+
+    let memberships = frontend.role_memberships().await;
+    assert!(memberships.is_empty());
+}
+
+#[tokio::test]
+async fn test_grant_revoke_role_membership_options_dispatch() {
+    let frontend = LocalFrontend::new(Default::default()).await;
+
+    frontend.run_sql("CREATE ROLE role_a").await.unwrap();
+    frontend
+        .run_sql("CREATE USER user_b WITH PASSWORD 'secret'")
+        .await
+        .unwrap();
+
+    frontend
+        .run_sql("GRANT role_a TO user_b WITH INHERIT FALSE, SET FALSE")
+        .await
+        .unwrap();
+
+    let memberships = frontend.role_memberships().await;
+    assert_eq!(memberships.len(), 1);
+    assert!(!memberships[0].admin_option);
+    assert!(!memberships[0].inherit_option);
+    assert!(!memberships[0].set_option);
+
+    let user_id = frontend.user_by_name("user_b").unwrap().id;
+    let session = frontend.session_user_ref(
+        DEFAULT_DATABASE_NAME.to_owned(),
+        "user_b".to_owned(),
+        user_id,
+    );
+    let set_role_err = frontend
+        .run_sql_with_session(session.clone(), "SET ROLE role_a")
+        .await
+        .unwrap_err()
+        .to_string();
+    assert!(
+        set_role_err.contains("permission denied to set role"),
+        "unexpected error: {set_role_err}"
+    );
+}
+
+#[tokio::test]
+async fn test_granted_by_requires_set_option_to_possess_grantor_role() {
+    let frontend = LocalFrontend::new(Default::default()).await;
+
+    frontend.run_sql("CREATE ROLE parent_role").await.unwrap();
+    frontend.run_sql("CREATE ROLE grantor_role").await.unwrap();
+    frontend.run_sql("CREATE ROLE grantee_role").await.unwrap();
+    frontend
+        .run_sql("CREATE USER app_user WITH CREATEROLE PASSWORD 'secret'")
+        .await
+        .unwrap();
+    frontend
+        .run_sql("GRANT parent_role TO grantor_role WITH ADMIN OPTION")
+        .await
+        .unwrap();
+    frontend
+        .run_sql("GRANT grantor_role TO app_user WITH INHERIT TRUE, SET FALSE")
+        .await
+        .unwrap();
+
+    let app_user_id = frontend.user_by_name("app_user").unwrap().id;
+    let session = frontend.session_user_ref(
+        DEFAULT_DATABASE_NAME.to_owned(),
+        "app_user".to_owned(),
+        app_user_id,
+    );
+
+    let err = frontend
+        .run_sql_with_session(
+            session,
+            "GRANT parent_role TO grantee_role GRANTED BY grantor_role",
+        )
+        .await
+        .unwrap_err()
+        .to_string();
+    assert!(
+        err.contains("does not possess grantor role"),
+        "unexpected error: {err}"
+    );
+}
+
+#[tokio::test]
+async fn test_createrole_creator_gets_admin_option_on_created_role() {
+    let frontend = LocalFrontend::new(Default::default()).await;
+
+    frontend
+        .run_sql("CREATE USER manager WITH CREATEROLE PASSWORD 'secret'")
+        .await
+        .unwrap();
+    let manager_id = frontend.user_by_name("manager").unwrap().id;
+    let session = frontend.session_user_ref(
+        DEFAULT_DATABASE_NAME.to_owned(),
+        "manager".to_owned(),
+        manager_id,
+    );
+
+    frontend
+        .run_sql_with_session(session.clone(), "CREATE USER managed_user")
+        .await
+        .unwrap();
+
+    let managed_user = frontend.user_by_name("managed_user").unwrap();
+    let memberships = frontend.role_memberships().await;
+    let auto_admin_membership = memberships
+        .iter()
+        .find(|membership| {
+            membership.role_id == managed_user.id.as_raw_id()
+                && membership.member_id == manager_id.as_raw_id()
+        })
+        .expect("created role should be granted back to its CREATEROLE creator");
+    assert!(auto_admin_membership.admin_option);
+    assert!(!auto_admin_membership.inherit_option);
+    assert!(!auto_admin_membership.set_option);
+
+    frontend
+        .run_sql_with_session(
+            session.clone(),
+            "ALTER USER managed_user WITH PASSWORD 'rotated_password'",
+        )
+        .await
+        .unwrap();
+    frontend
+        .run_sql_with_session(session, "DROP USER managed_user")
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+async fn test_grant_revoke_role_granted_by_current_user_only() {
+    let frontend = LocalFrontend::new(Default::default()).await;
+
+    frontend.run_sql("CREATE ROLE role_a").await.unwrap();
+    frontend
+        .run_sql("CREATE USER user_b WITH PASSWORD 'secret'")
+        .await
+        .unwrap();
+
+    frontend
+        .run_sql("GRANT role_a TO user_b GRANTED BY root")
+        .await
+        .unwrap();
+    assert_eq!(frontend.role_memberships().await.len(), 1);
+
+    let err = frontend
+        .run_sql(&format!(
+            "GRANT role_a TO user_b GRANTED BY {DEFAULT_SUPER_USER_FOR_PG}"
+        ))
+        .await
+        .unwrap_err()
+        .to_string();
+    assert!(
+        err.contains(&format!(
+            "User \"{DEFAULT_SUPER_USER_FOR_PG}\" does not exist"
+        )),
+        "unexpected error: {err}"
+    );
+
+    frontend
+        .run_sql("REVOKE role_a FROM user_b GRANTED BY root")
+        .await
+        .unwrap();
+    assert!(frontend.role_memberships().await.is_empty());
+}
+
+#[tokio::test]
+async fn test_granted_by_current_role_uses_current_role_after_set_role() {
+    let frontend = LocalFrontend::new(Default::default()).await;
+    let session = frontend.session_ref();
+
+    frontend.run_sql("CREATE ROLE parent_role").await.unwrap();
+    frontend.run_sql("CREATE ROLE grantor_role").await.unwrap();
+    frontend.run_sql("CREATE ROLE grantee_role").await.unwrap();
+    frontend
+        .run_sql("GRANT parent_role TO grantor_role WITH ADMIN OPTION")
+        .await
+        .unwrap();
+
+    frontend
+        .run_sql_with_session(session.clone(), "SET ROLE grantor_role")
+        .await
+        .unwrap();
+    frontend
+        .run_sql_with_session(
+            session.clone(),
+            "GRANT parent_role TO grantee_role GRANTED BY current_role",
+        )
+        .await
+        .unwrap();
+
+    assert!(
+        frontend
+            .run_sql_with_session(
+                session.clone(),
+                "REVOKE parent_role FROM grantee_role GRANTED BY session_user",
+            )
+            .await
+            .is_err(),
+        "session_user must not be treated as current_role after SET ROLE"
+    );
+
+    frontend
+        .run_sql_with_session(
+            session.clone(),
+            "REVOKE parent_role FROM grantee_role GRANTED BY current_role",
+        )
+        .await
+        .unwrap();
+    frontend
+        .run_sql_with_session(session, "RESET ROLE")
+        .await
+        .unwrap();
+
+    let grantee_role = frontend.user_by_name("grantee_role").unwrap();
+    assert!(
+        frontend
+            .role_memberships()
+            .await
+            .iter()
+            .all(|membership| membership.member_id != grantee_role.id.as_raw_id()),
+        "current_role grant should be removable by current_role grantor"
+    );
+}
+
+#[tokio::test]
+async fn test_set_reset_role_dispatches_and_changes_identity() {
+    let frontend = LocalFrontend::new(Default::default()).await;
+
+    frontend.run_sql("CREATE ROLE analytics").await.unwrap();
+    frontend
+        .run_sql("CREATE USER app_user WITH PASSWORD 'secret'")
+        .await
+        .unwrap();
+    frontend
+        .run_sql("GRANT analytics TO app_user")
+        .await
+        .unwrap();
+
+    let user_id = frontend.user_by_name("app_user").unwrap().id;
+    let session = frontend.session_user_ref(
+        DEFAULT_DATABASE_NAME.to_owned(),
+        "app_user".to_owned(),
+        user_id,
+    );
+
+    let before = session.auth_context();
+    assert_eq!(before.session_user_name(), "app_user");
+    assert_eq!(before.current_user_name(), "app_user");
+
+    frontend
+        .run_sql_with_session(session.clone(), "SET ROLE analytics")
+        .await
+        .unwrap();
+
+    let after_set = session.auth_context();
+    assert_eq!(after_set.session_user_name(), "app_user");
+    assert_eq!(after_set.current_user_name(), "analytics");
+
+    frontend
+        .run_sql_with_session(session.clone(), "RESET ROLE")
+        .await
+        .unwrap();
+
+    let after_reset = session.auth_context();
+    assert_eq!(after_reset.session_user_name(), "app_user");
+    assert_eq!(after_reset.current_user_name(), "app_user");
+
+    frontend
+        .run_sql_with_session(session.clone(), "SET ROLE NONE")
+        .await
+        .unwrap();
+
+    let after_none = session.auth_context();
+    assert_eq!(after_none.session_user_name(), "app_user");
+    assert_eq!(after_none.current_user_name(), "app_user");
+
+    frontend
+        .run_sql_with_session(session.clone(), "SET LOCAL ROLE missing_role")
+        .await
+        .unwrap();
+    let after_implicit_local = session.auth_context();
+    assert_eq!(after_implicit_local.session_user_name(), "app_user");
+    assert_eq!(after_implicit_local.current_user_name(), "app_user");
+
+    frontend
+        .run_sql_with_session(session.clone(), "START TRANSACTION READ ONLY")
+        .await
+        .unwrap();
+    frontend
+        .run_sql_with_session(session.clone(), "SET LOCAL ROLE analytics")
+        .await
+        .unwrap();
+    let after_local = session.auth_context();
+    assert_eq!(after_local.session_user_name(), "app_user");
+    assert_eq!(after_local.current_user_name(), "analytics");
+    frontend
+        .run_sql_with_session(session.clone(), "COMMIT")
+        .await
+        .unwrap();
+    let after_local_commit = session.auth_context();
+    assert_eq!(after_local_commit.session_user_name(), "app_user");
+    assert_eq!(after_local_commit.current_user_name(), "app_user");
+}
+
+#[tokio::test]
+async fn test_superuser_set_role_uses_session_user_after_role_switch() {
+    let frontend = LocalFrontend::new(Default::default()).await;
+
+    frontend.run_sql("CREATE ROLE first_role").await.unwrap();
+    frontend.run_sql("CREATE ROLE second_role").await.unwrap();
+
+    let session = frontend.session_ref();
+    frontend
+        .run_sql_with_session(session.clone(), "SET ROLE first_role")
+        .await
+        .unwrap();
+    assert_eq!(session.auth_context().current_user_name(), "first_role");
+
+    frontend
+        .run_sql_with_session(session.clone(), "SET ROLE second_role")
+        .await
+        .unwrap();
+    assert_eq!(session.auth_context().current_user_name(), "second_role");
+}
+
+#[tokio::test]
+async fn test_set_role_requires_membership() {
+    let frontend = LocalFrontend::new(Default::default()).await;
+
+    frontend.run_sql("CREATE ROLE analytics").await.unwrap();
+    frontend
+        .run_sql("CREATE USER app_user_2 WITH PASSWORD 'secret'")
+        .await
+        .unwrap();
+
+    let user_id = frontend.user_by_name("app_user_2").unwrap().id;
+    let session = frontend.session_user_ref(
+        DEFAULT_DATABASE_NAME.to_owned(),
+        "app_user_2".to_owned(),
+        user_id,
+    );
+    let set_role_err = frontend
+        .run_sql_with_session(session, "SET ROLE analytics")
+        .await
+        .unwrap_err()
+        .to_string();
+    assert!(
+        set_role_err.contains("permission denied to set role"),
+        "unexpected error: {set_role_err}"
+    );
+}


### PR DESCRIPTION
Part of the re-cut RBAC stack.

This is the frontend/runtime regression-test slice. It restores the SQLLogicTest coverage that was too large for the parser-only PR and adds frontend dispatch tests for the role runtime.

Covers:
- core role membership e2e (`role_membership.slt`);
- INHERIT/SET membership option e2e (`role_membership_options.slt`);
- frontend dispatch/unit coverage for create/alter/drop role, grant/revoke role, GRANTED BY, SET ROLE/RESET ROLE;
- LocalFrontend role membership test helpers.

Local verification:
- `cargo fmt`
- `git diff --check origin/main ralph/rbac-v2-10-pg-catalog-compat`

No compile/build/e2e was run in this recut pass.
