### PR TITLE
feat: 8/10 add RBAC inherited privilege e2e

### DIFF
--- a/e2e_test/ddl/role_inherited_privilege.slt
+++ b/e2e_test/ddl/role_inherited_privilege.slt
@@ -1,0 +1,281 @@
+# Test that actual query privilege checks honor role inheritance, not only
+# pg_catalog.has_table_privilege.
+
+statement ok
+SET RW_IMPLICIT_FLUSH TO true;
+
+statement ok
+DROP TABLE IF EXISTS role_inherited_privilege_t;
+
+statement ok
+DROP TABLE IF EXISTS role_inherited_owner_t;
+
+statement ok
+DROP TABLE IF EXISTS role_inherited_multi_grantor_t;
+
+statement ok
+DROP ROLE IF EXISTS role_inherited_privilege_user;
+
+statement ok
+DROP ROLE IF EXISTS role_noinherit_privilege_user;
+
+statement ok
+DROP ROLE IF EXISTS role_inherited_privilege_app;
+
+statement ok
+DROP ROLE IF EXISTS role_inherited_privilege_select;
+
+statement ok
+DROP ROLE IF EXISTS role_inherited_privilege_update;
+
+statement ok
+DROP ROLE IF EXISTS role_inherited_privilege_target;
+
+statement ok
+DROP ROLE IF EXISTS role_inherited_privilege_delegator;
+
+statement ok
+DROP ROLE IF EXISTS role_inherited_privilege_grantable;
+
+statement ok
+DROP ROLE IF EXISTS role_inherited_privilege_owner;
+
+statement ok
+DROP ROLE IF EXISTS role_inherited_multi_grantor_owner;
+
+statement ok
+DROP ROLE IF EXISTS role_inherited_multi_grantor_grantable;
+
+statement ok
+DROP ROLE IF EXISTS role_inherited_multi_grantor_delegator;
+
+statement ok
+DROP ROLE IF EXISTS role_inherited_multi_grantor_target;
+
+statement ok
+CREATE TABLE role_inherited_privilege_t (id int PRIMARY KEY, v int);
+
+statement ok
+CREATE TABLE role_inherited_owner_t (id int PRIMARY KEY, v int);
+
+statement ok
+CREATE TABLE role_inherited_multi_grantor_t (id int PRIMARY KEY, v int);
+
+statement ok
+INSERT INTO role_inherited_privilege_t VALUES (1, 10), (2, 20);
+
+statement ok
+INSERT INTO role_inherited_owner_t VALUES (1, 100), (2, 200);
+
+statement ok
+INSERT INTO role_inherited_multi_grantor_t VALUES (1, 1000), (2, 2000);
+
+statement ok
+CREATE ROLE role_inherited_privilege_select;
+
+statement ok
+CREATE ROLE role_inherited_privilege_update;
+
+statement ok
+CREATE ROLE role_inherited_privilege_app;
+
+statement ok
+CREATE USER role_inherited_privilege_user WITH PASSWORD 'secret';
+
+statement ok
+CREATE USER role_noinherit_privilege_user WITH PASSWORD 'secret';
+
+statement ok
+CREATE ROLE role_inherited_privilege_grantable;
+
+statement ok
+CREATE ROLE role_inherited_privilege_owner;
+
+statement ok
+CREATE ROLE role_inherited_multi_grantor_owner;
+
+statement ok
+CREATE ROLE role_inherited_multi_grantor_grantable;
+
+statement ok
+CREATE USER role_inherited_privilege_delegator WITH PASSWORD 'secret';
+
+statement ok
+CREATE USER role_inherited_privilege_target WITH PASSWORD 'secret';
+
+statement ok
+CREATE USER role_inherited_multi_grantor_delegator WITH PASSWORD 'secret';
+
+statement ok
+CREATE USER role_inherited_multi_grantor_target WITH PASSWORD 'secret';
+
+statement ok
+ALTER TABLE role_inherited_owner_t OWNER TO role_inherited_privilege_owner;
+
+statement ok
+ALTER TABLE role_inherited_multi_grantor_t OWNER TO role_inherited_multi_grantor_owner;
+
+statement ok
+GRANT SELECT ON TABLE role_inherited_privilege_t TO role_inherited_privilege_select;
+
+statement ok
+GRANT SELECT ON TABLE role_inherited_privilege_t TO role_inherited_privilege_grantable WITH GRANT OPTION;
+
+statement ok
+GRANT SELECT ON TABLE role_inherited_multi_grantor_t TO role_inherited_multi_grantor_grantable WITH GRANT OPTION;
+
+statement ok
+GRANT UPDATE ON TABLE role_inherited_privilege_t TO role_inherited_privilege_update;
+
+statement ok
+GRANT role_inherited_privilege_select TO role_inherited_privilege_app;
+
+statement ok
+GRANT role_inherited_privilege_update TO role_inherited_privilege_app;
+
+statement ok
+GRANT role_inherited_privilege_grantable TO role_inherited_privilege_delegator;
+
+statement ok
+GRANT role_inherited_multi_grantor_grantable TO role_inherited_multi_grantor_delegator;
+
+statement ok
+GRANT role_inherited_privilege_owner TO role_inherited_privilege_delegator;
+
+statement ok
+GRANT role_inherited_privilege_app TO role_inherited_privilege_user;
+
+statement ok
+GRANT role_inherited_privilege_app TO role_noinherit_privilege_user WITH INHERIT FALSE;
+
+# Actual SELECT should also honor role-to-role inheritance after SET ROLE.
+statement ok
+SET ROLE role_inherited_privilege_app;
+
+query II
+SELECT id, v FROM role_inherited_privilege_t ORDER BY id;
+----
+1 10
+2 20
+
+statement ok
+UPDATE role_inherited_privilege_t SET v = v + 1 WHERE id = 1;
+
+statement ok
+RESET ROLE;
+
+query II
+SELECT id, v FROM role_inherited_privilege_t ORDER BY id;
+----
+1 11
+2 20
+
+# Actual SELECT/UPDATE should honor role-to-user inheritance for a login user.
+system ok
+PGPASSWORD=secret psql -h "$SLT_HOST" -p "$SLT_PORT" -d "$SLT_DB" -U role_inherited_privilege_user -v ON_ERROR_STOP=1 -At -c "SELECT count(*) FROM role_inherited_privilege_t WHERE id = 1 AND v = 11;" | grep -qx "1"
+
+system ok
+PGPASSWORD=secret psql -h "$SLT_HOST" -p "$SLT_PORT" -d "$SLT_DB" -U role_inherited_privilege_user -v ON_ERROR_STOP=1 -c "SET RW_IMPLICIT_FLUSH TO true; UPDATE role_inherited_privilege_t SET v = v + 1 WHERE id = 2;"
+
+query II
+SELECT id, v FROM role_inherited_privilege_t ORDER BY id;
+----
+1 11
+2 21
+
+# Inherited WITH GRANT OPTION should let a login user delegate object privileges.
+system ok
+PGPASSWORD=secret psql -h "$SLT_HOST" -p "$SLT_PORT" -d "$SLT_DB" -U role_inherited_privilege_delegator -v ON_ERROR_STOP=1 -c "GRANT SELECT ON TABLE role_inherited_privilege_t TO role_inherited_privilege_target;"
+
+system ok
+PGPASSWORD=secret psql -h "$SLT_HOST" -p "$SLT_PORT" -d "$SLT_DB" -U role_inherited_privilege_target -v ON_ERROR_STOP=1 -At -c "SELECT count(*) FROM role_inherited_privilege_t WHERE id = 2 AND v = 21;" | grep -qx "1"
+
+# The same inherited grant-option path should also revoke the grant recorded under the effective role.
+system ok
+PGPASSWORD=secret psql -h "$SLT_HOST" -p "$SLT_PORT" -d "$SLT_DB" -U role_inherited_privilege_delegator -v ON_ERROR_STOP=1 -c "REVOKE SELECT ON TABLE role_inherited_privilege_t FROM role_inherited_privilege_target;"
+
+system ok
+PGPASSWORD=secret psql -h "$SLT_HOST" -p "$SLT_PORT" -d "$SLT_DB" -U role_inherited_privilege_target -v ON_ERROR_STOP=1 -c "SELECT id, v FROM role_inherited_privilege_t ORDER BY id;" 2>&1 | grep -qi "permission denied"
+
+# Inherited object ownership should also grant and revoke through the effective owner role.
+system ok
+PGPASSWORD=secret psql -h "$SLT_HOST" -p "$SLT_PORT" -d "$SLT_DB" -U role_inherited_privilege_delegator -v ON_ERROR_STOP=1 -c "GRANT SELECT ON TABLE role_inherited_owner_t TO role_inherited_privilege_target;"
+
+system ok
+PGPASSWORD=secret psql -h "$SLT_HOST" -p "$SLT_PORT" -d "$SLT_DB" -U role_inherited_privilege_target -v ON_ERROR_STOP=1 -At -c "SELECT count(*) FROM role_inherited_owner_t WHERE id = 2 AND v = 200;" | grep -qx "1"
+
+system ok
+PGPASSWORD=secret psql -h "$SLT_HOST" -p "$SLT_PORT" -d "$SLT_DB" -U role_inherited_privilege_delegator -v ON_ERROR_STOP=1 -c "REVOKE SELECT ON TABLE role_inherited_owner_t FROM role_inherited_privilege_target;"
+
+system ok
+PGPASSWORD=secret psql -h "$SLT_HOST" -p "$SLT_PORT" -d "$SLT_DB" -U role_inherited_privilege_target -v ON_ERROR_STOP=1 -c "SELECT id, v FROM role_inherited_owner_t ORDER BY id;" 2>&1 | grep -qi "permission denied"
+
+# REVOKE should match every effective grantor the revoker can act as, not only
+# the first principal. The grant below is recorded under the grantable role;
+# after adding the owner role, the revoker can act as both owner and grantable.
+system ok
+PGPASSWORD=secret psql -h "$SLT_HOST" -p "$SLT_PORT" -d "$SLT_DB" -U role_inherited_multi_grantor_delegator -v ON_ERROR_STOP=1 -c "GRANT SELECT ON TABLE role_inherited_multi_grantor_t TO role_inherited_multi_grantor_target;"
+
+system ok
+PGPASSWORD=secret psql -h "$SLT_HOST" -p "$SLT_PORT" -d "$SLT_DB" -U role_inherited_multi_grantor_target -v ON_ERROR_STOP=1 -At -c "SELECT count(*) FROM role_inherited_multi_grantor_t WHERE id = 2 AND v = 2000;" | grep -qx "1"
+
+statement ok
+GRANT role_inherited_multi_grantor_owner TO role_inherited_multi_grantor_delegator;
+
+system ok
+PGPASSWORD=secret psql -h "$SLT_HOST" -p "$SLT_PORT" -d "$SLT_DB" -U role_inherited_multi_grantor_delegator -v ON_ERROR_STOP=1 -c "REVOKE SELECT ON TABLE role_inherited_multi_grantor_t FROM role_inherited_multi_grantor_target;"
+
+system ok
+PGPASSWORD=secret psql -h "$SLT_HOST" -p "$SLT_PORT" -d "$SLT_DB" -U role_inherited_multi_grantor_target -v ON_ERROR_STOP=1 -c "SELECT id, v FROM role_inherited_multi_grantor_t ORDER BY id;" 2>&1 | grep -qi "permission denied"
+
+# INHERIT FALSE remains a denial for implicit role-to-user privileges.
+system ok
+PGPASSWORD=secret psql -h "$SLT_HOST" -p "$SLT_PORT" -d "$SLT_DB" -U role_noinherit_privilege_user -v ON_ERROR_STOP=1 -c "SELECT id, v FROM role_inherited_privilege_t ORDER BY id;" 2>&1 | grep -qi "permission denied"
+
+statement ok
+DROP TABLE role_inherited_privilege_t;
+
+statement ok
+DROP TABLE role_inherited_owner_t;
+
+statement ok
+DROP TABLE role_inherited_multi_grantor_t;
+
+statement ok
+DROP ROLE role_inherited_privilege_user;
+
+statement ok
+DROP ROLE role_noinherit_privilege_user;
+
+statement ok
+DROP ROLE role_inherited_privilege_app;
+
+statement ok
+DROP ROLE role_inherited_privilege_select;
+
+statement ok
+DROP ROLE role_inherited_privilege_update;
+
+statement ok
+DROP ROLE role_inherited_privilege_target;
+
+statement ok
+DROP ROLE role_inherited_privilege_delegator;
+
+statement ok
+DROP ROLE role_inherited_privilege_grantable;
+
+statement ok
+DROP ROLE role_inherited_privilege_owner;
+
+statement ok
+DROP ROLE role_inherited_multi_grantor_owner;
+
+statement ok
+DROP ROLE role_inherited_multi_grantor_grantable;
+
+statement ok
+DROP ROLE role_inherited_multi_grantor_delegator;
+
+statement ok
+DROP ROLE role_inherited_multi_grantor_target;

--- a/src/frontend/src/binder/mod.rs
+++ b/src/frontend/src/binder/mod.rs
@@ -62,6 +62,7 @@ pub use relation::{
 // Re-export common types
 pub use risingwave_common::gap_fill::FillStrategy;
 use risingwave_common::id::ObjectId;
+use risingwave_pb::user::RoleMembership;
 pub use select::{BoundDistinct, BoundSelect};
 pub use set_expr::*;
 pub use statement::BoundStatement;
@@ -75,6 +76,7 @@ use crate::catalog::{CatalogResult, DatabaseId, SecretId, ViewId};
 use crate::error::ErrorCode;
 use crate::handler::privilege::ObjectCheckItem;
 use crate::session::{AuthContext, SessionImpl, StagingCatalogManager, TemporarySourceManager};
+use crate::user::effective_privilege::role_memberships_snapshot;
 use crate::user::user_service::UserInfoReadGuard;
 
 pub type ShareId = usize;
@@ -101,6 +103,7 @@ pub struct Binder {
     session_id: SessionId,
     context: BindContext,
     auth_context: Arc<AuthContext>,
+    role_memberships: Vec<RoleMembership>,
     /// A stack holding contexts of outer queries when binding a subquery.
     /// It also holds all of the lateral contexts for each respective
     /// subquery.
@@ -257,6 +260,9 @@ impl Binder {
             session_id: session.id(),
             context: BindContext::new(),
             auth_context: session.auth_context(),
+            role_memberships: role_memberships_snapshot(
+                session.env().role_membership_info_reader(),
+            ),
             upper_subquery_contexts: vec![],
             lateral_contexts: vec![],
             next_subquery_id: 0,

--- a/src/frontend/src/binder/relation/table_or_source.rs
+++ b/src/frontend/src/binder/relation/table_or_source.rs
@@ -37,6 +37,7 @@ use crate::catalog::{CatalogError, DatabaseId, IndexCatalog, TableId};
 use crate::error::ErrorCode::PermissionDenied;
 use crate::error::{ErrorCode, Result, RwError};
 use crate::handler::privilege::ObjectCheckItem;
+use crate::user::effective_privilege::catalog_user_has_privilege;
 
 #[derive(Debug, Clone)]
 pub struct BoundBaseTable {
@@ -299,23 +300,34 @@ impl Binder {
                     .into());
                 }
                 if let Some(user) = self.user.get_user_by_name(&self.auth_context.user_name) {
-                    if user.is_super || user.id == item.owner {
-                        return Ok(());
-                    }
-                    if !user.has_privilege(item.object, item.mode) {
+                    if !catalog_user_has_privilege(
+                        &self.user,
+                        user,
+                        &self.role_memberships,
+                        item.owner,
+                        item.object,
+                        item.mode,
+                    ) {
                         return Err(PermissionDenied(item.error_message()).into());
                     }
 
                     // check CONNECT privilege for cross-db access
-                    if self.database_id != database_id
-                        && !user.has_privilege(database_id, AclMode::Connect)
-                    {
-                        let db_name = self.catalog.get_database_by_id(database_id)?.name.clone();
-
-                        return Err(PermissionDenied(format!(
-                            "permission denied for database \"{db_name}\""
-                        ))
-                        .into());
+                    if self.database_id != database_id {
+                        let db = self.catalog.get_database_by_id(database_id)?;
+                        if !catalog_user_has_privilege(
+                            &self.user,
+                            user,
+                            &self.role_memberships,
+                            db.owner,
+                            database_id,
+                            AclMode::Connect,
+                        ) {
+                            return Err(PermissionDenied(format!(
+                                "permission denied for database \"{}\"",
+                                db.name
+                            ))
+                            .into());
+                        }
                     }
                 } else {
                     return Err(PermissionDenied("Session user is invalid".to_owned()).into());

--- a/src/frontend/src/user/effective_privilege.rs
+++ b/src/frontend/src/user/effective_privilege.rs
@@ -20,6 +20,7 @@ use risingwave_pb::user::RoleMembership;
 use crate::session::AuthContext;
 use crate::user::UserId;
 use crate::user::user_catalog::UserCatalog;
+use crate::user::user_manager::UserInfoManager;
 use crate::user::user_service::{RoleMembershipInfoReader, UserInfoReader};
 
 fn reachable_role_ids(
@@ -82,23 +83,10 @@ pub fn session_has_privilege(
 ) -> bool {
     let current_user_id = auth_context.current_user_id();
     let reader = user_info_reader.read_guard();
-    if let Some(user) = reader.get_user_by_id(&current_user_id)
-        && has_direct_privilege_for_catalog_user(user, owner, object, mode)
-    {
-        return true;
-    }
-
-    for role_id in reachable_role_ids([current_user_id], memberships, |membership| {
-        membership.inherit_option
-    }) {
-        let Some(role) = reader.get_user_by_id(&role_id) else {
-            continue;
-        };
-        if has_inherited_privilege_for_catalog_user(role, owner, object, mode) {
-            return true;
-        }
-    }
-    false
+    let Some(user) = reader.get_user_by_id(&current_user_id) else {
+        return false;
+    };
+    catalog_user_has_privilege(&reader, user, memberships, owner, object, mode)
 }
 
 #[allow(dead_code)]
@@ -111,6 +99,17 @@ pub fn principal_has_privilege(
     mode: AclMode,
 ) -> bool {
     let reader = user_info_reader.read_guard();
+    catalog_user_has_privilege(&reader, principal, memberships, owner, object, mode)
+}
+
+pub fn catalog_user_has_privilege(
+    user_info: &UserInfoManager,
+    principal: &UserCatalog,
+    memberships: &[RoleMembership],
+    owner: UserId,
+    object: impl Copy + Into<risingwave_pb::user::grant_privilege::Object>,
+    mode: AclMode,
+) -> bool {
     if has_direct_privilege_for_catalog_user(principal, owner, object, mode) {
         return true;
     }
@@ -118,7 +117,7 @@ pub fn principal_has_privilege(
     for role_id in reachable_role_ids([principal.id], memberships, |membership| {
         membership.inherit_option
     }) {
-        let Some(role) = reader.get_user_by_id(&role_id) else {
+        let Some(role) = user_info.get_user_by_id(&role_id) else {
             continue;
         };
         if has_inherited_privilege_for_catalog_user(role, owner, object, mode) {


### PR DESCRIPTION
Part of the re-cut RBAC stack.

This slice adds inherited privilege checks in the binder and the focused e2e proving that inherited role privileges work for table access.

Local verification:
- `cargo fmt`
- `git diff --check origin/main ralph/rbac-v2-10-pg-catalog-compat`

No compile/build/e2e was run in this recut pass.
