### PR TITLE
fix(sink): wait for async truncate before reading next item

### DIFF
--- a/src/stream/src/common/log_store_impl/in_mem.rs
+++ b/src/stream/src/common/log_store_impl/in_mem.rs
@@ -169,9 +169,9 @@ impl LogReader for BoundedInMemLogStoreReader {
     }
 
     async fn next_item(&mut self) -> LogStoreResult<(u64, LogStoreReadItem)> {
-        match self.item_rx.recv().await {
-            Some(item) => match self.epoch_progress {
-                Consuming(current_epoch) => match item {
+        match self.epoch_progress {
+            Consuming(current_epoch) => match self.item_rx.recv().await {
+                Some(item) => match item {
                     InMemLogStoreItem::StreamChunk(chunk) => {
                         let chunk_id = match self.latest_offset {
                             TruncateOffset::Chunk { epoch, chunk_id } => {
@@ -223,11 +223,9 @@ impl LogReader for BoundedInMemLogStoreReader {
                         ))
                     }
                 },
-                AwaitingTruncate { .. } => Err(anyhow!(
-                    "should not call next_item on checkpoint barrier for in-mem log store"
-                )),
+                None => Err(anyhow!("end of log stream")),
             },
-            None => Err(anyhow!("end of log stream")),
+            AwaitingTruncate { .. } => std::future::pending().await,
         }
     }
 

--- a/src/tests/simulation/tests/integration_tests/sink/basic.rs
+++ b/src/tests/simulation/tests/integration_tests/sink/basic.rs
@@ -14,7 +14,7 @@
 
 use std::sync::Arc;
 use std::sync::atomic::Ordering::Relaxed;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use anyhow::Result;
 use itertools::Itertools;
@@ -102,6 +102,54 @@ async fn basic_test_inner(is_decouple: bool, test_type: TestSinkType) -> Result<
     assert_eq!(0, test_sink.parallelism_counter.load(Relaxed));
     test_sink.store.check_simple_result(&test_source.id_list)?;
     assert!(test_sink.store.checkpoint_count() > 0);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_async_truncate_nondecouple_waits_for_checkpoint_truncate() -> Result<()> {
+    let mut cluster = start_sink_test_cluster().await?;
+
+    let source_parallelism = 1;
+    let test_sink = SimulationTestSink::register_new(TestSinkType::DelayedAsyncTruncate);
+    let test_source = SimulationTestSource::register_new(source_parallelism, 0..12, 1.0, 12);
+
+    let mut session = cluster.start_session();
+    session.run("set streaming_parallelism = 1").await?;
+    session.run("set sink_decouple = false").await?;
+    session.run(CREATE_SOURCE).await?;
+    session.run(CREATE_SINK).await?;
+    test_sink.wait_initial_parallelism(1).await?;
+
+    let expected_count = test_source.id_list.len();
+    let deadline = Instant::now() + Duration::from_secs(30);
+    loop {
+        let sink_fail_count = session
+            .run("select count(*) from rw_event_logs where event_type = 'SINK_FAIL'")
+            .await?
+            .trim()
+            .parse::<usize>()?;
+        assert!(
+            sink_fail_count == 0,
+            "unexpected sink failure while waiting for async truncate checkpoint progress"
+        );
+
+        if test_sink.store.id_count() == expected_count && test_sink.store.checkpoint_count() > 0 {
+            break;
+        }
+
+        assert!(
+            Instant::now() < deadline,
+            "timed out waiting for async truncate sink to finish without sink failure"
+        );
+        sleep(Duration::from_secs(1)).await;
+    }
+
+    session.run(DROP_SINK).await?;
+    session.run(DROP_SOURCE).await?;
+
+    assert_eq!(0, test_sink.parallelism_counter.load(Relaxed));
+    test_sink.store.check_simple_result(&test_source.id_list)?;
 
     Ok(())
 }

--- a/src/tests/simulation/tests/integration_tests/sink/utils.rs
+++ b/src/tests/simulation/tests/integration_tests/sink/utils.rs
@@ -482,6 +482,53 @@ impl Drop for AsyncTruncateTestWriter {
     }
 }
 
+pub struct DelayedAsyncTruncateTestWriter {
+    store: TestSinkStore,
+    parallelism_counter: Arc<AtomicUsize>,
+}
+
+impl AsyncTruncateSinkWriter for DelayedAsyncTruncateTestWriter {
+    type DeliveryFuture = impl TryFuture<Ok = (), Error = SinkError> + Unpin + Send + 'static;
+
+    async fn write_chunk<'a>(
+        &'a mut self,
+        chunk: StreamChunk,
+        mut add_future: DeliveryFutureManagerAddFuture<'a, Self::DeliveryFuture>,
+    ) -> risingwave_connector::sink::Result<()> {
+        for (op, row) in chunk.rows() {
+            assert_eq!(op, Op::Insert);
+            assert!(row.len() >= 2);
+            let id = row.datum_at(0).unwrap().into_int32();
+            let name = row.datum_at(1).unwrap().into_utf8().to_string();
+            let store = self.store.clone();
+            add_future
+                .add_future_may_await(
+                    async move {
+                        sleep(Duration::from_secs(2)).await;
+                        store.insert(id, name);
+                        Ok(())
+                    }
+                    .boxed(),
+                )
+                .await?;
+        }
+        Ok(())
+    }
+
+    async fn barrier(&mut self, is_checkpoint: bool) -> risingwave_connector::sink::Result<()> {
+        if is_checkpoint {
+            self.store.inc_checkpoint();
+        }
+        Ok(())
+    }
+}
+
+impl Drop for DelayedAsyncTruncateTestWriter {
+    fn drop(&mut self) {
+        self.parallelism_counter.fetch_sub(1, Relaxed);
+    }
+}
+
 pub fn simple_name_of_id(id: i32) -> String {
     format!("name-{}", id)
 }
@@ -498,6 +545,7 @@ pub enum TestSinkType {
     SinglePhaseCoordinatedSink,
     TwoPhaseCoordinatedSink,
     AsyncTruncate,
+    DelayedAsyncTruncate,
     RetainLog,
 }
 
@@ -656,6 +704,21 @@ impl SimulationTestSink {
                             store: store.clone(),
                             parallelism_counter: parallelism_counter.clone(),
                             err_rate: err_rate.clone(),
+                        }
+                        .into_log_sinker(10),
+                    );
+                    async move { Ok(log_sinker) }.boxed()
+                }
+            }),
+            TestSinkType::DelayedAsyncTruncate => register_build_sink({
+                let parallelism_counter = parallelism_counter.clone();
+                let store = store.clone();
+                move |_, _| {
+                    parallelism_counter.fetch_add(1, Relaxed);
+                    let log_sinker = risingwave_connector::sink::boxed::boxed_log_sinker(
+                        DelayedAsyncTruncateTestWriter {
+                            store: store.clone(),
+                            parallelism_counter: parallelism_counter.clone(),
                         }
                         .into_log_sinker(10),
                     );


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

This PR picks the async-truncate sink fix out of `wenym1/sink-error-table`.

For the bounded in-memory log store used by non-decouple sinks, `next_item` now stays pending after a checkpoint barrier while the reader is waiting for that barrier to be truncated. This avoids surfacing an error when an async truncate log sinker still has in-flight delivery futures and asks for the next item before checkpoint truncation completes.

The PR also adds a deterministic simulation regression test with a delayed async-truncate test sink. The test verifies a non-decouple sink can finish data delivery and checkpoint progress without producing a `SINK_FAIL` event.

## Checklist

- [ ] I have written necessary rustdoc comments.
- [x] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [x] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

Fixes a non-decouple sink progress issue where async-truncate sinks could fail after a checkpoint barrier instead of waiting for the checkpoint truncate to complete.

</details>

## Local verification

- `cargo test -p risingwave_stream common::log_store_impl::in_mem::tests::test_in_memory_log_store`
- `git diff --check`
- `cargo clippy --all-targets --all-features` was attempted, but the local filesystem ran out of space while writing incremental query caches.
