### PR TITLE
feat(sink): carry error rows in log store truncation

### DIFF
--- a/src/bench/sink_bench/main.rs
+++ b/src/bench/sink_bench/main.rs
@@ -130,7 +130,11 @@ impl LogReader for MockRangeLogReader {
         }
     }
 
-    fn truncate(&mut self, _offset: TruncateOffset) -> LogStoreResult<()> {
+    fn truncate(
+        &mut self,
+        _offset: TruncateOffset,
+        _error_rows: Vec<risingwave_connector::sink::log_store::ReportedSinkErrorRow>,
+    ) -> LogStoreResult<()> {
         Ok(())
     }
 

--- a/src/connector/src/sink/big_query.rs
+++ b/src/connector/src/sink/big_query.rs
@@ -175,7 +175,7 @@ impl LogSinker for BigQueryLogSinker {
         loop {
             tokio::select!(
                 offset = self.bigquery_future_manager.next_offset() => {
-                        log_reader.truncate(offset?)?;
+                        log_reader.truncate(offset?, vec![])?;
                 }
                 item_result = log_reader.next_item(), if self.bigquery_future_manager.offset_queue.len() <= self.future_num => {
                     let (epoch, item) = item_result?;

--- a/src/connector/src/sink/boxed.rs
+++ b/src/connector/src/sink/boxed.rs
@@ -18,7 +18,9 @@ use async_trait::async_trait;
 use futures::FutureExt;
 use futures::future::BoxFuture;
 
-use crate::sink::log_store::{LogStoreReadItem, LogStoreResult, TruncateOffset};
+use crate::sink::log_store::{
+    LogStoreReadItem, LogStoreResult, ReportedSinkErrorRow, TruncateOffset,
+};
 use crate::sink::{
     LogSinker, SinglePhaseCommitCoordinator, SinkLogReader, TwoPhaseCommitCoordinator,
 };
@@ -37,7 +39,11 @@ pub trait DynLogReader: Send {
     async fn dyn_start_from(&mut self, start_offset: Option<u64>) -> LogStoreResult<()>;
     async fn dyn_next_item(&mut self) -> LogStoreResult<(u64, LogStoreReadItem)>;
 
-    fn dyn_truncate(&mut self, offset: TruncateOffset) -> LogStoreResult<()>;
+    fn dyn_truncate(
+        &mut self,
+        offset: TruncateOffset,
+        error_rows: Vec<ReportedSinkErrorRow>,
+    ) -> LogStoreResult<()>;
 }
 
 #[async_trait]
@@ -50,8 +56,12 @@ impl<R: SinkLogReader> DynLogReader for R {
         R::next_item(self).await
     }
 
-    fn dyn_truncate(&mut self, offset: TruncateOffset) -> LogStoreResult<()> {
-        R::truncate(self, offset)
+    fn dyn_truncate(
+        &mut self,
+        offset: TruncateOffset,
+        error_rows: Vec<ReportedSinkErrorRow>,
+    ) -> LogStoreResult<()> {
+        R::truncate(self, offset, error_rows)
     }
 }
 
@@ -69,8 +79,12 @@ impl SinkLogReader for &mut dyn DynLogReader {
         (*self).dyn_next_item()
     }
 
-    fn truncate(&mut self, offset: TruncateOffset) -> LogStoreResult<()> {
-        (*self).dyn_truncate(offset)
+    fn truncate(
+        &mut self,
+        offset: TruncateOffset,
+        error_rows: Vec<ReportedSinkErrorRow>,
+    ) -> LogStoreResult<()> {
+        (*self).dyn_truncate(offset, error_rows)
     }
 }
 

--- a/src/connector/src/sink/coordinate.rs
+++ b/src/connector/src/sink/coordinate.rs
@@ -254,10 +254,10 @@ impl<W: SinkWriter<CommitMetadata = Option<SinkMetadata>>> LogSinker for Coordin
                                     sink_id = %self.param.sink_id,
                                     "coordinated log sinker stops"
                                 );
-                                log_reader.truncate(TruncateOffset::Barrier { epoch })?;
+                                log_reader.truncate(TruncateOffset::Barrier { epoch }, vec![])?;
                                 return pending().await;
                             }
-                            log_reader.truncate(TruncateOffset::Barrier { epoch })?;
+                            log_reader.truncate(TruncateOffset::Barrier { epoch }, vec![])?;
                         } else {
                             let metadata = sink_writer.barrier(false).await?;
                             if let Some(metadata) = metadata {

--- a/src/connector/src/sink/decouple_checkpoint_log_sink.rs
+++ b/src/connector/src/sink/decouple_checkpoint_log_sink.rs
@@ -151,7 +151,7 @@ impl<W: SinkWriter<CommitMetadata = ()>> LogSinker for DecoupleCheckpointLogSink
                             sink_writer_metrics
                                 .sink_commit_duration
                                 .observe(start_time.elapsed().as_secs_f64());
-                            log_reader.truncate(TruncateOffset::Barrier { epoch })?;
+                            log_reader.truncate(TruncateOffset::Barrier { epoch }, vec![])?;
 
                             current_checkpoint = 0;
                         } else {

--- a/src/connector/src/sink/file_sink/batching_log_sink.rs
+++ b/src/connector/src/sink/file_sink/batching_log_sink.rs
@@ -81,7 +81,7 @@ impl LogSinker for BatchingLogSinker {
                     if sink_writer.try_commit().await? {
                         // The file has been successfully written and is now visible to downstream consumers.
                         // Truncate up to this chunk, which also covers any preceding barriers.
-                        log_reader.truncate(TruncateOffset::Chunk { epoch, chunk_id })?;
+                        log_reader.truncate(TruncateOffset::Chunk { epoch, chunk_id }, vec![])?;
                     }
                 }
                 LogStoreReadItem::Barrier { .. } => {
@@ -95,7 +95,8 @@ impl LogSinker for BatchingLogSinker {
                     // 2. there is no pending data (no active writer), so the barrier can be safely discarded.
                     // This avoids accumulating barriers in the log store during idle periods with no data.
                     if sink_writer.try_commit().await? || !sink_writer.has_pending_data() {
-                        log_reader.truncate(TruncateOffset::Barrier { epoch: prev_epoch })?;
+                        log_reader
+                            .truncate(TruncateOffset::Barrier { epoch: prev_epoch }, vec![])?;
                     }
 
                     state = LogConsumerState::BarrierReceived { prev_epoch }

--- a/src/connector/src/sink/log_store.rs
+++ b/src/connector/src/sink/log_store.rs
@@ -14,7 +14,6 @@
 
 use std::cmp::Ordering;
 use std::collections::VecDeque;
-use std::fmt::Debug;
 use std::future::{Future, pending, poll_fn};
 use std::pin::pin;
 use std::sync::Arc;
@@ -24,10 +23,12 @@ use std::time::Instant;
 use await_tree::InstrumentAwait;
 use futures::future::BoxFuture;
 use futures::{TryFuture, TryFutureExt};
-use risingwave_common::array::StreamChunk;
+use risingwave_common::array::{Op, StreamChunk};
 use risingwave_common::bail;
 use risingwave_common::bitmap::Bitmap;
 use risingwave_common::metrics::{LabelGuardedIntCounter, LabelGuardedIntGauge};
+use risingwave_common::row::OwnedRow;
+use risingwave_common::types::JsonbVal;
 use risingwave_common::util::epoch::{EpochPair, INVALID_EPOCH};
 use risingwave_common_estimate_size::EstimateSize;
 use risingwave_common_rate_limit::{RateLimit, RateLimiter};
@@ -155,6 +156,19 @@ pub struct FlushCurrentEpochOptions {
     pub wait_log_store_flush: bool,
 }
 
+#[derive(Clone, Debug, PartialEq)]
+pub struct ReportedSinkErrorRow {
+    pub epoch: u64,
+    pub op: Op,
+    pub row: OwnedRow,
+    pub extra_info: Option<JsonbVal>,
+}
+
+pub struct FlushCurrentEpochResult<'a> {
+    pub post_flush: LogWriterPostFlushCurrentEpoch<'a>,
+    pub reported_error_rows: Vec<ReportedSinkErrorRow>,
+}
+
 pub trait LogWriter: Send {
     /// Initialize the log writer with an epoch
     fn init(
@@ -174,7 +188,7 @@ pub trait LogWriter: Send {
         &mut self,
         next_epoch: u64,
         options: FlushCurrentEpochOptions,
-    ) -> impl Future<Output = LogStoreResult<LogWriterPostFlushCurrentEpoch<'_>>> + Send + '_;
+    ) -> impl Future<Output = LogStoreResult<FlushCurrentEpochResult<'_>>> + Send + '_;
 
     fn pause(&mut self) -> LogStoreResult<()>;
 
@@ -200,7 +214,11 @@ pub trait LogReader: Send + Sized + 'static {
 
     /// Mark that all items emitted so far have been consumed and it is safe to truncate the log
     /// from the current offset.
-    fn truncate(&mut self, offset: TruncateOffset) -> LogStoreResult<()>;
+    fn truncate(
+        &mut self,
+        offset: TruncateOffset,
+        error_rows: Vec<ReportedSinkErrorRow>,
+    ) -> LogStoreResult<()>;
 
     /// Reset the log reader to after the latest truncate offset
     ///
@@ -255,8 +273,12 @@ impl<F: Fn(StreamChunk) -> StreamChunk + Send + 'static, R: LogReader> LogReader
         Ok((epoch, item))
     }
 
-    fn truncate(&mut self, offset: TruncateOffset) -> LogStoreResult<()> {
-        self.inner.truncate(offset)
+    fn truncate(
+        &mut self,
+        offset: TruncateOffset,
+        error_rows: Vec<ReportedSinkErrorRow>,
+    ) -> LogStoreResult<()> {
+        self.inner.truncate(offset, error_rows)
     }
 
     fn rewind(&mut self) -> impl Future<Output = LogStoreResult<()>> + Send + '_ {
@@ -285,26 +307,42 @@ impl<R: LogReader> LogReader for TruncateBarrierLogReader<R> {
         Ok((epoch, item))
     }
 
-    fn truncate(&mut self, offset: TruncateOffset) -> LogStoreResult<()> {
+    fn truncate(
+        &mut self,
+        offset: TruncateOffset,
+        mut error_rows: Vec<ReportedSinkErrorRow>,
+    ) -> LogStoreResult<()> {
         while let Some(front_epoch) = self.pending_barriers.front().copied() {
             match (TruncateOffset::Barrier { epoch: front_epoch }).cmp(&offset) {
                 Ordering::Less => {
-                    self.inner
-                        .truncate(TruncateOffset::Barrier { epoch: front_epoch })?;
+                    let mut remaining_error_rows = Vec::with_capacity(error_rows.len());
+                    let mut barrier_error_rows = vec![];
+                    for error_row in error_rows {
+                        if error_row.epoch <= front_epoch {
+                            barrier_error_rows.push(error_row);
+                        } else {
+                            remaining_error_rows.push(error_row);
+                        }
+                    }
+                    error_rows = remaining_error_rows;
+                    self.inner.truncate(
+                        TruncateOffset::Barrier { epoch: front_epoch },
+                        barrier_error_rows,
+                    )?;
                     self.pending_barriers.pop_front();
                 }
                 Ordering::Equal => {
-                    self.inner.truncate(offset)?;
+                    self.inner.truncate(offset, error_rows)?;
                     self.pending_barriers.pop_front();
                     return Ok(());
                 }
                 Ordering::Greater => {
-                    self.inner.truncate(offset)?;
+                    self.inner.truncate(offset, error_rows)?;
                     return Ok(());
                 }
             }
         }
-        self.inner.truncate(offset)?;
+        self.inner.truncate(offset, error_rows)?;
         Ok(())
     }
 
@@ -355,8 +393,12 @@ impl<R: LogReader> LogReader for BackpressureMonitoredLogReader<R> {
         })
     }
 
-    fn truncate(&mut self, offset: TruncateOffset) -> LogStoreResult<()> {
-        self.inner.truncate(offset)
+    fn truncate(
+        &mut self,
+        offset: TruncateOffset,
+        error_rows: Vec<ReportedSinkErrorRow>,
+    ) -> LogStoreResult<()> {
+        self.inner.truncate(offset, error_rows)
     }
 
     fn rewind(&mut self) -> impl Future<Output = LogStoreResult<()>> + Send + '_ {
@@ -422,8 +464,12 @@ impl<R: LogReader> LogReader for MonitoredLogReader<R> {
             })
     }
 
-    fn truncate(&mut self, offset: TruncateOffset) -> LogStoreResult<()> {
-        self.inner.truncate(offset)
+    fn truncate(
+        &mut self,
+        offset: TruncateOffset,
+        error_rows: Vec<ReportedSinkErrorRow>,
+    ) -> LogStoreResult<()> {
+        self.inner.truncate(offset, error_rows)
     }
 
     fn rewind(&mut self) -> impl Future<Output = LogStoreResult<()>> + Send + '_ {
@@ -443,16 +489,26 @@ struct UpstreamChunkOffset(TruncateOffset);
 #[derive(Copy, Clone, PartialOrd, PartialEq)]
 struct DownstreamChunkOffset(TruncateOffset);
 
+struct ConsumedOffsets {
+    upstream_offset: UpstreamChunkOffset,
+    // Newer items at the front, push_front, pop_back
+    downstream_offsets: VecDeque<DownstreamChunkOffset>,
+    reported_error_rows: Vec<ReportedSinkErrorRow>,
+}
+
+struct ConsumingChunk {
+    upstream_offset: UpstreamChunkOffset,
+    // Newer items at the front, push_front, pop_back
+    downstream_offsets: VecDeque<DownstreamChunkOffset>,
+    pending_chunks: Vec<StreamChunk>,
+    reported_error_rows: Vec<ReportedSinkErrorRow>,
+}
+
 struct RateLimitedLogReaderCore<R: LogReader> {
     inner: R,
-    consuming_chunk: Option<(
-        UpstreamChunkOffset,
-        // Newer items at the front, push_front, pop_back
-        VecDeque<DownstreamChunkOffset>,
-        Vec<StreamChunk>, // split chunks
-    )>,
+    consuming_chunk: Option<ConsumingChunk>,
     // Newer items at the front, push_front, pop_back
-    consumed_offset_queue: VecDeque<(UpstreamChunkOffset, VecDeque<DownstreamChunkOffset>)>,
+    consumed_offset_queue: VecDeque<ConsumedOffsets>,
     next_chunk_id: usize,
     rate_limiter: RateLimiter,
 }
@@ -481,30 +537,38 @@ impl<R: LogReader> RateLimitedLogReaderCore<R> {
     fn peek_next_pending_chunk(&self) -> Option<&StreamChunk> {
         self.consuming_chunk
             .as_ref()
-            .and_then(|(_, _, chunk)| chunk.last())
+            .and_then(|chunk| chunk.pending_chunks.last())
     }
 
     fn consume_next_pending_chunk(&mut self) -> Option<(u64, StreamChunk, ChunkId)> {
-        let Some((upstream_offset, consumed_offsets, pending_chunk)) = &mut self.consuming_chunk
-        else {
+        let Some(consuming_chunk) = &mut self.consuming_chunk else {
             return None;
         };
-        let epoch = upstream_offset.0.epoch();
+        let epoch = consuming_chunk.upstream_offset.0.epoch();
 
-        let item = pending_chunk.pop().map(|chunk| {
+        let item = consuming_chunk.pending_chunks.pop().map(|chunk| {
             let chunk_id = self.next_chunk_id;
             self.next_chunk_id += 1;
-            consumed_offsets.push_front(DownstreamChunkOffset(TruncateOffset::Chunk {
-                epoch,
-                chunk_id,
-            }));
+            consuming_chunk
+                .downstream_offsets
+                .push_front(DownstreamChunkOffset(TruncateOffset::Chunk {
+                    epoch,
+                    chunk_id,
+                }));
             (epoch, chunk, chunk_id)
         });
-        if pending_chunk.is_empty() {
-            let (upstream_offset, consumed_offsets, _) =
-                self.consuming_chunk.take().expect("checked some");
-            self.consumed_offset_queue
-                .push_front((upstream_offset, consumed_offsets));
+        if consuming_chunk.pending_chunks.is_empty() {
+            let ConsumingChunk {
+                upstream_offset,
+                downstream_offsets,
+                pending_chunks: _,
+                reported_error_rows,
+            } = self.consuming_chunk.take().expect("checked some");
+            self.consumed_offset_queue.push_front(ConsumedOffsets {
+                upstream_offset,
+                downstream_offsets,
+                reported_error_rows,
+            });
         }
         item
     }
@@ -537,8 +601,11 @@ impl<R: LogReader> RateLimitedLogReaderCore<R> {
                 DownstreamChunkOffset(TruncateOffset::Barrier { epoch }),
             ),
         };
-        self.consumed_offset_queue
-            .push_front((upstream_offset, VecDeque::from_iter([downstream_offset])));
+        self.consumed_offset_queue.push_front(ConsumedOffsets {
+            upstream_offset,
+            downstream_offsets: VecDeque::from_iter([downstream_offset]),
+            reported_error_rows: vec![],
+        });
         (epoch, item)
     }
 
@@ -570,14 +637,14 @@ impl<R: LogReader> RateLimitedLogReaderCore<R> {
 
                             assert!(
                                 self.consuming_chunk
-                                    .replace((
-                                        UpstreamChunkOffset(TruncateOffset::Chunk {
-                                            epoch,
-                                            chunk_id
-                                        }),
-                                        VecDeque::new(),
-                                        chunks,
-                                    ))
+                                    .replace(ConsumingChunk {
+                                        upstream_offset: UpstreamChunkOffset(
+                                            TruncateOffset::Chunk { epoch, chunk_id },
+                                        ),
+                                        downstream_offsets: VecDeque::new(),
+                                        pending_chunks: chunks,
+                                        reported_error_rows: vec![],
+                                    })
                                     .is_none()
                             );
                         }
@@ -621,32 +688,68 @@ impl<R: LogReader> LogReader for RateLimitedLogReader<R> {
         }
     }
 
-    fn truncate(&mut self, offset: TruncateOffset) -> LogStoreResult<()> {
+    fn truncate(
+        &mut self,
+        offset: TruncateOffset,
+        error_rows: Vec<ReportedSinkErrorRow>,
+    ) -> LogStoreResult<()> {
         let downstream_offset = DownstreamChunkOffset(offset);
         let mut truncate_offset = None;
+        let mut pending_error_rows = error_rows;
+        let mut truncate_error_rows = vec![];
         let mut stop = false;
-        'outer: while let Some((upstream_offset, downstream_offsets)) =
-            self.core.consumed_offset_queue.back_mut()
-        {
-            while let Some(prev_downstream_offset) = downstream_offsets.back() {
+        'outer: while let Some(consumed_offsets) = self.core.consumed_offset_queue.back_mut() {
+            while let Some(prev_downstream_offset) = consumed_offsets.downstream_offsets.back() {
                 if *prev_downstream_offset <= downstream_offset {
-                    downstream_offsets.pop_back();
+                    consumed_offsets.downstream_offsets.pop_back();
+                    if !pending_error_rows.is_empty() {
+                        consumed_offsets
+                            .reported_error_rows
+                            .append(&mut pending_error_rows);
+                    }
                 } else {
                     stop = true;
                     break 'outer;
                 }
             }
-            truncate_offset = Some(*upstream_offset);
-            self.core.consumed_offset_queue.pop_back();
+            if consumed_offsets.downstream_offsets.is_empty() {
+                let consumed_offsets = self
+                    .core
+                    .consumed_offset_queue
+                    .pop_back()
+                    .expect("checked some");
+                truncate_offset = Some(consumed_offsets.upstream_offset);
+                truncate_error_rows.extend(consumed_offsets.reported_error_rows);
+            } else {
+                break;
+            }
         }
-        if !stop && let Some((_, downstream_offsets, _)) = &mut self.core.consuming_chunk {
+        if !stop
+            && let Some(ConsumingChunk {
+                downstream_offsets,
+                reported_error_rows,
+                ..
+            }) = &mut self.core.consuming_chunk
+        {
             while let Some(prev_downstream_offset) = downstream_offsets.back() {
                 if *prev_downstream_offset <= downstream_offset {
                     downstream_offsets.pop_back();
+                    if !pending_error_rows.is_empty() {
+                        reported_error_rows.append(&mut pending_error_rows);
+                    }
                 } else {
-                    // stop = true;
                     break;
                 }
+            }
+            if downstream_offsets.is_empty() {
+                let ConsumingChunk {
+                    upstream_offset,
+                    downstream_offsets: _,
+                    pending_chunks: _,
+                    reported_error_rows,
+                } = self.core.consuming_chunk.take().expect("checked some");
+                truncate_offset = Some(upstream_offset);
+                truncate_error_rows.extend(reported_error_rows);
             }
         }
         tracing::trace!(
@@ -655,7 +758,7 @@ impl<R: LogReader> LogReader for RateLimitedLogReader<R> {
             offset
         );
         if let Some(offset) = truncate_offset {
-            self.core.inner.truncate(offset.0)
+            self.core.inner.truncate(offset.0, truncate_error_rows)
         } else {
             Ok(())
         }
@@ -740,12 +843,15 @@ impl<W: LogWriter> LogWriter for MonitoredLogWriter<W> {
         &mut self,
         next_epoch: u64,
         options: FlushCurrentEpochOptions,
-    ) -> LogStoreResult<LogWriterPostFlushCurrentEpoch<'_>> {
-        let post_flush = self.inner.flush_current_epoch(next_epoch, options).await?;
+    ) -> LogStoreResult<FlushCurrentEpochResult<'_>> {
+        let mut result = self.inner.flush_current_epoch(next_epoch, options).await?;
         self.metrics
             .log_store_latest_write_epoch
             .set(next_epoch as _);
-        Ok(post_flush)
+        Ok(FlushCurrentEpochResult {
+            post_flush: result.post_flush,
+            reported_error_rows: std::mem::take(&mut result.reported_error_rows),
+        })
     }
 
     fn pause(&mut self) -> LogStoreResult<()> {
@@ -959,17 +1065,19 @@ mod tests {
     use std::task::Poll;
 
     use futures::{FutureExt, TryFuture};
-    use risingwave_common::array::StreamChunk;
+    use risingwave_common::array::{Op, StreamChunk};
+    use risingwave_common::row::OwnedRow;
+    use risingwave_common::types::ScalarImpl;
     use risingwave_common::util::epoch::test_epoch;
     use tokio::sync::oneshot;
     use tokio::sync::oneshot::Receiver;
 
     use super::{LogReader, LogStoreReadItem, LogStoreResult, TruncateBarrierLogReader};
-    use crate::sink::log_store::{DeliveryFutureManager, TruncateOffset};
+    use crate::sink::log_store::{DeliveryFutureManager, ReportedSinkErrorRow, TruncateOffset};
 
     struct MockLogReader {
         items: VecDeque<(u64, LogStoreReadItem)>,
-        truncate_calls: Vec<TruncateOffset>,
+        truncate_calls: Vec<(TruncateOffset, Vec<ReportedSinkErrorRow>)>,
     }
 
     impl MockLogReader {
@@ -996,8 +1104,12 @@ mod tests {
                 .ok_or_else(|| anyhow::anyhow!("no item"))
         }
 
-        fn truncate(&mut self, offset: TruncateOffset) -> LogStoreResult<()> {
-            self.truncate_calls.push(offset);
+        fn truncate(
+            &mut self,
+            offset: TruncateOffset,
+            error_rows: Vec<ReportedSinkErrorRow>,
+        ) -> LogStoreResult<()> {
+            self.truncate_calls.push((offset, error_rows));
             Ok(())
         }
 
@@ -1061,6 +1173,15 @@ mod tests {
     #[define_opaque(TestFuture)]
     fn to_test_future(rx: Receiver<LogStoreResult<()>>) -> TestFuture {
         async move { rx.await.unwrap() }.boxed()
+    }
+
+    fn test_error_row(epoch: u64, value: i64) -> ReportedSinkErrorRow {
+        ReportedSinkErrorRow {
+            epoch,
+            op: Op::Insert,
+            row: OwnedRow::new(vec![Some(ScalarImpl::Int64(value))]),
+            extra_info: None,
+        }
     }
 
     #[tokio::test]
@@ -1327,14 +1448,23 @@ mod tests {
         reader.next_item().await.unwrap();
         reader.next_item().await.unwrap();
         reader
-            .truncate(TruncateOffset::Barrier { epoch: 2 })
+            .truncate(
+                TruncateOffset::Barrier { epoch: 2 },
+                vec![test_error_row(1, 1), test_error_row(2, 2)],
+            )
             .unwrap();
 
         assert_eq!(
             reader.inner.truncate_calls,
             vec![
-                TruncateOffset::Barrier { epoch: 1 },
-                TruncateOffset::Barrier { epoch: 2 },
+                (
+                    TruncateOffset::Barrier { epoch: 1 },
+                    vec![test_error_row(1, 1)],
+                ),
+                (
+                    TruncateOffset::Barrier { epoch: 2 },
+                    vec![test_error_row(2, 2)],
+                ),
             ]
         );
     }
@@ -1376,35 +1506,44 @@ mod tests {
         reader.next_item().await.unwrap();
         reader.next_item().await.unwrap();
         reader
-            .truncate(TruncateOffset::Chunk {
-                epoch: 2,
-                chunk_id: 0,
-            })
+            .truncate(
+                TruncateOffset::Chunk {
+                    epoch: 2,
+                    chunk_id: 0,
+                },
+                vec![],
+            )
             .unwrap();
 
         assert_eq!(
             reader.inner.truncate_calls,
             vec![
-                TruncateOffset::Barrier { epoch: 1 },
-                TruncateOffset::Chunk {
-                    epoch: 2,
-                    chunk_id: 0,
-                },
+                (TruncateOffset::Barrier { epoch: 1 }, vec![]),
+                (
+                    TruncateOffset::Chunk {
+                        epoch: 2,
+                        chunk_id: 0,
+                    },
+                    vec![],
+                ),
             ]
         );
 
         reader
-            .truncate(TruncateOffset::Barrier { epoch: 2 })
+            .truncate(TruncateOffset::Barrier { epoch: 2 }, vec![])
             .unwrap();
         assert_eq!(
             reader.inner.truncate_calls,
             vec![
-                TruncateOffset::Barrier { epoch: 1 },
-                TruncateOffset::Chunk {
-                    epoch: 2,
-                    chunk_id: 0,
-                },
-                TruncateOffset::Barrier { epoch: 2 },
+                (TruncateOffset::Barrier { epoch: 1 }, vec![]),
+                (
+                    TruncateOffset::Chunk {
+                        epoch: 2,
+                        chunk_id: 0,
+                    },
+                    vec![],
+                ),
+                (TruncateOffset::Barrier { epoch: 2 }, vec![]),
             ]
         );
     }

--- a/src/connector/src/sink/mod.rs
+++ b/src/connector/src/sink/mod.rs
@@ -114,7 +114,9 @@ use crate::sink::catalog::desc::SinkDesc;
 use crate::sink::catalog::{SinkCatalog, SinkId};
 use crate::sink::decouple_checkpoint_log_sink::ICEBERG_DEFAULT_COMMIT_CHECKPOINT_INTERVAL;
 use crate::sink::file_sink::fs::FsSink;
-use crate::sink::log_store::{LogReader, LogStoreReadItem, LogStoreResult, TruncateOffset};
+use crate::sink::log_store::{
+    LogReader, LogStoreReadItem, LogStoreResult, ReportedSinkErrorRow, TruncateOffset,
+};
 use crate::sink::snowflake_redshift::snowflake::SNOWFLAKE_SINK_V2;
 use crate::sink::utils::feature_gated_sink_mod;
 
@@ -868,7 +870,11 @@ pub trait SinkLogReader: Send {
 
     /// Mark that all items emitted so far have been consumed and it is safe to truncate the log
     /// from the current offset.
-    fn truncate(&mut self, offset: TruncateOffset) -> LogStoreResult<()>;
+    fn truncate(
+        &mut self,
+        offset: TruncateOffset,
+        error_rows: Vec<ReportedSinkErrorRow>,
+    ) -> LogStoreResult<()>;
 }
 
 impl<R: LogReader> SinkLogReader for &mut R {
@@ -878,8 +884,12 @@ impl<R: LogReader> SinkLogReader for &mut R {
         <R as LogReader>::next_item(*self)
     }
 
-    fn truncate(&mut self, offset: TruncateOffset) -> LogStoreResult<()> {
-        <R as LogReader>::truncate(*self, offset)
+    fn truncate(
+        &mut self,
+        offset: TruncateOffset,
+        error_rows: Vec<ReportedSinkErrorRow>,
+    ) -> LogStoreResult<()> {
+        <R as LogReader>::truncate(*self, offset, error_rows)
     }
 
     fn start_from(

--- a/src/connector/src/sink/postgres.rs
+++ b/src/connector/src/sink/postgres.rs
@@ -551,10 +551,10 @@ impl LogSinker for PostgresSinkWriter {
             match item {
                 LogStoreReadItem::StreamChunk { chunk, chunk_id } => {
                     self.write_batch(chunk).await?;
-                    log_reader.truncate(TruncateOffset::Chunk { epoch, chunk_id })?;
+                    log_reader.truncate(TruncateOffset::Chunk { epoch, chunk_id }, vec![])?;
                 }
                 LogStoreReadItem::Barrier { .. } => {
-                    log_reader.truncate(TruncateOffset::Barrier { epoch })?;
+                    log_reader.truncate(TruncateOffset::Barrier { epoch }, vec![])?;
                 }
             }
         }

--- a/src/connector/src/sink/remote.rs
+++ b/src/connector/src/sink/remote.rs
@@ -384,7 +384,7 @@ impl LogSinker for RemoteLogSinker {
                         .observe(start_time.elapsed().as_secs_f64());
                 }
 
-                log_reader.truncate(persisted_offset)?;
+                log_reader.truncate(persisted_offset, vec![])?;
                 Ok(())
             }
 

--- a/src/connector/src/sink/trivial.rs
+++ b/src/connector/src/sink/trivial.rs
@@ -128,7 +128,7 @@ impl<T: TrivialSinkType> LogSinker for TrivialSink<T> {
                         );
                     }
 
-                    log_reader.truncate(TruncateOffset::Chunk { epoch, chunk_id })?;
+                    log_reader.truncate(TruncateOffset::Chunk { epoch, chunk_id }, vec![])?;
                 }
                 LogStoreReadItem::Barrier { schema_change, .. } => {
                     if T::TRACE_LOG {
@@ -144,7 +144,7 @@ impl<T: TrivialSinkType> LogSinker for TrivialSink<T> {
                         info!(?schema_change, "trivial sink receive schema change");
                     }
 
-                    log_reader.truncate(TruncateOffset::Barrier { epoch })?;
+                    log_reader.truncate(TruncateOffset::Barrier { epoch }, vec![])?;
                 }
             }
         }

--- a/src/connector/src/sink/turbopuffer.rs
+++ b/src/connector/src/sink/turbopuffer.rs
@@ -336,7 +336,7 @@ impl TurbopufferLogSinker {
             .observe(start_time.elapsed().as_secs_f64());
         linger_timer.as_mut().set(None);
         if let Some(offset) = latest_truncate_offset.take() {
-            log_reader.truncate(offset)?;
+            log_reader.truncate(offset, vec![])?;
         }
         Ok(())
     }
@@ -397,7 +397,7 @@ impl LogSinker for TurbopufferLogSinker {
                         schema_change.is_some(),
                     );
                     if self.writer.is_empty() {
-                        log_reader.truncate(offset)?;
+                        log_reader.truncate(offset, vec![])?;
                     } else if should_flush {
                         latest_truncate_offset = Some(offset);
                         self.flush_all_and_truncate(
@@ -901,7 +901,7 @@ mod tests {
 
     use super::*;
     #[cfg(not(madsim))]
-    use crate::sink::log_store::LogStoreResult;
+    use crate::sink::log_store::{LogStoreResult, ReportedSinkErrorRow};
 
     #[test]
     fn test_build_schema_flags() {
@@ -1624,7 +1624,11 @@ mod tests {
             }
         }
 
-        fn truncate(&mut self, offset: TruncateOffset) -> LogStoreResult<()> {
+        fn truncate(
+            &mut self,
+            offset: TruncateOffset,
+            _error_rows: Vec<ReportedSinkErrorRow>,
+        ) -> LogStoreResult<()> {
             self.truncates.lock().unwrap().push(offset);
             Ok(())
         }

--- a/src/connector/src/sink/writer.rs
+++ b/src/connector/src/sink/writer.rs
@@ -203,7 +203,7 @@ impl<W: SinkWriter<CommitMetadata = ()>> LogSinker for LogSinkerOf<W> {
                         metrics
                             .sink_commit_duration
                             .observe(start_time.elapsed().as_secs_f64());
-                        log_reader.truncate(TruncateOffset::Barrier { epoch })?;
+                        log_reader.truncate(TruncateOffset::Barrier { epoch }, vec![])?;
                     } else {
                         assert!(new_vnode_bitmap.is_none());
                         sink_writer
@@ -283,7 +283,7 @@ impl<W: AsyncTruncateSinkWriter> LogSinker for AsyncTruncateLogSinkerOf<W> {
                 }
                 Either::Right(offset_result) => {
                     let offset = offset_result?;
-                    log_reader.truncate(offset)?;
+                    log_reader.truncate(offset, vec![])?;
                 }
             }
         }

--- a/src/stream/src/common/log_store_impl/in_mem.rs
+++ b/src/stream/src/common/log_store_impl/in_mem.rs
@@ -19,8 +19,9 @@ use futures::future::BoxFuture;
 use risingwave_common::array::StreamChunk;
 use risingwave_common::util::epoch::{EpochExt, EpochPair, INVALID_EPOCH};
 use risingwave_connector::sink::log_store::{
-    FlushCurrentEpochOptions, LogReader, LogStoreFactory, LogStoreReadItem, LogStoreResult,
-    LogWriter, LogWriterPostFlushCurrentEpoch, TruncateBarrierLogReader, TruncateOffset,
+    FlushCurrentEpochOptions, FlushCurrentEpochResult, LogReader, LogStoreFactory,
+    LogStoreReadItem, LogStoreResult, LogWriter, LogWriterPostFlushCurrentEpoch,
+    ReportedSinkErrorRow, TruncateBarrierLogReader, TruncateOffset,
 };
 use tokio::sync::mpsc::{
     Receiver, Sender, UnboundedReceiver, UnboundedSender, channel, unbounded_channel,
@@ -29,6 +30,11 @@ use tokio::sync::oneshot;
 
 use crate::common::log_store_impl::in_mem::LogReaderEpochProgress::{AwaitingTruncate, Consuming};
 use crate::executor::StreamExecutorResult;
+
+enum TruncateNotification {
+    ReportedRows(Vec<ReportedSinkErrorRow>),
+    BarrierTruncated { epoch: u64 },
+}
 
 enum InMemLogStoreItem {
     StreamChunk(StreamChunk),
@@ -53,8 +59,8 @@ pub struct BoundedInMemLogStoreWriter {
     /// Sending log store item to log reader
     item_tx: Sender<InMemLogStoreItem>,
 
-    /// Receiver for the epoch consumed by log reader.
-    truncated_epoch_rx: UnboundedReceiver<u64>,
+    /// Receiver for truncate notifications from the log reader.
+    truncate_notification_rx: UnboundedReceiver<TruncateNotification>,
 
     wait_init_epoch: Option<WaitInitEpochFn>,
 }
@@ -80,8 +86,8 @@ pub struct BoundedInMemLogStoreReader {
     /// Receiver to fetch log store item
     item_rx: Receiver<InMemLogStoreItem>,
 
-    /// Sender of consumed epoch to the log writer
-    truncated_epoch_tx: UnboundedSender<u64>,
+    /// Sender of truncate notifications to the log writer.
+    truncate_notification_tx: UnboundedSender<TruncateNotification>,
 
     /// Offset of the latest emitted item
     latest_offset: TruncateOffset,
@@ -130,12 +136,12 @@ impl LogStoreFactory for BoundedInMemLogStoreFactory {
     async fn build(self) -> (Self::Reader, Self::Writer) {
         let (init_epoch_tx, init_epoch_rx) = oneshot::channel();
         let (item_tx, item_rx) = channel(self.bound);
-        let (truncated_epoch_tx, truncated_epoch_rx) = unbounded_channel();
+        let (truncate_notification_tx, truncate_notification_rx) = unbounded_channel();
         let reader = BoundedInMemLogStoreReader {
             epoch_progress: UNINITIALIZED,
             init_epoch_rx: Some(init_epoch_rx),
             item_rx,
-            truncated_epoch_tx,
+            truncate_notification_tx,
             latest_offset: TruncateOffset::Barrier { epoch: 0 },
             truncate_offset: TruncateOffset::Barrier { epoch: 0 },
         };
@@ -143,7 +149,7 @@ impl LogStoreFactory for BoundedInMemLogStoreFactory {
             curr_epoch: None,
             init_epoch_tx: Some(init_epoch_tx),
             item_tx,
-            truncated_epoch_rx,
+            truncate_notification_rx,
             wait_init_epoch: Some(self.wait_init_epoch),
         };
         (TruncateBarrierLogReader::new(reader), writer)
@@ -229,7 +235,11 @@ impl LogReader for BoundedInMemLogStoreReader {
         }
     }
 
-    fn truncate(&mut self, offset: TruncateOffset) -> LogStoreResult<()> {
+    fn truncate(
+        &mut self,
+        offset: TruncateOffset,
+        error_rows: Vec<ReportedSinkErrorRow>,
+    ) -> LogStoreResult<()> {
         // check the truncate offset is higher than prev truncate offset
         if self.truncate_offset >= offset {
             return Err(anyhow!(
@@ -248,6 +258,12 @@ impl LogReader for BoundedInMemLogStoreReader {
             ));
         }
 
+        if !error_rows.is_empty() {
+            self.truncate_notification_tx
+                .send(TruncateNotification::ReportedRows(error_rows))
+                .map_err(|_| anyhow!("unable to send reported error rows"))?;
+        }
+
         if let AwaitingTruncate {
             sealed_epoch,
             next_epoch,
@@ -255,11 +271,13 @@ impl LogReader for BoundedInMemLogStoreReader {
             && let TruncateOffset::Barrier { epoch } = offset
             && epoch == *sealed_epoch
         {
-            let sealed_epoch = *sealed_epoch;
             self.epoch_progress = Consuming(*next_epoch);
-            self.truncated_epoch_tx
-                .send(sealed_epoch)
-                .map_err(|_| anyhow!("unable to send sealed epoch"))?;
+        }
+
+        if let TruncateOffset::Barrier { epoch } = offset {
+            self.truncate_notification_tx
+                .send(TruncateNotification::BarrierTruncated { epoch })
+                .map_err(|_| anyhow!("unable to send truncated barrier"))?;
         }
         self.truncate_offset = offset;
         Ok(())
@@ -305,8 +323,9 @@ impl LogWriter for BoundedInMemLogStoreWriter {
         &mut self,
         next_epoch: u64,
         options: FlushCurrentEpochOptions,
-    ) -> LogStoreResult<LogWriterPostFlushCurrentEpoch<'_>> {
+    ) -> LogStoreResult<FlushCurrentEpochResult<'_>> {
         let is_checkpoint = options.is_checkpoint;
+        let mut reported_error_rows = vec![];
         self.item_tx
             .send(InMemLogStoreItem::Barrier {
                 next_epoch,
@@ -322,18 +341,34 @@ impl LogWriter for BoundedInMemLogStoreWriter {
             .expect("should have epoch");
 
         if is_checkpoint {
-            let truncated_epoch = self
-                .truncated_epoch_rx
-                .recv()
-                .instrument_await("in_mem_recv_truncated_epoch")
-                .await
-                .ok_or_else(|| anyhow!("cannot get truncated epoch"))?;
-            assert_eq!(truncated_epoch, prev_epoch);
+            let mut rows = vec![];
+            loop {
+                match self
+                    .truncate_notification_rx
+                    .recv()
+                    .instrument_await("in_mem_recv_truncate_notification")
+                    .await
+                    .ok_or_else(|| anyhow!("cannot get truncate notification"))?
+                {
+                    TruncateNotification::ReportedRows(new_rows) => {
+                        assert!(new_rows.iter().all(|row| row.epoch <= prev_epoch));
+                        rows.extend(new_rows);
+                    }
+                    TruncateNotification::BarrierTruncated { epoch } => {
+                        assert!(epoch <= prev_epoch);
+                        if epoch == prev_epoch {
+                            break;
+                        }
+                    }
+                }
+            }
+            reported_error_rows = rows;
         }
 
-        Ok(LogWriterPostFlushCurrentEpoch::new(move || {
-            async move { Ok(()) }.boxed()
-        }))
+        Ok(FlushCurrentEpochResult {
+            post_flush: LogWriterPostFlushCurrentEpoch::new(move || async move { Ok(()) }.boxed()),
+            reported_error_rows,
+        })
     }
 
     fn pause(&mut self) -> LogStoreResult<()> {
@@ -353,11 +388,13 @@ mod tests {
     use std::task::Poll;
 
     use futures::FutureExt;
-    use risingwave_common::array::{Op, StreamChunkBuilder};
+    use risingwave_common::array::{Op, StreamChunk, StreamChunkBuilder};
+    use risingwave_common::row::OwnedRow;
     use risingwave_common::types::{DataType, ScalarImpl};
     use risingwave_common::util::epoch::{EpochPair, test_epoch};
     use risingwave_connector::sink::log_store::{
-        LogReader, LogStoreFactory, LogStoreReadItem, LogWriter, TruncateOffset,
+        LogReader, LogStoreFactory, LogStoreReadItem, LogWriter, ReportedSinkErrorRow,
+        TruncateOffset,
     };
 
     use crate::common::log_store_impl::in_mem::BoundedInMemLogStoreFactory;
@@ -460,10 +497,13 @@ mod tests {
         }
 
         reader
-            .truncate(TruncateOffset::Chunk {
-                epoch: init_epoch,
-                chunk_id: chunk_id1_2,
-            })
+            .truncate(
+                TruncateOffset::Chunk {
+                    epoch: init_epoch,
+                    chunk_id: chunk_id1_2,
+                },
+                vec![],
+            )
             .unwrap();
         assert!(
             poll_fn(|cx| Poll::Ready(join_handle.poll_unpin(cx)))
@@ -471,10 +511,13 @@ mod tests {
                 .is_pending()
         );
         reader
-            .truncate(TruncateOffset::Chunk {
-                epoch: epoch1,
-                chunk_id: chunk_id2_1,
-            })
+            .truncate(
+                TruncateOffset::Chunk {
+                    epoch: epoch1,
+                    chunk_id: chunk_id2_1,
+                },
+                vec![],
+            )
             .unwrap();
         assert!(
             poll_fn(|cx| Poll::Ready(join_handle.poll_unpin(cx)))
@@ -482,8 +525,196 @@ mod tests {
                 .is_pending()
         );
         reader
-            .truncate(TruncateOffset::Barrier { epoch: epoch1 })
+            .truncate(TruncateOffset::Barrier { epoch: epoch1 }, vec![])
             .unwrap();
         join_handle.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_in_memory_log_store_reported_error_rows() {
+        let factory = BoundedInMemLogStoreFactory::for_test(4);
+        let (mut reader, mut writer) = factory.build().await;
+
+        let init_epoch = test_epoch(1);
+        let epoch1 = test_epoch(2);
+
+        writer
+            .init(EpochPair::new_test_epoch(init_epoch), false)
+            .await
+            .unwrap();
+        reader.init().await.unwrap();
+
+        let mut flush_future = Box::pin(writer.flush_current_epoch(
+            epoch1,
+            risingwave_connector::sink::log_store::FlushCurrentEpochOptions {
+                is_checkpoint: true,
+                new_vnode_bitmap: None,
+                is_stop: false,
+                schema_change: None,
+                wait_log_store_flush: true,
+            },
+        ));
+        assert!(
+            poll_fn(|cx| Poll::Ready(flush_future.as_mut().poll_unpin(cx)))
+                .await
+                .is_pending()
+        );
+
+        match reader.next_item().await.unwrap() {
+            (epoch, LogStoreReadItem::Barrier { is_checkpoint, .. }) => {
+                assert_eq!(epoch, init_epoch);
+                assert!(is_checkpoint);
+            }
+            _ => unreachable!(),
+        }
+
+        reader
+            .truncate(
+                TruncateOffset::Barrier { epoch: init_epoch },
+                vec![ReportedSinkErrorRow {
+                    epoch: init_epoch,
+                    op: Op::Delete,
+                    row: OwnedRow::new(vec![
+                        Some(ScalarImpl::Utf8("alice".into())),
+                        Some(ScalarImpl::Int32(7)),
+                    ]),
+                    extra_info: None,
+                }],
+            )
+            .unwrap();
+
+        let flush_result = flush_future.await.unwrap();
+        flush_result.post_flush.post_yield_barrier().await.unwrap();
+        assert_eq!(flush_result.reported_error_rows.len(), 1);
+        assert_eq!(flush_result.reported_error_rows[0].epoch, init_epoch);
+        assert_eq!(flush_result.reported_error_rows[0].op, Op::Delete);
+        assert_eq!(
+            flush_result.reported_error_rows[0].row,
+            OwnedRow::new(vec![
+                Some(ScalarImpl::Utf8("alice".into())),
+                Some(ScalarImpl::Int32(7)),
+            ])
+        );
+    }
+
+    #[tokio::test]
+    async fn test_in_memory_log_store_reported_error_rows_across_non_checkpoint_barrier() {
+        let factory = BoundedInMemLogStoreFactory::for_test(4);
+        let (mut reader, mut writer) = factory.build().await;
+
+        let init_epoch = test_epoch(1);
+        let epoch1 = test_epoch(2);
+        let epoch2 = test_epoch(3);
+
+        writer
+            .init(EpochPair::new_test_epoch(init_epoch), false)
+            .await
+            .unwrap();
+        reader.init().await.unwrap();
+
+        let chunk = StreamChunk::from_rows(
+            &[(Op::Insert, OwnedRow::new(vec![Some(ScalarImpl::Int32(1))]))],
+            &[DataType::Int32],
+        );
+        writer.write_chunk(chunk.clone()).await.unwrap();
+        writer
+            .flush_current_epoch_for_test(epoch1, false)
+            .await
+            .unwrap();
+        writer.write_chunk(chunk).await.unwrap();
+
+        let mut flush_future = Box::pin(writer.flush_current_epoch(
+            epoch2,
+            risingwave_connector::sink::log_store::FlushCurrentEpochOptions {
+                is_checkpoint: true,
+                new_vnode_bitmap: None,
+                is_stop: false,
+                schema_change: None,
+                wait_log_store_flush: true,
+            },
+        ));
+        assert!(
+            poll_fn(|cx| Poll::Ready(flush_future.as_mut().poll_unpin(cx)))
+                .await
+                .is_pending()
+        );
+
+        let init_chunk_id = match reader.next_item().await.unwrap() {
+            (epoch, LogStoreReadItem::StreamChunk { chunk: _, chunk_id }) => {
+                assert_eq!(epoch, init_epoch);
+                chunk_id
+            }
+            _ => unreachable!(),
+        };
+        match reader.next_item().await.unwrap() {
+            (epoch, LogStoreReadItem::Barrier { is_checkpoint, .. }) => {
+                assert_eq!(epoch, init_epoch);
+                assert!(!is_checkpoint);
+            }
+            _ => unreachable!(),
+        }
+        let epoch1_chunk_id = match reader.next_item().await.unwrap() {
+            (epoch, LogStoreReadItem::StreamChunk { chunk: _, chunk_id }) => {
+                assert_eq!(epoch, epoch1);
+                chunk_id
+            }
+            _ => unreachable!(),
+        };
+        match reader.next_item().await.unwrap() {
+            (epoch, LogStoreReadItem::Barrier { is_checkpoint, .. }) => {
+                assert_eq!(epoch, epoch1);
+                assert!(is_checkpoint);
+            }
+            _ => unreachable!(),
+        }
+
+        reader
+            .truncate(
+                TruncateOffset::Chunk {
+                    epoch: init_epoch,
+                    chunk_id: init_chunk_id,
+                },
+                vec![ReportedSinkErrorRow {
+                    epoch: init_epoch,
+                    op: Op::Insert,
+                    row: OwnedRow::new(vec![Some(ScalarImpl::Int32(1))]),
+                    extra_info: None,
+                }],
+            )
+            .unwrap();
+        reader
+            .truncate(TruncateOffset::Barrier { epoch: init_epoch }, vec![])
+            .unwrap();
+        reader
+            .truncate(
+                TruncateOffset::Chunk {
+                    epoch: epoch1,
+                    chunk_id: epoch1_chunk_id,
+                },
+                vec![ReportedSinkErrorRow {
+                    epoch: epoch1,
+                    op: Op::Insert,
+                    row: OwnedRow::new(vec![Some(ScalarImpl::Int32(2))]),
+                    extra_info: None,
+                }],
+            )
+            .unwrap();
+        reader
+            .truncate(TruncateOffset::Barrier { epoch: epoch1 }, vec![])
+            .unwrap();
+
+        let flush_result = flush_future.await.unwrap();
+        flush_result.post_flush.post_yield_barrier().await.unwrap();
+        assert_eq!(flush_result.reported_error_rows.len(), 2);
+        assert_eq!(flush_result.reported_error_rows[0].epoch, init_epoch);
+        assert_eq!(
+            flush_result.reported_error_rows[0].row,
+            OwnedRow::new(vec![Some(ScalarImpl::Int32(1))])
+        );
+        assert_eq!(flush_result.reported_error_rows[1].epoch, epoch1);
+        assert_eq!(
+            flush_result.reported_error_rows[1].row,
+            OwnedRow::new(vec![Some(ScalarImpl::Int32(2))])
+        );
     }
 }

--- a/src/stream/src/common/log_store_impl/kv_log_store/buffer.rs
+++ b/src/stream/src/common/log_store_impl/kv_log_store/buffer.rs
@@ -22,12 +22,14 @@ use parking_lot::{Mutex, MutexGuard};
 use risingwave_common::array::StreamChunk;
 use risingwave_common::bitmap::Bitmap;
 use risingwave_common_estimate_size::EstimateSize;
-use risingwave_connector::sink::log_store::{ChunkId, LogStoreResult, TruncateOffset};
+use risingwave_connector::sink::log_store::{
+    ChunkId, LogStoreResult, ReportedSinkErrorRow, TruncateOffset,
+};
 use risingwave_pb::stream_plan::PbSinkSchemaChange;
 use tokio::sync::Notify;
 
 use crate::common::log_store_impl::kv_log_store::{
-    KvLogStoreMetrics, ReaderTruncationOffsetType, SeqId,
+    KvLogStoreMetrics, ReaderTruncationOffsetType, ReaderTruncationProgress, SeqId,
 };
 
 #[derive(Clone)]
@@ -78,7 +80,9 @@ struct LogStoreBufferInner {
     max_row_count: usize,
     chunk_size: usize,
 
-    truncation_list: VecDeque<ReaderTruncationOffsetType>,
+    /// Finalized truncate progress that has advanced to a concrete reader offset and can be
+    /// consumed by the writer on `pop_truncation` / `wait_for_barrier_truncation`.
+    truncation_list: VecDeque<ReaderTruncationProgress>,
 
     next_chunk_id: ChunkId,
 
@@ -226,13 +230,16 @@ impl LogStoreBufferInner {
         self.update_buffer_metrics();
     }
 
-    fn add_truncate_offset(&mut self, (epoch, seq_id): ReaderTruncationOffsetType) {
-        if let Some((prev_epoch, prev_seq_id)) = self.truncation_list.back_mut()
-            && *prev_epoch == epoch
+    fn add_truncate_offset(&mut self, progress: ReaderTruncationProgress) {
+        if let Some(prev_progress) = self.truncation_list.back_mut()
+            && prev_progress.offset.0 == progress.offset.0
         {
-            *prev_seq_id = seq_id;
+            prev_progress.offset.1 = progress.offset.1;
+            prev_progress
+                .reported_error_rows
+                .extend(progress.reported_error_rows);
         } else {
-            self.truncation_list.push_back((epoch, seq_id));
+            self.truncation_list.push_back(progress);
         }
     }
 
@@ -336,27 +343,37 @@ impl LogStoreBufferSender {
         self.update_notify.notify_waiters();
     }
 
-    pub(crate) fn pop_truncation(&self, curr_epoch: u64) -> Option<ReaderTruncationOffsetType> {
+    pub(crate) fn pop_truncation(
+        &self,
+        curr_epoch: u64,
+    ) -> Option<(ReaderTruncationOffsetType, Vec<ReportedSinkErrorRow>)> {
         let mut inner = self.buffer.inner();
-        let mut ret = None;
-        while let Some((epoch, _)) = inner.truncation_list.front()
-            && *epoch < curr_epoch
+        let mut latest_offset = None;
+        let mut reported_error_rows = vec![];
+        while let Some(progress) = inner.truncation_list.front()
+            && progress.offset.0 <= curr_epoch
         {
-            ret = inner.truncation_list.pop_front();
+            let progress = inner.truncation_list.pop_front().expect("checked some");
+            latest_offset = Some(progress.offset);
+            if !progress.reported_error_rows.is_empty() {
+                reported_error_rows.extend(progress.reported_error_rows);
+            }
         }
-        ret
+        latest_offset.map(|offset| (offset, reported_error_rows))
     }
 
     pub(crate) async fn wait_for_barrier_truncation(
         &self,
         curr_epoch: u64,
-    ) -> LogStoreResult<ReaderTruncationOffsetType> {
+    ) -> LogStoreResult<(ReaderTruncationOffsetType, Vec<ReportedSinkErrorRow>)> {
         loop {
             let notified = self.truncate_notify.notified();
 
             {
                 let mut inner = self.buffer.inner();
-                while let Some((epoch, seq_id)) = inner.truncation_list.pop_front() {
+                let mut reported_error_rows = vec![];
+                while let Some(progress) = inner.truncation_list.pop_front() {
+                    let (epoch, seq_id) = progress.offset;
                     if epoch > curr_epoch {
                         // TODO: should panic, after we confirm the correctness
                         return Err(anyhow::anyhow!(
@@ -365,8 +382,11 @@ impl LogStoreBufferSender {
                             curr_epoch
                         ));
                     }
+                    if !progress.reported_error_rows.is_empty() {
+                        reported_error_rows.extend(progress.reported_error_rows);
+                    }
                     if epoch == curr_epoch && seq_id.is_none() {
-                        return Ok((epoch, seq_id));
+                        return Ok(((epoch, seq_id), reported_error_rows));
                     }
                 }
             }
@@ -433,7 +453,11 @@ impl LogStoreBufferReceiver {
         }
     }
 
-    pub(crate) fn truncate_buffer(&mut self, offset: TruncateOffset) {
+    pub(crate) fn truncate_buffer(
+        &mut self,
+        offset: TruncateOffset,
+        reported_error_rows: Vec<ReportedSinkErrorRow>,
+    ) {
         let mut inner = self.buffer.inner();
         let mut latest_offset: Option<ReaderTruncationOffsetType> = None;
         while let Some((epoch, item)) = inner.consumed_queue.back() {
@@ -455,9 +479,8 @@ impl LogStoreBufferReceiver {
                     if chunk_offset <= offset {
                         inner.row_count -= chunk.cardinality();
                         inner.consumed_queue.pop_back();
-                        if flushed {
-                            latest_offset = Some((epoch, Some(end_seq_id)));
-                        }
+                        let _ = flushed;
+                        latest_offset = Some((epoch, Some(end_seq_id)));
                     } else {
                         break;
                     }
@@ -492,14 +515,29 @@ impl LogStoreBufferReceiver {
         }
         inner.update_buffer_metrics();
         if let Some(offset) = latest_offset {
-            inner.add_truncate_offset(offset);
+            inner.add_truncate_offset(ReaderTruncationProgress {
+                offset,
+                reported_error_rows,
+            });
             self.truncate_notify.notify_waiters();
+        } else {
+            assert!(
+                reported_error_rows.is_empty(),
+                "buffered truncation should always yield finalized progress"
+            );
         }
     }
 
-    pub(crate) fn truncate_historical(&mut self, epoch: u64) {
+    pub(crate) fn truncate_historical(
+        &mut self,
+        epoch: u64,
+        reported_error_rows: Vec<ReportedSinkErrorRow>,
+    ) {
         let mut inner = self.buffer.inner();
-        inner.add_truncate_offset((epoch, None));
+        inner.add_truncate_offset(ReaderTruncationProgress {
+            offset: (epoch, None),
+            reported_error_rows,
+        });
         self.truncate_notify.notify_waiters();
     }
 

--- a/src/stream/src/common/log_store_impl/kv_log_store/mod.rs
+++ b/src/stream/src/common/log_store_impl/kv_log_store/mod.rs
@@ -23,7 +23,9 @@ use risingwave_common::metrics::{
     LabelGuardedHistogram, LabelGuardedIntCounter, LabelGuardedIntGauge,
 };
 use risingwave_connector::sink::SinkParam;
-use risingwave_connector::sink::log_store::{LogStoreFactory, TruncateBarrierLogReader};
+use risingwave_connector::sink::log_store::{
+    LogStoreFactory, ReportedSinkErrorRow, TruncateBarrierLogReader,
+};
 use risingwave_pb::catalog::Table;
 use risingwave_storage::StateStore;
 use risingwave_storage::store::{LocalStateStore, NewLocalOptions, OpConsistencyLevel};
@@ -190,6 +192,12 @@ pub(crate) const FIRST_SEQ_ID: SeqId = 0;
 /// Readers truncate the offset at the granularity of seq id.
 /// None `SeqIdType` means that the whole epoch is truncated.
 pub(crate) type ReaderTruncationOffsetType = (u64, Option<SeqId>);
+
+#[derive(Clone)]
+pub(crate) struct ReaderTruncationProgress {
+    pub offset: ReaderTruncationOffsetType,
+    pub reported_error_rows: Vec<ReportedSinkErrorRow>,
+}
 
 #[derive(Clone)]
 pub struct KvLogStoreReadMetrics {
@@ -896,7 +904,7 @@ mod tests {
         test_env.commit_epoch(epoch2).await;
         // The truncate does not work because it is after the sync
         reader
-            .truncate(TruncateOffset::Barrier { epoch: epoch2 })
+            .truncate(TruncateOffset::Barrier { epoch: epoch2 }, vec![])
             .unwrap();
 
         drop(writer);
@@ -1097,10 +1105,13 @@ mod tests {
 
         // The truncate should work because it is before the flush
         reader
-            .truncate(TruncateOffset::Chunk {
-                epoch: epoch1,
-                chunk_id: chunk_id1,
-            })
+            .truncate(
+                TruncateOffset::Chunk {
+                    epoch: epoch1,
+                    chunk_id: chunk_id1,
+                },
+                vec![],
+            )
             .unwrap();
         let epoch3 = epoch2.next_epoch();
         writer
@@ -1322,7 +1333,7 @@ mod tests {
 
         // Only reader1 will truncate
         reader1
-            .truncate(TruncateOffset::Barrier { epoch: epoch1 })
+            .truncate(TruncateOffset::Barrier { epoch: epoch1 }, vec![])
             .unwrap();
 
         match reader1.next_item().await.unwrap() {
@@ -1668,10 +1679,13 @@ mod tests {
         assert_eq!(3, chunk_ids.len());
 
         reader
-            .truncate(TruncateOffset::Chunk {
-                epoch: epoch1,
-                chunk_id: chunk_ids[0],
-            })
+            .truncate(
+                TruncateOffset::Chunk {
+                    epoch: epoch1,
+                    chunk_id: chunk_ids[0],
+                },
+                vec![],
+            )
             .unwrap();
         reader.rewind().await.unwrap();
         reader.start_from(None).await.unwrap();
@@ -1688,7 +1702,7 @@ mod tests {
         assert_eq!(2, chunk_ids.len());
 
         reader
-            .truncate(TruncateOffset::Barrier { epoch: epoch1 })
+            .truncate(TruncateOffset::Barrier { epoch: epoch1 }, vec![])
             .unwrap();
         reader.rewind().await.unwrap();
         reader.start_from(None).await.unwrap();
@@ -1704,10 +1718,13 @@ mod tests {
         assert_eq!(2, chunk_ids.len());
 
         reader
-            .truncate(TruncateOffset::Chunk {
-                epoch: epoch3,
-                chunk_id: chunk_ids[1],
-            })
+            .truncate(
+                TruncateOffset::Chunk {
+                    epoch: epoch3,
+                    chunk_id: chunk_ids[1],
+                },
+                vec![],
+            )
             .unwrap();
         reader.rewind().await.unwrap();
         reader.start_from(None).await.unwrap();
@@ -1752,7 +1769,7 @@ mod tests {
         assert_eq!(3, check_reader(&mut reader, data.iter()).await.len());
 
         reader
-            .truncate(TruncateOffset::Barrier { epoch: epoch1 })
+            .truncate(TruncateOffset::Barrier { epoch: epoch1 }, vec![])
             .unwrap();
         reader.rewind().await.unwrap();
         reader.start_from(None).await.unwrap();
@@ -1760,10 +1777,13 @@ mod tests {
         assert_eq!(2, chunk_ids.len());
 
         reader
-            .truncate(TruncateOffset::Chunk {
-                epoch: epoch2,
-                chunk_id: chunk_ids[0],
-            })
+            .truncate(
+                TruncateOffset::Chunk {
+                    epoch: epoch2,
+                    chunk_id: chunk_ids[0],
+                },
+                vec![],
+            )
             .unwrap();
         reader.rewind().await.unwrap();
         reader.start_from(None).await.unwrap();
@@ -1771,14 +1791,17 @@ mod tests {
         assert_eq!(2, chunk_ids.len());
 
         reader
-            .truncate(TruncateOffset::Chunk {
-                epoch: epoch2,
-                chunk_id: chunk_ids[0],
-            })
+            .truncate(
+                TruncateOffset::Chunk {
+                    epoch: epoch2,
+                    chunk_id: chunk_ids[0],
+                },
+                vec![],
+            )
             .unwrap();
 
         reader
-            .truncate(TruncateOffset::Barrier { epoch: epoch2 })
+            .truncate(TruncateOffset::Barrier { epoch: epoch2 }, vec![])
             .unwrap();
         reader.rewind().await.unwrap();
         reader.start_from(None).await.unwrap();
@@ -1835,7 +1858,7 @@ mod tests {
         );
 
         reader
-            .truncate(TruncateOffset::Barrier { epoch: epoch1 })
+            .truncate(TruncateOffset::Barrier { epoch: epoch1 }, vec![])
             .unwrap();
         reader.rewind().await.unwrap();
         reader.start_from(None).await.unwrap();
@@ -1843,10 +1866,13 @@ mod tests {
         assert_eq!(4, chunk_ids.len());
 
         reader
-            .truncate(TruncateOffset::Chunk {
-                epoch: epoch2,
-                chunk_id: chunk_ids[0],
-            })
+            .truncate(
+                TruncateOffset::Chunk {
+                    epoch: epoch2,
+                    chunk_id: chunk_ids[0],
+                },
+                vec![],
+            )
             .unwrap();
         reader.rewind().await.unwrap();
         reader.start_from(None).await.unwrap();
@@ -1854,7 +1880,7 @@ mod tests {
         assert_eq!(4, chunk_ids.len());
 
         reader
-            .truncate(TruncateOffset::Barrier { epoch: epoch2 })
+            .truncate(TruncateOffset::Barrier { epoch: epoch2 }, vec![])
             .unwrap();
         reader.rewind().await.unwrap();
         reader.start_from(None).await.unwrap();
@@ -1862,7 +1888,7 @@ mod tests {
         assert_eq!(3, chunk_ids.len());
 
         reader
-            .truncate(TruncateOffset::Barrier { epoch: epoch3 })
+            .truncate(TruncateOffset::Barrier { epoch: epoch3 }, vec![])
             .unwrap();
         reader.rewind().await.unwrap();
         reader.start_from(None).await.unwrap();
@@ -1870,10 +1896,13 @@ mod tests {
         assert_eq!(2, chunk_ids.len());
 
         reader
-            .truncate(TruncateOffset::Chunk {
-                epoch: epoch4,
-                chunk_id: chunk_ids[0],
-            })
+            .truncate(
+                TruncateOffset::Chunk {
+                    epoch: epoch4,
+                    chunk_id: chunk_ids[0],
+                },
+                vec![],
+            )
             .unwrap();
         reader.rewind().await.unwrap();
         reader.start_from(None).await.unwrap();
@@ -1885,7 +1914,7 @@ mod tests {
         assert_eq!(1, chunk_ids.len());
 
         reader
-            .truncate(TruncateOffset::Barrier { epoch: epoch4 })
+            .truncate(TruncateOffset::Barrier { epoch: epoch4 }, vec![])
             .unwrap();
         reader.rewind().await.unwrap();
         reader.start_from(None).await.unwrap();
@@ -1894,10 +1923,13 @@ mod tests {
         assert_eq!(1, chunk_ids.len());
 
         reader
-            .truncate(TruncateOffset::Chunk {
-                epoch: epoch5,
-                chunk_id: chunk_ids[0],
-            })
+            .truncate(
+                TruncateOffset::Chunk {
+                    epoch: epoch5,
+                    chunk_id: chunk_ids[0],
+                },
+                vec![],
+            )
             .unwrap();
         reader.rewind().await.unwrap();
         reader.start_from(None).await.unwrap();
@@ -2115,7 +2147,7 @@ mod tests {
         .await;
         // The truncate should take effect
         reader
-            .truncate(TruncateOffset::Barrier { epoch: epoch1 })
+            .truncate(TruncateOffset::Barrier { epoch: epoch1 }, vec![])
             .unwrap();
         let epoch4 = epoch3.next_epoch();
         writer
@@ -2296,14 +2328,16 @@ mod tests {
                 assert!(is_checkpoint);
                 assert_eq!(read_schema_change, Some(schema_change.clone()));
                 reader
-                    .truncate(TruncateOffset::Barrier { epoch: epoch1 })
+                    .truncate(TruncateOffset::Barrier { epoch: epoch1 }, vec![])
                     .unwrap();
             }
             item => unreachable!("{:?}", item),
         }
 
-        let post_flush = flush_future.await.unwrap();
-        post_flush.post_yield_barrier().await.unwrap();
+        {
+            let post_flush = flush_future.await.unwrap();
+            post_flush.post_flush.post_yield_barrier().await.unwrap();
+        }
 
         // Writer should be able to continue with the next epoch after reader truncation.
         writer.write_chunk(gen_stream_chunk(10)).await.unwrap();
@@ -2386,14 +2420,14 @@ mod tests {
                 assert!(is_stop);
                 assert_eq!(schema_change, None);
                 reader
-                    .truncate(TruncateOffset::Barrier { epoch: epoch1 })
+                    .truncate(TruncateOffset::Barrier { epoch: epoch1 }, vec![])
                     .unwrap();
             }
             item => unreachable!("{:?}", item),
         }
 
         let post_flush = flush_future.await.unwrap();
-        post_flush.post_yield_barrier().await.unwrap();
+        post_flush.post_flush.post_yield_barrier().await.unwrap();
     }
 
     #[tokio::test]
@@ -2488,14 +2522,14 @@ mod tests {
         let _ = reader.next_item().await.unwrap();
         let _ = reader.next_item().await.unwrap();
         reader
-            .truncate(TruncateOffset::Barrier { epoch: epoch1 })
+            .truncate(TruncateOffset::Barrier { epoch: epoch1 }, vec![])
             .unwrap();
         {
             let post_flush = tokio::time::timeout(Duration::from_secs(10), flush_future)
                 .await
                 .expect("schema-change flush should finish after reader truncates barrier")
                 .unwrap();
-            post_flush.post_yield_barrier().await.unwrap();
+            post_flush.post_flush.post_yield_barrier().await.unwrap();
         }
         tokio::time::timeout(Duration::from_secs(10), test_env.commit_epoch(epoch1))
             .await

--- a/src/stream/src/common/log_store_impl/kv_log_store/reader.rs
+++ b/src/stream/src/common/log_store_impl/kv_log_store/reader.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::collections::VecDeque;
 use std::future::Future;
 use std::mem::replace;
 use std::ops::Bound::{Excluded, Included, Unbounded};
@@ -30,7 +31,7 @@ use risingwave_common::hash::VnodeBitmapExt;
 use risingwave_common::metrics::{LabelGuardedHistogram, LabelGuardedIntCounter};
 use risingwave_common::util::epoch::{EpochExt, EpochPair};
 use risingwave_connector::sink::log_store::{
-    ChunkId, LogReader, LogStoreReadItem, LogStoreResult, TruncateOffset,
+    ChunkId, LogReader, LogStoreReadItem, LogStoreResult, ReportedSinkErrorRow, TruncateOffset,
 };
 use risingwave_hummock_sdk::key::prefixed_range_with_vnode;
 use risingwave_storage::hummock::CachePolicy;
@@ -77,8 +78,6 @@ mod rewind_backoff_policy {
 }
 
 use rewind_backoff_policy::*;
-use risingwave_common::must_match;
-
 struct RewindDelay {
     last_rewind_truncate_offset: Option<TruncateOffset>,
     backoff_policy: RewindBackoffPolicy,
@@ -123,12 +122,16 @@ impl RewindDelay {
 
 enum KvLogStoreReaderFutureState<S: StateStoreRead> {
     /// consuming historical log data
-    ReadStateStoreStream(
-        Pin<Box<LogStoreItemMergeStream<TimeoutAutoRebuildIter<S>>>>,
+    ReadStateStoreStream {
+        stream: Pin<Box<LogStoreItemMergeStream<TimeoutAutoRebuildIter<S>>>>,
         /// Held permit limiting concurrent historical reads. Automatically released
         /// when this variant is replaced (i.e. stream fully consumed or reset).
-        Option<OwnedSemaphorePermit>,
-    ),
+        _permit: Option<OwnedSemaphorePermit>,
+        pending_reported_error_rows: VecDeque<ReportedSinkErrorRow>,
+    },
+    HistoricalStreamDrained {
+        pending_reported_error_rows: VecDeque<ReportedSinkErrorRow>,
+    },
     ReadFlushedChunk(BoxFuture<'static, LogStoreResult<(ChunkId, StreamChunk, u64)>>),
     Reset,
     Empty,
@@ -142,8 +145,16 @@ impl<S: StateStoreRead> KvLogStoreReaderFutureState<S> {
     ) -> F::Output {
         // Store the future in case that in the subsequent pending await point,
         // the future is cancelled, and we lose an item.
-        must_match!(replace(self, future_state),
-                    KvLogStoreReaderFutureState::Empty => {});
+        let pending_reported_error_rows = match replace(self, future_state) {
+            KvLogStoreReaderFutureState::Empty => None,
+            KvLogStoreReaderFutureState::HistoricalStreamDrained {
+                pending_reported_error_rows,
+            } => Some(pending_reported_error_rows),
+            state => {
+                *self = state;
+                unreachable!("future state should be Empty or drained historical state")
+            }
+        };
 
         // for cancellation test
         #[cfg(test)]
@@ -152,8 +163,60 @@ impl<S: StateStoreRead> KvLogStoreReaderFutureState<S> {
         }
 
         let output = get_future(self).await;
-        *self = KvLogStoreReaderFutureState::Empty;
+        *self = if let Some(pending_reported_error_rows) = pending_reported_error_rows {
+            KvLogStoreReaderFutureState::HistoricalStreamDrained {
+                pending_reported_error_rows,
+            }
+        } else {
+            KvLogStoreReaderFutureState::Empty
+        };
         output
+    }
+
+    fn buffer_historical_truncate_rows(&mut self, rows: Vec<ReportedSinkErrorRow>) {
+        if rows.is_empty() {
+            return;
+        }
+        match self {
+            KvLogStoreReaderFutureState::ReadStateStoreStream {
+                pending_reported_error_rows,
+                ..
+            }
+            | KvLogStoreReaderFutureState::HistoricalStreamDrained {
+                pending_reported_error_rows,
+            } => {
+                pending_reported_error_rows.extend(rows);
+            }
+            _ => unreachable!(
+                "historical truncate rows should only exist while historical progress is active"
+            ),
+        }
+    }
+
+    fn take_historical_truncate_rows(&mut self, epoch: u64) -> Vec<ReportedSinkErrorRow> {
+        let pending_reported_error_rows = match self {
+            KvLogStoreReaderFutureState::ReadStateStoreStream {
+                pending_reported_error_rows,
+                ..
+            }
+            | KvLogStoreReaderFutureState::HistoricalStreamDrained {
+                pending_reported_error_rows,
+            } => pending_reported_error_rows,
+            _ => unreachable!(
+                "historical truncate rows should only exist while historical progress is active"
+            ),
+        };
+        let mut rows = vec![];
+        while pending_reported_error_rows
+            .front()
+            .is_some_and(|pending_row| pending_row.epoch <= epoch)
+        {
+            let pending_row = pending_reported_error_rows
+                .pop_front()
+                .expect("checked some");
+            rows.push(pending_row);
+        }
+        rows
     }
 }
 
@@ -308,10 +371,11 @@ impl<S: StateStoreRead> LogReader for KvLogStoreReader<S> {
                 } else {
                     None
                 };
-                KvLogStoreReaderFutureState::ReadStateStoreStream(
-                    self.read_persisted_log_store(range_start).await?,
-                    permit,
-                )
+                KvLogStoreReaderFutureState::ReadStateStoreStream {
+                    stream: self.read_persisted_log_store(range_start).await?,
+                    _permit: permit,
+                    pending_reported_error_rows: VecDeque::new(),
+                }
             };
         self.rx.rewind(start_offset);
         Ok(())
@@ -357,8 +421,8 @@ impl<S: StateStoreRead> LogReader for KvLogStoreReader<S> {
                 .map_err(|_| anyhow!("unable to subscribe resume"))?;
         }
         match &mut self.future_state {
-            KvLogStoreReaderFutureState::ReadStateStoreStream(state_store_stream, _permit) => {
-                match state_store_stream
+            KvLogStoreReaderFutureState::ReadStateStoreStream { stream, .. } => {
+                match stream
                     .try_next()
                     .instrument_await("Try Next for Historical Stream")
                     .await?
@@ -391,11 +455,26 @@ impl<S: StateStoreRead> LogReader for KvLogStoreReader<S> {
                         return Ok((epoch, item));
                     }
                     None => {
-                        // Historical stream fully consumed. Permit is dropped with the variant.
-                        self.future_state = KvLogStoreReaderFutureState::Empty;
+                        let pending_reported_error_rows = match replace(
+                            &mut self.future_state,
+                            KvLogStoreReaderFutureState::Empty,
+                        ) {
+                            KvLogStoreReaderFutureState::ReadStateStoreStream {
+                                pending_reported_error_rows,
+                                ..
+                            } => pending_reported_error_rows,
+                            _ => unreachable!("matched ReadStateStoreStream above"),
+                        };
+                        // Historical stream fully consumed. Permit is dropped with the replaced
+                        // variant, while pending historical rows stay attached to the historical
+                        // state until they are truncated.
+                        self.future_state = KvLogStoreReaderFutureState::HistoricalStreamDrained {
+                            pending_reported_error_rows,
+                        };
                     }
                 }
             }
+            KvLogStoreReaderFutureState::HistoricalStreamDrained { .. } => {}
             KvLogStoreReaderFutureState::ReadFlushedChunk(future) => {
                 let (chunk_id, chunk, item_epoch) = future.await?;
                 self.future_state = KvLogStoreReaderFutureState::Empty;
@@ -510,7 +589,11 @@ impl<S: StateStoreRead> LogReader for KvLogStoreReader<S> {
         })
     }
 
-    fn truncate(&mut self, offset: TruncateOffset) -> LogStoreResult<()> {
+    fn truncate(
+        &mut self,
+        offset: TruncateOffset,
+        error_rows: Vec<ReportedSinkErrorRow>,
+    ) -> LogStoreResult<()> {
         if offset > self.latest_offset.expect("should exist before truncation") {
             return Err(anyhow!(
                 "truncate at a later offset {:?} than the current latest offset {:?}",
@@ -528,22 +611,33 @@ impl<S: StateStoreRead> LogReader for KvLogStoreReader<S> {
                     truncate_offset
                 ));
             }
-            self.rx.truncate_buffer(offset);
+            self.rx.truncate_buffer(offset, error_rows);
             self.truncate_offset = Some(offset);
         } else {
-            // For historical data, no need to truncate at seq id level. Only truncate at barrier.
-            if let TruncateOffset::Barrier { epoch } = &offset {
-                if let Some(truncate_offset) = &self.truncate_offset
-                    && offset <= *truncate_offset
-                {
-                    return Err(anyhow!(
-                        "truncate offset {:?} earlier than prev truncate offset {:?}",
-                        offset,
-                        truncate_offset
-                    ));
+            // Historical replay does not surface seq-id-level truncate progress to the writer.
+            // Chunk truncation can still report error rows, which stay pending until the barrier
+            // for that epoch is truncated.
+            match offset {
+                TruncateOffset::Chunk { .. } => {
+                    self.future_state
+                        .buffer_historical_truncate_rows(error_rows);
                 }
-                self.rx.truncate_historical(*epoch);
-                self.truncate_offset = Some(offset);
+                TruncateOffset::Barrier { epoch } => {
+                    if let Some(truncate_offset) = &self.truncate_offset
+                        && offset <= *truncate_offset
+                    {
+                        return Err(anyhow!(
+                            "truncate offset {:?} earlier than prev truncate offset {:?}",
+                            offset,
+                            truncate_offset
+                        ));
+                    }
+                    let mut merged_error_rows =
+                        self.future_state.take_historical_truncate_rows(epoch);
+                    merged_error_rows.extend(error_rows);
+                    self.rx.truncate_historical(epoch, merged_error_rows);
+                    self.truncate_offset = Some(offset);
+                }
             }
         }
         Ok(())

--- a/src/stream/src/common/log_store_impl/kv_log_store/test_utils.rs
+++ b/src/stream/src/common/log_store_impl/kv_log_store/test_utils.rs
@@ -235,7 +235,7 @@ pub(crate) trait LogWriterTestExt: LogWriter {
         next_epoch: u64,
         is_checkpoint: bool,
     ) -> LogStoreResult<()> {
-        let post_flush = self
+        let result = self
             .flush_current_epoch(
                 next_epoch,
                 FlushCurrentEpochOptions {
@@ -247,7 +247,7 @@ pub(crate) trait LogWriterTestExt: LogWriter {
                 },
             )
             .await?;
-        (post_flush).post_yield_barrier().await?;
+        result.post_flush.post_yield_barrier().await?;
         Ok(())
     }
 }

--- a/src/stream/src/common/log_store_impl/kv_log_store/writer.rs
+++ b/src/stream/src/common/log_store_impl/kv_log_store/writer.rs
@@ -20,7 +20,8 @@ use risingwave_common::array::StreamChunk;
 use risingwave_common::bitmap::Bitmap;
 use risingwave_common::util::epoch::EpochPair;
 use risingwave_connector::sink::log_store::{
-    FlushCurrentEpochOptions, LogStoreResult, LogWriter, LogWriterPostFlushCurrentEpoch,
+    FlushCurrentEpochOptions, FlushCurrentEpochResult, LogStoreResult, LogWriter,
+    LogWriterPostFlushCurrentEpoch,
 };
 use risingwave_storage::store::LocalStateStore;
 use tokio::sync::mpsc::UnboundedSender;
@@ -137,9 +138,10 @@ impl<LS: LocalStateStore> LogWriter for KvLogStoreWriter<LS> {
         &mut self,
         next_epoch: u64,
         options: FlushCurrentEpochOptions,
-    ) -> LogStoreResult<LogWriterPostFlushCurrentEpoch<'_>> {
+    ) -> LogStoreResult<FlushCurrentEpochResult<'_>> {
         let epoch = self.state.epoch().curr;
         let mut writer = self.state.start_writer(false);
+        let mut reported_error_rows = vec![];
 
         // When the stream is paused, donot flush barrier to ensure there is no dirty data in state store.
         // Besides, barrier on a paused stream is useless in log store because it won't change the log store state.
@@ -174,12 +176,15 @@ impl<LS: LocalStateStore> LogWriter for KvLogStoreWriter<LS> {
             options.is_stop,
         );
         if should_wait_log_store_flush {
-            let truncate_offset = self.tx.wait_for_barrier_truncation(epoch).await?;
+            let (truncate_offset, new_reported_error_rows) =
+                self.tx.wait_for_barrier_truncation(epoch).await?;
             assert_eq!(truncate_offset, (epoch, None));
             self.last_truncate_offset = Some(truncate_offset);
+            reported_error_rows.extend(new_reported_error_rows);
         }
-        if let Some(truncate_offset) = self.tx.pop_truncation(epoch) {
+        if let Some((truncate_offset, new_reported_error_rows)) = self.tx.pop_truncation(epoch) {
             self.last_truncate_offset = Some(truncate_offset);
+            reported_error_rows.extend(new_reported_error_rows);
         }
         let post_seal_epoch = self.state.seal_current_epoch(
             next_epoch,
@@ -192,25 +197,30 @@ impl<LS: LocalStateStore> LogWriter for KvLogStoreWriter<LS> {
         let update_vnode_bitmap_tx = &mut self.update_vnode_bitmap_tx;
         let tx = &mut self.tx;
         self.seq_id = FIRST_SEQ_ID;
-        Ok(LogWriterPostFlushCurrentEpoch::new(move || {
-            async move {
-                {
-                    let new_vnodes = options.new_vnode_bitmap;
+        Ok(FlushCurrentEpochResult {
+            post_flush: LogWriterPostFlushCurrentEpoch::new(move || {
+                async move {
+                    {
+                        let new_vnodes = options.new_vnode_bitmap;
 
-                    post_seal_epoch
-                        .post_yield_barrier(new_vnodes.clone())
-                        .await?;
-                    if let Some(new_vnodes) = new_vnodes {
-                        update_vnode_bitmap_tx
-                            .send((new_vnodes, next_epoch))
-                            .map_err(|_| anyhow!("fail to send update vnode bitmap to reader"))?;
-                        tx.clear();
+                        post_seal_epoch
+                            .post_yield_barrier(new_vnodes.clone())
+                            .await?;
+                        if let Some(new_vnodes) = new_vnodes {
+                            update_vnode_bitmap_tx
+                                .send((new_vnodes, next_epoch))
+                                .map_err(|_| {
+                                    anyhow!("fail to send update vnode bitmap to reader")
+                                })?;
+                            tx.clear();
+                        }
+                        Ok(())
                     }
-                    Ok(())
                 }
-            }
-            .boxed()
-        }))
+                .boxed()
+            }),
+            reported_error_rows,
+        })
     }
 
     fn pause(&mut self) -> LogStoreResult<()> {

--- a/src/stream/src/executor/sink.rs
+++ b/src/stream/src/executor/sink.rs
@@ -30,8 +30,8 @@ use risingwave_common_rate_limit::RateLimit;
 use risingwave_connector::dispatch_sink;
 use risingwave_connector::sink::catalog::{SinkId, SinkType};
 use risingwave_connector::sink::log_store::{
-    FlushCurrentEpochOptions, LogReader, LogReaderExt, LogReaderMetrics, LogStoreFactory,
-    LogWriter, LogWriterExt, LogWriterMetrics,
+    FlushCurrentEpochOptions, FlushCurrentEpochResult, LogReader, LogReaderExt, LogReaderMetrics,
+    LogStoreFactory, LogWriter, LogWriterExt, LogWriterMetrics,
 };
 use risingwave_connector::sink::{
     GLOBAL_SINK_METRICS, LogSinker, SINK_USER_FORCE_COMPACTION,
@@ -471,7 +471,10 @@ impl<F: LogStoreFactory> SinkExecutor<F> {
                     if wait_log_store_flush {
                         info!(%sink_id, "sink wait for log store flush");
                     }
-                    let post_flush = log_writer
+                    let FlushCurrentEpochResult {
+                        post_flush,
+                        reported_error_rows,
+                    } = log_writer
                         .flush_current_epoch(
                             barrier.epoch.curr,
                             FlushCurrentEpochOptions {
@@ -483,6 +486,10 @@ impl<F: LogStoreFactory> SinkExecutor<F> {
                             },
                         )
                         .await?;
+                    assert!(
+                        reported_error_rows.is_empty(),
+                        "sink error rows are not handled in this branch"
+                    );
 
                     let mutation = barrier.mutation.clone();
                     yield Message::Barrier(barrier);
@@ -927,7 +934,9 @@ mod test {
     use risingwave_common::catalog::{ColumnDesc, ColumnId};
     use risingwave_common::util::epoch::test_epoch;
     use risingwave_connector::sink::build_sink;
-    use risingwave_connector::sink::log_store::{LogStoreReadItem, LogStoreResult, TruncateOffset};
+    use risingwave_connector::sink::log_store::{
+        LogStoreReadItem, LogStoreResult, ReportedSinkErrorRow, TruncateOffset,
+    };
     use risingwave_connector::sink::trivial::BlackHoleSink;
     use tokio::sync::Notify;
 
@@ -986,7 +995,11 @@ mod test {
             pending().await
         }
 
-        fn truncate(&mut self, _offset: TruncateOffset) -> LogStoreResult<()> {
+        fn truncate(
+            &mut self,
+            _offset: TruncateOffset,
+            _error_rows: Vec<ReportedSinkErrorRow>,
+        ) -> LogStoreResult<()> {
             Ok(())
         }
 

--- a/src/tests/simulation/tests/integration_tests/sink/utils.rs
+++ b/src/tests/simulation/tests/integration_tests/sink/utils.rs
@@ -822,8 +822,10 @@ impl SimulationTestSink {
                                                 store.inc_checkpoint();
                                             }
                                             if schema_change.is_some() {
-                                                log_reader
-                                                    .truncate(TruncateOffset::Barrier { epoch })?;
+                                                log_reader.truncate(
+                                                    TruncateOffset::Barrier { epoch },
+                                                    vec![],
+                                                )?;
                                             }
                                         }
                                     }


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

This PR picks the log-store truncate parameter changes from `wenym1/sink-error-table` onto current `main`.

The intention is to make the later rebase of `wenym1/sink-error-table` drop these shared log-store changes automatically, instead of conflicting with the async truncate fix and current main branch changes.

Main changes:

- Add `ReportedSinkErrorRow` and return `FlushCurrentEpochResult` from `LogWriter::flush_current_epoch`.
- Extend `LogReader::truncate` to carry reported sink error rows together with the truncate offset.
- Thread the new truncate parameter through log-reader wrappers, boxed sink readers, in-memory log store, and KV log store reader/writer/buffer logic.
- Keep ordinary sink implementations passing `vec![]` for now.
- Temporarily assert in the sink executor that `reported_error_rows` is empty, because this branch only picks the log-store plumbing and does not include sink error-table persistence.

Validation:

- `cargo fmt`
- `git diff --check`
- `CARGO_INCREMENTAL=0 cargo clippy -p risingwave_connector -p risingwave_stream --all-targets --all-features`
- `cargo clippy --all-targets --all-features`

## Checklist

- [ ] I have written necessary rustdoc comments.
- [x] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [x] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

No user-facing changes.

</details>
