### PR TITLE
chore: cherry-pick #25431 and #25699 to v2.8.4-pg-vector-toast-nectar

### DIFF
--- a/ci/scripts/e2e-sink-test.sh
+++ b/ci/scripts/e2e-sink-test.sh
@@ -177,8 +177,10 @@ grep -Fx 'before update' "$HTTP_SINK_OUTPUT"
 grep -Fx 'hello world' "$HTTP_SINK_OUTPUT"
 grep -Fx '{"key":"value"}' "$HTTP_SINK_OUTPUT"
 grep -q '"event"' "$HTTP_SINK_OUTPUT"
-# Exactly 1 line from ignore_delete test + 2 from varchar test (NULL was skipped) + 1 from jsonb
-test "$(wc -l < "$HTTP_SINK_OUTPUT")" -eq 4
+grep -Fx 'dynamic url payload' "$HTTP_SINK_OUTPUT"
+grep -Fx 'dynamic url as select payload' "$HTTP_SINK_OUTPUT"
+# Exactly 1 line from ignore_delete test + 2 from varchar test (NULL was skipped) + 1 from jsonb + 2 from dynamic URL tests
+test "$(wc -l < "$HTTP_SINK_OUTPUT")" -eq 6
 # Verify the custom header set via header.x_test = 'rw-http-sink' was sent
 grep -q '"x_test": "rw-http-sink"' "$HTTP_SINK_HEADERS"
 # Verify inferred default content types for varchar and jsonb payloads

--- a/e2e_test/sink/http_sink.slt
+++ b/e2e_test/sink/http_sink.slt
@@ -1,13 +1,13 @@
 statement ok
 set sink_decouple = false;
 
-# ---- Validation: multiple columns should be rejected ----
+# ---- Validation: multiple columns must use payload/url shape ----
 # force_append_only bypasses the planner-level retract-stream check so our
 # connector validate() is actually reached.
 statement ok
 CREATE TABLE t_multi_col (a varchar, b varchar);
 
-statement error HTTP sink requires exactly 1 column
+statement error HTTP sink with multiple columns only supports payload and url columns, got a
 CREATE SINK s_multi_col FROM t_multi_col WITH (
     connector = 'http',
     url = 'http://localhost:18081',
@@ -18,11 +18,82 @@ CREATE SINK s_multi_col FROM t_multi_col WITH (
 statement ok
 DROP TABLE t_multi_col;
 
+# ---- Validation: single payload column still requires url option ----
+statement ok
+CREATE TABLE t_static_url_missing_option (payload varchar);
+
+statement error HTTP sink requires url option when schema has exactly 1 column
+CREATE SINK s_static_url_missing_option FROM t_static_url_missing_option WITH (
+    connector = 'http',
+    type = 'append-only',
+    force_append_only = 'true'
+);
+
+statement ok
+DROP TABLE t_static_url_missing_option;
+
+# ---- Validation: dynamic url column cannot coexist with url option ----
+statement ok
+CREATE TABLE t_dynamic_url_with_static_option (payload varchar, url varchar);
+
+statement error HTTP sink url option cannot coexist with url column
+CREATE SINK s_dynamic_url_with_static_option FROM t_dynamic_url_with_static_option WITH (
+    connector = 'http',
+    url = 'http://localhost:18081',
+    type = 'append-only',
+    force_append_only = 'true'
+);
+
+statement ok
+DROP TABLE t_dynamic_url_with_static_option;
+
+# ---- Validation: unsupported metadata columns are rejected ----
+statement ok
+CREATE TABLE t_dynamic_url_missing_url (payload varchar, extra varchar);
+
+statement error HTTP sink with multiple columns only supports payload and url columns, got extra
+CREATE SINK s_dynamic_url_missing_url FROM t_dynamic_url_missing_url WITH (
+    connector = 'http',
+    type = 'append-only',
+    force_append_only = 'true'
+);
+
+statement ok
+DROP TABLE t_dynamic_url_missing_url;
+
+# ---- Validation: dynamic url column must be varchar ----
+statement ok
+CREATE TABLE t_dynamic_url_bad_type (payload varchar, url int);
+
+statement error HTTP sink url column must be varchar
+CREATE SINK s_dynamic_url_bad_type FROM t_dynamic_url_bad_type WITH (
+    connector = 'http',
+    type = 'append-only',
+    force_append_only = 'true'
+);
+
+statement ok
+DROP TABLE t_dynamic_url_bad_type;
+
+# ---- Validation: extra columns are rejected ----
+statement ok
+CREATE TABLE t_dynamic_url_extra_column (payload varchar, url varchar, extra varchar);
+
+statement error HTTP sink with multiple columns only supports payload and url columns, got extra
+CREATE SINK s_dynamic_url_extra_column FROM t_dynamic_url_extra_column WITH (
+    connector = 'http',
+    type = 'append-only',
+    force_append_only = 'true'
+);
+
+statement ok
+DROP TABLE t_dynamic_url_extra_column;
+
 # ---- Validation: wrong column type should be rejected ----
 statement ok
 CREATE TABLE t_int_col (payload int);
 
-statement error HTTP sink column must be varchar or jsonb
+statement error HTTP sink payload column must be varchar or jsonb
 CREATE SINK s_int_col FROM t_int_col WITH (
     connector = 'http',
     url = 'http://localhost:18081',
@@ -153,3 +224,52 @@ DROP SINK s_jsonb;
 
 statement ok
 DROP TABLE t_jsonb;
+
+# ---- Success: dynamic url column ----
+statement ok
+CREATE TABLE t_dynamic_url (payload varchar, url varchar);
+
+statement ok
+CREATE SINK s_dynamic_url FROM t_dynamic_url WITH (
+    connector = 'http',
+    type = 'append-only',
+    force_append_only = 'true'
+);
+
+statement ok
+INSERT INTO t_dynamic_url VALUES ('dynamic url payload', 'http://localhost:18081');
+
+statement ok
+INSERT INTO t_dynamic_url VALUES ('skipped dynamic url payload', 'not a url');
+
+statement ok
+FLUSH;
+
+statement ok
+DROP SINK s_dynamic_url;
+
+statement ok
+DROP TABLE t_dynamic_url;
+
+# ---- Success: dynamic url column with CREATE SINK AS SELECT ----
+statement ok
+CREATE TABLE t_dynamic_url_as_select_src (body varchar, target_url varchar);
+
+statement ok
+CREATE SINK s_dynamic_url_as_select AS SELECT body AS payload, target_url AS url FROM t_dynamic_url_as_select_src WITH (
+    connector = 'http',
+    type = 'append-only',
+    force_append_only = 'true'
+);
+
+statement ok
+INSERT INTO t_dynamic_url_as_select_src VALUES ('dynamic url as select payload', 'http://localhost:18081');
+
+statement ok
+FLUSH;
+
+statement ok
+DROP SINK s_dynamic_url_as_select;
+
+statement ok
+DROP TABLE t_dynamic_url_as_select_src;

--- a/e2e_test/source_legacy/cdc_inline/auto_schema_change_pg.slt
+++ b/e2e_test/source_legacy/cdc_inline/auto_schema_change_pg.slt
@@ -13,7 +13,7 @@ psql -c "
         v4 boolean DEFAULT false,
         v5 date DEFAULT '2020-01-01',
         v6 time DEFAULT '12:34:56',
-        v7 timestamp DEFAULT '2020-01-01 12:34:56',
+        v7 timestamp DEFAULT now(),
         v8 timestamptz DEFAULT '2020-01-01 12:34:56+00',
         v9 interval DEFAULT '1 day',
         v10 jsonb DEFAULT '{}',
@@ -61,12 +61,14 @@ distribution key id NULL NULL
 table description rw_test_schema_change NULL NULL
 
 
+# v7 defaults to `now()` upstream, so its value is non-deterministic;
+# use <slt:ignore> to skip matching those two tokens (date + time).
 query TTTTTTTTTTTTT retry 4 backoff 1s
 SELECT * from rw_test_schema_change order by id;
 ----
-1 name1 20 1.1 2.2 3.3 f 2020-01-01 12:34:56 2020-01-01 12:34:56 2020-01-01 12:34:56+00:00 1 day {}
-2 name2 21 1.1 2.2 3.3 f 2020-01-01 12:34:56 2020-01-01 12:34:56 2020-01-01 12:34:56+00:00 1 day {}
-3 name3 22 1.1 2.2 3.3 f 2020-01-01 12:34:56 2020-01-01 12:34:56 2020-01-01 12:34:56+00:00 1 day {}
+1 name1 20 1.1 2.2 3.3 f 2020-01-01 12:34:56 <slt:ignore> <slt:ignore> 2020-01-01 12:34:56+00:00 1 day {}
+2 name2 21 1.1 2.2 3.3 f 2020-01-01 12:34:56 <slt:ignore> <slt:ignore> 2020-01-01 12:34:56+00:00 1 day {}
+3 name3 22 1.1 2.2 3.3 f 2020-01-01 12:34:56 <slt:ignore> <slt:ignore> 2020-01-01 12:34:56+00:00 1 day {}
 
 sleep 3s
 
@@ -108,10 +110,10 @@ table description rw_test_schema_change NULL NULL
 query TTTTTTTTTTTTTTT retry 4 backoff 1s
 SELECT * from rw_test_schema_change order by id;
 ----
-1 name1 20 1.1 2.2 3.3 f 2020-01-01 12:34:56 2020-01-01 12:34:56 2020-01-01 12:34:56+00:00 1 day {} hello 1.2345
-2 name2 21 1.1 2.2 3.3 f 2020-01-01 12:34:56 2020-01-01 12:34:56 2020-01-01 12:34:56+00:00 1 day {} hello 1.2345
-3 name3 22 1.1 2.2 3.3 f 2020-01-01 12:34:56 2020-01-01 12:34:56 2020-01-01 12:34:56+00:00 1 day {} hello 1.2345
-11 aaa 11 1.1 2.2 3.3 f 2020-01-01 12:34:56 2020-01-01 12:34:56 2020-01-01 12:34:56+00:00 1 day {} hello 1.2345
+1 name1 20 1.1 2.2 3.3 f 2020-01-01 12:34:56 <slt:ignore> <slt:ignore> 2020-01-01 12:34:56+00:00 1 day {} hello 1.2345
+2 name2 21 1.1 2.2 3.3 f 2020-01-01 12:34:56 <slt:ignore> <slt:ignore> 2020-01-01 12:34:56+00:00 1 day {} hello 1.2345
+3 name3 22 1.1 2.2 3.3 f 2020-01-01 12:34:56 <slt:ignore> <slt:ignore> 2020-01-01 12:34:56+00:00 1 day {} hello 1.2345
+11 aaa 11 1.1 2.2 3.3 f 2020-01-01 12:34:56 <slt:ignore> <slt:ignore> 2020-01-01 12:34:56+00:00 1 day {} hello 1.2345
 
 
 system ok
@@ -153,11 +155,11 @@ table description rw_test_schema_change NULL NULL
 query TTTTTTTTTTTTTTT retry 4 backoff 1s
 SELECT * from rw_test_schema_change order by id;
 ----
-1 name1 20 3.3 f 2020-01-01 12:34:56 2020-01-01 12:34:56 2020-01-01 12:34:56+00:00 1 day {} hello 1.2345
-2 name2 21 3.3 f 2020-01-01 12:34:56 2020-01-01 12:34:56 2020-01-01 12:34:56+00:00 1 day {} hello 1.2345
-3 name3 22 3.3 f 2020-01-01 12:34:56 2020-01-01 12:34:56 2020-01-01 12:34:56+00:00 1 day {} hello 1.2345
-11 aaa 11 3.3 f 2020-01-01 12:34:56 2020-01-01 12:34:56 2020-01-01 12:34:56+00:00 1 day {} hello 1.2345
-12 bbb 12 3.3 f 2020-01-01 12:34:56 2020-01-01 12:34:56 2020-01-01 12:34:56+00:00 1 day {} hello 1.2345
+1 name1 20 3.3 f 2020-01-01 12:34:56 <slt:ignore> <slt:ignore> 2020-01-01 12:34:56+00:00 1 day {} hello 1.2345
+2 name2 21 3.3 f 2020-01-01 12:34:56 <slt:ignore> <slt:ignore> 2020-01-01 12:34:56+00:00 1 day {} hello 1.2345
+3 name3 22 3.3 f 2020-01-01 12:34:56 <slt:ignore> <slt:ignore> 2020-01-01 12:34:56+00:00 1 day {} hello 1.2345
+11 aaa 11 3.3 f 2020-01-01 12:34:56 <slt:ignore> <slt:ignore> 2020-01-01 12:34:56+00:00 1 day {} hello 1.2345
+12 bbb 12 3.3 f 2020-01-01 12:34:56 <slt:ignore> <slt:ignore> 2020-01-01 12:34:56+00:00 1 day {} hello 1.2345
 
 
 statement ok

--- a/src/connector/src/parser/unified/debezium.rs
+++ b/src/connector/src/parser/unified/debezium.rs
@@ -470,23 +470,49 @@ pub async fn parse_schema_change(
                                     }
                                 }
 
-                                let snapshot_value: Datum = if let Some(value_text) = value_text {
-                                    Some(ScalarImpl::from_text(value_text.as_str(), &data_type).map_err(
-                                        |err| {
-                                            tracing::error!(target: "auto_schema_change", error=%err.as_report(), "failed to parse default value expression");
-                                            AccessError::TypeError {
-                                                expected: "constant expression".into(),
-                                                got: data_type.to_string(),
-                                                value: value_text,
-                                            }
-                                        },
-                                    )?)
-                                } else {
-                                    None
-                                };
+                                // Handling default values during auto schema change is hard to get
+                                // completely right. The fundamental challenge is that we need to
+                                // accurately distinguish "literal constants" from "real expressions"
+                                // and evaluate each correctly. However, PostgreSQL / MySQL literal
+                                // grammar is quite complex (bit / hex / escape strings, arrays,
+                                // literals with casts, etc.), and `ScalarImpl::from_text` only
+                                // recognizes simple literals. Any function call (`now()`,
+                                // `gen_random_uuid()`) or unsupported literal form will fail here.
+                                //
+                                // Current strategy is fail-open: on parse failure we only emit a
+                                // warn log and add the column without a default, rather than
+                                // aborting the whole auto schema change. This is strictly better
+                                // than the previous hard-crash behavior — the pipeline stays
+                                // available, and the worst case is that existing rows are NULL in a
+                                // newly-added column (see the warn message below for details).
+                                //
+                                // TODO: the schema change event carries the **full** set of columns
+                                // of the table, so here we cannot tell "columns newly added by this
+                                // ALTER" from "columns that already existed". A better approach
+                                // would be to only process the delta columns that actually changed
+                                // in this event, which would let us precisely tell the user: which
+                                // columns have existing rows filled with NULL (needs attention),
+                                // and which ones are pre-existing columns merely surfaced by the
+                                // event (harmless, can be ignored silently).
+                                let snapshot_value: Datum = value_text.and_then(|value_text| {
+                                    ScalarImpl::from_text(value_text.as_str(), &data_type)
+                                        .inspect_err(|err| {
+                                            tracing::warn!(
+                                                target: "auto_schema_change",
+                                                error = %err.as_report(),
+                                                column = %name,
+                                                data_type = %data_type,
+                                                default_value_expression = default_val_expr_str,
+                                                upstream_ddl = %upstream_ddl,
+                                                "non-constant default expression, column added without default. \
+                                                 If this column is not newly added by this schema change, it is safe to ignore this warning. \
+                                                 If this column is newly added by this schema change, existing rows will be NULL in this column — consider using COALESCE in queries to provide a fallback value."
+                                            );
+                                        })
+                                        .ok()
+                                });
 
                                 if snapshot_value.is_none() {
-                                    tracing::warn!(target: "auto_schema_change", "failed to parse default value expression: {}", default_val_expr_str);
                                     ColumnDesc::named(name, ColumnId::placeholder(), data_type)
                                 } else {
                                     ColumnDesc::named_with_default_value(

--- a/src/connector/src/sink/http.rs
+++ b/src/connector/src/sink/http.rs
@@ -19,8 +19,9 @@ use reqwest::header::{CONTENT_TYPE, HeaderMap, HeaderName, HeaderValue};
 use risingwave_common::array::{Op, StreamChunk};
 use risingwave_common::catalog::Schema;
 use risingwave_common::row::Row;
-use risingwave_common::types::{DataType, ScalarRefImpl};
+use risingwave_common::types::{DataType, JsonbRef, ScalarRefImpl};
 use serde::Deserialize;
+use thiserror_ext::AsReport;
 use with_options::WithOptions;
 
 use crate::enforce_secret::EnforceSecret;
@@ -31,11 +32,13 @@ use crate::sink::writer::{
 use crate::sink::{Result, SINK_TYPE_APPEND_ONLY, Sink, SinkError, SinkParam, SinkWriterParam};
 
 pub const HTTP_SINK: &str = "http";
+const HTTP_SINK_PAYLOAD_COLUMN: &str = "payload";
+const HTTP_SINK_URL_COLUMN: &str = "url";
 
 #[derive(Clone, Debug, Deserialize, WithOptions)]
 pub struct HttpConfig {
     /// The endpoint URL to POST data to.
-    pub url: String,
+    pub url: Option<String>,
 
     /// Content-Type header value. Defaults to `text/plain` for `varchar` and `application/json`
     /// for `jsonb`.
@@ -75,47 +78,108 @@ impl HttpConfig {
     }
 }
 
-/// Validates the HTTP sink parameters and returns the parsed URL and default headers so callers
-/// can use them directly without re-parsing.
+#[derive(Clone, Debug)]
+enum HttpUrl {
+    Static(reqwest::Url),
+    Dynamic { url_index: usize },
+}
+
+/// Validates the HTTP sink parameters and returns the sink so callers can use it directly without
+/// re-parsing.
 fn validate_http_sink(
     is_append_only: bool,
     ignore_delete: bool,
     schema: &Schema,
-    url: &str,
+    url: Option<&str>,
     content_type: Option<&str>,
     headers: &BTreeMap<String, String>,
-) -> Result<(reqwest::Url, HeaderMap)> {
+) -> Result<HttpSink> {
     if !is_append_only && !ignore_delete {
         return Err(SinkError::Config(anyhow!(
             "HTTP sink only supports append-only mode"
         )));
     }
 
-    if schema.fields().len() != 1 {
+    let fields = schema.fields();
+    let (payload_index, url, payload_type) = if fields.len() == 1 {
+        let Some(url) = url else {
+            return Err(SinkError::Config(anyhow!(
+                "HTTP sink requires url option when schema has exactly 1 column"
+            )));
+        };
+        let url = url
+            .parse()
+            .context("invalid URL")
+            .map_err(SinkError::Config)?;
+        (0, HttpUrl::Static(url), fields[0].data_type.clone())
+    } else {
+        for field in fields {
+            match field.name.as_str() {
+                HTTP_SINK_PAYLOAD_COLUMN | HTTP_SINK_URL_COLUMN => {}
+                _ => {
+                    return Err(SinkError::Config(anyhow!(
+                        "HTTP sink with multiple columns only supports payload and url columns, got {}",
+                        field.name
+                    )));
+                }
+            }
+        }
+
+        let payload_index = fields
+            .iter()
+            .position(|field| field.name == HTTP_SINK_PAYLOAD_COLUMN)
+            .ok_or_else(|| {
+                SinkError::Config(anyhow!(
+                    "HTTP sink with multiple columns requires a payload column"
+                ))
+            })?;
+        let url_index = fields
+            .iter()
+            .position(|field| field.name == HTTP_SINK_URL_COLUMN);
+        let url = match (url, url_index) {
+            (Some(_), Some(_)) => {
+                return Err(SinkError::Config(anyhow!(
+                    "HTTP sink url option cannot coexist with url column"
+                )));
+            }
+            (Some(url), None) => {
+                let url = url
+                    .parse()
+                    .context("invalid URL")
+                    .map_err(SinkError::Config)?;
+                HttpUrl::Static(url)
+            }
+            (None, Some(url_index)) => {
+                if fields[url_index].data_type != DataType::Varchar {
+                    return Err(SinkError::Config(anyhow!(
+                        "HTTP sink url column must be varchar, got {:?}",
+                        fields[url_index].data_type
+                    )));
+                }
+                HttpUrl::Dynamic { url_index }
+            }
+            (None, None) => {
+                return Err(SinkError::Config(anyhow!(
+                    "HTTP sink requires either url option or url column"
+                )));
+            }
+        };
+
+        (payload_index, url, fields[payload_index].data_type.clone())
+    };
+
+    if payload_type != DataType::Varchar && payload_type != DataType::Jsonb {
         return Err(SinkError::Config(anyhow!(
-            "HTTP sink requires exactly 1 column, got {}",
-            schema.fields().len()
+            "HTTP sink payload column must be varchar or jsonb, got {:?}",
+            payload_type
         )));
     }
-
-    let col_type = schema.fields()[0].data_type.clone();
-    if col_type != DataType::Varchar && col_type != DataType::Jsonb {
-        return Err(SinkError::Config(anyhow!(
-            "HTTP sink column must be varchar or jsonb, got {:?}",
-            col_type
-        )));
-    }
-
-    let parsed_url = url
-        .parse()
-        .context("invalid URL")
-        .map_err(SinkError::Config)?;
 
     let mut header_map = HeaderMap::new();
     header_map.insert(
         CONTENT_TYPE,
         content_type
-            .unwrap_or(match col_type {
+            .unwrap_or(match payload_type {
                 DataType::Varchar => "text/plain",
                 DataType::Jsonb => "application/json",
                 _ => unreachable!("validated HTTP sink column type"),
@@ -136,12 +200,17 @@ fn validate_http_sink(
         header_map.insert(name, value);
     }
 
-    Ok((parsed_url, header_map))
+    Ok(HttpSink {
+        url,
+        payload_index,
+        header_map,
+    })
 }
 
 #[derive(Clone, Debug)]
 pub struct HttpSink {
-    endpoint: String,
+    url: HttpUrl,
+    payload_index: usize,
     header_map: HeaderMap,
 }
 
@@ -162,18 +231,14 @@ impl TryFrom<SinkParam> for HttpSink {
     fn try_from(param: SinkParam) -> std::result::Result<Self, Self::Error> {
         let schema = param.schema();
         let (config, headers) = HttpConfig::from_btreemap(param.properties)?;
-        let (_parsed_url, header_map) = validate_http_sink(
+        validate_http_sink(
             param.sink_type.is_append_only(),
             param.ignore_delete,
             &schema,
-            &config.url,
+            config.url.as_deref(),
             config.content_type.as_deref(),
             &headers,
-        )?;
-        Ok(Self {
-            endpoint: config.url,
-            header_map,
-        })
+        )
     }
 }
 
@@ -187,28 +252,149 @@ impl Sink for HttpSink {
     }
 
     async fn new_log_sinker(&self, _writer_param: SinkWriterParam) -> Result<Self::LogSinker> {
-        Ok(
-            HttpSinkWriter::new(self.endpoint.clone(), self.header_map.clone())?
-                .into_log_sinker(usize::MAX),
-        )
+        Ok(HttpSinkWriter::new(
+            self.url.clone(),
+            self.payload_index,
+            self.header_map.clone(),
+        )?
+        .into_log_sinker(usize::MAX))
     }
 }
 
 pub struct HttpSinkWriter {
     client: reqwest::Client,
-    endpoint: String,
+    url: HttpUrl,
+    payload_index: usize,
 }
 
 impl HttpSinkWriter {
-    pub fn new(endpoint: String, header_map: HeaderMap) -> Result<Self> {
+    fn new(url: HttpUrl, payload_index: usize, header_map: HeaderMap) -> Result<Self> {
         let client = reqwest::Client::builder()
             .default_headers(header_map)
             .build()
             .context("failed to build HTTP client")
             .map_err(SinkError::Http)?;
 
-        Ok(Self { client, endpoint })
+        Ok(Self {
+            client,
+            url,
+            payload_index,
+        })
     }
+
+    fn extract_url(&self, row: &impl Row) -> Result<Option<reqwest::Url>> {
+        match &self.url {
+            HttpUrl::Static(url) => Ok(Some(url.clone())),
+            HttpUrl::Dynamic { url_index } => match row.datum_at(*url_index) {
+                Some(ScalarRefImpl::Utf8(url)) if !url.is_empty() => {
+                    match url.parse::<reqwest::Url>() {
+                        Ok(url) => Ok(Some(url)),
+                        Err(err) => {
+                            tracing::warn!(
+                                error = %err.as_report(),
+                                payload = %self.strip_payload_for_log(row),
+                                "skip HTTP sink row due to invalid URL in url column"
+                            );
+                            Ok(None)
+                        }
+                    }
+                }
+                Some(ScalarRefImpl::Utf8(_)) | None => {
+                    tracing::warn!(
+                        payload = %self.strip_payload_for_log(row),
+                        "skip HTTP sink row due to null or empty url column"
+                    );
+                    Ok(None)
+                }
+                Some(_) => Err(SinkError::Http(anyhow!(
+                    "unexpected url column type, expected varchar"
+                ))),
+            },
+        }
+    }
+
+    fn strip_payload_for_log(&self, row: &impl Row) -> String {
+        match row.datum_at(self.payload_index) {
+            Some(ScalarRefImpl::Utf8(s)) => strip_text_payload(s),
+            Some(ScalarRefImpl::Jsonb(j)) => strip_jsonb_payload(j),
+            Some(_) => "<unexpected payload type>".to_owned(),
+            None => "NULL".to_owned(),
+        }
+    }
+
+    fn extract_payload(&self, row: &impl Row) -> Result<Option<String>> {
+        Ok(match row.datum_at(self.payload_index) {
+            Some(ScalarRefImpl::Utf8(s)) => Some(s.to_owned()),
+            Some(ScalarRefImpl::Jsonb(j)) => Some(j.to_string()),
+            Some(_) => {
+                return Err(SinkError::Http(anyhow!(
+                    "unexpected payload column type, expected varchar or jsonb"
+                )));
+            }
+            None => None, // skip NULL rows
+        })
+    }
+}
+
+fn strip_text_payload(payload: &str) -> String {
+    const EDGE_CHAR_COUNT: usize = 100;
+    let char_count = payload.chars().count();
+    if char_count <= EDGE_CHAR_COUNT * 2 {
+        return payload.to_owned();
+    }
+
+    let prefix: String = payload.chars().take(EDGE_CHAR_COUNT).collect();
+    let suffix: String = payload.chars().skip(char_count - EDGE_CHAR_COUNT).collect();
+    format!("{prefix}...{suffix}")
+}
+
+fn strip_jsonb_payload(payload: JsonbRef<'_>) -> String {
+    if payload.is_array() {
+        let len = payload.array_len().expect("checked JSON array type");
+        return match len {
+            0 => "[]".to_owned(),
+            1 => {
+                let first = payload.access_array_element(0).expect("JSON array element");
+                format!("[{}]", strip_jsonb_payload(first))
+            }
+            2 => {
+                let first = payload.access_array_element(0).expect("JSON array element");
+                let second = payload.access_array_element(1).expect("JSON array element");
+                format!(
+                    "[{},{}]",
+                    strip_jsonb_payload(first),
+                    strip_jsonb_payload(second)
+                )
+            }
+            _ => {
+                let first = payload.access_array_element(0).expect("JSON array element");
+                let last = payload
+                    .access_array_element(len - 1)
+                    .expect("JSON array element");
+                format!(
+                    "[{},...,{}]",
+                    strip_jsonb_payload(first),
+                    strip_jsonb_payload(last)
+                )
+            }
+        };
+    }
+
+    if let Ok(fields) = payload.object_key_values() {
+        let fields = fields
+            .map(|(key, value)| {
+                let key = serde_json::to_string(key).expect("serialize JSON object key");
+                format!("{key}:{}", strip_jsonb_payload(value))
+            })
+            .collect::<Vec<_>>();
+        return format!("{{{}}}", fields.join(","));
+    }
+
+    if let Ok(value) = payload.as_str() {
+        return serde_json::to_string(&strip_text_payload(value)).expect("serialize JSON string");
+    }
+
+    payload.to_string()
 }
 
 impl AsyncTruncateSinkWriter for HttpSinkWriter {
@@ -222,20 +408,16 @@ impl AsyncTruncateSinkWriter for HttpSinkWriter {
                 continue;
             }
 
-            let payload = match row.datum_at(0) {
-                Some(ScalarRefImpl::Utf8(s)) => s.to_owned(),
-                Some(ScalarRefImpl::Jsonb(j)) => j.to_string(),
-                Some(_) => {
-                    return Err(SinkError::Http(anyhow!(
-                        "unexpected column type, expected varchar or jsonb"
-                    )));
-                }
-                None => continue, // skip NULL rows
+            let Some(payload) = self.extract_payload(&row)? else {
+                continue;
+            };
+            let Some(url) = self.extract_url(&row)? else {
+                continue;
             };
 
             let resp = self
                 .client
-                .post(&self.endpoint)
+                .post(url)
                 .body(payload)
                 .send()
                 .await
@@ -254,5 +436,51 @@ impl AsyncTruncateSinkWriter for HttpSinkWriter {
         }
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use risingwave_common::types::{JsonbVal, Scalar};
+
+    use super::*;
+
+    #[test]
+    fn test_strip_text_payload() {
+        assert_eq!(strip_text_payload("short payload"), "short payload");
+
+        let payload = format!("{}{}", "a".repeat(100), "z".repeat(100));
+        assert_eq!(strip_text_payload(&payload), payload);
+
+        let payload = format!("{}middle{}", "a".repeat(101), "z".repeat(101));
+        assert_eq!(
+            strip_text_payload(&payload),
+            format!("{}...{}", "a".repeat(100), "z".repeat(100))
+        );
+    }
+
+    #[test]
+    fn test_strip_jsonb_payload() {
+        let payload: JsonbVal = r#"{
+            "id": 1,
+            "items": [1, {"nested": ["first", "middle", "last"]}, 3],
+            "message": "short"
+        }"#
+        .parse()
+        .unwrap();
+
+        assert_eq!(
+            strip_jsonb_payload(payload.as_scalar_ref()),
+            r#"{"id":1,"items":[1,...,3],"message":"short"}"#
+        );
+
+        let payload: JsonbVal = r#"["only"]"#.parse().unwrap();
+        assert_eq!(strip_jsonb_payload(payload.as_scalar_ref()), r#"["only"]"#);
+
+        let payload: JsonbVal = r#"["first","last"]"#.parse().unwrap();
+        assert_eq!(
+            strip_jsonb_payload(payload.as_scalar_ref()),
+            r#"["first","last"]"#
+        );
     }
 }

--- a/src/connector/with_options_sink.yaml
+++ b/src/connector/with_options_sink.yaml
@@ -439,7 +439,7 @@ HttpConfig:
   - name: url
     field_type: String
     comments: The endpoint URL to POST data to.
-    required: true
+    required: false
   - name: content_type
     field_type: String
     comments: |-


### PR DESCRIPTION
Cherry-pick the remaining two fixes requested for `v2.8.4-pg-vector-toast-nectar`.

Original PRs:
- #25431: https://github.com/risingwavelabs/risingwave/pull/25431
- #25699: https://github.com/risingwavelabs/risingwave/pull/25699

Cherry-pick commits:
- `34bc45459d`: `feat(sink): support dynamic URL for HTTP sink (#25699)`
- `754434bd36`: `fix(cdc): avoid aborting auto schema change on non-constant default expressions (#25431)`

What changed:
- Backports HTTP sink dynamic URL support from #25699.
- Backports the PostgreSQL CDC auto schema change non-constant default handling from #25431.
- Leaves #25742 untouched because it is already merged into this branch via #25888.

Local verification:
- `cargo fmt --check`
- `git diff --check origin/v2.8.4-pg-vector-toast-nectar..HEAD`

Tests:
- Not run per request.

Labels:
- Added: `cherry-pick`, `A-cdc`, `A-connector`, `pg-cdc`, `user-facing-changes`, `ci/run-e2e-source-tests`, `ci/run-e2e-sink-tests`.
- Intentionally not added: `ci/run-e2e-tests`, because source/sink e2e labels cover the affected connector areas more narrowly.

Label protocol note:
- The target branch does not contain `.agents/PR_LABELING.md`; I read the guide from `origin/main:.agents/PR_LABELING.md` before creating this PR.