### PR TITLE
fix(frontend): include indexes in fragment DDL mapping

### DIFF
--- a/e2e_test/ddl/index.slt
+++ b/e2e_test/ddl/index.slt
@@ -10,6 +10,13 @@ create materialized view ddl_mv as select v1 from ddl_t;
 statement ok
 create index ddl_index on ddl_t(v1);
 
+query TT
+select distinct ddl_type, name
+from rw_catalog.rw_fragment_id_to_ddl
+where ddl_type = 'index' and name = 'ddl_index';
+----
+index ddl_index
+
 statement error
 drop index ddl_mv;
 

--- a/src/frontend/src/catalog/system_catalog/rw_catalog/rw_fragment_id_to_ddl.rs
+++ b/src/frontend/src/catalog/system_catalog/rw_catalog/rw_fragment_id_to_ddl.rs
@@ -17,17 +17,18 @@ use risingwave_frontend_macro::system_catalog;
 
 /// Provides a mapping from `fragment_id` to its ddl info.
 #[system_catalog(
-view,
-"rw_catalog.rw_fragment_id_to_ddl",
-"with
-   job_id_to_mv as (select fragment_id, d.id as job_id, schema_id, 'mv' as ddl_type, name from rw_materialized_views d join rw_fragments f on d.id = f.table_id),
-   job_id_to_sink as (select fragment_id, d.id as job_id, schema_id, 'sink' as ddl_type, name from rw_sinks d join rw_fragments f on d.id = f.table_id),
-   job_id_to_source as (select fragment_id, d.id as job_id, schema_id, 'source' as ddl_type, name from rw_sources d join rw_fragments f on d.id = f.table_id),
-   job_id_to_table as (select fragment_id, d.id as job_id, schema_id, 'table' as ddl_type, name from rw_tables d join rw_fragments f on d.id = f.table_id)
-   select * from job_id_to_mv
-     union all select * from job_id_to_sink
-       union all select * from job_id_to_source
-         union all select * from job_id_to_table"
+    view,
+    "rw_catalog.rw_fragment_id_to_ddl",
+    "with
+   all_streaming_jobs as (
+     select id as job_id, schema_id, 'mv' as ddl_type, name from rw_materialized_views
+       union all select id as job_id, schema_id, 'sink' as ddl_type, name from rw_sinks
+         union all select id as job_id, schema_id, 'source' as ddl_type, name from rw_sources
+           union all select id as job_id, schema_id, 'table' as ddl_type, name from rw_tables
+             union all select id as job_id, schema_id, 'index' as ddl_type, name from rw_indexes
+   )
+   select f.fragment_id, job.job_id, job.schema_id, job.ddl_type, job.name
+   from all_streaming_jobs job join rw_fragments f on job.job_id = f.table_id"
 )]
 #[derive(Fields)]
 struct RwFragmentIdToDdl {


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

This PR includes index streaming jobs in `rw_catalog.rw_fragment_id_to_ddl`.

Previously, the view mapped fragment IDs for materialized views, sinks, sources, and tables, but omitted indexes. This made index fragments invisible to queries that use the view to resolve fragment IDs back to DDL objects. The view now first unions all streaming job catalog entries, including `rw_indexes`, and then joins `rw_fragments` once.

The PR also adds an SLT assertion that a created index appears in `rw_fragment_id_to_ddl` with `ddl_type = 'index'`.

- Closes #N/A

## Checklist

- [ ] I have written necessary rustdoc comments.
- [x] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [x] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

`rw_catalog.rw_fragment_id_to_ddl` now includes index streaming job fragments.

</details>
