### PR TITLE
Fix panic for DISTINCT ON with aggregate and no GROUP BY

### DIFF
--- a/src/frontend/planner_test/tests/testdata/input/distinct_on.yaml
+++ b/src/frontend/planner_test/tests/testdata/input/distinct_on.yaml
@@ -122,3 +122,9 @@
   expected_outputs:
     - batch_plan
     - logical_plan
+# Regression test: DISTINCT ON with an aggregate but no GROUP BY must error, not panic
+- sql: |
+    create table t (x int);
+    select distinct on(x) count(*) from t;
+  expected_outputs:
+    - planner_error

--- a/src/frontend/planner_test/tests/testdata/output/distinct_on.yaml
+++ b/src/frontend/planner_test/tests/testdata/output/distinct_on.yaml
@@ -238,3 +238,7 @@
         └─BatchGroupTopN { order: [], limit: 1, offset: 0, group_key: [t.a, t.b] }
           └─BatchExchange { order: [], dist: HashShard(t.a, t.b) }
             └─BatchScan { table: t, columns: [t.a, t.b], distribution: SomeShard }
+- sql: |
+    create table t (x int);
+    select distinct on(x) count(*) from t;
+  planner_error: 'Invalid input syntax: column must appear in the GROUP BY clause or be used in an aggregate function'

--- a/src/frontend/src/planner/select.rs
+++ b/src/frontend/src/planner/select.rs
@@ -50,7 +50,7 @@ impl Planner {
             mut select_items,
             group_by,
             mut having,
-            distinct,
+            mut distinct,
             ..
         }: BoundSelect,
         extra_order_exprs: Vec<ExprImpl>,
@@ -104,8 +104,25 @@ impl Planner {
         // TODO: select-agg, group-by, having can also contain subquery exprs.
         let has_agg_call = select_items.iter().any(|expr| expr.has_agg_call());
         if !group_by.is_empty() || having.is_some() || has_agg_call {
+            // The `DISTINCT ON` expressions must also be rewritten to reference the
+            // aggregated results, just like the SELECT and ORDER BY expressions. By
+            // appending them to `select_items` they go through the same agg rewriting,
+            // which maps group-key references and rejects any column that neither
+            // appears in GROUP BY nor inside an aggregate (matching PostgreSQL).
+            let n_distinct_on = if let BoundDistinct::DistinctOn(exprs) = &distinct {
+                select_items.extend(exprs.iter().cloned());
+                exprs.len()
+            } else {
+                0
+            };
+
             (root, select_items, having) =
                 LogicalAgg::create(select_items, group_by, having, root)?;
+
+            if n_distinct_on > 0 {
+                let rewritten = select_items.split_off(select_items.len() - n_distinct_on);
+                distinct = BoundDistinct::DistinctOn(rewritten);
+            }
         }
 
         if let Some(having) = having {


### PR DESCRIPTION
When a `SELECT DISTINCT ON` query contained an aggregate call but no `GROUP BY` clause, the planner would panic with an inconsistent input schema error instead of producing a proper error. This happened because the `DISTINCT ON` expressions were not being rewritten to reference the aggregated output, so the downstream `Dedup` node referenced bare columns after `LogicalAgg`.

This PR fixes the bug by appending the `DISTINCT ON` expressions to `select_items` before building the `LogicalAgg`, so they go through the same aggregation rewriting (which maps group-key references and rejects columns that neither appear in `GROUP BY` nor inside an aggregate). The rewritten expressions are then split back out to populate the `DistinctOn` node. As a result, `select distinct on(x) count(*) from t;` now correctly raises a planner error matching PostgreSQL's behavior. A regression test is added under `distinct_on.yaml`.

I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

- Resolves #15865
- Append `DISTINCT ON` expressions to `select_items` so they are rewritten by `LogicalAgg::create`, then split them back out to rebuild the `DistinctOn` node.
- Add a regression planner test for `select distinct on(x) count(*) from t;`.

## Checklist

- [ ] I have written necessary rustdoc comments.
- [x] I have added necessary unit tests and integration tests.
- [x] I have added test labels as necessary.
- [ ] I have added fuzzing tests or opened an issue to track them.
- [ ] My PR contains breaking changes.
- [ ] My PR changes performance-critical code, so I will run (micro) benchmarks and present the results.
- [ ] I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into.

## Documentation

- [ ] My PR needs documentation updates.

<details>
<summary><b>Release note</b></summary>

Fix a planner panic for `SELECT DISTINCT ON` combined with an aggregate and no `GROUP BY` clause. The query now produces a proper planner error instead of panicking with an inconsistent input schema.
</details>