### PR TITLE
fix(cdc): fix cdc backfill recovery

### DIFF
--- a/src/stream/src/executor/backfill/cdc/cdc_backfill.rs
+++ b/src/stream/src/executor/backfill/cdc/cdc_backfill.rs
@@ -152,7 +152,6 @@ impl<S: StateStore> CdcBackfillExecutor<S> {
         output_indices: &[usize],
     ) -> StreamExecutorResult<(Vec<StreamChunk>, u64, Option<CdcOffset>)> {
         let Some(current_pos) = current_pk_pos else {
-            upstream_chunk_buffer.clear();
             return Ok((vec![], 0, None));
         };
 

--- a/src/stream/src/executor/backfill/cdc/cdc_backfill.rs
+++ b/src/stream/src/executor/backfill/cdc/cdc_backfill.rs
@@ -190,11 +190,6 @@ impl<S: StateStore> CdcBackfillExecutor<S> {
                     continue;
                 }
                 let should_emit = reached_current_pos;
-                let should_retain = !reached_current_pos;
-
-                if should_retain {
-                    retained_vis.set(idx, true);
-                }
 
                 match op {
                     Op::Insert | Op::Delete => {
@@ -202,6 +197,8 @@ impl<S: StateStore> CdcBackfillExecutor<S> {
                             emitted_vis.set(idx, true);
                             consumed_binlog_offset = Some(event_offset);
                             upstream_processed_row_count += 1;
+                        } else {
+                            retained_vis.set(idx, true);
                         }
                     }
                     Op::UpdateDelete | Op::UpdateInsert => {

--- a/src/stream/src/executor/backfill/cdc/cdc_backfill.rs
+++ b/src/stream/src/executor/backfill/cdc/cdc_backfill.rs
@@ -21,6 +21,7 @@ use futures::stream;
 use futures::stream::select_with_strategy;
 use itertools::Itertools;
 use risingwave_common::array::{DataChunk, Op};
+use risingwave_common::bitmap::BitmapBuilder;
 use risingwave_common::bail;
 use risingwave_common::catalog::ColumnDesc;
 use risingwave_common::row::RowExt;
@@ -155,19 +156,20 @@ impl<S: StateStore> CdcBackfillExecutor<S> {
             return Ok((vec![], 0, None));
         };
 
-        let mut buffered_chunks = std::mem::take(upstream_chunk_buffer).into_iter();
+        let buffered_chunks = std::mem::take(upstream_chunk_buffer);
         let mut emitted_chunks = Vec::with_capacity(buffered_chunks.len());
         let mut upstream_processed_row_count = 0;
         let mut consumed_binlog_offset = None;
-        let mut retained_chunks = Vec::with_capacity(emitted_chunks.capacity());
+        let mut retained_chunks = Vec::with_capacity(buffered_chunks.len());
 
-        while let Some(chunk) = buffered_chunks.next() {
-            let data_types = chunk.data_types();
-            let mut emitted_rows = Vec::new();
-            let mut retain_from = None;
+        for chunk in buffered_chunks {
+            let mut emitted_vis = BitmapBuilder::zeroed(chunk.capacity());
+            let mut retained_vis = BitmapBuilder::zeroed(chunk.capacity());
             for idx in 0..chunk.capacity() {
                 let (op, row, visible) = chunk.row_at(idx);
-                debug_assert!(visible, "buffered chunk should have compact visibility");
+                if !visible {
+                    continue;
+                }
                 let event_offset = (*offset_parse_func)(
                     row.iter()
                         .last()
@@ -185,17 +187,16 @@ impl<S: StateStore> CdcBackfillExecutor<S> {
                         .is_le();
 
                 if in_binlog_range && !reached_current_pos {
-                    retain_from = Some(idx);
-                    break;
+                    retained_vis.set(idx, true);
                 }
 
                 match op {
                     Op::Insert | Op::Delete => {
-                        if in_binlog_range {
-                            emitted_rows.push((op, row.into_owned_row()));
+                        if in_binlog_range && reached_current_pos {
+                            emitted_vis.set(idx, true);
                             consumed_binlog_offset = Some(event_offset);
+                            upstream_processed_row_count += 1;
                         }
-                        upstream_processed_row_count += 1;
                     }
                     Op::UpdateDelete | Op::UpdateInsert => {
                         unreachable!("CDC buffered chunks should not contain update pairs")
@@ -203,21 +204,14 @@ impl<S: StateStore> CdcBackfillExecutor<S> {
                 }
             }
 
-            if !emitted_rows.is_empty() {
-                emitted_chunks.push(mapping_chunk(
-                    StreamChunk::from_rows(&emitted_rows, &data_types),
-                    output_indices,
-                ));
+            let emitted_vis = emitted_vis.finish();
+            if emitted_vis.count_ones() > 0 {
+                emitted_chunks.push(mapping_chunk(chunk.clone_with_vis(emitted_vis), output_indices));
             }
 
-            if let Some(retain_from) = retain_from {
-                let retained_rows = chunk
-                    .rows_in(retain_from..chunk.capacity())
-                    .map(|(op, row)| (op, row.into_owned_row()))
-                    .collect_vec();
-                retained_chunks.push(StreamChunk::from_rows(&retained_rows, &data_types));
-                retained_chunks.extend(buffered_chunks);
-                break;
+            let retained_vis = retained_vis.finish();
+            if retained_vis.count_ones() > 0 {
+                retained_chunks.push(chunk.clone_with_vis(retained_vis));
             }
         }
 
@@ -1366,7 +1360,98 @@ mod tests {
     }
 
     #[test]
-    fn test_consume_upstream_chunk_buffer_bulk_retains_remaining_chunks() {
+    fn test_consume_upstream_chunk_buffer_handles_non_monotonic_pk_within_chunk() {
+        let mut upstream_chunk_buffer = vec![StreamChunk::from_rows(
+            &[
+                (
+                    Op::Insert,
+                    OwnedRow::new(vec![
+                        Some(ScalarImpl::Int64(1)),
+                        Some(ScalarImpl::Int64(100)),
+                        Some(ScalarImpl::Utf8(
+                            r#"{"sourcePartition":{},"sourceOffset":{"file":"1.binlog","pos":3},"isHeartbeat":false}"#
+                                .into(),
+                        )),
+                    ]),
+                ),
+                (
+                    Op::Insert,
+                    OwnedRow::new(vec![
+                        Some(ScalarImpl::Int64(6)),
+                        Some(ScalarImpl::Int64(600)),
+                        Some(ScalarImpl::Utf8(
+                            r#"{"sourcePartition":{},"sourceOffset":{"file":"1.binlog","pos":4},"isHeartbeat":false}"#
+                                .into(),
+                        )),
+                    ]),
+                ),
+                (
+                    Op::Insert,
+                    OwnedRow::new(vec![
+                        Some(ScalarImpl::Int64(2)),
+                        Some(ScalarImpl::Int64(200)),
+                        Some(ScalarImpl::Utf8(
+                            r#"{"sourcePartition":{},"sourceOffset":{"file":"1.binlog","pos":5},"isHeartbeat":false}"#
+                                .into(),
+                        )),
+                    ]),
+                ),
+            ],
+            &[DataType::Int64, DataType::Int64, DataType::Varchar],
+        )];
+
+        let (emitted_chunks, drained_row_count, drained_offset) =
+            CdcBackfillExecutor::<MemoryStateStore>::consume_upstream_chunk_buffer(
+                &MockExternalTableReader::get_cdc_offset_parser(),
+                &mut upstream_chunk_buffer,
+                Some(&OwnedRow::new(vec![Some(ScalarImpl::Int64(5))])),
+                &[0],
+                &[OrderType::ascending()],
+                &Some(CdcOffset::MySql(MySqlOffset::new("1.binlog".to_owned(), 2))),
+                &[0, 1],
+            )
+            .unwrap();
+
+        assert_eq!(drained_row_count, 2);
+        assert_eq!(
+            drained_offset,
+            Some(CdcOffset::MySql(MySqlOffset::new("1.binlog".to_owned(), 5)))
+        );
+        assert_eq!(emitted_chunks.len(), 1);
+        assert_eq!(emitted_chunks[0].rows().count(), 2);
+        assert_eq!(
+            emitted_chunks[0]
+                .rows()
+                .map(|(_, row)| row.to_owned_row())
+                .collect::<Vec<_>>(),
+            vec![
+                OwnedRow::new(vec![Some(ScalarImpl::Int64(1)), Some(ScalarImpl::Int64(100))]),
+                OwnedRow::new(vec![Some(ScalarImpl::Int64(2)), Some(ScalarImpl::Int64(200))]),
+            ]
+        );
+
+        assert_eq!(upstream_chunk_buffer.len(), 1);
+        assert_eq!(upstream_chunk_buffer[0].rows().count(), 1);
+        assert_eq!(
+            upstream_chunk_buffer[0]
+                .rows()
+                .next()
+                .unwrap()
+                .1
+                .to_owned_row(),
+            OwnedRow::new(vec![
+                Some(ScalarImpl::Int64(6)),
+                Some(ScalarImpl::Int64(600)),
+                Some(ScalarImpl::Utf8(
+                    r#"{"sourcePartition":{},"sourceOffset":{"file":"1.binlog","pos":4},"isHeartbeat":false}"#
+                        .into(),
+                )),
+            ])
+        );
+    }
+
+    #[test]
+    fn test_consume_upstream_chunk_buffer_processes_following_chunks_after_future_row() {
         let mut upstream_chunk_buffer = vec![
             StreamChunk::from_rows(
                 &[
@@ -1399,8 +1484,8 @@ mod tests {
                 &[(
                     Op::Insert,
                     OwnedRow::new(vec![
-                        Some(ScalarImpl::Int64(7)),
-                        Some(ScalarImpl::Int64(700)),
+                        Some(ScalarImpl::Int64(2)),
+                        Some(ScalarImpl::Int64(200)),
                         Some(ScalarImpl::Utf8(
                             r#"{"sourcePartition":{},"sourceOffset":{"file":"1.binlog","pos":5},"isHeartbeat":false}"#
                                 .into(),
@@ -1411,7 +1496,7 @@ mod tests {
             ),
         ];
 
-        let (_, drained_row_count, drained_offset) =
+        let (emitted_chunks, drained_row_count, drained_offset) =
             CdcBackfillExecutor::<MemoryStateStore>::consume_upstream_chunk_buffer(
                 &MockExternalTableReader::get_cdc_offset_parser(),
                 &mut upstream_chunk_buffer,
@@ -1423,12 +1508,20 @@ mod tests {
             )
             .unwrap();
 
-        assert_eq!(drained_row_count, 1);
+        assert_eq!(drained_row_count, 2);
         assert_eq!(
             drained_offset,
-            Some(CdcOffset::MySql(MySqlOffset::new("1.binlog".to_owned(), 3)))
+            Some(CdcOffset::MySql(MySqlOffset::new("1.binlog".to_owned(), 5)))
         );
-        assert_eq!(upstream_chunk_buffer.len(), 2);
+        assert_eq!(emitted_chunks.len(), 2);
+        assert_eq!(emitted_chunks[0].rows().count(), 1);
+        assert_eq!(emitted_chunks[1].rows().count(), 1);
+        assert_eq!(
+            emitted_chunks[1].rows().next().unwrap().1.to_owned_row(),
+            OwnedRow::new(vec![Some(ScalarImpl::Int64(2)), Some(ScalarImpl::Int64(200))])
+        );
+
+        assert_eq!(upstream_chunk_buffer.len(), 1);
         assert_eq!(
             upstream_chunk_buffer[0]
                 .rows()
@@ -1441,22 +1534,6 @@ mod tests {
                 Some(ScalarImpl::Int64(600)),
                 Some(ScalarImpl::Utf8(
                     r#"{"sourcePartition":{},"sourceOffset":{"file":"1.binlog","pos":4},"isHeartbeat":false}"#
-                        .into(),
-                )),
-            ])
-        );
-        assert_eq!(
-            upstream_chunk_buffer[1]
-                .rows()
-                .next()
-                .unwrap()
-                .1
-                .to_owned_row(),
-            OwnedRow::new(vec![
-                Some(ScalarImpl::Int64(7)),
-                Some(ScalarImpl::Int64(700)),
-                Some(ScalarImpl::Utf8(
-                    r#"{"sourcePartition":{},"sourceOffset":{"file":"1.binlog","pos":5},"isHeartbeat":false}"#
                         .into(),
                 )),
             ])

--- a/src/stream/src/executor/backfill/cdc/cdc_backfill.rs
+++ b/src/stream/src/executor/backfill/cdc/cdc_backfill.rs
@@ -168,6 +168,7 @@ impl<S: StateStore> CdcBackfillExecutor<S> {
             for idx in 0..chunk.capacity() {
                 let (op, row, visible) = chunk.row_at(idx);
                 if !visible {
+                    // Buffered chunks may carry sparse visibility from previous filtering rounds.
                     continue;
                 }
                 let event_offset = (*offset_parse_func)(
@@ -185,14 +186,16 @@ impl<S: StateStore> CdcBackfillExecutor<S> {
                 let reached_current_pos =
                     cmp_datum_iter(row_pk.iter(), current_pos.iter(), pk_order.iter().copied())
                         .is_le();
+                let should_emit = in_binlog_range && reached_current_pos;
+                let should_retain = in_binlog_range && !reached_current_pos;
 
-                if in_binlog_range && !reached_current_pos {
+                if should_retain {
                     retained_vis.set(idx, true);
                 }
 
                 match op {
                     Op::Insert | Op::Delete => {
-                        if in_binlog_range && reached_current_pos {
+                        if should_emit {
                             emitted_vis.set(idx, true);
                             consumed_binlog_offset = Some(event_offset);
                             upstream_processed_row_count += 1;

--- a/src/stream/src/executor/backfill/cdc/cdc_backfill.rs
+++ b/src/stream/src/executor/backfill/cdc/cdc_backfill.rs
@@ -20,10 +20,11 @@ use either::Either;
 use futures::stream;
 use futures::stream::select_with_strategy;
 use itertools::Itertools;
-use risingwave_common::array::DataChunk;
+use risingwave_common::array::{DataChunk, Op};
 use risingwave_common::bail;
 use risingwave_common::catalog::ColumnDesc;
-use risingwave_common::util::sort_util::OrderType;
+use risingwave_common::row::RowExt;
+use risingwave_common::util::sort_util::{OrderType, cmp_datum_iter};
 use risingwave_connector::parser::{
     BigintUnsignedHandlingMode, ByteStreamSourceParser, DebeziumParser, DebeziumProps,
     EncodingProperties, JsonProperties, ProtocolProperties, SourceStreamChunkBuilder,
@@ -141,7 +142,7 @@ impl<S: StateStore> CdcBackfillExecutor<S> {
             .inc_by(upstream_processed_row_count);
     }
 
-    fn drain_upstream_chunk_buffer(
+    fn consume_upstream_chunk_buffer(
         offset_parse_func: &risingwave_connector::source::cdc::external::CdcOffsetParseFunc,
         upstream_chunk_buffer: &mut Vec<StreamChunk>,
         current_pk_pos: Option<&OwnedRow>,
@@ -158,22 +159,133 @@ impl<S: StateStore> CdcBackfillExecutor<S> {
         let mut emitted_chunks = Vec::with_capacity(upstream_chunk_buffer.len());
         let mut upstream_processed_row_count = 0;
         let mut consumed_binlog_offset = None;
+        let mut retained_chunks = Vec::new();
+        let mut should_retain_remaining_chunks = false;
 
         for chunk in upstream_chunk_buffer.drain(..) {
-            upstream_processed_row_count += chunk.cardinality() as u64;
-            consumed_binlog_offset = get_cdc_chunk_last_offset(offset_parse_func, &chunk)?;
-            emitted_chunks.push(mapping_chunk(
-                mark_cdc_chunk(
-                    offset_parse_func,
-                    chunk,
-                    current_pos,
-                    pk_indices,
-                    pk_order,
-                    last_binlog_offset.clone(),
-                )?,
-                output_indices,
-            ));
+            if should_retain_remaining_chunks {
+                retained_chunks.push(chunk);
+                continue;
+            }
+
+            let data_types = chunk.data_types();
+            let mut emitted_rows = Vec::new();
+            let mut retain_from = None;
+            let mut idx = 0;
+
+            while idx < chunk.capacity() {
+                let (op, row, visible) = chunk.row_at(idx);
+                debug_assert!(visible, "buffered chunk should have compact visibility");
+                let event_offset = (*offset_parse_func)(
+                    row.iter()
+                        .last()
+                        .flatten()
+                        .expect("cdc offset must exist")
+                        .into_utf8(),
+                )?;
+                let in_binlog_range = last_binlog_offset
+                    .as_ref()
+                    .is_none_or(|binlog_low| *binlog_low <= event_offset);
+
+                match op {
+                    Op::UpdateDelete => {
+                        let (next_op, next_row, next_visible) = chunk.row_at(idx + 1);
+                        debug_assert!(
+                            next_visible,
+                            "buffered chunk should have compact visibility"
+                        );
+                        debug_assert_eq!(next_op, Op::UpdateInsert);
+
+                        let next_event_offset = (*offset_parse_func)(
+                            next_row
+                                .iter()
+                                .last()
+                                .flatten()
+                                .expect("cdc offset must exist")
+                                .into_utf8(),
+                        )?;
+                        let next_in_binlog_range = last_binlog_offset
+                            .as_ref()
+                            .is_none_or(|binlog_low| *binlog_low <= next_event_offset);
+
+                        let row_pk = row.project(pk_indices);
+                        let next_row_pk = next_row.project(pk_indices);
+                        let row_reached_current_pos = cmp_datum_iter(
+                            row_pk.iter(),
+                            current_pos.iter(),
+                            pk_order.iter().copied(),
+                        )
+                        .is_le();
+                        let next_row_reached_current_pos = cmp_datum_iter(
+                            next_row_pk.iter(),
+                            current_pos.iter(),
+                            pk_order.iter().copied(),
+                        )
+                        .is_le();
+
+                        let should_retain_pair = (in_binlog_range && !row_reached_current_pos)
+                            || (next_in_binlog_range && !next_row_reached_current_pos);
+                        if should_retain_pair {
+                            retain_from = Some(idx);
+                            break;
+                        }
+
+                        if in_binlog_range {
+                            emitted_rows.push((op, row.into_owned_row()));
+                            consumed_binlog_offset = Some(event_offset);
+                        }
+                        if next_in_binlog_range {
+                            emitted_rows.push((next_op, next_row.into_owned_row()));
+                            consumed_binlog_offset = Some(next_event_offset);
+                        }
+                        upstream_processed_row_count += 2;
+                        idx += 2;
+                    }
+                    Op::UpdateInsert => {
+                        unreachable!("UpdateInsert should not be present without UpdateDelete")
+                    }
+                    Op::Insert | Op::Delete => {
+                        let row_pk = row.project(pk_indices);
+                        let reached_current_pos = cmp_datum_iter(
+                            row_pk.iter(),
+                            current_pos.iter(),
+                            pk_order.iter().copied(),
+                        )
+                        .is_le();
+
+                        if in_binlog_range && !reached_current_pos {
+                            retain_from = Some(idx);
+                            break;
+                        }
+
+                        if in_binlog_range {
+                            emitted_rows.push((op, row.into_owned_row()));
+                            consumed_binlog_offset = Some(event_offset);
+                        }
+                        upstream_processed_row_count += 1;
+                        idx += 1;
+                    }
+                }
+            }
+
+            if !emitted_rows.is_empty() {
+                emitted_chunks.push(mapping_chunk(
+                    StreamChunk::from_rows(&emitted_rows, &data_types),
+                    output_indices,
+                ));
+            }
+
+            if let Some(retain_from) = retain_from {
+                let retained_rows = chunk
+                    .rows_in(retain_from..chunk.capacity())
+                    .map(|(op, row)| (op, row.into_owned_row()))
+                    .collect_vec();
+                retained_chunks.push(StreamChunk::from_rows(&retained_rows, &data_types));
+                should_retain_remaining_chunks = true;
+            }
         }
+
+        *upstream_chunk_buffer = retained_chunks;
 
         Ok((
             emitted_chunks,
@@ -371,7 +483,8 @@ impl<S: StateStore> CdcBackfillExecutor<S> {
         // When a new barrier comes from upstream:
         //  - read the current binlog offset as `binlog_high`
         //  - for each row of the upstream change log, forward it to downstream if it in the range
-        //    of [binlog_low, binlog_high] and its pk <= `current_pos`, otherwise ignore it
+        //    of [binlog_low, binlog_high] and its pk <= `current_pos`, otherwise keep buffering it
+        //    until `current_pos` catches up
         //  - reconstruct the whole backfill stream with upstream changelog and a new table snapshot
         //
         // When a chunk comes from snapshot, we forward it to the downstream and raise
@@ -549,7 +662,7 @@ impl<S: StateStore> CdcBackfillExecutor<S> {
                                             emitted_upstream_chunks,
                                             drained_upstream_row_count,
                                             drained_binlog_offset,
-                                        ) = Self::drain_upstream_chunk_buffer(
+                                        ) = Self::consume_upstream_chunk_buffer(
                                             &offset_parse_func,
                                             &mut upstream_chunk_buffer,
                                             current_pk_pos.as_ref(),
@@ -1016,11 +1129,13 @@ mod tests {
     use futures::{StreamExt, pin_mut};
     use risingwave_common::array::{Array, DataChunk, Op, StreamChunk};
     use risingwave_common::catalog::{ColumnDesc, ColumnId, Field, Schema, TableId};
-    use risingwave_common::types::{DataType, Datum, JsonbVal};
+    use risingwave_common::row::{OwnedRow, Row};
+    use risingwave_common::types::{DataType, Datum, JsonbVal, ScalarImpl};
     use risingwave_common::util::epoch::test_epoch;
     use risingwave_common::util::iter_util::ZipEqFast;
     use risingwave_common::util::sort_util::OrderType;
     use risingwave_connector::source::cdc::CdcScanOptions;
+    use risingwave_connector::source::cdc::external::mock_external_table::MockExternalTableReader;
     use risingwave_connector::source::cdc::external::mysql::MySqlOffset;
     use risingwave_connector::source::cdc::external::{
         CdcOffset, ExternalCdcTableType, ExternalTableConfig, SchemaTableName,
@@ -1235,6 +1350,83 @@ mod tests {
             None,
         )
         .await
+    }
+
+    #[test]
+    fn test_consume_upstream_chunk_buffer_retains_future_rows() {
+        let mut upstream_chunk_buffer = vec![StreamChunk::from_rows(
+            &[
+                (
+                    Op::Insert,
+                    OwnedRow::new(vec![
+                        Some(ScalarImpl::Int64(1)),
+                        Some(ScalarImpl::Int64(100)),
+                        Some(ScalarImpl::Utf8(
+                            r#"{"sourcePartition":{},"sourceOffset":{"file":"1.binlog","pos":3},"isHeartbeat":false}"#
+                                .into(),
+                        )),
+                    ]),
+                ),
+                (
+                    Op::Insert,
+                    OwnedRow::new(vec![
+                        Some(ScalarImpl::Int64(6)),
+                        Some(ScalarImpl::Int64(600)),
+                        Some(ScalarImpl::Utf8(
+                            r#"{"sourcePartition":{},"sourceOffset":{"file":"1.binlog","pos":4},"isHeartbeat":false}"#
+                                .into(),
+                        )),
+                    ]),
+                ),
+            ],
+            &[DataType::Int64, DataType::Int64, DataType::Varchar],
+        )];
+
+        let (emitted_chunks, drained_row_count, drained_offset) =
+            CdcBackfillExecutor::<MemoryStateStore>::consume_upstream_chunk_buffer(
+                &MockExternalTableReader::get_cdc_offset_parser(),
+                &mut upstream_chunk_buffer,
+                Some(&OwnedRow::new(vec![Some(ScalarImpl::Int64(5))])),
+                &[0],
+                &[OrderType::ascending()],
+                &Some(CdcOffset::MySql(MySqlOffset::new("1.binlog".to_owned(), 2))),
+                &[0, 1],
+            )
+            .unwrap();
+
+        assert_eq!(drained_row_count, 1);
+        assert_eq!(
+            drained_offset,
+            Some(CdcOffset::MySql(MySqlOffset::new("1.binlog".to_owned(), 3)))
+        );
+        assert_eq!(emitted_chunks.len(), 1);
+        assert_eq!(emitted_chunks[0].rows().count(), 1);
+        assert_eq!(
+            emitted_chunks[0].rows().next().unwrap().1.to_owned_row(),
+            OwnedRow::new(vec![
+                Some(ScalarImpl::Int64(1)),
+                Some(ScalarImpl::Int64(100))
+            ])
+        );
+
+        assert_eq!(upstream_chunk_buffer.len(), 1);
+        assert_eq!(upstream_chunk_buffer[0].rows().count(), 1);
+        assert_eq!(
+            upstream_chunk_buffer[0]
+                .rows()
+                .next()
+                .unwrap()
+                .1
+                .to_owned_row(),
+            OwnedRow::new(vec![
+                Some(ScalarImpl::Int64(6)),
+                Some(ScalarImpl::Int64(600)),
+                Some(ScalarImpl::Utf8(
+                    r#"{"sourcePartition":{},"sourceOffset":{"file":"1.binlog","pos":4},"isHeartbeat":false}"#
+                        .into(),
+                )),
+            ])
+        );
     }
 
     #[tokio::test]

--- a/src/stream/src/executor/backfill/cdc/cdc_backfill.rs
+++ b/src/stream/src/executor/backfill/cdc/cdc_backfill.rs
@@ -21,8 +21,8 @@ use futures::stream;
 use futures::stream::select_with_strategy;
 use itertools::Itertools;
 use risingwave_common::array::{DataChunk, Op};
-use risingwave_common::bitmap::BitmapBuilder;
 use risingwave_common::bail;
+use risingwave_common::bitmap::BitmapBuilder;
 use risingwave_common::catalog::ColumnDesc;
 use risingwave_common::row::RowExt;
 use risingwave_common::util::sort_util::{OrderType, cmp_datum_iter};
@@ -213,7 +213,10 @@ impl<S: StateStore> CdcBackfillExecutor<S> {
 
             let emitted_vis = emitted_vis.finish();
             if emitted_vis.count_ones() > 0 {
-                emitted_chunks.push(mapping_chunk(chunk.clone_with_vis(emitted_vis), output_indices));
+                emitted_chunks.push(mapping_chunk(
+                    chunk.clone_with_vis(emitted_vis),
+                    output_indices,
+                ));
             }
 
             let retained_vis = retained_vis.finish();
@@ -610,7 +613,8 @@ impl<S: StateStore> CdcBackfillExecutor<S> {
                                         )?;
                                         cur_barrier_upstream_processed_rows +=
                                             consumed_upstream_row_count;
-                                        if let Some(consumed_binlog_offset) = consumed_binlog_offset {
+                                        if let Some(consumed_binlog_offset) = consumed_binlog_offset
+                                        {
                                             last_binlog_offset = Some(consumed_binlog_offset);
                                         }
                                         for chunk in emitted_upstream_chunks {
@@ -1432,8 +1436,14 @@ mod tests {
                 .map(|(_, row)| row.to_owned_row())
                 .collect::<Vec<_>>(),
             vec![
-                OwnedRow::new(vec![Some(ScalarImpl::Int64(1)), Some(ScalarImpl::Int64(100))]),
-                OwnedRow::new(vec![Some(ScalarImpl::Int64(2)), Some(ScalarImpl::Int64(200))]),
+                OwnedRow::new(vec![
+                    Some(ScalarImpl::Int64(1)),
+                    Some(ScalarImpl::Int64(100))
+                ]),
+                OwnedRow::new(vec![
+                    Some(ScalarImpl::Int64(2)),
+                    Some(ScalarImpl::Int64(200))
+                ]),
             ]
         );
 
@@ -1525,7 +1535,10 @@ mod tests {
         assert_eq!(emitted_chunks[1].rows().count(), 1);
         assert_eq!(
             emitted_chunks[1].rows().next().unwrap().1.to_owned_row(),
-            OwnedRow::new(vec![Some(ScalarImpl::Int64(2)), Some(ScalarImpl::Int64(200))])
+            OwnedRow::new(vec![
+                Some(ScalarImpl::Int64(2)),
+                Some(ScalarImpl::Int64(200))
+            ])
         );
 
         assert_eq!(upstream_chunk_buffer.len(), 1);

--- a/src/stream/src/executor/backfill/cdc/cdc_backfill.rs
+++ b/src/stream/src/executor/backfill/cdc/cdc_backfill.rs
@@ -155,18 +155,13 @@ impl<S: StateStore> CdcBackfillExecutor<S> {
             return Ok((vec![], 0, None));
         };
 
-        let mut emitted_chunks = Vec::with_capacity(upstream_chunk_buffer.len());
+        let mut buffered_chunks = std::mem::take(upstream_chunk_buffer).into_iter();
+        let mut emitted_chunks = Vec::with_capacity(buffered_chunks.len());
         let mut upstream_processed_row_count = 0;
         let mut consumed_binlog_offset = None;
-        let mut retained_chunks = Vec::new();
-        let mut should_retain_remaining_chunks = false;
+        let mut retained_chunks = Vec::with_capacity(emitted_chunks.capacity());
 
-        for chunk in upstream_chunk_buffer.drain(..) {
-            if should_retain_remaining_chunks {
-                retained_chunks.push(chunk);
-                continue;
-            }
-
+        while let Some(chunk) = buffered_chunks.next() {
             let data_types = chunk.data_types();
             let mut emitted_rows = Vec::new();
             let mut retain_from = None;
@@ -221,7 +216,8 @@ impl<S: StateStore> CdcBackfillExecutor<S> {
                     .map(|(op, row)| (op, row.into_owned_row()))
                     .collect_vec();
                 retained_chunks.push(StreamChunk::from_rows(&retained_rows, &data_types));
-                should_retain_remaining_chunks = true;
+                retained_chunks.extend(buffered_chunks);
+                break;
             }
         }
 
@@ -1363,6 +1359,104 @@ mod tests {
                 Some(ScalarImpl::Int64(600)),
                 Some(ScalarImpl::Utf8(
                     r#"{"sourcePartition":{},"sourceOffset":{"file":"1.binlog","pos":4},"isHeartbeat":false}"#
+                        .into(),
+                )),
+            ])
+        );
+    }
+
+    #[test]
+    fn test_consume_upstream_chunk_buffer_bulk_retains_remaining_chunks() {
+        let mut upstream_chunk_buffer = vec![
+            StreamChunk::from_rows(
+                &[
+                    (
+                        Op::Insert,
+                        OwnedRow::new(vec![
+                            Some(ScalarImpl::Int64(1)),
+                            Some(ScalarImpl::Int64(100)),
+                            Some(ScalarImpl::Utf8(
+                                r#"{"sourcePartition":{},"sourceOffset":{"file":"1.binlog","pos":3},"isHeartbeat":false}"#
+                                    .into(),
+                            )),
+                        ]),
+                    ),
+                    (
+                        Op::Insert,
+                        OwnedRow::new(vec![
+                            Some(ScalarImpl::Int64(6)),
+                            Some(ScalarImpl::Int64(600)),
+                            Some(ScalarImpl::Utf8(
+                                r#"{"sourcePartition":{},"sourceOffset":{"file":"1.binlog","pos":4},"isHeartbeat":false}"#
+                                    .into(),
+                            )),
+                        ]),
+                    ),
+                ],
+                &[DataType::Int64, DataType::Int64, DataType::Varchar],
+            ),
+            StreamChunk::from_rows(
+                &[(
+                    Op::Insert,
+                    OwnedRow::new(vec![
+                        Some(ScalarImpl::Int64(7)),
+                        Some(ScalarImpl::Int64(700)),
+                        Some(ScalarImpl::Utf8(
+                            r#"{"sourcePartition":{},"sourceOffset":{"file":"1.binlog","pos":5},"isHeartbeat":false}"#
+                                .into(),
+                        )),
+                    ]),
+                )],
+                &[DataType::Int64, DataType::Int64, DataType::Varchar],
+            ),
+        ];
+
+        let (_, drained_row_count, drained_offset) =
+            CdcBackfillExecutor::<MemoryStateStore>::consume_upstream_chunk_buffer(
+                &MockExternalTableReader::get_cdc_offset_parser(),
+                &mut upstream_chunk_buffer,
+                Some(&OwnedRow::new(vec![Some(ScalarImpl::Int64(5))])),
+                &[0],
+                &[OrderType::ascending()],
+                &Some(CdcOffset::MySql(MySqlOffset::new("1.binlog".to_owned(), 2))),
+                &[0, 1],
+            )
+            .unwrap();
+
+        assert_eq!(drained_row_count, 1);
+        assert_eq!(
+            drained_offset,
+            Some(CdcOffset::MySql(MySqlOffset::new("1.binlog".to_owned(), 3)))
+        );
+        assert_eq!(upstream_chunk_buffer.len(), 2);
+        assert_eq!(
+            upstream_chunk_buffer[0]
+                .rows()
+                .next()
+                .unwrap()
+                .1
+                .to_owned_row(),
+            OwnedRow::new(vec![
+                Some(ScalarImpl::Int64(6)),
+                Some(ScalarImpl::Int64(600)),
+                Some(ScalarImpl::Utf8(
+                    r#"{"sourcePartition":{},"sourceOffset":{"file":"1.binlog","pos":4},"isHeartbeat":false}"#
+                        .into(),
+                )),
+            ])
+        );
+        assert_eq!(
+            upstream_chunk_buffer[1]
+                .rows()
+                .next()
+                .unwrap()
+                .1
+                .to_owned_row(),
+            OwnedRow::new(vec![
+                Some(ScalarImpl::Int64(7)),
+                Some(ScalarImpl::Int64(700)),
+                Some(ScalarImpl::Utf8(
+                    r#"{"sourcePartition":{},"sourceOffset":{"file":"1.binlog","pos":5},"isHeartbeat":false}"#
                         .into(),
                 )),
             ])

--- a/src/stream/src/executor/backfill/cdc/cdc_backfill.rs
+++ b/src/stream/src/executor/backfill/cdc/cdc_backfill.rs
@@ -578,12 +578,6 @@ impl<S: StateStore> CdcBackfillExecutor<S> {
                                         }
                                     }
 
-                                    Self::report_metrics(
-                                        &self.metrics,
-                                        cur_barrier_snapshot_processed_rows,
-                                        cur_barrier_upstream_processed_rows,
-                                    );
-
                                     // when processing a barrier, check whether can start a new snapshot
                                     // if the number of barriers reaches the snapshot interval
                                     if can_start_new_snapshot {
@@ -598,6 +592,7 @@ impl<S: StateStore> CdcBackfillExecutor<S> {
                                         // Break the loop for consuming snapshot and prepare to start a new snapshot
                                         break;
                                     } else {
+                                        // Drain the in-memory buffer to ensure no data is lost during the recovery process.
                                         let (
                                             emitted_upstream_chunks,
                                             consumed_upstream_row_count,

--- a/src/stream/src/executor/backfill/cdc/cdc_backfill.rs
+++ b/src/stream/src/executor/backfill/cdc/cdc_backfill.rs
@@ -186,8 +186,11 @@ impl<S: StateStore> CdcBackfillExecutor<S> {
                 let reached_current_pos =
                     cmp_datum_iter(row_pk.iter(), current_pos.iter(), pk_order.iter().copied())
                         .is_le();
-                let should_emit = in_binlog_range && reached_current_pos;
-                let should_retain = in_binlog_range && !reached_current_pos;
+                if !in_binlog_range {
+                    continue;
+                }
+                let should_emit = reached_current_pos;
+                let should_retain = !reached_current_pos;
 
                 if should_retain {
                     retained_vis.set(idx, true);
@@ -1363,7 +1366,7 @@ mod tests {
     }
 
     #[test]
-    fn test_consume_upstream_chunk_buffer_handles_non_monotonic_pk_within_chunk() {
+    fn test_consume_buffer_non_monotonic_pk_in_chunk() {
         let mut upstream_chunk_buffer = vec![StreamChunk::from_rows(
             &[
                 (
@@ -1454,7 +1457,7 @@ mod tests {
     }
 
     #[test]
-    fn test_consume_upstream_chunk_buffer_processes_following_chunks_after_future_row() {
+    fn test_consume_buffer_processes_chunks_after_future_row() {
         let mut upstream_chunk_buffer = vec![
             StreamChunk::from_rows(
                 &[

--- a/src/stream/src/executor/backfill/cdc/cdc_backfill.rs
+++ b/src/stream/src/executor/backfill/cdc/cdc_backfill.rs
@@ -170,9 +170,7 @@ impl<S: StateStore> CdcBackfillExecutor<S> {
             let data_types = chunk.data_types();
             let mut emitted_rows = Vec::new();
             let mut retain_from = None;
-            let mut idx = 0;
-
-            while idx < chunk.capacity() {
+            for idx in 0..chunk.capacity() {
                 let (op, row, visible) = chunk.row_at(idx);
                 debug_assert!(visible, "buffered chunk should have compact visibility");
                 let event_offset = (*offset_parse_func)(
@@ -186,83 +184,26 @@ impl<S: StateStore> CdcBackfillExecutor<S> {
                     .as_ref()
                     .is_none_or(|binlog_low| *binlog_low <= event_offset);
 
+                let row_pk = row.project(pk_indices);
+                let reached_current_pos =
+                    cmp_datum_iter(row_pk.iter(), current_pos.iter(), pk_order.iter().copied())
+                        .is_le();
+
+                if in_binlog_range && !reached_current_pos {
+                    retain_from = Some(idx);
+                    break;
+                }
+
                 match op {
-                    Op::UpdateDelete => {
-                        let (next_op, next_row, next_visible) = chunk.row_at(idx + 1);
-                        debug_assert!(
-                            next_visible,
-                            "buffered chunk should have compact visibility"
-                        );
-                        debug_assert_eq!(next_op, Op::UpdateInsert);
-
-                        let next_event_offset = (*offset_parse_func)(
-                            next_row
-                                .iter()
-                                .last()
-                                .flatten()
-                                .expect("cdc offset must exist")
-                                .into_utf8(),
-                        )?;
-                        let next_in_binlog_range = last_binlog_offset
-                            .as_ref()
-                            .is_none_or(|binlog_low| *binlog_low <= next_event_offset);
-
-                        let row_pk = row.project(pk_indices);
-                        let next_row_pk = next_row.project(pk_indices);
-                        let row_reached_current_pos = cmp_datum_iter(
-                            row_pk.iter(),
-                            current_pos.iter(),
-                            pk_order.iter().copied(),
-                        )
-                        .is_le();
-                        let next_row_reached_current_pos = cmp_datum_iter(
-                            next_row_pk.iter(),
-                            current_pos.iter(),
-                            pk_order.iter().copied(),
-                        )
-                        .is_le();
-
-                        let should_retain_pair = (in_binlog_range && !row_reached_current_pos)
-                            || (next_in_binlog_range && !next_row_reached_current_pos);
-                        if should_retain_pair {
-                            retain_from = Some(idx);
-                            break;
-                        }
-
-                        if in_binlog_range {
-                            emitted_rows.push((op, row.into_owned_row()));
-                            consumed_binlog_offset = Some(event_offset);
-                        }
-                        if next_in_binlog_range {
-                            emitted_rows.push((next_op, next_row.into_owned_row()));
-                            consumed_binlog_offset = Some(next_event_offset);
-                        }
-                        upstream_processed_row_count += 2;
-                        idx += 2;
-                    }
-                    Op::UpdateInsert => {
-                        unreachable!("UpdateInsert should not be present without UpdateDelete")
-                    }
                     Op::Insert | Op::Delete => {
-                        let row_pk = row.project(pk_indices);
-                        let reached_current_pos = cmp_datum_iter(
-                            row_pk.iter(),
-                            current_pos.iter(),
-                            pk_order.iter().copied(),
-                        )
-                        .is_le();
-
-                        if in_binlog_range && !reached_current_pos {
-                            retain_from = Some(idx);
-                            break;
-                        }
-
                         if in_binlog_range {
                             emitted_rows.push((op, row.into_owned_row()));
                             consumed_binlog_offset = Some(event_offset);
                         }
                         upstream_processed_row_count += 1;
-                        idx += 1;
+                    }
+                    Op::UpdateDelete | Op::UpdateInsert => {
+                        unreachable!("CDC buffered chunks should not contain update pairs")
                     }
                 }
             }

--- a/src/stream/src/executor/backfill/cdc/cdc_backfill.rs
+++ b/src/stream/src/executor/backfill/cdc/cdc_backfill.rs
@@ -161,6 +161,7 @@ impl<S: StateStore> CdcBackfillExecutor<S> {
         let mut upstream_processed_row_count = 0;
         let mut consumed_binlog_offset = None;
         let mut retained_chunks = Vec::with_capacity(buffered_chunks.len());
+        let mut can_advance_consumed_offset = true;
 
         for chunk in buffered_chunks {
             let mut emitted_vis = BitmapBuilder::zeroed(chunk.capacity());
@@ -195,10 +196,13 @@ impl<S: StateStore> CdcBackfillExecutor<S> {
                     Op::Insert | Op::Delete => {
                         if should_emit {
                             emitted_vis.set(idx, true);
-                            consumed_binlog_offset = Some(event_offset);
+                            if can_advance_consumed_offset {
+                                consumed_binlog_offset = Some(event_offset);
+                            }
                             upstream_processed_row_count += 1;
                         } else {
                             retained_vis.set(idx, true);
+                            can_advance_consumed_offset = false;
                         }
                     }
                     Op::UpdateDelete | Op::UpdateInsert => {
@@ -593,8 +597,8 @@ impl<S: StateStore> CdcBackfillExecutor<S> {
                                     } else {
                                         let (
                                             emitted_upstream_chunks,
-                                            drained_upstream_row_count,
-                                            drained_binlog_offset,
+                                            consumed_upstream_row_count,
+                                            consumed_binlog_offset,
                                         ) = Self::consume_upstream_chunk_buffer(
                                             &offset_parse_func,
                                             &mut upstream_chunk_buffer,
@@ -605,9 +609,9 @@ impl<S: StateStore> CdcBackfillExecutor<S> {
                                             &self.output_indices,
                                         )?;
                                         cur_barrier_upstream_processed_rows +=
-                                            drained_upstream_row_count;
-                                        if let Some(drained_binlog_offset) = drained_binlog_offset {
-                                            last_binlog_offset = Some(drained_binlog_offset);
+                                            consumed_upstream_row_count;
+                                        if let Some(consumed_binlog_offset) = consumed_binlog_offset {
+                                            last_binlog_offset = Some(consumed_binlog_offset);
                                         }
                                         for chunk in emitted_upstream_chunks {
                                             yield Message::Chunk(chunk);
@@ -1418,7 +1422,7 @@ mod tests {
         assert_eq!(drained_row_count, 2);
         assert_eq!(
             drained_offset,
-            Some(CdcOffset::MySql(MySqlOffset::new("1.binlog".to_owned(), 5)))
+            Some(CdcOffset::MySql(MySqlOffset::new("1.binlog".to_owned(), 3)))
         );
         assert_eq!(emitted_chunks.len(), 1);
         assert_eq!(emitted_chunks[0].rows().count(), 2);
@@ -1514,7 +1518,7 @@ mod tests {
         assert_eq!(drained_row_count, 2);
         assert_eq!(
             drained_offset,
-            Some(CdcOffset::MySql(MySqlOffset::new("1.binlog".to_owned(), 5)))
+            Some(CdcOffset::MySql(MySqlOffset::new("1.binlog".to_owned(), 3)))
         );
         assert_eq!(emitted_chunks.len(), 2);
         assert_eq!(emitted_chunks[0].rows().count(), 1);
@@ -1541,6 +1545,56 @@ mod tests {
                 )),
             ])
         );
+    }
+
+    #[test]
+    fn test_consume_buffer_advances_offset_after_preceding_rows_are_emitted() {
+        let mut upstream_chunk_buffer = vec![StreamChunk::from_rows(
+            &[
+                (
+                    Op::Insert,
+                    OwnedRow::new(vec![
+                        Some(ScalarImpl::Int64(6)),
+                        Some(ScalarImpl::Int64(600)),
+                        Some(ScalarImpl::Utf8(
+                            r#"{"sourcePartition":{},"sourceOffset":{"file":"1.binlog","pos":4},"isHeartbeat":false}"#
+                                .into(),
+                        )),
+                    ]),
+                ),
+                (
+                    Op::Insert,
+                    OwnedRow::new(vec![
+                        Some(ScalarImpl::Int64(2)),
+                        Some(ScalarImpl::Int64(200)),
+                        Some(ScalarImpl::Utf8(
+                            r#"{"sourcePartition":{},"sourceOffset":{"file":"1.binlog","pos":5},"isHeartbeat":false}"#
+                                .into(),
+                        )),
+                    ]),
+                ),
+            ],
+            &[DataType::Int64, DataType::Int64, DataType::Varchar],
+        )];
+
+        let (_, drained_row_count, drained_offset) =
+            CdcBackfillExecutor::<MemoryStateStore>::consume_upstream_chunk_buffer(
+                &MockExternalTableReader::get_cdc_offset_parser(),
+                &mut upstream_chunk_buffer,
+                Some(&OwnedRow::new(vec![Some(ScalarImpl::Int64(6))])),
+                &[0],
+                &[OrderType::ascending()],
+                &Some(CdcOffset::MySql(MySqlOffset::new("1.binlog".to_owned(), 3))),
+                &[0, 1],
+            )
+            .unwrap();
+
+        assert_eq!(drained_row_count, 2);
+        assert_eq!(
+            drained_offset,
+            Some(CdcOffset::MySql(MySqlOffset::new("1.binlog".to_owned(), 5)))
+        );
+        assert!(upstream_chunk_buffer.is_empty());
     }
 
     #[tokio::test]

--- a/src/stream/src/executor/backfill/cdc/cdc_backfill.rs
+++ b/src/stream/src/executor/backfill/cdc/cdc_backfill.rs
@@ -23,6 +23,7 @@ use itertools::Itertools;
 use risingwave_common::array::DataChunk;
 use risingwave_common::bail;
 use risingwave_common::catalog::ColumnDesc;
+use risingwave_common::util::sort_util::OrderType;
 use risingwave_connector::parser::{
     BigintUnsignedHandlingMode, ByteStreamSourceParser, DebeziumParser, DebeziumProps,
     EncodingProperties, JsonProperties, ProtocolProperties, SourceStreamChunkBuilder,
@@ -138,6 +139,47 @@ impl<S: StateStore> CdcBackfillExecutor<S> {
         metrics
             .cdc_backfill_upstream_output_row_count
             .inc_by(upstream_processed_row_count);
+    }
+
+    fn drain_upstream_chunk_buffer(
+        offset_parse_func: &risingwave_connector::source::cdc::external::CdcOffsetParseFunc,
+        upstream_chunk_buffer: &mut Vec<StreamChunk>,
+        current_pk_pos: Option<&OwnedRow>,
+        pk_indices: &[usize],
+        pk_order: &[OrderType],
+        last_binlog_offset: &Option<CdcOffset>,
+        output_indices: &[usize],
+    ) -> StreamExecutorResult<(Vec<StreamChunk>, u64, Option<CdcOffset>)> {
+        let Some(current_pos) = current_pk_pos else {
+            upstream_chunk_buffer.clear();
+            return Ok((vec![], 0, None));
+        };
+
+        let mut emitted_chunks = Vec::with_capacity(upstream_chunk_buffer.len());
+        let mut upstream_processed_row_count = 0;
+        let mut consumed_binlog_offset = None;
+
+        for chunk in upstream_chunk_buffer.drain(..) {
+            upstream_processed_row_count += chunk.cardinality() as u64;
+            consumed_binlog_offset = get_cdc_chunk_last_offset(offset_parse_func, &chunk)?;
+            emitted_chunks.push(mapping_chunk(
+                mark_cdc_chunk(
+                    offset_parse_func,
+                    chunk,
+                    current_pos,
+                    pk_indices,
+                    pk_order,
+                    last_binlog_offset.clone(),
+                )?,
+                output_indices,
+            ));
+        }
+
+        Ok((
+            emitted_chunks,
+            upstream_processed_row_count,
+            consumed_binlog_offset,
+        ))
     }
 
     #[try_stream(ok = Message, error = StreamExecutorError)]
@@ -437,6 +479,7 @@ impl<S: StateStore> CdcBackfillExecutor<S> {
                                     barrier_count += 1;
                                     let can_start_new_snapshot =
                                         barrier_count == self.options.snapshot_barrier_interval;
+                                    let mut needs_rebuild_snapshot = false;
 
                                     if let Some(mutation) = barrier.mutation.as_deref() {
                                         use crate::executor::Mutation;
@@ -460,20 +503,7 @@ impl<S: StateStore> CdcBackfillExecutor<S> {
                                                     rate_limit_to_zero = self
                                                         .rate_limit_rps
                                                         .is_some_and(|val| val == 0);
-                                                    // update and persist current backfill progress without draining the buffered upstream chunks
-                                                    state_impl
-                                                        .mutate_state(
-                                                            current_pk_pos.clone(),
-                                                            last_binlog_offset.clone(),
-                                                            total_snapshot_row_count,
-                                                            false,
-                                                        )
-                                                        .await?;
-                                                    state_impl.commit_state(barrier.epoch).await?;
-                                                    yield Message::Barrier(barrier);
-
-                                                    // rebuild the snapshot stream with new rate limit
-                                                    continue 'backfill_loop;
+                                                    needs_rebuild_snapshot = true;
                                                 }
                                             }
                                             Mutation::Update(UpdateMutation {
@@ -515,6 +545,34 @@ impl<S: StateStore> CdcBackfillExecutor<S> {
                                         // Break the loop for consuming snapshot and prepare to start a new snapshot
                                         break;
                                     } else {
+                                        let (
+                                            emitted_upstream_chunks,
+                                            drained_upstream_row_count,
+                                            drained_binlog_offset,
+                                        ) = Self::drain_upstream_chunk_buffer(
+                                            &offset_parse_func,
+                                            &mut upstream_chunk_buffer,
+                                            current_pk_pos.as_ref(),
+                                            &pk_indices,
+                                            &pk_order,
+                                            &last_binlog_offset,
+                                            &self.output_indices,
+                                        )?;
+                                        cur_barrier_upstream_processed_rows +=
+                                            drained_upstream_row_count;
+                                        if let Some(drained_binlog_offset) = drained_binlog_offset {
+                                            last_binlog_offset = Some(drained_binlog_offset);
+                                        }
+                                        for chunk in emitted_upstream_chunks {
+                                            yield Message::Chunk(chunk);
+                                        }
+
+                                        Self::report_metrics(
+                                            &self.metrics,
+                                            cur_barrier_snapshot_processed_rows,
+                                            cur_barrier_upstream_processed_rows,
+                                        );
+
                                         // update and persist current backfill progress
                                         state_impl
                                             .mutate_state(
@@ -529,6 +587,10 @@ impl<S: StateStore> CdcBackfillExecutor<S> {
 
                                         // emit barrier and continue consume the backfill stream
                                         yield Message::Barrier(barrier);
+
+                                        if needs_rebuild_snapshot {
+                                            continue 'backfill_loop;
+                                        }
                                     }
                                 }
                                 Message::Chunk(chunk) => {
@@ -953,14 +1015,21 @@ mod tests {
 
     use futures::{StreamExt, pin_mut};
     use risingwave_common::array::{Array, DataChunk, Op, StreamChunk};
-    use risingwave_common::catalog::{ColumnDesc, ColumnId, Field, Schema};
+    use risingwave_common::catalog::{ColumnDesc, ColumnId, Field, Schema, TableId};
     use risingwave_common::types::{DataType, Datum, JsonbVal};
     use risingwave_common::util::epoch::test_epoch;
     use risingwave_common::util::iter_util::ZipEqFast;
+    use risingwave_common::util::sort_util::OrderType;
     use risingwave_connector::source::cdc::CdcScanOptions;
+    use risingwave_connector::source::cdc::external::mysql::MySqlOffset;
+    use risingwave_connector::source::cdc::external::{
+        CdcOffset, ExternalCdcTableType, ExternalTableConfig, SchemaTableName,
+    };
     use risingwave_storage::memory::MemoryStateStore;
 
+    use crate::common::table::test_utils::gen_pbtable;
     use crate::executor::backfill::cdc::cdc_backfill::transform_upstream;
+    use crate::executor::backfill::cdc::state::CdcBackfillState;
     use crate::executor::monitor::StreamingMetrics;
     use crate::executor::prelude::StateTable;
     use crate::executor::source::default_source_internal_table;
@@ -1113,6 +1182,166 @@ mod tests {
         assert_eq!(
             chunk.columns()[2].as_int64().iter().collect::<Vec<_>>(),
             vec![Some(100)]
+        );
+    }
+
+    fn create_raw_cdc_chunk(rows: &[(&str, &str)]) -> StreamChunk {
+        let schema = Schema::new(vec![
+            Field::unnamed(DataType::Jsonb),
+            Field::unnamed(DataType::Varchar),
+        ]);
+        let mut builders = schema.create_array_builders(rows.len());
+        for (payload, offset) in rows {
+            let payload_datum: Datum = Some(JsonbVal::from_str(payload).unwrap().into());
+            let offset_datum: Datum = Some((*offset).into());
+            builders[0].append(payload_datum);
+            builders[1].append(offset_datum);
+        }
+        let columns = builders
+            .into_iter()
+            .map(|builder| builder.finish().into())
+            .collect();
+        StreamChunk::from_parts(
+            vec![Op::Insert; rows.len()],
+            DataChunk::new(columns, rows.len()),
+        )
+    }
+
+    async fn create_cdc_state_table(store: MemoryStateStore) -> StateTable<MemoryStateStore> {
+        let state_schema = Schema::new(vec![
+            Field::with_name(DataType::Varchar, "split_id"),
+            Field::with_name(DataType::Int64, "id"),
+            Field::with_name(DataType::Boolean, "backfill_finished"),
+            Field::with_name(DataType::Int64, "row_count"),
+            Field::with_name(DataType::Jsonb, "cdc_offset"),
+        ]);
+        let column_descs = vec![
+            ColumnDesc::unnamed(ColumnId::from(0), state_schema[0].data_type.clone()),
+            ColumnDesc::unnamed(ColumnId::from(1), state_schema[1].data_type.clone()),
+            ColumnDesc::unnamed(ColumnId::from(2), state_schema[2].data_type.clone()),
+            ColumnDesc::unnamed(ColumnId::from(3), state_schema[3].data_type.clone()),
+            ColumnDesc::unnamed(ColumnId::from(4), state_schema[4].data_type.clone()),
+        ];
+
+        StateTable::from_table_catalog(
+            &gen_pbtable(
+                TableId::from(0x42),
+                column_descs,
+                vec![OrderType::ascending()],
+                vec![0],
+                0,
+            ),
+            store,
+            None,
+        )
+        .await
+    }
+
+    #[tokio::test]
+    async fn test_cdc_backfill_persists_buffered_offset_on_checkpoint() {
+        let memory_state_store = MemoryStateStore::new();
+        let state_table = create_cdc_state_table(memory_state_store.clone()).await;
+
+        let (mut tx, source) = MockSource::channel();
+        let source = source.into_executor(
+            Schema::new(vec![
+                Field::unnamed(DataType::Jsonb),
+                Field::unnamed(DataType::Varchar),
+            ]),
+            vec![0],
+        );
+
+        let external_table = ExternalStorageTable::new(
+            TableId::new(1234),
+            SchemaTableName {
+                schema_name: "public".to_owned(),
+                table_name: "mock_table".to_owned(),
+            },
+            "mydb".to_owned(),
+            ExternalTableConfig::default(),
+            ExternalCdcTableType::Mock,
+            Schema::new(vec![
+                Field::with_name(DataType::Int64, "id"),
+                Field::with_name(DataType::Float64, "price"),
+            ]),
+            vec![OrderType::ascending()],
+            vec![0],
+        );
+        let output_columns = vec![
+            ColumnDesc::named("id", ColumnId::new(1), DataType::Int64),
+            ColumnDesc::named("price", ColumnId::new(2), DataType::Float64),
+        ];
+
+        let executor = CdcBackfillExecutor::new(
+            ActorContext::for_test(0x1a),
+            external_table,
+            source,
+            vec![0, 1],
+            output_columns,
+            None,
+            StreamingMetrics::unused().into(),
+            state_table,
+            None,
+            CdcScanOptions {
+                snapshot_barrier_interval: 10,
+                ..Default::default()
+            },
+            BTreeMap::default(),
+        )
+        .execute_inner();
+        pin_mut!(executor);
+
+        tx.send_barrier(Barrier::new_test_barrier(test_epoch(1)));
+        assert!(matches!(
+            executor.next().await.unwrap().unwrap(),
+            Message::Barrier(_)
+        ));
+
+        tx.send_barrier(Barrier::new_test_barrier(test_epoch(2)));
+        assert!(matches!(
+            executor.next().await.unwrap().unwrap(),
+            Message::Barrier(_)
+        ));
+
+        assert!(matches!(
+            executor.next().await.unwrap().unwrap(),
+            Message::Chunk(_)
+        ));
+
+        tx.push_chunk(create_raw_cdc_chunk(&[
+            (
+                r#"{ "payload": { "before": null, "after": { "id": 1, "price": 10.01 }, "source": { "version": "1.9.7.Final", "connector": "mysql", "name": "RW_CDC_1002" }, "op": "r", "ts_ms": 1695277757017, "transaction": null } }"#,
+                r#"{"sourcePartition":{},"sourceOffset":{"file":"1.binlog","pos":3},"isHeartbeat":false}"#,
+            ),
+            (
+                r#"{ "payload": { "before": null, "after": { "id": 6, "price": 66.06 }, "source": { "version": "1.9.7.Final", "connector": "mysql", "name": "RW_CDC_1002" }, "op": "r", "ts_ms": 1695277757017, "transaction": null } }"#,
+                r#"{"sourcePartition":{},"sourceOffset":{"file":"1.binlog","pos":4},"isHeartbeat":false}"#,
+            ),
+        ]));
+        tx.send_barrier(Barrier::new_test_barrier(test_epoch(3)));
+
+        assert!(matches!(
+            executor.next().await.unwrap().unwrap(),
+            Message::Chunk(_)
+        ));
+        assert!(matches!(
+            executor.next().await.unwrap().unwrap(),
+            Message::Barrier(_)
+        ));
+
+        let mut restored_state = CdcBackfillState::new(
+            TableId::new(1234),
+            create_cdc_state_table(memory_state_store).await,
+            5,
+        );
+        restored_state
+            .init_epoch(Barrier::new_test_barrier(test_epoch(3)).epoch)
+            .await
+            .unwrap();
+        let state = restored_state.restore_state().await.unwrap();
+        assert_eq!(
+            state.last_cdc_offset,
+            Some(CdcOffset::MySql(MySqlOffset::new("1.binlog".to_owned(), 4)))
         );
     }
 }


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

Resolved bug within CdcBackfillExecutor. Refer to issue https://github.com/risingwavelabs/risingwave/issues/25848 for details.

### Summary of changes

- Removed incorrect early-break assumptions in buffered chunk consumption that could defer rows incorrectly when CDC event order differs from PK order.
- Fixed the same break-related issue across subsequent buffered chunks.
- Replaced per-row deep copies (`row.into_owned_row()`) with visibility-based chunk splitting using `chunk.clone_with_vis(...)` for both emitted and retained paths.
- Updated logic to work safely with non-compact/sparse visibility in buffered chunks.
- Added/updated unit tests covering:
  - non-monotonic PK ordering within a single buffered chunk,
  - processing following buffered chunks after encountering a future PK row,
  - existing retain-future-row behavior.

## Checklist

- [ ] I have written necessary rustdoc comments.
- [x] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

Fixes a CDC backfill recovery edge case where buffered CDC events could be mishandled when event order is not aligned with primary key order, preventing incorrect deferral during recovery and improving buffered chunk processing efficiency.

</details>