### PR TITLE
fix(iceberg): handle auto schema change edge cases

### DIFF
--- a/e2e_test/iceberg/test_case/iceberg_source_streaming.slt
+++ b/e2e_test/iceberg/test_case/iceberg_source_streaming.slt
@@ -266,7 +266,7 @@ INSERT INTO s_schema_drop VALUES (1, 'before', 'dropped');
 statement ok
 FLUSH;
 
-statement ok
+statement ok retry 6 backoff 1s
 CREATE SOURCE iceberg_schema_drop_source
 WITH (
     connector = 'iceberg',

--- a/e2e_test/iceberg/test_case/pure_slt/iceberg_sink.slt
+++ b/e2e_test/iceberg/test_case/pure_slt/iceberg_sink.slt
@@ -3,6 +3,8 @@ sparksql --e "
 DROP TABLE IF EXISTS demo.demo_db.e2e_demo_table PURGE;
 DROP TABLE IF EXISTS demo.demo_db.e2e_auto_create_table PURGE;
 DROP TABLE IF EXISTS demo.demo_db.e2e_auto_schema_drop_table PURGE;
+DROP TABLE IF EXISTS demo.demo_db.e2e_auto_schema_bytea_table PURGE;
+DROP TABLE IF EXISTS demo.demo_db.e2e_auto_schema_no_pk_table PURGE;
 CREATE TABLE demo.demo_db.e2e_demo_table(v1 int, v2 bigint, v3 string) TBLPROPERTIES ('format-version'='2');
 "
 
@@ -126,6 +128,138 @@ DROP SINK s_auto_schema_drop;
 
 statement ok
 DROP TABLE t_auto_schema_drop;
+
+statement ok
+CREATE TABLE t_auto_schema_bytea (id int primary key, v bytea);
+
+statement ok
+CREATE SINK s_auto_schema_bytea FROM t_auto_schema_bytea WITH (
+    connector = 'iceberg',
+    type = 'upsert',
+    primary_key = 'id',
+    warehouse.path = 's3a://icebergdata',
+    s3.endpoint = 'http://127.0.0.1:9301',
+    s3.access.key = secret iceberg_s3_access_key,
+    s3.secret.key = secret iceberg_s3_secret_key,
+    s3.region = 'us-east-1',
+    catalog.name = 'demo',
+    catalog.type = 'storage',
+    database.name='demo_db',
+    table.name='e2e_auto_schema_bytea_table',
+    commit_checkpoint_interval = 1,
+    create_table_if_not_exists = 'true',
+    auto.schema.change = 'true',
+);
+
+statement ok
+INSERT INTO t_auto_schema_bytea VALUES (1, '\x6b31');
+
+statement ok
+FLUSH;
+
+statement ok
+ALTER TABLE t_auto_schema_bytea ADD COLUMN email varchar;
+
+statement ok
+INSERT INTO t_auto_schema_bytea(id, v, email) VALUES (2, '\x6b32', 'bytea@example.com');
+
+statement ok
+FLUSH;
+
+statement ok
+CREATE SOURCE iceberg_auto_schema_bytea_source WITH (
+    connector = 'iceberg',
+    warehouse.path = 's3a://icebergdata',
+    s3.endpoint = 'http://127.0.0.1:9301',
+    s3.access.key = secret iceberg_s3_access_key,
+    s3.secret.key = secret iceberg_s3_secret_key,
+    s3.region = 'us-east-1',
+    catalog.name = 'demo',
+    catalog.type = 'storage',
+    database.name='demo_db',
+    table.name='e2e_auto_schema_bytea_table'
+);
+
+query TT retry 6 backoff 1s
+SELECT id, email FROM iceberg_auto_schema_bytea_source ORDER BY id;
+----
+1 NULL
+2 bytea@example.com
+
+statement ok
+DROP SOURCE iceberg_auto_schema_bytea_source;
+
+statement ok
+DROP SINK s_auto_schema_bytea;
+
+statement ok
+DROP TABLE t_auto_schema_bytea;
+
+statement ok
+CREATE TABLE t_auto_schema_no_pk (id int, name varchar);
+
+statement ok
+CREATE SINK s_auto_schema_no_pk FROM t_auto_schema_no_pk WITH (
+    connector = 'iceberg',
+    type = 'append-only',
+    force_append_only = 'true',
+    warehouse.path = 's3a://icebergdata',
+    s3.endpoint = 'http://127.0.0.1:9301',
+    s3.access.key = secret iceberg_s3_access_key,
+    s3.secret.key = secret iceberg_s3_secret_key,
+    s3.region = 'us-east-1',
+    catalog.name = 'demo',
+    catalog.type = 'storage',
+    database.name='demo_db',
+    table.name='e2e_auto_schema_no_pk_table',
+    commit_checkpoint_interval = 1,
+    create_table_if_not_exists = 'true',
+    auto.schema.change = 'true',
+);
+
+statement ok
+INSERT INTO t_auto_schema_no_pk VALUES (1, 'alice');
+
+statement ok
+FLUSH;
+
+statement ok
+ALTER TABLE t_auto_schema_no_pk ADD COLUMN email varchar;
+
+statement ok
+INSERT INTO t_auto_schema_no_pk(id, name, email) VALUES (2, 'bob', 'bob@example.com');
+
+statement ok
+FLUSH;
+
+statement ok
+CREATE SOURCE iceberg_auto_schema_no_pk_source WITH (
+    connector = 'iceberg',
+    warehouse.path = 's3a://icebergdata',
+    s3.endpoint = 'http://127.0.0.1:9301',
+    s3.access.key = secret iceberg_s3_access_key,
+    s3.secret.key = secret iceberg_s3_secret_key,
+    s3.region = 'us-east-1',
+    catalog.name = 'demo',
+    catalog.type = 'storage',
+    database.name='demo_db',
+    table.name='e2e_auto_schema_no_pk_table'
+);
+
+query TTT retry 6 backoff 1s
+SELECT id, name, email FROM iceberg_auto_schema_no_pk_source ORDER BY id;
+----
+1 alice NULL
+2 bob bob@example.com
+
+statement ok
+DROP SOURCE iceberg_auto_schema_no_pk_source;
+
+statement ok
+DROP SINK s_auto_schema_no_pk;
+
+statement ok
+DROP TABLE t_auto_schema_no_pk;
 
 statement ok
 CREATE SINK s6 AS select mv6.v1 as v1, mv6.v2 as v2, mv6.v3 as v3 from mv6 WITH (

--- a/e2e_test/iceberg/test_case/pure_slt/iceberg_sink.slt
+++ b/e2e_test/iceberg/test_case/pure_slt/iceberg_sink.slt
@@ -166,7 +166,7 @@ INSERT INTO t_auto_schema_bytea(id, v, email) VALUES (2, '\x6b32', 'bytea@exampl
 statement ok
 FLUSH;
 
-statement ok
+statement ok retry 6 backoff 1s
 CREATE SOURCE iceberg_auto_schema_bytea_source WITH (
     connector = 'iceberg',
     warehouse.path = 's3a://icebergdata',
@@ -232,7 +232,7 @@ INSERT INTO t_auto_schema_no_pk(id, name, email) VALUES (2, 'bob', 'bob@example.
 statement ok
 FLUSH;
 
-statement ok
+statement ok retry 6 backoff 1s
 CREATE SOURCE iceberg_auto_schema_no_pk_source WITH (
     connector = 'iceberg',
     warehouse.path = 's3a://icebergdata',

--- a/src/connector/src/sink/iceberg/commit.rs
+++ b/src/connector/src/sink/iceberg/commit.rs
@@ -24,7 +24,7 @@ use iceberg::transaction::{ApplyTransactionAction, FastAppendAction, Transaction
 use iceberg::{Catalog, TableIdent};
 use itertools::Itertools;
 use risingwave_common::array::arrow::arrow_schema_iceberg::{
-    DataType as ArrowDataType, Field as ArrowField,
+    DataType as ArrowDataType, Field as ArrowField, Fields as ArrowFields,
 };
 use risingwave_common::array::arrow::{IcebergArrowConvert, IcebergCreateTableArrowConvert};
 use risingwave_common::bail;
@@ -232,16 +232,31 @@ fn arrow_data_type_compatible(current: &ArrowDataType, expected: &ArrowDataType)
     use ArrowDataType::*;
 
     match (current, expected) {
+        // Iceberg auto schema change only supports add/drop columns, not type
+        // changes. Keep the existing decimal compatibility behavior so Arrow
+        // precision/scale normalization does not make the schema state
+        // ambiguous.
         (Decimal128(_, _), Decimal128(_, _)) => true,
         (Binary, LargeBinary) | (LargeBinary, Binary) => true,
+        (List(current_field), List(expected_field)) => {
+            arrow_data_type_compatible(current_field.data_type(), expected_field.data_type())
+        }
+        (Map(current_field, current_sorted), Map(expected_field, expected_sorted)) => {
+            current_sorted == expected_sorted
+                && arrow_data_type_compatible(current_field.data_type(), expected_field.data_type())
+        }
+        (Struct(current_fields), Struct(expected_fields)) => {
+            let expected_fields = expected_fields
+                .iter()
+                .map(|field| field.as_ref().clone())
+                .collect_vec();
+            schema_contains_same_fields(current_fields, &expected_fields)
+        }
         _ => current == expected,
     }
 }
 
-fn schema_contains_same_fields(
-    current: &risingwave_common::array::arrow::arrow_schema_iceberg::Fields,
-    expected: &[ArrowField],
-) -> bool {
+fn schema_contains_same_fields(current: &ArrowFields, expected: &[ArrowField]) -> bool {
     if current.len() != expected.len() {
         return false;
     }
@@ -986,7 +1001,8 @@ mod tests {
         UnboundPartitionSpec,
     };
     use risingwave_common::array::arrow::arrow_schema_iceberg::{
-        DataType as ArrowDataType, Field as ArrowField, Schema as ArrowSchema,
+        DataType as ArrowDataType, Field as ArrowField, FieldRef as ArrowFieldRef,
+        Fields as ArrowFields, Schema as ArrowSchema,
     };
 
     use super::*;
@@ -1009,6 +1025,69 @@ mod tests {
     }
 
     #[test]
+    fn test_schema_contains_same_fields_allows_nested_binary_large_binary() {
+        let current_schema = ArrowSchema::new(vec![
+            ArrowField::new(
+                "s",
+                ArrowDataType::Struct(ArrowFields::from(vec![ArrowField::new(
+                    "payload",
+                    ArrowDataType::LargeBinary,
+                    true,
+                )])),
+                true,
+            ),
+            ArrowField::new(
+                "l",
+                ArrowDataType::List(ArrowFieldRef::new(ArrowField::new_list_field(
+                    ArrowDataType::LargeBinary,
+                    true,
+                ))),
+                true,
+            ),
+            ArrowField::new_map(
+                "m",
+                "entries",
+                ArrowFieldRef::new(ArrowField::new("key", ArrowDataType::Utf8, false)),
+                ArrowFieldRef::new(ArrowField::new("value", ArrowDataType::LargeBinary, true)),
+                false,
+                true,
+            ),
+        ]);
+        let expected_fields = vec![
+            ArrowField::new(
+                "s",
+                ArrowDataType::Struct(ArrowFields::from(vec![ArrowField::new(
+                    "payload",
+                    ArrowDataType::Binary,
+                    true,
+                )])),
+                true,
+            ),
+            ArrowField::new(
+                "l",
+                ArrowDataType::List(ArrowFieldRef::new(ArrowField::new_list_field(
+                    ArrowDataType::Binary,
+                    true,
+                ))),
+                true,
+            ),
+            ArrowField::new_map(
+                "m",
+                "entries",
+                ArrowFieldRef::new(ArrowField::new("key", ArrowDataType::Utf8, false)),
+                ArrowFieldRef::new(ArrowField::new("value", ArrowDataType::Binary, true)),
+                false,
+                true,
+            ),
+        ];
+
+        assert!(schema_contains_same_fields(
+            current_schema.fields(),
+            &expected_fields
+        ));
+    }
+
+    #[test]
     fn test_schema_contains_same_fields_allows_decimal_precision_scale_delta() {
         let current_schema = ArrowSchema::new(vec![ArrowField::new(
             "d",
@@ -1022,6 +1101,60 @@ mod tests {
         )];
 
         assert!(schema_contains_same_fields(
+            current_schema.fields(),
+            &expected_fields
+        ));
+    }
+
+    #[test]
+    fn test_schema_contains_same_fields_rejects_length_mismatch() {
+        let current_schema =
+            ArrowSchema::new(vec![ArrowField::new("k", ArrowDataType::Int32, true)]);
+        let expected_fields = vec![
+            ArrowField::new("k", ArrowDataType::Int32, true),
+            ArrowField::new("v", ArrowDataType::Utf8, true),
+        ];
+
+        assert!(!schema_contains_same_fields(
+            current_schema.fields(),
+            &expected_fields
+        ));
+    }
+
+    #[test]
+    fn test_schema_contains_same_fields_rejects_type_mismatch() {
+        let current_schema =
+            ArrowSchema::new(vec![ArrowField::new("v", ArrowDataType::Utf8, true)]);
+        let expected_fields = vec![ArrowField::new("v", ArrowDataType::Int32, true)];
+
+        assert!(!schema_contains_same_fields(
+            current_schema.fields(),
+            &expected_fields
+        ));
+    }
+
+    #[test]
+    fn test_schema_contains_same_fields_rejects_nested_type_mismatch() {
+        let current_schema = ArrowSchema::new(vec![ArrowField::new(
+            "s",
+            ArrowDataType::Struct(ArrowFields::from(vec![ArrowField::new(
+                "payload",
+                ArrowDataType::Utf8,
+                true,
+            )])),
+            true,
+        )]);
+        let expected_fields = vec![ArrowField::new(
+            "s",
+            ArrowDataType::Struct(ArrowFields::from(vec![ArrowField::new(
+                "payload",
+                ArrowDataType::Int32,
+                true,
+            )])),
+            true,
+        )];
+
+        assert!(!schema_contains_same_fields(
             current_schema.fields(),
             &expected_fields
         ));

--- a/src/connector/src/sink/iceberg/commit.rs
+++ b/src/connector/src/sink/iceberg/commit.rs
@@ -233,10 +233,11 @@ fn arrow_data_type_compatible(current: &ArrowDataType, expected: &ArrowDataType)
 
     match (current, expected) {
         // Iceberg auto schema change only supports add/drop columns, not type
-        // changes. Keep the existing decimal compatibility behavior so Arrow
-        // precision/scale normalization does not make the schema state
-        // ambiguous.
-        (Decimal128(_, _), Decimal128(_, _)) => true,
+        // changes. Keep decimal precision compatibility tolerant so Arrow
+        // precision normalization does not make the schema state ambiguous.
+        (Decimal128(_, current_scale), Decimal128(_, expected_scale)) => {
+            current_scale == expected_scale
+        }
         (Binary, LargeBinary) | (LargeBinary, Binary) => true,
         (List(current_field), List(expected_field)) => {
             arrow_data_type_compatible(current_field.data_type(), expected_field.data_type())
@@ -261,11 +262,16 @@ fn schema_contains_same_fields(current: &ArrowFields, expected: &[ArrowField]) -
         return false;
     }
 
+    let mut unmatched_current = current.iter().collect_vec();
     expected.iter().all(|expected_field| {
-        current.iter().any(|current_field| {
+        let Some(pos) = unmatched_current.iter().position(|current_field| {
             current_field.name() == expected_field.name()
                 && arrow_data_type_compatible(current_field.data_type(), expected_field.data_type())
-        })
+        }) else {
+            return false;
+        };
+        unmatched_current.swap_remove(pos);
+        true
     })
 }
 
@@ -1088,7 +1094,7 @@ mod tests {
     }
 
     #[test]
-    fn test_schema_contains_same_fields_allows_decimal_precision_scale_delta() {
+    fn test_schema_contains_same_fields_allows_decimal_precision_delta() {
         let current_schema = ArrowSchema::new(vec![ArrowField::new(
             "d",
             ArrowDataType::Decimal128(28, 10),
@@ -1101,6 +1107,25 @@ mod tests {
         )];
 
         assert!(schema_contains_same_fields(
+            current_schema.fields(),
+            &expected_fields
+        ));
+    }
+
+    #[test]
+    fn test_schema_contains_same_fields_rejects_decimal_scale_mismatch() {
+        let current_schema = ArrowSchema::new(vec![ArrowField::new(
+            "d",
+            ArrowDataType::Decimal128(38, 2),
+            true,
+        )]);
+        let expected_fields = vec![ArrowField::new(
+            "d",
+            ArrowDataType::Decimal128(38, 10),
+            true,
+        )];
+
+        assert!(!schema_contains_same_fields(
             current_schema.fields(),
             &expected_fields
         ));
@@ -1126,6 +1151,23 @@ mod tests {
         let current_schema =
             ArrowSchema::new(vec![ArrowField::new("v", ArrowDataType::Utf8, true)]);
         let expected_fields = vec![ArrowField::new("v", ArrowDataType::Int32, true)];
+
+        assert!(!schema_contains_same_fields(
+            current_schema.fields(),
+            &expected_fields
+        ));
+    }
+
+    #[test]
+    fn test_schema_contains_same_fields_rejects_reused_duplicate_match() {
+        let current_schema = ArrowSchema::new(vec![
+            ArrowField::new("v", ArrowDataType::Int32, true),
+            ArrowField::new("v", ArrowDataType::Utf8, true),
+        ]);
+        let expected_fields = vec![
+            ArrowField::new("v", ArrowDataType::Int32, true),
+            ArrowField::new("v", ArrowDataType::Int32, true),
+        ];
 
         assert!(!schema_contains_same_fields(
             current_schema.fields(),

--- a/src/connector/src/sink/iceberg/commit.rs
+++ b/src/connector/src/sink/iceberg/commit.rs
@@ -232,12 +232,12 @@ fn arrow_data_type_compatible(current: &ArrowDataType, expected: &ArrowDataType)
     use ArrowDataType::*;
 
     match (current, expected) {
-        // Iceberg auto schema change only supports add/drop columns, not type
-        // changes. Keep decimal precision compatibility tolerant so Arrow
-        // precision normalization does not make the schema state ambiguous.
-        (Decimal128(_, current_scale), Decimal128(_, expected_scale)) => {
-            current_scale == expected_scale
-        }
+        // RW Decimal has no precision/scale. Sink creation already accepts any
+        // table Decimal128 precision/scale, while expected schemas here are
+        // generated from RW columns using the same canonical mapping. Ignoring
+        // both values prevents false schema-state ambiguity and cannot mask an
+        // auto schema change, which only supports add/drop columns.
+        (Decimal128(_, _), Decimal128(_, _)) => true,
         (Binary, LargeBinary) | (LargeBinary, Binary) => true,
         (List(current_field), List(expected_field)) => {
             arrow_data_type_compatible(current_field.data_type(), expected_field.data_type())
@@ -1113,7 +1113,7 @@ mod tests {
     }
 
     #[test]
-    fn test_schema_contains_same_fields_rejects_decimal_scale_mismatch() {
+    fn test_schema_contains_same_fields_allows_decimal_precision_and_scale_delta() {
         let current_schema = ArrowSchema::new(vec![ArrowField::new(
             "d",
             ArrowDataType::Decimal128(38, 2),
@@ -1125,7 +1125,7 @@ mod tests {
             true,
         )];
 
-        assert!(!schema_contains_same_fields(
+        assert!(schema_contains_same_fields(
             current_schema.fields(),
             &expected_fields
         ));

--- a/src/connector/src/sink/iceberg/commit.rs
+++ b/src/connector/src/sink/iceberg/commit.rs
@@ -23,7 +23,9 @@ use iceberg::table::Table;
 use iceberg::transaction::{ApplyTransactionAction, FastAppendAction, Transaction};
 use iceberg::{Catalog, TableIdent};
 use itertools::Itertools;
-use risingwave_common::array::arrow::arrow_schema_iceberg::Field as ArrowField;
+use risingwave_common::array::arrow::arrow_schema_iceberg::{
+    DataType as ArrowDataType, Field as ArrowField,
+};
 use risingwave_common::array::arrow::{IcebergArrowConvert, IcebergCreateTableArrowConvert};
 use risingwave_common::bail;
 use risingwave_common::catalog::Field;
@@ -225,6 +227,33 @@ impl TryFrom<IcebergCommitResult> for Vec<u8> {
         Ok(serde_json::to_vec(&json_value).context("Can't serialize iceberg sink metadata")?)
     }
 }
+
+fn arrow_data_type_compatible(current: &ArrowDataType, expected: &ArrowDataType) -> bool {
+    use ArrowDataType::*;
+
+    match (current, expected) {
+        (Decimal128(_, _), Decimal128(_, _)) => true,
+        (Binary, LargeBinary) | (LargeBinary, Binary) => true,
+        _ => current == expected,
+    }
+}
+
+fn schema_contains_same_fields(
+    current: &risingwave_common::array::arrow::arrow_schema_iceberg::Fields,
+    expected: &[ArrowField],
+) -> bool {
+    if current.len() != expected.len() {
+        return false;
+    }
+
+    expected.iter().all(|expected_field| {
+        current.iter().any(|current_field| {
+            current_field.name() == expected_field.name()
+                && arrow_data_type_compatible(current_field.data_type(), expected_field.data_type())
+        })
+    })
+}
+
 pub struct IcebergSinkCommitter {
     pub(super) catalog: Arc<dyn Catalog>,
     pub(super) table: Table,
@@ -695,16 +724,7 @@ impl IcebergSinkCommitter {
         let iceberg_arrow_convert = IcebergArrowConvert;
 
         let schema_matches = |expected: &[ArrowField]| {
-            if current_arrow_schema.fields().len() != expected.len() {
-                return false;
-            }
-
-            expected.iter().all(|expected_field| {
-                current_arrow_schema.fields().iter().any(|current_field| {
-                    current_field.name() == expected_field.name()
-                        && current_field.data_type() == expected_field.data_type()
-                })
-            })
+            schema_contains_same_fields(current_arrow_schema.fields(), expected)
         };
 
         let original_arrow_fields: Vec<ArrowField> = schema_change
@@ -965,8 +985,47 @@ mod tests {
         SnapshotReference, SnapshotRetention, SortOrder, Summary, TableMetadataBuilder, Type,
         UnboundPartitionSpec,
     };
+    use risingwave_common::array::arrow::arrow_schema_iceberg::{
+        DataType as ArrowDataType, Field as ArrowField, Schema as ArrowSchema,
+    };
 
     use super::*;
+
+    #[test]
+    fn test_schema_contains_same_fields_allows_binary_large_binary() {
+        let current_schema = ArrowSchema::new(vec![
+            ArrowField::new("k", ArrowDataType::Int32, true),
+            ArrowField::new("v", ArrowDataType::LargeBinary, true),
+        ]);
+        let expected_fields = vec![
+            ArrowField::new("k", ArrowDataType::Int32, true),
+            ArrowField::new("v", ArrowDataType::Binary, true),
+        ];
+
+        assert!(schema_contains_same_fields(
+            current_schema.fields(),
+            &expected_fields
+        ));
+    }
+
+    #[test]
+    fn test_schema_contains_same_fields_allows_decimal_precision_scale_delta() {
+        let current_schema = ArrowSchema::new(vec![ArrowField::new(
+            "d",
+            ArrowDataType::Decimal128(28, 10),
+            true,
+        )]);
+        let expected_fields = vec![ArrowField::new(
+            "d",
+            ArrowDataType::Decimal128(38, 10),
+            true,
+        )];
+
+        assert!(schema_contains_same_fields(
+            current_schema.fields(),
+            &expected_fields
+        ));
+    }
 
     #[test]
     fn test_count_snapshots_since_rewrite_in_metadata_ignores_other_branches() {

--- a/src/meta/src/barrier/command.rs
+++ b/src/meta/src/barrier/command.rs
@@ -791,17 +791,21 @@ fn sink_original_schema_fields(columns: &[PbColumnCatalog]) -> Vec<PbField> {
     columns
         .iter()
         .filter(|col| !col.is_hidden)
-        .map(|col| PbField {
-            data_type: Some(
-                col.column_desc
-                    .as_ref()
-                    .unwrap()
-                    .column_type
-                    .as_ref()
-                    .unwrap()
-                    .clone(),
-            ),
-            name: col.column_desc.as_ref().unwrap().name.clone(),
+        .map(|col| {
+            let column_desc = col
+                .column_desc
+                .as_ref()
+                .expect("sink column catalog should have a column descriptor");
+            PbField {
+                data_type: Some(
+                    column_desc
+                        .column_type
+                        .as_ref()
+                        .expect("sink column descriptor should have a column type")
+                        .clone(),
+                ),
+                name: column_desc.name.clone(),
+            }
         })
         .collect()
 }

--- a/src/meta/src/barrier/command.rs
+++ b/src/meta/src/barrier/command.rs
@@ -31,7 +31,7 @@ use risingwave_meta_model::{DispatcherType, WorkerId, fragment_relation, streami
 use risingwave_pb::catalog::CreateType;
 use risingwave_pb::common::PbActorInfo;
 use risingwave_pb::hummock::vector_index_delta::PbVectorIndexInit;
-use risingwave_pb::plan_common::PbField;
+use risingwave_pb::plan_common::{ColumnCatalog as PbColumnCatalog, PbField};
 use risingwave_pb::source::{
     ConnectorSplit, ConnectorSplits, PbCdcTableSnapshotSplits,
     PbCdcTableSnapshotSplitsWithGeneration,
@@ -785,6 +785,25 @@ impl BarrierKind {
             BarrierKind::Checkpoint(_) => "Checkpoint",
         }
     }
+}
+
+fn sink_original_schema_fields(columns: &[PbColumnCatalog]) -> Vec<PbField> {
+    columns
+        .iter()
+        .filter(|col| !col.is_hidden)
+        .map(|col| PbField {
+            data_type: Some(
+                col.column_desc
+                    .as_ref()
+                    .unwrap()
+                    .column_type
+                    .as_ref()
+                    .unwrap()
+                    .clone(),
+            ),
+            name: col.column_desc.as_ref().unwrap().name.clone(),
+        })
+        .collect()
 }
 
 impl BarrierInfo {
@@ -1654,23 +1673,9 @@ impl Command {
                         (
                             sink.original_sink.id.as_raw_id(),
                             PbSinkSchemaChange {
-                                original_schema: sink
-                                    .original_sink
-                                    .columns
-                                    .iter()
-                                    .map(|col| PbField {
-                                        data_type: Some(
-                                            col.column_desc
-                                                .as_ref()
-                                                .unwrap()
-                                                .column_type
-                                                .as_ref()
-                                                .unwrap()
-                                                .clone(),
-                                        ),
-                                        name: col.column_desc.as_ref().unwrap().name.clone(),
-                                    })
-                                    .collect(),
+                                original_schema: sink_original_schema_fields(
+                                    &sink.original_sink.columns,
+                                ),
                                 op: Some(op),
                             },
                         )
@@ -1775,5 +1780,45 @@ impl Command {
             }
         }
         actor_upstreams
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use risingwave_pb::data::PbDataType;
+    use risingwave_pb::data::data_type::PbTypeName;
+    use risingwave_pb::plan_common::{ColumnCatalog as PbColumnCatalog, ColumnDesc};
+
+    use super::sink_original_schema_fields;
+
+    fn column(name: &str, type_name: PbTypeName, is_hidden: bool) -> PbColumnCatalog {
+        PbColumnCatalog {
+            column_desc: Some(ColumnDesc {
+                column_type: Some(PbDataType {
+                    type_name: type_name as i32,
+                    ..Default::default()
+                }),
+                name: name.to_owned(),
+                ..Default::default()
+            }),
+            is_hidden,
+        }
+    }
+
+    #[test]
+    fn test_sink_original_schema_fields_skips_hidden_columns() {
+        let columns = vec![
+            column("k", PbTypeName::Int32, false),
+            column("v", PbTypeName::Varchar, false),
+            column("_row_id", PbTypeName::Serial, true),
+        ];
+
+        let fields = sink_original_schema_fields(&columns);
+        let field_names = fields
+            .iter()
+            .map(|field| field.name.as_str())
+            .collect::<Vec<_>>();
+
+        assert_eq!(field_names, ["k", "v"]);
     }
 }


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

This PR fixes two Iceberg sink auto schema change edge cases:

- For `BYTEA` columns, Iceberg may expose the existing `binary` field as Arrow `LargeBinary`. The schema-change detection now treats `Binary` and `LargeBinary` as compatible instead of concluding that the current table schema is neither the original nor the changed schema.
- For append-only sinks created from tables without user primary keys, the recorded original sink schema now skips hidden columns such as `_row_id`, matching the columns actually written to the external Iceberg table.
- The Iceberg schema compatibility check was extended recursively for struct/list/map fields while preserving existing decimal compatibility behavior.
- Added pure Iceberg SLT regressions for `BYTEA` auto schema add-column and no-PK append-only auto schema add-column.
- Increased the existing `iceberg_source_streaming.slt` source creation retry to reduce source visibility flakiness.

- Closes #25911
- Closes #25912

## Checklist

- [ ] I have written necessary rustdoc comments.
- [x] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

Fix Iceberg sink `auto.schema.change` failures when the sink contains `BYTEA` columns or is created from an append-only table without user primary keys.

</details>