### PR TITLE
feat(sink): add table.location sink option to set Iceberg table location on create

### DIFF
--- a/src/connector/src/sink/iceberg/config.rs
+++ b/src/connector/src/sink/iceberg/config.rs
@@ -311,6 +311,12 @@ pub struct IcebergConfig {
     #[serde(default)]
     pub order_key: Option<String>,
 
+    /// Explicit Iceberg table location used at table creation. When set, it is
+    /// used as `TableCreation.location` directly; otherwise the location is
+    /// derived from `warehouse.path`.
+    #[serde(rename = "table.location", default)]
+    pub table_location: Option<String>,
+
     /// Commit every n(>0) checkpoints, default is 60.
     #[serde(default = "iceberg_default_commit_checkpoint_interval")]
     #[serde_as(as = "DisplayFromStr")]

--- a/src/connector/src/sink/iceberg/create_table.rs
+++ b/src/connector/src/sink/iceberg/create_table.rs
@@ -117,7 +117,11 @@ pub(super) async fn create_table_if_not_exists_impl(
             .map_err(|e| SinkError::Iceberg(anyhow!(e)))
             .context("failed to convert arrow schema to iceberg schema")?;
 
-        let location = {
+        let location = if let Some(table_location) = &config.table_location {
+            // An explicit `table.location` takes precedence over the location
+            // derived from `warehouse.path` below.
+            Some(table_location.clone())
+        } else {
             let mut names = namespace.clone().inner();
             names.push(table_name.clone());
             match &config.common.warehouse_path {

--- a/src/connector/src/sink/iceberg/test.rs
+++ b/src/connector/src/sink/iceberg/test.rs
@@ -307,6 +307,7 @@ fn test_parse_iceberg_config() {
             primary_key: Some(vec!["v1".to_owned()]),
             partition_by: Some("v1, identity(v1), truncate(4,v2), bucket(5,v1), year(v3), month(v4), day(v5), hour(v6), void(v1)".to_owned()),
             order_key: None,
+            table_location: None,
             java_catalog_props: [("jdbc.user", "admin"), ("jdbc.password", "123456")]
                 .into_iter()
                 .map(|(k, v)| (k.to_owned(), v.to_owned()))
@@ -493,6 +494,48 @@ fn test_parse_google_auth_config() {
         config.common.catalog_header.as_deref(),
         Some("x-goog-user-project=my-gcp-project")
     );
+}
+
+/// Test that the `table.location` option is parsed, and is `None` when omitted.
+#[test]
+fn test_parse_iceberg_config_table_location() {
+    let values: BTreeMap<String, String> = [
+        ("connector", "iceberg"),
+        ("type", "append-only"),
+        ("force_append_only", "true"),
+        ("catalog.type", "rest"),
+        ("catalog.uri", "http://localhost:8181"),
+        ("warehouse.path", "my_warehouse"),
+        ("table.location", "s3://my-bucket/my_db/my_table"),
+        ("database.name", "my_db"),
+        ("table.name", "my_table"),
+    ]
+    .into_iter()
+    .map(|(k, v)| (k.to_owned(), v.to_owned()))
+    .collect();
+
+    let config = IcebergConfig::from_btreemap(values).unwrap();
+    assert_eq!(
+        config.table_location.as_deref(),
+        Some("s3://my-bucket/my_db/my_table")
+    );
+
+    // When `table.location` is absent, the field stays `None` and parsing is unaffected.
+    let values_without_location: BTreeMap<String, String> = [
+        ("connector", "iceberg"),
+        ("type", "append-only"),
+        ("force_append_only", "true"),
+        ("catalog.type", "rest"),
+        ("catalog.uri", "http://localhost:8181"),
+        ("warehouse.path", "my_warehouse"),
+        ("database.name", "my_db"),
+        ("table.name", "my_table"),
+    ]
+    .into_iter()
+    .map(|(k, v)| (k.to_owned(), v.to_owned()))
+    .collect();
+    let config = IcebergConfig::from_btreemap(values_without_location).unwrap();
+    assert_eq!(config.table_location, None);
 }
 
 /// Test parsing `oauth2` security configuration.

--- a/src/connector/with_options_sink.yaml
+++ b/src/connector/with_options_sink.yaml
@@ -648,6 +648,14 @@ IcebergConfig:
     field_type: String
     required: false
     default: Default::default
+  - name: table.location
+    field_type: String
+    comments: |-
+      Explicit Iceberg table location used at table creation. When set, it is
+      used as `TableCreation.location` directly; otherwise the location is
+      derived from `warehouse.path`.
+    required: false
+    default: Default::default
   - name: commit_checkpoint_interval
     field_type: u64
     comments: Commit every n(>0) checkpoints, default is 60.


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

This PR adds an optional `table.location` option to the Iceberg sink, used as the table's location when the sink auto-creates the table (`create_table_if_not_exists = 'true'`).

**Why it's needed:** the table location was only ever derived from `warehouse.path` (`{warehouse.path}/{database}/{table}`). For catalogs where `warehouse.path` is not a storage URL, that derivation intentionally produces nothing:

- BigQuery/BigLake catalog federation (`warehouse.path = 'bq://...'`)
- REST catalogs where `warehouse.path` is a logical warehouse name
- S3 Tables (`warehouse.path = 'arn:aws:s3tables:...'`)

In these cases the `CreateTableRequest` went out with an empty `location`, and the catalog rejected it unless the target namespace already had a default location.

**How it works:** when `table.location` is set, it is used as `TableCreation.location` directly and takes precedence over the `warehouse.path`-derived value; when omitted, behavior is unchanged. The option only affects table creation and is ignored when the table already exists (consistent with `partition_by`). No Java or catalog changes are needed, since the create request already carries the `location` field.

```sql
CREATE SINK my_sink FROM my_mv WITH (
    connector = 'iceberg',
    type = 'append-only',
    catalog.type = 'rest',
    catalog.uri = '...',
    warehouse.path = 'my_warehouse',
    database.name = 'my_db',
    table.name = 'my_table',
    create_table_if_not_exists = 'true',
    table.location = 's3://my-bucket/my_db/my_table'
);
```

Main changes:
- add `table.location` (`Option<String>`) to `IcebergConfig`
- use it with precedence over the derived location in `create_table_if_not_exists_impl`
- regenerate `with_options_sink.yaml` for the new option
- unit tests covering parsing with and without the option

- Closes #25916

## Checklist

- [x] I have written necessary rustdoc comments.
- [x] I have added necessary unit tests and integration tests.
- [ ] I have added test labels as necessary.
- [ ] I have added fuzzing tests or opened an issue to track them.
- [ ] My PR contains breaking changes.
- [ ] My PR changes performance-critical code, so I will run (micro) benchmarks and present the results.
- [ ] I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into.

## Documentation

- [x] My PR needs documentation updates.

<details>
<summary><b>Release note</b></summary>

The Iceberg sink now supports an optional `table.location` option. When `create_table_if_not_exists = 'true'`, it sets the location of the auto-created table explicitly, taking precedence over the location derived from `warehouse.path`. This enables table auto-creation with catalogs where the location cannot be inferred from `warehouse.path`, such as BigQuery/BigLake catalog federation (`bq://...`), REST catalogs using a logical warehouse name, and S3 Tables.

</details>