### PR TITLE
feat(session): add explain_column_width session variable

### DIFF
--- a/e2e_test/batch/catalog/pg_settings.slt.part
+++ b/e2e_test/batch/catalog/pg_settings.slt.part
@@ -47,6 +47,7 @@ user enable_mv_selection
 user enable_serverless_backfill
 user enable_share_plan
 user enable_two_phase_agg
+user explain_column_width
 user extra_float_digits
 user force_split_distinct_agg
 user force_two_phase_agg

--- a/src/common/src/session_config/mod.rs
+++ b/src/common/src/session_config/mod.rs
@@ -467,6 +467,10 @@ pub struct SessionConfig {
     #[parameter(default = 40_usize)] // default value borrowed from pg_vector
     batch_hnsw_ef_search: usize,
 
+    /// The column width used when pretty-printing the plan tree in `EXPLAIN` output.
+    #[parameter(default = 2048_usize)]
+    explain_column_width: usize,
+
     /// Enable index selection for queries
     #[parameter(default = true)]
     enable_index_selection: bool,

--- a/src/frontend/planner_test/tests/testdata/input/explain.yaml
+++ b/src/frontend/planner_test/tests/testdata/input/explain.yaml
@@ -44,3 +44,12 @@
     explain create table t (v1 int, v2 varchar primary key) append only with ( connector = 'kafka', kafka.topic = 'kafka_3_partition_topic', kafka.brokers = '127.0.0.1:1234', kafka.scan.startup.mode='earliest'  ) FORMAT PLAIN ENCODE JSON;
   expected_outputs:
   - explain_output
+- name: explain_column_width controls the pretty-print wrapping width
+  sql: |
+    create table t1(v1 int);
+    create table t2(v2 int);
+    explain (logical) select * from t1 join t2 on v1=v2;
+  with_config_map:
+    EXPLAIN_COLUMN_WIDTH: '20'
+  expected_outputs:
+  - explain_output

--- a/src/frontend/planner_test/tests/testdata/output/explain.yaml
+++ b/src/frontend/planner_test/tests/testdata/output/explain.yaml
@@ -264,3 +264,20 @@
       │ └─StreamDml { columns: [v1, v2] }
       │   └─StreamSource
       └─StreamUpstreamSinkUnion
+- name: explain_column_width controls the pretty-print wrapping width
+  sql: |
+    create table t1(v1 int);
+    create table t2(v2 int);
+    explain (logical) select * from t1 join t2 on v1=v2;
+  explain_output: |
+    LogicalJoin
+    ├─type: Inner
+    ├─on: (t1.v1 = t2.v2)
+    ├─LogicalScan
+    │ ├─table: t1
+    │ └─columns: [v1]
+    └─LogicalScan
+      ├─table: t2
+      └─columns: [v2]
+  with_config_map:
+    EXPLAIN_COLUMN_WIDTH: '20'

--- a/src/frontend/src/optimizer/plan_node/mod.rs
+++ b/src/frontend/src/optimizer/plan_node/mod.rs
@@ -796,8 +796,9 @@ impl<C: ConventionMarker> Explain for PlanRef<C> {
     fn explain_to_string(&self) -> String {
         let plan = reorganize_elements_id(self.clone());
 
+        let width = self.ctx().session_ctx().config().explain_column_width();
         let mut output = String::with_capacity(2048);
-        let mut config = pretty_config();
+        let mut config = pretty_config(width);
         config.unicode(&mut output, &plan.explain());
         output
     }
@@ -844,11 +845,11 @@ impl<C: ConventionMarker> PlanRef<C> {
     }
 }
 
-pub(crate) fn pretty_config() -> PrettyConfig {
+pub(crate) fn pretty_config(width: usize) -> PrettyConfig {
     PrettyConfig {
         indent: 3,
         need_boundaries: false,
-        width: 2048,
+        width,
         reduced_spaces: true,
     }
 }

--- a/src/frontend/src/optimizer/plan_node/utils.rs
+++ b/src/frontend/src/optimizer/plan_node/utils.rs
@@ -240,7 +240,7 @@ pub trait Distill {
     fn distill<'a>(&self) -> XmlNode<'a>;
 
     fn distill_to_string(&self) -> String {
-        let mut config = pretty_config();
+        let mut config = pretty_config(2048);
         let mut output = String::with_capacity(2048);
         config.unicode(&mut output, &Pretty::Record(self.distill()));
         output


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

This PR adds a new `explain_column_width` session variable (default `2048`) that controls the pretty-print wrapping width used by `EXPLAIN` output. The width is read from `SessionConfig` in `PlanRef::explain_to_string` and threaded through `pretty_config`, replacing the previously hardcoded `2048`. The default behavior is preserved.

- `src/common/src/session_config/mod.rs`: add the `explain_column_width` parameter (default `2048`).
- `src/frontend/src/optimizer/plan_node/mod.rs`: read the width from the session config in `explain_to_string` and update `pretty_config` to take a width argument.
- `src/frontend/src/optimizer/plan_node/utils.rs`: update the `distill_to_string` caller to pass the default width.
- `src/frontend/planner_test/tests/testdata/input/explain.yaml` and matching output: add a fixture that sets `EXPLAIN_COLUMN_WIDTH: '20'` and asserts the plan text wraps/indents differently than the default.
- `e2e_test/batch/catalog/pg_settings.slt.part`: list `explain_column_width` in sorted order under the `user` block.

Resolves #10517

## Checklist

- [x] I have written necessary rustdoc comments.
- [x]  I have added necessary unit tests and integration tests.
- [ ]  I have added test labels as necessary. 
- [ ]  I have added fuzzing tests or opened an issue to track them. 
- [ ]  My PR contains breaking changes. 
- [ ]  My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. 
- [ ]  I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. 

## Documentation

- [ ]  My PR needs documentation updates. 

<details>
<summary><b>Release note</b></summary>

Added a new session variable `explain_column_width` (default `2048`) that controls the pretty-print wrapping width used by `EXPLAIN` output. The previous hardcoded width is preserved as the default.
</details>