### PR TITLE
fix(cdc): parse MySQL binlog file seq independent of binlog basename

### DIFF
--- a/src/connector/src/source/cdc/enumerator/mod.rs
+++ b/src/connector/src/source/cdc/enumerator/mod.rs
@@ -38,7 +38,7 @@ use crate::connector_common::{SslMode, create_pg_client};
 use crate::error::ConnectorResult;
 use crate::sink::sqlserver::SqlServerClient;
 use crate::source::cdc::external::mysql::build_mysql_connection_pool;
-use crate::source::cdc::split::parse_sql_server_lsn_str;
+use crate::source::cdc::split::{extract_binlog_file_seq, parse_sql_server_lsn_str};
 use crate::source::cdc::{
     CdcProperties, CdcSourceTypeTrait, Citus, DebeziumCdcSplit, Mongodb, Mysql, Postgres,
     SqlServer, table_schema_exclude_additional_columns,
@@ -439,41 +439,39 @@ impl DebeziumSplitEnumerator<Mysql> {
         // Query binlog files and update metrics
         match self.query_binlog_files().await {
             Ok(binlog_files) => {
-                if let Some((oldest_file, oldest_size)) = binlog_files.first() {
-                    // Extract sequence number from filename (e.g., "binlog.000001" -> 1)
-                    if let Some(seq) = Self::extract_binlog_seq(oldest_file) {
-                        self.metrics
-                            .mysql_cdc_binlog_file_seq_min
-                            .with_guarded_label_values(&[hostname, port])
-                            .set(seq as i64);
-                        tracing::debug!(
-                            "MySQL CDC source {} ({}:{}): oldest binlog = {}, seq = {}, size = {}",
-                            self.source_id,
-                            hostname,
-                            port,
-                            oldest_file,
-                            seq,
-                            oldest_size
-                        );
-                    }
+                if let Some((oldest_file, oldest_size)) = binlog_files.first()
+                    && let Some(seq) = extract_binlog_file_seq(oldest_file)
+                {
+                    self.metrics
+                        .mysql_cdc_binlog_file_seq_min
+                        .with_guarded_label_values(&[hostname, port])
+                        .set(seq as i64);
+                    tracing::debug!(
+                        "MySQL CDC source {} ({}:{}): oldest binlog = {}, seq = {}, size = {}",
+                        self.source_id,
+                        hostname,
+                        port,
+                        oldest_file,
+                        seq,
+                        oldest_size
+                    );
                 }
-                if let Some((newest_file, newest_size)) = binlog_files.last() {
-                    // Extract sequence number from filename
-                    if let Some(seq) = Self::extract_binlog_seq(newest_file) {
-                        self.metrics
-                            .mysql_cdc_binlog_file_seq_max
-                            .with_guarded_label_values(&[hostname, port])
-                            .set(seq as i64);
-                        tracing::debug!(
-                            "MySQL CDC source {} ({}:{}): newest binlog = {}, seq = {}, size = {}",
-                            self.source_id,
-                            hostname,
-                            port,
-                            newest_file,
-                            seq,
-                            newest_size
-                        );
-                    }
+                if let Some((newest_file, newest_size)) = binlog_files.last()
+                    && let Some(seq) = extract_binlog_file_seq(newest_file)
+                {
+                    self.metrics
+                        .mysql_cdc_binlog_file_seq_max
+                        .with_guarded_label_values(&[hostname, port])
+                        .set(seq as i64);
+                    tracing::debug!(
+                        "MySQL CDC source {} ({}:{}): newest binlog = {}, seq = {}, size = {}",
+                        self.source_id,
+                        hostname,
+                        port,
+                        newest_file,
+                        seq,
+                        newest_size
+                    );
                 }
                 tracing::debug!(
                     "MySQL CDC source {} ({}:{}): total {} binlog files",
@@ -494,12 +492,6 @@ impl DebeziumSplitEnumerator<Mysql> {
             }
         }
         Ok(())
-    }
-
-    /// Extract sequence number from binlog filename
-    /// e.g., "binlog.000001" -> Some(1), "mysql-bin.000123" -> Some(123)
-    fn extract_binlog_seq(filename: &str) -> Option<u64> {
-        filename.rsplit('.').next()?.parse::<u64>().ok()
     }
 
     /// Query binlog files from MySQL, returns Vec<(filename, size)>

--- a/src/connector/src/source/cdc/split.rs
+++ b/src/connector/src/source/cdc/split.rs
@@ -132,8 +132,7 @@ impl MySqlCdcSplit {
         let file = source_offset.get("file")?.as_str()?;
         let pos = source_offset.get("pos")?.as_u64()?;
 
-        // Extract numeric sequence from "binlog.NNNNNN"
-        let file_seq = file.strip_prefix("binlog.")?.parse::<u64>().ok()?;
+        let file_seq = extract_binlog_file_seq(file)?;
 
         Some((file_seq, pos))
     }
@@ -460,6 +459,14 @@ impl DebeziumCdcSplit<SqlServer> {
     }
 }
 
+/// Extract the numeric sequence from a MySQL binlog file name `<basename>.<sequence>`.
+///
+/// The basename is configurable (`binlog`, `mysql-bin`, `mysql-bin-changelog` on RDS/Aurora, ...),
+/// so we take the number after the last `.` rather than assuming a fixed prefix.
+pub fn extract_binlog_file_seq(file_name: &str) -> Option<u64> {
+    file_name.rsplit('.').next()?.parse::<u64>().ok()
+}
+
 /// Extract PostgreSQL LSN value from a CDC offset JSON string.
 ///
 /// This is a standalone helper function that can be used when you only have the offset string
@@ -512,6 +519,38 @@ mod tests {
         let parsed = parse_sql_server_lsn_str(lsn).unwrap();
         let expected = ((0x00000027_u128) << 48) | ((0x00000ac0_u128) << 16) | (0x0002_u128);
         assert_eq!(parsed, expected);
+    }
+
+    #[test]
+    fn test_extract_binlog_file_seq() {
+        // default MySQL 8.0 basename
+        assert_eq!(extract_binlog_file_seq("binlog.000123"), Some(123));
+        // `--log-bin=mysql-bin`
+        assert_eq!(extract_binlog_file_seq("mysql-bin.000123"), Some(123));
+        // `<hostname>-bin` on older versions
+        assert_eq!(extract_binlog_file_seq("my-host-bin.000001"), Some(1));
+        // RDS / Aurora MySQL
+        assert_eq!(
+            extract_binlog_file_seq("mysql-bin-changelog.037568"),
+            Some(37568)
+        );
+        // invalid suffix
+        assert_eq!(extract_binlog_file_seq("binlog.index"), None);
+        assert_eq!(extract_binlog_file_seq("no-extension"), None);
+    }
+
+    #[test]
+    fn test_mysql_binlog_offset() {
+        let offset = r#"{
+            "sourcePartition": {"server": "test"},
+            "sourceOffset": {
+                "file": "mysql-bin-changelog.037568",
+                "pos": 12345
+            },
+            "isHeartbeat": false
+        }"#;
+        let split = MySqlCdcSplit::new(1, Some(offset.to_owned()));
+        assert_eq!(split.mysql_binlog_offset(), Some((37568, 12345)));
     }
 
     #[test]


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

The MySQL CDC state metric `stream_mysql_cdc_state_binlog_file_seq` (and `stream_mysql_cdc_state_binlog_position`) feeds the **MySQL CDC Binlog Progression** panel in the dev Grafana dashboard, letting operators see how far RisingWave has consumed the upstream binlog and derive consumption lag against the upstream min/max.

The metric was parsed from the Debezium offset's binlog file name with:

```rust
let file_seq = file.strip_prefix("binlog.")?.parse::<u64>().ok()?;
```

This only matches the MySQL 8.0 **default** basename `binlog`. The binlog basename is configurable and commonly differs:

- `mysql-bin.000001` when `--log-bin=mysql-bin` is set
- `<hostname>-bin.000001` on older MySQL
- `mysql-bin-changelog.000001` on **Amazon RDS / Aurora MySQL** ([AWS docs](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/USER_LogAccess.MySQL.Binarylog.html))

For any of these, `strip_prefix("binlog.")` returns `None`, so `mysql_binlog_offset()` returns `None` and the metric is **silently never emitted** — the State Table line in the panel stays empty with no error, which is hard to diagnose.

Meanwhile the enumerator-side metrics `mysql_cdc_binlog_file_seq_min/max` already parsed the sequence robustly via `rsplit('.')` on the last dot. So the two parsers of the same binlog file name had drifted out of sync, and only one of them worked for non-default naming.

This PR extracts a single shared helper `extract_binlog_file_seq` (taking the number after the last `.`) and uses it on both the split/state-table side and the enumerator side. After this, the State Table line shows up for all MySQL deployments (default, custom basename, RDS/Aurora), and both sides stay consistent by construction.

No change to CDC data ingestion or correctness — this is an observability/parsing fix only.

## Checklist

- [x] I have written necessary rustdoc comments.
- [x] I have added necessary unit tests and integration tests.

## Documentation

- [ ] My PR needs documentation updates.
