### PR TITLE
feat: support default argument for lag/lead window functions

### DIFF
--- a/e2e_test/batch/over_window/lag_lead_default/mod.slt.part
+++ b/e2e_test/batch/over_window/lag_lead_default/mod.slt.part
@@ -1,0 +1,19 @@
+statement ok
+create table t (id int, p int, v int);
+
+statement ok
+insert into t values (1,1,10),(2,1,null),(3,1,30),(4,2,null);
+
+statement ok
+flush;
+
+query iiii
+select id, p, lag(v,1,99) over (partition by p order by id), lead(v,1,88) over (partition by p order by id) from t order by p, id;
+----
+1 1 99 NULL
+2 1 10 30
+3 1 NULL 88
+4 2 99 88
+
+statement ok
+drop table t;

--- a/e2e_test/batch/over_window/main.slt.part
+++ b/e2e_test/batch/over_window/main.slt.part
@@ -1,2 +1,3 @@
 include ./generated/main.slt.part
 include ./session/mod.slt.part
+include ./lag_lead_default/mod.slt.part

--- a/src/frontend/planner_test/tests/testdata/input/over_window_function.yaml
+++ b/src/frontend/planner_test/tests/testdata/input/over_window_function.yaml
@@ -73,6 +73,22 @@
     - logical_plan
     - stream_plan
     - batch_plan
+- id: lag with default argument
+  sql: |
+    create table t(x int, y int);
+    select x, y, lag(x, 0, 5) over(PARTITION BY y ORDER BY x) from t;
+  expected_outputs:
+    - logical_plan
+    - stream_plan
+    - batch_plan
+- id: lead with default argument
+  sql: |
+    create table t(x int, y int);
+    select x, y, lead(x, 2, 5) over(PARTITION BY y ORDER BY x) from t;
+  expected_outputs:
+    - logical_plan
+    - stream_plan
+    - batch_plan
 - id: lag with over clause, ignoring frame definition
   sql: |
     create table t(x int, y int);

--- a/src/frontend/planner_test/tests/testdata/output/over_window_function.yaml
+++ b/src/frontend/planner_test/tests/testdata/output/over_window_function.yaml
@@ -127,6 +127,50 @@
     └─StreamOverWindow { window_functions: [first_value(t.x) OVER(PARTITION BY t.y ORDER BY t.x ASC ROWS BETWEEN 1 PRECEDING AND 1 PRECEDING)] }
       └─StreamExchange { dist: HashShard(t.y) }
         └─StreamTableScan { table: t, columns: [t.x, t.y, t._row_id], stream_scan_type: SnapshotBackfill, stream_key: [t._row_id], pk: [_row_id], dist: UpstreamHashShard(t._row_id) }
+- id: lag with default argument
+  sql: |
+    create table t(x int, y int);
+    select x, y, lag(x, 0, 5) over(PARTITION BY y ORDER BY x) from t;
+  logical_plan: |-
+    LogicalProject { exprs: [t.x, t.y, Case((count = 0:Int64), 5:Int32, first_value) as $expr1] }
+    └─LogicalOverWindow { window_functions: [first_value(t.x) OVER(PARTITION BY t.y ORDER BY t.x ASC ROWS BETWEEN 0 PRECEDING AND 0 PRECEDING), count() OVER(PARTITION BY t.y ORDER BY t.x ASC ROWS BETWEEN 0 PRECEDING AND 0 PRECEDING)] }
+      └─LogicalProject { exprs: [t.x, t.y, t._row_id, t._rw_timestamp, 0:Int32, 5:Int32] }
+        └─LogicalScan { table: t, columns: [t.x, t.y, t._row_id, t._rw_timestamp] }
+  batch_plan: |-
+    BatchExchange { order: [], dist: Single }
+    └─BatchProject { exprs: [t.x, t.y, Case((count = 0:Int64), 5:Int32, first_value) as $expr1] }
+      └─BatchOverWindow { window_functions: [first_value(t.x) OVER(PARTITION BY t.y ORDER BY t.x ASC ROWS BETWEEN 0 PRECEDING AND 0 PRECEDING), count() OVER(PARTITION BY t.y ORDER BY t.x ASC ROWS BETWEEN 0 PRECEDING AND 0 PRECEDING)] }
+        └─BatchExchange { order: [t.y ASC, t.x ASC], dist: HashShard(t.y) }
+          └─BatchSort { order: [t.y ASC, t.x ASC] }
+            └─BatchScan { table: t, columns: [t.x, t.y], distribution: SomeShard }
+  stream_plan: |-
+    StreamMaterialize { columns: [x, y, lag, t._row_id(hidden)], stream_key: [t._row_id, y], pk_columns: [t._row_id, y], pk_conflict: NoCheck }
+    └─StreamProject { exprs: [t.x, t.y, Case((count = 0:Int64), 5:Int32, first_value) as $expr1, t._row_id] }
+      └─StreamOverWindow { window_functions: [first_value(t.x) OVER(PARTITION BY t.y ORDER BY t.x ASC ROWS BETWEEN 0 PRECEDING AND 0 PRECEDING), count() OVER(PARTITION BY t.y ORDER BY t.x ASC ROWS BETWEEN 0 PRECEDING AND 0 PRECEDING)] }
+        └─StreamExchange { dist: HashShard(t.y) }
+          └─StreamTableScan { table: t, columns: [t.x, t.y, t._row_id], stream_scan_type: SnapshotBackfill, stream_key: [t._row_id], pk: [_row_id], dist: UpstreamHashShard(t._row_id) }
+- id: lead with default argument
+  sql: |
+    create table t(x int, y int);
+    select x, y, lead(x, 2, 5) over(PARTITION BY y ORDER BY x) from t;
+  logical_plan: |-
+    LogicalProject { exprs: [t.x, t.y, Case((count = 0:Int64), 5:Int32, first_value) as $expr1] }
+    └─LogicalOverWindow { window_functions: [first_value(t.x) OVER(PARTITION BY t.y ORDER BY t.x ASC ROWS BETWEEN 2 FOLLOWING AND 2 FOLLOWING), count() OVER(PARTITION BY t.y ORDER BY t.x ASC ROWS BETWEEN 2 FOLLOWING AND 2 FOLLOWING)] }
+      └─LogicalProject { exprs: [t.x, t.y, t._row_id, t._rw_timestamp, 2:Int32, 5:Int32] }
+        └─LogicalScan { table: t, columns: [t.x, t.y, t._row_id, t._rw_timestamp] }
+  batch_plan: |-
+    BatchExchange { order: [], dist: Single }
+    └─BatchProject { exprs: [t.x, t.y, Case((count = 0:Int64), 5:Int32, first_value) as $expr1] }
+      └─BatchOverWindow { window_functions: [first_value(t.x) OVER(PARTITION BY t.y ORDER BY t.x ASC ROWS BETWEEN 2 FOLLOWING AND 2 FOLLOWING), count() OVER(PARTITION BY t.y ORDER BY t.x ASC ROWS BETWEEN 2 FOLLOWING AND 2 FOLLOWING)] }
+        └─BatchExchange { order: [t.y ASC, t.x ASC], dist: HashShard(t.y) }
+          └─BatchSort { order: [t.y ASC, t.x ASC] }
+            └─BatchScan { table: t, columns: [t.x, t.y], distribution: SomeShard }
+  stream_plan: |-
+    StreamMaterialize { columns: [x, y, lead, t._row_id(hidden)], stream_key: [t._row_id, y], pk_columns: [t._row_id, y], pk_conflict: NoCheck }
+    └─StreamProject { exprs: [t.x, t.y, Case((count = 0:Int64), 5:Int32, first_value) as $expr1, t._row_id] }
+      └─StreamOverWindow { window_functions: [first_value(t.x) OVER(PARTITION BY t.y ORDER BY t.x ASC ROWS BETWEEN 2 FOLLOWING AND 2 FOLLOWING), count() OVER(PARTITION BY t.y ORDER BY t.x ASC ROWS BETWEEN 2 FOLLOWING AND 2 FOLLOWING)] }
+        └─StreamExchange { dist: HashShard(t.y) }
+          └─StreamTableScan { table: t, columns: [t.x, t.y, t._row_id], stream_scan_type: SnapshotBackfill, stream_key: [t._row_id], pk: [_row_id], dist: UpstreamHashShard(t._row_id) }
 - id: lag with over clause, ignoring frame definition
   sql: |
     create table t(x int, y int);

--- a/src/frontend/src/expr/window_function.rs
+++ b/src/frontend/src/expr/window_function.rs
@@ -84,10 +84,21 @@ impl WindowFunction {
                 }
                 Ok(value.return_type())
             }
-            (Lag | Lead, [_value, _offset, _default]) => {
-                bail_not_implemented!(
-                    "`{kind}` window function with `default` argument is not supported yet"
-                );
+            (Lag | Lead, [value, offset, default]) => {
+                if !offset.return_type().is_int() {
+                    return Err(ErrorCode::InvalidInputSyntax(format!(
+                        "the `offset` of `{kind}` function should be integer"
+                    ))
+                    .into());
+                }
+                if !offset.is_const() {
+                    bail_not_implemented!(
+                        "non-const `offset` of `{kind}` function is not supported yet"
+                    );
+                }
+                let return_type = value.return_type();
+                default.cast_implicit_mut(&return_type)?;
+                Ok(return_type)
             }
 
             (Aggregate(agg_type), args) => Ok(match agg_type {

--- a/src/frontend/src/optimizer/plan_node/logical_over_window.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_over_window.rs
@@ -99,7 +99,7 @@ impl<'a> LogicalOverWindowBuilder<'a> {
     fn try_rewrite_window_function(&mut self, window_func: WindowFunction) -> Result<ExprImpl> {
         let WindowFunction {
             kind,
-            args,
+            mut args,
             return_type,
             partition_by,
             order_by,
@@ -131,6 +131,45 @@ impl<'a> LogicalOverWindowBuilder<'a> {
                     )?,
                 ))
             })?
+        } else if matches!(kind, WindowFuncKind::Lag | WindowFuncKind::Lead) {
+            assert!(!ignore_nulls); // the conversion is not applicable to `LAG`/`LEAD` with `IGNORE NULLS`
+            let default = if args.len() == 3 {
+                let mut default = args.pop().unwrap();
+                default.cast_implicit_mut(&return_type)?;
+                Some(self.rewrite_expr(default))
+            } else {
+                None
+            };
+            let frame = LogicalOverWindow::lag_lead_frame(&kind, &mut args)?;
+
+            let first_value = ExprImpl::from(self.push_window_func(WindowFunction::new(
+                WindowFuncKind::Aggregate(AggType::Builtin(PbAggKind::FirstValue)),
+                args,
+                false,
+                partition_by.clone(),
+                order_by.clone(),
+                Some(frame.clone()),
+            )?));
+
+            if let Some(default) = default {
+                let count = ExprImpl::from(self.push_window_func(WindowFunction::new(
+                    WindowFuncKind::Aggregate(AggType::Builtin(PbAggKind::Count)),
+                    vec![],
+                    false,
+                    partition_by,
+                    order_by,
+                    Some(frame),
+                )?));
+                let zero = ExprImpl::literal_bigint(0);
+                let case_cond =
+                    ExprImpl::from(FunctionCall::new(ExprType::Equal, vec![count, zero])?);
+                ExprImpl::from(FunctionCall::new(
+                    ExprType::Case,
+                    vec![case_cond, default, first_value],
+                )?)
+            } else {
+                first_value
+            }
         } else {
             ExprImpl::from(self.push_window_func(WindowFunction::new(
                 kind,
@@ -336,46 +375,7 @@ impl LogicalOverWindow {
                 //     == `first_value(x) over (rows between N following and N following)`
                 assert!(!window_function.ignore_nulls); // the conversion is not applicable to `LAG`/`LEAD` with `IGNORE NULLS`
 
-                let offset = if args.len() > 1 {
-                    let offset_expr = args.remove(1);
-                    if !offset_expr.return_type().is_int() {
-                        return Err(ErrorCode::InvalidInputSyntax(format!(
-                            "the `offset` of `{}` function should be integer",
-                            window_function.kind
-                        ))
-                        .into());
-                    }
-                    let const_offset = offset_expr
-                        .cast_implicit(&DataType::Int64)?
-                        .try_fold_const();
-                    if const_offset.is_none() {
-                        // should already be checked in `WindowFunction::infer_return_type`,
-                        // but just in case
-                        bail_not_implemented!(
-                            "non-const `offset` of `lag`/`lead` is not supported yet"
-                        );
-                    }
-                    const_offset.unwrap()?.map(|v| *v.as_int64()).unwrap_or(1)
-                } else {
-                    1
-                };
-                let sign = if window_function.kind == WindowFuncKind::Lag {
-                    -1
-                } else {
-                    1
-                };
-                let abs_offset = offset.unsigned_abs() as usize;
-                let frame = if sign * offset <= 0 {
-                    Frame::rows(
-                        FrameBound::Preceding(abs_offset),
-                        FrameBound::Preceding(abs_offset),
-                    )
-                } else {
-                    Frame::rows(
-                        FrameBound::Following(abs_offset),
-                        FrameBound::Following(abs_offset),
-                    )
-                };
+                let frame = Self::lag_lead_frame(&window_function.kind, &mut args)?;
 
                 (
                     WindowFuncKind::Aggregate(AggType::Builtin(PbAggKind::FirstValue)),
@@ -413,6 +413,48 @@ impl LogicalOverWindow {
             order_by,
             frame,
         })
+    }
+
+    fn lag_lead_frame(kind: &WindowFuncKind, args: &mut Vec<ExprImpl>) -> Result<Frame> {
+        let offset = if args.len() > 1 {
+            let offset_expr = args.remove(1);
+            if !offset_expr.return_type().is_int() {
+                return Err(ErrorCode::InvalidInputSyntax(format!(
+                    "the `offset` of `{kind}` function should be integer"
+                ))
+                .into());
+            }
+            let const_offset = offset_expr
+                .cast_implicit(&DataType::Int64)?
+                .try_fold_const();
+            if const_offset.is_none() {
+                // should already be checked in `WindowFunction::infer_return_type`,
+                // but just in case
+                bail_not_implemented!("non-const `offset` of `lag`/`lead` is not supported yet");
+            }
+            const_offset.unwrap()?.map(|v| *v.as_int64()).unwrap_or(1)
+        } else {
+            1
+        };
+        let abs_offset = offset.unsigned_abs() as usize;
+        // Avoid `sign * offset` which can overflow for `offset == i64::MIN`.
+        let is_preceding = match kind {
+            WindowFuncKind::Lag => offset >= 0,
+            WindowFuncKind::Lead => offset <= 0,
+            _ => unreachable!(),
+        };
+        let frame = if is_preceding {
+            Frame::rows(
+                FrameBound::Preceding(abs_offset),
+                FrameBound::Preceding(abs_offset),
+            )
+        } else {
+            Frame::rows(
+                FrameBound::Following(abs_offset),
+                FrameBound::Following(abs_offset),
+            )
+        };
+        Ok(frame)
     }
 
     pub fn window_functions(&self) -> &[PlanWindowFunction] {


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

`lag` and `lead` window functions now accept a third `default` argument, which is returned when there is no row at the requested offset. The default is cast to the value's type and emitted via a `CASE WHEN count = 0 THEN default ELSE first_value END` constructed on top of the existing `first_value`/`count` over-window rewrite. The `offset` is also validated as a const integer up front in `WindowFunction::infer_return_type`, and the frame-building logic was extracted into a shared `lag_lead_frame` helper used by both the default and non-default paths.

Resolves #10817

## Checklist

- [ ] I have written necessary rustdoc comments.
- [x] I have added necessary unit tests and integration tests.
- [ ] I have added test labels as necessary.
- [ ] I have added fuzzing tests or opened an issue to track them.
- [ ] My PR contains breaking changes.
- [ ] My PR changes performance-critical code, so I will run (micro) benchmarks and present the results.
- [ ] I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into.

## Documentation

- [ ] My PR needs documentation updates.

<details>
<summary><b>Release note</b></summary>

Support the optional `default` argument for `lag` and `lead` window functions. When the offset points past the partition boundary, the supplied default is returned instead of `NULL`.

</details>

<!-- capy-pr-badge:start -->
<a href="https://capy.ai/project/337a7eb0-5e7b-411a-869a-76e45a4e4750/pull/25923"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open in Capy" src="https://capy.ai/api/badge/open.svg"></picture></a>
<!-- capy-pr-badge:end -->