### PR TITLE
feat(batch): push limit into iceberg scans

### DIFF
--- a/src/batch/executors/src/executor/iceberg_scan.rs
+++ b/src/batch/executors/src/executor/iceberg_scan.rs
@@ -228,28 +228,3 @@ fn take_first_visible_rows(chunk: DataChunk, limit: usize) -> DataChunk {
     let indexes = chunk.visibility().iter_ones().take(limit).collect_vec();
     chunk.reorder_rows(&indexes)
 }
-
-#[cfg(test)]
-mod tests {
-    use risingwave_common::test_prelude::DataChunkTestExt;
-
-    use super::*;
-
-    #[test]
-    fn test_take_first_visible_rows_keeps_visible_prefix() {
-        let chunk = DataChunk::from_pretty(
-            "i
-             1
-             2 D
-             3
-             4",
-        );
-        let expected = DataChunk::from_pretty(
-            "i
-             1
-             3",
-        );
-
-        assert_eq!(take_first_visible_rows(chunk, 2), expected);
-    }
-}

--- a/src/batch/executors/src/executor/iceberg_scan.rs
+++ b/src/batch/executors/src/executor/iceberg_scan.rs
@@ -42,6 +42,7 @@ pub struct IcebergScanExecutor {
     metrics: Option<BatchMetrics>,
     need_seq_num: bool,
     need_file_path_and_pos: bool,
+    limit: Option<u64>,
 }
 
 impl Executor for IcebergScanExecutor {
@@ -68,6 +69,7 @@ impl IcebergScanExecutor {
         metrics: Option<BatchMetrics>,
         need_seq_num: bool,
         need_file_path_and_pos: bool,
+        limit: Option<u64>,
     ) -> Self {
         Self {
             iceberg_config,
@@ -78,6 +80,7 @@ impl IcebergScanExecutor {
             metrics,
             need_seq_num,
             need_file_path_and_pos,
+            limit,
         }
     }
 
@@ -98,8 +101,15 @@ impl IcebergScanExecutor {
                 bail!("file_scan_tasks must be Some")
             }
         };
+        let mut remaining_limit = self
+            .limit
+            .map(|limit| usize::try_from(limit).unwrap_or(usize::MAX));
 
         for data_file_scan_task in data_file_scan_tasks {
+            if matches!(remaining_limit, Some(0)) {
+                return Ok(());
+            }
+
             #[for_await]
             for chunk in scan_task_to_chunk_with_deletes(
                 table.clone(),
@@ -115,7 +125,21 @@ impl IcebergScanExecutor {
             ) {
                 let chunk = chunk?;
                 assert_eq!(chunk.data_types(), data_types);
-                yield chunk;
+                if let Some(remaining) = &mut remaining_limit {
+                    if chunk.cardinality() > *remaining {
+                        yield take_first_visible_rows(chunk, *remaining);
+                        return Ok(());
+                    }
+
+                    *remaining -= chunk.cardinality();
+                    yield chunk;
+
+                    if *remaining == 0 {
+                        return Ok(());
+                    }
+                } else {
+                    yield chunk;
+                }
             }
         }
     }
@@ -188,9 +212,44 @@ impl BoxedExecutorBuilder for IcebergScanExecutorBuilder {
                 metrics,
                 need_seq_num,
                 need_file_path_and_pos,
+                split.limit,
             )))
         } else {
             unreachable!()
         }
+    }
+}
+
+fn take_first_visible_rows(chunk: DataChunk, limit: usize) -> DataChunk {
+    if limit >= chunk.cardinality() {
+        return chunk;
+    }
+
+    let indexes = chunk.visibility().iter_ones().take(limit).collect_vec();
+    chunk.reorder_rows(&indexes)
+}
+
+#[cfg(test)]
+mod tests {
+    use risingwave_common::test_prelude::DataChunkTestExt;
+
+    use super::*;
+
+    #[test]
+    fn test_take_first_visible_rows_keeps_visible_prefix() {
+        let chunk = DataChunk::from_pretty(
+            "i
+             1
+             2 D
+             3
+             4",
+        );
+        let expected = DataChunk::from_pretty(
+            "i
+             1
+             3",
+        );
+
+        assert_eq!(take_first_visible_rows(chunk, 2), expected);
     }
 }

--- a/src/connector/src/source/iceberg/mod.rs
+++ b/src/connector/src/source/iceberg/mod.rs
@@ -177,6 +177,8 @@ impl IcebergFileScanTask {
 pub struct IcebergSplit {
     pub split_id: i64,
     pub task: IcebergFileScanTask,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub limit: Option<u64>,
 }
 
 impl IcebergSplit {
@@ -187,7 +189,11 @@ impl IcebergSplit {
             IcebergScanType::PositionDeleteScan => IcebergFileScanTask::PositionDelete(vec![]),
             _ => unimplemented!(),
         };
-        Self { split_id: 0, task }
+        Self {
+            split_id: 0,
+            task,
+            limit: None,
+        }
     }
 }
 

--- a/src/frontend/src/datafusion/iceberg_executor.rs
+++ b/src/frontend/src/datafusion/iceberg_executor.rs
@@ -64,6 +64,7 @@ struct IcebergScanInner {
     need_file_path_and_pos: bool,
     plan_properties: Arc<PlanProperties>,
     projection: Option<Vec<usize>>,
+    limit: Option<usize>,
 }
 
 impl DisplayAs for IcebergScan {
@@ -94,6 +95,9 @@ impl DisplayAs for IcebergScan {
             )?;
             if let Some(projection) = &self.inner.projection {
                 write!(f, ", projection={:?}", projection)?;
+            }
+            if let Some(limit) = self.inner.limit {
+                write!(f, ", limit={}", limit)?;
             }
         }
         Ok(())
@@ -157,9 +161,9 @@ impl IcebergScan {
     pub async fn new(
         provider: &IcebergTableProvider,
         projection: Option<&Vec<usize>>,
-        // TODO: support filter pushdown and limit pushdown
+        // TODO: support filter pushdown
         _filters: &[Expr],
-        _limit: Option<usize>,
+        limit: Option<usize>,
         batch_parallelism: usize,
     ) -> DFResult<Self> {
         let mut arrow_schema = provider.schema();
@@ -198,7 +202,11 @@ impl IcebergScan {
         });
 
         let scan_tasks = provider.task.tasks();
-        let tasks = if scan_tasks.len() <= batch_parallelism {
+        let tasks = if limit.is_some() {
+            // A scan-local limit must be enforced globally. Keep the tasks in a single partition
+            // so execution can stop after enough rows without scanning all files.
+            vec![scan_tasks.to_vec()]
+        } else if scan_tasks.len() <= batch_parallelism {
             scan_tasks.iter().map(|task| vec![task.clone()]).collect()
         } else {
             IcebergSplitEnumerator::split_n_vecs(scan_tasks.to_vec(), batch_parallelism)
@@ -227,6 +235,7 @@ impl IcebergScan {
                 need_file_path_and_pos,
                 plan_properties,
                 projection: projection.cloned(),
+                limit,
             }),
         })
     }
@@ -241,8 +250,13 @@ impl IcebergScanInner {
             .with_batch_size(chunk_size)
             .with_row_group_filtering_enabled(true)
             .build();
+        let mut remaining_limit = self.limit;
 
         for task in &self.tasks[partition] {
+            if matches!(remaining_limit, Some(0)) {
+                return Ok(());
+            }
+
             let stream = reader
                 .clone()
                 .read(tokio_stream::once(Ok(task.clone())).boxed())
@@ -265,8 +279,24 @@ impl IcebergScanInner {
                     batch = batch.project(projection).map_err(to_datafusion_error)?;
                 }
                 batch = cast_batch(self.arrow_schema.clone(), batch)?;
-                pos_start += i64::try_from(batch.num_rows()).unwrap();
-                yield batch;
+
+                if let Some(remaining) = &mut remaining_limit {
+                    if batch.num_rows() > *remaining {
+                        yield batch.slice(0, *remaining);
+                        return Ok(());
+                    }
+
+                    *remaining -= batch.num_rows();
+                    pos_start += i64::try_from(batch.num_rows()).unwrap();
+                    yield batch;
+
+                    if *remaining == 0 {
+                        return Ok(());
+                    }
+                } else {
+                    pos_start += i64::try_from(batch.num_rows()).unwrap();
+                    yield batch;
+                }
             }
         }
     }

--- a/src/frontend/src/optimizer/plan_node/batch_iceberg_scan.rs
+++ b/src/frontend/src/optimizer/plan_node/batch_iceberg_scan.rs
@@ -38,6 +38,7 @@ pub struct BatchIcebergScan {
     pub base: PlanBase<Batch>,
     pub core: generic::Source,
     pub task: IcebergFileScanTask,
+    limit: Option<u64>,
 }
 
 impl Eq for BatchIcebergScan {}
@@ -47,6 +48,7 @@ impl Hash for BatchIcebergScan {
         self.base.hash(state);
         self.core.hash(state);
         self.iceberg_scan_type().hash(state);
+        self.limit.hash(state);
     }
 }
 
@@ -59,7 +61,25 @@ impl BatchIcebergScan {
             Order::any(),
         );
 
-        Self { base, core, task }
+        Self {
+            base,
+            core,
+            task,
+            limit: None,
+        }
+    }
+
+    pub fn clone_with_limit(&self, limit: Option<u64>) -> Self {
+        Self {
+            base: self.base.clone(),
+            core: self.core.clone(),
+            task: self.task.clone(),
+            limit,
+        }
+    }
+
+    pub fn limit(&self) -> Option<u64> {
+        self.limit
     }
 
     pub fn iceberg_scan_type(&self) -> IcebergScanType {
@@ -91,6 +111,7 @@ impl BatchIcebergScan {
             base,
             core: self.core.clone(),
             task: self.task.clone(),
+            limit: self.limit,
         }
     }
 
@@ -114,6 +135,9 @@ impl Distill for BatchIcebergScan {
         ];
         if let Some(predicate) = self.predicate() {
             fields.push(("predicate", Pretty::from(predicate)));
+        }
+        if let Some(limit) = self.limit {
+            fields.push(("limit", Pretty::debug(&limit)));
         }
         childless_record("BatchIcebergScan", fields)
     }

--- a/src/frontend/src/optimizer/rule/batch/batch_push_limit_to_scan_rule.rs
+++ b/src/frontend/src/optimizer/rule/batch/batch_push_limit_to_scan_rule.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use itertools::Itertools;
+use risingwave_pb::batch_plan::iceberg_scan_node::IcebergScanType;
 
 use super::prelude::*;
 use crate::optimizer::plan_node::generic::PhysicalPlanRef;
@@ -20,12 +21,16 @@ use crate::optimizer::plan_node::{BatchIcebergScan, BatchLimit, BatchSeqScan, Pl
 
 pub struct BatchPushLimitToScanRule {}
 
+// Pushing a limit into an Iceberg scan collapses file tasks into one split.
+// Keep large scans parallel and let the upper BatchLimit enforce exact results.
+const ICEBERG_LIMIT_PUSHDOWN_THRESHOLD: u64 = 1_000_000;
+
 impl Rule<Batch> for BatchPushLimitToScanRule {
     fn apply(&self, plan: PlanRef) -> Option<PlanRef> {
         let limit: &BatchLimit = plan.as_batch_limit()?;
         let limit_input = limit.input();
 
-        let pushed_limit = limit.limit() + limit.offset();
+        let pushed_limit = limit.limit().checked_add(limit.offset())?;
         if let Some(scan) = limit_input.as_batch_seq_scan() {
             if scan.limit().is_some() {
                 return None;
@@ -43,6 +48,12 @@ impl Rule<Batch> for BatchPushLimitToScanRule {
         if scan.limit().is_some() {
             return None;
         }
+        if scan.iceberg_scan_type() != IcebergScanType::DataScan {
+            return None;
+        }
+        if pushed_limit > ICEBERG_LIMIT_PUSHDOWN_THRESHOLD {
+            return None;
+        }
         let new_scan = scan.clone_with_limit(Some(pushed_limit));
         Some(limit.clone_with_input(new_scan.into()).into())
     }
@@ -51,61 +62,5 @@ impl Rule<Batch> for BatchPushLimitToScanRule {
 impl BatchPushLimitToScanRule {
     pub fn create() -> BoxedRule {
         Box::new(BatchPushLimitToScanRule {})
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use risingwave_common::catalog::{ColumnCatalog, ColumnDesc, Field};
-    use risingwave_common::types::DataType;
-    use risingwave_connector::source::iceberg::IcebergFileScanTask;
-
-    use super::*;
-    use crate::OptimizerContext;
-    use crate::optimizer::plan_node::generic::{Limit, Source, SourceNodeKind};
-
-    fn limit_over_iceberg_scan(limit: u64, offset: u64) -> PlanRef {
-        let column = ColumnCatalog {
-            column_desc: ColumnDesc::from_field_with_column_id(
-                &Field {
-                    name: "v".to_owned(),
-                    data_type: DataType::Int32,
-                },
-                0,
-            ),
-            is_hidden: false,
-        };
-        let source = Source {
-            catalog: None,
-            column_catalog: vec![column],
-            row_id_index: None,
-            kind: SourceNodeKind::CreateMViewOrBatch,
-            ctx: OptimizerContext::mock(),
-            as_of: None,
-        };
-        let scan = BatchIcebergScan::new(source, IcebergFileScanTask::Data(vec![]));
-        BatchLimit::new(Limit::new(scan.into(), limit, offset)).into()
-    }
-
-    #[test]
-    fn pushes_small_limit_to_iceberg_scan() {
-        let plan = limit_over_iceberg_scan(1, 2);
-        let rewritten = BatchPushLimitToScanRule {}.apply(plan).unwrap();
-        let limit = rewritten.as_batch_limit().unwrap();
-        let input = limit.input();
-        let scan = input.as_batch_iceberg_scan().unwrap();
-
-        assert_eq!(scan.limit(), Some(3));
-    }
-
-    #[test]
-    fn pushes_large_limit_to_iceberg_scan() {
-        let plan = limit_over_iceberg_scan(10_000, 0);
-        let rewritten = BatchPushLimitToScanRule {}.apply(plan).unwrap();
-        let limit = rewritten.as_batch_limit().unwrap();
-        let input = limit.input();
-        let scan = input.as_batch_iceberg_scan().unwrap();
-
-        assert_eq!(scan.limit(), Some(10_000));
     }
 }

--- a/src/frontend/src/optimizer/rule/batch/batch_push_limit_to_scan_rule.rs
+++ b/src/frontend/src/optimizer/rule/batch/batch_push_limit_to_scan_rule.rs
@@ -16,7 +16,7 @@ use itertools::Itertools;
 
 use super::prelude::*;
 use crate::optimizer::plan_node::generic::PhysicalPlanRef;
-use crate::optimizer::plan_node::{BatchLimit, BatchSeqScan, PlanTreeNodeUnary};
+use crate::optimizer::plan_node::{BatchIcebergScan, BatchLimit, BatchSeqScan, PlanTreeNodeUnary};
 
 pub struct BatchPushLimitToScanRule {}
 
@@ -24,17 +24,26 @@ impl Rule<Batch> for BatchPushLimitToScanRule {
     fn apply(&self, plan: PlanRef) -> Option<PlanRef> {
         let limit: &BatchLimit = plan.as_batch_limit()?;
         let limit_input = limit.input();
-        let scan: &BatchSeqScan = limit_input.as_batch_seq_scan()?;
+
+        let pushed_limit = limit.limit() + limit.offset();
+        if let Some(scan) = limit_input.as_batch_seq_scan() {
+            if scan.limit().is_some() {
+                return None;
+            }
+            let new_scan = BatchSeqScan::new_with_dist(
+                scan.core().clone(),
+                scan.base.distribution().clone(),
+                scan.scan_ranges().iter().cloned().collect_vec(),
+                Some(pushed_limit),
+            );
+            return Some(limit.clone_with_input(new_scan.into()).into());
+        }
+
+        let scan: &BatchIcebergScan = limit_input.as_batch_iceberg_scan()?;
         if scan.limit().is_some() {
             return None;
         }
-        let pushed_limit = limit.limit() + limit.offset();
-        let new_scan = BatchSeqScan::new_with_dist(
-            scan.core().clone(),
-            scan.base.distribution().clone(),
-            scan.scan_ranges().iter().cloned().collect_vec(),
-            Some(pushed_limit),
-        );
+        let new_scan = scan.clone_with_limit(Some(pushed_limit));
         Some(limit.clone_with_input(new_scan.into()).into())
     }
 }
@@ -42,5 +51,61 @@ impl Rule<Batch> for BatchPushLimitToScanRule {
 impl BatchPushLimitToScanRule {
     pub fn create() -> BoxedRule {
         Box::new(BatchPushLimitToScanRule {})
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use risingwave_common::catalog::{ColumnCatalog, ColumnDesc, Field};
+    use risingwave_common::types::DataType;
+    use risingwave_connector::source::iceberg::IcebergFileScanTask;
+
+    use super::*;
+    use crate::OptimizerContext;
+    use crate::optimizer::plan_node::generic::{Limit, Source, SourceNodeKind};
+
+    fn limit_over_iceberg_scan(limit: u64, offset: u64) -> PlanRef {
+        let column = ColumnCatalog {
+            column_desc: ColumnDesc::from_field_with_column_id(
+                &Field {
+                    name: "v".to_owned(),
+                    data_type: DataType::Int32,
+                },
+                0,
+            ),
+            is_hidden: false,
+        };
+        let source = Source {
+            catalog: None,
+            column_catalog: vec![column],
+            row_id_index: None,
+            kind: SourceNodeKind::CreateMViewOrBatch,
+            ctx: OptimizerContext::mock(),
+            as_of: None,
+        };
+        let scan = BatchIcebergScan::new(source, IcebergFileScanTask::Data(vec![]));
+        BatchLimit::new(Limit::new(scan.into(), limit, offset)).into()
+    }
+
+    #[test]
+    fn pushes_small_limit_to_iceberg_scan() {
+        let plan = limit_over_iceberg_scan(1, 2);
+        let rewritten = BatchPushLimitToScanRule {}.apply(plan).unwrap();
+        let limit = rewritten.as_batch_limit().unwrap();
+        let input = limit.input();
+        let scan = input.as_batch_iceberg_scan().unwrap();
+
+        assert_eq!(scan.limit(), Some(3));
+    }
+
+    #[test]
+    fn pushes_large_limit_to_iceberg_scan() {
+        let plan = limit_over_iceberg_scan(10_000, 0);
+        let rewritten = BatchPushLimitToScanRule {}.apply(plan).unwrap();
+        let limit = rewritten.as_batch_limit().unwrap();
+        let input = limit.input();
+        let scan = input.as_batch_iceberg_scan().unwrap();
+
+        assert_eq!(scan.limit(), Some(10_000));
     }
 }

--- a/src/frontend/src/scheduler/plan_fragmenter.rs
+++ b/src/frontend/src/scheduler/plan_fragmenter.rs
@@ -380,53 +380,38 @@ impl SourceScanInfo {
 
 impl UnpartitionedData {
     fn complete(self, batch_parallelism: usize) -> SchedulerResult<SourceScanInfo> {
-        macro_rules! split_iceberg_tasks {
+        macro_rules! iceberg_tasks {
             ($tasks:expr, $variant:ident, $limit:expr) => {
-                IcebergSplitEnumerator::split_n_vecs($tasks, batch_parallelism)
-                    .into_iter()
-                    .enumerate()
-                    .map(|(id, tasks)| {
-                        SplitImpl::Iceberg(IcebergSplit {
-                            split_id: id.try_into().unwrap(),
-                            task: IcebergFileScanTask::$variant(tasks),
-                            limit: $limit,
+                if let Some(limit) = $limit {
+                    vec![SplitImpl::Iceberg(IcebergSplit {
+                        split_id: 0,
+                        task: IcebergFileScanTask::$variant($tasks),
+                        limit: Some(limit),
+                    })]
+                } else {
+                    IcebergSplitEnumerator::split_n_vecs($tasks, batch_parallelism)
+                        .into_iter()
+                        .enumerate()
+                        .map(|(id, tasks)| {
+                            SplitImpl::Iceberg(IcebergSplit {
+                                split_id: id.try_into().unwrap(),
+                                task: IcebergFileScanTask::$variant(tasks),
+                                limit: None,
+                            })
                         })
-                    })
-                    .collect()
-            };
-        }
-        macro_rules! limited_iceberg_tasks {
-            ($tasks:expr, $variant:ident, $limit:expr) => {
-                vec![SplitImpl::Iceberg(IcebergSplit {
-                    split_id: 0,
-                    task: IcebergFileScanTask::$variant($tasks),
-                    limit: $limit,
-                })]
+                        .collect()
+                }
             };
         }
 
         let splits = match self {
             UnpartitionedData::Iceberg { task, limit } => match task {
-                IcebergFileScanTask::Data(tasks) => {
-                    if limit.is_some() {
-                        limited_iceberg_tasks!(tasks, Data, limit)
-                    } else {
-                        split_iceberg_tasks!(tasks, Data, limit)
-                    }
-                }
+                IcebergFileScanTask::Data(tasks) => iceberg_tasks!(tasks, Data, limit),
                 IcebergFileScanTask::EqualityDelete(tasks) => {
-                    if limit.is_some() {
-                        limited_iceberg_tasks!(tasks, EqualityDelete, limit)
-                    } else {
-                        split_iceberg_tasks!(tasks, EqualityDelete, limit)
-                    }
+                    iceberg_tasks!(tasks, EqualityDelete, None)
                 }
                 IcebergFileScanTask::PositionDelete(tasks) => {
-                    if limit.is_some() {
-                        limited_iceberg_tasks!(tasks, PositionDelete, limit)
-                    } else {
-                        split_iceberg_tasks!(tasks, PositionDelete, limit)
-                    }
+                    iceberg_tasks!(tasks, PositionDelete, None)
                 }
             },
         };

--- a/src/frontend/src/scheduler/plan_fragmenter.rs
+++ b/src/frontend/src/scheduler/plan_fragmenter.rs
@@ -325,7 +325,10 @@ pub enum SourceFetchParameters {
 
 #[derive(Debug, Clone)]
 pub enum UnpartitionedData {
-    Iceberg(IcebergFileScanTask),
+    Iceberg {
+        task: IcebergFileScanTask,
+        limit: Option<u64>,
+    },
 }
 
 #[derive(Debug, Clone)]
@@ -378,7 +381,7 @@ impl SourceScanInfo {
 impl UnpartitionedData {
     fn complete(self, batch_parallelism: usize) -> SchedulerResult<SourceScanInfo> {
         macro_rules! split_iceberg_tasks {
-            ($tasks:expr, $variant:ident) => {
+            ($tasks:expr, $variant:ident, $limit:expr) => {
                 IcebergSplitEnumerator::split_n_vecs($tasks, batch_parallelism)
                     .into_iter()
                     .enumerate()
@@ -386,20 +389,44 @@ impl UnpartitionedData {
                         SplitImpl::Iceberg(IcebergSplit {
                             split_id: id.try_into().unwrap(),
                             task: IcebergFileScanTask::$variant(tasks),
+                            limit: $limit,
                         })
                     })
                     .collect()
             };
         }
+        macro_rules! limited_iceberg_tasks {
+            ($tasks:expr, $variant:ident, $limit:expr) => {
+                vec![SplitImpl::Iceberg(IcebergSplit {
+                    split_id: 0,
+                    task: IcebergFileScanTask::$variant($tasks),
+                    limit: $limit,
+                })]
+            };
+        }
 
         let splits = match self {
-            UnpartitionedData::Iceberg(task) => match task {
-                IcebergFileScanTask::Data(tasks) => split_iceberg_tasks!(tasks, Data),
+            UnpartitionedData::Iceberg { task, limit } => match task {
+                IcebergFileScanTask::Data(tasks) => {
+                    if limit.is_some() {
+                        limited_iceberg_tasks!(tasks, Data, limit)
+                    } else {
+                        split_iceberg_tasks!(tasks, Data, limit)
+                    }
+                }
                 IcebergFileScanTask::EqualityDelete(tasks) => {
-                    split_iceberg_tasks!(tasks, EqualityDelete)
+                    if limit.is_some() {
+                        limited_iceberg_tasks!(tasks, EqualityDelete, limit)
+                    } else {
+                        split_iceberg_tasks!(tasks, EqualityDelete, limit)
+                    }
                 }
                 IcebergFileScanTask::PositionDelete(tasks) => {
-                    split_iceberg_tasks!(tasks, PositionDelete)
+                    if limit.is_some() {
+                        limited_iceberg_tasks!(tasks, PositionDelete, limit)
+                    } else {
+                        split_iceberg_tasks!(tasks, PositionDelete, limit)
+                    }
                 }
             },
         };
@@ -1230,8 +1257,9 @@ impl BatchPlanFragmenter {
         } else if let Some(batch_iceberg_scan) = node.as_batch_iceberg_scan() {
             let batch_iceberg_scan: &BatchIcebergScan = batch_iceberg_scan;
             let task = batch_iceberg_scan.task.clone();
+            let limit = batch_iceberg_scan.limit();
             return Ok(Some(SourceScanInfo::Unpartitioned(
-                UnpartitionedData::Iceberg(task),
+                UnpartitionedData::Iceberg { task, limit },
             )));
         } else if let Some(source_node) = node.as_batch_source() {
             // TODO: use specific batch operator instead of batch source.


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

This PR pushes query limits into Iceberg source scans so simple batch queries such as `SELECT * FROM t LIMIT 1` can stop reading Iceberg files after enough rows have been produced.

The change covers both execution paths:

- DataFusion Iceberg scan receives the optional scan limit from DataFusion, keeps limited scans in a single partition, and stops after the requested number of rows.
- RisingWave batch plans push `BatchLimit` into `BatchIcebergScan`, carry the limit through fragment generation as `IcebergSplit.limit`, and stop the batch Iceberg executor after enough visible rows have been emitted.

This avoids scanning all planned Iceberg tasks before returning a small limited result. `OFFSET` is handled by pushing `limit + offset`, while the original `BatchLimit` remains above the scan to preserve final semantics.

- Closes: N/A

## Checklist

- [x] I have written necessary rustdoc comments.
- [x] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->

## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

Iceberg source queries with `LIMIT` can now return earlier by stopping the scan once enough rows are read, instead of continuing through all planned files.

</details>

<!-- capy-pr-badge:start -->
<a href="https://capy.ai/project/337a7eb0-5e7b-411a-869a-76e45a4e4750/pull/25924"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open in Capy" src="https://capy.ai/api/badge/open.svg"></picture></a>
<!-- capy-pr-badge:end -->