### PR TITLE
refactor(meta): add compaction in-progress target projection

### DIFF
--- a/src/meta/src/hummock/compaction/in_progress_compaction.rs
+++ b/src/meta/src/hummock/compaction/in_progress_compaction.rs
@@ -1,0 +1,425 @@
+// Copyright 2026 RisingWave Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use itertools::Itertools;
+use risingwave_hummock_sdk::compact_task::CompactTask;
+use risingwave_hummock_sdk::key_range::{KeyRange, KeyRangeCommon};
+use risingwave_hummock_sdk::level::InputLevel;
+use risingwave_hummock_sdk::{CompactionGroupId, HummockCompactionTaskId, HummockSstableId};
+use risingwave_pb::hummock::{
+    CompactTask as PbCompactTask, CompactTaskAssignment as PbCompactTaskAssignment,
+    InputLevel as PbInputLevel, LevelType,
+};
+
+use super::picker::CompactionInput;
+
+/// A non-overlapping target container that a compaction task writes into.
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub enum TargetContainer {
+    /// A non-L0 level.
+    Level(u32),
+    /// A non-overlapping L0 sub-level.
+    L0SubLevel(u64),
+}
+
+/// The key range that a compaction task will rewrite in a non-overlapping target container.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct TargetWriteScope {
+    pub target_container: TargetContainer,
+    pub key_range: KeyRange,
+}
+
+/// A picker-facing projection of a running compaction task.
+///
+/// This is derived from the full `CompactTask` stored in `compact_task_assignment`. It should not
+/// become a separate source of truth.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct InProgressCompactInfo {
+    pub task_id: HummockCompactionTaskId,
+    pub compaction_group_id: CompactionGroupId,
+    /// Input SSTs selected by this running task.
+    pub input_sst_ids: Vec<HummockSstableId>,
+    /// Target write scope if the task writes to a non-overlapping target container.
+    pub target_write_scope: Option<TargetWriteScope>,
+}
+
+impl TargetWriteScope {
+    pub fn from_compaction_input(input: &CompactionInput) -> Option<Self> {
+        Self::from_input_levels(
+            input.target_level as u32,
+            input.target_sub_level_id,
+            &input.input_levels,
+        )
+    }
+
+    pub fn from_compact_task(task: &CompactTask) -> Option<Self> {
+        Self::from_input_levels(
+            task.target_level,
+            task.target_sub_level_id,
+            &task.input_ssts,
+        )
+    }
+
+    pub fn from_pb_compact_task(task: &PbCompactTask) -> Option<Self> {
+        let target_container = pb_target_container(
+            task.target_level,
+            task.target_sub_level_id,
+            &task.input_ssts,
+        )?;
+        let key_range = pb_input_key_range(&task.input_ssts)?;
+        Some(Self {
+            target_container,
+            key_range,
+        })
+    }
+
+    fn from_input_levels(
+        target_level: u32,
+        target_sub_level_id: u64,
+        input_levels: &[InputLevel],
+    ) -> Option<Self> {
+        let target_container = target_container(target_level, target_sub_level_id, input_levels)?;
+        let key_range = input_key_range(input_levels)?;
+        Some(Self {
+            target_container,
+            key_range,
+        })
+    }
+}
+
+impl InProgressCompactInfo {
+    pub fn from_compact_task(task: &CompactTask) -> Self {
+        Self {
+            task_id: task.task_id,
+            compaction_group_id: task.compaction_group_id,
+            input_sst_ids: input_sst_ids(&task.input_ssts),
+            target_write_scope: TargetWriteScope::from_compact_task(task),
+        }
+    }
+
+    pub fn from_pb_compact_task(task: &PbCompactTask) -> Self {
+        Self {
+            task_id: task.task_id,
+            compaction_group_id: task.compaction_group_id,
+            input_sst_ids: pb_input_sst_ids(&task.input_ssts),
+            target_write_scope: TargetWriteScope::from_pb_compact_task(task),
+        }
+    }
+}
+
+impl CompactionInput {
+    pub fn target_write_scope(&self) -> Option<TargetWriteScope> {
+        TargetWriteScope::from_compaction_input(self)
+    }
+}
+
+pub fn in_progress_compact_infos_for_group<'a>(
+    assignments: impl IntoIterator<Item = &'a PbCompactTaskAssignment>,
+    compaction_group_id: CompactionGroupId,
+) -> Vec<InProgressCompactInfo> {
+    assignments
+        .into_iter()
+        .filter_map(|assignment| assignment.compact_task.as_ref())
+        .filter(|task| task.compaction_group_id == compaction_group_id)
+        .map(InProgressCompactInfo::from_pb_compact_task)
+        .collect_vec()
+}
+
+fn target_container(
+    target_level: u32,
+    target_sub_level_id: u64,
+    input_levels: &[InputLevel],
+) -> Option<TargetContainer> {
+    if target_level > 0 {
+        return Some(TargetContainer::Level(target_level));
+    }
+
+    let writes_non_overlapping_l0 = input_levels
+        .iter()
+        .any(|level| !level.table_infos.is_empty())
+        && input_levels.iter().all(|level| {
+            level.level_idx == 0 && matches!(level.level_type, LevelType::Nonoverlapping)
+        });
+
+    writes_non_overlapping_l0.then_some(TargetContainer::L0SubLevel(target_sub_level_id))
+}
+
+fn pb_target_container(
+    target_level: u32,
+    target_sub_level_id: u64,
+    input_levels: &[PbInputLevel],
+) -> Option<TargetContainer> {
+    if target_level > 0 {
+        return Some(TargetContainer::Level(target_level));
+    }
+
+    let writes_non_overlapping_l0 = input_levels
+        .iter()
+        .any(|level| !level.table_infos.is_empty())
+        && input_levels.iter().all(|level| {
+            level.level_idx == 0
+                && matches!(
+                    LevelType::try_from(level.level_type),
+                    Ok(LevelType::Nonoverlapping)
+                )
+        });
+
+    writes_non_overlapping_l0.then_some(TargetContainer::L0SubLevel(target_sub_level_id))
+}
+
+fn input_key_range(input_levels: &[InputLevel]) -> Option<KeyRange> {
+    let mut range: Option<KeyRange> = None;
+    for sst in input_levels.iter().flat_map(|level| &level.table_infos) {
+        match range.as_mut() {
+            Some(range) => range.full_key_extend(&sst.key_range),
+            None => range = Some(sst.key_range.clone()),
+        }
+    }
+    range
+}
+
+fn input_sst_ids(input_levels: &[InputLevel]) -> Vec<HummockSstableId> {
+    input_levels
+        .iter()
+        .flat_map(|level| &level.table_infos)
+        .map(|sst| sst.sst_id)
+        .collect_vec()
+}
+
+fn pb_input_key_range(input_levels: &[PbInputLevel]) -> Option<KeyRange> {
+    let mut range: Option<KeyRange> = None;
+    for sst in input_levels.iter().flat_map(|level| &level.table_infos) {
+        let key_range = sst
+            .key_range
+            .as_ref()
+            .map(|key_range| KeyRange {
+                left: key_range.left.clone().into(),
+                right: key_range.right.clone().into(),
+                right_exclusive: key_range.right_exclusive,
+            })
+            .unwrap_or_else(KeyRange::inf);
+        match range.as_mut() {
+            Some(range) => range.full_key_extend(&key_range),
+            None => range = Some(key_range),
+        }
+    }
+    range
+}
+
+fn pb_input_sst_ids(input_levels: &[PbInputLevel]) -> Vec<HummockSstableId> {
+    input_levels
+        .iter()
+        .flat_map(|level| &level.table_infos)
+        .map(|sst| sst.sst_id)
+        .collect_vec()
+}
+
+#[cfg(test)]
+mod tests {
+    use bytes::Bytes;
+    use risingwave_hummock_sdk::HummockSstableId;
+    use risingwave_hummock_sdk::compact_task::CompactTask;
+    use risingwave_hummock_sdk::key_range::KeyRange;
+    use risingwave_hummock_sdk::level::InputLevel;
+    use risingwave_hummock_sdk::sstable_info::{SstableInfo, SstableInfoInner};
+    use risingwave_pb::hummock::LevelType;
+
+    use super::{
+        InProgressCompactInfo, TargetContainer, TargetWriteScope,
+        in_progress_compact_infos_for_group,
+    };
+    use crate::hummock::compaction::picker::CompactionInput;
+
+    fn sst(sst_id: u64, left: usize, right: usize) -> SstableInfo {
+        SstableInfoInner {
+            object_id: sst_id.into(),
+            sst_id: sst_id.into(),
+            key_range: KeyRange {
+                left: Bytes::from(crate::hummock::test_utils::iterator_test_key_of_epoch(
+                    sst_id, left, 1,
+                )),
+                right: Bytes::from(crate::hummock::test_utils::iterator_test_key_of_epoch(
+                    sst_id, right, 1,
+                )),
+                right_exclusive: false,
+            },
+            ..Default::default()
+        }
+        .into()
+    }
+
+    fn test_key(table: u64, idx: usize) -> Bytes {
+        Bytes::from(crate::hummock::test_utils::iterator_test_key_of_epoch(
+            table, idx, 1,
+        ))
+    }
+
+    fn input_level(
+        level_idx: u32,
+        level_type: LevelType,
+        table_infos: Vec<SstableInfo>,
+    ) -> InputLevel {
+        InputLevel {
+            level_idx,
+            level_type,
+            table_infos,
+        }
+    }
+
+    #[test]
+    fn compaction_input_scope_for_non_l0_target() {
+        let input = CompactionInput {
+            input_levels: vec![
+                input_level(0, LevelType::Nonoverlapping, vec![sst(2, 10, 20)]),
+                input_level(4, LevelType::Nonoverlapping, vec![sst(1, 1, 5)]),
+            ],
+            target_level: 4,
+            ..Default::default()
+        };
+
+        let scope = input.target_write_scope().unwrap();
+
+        assert_eq!(scope.target_container, TargetContainer::Level(4));
+        assert_eq!(scope.key_range.left, test_key(1, 1));
+        assert_eq!(scope.key_range.right, test_key(2, 20));
+    }
+
+    #[test]
+    fn compaction_input_scope_for_non_overlapping_l0_target() {
+        let input = CompactionInput {
+            input_levels: vec![input_level(
+                0,
+                LevelType::Nonoverlapping,
+                vec![sst(1, 2, 4), sst(2, 6, 8)],
+            )],
+            target_level: 0,
+            target_sub_level_id: 0,
+            ..Default::default()
+        };
+
+        let scope = input.target_write_scope().unwrap();
+
+        assert_eq!(scope.target_container, TargetContainer::L0SubLevel(0));
+        assert_eq!(scope.key_range.left, test_key(1, 2));
+        assert_eq!(scope.key_range.right, test_key(2, 8));
+    }
+
+    #[test]
+    fn compaction_input_scope_skips_overlapping_l0_target() {
+        let input = CompactionInput {
+            input_levels: vec![input_level(0, LevelType::Overlapping, vec![sst(1, 2, 4)])],
+            target_level: 0,
+            target_sub_level_id: 42,
+            ..Default::default()
+        };
+
+        assert!(input.target_write_scope().is_none());
+    }
+
+    #[test]
+    fn in_progress_info_uses_full_compact_task() {
+        let task = CompactTask {
+            task_id: 7,
+            compaction_group_id: 9.into(),
+            target_level: 3,
+            input_ssts: vec![input_level(
+                2,
+                LevelType::Nonoverlapping,
+                vec![sst(1, 3, 5)],
+            )],
+            ..Default::default()
+        };
+
+        let info = InProgressCompactInfo::from_compact_task(&task);
+
+        assert_eq!(info.task_id, 7);
+        assert_eq!(info.compaction_group_id, 9);
+        assert_eq!(info.input_sst_ids, vec![HummockSstableId::new(1)]);
+        assert_eq!(
+            info.target_write_scope,
+            Some(TargetWriteScope {
+                target_container: TargetContainer::Level(3),
+                key_range: KeyRange {
+                    left: test_key(1, 3),
+                    right: test_key(1, 5),
+                    right_exclusive: false,
+                },
+            })
+        );
+    }
+
+    #[test]
+    fn in_progress_info_keeps_input_ssts_without_target_scope() {
+        let task = CompactTask {
+            task_id: 7,
+            compaction_group_id: 9.into(),
+            target_level: 0,
+            target_sub_level_id: 42,
+            input_ssts: vec![input_level(0, LevelType::Overlapping, vec![sst(1, 3, 5)])],
+            ..Default::default()
+        };
+
+        let info = InProgressCompactInfo::from_compact_task(&task);
+
+        assert_eq!(info.input_sst_ids, vec![HummockSstableId::new(1)]);
+        assert!(info.target_write_scope.is_none());
+    }
+
+    #[test]
+    fn assignment_projection_filters_by_group() {
+        let group_9_task = CompactTask {
+            task_id: 7,
+            compaction_group_id: 9.into(),
+            target_level: 3,
+            input_ssts: vec![input_level(
+                2,
+                LevelType::Nonoverlapping,
+                vec![sst(1, 3, 5)],
+            )],
+            ..Default::default()
+        };
+        let group_10_task = CompactTask {
+            task_id: 8,
+            compaction_group_id: 10.into(),
+            target_level: 3,
+            input_ssts: vec![input_level(
+                2,
+                LevelType::Nonoverlapping,
+                vec![sst(2, 6, 8)],
+            )],
+            ..Default::default()
+        };
+        let assignments = vec![
+            risingwave_pb::hummock::CompactTaskAssignment {
+                compact_task: Some(group_9_task.clone().into()),
+                context_id: 1.into(),
+            },
+            risingwave_pb::hummock::CompactTaskAssignment {
+                compact_task: Some(group_10_task.into()),
+                context_id: 1.into(),
+            },
+        ];
+
+        let infos = in_progress_compact_infos_for_group(&assignments, 9.into());
+
+        assert_eq!(infos.len(), 1);
+        assert_eq!(infos[0].task_id, group_9_task.task_id);
+        assert_eq!(
+            infos[0].compaction_group_id,
+            group_9_task.compaction_group_id
+        );
+        assert_eq!(infos[0].input_sst_ids, vec![HummockSstableId::new(1)]);
+        assert!(infos[0].target_write_scope.is_some());
+    }
+}

--- a/src/meta/src/hummock/compaction/mod.rs
+++ b/src/meta/src/hummock/compaction/mod.rs
@@ -15,7 +15,6 @@
 #![expect(clippy::arc_with_non_send_sync, reason = "FIXME: later")]
 
 pub mod compaction_config;
-pub(crate) mod in_progress_compaction;
 mod overlap_strategy;
 use risingwave_common::catalog::{TableId, TableOption};
 use risingwave_hummock_sdk::compact_task::CompactTask;
@@ -39,12 +38,12 @@ use risingwave_pb::hummock::compaction_config::CompactionMode;
 use risingwave_pb::hummock::{CompactionConfig, PbSstableFilterLayout, PbSstableFilterType};
 pub use selector::{CompactionSelector, CompactionSelectorContext};
 
-use self::in_progress_compaction::InProgressCompactInfo;
 use self::selector::{EmergencySelector, LocalSelectorStatistic};
 use super::GroupStateValidator;
 use crate::MetaOpts;
 use crate::hummock::compaction::overlap_strategy::{OverlapStrategy, RangeOverlapStrategy};
 use crate::hummock::compaction::picker::CompactionInput;
+use crate::hummock::in_progress_compaction::InProgressCompactInfo;
 use crate::hummock::level_handler::LevelHandler;
 use crate::hummock::model::CompactionGroup;
 
@@ -163,6 +162,33 @@ impl CompactStatus {
     pub fn report_compact_task(&mut self, compact_task: &CompactTask) {
         for level in &compact_task.input_ssts {
             self.level_handlers[level.level_idx as usize].remove_task(compact_task.task_id);
+        }
+    }
+
+    pub fn add_pending_task(&mut self, compact_task: &CompactTask) {
+        let mut has_l0 = false;
+        for level in &compact_task.input_ssts {
+            if level.level_idx != 0 {
+                self.level_handlers[level.level_idx as usize].add_pending_task(
+                    compact_task.task_id,
+                    compact_task.target_level as usize,
+                    &level.table_infos,
+                );
+            } else {
+                has_l0 = true;
+            }
+        }
+        if has_l0 {
+            let table_infos = compact_task
+                .input_ssts
+                .iter()
+                .filter(|level| level.level_idx == 0)
+                .flat_map(|level| level.table_infos.iter());
+            self.level_handlers[0].add_pending_task(
+                compact_task.task_id,
+                compact_task.target_level as usize,
+                table_infos,
+            );
         }
     }
 

--- a/src/meta/src/hummock/compaction/mod.rs
+++ b/src/meta/src/hummock/compaction/mod.rs
@@ -15,6 +15,7 @@
 #![expect(clippy::arc_with_non_send_sync, reason = "FIXME: later")]
 
 pub mod compaction_config;
+pub(crate) mod in_progress_compaction;
 mod overlap_strategy;
 use risingwave_common::catalog::{TableId, TableOption};
 use risingwave_hummock_sdk::compact_task::CompactTask;
@@ -38,6 +39,7 @@ use risingwave_pb::hummock::compaction_config::CompactionMode;
 use risingwave_pb::hummock::{CompactionConfig, PbSstableFilterLayout, PbSstableFilterType};
 pub use selector::{CompactionSelector, CompactionSelectorContext};
 
+use self::in_progress_compaction::InProgressCompactInfo;
 use self::selector::{EmergencySelector, LocalSelectorStatistic};
 use super::GroupStateValidator;
 use crate::MetaOpts;
@@ -110,6 +112,7 @@ impl CompactStatus {
         developer_config: Arc<CompactionDeveloperConfig>,
         table_watermarks: &HashMap<TableId, Arc<TableWatermarks>>,
         state_table_info: &HummockVersionStateTableInfo,
+        in_progress_compactions: &[InProgressCompactInfo],
     ) -> Option<CompactionTask> {
         let selector_context = CompactionSelectorContext {
             group,
@@ -121,6 +124,7 @@ impl CompactStatus {
             developer_config: developer_config.clone(),
             table_watermarks,
             state_table_info,
+            in_progress_compactions,
         };
         // When we compact the files, we must make the result of compaction meet the following
         // conditions, for any user key, the epoch of it in the file existing in the lower
@@ -146,6 +150,7 @@ impl CompactStatus {
                         developer_config,
                         table_watermarks,
                         state_table_info,
+                        in_progress_compactions,
                     };
                     return EmergencySelector::default().pick_compaction(task_id, selector_context);
                 }

--- a/src/meta/src/hummock/compaction/picker/mod.rs
+++ b/src/meta/src/hummock/compaction/picker/mod.rs
@@ -44,6 +44,7 @@ pub use trivial_move_compaction_picker::TrivialMovePicker;
 pub use ttl_reclaim_compaction_picker::{TtlPickerState, TtlReclaimCompactionPicker};
 pub use vnode_watermark_picker::VnodeWatermarkCompactionPicker;
 
+use crate::hummock::in_progress_compaction::TargetWriteScope;
 use crate::hummock::level_handler::LevelHandler;
 
 #[derive(Default, Debug)]
@@ -66,6 +67,14 @@ pub struct CompactionInput {
 }
 
 impl CompactionInput {
+    pub fn target_write_scope(&self) -> Option<TargetWriteScope> {
+        TargetWriteScope::from_input_levels(
+            self.target_level as u32,
+            self.target_sub_level_id,
+            &self.input_levels,
+        )
+    }
+
     pub fn add_pending_task(&self, task_id: u64, level_handlers: &mut [LevelHandler]) {
         let mut has_l0 = false;
         for level in &self.input_levels {

--- a/src/meta/src/hummock/compaction/selector/emergency_selector.rs
+++ b/src/meta/src/hummock/compaction/selector/emergency_selector.rs
@@ -26,7 +26,7 @@ pub struct EmergencySelector {}
 impl CompactionSelector for EmergencySelector {
     fn pick_compaction(
         &mut self,
-        task_id: HummockCompactionTaskId,
+        _task_id: HummockCompactionTaskId,
         context: CompactionSelectorContext<'_>,
     ) -> Option<CompactionTask> {
         let CompactionSelectorContext {
@@ -50,8 +50,6 @@ impl CompactionSelector for EmergencySelector {
 
         let mut stats = LocalPickerStatistic::default();
         if let Some(compaction_input) = picker.pick_compaction(levels, level_handlers, &mut stats) {
-            compaction_input.add_pending_task(task_id, level_handlers);
-
             return Some(create_compaction_task(
                 group.compaction_config.as_ref(),
                 compaction_input,

--- a/src/meta/src/hummock/compaction/selector/level_selector.rs
+++ b/src/meta/src/hummock/compaction/selector/level_selector.rs
@@ -425,7 +425,7 @@ impl DynamicLevelSelectorCore {
 impl CompactionSelector for DynamicLevelSelector {
     fn pick_compaction(
         &mut self,
-        task_id: HummockCompactionTaskId,
+        _task_id: HummockCompactionTaskId,
         context: CompactionSelectorContext<'_>,
     ) -> Option<CompactionTask> {
         let CompactionSelectorContext {
@@ -459,7 +459,6 @@ impl CompactionSelector for DynamicLevelSelector {
 
             let mut stats = LocalPickerStatistic::default();
             if let Some(ret) = picker.pick_compaction(levels, level_handlers, &mut stats) {
-                ret.add_pending_task(task_id, level_handlers);
                 return Some(create_compaction_task(
                     dynamic_level_core.get_config(),
                     ret,

--- a/src/meta/src/hummock/compaction/selector/manual_selector.rs
+++ b/src/meta/src/hummock/compaction/selector/manual_selector.rs
@@ -92,7 +92,7 @@ impl ManualCompactionSelector {
 impl CompactionSelector for ManualCompactionSelector {
     fn pick_compaction(
         &mut self,
-        task_id: HummockCompactionTaskId,
+        _task_id: HummockCompactionTaskId,
         context: CompactionSelectorContext<'_>,
     ) -> Option<CompactionTask> {
         let CompactionSelectorContext {
@@ -187,7 +187,6 @@ impl CompactionSelector for ManualCompactionSelector {
         }
 
         let compaction_input = compaction_input?;
-        compaction_input.add_pending_task(task_id, level_handlers);
 
         Some(create_compaction_task(
             group.compaction_config.as_ref(),

--- a/src/meta/src/hummock/compaction/selector/mod.rs
+++ b/src/meta/src/hummock/compaction/selector/mod.rs
@@ -47,7 +47,7 @@ use super::{
     CompactionDeveloperConfig, LevelCompactionPicker, TierCompactionPicker, create_compaction_task,
 };
 use crate::hummock::compaction::CompactionTask;
-use crate::hummock::compaction::in_progress_compaction::InProgressCompactInfo;
+use crate::hummock::in_progress_compaction::InProgressCompactInfo;
 use crate::hummock::level_handler::LevelHandler;
 use crate::hummock::model::CompactionGroup;
 use crate::rpc::metrics::MetaMetrics;

--- a/src/meta/src/hummock/compaction/selector/mod.rs
+++ b/src/meta/src/hummock/compaction/selector/mod.rs
@@ -47,6 +47,7 @@ use super::{
     CompactionDeveloperConfig, LevelCompactionPicker, TierCompactionPicker, create_compaction_task,
 };
 use crate::hummock::compaction::CompactionTask;
+use crate::hummock::compaction::in_progress_compaction::InProgressCompactInfo;
 use crate::hummock::level_handler::LevelHandler;
 use crate::hummock::model::CompactionGroup;
 use crate::rpc::metrics::MetaMetrics;
@@ -61,6 +62,7 @@ pub struct CompactionSelectorContext<'a> {
     pub developer_config: Arc<CompactionDeveloperConfig>,
     pub table_watermarks: &'a HashMap<TableId, Arc<TableWatermarks>>,
     pub state_table_info: &'a HummockVersionStateTableInfo,
+    pub in_progress_compactions: &'a [InProgressCompactInfo],
 }
 
 pub trait CompactionSelector: Sync + Send {

--- a/src/meta/src/hummock/compaction/selector/space_reclaim_selector.rs
+++ b/src/meta/src/hummock/compaction/selector/space_reclaim_selector.rs
@@ -35,7 +35,7 @@ pub struct SpaceReclaimCompactionSelector {
 impl CompactionSelector for SpaceReclaimCompactionSelector {
     fn pick_compaction(
         &mut self,
-        task_id: HummockCompactionTaskId,
+        _task_id: HummockCompactionTaskId,
         context: CompactionSelectorContext<'_>,
     ) -> Option<CompactionTask> {
         let CompactionSelectorContext {
@@ -56,7 +56,6 @@ impl CompactionSelector for SpaceReclaimCompactionSelector {
         let state = self.state.entry(group.group_id).or_default();
 
         let compaction_input = picker.pick_compaction(levels, level_handlers, state)?;
-        compaction_input.add_pending_task(task_id, level_handlers);
 
         Some(create_compaction_task(
             dynamic_level_core.get_config(),

--- a/src/meta/src/hummock/compaction/selector/tombstone_compaction_selector.rs
+++ b/src/meta/src/hummock/compaction/selector/tombstone_compaction_selector.rs
@@ -32,7 +32,7 @@ pub struct TombstoneCompactionSelector {
 impl CompactionSelector for TombstoneCompactionSelector {
     fn pick_compaction(
         &mut self,
-        task_id: HummockCompactionTaskId,
+        _task_id: HummockCompactionTaskId,
         context: CompactionSelectorContext<'_>,
     ) -> Option<CompactionTask> {
         let CompactionSelectorContext {
@@ -57,7 +57,6 @@ impl CompactionSelector for TombstoneCompactionSelector {
         );
         let state = self.state.entry(group.group_id).or_default();
         let compaction_input = picker.pick_compaction(levels, level_handlers, state)?;
-        compaction_input.add_pending_task(task_id, level_handlers);
 
         Some(create_compaction_task(
             group.compaction_config.as_ref(),

--- a/src/meta/src/hummock/compaction/selector/ttl_selector.rs
+++ b/src/meta/src/hummock/compaction/selector/ttl_selector.rs
@@ -35,7 +35,7 @@ pub struct TtlCompactionSelector {
 impl CompactionSelector for TtlCompactionSelector {
     fn pick_compaction(
         &mut self,
-        task_id: HummockCompactionTaskId,
+        _task_id: HummockCompactionTaskId,
         context: CompactionSelectorContext<'_>,
     ) -> Option<CompactionTask> {
         let CompactionSelectorContext {
@@ -52,7 +52,6 @@ impl CompactionSelector for TtlCompactionSelector {
         let picker = TtlReclaimCompactionPicker::new(table_id_to_options);
         let state = self.state.entry(group.group_id).or_default();
         let compaction_input = picker.pick_compaction(levels, level_handlers, state)?;
-        compaction_input.add_pending_task(task_id, level_handlers);
 
         Some(create_compaction_task(
             group.compaction_config.as_ref(),

--- a/src/meta/src/hummock/compaction/selector/vnode_watermark_selector.rs
+++ b/src/meta/src/hummock/compaction/selector/vnode_watermark_selector.rs
@@ -34,7 +34,7 @@ pub struct VnodeWatermarkCompactionSelector {}
 impl CompactionSelector for VnodeWatermarkCompactionSelector {
     fn pick_compaction(
         &mut self,
-        task_id: HummockCompactionTaskId,
+        _task_id: HummockCompactionTaskId,
         context: CompactionSelectorContext<'_>,
     ) -> Option<CompactionTask> {
         let CompactionSelectorContext {
@@ -55,7 +55,6 @@ impl CompactionSelector for VnodeWatermarkCompactionSelector {
             safe_epoch_read_table_watermarks(table_watermarks, member_table_ids);
         let compaction_input =
             picker.pick_compaction(levels, level_handlers, &pk_table_watermarks)?;
-        compaction_input.add_pending_task(task_id, level_handlers);
         Some(create_compaction_task(
             dynamic_level_core.get_config(),
             compaction_input,

--- a/src/meta/src/hummock/in_progress_compaction.rs
+++ b/src/meta/src/hummock/in_progress_compaction.rs
@@ -12,17 +12,19 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::collections::HashMap;
+
 use itertools::Itertools;
 use risingwave_hummock_sdk::compact_task::CompactTask;
 use risingwave_hummock_sdk::key_range::{KeyRange, KeyRangeCommon};
-use risingwave_hummock_sdk::level::InputLevel;
+use risingwave_hummock_sdk::level::{InputLevel, Level};
+use risingwave_hummock_sdk::sstable_info::SstableInfo;
 use risingwave_hummock_sdk::{CompactionGroupId, HummockCompactionTaskId, HummockSstableId};
+use risingwave_pb::hummock::level_handler::RunningCompactTask;
 use risingwave_pb::hummock::{
     CompactTask as PbCompactTask, CompactTaskAssignment as PbCompactTaskAssignment,
     InputLevel as PbInputLevel, LevelType,
 };
-
-use super::picker::CompactionInput;
 
 /// A non-overlapping target container that a compaction task writes into.
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
@@ -40,6 +42,14 @@ pub struct TargetWriteScope {
     pub key_range: KeyRange,
 }
 
+/// Input files from one level selected by a running compaction task.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct InProgressInputLevel {
+    pub level_idx: u32,
+    pub sst_ids: Vec<HummockSstableId>,
+    pub total_file_size: u64,
+}
+
 /// A picker-facing projection of a running compaction task.
 ///
 /// This is derived from the full `CompactTask` stored in `compact_task_assignment`. It should not
@@ -48,21 +58,24 @@ pub struct TargetWriteScope {
 pub struct InProgressCompactInfo {
     pub task_id: HummockCompactionTaskId,
     pub compaction_group_id: CompactionGroupId,
-    /// Input SSTs selected by this running task.
-    pub input_sst_ids: Vec<HummockSstableId>,
+    /// Input SSTs selected by this running task, grouped by input level.
+    pub input_levels: Vec<InProgressInputLevel>,
+    pub target_level: u32,
     /// Target write scope if the task writes to a non-overlapping target container.
     pub target_write_scope: Option<TargetWriteScope>,
 }
 
-impl TargetWriteScope {
-    pub fn from_compaction_input(input: &CompactionInput) -> Option<Self> {
-        Self::from_input_levels(
-            input.target_level as u32,
-            input.target_sub_level_id,
-            &input.input_levels,
-        )
-    }
+/// Input-side pending index used by pickers to avoid selecting the same SST twice.
+///
+/// `tasks` is the compact protobuf-compatible representation. `sst_to_task` is derived from it for
+/// fast picker checks.
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct PendingInputSstIndex {
+    tasks: Vec<RunningCompactTask>,
+    sst_to_task: HashMap<HummockSstableId, HummockCompactionTaskId>,
+}
 
+impl TargetWriteScope {
     pub fn from_compact_task(task: &CompactTask) -> Option<Self> {
         Self::from_input_levels(
             task.target_level,
@@ -84,7 +97,7 @@ impl TargetWriteScope {
         })
     }
 
-    fn from_input_levels(
+    pub(crate) fn from_input_levels(
         target_level: u32,
         target_sub_level_id: u64,
         input_levels: &[InputLevel],
@@ -103,7 +116,8 @@ impl InProgressCompactInfo {
         Self {
             task_id: task.task_id,
             compaction_group_id: task.compaction_group_id,
-            input_sst_ids: input_sst_ids(&task.input_ssts),
+            input_levels: in_progress_input_levels(&task.input_ssts),
+            target_level: task.target_level,
             target_write_scope: TargetWriteScope::from_compact_task(task),
         }
     }
@@ -112,15 +126,132 @@ impl InProgressCompactInfo {
         Self {
             task_id: task.task_id,
             compaction_group_id: task.compaction_group_id,
-            input_sst_ids: pb_input_sst_ids(&task.input_ssts),
+            input_levels: pb_in_progress_input_levels(&task.input_ssts),
+            target_level: task.target_level,
             target_write_scope: TargetWriteScope::from_pb_compact_task(task),
         }
     }
+
+    pub fn input_sst_ids(&self) -> Vec<HummockSstableId> {
+        self.input_levels
+            .iter()
+            .flat_map(|level| level.sst_ids.iter().copied())
+            .collect_vec()
+    }
 }
 
-impl CompactionInput {
-    pub fn target_write_scope(&self) -> Option<TargetWriteScope> {
-        TargetWriteScope::from_compaction_input(self)
+impl PendingInputSstIndex {
+    pub fn from_tasks(tasks: impl IntoIterator<Item = RunningCompactTask>) -> Self {
+        let mut index = Self::default();
+        for task in tasks {
+            index.add_task(task);
+        }
+        index
+    }
+
+    pub fn remove_task(&mut self, target_task_id: HummockCompactionTaskId) {
+        for task in &self.tasks {
+            if task.task_id == target_task_id {
+                for sst in &task.ssts {
+                    self.sst_to_task.remove(sst);
+                }
+            }
+        }
+        self.tasks.retain(|task| task.task_id != target_task_id);
+    }
+
+    pub fn contains_sst(&self, sst_id: &HummockSstableId) -> bool {
+        self.sst_to_task.contains_key(sst_id)
+    }
+
+    pub fn task_id_by_sst(&self, sst_id: &HummockSstableId) -> Option<HummockCompactionTaskId> {
+        self.sst_to_task.get(sst_id).cloned()
+    }
+
+    pub fn contains_any_sst_in_level(&self, level: &Level) -> bool {
+        level
+            .table_infos
+            .iter()
+            .any(|table| self.sst_to_task.contains_key(&table.sst_id))
+    }
+
+    pub fn contains_all_ssts_in_level(&self, level: &Level) -> bool {
+        if level.table_infos.is_empty() {
+            return false;
+        }
+
+        level
+            .table_infos
+            .iter()
+            .all(|table| self.sst_to_task.contains_key(&table.sst_id))
+    }
+
+    pub fn add_pending_task<'a>(
+        &mut self,
+        task_id: HummockCompactionTaskId,
+        target_level: u32,
+        ssts: impl IntoIterator<Item = &'a SstableInfo>,
+    ) {
+        let mut sst_ids = vec![];
+        let mut total_file_size = 0;
+        for sst in ssts {
+            total_file_size += sst.sst_size;
+            sst_ids.push(sst.sst_id);
+        }
+
+        self.add_task(RunningCompactTask {
+            task_id,
+            target_level,
+            total_file_size,
+            ssts: sst_ids,
+        });
+    }
+
+    pub fn pending_file_count(&self) -> usize {
+        self.sst_to_task.len()
+    }
+
+    pub fn pending_file_size(&self) -> u64 {
+        self.tasks
+            .iter()
+            .map(|task| task.total_file_size)
+            .sum::<u64>()
+    }
+
+    pub fn pending_output_file_size(&self, target_level: u32) -> u64 {
+        self.tasks
+            .iter()
+            .filter(|task| task.target_level == target_level)
+            .map(|task| task.total_file_size)
+            .sum::<u64>()
+    }
+
+    pub fn task_ids(&self) -> Vec<HummockCompactionTaskId> {
+        self.tasks.iter().map(|task| task.task_id).collect_vec()
+    }
+
+    pub fn tasks(&self) -> &[RunningCompactTask] {
+        &self.tasks
+    }
+
+    pub fn sst_to_task(&self) -> &HashMap<HummockSstableId, HummockCompactionTaskId> {
+        &self.sst_to_task
+    }
+
+    #[cfg(test)]
+    pub(crate) fn test_add_pending_sst(
+        &mut self,
+        sst_id: HummockSstableId,
+        task_id: HummockCompactionTaskId,
+    ) {
+        self.sst_to_task.insert(sst_id, task_id);
+    }
+
+    fn add_task(&mut self, task: RunningCompactTask) {
+        for sst in &task.ssts {
+            self.sst_to_task.insert(*sst, task.task_id);
+        }
+        self.tasks.push(task);
     }
 }
 
@@ -189,11 +320,14 @@ fn input_key_range(input_levels: &[InputLevel]) -> Option<KeyRange> {
     range
 }
 
-fn input_sst_ids(input_levels: &[InputLevel]) -> Vec<HummockSstableId> {
+fn in_progress_input_levels(input_levels: &[InputLevel]) -> Vec<InProgressInputLevel> {
     input_levels
         .iter()
-        .flat_map(|level| &level.table_infos)
-        .map(|sst| sst.sst_id)
+        .map(|level| InProgressInputLevel {
+            level_idx: level.level_idx,
+            sst_ids: level.table_infos.iter().map(|sst| sst.sst_id).collect_vec(),
+            total_file_size: level.table_infos.iter().map(|sst| sst.sst_size).sum(),
+        })
         .collect_vec()
 }
 
@@ -217,11 +351,14 @@ fn pb_input_key_range(input_levels: &[PbInputLevel]) -> Option<KeyRange> {
     range
 }
 
-fn pb_input_sst_ids(input_levels: &[PbInputLevel]) -> Vec<HummockSstableId> {
+fn pb_in_progress_input_levels(input_levels: &[PbInputLevel]) -> Vec<InProgressInputLevel> {
     input_levels
         .iter()
-        .flat_map(|level| &level.table_infos)
-        .map(|sst| sst.sst_id)
+        .map(|level| InProgressInputLevel {
+            level_idx: level.level_idx,
+            sst_ids: level.table_infos.iter().map(|sst| sst.sst_id).collect_vec(),
+            total_file_size: level.table_infos.iter().map(|sst| sst.sst_size).sum(),
+        })
         .collect_vec()
 }
 
@@ -236,15 +373,15 @@ mod tests {
     use risingwave_pb::hummock::LevelType;
 
     use super::{
-        InProgressCompactInfo, TargetContainer, TargetWriteScope,
+        InProgressCompactInfo, PendingInputSstIndex, TargetContainer, TargetWriteScope,
         in_progress_compact_infos_for_group,
     };
-    use crate::hummock::compaction::picker::CompactionInput;
 
     fn sst(sst_id: u64, left: usize, right: usize) -> SstableInfo {
         SstableInfoInner {
             object_id: sst_id.into(),
             sst_id: sst_id.into(),
+            sst_size: (right - left) as u64,
             key_range: KeyRange {
                 left: Bytes::from(crate::hummock::test_utils::iterator_test_key_of_epoch(
                     sst_id, left, 1,
@@ -279,16 +416,15 @@ mod tests {
 
     #[test]
     fn compaction_input_scope_for_non_l0_target() {
-        let input = CompactionInput {
-            input_levels: vec![
+        let scope = TargetWriteScope::from_input_levels(
+            4,
+            0,
+            &[
                 input_level(0, LevelType::Nonoverlapping, vec![sst(2, 10, 20)]),
                 input_level(4, LevelType::Nonoverlapping, vec![sst(1, 1, 5)]),
             ],
-            target_level: 4,
-            ..Default::default()
-        };
-
-        let scope = input.target_write_scope().unwrap();
+        )
+        .unwrap();
 
         assert_eq!(scope.target_container, TargetContainer::Level(4));
         assert_eq!(scope.key_range.left, test_key(1, 1));
@@ -297,18 +433,16 @@ mod tests {
 
     #[test]
     fn compaction_input_scope_for_non_overlapping_l0_target() {
-        let input = CompactionInput {
-            input_levels: vec![input_level(
+        let scope = TargetWriteScope::from_input_levels(
+            0,
+            0,
+            &[input_level(
                 0,
                 LevelType::Nonoverlapping,
                 vec![sst(1, 2, 4), sst(2, 6, 8)],
             )],
-            target_level: 0,
-            target_sub_level_id: 0,
-            ..Default::default()
-        };
-
-        let scope = input.target_write_scope().unwrap();
+        )
+        .unwrap();
 
         assert_eq!(scope.target_container, TargetContainer::L0SubLevel(0));
         assert_eq!(scope.key_range.left, test_key(1, 2));
@@ -317,14 +451,14 @@ mod tests {
 
     #[test]
     fn compaction_input_scope_skips_overlapping_l0_target() {
-        let input = CompactionInput {
-            input_levels: vec![input_level(0, LevelType::Overlapping, vec![sst(1, 2, 4)])],
-            target_level: 0,
-            target_sub_level_id: 42,
-            ..Default::default()
-        };
-
-        assert!(input.target_write_scope().is_none());
+        assert!(
+            TargetWriteScope::from_input_levels(
+                0,
+                42,
+                &[input_level(0, LevelType::Overlapping, vec![sst(1, 2, 4)])]
+            )
+            .is_none()
+        );
     }
 
     #[test]
@@ -345,7 +479,10 @@ mod tests {
 
         assert_eq!(info.task_id, 7);
         assert_eq!(info.compaction_group_id, 9);
-        assert_eq!(info.input_sst_ids, vec![HummockSstableId::new(1)]);
+        assert_eq!(info.target_level, 3);
+        assert_eq!(info.input_sst_ids(), vec![HummockSstableId::new(1)]);
+        assert_eq!(info.input_levels.len(), 1);
+        assert_eq!(info.input_levels[0].level_idx, 2);
         assert_eq!(
             info.target_write_scope,
             Some(TargetWriteScope {
@@ -372,7 +509,7 @@ mod tests {
 
         let info = InProgressCompactInfo::from_compact_task(&task);
 
-        assert_eq!(info.input_sst_ids, vec![HummockSstableId::new(1)]);
+        assert_eq!(info.input_sst_ids(), vec![HummockSstableId::new(1)]);
         assert!(info.target_write_scope.is_none());
     }
 
@@ -419,7 +556,27 @@ mod tests {
             infos[0].compaction_group_id,
             group_9_task.compaction_group_id
         );
-        assert_eq!(infos[0].input_sst_ids, vec![HummockSstableId::new(1)]);
+        assert_eq!(infos[0].input_sst_ids(), vec![HummockSstableId::new(1)]);
         assert!(infos[0].target_write_scope.is_some());
+    }
+
+    #[test]
+    fn pending_input_sst_index_keeps_task_list_and_fast_index_in_sync() {
+        let mut index = PendingInputSstIndex::default();
+        index.add_pending_task(11, 4, [&sst(1, 1, 2), &sst(2, 3, 7)]);
+
+        assert!(index.contains_sst(&HummockSstableId::new(1)));
+        assert_eq!(index.task_id_by_sst(&HummockSstableId::new(2)), Some(11));
+        assert_eq!(index.pending_file_count(), 2);
+        assert_eq!(index.pending_file_size(), 5);
+        assert_eq!(index.pending_output_file_size(4), 5);
+        assert_eq!(index.task_ids(), vec![11]);
+        assert_eq!(index.tasks()[0].target_level, 4);
+
+        index.remove_task(11);
+
+        assert!(!index.contains_sst(&HummockSstableId::new(1)));
+        assert!(index.tasks().is_empty());
+        assert_eq!(index.pending_file_count(), 0);
     }
 }

--- a/src/meta/src/hummock/level_handler.rs
+++ b/src/meta/src/hummock/level_handler.rs
@@ -14,31 +14,25 @@
 
 use std::collections::HashMap;
 
-use itertools::Itertools;
 use risingwave_hummock_sdk::level::Level;
 use risingwave_hummock_sdk::sstable_info::SstableInfo;
 use risingwave_hummock_sdk::{HummockCompactionTaskId, HummockSstableId};
 use risingwave_pb::hummock::level_handler::RunningCompactTask;
 
+use crate::hummock::in_progress_compaction::PendingInputSstIndex;
+
 #[derive(Clone, Debug, PartialEq)]
 pub struct LevelHandler {
     level: u32,
-    /// Input SSTs that are already selected by running compaction tasks.
-    ///
-    /// This is an input-side pending index for picker checks. Full running task
-    /// metadata is stored in `Compaction::compact_task_assignment`.
-    compacting_files: HashMap<HummockSstableId, HummockCompactionTaskId>,
-    /// A lightweight summary used to persist and restore `compacting_files`, and
-    /// to report pending input task metrics.
-    pending_tasks: Vec<RunningCompactTask>,
+    /// Per-level input-side pending view used by picker checks and metrics.
+    pending_inputs: PendingInputSstIndex,
 }
 
 impl LevelHandler {
     pub fn new(level: u32) -> Self {
         Self {
             level,
-            compacting_files: HashMap::default(),
-            pending_tasks: vec![],
+            pending_inputs: PendingInputSstIndex::default(),
         }
     }
 
@@ -47,44 +41,26 @@ impl LevelHandler {
     }
 
     pub fn remove_task(&mut self, target_task_id: u64) {
-        for task in &self.pending_tasks {
-            if task.task_id == target_task_id {
-                for sst in &task.ssts {
-                    self.compacting_files.remove(sst);
-                }
-            }
-        }
-        self.pending_tasks
-            .retain(|task| task.task_id != target_task_id);
+        self.pending_inputs.remove_task(target_task_id);
     }
 
     pub fn is_pending_compact(&self, sst_id: &HummockSstableId) -> bool {
-        self.compacting_files.contains_key(sst_id)
+        self.pending_inputs.contains_sst(sst_id)
     }
 
     pub fn pending_task_id_by_sst(
         &self,
         sst_id: &HummockSstableId,
     ) -> Option<HummockCompactionTaskId> {
-        self.compacting_files.get(sst_id).cloned()
+        self.pending_inputs.task_id_by_sst(sst_id)
     }
 
     pub fn is_level_pending_compact(&self, level: &Level) -> bool {
-        level
-            .table_infos
-            .iter()
-            .any(|table| self.compacting_files.contains_key(&table.sst_id))
+        self.pending_inputs.contains_any_sst_in_level(level)
     }
 
     pub fn is_level_all_pending_compact(&self, level: &Level) -> bool {
-        if level.table_infos.is_empty() {
-            return false;
-        }
-
-        level
-            .table_infos
-            .iter()
-            .all(|table| self.compacting_files.contains_key(&table.sst_id))
+        self.pending_inputs.contains_all_ssts_in_level(level)
     }
 
     pub fn add_pending_task<'a>(
@@ -93,60 +69,37 @@ impl LevelHandler {
         target_level: usize,
         ssts: impl IntoIterator<Item = &'a SstableInfo>,
     ) {
-        let target_level = target_level as u32;
-        let mut table_ids = vec![];
-        let mut total_file_size = 0;
-        for sst in ssts {
-            self.compacting_files.insert(sst.sst_id, task_id);
-            total_file_size += sst.sst_size;
-            table_ids.push(sst.sst_id);
-        }
-
-        self.pending_tasks.push(RunningCompactTask {
-            task_id,
-            target_level,
-            total_file_size,
-            ssts: table_ids,
-        });
+        self.pending_inputs
+            .add_pending_task(task_id, target_level as u32, ssts);
     }
 
     pub fn pending_file_count(&self) -> usize {
-        self.compacting_files.len()
+        self.pending_inputs.pending_file_count()
     }
 
     pub fn pending_file_size(&self) -> u64 {
-        self.pending_tasks
-            .iter()
-            .map(|task| task.total_file_size)
-            .sum::<u64>()
+        self.pending_inputs.pending_file_size()
     }
 
     pub fn pending_output_file_size(&self, target_level: u32) -> u64 {
-        self.pending_tasks
-            .iter()
-            .filter(|task| task.target_level == target_level)
-            .map(|task| task.total_file_size)
-            .sum::<u64>()
+        self.pending_inputs.pending_output_file_size(target_level)
     }
 
     pub fn pending_tasks_ids(&self) -> Vec<u64> {
-        self.pending_tasks
-            .iter()
-            .map(|task| task.task_id)
-            .collect_vec()
+        self.pending_inputs.task_ids()
     }
 
     pub fn pending_tasks(&self) -> &[RunningCompactTask] {
-        &self.pending_tasks
+        self.pending_inputs.tasks()
     }
 
     pub fn compacting_files(&self) -> &HashMap<HummockSstableId, HummockCompactionTaskId> {
-        &self.compacting_files
+        self.pending_inputs.sst_to_task()
     }
 
     #[cfg(test)]
     pub(crate) fn test_add_pending_sst(&mut self, sst_id: HummockSstableId, task_id: u64) {
-        self.compacting_files.insert(sst_id, task_id);
+        self.pending_inputs.test_add_pending_sst(sst_id, task_id);
     }
 }
 
@@ -154,24 +107,15 @@ impl From<&LevelHandler> for risingwave_pb::hummock::LevelHandler {
     fn from(lh: &LevelHandler) -> Self {
         risingwave_pb::hummock::LevelHandler {
             level: lh.level,
-            tasks: lh.pending_tasks.clone(),
+            tasks: lh.pending_tasks().to_vec(),
         }
     }
 }
 
 impl From<&risingwave_pb::hummock::LevelHandler> for LevelHandler {
     fn from(lh: &risingwave_pb::hummock::LevelHandler) -> Self {
-        let mut pending_tasks = vec![];
-        let mut compacting_files = HashMap::new();
-        for task in &lh.tasks {
-            pending_tasks.push(task.clone());
-            for s in &task.ssts {
-                compacting_files.insert(*s, task.task_id);
-            }
-        }
         Self {
-            pending_tasks,
-            compacting_files,
+            pending_inputs: PendingInputSstIndex::from_tasks(lh.tasks.clone()),
             level: lh.level,
         }
     }

--- a/src/meta/src/hummock/level_handler.rs
+++ b/src/meta/src/hummock/level_handler.rs
@@ -23,7 +23,13 @@ use risingwave_pb::hummock::level_handler::RunningCompactTask;
 #[derive(Clone, Debug, PartialEq)]
 pub struct LevelHandler {
     level: u32,
+    /// Input SSTs that are already selected by running compaction tasks.
+    ///
+    /// This is an input-side pending index for picker checks. Full running task
+    /// metadata is stored in `Compaction::compact_task_assignment`.
     compacting_files: HashMap<HummockSstableId, HummockCompactionTaskId>,
+    /// A lightweight summary used to persist and restore `compacting_files`, and
+    /// to report pending input task metrics.
     pending_tasks: Vec<RunningCompactTask>,
 }
 

--- a/src/meta/src/hummock/manager/compaction/mod.rs
+++ b/src/meta/src/hummock/manager/compaction/mod.rs
@@ -58,9 +58,6 @@ use tokio::task::JoinHandle;
 use tonic::Streaming;
 use tracing::warn;
 
-use crate::hummock::compaction::in_progress_compaction::{
-    InProgressCompactInfo, in_progress_compact_infos_for_group,
-};
 use crate::hummock::compaction::selector::level_selector::PickerInfo;
 use crate::hummock::compaction::selector::{
     DynamicLevelSelector, DynamicLevelSelectorCore, LocalSelectorStatistic, ManualCompactionOption,
@@ -72,6 +69,9 @@ use crate::hummock::compaction::{
     CompactionTask as PickedCompactionTask,
 };
 use crate::hummock::error::{Error, Result};
+use crate::hummock::in_progress_compaction::{
+    InProgressCompactInfo, in_progress_compact_infos_for_group,
+};
 use crate::hummock::manager::CompactionTaskReportResult;
 use crate::hummock::manager::compaction::compact_task_builder::{
     CompactTaskBuildContext, attach_compact_task_table_metadata, build_base_compact_task,
@@ -498,7 +498,6 @@ impl HummockManager {
                             compact_task.input_ssts,
                             start_time.elapsed()
                         );
-                        compact_status.report_compact_task(&compact_task);
                         update_table_stats_for_vnode_watermark_trivial_reclaim(
                             &mut version_stats.table_stats,
                             &compact_task,
@@ -521,6 +520,7 @@ impl HummockManager {
                         }
                     }
                     BuiltCompactTask::PendingAssignment(compact_task) => {
+                        compact_status.add_pending_task(&compact_task);
                         // Keep the projection view complete if this loop later allows multiple
                         // pending assignments from the same compaction group.
                         in_progress_compactions

--- a/src/meta/src/hummock/manager/compaction/mod.rs
+++ b/src/meta/src/hummock/manager/compaction/mod.rs
@@ -58,6 +58,9 @@ use tokio::task::JoinHandle;
 use tonic::Streaming;
 use tracing::warn;
 
+use crate::hummock::compaction::in_progress_compaction::{
+    InProgressCompactInfo, in_progress_compact_infos_for_group,
+};
 use crate::hummock::compaction::selector::level_selector::PickerInfo;
 use crate::hummock::compaction::selector::{
     DynamicLevelSelector, DynamicLevelSelectorCore, LocalSelectorStatistic, ManualCompactionOption,
@@ -436,6 +439,11 @@ impl HummockManager {
                 }
             }
 
+            let mut in_progress_compactions = in_progress_compact_infos_for_group(
+                compact_task_assignment.tree_ref().values(),
+                compaction_group_id,
+            );
+
             while let Some(picked_task) = compact_status.get_compact_task(
                 version
                     .latest_version()
@@ -452,6 +460,7 @@ impl HummockManager {
                 developer_config.clone(),
                 &version.latest_version().table_watermarks,
                 &version.latest_version().state_table_info,
+                &in_progress_compactions,
             ) {
                 let compaction_group_levels = version
                     .latest_version()
@@ -512,6 +521,10 @@ impl HummockManager {
                         }
                     }
                     BuiltCompactTask::PendingAssignment(compact_task) => {
+                        // Keep the projection view complete if this loop later allows multiple
+                        // pending assignments from the same compaction group.
+                        in_progress_compactions
+                            .push(InProgressCompactInfo::from_compact_task(&compact_task));
                         compact_task_assignment.insert(
                             compact_task.task_id,
                             CompactTaskAssignment {

--- a/src/meta/src/hummock/mod.rs
+++ b/src/meta/src/hummock/mod.rs
@@ -20,6 +20,7 @@ pub(crate) use manager::checkpoint::{compress_payload, xxhash64_checksum};
 pub use manager::*;
 use thiserror_ext::AsReport;
 
+pub(crate) mod in_progress_compaction;
 mod level_handler;
 mod metrics_utils;
 #[cfg(any(test, feature = "test"))]

--- a/src/meta/src/hummock/test_utils.rs
+++ b/src/meta/src/hummock/test_utils.rs
@@ -426,6 +426,7 @@ pub fn compaction_selector_context<'a>(
         developer_config,
         table_watermarks,
         state_table_info,
+        in_progress_compactions: &[],
     }
 }
 


### PR DESCRIPTION
## Summary

- add a picker-facing `InProgressCompactInfo` projection for running compaction tasks
- include each task's input SST ids in the projection, matching the existing input-side pending semantics
- derive an optional target write scope from the input SST key-range envelope for non-overlapping target containers
- pass the derived in-progress compaction view through selector context without changing picker behavior
- clarify that `LevelHandler` remains the existing input SST pending index for now

This is Phase 1 only. It does not enable target range conflict checks yet.

## Tests

- `cargo fmt --all --check`
- `cargo test -p risingwave_meta hummock::compaction::in_progress_compaction --lib`
- `cargo check -p risingwave_meta --lib`