### PR TITLE
refactor: expose Kafka full headers as `map`

### DIFF
--- a/e2e_test/backwards-compat-tests/scripts/utils.sh
+++ b/e2e_test/backwards-compat-tests/scripts/utils.sh
@@ -108,6 +108,23 @@ insert_json_kafka() {
   rpk topic produce backwards_compat_test_kafka_source -f "%k,%v"
 }
 
+create_kafka_header_topic() {
+  RPK_BROKERS=message_queue:29092 \
+  rpk topic create backwards_compat_test_kafka_header_source
+}
+
+insert_json_kafka_with_headers() {
+  local JSON=$1
+
+  printf 'dup=first header1=v1 dup=second %s\n' "$JSON" | \
+  RPK_BROKERS=message_queue:29092 \
+  rpk topic produce backwards_compat_test_kafka_header_source -f "%H{3}%h{%k=%v }%k,%v"
+}
+
+seed_json_kafka_header() {
+  insert_json_kafka_with_headers '{"key": 1},{"a": 1}'
+}
+
 seed_json_kafka() {
   insert_json_kafka '{"user_id": 1},{"timestamp": "2023-07-28 07:11:00", "user_id": 1, "page_id": 1, "action": "gtrgretrg"}'
   insert_json_kafka '{"user_id": 2},{"timestamp": "2023-07-28 07:11:00", "user_id": 2, "page_id": 1, "action": "fsdfgerrg"}'
@@ -392,11 +409,19 @@ seed_old_cluster() {
     sqllogictest -d dev -h localhost -p 4566 "$TEST_DIR/kafka/upsert/include_key_as.slt"
   fi
 
+  echo "--- KAFKA HEADER TEST: Seeding old cluster with full-header list catalog"
+  create_kafka_header_topic
+  seed_json_kafka_header
+  sqllogictest -d dev -h localhost -p 4566 "$TEST_DIR/kafka/header/seed.slt"
+
   echo "--- KAFKA TEST: wait 5s for kafka to process data"
   sleep 5
 
   echo "--- KAFKA TEST: Validating old cluster"
   sqllogictest -d dev -h localhost -p 4566 "$TEST_DIR/kafka/validate_original.slt"
+
+  echo "--- KAFKA HEADER TEST: Validating old cluster"
+  sqllogictest -d dev -h localhost -p 4566 "$TEST_DIR/kafka/header/validate_original.slt"
 
   # Test version columns backwards compatibility, if OLD_VERSION <= 2.6.0
   if version_le "$OLD_VERSION" "2.6.0"; then
@@ -486,6 +511,9 @@ validate_new_cluster() {
 
   echo "--- KAFKA TEST: Validating new cluster"
   sqllogictest -d dev -h localhost -p 4566 "$TEST_DIR/kafka/validate_restart.slt"
+
+  echo "--- KAFKA HEADER TEST: Validating new cluster"
+  sqllogictest -d dev -h localhost -p 4566 "$TEST_DIR/kafka/header/validate_restart.slt"
 
   # Test version columns backwards compatibility, if OLD_VERSION <= 2.6.0
   if version_le "$OLD_VERSION" "2.6.0"; then

--- a/e2e_test/backwards-compat-tests/slt/kafka/header/seed.slt
+++ b/e2e_test/backwards-compat-tests/slt/kafka/header/seed.slt
@@ -1,0 +1,17 @@
+statement ok
+CREATE SOURCE IF NOT EXISTS kafka_header_source
+(
+ a integer
+)
+INCLUDE header AS header_col_combined
+WITH (
+ connector='kafka',
+ topic='backwards_compat_test_kafka_header_source',
+ properties.bootstrap.server='message_queue:29092',
+ scan.startup.mode='earliest',
+) FORMAT PLAIN ENCODE JSON;
+
+statement ok
+CREATE MATERIALIZED VIEW kafka_header_mv1 AS
+SELECT a, header_col_combined
+FROM kafka_header_source;

--- a/e2e_test/backwards-compat-tests/slt/kafka/header/validate_original.slt
+++ b/e2e_test/backwards-compat-tests/slt/kafka/header/validate_original.slt
@@ -1,0 +1,24 @@
+query T
+select c.data_type
+from rw_catalog.rw_columns c
+join rw_catalog.rw_relations r on c.relation_id = r.id
+where r.name = 'kafka_header_source'
+  and c.name = 'header_col_combined';
+----
+struct<key character varying, value bytea>[]
+
+query T rowsort retry 6 backoff 1s
+WITH arr AS (
+  SELECT header_col_combined
+  FROM kafka_header_mv1
+),
+unnested AS (
+  SELECT unnest(header_col_combined) AS h
+  FROM arr
+)
+SELECT h::varchar
+FROM unnested;
+----
+(dup,"\\x6669727374")
+(dup,"\\x7365636f6e64")
+(header1,"\\x7631")

--- a/e2e_test/backwards-compat-tests/slt/kafka/header/validate_restart.slt
+++ b/e2e_test/backwards-compat-tests/slt/kafka/header/validate_restart.slt
@@ -1,0 +1,76 @@
+query T
+select c.data_type
+from rw_catalog.rw_columns c
+join rw_catalog.rw_relations r on c.relation_id = r.id
+where r.name = 'kafka_header_source'
+  and c.name = 'header_col_combined';
+----
+struct<key character varying, value bytea>[]
+
+query T rowsort retry 6 backoff 1s
+WITH arr AS (
+  SELECT header_col_combined
+  FROM kafka_header_mv1
+),
+unnested AS (
+  SELECT unnest(header_col_combined) AS h
+  FROM arr
+)
+SELECT h::varchar
+FROM unnested;
+----
+(dup,"\\x6669727374")
+(dup,"\\x7365636f6e64")
+(header1,"\\x7631")
+
+statement ok
+CREATE MATERIALIZED VIEW kafka_header_mv2 AS
+SELECT a, header_col_combined
+FROM kafka_header_source;
+
+query T rowsort retry 6 backoff 1s
+WITH arr AS (
+  SELECT header_col_combined
+  FROM kafka_header_mv2
+),
+unnested AS (
+  SELECT unnest(header_col_combined) AS h
+  FROM arr
+)
+SELECT h::varchar
+FROM unnested;
+----
+(dup,"\\x6669727374")
+(dup,"\\x7365636f6e64")
+(header1,"\\x7631")
+
+statement ok
+CREATE SOURCE kafka_header_source_new
+(
+ a integer
+)
+INCLUDE header AS header_map
+WITH (
+ connector='kafka',
+ topic='backwards_compat_test_kafka_header_source',
+ properties.bootstrap.server='message_queue:29092',
+ scan.startup.mode='earliest',
+) FORMAT PLAIN ENCODE JSON;
+
+query B
+select c.data_type = 'map(character varying,bytea)'
+from rw_catalog.rw_columns c
+join rw_catalog.rw_relations r on c.relation_id = r.id
+where r.name = 'kafka_header_source_new'
+  and c.name = 'header_map';
+----
+t
+
+query TTT retry 6 backoff 1s
+select encode(header_map['dup'], 'hex'),
+       encode(header_map['header1'], 'hex'),
+       (header_map['missing'] is null)::varchar
+from kafka_header_source_new
+where a = 1;
+----
+7365636f6e64	7631	true

--- a/e2e_test/source_inline/kafka/include_key_as.slt
+++ b/e2e_test/source_inline/kafka/include_key_as.slt
@@ -174,7 +174,9 @@ system ok
 rpk topic create 'test_additional_columns'
 
 system ok
-for i in {0..10}; do echo "key$i:{\"a\": $i}" | rpk topic produce test_additional_columns -f "%k:%v\n" -H "header1=v1" -H "header2=v2"; done
+set -e
+for i in {0..9}; do echo "key$i:{\"a\": $i}" | rpk topic produce test_additional_columns -f "%k:%v\n" -H "header1=v1" -H "header2=v2"; done
+printf 'key10 header1=v1 header2=v2 header1=v1_override {"a": 10}\n' | rpk topic produce test_additional_columns -f "%k %H{3}%h{%k=%v }%v\n"
 
 statement error
 create table additional_columns (a int)
@@ -217,6 +219,15 @@ query T
 SELECT SUBSTRING(definition, 1, POSITION(' WITH' IN definition) - 1) FROM rw_sources WHERE name = 'additional_columns';
 ----
 CREATE TABLE additional_columns (a INT) INCLUDE key AS key_col INCLUDE partition AS partition_col INCLUDE offset AS offset_col INCLUDE timestamp AS timestamp_col INCLUDE header AS header_col_combined INCLUDE header 'header1' AS header_col_1 INCLUDE header 'header2' AS header_col_2 INCLUDE header 'header2' CHARACTER VARYING AS header_col_3 INCLUDE header 'header3' AS header_col_4
+
+query B
+select c.data_type = 'map(character varying,bytea)'
+from rw_catalog.rw_columns c
+join rw_catalog.rw_relations r on c.relation_id = r.id
+where r.name = 'additional_columns'
+  and c.name = 'header_col_combined';
+----
+t
 
 # Wait enough time to ensure SourceExecutor consumes all Kafka data.
 
@@ -269,13 +280,29 @@ WHERE  key_col IS NOT NULL
 11
 
 
-query ?? retry 3 backoff 1s
-WITH arr AS (SELECT header_col_combined FROM additional_columns),
-unnested AS (SELECT unnest(header_col_combined) FROM arr)
-select *, count(*) from unnested group by 1 order by 1;
+query TTT retry 3 backoff 1s
+select encode(header_col_combined['header1'], 'hex'),
+       encode(header_col_combined['header2'], 'hex'),
+       (header_col_combined['header3'] is null)::varchar
+from additional_columns
+where a = 0;
 ----
-(header1,"\\x7631") 11
-(header2,"\\x7632") 11
+7631	7632	true
+
+query T retry 3 backoff 1s
+select encode(header_col_combined['header1'], 'hex')
+from additional_columns
+where a = 10;
+----
+76315f6f76657272696465
+
+query TT retry 3 backoff 1s
+select encode(header_col_1, 'hex'),
+       encode(header_col_combined['header1'], 'hex')
+from additional_columns
+where a = 10;
+----
+7631	76315f6f76657272696465
 
 query ???? retry 3 backoff 1s
 select header_col_1, header_col_2, header_col_3, header_col_4 from additional_columns limit 1

--- a/src/connector/src/parser/additional_columns.rs
+++ b/src/connector/src/parser/additional_columns.rs
@@ -17,7 +17,7 @@ use std::sync::LazyLock;
 
 use risingwave_common::bail;
 use risingwave_common::catalog::{ColumnCatalog, ColumnDesc, ColumnId, max_column_id};
-use risingwave_common::types::{DataType, StructType};
+use risingwave_common::types::{DataType, MapType, StructType};
 use risingwave_pb::plan_common::additional_column::ColumnType as AdditionalColumnType;
 use risingwave_pb::plan_common::{
     AdditionalCollectionName, AdditionalColumn, AdditionalColumnFilename, AdditionalColumnHeader,
@@ -431,7 +431,7 @@ fn build_header_catalog(
         ColumnDesc::named_with_additional_column(
             col_name,
             column_id,
-            DataType::list(get_kafka_header_item_datatype()),
+            DataType::Map(MapType::from_kv(DataType::Varchar, DataType::Bytea)),
             AdditionalColumn {
                 column_type: Some(AdditionalColumnType::Headers(AdditionalColumnHeaders {})),
             },

--- a/src/connector/src/parser/chunk_builder.rs
+++ b/src/connector/src/parser/chunk_builder.rs
@@ -415,7 +415,7 @@ impl SourceStreamChunkRowWriter<'_> {
                 (_, &Some(AdditionalColumnType::Headers(_))) => Ok(A::output_for(
                     self.row_meta
                         .as_ref()
-                        .and_then(|ele| extract_headers_from_meta(ele.source_meta))
+                        .and_then(|ele| extract_headers_from_meta(ele.source_meta, &desc.data_type))
                         .unwrap_or(None),
                 )),
                 (_, &Some(AdditionalColumnType::PulsarMessageIdData(_))) => {

--- a/src/connector/src/parser/utils.rs
+++ b/src/connector/src/parser/utils.rs
@@ -18,7 +18,7 @@ use anyhow::Context;
 use bytes::Bytes;
 use reqwest::Url;
 use risingwave_common::bail;
-use risingwave_common::types::{Datum, DatumCow, DatumRef, ScalarRefImpl};
+use risingwave_common::types::{DataType, Datum, DatumCow, DatumRef, ScalarRefImpl};
 use risingwave_pb::data::DataType as PbDataType;
 
 use crate::aws_utils::load_file_descriptor_from_s3;
@@ -143,9 +143,10 @@ pub fn extract_cdc_meta_column<'a>(
     }
 }
 
-pub fn extract_headers_from_meta(meta: &SourceMeta) -> Option<Datum> {
+pub fn extract_headers_from_meta(meta: &SourceMeta, data_type: &DataType) -> Option<Datum> {
     match meta {
-        SourceMeta::Kafka(kafka_meta) => kafka_meta.extract_headers(), /* expect output of type `array[struct<varchar, bytea>]` */
+        SourceMeta::Kafka(kafka_meta) if data_type.is_map() => kafka_meta.extract_headers_as_map(), /* expect output of type `map<varchar, bytea>` */
+        SourceMeta::Kafka(kafka_meta) => kafka_meta.extract_headers(), /* compatibility path for existing catalogs with `array[struct<varchar, bytea>]` */
         _ => None,
     }
 }

--- a/src/connector/src/source/kafka/source/message.rs
+++ b/src/connector/src/source/kafka/source/message.rs
@@ -18,7 +18,8 @@ use itertools::Itertools;
 use rdkafka::message::{BorrowedMessage, Headers, OwnedHeaders};
 use rdkafka::{Message, Timestamp};
 use risingwave_common::types::{
-    Datum, DatumCow, DatumRef, ListValue, ScalarImpl, ScalarRefImpl, StructValue,
+    DataType, Datum, DatumCow, DatumRef, ListValue, MapValue, ScalarImpl, ScalarRefImpl,
+    StructValue,
 };
 use risingwave_pb::data::DataType as PbDataType;
 use risingwave_pb::data::data_type::TypeName as PbTypeName;
@@ -85,6 +86,36 @@ impl KafkaMeta {
                 &get_kafka_header_item_datatype(),
                 header_item,
             )))
+        })
+    }
+
+    pub fn extract_headers_as_map(&self) -> Option<Datum> {
+        self.headers.as_ref().map(|headers| {
+            let mut entries: Vec<(&str, Option<&[u8]>)> = Vec::with_capacity(headers.count());
+
+            for header in headers.iter() {
+                if let Some((_, value)) = entries.iter_mut().find(|(key, _)| *key == header.key) {
+                    tracing::warn!(
+                        header_key = header.key,
+                        "duplicate Kafka header key found when building header map; overwriting previous value"
+                    );
+                    *value = header.value;
+                } else {
+                    entries.push((header.key, header.value));
+                }
+            }
+
+            let keys = entries.iter().map(|(key, _)| Some(*key)).collect::<ListValue>();
+            let values = ListValue::from_datum_iter(
+                &DataType::Bytea,
+                entries
+                    .into_iter()
+                    .map(|(_, value)| value.map(|value| ScalarRefImpl::Bytea(value))),
+            );
+            Some(ScalarImpl::Map(
+                MapValue::try_from_kv(keys, values)
+                    .expect("Kafka header map keys are de-duplicated and non-null"),
+            ))
         })
     }
 }


### PR DESCRIPTION
## What's changed

This PR changes newly-created Kafka `INCLUDE header AS ...` full-header columns from the legacy list-of-struct representation to `map(varchar, bytea)`.

For duplicate Kafka header keys in the new map representation, RisingWave now uses last-write-wins semantics and emits a warning log when overwriting an earlier value.

## User-facing / breaking change

This is a user-facing breaking change for **newly-created** Kafka sources/tables that use full-header inclusion:

```sql
INCLUDE header AS header_col
```

Before this PR, `header_col` was exposed as:

```text
struct<key varchar, value bytea>[]
```

After this PR, newly-created pipelines expose it as:

```text
map(varchar, bytea)
```

User queries against newly-created full-header columns should use map access, for example:

```sql
header_col['trace_id']
```

instead of list/`unnest`-based access.

## Compatibility guarantee

Existing pipelines are kept compatible. The runtime extraction path now checks the persisted catalog column type:

- existing full-header columns that were created as `struct<key varchar, value bytea>[]` keep using the legacy list-of-struct extraction path;
- newly-created full-header columns with `map(varchar, bytea)` use the new map extraction path.

This means the type change is not applied retroactively to old catalogs after upgrade.

Note: keyed headers such as `INCLUDE header 'foo' AS foo_header` keep their existing scalar behavior. The map last-write-wins behavior applies to the new full-header map representation.

## Tests

- `cargo fmt --check -- src/connector/src/parser/additional_columns.rs src/connector/src/parser/utils.rs src/connector/src/parser/chunk_builder.rs src/connector/src/source/kafka/source/message.rs`
- `cargo check -p risingwave_connector --quiet`
- `bash -n e2e_test/backwards-compat-tests/scripts/utils.sh`
- `git diff --check`
- `python3 e2e_test/check_slt_coverage.py -d`
- `RISEDEV_KAFKA_WITH_OPTIONS_COMMON="connector='kafka',properties.bootstrap.server='127.0.0.1:9092'" RPK_BROKERS=127.0.0.1:9092 ./risedev slt-clean './e2e_test/source_inline/kafka/include_key_as.slt'`
- `RISEDEV_KAFKA_WITH_OPTIONS_COMMON="connector='kafka',properties.bootstrap.server='127.0.0.1:9092'" RPK_BROKERS=127.0.0.1:9092 ./risedev slt './e2e_test/source_inline/kafka/include_key_as.slt'`
- Verified warning log after SLT with `rg "duplicate Kafka header key found when building header map" .risingwave/log/compute-node-5688.log`

Backwards-compat SLTs are added and wired into the backwards-compat script, but I did not run the full local backwards-compat script because it checks out release tags and requires a committed clean worktree/runtime cycle.

<!-- capy-pr-badge:start -->
<a href="https://capy.ai/project/337a7eb0-5e7b-411a-869a-76e45a4e4750/pull/25927"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open in Capy" src="https://capy.ai/api/badge/open.svg"></picture></a>
<!-- capy-pr-badge:end -->