### PR TITLE
refactor: simplify table cache refill context

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11886,7 +11886,6 @@ dependencies = [
  "madsim-tokio",
  "madsim-tonic",
  "maplit",
- "parking_lot 0.12.5",
  "prometheus",
  "prost 0.14.3",
  "rand 0.9.2",

--- a/e2e_test/commands/psql_refill_validate.py
+++ b/e2e_test/commands/psql_refill_validate.py
@@ -13,10 +13,10 @@ What this script validates:
    union of vnode bitmaps from `stats.internal.streaming[table_id]`.
 
 Important note:
-`stats.internal.streaming` is worker-global `read_version_mapping` state, not a
-job-scoped view. Therefore this script only filters and validates the target
-job's internal tables. It does not require all entries in
-`stats.internal.streaming` to belong to the target job.
+`stats.internal.streaming` is worker-global refiller vnode state, using the
+table-level vnode union maintained by the refiller. Therefore this script only
+filters and validates the target job's internal tables. It does not require all
+entries in `stats.internal.streaming` to belong to the target job.
 
 Examples:
     psql_refill_validate.py --job-name s3 --job-type sink --mode streaming
@@ -533,7 +533,7 @@ def main() -> int:
 
         if args.mode in ("streaming", "both"):
             logger.info(
-                "Comparing streaming refill stats against internal.read_version_mapping-derived vnode distribution"
+                "Comparing streaming refill stats against internal refiller vnode distribution"
             )
             expected_streaming = project_internal_streaming_stats(
                 stats_by_worker, relevant_table_ids

--- a/src/compute/Cargo.toml
+++ b/src/compute/Cargo.toml
@@ -22,7 +22,6 @@ futures-async-stream = { workspace = true }
 http = "1"
 itertools = { workspace = true }
 maplit = "1.0.2"
-parking_lot = { workspace = true }
 prometheus = { version = "0.14" }
 prost = { workspace = true }
 risingwave_batch = { workspace = true }

--- a/src/compute/src/rpc/service/monitor_service.rs
+++ b/src/compute/src/rpc/service/monitor_service.rs
@@ -17,7 +17,6 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use foyer::{HybridCache, TracingOptions};
-use itertools::Itertools;
 use parking_lot::RwLock;
 use prometheus::core::Collector;
 use prometheus::proto::Metric;
@@ -36,7 +35,7 @@ use risingwave_pb::monitor_service::{
     TieredCacheTracingRequest, TieredCacheTracingResponse,
 };
 use risingwave_storage::hummock::compactor::await_tree_key::Compaction;
-use risingwave_storage::hummock::event_handler::refiller::TableCacheRefillContext;
+use risingwave_storage::hummock::event_handler::refiller::TableCacheRefillContextMap;
 use risingwave_storage::hummock::{Block, Sstable, SstableBlockIndex};
 use risingwave_stream::executor::monitor::global_streaming_metrics;
 use risingwave_stream::task::LocalStreamManager;
@@ -53,7 +52,7 @@ pub struct MonitorServiceImpl {
     profile_service: ProfileServiceImpl,
     meta_cache: Option<MetaCache>,
     block_cache: Option<BlockCache>,
-    table_cache_refill_context: Option<Arc<RwLock<TableCacheRefillContext>>>,
+    table_cache_refill_context_map: Option<Arc<RwLock<TableCacheRefillContextMap>>>,
 }
 
 impl MonitorServiceImpl {
@@ -62,14 +61,14 @@ impl MonitorServiceImpl {
         server_config: ServerConfig,
         meta_cache: Option<MetaCache>,
         block_cache: Option<BlockCache>,
-        table_cache_refill_context: Option<Arc<RwLock<TableCacheRefillContext>>>,
+        table_cache_refill_context_map: Option<Arc<RwLock<TableCacheRefillContextMap>>>,
     ) -> Self {
         Self {
             stream_mgr,
             profile_service: ProfileServiceImpl::new(server_config),
             meta_cache,
             block_cache,
-            table_cache_refill_context,
+            table_cache_refill_context_map,
         }
     }
 }
@@ -448,13 +447,13 @@ impl MonitorService for MonitorServiceImpl {
         &self,
         _request: Request<GetTableCacheRefillStatsRequest>,
     ) -> Result<Response<GetTableCacheRefillStatsResponse>, Status> {
-        let Some(context) = &self.table_cache_refill_context else {
+        let Some(context_map) = &self.table_cache_refill_context_map else {
             return Ok(Response::new(GetTableCacheRefillStatsResponse {
                 stats: "{}".to_owned(),
             }));
         };
 
-        let stats = TableCacheRefillStats::from(&*context.read());
+        let stats = TableCacheRefillStats::from(&*context_map.read());
         let json_value = serde_json::to_value(stats).map_err(|err| {
             Status::internal(format!(
                 "failed to serialize stats: {e}",
@@ -474,75 +473,45 @@ impl MonitorService for MonitorServiceImpl {
 }
 #[derive(Debug, serde::Serialize, serde::Deserialize)]
 struct TableCacheRefillStats {
-    streaming: HashMap<u32, Vec<u16>>,
-    serving: HashMap<u32, Vec<u16>>,
+    contexts: HashMap<u32, TableCacheRefillTableStats>,
     policies: HashMap<u32, String>,
-    default_policy: String,
-    internal: TableCacheRefillInternalStats,
 }
 
 #[derive(Debug, serde::Serialize, serde::Deserialize)]
-struct TableCacheRefillInternalStats {
-    streaming: HashMap<u32, Vec<Vec<u16>>>,
-    serving: HashMap<u32, Vec<u16>>,
+struct TableCacheRefillTableStats {
+    streaming: Option<Vec<u16>>,
+    serving: Option<Vec<u16>>,
+    policy: String,
 }
 
-impl From<&TableCacheRefillContext> for TableCacheRefillStats {
-    fn from(context: &TableCacheRefillContext) -> Self {
+impl From<&TableCacheRefillContextMap> for TableCacheRefillStats {
+    fn from(context_map: &TableCacheRefillContextMap) -> Self {
         fn bitmap_to_vnodes(bitmap: &risingwave_common::bitmap::Bitmap) -> Vec<u16> {
             bitmap.iter_ones().map(|idx| idx as u16).collect()
         }
 
-        let streaming = context
-            .streaming
+        let contexts: HashMap<_, _> = context_map
             .iter()
-            .map(|(table_id, bitmap)| (table_id.as_raw_id(), bitmap_to_vnodes(bitmap)))
-            .collect();
-
-        let serving = context
-            .serving
-            .iter()
-            .map(|(table_id, bitmap)| (table_id.as_raw_id(), bitmap_to_vnodes(bitmap)))
-            .collect();
-
-        let policies = context
-            .policies
-            .iter()
-            .map(|(table_id, policy)| (table_id.as_raw_id(), policy.to_string()))
-            .collect();
-
-        let read_version_mapping = context.read_version_mapping.read();
-        let internal_streaming = read_version_mapping
-            .iter()
-            .map(|(table_id, mappings)| {
-                let vnodes = mappings
-                    .iter()
-                    .sorted_by_key(|(version, _)| **version)
-                    .map(|(_, read_version)| {
-                        let vnodes = read_version.read().vnodes();
-                        bitmap_to_vnodes(vnodes.as_ref())
-                    })
-                    .collect();
-                (table_id.as_raw_id(), vnodes)
+            .map(|(table_id, context)| {
+                (
+                    table_id.as_raw_id(),
+                    TableCacheRefillTableStats {
+                        streaming: context
+                            .streaming_vnode_bitmap
+                            .as_ref()
+                            .map(bitmap_to_vnodes),
+                        serving: context.serving_vnode_bitmap.as_ref().map(bitmap_to_vnodes),
+                        policy: context.policy.to_string(),
+                    },
+                )
             })
             .collect();
-
-        let internal_serving = context
-            .serving_table_vnode_mapping
+        let policies = contexts
             .iter()
-            .map(|(table_id, bitmap)| (table_id.as_raw_id(), bitmap_to_vnodes(bitmap)))
+            .map(|(table_id, context)| (*table_id, context.policy.clone()))
             .collect();
 
-        Self {
-            streaming,
-            serving,
-            policies,
-            default_policy: context.default_policy.to_string(),
-            internal: TableCacheRefillInternalStats {
-                streaming: internal_streaming,
-                serving: internal_serving,
-            },
-        }
+        Self { contexts, policies }
     }
 }
 

--- a/src/compute/src/rpc/service/monitor_service.rs
+++ b/src/compute/src/rpc/service/monitor_service.rs
@@ -13,13 +13,12 @@
 // limitations under the License.
 
 use std::collections::{BTreeMap, HashMap, HashSet};
-use std::sync::Arc;
 use std::time::Duration;
 
 use foyer::{HybridCache, TracingOptions};
-use parking_lot::RwLock;
 use prometheus::core::Collector;
 use prometheus::proto::Metric;
+use risingwave_common::bitmap::Bitmap;
 use risingwave_common::config::{MetricLevel, ServerConfig};
 use risingwave_common_heap_profiling::ProfileServiceImpl;
 use risingwave_hummock_sdk::HummockSstableObjectId;
@@ -35,7 +34,10 @@ use risingwave_pb::monitor_service::{
     TieredCacheTracingRequest, TieredCacheTracingResponse,
 };
 use risingwave_storage::hummock::compactor::await_tree_key::Compaction;
-use risingwave_storage::hummock::event_handler::refiller::TableCacheRefillContextMap;
+use risingwave_storage::hummock::event_handler::refiller::{
+    TableCacheRefillContext, TableCacheRefillMonitorSnapshot,
+};
+use risingwave_storage::hummock::store::HummockStorage;
 use risingwave_storage::hummock::{Block, Sstable, SstableBlockIndex};
 use risingwave_stream::executor::monitor::global_streaming_metrics;
 use risingwave_stream::task::LocalStreamManager;
@@ -52,7 +54,7 @@ pub struct MonitorServiceImpl {
     profile_service: ProfileServiceImpl,
     meta_cache: Option<MetaCache>,
     block_cache: Option<BlockCache>,
-    table_cache_refill_context_map: Option<Arc<RwLock<TableCacheRefillContextMap>>>,
+    hummock_storage: Option<HummockStorage>,
 }
 
 impl MonitorServiceImpl {
@@ -61,14 +63,14 @@ impl MonitorServiceImpl {
         server_config: ServerConfig,
         meta_cache: Option<MetaCache>,
         block_cache: Option<BlockCache>,
-        table_cache_refill_context_map: Option<Arc<RwLock<TableCacheRefillContextMap>>>,
+        hummock_storage: Option<HummockStorage>,
     ) -> Self {
         Self {
             stream_mgr,
             profile_service: ProfileServiceImpl::new(server_config),
             meta_cache,
             block_cache,
-            table_cache_refill_context_map,
+            hummock_storage,
         }
     }
 }
@@ -447,13 +449,22 @@ impl MonitorService for MonitorServiceImpl {
         &self,
         _request: Request<GetTableCacheRefillStatsRequest>,
     ) -> Result<Response<GetTableCacheRefillStatsResponse>, Status> {
-        let Some(context_map) = &self.table_cache_refill_context_map else {
+        let Some(hummock_storage) = &self.hummock_storage else {
             return Ok(Response::new(GetTableCacheRefillStatsResponse {
                 stats: "{}".to_owned(),
             }));
         };
 
-        let stats = TableCacheRefillStats::from(&*context_map.read());
+        let monitor_snapshot = hummock_storage
+            .table_cache_refill_monitor_snapshot()
+            .await
+            .map_err(|err| {
+                Status::internal(format!(
+                    "failed to get table cache refill monitor snapshot: {e}",
+                    e = err.as_report()
+                ))
+            })?;
+        let stats = TableCacheRefillStats::from(&monitor_snapshot);
         let json_value = serde_json::to_value(stats).map_err(|err| {
             Status::internal(format!(
                 "failed to serialize stats: {e}",
@@ -471,10 +482,15 @@ impl MonitorService for MonitorServiceImpl {
         }))
     }
 }
+
 #[derive(Debug, serde::Serialize, serde::Deserialize)]
 struct TableCacheRefillStats {
     contexts: HashMap<u32, TableCacheRefillTableStats>,
+    streaming: HashMap<u32, Vec<u16>>,
+    serving: HashMap<u32, Vec<u16>>,
     policies: HashMap<u32, String>,
+    default_policy: String,
+    internal: TableCacheRefillInternalStats,
 }
 
 #[derive(Debug, serde::Serialize, serde::Deserialize)]
@@ -484,35 +500,89 @@ struct TableCacheRefillTableStats {
     policy: String,
 }
 
-impl From<&TableCacheRefillContextMap> for TableCacheRefillStats {
-    fn from(context_map: &TableCacheRefillContextMap) -> Self {
-        fn bitmap_to_vnodes(bitmap: &risingwave_common::bitmap::Bitmap) -> Vec<u16> {
-            bitmap.iter_ones().map(|idx| idx as u16).collect()
-        }
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
+struct TableCacheRefillInternalStats {
+    streaming: HashMap<u32, Vec<Vec<u16>>>,
+    serving: HashMap<u32, Vec<u16>>,
+}
 
-        let contexts: HashMap<_, _> = context_map
+impl From<&TableCacheRefillMonitorSnapshot> for TableCacheRefillStats {
+    fn from(snapshot: &TableCacheRefillMonitorSnapshot) -> Self {
+        let contexts = snapshot
+            .contexts
             .iter()
             .map(|(table_id, context)| {
                 (
                     table_id.as_raw_id(),
-                    TableCacheRefillTableStats {
-                        streaming: context
-                            .streaming_vnode_bitmap
-                            .as_ref()
-                            .map(bitmap_to_vnodes),
-                        serving: context.serving_vnode_bitmap.as_ref().map(bitmap_to_vnodes),
-                        policy: context.policy.to_string(),
-                    },
+                    TableCacheRefillTableStats::from(context.clone()),
                 )
             })
-            .collect();
-        let policies = contexts
+            .collect::<HashMap<_, _>>();
+        let streaming = contexts
             .iter()
-            .map(|(table_id, context)| (*table_id, context.policy.clone()))
+            .filter_map(|(table_id, context)| {
+                context
+                    .streaming
+                    .as_ref()
+                    .map(|vnodes| (*table_id, vnodes.clone()))
+            })
+            .collect();
+        let serving = contexts
+            .iter()
+            .filter_map(|(table_id, context)| {
+                context
+                    .serving
+                    .as_ref()
+                    .map(|vnodes| (*table_id, vnodes.clone()))
+            })
+            .collect();
+        let policies = snapshot
+            .policies
+            .iter()
+            .map(|(table_id, policy)| (table_id.as_raw_id(), policy.to_string()))
+            .collect();
+        let internal_streaming = snapshot
+            .streaming_table_vnode_mapping
+            .iter()
+            // Keep the historical list-of-lists JSON shape. The refiller stores one
+            // table-level union bitmap per table.
+            .map(|(table_id, bitmap)| (table_id.as_raw_id(), vec![bitmap_to_vnodes(bitmap)]))
+            .collect();
+        let internal_serving = snapshot
+            .serving_table_vnode_mapping
+            .iter()
+            .map(|(table_id, bitmap)| (table_id.as_raw_id(), bitmap_to_vnodes(bitmap)))
             .collect();
 
-        Self { contexts, policies }
+        Self {
+            contexts,
+            streaming,
+            serving,
+            policies,
+            default_policy: snapshot.default_policy.to_string(),
+            internal: TableCacheRefillInternalStats {
+                streaming: internal_streaming,
+                serving: internal_serving,
+            },
+        }
     }
+}
+
+impl From<TableCacheRefillContext> for TableCacheRefillTableStats {
+    fn from(context: TableCacheRefillContext) -> Self {
+        Self {
+            streaming: context
+                .streaming_vnode_bitmap
+                .as_ref()
+                .map(bitmap_to_vnodes),
+            serving: context.serving_vnode_bitmap.as_ref().map(bitmap_to_vnodes),
+            policy: context.policy.to_string(),
+        }
+    }
+}
+
+fn bitmap_to_vnodes(bitmap: &Bitmap) -> Vec<u16> {
+    bitmap.iter_ones().map(|idx| idx as u16).collect()
 }
 
 pub use grpc_middleware::*;

--- a/src/compute/src/server.rs
+++ b/src/compute/src/server.rs
@@ -419,22 +419,22 @@ pub async fn compute_node_serve(
     let stream_exchange_srv =
         StreamExchangeServiceImpl::new(stream_mgr.clone(), stream_exchange_srv_metrics);
     let stream_srv = StreamServiceImpl::new(stream_mgr.clone(), stream_env.clone());
-    let (meta_cache, block_cache, table_cache_refill_context_map) =
-        if let Some(hummock) = state_store.as_hummock() {
-            (
-                Some(hummock.sstable_store().meta_cache().clone()),
-                Some(hummock.sstable_store().block_cache().clone()),
-                Some(hummock.table_cache_refill_context_map().clone()),
-            )
-        } else {
-            (None, None, None)
-        };
+    let (meta_cache, block_cache, hummock_storage) = if let Some(hummock) = state_store.as_hummock()
+    {
+        (
+            Some(hummock.sstable_store().meta_cache().clone()),
+            Some(hummock.sstable_store().block_cache().clone()),
+            Some(hummock.clone()),
+        )
+    } else {
+        (None, None, None)
+    };
     let monitor_srv = MonitorServiceImpl::new(
         stream_mgr.clone(),
         config.server.clone(),
         meta_cache.clone(),
         block_cache.clone(),
-        table_cache_refill_context_map,
+        hummock_storage,
     );
     let config_srv = ConfigServiceImpl::new(batch_mgr, stream_mgr.clone(), meta_cache, block_cache);
     let health_srv = HealthServiceImpl::new();

--- a/src/compute/src/server.rs
+++ b/src/compute/src/server.rs
@@ -419,12 +419,12 @@ pub async fn compute_node_serve(
     let stream_exchange_srv =
         StreamExchangeServiceImpl::new(stream_mgr.clone(), stream_exchange_srv_metrics);
     let stream_srv = StreamServiceImpl::new(stream_mgr.clone(), stream_env.clone());
-    let (meta_cache, block_cache, table_cache_refill_context) =
+    let (meta_cache, block_cache, table_cache_refill_context_map) =
         if let Some(hummock) = state_store.as_hummock() {
             (
                 Some(hummock.sstable_store().meta_cache().clone()),
                 Some(hummock.sstable_store().block_cache().clone()),
-                Some(hummock.table_cache_refill_context().clone()),
+                Some(hummock.table_cache_refill_context_map().clone()),
             )
         } else {
             (None, None, None)
@@ -434,7 +434,7 @@ pub async fn compute_node_serve(
         config.server.clone(),
         meta_cache.clone(),
         block_cache.clone(),
-        table_cache_refill_context,
+        table_cache_refill_context_map,
     );
     let config_srv = ConfigServiceImpl::new(batch_mgr, stream_mgr.clone(), meta_cache, block_cache);
     let health_srv = HealthServiceImpl::new();

--- a/src/storage/src/hummock/event_handler/hummock_event_handler.rs
+++ b/src/storage/src/hummock/event_handler/hummock_event_handler.rs
@@ -46,9 +46,9 @@ use super::refiller::{CacheRefillConfig, CacheRefiller};
 use super::{LocalInstanceGuard, LocalInstanceId, ReadVersionMappingType};
 use crate::compaction_catalog_manager::CompactionCatalogManagerRef;
 use crate::hummock::compactor::{CompactorContext, await_tree_key, compact};
-use crate::hummock::event_handler::refiller::{
-    CacheRefillerEvent, SpawnRefillTask, TableCacheRefillContextMap,
-};
+#[cfg(test)]
+use crate::hummock::event_handler::refiller::TableCacheRefillContextMap;
+use crate::hummock::event_handler::refiller::{CacheRefillerEvent, SpawnRefillTask};
 use crate::hummock::event_handler::uploader::{
     HummockUploader, SpawnUploadTask, SyncedData, UploadTaskOutput,
 };
@@ -564,6 +564,7 @@ impl HummockEventHandler {
         self.uploader.buffer_tracker()
     }
 
+    #[cfg(test)]
     pub(crate) fn table_cache_refill_context_map(
         &self,
     ) -> &Arc<RwLock<TableCacheRefillContextMap>> {
@@ -1052,6 +1053,13 @@ impl HummockEventHandler {
                     .send(self.uploader.min_uncommitted_object_id())
                     .inspect_err(|e| {
                         error!("unable to send get_min_uncommitted_sst_id result: {:?}", e);
+                    });
+            }
+            HummockEvent::GetTableCacheRefillMonitorSnapshot { result_tx } => {
+                let _ = result_tx
+                    .send(self.refiller.table_cache_refill_monitor_snapshot())
+                    .inspect_err(|_| {
+                        error!("unable to send table cache refill monitor snapshot result");
                     });
             }
             HummockEvent::RegisterVectorWriter {

--- a/src/storage/src/hummock/event_handler/hummock_event_handler.rs
+++ b/src/storage/src/hummock/event_handler/hummock_event_handler.rs
@@ -47,7 +47,7 @@ use super::{LocalInstanceGuard, LocalInstanceId, ReadVersionMappingType};
 use crate::compaction_catalog_manager::CompactionCatalogManagerRef;
 use crate::hummock::compactor::{CompactorContext, await_tree_key, compact};
 use crate::hummock::event_handler::refiller::{
-    CacheRefillerEvent, SpawnRefillTask, TableCacheRefillContext,
+    CacheRefillerEvent, SpawnRefillTask, TableCacheRefillContextMap,
 };
 use crate::hummock::event_handler::uploader::{
     HummockUploader, SpawnUploadTask, SyncedData, UploadTaskOutput,
@@ -240,6 +240,100 @@ fn serving_table_vnode_mappings_to_map(
         .collect()
 }
 
+#[derive(Default)]
+struct LocalReadVersions {
+    by_instance: HashMap<LocalInstanceId, (TableId, HummockReadVersionRef)>,
+    by_table: HashMap<TableId, HashMap<LocalInstanceId, HummockReadVersionRef>>,
+}
+
+impl LocalReadVersions {
+    fn insert(
+        &mut self,
+        instance_id: LocalInstanceId,
+        table_id: TableId,
+        read_version: HummockReadVersionRef,
+    ) {
+        assert!(
+            !self.by_instance.contains_key(&instance_id),
+            "duplicated local read version instance_id {}",
+            instance_id
+        );
+        assert!(
+            !self
+                .by_table
+                .get(&table_id)
+                .is_some_and(|read_versions| read_versions.contains_key(&instance_id)),
+            "duplicated local read version table_id {} instance_id {}",
+            table_id,
+            instance_id
+        );
+        self.by_instance
+            .insert(instance_id, (table_id, read_version.clone()));
+        self.by_table
+            .entry(table_id)
+            .or_default()
+            .insert(instance_id, read_version);
+    }
+
+    fn remove(&mut self, instance_id: LocalInstanceId) -> (TableId, HummockReadVersionRef) {
+        let (table_id, read_version) = self.by_instance.remove(&instance_id).unwrap_or_else(|| {
+            panic!(
+                "DestroyHummockInstance nonexistent instance instance_id {}",
+                instance_id
+            )
+        });
+        let table_read_versions = self.by_table.get_mut(&table_id).unwrap_or_else(|| {
+            panic!(
+                "DestroyHummockInstance table_id {} instance_id {} fail in local mapping",
+                table_id, instance_id
+            )
+        });
+        let removed = table_read_versions.remove(&instance_id).unwrap_or_else(|| {
+            panic!(
+                "DestroyHummockInstance nonexistent instance in local mapping table_id {} instance_id {}",
+                table_id, instance_id
+            )
+        });
+        debug_assert!(Arc::ptr_eq(&read_version, &removed));
+        if table_read_versions.is_empty() {
+            self.by_table.remove(&table_id);
+        }
+        (table_id, read_version)
+    }
+
+    fn get(&self, instance_id: &LocalInstanceId) -> Option<&(TableId, HummockReadVersionRef)> {
+        self.by_instance.get(instance_id)
+    }
+
+    fn contains_instance(&self, instance_id: &LocalInstanceId) -> bool {
+        self.by_instance.contains_key(instance_id)
+    }
+
+    fn instance_ids(&self) -> impl Iterator<Item = LocalInstanceId> + '_ {
+        self.by_instance.keys().copied()
+    }
+
+    fn is_empty(&self) -> bool {
+        self.by_instance.is_empty() && self.by_table.is_empty()
+    }
+
+    fn table_ids(&self) -> impl Iterator<Item = TableId> + '_ {
+        self.by_table.keys().copied()
+    }
+
+    fn table_vnodes(&self, table_id: TableId) -> Option<Bitmap> {
+        let read_versions = self.by_table.get(&table_id)?;
+        let mut vnodes = None;
+        for read_version in read_versions.values() {
+            let read_version_vnodes = read_version.read().vnodes();
+            let current_vnodes =
+                vnodes.get_or_insert_with(|| Bitmap::zeros(read_version_vnodes.as_ref().len()));
+            *current_vnodes |= read_version_vnodes.as_ref();
+        }
+        vnodes
+    }
+}
+
 pub(crate) struct HummockEventHandler {
     hummock_event_tx: HummockEventSender,
     hummock_event_rx: HummockEventReceiver,
@@ -247,7 +341,7 @@ pub(crate) struct HummockEventHandler {
     pending_observer_events: VecDeque<HummockObserverEvent>,
     read_version_mapping: Arc<RwLock<ReadVersionMappingType>>,
     /// A copy of `read_version_mapping` but owned by event handler
-    local_read_version_mapping: HashMap<LocalInstanceId, (TableId, HummockReadVersionRef)>,
+    local_read_versions: LocalReadVersions,
 
     version_update_notifier_tx: Arc<tokio::sync::watch::Sender<PinnedVersion>>,
     recent_versions: Arc<ArcSwap<RecentVersions>>,
@@ -413,13 +507,8 @@ impl HummockEventHandler {
             spawn_upload_task,
             buffer_tracker,
         );
-        let mut refiller = CacheRefiller::new(
-            role,
-            refill_config,
-            sstable_store,
-            spawn_refill_task,
-            read_version_mapping.clone(),
-        );
+        let mut refiller =
+            CacheRefiller::new(role, refill_config, sstable_store, spawn_refill_task);
         let mut pending_observer_events = VecDeque::new();
         while let Ok(event) = observer_event_rx.try_recv() {
             pending_observer_events.push_back(event);
@@ -447,7 +536,7 @@ impl HummockEventHandler {
             version_update_notifier_tx,
             recent_versions: Arc::new(ArcSwap::from_pointee(recent_versions)),
             read_version_mapping,
-            local_read_version_mapping: Default::default(),
+            local_read_versions: Default::default(),
             uploader,
             refiller,
             last_instance_id: 0,
@@ -475,15 +564,17 @@ impl HummockEventHandler {
         self.uploader.buffer_tracker()
     }
 
-    pub(crate) fn table_cache_refill_context(&self) -> &Arc<RwLock<TableCacheRefillContext>> {
-        self.refiller.table_cache_refill_context()
+    pub(crate) fn table_cache_refill_context_map(
+        &self,
+    ) -> &Arc<RwLock<TableCacheRefillContextMap>> {
+        self.refiller.table_cache_refill_context_map()
     }
 }
 
 // Handler for different events
 impl HummockEventHandler {
-    /// This function will be performed under the protection of the `read_version_mapping` read
-    /// lock, and add write lock on each `read_version` operation
+    /// Applies the function to local read versions selected by instance ids.
+    /// Each read version is protected by its own write lock.
     fn for_each_read_version(
         &self,
         instances: impl IntoIterator<Item = LocalInstanceId>,
@@ -507,7 +598,7 @@ impl HummockEventHandler {
         let mut pending = VecDeque::new();
         let mut total_count = 0;
         for instance_id in instances {
-            let Some((_, read_version)) = self.local_read_version_mapping.get(&instance_id) else {
+            let Some((_, read_version)) = self.local_read_versions.get(&instance_id) else {
                 continue;
             };
             total_count += 1;
@@ -539,7 +630,7 @@ impl HummockEventHandler {
 
         while let Some(instance_id) = pending.pop_front() {
             let (_, read_version) = self
-                .local_read_version_mapping
+                .local_read_versions
                 .get(&instance_id)
                 .expect("have checked exist before");
             match read_version.try_write_for(TRY_LOCK_TIMEOUT) {
@@ -615,12 +706,9 @@ impl HummockEventHandler {
 
         if table_ids.is_none() {
             assert!(
-                self.local_read_version_mapping.is_empty(),
+                self.local_read_versions.is_empty(),
                 "read version mapping not empty when clear. remaining tables: {:?}",
-                self.local_read_version_mapping
-                    .values()
-                    .map(|(_, read_version)| read_version.read().table_id())
-                    .collect_vec()
+                self.local_read_versions.table_ids().collect_vec()
             );
         }
 
@@ -641,6 +729,10 @@ impl HummockEventHandler {
                 Self::apply_table_refill_runtime_config(&mut self.refiller, operation, config);
             }
         }
+    }
+
+    fn streaming_table_vnodes(&self, table_id: TableId) -> Option<Bitmap> {
+        self.local_read_versions.table_vnodes(table_id)
     }
 
     fn handle_version_update(&mut self, version_payload: HummockVersionUpdate) {
@@ -737,7 +829,7 @@ impl HummockEventHandler {
 
         {
             self.for_each_read_version(
-                self.local_read_version_mapping.keys().cloned(),
+                self.local_read_versions.instance_ids(),
                 |_, read_version| {
                     for CacheRefillerEvent {
                         new_pinned_version, ..
@@ -847,7 +939,7 @@ impl HummockEventHandler {
                 init_epoch,
             } => {
                 let table_id = self
-                    .local_read_version_mapping
+                    .local_read_versions
                     .get(&instance_id)
                     .expect("should exist")
                     .0;
@@ -856,7 +948,7 @@ impl HummockEventHandler {
             }
             HummockEvent::ImmToUploader { instance_id, imms } => {
                 assert!(
-                    self.local_read_version_mapping.contains_key(&instance_id),
+                    self.local_read_versions.contains_instance(&instance_id),
                     "add imm from non-existing read version instance: instance_id: {}, table_id {:?}",
                     instance_id,
                     imms.first().map(|(imm, _)| imm.table_id),
@@ -906,8 +998,11 @@ impl HummockEventHandler {
                 );
 
                 {
-                    self.local_read_version_mapping
-                        .insert(instance_id, (table_id, basic_read_version.clone()));
+                    self.local_read_versions.insert(
+                        instance_id,
+                        table_id,
+                        basic_read_version.clone(),
+                    );
                     let mut read_version_mapping_guard = self.read_version_mapping.write();
 
                     read_version_mapping_guard
@@ -935,18 +1030,22 @@ impl HummockEventHandler {
                     }
                 }
 
-                self.refiller.update_table_cache_refill_vnodes(table_id);
+                self.refiller
+                    .update_streaming_table_vnodes(table_id, self.streaming_table_vnodes(table_id));
             }
 
             HummockEvent::DestroyReadVersion { instance_id } => {
                 let table_id = self
-                    .local_read_version_mapping
+                    .local_read_versions
                     .get(&instance_id)
-                    .unwrap_or_else(|| panic!("query inexist instance instance_id {instance_id}"))
+                    .unwrap_or_else(|| {
+                        panic!("query nonexistent instance instance_id {instance_id}")
+                    })
                     .0;
                 self.uploader.may_destroy_instance(instance_id);
                 self.destroy_read_version(instance_id);
-                self.refiller.update_table_cache_refill_vnodes(table_id);
+                self.refiller
+                    .update_streaming_table_vnodes(table_id, self.streaming_table_vnodes(table_id));
             }
             HummockEvent::GetMinUncommittedObjectId { result_tx } => {
                 let _ = result_tx
@@ -977,15 +1076,7 @@ impl HummockEventHandler {
         {
             {
                 debug!("read version deregister: instance_id: {}", instance_id);
-                let (table_id, _) = self
-                    .local_read_version_mapping
-                    .remove(&instance_id)
-                    .unwrap_or_else(|| {
-                        panic!(
-                            "DestroyHummockInstance inexist instance instance_id {}",
-                            instance_id
-                        )
-                    });
+                let (table_id, _) = self.local_read_versions.remove(instance_id);
                 let mut read_version_mapping_guard = self.read_version_mapping.write();
                 let entry = read_version_mapping_guard
                     .get_mut(&table_id)
@@ -997,7 +1088,7 @@ impl HummockEventHandler {
                     });
                 entry.remove(&instance_id).unwrap_or_else(|| {
                     panic!(
-                        "DestroyHummockInstance inexist instance table_id {} instance_id {}",
+                        "DestroyHummockInstance nonexistent instance table_id {} instance_id {}",
                         table_id, instance_id
                     )
                 });
@@ -1091,11 +1182,12 @@ mod tests {
     };
     use crate::hummock::event_handler::{
         HummockEvent, HummockEventHandler, HummockObserverEvent, HummockReadVersionRef,
-        LocalInstanceGuard,
+        LocalInstanceGuard, LocalInstanceId,
     };
     use crate::hummock::iterator::test_utils::mock_sstable_store;
     use crate::hummock::local_version::pinned_version::PinnedVersion;
     use crate::hummock::local_version::recent_versions::RecentVersions;
+    use crate::hummock::store::version::HummockReadVersion;
     use crate::hummock::test_utils::default_opts_for_test;
     use crate::mem_table::ImmutableMemtable;
     use crate::monitor::HummockStateStoreMetrics;
@@ -1151,7 +1243,6 @@ mod tests {
             CacheRefillConfig::from_storage_opts(&storage_opt),
             mock_sstable_store().await,
             CacheRefiller::default_spawn_refill_task(),
-            Arc::new(RwLock::new(HashMap::new())),
         )
     }
 
@@ -1230,12 +1321,10 @@ mod tests {
             CacheRefiller::default_spawn_refill_task(),
         );
 
-        let context = event_handler.table_cache_refill_context().read();
-        assert_eq!(
-            context.policies.get(&table_id),
-            Some(&CacheRefillPolicy::Serving)
-        );
-        assert_eq!(context.serving.get(&table_id), Some(&serving_vnodes));
+        let context_map = event_handler.table_cache_refill_context_map().read();
+        let context = context_map.get(&table_id).unwrap();
+        assert_eq!(context.policy, CacheRefillPolicy::Serving);
+        assert_eq!(context.serving_vnode_bitmap.as_ref(), Some(&serving_vnodes));
     }
 
     #[tokio::test]
@@ -1291,12 +1380,10 @@ mod tests {
             CacheRefiller::default_spawn_refill_task(),
         );
 
-        let context = event_handler.table_cache_refill_context().read();
-        assert_eq!(
-            context.policies.get(&table_id),
-            Some(&CacheRefillPolicy::Serving)
-        );
-        drop(context);
+        let context_map = event_handler.table_cache_refill_context_map().read();
+        let context = context_map.get(&table_id).unwrap();
+        assert_eq!(context.policy, CacheRefillPolicy::Serving);
+        drop(context_map);
         assert!(matches!(
             event_handler.pending_observer_events.front(),
             Some(HummockObserverEvent::VersionUpdate(_))
@@ -1344,17 +1431,91 @@ mod tests {
                 ..Default::default()
             },
         );
+        HummockEventHandler::apply_table_refill_runtime_config(
+            &mut refiller,
+            Operation::Update,
+            PbTableRefillRuntimeConfig {
+                table_cache_refill_policies: Some(TableCacheRefillPolicies {
+                    policies: vec![PbTableCacheRefillPolicy {
+                        table_id: table_id.as_raw_id(),
+                        policy: PbCacheRefillPolicy::Serving as i32,
+                    }],
+                }),
+                ..Default::default()
+            },
+        );
 
-        let context = refiller.table_cache_refill_context().read();
-        assert_eq!(
-            context.policies.get(&table_id),
-            Some(&CacheRefillPolicy::Disabled)
+        let context_map = refiller.table_cache_refill_context_map().read();
+        let context = context_map.get(&table_id).unwrap();
+        assert_eq!(context.policy, CacheRefillPolicy::Serving);
+        assert_eq!(context.serving_vnode_bitmap.as_ref(), Some(&serving_vnodes));
+    }
+
+    #[test]
+    fn test_local_read_versions_tracks_per_table_vnodes() {
+        fn read_version(
+            table_id: TableId,
+            instance_id: LocalInstanceId,
+            committed_version: &PinnedVersion,
+            vnode_range: std::ops::Range<usize>,
+        ) -> HummockReadVersionRef {
+            Arc::new(RwLock::new(HummockReadVersion::new(
+                table_id,
+                instance_id,
+                committed_version.clone(),
+                Arc::new(Bitmap::from_range(VirtualNode::COUNT_FOR_TEST, vnode_range)),
+            )))
+        }
+
+        fn assert_vnodes(vnodes: Bitmap, expected: std::ops::Range<usize>) {
+            assert_eq!(vnodes.count_ones(), expected.len());
+            for vnode in expected {
+                assert!(vnodes.is_set(vnode));
+            }
+        }
+
+        let table_id = TableId::new(233);
+        let other_table_id = TableId::new(234);
+        let committed_version = RecentVersions::new(
+            pinned_version_for_test(1),
+            10,
+            Arc::new(HummockStateStoreMetrics::unused()),
+        )
+        .latest_version()
+        .clone();
+        let read_version_1 = read_version(table_id, 1, &committed_version, 0..8);
+        let read_version_2 = read_version(table_id, 2, &committed_version, 8..16);
+        let other_read_version = read_version(other_table_id, 3, &committed_version, 32..40);
+
+        let mut local_read_versions = super::LocalReadVersions::default();
+        local_read_versions.insert(1, table_id, read_version_1.clone());
+        local_read_versions.insert(2, table_id, read_version_2);
+        local_read_versions.insert(3, other_table_id, other_read_version);
+
+        assert_vnodes(local_read_versions.table_vnodes(table_id).unwrap(), 0..16);
+        assert_vnodes(
+            local_read_versions.table_vnodes(other_table_id).unwrap(),
+            32..40,
         );
-        assert!(!context.serving.contains_key(&table_id));
-        assert_eq!(
-            context.serving_table_vnode_mapping.get(&table_id),
-            Some(&serving_vnodes)
-        );
+
+        read_version_1
+            .write()
+            .update_vnode_bitmap(Arc::new(Bitmap::from_range(
+                VirtualNode::COUNT_FOR_TEST,
+                16..24,
+            )));
+        assert_vnodes(local_read_versions.table_vnodes(table_id).unwrap(), 8..24);
+
+        let (removed_table_id, removed_read_version) = local_read_versions.remove(1);
+        assert_eq!(removed_table_id, table_id);
+        assert!(Arc::ptr_eq(&removed_read_version, &read_version_1));
+        assert_vnodes(local_read_versions.table_vnodes(table_id).unwrap(), 8..16);
+
+        local_read_versions.remove(2);
+        assert!(local_read_versions.table_vnodes(table_id).is_none());
+        assert!(!local_read_versions.is_empty());
+        local_read_versions.remove(3);
+        assert!(local_read_versions.is_empty());
     }
 
     #[tokio::test]

--- a/src/storage/src/hummock/event_handler/mod.rs
+++ b/src/storage/src/hummock/event_handler/mod.rs
@@ -40,6 +40,7 @@ use risingwave_pb::meta::subscribe_response::Operation;
 
 use super::store::version::HummockReadVersion;
 use crate::hummock::event_handler::hummock_event_handler::HummockEventSender;
+use crate::hummock::event_handler::refiller::TableCacheRefillMonitorSnapshot;
 use crate::hummock::event_handler::uploader::SyncedData;
 use crate::hummock::utils::MemoryTracker;
 
@@ -134,6 +135,10 @@ pub enum HummockEvent {
     GetMinUncommittedObjectId {
         result_tx: oneshot::Sender<Option<HummockRawObjectId>>,
     },
+
+    GetTableCacheRefillMonitorSnapshot {
+        result_tx: oneshot::Sender<TableCacheRefillMonitorSnapshot>,
+    },
 }
 
 impl HummockEvent {
@@ -201,6 +206,9 @@ impl HummockEvent {
             HummockEvent::GetMinUncommittedObjectId { .. } => {
                 "GetMinUncommittedObjectId".to_owned()
             }
+            HummockEvent::GetTableCacheRefillMonitorSnapshot { .. } => {
+                "GetTableCacheRefillMonitorSnapshot".to_owned()
+            }
             HummockEvent::RegisterVectorWriter { .. } => "RegisterVectorWriter".to_owned(),
             HummockEvent::VectorWriterSealEpoch { .. } => "VectorWriterSealEpoch".to_owned(),
             HummockEvent::DropVectorWriter { .. } => "DropVectorWriter".to_owned(),
@@ -225,6 +233,9 @@ impl HummockEvent {
             HummockEvent::VectorWriterSealEpoch { .. } => "VectorWriterSealEpoch",
             HummockEvent::DropVectorWriter { .. } => "DropVectorWriter",
             HummockEvent::GetMinUncommittedObjectId { .. } => "GetMinUncommittedObjectId",
+            HummockEvent::GetTableCacheRefillMonitorSnapshot { .. } => {
+                "GetTableCacheRefillMonitorSnapshot"
+            }
         }
     }
 }

--- a/src/storage/src/hummock/event_handler/refiller.rs
+++ b/src/storage/src/hummock/event_handler/refiller.rs
@@ -276,6 +276,18 @@ pub struct TableCacheRefillContext {
     pub policy: CacheRefillPolicy,
 }
 
+/// Read-only data cloned from `CacheRefiller` for monitor/debugging APIs.
+///
+/// Streaming vnode mapping is the table-level union maintained by the refiller.
+#[derive(Clone)]
+pub struct TableCacheRefillMonitorSnapshot {
+    pub contexts: TableCacheRefillContextMap,
+    pub policies: HashMap<TableId, CacheRefillPolicy>,
+    pub default_policy: CacheRefillPolicy,
+    pub streaming_table_vnode_mapping: HashMap<TableId, Bitmap>,
+    pub serving_table_vnode_mapping: HashMap<TableId, Bitmap>,
+}
+
 fn vnode_range_overlaps_bitmap(vnode_range: (usize, usize), bitmap: &Bitmap) -> bool {
     assert!(vnode_range.0 <= vnode_range.1);
     let start = vnode_range.0.min(bitmap.len());
@@ -555,10 +567,21 @@ impl CacheRefiller {
             .collect()
     }
 
+    #[cfg(test)]
     pub(crate) fn table_cache_refill_context_map(
         &self,
     ) -> &Arc<RwLock<TableCacheRefillContextMap>> {
         &self.table_cache_refill_context_map
+    }
+
+    pub(crate) fn table_cache_refill_monitor_snapshot(&self) -> TableCacheRefillMonitorSnapshot {
+        TableCacheRefillMonitorSnapshot {
+            contexts: self.table_cache_refill_context_map.read().clone(),
+            policies: self.table_cache_refill_policies.clone(),
+            default_policy: self.default_policy,
+            streaming_table_vnode_mapping: self.streaming_table_vnode_mapping.clone(),
+            serving_table_vnode_mapping: self.serving_table_vnode_mapping.clone(),
+        }
     }
 }
 

--- a/src/storage/src/hummock/event_handler/refiller.rs
+++ b/src/storage/src/hummock/event_handler/refiller.rs
@@ -25,7 +25,7 @@ use foyer::RangeBoundsExt;
 use futures::future::{join_all, try_join_all};
 use futures::{Future, FutureExt};
 use itertools::Itertools;
-use parking_lot::{RwLock, RwLockReadGuard, RwLockWriteGuard};
+use parking_lot::RwLock;
 use prometheus::core::{AtomicU64, GenericCounter, GenericCounterVec};
 use prometheus::{
     Histogram, HistogramVec, IntGauge, Registry, register_histogram_vec_with_registry,
@@ -44,7 +44,6 @@ use thiserror_ext::AsReport;
 use tokio::sync::Semaphore;
 use tokio::task::JoinHandle;
 
-use crate::hummock::event_handler::ReadVersionMappingType;
 use crate::hummock::local_version::pinned_version::PinnedVersion;
 use crate::hummock::{
     Block, HummockError, HummockResult, RecentFilterTrait, Sstable, SstableBlockIndex,
@@ -263,20 +262,31 @@ pub(crate) type SpawnRefillTask = Arc<
         + 'static,
 >;
 
-pub struct TableCacheRefillContext {
-    pub streaming: HashMap<TableId, Bitmap>,
-    pub serving: HashMap<TableId, Bitmap>,
-    pub policies: HashMap<TableId, CacheRefillPolicy>,
-    pub default_policy: CacheRefillPolicy,
+pub type TableCacheRefillContextMap = HashMap<TableId, TableCacheRefillContext>;
 
-    pub read_version_mapping: Arc<RwLock<ReadVersionMappingType>>,
-    pub serving_table_vnode_mapping: HashMap<TableId, Bitmap>,
+/// Per-table metadata captured for a refill task to decide whether an sstable block should be
+/// refilled. Mutable runtime state used to build this snapshot is owned by `CacheRefiller`.
+#[derive(Clone)]
+pub struct TableCacheRefillContext {
+    /// Vnodes covered by local streaming read versions on this compute node.
+    pub streaming_vnode_bitmap: Option<Bitmap>,
+    /// Vnodes served by this compute node according to the serving vnode mapping.
+    pub serving_vnode_bitmap: Option<Bitmap>,
+    /// Effective refill policy after applying the default policy and per-table overrides.
+    pub policy: CacheRefillPolicy,
 }
 
-fn vnode_range_bitmap(num_bits: usize, vnode_range: (usize, usize)) -> Bitmap {
-    let start = vnode_range.0.min(num_bits);
-    let end = vnode_range.1.min(num_bits);
-    Bitmap::from_range(num_bits, start..end)
+fn vnode_range_overlaps_bitmap(vnode_range: (usize, usize), bitmap: &Bitmap) -> bool {
+    assert!(vnode_range.0 <= vnode_range.1);
+    let start = vnode_range.0.min(bitmap.len());
+    let end = vnode_range.1.min(bitmap.len());
+    if start == end || !bitmap.any() {
+        return false;
+    }
+    if bitmap.all() {
+        return true;
+    }
+    (start..end).any(|vnode| bitmap.is_set(vnode))
 }
 
 impl TableCacheRefillContext {
@@ -297,31 +307,28 @@ impl TableCacheRefillContext {
         .to_vec()
         .into_bytes();
 
-        let table_id = block_smallest_key.user_key.table_id;
         let table_key_range = (
             Bound::Included(block_smallest_key.user_key.table_key),
             Bound::Excluded(block_largest_key.user_key.table_key),
         );
         let vnode_range = vnode_range(&table_key_range);
 
-        let streaming_bitmap = self.streaming.get(&table_id);
-        let serving_bitmap = self.serving.get(&table_id);
-
-        let num_bits = streaming_bitmap
+        let num_bits = self
+            .streaming_vnode_bitmap
+            .as_ref()
             .map(|b| b.len())
-            .or(serving_bitmap.map(|b| b.len()))
+            .or(self.serving_vnode_bitmap.as_ref().map(|b| b.len()))
             .unwrap_or(0);
         if num_bits == 0 {
             return false;
         }
-        let bitmap = vnode_range_bitmap(num_bits, vnode_range);
-        if let Some(streaming_bitmap) = streaming_bitmap
-            && (&bitmap & streaming_bitmap).any()
+        if let Some(streaming_bitmap) = &self.streaming_vnode_bitmap
+            && vnode_range_overlaps_bitmap(vnode_range, streaming_bitmap)
         {
             return true;
         }
-        if let Some(serving_bitmap) = serving_bitmap
-            && (&bitmap & serving_bitmap).any()
+        if let Some(serving_bitmap) = &self.serving_vnode_bitmap
+            && vnode_range_overlaps_bitmap(vnode_range, serving_bitmap)
         {
             return true;
         }
@@ -334,12 +341,19 @@ pub(crate) struct CacheRefiller {
     /// order: old => new
     queue: VecDeque<Item>,
 
-    context: CacheRefillContext,
-
     spawn_refill_task: SpawnRefillTask,
 
+    config: Arc<CacheRefillConfig>,
+    meta_refill_concurrency: Option<Arc<Semaphore>>,
+    concurrency: Arc<Semaphore>,
+    sstable_store: SstableStoreRef,
+
     role: Role,
-    table_cache_refill_context: Arc<RwLock<TableCacheRefillContext>>,
+    default_policy: CacheRefillPolicy,
+    table_cache_refill_policies: HashMap<TableId, CacheRefillPolicy>,
+    streaming_table_vnode_mapping: HashMap<TableId, Bitmap>,
+    serving_table_vnode_mapping: HashMap<TableId, Bitmap>,
+    table_cache_refill_context_map: Arc<RwLock<TableCacheRefillContextMap>>,
 }
 
 impl CacheRefiller {
@@ -348,18 +362,11 @@ impl CacheRefiller {
         config: CacheRefillConfig,
         sstable_store: SstableStoreRef,
         spawn_refill_task: SpawnRefillTask,
-        read_version_mapping: Arc<RwLock<ReadVersionMappingType>>,
     ) -> Self {
         let config = Arc::new(config);
         let concurrency = Arc::new(Semaphore::new(config.concurrency));
-        let table_cache_refill_context = Arc::new(RwLock::new(TableCacheRefillContext {
-            streaming: HashMap::new(),
-            serving: HashMap::new(),
-            policies: HashMap::new(),
-            default_policy: config.table_cache_refill_default_policy,
-            read_version_mapping,
-            serving_table_vnode_mapping: HashMap::new(),
-        }));
+        let table_cache_refill_context_map = Arc::new(RwLock::new(HashMap::new()));
+        let default_policy = config.table_cache_refill_default_policy;
         let meta_refill_concurrency = if config.meta_refill_concurrency == 0 {
             None
         } else {
@@ -367,16 +374,17 @@ impl CacheRefiller {
         };
         Self {
             queue: VecDeque::new(),
-            context: CacheRefillContext {
-                config,
-                meta_refill_concurrency,
-                concurrency,
-                sstable_store,
-                table_cache_refill_context: table_cache_refill_context.clone(),
-            },
             spawn_refill_task,
+            config,
+            meta_refill_concurrency,
+            concurrency,
+            sstable_store,
             role,
-            table_cache_refill_context,
+            default_policy,
+            table_cache_refill_policies: HashMap::new(),
+            streaming_table_vnode_mapping: HashMap::new(),
+            serving_table_vnode_mapping: HashMap::new(),
+            table_cache_refill_context_map,
         }
     }
 
@@ -393,9 +401,10 @@ impl CacheRefiller {
         pinned_version: PinnedVersion,
         new_pinned_version: PinnedVersion,
     ) {
+        let context = self.new_cache_refill_context(&deltas);
         let handle = (self.spawn_refill_task)(
             deltas,
-            self.context.clone(),
+            context,
             pinned_version.clone(),
             new_pinned_version.clone(),
         );
@@ -408,92 +417,148 @@ impl CacheRefiller {
         GLOBAL_CACHE_REFILL_METRICS.refill_queue_total.add(1);
     }
 
+    fn new_cache_refill_context(&self, deltas: &[SstDeltaInfo]) -> CacheRefillContext {
+        let table_ids = Self::table_ids_in_deltas(deltas);
+        CacheRefillContext {
+            config: self.config.clone(),
+            meta_refill_concurrency: self.meta_refill_concurrency.clone(),
+            concurrency: self.concurrency.clone(),
+            sstable_store: self.sstable_store.clone(),
+            table_cache_refill_context_map: Arc::new(
+                self.get_table_cache_refill_context_map(&table_ids),
+            ),
+        }
+    }
+
     pub(crate) fn last_new_pinned_version(&self) -> Option<&PinnedVersion> {
         self.queue.back().map(|item| &item.event.new_pinned_version)
     }
 
+    /// Replaces the complete explicit table refill policy map and rebuilds affected tables.
     pub(crate) fn replace_table_cache_refill_policies(
         &mut self,
         policies: HashMap<TableId, CacheRefillPolicy>,
     ) {
-        let mut table_cache_refill_context = self.table_cache_refill_context.write();
-        let table_ids = table_cache_refill_context
-            .policies
+        let table_ids = self
+            .table_cache_refill_policies
             .keys()
             .chain(policies.keys())
             .copied()
             .collect::<HashSet<_>>();
-        table_cache_refill_context.policies = policies;
-        for table_id in table_ids {
-            self.update_table_cache_refill_vnodes_inner(&mut table_cache_refill_context, table_id);
-        }
+        self.table_cache_refill_policies = policies;
+        self.rebuild_table_cache_refill_contexts(table_ids);
     }
 
+    /// Replaces the complete serving vnode mapping snapshot and rebuilds affected tables.
     pub(crate) fn replace_serving_table_vnode_mapping(
         &mut self,
         mapping: HashMap<TableId, Bitmap>,
     ) {
-        let mut table_cache_refill_context = self.table_cache_refill_context.write();
-        let mut table_ids = table_cache_refill_context
+        let table_ids = self
             .serving_table_vnode_mapping
             .keys()
             .chain(mapping.keys())
             .copied()
             .collect::<HashSet<_>>();
-        table_cache_refill_context.serving_table_vnode_mapping = mapping;
-        for table_id in table_ids.drain() {
-            self.update_table_cache_refill_vnodes_inner(&mut table_cache_refill_context, table_id);
+        self.serving_table_vnode_mapping = mapping;
+        self.rebuild_table_cache_refill_contexts(table_ids);
+    }
+
+    pub(crate) fn update_streaming_table_vnodes(
+        &mut self,
+        table_id: TableId,
+        streaming_vnodes: Option<Bitmap>,
+    ) {
+        if let Some(streaming_vnodes) = streaming_vnodes {
+            self.streaming_table_vnode_mapping
+                .insert(table_id, streaming_vnodes);
+        } else {
+            self.streaming_table_vnode_mapping.remove(&table_id);
+        }
+        self.rebuild_table_cache_refill_contexts([table_id]);
+    }
+
+    fn rebuild_table_cache_refill_contexts(&self, table_ids: impl IntoIterator<Item = TableId>) {
+        let mut table_cache_refill_context_map = self.table_cache_refill_context_map.write();
+        for table_id in table_ids {
+            self.rebuild_table_cache_refill_context(&mut table_cache_refill_context_map, table_id);
         }
     }
 
-    fn update_table_cache_refill_vnodes_inner(
+    fn rebuild_table_cache_refill_context(
         &self,
-        table_cache_refill_context: &mut RwLockWriteGuard<'_, TableCacheRefillContext>,
+        table_cache_refill_context_map: &mut TableCacheRefillContextMap,
         table_id: TableId,
     ) {
-        tracing::debug!(?table_id, "update table cache refill vnodes for table");
+        tracing::debug!(?table_id, "rebuild table cache refill context for table");
 
-        let policy = table_cache_refill_context
-            .policies
+        let policy = self
+            .table_cache_refill_policies
             .get(&table_id)
             .copied()
-            .unwrap_or(table_cache_refill_context.default_policy);
+            .unwrap_or(self.default_policy);
 
-        table_cache_refill_context.streaming.remove(&table_id);
-        table_cache_refill_context.serving.remove(&table_id);
+        let streaming_vnode_bitmap = (self.role.for_streaming() && policy.for_streaming())
+            .then(|| self.streaming_table_vnode_mapping.get(&table_id).cloned())
+            .flatten();
+        let serving_vnode_bitmap = (self.role.for_serving() && policy.for_serving())
+            .then(|| self.serving_table_vnode_mapping.get(&table_id).cloned())
+            .flatten();
 
-        if self.role.for_streaming() && policy.for_streaming() {
-            let read_version_mapping = table_cache_refill_context.read_version_mapping.clone();
-            if let Some(mapping) = read_version_mapping.read().get(&table_id) {
-                for read_version in mapping.values() {
-                    let vnodes = read_version.read().vnodes();
-                    table_cache_refill_context
-                        .streaming
-                        .entry(table_id)
-                        .and_modify(|bitmap| *bitmap |= vnodes.as_ref())
-                        .or_insert_with(|| vnodes.as_ref().clone());
-                }
-            }
-        }
-
-        if self.role.for_serving()
-            && policy.for_serving()
-            && let Some(vnodes) = table_cache_refill_context
-                .serving_table_vnode_mapping
-                .get(&table_id)
-                .cloned()
+        if self.table_cache_refill_policies.contains_key(&table_id)
+            || streaming_vnode_bitmap.is_some()
+            || serving_vnode_bitmap.is_some()
         {
-            table_cache_refill_context.serving.insert(table_id, vnodes);
+            table_cache_refill_context_map.insert(
+                table_id,
+                TableCacheRefillContext {
+                    streaming_vnode_bitmap,
+                    serving_vnode_bitmap,
+                    policy,
+                },
+            );
+        } else {
+            table_cache_refill_context_map.remove(&table_id);
         }
     }
 
-    pub(crate) fn update_table_cache_refill_vnodes(&self, table_id: TableId) {
-        let mut table_cache_refill_context = self.table_cache_refill_context.write();
-        self.update_table_cache_refill_vnodes_inner(&mut table_cache_refill_context, table_id);
+    fn table_ids_in_deltas(deltas: &[SstDeltaInfo]) -> HashSet<TableId> {
+        deltas
+            .iter()
+            .flat_map(|delta| {
+                delta
+                    .insert_sst_infos
+                    .iter()
+                    .flat_map(|sst| sst.table_ids.iter().copied())
+            })
+            .collect()
     }
 
-    pub(crate) fn table_cache_refill_context(&self) -> &Arc<RwLock<TableCacheRefillContext>> {
-        &self.context.table_cache_refill_context
+    fn get_table_cache_refill_context_map(
+        &self,
+        table_ids: &HashSet<TableId>,
+    ) -> TableCacheRefillContextMap {
+        let table_cache_refill_context_map = self.table_cache_refill_context_map.read();
+        table_ids
+            .iter()
+            .map(|table_id| {
+                let context = table_cache_refill_context_map
+                    .get(table_id)
+                    .cloned()
+                    .unwrap_or(TableCacheRefillContext {
+                        streaming_vnode_bitmap: None,
+                        serving_vnode_bitmap: None,
+                        policy: self.default_policy,
+                    });
+                (*table_id, context)
+            })
+            .collect()
+    }
+
+    pub(crate) fn table_cache_refill_context_map(
+        &self,
+    ) -> &Arc<RwLock<TableCacheRefillContextMap>> {
+        &self.table_cache_refill_context_map
     }
 }
 
@@ -534,7 +599,7 @@ pub(crate) struct CacheRefillContext {
     meta_refill_concurrency: Option<Arc<Semaphore>>,
     concurrency: Arc<Semaphore>,
     sstable_store: SstableStoreRef,
-    table_cache_refill_context: Arc<RwLock<TableCacheRefillContext>>,
+    table_cache_refill_context_map: Arc<TableCacheRefillContextMap>,
 }
 
 struct DataCacheRefillTaskGenerator<'a> {
@@ -716,16 +781,14 @@ impl DataCacheRefillTaskGenerator<'_> {
         &self,
         mut tasks: Vec<DataCacheRefillTask>,
     ) -> Vec<DataCacheRefillTask> {
-        let table_cache_refill_context = self.context.table_cache_refill_context.read();
-        let check = |context: &RwLockReadGuard<'_, TableCacheRefillContext>,
-                     task: &DataCacheRefillTask| {
+        let table_cache_refill_context_map = &self.context.table_cache_refill_context_map;
+        let check = |task: &DataCacheRefillTask| {
             for blk in task.blks.start..task.blks.end {
-                let policy = context
-                    .policies
-                    .get(&task.sst.meta.block_metas[blk].table_id())
-                    .copied()
-                    .unwrap_or(context.default_policy);
-                match policy {
+                let table_id = task.sst.meta.block_metas[blk].table_id();
+                let Some(context) = table_cache_refill_context_map.get(&table_id) else {
+                    continue;
+                };
+                match context.policy {
                     CacheRefillPolicy::Enabled => return true,
                     CacheRefillPolicy::Streaming
                     | CacheRefillPolicy::Serving
@@ -739,7 +802,7 @@ impl DataCacheRefillTaskGenerator<'_> {
             }
             false
         };
-        tasks.retain(|task| check(&table_cache_refill_context, task));
+        tasks.retain(check);
         tasks
     }
 }
@@ -994,15 +1057,23 @@ mod tests {
     use std::sync::Arc;
     use std::time::Duration;
 
-    use parking_lot::RwLock;
+    use parking_lot::Mutex;
     use risingwave_common::bitmap::Bitmap;
     use risingwave_common::config::Role;
     use risingwave_common::config::streaming::CacheRefillPolicy;
     use risingwave_common::hash::VirtualNode;
+    use risingwave_hummock_sdk::sstable_info::{SstableInfo, SstableInfoInner};
+    use risingwave_hummock_sdk::version::HummockVersion;
+    use risingwave_pb::hummock::PbHummockVersion;
     use risingwave_pb::id::TableId;
+    use tokio::sync::mpsc::unbounded_channel;
 
-    use super::{CacheRefillConfig, CacheRefiller, vnode_range_bitmap};
+    use super::{
+        CacheRefillConfig, CacheRefillContext, CacheRefiller, SpawnRefillTask, SstDeltaInfo,
+        vnode_range_overlaps_bitmap,
+    };
     use crate::hummock::iterator::test_utils::mock_sstable_store;
+    use crate::hummock::local_version::pinned_version::PinnedVersion;
 
     fn test_refill_config(default_policy: CacheRefillPolicy) -> CacheRefillConfig {
         CacheRefillConfig {
@@ -1018,97 +1089,81 @@ mod tests {
         }
     }
 
-    #[tokio::test]
-    async fn test_serving_snapshot_restores_table_cache_refill_vnodes() {
-        let table_id = TableId::from(233);
-        let serving_vnodes = Bitmap::ones(VirtualNode::COUNT_FOR_TEST);
-        let read_version_mapping = Arc::new(RwLock::new(HashMap::new()));
-        let mut refiller = CacheRefiller::new(
-            Role::Serving,
-            test_refill_config(CacheRefillPolicy::Disabled),
-            mock_sstable_store().await,
-            CacheRefiller::default_spawn_refill_task(),
-            read_version_mapping,
-        );
-
-        refiller.replace_table_cache_refill_policies(HashMap::from([(
-            table_id,
-            CacheRefillPolicy::Serving,
-        )]));
-        assert!(
-            refiller
-                .table_cache_refill_context()
-                .read()
-                .serving
-                .is_empty()
-        );
-
-        refiller.replace_serving_table_vnode_mapping(HashMap::from([(
-            table_id,
-            serving_vnodes.clone(),
-        )]));
-
-        let context = refiller.table_cache_refill_context().read();
-        assert!(context.streaming.is_empty());
-        assert_eq!(context.serving.get(&table_id), Some(&serving_vnodes));
+    fn pinned_version_for_test() -> PinnedVersion {
+        PinnedVersion::new(
+            HummockVersion::from(PbHummockVersion::default()),
+            unbounded_channel().0,
+        )
     }
 
     #[tokio::test]
-    async fn test_serving_snapshot_replaces_existing_vnodes() {
+    async fn test_serving_snapshot_updates_table_context_lifecycle() {
         let table_id = TableId::from(233);
         let removed_table_id = TableId::from(234);
         let serving_vnodes = Bitmap::ones(VirtualNode::COUNT_FOR_TEST);
-        let read_version_mapping = Arc::new(RwLock::new(HashMap::new()));
         let mut refiller = CacheRefiller::new(
             Role::Serving,
             test_refill_config(CacheRefillPolicy::Disabled),
             mock_sstable_store().await,
             CacheRefiller::default_spawn_refill_task(),
-            read_version_mapping,
         );
 
         refiller.replace_table_cache_refill_policies(HashMap::from([
             (table_id, CacheRefillPolicy::Serving),
             (removed_table_id, CacheRefillPolicy::Serving),
         ]));
+        let context_map = refiller.table_cache_refill_context_map().read();
+        assert!(
+            context_map
+                .get(&table_id)
+                .is_none_or(|context| context.serving_vnode_bitmap.is_none())
+        );
+        drop(context_map);
+
         refiller.replace_serving_table_vnode_mapping(HashMap::from([
             (table_id, serving_vnodes.clone()),
             (removed_table_id, serving_vnodes.clone()),
         ]));
+
+        let context_map = refiller.table_cache_refill_context_map().read();
+        let context = context_map.get(&table_id).unwrap();
+        assert!(context.streaming_vnode_bitmap.is_none());
+        assert_eq!(context.serving_vnode_bitmap.as_ref(), Some(&serving_vnodes));
         assert!(
-            refiller
-                .table_cache_refill_context()
-                .read()
-                .serving
-                .contains_key(&removed_table_id)
+            context_map
+                .get(&removed_table_id)
+                .is_some_and(|context| context.serving_vnode_bitmap.is_some())
         );
+        drop(context_map);
 
         refiller.replace_serving_table_vnode_mapping(HashMap::from([(
             table_id,
             serving_vnodes.clone(),
         )]));
 
-        let context = refiller.table_cache_refill_context().read();
-        assert_eq!(context.serving.get(&table_id), Some(&serving_vnodes));
-        assert!(!context.serving.contains_key(&removed_table_id));
+        let context_map = refiller.table_cache_refill_context_map().read();
+        assert_eq!(
+            context_map
+                .get(&table_id)
+                .and_then(|context| context.serving_vnode_bitmap.as_ref()),
+            Some(&serving_vnodes)
+        );
         assert!(
-            !context
-                .serving_table_vnode_mapping
-                .contains_key(&removed_table_id)
+            context_map
+                .get(&removed_table_id)
+                .is_some_and(|context| context.serving_vnode_bitmap.is_none())
         );
     }
 
     #[tokio::test]
-    async fn test_policy_snapshot_replaces_existing_policies() {
+    async fn test_policy_update_removes_context_without_active_vnodes() {
         let table_id = TableId::from(233);
         let serving_vnodes = Bitmap::ones(VirtualNode::COUNT_FOR_TEST);
-        let read_version_mapping = Arc::new(RwLock::new(HashMap::new()));
         let mut refiller = CacheRefiller::new(
             Role::Serving,
             test_refill_config(CacheRefillPolicy::Disabled),
             mock_sstable_store().await,
             CacheRefiller::default_spawn_refill_task(),
-            read_version_mapping,
         );
 
         refiller.replace_serving_table_vnode_mapping(HashMap::from([(table_id, serving_vnodes)]));
@@ -1116,34 +1171,102 @@ mod tests {
             table_id,
             CacheRefillPolicy::Serving,
         )]));
+        let context_map = refiller.table_cache_refill_context_map().read();
         assert!(
-            refiller
-                .table_cache_refill_context()
-                .read()
-                .serving
-                .contains_key(&table_id)
+            context_map
+                .get(&table_id)
+                .is_some_and(|context| context.serving_vnode_bitmap.is_some())
         );
+        drop(context_map);
 
         refiller.replace_table_cache_refill_policies(HashMap::new());
 
-        let context = refiller.table_cache_refill_context().read();
-        assert!(context.policies.is_empty());
-        assert!(context.serving.is_empty());
+        let context_map = refiller.table_cache_refill_context_map().read();
+        assert!(context_map.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_refill_task_materializes_context_for_delta_tables() {
+        let explicit_table_id = TableId::from(233);
+        let default_table_id = TableId::from(234);
+        let excluded_table_id = TableId::from(235);
+        let serving_vnodes = Bitmap::ones(VirtualNode::COUNT_FOR_TEST);
+        let captured_context = Arc::new(Mutex::new(None::<CacheRefillContext>));
+        let captured_context_clone = captured_context.clone();
+        let spawn_refill_task: SpawnRefillTask = Arc::new(move |_, context, _, _| {
+            *captured_context_clone.lock() = Some(context);
+            tokio::spawn(async {})
+        });
+        let mut refiller = CacheRefiller::new(
+            Role::Both,
+            test_refill_config(CacheRefillPolicy::Enabled),
+            mock_sstable_store().await,
+            spawn_refill_task,
+        );
+
+        refiller.replace_table_cache_refill_policies(HashMap::from([
+            (explicit_table_id, CacheRefillPolicy::Serving),
+            (excluded_table_id, CacheRefillPolicy::Serving),
+        ]));
+        refiller.replace_serving_table_vnode_mapping(HashMap::from([
+            (explicit_table_id, serving_vnodes.clone()),
+            (excluded_table_id, serving_vnodes.clone()),
+        ]));
+
+        refiller.start_cache_refill(
+            vec![SstDeltaInfo {
+                insert_sst_infos: vec![SstableInfo::from(SstableInfoInner {
+                    table_ids: vec![explicit_table_id, default_table_id],
+                    ..Default::default()
+                })],
+                ..Default::default()
+            }],
+            pinned_version_for_test(),
+            pinned_version_for_test(),
+        );
+
+        let captured_context = captured_context.lock();
+        let table_cache_refill_context_map = &captured_context
+            .as_ref()
+            .unwrap()
+            .table_cache_refill_context_map;
+        let explicit_context = table_cache_refill_context_map
+            .get(&explicit_table_id)
+            .unwrap();
+        assert_eq!(explicit_context.policy, CacheRefillPolicy::Serving);
+        assert_eq!(
+            explicit_context.serving_vnode_bitmap.as_ref(),
+            Some(&serving_vnodes)
+        );
+
+        let default_context = table_cache_refill_context_map
+            .get(&default_table_id)
+            .unwrap();
+        assert_eq!(default_context.policy, CacheRefillPolicy::Enabled);
+        assert!(default_context.streaming_vnode_bitmap.is_none());
+        assert!(default_context.serving_vnode_bitmap.is_none());
+        assert!(!table_cache_refill_context_map.contains_key(&excluded_table_id));
     }
 
     #[test]
-    fn test_vnode_range_bitmap_uses_right_exclusive_end() {
-        let bitmap = vnode_range_bitmap(VirtualNode::COUNT_FOR_TEST, (10, 12));
-        assert_eq!(bitmap.count_ones(), 2);
-        assert!(bitmap.is_set(10));
-        assert!(bitmap.is_set(11));
-        assert!(!bitmap.is_set(12));
+    fn test_vnode_range_overlaps_bitmap_uses_right_exclusive_end() {
+        let right_exclusive = Bitmap::from_indices(VirtualNode::COUNT_FOR_TEST, [12]);
+        assert!(!vnode_range_overlaps_bitmap((10, 12), &right_exclusive));
 
-        let last = vnode_range_bitmap(
+        let inside_range = Bitmap::from_indices(VirtualNode::COUNT_FOR_TEST, [11]);
+        assert!(vnode_range_overlaps_bitmap((10, 12), &inside_range));
+
+        let last_vnode = Bitmap::from_indices(
             VirtualNode::COUNT_FOR_TEST,
-            (VirtualNode::COUNT_FOR_TEST - 1, VirtualNode::COUNT_FOR_TEST),
+            [VirtualNode::COUNT_FOR_TEST - 1],
         );
-        assert_eq!(last.count_ones(), 1);
-        assert!(last.is_set(VirtualNode::COUNT_FOR_TEST - 1));
+        assert!(vnode_range_overlaps_bitmap(
+            (VirtualNode::COUNT_FOR_TEST - 1, VirtualNode::COUNT_FOR_TEST),
+            &last_vnode
+        ));
+        assert!(!vnode_range_overlaps_bitmap(
+            (VirtualNode::COUNT_FOR_TEST, VirtualNode::COUNT_FOR_TEST + 1),
+            &last_vnode
+        ));
     }
 }

--- a/src/storage/src/hummock/store/hummock_storage.rs
+++ b/src/storage/src/hummock/store/hummock_storage.rs
@@ -20,7 +20,6 @@ use std::sync::Arc;
 use arc_swap::ArcSwap;
 use bytes::Bytes;
 use itertools::Itertools;
-use parking_lot::RwLock;
 use risingwave_common::array::VectorRef;
 use risingwave_common::catalog::{TableId, TableOption};
 use risingwave_common::config::Role;
@@ -51,7 +50,7 @@ use crate::hummock::compactor::{
     CompactionAwaitTreeRegRef, CompactorContext, new_compaction_await_tree_reg_ref,
 };
 use crate::hummock::event_handler::hummock_event_handler::{BufferTracker, HummockEventSender};
-use crate::hummock::event_handler::refiller::TableCacheRefillContextMap;
+use crate::hummock::event_handler::refiller::TableCacheRefillMonitorSnapshot;
 use crate::hummock::event_handler::{
     HummockEvent, HummockEventHandler, HummockObserverEvent, HummockVersionUpdate,
     ReadOnlyReadVersionMapping,
@@ -125,8 +124,6 @@ pub struct HummockStorage {
     hummock_meta_client: Arc<dyn HummockMetaClient>,
 
     simple_time_travel_version_cache: Arc<SimpleTimeTravelVersionCache>,
-
-    table_cache_refill_context_map: Arc<RwLock<TableCacheRefillContextMap>>,
 
     table_change_log_manager: Arc<TableChangeLogManager>,
 }
@@ -259,9 +256,6 @@ impl HummockStorage {
             simple_time_travel_version_cache: Arc::new(SimpleTimeTravelVersionCache::new(
                 options.time_travel_version_cache_capacity,
             )),
-            table_cache_refill_context_map: hummock_event_handler
-                .table_cache_refill_context_map()
-                .clone(),
             table_change_log_manager,
         };
 
@@ -621,8 +615,16 @@ impl HummockStorage {
         self.context.sstable_store.clone()
     }
 
-    pub fn table_cache_refill_context_map(&self) -> &Arc<RwLock<TableCacheRefillContextMap>> {
-        &self.table_cache_refill_context_map
+    pub async fn table_cache_refill_monitor_snapshot(
+        &self,
+    ) -> HummockResult<TableCacheRefillMonitorSnapshot> {
+        let (tx, rx) = oneshot::channel();
+        self.hummock_event_sender
+            .send(HummockEvent::GetTableCacheRefillMonitorSnapshot { result_tx: tx })
+            .map_err(|_| HummockError::other("failed to send table cache refill monitor query"))?;
+        rx.await.map_err(|_| {
+            HummockError::other("failed to receive table cache refill monitor snapshot")
+        })
     }
 
     pub fn object_id_manager(&self) -> &ObjectIdManagerRef {

--- a/src/storage/src/hummock/store/hummock_storage.rs
+++ b/src/storage/src/hummock/store/hummock_storage.rs
@@ -51,7 +51,7 @@ use crate::hummock::compactor::{
     CompactionAwaitTreeRegRef, CompactorContext, new_compaction_await_tree_reg_ref,
 };
 use crate::hummock::event_handler::hummock_event_handler::{BufferTracker, HummockEventSender};
-use crate::hummock::event_handler::refiller::TableCacheRefillContext;
+use crate::hummock::event_handler::refiller::TableCacheRefillContextMap;
 use crate::hummock::event_handler::{
     HummockEvent, HummockEventHandler, HummockObserverEvent, HummockVersionUpdate,
     ReadOnlyReadVersionMapping,
@@ -126,7 +126,7 @@ pub struct HummockStorage {
 
     simple_time_travel_version_cache: Arc<SimpleTimeTravelVersionCache>,
 
-    table_cache_refill_context: Arc<RwLock<TableCacheRefillContext>>,
+    table_cache_refill_context_map: Arc<RwLock<TableCacheRefillContextMap>>,
 
     table_change_log_manager: Arc<TableChangeLogManager>,
 }
@@ -259,7 +259,9 @@ impl HummockStorage {
             simple_time_travel_version_cache: Arc::new(SimpleTimeTravelVersionCache::new(
                 options.time_travel_version_cache_capacity,
             )),
-            table_cache_refill_context: hummock_event_handler.table_cache_refill_context().clone(),
+            table_cache_refill_context_map: hummock_event_handler
+                .table_cache_refill_context_map()
+                .clone(),
             table_change_log_manager,
         };
 
@@ -619,8 +621,8 @@ impl HummockStorage {
         self.context.sstable_store.clone()
     }
 
-    pub fn table_cache_refill_context(&self) -> &Arc<RwLock<TableCacheRefillContext>> {
-        &self.table_cache_refill_context
+    pub fn table_cache_refill_context_map(&self) -> &Arc<RwLock<TableCacheRefillContextMap>> {
+        &self.table_cache_refill_context_map
     }
 
     pub fn object_id_manager(&self) -> &ObjectIdManagerRef {


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

This PR is a structure-only follow-up to the table refill runtime config work. It refactors the table cache refill runtime context so refill tasks consume an immutable per-task snapshot, while mutable runtime ownership stays in `CacheRefiller` / `HummockEventHandler`.

The previous structure mixed two concepts in the refill context:

- task-check state used by the refill task hot path
- mutable owner state used to update policies and vnode mappings

This PR separates them:

- `TableCacheRefillContext` is per-table task-check state only: streaming vnode bitmap, serving vnode bitmap, and refill policy.
- `CacheRefiller` owns the mutable sources used to build that context: default policy, explicit table policies, streaming vnode mapping, and serving vnode mapping.
- When spawning a refill task, `CacheRefiller` collects table ids from the SST deltas and materializes an immutable `Arc<HashMap<TableId, TableCacheRefillContext>>` for only those tables.
- `HummockEventHandler` owns read-version facts and feeds `CacheRefiller` with per-table streaming vnode updates. It keeps a local per-table read-version index so single-table updates do not scan all local instances or read the shared read-version mapping lock.
- The compute monitor exposes the simplified context map, while preserving the top-level `policies` field for existing simulation-test consumers.

Limitations:

- This PR does not add online serving vnode mapping update support or change refill trigger semantics.
- Serving vnode mappings are still applied as snapshot/full-replace state in the current path.

## Checklist

- [x] I have written necessary rustdoc comments.
- [x] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

N/A. This is an internal refactor and does not change user-visible behavior.

</details>

<!-- capy-pr-badge:start -->
<a href="https://capy.ai/project/337a7eb0-5e7b-411a-869a-76e45a4e4750/pull/25928"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open in Capy" src="https://capy.ai/api/badge/open.svg"></picture></a>
<!-- capy-pr-badge:end -->
