### PR TITLE
fix(common): jsonb >= 8 MiB now rejected and transformed to `'null'::jsonb`

### DIFF
--- a/src/common/src/array/jsonb_array.rs
+++ b/src/common/src/array/jsonb_array.rs
@@ -34,6 +34,17 @@ pub struct JsonbArray {
     data: jsonbb::Value,
 }
 
+fn nullify_oversize(v: jsonbb::ValueRef<'_>) -> jsonbb::ValueRef<'_> {
+    const NULLIFY_BOUND: usize = 1 << 23; // 8 MiB, chosen arbitrarily
+
+    let size = v.capacity();
+    if size < NULLIFY_BOUND {
+        return v;
+    }
+    tracing::warn!("Large jsonb value is transformed into json-null: {size}");
+    jsonbb::ValueRef::Null
+}
+
 impl ArrayBuilder for JsonbArrayBuilder {
     type ArrayType = JsonbArray;
 
@@ -56,7 +67,8 @@ impl ArrayBuilder for JsonbArrayBuilder {
             Some(x) => {
                 self.bitmap.append_n(n, true);
                 for _ in 0..n {
-                    self.builder.add_value(x.0);
+                    let value = nullify_oversize(x.0);
+                    self.builder.add_value(value);
                 }
             }
             None => {
@@ -73,6 +85,7 @@ impl ArrayBuilder for JsonbArrayBuilder {
             self.bitmap.append(bit);
         }
         for value in other.data.as_array().unwrap().iter() {
+            let value = nullify_oversize(value);
             self.builder.add_value(value);
         }
     }


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

<!--

**Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

The jsonbb encoding uses a 29-bit offset, effectively limiting the max size to be 512 MiB. And in RisingWave the whole column (JsonbArray) is a jsonbb array. By limiting a single value to < 8 MiB in this PR, we could hold 32 rows * 8 MiB < 512 MiB. (Not 64 to leave some buffer.)

Related but not addressed in this PR:
* extend `jsonbb` to support larger value
* update `chunk_builder.rs` so it cuts earlier when the whole column is about to be full, especially inside cdc transaction.

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>

<!-- capy-pr-badge:start -->
<a href="https://capy.ai/project/337a7eb0-5e7b-411a-869a-76e45a4e4750/pull/25930"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open in Capy" src="https://capy.ai/api/badge/open.svg"></picture></a>
<!-- capy-pr-badge:end -->