### PR TITLE
refactor(stream): dispatch stream node body by macro

### DIFF
--- a/src/common/src/util/stream_graph_visitor.rs
+++ b/src/common/src/util/stream_graph_visitor.rs
@@ -18,6 +18,13 @@ use risingwave_pb::stream_plan::stream_fragment_graph::StreamFragment;
 use risingwave_pb::stream_plan::stream_node::NodeBody;
 use risingwave_pb::stream_plan::{SourceBackfillNode, StreamNode, StreamScanNode, agg_call_state};
 
+#[macro_export]
+macro_rules! dispatch_stream_node_body {
+    ($body:expr, $node_body:ident, $node:ident => $call:expr) => {
+        ::risingwave_pb::__dispatch_stream_node_body!($body, $node_body, $node => $call)
+    };
+}
+
 /// A utility for visiting and mutating the [`NodeBody`] of the [`StreamNode`]s recursively.
 pub fn visit_stream_node_mut(stream_node: &mut StreamNode, mut f: impl FnMut(&mut NodeBody)) {
     visit_stream_node_cont_mut(stream_node, |stream_node| {

--- a/src/prost/build.rs
+++ b/src/prost/build.rs
@@ -1116,6 +1116,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             "#[derive(::enum_as_inner::EnumAsInner, ::strum::Display, ::strum::EnumDiscriminants)]",
         )
         .type_attribute(
+            "stream_plan.StreamNode.node_body",
+            "#[derive(::prost_helpers::StreamNodeBodyVariants)]",
+        )
+        .type_attribute(
             "node_body",
             "#[strum_discriminants(derive(::strum::Display, Hash))]",
         )

--- a/src/prost/helpers/src/lib.rs
+++ b/src/prost/helpers/src/lib.rs
@@ -18,7 +18,7 @@
 use proc_macro::TokenStream;
 use proc_macro2::{Span, TokenStream as TokenStream2};
 use quote::{format_ident, quote};
-use syn::{Data, DataStruct, DeriveInput, Result, parse_macro_input};
+use syn::{Data, DataEnum, DataStruct, DeriveInput, Result, parse_macro_input};
 
 mod generate;
 
@@ -33,6 +33,61 @@ pub fn any_pb(input: TokenStream) -> TokenStream {
         Ok(tokens) => tokens.into(),
         Err(e) => e.to_compile_error().into(),
     }
+}
+
+#[proc_macro_derive(StreamNodeBodyVariants)]
+pub fn stream_node_body_variants(input: TokenStream) -> TokenStream {
+    let ast = parse_macro_input!(input as DeriveInput);
+
+    match produce_stream_node_body_variants(&ast) {
+        Ok(tokens) => tokens.into(),
+        Err(e) => e.to_compile_error().into(),
+    }
+}
+
+fn produce_stream_node_body_variants(ast: &DeriveInput) -> Result<TokenStream2> {
+    if ast.ident != "NodeBody" {
+        return Err(syn::Error::new_spanned(
+            &ast.ident,
+            "StreamNodeBodyVariants can only be derived for stream_plan::stream_node::NodeBody",
+        ));
+    }
+
+    let Data::Enum(DataEnum { variants, .. }) = &ast.data else {
+        return Err(syn::Error::new_spanned(
+            ast,
+            "StreamNodeBodyVariants can only be derived for enums",
+        ));
+    };
+
+    let variants: Vec<_> = variants.iter().map(|variant| &variant.ident).collect();
+    let marker_types: Vec<_> = variants
+        .iter()
+        .map(|variant| format_ident!("{variant}Variant"))
+        .collect();
+    let dollar = quote!($);
+
+    Ok(quote! {
+        #(
+            #[derive(Debug, Clone, Copy)]
+            pub struct #marker_types;
+        )*
+
+        #[macro_export]
+        #[doc(hidden)]
+        macro_rules! __dispatch_stream_node_body {
+            (#dollar body:expr, #dollar node_body:ident, #dollar node:ident => #dollar call:expr) => {
+                match #dollar body {
+                    #(
+                        ::risingwave_pb::stream_plan::stream_node::NodeBody::#variants(#dollar node) => {
+                            type #dollar node_body = ::risingwave_pb::stream_plan::stream_node::#marker_types;
+                            #dollar call
+                        }
+                    )*
+                }
+            };
+        }
+    })
 }
 
 // Procedure macros can not be tested from the same crate.
@@ -100,5 +155,77 @@ pub fn version(input: TokenStream) -> TokenStream {
     match version_inner(&ast) {
         Ok(tokens) => tokens.into(),
         Err(e) => e.to_compile_error().into(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use quote::quote;
+    use syn::parse_quote;
+
+    use super::*;
+
+    fn normalize(tokens: TokenStream2) -> String {
+        tokens
+            .to_string()
+            .split_whitespace()
+            .collect::<Vec<_>>()
+            .join(" ")
+    }
+
+    #[test]
+    fn stream_node_body_variants_generates_markers_and_dispatch() {
+        let input = parse_quote! {
+            enum NodeBody {
+                Source(Box<SourceNode>),
+                Project(Box<ProjectNode>),
+            }
+        };
+
+        let dollar = quote!($);
+        let expected_code = quote! {
+            #[derive(Debug, Clone, Copy)]
+            pub struct SourceVariant;
+
+            #[derive(Debug, Clone, Copy)]
+            pub struct ProjectVariant;
+
+            #[macro_export]
+            #[doc(hidden)]
+            macro_rules! __dispatch_stream_node_body {
+                (#dollar body:expr, #dollar node_body:ident, #dollar node:ident => #dollar call:expr) => {
+                    match #dollar body {
+                        ::risingwave_pb::stream_plan::stream_node::NodeBody::Source(#dollar node) => {
+                            type #dollar node_body = ::risingwave_pb::stream_plan::stream_node::SourceVariant;
+                            #dollar call
+                        }
+                        ::risingwave_pb::stream_plan::stream_node::NodeBody::Project(#dollar node) => {
+                            type #dollar node_body = ::risingwave_pb::stream_plan::stream_node::ProjectVariant;
+                            #dollar call
+                        }
+                    }
+                };
+            }
+        };
+
+        assert_eq!(
+            normalize(produce_stream_node_body_variants(&input).unwrap()),
+            normalize(expected_code)
+        );
+    }
+
+    #[test]
+    fn stream_node_body_variants_rejects_unexpected_enum_name() {
+        let input = parse_quote! {
+            enum OtherBody {
+                Source(Box<SourceNode>),
+            }
+        };
+
+        let err = produce_stream_node_body_variants(&input).unwrap_err();
+        assert_eq!(
+            err.to_string(),
+            "StreamNodeBodyVariants can only be derived for stream_plan::stream_node::NodeBody"
+        );
     }
 }

--- a/src/stream/src/from_proto/append_only_dedup.rs
+++ b/src/stream/src/from_proto/append_only_dedup.rs
@@ -25,6 +25,8 @@ use crate::task::ExecutorParams;
 
 pub struct AppendOnlyDedupExecutorBuilder;
 
+impl_stream_node_body!(AppendOnlyDedup(DedupNode) => AppendOnlyDedupExecutorBuilder);
+
 impl ExecutorBuilder for AppendOnlyDedupExecutorBuilder {
     type Node = DedupNode;
 

--- a/src/stream/src/from_proto/approx_percentile/global.rs
+++ b/src/stream/src/from_proto/approx_percentile/global.rs
@@ -20,6 +20,8 @@ use crate::from_proto::*;
 
 pub struct GlobalApproxPercentileExecutorBuilder;
 
+impl_stream_node_body!(GlobalApproxPercentile(GlobalApproxPercentileNode) => GlobalApproxPercentileExecutorBuilder);
+
 impl ExecutorBuilder for GlobalApproxPercentileExecutorBuilder {
     type Node = GlobalApproxPercentileNode;
 

--- a/src/stream/src/from_proto/approx_percentile/local.rs
+++ b/src/stream/src/from_proto/approx_percentile/local.rs
@@ -19,6 +19,8 @@ use crate::from_proto::*;
 
 pub struct LocalApproxPercentileExecutorBuilder;
 
+impl_stream_node_body!(LocalApproxPercentile(LocalApproxPercentileNode) => LocalApproxPercentileExecutorBuilder);
+
 impl ExecutorBuilder for LocalApproxPercentileExecutorBuilder {
     type Node = LocalApproxPercentileNode;
 

--- a/src/stream/src/from_proto/asof_join.rs
+++ b/src/stream/src/from_proto/asof_join.rs
@@ -25,6 +25,8 @@ use crate::executor::{AsOfCpuEncoding, AsOfDesc, AsOfJoinType, AsOfMemoryEncodin
 
 pub struct AsOfJoinExecutorBuilder;
 
+impl_stream_node_body!(AsOfJoin(AsOfJoinNode) => AsOfJoinExecutorBuilder);
+
 impl ExecutorBuilder for AsOfJoinExecutorBuilder {
     type Node = AsOfJoinNode;
 

--- a/src/stream/src/from_proto/barrier_recv.rs
+++ b/src/stream/src/from_proto/barrier_recv.rs
@@ -19,6 +19,8 @@ use crate::executor::BarrierRecvExecutor;
 
 pub struct BarrierRecvExecutorBuilder;
 
+impl_stream_node_body!(BarrierRecv(BarrierRecvNode) => BarrierRecvExecutorBuilder);
+
 impl ExecutorBuilder for BarrierRecvExecutorBuilder {
     type Node = BarrierRecvNode;
 

--- a/src/stream/src/from_proto/batch_query.rs
+++ b/src/stream/src/from_proto/batch_query.rs
@@ -22,6 +22,8 @@ use crate::executor::{BatchQueryExecutor, DummyExecutor};
 
 pub struct BatchQueryExecutorBuilder;
 
+impl_stream_node_body!(BatchPlan(BatchPlanNode) => BatchQueryExecutorBuilder);
+
 impl ExecutorBuilder for BatchQueryExecutorBuilder {
     type Node = BatchPlanNode;
 

--- a/src/stream/src/from_proto/cdc_filter.rs
+++ b/src/stream/src/from_proto/cdc_filter.rs
@@ -30,6 +30,8 @@ pub struct CdcFilterExecutorBuilder;
 /// Keep this value in sync with CDC source schema definition.
 const RW_TABLE_NAME_COLUMN_IDX: u32 = 2;
 
+impl_stream_node_body!(CdcFilter(CdcFilterNode) => CdcFilterExecutorBuilder);
+
 /// `CdcFilter` is an extension to the Filter executor
 impl ExecutorBuilder for CdcFilterExecutorBuilder {
     type Node = CdcFilterNode;

--- a/src/stream/src/from_proto/changelog.rs
+++ b/src/stream/src/from_proto/changelog.rs
@@ -22,6 +22,8 @@ use crate::task::ExecutorParams;
 
 pub struct ChangeLogExecutorBuilder;
 
+impl_stream_node_body!(Changelog(ChangeLogNode) => ChangeLogExecutorBuilder);
+
 impl ExecutorBuilder for ChangeLogExecutorBuilder {
     type Node = ChangeLogNode;
 

--- a/src/stream/src/from_proto/dml.rs
+++ b/src/stream/src/from_proto/dml.rs
@@ -24,6 +24,8 @@ use crate::task::ExecutorParams;
 
 pub struct DmlExecutorBuilder;
 
+impl_stream_node_body!(Dml(DmlNode) => DmlExecutorBuilder);
+
 impl ExecutorBuilder for DmlExecutorBuilder {
     type Node = DmlNode;
 

--- a/src/stream/src/from_proto/dynamic_filter.rs
+++ b/src/stream/src/from_proto/dynamic_filter.rs
@@ -26,6 +26,8 @@ use crate::executor::DynamicFilterExecutor;
 
 pub struct DynamicFilterExecutorBuilder;
 
+impl_stream_node_body!(DynamicFilter(DynamicFilterNode) => DynamicFilterExecutorBuilder);
+
 impl ExecutorBuilder for DynamicFilterExecutorBuilder {
     type Node = DynamicFilterNode;
 

--- a/src/stream/src/from_proto/eowc_gap_fill.rs
+++ b/src/stream/src/from_proto/eowc_gap_fill.rs
@@ -30,6 +30,8 @@ use crate::task::ExecutorParams;
 
 pub struct EowcGapFillExecutorBuilder;
 
+impl_stream_node_body!(EowcGapFill(EowcGapFillNode) => EowcGapFillExecutorBuilder);
+
 impl ExecutorBuilder for EowcGapFillExecutorBuilder {
     type Node = EowcGapFillNode;
 

--- a/src/stream/src/from_proto/eowc_over_window.rs
+++ b/src/stream/src/from_proto/eowc_over_window.rs
@@ -26,6 +26,8 @@ use crate::task::ExecutorParams;
 
 pub struct EowcOverWindowExecutorBuilder;
 
+impl_stream_node_body!(EowcOverWindow(PbEowcOverWindowNode) => EowcOverWindowExecutorBuilder);
+
 impl ExecutorBuilder for EowcOverWindowExecutorBuilder {
     type Node = PbEowcOverWindowNode;
 

--- a/src/stream/src/from_proto/expand.rs
+++ b/src/stream/src/from_proto/expand.rs
@@ -19,6 +19,8 @@ use crate::executor::ExpandExecutor;
 
 pub struct ExpandExecutorBuilder;
 
+impl_stream_node_body!(Expand(ExpandNode) => ExpandExecutorBuilder);
+
 impl ExecutorBuilder for ExpandExecutorBuilder {
     type Node = ExpandNode;
 

--- a/src/stream/src/from_proto/filter.rs
+++ b/src/stream/src/from_proto/filter.rs
@@ -21,6 +21,8 @@ use crate::executor::{FilterExecutor, UpsertFilterExecutor};
 
 pub struct FilterExecutorBuilder;
 
+impl_stream_node_body!(Filter(FilterNode) => FilterExecutorBuilder);
+
 impl ExecutorBuilder for FilterExecutorBuilder {
     type Node = FilterNode;
 

--- a/src/stream/src/from_proto/gap_fill.rs
+++ b/src/stream/src/from_proto/gap_fill.rs
@@ -28,6 +28,8 @@ use crate::task::ExecutorParams;
 
 pub struct GapFillExecutorBuilder;
 
+impl_stream_node_body!(GapFill(GapFillNode) => GapFillExecutorBuilder);
+
 impl ExecutorBuilder for GapFillExecutorBuilder {
     type Node = GapFillNode;
 

--- a/src/stream/src/from_proto/group_top_n.rs
+++ b/src/stream/src/from_proto/group_top_n.rs
@@ -27,6 +27,9 @@ use crate::task::AtomicU64Ref;
 
 pub struct GroupTopNExecutorBuilder<const APPEND_ONLY: bool>;
 
+impl_stream_node_body!(GroupTopN(GroupTopNNode) => GroupTopNExecutorBuilder<false>);
+impl_stream_node_body!(AppendOnlyGroupTopN(GroupTopNNode) => GroupTopNExecutorBuilder<true>);
+
 impl<const APPEND_ONLY: bool> ExecutorBuilder for GroupTopNExecutorBuilder<APPEND_ONLY> {
     type Node = GroupTopNNode;
 

--- a/src/stream/src/from_proto/hash_agg.rs
+++ b/src/stream/src/from_proto/hash_agg.rs
@@ -47,6 +47,8 @@ impl<S: StateStore> HashKeyDispatcher for HashAggExecutorDispatcherArgs<S> {
 
 pub struct HashAggExecutorBuilder;
 
+impl_stream_node_body!(HashAgg(HashAggNode) => HashAggExecutorBuilder);
+
 impl ExecutorBuilder for HashAggExecutorBuilder {
     type Node = HashAggNode;
 

--- a/src/stream/src/from_proto/hash_join.rs
+++ b/src/stream/src/from_proto/hash_join.rs
@@ -32,6 +32,8 @@ use crate::task::AtomicU64Ref;
 
 pub struct HashJoinExecutorBuilder;
 
+impl_stream_node_body!(HashJoin(HashJoinNode) => HashJoinExecutorBuilder);
+
 impl ExecutorBuilder for HashJoinExecutorBuilder {
     type Node = HashJoinNode;
 

--- a/src/stream/src/from_proto/hop_window.rs
+++ b/src/stream/src/from_proto/hop_window.rs
@@ -20,6 +20,8 @@ use crate::executor::HopWindowExecutor;
 
 pub struct HopWindowExecutorBuilder;
 
+impl_stream_node_body!(HopWindow(HopWindowNode) => HopWindowExecutorBuilder);
+
 impl ExecutorBuilder for HopWindowExecutorBuilder {
     type Node = HopWindowNode;
 

--- a/src/stream/src/from_proto/iceberg_with_pk_index/dv_merger.rs
+++ b/src/stream/src/from_proto/iceberg_with_pk_index/dv_merger.rs
@@ -25,6 +25,8 @@ use crate::task::ExecutorParams;
 
 pub struct IcebergWithPkIndexDvMergerExecutorBuilder;
 
+impl_stream_node_body!(IcebergWithPkIndexDvMerger(IcebergWithPkIndexDvMergerNode) => IcebergWithPkIndexDvMergerExecutorBuilder);
+
 impl ExecutorBuilder for IcebergWithPkIndexDvMergerExecutorBuilder {
     type Node = IcebergWithPkIndexDvMergerNode;
 

--- a/src/stream/src/from_proto/iceberg_with_pk_index/mod.rs
+++ b/src/stream/src/from_proto/iceberg_with_pk_index/mod.rs
@@ -14,6 +14,3 @@
 
 mod dv_merger;
 mod writer;
-
-pub use dv_merger::IcebergWithPkIndexDvMergerExecutorBuilder;
-pub use writer::IcebergWithPkIndexWriterExecutorBuilder;

--- a/src/stream/src/from_proto/iceberg_with_pk_index/writer.rs
+++ b/src/stream/src/from_proto/iceberg_with_pk_index/writer.rs
@@ -33,6 +33,8 @@ use crate::task::ExecutorParams;
 
 pub struct IcebergWithPkIndexWriterExecutorBuilder;
 
+impl_stream_node_body!(IcebergWithPkIndexWriter(IcebergWithPkIndexWriterNode) => IcebergWithPkIndexWriterExecutorBuilder);
+
 impl ExecutorBuilder for IcebergWithPkIndexWriterExecutorBuilder {
     type Node = IcebergWithPkIndexWriterNode;
 

--- a/src/stream/src/from_proto/locality_provider.rs
+++ b/src/stream/src/from_proto/locality_provider.rs
@@ -22,6 +22,8 @@ use crate::common::table::state_table::StateTableBuilder;
 use crate::executor::Executor;
 use crate::executor::locality_provider::LocalityProviderExecutor;
 
+impl_stream_node_body!(LocalityProvider(LocalityProviderNode) => LocalityProviderBuilder);
+
 impl ExecutorBuilder for LocalityProviderBuilder {
     type Node = LocalityProviderNode;
 

--- a/src/stream/src/from_proto/lookup.rs
+++ b/src/stream/src/from_proto/lookup.rs
@@ -27,6 +27,8 @@ use crate::executor::{LookupExecutor, LookupExecutorParams};
 
 pub struct LookupExecutorBuilder;
 
+impl_stream_node_body!(Lookup(LookupNode) => LookupExecutorBuilder);
+
 impl ExecutorBuilder for LookupExecutorBuilder {
     type Node = LookupNode;
 

--- a/src/stream/src/from_proto/lookup_union.rs
+++ b/src/stream/src/from_proto/lookup_union.rs
@@ -19,6 +19,8 @@ use crate::executor::LookupUnionExecutor;
 
 pub struct LookupUnionExecutorBuilder;
 
+impl_stream_node_body!(LookupUnion(LookupUnionNode) => LookupUnionExecutorBuilder);
+
 impl ExecutorBuilder for LookupUnionExecutorBuilder {
     type Node = LookupUnionNode;
 

--- a/src/stream/src/from_proto/materialized_exprs.rs
+++ b/src/stream/src/from_proto/materialized_exprs.rs
@@ -23,6 +23,8 @@ use crate::executor::project::{MaterializedExprsArgs, MaterializedExprsExecutor}
 
 pub struct MaterializedExprsExecutorBuilder;
 
+impl_stream_node_body!(MaterializedExprs(MaterializedExprsNode) => MaterializedExprsExecutorBuilder);
+
 impl ExecutorBuilder for MaterializedExprsExecutorBuilder {
     type Node = MaterializedExprsNode;
 

--- a/src/stream/src/from_proto/merge.rs
+++ b/src/stream/src/from_proto/merge.rs
@@ -90,6 +90,8 @@ impl MergeExecutorBuilder {
     }
 }
 
+impl_stream_node_body!(Merge(MergeNode) => MergeExecutorBuilder);
+
 impl ExecutorBuilder for MergeExecutorBuilder {
     type Node = MergeNode;
 

--- a/src/stream/src/from_proto/mod.rs
+++ b/src/stream/src/from_proto/mod.rs
@@ -14,6 +14,19 @@
 
 //! Build executor from protobuf.
 
+macro_rules! impl_stream_node_body {
+    ($variant:ident($node:ty) => $executor_builder:ty) => {
+        paste::paste! {
+            impl crate::from_proto::StreamNodeBody
+                for risingwave_pb::stream_plan::stream_node::[<$variant Variant>]
+            {
+                type Node = $node;
+                type ExecutorBuilder = $executor_builder;
+            }
+        }
+    };
+}
+
 mod agg_common;
 mod append_only_dedup;
 mod asof_join;
@@ -70,62 +83,13 @@ mod vector_index_write;
 
 // import for submodules
 use itertools::Itertools;
-use risingwave_pb::stream_plan::stream_node::NodeBody;
-use risingwave_pb::stream_plan::{StreamNode, TemporalJoinNode};
+use risingwave_common::dispatch_stream_node_body;
+use risingwave_pb::stream_plan::{self, StreamNode, TemporalJoinNode};
 use risingwave_storage::StateStore;
 
-use self::append_only_dedup::*;
-use self::approx_percentile::global::*;
-use self::approx_percentile::local::*;
-use self::asof_join::AsOfJoinExecutorBuilder;
-use self::barrier_recv::*;
-use self::batch_query::*;
-use self::cdc_filter::CdcFilterExecutorBuilder;
-use self::dml::*;
-use self::dynamic_filter::*;
-use self::eowc_gap_fill::EowcGapFillExecutorBuilder;
-use self::eowc_over_window::*;
-use self::expand::*;
-use self::filter::*;
-use self::gap_fill::GapFillExecutorBuilder;
-use self::group_top_n::GroupTopNExecutorBuilder;
-use self::hash_agg::*;
-use self::hash_join::*;
-use self::hop_window::*;
-use self::iceberg_with_pk_index::*;
-use self::locality_provider::*;
-use self::lookup::*;
-use self::lookup_union::*;
-use self::materialized_exprs::MaterializedExprsExecutorBuilder;
 pub(crate) use self::merge::MergeExecutorBuilder;
-use self::mview::*;
-use self::no_op::*;
-use self::now::NowExecutorBuilder;
-use self::over_window::*;
-use self::project::*;
-use self::project_set::*;
-use self::row_id_gen::RowIdGenExecutorBuilder;
-use self::row_merge::*;
-use self::simple_agg::*;
-use self::sink::*;
-use self::sort::*;
-use self::source::*;
-use self::source_backfill::*;
-use self::stateless_simple_agg::*;
-use self::stream_cdc_scan::*;
-use self::stream_scan::*;
-use self::sync_log_store::*;
-use self::temporal_join::*;
-use self::top_n::*;
-use self::union::*;
-use self::upstream_sink_union::*;
-use self::watermark_filter::WatermarkFilterBuilder;
 use crate::error::StreamResult;
 use crate::executor::{Execute, Executor, ExecutorInfo};
-use crate::from_proto::changelog::ChangeLogExecutorBuilder;
-use crate::from_proto::values::ValuesExecutorBuilder;
-use crate::from_proto::vector_index_lookup_join::VectorIndexLookupJoinBuilder;
-use crate::from_proto::vector_index_write::VectorIndexWriteExecutorBuilder;
 use crate::task::ExecutorParams;
 
 trait ExecutorBuilder {
@@ -139,17 +103,41 @@ trait ExecutorBuilder {
     ) -> StreamResult<Executor>;
 }
 
-macro_rules! build_executor {
-    ($source:expr, $node:expr, $store:expr, $($proto_type_name:path => $data_type:ty),* $(,)?) => {
-        match $node.get_node_body().unwrap() {
-            $(
-                $proto_type_name(node) => {
-                    <$data_type>::new_boxed_executor($source, node, $store).await
-                },
-            )*
-            NodeBody::Exchange(_) | NodeBody::DeltaIndexJoin(_) => unreachable!()
-        }
+trait StreamNodeBody {
+    type Node;
+    type ExecutorBuilder: ExecutorBuilder<Node = Self::Node>;
+}
+
+struct UnreachableExecutorBuilder<T>(std::marker::PhantomData<T>);
+
+impl<T> ExecutorBuilder for UnreachableExecutorBuilder<T> {
+    type Node = T;
+
+    async fn new_boxed_executor(
+        _params: ExecutorParams,
+        _node: &Self::Node,
+        _store: impl StateStore,
+    ) -> StreamResult<Executor> {
+        unreachable!()
     }
+}
+
+impl_stream_node_body!(
+    Exchange(stream_plan::ExchangeNode) => UnreachableExecutorBuilder<stream_plan::ExchangeNode>
+);
+impl_stream_node_body!(
+    DeltaIndexJoin(stream_plan::DeltaIndexJoinNode) => UnreachableExecutorBuilder<stream_plan::DeltaIndexJoinNode>
+);
+
+macro_rules! create_executor {
+    ($params:expr, $node:expr, $store:expr) => {
+        dispatch_stream_node_body!($node.get_node_body().unwrap(), NodeVariant, node_body => {
+            <NodeVariant as StreamNodeBody>::ExecutorBuilder::new_boxed_executor(
+                $params, node_body, $store,
+            )
+            .await
+        })
+    };
 }
 
 /// Create an executor from protobuf [`StreamNode`].
@@ -158,64 +146,5 @@ pub async fn create_executor(
     node: &StreamNode,
     store: impl StateStore,
 ) -> StreamResult<Executor> {
-    build_executor! {
-        params,
-        node,
-        store,
-        NodeBody::Source => SourceExecutorBuilder,
-        NodeBody::Sink => SinkExecutorBuilder,
-        NodeBody::Project => ProjectExecutorBuilder,
-        NodeBody::TopN => TopNExecutorBuilder::<false>,
-        NodeBody::AppendOnlyTopN => TopNExecutorBuilder::<true>,
-        NodeBody::StatelessSimpleAgg => StatelessSimpleAggExecutorBuilder,
-        NodeBody::SimpleAgg => SimpleAggExecutorBuilder,
-        NodeBody::HashAgg => HashAggExecutorBuilder,
-        NodeBody::HashJoin => HashJoinExecutorBuilder,
-        NodeBody::HopWindow => HopWindowExecutorBuilder,
-        NodeBody::StreamScan => StreamScanExecutorBuilder,
-        NodeBody::StreamCdcScan => StreamCdcScanExecutorBuilder,
-        NodeBody::BatchPlan => BatchQueryExecutorBuilder,
-        NodeBody::Merge => MergeExecutorBuilder,
-        NodeBody::Materialize => MaterializeExecutorBuilder,
-        NodeBody::Filter => FilterExecutorBuilder,
-        NodeBody::CdcFilter => CdcFilterExecutorBuilder,
-        NodeBody::Arrange => ArrangeExecutorBuilder,
-        NodeBody::Lookup => LookupExecutorBuilder,
-        NodeBody::Union => UnionExecutorBuilder,
-        NodeBody::LookupUnion => LookupUnionExecutorBuilder,
-        NodeBody::Expand => ExpandExecutorBuilder,
-        NodeBody::DynamicFilter => DynamicFilterExecutorBuilder,
-        NodeBody::ProjectSet => ProjectSetExecutorBuilder,
-        NodeBody::GroupTopN => GroupTopNExecutorBuilder::<false>,
-        NodeBody::AppendOnlyGroupTopN => GroupTopNExecutorBuilder::<true>,
-        NodeBody::Sort => SortExecutorBuilder,
-        NodeBody::WatermarkFilter => WatermarkFilterBuilder,
-        NodeBody::Dml => DmlExecutorBuilder,
-        NodeBody::RowIdGen => RowIdGenExecutorBuilder,
-        NodeBody::Now => NowExecutorBuilder,
-        NodeBody::TemporalJoin => TemporalJoinExecutorBuilder,
-        NodeBody::Values => ValuesExecutorBuilder,
-        NodeBody::BarrierRecv => BarrierRecvExecutorBuilder,
-        NodeBody::AppendOnlyDedup => AppendOnlyDedupExecutorBuilder,
-        NodeBody::NoOp => NoOpExecutorBuilder,
-        NodeBody::EowcOverWindow => EowcOverWindowExecutorBuilder,
-        NodeBody::OverWindow => OverWindowExecutorBuilder,
-        NodeBody::StreamFsFetch => FsFetchExecutorBuilder,
-        NodeBody::SourceBackfill => SourceBackfillExecutorBuilder,
-        NodeBody::Changelog => ChangeLogExecutorBuilder,
-        NodeBody::GlobalApproxPercentile => GlobalApproxPercentileExecutorBuilder,
-        NodeBody::LocalApproxPercentile => LocalApproxPercentileExecutorBuilder,
-        NodeBody::RowMerge => RowMergeExecutorBuilder,
-        NodeBody::AsOfJoin => AsOfJoinExecutorBuilder,
-        NodeBody::SyncLogStore => SyncLogStoreExecutorBuilder,
-        NodeBody::MaterializedExprs => MaterializedExprsExecutorBuilder,
-        NodeBody::VectorIndexWrite => VectorIndexWriteExecutorBuilder,
-        NodeBody::UpstreamSinkUnion => UpstreamSinkUnionExecutorBuilder,
-        NodeBody::LocalityProvider => LocalityProviderBuilder,
-        NodeBody::EowcGapFill => EowcGapFillExecutorBuilder,
-        NodeBody::GapFill => GapFillExecutorBuilder,
-        NodeBody::VectorIndexLookupJoin => VectorIndexLookupJoinBuilder,
-        NodeBody::IcebergWithPkIndexWriter => IcebergWithPkIndexWriterExecutorBuilder,
-        NodeBody::IcebergWithPkIndexDvMerger => IcebergWithPkIndexDvMergerExecutorBuilder,
-    }
+    create_executor!(params, node, store)
 }

--- a/src/stream/src/from_proto/mview.rs
+++ b/src/stream/src/from_proto/mview.rs
@@ -25,6 +25,8 @@ use crate::executor::{MaterializeExecutor, RefreshableMaterializeArgs};
 
 pub struct MaterializeExecutorBuilder;
 
+impl_stream_node_body!(Materialize(MaterializeNode) => MaterializeExecutorBuilder);
+
 impl ExecutorBuilder for MaterializeExecutorBuilder {
     type Node = MaterializeNode;
 
@@ -135,6 +137,8 @@ impl ExecutorBuilder for MaterializeExecutorBuilder {
 }
 
 pub struct ArrangeExecutorBuilder;
+
+impl_stream_node_body!(Arrange(ArrangeNode) => ArrangeExecutorBuilder);
 
 impl ExecutorBuilder for ArrangeExecutorBuilder {
     type Node = ArrangeNode;

--- a/src/stream/src/from_proto/no_op.rs
+++ b/src/stream/src/from_proto/no_op.rs
@@ -22,6 +22,8 @@ use crate::task::ExecutorParams;
 
 pub struct NoOpExecutorBuilder;
 
+impl_stream_node_body!(NoOp(NoOpNode) => NoOpExecutorBuilder);
+
 impl ExecutorBuilder for NoOpExecutorBuilder {
     type Node = NoOpNode;
 

--- a/src/stream/src/from_proto/now.rs
+++ b/src/stream/src/from_proto/now.rs
@@ -28,6 +28,8 @@ use crate::task::ExecutorParams;
 
 pub struct NowExecutorBuilder;
 
+impl_stream_node_body!(Now(NowNode) => NowExecutorBuilder);
+
 impl ExecutorBuilder for NowExecutorBuilder {
     type Node = NowNode;
 

--- a/src/stream/src/from_proto/over_window.rs
+++ b/src/stream/src/from_proto/over_window.rs
@@ -28,6 +28,8 @@ use crate::task::ExecutorParams;
 
 pub struct OverWindowExecutorBuilder;
 
+impl_stream_node_body!(OverWindow(PbOverWindowNode) => OverWindowExecutorBuilder);
+
 impl ExecutorBuilder for OverWindowExecutorBuilder {
     type Node = PbOverWindowNode;
 

--- a/src/stream/src/from_proto/project.rs
+++ b/src/stream/src/from_proto/project.rs
@@ -22,6 +22,8 @@ use crate::executor::project::ProjectExecutor;
 
 pub struct ProjectExecutorBuilder;
 
+impl_stream_node_body!(Project(ProjectNode) => ProjectExecutorBuilder);
+
 impl ExecutorBuilder for ProjectExecutorBuilder {
     type Node = ProjectNode;
 

--- a/src/stream/src/from_proto/project_set.rs
+++ b/src/stream/src/from_proto/project_set.rs
@@ -21,6 +21,8 @@ use crate::executor::project::{ProjectSetExecutor, ProjectSetSelectItem};
 
 pub struct ProjectSetExecutorBuilder;
 
+impl_stream_node_body!(ProjectSet(ProjectSetNode) => ProjectSetExecutorBuilder);
+
 impl ExecutorBuilder for ProjectSetExecutorBuilder {
     type Node = ProjectSetNode;
 

--- a/src/stream/src/from_proto/row_id_gen.rs
+++ b/src/stream/src/from_proto/row_id_gen.rs
@@ -23,6 +23,8 @@ use crate::task::ExecutorParams;
 
 pub struct RowIdGenExecutorBuilder;
 
+impl_stream_node_body!(RowIdGen(RowIdGenNode) => RowIdGenExecutorBuilder);
+
 impl ExecutorBuilder for RowIdGenExecutorBuilder {
     type Node = RowIdGenNode;
 

--- a/src/stream/src/from_proto/row_merge.rs
+++ b/src/stream/src/from_proto/row_merge.rs
@@ -20,6 +20,8 @@ use crate::from_proto::*;
 
 pub struct RowMergeExecutorBuilder;
 
+impl_stream_node_body!(RowMerge(RowMergeNode) => RowMergeExecutorBuilder);
+
 impl ExecutorBuilder for RowMergeExecutorBuilder {
     type Node = RowMergeNode;
 

--- a/src/stream/src/from_proto/simple_agg.rs
+++ b/src/stream/src/from_proto/simple_agg.rs
@@ -26,6 +26,8 @@ use crate::executor::aggregate::{AggExecutorArgs, SimpleAggExecutor, SimpleAggEx
 
 pub struct SimpleAggExecutorBuilder;
 
+impl_stream_node_body!(SimpleAgg(SimpleAggNode) => SimpleAggExecutorBuilder);
+
 impl ExecutorBuilder for SimpleAggExecutorBuilder {
     type Node = SimpleAggNode;
 

--- a/src/stream/src/from_proto/sink.rs
+++ b/src/stream/src/from_proto/sink.rs
@@ -194,6 +194,8 @@ fn validate_payload_schema(
     }
 }
 
+impl_stream_node_body!(Sink(SinkNode) => SinkExecutorBuilder);
+
 impl ExecutorBuilder for SinkExecutorBuilder {
     type Node = SinkNode;
 

--- a/src/stream/src/from_proto/sort.rs
+++ b/src/stream/src/from_proto/sort.rs
@@ -22,6 +22,8 @@ use crate::executor::eowc::{SortExecutor, SortExecutorArgs};
 
 pub struct SortExecutorBuilder;
 
+impl_stream_node_body!(Sort(SortNode) => SortExecutorBuilder);
+
 impl ExecutorBuilder for SortExecutorBuilder {
     type Node = SortNode;
 

--- a/src/stream/src/from_proto/source/fs_fetch.rs
+++ b/src/stream/src/from_proto/source/fs_fetch.rs
@@ -35,6 +35,8 @@ use crate::task::ExecutorParams;
 
 pub struct FsFetchExecutorBuilder;
 
+impl_stream_node_body!(StreamFsFetch(StreamFsFetchNode) => FsFetchExecutorBuilder);
+
 impl ExecutorBuilder for FsFetchExecutorBuilder {
     type Node = StreamFsFetchNode;
 

--- a/src/stream/src/from_proto/source/mod.rs
+++ b/src/stream/src/from_proto/source/mod.rs
@@ -14,15 +14,15 @@
 
 mod trad_source;
 
+mod fs_fetch;
+
 use std::collections::BTreeMap;
 
-pub use trad_source::{SourceExecutorBuilder, create_source_desc_builder};
-mod fs_fetch;
-pub use fs_fetch::FsFetchExecutorBuilder;
 use risingwave_connector::source::UPSTREAM_SOURCE_KEY;
 use risingwave_pb::catalog::PbStreamSourceInfo;
 use risingwave_pb::plan_common::SourceRefreshMode;
 use risingwave_pb::plan_common::source_refresh_mode::RefreshMode;
+pub use trad_source::create_source_desc_builder;
 
 use super::*;
 

--- a/src/stream/src/from_proto/source/trad_source.rs
+++ b/src/stream/src/from_proto/source/trad_source.rs
@@ -130,6 +130,8 @@ pub fn create_source_desc_builder(
     )
 }
 
+impl_stream_node_body!(Source(SourceNode) => SourceExecutorBuilder);
+
 impl ExecutorBuilder for SourceExecutorBuilder {
     type Node = SourceNode;
 

--- a/src/stream/src/from_proto/source_backfill.rs
+++ b/src/stream/src/from_proto/source_backfill.rs
@@ -23,6 +23,8 @@ use crate::executor::source::{
 
 pub struct SourceBackfillExecutorBuilder;
 
+impl_stream_node_body!(SourceBackfill(SourceBackfillNode) => SourceBackfillExecutorBuilder);
+
 impl ExecutorBuilder for SourceBackfillExecutorBuilder {
     type Node = SourceBackfillNode;
 

--- a/src/stream/src/from_proto/stateless_simple_agg.rs
+++ b/src/stream/src/from_proto/stateless_simple_agg.rs
@@ -20,6 +20,8 @@ use crate::executor::aggregate::StatelessSimpleAggExecutor;
 
 pub struct StatelessSimpleAggExecutorBuilder;
 
+impl_stream_node_body!(StatelessSimpleAgg(SimpleAggNode) => StatelessSimpleAggExecutorBuilder);
+
 impl ExecutorBuilder for StatelessSimpleAggExecutorBuilder {
     type Node = SimpleAggNode;
 

--- a/src/stream/src/from_proto/stream_cdc_scan.rs
+++ b/src/stream/src/from_proto/stream_cdc_scan.rs
@@ -31,6 +31,8 @@ use crate::task::cdc_progress::CdcProgressReporter;
 
 pub struct StreamCdcScanExecutorBuilder;
 
+impl_stream_node_body!(StreamCdcScan(StreamCdcScanNode) => StreamCdcScanExecutorBuilder);
+
 impl ExecutorBuilder for StreamCdcScanExecutorBuilder {
     type Node = StreamCdcScanNode;
 

--- a/src/stream/src/from_proto/stream_scan.rs
+++ b/src/stream/src/from_proto/stream_scan.rs
@@ -31,6 +31,8 @@ use crate::executor::{
 
 pub struct StreamScanExecutorBuilder;
 
+impl_stream_node_body!(StreamScan(StreamScanNode) => StreamScanExecutorBuilder);
+
 impl ExecutorBuilder for StreamScanExecutorBuilder {
     type Node = StreamScanNode;
 

--- a/src/stream/src/from_proto/sync_log_store.rs
+++ b/src/stream/src/from_proto/sync_log_store.rs
@@ -25,6 +25,8 @@ use crate::task::ExecutorParams;
 
 pub struct SyncLogStoreExecutorBuilder;
 
+impl_stream_node_body!(SyncLogStore(SyncLogStoreNode) => SyncLogStoreExecutorBuilder);
+
 impl ExecutorBuilder for SyncLogStoreExecutorBuilder {
     type Node = SyncLogStoreNode;
 

--- a/src/stream/src/from_proto/temporal_join.rs
+++ b/src/stream/src/from_proto/temporal_join.rs
@@ -35,6 +35,8 @@ use crate::task::AtomicU64Ref;
 
 pub struct TemporalJoinExecutorBuilder;
 
+impl_stream_node_body!(TemporalJoin(TemporalJoinNode) => TemporalJoinExecutorBuilder);
+
 impl ExecutorBuilder for TemporalJoinExecutorBuilder {
     type Node = TemporalJoinNode;
 

--- a/src/stream/src/from_proto/top_n.rs
+++ b/src/stream/src/from_proto/top_n.rs
@@ -23,6 +23,9 @@ use crate::executor::{AppendOnlyTopNExecutor, TopNExecutor};
 
 pub struct TopNExecutorBuilder<const APPEND_ONLY: bool>;
 
+impl_stream_node_body!(TopN(TopNNode) => TopNExecutorBuilder<false>);
+impl_stream_node_body!(AppendOnlyTopN(TopNNode) => TopNExecutorBuilder<true>);
+
 impl<const APPEND_ONLY: bool> ExecutorBuilder for TopNExecutorBuilder<APPEND_ONLY> {
     type Node = TopNNode;
 

--- a/src/stream/src/from_proto/union.rs
+++ b/src/stream/src/from_proto/union.rs
@@ -19,6 +19,8 @@ use crate::executor::UnionExecutor;
 
 pub struct UnionExecutorBuilder;
 
+impl_stream_node_body!(Union(UnionNode) => UnionExecutorBuilder);
+
 impl ExecutorBuilder for UnionExecutorBuilder {
     type Node = UnionNode;
 

--- a/src/stream/src/from_proto/upstream_sink_union.rs
+++ b/src/stream/src/from_proto/upstream_sink_union.rs
@@ -19,6 +19,8 @@ use crate::executor::{UpstreamFragmentInfo, UpstreamSinkUnionExecutor};
 
 pub struct UpstreamSinkUnionExecutorBuilder;
 
+impl_stream_node_body!(UpstreamSinkUnion(UpstreamSinkUnionNode) => UpstreamSinkUnionExecutorBuilder);
+
 impl ExecutorBuilder for UpstreamSinkUnionExecutorBuilder {
     type Node = UpstreamSinkUnionNode;
 

--- a/src/stream/src/from_proto/values.rs
+++ b/src/stream/src/from_proto/values.rs
@@ -26,6 +26,8 @@ use crate::task::ExecutorParams;
 /// this executor. May refractor with `BarrierRecvExecutor` in the near future.
 pub struct ValuesExecutorBuilder;
 
+impl_stream_node_body!(Values(ValuesNode) => ValuesExecutorBuilder);
+
 impl ExecutorBuilder for ValuesExecutorBuilder {
     type Node = ValuesNode;
 

--- a/src/stream/src/from_proto/vector_index_lookup_join.rs
+++ b/src/stream/src/from_proto/vector_index_lookup_join.rs
@@ -24,6 +24,8 @@ use crate::task::ExecutorParams;
 
 pub struct VectorIndexLookupJoinBuilder;
 
+impl_stream_node_body!(VectorIndexLookupJoin(VectorIndexLookupJoinNode) => VectorIndexLookupJoinBuilder);
+
 impl ExecutorBuilder for VectorIndexLookupJoinBuilder {
     type Node = VectorIndexLookupJoinNode;
 

--- a/src/stream/src/from_proto/vector_index_write.rs
+++ b/src/stream/src/from_proto/vector_index_write.rs
@@ -24,6 +24,8 @@ use crate::task::ExecutorParams;
 
 pub struct VectorIndexWriteExecutorBuilder;
 
+impl_stream_node_body!(VectorIndexWrite(VectorIndexWriteNode) => VectorIndexWriteExecutorBuilder);
+
 impl ExecutorBuilder for VectorIndexWriteExecutorBuilder {
     type Node = VectorIndexWriteNode;
 

--- a/src/stream/src/from_proto/watermark_filter.rs
+++ b/src/stream/src/from_proto/watermark_filter.rs
@@ -26,6 +26,8 @@ use crate::executor::{UpsertWatermarkFilterExecutor, WatermarkFilterExecutor};
 
 pub struct WatermarkFilterBuilder;
 
+impl_stream_node_body!(WatermarkFilter(WatermarkFilterNode) => WatermarkFilterBuilder);
+
 impl ExecutorBuilder for WatermarkFilterBuilder {
     type Node = WatermarkFilterNode;
 


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

This PR introduces a generated dispatch helper for `stream_plan::stream_node::NodeBody` and uses it to simplify stream executor construction.

- Add a `StreamNodeBodyVariants` derive in `prost-helpers`, applied to the generated stream `NodeBody` oneof through `prost-build` `type_attribute`.
- Generate one marker type per stream node body variant, named with the `Variant` suffix, plus a dispatch macro that matches over every generated `NodeBody` variant.
- Refactor `stream/src/from_proto` so each executor builder registers its own `impl_stream_node_body!` mapping, and `create_executor` no longer maintains a large hand-written `NodeBody` match.
- Add unit coverage for the generated token output and for rejecting unexpected enum names.

This is the downstack refactor needed by #25932, where meta schema-change rewrite code also dispatches over all stream node body variants.

## Checklist

- [ ] I have written necessary rustdoc comments.
- [x] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->

## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

Not user-facing.

</details>

<!-- capy-pr-badge:start -->
<a href="https://capy.ai/project/337a7eb0-5e7b-411a-869a-76e45a4e4750/pull/25931"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open in Capy" src="https://capy.ai/api/badge/open.svg"></picture></a>
<!-- capy-pr-badge:end -->
