### PR TITLE
refactor(meta): general framework for sink schema change rewrite

### DIFF
--- a/e2e_test/sink/auto_schema_change.slt
+++ b/e2e_test/sink/auto_schema_change.slt
@@ -194,6 +194,77 @@ drop table t_with_pk;
 
 # end
 
+# test dropping a column before sink primary key remaps rewritten sink stream key
+
+statement ok
+create table t_stream_key_shift(v int, id int primary key, name int);
+
+statement ok
+create sink s_stream_key_shift
+from t_stream_key_shift
+with (
+    connector = 'blackhole',
+    primary_key = 'id',
+    auto.schema.change = 'true'
+);
+
+statement ok
+insert into t_stream_key_shift values (0, 1, 10);
+
+statement ok
+flush;
+
+statement ok
+alter table t_stream_key_shift drop column v;
+
+query TTTT
+describe s_stream_key_shift;
+----
+id integer false NULL
+name integer false NULL
+primary key id NULL NULL
+distribution key id NULL NULL
+table description s_stream_key_shift NULL NULL
+
+statement ok
+update t_stream_key_shift set name = 20 where id = 1;
+
+statement ok
+flush;
+
+statement ok
+drop sink s_stream_key_shift;
+
+statement ok
+drop table t_stream_key_shift;
+
+# end
+
+# test dropping sink key columns is rejected
+
+statement ok
+create table t_drop_sink_key(id int primary key, name int);
+
+statement ok
+create sink s_drop_sink_key
+from t_drop_sink_key
+with (
+    connector = 'blackhole',
+    primary_key = 'id',
+    auto.schema.change = 'true'
+);
+
+statement error alter primary key
+alter table t_drop_sink_key drop column id;
+
+statement ok
+drop sink s_drop_sink_key;
+
+statement ok
+drop table t_drop_sink_key;
+
+# end
+
 # test auto schema change on empty table
 
 statement ok

--- a/src/common/src/catalog/column.rs
+++ b/src/common/src/catalog/column.rs
@@ -35,6 +35,15 @@ use crate::catalog::{Field, ROW_ID_COLUMN_ID};
 use crate::types::DataType;
 use crate::util::value_encoding::DatumToProtoExt;
 
+/// Derive the catalog column name used by internal table builders.
+///
+/// This mirrors the frontend internal-table column derivation: output `Field`
+/// names may contain dots from qualified columns, but internal table column
+/// names normalize them to underscores.
+pub fn derive_internal_table_column_name(field_name: &str) -> String {
+    field_name.replace('.', "_")
+}
+
 /// Column ID is the unique identifier of a column in a table. Different from table ID, column ID is
 /// not globally unique.
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]

--- a/src/frontend/src/optimizer/plan_node/utils.rs
+++ b/src/frontend/src/optimizer/plan_node/utils.rs
@@ -24,7 +24,7 @@ use itertools::Itertools;
 use pretty_xmlish::{Pretty, Str, StrAssocArr, XmlNode};
 use risingwave_common::catalog::{
     ColumnCatalog, ColumnDesc, ConflictBehavior, CreateType, Engine, Field, FieldDisplay, Schema,
-    StreamJobStatus,
+    StreamJobStatus, derive_internal_table_column_name,
 };
 use risingwave_common::constants::log_store::v2::{
     KV_LOG_STORE_PREDEFINED_COLUMNS, PK_ORDERING, VNODE_COLUMN_INDEX,
@@ -76,8 +76,7 @@ impl TableCatalogBuilder {
         // Add column desc.
         let mut column_desc = ColumnDesc::from_field_with_column_id(field, column_id);
 
-        // Replace dot of the internal table column name with underline.
-        column_desc.name = column_desc.name.replace('.', "_");
+        column_desc.name = derive_internal_table_column_name(&column_desc.name);
         // Avoid column name duplicate.
         self.avoid_duplicate_col_name(&mut column_desc);
 

--- a/src/meta/src/controller/streaming_job.rs
+++ b/src/meta/src/controller/streaming_job.rs
@@ -97,7 +97,7 @@ use crate::model::{
     FragmentDownstreamRelation, FragmentReplaceUpstream, StreamContext, StreamJobFragments,
     StreamJobFragmentsToCreate,
 };
-use crate::stream::{SplitAssignment, TableMetadataUpdate};
+use crate::stream::{SinkMetadataChange, SplitAssignment, TableMetadataUpdate};
 use crate::{MetaError, MetaResult};
 
 /// A planned fragment update for dependent sources when a connection's properties change.
@@ -1879,15 +1879,22 @@ impl CatalogController {
                     streaming_job::Entity::find_by_id(sink.sink_id.as_job_id())
                         .one(txn)
                         .await?;
-                let columns = ColumnCatalogArray::from(finish_sink_context.columns);
+                let sink_metadata_change = finish_sink_context.sink_metadata_change;
+                let columns = ColumnCatalogArray::from(sink_metadata_change.columns);
                 Sink::update(sink::ActiveModel {
                     sink_id: Set(finish_sink_context.original_sink_id),
                     columns: Set(columns.clone()),
+                    plan_pk: Set(sink_metadata_change.plan_pk.clone().into()),
+                    distribution_key: Set(sink_metadata_change.distribution_key.clone().into()),
+                    downstream_pk: Set(sink_metadata_change.downstream_pk.clone().into()),
                     ..Default::default()
                 })
                 .exec(txn)
                 .await?;
                 sink.columns = columns;
+                sink.plan_pk = sink_metadata_change.plan_pk.into();
+                sink.distribution_key = sink_metadata_change.distribution_key.into();
+                sink.downstream_pk = sink_metadata_change.downstream_pk.into();
                 objects.push(PbObject {
                     object_info: Some(PbObjectInfo::Sink(
                         ObjectModel(sink, sink_obj.unwrap(), sink_streaming_job.clone()).into(),
@@ -3499,7 +3506,7 @@ pub struct SinkIntoTableContext {
 pub struct FinishAutoRefreshSchemaSinkContext {
     pub tmp_sink_id: SinkId,
     pub original_sink_id: SinkId,
-    pub columns: Vec<PbColumnCatalog>,
+    pub sink_metadata_change: SinkMetadataChange,
     pub updated_tables: Vec<TableMetadataUpdate>,
 }
 

--- a/src/meta/src/controller/streaming_job.rs
+++ b/src/meta/src/controller/streaming_job.rs
@@ -97,7 +97,7 @@ use crate::model::{
     FragmentDownstreamRelation, FragmentReplaceUpstream, StreamContext, StreamJobFragments,
     StreamJobFragmentsToCreate,
 };
-use crate::stream::SplitAssignment;
+use crate::stream::{SplitAssignment, TableMetadataUpdate};
 use crate::{MetaError, MetaResult};
 
 /// A planned fragment update for dependent sources when a connection's properties change.
@@ -1893,27 +1893,26 @@ impl CatalogController {
                         ObjectModel(sink, sink_obj.unwrap(), sink_streaming_job.clone()).into(),
                     )),
                 });
-                if let Some(new_log_store_table) = finish_sink_context.new_log_store_table {
-                    let log_store_table_id = new_log_store_table.id;
-                    let new_log_store_table_columns: ColumnCatalogArray =
-                        new_log_store_table.columns.clone().into();
-                    let new_log_store_table_value_indices =
-                        new_log_store_table.value_indices.clone();
-                    let (mut table, table_obj) = Table::find_by_id(log_store_table_id)
+                for updated_table in finish_sink_context.updated_tables {
+                    let table_id = updated_table.table_id;
+                    let updated_table_columns: ColumnCatalogArray =
+                        updated_table.columns.clone().into();
+                    let updated_table_value_indices = updated_table.value_indices.clone();
+                    let (mut table, table_obj) = Table::find_by_id(table_id)
                         .find_also_related(Object)
                         .one(txn)
                         .await?
                         .ok_or_else(|| MetaError::catalog_id_not_found("table", original_job_id))?;
                     Table::update(table::ActiveModel {
-                        table_id: Set(log_store_table_id),
-                        columns: Set(new_log_store_table_columns.clone()),
-                        value_indices: Set(new_log_store_table_value_indices.clone().into()),
+                        table_id: Set(table_id),
+                        columns: Set(updated_table_columns.clone()),
+                        value_indices: Set(updated_table_value_indices.clone().into()),
                         ..Default::default()
                     })
                     .exec(txn)
                     .await?;
-                    table.columns = new_log_store_table_columns;
-                    table.value_indices = new_log_store_table_value_indices.into();
+                    table.columns = updated_table_columns;
+                    table.value_indices = updated_table_value_indices.into();
                     objects.push(PbObject {
                         object_info: Some(PbObjectInfo::Table(
                             ObjectModel(table, table_obj.unwrap(), sink_streaming_job.clone())
@@ -3501,7 +3500,7 @@ pub struct FinishAutoRefreshSchemaSinkContext {
     pub tmp_sink_id: SinkId,
     pub original_sink_id: SinkId,
     pub columns: Vec<PbColumnCatalog>,
-    pub new_log_store_table: Option<Box<PbTable>>,
+    pub updated_tables: Vec<TableMetadataUpdate>,
 }
 
 async fn update_connector_props_fragments<F>(

--- a/src/meta/src/rpc/ddl_controller.rs
+++ b/src/meta/src/rpc/ddl_controller.rs
@@ -1544,7 +1544,7 @@ impl DdlController {
                     let sink_ctx = sink_job_fragments.ctx;
                     let original_sink_fragment =
                         sink_job_fragments.fragments.into_values().next().unwrap();
-                    let (new_sink_fragment, new_schema, updated_tables) =
+                    let (new_sink_fragment, sink_metadata_change, updated_tables) =
                         rewrite_refresh_schema_sink_fragment(
                             &original_sink_fragment,
                             &sink,
@@ -1570,7 +1570,7 @@ impl DdlController {
                         tmp_sink_id,
                         original_sink: sink,
                         original_fragment: original_sink_fragment,
-                        new_schema,
+                        sink_metadata_change,
                         newly_add_fields: newly_added_columns
                             .iter()
                             .map(|col| Field::from(&col.column_desc))
@@ -1634,7 +1634,7 @@ impl DdlController {
                         .map(|sink| FinishAutoRefreshSchemaSinkContext {
                             tmp_sink_id: sink.tmp_sink_id,
                             original_sink_id: sink.original_sink.id,
-                            columns: sink.new_schema.clone(),
+                            sink_metadata_change: sink.sink_metadata_change.clone(),
                             updated_tables: sink.updated_tables.clone(),
                         })
                         .collect()

--- a/src/meta/src/rpc/ddl_controller.rs
+++ b/src/meta/src/rpc/ddl_controller.rs
@@ -93,8 +93,9 @@ use crate::stream::{
     CompleteStreamFragmentGraph, CreateStreamingJobContext, CreateStreamingJobOption,
     FragmentGraphDownstreamContext, FragmentGraphUpstreamContext, GlobalStreamManagerRef,
     ParallelismPolicy, ReplaceStreamJobContext, ReschedulePolicy, SourceChange, SourceManagerRef,
-    StreamFragmentGraph, UpstreamSinkInfo, check_sink_fragments_support_refresh_schema,
-    create_source_worker, rewrite_refresh_schema_sink_fragment, state_match, validate_sink,
+    StreamFragmentGraph, TableSchemaChange, UpstreamSinkInfo,
+    check_sink_fragments_support_refresh_schema, create_source_worker,
+    rewrite_refresh_schema_sink_fragment, state_match, validate_sink,
 };
 use crate::telemetry::report_event;
 use crate::{MetaError, MetaResult};
@@ -1512,6 +1513,21 @@ impl DdlController {
                     .filter(|col| !new_table_column_ids.contains(&col.column_id()))
                     .cloned()
                     .collect_vec();
+                if !newly_added_columns.is_empty() && !removed_columns.is_empty() {
+                    return Err(anyhow!(
+                        "auto schema change only supports adding or dropping columns in one replacement"
+                    )
+                    .into());
+                }
+                let sink_schema_change = if !removed_columns.is_empty() {
+                    TableSchemaChange::DropColumn {
+                        column_ids: removed_columns.iter().map(|col| col.column_id()).collect(),
+                    }
+                } else {
+                    TableSchemaChange::AddColumn {
+                        columns: newly_added_columns.clone(),
+                    }
+                };
                 let mut sinks = Vec::with_capacity(auto_refresh_schema_sinks.len());
                 for sink in auto_refresh_schema_sinks {
                     let sink_job_fragments = self
@@ -1528,12 +1544,11 @@ impl DdlController {
                     let sink_ctx = sink_job_fragments.ctx;
                     let original_sink_fragment =
                         sink_job_fragments.fragments.into_values().next().unwrap();
-                    let (new_sink_fragment, new_schema, new_log_store_table) =
+                    let (new_sink_fragment, new_schema, updated_tables) =
                         rewrite_refresh_schema_sink_fragment(
                             &original_sink_fragment,
                             &sink,
-                            &newly_added_columns,
-                            &removed_columns,
+                            sink_schema_change.clone(),
                             table,
                             fragment_graph.table_fragment_id(),
                             self.env.id_gen_manager(),
@@ -1565,7 +1580,7 @@ impl DdlController {
                             .map(|col| col.name.clone())
                             .collect(),
                         new_fragment: new_sink_fragment,
-                        new_log_store_table: new_log_store_table.map(Box::new),
+                        updated_tables,
                         ctx: sink_ctx,
                     });
                 }
@@ -1620,7 +1635,7 @@ impl DdlController {
                             tmp_sink_id: sink.tmp_sink_id,
                             original_sink_id: sink.original_sink.id,
                             columns: sink.new_schema.clone(),
-                            new_log_store_table: sink.new_log_store_table.clone(),
+                            updated_tables: sink.updated_tables.clone(),
                         })
                         .collect()
                 });

--- a/src/meta/src/stream/stream_graph.rs
+++ b/src/meta/src/stream/stream_graph.rs
@@ -17,6 +17,7 @@ mod assignment;
 mod fragment;
 mod id;
 mod schedule;
+mod schema_change;
 pub mod state_match;
 
 pub use actor::{ActorGraphBuildResult, ActorGraphBuilder};
@@ -24,8 +25,11 @@ pub use assignment::*;
 pub use fragment::{
     CompleteStreamFragmentGraph, ExtendedFragmentBackfillOrder, FragmentGraphDownstreamContext,
     FragmentGraphUpstreamContext, StreamFragmentGraph, UserDefinedFragmentBackfillOrder,
-    check_sink_fragments_support_refresh_schema, fill_snapshot_backfill_epoch,
-    rewrite_refresh_schema_sink_fragment,
+    fill_snapshot_backfill_epoch,
 };
 pub(crate) use id::GlobalActorIdGen;
 pub use schedule::Locations;
+pub use schema_change::{
+    TableSchemaChange, check_sink_fragments_support_refresh_schema,
+    rewrite_refresh_schema_sink_fragment,
+};

--- a/src/meta/src/stream/stream_graph/fragment.rs
+++ b/src/meta/src/stream/stream_graph/fragment.rs
@@ -22,8 +22,9 @@ use enum_as_inner::EnumAsInner;
 use itertools::Itertools;
 use risingwave_common::bail;
 use risingwave_common::catalog::{
-    CDC_SOURCE_COLUMN_NUM, ColumnCatalog, ColumnId, Field, FragmentTypeFlag, FragmentTypeMask,
-    TableId, generate_internal_table_name_with_type,
+    CDC_SOURCE_COLUMN_NUM, ColumnCatalog, ColumnDesc, ColumnId, Field, FragmentTypeFlag,
+    FragmentTypeMask, TableId, derive_internal_table_column_name,
+    generate_internal_table_name_with_type,
 };
 use risingwave_common::hash::VnodeCount;
 use risingwave_common::id::JobId;
@@ -37,7 +38,7 @@ use risingwave_pb::catalog::{PbSink, PbTable, Table};
 use risingwave_pb::ddl_service::TableJobType;
 use risingwave_pb::expr::{ExprNode as PbExprNode, expr_node};
 use risingwave_pb::id::{RelationId, StreamNodeLocalOperatorId};
-use risingwave_pb::plan_common::{PbColumnCatalog, PbColumnDesc};
+use risingwave_pb::plan_common::{PbColumnCatalog, PbColumnDesc, PbField};
 use risingwave_pb::stream_plan::dispatch_output_mapping::TypePair;
 use risingwave_pb::stream_plan::stream_fragment_graph::{
     Parallelism, StreamFragment, StreamFragmentEdge as StreamFragmentEdgeProto,
@@ -45,16 +46,20 @@ use risingwave_pb::stream_plan::stream_fragment_graph::{
 use risingwave_pb::stream_plan::stream_node::{NodeBody, PbNodeBody};
 use risingwave_pb::stream_plan::{
     BackfillOrder, DispatchOutputMapping, DispatchStrategy, DispatcherType, PbStreamNode,
-    PbStreamScanType, StreamFragmentGraph as StreamFragmentGraphProto, StreamNode, StreamScanNode,
-    StreamScanType,
+    PbStreamScanType, ProjectNode, SinkNode, StreamFragmentGraph as StreamFragmentGraphProto,
+    StreamNode, StreamScanNode, StreamScanType,
 };
 
 use crate::barrier::SnapshotBackfillInfo;
-use crate::controller::id::IdGeneratorManager;
 use crate::manager::{MetaSrvEnv, StreamingJob, StreamingJobType};
 use crate::model::{Fragment, FragmentDownstreamRelation, FragmentId};
+use crate::stream::TableMetadataUpdate;
 use crate::stream::stream_graph::id::{GlobalFragmentId, GlobalFragmentIdGen, GlobalTableIdGen};
 use crate::stream::stream_graph::schedule::Distribution;
+use crate::stream::stream_graph::schema_change::{
+    AddColumn, DropColumn, NodeSchemaRewrite, PropagatedSchemaChange, TableSchemaChange,
+    validate_log_store_schema_prefix,
+};
 use crate::{MetaError, MetaResult};
 
 /// The fragment in the building phase, including the [`StreamFragment`] from the frontend and
@@ -377,121 +382,31 @@ impl StreamFragmentEdge {
     }
 }
 
-fn clone_fragment(fragment: &Fragment, id_generator_manager: &IdGeneratorManager) -> Fragment {
-    let fragment_id = GlobalFragmentIdGen::new(id_generator_manager, 1)
-        .to_global_id(0)
-        .as_global_id();
-    Fragment {
-        fragment_id,
-        fragment_type_mask: fragment.fragment_type_mask,
-        distribution_type: fragment.distribution_type,
-        state_table_ids: fragment.state_table_ids.clone(),
-        maybe_vnode_count: fragment.maybe_vnode_count,
-        nodes: fragment.nodes.clone(),
-    }
-}
-
-pub fn check_sink_fragments_support_refresh_schema(
-    fragments: &BTreeMap<FragmentId, Fragment>,
-) -> MetaResult<()> {
-    if fragments.len() != 1 {
-        return Err(anyhow!(
-            "sink with auto schema change should have only 1 fragment, but got {:?}",
-            fragments.len()
-        )
-        .into());
-    }
-    let (_, fragment) = fragments.first_key_value().expect("non-empty");
-    let sink_node = &fragment.nodes;
-    let PbNodeBody::Sink(_) = sink_node.node_body.as_ref().unwrap() else {
-        return Err(anyhow!("expect PbNodeBody::Sink but got: {:?}", sink_node.node_body).into());
-    };
-    let [stream_input_node] = sink_node.input.as_slice() else {
-        panic!("Sink has more than 1 input: {:?}", sink_node.input);
-    };
-    let stream_scan_node = match stream_input_node.node_body.as_ref().unwrap() {
-        PbNodeBody::StreamScan(_) => stream_input_node,
-        PbNodeBody::Project(_) => {
-            let [stream_scan_node] = stream_input_node.input.as_slice() else {
-                return Err(anyhow!(
-                    "Project node must have exactly 1 input for auto schema change, but got {:?}",
-                    stream_input_node.input.len()
-                )
-                .into());
-            };
-            stream_scan_node
-        }
-        _ => {
-            return Err(anyhow!(
-                "expect PbNodeBody::StreamScan or PbNodeBody::Project but got: {:?}",
-                stream_input_node.node_body
-            )
-            .into());
-        }
-    };
-    let PbNodeBody::StreamScan(scan) = stream_scan_node.node_body.as_ref().unwrap() else {
-        return Err(anyhow!(
-            "expect PbNodeBody::StreamScan but got: {:?}",
-            stream_scan_node.node_body
-        )
-        .into());
-    };
-    let stream_scan_type = PbStreamScanType::try_from(scan.stream_scan_type).unwrap();
-    if stream_scan_type != PbStreamScanType::ArrangementBackfill {
-        return Err(anyhow!(
-            "unsupported stream_scan_type for auto refresh schema: {:?}",
-            stream_scan_type
-        )
-        .into());
-    }
-    let [merge_node, _batch_plan_node] = stream_scan_node.input.as_slice() else {
-        panic!(
-            "the number of StreamScan inputs is not 2: {:?}",
-            stream_scan_node.input
-        );
-    };
-    let NodeBody::Merge(_) = merge_node.node_body.as_ref().unwrap() else {
-        return Err(anyhow!(
-            "expect PbNodeBody::Merge but got: {:?}",
-            merge_node.node_body
-        )
-        .into());
-    };
-    Ok(())
-}
-
-/// Output mapping info after rewriting a `StreamScan` node.
-struct ScanRewriteResult {
-    old_output_index_to_new_output_index: HashMap<u32, u32>,
-    new_output_index_by_column_id: HashMap<ColumnId, u32>,
-    output_fields: Vec<risingwave_pb::plan_common::Field>,
-}
-
 /// Append new columns to a sink/log-store column list with updated names/ids.
-fn extend_sink_columns(
+fn extend_columns_from_fields(
     sink_columns: &mut Vec<PbColumnCatalog>,
-    new_columns: &[ColumnCatalog],
-    get_column_name: impl Fn(&String) -> String,
+    new_fields: &[PbField],
+    mut get_column_name: impl FnMut(&Field) -> String,
 ) {
     let next_column_id = sink_columns
         .iter()
         .map(|col| col.column_desc.as_ref().unwrap().column_id + 1)
         .max()
         .unwrap_or(1);
-    sink_columns.extend(new_columns.iter().enumerate().map(|(i, col)| {
-        let mut col = col.to_protobuf();
-        let column_desc = col.column_desc.as_mut().unwrap();
-        column_desc.column_id = next_column_id + (i as i32);
-        column_desc.name = get_column_name(&column_desc.name);
-        col
+    sink_columns.extend(new_fields.iter().enumerate().map(|(i, field)| {
+        let field = Field::from(field);
+        let mut column_desc =
+            ColumnDesc::from_field_with_column_id(&field, next_column_id + (i as i32));
+        column_desc.name = get_column_name(&field);
+        ColumnCatalog::visible(column_desc).to_protobuf()
     }));
 }
 
 /// Build sink column list after removing and appending columns.
-fn build_new_sink_columns(
+pub(super) fn build_new_sink_columns(
     sink: &PbSink,
     removed_column_names: &HashSet<String>,
-    newly_added_columns: &[ColumnCatalog],
+    newly_added_fields: &[PbField],
 ) -> Vec<PbColumnCatalog> {
     let mut columns: Vec<PbColumnCatalog> = sink
         .columns
@@ -502,34 +417,55 @@ fn build_new_sink_columns(
         })
         .cloned()
         .collect();
-    extend_sink_columns(&mut columns, newly_added_columns, |name| name.clone());
+    extend_columns_from_fields(&mut columns, newly_added_fields, |field| field.name.clone());
     columns
 }
 
 /// Rewrite log store table columns for schema change.
-fn rewrite_log_store_table(
+pub(super) fn rewrite_log_store_table(
     log_store_table: &mut PbTable,
     removed_log_store_column_names: &HashSet<String>,
-    newly_added_columns: &[ColumnCatalog],
-    upstream_table_name: &str,
-) {
+    newly_added_fields: &[PbField],
+) -> TableMetadataUpdate {
     log_store_table.columns.retain(|col| {
         !removed_log_store_column_names.contains(&col.column_desc.as_ref().unwrap().name)
     });
-    extend_sink_columns(&mut log_store_table.columns, newly_added_columns, |name| {
-        format!("{}_{}", upstream_table_name, name)
+    extend_columns_from_fields(&mut log_store_table.columns, newly_added_fields, |field| {
+        derive_internal_table_column_name(&field.name)
     });
     log_store_table.value_indices = (0..log_store_table.columns.len() as i32).collect();
+    TableMetadataUpdate {
+        table_id: log_store_table.id,
+        columns: log_store_table.columns.clone(),
+        value_indices: log_store_table.value_indices.clone(),
+    }
+}
+
+fn propagate_schema_change(
+    newly_added_fields: Vec<PbField>,
+    removed_indices: Vec<usize>,
+) -> Option<PropagatedSchemaChange> {
+    assert!(newly_added_fields.is_empty() || removed_indices.is_empty());
+    if !newly_added_fields.is_empty() {
+        Some(PropagatedSchemaChange::AddColumn(AddColumn {
+            added_fields: newly_added_fields,
+        }))
+    } else if !removed_indices.is_empty() {
+        Some(PropagatedSchemaChange::DropColumn(DropColumn {
+            removed_indices,
+        }))
+    } else {
+        None
+    }
 }
 
 /// Rewrite `StreamScan` + Merge to match the new upstream schema.
-fn rewrite_stream_scan_and_merge(
+pub(super) fn rewrite_stream_scan_and_merge(
     stream_scan_node: &mut StreamNode,
-    removed_column_ids: &HashSet<ColumnId>,
-    newly_added_columns: &[ColumnCatalog],
+    upstream_table_change: &TableSchemaChange,
     upstream_table: &PbTable,
-    upstream_table_fragment_id: FragmentId,
-) -> MetaResult<ScanRewriteResult> {
+    new_upstream_fragment_id: FragmentId,
+) -> MetaResult<Option<PropagatedSchemaChange>> {
     let PbNodeBody::StreamScan(scan) = stream_scan_node.node_body.as_mut().unwrap() else {
         return Err(anyhow!(
             "expect PbNodeBody::StreamScan but got: {:?}",
@@ -550,7 +486,6 @@ fn rewrite_stream_scan_and_merge(
         )
         .into());
     };
-
     let stream_scan_type = PbStreamScanType::try_from(scan.stream_scan_type).unwrap();
     if stream_scan_type != PbStreamScanType::ArrangementBackfill {
         return Err(anyhow!(
@@ -558,6 +493,13 @@ fn rewrite_stream_scan_and_merge(
             stream_scan_type
         )
         .into());
+    }
+    if scan.table_id != upstream_table.id {
+        bail!(
+            "StreamScan table id {} does not match upstream table id {}",
+            scan.table_id,
+            upstream_table.id
+        );
     }
 
     let upstream_columns_by_id: HashMap<i32, PbColumnDesc> = upstream_table
@@ -571,6 +513,19 @@ fn rewrite_stream_scan_and_merge(
 
     let old_upstream_column_ids = scan.upstream_column_ids.clone();
     let old_output_indices = scan.output_indices.clone();
+    let (removed_column_ids, newly_added_columns): (&[ColumnId], &[_]) = match upstream_table_change
+    {
+        TableSchemaChange::AddColumn { columns } => (&[], columns.as_slice()),
+        TableSchemaChange::DropColumn { column_ids } => (column_ids.as_slice(), &[] as &[_]),
+    };
+    let newly_added_fields = newly_added_columns
+        .iter()
+        .map(|col| PbField {
+            name: col.column_desc.name.clone(),
+            data_type: Some(col.data_type().to_protobuf()),
+        })
+        .collect();
+
     let mut old_upstream_index_to_new_upstream_index = HashMap::new();
     let mut new_upstream_column_ids = Vec::new();
     for (old_idx, &column_id) in old_upstream_column_ids.iter().enumerate() {
@@ -596,15 +551,11 @@ fn rewrite_stream_scan_and_merge(
         .iter()
         .map(|&idx| new_upstream_column_ids[idx as usize])
         .collect();
-    let mut new_output_index_by_column_id = HashMap::new();
-    for (pos, &column_id) in new_output_column_ids.iter().enumerate() {
-        new_output_index_by_column_id.insert(ColumnId::new(column_id as _), pos as u32);
-    }
-    let mut old_output_index_to_new_output_index = HashMap::new();
+    let mut removed_indices = Vec::new();
     for (old_pos, old_output_index) in old_output_indices.iter().enumerate() {
         let column_id = old_upstream_column_ids[*old_output_index as usize];
-        if let Some(new_pos) = new_output_index_by_column_id.get(&ColumnId::new(column_id as _)) {
-            old_output_index_to_new_output_index.insert(old_pos as u32, *new_pos);
+        if !new_output_column_ids.contains(&column_id) {
+            removed_indices.push(old_pos);
         }
     }
 
@@ -661,133 +612,120 @@ fn rewrite_stream_scan_and_merge(
             .to_prost()
         })
         .collect();
-    merge.upstream_fragment_id = upstream_table_fragment_id;
+    merge.upstream_fragment_id = new_upstream_fragment_id;
 
-    Ok(ScanRewriteResult {
-        old_output_index_to_new_output_index,
-        new_output_index_by_column_id,
-        output_fields: stream_scan_node.fields.clone(),
-    })
+    let change = propagate_schema_change(newly_added_fields, removed_indices);
+    Ok(change)
 }
 
 /// Rewrite Project node input refs and extend with newly added columns.
-fn rewrite_project_node(
-    project_node: &mut StreamNode,
-    scan_rewrite: &ScanRewriteResult,
-    newly_added_columns: &[ColumnCatalog],
-    removed_column_ids: &HashSet<ColumnId>,
-    upstream_table_name: &str,
-) -> MetaResult<()> {
-    let PbNodeBody::Project(project_node_body) = project_node.node_body.as_mut().unwrap() else {
-        return Err(anyhow!(
-            "expect PbNodeBody::Project but got: {:?}",
-            project_node.node_body
-        )
-        .into());
-    };
+pub(super) fn rewrite_project_node(
+    mut project_node_body: ProjectNode,
+    fields: Vec<PbField>,
+    input_change: PropagatedSchemaChange,
+    input_fields: Vec<PbField>,
+) -> MetaResult<NodeSchemaRewrite> {
     let has_non_input_ref = project_node_body
         .select_list
         .iter()
         .any(|expr| !matches!(expr.rex_node, Some(expr_node::RexNode::InputRef(_))));
-    if has_non_input_ref && !removed_column_ids.is_empty() {
-        return Err(anyhow!(
-            "auto schema change with drop column only supports Project with InputRef"
-        )
-        .into());
+    if has_non_input_ref && input_change.is_drop_column() {
+        bail!("auto schema change with drop column only supports Project with InputRef");
     }
 
+    let newly_added_fields = input_change.newly_added_fields();
+    let old_output_index_to_new_output_index: HashMap<u32, u32> = match &input_change {
+        PropagatedSchemaChange::AddColumn(_) => {
+            let old_input_len = input_fields.len() - newly_added_fields.len();
+            (0..old_input_len)
+                .map(|idx| (idx as u32, idx as u32))
+                .collect()
+        }
+        PropagatedSchemaChange::DropColumn(drop_column) => {
+            let old_input_len = input_fields.len() + drop_column.removed_indices.len();
+            (0..old_input_len)
+                .filter_map(|old_index| {
+                    remap_index_after_drop(old_index, &drop_column.removed_indices)
+                        .map(|new_index| (old_index as u32, new_index as u32))
+                })
+                .collect()
+        }
+    };
+
     let mut new_select_list = Vec::with_capacity(project_node_body.select_list.len());
-    let mut new_project_fields = Vec::with_capacity(project_node.fields.len());
+    let mut new_project_fields = Vec::with_capacity(fields.len());
+    let mut removed_indices = Vec::new();
     for (index, expr) in project_node_body.select_list.iter().enumerate() {
         let mut new_expr = expr.clone();
         if let Some(expr_node::RexNode::InputRef(old_index)) = new_expr.rex_node {
-            let Some(&new_index) = scan_rewrite
-                .old_output_index_to_new_output_index
-                .get(&old_index)
-            else {
+            let Some(&new_index) = old_output_index_to_new_output_index.get(&old_index) else {
+                removed_indices.push(index);
                 continue;
             };
             new_expr.rex_node = Some(expr_node::RexNode::InputRef(new_index));
-        } else if !removed_column_ids.is_empty() {
-            return Err(anyhow!(
-                "auto schema change with drop column only supports Project with InputRef"
-            )
-            .into());
+        } else if input_change.is_drop_column() {
+            bail!("auto schema change with drop column only supports Project with InputRef");
         }
         new_select_list.push(new_expr);
-        new_project_fields.push(project_node.fields[index].clone());
+        new_project_fields.push(fields[index].clone());
     }
 
-    for col in newly_added_columns {
-        let Some(&new_index) = scan_rewrite
-            .new_output_index_by_column_id
-            .get(&col.column_id())
-        else {
-            return Err(anyhow!("new column id not found in scan output").into());
-        };
+    let start_input_index = input_fields.len() - newly_added_fields.len();
+    for (offset, field) in newly_added_fields.iter().enumerate() {
+        let new_index = (start_input_index + offset) as u32;
+        // This mirrors frontend Project construction for pass-through
+        // `InputRef` expressions: output field names/types are taken from the
+        // input schema.
         new_select_list.push(PbExprNode {
             function_type: expr_node::Type::Unspecified as i32,
-            return_type: Some(col.data_type().to_protobuf()),
+            return_type: field.data_type.clone(),
             rex_node: Some(expr_node::RexNode::InputRef(new_index)),
         });
-        new_project_fields.push(
-            Field::new(
-                format!("{}.{}", upstream_table_name, col.column_desc.name),
-                col.data_type().clone(),
-            )
-            .to_prost(),
-        );
+        new_project_fields.push(input_fields[new_index as usize].clone());
     }
-
     project_node_body.select_list = new_select_list;
-    project_node.fields = new_project_fields;
-    Ok(())
+    let change = propagate_schema_change(newly_added_fields.to_vec(), removed_indices);
+
+    Ok(NodeSchemaRewrite {
+        body: NodeBody::Project(Box::new(project_node_body)),
+        fields: new_project_fields,
+        identity: None,
+        change,
+    })
 }
 
-pub fn rewrite_refresh_schema_sink_fragment(
-    original_sink_fragment: &Fragment,
+/// Rewrite Sink node columns, identity, and optional log-store table.
+pub(super) fn rewrite_sink_node(
+    mut sink_node_body: SinkNode,
+    input_change: PropagatedSchemaChange,
+    input_fields: Vec<PbField>,
     sink: &PbSink,
-    newly_added_columns: &[ColumnCatalog],
-    removed_columns: &[ColumnCatalog],
-    upstream_table: &PbTable,
-    upstream_table_fragment_id: FragmentId,
-    id_generator_manager: &IdGeneratorManager,
-) -> MetaResult<(Fragment, Vec<PbColumnCatalog>, Option<PbTable>)> {
-    let removed_column_ids: HashSet<_> =
-        removed_columns.iter().map(|col| col.column_id()).collect();
-    let removed_log_store_column_names: HashSet<_> = removed_columns
-        .iter()
-        .map(|col| format!("{}_{}", upstream_table.name, col.column_desc.name))
-        .collect();
-    let removed_sink_column_names: HashSet<_> = removed_columns
-        .iter()
-        .map(|col| col.column_desc.name.clone())
-        .collect();
+) -> MetaResult<(
+    NodeSchemaRewrite,
+    Vec<PbColumnCatalog>,
+    Option<TableMetadataUpdate>,
+)> {
+    let mut removed_column_names = HashSet::new();
+    let newly_added_sink_fields = match &input_change {
+        PropagatedSchemaChange::AddColumn(add_column) => add_column.added_fields.as_slice(),
+        PropagatedSchemaChange::DropColumn(drop_column) => {
+            for &idx in &drop_column.removed_indices {
+                let Some(column) = sink.columns.get(idx) else {
+                    bail!(
+                        "removed sink column index {} is out of range for sink columns {}",
+                        idx,
+                        sink.columns.len()
+                    );
+                };
+                removed_column_names.insert(column.column_desc.as_ref().unwrap().name.clone());
+            }
+            &[]
+        }
+    };
     let new_sink_columns =
-        build_new_sink_columns(sink, &removed_sink_column_names, newly_added_columns);
-
-    let mut new_sink_fragment = clone_fragment(original_sink_fragment, id_generator_manager);
-    let sink_node = &mut new_sink_fragment.nodes;
-    let PbNodeBody::Sink(sink_node_body) = sink_node.node_body.as_mut().unwrap() else {
-        return Err(anyhow!("expect PbNodeBody::Sink but got: {:?}", sink_node.node_body).into());
-    };
-    let [stream_input_node] = sink_node.input.as_mut_slice() else {
-        panic!("Sink has more than 1 input: {:?}", sink_node.input);
-    };
-    let stream_input_body = stream_input_node.node_body.as_ref().unwrap();
-    let stream_input_is_project = matches!(stream_input_body, PbNodeBody::Project(_));
-    let stream_input_is_scan = matches!(stream_input_body, PbNodeBody::StreamScan(_));
-    if !stream_input_is_project && !stream_input_is_scan {
-        return Err(anyhow!(
-            "expect PbNodeBody::StreamScan or PbNodeBody::Project but got: {:?}",
-            stream_input_body
-        )
-        .into());
-    }
-
-    // update sink_node
+        build_new_sink_columns(sink, &removed_column_names, newly_added_sink_fields);
     // following logic in <StreamSink as Explain>::distill
-    sink_node.identity = {
+    let identity = {
         let sink_type = SinkType::from_proto(sink.sink_type());
         let sink_type_str = sink_type.type_str();
         let column_names = new_sink_columns
@@ -810,55 +748,73 @@ pub fn rewrite_refresh_schema_sink_fragment(
         };
         format!("StreamSink {{ type: {sink_type_str}, columns: [{column_names}]{downstream_pk} }}")
     };
-    let new_log_store_table = if let Some(log_store_table) = &mut sink_node_body.table {
-        rewrite_log_store_table(
+
+    let updated_table = if let Some(log_store_table) = &mut sink_node_body.table {
+        let log_store_payload_offset = validate_log_store_schema_prefix(log_store_table)?;
+        let removed_log_store_column_names: HashSet<_>;
+        let newly_added_fields;
+        match &input_change {
+            PropagatedSchemaChange::AddColumn(add_column) => {
+                removed_log_store_column_names = HashSet::new();
+                newly_added_fields =
+                    &input_fields[input_fields.len() - add_column.added_fields.len()..];
+            }
+            PropagatedSchemaChange::DropColumn(drop_column) => {
+                let payload_columns_len = log_store_table.columns.len() - log_store_payload_offset;
+                removed_log_store_column_names = drop_column
+                    .removed_indices
+                    .iter()
+                    .map(|&idx| -> MetaResult<_> {
+                        let Some(column) = log_store_table.columns.get(log_store_payload_offset + idx) else {
+                            bail!(
+                                "removed sink column index {} is out of range for log store payload columns {}",
+                                idx,
+                                payload_columns_len
+                            );
+                        };
+                        Ok(column
+                            .column_desc
+                            .as_ref()
+                            .unwrap()
+                            .name
+                            .clone())
+                    })
+                    .collect::<MetaResult<_>>()?;
+                newly_added_fields = &[];
+            }
+        }
+        let updated_table = rewrite_log_store_table(
             log_store_table,
             &removed_log_store_column_names,
-            newly_added_columns,
-            &upstream_table.name,
+            newly_added_fields,
         );
-        Some(log_store_table.clone())
+        Some(updated_table)
     } else {
         None
     };
     sink_node_body.sink_desc.as_mut().unwrap().column_catalogs = new_sink_columns.clone();
 
-    let stream_scan_node = if stream_input_is_project {
-        let [stream_scan_node] = stream_input_node.input.as_mut_slice() else {
-            return Err(anyhow!(
-                "Project node must have exactly 1 input for auto schema change, but got {:?}",
-                stream_input_node.input.len()
-            )
-            .into());
-        };
-        stream_scan_node
-    } else {
-        stream_input_node
-    };
-    let scan_rewrite = rewrite_stream_scan_and_merge(
-        stream_scan_node,
-        &removed_column_ids,
-        newly_added_columns,
-        upstream_table,
-        upstream_table_fragment_id,
-    )?;
+    Ok((
+        NodeSchemaRewrite {
+            body: NodeBody::Sink(Box::new(sink_node_body)),
+            fields: input_fields,
+            identity: Some(identity),
+            change: Some(input_change),
+        },
+        new_sink_columns,
+        updated_table,
+    ))
+}
 
-    if stream_input_is_project {
-        let [project_node] = sink_node.input.as_mut_slice() else {
-            panic!("Sink has more than 1 input: {:?}", sink_node.input);
-        };
-        rewrite_project_node(
-            project_node,
-            &scan_rewrite,
-            newly_added_columns,
-            &removed_column_ids,
-            &upstream_table.name,
-        )?;
-        sink_node.fields = project_node.fields.clone();
-    } else {
-        sink_node.fields = scan_rewrite.output_fields;
+fn remap_index_after_drop(old_index: usize, removed_indices: &[usize]) -> Option<usize> {
+    if removed_indices.contains(&old_index) {
+        return None;
     }
-    Ok((new_sink_fragment, new_sink_columns, new_log_store_table))
+    let removed_before = removed_indices
+        .iter()
+        .filter(|&&removed_index| removed_index < old_index)
+        .count();
+    Some(old_index - removed_before)
 }
 
 /// Adjacency list (G) of backfill orders.
@@ -2263,23 +2219,30 @@ impl CompleteStreamFragmentGraph {
 
 #[cfg(test)]
 mod tests {
-    use risingwave_common::catalog::{ColumnDesc, ColumnId};
+    use risingwave_common::catalog::{
+        ColumnCatalog, ColumnDesc, ColumnId, Field, FragmentTypeMask,
+    };
+    use risingwave_common::constants::log_store::v2 as log_store_v2;
     use risingwave_common::types::DataType;
-    use risingwave_pb::catalog::SinkType as PbSinkType;
+    use risingwave_pb::catalog::{PbSink, PbTable, SinkType as PbSinkType};
+    use risingwave_pb::expr::{ExprNode as PbExprNode, expr_node};
     use risingwave_pb::meta::table_fragments::fragment::PbFragmentDistributionType;
-    use risingwave_pb::plan_common::StorageTableDesc;
+    use risingwave_pb::plan_common::{PbField, StorageTableDesc};
+    use risingwave_pb::stream_plan::stream_node::NodeBody;
     use risingwave_pb::stream_plan::{
         BatchPlanNode, MergeNode, ProjectNode, SinkDesc, SinkLogStoreType, SinkNode, StreamNode,
         StreamScanNode, StreamScanType,
     };
 
     use super::*;
+    use crate::manager::MetaSrvEnv;
+    use crate::stream::stream_graph::{TableSchemaChange, rewrite_refresh_schema_sink_fragment};
 
     fn make_column(name: &str, id: i32, data_type: DataType) -> ColumnCatalog {
         ColumnCatalog::visible(ColumnDesc::named(name, ColumnId::new(id), data_type))
     }
 
-    fn make_field(table_name: &str, column: &ColumnCatalog) -> risingwave_pb::plan_common::Field {
+    fn make_field(table_name: &str, column: &ColumnCatalog) -> PbField {
         Field::new(
             format!("{}.{}", table_name, column.column_desc.name),
             column.data_type().clone(),
@@ -2292,6 +2255,57 @@ mod tests {
             function_type: expr_node::Type::Unspecified as i32,
             return_type: Some(data_type.to_protobuf()),
             rex_node: Some(expr_node::RexNode::InputRef(index)),
+        }
+    }
+
+    fn make_upstream_table(table_name: &str, columns: &[ColumnCatalog]) -> PbTable {
+        PbTable {
+            id: 1.into(),
+            name: table_name.to_owned(),
+            columns: columns.iter().map(|col| col.to_protobuf()).collect(),
+            ..Default::default()
+        }
+    }
+
+    fn make_sink_and_desc(columns: &[ColumnCatalog]) -> (PbSink, SinkDesc) {
+        let sink = PbSink {
+            columns: columns.iter().map(|col| col.to_protobuf()).collect(),
+            sink_type: PbSinkType::AppendOnly as i32,
+            ..Default::default()
+        };
+        let sink_desc = SinkDesc {
+            sink_type: PbSinkType::AppendOnly as i32,
+            column_catalogs: sink.columns.clone(),
+            ..Default::default()
+        };
+        (sink, sink_desc)
+    }
+
+    fn make_log_store_table(table_name: &str, columns: &[ColumnCatalog]) -> PbTable {
+        let mut table_columns = vec![];
+        for (name, data_type) in log_store_v2::KV_LOG_STORE_PREDEFINED_COLUMNS {
+            let column_id = table_columns.len() as i32;
+            table_columns.push(
+                ColumnCatalog::visible(ColumnDesc::named(
+                    name,
+                    ColumnId::new(column_id),
+                    data_type,
+                ))
+                .to_protobuf(),
+            );
+        }
+        let payload_column_id_offset = table_columns.len() as i32;
+        table_columns.extend(columns.iter().cloned().enumerate().map(|(idx, mut col)| {
+            col.column_desc.column_id = ColumnId::new(payload_column_id_offset + idx as i32);
+            col.column_desc.name = format!("{}_{}", table_name, col.column_desc.name);
+            col.to_protobuf()
+        }));
+        PbTable {
+            columns: table_columns,
+            value_indices: (0..columns.len() + log_store_v2::KV_LOG_STORE_PREDEFINED_COLUMNS.len())
+                .map(|i| i as i32)
+                .collect(),
+            ..Default::default()
         }
     }
 
@@ -2369,59 +2383,16 @@ mod tests {
         }
     }
 
-    #[tokio::test]
-    async fn test_rewrite_refresh_schema_sink_fragment_with_project() {
-        let env = MetaSrvEnv::for_test().await;
-        let id_gen_manager = env.id_gen_manager().as_ref();
-
-        let table_name = "t";
-        let columns = vec![
-            make_column("a", 1, DataType::Int64),
-            make_column("b", 2, DataType::Int64),
-        ];
-        let new_column = make_column("c", 3, DataType::Varchar);
-
-        let mut upstream_columns = columns.clone();
-        upstream_columns.push(new_column.clone());
-        let upstream_table = PbTable {
-            name: table_name.to_owned(),
-            columns: upstream_columns
-                .iter()
-                .map(|col| col.to_protobuf())
-                .collect(),
-            ..Default::default()
-        };
-
-        let sink = PbSink {
-            columns: columns.iter().map(|col| col.to_protobuf()).collect(),
-            sink_type: PbSinkType::AppendOnly as i32,
-            ..Default::default()
-        };
-
-        let sink_desc = SinkDesc {
-            sink_type: PbSinkType::AppendOnly as i32,
-            column_catalogs: sink.columns.clone(),
-            ..Default::default()
-        };
-
-        let stream_scan_node = make_stream_scan_node(table_name, 1, &columns);
-        let project_node = make_project_node(table_name, &columns, stream_scan_node);
-
-        let log_store_table = PbTable {
-            columns: columns
-                .iter()
-                .cloned()
-                .map(|mut col| {
-                    col.column_desc.name = format!("{}_{}", table_name, col.column_desc.name);
-                    col.to_protobuf()
-                })
-                .collect(),
-            value_indices: (0..columns.len()).map(|i| i as i32).collect(),
-            ..Default::default()
-        };
-
-        let original_fragment = Fragment {
-            fragment_id: 1.into(),
+    fn make_sink_fragment(
+        fragment_id: FragmentId,
+        table_name: &str,
+        columns: &[ColumnCatalog],
+        sink_desc: SinkDesc,
+        input: StreamNode,
+        log_store_table: Option<PbTable>,
+    ) -> Fragment {
+        Fragment {
+            fragment_id,
             fragment_type_mask: FragmentTypeMask::default(),
             distribution_type: PbFragmentDistributionType::Single,
             state_table_ids: vec![],
@@ -2429,23 +2400,52 @@ mod tests {
             nodes: StreamNode {
                 node_body: Some(NodeBody::Sink(Box::new(SinkNode {
                     sink_desc: Some(sink_desc),
-                    table: Some(log_store_table),
+                    table: log_store_table,
+                    log_store_type: SinkLogStoreType::KvLogStore as i32,
                     ..Default::default()
                 }))),
                 fields: columns
                     .iter()
                     .map(|col| make_field(table_name, col))
                     .collect(),
-                input: vec![project_node],
+                input: vec![input],
                 ..Default::default()
             },
-        };
+        }
+    }
+
+    #[tokio::test]
+    async fn test_rewrite_refresh_schema_sink_fragment_with_project() {
+        let env = MetaSrvEnv::for_test().await;
+        let id_gen_manager = env.id_gen_manager().as_ref();
+        let table_name = "t";
+        let columns = vec![
+            make_column("a", 1, DataType::Int64),
+            make_column("b", 2, DataType::Int64),
+        ];
+        let new_column = make_column("c", 3, DataType::Varchar);
+        let upstream_table = make_upstream_table(
+            table_name,
+            &[columns[0].clone(), columns[1].clone(), new_column.clone()],
+        );
+        let (sink, sink_desc) = make_sink_and_desc(&columns);
+        let stream_scan_node = make_stream_scan_node(table_name, 1, &columns);
+        let project_node = make_project_node(table_name, &columns, stream_scan_node);
+        let original_fragment = make_sink_fragment(
+            1.into(),
+            table_name,
+            &columns,
+            sink_desc,
+            project_node,
+            Some(make_log_store_table(table_name, &columns)),
+        );
 
         let (new_fragment, _, _) = rewrite_refresh_schema_sink_fragment(
             &original_fragment,
             &sink,
-            std::slice::from_ref(&new_column),
-            &[],
+            TableSchemaChange::AddColumn {
+                columns: vec![new_column.clone()],
+            },
             &upstream_table,
             7.into(),
             id_gen_manager,
@@ -2496,80 +2496,49 @@ mod tests {
     async fn test_rewrite_refresh_schema_sink_fragment_drop_column_with_project() {
         let env = MetaSrvEnv::for_test().await;
         let id_gen_manager = env.id_gen_manager().as_ref();
-
         let table_name = "t";
         let columns = vec![
             make_column("a", 1, DataType::Int64),
             make_column("b", 2, DataType::Int64),
             make_column("tmp", 3, DataType::Varchar),
         ];
+        let row_id_column = ColumnCatalog::row_id_column();
         let removed_column = columns.last().unwrap().clone();
-        let upstream_columns = columns[..2].to_vec();
-
-        let upstream_table = PbTable {
-            name: table_name.to_owned(),
-            columns: upstream_columns
-                .iter()
-                .map(|col| col.to_protobuf())
-                .collect(),
-            ..Default::default()
-        };
-
-        let sink = PbSink {
-            columns: columns.iter().map(|col| col.to_protobuf()).collect(),
-            sink_type: PbSinkType::AppendOnly as i32,
-            ..Default::default()
-        };
-
-        let sink_desc = SinkDesc {
-            sink_type: PbSinkType::AppendOnly as i32,
-            column_catalogs: sink.columns.clone(),
-            ..Default::default()
-        };
-
-        let stream_scan_node = make_stream_scan_node(table_name, 1, &columns);
+        let upstream_table = make_upstream_table(
+            table_name,
+            &[
+                columns[0].clone(),
+                columns[1].clone(),
+                row_id_column.clone(),
+            ],
+        );
+        let (sink, sink_desc) = make_sink_and_desc(&columns);
+        let stream_scan_node = make_stream_scan_node(
+            table_name,
+            1,
+            &[
+                columns[0].clone(),
+                columns[1].clone(),
+                columns[2].clone(),
+                row_id_column,
+            ],
+        );
         let project_node = make_project_node(table_name, &columns, stream_scan_node);
+        let original_fragment = make_sink_fragment(
+            1.into(),
+            table_name,
+            &columns,
+            sink_desc,
+            project_node,
+            Some(make_log_store_table(table_name, &columns)),
+        );
 
-        let log_store_table = PbTable {
-            columns: columns
-                .iter()
-                .cloned()
-                .map(|mut col| {
-                    col.column_desc.name = format!("{}_{}", table_name, col.column_desc.name);
-                    col.to_protobuf()
-                })
-                .collect(),
-            value_indices: (0..columns.len()).map(|i| i as i32).collect(),
-            ..Default::default()
-        };
-
-        let original_fragment = Fragment {
-            fragment_id: 1.into(),
-            fragment_type_mask: FragmentTypeMask::default(),
-            distribution_type: PbFragmentDistributionType::Single,
-            state_table_ids: vec![],
-            maybe_vnode_count: None,
-            nodes: StreamNode {
-                node_body: Some(NodeBody::Sink(Box::new(SinkNode {
-                    sink_desc: Some(sink_desc),
-                    table: Some(log_store_table),
-                    log_store_type: SinkLogStoreType::KvLogStore as i32,
-                    ..Default::default()
-                }))),
-                fields: columns
-                    .iter()
-                    .map(|col| make_field(table_name, col))
-                    .collect(),
-                input: vec![project_node],
-                ..Default::default()
-            },
-        };
-
-        let (new_fragment, new_schema, new_log_store_table) = rewrite_refresh_schema_sink_fragment(
+        let (new_fragment, new_schema, updated_tables) = rewrite_refresh_schema_sink_fragment(
             &original_fragment,
             &sink,
-            &[],
-            std::slice::from_ref(&removed_column),
+            TableSchemaChange::DropColumn {
+                column_ids: vec![removed_column.column_id()],
+            },
             &upstream_table,
             7.into(),
             id_gen_manager,
@@ -2618,7 +2587,9 @@ mod tests {
                 .all(|f| !f.name.contains("tmp"))
         );
 
-        let new_log_store_table = new_log_store_table.expect("log store table should be updated");
+        let new_log_store_table = updated_tables
+            .first()
+            .expect("log store table should be updated");
         assert!(
             new_log_store_table.columns.iter().all(|col| !col
                 .column_desc
@@ -2631,5 +2602,198 @@ mod tests {
             new_log_store_table.value_indices,
             (0..new_log_store_table.columns.len() as i32).collect::<Vec<_>>()
         );
+    }
+
+    #[tokio::test]
+    async fn test_rewrite_refresh_schema_sink_fragment_with_scan() {
+        let env = MetaSrvEnv::for_test().await;
+        let id_gen_manager = env.id_gen_manager().as_ref();
+        let table_name = "t";
+        let columns = vec![
+            make_column("a", 1, DataType::Int64),
+            make_column("b", 2, DataType::Int64),
+        ];
+        let new_column = make_column("c", 3, DataType::Varchar);
+        let upstream_table = make_upstream_table(
+            table_name,
+            &[columns[0].clone(), columns[1].clone(), new_column.clone()],
+        );
+        let (sink, sink_desc) = make_sink_and_desc(&columns);
+        let original_fragment = make_sink_fragment(
+            1.into(),
+            table_name,
+            &columns,
+            sink_desc,
+            make_stream_scan_node(table_name, 1, &columns),
+            Some(make_log_store_table(table_name, &columns)),
+        );
+
+        let (new_fragment, new_schema, updated_tables) = rewrite_refresh_schema_sink_fragment(
+            &original_fragment,
+            &sink,
+            TableSchemaChange::AddColumn {
+                columns: vec![new_column.clone()],
+            },
+            &upstream_table,
+            7.into(),
+            id_gen_manager,
+        )
+        .unwrap();
+
+        assert_eq!(new_schema.len(), columns.len() + 1);
+        assert_eq!(new_fragment.nodes.fields.len(), columns.len() + 1);
+        let [stream_scan_node] = new_fragment.nodes.input.as_slice() else {
+            panic!("Sink has more than 1 input: {:?}", new_fragment.nodes.input);
+        };
+        let PbNodeBody::StreamScan(scan) = stream_scan_node.node_body.as_ref().unwrap() else {
+            panic!(
+                "expect PbNodeBody::StreamScan but got: {:?}",
+                stream_scan_node.node_body
+            );
+        };
+        assert_eq!(
+            scan.upstream_column_ids.last().copied(),
+            Some(new_column.column_id().get_id())
+        );
+        assert_eq!(
+            scan.output_indices.last().copied(),
+            Some(columns.len() as u32)
+        );
+        let [merge_node, batch_plan_node] = stream_scan_node.input.as_slice() else {
+            panic!("StreamScan should have Merge and BatchPlan inputs");
+        };
+        let PbNodeBody::Merge(merge) = merge_node.node_body.as_ref().unwrap() else {
+            panic!("expect Merge");
+        };
+        assert_eq!(merge.upstream_fragment_id, FragmentId::from(7));
+        assert!(matches!(
+            batch_plan_node.node_body.as_ref(),
+            Some(PbNodeBody::BatchPlan(_))
+        ));
+        assert!(batch_plan_node.fields.is_empty());
+
+        assert_eq!(updated_tables.len(), 1);
+        let new_log_store_table = updated_tables
+            .first()
+            .expect("log store table should be updated");
+        assert_eq!(
+            new_log_store_table.columns.len(),
+            log_store_v2::KV_LOG_STORE_PREDEFINED_COLUMNS.len() + columns.len() + 1
+        );
+        assert_eq!(
+            new_log_store_table
+                .columns
+                .last()
+                .unwrap()
+                .column_desc
+                .as_ref()
+                .unwrap()
+                .name,
+            format!("{}_{}", table_name, new_column.column_desc.name)
+        );
+    }
+
+    #[tokio::test]
+    async fn test_rewrite_refresh_schema_sink_fragment_rejects_unsupported_node() {
+        let env = MetaSrvEnv::for_test().await;
+        let id_gen_manager = env.id_gen_manager().as_ref();
+        let table_name = "t";
+        let columns = [make_column("a", 1, DataType::Int64)];
+        let new_column = make_column("b", 2, DataType::Int64);
+        let upstream_table =
+            make_upstream_table(table_name, &[columns[0].clone(), new_column.clone()]);
+        let (sink, sink_desc) = make_sink_and_desc(&columns);
+        let filter_node = StreamNode {
+            node_body: Some(NodeBody::Filter(Box::default())),
+            fields: columns
+                .iter()
+                .map(|col| make_field(table_name, col))
+                .collect(),
+            input: vec![make_stream_scan_node(table_name, 1, &columns)],
+            ..Default::default()
+        };
+        let original_fragment =
+            make_sink_fragment(1.into(), table_name, &columns, sink_desc, filter_node, None);
+
+        let err = rewrite_refresh_schema_sink_fragment(
+            &original_fragment,
+            &sink,
+            TableSchemaChange::AddColumn {
+                columns: vec![new_column],
+            },
+            &upstream_table,
+            7.into(),
+            id_gen_manager,
+        )
+        .unwrap_err();
+        let err = format!("{err:#}");
+        assert!(err.contains("Filter"), "{err}");
+    }
+
+    #[tokio::test]
+    async fn test_rewrite_refresh_schema_sink_fragment_rejects_multiple_changed_inputs() {
+        let env = MetaSrvEnv::for_test().await;
+        let id_gen_manager = env.id_gen_manager().as_ref();
+        let table_name = "t";
+        let columns = [make_column("a", 1, DataType::Int64)];
+        let new_column = make_column("b", 2, DataType::Int64);
+        let upstream_table =
+            make_upstream_table(table_name, &[columns[0].clone(), new_column.clone()]);
+        let (sink, sink_desc) = make_sink_and_desc(&columns);
+        let project_node = StreamNode {
+            node_body: Some(NodeBody::Project(Box::new(ProjectNode {
+                select_list: vec![make_input_ref(0, columns[0].data_type())],
+                ..Default::default()
+            }))),
+            fields: columns
+                .iter()
+                .map(|col| make_field(table_name, col))
+                .collect(),
+            input: vec![
+                make_stream_scan_node(table_name, 1, &columns),
+                make_stream_scan_node(table_name, 1, &columns),
+            ],
+            ..Default::default()
+        };
+        let original_fragment = make_sink_fragment(
+            1.into(),
+            table_name,
+            &columns,
+            sink_desc,
+            project_node,
+            None,
+        );
+
+        let err = rewrite_refresh_schema_sink_fragment(
+            &original_fragment,
+            &sink,
+            TableSchemaChange::AddColumn {
+                columns: vec![new_column],
+            },
+            &upstream_table,
+            7.into(),
+            id_gen_manager,
+        )
+        .unwrap_err();
+        let err = format!("{err:#}");
+        assert!(
+            err.contains("Project node should have exactly one input"),
+            "{err}"
+        );
+    }
+
+    #[test]
+    fn test_remap_index_after_drop() {
+        assert_eq!(remap_index_after_drop(0, &[1, 3]), Some(0));
+        assert_eq!(remap_index_after_drop(1, &[1, 3]), None);
+        assert_eq!(remap_index_after_drop(2, &[1, 3]), Some(1));
+        assert_eq!(remap_index_after_drop(3, &[1, 3]), None);
+        assert_eq!(remap_index_after_drop(4, &[1, 3]), Some(2));
+
+        assert_eq!(remap_index_after_drop(0, &[3, 1]), Some(0));
+        assert_eq!(remap_index_after_drop(1, &[3, 1]), None);
+        assert_eq!(remap_index_after_drop(2, &[3, 1]), Some(1));
+        assert_eq!(remap_index_after_drop(3, &[3, 1]), None);
+        assert_eq!(remap_index_after_drop(4, &[3, 1]), Some(2));
     }
 }

--- a/src/meta/src/stream/stream_graph/fragment.rs
+++ b/src/meta/src/stream/stream_graph/fragment.rs
@@ -35,6 +35,7 @@ use risingwave_common::util::stream_graph_visitor::{
 use risingwave_connector::sink::catalog::SinkType;
 use risingwave_meta_model::streaming_job::BackfillOrders;
 use risingwave_pb::catalog::{PbSink, PbTable, Table};
+use risingwave_pb::common::ColumnOrder;
 use risingwave_pb::ddl_service::TableJobType;
 use risingwave_pb::expr::{ExprNode as PbExprNode, expr_node};
 use risingwave_pb::id::{RelationId, StreamNodeLocalOperatorId};
@@ -53,13 +54,13 @@ use risingwave_pb::stream_plan::{
 use crate::barrier::SnapshotBackfillInfo;
 use crate::manager::{MetaSrvEnv, StreamingJob, StreamingJobType};
 use crate::model::{Fragment, FragmentDownstreamRelation, FragmentId};
-use crate::stream::TableMetadataUpdate;
 use crate::stream::stream_graph::id::{GlobalFragmentId, GlobalFragmentIdGen, GlobalTableIdGen};
 use crate::stream::stream_graph::schedule::Distribution;
 use crate::stream::stream_graph::schema_change::{
     AddColumn, DropColumn, NodeSchemaRewrite, PropagatedSchemaChange, TableSchemaChange,
-    validate_log_store_schema_prefix,
+    remap_index_after_drop, validate_log_store_schema_prefix,
 };
+use crate::stream::{SinkMetadataChange, TableMetadataUpdate};
 use crate::{MetaError, MetaResult};
 
 /// The fragment in the building phase, including the [`StreamFragment`] from the frontend and
@@ -598,6 +599,8 @@ pub(super) fn rewrite_stream_scan_and_merge(
     };
 
     // update merge node
+    // The Merge node input of StreamScan has an empty stream key, so only its fields and upstream
+    // fragment need to be rewritten here.
     merge_node.fields = scan
         .upstream_column_ids
         .iter()
@@ -621,9 +624,8 @@ pub(super) fn rewrite_stream_scan_and_merge(
 /// Rewrite Project node input refs and extend with newly added columns.
 pub(super) fn rewrite_project_node(
     mut project_node_body: ProjectNode,
-    fields: Vec<PbField>,
     input_change: PropagatedSchemaChange,
-    input_fields: Vec<PbField>,
+    input_fields: &[PbField],
 ) -> MetaResult<NodeSchemaRewrite> {
     let has_non_input_ref = project_node_body
         .select_list
@@ -653,7 +655,6 @@ pub(super) fn rewrite_project_node(
     };
 
     let mut new_select_list = Vec::with_capacity(project_node_body.select_list.len());
-    let mut new_project_fields = Vec::with_capacity(fields.len());
     let mut removed_indices = Vec::new();
     for (index, expr) in project_node_body.select_list.iter().enumerate() {
         let mut new_expr = expr.clone();
@@ -667,7 +668,6 @@ pub(super) fn rewrite_project_node(
             bail!("auto schema change with drop column only supports Project with InputRef");
         }
         new_select_list.push(new_expr);
-        new_project_fields.push(fields[index].clone());
     }
 
     let start_input_index = input_fields.len() - newly_added_fields.len();
@@ -681,14 +681,12 @@ pub(super) fn rewrite_project_node(
             return_type: field.data_type.clone(),
             rex_node: Some(expr_node::RexNode::InputRef(new_index)),
         });
-        new_project_fields.push(input_fields[new_index as usize].clone());
     }
     project_node_body.select_list = new_select_list;
     let change = propagate_schema_change(newly_added_fields.to_vec(), removed_indices);
 
     Ok(NodeSchemaRewrite {
         body: NodeBody::Project(Box::new(project_node_body)),
-        fields: new_project_fields,
         identity: None,
         change,
     })
@@ -698,11 +696,11 @@ pub(super) fn rewrite_project_node(
 pub(super) fn rewrite_sink_node(
     mut sink_node_body: SinkNode,
     input_change: PropagatedSchemaChange,
-    input_fields: Vec<PbField>,
+    input_fields: &[PbField],
     sink: &PbSink,
 ) -> MetaResult<(
     NodeSchemaRewrite,
-    Vec<PbColumnCatalog>,
+    SinkMetadataChange,
     Option<TableMetadataUpdate>,
 )> {
     let mut removed_column_names = HashSet::new();
@@ -792,29 +790,63 @@ pub(super) fn rewrite_sink_node(
     } else {
         None
     };
-    sink_node_body.sink_desc.as_mut().unwrap().column_catalogs = new_sink_columns.clone();
+    let new_plan_pk = sink
+        .plan_pk
+        .iter()
+        .map(|order| {
+            let column_index = input_change
+                .remap_index(order.column_index as usize, "sink plan primary key")?
+                as u32;
+            Ok(ColumnOrder {
+                column_index,
+                order_type: order.order_type,
+            })
+        })
+        .collect::<MetaResult<Vec<_>>>()?;
+    let new_distribution_key = sink
+        .distribution_key
+        .iter()
+        .map(|&index| {
+            input_change
+                .remap_index(index as usize, "sink distribution key")
+                .map(|index| index as i32)
+        })
+        .collect::<MetaResult<Vec<_>>>()?;
+    let new_downstream_pk = sink
+        .downstream_pk
+        .iter()
+        .map(|&index| {
+            input_change
+                .remap_index(index as usize, "sink downstream primary key")
+                .map(|index| index as i32)
+        })
+        .collect::<MetaResult<Vec<_>>>()?;
+    let sink_desc = sink_node_body.sink_desc.as_mut().unwrap();
+    sink_desc.column_catalogs = new_sink_columns.clone();
+    sink_desc.plan_pk = new_plan_pk.clone();
+    sink_desc.distribution_key = new_distribution_key
+        .iter()
+        .map(|&index| index as u32)
+        .collect();
+    sink_desc.downstream_pk = new_downstream_pk
+        .iter()
+        .map(|&index| index as u32)
+        .collect();
 
     Ok((
         NodeSchemaRewrite {
             body: NodeBody::Sink(Box::new(sink_node_body)),
-            fields: input_fields,
             identity: Some(identity),
             change: Some(input_change),
         },
-        new_sink_columns,
+        SinkMetadataChange {
+            columns: new_sink_columns,
+            plan_pk: new_plan_pk,
+            distribution_key: new_distribution_key,
+            downstream_pk: new_downstream_pk,
+        },
         updated_table,
     ))
-}
-
-fn remap_index_after_drop(old_index: usize, removed_indices: &[usize]) -> Option<usize> {
-    if removed_indices.contains(&old_index) {
-        return None;
-    }
-    let removed_before = removed_indices
-        .iter()
-        .filter(|&&removed_index| removed_index < old_index)
-        .count();
-    Some(old_index - removed_before)
 }
 
 /// Adjacency list (G) of backfill orders.
@@ -2224,7 +2256,9 @@ mod tests {
     };
     use risingwave_common::constants::log_store::v2 as log_store_v2;
     use risingwave_common::types::DataType;
+    use risingwave_common::util::sort_util::OrderType;
     use risingwave_pb::catalog::{PbSink, PbTable, SinkType as PbSinkType};
+    use risingwave_pb::common::ColumnOrder;
     use risingwave_pb::expr::{ExprNode as PbExprNode, expr_node};
     use risingwave_pb::meta::table_fragments::fragment::PbFragmentDistributionType;
     use risingwave_pb::plan_common::{PbField, StorageTableDesc};
@@ -2533,21 +2567,22 @@ mod tests {
             Some(make_log_store_table(table_name, &columns)),
         );
 
-        let (new_fragment, new_schema, updated_tables) = rewrite_refresh_schema_sink_fragment(
-            &original_fragment,
-            &sink,
-            TableSchemaChange::DropColumn {
-                column_ids: vec![removed_column.column_id()],
-            },
-            &upstream_table,
-            7.into(),
-            id_gen_manager,
-        )
-        .unwrap();
+        let (new_fragment, sink_metadata_change, updated_tables) =
+            rewrite_refresh_schema_sink_fragment(
+                &original_fragment,
+                &sink,
+                TableSchemaChange::DropColumn {
+                    column_ids: vec![removed_column.column_id()],
+                },
+                &upstream_table,
+                7.into(),
+                id_gen_manager,
+            )
+            .unwrap();
 
-        assert_eq!(new_schema.len(), 2);
+        assert_eq!(sink_metadata_change.columns.len(), 2);
         assert!(
-            new_schema.iter().all(|col| {
+            sink_metadata_change.columns.iter().all(|col| {
                 col.column_desc.as_ref().map(|desc| desc.name.as_str()) != Some("tmp")
             })
         );
@@ -2605,6 +2640,81 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_rewrite_refresh_schema_sink_fragment_remaps_stream_key_after_drop_column() {
+        let env = MetaSrvEnv::for_test().await;
+        let id_gen_manager = env.id_gen_manager().as_ref();
+        let table_name = "t";
+        let columns = vec![
+            make_column("tmp", 1, DataType::Int64),
+            make_column("id", 2, DataType::Int64),
+            make_column("name", 3, DataType::Int64),
+        ];
+        let removed_column = columns[0].clone();
+        let upstream_table =
+            make_upstream_table(table_name, &[columns[1].clone(), columns[2].clone()]);
+        let (mut sink, mut sink_desc) = make_sink_and_desc(&columns);
+        sink.plan_pk = vec![ColumnOrder {
+            column_index: 1,
+            order_type: Some(OrderType::ascending().to_protobuf()),
+        }];
+        sink.distribution_key = vec![1];
+        sink.downstream_pk = vec![1];
+        sink_desc.plan_pk = sink.plan_pk.clone();
+        sink_desc.distribution_key = vec![1];
+        sink_desc.downstream_pk = vec![1];
+
+        let mut stream_scan_node = make_stream_scan_node(table_name, 1, &columns);
+        stream_scan_node.stream_key = vec![1];
+        stream_scan_node.input[0].stream_key = vec![1];
+        let mut project_node = make_project_node(table_name, &columns, stream_scan_node);
+        project_node.stream_key = vec![1];
+        let mut original_fragment = make_sink_fragment(
+            1.into(),
+            table_name,
+            &columns,
+            sink_desc,
+            project_node,
+            Some(make_log_store_table(table_name, &columns)),
+        );
+        original_fragment.nodes.stream_key = vec![1];
+
+        let (new_fragment, sink_metadata_change, _) = rewrite_refresh_schema_sink_fragment(
+            &original_fragment,
+            &sink,
+            TableSchemaChange::DropColumn {
+                column_ids: vec![removed_column.column_id()],
+            },
+            &upstream_table,
+            7.into(),
+            id_gen_manager,
+        )
+        .unwrap();
+
+        assert_eq!(new_fragment.nodes.stream_key, vec![0]);
+        assert_eq!(sink_metadata_change.plan_pk[0].column_index, 0);
+        assert_eq!(sink_metadata_change.distribution_key, vec![0]);
+        assert_eq!(sink_metadata_change.downstream_pk, vec![0]);
+        let PbNodeBody::Sink(sink_body) = new_fragment.nodes.node_body.as_ref().unwrap() else {
+            panic!(
+                "expect PbNodeBody::Sink but got: {:?}",
+                new_fragment.nodes.node_body
+            );
+        };
+        let sink_desc = sink_body.sink_desc.as_ref().unwrap();
+        assert_eq!(sink_desc.plan_pk[0].column_index, 0);
+        assert_eq!(sink_desc.distribution_key, vec![0]);
+        assert_eq!(sink_desc.downstream_pk, vec![0]);
+        let [project_node] = new_fragment.nodes.input.as_slice() else {
+            panic!("Sink has more than 1 input: {:?}", new_fragment.nodes.input);
+        };
+        assert_eq!(project_node.stream_key, vec![0]);
+        let [stream_scan_node] = project_node.input.as_slice() else {
+            panic!("Project has more than 1 input: {:?}", project_node.input);
+        };
+        assert_eq!(stream_scan_node.stream_key, vec![0]);
+    }
+
+    #[tokio::test]
     async fn test_rewrite_refresh_schema_sink_fragment_with_scan() {
         let env = MetaSrvEnv::for_test().await;
         let id_gen_manager = env.id_gen_manager().as_ref();
@@ -2628,19 +2738,20 @@ mod tests {
             Some(make_log_store_table(table_name, &columns)),
         );
 
-        let (new_fragment, new_schema, updated_tables) = rewrite_refresh_schema_sink_fragment(
-            &original_fragment,
-            &sink,
-            TableSchemaChange::AddColumn {
-                columns: vec![new_column.clone()],
-            },
-            &upstream_table,
-            7.into(),
-            id_gen_manager,
-        )
-        .unwrap();
+        let (new_fragment, sink_metadata_change, updated_tables) =
+            rewrite_refresh_schema_sink_fragment(
+                &original_fragment,
+                &sink,
+                TableSchemaChange::AddColumn {
+                    columns: vec![new_column.clone()],
+                },
+                &upstream_table,
+                7.into(),
+                id_gen_manager,
+            )
+            .unwrap();
 
-        assert_eq!(new_schema.len(), columns.len() + 1);
+        assert_eq!(sink_metadata_change.columns.len(), columns.len() + 1);
         assert_eq!(new_fragment.nodes.fields.len(), columns.len() + 1);
         let [stream_scan_node] = new_fragment.nodes.input.as_slice() else {
             panic!("Sink has more than 1 input: {:?}", new_fragment.nodes.input);
@@ -2780,20 +2891,5 @@ mod tests {
             err.contains("Project node should have exactly one input"),
             "{err}"
         );
-    }
-
-    #[test]
-    fn test_remap_index_after_drop() {
-        assert_eq!(remap_index_after_drop(0, &[1, 3]), Some(0));
-        assert_eq!(remap_index_after_drop(1, &[1, 3]), None);
-        assert_eq!(remap_index_after_drop(2, &[1, 3]), Some(1));
-        assert_eq!(remap_index_after_drop(3, &[1, 3]), None);
-        assert_eq!(remap_index_after_drop(4, &[1, 3]), Some(2));
-
-        assert_eq!(remap_index_after_drop(0, &[3, 1]), Some(0));
-        assert_eq!(remap_index_after_drop(1, &[3, 1]), None);
-        assert_eq!(remap_index_after_drop(2, &[3, 1]), Some(1));
-        assert_eq!(remap_index_after_drop(3, &[3, 1]), None);
-        assert_eq!(remap_index_after_drop(4, &[3, 1]), Some(2));
     }
 }

--- a/src/meta/src/stream/stream_graph/fragment.rs
+++ b/src/meta/src/stream/stream_graph/fragment.rs
@@ -464,7 +464,7 @@ pub(super) fn rewrite_stream_scan_and_merge(
     stream_scan_node: &mut StreamNode,
     upstream_table_change: &TableSchemaChange,
     upstream_table: &PbTable,
-    new_upstream_fragment_id: FragmentId,
+    upstream_table_fragment_id: FragmentId,
 ) -> MetaResult<Option<PropagatedSchemaChange>> {
     let PbNodeBody::StreamScan(scan) = stream_scan_node.node_body.as_mut().unwrap() else {
         return Err(anyhow!(
@@ -612,7 +612,7 @@ pub(super) fn rewrite_stream_scan_and_merge(
             .to_prost()
         })
         .collect();
-    merge.upstream_fragment_id = new_upstream_fragment_id;
+    merge.upstream_fragment_id = upstream_table_fragment_id;
 
     let change = propagate_schema_change(newly_added_fields, removed_indices);
     Ok(change)

--- a/src/meta/src/stream/stream_graph/schema_change.rs
+++ b/src/meta/src/stream/stream_graph/schema_change.rs
@@ -1,0 +1,522 @@
+// Copyright 2026 RisingWave Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::BTreeMap;
+
+use anyhow::{Context, anyhow};
+use risingwave_common::catalog::{ColumnCatalog, ColumnId};
+use risingwave_common::constants::log_store::v2 as log_store_v2;
+use risingwave_common::types::DataType;
+use risingwave_common::util::iter_util::ZipEqFast;
+use risingwave_common::{bail, dispatch_stream_node_body};
+use risingwave_pb::catalog::{PbSink, PbTable};
+use risingwave_pb::plan_common::{PbColumnCatalog, PbField};
+use risingwave_pb::stream_plan::stream_node::NodeBody;
+use risingwave_pb::stream_plan::{
+    self, PbStreamScanType, ProjectNode, SinkNode, StreamNode, StreamScanNode,
+};
+
+use crate::MetaResult;
+use crate::controller::id::IdGeneratorManager;
+use crate::model::{Fragment, FragmentId};
+use crate::stream::TableMetadataUpdate;
+use crate::stream::stream_graph::fragment::{
+    rewrite_project_node, rewrite_sink_node, rewrite_stream_scan_and_merge,
+};
+use crate::stream::stream_graph::id::GlobalFragmentIdGen;
+
+pub fn check_sink_fragments_support_refresh_schema(
+    fragments: &BTreeMap<FragmentId, Fragment>,
+) -> MetaResult<()> {
+    if fragments.len() != 1 {
+        return Err(anyhow!(
+            "sink with auto schema change should have only 1 fragment, but got {:?}",
+            fragments.len()
+        )
+        .into());
+    }
+    let (_, fragment) = fragments.first_key_value().expect("non-empty");
+    if !matches!(fragment.nodes.node_body.as_ref(), Some(NodeBody::Sink(_))) {
+        return Err(anyhow!(
+            "expect Sink node for auto schema change but got: {:?}",
+            fragment.nodes.node_body
+        )
+        .into());
+    }
+    check_stream_node_schema_change_support(&fragment.nodes)?;
+    Ok(())
+}
+
+#[derive(Clone, Debug)]
+pub enum TableSchemaChange {
+    AddColumn { columns: Vec<ColumnCatalog> },
+    DropColumn { column_ids: Vec<ColumnId> },
+}
+
+#[derive(Clone, Debug)]
+pub(super) enum PropagatedSchemaChange {
+    AddColumn(AddColumn),
+    DropColumn(DropColumn),
+}
+
+impl PropagatedSchemaChange {
+    pub(super) fn newly_added_fields(&self) -> &[PbField] {
+        match self {
+            Self::AddColumn(add_column) => &add_column.added_fields,
+            Self::DropColumn(_) => &[],
+        }
+    }
+
+    pub(super) fn is_drop_column(&self) -> bool {
+        matches!(self, Self::DropColumn(_))
+    }
+}
+
+#[derive(Clone, Debug)]
+pub(super) struct AddColumn {
+    /// Logical fields appended by this change. `StreamScan` reads upstream
+    /// table-specific catalog metadata, such as column ids, from the collector's
+    /// new upstream table.
+    pub added_fields: Vec<PbField>,
+}
+
+#[derive(Clone, Debug)]
+pub(super) struct DropColumn {
+    /// Old output indices removed by this change.
+    pub removed_indices: Vec<usize>,
+}
+
+struct SinkSchemaChangeCollector<'a> {
+    new_upstream_table: &'a PbTable,
+    upstream_table_change: &'a TableSchemaChange,
+    new_upstream_fragment_id: FragmentId,
+    original_sink: &'a PbSink,
+    new_sink_columns: &'a mut Option<Vec<PbColumnCatalog>>,
+    updated_tables: &'a mut Vec<TableMetadataUpdate>,
+}
+
+impl<'a> SinkSchemaChangeCollector<'a> {
+    fn reborrow<'b>(&'b mut self) -> SinkSchemaChangeCollector<'b> {
+        SinkSchemaChangeCollector {
+            new_upstream_table: self.new_upstream_table,
+            upstream_table_change: self.upstream_table_change,
+            new_upstream_fragment_id: self.new_upstream_fragment_id,
+            original_sink: self.original_sink,
+            new_sink_columns: &mut *self.new_sink_columns,
+            updated_tables: &mut *self.updated_tables,
+        }
+    }
+}
+
+pub(super) fn validate_log_store_schema_prefix(log_store_table: &PbTable) -> MetaResult<usize> {
+    let predefined_len = log_store_v2::KV_LOG_STORE_PREDEFINED_COLUMNS.len();
+    if log_store_table.columns.len() < predefined_len {
+        bail!(
+            "invalid log store table column count {} for sink schema change",
+            log_store_table.columns.len()
+        );
+    }
+    for (column, (expected_name, expected_type)) in log_store_table.columns[..predefined_len]
+        .iter()
+        .zip_eq_fast(log_store_v2::KV_LOG_STORE_PREDEFINED_COLUMNS.iter())
+    {
+        let column_desc = column.column_desc.as_ref().unwrap();
+        if column_desc.name != *expected_name {
+            bail!(
+                "log store predefined column name {} does not match expected {}",
+                column_desc.name,
+                expected_name
+            );
+        }
+        let column_type = DataType::from(column_desc.column_type.as_ref().unwrap());
+        if !column_type.equals_datatype(expected_type) {
+            bail!(
+                "log store predefined column type mismatch for column {}",
+                column_desc.name
+            );
+        }
+    }
+    Ok(predefined_len)
+}
+
+pub(super) fn sink_node_supports_log_store_schema_change(sink_node: &SinkNode) -> bool {
+    sink_node
+        .table
+        .as_ref()
+        .is_none_or(|log_store_table| validate_log_store_schema_prefix(log_store_table).is_ok())
+}
+
+pub(super) struct NodeSchemaRewrite {
+    pub body: NodeBody,
+    pub fields: Vec<PbField>,
+    pub identity: Option<String>,
+    pub change: Option<PropagatedSchemaChange>,
+}
+
+trait SinkSchemaChangeSupport {
+    fn supports_schema_change(&self) -> bool {
+        false
+    }
+
+    fn apply_schema_change(
+        self,
+        _fields: Vec<PbField>,
+        _input_changes: Vec<(Option<PropagatedSchemaChange>, Vec<PbField>)>,
+        _collector: SinkSchemaChangeCollector<'_>,
+    ) -> MetaResult<NodeSchemaRewrite>
+    where
+        Self: Sized,
+    {
+        Err(anyhow!(
+            "{} node does not support sink auto schema change",
+            std::any::type_name::<Self>()
+        )
+        .into())
+    }
+}
+
+impl SinkSchemaChangeSupport for stream_plan::MergeNode {
+    fn supports_schema_change(&self) -> bool {
+        true
+    }
+
+    fn apply_schema_change(
+        self,
+        _fields: Vec<PbField>,
+        _input_changes: Vec<(Option<PropagatedSchemaChange>, Vec<PbField>)>,
+        _collector: SinkSchemaChangeCollector<'_>,
+    ) -> MetaResult<NodeSchemaRewrite> {
+        Err(anyhow!("Merge node should be rewritten together with StreamScan node").into())
+    }
+}
+
+impl SinkSchemaChangeSupport for StreamScanNode {
+    fn supports_schema_change(&self) -> bool {
+        self.stream_scan_type == PbStreamScanType::ArrangementBackfill as i32
+    }
+
+    fn apply_schema_change(
+        self,
+        _fields: Vec<PbField>,
+        _input_changes: Vec<(Option<PropagatedSchemaChange>, Vec<PbField>)>,
+        _collector: SinkSchemaChangeCollector<'_>,
+    ) -> MetaResult<NodeSchemaRewrite> {
+        Err(anyhow!("StreamScan node should be rewritten together with Merge node").into())
+    }
+}
+
+impl SinkSchemaChangeSupport for ProjectNode {
+    fn supports_schema_change(&self) -> bool {
+        true
+    }
+
+    fn apply_schema_change(
+        self,
+        fields: Vec<PbField>,
+        input_changes: Vec<(Option<PropagatedSchemaChange>, Vec<PbField>)>,
+        _collector: SinkSchemaChangeCollector<'_>,
+    ) -> MetaResult<NodeSchemaRewrite> {
+        if input_changes.len() != 1 {
+            return Err(anyhow!(
+                "Project node should have exactly one input for sink schema change, but got {}",
+                input_changes.len()
+            )
+            .into());
+        }
+        let [(input_change, input_fields)] = input_changes.as_slice() else {
+            unreachable!("Project input length is checked above")
+        };
+        let Some(input_change) = input_change else {
+            return Ok(NodeSchemaRewrite {
+                body: NodeBody::Project(Box::new(self)),
+                fields,
+                identity: None,
+                change: None,
+            });
+        };
+        rewrite_project_node(self, fields, input_change.clone(), input_fields.clone())
+    }
+}
+
+impl SinkSchemaChangeSupport for SinkNode {
+    fn supports_schema_change(&self) -> bool {
+        sink_node_supports_log_store_schema_change(self)
+    }
+
+    fn apply_schema_change(
+        self,
+        fields: Vec<PbField>,
+        input_changes: Vec<(Option<PropagatedSchemaChange>, Vec<PbField>)>,
+        collector: SinkSchemaChangeCollector<'_>,
+    ) -> MetaResult<NodeSchemaRewrite> {
+        if input_changes.len() != 1 {
+            return Err(anyhow!(
+                "Sink node should have exactly one input for sink schema change, but got {}",
+                input_changes.len()
+            )
+            .into());
+        }
+        let [(input_change, input_fields)] = input_changes.as_slice() else {
+            unreachable!("Sink input length is checked above")
+        };
+        let Some(input_change) = input_change else {
+            return Ok(NodeSchemaRewrite {
+                body: NodeBody::Sink(Box::new(self)),
+                fields,
+                identity: None,
+                change: None,
+            });
+        };
+        let (rewrite, sink_columns, updated_table) = rewrite_sink_node(
+            self,
+            input_change.clone(),
+            input_fields.clone(),
+            collector.original_sink,
+        )?;
+        if let Some(updated_table) = updated_table {
+            collector.updated_tables.push(updated_table);
+        }
+        *collector.new_sink_columns = Some(sink_columns);
+        Ok(rewrite)
+    }
+}
+
+impl SinkSchemaChangeSupport for stream_plan::BatchPlanNode {
+    fn supports_schema_change(&self) -> bool {
+        true
+    }
+
+    fn apply_schema_change(
+        self,
+        _fields: Vec<PbField>,
+        _input_changes: Vec<(Option<PropagatedSchemaChange>, Vec<PbField>)>,
+        _collector: SinkSchemaChangeCollector<'_>,
+    ) -> MetaResult<NodeSchemaRewrite> {
+        Err(anyhow!("BatchPlan node should be rewritten together with StreamScan node").into())
+    }
+}
+
+macro_rules! impl_unsupported_schema_change {
+    ($($ty:ty),* $(,)?) => {
+        $(
+            impl SinkSchemaChangeSupport for $ty {}
+        )*
+    };
+}
+
+impl_unsupported_schema_change!(
+    stream_plan::SourceNode,
+    stream_plan::FilterNode,
+    stream_plan::MaterializeNode,
+    stream_plan::SimpleAggNode,
+    stream_plan::HashAggNode,
+    stream_plan::TopNNode,
+    stream_plan::HashJoinNode,
+    stream_plan::HopWindowNode,
+    stream_plan::ExchangeNode,
+    stream_plan::LookupNode,
+    stream_plan::ArrangeNode,
+    stream_plan::LookupUnionNode,
+    stream_plan::UnionNode,
+    stream_plan::DeltaIndexJoinNode,
+    stream_plan::ExpandNode,
+    stream_plan::DynamicFilterNode,
+    stream_plan::ProjectSetNode,
+    stream_plan::GroupTopNNode,
+    stream_plan::SortNode,
+    stream_plan::WatermarkFilterNode,
+    stream_plan::DmlNode,
+    stream_plan::RowIdGenNode,
+    stream_plan::NowNode,
+    stream_plan::TemporalJoinNode,
+    stream_plan::BarrierRecvNode,
+    stream_plan::ValuesNode,
+    stream_plan::DedupNode,
+    stream_plan::NoOpNode,
+    stream_plan::EowcOverWindowNode,
+    stream_plan::OverWindowNode,
+    stream_plan::StreamFsFetchNode,
+    stream_plan::StreamCdcScanNode,
+    stream_plan::CdcFilterNode,
+    stream_plan::SourceBackfillNode,
+    stream_plan::ChangeLogNode,
+    stream_plan::LocalApproxPercentileNode,
+    stream_plan::GlobalApproxPercentileNode,
+    stream_plan::RowMergeNode,
+    stream_plan::AsOfJoinNode,
+    stream_plan::SyncLogStoreNode,
+    stream_plan::MaterializedExprsNode,
+    stream_plan::VectorIndexWriteNode,
+    stream_plan::UpstreamSinkUnionNode,
+    stream_plan::LocalityProviderNode,
+    stream_plan::EowcGapFillNode,
+    stream_plan::GapFillNode,
+    stream_plan::VectorIndexLookupJoinNode,
+    stream_plan::IcebergWithPkIndexWriterNode,
+    stream_plan::IcebergWithPkIndexDvMergerNode,
+);
+
+fn node_body_name(body: &NodeBody) -> &'static str {
+    dispatch_stream_node_body!(body, _NodeVariant, node => std::any::type_name_of_val(node))
+}
+
+fn node_supports_schema_change(body: &NodeBody) -> bool {
+    dispatch_stream_node_body!(body, _NodeVariant, node => {
+        node.supports_schema_change()
+    })
+}
+
+fn apply_node_schema_change(
+    body: NodeBody,
+    fields: Vec<PbField>,
+    input_changes: Vec<(Option<PropagatedSchemaChange>, Vec<PbField>)>,
+    collector: SinkSchemaChangeCollector<'_>,
+) -> MetaResult<NodeSchemaRewrite> {
+    let node_name = node_body_name(&body);
+    if !node_supports_schema_change(&body) {
+        return Err(anyhow!("{} node does not support sink schema change", node_name).into());
+    }
+    let rewrite = dispatch_stream_node_body!(body, _NodeVariant, node => {
+        node.apply_schema_change(fields, input_changes, collector)
+    });
+    rewrite
+        .with_context(|| format!("failed to apply sink schema change on {} node", node_name))
+        .map_err(Into::into)
+}
+
+fn check_stream_node_schema_change_support(node: &StreamNode) -> MetaResult<()> {
+    let body = node
+        .node_body
+        .as_ref()
+        .ok_or_else(|| anyhow!("stream node body is missing"))?;
+
+    for input_node in &node.input {
+        check_stream_node_schema_change_support(input_node)?;
+    }
+    if !node_supports_schema_change(body) {
+        return Err(anyhow!(
+            "{} node {} does not support sink schema change",
+            node_body_name(body),
+            node.operator_id
+        )
+        .into());
+    }
+    Ok(())
+}
+
+fn rewrite_stream_node_for_sink_schema_change(
+    node: StreamNode,
+    mut collector: SinkSchemaChangeCollector<'_>,
+) -> MetaResult<(StreamNode, Option<PropagatedSchemaChange>)> {
+    if matches!(node.node_body.as_ref(), Some(NodeBody::StreamScan(_))) {
+        let mut stream_scan_node = node;
+        let change = rewrite_stream_scan_and_merge(
+            &mut stream_scan_node,
+            collector.upstream_table_change,
+            collector.new_upstream_table,
+            collector.new_upstream_fragment_id,
+        )?;
+        return Ok((stream_scan_node, change));
+    }
+
+    let StreamNode {
+        operator_id,
+        input,
+        stream_key,
+        stream_kind,
+        identity,
+        fields,
+        node_body,
+    } = node;
+    let body = node_body.ok_or_else(|| anyhow!("stream node body is missing"))?;
+
+    let mut new_inputs = Vec::with_capacity(input.len());
+    let mut input_changes = vec![];
+    for input_node in input {
+        let (new_input, input_change) =
+            rewrite_stream_node_for_sink_schema_change(input_node, collector.reborrow())?;
+        let input_fields = new_input.fields.clone();
+        new_inputs.push(new_input);
+        input_changes.push((input_change, input_fields));
+    }
+    let rewrite = apply_node_schema_change(body, fields, input_changes, collector.reborrow())
+        .with_context(|| format!("failed to rewrite stream node {}", operator_id))?;
+
+    Ok((
+        StreamNode {
+            operator_id,
+            input: new_inputs,
+            stream_key,
+            stream_kind,
+            identity: rewrite.identity.unwrap_or(identity),
+            fields: rewrite.fields,
+            node_body: Some(rewrite.body),
+        },
+        rewrite.change,
+    ))
+}
+
+pub fn rewrite_refresh_schema_sink_fragment(
+    original_sink_fragment: &Fragment,
+    sink: &PbSink,
+    schema_change: TableSchemaChange,
+    upstream_table: &PbTable,
+    upstream_table_fragment_id: FragmentId,
+    id_generator_manager: &IdGeneratorManager,
+) -> MetaResult<(Fragment, Vec<PbColumnCatalog>, Vec<TableMetadataUpdate>)> {
+    let root_body = original_sink_fragment
+        .nodes
+        .node_body
+        .as_ref()
+        .ok_or_else(|| anyhow!("stream node body is missing"))?;
+    if !matches!(root_body, NodeBody::Sink(_)) {
+        return Err(anyhow!(
+            "expect Sink node for auto schema change but got {}",
+            node_body_name(root_body)
+        )
+        .into());
+    }
+    let fragment_id = GlobalFragmentIdGen::new(id_generator_manager, 1)
+        .to_global_id(0)
+        .as_global_id();
+    let mut new_sink_columns = None;
+    let mut updated_tables = vec![];
+
+    let collector = SinkSchemaChangeCollector {
+        new_upstream_table: upstream_table,
+        upstream_table_change: &schema_change,
+        new_upstream_fragment_id: upstream_table_fragment_id,
+        original_sink: sink,
+        new_sink_columns: &mut new_sink_columns,
+        updated_tables: &mut updated_tables,
+    };
+    let (new_nodes, output_change) = rewrite_stream_node_for_sink_schema_change(
+        original_sink_fragment.nodes.clone(),
+        collector,
+    )?;
+    if output_change.is_none() {
+        tracing::warn!("sink schema change did not affect the Sink node while rewriting fragment");
+    }
+
+    let new_sink_columns = new_sink_columns.unwrap_or_else(|| sink.columns.clone());
+    let new_sink_fragment = Fragment {
+        fragment_id,
+        fragment_type_mask: original_sink_fragment.fragment_type_mask,
+        distribution_type: original_sink_fragment.distribution_type,
+        state_table_ids: original_sink_fragment.state_table_ids.clone(),
+        maybe_vnode_count: original_sink_fragment.maybe_vnode_count,
+        nodes: new_nodes,
+    };
+    Ok((new_sink_fragment, new_sink_columns, updated_tables))
+}

--- a/src/meta/src/stream/stream_graph/schema_change.rs
+++ b/src/meta/src/stream/stream_graph/schema_change.rs
@@ -21,7 +21,7 @@ use risingwave_common::types::DataType;
 use risingwave_common::util::iter_util::ZipEqFast;
 use risingwave_common::{bail, dispatch_stream_node_body};
 use risingwave_pb::catalog::{PbSink, PbTable};
-use risingwave_pb::plan_common::{PbColumnCatalog, PbField};
+use risingwave_pb::plan_common::PbField;
 use risingwave_pb::stream_plan::stream_node::NodeBody;
 use risingwave_pb::stream_plan::{
     self, PbStreamScanType, ProjectNode, SinkNode, StreamNode, StreamScanNode,
@@ -30,11 +30,11 @@ use risingwave_pb::stream_plan::{
 use crate::MetaResult;
 use crate::controller::id::IdGeneratorManager;
 use crate::model::{Fragment, FragmentId};
-use crate::stream::TableMetadataUpdate;
 use crate::stream::stream_graph::fragment::{
     rewrite_project_node, rewrite_sink_node, rewrite_stream_scan_and_merge,
 };
 use crate::stream::stream_graph::id::GlobalFragmentIdGen;
+use crate::stream::{SinkMetadataChange, TableMetadataUpdate};
 
 pub fn check_sink_fragments_support_refresh_schema(
     fragments: &BTreeMap<FragmentId, Fragment>,
@@ -81,6 +81,57 @@ impl PropagatedSchemaChange {
     pub(super) fn is_drop_column(&self) -> bool {
         matches!(self, Self::DropColumn(_))
     }
+
+    fn apply_fields(&self, fields: &[PbField]) -> MetaResult<Vec<PbField>> {
+        match self {
+            Self::AddColumn(add_column) => {
+                let mut new_fields =
+                    Vec::with_capacity(fields.len() + add_column.added_fields.len());
+                new_fields.extend_from_slice(fields);
+                new_fields.extend_from_slice(&add_column.added_fields);
+                Ok(new_fields)
+            }
+            Self::DropColumn(drop_column) => {
+                for &index in &drop_column.removed_indices {
+                    if index >= fields.len() {
+                        bail!(
+                            "removed field index {} is out of range for fields {}",
+                            index,
+                            fields.len()
+                        );
+                    }
+                }
+                Ok(fields
+                    .iter()
+                    .enumerate()
+                    .filter(|(index, _)| !drop_column.removed_indices.contains(index))
+                    .map(|(_, field)| field.clone())
+                    .collect())
+            }
+        }
+    }
+
+    pub(super) fn remap_index(&self, old_index: usize, index_name: &str) -> MetaResult<usize> {
+        match self {
+            Self::AddColumn(_) => Ok(old_index),
+            Self::DropColumn(drop_column) => {
+                remap_index_after_drop(old_index, &drop_column.removed_indices).ok_or_else(|| {
+                    anyhow!("cannot drop {} column at index {}", index_name, old_index).into()
+                })
+            }
+        }
+    }
+}
+
+pub(super) fn remap_index_after_drop(old_index: usize, removed_indices: &[usize]) -> Option<usize> {
+    if removed_indices.contains(&old_index) {
+        return None;
+    }
+    let removed_before = removed_indices
+        .iter()
+        .filter(|&&removed_index| removed_index < old_index)
+        .count();
+    Some(old_index - removed_before)
 }
 
 #[derive(Clone, Debug)]
@@ -102,7 +153,7 @@ struct SinkSchemaChangeCollector<'a> {
     upstream_table_change: &'a TableSchemaChange,
     upstream_table_fragment_id: FragmentId,
     original_sink: &'a PbSink,
-    new_sink_columns: &'a mut Option<Vec<PbColumnCatalog>>,
+    sink_metadata_change: &'a mut Option<SinkMetadataChange>,
     updated_tables: &'a mut Vec<TableMetadataUpdate>,
 }
 
@@ -113,7 +164,7 @@ impl<'a> SinkSchemaChangeCollector<'a> {
             upstream_table_change: self.upstream_table_change,
             upstream_table_fragment_id: self.upstream_table_fragment_id,
             original_sink: self.original_sink,
-            new_sink_columns: &mut *self.new_sink_columns,
+            sink_metadata_change: &mut *self.sink_metadata_change,
             updated_tables: &mut *self.updated_tables,
         }
     }
@@ -159,7 +210,6 @@ pub(super) fn sink_node_supports_log_store_schema_change(sink_node: &SinkNode) -
 
 pub(super) struct NodeSchemaRewrite {
     pub body: NodeBody,
-    pub fields: Vec<PbField>,
     pub identity: Option<String>,
     pub change: Option<PropagatedSchemaChange>,
 }
@@ -171,7 +221,6 @@ trait SinkSchemaChangeSupport {
 
     fn apply_schema_change(
         self,
-        _fields: Vec<PbField>,
         _input_changes: Vec<(Option<PropagatedSchemaChange>, Vec<PbField>)>,
         _collector: SinkSchemaChangeCollector<'_>,
     ) -> MetaResult<NodeSchemaRewrite>
@@ -193,7 +242,6 @@ impl SinkSchemaChangeSupport for stream_plan::MergeNode {
 
     fn apply_schema_change(
         self,
-        _fields: Vec<PbField>,
         _input_changes: Vec<(Option<PropagatedSchemaChange>, Vec<PbField>)>,
         _collector: SinkSchemaChangeCollector<'_>,
     ) -> MetaResult<NodeSchemaRewrite> {
@@ -208,7 +256,6 @@ impl SinkSchemaChangeSupport for StreamScanNode {
 
     fn apply_schema_change(
         self,
-        _fields: Vec<PbField>,
         _input_changes: Vec<(Option<PropagatedSchemaChange>, Vec<PbField>)>,
         _collector: SinkSchemaChangeCollector<'_>,
     ) -> MetaResult<NodeSchemaRewrite> {
@@ -223,7 +270,6 @@ impl SinkSchemaChangeSupport for ProjectNode {
 
     fn apply_schema_change(
         self,
-        fields: Vec<PbField>,
         input_changes: Vec<(Option<PropagatedSchemaChange>, Vec<PbField>)>,
         _collector: SinkSchemaChangeCollector<'_>,
     ) -> MetaResult<NodeSchemaRewrite> {
@@ -240,12 +286,11 @@ impl SinkSchemaChangeSupport for ProjectNode {
         let Some(input_change) = input_change else {
             return Ok(NodeSchemaRewrite {
                 body: NodeBody::Project(Box::new(self)),
-                fields,
                 identity: None,
                 change: None,
             });
         };
-        rewrite_project_node(self, fields, input_change.clone(), input_fields.clone())
+        rewrite_project_node(self, input_change.clone(), input_fields)
     }
 }
 
@@ -256,7 +301,6 @@ impl SinkSchemaChangeSupport for SinkNode {
 
     fn apply_schema_change(
         self,
-        fields: Vec<PbField>,
         input_changes: Vec<(Option<PropagatedSchemaChange>, Vec<PbField>)>,
         collector: SinkSchemaChangeCollector<'_>,
     ) -> MetaResult<NodeSchemaRewrite> {
@@ -273,21 +317,20 @@ impl SinkSchemaChangeSupport for SinkNode {
         let Some(input_change) = input_change else {
             return Ok(NodeSchemaRewrite {
                 body: NodeBody::Sink(Box::new(self)),
-                fields,
                 identity: None,
                 change: None,
             });
         };
-        let (rewrite, sink_columns, updated_table) = rewrite_sink_node(
+        let (rewrite, sink_metadata_change, updated_table) = rewrite_sink_node(
             self,
             input_change.clone(),
-            input_fields.clone(),
+            input_fields,
             collector.original_sink,
         )?;
         if let Some(updated_table) = updated_table {
             collector.updated_tables.push(updated_table);
         }
-        *collector.new_sink_columns = Some(sink_columns);
+        *collector.sink_metadata_change = Some(sink_metadata_change);
         Ok(rewrite)
     }
 }
@@ -299,7 +342,6 @@ impl SinkSchemaChangeSupport for stream_plan::BatchPlanNode {
 
     fn apply_schema_change(
         self,
-        _fields: Vec<PbField>,
         _input_changes: Vec<(Option<PropagatedSchemaChange>, Vec<PbField>)>,
         _collector: SinkSchemaChangeCollector<'_>,
     ) -> MetaResult<NodeSchemaRewrite> {
@@ -403,12 +445,23 @@ fn rewrite_stream_node_for_sink_schema_change(
 ) -> MetaResult<(StreamNode, Option<PropagatedSchemaChange>)> {
     if matches!(node.node_body.as_ref(), Some(NodeBody::StreamScan(_))) {
         let mut stream_scan_node = node;
+        let old_stream_key = stream_scan_node.stream_key.clone();
         let change = rewrite_stream_scan_and_merge(
             &mut stream_scan_node,
             collector.upstream_table_change,
             collector.new_upstream_table,
             collector.upstream_table_fragment_id,
         )?;
+        if let Some(change) = &change {
+            stream_scan_node.stream_key = old_stream_key
+                .into_iter()
+                .map(|index| {
+                    change
+                        .remap_index(index as usize, "stream key")
+                        .map(|index| index as u32)
+                })
+                .collect::<MetaResult<_>>()?;
+        }
         return Ok((stream_scan_node, change));
     }
 
@@ -434,7 +487,7 @@ fn rewrite_stream_node_for_sink_schema_change(
     }
     let node_name = node_body_name(&body);
     let rewrite = dispatch_stream_node_body!(body, _NodeVariant, node => {
-        node.apply_schema_change(fields, input_changes, collector.reborrow())
+        node.apply_schema_change(input_changes, collector.reborrow())
             .with_context(|| {
                 format!(
                     "failed to rewrite {} stream node {}",
@@ -442,6 +495,21 @@ fn rewrite_stream_node_for_sink_schema_change(
                 )
             })
     })?;
+    let (fields, stream_key) = if let Some(change) = &rewrite.change {
+        (
+            change.apply_fields(&fields)?,
+            stream_key
+                .into_iter()
+                .map(|index| {
+                    change
+                        .remap_index(index as usize, "stream key")
+                        .map(|index| index as u32)
+                })
+                .collect::<MetaResult<_>>()?,
+        )
+    } else {
+        (fields, stream_key)
+    };
 
     Ok((
         StreamNode {
@@ -450,7 +518,7 @@ fn rewrite_stream_node_for_sink_schema_change(
             stream_key,
             stream_kind,
             identity: rewrite.identity.unwrap_or(identity),
-            fields: rewrite.fields,
+            fields,
             node_body: Some(rewrite.body),
         },
         rewrite.change,
@@ -464,7 +532,7 @@ pub fn rewrite_refresh_schema_sink_fragment(
     upstream_table: &PbTable,
     upstream_table_fragment_id: FragmentId,
     id_generator_manager: &IdGeneratorManager,
-) -> MetaResult<(Fragment, Vec<PbColumnCatalog>, Vec<TableMetadataUpdate>)> {
+) -> MetaResult<(Fragment, SinkMetadataChange, Vec<TableMetadataUpdate>)> {
     let root_body = original_sink_fragment
         .nodes
         .node_body
@@ -480,7 +548,7 @@ pub fn rewrite_refresh_schema_sink_fragment(
     let fragment_id = GlobalFragmentIdGen::new(id_generator_manager, 1)
         .to_global_id(0)
         .as_global_id();
-    let mut new_sink_columns = None;
+    let mut sink_metadata_change = None;
     let mut updated_tables = vec![];
 
     let collector = SinkSchemaChangeCollector {
@@ -488,7 +556,7 @@ pub fn rewrite_refresh_schema_sink_fragment(
         upstream_table_change: &schema_change,
         upstream_table_fragment_id,
         original_sink: sink,
-        new_sink_columns: &mut new_sink_columns,
+        sink_metadata_change: &mut sink_metadata_change,
         updated_tables: &mut updated_tables,
     };
     let (new_nodes, output_change) = rewrite_stream_node_for_sink_schema_change(
@@ -499,7 +567,12 @@ pub fn rewrite_refresh_schema_sink_fragment(
         tracing::warn!("sink schema change did not affect the Sink node while rewriting fragment");
     }
 
-    let new_sink_columns = new_sink_columns.unwrap_or_else(|| sink.columns.clone());
+    let sink_metadata_change = sink_metadata_change.unwrap_or_else(|| SinkMetadataChange {
+        columns: sink.columns.clone(),
+        plan_pk: sink.plan_pk.clone(),
+        distribution_key: sink.distribution_key.clone(),
+        downstream_pk: sink.downstream_pk.clone(),
+    });
     let new_sink_fragment = Fragment {
         fragment_id,
         fragment_type_mask: original_sink_fragment.fragment_type_mask,
@@ -508,5 +581,25 @@ pub fn rewrite_refresh_schema_sink_fragment(
         maybe_vnode_count: original_sink_fragment.maybe_vnode_count,
         nodes: new_nodes,
     };
-    Ok((new_sink_fragment, new_sink_columns, updated_tables))
+    Ok((new_sink_fragment, sink_metadata_change, updated_tables))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::remap_index_after_drop;
+
+    #[test]
+    fn test_remap_index_after_drop() {
+        assert_eq!(remap_index_after_drop(0, &[1, 3]), Some(0));
+        assert_eq!(remap_index_after_drop(1, &[1, 3]), None);
+        assert_eq!(remap_index_after_drop(2, &[1, 3]), Some(1));
+        assert_eq!(remap_index_after_drop(3, &[1, 3]), None);
+        assert_eq!(remap_index_after_drop(4, &[1, 3]), Some(2));
+
+        assert_eq!(remap_index_after_drop(0, &[3, 1]), Some(0));
+        assert_eq!(remap_index_after_drop(1, &[3, 1]), None);
+        assert_eq!(remap_index_after_drop(2, &[3, 1]), Some(1));
+        assert_eq!(remap_index_after_drop(3, &[3, 1]), None);
+        assert_eq!(remap_index_after_drop(4, &[3, 1]), Some(2));
+    }
 }

--- a/src/meta/src/stream/stream_graph/schema_change.rs
+++ b/src/meta/src/stream/stream_graph/schema_change.rs
@@ -100,7 +100,7 @@ pub(super) struct DropColumn {
 struct SinkSchemaChangeCollector<'a> {
     new_upstream_table: &'a PbTable,
     upstream_table_change: &'a TableSchemaChange,
-    new_upstream_fragment_id: FragmentId,
+    upstream_table_fragment_id: FragmentId,
     original_sink: &'a PbSink,
     new_sink_columns: &'a mut Option<Vec<PbColumnCatalog>>,
     updated_tables: &'a mut Vec<TableMetadataUpdate>,
@@ -111,7 +111,7 @@ impl<'a> SinkSchemaChangeCollector<'a> {
         SinkSchemaChangeCollector {
             new_upstream_table: self.new_upstream_table,
             upstream_table_change: self.upstream_table_change,
-            new_upstream_fragment_id: self.new_upstream_fragment_id,
+            upstream_table_fragment_id: self.upstream_table_fragment_id,
             original_sink: self.original_sink,
             new_sink_columns: &mut *self.new_sink_columns,
             updated_tables: &mut *self.updated_tables,
@@ -377,24 +377,6 @@ fn node_supports_schema_change(body: &NodeBody) -> bool {
     })
 }
 
-fn apply_node_schema_change(
-    body: NodeBody,
-    fields: Vec<PbField>,
-    input_changes: Vec<(Option<PropagatedSchemaChange>, Vec<PbField>)>,
-    collector: SinkSchemaChangeCollector<'_>,
-) -> MetaResult<NodeSchemaRewrite> {
-    let node_name = node_body_name(&body);
-    if !node_supports_schema_change(&body) {
-        return Err(anyhow!("{} node does not support sink schema change", node_name).into());
-    }
-    let rewrite = dispatch_stream_node_body!(body, _NodeVariant, node => {
-        node.apply_schema_change(fields, input_changes, collector)
-    });
-    rewrite
-        .with_context(|| format!("failed to apply sink schema change on {} node", node_name))
-        .map_err(Into::into)
-}
-
 fn check_stream_node_schema_change_support(node: &StreamNode) -> MetaResult<()> {
     let body = node
         .node_body
@@ -425,7 +407,7 @@ fn rewrite_stream_node_for_sink_schema_change(
             &mut stream_scan_node,
             collector.upstream_table_change,
             collector.new_upstream_table,
-            collector.new_upstream_fragment_id,
+            collector.upstream_table_fragment_id,
         )?;
         return Ok((stream_scan_node, change));
     }
@@ -450,8 +432,16 @@ fn rewrite_stream_node_for_sink_schema_change(
         new_inputs.push(new_input);
         input_changes.push((input_change, input_fields));
     }
-    let rewrite = apply_node_schema_change(body, fields, input_changes, collector.reborrow())
-        .with_context(|| format!("failed to rewrite stream node {}", operator_id))?;
+    let node_name = node_body_name(&body);
+    let rewrite = dispatch_stream_node_body!(body, _NodeVariant, node => {
+        node.apply_schema_change(fields, input_changes, collector.reborrow())
+            .with_context(|| {
+                format!(
+                    "failed to rewrite {} stream node {}",
+                    node_name, operator_id
+                )
+            })
+    })?;
 
     Ok((
         StreamNode {
@@ -496,7 +486,7 @@ pub fn rewrite_refresh_schema_sink_fragment(
     let collector = SinkSchemaChangeCollector {
         new_upstream_table: upstream_table,
         upstream_table_change: &schema_change,
-        new_upstream_fragment_id: upstream_table_fragment_id,
+        upstream_table_fragment_id,
         original_sink: sink,
         new_sink_columns: &mut new_sink_columns,
         updated_tables: &mut updated_tables,

--- a/src/meta/src/stream/stream_manager.rs
+++ b/src/meta/src/stream/stream_manager.rs
@@ -25,7 +25,7 @@ use risingwave_common::id::{JobId, SinkId};
 use risingwave_connector::source::CdcTableSnapshotSplitRaw;
 use risingwave_meta_model::prelude::Fragment as FragmentModel;
 use risingwave_meta_model::{StreamingParallelism, WorkerId, fragment, streaming_job};
-use risingwave_pb::catalog::{CreateType, PbSink, PbTable, Subscription};
+use risingwave_pb::catalog::{CreateType, PbSink, Subscription};
 use risingwave_pb::expr::PbExprNode;
 use risingwave_pb::plan_common::{PbColumnCatalog, PbField};
 use sea_orm::{ColumnTrait, EntityTrait, QueryFilter, QuerySelect};
@@ -215,6 +215,13 @@ impl CreatingStreamingJobInfo {
 type CreatingStreamingJobInfoRef = Arc<CreatingStreamingJobInfo>;
 
 #[derive(Debug, Clone)]
+pub struct TableMetadataUpdate {
+    pub table_id: TableId,
+    pub columns: Vec<PbColumnCatalog>,
+    pub value_indices: Vec<i32>,
+}
+
+#[derive(Debug, Clone)]
 pub struct AutoRefreshSchemaSinkContext {
     pub tmp_sink_id: SinkId,
     pub original_sink: PbSink,
@@ -223,7 +230,7 @@ pub struct AutoRefreshSchemaSinkContext {
     pub newly_add_fields: Vec<Field>,
     pub removed_column_names: Vec<String>,
     pub new_fragment: Fragment,
-    pub new_log_store_table: Option<Box<PbTable>>,
+    pub updated_tables: Vec<TableMetadataUpdate>,
     /// The sink's own stream context (timezone, `config_override`).
     pub ctx: StreamContext,
 }

--- a/src/meta/src/stream/stream_manager.rs
+++ b/src/meta/src/stream/stream_manager.rs
@@ -26,6 +26,7 @@ use risingwave_connector::source::CdcTableSnapshotSplitRaw;
 use risingwave_meta_model::prelude::Fragment as FragmentModel;
 use risingwave_meta_model::{StreamingParallelism, WorkerId, fragment, streaming_job};
 use risingwave_pb::catalog::{CreateType, PbSink, Subscription};
+use risingwave_pb::common::ColumnOrder;
 use risingwave_pb::expr::PbExprNode;
 use risingwave_pb::plan_common::{PbColumnCatalog, PbField};
 use sea_orm::{ColumnTrait, EntityTrait, QueryFilter, QuerySelect};
@@ -221,12 +222,20 @@ pub struct TableMetadataUpdate {
     pub value_indices: Vec<i32>,
 }
 
+#[derive(Clone, Debug)]
+pub struct SinkMetadataChange {
+    pub columns: Vec<PbColumnCatalog>,
+    pub plan_pk: Vec<ColumnOrder>,
+    pub distribution_key: Vec<i32>,
+    pub downstream_pk: Vec<i32>,
+}
+
 #[derive(Debug, Clone)]
 pub struct AutoRefreshSchemaSinkContext {
     pub tmp_sink_id: SinkId,
     pub original_sink: PbSink,
     pub original_fragment: Fragment,
-    pub new_schema: Vec<PbColumnCatalog>,
+    pub sink_metadata_change: SinkMetadataChange,
     pub newly_add_fields: Vec<Field>,
     pub removed_column_names: Vec<String>,
     pub new_fragment: Fragment,


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

This PR refactors the sink auto schema-change rewrite path into a bottom-up framework that rewrites the sink fragment stream node tree by propagating schema changes from the upstream table scan boundary to the sink node.

Core types:

```rust
enum PropagatedSchemaChange {
    AddColumn {
        added_fields: Vec<PbField>,
    },
    DropColumn {
        removed_indices: Vec<usize>,
    },
}

impl PropagatedSchemaChange {
    fn apply_fields(&self, fields: &[PbField]) -> MetaResult<Vec<PbField>>;
    fn remap_index(&self, old_index: usize, index_name: &str) -> MetaResult<usize>;
}

struct NodeSchemaRewrite {
    body: NodeBody,
    identity: Option<String>,
    change: Option<PropagatedSchemaChange>,
}

struct SinkSchemaChangeCollector<'a> {
    new_upstream_table: &'a PbTable,
    upstream_table_change: &'a TableSchemaChange,
    upstream_table_fragment_id: FragmentId,
    original_sink: &'a PbSink,
    sink_metadata_change: &'a mut Option<SinkMetadataChange>,
    updated_tables: &'a mut Vec<TableMetadataUpdate>,
}

trait SinkSchemaChangeSupport {
    fn supports_schema_change(&self) -> bool;

    fn apply_schema_change(
        self,
        input_changes: Vec<(Option<PropagatedSchemaChange>, Vec<PbField>)>,
        collector: SinkSchemaChangeCollector<'_>,
    ) -> MetaResult<NodeSchemaRewrite>;
}
```

The rewrite runs bottom-up on the sink fragment:

```rust
fn rewrite_stream_node_for_sink_schema_change(node, collector)
    -> (new_node, propagated_change)
{
    if node is StreamScan {
        // Leaf boundary of the sink fragment.
        // Rewrite StreamScan together with its Merge input using the new upstream schema.
        return rewrite_stream_scan_and_merge(node, collector);
    }

    for input in node.inputs {
        (new_input, input_change) = rewrite_stream_node_for_sink_schema_change(input, collector);
        input_changes.push((input_change, new_input.fields));
        new_inputs.push(new_input);
    }

    rewrite = dispatch_stream_node_body!(node.body, NodeVariant, body => {
        body.apply_schema_change(input_changes, collector)
    });

    fields = rewrite.change.apply_fields(node.fields);

    return StreamNode {
        input: new_inputs,
        fields,
        identity: rewrite.identity.unwrap_or(old_identity),
        node_body: rewrite.body,
        stream_key: remap_stream_key(node.stream_key, rewrite.change),
        ...
    }, rewrite.change;
}
```

Node responsibilities:

- `StreamScan` consumes the table-level schema change, rewrites scan upstream column ids, output indices, fields, and stream key, updates the `Merge` fields and upstream fragment id, and emits the first `PropagatedSchemaChange`.
- The `Merge` input under `StreamScan` has an empty stream key in the generated fragment, so only its fields and upstream fragment id are rewritten.
- `Project` consumes an input propagated change, rewrites/removes input refs for dropped columns, appends pass-through input refs for added columns, and emits a propagated change when its output changed.
- `Sink` consumes the final propagated change, rebuilds sink columns, rewrites optional log-store table columns, remaps `plan_pk`, `distribution_key`, and `downstream_pk` in both the running `SinkDesc` and persisted sink metadata, and updates sink identity.
- Unsupported node types fail during validation before rewrite.

The PR also adds regression coverage for dropping a column before the sink primary key. The test verifies that the rewritten sink fragment keeps stream keys and sink metadata keys aligned, and that dropping the sink key itself is rejected.

`dispatch_stream_node_body!` from #25931 is used for both support checking and rewrite dispatch, so the framework does not maintain separate hand-written `NodeBody` matches.

Depends on #25931.

## Checklist

- [ ] I have written necessary rustdoc comments.
- [x] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [x] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->

## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

Not user-facing.

</details>

<!-- capy-pr-badge:start -->
<a href="https://capy.ai/project/337a7eb0-5e7b-411a-869a-76e45a4e4750/pull/25932"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open in Capy" src="https://capy.ai/api/badge/open.svg"></picture></a>
<!-- capy-pr-badge:end -->
