### PR TITLE
fix(cdc): allow MySQL public key retrieval in Debezium

### DIFF
--- a/java/connector-node/risingwave-connector-service/src/main/resources/mysql.properties
+++ b/java/connector-node/risingwave-connector-service/src/main/resources/mysql.properties
@@ -33,3 +33,4 @@ provide.transaction.metadata=${transactional:-false}
 # force connection session timezone to UTC(+00:00)
 driver.connectionTimeZone=+00:00
 driver.forceConnectionTimeZoneToSession=true
+driver.allowPublicKeyRetrieval=true


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

Add `driver.allowPublicKeyRetrieval=true` to the MySQL CDC Debezium runtime properties.

MySQL CDC validation already opens its preflight JDBC connection with `allowPublicKeyRetrieval=true`, but the Debezium runtime connection was built from `mysql.properties` without the same Connector/J property. When MySQL 8 `caching_sha2_password` takes the slow authentication path, especially after `FLUSH PRIVILEGES` clears the auth cache during parallel CDC SLT runs, the Debezium connection can fail with `Public Key Retrieval is not allowed`.

This aligns the runtime connection behavior with validation and fixes the flaky inline MySQL CDC source tests.

- Closes #25617

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [x] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

Fixed a MySQL CDC connection failure where Debezium could fail to reconnect to MySQL 8 with `Public Key Retrieval is not allowed` after the MySQL authentication cache was cleared.

</details>

<!-- capy-pr-badge:start -->
<a href="https://capy.ai/project/337a7eb0-5e7b-411a-869a-76e45a4e4750/pull/25933"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open in Capy" src="https://capy.ai/api/badge/open.svg"></picture></a>
<!-- capy-pr-badge:end -->
