### PR TITLE
feat(sink): support LanceDB sink

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -271,7 +271,7 @@ dependencies = [
  "serde_json",
  "strum 0.27.2",
  "strum_macros 0.27.2",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "uuid",
  "zstd",
 ]
@@ -295,7 +295,7 @@ dependencies = [
  "serde_json",
  "strum 0.27.2",
  "strum_macros 0.27.2",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "uuid",
 ]
 
@@ -354,10 +354,8 @@ dependencies = [
  "arrow-array 56.2.0",
  "arrow-buffer 56.2.0",
  "arrow-cast 56.2.0",
- "arrow-csv 56.2.0",
  "arrow-data 56.2.0",
  "arrow-ipc 56.2.0",
- "arrow-json 56.2.0",
  "arrow-ord 56.2.0",
  "arrow-row 56.2.0",
  "arrow-schema 56.2.0",
@@ -375,10 +373,10 @@ dependencies = [
  "arrow-array 58.1.0",
  "arrow-buffer 58.1.0",
  "arrow-cast 58.1.0",
- "arrow-csv 58.1.0",
+ "arrow-csv",
  "arrow-data 58.1.0",
  "arrow-ipc 58.1.0",
- "arrow-json 58.1.0",
+ "arrow-json",
  "arrow-ord 58.1.0",
  "arrow-row 58.1.0",
  "arrow-schema 58.1.0",
@@ -425,7 +423,6 @@ dependencies = [
  "arrow-data 56.2.0",
  "arrow-schema 56.2.0",
  "chrono",
- "chrono-tz",
  "half 2.7.1",
  "hashbrown 0.16.1",
  "num",
@@ -487,7 +484,6 @@ dependencies = [
  "atoi",
  "base64 0.22.1",
  "chrono",
- "comfy-table",
  "half 2.7.1",
  "lexical-core",
  "num",
@@ -514,21 +510,6 @@ dependencies = [
  "lexical-core",
  "num-traits",
  "ryu",
-]
-
-[[package]]
-name = "arrow-csv"
-version = "56.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa9bf02705b5cf762b6f764c65f04ae9082c7cfc4e96e0c33548ee3f67012eb"
-dependencies = [
- "arrow-array 56.2.0",
- "arrow-cast 56.2.0",
- "arrow-schema 56.2.0",
- "chrono",
- "csv",
- "csv-core",
- "regex",
 ]
 
 [[package]]
@@ -603,8 +584,6 @@ dependencies = [
  "arrow-schema 56.2.0",
  "arrow-select 56.2.0",
  "flatbuffers",
- "lz4_flex 0.11.6",
- "zstd",
 ]
 
 [[package]]
@@ -621,28 +600,6 @@ dependencies = [
  "flatbuffers",
  "lz4_flex 0.13.0",
  "zstd",
-]
-
-[[package]]
-name = "arrow-json"
-version = "56.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88cf36502b64a127dc659e3b305f1d993a544eab0d48cce704424e62074dc04b"
-dependencies = [
- "arrow-array 56.2.0",
- "arrow-buffer 56.2.0",
- "arrow-cast 56.2.0",
- "arrow-data 56.2.0",
- "arrow-schema 56.2.0",
- "chrono",
- "half 2.7.1",
- "indexmap 2.13.0",
- "lexical-core",
- "memchr",
- "num",
- "serde",
- "serde_json",
- "simdutf8",
 ]
 
 [[package]]
@@ -726,11 +683,6 @@ name = "arrow-schema"
 version = "56.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3aa9e59c611ebc291c28582077ef25c97f1975383f1479b12f3b9ffee2ffabe"
-dependencies = [
- "bitflags 2.11.1",
- "serde",
- "serde_json",
-]
 
 [[package]]
 name = "arrow-schema"
@@ -831,7 +783,7 @@ dependencies = [
  "rquickjs",
  "serde_json",
  "tempfile",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tonic",
  "tracing",
@@ -857,7 +809,7 @@ dependencies = [
  "nom 7.1.3",
  "num-traits",
  "rusticata-macros",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "time",
 ]
 
@@ -991,7 +943,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-stream 0.1.17",
  "tokio-util",
@@ -2401,12 +2353,12 @@ dependencies = [
  "parquet",
  "rand 0.9.2",
  "reqwest 0.13.2",
- "roaring 0.11.2",
+ "roaring",
  "rustc_version",
  "serde",
  "serde_json",
  "strum 0.27.2",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "url",
@@ -2587,10 +2539,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "census"
-version = "0.4.2"
+name = "cedarwood"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f4c707c6a209cbe82d10abd08e1ea8995e9ea937d2550646e02798948992be0"
+checksum = "6d910bedd62c24733263d0bed247460853c9d22e8956bd4cd964302095e04e90"
+dependencies = [
+ "smallvec",
+]
 
 [[package]]
 name = "cesu8"
@@ -2674,7 +2629,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7d8d1efd5109b9c1cd3b7966bd071cdfb53bb6eb0b22a473a68c2f70a11a1eb"
 dependencies = [
  "parse-zoneinfo",
- "phf_codegen",
+ "phf_codegen 0.12.1",
  "phf_shared 0.12.1",
  "uncased",
 ]
@@ -3419,15 +3374,11 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.15"
+version = "0.9.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae211234986c545741a7dc064309f67ee1e5ad243d0e48335adc0484d960bcc7"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
 dependencies = [
- "autocfg",
- "cfg-if",
  "crossbeam-utils",
- "memoffset",
- "scopeguard",
 ]
 
 [[package]]
@@ -3441,13 +3392,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "crossbeam-utils"
-version = "0.8.16"
+name = "crossbeam-skiplist"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a22b2d63d4d1dc0b7f1b6b2747dd0088008a9be28b6ddf0b1e7d335e3037294"
+checksum = "df29de440c58ca2cc6e587ec3d22347551a32435fbde9d2bff64e78a9ffa151b"
 dependencies = [
- "cfg-if",
+ "crossbeam-epoch",
+ "crossbeam-utils",
 ]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crossterm"
@@ -3781,55 +3739,6 @@ checksum = "be1e0bca6c3637f992fc1cc7cbc52a78c1ef6db076dbf1059c4323d6a2048376"
 
 [[package]]
 name = "datafusion"
-version = "50.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2af15bb3c6ffa33011ef579f6b0bcbe7c26584688bd6c994f548e44df67f011a"
-dependencies = [
- "arrow 56.2.0",
- "arrow-ipc 56.2.0",
- "arrow-schema 56.2.0",
- "async-trait",
- "bytes",
- "chrono",
- "datafusion-catalog 50.3.0",
- "datafusion-catalog-listing 50.3.0",
- "datafusion-common 50.3.0",
- "datafusion-common-runtime 50.3.0",
- "datafusion-datasource 50.3.0",
- "datafusion-datasource-csv 50.3.0",
- "datafusion-datasource-json 50.3.0",
- "datafusion-execution 50.3.0",
- "datafusion-expr 50.3.0",
- "datafusion-expr-common 50.3.0",
- "datafusion-functions 50.3.0",
- "datafusion-functions-aggregate 50.3.0",
- "datafusion-functions-nested 50.3.0",
- "datafusion-functions-table 50.3.0",
- "datafusion-functions-window 50.3.0",
- "datafusion-optimizer 50.3.0",
- "datafusion-physical-expr 50.3.0",
- "datafusion-physical-expr-adapter 50.3.0",
- "datafusion-physical-expr-common 50.3.0",
- "datafusion-physical-optimizer 50.3.0",
- "datafusion-physical-plan 50.3.0",
- "datafusion-session 50.3.0",
- "datafusion-sql 50.3.0",
- "futures",
- "itertools 0.14.0",
- "log",
- "object_store 0.12.5",
- "parking_lot 0.12.5",
- "rand 0.9.2",
- "regex",
- "sqlparser 0.58.0",
- "tempfile",
- "tokio",
- "url",
- "uuid",
-]
-
-[[package]]
-name = "datafusion"
 version = "53.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de9f8117889ba9503440f1dd79ebab32ba52ccf1720bb83cd718a29d4edc0d16"
@@ -3840,31 +3749,31 @@ dependencies = [
  "bytes",
  "bzip2",
  "chrono",
- "datafusion-catalog 53.0.0",
- "datafusion-catalog-listing 53.0.0",
- "datafusion-common 53.0.0",
- "datafusion-common-runtime 53.0.0",
- "datafusion-datasource 53.0.0",
+ "datafusion-catalog",
+ "datafusion-catalog-listing",
+ "datafusion-common",
+ "datafusion-common-runtime",
+ "datafusion-datasource",
  "datafusion-datasource-arrow",
- "datafusion-datasource-csv 53.0.0",
- "datafusion-datasource-json 53.0.0",
+ "datafusion-datasource-csv",
+ "datafusion-datasource-json",
  "datafusion-datasource-parquet",
- "datafusion-execution 53.0.0",
- "datafusion-expr 53.0.0",
- "datafusion-expr-common 53.0.0",
- "datafusion-functions 53.0.0",
- "datafusion-functions-aggregate 53.0.0",
- "datafusion-functions-nested 53.0.0",
- "datafusion-functions-table 53.0.0",
- "datafusion-functions-window 53.0.0",
- "datafusion-optimizer 53.0.0",
- "datafusion-physical-expr 53.0.0",
- "datafusion-physical-expr-adapter 53.0.0",
- "datafusion-physical-expr-common 53.0.0",
- "datafusion-physical-optimizer 53.0.0",
- "datafusion-physical-plan 53.0.0",
- "datafusion-session 53.0.0",
- "datafusion-sql 53.0.0",
+ "datafusion-execution",
+ "datafusion-expr",
+ "datafusion-expr-common",
+ "datafusion-functions",
+ "datafusion-functions-aggregate",
+ "datafusion-functions-nested",
+ "datafusion-functions-table",
+ "datafusion-functions-window",
+ "datafusion-optimizer",
+ "datafusion-physical-expr",
+ "datafusion-physical-expr-adapter",
+ "datafusion-physical-expr-common",
+ "datafusion-physical-optimizer",
+ "datafusion-physical-plan",
+ "datafusion-session",
+ "datafusion-sql",
  "flate2",
  "futures",
  "itertools 0.14.0",
@@ -3875,38 +3784,12 @@ dependencies = [
  "parquet",
  "rand 0.9.2",
  "regex",
- "sqlparser 0.61.0",
+ "sqlparser",
  "tempfile",
  "tokio",
  "url",
  "uuid",
  "zstd",
-]
-
-[[package]]
-name = "datafusion-catalog"
-version = "50.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "187622262ad8f7d16d3be9202b4c1e0116f1c9aa387e5074245538b755261621"
-dependencies = [
- "arrow 56.2.0",
- "async-trait",
- "dashmap",
- "datafusion-common 50.3.0",
- "datafusion-common-runtime 50.3.0",
- "datafusion-datasource 50.3.0",
- "datafusion-execution 50.3.0",
- "datafusion-expr 50.3.0",
- "datafusion-physical-expr 50.3.0",
- "datafusion-physical-plan 50.3.0",
- "datafusion-session 50.3.0",
- "datafusion-sql 50.3.0",
- "futures",
- "itertools 0.14.0",
- "log",
- "object_store 0.12.5",
- "parking_lot 0.12.5",
- "tokio",
 ]
 
 [[package]]
@@ -3918,42 +3801,19 @@ dependencies = [
  "arrow 58.1.0",
  "async-trait",
  "dashmap",
- "datafusion-common 53.0.0",
- "datafusion-common-runtime 53.0.0",
- "datafusion-datasource 53.0.0",
- "datafusion-execution 53.0.0",
- "datafusion-expr 53.0.0",
- "datafusion-physical-expr 53.0.0",
- "datafusion-physical-plan 53.0.0",
- "datafusion-session 53.0.0",
+ "datafusion-common",
+ "datafusion-common-runtime",
+ "datafusion-datasource",
+ "datafusion-execution",
+ "datafusion-expr",
+ "datafusion-physical-expr",
+ "datafusion-physical-plan",
+ "datafusion-session",
  "futures",
  "itertools 0.14.0",
  "log",
  "object_store 0.13.2",
  "parking_lot 0.12.5",
- "tokio",
-]
-
-[[package]]
-name = "datafusion-catalog-listing"
-version = "50.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9657314f0a32efd0382b9a46fdeb2d233273ece64baa68a7c45f5a192daf0f83"
-dependencies = [
- "arrow 56.2.0",
- "async-trait",
- "datafusion-catalog 50.3.0",
- "datafusion-common 50.3.0",
- "datafusion-datasource 50.3.0",
- "datafusion-execution 50.3.0",
- "datafusion-expr 50.3.0",
- "datafusion-physical-expr 50.3.0",
- "datafusion-physical-expr-common 50.3.0",
- "datafusion-physical-plan 50.3.0",
- "datafusion-session 50.3.0",
- "futures",
- "log",
- "object_store 0.12.5",
  "tokio",
 ]
 
@@ -3965,42 +3825,19 @@ checksum = "830487b51ed83807d6b32d6325f349c3144ae0c9bf772cf2a712db180c31d5e6"
 dependencies = [
  "arrow 58.1.0",
  "async-trait",
- "datafusion-catalog 53.0.0",
- "datafusion-common 53.0.0",
- "datafusion-datasource 53.0.0",
- "datafusion-execution 53.0.0",
- "datafusion-expr 53.0.0",
- "datafusion-physical-expr 53.0.0",
- "datafusion-physical-expr-adapter 53.0.0",
- "datafusion-physical-expr-common 53.0.0",
- "datafusion-physical-plan 53.0.0",
+ "datafusion-catalog",
+ "datafusion-common",
+ "datafusion-datasource",
+ "datafusion-execution",
+ "datafusion-expr",
+ "datafusion-physical-expr",
+ "datafusion-physical-expr-adapter",
+ "datafusion-physical-expr-common",
+ "datafusion-physical-plan",
  "futures",
  "itertools 0.14.0",
  "log",
  "object_store 0.13.2",
-]
-
-[[package]]
-name = "datafusion-common"
-version = "50.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a83760d9a13122d025fbdb1d5d5aaf93dd9ada5e90ea229add92aa30898b2d1"
-dependencies = [
- "ahash 0.8.11",
- "arrow 56.2.0",
- "arrow-ipc 56.2.0",
- "base64 0.22.1",
- "chrono",
- "half 2.7.1",
- "hashbrown 0.14.5",
- "indexmap 2.13.0",
- "libc",
- "log",
- "object_store 0.12.5",
- "paste",
- "sqlparser 0.58.0",
- "tokio",
- "web-time",
 ]
 
 [[package]]
@@ -4023,20 +3860,9 @@ dependencies = [
  "parquet",
  "paste",
  "recursive",
- "sqlparser 0.61.0",
+ "sqlparser",
  "tokio",
  "web-time",
-]
-
-[[package]]
-name = "datafusion-common-runtime"
-version = "50.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b6234a6c7173fe5db1c6c35c01a12b2aa0f803a3007feee53483218817f8b1e"
-dependencies = [
- "futures",
- "log",
- "tokio",
 ]
 
 [[package]]
@@ -4052,35 +3878,6 @@ dependencies = [
 
 [[package]]
 name = "datafusion-datasource"
-version = "50.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7256c9cb27a78709dd42d0c80f0178494637209cac6e29d5c93edd09b6721b86"
-dependencies = [
- "arrow 56.2.0",
- "async-trait",
- "bytes",
- "chrono",
- "datafusion-common 50.3.0",
- "datafusion-common-runtime 50.3.0",
- "datafusion-execution 50.3.0",
- "datafusion-expr 50.3.0",
- "datafusion-physical-expr 50.3.0",
- "datafusion-physical-expr-adapter 50.3.0",
- "datafusion-physical-expr-common 50.3.0",
- "datafusion-physical-plan 50.3.0",
- "datafusion-session 50.3.0",
- "futures",
- "glob",
- "itertools 0.14.0",
- "log",
- "object_store 0.12.5",
- "rand 0.9.2",
- "tokio",
- "url",
-]
-
-[[package]]
-name = "datafusion-datasource"
 version = "53.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fde1e030a9dc87b743c806fbd631f5ecfa2ccaa4ffb61fa19144a07fea406b79"
@@ -4091,15 +3888,15 @@ dependencies = [
  "bytes",
  "bzip2",
  "chrono",
- "datafusion-common 53.0.0",
- "datafusion-common-runtime 53.0.0",
- "datafusion-execution 53.0.0",
- "datafusion-expr 53.0.0",
- "datafusion-physical-expr 53.0.0",
- "datafusion-physical-expr-adapter 53.0.0",
- "datafusion-physical-expr-common 53.0.0",
- "datafusion-physical-plan 53.0.0",
- "datafusion-session 53.0.0",
+ "datafusion-common",
+ "datafusion-common-runtime",
+ "datafusion-execution",
+ "datafusion-expr",
+ "datafusion-physical-expr",
+ "datafusion-physical-expr-adapter",
+ "datafusion-physical-expr-common",
+ "datafusion-physical-plan",
+ "datafusion-session",
  "flate2",
  "futures",
  "glob",
@@ -4124,42 +3921,17 @@ dependencies = [
  "arrow-ipc 58.1.0",
  "async-trait",
  "bytes",
- "datafusion-common 53.0.0",
- "datafusion-common-runtime 53.0.0",
- "datafusion-datasource 53.0.0",
- "datafusion-execution 53.0.0",
- "datafusion-expr 53.0.0",
- "datafusion-physical-expr-common 53.0.0",
- "datafusion-physical-plan 53.0.0",
- "datafusion-session 53.0.0",
+ "datafusion-common",
+ "datafusion-common-runtime",
+ "datafusion-datasource",
+ "datafusion-execution",
+ "datafusion-expr",
+ "datafusion-physical-expr-common",
+ "datafusion-physical-plan",
+ "datafusion-session",
  "futures",
  "itertools 0.14.0",
  "object_store 0.13.2",
- "tokio",
-]
-
-[[package]]
-name = "datafusion-datasource-csv"
-version = "50.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64533a90f78e1684bfb113d200b540f18f268134622d7c96bbebc91354d04825"
-dependencies = [
- "arrow 56.2.0",
- "async-trait",
- "bytes",
- "datafusion-catalog 50.3.0",
- "datafusion-common 50.3.0",
- "datafusion-common-runtime 50.3.0",
- "datafusion-datasource 50.3.0",
- "datafusion-execution 50.3.0",
- "datafusion-expr 50.3.0",
- "datafusion-physical-expr 50.3.0",
- "datafusion-physical-expr-common 50.3.0",
- "datafusion-physical-plan 50.3.0",
- "datafusion-session 50.3.0",
- "futures",
- "object_store 0.12.5",
- "regex",
  "tokio",
 ]
 
@@ -4172,42 +3944,17 @@ dependencies = [
  "arrow 58.1.0",
  "async-trait",
  "bytes",
- "datafusion-common 53.0.0",
- "datafusion-common-runtime 53.0.0",
- "datafusion-datasource 53.0.0",
- "datafusion-execution 53.0.0",
- "datafusion-expr 53.0.0",
- "datafusion-physical-expr-common 53.0.0",
- "datafusion-physical-plan 53.0.0",
- "datafusion-session 53.0.0",
+ "datafusion-common",
+ "datafusion-common-runtime",
+ "datafusion-datasource",
+ "datafusion-execution",
+ "datafusion-expr",
+ "datafusion-physical-expr-common",
+ "datafusion-physical-plan",
+ "datafusion-session",
  "futures",
  "object_store 0.13.2",
  "regex",
- "tokio",
-]
-
-[[package]]
-name = "datafusion-datasource-json"
-version = "50.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d7ebeb12c77df0aacad26f21b0d033aeede423a64b2b352f53048a75bf1d6e6"
-dependencies = [
- "arrow 56.2.0",
- "async-trait",
- "bytes",
- "datafusion-catalog 50.3.0",
- "datafusion-common 50.3.0",
- "datafusion-common-runtime 50.3.0",
- "datafusion-datasource 50.3.0",
- "datafusion-execution 50.3.0",
- "datafusion-expr 50.3.0",
- "datafusion-physical-expr 50.3.0",
- "datafusion-physical-expr-common 50.3.0",
- "datafusion-physical-plan 50.3.0",
- "datafusion-session 50.3.0",
- "futures",
- "object_store 0.12.5",
- "serde_json",
  "tokio",
 ]
 
@@ -4220,14 +3967,14 @@ dependencies = [
  "arrow 58.1.0",
  "async-trait",
  "bytes",
- "datafusion-common 53.0.0",
- "datafusion-common-runtime 53.0.0",
- "datafusion-datasource 53.0.0",
- "datafusion-execution 53.0.0",
- "datafusion-expr 53.0.0",
- "datafusion-physical-expr-common 53.0.0",
- "datafusion-physical-plan 53.0.0",
- "datafusion-session 53.0.0",
+ "datafusion-common",
+ "datafusion-common-runtime",
+ "datafusion-datasource",
+ "datafusion-execution",
+ "datafusion-expr",
+ "datafusion-physical-expr-common",
+ "datafusion-physical-plan",
+ "datafusion-session",
  "futures",
  "object_store 0.13.2",
  "serde_json",
@@ -4244,18 +3991,18 @@ dependencies = [
  "arrow 58.1.0",
  "async-trait",
  "bytes",
- "datafusion-common 53.0.0",
- "datafusion-common-runtime 53.0.0",
- "datafusion-datasource 53.0.0",
- "datafusion-execution 53.0.0",
- "datafusion-expr 53.0.0",
- "datafusion-functions-aggregate-common 53.0.0",
- "datafusion-physical-expr 53.0.0",
- "datafusion-physical-expr-adapter 53.0.0",
- "datafusion-physical-expr-common 53.0.0",
- "datafusion-physical-plan 53.0.0",
- "datafusion-pruning 53.0.0",
- "datafusion-session 53.0.0",
+ "datafusion-common",
+ "datafusion-common-runtime",
+ "datafusion-datasource",
+ "datafusion-execution",
+ "datafusion-expr",
+ "datafusion-functions-aggregate-common",
+ "datafusion-physical-expr",
+ "datafusion-physical-expr-adapter",
+ "datafusion-physical-expr-common",
+ "datafusion-physical-plan",
+ "datafusion-pruning",
+ "datafusion-session",
  "futures",
  "itertools 0.14.0",
  "log",
@@ -4267,35 +4014,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-doc"
-version = "50.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99ee6b1d9a80d13f9deb2291f45c07044b8e62fb540dbde2453a18be17a36429"
-
-[[package]]
-name = "datafusion-doc"
 version = "53.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c93ad9e37730d2c7196e68616f3f2dd3b04c892e03acd3a8eeca6e177f3c06a"
-
-[[package]]
-name = "datafusion-execution"
-version = "50.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4cec0a57653bec7b933fb248d3ffa3fa3ab3bd33bd140dc917f714ac036f531"
-dependencies = [
- "arrow 56.2.0",
- "async-trait",
- "dashmap",
- "datafusion-common 50.3.0",
- "datafusion-expr 50.3.0",
- "futures",
- "log",
- "object_store 0.12.5",
- "parking_lot 0.12.5",
- "rand 0.9.2",
- "tempfile",
- "url",
-]
 
 [[package]]
 name = "datafusion-execution"
@@ -4308,9 +4029,9 @@ dependencies = [
  "async-trait",
  "chrono",
  "dashmap",
- "datafusion-common 53.0.0",
- "datafusion-expr 53.0.0",
- "datafusion-physical-expr-common 53.0.0",
+ "datafusion-common",
+ "datafusion-expr",
+ "datafusion-physical-expr-common",
  "futures",
  "log",
  "object_store 0.13.2",
@@ -4322,27 +4043,6 @@ dependencies = [
 
 [[package]]
 name = "datafusion-expr"
-version = "50.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef76910bdca909722586389156d0aa4da4020e1631994d50fadd8ad4b1aa05fe"
-dependencies = [
- "arrow 56.2.0",
- "async-trait",
- "chrono",
- "datafusion-common 50.3.0",
- "datafusion-doc 50.3.0",
- "datafusion-expr-common 50.3.0",
- "datafusion-functions-aggregate-common 50.3.0",
- "datafusion-functions-window-common 50.3.0",
- "datafusion-physical-expr-common 50.3.0",
- "indexmap 2.13.0",
- "paste",
- "serde_json",
- "sqlparser 0.58.0",
-]
-
-[[package]]
-name = "datafusion-expr"
 version = "53.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67164333342b86521d6d93fa54081ee39839894fb10f7a700c099af96d7552cf"
@@ -4350,31 +4050,18 @@ dependencies = [
  "arrow 58.1.0",
  "async-trait",
  "chrono",
- "datafusion-common 53.0.0",
- "datafusion-doc 53.0.0",
- "datafusion-expr-common 53.0.0",
- "datafusion-functions-aggregate-common 53.0.0",
- "datafusion-functions-window-common 53.0.0",
- "datafusion-physical-expr-common 53.0.0",
+ "datafusion-common",
+ "datafusion-doc",
+ "datafusion-expr-common",
+ "datafusion-functions-aggregate-common",
+ "datafusion-functions-window-common",
+ "datafusion-physical-expr-common",
  "indexmap 2.13.0",
  "itertools 0.14.0",
  "paste",
  "recursive",
  "serde_json",
- "sqlparser 0.61.0",
-]
-
-[[package]]
-name = "datafusion-expr-common"
-version = "50.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d155ccbda29591ca71a1344dd6bed26c65a4438072b400df9db59447f590bb6"
-dependencies = [
- "arrow 56.2.0",
- "datafusion-common 50.3.0",
- "indexmap 2.13.0",
- "itertools 0.14.0",
- "paste",
+ "sqlparser",
 ]
 
 [[package]]
@@ -4384,39 +4071,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab05fdd00e05d5a6ee362882546d29d6d3df43a6c55355164a7fbee12d163bc9"
 dependencies = [
  "arrow 58.1.0",
- "datafusion-common 53.0.0",
+ "datafusion-common",
  "indexmap 2.13.0",
  "itertools 0.14.0",
  "paste",
-]
-
-[[package]]
-name = "datafusion-functions"
-version = "50.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7de2782136bd6014670fd84fe3b0ca3b3e4106c96403c3ae05c0598577139977"
-dependencies = [
- "arrow 56.2.0",
- "arrow-buffer 56.2.0",
- "base64 0.22.1",
- "blake2",
- "blake3",
- "chrono",
- "datafusion-common 50.3.0",
- "datafusion-doc 50.3.0",
- "datafusion-execution 50.3.0",
- "datafusion-expr 50.3.0",
- "datafusion-expr-common 50.3.0",
- "datafusion-macros 50.3.0",
- "hex",
- "itertools 0.14.0",
- "log",
- "md-5",
- "rand 0.9.2",
- "regex",
- "sha2 0.10.9",
- "unicode-segmentation",
- "uuid",
 ]
 
 [[package]]
@@ -4432,12 +4090,12 @@ dependencies = [
  "blake3",
  "chrono",
  "chrono-tz",
- "datafusion-common 53.0.0",
- "datafusion-doc 53.0.0",
- "datafusion-execution 53.0.0",
- "datafusion-expr 53.0.0",
- "datafusion-expr-common 53.0.0",
- "datafusion-macros 53.0.0",
+ "datafusion-common",
+ "datafusion-doc",
+ "datafusion-execution",
+ "datafusion-expr",
+ "datafusion-expr-common",
+ "datafusion-macros",
  "hex",
  "itertools 0.14.0",
  "log",
@@ -4453,58 +4111,24 @@ dependencies = [
 
 [[package]]
 name = "datafusion-functions-aggregate"
-version = "50.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07331fc13603a9da97b74fd8a273f4238222943dffdbbed1c4c6f862a30105bf"
-dependencies = [
- "ahash 0.8.11",
- "arrow 56.2.0",
- "datafusion-common 50.3.0",
- "datafusion-doc 50.3.0",
- "datafusion-execution 50.3.0",
- "datafusion-expr 50.3.0",
- "datafusion-functions-aggregate-common 50.3.0",
- "datafusion-macros 50.3.0",
- "datafusion-physical-expr 50.3.0",
- "datafusion-physical-expr-common 50.3.0",
- "half 2.7.1",
- "log",
- "paste",
-]
-
-[[package]]
-name = "datafusion-functions-aggregate"
 version = "53.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "829856f4e14275fb376c104f27cbf3c3b57a9cfe24885d98677525f5e43ce8d6"
 dependencies = [
  "ahash 0.8.11",
  "arrow 58.1.0",
- "datafusion-common 53.0.0",
- "datafusion-doc 53.0.0",
- "datafusion-execution 53.0.0",
- "datafusion-expr 53.0.0",
- "datafusion-functions-aggregate-common 53.0.0",
- "datafusion-macros 53.0.0",
- "datafusion-physical-expr 53.0.0",
- "datafusion-physical-expr-common 53.0.0",
+ "datafusion-common",
+ "datafusion-doc",
+ "datafusion-execution",
+ "datafusion-expr",
+ "datafusion-functions-aggregate-common",
+ "datafusion-macros",
+ "datafusion-physical-expr",
+ "datafusion-physical-expr-common",
  "half 2.7.1",
  "log",
  "num-traits",
  "paste",
-]
-
-[[package]]
-name = "datafusion-functions-aggregate-common"
-version = "50.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5951e572a8610b89968a09b5420515a121fbc305c0258651f318dc07c97ab17"
-dependencies = [
- "ahash 0.8.11",
- "arrow 56.2.0",
- "datafusion-common 50.3.0",
- "datafusion-expr-common 50.3.0",
- "datafusion-physical-expr-common 50.3.0",
 ]
 
 [[package]]
@@ -4515,31 +4139,9 @@ checksum = "08af79cc3d2aa874a362fb97decfcbd73d687190cb096f16a6c85a7780cce311"
 dependencies = [
  "ahash 0.8.11",
  "arrow 58.1.0",
- "datafusion-common 53.0.0",
- "datafusion-expr-common 53.0.0",
- "datafusion-physical-expr-common 53.0.0",
-]
-
-[[package]]
-name = "datafusion-functions-nested"
-version = "50.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdacca9302c3d8fc03f3e94f338767e786a88a33f5ebad6ffc0e7b50364b9ea3"
-dependencies = [
- "arrow 56.2.0",
- "arrow-ord 56.2.0",
- "datafusion-common 50.3.0",
- "datafusion-doc 50.3.0",
- "datafusion-execution 50.3.0",
- "datafusion-expr 50.3.0",
- "datafusion-functions 50.3.0",
- "datafusion-functions-aggregate 50.3.0",
- "datafusion-functions-aggregate-common 50.3.0",
- "datafusion-macros 50.3.0",
- "datafusion-physical-expr-common 50.3.0",
- "itertools 0.14.0",
- "log",
- "paste",
+ "datafusion-common",
+ "datafusion-expr-common",
+ "datafusion-physical-expr-common",
 ]
 
 [[package]]
@@ -4550,36 +4152,20 @@ checksum = "465ae3368146d49c2eda3e2c0ef114424c87e8a6b509ab34c1026ace6497e790"
 dependencies = [
  "arrow 58.1.0",
  "arrow-ord 58.1.0",
- "datafusion-common 53.0.0",
- "datafusion-doc 53.0.0",
- "datafusion-execution 53.0.0",
- "datafusion-expr 53.0.0",
- "datafusion-expr-common 53.0.0",
- "datafusion-functions 53.0.0",
- "datafusion-functions-aggregate 53.0.0",
- "datafusion-functions-aggregate-common 53.0.0",
- "datafusion-macros 53.0.0",
- "datafusion-physical-expr-common 53.0.0",
+ "datafusion-common",
+ "datafusion-doc",
+ "datafusion-execution",
+ "datafusion-expr",
+ "datafusion-expr-common",
+ "datafusion-functions",
+ "datafusion-functions-aggregate",
+ "datafusion-functions-aggregate-common",
+ "datafusion-macros",
+ "datafusion-physical-expr-common",
  "hashbrown 0.16.1",
  "itertools 0.14.0",
  "itoa",
  "log",
- "paste",
-]
-
-[[package]]
-name = "datafusion-functions-table"
-version = "50.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c37ff8a99434fbbad604a7e0669717c58c7c4f14c472d45067c4b016621d981"
-dependencies = [
- "arrow 56.2.0",
- "async-trait",
- "datafusion-catalog 50.3.0",
- "datafusion-common 50.3.0",
- "datafusion-expr 50.3.0",
- "datafusion-physical-plan 50.3.0",
- "parking_lot 0.12.5",
  "paste",
 ]
 
@@ -4591,29 +4177,11 @@ checksum = "6156e6b22fcf1784112fc0173f3ae6e78c8fdb4d3ed0eace9543873b437e2af6"
 dependencies = [
  "arrow 58.1.0",
  "async-trait",
- "datafusion-catalog 53.0.0",
- "datafusion-common 53.0.0",
- "datafusion-expr 53.0.0",
- "datafusion-physical-plan 53.0.0",
+ "datafusion-catalog",
+ "datafusion-common",
+ "datafusion-expr",
+ "datafusion-physical-plan",
  "parking_lot 0.12.5",
- "paste",
-]
-
-[[package]]
-name = "datafusion-functions-window"
-version = "50.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48e2aea7c79c926cffabb13dc27309d4eaeb130f4a21c8ba91cdd241c813652b"
-dependencies = [
- "arrow 56.2.0",
- "datafusion-common 50.3.0",
- "datafusion-doc 50.3.0",
- "datafusion-expr 50.3.0",
- "datafusion-functions-window-common 50.3.0",
- "datafusion-macros 50.3.0",
- "datafusion-physical-expr 50.3.0",
- "datafusion-physical-expr-common 50.3.0",
- "log",
  "paste",
 ]
 
@@ -4624,25 +4192,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca7baec14f866729012efb89011a6973f3a346dc8090c567bfcd328deff551c1"
 dependencies = [
  "arrow 58.1.0",
- "datafusion-common 53.0.0",
- "datafusion-doc 53.0.0",
- "datafusion-expr 53.0.0",
- "datafusion-functions-window-common 53.0.0",
- "datafusion-macros 53.0.0",
- "datafusion-physical-expr 53.0.0",
- "datafusion-physical-expr-common 53.0.0",
+ "datafusion-common",
+ "datafusion-doc",
+ "datafusion-expr",
+ "datafusion-functions-window-common",
+ "datafusion-macros",
+ "datafusion-physical-expr",
+ "datafusion-physical-expr-common",
  "log",
  "paste",
-]
-
-[[package]]
-name = "datafusion-functions-window-common"
-version = "50.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fead257ab5fd2ffc3b40fda64da307e20de0040fe43d49197241d9de82a487f"
-dependencies = [
- "datafusion-common 50.3.0",
- "datafusion-physical-expr-common 50.3.0",
 ]
 
 [[package]]
@@ -4651,19 +4209,8 @@ version = "53.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "159228c3280d342658466bb556dc24de30047fe1d7e559dc5d16ccc5324166f9"
 dependencies = [
- "datafusion-common 53.0.0",
- "datafusion-physical-expr-common 53.0.0",
-]
-
-[[package]]
-name = "datafusion-macros"
-version = "50.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec6f637bce95efac05cdfb9b6c19579ed4aa5f6b94d951cfa5bb054b7bb4f730"
-dependencies = [
- "datafusion-expr 50.3.0",
- "quote",
- "syn 2.0.117",
+ "datafusion-common",
+ "datafusion-physical-expr-common",
 ]
 
 [[package]]
@@ -4672,28 +4219,9 @@ version = "53.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5427e5da5edca4d21ea1c7f50e1c9421775fe33d7d5726e5641a833566e7578"
 dependencies = [
- "datafusion-doc 53.0.0",
+ "datafusion-doc",
  "quote",
  "syn 2.0.117",
-]
-
-[[package]]
-name = "datafusion-optimizer"
-version = "50.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6583ef666ae000a613a837e69e456681a9faa96347bf3877661e9e89e141d8a"
-dependencies = [
- "arrow 56.2.0",
- "chrono",
- "datafusion-common 50.3.0",
- "datafusion-expr 50.3.0",
- "datafusion-expr-common 50.3.0",
- "datafusion-physical-expr 50.3.0",
- "indexmap 2.13.0",
- "itertools 0.14.0",
- "log",
- "regex",
- "regex-syntax",
 ]
 
 [[package]]
@@ -4704,10 +4232,10 @@ checksum = "89099eefcd5b223ec685c36a41d35c69239236310d71d339f2af0fa4383f3f46"
 dependencies = [
  "arrow 58.1.0",
  "chrono",
- "datafusion-common 53.0.0",
- "datafusion-expr 53.0.0",
- "datafusion-expr-common 53.0.0",
- "datafusion-physical-expr 53.0.0",
+ "datafusion-common",
+ "datafusion-expr",
+ "datafusion-expr-common",
+ "datafusion-physical-expr",
  "indexmap 2.13.0",
  "itertools 0.14.0",
  "log",
@@ -4718,40 +4246,17 @@ dependencies = [
 
 [[package]]
 name = "datafusion-physical-expr"
-version = "50.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8668103361a272cbbe3a61f72eca60c9b7c706e87cc3565bcf21e2b277b84f6"
-dependencies = [
- "ahash 0.8.11",
- "arrow 56.2.0",
- "datafusion-common 50.3.0",
- "datafusion-expr 50.3.0",
- "datafusion-expr-common 50.3.0",
- "datafusion-functions-aggregate-common 50.3.0",
- "datafusion-physical-expr-common 50.3.0",
- "half 2.7.1",
- "hashbrown 0.14.5",
- "indexmap 2.13.0",
- "itertools 0.14.0",
- "log",
- "parking_lot 0.12.5",
- "paste",
- "petgraph 0.8.3",
-]
-
-[[package]]
-name = "datafusion-physical-expr"
 version = "53.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0f222df5195d605d79098ef37bdd5323bff0131c9d877a24da6ec98dfca9fe36"
 dependencies = [
  "ahash 0.8.11",
  "arrow 58.1.0",
- "datafusion-common 53.0.0",
- "datafusion-expr 53.0.0",
- "datafusion-expr-common 53.0.0",
- "datafusion-functions-aggregate-common 53.0.0",
- "datafusion-physical-expr-common 53.0.0",
+ "datafusion-common",
+ "datafusion-expr",
+ "datafusion-expr-common",
+ "datafusion-functions-aggregate-common",
+ "datafusion-physical-expr-common",
  "half 2.7.1",
  "hashbrown 0.16.1",
  "indexmap 2.13.0",
@@ -4765,45 +4270,16 @@ dependencies = [
 
 [[package]]
 name = "datafusion-physical-expr-adapter"
-version = "50.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "815acced725d30601b397e39958e0e55630e0a10d66ef7769c14ae6597298bb0"
-dependencies = [
- "arrow 56.2.0",
- "datafusion-common 50.3.0",
- "datafusion-expr 50.3.0",
- "datafusion-functions 50.3.0",
- "datafusion-physical-expr 50.3.0",
- "datafusion-physical-expr-common 50.3.0",
- "itertools 0.14.0",
-]
-
-[[package]]
-name = "datafusion-physical-expr-adapter"
 version = "53.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40838625d63d9c12549d81979db3dd675d159055eb9135009ba272ab0e8d0f64"
 dependencies = [
  "arrow 58.1.0",
- "datafusion-common 53.0.0",
- "datafusion-expr 53.0.0",
- "datafusion-functions 53.0.0",
- "datafusion-physical-expr 53.0.0",
- "datafusion-physical-expr-common 53.0.0",
- "itertools 0.14.0",
-]
-
-[[package]]
-name = "datafusion-physical-expr-common"
-version = "50.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6652fe7b5bf87e85ed175f571745305565da2c0b599d98e697bcbedc7baa47c3"
-dependencies = [
- "ahash 0.8.11",
- "arrow 56.2.0",
- "datafusion-common 50.3.0",
- "datafusion-expr-common 50.3.0",
- "hashbrown 0.14.5",
+ "datafusion-common",
+ "datafusion-expr",
+ "datafusion-functions",
+ "datafusion-physical-expr",
+ "datafusion-physical-expr-common",
  "itertools 0.14.0",
 ]
 
@@ -4816,31 +4292,12 @@ dependencies = [
  "ahash 0.8.11",
  "arrow 58.1.0",
  "chrono",
- "datafusion-common 53.0.0",
- "datafusion-expr-common 53.0.0",
+ "datafusion-common",
+ "datafusion-expr-common",
  "hashbrown 0.16.1",
  "indexmap 2.13.0",
  "itertools 0.14.0",
  "parking_lot 0.12.5",
-]
-
-[[package]]
-name = "datafusion-physical-optimizer"
-version = "50.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49b7d623eb6162a3332b564a0907ba00895c505d101b99af78345f1acf929b5c"
-dependencies = [
- "arrow 56.2.0",
- "datafusion-common 50.3.0",
- "datafusion-execution 50.3.0",
- "datafusion-expr 50.3.0",
- "datafusion-expr-common 50.3.0",
- "datafusion-physical-expr 50.3.0",
- "datafusion-physical-expr-common 50.3.0",
- "datafusion-physical-plan 50.3.0",
- "datafusion-pruning 50.3.0",
- "itertools 0.14.0",
- "log",
 ]
 
 [[package]]
@@ -4850,47 +4307,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d501d0e1d0910f015677121601ac177ec59272ef5c9324d1147b394988f40941"
 dependencies = [
  "arrow 58.1.0",
- "datafusion-common 53.0.0",
- "datafusion-execution 53.0.0",
- "datafusion-expr 53.0.0",
- "datafusion-expr-common 53.0.0",
- "datafusion-physical-expr 53.0.0",
- "datafusion-physical-expr-common 53.0.0",
- "datafusion-physical-plan 53.0.0",
- "datafusion-pruning 53.0.0",
+ "datafusion-common",
+ "datafusion-execution",
+ "datafusion-expr",
+ "datafusion-expr-common",
+ "datafusion-physical-expr",
+ "datafusion-physical-expr-common",
+ "datafusion-physical-plan",
+ "datafusion-pruning",
  "itertools 0.14.0",
  "recursive",
-]
-
-[[package]]
-name = "datafusion-physical-plan"
-version = "50.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2f7f778a1a838dec124efb96eae6144237d546945587557c9e6936b3414558c"
-dependencies = [
- "ahash 0.8.11",
- "arrow 56.2.0",
- "arrow-ord 56.2.0",
- "arrow-schema 56.2.0",
- "async-trait",
- "chrono",
- "datafusion-common 50.3.0",
- "datafusion-common-runtime 50.3.0",
- "datafusion-execution 50.3.0",
- "datafusion-expr 50.3.0",
- "datafusion-functions-aggregate-common 50.3.0",
- "datafusion-functions-window-common 50.3.0",
- "datafusion-physical-expr 50.3.0",
- "datafusion-physical-expr-common 50.3.0",
- "futures",
- "half 2.7.1",
- "hashbrown 0.14.5",
- "indexmap 2.13.0",
- "itertools 0.14.0",
- "log",
- "parking_lot 0.12.5",
- "pin-project-lite",
- "tokio",
 ]
 
 [[package]]
@@ -4904,15 +4330,15 @@ dependencies = [
  "arrow-ord 58.1.0",
  "arrow-schema 58.1.0",
  "async-trait",
- "datafusion-common 53.0.0",
- "datafusion-common-runtime 53.0.0",
- "datafusion-execution 53.0.0",
- "datafusion-expr 53.0.0",
- "datafusion-functions 53.0.0",
- "datafusion-functions-aggregate-common 53.0.0",
- "datafusion-functions-window-common 53.0.0",
- "datafusion-physical-expr 53.0.0",
- "datafusion-physical-expr-common 53.0.0",
+ "datafusion-common",
+ "datafusion-common-runtime",
+ "datafusion-execution",
+ "datafusion-expr",
+ "datafusion-functions",
+ "datafusion-functions-aggregate-common",
+ "datafusion-functions-window-common",
+ "datafusion-physical-expr",
+ "datafusion-physical-expr-common",
  "futures",
  "half 2.7.1",
  "hashbrown 0.16.1",
@@ -4927,61 +4353,19 @@ dependencies = [
 
 [[package]]
 name = "datafusion-pruning"
-version = "50.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd1e59e2ca14fe3c30f141600b10ad8815e2856caa59ebbd0e3e07cd3d127a65"
-dependencies = [
- "arrow 56.2.0",
- "arrow-schema 56.2.0",
- "datafusion-common 50.3.0",
- "datafusion-datasource 50.3.0",
- "datafusion-expr-common 50.3.0",
- "datafusion-physical-expr 50.3.0",
- "datafusion-physical-expr-common 50.3.0",
- "datafusion-physical-plan 50.3.0",
- "itertools 0.14.0",
- "log",
-]
-
-[[package]]
-name = "datafusion-pruning"
 version = "53.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2857618a0ecbd8cd0cf29826889edd3a25774ec26b2995fc3862095c95d88fc6"
 dependencies = [
  "arrow 58.1.0",
- "datafusion-common 53.0.0",
- "datafusion-datasource 53.0.0",
- "datafusion-expr-common 53.0.0",
- "datafusion-physical-expr 53.0.0",
- "datafusion-physical-expr-common 53.0.0",
- "datafusion-physical-plan 53.0.0",
+ "datafusion-common",
+ "datafusion-datasource",
+ "datafusion-expr-common",
+ "datafusion-physical-expr",
+ "datafusion-physical-expr-common",
+ "datafusion-physical-plan",
  "itertools 0.14.0",
  "log",
-]
-
-[[package]]
-name = "datafusion-session"
-version = "50.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21ef8e2745583619bd7a49474e8f45fbe98ebb31a133f27802217125a7b3d58d"
-dependencies = [
- "arrow 56.2.0",
- "async-trait",
- "dashmap",
- "datafusion-common 50.3.0",
- "datafusion-common-runtime 50.3.0",
- "datafusion-execution 50.3.0",
- "datafusion-expr 50.3.0",
- "datafusion-physical-expr 50.3.0",
- "datafusion-physical-plan 50.3.0",
- "datafusion-sql 50.3.0",
- "futures",
- "itertools 0.14.0",
- "log",
- "object_store 0.12.5",
- "parking_lot 0.12.5",
- "tokio",
 ]
 
 [[package]]
@@ -4991,27 +4375,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef8637e35022c5c775003b3ab1debc6b4a8f0eb41b069bdd5475dd3aa93f6eba"
 dependencies = [
  "async-trait",
- "datafusion-common 53.0.0",
- "datafusion-execution 53.0.0",
- "datafusion-expr 53.0.0",
- "datafusion-physical-plan 53.0.0",
+ "datafusion-common",
+ "datafusion-execution",
+ "datafusion-expr",
+ "datafusion-physical-plan",
  "parking_lot 0.12.5",
-]
-
-[[package]]
-name = "datafusion-sql"
-version = "50.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89abd9868770386fede29e5a4b14f49c0bf48d652c3b9d7a8a0332329b87d50b"
-dependencies = [
- "arrow 56.2.0",
- "bigdecimal 0.4.10",
- "datafusion-common 50.3.0",
- "datafusion-expr 50.3.0",
- "indexmap 2.13.0",
- "log",
- "regex",
- "sqlparser 0.58.0",
 ]
 
 [[package]]
@@ -5023,14 +4391,14 @@ dependencies = [
  "arrow 58.1.0",
  "bigdecimal 0.4.10",
  "chrono",
- "datafusion-common 53.0.0",
- "datafusion-expr 53.0.0",
- "datafusion-functions-nested 53.0.0",
+ "datafusion-common",
+ "datafusion-expr",
+ "datafusion-functions-nested",
  "indexmap 2.13.0",
  "log",
  "recursive",
  "regex",
- "sqlparser 0.61.0",
+ "sqlparser",
 ]
 
 [[package]]
@@ -5120,7 +4488,7 @@ dependencies = [
  "futures",
  "object_store 0.13.2",
  "regex",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "typed-builder 0.23.0",
@@ -5140,7 +4508,7 @@ dependencies = [
  "arrow-buffer 58.1.0",
  "arrow-cast 58.1.0",
  "arrow-ipc 58.1.0",
- "arrow-json 58.1.0",
+ "arrow-json",
  "arrow-ord 58.1.0",
  "arrow-row 58.1.0",
  "arrow-schema 58.1.0",
@@ -5169,9 +4537,9 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
- "sqlparser 0.61.0",
+ "sqlparser",
  "strum 0.27.2",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "url",
@@ -5203,7 +4571,7 @@ dependencies = [
  "deltalake-core",
  "futures",
  "object_store 0.13.2",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "url",
@@ -5578,7 +4946,7 @@ dependencies = [
  "chrono",
  "rust_decimal",
  "serde",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "time",
  "winnow 0.7.15",
 ]
@@ -5749,12 +5117,85 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
-name = "encoding_rs"
-version = "0.8.33"
+name = "encoding"
+version = "0.2.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7268b386296a025e474d5140678f75d6de9493ae55a5d709eeb9dd08149945e1"
+checksum = "6b0d943856b990d12d3b55b359144ff341533e516d94098b1d3fc1ac666d36ec"
+dependencies = [
+ "encoding-index-japanese",
+ "encoding-index-korean",
+ "encoding-index-simpchinese",
+ "encoding-index-singlebyte",
+ "encoding-index-tradchinese",
+]
+
+[[package]]
+name = "encoding-index-japanese"
+version = "1.20141219.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04e8b2ff42e9a05335dbf8b5c6f7567e5591d0d916ccef4e0b1710d32a0d0c91"
+dependencies = [
+ "encoding_index_tests",
+]
+
+[[package]]
+name = "encoding-index-korean"
+version = "1.20141219.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4dc33fb8e6bcba213fe2f14275f0963fd16f0a02c878e3095ecfdf5bee529d81"
+dependencies = [
+ "encoding_index_tests",
+]
+
+[[package]]
+name = "encoding-index-simpchinese"
+version = "1.20141219.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d87a7194909b9118fc707194baa434a4e3b0fb6a5a757c73c3adb07aa25031f7"
+dependencies = [
+ "encoding_index_tests",
+]
+
+[[package]]
+name = "encoding-index-singlebyte"
+version = "1.20141219.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3351d5acffb224af9ca265f435b859c7c01537c0849754d3db3fdf2bfe2ae84a"
+dependencies = [
+ "encoding_index_tests",
+]
+
+[[package]]
+name = "encoding-index-tradchinese"
+version = "1.20141219.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd0e20d5688ce3cab59eb3ef3a2083a5c77bf496cb798dc6fcdb75f323890c18"
+dependencies = [
+ "encoding_index_tests",
+]
+
+[[package]]
+name = "encoding_index_tests"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a246d82be1c9d791c5dfde9a2bd045fc3cbba3fa2b11ad558f27d01712f00569"
+
+[[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "encoding_rs_io"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cc3c5651fb62ab8aa3103998dade57efdd028544bd300516baa31840c252a83"
+dependencies = [
+ "encoding_rs",
 ]
 
 [[package]]
@@ -6045,12 +5486,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fastdivide"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9afc2bd4d5a73106dd53d10d73d3401c2f32730ba2c0b93ddb888a8983680471"
-
-[[package]]
 name = "fastnum"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6144,6 +5579,16 @@ name = "fiat-crypto"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0870c84016d4b481be5c9f323c24f65e31e901ae618f0e80f4308fb00de1d2d"
+
+[[package]]
+name = "filetime"
+version = "0.2.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759"
+dependencies = [
+ "cfg-if",
+ "libc",
+]
 
 [[package]]
 name = "find-msvc-tools"
@@ -6379,7 +5824,7 @@ dependencies = [
  "flume",
  "foyer-common",
  "foyer-memory",
- "fs4 0.13.1",
+ "fs4",
  "futures-core",
  "futures-util",
  "hashbrown 0.16.1",
@@ -6437,16 +5882,6 @@ dependencies = [
 
 [[package]]
 name = "fs4"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7e180ac76c23b45e767bd7ae9579bc0bb458618c4bc71835926e098e61d15f8"
-dependencies = [
- "rustix 0.38.41",
- "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "fs4"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8640e34b88f7652208ce9e88b1a37a2ae95227d84abec377ccd3c5cfeb141ed4"
@@ -6472,11 +5907,11 @@ dependencies = [
 
 [[package]]
 name = "fsst"
-version = "0.39.0"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d2475ce218217196b161b025598f77e2b405d5e729f7c37bfff145f5df00a41"
+checksum = "65f4a8c268d4d18be0f79a897c758f4eb6b074cc5c4bab56e828f0657d6bd521"
 dependencies = [
- "arrow-array 56.2.0",
+ "arrow-array 58.1.0",
  "rand 0.9.2",
 ]
 
@@ -6668,7 +6103,7 @@ dependencies = [
  "reqwest 0.13.2",
  "serde",
  "serde_json",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "time",
  "token-source",
  "tokio",
@@ -6698,7 +6133,7 @@ dependencies = [
  "reqwest-middleware",
  "serde",
  "serde_json",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "time",
  "token-source",
  "tokio",
@@ -6712,7 +6147,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "558634081d1cf458d1bc0166f69475a80f445b5b991f162028b293a38307059d"
 dependencies = [
  "http 1.4.0",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "token-source",
  "tokio",
  "tokio-retry2",
@@ -6740,7 +6175,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd3152612316be627be52fe9ca72331eb48425059b3a6a700e7adde223e061d5"
 dependencies = [
  "reqwest 0.13.2",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
 ]
 
@@ -6756,7 +6191,7 @@ dependencies = [
  "gcloud-gax",
  "gcloud-googleapis",
  "prost-types 0.14.3",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "token-source",
  "tokio",
  "tracing",
@@ -6783,7 +6218,7 @@ dependencies = [
  "reqwest 0.12.25",
  "serde",
  "serde_json",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "time",
  "tokio",
  "tokio-stream 0.1.17",
@@ -6814,7 +6249,7 @@ dependencies = [
  "rustls-pki-types",
  "serde",
  "serde_json",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "tracing-futures",
@@ -6959,7 +6394,7 @@ dependencies = [
  "async-trait",
  "hickory-resolver",
  "http 1.4.0",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tonic",
  "tower",
@@ -6968,9 +6403,9 @@ dependencies = [
 
 [[package]]
 name = "glob"
-version = "0.3.1"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "gloo-timers"
@@ -7209,6 +6644,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
 
 [[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7238,7 +6679,7 @@ dependencies = [
  "once_cell",
  "rand 0.9.2",
  "ring",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tinyvec",
  "tokio",
  "tracing",
@@ -7261,7 +6702,7 @@ dependencies = [
  "rand 0.9.2",
  "resolv-conf",
  "smallvec",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
 ]
@@ -7312,12 +6753,6 @@ dependencies = [
  "libc",
  "windows-link 0.1.1",
 ]
-
-[[package]]
-name = "htmlescape"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9025058dae765dee5070ec375f591e2ba14638c63feff74f13805a72e523163"
 
 [[package]]
 name = "http"
@@ -7632,13 +7067,13 @@ dependencies = [
  "moka",
  "murmur3",
  "once_cell",
- "opendal 0.55.0",
+ "opendal",
  "ordered-float 4.1.1",
  "parquet",
  "rand 0.8.5",
  "reqsign",
  "reqwest 0.12.25",
- "roaring 0.11.2",
+ "roaring",
  "serde",
  "serde_bytes",
  "serde_derive",
@@ -7701,7 +7136,7 @@ dependencies = [
  "async-trait",
  "backon",
  "ctor 0.2.9",
- "datafusion 53.0.0",
+ "datafusion",
  "derive_builder",
  "futures",
  "iceberg",
@@ -7714,7 +7149,7 @@ dependencies = [
  "port_scanner",
  "rand 0.9.2",
  "tempfile",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "url",
@@ -7729,7 +7164,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "dashmap",
- "datafusion 53.0.0",
+ "datafusion",
  "futures",
  "iceberg",
  "parquet",
@@ -7978,7 +7413,7 @@ version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb0889898416213fab133e1d33a0e5858a48177452750691bde3666d0fdbaf8b"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.3.9",
  "rustix 0.38.41",
  "windows-sys 0.48.0",
 ]
@@ -8068,6 +7503,28 @@ checksum = "90003f2fd9c52f212c21d8520f1128da0080bad6fff16b68fe6e7f2f0c3780c2"
 dependencies = [
  "glob",
  "lazy_static",
+]
+
+[[package]]
+name = "jieba-macros"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a29cfc5dcd898604c6f80363411fa6b6b08e27d1d253d6225b9cb6702ea02fc0"
+dependencies = [
+ "phf_codegen 0.13.1",
+]
+
+[[package]]
+name = "jieba-rs"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3245d6e9d1d5facbd6a23848d6b67e3439738ccbb4fa5a3d65da315ba1a910a2"
+dependencies = [
+ "cedarwood",
+ "jieba-macros",
+ "phf 0.13.1",
+ "regex",
+ "rustc-hash 2.1.0",
 ]
 
 [[package]]
@@ -8255,6 +7712,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "kanaria"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f9d9652540055ac4fded998a73aca97d965899077ab1212587437da44196ff"
+dependencies = [
+ "bitflags 1.3.2",
+]
+
+[[package]]
 name = "keyed_priority_queue"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8294,32 +7760,33 @@ dependencies = [
 
 [[package]]
 name = "lance"
-version = "0.39.0"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2f0ca022d0424d991933a62d2898864cf5621873962bd84e65e7d1f023f9c36"
+checksum = "1dec6c13a1b9a608cc8275bb7e967250aba18b1dfde65ea07a78c6d442e8bf5c"
 dependencies = [
- "arrow 56.2.0",
- "arrow-arith 56.2.0",
- "arrow-array 56.2.0",
- "arrow-buffer 56.2.0",
- "arrow-ipc 56.2.0",
- "arrow-ord 56.2.0",
- "arrow-row 56.2.0",
- "arrow-schema 56.2.0",
- "arrow-select 56.2.0",
+ "arrow 58.1.0",
+ "arrow-arith 58.1.0",
+ "arrow-array 58.1.0",
+ "arrow-buffer 58.1.0",
+ "arrow-cast 58.1.0",
+ "arrow-ipc 58.1.0",
+ "arrow-ord 58.1.0",
+ "arrow-row 58.1.0",
+ "arrow-schema 58.1.0",
+ "arrow-select 58.1.0",
  "async-recursion",
  "async-trait",
  "async_cell",
- "aws-credential-types",
  "byteorder",
  "bytes",
  "chrono",
+ "crossbeam-skiplist",
  "dashmap",
- "datafusion 50.3.0",
- "datafusion-expr 50.3.0",
- "datafusion-functions 50.3.0",
- "datafusion-physical-expr 50.3.0",
- "datafusion-physical-plan 50.3.0",
+ "datafusion",
+ "datafusion-expr",
+ "datafusion-functions",
+ "datafusion-physical-expr",
+ "datafusion-physical-plan",
  "deepsize",
  "either",
  "futures",
@@ -8336,22 +7803,24 @@ dependencies = [
  "lance-linalg",
  "lance-namespace",
  "lance-table",
+ "lance-tokenizer",
  "log",
  "moka",
  "object_store 0.12.5",
  "permutation",
  "pin-project",
- "prost 0.13.5",
- "prost-types 0.13.5",
+ "prost 0.14.3",
+ "prost-build 0.14.3",
+ "prost-types 0.14.3",
  "rand 0.9.2",
- "roaring 0.10.12",
+ "roaring",
  "semver",
  "serde",
  "serde_json",
- "snafu",
- "tantivy",
+ "snafu 0.9.1",
  "tokio",
  "tokio-stream 0.1.17",
+ "tokio-util",
  "tracing",
  "url",
  "uuid",
@@ -8359,17 +7828,20 @@ dependencies = [
 
 [[package]]
 name = "lance-arrow"
-version = "0.39.0"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7552f8d528775bf0ab21e1f75dcb70bdb2a828eeae58024a803b5a4655fd9a11"
+checksum = "32f0efc3607bac297f1b41ac4dc3d6ffbadd36f61a24bec46b70c1f9bda1feda"
 dependencies = [
- "arrow-array 56.2.0",
- "arrow-buffer 56.2.0",
- "arrow-cast 56.2.0",
- "arrow-data 56.2.0",
- "arrow-schema 56.2.0",
- "arrow-select 56.2.0",
+ "arrow-array 58.1.0",
+ "arrow-buffer 58.1.0",
+ "arrow-cast 58.1.0",
+ "arrow-data 58.1.0",
+ "arrow-ipc 58.1.0",
+ "arrow-ord 58.1.0",
+ "arrow-schema 58.1.0",
+ "arrow-select 58.1.0",
  "bytes",
+ "futures",
  "getrandom 0.2.11",
  "half 2.7.1",
  "jsonb",
@@ -8379,9 +7851,9 @@ dependencies = [
 
 [[package]]
 name = "lance-bitpacking"
-version = "0.39.0"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2ea14583cc6fa0bb190bcc2d3bc364b0aa545b345702976025f810e4740e8ce"
+checksum = "0c04b043c89e46ed3548f3b6423dcbdfac485e636c6e670d642424e954cfab66"
 dependencies = [
  "arrayref",
  "paste",
@@ -8390,21 +7862,22 @@ dependencies = [
 
 [[package]]
 name = "lance-core"
-version = "0.39.0"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69c752dedd207384892006c40930f898d6634e05e3d489e89763abfe4b9307e7"
+checksum = "62e954fbffdf484587e956d34613b187a4d4785f6a52b0d89b0c04f1d75d6246"
 dependencies = [
- "arrow-array 56.2.0",
- "arrow-buffer 56.2.0",
- "arrow-schema 56.2.0",
+ "arrow-array 58.1.0",
+ "arrow-buffer 58.1.0",
+ "arrow-schema 58.1.0",
  "async-trait",
  "byteorder",
  "bytes",
  "chrono",
- "datafusion-common 50.3.0",
- "datafusion-sql 50.3.0",
+ "datafusion-common",
+ "datafusion-sql",
  "deepsize",
  "futures",
+ "itertools 0.13.0",
  "lance-arrow",
  "libc",
  "log",
@@ -8413,11 +7886,11 @@ dependencies = [
  "num_cpus",
  "object_store 0.12.5",
  "pin-project",
- "prost 0.13.5",
+ "prost 0.14.3",
  "rand 0.9.2",
- "roaring 0.10.12",
+ "roaring",
  "serde_json",
- "snafu",
+ "snafu 0.9.1",
  "tempfile",
  "tokio",
  "tokio-stream 0.1.17",
@@ -8428,22 +7901,23 @@ dependencies = [
 
 [[package]]
 name = "lance-datafusion"
-version = "0.39.0"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21e1e98ca6e5cd337bdda2d9fb66063f295c0c2852d2bc6831366fea833ee608"
+checksum = "0ac79df93aa8050f1c33fdc76bd1e86da714c309c08170be5eb1e353a67dc29b"
 dependencies = [
- "arrow 56.2.0",
- "arrow-array 56.2.0",
- "arrow-buffer 56.2.0",
- "arrow-ord 56.2.0",
- "arrow-schema 56.2.0",
- "arrow-select 56.2.0",
+ "arrow 58.1.0",
+ "arrow-array 58.1.0",
+ "arrow-buffer 58.1.0",
+ "arrow-cast 58.1.0",
+ "arrow-ord 58.1.0",
+ "arrow-schema 58.1.0",
+ "arrow-select 58.1.0",
  "async-trait",
  "chrono",
- "datafusion 50.3.0",
- "datafusion-common 50.3.0",
- "datafusion-functions 50.3.0",
- "datafusion-physical-expr 50.3.0",
+ "datafusion",
+ "datafusion-common",
+ "datafusion-functions",
+ "datafusion-physical-expr",
  "futures",
  "jsonb",
  "lance-arrow",
@@ -8451,44 +7925,46 @@ dependencies = [
  "lance-datagen",
  "log",
  "pin-project",
- "prost 0.13.5",
- "snafu",
+ "prost 0.14.3",
+ "prost-build 0.14.3",
+ "snafu 0.9.1",
  "tokio",
  "tracing",
 ]
 
 [[package]]
 name = "lance-datagen"
-version = "0.39.0"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "483c643fc2806ed1a2766edf4d180511bbd1d549bcc60373e33f4785c6185891"
+checksum = "52d904119ec5682fdf5729dd943bfdeea78e43585d07a13cce34b2bcee41328b"
 dependencies = [
- "arrow 56.2.0",
- "arrow-array 56.2.0",
- "arrow-cast 56.2.0",
- "arrow-schema 56.2.0",
+ "arrow 58.1.0",
+ "arrow-array 58.1.0",
+ "arrow-cast 58.1.0",
+ "arrow-schema 58.1.0",
  "chrono",
  "futures",
  "half 2.7.1",
  "hex",
  "rand 0.9.2",
+ "rand_distr",
  "rand_xoshiro 0.7.0",
  "random_word",
 ]
 
 [[package]]
 name = "lance-encoding"
-version = "0.39.0"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a199d1fa3487529c5ffc433fbd1721231330b9350c2ff9b0c7b7dbdb98f0806a"
+checksum = "b4386ea75123fe6194e166f0f1d375b6041d44507fe7b7c63ac0da493de78a2f"
 dependencies = [
- "arrow-arith 56.2.0",
- "arrow-array 56.2.0",
- "arrow-buffer 56.2.0",
- "arrow-cast 56.2.0",
- "arrow-data 56.2.0",
- "arrow-schema 56.2.0",
- "arrow-select 56.2.0",
+ "arrow-arith 58.1.0",
+ "arrow-array 58.1.0",
+ "arrow-buffer 58.1.0",
+ "arrow-cast 58.1.0",
+ "arrow-data 58.1.0",
+ "arrow-schema 58.1.0",
+ "arrow-select 58.1.0",
  "bytemuck",
  "byteorder",
  "bytes",
@@ -8503,11 +7979,11 @@ dependencies = [
  "log",
  "lz4",
  "num-traits",
- "prost 0.13.5",
- "prost-build 0.13.5",
- "prost-types 0.13.5",
+ "prost 0.14.3",
+ "prost-build 0.14.3",
+ "prost-types 0.14.3",
  "rand 0.9.2",
- "snafu",
+ "snafu 0.9.1",
  "strum 0.26.3",
  "tokio",
  "tracing",
@@ -8517,21 +7993,21 @@ dependencies = [
 
 [[package]]
 name = "lance-file"
-version = "0.39.0"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b57def2279465232cf5a8cd996300c632442e368745768bbed661c7f0a35334b"
+checksum = "422ad760cadf7c3e8e23aefc60d4f08eff553f4ad899c40c4a5bb9a976888c44"
 dependencies = [
- "arrow-arith 56.2.0",
- "arrow-array 56.2.0",
- "arrow-buffer 56.2.0",
- "arrow-data 56.2.0",
- "arrow-schema 56.2.0",
- "arrow-select 56.2.0",
+ "arrow-arith 58.1.0",
+ "arrow-array 58.1.0",
+ "arrow-buffer 58.1.0",
+ "arrow-data 58.1.0",
+ "arrow-schema 58.1.0",
+ "arrow-select 58.1.0",
  "async-recursion",
  "async-trait",
  "byteorder",
  "bytes",
- "datafusion-common 50.3.0",
+ "datafusion-common",
  "deepsize",
  "futures",
  "lance-arrow",
@@ -8541,44 +8017,46 @@ dependencies = [
  "log",
  "num-traits",
  "object_store 0.12.5",
- "prost 0.13.5",
- "prost-build 0.13.5",
- "prost-types 0.13.5",
- "snafu",
+ "prost 0.14.3",
+ "prost-build 0.14.3",
+ "prost-types 0.14.3",
+ "snafu 0.9.1",
  "tokio",
  "tracing",
 ]
 
 [[package]]
 name = "lance-index"
-version = "0.39.0"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75938c61e986aef8c615dc44c92e4c19e393160a59e2b57402ccfe08c5e63af"
+checksum = "a653b7dc78a171f0692ddd15afc458e296667c481228171d39f5d9a1f2a1faf0"
 dependencies = [
- "arrow 56.2.0",
- "arrow-arith 56.2.0",
- "arrow-array 56.2.0",
- "arrow-ord 56.2.0",
- "arrow-schema 56.2.0",
- "arrow-select 56.2.0",
+ "arrow 58.1.0",
+ "arrow-arith 58.1.0",
+ "arrow-array 58.1.0",
+ "arrow-ord 58.1.0",
+ "arrow-schema 58.1.0",
+ "arrow-select 58.1.0",
  "async-channel 2.5.0",
  "async-recursion",
  "async-trait",
  "bitpacking",
  "bitvec",
  "bytes",
+ "chrono",
  "crossbeam-queue",
- "datafusion 50.3.0",
- "datafusion-common 50.3.0",
- "datafusion-expr 50.3.0",
- "datafusion-physical-expr 50.3.0",
- "datafusion-sql 50.3.0",
+ "datafusion",
+ "datafusion-common",
+ "datafusion-expr",
+ "datafusion-physical-expr",
+ "datafusion-sql",
  "deepsize",
  "dirs 6.0.0",
  "fst",
  "futures",
  "half 2.7.1",
  "itertools 0.13.0",
+ "jieba-rs",
  "jsonb",
  "lance-arrow",
  "lance-core",
@@ -8589,22 +8067,24 @@ dependencies = [
  "lance-io",
  "lance-linalg",
  "lance-table",
+ "lance-tokenizer",
  "libm",
  "log",
  "ndarray",
  "num-traits",
  "object_store 0.12.5",
- "prost 0.13.5",
- "prost-build 0.13.5",
- "prost-types 0.13.5",
+ "prost 0.14.3",
+ "prost-build 0.14.3",
+ "prost-types 0.14.3",
  "rand 0.9.2",
- "rand_distr 0.5.1",
+ "rand_distr",
+ "rangemap",
  "rayon",
- "roaring 0.10.12",
+ "roaring",
  "serde",
  "serde_json",
- "snafu",
- "tantivy",
+ "smallvec",
+ "snafu 0.9.1",
  "tempfile",
  "tokio",
  "tracing",
@@ -8614,41 +8094,41 @@ dependencies = [
 
 [[package]]
 name = "lance-io"
-version = "0.39.0"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa6c3b5b28570d6c951206c5b043f1b35c936928af14fca6f2ac25b0097e4c32"
+checksum = "313f83fe349a5df2a7a24ad7707696ae0437d0270b0a1b78b340ee553eef7a6c"
 dependencies = [
- "arrow 56.2.0",
- "arrow-arith 56.2.0",
- "arrow-array 56.2.0",
- "arrow-buffer 56.2.0",
- "arrow-cast 56.2.0",
- "arrow-data 56.2.0",
- "arrow-schema 56.2.0",
- "arrow-select 56.2.0",
+ "arrow 58.1.0",
+ "arrow-arith 58.1.0",
+ "arrow-array 58.1.0",
+ "arrow-buffer 58.1.0",
+ "arrow-cast 58.1.0",
+ "arrow-data 58.1.0",
+ "arrow-schema 58.1.0",
+ "arrow-select 58.1.0",
  "async-recursion",
  "async-trait",
- "aws-config",
- "aws-credential-types",
  "byteorder",
  "bytes",
  "chrono",
  "deepsize",
  "futures",
+ "http 1.4.0",
+ "io-uring",
  "lance-arrow",
  "lance-core",
  "lance-namespace",
+ "libc",
  "log",
+ "moka",
  "object_store 0.12.5",
- "object_store_opendal",
- "opendal 0.54.1",
  "path_abs",
  "pin-project",
- "prost 0.13.5",
+ "prost 0.14.3",
  "rand 0.9.2",
  "serde",
- "shellexpand",
- "snafu",
+ "snafu 0.9.1",
+ "tempfile",
  "tokio",
  "tracing",
  "url",
@@ -8656,13 +8136,13 @@ dependencies = [
 
 [[package]]
 name = "lance-linalg"
-version = "0.39.0"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3cbc7e85a89ff9cb3a4627559dea3fd1c1fb16c0d8bc46ede75eefef51eec06"
+checksum = "66bb2b89cc84b4fdb96c2436224394c1bb32d38e1e38a9c96e22e6e3918b0458"
 dependencies = [
- "arrow-array 56.2.0",
- "arrow-buffer 56.2.0",
- "arrow-schema 56.2.0",
+ "arrow-array 58.1.0",
+ "arrow-buffer 58.1.0",
+ "arrow-schema 58.1.0",
  "cc",
  "deepsize",
  "half 2.7.1",
@@ -8674,64 +8154,73 @@ dependencies = [
 
 [[package]]
 name = "lance-namespace"
-version = "0.39.0"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "897dd6726816515bb70a698ce7cda44670dca5761637696d7905b45f405a8cd9"
+checksum = "fbfd6ad2e589bd8fc00965f808f16895b50d6cbd6405bd7a972db82fe62e2e24"
 dependencies = [
- "arrow 56.2.0",
+ "arrow 58.1.0",
  "async-trait",
  "bytes",
  "lance-core",
  "lance-namespace-reqwest-client",
- "snafu",
+ "serde",
+ "snafu 0.9.1",
 ]
 
 [[package]]
 name = "lance-namespace-impls"
-version = "0.39.0"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e3cfcd3ba369de2719abf6fb6233f69cda639eb5cbcb328487a790e745ab988"
+checksum = "08c9d4a7b0dceb1a4d2697bab8ce62d52f8b8fd0eec4b4ae6d40017f0ccad0cc"
 dependencies = [
- "arrow 56.2.0",
- "arrow-ipc 56.2.0",
- "arrow-schema 56.2.0",
+ "arrow 58.1.0",
+ "arrow-ipc 58.1.0",
+ "arrow-schema 58.1.0",
  "async-trait",
  "bytes",
+ "chrono",
+ "futures",
  "lance",
  "lance-core",
+ "lance-index",
  "lance-io",
+ "lance-linalg",
  "lance-namespace",
+ "lance-table",
+ "log",
  "object_store 0.12.5",
- "reqwest 0.12.25",
+ "rand 0.9.2",
  "serde_json",
- "snafu",
+ "snafu 0.9.1",
+ "tokio",
  "url",
 ]
 
 [[package]]
 name = "lance-namespace-reqwest-client"
-version = "0.0.18"
+version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ea349999bcda4eea53fc05d334b3775ec314761e6a706555c777d7a29b18d19"
+checksum = "6369eee4682fb11edf538388b43c61ce288b8302fe89bb40944d7daa7faaae99"
 dependencies = [
  "reqwest 0.12.25",
  "serde",
  "serde_json",
  "serde_repr",
+ "serde_with",
  "url",
 ]
 
 [[package]]
 name = "lance-table"
-version = "0.39.0"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8facc13760ba034b6c38767b16adba85e44cbcbea8124dc0c63c43865c60630"
+checksum = "5a427dea3c93535c65f3c44985742c08ec4bf4f5f817779157b1dc3c6a2a3288"
 dependencies = [
- "arrow 56.2.0",
- "arrow-array 56.2.0",
- "arrow-buffer 56.2.0",
- "arrow-ipc 56.2.0",
- "arrow-schema 56.2.0",
+ "arrow 58.1.0",
+ "arrow-array 58.1.0",
+ "arrow-buffer 58.1.0",
+ "arrow-ipc 58.1.0",
+ "arrow-schema 58.1.0",
  "async-trait",
  "byteorder",
  "bytes",
@@ -8744,16 +8233,16 @@ dependencies = [
  "lance-io",
  "log",
  "object_store 0.12.5",
- "prost 0.13.5",
- "prost-build 0.13.5",
- "prost-types 0.13.5",
+ "prost 0.14.3",
+ "prost-build 0.14.3",
+ "prost-types 0.14.3",
  "rand 0.9.2",
  "rangemap",
- "roaring 0.10.12",
+ "roaring",
  "semver",
  "serde",
  "serde_json",
- "snafu",
+ "snafu 0.9.1",
  "tokio",
  "tracing",
  "url",
@@ -8762,41 +8251,57 @@ dependencies = [
 
 [[package]]
 name = "lance-testing"
-version = "0.39.0"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b05052ef86188d6ae6339bdd9f2c5d77190e8ad1158f3dc8a42fa91bde9e5246"
+checksum = "cf17e430caece4d5eb72e8ed76a61b05afc56ae66e79f2abe0945a9794a861d9"
 dependencies = [
- "arrow-array 56.2.0",
- "arrow-schema 56.2.0",
+ "arrow-array 58.1.0",
+ "arrow-schema 58.1.0",
  "lance-arrow",
  "num-traits",
  "rand 0.9.2",
 ]
 
 [[package]]
-name = "lancedb"
-version = "0.22.3"
+name = "lance-tokenizer"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1da241266792d8caa58005a3deb06ba1388a99350d89b5c904ef6f8de5d936f"
+checksum = "810ae0847a16b92629c2d894843b9666d2d975d8a7c3bd3ce21ad19c7900b140"
+dependencies = [
+ "jieba-rs",
+ "lindera",
+ "rust-stemmers",
+ "serde",
+ "unicode-normalization",
+]
+
+[[package]]
+name = "lancedb"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b1c425caac39870073f400cf1836383a0a1858134b77e9a0aef7e2f12fd47aa"
 dependencies = [
  "ahash 0.8.11",
- "arrow 56.2.0",
- "arrow-array 56.2.0",
- "arrow-cast 56.2.0",
- "arrow-data 56.2.0",
- "arrow-ipc 56.2.0",
- "arrow-ord 56.2.0",
- "arrow-schema 56.2.0",
- "arrow-select 56.2.0",
+ "arrow 58.1.0",
+ "arrow-array 58.1.0",
+ "arrow-cast 58.1.0",
+ "arrow-data 58.1.0",
+ "arrow-ipc 58.1.0",
+ "arrow-ord 58.1.0",
+ "arrow-schema 58.1.0",
+ "arrow-select 58.1.0",
  "async-trait",
  "bytes",
  "chrono",
- "datafusion 50.3.0",
- "datafusion-catalog 50.3.0",
- "datafusion-common 50.3.0",
- "datafusion-execution 50.3.0",
- "datafusion-expr 50.3.0",
- "datafusion-physical-plan 50.3.0",
+ "datafusion",
+ "datafusion-catalog",
+ "datafusion-common",
+ "datafusion-execution",
+ "datafusion-expr",
+ "datafusion-functions",
+ "datafusion-physical-expr",
+ "datafusion-physical-plan",
+ "datafusion-sql",
  "futures",
  "half 2.7.1",
  "lance",
@@ -8825,7 +8330,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
- "snafu",
+ "snafu 0.8.9",
  "tempfile",
  "tokio",
  "url",
@@ -8867,7 +8372,7 @@ dependencies = [
  "percent-encoding",
  "rustls 0.23.35",
  "rustls-native-certs 0.8.1",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-rustls 0.26.4",
  "tokio-stream 0.1.17",
@@ -8887,12 +8392,6 @@ name = "leb128fmt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
-
-[[package]]
-name = "levenshtein_automata"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c2cdeb66e45e9f36bfad5bbdb4d2384e70936afbee843c6f6543f0c551ebb25"
 
 [[package]]
 name = "lexical-core"
@@ -9073,6 +8572,130 @@ dependencies = [
 ]
 
 [[package]]
+name = "lindera"
+version = "0.44.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50aba4ef41052280722f2120f65606b9218e8718032a3c752b953c4d8091f02e"
+dependencies = [
+ "anyhow",
+ "bincode 2.0.1",
+ "byteorder",
+ "csv",
+ "kanaria",
+ "lindera-cc-cedict",
+ "lindera-dictionary",
+ "lindera-ipadic",
+ "lindera-ipadic-neologd",
+ "lindera-ko-dic",
+ "lindera-unidic",
+ "once_cell",
+ "regex",
+ "serde",
+ "serde_json",
+ "serde_yaml",
+ "strum 0.27.2",
+ "strum_macros 0.27.2",
+ "unicode-blocks",
+ "unicode-normalization",
+ "unicode-segmentation",
+ "yada",
+]
+
+[[package]]
+name = "lindera-cc-cedict"
+version = "0.44.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d77e7a0830fd60f23828ad914439997288c1d2cdd9e269be67f967c27b56350"
+dependencies = [
+ "bincode 2.0.1",
+ "byteorder",
+ "lindera-dictionary",
+ "once_cell",
+ "tokio",
+]
+
+[[package]]
+name = "lindera-dictionary"
+version = "0.44.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "489cc70922782af3fd397c0e130846caefe1c15b27c2211aac8f88a9f4590aaf"
+dependencies = [
+ "anyhow",
+ "bincode 2.0.1",
+ "byteorder",
+ "csv",
+ "derive_builder",
+ "encoding",
+ "encoding_rs",
+ "encoding_rs_io",
+ "flate2",
+ "glob",
+ "log",
+ "md5",
+ "memmap2 0.9.10",
+ "once_cell",
+ "rand 0.9.2",
+ "reqwest 0.12.25",
+ "serde",
+ "tar",
+ "thiserror 2.0.18",
+ "tokio",
+ "yada",
+]
+
+[[package]]
+name = "lindera-ipadic"
+version = "0.44.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78870521431dfaf0f94ddd3484fa08367e9d354fc8c708572f2f00007225ddfa"
+dependencies = [
+ "bincode 2.0.1",
+ "byteorder",
+ "lindera-dictionary",
+ "once_cell",
+ "tokio",
+]
+
+[[package]]
+name = "lindera-ipadic-neologd"
+version = "0.44.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "abcb3dc3056e5c683e12c2c5e8d40076f7ecfd7bd46f5fc0e4ae9e58152b5d85"
+dependencies = [
+ "bincode 2.0.1",
+ "byteorder",
+ "lindera-dictionary",
+ "once_cell",
+ "tokio",
+]
+
+[[package]]
+name = "lindera-ko-dic"
+version = "0.44.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e99316158bab14f0256d912055521ca784f76c63e7460db8a74775c5dc1f8bc2"
+dependencies = [
+ "bincode 2.0.1",
+ "byteorder",
+ "lindera-dictionary",
+ "once_cell",
+ "tokio",
+]
+
+[[package]]
+name = "lindera-unidic"
+version = "0.44.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52672945166c14276bbba25e4ec79d7e126db1b503c0a6aa07ffc0141ae15cfa"
+dependencies = [
+ "bincode 2.0.1",
+ "byteorder",
+ "lindera-dictionary",
+ "once_cell",
+ "tokio",
+]
+
+[[package]]
 name = "link-section"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9235,9 +8858,6 @@ name = "lz4_flex"
 version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "373f5eceeeab7925e0c1098212f2fbc4d416adec9d35051a6ab251e824c1854a"
-dependencies = [
- "twox-hash",
-]
 
 [[package]]
 name = "lz4_flex"
@@ -9512,13 +9132,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "measure_time"
-version = "0.9.0"
+name = "md5"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51c55d61e72fc3ab704396c5fa16f4c184db37978ae4e94ca8959693a235fc0e"
-dependencies = [
- "log",
-]
+checksum = "ae960838283323069879657ca3de837e9f7bbb4c7bf6ea7f1b290d5e9476d2e0"
 
 [[package]]
 name = "memchr"
@@ -9650,7 +9267,7 @@ version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "80e04d1dcff3aae0704555fe5fee3bcfaf3d1fdf8a7e521d5b9d2b42acb52cec"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.3.9",
  "libc",
  "log",
  "wasi 0.11.0+wasi-snapshot-preview1",
@@ -9778,7 +9395,7 @@ dependencies = [
  "stringprep",
  "strsim 0.11.1",
  "take_mut",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-rustls 0.26.4",
  "tokio-util",
@@ -9821,12 +9438,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9252111cf132ba0929b6f8e030cac2a24b507f3a4d6db6fb2896f27b354c714b"
 
 [[package]]
-name = "murmurhash32"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2195bf6aa996a481483b29d62a7663eed3fe39600c460e323f8ff41e90bdd89b"
-
-[[package]]
 name = "mysql-common-derive"
 version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9841,7 +9452,7 @@ dependencies = [
  "quote",
  "syn 2.0.117",
  "termcolor",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -9866,7 +9477,7 @@ dependencies = [
  "serde",
  "serde_json",
  "socket2 0.5.10",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-native-tls",
  "tokio-util",
@@ -9899,7 +9510,7 @@ dependencies = [
  "serde_json",
  "sha1",
  "sha2 0.10.9",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "uuid",
 ]
 
@@ -10200,11 +9811,11 @@ dependencies = [
 
 [[package]]
 name = "num_cpus"
-version = "1.16.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
+checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.5.2",
  "libc",
 ]
 
@@ -10306,29 +9917,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fbfbfff40aeccab00ec8a910b57ca8ecf4319b335c542f2edcd19dd25a1e2a00"
 dependencies = [
  "async-trait",
- "base64 0.22.1",
  "bytes",
  "chrono",
- "form_urlencoded",
  "futures",
  "http 1.4.0",
- "http-body-util",
- "httparse",
  "humantime",
- "hyper 1.10.0",
  "itertools 0.14.0",
- "md-5",
  "parking_lot 0.12.5",
  "percent-encoding",
- "quick-xml 0.38.4",
- "rand 0.9.2",
- "reqwest 0.12.25",
- "ring",
- "rustls-pemfile 2.2.0",
- "serde",
- "serde_json",
- "serde_urlencoded",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "url",
@@ -10368,28 +9965,13 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "url",
  "walkdir",
  "wasm-bindgen-futures",
  "web-time",
-]
-
-[[package]]
-name = "object_store_opendal"
-version = "0.54.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0b88fc0e0c4890c1d99e2b8c519c5db40f7d9b69a0f562ff1ad4967a4c8bbc6"
-dependencies = [
- "async-trait",
- "bytes",
- "futures",
- "object_store 0.12.5",
- "opendal 0.54.1",
- "pin-project",
- "tokio",
 ]
 
 [[package]]
@@ -10403,19 +9985,13 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.21.3"
+version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 dependencies = [
  "critical-section",
  "portable-atomic",
 ]
-
-[[package]]
-name = "oneshot"
-version = "0.1.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "269bca4c2591a28585d6bf10d9ed0332b7d76900a1b02bec41bdc3a2cdcda107"
 
 [[package]]
 name = "oorandom"
@@ -10434,35 +10010,6 @@ dependencies = [
  "serde_json",
  "tracing",
  "tracing-subscriber",
-]
-
-[[package]]
-name = "opendal"
-version = "0.54.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42afda58fa2cf50914402d132cc1caacff116a85d10c72ab2082bb7c50021754"
-dependencies = [
- "anyhow",
- "backon",
- "base64 0.22.1",
- "bytes",
- "chrono",
- "crc32c",
- "futures",
- "getrandom 0.2.11",
- "http 1.4.0",
- "http-body 1.0.1",
- "log",
- "md-5",
- "percent-encoding",
- "quick-xml 0.38.4",
- "reqsign",
- "reqwest 0.12.25",
- "serde",
- "serde_json",
- "sha2 0.10.9",
- "tokio",
- "uuid",
 ]
 
 [[package]]
@@ -10609,7 +10156,7 @@ dependencies = [
  "futures-sink",
  "js-sys",
  "pin-project-lite",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tracing",
 ]
 
@@ -10639,7 +10186,7 @@ dependencies = [
  "opentelemetry_sdk",
  "prost 0.14.3",
  "reqwest 0.12.25",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tonic",
  "tracing",
@@ -10676,7 +10223,7 @@ dependencies = [
  "opentelemetry",
  "percent-encoding",
  "rand 0.9.2",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-stream 0.1.17",
 ]
@@ -10794,15 +10341,6 @@ name = "outref"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4030760ffd992bef45b0ae3f10ce1aba99e33464c90d14dd7c039884963ddc7a"
-
-[[package]]
-name = "ownedbytes"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fbd56f7631767e61784dc43f8580f403f4475bd4aaa4da003e6295e1bab4a7e"
-dependencies = [
- "stable_deref_trait",
-]
 
 [[package]]
 name = "owo-colors"
@@ -11184,7 +10722,7 @@ dependencies = [
  "serde_json",
  "socket2 0.6.0",
  "tempfile",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "thiserror-ext",
  "tokio-openssl",
  "tokio-postgres",
@@ -11231,6 +10769,16 @@ checksum = "efbdcb6f01d193b17f0b9c3360fa7e0e620991b193ff08702f78b3ce365d7e61"
 dependencies = [
  "phf_generator 0.12.1",
  "phf_shared 0.12.1",
+]
+
+[[package]]
+name = "phf_codegen"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49aa7f9d80421bca176ca8dbfebe668cc7a2684708594ec9f3c0db0805d5d6e1"
+dependencies = [
+ "phf_generator 0.13.1",
+ "phf_shared 0.13.1",
 ]
 
 [[package]]
@@ -11545,7 +11093,7 @@ dependencies = [
  "spin 0.10.0",
  "symbolic-demangle",
  "tempfile",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -11806,7 +11354,7 @@ dependencies = [
  "parking_lot 0.12.5",
  "procfs 0.17.0",
  "protobuf",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -11980,7 +11528,7 @@ dependencies = [
  "prost-reflect",
  "prost-types 0.14.3",
  "protox-parse",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -11992,7 +11540,7 @@ dependencies = [
  "logos",
  "miette",
  "prost-types 0.14.3",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -12231,7 +11779,7 @@ dependencies = [
  "rustc-hash 2.1.0",
  "rustls 0.23.35",
  "socket2 0.5.10",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "web-time",
@@ -12253,7 +11801,7 @@ dependencies = [
  "rustls 0.23.35",
  "rustls-pki-types",
  "slab",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tinyvec",
  "tracing",
  "web-time",
@@ -12392,16 +11940,6 @@ name = "rand_core"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
-
-[[package]]
-name = "rand_distr"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32cb0b9bc82b0a0876c2dd994a7e7a2683d3e7390ca40e6886785ef0c7e3ee31"
-dependencies = [
- "num-traits",
- "rand 0.8.5",
-]
 
 [[package]]
 name = "rand_distr"
@@ -12593,7 +12131,7 @@ checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
 dependencies = [
  "getrandom 0.2.11",
  "libredox 0.1.3",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -12834,7 +12372,7 @@ dependencies = [
  "http 1.4.0",
  "reqwest 0.13.2",
  "serde",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tower-service",
 ]
 
@@ -12965,7 +12503,7 @@ dependencies = [
  "risingwave_pb",
  "serde",
  "serde_json",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "twox-hash",
 ]
 
@@ -12988,7 +12526,7 @@ dependencies = [
  "madsim-tonic",
  "memcomparable",
  "mysql_async",
- "opendal 0.55.0",
+ "opendal",
  "panic-message",
  "parking_lot 0.12.5",
  "parquet",
@@ -13004,7 +12542,7 @@ dependencies = [
  "scopeguard",
  "serde_json",
  "tempfile",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "thiserror-ext",
  "tokio-postgres",
  "tokio-stream 0.1.15",
@@ -13034,7 +12572,7 @@ dependencies = [
  "linkme",
  "madsim-tokio",
  "mysql_async",
- "opendal 0.55.0",
+ "opendal",
  "prometheus",
  "rand 0.9.2",
  "risingwave_batch",
@@ -13232,7 +12770,7 @@ dependencies = [
  "strum_macros 0.28.0",
  "sysinfo",
  "tempfile",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "thiserror-ext",
  "tinyvec",
  "tokio-retry",
@@ -13277,7 +12815,7 @@ dependencies = [
  "risingwave_common",
  "risingwave_pb",
  "risingwave_rpc_client",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "thiserror-ext",
  "tikv-jemalloc-ctl",
  "tracing",
@@ -13371,7 +12909,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "thiserror-ext",
  "tracing",
  "url",
@@ -13393,7 +12931,7 @@ dependencies = [
  "risingwave_pb",
  "risingwave_rpc_client",
  "serde",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "thiserror-ext",
  "tower",
  "tower-http",
@@ -13563,7 +13101,7 @@ dependencies = [
  "mysql_common",
  "nexmark",
  "num-bigint",
- "opendal 0.55.0",
+ "opendal",
  "opensearch",
  "openssl",
  "parking_lot 0.12.5",
@@ -13611,7 +13149,7 @@ dependencies = [
  "strum_macros 0.28.0",
  "syn 2.0.117",
  "tempfile",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "thiserror-ext",
  "tiberius",
  "time",
@@ -13659,7 +13197,7 @@ dependencies = [
  "risingwave_pb",
  "rust_decimal",
  "serde_json",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "thiserror-ext",
  "time",
  "tracing",
@@ -13720,7 +13258,7 @@ dependencies = [
  "paste",
  "risingwave_common",
  "tempfile",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tracing",
  "workspace-hack",
 ]
@@ -13751,7 +13289,7 @@ dependencies = [
  "madsim-tonic",
  "serde",
  "serde-error",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "thiserror-ext",
  "tracing",
 ]
@@ -13788,7 +13326,7 @@ dependencies = [
  "risingwave_pb",
  "smallvec",
  "static_assertions",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "thiserror-ext",
  "tracing",
  "workspace-hack",
@@ -13846,7 +13384,7 @@ dependencies = [
  "sha2 0.10.9",
  "smallvec",
  "sql-json-path",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "thiserror-ext",
  "tracing",
  "workspace-hack",
@@ -13882,8 +13420,8 @@ dependencies = [
  "bytes",
  "chrono",
  "clap",
- "datafusion 53.0.0",
- "datafusion-common 53.0.0",
+ "datafusion",
+ "datafusion-common",
  "downcast-rs 2.0.1",
  "dyn-clone",
  "easy-ext",
@@ -13950,7 +13488,7 @@ dependencies = [
  "speedate",
  "static_assertions",
  "tempfile",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "thiserror-ext",
  "tokio-postgres",
  "tokio-stream 0.1.15",
@@ -14038,7 +13576,7 @@ dependencies = [
  "risingwave_common",
  "risingwave_hummock_sdk",
  "risingwave_pb",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tracing",
 ]
 
@@ -14086,7 +13624,7 @@ dependencies = [
  "risingwave_common",
  "risingwave_object_store",
  "risingwave_pb",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "thiserror-ext",
  "tracing",
 ]
@@ -14104,7 +13642,7 @@ dependencies = [
  "risingwave_telemetry_event",
  "serde",
  "strum 0.28.0",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "thiserror-ext",
  "tracing",
  "typify",
@@ -14185,7 +13723,7 @@ dependencies = [
  "strum 0.28.0",
  "sync-point",
  "tempfile",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "thiserror-ext",
  "tokio-retry",
  "tokio-stream 0.1.15",
@@ -14334,12 +13872,12 @@ dependencies = [
  "madsim",
  "madsim-aws-sdk-s3",
  "madsim-tokio",
- "opendal 0.55.0",
+ "opendal",
  "prometheus",
  "reqwest 0.12.25",
  "risingwave_common",
  "spin 0.10.0",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "thiserror-ext",
  "tokio-retry",
  "tracing",
@@ -14364,7 +13902,7 @@ dependencies = [
  "serde",
  "static_assertions",
  "strum 0.28.0",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "thiserror-ext",
  "tonic-prost",
  "tracing",
@@ -14430,7 +13968,7 @@ dependencies = [
  "risingwave_pb",
  "rw_futures_util",
  "static_assertions",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "thiserror-ext",
  "tokio-retry",
  "tokio-stream 0.1.15",
@@ -14537,7 +14075,7 @@ dependencies = [
  "serde_with",
  "serde_yaml",
  "task-local",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tracing",
  "tracing-subscriber",
  "walkdir",
@@ -14655,7 +14193,7 @@ dependencies = [
  "spin 0.10.0",
  "sync-point",
  "tempfile",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "thiserror-ext",
  "tokio-retry",
  "tracing",
@@ -14731,7 +14269,7 @@ dependencies = [
  "smallvec",
  "static_assertions",
  "strum_macros 0.28.0",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "thiserror-ext",
  "tokio-metrics",
  "tokio-retry",
@@ -14815,19 +14353,9 @@ dependencies = [
 
 [[package]]
 name = "roaring"
-version = "0.10.12"
+version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19e8d2cfa184d94d0726d650a9f4a1be7f9b76ac9fdb954219878dc00c1c1e7b"
-dependencies = [
- "bytemuck",
- "byteorder",
-]
-
-[[package]]
-name = "roaring"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f08d6a905edb32d74a5d5737a0c9d7e950c312f3c46cb0ca0a2ca09ea11878a0"
+checksum = "1dedc5658c6ecb3bdb5ef5f3295bb9253f42dcf3fd1402c03f6b1f7659c3c4a9"
 dependencies = [
  "bytemuck",
  "byteorder",
@@ -14922,7 +14450,7 @@ dependencies = [
  "rustls-native-certs 0.8.1",
  "rustls-pemfile 2.2.0",
  "rustls-webpki 0.102.8",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-rustls 0.26.4",
  "tokio-stream 0.1.17",
@@ -15807,9 +15335,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.145"
+version = "1.0.146"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "402a6f66d8c709116cf22f558eab210f5a50187f702eb4d7e5ef38d9a7f1c79c"
+checksum = "217ca874ae0207aac254aa02c957ded05585a90892cc8d87f9e5fa49669dadd8"
 dependencies = [
  "itoa",
  "memchr",
@@ -15931,9 +15459,9 @@ dependencies = [
 
 [[package]]
 name = "serde_yaml"
-version = "0.9.25"
+version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a49e178e4452f45cb61d0cd8cebc1b0fafd3e41929e996cef79aa3aca91f574"
+checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
 dependencies = [
  "indexmap 2.13.0",
  "itoa",
@@ -16166,15 +15694,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b6709c7b6754dca1311b3c73e79fcce40dd414c782c66d88e8823030093b02b"
 
 [[package]]
-name = "sketches-ddsketch"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c6f73aeb92d671e0cc4dca167e59b2deb6387c375391bc99ee743f326994a2b"
-dependencies = [
- "serde",
-]
-
-[[package]]
 name = "slab"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -16229,7 +15748,16 @@ version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e84b3f4eacbf3a1ce05eac6763b4d629d60cbc94d632e4092c54ade71f1e1a2"
 dependencies = [
- "snafu-derive",
+ "snafu-derive 0.8.9",
+]
+
+[[package]]
+name = "snafu"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1a012328be2e3f5d5f6f3218147ca02588cea4cb865e876849ab6debcf36522"
+dependencies = [
+ "snafu-derive 0.9.1",
 ]
 
 [[package]]
@@ -16237,6 +15765,18 @@ name = "snafu-derive"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1c97747dbf44bb1ca44a561ece23508e99cb592e862f22222dcf42f51d1e451"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "snafu-derive"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f103c50866b8743da9429b8a581d81a27c2d3a9c4ac7df8f8571c1dd7896eda"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
@@ -16347,7 +15887,7 @@ dependencies = [
  "nom 7.1.3",
  "regex",
  "serde_json",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -16382,18 +15922,8 @@ dependencies = [
  "similar",
  "subst",
  "tempfile",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tracing",
-]
-
-[[package]]
-name = "sqlparser"
-version = "0.58.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec4b661c54b1e4b603b37873a18c59920e4c51ea8ea2cf527d925424dbd4437c"
-dependencies = [
- "log",
- "sqlparser_derive 0.3.0",
 ]
 
 [[package]]
@@ -16404,18 +15934,7 @@ checksum = "dbf5ea8d4d7c808e1af1cbabebca9a2abe603bcefc22294c5b95018d53200cb7"
 dependencies = [
  "log",
  "recursive",
- "sqlparser_derive 0.5.0",
-]
-
-[[package]]
-name = "sqlparser_derive"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da5fc6819faabb412da764b99d3b713bb55083c11e7e0c00144d386cd6a1939c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
+ "sqlparser_derive",
 ]
 
 [[package]]
@@ -16880,7 +16399,7 @@ dependencies = [
  "futures-util",
  "madsim-tokio",
  "spin 0.10.0",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -16973,156 +16492,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f764005d11ee5f36500a149ace24e00e3da98b0158b3e2d53a7495660d3f4d60"
 
 [[package]]
-name = "tantivy"
-version = "0.24.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64a966cb0e76e311f09cf18507c9af192f15d34886ee43d7ba7c7e3803660c43"
-dependencies = [
- "aho-corasick",
- "arc-swap",
- "base64 0.22.1",
- "bitpacking",
- "bon",
- "byteorder",
- "census",
- "crc32fast",
- "crossbeam-channel",
- "downcast-rs 2.0.1",
- "fastdivide",
- "fnv",
- "fs4 0.8.4",
- "htmlescape",
- "hyperloglogplus",
- "itertools 0.14.0",
- "levenshtein_automata",
- "log",
- "lru 0.12.5",
- "lz4_flex 0.11.6",
- "measure_time",
- "memmap2 0.9.10",
- "once_cell",
- "oneshot",
- "rayon",
- "regex",
- "rust-stemmers",
- "rustc-hash 2.1.0",
- "serde",
- "serde_json",
- "sketches-ddsketch",
- "smallvec",
- "tantivy-bitpacker",
- "tantivy-columnar",
- "tantivy-common",
- "tantivy-fst",
- "tantivy-query-grammar",
- "tantivy-stacker",
- "tantivy-tokenizer-api",
- "tempfile",
- "thiserror 2.0.17",
- "time",
- "uuid",
- "winapi",
-]
-
-[[package]]
-name = "tantivy-bitpacker"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1adc286a39e089ae9938935cd488d7d34f14502544a36607effd2239ff0e2494"
-dependencies = [
- "bitpacking",
-]
-
-[[package]]
-name = "tantivy-columnar"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6300428e0c104c4f7db6f95b466a6f5c1b9aece094ec57cdd365337908dc7344"
-dependencies = [
- "downcast-rs 2.0.1",
- "fastdivide",
- "itertools 0.14.0",
- "serde",
- "tantivy-bitpacker",
- "tantivy-common",
- "tantivy-sstable",
- "tantivy-stacker",
-]
-
-[[package]]
-name = "tantivy-common"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e91b6ea6090ce03dc72c27d0619e77185d26cc3b20775966c346c6d4f7e99d7f"
-dependencies = [
- "async-trait",
- "byteorder",
- "ownedbytes",
- "serde",
- "time",
-]
-
-[[package]]
-name = "tantivy-fst"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d60769b80ad7953d8a7b2c70cdfe722bbcdcac6bccc8ac934c40c034d866fc18"
-dependencies = [
- "byteorder",
- "regex-syntax",
- "utf8-ranges",
-]
-
-[[package]]
-name = "tantivy-query-grammar"
-version = "0.24.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e810cdeeebca57fc3f7bfec5f85fdbea9031b2ac9b990eb5ff49b371d52bbe6a"
-dependencies = [
- "nom 7.1.3",
- "serde",
- "serde_json",
-]
-
-[[package]]
-name = "tantivy-sstable"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "709f22c08a4c90e1b36711c1c6cad5ae21b20b093e535b69b18783dd2cb99416"
-dependencies = [
- "futures-util",
- "itertools 0.14.0",
- "tantivy-bitpacker",
- "tantivy-common",
- "tantivy-fst",
- "zstd",
-]
-
-[[package]]
-name = "tantivy-stacker"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bcdebb267671311d1e8891fd9d1301803fdb8ad21ba22e0a30d0cab49ba59c1"
-dependencies = [
- "murmurhash32",
- "rand_distr 0.4.3",
- "tantivy-common",
-]
-
-[[package]]
-name = "tantivy-tokenizer-api"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfa942fcee81e213e09715bbce8734ae2180070b97b33839a795ba1de201547d"
-dependencies = [
- "serde",
-]
-
-[[package]]
 name = "tap"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
+
+[[package]]
+name = "tar"
+version = "0.4.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f6221d9a6003c78398e3b239969f352578258df48c8eb051caadae0015bc840"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
+]
 
 [[package]]
 name = "target-lexicon"
@@ -17178,11 +16562,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.17"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f63587ca0f12b72a0600bcba1d40081f830876000bb46dd2337a3051618f4fc8"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl 2.0.17",
+ "thiserror-impl 2.0.18",
 ]
 
 [[package]]
@@ -17219,9 +16603,9 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.17"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ff15c8ecd7de3849db632e14d18d2571fa09dfc5ed93479bc4485c7a517c913"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -17916,7 +17300,7 @@ dependencies = [
  "opentelemetry_sdk",
  "rustversion",
  "smallvec",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tracing",
  "tracing-core",
  "tracing-log",
@@ -18022,7 +17406,7 @@ dependencies = [
  "log",
  "rand 0.9.2",
  "sha1",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "utf-8",
 ]
 
@@ -18157,7 +17541,7 @@ dependencies = [
  "serde",
  "serde_json",
  "syn 2.0.117",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "unicode-ident",
 ]
 
@@ -18203,6 +17587,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92888ba5573ff080736b3648696b70cafad7d250551175acbaa4e0385b3e1460"
 
 [[package]]
+name = "unicode-blocks"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b12e05d9e06373163a9bb6bb8c263c261b396643a99445fe6b9811fd376581b"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -18210,18 +17600,18 @@ checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
 
 [[package]]
 name = "unicode-normalization"
-version = "0.1.22"
+version = "0.1.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c5713f0fc4b5db668a2ac63cdb7bb4469d8c9fed047b1d0292cc7b0ce2ba921"
+checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
 dependencies = [
  "tinyvec",
 ]
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.10.1"
+version = "1.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1dd624098567895118886609431a7c3b8f516e41d30e0643f03d94592a147e36"
+checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
 
 [[package]]
 name = "unicode-width"
@@ -18261,9 +17651,9 @@ checksum = "81e544489bf3d8ef66c953931f56617f423cd4b5494be343d9b9d3dda037b9a3"
 
 [[package]]
 name = "unsafe-libyaml"
-version = "0.2.10"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab4c90930b95a82d00dc9e9ac071b4991924390d46cbd0dfe566148667605e4b"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "untrusted"
@@ -18490,7 +17880,7 @@ dependencies = [
  "log",
  "rustix 1.1.3",
  "system-interface",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tracing",
  "wasmtime",
  "wiggle",
@@ -18843,7 +18233,7 @@ dependencies = [
  "pulley-interpreter",
  "smallvec",
  "target-lexicon",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "wasmparser 0.236.1",
  "wasmtime-environ",
  "wasmtime-internal-math",
@@ -19069,7 +18459,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "bitflags 2.11.1",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tracing",
  "wasmtime",
  "wiggle-macro",
@@ -19145,7 +18535,7 @@ dependencies = [
  "regalloc2",
  "smallvec",
  "target-lexicon",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "wasmparser 0.236.1",
  "wasmtime-environ",
  "wasmtime-internal-cranelift",
@@ -19871,8 +19261,18 @@ dependencies = [
  "nom 7.1.3",
  "oid-registry",
  "rusticata-macros",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "time",
+]
+
+[[package]]
+name = "xattr"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
+dependencies = [
+ "libc",
+ "rustix 1.1.3",
 ]
 
 [[package]]
@@ -19896,6 +19296,12 @@ name = "xxhash-rust"
 version = "0.8.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdd20c5420375476fbd4394763288da7eb0cc0b8c11deed431a91562af7335d3"
+
+[[package]]
+name = "yada"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aed111bd9e48a802518765906cbdadf0b45afb72b9c81ab049a3b86252adffdd"
 
 [[package]]
 name = "yaml-rust2"
@@ -19939,7 +19345,7 @@ dependencies = [
  "seahash",
  "serde",
  "serde_json",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "time",
  "tokio",
  "url",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -354,8 +354,10 @@ dependencies = [
  "arrow-array 56.2.0",
  "arrow-buffer 56.2.0",
  "arrow-cast 56.2.0",
+ "arrow-csv 56.2.0",
  "arrow-data 56.2.0",
  "arrow-ipc 56.2.0",
+ "arrow-json 56.2.0",
  "arrow-ord 56.2.0",
  "arrow-row 56.2.0",
  "arrow-schema 56.2.0",
@@ -373,10 +375,10 @@ dependencies = [
  "arrow-array 58.1.0",
  "arrow-buffer 58.1.0",
  "arrow-cast 58.1.0",
- "arrow-csv",
+ "arrow-csv 58.1.0",
  "arrow-data 58.1.0",
  "arrow-ipc 58.1.0",
- "arrow-json",
+ "arrow-json 58.1.0",
  "arrow-ord 58.1.0",
  "arrow-row 58.1.0",
  "arrow-schema 58.1.0",
@@ -423,6 +425,7 @@ dependencies = [
  "arrow-data 56.2.0",
  "arrow-schema 56.2.0",
  "chrono",
+ "chrono-tz",
  "half 2.7.1",
  "hashbrown 0.16.1",
  "num",
@@ -484,6 +487,7 @@ dependencies = [
  "atoi",
  "base64 0.22.1",
  "chrono",
+ "comfy-table",
  "half 2.7.1",
  "lexical-core",
  "num",
@@ -510,6 +514,21 @@ dependencies = [
  "lexical-core",
  "num-traits",
  "ryu",
+]
+
+[[package]]
+name = "arrow-csv"
+version = "56.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa9bf02705b5cf762b6f764c65f04ae9082c7cfc4e96e0c33548ee3f67012eb"
+dependencies = [
+ "arrow-array 56.2.0",
+ "arrow-cast 56.2.0",
+ "arrow-schema 56.2.0",
+ "chrono",
+ "csv",
+ "csv-core",
+ "regex",
 ]
 
 [[package]]
@@ -584,6 +603,8 @@ dependencies = [
  "arrow-schema 56.2.0",
  "arrow-select 56.2.0",
  "flatbuffers",
+ "lz4_flex 0.11.6",
+ "zstd",
 ]
 
 [[package]]
@@ -600,6 +621,28 @@ dependencies = [
  "flatbuffers",
  "lz4_flex 0.13.0",
  "zstd",
+]
+
+[[package]]
+name = "arrow-json"
+version = "56.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88cf36502b64a127dc659e3b305f1d993a544eab0d48cce704424e62074dc04b"
+dependencies = [
+ "arrow-array 56.2.0",
+ "arrow-buffer 56.2.0",
+ "arrow-cast 56.2.0",
+ "arrow-data 56.2.0",
+ "arrow-schema 56.2.0",
+ "chrono",
+ "half 2.7.1",
+ "indexmap 2.13.0",
+ "lexical-core",
+ "memchr",
+ "num",
+ "serde",
+ "serde_json",
+ "simdutf8",
 ]
 
 [[package]]
@@ -683,6 +726,11 @@ name = "arrow-schema"
 version = "56.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3aa9e59c611ebc291c28582077ef25c97f1975383f1479b12f3b9ffee2ffabe"
+dependencies = [
+ "bitflags 2.11.1",
+ "serde",
+ "serde_json",
+]
 
 [[package]]
 name = "arrow-schema"
@@ -806,7 +854,7 @@ dependencies = [
  "asn1-rs-derive",
  "asn1-rs-impl",
  "displaydoc",
- "nom",
+ "nom 7.1.3",
  "num-traits",
  "rusticata-macros",
  "thiserror 2.0.17",
@@ -1011,6 +1059,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "async_cell"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "447ab28afbb345f5408b120702a44e5529ebf90b1796ec76e9528df8e288e6c2"
+dependencies = [
+ "loom",
 ]
 
 [[package]]
@@ -2118,6 +2175,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "bitpacking"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96a7139abd3d9cebf8cd6f920a389cf3dc9576172e32f4563f188cae3c3eb019"
+dependencies = [
+ "crunchy",
+]
+
+[[package]]
 name = "bitvec"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2331,11 +2397,11 @@ dependencies = [
  "futures",
  "indexmap 2.13.0",
  "itertools 0.14.0",
- "object_store",
+ "object_store 0.13.2",
  "parquet",
  "rand 0.9.2",
  "reqwest 0.13.2",
- "roaring",
+ "roaring 0.11.2",
  "rustc_version",
  "serde",
  "serde_json",
@@ -2521,6 +2587,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "census"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f4c707c6a209cbe82d10abd08e1ea8995e9ea937d2550646e02798948992be0"
+
+[[package]]
 name = "cesu8"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2532,7 +2604,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
 dependencies = [
- "nom",
+ "nom 7.1.3",
 ]
 
 [[package]]
@@ -2809,12 +2881,14 @@ dependencies = [
 
 [[package]]
 name = "comfy-table"
-version = "7.2.2"
+version = "7.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "958c5d6ecf1f214b4c2bbbbf6ab9523a864bd136dcf71a7e8904799acfe1ad47"
+checksum = "e0d05af1e006a2407bedef5af410552494ce5be9090444dbbcb57258c1af3d56"
 dependencies = [
- "crossterm",
- "unicode-segmentation",
+ "crossterm 0.27.0",
+ "crossterm 0.28.1",
+ "strum 0.26.3",
+ "strum_macros 0.26.4",
  "unicode-width 0.2.0",
 ]
 
@@ -3377,6 +3451,30 @@ dependencies = [
 
 [[package]]
 name = "crossterm"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f476fe445d41c9e991fd07515a6f463074b782242ccf4a5b7b1d1012e70824df"
+dependencies = [
+ "bitflags 2.11.1",
+ "crossterm_winapi",
+ "libc",
+ "parking_lot 0.12.5",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm"
+version = "0.28.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
+dependencies = [
+ "bitflags 2.11.1",
+ "parking_lot 0.12.5",
+ "rustix 0.38.41",
+]
+
+[[package]]
+name = "crossterm"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
@@ -3683,6 +3781,55 @@ checksum = "be1e0bca6c3637f992fc1cc7cbc52a78c1ef6db076dbf1059c4323d6a2048376"
 
 [[package]]
 name = "datafusion"
+version = "50.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2af15bb3c6ffa33011ef579f6b0bcbe7c26584688bd6c994f548e44df67f011a"
+dependencies = [
+ "arrow 56.2.0",
+ "arrow-ipc 56.2.0",
+ "arrow-schema 56.2.0",
+ "async-trait",
+ "bytes",
+ "chrono",
+ "datafusion-catalog 50.3.0",
+ "datafusion-catalog-listing 50.3.0",
+ "datafusion-common 50.3.0",
+ "datafusion-common-runtime 50.3.0",
+ "datafusion-datasource 50.3.0",
+ "datafusion-datasource-csv 50.3.0",
+ "datafusion-datasource-json 50.3.0",
+ "datafusion-execution 50.3.0",
+ "datafusion-expr 50.3.0",
+ "datafusion-expr-common 50.3.0",
+ "datafusion-functions 50.3.0",
+ "datafusion-functions-aggregate 50.3.0",
+ "datafusion-functions-nested 50.3.0",
+ "datafusion-functions-table 50.3.0",
+ "datafusion-functions-window 50.3.0",
+ "datafusion-optimizer 50.3.0",
+ "datafusion-physical-expr 50.3.0",
+ "datafusion-physical-expr-adapter 50.3.0",
+ "datafusion-physical-expr-common 50.3.0",
+ "datafusion-physical-optimizer 50.3.0",
+ "datafusion-physical-plan 50.3.0",
+ "datafusion-session 50.3.0",
+ "datafusion-sql 50.3.0",
+ "futures",
+ "itertools 0.14.0",
+ "log",
+ "object_store 0.12.5",
+ "parking_lot 0.12.5",
+ "rand 0.9.2",
+ "regex",
+ "sqlparser 0.58.0",
+ "tempfile",
+ "tokio",
+ "url",
+ "uuid",
+]
+
+[[package]]
+name = "datafusion"
 version = "53.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de9f8117889ba9503440f1dd79ebab32ba52ccf1720bb83cd718a29d4edc0d16"
@@ -3693,47 +3840,73 @@ dependencies = [
  "bytes",
  "bzip2",
  "chrono",
- "datafusion-catalog",
- "datafusion-catalog-listing",
- "datafusion-common",
- "datafusion-common-runtime",
- "datafusion-datasource",
+ "datafusion-catalog 53.0.0",
+ "datafusion-catalog-listing 53.0.0",
+ "datafusion-common 53.0.0",
+ "datafusion-common-runtime 53.0.0",
+ "datafusion-datasource 53.0.0",
  "datafusion-datasource-arrow",
- "datafusion-datasource-csv",
- "datafusion-datasource-json",
+ "datafusion-datasource-csv 53.0.0",
+ "datafusion-datasource-json 53.0.0",
  "datafusion-datasource-parquet",
- "datafusion-execution",
- "datafusion-expr",
- "datafusion-expr-common",
- "datafusion-functions",
- "datafusion-functions-aggregate",
- "datafusion-functions-nested",
- "datafusion-functions-table",
- "datafusion-functions-window",
- "datafusion-optimizer",
- "datafusion-physical-expr",
- "datafusion-physical-expr-adapter",
- "datafusion-physical-expr-common",
- "datafusion-physical-optimizer",
- "datafusion-physical-plan",
- "datafusion-session",
- "datafusion-sql",
+ "datafusion-execution 53.0.0",
+ "datafusion-expr 53.0.0",
+ "datafusion-expr-common 53.0.0",
+ "datafusion-functions 53.0.0",
+ "datafusion-functions-aggregate 53.0.0",
+ "datafusion-functions-nested 53.0.0",
+ "datafusion-functions-table 53.0.0",
+ "datafusion-functions-window 53.0.0",
+ "datafusion-optimizer 53.0.0",
+ "datafusion-physical-expr 53.0.0",
+ "datafusion-physical-expr-adapter 53.0.0",
+ "datafusion-physical-expr-common 53.0.0",
+ "datafusion-physical-optimizer 53.0.0",
+ "datafusion-physical-plan 53.0.0",
+ "datafusion-session 53.0.0",
+ "datafusion-sql 53.0.0",
  "flate2",
  "futures",
  "itertools 0.14.0",
  "liblzma",
  "log",
- "object_store",
+ "object_store 0.13.2",
  "parking_lot 0.12.5",
  "parquet",
  "rand 0.9.2",
  "regex",
- "sqlparser",
+ "sqlparser 0.61.0",
  "tempfile",
  "tokio",
  "url",
  "uuid",
  "zstd",
+]
+
+[[package]]
+name = "datafusion-catalog"
+version = "50.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "187622262ad8f7d16d3be9202b4c1e0116f1c9aa387e5074245538b755261621"
+dependencies = [
+ "arrow 56.2.0",
+ "async-trait",
+ "dashmap",
+ "datafusion-common 50.3.0",
+ "datafusion-common-runtime 50.3.0",
+ "datafusion-datasource 50.3.0",
+ "datafusion-execution 50.3.0",
+ "datafusion-expr 50.3.0",
+ "datafusion-physical-expr 50.3.0",
+ "datafusion-physical-plan 50.3.0",
+ "datafusion-session 50.3.0",
+ "datafusion-sql 50.3.0",
+ "futures",
+ "itertools 0.14.0",
+ "log",
+ "object_store 0.12.5",
+ "parking_lot 0.12.5",
+ "tokio",
 ]
 
 [[package]]
@@ -3745,19 +3918,42 @@ dependencies = [
  "arrow 58.1.0",
  "async-trait",
  "dashmap",
- "datafusion-common",
- "datafusion-common-runtime",
- "datafusion-datasource",
- "datafusion-execution",
- "datafusion-expr",
- "datafusion-physical-expr",
- "datafusion-physical-plan",
- "datafusion-session",
+ "datafusion-common 53.0.0",
+ "datafusion-common-runtime 53.0.0",
+ "datafusion-datasource 53.0.0",
+ "datafusion-execution 53.0.0",
+ "datafusion-expr 53.0.0",
+ "datafusion-physical-expr 53.0.0",
+ "datafusion-physical-plan 53.0.0",
+ "datafusion-session 53.0.0",
  "futures",
  "itertools 0.14.0",
  "log",
- "object_store",
+ "object_store 0.13.2",
  "parking_lot 0.12.5",
+ "tokio",
+]
+
+[[package]]
+name = "datafusion-catalog-listing"
+version = "50.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9657314f0a32efd0382b9a46fdeb2d233273ece64baa68a7c45f5a192daf0f83"
+dependencies = [
+ "arrow 56.2.0",
+ "async-trait",
+ "datafusion-catalog 50.3.0",
+ "datafusion-common 50.3.0",
+ "datafusion-datasource 50.3.0",
+ "datafusion-execution 50.3.0",
+ "datafusion-expr 50.3.0",
+ "datafusion-physical-expr 50.3.0",
+ "datafusion-physical-expr-common 50.3.0",
+ "datafusion-physical-plan 50.3.0",
+ "datafusion-session 50.3.0",
+ "futures",
+ "log",
+ "object_store 0.12.5",
  "tokio",
 ]
 
@@ -3769,19 +3965,42 @@ checksum = "830487b51ed83807d6b32d6325f349c3144ae0c9bf772cf2a712db180c31d5e6"
 dependencies = [
  "arrow 58.1.0",
  "async-trait",
- "datafusion-catalog",
- "datafusion-common",
- "datafusion-datasource",
- "datafusion-execution",
- "datafusion-expr",
- "datafusion-physical-expr",
- "datafusion-physical-expr-adapter",
- "datafusion-physical-expr-common",
- "datafusion-physical-plan",
+ "datafusion-catalog 53.0.0",
+ "datafusion-common 53.0.0",
+ "datafusion-datasource 53.0.0",
+ "datafusion-execution 53.0.0",
+ "datafusion-expr 53.0.0",
+ "datafusion-physical-expr 53.0.0",
+ "datafusion-physical-expr-adapter 53.0.0",
+ "datafusion-physical-expr-common 53.0.0",
+ "datafusion-physical-plan 53.0.0",
  "futures",
  "itertools 0.14.0",
  "log",
- "object_store",
+ "object_store 0.13.2",
+]
+
+[[package]]
+name = "datafusion-common"
+version = "50.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a83760d9a13122d025fbdb1d5d5aaf93dd9ada5e90ea229add92aa30898b2d1"
+dependencies = [
+ "ahash 0.8.11",
+ "arrow 56.2.0",
+ "arrow-ipc 56.2.0",
+ "base64 0.22.1",
+ "chrono",
+ "half 2.7.1",
+ "hashbrown 0.14.5",
+ "indexmap 2.13.0",
+ "libc",
+ "log",
+ "object_store 0.12.5",
+ "paste",
+ "sqlparser 0.58.0",
+ "tokio",
+ "web-time",
 ]
 
 [[package]]
@@ -3800,13 +4019,24 @@ dependencies = [
  "itertools 0.14.0",
  "libc",
  "log",
- "object_store",
+ "object_store 0.13.2",
  "parquet",
  "paste",
  "recursive",
- "sqlparser",
+ "sqlparser 0.61.0",
  "tokio",
  "web-time",
+]
+
+[[package]]
+name = "datafusion-common-runtime"
+version = "50.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b6234a6c7173fe5db1c6c35c01a12b2aa0f803a3007feee53483218817f8b1e"
+dependencies = [
+ "futures",
+ "log",
+ "tokio",
 ]
 
 [[package]]
@@ -3822,6 +4052,35 @@ dependencies = [
 
 [[package]]
 name = "datafusion-datasource"
+version = "50.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7256c9cb27a78709dd42d0c80f0178494637209cac6e29d5c93edd09b6721b86"
+dependencies = [
+ "arrow 56.2.0",
+ "async-trait",
+ "bytes",
+ "chrono",
+ "datafusion-common 50.3.0",
+ "datafusion-common-runtime 50.3.0",
+ "datafusion-execution 50.3.0",
+ "datafusion-expr 50.3.0",
+ "datafusion-physical-expr 50.3.0",
+ "datafusion-physical-expr-adapter 50.3.0",
+ "datafusion-physical-expr-common 50.3.0",
+ "datafusion-physical-plan 50.3.0",
+ "datafusion-session 50.3.0",
+ "futures",
+ "glob",
+ "itertools 0.14.0",
+ "log",
+ "object_store 0.12.5",
+ "rand 0.9.2",
+ "tokio",
+ "url",
+]
+
+[[package]]
+name = "datafusion-datasource"
 version = "53.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fde1e030a9dc87b743c806fbd631f5ecfa2ccaa4ffb61fa19144a07fea406b79"
@@ -3832,22 +4091,22 @@ dependencies = [
  "bytes",
  "bzip2",
  "chrono",
- "datafusion-common",
- "datafusion-common-runtime",
- "datafusion-execution",
- "datafusion-expr",
- "datafusion-physical-expr",
- "datafusion-physical-expr-adapter",
- "datafusion-physical-expr-common",
- "datafusion-physical-plan",
- "datafusion-session",
+ "datafusion-common 53.0.0",
+ "datafusion-common-runtime 53.0.0",
+ "datafusion-execution 53.0.0",
+ "datafusion-expr 53.0.0",
+ "datafusion-physical-expr 53.0.0",
+ "datafusion-physical-expr-adapter 53.0.0",
+ "datafusion-physical-expr-common 53.0.0",
+ "datafusion-physical-plan 53.0.0",
+ "datafusion-session 53.0.0",
  "flate2",
  "futures",
  "glob",
  "itertools 0.14.0",
  "liblzma",
  "log",
- "object_store",
+ "object_store 0.13.2",
  "rand 0.9.2",
  "tokio",
  "tokio-util",
@@ -3865,17 +4124,42 @@ dependencies = [
  "arrow-ipc 58.1.0",
  "async-trait",
  "bytes",
- "datafusion-common",
- "datafusion-common-runtime",
- "datafusion-datasource",
- "datafusion-execution",
- "datafusion-expr",
- "datafusion-physical-expr-common",
- "datafusion-physical-plan",
- "datafusion-session",
+ "datafusion-common 53.0.0",
+ "datafusion-common-runtime 53.0.0",
+ "datafusion-datasource 53.0.0",
+ "datafusion-execution 53.0.0",
+ "datafusion-expr 53.0.0",
+ "datafusion-physical-expr-common 53.0.0",
+ "datafusion-physical-plan 53.0.0",
+ "datafusion-session 53.0.0",
  "futures",
  "itertools 0.14.0",
- "object_store",
+ "object_store 0.13.2",
+ "tokio",
+]
+
+[[package]]
+name = "datafusion-datasource-csv"
+version = "50.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64533a90f78e1684bfb113d200b540f18f268134622d7c96bbebc91354d04825"
+dependencies = [
+ "arrow 56.2.0",
+ "async-trait",
+ "bytes",
+ "datafusion-catalog 50.3.0",
+ "datafusion-common 50.3.0",
+ "datafusion-common-runtime 50.3.0",
+ "datafusion-datasource 50.3.0",
+ "datafusion-execution 50.3.0",
+ "datafusion-expr 50.3.0",
+ "datafusion-physical-expr 50.3.0",
+ "datafusion-physical-expr-common 50.3.0",
+ "datafusion-physical-plan 50.3.0",
+ "datafusion-session 50.3.0",
+ "futures",
+ "object_store 0.12.5",
+ "regex",
  "tokio",
 ]
 
@@ -3888,17 +4172,42 @@ dependencies = [
  "arrow 58.1.0",
  "async-trait",
  "bytes",
- "datafusion-common",
- "datafusion-common-runtime",
- "datafusion-datasource",
- "datafusion-execution",
- "datafusion-expr",
- "datafusion-physical-expr-common",
- "datafusion-physical-plan",
- "datafusion-session",
+ "datafusion-common 53.0.0",
+ "datafusion-common-runtime 53.0.0",
+ "datafusion-datasource 53.0.0",
+ "datafusion-execution 53.0.0",
+ "datafusion-expr 53.0.0",
+ "datafusion-physical-expr-common 53.0.0",
+ "datafusion-physical-plan 53.0.0",
+ "datafusion-session 53.0.0",
  "futures",
- "object_store",
+ "object_store 0.13.2",
  "regex",
+ "tokio",
+]
+
+[[package]]
+name = "datafusion-datasource-json"
+version = "50.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d7ebeb12c77df0aacad26f21b0d033aeede423a64b2b352f53048a75bf1d6e6"
+dependencies = [
+ "arrow 56.2.0",
+ "async-trait",
+ "bytes",
+ "datafusion-catalog 50.3.0",
+ "datafusion-common 50.3.0",
+ "datafusion-common-runtime 50.3.0",
+ "datafusion-datasource 50.3.0",
+ "datafusion-execution 50.3.0",
+ "datafusion-expr 50.3.0",
+ "datafusion-physical-expr 50.3.0",
+ "datafusion-physical-expr-common 50.3.0",
+ "datafusion-physical-plan 50.3.0",
+ "datafusion-session 50.3.0",
+ "futures",
+ "object_store 0.12.5",
+ "serde_json",
  "tokio",
 ]
 
@@ -3911,16 +4220,16 @@ dependencies = [
  "arrow 58.1.0",
  "async-trait",
  "bytes",
- "datafusion-common",
- "datafusion-common-runtime",
- "datafusion-datasource",
- "datafusion-execution",
- "datafusion-expr",
- "datafusion-physical-expr-common",
- "datafusion-physical-plan",
- "datafusion-session",
+ "datafusion-common 53.0.0",
+ "datafusion-common-runtime 53.0.0",
+ "datafusion-datasource 53.0.0",
+ "datafusion-execution 53.0.0",
+ "datafusion-expr 53.0.0",
+ "datafusion-physical-expr-common 53.0.0",
+ "datafusion-physical-plan 53.0.0",
+ "datafusion-session 53.0.0",
  "futures",
- "object_store",
+ "object_store 0.13.2",
  "serde_json",
  "tokio",
  "tokio-stream 0.1.17",
@@ -3935,22 +4244,22 @@ dependencies = [
  "arrow 58.1.0",
  "async-trait",
  "bytes",
- "datafusion-common",
- "datafusion-common-runtime",
- "datafusion-datasource",
- "datafusion-execution",
- "datafusion-expr",
- "datafusion-functions-aggregate-common",
- "datafusion-physical-expr",
- "datafusion-physical-expr-adapter",
- "datafusion-physical-expr-common",
- "datafusion-physical-plan",
- "datafusion-pruning",
- "datafusion-session",
+ "datafusion-common 53.0.0",
+ "datafusion-common-runtime 53.0.0",
+ "datafusion-datasource 53.0.0",
+ "datafusion-execution 53.0.0",
+ "datafusion-expr 53.0.0",
+ "datafusion-functions-aggregate-common 53.0.0",
+ "datafusion-physical-expr 53.0.0",
+ "datafusion-physical-expr-adapter 53.0.0",
+ "datafusion-physical-expr-common 53.0.0",
+ "datafusion-physical-plan 53.0.0",
+ "datafusion-pruning 53.0.0",
+ "datafusion-session 53.0.0",
  "futures",
  "itertools 0.14.0",
  "log",
- "object_store",
+ "object_store 0.13.2",
  "parking_lot 0.12.5",
  "parquet",
  "tokio",
@@ -3958,9 +4267,35 @@ dependencies = [
 
 [[package]]
 name = "datafusion-doc"
+version = "50.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99ee6b1d9a80d13f9deb2291f45c07044b8e62fb540dbde2453a18be17a36429"
+
+[[package]]
+name = "datafusion-doc"
 version = "53.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c93ad9e37730d2c7196e68616f3f2dd3b04c892e03acd3a8eeca6e177f3c06a"
+
+[[package]]
+name = "datafusion-execution"
+version = "50.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4cec0a57653bec7b933fb248d3ffa3fa3ab3bd33bd140dc917f714ac036f531"
+dependencies = [
+ "arrow 56.2.0",
+ "async-trait",
+ "dashmap",
+ "datafusion-common 50.3.0",
+ "datafusion-expr 50.3.0",
+ "futures",
+ "log",
+ "object_store 0.12.5",
+ "parking_lot 0.12.5",
+ "rand 0.9.2",
+ "tempfile",
+ "url",
+]
 
 [[package]]
 name = "datafusion-execution"
@@ -3973,16 +4308,37 @@ dependencies = [
  "async-trait",
  "chrono",
  "dashmap",
- "datafusion-common",
- "datafusion-expr",
- "datafusion-physical-expr-common",
+ "datafusion-common 53.0.0",
+ "datafusion-expr 53.0.0",
+ "datafusion-physical-expr-common 53.0.0",
  "futures",
  "log",
- "object_store",
+ "object_store 0.13.2",
  "parking_lot 0.12.5",
  "rand 0.9.2",
  "tempfile",
  "url",
+]
+
+[[package]]
+name = "datafusion-expr"
+version = "50.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef76910bdca909722586389156d0aa4da4020e1631994d50fadd8ad4b1aa05fe"
+dependencies = [
+ "arrow 56.2.0",
+ "async-trait",
+ "chrono",
+ "datafusion-common 50.3.0",
+ "datafusion-doc 50.3.0",
+ "datafusion-expr-common 50.3.0",
+ "datafusion-functions-aggregate-common 50.3.0",
+ "datafusion-functions-window-common 50.3.0",
+ "datafusion-physical-expr-common 50.3.0",
+ "indexmap 2.13.0",
+ "paste",
+ "serde_json",
+ "sqlparser 0.58.0",
 ]
 
 [[package]]
@@ -3994,18 +4350,31 @@ dependencies = [
  "arrow 58.1.0",
  "async-trait",
  "chrono",
- "datafusion-common",
- "datafusion-doc",
- "datafusion-expr-common",
- "datafusion-functions-aggregate-common",
- "datafusion-functions-window-common",
- "datafusion-physical-expr-common",
+ "datafusion-common 53.0.0",
+ "datafusion-doc 53.0.0",
+ "datafusion-expr-common 53.0.0",
+ "datafusion-functions-aggregate-common 53.0.0",
+ "datafusion-functions-window-common 53.0.0",
+ "datafusion-physical-expr-common 53.0.0",
  "indexmap 2.13.0",
  "itertools 0.14.0",
  "paste",
  "recursive",
  "serde_json",
- "sqlparser",
+ "sqlparser 0.61.0",
+]
+
+[[package]]
+name = "datafusion-expr-common"
+version = "50.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d155ccbda29591ca71a1344dd6bed26c65a4438072b400df9db59447f590bb6"
+dependencies = [
+ "arrow 56.2.0",
+ "datafusion-common 50.3.0",
+ "indexmap 2.13.0",
+ "itertools 0.14.0",
+ "paste",
 ]
 
 [[package]]
@@ -4015,10 +4384,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab05fdd00e05d5a6ee362882546d29d6d3df43a6c55355164a7fbee12d163bc9"
 dependencies = [
  "arrow 58.1.0",
- "datafusion-common",
+ "datafusion-common 53.0.0",
  "indexmap 2.13.0",
  "itertools 0.14.0",
  "paste",
+]
+
+[[package]]
+name = "datafusion-functions"
+version = "50.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7de2782136bd6014670fd84fe3b0ca3b3e4106c96403c3ae05c0598577139977"
+dependencies = [
+ "arrow 56.2.0",
+ "arrow-buffer 56.2.0",
+ "base64 0.22.1",
+ "blake2",
+ "blake3",
+ "chrono",
+ "datafusion-common 50.3.0",
+ "datafusion-doc 50.3.0",
+ "datafusion-execution 50.3.0",
+ "datafusion-expr 50.3.0",
+ "datafusion-expr-common 50.3.0",
+ "datafusion-macros 50.3.0",
+ "hex",
+ "itertools 0.14.0",
+ "log",
+ "md-5",
+ "rand 0.9.2",
+ "regex",
+ "sha2 0.10.9",
+ "unicode-segmentation",
+ "uuid",
 ]
 
 [[package]]
@@ -4034,12 +4432,12 @@ dependencies = [
  "blake3",
  "chrono",
  "chrono-tz",
- "datafusion-common",
- "datafusion-doc",
- "datafusion-execution",
- "datafusion-expr",
- "datafusion-expr-common",
- "datafusion-macros",
+ "datafusion-common 53.0.0",
+ "datafusion-doc 53.0.0",
+ "datafusion-execution 53.0.0",
+ "datafusion-expr 53.0.0",
+ "datafusion-expr-common 53.0.0",
+ "datafusion-macros 53.0.0",
  "hex",
  "itertools 0.14.0",
  "log",
@@ -4055,24 +4453,58 @@ dependencies = [
 
 [[package]]
 name = "datafusion-functions-aggregate"
+version = "50.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07331fc13603a9da97b74fd8a273f4238222943dffdbbed1c4c6f862a30105bf"
+dependencies = [
+ "ahash 0.8.11",
+ "arrow 56.2.0",
+ "datafusion-common 50.3.0",
+ "datafusion-doc 50.3.0",
+ "datafusion-execution 50.3.0",
+ "datafusion-expr 50.3.0",
+ "datafusion-functions-aggregate-common 50.3.0",
+ "datafusion-macros 50.3.0",
+ "datafusion-physical-expr 50.3.0",
+ "datafusion-physical-expr-common 50.3.0",
+ "half 2.7.1",
+ "log",
+ "paste",
+]
+
+[[package]]
+name = "datafusion-functions-aggregate"
 version = "53.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "829856f4e14275fb376c104f27cbf3c3b57a9cfe24885d98677525f5e43ce8d6"
 dependencies = [
  "ahash 0.8.11",
  "arrow 58.1.0",
- "datafusion-common",
- "datafusion-doc",
- "datafusion-execution",
- "datafusion-expr",
- "datafusion-functions-aggregate-common",
- "datafusion-macros",
- "datafusion-physical-expr",
- "datafusion-physical-expr-common",
+ "datafusion-common 53.0.0",
+ "datafusion-doc 53.0.0",
+ "datafusion-execution 53.0.0",
+ "datafusion-expr 53.0.0",
+ "datafusion-functions-aggregate-common 53.0.0",
+ "datafusion-macros 53.0.0",
+ "datafusion-physical-expr 53.0.0",
+ "datafusion-physical-expr-common 53.0.0",
  "half 2.7.1",
  "log",
  "num-traits",
  "paste",
+]
+
+[[package]]
+name = "datafusion-functions-aggregate-common"
+version = "50.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5951e572a8610b89968a09b5420515a121fbc305c0258651f318dc07c97ab17"
+dependencies = [
+ "ahash 0.8.11",
+ "arrow 56.2.0",
+ "datafusion-common 50.3.0",
+ "datafusion-expr-common 50.3.0",
+ "datafusion-physical-expr-common 50.3.0",
 ]
 
 [[package]]
@@ -4083,9 +4515,31 @@ checksum = "08af79cc3d2aa874a362fb97decfcbd73d687190cb096f16a6c85a7780cce311"
 dependencies = [
  "ahash 0.8.11",
  "arrow 58.1.0",
- "datafusion-common",
- "datafusion-expr-common",
- "datafusion-physical-expr-common",
+ "datafusion-common 53.0.0",
+ "datafusion-expr-common 53.0.0",
+ "datafusion-physical-expr-common 53.0.0",
+]
+
+[[package]]
+name = "datafusion-functions-nested"
+version = "50.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdacca9302c3d8fc03f3e94f338767e786a88a33f5ebad6ffc0e7b50364b9ea3"
+dependencies = [
+ "arrow 56.2.0",
+ "arrow-ord 56.2.0",
+ "datafusion-common 50.3.0",
+ "datafusion-doc 50.3.0",
+ "datafusion-execution 50.3.0",
+ "datafusion-expr 50.3.0",
+ "datafusion-functions 50.3.0",
+ "datafusion-functions-aggregate 50.3.0",
+ "datafusion-functions-aggregate-common 50.3.0",
+ "datafusion-macros 50.3.0",
+ "datafusion-physical-expr-common 50.3.0",
+ "itertools 0.14.0",
+ "log",
+ "paste",
 ]
 
 [[package]]
@@ -4096,20 +4550,36 @@ checksum = "465ae3368146d49c2eda3e2c0ef114424c87e8a6b509ab34c1026ace6497e790"
 dependencies = [
  "arrow 58.1.0",
  "arrow-ord 58.1.0",
- "datafusion-common",
- "datafusion-doc",
- "datafusion-execution",
- "datafusion-expr",
- "datafusion-expr-common",
- "datafusion-functions",
- "datafusion-functions-aggregate",
- "datafusion-functions-aggregate-common",
- "datafusion-macros",
- "datafusion-physical-expr-common",
+ "datafusion-common 53.0.0",
+ "datafusion-doc 53.0.0",
+ "datafusion-execution 53.0.0",
+ "datafusion-expr 53.0.0",
+ "datafusion-expr-common 53.0.0",
+ "datafusion-functions 53.0.0",
+ "datafusion-functions-aggregate 53.0.0",
+ "datafusion-functions-aggregate-common 53.0.0",
+ "datafusion-macros 53.0.0",
+ "datafusion-physical-expr-common 53.0.0",
  "hashbrown 0.16.1",
  "itertools 0.14.0",
  "itoa",
  "log",
+ "paste",
+]
+
+[[package]]
+name = "datafusion-functions-table"
+version = "50.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c37ff8a99434fbbad604a7e0669717c58c7c4f14c472d45067c4b016621d981"
+dependencies = [
+ "arrow 56.2.0",
+ "async-trait",
+ "datafusion-catalog 50.3.0",
+ "datafusion-common 50.3.0",
+ "datafusion-expr 50.3.0",
+ "datafusion-physical-plan 50.3.0",
+ "parking_lot 0.12.5",
  "paste",
 ]
 
@@ -4121,11 +4591,29 @@ checksum = "6156e6b22fcf1784112fc0173f3ae6e78c8fdb4d3ed0eace9543873b437e2af6"
 dependencies = [
  "arrow 58.1.0",
  "async-trait",
- "datafusion-catalog",
- "datafusion-common",
- "datafusion-expr",
- "datafusion-physical-plan",
+ "datafusion-catalog 53.0.0",
+ "datafusion-common 53.0.0",
+ "datafusion-expr 53.0.0",
+ "datafusion-physical-plan 53.0.0",
  "parking_lot 0.12.5",
+ "paste",
+]
+
+[[package]]
+name = "datafusion-functions-window"
+version = "50.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48e2aea7c79c926cffabb13dc27309d4eaeb130f4a21c8ba91cdd241c813652b"
+dependencies = [
+ "arrow 56.2.0",
+ "datafusion-common 50.3.0",
+ "datafusion-doc 50.3.0",
+ "datafusion-expr 50.3.0",
+ "datafusion-functions-window-common 50.3.0",
+ "datafusion-macros 50.3.0",
+ "datafusion-physical-expr 50.3.0",
+ "datafusion-physical-expr-common 50.3.0",
+ "log",
  "paste",
 ]
 
@@ -4136,15 +4624,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca7baec14f866729012efb89011a6973f3a346dc8090c567bfcd328deff551c1"
 dependencies = [
  "arrow 58.1.0",
- "datafusion-common",
- "datafusion-doc",
- "datafusion-expr",
- "datafusion-functions-window-common",
- "datafusion-macros",
- "datafusion-physical-expr",
- "datafusion-physical-expr-common",
+ "datafusion-common 53.0.0",
+ "datafusion-doc 53.0.0",
+ "datafusion-expr 53.0.0",
+ "datafusion-functions-window-common 53.0.0",
+ "datafusion-macros 53.0.0",
+ "datafusion-physical-expr 53.0.0",
+ "datafusion-physical-expr-common 53.0.0",
  "log",
  "paste",
+]
+
+[[package]]
+name = "datafusion-functions-window-common"
+version = "50.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fead257ab5fd2ffc3b40fda64da307e20de0040fe43d49197241d9de82a487f"
+dependencies = [
+ "datafusion-common 50.3.0",
+ "datafusion-physical-expr-common 50.3.0",
 ]
 
 [[package]]
@@ -4153,8 +4651,19 @@ version = "53.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "159228c3280d342658466bb556dc24de30047fe1d7e559dc5d16ccc5324166f9"
 dependencies = [
- "datafusion-common",
- "datafusion-physical-expr-common",
+ "datafusion-common 53.0.0",
+ "datafusion-physical-expr-common 53.0.0",
+]
+
+[[package]]
+name = "datafusion-macros"
+version = "50.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec6f637bce95efac05cdfb9b6c19579ed4aa5f6b94d951cfa5bb054b7bb4f730"
+dependencies = [
+ "datafusion-expr 50.3.0",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4163,9 +4672,28 @@ version = "53.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5427e5da5edca4d21ea1c7f50e1c9421775fe33d7d5726e5641a833566e7578"
 dependencies = [
- "datafusion-doc",
+ "datafusion-doc 53.0.0",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "datafusion-optimizer"
+version = "50.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6583ef666ae000a613a837e69e456681a9faa96347bf3877661e9e89e141d8a"
+dependencies = [
+ "arrow 56.2.0",
+ "chrono",
+ "datafusion-common 50.3.0",
+ "datafusion-expr 50.3.0",
+ "datafusion-expr-common 50.3.0",
+ "datafusion-physical-expr 50.3.0",
+ "indexmap 2.13.0",
+ "itertools 0.14.0",
+ "log",
+ "regex",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -4176,10 +4704,10 @@ checksum = "89099eefcd5b223ec685c36a41d35c69239236310d71d339f2af0fa4383f3f46"
 dependencies = [
  "arrow 58.1.0",
  "chrono",
- "datafusion-common",
- "datafusion-expr",
- "datafusion-expr-common",
- "datafusion-physical-expr",
+ "datafusion-common 53.0.0",
+ "datafusion-expr 53.0.0",
+ "datafusion-expr-common 53.0.0",
+ "datafusion-physical-expr 53.0.0",
  "indexmap 2.13.0",
  "itertools 0.14.0",
  "log",
@@ -4190,17 +4718,40 @@ dependencies = [
 
 [[package]]
 name = "datafusion-physical-expr"
+version = "50.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8668103361a272cbbe3a61f72eca60c9b7c706e87cc3565bcf21e2b277b84f6"
+dependencies = [
+ "ahash 0.8.11",
+ "arrow 56.2.0",
+ "datafusion-common 50.3.0",
+ "datafusion-expr 50.3.0",
+ "datafusion-expr-common 50.3.0",
+ "datafusion-functions-aggregate-common 50.3.0",
+ "datafusion-physical-expr-common 50.3.0",
+ "half 2.7.1",
+ "hashbrown 0.14.5",
+ "indexmap 2.13.0",
+ "itertools 0.14.0",
+ "log",
+ "parking_lot 0.12.5",
+ "paste",
+ "petgraph 0.8.3",
+]
+
+[[package]]
+name = "datafusion-physical-expr"
 version = "53.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0f222df5195d605d79098ef37bdd5323bff0131c9d877a24da6ec98dfca9fe36"
 dependencies = [
  "ahash 0.8.11",
  "arrow 58.1.0",
- "datafusion-common",
- "datafusion-expr",
- "datafusion-expr-common",
- "datafusion-functions-aggregate-common",
- "datafusion-physical-expr-common",
+ "datafusion-common 53.0.0",
+ "datafusion-expr 53.0.0",
+ "datafusion-expr-common 53.0.0",
+ "datafusion-functions-aggregate-common 53.0.0",
+ "datafusion-physical-expr-common 53.0.0",
  "half 2.7.1",
  "hashbrown 0.16.1",
  "indexmap 2.13.0",
@@ -4214,16 +4765,45 @@ dependencies = [
 
 [[package]]
 name = "datafusion-physical-expr-adapter"
+version = "50.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "815acced725d30601b397e39958e0e55630e0a10d66ef7769c14ae6597298bb0"
+dependencies = [
+ "arrow 56.2.0",
+ "datafusion-common 50.3.0",
+ "datafusion-expr 50.3.0",
+ "datafusion-functions 50.3.0",
+ "datafusion-physical-expr 50.3.0",
+ "datafusion-physical-expr-common 50.3.0",
+ "itertools 0.14.0",
+]
+
+[[package]]
+name = "datafusion-physical-expr-adapter"
 version = "53.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40838625d63d9c12549d81979db3dd675d159055eb9135009ba272ab0e8d0f64"
 dependencies = [
  "arrow 58.1.0",
- "datafusion-common",
- "datafusion-expr",
- "datafusion-functions",
- "datafusion-physical-expr",
- "datafusion-physical-expr-common",
+ "datafusion-common 53.0.0",
+ "datafusion-expr 53.0.0",
+ "datafusion-functions 53.0.0",
+ "datafusion-physical-expr 53.0.0",
+ "datafusion-physical-expr-common 53.0.0",
+ "itertools 0.14.0",
+]
+
+[[package]]
+name = "datafusion-physical-expr-common"
+version = "50.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6652fe7b5bf87e85ed175f571745305565da2c0b599d98e697bcbedc7baa47c3"
+dependencies = [
+ "ahash 0.8.11",
+ "arrow 56.2.0",
+ "datafusion-common 50.3.0",
+ "datafusion-expr-common 50.3.0",
+ "hashbrown 0.14.5",
  "itertools 0.14.0",
 ]
 
@@ -4236,12 +4816,31 @@ dependencies = [
  "ahash 0.8.11",
  "arrow 58.1.0",
  "chrono",
- "datafusion-common",
- "datafusion-expr-common",
+ "datafusion-common 53.0.0",
+ "datafusion-expr-common 53.0.0",
  "hashbrown 0.16.1",
  "indexmap 2.13.0",
  "itertools 0.14.0",
  "parking_lot 0.12.5",
+]
+
+[[package]]
+name = "datafusion-physical-optimizer"
+version = "50.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49b7d623eb6162a3332b564a0907ba00895c505d101b99af78345f1acf929b5c"
+dependencies = [
+ "arrow 56.2.0",
+ "datafusion-common 50.3.0",
+ "datafusion-execution 50.3.0",
+ "datafusion-expr 50.3.0",
+ "datafusion-expr-common 50.3.0",
+ "datafusion-physical-expr 50.3.0",
+ "datafusion-physical-expr-common 50.3.0",
+ "datafusion-physical-plan 50.3.0",
+ "datafusion-pruning 50.3.0",
+ "itertools 0.14.0",
+ "log",
 ]
 
 [[package]]
@@ -4251,16 +4850,47 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d501d0e1d0910f015677121601ac177ec59272ef5c9324d1147b394988f40941"
 dependencies = [
  "arrow 58.1.0",
- "datafusion-common",
- "datafusion-execution",
- "datafusion-expr",
- "datafusion-expr-common",
- "datafusion-physical-expr",
- "datafusion-physical-expr-common",
- "datafusion-physical-plan",
- "datafusion-pruning",
+ "datafusion-common 53.0.0",
+ "datafusion-execution 53.0.0",
+ "datafusion-expr 53.0.0",
+ "datafusion-expr-common 53.0.0",
+ "datafusion-physical-expr 53.0.0",
+ "datafusion-physical-expr-common 53.0.0",
+ "datafusion-physical-plan 53.0.0",
+ "datafusion-pruning 53.0.0",
  "itertools 0.14.0",
  "recursive",
+]
+
+[[package]]
+name = "datafusion-physical-plan"
+version = "50.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2f7f778a1a838dec124efb96eae6144237d546945587557c9e6936b3414558c"
+dependencies = [
+ "ahash 0.8.11",
+ "arrow 56.2.0",
+ "arrow-ord 56.2.0",
+ "arrow-schema 56.2.0",
+ "async-trait",
+ "chrono",
+ "datafusion-common 50.3.0",
+ "datafusion-common-runtime 50.3.0",
+ "datafusion-execution 50.3.0",
+ "datafusion-expr 50.3.0",
+ "datafusion-functions-aggregate-common 50.3.0",
+ "datafusion-functions-window-common 50.3.0",
+ "datafusion-physical-expr 50.3.0",
+ "datafusion-physical-expr-common 50.3.0",
+ "futures",
+ "half 2.7.1",
+ "hashbrown 0.14.5",
+ "indexmap 2.13.0",
+ "itertools 0.14.0",
+ "log",
+ "parking_lot 0.12.5",
+ "pin-project-lite",
+ "tokio",
 ]
 
 [[package]]
@@ -4274,15 +4904,15 @@ dependencies = [
  "arrow-ord 58.1.0",
  "arrow-schema 58.1.0",
  "async-trait",
- "datafusion-common",
- "datafusion-common-runtime",
- "datafusion-execution",
- "datafusion-expr",
- "datafusion-functions",
- "datafusion-functions-aggregate-common",
- "datafusion-functions-window-common",
- "datafusion-physical-expr",
- "datafusion-physical-expr-common",
+ "datafusion-common 53.0.0",
+ "datafusion-common-runtime 53.0.0",
+ "datafusion-execution 53.0.0",
+ "datafusion-expr 53.0.0",
+ "datafusion-functions 53.0.0",
+ "datafusion-functions-aggregate-common 53.0.0",
+ "datafusion-functions-window-common 53.0.0",
+ "datafusion-physical-expr 53.0.0",
+ "datafusion-physical-expr-common 53.0.0",
  "futures",
  "half 2.7.1",
  "hashbrown 0.16.1",
@@ -4297,19 +4927,61 @@ dependencies = [
 
 [[package]]
 name = "datafusion-pruning"
+version = "50.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd1e59e2ca14fe3c30f141600b10ad8815e2856caa59ebbd0e3e07cd3d127a65"
+dependencies = [
+ "arrow 56.2.0",
+ "arrow-schema 56.2.0",
+ "datafusion-common 50.3.0",
+ "datafusion-datasource 50.3.0",
+ "datafusion-expr-common 50.3.0",
+ "datafusion-physical-expr 50.3.0",
+ "datafusion-physical-expr-common 50.3.0",
+ "datafusion-physical-plan 50.3.0",
+ "itertools 0.14.0",
+ "log",
+]
+
+[[package]]
+name = "datafusion-pruning"
 version = "53.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2857618a0ecbd8cd0cf29826889edd3a25774ec26b2995fc3862095c95d88fc6"
 dependencies = [
  "arrow 58.1.0",
- "datafusion-common",
- "datafusion-datasource",
- "datafusion-expr-common",
- "datafusion-physical-expr",
- "datafusion-physical-expr-common",
- "datafusion-physical-plan",
+ "datafusion-common 53.0.0",
+ "datafusion-datasource 53.0.0",
+ "datafusion-expr-common 53.0.0",
+ "datafusion-physical-expr 53.0.0",
+ "datafusion-physical-expr-common 53.0.0",
+ "datafusion-physical-plan 53.0.0",
  "itertools 0.14.0",
  "log",
+]
+
+[[package]]
+name = "datafusion-session"
+version = "50.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21ef8e2745583619bd7a49474e8f45fbe98ebb31a133f27802217125a7b3d58d"
+dependencies = [
+ "arrow 56.2.0",
+ "async-trait",
+ "dashmap",
+ "datafusion-common 50.3.0",
+ "datafusion-common-runtime 50.3.0",
+ "datafusion-execution 50.3.0",
+ "datafusion-expr 50.3.0",
+ "datafusion-physical-expr 50.3.0",
+ "datafusion-physical-plan 50.3.0",
+ "datafusion-sql 50.3.0",
+ "futures",
+ "itertools 0.14.0",
+ "log",
+ "object_store 0.12.5",
+ "parking_lot 0.12.5",
+ "tokio",
 ]
 
 [[package]]
@@ -4319,11 +4991,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef8637e35022c5c775003b3ab1debc6b4a8f0eb41b069bdd5475dd3aa93f6eba"
 dependencies = [
  "async-trait",
- "datafusion-common",
- "datafusion-execution",
- "datafusion-expr",
- "datafusion-physical-plan",
+ "datafusion-common 53.0.0",
+ "datafusion-execution 53.0.0",
+ "datafusion-expr 53.0.0",
+ "datafusion-physical-plan 53.0.0",
  "parking_lot 0.12.5",
+]
+
+[[package]]
+name = "datafusion-sql"
+version = "50.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89abd9868770386fede29e5a4b14f49c0bf48d652c3b9d7a8a0332329b87d50b"
+dependencies = [
+ "arrow 56.2.0",
+ "bigdecimal 0.4.10",
+ "datafusion-common 50.3.0",
+ "datafusion-expr 50.3.0",
+ "indexmap 2.13.0",
+ "log",
+ "regex",
+ "sqlparser 0.58.0",
 ]
 
 [[package]]
@@ -4335,14 +5023,14 @@ dependencies = [
  "arrow 58.1.0",
  "bigdecimal 0.4.10",
  "chrono",
- "datafusion-common",
- "datafusion-expr",
- "datafusion-functions-nested",
+ "datafusion-common 53.0.0",
+ "datafusion-expr 53.0.0",
+ "datafusion-functions-nested 53.0.0",
  "indexmap 2.13.0",
  "log",
  "recursive",
  "regex",
- "sqlparser",
+ "sqlparser 0.61.0",
 ]
 
 [[package]]
@@ -4370,6 +5058,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef552e6f588e446098f6ba40d89ac146c8c7b64aade83c051ee00bb5d2bc18d"
 dependencies = [
  "uuid",
+]
+
+[[package]]
+name = "deepsize"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cdb987ec36f6bf7bfbea3f928b75590b736fc42af8e54d97592481351b2b96c"
+dependencies = [
+ "deepsize_derive",
+]
+
+[[package]]
+name = "deepsize_derive"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990101d41f3bc8c1a45641024377ee284ecc338e5ecf3ea0f0e236d897c72796"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -4410,7 +5118,7 @@ dependencies = [
  "chrono",
  "deltalake-core",
  "futures",
- "object_store",
+ "object_store 0.13.2",
  "regex",
  "thiserror 2.0.17",
  "tokio",
@@ -4432,7 +5140,7 @@ dependencies = [
  "arrow-buffer 58.1.0",
  "arrow-cast 58.1.0",
  "arrow-ipc 58.1.0",
- "arrow-json",
+ "arrow-json 58.1.0",
  "arrow-ord 58.1.0",
  "arrow-row 58.1.0",
  "arrow-schema 58.1.0",
@@ -4451,7 +5159,7 @@ dependencies = [
  "indexmap 2.13.0",
  "itertools 0.14.0",
  "num_cpus",
- "object_store",
+ "object_store 0.13.2",
  "parking_lot 0.12.5",
  "parquet",
  "percent-encoding",
@@ -4461,7 +5169,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
- "sqlparser",
+ "sqlparser 0.61.0",
  "strum 0.27.2",
  "thiserror 2.0.17",
  "tokio",
@@ -4494,7 +5202,7 @@ dependencies = [
  "bytes",
  "deltalake-core",
  "futures",
- "object_store",
+ "object_store 0.13.2",
  "thiserror 2.0.17",
  "tokio",
  "tracing",
@@ -4530,7 +5238,7 @@ checksum = "07da5016415d5a3c4dd39b11ed26f915f52fc4e0dc197d87908bc916e51bc1a6"
 dependencies = [
  "asn1-rs",
  "displaydoc",
- "nom",
+ "nom 7.1.3",
  "num-bigint",
  "num-traits",
  "rusticata-macros",
@@ -5215,9 +5923,9 @@ dependencies = [
 
 [[package]]
 name = "ethnum"
-version = "1.5.0"
+version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b90ca2580b73ab6a1f724b76ca11ab632df820fd6040c336200d2c1df7b3c82c"
+checksum = "40404c3f5f511ec4da6fe866ddf6a717c309fdbb69fbbad7b0f3edab8f2e835f"
 dependencies = [
  "serde",
 ]
@@ -5256,7 +5964,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74fef4569247a5f429d9156b9d0a2599914385dd189c539334c625d8099d90ab"
 dependencies = [
  "futures-core",
- "nom",
+ "nom 7.1.3",
  "pin-project-lite",
 ]
 
@@ -5321,6 +6029,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fast-float2"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8eb564c5c7423d25c886fb561d1e4ee69f72354d16918afa32c08811f6b6a55"
+
+[[package]]
 name = "fastant"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5329,6 +6043,12 @@ dependencies = [
  "small_ctor",
  "web-time",
 ]
+
+[[package]]
+name = "fastdivide"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afc2bd4d5a73106dd53d10d73d3401c2f32730ba2c0b93ddb888a8983680471"
 
 [[package]]
 name = "fastnum"
@@ -5659,7 +6379,7 @@ dependencies = [
  "flume",
  "foyer-common",
  "foyer-memory",
- "fs4",
+ "fs4 0.13.1",
  "futures-core",
  "futures-util",
  "hashbrown 0.16.1",
@@ -5717,6 +6437,16 @@ dependencies = [
 
 [[package]]
 name = "fs4"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7e180ac76c23b45e767bd7ae9579bc0bb458618c4bc71835926e098e61d15f8"
+dependencies = [
+ "rustix 0.38.41",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "fs4"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8640e34b88f7652208ce9e88b1a37a2ae95227d84abec377ccd3c5cfeb141ed4"
@@ -5738,6 +6468,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "fsst"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d2475ce218217196b161b025598f77e2b405d5e729f7c37bfff145f5df00a41"
+dependencies = [
+ "arrow-array 56.2.0",
+ "rand 0.9.2",
+]
+
+[[package]]
+name = "fst"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ab85b9b05e3978cc9a9cf8fea7f01b494e1a09ed3037e16ba39edc7a29eb61a"
+dependencies = [
+ "utf8-ranges",
 ]
 
 [[package]]
@@ -6428,7 +7177,7 @@ dependencies = [
  "base64 0.13.1",
  "byteorder",
  "flate2",
- "nom",
+ "nom 7.1.3",
  "num-traits",
 ]
 
@@ -6563,6 +7312,12 @@ dependencies = [
  "libc",
  "windows-link 0.1.1",
 ]
+
+[[package]]
+name = "htmlescape"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9025058dae765dee5070ec375f591e2ba14638c63feff74f13805a72e523163"
 
 [[package]]
 name = "http"
@@ -6796,6 +7551,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyperloglogplus"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "621debdf94dcac33e50475fdd76d34d5ea9c0362a834b9db08c3024696c1fbe3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "hytra"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6868,13 +7632,13 @@ dependencies = [
  "moka",
  "murmur3",
  "once_cell",
- "opendal",
+ "opendal 0.55.0",
  "ordered-float 4.1.1",
  "parquet",
  "rand 0.8.5",
  "reqsign",
  "reqwest 0.12.25",
- "roaring",
+ "roaring 0.11.2",
  "serde",
  "serde_bytes",
  "serde_derive",
@@ -6937,7 +7701,7 @@ dependencies = [
  "async-trait",
  "backon",
  "ctor 0.2.9",
- "datafusion",
+ "datafusion 53.0.0",
  "derive_builder",
  "futures",
  "iceberg",
@@ -6965,7 +7729,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "dashmap",
- "datafusion",
+ "datafusion 53.0.0",
  "futures",
  "iceberg",
  "parquet",
@@ -7116,7 +7880,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2628910d0114e9139056161d8644a2026be7b117f8498943f9437748b04c9e0a"
 dependencies = [
  "bitflags 2.11.1",
- "crossterm",
+ "crossterm 0.29.0",
  "dyn-clone",
  "fuzzy-matcher",
  "unicode-segmentation",
@@ -7403,6 +8167,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "jsonb"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb98fb29636087c40ad0d1274d9a30c0c1e83e03ae93f6e7e89247b37fcc6953"
+dependencies = [
+ "byteorder",
+ "ethnum",
+ "fast-float2",
+ "itoa",
+ "jiff 0.2.22",
+ "nom 8.0.0",
+ "num-traits",
+ "ordered-float 5.3.0",
+ "rand 0.9.2",
+ "serde",
+ "serde_json",
+ "zmij",
+]
+
+[[package]]
 name = "jsonbb"
 version = "0.2.3"
 source = "git+https://github.com/risingwavelabs/jsonbb.git?rev=f618cd8c9bc517f35dec192d4e7553650894a011#f618cd8c9bc517f35dec192d4e7553650894a011"
@@ -7509,6 +8293,546 @@ dependencies = [
 ]
 
 [[package]]
+name = "lance"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2f0ca022d0424d991933a62d2898864cf5621873962bd84e65e7d1f023f9c36"
+dependencies = [
+ "arrow 56.2.0",
+ "arrow-arith 56.2.0",
+ "arrow-array 56.2.0",
+ "arrow-buffer 56.2.0",
+ "arrow-ipc 56.2.0",
+ "arrow-ord 56.2.0",
+ "arrow-row 56.2.0",
+ "arrow-schema 56.2.0",
+ "arrow-select 56.2.0",
+ "async-recursion",
+ "async-trait",
+ "async_cell",
+ "aws-credential-types",
+ "byteorder",
+ "bytes",
+ "chrono",
+ "dashmap",
+ "datafusion 50.3.0",
+ "datafusion-expr 50.3.0",
+ "datafusion-functions 50.3.0",
+ "datafusion-physical-expr 50.3.0",
+ "datafusion-physical-plan 50.3.0",
+ "deepsize",
+ "either",
+ "futures",
+ "half 2.7.1",
+ "humantime",
+ "itertools 0.13.0",
+ "lance-arrow",
+ "lance-core",
+ "lance-datafusion",
+ "lance-encoding",
+ "lance-file",
+ "lance-index",
+ "lance-io",
+ "lance-linalg",
+ "lance-namespace",
+ "lance-table",
+ "log",
+ "moka",
+ "object_store 0.12.5",
+ "permutation",
+ "pin-project",
+ "prost 0.13.5",
+ "prost-types 0.13.5",
+ "rand 0.9.2",
+ "roaring 0.10.12",
+ "semver",
+ "serde",
+ "serde_json",
+ "snafu",
+ "tantivy",
+ "tokio",
+ "tokio-stream 0.1.17",
+ "tracing",
+ "url",
+ "uuid",
+]
+
+[[package]]
+name = "lance-arrow"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7552f8d528775bf0ab21e1f75dcb70bdb2a828eeae58024a803b5a4655fd9a11"
+dependencies = [
+ "arrow-array 56.2.0",
+ "arrow-buffer 56.2.0",
+ "arrow-cast 56.2.0",
+ "arrow-data 56.2.0",
+ "arrow-schema 56.2.0",
+ "arrow-select 56.2.0",
+ "bytes",
+ "getrandom 0.2.11",
+ "half 2.7.1",
+ "jsonb",
+ "num-traits",
+ "rand 0.9.2",
+]
+
+[[package]]
+name = "lance-bitpacking"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2ea14583cc6fa0bb190bcc2d3bc364b0aa545b345702976025f810e4740e8ce"
+dependencies = [
+ "arrayref",
+ "paste",
+ "seq-macro",
+]
+
+[[package]]
+name = "lance-core"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69c752dedd207384892006c40930f898d6634e05e3d489e89763abfe4b9307e7"
+dependencies = [
+ "arrow-array 56.2.0",
+ "arrow-buffer 56.2.0",
+ "arrow-schema 56.2.0",
+ "async-trait",
+ "byteorder",
+ "bytes",
+ "chrono",
+ "datafusion-common 50.3.0",
+ "datafusion-sql 50.3.0",
+ "deepsize",
+ "futures",
+ "lance-arrow",
+ "libc",
+ "log",
+ "mock_instant",
+ "moka",
+ "num_cpus",
+ "object_store 0.12.5",
+ "pin-project",
+ "prost 0.13.5",
+ "rand 0.9.2",
+ "roaring 0.10.12",
+ "serde_json",
+ "snafu",
+ "tempfile",
+ "tokio",
+ "tokio-stream 0.1.17",
+ "tokio-util",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "lance-datafusion"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21e1e98ca6e5cd337bdda2d9fb66063f295c0c2852d2bc6831366fea833ee608"
+dependencies = [
+ "arrow 56.2.0",
+ "arrow-array 56.2.0",
+ "arrow-buffer 56.2.0",
+ "arrow-ord 56.2.0",
+ "arrow-schema 56.2.0",
+ "arrow-select 56.2.0",
+ "async-trait",
+ "chrono",
+ "datafusion 50.3.0",
+ "datafusion-common 50.3.0",
+ "datafusion-functions 50.3.0",
+ "datafusion-physical-expr 50.3.0",
+ "futures",
+ "jsonb",
+ "lance-arrow",
+ "lance-core",
+ "lance-datagen",
+ "log",
+ "pin-project",
+ "prost 0.13.5",
+ "snafu",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "lance-datagen"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "483c643fc2806ed1a2766edf4d180511bbd1d549bcc60373e33f4785c6185891"
+dependencies = [
+ "arrow 56.2.0",
+ "arrow-array 56.2.0",
+ "arrow-cast 56.2.0",
+ "arrow-schema 56.2.0",
+ "chrono",
+ "futures",
+ "half 2.7.1",
+ "hex",
+ "rand 0.9.2",
+ "rand_xoshiro 0.7.0",
+ "random_word",
+]
+
+[[package]]
+name = "lance-encoding"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a199d1fa3487529c5ffc433fbd1721231330b9350c2ff9b0c7b7dbdb98f0806a"
+dependencies = [
+ "arrow-arith 56.2.0",
+ "arrow-array 56.2.0",
+ "arrow-buffer 56.2.0",
+ "arrow-cast 56.2.0",
+ "arrow-data 56.2.0",
+ "arrow-schema 56.2.0",
+ "arrow-select 56.2.0",
+ "bytemuck",
+ "byteorder",
+ "bytes",
+ "fsst",
+ "futures",
+ "hex",
+ "hyperloglogplus",
+ "itertools 0.13.0",
+ "lance-arrow",
+ "lance-bitpacking",
+ "lance-core",
+ "log",
+ "lz4",
+ "num-traits",
+ "prost 0.13.5",
+ "prost-build 0.13.5",
+ "prost-types 0.13.5",
+ "rand 0.9.2",
+ "snafu",
+ "strum 0.26.3",
+ "tokio",
+ "tracing",
+ "xxhash-rust",
+ "zstd",
+]
+
+[[package]]
+name = "lance-file"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b57def2279465232cf5a8cd996300c632442e368745768bbed661c7f0a35334b"
+dependencies = [
+ "arrow-arith 56.2.0",
+ "arrow-array 56.2.0",
+ "arrow-buffer 56.2.0",
+ "arrow-data 56.2.0",
+ "arrow-schema 56.2.0",
+ "arrow-select 56.2.0",
+ "async-recursion",
+ "async-trait",
+ "byteorder",
+ "bytes",
+ "datafusion-common 50.3.0",
+ "deepsize",
+ "futures",
+ "lance-arrow",
+ "lance-core",
+ "lance-encoding",
+ "lance-io",
+ "log",
+ "num-traits",
+ "object_store 0.12.5",
+ "prost 0.13.5",
+ "prost-build 0.13.5",
+ "prost-types 0.13.5",
+ "snafu",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "lance-index"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75938c61e986aef8c615dc44c92e4c19e393160a59e2b57402ccfe08c5e63af"
+dependencies = [
+ "arrow 56.2.0",
+ "arrow-arith 56.2.0",
+ "arrow-array 56.2.0",
+ "arrow-ord 56.2.0",
+ "arrow-schema 56.2.0",
+ "arrow-select 56.2.0",
+ "async-channel 2.5.0",
+ "async-recursion",
+ "async-trait",
+ "bitpacking",
+ "bitvec",
+ "bytes",
+ "crossbeam-queue",
+ "datafusion 50.3.0",
+ "datafusion-common 50.3.0",
+ "datafusion-expr 50.3.0",
+ "datafusion-physical-expr 50.3.0",
+ "datafusion-sql 50.3.0",
+ "deepsize",
+ "dirs 6.0.0",
+ "fst",
+ "futures",
+ "half 2.7.1",
+ "itertools 0.13.0",
+ "jsonb",
+ "lance-arrow",
+ "lance-core",
+ "lance-datafusion",
+ "lance-datagen",
+ "lance-encoding",
+ "lance-file",
+ "lance-io",
+ "lance-linalg",
+ "lance-table",
+ "libm",
+ "log",
+ "ndarray",
+ "num-traits",
+ "object_store 0.12.5",
+ "prost 0.13.5",
+ "prost-build 0.13.5",
+ "prost-types 0.13.5",
+ "rand 0.9.2",
+ "rand_distr 0.5.1",
+ "rayon",
+ "roaring 0.10.12",
+ "serde",
+ "serde_json",
+ "snafu",
+ "tantivy",
+ "tempfile",
+ "tokio",
+ "tracing",
+ "twox-hash",
+ "uuid",
+]
+
+[[package]]
+name = "lance-io"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa6c3b5b28570d6c951206c5b043f1b35c936928af14fca6f2ac25b0097e4c32"
+dependencies = [
+ "arrow 56.2.0",
+ "arrow-arith 56.2.0",
+ "arrow-array 56.2.0",
+ "arrow-buffer 56.2.0",
+ "arrow-cast 56.2.0",
+ "arrow-data 56.2.0",
+ "arrow-schema 56.2.0",
+ "arrow-select 56.2.0",
+ "async-recursion",
+ "async-trait",
+ "aws-config",
+ "aws-credential-types",
+ "byteorder",
+ "bytes",
+ "chrono",
+ "deepsize",
+ "futures",
+ "lance-arrow",
+ "lance-core",
+ "lance-namespace",
+ "log",
+ "object_store 0.12.5",
+ "object_store_opendal",
+ "opendal 0.54.1",
+ "path_abs",
+ "pin-project",
+ "prost 0.13.5",
+ "rand 0.9.2",
+ "serde",
+ "shellexpand",
+ "snafu",
+ "tokio",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "lance-linalg"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3cbc7e85a89ff9cb3a4627559dea3fd1c1fb16c0d8bc46ede75eefef51eec06"
+dependencies = [
+ "arrow-array 56.2.0",
+ "arrow-buffer 56.2.0",
+ "arrow-schema 56.2.0",
+ "cc",
+ "deepsize",
+ "half 2.7.1",
+ "lance-arrow",
+ "lance-core",
+ "num-traits",
+ "rand 0.9.2",
+]
+
+[[package]]
+name = "lance-namespace"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "897dd6726816515bb70a698ce7cda44670dca5761637696d7905b45f405a8cd9"
+dependencies = [
+ "arrow 56.2.0",
+ "async-trait",
+ "bytes",
+ "lance-core",
+ "lance-namespace-reqwest-client",
+ "snafu",
+]
+
+[[package]]
+name = "lance-namespace-impls"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e3cfcd3ba369de2719abf6fb6233f69cda639eb5cbcb328487a790e745ab988"
+dependencies = [
+ "arrow 56.2.0",
+ "arrow-ipc 56.2.0",
+ "arrow-schema 56.2.0",
+ "async-trait",
+ "bytes",
+ "lance",
+ "lance-core",
+ "lance-io",
+ "lance-namespace",
+ "object_store 0.12.5",
+ "reqwest 0.12.25",
+ "serde_json",
+ "snafu",
+ "url",
+]
+
+[[package]]
+name = "lance-namespace-reqwest-client"
+version = "0.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ea349999bcda4eea53fc05d334b3775ec314761e6a706555c777d7a29b18d19"
+dependencies = [
+ "reqwest 0.12.25",
+ "serde",
+ "serde_json",
+ "serde_repr",
+ "url",
+]
+
+[[package]]
+name = "lance-table"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8facc13760ba034b6c38767b16adba85e44cbcbea8124dc0c63c43865c60630"
+dependencies = [
+ "arrow 56.2.0",
+ "arrow-array 56.2.0",
+ "arrow-buffer 56.2.0",
+ "arrow-ipc 56.2.0",
+ "arrow-schema 56.2.0",
+ "async-trait",
+ "byteorder",
+ "bytes",
+ "chrono",
+ "deepsize",
+ "futures",
+ "lance-arrow",
+ "lance-core",
+ "lance-file",
+ "lance-io",
+ "log",
+ "object_store 0.12.5",
+ "prost 0.13.5",
+ "prost-build 0.13.5",
+ "prost-types 0.13.5",
+ "rand 0.9.2",
+ "rangemap",
+ "roaring 0.10.12",
+ "semver",
+ "serde",
+ "serde_json",
+ "snafu",
+ "tokio",
+ "tracing",
+ "url",
+ "uuid",
+]
+
+[[package]]
+name = "lance-testing"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b05052ef86188d6ae6339bdd9f2c5d77190e8ad1158f3dc8a42fa91bde9e5246"
+dependencies = [
+ "arrow-array 56.2.0",
+ "arrow-schema 56.2.0",
+ "lance-arrow",
+ "num-traits",
+ "rand 0.9.2",
+]
+
+[[package]]
+name = "lancedb"
+version = "0.22.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1da241266792d8caa58005a3deb06ba1388a99350d89b5c904ef6f8de5d936f"
+dependencies = [
+ "ahash 0.8.11",
+ "arrow 56.2.0",
+ "arrow-array 56.2.0",
+ "arrow-cast 56.2.0",
+ "arrow-data 56.2.0",
+ "arrow-ipc 56.2.0",
+ "arrow-ord 56.2.0",
+ "arrow-schema 56.2.0",
+ "arrow-select 56.2.0",
+ "async-trait",
+ "bytes",
+ "chrono",
+ "datafusion 50.3.0",
+ "datafusion-catalog 50.3.0",
+ "datafusion-common 50.3.0",
+ "datafusion-execution 50.3.0",
+ "datafusion-expr 50.3.0",
+ "datafusion-physical-plan 50.3.0",
+ "futures",
+ "half 2.7.1",
+ "lance",
+ "lance-arrow",
+ "lance-core",
+ "lance-datafusion",
+ "lance-datagen",
+ "lance-encoding",
+ "lance-file",
+ "lance-index",
+ "lance-io",
+ "lance-linalg",
+ "lance-namespace",
+ "lance-namespace-impls",
+ "lance-table",
+ "lance-testing",
+ "lazy_static",
+ "log",
+ "moka",
+ "num-traits",
+ "object_store 0.12.5",
+ "pin-project",
+ "rand 0.9.2",
+ "regex",
+ "semver",
+ "serde",
+ "serde_json",
+ "serde_with",
+ "snafu",
+ "tempfile",
+ "tokio",
+ "url",
+ "uuid",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7524,7 +8848,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cbcf559624bfd9fe8d488329a8959766335a43a9b8b2cdd6a2c379fca02909a5"
 dependencies = [
  "bytes",
- "nom",
+ "nom 7.1.3",
 ]
 
 [[package]]
@@ -7539,7 +8863,7 @@ dependencies = [
  "futures-util",
  "lber",
  "log",
- "nom",
+ "nom 7.1.3",
  "percent-encoding",
  "rustls 0.23.35",
  "rustls-native-certs 0.8.1",
@@ -7563,6 +8887,12 @@ name = "leb128fmt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
+name = "levenshtein_automata"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c2cdeb66e45e9f36bfad5bbdb4d2384e70936afbee843c6f6543f0c551ebb25"
 
 [[package]]
 name = "lexical-core"
@@ -7682,9 +9012,9 @@ dependencies = [
 
 [[package]]
 name = "libm"
-version = "0.2.7"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7012b1bbb0719e1097c47611d3898568c546d597c2e74d66f6087edd5233ff4"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libredox"
@@ -7905,6 +9235,9 @@ name = "lz4_flex"
 version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "373f5eceeeab7925e0c1098212f2fbc4d416adec9d35051a6ab251e824c1854a"
+dependencies = [
+ "twox-hash",
+]
 
 [[package]]
 name = "lz4_flex"
@@ -7998,7 +9331,7 @@ dependencies = [
  "naive-timer",
  "panic-message",
  "rand 0.8.5",
- "rand_xoshiro",
+ "rand_xoshiro 0.6.0",
  "rustversion",
  "serde",
  "spin 0.9.8",
@@ -8150,6 +9483,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
+name = "matrixmultiply"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06de3016e9fae57a36fd14dba131fccf49f74b40b7fbdb472f96e361ec71a08"
+dependencies = [
+ "autocfg",
+ "num_cpus",
+ "once_cell",
+ "rawpointer",
+ "thread-tree",
+]
+
+[[package]]
 name = "maybe-owned"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8163,6 +9509,15 @@ checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
 dependencies = [
  "cfg-if",
  "digest 0.10.7",
+]
+
+[[package]]
+name = "measure_time"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51c55d61e72fc3ab704396c5fa16f4c184db37978ae4e94ca8959693a235fc0e"
+dependencies = [
+ "log",
 ]
 
 [[package]]
@@ -8197,6 +9552,15 @@ name = "memmap2"
 version = "0.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83faa42c0a078c393f6b29d5db232d8be22776a891f8f56e5284faee4a20b327"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "memmap2"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
 dependencies = [
  "libc",
 ]
@@ -8303,6 +9667,12 @@ dependencies = [
  "parking_lot 0.12.5",
  "prometheus",
 ]
+
+[[package]]
+name = "mock_instant"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dce6dd36094cac388f119d2e9dc82dc730ef91c32a6222170d630e5414b956e6"
 
 [[package]]
 name = "mockall"
@@ -8451,6 +9821,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9252111cf132ba0929b6f8e030cac2a24b507f3a4d6db6fb2896f27b354c714b"
 
 [[package]]
+name = "murmurhash32"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2195bf6aa996a481483b29d62a7663eed3fe39600c460e323f8ff41e90bdd89b"
+
+[[package]]
 name = "mysql-common-derive"
 version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8560,6 +9936,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "ndarray"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "882ed72dce9365842bf196bdeedf5055305f11fc8c03dee7bb0194a6cad34841"
+dependencies = [
+ "matrixmultiply",
+ "num-complex",
+ "num-integer",
+ "num-traits",
+ "portable-atomic",
+ "portable-atomic-util",
+ "rawpointer",
+]
+
+[[package]]
 name = "nexmark"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8617,6 +10008,15 @@ checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
  "memchr",
  "minimal-lexical",
+]
+
+[[package]]
+name = "nom"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -8901,6 +10301,44 @@ dependencies = [
 
 [[package]]
 name = "object_store"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbfbfff40aeccab00ec8a910b57ca8ecf4319b335c542f2edcd19dd25a1e2a00"
+dependencies = [
+ "async-trait",
+ "base64 0.22.1",
+ "bytes",
+ "chrono",
+ "form_urlencoded",
+ "futures",
+ "http 1.4.0",
+ "http-body-util",
+ "httparse",
+ "humantime",
+ "hyper 1.10.0",
+ "itertools 0.14.0",
+ "md-5",
+ "parking_lot 0.12.5",
+ "percent-encoding",
+ "quick-xml 0.38.4",
+ "rand 0.9.2",
+ "reqwest 0.12.25",
+ "ring",
+ "rustls-pemfile 2.2.0",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "thiserror 2.0.17",
+ "tokio",
+ "tracing",
+ "url",
+ "walkdir",
+ "wasm-bindgen-futures",
+ "web-time",
+]
+
+[[package]]
+name = "object_store"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "622acbc9100d3c10e2ee15804b0caa40e55c933d5aa53814cd520805b7958a49"
@@ -8940,6 +10378,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "object_store_opendal"
+version = "0.54.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0b88fc0e0c4890c1d99e2b8c519c5db40f7d9b69a0f562ff1ad4967a4c8bbc6"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures",
+ "object_store 0.12.5",
+ "opendal 0.54.1",
+ "pin-project",
+ "tokio",
+]
+
+[[package]]
 name = "oid-registry"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8959,6 +10412,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "oneshot"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "269bca4c2591a28585d6bf10d9ed0332b7d76900a1b02bec41bdc3a2cdcda107"
+
+[[package]]
 name = "oorandom"
 version = "11.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8975,6 +10434,35 @@ dependencies = [
  "serde_json",
  "tracing",
  "tracing-subscriber",
+]
+
+[[package]]
+name = "opendal"
+version = "0.54.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42afda58fa2cf50914402d132cc1caacff116a85d10c72ab2082bb7c50021754"
+dependencies = [
+ "anyhow",
+ "backon",
+ "base64 0.22.1",
+ "bytes",
+ "chrono",
+ "crc32c",
+ "futures",
+ "getrandom 0.2.11",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "log",
+ "md-5",
+ "percent-encoding",
+ "quick-xml 0.38.4",
+ "reqsign",
+ "reqwest 0.12.25",
+ "serde",
+ "serde_json",
+ "sha2 0.10.9",
+ "tokio",
+ "uuid",
 ]
 
 [[package]]
@@ -9227,6 +10715,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ordered-float"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7d950ca161dc355eaf28f82b11345ed76c6e1f6eb1f4f4479e0323b9e2fbd0e"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "ordered-multimap"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9297,6 +10794,15 @@ name = "outref"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4030760ffd992bef45b0ae3f10ce1aba99e33464c90d14dd7c039884963ddc7a"
+
+[[package]]
+name = "ownedbytes"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fbd56f7631767e61784dc43f8580f403f4475bd4aaa4da003e6295e1bab4a7e"
+dependencies = [
+ "stable_deref_trait",
+]
 
 [[package]]
 name = "owo-colors"
@@ -9436,7 +10942,7 @@ dependencies = [
  "num-bigint",
  "num-integer",
  "num-traits",
- "object_store",
+ "object_store 0.13.2",
  "paste",
  "seq-macro",
  "simdutf8",
@@ -9507,6 +11013,18 @@ name = "path-slash"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e91099d4268b0e11973f036e885d652fb0b21fedcf69738c627f94db6a44f42"
+
+[[package]]
+name = "path_abs"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05ef02f6342ac01d8a93b65f96db53fe68a92a15f41144f97fb00a9e669633c3"
+dependencies = [
+ "serde",
+ "serde_derive",
+ "std_prelude",
+ "stfu8",
+]
 
 [[package]]
 name = "pbjson"
@@ -9582,6 +11100,12 @@ name = "percent-encoding-rfc3986"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3637c05577168127568a64e9dc5a6887da720efef07b3d9472d45f63ab191166"
+
+[[package]]
+name = "permutation"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df202b0b0f5b8e389955afd5f27b007b00fb948162953f1db9c70d2c7e3157d7"
 
 [[package]]
 name = "petgraph"
@@ -10560,7 +12084,7 @@ dependencies = [
  "lz4",
  "murmur3",
  "native-tls",
- "nom",
+ "nom 7.1.3",
  "oauth2",
  "openidconnect",
  "pem",
@@ -10870,6 +12394,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
+name = "rand_distr"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32cb0b9bc82b0a0876c2dd994a7e7a2683d3e7390ca40e6886785ef0c7e3ee31"
+dependencies = [
+ "num-traits",
+ "rand 0.8.5",
+]
+
+[[package]]
+name = "rand_distr"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8615d50dcf34fa31f7ab52692afec947c4dd0ab803cc87cb3b0b4570ff7463"
+dependencies = [
+ "num-traits",
+ "rand 0.9.2",
+]
+
+[[package]]
 name = "rand_xoshiro"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10879,10 +12423,44 @@ dependencies = [
 ]
 
 [[package]]
-name = "rayon"
-version = "1.7.0"
+name = "rand_xoshiro"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d2df5196e37bcc87abebc0053e20787d73847bb33134a69841207dd0a47f03b"
+checksum = "f703f4665700daf5512dcca5f43afa6af89f09db47fb56be587f80636bda2d41"
+dependencies = [
+ "rand_core 0.9.0",
+]
+
+[[package]]
+name = "random_word"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e47a395bdb55442b883c89062d6bcff25dc90fa5f8369af81e0ac6d49d78cf81"
+dependencies = [
+ "ahash 0.8.11",
+ "brotli",
+ "paste",
+ "rand 0.9.2",
+ "unicase",
+]
+
+[[package]]
+name = "rangemap"
+version = "1.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "973443cf09a9c8656b574a866ab68dfa19f0867d0340648c7d2f6a71b8a8ea68"
+
+[[package]]
+name = "rawpointer"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
+
+[[package]]
+name = "rayon"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
 dependencies = [
  "either",
  "rayon-core",
@@ -10890,14 +12468,12 @@ dependencies = [
 
 [[package]]
 name = "rayon-core"
-version = "1.11.0"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b8f95bd6966f5c87776639160a66bd8ab9895d9d4ab01ddba9fc60661aebe8d"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
 dependencies = [
- "crossbeam-channel",
  "crossbeam-deque",
  "crossbeam-utils",
- "num_cpus",
 ]
 
 [[package]]
@@ -11175,6 +12751,7 @@ dependencies = [
  "js-sys",
  "log",
  "mime",
+ "mime_guess",
  "native-tls",
  "percent-encoding",
  "pin-project-lite",
@@ -11411,7 +12988,7 @@ dependencies = [
  "madsim-tonic",
  "memcomparable",
  "mysql_async",
- "opendal",
+ "opendal 0.55.0",
  "panic-message",
  "parking_lot 0.12.5",
  "parquet",
@@ -11457,7 +13034,7 @@ dependencies = [
  "linkme",
  "madsim-tokio",
  "mysql_async",
- "opendal",
+ "opendal 0.55.0",
  "prometheus",
  "rand 0.9.2",
  "risingwave_batch",
@@ -11973,6 +13550,9 @@ dependencies = [
  "indexmap 2.13.0",
  "itertools 0.14.0",
  "jni",
+ "lance",
+ "lance-table",
+ "lancedb",
  "madsim-rdkafka",
  "madsim-tokio",
  "madsim-tonic",
@@ -11983,7 +13563,7 @@ dependencies = [
  "mysql_common",
  "nexmark",
  "num-bigint",
- "opendal",
+ "opendal 0.55.0",
  "opensearch",
  "openssl",
  "parking_lot 0.12.5",
@@ -12302,8 +13882,8 @@ dependencies = [
  "bytes",
  "chrono",
  "clap",
- "datafusion",
- "datafusion-common",
+ "datafusion 53.0.0",
+ "datafusion-common 53.0.0",
  "downcast-rs 2.0.1",
  "dyn-clone",
  "easy-ext",
@@ -12754,7 +14334,7 @@ dependencies = [
  "madsim",
  "madsim-aws-sdk-s3",
  "madsim-tokio",
- "opendal",
+ "opendal 0.55.0",
  "prometheus",
  "reqwest 0.12.25",
  "risingwave_common",
@@ -13235,6 +14815,16 @@ dependencies = [
 
 [[package]]
 name = "roaring"
+version = "0.10.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19e8d2cfa184d94d0726d650a9f4a1be7f9b76ac9fdb954219878dc00c1c1e7b"
+dependencies = [
+ "bytemuck",
+ "byteorder",
+]
+
+[[package]]
+name = "roaring"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f08d6a905edb32d74a5d5737a0c9d7e950c312f3c46cb0ca0a2ca09ea11878a0"
@@ -13388,6 +14978,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rust-stemmers"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e46a2036019fdb888131db7a4c847a1063a7493f971ed94ea82c67eada63ca54"
+dependencies = [
+ "serde",
+ "serde_derive",
+]
+
+[[package]]
 name = "rust_decimal"
 version = "1.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -13447,7 +15047,7 @@ version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf0c4a6ece9950b9abdb62b1cfcf2a68b3b67a10ba445b3bb85be2a293d0632"
 dependencies = [
- "nom",
+ "nom 7.1.3",
 ]
 
 [[package]]
@@ -14566,6 +16166,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b6709c7b6754dca1311b3c73e79fcce40dd414c782c66d88e8823030093b02b"
 
 [[package]]
+name = "sketches-ddsketch"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c6f73aeb92d671e0cc4dca167e59b2deb6387c375391bc99ee743f326994a2b"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -14612,6 +16221,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8917285742e9f3e1683f0a9c4e6b57960b7314d0b08d30d1ecd426713ee2eee9"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "snafu"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e84b3f4eacbf3a1ce05eac6763b4d629d60cbc94d632e4092c54ade71f1e1a2"
+dependencies = [
+ "snafu-derive",
+]
+
+[[package]]
+name = "snafu-derive"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1c97747dbf44bb1ca44a561ece23508e99cb592e862f22222dcf42f51d1e451"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -14714,7 +16344,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa30c054bdeed860dd36c1e5a467ec4251d925246f7f57b55bfb77decc2e0ed4"
 dependencies = [
  "jsonbb",
- "nom",
+ "nom 7.1.3",
  "regex",
  "serde_json",
  "thiserror 2.0.17",
@@ -14727,7 +16357,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b7b278788e7be4d0d29c0f39497a0eef3fba6bbc8e70d8bf7fde46edeaa9e85"
 dependencies = [
  "itertools 0.11.0",
- "nom",
+ "nom 7.1.3",
  "unicode_categories",
 ]
 
@@ -14758,13 +16388,34 @@ dependencies = [
 
 [[package]]
 name = "sqlparser"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec4b661c54b1e4b603b37873a18c59920e4c51ea8ea2cf527d925424dbd4437c"
+dependencies = [
+ "log",
+ "sqlparser_derive 0.3.0",
+]
+
+[[package]]
+name = "sqlparser"
 version = "0.61.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dbf5ea8d4d7c808e1af1cbabebca9a2abe603bcefc22294c5b95018d53200cb7"
 dependencies = [
  "log",
  "recursive",
- "sqlparser_derive",
+ "sqlparser_derive 0.5.0",
+]
+
+[[package]]
+name = "sqlparser_derive"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da5fc6819faabb412da764b99d3b713bb55083c11e7e0c00144d386cd6a1939c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -15011,6 +16662,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
+name = "std_prelude"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8207e78455ffdf55661170876f88daf85356e4edd54e0a3dbc79586ca1e50cbe"
+
+[[package]]
+name = "stfu8"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e51f1e89f093f99e7432c491c382b88a6860a5adbe6bf02574bf0a08efff1978"
+
+[[package]]
 name = "str_stack"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -15149,7 +16812,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e0e9bc48b3852f36a84f8d0da275d50cb3c2b88b59b9ec35fdd8b7fa239e37d"
 dependencies = [
  "debugid",
- "memmap2",
+ "memmap2 0.5.10",
  "stable_deref_trait",
  "uuid",
 ]
@@ -15310,6 +16973,152 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f764005d11ee5f36500a149ace24e00e3da98b0158b3e2d53a7495660d3f4d60"
 
 [[package]]
+name = "tantivy"
+version = "0.24.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64a966cb0e76e311f09cf18507c9af192f15d34886ee43d7ba7c7e3803660c43"
+dependencies = [
+ "aho-corasick",
+ "arc-swap",
+ "base64 0.22.1",
+ "bitpacking",
+ "bon",
+ "byteorder",
+ "census",
+ "crc32fast",
+ "crossbeam-channel",
+ "downcast-rs 2.0.1",
+ "fastdivide",
+ "fnv",
+ "fs4 0.8.4",
+ "htmlescape",
+ "hyperloglogplus",
+ "itertools 0.14.0",
+ "levenshtein_automata",
+ "log",
+ "lru 0.12.5",
+ "lz4_flex 0.11.6",
+ "measure_time",
+ "memmap2 0.9.10",
+ "once_cell",
+ "oneshot",
+ "rayon",
+ "regex",
+ "rust-stemmers",
+ "rustc-hash 2.1.0",
+ "serde",
+ "serde_json",
+ "sketches-ddsketch",
+ "smallvec",
+ "tantivy-bitpacker",
+ "tantivy-columnar",
+ "tantivy-common",
+ "tantivy-fst",
+ "tantivy-query-grammar",
+ "tantivy-stacker",
+ "tantivy-tokenizer-api",
+ "tempfile",
+ "thiserror 2.0.17",
+ "time",
+ "uuid",
+ "winapi",
+]
+
+[[package]]
+name = "tantivy-bitpacker"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1adc286a39e089ae9938935cd488d7d34f14502544a36607effd2239ff0e2494"
+dependencies = [
+ "bitpacking",
+]
+
+[[package]]
+name = "tantivy-columnar"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6300428e0c104c4f7db6f95b466a6f5c1b9aece094ec57cdd365337908dc7344"
+dependencies = [
+ "downcast-rs 2.0.1",
+ "fastdivide",
+ "itertools 0.14.0",
+ "serde",
+ "tantivy-bitpacker",
+ "tantivy-common",
+ "tantivy-sstable",
+ "tantivy-stacker",
+]
+
+[[package]]
+name = "tantivy-common"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91b6ea6090ce03dc72c27d0619e77185d26cc3b20775966c346c6d4f7e99d7f"
+dependencies = [
+ "async-trait",
+ "byteorder",
+ "ownedbytes",
+ "serde",
+ "time",
+]
+
+[[package]]
+name = "tantivy-fst"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d60769b80ad7953d8a7b2c70cdfe722bbcdcac6bccc8ac934c40c034d866fc18"
+dependencies = [
+ "byteorder",
+ "regex-syntax",
+ "utf8-ranges",
+]
+
+[[package]]
+name = "tantivy-query-grammar"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e810cdeeebca57fc3f7bfec5f85fdbea9031b2ac9b990eb5ff49b371d52bbe6a"
+dependencies = [
+ "nom 7.1.3",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "tantivy-sstable"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "709f22c08a4c90e1b36711c1c6cad5ae21b20b093e535b69b18783dd2cb99416"
+dependencies = [
+ "futures-util",
+ "itertools 0.14.0",
+ "tantivy-bitpacker",
+ "tantivy-common",
+ "tantivy-fst",
+ "zstd",
+]
+
+[[package]]
+name = "tantivy-stacker"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bcdebb267671311d1e8891fd9d1301803fdb8ad21ba22e0a30d0cab49ba59c1"
+dependencies = [
+ "murmurhash32",
+ "rand_distr 0.4.3",
+ "tantivy-common",
+]
+
+[[package]]
+name = "tantivy-tokenizer-api"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dfa942fcee81e213e09715bbce8734ae2180070b97b33839a795ba1de201547d"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "tap"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -15424,6 +17233,15 @@ name = "thousands"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3bf63baf9f5039dadc247375c29eb13706706cfde997d0330d05aa63a77d8820"
+
+[[package]]
+name = "thread-tree"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffbd370cb847953a25954d9f63e14824a36113f8c72eecf6eccef5dc4b45d630"
+dependencies = [
+ "crossbeam-channel",
+]
 
 [[package]]
 name = "thread_local"
@@ -16489,6 +18307,12 @@ name = "utf-8"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
+
+[[package]]
+name = "utf8-ranges"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fcfc827f90e53a02eaef5e535ee14266c1d569214c6aa70133a624d8a3164ba"
 
 [[package]]
 name = "utf8_iter"
@@ -18044,7 +19868,7 @@ dependencies = [
  "data-encoding",
  "der-parser",
  "lazy_static",
- "nom",
+ "nom 7.1.3",
  "oid-registry",
  "rusticata-macros",
  "thiserror 2.0.17",
@@ -18069,9 +19893,9 @@ dependencies = [
 
 [[package]]
 name = "xxhash-rust"
-version = "0.8.7"
+version = "0.8.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9828b178da53440fa9c766a3d2f73f7cf5d0ac1fe3980c1e5018d899fd19e07b"
+checksum = "fdd20c5420375476fbd4394763288da7eb0cc0b8c11deed431a91562af7335d3"
 
 [[package]]
 name = "yaml-rust2"
@@ -18178,6 +20002,12 @@ name = "zlib-rs"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3be3d40e40a133f9c916ee3f9f4fa2d9d63435b5fbe1bfc6d9dae0aa0ada1513"
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
 
 [[package]]
 name = "zstd"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -833,7 +833,7 @@ dependencies = [
  "asn1-rs-derive",
  "asn1-rs-impl",
  "displaydoc",
- "nom",
+ "nom 7.1.3",
  "num-traits",
  "rusticata-macros",
  "thiserror 2.0.17",
@@ -1038,6 +1038,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "async_cell"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "447ab28afbb345f5408b120702a44e5529ebf90b1796ec76e9528df8e288e6c2"
+dependencies = [
+ "loom",
 ]
 
 [[package]]
@@ -2153,6 +2162,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "bitpacking"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96a7139abd3d9cebf8cd6f920a389cf3dc9576172e32f4563f188cae3c3eb019"
+dependencies = [
+ "crunchy",
+]
+
+[[package]]
 name = "bitvec"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2366,7 +2384,7 @@ dependencies = [
  "futures",
  "indexmap 2.14.0",
  "itertools 0.14.0",
- "object_store",
+ "object_store 0.13.2",
  "parquet",
  "rand 0.9.5",
  "reqwest 0.13.4",
@@ -2556,6 +2574,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cedarwood"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d910bedd62c24733263d0bed247460853c9d22e8956bd4cd964302095e04e90"
+dependencies = [
+ "smallvec",
+]
+
+[[package]]
 name = "cesu8"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2567,7 +2594,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
 dependencies = [
- "nom",
+ "nom 7.1.3",
 ]
 
 [[package]]
@@ -2637,7 +2664,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7d8d1efd5109b9c1cd3b7966bd071cdfb53bb6eb0b22a473a68c2f70a11a1eb"
 dependencies = [
  "parse-zoneinfo",
- "phf_codegen",
+ "phf_codegen 0.12.1",
  "phf_shared 0.12.1",
  "uncased",
 ]
@@ -3377,15 +3404,11 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.15"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae211234986c545741a7dc064309f67ee1e5ad243d0e48335adc0484d960bcc7"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
- "autocfg",
- "cfg-if",
  "crossbeam-utils",
- "memoffset",
- "scopeguard",
 ]
 
 [[package]]
@@ -3399,13 +3422,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "crossbeam-utils"
-version = "0.8.16"
+name = "crossbeam-skiplist"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a22b2d63d4d1dc0b7f1b6b2747dd0088008a9be28b6ddf0b1e7d335e3037294"
+checksum = "df29de440c58ca2cc6e587ec3d22347551a32435fbde9d2bff64e78a9ffa151b"
 dependencies = [
- "cfg-if",
+ "crossbeam-epoch",
+ "crossbeam-utils",
 ]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
 
 [[package]]
 name = "crossterm"
@@ -3790,7 +3820,7 @@ dependencies = [
  "itertools 0.14.0",
  "liblzma",
  "log",
- "object_store",
+ "object_store 0.13.2",
  "parking_lot 0.12.5",
  "parquet",
  "rand 0.9.5",
@@ -3845,7 +3875,7 @@ dependencies = [
  "itertools 0.14.0",
  "liblzma",
  "log",
- "object_store",
+ "object_store 0.13.2",
  "parking_lot 0.12.5",
  "parquet",
  "sqlparser 0.62.0",
@@ -3876,7 +3906,7 @@ dependencies = [
  "futures",
  "itertools 0.14.0",
  "log",
- "object_store",
+ "object_store 0.13.2",
  "parking_lot 0.12.5",
  "tokio",
 ]
@@ -3901,7 +3931,7 @@ dependencies = [
  "futures",
  "itertools 0.14.0",
  "log",
- "object_store",
+ "object_store 0.13.2",
  "parking_lot 0.12.5",
  "tokio",
 ]
@@ -3926,7 +3956,7 @@ dependencies = [
  "futures",
  "itertools 0.14.0",
  "log",
- "object_store",
+ "object_store 0.13.2",
 ]
 
 [[package]]
@@ -3949,7 +3979,7 @@ dependencies = [
  "futures",
  "itertools 0.14.0",
  "log",
- "object_store",
+ "object_store 0.13.2",
 ]
 
 [[package]]
@@ -3968,7 +3998,7 @@ dependencies = [
  "itertools 0.14.0",
  "libc",
  "log",
- "object_store",
+ "object_store 0.13.2",
  "parquet",
  "paste",
  "recursive",
@@ -3994,7 +4024,7 @@ dependencies = [
  "itertools 0.14.0",
  "libc",
  "log",
- "object_store",
+ "object_store 0.13.2",
  "parquet",
  "recursive",
  "sqlparser 0.62.0",
@@ -4052,7 +4082,7 @@ dependencies = [
  "itertools 0.14.0",
  "liblzma",
  "log",
- "object_store",
+ "object_store 0.13.2",
  "rand 0.9.5",
  "tokio",
  "tokio-util",
@@ -4087,7 +4117,7 @@ dependencies = [
  "itertools 0.14.0",
  "liblzma",
  "log",
- "object_store",
+ "object_store 0.13.2",
  "parking_lot 0.12.5",
  "rand 0.9.5",
  "tokio",
@@ -4116,7 +4146,7 @@ dependencies = [
  "datafusion-session 53.0.0",
  "futures",
  "itertools 0.14.0",
- "object_store",
+ "object_store 0.13.2",
  "tokio",
 ]
 
@@ -4140,7 +4170,7 @@ dependencies = [
  "datafusion-session 54.1.0",
  "futures",
  "itertools 0.14.0",
- "object_store",
+ "object_store 0.13.2",
  "tokio",
 ]
 
@@ -4162,7 +4192,7 @@ dependencies = [
  "datafusion-physical-plan 53.0.0",
  "datafusion-session 53.0.0",
  "futures",
- "object_store",
+ "object_store 0.13.2",
  "regex",
  "tokio",
 ]
@@ -4185,7 +4215,7 @@ dependencies = [
  "datafusion-physical-plan 54.1.0",
  "datafusion-session 54.1.0",
  "futures",
- "object_store",
+ "object_store 0.13.2",
  "regex",
  "tokio",
 ]
@@ -4208,7 +4238,7 @@ dependencies = [
  "datafusion-physical-plan 53.0.0",
  "datafusion-session 53.0.0",
  "futures",
- "object_store",
+ "object_store 0.13.2",
  "serde_json",
  "tokio",
  "tokio-stream 0.1.17",
@@ -4232,7 +4262,7 @@ dependencies = [
  "datafusion-physical-plan 54.1.0",
  "datafusion-session 54.1.0",
  "futures",
- "object_store",
+ "object_store 0.13.2",
  "tokio",
  "tokio-stream 0.1.17",
 ]
@@ -4261,7 +4291,7 @@ dependencies = [
  "futures",
  "itertools 0.14.0",
  "log",
- "object_store",
+ "object_store 0.13.2",
  "parking_lot 0.12.5",
  "parquet",
  "tokio",
@@ -4292,7 +4322,7 @@ dependencies = [
  "futures",
  "itertools 0.14.0",
  "log",
- "object_store",
+ "object_store 0.13.2",
  "parking_lot 0.12.5",
  "parquet",
  "tokio",
@@ -4326,7 +4356,7 @@ dependencies = [
  "datafusion-physical-expr-common 53.0.0",
  "futures",
  "log",
- "object_store",
+ "object_store 0.13.2",
  "parking_lot 0.12.5",
  "rand 0.9.5",
  "tempfile",
@@ -4348,7 +4378,7 @@ dependencies = [
  "datafusion-physical-expr-common 54.1.0",
  "futures",
  "log",
- "object_store",
+ "object_store 0.13.2",
  "parking_lot 0.12.5",
  "rand 0.9.5",
  "tempfile",
@@ -5097,6 +5127,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "deepsize"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cdb987ec36f6bf7bfbea3f928b75590b736fc42af8e54d97592481351b2b96c"
+dependencies = [
+ "deepsize_derive",
+]
+
+[[package]]
+name = "deepsize_derive"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990101d41f3bc8c1a45641024377ee284ecc338e5ecf3ea0f0e236d897c72796"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "defmt"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5165,7 +5215,7 @@ dependencies = [
  "chrono",
  "deltalake-core",
  "futures",
- "object_store",
+ "object_store 0.13.2",
  "regex",
  "thiserror 2.0.17",
  "tokio",
@@ -5206,7 +5256,7 @@ dependencies = [
  "indexmap 2.14.0",
  "itertools 0.14.0",
  "num_cpus",
- "object_store",
+ "object_store 0.13.2",
  "parking_lot 0.12.5",
  "parquet",
  "percent-encoding",
@@ -5249,7 +5299,7 @@ dependencies = [
  "bytes",
  "deltalake-core",
  "futures",
- "object_store",
+ "object_store 0.13.2",
  "thiserror 2.0.17",
  "tokio",
  "tracing",
@@ -5285,7 +5335,7 @@ checksum = "07da5016415d5a3c4dd39b11ed26f915f52fc4e0dc197d87908bc916e51bc1a6"
 dependencies = [
  "asn1-rs",
  "displaydoc",
- "nom",
+ "nom 7.1.3",
  "num-bigint",
  "num-traits",
  "rusticata-macros",
@@ -5796,12 +5846,85 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
-name = "encoding_rs"
-version = "0.8.33"
+name = "encoding"
+version = "0.2.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7268b386296a025e474d5140678f75d6de9493ae55a5d709eeb9dd08149945e1"
+checksum = "6b0d943856b990d12d3b55b359144ff341533e516d94098b1d3fc1ac666d36ec"
+dependencies = [
+ "encoding-index-japanese",
+ "encoding-index-korean",
+ "encoding-index-simpchinese",
+ "encoding-index-singlebyte",
+ "encoding-index-tradchinese",
+]
+
+[[package]]
+name = "encoding-index-japanese"
+version = "1.20141219.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04e8b2ff42e9a05335dbf8b5c6f7567e5591d0d916ccef4e0b1710d32a0d0c91"
+dependencies = [
+ "encoding_index_tests",
+]
+
+[[package]]
+name = "encoding-index-korean"
+version = "1.20141219.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4dc33fb8e6bcba213fe2f14275f0963fd16f0a02c878e3095ecfdf5bee529d81"
+dependencies = [
+ "encoding_index_tests",
+]
+
+[[package]]
+name = "encoding-index-simpchinese"
+version = "1.20141219.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d87a7194909b9118fc707194baa434a4e3b0fb6a5a757c73c3adb07aa25031f7"
+dependencies = [
+ "encoding_index_tests",
+]
+
+[[package]]
+name = "encoding-index-singlebyte"
+version = "1.20141219.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3351d5acffb224af9ca265f435b859c7c01537c0849754d3db3fdf2bfe2ae84a"
+dependencies = [
+ "encoding_index_tests",
+]
+
+[[package]]
+name = "encoding-index-tradchinese"
+version = "1.20141219.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd0e20d5688ce3cab59eb3ef3a2083a5c77bf496cb798dc6fcdb75f323890c18"
+dependencies = [
+ "encoding_index_tests",
+]
+
+[[package]]
+name = "encoding_index_tests"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a246d82be1c9d791c5dfde9a2bd045fc3cbba3fa2b11ad558f27d01712f00569"
+
+[[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "encoding_rs_io"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fba3fe847045ecff794b9c138293a80db914678c453ad63fbf0c6a9eb6e00b22"
+dependencies = [
+ "encoding_rs",
 ]
 
 [[package]]
@@ -6011,7 +6134,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74fef4569247a5f429d9156b9d0a2599914385dd189c539334c625d8099d90ab"
 dependencies = [
  "futures-core",
- "nom",
+ "nom 7.1.3",
  "pin-project-lite",
 ]
 
@@ -6074,6 +6197,12 @@ dependencies = [
  "regex-automata",
  "regex-syntax",
 ]
+
+[[package]]
+name = "fast-float2"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6e8948ce679d00a02a94739ea185595dca7118ed04feb991127e443bd3d761f"
 
 [[package]]
 name = "fastant"
@@ -6179,6 +6308,16 @@ name = "fiat-crypto"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0870c84016d4b481be5c9f323c24f65e31e901ae618f0e80f4308fb00de1d2d"
+
+[[package]]
+name = "filetime"
+version = "0.2.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759"
+dependencies = [
+ "cfg-if",
+ "libc",
+]
 
 [[package]]
 name = "find-msvc-tools"
@@ -6498,6 +6637,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "fsst"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65f4a8c268d4d18be0f79a897c758f4eb6b074cc5c4bab56e828f0657d6bd521"
+dependencies = [
+ "arrow-array 58.4.0",
+ "rand 0.9.5",
+]
+
+[[package]]
+name = "fst"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ab85b9b05e3978cc9a9cf8fea7f01b494e1a09ed3037e16ba39edc7a29eb61a"
+dependencies = [
+ "utf8-ranges",
 ]
 
 [[package]]
@@ -6991,9 +7149,9 @@ dependencies = [
 
 [[package]]
 name = "glob"
-version = "0.3.1"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
+checksum = "e4eba85ea1d0a966a983acd07deee566e67395d2d96b6fb39e62b5a833f1eb0b"
 
 [[package]]
 name = "gloo-timers"
@@ -7200,7 +7358,7 @@ dependencies = [
  "base64 0.13.1",
  "byteorder",
  "flate2",
- "nom",
+ "nom 7.1.3",
  "num-traits",
 ]
 
@@ -7565,6 +7723,15 @@ dependencies = [
  "tower-service",
  "tracing",
  "windows-registry",
+]
+
+[[package]]
+name = "hyperloglogplus"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "621debdf94dcac33e50475fdd76d34d5ea9c0362a834b9db08c3024696c1fbe3"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -8098,6 +8265,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "jieba-macros"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a29cfc5dcd898604c6f80363411fa6b6b08e27d1d253d6225b9cb6702ea02fc0"
+dependencies = [
+ "phf_codegen 0.13.1",
+]
+
+[[package]]
+name = "jieba-rs"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3245d6e9d1d5facbd6a23848d6b67e3439738ccbb4fa5a3d65da315ba1a910a2"
+dependencies = [
+ "cedarwood",
+ "jieba-macros",
+ "phf 0.13.1",
+ "regex",
+ "rustc-hash 2.1.0",
+]
+
+[[package]]
 name = "jiff"
 version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8208,6 +8397,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "jsonb"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb98fb29636087c40ad0d1274d9a30c0c1e83e03ae93f6e7e89247b37fcc6953"
+dependencies = [
+ "byteorder",
+ "ethnum",
+ "fast-float2",
+ "itoa",
+ "jiff 0.2.35",
+ "nom 8.0.0",
+ "num-traits",
+ "ordered-float 5.5.0",
+ "rand 0.9.5",
+ "serde",
+ "serde_json",
+ "zmij",
+]
+
+[[package]]
 name = "jsonbb"
 version = "0.2.3"
 source = "git+https://github.com/risingwavelabs/jsonbb.git?rev=f618cd8c9bc517f35dec192d4e7553650894a011#f618cd8c9bc517f35dec192d4e7553650894a011"
@@ -8261,6 +8470,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "kanaria"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f9d9652540055ac4fded998a73aca97d965899077ab1212587437da44196ff"
+dependencies = [
+ "bitflags 1.3.2",
+]
+
+[[package]]
 name = "keyed_priority_queue"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8299,6 +8517,585 @@ dependencies = [
 ]
 
 [[package]]
+name = "lance"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1dec6c13a1b9a608cc8275bb7e967250aba18b1dfde65ea07a78c6d442e8bf5c"
+dependencies = [
+ "arrow 58.4.0",
+ "arrow-arith 58.4.0",
+ "arrow-array 58.4.0",
+ "arrow-buffer 58.4.0",
+ "arrow-cast 58.4.0",
+ "arrow-ipc 58.4.0",
+ "arrow-ord 58.4.0",
+ "arrow-row 58.4.0",
+ "arrow-schema 58.4.0",
+ "arrow-select 58.4.0",
+ "async-recursion",
+ "async-trait",
+ "async_cell",
+ "byteorder",
+ "bytes",
+ "chrono",
+ "crossbeam-skiplist",
+ "dashmap",
+ "datafusion 53.0.0",
+ "datafusion-expr 53.0.0",
+ "datafusion-functions 53.0.0",
+ "datafusion-physical-expr 53.0.0",
+ "datafusion-physical-plan 53.0.0",
+ "deepsize",
+ "either",
+ "futures",
+ "half 2.7.1",
+ "humantime",
+ "itertools 0.13.0",
+ "lance-arrow",
+ "lance-core",
+ "lance-datafusion",
+ "lance-encoding",
+ "lance-file",
+ "lance-index",
+ "lance-io",
+ "lance-linalg",
+ "lance-namespace",
+ "lance-table",
+ "lance-tokenizer",
+ "log",
+ "moka",
+ "object_store 0.12.5",
+ "permutation",
+ "pin-project",
+ "prost 0.14.3",
+ "prost-build 0.14.3",
+ "prost-types 0.14.3",
+ "rand 0.9.5",
+ "roaring",
+ "semver",
+ "serde",
+ "serde_json",
+ "snafu 0.9.2",
+ "tokio",
+ "tokio-stream 0.1.17",
+ "tokio-util",
+ "tracing",
+ "url",
+ "uuid",
+]
+
+[[package]]
+name = "lance-arrow"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32f0efc3607bac297f1b41ac4dc3d6ffbadd36f61a24bec46b70c1f9bda1feda"
+dependencies = [
+ "arrow-array 58.4.0",
+ "arrow-buffer 58.4.0",
+ "arrow-cast 58.4.0",
+ "arrow-data 58.4.0",
+ "arrow-ipc 58.4.0",
+ "arrow-ord 58.4.0",
+ "arrow-schema 58.4.0",
+ "arrow-select 58.4.0",
+ "bytes",
+ "futures",
+ "getrandom 0.2.11",
+ "half 2.7.1",
+ "jsonb",
+ "num-traits",
+ "rand 0.9.5",
+]
+
+[[package]]
+name = "lance-bitpacking"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c04b043c89e46ed3548f3b6423dcbdfac485e636c6e670d642424e954cfab66"
+dependencies = [
+ "arrayref",
+ "paste",
+ "seq-macro",
+]
+
+[[package]]
+name = "lance-core"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62e954fbffdf484587e956d34613b187a4d4785f6a52b0d89b0c04f1d75d6246"
+dependencies = [
+ "arrow-array 58.4.0",
+ "arrow-buffer 58.4.0",
+ "arrow-schema 58.4.0",
+ "async-trait",
+ "byteorder",
+ "bytes",
+ "chrono",
+ "datafusion-common 53.0.0",
+ "datafusion-sql 53.0.0",
+ "deepsize",
+ "futures",
+ "itertools 0.13.0",
+ "lance-arrow",
+ "libc",
+ "log",
+ "mock_instant",
+ "moka",
+ "num_cpus",
+ "object_store 0.12.5",
+ "pin-project",
+ "prost 0.14.3",
+ "rand 0.9.5",
+ "roaring",
+ "serde_json",
+ "snafu 0.9.2",
+ "tempfile",
+ "tokio",
+ "tokio-stream 0.1.17",
+ "tokio-util",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "lance-datafusion"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ac79df93aa8050f1c33fdc76bd1e86da714c309c08170be5eb1e353a67dc29b"
+dependencies = [
+ "arrow 58.4.0",
+ "arrow-array 58.4.0",
+ "arrow-buffer 58.4.0",
+ "arrow-cast 58.4.0",
+ "arrow-ord 58.4.0",
+ "arrow-schema 58.4.0",
+ "arrow-select 58.4.0",
+ "async-trait",
+ "chrono",
+ "datafusion 53.0.0",
+ "datafusion-common 53.0.0",
+ "datafusion-functions 53.0.0",
+ "datafusion-physical-expr 53.0.0",
+ "futures",
+ "jsonb",
+ "lance-arrow",
+ "lance-core",
+ "lance-datagen",
+ "log",
+ "pin-project",
+ "prost 0.14.3",
+ "prost-build 0.14.3",
+ "snafu 0.9.2",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "lance-datagen"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52d904119ec5682fdf5729dd943bfdeea78e43585d07a13cce34b2bcee41328b"
+dependencies = [
+ "arrow 58.4.0",
+ "arrow-array 58.4.0",
+ "arrow-cast 58.4.0",
+ "arrow-schema 58.4.0",
+ "chrono",
+ "futures",
+ "half 2.7.1",
+ "hex",
+ "rand 0.9.5",
+ "rand_distr",
+ "rand_xoshiro 0.7.0",
+ "random_word",
+]
+
+[[package]]
+name = "lance-encoding"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4386ea75123fe6194e166f0f1d375b6041d44507fe7b7c63ac0da493de78a2f"
+dependencies = [
+ "arrow-arith 58.4.0",
+ "arrow-array 58.4.0",
+ "arrow-buffer 58.4.0",
+ "arrow-cast 58.4.0",
+ "arrow-data 58.4.0",
+ "arrow-schema 58.4.0",
+ "arrow-select 58.4.0",
+ "bytemuck",
+ "byteorder",
+ "bytes",
+ "fsst",
+ "futures",
+ "hex",
+ "hyperloglogplus",
+ "itertools 0.13.0",
+ "lance-arrow",
+ "lance-bitpacking",
+ "lance-core",
+ "log",
+ "lz4",
+ "num-traits",
+ "prost 0.14.3",
+ "prost-build 0.14.3",
+ "prost-types 0.14.3",
+ "rand 0.9.5",
+ "snafu 0.9.2",
+ "strum 0.26.3",
+ "tokio",
+ "tracing",
+ "xxhash-rust",
+ "zstd",
+]
+
+[[package]]
+name = "lance-file"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "422ad760cadf7c3e8e23aefc60d4f08eff553f4ad899c40c4a5bb9a976888c44"
+dependencies = [
+ "arrow-arith 58.4.0",
+ "arrow-array 58.4.0",
+ "arrow-buffer 58.4.0",
+ "arrow-data 58.4.0",
+ "arrow-schema 58.4.0",
+ "arrow-select 58.4.0",
+ "async-recursion",
+ "async-trait",
+ "byteorder",
+ "bytes",
+ "datafusion-common 53.0.0",
+ "deepsize",
+ "futures",
+ "lance-arrow",
+ "lance-core",
+ "lance-encoding",
+ "lance-io",
+ "log",
+ "num-traits",
+ "object_store 0.12.5",
+ "prost 0.14.3",
+ "prost-build 0.14.3",
+ "prost-types 0.14.3",
+ "snafu 0.9.2",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "lance-index"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a653b7dc78a171f0692ddd15afc458e296667c481228171d39f5d9a1f2a1faf0"
+dependencies = [
+ "arrow 58.4.0",
+ "arrow-arith 58.4.0",
+ "arrow-array 58.4.0",
+ "arrow-ord 58.4.0",
+ "arrow-schema 58.4.0",
+ "arrow-select 58.4.0",
+ "async-channel 2.5.0",
+ "async-recursion",
+ "async-trait",
+ "bitpacking",
+ "bitvec",
+ "bytes",
+ "chrono",
+ "crossbeam-queue",
+ "datafusion 53.0.0",
+ "datafusion-common 53.0.0",
+ "datafusion-expr 53.0.0",
+ "datafusion-physical-expr 53.0.0",
+ "datafusion-sql 53.0.0",
+ "deepsize",
+ "dirs 6.0.0",
+ "fst",
+ "futures",
+ "half 2.7.1",
+ "itertools 0.13.0",
+ "jieba-rs",
+ "jsonb",
+ "lance-arrow",
+ "lance-core",
+ "lance-datafusion",
+ "lance-datagen",
+ "lance-encoding",
+ "lance-file",
+ "lance-io",
+ "lance-linalg",
+ "lance-table",
+ "lance-tokenizer",
+ "libm",
+ "log",
+ "ndarray",
+ "num-traits",
+ "object_store 0.12.5",
+ "prost 0.14.3",
+ "prost-build 0.14.3",
+ "prost-types 0.14.3",
+ "rand 0.9.5",
+ "rand_distr",
+ "rangemap",
+ "rayon",
+ "roaring",
+ "serde",
+ "serde_json",
+ "smallvec",
+ "snafu 0.9.2",
+ "tempfile",
+ "tokio",
+ "tracing",
+ "twox-hash",
+ "uuid",
+]
+
+[[package]]
+name = "lance-io"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "313f83fe349a5df2a7a24ad7707696ae0437d0270b0a1b78b340ee553eef7a6c"
+dependencies = [
+ "arrow 58.4.0",
+ "arrow-arith 58.4.0",
+ "arrow-array 58.4.0",
+ "arrow-buffer 58.4.0",
+ "arrow-cast 58.4.0",
+ "arrow-data 58.4.0",
+ "arrow-schema 58.4.0",
+ "arrow-select 58.4.0",
+ "async-recursion",
+ "async-trait",
+ "byteorder",
+ "bytes",
+ "chrono",
+ "deepsize",
+ "futures",
+ "http 1.4.0",
+ "io-uring",
+ "lance-arrow",
+ "lance-core",
+ "lance-namespace",
+ "libc",
+ "log",
+ "moka",
+ "object_store 0.12.5",
+ "path_abs",
+ "pin-project",
+ "prost 0.14.3",
+ "rand 0.9.5",
+ "serde",
+ "snafu 0.9.2",
+ "tempfile",
+ "tokio",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "lance-linalg"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66bb2b89cc84b4fdb96c2436224394c1bb32d38e1e38a9c96e22e6e3918b0458"
+dependencies = [
+ "arrow-array 58.4.0",
+ "arrow-buffer 58.4.0",
+ "arrow-schema 58.4.0",
+ "cc",
+ "deepsize",
+ "half 2.7.1",
+ "lance-arrow",
+ "lance-core",
+ "num-traits",
+ "rand 0.9.5",
+]
+
+[[package]]
+name = "lance-namespace"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbfd6ad2e589bd8fc00965f808f16895b50d6cbd6405bd7a972db82fe62e2e24"
+dependencies = [
+ "arrow 58.4.0",
+ "async-trait",
+ "bytes",
+ "lance-core",
+ "lance-namespace-reqwest-client",
+ "serde",
+ "snafu 0.9.2",
+]
+
+[[package]]
+name = "lance-namespace-impls"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08c9d4a7b0dceb1a4d2697bab8ce62d52f8b8fd0eec4b4ae6d40017f0ccad0cc"
+dependencies = [
+ "arrow 58.4.0",
+ "arrow-ipc 58.4.0",
+ "arrow-schema 58.4.0",
+ "async-trait",
+ "bytes",
+ "chrono",
+ "futures",
+ "lance",
+ "lance-core",
+ "lance-index",
+ "lance-io",
+ "lance-linalg",
+ "lance-namespace",
+ "lance-table",
+ "log",
+ "object_store 0.12.5",
+ "rand 0.9.5",
+ "serde_json",
+ "snafu 0.9.2",
+ "tokio",
+ "url",
+]
+
+[[package]]
+name = "lance-namespace-reqwest-client"
+version = "0.7.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6369eee4682fb11edf538388b43c61ce288b8302fe89bb40944d7daa7faaae99"
+dependencies = [
+ "reqwest 0.12.25",
+ "serde",
+ "serde_json",
+ "serde_repr",
+ "serde_with",
+ "url",
+]
+
+[[package]]
+name = "lance-table"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a427dea3c93535c65f3c44985742c08ec4bf4f5f817779157b1dc3c6a2a3288"
+dependencies = [
+ "arrow 58.4.0",
+ "arrow-array 58.4.0",
+ "arrow-buffer 58.4.0",
+ "arrow-ipc 58.4.0",
+ "arrow-schema 58.4.0",
+ "async-trait",
+ "byteorder",
+ "bytes",
+ "chrono",
+ "deepsize",
+ "futures",
+ "lance-arrow",
+ "lance-core",
+ "lance-file",
+ "lance-io",
+ "log",
+ "object_store 0.12.5",
+ "prost 0.14.3",
+ "prost-build 0.14.3",
+ "prost-types 0.14.3",
+ "rand 0.9.5",
+ "rangemap",
+ "roaring",
+ "semver",
+ "serde",
+ "serde_json",
+ "snafu 0.9.2",
+ "tokio",
+ "tracing",
+ "url",
+ "uuid",
+]
+
+[[package]]
+name = "lance-testing"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf17e430caece4d5eb72e8ed76a61b05afc56ae66e79f2abe0945a9794a861d9"
+dependencies = [
+ "arrow-array 58.4.0",
+ "arrow-schema 58.4.0",
+ "lance-arrow",
+ "num-traits",
+ "rand 0.9.5",
+]
+
+[[package]]
+name = "lance-tokenizer"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "810ae0847a16b92629c2d894843b9666d2d975d8a7c3bd3ce21ad19c7900b140"
+dependencies = [
+ "jieba-rs",
+ "lindera",
+ "rust-stemmers",
+ "serde",
+ "unicode-normalization",
+]
+
+[[package]]
+name = "lancedb"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b1c425caac39870073f400cf1836383a0a1858134b77e9a0aef7e2f12fd47aa"
+dependencies = [
+ "ahash 0.8.11",
+ "arrow 58.4.0",
+ "arrow-array 58.4.0",
+ "arrow-cast 58.4.0",
+ "arrow-data 58.4.0",
+ "arrow-ipc 58.4.0",
+ "arrow-ord 58.4.0",
+ "arrow-schema 58.4.0",
+ "arrow-select 58.4.0",
+ "async-trait",
+ "bytes",
+ "chrono",
+ "datafusion 53.0.0",
+ "datafusion-catalog 53.0.0",
+ "datafusion-common 53.0.0",
+ "datafusion-execution 53.0.0",
+ "datafusion-expr 53.0.0",
+ "datafusion-functions 53.0.0",
+ "datafusion-physical-expr 53.0.0",
+ "datafusion-physical-plan 53.0.0",
+ "datafusion-sql 53.0.0",
+ "futures",
+ "half 2.7.1",
+ "lance",
+ "lance-arrow",
+ "lance-core",
+ "lance-datafusion",
+ "lance-datagen",
+ "lance-encoding",
+ "lance-file",
+ "lance-index",
+ "lance-io",
+ "lance-linalg",
+ "lance-namespace",
+ "lance-namespace-impls",
+ "lance-table",
+ "lance-testing",
+ "lazy_static",
+ "log",
+ "moka",
+ "num-traits",
+ "object_store 0.12.5",
+ "pin-project",
+ "rand 0.9.5",
+ "regex",
+ "semver",
+ "serde",
+ "serde_json",
+ "serde_with",
+ "snafu 0.8.9",
+ "tempfile",
+ "tokio",
+ "url",
+ "uuid",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8314,7 +9111,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cbcf559624bfd9fe8d488329a8959766335a43a9b8b2cdd6a2c379fca02909a5"
 dependencies = [
  "bytes",
- "nom",
+ "nom 7.1.3",
 ]
 
 [[package]]
@@ -8329,7 +9126,7 @@ dependencies = [
  "futures-util",
  "lber",
  "log",
- "nom",
+ "nom 7.1.3",
  "percent-encoding",
  "rustls 0.23.35",
  "rustls-native-certs 0.8.1",
@@ -8472,9 +9269,9 @@ dependencies = [
 
 [[package]]
 name = "libm"
-version = "0.2.7"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7012b1bbb0719e1097c47611d3898568c546d597c2e74d66f6087edd5233ff4"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libredox"
@@ -8530,6 +9327,130 @@ dependencies = [
  "libc",
  "pkg-config",
  "vcpkg",
+]
+
+[[package]]
+name = "lindera"
+version = "0.44.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50aba4ef41052280722f2120f65606b9218e8718032a3c752b953c4d8091f02e"
+dependencies = [
+ "anyhow",
+ "bincode 2.0.1",
+ "byteorder",
+ "csv",
+ "kanaria",
+ "lindera-cc-cedict",
+ "lindera-dictionary",
+ "lindera-ipadic",
+ "lindera-ipadic-neologd",
+ "lindera-ko-dic",
+ "lindera-unidic",
+ "once_cell",
+ "regex",
+ "serde",
+ "serde_json",
+ "serde_yaml",
+ "strum 0.27.2",
+ "strum_macros 0.27.2",
+ "unicode-blocks",
+ "unicode-normalization",
+ "unicode-segmentation",
+ "yada",
+]
+
+[[package]]
+name = "lindera-cc-cedict"
+version = "0.44.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d77e7a0830fd60f23828ad914439997288c1d2cdd9e269be67f967c27b56350"
+dependencies = [
+ "bincode 2.0.1",
+ "byteorder",
+ "lindera-dictionary",
+ "once_cell",
+ "tokio",
+]
+
+[[package]]
+name = "lindera-dictionary"
+version = "0.44.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "489cc70922782af3fd397c0e130846caefe1c15b27c2211aac8f88a9f4590aaf"
+dependencies = [
+ "anyhow",
+ "bincode 2.0.1",
+ "byteorder",
+ "csv",
+ "derive_builder",
+ "encoding",
+ "encoding_rs",
+ "encoding_rs_io",
+ "flate2",
+ "glob",
+ "log",
+ "md5",
+ "memmap2 0.9.11",
+ "once_cell",
+ "rand 0.9.5",
+ "reqwest 0.12.25",
+ "serde",
+ "tar",
+ "thiserror 2.0.17",
+ "tokio",
+ "yada",
+]
+
+[[package]]
+name = "lindera-ipadic"
+version = "0.44.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78870521431dfaf0f94ddd3484fa08367e9d354fc8c708572f2f00007225ddfa"
+dependencies = [
+ "bincode 2.0.1",
+ "byteorder",
+ "lindera-dictionary",
+ "once_cell",
+ "tokio",
+]
+
+[[package]]
+name = "lindera-ipadic-neologd"
+version = "0.44.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "abcb3dc3056e5c683e12c2c5e8d40076f7ecfd7bd46f5fc0e4ae9e58152b5d85"
+dependencies = [
+ "bincode 2.0.1",
+ "byteorder",
+ "lindera-dictionary",
+ "once_cell",
+ "tokio",
+]
+
+[[package]]
+name = "lindera-ko-dic"
+version = "0.44.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e99316158bab14f0256d912055521ca784f76c63e7460db8a74775c5dc1f8bc2"
+dependencies = [
+ "bincode 2.0.1",
+ "byteorder",
+ "lindera-dictionary",
+ "once_cell",
+ "tokio",
+]
+
+[[package]]
+name = "lindera-unidic"
+version = "0.44.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52672945166c14276bbba25e4ec79d7e126db1b503c0a6aa07ffc0141ae15cfa"
+dependencies = [
+ "bincode 2.0.1",
+ "byteorder",
+ "lindera-dictionary",
+ "once_cell",
+ "tokio",
 ]
 
 [[package]]
@@ -8800,7 +9721,7 @@ dependencies = [
  "naive-timer",
  "panic-message",
  "rand 0.8.5",
- "rand_xoshiro",
+ "rand_xoshiro 0.6.0",
  "rustversion",
  "serde",
  "spin 0.9.8",
@@ -8952,6 +9873,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
+name = "matrixmultiply"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f607c237553f086e7043417a51df26b2eb899d3caff94e6a67592ff992fedc7"
+dependencies = [
+ "autocfg",
+ "num_cpus",
+ "once_cell",
+ "rawpointer",
+ "thread-tree",
+]
+
+[[package]]
 name = "maybe-owned"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8976,6 +9910,12 @@ dependencies = [
  "cfg-if",
  "digest 0.11.2",
 ]
+
+[[package]]
+name = "md5"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ebb8d8732c6a6df3d8f032a82911cfc747e00efb95cc46e8d0acd5b5b88570c"
 
 [[package]]
 name = "mea"
@@ -9018,6 +9958,15 @@ name = "memmap2"
 version = "0.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83faa42c0a078c393f6b29d5db232d8be22776a891f8f56e5284faee4a20b327"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "memmap2"
+version = "0.9.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1219ed1b7f229ee7104d281dd01d6802fe28bb6e95d292942c4daacdeb798c0"
 dependencies = [
  "libc",
 ]
@@ -9123,6 +10072,12 @@ dependencies = [
  "parking_lot 0.12.5",
  "prometheus",
 ]
+
+[[package]]
+name = "mock_instant"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9bb517913cfcfb9eeda59f36020269075a152701a01606c612f547e4890be399"
 
 [[package]]
 name = "mockall"
@@ -9371,6 +10326,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "ndarray"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "882ed72dce9365842bf196bdeedf5055305f11fc8c03dee7bb0194a6cad34841"
+dependencies = [
+ "matrixmultiply",
+ "num-complex",
+ "num-integer",
+ "num-traits",
+ "portable-atomic",
+ "portable-atomic-util",
+ "rawpointer",
+]
+
+[[package]]
 name = "nexmark"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9428,6 +10398,15 @@ checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
  "memchr",
  "minimal-lexical",
+]
+
+[[package]]
+name = "nom"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -9699,6 +10678,30 @@ dependencies = [
  "hashbrown 0.15.5",
  "indexmap 2.14.0",
  "memchr",
+]
+
+[[package]]
+name = "object_store"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbfbfff40aeccab00ec8a910b57ca8ecf4319b335c542f2edcd19dd25a1e2a00"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "chrono",
+ "futures",
+ "http 1.4.0",
+ "humantime",
+ "itertools 0.14.0",
+ "parking_lot 0.12.5",
+ "percent-encoding",
+ "thiserror 2.0.17",
+ "tokio",
+ "tracing",
+ "url",
+ "walkdir",
+ "wasm-bindgen-futures",
+ "web-time",
 ]
 
 [[package]]
@@ -10295,6 +11298,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ordered-float"
+version = "5.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c7c9e0d9b23589f26070720bac724174bfec1083e82f7854cdd0267518343c0"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "ordered-multimap"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10504,7 +11516,7 @@ dependencies = [
  "num-bigint",
  "num-integer",
  "num-traits",
- "object_store",
+ "object_store 0.13.2",
  "parquet-variant",
  "parquet-variant-compute",
  "parquet-variant-json",
@@ -10628,6 +11640,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e91099d4268b0e11973f036e885d652fb0b21fedcf69738c627f94db6a44f42"
 
 [[package]]
+name = "path_abs"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05ef02f6342ac01d8a93b65f96db53fe68a92a15f41144f97fb00a9e669633c3"
+dependencies = [
+ "serde",
+ "serde_derive",
+ "std_prelude",
+ "stfu8",
+]
+
+[[package]]
 name = "pbjson"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10711,6 +11735,12 @@ name = "percent-encoding-rfc3986"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3637c05577168127568a64e9dc5a6887da720efef07b3d9472d45f63ab191166"
+
+[[package]]
+name = "permutation"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df202b0b0f5b8e389955afd5f27b007b00fb948162953f1db9c70d2c7e3157d7"
 
 [[package]]
 name = "petgraph"
@@ -10836,6 +11866,16 @@ checksum = "efbdcb6f01d193b17f0b9c3360fa7e0e620991b193ff08702f78b3ce365d7e61"
 dependencies = [
  "phf_generator 0.12.1",
  "phf_shared 0.12.1",
+]
+
+[[package]]
+name = "phf_codegen"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49aa7f9d80421bca176ca8dbfebe668cc7a2684708594ec9f3c0db0805d5d6e1"
+dependencies = [
+ "phf_generator 0.13.1",
+ "phf_shared 0.13.1",
 ]
 
 [[package]]
@@ -11713,7 +12753,7 @@ dependencies = [
  "lz4",
  "murmur3",
  "native-tls",
- "nom",
+ "nom 7.1.3",
  "oauth2",
  "openidconnect",
  "pem 3.0.6",
@@ -12018,6 +13058,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
+name = "rand_distr"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8615d50dcf34fa31f7ab52692afec947c4dd0ab803cc87cb3b0b4570ff7463"
+dependencies = [
+ "num-traits",
+ "rand 0.9.5",
+]
+
+[[package]]
 name = "rand_pcg"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12036,10 +13086,44 @@ dependencies = [
 ]
 
 [[package]]
-name = "rayon"
-version = "1.7.0"
+name = "rand_xoshiro"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d2df5196e37bcc87abebc0053e20787d73847bb33134a69841207dd0a47f03b"
+checksum = "f703f4665700daf5512dcca5f43afa6af89f09db47fb56be587f80636bda2d41"
+dependencies = [
+ "rand_core 0.9.0",
+]
+
+[[package]]
+name = "random_word"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e47a395bdb55442b883c89062d6bcff25dc90fa5f8369af81e0ac6d49d78cf81"
+dependencies = [
+ "ahash 0.8.11",
+ "brotli",
+ "paste",
+ "rand 0.9.5",
+ "unicase",
+]
+
+[[package]]
+name = "rangemap"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a611d15b50743feb4c76b7d03edcb0e64f399c26961e4efe6975bc398be6aa3d"
+
+[[package]]
+name = "rawpointer"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
+
+[[package]]
+name = "rayon"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
 dependencies = [
  "either",
  "rayon-core",
@@ -12047,14 +13131,12 @@ dependencies = [
 
 [[package]]
 name = "rayon-core"
-version = "1.11.0"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b8f95bd6966f5c87776639160a66bd8ab9895d9d4ab01ddba9fc60661aebe8d"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
 dependencies = [
- "crossbeam-channel",
  "crossbeam-deque",
  "crossbeam-utils",
- "num_cpus",
 ]
 
 [[package]]
@@ -12443,6 +13525,7 @@ dependencies = [
  "js-sys",
  "log",
  "mime",
+ "mime_guess",
  "native-tls",
  "percent-encoding",
  "pin-project-lite",
@@ -13251,6 +14334,9 @@ dependencies = [
  "indexmap 2.14.0",
  "itertools 0.14.0",
  "jni",
+ "lance",
+ "lance-table",
+ "lancedb",
  "madsim-rdkafka",
  "madsim-tokio",
  "madsim-tonic",
@@ -14531,9 +15617,9 @@ dependencies = [
 
 [[package]]
 name = "roaring"
-version = "0.11.2"
+version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f08d6a905edb32d74a5d5737a0c9d7e950c312f3c46cb0ca0a2ca09ea11878a0"
+checksum = "1dedc5658c6ecb3bdb5ef5f3295bb9253f42dcf3fd1402c03f6b1f7659c3c4a9"
 dependencies = [
  "bytemuck",
  "byteorder",
@@ -14684,6 +15770,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rust-stemmers"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e46a2036019fdb888131db7a4c847a1063a7493f971ed94ea82c67eada63ca54"
+dependencies = [
+ "serde",
+ "serde_derive",
+]
+
+[[package]]
 name = "rust_decimal"
 version = "1.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -14743,7 +15839,7 @@ version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf0c4a6ece9950b9abdb62b1cfcf2a68b3b67a10ba445b3bb85be2a293d0632"
 dependencies = [
- "nom",
+ "nom 7.1.3",
 ]
 
 [[package]]
@@ -15612,9 +16708,9 @@ dependencies = [
 
 [[package]]
 name = "serde_yaml"
-version = "0.9.25"
+version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a49e178e4452f45cb61d0cd8cebc1b0fafd3e41929e996cef79aa3aca91f574"
+checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
 dependencies = [
  "indexmap 2.14.0",
  "itoa",
@@ -15903,6 +16999,48 @@ dependencies = [
 ]
 
 [[package]]
+name = "snafu"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e84b3f4eacbf3a1ce05eac6763b4d629d60cbc94d632e4092c54ade71f1e1a2"
+dependencies = [
+ "snafu-derive 0.8.9",
+]
+
+[[package]]
+name = "snafu"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e45cb604038abb7b926b679887b3226d8d0f23874b66623625a0454be425a4b7"
+dependencies = [
+ "snafu-derive 0.9.2",
+]
+
+[[package]]
+name = "snafu-derive"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1c97747dbf44bb1ca44a561ece23508e99cb592e862f22222dcf42f51d1e451"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "snafu-derive"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "287f59010008f0d7cf5e3b03196d666c1acc46c8d3e9cf34c28a1a7157601e72"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "snap"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -16002,7 +17140,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa30c054bdeed860dd36c1e5a467ec4251d925246f7f57b55bfb77decc2e0ed4"
 dependencies = [
  "jsonbb",
- "nom",
+ "nom 7.1.3",
  "regex",
  "serde_json",
  "thiserror 2.0.17",
@@ -16015,7 +17153,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b7b278788e7be4d0d29c0f39497a0eef3fba6bbc8e70d8bf7fde46edeaa9e85"
 dependencies = [
  "itertools 0.11.0",
- "nom",
+ "nom 7.1.3",
  "unicode_categories",
 ]
 
@@ -16310,6 +17448,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
+name = "std_prelude"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8207e78455ffdf55661170876f88daf85356e4edd54e0a3dbc79586ca1e50cbe"
+
+[[package]]
+name = "stfu8"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e51f1e89f093f99e7432c491c382b88a6860a5adbe6bf02574bf0a08efff1978"
+
+[[package]]
 name = "str_stack"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -16448,7 +17598,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e0e9bc48b3852f36a84f8d0da275d50cb3c2b88b59b9ec35fdd8b7fa239e37d"
 dependencies = [
  "debugid",
- "memmap2",
+ "memmap2 0.5.10",
  "stable_deref_trait",
  "uuid",
 ]
@@ -16626,6 +17776,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
+name = "tar"
+version = "0.4.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f6221d9a6003c78398e3b239969f352578258df48c8eb051caadae0015bc840"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
+]
+
+[[package]]
 name = "target-lexicon"
 version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -16734,6 +17895,15 @@ name = "thousands"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3bf63baf9f5039dadc247375c29eb13706706cfde997d0330d05aa63a77d8820"
+
+[[package]]
+name = "thread-tree"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffbd370cb847953a25954d9f63e14824a36113f8c72eecf6eccef5dc4b45d630"
+dependencies = [
+ "crossbeam-channel",
+]
 
 [[package]]
 name = "thread_local"
@@ -17695,6 +18865,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92888ba5573ff080736b3648696b70cafad7d250551175acbaa4e0385b3e1460"
 
 [[package]]
+name = "unicode-blocks"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "328edfd6d0bb91a22e592bed3a3b54c7b1f5c92a517f5a7aca24a2caef10c363"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -17702,18 +18878,18 @@ checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
 
 [[package]]
 name = "unicode-normalization"
-version = "0.1.22"
+version = "0.1.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c5713f0fc4b5db668a2ac63cdb7bb4469d8c9fed047b1d0292cc7b0ce2ba921"
+checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
 dependencies = [
  "tinyvec",
 ]
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.10.1"
+version = "1.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1dd624098567895118886609431a7c3b8f516e41d30e0643f03d94592a147e36"
+checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
 
 [[package]]
 name = "unicode-width"
@@ -17757,9 +18933,9 @@ dependencies = [
 
 [[package]]
 name = "unsafe-libyaml"
-version = "0.2.10"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab4c90930b95a82d00dc9e9ac071b4991924390d46cbd0dfe566148667605e4b"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "untrusted"
@@ -17803,6 +18979,12 @@ name = "utf-8"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
+
+[[package]]
+name = "utf8-ranges"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fcfc827f90e53a02eaef5e535ee14266c1d569214c6aa70133a624d8a3164ba"
 
 [[package]]
 name = "utf8_iter"
@@ -19358,7 +20540,7 @@ dependencies = [
  "data-encoding",
  "der-parser",
  "lazy_static",
- "nom",
+ "nom 7.1.3",
  "oid-registry",
  "rusticata-macros",
  "thiserror 2.0.17",
@@ -19393,9 +20575,15 @@ dependencies = [
 
 [[package]]
 name = "xxhash-rust"
-version = "0.8.7"
+version = "0.8.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9828b178da53440fa9c766a3d2f73f7cf5d0ac1fe3980c1e5018d899fd19e07b"
+checksum = "aee1b19627c7c60102ab80d3a9cbe18de90bfe03bfa6c3715447681f0e8c8af6"
+
+[[package]]
+name = "yada"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aed111bd9e48a802518765906cbdadf0b45afb72b9c81ab049a3b86252adffdd"
 
 [[package]]
 name = "yaml-rust2"
@@ -19502,6 +20690,12 @@ name = "zlib-rs"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3be3d40e40a133f9c916ee3f9f4fa2d9d63435b5fbe1bfc6d9dae0aa0ada1513"
+
+[[package]]
+name = "zmij"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"
 
 [[package]]
 name = "zstd"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -106,6 +106,8 @@ development = ["expect-test", "pretty_assertions"]
 libraries = [{ path = "./lints" }]
 
 [workspace.dependencies]
+adbc_core = { version = "0.23" }
+adbc_snowflake = { version = "0.23", default-features = false }
 apache-avro = { git = "https://github.com/risingwavelabs/avro-rs", rev = "1f2723802d4fb77b97fa084f7bb81e3b60b9e03f" }
 arc-swap = "1"
 arrow-udf-runtime = "0.9.0"
@@ -169,14 +171,14 @@ iceberg = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "c
 ] }
 iceberg-catalog-glue = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "c034b19105fa0f540256fbe4859be8121c5c0551" }
 iceberg-catalog-rest = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "c034b19105fa0f540256fbe4859be8121c5c0551" }
-
-adbc_core = { version = "0.23" }
-adbc_snowflake = { version = "0.23", default-features = false }
 indexmap = { version = "2.12.0", features = ["serde"] }
 itertools = "0.14.0"
 jni = { version = "0.21.1", features = ["invocation"] }
 jsonbb = { version = "0.2.3", features = ["float_roundtrip"] }
 jsonwebtoken = { version = "10", features = ["aws_lc_rs"] }
+lance = { version = "0.39", default-features = false }
+lance-table = { version = "0.39", default-features = false }
+lancedb = { version = "0.22", default-features = false }
 linkme = { version = "0.3.32", features = ["used_linker"] }
 lru = "0.16"
 madsim = { git = "https://github.com/risingwavelabs/madsim.git", rev = "595455fd05058b3b48bf281bea3ada1bca3d6646" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -176,9 +176,12 @@ itertools = "0.14.0"
 jni = { version = "0.21.1", features = ["invocation"] }
 jsonbb = { version = "0.2.3", features = ["float_roundtrip"] }
 jsonwebtoken = { version = "10", features = ["aws_lc_rs"] }
-lance = { version = "0.39", default-features = false }
-lance-table = { version = "0.39", default-features = false }
-lancedb = { version = "0.22", default-features = false }
+# Keep LanceDB on the Lance 6 stack for now. Lance 7 pulls in dependencies
+# that require serde_json >= 1.0.149, while RisingWave pins serde_json below
+# 1.0.147 to preserve SQL JSONB float formatting compatibility. See #25739.
+lance = { version = "6.0", default-features = false }
+lance-table = { version = "6.0", default-features = false }
+lancedb = { version = "0.29", default-features = false }
 linkme = { version = "0.3.32", features = ["used_linker"] }
 lru = "0.16"
 madsim = { git = "https://github.com/risingwavelabs/madsim.git", rev = "595455fd05058b3b48bf281bea3ada1bca3d6646" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -192,6 +192,12 @@ itertools = "0.14.0"
 jni = { version = "0.21.1", features = ["invocation"] }
 jsonbb = { version = "0.2.3", features = ["float_roundtrip"] }
 jsonwebtoken = { version = "10", features = ["aws_lc_rs"] }
+# Keep LanceDB on the Lance 6 stack for now. Lance 7 pulls in dependencies
+# that require serde_json >= 1.0.149, while RisingWave pins serde_json below
+# 1.0.147 to preserve SQL JSONB float formatting compatibility. See #25739.
+lance = { version = "6.0", default-features = false }
+lance-table = { version = "6.0", default-features = false }
+lancedb = { version = "0.29", default-features = false }
 linkme = { version = "0.3.32", features = ["used_linker"] }
 lru = "0.18"
 madsim = { git = "https://github.com/risingwavelabs/madsim.git", rev = "595455fd05058b3b48bf281bea3ada1bca3d6646" }

--- a/ci/scripts/e2e-lancedb-sink-test.sh
+++ b/ci/scripts/e2e-lancedb-sink-test.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+
+# Exits as soon as any line fails.
+set -euo pipefail
+
+source ci/scripts/common.sh
+
+while getopts 'p:' opt; do
+    case ${opt} in
+        p )
+            profile=$OPTARG
+            ;;
+        \? )
+            echo "Invalid Option: -$OPTARG" 1>&2
+            exit 1
+            ;;
+        : )
+            echo "Invalid option: $OPTARG requires an argument" 1>&2
+            ;;
+    esac
+done
+shift $((OPTIND -1))
+
+download_and_prepare_rw "$profile" source
+
+LANCEDB_DIR="/tmp/lancedb-e2e"
+
+echo "--- installing Python lancedb package"
+pip3 install --quiet lancedb
+
+echo "--- preparing LanceDB table"
+rm -rf "$LANCEDB_DIR"
+python3 ./e2e_test/sink/lancedb/lancedb_helper.py setup "$LANCEDB_DIR"
+
+echo "--- starting risingwave cluster"
+risedev ci-start ci-sink-test
+sleep 1
+
+echo "--- running LanceDB sink e2e test"
+sqllogictest -p 4566 -d dev './e2e_test/sink/lancedb/lancedb_sink.slt'
+sleep 3
+
+echo "--- verifying LanceDB sink output"
+actual_output=$(python3 ./e2e_test/sink/lancedb/lancedb_helper.py verify "$LANCEDB_DIR" 5)
+
+if diff -u ./e2e_test/sink/lancedb/expected_output.csv <(echo "$actual_output"); then
+    echo "LanceDB sink check passed"
+else
+    echo "LanceDB sink output mismatch!"
+    echo "Actual output:"
+    echo "$actual_output"
+    exit 1
+fi
+
+echo "--- Kill cluster"
+risedev ci-kill
+
+echo "--- cleaning up"
+rm -rf "$LANCEDB_DIR"

--- a/ci/scripts/e2e-lancedb-sink-test.sh
+++ b/ci/scripts/e2e-lancedb-sink-test.sh
@@ -26,7 +26,7 @@ download_and_prepare_rw "$profile" source
 LANCEDB_DIR="/tmp/lancedb-e2e"
 
 echo "--- installing Python lancedb package"
-pip3 install --quiet lancedb
+python3 -m pip install --break-system-packages --quiet 'lancedb==0.29.0'
 
 echo "--- preparing LanceDB table"
 rm -rf "$LANCEDB_DIR"

--- a/ci/scripts/notify.py
+++ b/ci/scripts/notify.py
@@ -54,6 +54,7 @@ MAIN_CRON_TEST_MAP = {
     "e2e-single-node-binary-tests": ["pin", "peng", "noelkwan"],
     "e2e-test-opendal-parallel": ["congyi"],
     "e2e-deltalake-sink-rust-tests": ["xinhao"],
+    "e2e-lancedb-sink-tests": ["yiming"],
     "e2e-redis-sink-tests": ["xinhao"],
     "e2e-starrocks-sink-tests": ["xinhao"],
     "e2e-cassandra-sink-tests": ["xinhao"],

--- a/ci/workflows/main-cron.yml
+++ b/ci/workflows/main-cron.yml
@@ -933,6 +933,24 @@ steps:
     timeout_in_minutes: 10
     retry: *auto-retry
 
+  - label: "end-to-end lancedb sink test"
+    key: "e2e-lancedb-sink-tests"
+    command: "ci/scripts/e2e-lancedb-sink-test.sh -p ci-release"
+    if: |
+      !(build.pull_request.labels includes "ci/main-cron/run-selected") && build.env("CI_STEPS") == null
+      || build.pull_request.labels includes "ci/run-e2e-lancedb-sink-tests"
+      || build.env("CI_STEPS") =~ /(^|,)e2e-lancedb-sink-tests?(,|$$)/
+    depends_on:
+      - "build"
+      - "build-other"
+    plugins:
+      - docker-compose#v5.5.0:
+          <<: *docker-compose
+          run: sink-test-env
+      - ./ci/plugins/upload-failure-logs
+    timeout_in_minutes: 10
+    retry: *auto-retry
+
   - label: "end-to-end redis sink test"
     key: "e2e-redis-sink-tests"
     command: "ci/scripts/e2e-redis-sink-test.sh -p ci-release"

--- a/ci/workflows/main-cron.yml
+++ b/ci/workflows/main-cron.yml
@@ -985,6 +985,24 @@ steps:
     timeout_in_minutes: 20
     retry: *auto-retry
 
+  - label: "end-to-end lancedb sink test"
+    key: "e2e-lancedb-sink-tests"
+    command: "ci/scripts/e2e-lancedb-sink-test.sh -p ci-release"
+    if: |
+      !(build.pull_request.labels includes "ci/main-cron/run-selected") && build.env("CI_STEPS") == null
+      || build.pull_request.labels includes "ci/run-e2e-lancedb-sink-tests"
+      || build.env("CI_STEPS") =~ /(^|,)e2e-lancedb-sink-tests?(,|$$)/
+    depends_on:
+      - "build"
+      - "build-other"
+    plugins:
+      - docker-compose#v5.5.0:
+          <<: *docker-compose
+          run: sink-test-env
+      - ./ci/plugins/upload-failure-logs
+    timeout_in_minutes: 10
+    retry: *auto-retry
+
   - label: "end-to-end redis sink test"
     key: "e2e-redis-sink-tests"
     command: "ci/scripts/e2e-redis-sink-test.sh -p ci-release"

--- a/ci/workflows/main-cron.yml
+++ b/ci/workflows/main-cron.yml
@@ -52,7 +52,7 @@ steps:
       build.env("CI_STEPS") !~ /(^|,)disable-build(,|$$)/
     plugins:
       - docker-compose#v5.5.0: *docker-compose
-    timeout_in_minutes: 20
+    timeout_in_minutes: 25
     retry: *auto-retry
 
   - label: "build other components"

--- a/ci/workflows/pull-request.yml
+++ b/ci/workflows/pull-request.yml
@@ -540,6 +540,20 @@ steps:
     timeout_in_minutes: 10
     retry: *auto-retry
 
+  - label: "end-to-end lancedb sink test"
+    if: build.pull_request.labels includes "ci/run-e2e-lancedb-sink-tests" || build.env("CI_STEPS") =~ /(^|,)e2e-lancedb-sink-tests?(,|$$)/
+    command: "ci/scripts/e2e-lancedb-sink-test.sh -p ci-dev"
+    depends_on:
+      - "build"
+      - "build-other"
+    plugins:
+      - docker-compose#v5.5.0:
+          <<: *docker-compose
+          run: sink-test-env
+      - ./ci/plugins/upload-failure-logs
+    timeout_in_minutes: 10
+    retry: *auto-retry
+
   - label: "end-to-end redis sink test"
     if: build.pull_request.labels includes "ci/run-e2e-redis-sink-tests" || build.env("CI_STEPS") =~ /(^|,)e2e-redis-sink-tests?(,|$$)/
     command: "ci/scripts/e2e-redis-sink-test.sh -p ci-dev"

--- a/ci/workflows/pull-request.yml
+++ b/ci/workflows/pull-request.yml
@@ -569,6 +569,20 @@ steps:
     timeout_in_minutes: 20
     retry: *auto-retry
 
+  - label: "end-to-end lancedb sink test"
+    if: build.pull_request.labels includes "ci/run-e2e-lancedb-sink-tests" || build.env("CI_STEPS") =~ /(^|,)e2e-lancedb-sink-tests?(,|$$)/
+    command: "ci/scripts/e2e-lancedb-sink-test.sh -p ci-dev"
+    depends_on:
+      - "build"
+      - "build-other"
+    plugins:
+      - docker-compose#v5.5.0:
+          <<: *docker-compose
+          run: sink-test-env
+      - ./ci/plugins/upload-failure-logs
+    timeout_in_minutes: 10
+    retry: *auto-retry
+
   - label: "end-to-end redis sink test"
     if: build.pull_request.labels includes "ci/run-e2e-redis-sink-tests" || build.env("CI_STEPS") =~ /(^|,)e2e-redis-sink-tests?(,|$$)/
     command: "ci/scripts/e2e-redis-sink-test.sh -p ci-dev"

--- a/ci/workflows/pull-request.yml
+++ b/ci/workflows/pull-request.yml
@@ -89,7 +89,7 @@ steps:
     plugins:
       - *cargo-cache
       - docker-compose#v5.5.0: *docker-compose
-    timeout_in_minutes: 15
+    timeout_in_minutes: 20
     retry: *auto-retry
 
   - label: "build other components"
@@ -706,7 +706,7 @@ steps:
     plugins:
       - *cargo-cache
       - docker-compose#v5.5.0: *docker-compose
-    timeout_in_minutes: 25
+    timeout_in_minutes: 35
     retry: *auto-retry
 
   - label: "check dylint"
@@ -730,7 +730,7 @@ steps:
     plugins:
       - *cargo-cache
       - docker-compose#v5.5.0: *docker-compose
-    timeout_in_minutes: 15
+    timeout_in_minutes: 25
     retry: *auto-retry
 
   - label: "unit test (deterministic simulation)"

--- a/ci/workflows/pull-request.yml
+++ b/ci/workflows/pull-request.yml
@@ -89,7 +89,7 @@ steps:
     plugins:
       - *cargo-cache
       - docker-compose#v5.5.0: *docker-compose
-    timeout_in_minutes: 20
+    timeout_in_minutes: 15
     retry: *auto-retry
 
   - label: "build other components"
@@ -706,7 +706,7 @@ steps:
     plugins:
       - *cargo-cache
       - docker-compose#v5.5.0: *docker-compose
-    timeout_in_minutes: 35
+    timeout_in_minutes: 25
     retry: *auto-retry
 
   - label: "check dylint"
@@ -730,7 +730,7 @@ steps:
     plugins:
       - *cargo-cache
       - docker-compose#v5.5.0: *docker-compose
-    timeout_in_minutes: 25
+    timeout_in_minutes: 15
     retry: *auto-retry
 
   - label: "unit test (deterministic simulation)"

--- a/ci/workflows/pull-request.yml
+++ b/ci/workflows/pull-request.yml
@@ -89,7 +89,7 @@ steps:
     plugins:
       - *cargo-cache
       - docker-compose#v5.5.0: *docker-compose
-    timeout_in_minutes: 15
+    timeout_in_minutes: 25
     retry: *auto-retry
 
   - label: "build other components"
@@ -706,7 +706,7 @@ steps:
     plugins:
       - *cargo-cache
       - docker-compose#v5.5.0: *docker-compose
-    timeout_in_minutes: 25
+    timeout_in_minutes: 35
     retry: *auto-retry
 
   - label: "check dylint"
@@ -730,7 +730,7 @@ steps:
     plugins:
       - *cargo-cache
       - docker-compose#v5.5.0: *docker-compose
-    timeout_in_minutes: 15
+    timeout_in_minutes: 25
     retry: *auto-retry
 
   - label: "unit test (deterministic simulation)"
@@ -741,7 +741,7 @@ steps:
       || build.env("CI_STEPS") =~ /(^|,)unit-tests?-deterministic-simulation(,|$$)/
     plugins:
       - docker-compose#v5.5.0: *docker-compose
-    timeout_in_minutes: 12
+    timeout_in_minutes: 15
     retry: *auto-retry
 
   - label: "integration test (deterministic simulation)"

--- a/e2e_test/sink/lancedb/expected_output.csv
+++ b/e2e_test/sink/lancedb/expected_output.csv
@@ -1,0 +1,5 @@
+1,Alice,95.5,true
+2,Bob,87.0,false
+3,Clare,92.3,true
+4,Dave,78.1,false
+5,Eve,99.9,true

--- a/e2e_test/sink/lancedb/lancedb_helper.py
+++ b/e2e_test/sink/lancedb/lancedb_helper.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+# Copyright 2025 RisingWave Labs
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Helper script for LanceDB e2e sink tests.
+
+Usage:
+  python3 lancedb_helper.py setup <db_uri>
+      Create the LanceDB database and "e2e_test" table with the expected schema.
+
+  python3 lancedb_helper.py verify <db_uri> <expected_count>
+      Verify row count and print all rows in CSV format for diffing.
+"""
+
+import sys
+
+import lancedb
+import pyarrow as pa
+import pyarrow.compute
+
+
+TABLE_NAME = "e2e_test"
+
+SCHEMA = pa.schema([
+    pa.field("id", pa.int32(), nullable=False),
+    pa.field("name", pa.utf8(), nullable=False),
+    pa.field("score", pa.float64(), nullable=False),
+    pa.field("flag", pa.bool_(), nullable=False),
+])
+
+
+def setup(db_uri: str):
+    """Create a LanceDB database with an empty table."""
+    db = lancedb.connect(db_uri)
+    # Create an empty table with the defined schema
+    db.create_table(TABLE_NAME, schema=SCHEMA)
+    print(f"Created LanceDB table '{TABLE_NAME}' at {db_uri}")
+
+
+def verify(db_uri: str, expected_count: int):
+    """Verify row count and print rows as CSV."""
+    db = lancedb.connect(db_uri)
+    table = db.open_table(TABLE_NAME)
+    arrow_table = table.to_arrow()
+
+    actual_count = arrow_table.num_rows
+    if actual_count != expected_count:
+        print(
+            f"ERROR: expected {expected_count} rows but found {actual_count}",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    # Sort by id for deterministic output
+    indices = pa.compute.sort_indices(arrow_table, sort_keys=[("id", "ascending")])
+    arrow_table = arrow_table.take(indices)
+
+    # Print CSV without header for easy diffing
+    for i in range(arrow_table.num_rows):
+        row_id = arrow_table.column("id")[i].as_py()
+        name = arrow_table.column("name")[i].as_py()
+        score = arrow_table.column("score")[i].as_py()
+        flag = arrow_table.column("flag")[i].as_py()
+        flag_str = "true" if flag else "false"
+        print(f"{row_id},{name},{score},{flag_str}")
+
+
+def main():
+    if len(sys.argv) < 3:
+        print(__doc__, file=sys.stderr)
+        sys.exit(1)
+
+    command = sys.argv[1]
+    db_uri = sys.argv[2]
+
+    if command == "setup":
+        setup(db_uri)
+    elif command == "verify":
+        if len(sys.argv) < 4:
+            print("Usage: lancedb_helper.py verify <db_uri> <expected_count>", file=sys.stderr)
+            sys.exit(1)
+        expected_count = int(sys.argv[3])
+        verify(db_uri, expected_count)
+    else:
+        print(f"Unknown command: {command}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/e2e_test/sink/lancedb/lancedb_sink.slt
+++ b/e2e_test/sink/lancedb/lancedb_sink.slt
@@ -1,0 +1,55 @@
+# LanceDB sink e2e test.
+#
+# Prerequisites:
+#   - A LanceDB database must exist at the path specified in `lancedb.uri`
+#     with a table named "e2e_test" and schema: id INT, name VARCHAR, score DOUBLE, flag BOOLEAN
+#   - The table can be created via: python3 e2e_test/sink/lancedb/lancedb_helper.py setup /tmp/lancedb-e2e
+
+statement ok
+set sink_decouple = false;
+
+statement ok
+CREATE TABLE t_lance (id INT PRIMARY KEY, name VARCHAR, score DOUBLE, flag BOOLEAN);
+
+statement ok
+CREATE MATERIALIZED VIEW mv_lance AS SELECT * FROM t_lance;
+
+statement ok
+CREATE SINK s_lance AS SELECT * FROM mv_lance
+WITH (
+    connector = 'lancedb',
+    type = 'append-only',
+    force_append_only = 'true',
+    lancedb.uri = '/tmp/lancedb-e2e',
+    lancedb.table = 'e2e_test'
+);
+
+statement ok
+INSERT INTO t_lance VALUES
+    (1, 'Alice', 95.5, true),
+    (2, 'Bob', 87.0, false),
+    (3, 'Clare', 92.3, true);
+
+statement ok
+FLUSH;
+
+sleep 5s
+
+statement ok
+INSERT INTO t_lance VALUES
+    (4, 'Dave', 78.1, false),
+    (5, 'Eve', 99.9, true);
+
+statement ok
+FLUSH;
+
+sleep 5s
+
+statement ok
+DROP SINK s_lance;
+
+statement ok
+DROP MATERIALIZED VIEW mv_lance;
+
+statement ok
+DROP TABLE t_lance;

--- a/e2e_test/sink/lancedb/lancedb_sink.slt
+++ b/e2e_test/sink/lancedb/lancedb_sink.slt
@@ -21,7 +21,8 @@ WITH (
     type = 'append-only',
     force_append_only = 'true',
     lancedb.uri = '/tmp/lancedb-e2e',
-    lancedb.table = 'e2e_test'
+    lancedb.table = 'e2e_test',
+    commit_checkpoint_interval = '1'
 );
 
 statement ok

--- a/src/common/src/array/arrow/arrow_lancedb.rs
+++ b/src/common/src/array/arrow/arrow_lancedb.rs
@@ -1,4 +1,4 @@
-// Copyright 2025 RisingWave Labs
+// Copyright 2026 RisingWave Labs
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/common/src/array/arrow/arrow_lancedb.rs
+++ b/src/common/src/array/arrow/arrow_lancedb.rs
@@ -1,0 +1,58 @@
+// Copyright 2025 RisingWave Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Arrow conversion for LanceDB sink.
+//!
+//! LanceDB uses arrow-57, same as the `arrow_57` module.
+//! This module re-exports the arrow-57 types and provides a `LanceDbConvert` struct
+//! with a `to_record_batch` method (same pattern as `DeltaLakeConvert`).
+
+pub use super::arrow_56::{
+    FromArrow, ToArrow, arrow_array, arrow_buffer, arrow_cast, arrow_schema,
+};
+use crate::array::{ArrayError, DataChunk};
+use crate::catalog::Schema;
+
+pub struct LanceDbConvert;
+
+impl LanceDbConvert {
+    /// Convert a RisingWave DataChunk to an Arrow RecordBatch.
+    pub fn to_record_batch(
+        &self,
+        schema: arrow_schema::SchemaRef,
+        chunk: &DataChunk,
+    ) -> Result<arrow_array::RecordBatch, ArrayError> {
+        ToArrow::to_record_batch(self, schema, chunk)
+    }
+
+    /// Convert a RisingWave Schema to an Arrow Schema.
+    pub fn rw_schema_to_arrow_schema(
+        &self,
+        rw_schema: &Schema,
+    ) -> Result<arrow_schema::Schema, ArrayError> {
+        let fields = rw_schema
+            .fields()
+            .iter()
+            .map(|f| self.to_arrow_field(&f.name, &f.data_type))
+            .collect::<Result<Vec<_>, _>>()?;
+        Ok(arrow_schema::Schema::new(fields))
+    }
+}
+
+/// Use the default ToArrow implementation (no overrides needed for LanceDB initially).
+/// DeltaLake overrides `decimal_to_arrow` because of special Inf/NaN handling.
+/// LanceDB can use the default behavior. If custom type mapping is needed later
+/// (e.g., Vector → FixedSizeList), add overrides here.
+impl ToArrow for LanceDbConvert {}
+impl FromArrow for LanceDbConvert {}

--- a/src/common/src/array/arrow/arrow_lancedb.rs
+++ b/src/common/src/array/arrow/arrow_lancedb.rs
@@ -12,13 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! Arrow conversion for LanceDB sink.
+//! Arrow conversion for `LanceDB` sink.
 //!
-//! LanceDB uses arrow-57, same as the `arrow_57` module.
-//! This module re-exports the arrow-57 types and provides a `LanceDbConvert` struct
+//! `LanceDB` uses arrow-58, same as the `arrow_58` module.
+//! This module re-exports the arrow-58 types and provides a `LanceDbConvert` struct
 //! with a `to_record_batch` method (same pattern as `DeltaLakeConvert`).
 
-pub use super::arrow_56::{
+pub use super::arrow_58::{
     FromArrow, ToArrow, arrow_array, arrow_buffer, arrow_cast, arrow_schema,
 };
 use crate::array::{ArrayError, DataChunk};
@@ -27,7 +27,7 @@ use crate::catalog::Schema;
 pub struct LanceDbConvert;
 
 impl LanceDbConvert {
-    /// Convert a RisingWave DataChunk to an Arrow RecordBatch.
+    /// Convert a RisingWave `DataChunk` to an Arrow `RecordBatch`.
     pub fn to_record_batch(
         &self,
         schema: arrow_schema::SchemaRef,
@@ -50,9 +50,9 @@ impl LanceDbConvert {
     }
 }
 
-/// Use the default ToArrow implementation (no overrides needed for LanceDB initially).
-/// DeltaLake overrides `decimal_to_arrow` because of special Inf/NaN handling.
-/// LanceDB can use the default behavior. If custom type mapping is needed later
-/// (e.g., Vector → FixedSizeList), add overrides here.
+/// Use the default `ToArrow` implementation (no overrides needed for `LanceDB` initially).
+/// `DeltaLake` overrides `decimal_to_arrow` because of special Inf/NaN handling.
+/// `LanceDB` can use the default behavior. If custom type mapping is needed later
+/// (e.g., Vector → `FixedSizeList`), add overrides here.
 impl ToArrow for LanceDbConvert {}
 impl FromArrow for LanceDbConvert {}

--- a/src/common/src/array/arrow/arrow_lancedb.rs
+++ b/src/common/src/array/arrow/arrow_lancedb.rs
@@ -1,0 +1,58 @@
+// Copyright 2025 RisingWave Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Arrow conversion for LanceDB sink.
+//!
+//! LanceDB uses arrow-58, same as the `arrow_58` module.
+//! This module re-exports the arrow-58 types and provides a `LanceDbConvert` struct
+//! with a `to_record_batch` method (same pattern as `DeltaLakeConvert`).
+
+pub use super::arrow_58::{
+    FromArrow, ToArrow, arrow_array, arrow_buffer, arrow_cast, arrow_schema,
+};
+use crate::array::{ArrayError, DataChunk};
+use crate::catalog::Schema;
+
+pub struct LanceDbConvert;
+
+impl LanceDbConvert {
+    /// Convert a RisingWave DataChunk to an Arrow RecordBatch.
+    pub fn to_record_batch(
+        &self,
+        schema: arrow_schema::SchemaRef,
+        chunk: &DataChunk,
+    ) -> Result<arrow_array::RecordBatch, ArrayError> {
+        ToArrow::to_record_batch(self, schema, chunk)
+    }
+
+    /// Convert a RisingWave Schema to an Arrow Schema.
+    pub fn rw_schema_to_arrow_schema(
+        &self,
+        rw_schema: &Schema,
+    ) -> Result<arrow_schema::Schema, ArrayError> {
+        let fields = rw_schema
+            .fields()
+            .iter()
+            .map(|f| self.to_arrow_field(&f.name, &f.data_type))
+            .collect::<Result<Vec<_>, _>>()?;
+        Ok(arrow_schema::Schema::new(fields))
+    }
+}
+
+/// Use the default ToArrow implementation (no overrides needed for LanceDB initially).
+/// DeltaLake overrides `decimal_to_arrow` because of special Inf/NaN handling.
+/// LanceDB can use the default behavior. If custom type mapping is needed later
+/// (e.g., Vector → FixedSizeList), add overrides here.
+impl ToArrow for LanceDbConvert {}
+impl FromArrow for LanceDbConvert {}

--- a/src/common/src/array/arrow/arrow_lancedb.rs
+++ b/src/common/src/array/arrow/arrow_lancedb.rs
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! Arrow conversion for LanceDB sink.
+//! Arrow conversion for `LanceDB` sink.
 //!
-//! LanceDB uses arrow-58, same as the `arrow_58` module.
+//! `LanceDB` uses arrow-58, same as the `arrow_58` module.
 //! This module re-exports the arrow-58 types and provides a `LanceDbConvert` struct
 //! with a `to_record_batch` method (same pattern as `DeltaLakeConvert`).
 
@@ -27,7 +27,7 @@ use crate::catalog::Schema;
 pub struct LanceDbConvert;
 
 impl LanceDbConvert {
-    /// Convert a RisingWave DataChunk to an Arrow RecordBatch.
+    /// Convert a RisingWave `DataChunk` to an Arrow `RecordBatch`.
     pub fn to_record_batch(
         &self,
         schema: arrow_schema::SchemaRef,
@@ -36,7 +36,7 @@ impl LanceDbConvert {
         ToArrow::to_record_batch(self, schema, chunk)
     }
 
-    /// Convert a RisingWave Schema to an Arrow Schema.
+    /// Convert a RisingWave `Schema` to an Arrow `Schema`.
     pub fn rw_schema_to_arrow_schema(
         &self,
         rw_schema: &Schema,
@@ -50,9 +50,9 @@ impl LanceDbConvert {
     }
 }
 
-/// Use the default ToArrow implementation (no overrides needed for LanceDB initially).
-/// DeltaLake overrides `decimal_to_arrow` because of special Inf/NaN handling.
-/// LanceDB can use the default behavior. If custom type mapping is needed later
-/// (e.g., Vector → FixedSizeList), add overrides here.
+/// Use the default `ToArrow` implementation (no overrides needed for `LanceDB` initially).
+/// `DeltaLake` overrides `decimal_to_arrow` because of special Inf/NaN handling.
+/// `LanceDB` can use the default behavior. If custom type mapping is needed later
+/// (e.g., `Vector` -> `FixedSizeList`), add overrides here.
 impl ToArrow for LanceDbConvert {}
 impl FromArrow for LanceDbConvert {}

--- a/src/common/src/array/arrow/mod.rs
+++ b/src/common/src/array/arrow/mod.rs
@@ -19,6 +19,7 @@ mod arrow_58;
 // These mods import mods above and may override some methods.
 mod arrow_deltalake;
 mod arrow_iceberg;
+mod arrow_lancedb;
 mod arrow_udf;
 
 pub use arrow_deltalake::DeltaLakeConvert;
@@ -26,6 +27,7 @@ pub use arrow_iceberg::{
     ICEBERG_DECIMAL_PRECISION, ICEBERG_DECIMAL_SCALE, IcebergArrowConvert,
     IcebergCreateTableArrowConvert,
 };
+pub use arrow_lancedb::LanceDbConvert;
 pub use arrow_udf::UdfArrowConvert;
 pub use reexport::*;
 /// For other RisingWave crates, they can directly use arrow re-exported here, without adding
@@ -46,6 +48,11 @@ mod reexport {
         arrow_array as arrow_array_iceberg, arrow_buffer as arrow_buffer_iceberg,
         arrow_cast as arrow_cast_iceberg, arrow_schema as arrow_schema_iceberg,
         is_parquet_schema_match_source_schema,
+    };
+    pub use super::arrow_lancedb::{
+        FromArrow as LanceDbFromArrow, ToArrow as LanceDbToArrow,
+        arrow_array as arrow_array_lancedb, arrow_buffer as arrow_buffer_lancedb,
+        arrow_cast as arrow_cast_lancedb, arrow_schema as arrow_schema_lancedb,
     };
     pub use super::arrow_udf::{
         FromArrow as UdfFromArrow, ToArrow as UdfToArrow, arrow_array as arrow_array_udf,

--- a/src/common/src/array/arrow/mod.rs
+++ b/src/common/src/array/arrow/mod.rs
@@ -19,6 +19,7 @@ mod arrow_58;
 // These mods import mods above and may override some methods.
 mod arrow_deltalake;
 mod arrow_iceberg;
+mod arrow_lancedb;
 mod arrow_udf;
 
 pub use arrow_deltalake::DeltaLakeConvert;
@@ -26,6 +27,7 @@ pub use arrow_iceberg::{
     ICEBERG_DECIMAL_PRECISION, ICEBERG_DECIMAL_SCALE, IcebergArrowConvert,
     IcebergCreateTableArrowConvert,
 };
+pub use arrow_lancedb::LanceDbConvert;
 pub use arrow_udf::UdfArrowConvert;
 pub use reexport::*;
 /// For other RisingWave crates, they can directly use arrow re-exported here, without adding
@@ -46,6 +48,11 @@ mod reexport {
         arrow_array as arrow_array_iceberg, arrow_buffer as arrow_buffer_iceberg,
         arrow_cast as arrow_cast_iceberg, arrow_schema as arrow_schema_iceberg,
         is_parquet_field_match_source_schema, is_parquet_schema_match_source_schema,
+    };
+    pub use super::arrow_lancedb::{
+        FromArrow as LanceDbFromArrow, ToArrow as LanceDbToArrow,
+        arrow_array as arrow_array_lancedb, arrow_buffer as arrow_buffer_lancedb,
+        arrow_cast as arrow_cast_lancedb, arrow_schema as arrow_schema_lancedb,
     };
     pub use super::arrow_udf::{
         FromArrow as UdfFromArrow, ToArrow as UdfToArrow, arrow_array as arrow_array_udf,

--- a/src/connector/Cargo.toml
+++ b/src/connector/Cargo.toml
@@ -19,6 +19,7 @@ all-sinks = [
     "sink-google_pubsub",
     "sink-clickhouse",
     "sink-doris",
+    "sink-lancedb",
     "sink-starrocks",
 ]
 all-sources = ["source-adbc_snowflake"]
@@ -29,6 +30,7 @@ sink-bigquery = [
     "dep:google-cloud-googleapis",
 ]
 sink-deltalake = ["dep:deltalake"]
+sink-lancedb = ["dep:lancedb", "dep:lance", "dep:lance-table"]
 # TODO: pubsub source is not feature-gated, thus `google-cloud-pubsub` cannot be optional.
 sink-google_pubsub = ["dep:google-cloud-googleapis"]
 sink-clickhouse = ["dep:clickhouse"]
@@ -96,6 +98,9 @@ iceberg-catalog-rest = { workspace = true }
 indexmap = { workspace = true }
 itertools = { workspace = true }
 jni = { workspace = true }
+lance = { workspace = true, optional = true }
+lance-table = { workspace = true, optional = true }
+lancedb = { workspace = true, optional = true }
 maplit = "1.0.2"
 moka = { version = "0.12.10", features = ["future"] }
 mongodb = "3.5.1"
@@ -215,6 +220,9 @@ criterion = { workspace = true, features = ["async_tokio", "async"] }
 deltalake = { workspace = true }
 expect-test = "1"
 fs-err = "3"
+lance = { workspace = true }
+lance-table = { workspace = true }
+lancedb = { workspace = true }
 paste = "1"
 pretty_assertions = "1"
 proc-macro2 = "1.0"

--- a/src/connector/Cargo.toml
+++ b/src/connector/Cargo.toml
@@ -19,6 +19,7 @@ all-sinks = [
     "sink-google_pubsub",
     "sink-clickhouse",
     "sink-doris",
+    "sink-lancedb",
     "sink-starrocks",
 ]
 all-sources = ["source-adbc_snowflake"]
@@ -29,6 +30,7 @@ sink-bigquery = [
     "dep:google-cloud-googleapis",
 ]
 sink-deltalake = ["dep:deltalake"]
+sink-lancedb = ["dep:lancedb", "dep:lance", "dep:lance-table"]
 # TODO: pubsub source is not feature-gated, thus `google-cloud-pubsub` cannot be optional.
 sink-google_pubsub = ["dep:google-cloud-googleapis"]
 sink-clickhouse = ["dep:clickhouse"]
@@ -96,6 +98,9 @@ iceberg-storage-opendal = { workspace = true }
 indexmap = { workspace = true }
 itertools = { workspace = true }
 jni = { workspace = true }
+lance = { workspace = true, optional = true }
+lance-table = { workspace = true, optional = true }
+lancedb = { workspace = true, optional = true }
 maplit = "1.0.2"
 moka = { version = "0.12.10", features = ["future"] }
 mongodb = "3.5.1"
@@ -220,6 +225,9 @@ criterion = { workspace = true, features = ["async_tokio", "async"] }
 deltalake = { workspace = true }
 expect-test = "1"
 fs-err = "3"
+lance = { workspace = true }
+lance-table = { workspace = true }
+lancedb = { workspace = true }
 paste = "1"
 pretty_assertions = "1"
 proc-macro2 = "1.0"

--- a/src/connector/src/allow_alter_on_fly_fields.rs
+++ b/src/connector/src/allow_alter_on_fly_fields.rs
@@ -276,6 +276,13 @@ pub static SINK_ALLOW_ALTER_ON_FLY_FIELDS: LazyLock<HashMap<String, HashSet<Stri
             "properties.request.required.acks".to_owned(),
         ].into_iter().collect(),
     ).unwrap();
+    // LanceDbConfig
+    map.try_insert(
+        std::any::type_name::<LanceDbConfig>().to_owned(),
+        [
+            "commit_checkpoint_interval".to_owned(),
+        ].into_iter().collect(),
+    ).unwrap();
     // SnowflakeV2Config
     map.try_insert(
         std::any::type_name::<SnowflakeV2Config>().to_owned(),

--- a/src/connector/src/allow_alter_on_fly_fields.rs
+++ b/src/connector/src/allow_alter_on_fly_fields.rs
@@ -353,6 +353,13 @@ pub static SINK_ALLOW_ALTER_ON_FLY_FIELDS: LazyLock<HashMap<String, HashSet<Stri
             "pulsar.properties.routing_mode".to_owned(),
         ].into_iter().collect(),
     ).unwrap();
+    // LanceDbConfig
+    map.try_insert(
+        std::any::type_name::<LanceDbConfig>().to_owned(),
+        [
+            "commit_checkpoint_interval".to_owned(),
+        ].into_iter().collect(),
+    ).unwrap();
     // SnowflakeV2Config
     map.try_insert(
         std::any::type_name::<SnowflakeV2Config>().to_owned(),

--- a/src/connector/src/allow_alter_on_fly_fields.rs
+++ b/src/connector/src/allow_alter_on_fly_fields.rs
@@ -331,6 +331,13 @@ pub static SINK_ALLOW_ALTER_ON_FLY_FIELDS: LazyLock<HashMap<String, HashSet<Stri
             "properties.request.required.acks".to_owned(),
         ].into_iter().collect(),
     ).unwrap();
+    // LanceDbConfig
+    map.try_insert(
+        std::any::type_name::<LanceDbConfig>().to_owned(),
+        [
+            "commit_checkpoint_interval".to_owned(),
+        ].into_iter().collect(),
+    ).unwrap();
     // OpenSearchConfig
     map.try_insert(
         std::any::type_name::<OpenSearchConfig>().to_owned(),
@@ -351,13 +358,6 @@ pub static SINK_ALLOW_ALTER_ON_FLY_FIELDS: LazyLock<HashMap<String, HashSet<Stri
             "pulsar.routing.mode".to_owned(),
             "pulsar.properties.routing.mode".to_owned(),
             "pulsar.properties.routing_mode".to_owned(),
-        ].into_iter().collect(),
-    ).unwrap();
-    // LanceDbConfig
-    map.try_insert(
-        std::any::type_name::<LanceDbConfig>().to_owned(),
-        [
-            "commit_checkpoint_interval".to_owned(),
         ].into_iter().collect(),
     ).unwrap();
     // SnowflakeV2Config

--- a/src/connector/src/sink/deltalake.rs
+++ b/src/connector/src/sink/deltalake.rs
@@ -379,6 +379,17 @@ impl Sink for DeltaLakeSink {
 
     crate::impl_validate_sink_unknown_fields!();
 
+    fn is_exactly_once(properties: &BTreeMap<String, String>) -> Result<bool> {
+        let Some(value) = properties.get("is_exactly_once") else {
+            return Ok(false);
+        };
+        value.parse::<bool>().map_err(|_| {
+            SinkError::Config(anyhow!(
+                "invalid value for `is_exactly_once`: expected `true` or `false`, got `{value}`"
+            ))
+        })
+    }
+
     async fn new_log_sinker(&self, writer_param: SinkWriterParam) -> Result<Self::LogSinker> {
         let inner = DeltaLakeSinkWriter::new(
             self.config.clone(),
@@ -468,7 +479,7 @@ impl Sink for DeltaLakeSink {
         let coordinator = DeltaLakeSinkCommitter {
             table: self.config.common.create_deltalake_client().await?,
             app_id: format!("risingwave-deltalake-{}", self.param.sink_id),
-            exactly_once: self.config.is_exactly_once.unwrap_or_default(),
+            exactly_once: Self::is_exactly_once(&self.param.properties)?,
         };
         if coordinator.exactly_once {
             Ok(SinkCommitCoordinator::TwoPhase(Box::new(coordinator)))

--- a/src/connector/src/sink/iceberg/mod.rs
+++ b/src/connector/src/sink/iceberg/mod.rs
@@ -213,6 +213,17 @@ impl Sink for IcebergSink {
 
     crate::impl_validate_sink_unknown_fields!();
 
+    fn is_exactly_once(properties: &BTreeMap<String, String>) -> Result<bool> {
+        let Some(value) = properties.get("is_exactly_once") else {
+            return Ok(true);
+        };
+        value.parse::<bool>().map_err(|_| {
+            SinkError::Config(anyhow!(
+                "invalid value for `is_exactly_once`: expected `true` or `false`, got `{value}`"
+            ))
+        })
+    }
+
     async fn validate(&self) -> Result<()> {
         let catalog_kind = self.config.catalog_kind()?;
         if matches!(catalog_kind, IcebergCatalogKind::Snowflake) {
@@ -406,7 +417,7 @@ impl Sink for IcebergSink {
             commit_retry_num: self.config.commit_retry_num,
             iceberg_compact_stat_sender,
         };
-        if self.config.is_exactly_once.unwrap_or_default() {
+        if Self::is_exactly_once(&self.param.properties)? {
             Ok(SinkCommitCoordinator::TwoPhase(Box::new(coordinator)))
         } else {
             Ok(SinkCommitCoordinator::SinglePhase(Box::new(coordinator)))

--- a/src/connector/src/sink/lancedb.rs
+++ b/src/connector/src/sink/lancedb.rs
@@ -1,4 +1,4 @@
-// Copyright 2025 RisingWave Labs
+// Copyright 2026 RisingWave Labs
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/connector/src/sink/lancedb.rs
+++ b/src/connector/src/sink/lancedb.rs
@@ -1,0 +1,596 @@
+// Copyright 2025 RisingWave Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use core::num::NonZeroU64;
+use std::collections::BTreeMap;
+use std::sync::Arc;
+
+use anyhow::{Context, anyhow};
+use async_trait::async_trait;
+use lance::dataset::fragment::FileFragment;
+use lance::dataset::transaction::Operation;
+use lance::Dataset;
+use lance_table::format::Fragment;
+use lancedb::Connection as LanceDbConnection;
+use lancedb::connection::ConnectBuilder;
+use risingwave_common::array::StreamChunk;
+use risingwave_common::array::arrow::LanceDbConvert;
+use risingwave_common::catalog::Schema;
+use risingwave_pb::connector_service::SinkMetadata;
+use risingwave_pb::connector_service::sink_metadata::Metadata::Serialized;
+use risingwave_pb::connector_service::sink_metadata::SerializedMetadata;
+use serde::Deserialize;
+use serde_with::{DisplayFromStr, serde_as};
+use tokio::sync::mpsc::UnboundedSender;
+use with_options::WithOptions;
+
+use crate::connector_common::IcebergSinkCompactionUpdate;
+use crate::enforce_secret::EnforceSecret;
+use crate::sink::coordinate::CoordinatedLogSinker;
+use crate::sink::decouple_checkpoint_log_sink::default_commit_checkpoint_interval;
+use crate::sink::writer::SinkWriter;
+use crate::sink::{
+    Result, SINK_TYPE_APPEND_ONLY, SINK_USER_FORCE_APPEND_ONLY_OPTION,
+    SinglePhaseCommitCoordinator, Sink, SinkCommitCoordinator, SinkError, SinkParam,
+    SinkWriterParam,
+};
+
+pub const LANCEDB_SINK: &str = "lancedb";
+
+// ---------------------------------------------------------------------------
+// Config
+// ---------------------------------------------------------------------------
+
+#[serde_as]
+#[derive(Deserialize, Debug, Clone, WithOptions)]
+pub struct LanceDbCommon {
+    /// URI of the LanceDB database (e.g., "/tmp/lancedb", "s3://bucket/path/db")
+    #[serde(rename = "lancedb.uri")]
+    pub uri: String,
+
+    /// Table name in the LanceDB database
+    #[serde(rename = "lancedb.table")]
+    pub table: String,
+
+    /// Commit every n(>0) checkpoints, default is 10.
+    #[serde(default = "default_commit_checkpoint_interval")]
+    #[serde_as(as = "DisplayFromStr")]
+    #[with_option(allow_alter_on_fly)]
+    pub commit_checkpoint_interval: u64,
+}
+
+impl LanceDbCommon {
+    pub async fn create_connection(&self) -> Result<LanceDbConnection> {
+        let conn = ConnectBuilder::new(&self.uri)
+            .execute()
+            .await
+            .context("failed to connect to LanceDB")
+            .map_err(SinkError::LanceDb)?;
+        Ok(conn)
+    }
+
+    /// Get the lance Dataset URI for the table.
+    /// LanceDB stores each table as a lance dataset at `{db_uri}/{table_name}.lance`.
+    pub fn dataset_uri(&self) -> String {
+        format!("{}/{}.lance", self.uri.trim_end_matches('/'), self.table)
+    }
+}
+
+#[serde_as]
+#[derive(Clone, Debug, Deserialize, WithOptions)]
+pub struct LanceDbConfig {
+    #[serde(flatten)]
+    pub common: LanceDbCommon,
+
+    pub r#type: String,
+}
+
+impl LanceDbConfig {
+    pub fn from_btreemap(properties: BTreeMap<String, String>) -> Result<Self> {
+        let config = serde_json::from_value::<LanceDbConfig>(
+            serde_json::to_value(properties).map_err(|e| SinkError::LanceDb(e.into()))?,
+        )
+        .map_err(|e| SinkError::Config(anyhow!(e)))?;
+        Ok(config)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Sink
+// ---------------------------------------------------------------------------
+
+#[derive(Debug)]
+pub struct LanceDbSink {
+    pub config: LanceDbConfig,
+    param: SinkParam,
+}
+
+impl EnforceSecret for LanceDbSink {
+    fn enforce_secret<'a>(
+        _prop_iter: impl Iterator<Item = &'a str>,
+    ) -> crate::error::ConnectorResult<()> {
+        // LanceDB currently has no secret properties.
+        Ok(())
+    }
+}
+
+impl LanceDbSink {
+    pub fn new(config: LanceDbConfig, param: SinkParam) -> Result<Self> {
+        Ok(Self { config, param })
+    }
+}
+
+impl Sink for LanceDbSink {
+    type LogSinker = CoordinatedLogSinker<LanceDbSinkWriter>;
+
+    const SINK_NAME: &'static str = LANCEDB_SINK;
+
+    async fn new_log_sinker(&self, writer_param: SinkWriterParam) -> Result<Self::LogSinker> {
+        let inner =
+            LanceDbSinkWriter::new(self.config.clone(), self.param.schema().clone()).await?;
+
+        let commit_checkpoint_interval =
+            NonZeroU64::new(self.config.common.commit_checkpoint_interval).expect(
+                "commit_checkpoint_interval should be greater than 0, and it should be checked in config validation",
+            );
+
+        let writer = CoordinatedLogSinker::new(
+            &writer_param,
+            self.param.clone(),
+            inner,
+            commit_checkpoint_interval,
+        )
+        .await?;
+
+        Ok(writer)
+    }
+
+    fn validate_alter_config(config: &BTreeMap<String, String>) -> Result<()> {
+        LanceDbConfig::from_btreemap(config.clone())?;
+        Ok(())
+    }
+
+    async fn validate(&self) -> Result<()> {
+        // Only append-only is supported
+        if self.config.r#type != SINK_TYPE_APPEND_ONLY
+            && self.config.r#type != SINK_USER_FORCE_APPEND_ONLY_OPTION
+        {
+            return Err(SinkError::Config(anyhow!(
+                "only append-only LanceDB sink is supported",
+            )));
+        }
+
+        if self.config.common.commit_checkpoint_interval == 0 {
+            return Err(SinkError::Config(anyhow!(
+                "`commit_checkpoint_interval` must be greater than 0"
+            )));
+        }
+
+        // Validate connection
+        let conn = self.config.common.create_connection().await?;
+
+        // Validate table exists and schema is compatible
+        let table = conn
+            .open_table(&self.config.common.table)
+            .execute()
+            .await
+            .context("failed to open LanceDB table")
+            .map_err(SinkError::LanceDb)?;
+
+        // Get the Lance table schema (Arrow schema)
+        let lance_schema = table
+            .schema()
+            .await
+            .context("failed to get LanceDB table schema")
+            .map_err(SinkError::LanceDb)?;
+
+        // Convert RW schema to arrow schema and compare
+        let rw_schema = self.param.schema();
+        let rw_arrow_schema = LanceDbConvert
+            .rw_schema_to_arrow_schema(&rw_schema)
+            .map_err(|e| SinkError::LanceDb(anyhow!(e)))?;
+
+        // Check field count matches
+        if rw_arrow_schema.fields().len() != lance_schema.fields().len() {
+            return Err(SinkError::LanceDb(anyhow!(
+                "Columns mismatch. RisingWave schema has {} fields, LanceDB table has {} fields",
+                rw_arrow_schema.fields().len(),
+                lance_schema.fields().len()
+            )));
+        }
+
+        // Check each field name exists and type is compatible
+        for rw_field in rw_arrow_schema.fields() {
+            match lance_schema.field_with_name(rw_field.name()) {
+                Ok(lance_field) => {
+                    if rw_field.data_type() != lance_field.data_type() {
+                        return Err(SinkError::LanceDb(anyhow!(
+                            "column '{}' type mismatch: LanceDB type is {:?}, RisingWave type is {:?}",
+                            rw_field.name(),
+                            lance_field.data_type(),
+                            rw_field.data_type()
+                        )));
+                    }
+                }
+                Err(_) => {
+                    return Err(SinkError::LanceDb(anyhow!(
+                        "column '{}' not found in LanceDB table",
+                        rw_field.name()
+                    )));
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    fn is_coordinated_sink(&self) -> bool {
+        true
+    }
+
+    async fn new_coordinator(
+        &self,
+        _iceberg_compact_stat_sender: Option<UnboundedSender<IcebergSinkCompactionUpdate>>,
+    ) -> Result<SinkCommitCoordinator> {
+        let committer = LanceDbSinkCommitter::new(self.config.clone()).await?;
+        Ok(SinkCommitCoordinator::SinglePhase(Box::new(committer)))
+    }
+}
+
+impl TryFrom<SinkParam> for LanceDbSink {
+    type Error = SinkError;
+
+    fn try_from(param: SinkParam) -> std::result::Result<Self, Self::Error> {
+        let config = LanceDbConfig::from_btreemap(param.properties.clone())?;
+        LanceDbSink::new(config, param)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Writer
+// ---------------------------------------------------------------------------
+
+// Re-export arrow types from the LanceDb arrow module so they're used consistently.
+use risingwave_common::array::arrow::arrow_array_lancedb as arrow_array;
+use risingwave_common::array::arrow::arrow_schema_lancedb as arrow_schema;
+
+/// The writer writes data files directly to the Lance dataset storage using the
+/// low-level `FileFragment::create_fragments()` API. On checkpoint, it returns
+/// lightweight `Fragment` metadata (file paths + row counts) instead of the
+/// actual data payload. The coordinator then commits these fragments atomically
+/// via `Dataset::commit()`.
+///
+/// This follows the same pattern as the Iceberg sink, where writers handle I/O
+/// and the coordinator only performs a metadata-only commit.
+pub struct LanceDbSinkWriter {
+    pub config: LanceDbConfig,
+    #[expect(dead_code)]
+    schema: Schema,
+    arrow_schema: Arc<arrow_schema::Schema>,
+    /// Dataset URI for the target Lance table (e.g., "/tmp/lancedb/my_table.lance")
+    dataset_uri: String,
+    /// Buffered record batches for the current epoch
+    batches: Vec<arrow_array::RecordBatch>,
+}
+
+impl LanceDbSinkWriter {
+    pub async fn new(config: LanceDbConfig, schema: Schema) -> Result<Self> {
+        let arrow_schema = LanceDbConvert
+            .rw_schema_to_arrow_schema(&schema)
+            .map_err(|e| SinkError::LanceDb(anyhow!(e)))?;
+
+        let dataset_uri = config.common.dataset_uri();
+
+        Ok(Self {
+            config,
+            schema,
+            arrow_schema: Arc::new(arrow_schema),
+            dataset_uri,
+            batches: Vec::new(),
+        })
+    }
+
+    /// Flush buffered batches by writing them as lance data files directly to storage.
+    /// Returns a list of `Fragment` metadata describing the written files.
+    async fn flush_to_fragments(&mut self) -> Result<Vec<Fragment>> {
+        if self.batches.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        let batches = std::mem::take(&mut self.batches);
+        let schema = batches[0].schema();
+        let reader =
+            arrow_array::RecordBatchIterator::new(batches.into_iter().map(Ok), schema);
+
+        let fragments = FileFragment::create_fragments(
+            &self.dataset_uri,
+            reader,
+            None, // default WriteParams
+        )
+        .await
+        .context("failed to write lance data files")
+        .map_err(SinkError::LanceDb)?;
+
+        Ok(fragments)
+    }
+}
+
+#[async_trait]
+impl SinkWriter for LanceDbSinkWriter {
+    type CommitMetadata = Option<SinkMetadata>;
+
+    async fn write_batch(&mut self, chunk: StreamChunk) -> Result<()> {
+        let record_batch = LanceDbConvert
+            .to_record_batch(self.arrow_schema.clone(), &chunk)
+            .context("failed to convert DataChunk to RecordBatch for LanceDB")
+            .map_err(SinkError::LanceDb)?;
+        self.batches.push(record_batch);
+        Ok(())
+    }
+
+    async fn begin_epoch(&mut self, _epoch: u64) -> Result<()> {
+        Ok(())
+    }
+
+    async fn abort(&mut self) -> Result<()> {
+        self.batches.clear();
+        Ok(())
+    }
+
+    async fn barrier(&mut self, is_checkpoint: bool) -> Result<Option<SinkMetadata>> {
+        if !is_checkpoint {
+            return Ok(None);
+        }
+
+        if self.batches.is_empty() {
+            return Ok(None);
+        }
+
+        // Write data files directly to storage and get fragment metadata.
+        let fragments = self.flush_to_fragments().await?;
+
+        if fragments.is_empty() {
+            return Ok(None);
+        }
+
+        // Serialize fragment metadata as JSON — this is lightweight (file paths + row counts).
+        let metadata = serde_json::to_vec(&fragments)
+            .context("failed to serialize fragment metadata")
+            .map_err(SinkError::LanceDb)?;
+
+        Ok(Some(SinkMetadata {
+            metadata: Some(Serialized(SerializedMetadata { metadata })),
+        }))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Committer (Coordinator)
+// ---------------------------------------------------------------------------
+
+/// The coordinator collects lightweight `Fragment` metadata from all writers
+/// and commits them atomically via `Dataset::commit(Operation::Append { fragments })`.
+/// No data payload flows through the coordinator — only file-level metadata.
+pub struct LanceDbSinkCommitter {
+    config: LanceDbConfig,
+    conn: LanceDbConnection,
+}
+
+impl LanceDbSinkCommitter {
+    pub async fn new(config: LanceDbConfig) -> Result<Self> {
+        let conn = config.common.create_connection().await?;
+        Ok(Self { config, conn })
+    }
+}
+
+#[async_trait::async_trait]
+impl SinglePhaseCommitCoordinator for LanceDbSinkCommitter {
+    async fn init(&mut self) -> Result<()> {
+        tracing::info!(
+            "LanceDB commit coordinator initialized for table '{}'",
+            self.config.common.table
+        );
+        Ok(())
+    }
+
+    async fn commit_data(&mut self, epoch: u64, metadata: Vec<SinkMetadata>) -> Result<()> {
+        tracing::debug!("Starting LanceDB commit in epoch {epoch}.");
+
+        // Collect all Fragment metadata from all writers.
+        let mut all_fragments: Vec<Fragment> = Vec::new();
+        for meta in &metadata {
+            if let Some(Serialized(s)) = &meta.metadata {
+                let fragments: Vec<Fragment> = serde_json::from_slice(&s.metadata)
+                    .context("failed to deserialize fragment metadata")
+                    .map_err(SinkError::LanceDb)?;
+                all_fragments.extend(fragments);
+            }
+        }
+
+        if all_fragments.is_empty() {
+            tracing::debug!("No fragments to commit in epoch {epoch}, skipping.");
+            return Ok(());
+        }
+
+        // Open the table to get the underlying lance Dataset.
+        let table = self
+            .conn
+            .open_table(&self.config.common.table)
+            .execute()
+            .await
+            .context("failed to open LanceDB table for commit")
+            .map_err(SinkError::LanceDb)?;
+
+        let dataset_wrapper = table.dataset().ok_or_else(|| {
+            SinkError::LanceDb(anyhow!(
+                "failed to get underlying lance Dataset (table may be remote)"
+            ))
+        })?;
+
+        let dataset_guard = dataset_wrapper
+            .get()
+            .await
+            .map_err(|e| SinkError::LanceDb(anyhow!(e)))?;
+
+        let read_version = dataset_guard.version().version;
+        let session = dataset_guard.session();
+
+        // Drop the read guard before commit to avoid holding the lock.
+        drop(dataset_guard);
+
+        // Commit fragments via low-level Dataset::commit with Operation::Append.
+        // This is a metadata-only operation — the data files were already written by workers.
+        let operation = Operation::Append {
+            fragments: all_fragments,
+        };
+
+        let dataset_uri = self.config.common.dataset_uri();
+
+        let new_dataset = Dataset::commit(
+            &dataset_uri as &str,
+            operation,
+            Some(read_version),
+            None, // store_params
+            None, // commit_handler
+            session,
+            false, // enable_v2_manifest_paths
+        )
+        .await
+        .context("failed to commit fragments to lance dataset")
+        .map_err(SinkError::LanceDb)?;
+
+        // Update the lancedb Table's internal dataset to the new version.
+        dataset_wrapper.set_latest(new_dataset).await;
+
+        tracing::debug!(
+            "Succeeded to commit fragments to LanceDB table in epoch {epoch}."
+        );
+        Ok(())
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Error conversion
+// ---------------------------------------------------------------------------
+
+impl From<lancedb::Error> for SinkError {
+    fn from(value: lancedb::Error) -> Self {
+        SinkError::LanceDb(anyhow!(value))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(all(test, not(madsim)))]
+mod tests {
+    use risingwave_common::array::{Array, I32Array, Op, StreamChunk, Utf8Array};
+    use risingwave_common::catalog::{Field, Schema};
+    use risingwave_common::types::DataType;
+
+    use super::*;
+    use crate::sink::SinglePhaseCommitCoordinator;
+    use crate::sink::writer::SinkWriter;
+
+    #[tokio::test]
+    async fn test_lancedb_sink_roundtrip() {
+        // 1. Create a temp directory for LanceDB
+        let dir = tempfile::tempdir().unwrap();
+        let uri = dir.path().to_str().unwrap();
+
+        // 2. Create a LanceDB table with a schema
+        let conn = lancedb::connect(uri).execute().await.unwrap();
+
+        // Create initial data to define the table schema
+        let arrow_schema = Arc::new(arrow_schema::Schema::new(vec![
+            arrow_schema::Field::new("id", arrow_schema::DataType::Int32, false),
+            arrow_schema::Field::new("name", arrow_schema::DataType::Utf8, false),
+        ]));
+        let id_array = arrow_array::Int32Array::from(vec![0i32]);
+        let name_array = arrow_array::StringArray::from(vec!["init"]);
+        let init_batch = arrow_array::RecordBatch::try_new(
+            arrow_schema.clone(),
+            vec![Arc::new(id_array), Arc::new(name_array)],
+        )
+        .unwrap();
+        let reader =
+            arrow_array::RecordBatchIterator::new(vec![Ok(init_batch)], arrow_schema.clone());
+        conn.create_table("test_table", reader)
+            .execute()
+            .await
+            .unwrap();
+
+        // 3. Create a LanceDB sink writer
+        let properties: BTreeMap<String, String> = [
+            ("connector".to_owned(), "lancedb".to_owned()),
+            ("type".to_owned(), "append-only".to_owned()),
+            ("lancedb.uri".to_owned(), uri.to_owned()),
+            ("lancedb.table".to_owned(), "test_table".to_owned()),
+        ]
+        .into();
+
+        let schema = Schema::new(vec![
+            Field {
+                data_type: DataType::Int32,
+                name: "id".into(),
+            },
+            Field {
+                data_type: DataType::Varchar,
+                name: "name".into(),
+            },
+        ]);
+
+        let config = LanceDbConfig::from_btreemap(properties).unwrap();
+        let mut writer = LanceDbSinkWriter::new(config.clone(), schema).await.unwrap();
+
+        // 4. Write a chunk
+        let chunk = StreamChunk::new(
+            vec![Op::Insert, Op::Insert, Op::Insert],
+            vec![
+                I32Array::from_iter(vec![1, 2, 3]).into_ref(),
+                Utf8Array::from_iter(vec!["Alice", "Bob", "Clare"]).into_ref(),
+            ],
+        );
+        writer.write_batch(chunk).await.unwrap();
+
+        // 5. Barrier → get SinkMetadata (lightweight fragment metadata, not data payload)
+        let metadata = writer.barrier(true).await.unwrap().unwrap();
+
+        // Verify the metadata is lightweight JSON (not Arrow IPC payload)
+        if let Some(Serialized(s)) = &metadata.metadata {
+            let fragments: Vec<Fragment> = serde_json::from_slice(&s.metadata).unwrap();
+            assert!(!fragments.is_empty(), "should have at least one fragment");
+            // Fragment metadata should be much smaller than actual data
+            assert!(
+                s.metadata.len() < 4096,
+                "fragment metadata should be lightweight, got {} bytes",
+                s.metadata.len()
+            );
+        } else {
+            panic!("expected serialized metadata");
+        }
+
+        // 6. Commit via coordinator (metadata-only commit)
+        let mut committer = LanceDbSinkCommitter::new(config).await.unwrap();
+        committer.init().await.unwrap();
+        committer.commit_data(1, vec![metadata]).await.unwrap();
+
+        // 7. Verify data was written by reading back
+        let table = conn.open_table("test_table").execute().await.unwrap();
+        let count = table.count_rows(None).await.unwrap();
+        // 1 initial row + 3 new rows = 4
+        assert_eq!(count, 4);
+    }
+}

--- a/src/connector/src/sink/lancedb.rs
+++ b/src/connector/src/sink/lancedb.rs
@@ -13,13 +13,14 @@
 // limitations under the License.
 
 use core::num::NonZeroU64;
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashMap};
 use std::sync::Arc;
 
 use anyhow::{Context, anyhow};
 use async_trait::async_trait;
+use lance::dataset::CommitBuilder;
 use lance::dataset::fragment::FileFragment;
-use lance::dataset::transaction::Operation;
+use lance::dataset::transaction::{Operation, TransactionBuilder};
 use lance::Dataset;
 use lance_table::format::Fragment;
 use lancedb::Connection as LanceDbConnection;
@@ -30,7 +31,8 @@ use risingwave_common::catalog::Schema;
 use risingwave_pb::connector_service::SinkMetadata;
 use risingwave_pb::connector_service::sink_metadata::Metadata::Serialized;
 use risingwave_pb::connector_service::sink_metadata::SerializedMetadata;
-use serde::Deserialize;
+use risingwave_pb::stream_plan::PbSinkSchemaChange;
+use serde::{Deserialize, Serialize};
 use serde_with::{DisplayFromStr, serde_as};
 use tokio::sync::mpsc::UnboundedSender;
 use with_options::WithOptions;
@@ -43,10 +45,13 @@ use crate::sink::writer::SinkWriter;
 use crate::sink::{
     Result, SINK_TYPE_APPEND_ONLY, SINK_USER_FORCE_APPEND_ONLY_OPTION,
     SinglePhaseCommitCoordinator, Sink, SinkCommitCoordinator, SinkError, SinkParam,
-    SinkWriterParam,
+    SinkWriterParam, TwoPhaseCommitCoordinator,
 };
 
 pub const LANCEDB_SINK: &str = "lancedb";
+
+const RW_SINK_ID_TRANSACTION_PROPERTY: &str = "risingwave.sink_id";
+const RW_EPOCH_TRANSACTION_PROPERTY: &str = "risingwave.epoch";
 
 // ---------------------------------------------------------------------------
 // Config
@@ -55,11 +60,11 @@ pub const LANCEDB_SINK: &str = "lancedb";
 #[serde_as]
 #[derive(Deserialize, Debug, Clone, WithOptions)]
 pub struct LanceDbCommon {
-    /// URI of the LanceDB database (e.g., "/tmp/lancedb", "s3://bucket/path/db")
+    /// URI of the `LanceDB` database (e.g., `/tmp/lancedb`, `<s3://bucket/path/db>`)
     #[serde(rename = "lancedb.uri")]
     pub uri: String,
 
-    /// Table name in the LanceDB database
+    /// Table name in the `LanceDB` database
     #[serde(rename = "lancedb.table")]
     pub table: String,
 
@@ -81,7 +86,7 @@ impl LanceDbCommon {
     }
 
     /// Get the lance Dataset URI for the table.
-    /// LanceDB stores each table as a lance dataset at `{db_uri}/{table_name}.lance`.
+    /// `LanceDB` stores each table as a Lance dataset at `{db_uri}/{table_name}.lance`.
     pub fn dataset_uri(&self) -> String {
         format!("{}/{}.lance", self.uri.trim_end_matches('/'), self.table)
     }
@@ -94,6 +99,11 @@ pub struct LanceDbConfig {
     pub common: LanceDbCommon,
 
     pub r#type: String,
+
+    /// Whether to use RisingWave's two-phase commit framework for exactly-once commits.
+    /// Defaults to true. Set to false to use single-phase commits.
+    #[serde_as(as = "Option<DisplayFromStr>")]
+    pub is_exactly_once: Option<bool>,
 }
 
 impl LanceDbConfig {
@@ -137,8 +147,7 @@ impl Sink for LanceDbSink {
     const SINK_NAME: &'static str = LANCEDB_SINK;
 
     async fn new_log_sinker(&self, writer_param: SinkWriterParam) -> Result<Self::LogSinker> {
-        let inner =
-            LanceDbSinkWriter::new(self.config.clone(), self.param.schema().clone()).await?;
+        let inner = LanceDbSinkWriter::new(self.config.clone(), self.param.schema())?;
 
         let commit_checkpoint_interval =
             NonZeroU64::new(self.config.common.commit_checkpoint_interval).expect(
@@ -243,8 +252,13 @@ impl Sink for LanceDbSink {
         &self,
         _iceberg_compact_stat_sender: Option<UnboundedSender<IcebergSinkCompactionUpdate>>,
     ) -> Result<SinkCommitCoordinator> {
-        let committer = LanceDbSinkCommitter::new(self.config.clone()).await?;
-        Ok(SinkCommitCoordinator::SinglePhase(Box::new(committer)))
+        let committer =
+            LanceDbSinkCommitter::new(self.config.clone(), self.param.sink_id.to_string()).await?;
+        if self.config.is_exactly_once.unwrap_or(true) {
+            Ok(SinkCommitCoordinator::TwoPhase(Box::new(committer)))
+        } else {
+            Ok(SinkCommitCoordinator::SinglePhase(Box::new(committer)))
+        }
     }
 }
 
@@ -268,8 +282,7 @@ use risingwave_common::array::arrow::arrow_schema_lancedb as arrow_schema;
 /// The writer writes data files directly to the Lance dataset storage using the
 /// low-level `FileFragment::create_fragments()` API. On checkpoint, it returns
 /// lightweight `Fragment` metadata (file paths + row counts) instead of the
-/// actual data payload. The coordinator then commits these fragments atomically
-/// via `Dataset::commit()`.
+/// actual data payload. The coordinator then commits these fragments atomically.
 ///
 /// This follows the same pattern as the Iceberg sink, where writers handle I/O
 /// and the coordinator only performs a metadata-only commit.
@@ -278,14 +291,14 @@ pub struct LanceDbSinkWriter {
     #[expect(dead_code)]
     schema: Schema,
     arrow_schema: Arc<arrow_schema::Schema>,
-    /// Dataset URI for the target Lance table (e.g., "/tmp/lancedb/my_table.lance")
+    /// Dataset URI for the target Lance table (e.g., `/tmp/lancedb/my_table.lance`)
     dataset_uri: String,
     /// Buffered record batches for the current epoch
     batches: Vec<arrow_array::RecordBatch>,
 }
 
 impl LanceDbSinkWriter {
-    pub async fn new(config: LanceDbConfig, schema: Schema) -> Result<Self> {
+    pub fn new(config: LanceDbConfig, schema: Schema) -> Result<Self> {
         let arrow_schema = LanceDbConvert
             .rw_schema_to_arrow_schema(&schema)
             .map_err(|e| SinkError::LanceDb(anyhow!(e)))?;
@@ -353,16 +366,8 @@ impl SinkWriter for LanceDbSinkWriter {
             return Ok(None);
         }
 
-        if self.batches.is_empty() {
-            return Ok(None);
-        }
-
         // Write data files directly to storage and get fragment metadata.
         let fragments = self.flush_to_fragments().await?;
-
-        if fragments.is_empty() {
-            return Ok(None);
-        }
 
         // Serialize fragment metadata as JSON — this is lightweight (file paths + row counts).
         let metadata = serde_json::to_vec(&fragments)
@@ -380,36 +385,27 @@ impl SinkWriter for LanceDbSinkWriter {
 // ---------------------------------------------------------------------------
 
 /// The coordinator collects lightweight `Fragment` metadata from all writers
-/// and commits them atomically via `Dataset::commit(Operation::Append { fragments })`.
+/// and commits them atomically via `CommitBuilder`.
 /// No data payload flows through the coordinator — only file-level metadata.
 pub struct LanceDbSinkCommitter {
     config: LanceDbConfig,
     conn: LanceDbConnection,
+    sink_id: String,
 }
 
 impl LanceDbSinkCommitter {
-    pub async fn new(config: LanceDbConfig) -> Result<Self> {
+    pub async fn new(config: LanceDbConfig, sink_id: String) -> Result<Self> {
         let conn = config.common.create_connection().await?;
-        Ok(Self { config, conn })
-    }
-}
-
-#[async_trait::async_trait]
-impl SinglePhaseCommitCoordinator for LanceDbSinkCommitter {
-    async fn init(&mut self) -> Result<()> {
-        tracing::info!(
-            "LanceDB commit coordinator initialized for table '{}'",
-            self.config.common.table
-        );
-        Ok(())
+        Ok(Self {
+            config,
+            conn,
+            sink_id,
+        })
     }
 
-    async fn commit_data(&mut self, epoch: u64, metadata: Vec<SinkMetadata>) -> Result<()> {
-        tracing::debug!("Starting LanceDB commit in epoch {epoch}.");
-
-        // Collect all Fragment metadata from all writers.
-        let mut all_fragments: Vec<Fragment> = Vec::new();
-        for meta in &metadata {
+    fn collect_fragments(metadata: &[SinkMetadata]) -> Result<Vec<Fragment>> {
+        let mut all_fragments = Vec::new();
+        for meta in metadata {
             if let Some(Serialized(s)) = &meta.metadata {
                 let fragments: Vec<Fragment> = serde_json::from_slice(&s.metadata)
                     .context("failed to deserialize fragment metadata")
@@ -417,8 +413,50 @@ impl SinglePhaseCommitCoordinator for LanceDbSinkCommitter {
                 all_fragments.extend(fragments);
             }
         }
+        Ok(all_fragments)
+    }
 
-        if all_fragments.is_empty() {
+    async fn is_epoch_committed(
+        &self,
+        dataset: &Dataset,
+        target_sink_id: &str,
+        target_epoch: u64,
+    ) -> Result<bool> {
+        let target_epoch = target_epoch.to_string();
+        let latest_version = dataset.version().version;
+
+        for version in 1..=latest_version {
+            let Some(transaction) = dataset
+                .read_transaction_by_version(version)
+                .await
+                .context("failed to read Lance transaction history")
+                .map_err(SinkError::LanceDb)?
+            else {
+                continue;
+            };
+
+            if let Some(properties) = transaction.transaction_properties
+                && properties
+                    .get(RW_SINK_ID_TRANSACTION_PROPERTY)
+                    .is_some_and(|sink_id| sink_id == target_sink_id)
+                && properties
+                    .get(RW_EPOCH_TRANSACTION_PROPERTY)
+                    .is_some_and(|epoch| epoch == &target_epoch)
+            {
+                return Ok(true);
+            }
+        }
+
+        Ok(false)
+    }
+
+    async fn commit_fragments(
+        &mut self,
+        epoch: u64,
+        fragments: Vec<Fragment>,
+        transaction_properties: Option<HashMap<String, String>>,
+    ) -> Result<()> {
+        if fragments.is_empty() {
             tracing::debug!("No fragments to commit in epoch {epoch}, skipping.");
             return Ok(());
         }
@@ -442,41 +480,167 @@ impl SinglePhaseCommitCoordinator for LanceDbSinkCommitter {
             .get()
             .await
             .map_err(|e| SinkError::LanceDb(anyhow!(e)))?;
-
-        let read_version = dataset_guard.version().version;
-        let session = dataset_guard.session();
-
-        // Drop the read guard before commit to avoid holding the lock.
+        let dataset = (*dataset_guard).clone();
         drop(dataset_guard);
 
-        // Commit fragments via low-level Dataset::commit with Operation::Append.
+        if let Some(properties) = &transaction_properties
+            && let Some(sink_id) = properties.get(RW_SINK_ID_TRANSACTION_PROPERTY)
+            && self.is_epoch_committed(&dataset, sink_id, epoch).await?
+        {
+            tracing::info!(
+                "LanceDB epoch {epoch} has already been committed, skipping duplicate commit."
+            );
+            return Ok(());
+        }
+
+        // Commit fragments via low-level Lance transaction with Operation::Append.
         // This is a metadata-only operation — the data files were already written by workers.
-        let operation = Operation::Append {
-            fragments: all_fragments,
-        };
+        let operation = Operation::Append { fragments };
 
-        let dataset_uri = self.config.common.dataset_uri();
+        let mut transaction_builder =
+            TransactionBuilder::new(dataset.version().version, operation);
+        if let Some(transaction_properties) = transaction_properties {
+            transaction_builder = transaction_builder
+                .transaction_properties(Some(Arc::new(transaction_properties)));
+        }
+        let transaction = transaction_builder.build();
 
-        let new_dataset = Dataset::commit(
-            &dataset_uri as &str,
-            operation,
-            Some(read_version),
-            None, // store_params
-            None, // commit_handler
-            session,
-            false, // enable_v2_manifest_paths
-        )
-        .await
-        .context("failed to commit fragments to lance dataset")
-        .map_err(SinkError::LanceDb)?;
+        let new_dataset = CommitBuilder::new(Arc::new(dataset))
+            .execute(transaction)
+            .await
+            .context("failed to commit fragments to lance dataset")
+            .map_err(SinkError::LanceDb)?;
 
         // Update the lancedb Table's internal dataset to the new version.
-        dataset_wrapper.set_latest(new_dataset).await;
+        dataset_wrapper.update(new_dataset);
 
         tracing::debug!(
             "Succeeded to commit fragments to LanceDB table in epoch {epoch}."
         );
         Ok(())
+    }
+}
+
+#[async_trait::async_trait]
+impl SinglePhaseCommitCoordinator for LanceDbSinkCommitter {
+    async fn init(&mut self) -> Result<()> {
+        tracing::info!(
+            "LanceDB commit coordinator initialized for table '{}'",
+            self.config.common.table
+        );
+        Ok(())
+    }
+
+    async fn commit_data(&mut self, epoch: u64, metadata: Vec<SinkMetadata>) -> Result<()> {
+        tracing::debug!("Starting LanceDB single-phase commit in epoch {epoch}.");
+
+        let fragments = Self::collect_fragments(&metadata)?;
+        self.commit_fragments(epoch, fragments, None).await
+    }
+}
+
+#[async_trait::async_trait]
+impl TwoPhaseCommitCoordinator for LanceDbSinkCommitter {
+    async fn init(&mut self) -> Result<()> {
+        tracing::info!(
+            "LanceDB commit coordinator initialized for table '{}'",
+            self.config.common.table
+        );
+        Ok(())
+    }
+
+    async fn pre_commit(
+        &mut self,
+        epoch: u64,
+        metadata: Vec<SinkMetadata>,
+        schema_change: Option<PbSinkSchemaChange>,
+    ) -> Result<Option<Vec<u8>>> {
+        if schema_change.is_some() {
+            return Err(SinkError::LanceDb(anyhow!(
+                "LanceDB sink does not support schema change"
+            )));
+        }
+
+        let fragments = Self::collect_fragments(&metadata)?;
+        if fragments.is_empty() {
+            return Ok(None);
+        }
+
+        Ok(Some(
+            LanceDbPreCommitMetadata {
+                sink_id: self.sink_id.clone(),
+                epoch,
+                fragments,
+            }
+            .try_into_bytes()?,
+        ))
+    }
+
+    async fn commit_data(&mut self, epoch: u64, commit_metadata: Vec<u8>) -> Result<()> {
+        tracing::debug!("Starting LanceDB two-phase commit in epoch {epoch}.");
+
+        if commit_metadata.is_empty() {
+            return Ok(());
+        }
+
+        let pre_commit_metadata = LanceDbPreCommitMetadata::try_from_bytes(&commit_metadata)?;
+        if pre_commit_metadata.epoch != epoch {
+            return Err(SinkError::LanceDb(anyhow!(
+                "LanceDB pre-commit epoch {} does not match commit epoch {}",
+                pre_commit_metadata.epoch,
+                epoch
+            )));
+        }
+        if pre_commit_metadata.sink_id != self.sink_id {
+            return Err(SinkError::LanceDb(anyhow!(
+                "LanceDB pre-commit sink id {} does not match coordinator sink id {}",
+                pre_commit_metadata.sink_id,
+                self.sink_id
+            )));
+        }
+
+        let transaction_properties = pre_commit_metadata.transaction_properties();
+        self.commit_fragments(
+            epoch,
+            pre_commit_metadata.fragments,
+            Some(transaction_properties),
+        )
+        .await
+    }
+
+    async fn abort(&mut self, epoch: u64, _commit_metadata: Vec<u8>) {
+        tracing::debug!("Abort not implemented for LanceDB epoch {epoch}");
+    }
+}
+
+#[derive(Serialize, Deserialize)]
+struct LanceDbPreCommitMetadata {
+    sink_id: String,
+    epoch: u64,
+    fragments: Vec<Fragment>,
+}
+
+impl LanceDbPreCommitMetadata {
+    fn try_into_bytes(self) -> Result<Vec<u8>> {
+        serde_json::to_vec(&self)
+            .context("cannot serialize LanceDB pre-commit metadata")
+            .map_err(SinkError::LanceDb)
+    }
+
+    fn try_from_bytes(value: &[u8]) -> Result<Self> {
+        serde_json::from_slice(value)
+            .context("cannot deserialize LanceDB pre-commit metadata")
+            .map_err(SinkError::LanceDb)
+    }
+
+    fn transaction_properties(&self) -> HashMap<String, String> {
+        HashMap::from([
+            (
+                RW_SINK_ID_TRANSACTION_PROPERTY.to_owned(),
+                self.sink_id.clone(),
+            ),
+            (RW_EPOCH_TRANSACTION_PROPERTY.to_owned(), self.epoch.to_string()),
+        ])
     }
 }
 
@@ -501,7 +665,7 @@ mod tests {
     use risingwave_common::types::DataType;
 
     use super::*;
-    use crate::sink::SinglePhaseCommitCoordinator;
+    use crate::sink::{SinglePhaseCommitCoordinator, TwoPhaseCommitCoordinator};
     use crate::sink::writer::SinkWriter;
 
     #[tokio::test]
@@ -525,9 +689,7 @@ mod tests {
             vec![Arc::new(id_array), Arc::new(name_array)],
         )
         .unwrap();
-        let reader =
-            arrow_array::RecordBatchIterator::new(vec![Ok(init_batch)], arrow_schema.clone());
-        conn.create_table("test_table", reader)
+        conn.create_table("test_table", init_batch)
             .execute()
             .await
             .unwrap();
@@ -553,7 +715,8 @@ mod tests {
         ]);
 
         let config = LanceDbConfig::from_btreemap(properties).unwrap();
-        let mut writer = LanceDbSinkWriter::new(config.clone(), schema).await.unwrap();
+        assert_eq!(config.is_exactly_once, None);
+        let mut writer = LanceDbSinkWriter::new(config.clone(), schema.clone()).unwrap();
 
         // 4. Write a chunk
         let chunk = StreamChunk::new(
@@ -582,15 +745,72 @@ mod tests {
             panic!("expected serialized metadata");
         }
 
-        // 6. Commit via coordinator (metadata-only commit)
-        let mut committer = LanceDbSinkCommitter::new(config).await.unwrap();
-        committer.init().await.unwrap();
-        committer.commit_data(1, vec![metadata]).await.unwrap();
+        // 6. Commit via two-phase coordinator (metadata-only commit)
+        let mut committer = LanceDbSinkCommitter::new(config.clone(), "test-sink".to_owned())
+            .await
+            .unwrap();
+        TwoPhaseCommitCoordinator::init(&mut committer)
+            .await
+            .unwrap();
+        let commit_metadata = TwoPhaseCommitCoordinator::pre_commit(
+            &mut committer,
+            1,
+            vec![metadata],
+            None,
+        )
+        .await
+        .unwrap()
+        .unwrap();
+        TwoPhaseCommitCoordinator::commit_data(
+            &mut committer,
+            1,
+            commit_metadata.clone(),
+        )
+        .await
+        .unwrap();
 
         // 7. Verify data was written by reading back
         let table = conn.open_table("test_table").execute().await.unwrap();
         let count = table.count_rows(None).await.unwrap();
         // 1 initial row + 3 new rows = 4
         assert_eq!(count, 4);
+
+        // 8. Retrying the same committed epoch should be idempotent in two-phase mode.
+        TwoPhaseCommitCoordinator::commit_data(&mut committer, 1, commit_metadata)
+            .await
+            .unwrap();
+        let table = conn.open_table("test_table").execute().await.unwrap();
+        let count = table.count_rows(None).await.unwrap();
+        assert_eq!(count, 4);
+
+        // 9. Single-phase commit remains available when exactly-once is disabled.
+        let mut writer = LanceDbSinkWriter::new(config.clone(), schema).unwrap();
+        let chunk = StreamChunk::new(
+            vec![Op::Insert],
+            vec![
+                I32Array::from_iter(vec![4]).into_ref(),
+                Utf8Array::from_iter(vec!["David"]).into_ref(),
+            ],
+        );
+        writer.write_batch(chunk).await.unwrap();
+        let metadata = writer.barrier(true).await.unwrap().unwrap();
+
+        let mut single_phase_committer =
+            LanceDbSinkCommitter::new(config, "test-sink".to_owned())
+                .await
+                .unwrap();
+        SinglePhaseCommitCoordinator::init(&mut single_phase_committer)
+            .await
+            .unwrap();
+        SinglePhaseCommitCoordinator::commit_data(
+            &mut single_phase_committer,
+            2,
+            vec![metadata],
+        )
+        .await
+        .unwrap();
+        let table = conn.open_table("test_table").execute().await.unwrap();
+        let count = table.count_rows(None).await.unwrap();
+        assert_eq!(count, 5);
     }
 }

--- a/src/connector/src/sink/lancedb.rs
+++ b/src/connector/src/sink/lancedb.rs
@@ -22,6 +22,7 @@ use lance::Dataset;
 use lance::dataset::CommitBuilder;
 use lance::dataset::fragment::FileFragment;
 use lance::dataset::transaction::{Operation, TransactionBuilder};
+use lance::dataset::write::WriteParams;
 use lance_table::format::Fragment;
 use lancedb::connection::ConnectBuilder;
 use lancedb::{Connection as LanceDbConnection, Table as LanceDbTable};
@@ -317,6 +318,8 @@ pub struct LanceDbSinkWriter {
     arrow_schema: Arc<arrow_schema::Schema>,
     /// Dataset URI for the target Lance table (e.g., `/tmp/lancedb/my_table.lance`)
     dataset_uri: String,
+    /// Lance write parameters matching the target dataset format.
+    write_params: WriteParams,
     /// Buffered record batches for the current epoch
     batches: Vec<arrow_array::RecordBatch>,
 }
@@ -329,6 +332,22 @@ impl LanceDbSinkWriter {
 
         let conn = config.common.create_connection().await?;
         let table = config.common.open_table(&conn).await?;
+        let dataset_wrapper = table.dataset().ok_or_else(|| {
+            SinkError::LanceDb(anyhow!(
+                "failed to get underlying lance Dataset (table may be remote)"
+            ))
+        })?;
+        let dataset_guard = dataset_wrapper
+            .get()
+            .await
+            .map_err(|e| SinkError::LanceDb(anyhow!(e)))?;
+        let data_storage_version = dataset_guard
+            .manifest
+            .data_storage_format
+            .lance_file_version()
+            .context("failed to get LanceDB table storage version")
+            .map_err(SinkError::LanceDb)?;
+        drop(dataset_guard);
         let dataset_uri = config.common.dataset_uri(&table).await?;
 
         Ok(Self {
@@ -336,6 +355,10 @@ impl LanceDbSinkWriter {
             schema,
             arrow_schema: Arc::new(arrow_schema),
             dataset_uri,
+            write_params: WriteParams {
+                data_storage_version: Some(data_storage_version),
+                ..Default::default()
+            },
             batches: Vec::new(),
         })
     }
@@ -354,7 +377,7 @@ impl LanceDbSinkWriter {
         let fragments = FileFragment::create_fragments(
             &self.dataset_uri,
             reader,
-            None, // default WriteParams
+            Some(self.write_params.clone()),
         )
         .await
         .context("failed to write lance data files")
@@ -508,6 +531,13 @@ impl LanceDbSinkCommitter {
         let dataset = (*dataset_guard).clone();
         drop(dataset_guard);
 
+        let data_storage_version = dataset
+            .manifest
+            .data_storage_format
+            .lance_file_version()
+            .context("failed to get LanceDB table storage version")
+            .map_err(SinkError::LanceDb)?;
+
         if let Some(properties) = &transaction_properties
             && let Some(sink_id) = properties.get(RW_SINK_ID_TRANSACTION_PROPERTY)
             && self.is_epoch_committed(&dataset, sink_id, epoch).await?
@@ -530,6 +560,7 @@ impl LanceDbSinkCommitter {
         let transaction = transaction_builder.build();
 
         let new_dataset = CommitBuilder::new(Arc::new(dataset))
+            .with_storage_format(data_storage_version)
             .execute(transaction)
             .await
             .context("failed to commit fragments to lance dataset")
@@ -704,19 +735,12 @@ mod tests {
         // 2. Create a LanceDB table with a schema
         let conn = lancedb::connect(uri).execute().await.unwrap();
 
-        // Create initial data to define the table schema
+        // Create a schema-only table, matching the e2e test setup.
         let arrow_schema = Arc::new(arrow_schema::Schema::new(vec![
             arrow_schema::Field::new("id", arrow_schema::DataType::Int32, false),
             arrow_schema::Field::new("name", arrow_schema::DataType::Utf8, false),
         ]));
-        let id_array = arrow_array::Int32Array::from(vec![0i32]);
-        let name_array = arrow_array::StringArray::from(vec!["init"]);
-        let init_batch = arrow_array::RecordBatch::try_new(
-            arrow_schema.clone(),
-            vec![Arc::new(id_array), Arc::new(name_array)],
-        )
-        .unwrap();
-        conn.create_table("test_table", init_batch)
+        conn.create_table("test_table", arrow_array::RecordBatch::new_empty(arrow_schema.clone()))
             .execute()
             .await
             .unwrap();
@@ -795,8 +819,7 @@ mod tests {
         // 7. Verify data was written by reading back
         let table = conn.open_table("test_table").execute().await.unwrap();
         let count = table.count_rows(None).await.unwrap();
-        // 1 initial row + 3 new rows = 4
-        assert_eq!(count, 4);
+        assert_eq!(count, 3);
 
         // 8. Retrying the same committed epoch should be idempotent in two-phase mode.
         TwoPhaseCommitCoordinator::commit_data(&mut committer, 1, commit_metadata)
@@ -804,7 +827,7 @@ mod tests {
             .unwrap();
         let table = conn.open_table("test_table").execute().await.unwrap();
         let count = table.count_rows(None).await.unwrap();
-        assert_eq!(count, 4);
+        assert_eq!(count, 3);
 
         // 9. Single-phase commit remains available when exactly-once is disabled.
         let mut writer = LanceDbSinkWriter::new(config.clone(), schema)
@@ -831,7 +854,7 @@ mod tests {
             .unwrap();
         let table = conn.open_table("test_table").execute().await.unwrap();
         let count = table.count_rows(None).await.unwrap();
-        assert_eq!(count, 5);
+        assert_eq!(count, 4);
     }
 
     #[test]

--- a/src/connector/src/sink/lancedb.rs
+++ b/src/connector/src/sink/lancedb.rs
@@ -24,6 +24,7 @@ use lance::dataset::CommitBuilder;
 use lance::dataset::fragment::FileFragment;
 use lance::dataset::transaction::{Operation, TransactionBuilder};
 use lance::dataset::write::WriteParams;
+use lance::io::ObjectStoreParams;
 use lance_table::format::Fragment;
 use lancedb::arrow::{
     SendableRecordBatchStream, SendableRecordBatchStreamExt, SimpleRecordBatchStream,
@@ -59,6 +60,7 @@ use crate::sink::{
 pub const LANCEDB_SINK: &str = "lancedb";
 
 const RW_EPOCH_TRANSACTION_PROPERTY: &str = "risingwave.epoch";
+const RW_SINK_ID_TRANSACTION_PROPERTY: &str = "risingwave.sink_id";
 const WRITE_CHANNEL_CAPACITY: usize = 16;
 
 // ---------------------------------------------------------------------------
@@ -170,6 +172,17 @@ impl Sink for LanceDbSink {
 
     const SINK_NAME: &'static str = LANCEDB_SINK;
 
+    fn is_exactly_once(properties: &BTreeMap<String, String>) -> Result<bool> {
+        let Some(value) = properties.get("is_exactly_once") else {
+            return Ok(true);
+        };
+        value.parse::<bool>().map_err(|_| {
+            SinkError::Config(anyhow!(
+                "invalid value for `is_exactly_once`: expected `true` or `false`, got `{value}`"
+            ))
+        })
+    }
+
     async fn new_log_sinker(&self, writer_param: SinkWriterParam) -> Result<Self::LogSinker> {
         let inner = LanceDbSinkWriter::new(self.config.clone(), self.param.schema()).await?;
 
@@ -244,7 +257,7 @@ impl Sink for LanceDbSink {
     ) -> Result<SinkCommitCoordinator> {
         let committer =
             LanceDbSinkCommitter::new(self.config.clone(), self.param.sink_id.to_string()).await?;
-        if self.config.is_exactly_once.unwrap_or(true) {
+        if Self::is_exactly_once(&self.param.properties)? {
             Ok(SinkCommitCoordinator::TwoPhase(Box::new(committer)))
         } else {
             Ok(SinkCommitCoordinator::SinglePhase(Box::new(committer)))
@@ -366,6 +379,13 @@ impl LanceDbSinkWriter {
             .lance_file_version()
             .context("failed to get LanceDB table storage version")
             .map_err(SinkError::LanceDb)?;
+        let store_params =
+            dataset_guard
+                .storage_options_accessor()
+                .map(|storage_options_accessor| ObjectStoreParams {
+                    storage_options_accessor: Some(storage_options_accessor),
+                    ..Default::default()
+                });
         drop(dataset_guard);
         let dataset_uri = config.common.dataset_uri(&table).await?;
 
@@ -375,6 +395,11 @@ impl LanceDbSinkWriter {
             arrow_schema: Arc::new(arrow_schema),
             dataset_uri,
             write_params: WriteParams {
+                // Reuse the opened dataset's storage options so fragment writes use the same
+                // credentials and object-store configuration as table access.
+                store_params,
+                // Lance otherwise chooses its latest stable format. Detached fragments must use
+                // the existing table's format so they remain compatible when committed later.
                 data_storage_version: Some(data_storage_version),
                 ..Default::default()
             },
@@ -469,7 +494,7 @@ impl SinkWriter for LanceDbSinkWriter {
             Ok(Ok(fragments)) => {
                 tracing::debug!(
                     fragment_count = fragments.len(),
-                    "Discarded uncommitted Lance fragments after sink writer abort"
+                    "Left uncommitted Lance fragments for table-level orphan cleanup after sink writer abort"
                 );
             }
             Ok(Err(error)) => {
@@ -536,27 +561,19 @@ impl LanceDbSinkCommitter {
         Ok(all_fragments)
     }
 
-    async fn is_epoch_committed(
-        &self,
-        dataset: &Dataset,
-        target_epoch: u64,
-    ) -> Result<bool> {
-        let latest_version = dataset.version().version;
+    async fn is_epoch_committed(&self, dataset: &Dataset, target_epoch: u64) -> Result<bool> {
+        let mut dataset = dataset.clone();
 
-        // Lance's transaction history API traverses versions the same way, from the latest
-        // version towards version 1:
-        // https://docs.rs/lance/6.0.0/lance/dataset/struct.Dataset.html#method.get_transactions
-        for version in (1..=latest_version).rev() {
-            let Some(transaction) = dataset
-                .read_transaction_by_version(version)
+        loop {
+            if let Some(transaction) = dataset
+                .read_transaction()
                 .await
                 .context("failed to read Lance transaction history")
                 .map_err(SinkError::LanceDb)?
-            else {
-                continue;
-            };
-
-            if let Some(properties) = transaction.transaction_properties
+                && let Some(properties) = transaction.transaction_properties
+                && properties
+                    .get(RW_SINK_ID_TRANSACTION_PROPERTY)
+                    .is_some_and(|sink_id| sink_id == &self.sink_id)
                 && let Some(committed_epoch) = properties.get(RW_EPOCH_TRANSACTION_PROPERTY)
             {
                 let committed_epoch = committed_epoch
@@ -565,9 +582,25 @@ impl LanceDbSinkCommitter {
                     .map_err(SinkError::LanceDb)?;
                 return Ok(committed_epoch >= target_epoch);
             }
-        }
 
-        Ok(false)
+            let version = dataset.version().version;
+            if version <= 1 {
+                return Ok(false);
+            }
+
+            dataset = match dataset.checkout_version(version - 1).await {
+                Ok(dataset) => dataset,
+                // Lance cleanup removes a contiguous prefix of old versions. Reaching a
+                // missing previous version therefore means that all retained history has
+                // already been inspected.
+                Err(lance::Error::DatasetNotFound { .. }) => return Ok(false),
+                Err(error) => {
+                    return Err(SinkError::LanceDb(
+                        anyhow!(error).context("failed to read Lance transaction history"),
+                    ));
+                }
+            };
+        }
     }
 
     async fn commit_fragments(
@@ -610,8 +643,7 @@ impl LanceDbSinkCommitter {
             .context("failed to get LanceDB table storage version")
             .map_err(SinkError::LanceDb)?;
 
-        if transaction_properties.is_some() && self.is_epoch_committed(&dataset, epoch).await?
-        {
+        if transaction_properties.is_some() && self.is_epoch_committed(&dataset, epoch).await? {
             tracing::info!(
                 "LanceDB epoch {epoch} has already been committed, skipping duplicate commit."
             );
@@ -732,7 +764,10 @@ impl TwoPhaseCommitCoordinator for LanceDbSinkCommitter {
     }
 
     async fn abort(&mut self, epoch: u64, _commit_metadata: Vec<u8>) {
-        tracing::debug!("Abort not implemented for LanceDB epoch {epoch}");
+        // Unreferenced files are reclaimed by Lance's old-version/orphan cleanup. This is
+        // intentionally not an eager delete: the commit may have succeeded even if its result
+        // was lost, and process crashes can bypass this callback entirely.
+        tracing::debug!("Left LanceDB epoch {epoch} for table-level orphan cleanup");
     }
 }
 
@@ -757,10 +792,16 @@ impl LanceDbPreCommitMetadata {
     }
 
     fn transaction_properties(&self) -> HashMap<String, String> {
-        HashMap::from([(
-            RW_EPOCH_TRANSACTION_PROPERTY.to_owned(),
-            self.epoch.to_string(),
-        )])
+        HashMap::from([
+            (
+                RW_SINK_ID_TRANSACTION_PROPERTY.to_owned(),
+                self.sink_id.clone(),
+            ),
+            (
+                RW_EPOCH_TRANSACTION_PROPERTY.to_owned(),
+                self.epoch.to_string(),
+            ),
+        ])
     }
 }
 
@@ -804,10 +845,13 @@ mod tests {
             arrow_schema::Field::new("id", arrow_schema::DataType::Int32, false),
             arrow_schema::Field::new("name", arrow_schema::DataType::Utf8, false),
         ]));
-        conn.create_table("test_table", arrow_array::RecordBatch::new_empty(arrow_schema.clone()))
-            .execute()
-            .await
-            .unwrap();
+        conn.create_table(
+            "test_table",
+            arrow_array::RecordBatch::new_empty(arrow_schema.clone()),
+        )
+        .execute()
+        .await
+        .unwrap();
 
         // 3. Create a LanceDB sink writer
         let properties: BTreeMap<String, String> = [
@@ -904,34 +948,43 @@ mod tests {
         assert_eq!(count, 3);
         let dataset_wrapper = table.dataset().unwrap();
         let dataset_guard = dataset_wrapper.get().await.unwrap();
-        assert!(committer.is_epoch_committed(&dataset_guard, 0).await.unwrap());
-        assert!(committer.is_epoch_committed(&dataset_guard, 1).await.unwrap());
-        assert!(!committer.is_epoch_committed(&dataset_guard, 2).await.unwrap());
-        drop(dataset_guard);
+        let transaction = dataset_guard.read_transaction().await.unwrap().unwrap();
+        let transaction_properties = transaction.transaction_properties.unwrap();
+        assert_eq!(
+            transaction_properties.get(RW_SINK_ID_TRANSACTION_PROPERTY),
+            Some(&"test-sink".to_owned())
+        );
+        assert!(
+            committer
+                .is_epoch_committed(&dataset_guard, 0)
+                .await
+                .unwrap()
+        );
+        assert!(
+            committer
+                .is_epoch_committed(&dataset_guard, 1)
+                .await
+                .unwrap()
+        );
+        assert!(
+            !committer
+                .is_epoch_committed(&dataset_guard, 2)
+                .await
+                .unwrap()
+        );
 
-        // 8. A replacement sink ID must still recognize the committed epoch.
-        let pre_commit_metadata =
-            LanceDbPreCommitMetadata::try_from_bytes(&commit_metadata).unwrap();
-        let replacement_commit_metadata = LanceDbPreCommitMetadata {
-            sink_id: "replacement-sink".to_owned(),
-            ..pre_commit_metadata
-        }
-        .try_into_bytes()
-        .unwrap();
-        let mut replacement_committer =
+        // 8. An independent sink must not use another sink's epoch marker.
+        let replacement_committer =
             LanceDbSinkCommitter::new(config.clone(), "replacement-sink".to_owned())
                 .await
                 .unwrap();
-        TwoPhaseCommitCoordinator::commit_data(
-            &mut replacement_committer,
-            1,
-            replacement_commit_metadata,
-        )
-        .await
-        .unwrap();
-        let table = conn.open_table("test_table").execute().await.unwrap();
-        let count = table.count_rows(None).await.unwrap();
-        assert_eq!(count, 3);
+        assert!(
+            !replacement_committer
+                .is_epoch_committed(&dataset_guard, 1)
+                .await
+                .unwrap()
+        );
+        drop(dataset_guard);
 
         // 9. Retrying the same committed epoch should be idempotent in two-phase mode.
         TwoPhaseCommitCoordinator::commit_data(&mut committer, 1, commit_metadata)
@@ -967,6 +1020,66 @@ mod tests {
         let table = conn.open_table("test_table").execute().await.unwrap();
         let count = table.count_rows(None).await.unwrap();
         assert_eq!(count, 4);
+    }
+
+    #[tokio::test]
+    async fn test_epoch_lookup_stops_at_pruned_history() {
+        let dir = tempfile::tempdir().unwrap();
+        let uri = dir.path().to_str().unwrap();
+        let arrow_schema = Arc::new(arrow_schema::Schema::new(vec![arrow_schema::Field::new(
+            "id",
+            arrow_schema::DataType::Int32,
+            false,
+        )]));
+        let batch = arrow_array::RecordBatch::try_new(
+            arrow_schema.clone(),
+            vec![Arc::new(arrow_array::Int32Array::from(vec![0i32]))],
+        )
+        .unwrap();
+
+        let conn = lancedb::connect(uri).execute().await.unwrap();
+        let table = conn
+            .create_table("test_table", batch.clone())
+            .execute()
+            .await
+            .unwrap();
+        table.add(batch).execute().await.unwrap();
+
+        let dataset_wrapper = table.dataset().unwrap();
+        let dataset_guard = dataset_wrapper.get().await.unwrap();
+        dataset_guard
+            .cleanup_old_versions(chrono::Duration::zero(), Some(true), Some(false))
+            .await
+            .unwrap();
+        drop(dataset_guard);
+        drop(table);
+        drop(conn);
+
+        // Reopen with a fresh session so a cached old manifest cannot hide the pruning boundary.
+        let conn = lancedb::connect(uri).execute().await.unwrap();
+        let table = conn.open_table("test_table").execute().await.unwrap();
+        let dataset_wrapper = table.dataset().unwrap();
+        let dataset_guard = dataset_wrapper.get().await.unwrap();
+        assert!(dataset_guard.checkout_version(1).await.is_err());
+
+        let properties: BTreeMap<String, String> = [
+            ("connector".to_owned(), "lancedb".to_owned()),
+            ("type".to_owned(), "append-only".to_owned()),
+            ("lancedb.uri".to_owned(), uri.to_owned()),
+            ("lancedb.table".to_owned(), "test_table".to_owned()),
+        ]
+        .into();
+        let config = LanceDbConfig::from_btreemap(properties).unwrap();
+        let committer = LanceDbSinkCommitter::new(config, "test-sink".to_owned())
+            .await
+            .unwrap();
+
+        assert!(
+            !committer
+                .is_epoch_committed(&dataset_guard, 1)
+                .await
+                .unwrap()
+        );
     }
 
     #[test]

--- a/src/connector/src/sink/lancedb.rs
+++ b/src/connector/src/sink/lancedb.rs
@@ -18,10 +18,10 @@ use std::sync::Arc;
 
 use anyhow::{Context, anyhow};
 use async_trait::async_trait;
+use lance::Dataset;
 use lance::dataset::CommitBuilder;
 use lance::dataset::fragment::FileFragment;
 use lance::dataset::transaction::{Operation, TransactionBuilder};
-use lance::Dataset;
 use lance_table::format::Fragment;
 use lancedb::connection::ConnectBuilder;
 use lancedb::{Connection as LanceDbConnection, Table as LanceDbTable};
@@ -259,8 +259,9 @@ impl TryFrom<SinkParam> for LanceDbSink {
 // ---------------------------------------------------------------------------
 
 // Re-export arrow types from the LanceDb arrow module so they're used consistently.
-use risingwave_common::array::arrow::arrow_array_lancedb as arrow_array;
-use risingwave_common::array::arrow::arrow_schema_lancedb as arrow_schema;
+use risingwave_common::array::arrow::{
+    arrow_array_lancedb as arrow_array, arrow_schema_lancedb as arrow_schema,
+};
 
 fn validate_ordered_schema(
     rw_arrow_schema: &arrow_schema::Schema,
@@ -348,8 +349,7 @@ impl LanceDbSinkWriter {
 
         let batches = std::mem::take(&mut self.batches);
         let schema = batches[0].schema();
-        let reader =
-            arrow_array::RecordBatchIterator::new(batches.into_iter().map(Ok), schema);
+        let reader = arrow_array::RecordBatchIterator::new(batches.into_iter().map(Ok), schema);
 
         let fragments = FileFragment::create_fragments(
             &self.dataset_uri,
@@ -522,11 +522,10 @@ impl LanceDbSinkCommitter {
         // This is a metadata-only operation — the data files were already written by workers.
         let operation = Operation::Append { fragments };
 
-        let mut transaction_builder =
-            TransactionBuilder::new(dataset.version().version, operation);
+        let mut transaction_builder = TransactionBuilder::new(dataset.version().version, operation);
         if let Some(transaction_properties) = transaction_properties {
-            transaction_builder = transaction_builder
-                .transaction_properties(Some(Arc::new(transaction_properties)));
+            transaction_builder =
+                transaction_builder.transaction_properties(Some(Arc::new(transaction_properties)));
         }
         let transaction = transaction_builder.build();
 
@@ -539,9 +538,7 @@ impl LanceDbSinkCommitter {
         // Update the lancedb Table's internal dataset to the new version.
         dataset_wrapper.update(new_dataset);
 
-        tracing::debug!(
-            "Succeeded to commit fragments to LanceDB table in epoch {epoch}."
-        );
+        tracing::debug!("Succeeded to commit fragments to LanceDB table in epoch {epoch}.");
         Ok(())
     }
 }
@@ -664,7 +661,10 @@ impl LanceDbPreCommitMetadata {
                 RW_SINK_ID_TRANSACTION_PROPERTY.to_owned(),
                 self.sink_id.clone(),
             ),
-            (RW_EPOCH_TRANSACTION_PROPERTY.to_owned(), self.epoch.to_string()),
+            (
+                RW_EPOCH_TRANSACTION_PROPERTY.to_owned(),
+                self.epoch.to_string(),
+            ),
         ])
     }
 }
@@ -686,12 +686,14 @@ impl From<lancedb::Error> for SinkError {
 #[cfg(all(test, not(madsim)))]
 mod tests {
     use risingwave_common::array::{Array, I32Array, Op, StreamChunk, Utf8Array};
-    use risingwave_common::catalog::{Field, Schema};
+    use risingwave_common::catalog::{ColumnDesc, ColumnId, Field, Schema};
+    use risingwave_common::id::SinkId;
     use risingwave_common::types::DataType;
 
     use super::*;
-    use crate::sink::{SinglePhaseCommitCoordinator, TwoPhaseCommitCoordinator};
+    use crate::sink::catalog::SinkType;
     use crate::sink::writer::SinkWriter;
+    use crate::sink::{SinglePhaseCommitCoordinator, TwoPhaseCommitCoordinator};
 
     #[tokio::test]
     async fn test_lancedb_sink_roundtrip() {
@@ -781,22 +783,14 @@ mod tests {
         TwoPhaseCommitCoordinator::init(&mut committer)
             .await
             .unwrap();
-        let commit_metadata = TwoPhaseCommitCoordinator::pre_commit(
-            &mut committer,
-            1,
-            vec![metadata],
-            None,
-        )
-        .await
-        .unwrap()
-        .unwrap();
-        TwoPhaseCommitCoordinator::commit_data(
-            &mut committer,
-            1,
-            commit_metadata.clone(),
-        )
-        .await
-        .unwrap();
+        let commit_metadata =
+            TwoPhaseCommitCoordinator::pre_commit(&mut committer, 1, vec![metadata], None)
+                .await
+                .unwrap()
+                .unwrap();
+        TwoPhaseCommitCoordinator::commit_data(&mut committer, 1, commit_metadata.clone())
+            .await
+            .unwrap();
 
         // 7. Verify data was written by reading back
         let table = conn.open_table("test_table").execute().await.unwrap();
@@ -826,20 +820,15 @@ mod tests {
         writer.write_batch(chunk).await.unwrap();
         let metadata = writer.barrier(true).await.unwrap().unwrap();
 
-        let mut single_phase_committer =
-            LanceDbSinkCommitter::new(config, "test-sink".to_owned())
-                .await
-                .unwrap();
+        let mut single_phase_committer = LanceDbSinkCommitter::new(config, "test-sink".to_owned())
+            .await
+            .unwrap();
         SinglePhaseCommitCoordinator::init(&mut single_phase_committer)
             .await
             .unwrap();
-        SinglePhaseCommitCoordinator::commit_data(
-            &mut single_phase_committer,
-            2,
-            vec![metadata],
-        )
-        .await
-        .unwrap();
+        SinglePhaseCommitCoordinator::commit_data(&mut single_phase_committer, 2, vec![metadata])
+            .await
+            .unwrap();
         let table = conn.open_table("test_table").execute().await.unwrap();
         let count = table.count_rows(None).await.unwrap();
         assert_eq!(count, 5);
@@ -857,6 +846,61 @@ mod tests {
         ]);
 
         let err = validate_ordered_schema(&rw_schema, &reordered_lance_schema).unwrap_err();
+        assert!(
+            format!("{err:?}").contains("column order mismatch"),
+            "unexpected error: {err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_validate_rejects_reordered_lancedb_table_columns() {
+        let dir = tempfile::tempdir().unwrap();
+        let uri = dir.path().to_str().unwrap();
+
+        let conn = lancedb::connect(uri).execute().await.unwrap();
+        let arrow_schema = Arc::new(arrow_schema::Schema::new(vec![
+            arrow_schema::Field::new("name", arrow_schema::DataType::Utf8, false),
+            arrow_schema::Field::new("id", arrow_schema::DataType::Int32, false),
+        ]));
+        let batch = arrow_array::RecordBatch::try_new(
+            arrow_schema,
+            vec![
+                Arc::new(arrow_array::StringArray::from(vec!["init"])),
+                Arc::new(arrow_array::Int32Array::from(vec![0i32])),
+            ],
+        )
+        .unwrap();
+        conn.create_table("reordered_table", batch)
+            .execute()
+            .await
+            .unwrap();
+
+        let properties: BTreeMap<String, String> = [
+            ("connector".to_owned(), "lancedb".to_owned()),
+            ("type".to_owned(), "append-only".to_owned()),
+            ("lancedb.uri".to_owned(), uri.to_owned()),
+            ("lancedb.table".to_owned(), "reordered_table".to_owned()),
+        ]
+        .into();
+        let config = LanceDbConfig::from_btreemap(properties.clone()).unwrap();
+        let param = SinkParam {
+            sink_id: SinkId::from(1u32),
+            sink_name: "test_sink".to_owned(),
+            properties,
+            columns: vec![
+                ColumnDesc::named("id", ColumnId::new(1), DataType::Int32),
+                ColumnDesc::named("name", ColumnId::new(2), DataType::Varchar),
+            ],
+            downstream_pk: None,
+            sink_type: SinkType::AppendOnly,
+            ignore_delete: false,
+            format_desc: None,
+            db_name: "dev".to_owned(),
+            sink_from_name: "test_sink".to_owned(),
+        };
+
+        let sink = LanceDbSink::new(config, param).unwrap();
+        let err = sink.validate().await.unwrap_err();
         assert!(
             format!("{err:?}").contains("column order mismatch"),
             "unexpected error: {err:?}"

--- a/src/connector/src/sink/lancedb.rs
+++ b/src/connector/src/sink/lancedb.rs
@@ -41,6 +41,7 @@ use risingwave_pb::connector_service::sink_metadata::SerializedMetadata;
 use risingwave_pb::stream_plan::PbSinkSchemaChange;
 use serde::{Deserialize, Serialize};
 use serde_with::{DisplayFromStr, serde_as};
+use thiserror_ext::AsReport;
 use tokio::sync::mpsc::{self, UnboundedSender};
 use tokio::task::JoinHandle;
 use tokio_stream::wrappers::ReceiverStream;
@@ -498,10 +499,16 @@ impl SinkWriter for LanceDbSinkWriter {
                 );
             }
             Ok(Err(error)) => {
-                tracing::warn!(%error, "Lance fragment write failed while aborting sink writer");
+                tracing::warn!(
+                    error = %error.as_report(),
+                    "Lance fragment write failed while aborting sink writer"
+                );
             }
             Err(error) => {
-                tracing::warn!(%error, "Lance fragment write task failed while aborting sink writer");
+                tracing::warn!(
+                    error = %error.as_report(),
+                    "Lance fragment write task failed while aborting sink writer"
+                );
             }
         }
         Ok(())

--- a/src/connector/src/sink/lancedb.rs
+++ b/src/connector/src/sink/lancedb.rs
@@ -18,12 +18,16 @@ use std::sync::Arc;
 
 use anyhow::{Context, anyhow};
 use async_trait::async_trait;
+use futures::StreamExt;
 use lance::Dataset;
 use lance::dataset::CommitBuilder;
 use lance::dataset::fragment::FileFragment;
 use lance::dataset::transaction::{Operation, TransactionBuilder};
 use lance::dataset::write::WriteParams;
 use lance_table::format::Fragment;
+use lancedb::arrow::{
+    SendableRecordBatchStream, SendableRecordBatchStreamExt, SimpleRecordBatchStream,
+};
 use lancedb::connection::ConnectBuilder;
 use lancedb::{Connection as LanceDbConnection, Table as LanceDbTable};
 use risingwave_common::array::StreamChunk;
@@ -36,7 +40,9 @@ use risingwave_pb::connector_service::sink_metadata::SerializedMetadata;
 use risingwave_pb::stream_plan::PbSinkSchemaChange;
 use serde::{Deserialize, Serialize};
 use serde_with::{DisplayFromStr, serde_as};
-use tokio::sync::mpsc::UnboundedSender;
+use tokio::sync::mpsc::{self, UnboundedSender};
+use tokio::task::JoinHandle;
+use tokio_stream::wrappers::ReceiverStream;
 use with_options::WithOptions;
 
 use crate::connector_common::IcebergSinkCompactionUpdate;
@@ -52,8 +58,8 @@ use crate::sink::{
 
 pub const LANCEDB_SINK: &str = "lancedb";
 
-const RW_SINK_ID_TRANSACTION_PROPERTY: &str = "risingwave.sink_id";
 const RW_EPOCH_TRANSACTION_PROPERTY: &str = "risingwave.epoch";
+const WRITE_CHANNEL_CAPACITY: usize = 16;
 
 // ---------------------------------------------------------------------------
 // Config
@@ -306,8 +312,9 @@ fn validate_ordered_schema(
 
 /// The writer writes data files directly to the Lance dataset storage using the
 /// low-level `FileFragment::create_fragments()` API. On checkpoint, it returns
-/// lightweight `Fragment` metadata (file paths + row counts) instead of the
-/// actual data payload. The coordinator then commits these fragments atomically.
+/// lightweight `Fragment` metadata instead of the actual data payload. A fragment
+/// is a logical row segment that references one or more files containing columns
+/// for those rows. The coordinator then commits these fragments atomically.
 ///
 /// This follows the same pattern as the Iceberg sink, where writers handle I/O
 /// and the coordinator only performs a metadata-only commit.
@@ -320,8 +327,20 @@ pub struct LanceDbSinkWriter {
     dataset_uri: String,
     /// Lance write parameters matching the target dataset format.
     write_params: WriteParams,
-    /// Buffered record batches for the current epoch
-    batches: Vec<arrow_array::RecordBatch>,
+    fragment_write: Option<FragmentWrite>,
+}
+
+struct FragmentWrite {
+    sender: Option<mpsc::Sender<arrow_array::RecordBatch>>,
+    task: Option<JoinHandle<Result<Vec<Fragment>>>>,
+}
+
+impl Drop for FragmentWrite {
+    fn drop(&mut self) {
+        if let Some(task) = &self.task {
+            task.abort();
+        }
+    }
 }
 
 impl LanceDbSinkWriter {
@@ -359,31 +378,46 @@ impl LanceDbSinkWriter {
                 data_storage_version: Some(data_storage_version),
                 ..Default::default()
             },
-            batches: Vec::new(),
+            fragment_write: None,
         })
     }
 
-    /// Flush buffered batches by writing them as lance data files directly to storage.
-    /// Returns a list of `Fragment` metadata describing the written files.
-    async fn flush_to_fragments(&mut self) -> Result<Vec<Fragment>> {
-        if self.batches.is_empty() {
-            return Ok(Vec::new());
+    fn start_fragment_write(&self) -> FragmentWrite {
+        let (sender, receiver) = mpsc::channel(WRITE_CHANNEL_CAPACITY);
+        let stream = ReceiverStream::new(receiver).map(Ok::<_, lancedb::Error>);
+        let stream: SendableRecordBatchStream = Box::pin(SimpleRecordBatchStream::new(
+            stream,
+            self.arrow_schema.clone(),
+        ));
+        let stream = stream.into_df_stream();
+        let dataset_uri = self.dataset_uri.clone();
+        let write_params = self.write_params.clone();
+        let task = tokio::spawn(async move {
+            FileFragment::create_fragments(&dataset_uri, stream, Some(write_params))
+                .await
+                .context("failed to write lance data files")
+                .map_err(SinkError::LanceDb)
+        });
+
+        FragmentWrite {
+            sender: Some(sender),
+            task: Some(task),
         }
+    }
 
-        let batches = std::mem::take(&mut self.batches);
-        let schema = batches[0].schema();
-        let reader = arrow_array::RecordBatchIterator::new(batches.into_iter().map(Ok), schema);
+    async fn finish_fragment_write(&mut self) -> Result<Vec<Fragment>> {
+        let Some(mut fragment_write) = self.fragment_write.take() else {
+            return Ok(Vec::new());
+        };
 
-        let fragments = FileFragment::create_fragments(
-            &self.dataset_uri,
-            reader,
-            Some(self.write_params.clone()),
-        )
-        .await
-        .context("failed to write lance data files")
-        .map_err(SinkError::LanceDb)?;
-
-        Ok(fragments)
+        drop(fragment_write.sender.take());
+        fragment_write
+            .task
+            .take()
+            .expect("fragment write task should be initialized")
+            .await
+            .context("Lance fragment write task failed")
+            .map_err(SinkError::LanceDb)?
     }
 }
 
@@ -396,7 +430,23 @@ impl SinkWriter for LanceDbSinkWriter {
             .to_record_batch(self.arrow_schema.clone(), &chunk)
             .context("failed to convert DataChunk to RecordBatch for LanceDB")
             .map_err(SinkError::LanceDb)?;
-        self.batches.push(record_batch);
+
+        if self.fragment_write.is_none() {
+            self.fragment_write = Some(self.start_fragment_write());
+        }
+        self.fragment_write
+            .as_ref()
+            .expect("fragment write should be initialized")
+            .sender
+            .as_ref()
+            .expect("fragment write sender should be initialized")
+            .send(record_batch)
+            .await
+            .map_err(|_| {
+                SinkError::LanceDb(anyhow!(
+                    "Lance fragment write task stopped before accepting a record batch"
+                ))
+            })?;
         Ok(())
     }
 
@@ -405,7 +455,30 @@ impl SinkWriter for LanceDbSinkWriter {
     }
 
     async fn abort(&mut self) -> Result<()> {
-        self.batches.clear();
+        let Some(mut fragment_write) = self.fragment_write.take() else {
+            return Ok(());
+        };
+
+        drop(fragment_write.sender.take());
+        match fragment_write
+            .task
+            .take()
+            .expect("fragment write task should be initialized")
+            .await
+        {
+            Ok(Ok(fragments)) => {
+                tracing::debug!(
+                    fragment_count = fragments.len(),
+                    "Discarded uncommitted Lance fragments after sink writer abort"
+                );
+            }
+            Ok(Err(error)) => {
+                tracing::warn!(%error, "Lance fragment write failed while aborting sink writer");
+            }
+            Err(error) => {
+                tracing::warn!(%error, "Lance fragment write task failed while aborting sink writer");
+            }
+        }
         Ok(())
     }
 
@@ -414,8 +487,7 @@ impl SinkWriter for LanceDbSinkWriter {
             return Ok(None);
         }
 
-        // Write data files directly to storage and get fragment metadata.
-        let fragments = self.flush_to_fragments().await?;
+        let fragments = self.finish_fragment_write().await?;
 
         // Serialize fragment metadata as JSON — this is lightweight (file paths + row counts).
         let metadata = serde_json::to_vec(&fragments)
@@ -467,13 +539,14 @@ impl LanceDbSinkCommitter {
     async fn is_epoch_committed(
         &self,
         dataset: &Dataset,
-        target_sink_id: &str,
         target_epoch: u64,
     ) -> Result<bool> {
-        let target_epoch = target_epoch.to_string();
         let latest_version = dataset.version().version;
 
-        for version in 1..=latest_version {
+        // Lance's transaction history API traverses versions the same way, from the latest
+        // version towards version 1:
+        // https://docs.rs/lance/6.0.0/lance/dataset/struct.Dataset.html#method.get_transactions
+        for version in (1..=latest_version).rev() {
             let Some(transaction) = dataset
                 .read_transaction_by_version(version)
                 .await
@@ -484,14 +557,13 @@ impl LanceDbSinkCommitter {
             };
 
             if let Some(properties) = transaction.transaction_properties
-                && properties
-                    .get(RW_SINK_ID_TRANSACTION_PROPERTY)
-                    .is_some_and(|sink_id| sink_id == target_sink_id)
-                && properties
-                    .get(RW_EPOCH_TRANSACTION_PROPERTY)
-                    .is_some_and(|epoch| epoch == &target_epoch)
+                && let Some(committed_epoch) = properties.get(RW_EPOCH_TRANSACTION_PROPERTY)
             {
-                return Ok(true);
+                let committed_epoch = committed_epoch
+                    .parse::<u64>()
+                    .context("invalid RisingWave epoch in Lance transaction history")
+                    .map_err(SinkError::LanceDb)?;
+                return Ok(committed_epoch >= target_epoch);
             }
         }
 
@@ -538,9 +610,7 @@ impl LanceDbSinkCommitter {
             .context("failed to get LanceDB table storage version")
             .map_err(SinkError::LanceDb)?;
 
-        if let Some(properties) = &transaction_properties
-            && let Some(sink_id) = properties.get(RW_SINK_ID_TRANSACTION_PROPERTY)
-            && self.is_epoch_committed(&dataset, sink_id, epoch).await?
+        if transaction_properties.is_some() && self.is_epoch_committed(&dataset, epoch).await?
         {
             tracing::info!(
                 "LanceDB epoch {epoch} has already been committed, skipping duplicate commit."
@@ -687,16 +757,10 @@ impl LanceDbPreCommitMetadata {
     }
 
     fn transaction_properties(&self) -> HashMap<String, String> {
-        HashMap::from([
-            (
-                RW_SINK_ID_TRANSACTION_PROPERTY.to_owned(),
-                self.sink_id.clone(),
-            ),
-            (
-                RW_EPOCH_TRANSACTION_PROPERTY.to_owned(),
-                self.epoch.to_string(),
-            ),
-        ])
+        HashMap::from([(
+            RW_EPOCH_TRANSACTION_PROPERTY.to_owned(),
+            self.epoch.to_string(),
+        )])
     }
 }
 
@@ -773,12 +837,30 @@ mod tests {
         let table = conn.open_table("test_table").execute().await.unwrap();
         assert_eq!(writer.dataset_uri, table.uri().await.unwrap());
 
-        // 4. Write a chunk
+        // 4. Abort one streamed batch, then write two batches for the checkpoint.
         let chunk = StreamChunk::new(
-            vec![Op::Insert, Op::Insert, Op::Insert],
+            vec![Op::Insert],
             vec![
-                I32Array::from_iter(vec![1, 2, 3]).into_ref(),
-                Utf8Array::from_iter(vec!["Alice", "Bob", "Clare"]).into_ref(),
+                I32Array::from_iter(vec![0]).into_ref(),
+                Utf8Array::from_iter(vec!["Aborted"]).into_ref(),
+            ],
+        );
+        writer.write_batch(chunk).await.unwrap();
+        writer.abort().await.unwrap();
+
+        let chunk = StreamChunk::new(
+            vec![Op::Insert, Op::Insert],
+            vec![
+                I32Array::from_iter(vec![1, 2]).into_ref(),
+                Utf8Array::from_iter(vec!["Alice", "Bob"]).into_ref(),
+            ],
+        );
+        writer.write_batch(chunk).await.unwrap();
+        let chunk = StreamChunk::new(
+            vec![Op::Insert],
+            vec![
+                I32Array::from_iter(vec![3]).into_ref(),
+                Utf8Array::from_iter(vec!["Clare"]).into_ref(),
             ],
         );
         writer.write_batch(chunk).await.unwrap();
@@ -820,8 +902,38 @@ mod tests {
         let table = conn.open_table("test_table").execute().await.unwrap();
         let count = table.count_rows(None).await.unwrap();
         assert_eq!(count, 3);
+        let dataset_wrapper = table.dataset().unwrap();
+        let dataset_guard = dataset_wrapper.get().await.unwrap();
+        assert!(committer.is_epoch_committed(&dataset_guard, 0).await.unwrap());
+        assert!(committer.is_epoch_committed(&dataset_guard, 1).await.unwrap());
+        assert!(!committer.is_epoch_committed(&dataset_guard, 2).await.unwrap());
+        drop(dataset_guard);
 
-        // 8. Retrying the same committed epoch should be idempotent in two-phase mode.
+        // 8. A replacement sink ID must still recognize the committed epoch.
+        let pre_commit_metadata =
+            LanceDbPreCommitMetadata::try_from_bytes(&commit_metadata).unwrap();
+        let replacement_commit_metadata = LanceDbPreCommitMetadata {
+            sink_id: "replacement-sink".to_owned(),
+            ..pre_commit_metadata
+        }
+        .try_into_bytes()
+        .unwrap();
+        let mut replacement_committer =
+            LanceDbSinkCommitter::new(config.clone(), "replacement-sink".to_owned())
+                .await
+                .unwrap();
+        TwoPhaseCommitCoordinator::commit_data(
+            &mut replacement_committer,
+            1,
+            replacement_commit_metadata,
+        )
+        .await
+        .unwrap();
+        let table = conn.open_table("test_table").execute().await.unwrap();
+        let count = table.count_rows(None).await.unwrap();
+        assert_eq!(count, 3);
+
+        // 9. Retrying the same committed epoch should be idempotent in two-phase mode.
         TwoPhaseCommitCoordinator::commit_data(&mut committer, 1, commit_metadata)
             .await
             .unwrap();
@@ -829,7 +941,7 @@ mod tests {
         let count = table.count_rows(None).await.unwrap();
         assert_eq!(count, 3);
 
-        // 9. Single-phase commit remains available when exactly-once is disabled.
+        // 10. Single-phase commit remains available when exactly-once is disabled.
         let mut writer = LanceDbSinkWriter::new(config.clone(), schema)
             .await
             .unwrap();

--- a/src/connector/src/sink/lancedb.rs
+++ b/src/connector/src/sink/lancedb.rs
@@ -23,11 +23,12 @@ use lance::dataset::fragment::FileFragment;
 use lance::dataset::transaction::{Operation, TransactionBuilder};
 use lance::Dataset;
 use lance_table::format::Fragment;
-use lancedb::Connection as LanceDbConnection;
 use lancedb::connection::ConnectBuilder;
+use lancedb::{Connection as LanceDbConnection, Table as LanceDbTable};
 use risingwave_common::array::StreamChunk;
 use risingwave_common::array::arrow::LanceDbConvert;
 use risingwave_common::catalog::Schema;
+use risingwave_common::util::iter_util::ZipEqFast;
 use risingwave_pb::connector_service::SinkMetadata;
 use risingwave_pb::connector_service::sink_metadata::Metadata::Serialized;
 use risingwave_pb::connector_service::sink_metadata::SerializedMetadata;
@@ -85,10 +86,26 @@ impl LanceDbCommon {
         Ok(conn)
     }
 
-    /// Get the lance Dataset URI for the table.
-    /// `LanceDB` stores each table as a Lance dataset at `{db_uri}/{table_name}.lance`.
-    pub fn dataset_uri(&self) -> String {
-        format!("{}/{}.lance", self.uri.trim_end_matches('/'), self.table)
+    async fn open_table(&self, conn: &LanceDbConnection) -> Result<LanceDbTable> {
+        conn.open_table(&self.table)
+            .execute()
+            .await
+            .context("failed to open LanceDB table")
+            .map_err(SinkError::LanceDb)
+    }
+
+    /// Get the Lance dataset URI from the opened native `LanceDB` table.
+    async fn dataset_uri(&self, table: &LanceDbTable) -> Result<String> {
+        let dataset_wrapper = table.dataset().ok_or_else(|| {
+            SinkError::LanceDb(anyhow!(
+                "failed to get underlying lance Dataset (table may be remote)"
+            ))
+        })?;
+        let dataset_guard = dataset_wrapper
+            .get()
+            .await
+            .map_err(|e| SinkError::LanceDb(anyhow!(e)))?;
+        Ok(dataset_guard.uri().to_owned())
     }
 }
 
@@ -147,7 +164,7 @@ impl Sink for LanceDbSink {
     const SINK_NAME: &'static str = LANCEDB_SINK;
 
     async fn new_log_sinker(&self, writer_param: SinkWriterParam) -> Result<Self::LogSinker> {
-        let inner = LanceDbSinkWriter::new(self.config.clone(), self.param.schema())?;
+        let inner = LanceDbSinkWriter::new(self.config.clone(), self.param.schema()).await?;
 
         let commit_checkpoint_interval =
             NonZeroU64::new(self.config.common.commit_checkpoint_interval).expect(
@@ -190,12 +207,7 @@ impl Sink for LanceDbSink {
         let conn = self.config.common.create_connection().await?;
 
         // Validate table exists and schema is compatible
-        let table = conn
-            .open_table(&self.config.common.table)
-            .execute()
-            .await
-            .context("failed to open LanceDB table")
-            .map_err(SinkError::LanceDb)?;
+        let table = self.config.common.open_table(&conn).await?;
 
         // Get the Lance table schema (Arrow schema)
         let lance_schema = table
@@ -210,36 +222,7 @@ impl Sink for LanceDbSink {
             .rw_schema_to_arrow_schema(&rw_schema)
             .map_err(|e| SinkError::LanceDb(anyhow!(e)))?;
 
-        // Check field count matches
-        if rw_arrow_schema.fields().len() != lance_schema.fields().len() {
-            return Err(SinkError::LanceDb(anyhow!(
-                "Columns mismatch. RisingWave schema has {} fields, LanceDB table has {} fields",
-                rw_arrow_schema.fields().len(),
-                lance_schema.fields().len()
-            )));
-        }
-
-        // Check each field name exists and type is compatible
-        for rw_field in rw_arrow_schema.fields() {
-            match lance_schema.field_with_name(rw_field.name()) {
-                Ok(lance_field) => {
-                    if rw_field.data_type() != lance_field.data_type() {
-                        return Err(SinkError::LanceDb(anyhow!(
-                            "column '{}' type mismatch: LanceDB type is {:?}, RisingWave type is {:?}",
-                            rw_field.name(),
-                            lance_field.data_type(),
-                            rw_field.data_type()
-                        )));
-                    }
-                }
-                Err(_) => {
-                    return Err(SinkError::LanceDb(anyhow!(
-                        "column '{}' not found in LanceDB table",
-                        rw_field.name()
-                    )));
-                }
-            }
-        }
+        validate_ordered_schema(&rw_arrow_schema, lance_schema.as_ref())?;
 
         Ok(())
     }
@@ -279,6 +262,46 @@ impl TryFrom<SinkParam> for LanceDbSink {
 use risingwave_common::array::arrow::arrow_array_lancedb as arrow_array;
 use risingwave_common::array::arrow::arrow_schema_lancedb as arrow_schema;
 
+fn validate_ordered_schema(
+    rw_arrow_schema: &arrow_schema::Schema,
+    lance_schema: &arrow_schema::Schema,
+) -> Result<()> {
+    if rw_arrow_schema.fields().len() != lance_schema.fields().len() {
+        return Err(SinkError::LanceDb(anyhow!(
+            "Columns mismatch. RisingWave schema has {} fields, LanceDB table has {} fields",
+            rw_arrow_schema.fields().len(),
+            lance_schema.fields().len()
+        )));
+    }
+
+    for (idx, (rw_field, lance_field)) in rw_arrow_schema
+        .fields()
+        .iter()
+        .zip_eq_fast(lance_schema.fields().iter())
+        .enumerate()
+    {
+        if rw_field.name() != lance_field.name() {
+            return Err(SinkError::LanceDb(anyhow!(
+                "column order mismatch at position {}: LanceDB column is '{}', RisingWave column is '{}'",
+                idx,
+                lance_field.name(),
+                rw_field.name()
+            )));
+        }
+
+        if rw_field.data_type() != lance_field.data_type() {
+            return Err(SinkError::LanceDb(anyhow!(
+                "column '{}' type mismatch: LanceDB type is {:?}, RisingWave type is {:?}",
+                rw_field.name(),
+                lance_field.data_type(),
+                rw_field.data_type()
+            )));
+        }
+    }
+
+    Ok(())
+}
+
 /// The writer writes data files directly to the Lance dataset storage using the
 /// low-level `FileFragment::create_fragments()` API. On checkpoint, it returns
 /// lightweight `Fragment` metadata (file paths + row counts) instead of the
@@ -298,12 +321,14 @@ pub struct LanceDbSinkWriter {
 }
 
 impl LanceDbSinkWriter {
-    pub fn new(config: LanceDbConfig, schema: Schema) -> Result<Self> {
+    pub async fn new(config: LanceDbConfig, schema: Schema) -> Result<Self> {
         let arrow_schema = LanceDbConvert
             .rw_schema_to_arrow_schema(&schema)
             .map_err(|e| SinkError::LanceDb(anyhow!(e)))?;
 
-        let dataset_uri = config.common.dataset_uri();
+        let conn = config.common.create_connection().await?;
+        let table = config.common.open_table(&conn).await?;
+        let dataset_uri = config.common.dataset_uri(&table).await?;
 
         Ok(Self {
             config,
@@ -716,7 +741,11 @@ mod tests {
 
         let config = LanceDbConfig::from_btreemap(properties).unwrap();
         assert_eq!(config.is_exactly_once, None);
-        let mut writer = LanceDbSinkWriter::new(config.clone(), schema.clone()).unwrap();
+        let mut writer = LanceDbSinkWriter::new(config.clone(), schema.clone())
+            .await
+            .unwrap();
+        let table = conn.open_table("test_table").execute().await.unwrap();
+        assert_eq!(writer.dataset_uri, table.uri().await.unwrap());
 
         // 4. Write a chunk
         let chunk = StreamChunk::new(
@@ -784,7 +813,9 @@ mod tests {
         assert_eq!(count, 4);
 
         // 9. Single-phase commit remains available when exactly-once is disabled.
-        let mut writer = LanceDbSinkWriter::new(config.clone(), schema).unwrap();
+        let mut writer = LanceDbSinkWriter::new(config.clone(), schema)
+            .await
+            .unwrap();
         let chunk = StreamChunk::new(
             vec![Op::Insert],
             vec![
@@ -812,5 +843,23 @@ mod tests {
         let table = conn.open_table("test_table").execute().await.unwrap();
         let count = table.count_rows(None).await.unwrap();
         assert_eq!(count, 5);
+    }
+
+    #[test]
+    fn test_validate_ordered_schema_rejects_reordered_columns() {
+        let rw_schema = arrow_schema::Schema::new(vec![
+            arrow_schema::Field::new("id", arrow_schema::DataType::Int32, false),
+            arrow_schema::Field::new("name", arrow_schema::DataType::Utf8, false),
+        ]);
+        let reordered_lance_schema = arrow_schema::Schema::new(vec![
+            arrow_schema::Field::new("name", arrow_schema::DataType::Utf8, false),
+            arrow_schema::Field::new("id", arrow_schema::DataType::Int32, false),
+        ]);
+
+        let err = validate_ordered_schema(&rw_schema, &reordered_lance_schema).unwrap_err();
+        assert!(
+            format!("{err:?}").contains("column order mismatch"),
+            "unexpected error: {err:?}"
+        );
     }
 }

--- a/src/connector/src/sink/mod.rs
+++ b/src/connector/src/sink/mod.rs
@@ -28,6 +28,7 @@ pub mod encoder;
 pub mod file_sink;
 pub mod formatter;
 feature_gated_sink_mod!(google_pubsub, GooglePubSub, "google_pubsub");
+feature_gated_sink_mod!(lancedb, LanceDb, "lancedb");
 pub mod http;
 pub mod iceberg;
 pub mod kafka;
@@ -104,6 +105,7 @@ use self::catalog::{SinkFormatDesc, SinkType};
 use self::clickhouse::CLICKHOUSE_SINK;
 use self::deltalake::DELTALAKE_SINK;
 use self::iceberg::ICEBERG_SINK;
+use self::lancedb::LANCEDB_SINK;
 use self::mock_coordination_client::{MockMetaClient, SinkCoordinationRpcClientEnum};
 use crate::WithPropertiesExt;
 use crate::connector_common::IcebergSinkCompactionUpdate;
@@ -151,6 +153,7 @@ macro_rules! for_all_sinks {
                 { Snowflake, $crate::sink::file_sink::opendal_sink::FileSink<$crate::sink::file_sink::s3::SnowflakeSink>, $crate::sink::file_sink::s3::SnowflakeConfig },
                 { RedShift, $crate::sink::snowflake_redshift::redshift::RedshiftSink, $crate::sink::snowflake_redshift::redshift::RedShiftConfig },
                 { DeltaLake, $crate::sink::deltalake::DeltaLakeSink, $crate::sink::deltalake::DeltaLakeConfig },
+                { LanceDb, $crate::sink::lancedb::LanceDbSink, $crate::sink::lancedb::LanceDbConfig },
                 { BigQuery, $crate::sink::big_query::BigQuerySink, $crate::sink::big_query::BigQueryConfig },
                 { DynamoDb, $crate::sink::dynamodb::DynamoDbSink, $crate::sink::dynamodb::DynamoDbConfig },
                 { Mongodb, $crate::sink::mongodb::MongodbSink, $crate::sink::mongodb::MongodbConfig },
@@ -696,7 +699,12 @@ impl SinkWriterParam {
 fn is_sink_support_commit_checkpoint_interval(sink_name: &str) -> bool {
     matches!(
         sink_name,
-        ICEBERG_SINK | CLICKHOUSE_SINK | STARROCKS_SINK | DELTALAKE_SINK | SNOWFLAKE_SINK_V2
+        ICEBERG_SINK
+            | CLICKHOUSE_SINK
+            | STARROCKS_SINK
+            | DELTALAKE_SINK
+            | SNOWFLAKE_SINK_V2
+            | LANCEDB_SINK
     )
 }
 pub trait Sink: TryFrom<SinkParam, Error = SinkError> {
@@ -1032,6 +1040,12 @@ pub enum SinkError {
     Doris(String),
     #[error("DeltaLake error: {0}")]
     DeltaLake(
+        #[source]
+        #[backtrace]
+        anyhow::Error,
+    ),
+    #[error("LanceDB error: {0}")]
+    LanceDb(
         #[source]
         #[backtrace]
         anyhow::Error,

--- a/src/connector/src/sink/mod.rs
+++ b/src/connector/src/sink/mod.rs
@@ -254,6 +254,27 @@ pub const SINK_USER_FORCE_COMPACTION: &str = "force_compaction";
 /// barrier. Upstream changes under the same stream key may still be compacted earlier.
 pub const SINK_USER_PRESERVE_ROW_LEVEL_CHANGES: &str = "preserve_row_level_changes";
 
+/// Return whether the configured sink uses exactly-once commit state.
+///
+/// Connector dispatch is centralized here, while each [`Sink`] implementation owns the
+/// interpretation and default of its properties.
+pub fn sink_is_exactly_once(properties: &BTreeMap<String, String>) -> Result<bool> {
+    let sink_type = properties
+        .get(CONNECTOR_TYPE_KEY)
+        .ok_or_else(|| SinkError::Config(anyhow!("missing config: {}", CONNECTOR_TYPE_KEY)))?
+        .to_lowercase();
+
+    match_sink_name_str!(
+        sink_type.as_str(),
+        SinkType,
+        SinkType::is_exactly_once(properties),
+        |other| Err(SinkError::Config(anyhow!(
+            "unsupported sink connector {}",
+            other
+        )))
+    )
+}
+
 pub trait UnknownFields {
     /// Unrecognized fields in the `WITH` clause.
     fn unknown_fields(&self) -> HashMap<String, String>;
@@ -786,6 +807,11 @@ pub trait Sink: TryFrom<SinkParam, Error = SinkError> {
     const SINK_NAME: &'static str;
 
     type LogSinker: LogSinker;
+
+    /// Return whether this sink uses exactly-once commit state for the loaded properties.
+    fn is_exactly_once(_properties: &BTreeMap<String, String>) -> Result<bool> {
+        Ok(false)
+    }
 
     fn set_default_commit_checkpoint_interval(
         desc: &mut SinkDesc,
@@ -1326,5 +1352,41 @@ mod tests {
         ]))
         .unwrap_err();
         assert!(err.to_report_string().contains("missing field `topic`"));
+    }
+
+    #[test]
+    fn test_sink_exactly_once_policy() {
+        assert!(sink_is_exactly_once(&btreemap([(CONNECTOR_TYPE_KEY, ICEBERG_SINK)])).unwrap());
+        assert!(
+            !sink_is_exactly_once(&btreemap([
+                (CONNECTOR_TYPE_KEY, ICEBERG_SINK),
+                ("is_exactly_once", "false"),
+            ]))
+            .unwrap()
+        );
+
+        #[cfg(feature = "sink-deltalake")]
+        {
+            assert!(
+                !sink_is_exactly_once(&btreemap([(CONNECTOR_TYPE_KEY, DELTALAKE_SINK)])).unwrap()
+            );
+            assert!(
+                sink_is_exactly_once(&btreemap([
+                    (CONNECTOR_TYPE_KEY, DELTALAKE_SINK),
+                    ("is_exactly_once", "true"),
+                ]))
+                .unwrap()
+            );
+        }
+
+        #[cfg(feature = "sink-lancedb")]
+        assert!(sink_is_exactly_once(&btreemap([(CONNECTOR_TYPE_KEY, LANCEDB_SINK)])).unwrap());
+
+        let error = sink_is_exactly_once(&btreemap([
+            (CONNECTOR_TYPE_KEY, ICEBERG_SINK),
+            ("is_exactly_once", "invalid"),
+        ]))
+        .unwrap_err();
+        assert!(error.to_report_string().contains("is_exactly_once"));
     }
 }

--- a/src/connector/src/sink/mod.rs
+++ b/src/connector/src/sink/mod.rs
@@ -28,6 +28,7 @@ pub mod encoder;
 pub mod file_sink;
 pub mod formatter;
 feature_gated_sink_mod!(google_pubsub, GooglePubSub, "google_pubsub");
+feature_gated_sink_mod!(lancedb, LanceDb, "lancedb");
 pub mod http;
 pub mod iceberg;
 pub mod kafka;
@@ -105,6 +106,7 @@ use self::catalog::{SinkFormatDesc, SinkType};
 use self::clickhouse::CLICKHOUSE_SINK;
 use self::deltalake::DELTALAKE_SINK;
 use self::iceberg::ICEBERG_SINK;
+use self::lancedb::LANCEDB_SINK;
 use self::mock_coordination_client::{MockMetaClient, SinkCoordinationRpcClientEnum};
 use crate::WithPropertiesExt;
 use crate::connector_common::IcebergSinkCompactionUpdate;
@@ -153,6 +155,7 @@ macro_rules! for_all_sinks {
                 { Snowflake, $crate::sink::file_sink::opendal_sink::FileSink<$crate::sink::file_sink::s3::SnowflakeSink>, $crate::sink::file_sink::s3::SnowflakeConfig },
                 { RedShift, $crate::sink::snowflake_redshift::redshift::RedshiftSink, $crate::sink::snowflake_redshift::redshift::RedShiftConfig },
                 { DeltaLake, $crate::sink::deltalake::DeltaLakeSink, $crate::sink::deltalake::DeltaLakeConfig },
+                { LanceDb, $crate::sink::lancedb::LanceDbSink, $crate::sink::lancedb::LanceDbConfig },
                 { BigQuery, $crate::sink::big_query::BigQuerySink, $crate::sink::big_query::BigQueryConfig },
                 { DynamoDb, $crate::sink::dynamodb::DynamoDbSink, $crate::sink::dynamodb::DynamoDbConfig },
                 { Mongodb, $crate::sink::mongodb::MongodbSink, $crate::sink::mongodb::MongodbConfig },
@@ -771,7 +774,12 @@ impl SinkWriterParam {
 fn is_sink_support_commit_checkpoint_interval(sink_name: &str) -> bool {
     matches!(
         sink_name,
-        ICEBERG_SINK | CLICKHOUSE_SINK | STARROCKS_SINK | DELTALAKE_SINK | SNOWFLAKE_SINK_V2
+        ICEBERG_SINK
+            | CLICKHOUSE_SINK
+            | STARROCKS_SINK
+            | DELTALAKE_SINK
+            | SNOWFLAKE_SINK_V2
+            | LANCEDB_SINK
     )
 }
 pub trait Sink: TryFrom<SinkParam, Error = SinkError> {
@@ -1126,6 +1134,12 @@ pub enum SinkError {
     Doris(String),
     #[error("DeltaLake error: {0}")]
     DeltaLake(
+        #[source]
+        #[backtrace]
+        anyhow::Error,
+    ),
+    #[error("LanceDB error: {0}")]
+    LanceDb(
         #[source]
         #[backtrace]
         anyhow::Error,

--- a/src/connector/with_options_sink.yaml
+++ b/src/connector/with_options_sink.yaml
@@ -1155,6 +1155,31 @@ KinesisSinkConfig:
     field_type: u64
     required: false
     default: '20000'
+LanceDbConfig:
+  fields:
+  - name: lancedb.uri
+    field_type: String
+    comments: URI of the `LanceDB` database (e.g., `/tmp/lancedb`, `<s3://bucket/path/db>`)
+    required: true
+  - name: lancedb.table
+    field_type: String
+    comments: Table name in the `LanceDB` database
+    required: true
+  - name: commit_checkpoint_interval
+    field_type: u64
+    comments: Commit every n(>0) checkpoints, default is 10.
+    required: false
+    default: DEFAULT_COMMIT_CHECKPOINT_INTERVAL_WITH_SINK_DECOUPLE
+    allow_alter_on_fly: true
+  - name: r#type
+    field_type: String
+    required: true
+  - name: is_exactly_once
+    field_type: bool
+    comments: |-
+      Whether to use RisingWave's two-phase commit framework for exactly-once commits.
+      Defaults to true. Set to false to use single-phase commits.
+    required: false
 MongodbConfig:
   fields:
   - name: mongodb.url

--- a/src/connector/with_options_sink.yaml
+++ b/src/connector/with_options_sink.yaml
@@ -1294,6 +1294,31 @@ KinesisSinkConfig:
     field_type: u64
     required: false
     default: '20000'
+LanceDbConfig:
+  fields:
+  - name: lancedb.uri
+    field_type: String
+    comments: URI of the `LanceDB` database (e.g., `/tmp/lancedb`, `<s3://bucket/path/db>`)
+    required: true
+  - name: lancedb.table
+    field_type: String
+    comments: Table name in the `LanceDB` database
+    required: true
+  - name: commit_checkpoint_interval
+    field_type: u64
+    comments: Commit every n(>0) checkpoints, default is 10.
+    required: false
+    default: DEFAULT_COMMIT_CHECKPOINT_INTERVAL_WITH_SINK_DECOUPLE
+    allow_alter_on_fly: true
+  - name: r#type
+    field_type: String
+    required: true
+  - name: is_exactly_once
+    field_type: bool
+    comments: |-
+      Whether to use RisingWave's two-phase commit framework for exactly-once commits.
+      Defaults to true. Set to false to use single-phase commits.
+    required: false
 MongodbConfig:
   fields:
   - name: mongodb.url

--- a/src/frontend/src/handler/create_sink.rs
+++ b/src/frontend/src/handler/create_sink.rs
@@ -1287,7 +1287,7 @@ pub mod tests {
             ("connector".to_owned(), "jdbc".to_owned()),
             ("is_exactly_once".to_owned(), "true".to_owned()),
         ]);
-        assert!(super::sink_is_exactly_once(&properties).unwrap());
+        assert!(!super::sink_is_exactly_once(&properties).unwrap());
     }
 
     #[tokio::test]

--- a/src/frontend/src/handler/create_sink.rs
+++ b/src/frontend/src/handler/create_sink.rs
@@ -43,6 +43,7 @@ use risingwave_connector::sink::snowflake_redshift::snowflake::SnowflakeV2Sink;
 use risingwave_connector::sink::{
     CONNECTOR_TYPE_KEY, SINK_SNAPSHOT_OPTION, SINK_TYPE_OPTION, SINK_TYPE_UPSERT,
     SINK_USER_FORCE_APPEND_ONLY_OPTION, SINK_USER_IGNORE_DELETE_OPTION, Sink, enforce_secret_sink,
+    sink_is_exactly_once,
 };
 use risingwave_connector::{
     AUTO_SCHEMA_CHANGE_KEY, SINK_CREATE_TABLE_IF_NOT_EXISTS_KEY, SINK_INTERMEDIATE_TABLE_NAME,
@@ -829,16 +830,6 @@ async fn create_sink_or_replace(
     Ok(PgResponse::empty_result(StatementType::CREATE_SINK))
 }
 
-fn sink_replace_requires_exactly_once_state(sink: &SinkCatalog) -> bool {
-    match sink.properties.get("is_exactly_once") {
-        Some(value) => value.eq_ignore_ascii_case("true"),
-        None => sink
-            .properties
-            .get(CONNECTOR_TYPE_KEY)
-            .is_some_and(|connector| connector.eq_ignore_ascii_case(ICEBERG_SINK)),
-    }
-}
-
 fn prepare_replace_sink(
     handle_args: &mut HandlerArgs,
     stmt: &CreateSinkStatement,
@@ -925,7 +916,7 @@ fn prepare_replace_sink(
             )
             .into());
         }
-        if sink_replace_requires_exactly_once_state(sink) {
+        if sink_is_exactly_once(&sink.properties)? {
             return Err(ErrorCode::NotSupported(
                 "REPLACE SINK does not support exactly-once sinks yet".to_owned(),
                 "set is_exactly_once=false or recreate the sink manually".to_owned(),
@@ -1279,6 +1270,24 @@ pub mod tests {
             options.get(SINK_INTERMEDIATE_TABLE_NAME).unwrap(),
             "custom_cdc"
         );
+    }
+
+    #[test]
+    fn test_sink_replace_requires_exactly_once_state_defaults() {
+        let properties = BTreeMap::from([("connector".to_owned(), "iceberg".to_owned())]);
+        assert!(super::sink_is_exactly_once(&properties).unwrap());
+
+        let properties = BTreeMap::from([
+            ("connector".to_owned(), "iceberg".to_owned()),
+            ("is_exactly_once".to_owned(), "false".to_owned()),
+        ]);
+        assert!(!super::sink_is_exactly_once(&properties).unwrap());
+
+        let properties = BTreeMap::from([
+            ("connector".to_owned(), "jdbc".to_owned()),
+            ("is_exactly_once".to_owned(), "true".to_owned()),
+        ]);
+        assert!(super::sink_is_exactly_once(&properties).unwrap());
     }
 
     #[tokio::test]

--- a/src/meta/src/lib.rs
+++ b/src/meta/src/lib.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #![allow(clippy::derive_partial_eq_without_eq)]
+#![recursion_limit = "256"]
 #![feature(trait_alias)]
 #![feature(type_alias_impl_trait)]
 #![feature(map_try_insert)]


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

This PR adds a new **LanceDB sink connector** that writes streaming data from RisingWave into [LanceDB](https://lancedb.com/) tables.

This is a fresh PR for the work from #25186, which was closed as stale.

### Architecture

The sink follows the **writer/coordinator pattern** with low-level write/commit separation:

- **Writer** (`LanceDbSinkWriter`): Converts each incoming `StreamChunk` to an Arrow `RecordBatch` and sends it through a bounded channel to a Lance fragment-writing task. `FileFragment::create_fragments()` consumes this stream incrementally, so the writer applies backpressure without buffering an entire fragment in RisingWave memory. At a checkpoint, the writer closes the stream, waits for the data files to finish, and returns lightweight `Fragment` metadata (file paths and row counts), not the data payload.
- **Coordinator** (`LanceDbSinkCommitter`): Collects `Fragment` metadata from all writers and atomically appends it through the Lance dataset transaction path. No data flows through the coordinator.

The sink supports both commit modes:

- **Two-phase commit** is the default (`is_exactly_once = true` or omitted). It stores both the stable `risingwave.sink_id` and monotonically increasing `risingwave.epoch` in Lance transaction properties. Retry detection scans transaction history from newest to oldest, ignores transactions from other sinks, and stops cleanly at the retained-history boundary. Because replacing a sink changes its catalog sink ID, `REPLACE SINK` rejects exactly-once sinks; set `is_exactly_once = false` to use replacement.
- **Single-phase commit** is available by setting `is_exactly_once = false`.

This design keeps memory bounded, avoids routing data through the coordinator, and makes replayed two-phase commits idempotent.

### Changes

| File | Description |
|------|-------------|
| `Cargo.toml` | Add workspace dependencies for LanceDB 0.29 and Lance 6.0 |
| `src/connector/Cargo.toml` | Add the `sink-lancedb` feature gate |
| `src/common/src/array/arrow/arrow_lancedb.rs` | Add Arrow type conversion for the Lance dependency stack |
| `src/connector/src/sink/lancedb.rs` | Add validation, streaming fragment writer, and single-/two-phase coordinators |
| `src/connector/src/sink/mod.rs` | Register the LanceDB sink |
| `e2e_test/sink/lancedb/` | Add the LanceDB sink end-to-end test |
| `ci/scripts/e2e-lancedb-sink-test.sh` | Add the CI test runner |
| `ci/workflows/pull-request.yml` | Add the label-gated `ci/run-e2e-lancedb-sink-tests` step |
| `ci/workflows/main-cron.yml` | Add the LanceDB sink main-cron step |

### Sink properties

```sql
CREATE SINK s AS SELECT * FROM mv
WITH (
    connector = 'lancedb',
    type = 'append-only',
    force_append_only = 'true',
    lancedb.uri = '/path/to/db',
    lancedb.table = 'my_table',
    is_exactly_once = 'true' -- optional, defaults to true
);
```

- Only **append-only** mode is supported.
- The LanceDB table must be pre-created with a compatible schema.
- `commit_checkpoint_interval` is configurable and defaults to 10.
- `is_exactly_once` controls the commit mode and defaults to `true`.

- Related to #25149
- Replaces #25186

## Checklist

- [x] I have written necessary rustdoc comments.
- [x] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [x] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/dev/src/ci.md#ci-labels-guide -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [x] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

Adds LanceDB as a new sink connector. The sink supports append-only streaming writes to an existing LanceDB table and defaults to two-phase commit for exactly-once commit replay safety.

</details>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a LanceDB sink for writing append-only data to LanceDB tables.
  * Added configuration for database URI, table name, checkpoint commit intervals, and commit behavior.
  * Added schema validation and support for atomic, idempotent sink commits.

* **Bug Fixes**
  * Improved exactly-once configuration handling for Iceberg and Delta Lake sinks, including validation of invalid values.

* **Tests**
  * Added end-to-end coverage validating LanceDB sink output and checkpoint commits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->