### PR TITLE
fix(meta): guard pending compaction target ranges

### DIFF
--- a/src/meta/src/hummock/compaction/in_progress_compaction.rs
+++ b/src/meta/src/hummock/compaction/in_progress_compaction.rs
@@ -1,0 +1,731 @@
+// Copyright 2026 RisingWave Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::cmp::Ordering;
+use std::collections::HashMap;
+
+use risingwave_hummock_sdk::compact_task::CompactTaskAssignment;
+use risingwave_hummock_sdk::key_range::{KeyRange, KeyRangeCommon};
+use risingwave_hummock_sdk::level::InputLevel;
+use risingwave_hummock_sdk::{CompactionGroupId, HummockCompactionTaskId};
+
+use crate::hummock::compaction::picker::CompactionInput;
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+enum TargetContainer {
+    Level(u32),
+    L0SubLevel(u64),
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct CompactionTargetRange {
+    target_container: TargetContainer,
+    key_range: KeyRange,
+}
+
+impl CompactionTargetRange {
+    fn from_input_levels(
+        target_level: u32,
+        target_sub_level_id: u64,
+        input_levels: &[InputLevel],
+    ) -> Option<Self> {
+        let key_range = input_key_range(input_levels)?;
+        Some(Self {
+            target_container: target_container(target_level, target_sub_level_id),
+            key_range,
+        })
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct InProgressTargetRange {
+    task_id: HummockCompactionTaskId,
+    key_range: KeyRange,
+}
+
+#[derive(Default)]
+pub struct InProgressCompactionView {
+    ranges_by_target_container: HashMap<TargetContainer, Vec<InProgressTargetRange>>,
+}
+
+impl InProgressCompactionView {
+    pub(crate) fn for_group<'a>(
+        assignments: impl IntoIterator<Item = &'a CompactTaskAssignment>,
+        compaction_group_id: CompactionGroupId,
+    ) -> Self {
+        let mut view = Self::default();
+        for assignment in assignments {
+            let task = &assignment.compact_task;
+            if task.compaction_group_id != compaction_group_id {
+                continue;
+            }
+
+            let Some(target_range) = CompactionTargetRange::from_input_levels(
+                task.target_level,
+                task.target_sub_level_id,
+                &task.input_ssts,
+            ) else {
+                continue;
+            };
+            view.ranges_by_target_container
+                .entry(target_range.target_container)
+                .or_default()
+                .push(InProgressTargetRange {
+                    task_id: task.task_id,
+                    key_range: target_range.key_range,
+                });
+        }
+
+        // Finalize each target bucket for binary-search based overlap checks.
+        for ranges in view.ranges_by_target_container.values_mut() {
+            ranges.sort_by(|left, right| left.key_range.cmp(&right.key_range));
+            assert!(
+                ranges
+                    .windows(2)
+                    .all(|pair| !pair[0].key_range.sstable_overlap(&pair[1].key_range)),
+                "in-progress target ranges must not overlap within the same target container"
+            );
+        }
+
+        view
+    }
+
+    pub(crate) fn has_conflict_with_input(&self, input: &CompactionInput) -> bool {
+        let target_range = CompactionTargetRange::from_input_levels(
+            input.target_level as u32,
+            input.target_sub_level_id,
+            &input.input_levels,
+        );
+        target_range
+            .as_ref()
+            .and_then(|target_range| self.conflict_target_range(target_range))
+            .is_some()
+    }
+
+    fn conflict_target_range(
+        &self,
+        target_range: &CompactionTargetRange,
+    ) -> Option<HummockCompactionTaskId> {
+        let ranges = self
+            .ranges_by_target_container
+            .get(&target_range.target_container)?;
+        // Follow the range overlap strategy: `compare_right_with` skips ranges that end before the
+        // candidate, and `sstable_overlap` performs the final right-exclusive-aware check. Ranges
+        // in the same target container are non-overlapping, so the first remaining range is enough.
+        let pos = ranges.partition_point(|range| {
+            range
+                .key_range
+                .compare_right_with(&target_range.key_range.left)
+                == Ordering::Less
+        });
+
+        ranges.get(pos).and_then(|range| {
+            target_range
+                .key_range
+                .sstable_overlap(&range.key_range)
+                .then_some(range.task_id)
+        })
+    }
+}
+
+fn target_container(target_level: u32, target_sub_level_id: u64) -> TargetContainer {
+    match target_level {
+        0 => TargetContainer::L0SubLevel(target_sub_level_id),
+        level => TargetContainer::Level(level),
+    }
+}
+
+fn input_key_range(input_levels: &[InputLevel]) -> Option<KeyRange> {
+    let mut range: Option<KeyRange> = None;
+    for level in input_levels {
+        for sst in &level.table_infos {
+            assert!(
+                !sst.key_range.inf_key_range(),
+                "input SST key range for pending compaction target range must be finite: level_idx={}, sst_id={}",
+                level.level_idx,
+                sst.sst_id,
+            );
+            match range.as_mut() {
+                Some(range) => range.full_key_extend(&sst.key_range),
+                None => range = Some(sst.key_range.clone()),
+            }
+        }
+    }
+    range
+}
+
+#[cfg(test)]
+mod tests {
+    use bytes::Bytes;
+    use risingwave_hummock_sdk::compact_task::{CompactTask, CompactTaskAssignment};
+    use risingwave_hummock_sdk::sstable_info::{SstableInfo, SstableInfoInner};
+    use risingwave_pb::hummock::LevelType;
+
+    use super::*;
+
+    fn sst(sst_id: u64, left: usize, right: usize) -> SstableInfo {
+        SstableInfoInner {
+            object_id: sst_id.into(),
+            sst_id: sst_id.into(),
+            sst_size: (right - left) as u64,
+            key_range: KeyRange {
+                left: Bytes::from(crate::hummock::test_utils::iterator_test_key_of_epoch(
+                    1, left, 1,
+                )),
+                right: Bytes::from(crate::hummock::test_utils::iterator_test_key_of_epoch(
+                    1, right, 1,
+                )),
+                right_exclusive: false,
+            },
+            ..Default::default()
+        }
+        .into()
+    }
+
+    fn input_level(
+        level_idx: u32,
+        level_type: LevelType,
+        table_infos: Vec<SstableInfo>,
+    ) -> InputLevel {
+        InputLevel {
+            level_idx,
+            level_type,
+            table_infos,
+        }
+    }
+
+    fn compact_task(
+        task_id: u64,
+        compaction_group_id: u64,
+        target_level: u32,
+        target_sub_level_id: u64,
+        input_ssts: Vec<InputLevel>,
+    ) -> CompactTask {
+        CompactTask {
+            task_id,
+            compaction_group_id: compaction_group_id.into(),
+            target_level,
+            target_sub_level_id,
+            input_ssts,
+            ..Default::default()
+        }
+    }
+
+    fn compaction_input(
+        target_level: usize,
+        target_sub_level_id: u64,
+        input_levels: Vec<InputLevel>,
+    ) -> CompactionInput {
+        CompactionInput {
+            input_levels,
+            target_level,
+            target_sub_level_id,
+            ..Default::default()
+        }
+    }
+
+    fn assignment(task: CompactTask) -> CompactTaskAssignment {
+        CompactTaskAssignment {
+            compact_task: task,
+            context_id: 1.into(),
+        }
+    }
+
+    fn view_for_group(
+        tasks: Vec<CompactTask>,
+        compaction_group_id: u64,
+    ) -> InProgressCompactionView {
+        let assignments: Vec<_> = tasks.into_iter().map(assignment).collect();
+        InProgressCompactionView::for_group(&assignments, compaction_group_id.into())
+    }
+
+    #[test]
+    fn target_range_uses_apply_target_container() {
+        for (target_level, target_sub_level_id, input_levels, expected_container) in [
+            (
+                4,
+                0,
+                vec![
+                    input_level(0, LevelType::Nonoverlapping, vec![sst(2, 10, 20)]),
+                    input_level(4, LevelType::Nonoverlapping, vec![sst(1, 1, 5)]),
+                ],
+                TargetContainer::Level(4),
+            ),
+            (
+                0,
+                42,
+                vec![input_level(
+                    0,
+                    LevelType::Nonoverlapping,
+                    vec![sst(1, 2, 4)],
+                )],
+                TargetContainer::L0SubLevel(42),
+            ),
+            (
+                0,
+                42,
+                vec![input_level(0, LevelType::Overlapping, vec![sst(1, 2, 4)])],
+                TargetContainer::L0SubLevel(42),
+            ),
+            (
+                0,
+                42,
+                vec![
+                    input_level(0, LevelType::Nonoverlapping, vec![sst(1, 2, 4)]),
+                    input_level(0, LevelType::Overlapping, vec![sst(2, 5, 7)]),
+                ],
+                TargetContainer::L0SubLevel(42),
+            ),
+        ] {
+            let range = CompactionTargetRange::from_input_levels(
+                target_level,
+                target_sub_level_id,
+                &input_levels,
+            )
+            .unwrap();
+
+            assert_eq!(range.target_container, expected_container);
+        }
+    }
+
+    #[test]
+    #[should_panic(
+        expected = "input SST key range for pending compaction target range must be finite"
+    )]
+    fn target_range_rejects_infinite_input_sst_key_range() {
+        let _ = CompactionTargetRange::from_input_levels(
+            4,
+            0,
+            &[input_level(
+                0,
+                LevelType::Nonoverlapping,
+                vec![
+                    SstableInfoInner {
+                        object_id: 1.into(),
+                        sst_id: 1.into(),
+                        key_range: KeyRange::inf(),
+                        ..Default::default()
+                    }
+                    .into(),
+                ],
+            )],
+        );
+    }
+
+    #[test]
+    fn target_conflict_requires_same_container_and_overlapping_key_range() {
+        let in_progress = view_for_group(
+            vec![compact_task(
+                7,
+                9,
+                4,
+                0,
+                vec![input_level(
+                    0,
+                    LevelType::Nonoverlapping,
+                    vec![sst(1, 10, 20)],
+                )],
+            )],
+            9,
+        );
+        let overlapping = CompactionTargetRange::from_input_levels(
+            4,
+            0,
+            &[input_level(
+                0,
+                LevelType::Nonoverlapping,
+                vec![sst(2, 15, 25)],
+            )],
+        );
+        let different_level = CompactionTargetRange::from_input_levels(
+            5,
+            0,
+            &[input_level(
+                0,
+                LevelType::Nonoverlapping,
+                vec![sst(3, 15, 25)],
+            )],
+        );
+        let disjoint = CompactionTargetRange::from_input_levels(
+            4,
+            0,
+            &[input_level(
+                0,
+                LevelType::Nonoverlapping,
+                vec![sst(4, 30, 40)],
+            )],
+        );
+        let touching_right_boundary = CompactionTargetRange::from_input_levels(
+            4,
+            0,
+            &[input_level(
+                0,
+                LevelType::Nonoverlapping,
+                vec![sst(5, 20, 30)],
+            )],
+        );
+
+        assert_eq!(
+            in_progress.conflict_target_range(&overlapping.unwrap()),
+            Some(7)
+        );
+        assert_eq!(
+            in_progress.conflict_target_range(&different_level.unwrap()),
+            None
+        );
+        assert_eq!(in_progress.conflict_target_range(&disjoint.unwrap()), None);
+        assert_eq!(
+            in_progress.conflict_target_range(&touching_right_boundary.unwrap()),
+            Some(7)
+        );
+    }
+
+    #[test]
+    fn target_conflict_from_input_ignores_skip_policy() {
+        let in_progress = view_for_group(
+            vec![compact_task(
+                7,
+                9,
+                4,
+                0,
+                vec![input_level(
+                    0,
+                    LevelType::Nonoverlapping,
+                    vec![sst(1, 10, 20)],
+                )],
+            )],
+            9,
+        );
+        let mut input = compaction_input(
+            4,
+            0,
+            vec![input_level(
+                0,
+                LevelType::Nonoverlapping,
+                vec![sst(2, 15, 25)],
+            )],
+        );
+
+        assert!(in_progress.has_conflict_with_input(&input));
+        input.skip_target_range_conflict_check = true;
+
+        assert!(in_progress.has_conflict_with_input(&input));
+    }
+
+    #[test]
+    fn target_conflict_respects_right_exclusive_boundary() {
+        let in_progress = view_for_group(
+            vec![compact_task(
+                7,
+                9,
+                4,
+                0,
+                vec![input_level(
+                    0,
+                    LevelType::Nonoverlapping,
+                    vec![
+                        SstableInfoInner {
+                            object_id: 1.into(),
+                            sst_id: 1.into(),
+                            sst_size: 10,
+                            key_range: KeyRange {
+                                left: Bytes::from(
+                                    crate::hummock::test_utils::iterator_test_key_of_epoch(
+                                        1, 10, 1,
+                                    ),
+                                ),
+                                right: Bytes::from(
+                                    crate::hummock::test_utils::iterator_test_key_of_epoch(
+                                        1, 20, 1,
+                                    ),
+                                ),
+                                right_exclusive: true,
+                            },
+                            ..Default::default()
+                        }
+                        .into(),
+                    ],
+                )],
+            )],
+            9,
+        );
+        let touching_exclusive_boundary = CompactionTargetRange::from_input_levels(
+            4,
+            0,
+            &[input_level(
+                0,
+                LevelType::Nonoverlapping,
+                vec![sst(2, 20, 30)],
+            )],
+        );
+
+        assert_eq!(
+            in_progress.conflict_target_range(&touching_exclusive_boundary.unwrap()),
+            None
+        );
+    }
+
+    #[test]
+    fn target_conflict_uses_input_key_range_envelope() {
+        let in_progress = view_for_group(
+            vec![compact_task(
+                7,
+                9,
+                4,
+                0,
+                vec![input_level(
+                    0,
+                    LevelType::Nonoverlapping,
+                    vec![sst(1, 10, 20), sst(2, 40, 50)],
+                )],
+            )],
+            9,
+        );
+        let gap_inside_input_envelope = CompactionTargetRange::from_input_levels(
+            4,
+            0,
+            &[input_level(
+                0,
+                LevelType::Nonoverlapping,
+                vec![sst(3, 25, 35)],
+            )],
+        );
+
+        assert_eq!(
+            in_progress.conflict_target_range(&gap_inside_input_envelope.unwrap()),
+            Some(7)
+        );
+    }
+
+    #[test]
+    fn target_conflict_finds_later_range_in_same_container() {
+        let in_progress = view_for_group(
+            vec![
+                compact_task(
+                    7,
+                    9,
+                    4,
+                    0,
+                    vec![input_level(
+                        0,
+                        LevelType::Nonoverlapping,
+                        vec![sst(1, 10, 20)],
+                    )],
+                ),
+                compact_task(
+                    8,
+                    9,
+                    4,
+                    0,
+                    vec![input_level(
+                        0,
+                        LevelType::Nonoverlapping,
+                        vec![sst(2, 40, 50)],
+                    )],
+                ),
+                compact_task(
+                    9,
+                    9,
+                    4,
+                    0,
+                    vec![input_level(
+                        0,
+                        LevelType::Nonoverlapping,
+                        vec![sst(3, 70, 80)],
+                    )],
+                ),
+            ],
+            9,
+        );
+        let overlapping_later = CompactionTargetRange::from_input_levels(
+            4,
+            0,
+            &[input_level(
+                0,
+                LevelType::Nonoverlapping,
+                vec![sst(4, 45, 46)],
+            )],
+        );
+        let disjoint_gap = CompactionTargetRange::from_input_levels(
+            4,
+            0,
+            &[input_level(
+                0,
+                LevelType::Nonoverlapping,
+                vec![sst(5, 25, 35)],
+            )],
+        );
+
+        assert_eq!(
+            in_progress.conflict_target_range(&overlapping_later.unwrap()),
+            Some(8)
+        );
+        assert_eq!(
+            in_progress.conflict_target_range(&disjoint_gap.unwrap()),
+            None
+        );
+    }
+
+    #[test]
+    fn target_conflict_checks_non_overlapping_l0_sub_level_container() {
+        let in_progress = view_for_group(
+            vec![compact_task(
+                7,
+                9,
+                0,
+                42,
+                vec![input_level(
+                    0,
+                    LevelType::Nonoverlapping,
+                    vec![sst(1, 10, 20)],
+                )],
+            )],
+            9,
+        );
+        let same_sub_level = CompactionTargetRange::from_input_levels(
+            0,
+            42,
+            &[input_level(
+                0,
+                LevelType::Nonoverlapping,
+                vec![sst(2, 15, 25)],
+            )],
+        );
+        let different_sub_level = CompactionTargetRange::from_input_levels(
+            0,
+            43,
+            &[input_level(
+                0,
+                LevelType::Nonoverlapping,
+                vec![sst(3, 15, 25)],
+            )],
+        );
+
+        assert_eq!(
+            in_progress.conflict_target_range(&same_sub_level.unwrap()),
+            Some(7)
+        );
+        assert_eq!(
+            in_progress.conflict_target_range(&different_sub_level.unwrap()),
+            None
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "in-progress target ranges must not overlap")]
+    fn assignment_projection_rejects_overlapping_target_ranges() {
+        let assignments = vec![
+            assignment(compact_task(
+                7,
+                9,
+                4,
+                0,
+                vec![input_level(
+                    0,
+                    LevelType::Nonoverlapping,
+                    vec![sst(1, 10, 20)],
+                )],
+            )),
+            assignment(compact_task(
+                8,
+                9,
+                4,
+                0,
+                vec![input_level(
+                    0,
+                    LevelType::Nonoverlapping,
+                    vec![sst(2, 15, 25)],
+                )],
+            )),
+        ];
+
+        let _ = InProgressCompactionView::for_group(&assignments, 9.into());
+    }
+
+    #[test]
+    fn assignment_projection_filters_by_compaction_group_and_target_range() {
+        let group_9_task = compact_task(
+            7,
+            9,
+            4,
+            0,
+            vec![input_level(
+                0,
+                LevelType::Nonoverlapping,
+                vec![sst(1, 10, 20)],
+            )],
+        );
+        let group_10_task = compact_task(
+            8,
+            10,
+            4,
+            0,
+            vec![input_level(
+                0,
+                LevelType::Nonoverlapping,
+                vec![sst(2, 30, 40)],
+            )],
+        );
+        let group_9_l0_task = compact_task(
+            9,
+            9,
+            0,
+            0,
+            vec![input_level(0, LevelType::Overlapping, vec![sst(3, 50, 60)])],
+        );
+        let assignments = vec![
+            assignment(group_9_task),
+            assignment(group_10_task),
+            assignment(group_9_l0_task),
+        ];
+
+        let projection = InProgressCompactionView::for_group(&assignments, 9.into());
+        let group_9_range = CompactionTargetRange::from_input_levels(
+            4,
+            0,
+            &[input_level(
+                0,
+                LevelType::Nonoverlapping,
+                vec![sst(4, 15, 16)],
+            )],
+        );
+        let group_10_range = CompactionTargetRange::from_input_levels(
+            4,
+            0,
+            &[input_level(
+                0,
+                LevelType::Nonoverlapping,
+                vec![sst(5, 35, 36)],
+            )],
+        );
+        let group_9_l0_range = CompactionTargetRange::from_input_levels(
+            0,
+            0,
+            &[input_level(0, LevelType::Overlapping, vec![sst(6, 55, 56)])],
+        );
+
+        assert_eq!(
+            projection.conflict_target_range(&group_9_range.unwrap()),
+            Some(7)
+        );
+        assert_eq!(
+            projection.conflict_target_range(&group_10_range.unwrap()),
+            None
+        );
+        assert_eq!(
+            projection.conflict_target_range(&group_9_l0_range.unwrap()),
+            Some(9)
+        );
+    }
+}

--- a/src/meta/src/hummock/compaction/mod.rs
+++ b/src/meta/src/hummock/compaction/mod.rs
@@ -15,6 +15,7 @@
 #![expect(clippy::arc_with_non_send_sync, reason = "FIXME: later")]
 
 pub mod compaction_config;
+pub(crate) mod in_progress_compaction;
 mod overlap_strategy;
 use risingwave_common::catalog::{TableId, TableOption};
 use risingwave_hummock_sdk::compact_task::CompactTask;
@@ -41,6 +42,7 @@ pub use selector::{CompactionSelector, CompactionSelectorContext};
 use self::selector::{EmergencySelector, LocalSelectorStatistic};
 use super::GroupStateValidator;
 use crate::MetaOpts;
+use crate::hummock::compaction::in_progress_compaction::InProgressCompactionView;
 use crate::hummock::compaction::overlap_strategy::{OverlapStrategy, RangeOverlapStrategy};
 use crate::hummock::compaction::picker::CompactionInput;
 use crate::hummock::level_handler::LevelHandler;
@@ -110,6 +112,7 @@ impl CompactStatus {
         developer_config: Arc<CompactionDeveloperConfig>,
         table_watermarks: &HashMap<TableId, Arc<TableWatermarks>>,
         state_table_info: &HummockVersionStateTableInfo,
+        in_progress_compactions: &InProgressCompactionView,
     ) -> Option<CompactionTask> {
         let selector_context = CompactionSelectorContext {
             group,
@@ -121,6 +124,7 @@ impl CompactStatus {
             developer_config: developer_config.clone(),
             table_watermarks,
             state_table_info,
+            in_progress_compactions,
         };
         // When we compact the files, we must make the result of compaction meet the following
         // conditions, for any user key, the epoch of it in the file existing in the lower
@@ -146,6 +150,7 @@ impl CompactStatus {
                         developer_config,
                         table_watermarks,
                         state_table_info,
+                        in_progress_compactions,
                     };
                     return EmergencySelector::default().pick_compaction(task_id, selector_context);
                 }

--- a/src/meta/src/hummock/compaction/picker/intra_compaction_picker.rs
+++ b/src/meta/src/hummock/compaction/picker/intra_compaction_picker.rs
@@ -400,6 +400,7 @@ impl WholeLevelCompactionPicker {
                     select_input_size,
                     total_file_count,
                     vnode_partition_count,
+                    skip_target_range_conflict_check: true,
                     ..Default::default()
                 };
                 if wait_enough

--- a/src/meta/src/hummock/compaction/picker/mod.rs
+++ b/src/meta/src/hummock/compaction/picker/mod.rs
@@ -63,6 +63,7 @@ pub struct CompactionInput {
     pub target_input_size: u64,
     pub total_file_count: u64,
     pub vnode_partition_count: u32,
+    pub skip_target_range_conflict_check: bool,
 }
 
 impl CompactionInput {

--- a/src/meta/src/hummock/compaction/picker/tier_compaction_picker.rs
+++ b/src/meta/src/hummock/compaction/picker/tier_compaction_picker.rs
@@ -123,6 +123,7 @@ impl TierCompactionPicker {
                 target_input_size: 0,
                 total_file_count: compact_file_count,
                 vnode_partition_count,
+                skip_target_range_conflict_check: true,
             };
 
             if !self.compaction_task_validator.valid_compact_task(

--- a/src/meta/src/hummock/compaction/picker/vnode_watermark_picker.rs
+++ b/src/meta/src/hummock/compaction/picker/vnode_watermark_picker.rs
@@ -67,6 +67,7 @@ impl VnodeWatermarkCompactionPicker {
             ],
             target_level: level.level_idx as usize,
             target_sub_level_id: level.sub_level_id,
+            skip_target_range_conflict_check: true,
             ..Default::default()
         })
     }
@@ -110,10 +111,22 @@ mod tests {
     use risingwave_common::hash::VirtualNode;
     use risingwave_hummock_sdk::key::{FullKey, TableKey};
     use risingwave_hummock_sdk::key_range::KeyRange;
+    use risingwave_hummock_sdk::level::{Level, Levels};
     use risingwave_hummock_sdk::sstable_info::SstableInfoInner;
     use risingwave_hummock_sdk::table_watermark::{ReadTableWatermark, WatermarkDirection};
+    use risingwave_pb::hummock::LevelType;
 
-    use crate::hummock::compaction::picker::vnode_watermark_picker::should_delete_sst_by_watermark;
+    use crate::hummock::compaction::picker::vnode_watermark_picker::{
+        VnodeWatermarkCompactionPicker, should_delete_sst_by_watermark,
+    };
+    use crate::hummock::level_handler::LevelHandler;
+
+    fn table_key(vnode_part: usize, key_part: &str) -> TableKey<Bytes> {
+        let mut builder = BytesMut::new();
+        builder.put_slice(&VirtualNode::from_index(vnode_part).to_be_bytes());
+        builder.put_slice(&Bytes::copy_from_slice(key_part.as_bytes()));
+        TableKey(builder.freeze())
+    }
 
     #[test]
     fn test_should_delete_sst_by_watermark() {
@@ -125,12 +138,6 @@ mod tests {
                     VirtualNode::from_index(17) => "some_watermark_key_8".into(),
                 },
             },
-        };
-        let table_key = |vnode_part: usize, key_part: &str| {
-            let mut builder = BytesMut::new();
-            builder.put_slice(&VirtualNode::from_index(vnode_part).to_be_bytes());
-            builder.put_slice(&Bytes::copy_from_slice(key_part.as_bytes()));
-            TableKey(builder.freeze())
         };
 
         let sst_info = SstableInfoInner {
@@ -234,5 +241,22 @@ mod tests {
         }
         .into();
         assert!(should_delete_sst_by_watermark(&sst_info, &table_watermarks));
+
+        let levels = Levels {
+            levels: vec![Level {
+                level_idx: 1,
+                level_type: LevelType::Nonoverlapping,
+                table_infos: vec![sst_info],
+                ..Default::default()
+            }],
+            ..Default::default()
+        };
+        let level_handlers = vec![LevelHandler::new(0), LevelHandler::new(1)];
+
+        let input = VnodeWatermarkCompactionPicker::new()
+            .pick_compaction(&levels, &level_handlers, &table_watermarks)
+            .unwrap();
+
+        assert!(input.skip_target_range_conflict_check);
     }
 }

--- a/src/meta/src/hummock/compaction/selector/emergency_selector.rs
+++ b/src/meta/src/hummock/compaction/selector/emergency_selector.rs
@@ -35,6 +35,7 @@ impl CompactionSelector for EmergencySelector {
             level_handlers,
             selector_stats,
             developer_config,
+            in_progress_compactions,
             ..
         } = context;
         let dynamic_level_core = DynamicLevelSelectorCore::new(
@@ -50,6 +51,14 @@ impl CompactionSelector for EmergencySelector {
 
         let mut stats = LocalPickerStatistic::default();
         if let Some(compaction_input) = picker.pick_compaction(levels, level_handlers, &mut stats) {
+            if !compaction_input.skip_target_range_conflict_check
+                && in_progress_compactions.has_conflict_with_input(&compaction_input)
+            {
+                stats.skip_by_overlapping += 1;
+                selector_stats.skip_picker.push((0, ctx.base_level, stats));
+                return None;
+            }
+
             compaction_input.add_pending_task(task_id, level_handlers);
 
             return Some(create_compaction_task(

--- a/src/meta/src/hummock/compaction/selector/level_selector.rs
+++ b/src/meta/src/hummock/compaction/selector/level_selector.rs
@@ -434,6 +434,7 @@ impl CompactionSelector for DynamicLevelSelector {
             level_handlers,
             selector_stats,
             developer_config,
+            in_progress_compactions,
             ..
         } = context;
         let dynamic_level_core = DynamicLevelSelectorCore::new(
@@ -459,6 +460,18 @@ impl CompactionSelector for DynamicLevelSelector {
 
             let mut stats = LocalPickerStatistic::default();
             if let Some(ret) = picker.pick_compaction(levels, level_handlers, &mut stats) {
+                if !ret.skip_target_range_conflict_check
+                    && in_progress_compactions.has_conflict_with_input(&ret)
+                {
+                    stats.skip_by_overlapping += 1;
+                    selector_stats.skip_picker.push((
+                        picker_info.select_level,
+                        picker_info.target_level,
+                        stats,
+                    ));
+                    continue;
+                }
+
                 ret.add_pending_task(task_id, level_handlers);
                 return Some(create_compaction_task(
                     dynamic_level_core.get_config(),
@@ -492,22 +505,53 @@ pub mod tests {
 
     use itertools::Itertools;
     use risingwave_common::constants::hummock::CompactionFilterFlag;
-    use risingwave_hummock_sdk::level::Levels;
+    use risingwave_hummock_sdk::HummockCompactionTaskId;
+    use risingwave_hummock_sdk::compact_task::{CompactTask, CompactTaskAssignment};
+    use risingwave_hummock_sdk::level::{InputLevel, Levels};
     use risingwave_hummock_sdk::version::HummockVersionStateTableInfo;
+    use risingwave_pb::hummock::LevelType;
     use risingwave_pb::hummock::compaction_config::CompactionMode;
 
-    use crate::hummock::compaction::CompactionDeveloperConfig;
     use crate::hummock::compaction::compaction_config::CompactionConfigBuilder;
+    use crate::hummock::compaction::in_progress_compaction::InProgressCompactionView;
     use crate::hummock::compaction::selector::tests::{
         assert_compaction_task, generate_l0_nonoverlapping_sublevels, generate_level,
-        generate_tables, push_tables_level0_nonoverlapping,
+        generate_table, generate_tables, push_tables_level0_nonoverlapping,
     };
     use crate::hummock::compaction::selector::{
-        CompactionSelector, DynamicLevelSelector, DynamicLevelSelectorCore, LocalSelectorStatistic,
+        CompactionSelector, CompactionSelectorContext, DynamicLevelSelector,
+        DynamicLevelSelectorCore, LocalSelectorStatistic,
     };
+    use crate::hummock::compaction::{CompactionDeveloperConfig, CompactionTask};
     use crate::hummock::level_handler::LevelHandler;
     use crate::hummock::model::CompactionGroup;
     use crate::hummock::test_utils::compaction_selector_context;
+
+    fn pick_compaction_with_in_progress(
+        selector: &mut DynamicLevelSelector,
+        task_id: HummockCompactionTaskId,
+        group: &CompactionGroup,
+        levels: &Levels,
+        level_handlers: &mut [LevelHandler],
+        selector_stats: &mut LocalSelectorStatistic,
+        in_progress_compactions: &InProgressCompactionView,
+    ) -> Option<CompactionTask> {
+        selector.pick_compaction(
+            task_id,
+            CompactionSelectorContext {
+                group,
+                levels,
+                member_table_ids: &BTreeSet::new(),
+                level_handlers,
+                selector_stats,
+                table_id_to_options: &HashMap::default(),
+                developer_config: Arc::new(CompactionDeveloperConfig::default()),
+                table_watermarks: &HashMap::default(),
+                state_table_info: &HummockVersionStateTableInfo::empty(),
+                in_progress_compactions,
+            },
+        )
+    }
 
     #[test]
     fn test_dynamic_level() {
@@ -725,6 +769,99 @@ pub mod tests {
             ),
         );
         assert!(compaction.is_none());
+    }
+
+    #[test]
+    fn test_trivial_move_skips_in_progress_target_overlap() {
+        let config = CompactionConfigBuilder::new()
+            .max_bytes_for_level_base(1000)
+            .max_bytes_for_level_multiplier(10)
+            .max_level(4)
+            .max_compaction_bytes(10000)
+            .level0_sub_level_compact_level_count(20)
+            .sst_allowed_trivial_move_min_size(Some(0))
+            .sst_allowed_trivial_move_max_count(Some(10))
+            .compaction_mode(CompactionMode::Range as i32)
+            .build();
+        let group_config = CompactionGroup::new(9, config);
+        let levels = Levels {
+            levels: vec![
+                generate_level(1, vec![]),
+                generate_level(2, vec![]),
+                generate_level(3, vec![]),
+                generate_level(4, vec![generate_table(878784, 1, 565, 633, 1)]),
+            ],
+            l0: generate_l0_nonoverlapping_sublevels(vec![
+                generate_table(877832, 1, 706, 718, 1),
+                generate_table(877833, 1, 800, 2000, 1),
+            ]),
+            ..Default::default()
+        };
+        let in_progress = InProgressCompactionView::for_group(
+            &[CompactTaskAssignment {
+                compact_task: CompactTask {
+                    task_id: 15040,
+                    compaction_group_id: 9.into(),
+                    target_level: 4,
+                    input_ssts: vec![
+                        InputLevel {
+                            level_idx: 0,
+                            level_type: LevelType::Nonoverlapping,
+                            table_infos: vec![generate_table(881160, 1, 592, 722, 1)],
+                        },
+                        InputLevel {
+                            level_idx: 4,
+                            level_type: LevelType::Nonoverlapping,
+                            table_infos: vec![generate_table(878784, 1, 565, 633, 1)],
+                        },
+                    ],
+                    ..Default::default()
+                },
+                context_id: 1.into(),
+            }],
+            9.into(),
+        );
+
+        let mut selector = DynamicLevelSelector::default();
+        let mut levels_handlers = (0..5).map(LevelHandler::new).collect_vec();
+        let mut local_stats = LocalSelectorStatistic::default();
+        let empty_in_progress = InProgressCompactionView::default();
+        let compaction = pick_compaction_with_in_progress(
+            &mut selector,
+            1,
+            &group_config,
+            &levels,
+            &mut levels_handlers,
+            &mut local_stats,
+            &empty_in_progress,
+        )
+        .unwrap();
+        assert_eq!(compaction.input.target_level, 4);
+        assert!(compaction.input.input_levels[1].table_infos.is_empty());
+        assert!(
+            compaction.input.input_levels[0]
+                .table_infos
+                .iter()
+                .any(|sst| sst.sst_id.as_raw_id() == 877832)
+        );
+
+        let mut selector = DynamicLevelSelector::default();
+        let mut levels_handlers = (0..5).map(LevelHandler::new).collect_vec();
+        let mut local_stats = LocalSelectorStatistic::default();
+        assert!(
+            pick_compaction_with_in_progress(
+                &mut selector,
+                2,
+                &group_config,
+                &levels,
+                &mut levels_handlers,
+                &mut local_stats,
+                &in_progress,
+            )
+            .is_none()
+        );
+        assert_eq!(local_stats.skip_picker.len(), 1);
+        assert_eq!(local_stats.skip_picker[0].2.skip_by_overlapping, 1);
     }
 
     #[test]

--- a/src/meta/src/hummock/compaction/selector/manual_selector.rs
+++ b/src/meta/src/hummock/compaction/selector/manual_selector.rs
@@ -100,6 +100,7 @@ impl CompactionSelector for ManualCompactionSelector {
             levels,
             level_handlers,
             developer_config,
+            in_progress_compactions,
             ..
         } = context;
         self.blocked_by_pending = false;
@@ -187,6 +188,11 @@ impl CompactionSelector for ManualCompactionSelector {
         }
 
         let compaction_input = compaction_input?;
+        if !compaction_input.skip_target_range_conflict_check
+            && in_progress_compactions.has_conflict_with_input(&compaction_input)
+        {
+            return None;
+        }
         compaction_input.add_pending_task(task_id, level_handlers);
 
         Some(create_compaction_task(

--- a/src/meta/src/hummock/compaction/selector/mod.rs
+++ b/src/meta/src/hummock/compaction/selector/mod.rs
@@ -42,6 +42,7 @@ pub use tombstone_compaction_selector::TombstoneCompactionSelector;
 pub use ttl_selector::TtlCompactionSelector;
 pub use vnode_watermark_selector::VnodeWatermarkCompactionSelector;
 
+use super::in_progress_compaction::InProgressCompactionView;
 use super::picker::LocalPickerStatistic;
 use super::{
     CompactionDeveloperConfig, LevelCompactionPicker, TierCompactionPicker, create_compaction_task,
@@ -61,6 +62,7 @@ pub struct CompactionSelectorContext<'a> {
     pub developer_config: Arc<CompactionDeveloperConfig>,
     pub table_watermarks: &'a HashMap<TableId, Arc<TableWatermarks>>,
     pub state_table_info: &'a HummockVersionStateTableInfo,
+    pub in_progress_compactions: &'a InProgressCompactionView,
 }
 
 pub trait CompactionSelector: Sync + Send {

--- a/src/meta/src/hummock/compaction/selector/space_reclaim_selector.rs
+++ b/src/meta/src/hummock/compaction/selector/space_reclaim_selector.rs
@@ -44,6 +44,7 @@ impl CompactionSelector for SpaceReclaimCompactionSelector {
             member_table_ids,
             level_handlers,
             developer_config,
+            in_progress_compactions,
             ..
         } = context;
         let dynamic_level_core =
@@ -56,6 +57,11 @@ impl CompactionSelector for SpaceReclaimCompactionSelector {
         let state = self.state.entry(group.group_id).or_default();
 
         let compaction_input = picker.pick_compaction(levels, level_handlers, state)?;
+        if !compaction_input.skip_target_range_conflict_check
+            && in_progress_compactions.has_conflict_with_input(&compaction_input)
+        {
+            return None;
+        }
         compaction_input.add_pending_task(task_id, level_handlers);
 
         Some(create_compaction_task(

--- a/src/meta/src/hummock/compaction/selector/tombstone_compaction_selector.rs
+++ b/src/meta/src/hummock/compaction/selector/tombstone_compaction_selector.rs
@@ -40,6 +40,7 @@ impl CompactionSelector for TombstoneCompactionSelector {
             levels,
             level_handlers,
             developer_config,
+            in_progress_compactions,
             ..
         } = context;
         if group.compaction_config.tombstone_reclaim_ratio == 0 {
@@ -57,6 +58,11 @@ impl CompactionSelector for TombstoneCompactionSelector {
         );
         let state = self.state.entry(group.group_id).or_default();
         let compaction_input = picker.pick_compaction(levels, level_handlers, state)?;
+        if !compaction_input.skip_target_range_conflict_check
+            && in_progress_compactions.has_conflict_with_input(&compaction_input)
+        {
+            return None;
+        }
         compaction_input.add_pending_task(task_id, level_handlers);
 
         Some(create_compaction_task(

--- a/src/meta/src/hummock/compaction/selector/ttl_selector.rs
+++ b/src/meta/src/hummock/compaction/selector/ttl_selector.rs
@@ -44,6 +44,7 @@ impl CompactionSelector for TtlCompactionSelector {
             level_handlers,
             table_id_to_options,
             developer_config,
+            in_progress_compactions,
             ..
         } = context;
         let dynamic_level_core =
@@ -52,6 +53,11 @@ impl CompactionSelector for TtlCompactionSelector {
         let picker = TtlReclaimCompactionPicker::new(table_id_to_options);
         let state = self.state.entry(group.group_id).or_default();
         let compaction_input = picker.pick_compaction(levels, level_handlers, state)?;
+        if !compaction_input.skip_target_range_conflict_check
+            && in_progress_compactions.has_conflict_with_input(&compaction_input)
+        {
+            return None;
+        }
         compaction_input.add_pending_task(task_id, level_handlers);
 
         Some(create_compaction_task(

--- a/src/meta/src/hummock/compaction/selector/vnode_watermark_selector.rs
+++ b/src/meta/src/hummock/compaction/selector/vnode_watermark_selector.rs
@@ -45,6 +45,7 @@ impl CompactionSelector for VnodeWatermarkCompactionSelector {
             table_watermarks,
             state_table_info: _,
             member_table_ids,
+            in_progress_compactions,
             ..
         } = context;
         let dynamic_level_core =
@@ -55,6 +56,11 @@ impl CompactionSelector for VnodeWatermarkCompactionSelector {
             safe_epoch_read_table_watermarks(table_watermarks, member_table_ids);
         let compaction_input =
             picker.pick_compaction(levels, level_handlers, &pk_table_watermarks)?;
+        if !compaction_input.skip_target_range_conflict_check
+            && in_progress_compactions.has_conflict_with_input(&compaction_input)
+        {
+            return None;
+        }
         compaction_input.add_pending_task(task_id, level_handlers);
         Some(create_compaction_task(
             dynamic_level_core.get_config(),

--- a/src/meta/src/hummock/manager/compaction/mod.rs
+++ b/src/meta/src/hummock/manager/compaction/mod.rs
@@ -58,6 +58,7 @@ use tokio::task::JoinHandle;
 use tonic::Streaming;
 use tracing::warn;
 
+use crate::hummock::compaction::in_progress_compaction::InProgressCompactionView;
 use crate::hummock::compaction::selector::level_selector::PickerInfo;
 use crate::hummock::compaction::selector::{
     DynamicLevelSelector, DynamicLevelSelectorCore, LocalSelectorStatistic, ManualCompactionOption,
@@ -450,6 +451,11 @@ impl HummockManager {
                 }
             }
 
+            let in_progress_compactions = InProgressCompactionView::for_group(
+                compact_task_assignment.tree_ref().values(),
+                compaction_group_id,
+            );
+
             while let Some(picked_task) = compact_status.get_compact_task(
                 version
                     .latest_version()
@@ -466,6 +472,7 @@ impl HummockManager {
                 developer_config.clone(),
                 &version.latest_version().table_watermarks,
                 &version.latest_version().state_table_info,
+                &in_progress_compactions,
             ) {
                 let compaction_group_levels = version
                     .latest_version()

--- a/src/meta/src/hummock/test_utils.rs
+++ b/src/meta/src/hummock/test_utils.rs
@@ -15,7 +15,7 @@
 #![cfg(any(test, feature = "test"))]
 
 use std::collections::{BTreeSet, HashMap};
-use std::sync::Arc;
+use std::sync::{Arc, LazyLock};
 use std::time::Duration;
 
 use bytes::Bytes;
@@ -41,6 +41,7 @@ use risingwave_rpc_client::HummockMetaClient;
 use crate::controller::catalog::CatalogController;
 use crate::controller::cluster::{ClusterController, ClusterControllerRef};
 use crate::hummock::compaction::compaction_config::CompactionConfigBuilder;
+use crate::hummock::compaction::in_progress_compaction::InProgressCompactionView;
 use crate::hummock::compaction::selector::{LocalSelectorStatistic, default_compaction_selector};
 use crate::hummock::compaction::{CompactionDeveloperConfig, CompactionSelectorContext};
 use crate::hummock::level_handler::LevelHandler;
@@ -49,6 +50,9 @@ use crate::hummock::model::CompactionGroup;
 use crate::hummock::{CompactorManager, HummockManager, HummockManagerRef};
 use crate::manager::MetaSrvEnv;
 use crate::rpc::metrics::MetaMetrics;
+
+static EMPTY_IN_PROGRESS_COMPACTION_VIEW: LazyLock<InProgressCompactionView> =
+    LazyLock::new(InProgressCompactionView::default);
 
 pub fn to_local_sstable_info(ssts: &[SstableInfo]) -> Vec<LocalSstableInfo> {
     ssts.iter()
@@ -426,6 +430,7 @@ pub fn compaction_selector_context<'a>(
         developer_config,
         table_watermarks,
         state_table_info,
+        in_progress_compactions: &EMPTY_IN_PROGRESS_COMPACTION_VIEW,
     }
 }
 


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

This PR adds a target key-range guard for in-progress Hummock compaction tasks. The fix is scoped to the target-overlap bug: it keeps the existing `LevelHandler` / input-SST pending guard unchanged, and derives an `InProgressCompactionView` from `compact_task_assignment` for target write-range checks.

The view projects each running compaction task into a target container plus a pending key-range envelope computed from its full input levels:

- non-L0 output is guarded by `TargetContainer::Level(target_level)`;
- L0 output is guarded by `TargetContainer::L0SubLevel(target_sub_level_id)`;
- the pending key-range is extended from all input SST key ranges, using the same key-range overlap semantics as existing compaction overlap checks.

Selectors check the projection after a candidate `CompactionInput` is picked and before `add_pending_task(...)` registers input-SST pending state. If the candidate target range overlaps an in-progress task in the same target container, the selector rejects the candidate; `DynamicLevelSelector` can then try the next picker plan when available.

Whole-level L0 candidates such as tier compaction and whole-level intra compaction set `skip_target_range_conflict_check` on `CompactionInput`, so the selector can deliberately skip this target-range guard without leaking that policy into `InProgressCompactionView`.

This PR does not refactor input pending ownership and does not add an assignment-time second conflict check. It only adds the target-range projection and picker-time guard needed for the bug fix. The `compact_task_assignment` in-memory struct refactor is already in `main` via #25951 and is not part of this PR diff after rebase.

## Checklist

- [ ] I have written necessary rustdoc comments.
- [x] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [x] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

Not user-facing.

</details>

## Local verification

- `cargo fmt --all --check`
- `cargo check -p risingwave_meta --lib`
- `cargo test -p risingwave_meta hummock::compaction::in_progress_compaction --lib`
- `cargo test -p risingwave_meta hummock::compaction::selector::level_selector::tests::test_trivial_move_skips_in_progress_target_overlap --lib`