### PR TITLE
perf: store compact task assignments in memory form

### DIFF
--- a/src/meta/src/hummock/compactor_manager.rs
+++ b/src/meta/src/hummock/compactor_manager.rs
@@ -23,7 +23,7 @@ use risingwave_hummock_sdk::compact_task::CompactTask;
 use risingwave_hummock_sdk::{HummockCompactionTaskId, HummockContextId};
 use risingwave_pb::hummock::subscribe_compaction_event_response::Event as ResponseEvent;
 use risingwave_pb::hummock::{
-    CancelCompactTask, CompactTaskAssignment, CompactTaskProgress, SubscribeCompactionEventResponse,
+    CancelCompactTask, CompactTaskProgress, SubscribeCompactionEventResponse,
 };
 use risingwave_pb::iceberg_compaction::subscribe_iceberg_compaction_event_response::Event as IcebergResponseEvent;
 use risingwave_pb::iceberg_compaction::{
@@ -32,6 +32,7 @@ use risingwave_pb::iceberg_compaction::{
 use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender};
 
 use crate::MetaResult;
+use crate::hummock::model::ext::compaction_task_model_to_assignment;
 use crate::manager::MetaSrvEnv;
 use crate::model::MetadataModelError;
 
@@ -156,12 +157,12 @@ impl CompactorManagerInner {
         use risingwave_meta_model::compaction_task;
         use sea_orm::EntityTrait;
         // Retrieve the existing task assignments from metastore.
-        let task_assignment: Vec<CompactTaskAssignment> = compaction_task::Entity::find()
+        let task_assignment: Vec<_> = compaction_task::Entity::find()
             .all(&env.meta_store_ref().conn)
             .await
             .map_err(MetadataModelError::from)?
             .into_iter()
-            .map(Into::into)
+            .map(compaction_task_model_to_assignment)
             .collect();
         let mut manager = Self {
             task_expired_seconds: env.opts.compaction_task_max_progress_interval_secs,
@@ -171,7 +172,7 @@ impl CompactorManagerInner {
         };
         // Initialize heartbeat for existing tasks.
         task_assignment.into_iter().for_each(|assignment| {
-            manager.initiate_task_heartbeat(CompactTask::from(assignment.compact_task.unwrap()));
+            manager.initiate_task_heartbeat(assignment.compact_task);
         });
         Ok(manager)
     }

--- a/src/meta/src/hummock/manager/compaction/compaction_group_schedule.rs
+++ b/src/meta/src/hummock/manager/compaction/compaction_group_schedule.rs
@@ -469,16 +469,15 @@ impl HummockManager {
         compact_task_assignments
             .into_iter()
             .for_each(|task_assignment| {
-                if let Some(task) = task_assignment.compact_task.as_ref() {
-                    assert_eq!(task.compaction_group_id, right_group_id);
-                    canceled_tasks.push(ReportTask {
-                        task_id: task.task_id,
-                        task_status: TaskStatus::ManualCanceled,
-                        table_stats_change: HashMap::default(),
-                        sorted_output_ssts: vec![],
-                        object_timestamps: HashMap::default(),
-                    });
-                }
+                let task = &task_assignment.compact_task;
+                assert_eq!(task.compaction_group_id, right_group_id);
+                canceled_tasks.push(ReportTask {
+                    task_id: task.task_id,
+                    task_status: TaskStatus::ManualCanceled,
+                    table_stats_change: HashMap::default(),
+                    sorted_output_ssts: vec![],
+                    object_timestamps: HashMap::default(),
+                });
             });
 
         if !canceled_tasks.is_empty() {
@@ -794,20 +793,19 @@ impl HummockManager {
         compact_task_assignments
             .into_iter()
             .for_each(|task_assignment| {
-                if let Some(task) = task_assignment.compact_task.as_ref() {
-                    let is_expired = is_compaction_task_expired(
-                        task.compaction_group_version_id,
-                        levels.compaction_group_version_id,
-                    );
-                    if is_expired {
-                        canceled_tasks.push(ReportTask {
-                            task_id: task.task_id,
-                            task_status: TaskStatus::ManualCanceled,
-                            table_stats_change: HashMap::default(),
-                            sorted_output_ssts: vec![],
-                            object_timestamps: HashMap::default(),
-                        });
-                    }
+                let task = &task_assignment.compact_task;
+                let is_expired = is_compaction_task_expired(
+                    task.compaction_group_version_id,
+                    levels.compaction_group_version_id,
+                );
+                if is_expired {
+                    canceled_tasks.push(ReportTask {
+                        task_id: task.task_id,
+                        task_status: TaskStatus::ManualCanceled,
+                        table_stats_change: HashMap::default(),
+                        sorted_output_ssts: vec![],
+                        object_timestamps: HashMap::default(),
+                    });
                 }
             });
 
@@ -1097,12 +1095,11 @@ impl HummockManager {
         compact_task_assignments
             .into_iter()
             .for_each(|task_assignment| {
-                if let Some(task) = task_assignment.compact_task.as_ref()
-                    && is_compaction_task_expired(
-                        task.compaction_group_version_id,
-                        levels.compaction_group_version_id,
-                    )
-                {
+                let task = &task_assignment.compact_task;
+                if is_compaction_task_expired(
+                    task.compaction_group_version_id,
+                    levels.compaction_group_version_id,
+                ) {
                     canceled_tasks.push(ReportTask {
                         task_id: task.task_id,
                         task_status: TaskStatus::ManualCanceled,

--- a/src/meta/src/hummock/manager/compaction/mod.rs
+++ b/src/meta/src/hummock/manager/compaction/mod.rs
@@ -29,7 +29,7 @@ use rand::seq::SliceRandom;
 use risingwave_common::catalog::TableId;
 use risingwave_common::config::meta::default::compaction_config;
 use risingwave_common::util::epoch::Epoch;
-use risingwave_hummock_sdk::compact_task::{CompactTask, ReportTask};
+use risingwave_hummock_sdk::compact_task::{CompactTask, CompactTaskAssignment, ReportTask};
 use risingwave_hummock_sdk::compaction_group::StateTableId;
 use risingwave_hummock_sdk::compaction_group::hummock_version_ext::safe_epoch_table_watermarks_impl;
 use risingwave_hummock_sdk::level::Levels;
@@ -47,7 +47,7 @@ use risingwave_meta_model::hummock_sequence::COMPACTION_TASK_ID;
 use risingwave_pb::hummock::compact_task::{TaskStatus, TaskType};
 use risingwave_pb::hummock::subscribe_compaction_event_response::Event as ResponseEvent;
 use risingwave_pb::hummock::{
-    CompactTaskAssignment, CompactionConfig, PbCompactStatus, PbCompactTaskAssignment,
+    CompactTaskAssignment as PbCompactTaskAssignment, CompactionConfig, PbCompactStatus,
     SubscribeCompactionEventRequest, TableOption, compact_task,
 };
 use thiserror_ext::AsReport;
@@ -196,7 +196,7 @@ impl HummockVersionTransaction<'_> {
 #[derive(Default)]
 pub struct Compaction {
     /// Compaction task that is already assigned to a compactor
-    pub compact_task_assignment: BTreeMap<HummockCompactionTaskId, PbCompactTaskAssignment>,
+    pub compact_task_assignment: BTreeMap<HummockCompactionTaskId, CompactTaskAssignment>,
     /// `CompactStatus` of each compaction group
     pub compaction_statuses: BTreeMap<CompactionGroupId, CompactStatus>,
 
@@ -210,14 +210,28 @@ impl HummockManager {
 
     pub async fn list_compaction_status(
         &self,
-    ) -> (Vec<PbCompactStatus>, Vec<CompactTaskAssignment>) {
-        let compaction = self.compaction.read().await;
+    ) -> (Vec<PbCompactStatus>, Vec<PbCompactTaskAssignment>) {
+        let (compaction_statuses, compact_task_assignments) = {
+            let compaction = self.compaction.read().await;
+            (
+                compaction
+                    .compaction_statuses
+                    .values()
+                    .map_into()
+                    .collect_vec(),
+                compaction
+                    .compact_task_assignment
+                    .values()
+                    .cloned()
+                    .collect_vec(),
+            )
+        };
+
         (
-            compaction.compaction_statuses.values().map_into().collect(),
-            compaction
-                .compact_task_assignment
-                .values()
-                .cloned()
+            compaction_statuses,
+            compact_task_assignments
+                .into_iter()
+                .map(PbCompactTaskAssignment::from)
                 .collect(),
         )
     }
@@ -515,7 +529,7 @@ impl HummockManager {
                         compact_task_assignment.insert(
                             compact_task.task_id,
                             CompactTaskAssignment {
-                                compact_task: Some(compact_task.clone().into()),
+                                compact_task: compact_task.clone(),
                                 context_id: META_NODE_ID, // deprecated
                             },
                         );
@@ -839,7 +853,7 @@ impl HummockManager {
             let task_id = task.task_id;
             let mut task_status = task.task_status;
             let mut compact_task = match compact_task_assignment.remove(task.task_id) {
-                Some(compact_task) => CompactTask::from(compact_task.compact_task.unwrap()),
+                Some(compact_task_assignment) => compact_task_assignment.compact_task,
                 None => {
                     tracing::warn!("{}", format!("compact task {} not found", task.task_id));
                     rets[idx] = false;
@@ -1350,7 +1364,7 @@ impl HummockManager {
             guard.compact_task_assignment.insert(
                 task_id,
                 CompactTaskAssignment {
-                    compact_task: Some(task.into()),
+                    compact_task: task,
                     context_id: 0.into(),
                 },
             );
@@ -1543,15 +1557,8 @@ impl Compaction {
         self.compact_task_assignment
             .iter()
             .filter_map(|(_, assignment)| {
-                if assignment
-                    .compact_task
-                    .as_ref()
-                    .is_some_and(|task| task.compaction_group_id == compaction_group_id)
-                {
-                    Some(CompactTaskAssignment {
-                        compact_task: assignment.compact_task.clone(),
-                        context_id: assignment.context_id,
-                    })
+                if assignment.compact_task.compaction_group_id == compaction_group_id {
+                    Some(assignment.clone())
                 } else {
                     None
                 }

--- a/src/meta/src/hummock/manager/mod.rs
+++ b/src/meta/src/hummock/manager/mod.rs
@@ -36,8 +36,7 @@ use risingwave_meta_model::{
 };
 use risingwave_pb::hummock::compact_task::TaskStatus;
 use risingwave_pb::hummock::{
-    HummockVersionStats, PbCompactTaskAssignment, PbCompactionGroupInfo,
-    SubscribeCompactionEventRequest,
+    HummockVersionStats, PbCompactionGroupInfo, SubscribeCompactionEventRequest,
 };
 use table_write_throughput_statistic::TableWriteThroughputStatisticManager;
 use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender, unbounded_channel};
@@ -52,7 +51,7 @@ use crate::hummock::manager::checkpoint::HummockVersionCheckpoint;
 use crate::hummock::manager::context::ContextInfo;
 use crate::hummock::manager::gc::{FullGcState, GcManager};
 use crate::hummock::manager::sequence::PrefetchedSequence;
-use crate::hummock::model::ext::to_table_change_log;
+use crate::hummock::model::ext::{compaction_task_model_to_assignment, to_table_change_log};
 use crate::manager::{MetaSrvEnv, MetadataManager};
 use crate::model::{ClusterId, MetadataModelError};
 use crate::rpc::metrics::MetaMetrics;
@@ -452,7 +451,7 @@ impl HummockManager {
             .map(|m| {
                 (
                     m.id as HummockCompactionTaskId,
-                    PbCompactTaskAssignment::from(m),
+                    compaction_task_model_to_assignment(m),
                 )
             })
             .collect();

--- a/src/meta/src/hummock/model/ext/hummock.rs
+++ b/src/meta/src/hummock/model/ext/hummock.rs
@@ -15,6 +15,7 @@
 use itertools::Itertools;
 use risingwave_common::catalog::TableId;
 use risingwave_hummock_sdk::change_log::EpochNewChangeLog;
+use risingwave_hummock_sdk::compact_task::{CompactTask, CompactTaskAssignment};
 use risingwave_hummock_sdk::version::HummockVersionDelta;
 use risingwave_meta_model::compaction_config::CompactionConfig;
 use risingwave_meta_model::compaction_status::LevelHandlers;
@@ -28,8 +29,7 @@ use risingwave_meta_model::{
     hummock_version_delta, hummock_version_stats,
 };
 use risingwave_pb::hummock::{
-    CompactTaskAssignment, HummockPinnedSnapshot, HummockPinnedVersion, HummockVersionStats,
-    PbSstableInfo,
+    HummockPinnedSnapshot, HummockPinnedVersion, HummockVersionStats, PbSstableInfo,
 };
 use sea_orm::ActiveValue::Set;
 use sea_orm::EntityTrait;
@@ -40,6 +40,15 @@ use crate::hummock::model::CompactionGroup;
 use crate::model::{MetadataModelError, MetadataModelResult, Transactional};
 
 pub type Transaction = sea_orm::DatabaseTransaction;
+
+pub(crate) fn compaction_task_model_to_assignment(
+    model: compaction_task::Model,
+) -> CompactTaskAssignment {
+    CompactTaskAssignment {
+        compact_task: CompactTask::from(model.task.to_protobuf()),
+        context_id: model.context_id,
+    }
+}
 
 impl From<sea_orm::DbErr> for MetadataModelError {
     fn from(err: sea_orm::DbErr) -> Self {
@@ -111,9 +120,9 @@ impl Transactional<Transaction> for CompactStatus {
 #[async_trait::async_trait]
 impl Transactional<Transaction> for CompactTaskAssignment {
     async fn upsert_in_transaction(&self, trx: &mut Transaction) -> MetadataModelResult<()> {
-        let task = self.compact_task.clone().unwrap();
+        let task: risingwave_pb::hummock::CompactTask = (&self.compact_task).into();
         let m = compaction_task::ActiveModel {
-            id: Set(task.task_id.try_into().unwrap()),
+            id: Set(self.compact_task.task_id.try_into().unwrap()),
             context_id: Set(self.context_id),
             task: Set(CompactionTask::from(&task)),
         };
@@ -133,7 +142,7 @@ impl Transactional<Transaction> for CompactTaskAssignment {
 
     async fn delete_in_transaction(&self, trx: &mut Transaction) -> MetadataModelResult<()> {
         compaction_task::Entity::delete_by_id(
-            CompactionTaskId::try_from(self.compact_task.as_ref().unwrap().task_id).unwrap(),
+            CompactionTaskId::try_from(self.compact_task.task_id).unwrap(),
         )
         .exec(trx)
         .await?;

--- a/src/storage/hummock_sdk/src/compact_task.rs
+++ b/src/storage/hummock_sdk/src/compact_task.rs
@@ -20,8 +20,9 @@ use risingwave_common::catalog::TableId;
 use risingwave_pb::hummock::compact_task::{PbTaskStatus, PbTaskType, TaskStatus, TaskType};
 use risingwave_pb::hummock::subscribe_compaction_event_request::PbReportTask;
 use risingwave_pb::hummock::{
-    LevelType, PbCompactTask, PbKeyRange, PbSstableFilterLayout, PbSstableFilterType,
-    PbTableOption, PbTableSchema, PbTableStats, PbValidationTask,
+    CompactTaskAssignment as PbCompactTaskAssignment, LevelType, PbCompactTask, PbKeyRange,
+    PbSstableFilterLayout, PbSstableFilterType, PbTableOption, PbTableSchema, PbTableStats,
+    PbValidationTask,
 };
 use risingwave_pb::id::WorkerId;
 
@@ -30,7 +31,7 @@ use crate::key_range::KeyRange;
 use crate::level::InputLevel;
 use crate::sstable_info::SstableInfo;
 use crate::table_watermark::{TableWatermarks, WatermarkSerdeType};
-use crate::{CompactionGroupId, HummockSstableObjectId};
+use crate::{CompactionGroupId, HummockContextId, HummockSstableObjectId};
 
 #[derive(Clone, PartialEq, Default, Debug)]
 pub struct CompactTask {
@@ -93,6 +94,12 @@ pub struct CompactTask {
     pub sstable_filter_kind: PbSstableFilterType,
 
     pub sstable_filter_layout: PbSstableFilterLayout,
+}
+
+#[derive(Clone, PartialEq, Default, Debug)]
+pub struct CompactTaskAssignment {
+    pub compact_task: CompactTask,
+    pub context_id: HummockContextId,
 }
 
 impl CompactTask {
@@ -596,6 +603,42 @@ impl From<&CompactTask> for PbCompactTask {
             max_vnode_key_range_bytes: compact_task.max_vnode_key_range_bytes,
             sstable_filter_kind: compact_task.sstable_filter_kind.into(),
             sstable_filter_layout: compact_task.sstable_filter_layout.into(),
+        }
+    }
+}
+
+impl From<PbCompactTaskAssignment> for CompactTaskAssignment {
+    fn from(assignment: PbCompactTaskAssignment) -> Self {
+        Self {
+            compact_task: CompactTask::from(assignment.compact_task.unwrap()),
+            context_id: assignment.context_id,
+        }
+    }
+}
+
+impl From<&PbCompactTaskAssignment> for CompactTaskAssignment {
+    fn from(assignment: &PbCompactTaskAssignment) -> Self {
+        Self {
+            compact_task: CompactTask::from(assignment.compact_task.as_ref().unwrap()),
+            context_id: assignment.context_id,
+        }
+    }
+}
+
+impl From<CompactTaskAssignment> for PbCompactTaskAssignment {
+    fn from(assignment: CompactTaskAssignment) -> Self {
+        Self {
+            compact_task: Some(assignment.compact_task.into()),
+            context_id: assignment.context_id,
+        }
+    }
+}
+
+impl From<&CompactTaskAssignment> for PbCompactTaskAssignment {
+    fn from(assignment: &CompactTaskAssignment) -> Self {
+        Self {
+            compact_task: Some((&assignment.compact_task).into()),
+            context_id: assignment.context_id,
         }
     }
 }


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

This PR changes meta's in-memory compaction assignment state from protobuf `CompactTaskAssignment` to the SDK in-memory `CompactTaskAssignment` that owns a `CompactTask`.

The goal is to avoid keeping assigned compaction tasks in protobuf-owned form inside meta after `CompactTask` and related SST metadata have already moved to memory-friendly structures such as `Arc<SstableInfoInner>`. The protobuf representation is still preserved at RPC and metastore boundaries.

Main changes:

- Add SDK `CompactTaskAssignment` and conversions to/from protobuf assignment.
- Store `Compaction::compact_task_assignment` as the SDK in-memory assignment.
- Persist assigned tasks by converting to protobuf only in the metastore transaction boundary.
- Convert back to protobuf only for `ListCompactTaskAssignment`/status RPC output, outside the compaction read lock.
- Reuse the in-memory assignment in report and group-scheduling cancellation paths.


## Checklist

- [ ] I have written necessary rustdoc comments.
- [x] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [x] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

No user-facing behavior changes.

<details>
<summary><b>Release note</b></summary>

Not user-facing.

</details>