### PR TITLE
fix(stream): report recovered snapshot backfill row count

### DIFF
--- a/src/stream/src/executor/backfill/snapshot_backfill/executor.rs
+++ b/src/stream/src/executor/backfill/snapshot_backfill/executor.rs
@@ -1054,7 +1054,6 @@ async fn make_consume_snapshot_stream<'a, S: StateStore>(
         )
     }
 
-    let mut count = 0;
     let mut epoch_row_count = 0;
     let mut backfill_paused = initial_backfill_paused;
     loop {
@@ -1078,7 +1077,6 @@ async fn make_consume_snapshot_stream<'a, S: StateStore>(
                     backfill_paused = false;
                 }
                 if let Some(chunk) = snapshot_stream.consume_builder() {
-                    count += chunk.cardinality();
                     epoch_row_count += chunk.cardinality();
                     yield Message::Chunk(chunk);
                 }
@@ -1096,6 +1094,7 @@ async fn make_consume_snapshot_stream<'a, S: StateStore>(
                         }
                     })
                     .await?;
+                let count = backfill_state.total_row_count();
                 let post_commit = backfill_state.commit(barrier.epoch).await?;
                 trace!(?barrier_epoch, count, epoch_row_count, "update progress");
                 progress.update(barrier_epoch, barrier_epoch.prev, count as _);
@@ -1126,7 +1125,6 @@ async fn make_consume_snapshot_stream<'a, S: StateStore>(
                         anyhow!("snapshot backfill paused, but received snapshot chunk").into(),
                     );
                 }
-                count += chunk.cardinality();
                 epoch_row_count += chunk.cardinality();
                 yield Message::Chunk(chunk);
             }
@@ -1140,13 +1138,14 @@ async fn make_consume_snapshot_stream<'a, S: StateStore>(
     let barrier_to_report_finish = receive_next_barrier(barrier_rx).await?;
     assert_eq!(barrier_to_report_finish.epoch.prev, barrier_epoch.curr);
     barrier_epoch = barrier_to_report_finish.epoch;
-    trace!(?barrier_epoch, count, "report finish");
     snapshot_stream
         .for_vnode_pk_progress(|vnode, row_count, pk_progress| {
             assert_eq!(pk_progress, None);
             backfill_state.finish_epoch(vnode, snapshot_epoch, row_count);
         })
         .await?;
+    let count = backfill_state.total_row_count();
+    trace!(?barrier_epoch, count, "report finish");
     let post_commit = backfill_state.commit(barrier_epoch).await?;
     progress.finish(barrier_epoch, count as _);
     yield Message::Barrier(barrier_to_report_finish);

--- a/src/stream/src/executor/backfill/snapshot_backfill/state.rs
+++ b/src/stream/src/executor/backfill/snapshot_backfill/state.rs
@@ -362,6 +362,12 @@ impl<S: StateStore> BackfillState<S> {
         })
     }
 
+    pub(super) fn total_row_count(&self) -> usize {
+        self.latest_progress()
+            .filter_map(|(_, progress)| progress.map(|progress| progress.row_count))
+            .sum()
+    }
+
     pub(super) async fn commit(
         &mut self,
         barrier_epoch: EpochPair,


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

Snapshot backfill progress reports used an executor-local row counter while the per-vnode progress state table persisted absolute row counts. After recovery, the local counter started from zero, so `rw_ddl_progress` could show only rows consumed after restart while the internal progress table still contained the full consumed row count.

This PR reports snapshot backfill consumed rows from the persisted per-vnode progress state at each progress update and finish report. That keeps DDL progress aligned with the internal table after recovery.

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

Fixes snapshot backfill DDL progress reporting after recovery so the displayed consumed row count does not restart from zero.

</details>

## Tests

- `cargo fmt --check`
- `cargo test -p risingwave_stream --lib executor::backfill::snapshot_backfill::executor::tests::test_snapshot_backfill_without_upstream_on_hummock`
- `cargo clippy --all-targets --all-features`
