### PR TITLE
feat(frontend): support serverless backfill for sinks and indexes

### DIFF
--- a/e2e_test/ddl/serverless_backfill.slt
+++ b/e2e_test/ddl/serverless_backfill.slt
@@ -4,5 +4,16 @@ create table t(id int, name string);
 statement error Serverless Backfill is disabled
 create materialized view serverless_backfill_mv with (cloud.serverless_backfill_enabled = true) as select * from t;
 
+statement error Serverless Backfill is disabled
+create sink serverless_backfill_sink as select * from t with (
+    connector = 'blackhole',
+    cloud.serverless_backfill_enabled = true
+);
+
+statement error Serverless Backfill is disabled
+create index serverless_backfill_idx on t(id) with (
+    cloud.serverless_backfill_enabled = true
+);
+
 statement ok
 drop table t;

--- a/proto/ddl_service.proto
+++ b/proto/ddl_service.proto
@@ -103,6 +103,7 @@ message CreateSinkRequest {
   // The list of object IDs that this sink depends on.
   repeated uint32 dependencies = 4;
   bool if_not_exists = 5;
+  StreamingJobResourceType resource_type = 6;
 }
 
 message CreateSinkResponse {
@@ -454,6 +455,7 @@ message CreateIndexRequest {
   catalog.Table index_table = 2;
   stream_plan.StreamFragmentGraph fragment_graph = 3;
   bool if_not_exists = 4;
+  StreamingJobResourceType resource_type = 5;
 }
 
 message CreateIndexResponse {

--- a/src/frontend/src/catalog/catalog_service.rs
+++ b/src/frontend/src/catalog/catalog_service.rs
@@ -130,6 +130,7 @@ pub trait CatalogWriter: Send + Sync {
         index: PbIndex,
         table: PbTable,
         graph: StreamFragmentGraph,
+        resource_type: streaming_job_resource_type::ResourceType,
         if_not_exists: bool,
     ) -> Result<()>;
 
@@ -145,6 +146,7 @@ pub trait CatalogWriter: Send + Sync {
         sink: PbSink,
         graph: StreamFragmentGraph,
         dependencies: HashSet<ObjectId>,
+        resource_type: streaming_job_resource_type::ResourceType,
         if_not_exists: bool,
     ) -> Result<()>;
 
@@ -398,11 +400,12 @@ impl CatalogWriter for CatalogWriterImpl {
         index: PbIndex,
         table: PbTable,
         graph: StreamFragmentGraph,
+        resource_type: streaming_job_resource_type::ResourceType,
         if_not_exists: bool,
     ) -> Result<()> {
         let version = self
             .meta_client
-            .create_index(index, table, graph, if_not_exists)
+            .create_index(index, table, graph, resource_type, if_not_exists)
             .await?;
         self.wait_version(version).await
     }
@@ -475,11 +478,12 @@ impl CatalogWriter for CatalogWriterImpl {
         sink: PbSink,
         graph: StreamFragmentGraph,
         dependencies: HashSet<ObjectId>,
+        resource_type: streaming_job_resource_type::ResourceType,
         if_not_exists: bool,
     ) -> Result<()> {
         let version = self
             .meta_client
-            .create_sink(sink, graph, dependencies, if_not_exists)
+            .create_sink(sink, graph, dependencies, resource_type, if_not_exists)
             .await?;
         self.wait_version(version).await
     }

--- a/src/frontend/src/handler/create_index.rs
+++ b/src/frontend/src/handler/create_index.rs
@@ -41,7 +41,11 @@ use crate::catalog::{DatabaseId, SchemaId};
 use crate::error::{ErrorCode, Result};
 use crate::expr::{Expr, ExprImpl, ExprRewriter, ExprVisitor, InputRef, is_impure_func_call};
 use crate::handler::HandlerArgs;
-use crate::handler::util::reject_internal_table_dependency;
+use crate::handler::create_mv::resolve_streaming_job_resource_type;
+use crate::handler::util::{
+    LongRunningNotificationAction, execute_with_long_running_notification,
+    reject_internal_table_dependency,
+};
 use crate::optimizer::plan_expr_rewriter::ConstEvalRewriter;
 use crate::optimizer::plan_node::utils::plan_can_use_background_ddl;
 use crate::optimizer::plan_node::{
@@ -640,7 +644,7 @@ fn assemble_materialize(
 }
 
 pub async fn handle_create_index(
-    handler_args: HandlerArgs,
+    mut handler_args: HandlerArgs,
     if_not_exists: bool,
     index_name: ObjectName,
     table_name: ObjectName,
@@ -650,6 +654,9 @@ pub async fn handle_create_index(
     distributed_by: Vec<ast::Expr>,
 ) -> Result<RwPgResponse> {
     let session = handler_args.session.clone();
+    let resource_type =
+        resolve_streaming_job_resource_type(session.as_ref(), &mut handler_args.with_options)
+            .await?;
 
     let (graph, index_table, index) = {
         let (schema_name, table, index_table_name) =
@@ -701,9 +708,19 @@ pub async fn handle_create_index(
             ));
 
     let catalog_writer = session.catalog_writer()?;
-    catalog_writer
-        .create_index(index, index_table.to_prost(), graph, if_not_exists)
-        .await?;
+    execute_with_long_running_notification(
+        catalog_writer.create_index(
+            index,
+            index_table.to_prost(),
+            graph,
+            resource_type,
+            if_not_exists,
+        ),
+        &session,
+        "CREATE INDEX",
+        LongRunningNotificationAction::MonitorBackfillJob,
+    )
+    .await?;
 
     Ok(PgResponse::empty_result(StatementType::CREATE_INDEX))
 }

--- a/src/frontend/src/handler/create_mv.rs
+++ b/src/frontend/src/handler/create_mv.rs
@@ -18,6 +18,7 @@ use either::Either;
 use itertools::Itertools;
 use pgwire::pg_response::{PgResponse, StatementType};
 use risingwave_common::catalog::{FunctionId, ObjectId, SecretId};
+use risingwave_common::license::Feature;
 use risingwave_pb::ddl_service::streaming_job_resource_type;
 use risingwave_pb::serverless_backfill_controller::{
     ProvisionRequest, node_group_controller_service_client,
@@ -51,6 +52,22 @@ use crate::{TableCatalog, WithOptions};
 
 pub const RESOURCE_GROUP_KEY: &str = "resource_group";
 pub const CLOUD_SERVERLESS_BACKFILL_ENABLED: &str = "cloud.serverless_backfill_enabled";
+
+pub(crate) struct StreamingJobResourceOptions {
+    pub resource_group: Option<String>,
+    pub serverless_backfill_enabled: Option<bool>,
+}
+
+pub(crate) fn extract_streaming_job_resource_options(
+    with_options: &mut WithOptions,
+) -> StreamingJobResourceOptions {
+    StreamingJobResourceOptions {
+        resource_group: with_options.remove(RESOURCE_GROUP_KEY),
+        serverless_backfill_enabled: with_options
+            .remove(CLOUD_SERVERLESS_BACKFILL_ENABLED)
+            .map(|value| value.parse::<bool>().unwrap_or(false)),
+    }
+}
 
 pub(super) fn parse_column_names(columns: &[Ident]) -> Option<Vec<String>> {
     if columns.is_empty() {
@@ -227,6 +244,80 @@ pub async fn provision_resource_group(sbc_addr: String) -> Result<String> {
     }
 }
 
+pub(crate) async fn resolve_streaming_job_resource_type(
+    session: &SessionImpl,
+    with_options: &mut WithOptions,
+) -> Result<streaming_job_resource_type::ResourceType> {
+    let StreamingJobResourceOptions {
+        resource_group,
+        serverless_backfill_enabled,
+    } = extract_streaming_job_resource_options(with_options);
+
+    if resource_group.is_some() {
+        Feature::ResourceGroup.check_available()?;
+    }
+
+    let is_serverless_backfill = match serverless_backfill_enabled {
+        Some(value) => value,
+        None => {
+            if resource_group.is_some() {
+                false
+            } else {
+                session.config().enable_serverless_backfill()
+            }
+        }
+    };
+
+    if resource_group.is_some() && is_serverless_backfill {
+        return Err(RwError::from(InvalidInputSyntax(
+            "Please do not specify serverless backfilling and resource group together".to_owned(),
+        )));
+    }
+
+    let sbc_addr = match SESSION_MANAGER.get() {
+        Some(manager) => manager.env().sbc_address(),
+        None => "",
+    }
+    .to_owned();
+
+    if is_serverless_backfill && sbc_addr.is_empty() {
+        return Err(RwError::from(InvalidInputSyntax(
+            "Serverless Backfill is disabled. Use RisingWave cloud at https://cloud.risingwave.com/auth/signup to try this feature".to_owned(),
+        )));
+    }
+
+    let resource_type = if is_serverless_backfill {
+        assert_eq!(resource_group, None);
+        match provision_resource_group(sbc_addr).await {
+            Err(e) => {
+                return Err(RwError::from(ProtocolError(format!(
+                    "failed to provision serverless backfill nodes: {}",
+                    e.as_report()
+                ))));
+            }
+            Ok(group) => {
+                tracing::info!(
+                    resource_group = group,
+                    "provisioning serverless backfill resource group"
+                );
+                streaming_job_resource_type::ResourceType::ServerlessBackfillResourceGroup(group)
+            }
+        }
+    } else if let Some(group) = resource_group {
+        streaming_job_resource_type::ResourceType::SpecificResourceGroup(group)
+    } else {
+        streaming_job_resource_type::ResourceType::Regular(true)
+    };
+
+    if resource_type.resource_group().is_some()
+        && !session.config().streaming_use_arrangement_backfill()
+    {
+        return Err(RwError::from(ProtocolError("The session config arrangement backfill must be enabled to use the resource_group option".to_owned())));
+    }
+
+    Ok(resource_type)
+}
+
 fn get_with_options(handler_args: HandlerArgs) -> WithOptions {
     let context = OptimizerContext::from_handler_args(handler_args);
     context.with_options().clone()
@@ -328,31 +419,9 @@ pub(crate) async fn gen_create_mv_graph(
     let mut with_options = get_with_options(handler_args.clone());
     let refresh_interval_sec = with_options.refresh_interval_sec()?;
     with_options.remove(MV_REFRESH_INTERVAL_SEC_KEY);
-    let resource_group = with_options.remove(&RESOURCE_GROUP_KEY.to_owned());
-
-    if resource_group.is_some() {
-        risingwave_common::license::Feature::ResourceGroup.check_available()?;
-    }
-
-    let serverless_backfill_from_with = with_options
-        .remove(&CLOUD_SERVERLESS_BACKFILL_ENABLED.to_owned())
-        .map(|value| value.parse::<bool>().unwrap_or(false));
-    let is_serverless_backfill = match serverless_backfill_from_with {
-        Some(value) => value,
-        None => {
-            if resource_group.is_some() {
-                false
-            } else {
-                handler_args.session.config().enable_serverless_backfill()
-            }
-        }
-    };
-
-    if resource_group.is_some() && is_serverless_backfill {
-        return Err(RwError::from(InvalidInputSyntax(
-            "Please do not specify serverless backfilling and resource group together".to_owned(),
-        )));
-    }
+    let resource_type =
+        resolve_streaming_job_resource_type(handler_args.session.as_ref(), &mut with_options)
+            .await?;
 
     if !with_options.is_empty() {
         // get other useful fields by `remove`, the logic here is to reject unknown options.
@@ -362,55 +431,12 @@ pub(crate) async fn gen_create_mv_graph(
         ))));
     }
 
-    let sbc_addr = match SESSION_MANAGER.get() {
-        Some(manager) => manager.env().sbc_address(),
-        None => "",
-    }
-    .to_owned();
-
-    if is_serverless_backfill && sbc_addr.is_empty() {
-        return Err(RwError::from(InvalidInputSyntax(
-            "Serverless Backfill is disabled. Use RisingWave cloud at https://cloud.risingwave.com/auth/signup to try this feature".to_owned(),
-        )));
-    }
-
-    let resource_type = if is_serverless_backfill {
-        assert_eq!(resource_group, None);
-        match provision_resource_group(sbc_addr).await {
-            Err(e) => {
-                return Err(RwError::from(ProtocolError(format!(
-                    "failed to provision serverless backfill nodes: {}",
-                    e.as_report()
-                ))));
-            }
-            Ok(group) => {
-                tracing::info!(
-                    resource_group = group,
-                    "provisioning serverless backfill resource group"
-                );
-                streaming_job_resource_type::ResourceType::ServerlessBackfillResourceGroup(group)
-            }
-        }
-    } else if let Some(group) = resource_group {
-        streaming_job_resource_type::ResourceType::SpecificResourceGroup(group)
-    } else {
-        streaming_job_resource_type::ResourceType::Regular(true)
-    };
     let context = OptimizerContext::from_handler_args(handler_args);
     let has_order_by = !query.order.is_empty();
     if has_order_by {
         context.warn_to_user(r#"The ORDER BY clause in the CREATE MATERIALIZED VIEW statement does not guarantee that the rows selected out of this materialized view is returned in this order.
 It only indicates the physical clustering of the data, which may improve the performance of queries issued against this materialized view.
 "#.to_owned());
-    }
-
-    if resource_type.resource_group().is_some()
-        && !context
-            .session_ctx()
-            .config()
-            .streaming_use_arrangement_backfill()
-    {
-        return Err(RwError::from(ProtocolError("The session config arrangement backfill must be enabled to use the resource_group option".to_owned())));
     }
 
     let context: OptimizerContextRef = context.into();

--- a/src/frontend/src/handler/create_sink.rs
+++ b/src/frontend/src/handler/create_sink.rs
@@ -65,7 +65,9 @@ use crate::error::{ErrorCode, Result, RwError};
 use crate::expr::{ExprImpl, InputRef, rewrite_now_to_proctime};
 use crate::handler::HandlerArgs;
 use crate::handler::alter_table_column::fetch_table_catalog_for_alter;
-use crate::handler::create_mv::parse_column_names;
+use crate::handler::create_mv::{
+    extract_streaming_job_resource_options, parse_column_names, resolve_streaming_job_resource_type,
+};
 use crate::handler::util::{
     LongRunningNotificationAction, check_connector_match_connection_type,
     ensure_connection_type_allowed, execute_with_long_running_notification,
@@ -125,6 +127,9 @@ pub async fn gen_sink_plan(
         Binder::resolve_schema_qualified_name(db_name, &stmt.sink_name)?;
 
     let mut with_options = handler_args.with_options.clone();
+    // These are frontend-level streaming job options. They must not be passed to connector
+    // property validation.
+    extract_streaming_job_resource_options(&mut with_options);
 
     if session
         .env()
@@ -604,7 +609,7 @@ async fn get_partition_compute_info_for_iceberg(
 }
 
 pub async fn handle_create_sink(
-    handle_args: HandlerArgs,
+    mut handle_args: HandlerArgs,
     stmt: CreateSinkStatement,
     is_iceberg_engine_internal: bool,
 ) -> Result<RwPgResponse> {
@@ -627,6 +632,10 @@ pub async fn handle_create_sink(
             ICEBERG_SINK_PREFIX
         ))));
     }
+
+    let resource_type =
+        resolve_streaming_job_resource_type(session.as_ref(), &mut handle_args.with_options)
+            .await?;
 
     let (mut sink, graph, target_table_catalog, dependencies) = {
         let backfill_order_strategy = handle_args.with_options.backfill_order_strategy();
@@ -673,7 +682,13 @@ pub async fn handle_create_sink(
 
     let catalog_writer = session.catalog_writer()?;
     execute_with_long_running_notification(
-        catalog_writer.create_sink(sink.to_proto(), graph, dependencies, if_not_exists),
+        catalog_writer.create_sink(
+            sink.to_proto(),
+            graph,
+            dependencies,
+            resource_type,
+            if_not_exists,
+        ),
         &session,
         "CREATE SINK",
         LongRunningNotificationAction::MonitorBackfillJob,

--- a/src/frontend/src/test_utils.rs
+++ b/src/frontend/src/test_utils.rs
@@ -396,6 +396,7 @@ impl CatalogWriter for MockCatalogWriter {
         sink: PbSink,
         graph: StreamFragmentGraph,
         dependencies: HashSet<ObjectId>,
+        _resource_type: streaming_job_resource_type::ResourceType,
         _if_not_exists: bool,
     ) -> Result<()> {
         let sink_id = self.create_sink_inner(sink, graph)?;
@@ -412,6 +413,7 @@ impl CatalogWriter for MockCatalogWriter {
         mut index: PbIndex,
         mut index_table: PbTable,
         _graph: StreamFragmentGraph,
+        _resource_type: streaming_job_resource_type::ResourceType,
         _if_not_exists: bool,
     ) -> Result<()> {
         index_table.id = self.gen_id();

--- a/src/meta/service/src/ddl_service.rs
+++ b/src/meta/service/src/ddl_service.rs
@@ -450,6 +450,10 @@ impl DdlService for DdlServiceImpl {
         let sink = req.get_sink()?.clone();
         let fragment_graph = req.get_fragment_graph()?.clone();
         let dependencies = req.get_dependencies().iter().copied().collect();
+        let resource_type = req
+            .resource_type
+            .and_then(|resource_type| resource_type.resource_type)
+            .unwrap_or_else(Self::default_streaming_job_resource_type);
 
         let stream_job = StreamingJob::Sink(sink);
 
@@ -457,7 +461,7 @@ impl DdlService for DdlServiceImpl {
             stream_job,
             fragment_graph,
             dependencies,
-            resource_type: Self::default_streaming_job_resource_type(),
+            resource_type,
             if_not_exists: req.if_not_exists,
             refresh_interval_sec: None,
         };
@@ -599,6 +603,10 @@ impl DdlService for DdlServiceImpl {
         let index = req.get_index()?.clone();
         let index_table = req.get_index_table()?.clone();
         let fragment_graph = req.get_fragment_graph()?.clone();
+        let resource_type = req
+            .resource_type
+            .and_then(|resource_type| resource_type.resource_type)
+            .unwrap_or_else(Self::default_streaming_job_resource_type);
 
         let stream_job = StreamingJob::Index(index, index_table);
         let version = self
@@ -607,7 +615,7 @@ impl DdlService for DdlServiceImpl {
                 stream_job,
                 fragment_graph,
                 dependencies: HashSet::new(),
-                resource_type: Self::default_streaming_job_resource_type(),
+                resource_type,
                 if_not_exists: req.if_not_exists,
                 refresh_interval_sec: None,
             })

--- a/src/rpc_client/src/meta_client.rs
+++ b/src/rpc_client/src/meta_client.rs
@@ -483,6 +483,7 @@ impl MetaClient {
         sink: PbSink,
         graph: StreamFragmentGraph,
         dependencies: HashSet<ObjectId>,
+        resource_type: streaming_job_resource_type::ResourceType,
         if_not_exists: bool,
     ) -> Result<WaitVersion> {
         let request = CreateSinkRequest {
@@ -490,6 +491,9 @@ impl MetaClient {
             fragment_graph: Some(graph),
             dependencies: dependencies.into_iter().collect(),
             if_not_exists,
+            resource_type: Some(PbStreamingJobResourceType {
+                resource_type: Some(resource_type),
+            }),
         };
 
         let resp = self.inner.create_sink(request).await?;
@@ -838,6 +842,7 @@ impl MetaClient {
         index: PbIndex,
         table: PbTable,
         graph: StreamFragmentGraph,
+        resource_type: streaming_job_resource_type::ResourceType,
         if_not_exists: bool,
     ) -> Result<WaitVersion> {
         let request = CreateIndexRequest {
@@ -845,6 +850,9 @@ impl MetaClient {
             index_table: Some(table),
             fragment_graph: Some(graph),
             if_not_exists,
+            resource_type: Some(PbStreamingJobResourceType {
+                resource_type: Some(resource_type),
+            }),
         };
         let resp = self.inner.create_index(request).await?;
         // TODO: handle error in `resp.status` here


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

This PR extends serverless backfill resource handling from `CREATE MATERIALIZED VIEW` to `CREATE SINK` and `CREATE INDEX`.

The main changes are:

- Add a shared frontend helper to extract `resource_group` and `cloud.serverless_backfill_enabled` from `WITH` options.
- Resolve and pass `StreamingJobResourceType` through sink/index DDL requests to meta.
- Strip resource-related frontend options from sink connector properties before connector planning/validation, including `EXPLAIN CREATE SINK` paths.
- Keep `CREATE INDEX` graph construction on the existing default backfill-order path.
- Add disabled-controller SLT coverage for sink and index serverless backfill options.

## Checklist

- [ ] I have written necessary rustdoc comments.
- [x] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [x] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->

## Documentation

- [x] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

`CREATE SINK` and `CREATE INDEX` now accept the same serverless backfill resource options used by `CREATE MATERIALIZED VIEW`, including `cloud.serverless_backfill_enabled` and `resource_group`.

</details>
