### PR TITLE
perf(array): speed up datum size estimation for struct and list

### DIFF
--- a/src/common/src/array/list_array.rs
+++ b/src/common/src/array/list_array.rs
@@ -36,7 +36,9 @@ use crate::types::{
     ToDatumRef, ToText, hash_datum,
 };
 use crate::util::memcmp_encoding;
-use crate::util::value_encoding::estimate_serialize_datum_size;
+use crate::util::value_encoding::{
+    estimate_serialize_datum_size, try_get_exact_serialize_datum_size,
+};
 
 #[derive(Debug, Clone, EstimateSize)]
 pub struct ListArrayBuilder {
@@ -575,7 +577,19 @@ impl<'a> ListRef<'a> {
 
     /// estimate the serialized size with value encoding
     pub fn estimate_serialize_size_inner(self) -> usize {
-        self.iter().map(estimate_serialize_datum_size).sum()
+        if let Some(element_size) = try_get_exact_serialize_datum_size(self.array) {
+            return self.len() * element_size;
+        }
+
+        let len = self.len();
+        if len <= 3 {
+            self.iter().map(estimate_serialize_datum_size).sum()
+        } else {
+            let sample_sum = estimate_serialize_datum_size(self.get(0).unwrap())
+                + estimate_serialize_datum_size(self.get(len / 2).unwrap())
+                + estimate_serialize_datum_size(self.get(len - 1).unwrap());
+            sample_sum * len / 3
+        }
     }
 
     pub fn as_primitive_slice<T: PrimitiveArrayItemType>(self) -> Option<&'a [T]> {

--- a/src/common/src/array/struct_array.rs
+++ b/src/common/src/array/struct_array.rs
@@ -34,7 +34,7 @@ use crate::types::{
 };
 use crate::util::iter_util::{ZipEqDebug, ZipEqFast};
 use crate::util::memcmp_encoding;
-use crate::util::value_encoding::estimate_serialize_datum_size;
+use crate::util::value_encoding::estimate_struct_field_size;
 
 macro_rules! iter_fields_ref {
     ($self:expr, $it:ident, { $($body:tt)* }) => {
@@ -446,7 +446,7 @@ impl<'a> StructRef<'a> {
     pub fn estimate_serialize_size_inner(self) -> usize {
         iter_fields_ref!(self, it, {
             it.fold(0, |acc, datum_ref| {
-                acc + estimate_serialize_datum_size(datum_ref)
+                acc + estimate_struct_field_size(datum_ref)
             })
         })
     }

--- a/src/common/src/util/value_encoding/mod.rs
+++ b/src/common/src/util/value_encoding/mod.rs
@@ -130,6 +130,7 @@ pub fn try_get_exact_serialize_datum_size(arr: &ArrayImpl) -> Option<usize> {
         ArrayImpl::Int16(_) => Some(2),
         ArrayImpl::Int32(_) => Some(4),
         ArrayImpl::Int64(_) => Some(8),
+        ArrayImpl::Int256(_) => Some(32),
         ArrayImpl::Serial(_) => Some(8),
         ArrayImpl::Float32(_) => Some(4),
         ArrayImpl::Float64(_) => Some(8),
@@ -138,7 +139,12 @@ pub fn try_get_exact_serialize_datum_size(arr: &ArrayImpl) -> Option<usize> {
         ArrayImpl::Interval(_) => Some(estimate_serialize_interval_size()),
         ArrayImpl::Date(_) => Some(estimate_serialize_date_size()),
         ArrayImpl::Timestamp(_) => Some(estimate_serialize_timestamp_size()),
+        ArrayImpl::Timestamptz(_) => Some(8),
         ArrayImpl::Time(_) => Some(estimate_serialize_time_size()),
+        ArrayImpl::Struct(struct_arr) => struct_arr
+            .fields()
+            .map(|field| try_get_exact_serialize_datum_size(field))
+            .sum(),
         _ => None,
     }
     .map(|x| x + 1)
@@ -164,6 +170,30 @@ pub fn serialize_datum_into(datum_ref: impl ToDatumRef, buf: &mut impl BufMut) {
 pub fn estimate_serialize_datum_size(datum_ref: impl ToDatumRef) -> usize {
     if let Some(d) = datum_ref.to_datum_ref() {
         1 + estimate_serialize_scalar_size(d)
+    } else {
+        1
+    }
+}
+
+pub fn estimate_struct_field_size(datum_ref: DatumRef<'_>) -> usize {
+    if let Some(d) = datum_ref {
+        1 + match d {
+            ScalarRefImpl::Int16(_) => 2,
+            ScalarRefImpl::Int32(_) => 4,
+            ScalarRefImpl::Int64(_) => 8,
+            ScalarRefImpl::Int256(_) => 32,
+            ScalarRefImpl::Serial(_) => 8,
+            ScalarRefImpl::Float32(_) => 4,
+            ScalarRefImpl::Float64(_) => 8,
+            ScalarRefImpl::Bool(_) => 1,
+            ScalarRefImpl::Decimal(_) => estimate_serialize_decimal_size(),
+            ScalarRefImpl::Interval(_) => estimate_serialize_interval_size(),
+            ScalarRefImpl::Date(_) => estimate_serialize_date_size(),
+            ScalarRefImpl::Timestamp(_) => estimate_serialize_timestamp_size(),
+            ScalarRefImpl::Timestamptz(_) => 8,
+            ScalarRefImpl::Time(_) => estimate_serialize_time_size(),
+            _ => 0,
+        }
     } else {
         1
     }
@@ -471,10 +501,13 @@ fn deserialize_decimal(data: &mut impl Buf) -> Result<Decimal> {
 
 #[cfg(test)]
 mod tests {
-    use crate::array::{ArrayImpl, ListValue, StructValue};
+    use crate::array::{
+        Array, ArrayImpl, I32Array, I64Array, ListValue, StructArray, StructValue, Utf8Array,
+    };
+    use crate::bitmap::Bitmap;
     use crate::test_utils::rand_chunk;
     use crate::types::{
-        DataType, Date, Datum, Decimal, Interval, ScalarImpl, Serial, Time, Timestamp,
+        DataType, Date, Datum, Decimal, Interval, ScalarImpl, Serial, StructType, Time, Timestamp,
     };
     use crate::util::value_encoding::{
         estimate_serialize_datum_size, serialize_datum, try_get_exact_serialize_datum_size,
@@ -554,5 +587,35 @@ mod tests {
         for column in chunk.columns() {
             test_try_get_exact_serialize_datum_size(column);
         }
+    }
+
+    #[test]
+    fn test_try_estimate_struct_size() {
+        let fixed_size_struct = ArrayImpl::Struct(StructArray::new(
+            StructType::unnamed(vec![DataType::Int32, DataType::Int64]),
+            vec![
+                I32Array::from_iter([Some(1)]).into_ref(),
+                I64Array::from_iter([Some(2)]).into_ref(),
+            ],
+            Bitmap::ones(1),
+        ));
+        assert_eq!(
+            try_get_exact_serialize_datum_size(&fixed_size_struct),
+            Some(1 + (1 + 4) + (1 + 8))
+        );
+        test_try_get_exact_serialize_datum_size(&fixed_size_struct);
+
+        let variable_size_struct = ArrayImpl::Struct(StructArray::new(
+            StructType::unnamed(vec![DataType::Int32, DataType::Varchar]),
+            vec![
+                I32Array::from_iter([Some(1)]).into_ref(),
+                Utf8Array::from_iter([Some("hello")]).into_ref(),
+            ],
+            Bitmap::ones(1),
+        ));
+        assert_eq!(
+            try_get_exact_serialize_datum_size(&variable_size_struct),
+            None
+        );
     }
 }


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

- For deeply nested struct and list types, calling `estimate_serialize_datum_size` on every element becomes expensive when estimating the size of a serialized hash key. This PR optimizes the estimation by short-circuiting on known fixed-size cases and by sampling instead of summing every element for large lists.
- `try_get_exact_serialize_datum_size` now also handles `Int256`, `Timestamptz`, and `Struct` (when all its fields have a known exact size), so nested structs composed entirely of fixed-size fields can report an exact size without iteration.
- A new helper `estimate_struct_field_size` is introduced and used by `StructRef::estimate_serialize_size_inner`, ignoring any variable-sized fields of a struct so the cost stays proportional to the number of fields rather than the row content.
- `ListRef::estimate_serialize_size_inner` now uses the exact size when the element array has one, and otherwise falls back to summing every element for small lists (length <= 3) or to averaging the first, middle, and last element for larger lists, which keeps the work bounded.
- Added a unit test `test_try_estimate_struct_size` covering both a fully fixed-size struct and one containing a variable-size field.

Resolves #9625

## Checklist

- [ ] I have written necessary rustdoc comments.
- [x] I have added necessary unit tests and integration tests.
- [ ] I have added test labels as necessary.
- [ ] I have added fuzzing tests or opened an issue to track them.
- [ ] My PR contains breaking changes.
- [x] My PR changes performance-critical code, so I will run (micro) benchmarks and present the results.
- [ ] I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into.

## Documentation

- [ ] My PR needs documentation updates.

<details>
<summary><b>Release note</b></summary>

Optimize datum size estimation for struct and list to avoid the cost of traversing deeply nested values when estimating serialized hash key size.
</details>