### PR TITLE
fix(pg-cdc): support arrays of enum in auto schema change

### DIFF
--- a/e2e_test/source_inline/cdc/postgres/postgres_corner_schema_change.slt
+++ b/e2e_test/source_inline/cdc/postgres/postgres_corner_schema_change.slt
@@ -1,0 +1,139 @@
+# Corner-case auto schema change tests for PG CDC.
+#
+# Focus: columns whose type is an *array of a user-defined type* (here
+# `mood_enum[]`). These are special because Debezium's schema-change event marks
+# them neither as enum (`enumValues`) nor as composite (`jdbcType == STRUCT`),
+# and their `_`-prefixed type name is not in the builtin whitelist. Without
+# dedicated handling, any schema change on such a table fails with
+# `unsupported data type _mood_enum`.
+#
+# Two scenarios are covered:
+#  1. Existing column: an `mood_enum[]` column present before the schema change
+#     must NOT break an unrelated `ADD COLUMN`.
+#  2. New column: an `mood_enum[]` column added by the schema change itself must
+#     be derived as `varchar[]`.
+
+control substitution on
+
+system ok
+psql -c "
+    SELECT pg_terminate_backend(active_pid)
+    FROM pg_replication_slots
+    WHERE slot_name = 'corner_schema_change_slot' AND active_pid IS NOT NULL;
+    SELECT pg_sleep(1);
+    SELECT pg_drop_replication_slot(slot_name)
+    FROM pg_replication_slots
+    WHERE slot_name = 'corner_schema_change_slot';
+    DROP TABLE IF EXISTS corner_enum_arr;
+    DROP TYPE IF EXISTS mood_enum;
+"
+
+system ok
+psql -c "
+    CREATE TYPE mood_enum AS ENUM ('happy', 'sad', 'neutral');
+    CREATE TABLE corner_enum_arr (
+        id int PRIMARY KEY,
+        tags mood_enum[] NOT NULL,
+        note varchar
+    );
+    INSERT INTO corner_enum_arr (id, tags, note) VALUES
+        (1, ARRAY['happy', 'sad']::mood_enum[], 'backfill_1'),
+        (2, ARRAY['neutral']::mood_enum[], 'backfill_2');
+"
+
+statement ok
+create source s with (
+  connector = 'postgres-cdc',
+  hostname = '${PGHOST:localhost}',
+  port = '${PGPORT:5432}',
+  username = '${PGUSER:$USER}',
+  password = '${PGPASSWORD:}',
+  database.name = '${PGDATABASE:postgres}',
+  schema.name = 'public',
+  slot.name = 'corner_schema_change_slot',
+  auto.schema.change = 'true'
+);
+
+# The existing `mood_enum[]` column is derived as `varchar[]`.
+statement ok
+create table corner_enum_arr (*) from s table 'public.corner_enum_arr';
+
+query ITT retry 6 backoff 1s
+select id, tags, note from corner_enum_arr order by id;
+----
+1 {happy,sad} backfill_1
+2 {neutral} backfill_2
+
+# Scenario 1: an unrelated `ADD COLUMN` must succeed even though the table
+# already has an `mood_enum[]` column (the original bug failed here).
+system ok
+psql -c "
+    ALTER TABLE corner_enum_arr ADD COLUMN extra int DEFAULT NULL;
+    INSERT INTO corner_enum_arr (id, tags, note, extra) VALUES
+        (3, ARRAY['neutral', 'happy']::mood_enum[], 'after_alter_1', 7);
+"
+
+query ITTI retry 6 backoff 1s
+select id, tags, note, extra from corner_enum_arr order by id;
+----
+1 {happy,sad} backfill_1 NULL
+2 {neutral} backfill_2 NULL
+3 {neutral,happy} after_alter_1 7
+
+# The existing array-of-enum column stays `varchar[]` after the schema change.
+query TTTT retry 6 backoff 1s
+describe corner_enum_arr;
+----
+id integer false NULL
+tags character varying[] false NULL
+note character varying false NULL
+extra integer false NULL
+_rw_timestamp timestamp with time zone true NULL
+primary key id NULL NULL
+distribution key id NULL NULL
+table description corner_enum_arr NULL NULL
+
+# Scenario 2: a newly added `mood_enum[]` column is derived as `varchar[]`.
+system ok
+psql -c "
+    ALTER TABLE corner_enum_arr ADD COLUMN moods mood_enum[] DEFAULT NULL;
+    INSERT INTO corner_enum_arr (id, tags, note, extra, moods) VALUES
+        (4, ARRAY['happy']::mood_enum[], 'after_alter_2', 8, ARRAY['sad', 'neutral']::mood_enum[]);
+"
+
+query ITTIT retry 6 backoff 1s
+select id, tags, note, extra, moods from corner_enum_arr order by id;
+----
+1 {happy,sad} backfill_1 NULL NULL
+2 {neutral} backfill_2 NULL NULL
+3 {neutral,happy} after_alter_1 7 NULL
+4 {happy} after_alter_2 8 {sad,neutral}
+
+query TTTT retry 6 backoff 1s
+describe corner_enum_arr;
+----
+id integer false NULL
+tags character varying[] false NULL
+note character varying false NULL
+extra integer false NULL
+moods character varying[] false NULL
+_rw_timestamp timestamp with time zone true NULL
+primary key id NULL NULL
+distribution key id NULL NULL
+table description corner_enum_arr NULL NULL
+
+statement ok
+drop source s cascade;
+
+system ok
+psql -c "
+    SELECT pg_terminate_backend(active_pid)
+    FROM pg_replication_slots
+    WHERE slot_name = 'corner_schema_change_slot' AND active_pid IS NOT NULL;
+    SELECT pg_sleep(1);
+    SELECT pg_drop_replication_slot(slot_name)
+    FROM pg_replication_slots
+    WHERE slot_name = 'corner_schema_change_slot';
+    DROP TABLE IF EXISTS corner_enum_arr;
+    DROP TYPE IF EXISTS mood_enum;
+"

--- a/src/connector/src/parser/unified/debezium.rs
+++ b/src/connector/src/parser/unified/debezium.rs
@@ -30,6 +30,7 @@ use super::{Access, AccessError, AccessResult, ChangeEvent, ChangeEventOperation
 /// JDBC type constants found in Debezium schema change events.
 mod debezium_sql_types {
     pub const STRUCT: i32 = 2002;
+    pub const ARRAY: i32 = 2003;
 }
 use crate::connector_common::{create_pg_client_from_properties, discover_pgvector_dimensions};
 use crate::parser::TransactionControl;
@@ -110,6 +111,58 @@ async fn fetch_pgvector_dimensions_for_table(
                 err.as_report()
             ),
         })
+}
+
+/// Decide whether an unknown array column type (one not resolved by
+/// `type_name_to_pg_type`) can be represented as `varchar[]` in RW. This is the
+/// single question this function answers; the criteria behind it may grow over
+/// time.
+///
+/// Right now the answer is "yes iff the array's element type is a user-defined
+/// enum". Debezium does not expose element enum metadata on the array column
+/// (the `enumValues` field is only set for scalar enum columns), so we ask the
+/// upstream catalog directly: follow the array type's `typelem` to its element
+/// type and check `typtype = 'e'`. Enum values are plain text, hence `varchar[]`.
+///
+/// TODO(composite): arrays of composite types (`typtype = 'c'`) should likewise
+/// map to `varchar[]`. That is deferred to a follow-up PR — the snapshot/streaming
+/// side for composite arrays is handled in #25818, and this predicate should be
+/// extended to `typtype IN ('e', 'c')` once that lands.
+async fn can_fallback_array_to_varchar(
+    connector_props: &ConnectorProperties,
+    array_type_name: &str,
+) -> AccessResult<bool> {
+    let ConnectorProperties::PostgresCdc(cdc_props) = connector_props else {
+        return Ok(false);
+    };
+
+    let client = create_pg_client_from_properties(&cdc_props.properties, None)
+        .await
+        .map_err(|err| AccessError::Uncategorized {
+            message: format!(
+                "failed to connect upstream postgres for schema change lookup: {}",
+                err.as_report()
+            ),
+        })?;
+
+    let row = client
+        .query_opt(
+            "SELECT t_elem.typtype = 'e' \
+             FROM pg_type t \
+             JOIN pg_type t_elem ON t.typelem = t_elem.oid \
+             WHERE t.typname = $1 \
+             LIMIT 1",
+            &[&array_type_name],
+        )
+        .await
+        .map_err(|err| AccessError::Uncategorized {
+            message: format!(
+                "failed to query upstream postgres for array element type of `{array_type_name}`: {}",
+                err.as_report()
+            ),
+        })?;
+
+    Ok(row.map(|r| r.get::<_, bool>(0)).unwrap_or(false))
 }
 
 // Example of Debezium JSON value:
@@ -293,11 +346,11 @@ pub async fn parse_schema_change(
                     // Both are mapped to Varchar — enum values are plain strings, and
                     // composite values are converted to text by our CustomConverter.
                     let is_enum = matches!(col.access_object_field("enumValues"), Some(val) if !val.is_jsonb_null());
-                    let is_composite = col
+                    let jdbc_type = col
                         .access_object_field("jdbcType")
                         .and_then(|v| v.as_number().ok())
-                        .map(|n| n.0 as i32)
-                        == Some(debezium_sql_types::STRUCT);
+                        .map(|n| n.0 as i32);
+                    let is_composite = jdbc_type == Some(debezium_sql_types::STRUCT);
 
                     let data_type = match *connector_props {
                         ConnectorProperties::PostgresCdc(_) => {
@@ -346,6 +399,12 @@ pub async fn parse_schema_change(
                                     }
                                 }
                             } else {
+                                // Resolve builtin types first, so arrays of builtin element
+                                // types keep their proper element type (e.g. `_int4` -> int[],
+                                // `_text` -> text[]). `type_name_to_pg_type` only covers PG
+                                // builtins (the `PgType` it returns carries a static OID);
+                                // user-defined and extension types are not representable here
+                                // and fall through to the catalog lookup below.
                                 let ty = type_name_to_pg_type(type_name.as_str());
                                 match ty {
                                     Some(ty) => match pg_type_to_rw_type(&ty) {
@@ -361,6 +420,23 @@ pub async fn parse_schema_change(
                                             });
                                         }
                                     },
+                                    // An unrecognized ARRAY type may be an array of a
+                                    // user-defined enum (e.g. `_mood_enum`). Debezium carries
+                                    // no enum metadata on the array column, so ask upstream
+                                    // whether the element is an enum; if so, map to
+                                    // `varchar[]` (enum values are plain text).
+                                    None if jdbc_type == Some(debezium_sql_types::ARRAY)
+                                        && can_fallback_array_to_varchar(
+                                            connector_props,
+                                            type_name.as_str(),
+                                        )
+                                        .await? =>
+                                    {
+                                        tracing::debug!(target: "auto_schema_change",
+                                            "Fall back PostgreSQL array type '{}' to VARCHAR[]",
+                                            type_name);
+                                        DataType::Varchar.list()
+                                    }
                                     None => {
                                         return Err(AccessError::CdcAutoSchemaChangeError {
                                             ty: type_name,


### PR DESCRIPTION
## Problem

A schema change on a PG CDC table that has an **array-of-enum** column (e.g. `mood_enum[]`, PG internal type name `_mood_enum`) fails with:

```
CDC auto schema change error: unsupported data type `_mood_enum` in table `...`
```

Debezium marks the array column **neither** as enum (`enumValues` is only set on scalar enum columns) **nor** as composite (`jdbcType == STRUCT`), and its `_`-prefixed type name is not in the builtin whitelist. Type resolution falls through to an error, and the **whole** schema change is rejected — even when the offending column is a pre-existing one untouched by the `ALTER`.

## Fix

Resolve column types via the builtin **name-based** mapping `type_name_to_pg_type` first, so arrays of builtin element types keep their proper element type (`_int4` → `int[]`, `_text` → `text[]`). Only for an **unrecognized** ARRAY type do we ask the upstream catalog whether the element is an enum — follow the array type's `typelem` to its element and check `typtype = 'e'`:

```sql
SELECT t_elem.typtype = 'e'
FROM pg_type t JOIN pg_type t_elem ON t.typelem = t_elem.oid
WHERE t.typname = $1
```

If the element is an enum, map the column to `varchar[]`, mirroring the snapshot/streaming data paths that render enum values as text. This intentionally avoids any OID/`FirstNormalObjectId` heuristic — we ask Postgres directly.

## Scope

- **Enum arrays**: fixed. Self-contained — the data path already produces `varchar[]` for them.
- **Composite arrays** (`typtype = 'c'`): **out of scope here**, deferred to a follow-up PR. The lookup predicate is documented (`TODO`) to be extended to `typtype IN ('e', 'c')` once the snapshot/streaming side (#25818) lands.
- Builtin arrays (`_int4` → `int[]`, etc.) are unaffected — the name-based mapping runs first and keeps them off the fallback path.

## Test

`e2e_test/source_inline/cdc/postgres/postgres_corner_schema_change.slt` covers both an existing `mood_enum[]` column (an unrelated `ADD COLUMN` must not break) and a newly added `mood_enum[]` column (derived as `varchar[]`).