### PR TITLE
fix(meta): remove reset dropped jobs on worker error

### DIFF
--- a/src/meta/src/barrier/checkpoint/control.rs
+++ b/src/meta/src/barrier/checkpoint/control.rs
@@ -406,6 +406,10 @@ impl CheckpointControl {
                 }
             };
 
+            database_checkpoint_control
+                .creating_streaming_job_controls
+                .retain(|_, job| !job.dropped_after_worker_err(worker_id));
+
             if !database_checkpoint_control.is_valid_after_worker_err(worker_id as _)
                 || database_checkpoint_control
                     .database_info

--- a/src/meta/src/barrier/checkpoint/creating_job/mod.rs
+++ b/src/meta/src/barrier/checkpoint/creating_job/mod.rs
@@ -523,6 +523,19 @@ impl CreatingStreamingJobControl {
         self.barrier_control.is_empty()
     }
 
+    pub(crate) fn dropped_after_worker_err(&mut self, worker_id: WorkerId) -> bool {
+        if let CreatingStreamingJobStatus::Resetting(collector, notifiers) = &mut self.status {
+            collector.remaining_workers.remove(&worker_id);
+            if collector.remaining_workers.is_empty() {
+                for notifier in notifiers.drain(..) {
+                    notifier.notify_collected();
+                }
+                return true;
+            }
+        }
+        false
+    }
+
     pub(crate) fn is_valid_after_worker_err(&self, worker_id: WorkerId) -> bool {
         self.barrier_control.is_valid_after_worker_err(worker_id)
             && self


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

This PR fixes a release-2.8 meta recovery edge case for dropped snapshot backfill creating jobs.

When a creating job is already resetting because it is being dropped, a simultaneous worker removal can be observed through `databases_failed_at_worker_err`. Previously, the running database validity check only checked whether the creating job still referenced the failed worker. For a resetting creating job, `is_valid_after_worker_err` does not remove the worker from `ResetPartialGraphCollector.remaining_workers`, so the dropped job could remain waiting for a reset response from a removed worker.

The fix adds `CreatingStreamingJobControl::dropped_after_worker_err`, which removes the failed worker from a resetting dropped job's reset collector. If that was the last remaining worker, it notifies waiters and lets `databases_failed_at_worker_err` remove the dropped job from `creating_streaming_job_controls` via `retain`.

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [x] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

Fixes a meta recovery edge case where a database could stay blocked after a worker removal races with cancelling a snapshot backfill creating job.

</details>
