### PR TITLE
fix(meta): defer serverless backfill provisioning

### DIFF
--- a/proto/ddl_service.proto
+++ b/proto/ddl_service.proto
@@ -151,7 +151,7 @@ message StreamingJobResourceType {
     bool regular = 1;
     // The specific resource group to use for the streaming job. If not set, the database resource group is used.
     string specific_resource_group = 2;
-    string serverless_backfill_resource_group = 3;
+    bool serverless_backfill = 3;
   }
 }
 

--- a/src/frontend/src/handler/alter_mv.rs
+++ b/src/frontend/src/handler/alter_mv.rs
@@ -156,8 +156,7 @@ async fn handle_alter_mv_bound(
             dependent_secrets,
             columns,
             emit_mode,
-        )
-        .await?
+        )?
     };
 
     if refresh_interval_sec.is_some() {

--- a/src/frontend/src/handler/create_index.rs
+++ b/src/frontend/src/handler/create_index.rs
@@ -655,8 +655,7 @@ pub async fn handle_create_index(
 ) -> Result<RwPgResponse> {
     let session = handler_args.session.clone();
     let resource_type =
-        resolve_streaming_job_resource_type(session.as_ref(), &mut handler_args.with_options)
-            .await?;
+        resolve_streaming_job_resource_type(session.as_ref(), &mut handler_args.with_options)?;
 
     let (graph, index_table, index) = {
         let (schema_name, table, index_table_name) =

--- a/src/frontend/src/handler/create_mv.rs
+++ b/src/frontend/src/handler/create_mv.rs
@@ -20,12 +20,8 @@ use pgwire::pg_response::{PgResponse, StatementType};
 use risingwave_common::catalog::{FunctionId, ObjectId, SecretId};
 use risingwave_common::license::Feature;
 use risingwave_pb::ddl_service::streaming_job_resource_type;
-use risingwave_pb::serverless_backfill_controller::{
-    ProvisionRequest, node_group_controller_service_client,
-};
 use risingwave_pb::stream_plan::PbStreamFragmentGraph;
 use risingwave_sqlparser::ast::{EmitMode, Ident, ObjectName, Query};
-use thiserror_ext::AsReport;
 
 use super::RwPgResponse;
 use crate::binder::{Binder, BoundQuery, BoundSetExpr};
@@ -45,7 +41,7 @@ use crate::optimizer::plan_node::{
 use crate::optimizer::{OptimizerContext, OptimizerContextRef, RelationCollectorVisitor};
 use crate::planner::Planner;
 use crate::scheduler::streaming_manager::CreatingStreamingJobInfo;
-use crate::session::{SESSION_MANAGER, SessionImpl};
+use crate::session::SessionImpl;
 use crate::stream_fragmenter::{GraphJobType, build_graph_with_strategy};
 use crate::utils::{MV_REFRESH_INTERVAL_SEC_KEY, ordinal};
 use crate::{TableCatalog, WithOptions};
@@ -219,32 +215,7 @@ pub async fn handle_create_mv(
     .await
 }
 
-/// Send a provision request to the serverless backfill controller
-pub async fn provision_resource_group(sbc_addr: String) -> Result<String> {
-    let request = tonic::Request::new(ProvisionRequest {});
-    let mut client =
-        node_group_controller_service_client::NodeGroupControllerServiceClient::connect(
-            sbc_addr.clone(),
-        )
-        .await
-        .map_err(|e| {
-            RwError::from(ErrorCode::InternalError(format!(
-                "unable to reach serverless backfill controller at addr {}: {}",
-                sbc_addr,
-                e.as_report()
-            )))
-        })?;
-
-    match client.provision(request).await {
-        Ok(resp) => Ok(resp.into_inner().resource_group),
-        Err(e) => Err(RwError::from(ErrorCode::InternalError(format!(
-            "serverless backfill controller returned error :{}",
-            e.as_report()
-        )))),
-    }
-}
-
-pub(crate) async fn resolve_streaming_job_resource_type(
+pub(crate) fn resolve_streaming_job_resource_type(
     session: &SessionImpl,
     with_options: &mut WithOptions,
 ) -> Result<streaming_job_resource_type::ResourceType> {
@@ -274,35 +245,9 @@ pub(crate) async fn resolve_streaming_job_resource_type(
         )));
     }
 
-    let sbc_addr = match SESSION_MANAGER.get() {
-        Some(manager) => manager.env().sbc_address(),
-        None => "",
-    }
-    .to_owned();
-
-    if is_serverless_backfill && sbc_addr.is_empty() {
-        return Err(RwError::from(InvalidInputSyntax(
-            "Serverless Backfill is disabled. Use RisingWave cloud at https://cloud.risingwave.com/auth/signup to try this feature".to_owned(),
-        )));
-    }
-
     let resource_type = if is_serverless_backfill {
         assert_eq!(resource_group, None);
-        match provision_resource_group(sbc_addr).await {
-            Err(e) => {
-                return Err(RwError::from(ProtocolError(format!(
-                    "failed to provision serverless backfill nodes: {}",
-                    e.as_report()
-                ))));
-            }
-            Ok(group) => {
-                tracing::info!(
-                    resource_group = group,
-                    "provisioning serverless backfill resource group"
-                );
-                streaming_job_resource_type::ResourceType::ServerlessBackfillResourceGroup(group)
-            }
-        }
+        streaming_job_resource_type::ResourceType::ServerlessBackfill(true)
     } else if let Some(group) = resource_group {
         streaming_job_resource_type::ResourceType::SpecificResourceGroup(group)
     } else {
@@ -357,8 +302,7 @@ pub async fn handle_create_mv_bound(
             dependent_secrets,
             columns,
             emit_mode,
-        )
-        .await?
+        )?
     };
 
     // Ensure writes to `StreamJobTracker` are atomic.
@@ -394,7 +338,8 @@ pub async fn handle_create_mv_bound(
     ))
 }
 
-pub(crate) async fn gen_create_mv_graph(
+#[expect(clippy::type_complexity)]
+pub(crate) fn gen_create_mv_graph(
     handler_args: HandlerArgs,
     name: ObjectName,
     query: BoundQuery,
@@ -414,8 +359,7 @@ pub(crate) async fn gen_create_mv_graph(
     let refresh_interval_sec = with_options.refresh_interval_sec()?;
     with_options.remove(MV_REFRESH_INTERVAL_SEC_KEY);
     let resource_type =
-        resolve_streaming_job_resource_type(handler_args.session.as_ref(), &mut with_options)
-            .await?;
+        resolve_streaming_job_resource_type(handler_args.session.as_ref(), &mut with_options)?;
 
     if !with_options.is_empty() {
         // get other useful fields by `remove`, the logic here is to reject unknown options.

--- a/src/frontend/src/handler/create_sink.rs
+++ b/src/frontend/src/handler/create_sink.rs
@@ -684,8 +684,7 @@ pub async fn handle_create_sink(
     }
 
     let resource_type =
-        resolve_streaming_job_resource_type(session.as_ref(), &mut handle_args.with_options)
-            .await?;
+        resolve_streaming_job_resource_type(session.as_ref(), &mut handle_args.with_options)?;
 
     let (mut sink, graph, target_table_catalog, dependencies, since_timestamp_epoch) = {
         let backfill_order_strategy = handle_args.with_options.backfill_order_strategy();

--- a/src/frontend/src/lib.rs
+++ b/src/frontend/src/lib.rs
@@ -178,10 +178,10 @@ pub struct FrontendOpts {
     #[clap(long, env = "RW_WEBHOOK_LISTEN_ADDR", default_value = "0.0.0.0:4560")]
     pub webhook_listen_addr: String,
 
-    /// Address of the serverless backfill controller.
-    /// Needed if frontend receives a query like
-    /// CREATE MATERIALIZED VIEW ... WITH ( `cloud.serverless_backfill_enabled=true` )
-    /// Feature disabled by default.
+    /// Deprecated. Configure the serverless backfill controller address on meta nodes instead.
+    #[deprecated(
+        note = "Configure the serverless backfill controller address on meta nodes instead"
+    )]
     #[clap(long, env = "RW_SBC_ADDR", default_value = "")]
     pub serverless_backfill_controller_addr: String,
 

--- a/src/frontend/src/session.rs
+++ b/src/frontend/src/session.rs
@@ -200,9 +200,6 @@ pub(crate) struct FrontendEnv {
     /// Not used by the RisingWave batch engine.
     df_spillable_budget_ctx: MemoryContext,
 
-    /// address of the serverless backfill controller.
-    serverless_backfill_controller_addr: String,
-
     /// Prometheus client for querying metrics.
     prometheus_client: Option<PrometheusClient>,
 
@@ -294,7 +291,6 @@ impl FrontendEnv {
             mem_context: MemoryContext::none(),
             #[cfg(feature = "datafusion")]
             df_spillable_budget_ctx: MemoryContext::none(),
-            serverless_backfill_controller_addr: Default::default(),
             prometheus_client: None,
             prometheus_selector: String::new(),
         }
@@ -579,7 +575,6 @@ impl FrontendEnv {
                 frontend_config: config.frontend,
                 meta_config: config.meta,
                 streaming_config: config.streaming,
-                serverless_backfill_controller_addr: opts.serverless_backfill_controller_addr,
                 udf_config: config.udf,
                 source_metrics,
                 creating_streaming_job_tracker,
@@ -647,10 +642,6 @@ impl FrontendEnv {
 
     pub fn session_params_snapshot(&self) -> SessionConfig {
         self.session_params.read_recursive().clone()
-    }
-
-    pub fn sbc_address(&self) -> &String {
-        &self.serverless_backfill_controller_addr
     }
 
     /// Get a reference to the Prometheus client if available.

--- a/src/meta/node/src/lib.rs
+++ b/src/meta/node/src/lib.rs
@@ -199,6 +199,12 @@ pub struct MetaNodeOpts {
         default_value = "./secrets"
     )]
     pub temp_secret_file_dir: String,
+
+    /// Address of the serverless backfill controller.
+    /// Needed if meta receives a streaming job with serverless backfill enabled.
+    /// Feature disabled by default.
+    #[clap(long, env = "RW_SBC_ADDR", default_value = "")]
+    pub serverless_backfill_controller_addr: String,
 }
 
 impl risingwave_common::opts::Opts for MetaNodeOpts {
@@ -584,6 +590,7 @@ pub fn start(
 
                 enable_legacy_table_migration: config.meta.enable_legacy_table_migration,
                 pause_on_next_bootstrap_offline: config.meta.pause_on_next_bootstrap_offline,
+                serverless_backfill_controller_addr: opts.serverless_backfill_controller_addr,
             },
             config.system.into_init_system_params(),
             config.session_init,

--- a/src/meta/src/controller/streaming_job.rs
+++ b/src/meta/src/controller/streaming_job.rs
@@ -100,6 +100,26 @@ use crate::model::{
 use crate::stream::SplitAssignment;
 use crate::{MetaError, MetaResult};
 
+fn serverless_backfill_resource_group_placeholder(job_id: JobId) -> String {
+    format!("SERVERLESS_BACKFILL_RESOURCE_GROUP_TBD_FOR_{job_id}")
+}
+
+fn job_initial_catalog_resource_group(
+    resource_type: &streaming_job_resource_type::ResourceType,
+    job_id: JobId,
+) -> Option<String> {
+    match resource_type {
+        streaming_job_resource_type::ResourceType::Regular(_)
+        | streaming_job_resource_type::ResourceType::ServerlessBackfill(false) => None,
+        streaming_job_resource_type::ResourceType::SpecificResourceGroup(group) => {
+            Some(group.clone())
+        }
+        streaming_job_resource_type::ResourceType::ServerlessBackfill(true) => {
+            Some(serverless_backfill_resource_group_placeholder(job_id))
+        }
+    }
+}
+
 /// A planned fragment update for dependent sources when a connection's properties change.
 ///
 /// We keep it as a named struct (instead of a tuple) for readability and to avoid clippy
@@ -186,10 +206,9 @@ impl CatalogController {
     ) -> MetaResult<streaming_job::Model> {
         let obj = Self::create_object(txn, obj_type, owner_id, database_id, schema_id).await?;
         let job_id = obj.oid.as_job_id();
-        let specific_resource_group = resource_type.resource_group();
         let is_serverless_backfill = matches!(
             &resource_type,
-            streaming_job_resource_type::ResourceType::ServerlessBackfillResourceGroup(_)
+            streaming_job_resource_type::ResourceType::ServerlessBackfill(true)
         );
         let model = streaming_job::Model {
             job_id,
@@ -207,7 +226,7 @@ impl CatalogController {
                 .map(ToString::to_string),
             backfill_orders: None,
             max_parallelism: max_parallelism as _,
-            specific_resource_group,
+            specific_resource_group: job_initial_catalog_resource_group(&resource_type, job_id),
             is_serverless_backfill,
             refresh_interval_sec: refresh_interval_sec.map(|s| s as i64),
         };
@@ -327,7 +346,7 @@ impl CatalogController {
                     adaptive_parallelism_strategy,
                     streaming_parallelism,
                     max_parallelism,
-                    resource_type,
+                    resource_type.clone(),
                     backfill_parallelism.clone(),
                     backfill_adaptive_parallelism_strategy,
                     refresh_interval_sec,
@@ -361,7 +380,7 @@ impl CatalogController {
                     adaptive_parallelism_strategy,
                     streaming_parallelism,
                     max_parallelism,
-                    resource_type,
+                    resource_type.clone(),
                     backfill_parallelism.clone(),
                     backfill_adaptive_parallelism_strategy,
                     None, // refresh_interval_sec: only for MV
@@ -384,7 +403,7 @@ impl CatalogController {
                     adaptive_parallelism_strategy,
                     streaming_parallelism,
                     max_parallelism,
-                    resource_type,
+                    resource_type.clone(),
                     backfill_parallelism.clone(),
                     backfill_adaptive_parallelism_strategy,
                     None, // refresh_interval_sec: only for MV
@@ -449,7 +468,7 @@ impl CatalogController {
                     adaptive_parallelism_strategy,
                     streaming_parallelism,
                     max_parallelism,
-                    resource_type,
+                    resource_type.clone(),
                     backfill_parallelism.clone(),
                     backfill_adaptive_parallelism_strategy,
                     None, // refresh_interval_sec: only for MV
@@ -487,7 +506,7 @@ impl CatalogController {
                     adaptive_parallelism_strategy,
                     streaming_parallelism,
                     max_parallelism,
-                    resource_type,
+                    resource_type.clone(),
                     backfill_parallelism.clone(),
                     backfill_adaptive_parallelism_strategy,
                     None, // refresh_interval_sec: only for MV
@@ -579,6 +598,28 @@ impl CatalogController {
         txn.commit().await?;
 
         Ok(table_id_map)
+    }
+
+    pub async fn update_streaming_job_resource_group(
+        &self,
+        job_id: JobId,
+        resource_group: String,
+    ) -> MetaResult<()> {
+        let inner = self.inner.write().await;
+        let txn = inner.db.begin().await?;
+
+        ensure_job_not_canceled(job_id, &txn).await?;
+
+        let job = streaming_job::ActiveModel {
+            job_id: Set(job_id),
+            specific_resource_group: Set(Some(resource_group)),
+            ..Default::default()
+        };
+        StreamingJobModel::update(job).exec(&txn).await?;
+
+        txn.commit().await?;
+
+        Ok(())
     }
 
     pub async fn prepare_stream_job_fragments(

--- a/src/meta/src/manager/env.rs
+++ b/src/meta/src/manager/env.rs
@@ -310,6 +310,7 @@ pub struct MetaOpts {
 
     pub enable_legacy_table_migration: bool,
     pub pause_on_next_bootstrap_offline: bool,
+    pub serverless_backfill_controller_addr: String,
 }
 
 impl MetaOpts {
@@ -416,6 +417,7 @@ impl MetaOpts {
             enable_legacy_table_migration: true,
             refresh_scheduler_interval_sec: 60,
             pause_on_next_bootstrap_offline: false,
+            serverless_backfill_controller_addr: String::new(),
             table_change_log_insert_batch_size: 1000,
             table_change_log_delete_batch_size: 1000,
         }

--- a/src/meta/src/rpc/ddl_controller.rs
+++ b/src/meta/src/rpc/ddl_controller.rs
@@ -384,6 +384,23 @@ impl DdlController {
         Ok(())
     }
 
+    fn validate_serverless_backfill_enabled(
+        &self,
+        resource_type: &streaming_job_resource_type::ResourceType,
+    ) -> MetaResult<()> {
+        if matches!(
+            resource_type,
+            streaming_job_resource_type::ResourceType::ServerlessBackfill(true)
+        ) && self.env.opts.serverless_backfill_controller_addr.is_empty()
+        {
+            bail_invalid_parameter!(
+                "Serverless Backfill is disabled. Use RisingWave cloud at https://cloud.risingwave.com/auth/signup to try this feature"
+            );
+        }
+
+        Ok(())
+    }
+
     pub async fn new(
         env: MetaSrvEnv,
         metadata_manager: MetadataManager,
@@ -1084,6 +1101,8 @@ impl DdlController {
         {
             self.validate_table_for_sink(target_table).await?;
         }
+        self.validate_serverless_backfill_enabled(&resource_type)?;
+
         let ctx = StreamContext::from_protobuf(fragment_graph.get_ctx().unwrap());
         let adaptive_parallelism_strategy =
             (!fragment_graph.adaptive_parallelism_strategy.is_empty()).then(|| {
@@ -1097,6 +1116,7 @@ impl DdlController {
             parse_strategy(&fragment_graph.backfill_adaptive_parallelism_strategy)
                 .expect("backfill adaptive parallelism strategy should be validated in frontend")
         });
+
         let streaming_job_model = match self
             .metadata_manager
             .catalog_controller
@@ -1165,7 +1185,7 @@ impl DdlController {
                 ctx,
                 streaming_job,
                 fragment_graph,
-                resource_type,
+                resource_type.clone(),
                 streaming_job_model,
                 since_timestamp_epoch,
             )
@@ -1891,16 +1911,13 @@ impl DdlController {
             },
             (&stream_job).into(),
         )?;
-        let resource_group = if let Some(group) = resource_type.resource_group() {
-            group
-        } else {
-            self.metadata_manager
-                .get_database_resource_group(stream_job.database_id())
-                .await?
-        };
+        let database_resource_group = self
+            .metadata_manager
+            .get_database_resource_group(stream_job.database_id())
+            .await?;
         let is_serverless_backfill = matches!(
             &resource_type,
-            streaming_job_resource_type::ResourceType::ServerlessBackfillResourceGroup(_)
+            streaming_job_resource_type::ResourceType::ServerlessBackfill(true)
         );
 
         // 3. Build the actor graph.
@@ -1978,7 +1995,7 @@ impl DdlController {
 
         let ctx = CreateStreamingJobContext {
             upstream_fragment_downstreams,
-            database_resource_group: resource_group,
+            database_resource_group,
             definition: stream_job.definition(),
             create_type: stream_job.create_type(),
             job_type: (&stream_job).into(),
@@ -1991,6 +2008,7 @@ impl DdlController {
             locality_fragment_state_table_mapping,
             cdc_table_snapshot_splits,
             is_serverless_backfill,
+            resource_type,
             streaming_job_model: streaming_job_model.clone(),
             refresh_interval_sec: streaming_job_model.refresh_interval_sec.map(|s| s as u64),
             since_timestamp_epoch,

--- a/src/meta/src/stream/stream_manager.rs
+++ b/src/meta/src/stream/stream_manager.rs
@@ -15,6 +15,7 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
+use anyhow::Context;
 use await_tree::span;
 use futures::future::join_all;
 use itertools::Itertools;
@@ -26,8 +27,13 @@ use risingwave_connector::source::CdcTableSnapshotSplitRaw;
 use risingwave_meta_model::prelude::Fragment as FragmentModel;
 use risingwave_meta_model::{StreamingParallelism, WorkerId, fragment, streaming_job};
 use risingwave_pb::catalog::{CreateType, PbSink, PbTable, Subscription};
+use risingwave_pb::ddl_service::streaming_job_resource_type;
 use risingwave_pb::expr::PbExprNode;
 use risingwave_pb::plan_common::{PbColumnCatalog, PbField};
+use risingwave_pb::serverless_backfill_controller::{
+    ProvisionRequest, node_group_controller_service_client,
+};
+use risingwave_rpc_client::error::TonicStatusWrapper;
 use sea_orm::{ColumnTrait, EntityTrait, QueryFilter, QuerySelect};
 use thiserror_ext::AsReport;
 use tokio::sync::{Mutex, OwnedSemaphorePermit, oneshot};
@@ -134,6 +140,8 @@ pub struct CreateStreamingJobContext {
     pub locality_fragment_state_table_mapping: HashMap<FragmentId, Vec<TableId>>,
 
     pub is_serverless_backfill: bool,
+
+    pub resource_type: streaming_job_resource_type::ResourceType,
 
     /// The `streaming_job::Model` for this job, loaded from meta store.
     pub streaming_job_model: streaming_job::Model,
@@ -502,6 +510,62 @@ impl GlobalStreamManager {
         result
     }
 
+    async fn provision_serverless_backfill_resource_group(&self) -> MetaResult<String> {
+        let sbc_addr = &self.env.opts.serverless_backfill_controller_addr;
+        if sbc_addr.is_empty() {
+            bail_invalid_parameter!(
+                "Serverless Backfill is disabled. Use RisingWave cloud at https://cloud.risingwave.com/auth/signup to try this feature"
+            );
+        }
+
+        let request = tonic::Request::new(ProvisionRequest {});
+        let mut client =
+            node_group_controller_service_client::NodeGroupControllerServiceClient::connect(
+                sbc_addr.clone(),
+            )
+            .await
+            .with_context(|| {
+                format!(
+                    "unable to reach serverless backfill controller at addr {}",
+                    sbc_addr
+                )
+            })?;
+
+        match client.provision(request).await {
+            Ok(resp) => Ok(resp.into_inner().resource_group),
+            Err(e) => Err(anyhow::Error::new(TonicStatusWrapper::new(e))
+                .context("serverless backfill controller returned error")
+                .into()),
+        }
+    }
+
+    async fn finalize_create_streaming_job_resource_group(
+        &self,
+        resource_type: &streaming_job_resource_type::ResourceType,
+        streaming_job_model: &mut streaming_job::Model,
+    ) -> MetaResult<()> {
+        if !matches!(
+            resource_type,
+            streaming_job_resource_type::ResourceType::ServerlessBackfill(true)
+        ) {
+            return Ok(());
+        }
+
+        let group = self.provision_serverless_backfill_resource_group().await?;
+        tracing::info!(
+            resource_group = group,
+            "provisioning serverless backfill resource group"
+        );
+
+        self.metadata_manager
+            .catalog_controller
+            .update_streaming_job_resource_group(streaming_job_model.job_id, group.clone())
+            .await?;
+        streaming_job_model.specific_resource_group = Some(group);
+
+        Ok(())
+    }
+
     /// The function will return after barrier collected
     /// ([`crate::manager::MetadataManager::wait_streaming_job_finished`]).
     #[await_tree::instrument]
@@ -522,7 +586,8 @@ impl GlobalStreamManager {
             locality_fragment_state_table_mapping,
             cdc_table_snapshot_splits,
             is_serverless_backfill,
-            streaming_job_model,
+            resource_type,
+            mut streaming_job_model,
             refresh_interval_sec,
             since_timestamp_epoch,
             ..
@@ -555,6 +620,9 @@ impl GlobalStreamManager {
                         })
                 },
             );
+
+        self.finalize_create_streaming_job_resource_group(&resource_type, &mut streaming_job_model)
+            .await?;
 
         let info = CreateStreamingJobCommandInfo {
             stream_job_fragments,

--- a/src/prost/src/lib.rs
+++ b/src/prost/src/lib.rs
@@ -834,10 +834,10 @@ impl streaming_job_resource_type::ResourceType {
     pub fn resource_group(&self) -> Option<String> {
         match self {
             streaming_job_resource_type::ResourceType::Regular(_) => None,
-            streaming_job_resource_type::ResourceType::SpecificResourceGroup(group)
-            | streaming_job_resource_type::ResourceType::ServerlessBackfillResourceGroup(group) => {
+            streaming_job_resource_type::ResourceType::SpecificResourceGroup(group) => {
                 Some(group.clone())
             }
+            streaming_job_resource_type::ResourceType::ServerlessBackfill(_) => None,
         }
     }
 }


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

This PR moves serverless backfill resource provisioning from frontend to meta and delays provisioning until the create streaming job command is about to be issued.

The frontend still accepts the serverless backfill controller address option for backward-compatible startup parsing, but the option is deprecated. Frontend now only encodes whether the job requests serverless backfill in the DDL request. Meta owns the controller address, validates that serverless backfill is enabled before catalog creation, writes a debug placeholder resource group into the initial job catalog, provisions the real resource group after frontend/meta validation and graph building, updates the job catalog, and then renders the create command with the real resource group.

This keeps failed validation paths from provisioning serverless resources while preserving the resource group needed by the job catalog and actor creation path.

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [x] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [x] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

Serverless backfill provisioning is now handled by meta instead of frontend. Configure the serverless backfill controller address on meta nodes; the frontend option is deprecated and kept only for compatibility.

</details>
