### PR TITLE
fix(meta): skip batch refresh ack after reset

### DIFF
--- a/src/meta/src/barrier/checkpoint/independent_job/batch_refresh_job/mod.rs
+++ b/src/meta/src/barrier/checkpoint/independent_job/batch_refresh_job/mod.rs
@@ -975,48 +975,59 @@ impl BatchRefreshJobCheckpointControl {
         partial_graph_manager: &mut PartialGraphManager,
         completed_epoch: u64,
     ) {
-        partial_graph_manager.ack_completed(self.partial_graph_id, completed_epoch);
-
-        // Check if snapshot stop barrier committed (FinishingSnapshot → Idle).
-        // Note: must check status first; target_upstream_epoch in ConsumingLogStore may
-        // coincidentally equal snapshot_epoch when no new upstream commits occurred.
-        if let BatchRefreshJobStatus::FinishingSnapshot { tracking_job, .. } = &self.status
-            && completed_epoch == self.snapshot_epoch
-        {
-            assert!(
-                tracking_job.is_none(),
-                "tracking job should have been taken at start_completing"
-            );
-            info!(
-                job_id = %self.job_id,
-                completed_epoch,
-                "batch refresh job: snapshot done, transitioned to idle, removing partial graph"
-            );
-            partial_graph_manager.remove_partial_graphs(vec![self.partial_graph_id]);
-            self.status = BatchRefreshJobStatus::Idle {
-                last_committed_epoch: completed_epoch,
-            };
-            return;
-        }
-
-        // Check if logstore consumption is done (target_upstream_epoch committed).
-        if let BatchRefreshJobStatus::ConsumingLogStore {
-            target_upstream_epoch,
-            ..
-        } = &self.status
-            && completed_epoch == *target_upstream_epoch
-        {
-            let target = *target_upstream_epoch;
-            info!(
-                job_id = %self.job_id,
-                completed_epoch,
-                target_upstream_epoch = target,
-                "batch refresh job: logstore done, transitioned to idle, removing partial graph"
-            );
-            partial_graph_manager.remove_partial_graphs(vec![self.partial_graph_id]);
-            self.status = BatchRefreshJobStatus::Idle {
-                last_committed_epoch: target,
-            };
+        match &self.status {
+            BatchRefreshJobStatus::ConsumingSnapshot { .. } => {
+                partial_graph_manager.ack_completed(self.partial_graph_id, completed_epoch);
+            }
+            BatchRefreshJobStatus::FinishingSnapshot { tracking_job, .. }
+                if completed_epoch == self.snapshot_epoch =>
+            {
+                partial_graph_manager.ack_completed(self.partial_graph_id, completed_epoch);
+                assert!(
+                    tracking_job.is_none(),
+                    "tracking job should have been taken at start_completing"
+                );
+                info!(
+                    job_id = %self.job_id,
+                    completed_epoch,
+                    "batch refresh job: snapshot done, transitioned to idle, removing partial graph"
+                );
+                partial_graph_manager.remove_partial_graphs(vec![self.partial_graph_id]);
+                self.status = BatchRefreshJobStatus::Idle {
+                    last_committed_epoch: completed_epoch,
+                };
+            }
+            BatchRefreshJobStatus::FinishingSnapshot { .. } => {
+                partial_graph_manager.ack_completed(self.partial_graph_id, completed_epoch);
+            }
+            BatchRefreshJobStatus::ConsumingLogStore {
+                target_upstream_epoch,
+                ..
+            } if completed_epoch == *target_upstream_epoch => {
+                let target = *target_upstream_epoch;
+                partial_graph_manager.ack_completed(self.partial_graph_id, completed_epoch);
+                info!(
+                    job_id = %self.job_id,
+                    completed_epoch,
+                    target_upstream_epoch = target,
+                    "batch refresh job: logstore done, transitioned to idle, removing partial graph"
+                );
+                partial_graph_manager.remove_partial_graphs(vec![self.partial_graph_id]);
+                self.status = BatchRefreshJobStatus::Idle {
+                    last_committed_epoch: target,
+                };
+            }
+            BatchRefreshJobStatus::ConsumingLogStore { .. } => {
+                partial_graph_manager.ack_completed(self.partial_graph_id, completed_epoch);
+            }
+            BatchRefreshJobStatus::Resetting { .. } => {
+                // The job was dropped while the completing task was running in the background.
+                // The partial graph has already been reset, so skip the ack.
+            }
+            BatchRefreshJobStatus::Idle { .. }
+            | BatchRefreshJobStatus::InitializingBatchRefresh { .. } => {
+                unreachable!("batch refresh job should not be completing in this state")
+            }
         }
     }
 


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

Batch-refresh partial graph completion can race with dropping the batch-refresh materialized view. In that case the drop path resets the partial graph and moves the job into `Resetting`, while an async barrier completion task can still later ack the completed epoch.

This PR makes `BatchRefreshJobCheckpointControl::ack_completed` handle each job status explicitly. It now skips the partial-graph ack when the batch-refresh job is already `Resetting`, matching the existing behavior for normal creating streaming jobs and avoiding a panic in `PartialGraphManager::running_graph_mut`.

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [x] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

Not required. This is an internal meta stability fix for a drop/reset race.

</details>
