### PR TITLE
feat(sink): support turbopuffer sink

### DIFF
--- a/ci/scripts/e2e-sink-test.sh
+++ b/ci/scripts/e2e-sink-test.sh
@@ -65,6 +65,24 @@ grep -q '"content-type": "application/json"' "$HTTP_SINK_HEADERS"
 kill "$HTTP_SINK_SERVER_PID" || true
 rm -f "$HTTP_SINK_OUTPUT" "$HTTP_SINK_HEADERS"
 
+echo "--- e2e, turbopuffer sink"
+TURBOPUFFER_SINK_OUTPUT=$(mktemp)
+TURBOPUFFER_SINK_HEADERS=$(mktemp)
+TURBOPUFFER_SINK_PATHS=$(mktemp)
+python3 e2e_test/sink/http_sink_mock_server.py "$TURBOPUFFER_SINK_OUTPUT" 18082 "$TURBOPUFFER_SINK_HEADERS" "$TURBOPUFFER_SINK_PATHS" &
+TURBOPUFFER_SINK_SERVER_PID=$!
+# Wait for the server to be ready
+for i in $(seq 1 20); do curl -sf http://localhost:18082/ && break; sleep 0.5; done
+
+risedev slt './e2e_test/sink/turbopuffer_sink.slt'
+
+# Allow a moment for in-flight requests to complete
+sleep 1
+python3 e2e_test/sink/turbopuffer_sink_check.py "$TURBOPUFFER_SINK_OUTPUT" "$TURBOPUFFER_SINK_HEADERS" "$TURBOPUFFER_SINK_PATHS"
+
+kill "$TURBOPUFFER_SINK_SERVER_PID" || true
+rm -f "$TURBOPUFFER_SINK_OUTPUT" "$TURBOPUFFER_SINK_HEADERS" "$TURBOPUFFER_SINK_PATHS"
+
 echo "--- Kill cluster"
 risedev ci-kill
 

--- a/e2e_test/sink/http_sink_mock_server.py
+++ b/e2e_test/sink/http_sink_mock_server.py
@@ -17,10 +17,11 @@
 Mock HTTP server for testing the RisingWave HTTP sink.
 
 Usage:
-    python3 http_sink_mock_server.py <body_output_file> <port> [<header_output_file>]
+    python3 http_sink_mock_server.py <body_output_file> <port> [<header_output_file>] [<path_output_file>]
 
 Each POST request body is appended as a line to the body output file.
 If a header output file is given, received headers are appended as a JSON line per request.
+If a path output file is given, each request path is appended as a line per request.
 Responds 200 OK to every POST, 400 to anything else.
 """
 
@@ -34,6 +35,7 @@ def main():
     body_output_file = sys.argv[1] if len(sys.argv) > 1 else "/tmp/http_sink_test_body.txt"
     port = int(sys.argv[2]) if len(sys.argv) > 2 else 18081
     header_output_file = sys.argv[3] if len(sys.argv) > 3 else None
+    path_output_file = sys.argv[4] if len(sys.argv) > 4 else None
 
     class Handler(BaseHTTPRequestHandler):
         def do_POST(self):
@@ -41,6 +43,9 @@ def main():
             body = self.rfile.read(length).decode("utf-8")
             with open(body_output_file, "a") as f:
                 f.write(body + "\n")
+            if path_output_file is not None:
+                with open(path_output_file, "a") as f:
+                    f.write(self.path + "\n")
             if header_output_file is not None:
                 headers = {k.lower(): v for k, v in self.headers.items()}
                 with open(header_output_file, "a") as f:

--- a/e2e_test/sink/turbopuffer_sink.slt
+++ b/e2e_test/sink/turbopuffer_sink.slt
@@ -253,6 +253,7 @@ CREATE SINK tpuf_bad_fts_type FROM tpuf_items WITH (
     api_key = secret tpuf_api_key,
     primary_key = 'id',
     type = 'upsert',
+    distance_metric = 'cosine_distance',
     full_text_search_columns = 'is_starred'
 );
 

--- a/e2e_test/sink/turbopuffer_sink.slt
+++ b/e2e_test/sink/turbopuffer_sink.slt
@@ -1,0 +1,243 @@
+statement ok
+set sink_decouple = false;
+
+statement ok
+CREATE SECRET tpuf_api_key WITH (backend = 'meta') AS 'tpuf_test';
+
+# ---- Success: write payload, headers, dynamic namespace, and mixed upsert/delete request ----
+statement ok
+CREATE TABLE tpuf_e2e_items (
+    id varchar primary key,
+    workspace_id varchar,
+    body varchar,
+    note_contents varchar[],
+    is_starred boolean,
+    published_at timestamp,
+    embedding vector(3)
+);
+
+statement ok
+INSERT INTO tpuf_e2e_items VALUES
+    ('delete-me', 'IFI-ns-1', 'to be deleted', ARRAY['old', 'row'], true, '2026-06-16 01:02:03+00:00', '[0.1,0.2,0.3]');
+
+statement ok
+CREATE SINK tpuf_e2e_sink FROM tpuf_e2e_items WITH (
+    connector = 'turbopuffer',
+    base_url = 'http://localhost:18082',
+    namespace_column = 'workspace_id',
+    api_key = secret tpuf_api_key,
+    primary_key = 'id',
+    type = 'upsert',
+    distance_metric = 'cosine_distance',
+    disable_backpressure = 'true',
+    full_text_search_columns = 'body,note_contents',
+    filterable_columns = '*'
+);
+
+statement ok
+FLUSH;
+
+statement ok
+UPDATE tpuf_e2e_items
+SET id = 'upsert-me',
+    body = 'inserted after delete',
+    note_contents = ARRAY['new', 'row'],
+    is_starred = false,
+    published_at = '2026-06-16 04:05:06',
+    embedding = '[0.4,0.5,0.6]'
+WHERE id = 'delete-me';
+
+statement ok
+FLUSH;
+
+statement ok
+DROP SINK tpuf_e2e_sink;
+
+statement ok
+DROP TABLE tpuf_e2e_items;
+
+statement ok
+CREATE TABLE tpuf_items (
+    id varchar primary key,
+    workspace_id varchar,
+    body varchar,
+    note_contents varchar[],
+    is_starred boolean,
+    published_at timestamp,
+    vector vector(3)
+);
+
+# ---- Validation: static namespace success path ----
+statement ok
+CREATE SINK tpuf_static FROM tpuf_items WITH (
+    connector = 'turbopuffer',
+    base_url = 'https://aws-us-east-2.turbopuffer.com',
+    namespace = 'IFI-static',
+    api_key = secret tpuf_api_key,
+    primary_key = 'id',
+    type = 'upsert',
+    distance_metric = 'cosine_distance',
+    disable_backpressure = 'true',
+    full_text_search_columns = 'body,note_contents',
+    filterable_columns = '*'
+);
+
+statement ok
+DROP SINK tpuf_static;
+
+# ---- Validation: dynamic namespace success path ----
+statement ok
+CREATE SINK tpuf_dynamic FROM tpuf_items WITH (
+    connector = 'turbopuffer',
+    base_url = 'https://aws-us-east-2.turbopuffer.com',
+    namespace_column = 'workspace_id',
+    api_key = secret tpuf_api_key,
+    primary_key = 'id',
+    type = 'upsert',
+    distance_metric = 'cosine_distance',
+    full_text_search_columns = 'body',
+    filterable_columns = '*'
+);
+
+statement ok
+DROP SINK tpuf_dynamic;
+
+# ---- Validation: append-only sinks also require a single primary_key document id ----
+statement ok
+CREATE TABLE tpuf_append_only (
+    id varchar,
+    body varchar
+) append only;
+
+statement ok
+CREATE SINK tpuf_append_only_sink FROM tpuf_append_only WITH (
+    connector = 'turbopuffer',
+    base_url = 'https://aws-us-east-2.turbopuffer.com',
+    namespace = 'IFI-append-only',
+    api_key = secret tpuf_api_key,
+    primary_key = 'id',
+    type = 'append-only',
+    filterable_columns = '*'
+);
+
+statement ok
+DROP SINK tpuf_append_only_sink;
+
+statement ok
+DROP TABLE tpuf_append_only;
+
+# ---- Validation: distance_metric is optional without vector columns ----
+statement ok
+CREATE TABLE tpuf_no_vector (
+    id varchar primary key,
+    body varchar
+);
+
+statement ok
+CREATE SINK tpuf_no_vector_sink FROM tpuf_no_vector WITH (
+    connector = 'turbopuffer',
+    base_url = 'https://aws-us-east-2.turbopuffer.com',
+    namespace = 'IFI-no-vector',
+    api_key = secret tpuf_api_key,
+    primary_key = 'id',
+    type = 'upsert',
+    filterable_columns = '*'
+);
+
+statement ok
+DROP SINK tpuf_no_vector_sink;
+
+statement ok
+DROP TABLE tpuf_no_vector;
+
+# ---- Validation: primary key is required and must be single-column ----
+statement error Turbopuffer sink requires exactly one primary_key column
+CREATE SINK tpuf_missing_pk FROM tpuf_items WITH (
+    connector = 'turbopuffer',
+    base_url = 'https://aws-us-east-2.turbopuffer.com',
+    namespace = 'IFI-static',
+    api_key = secret tpuf_api_key,
+    type = 'upsert'
+);
+
+statement error Turbopuffer sink requires exactly one primary_key column
+CREATE SINK tpuf_composite_pk FROM tpuf_items WITH (
+    connector = 'turbopuffer',
+    base_url = 'https://aws-us-east-2.turbopuffer.com',
+    namespace = 'IFI-static',
+    api_key = secret tpuf_api_key,
+    primary_key = 'id,workspace_id',
+    type = 'upsert'
+);
+
+# ---- Validation: namespace must be static or dynamic, not both ----
+statement error Turbopuffer sink requires only one of namespace or namespace_column
+CREATE SINK tpuf_namespace_conflict FROM tpuf_items WITH (
+    connector = 'turbopuffer',
+    base_url = 'https://aws-us-east-2.turbopuffer.com',
+    namespace = 'IFI-static',
+    namespace_column = 'workspace_id',
+    api_key = secret tpuf_api_key,
+    primary_key = 'id',
+    type = 'upsert'
+);
+
+# ---- Validation: schema option columns must refer to generated attributes ----
+statement error Turbopuffer schema option references unknown attribute column
+CREATE SINK tpuf_unknown_schema_column FROM tpuf_items WITH (
+    connector = 'turbopuffer',
+    base_url = 'https://aws-us-east-2.turbopuffer.com',
+    namespace = 'IFI-static',
+    api_key = secret tpuf_api_key,
+    primary_key = 'id',
+    type = 'upsert',
+    full_text_search_columns = 'missing_column'
+);
+
+statement ok
+CREATE TABLE tpuf_id_attribute (
+    doc_id varchar primary key,
+    id varchar,
+    body varchar
+);
+
+statement error Turbopuffer attribute column must not be named id
+CREATE SINK tpuf_id_attribute_sink FROM tpuf_id_attribute WITH (
+    connector = 'turbopuffer',
+    base_url = 'https://aws-us-east-2.turbopuffer.com',
+    namespace = 'IFI-static',
+    api_key = secret tpuf_api_key,
+    primary_key = 'doc_id',
+    type = 'upsert',
+    filterable_columns = '*'
+);
+
+statement ok
+DROP TABLE tpuf_id_attribute;
+
+statement error Turbopuffer sink requires distance_metric when sink schema contains vector columns
+CREATE SINK tpuf_missing_distance_metric FROM tpuf_items WITH (
+    connector = 'turbopuffer',
+    base_url = 'https://aws-us-east-2.turbopuffer.com',
+    namespace = 'IFI-static',
+    api_key = secret tpuf_api_key,
+    primary_key = 'id',
+    type = 'upsert'
+);
+
+statement error Turbopuffer full_text_search column
+CREATE SINK tpuf_bad_fts_type FROM tpuf_items WITH (
+    connector = 'turbopuffer',
+    base_url = 'https://aws-us-east-2.turbopuffer.com',
+    namespace = 'IFI-static',
+    api_key = secret tpuf_api_key,
+    primary_key = 'id',
+    type = 'upsert',
+    full_text_search_columns = 'is_starred'
+);
+
+statement ok
+DROP TABLE tpuf_items;
+
+statement ok
+DROP SECRET tpuf_api_key;

--- a/e2e_test/sink/turbopuffer_sink.slt
+++ b/e2e_test/sink/turbopuffer_sink.slt
@@ -150,6 +150,29 @@ DROP SINK tpuf_no_vector_sink;
 statement ok
 DROP TABLE tpuf_no_vector;
 
+# ---- Validation: numeric attribute JSON payloads match generated schema types ----
+statement ok
+CREATE TABLE tpuf_decimal_attr (
+    id varchar primary key,
+    price decimal
+);
+
+statement ok
+CREATE SINK tpuf_decimal_attr_sink FROM tpuf_decimal_attr WITH (
+    connector = 'turbopuffer',
+    base_url = 'https://aws-us-east-2.turbopuffer.com',
+    namespace = 'IFI-decimal',
+    api_key = secret tpuf_api_key,
+    primary_key = 'id',
+    type = 'upsert'
+);
+
+statement ok
+DROP SINK tpuf_decimal_attr_sink;
+
+statement ok
+DROP TABLE tpuf_decimal_attr;
+
 # ---- Validation: primary key is required and must be single-column ----
 statement error Turbopuffer sink requires exactly one primary_key column
 CREATE SINK tpuf_missing_pk FROM tpuf_items WITH (

--- a/e2e_test/sink/turbopuffer_sink.slt
+++ b/e2e_test/sink/turbopuffer_sink.slt
@@ -4,7 +4,7 @@ set sink_decouple = false;
 statement ok
 CREATE SECRET tpuf_api_key WITH (backend = 'meta') AS 'tpuf_test';
 
-# ---- Success: write payload, headers, dynamic namespace, and mixed upsert/delete request ----
+# ---- Success: write payload, headers, dynamic namespace, and upsert/delete requests ----
 statement ok
 CREATE TABLE tpuf_e2e_items (
     id varchar primary key,
@@ -38,14 +38,11 @@ statement ok
 FLUSH;
 
 statement ok
-UPDATE tpuf_e2e_items
-SET id = 'upsert-me',
-    body = 'inserted after delete',
-    note_contents = ARRAY['new', 'row'],
-    is_starred = false,
-    published_at = '2026-06-16 04:05:06',
-    embedding = '[0.4,0.5,0.6]'
-WHERE id = 'delete-me';
+DELETE FROM tpuf_e2e_items WHERE id = 'delete-me';
+
+statement ok
+INSERT INTO tpuf_e2e_items VALUES
+    ('upsert-me', 'IFI-ns-1', 'inserted after delete', ARRAY['new', 'row'], false, '2026-06-16 04:05:06', '[0.4,0.5,0.6]');
 
 statement ok
 FLUSH;

--- a/e2e_test/sink/turbopuffer_sink_check.py
+++ b/e2e_test/sink/turbopuffer_sink_check.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+# Copyright 2026 RisingWave Labs
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+import sys
+
+
+def read_json_lines(path):
+    with open(path) as f:
+        return [json.loads(line) for line in f if line.strip()]
+
+
+def read_lines(path):
+    with open(path) as f:
+        return [line.strip() for line in f if line.strip()]
+
+
+def assert_equal(actual, expected, message):
+    if actual != expected:
+        raise AssertionError(f"{message}: expected {expected!r}, got {actual!r}")
+
+
+def find_body(bodies, predicate, description):
+    for body in bodies:
+        if predicate(body):
+            return body
+    raise AssertionError(f"missing turbopuffer request body: {description}")
+
+
+def main():
+    if len(sys.argv) != 4:
+        raise SystemExit(
+            "usage: turbopuffer_sink_check.py <body_file> <header_file> <path_file>"
+        )
+
+    bodies = read_json_lines(sys.argv[1])
+    headers = read_json_lines(sys.argv[2])
+    paths = read_lines(sys.argv[3])
+
+    if len(bodies) < 2:
+        raise AssertionError(f"expected at least 2 turbopuffer requests, got {len(bodies)}")
+    assert_equal(len(headers), len(bodies), "header/body request count mismatch")
+    assert_equal(len(paths), len(bodies), "path/body request count mismatch")
+
+    if "/v2/namespaces/IFI-ns-1" not in paths:
+        raise AssertionError(f"dynamic namespace path was not observed: {paths!r}")
+
+    for header in headers:
+        assert_equal(header.get("authorization"), "Bearer tpuf_test", "authorization header")
+        assert "application/json" in header.get("content-type", ""), "content-type header"
+
+    backfill = find_body(
+        bodies,
+        lambda body: "upsert_rows" in body
+        and any(row.get("id") == "delete-me" for row in body["upsert_rows"]),
+        "initial upsert for delete-me",
+    )
+    assert_equal(backfill["distance_metric"], "cosine_distance", "distance metric")
+    assert_equal(backfill["disable_backpressure"], True, "disable_backpressure")
+
+    schema = backfill["schema"]
+    assert_equal(schema["body"]["type"], "string", "body type")
+    assert_equal(schema["body"]["filterable"], True, "body filterable")
+    assert_equal(schema["body"]["full_text_search"], True, "body full_text_search")
+    assert_equal(schema["note_contents"]["type"], "[]string", "note_contents type")
+    assert_equal(
+        schema["note_contents"]["full_text_search"],
+        True,
+        "note_contents full_text_search",
+    )
+    assert_equal(schema["is_starred"]["type"], "bool", "is_starred type")
+    assert_equal(schema["published_at"]["type"], "datetime", "published_at type")
+    assert_equal(schema["embedding"]["type"], "[3]f32", "embedding type")
+    assert_equal(schema["embedding"]["ann"], True, "embedding ann")
+
+    mixed = find_body(
+        bodies,
+        lambda body: "upsert_rows" in body
+        and "deletes" in body
+        and "delete-me" in body["deletes"]
+        and any(row.get("id") == "upsert-me" for row in body["upsert_rows"]),
+        "single request containing both upsert_rows and deletes",
+    )
+    rows = {row["id"]: row for row in mixed["upsert_rows"]}
+    assert_equal(rows["upsert-me"]["body"], "inserted after delete", "upsert body")
+    assert_equal(rows["upsert-me"]["note_contents"], ["new", "row"], "upsert note contents")
+    assert_equal(rows["upsert-me"]["embedding"], [0.4, 0.5, 0.6], "upsert vector")
+
+
+if __name__ == "__main__":
+    main()

--- a/e2e_test/sink/turbopuffer_sink_check.py
+++ b/e2e_test/sink/turbopuffer_sink_check.py
@@ -32,6 +32,16 @@ def assert_equal(actual, expected, message):
         raise AssertionError(f"{message}: expected {expected!r}, got {actual!r}")
 
 
+def assert_float_list_close(actual, expected, message, tolerance=1e-6):
+    if len(actual) != len(expected):
+        raise AssertionError(f"{message}: expected {expected!r}, got {actual!r}")
+    for index, (actual_value, expected_value) in enumerate(zip(actual, expected)):
+        if abs(actual_value - expected_value) > tolerance:
+            raise AssertionError(
+                f"{message}[{index}]: expected {expected_value!r}, got {actual_value!r}"
+            )
+
+
 def find_body(bodies, predicate, description):
     for body in bodies:
         if predicate(body):
@@ -101,7 +111,7 @@ def main():
     rows = {row["id"]: row for row in upsert_request["upsert_rows"]}
     assert_equal(rows["upsert-me"]["body"], "inserted after delete", "upsert body")
     assert_equal(rows["upsert-me"]["note_contents"], ["new", "row"], "upsert note contents")
-    assert_equal(rows["upsert-me"]["embedding"], [0.4, 0.5, 0.6], "upsert vector")
+    assert_float_list_close(rows["upsert-me"]["embedding"], [0.4, 0.5, 0.6], "upsert vector")
 
 
 if __name__ == "__main__":

--- a/e2e_test/sink/turbopuffer_sink_check.py
+++ b/e2e_test/sink/turbopuffer_sink_check.py
@@ -85,15 +85,20 @@ def main():
     assert_equal(schema["embedding"]["type"], "[3]f32", "embedding type")
     assert_equal(schema["embedding"]["ann"], True, "embedding ann")
 
-    mixed = find_body(
+    delete_request = find_body(
+        bodies,
+        lambda body: "deletes" in body and "delete-me" in body["deletes"],
+        "delete request for delete-me",
+    )
+    assert_equal(delete_request["distance_metric"], "cosine_distance", "delete distance metric")
+
+    upsert_request = find_body(
         bodies,
         lambda body: "upsert_rows" in body
-        and "deletes" in body
-        and "delete-me" in body["deletes"]
         and any(row.get("id") == "upsert-me" for row in body["upsert_rows"]),
-        "single request containing both upsert_rows and deletes",
+        "upsert request for upsert-me",
     )
-    rows = {row["id"]: row for row in mixed["upsert_rows"]}
+    rows = {row["id"]: row for row in upsert_request["upsert_rows"]}
     assert_equal(rows["upsert-me"]["body"], "inserted after delete", "upsert body")
     assert_equal(rows["upsert-me"]["note_contents"], ["new", "row"], "upsert note contents")
     assert_equal(rows["upsert-me"]["embedding"], [0.4, 0.5, 0.6], "upsert vector")

--- a/src/connector/src/sink/encoder/json.rs
+++ b/src/connector/src/sink/encoder/json.rs
@@ -269,7 +269,10 @@ fn datum_to_json_object(
             }
             CustomJsonType::Turbopuffer => {
                 let value = f64::try_from(v).map_err(|err| {
-                    ArrayError::internal(format!("failed to convert decimal to f64: {err}"))
+                    ArrayError::internal(format!(
+                        "failed to convert decimal to f64: {}",
+                        err.as_report()
+                    ))
                 })?;
                 serde_json::Number::from_f64(value)
                     .map(Value::Number)

--- a/src/connector/src/sink/encoder/json.rs
+++ b/src/connector/src/sink/encoder/json.rs
@@ -139,6 +139,23 @@ impl JsonEncoder {
         }
     }
 
+    pub fn new_with_turbopuffer(schema: Schema, col_indices: Option<Vec<usize>>) -> Self {
+        let config = JsonEncoderConfig {
+            time_handling_mode: TimeHandlingMode::String,
+            date_handling_mode: DateHandlingMode::String,
+            timestamp_handling_mode: TimestampHandlingMode::String,
+            timestamptz_handling_mode: TimestamptzHandlingMode::UtcString,
+            custom_json_type: CustomJsonType::Turbopuffer,
+            jsonb_handling_mode: JsonbHandlingMode::Dynamic,
+        };
+        Self {
+            schema,
+            col_indices,
+            kafka_connect: None,
+            config,
+        }
+    }
+
     pub fn with_kafka_connect(self, kafka_connect: KafkaConnectParams) -> Self {
         Self {
             kafka_connect: Some(Arc::new(kafka_connect)),
@@ -227,8 +244,12 @@ fn datum_to_json_object(
             json!(v)
         }
         (DataType::Serial, ScalarRefImpl::Serial(v)) => {
-            // The serial type needs to be handled as a string to prevent primary key conflicts caused by the precision issues of JSON numbers.
-            json!(format!("{:#018x}", v.into_inner()))
+            if matches!(&config.custom_json_type, CustomJsonType::Turbopuffer) {
+                json!(v.into_inner())
+            } else {
+                // The serial type needs to be handled as a string to prevent primary key conflicts caused by the precision issues of JSON numbers.
+                json!(format!("{:#018x}", v.into_inner()))
+            }
         }
         (DataType::Float32, ScalarRefImpl::Float32(v)) => {
             json!(f32::from(v))
@@ -245,6 +266,18 @@ fn datum_to_json_object(
                 let s = map.get(&field.name).unwrap();
                 v.rescale(*s as u32);
                 json!(v.to_text())
+            }
+            CustomJsonType::Turbopuffer => {
+                let value = f64::try_from(v).map_err(|err| {
+                    ArrayError::internal(format!("failed to convert decimal to f64: {err}"))
+                })?;
+                serde_json::Number::from_f64(value)
+                    .map(Value::Number)
+                    .ok_or_else(|| {
+                        ArrayError::internal(
+                            "failed to encode non-finite decimal as JSON number".to_owned(),
+                        )
+                    })?
             }
             CustomJsonType::Es | CustomJsonType::None | CustomJsonType::StarRocks => {
                 json!(v.to_text())
@@ -356,7 +389,7 @@ fn datum_to_json_object(
                         "starrocks can't support struct".to_owned(),
                     ));
                 }
-                CustomJsonType::Es | CustomJsonType::None => {
+                CustomJsonType::Es | CustomJsonType::None | CustomJsonType::Turbopuffer => {
                     let mut map = Map::with_capacity(st.len());
                     for (sub_datum_ref, sub_field) in struct_ref.iter_fields_ref().zip_eq_debug(
                         st.iter()
@@ -548,6 +581,48 @@ mod tests {
         assert_eq!(
             serde_json::to_string(&serial_value).unwrap(),
             format!("\"{:#018x}\"", i64::MAX)
+        );
+
+        let turbopuffer_config = JsonEncoderConfig {
+            time_handling_mode: TimeHandlingMode::String,
+            date_handling_mode: DateHandlingMode::String,
+            timestamp_handling_mode: TimestampHandlingMode::String,
+            timestamptz_handling_mode: TimestamptzHandlingMode::UtcString,
+            custom_json_type: CustomJsonType::Turbopuffer,
+            jsonb_handling_mode: JsonbHandlingMode::Dynamic,
+        };
+        let turbopuffer_serial_value = datum_to_json_object(
+            &Field {
+                data_type: DataType::Serial,
+                ..mock_field.clone()
+            },
+            Some(ScalarImpl::Serial(i64::MAX.into()).as_scalar_ref_impl()),
+            &turbopuffer_config,
+        )
+        .unwrap();
+        assert_eq!(turbopuffer_serial_value, json!(i64::MAX));
+        let turbopuffer_decimal_value = datum_to_json_object(
+            &Field {
+                data_type: DataType::Decimal,
+                ..mock_field.clone()
+            },
+            Some(ScalarImpl::Decimal(Decimal::try_from(1.25).unwrap()).as_scalar_ref_impl()),
+            &turbopuffer_config,
+        )
+        .unwrap();
+        assert_eq!(turbopuffer_decimal_value, json!(1.25));
+        assert!(
+            datum_to_json_object(
+                &Field {
+                    data_type: DataType::Decimal,
+                    ..mock_field.clone()
+                },
+                Some(ScalarImpl::Decimal(Decimal::NaN).as_scalar_ref_impl()),
+                &turbopuffer_config,
+            )
+            .unwrap_err()
+            .to_string()
+            .contains("non-finite decimal")
         );
 
         // https://github.com/debezium/debezium/blob/main/debezium-core/src/main/java/io/debezium/time/ZonedTimestamp.java

--- a/src/connector/src/sink/encoder/mod.rs
+++ b/src/connector/src/sink/encoder/mod.rs
@@ -150,6 +150,8 @@ pub enum CustomJsonType {
     Es,
     // starrocks' need jsonb is struct
     StarRocks,
+    // turbopuffer expects serial and decimal attributes to match `int` and `float` schema types.
+    Turbopuffer,
     None,
 }
 

--- a/src/connector/src/sink/mod.rs
+++ b/src/connector/src/sink/mod.rs
@@ -49,6 +49,7 @@ pub mod sqlserver;
 feature_gated_sink_mod!(starrocks, "starrocks");
 pub mod test_sink;
 pub mod trivial;
+pub mod turbopuffer;
 pub mod utils;
 pub mod writer;
 pub mod prelude {
@@ -128,6 +129,7 @@ macro_rules! for_all_sinks {
                 { Pulsar, $crate::sink::pulsar::PulsarSink, $crate::sink::pulsar::PulsarConfig },
                 { BlackHole, $crate::sink::trivial::BlackHoleSink, () },
                 { Http, $crate::sink::http::HttpSink, $crate::sink::http::HttpConfig },
+                { Turbopuffer, $crate::sink::turbopuffer::TurbopufferSink, $crate::sink::turbopuffer::TurbopufferConfig },
                 { Kinesis, $crate::sink::kinesis::KinesisSink, $crate::sink::kinesis::KinesisSinkConfig },
                 { ClickHouse, $crate::sink::clickhouse::ClickHouseSink, $crate::sink::clickhouse::ClickHouseConfig },
                 { Iceberg, $crate::sink::iceberg::IcebergSink, $crate::sink::iceberg::IcebergConfig },

--- a/src/connector/src/sink/turbopuffer.rs
+++ b/src/connector/src/sink/turbopuffer.rs
@@ -715,19 +715,27 @@ fn unsupported_type(data_type: &str) -> SinkError {
 
 #[cfg(test)]
 mod tests {
+    #[cfg(not(madsim))]
     use std::io::{Read, Write};
+    #[cfg(not(madsim))]
     use std::net::TcpListener;
+    #[cfg(not(madsim))]
     use std::sync::mpsc;
+    #[cfg(not(madsim))]
     use std::thread;
 
+    #[cfg(not(madsim))]
+    use risingwave_common::array::StreamChunk;
+    #[cfg(not(madsim))]
     use risingwave_common::array::stream_chunk::StreamChunkTestExt as _;
-    use risingwave_common::array::{ListValue, StreamChunk, VectorVal};
+    use risingwave_common::array::{ListValue, VectorVal};
     use risingwave_common::catalog::Field;
     use risingwave_common::row::OwnedRow;
     use risingwave_common::types::{ListType, ScalarImpl, Timestamp};
     use serde_json::json;
 
     use super::*;
+    #[cfg(not(madsim))]
     use crate::sink::log_store::DeliveryFutureManager;
 
     #[test]
@@ -756,6 +764,7 @@ mod tests {
         assert_eq!(generated["vector"]["ann"], json!(true));
     }
 
+    #[cfg(not(madsim))]
     #[tokio::test]
     async fn test_write_chunk_posts_batched_payload_and_headers() {
         let (base_url, request_rx, server_thread) = spawn_mock_http_server();
@@ -989,6 +998,7 @@ mod tests {
         assert_eq!(body["upsert_rows"][0]["vector"][0], json!(0.25));
     }
 
+    #[cfg(not(madsim))]
     fn spawn_mock_http_server() -> (String, mpsc::Receiver<String>, thread::JoinHandle<()>) {
         let listener = TcpListener::bind("127.0.0.1:0").unwrap();
         let addr = listener.local_addr().unwrap();
@@ -1030,6 +1040,7 @@ mod tests {
         (format!("http://{}", addr), request_rx, server_thread)
     }
 
+    #[cfg(not(madsim))]
     fn find_header_end(buf: &[u8]) -> Option<usize> {
         buf.windows(4).position(|window| window == b"\r\n\r\n")
     }

--- a/src/connector/src/sink/turbopuffer.rs
+++ b/src/connector/src/sink/turbopuffer.rs
@@ -1,0 +1,854 @@
+// Copyright 2026 RisingWave Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::{BTreeMap, HashMap, HashSet};
+
+use anyhow::{Context, anyhow};
+use itertools::Itertools;
+use reqwest::header::{AUTHORIZATION, CONTENT_TYPE, HeaderMap, HeaderValue};
+use risingwave_common::array::{Op, StreamChunk};
+use risingwave_common::catalog::Schema;
+use risingwave_common::row::Row;
+use risingwave_common::types::{DataType, ScalarRefImpl};
+use serde::{Deserialize, Serialize};
+use serde_json::{Map, Value};
+use serde_with::{DisplayFromStr, serde_as};
+use thiserror_ext::AsReport;
+use with_options::WithOptions;
+
+use crate::enforce_secret::EnforceSecret;
+use crate::sink::encoder::{
+    DateHandlingMode, JsonEncoder, JsonbHandlingMode, RowEncoder, TimeHandlingMode,
+    TimestampHandlingMode, TimestamptzHandlingMode,
+};
+use crate::sink::log_store::DeliveryFutureManagerAddFuture;
+use crate::sink::writer::{
+    AsyncTruncateLogSinkerOf, AsyncTruncateSinkWriter, AsyncTruncateSinkWriterExt,
+};
+use crate::sink::{Result, Sink, SinkError, SinkParam, SinkWriterParam};
+
+pub const TURBOPUFFER_SINK: &str = "turbopuffer";
+
+#[serde_as]
+#[derive(Clone, Debug, Deserialize, WithOptions)]
+pub struct TurbopufferConfig {
+    pub base_url: String,
+    pub namespace: Option<String>,
+    pub namespace_column: Option<String>,
+    pub api_key: String,
+    pub distance_metric: Option<String>,
+    #[serde_as(as = "Option<DisplayFromStr>")]
+    pub disable_backpressure: Option<bool>,
+    pub full_text_search_columns: Option<String>,
+    pub filterable_columns: Option<String>,
+    pub r#type: String, // accept "append-only" or "upsert"
+}
+
+impl EnforceSecret for TurbopufferConfig {
+    const ENFORCE_SECRET_PROPERTIES: phf::Set<&'static str> = phf::phf_set! {
+        "api_key",
+    };
+}
+
+impl TurbopufferConfig {
+    fn from_btreemap(values: BTreeMap<String, String>) -> Result<Self> {
+        serde_json::from_value::<TurbopufferConfig>(
+            serde_json::to_value(values).expect("serialize sink properties"),
+        )
+        .map_err(|e| SinkError::Config(anyhow!(e)))
+    }
+}
+
+#[derive(Clone, Debug)]
+enum TurbopufferNamespace {
+    Static(String),
+    Dynamic { index: usize },
+}
+
+#[derive(Clone, Debug)]
+pub struct TurbopufferSink {
+    config: TurbopufferConfig,
+    schema: Schema,
+    is_append_only: bool,
+    pk_index: usize,
+    namespace: TurbopufferNamespace,
+    attribute_indices: Vec<usize>,
+    generated_schema: Value,
+}
+
+impl EnforceSecret for TurbopufferSink {
+    fn enforce_secret<'a>(
+        prop_iter: impl Iterator<Item = &'a str>,
+    ) -> crate::error::ConnectorResult<()> {
+        for prop in prop_iter {
+            TurbopufferConfig::enforce_one(prop)?;
+        }
+        Ok(())
+    }
+}
+
+impl TryFrom<SinkParam> for TurbopufferSink {
+    type Error = SinkError;
+
+    fn try_from(param: SinkParam) -> std::result::Result<Self, Self::Error> {
+        let schema = param.schema();
+        let is_append_only = param.sink_type.is_append_only();
+        let pk_indices = param.downstream_pk_or_empty();
+        let [pk_index] = pk_indices.as_slice() else {
+            return Err(SinkError::Config(anyhow!(
+                "Turbopuffer sink requires exactly one primary_key column"
+            )));
+        };
+        let pk_index = *pk_index;
+        match schema[pk_index].data_type() {
+            DataType::Int16
+            | DataType::Int32
+            | DataType::Int64
+            | DataType::Serial
+            | DataType::Varchar => {}
+            data_type => {
+                return Err(SinkError::Config(anyhow!(
+                    "Turbopuffer document id column must be an integer or varchar, got {:?}",
+                    data_type
+                )));
+            }
+        };
+        let config = TurbopufferConfig::from_btreemap(param.properties)?;
+
+        let namespace = match (&config.namespace, &config.namespace_column) {
+            (Some(namespace), None) => {
+                validate_namespace(namespace)?;
+                TurbopufferNamespace::Static(namespace.clone())
+            }
+            (None, Some(namespace_column)) => {
+                let index = schema
+                    .fields()
+                    .iter()
+                    .position(|field| field.name == *namespace_column)
+                    .ok_or_else(|| {
+                        SinkError::Config(anyhow!(
+                            "Turbopuffer namespace_column '{}' not found in sink schema",
+                            namespace_column
+                        ))
+                    })?;
+                if schema[index].data_type != DataType::Varchar {
+                    return Err(SinkError::Config(anyhow!(
+                        "Turbopuffer namespace_column must be varchar, got {:?}",
+                        schema[index].data_type
+                    )));
+                }
+                TurbopufferNamespace::Dynamic { index }
+            }
+            (Some(_), Some(_)) => {
+                return Err(SinkError::Config(anyhow!(
+                    "Turbopuffer sink requires only one of namespace or namespace_column"
+                )));
+            }
+            (None, None) => {
+                return Err(SinkError::Config(anyhow!(
+                    "Turbopuffer sink requires either namespace or namespace_column"
+                )));
+            }
+        };
+
+        // Turbopuffer treats `id` as the document ID in write requests; it is not a schema
+        // attribute. Dynamic namespace is also metadata for routing, not a document attribute.
+        let excluded_indices = match &namespace {
+            TurbopufferNamespace::Static(_) => HashSet::from([pk_index]),
+            TurbopufferNamespace::Dynamic { index } => HashSet::from([pk_index, *index]),
+        };
+        let attribute_indices = (0..schema.len())
+            .filter(|idx| !excluded_indices.contains(idx))
+            .collect_vec();
+        for index in &attribute_indices {
+            if schema[*index].name == "id" {
+                return Err(SinkError::Config(anyhow!(
+                    "Turbopuffer attribute column must not be named id"
+                )));
+            }
+        }
+        let full_text_search_columns = parse_column_selection(
+            config.full_text_search_columns.as_deref(),
+            &schema,
+            &attribute_indices,
+        )?;
+        let filterable_columns = parse_column_selection(
+            config.filterable_columns.as_deref(),
+            &schema,
+            &attribute_indices,
+        )?;
+        let has_vector = attribute_indices
+            .iter()
+            .any(|idx| matches!(schema[*idx].data_type, DataType::Vector(_)));
+        if has_vector && config.distance_metric.is_none() {
+            return Err(SinkError::Config(anyhow!(
+                "Turbopuffer sink requires distance_metric when sink schema contains vector columns"
+            )));
+        }
+        let generated_schema = build_turbopuffer_schema(
+            &schema,
+            &attribute_indices,
+            &full_text_search_columns,
+            &filterable_columns,
+        )?;
+
+        Ok(Self {
+            config,
+            schema,
+            is_append_only,
+            pk_index,
+            namespace,
+            attribute_indices,
+            generated_schema,
+        })
+    }
+}
+
+impl Sink for TurbopufferSink {
+    type LogSinker = AsyncTruncateLogSinkerOf<TurbopufferSinkWriter>;
+
+    const SINK_NAME: &'static str = TURBOPUFFER_SINK;
+
+    async fn validate(&self) -> Result<()> {
+        Ok(())
+    }
+
+    async fn new_log_sinker(&self, _writer_param: SinkWriterParam) -> Result<Self::LogSinker> {
+        Ok(TurbopufferSinkWriter::new(
+            self.config.clone(),
+            self.schema.clone(),
+            self.is_append_only,
+            self.pk_index,
+            self.namespace.clone(),
+            self.attribute_indices.clone(),
+            self.generated_schema.clone(),
+        )?
+        .into_log_sinker(usize::MAX))
+    }
+}
+
+pub struct TurbopufferSinkWriter {
+    client: reqwest::Client,
+    base_url: String,
+    distance_metric: Option<String>,
+    disable_backpressure: Option<bool>,
+    schema: Value,
+    is_append_only: bool,
+    pk_index: usize,
+    namespace: TurbopufferNamespace,
+    row_encoder: JsonEncoder,
+}
+
+impl TurbopufferSinkWriter {
+    fn new(
+        config: TurbopufferConfig,
+        schema: Schema,
+        is_append_only: bool,
+        pk_index: usize,
+        namespace: TurbopufferNamespace,
+        attribute_indices: Vec<usize>,
+        generated_schema: Value,
+    ) -> Result<Self> {
+        let mut header_map = HeaderMap::new();
+        header_map.insert(CONTENT_TYPE, HeaderValue::from_static("application/json"));
+        let authorization = format!("Bearer {}", config.api_key);
+        header_map.insert(
+            AUTHORIZATION,
+            authorization
+                .parse()
+                .context("invalid turbopuffer api_key")
+                .map_err(SinkError::Config)?,
+        );
+        let client = reqwest::Client::builder()
+            .default_headers(header_map)
+            .build()
+            .context("failed to build turbopuffer HTTP client")
+            .map_err(SinkError::Http)?;
+        let base_url = config
+            .base_url
+            .parse::<reqwest::Url>()
+            .context("invalid turbopuffer base_url")
+            .map_err(SinkError::Config)?
+            .to_string()
+            .trim_end_matches('/')
+            .to_owned();
+        let row_encoder = JsonEncoder::new(
+            schema,
+            Some(attribute_indices),
+            DateHandlingMode::String,
+            TimestampHandlingMode::String,
+            TimestamptzHandlingMode::UtcString,
+            TimeHandlingMode::String,
+            JsonbHandlingMode::Dynamic,
+        );
+        Ok(Self {
+            client,
+            base_url,
+            distance_metric: config.distance_metric,
+            disable_backpressure: config.disable_backpressure,
+            schema: generated_schema,
+            is_append_only,
+            pk_index,
+            namespace,
+            row_encoder,
+        })
+    }
+
+    fn url_for_row(&self, row: &impl Row) -> Result<String> {
+        match &self.namespace {
+            TurbopufferNamespace::Static(namespace) => Ok(format!(
+                "{}/v2/namespaces/{}",
+                self.base_url,
+                namespace.as_str()
+            )),
+            TurbopufferNamespace::Dynamic { index } => {
+                let namespace = match row.datum_at(*index) {
+                    Some(ScalarRefImpl::Utf8(namespace)) => namespace,
+                    None => {
+                        return Err(SinkError::Http(anyhow!(
+                            "Turbopuffer namespace_column cannot be null"
+                        )));
+                    }
+                    Some(_) => {
+                        return Err(SinkError::Http(anyhow!(
+                            "unexpected namespace_column type, expected varchar"
+                        )));
+                    }
+                };
+                validate_namespace(namespace)?;
+                Ok(format!("{}/v2/namespaces/{}", self.base_url, namespace))
+            }
+        }
+    }
+
+    // Turbopuffer document IDs are unsigned 64-bit integers, UUIDs, or strings up to 64 bytes.
+    // RisingWave UUID IDs can be represented with varchar.
+    fn id_for_row(&self, row: &impl Row) -> Result<DocumentId> {
+        let datum = row.datum_at(self.pk_index).ok_or_else(|| {
+            SinkError::Http(anyhow!("Turbopuffer document id column cannot be null"))
+        })?;
+        match datum {
+            ScalarRefImpl::Int16(value) => Ok(document_id_from_i64(value as i64)),
+            ScalarRefImpl::Int32(value) => Ok(document_id_from_i64(value as i64)),
+            ScalarRefImpl::Int64(value) => Ok(document_id_from_i64(value)),
+            ScalarRefImpl::Serial(value) => Ok(document_id_from_i64(value.into_inner())),
+            ScalarRefImpl::Utf8(value) => {
+                if value.len() > 64 {
+                    return Err(SinkError::Http(anyhow!(
+                        "Turbopuffer string document id exceeds 64 bytes"
+                    )));
+                }
+                Ok(DocumentId::String(value.to_owned()))
+            }
+            _ => Err(SinkError::Http(anyhow!(
+                "Turbopuffer document id column must be an integer or varchar"
+            ))),
+        }
+    }
+
+    fn upsert_row(&self, row: &impl Row, id: DocumentId) -> Result<Map<String, Value>> {
+        let mut value = self.row_encoder.encode(row)?;
+        value.insert(
+            "id".to_owned(),
+            serde_json::to_value(id).expect("serialize document id"),
+        );
+        Ok(value)
+    }
+
+    fn request_body(
+        &self,
+        upsert_rows: Vec<Map<String, Value>>,
+        deletes: Vec<DocumentId>,
+    ) -> Value {
+        let mut body = Map::new();
+        if let Some(distance_metric) = &self.distance_metric {
+            body.insert(
+                "distance_metric".to_owned(),
+                Value::String(distance_metric.clone()),
+            );
+        }
+        if !upsert_rows.is_empty() {
+            if let Some(disable_backpressure) = self.disable_backpressure {
+                body.insert(
+                    "disable_backpressure".to_owned(),
+                    Value::Bool(disable_backpressure),
+                );
+            }
+            body.insert("schema".to_owned(), self.schema.clone());
+            body.insert(
+                "upsert_rows".to_owned(),
+                Value::Array(upsert_rows.into_iter().map(Value::Object).collect()),
+            );
+        }
+        if !deletes.is_empty() {
+            body.insert(
+                "deletes".to_owned(),
+                Value::Array(
+                    deletes
+                        .into_iter()
+                        .map(|id| serde_json::to_value(id).expect("serialize document id"))
+                        .collect(),
+                ),
+            );
+        }
+        Value::Object(body)
+    }
+}
+
+impl AsyncTruncateSinkWriter for TurbopufferSinkWriter {
+    async fn write_chunk<'a>(
+        &'a mut self,
+        chunk: StreamChunk,
+        _add_future: DeliveryFutureManagerAddFuture<'a, Self::DeliveryFuture>,
+    ) -> Result<()> {
+        if self.is_append_only {
+            let mut batches = BTreeMap::<String, Vec<Map<String, Value>>>::new();
+            for (op, row) in chunk.rows() {
+                match op {
+                    Op::Insert | Op::UpdateInsert => {
+                        let id = match self.id_for_row(&row) {
+                            Ok(id) => id,
+                            Err(err) => {
+                                tracing::warn!(error = %err.as_report(), "skip turbopuffer row with invalid document id");
+                                continue;
+                            }
+                        };
+                        let upsert_row = match self.upsert_row(&row, id) {
+                            Ok(row) => row,
+                            Err(err) => {
+                                tracing::warn!(error = %err.as_report(), "skip turbopuffer row failed to encode upsert payload");
+                                continue;
+                            }
+                        };
+                        let url = match self.url_for_row(&row) {
+                            Ok(url) => url,
+                            Err(err) => {
+                                tracing::warn!(error = %err.as_report(), "skip turbopuffer row with invalid namespace");
+                                continue;
+                            }
+                        };
+                        batches.entry(url).or_default().push(upsert_row);
+                    }
+                    Op::Delete | Op::UpdateDelete => {
+                        return Err(SinkError::Http(anyhow!(
+                            "`Delete` or `UpdateDelete` operation is not supported in append-only turbopuffer sink"
+                        )));
+                    }
+                }
+            }
+
+            for (url, upsert_rows) in batches {
+                if upsert_rows.is_empty() {
+                    continue;
+                }
+                let resp = self
+                    .client
+                    .post(url)
+                    .json(&self.request_body(upsert_rows, Vec::new()))
+                    .send()
+                    .await
+                    .context("turbopuffer write request failed")
+                    .map_err(SinkError::Http)?;
+
+                if !resp.status().is_success() {
+                    let status = resp.status();
+                    let body = resp.text().await.unwrap_or_default();
+                    return Err(SinkError::Http(anyhow!(
+                        "Turbopuffer sink received non-success response: {} {}",
+                        status,
+                        body
+                    )));
+                }
+            }
+        } else {
+            let mut batches = BTreeMap::<String, HashMap<DocumentId, CompactedOp>>::new();
+            for (op, row) in chunk.rows() {
+                let id = match self.id_for_row(&row) {
+                    Ok(id) => id,
+                    Err(err) => {
+                        tracing::warn!(error = %err.as_report(), "skip turbopuffer row with invalid document id");
+                        continue;
+                    }
+                };
+                let url = match self.url_for_row(&row) {
+                    Ok(url) => url,
+                    Err(err) => {
+                        tracing::warn!(error = %err.as_report(), "skip turbopuffer row with invalid namespace");
+                        continue;
+                    }
+                };
+                match op {
+                    Op::Insert | Op::UpdateInsert => {
+                        let upsert_row = match self.upsert_row(&row, id.clone()) {
+                            Ok(row) => row,
+                            Err(err) => {
+                                tracing::warn!(error = %err.as_report(), "skip turbopuffer row failed to encode upsert payload");
+                                continue;
+                            }
+                        };
+                        batches
+                            .entry(url)
+                            .or_default()
+                            .insert(id, CompactedOp::Upsert(upsert_row));
+                    }
+                    Op::Delete | Op::UpdateDelete => {
+                        batches
+                            .entry(url)
+                            .or_default()
+                            .insert(id, CompactedOp::Delete);
+                    }
+                }
+            }
+
+            for (url, batch) in batches {
+                let mut upsert_rows = Vec::new();
+                let mut deletes = Vec::new();
+                for (id, op) in batch {
+                    match op {
+                        CompactedOp::Upsert(row) => upsert_rows.push(row),
+                        CompactedOp::Delete => deletes.push(id),
+                    }
+                }
+                if upsert_rows.is_empty() && deletes.is_empty() {
+                    continue;
+                }
+                let resp = self
+                    .client
+                    .post(url)
+                    .json(&self.request_body(upsert_rows, deletes))
+                    .send()
+                    .await
+                    .context("turbopuffer write request failed")
+                    .map_err(SinkError::Http)?;
+
+                if !resp.status().is_success() {
+                    let status = resp.status();
+                    let body = resp.text().await.unwrap_or_default();
+                    return Err(SinkError::Http(anyhow!(
+                        "Turbopuffer sink received non-success response: {} {}",
+                        status,
+                        body
+                    )));
+                }
+            }
+        }
+
+        Ok(())
+    }
+}
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize)]
+#[serde(untagged)]
+enum DocumentId {
+    U64(u64),
+    String(String),
+}
+
+#[derive(Debug)]
+enum CompactedOp {
+    Upsert(Map<String, Value>),
+    Delete,
+}
+
+fn document_id_from_i64(value: i64) -> DocumentId {
+    if value < 0 {
+        tracing::warn!(
+            value,
+            "cast negative turbopuffer integer document id to unsigned integer"
+        );
+    }
+    DocumentId::U64(value as u64)
+}
+
+fn validate_namespace(namespace: &str) -> Result<()> {
+    if namespace.is_empty() || namespace.len() > 128 {
+        return Err(SinkError::Config(anyhow!(
+            "Turbopuffer namespace must be 1 to 128 bytes"
+        )));
+    }
+    if !namespace
+        .bytes()
+        .all(|b| b.is_ascii_alphanumeric() || matches!(b, b'-' | b'_' | b'.'))
+    {
+        return Err(SinkError::Config(anyhow!(
+            "Turbopuffer namespace must match [A-Za-z0-9-_.]{{1,128}}"
+        )));
+    }
+    Ok(())
+}
+
+fn parse_column_selection(
+    value: Option<&str>,
+    schema: &Schema,
+    attribute_indices: &[usize],
+) -> Result<HashSet<String>> {
+    let attribute_names = attribute_indices
+        .iter()
+        .map(|index| schema[*index].name.as_str())
+        .collect::<HashSet<_>>();
+    let columns: HashSet<String> = match value {
+        Some(value) if value.trim() == "*" => {
+            return Ok(attribute_names
+                .into_iter()
+                .map(str::to_owned)
+                .collect::<HashSet<_>>());
+        }
+        Some(value) => value
+            .split(',')
+            .map(str::trim)
+            .filter(|name| !name.is_empty())
+            .map(str::to_owned)
+            .collect(),
+        None => return Ok(HashSet::new()),
+    };
+    for column in &columns {
+        if !attribute_names.contains(column.as_str()) {
+            return Err(SinkError::Config(anyhow!(
+                "Turbopuffer schema option references unknown attribute column '{}'",
+                column
+            )));
+        }
+    }
+    Ok(columns)
+}
+
+fn build_turbopuffer_schema(
+    schema: &Schema,
+    attribute_indices: &[usize],
+    full_text_search_columns: &HashSet<String>,
+    filterable_columns: &HashSet<String>,
+) -> Result<Value> {
+    let mut result = Map::new();
+    for index in attribute_indices {
+        let field = &schema[*index];
+        let mut config = Map::new();
+        let data_type = field.data_type();
+        let turbopuffer_type = turbopuffer_type(&data_type)?;
+        let is_vector = matches!(data_type, DataType::Vector(_));
+        let is_full_text_search = full_text_search_columns.contains(&field.name);
+        if is_full_text_search && !supports_full_text_search(&data_type) {
+            return Err(SinkError::Config(anyhow!(
+                "Turbopuffer full_text_search column '{}' must be string or []string",
+                field.name
+            )));
+        }
+        config.insert("type".to_owned(), Value::String(turbopuffer_type));
+        if filterable_columns.contains(&field.name) {
+            config.insert("filterable".to_owned(), Value::Bool(true));
+        }
+        if is_full_text_search {
+            config.insert("full_text_search".to_owned(), Value::Bool(true));
+        }
+        if is_vector {
+            config.insert("ann".to_owned(), Value::Bool(true));
+        }
+        result.insert(field.name.clone(), Value::Object(config));
+    }
+    Ok(Value::Object(result))
+}
+
+fn supports_full_text_search(data_type: &DataType) -> bool {
+    match data_type {
+        DataType::Varchar => true,
+        DataType::List(list_type) => matches!(list_type.elem(), DataType::Varchar),
+        _ => false,
+    }
+}
+
+fn turbopuffer_type(data_type: &DataType) -> Result<String> {
+    match data_type {
+        DataType::Boolean => Ok("bool".to_owned()),
+        DataType::Int16 | DataType::Int32 | DataType::Int64 | DataType::Serial => {
+            Ok("int".to_owned())
+        }
+        DataType::Float32 | DataType::Float64 | DataType::Decimal => Ok("float".to_owned()),
+        DataType::Varchar => Ok("string".to_owned()),
+        DataType::Date | DataType::Timestamp => Ok("datetime".to_owned()),
+        DataType::List(list_type) => match list_type.elem() {
+            DataType::Boolean => Ok("[]bool".to_owned()),
+            DataType::Int16 | DataType::Int32 | DataType::Int64 | DataType::Serial => {
+                Ok("[]int".to_owned())
+            }
+            DataType::Float32 | DataType::Float64 | DataType::Decimal => Ok("[]float".to_owned()),
+            DataType::Varchar => Ok("[]string".to_owned()),
+            DataType::Date | DataType::Timestamp => Ok("[]datetime".to_owned()),
+            elem_type => Err(unsupported_type(&format!("list element {:?}", elem_type))),
+        },
+        DataType::Vector(dimension) => Ok(format!("[{}]f32", dimension)),
+        data_type => Err(unsupported_type(&format!("{:?}", data_type))),
+    }
+}
+
+fn unsupported_type(data_type: &str) -> SinkError {
+    SinkError::Config(anyhow!(
+        "Turbopuffer sink does not support column type {}",
+        data_type
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::{Read, Write};
+    use std::net::TcpListener;
+    use std::sync::mpsc;
+    use std::thread;
+
+    use risingwave_common::array::StreamChunk;
+    use risingwave_common::array::stream_chunk::StreamChunkTestExt as _;
+    use risingwave_common::catalog::Field;
+    use risingwave_common::types::ListType;
+    use serde_json::json;
+
+    use super::*;
+    use crate::sink::log_store::DeliveryFutureManager;
+
+    #[test]
+    fn test_build_schema_flags() {
+        let schema = Schema::new(vec![
+            Field::with_name(DataType::Varchar, "id"),
+            Field::with_name(DataType::Varchar, "body"),
+            Field::with_name(DataType::List(ListType::new(DataType::Varchar)), "tags"),
+            Field::with_name(DataType::Boolean, "flag"),
+            Field::with_name(DataType::Vector(384), "vector"),
+        ]);
+        let generated = build_turbopuffer_schema(
+            &schema,
+            &[1, 2, 3, 4],
+            &parse_column_selection(Some("body,tags"), &schema, &[1, 2, 3, 4]).unwrap(),
+            &parse_column_selection(Some("*"), &schema, &[1, 2, 3, 4]).unwrap(),
+        )
+        .unwrap();
+
+        assert_eq!(generated["body"]["type"], json!("string"));
+        assert_eq!(generated["body"]["filterable"], json!(true));
+        assert_eq!(generated["body"]["full_text_search"], json!(true));
+        assert_eq!(generated["tags"]["type"], json!("[]string"));
+        assert_eq!(generated["tags"]["full_text_search"], json!(true));
+        assert_eq!(generated["vector"]["type"], json!("[384]f32"));
+        assert_eq!(generated["vector"]["ann"], json!(true));
+    }
+
+    #[tokio::test]
+    async fn test_write_chunk_posts_batched_payload_and_headers() {
+        let (base_url, request_rx, server_thread) = spawn_mock_http_server();
+        let schema = Schema::new(vec![
+            Field::with_name(DataType::Varchar, "id"),
+            Field::with_name(DataType::Varchar, "body"),
+            Field::with_name(DataType::Varchar, "workspace_id"),
+        ]);
+        let payload_indices = vec![1];
+        let generated_schema = build_turbopuffer_schema(
+            &schema,
+            &payload_indices,
+            &parse_column_selection(Some("body"), &schema, &payload_indices).unwrap(),
+            &parse_column_selection(Some("*"), &schema, &payload_indices).unwrap(),
+        )
+        .unwrap();
+        let config = TurbopufferConfig {
+            base_url,
+            namespace: None,
+            namespace_column: Some("workspace_id".to_owned()),
+            api_key: "tpuf_test_key".to_owned(),
+            distance_metric: None,
+            disable_backpressure: Some(true),
+            full_text_search_columns: Some("body".to_owned()),
+            filterable_columns: Some("*".to_owned()),
+            r#type: "upsert".to_owned(),
+        };
+        let mut writer = TurbopufferSinkWriter::new(
+            config,
+            schema,
+            false,
+            0,
+            TurbopufferNamespace::Dynamic { index: 2 },
+            payload_indices,
+            generated_schema,
+        )
+        .unwrap();
+        let chunk = StreamChunk::from_pretty(
+            "T  T        T
+            U- old-id   old_body ns_1
+            U+ new-id   new_body ns_1",
+        );
+        let mut future_manager = DeliveryFutureManager::new(0);
+
+        writer
+            .write_chunk(chunk, future_manager.start_write_chunk(0, 0))
+            .await
+            .unwrap();
+        let request = request_rx.recv().unwrap();
+        server_thread.join().unwrap();
+
+        assert!(request.starts_with("post /v2/namespaces/ns_1 http/1.1"));
+        assert!(request.contains("authorization: bearer tpuf_test_key"));
+        assert!(request.contains("content-type: application/json"));
+
+        let body = request.split("\r\n\r\n").nth(1).unwrap();
+        let body: Value = serde_json::from_str(body).unwrap();
+        assert_eq!(body["disable_backpressure"], json!(true));
+        assert_eq!(body["schema"]["body"]["type"], json!("string"));
+        assert_eq!(body["schema"]["body"]["filterable"], json!(true));
+        assert_eq!(body["schema"]["body"]["full_text_search"], json!(true));
+        assert_eq!(body["deletes"], json!(["old-id"]));
+        assert_eq!(body["upsert_rows"].as_array().unwrap().len(), 1);
+        assert_eq!(body["upsert_rows"][0]["id"], json!("new-id"));
+        assert_eq!(body["upsert_rows"][0]["body"], json!("new_body"));
+        assert!(body.get("distance_metric").is_none());
+    }
+
+    fn spawn_mock_http_server() -> (String, mpsc::Receiver<String>, thread::JoinHandle<()>) {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+        let (request_tx, request_rx) = mpsc::channel();
+        let server_thread = thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            let mut buf = Vec::new();
+            let header_end = loop {
+                let mut tmp = [0; 1024];
+                let read = stream.read(&mut tmp).unwrap();
+                assert_ne!(read, 0);
+                buf.extend_from_slice(&tmp[..read]);
+                if let Some(header_end) = find_header_end(&buf) {
+                    break header_end;
+                }
+            };
+            let headers = String::from_utf8_lossy(&buf[..header_end]);
+            let content_length = headers
+                .lines()
+                .find_map(|line| {
+                    let (name, value) = line.split_once(':')?;
+                    name.eq_ignore_ascii_case("content-length")
+                        .then(|| value.trim().parse::<usize>().unwrap())
+                })
+                .unwrap();
+            while buf.len() < header_end + 4 + content_length {
+                let mut tmp = [0; 1024];
+                let read = stream.read(&mut tmp).unwrap();
+                assert_ne!(read, 0);
+                buf.extend_from_slice(&tmp[..read]);
+            }
+            let request = String::from_utf8(buf[..header_end + 4 + content_length].to_vec())
+                .expect("HTTP request should be utf8");
+            request_tx.send(request.to_lowercase()).unwrap();
+            stream
+                .write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 0\r\nConnection: close\r\n\r\n")
+                .unwrap();
+        });
+        (format!("http://{}", addr), request_rx, server_thread)
+    }
+
+    fn find_header_end(buf: &[u8]) -> Option<usize> {
+        buf.windows(4).position(|window| window == b"\r\n\r\n")
+    }
+}

--- a/src/connector/src/sink/turbopuffer.rs
+++ b/src/connector/src/sink/turbopuffer.rs
@@ -28,10 +28,7 @@ use thiserror_ext::AsReport;
 use with_options::WithOptions;
 
 use crate::enforce_secret::EnforceSecret;
-use crate::sink::encoder::{
-    DateHandlingMode, JsonEncoder, JsonbHandlingMode, RowEncoder, TimeHandlingMode,
-    TimestampHandlingMode, TimestamptzHandlingMode,
-};
+use crate::sink::encoder::{JsonEncoder, RowEncoder};
 use crate::sink::log_store::DeliveryFutureManagerAddFuture;
 use crate::sink::writer::{
     AsyncTruncateLogSinkerOf, AsyncTruncateSinkWriter, AsyncTruncateSinkWriterExt,
@@ -196,6 +193,9 @@ impl TryFrom<SinkParam> for TurbopufferSink {
                 "Turbopuffer sink requires distance_metric when sink schema contains vector columns"
             )));
         }
+        // This validates every document attribute type before the writer is created:
+        // `build_turbopuffer_schema` calls `turbopuffer_type` for each attribute and
+        // returns a config error for unsupported types.
         let generated_schema = build_turbopuffer_schema(
             &schema,
             &attribute_indices,
@@ -283,15 +283,7 @@ impl TurbopufferSinkWriter {
             .to_string()
             .trim_end_matches('/')
             .to_owned();
-        let row_encoder = JsonEncoder::new(
-            schema,
-            Some(attribute_indices),
-            DateHandlingMode::String,
-            TimestampHandlingMode::String,
-            TimestamptzHandlingMode::UtcString,
-            TimeHandlingMode::String,
-            JsonbHandlingMode::Dynamic,
-        );
+        let row_encoder = JsonEncoder::new_with_turbopuffer(schema, Some(attribute_indices));
         Ok(Self {
             client,
             base_url,
@@ -666,6 +658,30 @@ fn supports_full_text_search(data_type: &DataType) -> bool {
     }
 }
 
+// Mapping from RisingWave attribute types to generated turbopuffer schema types and
+// the JSON value shapes emitted by `JsonEncoder`:
+//
+// | RisingWave type                  | turbopuffer type | JSON payload                  |
+// |----------------------------------|------------------|-------------------------------|
+// | boolean                          | bool             | boolean                       |
+// | int16, int32, int64              | int              | number                        |
+// | float32, float64                 | float            | number                        |
+// | varchar                          | string           | string                        |
+// | date                             | datetime         | string: YYYY-MM-DD            |
+// | timestamp                        | datetime         | string: YYYY-MM-DD HH:MM:SS   |
+// | boolean[]                        | []bool           | array of booleans             |
+// | int16[], int32[], int64[]        | []int            | array of numbers              |
+// | float32[], float64[]             | []float          | array of numbers              |
+// | varchar[]                        | []string         | array of strings              |
+// | date[], timestamp[]              | []datetime       | array of datetime strings     |
+// | vector(N)                        | [N]f32           | array of numbers              |
+// | serial                           | int              | number                        |
+// | decimal                          | float            | number, converted through f64 |
+// | serial[]                         | []int            | array of numbers              |
+// | decimal[]                        | []float          | array of f64-converted numbers|
+//
+// The primary key column is encoded separately as the turbopuffer document id, so
+// it does not participate in this schema mapping.
 fn turbopuffer_type(data_type: &DataType) -> Result<String> {
     match data_type {
         DataType::Boolean => Ok("bool".to_owned()),
@@ -704,10 +720,11 @@ mod tests {
     use std::sync::mpsc;
     use std::thread;
 
-    use risingwave_common::array::StreamChunk;
     use risingwave_common::array::stream_chunk::StreamChunkTestExt as _;
+    use risingwave_common::array::{ListValue, StreamChunk, VectorVal};
     use risingwave_common::catalog::Field;
-    use risingwave_common::types::ListType;
+    use risingwave_common::row::OwnedRow;
+    use risingwave_common::types::{ListType, ScalarImpl, Timestamp};
     use serde_json::json;
 
     use super::*;
@@ -805,6 +822,171 @@ mod tests {
         assert_eq!(body["upsert_rows"][0]["id"], json!("new-id"));
         assert_eq!(body["upsert_rows"][0]["body"], json!("new_body"));
         assert!(body.get("distance_metric").is_none());
+    }
+
+    #[test]
+    fn test_decimal_and_serial_schema_types() {
+        assert_eq!(turbopuffer_type(&DataType::Decimal).unwrap(), "float");
+        assert_eq!(turbopuffer_type(&DataType::Serial).unwrap(), "int");
+        assert_eq!(
+            turbopuffer_type(&DataType::List(ListType::new(DataType::Decimal))).unwrap(),
+            "[]float"
+        );
+        assert_eq!(
+            turbopuffer_type(&DataType::List(ListType::new(DataType::Serial))).unwrap(),
+            "[]int"
+        );
+    }
+
+    #[test]
+    fn test_manual_http_sink_schema_and_payload_shape() {
+        let schema = Schema::new(vec![
+            Field::with_name(DataType::Varchar, "id"),
+            Field::with_name(DataType::Varchar, "workspaceId"),
+            Field::with_name(DataType::Varchar, "inboxFeedItemId"),
+            Field::with_name(DataType::Varchar, "body"),
+            Field::with_name(
+                DataType::List(ListType::new(DataType::Varchar)),
+                "noteContents",
+            ),
+            Field::with_name(DataType::Varchar, "communityMemberHandle"),
+            Field::with_name(DataType::Varchar, "communityMemberIdentifier"),
+            Field::with_name(DataType::Varchar, "inboxFeedItemTitle"),
+            Field::with_name(DataType::Boolean, "isInboxFeedItemStarred"),
+            Field::with_name(DataType::Boolean, "isInboxFeedItemAnswered"),
+            Field::with_name(DataType::Timestamp, "inboxFeedItemPreviewTimestamp"),
+            Field::with_name(DataType::Timestamp, "inboxFeedItemPublishTimestamp"),
+            Field::with_name(DataType::Int64, "inboxFeedItemAuthorInstagramFollowerCount"),
+            Field::with_name(DataType::Int64, "inboxFeedItemAuthorTikTokFollowerCount"),
+            Field::with_name(
+                DataType::List(ListType::new(DataType::Varchar)),
+                "attributes",
+            ),
+            Field::with_name(DataType::Varchar, "threadId"),
+            Field::with_name(DataType::Vector(384), "vector"),
+        ]);
+        let attribute_indices = (2..schema.len()).collect_vec();
+        let full_text_search_columns = parse_column_selection(
+            Some(
+                "body,noteContents,communityMemberHandle,communityMemberIdentifier,inboxFeedItemTitle",
+            ),
+            &schema,
+            &attribute_indices,
+        )
+        .unwrap();
+        let filterable_columns =
+            parse_column_selection(Some("*"), &schema, &attribute_indices).unwrap();
+        let generated_schema = build_turbopuffer_schema(
+            &schema,
+            &attribute_indices,
+            &full_text_search_columns,
+            &filterable_columns,
+        )
+        .unwrap();
+
+        assert_eq!(
+            generated_schema,
+            json!({
+                "inboxFeedItemId": {"type": "string", "filterable": true},
+                "body": {"type": "string", "filterable": true, "full_text_search": true},
+                "noteContents": {"type": "[]string", "filterable": true, "full_text_search": true},
+                "communityMemberHandle": {"type": "string", "filterable": true, "full_text_search": true},
+                "communityMemberIdentifier": {"type": "string", "filterable": true, "full_text_search": true},
+                "inboxFeedItemTitle": {"type": "string", "filterable": true, "full_text_search": true},
+                "isInboxFeedItemStarred": {"type": "bool", "filterable": true},
+                "isInboxFeedItemAnswered": {"type": "bool", "filterable": true},
+                "inboxFeedItemPreviewTimestamp": {"type": "datetime", "filterable": true},
+                "inboxFeedItemPublishTimestamp": {"type": "datetime", "filterable": true},
+                "inboxFeedItemAuthorInstagramFollowerCount": {"type": "int", "filterable": true},
+                "inboxFeedItemAuthorTikTokFollowerCount": {"type": "int", "filterable": true},
+                "attributes": {"type": "[]string", "filterable": true},
+                "threadId": {"type": "string", "filterable": true},
+                "vector": {"type": "[384]f32", "filterable": true, "ann": true}
+            })
+        );
+
+        let config = TurbopufferConfig {
+            base_url: "http://127.0.0.1:0".to_owned(),
+            namespace: None,
+            namespace_column: Some("workspaceId".to_owned()),
+            api_key: "tpuf_test_key".to_owned(),
+            distance_metric: Some("cosine_distance".to_owned()),
+            disable_backpressure: Some(true),
+            full_text_search_columns: Some("body,noteContents,communityMemberHandle,communityMemberIdentifier,inboxFeedItemTitle".to_owned()),
+            filterable_columns: Some("*".to_owned()),
+            r#type: "upsert".to_owned(),
+        };
+        let writer = TurbopufferSinkWriter::new(
+            config,
+            schema,
+            false,
+            0,
+            TurbopufferNamespace::Dynamic { index: 1 },
+            attribute_indices,
+            generated_schema.clone(),
+        )
+        .unwrap();
+        let vector =
+            VectorVal::from_text(&format!("[{}]", vec!["0.25"; 384].join(",")), 384).unwrap();
+        let row = OwnedRow::new(vec![
+            Some(ScalarImpl::Utf8("doc-1".into())),
+            Some(ScalarImpl::Utf8("workspace-1".into())),
+            Some(ScalarImpl::Utf8("item-1".into())),
+            Some(ScalarImpl::Utf8("body text".into())),
+            Some(ScalarImpl::List(ListValue::from_iter(["note a", "note b"]))),
+            Some(ScalarImpl::Utf8("@member".into())),
+            Some(ScalarImpl::Utf8("member-1".into())),
+            Some(ScalarImpl::Utf8("title".into())),
+            Some(ScalarImpl::Bool(true)),
+            Some(ScalarImpl::Bool(false)),
+            Some(ScalarImpl::Timestamp(Timestamp::from_timestamp_uncheck(
+                1_781_582_706,
+                0,
+            ))),
+            Some(ScalarImpl::Timestamp(Timestamp::from_timestamp_uncheck(
+                1_781_598_707,
+                0,
+            ))),
+            Some(ScalarImpl::Int64(12345)),
+            Some(ScalarImpl::Int64(67890)),
+            Some(ScalarImpl::List(ListValue::from_iter(["important", "vip"]))),
+            Some(ScalarImpl::Utf8("thread-1".into())),
+            Some(ScalarImpl::Vector(vector)),
+        ]);
+        let id = writer.id_for_row(&row).unwrap();
+        let upsert_row = writer.upsert_row(&row, id).unwrap();
+        let body = writer.request_body(vec![upsert_row], Vec::new());
+
+        assert_eq!(body["distance_metric"], json!("cosine_distance"));
+        assert_eq!(body["disable_backpressure"], json!(true));
+        assert_eq!(body["schema"], generated_schema);
+        assert_eq!(body["upsert_rows"][0]["id"], json!("doc-1"));
+        assert_eq!(body["upsert_rows"][0]["body"], json!("body text"));
+        assert_eq!(
+            body["upsert_rows"][0]["noteContents"],
+            json!(["note a", "note b"])
+        );
+        assert_eq!(
+            body["upsert_rows"][0]["isInboxFeedItemStarred"],
+            json!(true)
+        );
+        assert_eq!(
+            body["upsert_rows"][0]["isInboxFeedItemAnswered"],
+            json!(false)
+        );
+        assert_eq!(
+            body["upsert_rows"][0]["inboxFeedItemAuthorInstagramFollowerCount"],
+            json!(12345)
+        );
+        assert_eq!(
+            body["upsert_rows"][0]["inboxFeedItemPreviewTimestamp"],
+            json!("2026-06-16 04:05:06.000000")
+        );
+        assert_eq!(
+            body["upsert_rows"][0]["vector"].as_array().unwrap().len(),
+            384
+        );
+        assert_eq!(body["upsert_rows"][0]["vector"][0], json!(0.25));
     }
 
     fn spawn_mock_http_server() -> (String, mpsc::Receiver<String>, thread::JoinHandle<()>) {

--- a/src/connector/with_options_sink.yaml
+++ b/src/connector/with_options_sink.yaml
@@ -1809,6 +1809,35 @@ StarrocksConfig:
   - name: r#type
     field_type: String
     required: true
+TurbopufferConfig:
+  fields:
+  - name: base_url
+    field_type: String
+    required: true
+  - name: namespace
+    field_type: String
+    required: false
+  - name: namespace_column
+    field_type: String
+    required: false
+  - name: api_key
+    field_type: String
+    required: true
+  - name: distance_metric
+    field_type: String
+    required: false
+  - name: disable_backpressure
+    field_type: bool
+    required: false
+  - name: full_text_search_columns
+    field_type: String
+    required: false
+  - name: filterable_columns
+    field_type: String
+    required: false
+  - name: r#type
+    field_type: String
+    required: true
 WebhdfsConfig:
   fields:
   - name: webhdfs.endpoint


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

- Add a native `turbopuffer` sink connector that writes stream changes to turbopuffer namespace write APIs.
- Support either a static `namespace` or dynamic `namespace_column`, with `base_url`, `api_key`, `primary_key`, `distance_metric`, `disable_backpressure`, `filterable_columns`, and `full_text_search_columns` connector options.
- Batch rows at stream-chunk granularity by primary key, compacting multiple changes for the same document so upserts and deletes can be sent in the same turbopuffer request payload.
- Generate turbopuffer request schema from the RisingWave input schema, including filterable attributes, full-text search attributes, vector ANN metadata, and request-level distance metric/backpressure options.
- Add a turbopuffer-specific JSON encoder mode so request payload values match the generated turbopuffer schema. In particular, non-PK `serial` attributes are encoded as JSON integers and `decimal` attributes are encoded as JSON numbers through `f64`; non-finite decimals fail encoding because JSON numbers cannot represent `NaN` or infinities.
- Add sink e2e coverage with a mocked HTTP server/checker that verifies request path, authorization header, generated schema, batching, dynamic namespace routing, and mixed upsert/delete payloads. Unit tests also cover schema/payload shape for a manual HTTP-sink-equivalent schema with strings, `[]string`, booleans, timestamps, integers, and `[384]f32` vectors.

### User-facing changes

Users can create native turbopuffer sinks instead of manually building HTTP sink payloads. The connector exposes sink options for namespace routing, document primary keys, vector distance metric, backpressure, filterable attributes, and full-text-search attributes.

The connector automatically generates the turbopuffer `schema` object from the sink input schema and sends rows in turbopuffer's `upsert_rows` / `deletes` write format. Dynamic namespaces are formed from `namespace_column`; static namespaces use `namespace`.

### Data type mapping

| RisingWave data type | Turbopuffer schema type | JSON payload type / format |
|---|---|---|
| `boolean` | `bool` | JSON boolean |
| `smallint`, `integer`, `bigint` | `int` | JSON number |
| `serial` attribute | `int` | JSON number |
| `real`, `double precision` | `float` | JSON number |
| `decimal` | `float` | JSON number converted through `f64`; non-finite values fail encoding |
| `varchar` | `string` | JSON string |
| `date` | `datetime` | JSON string, `YYYY-MM-DD` |
| `timestamp` | `datetime` | JSON string, `YYYY-MM-DD HH:MM:SS.ffffff` |
| `boolean[]` | `[]bool` | JSON array of booleans |
| integer arrays | `[]int` | JSON array of numbers |
| `serial[]` | `[]int` | JSON array of numbers |
| float arrays | `[]float` | JSON array of numbers |
| `decimal[]` | `[]float` | JSON array of `f64`-converted numbers |
| `varchar[]` | `[]string` | JSON array of strings |
| `date[]`, `timestamp[]` | `[]datetime` | JSON array of datetime strings |
| `vector(N)` | `[N]f32` | JSON array of `N` numbers |

The primary key column is encoded separately as the turbopuffer document `id`, so it is not included as a schema attribute.

## Checklist

- [ ] I have written necessary rustdoc comments.
- [x] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [x] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [x] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

RisingWave now supports a native turbopuffer sink connector for writing stream changes to turbopuffer namespaces. Users can configure static or dynamic namespace routing, document primary keys, vector distance metric, generated filterable attributes, and full-text-search attributes through sink options.

The connector generates the turbopuffer schema from RisingWave column types and sends payload values that match that schema, including booleans, strings, string arrays, timestamps, integer attributes, decimal-as-float attributes, and vector columns.

</details>
