### PR TITLE
feat(frontend): track row-id-unfilled stream kind

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12369,7 +12369,6 @@ dependencies = [
  "sha2 0.10.9",
  "smallvec",
  "speedate",
- "static_assertions",
  "tempfile",
  "thiserror 2.0.17",
  "thiserror-ext",

--- a/src/frontend/Cargo.toml
+++ b/src/frontend/Cargo.toml
@@ -97,7 +97,6 @@ serde_yaml = "0.9"
 sha2 = "0.10.7"
 smallvec = { workspace = true, features = ["serde"] }
 speedate = "0.15.0"
-static_assertions = "1"
 tempfile = "3"
 thiserror = { workspace = true }
 thiserror-ext = { workspace = true }

--- a/src/frontend/src/catalog/source_catalog.rs
+++ b/src/frontend/src/catalog/source_catalog.rs
@@ -38,7 +38,6 @@ pub struct SourceCatalog {
     pub database_id: DatabaseId,
     pub columns: Vec<ColumnCatalog>,
     pub pk_col_ids: Vec<ColumnId>,
-    pub append_only: bool,
     pub owner: UserId,
     pub info: StreamSourceInfo,
     pub row_id_index: Option<usize>,
@@ -106,6 +105,10 @@ impl SourceCatalog {
         self.with_properties
             .get_connector()
             .expect("connector name is missing")
+    }
+
+    pub fn is_append_only(&self) -> bool {
+        self.row_id_index.is_some()
     }
 
     pub fn is_iceberg_connector(&self) -> bool {
@@ -184,7 +187,6 @@ impl From<&PbSource> for SourceCatalog {
         let columns = prost_columns.into_iter().map(ColumnCatalog::from).collect();
         let row_id_index = prost.row_id_index.map(|idx| idx as _);
 
-        let append_only = row_id_index.is_some();
         let owner = prost.owner;
         let watermark_descs = prost.get_watermark_descs().clone();
 
@@ -201,7 +203,6 @@ impl From<&PbSource> for SourceCatalog {
             database_id,
             columns,
             pk_col_ids,
-            append_only,
             owner,
             info: prost.info.clone().unwrap(),
             row_id_index,

--- a/src/frontend/src/catalog/system_catalog/rw_catalog/rw_sources.rs
+++ b/src/frontend/src/catalog/system_catalog/rw_catalog/rw_sources.rs
@@ -87,7 +87,7 @@ fn read_rw_sources_info(reader: &SysCatalogReaderImpl) -> Result<Vec<RwSource>> 
                         .get_row_encode()
                         .ok()
                         .map(|row_encode| row_encode.as_str_name().into()),
-                    append_only: source.append_only,
+                    append_only: source.is_append_only(),
                     associated_table_id: source.associated_table_id,
                     connection_id: source.connection_id,
                     definition: source.create_sql_purified(),

--- a/src/frontend/src/handler/create_source.rs
+++ b/src/frontend/src/handler/create_source.rs
@@ -1095,7 +1095,6 @@ HINT: use `CREATE TABLE <name> WITH (...)` instead of `CREATE TABLE <name> (<col
         database_id,
         columns,
         pk_col_ids,
-        append_only,
         owner: session.user_id(),
         info: source_info,
         row_id_index,

--- a/src/frontend/src/optimizer/mod.rs
+++ b/src/frontend/src/optimizer/mod.rs
@@ -836,7 +836,13 @@ impl LogicalPlanRoot {
             kind: PrimaryKeyKind,
             column_descs: Vec<ColumnDesc>,
         ) -> Result<StreamPlanRef> {
-            let mut dml_node = StreamDml::new(stream_plan, append_only, column_descs).into();
+            let mut dml_node = StreamDml::new(
+                stream_plan,
+                append_only,
+                kind != PrimaryKeyKind::UserDefinedPrimaryKey,
+                column_descs,
+            )
+            .into();
 
             // Add generated columns.
             dml_node = inject_project_for_generated_column_if_needed(columns, dml_node)?;

--- a/src/frontend/src/optimizer/plan_node/generic/source.rs
+++ b/src/frontend/src/optimizer/plan_node/generic/source.rs
@@ -118,9 +118,9 @@ impl GenericPlanNode for Source {
 
 impl Source {
     pub fn stream_kind(&self) -> StreamKind {
-        if let Some(catalog) = &self.catalog {
-            if catalog.append_only {
-                StreamKind::AppendOnly
+        if self.catalog.is_some() {
+            if self.row_id_index.is_some() {
+                StreamKind::RowIdNotFilled { append_only: true }
             } else {
                 // Always treat source as upsert, as we either don't parse the old record for `Update`, or we don't
                 // trust the old record from external source.

--- a/src/frontend/src/optimizer/plan_node/logical_project.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_project.rs
@@ -269,13 +269,15 @@ impl ToStream for LogicalProject {
                     .streaming_unsafe_allow_unmaterialized_impure_expr()
             });
         let should_materialize_expr = match new_input.stream_kind() {
-            StreamKind::AppendOnly => None,
-            StreamKind::Retract | StreamKind::Upsert if unsafe_allow_unmaterialized_impure_expr => {
+            StreamKind::AppendOnly | StreamKind::RowIdNotFilled { append_only: true } => None,
+            _ if unsafe_allow_unmaterialized_impure_expr => {
                 // This deliberately leaves impure expressions in `StreamProject` on retract/upsert
                 // streams. The behavior is unsafe and only enabled by the explicit session option.
                 None
             }
-            kind @ (StreamKind::Retract | StreamKind::Upsert) => {
+            kind @ (StreamKind::Retract
+            | StreamKind::Upsert
+            | StreamKind::RowIdNotFilled { append_only: false }) => {
                 // Extract impure functions to `MaterializedExprs` operator
                 let mut impure_field_names = BTreeMap::new();
                 let mut impure_expr_indices = HashSet::new();
@@ -298,12 +300,14 @@ impl ToStream for LogicalProject {
                     .collect();
                 if impure_exprs.is_empty() {
                     None
-                } else if kind == StreamKind::Upsert
-                    && new_input
-                        .stream_key()
-                        .into_iter()
-                        .flatten()
-                        .all(|stream_key_idx| !impure_expr_indices.contains(stream_key_idx))
+                } else if matches!(
+                    kind,
+                    StreamKind::Upsert | StreamKind::RowIdNotFilled { append_only: false }
+                ) && new_input
+                    .stream_key()
+                    .into_iter()
+                    .flatten()
+                    .all(|stream_key_idx| !impure_expr_indices.contains(stream_key_idx))
                 {
                     // We're operating on non-stream-key columns of upsert stream, no need to materialize.
                     None

--- a/src/frontend/src/optimizer/plan_node/logical_source.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_source.rs
@@ -113,9 +113,6 @@ impl LogicalSource {
     ) -> Result<Self> {
         let column_catalogs = source_catalog.columns.clone();
         let row_id_index = source_catalog.row_id_index;
-        if !source_catalog.append_only {
-            assert!(row_id_index.is_none());
-        }
 
         Self::new(
             Some(source_catalog),

--- a/src/frontend/src/optimizer/plan_node/stream_dml.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_dml.rs
@@ -28,25 +28,29 @@ pub struct StreamDml {
     pub base: PlanBase<Stream>,
     input: PlanRef,
     column_descs: Vec<ColumnDesc>,
+    append_only: bool,
+    row_id_as_pk: bool,
 }
 
 impl StreamDml {
     // `append_only` indicates whether only `INSERT` is allowed.
-    pub fn new(input: PlanRef, append_only: bool, column_descs: Vec<ColumnDesc>) -> Self {
+    pub fn new(
+        input: PlanRef,
+        append_only: bool,
+        row_id_as_pk: bool,
+        column_descs: Vec<ColumnDesc>,
+    ) -> Self {
         let base = PlanBase::new_stream(
             input.ctx(),
             input.schema().clone(),
             input.stream_key().map(|v| v.to_vec()),
             input.functional_dependency().clone(),
             input.distribution().clone(),
-            input.stream_kind().merge(if append_only {
-                // For append-only table. Either there will be a `RowIdGen` following the `Dml` and `Union`,
-                // or there will be a `Materialize` with conflict handling enabled. In both cases there
-                // will be no key conflict, so we can treat the merged stream as append-only here.
+            input.stream_kind().merge(if row_id_as_pk {
+                StreamKind::RowIdNotFilled { append_only }
+            } else if append_only {
                 StreamKind::AppendOnly
             } else {
-                // We cannot guarantee that there's no conflict on stream key between upstream
-                // source and DML input, so we must treat it as upsert here.
                 StreamKind::Upsert
             }),
             false,                   // TODO(rc): decide EOWC property
@@ -58,6 +62,8 @@ impl StreamDml {
             base,
             input,
             column_descs,
+            append_only,
+            row_id_as_pk,
         }
     }
 
@@ -87,7 +93,12 @@ impl PlanTreeNodeUnary<Stream> for StreamDml {
     }
 
     fn clone_with_input(&self, input: PlanRef) -> Self {
-        Self::new(input, self.append_only(), self.column_descs.clone())
+        Self::new(
+            input,
+            self.append_only,
+            self.row_id_as_pk,
+            self.column_descs.clone(),
+        )
     }
 }
 

--- a/src/frontend/src/optimizer/plan_node/stream_dml.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_dml.rs
@@ -47,10 +47,19 @@ impl StreamDml {
             input.functional_dependency().clone(),
             input.distribution().clone(),
             input.stream_kind().merge(if row_id_as_pk {
+                // For row-id table. There will be a `RowIdGen` following the `Dml` and `Union`.
+                // Until then the row-id key is not filled, so track the stream with the
+                // frontend-only kind.
                 StreamKind::RowIdNotFilled { append_only }
             } else if append_only {
+                // For append-only table. Either there will be a `RowIdGen` following the `Dml` and
+                // `Union`, or there will be a `Materialize` with conflict handling enabled. In
+                // both cases there will be no key conflict, so we can treat the merged stream as
+                // append-only here.
                 StreamKind::AppendOnly
             } else {
+                // We cannot guarantee that there's no conflict on stream key between upstream
+                // source and DML input, so we must treat it as upsert here.
                 StreamKind::Upsert
             }),
             false,                   // TODO(rc): decide EOWC property

--- a/src/frontend/src/optimizer/plan_node/stream_dynamic_filter.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_dynamic_filter.rs
@@ -52,7 +52,7 @@ impl StreamDynamicFilter {
         let out_kind = match left_kind {
             StreamKind::AppendOnly if condition_always_relax => StreamKind::AppendOnly,
             StreamKind::AppendOnly | StreamKind::Retract => StreamKind::Retract,
-            StreamKind::Upsert => unreachable!(),
+            StreamKind::Upsert | StreamKind::RowIdNotFilled { .. } => unreachable!(),
         };
 
         let base = PlanBase::new_stream_with_core(

--- a/src/frontend/src/optimizer/plan_node/stream_materialize.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_materialize.rs
@@ -82,6 +82,12 @@ impl StreamMaterialize {
             | ConflictBehavior::DoUpdateIfNotNull => match input.stream_kind() {
                 StreamKind::AppendOnly => StreamKind::AppendOnly,
                 StreamKind::Retract | StreamKind::Upsert => StreamKind::Retract,
+                StreamKind::RowIdNotFilled { .. } => {
+                    risingwave_common::bail!(
+                        "{} stream is not supported as input of Materialize with conflict handling",
+                        input.stream_kind()
+                    )
+                }
             },
         };
         let base = PlanBase::new_stream(
@@ -144,6 +150,12 @@ impl StreamMaterialize {
         let conflict_behavior = match input.stream_kind() {
             StreamKind::Retract | StreamKind::AppendOnly => ConflictBehavior::NoCheck,
             StreamKind::Upsert => ConflictBehavior::Overwrite,
+            StreamKind::RowIdNotFilled { .. } => {
+                risingwave_common::bail!(
+                    "{} stream is not supported as input of Materialize",
+                    input.stream_kind()
+                )
+            }
         };
 
         let table = Self::derive_table_catalog(

--- a/src/frontend/src/optimizer/plan_node/stream_row_id_gen.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_row_id_gen.rs
@@ -41,13 +41,18 @@ impl StreamRowIdGen {
         row_id_index: usize,
         distribution: Distribution,
     ) -> StreamRowIdGen {
+        let stream_kind = match input.stream_kind() {
+            StreamKind::RowIdNotFilled { append_only: true } => StreamKind::AppendOnly,
+            StreamKind::RowIdNotFilled { append_only: false } => StreamKind::Upsert,
+            kind => kind,
+        };
         let base = PlanBase::new_stream(
             input.ctx(),
             input.schema().clone(),
             input.stream_key().map(|v| v.to_vec()),
             input.functional_dependency().clone(),
             distribution,
-            input.stream_kind(),
+            stream_kind,
             input.emit_on_window_close(),
             input.watermark_columns().clone(),
             input.columns_monotonicity().clone(),

--- a/src/frontend/src/optimizer/plan_node/stream_sink.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_sink.rs
@@ -781,10 +781,14 @@ impl StreamSink {
                              Please use `type = 'append-only'` or `type = 'upsert'` instead.",
                         );
                     }
-                    if derived_stream_kind == StreamKind::Upsert {
+                    if matches!(
+                        derived_stream_kind,
+                        StreamKind::Upsert | StreamKind::RowIdNotFilled { .. }
+                    ) {
                         bail_invalid_input_syntax!(
-                            "The sink of upsert stream cannot be retract. \
+                            "The sink of {} stream cannot be retract. \
                              Please create a materialized view or sink-into-table with this query before sinking it.",
+                            derived_stream_kind,
                         );
                     }
                 }
@@ -798,6 +802,12 @@ impl StreamSink {
                 // as it is well supported by most sinks and reduces the amount of data written.
                 StreamKind::Retract | StreamKind::Upsert => SinkType::Upsert,
                 StreamKind::AppendOnly => SinkType::AppendOnly,
+                StreamKind::RowIdNotFilled { .. } => {
+                    bail_invalid_input_syntax!(
+                        "The sink of {} stream is not supported before row id is filled.",
+                        derived_stream_kind,
+                    );
+                }
             };
             Ok((sink_type, user_ignore_delete))
         }

--- a/src/frontend/src/optimizer/plan_node/stream_union.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_union.rs
@@ -83,6 +83,15 @@ impl StreamUnion {
             if inputs.len() == 1 {
                 // Single input. Follow the input's kind.
                 inputs[0].stream_kind()
+            } else if inputs
+                .iter()
+                .any(|x| x.stream_kind().is_row_id_not_filled())
+            {
+                StreamKind::RowIdNotFilled {
+                    append_only: inputs
+                        .iter()
+                        .all(|x| x.stream_kind().is_semantic_append_only()),
+                }
             } else if inputs.iter().all(|x| x.stream_kind().is_append_only()) {
                 // Special case for append-only table. Either there will be a `RowIdGen` following the `Union`,
                 // or there will be a `Materialize` with conflict handling enabled. In both cases there

--- a/src/frontend/src/optimizer/plan_node/stream_upstream_sink_union.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_upstream_sink_union.rs
@@ -63,7 +63,9 @@ impl StreamUpstreamSinkUnion {
     ) -> Self {
         // For upstream sink creating, we require that if the table doesn't define pk or the table is `append_only`, the
         // upstream sink must be `append_only`.
-        let stream_kind = if append_only || !user_defined_pk {
+        let stream_kind = if !user_defined_pk {
+            StreamKind::RowIdNotFilled { append_only: true }
+        } else if append_only {
             StreamKind::AppendOnly
         } else {
             StreamKind::Upsert

--- a/src/frontend/src/optimizer/plan_node/stream_watermark_filter.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_watermark_filter.rs
@@ -37,6 +37,15 @@ pub struct StreamWatermarkFilter {
 
 impl StreamWatermarkFilter {
     pub fn new(input: PlanRef, watermark_descs: Vec<WatermarkDesc>) -> Self {
+        // `RowIdNotFilled` must be resolved by `StreamRowIdGen` before watermark filtering.
+        // Current callers are table planning and source scan planning; both should insert
+        // `StreamRowIdGen` first whenever the input has a hidden row id.
+        assert!(
+            !input.stream_kind().is_row_id_not_filled(),
+            "StreamWatermarkFilter does not support input with unfilled row id, got {}",
+            input.stream_kind()
+        );
+
         if watermark_descs.iter().any(|d| !d.with_ttl) {
             assert!(
                 input.append_only(),

--- a/src/frontend/src/optimizer/property/stream_kind.rs
+++ b/src/frontend/src/optimizer/property/stream_kind.rs
@@ -15,7 +15,6 @@
 use std::fmt::Display;
 
 use risingwave_pb::stream_plan::stream_node::PbStreamKind;
-use static_assertions::const_assert_eq;
 
 /// The kind of the changelog stream output by a stream operator.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -38,6 +37,16 @@ pub enum StreamKind {
     /// Stateful operators typically can not process such streams correctly. It must be converted
     /// to `Retract` before being sent to stateful operators in this case.
     Upsert,
+
+    /// The stream carries a hidden `_row_id` column, but the column has not been filled yet.
+    ///
+    /// This is a frontend-only intermediate state before `StreamRowIdGen`. When the stream is
+    /// serialized to protobuf before row id generation, it is represented by its semantic
+    /// append-only property. If `append_only` is true, all visible operations must be insert-like
+    /// operations (`Insert` or `UpdateInsert`) and some `_row_id` values may still be unfilled, but
+    /// they must be unique after being filled later. If it is false, the stream should be treated
+    /// like an upsert stream until row id is filled.
+    RowIdNotFilled { append_only: bool },
 }
 
 impl Display for StreamKind {
@@ -49,19 +58,14 @@ impl Display for StreamKind {
                 Self::Retract => "retract",
                 Self::AppendOnly => "append-only",
                 Self::Upsert => "upsert",
+                Self::RowIdNotFilled { append_only: true } => {
+                    "row-id-not-filled-append-only"
+                }
+                Self::RowIdNotFilled { append_only: false } => "row-id-not-filled-upsert",
             }
         )
     }
 }
-
-// Although there's a `to_protobuf` method, we have no way to avoid calling `as i32` to fit
-// `StreamKind` to the protobuf enum. We ensure their values are the same here for safety.
-const_assert_eq!(StreamKind::Retract as i32, PbStreamKind::Retract as i32);
-const_assert_eq!(
-    StreamKind::AppendOnly as i32,
-    PbStreamKind::AppendOnly as i32
-);
-const_assert_eq!(StreamKind::Upsert as i32, PbStreamKind::Upsert as i32);
 
 impl StreamKind {
     /// Returns `true` if it's [`StreamKind::Retract`].
@@ -79,19 +83,45 @@ impl StreamKind {
         matches!(self, Self::Upsert)
     }
 
+    /// Returns `true` if it's [`StreamKind::RowIdNotFilled`].
+    pub fn is_row_id_not_filled(self) -> bool {
+        matches!(self, Self::RowIdNotFilled { .. })
+    }
+
+    /// Returns whether the stream is semantically append-only.
+    ///
+    /// This differs from [`Self::is_append_only`] for `RowIdNotFilled`, which is still an
+    /// unresolved frontend-only stream kind and should not be accepted by stateful operators.
+    pub fn is_semantic_append_only(self) -> bool {
+        match self {
+            Self::AppendOnly => true,
+            Self::RowIdNotFilled { append_only } => append_only,
+            Self::Retract | Self::Upsert => false,
+        }
+    }
+
     /// Returns the stream kind representing the merge (union) of the two.
     ///
     /// Note that there should be no conflict on the stream key between the two streams,
     /// otherwise it will result in an "inconsistent" stream.
     pub fn merge(self, other: Self) -> Self {
-        let any = |kind| self == kind || other == kind;
-
-        if any(Self::Upsert) {
-            Self::Upsert
-        } else if any(Self::Retract) {
-            Self::Retract
-        } else {
-            Self::AppendOnly
+        match (self, other) {
+            (
+                Self::RowIdNotFilled { append_only: left },
+                Self::RowIdNotFilled { append_only: right },
+            ) => Self::RowIdNotFilled {
+                append_only: left && right,
+            },
+            (Self::RowIdNotFilled { append_only }, Self::AppendOnly)
+            | (Self::AppendOnly, Self::RowIdNotFilled { append_only }) => {
+                Self::RowIdNotFilled { append_only }
+            }
+            (Self::RowIdNotFilled { .. }, _) | (_, Self::RowIdNotFilled { .. }) => {
+                Self::RowIdNotFilled { append_only: false }
+            }
+            (Self::Upsert, _) | (_, Self::Upsert) => Self::Upsert,
+            (Self::Retract, _) | (_, Self::Retract) => Self::Retract,
+            (Self::AppendOnly, Self::AppendOnly) => Self::AppendOnly,
         }
     }
 
@@ -101,6 +131,8 @@ impl StreamKind {
             Self::Retract => PbStreamKind::Retract,
             Self::AppendOnly => PbStreamKind::AppendOnly,
             Self::Upsert => PbStreamKind::Upsert,
+            Self::RowIdNotFilled { append_only: true } => PbStreamKind::AppendOnly,
+            Self::RowIdNotFilled { append_only: false } => PbStreamKind::Upsert,
         }
     }
 }
@@ -119,9 +151,10 @@ macro_rules! reject_upsert_input {
         use crate::optimizer::property::StreamKind;
 
         let kind = $input.stream_kind();
-        if let StreamKind::Upsert = kind {
+        if matches!(kind, StreamKind::Upsert | StreamKind::RowIdNotFilled { .. }) {
             risingwave_common::bail!(
-                "upsert stream is not supported as input of {}, plan:\n{}",
+                "{} stream is not supported as input of {}, plan:\n{}",
+                kind,
                 $curr,
                 $input.explain_to_string()
             );
@@ -130,3 +163,43 @@ macro_rules! reject_upsert_input {
     }};
 }
 pub(crate) use reject_upsert_input;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_to_protobuf() {
+        assert_eq!(StreamKind::Retract.to_protobuf(), PbStreamKind::Retract);
+        assert_eq!(
+            StreamKind::AppendOnly.to_protobuf(),
+            PbStreamKind::AppendOnly
+        );
+        assert_eq!(StreamKind::Upsert.to_protobuf(), PbStreamKind::Upsert);
+        assert_eq!(
+            StreamKind::RowIdNotFilled { append_only: true }.to_protobuf(),
+            PbStreamKind::AppendOnly
+        );
+        assert_eq!(
+            StreamKind::RowIdNotFilled { append_only: false }.to_protobuf(),
+            PbStreamKind::Upsert
+        );
+    }
+
+    #[test]
+    fn test_merge_row_id_not_filled() {
+        assert_eq!(
+            StreamKind::RowIdNotFilled { append_only: true }.merge(StreamKind::AppendOnly),
+            StreamKind::RowIdNotFilled { append_only: true }
+        );
+        assert_eq!(
+            StreamKind::RowIdNotFilled { append_only: true }.merge(StreamKind::Upsert),
+            StreamKind::RowIdNotFilled { append_only: false }
+        );
+        assert_eq!(
+            StreamKind::RowIdNotFilled { append_only: false }
+                .merge(StreamKind::RowIdNotFilled { append_only: true }),
+            StreamKind::RowIdNotFilled { append_only: false }
+        );
+    }
+}


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

This PR introduces a frontend-only `StreamKind::RowIdNotFilled { append_only }` for planner streams that already carry a hidden `_row_id` column but have not passed through `StreamRowIdGen` yet.

The temporary kind is preserved only across the required intermediate stream nodes before row-id generation, and is rejected by stateful operators that cannot safely consume unresolved row ids. `StreamRowIdGen` resolves it to `AppendOnly` or `Upsert` based on the semantic append-only flag. Serialization to protobuf still uses the existing `PbStreamKind` values, so no executor or protobuf enum changes are needed.

This also removes the redundant stored `SourceCatalog::append_only` field. Source append-only-ness is derived from `row_id_index.is_some()` through `SourceCatalog::is_append_only()`.

## Checklist

- [x] I have written necessary rustdoc comments.
- [x] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

No user-facing behavior change.

</details>
