### PR TITLE
fix(cdc): avoid panic when schema change oneshot receiver is dropped during topology change

### DIFF
--- a/src/stream/src/executor/source/reader_stream.rs
+++ b/src/stream/src/executor/source/reader_stream.rs
@@ -120,14 +120,14 @@ impl StreamReaderBuilder {
                                 tracing::info!(
                                     target: "auto_schema_change",
                                     "schema change success for tables: {:?}", table_ids);
-                                finish_tx.send(()).unwrap();
+                                let _ = finish_tx.send(());
                             }
                             Err(e) => {
                                 tracing::error!(
                                     target: "auto_schema_change",
                                     error = %e.as_report(), "schema change error");
 
-                                finish_tx.send(()).unwrap();
+                                let _ = finish_tx.send(());
                             }
                         }
                     }


### PR DESCRIPTION
## What

In `StreamReaderBuilder::setup_auto_schema_change`, the spawned task that handles CDC schema change events called `finish_tx.send(()).unwrap()` after the `auto_schema_change` RPC returned. This panics when the receiver has already been dropped — which happens during a topology change (e.g., peer compute node OOM-killed) that tears down the actor mid-flight.

The panic was reported in https://github.com/risingwavelabs/risingwave/issues/25976: a surviving compute node crashed because of this `.unwrap()` while processing a partial graph reset, compounding a single OOM-kill into a two-node outage.

## Fix

Replace `finish_tx.send(()).unwrap()` with `let _ = finish_tx.send(())` in both the `Ok` and `Err` branches. When the receiver is dropped the actor is already shutting down; ignoring the send failure is the correct behavior. The `auto_schema_change` RPC itself completes before the send, so no schema change result is lost.