### PR TITLE
chore(test): drop leftover UDT in pg cdc schema check test

### DIFF
--- a/e2e_test/source_inline/cdc/postgres/postgres_schema_check_and_schema_change.slt
+++ b/e2e_test/source_inline/cdc/postgres/postgres_schema_check_and_schema_change.slt
@@ -4,6 +4,7 @@ system ok
 psql -c "
     DROP TABLE IF EXISTS t;
     CREATE EXTENSION IF NOT EXISTS citext;
+    DROP TYPE IF EXISTS mood_enum;
     CREATE TYPE mood_enum AS ENUM ('happy', 'sad', 'angry');
     CREATE TABLE t (
         v1 bigserial PRIMARY KEY,


### PR DESCRIPTION
## What's changed

`e2e_test/source_inline/cdc/postgres/postgres_schema_check_and_schema_change.slt` has been flaky in CI, failing on setup with:

```
ERROR:  type "mood_enum" already exists
```

The setup block runs `DROP TABLE IF EXISTS t` and then `CREATE TYPE mood_enum AS ENUM (...)`, but it never drops the type up front. The type is only cleaned up in the trailing cleanup block at the end of the file. If a previous run fails or crashes before reaching that cleanup, `mood_enum` lingers in the upstream Postgres and the next run's `CREATE TYPE` aborts the whole setup statement.

This adds `DROP TYPE IF EXISTS mood_enum;` right before the `CREATE TYPE`, so the setup is self-healing regardless of prior-run state — same clean-slate pattern already used by `postgres_corner_schema_change.slt`.

## Checks
- Other CDC/sink tests creating enums were audited: `postgres_corner_schema_change.slt` already drops first; `postgres_sink.slt` and `postgres_cdc.sql` run against freshly created databases, so no change needed.