### PR TITLE
fix(meta): reject unsafe compaction group merges

### DIFF
--- a/src/meta/src/hummock/manager/compaction/compaction_group_schedule.rs
+++ b/src/meta/src/hummock/manager/compaction/compaction_group_schedule.rs
@@ -1663,7 +1663,7 @@ impl GroupMergeValidator {
             // check whether the group is in the write stop state after merge
             let l0_sub_level_count_after_merge =
                 group_levels.l0.sub_levels.len() + next_group_levels.l0.sub_levels.len();
-            if GroupStateValidator::write_stop_l0_file_count(
+            if GroupStateValidator::write_stop_sub_level_count(
                 (l0_sub_level_count_after_merge as f64
                     * opts.compaction_group_merge_dimension_threshold) as usize,
                 group.compaction_group_config.compaction_config().deref(),
@@ -1674,8 +1674,13 @@ impl GroupMergeValidator {
                 )));
             }
 
-            let l0_file_count_after_merge =
-                group_levels.l0.sub_levels.len() + next_group_levels.l0.sub_levels.len();
+            let l0_file_count_after_merge = group_levels
+                .l0
+                .sub_levels
+                .iter()
+                .chain(next_group_levels.l0.sub_levels.iter())
+                .map(|level| level.table_infos.len())
+                .sum::<usize>();
             if GroupStateValidator::write_stop_l0_file_count(
                 (l0_file_count_after_merge as f64 * opts.compaction_group_merge_dimension_threshold)
                     as usize,
@@ -1703,8 +1708,8 @@ impl GroupMergeValidator {
 
             // check whether the group is in the emergency state after merge
             if GroupStateValidator::emergency_l0_file_count(
-                (l0_sub_level_count_after_merge as f64
-                    * opts.compaction_group_merge_dimension_threshold) as usize,
+                (l0_file_count_after_merge as f64 * opts.compaction_group_merge_dimension_threshold)
+                    as usize,
                 group.compaction_group_config.compaction_config().deref(),
             ) {
                 return Err(Error::CompactionGroup(format!(

--- a/src/meta/src/hummock/manager/tests.rs
+++ b/src/meta/src/hummock/manager/tests.rs
@@ -3123,50 +3123,66 @@ async fn test_old_version_dropped_table_sst_does_not_make_new_compaction_fail() 
 /// the same unmergeable pair infinitely (167K+ error log spam).
 #[tokio::test]
 async fn test_try_merge_compaction_group_error_propagation() {
-    let (_env, hummock_manager, _, worker_id) = setup_compute_env(80).await;
+    let config = CompactionConfigBuilder::new()
+        .level0_tier_compact_file_number(1)
+        .level0_max_compact_file_number(130)
+        .level0_sub_level_compact_level_count(1)
+        .level0_overlapping_sub_level_compact_level_count(1)
+        .level0_stop_write_threshold_sub_level_number(10)
+        .level0_stop_write_threshold_max_sst_count(Some(6))
+        .emergency_level0_sst_file_count(Some(100))
+        .build();
+    let (_env, hummock_manager, _, worker_id) = setup_compute_env_with_config(80, config).await;
     let hummock_meta_client: Arc<dyn HummockMetaClient> = Arc::new(MockHummockMetaClient::new(
         hummock_manager.clone(),
         worker_id as _,
     ));
 
-    // StateDefault(2): [100, 102], MaterializedView(3): [101, 200]
+    // StateDefault(2): [200, 202], MaterializedView(3): [100, 201]
     hummock_manager
-        .register_table_ids_for_test(&[(100, 2.into()), (102, 2.into())])
+        .register_table_ids_for_test(&[(200, 2.into()), (202, 2.into())])
         .await
         .unwrap();
     hummock_manager
-        .register_table_ids_for_test(&[(101, 3.into()), (200, 3.into())])
+        .register_table_ids_for_test(&[(100, 3.into()), (201, 3.into())])
         .await
         .unwrap();
 
     // Commit SSTs so that split can proceed
-    let sst_1 = gen_local_sstable_info(1, vec![100, 102], test_epoch(20));
-    let sst_2 = gen_local_sstable_info(2, vec![101, 200], test_epoch(20));
+    let epoch = test_epoch(20);
     hummock_meta_client
         .commit_epoch(
-            30,
+            epoch,
             SyncResult {
-                uncommitted_ssts: vec![sst_1, sst_2],
+                uncommitted_ssts: vec![
+                    gen_local_sstable_info(1, vec![200, 202], epoch),
+                    gen_local_sstable_info(2, vec![100, 201], epoch),
+                    gen_local_sstable_info(3, vec![100, 201], epoch),
+                    gen_local_sstable_info(4, vec![100, 201], epoch),
+                    gen_local_sstable_info(5, vec![100, 201], epoch),
+                ],
                 ..Default::default()
             },
         )
         .await
         .unwrap();
 
-    // Split table 101 out of MV(3) → Group_X = [101].
-    // Now StateDefault(2)=[100,102] and Group_X=[101] have overlapping table ID ranges.
+    // Split table 201 out of MV(3) → Group_X = [201].
+    // Now StateDefault(2)=[200,202] and Group_X=[201] have overlapping table ID ranges.
     hummock_manager
         .move_state_tables_to_dedicated_compaction_group(
             StaticCompactionGroupId::MaterializedView,
-            &[101.into()],
+            &[201.into()],
             None,
         )
         .await
         .unwrap();
 
     let state_default_id: CompactionGroupId = StaticCompactionGroupId::StateDefault;
-    let group_x_id = get_compaction_group_id_by_table_id(hummock_manager.clone(), 101).await;
+    let mv_id: CompactionGroupId = StaticCompactionGroupId::MaterializedView;
+    let group_x_id = get_compaction_group_id_by_table_id(hummock_manager.clone(), 201).await;
     assert_ne!(state_default_id, group_x_id);
+    assert_ne!(mv_id, group_x_id);
 
     let group_infos = hummock_manager.calculate_compaction_group_statistic().await;
     let sd_stat = group_infos
@@ -3177,10 +3193,26 @@ async fn test_try_merge_compaction_group_error_propagation() {
         .iter()
         .find(|g| g.group_id == group_x_id)
         .unwrap();
+    let mv_stat = group_infos.iter().find(|g| g.group_id == mv_id).unwrap();
 
     let throughput_manager = TableWriteThroughputStatisticManager::new(100);
     let created_tables: HashSet<TableId> =
-        HashSet::from_iter(vec![100.into(), 101.into(), 102.into(), 200.into()]);
+        HashSet::from_iter(vec![100.into(), 200.into(), 201.into(), 202.into()]);
+
+    // Group_X and MaterializedView are each below the L0 SST count write-stop threshold, but the
+    // merged group should be rejected by the post-merge L0 SST count check.
+    let result = hummock_manager
+        .try_merge_compaction_group(&throughput_manager, gx_stat, mv_stat, &created_tables)
+        .await;
+    let err =
+        result.expect_err("try_merge_compaction_group must reject merged L0 SST count write stop");
+    assert!(
+        err.as_report()
+            .to_string()
+            .contains("will trigger write stop after merge"),
+        "unexpected merge rejection: {}",
+        err.as_report()
+    );
 
     // Must return Err for overlapping groups — guards against the swallowed-error regression.
     let result = hummock_manager


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

This PR fixes compaction group merge validation so that a merge is rejected when the merged group would enter write-stop or emergency state due to L0 pressure.

The previous post-merge checks mixed up L0 sub-level count and L0 SST count:

- the merged sub-level count was checked with `write_stop_l0_file_count` instead of `write_stop_sub_level_count`
- the merged L0 SST count was computed from `sub_levels.len()` instead of summing `table_infos.len()`
- the emergency L0 SST count check also used the merged sub-level count

The fix keeps the existing inline validation structure and only corrects those dimensions. The existing `test_try_merge_compaction_group_error_propagation` now also covers the case where both groups are individually below the L0 SST count threshold, but their merged L0 SST count should be rejected.

No related issue.

## Checklist

- [ ] I have written necessary rustdoc comments.
- [x] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [x] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

</details>

## Tests

- `cargo test -p risingwave_meta test_try_merge_compaction_group_error_propagation -- --nocapture`
- `cargo clippy --workspace --all-targets -- -D warnings 2>&1`
