### PR TITLE
feat(cdc): support timestamp.handling.mode and timestamptz.handling.mode

### DIFF
--- a/src/connector/src/parser/unified/json.rs
+++ b/src/connector/src/parser/unified/json.rs
@@ -110,7 +110,10 @@ pub enum TimestamptzHandling {
     Milli,
     /// `1712800800123456`
     Micro,
-    /// Both `1712800800123` (ms) and `1712800800123456` (us) maps to `2024-04-11`.
+    /// `1712800800123456789`
+    Nano,
+    /// `1712800800` (s), `1712800800123` (ms), `1712800800123456` (us), and
+    /// `1712800800123456789` (ns) all map to the same UTC instant.
     ///
     /// Only works for `[1973-03-03 09:46:40, 5138-11-16 09:46:40)`.
     ///
@@ -127,6 +130,7 @@ impl TimestamptzHandling {
             "utc_without_suffix" => Self::UtcWithoutSuffix,
             "micro" => Self::Micro,
             "milli" => Self::Milli,
+            "nano" => Self::Nano,
             "guess_number_unit" => Self::GuessNumberUnit,
             v => bail_invalid_option_error!("unrecognized {} value {}", Self::OPTION_KEY, v),
         };
@@ -136,8 +140,25 @@ impl TimestamptzHandling {
 
 #[derive(Clone, Debug)]
 pub enum TimestampHandling {
+    Micro,
     Milli,
+    Nano,
     GuessNumberUnit,
+}
+
+impl TimestampHandling {
+    pub const OPTION_KEY: &'static str = "timestamp.handling.mode";
+
+    pub fn from_options(value: &str) -> Result<Self, InvalidOptionError> {
+        let mode = match value {
+            "micro" => Self::Micro,
+            "milli" => Self::Milli,
+            "nano" => Self::Nano,
+            "guess_number_unit" => Self::GuessNumberUnit,
+            v => bail_invalid_option_error!("unrecognized {} value {}", Self::OPTION_KEY, v),
+        };
+        Ok(mode)
+    }
 }
 
 #[derive(Clone, Debug)]
@@ -571,18 +592,24 @@ impl JsonParseOptions {
             (
                 DataType::Timestamp,
                 ValueType::I64 | ValueType::I128 | ValueType::U64 | ValueType::U128,
-            ) => {
-                match self.timestamp_handling {
-                    // Only when user configures debezium.time.precision.mode = 'connect',
-                    // the Milli branch will be executed
-                    TimestampHandling::Milli => Timestamp::with_millis(value.as_i64().unwrap())
-                        .map_err(|_| create_error())?
-                        .into(),
-                    TimestampHandling::GuessNumberUnit => i64_to_timestamp(value.as_i64().unwrap())
-                        .map_err(|_| create_error())?
-                        .into(),
-                }
-            }
+            ) => value
+                .as_i64()
+                .map(|num| match self.timestamp_handling {
+                    TimestampHandling::Micro => {
+                        Timestamp::with_micros(num).map_err(|_| create_error())
+                    }
+                    TimestampHandling::Milli => {
+                        Timestamp::with_millis(num).map_err(|_| create_error())
+                    }
+                    TimestampHandling::Nano => {
+                        Timestamp::with_micros(num / 1_000).map_err(|_| create_error())
+                    }
+                    TimestampHandling::GuessNumberUnit => {
+                        i64_to_timestamp(num).map_err(|_| create_error())
+                    }
+                })
+                .ok_or_else(create_error)??
+                .into(),
             // ---- Timestamptz -----
             (DataType::Timestamptz, ValueType::String) => match self.timestamptz_handling {
                 TimestamptzHandling::UtcWithoutSuffix => value
@@ -611,6 +638,7 @@ impl JsonParseOptions {
                     TimestamptzHandling::GuessNumberUnit => i64_to_timestamptz(num).ok(),
                     TimestamptzHandling::Micro => Some(Timestamptz::from_micros(num)),
                     TimestamptzHandling::Milli => Timestamptz::from_millis(num),
+                    TimestamptzHandling::Nano => Timestamptz::from_nanos(num),
                     // When explicitly requested string format, number without units are rejected.
                     TimestamptzHandling::UtcString | TimestamptzHandling::UtcWithoutSuffix => None,
                 })
@@ -891,4 +919,41 @@ fn json_object_get_case_insensitive<'b>(
         }
     }
     None
+}
+
+#[cfg(test)]
+mod tests {
+    use risingwave_common::types::ScalarImpl;
+
+    use super::*;
+
+    fn parse_timestamptz_number(value: &str, handling: TimestamptzHandling) -> Timestamptz {
+        let mut bytes = value.as_bytes().to_vec();
+        let value = simd_json::to_borrowed_value(&mut bytes[..]).unwrap();
+        let options = JsonParseOptions {
+            timestamptz_handling: handling,
+            ..Default::default()
+        };
+        let datum = options.parse(&value, &DataType::Timestamptz).unwrap();
+        match datum.to_owned_datum().unwrap() {
+            ScalarImpl::Timestamptz(timestamptz) => timestamptz,
+            other => panic!("expected timestamptz, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_timestamptz_handling_accepts_nano_option() {
+        assert!(matches!(
+            TimestamptzHandling::from_options("nano").unwrap(),
+            TimestamptzHandling::Nano
+        ));
+    }
+
+    #[test]
+    fn test_parse_timestamptz_nano_number() {
+        assert_eq!(
+            parse_timestamptz_number("1712800800123456789", TimestamptzHandling::Nano),
+            Timestamptz::from_nanos(1_712_800_800_123_456_789).unwrap()
+        );
+    }
 }

--- a/src/frontend/src/webhook/payload.rs
+++ b/src/frontend/src/webhook/payload.rs
@@ -239,12 +239,12 @@ mod tests {
         let mut headers = HeaderMap::new();
         headers.insert(
             WEBHOOK_JSON_TIMESTAMPTZ_HANDLING_HEADER,
-            HeaderValue::from_static("milli"),
+            HeaderValue::from_static("nano"),
         );
         let config = json_properties_from_headers(&headers).unwrap();
         assert!(matches!(
             config.timestamptz_handling,
-            Some(TimestamptzHandling::Milli)
+            Some(TimestamptzHandling::Nano)
         ));
     }
 

--- a/src/stream/src/executor/backfill/cdc/cdc_backfill.rs
+++ b/src/stream/src/executor/backfill/cdc/cdc_backfill.rs
@@ -55,6 +55,50 @@ use crate::task::CreateMviewProgressReporter;
 /// `split_id`, `is_finished`, `row_count`, `cdc_offset` all occupy 1 column each.
 const METADATA_STATE_LEN: usize = 4;
 
+pub(crate) fn get_cdc_json_parse_handling_from_properties(
+    properties: &BTreeMap<String, String>,
+) -> (
+    Option<TimestampHandling>,
+    Option<TimestamptzHandling>,
+    Option<TimeHandling>,
+    Option<BigintUnsignedHandlingMode>,
+) {
+    let use_connect_time_precision = properties
+        .get("debezium.time.precision.mode")
+        .is_some_and(|v| v == "connect");
+
+    let timestamp_handling = if use_connect_time_precision {
+        Some(TimestampHandling::Milli)
+    } else {
+        properties
+            .get(TimestampHandling::OPTION_KEY)
+            .map(|v| TimestampHandling::from_options(v))
+            .transpose()
+            .expect("timestamp.handling.mode should have been validated during source creation")
+    };
+    let timestamptz_handling = if use_connect_time_precision {
+        Some(TimestamptzHandling::Milli)
+    } else {
+        properties
+            .get(TimestamptzHandling::OPTION_KEY)
+            .map(|v| TimestamptzHandling::from_options(v))
+            .transpose()
+            .expect("timestamptz.handling.mode should have been validated during source creation")
+    };
+    let time_handling = use_connect_time_precision.then_some(TimeHandling::Milli);
+    let bigint_unsigned_handling = properties
+        .get("debezium.bigint.unsigned.handling.mode")
+        .is_some_and(|v| v == "precise")
+        .then_some(BigintUnsignedHandlingMode::Precise);
+
+    (
+        timestamp_handling,
+        timestamptz_handling,
+        time_handling,
+        bigint_unsigned_handling,
+    )
+}
+
 pub struct CdcBackfillExecutor<S: StateStore> {
     actor_ctx: ActorContextRef,
 
@@ -209,30 +253,8 @@ impl<S: StateStore> CdcBackfillExecutor<S> {
             .await
             .expect("Retry create cdc table reader until success.")
         });
-        let timestamp_handling: Option<TimestampHandling> = self
-            .properties
-            .get("debezium.time.precision.mode")
-            .map(|v| v == "connect")
-            .unwrap_or(false)
-            .then_some(TimestampHandling::Milli);
-        let timestamptz_handling: Option<TimestamptzHandling> = self
-            .properties
-            .get("debezium.time.precision.mode")
-            .map(|v| v == "connect")
-            .unwrap_or(false)
-            .then_some(TimestamptzHandling::Milli);
-        let time_handling: Option<TimeHandling> = self
-            .properties
-            .get("debezium.time.precision.mode")
-            .map(|v| v == "connect")
-            .unwrap_or(false)
-            .then_some(TimeHandling::Milli);
-        let bigint_unsigned_handling: Option<BigintUnsignedHandlingMode> = self
-            .properties
-            .get("debezium.bigint.unsigned.handling.mode")
-            .map(|v| v == "precise")
-            .unwrap_or(false)
-            .then_some(BigintUnsignedHandlingMode::Precise);
+        let (timestamp_handling, timestamptz_handling, time_handling, bigint_unsigned_handling) =
+            get_cdc_json_parse_handling_from_properties(&self.properties);
         // Only postgres-cdc connector may trigger TOAST.
         let handle_toast_columns: bool =
             self.external_table.table_type() == &ExternalCdcTableType::Postgres;
@@ -955,10 +977,13 @@ mod tests {
     use risingwave_common::types::{DataType, Datum, JsonbVal};
     use risingwave_common::util::epoch::test_epoch;
     use risingwave_common::util::iter_util::ZipEqFast;
+    use risingwave_connector::parser::{TimeHandling, TimestampHandling, TimestamptzHandling};
     use risingwave_connector::source::cdc::CdcScanOptions;
     use risingwave_storage::memory::MemoryStateStore;
 
-    use crate::executor::backfill::cdc::cdc_backfill::transform_upstream;
+    use crate::executor::backfill::cdc::cdc_backfill::{
+        get_cdc_json_parse_handling_from_properties, transform_upstream,
+    };
     use crate::executor::monitor::StreamingMetrics;
     use crate::executor::prelude::StateTable;
     use crate::executor::source::default_source_internal_table;
@@ -1112,5 +1137,45 @@ mod tests {
             chunk.columns()[2].as_int64().iter().collect::<Vec<_>>(),
             vec![Some(100)]
         );
+    }
+
+    #[test]
+    fn test_get_cdc_json_parse_handling_from_properties() {
+        let properties = BTreeMap::from([(
+            TimestamptzHandling::OPTION_KEY.to_owned(),
+            "nano".to_owned(),
+        )]);
+        let (timestamp_handling, timestamptz_handling, time_handling, bigint_unsigned_handling) =
+            get_cdc_json_parse_handling_from_properties(&properties);
+        assert!(timestamp_handling.is_none());
+        assert!(matches!(
+            timestamptz_handling,
+            Some(TimestamptzHandling::Nano)
+        ));
+        assert!(time_handling.is_none());
+        assert!(bigint_unsigned_handling.is_none());
+    }
+
+    #[test]
+    fn test_debezium_time_precision_mode_overrides_timestamptz_handling() {
+        let properties = BTreeMap::from([
+            (
+                "debezium.time.precision.mode".to_owned(),
+                "connect".to_owned(),
+            ),
+            (
+                TimestamptzHandling::OPTION_KEY.to_owned(),
+                "nano".to_owned(),
+            ),
+        ]);
+        let (timestamp_handling, timestamptz_handling, time_handling, bigint_unsigned_handling) =
+            get_cdc_json_parse_handling_from_properties(&properties);
+        assert!(matches!(timestamp_handling, Some(TimestampHandling::Milli)));
+        assert!(matches!(
+            timestamptz_handling,
+            Some(TimestamptzHandling::Milli)
+        ));
+        assert!(matches!(time_handling, Some(TimeHandling::Milli)));
+        assert!(bigint_unsigned_handling.is_none());
     }
 }

--- a/src/stream/src/executor/backfill/cdc/cdc_backill_v2.rs
+++ b/src/stream/src/executor/backfill/cdc/cdc_backill_v2.rs
@@ -23,9 +23,6 @@ use risingwave_common::catalog::{ColumnDesc, Field};
 use risingwave_common::row::RowDeserializer;
 use risingwave_common::util::iter_util::ZipEqFast;
 use risingwave_common::util::sort_util::{OrderType, cmp_datum};
-use risingwave_connector::parser::{
-    BigintUnsignedHandlingMode, TimeHandling, TimestampHandling, TimestamptzHandling,
-};
 use risingwave_connector::source::cdc::CdcScanOptions;
 use risingwave_connector::source::cdc::external::{
     CdcOffset, ExternalCdcTableType, ExternalTableReaderImpl,
@@ -38,7 +35,7 @@ use tracing::Instrument;
 
 use crate::executor::UpdateMutation;
 use crate::executor::backfill::cdc::cdc_backfill::{
-    build_reader_and_poll_upstream, transform_upstream,
+    build_reader_and_poll_upstream, get_cdc_json_parse_handling_from_properties, transform_upstream,
 };
 use crate::executor::backfill::cdc::state_v2::ParallelizedCdcBackfillState;
 use crate::executor::backfill::cdc::upstream_table::external::ExternalStorageTable;
@@ -138,30 +135,8 @@ impl<S: StateStore> ParallelizedCdcBackfillExecutor<S> {
         // If user sets debezium.time.precision.mode to "connect", it means the user can guarantee
         // that the upstream data precision is MilliSecond. In this case, we don't use GuessNumberUnit
         // mode to guess precision, but use Milli mode directly, which can handle extreme timestamps.
-        let timestamp_handling: Option<TimestampHandling> = self
-            .properties
-            .get("debezium.time.precision.mode")
-            .map(|v| v == "connect")
-            .unwrap_or(false)
-            .then_some(TimestampHandling::Milli);
-        let timestamptz_handling: Option<TimestamptzHandling> = self
-            .properties
-            .get("debezium.time.precision.mode")
-            .map(|v| v == "connect")
-            .unwrap_or(false)
-            .then_some(TimestamptzHandling::Milli);
-        let time_handling: Option<TimeHandling> = self
-            .properties
-            .get("debezium.time.precision.mode")
-            .map(|v| v == "connect")
-            .unwrap_or(false)
-            .then_some(TimeHandling::Milli);
-        let bigint_unsigned_handling: Option<BigintUnsignedHandlingMode> = self
-            .properties
-            .get("debezium.bigint.unsigned.handling.mode")
-            .map(|v| v == "precise")
-            .unwrap_or(false)
-            .then_some(BigintUnsignedHandlingMode::Precise);
+        let (timestamp_handling, timestamptz_handling, time_handling, bigint_unsigned_handling) =
+            get_cdc_json_parse_handling_from_properties(&self.properties);
         // Only postgres-cdc connector may trigger TOAST.
         let handle_toast_columns: bool =
             self.external_table.table_type() == &ExternalCdcTableType::Postgres;


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

Currently debezium source uses either `TimestampHandling::GuessNumberUnit` by default, or `TimestampHandling::Milli` enabled by `debezium.time.precision.mode`.
However, `TimestampHandling::GuessNumberUnit` restrict the range to [1973-03-03 09:46:40, 5138-11-16 09:46:40) in UTC. This is not sufficient when upstream database stores out-of-bound value with other precision. e.g. `TimestampHandling::GuessNumberUnit` cannot handle `1967-06-30 22:00:00.0000000` of datetime2(7) data type for sqlserver, which requires nano precision.

This PR:
- Extend TimestampHandling to support TimestampHandling::Micro and TimestampHandling::Nano.
- Extend TimestamptzHandling to support TimestamptzHandling::Nano.
- Support `timestamp.handling.mode` and `timestamptz.handling.mode` for debezium source.

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
