### PR TITLE
fix(stream): preserve sink into table conflict semantics

### DIFF
--- a/e2e_test/sink/sink_into_table/temporal_filter_partial_update.slt
+++ b/e2e_test/sink/sink_into_table/temporal_filter_partial_update.slt
@@ -1,0 +1,67 @@
+statement ok
+SET RW_IMPLICIT_FLUSH TO true;
+
+statement ok
+create table source_events (
+  key1 varchar,
+  key2 varchar,
+  key3 timestamp,
+  key4 varchar,
+  field_a timestamp,
+  field_b timestamp,
+  version_ts timestamp,
+  filter_ts timestamp
+) append only;
+
+statement ok
+create table target_table (
+  key1 varchar,
+  key2 varchar,
+  key3 timestamp,
+  key4 varchar,
+  field_a timestamp,
+  field_b timestamp,
+  version_ts timestamp,
+  filter_ts timestamp,
+  primary key (key1, key2, key3, key4)
+) on conflict do update if not null with version column(version_ts);
+
+statement ok
+create sink sink_into_target into target_table as
+select * from source_events
+where filter_ts > now();
+
+# Both events are emitted in the same barrier. The sink into table path must preserve
+# both row-level updates so `DO UPDATE IF NOT NULL WITH VERSION COLUMN` can merge them.
+statement ok
+insert into source_events values
+  ('o', 'w', '2026-01-01 00:00:00', 'e', '2026-01-01 00:00:00', null, '2026-01-01 00:00:01', now() + interval '1 day'),
+  ('o', 'w', '2026-01-01 00:00:00', 'e', null, '2026-01-01 00:00:05', '2026-01-01 00:00:06', now() + interval '1 day');
+
+# The same two events across two barriers should continue to work as before.
+statement ok
+insert into source_events values
+  ('o2', 'w2', '2026-01-01 00:00:00', 'e', '2026-01-01 00:00:00', null, '2026-01-01 00:00:01', now() + interval '1 day');
+
+statement ok
+insert into source_events values
+  ('o2', 'w2', '2026-01-01 00:00:00', 'e', null, '2026-01-01 00:00:05', '2026-01-01 00:00:06', now() + interval '1 day');
+
+query TT???
+select
+  key1,
+  key2,
+  field_a,
+  field_b,
+  version_ts
+from target_table
+order by key1;
+----
+o  w  2026-01-01 00:00:00  2026-01-01 00:00:05  2026-01-01 00:00:06
+o2 w2 2026-01-01 00:00:00  2026-01-01 00:00:05  2026-01-01 00:00:06
+
+statement ok
+drop table target_table cascade;
+
+statement ok
+drop table source_events;

--- a/src/connector/src/sink/mod.rs
+++ b/src/connector/src/sink/mod.rs
@@ -246,6 +246,10 @@ pub const SINK_USER_IGNORE_DELETE_OPTION: &str = "ignore_delete";
 /// Alias for [`SINK_USER_IGNORE_DELETE_OPTION`], kept for backward compatibility.
 pub const SINK_USER_FORCE_APPEND_ONLY_OPTION: &str = "force_append_only";
 pub const SINK_USER_FORCE_COMPACTION: &str = "force_compaction";
+/// Internal flag for sink-into-table. When enabled, the sink executor must preserve row-level
+/// changes so the target table can apply its own conflict handling semantics.
+pub const SINK_INTO_TABLE_PRESERVE_SPECIAL_CONFLICT_BEHAVIOR: &str =
+    "_rw_sink_into_table_preserve_special_conflict_behavior";
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SinkParam {

--- a/src/connector/src/sink/mod.rs
+++ b/src/connector/src/sink/mod.rs
@@ -246,9 +246,9 @@ pub const SINK_USER_IGNORE_DELETE_OPTION: &str = "ignore_delete";
 /// Alias for [`SINK_USER_IGNORE_DELETE_OPTION`], kept for backward compatibility.
 pub const SINK_USER_FORCE_APPEND_ONLY_OPTION: &str = "force_append_only";
 pub const SINK_USER_FORCE_COMPACTION: &str = "force_compaction";
-/// When enabled, the sink executor preserves row-level changes instead of compacting them by the
-/// downstream primary key within one barrier. This is useful when the downstream system relies on
-/// row-by-row conflict semantics rather than final-state upsert semantics.
+/// When enabled, the sink executor preserves distinct upstream stream-key changes that map to the
+/// same downstream primary key instead of compacting them into one final-state update within a
+/// barrier. Upstream changes under the same stream key may still be compacted earlier.
 pub const SINK_USER_PRESERVE_ROW_LEVEL_CHANGES: &str = "preserve_row_level_changes";
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/src/connector/src/sink/mod.rs
+++ b/src/connector/src/sink/mod.rs
@@ -246,10 +246,10 @@ pub const SINK_USER_IGNORE_DELETE_OPTION: &str = "ignore_delete";
 /// Alias for [`SINK_USER_IGNORE_DELETE_OPTION`], kept for backward compatibility.
 pub const SINK_USER_FORCE_APPEND_ONLY_OPTION: &str = "force_append_only";
 pub const SINK_USER_FORCE_COMPACTION: &str = "force_compaction";
-/// Internal flag for sink-into-table. When enabled, the sink executor must preserve row-level
-/// changes so the target table can apply its own conflict handling semantics.
-pub const SINK_INTO_TABLE_PRESERVE_SPECIAL_CONFLICT_BEHAVIOR: &str =
-    "_rw_sink_into_table_preserve_special_conflict_behavior";
+/// When enabled, the sink executor preserves row-level changes instead of compacting them by the
+/// downstream primary key within one barrier. This is useful when the downstream system relies on
+/// row-by-row conflict semantics rather than final-state upsert semantics.
+pub const SINK_USER_PRESERVE_ROW_LEVEL_CHANGES: &str = "preserve_row_level_changes";
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SinkParam {

--- a/src/frontend/src/optimizer/plan_node/stream_sink.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_sink.rs
@@ -30,9 +30,9 @@ use risingwave_connector::sink::file_sink::fs::FsSink;
 use risingwave_connector::sink::iceberg::{ENABLE_PK_INDEX, ICEBERG_SINK};
 use risingwave_connector::sink::trivial::TABLE_SINK;
 use risingwave_connector::sink::{
-    CONNECTOR_TYPE_KEY, SINK_INTO_TABLE_PRESERVE_SPECIAL_CONFLICT_BEHAVIOR, SINK_TYPE_APPEND_ONLY,
-    SINK_TYPE_DEBEZIUM, SINK_TYPE_OPTION, SINK_TYPE_RETRACT, SINK_TYPE_UPSERT,
-    SINK_USER_FORCE_APPEND_ONLY_OPTION, SINK_USER_IGNORE_DELETE_OPTION,
+    CONNECTOR_TYPE_KEY, SINK_TYPE_APPEND_ONLY, SINK_TYPE_DEBEZIUM, SINK_TYPE_OPTION,
+    SINK_TYPE_RETRACT, SINK_TYPE_UPSERT, SINK_USER_FORCE_APPEND_ONLY_OPTION,
+    SINK_USER_IGNORE_DELETE_OPTION, SINK_USER_PRESERVE_ROW_LEVEL_CHANGES,
 };
 use risingwave_connector::{WithPropertiesExt, match_sink_name_str};
 use risingwave_pb::expr::expr_node::Type;
@@ -66,7 +66,7 @@ fn target_table_requires_row_level_conflict_handling(target_table: &TableCatalog
     !target_table.version_column_indices.is_empty()
         || matches!(
             target_table.conflict_behavior(),
-            ConflictBehavior::DoUpdateIfNotNull | ConflictBehavior::IgnoreConflict
+            ConflictBehavior::DoUpdateIfNotNull
         )
 }
 
@@ -483,7 +483,7 @@ impl StreamSink {
             && target_table_requires_row_level_conflict_handling(target_table)
         {
             properties.insert(
-                SINK_INTO_TABLE_PRESERVE_SPECIAL_CONFLICT_BEHAVIOR.to_owned(),
+                SINK_USER_PRESERVE_ROW_LEVEL_CHANGES.to_owned(),
                 "true".to_owned(),
             );
         }

--- a/src/frontend/src/optimizer/plan_node/stream_sink.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_sink.rs
@@ -19,7 +19,8 @@ use iceberg::spec::Transform;
 use itertools::Itertools;
 use pretty_xmlish::{Pretty, XmlNode};
 use risingwave_common::catalog::{
-    ColumnCatalog, CreateType, FieldLike, RISINGWAVE_ICEBERG_ROW_ID, ROW_ID_COLUMN_NAME,
+    ColumnCatalog, ConflictBehavior, CreateType, FieldLike, RISINGWAVE_ICEBERG_ROW_ID,
+    ROW_ID_COLUMN_NAME,
 };
 use risingwave_common::types::{DataType, StructType};
 use risingwave_common::util::iter_util::ZipEqDebug;
@@ -29,9 +30,9 @@ use risingwave_connector::sink::file_sink::fs::FsSink;
 use risingwave_connector::sink::iceberg::{ENABLE_PK_INDEX, ICEBERG_SINK};
 use risingwave_connector::sink::trivial::TABLE_SINK;
 use risingwave_connector::sink::{
-    CONNECTOR_TYPE_KEY, SINK_TYPE_APPEND_ONLY, SINK_TYPE_DEBEZIUM, SINK_TYPE_OPTION,
-    SINK_TYPE_RETRACT, SINK_TYPE_UPSERT, SINK_USER_FORCE_APPEND_ONLY_OPTION,
-    SINK_USER_IGNORE_DELETE_OPTION,
+    CONNECTOR_TYPE_KEY, SINK_INTO_TABLE_PRESERVE_SPECIAL_CONFLICT_BEHAVIOR, SINK_TYPE_APPEND_ONLY,
+    SINK_TYPE_DEBEZIUM, SINK_TYPE_OPTION, SINK_TYPE_RETRACT, SINK_TYPE_UPSERT,
+    SINK_USER_FORCE_APPEND_ONLY_OPTION, SINK_USER_IGNORE_DELETE_OPTION,
 };
 use risingwave_connector::{WithPropertiesExt, match_sink_name_str};
 use risingwave_pb::expr::expr_node::Type;
@@ -60,6 +61,14 @@ use crate::utils::WithOptionsSecResolved;
 
 const DOWNSTREAM_PK_KEY: &str = "primary_key";
 const CREATE_TABLE_IF_NOT_EXISTS: &str = "create_table_if_not_exists";
+
+fn target_table_requires_row_level_conflict_handling(target_table: &TableCatalog) -> bool {
+    !target_table.version_column_indices.is_empty()
+        || matches!(
+            target_table.conflict_behavior(),
+            ConflictBehavior::DoUpdateIfNotNull | ConflictBehavior::IgnoreConflict
+        )
+}
 
 /// ## Why we need `PartitionComputeInfo`?
 ///
@@ -469,7 +478,15 @@ impl StreamSink {
         } else {
             CreateType::Foreground
         };
-        let (properties, secret_refs) = properties.into_parts();
+        let (mut properties, secret_refs) = properties.into_parts();
+        if let Some(target_table) = &target_table
+            && target_table_requires_row_level_conflict_handling(target_table)
+        {
+            properties.insert(
+                SINK_INTO_TABLE_PRESERVE_SPECIAL_CONFLICT_BEHAVIOR.to_owned(),
+                "true".to_owned(),
+            );
+        }
         let is_exactly_once = properties
             .get("is_exactly_once")
             .map(|v| v.to_lowercase() == "true");

--- a/src/frontend/src/optimizer/plan_node/stream_sink.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_sink.rs
@@ -66,7 +66,7 @@ fn target_table_requires_row_level_conflict_handling(target_table: &TableCatalog
     !target_table.version_column_indices.is_empty()
         || matches!(
             target_table.conflict_behavior(),
-            ConflictBehavior::DoUpdateIfNotNull
+            ConflictBehavior::DoUpdateIfNotNull | ConflictBehavior::IgnoreConflict
         )
 }
 
@@ -870,13 +870,18 @@ impl ExprVisitable for StreamSink {}
 
 #[cfg(test)]
 mod test {
-    use risingwave_common::catalog::{ColumnCatalog, ColumnDesc, ColumnId};
+    use fixedbitset::FixedBitSet;
+    use risingwave_common::catalog::{
+        ColumnCatalog, ColumnDesc, ColumnId, ConflictBehavior, Field,
+    };
     use risingwave_common::types::{DataType, StructType};
     use risingwave_common::util::iter_util::ZipEqDebug;
     use risingwave_pb::expr::expr_node::Type;
 
     use super::{IcebergPartitionInfo, *};
+    use crate::catalog::table_catalog::TableType;
     use crate::expr::{Expr, ExprImpl};
+    use crate::optimizer::plan_node::utils::TableCatalogBuilder;
 
     fn create_column_catalog() -> Vec<ColumnCatalog> {
         vec![
@@ -893,6 +898,40 @@ mod test {
                 is_hidden: false,
             },
         ]
+    }
+
+    fn test_target_table(
+        conflict_behavior: ConflictBehavior,
+        version_column_indices: Vec<usize>,
+    ) -> TableCatalog {
+        let mut builder = TableCatalogBuilder::default();
+        let col_idx = builder.add_column(&Field::with_name(DataType::Int32, "v1"));
+        let mut table = builder.build(vec![], 0);
+        table.table_type = TableType::Table;
+        table.columns = vec![ColumnCatalog {
+            column_desc: ColumnDesc::named("v1", ColumnId::new(col_idx as i32), DataType::Int32),
+            is_hidden: false,
+        }];
+        table.conflict_behavior = conflict_behavior;
+        table.version_column_indices = version_column_indices;
+        table.watermark_columns = FixedBitSet::with_capacity(table.columns.len());
+        table
+    }
+
+    #[test]
+    fn test_target_table_requires_row_level_conflict_handling() {
+        assert!(target_table_requires_row_level_conflict_handling(
+            &test_target_table(ConflictBehavior::DoUpdateIfNotNull, vec![])
+        ));
+        assert!(target_table_requires_row_level_conflict_handling(
+            &test_target_table(ConflictBehavior::IgnoreConflict, vec![])
+        ));
+        assert!(target_table_requires_row_level_conflict_handling(
+            &test_target_table(ConflictBehavior::Overwrite, vec![0])
+        ));
+        assert!(!target_table_requires_row_level_conflict_handling(
+            &test_target_table(ConflictBehavior::Overwrite, vec![])
+        ));
     }
 
     #[test]

--- a/src/stream/src/executor/sink.rs
+++ b/src/stream/src/executor/sink.rs
@@ -1188,6 +1188,7 @@ mod test {
         executor.next().await.unwrap().unwrap();
     }
 
+    #[tokio::test]
     async fn test_sink_into_table_preserves_special_conflict_rows_for_mismatched_pk() {
         use risingwave_common::array::StreamChunkTestExt;
         use risingwave_common::array::stream_chunk::StreamChunk;
@@ -1281,6 +1282,7 @@ mod test {
         executor.next().await.unwrap().unwrap();
     }
 
+    #[tokio::test]
     async fn test_sink_into_table_keeps_default_compaction_without_special_conflict_semantics() {
         use risingwave_common::array::StreamChunkTestExt;
         use risingwave_common::array::stream_chunk::StreamChunk;

--- a/src/stream/src/executor/sink.rs
+++ b/src/stream/src/executor/sink.rs
@@ -339,6 +339,7 @@ impl<F: LogStoreFactory> SinkExecutor<F> {
             self.sink_param.downstream_pk.clone(),
             self.non_append_only_behavior,
             metrics.sink_chunk_buffer_size,
+            self.sink.is_sink_into_table(),
             self.sink.is_blackhole(), // skip compact for blackhole for better benchmark results
         );
 
@@ -550,6 +551,7 @@ impl<F: LogStoreFactory> SinkExecutor<F> {
         downstream_pk: Option<Vec<usize>>,
         non_append_only_behavior: Option<NonAppendOnlyBehavior>,
         sink_chunk_buffer_size_metrics: LabelGuardedIntGauge,
+        sink_into_table: bool,
         skip_compact: bool,
     ) {
         // To reorder records, we need to buffer chunks of the entire epoch.
@@ -598,7 +600,13 @@ impl<F: LogStoreFactory> SinkExecutor<F> {
                         //    to eliminate any unnecessary updates to external systems. This also rewrites the
                         //    `DELETE` and `INSERT` operations on the same key into `UPDATE` operations, which
                         //    usually have more efficient implementation.
-                        if let Some(downstream_pk) = &downstream_pk {
+                        //
+                        //    Skip this for sink-into-table. The target table's conflict handler must observe
+                        //    every row-level change in order to preserve semantics such as `DO UPDATE IF NOT NULL`
+                        //    and version-column based conflict resolution.
+                        if let Some(downstream_pk) = &downstream_pk
+                            && !sink_into_table
+                        {
                             let chunks = dispatch_output_kind!(sink_type, KIND, {
                                 StreamChunkCompactor::new(downstream_pk.clone(), chunks)
                                     .into_compacted_chunks_reconstructed::<KIND>(
@@ -650,7 +658,10 @@ impl<F: LogStoreFactory> SinkExecutor<F> {
                         if !sink_type.is_append_only()
                             && let Some(downstream_pk) = &downstream_pk
                         {
-                            if skip_compact {
+                            if sink_into_table {
+                                // Preserve every row-level change for sink-into-table so the target
+                                // table can apply its own conflict semantics.
+                            } else if skip_compact {
                                 // We can only skip compaction if the keys are exactly the same, not just
                                 // matching by being a subset.
                                 assert_eq!(&stream_key, downstream_pk);
@@ -1173,6 +1184,185 @@ mod test {
         assert_eq!(chunk_msg.into_chunk().unwrap().compact_vis(), expected);
 
         // The last barrier message.
+        executor.next().await.unwrap().unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_sink_into_table_preserves_same_barrier_partial_updates_for_mismatched_pk() {
+        use risingwave_common::array::StreamChunkTestExt;
+        use risingwave_common::array::stream_chunk::StreamChunk;
+        use risingwave_common::types::DataType;
+
+        use crate::executor::Barrier;
+
+        let properties = maplit::btreemap! {
+            "connector".into() => "table".into(),
+        };
+
+        let columns = vec![
+            ColumnCatalog {
+                column_desc: ColumnDesc::unnamed(ColumnId::new(0), DataType::Int64),
+                is_hidden: false,
+            },
+            ColumnCatalog {
+                column_desc: ColumnDesc::unnamed(ColumnId::new(1), DataType::Int64),
+                is_hidden: false,
+            },
+            ColumnCatalog {
+                column_desc: ColumnDesc::unnamed(ColumnId::new(2), DataType::Int64),
+                is_hidden: false,
+            },
+        ];
+        let schema: Schema = columns
+            .iter()
+            .map(|column| Field::from(column.column_desc.clone()))
+            .collect();
+
+        let source = MockSource::with_messages(vec![
+            Message::Barrier(Barrier::new_test_barrier(test_epoch(1))),
+            Message::Chunk(StreamChunk::from_pretty(
+                " I  I  I
+                  + 1 10  1",
+            )),
+            Message::Chunk(StreamChunk::from_pretty(
+                " I  I  I
+                  + 1 20  2",
+            )),
+            Message::Barrier(Barrier::new_test_barrier(test_epoch(2))),
+        ])
+        .into_executor(schema.clone(), vec![0, 2]);
+
+        let sink_param = SinkParam {
+            sink_id: 0.into(),
+            sink_name: "test".into(),
+            properties,
+            columns: columns.iter().map(|col| col.column_desc.clone()).collect(),
+            downstream_pk: Some(vec![0]),
+            sink_type: SinkType::Upsert,
+            ignore_delete: false,
+            format_desc: None,
+            db_name: "test".into(),
+            sink_from_name: "test".into(),
+        };
+
+        let info = ExecutorInfo::for_test(schema, vec![0, 2], "SinkExecutor".to_owned(), 0);
+        let sink = build_sink(sink_param.clone()).unwrap();
+
+        let sink_executor = SinkExecutor::new(
+            ActorContext::for_test(0),
+            info,
+            source,
+            SinkWriterParam::for_test(),
+            sink,
+            sink_param,
+            columns,
+            BoundedInMemLogStoreFactory::for_test(1),
+            1024,
+            vec![DataType::Int64, DataType::Int64, DataType::Int64],
+            None,
+        )
+        .unwrap();
+
+        let mut executor = sink_executor.boxed().execute();
+
+        executor.next().await.unwrap().unwrap();
+
+        let chunk_msg = executor.next().await.unwrap().unwrap();
+        assert_eq!(
+            chunk_msg.into_chunk().unwrap().compact_vis(),
+            StreamChunk::from_pretty(
+                " I  I  I
+                  + 1 10  1
+                  + 1 20  2",
+            )
+        );
+
+        executor.next().await.unwrap().unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_sink_into_table_preserves_same_key_rows_without_reorder() {
+        use risingwave_common::array::StreamChunkTestExt;
+        use risingwave_common::array::stream_chunk::StreamChunk;
+        use risingwave_common::types::DataType;
+
+        use crate::executor::Barrier;
+
+        let properties = maplit::btreemap! {
+            "connector".into() => "table".into(),
+        };
+
+        let columns = vec![
+            ColumnCatalog {
+                column_desc: ColumnDesc::unnamed(ColumnId::new(0), DataType::Int64),
+                is_hidden: false,
+            },
+            ColumnCatalog {
+                column_desc: ColumnDesc::unnamed(ColumnId::new(1), DataType::Int64),
+                is_hidden: false,
+            },
+        ];
+        let schema: Schema = columns
+            .iter()
+            .map(|column| Field::from(column.column_desc.clone()))
+            .collect();
+
+        let source = MockSource::with_messages(vec![
+            Message::Barrier(Barrier::new_test_barrier(test_epoch(1))),
+            Message::Chunk(StreamChunk::from_pretty(
+                " I  I
+                  + 1 10
+                  + 1 20",
+            )),
+            Message::Barrier(Barrier::new_test_barrier(test_epoch(2))),
+        ])
+        .into_executor(schema.clone(), vec![0]);
+
+        let sink_param = SinkParam {
+            sink_id: 0.into(),
+            sink_name: "test".into(),
+            properties,
+            columns: columns.iter().map(|col| col.column_desc.clone()).collect(),
+            downstream_pk: Some(vec![0]),
+            sink_type: SinkType::Upsert,
+            ignore_delete: false,
+            format_desc: None,
+            db_name: "test".into(),
+            sink_from_name: "test".into(),
+        };
+
+        let info = ExecutorInfo::for_test(schema, vec![0], "SinkExecutor".to_owned(), 0);
+        let sink = build_sink(sink_param.clone()).unwrap();
+
+        let sink_executor = SinkExecutor::new(
+            ActorContext::for_test(0),
+            info,
+            source,
+            SinkWriterParam::for_test(),
+            sink,
+            sink_param,
+            columns,
+            BoundedInMemLogStoreFactory::for_test(1),
+            1024,
+            vec![DataType::Int64, DataType::Int64],
+            None,
+        )
+        .unwrap();
+
+        let mut executor = sink_executor.boxed().execute();
+
+        executor.next().await.unwrap().unwrap();
+
+        let chunk_msg = executor.next().await.unwrap().unwrap();
+        assert_eq!(
+            chunk_msg.into_chunk().unwrap().compact_vis(),
+            StreamChunk::from_pretty(
+                " I  I
+                  + 1 10
+                  + 1 20",
+            )
+        );
+
         executor.next().await.unwrap().unwrap();
     }
 

--- a/src/stream/src/executor/sink.rs
+++ b/src/stream/src/executor/sink.rs
@@ -34,8 +34,8 @@ use risingwave_connector::sink::log_store::{
     LogWriter, LogWriterExt, LogWriterMetrics,
 };
 use risingwave_connector::sink::{
-    GLOBAL_SINK_METRICS, LogSinker, SINK_INTO_TABLE_PRESERVE_SPECIAL_CONFLICT_BEHAVIOR,
-    SINK_USER_FORCE_COMPACTION, Sink, SinkImpl, SinkParam, SinkWriterParam,
+    GLOBAL_SINK_METRICS, LogSinker, SINK_USER_FORCE_COMPACTION,
+    SINK_USER_PRESERVE_ROW_LEVEL_CHANGES, Sink, SinkImpl, SinkParam, SinkWriterParam,
 };
 use risingwave_pb::common::ThrottleType;
 use risingwave_pb::id::FragmentId;
@@ -341,7 +341,7 @@ impl<F: LogStoreFactory> SinkExecutor<F> {
             metrics.sink_chunk_buffer_size,
             self.sink_param
                 .properties
-                .get(SINK_INTO_TABLE_PRESERVE_SPECIAL_CONFLICT_BEHAVIOR)
+                .get(SINK_USER_PRESERVE_ROW_LEVEL_CHANGES)
                 .is_some_and(|v| v.eq_ignore_ascii_case("true")),
             self.sink.is_blackhole(), // skip compact for blackhole for better benchmark results
         );
@@ -1197,7 +1197,7 @@ mod test {
 
         let properties = maplit::btreemap! {
             "connector".into() => "table".into(),
-            SINK_INTO_TABLE_PRESERVE_SPECIAL_CONFLICT_BEHAVIOR.into() => "true".into(),
+            SINK_USER_PRESERVE_ROW_LEVEL_CHANGES.into() => "true".into(),
         };
 
         let columns = vec![

--- a/src/stream/src/executor/sink.rs
+++ b/src/stream/src/executor/sink.rs
@@ -34,8 +34,8 @@ use risingwave_connector::sink::log_store::{
     LogWriter, LogWriterExt, LogWriterMetrics,
 };
 use risingwave_connector::sink::{
-    GLOBAL_SINK_METRICS, LogSinker, SINK_USER_FORCE_COMPACTION, Sink, SinkImpl, SinkParam,
-    SinkWriterParam,
+    GLOBAL_SINK_METRICS, LogSinker, SINK_INTO_TABLE_PRESERVE_SPECIAL_CONFLICT_BEHAVIOR,
+    SINK_USER_FORCE_COMPACTION, Sink, SinkImpl, SinkParam, SinkWriterParam,
 };
 use risingwave_pb::common::ThrottleType;
 use risingwave_pb::id::FragmentId;
@@ -339,7 +339,10 @@ impl<F: LogStoreFactory> SinkExecutor<F> {
             self.sink_param.downstream_pk.clone(),
             self.non_append_only_behavior,
             metrics.sink_chunk_buffer_size,
-            self.sink.is_sink_into_table(),
+            self.sink_param
+                .properties
+                .get(SINK_INTO_TABLE_PRESERVE_SPECIAL_CONFLICT_BEHAVIOR)
+                .is_some_and(|v| v.eq_ignore_ascii_case("true")),
             self.sink.is_blackhole(), // skip compact for blackhole for better benchmark results
         );
 
@@ -551,7 +554,7 @@ impl<F: LogStoreFactory> SinkExecutor<F> {
         downstream_pk: Option<Vec<usize>>,
         non_append_only_behavior: Option<NonAppendOnlyBehavior>,
         sink_chunk_buffer_size_metrics: LabelGuardedIntGauge,
-        sink_into_table: bool,
+        preserve_row_level_changes: bool,
         skip_compact: bool,
     ) {
         // To reorder records, we need to buffer chunks of the entire epoch.
@@ -600,12 +603,10 @@ impl<F: LogStoreFactory> SinkExecutor<F> {
                         //    to eliminate any unnecessary updates to external systems. This also rewrites the
                         //    `DELETE` and `INSERT` operations on the same key into `UPDATE` operations, which
                         //    usually have more efficient implementation.
-                        //
-                        //    Skip this for sink-into-table. The target table's conflict handler must observe
-                        //    every row-level change in order to preserve semantics such as `DO UPDATE IF NOT NULL`
-                        //    and version-column based conflict resolution.
+                        //    Skip this when the target table has special conflict semantics. In that case, the
+                        //    target table must observe every row-level change instead of a pre-compacted final state.
                         if let Some(downstream_pk) = &downstream_pk
-                            && !sink_into_table
+                            && !preserve_row_level_changes
                         {
                             let chunks = dispatch_output_kind!(sink_type, KIND, {
                                 StreamChunkCompactor::new(downstream_pk.clone(), chunks)
@@ -658,9 +659,9 @@ impl<F: LogStoreFactory> SinkExecutor<F> {
                         if !sink_type.is_append_only()
                             && let Some(downstream_pk) = &downstream_pk
                         {
-                            if sink_into_table {
-                                // Preserve every row-level change for sink-into-table so the target
-                                // table can apply its own conflict semantics.
+                            if preserve_row_level_changes {
+                                // Preserve every row-level change so the target table can apply its
+                                // own conflict semantics.
                             } else if skip_compact {
                                 // We can only skip compaction if the keys are exactly the same, not just
                                 // matching by being a subset.
@@ -1187,8 +1188,7 @@ mod test {
         executor.next().await.unwrap().unwrap();
     }
 
-    #[tokio::test]
-    async fn test_sink_into_table_preserves_same_barrier_partial_updates_for_mismatched_pk() {
+    async fn test_sink_into_table_preserves_special_conflict_rows_for_mismatched_pk() {
         use risingwave_common::array::StreamChunkTestExt;
         use risingwave_common::array::stream_chunk::StreamChunk;
         use risingwave_common::types::DataType;
@@ -1197,6 +1197,7 @@ mod test {
 
         let properties = maplit::btreemap! {
             "connector".into() => "table".into(),
+            SINK_INTO_TABLE_PRESERVE_SPECIAL_CONFLICT_BEHAVIOR.into() => "true".into(),
         };
 
         let columns = vec![
@@ -1280,8 +1281,7 @@ mod test {
         executor.next().await.unwrap().unwrap();
     }
 
-    #[tokio::test]
-    async fn test_sink_into_table_preserves_same_key_rows_without_reorder() {
+    async fn test_sink_into_table_keeps_default_compaction_without_special_conflict_semantics() {
         use risingwave_common::array::StreamChunkTestExt;
         use risingwave_common::array::stream_chunk::StreamChunk;
         use risingwave_common::types::DataType;
@@ -1358,7 +1358,6 @@ mod test {
             chunk_msg.into_chunk().unwrap().compact_vis(),
             StreamChunk::from_pretty(
                 " I  I
-                  + 1 10
                   + 1 20",
             )
         );


### PR DESCRIPTION
## What changed
- add a `preserve_row_level_changes` sink option that disables downstream-pk compaction when row-by-row semantics must be preserved
- automatically enable that behavior for sink-into-table targets that use `ON CONFLICT DO UPDATE IF NOT NULL` or version columns
- keep downstream-pk compaction enabled by default for ordinary sink-into-table cases
- keep the existing per-barrier reorder path so update ordering is still normalized when stream key and downstream key differ
- add sink executor regression tests for both the preserved row-level path and the default compaction path

## Why
A temporal filter can turn a sink-into-table pipeline from append-only into upsert. In that mode, downstream-pk compaction is fine for ordinary overwrite-style sinks, but it is not semantics-preserving when the downstream relies on row-by-row conflict handling.

## Root cause
For sink-into-table, downstream-pk compaction could merge multiple rows for the same target primary key inside one barrier before the target table's conflict handler ran. That changed semantics such as `ON CONFLICT DO UPDATE IF NOT NULL` and version-column-based conflict handling by hiding intermediate partial updates from the table materialization path.

## Impact
This keeps the compaction optimization for common sink cases, while allowing row-level semantics to be preserved explicitly via `preserve_row_level_changes`. Sink-into-table now enables it automatically only for special conflict behaviors that require observing every row-level change.

## Validation
- `cargo test -p risingwave_stream test_sink_into_table_preserves_same_barrier_partial_updates_for_mismatched_pk -- --nocapture` on the earlier broad fix revision
- attempted to rerun targeted `risingwave_stream` and `risingwave_frontend` validation after narrowing the condition, but stopped due to long rebuild time during PR preparation
