### PR TITLE
fix(stream): rate limit snapshot backfill chunks

### DIFF
--- a/src/stream/src/executor/backfill/snapshot_backfill/executor.rs
+++ b/src/stream/src/executor/backfill/snapshot_backfill/executor.rs
@@ -27,7 +27,7 @@ use risingwave_common::hash::VnodeBitmapExt;
 use risingwave_common::metrics::LabelGuardedIntCounter;
 use risingwave_common::row::OwnedRow;
 use risingwave_common::util::epoch::{Epoch, EpochPair};
-use risingwave_common_rate_limit::RateLimit;
+use risingwave_common_rate_limit::{MonitoredRateLimiter, RateLimit, RateLimiter};
 use risingwave_hummock_sdk::HummockReadEpoch;
 use risingwave_pb::batch_plan::ScanRange;
 use risingwave_pb::common::PbThrottleType;
@@ -75,7 +75,7 @@ pub struct SnapshotBackfillExecutor<S: StateStore> {
     progress: CreateMviewProgressReporter,
 
     chunk_size: usize,
-    rate_limit: RateLimit,
+    rate_limiter: MonitoredRateLimiter,
 
     barrier_rx: UnboundedReceiver<Barrier>,
 
@@ -141,6 +141,7 @@ impl<S: StateStore> SnapshotBackfillExecutor<S> {
                 "create snapshot backfill executor with rate limit"
             );
         }
+        let rate_limiter = RateLimiter::new(rate_limit).monitored(upstream_table.table_id());
         Ok(Self {
             upstream_table,
             progress_state_table,
@@ -149,7 +150,7 @@ impl<S: StateStore> SnapshotBackfillExecutor<S> {
             stream_key,
             progress,
             chunk_size,
-            rate_limit,
+            rate_limiter,
             barrier_rx,
             actor_ctx,
             metrics,
@@ -260,7 +261,7 @@ impl<S: StateStore> SnapshotBackfillExecutor<S> {
                             &self.upstream_table,
                             snapshot_epoch,
                             self.chunk_size,
-                            &mut self.rate_limit,
+                            &self.rate_limiter,
                             &mut self.barrier_rx,
                             &mut self.progress,
                             &mut backfill_state,
@@ -1015,7 +1016,7 @@ async fn make_consume_snapshot_stream<'a, S: StateStore>(
     upstream_table: &'a BatchTable<S>,
     snapshot_epoch: u64,
     chunk_size: usize,
-    rate_limit: &'a mut RateLimit,
+    rate_limiter: &'a MonitoredRateLimiter,
     barrier_rx: &'a mut UnboundedReceiver<Barrier>,
     progress: &'a mut CreateMviewProgressReporter,
     backfill_state: &'a mut BackfillState<S>,
@@ -1031,7 +1032,7 @@ async fn make_consume_snapshot_stream<'a, S: StateStore>(
         upstream_table,
         snapshot_epoch,
         &*backfill_state,
-        *rate_limit,
+        rate_limiter.rate_limit(),
         chunk_size,
         actor_ctx.config.developer.snapshot_iter_rebuild_interval(),
         pk_scan_range,
@@ -1054,10 +1055,9 @@ async fn make_consume_snapshot_stream<'a, S: StateStore>(
         )
     }
 
-    let mut epoch_row_count = 0;
     let mut backfill_paused = initial_backfill_paused;
     loop {
-        let throttle_snapshot_stream = epoch_row_count as u64 >= rate_limit.to_u64();
+        let throttle_snapshot_stream = matches!(rate_limiter.rate_limit(), RateLimit::Pause);
         match select_barrier_and_snapshot_stream(
             barrier_rx,
             &mut snapshot_stream,
@@ -1077,7 +1077,7 @@ async fn make_consume_snapshot_stream<'a, S: StateStore>(
                     backfill_paused = false;
                 }
                 if let Some(chunk) = snapshot_stream.consume_builder() {
-                    epoch_row_count += chunk.cardinality();
+                    rate_limiter.wait(chunk.cardinality() as _).await;
                     yield Message::Chunk(chunk);
                 }
                 snapshot_stream
@@ -1096,9 +1096,8 @@ async fn make_consume_snapshot_stream<'a, S: StateStore>(
                     .await?;
                 let count = backfill_state.total_row_count();
                 let post_commit = backfill_state.commit(barrier.epoch).await?;
-                trace!(?barrier_epoch, count, epoch_row_count, "update progress");
+                trace!(?barrier_epoch, count, "update progress");
                 progress.update(barrier_epoch, barrier_epoch.prev, count as _);
-                epoch_row_count = 0;
 
                 let new_rate_limit = barrier.mutation.as_ref().and_then(|m| {
                     if let Mutation::Throttle(config) = &**m
@@ -1115,7 +1114,7 @@ async fn make_consume_snapshot_stream<'a, S: StateStore>(
 
                 if let Some(new_rate_limit) = new_rate_limit {
                     let new_rate_limit = new_rate_limit.into();
-                    *rate_limit = new_rate_limit;
+                    rate_limiter.update(new_rate_limit);
                     snapshot_stream.update_rate_limiter(new_rate_limit, chunk_size);
                 }
             }
@@ -1125,7 +1124,7 @@ async fn make_consume_snapshot_stream<'a, S: StateStore>(
                         anyhow!("snapshot backfill paused, but received snapshot chunk").into(),
                     );
                 }
-                epoch_row_count += chunk.cardinality();
+                rate_limiter.wait(chunk.cardinality() as _).await;
                 yield Message::Chunk(chunk);
             }
             Either::Right(None) => {

--- a/src/tests/simulation/tests/integration_tests/recovery/locality_backfill.rs
+++ b/src/tests/simulation/tests/integration_tests/recovery/locality_backfill.rs
@@ -14,8 +14,8 @@
 
 use std::time::Duration;
 
-use anyhow::Result;
-use risingwave_simulation::cluster::{Cluster, Configuration};
+use anyhow::{Result, bail};
+use risingwave_simulation::cluster::{Cluster, Configuration, Session};
 use tokio::time::sleep;
 
 const SET_LOCALITY_BACKFILL: &str = "SET enable_locality_backfill = true;";
@@ -27,6 +27,27 @@ const CREATE_MV: &str = "CREATE MATERIALIZED VIEW mv AS SELECT count(*) FROM t G
 const ALTER_RATE_LIMIT_DEFAULT: &str =
     "ALTER MATERIALIZED VIEW mv SET BACKFILL_RATE_LIMIT = DEFAULT;";
 const WAIT: &str = "WAIT;";
+const WAIT_INTERNAL_STATE_SECS: u64 = 60;
+
+async fn wait_internal_state_table_non_empty(
+    session: &mut Session,
+    state_table_name: &str,
+    context: &str,
+) -> Result<i64> {
+    for _ in 0..WAIT_INTERNAL_STATE_SECS * 10 {
+        let state_count = session
+            .run(&format!("SELECT COUNT(*) FROM {};", state_table_name))
+            .await?;
+        let state_count_val = state_count.parse::<i64>()?;
+        if state_count_val > 0 {
+            return Ok(state_count_val);
+        }
+
+        sleep(Duration::from_millis(100)).await;
+    }
+
+    bail!("State table should have rows {}, got 0", context);
+}
 
 /// Test that locality backfill internal tables behave correctly during recovery.
 /// This test verifies:
@@ -70,20 +91,9 @@ async fn test_locality_backfill_recovery_internal_tables() -> Result<()> {
         "Progress table should exist"
     );
 
-    // Step 6: Wait for some backfill progress
-    sleep(Duration::from_secs(5)).await;
-
-    // Step 7: Check internal tables before recovery
+    // Step 6: Check internal tables before recovery
     // State table should be non-empty (contains vnode positions during backfill)
-    let state_count = session
-        .run(&format!("SELECT COUNT(*) FROM {};", state_table_name))
-        .await?;
-    let state_count_val = state_count.parse::<i64>()?;
-    assert!(
-        state_count_val > 0,
-        "State table should have rows during backfill, got {}",
-        state_count_val
-    );
+    wait_internal_state_table_non_empty(&mut session, &state_table_name, "during backfill").await?;
 
     // Progress table should be empty
     let progress_count = session
@@ -94,21 +104,12 @@ async fn test_locality_backfill_recovery_internal_tables() -> Result<()> {
         "Progress table should be empty during backfill"
     );
 
-    // Step 8: Trigger recovery
+    // Step 7: Trigger recovery
     cluster.run("RECOVER").await?;
-    sleep(Duration::from_secs(10)).await;
 
-    // Step 9: Check internal tables after recovery
+    // Step 8: Check internal tables after recovery
     // State table should still be non-empty
-    let state_count_after = session
-        .run(&format!("SELECT COUNT(*) FROM {};", state_table_name))
-        .await?;
-    let state_count_after_val = state_count_after.parse::<i64>()?;
-    assert!(
-        state_count_after_val > 0,
-        "State table should have rows after recovery, got {}",
-        state_count_after_val
-    );
+    wait_internal_state_table_non_empty(&mut session, &state_table_name, "after recovery").await?;
 
     // Progress table should still be empty
     let progress_count_after = session
@@ -119,11 +120,11 @@ async fn test_locality_backfill_recovery_internal_tables() -> Result<()> {
         "Progress table should still be empty after recovery"
     );
 
-    // Step 10: Remove rate limit and wait for completion
+    // Step 9: Remove rate limit and wait for completion
     session.run(ALTER_RATE_LIMIT_DEFAULT).await?;
     session.run(WAIT).await?;
 
-    // Step 11: Verify MV result
+    // Step 10: Verify MV result
     // Each value from 1 to 10000 appears once, so count(*) group by a should give 10000 rows with count=1
     let mv_count = session.run("SELECT COUNT(*) FROM mv;").await?;
     assert_eq!(

--- a/src/tests/simulation/tests/integration_tests/scale/backfill_parallelism.rs
+++ b/src/tests/simulation/tests/integration_tests/scale/backfill_parallelism.rs
@@ -298,7 +298,7 @@ async fn test_backfill_parallelism_persists_after_recovery() -> Result<()> {
     wait_parallelism(&mut session, "m", "2").await?;
 
     // Eventually backfill finishes and parallelism restores to the normal value.
-    wait_jobs_finished(&mut session).await?;
+    wait_jobs_finished_with_multiplier(&mut session, 60).await?;
     wait_parallelism(&mut session, "m", "4").await?;
 
     Ok(())


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

This PR cherry-picks the snapshot backfill rate-limit fix from `wenym1/concurrent-expr-chunks`.

Snapshot backfill now uses a `MonitoredRateLimiter` and waits on each emitted chunk's cardinality before yielding the chunk. Throttle mutations update the monitored limiter, while the snapshot iterator still receives the current rate limit so iterator-side throttling remains in sync.

This avoids only gating snapshot output by per-epoch row counts and makes the configured snapshot backfill rate limit apply to the chunks actually sent downstream.

- Closes: N/A

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [x] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->

## Local checks

- `cargo clippy --all-targets --all-features` failed because the local filesystem ran out of space while writing cargo artifacts: `No space left on device`.

## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

N/A.

</details>
