### PR TITLE
feat(frontend): allow snapshot-free sink queries

### DIFF
--- a/e2e_test/sink/append_only_sink.slt
+++ b/e2e_test/sink/append_only_sink.slt
@@ -23,6 +23,23 @@ statement error unsupported sink type invalid
 create sink invalid_connector from t with (connector = 'invalid');
 
 statement ok
+create table snapshot_free_t (id int primary key, v1 int, v2 int);
+
+statement ok
+create sink snapshot_free_project_filter as
+select id, v1 + 1 as projected_v1
+from snapshot_free_t
+where v2 > 10
+with (connector = 'blackhole', snapshot = 'false');
+
+statement error upsert stream is not supported
+create sink snapshot_free_agg as
+select v2, count(*) as cnt
+from snapshot_free_t
+group by v2
+with (connector = 'blackhole', snapshot = 'false');
+
+statement ok
 set sink_decouple=false;
 
 statement error
@@ -54,6 +71,12 @@ drop sink s2
 
 statement ok
 drop sink s3
+
+statement ok
+drop sink snapshot_free_project_filter
+
+statement ok
+drop table snapshot_free_t
 
 statement ok
 drop table t

--- a/e2e_test/sink/kafka/create_sink.slt
+++ b/e2e_test/sink/kafka/create_sink.slt
@@ -270,11 +270,11 @@ insert into t_kafka values
     (6, 'V4y71v4Gip', 4014, 10844, 28842, 5885.368, 11210.458724794062, '2023-04-13 10:42:02.137742', '\xCAFEBABE', '4 hour', '0001-01-01', '00:00:01.123456', '0001-01-01 00:00:00.123456'::timestamptz, '{}'),
     (7, 'YIVLnWxHyf', 10324, 12652, 15914, 3946.7434, 10967.182297153104, '2023-04-14 04:41:03.083742', '\xBABEC0DE', '3 day', '0001-01-01', '01:00:01.123456', '0001-01-01 00:00:00.123456'::timestamptz, '{}');
 
-statement error
-create sink si_kafka_without_snapshot as select * from t_kafka with (
+statement ok
+create sink si_kafka_without_snapshot_as as select * from t_kafka with (
     connector = 'kafka',
     properties.bootstrap.server = 'message_queue:29092',
-    topic = 'test-rw-sink-without-snapshot',
+    topic = 'test-rw-sink-as-without-snapshot',
     type = 'append-only',
     force_append_only = 'true',
     primary_key = 'id',

--- a/e2e_test/sink/kafka/drop_sink.slt
+++ b/e2e_test/sink/kafka/drop_sink.slt
@@ -14,6 +14,9 @@ statement ok
 drop sink si_kafka_without_snapshot;
 
 statement ok
+drop sink si_kafka_without_snapshot_as;
+
+statement ok
 drop sink sink_text_id;
 
 statement ok

--- a/e2e_test/sink/sink_into_table/snapshot.slt
+++ b/e2e_test/sink/sink_into_table/snapshot.slt
@@ -28,6 +28,49 @@ select * from t;
 2	22
 
 statement ok
+create table snapshot_free_src (id int primary key, v int);
+
+statement ok
+insert into snapshot_free_src values (1, 10), (20, 20);
+
+statement ok
+create table snapshot_free_target (id int primary key, projected_v int);
+
+statement ok
+create sink snapshot_free_sink into snapshot_free_target as
+select id, v + 100 as projected_v
+from snapshot_free_src
+where id >= 10
+with (snapshot = 'false');
+
+query II
+select * from snapshot_free_target order by id;
+----
+
+statement ok
+insert into snapshot_free_src values (2, 200), (10, 10), (11, 11);
+
+statement ok
+update snapshot_free_src set v = 15 where id = 10;
+
+statement ok
+delete from snapshot_free_src where id in (11, 20);
+
+query II
+select * from snapshot_free_target order by id;
+----
+10	115
+
+statement ok
+drop sink snapshot_free_sink;
+
+statement ok
+drop table snapshot_free_target;
+
+statement ok
+drop table snapshot_free_src;
+
+statement ok
 drop sink s1;
 
 statement ok

--- a/src/frontend/planner_test/tests/testdata/input/sink.yaml
+++ b/src/frontend/planner_test/tests/testdata/input/sink.yaml
@@ -251,3 +251,10 @@
     with (type = 'append-only', force_append_only = 'true');
   expected_outputs:
     - explain_output
+- id: create_snapshot_free_sink_query_with_project_filter
+  sql: |
+    create table t (id int primary key, v1 int, v2 int);
+    explain (verbose) create sink s as select id, v1 + 1 as v1 from t where v2 > 10
+    with (connector = 'blackhole', snapshot = 'false');
+  expected_outputs:
+    - explain_output

--- a/src/frontend/planner_test/tests/testdata/output/sink.yaml
+++ b/src/frontend/planner_test/tests/testdata/output/sink.yaml
@@ -380,3 +380,13 @@
           │ └─StreamTableScan { table: t, columns: [v1, _row_id] }
           └─StreamExchange { dist: HashShard(t.v1) }
             └─StreamTableScan { table: t, columns: [v1, v2, _row_id] }
+- id: create_snapshot_free_sink_query_with_project_filter
+  sql: |
+    create table t (id int primary key, v1 int, v2 int);
+    explain (verbose) create sink s as select id, v1 + 1 as v1 from t where v2 > 10
+    with (connector = 'blackhole', snapshot = 'false');
+  explain_output: |
+    StreamSink { type: upsert, columns: [id, v1] }
+    └─StreamProject { exprs: [t.id, (t.v1 + 1:Int32) as $expr1] }
+      └─StreamFilter [upsert] { predicate: (t.v2 > 10:Int32) }
+        └─StreamTableScan { table: t, columns: [t.id, t.v1, t.v2], stream_scan_type: UpstreamOnly, stream_key: [t.id], pk: [id], dist: UpstreamHashShard(t.id) }

--- a/src/frontend/src/handler/create_sink.rs
+++ b/src/frontend/src/handler/create_sink.rs
@@ -381,19 +381,10 @@ pub async fn gen_sink_plan(
         plan_root.set_out_names(col_names.clone())?;
     };
 
-    let without_backfill = match resolved_with_options.remove(SINK_SNAPSHOT_OPTION) {
-        Some(flag) if flag.eq_ignore_ascii_case("false") => {
-            if direct_sink_from_name.is_some() || is_iceberg_engine_internal {
-                true
-            } else {
-                return Err(ErrorCode::BindError(
-                    "`snapshot = false` only support `CREATE SINK FROM MV or TABLE`".to_owned(),
-                )
-                .into());
-            }
-        }
-        _ => false,
-    };
+    let without_backfill = matches!(
+        resolved_with_options.remove(SINK_SNAPSHOT_OPTION),
+        Some(flag) if flag.eq_ignore_ascii_case("false")
+    );
 
     let target_table_catalog = stmt
         .into_table_name

--- a/src/frontend/src/optimizer/mod.rs
+++ b/src/frontend/src/optimizer/mod.rs
@@ -1171,7 +1171,7 @@ impl LogicalPlanRoot {
         allow_snapshot_backfill: bool,
     ) -> Result<StreamSink> {
         let backfill_type = if without_backfill {
-            BackfillType::UpstreamOnly
+            BackfillType::UpstreamOnlySink
         } else if allow_snapshot_backfill
             && self.should_use_snapshot_backfill()
             && {

--- a/src/frontend/src/optimizer/plan_node/convert.rs
+++ b/src/frontend/src/optimizer/plan_node/convert.rs
@@ -150,18 +150,27 @@ impl RewriteStreamContext {
     }
 }
 
-#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
 pub enum BackfillType {
-    UpstreamOnly,
+    Replicated,
+    /// Frontend-only variant for snapshot-free sinks. It is serialized as
+    /// `StreamScanType::UpstreamOnly`, but derives an upsert stream kind.
+    UpstreamOnlySink,
     Backfill,
     ArrangementBackfill,
     SnapshotBackfill,
 }
 
 impl BackfillType {
-    pub fn to_stream_scan_type(self) -> StreamScanType {
+    pub fn to_stream_scan_type(self, is_cross_db: bool) -> StreamScanType {
+        if is_cross_db {
+            return StreamScanType::CrossDbSnapshotBackfill;
+        }
+
         match self {
-            BackfillType::UpstreamOnly => StreamScanType::UpstreamOnly,
+            BackfillType::Replicated | BackfillType::UpstreamOnlySink => {
+                StreamScanType::UpstreamOnly
+            }
             BackfillType::Backfill => StreamScanType::Backfill,
             BackfillType::ArrangementBackfill => StreamScanType::ArrangementBackfill,
             BackfillType::SnapshotBackfill => StreamScanType::SnapshotBackfill,

--- a/src/frontend/src/optimizer/plan_node/logical_join.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_join.rs
@@ -21,7 +21,6 @@ use pretty_xmlish::{Pretty, XmlNode};
 use risingwave_expr::bail;
 use risingwave_pb::expr::expr_node::PbType;
 use risingwave_pb::plan_common::{AsOfJoinDesc, JoinType, PbAsOfJoinInequalityType};
-use risingwave_pb::stream_plan::StreamScanType;
 use risingwave_sqlparser::ast::AsOf;
 
 use super::generic::{
@@ -1229,7 +1228,7 @@ impl LogicalJoin {
             .collect_vec();
 
         let new_stream_table_scan =
-            StreamTableScan::new_with_stream_scan_type(new_scan, StreamScanType::UpstreamOnly);
+            StreamTableScan::new_with_backfill_type(new_scan, BackfillType::Replicated);
         Ok((
             new_stream_table_scan,
             new_predicate,

--- a/src/frontend/src/optimizer/plan_node/logical_scan.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_scan.rs
@@ -620,7 +620,12 @@ impl ToStream for LogicalScan {
         ctx: &mut ToStreamContext,
     ) -> Result<crate::optimizer::plan_node::StreamPlanRef> {
         if self.predicate().always_true() {
-            if self.core.cross_database() && ctx.backfill_type() == BackfillType::UpstreamOnly {
+            if self.core.cross_database()
+                && matches!(
+                    ctx.backfill_type(),
+                    BackfillType::Replicated | BackfillType::UpstreamOnlySink
+                )
+            {
                 return Err(ErrorCode::NotSupported(
                     "We currently do not support cross database scan in upstream only mode."
                         .to_owned(),
@@ -629,11 +634,10 @@ impl ToStream for LogicalScan {
                 .into());
             }
 
-            Ok(StreamTableScan::new_with_stream_scan_type(
-                self.core.clone(),
-                ctx.backfill_type().to_stream_scan_type(),
+            Ok(
+                StreamTableScan::new_with_backfill_type(self.core.clone(), ctx.backfill_type())
+                    .into(),
             )
-            .into())
         } else {
             if ctx.backfill_type() == BackfillType::SnapshotBackfill {
                 let (scan_ranges, _residual) = self.predicate().clone().split_to_scan_ranges(
@@ -646,7 +650,7 @@ impl ToStream for LogicalScan {
                     let (core, predicate, project_expr) = self.predicate_pull_up();
                     let scan = StreamTableScan::new_with_scan_range(
                         core,
-                        ctx.backfill_type().to_stream_scan_type(),
+                        ctx.backfill_type(),
                         Some(scan_ranges.into_iter().next().unwrap()),
                     );
                     LogicalFilter::check_stream_predicate(&predicate)?;

--- a/src/frontend/src/optimizer/plan_node/stream_table_scan.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_table_scan.rs
@@ -92,14 +92,18 @@ impl StreamTableScan {
             }
         };
 
+        let stream_kind = if core.append_only() {
+            StreamKind::AppendOnly
+        } else if stream_scan_type == StreamScanType::UpstreamOnly {
+            StreamKind::Upsert
+        } else {
+            StreamKind::Retract
+        };
+
         let base = PlanBase::new_stream_with_core(
             &core,
             distribution,
-            if core.append_only() {
-                StreamKind::AppendOnly
-            } else {
-                StreamKind::Retract
-            },
+            stream_kind,
             false,
             core.watermark_columns(),
             MonotonicityMap::new(),

--- a/src/frontend/src/optimizer/plan_node/stream_table_scan.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_table_scan.rs
@@ -28,7 +28,10 @@ use risingwave_pb::stream_plan::{PbStreamNode, StreamScanType};
 
 use super::stream::prelude::*;
 use super::utils::{Distill, childless_record};
-use super::{ExprRewritable, PlanBase, PlanNodeId, StreamNode, StreamPlanRef as PlanRef, generic};
+use super::{
+    BackfillType, ExprRewritable, PlanBase, PlanNodeId, StreamNode, StreamPlanRef as PlanRef,
+    generic,
+};
 use crate::TableCatalog;
 use crate::catalog::ColumnId;
 use crate::expr::{ExprRewriter, ExprVisitor, FunctionCall};
@@ -46,7 +49,7 @@ pub struct StreamTableScan {
     pub base: PlanBase<Stream>,
     core: generic::TableScan,
     batch_plan_id: PlanNodeId,
-    stream_scan_type: StreamScanType,
+    backfill_type: BackfillType,
     pk_scan_range: Option<ScanRange>,
 }
 
@@ -57,25 +60,25 @@ impl StreamTableScan {
     pub const ROW_COUNT_COLUMN_NAME: &str = "row_count";
     pub const VNODE_COLUMN_NAME: &str = "vnode";
 
-    pub fn new_with_stream_scan_type(
-        core: generic::TableScan,
-        stream_scan_type: StreamScanType,
-    ) -> Self {
-        Self::new_with_scan_range(core, stream_scan_type, None)
+    pub fn new_with_backfill_type(core: generic::TableScan, backfill_type: BackfillType) -> Self {
+        Self::new_with_scan_range(core, backfill_type, None)
     }
 
     pub fn new_with_scan_range(
         core: generic::TableScan,
-        stream_scan_type: StreamScanType,
+        backfill_type: BackfillType,
         pk_scan_range: Option<ScanRange>,
     ) -> Self {
         let batch_plan_id = core.ctx.next_plan_node_id();
 
-        let mut stream_scan_type = stream_scan_type;
         if core.cross_database() {
-            assert_ne!(stream_scan_type, StreamScanType::UpstreamOnly);
-            // Force rewrite scan type to cross-db scan
-            stream_scan_type = StreamScanType::CrossDbSnapshotBackfill;
+            assert!(
+                !matches!(
+                    backfill_type,
+                    BackfillType::Replicated | BackfillType::UpstreamOnlySink
+                ),
+                "cross-database upstream-only scan is not supported"
+            );
         }
 
         let distribution = {
@@ -94,7 +97,7 @@ impl StreamTableScan {
 
         let stream_kind = if core.append_only() {
             StreamKind::AppendOnly
-        } else if stream_scan_type == StreamScanType::UpstreamOnly {
+        } else if backfill_type == BackfillType::UpstreamOnlySink {
             StreamKind::Upsert
         } else {
             StreamKind::Retract
@@ -112,7 +115,7 @@ impl StreamTableScan {
             base,
             core,
             batch_plan_id,
-            stream_scan_type,
+            backfill_type,
             pk_scan_range,
         }
     }
@@ -130,7 +133,7 @@ impl StreamTableScan {
         index_table_catalog: Arc<TableCatalog>,
         primary_to_secondary_mapping: &BTreeMap<usize, usize>,
         function_mapping: &HashMap<FunctionCall, usize>,
-        stream_scan_type: StreamScanType,
+        backfill_type: BackfillType,
     ) -> StreamTableScan {
         let logical_index_scan = self.core.to_index_scan(
             index_table_catalog,
@@ -140,11 +143,16 @@ impl StreamTableScan {
         logical_index_scan
             .distribution_key()
             .expect("distribution key of stream chain must exist in output columns");
-        StreamTableScan::new_with_stream_scan_type(logical_index_scan, stream_scan_type)
+        StreamTableScan::new_with_backfill_type(logical_index_scan, backfill_type)
     }
 
     pub fn stream_scan_type(&self) -> StreamScanType {
-        self.stream_scan_type
+        self.backfill_type
+            .to_stream_scan_type(self.core.cross_database())
+    }
+
+    pub fn backfill_type(&self) -> BackfillType {
+        self.backfill_type
     }
 
     pub fn pk_scan_range(&self) -> Option<&ScanRange> {
@@ -333,7 +341,7 @@ impl Distill for StreamTableScan {
         }
 
         if verbose {
-            vec.push(("stream_scan_type", Pretty::debug(&self.stream_scan_type)));
+            vec.push(("stream_scan_type", Pretty::debug(&self.stream_scan_type())));
             let stream_key = IndicesDisplay {
                 indices: self.stream_key().unwrap_or_default(),
                 schema: self.base.schema(),
@@ -383,7 +391,8 @@ impl StreamTableScan {
             .collect_vec();
 
         // The required columns from the table (both scan and upstream).
-        let upstream_column_ids = match self.stream_scan_type {
+        let stream_scan_type = self.stream_scan_type();
+        let upstream_column_ids = match stream_scan_type {
             // For backfill, we additionally need the primary key columns.
             StreamScanType::Backfill
             | StreamScanType::ArrangementBackfill
@@ -421,7 +430,7 @@ impl StreamTableScan {
         };
 
         let catalog = self
-            .build_backfill_state_catalog(state, self.stream_scan_type)
+            .build_backfill_state_catalog(state, stream_scan_type)
             .to_internal_table_prost();
 
         // For backfill, we first read pk + output_indices from upstream.
@@ -439,14 +448,14 @@ impl StreamTableScan {
             })
             .collect_vec();
 
-        let arrangement_table = if self.stream_scan_type == StreamScanType::ArrangementBackfill {
+        let arrangement_table = if stream_scan_type == StreamScanType::ArrangementBackfill {
             let upstream_table_catalog = self.get_upstream_state_table();
             Some(upstream_table_catalog.to_internal_table_prost())
         } else {
             None
         };
 
-        let input = if self.stream_scan_type == StreamScanType::CrossDbSnapshotBackfill {
+        let input = if stream_scan_type == StreamScanType::CrossDbSnapshotBackfill {
             vec![]
         } else {
             vec![
@@ -474,7 +483,7 @@ impl StreamTableScan {
 
         let node_body = PbNodeBody::StreamScan(Box::new(StreamScanNode {
             table_id: self.core.table_catalog.id,
-            stream_scan_type: self.stream_scan_type as i32,
+            stream_scan_type: stream_scan_type as i32,
             // The column indices need to be forwarded to the downstream
             output_indices,
             upstream_column_ids,
@@ -507,7 +516,7 @@ impl ExprRewritable<Stream> for StreamTableScan {
     fn rewrite_exprs(&self, r: &mut dyn ExprRewriter) -> PlanRef {
         let mut core = self.core.clone();
         core.rewrite_exprs(r);
-        Self::new_with_scan_range(core, self.stream_scan_type, self.pk_scan_range.clone()).into()
+        Self::new_with_scan_range(core, self.backfill_type, self.pk_scan_range.clone()).into()
     }
 }
 

--- a/src/frontend/src/optimizer/rule/index_delta_join_rule.rs
+++ b/src/frontend/src/optimizer/rule/index_delta_join_rule.rs
@@ -14,7 +14,6 @@
 
 use itertools::Itertools;
 use risingwave_pb::plan_common::JoinType;
-use risingwave_pb::stream_plan::StreamScanType;
 
 use crate::optimizer::plan_node::{Stream, StreamPlanRef as PlanRef, *};
 use crate::optimizer::rule::{BoxedRule, Rule};
@@ -52,10 +51,10 @@ impl Rule<Stream> for IndexDeltaJoinRule {
         fn match_indexes(
             join_indices: &[usize],
             table_scan: &StreamTableScan,
-            stream_scan_type: StreamScanType,
+            backfill_type: BackfillType,
         ) -> Option<PlanRef> {
             if table_scan.core().cross_database()
-                && stream_scan_type == StreamScanType::UpstreamOnly
+                && matches!(backfill_type, BackfillType::Replicated)
             {
                 // We currently do not support cross database index scan in upstream only mode.
                 return None;
@@ -102,7 +101,7 @@ impl Rule<Stream> for IndexDeltaJoinRule {
                             index.index_table.clone(),
                             p2s_mapping,
                             index.function_mapping(),
-                            stream_scan_type,
+                            backfill_type,
                         )
                         .into(),
                 );
@@ -126,11 +125,11 @@ impl Rule<Stream> for IndexDeltaJoinRule {
                     return None;
                 }
 
-                if stream_scan_type != table_scan.stream_scan_type() {
+                if backfill_type != table_scan.backfill_type() {
                     Some(
-                        StreamTableScan::new_with_stream_scan_type(
+                        StreamTableScan::new_with_backfill_type(
                             table_scan.core().clone(),
-                            stream_scan_type,
+                            backfill_type,
                         )
                         .into(),
                     )
@@ -145,9 +144,9 @@ impl Rule<Stream> for IndexDeltaJoinRule {
         // Delta join only needs to backfill one stream flow and others should be upstream only
         // chain. Here we choose the left one to backfill and right one to upstream only
         // chain.
-        if let Some(left) = match_indexes(&left_indices, input_left, StreamScanType::Backfill) {
+        if let Some(left) = match_indexes(&left_indices, input_left, BackfillType::Backfill) {
             if let Some(right) =
-                match_indexes(&right_indices, input_right, StreamScanType::UpstreamOnly)
+                match_indexes(&right_indices, input_right, BackfillType::Replicated)
             {
                 // We already ensured that index and join use the same distribution, so we directly
                 // replace the children with stream index scan without inserting any exchanges.


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

This PR allows `CREATE SINK AS SELECT ... WITH (snapshot = false)` when the stream plan can safely consume upstream-only table or MV changes as an upsert stream.

Previously, `snapshot = false` was rejected for all `CREATE SINK AS SELECT` queries unless the sink was created directly from a table/MV. The planner now:

- maps `snapshot = false` to upstream-only planning for sink queries;
- derives non-append-only upstream-only table scans as `StreamKind::Upsert` instead of `Retract`;
- relies on existing upsert-input checks to reject operators that require retractable input, such as aggregation and join;
- keeps append-only sink validation unchanged, so append-only sinks over upsert streams still require `force_append_only` / `ignore_delete`.

This enables the intended project/filter use case while preserving automatic rejection for unsupported stream plans.

No issue.

## Checklist

- [ ] I have written necessary rustdoc comments.
- [x] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [x] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [x] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

`CREATE SINK AS SELECT ... WITH (snapshot = false)` can now be used for upsert-safe sink queries such as projection and filtering from a table or materialized view. Queries containing operators that require retractable input are still rejected.

</details>
