### PR TITLE
fix(optimizer): allow unsafe impure project expressions

### DIFF
--- a/src/frontend/planner_test/tests/testdata/input/project.yaml
+++ b/src/frontend/planner_test/tests/testdata/input/project.yaml
@@ -12,7 +12,8 @@
   sql: create table t (id int, value string) append only;
   expected_outputs: []
 # Test openai_embedding function with MaterializedExprs for impure function
-- before:
+- name: materialize impure select-list expressions by default on upsert stream
+  before:
     - create_table
   sql: |
     select id, value, openai_embedding('{"api_key":"sk-test-key", "model": "text-embedding-3-small"}'::jsonb, value) as embedding
@@ -20,6 +21,15 @@
   expected_outputs:
     - logical_plan
     - batch_plan
+    - stream_plan
+- name: skip impure select-list materialization with unsafe session option
+  before:
+    - create_table
+  sql: |
+    set streaming_unsafe_allow_unmaterialized_impure_expr = true;
+    select id, value, openai_embedding('{"api_key":"sk-test-key", "model": "text-embedding-3-small"}'::jsonb, value) as embedding
+    from t;
+  expected_outputs:
     - stream_plan
 # Test mixed pure and impure expressions with openai_embedding
 - before:

--- a/src/frontend/planner_test/tests/testdata/output/project.yaml
+++ b/src/frontend/planner_test/tests/testdata/output/project.yaml
@@ -8,7 +8,8 @@
   sql: create table t (id int, value string);
 - id: create_append_only_table
   sql: create table t (id int, value string) append only;
-- before:
+- name: materialize impure select-list expressions by default on upsert stream
+  before:
   - create_table
   sql: |
     select id, value, openai_embedding('{"api_key":"sk-test-key", "model": "text-embedding-3-small"}'::jsonb, value) as embedding
@@ -25,6 +26,17 @@
     └─StreamProject { exprs: [t.id, t.value, $expr1, t._row_id] }
       └─StreamMaterializedExprs { exprs: [OpenaiEmbedding('{"api_key": "sk-test-key", "model": "text-embedding-3-small"}':Jsonb, t.value) as $expr1] }
         └─StreamTableScan { table: t, columns: [t.id, t.value, t._row_id], stream_scan_type: SnapshotBackfill, stream_key: [t._row_id], pk: [_row_id], dist: UpstreamHashShard(t._row_id) }
+- name: skip impure select-list materialization with unsafe session option
+  before:
+  - create_table
+  sql: |
+    set streaming_unsafe_allow_unmaterialized_impure_expr = true;
+    select id, value, openai_embedding('{"api_key":"sk-test-key", "model": "text-embedding-3-small"}'::jsonb, value) as embedding
+    from t;
+  stream_plan: |-
+    StreamMaterialize { columns: [id, value, embedding, t._row_id(hidden)], stream_key: [t._row_id], pk_columns: [t._row_id], pk_conflict: NoCheck }
+    └─StreamProject { exprs: [t.id, t.value, OpenaiEmbedding('{"api_key": "sk-test-key", "model": "text-embedding-3-small"}':Jsonb, t.value) as $expr1, t._row_id] }
+      └─StreamTableScan { table: t, columns: [t.id, t.value, t._row_id], stream_scan_type: SnapshotBackfill, stream_key: [t._row_id], pk: [_row_id], dist: UpstreamHashShard(t._row_id) }
 - before:
   - create_table
   sql: |

--- a/src/frontend/src/optimizer/plan_node/logical_project.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_project.rs
@@ -33,6 +33,7 @@ use crate::optimizer::plan_node::{
     ColumnPruningContext, PredicatePushdownContext, RewriteStreamContext, ToStreamContext,
 };
 use crate::optimizer::property::{Distribution, Order, RequiredDist, StreamKind};
+use crate::session::current;
 use crate::utils::{ColIndexMapping, ColIndexMappingRewriteExt, Condition, Substitute};
 
 /// `LogicalProject` computes a set of expressions from its input relation.
@@ -258,8 +259,22 @@ impl ToStream for LogicalProject {
             .input()
             .to_stream_with_dist_required(&input_required, ctx)?;
 
+        let unsafe_allow_unmaterialized_impure_expr = current::config()
+            .map(|c| c.read().streaming_unsafe_allow_unmaterialized_impure_expr())
+            .unwrap_or_else(|| {
+                self.base
+                    .ctx()
+                    .session_ctx()
+                    .config()
+                    .streaming_unsafe_allow_unmaterialized_impure_expr()
+            });
         let should_materialize_expr = match new_input.stream_kind() {
             StreamKind::AppendOnly => None,
+            StreamKind::Retract | StreamKind::Upsert if unsafe_allow_unmaterialized_impure_expr => {
+                // This deliberately leaves impure expressions in `StreamProject` on retract/upsert
+                // streams. The behavior is unsafe and only enabled by the explicit session option.
+                None
+            }
             kind @ (StreamKind::Retract | StreamKind::Upsert) => {
                 // Extract impure functions to `MaterializedExprs` operator
                 let mut impure_field_names = BTreeMap::new();


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

This PR makes the existing session variable `streaming_unsafe_allow_unmaterialized_impure_expr` also control `StreamMaterializedExprs` insertion for impure select-list expressions in `LogicalProject`.

When the option is false, the planner keeps the existing default behavior and materializes impure select-list expressions on retract/upsert streams. When the option is true, the planner intentionally leaves those impure expressions directly in `StreamProject`, matching the unsafe opt-out already used by stream plan protobuf purity checks.

This is needed for native sink plans that intentionally select impure embedding expressions such as `get_embedding(...)::vector(...)` on retract/upsert streams.

## Checklist

- [ ] I have written necessary rustdoc comments.
- [x] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [x] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

`SET streaming_unsafe_allow_unmaterialized_impure_expr = true` now also skips planner-inserted materialization for impure select-list expressions on retract/upsert streams, leaving them in `StreamProject` directly. The default behavior is unchanged.

</details>
