### PR TITLE
feat(frontend): support make_interval named args

### DIFF
--- a/e2e_test/batch/basic/make_time.slt.part
+++ b/e2e_test/batch/basic/make_time.slt.part
@@ -183,3 +183,46 @@ query T
 select '0001-01-01 12:34:56'::timestamptz - '10 year'::interval;
 ----
 0010-01-01 12:34:56+00:00 BC
+
+query T
+SELECT make_interval();
+----
+00:00:00
+
+query T
+SELECT make_interval(1, 2, 3, 4, 5, 6, 7.8);
+----
+1 year 2 mons 25 days 05:06:07.8
+
+query T
+SELECT make_interval(days => 10);
+----
+10 days
+
+query T
+SELECT make_interval(weeks => 2, days => 3);
+----
+17 days
+
+query T
+SELECT make_interval(1, days => 2);
+----
+1 year 2 days
+
+query IT
+WITH input(some_col) AS (VALUES (10), (NULL::int))
+SELECT some_col, make_interval(days => some_col)
+FROM input
+ORDER BY some_col NULLS LAST;
+----
+10 10 days
+NULL NULL
+
+statement error specified more than once
+SELECT make_interval(days => 1, days => 2);
+
+statement error no argument named
+SELECT make_interval(day => 1);
+
+statement error positional argument cannot follow named argument
+SELECT make_interval(days => 1, 2);

--- a/e2e_test/batch/basic/make_time.slt.part
+++ b/e2e_test/batch/basic/make_time.slt.part
@@ -200,6 +200,11 @@ SELECT make_interval(days => 10);
 10 days
 
 query T
+SELECT make_interval(days := 10);
+----
+10 days
+
+query T
 SELECT make_interval(weeks => 2, days => 3);
 ----
 17 days
@@ -226,3 +231,23 @@ SELECT make_interval(day => 1);
 
 statement error positional argument cannot follow named argument
 SELECT make_interval(days => 1, 2);
+
+statement ok
+DROP SCHEMA IF EXISTS make_interval_schema CASCADE;
+
+statement ok
+CREATE SCHEMA make_interval_schema;
+
+statement ok
+CREATE FUNCTION make_interval_schema.make_interval(i int)
+RETURNS int
+LANGUAGE sql
+AS $$ select i + 100 $$;
+
+query I
+SELECT make_interval_schema.make_interval(1);
+----
+101
+
+statement ok
+DROP SCHEMA make_interval_schema CASCADE;

--- a/src/frontend/src/binder/expr/function/mod.rs
+++ b/src/frontend/src/binder/expr/function/mod.rs
@@ -186,7 +186,7 @@ impl Binder {
             }
         }
 
-        if func_name == "make_interval" {
+        if schema_name.is_none() && func_name == "make_interval" {
             if has_secret_ref_arg {
                 return Err(ErrorCode::InvalidInputSyntax(
                     "secret reference is only allowed in user-defined function arguments"
@@ -374,22 +374,11 @@ impl Binder {
         }
 
         // now it's a scalar/table function call
-        reject_syntax!(
-            arg_list.distinct,
-            "`DISTINCT` is not allowed in scalar/table function call"
-        );
-        reject_syntax!(
-            !arg_list.order_by.is_empty(),
-            "`ORDER BY` is not allowed in scalar/table function call"
-        );
-        reject_syntax!(
-            within_group.is_some(),
-            "`WITHIN GROUP` is not allowed in scalar/table function call"
-        );
-        reject_syntax!(
-            filter.is_some(),
-            "`FILTER` is not allowed in scalar/table function call"
-        );
+        Self::reject_scalar_table_function_syntax(
+            arg_list,
+            within_group.as_deref(),
+            filter.as_deref(),
+        )?;
 
         // try to bind it as a table function call
         {
@@ -503,33 +492,18 @@ impl Binder {
         self.bind_builtin_scalar_function(&func_name, args, arg_list.variadic)
     }
 
-    fn validate_and_bind_make_interval_params(
-        &mut self,
-        scalar_as_agg: bool,
+    fn reject_scalar_table_function_syntax(
         arg_list: &FunctionArgList,
         within_group: Option<&OrderByExpr>,
-        filter: Option<&risingwave_sqlparser::ast::Expr>,
-        over: Option<&Window>,
-    ) -> Result<ExprImpl> {
-        reject_syntax!(
-            scalar_as_agg,
-            "`AGGREGATE:` prefix is not allowed for `make_interval`"
-        );
+        filter: Option<&AstExpr>,
+    ) -> Result<()> {
         reject_syntax!(
             arg_list.distinct,
             "`DISTINCT` is not allowed in scalar/table function call"
         );
         reject_syntax!(
-            arg_list.variadic,
-            "`VARIADIC` is not allowed in scalar function call"
-        );
-        reject_syntax!(
             !arg_list.order_by.is_empty(),
             "`ORDER BY` is not allowed in scalar/table function call"
-        );
-        reject_syntax!(
-            arg_list.ignore_nulls,
-            "`IGNORE NULLS` is not allowed in aggregate/scalar/table function call"
         );
         reject_syntax!(
             within_group.is_some(),
@@ -539,10 +513,46 @@ impl Binder {
             filter.is_some(),
             "`FILTER` is not allowed in scalar/table function call"
         );
+
+        Ok(())
+    }
+
+    fn reject_scalar_function_syntax(
+        arg_list: &FunctionArgList,
+        within_group: Option<&OrderByExpr>,
+        filter: Option<&AstExpr>,
+        over: Option<&Window>,
+    ) -> Result<()> {
+        Self::reject_scalar_table_function_syntax(arg_list, within_group, filter)?;
+        reject_syntax!(
+            arg_list.variadic,
+            "`VARIADIC` is not allowed in scalar function call"
+        );
+        reject_syntax!(
+            arg_list.ignore_nulls,
+            "`IGNORE NULLS` is not allowed in aggregate/scalar/table function call"
+        );
         reject_syntax!(
             over.is_some(),
             "`OVER` is not allowed in scalar function call"
         );
+
+        Ok(())
+    }
+
+    fn validate_and_bind_make_interval_params(
+        &mut self,
+        scalar_as_agg: bool,
+        arg_list: &FunctionArgList,
+        within_group: Option<&OrderByExpr>,
+        filter: Option<&AstExpr>,
+        over: Option<&Window>,
+    ) -> Result<ExprImpl> {
+        reject_syntax!(
+            scalar_as_agg,
+            "`AGGREGATE:` prefix is not allowed for `make_interval`"
+        );
+        Self::reject_scalar_function_syntax(arg_list, within_group, filter, over)?;
 
         self.bind_make_interval(&arg_list.args)
     }

--- a/src/frontend/src/binder/expr/function/mod.rs
+++ b/src/frontend/src/binder/expr/function/mod.rs
@@ -21,7 +21,7 @@ use itertools::Itertools;
 use risingwave_common::acl::AclMode;
 use risingwave_common::bail_not_implemented;
 use risingwave_common::catalog::INFORMATION_SCHEMA_SCHEMA_NAME;
-use risingwave_common::types::{DataType, MapType, StructType};
+use risingwave_common::types::{DataType, Interval, MapType, ScalarImpl, StructType};
 use risingwave_common::util::iter_util::ZipEqFast;
 use risingwave_expr::aggregate::AggType;
 use risingwave_expr::window_function::WindowFuncKind;
@@ -37,8 +37,8 @@ use crate::catalog::OwnedByUserCatalog;
 use crate::catalog::function_catalog::FunctionCatalog;
 use crate::error::{ErrorCode, Result, RwError};
 use crate::expr::{
-    Expr, ExprImpl, ExprType, FunctionCall, FunctionCallWithLambda, InputRef, TableFunction,
-    TableFunctionType, UserDefinedFunction,
+    Expr, ExprImpl, ExprType, FunctionCall, FunctionCallWithLambda, InputRef, Literal,
+    TableFunction, TableFunctionType, UserDefinedFunction,
 };
 use crate::handler::privilege::ObjectCheckItem;
 
@@ -184,6 +184,23 @@ impl Binder {
                 )
                 .into());
             }
+        }
+
+        if func_name == "make_interval" {
+            if has_secret_ref_arg {
+                return Err(ErrorCode::InvalidInputSyntax(
+                    "secret reference is only allowed in user-defined function arguments"
+                        .to_owned(),
+                )
+                .into());
+            }
+            return self.validate_and_bind_make_interval_params(
+                *scalar_as_agg,
+                arg_list,
+                within_group.as_deref(),
+                filter.as_deref(),
+                over.as_ref(),
+            );
         }
 
         let bind_arg = if func_name.eq_ignore_ascii_case("jsonb_agg") {
@@ -484,6 +501,172 @@ impl Binder {
         }
 
         self.bind_builtin_scalar_function(&func_name, args, arg_list.variadic)
+    }
+
+    fn validate_and_bind_make_interval_params(
+        &mut self,
+        scalar_as_agg: bool,
+        arg_list: &FunctionArgList,
+        within_group: Option<&OrderByExpr>,
+        filter: Option<&risingwave_sqlparser::ast::Expr>,
+        over: Option<&Window>,
+    ) -> Result<ExprImpl> {
+        reject_syntax!(
+            scalar_as_agg,
+            "`AGGREGATE:` prefix is not allowed for `make_interval`"
+        );
+        reject_syntax!(
+            arg_list.distinct,
+            "`DISTINCT` is not allowed in scalar/table function call"
+        );
+        reject_syntax!(
+            arg_list.variadic,
+            "`VARIADIC` is not allowed in scalar function call"
+        );
+        reject_syntax!(
+            !arg_list.order_by.is_empty(),
+            "`ORDER BY` is not allowed in scalar/table function call"
+        );
+        reject_syntax!(
+            arg_list.ignore_nulls,
+            "`IGNORE NULLS` is not allowed in aggregate/scalar/table function call"
+        );
+        reject_syntax!(
+            within_group.is_some(),
+            "`WITHIN GROUP` is not allowed in scalar/table function call"
+        );
+        reject_syntax!(
+            filter.is_some(),
+            "`FILTER` is not allowed in scalar/table function call"
+        );
+        reject_syntax!(
+            over.is_some(),
+            "`OVER` is not allowed in scalar function call"
+        );
+
+        self.bind_make_interval(&arg_list.args)
+    }
+
+    fn bind_make_interval(&mut self, args: &[FunctionArg]) -> Result<ExprImpl> {
+        const FIELD_NAMES: [&str; 7] =
+            ["years", "months", "weeks", "days", "hours", "mins", "secs"];
+
+        let mut fields = vec![None; FIELD_NAMES.len()];
+        let mut positional_count = 0;
+        let mut has_named_arg = false;
+
+        for arg in args {
+            match arg {
+                FunctionArg::Unnamed(arg_expr) => {
+                    if has_named_arg {
+                        return Err(ErrorCode::BindError(
+                            "positional argument cannot follow named argument".to_owned(),
+                        )
+                        .into());
+                    }
+                    if positional_count >= FIELD_NAMES.len() {
+                        return Err(ErrorCode::ExprError(
+                            format!(
+                                "unexpected arguments number {}, expect at most {}",
+                                args.len(),
+                                FIELD_NAMES.len()
+                            )
+                            .into(),
+                        )
+                        .into());
+                    }
+
+                    let target_type = Self::make_interval_arg_type(positional_count);
+                    fields[positional_count] = Some(self.bind_make_interval_arg(
+                        arg_expr,
+                        FIELD_NAMES[positional_count],
+                        &target_type,
+                    )?);
+                    positional_count += 1;
+                }
+                FunctionArg::Named { name, arg } => {
+                    has_named_arg = true;
+                    let name = name.real_value();
+                    let Some(idx) = FIELD_NAMES.iter().position(|field| *field == name) else {
+                        return Err(ErrorCode::BindError(format!(
+                            "function make_interval has no argument named `{}`",
+                            name
+                        ))
+                        .into());
+                    };
+                    if fields[idx].is_some() {
+                        return Err(ErrorCode::BindError(format!(
+                            "argument `{}` specified more than once",
+                            name
+                        ))
+                        .into());
+                    }
+
+                    let target_type = Self::make_interval_arg_type(idx);
+                    fields[idx] = Some(self.bind_make_interval_arg(arg, &name, &target_type)?);
+                }
+            }
+        }
+
+        let mut interval = Self::interval_literal(Interval::from_month_day_usec(0, 0, 0));
+        for (idx, field) in fields.into_iter().enumerate() {
+            if let Some(field) = field {
+                let component = FunctionCall::new(
+                    ExprType::Multiply,
+                    vec![Self::make_interval_unit(idx), field],
+                )?
+                .into();
+                interval = FunctionCall::new(ExprType::Add, vec![interval, component])?.into();
+            }
+        }
+
+        Ok(interval)
+    }
+
+    fn bind_make_interval_arg(
+        &mut self,
+        arg_expr: &FunctionArgExpr,
+        arg_name: &str,
+        target_type: &DataType,
+    ) -> Result<ExprImpl> {
+        let mut args = self.bind_function_expr_arg(arg_expr)?;
+        if args.len() != 1 {
+            return Err(ErrorCode::BindError(format!(
+                "argument `{}` for make_interval must be a single expression",
+                arg_name
+            ))
+            .into());
+        }
+
+        let mut arg = args.pop().unwrap();
+        arg.cast_implicit_mut(target_type)?;
+        Ok(arg)
+    }
+
+    fn make_interval_arg_type(idx: usize) -> DataType {
+        if idx == 6 {
+            DataType::Float64
+        } else {
+            DataType::Int32
+        }
+    }
+
+    fn make_interval_unit(idx: usize) -> ExprImpl {
+        let interval = match idx {
+            0 => Interval::from_month_day_usec(12, 0, 0),
+            1 => Interval::from_month_day_usec(1, 0, 0),
+            2 => Interval::from_month_day_usec(0, 7, 0),
+            3 => Interval::from_month_day_usec(0, 1, 0),
+            4 => Interval::from_month_day_usec(0, 0, 60 * 60 * Interval::USECS_PER_SEC),
+            5 => Interval::from_month_day_usec(0, 0, 60 * Interval::USECS_PER_SEC),
+            6 => Interval::from_month_day_usec(0, 0, Interval::USECS_PER_SEC),
+            _ => unreachable!("invalid make_interval field index"),
+        };
+        Self::interval_literal(interval)
+    }
+
+    fn interval_literal(interval: Interval) -> ExprImpl {
+        Literal::new(Some(ScalarImpl::Interval(interval)), DataType::Interval).into()
     }
 
     fn validate_and_bind_special_function_params(

--- a/src/sqlparser/src/parser.rs
+++ b/src/sqlparser/src/parser.rs
@@ -6090,13 +6090,15 @@ impl Parser<'_> {
         Ok(Assignment { id, value })
     }
 
-    /// Parse a `[VARIADIC] name => expr`.
+    /// Parse a `[VARIADIC] name {=>|:=} expr`.
     fn parse_function_args(&mut self) -> ModalResult<(bool, FunctionArg)> {
         let variadic = self.parse_keyword(Keyword::VARIADIC);
-        let arg = if self.peek_nth_token(1) == Token::RArrow {
+        let arg = if matches!(self.peek_nth_token(1).token, Token::RArrow | Token::ColonEq) {
             let name = self.parse_identifier()?;
 
-            self.expect_token(&Token::RArrow)?;
+            if !self.consume_token(&Token::RArrow) {
+                self.expect_token(&Token::ColonEq)?;
+            }
             let arg = if self.parse_keyword(Keyword::SECRET) {
                 FunctionArgExpr::SecretRef(self.parse_secret_ref()?)
             } else {
@@ -6513,6 +6515,21 @@ mod tests {
 
         // Named secret argument
         run_parser_method("header => SECRET my_secret", |parser| {
+            let (_variadic, arg) = parser.parse_function_args().unwrap();
+            assert_eq!(
+                arg,
+                FunctionArg::Named {
+                    name: Ident::new_unchecked("header"),
+                    arg: FunctionArgExpr::SecretRef(SecretRefValue {
+                        secret_name: ObjectName(vec![Ident::new_unchecked("my_secret")]),
+                        ref_as: SecretRefAsType::Text,
+                    }),
+                }
+            );
+        });
+
+        // Legacy named secret argument
+        run_parser_method("header := SECRET my_secret", |parser| {
             let (_variadic, arg) = parser.parse_function_args().unwrap();
             assert_eq!(
                 arg,

--- a/src/sqlparser/src/tokenizer.rs
+++ b/src/sqlparser/src/tokenizer.rs
@@ -85,6 +85,8 @@ pub enum Token {
     Colon,
     /// DoubleColon `::` (used for casting in postgresql)
     DoubleColon,
+    /// ColonEquals `:=` (legacy named function argument syntax in postgresql)
+    ColonEq,
     /// SemiColon `;` used as separator for COPY and payload
     SemiColon,
     /// Backslash `\` used in terminating the COPY payload with `\.`
@@ -137,6 +139,7 @@ impl fmt::Display for Token {
             Token::Period => f.write_str("."),
             Token::Colon => f.write_str(":"),
             Token::DoubleColon => f.write_str("::"),
+            Token::ColonEq => f.write_str(":="),
             Token::SemiColon => f.write_str(";"),
             Token::Backslash => f.write_str("\\"),
             Token::LBracket => f.write_str("["),
@@ -561,6 +564,7 @@ impl<'a> Tokenizer<'a> {
                     self.next();
                     match self.peek() {
                         Some(':') => self.consume_and_return(Token::DoubleColon),
+                        Some('=') => self.consume_and_return(Token::ColonEq),
                         _ => Ok(Some(Token::Colon)),
                     }
                 }
@@ -1386,6 +1390,22 @@ mod tests {
             Token::LParen,
             Token::make_word("key", None),
             Token::RArrow,
+            Token::make_word("value", None),
+            Token::RParen,
+        ];
+        compare(expected, tokens);
+    }
+
+    #[test]
+    fn tokenize_colon_equals() {
+        let sql = String::from("FUNCTION(key:=value)");
+        let mut tokenizer = Tokenizer::new(&sql);
+        let tokens = tokenizer.tokenize_with_whitespace().unwrap();
+        let expected = vec![
+            Token::make_word("FUNCTION", None),
+            Token::LParen,
+            Token::make_word("key", None),
+            Token::ColonEq,
             Token::make_word("value", None),
             Token::RParen,
         ];

--- a/src/sqlparser/tests/sqlparser_common.rs
+++ b/src/sqlparser/tests/sqlparser_common.rs
@@ -2015,6 +2015,37 @@ fn parse_named_argument_function() {
         }),
         expr_from_projection(only(&select.projection))
     );
+
+    let sql = "SELECT FUN(a := '1', b := '2') FROM foo";
+    let select = match query(sql, "SELECT FUN(a => '1', b => '2') FROM foo").body {
+        SetExpr::Select(s) => *s,
+        _ => panic!("Expected SetExpr::Select"),
+    };
+
+    assert_eq!(
+        &Expr::Function(Function {
+            scalar_as_agg: false,
+            name: ObjectName(vec![Ident::new_unchecked("FUN")]),
+            arg_list: FunctionArgList::args_only(vec![
+                FunctionArg::Named {
+                    name: Ident::new_unchecked("a"),
+                    arg: FunctionArgExpr::Expr(Expr::Value(Value::SingleQuotedString(
+                        "1".to_owned()
+                    ))),
+                },
+                FunctionArg::Named {
+                    name: Ident::new_unchecked("b"),
+                    arg: FunctionArgExpr::Expr(Expr::Value(Value::SingleQuotedString(
+                        "2".to_owned()
+                    ))),
+                },
+            ]),
+            within_group: None,
+            filter: None,
+            over: None,
+        }),
+        expr_from_projection(only(&select.projection))
+    );
 }
 
 #[test]


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

- Closes #23763.
- Discussed the approach in the RisingWave Community Slack before opening this PR.
- Adds binder support for PostgreSQL-compatible `make_interval` calls, including named arguments like `make_interval(days => some_col)`.
- Supports the PostgreSQL argument order `years`, `months`, `weeks`, `days`, `hours`, `mins`, and `secs`, with omitted fields defaulting to zero.
- Rewrites `make_interval` to existing interval literal, multiplication, and addition expressions, so it reuses existing interval arithmetic, null propagation, coercion, and overflow behavior instead of adding a new scalar expression type.
- Adds SLT coverage for empty, positional, named, mixed positional-before-named, column-driven, duplicate-name, unknown-name, and positional-after-named cases.

## Checklist

- [x] I have written necessary rustdoc comments.
- [x] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [x] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [x] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

RisingWave now supports PostgreSQL-compatible `make_interval` calls for building intervals from integer and floating-point fields, including named arguments such as `make_interval(days => some_col)`.

</details>

## Local verification

- `cargo fmt --check`
- `git diff --check`
- `cargo check -p risingwave_frontend`
- `./risedev slt './e2e_test/batch/basic/make_time.slt.part'`
