### PR TITLE
feat(sink): support turbopuffer batching controls

### DIFF
--- a/e2e_test/sink/turbopuffer_sink.slt
+++ b/e2e_test/sink/turbopuffer_sink.slt
@@ -18,7 +18,8 @@ CREATE TABLE tpuf_e2e_items (
 
 statement ok
 INSERT INTO tpuf_e2e_items VALUES
-    ('delete-me', 'IFI-ns-1', 'to be deleted', ARRAY['old', 'row'], true, '2026-06-16 01:02:03+00:00', '[0.1,0.2,0.3]');
+    ('delete-me', 'IFI-ns-1', 'to be deleted', ARRAY['old', 'row'], true, '2026-06-16 01:02:03+00:00', '[0.1,0.2,0.3]'),
+    ('keep-me', 'IFI-ns-1', 'threshold row', ARRAY['old', 'row'], false, '2026-06-16 02:03:04', '[0.2,0.3,0.4]');
 
 statement ok
 CREATE SINK tpuf_e2e_sink FROM tpuf_e2e_items WITH (
@@ -37,12 +38,6 @@ CREATE SINK tpuf_e2e_sink FROM tpuf_e2e_items WITH (
 );
 
 statement ok
-ALTER SINK tpuf_e2e_sink CONNECTOR WITH (
-    write_batch_size = 3,
-    max_linger_second = 1
-);
-
-statement ok
 FLUSH;
 
 statement ok
@@ -54,6 +49,12 @@ INSERT INTO tpuf_e2e_items VALUES
 
 statement ok
 FLUSH;
+
+statement ok
+ALTER SINK tpuf_e2e_sink CONNECTOR WITH (
+    write_batch_size = 3,
+    max_linger_second = 1
+);
 
 statement ok
 DROP SINK tpuf_e2e_sink;

--- a/e2e_test/sink/turbopuffer_sink.slt
+++ b/e2e_test/sink/turbopuffer_sink.slt
@@ -1,5 +1,5 @@
 statement ok
-set sink_decouple = false;
+set sink_decouple = true;
 
 statement ok
 CREATE SECRET tpuf_api_key WITH (backend = 'meta') AS 'tpuf_test';
@@ -37,7 +37,10 @@ CREATE SINK tpuf_e2e_sink FROM tpuf_e2e_items WITH (
 );
 
 statement ok
-ALTER SINK tpuf_e2e_sink SET CONFIG (write_batch_size = 3, max_linger_second = 1);
+ALTER SINK tpuf_e2e_sink CONNECTOR WITH (
+    write_batch_size = 3,
+    max_linger_second = 1
+);
 
 statement ok
 FLUSH;
@@ -68,6 +71,24 @@ CREATE TABLE tpuf_items (
     published_at timestamp,
     vector vector(3)
 );
+
+# ---- Validation: Turbopuffer requires decoupled sink ----
+statement ok
+set sink_decouple = false;
+
+statement error Turbopuffer sink can only be created with sink_decouple enabled
+CREATE SINK tpuf_no_decouple FROM tpuf_items WITH (
+    connector = 'turbopuffer',
+    base_url = 'https://aws-us-east-2.turbopuffer.com',
+    namespace = 'IFI-no-decouple',
+    api_key = secret tpuf_api_key,
+    primary_key = 'id',
+    type = 'upsert',
+    distance_metric = 'cosine_distance'
+);
+
+statement ok
+set sink_decouple = true;
 
 # ---- Validation: static namespace success path ----
 statement ok

--- a/e2e_test/sink/turbopuffer_sink.slt
+++ b/e2e_test/sink/turbopuffer_sink.slt
@@ -31,8 +31,13 @@ CREATE SINK tpuf_e2e_sink FROM tpuf_e2e_items WITH (
     distance_metric = 'cosine_distance',
     disable_backpressure = 'true',
     full_text_search_columns = 'body,note_contents',
-    filterable_columns = '*'
+    filterable_columns = '*',
+    write_batch_size = 2,
+    max_linger_second = 1
 );
+
+statement ok
+ALTER SINK tpuf_e2e_sink SET CONFIG (write_batch_size = 3, max_linger_second = 1);
 
 statement ok
 FLUSH;

--- a/e2e_test/sink/turbopuffer_sink_check.py
+++ b/e2e_test/sink/turbopuffer_sink_check.py
@@ -59,8 +59,8 @@ def main():
     headers = read_json_lines(sys.argv[2])
     paths = read_lines(sys.argv[3])
 
-    if len(bodies) < 2:
-        raise AssertionError(f"expected at least 2 turbopuffer requests, got {len(bodies)}")
+    if not bodies:
+        raise AssertionError("expected at least 1 turbopuffer request, got 0")
     assert_equal(len(headers), len(bodies), "header/body request count mismatch")
     assert_equal(len(paths), len(bodies), "path/body request count mismatch")
 
@@ -71,16 +71,15 @@ def main():
         assert_equal(header.get("authorization"), "Bearer tpuf_test", "authorization header")
         assert "application/json" in header.get("content-type", ""), "content-type header"
 
-    backfill = find_body(
+    schema_body = find_body(
         bodies,
-        lambda body: "upsert_rows" in body
-        and any(row.get("id") == "delete-me" for row in body["upsert_rows"]),
-        "initial upsert for delete-me",
+        lambda body: "schema" in body,
+        "request with schema",
     )
-    assert_equal(backfill["distance_metric"], "cosine_distance", "distance metric")
-    assert_equal(backfill["disable_backpressure"], True, "disable_backpressure")
+    assert_equal(schema_body["distance_metric"], "cosine_distance", "distance metric")
+    assert_equal(schema_body["disable_backpressure"], True, "disable_backpressure")
 
-    schema = backfill["schema"]
+    schema = schema_body["schema"]
     assert_equal(schema["body"]["type"], "string", "body type")
     assert_equal(schema["body"]["filterable"], True, "body filterable")
     assert_equal(schema["body"]["full_text_search"], True, "body full_text_search")

--- a/e2e_test/sink/turbopuffer_sink_check.py
+++ b/e2e_test/sink/turbopuffer_sink_check.py
@@ -111,6 +111,11 @@ def main():
     rows = {row["id"]: row for row in upsert_request["upsert_rows"]}
     assert_equal(rows["upsert-me"]["body"], "inserted after delete", "upsert body")
     assert_equal(rows["upsert-me"]["note_contents"], ["new", "row"], "upsert note contents")
+    assert_equal(
+        rows["upsert-me"]["published_at"],
+        "2026-06-16T04:05:06.000000",
+        "upsert published_at",
+    )
     assert_float_list_close(rows["upsert-me"]["embedding"], [0.4, 0.5, 0.6], "upsert vector")
 
 

--- a/src/connector/src/allow_alter_on_fly_fields.rs
+++ b/src/connector/src/allow_alter_on_fly_fields.rs
@@ -291,6 +291,14 @@ pub static SINK_ALLOW_ALTER_ON_FLY_FIELDS: LazyLock<HashMap<String, HashSet<Stri
             "commit_checkpoint_interval".to_owned(),
         ].into_iter().collect(),
     ).unwrap();
+    // TurbopufferConfig
+    map.try_insert(
+        std::any::type_name::<TurbopufferConfig>().to_owned(),
+        [
+            "write_batch_size".to_owned(),
+            "max_linger_second".to_owned(),
+        ].into_iter().collect(),
+    ).unwrap();
     // Jdbc
     map.try_insert(
         JdbcSink::SINK_NAME.to_owned(),

--- a/src/connector/src/sink/encoder/json.rs
+++ b/src/connector/src/sink/encoder/json.rs
@@ -143,7 +143,7 @@ impl JsonEncoder {
         let config = JsonEncoderConfig {
             time_handling_mode: TimeHandlingMode::String,
             date_handling_mode: DateHandlingMode::String,
-            timestamp_handling_mode: TimestampHandlingMode::String,
+            timestamp_handling_mode: TimestampHandlingMode::Iso8601String,
             timestamptz_handling_mode: TimestamptzHandlingMode::UtcString,
             custom_json_type: CustomJsonType::Turbopuffer,
             jsonb_handling_mode: JsonbHandlingMode::Dynamic,
@@ -333,6 +333,9 @@ fn datum_to_json_object(
                 TimestampHandlingMode::Milli => json!(v.0.and_utc().timestamp_millis()),
                 TimestampHandlingMode::String => {
                     json!(v.0.format("%Y-%m-%d %H:%M:%S%.6f").to_string())
+                }
+                TimestampHandlingMode::Iso8601String => {
+                    json!(v.0.format("%Y-%m-%dT%H:%M:%S%.6f").to_string())
                 }
             }
         }

--- a/src/connector/src/sink/encoder/mod.rs
+++ b/src/connector/src/sink/encoder/mod.rs
@@ -100,6 +100,8 @@ pub enum DateHandlingMode {
 pub enum TimestampHandlingMode {
     Milli,
     String,
+    /// ISO 8601 string without a timezone suffix.
+    Iso8601String,
 }
 
 #[derive(Clone, Copy)]

--- a/src/connector/src/sink/turbopuffer.rs
+++ b/src/connector/src/sink/turbopuffer.rs
@@ -25,6 +25,7 @@ use reqwest::header::{AUTHORIZATION, CONTENT_TYPE, HeaderMap, HeaderValue};
 use risingwave_common::array::{Op, StreamChunk};
 use risingwave_common::catalog::Schema;
 use risingwave_common::row::Row;
+use risingwave_common::session_config::sink_decouple::SinkDecouple;
 use risingwave_common::types::{DataType, ScalarRefImpl};
 use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value};
@@ -255,6 +256,15 @@ impl Sink for TurbopufferSink {
 
     async fn validate(&self) -> Result<()> {
         Ok(())
+    }
+
+    fn is_sink_decouple(user_specified: &SinkDecouple) -> Result<bool> {
+        match user_specified {
+            SinkDecouple::Default | SinkDecouple::Enable => Ok(true),
+            SinkDecouple::Disable => Err(SinkError::Config(anyhow!(
+                "Turbopuffer sink can only be created with sink_decouple enabled"
+            ))),
+        }
     }
 
     async fn new_log_sinker(&self, writer_param: SinkWriterParam) -> Result<Self::LogSinker> {
@@ -992,6 +1002,17 @@ mod tests {
         ]))
         .unwrap_err();
         assert!(err.to_string().contains("max_linger_second"));
+    }
+
+    #[test]
+    fn test_requires_sink_decouple() {
+        assert!(TurbopufferSink::is_sink_decouple(&SinkDecouple::Default).unwrap());
+        assert!(TurbopufferSink::is_sink_decouple(&SinkDecouple::Enable).unwrap());
+        let err = TurbopufferSink::is_sink_decouple(&SinkDecouple::Disable).unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("Turbopuffer sink can only be created with sink_decouple enabled")
+        );
     }
 
     #[cfg(not(madsim))]

--- a/src/connector/src/sink/turbopuffer.rs
+++ b/src/connector/src/sink/turbopuffer.rs
@@ -779,7 +779,7 @@ fn supports_full_text_search(data_type: &DataType) -> bool {
 }
 
 // Mapping from RisingWave attribute types to generated turbopuffer schema types and
-// the JSON value shapes emitted by `JsonEncoder`:
+// the JSON value shapes sent to turbopuffer:
 //
 // | RisingWave type                  | turbopuffer type | JSON payload                  |
 // |----------------------------------|------------------|-------------------------------|
@@ -788,12 +788,13 @@ fn supports_full_text_search(data_type: &DataType) -> bool {
 // | float32, float64                 | float            | number                        |
 // | varchar                          | string           | string                        |
 // | date                             | datetime         | string: YYYY-MM-DD            |
-// | timestamp                        | datetime         | string: YYYY-MM-DD HH:MM:SS   |
+// | timestamp                        | datetime         | ISO 8601 string without zone  |
+// | timestamptz                      | datetime         | RFC3339 UTC string            |
 // | boolean[]                        | []bool           | array of booleans             |
 // | int16[], int32[], int64[]        | []int            | array of numbers              |
 // | float32[], float64[]             | []float          | array of numbers              |
 // | varchar[]                        | []string         | array of strings              |
-// | date[], timestamp[]              | []datetime       | array of datetime strings     |
+// | date[], timestamp[], timestamptz[] | []datetime      | array of datetime strings     |
 // | vector(N)                        | [N]f32           | array of numbers              |
 // | serial                           | int              | number                        |
 // | decimal                          | float            | number, converted through f64 |
@@ -810,7 +811,7 @@ fn turbopuffer_type(data_type: &DataType) -> Result<String> {
         }
         DataType::Float32 | DataType::Float64 | DataType::Decimal => Ok("float".to_owned()),
         DataType::Varchar => Ok("string".to_owned()),
-        DataType::Date | DataType::Timestamp => Ok("datetime".to_owned()),
+        DataType::Date | DataType::Timestamp | DataType::Timestamptz => Ok("datetime".to_owned()),
         DataType::List(list_type) => match list_type.elem() {
             DataType::Boolean => Ok("[]bool".to_owned()),
             DataType::Int16 | DataType::Int32 | DataType::Int64 | DataType::Serial => {
@@ -818,7 +819,9 @@ fn turbopuffer_type(data_type: &DataType) -> Result<String> {
             }
             DataType::Float32 | DataType::Float64 | DataType::Decimal => Ok("[]float".to_owned()),
             DataType::Varchar => Ok("[]string".to_owned()),
-            DataType::Date | DataType::Timestamp => Ok("[]datetime".to_owned()),
+            DataType::Date | DataType::Timestamp | DataType::Timestamptz => {
+                Ok("[]datetime".to_owned())
+            }
             elem_type => Err(unsupported_type(&format!("list element {:?}", elem_type))),
         },
         DataType::Vector(dimension) => Ok(format!("[{}]f32", dimension)),
@@ -855,7 +858,7 @@ mod tests {
     use risingwave_common::bitmap::Bitmap;
     use risingwave_common::catalog::Field;
     use risingwave_common::row::OwnedRow;
-    use risingwave_common::types::{ListType, ScalarImpl, Timestamp};
+    use risingwave_common::types::{ListType, ScalarImpl, Timestamp, Timestamptz};
     use serde_json::json;
 
     use super::*;
@@ -1265,34 +1268,29 @@ mod tests {
     fn test_manual_http_sink_schema_and_payload_shape() {
         let schema = Schema::new(vec![
             Field::with_name(DataType::Varchar, "id"),
-            Field::with_name(DataType::Varchar, "workspaceId"),
-            Field::with_name(DataType::Varchar, "inboxFeedItemId"),
-            Field::with_name(DataType::Varchar, "body"),
+            Field::with_name(DataType::Varchar, "namespace_id"),
+            Field::with_name(DataType::Varchar, "record_id"),
+            Field::with_name(DataType::Varchar, "content"),
             Field::with_name(
                 DataType::List(ListType::new(DataType::Varchar)),
-                "noteContents",
+                "content_segments",
             ),
-            Field::with_name(DataType::Varchar, "communityMemberHandle"),
-            Field::with_name(DataType::Varchar, "communityMemberIdentifier"),
-            Field::with_name(DataType::Varchar, "inboxFeedItemTitle"),
-            Field::with_name(DataType::Boolean, "isInboxFeedItemStarred"),
-            Field::with_name(DataType::Boolean, "isInboxFeedItemAnswered"),
-            Field::with_name(DataType::Timestamp, "inboxFeedItemPreviewTimestamp"),
-            Field::with_name(DataType::Timestamp, "inboxFeedItemPublishTimestamp"),
-            Field::with_name(DataType::Int64, "inboxFeedItemAuthorInstagramFollowerCount"),
-            Field::with_name(DataType::Int64, "inboxFeedItemAuthorTikTokFollowerCount"),
-            Field::with_name(
-                DataType::List(ListType::new(DataType::Varchar)),
-                "attributes",
-            ),
-            Field::with_name(DataType::Varchar, "threadId"),
+            Field::with_name(DataType::Varchar, "user_name"),
+            Field::with_name(DataType::Varchar, "user_identifier"),
+            Field::with_name(DataType::Varchar, "title"),
+            Field::with_name(DataType::Boolean, "is_flagged"),
+            Field::with_name(DataType::Boolean, "is_resolved"),
+            Field::with_name(DataType::Timestamp, "local_event_time"),
+            Field::with_name(DataType::Timestamptz, "event_time"),
+            Field::with_name(DataType::Int64, "metric_a_count"),
+            Field::with_name(DataType::Int64, "metric_b_count"),
+            Field::with_name(DataType::List(ListType::new(DataType::Varchar)), "labels"),
+            Field::with_name(DataType::Varchar, "group_id"),
             Field::with_name(DataType::Vector(384), "vector"),
         ]);
         let attribute_indices = (2..schema.len()).collect_vec();
         let full_text_search_columns = parse_column_selection(
-            Some(
-                "body,noteContents,communityMemberHandle,communityMemberIdentifier,inboxFeedItemTitle",
-            ),
+            Some("content,content_segments,user_name,user_identifier,title"),
             &schema,
             &attribute_indices,
         )
@@ -1310,20 +1308,20 @@ mod tests {
         assert_eq!(
             generated_schema,
             json!({
-                "inboxFeedItemId": {"type": "string", "filterable": true},
-                "body": {"type": "string", "filterable": true, "full_text_search": true},
-                "noteContents": {"type": "[]string", "filterable": true, "full_text_search": true},
-                "communityMemberHandle": {"type": "string", "filterable": true, "full_text_search": true},
-                "communityMemberIdentifier": {"type": "string", "filterable": true, "full_text_search": true},
-                "inboxFeedItemTitle": {"type": "string", "filterable": true, "full_text_search": true},
-                "isInboxFeedItemStarred": {"type": "bool", "filterable": true},
-                "isInboxFeedItemAnswered": {"type": "bool", "filterable": true},
-                "inboxFeedItemPreviewTimestamp": {"type": "datetime", "filterable": true},
-                "inboxFeedItemPublishTimestamp": {"type": "datetime", "filterable": true},
-                "inboxFeedItemAuthorInstagramFollowerCount": {"type": "int", "filterable": true},
-                "inboxFeedItemAuthorTikTokFollowerCount": {"type": "int", "filterable": true},
-                "attributes": {"type": "[]string", "filterable": true},
-                "threadId": {"type": "string", "filterable": true},
+                "record_id": {"type": "string", "filterable": true},
+                "content": {"type": "string", "filterable": true, "full_text_search": true},
+                "content_segments": {"type": "[]string", "filterable": true, "full_text_search": true},
+                "user_name": {"type": "string", "filterable": true, "full_text_search": true},
+                "user_identifier": {"type": "string", "filterable": true, "full_text_search": true},
+                "title": {"type": "string", "filterable": true, "full_text_search": true},
+                "is_flagged": {"type": "bool", "filterable": true},
+                "is_resolved": {"type": "bool", "filterable": true},
+                "local_event_time": {"type": "datetime", "filterable": true},
+                "event_time": {"type": "datetime", "filterable": true},
+                "metric_a_count": {"type": "int", "filterable": true},
+                "metric_b_count": {"type": "int", "filterable": true},
+                "labels": {"type": "[]string", "filterable": true},
+                "group_id": {"type": "string", "filterable": true},
                 "vector": {"type": "[384]f32", "filterable": true, "ann": true}
             })
         );
@@ -1331,11 +1329,13 @@ mod tests {
         let config = TurbopufferConfig {
             base_url: "http://127.0.0.1:0".to_owned(),
             namespace: None,
-            namespace_column: Some("workspaceId".to_owned()),
+            namespace_column: Some("namespace_id".to_owned()),
             api_key: "tpuf_test_key".to_owned(),
             distance_metric: Some("cosine_distance".to_owned()),
             disable_backpressure: Some(true),
-            full_text_search_columns: Some("body,noteContents,communityMemberHandle,communityMemberIdentifier,inboxFeedItemTitle".to_owned()),
+            full_text_search_columns: Some(
+                "content,content_segments,user_name,user_identifier,title".to_owned(),
+            ),
             filterable_columns: Some("*".to_owned()),
             write_batch_size: DEFAULT_WRITE_BATCH_SIZE,
             max_linger_second: DEFAULT_MAX_LINGER_SECOND,
@@ -1356,27 +1356,31 @@ mod tests {
             VectorVal::from_text(&format!("[{}]", vec!["0.25"; 384].join(",")), 384).unwrap();
         let row = OwnedRow::new(vec![
             Some(ScalarImpl::Utf8("doc-1".into())),
-            Some(ScalarImpl::Utf8("workspace-1".into())),
-            Some(ScalarImpl::Utf8("item-1".into())),
-            Some(ScalarImpl::Utf8("body text".into())),
-            Some(ScalarImpl::List(ListValue::from_iter(["note a", "note b"]))),
-            Some(ScalarImpl::Utf8("@member".into())),
-            Some(ScalarImpl::Utf8("member-1".into())),
+            Some(ScalarImpl::Utf8("namespace-1".into())),
+            Some(ScalarImpl::Utf8("record-1".into())),
+            Some(ScalarImpl::Utf8("content text".into())),
+            Some(ScalarImpl::List(ListValue::from_iter([
+                "segment a",
+                "segment b",
+            ]))),
+            Some(ScalarImpl::Utf8("user-a".into())),
+            Some(ScalarImpl::Utf8("user-1".into())),
             Some(ScalarImpl::Utf8("title".into())),
             Some(ScalarImpl::Bool(true)),
             Some(ScalarImpl::Bool(false)),
             Some(ScalarImpl::Timestamp(Timestamp::from_timestamp_uncheck(
                 1_781_582_706,
-                0,
+                123_456_789,
             ))),
-            Some(ScalarImpl::Timestamp(Timestamp::from_timestamp_uncheck(
-                1_781_598_707,
-                0,
+            Some(ScalarImpl::Timestamptz(Timestamptz::from_micros(
+                1_781_598_707_000_000,
             ))),
             Some(ScalarImpl::Int64(12345)),
             Some(ScalarImpl::Int64(67890)),
-            Some(ScalarImpl::List(ListValue::from_iter(["important", "vip"]))),
-            Some(ScalarImpl::Utf8("thread-1".into())),
+            Some(ScalarImpl::List(ListValue::from_iter([
+                "label-a", "label-b",
+            ]))),
+            Some(ScalarImpl::Utf8("group-1".into())),
             Some(ScalarImpl::Vector(vector)),
         ]);
         let id = writer.id_for_row(&row).unwrap();
@@ -1387,26 +1391,21 @@ mod tests {
         assert_eq!(body["disable_backpressure"], json!(true));
         assert_eq!(body["schema"], generated_schema);
         assert_eq!(body["upsert_rows"][0]["id"], json!("doc-1"));
-        assert_eq!(body["upsert_rows"][0]["body"], json!("body text"));
+        assert_eq!(body["upsert_rows"][0]["content"], json!("content text"));
         assert_eq!(
-            body["upsert_rows"][0]["noteContents"],
-            json!(["note a", "note b"])
+            body["upsert_rows"][0]["content_segments"],
+            json!(["segment a", "segment b"])
+        );
+        assert_eq!(body["upsert_rows"][0]["is_flagged"], json!(true));
+        assert_eq!(body["upsert_rows"][0]["is_resolved"], json!(false));
+        assert_eq!(body["upsert_rows"][0]["metric_a_count"], json!(12345));
+        assert_eq!(
+            body["upsert_rows"][0]["local_event_time"],
+            json!("2026-06-16T04:05:06.123456")
         );
         assert_eq!(
-            body["upsert_rows"][0]["isInboxFeedItemStarred"],
-            json!(true)
-        );
-        assert_eq!(
-            body["upsert_rows"][0]["isInboxFeedItemAnswered"],
-            json!(false)
-        );
-        assert_eq!(
-            body["upsert_rows"][0]["inboxFeedItemAuthorInstagramFollowerCount"],
-            json!(12345)
-        );
-        assert_eq!(
-            body["upsert_rows"][0]["inboxFeedItemPreviewTimestamp"],
-            json!("2026-06-16 04:05:06.000000")
+            body["upsert_rows"][0]["event_time"],
+            json!("2026-06-16T08:31:47.000000Z")
         );
         assert_eq!(
             body["upsert_rows"][0]["vector"].as_array().unwrap().len(),

--- a/src/connector/src/sink/turbopuffer.rs
+++ b/src/connector/src/sink/turbopuffer.rs
@@ -13,8 +13,13 @@
 // limitations under the License.
 
 use std::collections::{BTreeMap, HashMap, HashSet};
+use std::future::pending;
+use std::pin::Pin;
+use std::time::{Duration, Instant as StdInstant};
 
 use anyhow::{Context, anyhow};
+use async_trait::async_trait;
+use futures::future::try_join_all;
 use itertools::Itertools;
 use reqwest::header::{AUTHORIZATION, CONTENT_TYPE, HeaderMap, HeaderValue};
 use risingwave_common::array::{Op, StreamChunk};
@@ -25,17 +30,29 @@ use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value};
 use serde_with::{DisplayFromStr, serde_as};
 use thiserror_ext::AsReport;
+use tokio::time::Sleep;
 use with_options::WithOptions;
 
 use crate::enforce_secret::EnforceSecret;
 use crate::sink::encoder::{JsonEncoder, RowEncoder};
-use crate::sink::log_store::DeliveryFutureManagerAddFuture;
-use crate::sink::writer::{
-    AsyncTruncateLogSinkerOf, AsyncTruncateSinkWriter, AsyncTruncateSinkWriterExt,
+use crate::sink::log_store::{LogStoreReadItem, TruncateOffset};
+use crate::sink::{
+    LogSinker, Result, Sink, SinkError, SinkLogReader, SinkParam, SinkWriterMetrics,
+    SinkWriterParam,
 };
-use crate::sink::{Result, Sink, SinkError, SinkParam, SinkWriterParam};
+
+const DEFAULT_WRITE_BATCH_SIZE: usize = 1000;
+const DEFAULT_MAX_LINGER_SECOND: u64 = 1;
 
 pub const TURBOPUFFER_SINK: &str = "turbopuffer";
+
+fn default_write_batch_size() -> usize {
+    DEFAULT_WRITE_BATCH_SIZE
+}
+
+fn default_max_linger_second() -> u64 {
+    DEFAULT_MAX_LINGER_SECOND
+}
 
 #[serde_as]
 #[derive(Clone, Debug, Deserialize, WithOptions)]
@@ -49,6 +66,14 @@ pub struct TurbopufferConfig {
     pub disable_backpressure: Option<bool>,
     pub full_text_search_columns: Option<String>,
     pub filterable_columns: Option<String>,
+    #[serde(default = "default_write_batch_size")]
+    #[serde_as(as = "DisplayFromStr")]
+    #[with_option(allow_alter_on_fly)]
+    pub write_batch_size: usize,
+    #[serde(default = "default_max_linger_second")]
+    #[serde_as(as = "DisplayFromStr")]
+    #[with_option(allow_alter_on_fly)]
+    pub max_linger_second: u64,
     pub r#type: String, // accept "append-only" or "upsert"
 }
 
@@ -60,10 +85,21 @@ impl EnforceSecret for TurbopufferConfig {
 
 impl TurbopufferConfig {
     fn from_btreemap(values: BTreeMap<String, String>) -> Result<Self> {
-        serde_json::from_value::<TurbopufferConfig>(
+        let config = serde_json::from_value::<TurbopufferConfig>(
             serde_json::to_value(values).expect("serialize sink properties"),
         )
-        .map_err(|e| SinkError::Config(anyhow!(e)))
+        .map_err(|e| SinkError::Config(anyhow!(e)))?;
+        if config.write_batch_size == 0 {
+            return Err(SinkError::Config(anyhow!(
+                "`write_batch_size` must be greater than 0"
+            )));
+        }
+        if config.max_linger_second == 0 {
+            return Err(SinkError::Config(anyhow!(
+                "`max_linger_second` must be greater than 0"
+            )));
+        }
+        Ok(config)
     }
 }
 
@@ -77,7 +113,6 @@ enum TurbopufferNamespace {
 pub struct TurbopufferSink {
     config: TurbopufferConfig,
     schema: Schema,
-    is_append_only: bool,
     pk_index: usize,
     namespace: TurbopufferNamespace,
     attribute_indices: Vec<usize>,
@@ -100,7 +135,6 @@ impl TryFrom<SinkParam> for TurbopufferSink {
 
     fn try_from(param: SinkParam) -> std::result::Result<Self, Self::Error> {
         let schema = param.schema();
-        let is_append_only = param.sink_type.is_append_only();
         let pk_indices = param.downstream_pk_or_empty();
         let [pk_index] = pk_indices.as_slice() else {
             return Err(SinkError::Config(anyhow!(
@@ -206,7 +240,6 @@ impl TryFrom<SinkParam> for TurbopufferSink {
         Ok(Self {
             config,
             schema,
-            is_append_only,
             pk_index,
             namespace,
             attribute_indices,
@@ -216,7 +249,7 @@ impl TryFrom<SinkParam> for TurbopufferSink {
 }
 
 impl Sink for TurbopufferSink {
-    type LogSinker = AsyncTruncateLogSinkerOf<TurbopufferSinkWriter>;
+    type LogSinker = TurbopufferLogSinker;
 
     const SINK_NAME: &'static str = TURBOPUFFER_SINK;
 
@@ -224,17 +257,137 @@ impl Sink for TurbopufferSink {
         Ok(())
     }
 
-    async fn new_log_sinker(&self, _writer_param: SinkWriterParam) -> Result<Self::LogSinker> {
-        Ok(TurbopufferSinkWriter::new(
+    async fn new_log_sinker(&self, writer_param: SinkWriterParam) -> Result<Self::LogSinker> {
+        let write_batch_size = self.config.write_batch_size;
+        let max_linger = Duration::from_secs(self.config.max_linger_second);
+        let writer = TurbopufferSinkWriter::new(
             self.config.clone(),
             self.schema.clone(),
-            self.is_append_only,
             self.pk_index,
             self.namespace.clone(),
             self.attribute_indices.clone(),
             self.generated_schema.clone(),
-        )?
-        .into_log_sinker(usize::MAX))
+            write_batch_size,
+            max_linger,
+        )?;
+        Ok(TurbopufferLogSinker::new(
+            writer,
+            SinkWriterMetrics::new(&writer_param),
+        ))
+    }
+}
+
+pub struct TurbopufferLogSinker {
+    writer: TurbopufferSinkWriter,
+    sink_writer_metrics: SinkWriterMetrics,
+}
+
+impl TurbopufferLogSinker {
+    fn new(writer: TurbopufferSinkWriter, sink_writer_metrics: SinkWriterMetrics) -> Self {
+        Self {
+            writer,
+            sink_writer_metrics,
+        }
+    }
+
+    fn ensure_linger_timer(&self, linger_timer: &mut Pin<&mut Option<Sleep>>) {
+        if linger_timer.as_ref().get_ref().is_none() {
+            linger_timer
+                .as_mut()
+                .set(Some(tokio::time::sleep(self.writer.max_linger)));
+        }
+    }
+
+    async fn flush_all_and_truncate(
+        &mut self,
+        log_reader: &mut impl SinkLogReader,
+        latest_truncate_offset: &mut Option<TruncateOffset>,
+        linger_timer: &mut Pin<&mut Option<Sleep>>,
+    ) -> Result<()> {
+        let start_time = StdInstant::now();
+        self.writer.flush_all().await?;
+        self.sink_writer_metrics
+            .sink_commit_duration
+            .observe(start_time.elapsed().as_secs_f64());
+        linger_timer.as_mut().set(None);
+        if let Some(offset) = latest_truncate_offset.take() {
+            log_reader.truncate(offset)?;
+        }
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl LogSinker for TurbopufferLogSinker {
+    async fn consume_log_and_sink(mut self, mut log_reader: impl SinkLogReader) -> Result<!> {
+        log_reader.start_from(None).await?;
+        let mut latest_truncate_offset = None;
+        let linger_timer = None;
+        let mut linger_timer = std::pin::pin!(linger_timer);
+
+        loop {
+            let (epoch, item) = tokio::select! {
+                item = log_reader.next_item() => item?,
+                _ = async {
+                    match linger_timer.as_mut().as_pin_mut() {
+                        Some(timer) => timer.await,
+                        None => pending().await,
+                    }
+                } => {
+                    self.flush_all_and_truncate(
+                        &mut log_reader,
+                        &mut latest_truncate_offset,
+                        &mut linger_timer,
+                    )
+                    .await?;
+                    continue;
+                }
+            };
+            match item {
+                LogStoreReadItem::StreamChunk { chunk, chunk_id } => {
+                    let offset = TruncateOffset::Chunk { epoch, chunk_id };
+                    let has_pending_update = self.writer.write_chunk(chunk)?;
+                    latest_truncate_offset = Some(offset);
+                    if self.writer.should_flush_by_size() {
+                        self.flush_all_and_truncate(
+                            &mut log_reader,
+                            &mut latest_truncate_offset,
+                            &mut linger_timer,
+                        )
+                        .await?;
+                    } else if has_pending_update {
+                        self.ensure_linger_timer(&mut linger_timer);
+                    }
+                }
+                LogStoreReadItem::Barrier {
+                    new_vnode_bitmap,
+                    is_stop,
+                    schema_change,
+                    ..
+                } => {
+                    let offset = TruncateOffset::Barrier { epoch };
+                    let should_flush =
+                        is_stop || new_vnode_bitmap.is_some() || schema_change.is_some();
+                    if self.writer.is_empty() {
+                        log_reader.truncate(offset)?;
+                    } else if should_flush {
+                        latest_truncate_offset = Some(offset);
+                        self.flush_all_and_truncate(
+                            &mut log_reader,
+                            &mut latest_truncate_offset,
+                            &mut linger_timer,
+                        )
+                        .await?;
+                    } else {
+                        latest_truncate_offset = Some(offset);
+                    }
+
+                    if is_stop {
+                        return pending().await;
+                    }
+                }
+            }
+        }
     }
 }
 
@@ -244,21 +397,24 @@ pub struct TurbopufferSinkWriter {
     distance_metric: Option<String>,
     disable_backpressure: Option<bool>,
     schema: Value,
-    is_append_only: bool,
     pk_index: usize,
     namespace: TurbopufferNamespace,
     row_encoder: JsonEncoder,
+    write_batch_size: usize,
+    max_linger: Duration,
+    pending_batches: BTreeMap<String, HashMap<DocumentId, CompactedOp>>,
 }
 
 impl TurbopufferSinkWriter {
     fn new(
         config: TurbopufferConfig,
         schema: Schema,
-        is_append_only: bool,
         pk_index: usize,
         namespace: TurbopufferNamespace,
         attribute_indices: Vec<usize>,
         generated_schema: Value,
+        write_batch_size: usize,
+        max_linger: Duration,
     ) -> Result<Self> {
         let mut header_map = HeaderMap::new();
         header_map.insert(CONTENT_TYPE, HeaderValue::from_static("application/json"));
@@ -290,10 +446,12 @@ impl TurbopufferSinkWriter {
             distance_metric: config.distance_metric,
             disable_backpressure: config.disable_backpressure,
             schema: generated_schema,
-            is_append_only,
             pk_index,
             namespace,
             row_encoder,
+            write_batch_size,
+            max_linger,
+            pending_batches: BTreeMap::new(),
         })
     }
 
@@ -396,148 +554,96 @@ impl TurbopufferSinkWriter {
         }
         Value::Object(body)
     }
-}
 
-impl AsyncTruncateSinkWriter for TurbopufferSinkWriter {
-    async fn write_chunk<'a>(
-        &'a mut self,
-        chunk: StreamChunk,
-        _add_future: DeliveryFutureManagerAddFuture<'a, Self::DeliveryFuture>,
-    ) -> Result<()> {
-        if self.is_append_only {
-            let mut batches = BTreeMap::<String, Vec<Map<String, Value>>>::new();
-            for (op, row) in chunk.rows() {
-                match op {
-                    Op::Insert | Op::UpdateInsert => {
-                        let id = match self.id_for_row(&row) {
-                            Ok(id) => id,
-                            Err(err) => {
-                                tracing::warn!(error = %err.as_report(), "skip turbopuffer row with invalid document id");
-                                continue;
-                            }
-                        };
-                        let upsert_row = match self.upsert_row(&row, id) {
-                            Ok(row) => row,
-                            Err(err) => {
-                                tracing::warn!(error = %err.as_report(), "skip turbopuffer row failed to encode upsert payload");
-                                continue;
-                            }
-                        };
-                        let url = match self.url_for_row(&row) {
-                            Ok(url) => url,
-                            Err(err) => {
-                                tracing::warn!(error = %err.as_report(), "skip turbopuffer row with invalid namespace");
-                                continue;
-                            }
-                        };
-                        batches.entry(url).or_default().push(upsert_row);
-                    }
-                    Op::Delete | Op::UpdateDelete => {
-                        return Err(SinkError::Http(anyhow!(
-                            "`Delete` or `UpdateDelete` operation is not supported in append-only turbopuffer sink"
-                        )));
-                    }
-                }
-            }
-
-            for (url, upsert_rows) in batches {
-                if upsert_rows.is_empty() {
+    fn write_chunk(&mut self, chunk: StreamChunk) -> Result<bool> {
+        let mut has_pending_update = false;
+        for (op, row) in chunk.rows() {
+            let id = match self.id_for_row(&row) {
+                Ok(id) => id,
+                Err(err) => {
+                    tracing::warn!(error = %err.as_report(), "skip turbopuffer row with invalid document id");
                     continue;
                 }
-                let resp = self
-                    .client
-                    .post(url)
-                    .json(&self.request_body(upsert_rows, Vec::new()))
-                    .send()
-                    .await
-                    .context("turbopuffer write request failed")
-                    .map_err(SinkError::Http)?;
-
-                if !resp.status().is_success() {
-                    let status = resp.status();
-                    let body = resp.text().await.unwrap_or_default();
-                    return Err(SinkError::Http(anyhow!(
-                        "Turbopuffer sink received non-success response: {} {}",
-                        status,
-                        body
-                    )));
-                }
-            }
-        } else {
-            let mut batches = BTreeMap::<String, HashMap<DocumentId, CompactedOp>>::new();
-            for (op, row) in chunk.rows() {
-                let id = match self.id_for_row(&row) {
-                    Ok(id) => id,
-                    Err(err) => {
-                        tracing::warn!(error = %err.as_report(), "skip turbopuffer row with invalid document id");
-                        continue;
-                    }
-                };
-                let url = match self.url_for_row(&row) {
-                    Ok(url) => url,
-                    Err(err) => {
-                        tracing::warn!(error = %err.as_report(), "skip turbopuffer row with invalid namespace");
-                        continue;
-                    }
-                };
-                match op {
-                    Op::Insert | Op::UpdateInsert => {
-                        let upsert_row = match self.upsert_row(&row, id.clone()) {
-                            Ok(row) => row,
-                            Err(err) => {
-                                tracing::warn!(error = %err.as_report(), "skip turbopuffer row failed to encode upsert payload");
-                                continue;
-                            }
-                        };
-                        batches
-                            .entry(url)
-                            .or_default()
-                            .insert(id, CompactedOp::Upsert(upsert_row));
-                    }
-                    Op::Delete | Op::UpdateDelete => {
-                        batches
-                            .entry(url)
-                            .or_default()
-                            .insert(id, CompactedOp::Delete);
-                    }
-                }
-            }
-
-            for (url, batch) in batches {
-                let mut upsert_rows = Vec::new();
-                let mut deletes = Vec::new();
-                for (id, op) in batch {
-                    match op {
-                        CompactedOp::Upsert(row) => upsert_rows.push(row),
-                        CompactedOp::Delete => deletes.push(id),
-                    }
-                }
-                if upsert_rows.is_empty() && deletes.is_empty() {
+            };
+            let url = match self.url_for_row(&row) {
+                Ok(url) => url,
+                Err(err) => {
+                    tracing::warn!(error = %err.as_report(), "skip turbopuffer row with invalid namespace");
                     continue;
                 }
-                let resp = self
-                    .client
-                    .post(url)
-                    .json(&self.request_body(upsert_rows, deletes))
-                    .send()
-                    .await
-                    .context("turbopuffer write request failed")
-                    .map_err(SinkError::Http)?;
-
-                if !resp.status().is_success() {
-                    let status = resp.status();
-                    let body = resp.text().await.unwrap_or_default();
-                    return Err(SinkError::Http(anyhow!(
-                        "Turbopuffer sink received non-success response: {} {}",
-                        status,
-                        body
-                    )));
+            };
+            let compacted_op = match op {
+                Op::Insert | Op::UpdateInsert => {
+                    let upsert_row = match self.upsert_row(&row, id.clone()) {
+                        Ok(row) => row,
+                        Err(err) => {
+                            tracing::warn!(error = %err.as_report(), "skip turbopuffer row failed to encode upsert payload");
+                            continue;
+                        }
+                    };
+                    CompactedOp::Upsert(upsert_row)
                 }
-            }
+                Op::Delete | Op::UpdateDelete => CompactedOp::Delete,
+            };
+            self.pending_batches
+                .entry(url)
+                .or_default()
+                .insert(id, compacted_op);
+            has_pending_update = true;
         }
 
+        Ok(has_pending_update)
+    }
+
+    fn pending_row_count(&self) -> usize {
+        self.pending_batches.values().map(HashMap::len).sum()
+    }
+
+    fn should_flush_by_size(&self) -> bool {
+        self.pending_row_count() >= self.write_batch_size
+    }
+
+    fn is_empty(&self) -> bool {
+        self.pending_batches.is_empty()
+    }
+
+    async fn flush_all(&mut self) -> Result<()> {
+        let batches = std::mem::take(&mut self.pending_batches);
+        let client = self.client.clone();
+        try_join_all(batches.into_iter().filter_map(|(url, batch)| {
+            let (upsert_rows, deletes) = batch_into_request_parts(batch);
+            if upsert_rows.is_empty() && deletes.is_empty() {
+                return None;
+            }
+
+            let client = client.clone();
+            let body = self.request_body(upsert_rows, deletes);
+            Some(async move { send_turbopuffer_request(client, url, body).await })
+        }))
+        .await?;
         Ok(())
     }
+}
+
+async fn send_turbopuffer_request(client: reqwest::Client, url: String, body: Value) -> Result<()> {
+    let resp = client
+        .post(url)
+        .json(&body)
+        .send()
+        .await
+        .context("turbopuffer write request failed")
+        .map_err(SinkError::Http)?;
+
+    if !resp.status().is_success() {
+        let status = resp.status();
+        let body = resp.text().await.unwrap_or_default();
+        return Err(SinkError::Http(anyhow!(
+            "Turbopuffer sink received non-success response: {} {}",
+            status,
+            body
+        )));
+    }
+    Ok(())
 }
 
 #[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize)]
@@ -551,6 +657,20 @@ enum DocumentId {
 enum CompactedOp {
     Upsert(Map<String, Value>),
     Delete,
+}
+
+fn batch_into_request_parts(
+    batch: HashMap<DocumentId, CompactedOp>,
+) -> (Vec<Map<String, Value>>, Vec<DocumentId>) {
+    let mut upsert_rows = Vec::new();
+    let mut deletes = Vec::new();
+    for (id, op) in batch {
+        match op {
+            CompactedOp::Upsert(row) => upsert_rows.push(row),
+            CompactedOp::Delete => deletes.push(id),
+        }
+    }
+    (upsert_rows, deletes)
 }
 
 fn document_id_from_i64(value: i64) -> DocumentId {
@@ -716,11 +836,13 @@ fn unsupported_type(data_type: &str) -> SinkError {
 #[cfg(test)]
 mod tests {
     #[cfg(not(madsim))]
+    use std::collections::VecDeque;
+    #[cfg(not(madsim))]
     use std::io::{Read, Write};
     #[cfg(not(madsim))]
     use std::net::TcpListener;
     #[cfg(not(madsim))]
-    use std::sync::mpsc;
+    use std::sync::{Arc, Mutex, mpsc};
     #[cfg(not(madsim))]
     use std::thread;
 
@@ -729,6 +851,8 @@ mod tests {
     #[cfg(not(madsim))]
     use risingwave_common::array::stream_chunk::StreamChunkTestExt as _;
     use risingwave_common::array::{ListValue, VectorVal};
+    #[cfg(not(madsim))]
+    use risingwave_common::bitmap::Bitmap;
     use risingwave_common::catalog::Field;
     use risingwave_common::row::OwnedRow;
     use risingwave_common::types::{ListType, ScalarImpl, Timestamp};
@@ -736,7 +860,7 @@ mod tests {
 
     use super::*;
     #[cfg(not(madsim))]
-    use crate::sink::log_store::DeliveryFutureManager;
+    use crate::sink::log_store::LogStoreResult;
 
     #[test]
     fn test_build_schema_flags() {
@@ -766,8 +890,8 @@ mod tests {
 
     #[cfg(not(madsim))]
     #[tokio::test]
-    async fn test_write_chunk_posts_batched_payload_and_headers() {
-        let (base_url, request_rx, server_thread) = spawn_mock_http_server();
+    async fn test_write_chunk_buffers_until_flush_and_posts_payload_and_headers() {
+        let (base_url, request_rx, server_thread) = spawn_mock_http_server(1);
         let schema = Schema::new(vec![
             Field::with_name(DataType::Varchar, "id"),
             Field::with_name(DataType::Varchar, "body"),
@@ -790,16 +914,19 @@ mod tests {
             disable_backpressure: Some(true),
             full_text_search_columns: Some("body".to_owned()),
             filterable_columns: Some("*".to_owned()),
+            write_batch_size: DEFAULT_WRITE_BATCH_SIZE,
+            max_linger_second: DEFAULT_MAX_LINGER_SECOND,
             r#type: "upsert".to_owned(),
         };
         let mut writer = TurbopufferSinkWriter::new(
             config,
             schema,
-            false,
             0,
             TurbopufferNamespace::Dynamic { index: 2 },
             payload_indices,
             generated_schema,
+            DEFAULT_WRITE_BATCH_SIZE,
+            Duration::from_secs(DEFAULT_MAX_LINGER_SECOND),
         )
         .unwrap();
         let chunk = StreamChunk::from_pretty(
@@ -807,12 +934,10 @@ mod tests {
             U- old-id   old_body ns_1
             U+ new-id   new_body ns_1",
         );
-        let mut future_manager = DeliveryFutureManager::new(0);
 
-        writer
-            .write_chunk(chunk, future_manager.start_write_chunk(0, 0))
-            .await
-            .unwrap();
+        writer.write_chunk(chunk).unwrap();
+        assert!(request_rx.try_recv().is_err());
+        writer.flush_all().await.unwrap();
         let request = request_rx.recv().unwrap();
         server_thread.join().unwrap();
 
@@ -831,6 +956,295 @@ mod tests {
         assert_eq!(body["upsert_rows"][0]["id"], json!("new-id"));
         assert_eq!(body["upsert_rows"][0]["body"], json!("new_body"));
         assert!(body.get("distance_metric").is_none());
+    }
+
+    #[test]
+    fn test_config_defaults_and_validation() {
+        let config = TurbopufferConfig::from_btreemap(BTreeMap::from([
+            ("base_url".to_owned(), "http://127.0.0.1:0".to_owned()),
+            ("namespace".to_owned(), "ns".to_owned()),
+            ("api_key".to_owned(), "key".to_owned()),
+            ("type".to_owned(), "upsert".to_owned()),
+        ]))
+        .unwrap();
+        assert_eq!(config.write_batch_size, DEFAULT_WRITE_BATCH_SIZE);
+        assert_eq!(config.max_linger_second, DEFAULT_MAX_LINGER_SECOND);
+
+        let err = TurbopufferConfig::from_btreemap(BTreeMap::from([
+            ("base_url".to_owned(), "http://127.0.0.1:0".to_owned()),
+            ("namespace".to_owned(), "ns".to_owned()),
+            ("api_key".to_owned(), "key".to_owned()),
+            ("type".to_owned(), "upsert".to_owned()),
+            ("write_batch_size".to_owned(), "0".to_owned()),
+        ]))
+        .unwrap_err();
+        assert!(err.to_string().contains("write_batch_size"));
+
+        let err = TurbopufferConfig::from_btreemap(BTreeMap::from([
+            ("base_url".to_owned(), "http://127.0.0.1:0".to_owned()),
+            ("namespace".to_owned(), "ns".to_owned()),
+            ("api_key".to_owned(), "key".to_owned()),
+            ("type".to_owned(), "upsert".to_owned()),
+            ("max_linger_second".to_owned(), "0".to_owned()),
+        ]))
+        .unwrap_err();
+        assert!(err.to_string().contains("max_linger_second"));
+    }
+
+    #[cfg(not(madsim))]
+    #[tokio::test]
+    async fn test_global_threshold_flushes_all_namespaces() {
+        let (base_url, request_rx, server_thread) = spawn_mock_http_server(2);
+        let schema = Schema::new(vec![
+            Field::with_name(DataType::Varchar, "id"),
+            Field::with_name(DataType::Varchar, "body"),
+            Field::with_name(DataType::Varchar, "workspace_id"),
+        ]);
+        let generated_schema =
+            build_turbopuffer_schema(&schema, &[1], &HashSet::new(), &HashSet::new()).unwrap();
+        let config = TurbopufferConfig {
+            base_url,
+            namespace: None,
+            namespace_column: Some("workspace_id".to_owned()),
+            api_key: "tpuf_test_key".to_owned(),
+            distance_metric: None,
+            disable_backpressure: None,
+            full_text_search_columns: None,
+            filterable_columns: None,
+            write_batch_size: 2,
+            max_linger_second: DEFAULT_MAX_LINGER_SECOND,
+            r#type: "upsert".to_owned(),
+        };
+        let mut writer = TurbopufferSinkWriter::new(
+            config,
+            schema,
+            0,
+            TurbopufferNamespace::Dynamic { index: 2 },
+            vec![1],
+            generated_schema,
+            2,
+            Duration::from_secs(DEFAULT_MAX_LINGER_SECOND),
+        )
+        .unwrap();
+
+        writer
+            .write_chunk(StreamChunk::from_pretty(
+                "  T  T    T
+                + a1 body ns_a
+                + b1 body ns_b",
+            ))
+            .unwrap();
+        assert!(writer.should_flush_by_size());
+        writer.flush_all().await.unwrap();
+
+        let requests = [request_rx.recv().unwrap(), request_rx.recv().unwrap()];
+        server_thread.join().unwrap();
+        assert!(
+            requests
+                .iter()
+                .any(|request| request.starts_with("post /v2/namespaces/ns_a http/1.1"))
+        );
+        assert!(
+            requests
+                .iter()
+                .any(|request| request.starts_with("post /v2/namespaces/ns_b http/1.1"))
+        );
+        assert!(writer.pending_batches.is_empty());
+    }
+
+    #[cfg(not(madsim))]
+    #[tokio::test]
+    async fn test_upsert_compacts_across_chunks() {
+        let (base_url, request_rx, server_thread) = spawn_mock_http_server(1);
+        let schema = Schema::new(vec![
+            Field::with_name(DataType::Varchar, "id"),
+            Field::with_name(DataType::Varchar, "body"),
+        ]);
+        let generated_schema =
+            build_turbopuffer_schema(&schema, &[1], &HashSet::new(), &HashSet::new()).unwrap();
+        let config = TurbopufferConfig {
+            base_url,
+            namespace: Some("ns".to_owned()),
+            namespace_column: None,
+            api_key: "tpuf_test_key".to_owned(),
+            distance_metric: None,
+            disable_backpressure: None,
+            full_text_search_columns: None,
+            filterable_columns: None,
+            write_batch_size: DEFAULT_WRITE_BATCH_SIZE,
+            max_linger_second: DEFAULT_MAX_LINGER_SECOND,
+            r#type: "upsert".to_owned(),
+        };
+        let mut writer = TurbopufferSinkWriter::new(
+            config,
+            schema,
+            0,
+            TurbopufferNamespace::Static("ns".to_owned()),
+            vec![1],
+            generated_schema,
+            DEFAULT_WRITE_BATCH_SIZE,
+            Duration::from_secs(DEFAULT_MAX_LINGER_SECOND),
+        )
+        .unwrap();
+
+        writer
+            .write_chunk(StreamChunk::from_pretty(
+                "  T  T
+                + id body1",
+            ))
+            .unwrap();
+        writer
+            .write_chunk(StreamChunk::from_pretty(
+                "  T  T
+                - id body1
+                + id body2",
+            ))
+            .unwrap();
+        writer.flush_all().await.unwrap();
+
+        let request = request_rx.recv().unwrap();
+        server_thread.join().unwrap();
+        let body = request.split("\r\n\r\n").nth(1).unwrap();
+        let body: Value = serde_json::from_str(body).unwrap();
+        assert!(body.get("deletes").is_none());
+        assert_eq!(body["upsert_rows"].as_array().unwrap().len(), 1);
+        assert_eq!(body["upsert_rows"][0]["id"], json!("id"));
+        assert_eq!(body["upsert_rows"][0]["body"], json!("body2"));
+    }
+
+    #[cfg(not(madsim))]
+    #[tokio::test]
+    async fn test_log_sinker_flushes_after_linger() {
+        let (base_url, request_rx, server_thread) = spawn_mock_http_server(1);
+        let writer = new_test_static_writer_with_linger(
+            base_url,
+            DEFAULT_WRITE_BATCH_SIZE,
+            Duration::from_millis(1),
+        );
+        let truncates = Arc::new(Mutex::new(Vec::new()));
+        let reader = TestSinkLogReader::new(
+            vec![
+                (
+                    1,
+                    LogStoreReadItem::StreamChunk {
+                        chunk: StreamChunk::from_pretty(
+                            "  T  T
+                            + id body",
+                        ),
+                        chunk_id: 0,
+                    },
+                ),
+                (
+                    2,
+                    LogStoreReadItem::Barrier {
+                        is_checkpoint: false,
+                        new_vnode_bitmap: None,
+                        is_stop: false,
+                        schema_change: None,
+                    },
+                ),
+            ],
+            truncates.clone(),
+        )
+        .pending_on_empty();
+        tokio::time::timeout(
+            Duration::from_millis(200),
+            TurbopufferLogSinker::new(writer, SinkWriterMetrics::for_test())
+                .consume_log_and_sink(reader),
+        )
+        .await
+        .unwrap_err();
+
+        let request = request_rx.recv().unwrap();
+        server_thread.join().unwrap();
+        let body = request.split("\r\n\r\n").nth(1).unwrap();
+        let body: Value = serde_json::from_str(body).unwrap();
+        assert_eq!(body["upsert_rows"].as_array().unwrap().len(), 1);
+        assert_eq!(
+            *truncates.lock().unwrap(),
+            vec![TruncateOffset::Barrier { epoch: 2 }]
+        );
+    }
+
+    #[cfg(not(madsim))]
+    #[tokio::test]
+    async fn test_log_sinker_truncates_latest_chunk_after_threshold_flush() {
+        let (base_url, _request_rx, server_thread) = spawn_mock_http_server(1);
+        let writer = new_test_static_writer(base_url, 1);
+        let truncates = Arc::new(Mutex::new(Vec::new()));
+        let reader = TestSinkLogReader::new(
+            vec![(
+                1,
+                LogStoreReadItem::StreamChunk {
+                    chunk: StreamChunk::from_pretty(
+                        "  T  T
+                        + id body",
+                    ),
+                    chunk_id: 7,
+                },
+            )],
+            truncates.clone(),
+        );
+        let err = TurbopufferLogSinker::new(writer, SinkWriterMetrics::for_test())
+            .consume_log_and_sink(reader)
+            .await
+            .unwrap_err();
+        assert!(err.to_string().contains("done"));
+        server_thread.join().unwrap();
+        assert_eq!(
+            *truncates.lock().unwrap(),
+            vec![TruncateOffset::Chunk {
+                epoch: 1,
+                chunk_id: 7
+            }]
+        );
+    }
+
+    #[cfg(not(madsim))]
+    #[tokio::test]
+    async fn test_log_sinker_flushes_on_vnode_bitmap_change() {
+        let (base_url, request_rx, server_thread) = spawn_mock_http_server(1);
+        let writer = new_test_static_writer(base_url, DEFAULT_WRITE_BATCH_SIZE);
+        let truncates = Arc::new(Mutex::new(Vec::new()));
+        let reader = TestSinkLogReader::new(
+            vec![
+                (
+                    1,
+                    LogStoreReadItem::StreamChunk {
+                        chunk: StreamChunk::from_pretty(
+                            "  T  T
+                            + id body",
+                        ),
+                        chunk_id: 0,
+                    },
+                ),
+                (
+                    2,
+                    LogStoreReadItem::Barrier {
+                        is_checkpoint: false,
+                        new_vnode_bitmap: Some(Arc::new(Bitmap::ones(1))),
+                        is_stop: false,
+                        schema_change: None,
+                    },
+                ),
+            ],
+            truncates.clone(),
+        );
+        let err = TurbopufferLogSinker::new(writer, SinkWriterMetrics::for_test())
+            .consume_log_and_sink(reader)
+            .await
+            .unwrap_err();
+        assert!(err.to_string().contains("done"));
+
+        let request = request_rx.recv().unwrap();
+        server_thread.join().unwrap();
+        let body = request.split("\r\n\r\n").nth(1).unwrap();
+        let body: Value = serde_json::from_str(body).unwrap();
+        assert_eq!(body["upsert_rows"].as_array().unwrap().len(), 1);
+        assert_eq!(
+            *truncates.lock().unwrap(),
+            vec![TruncateOffset::Barrier { epoch: 2 }]
+        );
     }
 
     #[test]
@@ -923,16 +1337,19 @@ mod tests {
             disable_backpressure: Some(true),
             full_text_search_columns: Some("body,noteContents,communityMemberHandle,communityMemberIdentifier,inboxFeedItemTitle".to_owned()),
             filterable_columns: Some("*".to_owned()),
+            write_batch_size: DEFAULT_WRITE_BATCH_SIZE,
+            max_linger_second: DEFAULT_MAX_LINGER_SECOND,
             r#type: "upsert".to_owned(),
         };
         let writer = TurbopufferSinkWriter::new(
             config,
             schema,
-            false,
             0,
             TurbopufferNamespace::Dynamic { index: 1 },
             attribute_indices,
             generated_schema.clone(),
+            DEFAULT_WRITE_BATCH_SIZE,
+            Duration::from_secs(DEFAULT_MAX_LINGER_SECOND),
         )
         .unwrap();
         let vector =
@@ -999,43 +1416,47 @@ mod tests {
     }
 
     #[cfg(not(madsim))]
-    fn spawn_mock_http_server() -> (String, mpsc::Receiver<String>, thread::JoinHandle<()>) {
+    fn spawn_mock_http_server(
+        expected_requests: usize,
+    ) -> (String, mpsc::Receiver<String>, thread::JoinHandle<()>) {
         let listener = TcpListener::bind("127.0.0.1:0").unwrap();
         let addr = listener.local_addr().unwrap();
         let (request_tx, request_rx) = mpsc::channel();
         let server_thread = thread::spawn(move || {
-            let (mut stream, _) = listener.accept().unwrap();
-            let mut buf = Vec::new();
-            let header_end = loop {
-                let mut tmp = [0; 1024];
-                let read = stream.read(&mut tmp).unwrap();
-                assert_ne!(read, 0);
-                buf.extend_from_slice(&tmp[..read]);
-                if let Some(header_end) = find_header_end(&buf) {
-                    break header_end;
+            for _ in 0..expected_requests {
+                let (mut stream, _) = listener.accept().unwrap();
+                let mut buf = Vec::new();
+                let header_end = loop {
+                    let mut tmp = [0; 1024];
+                    let read = stream.read(&mut tmp).unwrap();
+                    assert_ne!(read, 0);
+                    buf.extend_from_slice(&tmp[..read]);
+                    if let Some(header_end) = find_header_end(&buf) {
+                        break header_end;
+                    }
+                };
+                let headers = String::from_utf8_lossy(&buf[..header_end]);
+                let content_length = headers
+                    .lines()
+                    .find_map(|line| {
+                        let (name, value) = line.split_once(':')?;
+                        name.eq_ignore_ascii_case("content-length")
+                            .then(|| value.trim().parse::<usize>().unwrap())
+                    })
+                    .unwrap();
+                while buf.len() < header_end + 4 + content_length {
+                    let mut tmp = [0; 1024];
+                    let read = stream.read(&mut tmp).unwrap();
+                    assert_ne!(read, 0);
+                    buf.extend_from_slice(&tmp[..read]);
                 }
-            };
-            let headers = String::from_utf8_lossy(&buf[..header_end]);
-            let content_length = headers
-                .lines()
-                .find_map(|line| {
-                    let (name, value) = line.split_once(':')?;
-                    name.eq_ignore_ascii_case("content-length")
-                        .then(|| value.trim().parse::<usize>().unwrap())
-                })
-                .unwrap();
-            while buf.len() < header_end + 4 + content_length {
-                let mut tmp = [0; 1024];
-                let read = stream.read(&mut tmp).unwrap();
-                assert_ne!(read, 0);
-                buf.extend_from_slice(&tmp[..read]);
+                let request = String::from_utf8(buf[..header_end + 4 + content_length].to_vec())
+                    .expect("HTTP request should be utf8");
+                request_tx.send(request.to_lowercase()).unwrap();
+                stream
+                    .write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 0\r\nConnection: close\r\n\r\n")
+                    .unwrap();
             }
-            let request = String::from_utf8(buf[..header_end + 4 + content_length].to_vec())
-                .expect("HTTP request should be utf8");
-            request_tx.send(request.to_lowercase()).unwrap();
-            stream
-                .write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 0\r\nConnection: close\r\n\r\n")
-                .unwrap();
         });
         (format!("http://{}", addr), request_rx, server_thread)
     }
@@ -1043,5 +1464,98 @@ mod tests {
     #[cfg(not(madsim))]
     fn find_header_end(buf: &[u8]) -> Option<usize> {
         buf.windows(4).position(|window| window == b"\r\n\r\n")
+    }
+
+    #[cfg(not(madsim))]
+    fn new_test_static_writer(base_url: String, write_batch_size: usize) -> TurbopufferSinkWriter {
+        new_test_static_writer_with_linger(
+            base_url,
+            write_batch_size,
+            Duration::from_secs(DEFAULT_MAX_LINGER_SECOND),
+        )
+    }
+
+    #[cfg(not(madsim))]
+    fn new_test_static_writer_with_linger(
+        base_url: String,
+        write_batch_size: usize,
+        max_linger: Duration,
+    ) -> TurbopufferSinkWriter {
+        let schema = Schema::new(vec![
+            Field::with_name(DataType::Varchar, "id"),
+            Field::with_name(DataType::Varchar, "body"),
+        ]);
+        let generated_schema =
+            build_turbopuffer_schema(&schema, &[1], &HashSet::new(), &HashSet::new()).unwrap();
+        let config = TurbopufferConfig {
+            base_url,
+            namespace: Some("ns".to_owned()),
+            namespace_column: None,
+            api_key: "tpuf_test_key".to_owned(),
+            distance_metric: None,
+            disable_backpressure: None,
+            full_text_search_columns: None,
+            filterable_columns: None,
+            write_batch_size,
+            max_linger_second: DEFAULT_MAX_LINGER_SECOND,
+            r#type: "upsert".to_owned(),
+        };
+        TurbopufferSinkWriter::new(
+            config,
+            schema,
+            0,
+            TurbopufferNamespace::Static("ns".to_owned()),
+            vec![1],
+            generated_schema,
+            write_batch_size,
+            max_linger,
+        )
+        .unwrap()
+    }
+
+    #[cfg(not(madsim))]
+    struct TestSinkLogReader {
+        items: VecDeque<(u64, LogStoreReadItem)>,
+        truncates: Arc<Mutex<Vec<TruncateOffset>>>,
+        pending_on_empty: bool,
+    }
+
+    #[cfg(not(madsim))]
+    impl TestSinkLogReader {
+        fn new(
+            items: Vec<(u64, LogStoreReadItem)>,
+            truncates: Arc<Mutex<Vec<TruncateOffset>>>,
+        ) -> Self {
+            Self {
+                items: items.into(),
+                truncates,
+                pending_on_empty: false,
+            }
+        }
+
+        fn pending_on_empty(mut self) -> Self {
+            self.pending_on_empty = true;
+            self
+        }
+    }
+
+    #[cfg(not(madsim))]
+    impl SinkLogReader for TestSinkLogReader {
+        async fn start_from(&mut self, _start_offset: Option<u64>) -> LogStoreResult<()> {
+            Ok(())
+        }
+
+        async fn next_item(&mut self) -> LogStoreResult<(u64, LogStoreReadItem)> {
+            match self.items.pop_front() {
+                Some(item) => Ok(item),
+                None if self.pending_on_empty => pending().await,
+                None => Err(anyhow!("done")),
+            }
+        }
+
+        fn truncate(&mut self, offset: TruncateOffset) -> LogStoreResult<()> {
+            self.truncates.lock().unwrap().push(offset);
+            Ok(())
+        }
     }
 }

--- a/src/connector/with_options_sink.yaml
+++ b/src/connector/with_options_sink.yaml
@@ -1835,6 +1835,16 @@ TurbopufferConfig:
   - name: filterable_columns
     field_type: String
     required: false
+  - name: write_batch_size
+    field_type: usize
+    required: false
+    default: DEFAULT_WRITE_BATCH_SIZE
+    allow_alter_on_fly: true
+  - name: max_linger_second
+    field_type: u64
+    required: false
+    default: DEFAULT_MAX_LINGER_SECOND
+    allow_alter_on_fly: true
   - name: r#type
     field_type: String
     required: true


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

This PR adds configurable cross-chunk batching controls for the Turbopuffer sink and replaces the async-truncate writer path with a Turbopuffer-owned log sinker.

- Adds alterable `write_batch_size` (default `1000`) and `max_linger_second` (default `1`), with validation rejecting zero.
- Buffers pending Turbopuffer operations across stream chunks, keyed by namespace URL and document id, compacting later operations for the same document.
- Flushes all pending namespaces together when total pending rows reaches `write_batch_size`, when the linger timer fires, or when stop/vnode/schema-change barriers require it.
- Truncates log offsets only after successful flushes, while directly truncating barriers when there is no pending data.
- Updates generated alter-on-fly metadata and Turbopuffer SLT coverage.

## Checklist

- [ ] I have written necessary rustdoc comments.
- [x] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [x] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

Turbopuffer sinks now support alterable `write_batch_size` and `max_linger_second` options to control cross-chunk batching and flush latency.

</details>
