### PR TITLE
fix(meta): add ON DELETE CASCADE foreign key for pending_sink_state

### DIFF
--- a/e2e_test/backwards-compat-tests/scripts/utils.sh
+++ b/e2e_test/backwards-compat-tests/scripts/utils.sh
@@ -446,6 +446,13 @@ seed_old_cluster() {
   echo "--- CDC TEST: Validating old cluster"
   sqllogictest -d dev -h localhost -p 4566 "$TEST_DIR/cdc/validate_original.slt"
 
+  # The `pending_sink_state` table and exactly-once Iceberg sinks exist since 2.8.0.
+  if version_le "2.8.0" "$OLD_VERSION"; then
+    echo "--- PENDING SINK STATE TEST: Seeding old cluster with a dropped Iceberg sink"
+    ./risedev mc mb -p hummock-minio/icebergdata || true
+    sqllogictest -d dev -h localhost -p 4566 "$TEST_DIR/pending-sink-state/seed.slt"
+  fi
+
   # work around https://github.com/risingwavelabs/risingwave/issues/18650
   echo "--- wait for a version checkpoint"
   sleep 60
@@ -513,6 +520,12 @@ validate_new_cluster() {
 
   echo "--- CDC TEST: Validating new cluster"
   sqllogictest -d dev -h localhost -p 4566 "$TEST_DIR/cdc/validate_restart.slt"
+
+  # The `pending_sink_state` table and exactly-once Iceberg sinks exist since 2.8.0.
+  if version_le "2.8.0" "$OLD_VERSION"; then
+    echo "--- PENDING SINK STATE TEST: Validating new cluster"
+    sqllogictest -d dev -h localhost -p 4566 "$TEST_DIR/pending-sink-state/validate_restart.slt"
+  fi
 
   validate_hummock_stale_table_ids
 

--- a/e2e_test/backwards-compat-tests/slt/pending-sink-state/seed.slt
+++ b/e2e_test/backwards-compat-tests/slt/pending-sink-state/seed.slt
@@ -1,0 +1,62 @@
+# Seed a dropped exactly-once Iceberg sink so it leaks `pending_sink_state` rows.
+#
+# Exactly-once (two-phase) sinks persist per-epoch pre-commit metadata in the
+# `pending_sink_state` meta-store table. On versions before the `ON DELETE CASCADE`
+# foreign key was added, dropping such a sink leaves those rows orphaned forever.
+# The upgrade migration must clean them up, otherwise adding the foreign key would
+# fail referential-integrity validation (on Postgres/MySQL) or the table recreate
+# would have to cope with the leftover data (on SQLite).
+#
+# See https://github.com/risingwavelabs/risingwave/issues/26044.
+
+statement ok
+SET sink_decouple = false;
+
+statement ok
+SET RW_IMPLICIT_FLUSH = true;
+
+statement ok
+CREATE TABLE pending_sink_state_src (v1 int primary key, v2 bigint);
+
+statement ok
+CREATE SINK pending_sink_state_sink AS SELECT v1, v2 FROM pending_sink_state_src WITH (
+    connector = 'iceberg',
+    type = 'upsert',
+    primary_key = 'v1',
+    is_exactly_once = 'true',
+    warehouse.path = 's3a://icebergdata/backwards_compat',
+    s3.endpoint = 'http://127.0.0.1:9301',
+    s3.access.key = 'hummockadmin',
+    s3.secret.key = 'hummockadmin',
+    s3.region = 'us-east-1',
+    catalog.name = 'demo',
+    catalog.type = 'storage',
+    database.name = 'backwards_compat_db',
+    table.name = 'pending_sink_state_table',
+    commit_checkpoint_interval = 1,
+    create_table_if_not_exists = 'true'
+);
+
+statement ok
+INSERT INTO pending_sink_state_src VALUES (1, 10), (2, 20), (3, 30);
+
+statement ok
+FLUSH;
+
+# Let the exactly-once coordinator persist at least one epoch of `pending_sink_state`.
+sleep 10s
+
+statement ok
+INSERT INTO pending_sink_state_src VALUES (4, 40);
+
+statement ok
+FLUSH;
+
+sleep 5s
+
+# Drop the sink. Before the foreign-key fix this leaks its `pending_sink_state` rows.
+statement ok
+DROP SINK pending_sink_state_sink;
+
+statement ok
+DROP TABLE pending_sink_state_src;

--- a/e2e_test/backwards-compat-tests/slt/pending-sink-state/validate_restart.slt
+++ b/e2e_test/backwards-compat-tests/slt/pending-sink-state/validate_restart.slt
@@ -1,0 +1,25 @@
+# Validate that the upgrade succeeded despite the dropped Iceberg sink's leaked
+# `pending_sink_state` rows.
+#
+# Reaching this point already proves the most important property: the new meta
+# node started, which means the upgrade migration cleaned up the orphaned rows
+# and added the foreign key without erroring out. The queries below just confirm
+# the catalog is consistent and the cluster is serving.
+#
+# See https://github.com/risingwavelabs/risingwave/issues/26044.
+
+query I
+SELECT 1;
+----
+1
+
+# The dropped sink and its table must not reappear after the upgrade.
+query I
+SELECT count(*) FROM rw_sinks WHERE name = 'pending_sink_state_sink';
+----
+0
+
+query I
+SELECT count(*) FROM rw_tables WHERE name = 'pending_sink_state_src';
+----
+0

--- a/src/meta/model/migration/src/lib.rs
+++ b/src/meta/model/migration/src/lib.rs
@@ -72,6 +72,7 @@ mod m20260311_000000_legacy_streaming_parallelism_session_params;
 mod m20260312_000000_streaming_job_backfill_parallelism_strategy;
 mod m20260518_000000_disable_unused_read_prefix_hints;
 mod m20260519_000000_streaming_job_batch_refresh_seconds;
+mod m20260624_000000_pending_sink_state_object_fk;
 mod utils;
 
 pub struct Migrator;
@@ -182,6 +183,7 @@ impl MigratorTrait for Migrator {
             Box::new(m20260312_000000_streaming_job_backfill_parallelism_strategy::Migration),
             Box::new(m20260518_000000_disable_unused_read_prefix_hints::Migration),
             Box::new(m20260519_000000_streaming_job_batch_refresh_seconds::Migration),
+            Box::new(m20260624_000000_pending_sink_state_object_fk::Migration),
         ]
     }
 }

--- a/src/meta/model/migration/src/m20260624_000000_pending_sink_state_object_fk.rs
+++ b/src/meta/model/migration/src/m20260624_000000_pending_sink_state_object_fk.rs
@@ -1,0 +1,146 @@
+use sea_orm_migration::prelude::*;
+
+use crate::m20230908_072257_init::Object;
+use crate::sea_orm::{DatabaseBackend, Statement};
+use crate::utils::ColumnDefExt;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+const FK_NAME: &str = "FK_pending_sink_state_object_id";
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        let conn = manager.get_connection();
+        let backend = manager.get_database_backend();
+
+        // Clean up rows leaked by sink drops before the foreign key existed, so the key
+        // below passes validation. See https://github.com/risingwavelabs/risingwave/issues/26044.
+        conn.execute(Statement::from_string(
+            backend,
+            "DELETE FROM pending_sink_state WHERE sink_id NOT IN (SELECT oid FROM object)",
+        ))
+        .await?;
+
+        match backend {
+            DatabaseBackend::MySql | DatabaseBackend::Postgres => {
+                manager
+                    .alter_table(
+                        Table::alter()
+                            .table(PendingSinkState::Table)
+                            .add_foreign_key(
+                                TableForeignKey::new()
+                                    .name(FK_NAME)
+                                    .from_tbl(PendingSinkState::Table)
+                                    .from_col(PendingSinkState::SinkId)
+                                    .to_tbl(Object::Table)
+                                    .to_col(Object::Oid)
+                                    .on_delete(ForeignKeyAction::Cascade),
+                            )
+                            .to_owned(),
+                    )
+                    .await?;
+            }
+            DatabaseBackend::Sqlite => {
+                // SQLite cannot add a foreign key to an existing table; recreate it instead.
+                // SQLite is not for prod usage, so recreating the table is fine.
+                let tmp_table = Alias::new("pending_sink_state_new");
+                manager
+                    .create_table(
+                        Table::create()
+                            .table(tmp_table.clone())
+                            .col(
+                                ColumnDef::new(PendingSinkState::SinkId)
+                                    .integer()
+                                    .not_null(),
+                            )
+                            .col(
+                                ColumnDef::new(PendingSinkState::Epoch)
+                                    .big_integer()
+                                    .not_null(),
+                            )
+                            .col(
+                                ColumnDef::new(PendingSinkState::SinkState)
+                                    .string()
+                                    .not_null(),
+                            )
+                            .col(
+                                ColumnDef::new(PendingSinkState::Metadata)
+                                    .rw_binary(manager)
+                                    .null(),
+                            )
+                            .col(
+                                ColumnDef::new(PendingSinkState::SchemaChange)
+                                    .rw_binary(manager)
+                                    .null(),
+                            )
+                            .primary_key(
+                                Index::create()
+                                    .col(PendingSinkState::SinkId)
+                                    .col(PendingSinkState::Epoch),
+                            )
+                            .foreign_key(
+                                &mut ForeignKey::create()
+                                    .name(FK_NAME)
+                                    .from(tmp_table.clone(), PendingSinkState::SinkId)
+                                    .to(Object::Table, Object::Oid)
+                                    .on_delete(ForeignKeyAction::Cascade)
+                                    .to_owned(),
+                            )
+                            .to_owned(),
+                    )
+                    .await?;
+                conn.execute(Statement::from_string(
+                    backend,
+                    "INSERT INTO pending_sink_state_new \
+                        (sink_id, epoch, sink_state, metadata, schema_change) \
+                     SELECT sink_id, epoch, sink_state, metadata, schema_change \
+                     FROM pending_sink_state",
+                ))
+                .await?;
+                manager
+                    .drop_table(Table::drop().table(PendingSinkState::Table).to_owned())
+                    .await?;
+                manager
+                    .rename_table(
+                        Table::rename()
+                            .table(tmp_table, PendingSinkState::Table)
+                            .to_owned(),
+                    )
+                    .await?;
+            }
+        }
+
+        Ok(())
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        match manager.get_database_backend() {
+            DatabaseBackend::MySql | DatabaseBackend::Postgres => {
+                manager
+                    .alter_table(
+                        Table::alter()
+                            .table(PendingSinkState::Table)
+                            .drop_foreign_key(Alias::new(FK_NAME))
+                            .to_owned(),
+                    )
+                    .await?;
+            }
+            DatabaseBackend::Sqlite => {
+                // No-op: the key is part of the table definition and SQLite is not for prod usage.
+            }
+        }
+        Ok(())
+    }
+}
+
+#[derive(DeriveIden)]
+enum PendingSinkState {
+    Table,
+    SinkId,
+    Epoch,
+    SinkState,
+    Metadata,
+    SchemaChange,
+}

--- a/src/meta/model/migration/src/m20260624_000000_pending_sink_state_object_fk.rs
+++ b/src/meta/model/migration/src/m20260624_000000_pending_sink_state_object_fk.rs
@@ -1,117 +1,45 @@
 use sea_orm_migration::prelude::*;
 
 use crate::m20230908_072257_init::Object;
-use crate::sea_orm::{DatabaseBackend, Statement};
+use crate::sea_orm::{ConnectionTrait, DatabaseBackend, Statement, TransactionTrait};
 use crate::utils::ColumnDefExt;
 
 #[derive(DeriveMigrationName)]
 pub struct Migration;
 
 const FK_NAME: &str = "FK_pending_sink_state_object_id";
+const NEW_TABLE: &str = "pending_sink_state_new";
 
 #[async_trait::async_trait]
 impl MigrationTrait for Migration {
     async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
-        let conn = manager.get_connection();
+        // The model declares the `sink_id -> object(oid)` cascade but the foreign key was never
+        // created, leaking rows on DROP SINK. Add the key and clean up the leaked rows.
+        // https://github.com/risingwavelabs/risingwave/issues/26044
         let backend = manager.get_database_backend();
-
-        // Clean up rows leaked by sink drops before the foreign key existed, so the key
-        // below passes validation. See https://github.com/risingwavelabs/risingwave/issues/26044.
-        conn.execute(Statement::from_string(
-            backend,
-            "DELETE FROM pending_sink_state WHERE sink_id NOT IN (SELECT oid FROM object)",
-        ))
-        .await?;
-
         match backend {
             DatabaseBackend::MySql | DatabaseBackend::Postgres => {
+                manager
+                    .get_connection()
+                    .execute(Statement::from_string(
+                        backend,
+                        "DELETE FROM pending_sink_state WHERE sink_id NOT IN (SELECT oid FROM object)",
+                    ))
+                    .await?;
                 manager
                     .alter_table(
                         Table::alter()
                             .table(PendingSinkState::Table)
-                            .add_foreign_key(
-                                TableForeignKey::new()
-                                    .name(FK_NAME)
-                                    .from_tbl(PendingSinkState::Table)
-                                    .from_col(PendingSinkState::SinkId)
-                                    .to_tbl(Object::Table)
-                                    .to_col(Object::Oid)
-                                    .on_delete(ForeignKeyAction::Cascade),
-                            )
+                            .add_foreign_key(&object_foreign_key())
                             .to_owned(),
                     )
                     .await?;
             }
             DatabaseBackend::Sqlite => {
-                // SQLite cannot add a foreign key to an existing table; recreate it instead.
-                // SQLite is not for prod usage, so recreating the table is fine.
-                let tmp_table = Alias::new("pending_sink_state_new");
-                manager
-                    .create_table(
-                        Table::create()
-                            .table(tmp_table.clone())
-                            .col(
-                                ColumnDef::new(PendingSinkState::SinkId)
-                                    .integer()
-                                    .not_null(),
-                            )
-                            .col(
-                                ColumnDef::new(PendingSinkState::Epoch)
-                                    .big_integer()
-                                    .not_null(),
-                            )
-                            .col(
-                                ColumnDef::new(PendingSinkState::SinkState)
-                                    .string()
-                                    .not_null(),
-                            )
-                            .col(
-                                ColumnDef::new(PendingSinkState::Metadata)
-                                    .rw_binary(manager)
-                                    .null(),
-                            )
-                            .col(
-                                ColumnDef::new(PendingSinkState::SchemaChange)
-                                    .rw_binary(manager)
-                                    .null(),
-                            )
-                            .primary_key(
-                                Index::create()
-                                    .col(PendingSinkState::SinkId)
-                                    .col(PendingSinkState::Epoch),
-                            )
-                            .foreign_key(
-                                &mut ForeignKey::create()
-                                    .name(FK_NAME)
-                                    .from(tmp_table.clone(), PendingSinkState::SinkId)
-                                    .to(Object::Table, Object::Oid)
-                                    .on_delete(ForeignKeyAction::Cascade)
-                                    .to_owned(),
-                            )
-                            .to_owned(),
-                    )
-                    .await?;
-                conn.execute(Statement::from_string(
-                    backend,
-                    "INSERT INTO pending_sink_state_new \
-                        (sink_id, epoch, sink_state, metadata, schema_change) \
-                     SELECT sink_id, epoch, sink_state, metadata, schema_change \
-                     FROM pending_sink_state",
-                ))
-                .await?;
-                manager
-                    .drop_table(Table::drop().table(PendingSinkState::Table).to_owned())
-                    .await?;
-                manager
-                    .rename_table(
-                        Table::rename()
-                            .table(tmp_table, PendingSinkState::Table)
-                            .to_owned(),
-                    )
-                    .await?;
+                // SQLite can't `ALTER TABLE ADD FOREIGN KEY`; recreate the table with it instead.
+                recreate_table(manager, true).await?;
             }
         }
-
         Ok(())
     }
 
@@ -128,11 +56,103 @@ impl MigrationTrait for Migration {
                     .await?;
             }
             DatabaseBackend::Sqlite => {
-                // No-op: the key is part of the table definition and SQLite is not for prod usage.
+                recreate_table(manager, false).await?;
             }
         }
         Ok(())
     }
+}
+
+fn object_foreign_key() -> TableForeignKey {
+    TableForeignKey::new()
+        .name(FK_NAME)
+        .from_tbl(PendingSinkState::Table)
+        .from_col(PendingSinkState::SinkId)
+        .to_tbl(Object::Table)
+        .to_col(Object::Oid)
+        .on_delete(ForeignKeyAction::Cascade)
+        .to_owned()
+}
+
+/// Recreate `pending_sink_state` with (or without) the object foreign key, dropping leaked rows
+/// during the copy. The swap runs in one transaction so it stays atomic and re-runnable even
+/// though the migrator opens none for SQLite. SQLite-only: it can't alter foreign keys in place.
+async fn recreate_table(manager: &SchemaManager<'_>, with_foreign_key: bool) -> Result<(), DbErr> {
+    let backend = manager.get_database_backend();
+    // TODO(#26046): on sea-orm 2.0, drop this manual transaction and override
+    // `MigrationTrait::use_transaction()` to return `Some(true)` instead.
+    let txn = manager.get_connection().begin().await?;
+    {
+        let txn_manager = SchemaManager::new(&txn);
+
+        let mut create = Table::create();
+        create
+            .table(Alias::new(NEW_TABLE))
+            .col(
+                ColumnDef::new(PendingSinkState::SinkId)
+                    .integer()
+                    .not_null(),
+            )
+            .col(
+                ColumnDef::new(PendingSinkState::Epoch)
+                    .big_integer()
+                    .not_null(),
+            )
+            .col(
+                ColumnDef::new(PendingSinkState::SinkState)
+                    .string()
+                    .not_null(),
+            )
+            .col(
+                ColumnDef::new(PendingSinkState::Metadata)
+                    .rw_binary(&txn_manager)
+                    .null(),
+            )
+            .col(
+                ColumnDef::new(PendingSinkState::SchemaChange)
+                    .rw_binary(&txn_manager)
+                    .null(),
+            )
+            .primary_key(
+                Index::create()
+                    .col(PendingSinkState::SinkId)
+                    .col(PendingSinkState::Epoch),
+            );
+        if with_foreign_key {
+            create.foreign_key(
+                ForeignKey::create()
+                    .name(FK_NAME)
+                    .from_tbl(Alias::new(NEW_TABLE))
+                    .from_col(PendingSinkState::SinkId)
+                    .to_tbl(Object::Table)
+                    .to_col(Object::Oid)
+                    .on_delete(ForeignKeyAction::Cascade),
+            );
+        }
+        txn_manager.create_table(create).await?;
+
+        txn.execute(Statement::from_string(
+            backend,
+            "INSERT INTO pending_sink_state_new \
+             (sink_id, epoch, sink_state, metadata, schema_change) \
+             SELECT sink_id, epoch, sink_state, metadata, schema_change \
+             FROM pending_sink_state WHERE sink_id IN (SELECT oid FROM object)",
+        ))
+        .await?;
+
+        txn_manager
+            .drop_table(Table::drop().table(PendingSinkState::Table).to_owned())
+            .await?;
+        txn_manager
+            .rename_table(
+                Table::rename()
+                    .table(Alias::new(NEW_TABLE), PendingSinkState::Table)
+                    .to_owned(),
+            )
+            .await?;
+    }
+    txn.commit().await?;
+    Ok(())
 }
 
 #[derive(DeriveIden)]


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

`pending_sink_state` rows leaked on `DROP SINK`. The model declares `on_delete = "Cascade"`, but the original migration never created the DB foreign key, so the cascade from `Object::delete_many` never reached the table. Rows accumulated forever (notably from exactly-once Iceberg sinks) and bloated the meta snapshot/backup, risking meta OOM.

This PR adds a migration that:

1. Deletes existing orphaned rows (`sink_id` with no matching `object`), cleaning up leaks on upgrade and letting the FK pass validation.
2. Creates the `pending_sink_state.sink_id → object(oid)` foreign key with `ON DELETE CASCADE` (recreates the table on SQLite, which cannot `ALTER ADD` a foreign key).

Verified end-to-end on Postgres and MySQL meta backends: a real exactly-once Iceberg sink writes a `pending_sink_state` row, and `DROP SINK` now cascade-deletes it.

- Closes #26044

## Checklist

- [x] I have added necessary unit tests and integration tests. <!-- Covered by the migration apply path on all backends + manual PG/MySQL cascade verification; FK cascade is only enforced on prod backends, not the SQLite test backend. -->

## Documentation

- [ ] My PR needs documentation updates.
