### PR TITLE
feat(storage): add backfill serving latency diagnostics

### DIFF
--- a/src/storage/src/hummock/event_handler/hummock_event_handler.rs
+++ b/src/storage/src/hummock/event_handler/hummock_event_handler.rs
@@ -41,7 +41,9 @@ use super::refiller::{CacheRefillConfig, CacheRefiller};
 use super::{LocalInstanceGuard, LocalInstanceId, ReadVersionMappingType};
 use crate::compaction_catalog_manager::CompactionCatalogManagerRef;
 use crate::hummock::compactor::{CompactorContext, await_tree_key, compact};
-use crate::hummock::event_handler::refiller::{CacheRefillerEvent, SpawnRefillTask};
+use crate::hummock::event_handler::refiller::{
+    CacheRefillerEvent, GLOBAL_CACHE_REFILL_METRICS, SpawnRefillTask,
+};
 use crate::hummock::event_handler::uploader::{
     HummockUploader, SpawnUploadTask, SyncedData, UploadTaskOutput,
 };
@@ -639,6 +641,7 @@ impl HummockEventHandler {
             for CacheRefillerEvent {
                 pinned_version,
                 new_pinned_version,
+                ..
             } in &events
             {
                 assert_eq!(pinned_version.id(), state.id());
@@ -651,6 +654,17 @@ impl HummockEventHandler {
             }
             modified
         });
+        for event in &events {
+            GLOBAL_CACHE_REFILL_METRICS
+                .version_update_to_apply_duration
+                .observe(event.started_at.elapsed().as_secs_f64());
+            GLOBAL_CACHE_REFILL_METRICS
+                .version_update_sst_delta_count
+                .observe(event.sst_delta_count as f64);
+            GLOBAL_CACHE_REFILL_METRICS
+                .version_update_inserted_sstable_count
+                .observe(event.inserted_sstable_count as f64);
+        }
 
         debug!("update to hummock version: {}", latest_pinned_version.id(),);
 

--- a/src/storage/src/hummock/event_handler/refiller.rs
+++ b/src/storage/src/hummock/event_handler/refiller.rs
@@ -25,7 +25,8 @@ use futures::{Future, FutureExt};
 use itertools::Itertools;
 use prometheus::core::{AtomicU64, GenericCounter, GenericCounterVec};
 use prometheus::{
-    Histogram, HistogramVec, IntGauge, Registry, register_histogram_vec_with_registry,
+    Histogram, HistogramVec, IntGauge, Registry, exponential_buckets, histogram_opts,
+    register_histogram_vec_with_registry, register_histogram_with_registry,
     register_int_counter_vec_with_registry, register_int_gauge_with_registry,
 };
 use risingwave_common::license::Feature;
@@ -54,6 +55,11 @@ pub struct CacheRefillMetrics {
 
     pub data_refill_success_duration: Histogram,
     pub meta_refill_success_duration: Histogram,
+    pub version_update_to_apply_duration: Histogram,
+    pub version_update_sst_delta_count: Histogram,
+    pub version_update_inserted_sstable_count: Histogram,
+    pub delta_refill_duration: HistogramVec,
+    pub meta_refill_sstable_duration: Histogram,
 
     pub data_refill_filtered_total: GenericCounter<AtomicU64>,
     pub data_refill_attempts_total: GenericCounter<AtomicU64>,
@@ -152,6 +158,57 @@ impl CacheRefillMetrics {
         )
         .unwrap();
 
+        let duration_buckets = exponential_buckets(0.001, 5.0, 8).unwrap(); // 1ms - 78s
+        let count_buckets = vec![
+            0.0, 1.0, 2.0, 4.0, 8.0, 16.0, 32.0, 64.0, 128.0, 256.0, 512.0, 1024.0,
+        ];
+        let version_update_to_apply_duration = register_histogram_with_registry!(
+            histogram_opts!(
+                "hummock_cache_refill_version_update_to_apply_duration",
+                "Time from receiving a Hummock version update to making it visible locally after cache refill",
+                duration_buckets.clone(),
+            ),
+            registry
+        )
+        .unwrap();
+        let version_update_sst_delta_count = register_histogram_with_registry!(
+            histogram_opts!(
+                "hummock_cache_refill_version_update_sst_delta_count",
+                "Number of SST delta groups in one Hummock version update cache refill",
+                count_buckets.clone(),
+            ),
+            registry
+        )
+        .unwrap();
+        let version_update_inserted_sstable_count = register_histogram_with_registry!(
+            histogram_opts!(
+                "hummock_cache_refill_version_update_inserted_sstable_count",
+                "Number of inserted SSTs in one Hummock version update cache refill",
+                count_buckets,
+            ),
+            registry
+        )
+        .unwrap();
+        let delta_refill_duration = register_histogram_vec_with_registry!(
+            histogram_opts!(
+                "hummock_cache_refill_delta_duration",
+                "Time spent refilling cache for one SST delta group",
+                duration_buckets.clone(),
+            ),
+            &["type"],
+            registry
+        )
+        .unwrap();
+        let meta_refill_sstable_duration = register_histogram_with_registry!(
+            histogram_opts!(
+                "hummock_cache_refill_meta_sstable_duration",
+                "Time spent loading one inserted SSTable meta during cache refill",
+                duration_buckets,
+            ),
+            registry
+        )
+        .unwrap();
+
         Self {
             refill_duration,
             refill_total,
@@ -159,6 +216,11 @@ impl CacheRefillMetrics {
 
             data_refill_success_duration,
             meta_refill_success_duration,
+            version_update_to_apply_duration,
+            version_update_sst_delta_count,
+            version_update_inserted_sstable_count,
+            delta_refill_duration,
+            meta_refill_sstable_duration,
             data_refill_filtered_total,
             data_refill_attempts_total,
             data_refill_started_total,
@@ -293,6 +355,12 @@ impl CacheRefiller {
         pinned_version: PinnedVersion,
         new_pinned_version: PinnedVersion,
     ) {
+        let started_at = Instant::now();
+        let sst_delta_count = deltas.len();
+        let inserted_sstable_count = deltas
+            .iter()
+            .map(|delta| delta.insert_sst_infos.len())
+            .sum();
         let handle = (self.spawn_refill_task)(
             deltas,
             self.context.clone(),
@@ -302,6 +370,9 @@ impl CacheRefiller {
         let event = CacheRefillerEvent {
             pinned_version,
             new_pinned_version,
+            started_at,
+            sst_delta_count,
+            inserted_sstable_count,
         };
         let item = Item { handle, event };
         self.queue.push_back(item);
@@ -342,6 +413,9 @@ impl CacheRefiller {
 pub struct CacheRefillerEvent {
     pub pinned_version: PinnedVersion,
     pub new_pinned_version: PinnedVersion,
+    pub started_at: Instant,
+    pub sst_delta_count: usize,
+    pub inserted_sstable_count: usize,
 }
 
 #[derive(Clone)]
@@ -365,14 +439,28 @@ impl CacheRefillTask {
             .map(|delta| {
                 let context = self.context.clone();
                 async move {
+                    let meta_started_at = Instant::now();
                     let holders = match Self::meta_cache_refill(&context, delta).await {
                         Ok(holders) => holders,
                         Err(e) => {
+                            GLOBAL_CACHE_REFILL_METRICS
+                                .delta_refill_duration
+                                .with_label_values(&["meta"])
+                                .observe(meta_started_at.elapsed().as_secs_f64());
                             tracing::warn!(error = %e.as_report(), "meta cache refill error");
                             return;
                         }
                     };
+                    GLOBAL_CACHE_REFILL_METRICS
+                        .delta_refill_duration
+                        .with_label_values(&["meta"])
+                        .observe(meta_started_at.elapsed().as_secs_f64());
+                    let data_started_at = Instant::now();
                     Self::data_cache_refill(&context, delta, holders).await;
+                    GLOBAL_CACHE_REFILL_METRICS
+                        .delta_refill_duration
+                        .with_label_values(&["data"])
+                        .observe(data_started_at.elapsed().as_secs_f64());
                 }
             })
             .collect_vec();
@@ -401,6 +489,9 @@ impl CacheRefillTask {
                 let now = Instant::now();
                 let res = context.sstable_store.sstable(info, &mut stats).await;
                 stats.discard();
+                GLOBAL_CACHE_REFILL_METRICS
+                    .meta_refill_sstable_duration
+                    .observe(now.elapsed().as_secs_f64());
                 GLOBAL_CACHE_REFILL_METRICS
                     .meta_refill_success_duration
                     .observe(now.elapsed().as_secs_f64());

--- a/src/storage/src/hummock/store/hummock_storage.rs
+++ b/src/storage/src/hummock/store/hummock_storage.rs
@@ -945,15 +945,9 @@ impl HummockStorage {
                     start.elapsed(),
                 );
             }
-            HummockReadEpoch::NoWait(_) => {
-                self.observe_try_wait_epoch(table_id, "no_wait", "noop", start.elapsed());
-            }
-            HummockReadEpoch::Backup(_) => {
-                self.observe_try_wait_epoch(table_id, "backup", "noop", start.elapsed());
-            }
-            HummockReadEpoch::TimeTravel(_) => {
-                self.observe_try_wait_epoch(table_id, "time_travel", "noop", start.elapsed());
-            }
+            HummockReadEpoch::NoWait(_)
+            | HummockReadEpoch::Backup(_)
+            | HummockReadEpoch::TimeTravel(_) => {}
         };
         Ok(())
     }

--- a/src/storage/src/hummock/store/hummock_storage.rs
+++ b/src/storage/src/hummock/store/hummock_storage.rs
@@ -16,6 +16,7 @@ use std::collections::HashSet;
 use std::future::Future;
 use std::ops::{Bound, Deref};
 use std::sync::Arc;
+use std::time::{Duration, Instant};
 
 use arc_swap::ArcSwap;
 use bytes::Bytes;
@@ -124,6 +125,8 @@ pub struct HummockStorage {
     simple_time_travel_version_cache: Arc<SimpleTimeTravelVersionCache>,
 
     table_change_log_manager: Arc<TableChangeLogManager>,
+
+    state_store_metrics: Arc<HummockStateStoreMetrics>,
 }
 
 pub type ReadVersionTuple = (Vec<ImmutableMemtable>, Vec<SstableInfo>, CommittedVersion);
@@ -253,6 +256,7 @@ impl HummockStorage {
                 options.time_travel_version_cache_capacity,
             )),
             table_change_log_manager,
+            state_store_metrics,
         };
 
         tokio::spawn(hummock_event_handler.start_hummock_event_handler_worker());
@@ -881,10 +885,12 @@ impl HummockStorage {
             wait_epoch,
             table_id
         );
+        let start = Instant::now();
         match wait_epoch {
             HummockReadEpoch::Committed(wait_epoch) => {
                 assert!(!is_max_epoch(wait_epoch), "epoch should not be MAX EPOCH");
                 wait_for_epoch(&self.version_update_notifier_tx, wait_epoch, table_id).await?;
+                self.observe_try_wait_epoch(table_id, "committed", "wait", start.elapsed());
             }
             HummockReadEpoch::BatchQueryCommitted(wait_epoch, wait_version_id) => {
                 assert!(!is_max_epoch(wait_epoch), "epoch should not be MAX EPOCH");
@@ -897,6 +903,12 @@ impl HummockStorage {
                             latest_version.table_committed_epoch(table_id)
                         && committed_epoch >= wait_epoch
                     {
+                        self.observe_try_wait_epoch(
+                            table_id,
+                            "batch_query_committed",
+                            "fast",
+                            start.elapsed(),
+                        );
                         return Ok(());
                     }
                 }
@@ -926,10 +938,38 @@ impl HummockStorage {
                     },
                 )
                 .await?;
+                self.observe_try_wait_epoch(
+                    table_id,
+                    "batch_query_committed",
+                    "slow",
+                    start.elapsed(),
+                );
             }
-            _ => {}
+            HummockReadEpoch::NoWait(_) => {
+                self.observe_try_wait_epoch(table_id, "no_wait", "noop", start.elapsed());
+            }
+            HummockReadEpoch::Backup(_) => {
+                self.observe_try_wait_epoch(table_id, "backup", "noop", start.elapsed());
+            }
+            HummockReadEpoch::TimeTravel(_) => {
+                self.observe_try_wait_epoch(table_id, "time_travel", "noop", start.elapsed());
+            }
         };
         Ok(())
+    }
+
+    fn observe_try_wait_epoch(
+        &self,
+        table_id: TableId,
+        epoch_type: &'static str,
+        path: &'static str,
+        duration: Duration,
+    ) {
+        let table_id_label = table_id.to_string();
+        self.state_store_metrics
+            .try_wait_epoch_duration
+            .with_guarded_label_values(&[table_id_label.as_str(), epoch_type, path])
+            .observe(duration.as_secs_f64());
     }
 }
 

--- a/src/storage/src/monitor/hummock_state_store_metrics.rs
+++ b/src/storage/src/monitor/hummock_state_store_metrics.rs
@@ -96,6 +96,11 @@ pub struct HummockStateStoreMetrics {
 
     pub safe_version_hit: GenericCounter<AtomicU64>,
     pub safe_version_miss: GenericCounter<AtomicU64>,
+
+    /// Duration spent waiting for the local Hummock version to cover a read epoch.
+    /// This is intentionally outside `state_store_get_duration`: batch point lookups
+    /// can wait here before the actual table get starts.
+    pub try_wait_epoch_duration: RelabeledGuardedHistogramVec,
 }
 
 pub static GLOBAL_HUMMOCK_STATE_STORE_METRICS: OnceLock<HummockStateStoreMetrics> = OnceLock::new();
@@ -595,6 +600,23 @@ impl HummockStateStoreMetrics {
             .register(Box::new(safe_version_miss.clone()))
             .unwrap();
 
+        let opts = histogram_opts!(
+            "state_store_try_wait_epoch_duration",
+            "Duration spent waiting for the local Hummock version to cover a read epoch",
+            exponential_buckets(0.000001, 4.0, 12).unwrap(), // 1us - 4s
+        );
+        let try_wait_epoch_duration = register_guarded_histogram_vec_with_registry!(
+            opts,
+            &["table_id", "epoch_type", "path"],
+            registry
+        )
+        .unwrap();
+        let try_wait_epoch_duration = RelabeledGuardedHistogramVec::with_metric_level(
+            MetricLevel::Info,
+            try_wait_epoch_duration,
+            metric_level,
+        );
+
         Self {
             bloom_filter_true_negative_counts,
             bloom_filter_check_counts,
@@ -638,6 +660,7 @@ impl HummockStateStoreMetrics {
             event_handler_latency,
             safe_version_hit,
             safe_version_miss,
+            try_wait_epoch_duration,
         }
     }
 


### PR DESCRIPTION
## Summary

Add targeted storage diagnostics for the suspected path where an unrelated MV backfill delays serving reads through Hummock version visibility/cache-refill rather than through the serving MV's direct get path.

New metrics:

- `state_store_try_wait_epoch_duration{table_id, epoch_type, path}`
  - Measures time spent before a read can use a local Hummock version.
  - `path="fast"` / `path="slow"` distinguishes the `BatchQueryCommitted` recent-version hit from the watch-notifier wait path.
- `hummock_cache_refill_version_update_to_apply_duration`
  - Measures version update receipt -> cache refill -> `recent_versions`/notifier update visibility.
- `hummock_cache_refill_version_update_sst_delta_count`
- `hummock_cache_refill_version_update_inserted_sstable_count`
- `hummock_cache_refill_delta_duration{type="meta|data"}`
- `hummock_cache_refill_meta_sstable_duration`

These should let us correlate:

1. MV A backfill produces SST deltas.
2. Serving CN cache-refills SST metadata before applying the local Hummock version.
3. MV B serving query enters `try_wait_epoch` slow path.
4. MV B's direct `state_store_get_duration{table_id=B}` stays flat while end-to-end serving latency increases.

## Why

In the controlled experiment, MV B's direct Hummock get metric stayed flat, but serving latency tail increased during unrelated MV A backfill. The code path suggests the missing timing is before the actual table get: `try_wait_epoch` may wait for local version visibility, which is gated by cache refill of newly inserted SST metadata.

## Validation

- `cargo fmt --check`
- `git diff --check`
- `cargo check -p risingwave_storage --lib`
