### PR TITLE
test: relax iceberg v3 commit fault wait

### DIFF
--- a/src/tests/simulation/tests/integration_tests/sink/iceberg_v3_2pc/mod.rs
+++ b/src/tests/simulation/tests/integration_tests/sink/iceberg_v3_2pc/mod.rs
@@ -333,9 +333,12 @@ mod failpoint_limited {
         tokio::time::sleep(Duration::from_secs(10)).await;
         handle.mock.set_err_rate_txn_commit(0.0);
 
-        // Sink resumes committing once the fault clears.
+        // Sink resumes committing once the fault clears. The commit retry helper uses
+        // exponential backoff capped at 60s, and the probabilistic fault window above
+        // may already have pushed the next retry to that cap. Wait beyond the max
+        // backoff so this assertion checks recovery instead of retry sleep timing.
         tokio::time::timeout(
-            Duration::from_secs(30),
+            Duration::from_secs(90),
             handle.mock.wait_for_event_count('I', baseline_i_count + 1),
         )
         .await


### PR DESCRIPTION
## What's changed

Relax `failpoint_limited_test_v3_iceberg_commit_failure` so it waits up to 90s, instead of 30s, for a new successful Iceberg commit after clearing the mock commit-failure fault.

## Why

The test keeps a probabilistic Iceberg commit-failure window before clearing the fault. During that window, the shared Iceberg commit retry helper can advance to its 60s max exponential backoff. If the test only waits 30s after clearing the fault, it may fail while the next retry is still sleeping, instead of because recovery is broken.

The observed CI failure on PR #26049 matched this timing window:

```text
no new 'I' commits after fault cleared; baseline=1, current=1, trace = "Iiiiii"
```

## Impact

This keeps the test assertion focused on post-fault recovery progress rather than retry sleep timing. No product behavior is changed.

## Validation

- `cargo fmt --check`
- `git diff --check`

Attempted local narrow madsim run for seed 4, but did not complete locally:

- First attempt used an incomplete `RUSTFLAGS` override and failed during compilation because repo-required flags were missing.
- Second attempt used the full flags but triggered a large local madsim rebuild and was interrupted before test execution.

Requested CI coverage should validate the deterministic simulation case.
