### PR TITLE
perf(meta): reduce hummock versioning lock contention

### DIFF
--- a/src/meta/Cargo.toml
+++ b/src/meta/Cargo.toml
@@ -8,7 +8,7 @@ license = { workspace = true }
 repository = { workspace = true }
 
 [features]
-test = []
+test = ["risingwave_hummock_sdk/test"]
 failpoints = ["fail/failpoints"]
 
 [dependencies]

--- a/src/meta/node/Cargo.toml
+++ b/src/meta/node/Cargo.toml
@@ -10,6 +10,9 @@ repository = { workspace = true }
 [lib]
 test = false
 
+[features]
+test = ["risingwave_meta/test", "risingwave_meta_service/test"]
+
 [dependencies]
 clap = { workspace = true }
 educe = "0.6"

--- a/src/meta/service/Cargo.toml
+++ b/src/meta/service/Cargo.toml
@@ -7,6 +7,9 @@ keywords = { workspace = true }
 license = { workspace = true }
 repository = { workspace = true }
 
+[features]
+test = ["risingwave_meta/test"]
+
 [dependencies]
 anyhow = "1"
 async-trait = "0.1"

--- a/src/meta/service/src/hummock_service.rs
+++ b/src/meta/service/src/hummock_service.rs
@@ -108,17 +108,27 @@ impl HummockManagerService for HummockServiceImpl {
         &self,
         request: Request<ReplayVersionDeltaRequest>,
     ) -> Result<Response<ReplayVersionDeltaResponse>, Status> {
-        let req = request.into_inner();
-        let (version, compaction_groups) = self
-            .hummock_manager
-            .replay_version_delta(HummockVersionDelta::from_rpc_protobuf(
-                &req.version_delta.unwrap(),
+        #[cfg(any(test, feature = "test"))]
+        {
+            let req = request.into_inner();
+            let (version, compaction_groups) = self
+                .hummock_manager
+                .replay_version_delta(HummockVersionDelta::from_rpc_protobuf(
+                    &req.version_delta.unwrap(),
+                ))
+                .await?;
+            Ok(Response::new(ReplayVersionDeltaResponse {
+                version: Some(version.into()),
+                modified_compaction_groups: compaction_groups,
+            }))
+        }
+        #[cfg(not(any(test, feature = "test")))]
+        {
+            let _ = request;
+            Err(Status::unimplemented(
+                "replay_version_delta is only available in test builds",
             ))
-            .await?;
-        Ok(Response::new(ReplayVersionDeltaResponse {
-            version: Some(version.into()),
-            modified_compaction_groups: compaction_groups,
-        }))
+        }
     }
 
     async fn trigger_compaction_deterministic(
@@ -138,7 +148,7 @@ impl HummockManagerService for HummockServiceImpl {
     ) -> Result<Response<DisableCommitEpochResponse>, Status> {
         let version = self.hummock_manager.disable_commit_epoch().await;
         Ok(Response::new(DisableCommitEpochResponse {
-            current_version: Some(version.into()),
+            current_version: Some(PbHummockVersion::from(&*version)),
         }))
     }
 
@@ -349,7 +359,7 @@ impl HummockManagerService for HummockServiceImpl {
         let req = request.into_inner();
         let version = self.hummock_manager.pin_version(req.context_id).await?;
         Ok(Response::new(PinVersionResponse {
-            pinned_version: Some(version.into()),
+            pinned_version: Some(PbHummockVersion::from(&*version)),
         }))
     }
 
@@ -396,7 +406,7 @@ impl HummockManagerService for HummockServiceImpl {
     ) -> Result<Response<RiseCtlGetCheckpointVersionResponse>, Status> {
         let checkpoint_version = self.hummock_manager.get_checkpoint_version().await;
         Ok(Response::new(RiseCtlGetCheckpointVersionResponse {
-            checkpoint_version: Some(checkpoint_version.into()),
+            checkpoint_version: Some(PbHummockVersion::from(&*checkpoint_version)),
         }))
     }
 

--- a/src/meta/src/hummock/manager/checkpoint.rs
+++ b/src/meta/src/hummock/manager/checkpoint.rs
@@ -15,6 +15,7 @@
 use std::collections::{HashMap, HashSet};
 use std::ops::Bound::{Excluded, Included};
 use std::ops::{Deref, DerefMut};
+use std::sync::Arc;
 use std::sync::atomic::Ordering;
 
 use bytes::BytesMut;
@@ -33,7 +34,7 @@ use tracing::warn;
 use crate::hummock::HummockManager;
 use crate::hummock::error::Result;
 use crate::hummock::manager::versioning::Versioning;
-use crate::hummock::metrics_utils::{trigger_gc_stat, trigger_split_stat};
+use crate::hummock::metrics_utils::{gc_stale_object_stats, trigger_gc_stat, trigger_split_stat};
 
 /// Computes xxhash64 checksum of the given data, using seed 0.
 /// This matches the xxhash64 used in block checksum (see `sstable/utils.rs`).
@@ -46,7 +47,7 @@ pub(crate) fn xxhash64_checksum(data: &[u8]) -> u64 {
 
 #[derive(Default)]
 pub struct HummockVersionCheckpoint {
-    pub version: HummockVersion,
+    pub version: Arc<HummockVersion>,
 
     /// stale objects of versions before the current checkpoint.
     ///
@@ -59,7 +60,9 @@ pub struct HummockVersionCheckpoint {
 impl HummockVersionCheckpoint {
     pub fn from_protobuf(checkpoint: &PbHummockVersionCheckpoint) -> Self {
         Self {
-            version: HummockVersion::from_persisted_protobuf(checkpoint.version.as_ref().unwrap()),
+            version: Arc::new(HummockVersion::from_persisted_protobuf(
+                checkpoint.version.as_ref().unwrap(),
+            )),
             stale_objects: checkpoint
                 .stale_objects
                 .iter()
@@ -79,7 +82,7 @@ impl HummockVersionCheckpoint {
 
     pub fn to_protobuf(&self) -> PbHummockVersionCheckpoint {
         PbHummockVersionCheckpoint {
-            version: Some(PbHummockVersion::from(&self.version)),
+            version: Some(PbHummockVersion::from(self.version.as_ref())),
             stale_objects: self
                 .stale_objects
                 .iter()
@@ -388,40 +391,63 @@ impl HummockManager {
     /// lock throughout the method.
     pub async fn create_version_checkpoint(&self, min_delta_log_num: u64) -> Result<u64> {
         let timer = self.metrics.version_checkpoint_latency.start_timer();
-        // 1. hold read lock and create new checkpoint
-        let versioning_guard = self.versioning.read().await;
-        let versioning: &Versioning = versioning_guard.deref();
-        let current_version: &HummockVersion = &versioning.current_version;
-        let old_checkpoint: &HummockVersionCheckpoint = &versioning.checkpoint;
-        let new_checkpoint_id = current_version.id;
-        let old_checkpoint_id = old_checkpoint.version.id;
-        if new_checkpoint_id < old_checkpoint_id + min_delta_log_num {
-            return Ok(0);
-        }
-        if cfg!(test) && new_checkpoint_id == old_checkpoint_id {
-            drop(versioning_guard);
-            let versioning = self.versioning.read().await;
-            let context_info = self.context_info.read().await;
-            let min_pinned_version_id = context_info.min_pinned_version_id();
-            trigger_gc_stat(
-                &self.metrics,
-                &versioning.checkpoint,
-                min_pinned_version_id,
-                &versioning.table_change_log,
-            );
-            return Ok(0);
-        }
+        // 1. hold read lock briefly and snapshot checkpoint inputs.
+        let (
+            current_version,
+            old_checkpoint_version,
+            mut stale_objects,
+            version_deltas,
+            new_checkpoint_id,
+            old_checkpoint_id,
+        ) = {
+            let versioning_guard = self.versioning.read().await;
+            let versioning: &Versioning = versioning_guard.deref();
+            let current_version = versioning.current_version.clone();
+            let old_checkpoint: &HummockVersionCheckpoint = &versioning.checkpoint;
+            let new_checkpoint_id = current_version.id;
+            let old_checkpoint_id = old_checkpoint.version.id;
+            if new_checkpoint_id < old_checkpoint_id + min_delta_log_num {
+                return Ok(0);
+            }
+            if cfg!(test) && new_checkpoint_id == old_checkpoint_id {
+                drop(versioning_guard);
+                let versioning = self.versioning.read().await;
+                let context_info = self.context_info.read().await;
+                let min_pinned_version_id = context_info.min_pinned_version_id();
+                let stale_object_stats = gc_stale_object_stats(
+                    &versioning.checkpoint.stale_objects,
+                    min_pinned_version_id,
+                );
+                trigger_gc_stat(
+                    &self.metrics,
+                    versioning.checkpoint.version.as_ref(),
+                    &versioning.table_change_log,
+                    stale_object_stats,
+                );
+                return Ok(0);
+            }
+            let old_checkpoint_version = old_checkpoint.version.clone();
+            let version_deltas = versioning
+                .hummock_version_deltas
+                .range((Excluded(old_checkpoint_id), Included(new_checkpoint_id)))
+                .map(|(_, version_delta)| version_delta.clone())
+                .collect::<Vec<_>>();
+            (
+                current_version,
+                old_checkpoint_version,
+                old_checkpoint.stale_objects.clone(),
+                version_deltas,
+                new_checkpoint_id,
+                old_checkpoint_id,
+            )
+        };
         assert!(new_checkpoint_id > old_checkpoint_id);
         let mut archive: Option<PbHummockVersionArchive> = None;
-        let mut stale_objects = old_checkpoint.stale_objects.clone();
         // `object_sizes` is used to calculate size of stale objects.
-        let mut object_sizes = version_object_size_map(&old_checkpoint.version);
+        let mut object_sizes = version_object_size_map(old_checkpoint_version.as_ref());
         // The set of object ids that once exist in any hummock version
-        let mut versions_object_ids: HashSet<_> = old_checkpoint.version.get_object_ids().collect();
-        for (_, version_delta) in versioning
-            .hummock_version_deltas
-            .range((Excluded(old_checkpoint_id), Included(new_checkpoint_id)))
-        {
+        let mut versions_object_ids: HashSet<_> = old_checkpoint_version.get_object_ids().collect();
+        for version_delta in &version_deltas {
             // DO NOT REMOVE THIS LINE
             // This is to ensure that when adding new variant to `HummockObjectId`,
             // the compiler will warn us if we forget to handle it here.
@@ -493,11 +519,10 @@ impl HummockManager {
         });
         if self.env.opts.enable_hummock_data_archive {
             archive = Some(PbHummockVersionArchive {
-                version: Some(PbHummockVersion::from(&old_checkpoint.version)),
-                version_deltas: versioning
-                    .hummock_version_deltas
-                    .range((Excluded(old_checkpoint_id), Included(new_checkpoint_id)))
-                    .map(|(_, version_delta)| version_delta.into())
+                version: Some(PbHummockVersion::from(old_checkpoint_version.as_ref())),
+                version_deltas: version_deltas
+                    .iter()
+                    .map(|version_delta| version_delta.into())
                     .collect(),
             });
         }
@@ -517,7 +542,7 @@ impl HummockManager {
             version: current_version.clone(),
             stale_objects,
         };
-        drop(versioning_guard);
+        // 2. persist the new checkpoint without holding lock
         self.write_checkpoint(&new_checkpoint).await?;
         if let Some(archive) = archive
             && let Err(e) = self.write_version_archive(&archive).await
@@ -528,19 +553,24 @@ impl HummockManager {
                 archive.version.as_ref().unwrap().id
             );
         }
-        let mut versioning_guard = self.versioning.write().await;
-        let versioning = versioning_guard.deref_mut();
-        assert!(new_checkpoint.version.id > versioning.checkpoint.version.id);
-        versioning.checkpoint = new_checkpoint;
         let min_pinned_version_id = self.context_info.read().await.min_pinned_version_id();
+        let stale_object_stats =
+            gc_stale_object_stats(&new_checkpoint.stale_objects, min_pinned_version_id);
+        // 3. hold write lock briefly and update in memory state
+        let current_version_for_metrics = {
+            let mut versioning_guard = self.versioning.write().await;
+            let versioning = versioning_guard.deref_mut();
+            assert!(new_checkpoint.version.id > versioning.checkpoint.version.id);
+            versioning.checkpoint = new_checkpoint;
+            versioning.current_version.clone()
+        };
         trigger_gc_stat(
             &self.metrics,
-            &versioning.checkpoint,
-            min_pinned_version_id,
+            current_version.as_ref(),
             &versioning.table_change_log,
+            stale_object_stats,
         );
-        trigger_split_stat(&self.metrics, &versioning.current_version);
-        drop(versioning_guard);
+        trigger_split_stat(&self.metrics, current_version_for_metrics.as_ref());
         timer.observe_duration();
         self.metrics
             .checkpoint_version_id
@@ -564,7 +594,7 @@ impl HummockManager {
         self.pause_version_checkpoint.load(Ordering::Relaxed)
     }
 
-    pub async fn get_checkpoint_version(&self) -> HummockVersion {
+    pub async fn get_checkpoint_version(&self) -> Arc<HummockVersion> {
         let versioning_guard = self.versioning.read().await;
         versioning_guard.checkpoint.version.clone()
     }

--- a/src/meta/src/hummock/manager/checkpoint.rs
+++ b/src/meta/src/hummock/manager/checkpoint.rs
@@ -75,7 +75,8 @@ impl HummockVersionCheckpoint {
     /// moving data instead of cloning for better performance on large checkpoints.
     pub fn from_protobuf_owned(checkpoint: PbHummockVersionCheckpoint) -> Self {
         Self {
-            version: HummockVersion::from_persisted_protobuf_owned(checkpoint.version.unwrap()),
+            version: HummockVersion::from_persisted_protobuf_owned(checkpoint.version.unwrap())
+                .into(),
             stale_objects: checkpoint.stale_objects,
         }
     }
@@ -397,6 +398,7 @@ impl HummockManager {
             old_checkpoint_version,
             mut stale_objects,
             version_deltas,
+            current_table_change_log,
             new_checkpoint_id,
             old_checkpoint_id,
         ) = {
@@ -437,6 +439,7 @@ impl HummockManager {
                 old_checkpoint_version,
                 old_checkpoint.stale_objects.clone(),
                 version_deltas,
+                versioning.table_change_log.clone(),
                 new_checkpoint_id,
                 old_checkpoint_id,
             )
@@ -475,8 +478,7 @@ impl HummockManager {
         let current_version_object_ids = current_version
             .get_object_ids()
             .chain(
-                versioning
-                    .table_change_log
+                current_table_change_log
                     .values()
                     .flat_map(|l| l.get_object_ids()),
             )
@@ -567,7 +569,7 @@ impl HummockManager {
         trigger_gc_stat(
             &self.metrics,
             current_version.as_ref(),
-            &versioning.table_change_log,
+            &current_table_change_log,
             stale_object_stats,
         );
         trigger_split_stat(&self.metrics, current_version_for_metrics.as_ref());

--- a/src/meta/src/hummock/manager/commit_epoch.rs
+++ b/src/meta/src/hummock/manager/commit_epoch.rs
@@ -124,6 +124,7 @@ impl HummockManager {
             Some(&self.table_committed_epoch_notifiers),
             &self.metrics,
             &self.env.opts,
+            &self.version_stat_tx,
         );
 
         let state_table_info = &version.latest_version().state_table_info;

--- a/src/meta/src/hummock/manager/compaction/compaction_group_manager.rs
+++ b/src/meta/src/hummock/manager/compaction/compaction_group_manager.rs
@@ -201,6 +201,7 @@ impl HummockManager {
             None,
             &self.metrics,
             &self.env.opts,
+            &self.version_stat_tx,
         );
         let mut new_version_delta = version.new_delta();
 
@@ -300,6 +301,7 @@ impl HummockManager {
             None,
             &self.metrics,
             &self.env.opts,
+            &self.version_stat_tx,
         );
         let mut new_version_delta = version.new_delta();
         struct UnregisterGroupChange {

--- a/src/meta/src/hummock/manager/compaction/compaction_group_schedule.rs
+++ b/src/meta/src/hummock/manager/compaction/compaction_group_schedule.rs
@@ -372,6 +372,7 @@ impl HummockManager {
             None,
             &self.metrics,
             &self.env.opts,
+            &self.version_stat_tx,
         );
         let mut new_version_delta = version.new_delta();
 
@@ -685,6 +686,7 @@ impl HummockManager {
             None,
             &self.metrics,
             &self.env.opts,
+            &self.version_stat_tx,
         );
         let mut new_version_delta = version.new_delta();
 
@@ -1014,6 +1016,7 @@ impl HummockManager {
                 None,
                 &self.metrics,
                 &self.env.opts,
+                &self.version_stat_tx,
             );
             let mut new_version_delta = version.new_delta();
             let split_key = plan.split_key();

--- a/src/meta/src/hummock/manager/compaction/mod.rs
+++ b/src/meta/src/hummock/manager/compaction/mod.rs
@@ -358,6 +358,7 @@ impl HummockManager {
             None,
             &self.metrics,
             &self.env.opts,
+            &self.version_stat_tx,
         );
         // Apply stats changes.
         let mut version_stats = HummockVersionStatsTransaction::new(
@@ -843,6 +844,7 @@ impl HummockManager {
             None,
             &self.metrics,
             &self.env.opts,
+            &self.version_stat_tx,
         );
 
         if deterministic_mode {

--- a/src/meta/src/hummock/manager/context.rs
+++ b/src/meta/src/hummock/manager/context.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use std::collections::{BTreeMap, HashMap, HashSet};
+use std::sync::Arc;
 
 use fail::fail_point;
 use futures::{StreamExt, stream};
@@ -30,8 +31,8 @@ use sea_orm::{DatabaseConnection, EntityTrait};
 use crate::controller::SqlMetaStore;
 use crate::hummock::HummockManager;
 use crate::hummock::error::{Error, Result};
+use crate::hummock::manager::commit_multi_var;
 use crate::hummock::manager::worker::{HummockManagerEvent, HummockManagerEventSender};
-use crate::hummock::manager::{commit_multi_var, start_measure_real_process_timer};
 use crate::hummock::metrics_utils::trigger_pin_unpin_version_state;
 use crate::manager::{META_NODE_ID, MetadataManager};
 use crate::model::BTreeMapTransaction;
@@ -161,7 +162,6 @@ impl HummockManager {
         let (active_context_ids, mut context_info) = {
             let compaction_guard = self.compaction.read().await;
             let context_info = self.context_info.write().await;
-            let _timer = start_measure_real_process_timer!(self, "release_invalid_contexts");
             let mut active_context_ids = HashSet::new();
             active_context_ids.extend(
                 compaction_guard
@@ -356,12 +356,11 @@ async fn check_gc_history(
 impl HummockManager {
     /// Pin the current greatest hummock version. The pin belongs to `context_id`
     /// and will be unpinned when `context_id` is invalidated.
-    pub async fn pin_version(&self, context_id: HummockContextId) -> Result<HummockVersion> {
+    pub async fn pin_version(&self, context_id: HummockContextId) -> Result<Arc<HummockVersion>> {
         let versioning = self.versioning.read().await;
         let mut context_info = self.context_info.write().await;
         self.check_context_with_meta_node(context_id, &context_info)
             .await?;
-        let _timer = start_measure_real_process_timer!(self, "pin_version");
         let mut pinned_versions = BTreeMapTransaction::new(&mut context_info.pinned_versions);
         let mut context_pinned_version = pinned_versions.new_entry_txn_or_default(
             context_id,
@@ -401,7 +400,6 @@ impl HummockManager {
         let mut context_info = self.context_info.write().await;
         self.check_context_with_meta_node(context_id, &context_info)
             .await?;
-        let _timer = start_measure_real_process_timer!(self, "unpin_version_before");
         let mut pinned_versions = BTreeMapTransaction::new(&mut context_info.pinned_versions);
         let mut context_pinned_version = pinned_versions.new_entry_txn_or_default(
             context_id,

--- a/src/meta/src/hummock/manager/mod.rs
+++ b/src/meta/src/hummock/manager/mod.rs
@@ -20,6 +20,7 @@ use std::sync::atomic::AtomicBool;
 use anyhow::anyhow;
 use bytes::Bytes;
 use futures::FutureExt;
+use itertools::Itertools;
 use parking_lot::lock_api::RwLock;
 use risingwave_common::catalog::{TableId, TableOption};
 use risingwave_common::monitor::MonitoredRwLock;

--- a/src/meta/src/hummock/manager/mod.rs
+++ b/src/meta/src/hummock/manager/mod.rs
@@ -19,7 +19,7 @@ use std::sync::atomic::AtomicBool;
 
 use anyhow::anyhow;
 use bytes::Bytes;
-use itertools::Itertools;
+use futures::FutureExt;
 use parking_lot::lock_api::RwLock;
 use risingwave_common::catalog::{TableId, TableOption};
 use risingwave_common::monitor::MonitoredRwLock;
@@ -173,6 +173,7 @@ pub struct HummockManager {
         parking_lot::RwLock<TableWriteThroughputStatisticManager>,
     table_committed_epoch_notifiers: parking_lot::Mutex<TableCommittedEpochNotifiers>,
     compaction_task_report_notifiers: parking_lot::Mutex<CompactionTaskReportNotifiers>,
+    version_stat_tx: UnboundedSender<Arc<HummockVersion>>,
 
     // for compactor
     // `compactor_streams_change_tx` is used to pass the mapping from `context_id` to event_stream
@@ -323,6 +324,7 @@ impl HummockManager {
         let version_checkpoint_path = version_checkpoint_path(state_store_dir);
         let version_archive_dir = version_archive_dir(state_store_dir);
         let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
+        let (version_stat_tx, mut version_stat_rx) = tokio::sync::mpsc::unbounded_channel();
         let inflight_time_travel_query = env.opts.max_inflight_time_travel_query;
         let gc_manager = GcManager::new(
             object_store.clone(),
@@ -381,6 +383,7 @@ impl HummockManager {
                     txs: Default::default(),
                 },
             ),
+            version_stat_tx,
             compactor_streams_change_tx,
             compaction_state: CompactionState::new(),
             full_gc_state: FullGcState::new().into(),
@@ -391,6 +394,15 @@ impl HummockManager {
             table_id_to_table_option: RwLock::new(HashMap::new()),
         };
         let instance = Arc::new(instance);
+        let version_stat_metrics = instance.metrics.clone();
+        tokio::spawn(async move {
+            while let Some(mut version) = version_stat_rx.recv().await {
+                while let Some(Some(next_version)) = version_stat_rx.recv().now_or_never() {
+                    version = next_version;
+                }
+                transaction::trigger_version_stat(&version_stat_metrics, version.as_ref());
+            }
+        });
         instance.init_time_travel_state().await?;
         instance.load_meta_store_state().await?;
         // may_fill_backward_table_change_logs MUST execute after load_meta_store_state
@@ -473,7 +485,7 @@ impl HummockManager {
         let checkpoint = self.try_read_checkpoint().await?;
         let mut redo_state = if let Some(c) = checkpoint {
             versioning_guard.checkpoint = c;
-            versioning_guard.checkpoint.version.clone()
+            versioning_guard.checkpoint.version.as_ref().clone()
         } else {
             let default_compaction_config = self
                 .compaction_group_manager
@@ -483,7 +495,7 @@ impl HummockManager {
             let checkpoint_version = HummockVersion::create_init_version(default_compaction_config);
             tracing::info!("init hummock version checkpoint");
             versioning_guard.checkpoint = HummockVersionCheckpoint {
-                version: checkpoint_version.clone(),
+                version: Arc::new(checkpoint_version.clone()),
                 stale_objects: Default::default(),
             };
             self.write_checkpoint(&versioning_guard.checkpoint).await?;
@@ -533,7 +545,7 @@ impl HummockManager {
                 ..Default::default()
             });
 
-        versioning_guard.current_version = redo_state;
+        versioning_guard.current_version = Arc::new(redo_state);
         versioning_guard.hummock_version_deltas = hummock_version_deltas;
         versioning_guard.table_change_log =
             risingwave_meta_model::hummock_table_change_log::Entity::find()
@@ -584,6 +596,7 @@ impl HummockManager {
     /// Replay a version delta to current hummock version.
     /// Returns the `version_id`, `max_committed_epoch` of the new version and the modified
     /// compaction groups
+    #[cfg(any(test, feature = "test"))]
     pub async fn replay_version_delta(
         &self,
         mut version_delta: HummockVersionDelta,
@@ -592,16 +605,15 @@ impl HummockManager {
         // ensure the version id is ascending after replay
         version_delta.id = versioning_guard.current_version.next_version_id();
         version_delta.prev_id = versioning_guard.current_version.id;
-        versioning_guard
-            .current_version
-            .apply_version_delta(&version_delta);
+        let mut version_new = versioning_guard.current_version.as_ref().clone();
+        version_new.apply_version_delta(&version_delta);
 
-        let version_new = versioning_guard.current_version.clone();
-        let compaction_group_ids = version_delta.group_deltas.keys().cloned().collect_vec();
+        let compaction_group_ids = version_delta.group_deltas.keys().cloned().collect();
+        versioning_guard.current_version = Arc::new(version_new.clone());
         Ok((version_new, compaction_group_ids))
     }
 
-    pub async fn disable_commit_epoch(&self) -> HummockVersion {
+    pub async fn disable_commit_epoch(&self) -> Arc<HummockVersion> {
         let mut versioning_guard = self.versioning.write().await;
         versioning_guard.disable_commit_epochs = true;
         versioning_guard.current_version.clone()

--- a/src/meta/src/hummock/manager/tests.rs
+++ b/src/meta/src/hummock/manager/tests.rs
@@ -1411,7 +1411,7 @@ async fn test_extend_objects_to_delete() {
             .len(),
         orphan_sst_num
     );
-    let pinned_version2: HummockVersion = hummock_manager.pin_version(context_id).await.unwrap();
+    let pinned_version2 = hummock_manager.pin_version(context_id).await.unwrap();
     hummock_manager
         .unpin_version_before(context_id, pinned_version2.id)
         .await
@@ -1437,7 +1437,7 @@ async fn test_extend_objects_to_delete() {
         )
         .await
         .unwrap();
-    let pinned_version3: HummockVersion = hummock_manager.pin_version(context_id).await.unwrap();
+    let pinned_version3 = hummock_manager.pin_version(context_id).await.unwrap();
     assert_eq!(new_epoch, version_max_committed_epoch(&pinned_version3));
     hummock_manager
         .unpin_version_before(context_id, pinned_version3.id)
@@ -3070,7 +3070,7 @@ async fn test_old_version_dropped_table_sst_does_not_make_new_compaction_fail() 
     // will pass the stale read set to catalog acquire and fail before compaction can run.
     initial_manager
         .write_checkpoint(&HummockVersionCheckpoint {
-            version: dirty_version,
+            version: Arc::new(dirty_version),
             stale_objects: Default::default(),
         })
         .await

--- a/src/meta/src/hummock/manager/transaction.rs
+++ b/src/meta/src/hummock/manager/transaction.rs
@@ -14,6 +14,7 @@
 
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::ops::{Deref, DerefMut};
+use std::sync::Arc;
 
 use parking_lot::Mutex;
 use risingwave_common::catalog::TableId;
@@ -47,7 +48,7 @@ fn trigger_delta_log_stats(metrics: &MetaMetrics, total_number: usize) {
     metrics.delta_log_count.set(total_number as _);
 }
 
-fn trigger_version_stat(metrics: &MetaMetrics, current_version: &HummockVersion) {
+pub(super) fn trigger_version_stat(metrics: &MetaMetrics, current_version: &HummockVersion) {
     metrics
         .version_size
         .set(current_version.estimated_encode_len() as i64);
@@ -57,12 +58,13 @@ fn trigger_version_stat(metrics: &MetaMetrics, current_version: &HummockVersion)
 }
 
 pub(super) struct HummockVersionTransaction<'a> {
-    orig_version: &'a mut HummockVersion,
+    orig_version: &'a mut Arc<HummockVersion>,
     orig_deltas: &'a mut BTreeMap<HummockVersionId, HummockVersionDelta>,
     orig_table_change_log: &'a mut HashMap<TableId, TableChangeLog>,
     notification_manager: &'a NotificationManager,
     table_committed_epoch_notifiers: Option<&'a Mutex<TableCommittedEpochNotifiers>>,
     meta_metrics: &'a MetaMetrics,
+    version_stat_tx: &'a tokio::sync::mpsc::UnboundedSender<Arc<HummockVersion>>,
 
     pre_applied_version: Option<(HummockVersion, Vec<HummockVersionDelta>, HashSet<TableId>)>,
     disable_apply_to_txn: bool,
@@ -71,13 +73,14 @@ pub(super) struct HummockVersionTransaction<'a> {
 
 impl<'a> HummockVersionTransaction<'a> {
     pub(super) fn new(
-        version: &'a mut HummockVersion,
+        version: &'a mut Arc<HummockVersion>,
         deltas: &'a mut BTreeMap<HummockVersionId, HummockVersionDelta>,
         table_change_log: &'a mut HashMap<TableId, TableChangeLog>,
         notification_manager: &'a NotificationManager,
         table_committed_epoch_notifiers: Option<&'a Mutex<TableCommittedEpochNotifiers>>,
         meta_metrics: &'a MetaMetrics,
         opts: &'a MetaOpts,
+        version_stat_tx: &'a tokio::sync::mpsc::UnboundedSender<Arc<HummockVersion>>,
     ) -> Self {
         Self {
             orig_version: version,
@@ -89,6 +92,7 @@ impl<'a> HummockVersionTransaction<'a> {
             table_committed_epoch_notifiers,
             meta_metrics,
             opts,
+            version_stat_tx,
         }
     }
 
@@ -104,7 +108,7 @@ impl<'a> HummockVersionTransaction<'a> {
         if let Some((version, _, _)) = &self.pre_applied_version {
             version
         } else {
-            self.orig_version
+            self.orig_version.as_ref()
         }
     }
 
@@ -120,7 +124,7 @@ impl<'a> HummockVersionTransaction<'a> {
         let (version, deltas, gc_change_log_deltas) =
             self.pre_applied_version.get_or_insert_with(|| {
                 (
-                    self.orig_version.clone(),
+                    self.orig_version.as_ref().clone(),
                     Vec::with_capacity(1),
                     HashSet::new(),
                 )
@@ -249,7 +253,7 @@ impl<'a> HummockVersionTransaction<'a> {
 impl InMemValTransaction for HummockVersionTransaction<'_> {
     fn commit(self) {
         if let Some((version, deltas, gc_change_log_deltas)) = self.pre_applied_version {
-            *self.orig_version = version;
+            *self.orig_version = Arc::new(version);
             for delta in &deltas {
                 HummockVersion::apply_change_log_delta(
                     self.orig_table_change_log,
@@ -291,7 +295,7 @@ impl InMemValTransaction for HummockVersionTransaction<'_> {
             }
 
             trigger_delta_log_stats(self.meta_metrics, self.orig_deltas.len());
-            trigger_version_stat(self.meta_metrics, self.orig_version);
+            let _ = self.version_stat_tx.send(self.orig_version.clone());
         }
     }
 }

--- a/src/meta/src/hummock/manager/versioning.rs
+++ b/src/meta/src/hummock/manager/versioning.rs
@@ -301,8 +301,6 @@ impl HummockManager {
     }
 
     pub async fn may_fill_backward_table_change_logs(&self) -> Result<()> {
-        let mut versioning = self.versioning.write().await;
-
         let is_nonempty_meta_store =
             risingwave_meta_model::hummock_table_change_log::Entity::find()
                 .select_only()
@@ -314,33 +312,33 @@ impl HummockManager {
                 .one(&self.env.meta_store_ref().conn)
                 .await?
                 .is_some();
-        #[expect(deprecated)]
-        if versioning.current_version.table_change_log.is_empty() {
-            tracing::info!("No legacy table change log to migrate.");
-            return Ok(());
-        }
-        let version = Arc::make_mut(&mut versioning.current_version);
-        if is_nonempty_meta_store {
-            tracing::info!("meta store table change log is non-empty.");
+
+        let table_change_logs = {
+            let mut versioning = self.versioning.write().await;
+            #[expect(deprecated)]
+            if versioning.current_version.table_change_log.is_empty() {
+                tracing::info!("No legacy table change log to migrate.");
+                return Ok(());
+            }
+            let version = Arc::make_mut(&mut versioning.current_version);
+            if is_nonempty_meta_store {
+                tracing::info!("meta store table change log is non-empty.");
+                // Clear legacy in-mem state.
+                #[expect(deprecated)]
+                version.table_change_log = HashMap::default();
+                // Either there are no table change logs to commit to the metastore, or the operation has already been completed.
+                return Ok(());
+            }
+
             // Clear legacy in-mem state.
             #[expect(deprecated)]
-            {
-                version.table_change_log = HashMap::default();
-            }
-            // Either there are no table change logs to commit to the metastore, or the operation has already been completed.
-            return Ok(());
-        }
-
-        // Remove table change log from version.
-        #[expect(deprecated)]
-        let table_change_logs = {
-            // Clear legacy in-mem state.
             let logs = std::mem::take(&mut version.table_change_log);
             if logs.values().all(|t| t.is_empty()) {
                 return Ok(());
             }
             logs
         };
+
         // Store table change log in meta store.
         let insert_batch_size = self.env.opts.table_change_log_insert_batch_size as usize;
         let count = {
@@ -376,6 +374,7 @@ impl HummockManager {
         };
         tracing::info!("Migrated {count} table change log to meta store.");
         // Initialize new in-mem state.
+        let mut versioning = self.versioning.write().await;
         versioning.table_change_log = table_change_logs;
         Ok(())
     }

--- a/src/meta/src/hummock/manager/versioning.rs
+++ b/src/meta/src/hummock/manager/versioning.rs
@@ -302,7 +302,6 @@ impl HummockManager {
 
     pub async fn may_fill_backward_table_change_logs(&self) -> Result<()> {
         let mut versioning = self.versioning.write().await;
-        let version = &mut versioning.current_version;
 
         let is_nonempty_meta_store =
             risingwave_meta_model::hummock_table_change_log::Entity::find()
@@ -316,15 +315,18 @@ impl HummockManager {
                 .await?
                 .is_some();
         #[expect(deprecated)]
-        if version.table_change_log.is_empty() || is_nonempty_meta_store {
-            if version.table_change_log.is_empty() {
-                tracing::info!("No legacy table change log to migrate.");
-            }
-            if is_nonempty_meta_store {
-                tracing::info!("meta store table change log is non-empty.");
-            }
+        if versioning.current_version.table_change_log.is_empty() {
+            tracing::info!("No legacy table change log to migrate.");
+            return Ok(());
+        }
+        let version = Arc::make_mut(&mut versioning.current_version);
+        if is_nonempty_meta_store {
+            tracing::info!("meta store table change log is non-empty.");
             // Clear legacy in-mem state.
-            version.table_change_log = HashMap::default();
+            #[expect(deprecated)]
+            {
+                version.table_change_log = HashMap::default();
+            }
             // Either there are no table change logs to commit to the metastore, or the operation has already been completed.
             return Ok(());
         }

--- a/src/meta/src/hummock/manager/versioning.rs
+++ b/src/meta/src/hummock/manager/versioning.rs
@@ -15,6 +15,7 @@
 use std::cmp;
 use std::collections::Bound::{Excluded, Included};
 use std::collections::{BTreeMap, HashMap, HashSet};
+use std::sync::Arc;
 
 use itertools::Itertools;
 use risingwave_hummock_sdk::change_log::{EpochNewChangeLog, TableChangeLog, TableChangeLogs};
@@ -59,7 +60,7 @@ pub struct Versioning {
     /// Don't persist compaction version delta to meta store
     pub disable_commit_epochs: bool,
     /// Latest hummock version
-    pub current_version: HummockVersion,
+    pub current_version: Arc<HummockVersion>,
     pub local_metrics: HashMap<TableId, LocalTableMetrics>,
     pub time_travel_snapshot_interval_counter: u64,
     /// Used to avoid the attempts to rewrite the same SST to meta store
@@ -165,7 +166,7 @@ impl HummockManager {
     }
 
     pub async fn on_current_version<T>(&self, mut f: impl FnMut(&HummockVersion) -> T) -> T {
-        f(&self.versioning.read().await.current_version)
+        f(self.versioning.read().await.current_version.as_ref())
     }
 
     pub async fn on_current_version_and_table_change_log<T>(
@@ -287,6 +288,7 @@ impl HummockManager {
                 None,
                 &self.metrics,
                 &self.env.opts,
+                &self.version_stat_tx,
             );
             let mut new_version_delta = version.new_delta();
             new_version_delta.with_latest_version(|version, delta| {

--- a/src/meta/src/hummock/metrics_utils.rs
+++ b/src/meta/src/hummock/metrics_utils.rs
@@ -564,9 +564,8 @@ pub fn trigger_gc_stat(
         stale_object_size,
         stale_object_count,
     } = stale_object_stats;
-    let current_version_object_size_map = object_size_map(checkpoint_version);
     let mut current_version_object_size_map: HashMap<_, _> =
-        version_object_size_map(&checkpoint.version);
+        version_object_size_map(checkpoint_version);
     // Note: Because table change logs do not support MVCC, their objects are tracked
     // exclusively in current_version_object, rather than in old_version_object or stale_object.
     current_version_object_size_map.extend(current_table_change_log.values().flat_map(

--- a/src/meta/src/hummock/metrics_utils.rs
+++ b/src/meta/src/hummock/metrics_utils.rs
@@ -30,6 +30,7 @@ use risingwave_hummock_sdk::version::HummockVersion;
 use risingwave_hummock_sdk::{
     CompactionGroupId, HummockContextId, HummockObjectId, HummockVersionId,
 };
+use risingwave_pb::hummock::hummock_version_checkpoint::PbStaleObjects;
 use risingwave_pb::hummock::write_limits::WriteLimit;
 use risingwave_pb::hummock::{
     CompactionConfig, HummockPinnedVersion, HummockVersionStats, LevelType,
@@ -37,7 +38,6 @@ use risingwave_pb::hummock::{
 
 use super::compaction::selector::DynamicLevelSelectorCore;
 use super::compaction::{CompactionDeveloperConfig, get_compression_algorithm};
-use crate::hummock::checkpoint::HummockVersionCheckpoint;
 use crate::hummock::compaction::CompactStatus;
 use crate::rpc::metrics::MetaMetrics;
 
@@ -520,12 +520,51 @@ pub fn trigger_pin_unpin_version_state(
     }
 }
 
+pub struct GcStaleObjectStats {
+    old_version_object_size: u64,
+    old_version_object_count: u64,
+    stale_object_size: u64,
+    stale_object_count: u64,
+}
+
+pub fn gc_stale_object_stats(
+    stale_objects: &HashMap<HummockVersionId, PbStaleObjects>,
+    min_pinned_version_id: HummockVersionId,
+) -> GcStaleObjectStats {
+    let mut old_version_object_size = 0;
+    let mut old_version_object_count = 0;
+    let mut stale_object_size = 0;
+    let mut stale_object_count = 0;
+    stale_objects.iter().for_each(|(id, objects)| {
+        if *id <= min_pinned_version_id {
+            stale_object_size += objects.total_file_size;
+            stale_object_count += objects.id.len() as u64;
+        } else {
+            old_version_object_size += objects.total_file_size;
+            old_version_object_count += objects.id.len() as u64;
+        }
+    });
+    GcStaleObjectStats {
+        old_version_object_size,
+        old_version_object_count,
+        stale_object_size,
+        stale_object_count,
+    }
+}
+
 pub fn trigger_gc_stat(
     metrics: &MetaMetrics,
-    checkpoint: &HummockVersionCheckpoint,
-    min_pinned_version_id: HummockVersionId,
+    checkpoint_version: &HummockVersion,
     current_table_change_log: &HashMap<TableId, TableChangeLog>,
+    stale_object_stats: GcStaleObjectStats,
 ) {
+    let GcStaleObjectStats {
+        old_version_object_size,
+        old_version_object_count,
+        stale_object_size,
+        stale_object_count,
+    } = stale_object_stats;
+    let current_version_object_size_map = object_size_map(checkpoint_version);
     let mut current_version_object_size_map: HashMap<_, _> =
         version_object_size_map(&checkpoint.version);
     // Note: Because table change logs do not support MVCC, their objects are tracked
@@ -540,19 +579,6 @@ pub fn trigger_gc_stat(
     ));
     let current_version_object_size = current_version_object_size_map.values().sum::<u64>();
     let current_version_object_count = current_version_object_size_map.len();
-    let mut old_version_object_size = 0;
-    let mut old_version_object_count = 0;
-    let mut stale_object_size = 0;
-    let mut stale_object_count = 0;
-    checkpoint.stale_objects.iter().for_each(|(id, objects)| {
-        if *id <= min_pinned_version_id {
-            stale_object_size += objects.total_file_size;
-            stale_object_count += objects.id.len() as u64;
-        } else {
-            old_version_object_size += objects.total_file_size;
-            old_version_object_count += objects.id.len() as u64;
-        }
-    });
     metrics
         .current_version_object_size
         .set(current_version_object_size as _);

--- a/src/tests/compaction_test/Cargo.toml
+++ b/src/tests/compaction_test/Cargo.toml
@@ -15,7 +15,7 @@ foyer = { workspace = true }
 risingwave_common = { workspace = true }
 risingwave_compactor = { workspace = true }
 risingwave_hummock_sdk = { workspace = true }
-risingwave_meta_node = { workspace = true }
+risingwave_meta_node = { workspace = true, features = ["test"] }
 risingwave_pb = { workspace = true }
 risingwave_rpc_client = { workspace = true }
 risingwave_rt = { workspace = true }


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

This PR reduces Hummock versioning lock contention in meta by shortening critical sections around version checkpoint creation and version-stat updates.

- Snapshot checkpoint inputs while holding the versioning read lock, then persist checkpoint/archive data outside the lock.
- Reacquire the write lock only to publish the new in-memory checkpoint.
- Route version-stat reporting through an async channel so transaction paths do not do that work while holding the versioning lock.
- Keep table change log compatibility handling on the rebased `main` code path.

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [x] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

No user-facing behavior change.

</details>

