### PR TITLE
test(sink): fix flaky V3 iceberg fault-injection convergence timeout

### DIFF
--- a/src/tests/simulation/tests/integration_tests/sink/iceberg_v3_2pc/mod.rs
+++ b/src/tests/simulation/tests/integration_tests/sink/iceberg_v3_2pc/mod.rs
@@ -272,9 +272,15 @@ mod failpoint_limited {
         tokio::time::sleep(Duration::from_secs(10)).await;
         fail::remove("iceberg_v3_persist_pre_commit_fail");
 
-        // Give the cluster time to recover and commit again past the fault window.
+        // Give the cluster time to recover and commit again past the fault
+        // window. A persist failure fails the barrier and drives a full meta
+        // recovery (bootstrap + recovery backoff up to 5s/attempt). Once the
+        // fault clears no further commit can fail, so this wait only ever
+        // drains the single in-flight recovery cascade; a seed-sweep over the
+        // 30 CI seeds measured that cascade at ~30s worst case. Budget 120s
+        // (~4x) so the test cannot boundary-flake (30s was provably too tight).
         tokio::time::timeout(
-            Duration::from_secs(30),
+            Duration::from_secs(120),
             handle.mock.wait_for_event_count('I', baseline_i_count + 1),
         )
         .await
@@ -333,9 +339,16 @@ mod failpoint_limited {
         tokio::time::sleep(Duration::from_secs(10)).await;
         handle.mock.set_err_rate_txn_commit(0.0);
 
-        // Sink resumes committing once the fault clears.
+        // Sink resumes committing once the fault clears. F11 pinned at 100%
+        // guarantees at least one retry-exhausted commit, which fails the
+        // barrier and drives a full meta recovery (bootstrap + recovery backoff
+        // up to 5s/attempt). Once the rate is 0 no further commit can fail, so
+        // this wait only drains the single in-flight cascade. A seed-sweep over
+        // the 30 CI seeds measured that cascade at ~30s worst case (this test,
+        // seed 26); seed 4 fails at the old 30s budget as a boundary flake.
+        // Budget 120s (~4x) so it cannot recur.
         tokio::time::timeout(
-            Duration::from_secs(30),
+            Duration::from_secs(120),
             handle.mock.wait_for_event_count('I', baseline_i_count + 1),
         )
         .await
@@ -380,8 +393,12 @@ mod failpoint_limited {
         fail::remove("iceberg_v3_commit_prune_fail");
 
         // Sink should eventually commit fresh snapshots once the fault clears.
+        // A prune failure leaves the row Pending and is redriven through a full
+        // meta recovery cascade (~30s worst case across the 30 CI seeds). The
+        // post-clear wait only drains the single in-flight cascade, so budget
+        // 120s (~4x) for ample margin.
         tokio::time::timeout(
-            Duration::from_secs(30),
+            Duration::from_secs(120),
             handle.mock.wait_for_event_count('I', baseline_i_count + 1),
         )
         .await
@@ -441,9 +458,13 @@ mod failpoint_limited {
 
         fail::remove("iceberg_v3_commit_prune_fail");
 
-        // After clearing, the cluster recovers and commits a new epoch.
+        // After clearing, the cluster recovers and commits a new epoch. The
+        // sustained prune failure keeps the row Pending until a full meta
+        // recovery cascade redrives it (~30s worst case across the 30 CI
+        // seeds). The post-clear wait only drains the single in-flight cascade,
+        // so budget 120s (~4x) for ample margin.
         tokio::time::timeout(
-            Duration::from_secs(30),
+            Duration::from_secs(120),
             handle.mock.wait_for_event_count('I', baseline_i_count + 1),
         )
         .await
@@ -505,9 +526,14 @@ mod failpoint_limited {
         fail::remove("iceberg_v3_commit_prune_fail");
         handle.mock.set_err_rate_txn_commit(0.0);
 
-        // Sink commits at least one fresh snapshot after the fault window.
+        // Sink commits at least one fresh snapshot after the fault window. The
+        // compound F5/F11/F12 window drives a full meta recovery (F11 pinned at
+        // 100% guarantees at least one retry-exhausted commit). Once every rate
+        // is 0 the post-clear wait only drains the single in-flight cascade
+        // (~30s worst case across the 30 CI seeds), so budget 120s (~4x) for
+        // ample margin.
         tokio::time::timeout(
-            Duration::from_secs(30),
+            Duration::from_secs(120),
             handle.mock.wait_for_event_count('I', baseline_i_count + 1),
         )
         .await


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

Fixes a deterministic flake in the V3 iceberg sink fault-injection suite (madsim), introduced by #25778. **Test-only change** — no product code is touched.

### Symptom

`failpoint_limited_test_v3_iceberg_commit_failure` fails at `MADSIM_TEST_SEED=4` with:

```
Error: no new 'I' commits after fault cleared; baseline=1, current=1, trace = "Iiiiii"
```

CI runs the sink suite at **fixed deterministic seeds 1..30** (`TEST_NUM=30 ci/scripts/deterministic-it-test.sh sink`; `it-test-N.log` = seed N). madsim is fully deterministic, so this is **not random flakiness** — seed 4 fails on every run until fixed.

### Root cause

Five fault-injection tests budget only **30s** to wait for a fresh commit (`'I'`) after they clear the injected fault. But every fault drives the streaming job through a **full meta recovery cascade**:

- a `persist` / `commit_prune` failure fails the barrier;
- `F11` (iceberg `update_table`) pinned at 100% first exhausts the 8-retry commit budget, then fails the barrier;
- recovery = bootstrap of 3 CN + meta + recovery backoff (up to 5s/attempt).

One such cascade costs **~30s of simulated time**. At seed 4 the first post-fault commit lands just past the 30s deadline → timeout. The trace `Iiiiii` (one baseline commit, several failures, then silence) is the cluster sitting in that cascade.

### Scope of the change

- ✅ Bumped: the 5 post-fault `wait_for_event_count('I', baseline + 1)` timeouts (`persist_failure`, `iceberg_commit_failure`, `commit_prune_failure`, `idempotent_on_retry`, `random_failures_corner_case`).

### Verification

- Local sweep of seeds 1..30: all 5 tests pass, no hangs (data above).
- CI: `ci/run-integration-test-deterministic-simulation` requested to re-run the suite (incl. seed 4) on Buildkite.

## Checklist

- [x] I have written necessary rustdoc comments.
- [x] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [x] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

No user-facing changes — test-only fix.

</details>
