### PR TITLE
[draft] fix(stream): avoid snapshot-backfill finishing-edge deadlock

### DIFF
--- a/src/stream/src/executor/backfill/snapshot_backfill/executor.rs
+++ b/src/stream/src/executor/backfill/snapshot_backfill/executor.rs
@@ -14,7 +14,7 @@
 
 use std::cmp::min;
 use std::collections::VecDeque;
-use std::future::{Future, pending, ready};
+use std::future::{Future, ready};
 use std::mem::take;
 use std::sync::Arc;
 use std::time::Duration;
@@ -404,11 +404,20 @@ impl<S: StateStore> SnapshotBackfillExecutor<S> {
                                 pending_non_checkpoint_barrier.push(barrier.epoch);
                             }
 
+                            // `is_finished` was computed before the log-store reads above; the
+                            // concurrent upstream drain during those reads can pull in a straggler
+                            // barrier, so re-check that we are actually caught up (lag == 0).
+                            let caught_up = is_finished
+                                && match &upstream_buffer {
+                                    SnapshotBackfillUpstream::Buffer(b) => {
+                                        b.pending_epoch_lag() == 0
+                                    }
+                                    SnapshotBackfillUpstream::Empty => true,
+                                };
                             if let SnapshotBackfillUpstream::Buffer(upstream_buffer) =
                                 &upstream_buffer
                             {
-                                if is_finished {
-                                    assert_eq!(upstream_buffer.pending_epoch_lag(), 0);
+                                if caught_up {
                                     assert!(pending_non_checkpoint_barrier.is_empty());
                                     self.progress.finish_consuming_log_store(barrier.epoch);
                                 } else {
@@ -431,7 +440,7 @@ impl<S: StateStore> SnapshotBackfillExecutor<S> {
                                 .into());
                             }
 
-                            if is_finished {
+                            if caught_up {
                                 assert!(
                                     pending_non_checkpoint_barrier.is_empty(),
                                     "{pending_non_checkpoint_barrier:?}"
@@ -723,6 +732,10 @@ struct UpstreamBuffer<S> {
     /// must be read from log store
     is_polling_epoch_data: bool,
     consume_upstream_row_count: LabelGuardedIntCounter,
+    /// Measured upstream checkpoint cadence (physical ms between consecutive checkpoints),
+    /// used to pace back-pressure. Stable across the catch-up, including at lag == 0.
+    cadence_ms: u64,
+    last_checkpoint_physical_ms: u64,
     _phase: S,
 }
 
@@ -740,6 +753,8 @@ impl UpstreamBuffer<ConsumingSnapshot> {
             // no limit on the number of pending barrier in the beginning
             max_pending_epoch_lag: u64::MAX,
             consumed_epoch: 0,
+            cadence_ms: 1000,
+            last_checkpoint_physical_ms: 0,
             _phase: ConsumingSnapshot {},
         }
     }
@@ -770,6 +785,8 @@ impl UpstreamBuffer<ConsumingSnapshot> {
             is_polling_epoch_data: self.is_polling_epoch_data,
             consume_upstream_row_count: self.consume_upstream_row_count,
             consumed_epoch,
+            cadence_ms: self.cadence_ms,
+            last_checkpoint_physical_ms: self.last_checkpoint_physical_ms,
             _phase: ConsumingLogStore {},
         };
         if buffer.is_finished() {
@@ -790,10 +807,13 @@ impl<S> UpstreamBuffer<S> {
             loop {
                 if let Err(e) = try {
                     if !self.can_consume_upstream() {
-                        // pause the future to block consuming upstream
-                        sleep(Duration::from_secs(30)).await;
-                        warn!(pending_barrier = ?self.upstream_pending_barriers, "not polling upstream but timeout");
-                        return pending().await;
+                        // Back-pressure by SLOWING the drain to ~one checkpoint cadence, never
+                        // fully stopping. Fully stopping (the old `return pending()`) blocks the
+                        // upstream from collecting the next checkpoint barrier that this
+                        // backfill's own `Committed(end_epoch)` read needs committed -> deadlock.
+                        // Sleeping then draining keeps the upstream committing; sleeping at
+                        // lag == 0 too lets the main loop observe the finish.
+                        sleep(Duration::from_millis(self.cadence_ms)).await;
                     }
                     self.consume_until_next_checkpoint_barrier().await?;
                 } {
@@ -819,6 +839,15 @@ impl<S> UpstreamBuffer<S> {
                 }
                 DispatcherMessage::Barrier(barrier) => {
                     let is_checkpoint = barrier.kind.is_checkpoint();
+                    if is_checkpoint {
+                        let phys = Epoch(barrier.epoch.prev).physical_time();
+                        if self.last_checkpoint_physical_ms != 0
+                            && phys > self.last_checkpoint_physical_ms
+                        {
+                            self.cadence_ms = phys - self.last_checkpoint_physical_ms;
+                        }
+                        self.last_checkpoint_physical_ms = phys;
+                    }
                     self.upstream_pending_barriers.add(barrier);
                     if is_checkpoint {
                         self.is_polling_epoch_data = false;


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

> ⚠️ **Draft / WIP** — opening for early review of the approach. A deterministic madsim regression test still needs to be added before merge.

Fixes the long-standing silent hang in `-j16` parallel e2e ("system hung causing timeout" flaky, #24991): a **self-referential deadlock in the `ConsumingLogStore` phase of `SnapshotBackfillExecutor`** (`src/stream/src/executor/backfill/snapshot_backfill/executor.rs`).

### Mechanism (confirmed end-to-end on a repro box)

A snapshot-backfill `StreamScan` catches up by reading its upstream table's change log with `HummockReadEpoch::Committed(end_epoch)` (blocks until `end_epoch` commits to hummock), while concurrently draining the live upstream channel via `concurrently_consume_upstream` to keep the upstream un-back-pressured. That drain's escape hatch is the bug:

```rust
if !self.can_consume_upstream() {        // pending_epoch_lag() >= max_pending_epoch_lag
    sleep(Duration::from_secs(30)).await;
    return pending().await;              // permanently stops draining the upstream
}
```

`max_pending_epoch_lag` shrinks toward 0 over the catch-up (`saturating_sub(elapsed_epoch / 2)`). **Once it reaches 0 while the upstream is still active, the drain parks permanently at a clean checkpoint boundary** — and the read it was protecting needs the *next* checkpoint to commit:

```
park the upstream drain (return pending; max==0, lag==0)
  -> upstream MV's dispatch channel fills -> upstream blocks on send
  -> upstream can't collect the NEXT checkpoint barrier
  -> meta never commits that checkpoint (database-wide, in-order)
  -> the backfill's own Committed(end_epoch) read never satisfies -> deadlock
```

With `disable_recovery=true` the whole database wedges silently → CN/FE `send_heartbeat: timeout`. Captured at the deadlock: read target `end_epoch == consumed_epoch`, the needed next checkpoint uncommitted, `latest_buffered == None`, `lag == 0`, `max == 0`. `max == 0` is the deterministic trigger; the flakiness is just whether a job finishes before `max` reaches 0.

### Fix

Two changes in `snapshot_backfill/executor.rs`:

1. **Throttle, don't park** — replace `return pending()` with `sleep(cadence_ms)` then keep draining. It never permanently stops (the upstream keeps committing → deadlock gone); slowing the drain still provides the back-pressure that drives convergence. `cadence_ms` is the **measured** upstream checkpoint cadence (physical-time delta between consecutive checkpoint epochs), so the throttle tracks the deployment's own barrier cadence instead of being a magic constant.
2. **Finish gate** — compute `caught_up = is_finished && pending_epoch_lag() == 0` *after* the per-epoch log-store reads (the concurrent drain during those reads can buffer a straggler barrier, so the pre-reads `is_finished` is only provisional), and gate finish/break on `caught_up`. This turns the racy `assert_eq!(pending_epoch_lag(), 0)` at finish into a condition we wait for (and fixes the panic a naive park-removal hits).

No protocol / persisted-state / schema changes; the same data is emitted and the same `ConsumingLogStore → ConsumingUpstream` hand-off is preserved.

Why not simpler fixes (ruled out empirically): just deleting `return pending()` breaks the `lag == 0` finish invariant (panics ~45 s in); releasing back-pressure only at `lag == 0` is insufficient because *any* permanent park stops that actor's upstream barrier flow and can gate the cluster-wide in-order commit. So the back-pressure must **slow** the drain, never **stop** it.

### Validation

Reproduced the hang on a dedicated box (faithful `ci-3streaming-2serving-3fe`, `risedev slt ... -j16 --label parallel`, `disable_recovery=true`). With the fix, ran the parallel suite in a loop: **4 consecutive 12-min iterations, 0 hang and 0 panic** (vs. deadlock in the unpatched build). Measured cadence stayed stable ~1.25 s.

Full RCA: https://github.com/risingwavelabs/risingwave/issues/24991#issuecomment-4806801217

- Closes #24991

## Checklist

- [x] I have written necessary rustdoc comments.
- [ ] I have added necessary unit tests and integration tests. <!-- TODO: deterministic madsim regression test driving the max==0 finishing edge -->
- [ ] <!-- OPTIONAL --> I have added test labels as necessary.
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them.
- [ ] <!-- OPTIONAL --> My PR contains breaking changes.
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results.
- [ ] <!-- OPTIONAL --> I have checked the Release Timeline and Currently Supported Versions to determine which release branches I need to cherry-pick this PR into.


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates.

<details>
<summary><b>Release note</b></summary>

Fixed a silent cluster hang that could occur when many snapshot-backfill `CREATE MATERIALIZED VIEW` jobs run concurrently while their upstreams stay active: the backfill could permanently stop consuming its upstream at the catch-up's finishing edge, stalling barrier collection for the whole database.

</details>
