### PR TITLE
fix(cdc): diagnose postgres select privilege

### DIFF
--- a/e2e_test/source_inline/cdc/postgres/postgres_select_privilege.slt
+++ b/e2e_test/source_inline/cdc/postgres/postgres_select_privilege.slt
@@ -1,0 +1,59 @@
+control substitution on
+
+statement ok
+drop source if exists pg_cdc_select_privilege_source;
+
+system ok
+PGDATABASE=${PGDATABASE:-postgres} psql -v ON_ERROR_STOP=1 -c "
+    SELECT pg_terminate_backend(active_pid)
+    FROM pg_replication_slots
+    WHERE slot_name = 'pg_cdc_select_privilege_slot' AND active_pid IS NOT NULL;
+    SELECT pg_sleep(1);
+    SELECT pg_drop_replication_slot(slot_name)
+    FROM pg_replication_slots
+    WHERE slot_name = 'pg_cdc_select_privilege_slot';
+    DROP PUBLICATION IF EXISTS pg_cdc_select_privilege_pub;
+    DROP TABLE IF EXISTS public.pg_cdc_select_privilege_test CASCADE;
+    DROP ROLE IF EXISTS rw_cdc_slt_limited;
+    CREATE ROLE rw_cdc_slt_limited LOGIN PASSWORD 'rw_cdc_slt_limited';
+    CREATE TABLE public.pg_cdc_select_privilege_test (
+        id int PRIMARY KEY,
+        value text
+    );
+    REVOKE ALL ON TABLE public.pg_cdc_select_privilege_test FROM PUBLIC;
+    "
+
+statement ok
+create source pg_cdc_select_privilege_source with (
+    connector = 'postgres-cdc',
+    hostname = '${PGHOST:localhost}',
+    port = '${PGPORT:5432}',
+    username = 'rw_cdc_slt_limited',
+    password = 'rw_cdc_slt_limited',
+    database.name = '${PGDATABASE:postgres}',
+    schema.name = 'public',
+    publication.name = 'pg_cdc_select_privilege_pub',
+    slot.name = 'pg_cdc_select_privilege_slot',
+    auto.schema.change = 'true'
+);
+
+statement error PostgreSQL table "public"."pg_cdc_select_privilege_test" exists, but the connection user `rw_cdc_slt_limited` does not have SELECT privilege on it.*GRANT USAGE ON SCHEMA "public" TO "rw_cdc_slt_limited";.*GRANT SELECT ON TABLE "public"."pg_cdc_select_privilege_test" TO "rw_cdc_slt_limited";
+create table pg_cdc_select_privilege_table (*)
+from pg_cdc_select_privilege_source table 'public.pg_cdc_select_privilege_test';
+
+statement ok
+drop source pg_cdc_select_privilege_source;
+
+system ok
+PGDATABASE=${PGDATABASE:-postgres} psql -v ON_ERROR_STOP=1 -c "
+    SELECT pg_terminate_backend(active_pid)
+    FROM pg_replication_slots
+    WHERE slot_name = 'pg_cdc_select_privilege_slot' AND active_pid IS NOT NULL;
+    SELECT pg_sleep(1);
+    SELECT pg_drop_replication_slot(slot_name)
+    FROM pg_replication_slots
+    WHERE slot_name = 'pg_cdc_select_privilege_slot';
+    DROP PUBLICATION IF EXISTS pg_cdc_select_privilege_pub;
+    DROP TABLE IF EXISTS public.pg_cdc_select_privilege_test CASCADE;
+    DROP ROLE IF EXISTS rw_cdc_slt_limited;
+    "

--- a/e2e_test/source_inline/cdc/postgres/postgres_select_privilege.slt
+++ b/e2e_test/source_inline/cdc/postgres/postgres_select_privilege.slt
@@ -15,12 +15,14 @@ PGDATABASE=${PGDATABASE:-postgres} psql -v ON_ERROR_STOP=1 -c "
     DROP PUBLICATION IF EXISTS pg_cdc_select_privilege_pub;
     DROP TABLE IF EXISTS public.pg_cdc_select_privilege_test CASCADE;
     DROP ROLE IF EXISTS rw_cdc_slt_limited;
-    CREATE ROLE rw_cdc_slt_limited LOGIN PASSWORD 'rw_cdc_slt_limited';
+    CREATE ROLE rw_cdc_slt_limited LOGIN REPLICATION PASSWORD 'rw_cdc_slt_limited';
     CREATE TABLE public.pg_cdc_select_privilege_test (
         id int PRIMARY KEY,
         value text
     );
     REVOKE ALL ON TABLE public.pg_cdc_select_privilege_test FROM PUBLIC;
+    CREATE PUBLICATION pg_cdc_select_privilege_pub
+        FOR TABLE public.pg_cdc_select_privilege_test;
     "
 
 statement ok

--- a/src/connector/src/connector_common/postgres.rs
+++ b/src/connector/src/connector_common/postgres.rs
@@ -78,6 +78,23 @@ const DISCOVER_PGVECTOR_COLUMNS_QUERY: &str = r#"
 /// this from its own user-facing config struct before invoking the shared helpers
 /// like `create_pg_client` or `PostgresExternalTable::connect`.
 #[derive(Debug, Clone)]
+
+const CHECK_TABLE_PRIVILEGE_QUERY: &str = r#"
+    SELECT
+      current_user::text AS user_name,
+      n.oid IS NOT NULL AS schema_exists,
+      c.oid IS NOT NULL AS table_exists,
+      COALESCE(has_schema_privilege(current_user, n.oid, 'USAGE'), false) AS has_schema_usage,
+      COALESCE(has_table_privilege(current_user, c.oid, $3), false) AS has_table_privilege,
+      COALESCE(has_any_column_privilege(current_user, c.oid, $3), false) AS has_any_column_privilege
+    FROM (SELECT 1) AS one
+    LEFT JOIN pg_namespace n ON n.nspname = $1
+    LEFT JOIN pg_class c ON c.relnamespace = n.oid
+      AND c.relname = $2
+      AND c.relkind IN ('r', 'p')
+    LIMIT 1
+"#;
+
 pub struct PgConnectionConfig {
     pub host: String,
     pub port: u16,
@@ -230,6 +247,15 @@ pub struct PostgresExternalTable {
     pk_names: Vec<String>,
 }
 
+struct PostgresTablePrivilege {
+    user_name: String,
+    schema_exists: bool,
+    table_exists: bool,
+    has_schema_usage: bool,
+    has_table_privilege: bool,
+    has_any_column_privilege: bool,
+}
+
 impl PostgresExternalTable {
     /// Discover primary key columns directly from PostgreSQL system tables.
     /// This bypasses querying `information_schema.table_constraints` to avoid requiring table owner permissions.
@@ -260,11 +286,12 @@ impl PostgresExternalTable {
         config: &PgConnectionConfig,
         schema: &str,
         table: &str,
+        required_table_privilege: Option<&str>,
     ) -> ConnectorResult<(Vec<sea_schema::postgres::def::ColumnInfo>, Vec<String>)> {
         let options = config.to_sqlx_connect_options();
         let connection = PgPool::connect_with(options).await?;
 
-        // Use sea-schema only for column discovery (no permission issues)
+        // Keep using sea-schema for column discovery, then run targeted access diagnostics below.
         let schema_discovery = SchemaDiscovery::new(connection.clone(), schema);
         let empty_map: HashMap<String, Vec<String>> = HashMap::new();
         let columns = schema_discovery
@@ -294,6 +321,10 @@ impl PostgresExternalTable {
         // sea-schema reports pgvector as `Unknown("vector")` and drops the dimension.
         // Patch it with PostgreSQL's formatted type text so we can derive vector(n).
         let mut columns = columns;
+        if let Some(privilege) = required_table_privilege {
+            Self::ensure_table_privilege(&connection, schema, table, privilege).await?;
+        }
+
         for col in &mut columns {
             if let SeaType::Unknown(name) = &col.col_type
                 && name.eq_ignore_ascii_case("vector")
@@ -307,6 +338,68 @@ impl PostgresExternalTable {
         let pk_columns = Self::discover_primary_key(&connection, schema, table).await?;
 
         Ok((columns, pk_columns))
+    }
+
+    async fn ensure_table_privilege(
+        connection: &PgPool,
+        schema: &str,
+        table: &str,
+        required_privilege: &str,
+    ) -> ConnectorResult<()> {
+        let row = sqlx::query(CHECK_TABLE_PRIVILEGE_QUERY)
+            .bind(schema)
+            .bind(table)
+            .bind(required_privilege)
+            .fetch_one(connection)
+            .await
+            .context("Failed to check PostgreSQL table privileges")?;
+
+        let privilege_status = PostgresTablePrivilege {
+            user_name: row.get("user_name"),
+            schema_exists: row.get("schema_exists"),
+            table_exists: row.get("table_exists"),
+            has_schema_usage: row.get("has_schema_usage"),
+            has_table_privilege: row.get("has_table_privilege"),
+            has_any_column_privilege: row.get("has_any_column_privilege"),
+        };
+
+        if !privilege_status.schema_exists {
+            return Err(anyhow!("PostgreSQL schema `{schema}` does not exist").into());
+        }
+
+        if !privilege_status.table_exists {
+            return Err(anyhow!("PostgreSQL table `{schema}`.`{table}` does not exist").into());
+        }
+
+        if !privilege_status.has_schema_usage {
+            return Err(anyhow!(
+                "PostgreSQL table {} exists, but the connection user `{}` does not have USAGE privilege on schema `{}`. Grant privileges on the upstream PostgreSQL database: {}",
+                format_pg_table_name(schema, table),
+                privilege_status.user_name,
+                schema,
+                format_grant_usage(schema, &privilege_status.user_name),
+            )
+            .into());
+        }
+
+        if !privilege_status.has_table_privilege {
+            let column_privilege_msg = if privilege_status.has_any_column_privilege {
+                " The user has column-level privilege on at least one column, but RisingWave requires table-level privilege for CDC schema discovery and snapshot reads."
+            } else {
+                ""
+            };
+            return Err(anyhow!(
+                "PostgreSQL table {} exists, but the connection user `{}` does not have {} privilege on it.{} Grant privileges on the upstream PostgreSQL database: {}",
+                format_pg_table_name(schema, table),
+                privilege_status.user_name,
+                required_privilege,
+                column_privilege_msg,
+                format_grant_table_privilege(schema, table, &privilege_status.user_name, required_privilege),
+            )
+            .into());
+        }
+
+        Ok(())
     }
 
     async fn discover_schema(
@@ -336,10 +429,13 @@ impl PostgresExternalTable {
         schema: &str,
         table: &str,
         is_append_only: bool,
+        required_table_privilege: Option<&str>,
     ) -> ConnectorResult<Self> {
         tracing::debug!("connect to postgres external table");
 
-        let (columns, pk_names) = Self::discover_pk_and_full_columns(config, schema, table).await?;
+        let (columns, pk_names) =
+            Self::discover_pk_and_full_columns(config, schema, table, required_table_privilege)
+                .await?;
 
         let mut column_descs = vec![];
         for col in &columns {
@@ -416,6 +512,40 @@ impl PostgresExternalTable {
     pub fn pk_names(&self) -> &Vec<String> {
         &self.pk_names
     }
+}
+
+fn format_pg_table_name(schema: &str, table: &str) -> String {
+    format!(
+        "{}.{}",
+        quote_pg_identifier(schema),
+        quote_pg_identifier(table)
+    )
+}
+
+fn format_grant_usage(schema: &str, user_name: &str) -> String {
+    format!(
+        "GRANT USAGE ON SCHEMA {} TO {};",
+        quote_pg_identifier(schema),
+        quote_pg_identifier(user_name)
+    )
+}
+
+fn format_grant_table_privilege(
+    schema: &str,
+    table: &str,
+    user_name: &str,
+    privilege: &str,
+) -> String {
+    format!(
+        "GRANT {} ON TABLE {} TO {};",
+        privilege,
+        format_pg_table_name(schema, table),
+        quote_pg_identifier(user_name)
+    )
+}
+
+fn quote_pg_identifier(identifier: &str) -> String {
+    format!("\"{}\"", identifier.replace('"', "\"\""))
 }
 
 impl fmt::Display for SslMode {
@@ -724,7 +854,10 @@ fn sea_type_to_pg_type(sea_type: &SeaType) -> ConnectorResult<tokio_postgres::ty
 
 #[cfg(test)]
 mod tests {
-    use super::parse_pgvector_dimension;
+    use super::{
+        format_grant_table_privilege, format_grant_usage, format_pg_table_name,
+        parse_pgvector_dimension,
+    };
 
     #[test]
     fn test_parse_pgvector_dimension() {
@@ -737,5 +870,21 @@ mod tests {
     fn test_parse_pgvector_dimension_requires_size() {
         let err = parse_pgvector_dimension("vector").unwrap_err();
         assert!(err.to_string().contains("missing dimension"));
+    }
+
+    #[test]
+    fn test_format_postgres_privilege_grants_quote_identifiers() {
+        assert_eq!(
+            format_pg_table_name("public", "GlobalBrandContentAnalysis"),
+            r#""public"."GlobalBrandContentAnalysis""#
+        );
+        assert_eq!(
+            format_grant_usage("tenant schema", r#"cdc"user"#),
+            r#"GRANT USAGE ON SCHEMA "tenant schema" TO "cdc""user";"#
+        );
+        assert_eq!(
+            format_grant_table_privilege("tenant schema", "Orders", r#"cdc"user"#, "SELECT"),
+            r#"GRANT SELECT ON TABLE "tenant schema"."Orders" TO "cdc""user";"#
+        );
     }
 }

--- a/src/connector/src/connector_common/postgres.rs
+++ b/src/connector/src/connector_common/postgres.rs
@@ -73,12 +73,6 @@ const DISCOVER_PGVECTOR_COLUMNS_QUERY: &str = r#"
     ORDER BY a.attnum
 "#;
 
-/// Canonical Postgres connection parameters shared across sink, source CDC, batch
-/// executor, and frontend `postgres_query` table function. Each caller constructs
-/// this from its own user-facing config struct before invoking the shared helpers
-/// like `create_pg_client` or `PostgresExternalTable::connect`.
-#[derive(Debug, Clone)]
-
 const CHECK_TABLE_PRIVILEGE_QUERY: &str = r#"
     SELECT
       current_user::text AS user_name,
@@ -95,6 +89,11 @@ const CHECK_TABLE_PRIVILEGE_QUERY: &str = r#"
     LIMIT 1
 "#;
 
+/// Canonical Postgres connection parameters shared across sink, source CDC, batch
+/// executor, and frontend `postgres_query` table function. Each caller constructs
+/// this from its own user-facing config struct before invoking the shared helpers
+/// like `create_pg_client` or `PostgresExternalTable::connect`.
+#[derive(Debug, Clone)]
 pub struct PgConnectionConfig {
     pub host: String,
     pub port: u16,
@@ -394,7 +393,12 @@ impl PostgresExternalTable {
                 privilege_status.user_name,
                 required_privilege,
                 column_privilege_msg,
-                format_grant_table_privilege(schema, table, &privilege_status.user_name, required_privilege),
+                format_required_table_grants(
+                    schema,
+                    table,
+                    &privilege_status.user_name,
+                    required_privilege
+                ),
             )
             .into());
         }
@@ -541,6 +545,19 @@ fn format_grant_table_privilege(
         privilege,
         format_pg_table_name(schema, table),
         quote_pg_identifier(user_name)
+    )
+}
+
+fn format_required_table_grants(
+    schema: &str,
+    table: &str,
+    user_name: &str,
+    privilege: &str,
+) -> String {
+    format!(
+        "{} {}",
+        format_grant_usage(schema, user_name),
+        format_grant_table_privilege(schema, table, user_name, privilege)
     )
 }
 
@@ -856,7 +873,7 @@ fn sea_type_to_pg_type(sea_type: &SeaType) -> ConnectorResult<tokio_postgres::ty
 mod tests {
     use super::{
         format_grant_table_privilege, format_grant_usage, format_pg_table_name,
-        parse_pgvector_dimension,
+        format_required_table_grants, parse_pgvector_dimension,
     };
 
     #[test]
@@ -885,6 +902,10 @@ mod tests {
         assert_eq!(
             format_grant_table_privilege("tenant schema", "Orders", r#"cdc"user"#, "SELECT"),
             r#"GRANT SELECT ON TABLE "tenant schema"."Orders" TO "cdc""user";"#
+        );
+        assert_eq!(
+            format_required_table_grants("tenant schema", "Orders", r#"cdc"user"#, "SELECT"),
+            r#"GRANT USAGE ON SCHEMA "tenant schema" TO "cdc""user"; GRANT SELECT ON TABLE "tenant schema"."Orders" TO "cdc""user";"#
         );
     }
 }

--- a/src/connector/src/sink/postgres.rs
+++ b/src/connector/src/sink/postgres.rs
@@ -241,6 +241,7 @@ impl Sink for PostgresSink {
                 &self.config.schema,
                 &self.config.table,
                 self.is_append_only,
+                None,
             )
             .await
             .context(format!(

--- a/src/connector/src/source/cdc/external/mod.rs
+++ b/src/connector/src/source/cdc/external/mod.rs
@@ -506,8 +506,14 @@ impl ExternalTableImpl {
             CdcSourceType::Postgres => {
                 let pg_conn = config.pg_connection_config()?;
                 Ok(ExternalTableImpl::Postgres(
-                    PostgresExternalTable::connect(&pg_conn, &config.schema, &config.table, false)
-                        .await?,
+                    PostgresExternalTable::connect(
+                        &pg_conn,
+                        &config.schema,
+                        &config.table,
+                        false,
+                        Some("SELECT"),
+                    )
+                    .await?,
                 ))
             }
             CdcSourceType::SqlServer => Ok(ExternalTableImpl::SqlServer(

--- a/src/connector/src/source/cdc/external/postgres.rs
+++ b/src/connector/src/source/cdc/external/postgres.rs
@@ -996,6 +996,7 @@ mod tests {
             &config.schema,
             &config.table,
             false,
+            Some("SELECT"),
         )
         .await
         .unwrap();


### PR DESCRIPTION
## Summary
- add PostgreSQL privilege diagnostics for CDC schema discovery when the upstream table exists but the connection user lacks required access
- surface actionable grant suggestions in the error message, including schema `USAGE` and table `SELECT`
- add an SLT case covering the missing `SELECT` privilege error path

## Testing
- cargo fmt
- cargo test -p risingwave_connector connector_common::postgres::tests:: --no-default-features
- cargo check -p risingwave_connector
- SLT added: `e2e_test/source_inline/cdc/postgres/postgres_select_privilege.slt`
  - not executed locally because the local environment did not have a running risedev cluster / external PostgreSQL
