### PR TITLE
fix(cdc/postgres): force-close PG connections on stop to release zombie replication slot

### DIFF
--- a/java/connector-node/risingwave-source-cdc/src/main/java/io/debezium/connector/postgresql/PostgresStreamingChangeEventSource.java
+++ b/java/connector-node/risingwave-source-cdc/src/main/java/io/debezium/connector/postgresql/PostgresStreamingChangeEventSource.java
@@ -180,7 +180,9 @@ public class PostgresStreamingChangeEventSource
                 }
             }
         } catch (Exception e) {
-            LOGGER.debug("Exception while force-aborting regular PG connection", e);
+            // Not expected on the abort path: abort() does a raw Socket.close() and should not
+            // throw under normal operation, so surface it at warn instead of swallowing silently.
+            LOGGER.warn("Exception while force-aborting regular PG connection", e);
         }
         try {
             if (replicationConnection instanceof io.debezium.jdbc.JdbcConnection) {
@@ -191,7 +193,7 @@ public class PostgresStreamingChangeEventSource
                 }
             }
         } catch (Exception e) {
-            LOGGER.debug("Exception while force-aborting replication connection", e);
+            LOGGER.warn("Exception while force-aborting replication connection", e);
         }
     }
 

--- a/java/connector-node/risingwave-source-cdc/src/main/java/io/debezium/connector/postgresql/PostgresStreamingChangeEventSource.java
+++ b/java/connector-node/risingwave-source-cdc/src/main/java/io/debezium/connector/postgresql/PostgresStreamingChangeEventSource.java
@@ -49,6 +49,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.OptionalLong;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
@@ -149,31 +150,48 @@ public class PostgresStreamingChangeEventSource
     }
 
     /**
-     * Close the underlying PG connections from a thread other than the source thread, so that an
+     * Abort the underlying PG connections from a thread other than the source thread, so that an
      * in-flight {@code connection.commit()} stuck in uninterruptible native JDBC I/O is unblocked
-     * via {@link java.net.SocketException}. The wedged commit then unwinds through {@link
-     * #execute}'s finally block, which runs {@link #cleanUpStreamingOnStop} and releases the
-     * keep-alive thread + replication slot.
+     * via {@link java.io.IOException}. The wedged commit then unwinds through {@link #execute}'s
+     * finally block, which runs {@link #cleanUpStreamingOnStop} and releases the keep-alive thread
+     * + replication slot.
      *
      * <p>Used by the coordinator's stop path as a last-resort escape hatch when {@code
      * executor.shutdownNow()} has failed to terminate the source thread within the configured
      * shutdown timeout, because {@link Thread#interrupt()} does not unblock native JDBC sockets.
+     *
+     * <p>Uses {@link java.sql.Connection#abort(Executor)} (JDBC 4.1) rather than {@code close()}.
+     * pgjdbc's {@code close()} iterates prepared statements via {@code
+     * PgStatement.closeForNextExecution()}, which acquires the {@code ResourceLock} that the wedged
+     * {@code commit()} is holding for the duration of its native socket I/O. This deadlocks the
+     * close. {@code abort()} on pgjdbc instead does a CAS-guarded raw {@code Socket.close()} with
+     * zero lock acquisition (see {@code QueryExecutorCloseAction.abort()}), which causes the wedged
+     * thread's blocked socket read/write to throw {@code IOException} and release the {@code
+     * ResourceLock}.
      */
     public void forceCloseConnection() {
-        LOGGER.warn("Force-closing PostgresConnection to unblock wedged native I/O");
+        LOGGER.warn("Force-aborting PG connections to unblock wedged native I/O");
+        Executor abortExecutor = Runnable::run;
         try {
             if (connection != null) {
-                connection.close();
+                java.sql.Connection raw = connection.connection(false);
+                if (raw != null) {
+                    raw.abort(abortExecutor);
+                }
             }
         } catch (Exception e) {
-            LOGGER.debug("Exception while force-closing PostgresConnection", e);
+            LOGGER.debug("Exception while force-aborting regular PG connection", e);
         }
         try {
-            if (replicationConnection != null) {
-                replicationConnection.close();
+            if (replicationConnection instanceof io.debezium.jdbc.JdbcConnection) {
+                java.sql.Connection raw =
+                        ((io.debezium.jdbc.JdbcConnection) replicationConnection).connection(false);
+                if (raw != null) {
+                    raw.abort(abortExecutor);
+                }
             }
         } catch (Exception e) {
-            LOGGER.debug("Exception while force-closing ReplicationConnection", e);
+            LOGGER.debug("Exception while force-aborting replication connection", e);
         }
     }
 

--- a/java/connector-node/risingwave-source-cdc/src/main/java/io/debezium/connector/postgresql/PostgresStreamingChangeEventSource.java
+++ b/java/connector-node/risingwave-source-cdc/src/main/java/io/debezium/connector/postgresql/PostgresStreamingChangeEventSource.java
@@ -148,6 +148,35 @@ public class PostgresStreamingChangeEventSource
         this.onConnectedCallback = callback;
     }
 
+    /**
+     * Close the underlying PG connections from a thread other than the source thread, so that an
+     * in-flight {@code connection.commit()} stuck in uninterruptible native JDBC I/O is unblocked
+     * via {@link java.net.SocketException}. The wedged commit then unwinds through {@link
+     * #execute}'s finally block, which runs {@link #cleanUpStreamingOnStop} and releases the
+     * keep-alive thread + replication slot.
+     *
+     * <p>Used by the coordinator's stop path as a last-resort escape hatch when {@code
+     * executor.shutdownNow()} has failed to terminate the source thread within the configured
+     * shutdown timeout, because {@link Thread#interrupt()} does not unblock native JDBC sockets.
+     */
+    public void forceCloseConnection() {
+        LOGGER.warn("Force-closing PostgresConnection to unblock wedged native I/O");
+        try {
+            if (connection != null) {
+                connection.close();
+            }
+        } catch (Exception e) {
+            LOGGER.debug("Exception while force-closing PostgresConnection", e);
+        }
+        try {
+            if (replicationConnection != null) {
+                replicationConnection.close();
+            }
+        } catch (Exception e) {
+            LOGGER.debug("Exception while force-closing ReplicationConnection", e);
+        }
+    }
+
     @Override
     public void init(PostgresOffsetContext offsetContext) {
 

--- a/java/connector-node/risingwave-source-cdc/src/main/java/io/debezium/pipeline/ChangeEventSourceCoordinator.java
+++ b/java/connector-node/risingwave-source-cdc/src/main/java/io/debezium/pipeline/ChangeEventSourceCoordinator.java
@@ -540,7 +540,14 @@ public class ChangeEventSourceCoordinator<P extends Partition, O extends OffsetC
                     // through its finally block (which releases keep-alive threads + replication
                     // slot). See risingwavelabs/risingwave#26075.
                     forceCloseStreamingSourceConnection();
-                    executor.awaitTermination(shutdownWaitTimeout, TimeUnit.MILLISECONDS);
+                    boolean forceCloseOk =
+                            executor.awaitTermination(shutdownWaitTimeout, TimeUnit.MILLISECONDS);
+                    if (!forceCloseOk) {
+                        LOGGER.warn(
+                                "Source thread still not terminated after force-closing the "
+                                        + "connection; the replication slot may remain held. See "
+                                        + "risingwavelabs/risingwave#26075");
+                    }
                 }
             }
 

--- a/java/connector-node/risingwave-source-cdc/src/main/java/io/debezium/pipeline/ChangeEventSourceCoordinator.java
+++ b/java/connector-node/risingwave-source-cdc/src/main/java/io/debezium/pipeline/ChangeEventSourceCoordinator.java
@@ -497,6 +497,16 @@ public class ChangeEventSourceCoordinator<P extends Partition, O extends OffsetC
         }
     }
 
+    private void forceCloseStreamingSourceConnection() {
+        if (streamingSource
+                instanceof io.debezium.connector.postgresql.PostgresStreamingChangeEventSource) {
+            ((io.debezium.connector.postgresql.PostgresStreamingChangeEventSource) streamingSource)
+                    .forceCloseConnection();
+        }
+        // SQL Server has the same uninterruptible JDBC commit() pattern; follow-up tracked
+        // separately. MySQL (BinaryLogClient) and MongoDB (cursor) are not affected.
+    }
+
     /** Stops this coordinator. */
     public synchronized void stop() throws InterruptedException {
         running = false;
@@ -521,7 +531,17 @@ public class ChangeEventSourceCoordinator<P extends Partition, O extends OffsetC
                 // Clear interrupt flag so the forced termination is always attempted
                 Thread.interrupted();
                 executor.shutdownNow();
-                executor.awaitTermination(shutdownWaitTimeout, TimeUnit.MILLISECONDS);
+                boolean shutdownNowOk =
+                        executor.awaitTermination(shutdownWaitTimeout, TimeUnit.MILLISECONDS);
+                if (!shutdownNowOk) {
+                    // shutdownNow() only interrupts; native JDBC commit() ignores
+                    // Thread.interrupt(). Force-close the underlying source connection so the
+                    // wedged commit throws SocketException, allowing the source thread to unwind
+                    // through its finally block (which releases keep-alive threads + replication
+                    // slot). See risingwavelabs/risingwave#26075.
+                    forceCloseStreamingSourceConnection();
+                    executor.awaitTermination(shutdownWaitTimeout, TimeUnit.MILLISECONDS);
+                }
             }
 
             if (!isBlockingSnapshotShutdown) {


### PR DESCRIPTION
## Summary

Adds a last-resort force-abort hook to RisingWave's vendored Debezium `ChangeEventSourceCoordinator.stop()`: when the `executor.shutdownNow()` cycle's second `awaitTermination` also times out, abort the underlying `PostgresConnection` (and its replication connection) from outside the source thread via `java.sql.Connection.abort(Executor)`.

pgjdbc's `PgConnection.abort` runs `QueryExecutorCloseAction.abort()`, which does a CAS-guarded raw `Socket.close()` with zero lock acquisition. This causes the wedged thread's blocked socket read/write to throw `IOException` and release the `ResourceLock` cleanly, allowing the source thread to unwind through `cleanUpStreamingOnStop()` and release the PG replication slot.

Closes #26075.

## Root cause

Three layers compound:

1. `DbzCdcEngineRunner.stop()` does not `awaitTermination` and `cleanUp()` only `executor.shutdownNow()`s the RW-owned runner executor. The actual coordinator and keep-alive threads live in Debezium-internal executors, untouched.
2. The PG source coordinator's `processMessages()` loop calls `connection.commit()` (regular JDBC), which performs uninterruptible native socket I/O. `Thread.interrupt()` (from `shutdownNow`) does not unblock it; `context.isRunning()` is never re-checked while wedged.
3. The keep-alive thread is only stopped in `execute()`'s `finally` via `cleanUpStreamingOnStop()`. Because `execute()` never returns, keep-alive heartbeats keep flowing to PG, so `wal_sender_timeout` never fires.

Net effect: RW logs `"engine terminated"`, but the PG walsender stays alive and holds the replication slot. Observed in production on Aurora PostgreSQL 15 for **7h46min** with ~3.2 GB of WAL accumulation. See #26075 for the full analysis.

## Why `abort()` rather than `close()`

The first attempt (now superseded within the same branch) used `connection.close()`. jstack of the wedged JVM showed this deadlocks against pgjdbc's per-statement `ResourceLock`:

```
"pool-1-thread-1" #46 ... WAITING (parking)
  parking to wait for <0x000000030441bae8>
                   (a java.util.concurrent.locks.ReentrantLock$NonfairSync)
  at org.postgresql.jdbc.ResourceLock.obtain(ResourceLock.java:28)
  at org.postgresql.jdbc.PgStatement.closeForNextExecution(PgStatement.java:396)
  at org.postgresql.jdbc.PgStatement.close(PgStatement.java:719)
  at io.debezium.jdbc.JdbcConnection.cleanupPreparedStatement(JdbcConnection.java:1484)
  at io.debezium.jdbc.JdbcConnection.close(JdbcConnection.java:972)
    - locked <0x000000030442fd48> (a io.debezium.connector.postgresql.connection.PostgresConnection)
  at io.debezium.connector.postgresql.PostgresStreamingChangeEventSource.forceCloseConnection
```

`JdbcConnection.close()` iterates prepared statements via `cleanupPreparedStatement`, which acquires the `ResourceLock` that the wedged `commit()` is holding for the duration of its native socket I/O. The force-close call itself deadlocks.

`Connection.abort(Executor)` (JDBC 4.1) is the standard API for "force-close even when other operations are in progress." pgjdbc's implementation ([`QueryExecutorCloseAction.abort()` in REL42.7.7](https://github.com/pgjdbc/pgjdbc/blob/REL42.7.7/pgjdbc/src/main/java/org/postgresql/core/QueryExecutorCloseAction.java#L42-L54)) does a CAS-guarded raw `Socket.close()` with zero lock acquisition.

## Why this placement (coordinator, not runner)

`DbzCdcEngineRunner.executor` runs the `engine.run()` call, but the wedged coordinator and keep-alive threads live in `AsyncEmbeddedEngine`'s internal `taskService`, not in this executor. Adding `awaitTermination` there is a no-op against the actual wedged threads. This patch instead patches the RW-vendored `ChangeEventSourceCoordinator`, which is the layer that already owns the source-thread lifecycle. The dispatch follows the same per-connector `instanceof` pattern that the file already uses in `initStreamEvents` (L434+).

## Scope (cross-connector)

| Connector | Affected by stop-hang | Handled |
|---|---|---|
| PostgreSQL | Yes (severe; holds long-lived replication slot) | **This PR** |
| SQL Server | Yes (same `commitTransaction()` JDBC pattern; per-iteration window shorter, no replication slot) | Follow-up: #26081 |
| MySQL | No (`BinaryLogClient` callback-driven; `disconnect()` closes socket cleanly) | n/a |
| MongoDB | No (`cursor.tryNext()` non-blocking; try-with-resources auto-closes) | n/a |

## Worst-case stop wait

**~12 s** on default configuration: `executor.shutdown.timeout.ms` (default 4000 ms) is applied three times in the coordinator stop path before the abort fires. The abort itself is a single non-blocking `Socket.close()`; the wedged commit unblocks in milliseconds (measured 26 ms below). Two orders of magnitude better than the 7 h zombie observed in production.

If a user has overridden `executor.shutdown.timeout.ms` upward (e.g., 30 min), the worst-case stop wait grows proportionally.

## Test plan

- [x] Baseline (main, no fix) under Toxiproxy `timeout=0` toxic: zombie reproduces deterministically (walsender alive, `pg_replication_slots.active=t` at T+30s and T+390s).
- [x] **Verified with the new `abort()`-based fix** under the same Toxiproxy setup, including jstack at force-abort+5s. See evidence below.

### Verification evidence (fix run)

ZOMBIE assertions at both T+30s and T+390s:
```
[T+30s]  walsender count = 0, slot active = false  → NO ZOMBIE
[T+390s] walsender count = 0, slot active = false  → NO ZOMBIE
```

Time from `Force-aborting` log to wedged `commit()` unwinding via `SocketException`:
```
11:53:49.081  WARN  Force-aborting PG connections to unblock wedged native I/O
                    thread="pool-1-thread-1"
                    class="io.debezium.connector.postgresql.PostgresStreamingChangeEventSource"
11:53:49.107  ERROR Producer failure ... Caused by: java.net.SocketException: Socket closed
                    thread="...coordinator"
                    [stack: ...PostgresStreamingChangeEventSource.processMessages:398]
```
Gap = **26 ms**.

jstack at force-abort + 5 s: `pool-1-thread-1` has already exited; only JVM internal threads remain. Socket state via `lsof`: all connections cleanly closed (only `TIME_WAIT` entries).

A/B summary:

| Run | T+30s | T+390s | abort/close → commit unwind |
|-----|-------|--------|------|
| Baseline (main) | ZOMBIE | ZOMBIE | N/A (no fix code) |
| First attempt (close-based) | ZOMBIE | ZOMBIE | **6 min 30 s** (deadlock on `ResourceLock`) |
| **Final (abort-based)** | NO ZOMBIE | NO ZOMBIE | **26 ms** |

## Related

- #15739 (closed/not-planned, 2024-03): earlier stack trace from the same `ChangeEventSourceCoordinator.stop() → awaitTermination` fragile path; closed as test flakiness at the time but is the same code path.
- #25200 (open, P-high): framework-level heartbeat stall detection from the same customer incident. Complementary: this PR fixes the underlying cause (zombie slot), #25200 adds a detection / self-recovery layer that remains useful as belt-and-suspenders for other classes of silent stalls.