### PR TITLE
fix(storage): notify serving refill vnode updates

### DIFF
--- a/e2e_test/commands/psql_refill_validate.py
+++ b/e2e_test/commands/psql_refill_validate.py
@@ -32,7 +32,7 @@ import re
 import subprocess
 import sys
 from collections import defaultdict
-from typing import Any
+from typing import Any, Optional, Union
 
 import psycopg2
 
@@ -112,7 +112,7 @@ def run_command(command: list[str]) -> str:
     return result.stdout
 
 
-def resolve_risectl(explicit_risectl: str | None) -> str:
+def resolve_risectl(explicit_risectl: Optional[str]) -> str:
     if explicit_risectl:
         return explicit_risectl
 
@@ -123,7 +123,7 @@ def resolve_risectl(explicit_risectl: str | None) -> str:
     return "risectl"
 
 
-def resolve_job(conn, job_name: str, job_type: str | None) -> tuple[int, str]:
+def resolve_job(conn, job_name: str, job_type: Optional[str]) -> tuple[int, str]:
     query = """
     WITH all_jobs AS (
         SELECT id, name, 'table' AS job_type FROM rw_catalog.rw_tables
@@ -241,14 +241,21 @@ def parse_refill_stats(output: str) -> dict[int, dict[str, Any]]:
 def parse_serving_fragment_mapping(output: str) -> list[tuple[int, int, int, list[int]]]:
     rows: list[tuple[int, int, int, list[int]]] = []
     for line in output.splitlines():
-        if "│" not in line:
+        if "│" in line:
+            parts = [part.strip() for part in line.split("│")[1:-1]]
+        elif "|" in line:
+            parts = [part.strip() for part in line.split("|")[1:-1]]
+        else:
             continue
-        parts = [part.strip() for part in line.split("│")[1:-1]]
+
         if len(parts) != 4 or parts[0] == "Job Id":
             continue
 
-        job_id = int(parts[0])
-        fragment_id = int(parts[1])
+        try:
+            job_id = int(parts[0])
+            fragment_id = int(parts[1])
+        except ValueError:
+            continue
 
         vnode_match = re.search(r"in total:\s*(.*)$", parts[2])
         if vnode_match and vnode_match.group(1):
@@ -283,7 +290,7 @@ def build_expected_serving_worker_vnodes(
 
 
 def normalize_nested_vnodes(
-    data: dict[int, dict[int, set[int] | list[int]]]
+    data: dict[int, dict[int, Union[set[int], list[int]]]]
 ) -> dict[int, dict[int, list[int]]]:
     normalized: dict[int, dict[int, list[int]]] = {}
     for worker_id, per_table in data.items():

--- a/e2e_test/refill/table_refill.slt
+++ b/e2e_test/refill/table_refill.slt
@@ -29,7 +29,7 @@ recover;
 
 skipif parallel
 system ok
-psql_refill_validate.py --job-name s3 --job-type sink --mode streaming --expect-policy both
+psql_refill_validate.py --job-name s3 --job-type sink --mode both --expect-policy both
 
 statement ok
 drop sink s3;

--- a/src/meta/node/src/server.rs
+++ b/src/meta/node/src/server.rs
@@ -505,6 +505,7 @@ pub async fn start_service_as_election_leader(
         env.clone(),
         metadata_manager.clone(),
         hummock_manager.clone(),
+        serving_vnode_mapping.clone(),
         source_manager.clone(),
         sink_manager.clone(),
         scale_controller.clone(),
@@ -695,7 +696,7 @@ pub async fn start_service_as_election_leader(
     sub_tasks.push(serving::start_serving_vnode_mapping_worker(
         env.notification_manager_ref(),
         metadata_manager.clone(),
-        serving_vnode_mapping,
+        serving_vnode_mapping.clone(),
         env.session_params_manager_impl_ref(),
     ));
 

--- a/src/meta/src/barrier/context/context_impl.rs
+++ b/src/meta/src/barrier/context/context_impl.rs
@@ -43,7 +43,7 @@ use crate::barrier::{
 use crate::hummock::CommitEpochInfo;
 use crate::manager::LocalNotification;
 use crate::model::FragmentDownstreamRelation;
-use crate::serving::{fetch_serving_infos, notify_hummock_serving_table_vnode_mappings};
+use crate::serving::{fetch_serving_infos, sync_serving_table_vnode_mappings_to_hummock};
 use crate::stream::{SourceChange, cleanup_dropped_streaming_jobs};
 use crate::{MetaError, MetaResult};
 
@@ -88,10 +88,10 @@ impl GlobalBarrierWorkerContext for GlobalBarrierWorkerContextImpl {
             .await
     }
 
-    async fn notify_hummock_serving_table_vnode_mappings(&self) -> MetaResult<()> {
+    async fn sync_serving_table_vnode_mappings_to_hummock(&self) -> MetaResult<()> {
         let (serving_workers, fragment_parallelisms) =
             fetch_serving_infos(&self.metadata_manager).await?;
-        notify_hummock_serving_table_vnode_mappings(
+        sync_serving_table_vnode_mappings_to_hummock(
             &self.env.notification_manager_ref(),
             &self.serving_vnode_mapping,
             &serving_workers,

--- a/src/meta/src/barrier/context/context_impl.rs
+++ b/src/meta/src/barrier/context/context_impl.rs
@@ -43,6 +43,7 @@ use crate::barrier::{
 use crate::hummock::CommitEpochInfo;
 use crate::manager::LocalNotification;
 use crate::model::FragmentDownstreamRelation;
+use crate::serving::{fetch_serving_infos, notify_hummock_serving_table_vnode_mappings};
 use crate::stream::{SourceChange, cleanup_dropped_streaming_jobs};
 use crate::{MetaError, MetaResult};
 
@@ -85,6 +86,19 @@ impl GlobalBarrierWorkerContext for GlobalBarrierWorkerContextImpl {
             .catalog_controller
             .table_cache_refill_policies_snapshot()
             .await
+    }
+
+    async fn notify_hummock_serving_table_vnode_mappings(&self) -> MetaResult<()> {
+        let (serving_workers, fragment_parallelisms) =
+            fetch_serving_infos(&self.metadata_manager).await?;
+        notify_hummock_serving_table_vnode_mappings(
+            &self.env.notification_manager_ref(),
+            &self.serving_vnode_mapping,
+            &serving_workers,
+            &fragment_parallelisms,
+        )
+        .await;
+        Ok(())
     }
 
     #[await_tree::instrument("post_collect_command({command})")]

--- a/src/meta/src/barrier/context/mod.rs
+++ b/src/meta/src/barrier/context/mod.rs
@@ -93,7 +93,7 @@ pub(super) trait GlobalBarrierWorkerContext: Send + Sync + 'static {
         Ok(PbTableCacheRefillPolicies::default())
     }
 
-    async fn notify_hummock_serving_table_vnode_mappings(&self) -> MetaResult<()> {
+    async fn sync_serving_table_vnode_mappings_to_hummock(&self) -> MetaResult<()> {
         Ok(())
     }
 

--- a/src/meta/src/barrier/context/mod.rs
+++ b/src/meta/src/barrier/context/mod.rs
@@ -42,6 +42,7 @@ use crate::barrier::{
 use crate::hummock::{CommitEpochInfo, HummockManagerRef};
 use crate::manager::sink_coordination::SinkCoordinatorManager;
 use crate::manager::{MetaSrvEnv, MetadataManager};
+use crate::serving::ServingVnodeMappingRef;
 use crate::stream::source_manager::SplitAssignment;
 use crate::stream::{GlobalRefreshManagerRef, ScaleControllerRef, SourceManagerRef};
 
@@ -90,6 +91,10 @@ pub(super) trait GlobalBarrierWorkerContext: Send + Sync + 'static {
 
     async fn table_cache_refill_policies_snapshot(&self) -> MetaResult<PbTableCacheRefillPolicies> {
         Ok(PbTableCacheRefillPolicies::default())
+    }
+
+    async fn notify_hummock_serving_table_vnode_mappings(&self) -> MetaResult<()> {
+        Ok(())
     }
 
     fn post_collect_command(
@@ -147,6 +152,8 @@ pub(super) struct GlobalBarrierWorkerContextImpl {
 
     hummock_manager: HummockManagerRef,
 
+    serving_vnode_mapping: ServingVnodeMappingRef,
+
     source_manager: SourceManagerRef,
 
     _scale_controller: ScaleControllerRef,
@@ -162,11 +169,13 @@ pub(super) struct GlobalBarrierWorkerContextImpl {
 }
 
 impl GlobalBarrierWorkerContextImpl {
+    #[expect(clippy::too_many_arguments)]
     pub(super) fn new(
         scheduled_barriers: ScheduledBarriers,
         status: Arc<ArcSwap<BarrierManagerStatus>>,
         metadata_manager: MetadataManager,
         hummock_manager: HummockManagerRef,
+        serving_vnode_mapping: ServingVnodeMappingRef,
         source_manager: SourceManagerRef,
         scale_controller: ScaleControllerRef,
         env: MetaSrvEnv,
@@ -179,6 +188,7 @@ impl GlobalBarrierWorkerContextImpl {
             status,
             metadata_manager,
             hummock_manager,
+            serving_vnode_mapping,
             source_manager,
             _scale_controller: scale_controller,
             env,

--- a/src/meta/src/barrier/manager.rs
+++ b/src/meta/src/barrier/manager.rs
@@ -41,6 +41,7 @@ use crate::barrier::{
 use crate::hummock::HummockManagerRef;
 use crate::manager::sink_coordination::SinkCoordinatorManager;
 use crate::manager::{MetaSrvEnv, MetadataManager};
+use crate::serving::ServingVnodeMappingRef;
 use crate::stream::{GlobalRefreshManagerRef, ScaleControllerRef, SourceManagerRef};
 
 pub struct GlobalBarrierManager {
@@ -197,6 +198,7 @@ impl GlobalBarrierManager {
         env: MetaSrvEnv,
         metadata_manager: MetadataManager,
         hummock_manager: HummockManagerRef,
+        serving_vnode_mapping: ServingVnodeMappingRef,
         source_manager: SourceManagerRef,
         sink_manager: SinkCoordinatorManager,
         scale_controller: ScaleControllerRef,
@@ -211,6 +213,7 @@ impl GlobalBarrierManager {
             env,
             metadata_manager,
             hummock_manager,
+            serving_vnode_mapping,
             source_manager,
             sink_manager,
             scale_controller,

--- a/src/meta/src/barrier/worker.rs
+++ b/src/meta/src/barrier/worker.rs
@@ -61,6 +61,7 @@ use crate::manager::{
     MetadataManager,
 };
 use crate::rpc::metrics::GLOBAL_META_METRICS;
+use crate::serving::ServingVnodeMappingRef;
 use crate::stream::{
     GlobalRefreshManagerRef, ScaleControllerRef, SourceManagerRef, build_reschedule_commands,
     rendered_layout_matches_current,
@@ -298,11 +299,13 @@ fn build_reschedule_from_context(
 
 impl GlobalBarrierWorker<GlobalBarrierWorkerContextImpl> {
     /// Create a new [`crate::barrier::worker::GlobalBarrierWorker`].
+    #[expect(clippy::too_many_arguments)]
     pub async fn new(
         scheduled_barriers: schedule::ScheduledBarriers,
         env: MetaSrvEnv,
         metadata_manager: MetadataManager,
         hummock_manager: HummockManagerRef,
+        serving_vnode_mapping: ServingVnodeMappingRef,
         source_manager: SourceManagerRef,
         sink_manager: SinkCoordinatorManager,
         scale_controller: ScaleControllerRef,
@@ -317,6 +320,7 @@ impl GlobalBarrierWorker<GlobalBarrierWorkerContextImpl> {
             status,
             metadata_manager,
             hummock_manager,
+            serving_vnode_mapping,
             source_manager,
             scale_controller,
             env.clone(),
@@ -403,9 +407,11 @@ impl GlobalBarrierWorker<GlobalBarrierWorkerContextImpl> {
 
             let paused = self.take_pause_on_bootstrap().await.unwrap_or(false);
 
-            self.recovery(paused, RecoveryReason::Bootstrap)
-                .instrument(span)
-                .await;
+            Box::pin(
+                self.recovery(paused, RecoveryReason::Bootstrap)
+                    .instrument(span),
+            )
+            .await;
         }
 
         Box::pin(self.run_inner(shutdown_rx)).await
@@ -963,6 +969,12 @@ impl<C: GlobalBarrierWorkerContext> GlobalBarrierWorker<C> {
                     "failed to notify table cache refill policies after recovery"
                 );
             }
+        }
+        if let Err(err) = context.notify_hummock_serving_table_vnode_mappings().await {
+            warn!(
+                error = %err.as_report(),
+                "failed to notify serving table vnode mappings after recovery"
+            );
         }
     }
 

--- a/src/meta/src/barrier/worker.rs
+++ b/src/meta/src/barrier/worker.rs
@@ -616,7 +616,7 @@ impl<C: GlobalBarrierWorkerContext> GlobalBarrierWorker<C> {
                                         // mark ready to unblock subsequent request
                                         self.context.mark_ready(MarkReadyOptions::Database(database_id));
                                         entering_initializing.remove();
-                                        Self::notify_table_refill_runtime_config_after_recovery(
+                                        Self::refresh_table_refill_runtime_state_after_recovery(
                                             self.context.clone(),
                                             self.env.clone(),
                                         ).await;
@@ -629,7 +629,7 @@ impl<C: GlobalBarrierWorkerContext> GlobalBarrierWorker<C> {
                             CheckpointControlEvent::EnteringRunning(entering_running) => {
                                 self.context.mark_ready(MarkReadyOptions::Database(entering_running.database_id()));
                                 entering_running.enter();
-                                Self::notify_table_refill_runtime_config_after_recovery(
+                                Self::refresh_table_refill_runtime_state_after_recovery(
                                     self.context.clone(),
                                     self.env.clone(),
                                 ).await;
@@ -952,7 +952,16 @@ use crate::barrier::partial_graph::{
 };
 
 impl<C: GlobalBarrierWorkerContext> GlobalBarrierWorker<C> {
-    async fn notify_table_refill_runtime_config_after_recovery(context: Arc<C>, env: MetaSrvEnv) {
+    async fn refresh_table_refill_runtime_state_after_recovery(context: Arc<C>, env: MetaSrvEnv) {
+        // Table refill is a best-effort runtime optimization. Recovery uses an
+        // eventually consistent refresh for meta-owned state: policy is global and
+        // broadcast, while serving vnode mapping is worker-specific and delivered
+        // through targeted updates.
+        Self::refresh_table_cache_refill_policies_after_recovery(context.clone(), env).await;
+        Self::refresh_serving_table_vnode_mappings_after_recovery(context).await;
+    }
+
+    async fn refresh_table_cache_refill_policies_after_recovery(context: Arc<C>, env: MetaSrvEnv) {
         match context.table_cache_refill_policies_snapshot().await {
             Ok(policies) => {
                 env.notification_manager()
@@ -968,14 +977,17 @@ impl<C: GlobalBarrierWorkerContext> GlobalBarrierWorker<C> {
             Err(err) => {
                 warn!(
                     error = %err.as_report(),
-                    "failed to notify table cache refill policies after recovery"
+                    "failed to refresh table cache refill policies after recovery"
                 );
             }
         }
+    }
+
+    async fn refresh_serving_table_vnode_mappings_after_recovery(context: Arc<C>) {
         if let Err(err) = context.sync_serving_table_vnode_mappings_to_hummock().await {
             warn!(
                 error = %err.as_report(),
-                "failed to notify serving table vnode mappings after recovery"
+                "failed to refresh serving table vnode mappings after recovery"
             );
         }
     }
@@ -1339,7 +1351,7 @@ impl<C: GlobalBarrierWorkerContext> GlobalBarrierWorker<C> {
             ),
         )]);
 
-        Self::notify_table_refill_runtime_config_after_recovery(
+        Self::refresh_table_refill_runtime_state_after_recovery(
             self.context.clone(),
             self.env.clone(),
         )

--- a/src/meta/src/barrier/worker.rs
+++ b/src/meta/src/barrier/worker.rs
@@ -407,6 +407,8 @@ impl GlobalBarrierWorker<GlobalBarrierWorkerContextImpl> {
 
             let paused = self.take_pause_on_bootstrap().await.unwrap_or(false);
 
+            // Keep the bootstrap recovery future boxed so the outer barrier worker future
+            // stays below clippy's large-futures threshold.
             Box::pin(
                 self.recovery(paused, RecoveryReason::Bootstrap)
                     .instrument(span),
@@ -614,7 +616,7 @@ impl<C: GlobalBarrierWorkerContext> GlobalBarrierWorker<C> {
                                         // mark ready to unblock subsequent request
                                         self.context.mark_ready(MarkReadyOptions::Database(database_id));
                                         entering_initializing.remove();
-                                        Self::notify_table_cache_refill_policies_after_recovery(
+                                        Self::notify_table_refill_runtime_config_after_recovery(
                                             self.context.clone(),
                                             self.env.clone(),
                                         ).await;
@@ -627,7 +629,7 @@ impl<C: GlobalBarrierWorkerContext> GlobalBarrierWorker<C> {
                             CheckpointControlEvent::EnteringRunning(entering_running) => {
                                 self.context.mark_ready(MarkReadyOptions::Database(entering_running.database_id()));
                                 entering_running.enter();
-                                Self::notify_table_cache_refill_policies_after_recovery(
+                                Self::notify_table_refill_runtime_config_after_recovery(
                                     self.context.clone(),
                                     self.env.clone(),
                                 ).await;
@@ -950,7 +952,7 @@ use crate::barrier::partial_graph::{
 };
 
 impl<C: GlobalBarrierWorkerContext> GlobalBarrierWorker<C> {
-    async fn notify_table_cache_refill_policies_after_recovery(context: Arc<C>, env: MetaSrvEnv) {
+    async fn notify_table_refill_runtime_config_after_recovery(context: Arc<C>, env: MetaSrvEnv) {
         match context.table_cache_refill_policies_snapshot().await {
             Ok(policies) => {
                 env.notification_manager()
@@ -970,7 +972,7 @@ impl<C: GlobalBarrierWorkerContext> GlobalBarrierWorker<C> {
                 );
             }
         }
-        if let Err(err) = context.notify_hummock_serving_table_vnode_mappings().await {
+        if let Err(err) = context.sync_serving_table_vnode_mappings_to_hummock().await {
             warn!(
                 error = %err.as_report(),
                 "failed to notify serving table vnode mappings after recovery"
@@ -1337,7 +1339,7 @@ impl<C: GlobalBarrierWorkerContext> GlobalBarrierWorker<C> {
             ),
         )]);
 
-        Self::notify_table_cache_refill_policies_after_recovery(
+        Self::notify_table_refill_runtime_config_after_recovery(
             self.context.clone(),
             self.env.clone(),
         )

--- a/src/meta/src/manager/notification.rs
+++ b/src/meta/src/manager/notification.rs
@@ -214,10 +214,9 @@ impl NotificationManager {
             .await
     }
 
-    pub async fn notify_hummock_targeted(
+    pub(crate) async fn notify_hummock_targeted_update(
         &self,
         worker_key: WorkerKey,
-        operation: Operation,
         info: Info,
     ) -> NotificationVersion {
         self.notify_with_version(
@@ -225,7 +224,7 @@ impl NotificationManager {
                 subscribe_type: SubscribeType::Hummock,
                 worker_key: Some(worker_key),
             },
-            operation,
+            Operation::Update,
             info,
         )
         .await
@@ -444,7 +443,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_notify_hummock_targeted() {
+    async fn test_notify_hummock_targeted_update() {
         let mgr = NotificationManager::new(SqlMetaStore::for_test().await).await;
         let worker_key1 = WorkerKey(HostAddress {
             host: "a".to_owned(),
@@ -461,12 +460,8 @@ mod tests {
         mgr.insert_sender(SubscribeType::Hummock, worker_key2.clone(), hummock_tx2);
         mgr.insert_sender(SubscribeType::Frontend, worker_key1.clone(), frontend_tx1);
 
-        mgr.notify_hummock_targeted(
-            worker_key1,
-            Operation::Update,
-            Info::Database(Default::default()),
-        )
-        .await;
+        mgr.notify_hummock_targeted_update(worker_key1, Info::Database(Default::default()))
+            .await;
 
         assert!(hummock_rx1.recv().await.is_some());
         assert!(hummock_rx2.try_recv().is_err());

--- a/src/meta/src/manager/notification.rs
+++ b/src/meta/src/manager/notification.rs
@@ -214,6 +214,23 @@ impl NotificationManager {
             .await
     }
 
+    pub async fn notify_hummock_targeted(
+        &self,
+        worker_key: WorkerKey,
+        operation: Operation,
+        info: Info,
+    ) -> NotificationVersion {
+        self.notify_with_version(
+            Target {
+                subscribe_type: SubscribeType::Hummock,
+                worker_key: Some(worker_key),
+            },
+            operation,
+            info,
+        )
+        .await
+    }
+
     pub async fn notify_compactor(&self, operation: Operation, info: Info) -> NotificationVersion {
         self.notify_with_version(SubscribeType::Compactor.into(), operation, info)
             .await
@@ -424,6 +441,36 @@ mod tests {
         assert!(rx1.try_recv().is_err());
         assert!(rx2.recv().await.is_some());
         assert!(rx3.recv().await.is_some());
+    }
+
+    #[tokio::test]
+    async fn test_notify_hummock_targeted() {
+        let mgr = NotificationManager::new(SqlMetaStore::for_test().await).await;
+        let worker_key1 = WorkerKey(HostAddress {
+            host: "a".to_owned(),
+            port: 1,
+        });
+        let worker_key2 = WorkerKey(HostAddress {
+            host: "a".to_owned(),
+            port: 2,
+        });
+        let (hummock_tx1, mut hummock_rx1) = mpsc::unbounded_channel();
+        let (hummock_tx2, mut hummock_rx2) = mpsc::unbounded_channel();
+        let (frontend_tx1, mut frontend_rx1) = mpsc::unbounded_channel();
+        mgr.insert_sender(SubscribeType::Hummock, worker_key1.clone(), hummock_tx1);
+        mgr.insert_sender(SubscribeType::Hummock, worker_key2.clone(), hummock_tx2);
+        mgr.insert_sender(SubscribeType::Frontend, worker_key1.clone(), frontend_tx1);
+
+        mgr.notify_hummock_targeted(
+            worker_key1,
+            Operation::Update,
+            Info::Database(Default::default()),
+        )
+        .await;
+
+        assert!(hummock_rx1.recv().await.is_some());
+        assert!(hummock_rx2.try_recv().is_err());
+        assert!(frontend_rx1.try_recv().is_err());
     }
 
     #[tokio::test]

--- a/src/meta/src/serving/mod.rs
+++ b/src/meta/src/serving/mod.rs
@@ -30,10 +30,12 @@ use risingwave_pb::meta::{
 use tokio::sync::oneshot::Sender;
 use tokio::task::JoinHandle;
 
+use crate::MetaResult;
 use crate::controller::fragment::FragmentParallelismInfo;
 use crate::controller::session_params::SessionParamsControllerRef;
-use crate::manager::{LocalNotification, MetadataManager, NotificationManagerRef};
+use crate::manager::{LocalNotification, MetadataManager, NotificationManagerRef, WorkerKey};
 use crate::model::FragmentId;
+use crate::table_refill::build_hummock_serving_table_vnode_runtime_config;
 
 pub type ServingVnodeMappingRef = Arc<ServingVnodeMapping>;
 
@@ -123,8 +125,9 @@ pub async fn on_meta_start(
     serving_vnode_mapping: ServingVnodeMappingRef,
     max_serving_parallelism: Option<u64>,
 ) {
-    let (serving_compute_nodes, streaming_parallelisms) =
-        fetch_serving_infos(metadata_manager).await;
+    let (serving_compute_nodes, streaming_parallelisms) = fetch_serving_infos(metadata_manager)
+        .await
+        .expect("fail to fetch serving infos");
     let (mappings, failed) = serving_vnode_mapping.upsert(
         &streaming_parallelisms,
         &serving_compute_nodes,
@@ -148,29 +151,54 @@ pub async fn on_meta_start(
     );
 }
 
-async fn fetch_serving_infos(
+pub(crate) async fn fetch_serving_infos(
     metadata_manager: &MetadataManager,
-) -> (
+) -> MetaResult<(
     Vec<WorkerNode>,
     HashMap<FragmentId, FragmentParallelismInfo>,
-) {
+)> {
     let parallelisms = metadata_manager
         .catalog_controller
         .fragment_parallelisms()
-        .await
-        .expect("fail to fetch running parallelisms");
+        .await?;
     let serving_compute_nodes = metadata_manager
         .cluster_controller
         .list_active_serving_workers()
-        .await
-        .expect("fail to list serving compute nodes");
-    (
+        .await?;
+    Ok((
         serving_compute_nodes,
         parallelisms
             .into_iter()
             .map(|(fragment_id, info)| (fragment_id as FragmentId, info))
             .collect(),
-    )
+    ))
+}
+
+pub async fn notify_hummock_serving_table_vnode_mappings(
+    notification_manager: &NotificationManagerRef,
+    serving_vnode_mapping: &ServingVnodeMappingRef,
+    workers: &[WorkerNode],
+    streaming_parallelisms: &HashMap<FragmentId, FragmentParallelismInfo>,
+) {
+    for worker in workers {
+        let Some(host) = worker.host.clone() else {
+            tracing::warn!(worker_id = %worker.id, "serving worker host not found");
+            continue;
+        };
+        let config = build_hummock_serving_table_vnode_runtime_config(
+            serving_vnode_mapping,
+            worker.id,
+            streaming_parallelisms,
+            0,
+        );
+        notification_manager
+            .notify_hummock_targeted(
+                WorkerKey(host),
+                Operation::Update,
+                Info::TableRefillRuntimeConfig(config),
+            )
+            .await;
+    }
 }
 
 pub fn start_serving_vnode_mapping_worker(
@@ -184,7 +212,9 @@ pub fn start_serving_vnode_mapping_worker(
     notification_manager.insert_local_sender(local_notification_tx);
     let join_handle = tokio::spawn(async move {
         let reset = || async {
-            let (workers, streaming_parallelisms) = fetch_serving_infos(&metadata_manager).await;
+            let (workers, streaming_parallelisms) = fetch_serving_infos(&metadata_manager)
+                .await
+                .expect("fail to fetch serving infos");
             let max_serving_parallelism = session_params
                 .get_params()
                 .await
@@ -211,6 +241,13 @@ pub fn start_serving_vnode_mapping_worker(
                     mappings: to_fragment_worker_slot_mapping(&mappings),
                 }),
             );
+            notify_hummock_serving_table_vnode_mappings(
+                &notification_manager,
+                &serving_vnode_mapping,
+                &workers,
+                &streaming_parallelisms,
+            )
+            .await;
         };
         loop {
             tokio::select! {
@@ -231,7 +268,9 @@ pub fn start_serving_vnode_mapping_worker(
                                     if fragment_ids.is_empty() {
                                         continue;
                                     }
-                                    let (workers, streaming_parallelisms) = fetch_serving_infos(&metadata_manager).await;
+                                    let (workers, streaming_parallelisms) = fetch_serving_infos(&metadata_manager)
+                                        .await
+                                        .expect("fail to fetch serving infos");
                                     let filtered_streaming_parallelisms = fragment_ids.iter().filter_map(|frag_id| {
                                         match streaming_parallelisms.get(frag_id) {
                                             Some(info) => Some((*frag_id, info.clone())),
@@ -255,6 +294,13 @@ pub fn start_serving_vnode_mapping_worker(
                                         tracing::warn!("Fail to update serving vnode mapping for fragments {:?}.", failed);
                                         notification_manager.notify_frontend_without_version(Operation::Delete, Info::ServingWorkerSlotMappings(FragmentWorkerSlotMappings{ mappings: to_deleted_fragment_worker_slot_mapping(failed.keys().cloned())}));
                                     }
+                                    notify_hummock_serving_table_vnode_mappings(
+                                        &notification_manager,
+                                        &serving_vnode_mapping,
+                                        &workers,
+                                        &streaming_parallelisms,
+                                    )
+                                    .await;
                                 }
                                 LocalNotification::ServingFragmentMappingsDelete(fragment_ids) => {
                                     if fragment_ids.is_empty() {
@@ -265,6 +311,16 @@ pub fn start_serving_vnode_mapping_worker(
 
                                     serving_vnode_mapping.remove(&fragment_ids);
                                     notification_manager.notify_frontend_without_version(Operation::Delete, Info::ServingWorkerSlotMappings(FragmentWorkerSlotMappings{ mappings: to_deleted_fragment_worker_slot_mapping(fragment_ids.iter().cloned()) }));
+                                    let (workers, streaming_parallelisms) = fetch_serving_infos(&metadata_manager)
+                                        .await
+                                        .expect("fail to fetch serving infos");
+                                    notify_hummock_serving_table_vnode_mappings(
+                                        &notification_manager,
+                                        &serving_vnode_mapping,
+                                        &workers,
+                                        &streaming_parallelisms,
+                                    )
+                                    .await;
                                 }
                                 _ => {}
                             }

--- a/src/meta/src/serving/mod.rs
+++ b/src/meta/src/serving/mod.rs
@@ -26,6 +26,7 @@ use risingwave_pb::meta::subscribe_response::{Info, Operation};
 use risingwave_pb::meta::table_fragments::fragment::FragmentDistributionType;
 use risingwave_pb::meta::{
     FragmentWorkerSlotMapping, FragmentWorkerSlotMappings, PbServingTableVnodeMappings,
+    PbTableRefillRuntimeConfig,
 };
 use tokio::sync::oneshot::Sender;
 use tokio::task::JoinHandle;
@@ -35,7 +36,7 @@ use crate::controller::fragment::FragmentParallelismInfo;
 use crate::controller::session_params::SessionParamsControllerRef;
 use crate::manager::{LocalNotification, MetadataManager, NotificationManagerRef, WorkerKey};
 use crate::model::FragmentId;
-use crate::table_refill::build_hummock_serving_table_vnode_runtime_config;
+use crate::table_refill::build_hummock_serving_table_vnode_mappings;
 
 pub type ServingVnodeMappingRef = Arc<ServingVnodeMapping>;
 
@@ -174,7 +175,7 @@ pub(crate) async fn fetch_serving_infos(
     ))
 }
 
-pub async fn notify_hummock_serving_table_vnode_mappings(
+pub(crate) async fn sync_serving_table_vnode_mappings_to_hummock(
     notification_manager: &NotificationManagerRef,
     serving_vnode_mapping: &ServingVnodeMappingRef,
     workers: &[WorkerNode],
@@ -185,18 +186,16 @@ pub async fn notify_hummock_serving_table_vnode_mappings(
             tracing::warn!(worker_id = %worker.id, "serving worker host not found");
             continue;
         };
-        let config = build_hummock_serving_table_vnode_runtime_config(
-            serving_vnode_mapping,
-            worker.id,
-            streaming_parallelisms,
-            0,
-        );
+        let config = PbTableRefillRuntimeConfig {
+            serving_table_vnode_mappings: Some(build_hummock_serving_table_vnode_mappings(
+                serving_vnode_mapping,
+                worker.id,
+                streaming_parallelisms,
+            )),
+            ..Default::default()
+        };
         notification_manager
-            .notify_hummock_targeted(
-                WorkerKey(host),
-                Operation::Update,
-                Info::TableRefillRuntimeConfig(config),
-            )
+            .notify_hummock_targeted_update(WorkerKey(host), Info::TableRefillRuntimeConfig(config))
             .await;
     }
 }
@@ -241,7 +240,7 @@ pub fn start_serving_vnode_mapping_worker(
                     mappings: to_fragment_worker_slot_mapping(&mappings),
                 }),
             );
-            notify_hummock_serving_table_vnode_mappings(
+            sync_serving_table_vnode_mappings_to_hummock(
                 &notification_manager,
                 &serving_vnode_mapping,
                 &workers,
@@ -294,7 +293,7 @@ pub fn start_serving_vnode_mapping_worker(
                                         tracing::warn!("Fail to update serving vnode mapping for fragments {:?}.", failed);
                                         notification_manager.notify_frontend_without_version(Operation::Delete, Info::ServingWorkerSlotMappings(FragmentWorkerSlotMappings{ mappings: to_deleted_fragment_worker_slot_mapping(failed.keys().cloned())}));
                                     }
-                                    notify_hummock_serving_table_vnode_mappings(
+                                    sync_serving_table_vnode_mappings_to_hummock(
                                         &notification_manager,
                                         &serving_vnode_mapping,
                                         &workers,
@@ -314,7 +313,7 @@ pub fn start_serving_vnode_mapping_worker(
                                     let (workers, streaming_parallelisms) = fetch_serving_infos(&metadata_manager)
                                         .await
                                         .expect("fail to fetch serving infos");
-                                    notify_hummock_serving_table_vnode_mappings(
+                                    sync_serving_table_vnode_mappings_to_hummock(
                                         &notification_manager,
                                         &serving_vnode_mapping,
                                         &workers,
@@ -390,5 +389,95 @@ pub fn to_pb_serving_table_vnode_mappings(
                 bitmap: Some(bitmap.to_protobuf()),
             })
             .collect(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use risingwave_common::hash::VirtualNode;
+    use risingwave_pb::common::{HostAddress, worker_node};
+    use risingwave_pb::meta::subscribe_response::Info;
+    use risingwave_pb::meta::{SubscribeResponse, SubscribeType};
+    use tokio::sync::mpsc;
+
+    use super::*;
+    use crate::controller::SqlMetaStore;
+    use crate::manager::NotificationManager;
+
+    fn serving_worker(id: u32) -> WorkerNode {
+        WorkerNode {
+            id: id.into(),
+            r#type: WorkerType::ComputeNode.into(),
+            host: Some(HostAddress {
+                host: format!("host{}", id),
+                port: id as i32,
+            }),
+            state: worker_node::State::Running as i32,
+            property: Some(worker_node::Property {
+                is_serving: true,
+                parallelism: 1,
+                ..Default::default()
+            }),
+            ..Default::default()
+        }
+    }
+
+    #[tokio::test]
+    async fn test_sync_serving_table_vnode_mappings_to_hummock_targets_each_worker() {
+        let notification_manager =
+            Arc::new(NotificationManager::new(SqlMetaStore::for_test().await).await);
+        let worker1 = serving_worker(1);
+        let worker2 = serving_worker(2);
+        let workers = vec![worker1.clone(), worker2.clone()];
+        let worker_key1 = WorkerKey(worker1.host.clone().unwrap());
+        let worker_key2 = WorkerKey(worker2.host.clone().unwrap());
+        let (tx1, mut rx1) = mpsc::unbounded_channel();
+        let (tx2, mut rx2) = mpsc::unbounded_channel();
+        notification_manager.insert_sender(SubscribeType::Hummock, worker_key1, tx1);
+        notification_manager.insert_sender(SubscribeType::Hummock, worker_key2, tx2);
+
+        let table_id = TableId::from(233);
+        let fragment_id = FragmentId::new(234);
+        let serving_vnode_mapping = Arc::new(ServingVnodeMapping::default());
+        let streaming_parallelisms = HashMap::from([(
+            fragment_id,
+            FragmentParallelismInfo {
+                distribution_type: FragmentDistributionType::Hash,
+                vnode_count: VirtualNode::COUNT_FOR_TEST,
+                state_table_ids: HashSet::from([table_id]),
+            },
+        )]);
+        let (upserted, failed) =
+            serving_vnode_mapping.upsert(&streaming_parallelisms, &workers, None);
+        assert_eq!(upserted.len(), 1);
+        assert!(failed.is_empty());
+
+        sync_serving_table_vnode_mappings_to_hummock(
+            &notification_manager,
+            &serving_vnode_mapping,
+            &workers,
+            &streaming_parallelisms,
+        )
+        .await;
+
+        let response1 = rx1.recv().await.unwrap().unwrap();
+        let response2 = rx2.recv().await.unwrap().unwrap();
+        assert!(rx1.try_recv().is_err());
+        assert!(rx2.try_recv().is_err());
+
+        let serving_bitmap_count = |response: SubscribeResponse| {
+            let Some(Info::TableRefillRuntimeConfig(config)) = response.info else {
+                panic!("expect table refill runtime config");
+            };
+            let mappings = config.serving_table_vnode_mappings.unwrap().mappings;
+            assert_eq!(mappings.len(), 1);
+            assert_eq!(mappings[0].table_id, table_id.as_raw_id());
+            Bitmap::from(mappings[0].bitmap.clone().unwrap()).count_ones()
+        };
+        let count1 = serving_bitmap_count(response1);
+        let count2 = serving_bitmap_count(response2);
+        assert!(count1 > 0);
+        assert!(count2 > 0);
+        assert_eq!(count1 + count2, VirtualNode::COUNT_FOR_TEST);
     }
 }

--- a/src/meta/src/table_refill.rs
+++ b/src/meta/src/table_refill.rs
@@ -41,23 +41,6 @@ pub fn build_hummock_serving_table_vnode_mappings(
     to_pb_serving_table_vnode_mappings(&table_vnode_mapping)
 }
 
-pub fn build_hummock_serving_table_vnode_runtime_config(
-    serving_vnode_mapping: &ServingVnodeMappingRef,
-    worker_id: WorkerId,
-    streaming_parallelisms: &HashMap<FragmentId, FragmentParallelismInfo>,
-    version: NotificationVersion,
-) -> PbTableRefillRuntimeConfig {
-    PbTableRefillRuntimeConfig {
-        serving_table_vnode_mappings: Some(build_hummock_serving_table_vnode_mappings(
-            serving_vnode_mapping,
-            worker_id,
-            streaming_parallelisms,
-        )),
-        version,
-        ..Default::default()
-    }
-}
-
 pub fn build_hummock_table_refill_runtime_config(
     serving_vnode_mapping: &ServingVnodeMappingRef,
     worker_id: WorkerId,

--- a/src/meta/src/table_refill.rs
+++ b/src/meta/src/table_refill.rs
@@ -26,7 +26,7 @@ use crate::serving::{
     to_pb_serving_table_vnode_mappings,
 };
 
-fn build_hummock_serving_table_vnode_mappings(
+pub fn build_hummock_serving_table_vnode_mappings(
     serving_vnode_mapping: &ServingVnodeMappingRef,
     worker_id: WorkerId,
     streaming_parallelisms: &HashMap<FragmentId, FragmentParallelismInfo>,
@@ -39,6 +39,23 @@ fn build_hummock_serving_table_vnode_mappings(
     );
 
     to_pb_serving_table_vnode_mappings(&table_vnode_mapping)
+}
+
+pub fn build_hummock_serving_table_vnode_runtime_config(
+    serving_vnode_mapping: &ServingVnodeMappingRef,
+    worker_id: WorkerId,
+    streaming_parallelisms: &HashMap<FragmentId, FragmentParallelismInfo>,
+    version: NotificationVersion,
+) -> PbTableRefillRuntimeConfig {
+    PbTableRefillRuntimeConfig {
+        serving_table_vnode_mappings: Some(build_hummock_serving_table_vnode_mappings(
+            serving_vnode_mapping,
+            worker_id,
+            streaming_parallelisms,
+        )),
+        version,
+        ..Default::default()
+    }
 }
 
 pub fn build_hummock_table_refill_runtime_config(

--- a/src/storage/src/hummock/event_handler/hummock_event_handler.rs
+++ b/src/storage/src/hummock/event_handler/hummock_event_handler.rs
@@ -371,9 +371,10 @@ async fn flush_imms(
 }
 
 impl HummockEventHandler {
+    // Table refill runtime config applies by field presence for both snapshot
+    // and update notifications.
     fn apply_table_refill_runtime_config(
         refiller: &mut CacheRefiller,
-        _operation: Operation,
         config: PbTableRefillRuntimeConfig,
     ) {
         if let Some(policies) = config.table_cache_refill_policies {
@@ -516,12 +517,12 @@ impl HummockEventHandler {
                 _
             ))
         ) {
-            let Some(HummockObserverEvent::TableRefillRuntimeConfig(operation, config)) =
+            let Some(HummockObserverEvent::TableRefillRuntimeConfig(_, config)) =
                 pending_observer_events.pop_front()
             else {
                 unreachable!();
             };
-            Self::apply_table_refill_runtime_config(&mut refiller, operation, config);
+            Self::apply_table_refill_runtime_config(&mut refiller, config);
         }
 
         Self {
@@ -722,8 +723,8 @@ impl HummockEventHandler {
             HummockObserverEvent::VersionUpdate(version_update) => {
                 self.handle_version_update(version_update);
             }
-            HummockObserverEvent::TableRefillRuntimeConfig(operation, config) => {
-                Self::apply_table_refill_runtime_config(&mut self.refiller, operation, config);
+            HummockObserverEvent::TableRefillRuntimeConfig(_, config) => {
+                Self::apply_table_refill_runtime_config(&mut self.refiller, config);
             }
         }
     }
@@ -1411,7 +1412,6 @@ mod tests {
 
         HummockEventHandler::apply_table_refill_runtime_config(
             &mut refiller,
-            Operation::Snapshot,
             table_refill_runtime_config_for_test(
                 [
                     (old_table_id, CacheRefillPolicy::Serving),
@@ -1422,7 +1422,6 @@ mod tests {
         );
         HummockEventHandler::apply_table_refill_runtime_config(
             &mut refiller,
-            Operation::Update,
             PbTableRefillRuntimeConfig {
                 table_cache_refill_policies: Some(TableCacheRefillPolicies {
                     policies: vec![
@@ -1450,7 +1449,6 @@ mod tests {
         }
         HummockEventHandler::apply_table_refill_runtime_config(
             &mut refiller,
-            Operation::Update,
             PbTableRefillRuntimeConfig {
                 serving_table_vnode_mappings: Some(PbServingTableVnodeMappings {
                     mappings: vec![PbServingTableVnodeMapping {

--- a/src/storage/src/hummock/event_handler/hummock_event_handler.rs
+++ b/src/storage/src/hummock/event_handler/hummock_event_handler.rs
@@ -373,19 +373,15 @@ async fn flush_imms(
 impl HummockEventHandler {
     fn apply_table_refill_runtime_config(
         refiller: &mut CacheRefiller,
-        operation: Operation,
+        _operation: Operation,
         config: PbTableRefillRuntimeConfig,
     ) {
-        // Meta only emits non-snapshot table refill runtime config after recovery. Online
-        // runtime updates are not supported for either policies or serving vnode mappings.
         if let Some(policies) = config.table_cache_refill_policies {
             refiller
                 .replace_table_cache_refill_policies(table_cache_refill_policies_to_map(policies));
         }
 
-        if operation == Operation::Snapshot
-            && let Some(mappings) = config.serving_table_vnode_mappings
-        {
+        if let Some(mappings) = config.serving_table_vnode_mappings {
             refiller
                 .replace_serving_table_vnode_mapping(serving_table_vnode_mappings_to_map(mappings));
         }
@@ -1406,18 +1402,22 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_recovery_policy_update_preserves_serving_mapping() {
-        let table_id = TableId::new(233);
-        let serving_vnodes = Bitmap::ones(VirtualNode::COUNT_FOR_TEST);
-        let ignored_update_vnodes = Bitmap::zeros(VirtualNode::COUNT_FOR_TEST);
+    async fn test_runtime_serving_mapping_update_full_replaces_context() {
+        let old_table_id = TableId::new(233);
+        let new_table_id = TableId::new(234);
+        let old_serving_vnodes = Bitmap::ones(VirtualNode::COUNT_FOR_TEST);
+        let new_serving_vnodes = Bitmap::from_range(VirtualNode::COUNT_FOR_TEST, 0..8);
         let mut refiller = refiller_for_test(Role::Serving).await;
 
         HummockEventHandler::apply_table_refill_runtime_config(
             &mut refiller,
             Operation::Snapshot,
             table_refill_runtime_config_for_test(
-                [(table_id, CacheRefillPolicy::Serving)],
-                HashMap::from([(table_id, serving_vnodes.clone())]),
+                [
+                    (old_table_id, CacheRefillPolicy::Serving),
+                    (new_table_id, CacheRefillPolicy::Serving),
+                ],
+                HashMap::from([(old_table_id, old_serving_vnodes.clone())]),
             ),
         );
         HummockEventHandler::apply_table_refill_runtime_config(
@@ -1425,28 +1425,37 @@ mod tests {
             Operation::Update,
             PbTableRefillRuntimeConfig {
                 table_cache_refill_policies: Some(TableCacheRefillPolicies {
-                    policies: vec![PbTableCacheRefillPolicy {
-                        table_id: table_id.as_raw_id(),
-                        policy: PbCacheRefillPolicy::Disabled as i32,
-                    }],
-                }),
-                serving_table_vnode_mappings: Some(PbServingTableVnodeMappings {
-                    mappings: vec![PbServingTableVnodeMapping {
-                        table_id: table_id.as_raw_id(),
-                        bitmap: Some(ignored_update_vnodes.to_protobuf()),
-                    }],
+                    policies: vec![
+                        PbTableCacheRefillPolicy {
+                            table_id: old_table_id.as_raw_id(),
+                            policy: PbCacheRefillPolicy::Serving as i32,
+                        },
+                        PbTableCacheRefillPolicy {
+                            table_id: new_table_id.as_raw_id(),
+                            policy: PbCacheRefillPolicy::Serving as i32,
+                        },
+                    ],
                 }),
                 ..Default::default()
             },
         );
+        {
+            let context_map = refiller.table_cache_refill_context_map().read();
+            let old_context = context_map.get(&old_table_id).unwrap();
+            assert_eq!(old_context.policy, CacheRefillPolicy::Serving);
+            assert_eq!(
+                old_context.serving_vnode_bitmap.as_ref(),
+                Some(&old_serving_vnodes)
+            );
+        }
         HummockEventHandler::apply_table_refill_runtime_config(
             &mut refiller,
             Operation::Update,
             PbTableRefillRuntimeConfig {
-                table_cache_refill_policies: Some(TableCacheRefillPolicies {
-                    policies: vec![PbTableCacheRefillPolicy {
-                        table_id: table_id.as_raw_id(),
-                        policy: PbCacheRefillPolicy::Serving as i32,
+                serving_table_vnode_mappings: Some(PbServingTableVnodeMappings {
+                    mappings: vec![PbServingTableVnodeMapping {
+                        table_id: new_table_id.as_raw_id(),
+                        bitmap: Some(new_serving_vnodes.to_protobuf()),
                     }],
                 }),
                 ..Default::default()
@@ -1454,9 +1463,17 @@ mod tests {
         );
 
         let context_map = refiller.table_cache_refill_context_map().read();
-        let context = context_map.get(&table_id).unwrap();
-        assert_eq!(context.policy, CacheRefillPolicy::Serving);
-        assert_eq!(context.serving_vnode_bitmap.as_ref(), Some(&serving_vnodes));
+        assert!(
+            context_map
+                .get(&old_table_id)
+                .is_some_and(|context| context.serving_vnode_bitmap.is_none())
+        );
+        let new_context = context_map.get(&new_table_id).unwrap();
+        assert_eq!(new_context.policy, CacheRefillPolicy::Serving);
+        assert_eq!(
+            new_context.serving_vnode_bitmap.as_ref(),
+            Some(&new_serving_vnodes)
+        );
     }
 
     #[test]

--- a/src/tests/simulation/tests/integration_tests/scale/isolation.rs
+++ b/src/tests/simulation/tests/integration_tests/scale/isolation.rs
@@ -17,8 +17,12 @@ use std::str::FromStr;
 use std::time::Duration;
 
 use anyhow::{Context, Result, anyhow};
+#[cfg(madsim)]
+use clap::Parser;
 use itertools::Itertools;
 use risingwave_common::monitor::EndpointExt;
+#[cfg(madsim)]
+use risingwave_common::util::tokio_util::sync::CancellationToken;
 use risingwave_pb::common::WorkerType;
 use risingwave_pb::monitor_service::GetTableCacheRefillStatsRequest;
 use risingwave_pb::monitor_service::monitor_service_client::MonitorServiceClient;
@@ -30,6 +34,7 @@ use tonic::transport::Endpoint;
 const DATABASE_RECOVERY_START: &str = "DATABASE_RECOVERY_START";
 const DATABASE_RECOVERY_SUCCESS: &str = "DATABASE_RECOVERY_SUCCESS";
 const COMPUTE_2_HOST: &str = "192.168.3.2";
+const COMPUTE_4_HOST: &str = "192.168.3.4";
 
 async fn assert_no_expected_global_recovery(session: &mut Session) -> Result<()> {
     let global_recovery_events = global_recovery_events(session).await?;
@@ -103,8 +108,9 @@ async fn test_isolation_simple_two_databases() -> Result<()> {
 }
 
 #[tokio::test]
-async fn test_table_cache_refill_policy_after_database_recovery() -> Result<()> {
-    let (cluster, mut session) = prepare_refill_policy_db_recovery_env().await?;
+async fn test_table_cache_refill_runtime_state_after_database_recovery_and_serving_node_change()
+-> Result<()> {
+    let (cluster, mut session) = prepare_refill_runtime_state_db_recovery_env().await?;
 
     let database_mapping = database_id_mapping(&mut session).await?;
     let group1_database_id = database_mapping["group1"];
@@ -152,6 +158,28 @@ async fn test_table_cache_refill_policy_after_database_recovery() -> Result<()> 
     wait_refill_policy_on_compute(&cluster, COMPUTE_2_HOST, &internal_table_ids, Some("both"))
         .await?;
 
+    // Adding a serving compute node rebuilds serving vnode mappings and pushes the full
+    // replacement to both existing and new serving nodes.
+    let serving_before_add_node =
+        wait_serving_refill_on_compute(&cluster, COMPUTE_2_HOST, &internal_table_ids, None).await?;
+    create_compute_node(&cluster, 4, "serving");
+    wait_until(
+        &mut session,
+        "select count(*) from rw_catalog.rw_worker_nodes where host = '192.168.3.4';",
+        "1",
+    )
+    .await?;
+    wait_serving_refill_on_compute(
+        &cluster,
+        COMPUTE_2_HOST,
+        &internal_table_ids,
+        Some(&serving_before_add_node),
+    )
+    .await?;
+    wait_refill_policy_on_compute(&cluster, COMPUTE_4_HOST, &internal_table_ids, Some("both"))
+        .await?;
+    wait_serving_refill_on_compute(&cluster, COMPUTE_4_HOST, &internal_table_ids, None).await?;
+
     let mut database_recovery_events = database_recovery_events(&mut session).await?;
     assert!(!database_recovery_events.contains_key(&group2_database_id));
     assert_eq!(
@@ -164,6 +192,39 @@ async fn test_table_cache_refill_policy_after_database_recovery() -> Result<()> 
     assert_no_expected_global_recovery(&mut session).await?;
 
     Ok(())
+}
+
+#[cfg(madsim)]
+fn create_compute_node(cluster: &Cluster, idx: usize, role: &str) {
+    let config = cluster.config();
+    let opts = risingwave_compute::ComputeNodeOpts::parse_from([
+        "compute-node",
+        "--config-path",
+        config.config_path.as_str(),
+        "--listen-addr",
+        "0.0.0.0:5688",
+        "--advertise-addr",
+        &format!("192.168.3.{idx}:5688"),
+        "--total-memory-bytes",
+        "6979321856",
+        "--parallelism",
+        &config.compute_node_cores.to_string(),
+        "--role",
+        role,
+    ]);
+    cluster
+        .handle()
+        .create_node()
+        .name(format!("compute-{idx}"))
+        .ip([192, 168, 3, idx as u8].into())
+        .cores(config.compute_node_cores)
+        .init(move || risingwave_compute::start(opts.clone(), CancellationToken::new()))
+        .build();
+}
+
+#[cfg(not(madsim))]
+fn create_compute_node(_cluster: &Cluster, _idx: usize, _role: &str) {
+    panic!("dynamic compute node creation requires madsim");
 }
 
 async fn database_id_mapping(session: &mut Session) -> Result<HashMap<String, u32>> {
@@ -471,10 +532,10 @@ async fn internal_table_ids_for_job(session: &mut Session, job_name: &str) -> Re
         .collect()
 }
 
-async fn table_cache_refill_policies_on_compute(
+async fn table_cache_refill_stats_on_compute(
     cluster: &Cluster,
     worker_host: &str,
-) -> Result<serde_json::Map<String, Value>> {
+) -> Result<Value> {
     let worker_nodes = cluster.get_cluster_info().await?.worker_nodes;
     let worker = worker_nodes
         .into_iter()
@@ -500,16 +561,34 @@ async fn table_cache_refill_policies_on_compute(
                 .get_table_cache_refill_stats(GetTableCacheRefillStatsRequest {})
                 .await?
                 .into_inner();
-            let stats: Value = serde_json::from_str(&response.stats)
-                .context("failed to parse table cache refill stats")?;
-
-            stats
-                .get("policies")
-                .and_then(Value::as_object)
-                .cloned()
-                .context("table cache refill stats missing policies")
+            serde_json::from_str(&response.stats)
+                .context("failed to parse table cache refill stats")
         })
         .await
+}
+
+async fn table_cache_refill_policies_on_compute(
+    cluster: &Cluster,
+    worker_host: &str,
+) -> Result<serde_json::Map<String, Value>> {
+    table_cache_refill_stats_on_compute(cluster, worker_host)
+        .await?
+        .get("policies")
+        .and_then(Value::as_object)
+        .cloned()
+        .context("table cache refill stats missing policies")
+}
+
+async fn serving_refill_vnodes_on_compute(
+    cluster: &Cluster,
+    worker_host: &str,
+) -> Result<serde_json::Map<String, Value>> {
+    table_cache_refill_stats_on_compute(cluster, worker_host)
+        .await?
+        .get("serving")
+        .and_then(Value::as_object)
+        .cloned()
+        .context("table cache refill stats missing serving vnodes")
 }
 
 fn refill_policy_matches(
@@ -520,6 +599,18 @@ fn refill_policy_matches(
     table_ids.iter().all(|table_id| {
         let actual_policy = policies.get(&table_id.to_string()).and_then(Value::as_str);
         actual_policy == expected_policy
+    })
+}
+
+fn serving_refill_matches(
+    serving_vnodes: &serde_json::Map<String, Value>,
+    table_ids: &[u32],
+) -> bool {
+    table_ids.iter().all(|table_id| {
+        serving_vnodes
+            .get(&table_id.to_string())
+            .and_then(Value::as_array)
+            .is_some_and(|vnodes| !vnodes.is_empty())
     })
 }
 
@@ -544,6 +635,33 @@ async fn wait_refill_policy_on_compute(
         anyhow!(
             "timed out waiting for table cache refill policy {:?} on {} for {:?}",
             expected_policy,
+            worker_host,
+            table_ids
+        )
+    })?
+}
+
+async fn wait_serving_refill_on_compute(
+    cluster: &Cluster,
+    worker_host: &str,
+    table_ids: &[u32],
+    previous: Option<&serde_json::Map<String, Value>>,
+) -> Result<serde_json::Map<String, Value>> {
+    tokio::time::timeout(Duration::from_secs(100), async {
+        loop {
+            if let Ok(serving_vnodes) = serving_refill_vnodes_on_compute(cluster, worker_host).await
+                && serving_refill_matches(&serving_vnodes, table_ids)
+                && previous.is_none_or(|previous| &serving_vnodes != previous)
+            {
+                return Ok::<_, anyhow::Error>(serving_vnodes);
+            }
+            sleep(Duration::from_secs(1)).await;
+        }
+    })
+    .await
+    .map_err(|_| {
+        anyhow!(
+            "timed out waiting for serving refill vnodes on {} for {:?}",
             worker_host,
             table_ids
         )
@@ -579,7 +697,7 @@ async fn prepare_isolation_env() -> Result<(Cluster, Session)> {
     Ok((cluster, session))
 }
 
-async fn prepare_refill_policy_db_recovery_env() -> Result<(Cluster, Session)> {
+async fn prepare_refill_runtime_state_db_recovery_env() -> Result<(Cluster, Session)> {
     let mut config = Configuration::for_auto_parallelism(MAX_HEARTBEAT_INTERVAL_SEC, true);
 
     config.compute_nodes = 3;


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

- Refresh table-refill runtime state after recovery with policy broadcast and serving targeted sync.
- Send targeted Hummock runtime config updates when serving vnode mappings change, and let CN apply serving mappings as full replacements.
- Add coverage for recovery and serving-node-change paths.

## Checklist

- [ ] I have written necessary rustdoc comments.
- [x] I have added necessary unit tests and integration tests.
- [ ] I have added test labels as necessary.
- [ ] I have added fuzzing tests or opened an issue to track them.
- [ ] My PR contains breaking changes.
- [ ] My PR changes performance-critical code, so I will run (micro) benchmarks and present the results.
- [ ] I have checked the Release Timeline and Currently Supported Versions to determine which release branches I need to cherry-pick this PR into.

## Documentation

- [ ] My PR needs documentation updates.
