### PR TITLE
fix(connector): avoid sea-schema FK constraint panic in postgres sink type discovery

### DIFF
--- a/e2e_test/sink/postgres_sink.slt
+++ b/e2e_test/sink/postgres_sink.slt
@@ -648,6 +648,46 @@ DROP TABLE rw_pk_only_table;
 system ok
 PGDATABASE=sink_test psql -c "DROP TABLE pg_pk_only_table"
 
+################### test foreign key table discovery doesn't panic
+
+system ok
+PGDATABASE=sink_test psql -c "CREATE TABLE pg_parent_table (id BIGINT PRIMARY KEY)"
+
+system ok
+PGDATABASE=sink_test psql -c "CREATE TABLE pg_child_table (id BIGINT PRIMARY KEY, parent_id BIGINT REFERENCES pg_parent_table(id), val VARCHAR)"
+
+statement ok
+CREATE TABLE rw_child_table (
+    id BIGINT,
+    parent_id BIGINT,
+    val VARCHAR
+);
+
+statement ok
+CREATE SINK postgres_child_sink FROM rw_child_table WITH (
+    connector='postgres',
+    host='$PGHOST',
+    port='$PGPORT',
+    user='$PGUSER',
+    password='$PGPASSWORD',
+    database='sink_test',
+    table='pg_child_table',
+    type='upsert',
+    primary_key='id',
+);
+
+statement ok
+DROP SINK postgres_child_sink;
+
+statement ok
+DROP TABLE rw_child_table;
+
+system ok
+PGDATABASE=sink_test psql -c "DROP TABLE pg_child_table"
+
+system ok
+PGDATABASE=sink_test psql -c "DROP TABLE pg_parent_table"
+
 ################### Drop DB
 
 system ok

--- a/src/connector/src/connector_common/postgres.rs
+++ b/src/connector/src/connector_common/postgres.rs
@@ -21,7 +21,7 @@ use postgres_openssl::MakeTlsConnector;
 use risingwave_common::bail;
 use risingwave_common::catalog::{ColumnDesc, ColumnId};
 use risingwave_common::types::{DataType, ScalarImpl, StructType};
-use sea_schema::postgres::def::{ColumnType as SeaType, TableDef, TableInfo};
+use sea_schema::postgres::def::ColumnType as SeaType;
 use sea_schema::postgres::discovery::SchemaDiscovery;
 use sea_schema::sea_query::{Alias, IntoIden};
 use serde::Deserialize;
@@ -282,53 +282,6 @@ impl PostgresExternalTable {
         Ok((columns, pk_columns))
     }
 
-    async fn discover_schema(
-        username: &str,
-        password: &str,
-        host: &str,
-        port: u16,
-        database: &str,
-        schema: &str,
-        table: &str,
-        ssl_mode: &SslMode,
-        ssl_root_cert: &Option<String>,
-    ) -> ConnectorResult<TableDef> {
-        let mut options = PgConnectOptions::new()
-            .username(username)
-            .password(password)
-            .host(host)
-            .port(port)
-            .database(database)
-            .ssl_mode(match ssl_mode {
-                SslMode::Disabled => PgSslMode::Disable,
-                SslMode::Preferred => PgSslMode::Prefer,
-                SslMode::Required => PgSslMode::Require,
-                SslMode::VerifyCa => PgSslMode::VerifyCa,
-                SslMode::VerifyFull => PgSslMode::VerifyFull,
-            });
-
-        if (*ssl_mode == SslMode::VerifyCa || *ssl_mode == SslMode::VerifyFull)
-            && let Some(root_cert) = ssl_root_cert
-        {
-            options = options.ssl_root_cert(root_cert.as_str());
-        }
-
-        let connection = PgPool::connect_with(options).await?;
-        let schema_discovery = SchemaDiscovery::new(connection, schema);
-        // fetch column schema and primary key
-        let empty_map = HashMap::new();
-        let table_schema = schema_discovery
-            .discover_table(
-                TableInfo {
-                    name: table.to_owned(),
-                    of_type: None,
-                },
-                &empty_map,
-            )
-            .await?;
-        Ok(table_schema)
-    }
-
     pub async fn connect(
         username: &str,
         password: &str,
@@ -415,7 +368,12 @@ impl PostgresExternalTable {
         is_append_only: bool,
     ) -> ConnectorResult<HashMap<String, tokio_postgres::types::Type>> {
         tracing::debug!("connect to postgres external table to get type mapping");
-        let table_schema = Self::discover_schema(
+        // NOTE: We deliberately avoid sea-schema's `discover_table` here. It parses
+        // `information_schema.table_constraints`, and its constraint parser panics when
+        // the table has a foreign key (see #20625). We only need each column's type and
+        // whether a primary key exists, both of which `discover_pk_and_full_columns`
+        // derives without touching foreign-key constraints.
+        let (columns, pk_names) = Self::discover_pk_and_full_columns(
             username,
             password,
             host,
@@ -428,11 +386,11 @@ impl PostgresExternalTable {
         )
         .await?;
         let mut column_name_to_pg_type = HashMap::new();
-        for col in &table_schema.columns {
+        for col in &columns {
             let pg_type = sea_type_to_pg_type(&col.col_type)?;
             column_name_to_pg_type.insert(col.name.clone(), pg_type);
         }
-        if !is_append_only && table_schema.primary_key_constraints.is_empty() {
+        if !is_append_only && pk_names.is_empty() {
             return Err(anyhow!(
                 "Postgres table should define the primary key for non-append-only tables"
             )


### PR DESCRIPTION
# fix(connector): avoid sea-schema FK constraint panic in Postgres sink type discovery

Fixes part of #20625 (the foreign-key panic; recurred for the downstream Postgres sink, reported 2025-11-07).
Also addresses #24220 and #25018.

## Problem
`PostgresExternalTable::type_mapping` — used by the Postgres sink (and pg-cdc type discovery) — called sea-schema's `discover_table`, which parses `information_schema.table_constraints`. sea-schema's constraint parser does `unwrap()` on a `None` while handling **foreign-key** rows, so any source/target table that has a foreign key crashes the frontend:

```
thread 'rw-standalone-frontend' panicked at sea-schema-0.16.0/src/postgres/parser/table_constraints.rs:52:63:
called `Option::unwrap()` on a `None` value
...
server closed the connection unexpectedly
```

The CDC **source** path (`connect`) was already reworked to avoid this via `discover_pk_and_full_columns` (column discovery + a direct `pg_index` primary-key query, which also avoids the table-owner permission requirement). The **sink** path was still going through `discover_table`, so the panic remained — matching the recent report in #20625 and the related #24220 / #25018.

## Fix
- Reuse `discover_pk_and_full_columns` in `type_mapping`. It returns the columns and the primary-key names without ever parsing foreign-key constraints, so the panic can't be triggered.
- Remove `discover_schema` (its only caller) and the now-unused `TableDef` / `TableInfo` imports.

Net: 1 file changed, 9 insertions(+), 51 deletions(-). No new dependency, no `[patch]` of sea-schema required.

## Behavior
- Tables with foreign keys no longer crash the frontend during sink creation / type discovery.
- Type mapping and the "primary key required for non-append-only" check are unchanged for non-FK tables (same column discovery, PK now sourced from the direct system-table query — consistent with the source path).

## Testing
- Added an E2E regression test to `e2e_test/sink/postgres_sink.slt` to verify that target tables with foreign key constraints do not trigger a panic during `CREATE SINK` validation.
