### PR TITLE
ci: add opt-in docker sccache cache

### DIFF
--- a/.github/workflows/build-docker-image-on-demand-ec2.yml
+++ b/.github/workflows/build-docker-image-on-demand-ec2.yml
@@ -18,6 +18,11 @@ on:
         required: false
         type: boolean
         default: false
+      enable_docker_sccache:
+        description: 'Enable S3-backed sccache for the Docker build'
+        required: false
+        type: boolean
+        default: false
 
 jobs:
   build_image:
@@ -77,6 +82,10 @@ jobs:
           fi
           echo "PUSH_DOCKERHUB=$PUSH_DOCKERHUB"
           echo "PUSH_DOCKERHUB=$PUSH_DOCKERHUB" >> $GITHUB_ENV
+
+          ENABLE_DOCKER_SCCACHE="${{ github.event.inputs.enable_docker_sccache }}"
+          echo "ENABLE_DOCKER_SCCACHE=$ENABLE_DOCKER_SCCACHE"
+          echo "ENABLE_DOCKER_SCCACHE=$ENABLE_DOCKER_SCCACHE" >> $GITHUB_ENV
       - name: 'Trigger Docker build Workflow via Buildkite'
         uses: buildkite/trigger-pipeline-action@v2.3.0
         with:
@@ -85,4 +94,4 @@ jobs:
           branch: ${{ env.BRANCH_NAME }}
           commit: HEAD
           message: ':github: Triggering Docker build with image tag: ${{ env.IMAGE_TAG }}'
-          build_env_vars: '{ "IMAGE_TAG": "${{ env.IMAGE_TAG }}", "PUSH_DOCKERHUB": "${{ env.PUSH_DOCKERHUB }}", "SKIP_TARGET_AMD64": "${{ env.SKIP_TARGET_AMD64 }}", "CARGO_PROFILE": "${{ env.CARGO_PROFILE }}" }'
+          build_env_vars: '{ "IMAGE_TAG": "${{ env.IMAGE_TAG }}", "PUSH_DOCKERHUB": "${{ env.PUSH_DOCKERHUB }}", "SKIP_TARGET_AMD64": "${{ env.SKIP_TARGET_AMD64 }}", "CARGO_PROFILE": "${{ env.CARGO_PROFILE }}", "ENABLE_DOCKER_SCCACHE": "${{ env.ENABLE_DOCKER_SCCACHE }}" }'

--- a/.github/workflows/build-docker-image-on-demand-ec2.yml
+++ b/.github/workflows/build-docker-image-on-demand-ec2.yml
@@ -22,6 +22,11 @@ on:
         required: false
         type: boolean
         default: false
+      enable_docker_sccache:
+        description: 'Enable S3-backed sccache for the Docker build'
+        required: false
+        type: boolean
+        default: false
 
 jobs:
   build_image:
@@ -81,6 +86,10 @@ jobs:
           fi
           echo "PUSH_DOCKERHUB=$PUSH_DOCKERHUB"
           echo "PUSH_DOCKERHUB=$PUSH_DOCKERHUB" >> $GITHUB_ENV
+
+          ENABLE_DOCKER_SCCACHE="${{ github.event.inputs.enable_docker_sccache }}"
+          echo "ENABLE_DOCKER_SCCACHE=$ENABLE_DOCKER_SCCACHE"
+          echo "ENABLE_DOCKER_SCCACHE=$ENABLE_DOCKER_SCCACHE" >> $GITHUB_ENV
       - name: 'Trigger Docker build Workflow via Buildkite'
         uses: buildkite/trigger-pipeline-action@v2.3.0
         with:
@@ -89,4 +98,4 @@ jobs:
           branch: ${{ env.BRANCH_NAME }}
           commit: HEAD
           message: ':github: Triggering Docker build with image tag: ${{ env.IMAGE_TAG }}'
-          build_env_vars: '{ "IMAGE_TAG": "${{ env.IMAGE_TAG }}", "PUSH_DOCKERHUB": "${{ env.PUSH_DOCKERHUB }}", "SKIP_TARGET_AMD64": "${{ env.SKIP_TARGET_AMD64 }}", "CARGO_PROFILE": "${{ env.CARGO_PROFILE }}" }'
+          build_env_vars: '{ "IMAGE_TAG": "${{ env.IMAGE_TAG }}", "PUSH_DOCKERHUB": "${{ env.PUSH_DOCKERHUB }}", "SKIP_TARGET_AMD64": "${{ env.SKIP_TARGET_AMD64 }}", "CARGO_PROFILE": "${{ env.CARGO_PROFILE }}", "ENABLE_DOCKER_SCCACHE": "${{ env.ENABLE_DOCKER_SCCACHE }}" }'

--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -18,6 +18,11 @@ on:
         required: false
         type: boolean
         default: false
+      enable_docker_sccache:
+        description: 'Enable S3-backed sccache for the Docker build'
+        required: false
+        type: boolean
+        default: false
 
 jobs:
   build_image:
@@ -77,6 +82,10 @@ jobs:
           fi
           echo "PUSH_DOCKERHUB=$PUSH_DOCKERHUB"
           echo "PUSH_DOCKERHUB=$PUSH_DOCKERHUB" >> $GITHUB_ENV
+
+          ENABLE_DOCKER_SCCACHE="${{ github.event.inputs.enable_docker_sccache }}"
+          echo "ENABLE_DOCKER_SCCACHE=$ENABLE_DOCKER_SCCACHE"
+          echo "ENABLE_DOCKER_SCCACHE=$ENABLE_DOCKER_SCCACHE" >> $GITHUB_ENV
       - name: 'Trigger Docker build Workflow via Buildkite'
         uses: buildkite/trigger-pipeline-action@v2.3.0
         with:
@@ -85,4 +94,4 @@ jobs:
           branch: ${{ env.BRANCH_NAME }}
           commit: HEAD
           message: ':github: Triggering Docker build with image tag: ${{ env.IMAGE_TAG }}'
-          build_env_vars: '{ "IMAGE_TAG": "${{ env.IMAGE_TAG }}", "PUSH_DOCKERHUB": "${{ env.PUSH_DOCKERHUB }}", "SKIP_TARGET_AMD64": "${{ env.SKIP_TARGET_AMD64 }}", "CARGO_PROFILE": "${{ env.CARGO_PROFILE }}" }'
+          build_env_vars: '{ "IMAGE_TAG": "${{ env.IMAGE_TAG }}", "PUSH_DOCKERHUB": "${{ env.PUSH_DOCKERHUB }}", "SKIP_TARGET_AMD64": "${{ env.SKIP_TARGET_AMD64 }}", "CARGO_PROFILE": "${{ env.CARGO_PROFILE }}", "ENABLE_DOCKER_SCCACHE": "${{ env.ENABLE_DOCKER_SCCACHE }}" }'

--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -27,6 +27,11 @@ on:
         required: false
         type: boolean
         default: false
+      enable_docker_sccache:
+        description: 'Enable S3-backed sccache for the Docker build'
+        required: false
+        type: boolean
+        default: false
 
 jobs:
   build_image:
@@ -86,6 +91,10 @@ jobs:
           fi
           echo "PUSH_DOCKERHUB=$PUSH_DOCKERHUB"
           echo "PUSH_DOCKERHUB=$PUSH_DOCKERHUB" >> $GITHUB_ENV
+
+          ENABLE_DOCKER_SCCACHE="${{ github.event.inputs.enable_docker_sccache }}"
+          echo "ENABLE_DOCKER_SCCACHE=$ENABLE_DOCKER_SCCACHE"
+          echo "ENABLE_DOCKER_SCCACHE=$ENABLE_DOCKER_SCCACHE" >> $GITHUB_ENV
       - name: 'Trigger Docker build Workflow via Buildkite'
         id: trigger_docker
         uses: buildkite/trigger-pipeline-action@v2.3.0
@@ -95,7 +104,7 @@ jobs:
           branch: ${{ env.BRANCH_NAME }}
           commit: HEAD
           message: ':github: Triggering Docker build with image tag: ${{ env.IMAGE_TAG }}'
-          build_env_vars: '{ "IMAGE_TAG": "${{ env.IMAGE_TAG }}", "PUSH_DOCKERHUB": "${{ env.PUSH_DOCKERHUB }}", "SKIP_TARGET_AMD64": "${{ env.SKIP_TARGET_AMD64 }}", "CARGO_PROFILE": "${{ env.CARGO_PROFILE }}" }'
+          build_env_vars: '{ "IMAGE_TAG": "${{ env.IMAGE_TAG }}", "PUSH_DOCKERHUB": "${{ env.PUSH_DOCKERHUB }}", "SKIP_TARGET_AMD64": "${{ env.SKIP_TARGET_AMD64 }}", "CARGO_PROFILE": "${{ env.CARGO_PROFILE }}", "ENABLE_DOCKER_SCCACHE": "${{ env.ENABLE_DOCKER_SCCACHE }}" }'
       - name: 'Trigger main-cron Workflow via Buildkite'
         id: trigger_main_cron
         if: ${{ inputs.run_main_cron }}

--- a/ci/scripts/docker.sh
+++ b/ci/scripts/docker.sh
@@ -7,6 +7,34 @@ ghcraddr="ghcr.io/risingwavelabs/risingwave"
 dockerhubaddr="risingwavelabs/risingwave"
 arch="$(uname -m)"
 CARGO_PROFILE=${CARGO_PROFILE:-production}
+ENABLE_DOCKER_SCCACHE=${ENABLE_DOCKER_SCCACHE:-false}
+DOCKER_SCCACHE_REGION=${DOCKER_SCCACHE_REGION:-us-east-2}
+
+sanitize_cache_component() {
+  local value="$1"
+  value="${value//\//-}"
+  value="$(printf "%s" "$value" | tr -c 'A-Za-z0-9._=-' '-')"
+  value="${value##-}"
+  value="${value%%-}"
+  if [[ -z "${value}" ]]; then
+    value="unknown"
+  fi
+  printf "%s" "$value"
+}
+
+build_secret_args=()
+docker_build_args=(
+  --build-arg "GIT_SHA=${BUILDKITE_COMMIT}"
+  --build-arg "CARGO_PROFILE=${CARGO_PROFILE}"
+  --build-arg "ENABLE_DOCKER_SCCACHE=${ENABLE_DOCKER_SCCACHE}"
+)
+
+cleanup_docker_sccache_credentials() {
+  if [[ -n "${docker_sccache_credentials_dir:-}" ]]; then
+    rm -rf "${docker_sccache_credentials_dir}"
+  fi
+}
+trap cleanup_docker_sccache_credentials EXIT
 
 echo "--- ghcr login"
 echo "$GHCR_TOKEN" | docker login ghcr.io -u "$GHCR_USERNAME" --password-stdin
@@ -29,19 +57,79 @@ docker buildx create \
   --name container \
   --driver=docker-container
 
-PULL_PARAM=""
+pull_param=()
 if [[ "${ALWAYS_PULL:-false}" = "true" ]]; then
-  PULL_PARAM="--pull"
+  pull_param=(--pull)
+fi
+
+if [[ "${ENABLE_DOCKER_SCCACHE}" == "true" ]]; then
+  echo "--- configure docker sccache"
+  if [[ -z "${DOCKER_SCCACHE_BUCKET:-}" ]]; then
+    echo "DOCKER_SCCACHE_BUCKET must be set when ENABLE_DOCKER_SCCACHE=true" >&2
+    exit 1
+  fi
+
+  if [[ -n "${DOCKER_SCCACHE_ROLE_ARN:-}" ]]; then
+    if ! command -v aws >/dev/null 2>&1; then
+      echo "aws CLI is required to assume DOCKER_SCCACHE_ROLE_ARN" >&2
+      exit 1
+    fi
+
+    read -r AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN < <(
+      aws sts assume-role \
+        --role-arn "${DOCKER_SCCACHE_ROLE_ARN}" \
+        --role-session-name "${DOCKER_SCCACHE_ROLE_SESSION_NAME:-docker-sccache-${BUILDKITE_BUILD_NUMBER:-local}}" \
+        --duration-seconds "${DOCKER_SCCACHE_SESSION_DURATION_SECONDS:-14400}" \
+        --query 'Credentials.[AccessKeyId,SecretAccessKey,SessionToken]' \
+        --output text
+    )
+    export AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN
+  fi
+
+  if [[ -z "${AWS_ACCESS_KEY_ID:-}" || -z "${AWS_SECRET_ACCESS_KEY:-}" ]]; then
+    echo "AWS credentials are required for docker sccache. Set DOCKER_SCCACHE_ROLE_ARN or provide AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY in the environment." >&2
+    exit 1
+  fi
+
+  docker_sccache_credentials_dir="$(mktemp -d)"
+  {
+    echo "[default]"
+    printf "aws_access_key_id = %s\n" "${AWS_ACCESS_KEY_ID}"
+    printf "aws_secret_access_key = %s\n" "${AWS_SECRET_ACCESS_KEY}"
+    if [[ -n "${AWS_SESSION_TOKEN:-}" ]]; then
+      printf "aws_session_token = %s\n" "${AWS_SESSION_TOKEN}"
+    fi
+  } >"${docker_sccache_credentials_dir}/credentials"
+  chmod 0600 "${docker_sccache_credentials_dir}/credentials"
+
+  {
+    echo "[default]"
+    printf "region = %s\n" "${DOCKER_SCCACHE_REGION}"
+  } >"${docker_sccache_credentials_dir}/config"
+
+  cache_branch="$(sanitize_cache_component "${BUILDKITE_BRANCH:-unknown}")"
+  DOCKER_SCCACHE_S3_KEY_PREFIX=${DOCKER_SCCACHE_S3_KEY_PREFIX:-"docker/${cache_branch}/${arch}/${CARGO_PROFILE}"}
+  echo "Docker sccache prefix: ${DOCKER_SCCACHE_S3_KEY_PREFIX}"
+
+  build_secret_args+=(
+    --secret "id=aws_credentials,src=${docker_sccache_credentials_dir}/credentials"
+    --secret "id=aws_config,src=${docker_sccache_credentials_dir}/config"
+  )
+  docker_build_args+=(
+    --build-arg "DOCKER_SCCACHE_BUCKET=${DOCKER_SCCACHE_BUCKET}"
+    --build-arg "DOCKER_SCCACHE_REGION=${DOCKER_SCCACHE_REGION}"
+    --build-arg "DOCKER_SCCACHE_S3_KEY_PREFIX=${DOCKER_SCCACHE_S3_KEY_PREFIX}"
+  )
 fi
 
 docker buildx build -f docker/Dockerfile \
-  --build-arg "GIT_SHA=${BUILDKITE_COMMIT}" \
-  --build-arg "CARGO_PROFILE=${CARGO_PROFILE}" \
+  "${docker_build_args[@]}" \
   -t "${ghcraddr}:${BUILDKITE_COMMIT}-${arch}" \
   --progress plain \
   --builder=container \
   --load \
-  ${PULL_PARAM} \
+  "${pull_param[@]}" \
+  "${build_secret_args[@]}" \
   --cache-to "type=registry,ref=ghcr.io/risingwavelabs/risingwave-build-cache:${arch}" \
   --cache-from "type=registry,ref=ghcr.io/risingwavelabs/risingwave-build-cache:${arch}" \
   .

--- a/ci/scripts/docker.sh
+++ b/ci/scripts/docker.sh
@@ -9,6 +9,7 @@ arch="$(uname -m)"
 CARGO_PROFILE=${CARGO_PROFILE:-production}
 ENABLE_DOCKER_SCCACHE=${ENABLE_DOCKER_SCCACHE:-false}
 DOCKER_SCCACHE_REGION=${DOCKER_SCCACHE_REGION:-us-east-2}
+PUSH_DOCKERHUB=${PUSH_DOCKERHUB:-true}
 
 sanitize_cache_component() {
   local value="$1"
@@ -39,8 +40,10 @@ trap cleanup_docker_sccache_credentials EXIT
 echo "--- ghcr login"
 echo "$GHCR_TOKEN" | docker login ghcr.io -u "$GHCR_USERNAME" --password-stdin
 
-echo "--- dockerhub login"
-echo "$DOCKER_TOKEN" | docker login -u "risingwavelabs" --password-stdin
+if [[ "${PUSH_DOCKERHUB}" == "true" ]]; then
+  echo "--- dockerhub login"
+  echo "$DOCKER_TOKEN" | docker login -u "risingwavelabs" --password-stdin
+fi
 
 if [[ -n "${ORIGINAL_IMAGE_TAG+x}" ]] && [[ -n "${NEW_IMAGE_TAG+x}" ]]; then
   echo "--- retag docker image"
@@ -108,8 +111,8 @@ if [[ "${ENABLE_DOCKER_SCCACHE}" == "true" ]]; then
   } >"${docker_sccache_credentials_dir}/config"
 
   cache_branch="$(sanitize_cache_component "${BUILDKITE_BRANCH:-unknown}")"
-  DOCKER_SCCACHE_S3_KEY_PREFIX=${DOCKER_SCCACHE_S3_KEY_PREFIX:-"docker/${cache_branch}/${arch}/${CARGO_PROFILE}"}
-  echo "Docker sccache prefix: ${DOCKER_SCCACHE_S3_KEY_PREFIX}"
+  DOCKER_SCCACHE_PREFIX=${DOCKER_SCCACHE_PREFIX:-${DOCKER_SCCACHE_S3_KEY_PREFIX:-"docker/${cache_branch}/${arch}/${CARGO_PROFILE}"}}
+  echo "Docker sccache prefix: ${DOCKER_SCCACHE_PREFIX}"
 
   build_secret_args+=(
     --secret "id=aws_credentials,src=${docker_sccache_credentials_dir}/credentials"
@@ -118,7 +121,7 @@ if [[ "${ENABLE_DOCKER_SCCACHE}" == "true" ]]; then
   docker_build_args+=(
     --build-arg "DOCKER_SCCACHE_BUCKET=${DOCKER_SCCACHE_BUCKET}"
     --build-arg "DOCKER_SCCACHE_REGION=${DOCKER_SCCACHE_REGION}"
-    --build-arg "DOCKER_SCCACHE_S3_KEY_PREFIX=${DOCKER_SCCACHE_S3_KEY_PREFIX}"
+    --build-arg "DOCKER_SCCACHE_PREFIX=${DOCKER_SCCACHE_PREFIX}"
   )
 fi
 
@@ -152,5 +155,9 @@ echo "--- docker push to ghcr"
 docker push "${ghcraddr}:${BUILDKITE_COMMIT}-${arch}"
 
 echo "--- docker push to dockerhub"
-docker tag "${ghcraddr}:${BUILDKITE_COMMIT}-${arch}" "${dockerhubaddr}:${BUILDKITE_COMMIT}-${arch}"
-docker push "${dockerhubaddr}:${BUILDKITE_COMMIT}-${arch}"
+if [[ "${PUSH_DOCKERHUB}" == "true" ]]; then
+  docker tag "${ghcraddr}:${BUILDKITE_COMMIT}-${arch}" "${dockerhubaddr}:${BUILDKITE_COMMIT}-${arch}"
+  docker push "${dockerhubaddr}:${BUILDKITE_COMMIT}-${arch}"
+else
+  echo "Skipped because PUSH_DOCKERHUB=${PUSH_DOCKERHUB}"
+fi

--- a/ci/scripts/docker.sh
+++ b/ci/scripts/docker.sh
@@ -40,10 +40,8 @@ trap cleanup_docker_sccache_credentials EXIT
 echo "--- ghcr login"
 echo "$GHCR_TOKEN" | docker login ghcr.io -u "$GHCR_USERNAME" --password-stdin
 
-if [[ "${PUSH_DOCKERHUB}" == "true" ]]; then
-  echo "--- dockerhub login"
-  echo "$DOCKER_TOKEN" | docker login -u "risingwavelabs" --password-stdin
-fi
+echo "--- dockerhub login"
+echo "$DOCKER_TOKEN" | docker login -u "risingwavelabs" --password-stdin
 
 if [[ -n "${ORIGINAL_IMAGE_TAG+x}" ]] && [[ -n "${NEW_IMAGE_TAG+x}" ]]; then
   echo "--- retag docker image"
@@ -82,7 +80,7 @@ if [[ "${ENABLE_DOCKER_SCCACHE}" == "true" ]]; then
       aws sts assume-role \
         --role-arn "${DOCKER_SCCACHE_ROLE_ARN}" \
         --role-session-name "${DOCKER_SCCACHE_ROLE_SESSION_NAME:-docker-sccache-${BUILDKITE_BUILD_NUMBER:-local}}" \
-        --duration-seconds "${DOCKER_SCCACHE_SESSION_DURATION_SECONDS:-14400}" \
+        --duration-seconds "${DOCKER_SCCACHE_SESSION_DURATION_SECONDS:-3600}" \
         --query 'Credentials.[AccessKeyId,SecretAccessKey,SessionToken]' \
         --output text
     )

--- a/ci/scripts/docker.sh
+++ b/ci/scripts/docker.sh
@@ -109,7 +109,10 @@ if [[ "${ENABLE_DOCKER_SCCACHE}" == "true" ]]; then
   } >"${docker_sccache_credentials_dir}/config"
 
   cache_branch="$(sanitize_cache_component "${BUILDKITE_BRANCH:-unknown}")"
-  DOCKER_SCCACHE_PREFIX=${DOCKER_SCCACHE_PREFIX:-${DOCKER_SCCACHE_S3_KEY_PREFIX:-"docker/${cache_branch}/${arch}/${CARGO_PROFILE}"}}
+  DOCKER_SCCACHE_PREFIX_ROOT="${DOCKER_SCCACHE_PREFIX_ROOT:-sccache/docker}"
+  DOCKER_SCCACHE_PREFIX_ROOT="${DOCKER_SCCACHE_PREFIX_ROOT#/}"
+  DOCKER_SCCACHE_PREFIX_ROOT="${DOCKER_SCCACHE_PREFIX_ROOT%/}"
+  DOCKER_SCCACHE_PREFIX=${DOCKER_SCCACHE_PREFIX:-"${DOCKER_SCCACHE_PREFIX_ROOT}/${cache_branch}/${arch}/${CARGO_PROFILE}"}
   echo "Docker sccache prefix: ${DOCKER_SCCACHE_PREFIX}"
 
   build_secret_args+=(

--- a/ci/scripts/docker.sh
+++ b/ci/scripts/docker.sh
@@ -40,8 +40,10 @@ trap cleanup_docker_sccache_credentials EXIT
 echo "--- ghcr login"
 echo "$GHCR_TOKEN" | docker login ghcr.io -u "$GHCR_USERNAME" --password-stdin
 
-echo "--- dockerhub login"
-echo "$DOCKER_TOKEN" | docker login -u "risingwavelabs" --password-stdin
+if [[ "${PUSH_DOCKERHUB}" == "true" ]]; then
+  echo "--- dockerhub login"
+  echo "$DOCKER_TOKEN" | docker login -u "risingwavelabs" --password-stdin
+fi
 
 if [[ -n "${ORIGINAL_IMAGE_TAG+x}" ]] && [[ -n "${NEW_IMAGE_TAG+x}" ]]; then
   echo "--- retag docker image"
@@ -80,7 +82,7 @@ if [[ "${ENABLE_DOCKER_SCCACHE}" == "true" ]]; then
       aws sts assume-role \
         --role-arn "${DOCKER_SCCACHE_ROLE_ARN}" \
         --role-session-name "${DOCKER_SCCACHE_ROLE_SESSION_NAME:-docker-sccache-${BUILDKITE_BUILD_NUMBER:-local}}" \
-        --duration-seconds "${DOCKER_SCCACHE_SESSION_DURATION_SECONDS:-3600}" \
+        --duration-seconds "${DOCKER_SCCACHE_SESSION_DURATION_SECONDS:-14400}" \
         --query 'Credentials.[AccessKeyId,SecretAccessKey,SessionToken]' \
         --output text
     )

--- a/ci/scripts/multi-arch-docker.sh
+++ b/ci/scripts/multi-arch-docker.sh
@@ -17,6 +17,7 @@ export PATH=$PATH:/var/lib/buildkite-agent/.local/bin
 date="$(date +%Y%m%d)"
 ghcraddr="ghcr.io/risingwavelabs/risingwave"
 dockerhubaddr="risingwavelabs/risingwave"
+PUSH_DOCKERHUB=${PUSH_DOCKERHUB:-true}
 
 
 arches=()
@@ -46,6 +47,11 @@ function pushGchr() {
 
 # push images to dockerhub
 function pushDockerhub() {
+  if [[ "${PUSH_DOCKERHUB}" != "true" ]]; then
+    echo "skip dockerhub image because PUSH_DOCKERHUB=${PUSH_DOCKERHUB}"
+    return
+  fi
+
   DOCKERTAG="${dockerhubaddr}:$1"
   echo "push to dockerhub, image tag: ${DOCKERTAG}"
   args=()
@@ -80,8 +86,10 @@ function isLatestVersion() {
 echo "--- ghcr login"
 echo "$GHCR_TOKEN" | docker login ghcr.io -u "$GHCR_USERNAME" --password-stdin
 
-echo "--- dockerhub login"
-echo "$DOCKER_TOKEN" | docker login -u "risingwavelabs" --password-stdin
+if [[ "${PUSH_DOCKERHUB}" == "true" ]]; then
+  echo "--- dockerhub login"
+  echo "$DOCKER_TOKEN" | docker login -u "risingwavelabs" --password-stdin
+fi
 
 if [[ -n "${ORIGINAL_IMAGE_TAG+x}" ]] && [[ -n "${NEW_IMAGE_TAG+x}" ]]; then
   echo "--- retag docker image"
@@ -123,18 +131,14 @@ if [ "$BUILDKITE_BRANCH" != "main" ] && [[ ! "$BUILDKITE_BRANCH" =~ "^release-.*
   pip install toml-cli
   TAG="v$(toml get --toml-path Cargo.toml workspace.package.version)-${postfix}"
   pushGchr "${TAG}"
-  if [[ "${PUSH_DOCKERHUB:-false}" == "true" ]]; then
-    pushDockerhub "${TAG}"
-  fi
+  pushDockerhub "${TAG}"
 fi
 
 if [[ -n "${IMAGE_TAG+x}" ]]; then
   # Tag the image with the $IMAGE_TAG.
   TAG="${IMAGE_TAG}"
   pushGchr "${TAG}"
-  if [[ "${PUSH_DOCKERHUB:-false}" == "true" ]]; then
-    pushDockerhub "${TAG}"
-  fi
+  pushDockerhub "${TAG}"
 fi
 
 if [[ -n "${BUILDKITE_TAG}" ]]; then
@@ -151,11 +155,15 @@ if [[ -n "${BUILDKITE_TAG}" ]]; then
   fi
 fi
 
-echo "--- delete the manifest images from dockerhub"
-args=()
-for arch in "${arches[@]}"
-do
-  args+=( "${dockerhubaddr}:${BUILDKITE_COMMIT}-${arch}" )
-done
-docker run --rm lumir/remove-dockerhub-tag \
-  --user "risingwavelabs" --password "$DOCKER_TOKEN" "${args[@]}"
+if [[ "${PUSH_DOCKERHUB}" == "true" ]]; then
+  echo "--- delete the manifest images from dockerhub"
+  args=()
+  for arch in "${arches[@]}"
+  do
+    args+=( "${dockerhubaddr}:${BUILDKITE_COMMIT}-${arch}" )
+  done
+  docker run --rm lumir/remove-dockerhub-tag \
+    --user "risingwavelabs" --password "$DOCKER_TOKEN" "${args[@]}"
+else
+  echo "--- skip dockerhub manifest cleanup because PUSH_DOCKERHUB=${PUSH_DOCKERHUB}"
+fi

--- a/ci/terraform/docker-sccache/README.md
+++ b/ci/terraform/docker-sccache/README.md
@@ -3,21 +3,44 @@
 This Terraform configuration sketches the AWS resources needed for an
 S3-backed `sccache` cache used by ad-hoc Docker image builds.
 
+The cache is intended to live in a shared build-cache bucket and use a scoped
+prefix, instead of creating a new bucket for each cache type. By default, Docker
+compiler objects are stored under `sccache/docker/`.
+
 It intentionally does not create or store any long-lived access keys. The
 recommended path is:
 
-1. Create the S3 bucket and the scoped IAM role with this configuration.
-2. Allow the Buildkite agent role to assume the generated role.
+1. Create or select one shared build-cache bucket.
+2. Create the scoped IAM role with this configuration.
 3. Set `DOCKER_SCCACHE_BUCKET`, `DOCKER_SCCACHE_REGION`, and
    `DOCKER_SCCACHE_ROLE_ARN` in the Buildkite docker pipeline environment.
+   Optionally set `DOCKER_SCCACHE_PREFIX_ROOT` if you changed the default
+   prefix.
 4. Trigger a Docker image build with `ENABLE_DOCKER_SCCACHE=true`.
 
-Example:
+Example that creates the shared build-cache bucket:
 
 ```bash
 terraform init
 terraform plan \
+  -var='bucket_name=<shared-build-cache-bucket>' \
   -var='buildkite_agent_role_arns=["arn:aws:iam::<account-id>:role/<buildkite-agent-role>"]'
 ```
+
+Example that reuses an existing shared build-cache bucket:
+
+```bash
+terraform plan \
+  -var='create_bucket=false' \
+  -var='bucket_name=<shared-build-cache-bucket>' \
+  -var='manage_lifecycle_rules=false' \
+  -var='buildkite_agent_role_arns=["arn:aws:iam::<account-id>:role/<buildkite-agent-role>"]'
+```
+
+`manage_lifecycle_rules=false` is recommended when the existing bucket's
+lifecycle configuration is owned by another Terraform module, because the AWS
+provider manages the whole bucket lifecycle configuration as one resource.
+When unset, `manage_lifecycle_rules` defaults to `create_bucket`, so existing
+buckets are not modified unless this is explicitly enabled.
 
 The provider defaults to the `rwc-cicd` AWS profile.

--- a/ci/terraform/docker-sccache/README.md
+++ b/ci/terraform/docker-sccache/README.md
@@ -1,0 +1,23 @@
+# Docker sccache cache
+
+This Terraform configuration sketches the AWS resources needed for an
+S3-backed `sccache` cache used by ad-hoc Docker image builds.
+
+It intentionally does not create or store any long-lived access keys. The
+recommended path is:
+
+1. Create the S3 bucket and the scoped IAM role with this configuration.
+2. Allow the Buildkite agent role to assume the generated role.
+3. Set `DOCKER_SCCACHE_BUCKET`, `DOCKER_SCCACHE_REGION`, and
+   `DOCKER_SCCACHE_ROLE_ARN` in the Buildkite docker pipeline environment.
+4. Trigger a Docker image build with `ENABLE_DOCKER_SCCACHE=true`.
+
+Example:
+
+```bash
+terraform init
+terraform plan \
+  -var='buildkite_agent_role_arns=["arn:aws:iam::<account-id>:role/<buildkite-agent-role>"]'
+```
+
+The provider defaults to the `rwc-cicd` AWS profile.

--- a/ci/terraform/docker-sccache/README.md
+++ b/ci/terraform/docker-sccache/README.md
@@ -18,10 +18,10 @@ recommended path is:
    prefix.
 4. Trigger a Docker image build with `ENABLE_DOCKER_SCCACHE=true`.
 
-Example that creates the shared build-cache bucket:
+After initializing the shared backend as described below, an example that
+creates the shared build-cache bucket is:
 
 ```bash
-terraform init
 terraform plan \
   -var='bucket_name=<shared-build-cache-bucket>' \
   -var='buildkite_agent_role_arns=["arn:aws:iam::<account-id>:role/<buildkite-agent-role>"]'
@@ -44,3 +44,70 @@ When unset, `manage_lifecycle_rules` defaults to `create_bucket`, so existing
 buckets are not modified unless this is explicitly enabled.
 
 The provider defaults to the `rwc-cicd` AWS profile.
+
+## Shared Terraform state
+
+This stack uses an S3 backend with native lockfiles. The backend bucket must be
+a pre-existing, versioned Terraform state bucket managed outside this stack; do
+not use a bucket that this configuration is expected to create. Terraform 1.10
+or later is required for S3 lockfiles.
+
+The state-bucket IAM principal needs `s3:ListBucket` on the bucket,
+`s3:GetObject` and `s3:PutObject` on
+`risingwave/docker-sccache/terraform.tfstate`, and `s3:GetObject`,
+`s3:PutObject`, and `s3:DeleteObject` on the adjacent `.tflock` object.
+
+Supply the deployment-specific bucket and region during initialization. Do not
+put credentials in backend configuration:
+
+```bash
+AWS_PROFILE=rwc-cicd terraform init \
+  -backend-config='bucket=<terraform-state-bucket>' \
+  -backend-config='region=<terraform-state-bucket-region>'
+```
+
+### Migrate the existing local state
+
+The maintainer who has the state from the original apply must first back up
+`terraform.tfstate`, then migrate it into the shared backend:
+
+```bash
+cp terraform.tfstate terraform.tfstate.pre-s3-backend
+AWS_PROFILE=rwc-cicd terraform init -migrate-state \
+  -backend-config='bucket=<terraform-state-bucket>' \
+  -backend-config='region=<terraform-state-bucket-region>'
+```
+
+After migration, run `terraform plan` and verify that it proposes no resource
+creation or replacement before applying further changes.
+
+### Recover when the original state is unavailable
+
+If the resources were applied but the original local state cannot be recovered,
+initialize the empty shared backend, set the same `TF_VAR_*` values used by the
+deployment, and import every resource that this stack owns before planning:
+
+```bash
+AWS_PROFILE=rwc-cicd terraform init -reconfigure \
+  -backend-config='bucket=<terraform-state-bucket>' \
+  -backend-config='region=<terraform-state-bucket-region>'
+export TF_VAR_bucket_name=<cache-bucket-name>
+```
+
+Depending on `create_bucket`, `manage_lifecycle_rules`, and whether an
+assumable role was created, the imports are:
+
+```bash
+terraform import 'aws_s3_bucket.docker_sccache[0]' <cache-bucket-name>
+terraform import 'aws_s3_bucket_public_access_block.docker_sccache[0]' <cache-bucket-name>
+terraform import 'aws_s3_bucket_ownership_controls.docker_sccache[0]' <cache-bucket-name>
+terraform import 'aws_s3_bucket_server_side_encryption_configuration.docker_sccache[0]' <cache-bucket-name>
+terraform import 'aws_s3_bucket_lifecycle_configuration.docker_sccache[0]' <cache-bucket-name>
+terraform import aws_iam_policy.docker_sccache <policy-arn>
+terraform import 'aws_iam_role.docker_sccache[0]' <role-name>
+terraform import 'aws_iam_role_policy_attachment.docker_sccache[0]' '<role-name>/<policy-arn>'
+```
+
+Skip addresses disabled by the selected variables. Do not run `terraform apply`
+until all existing owned resources are imported and `terraform plan` has been
+checked for unintended creates, replacements, or deletes.

--- a/ci/terraform/docker-sccache/main.tf
+++ b/ci/terraform/docker-sccache/main.tf
@@ -1,16 +1,29 @@
 locals {
-  cache_prefix = "docker/"
+  docker_sccache_prefix = "${trimsuffix(var.docker_sccache_prefix, "/")}/"
+  manage_lifecycle      = coalesce(var.manage_lifecycle_rules, var.create_bucket)
+  bucket_id             = var.create_bucket ? aws_s3_bucket.docker_sccache[0].id : data.aws_s3_bucket.docker_sccache[0].id
+  bucket_arn            = var.create_bucket ? aws_s3_bucket.docker_sccache[0].arn : data.aws_s3_bucket.docker_sccache[0].arn
+  bucket_name           = var.create_bucket ? aws_s3_bucket.docker_sccache[0].bucket : data.aws_s3_bucket.docker_sccache[0].bucket
 }
 
 resource "aws_s3_bucket" "docker_sccache" {
-  bucket        = var.bucket_name
-  bucket_prefix = var.bucket_name == null ? var.bucket_name_prefix : null
+  count = var.create_bucket ? 1 : 0
+
+  bucket = var.bucket_name
 
   tags = var.tags
 }
 
+data "aws_s3_bucket" "docker_sccache" {
+  count = var.create_bucket ? 0 : 1
+
+  bucket = var.bucket_name
+}
+
 resource "aws_s3_bucket_public_access_block" "docker_sccache" {
-  bucket = aws_s3_bucket.docker_sccache.id
+  count = var.create_bucket ? 1 : 0
+
+  bucket = aws_s3_bucket.docker_sccache[0].id
 
   block_public_acls       = true
   block_public_policy     = true
@@ -19,7 +32,9 @@ resource "aws_s3_bucket_public_access_block" "docker_sccache" {
 }
 
 resource "aws_s3_bucket_ownership_controls" "docker_sccache" {
-  bucket = aws_s3_bucket.docker_sccache.id
+  count = var.create_bucket ? 1 : 0
+
+  bucket = aws_s3_bucket.docker_sccache[0].id
 
   rule {
     object_ownership = "BucketOwnerEnforced"
@@ -27,7 +42,9 @@ resource "aws_s3_bucket_ownership_controls" "docker_sccache" {
 }
 
 resource "aws_s3_bucket_server_side_encryption_configuration" "docker_sccache" {
-  bucket = aws_s3_bucket.docker_sccache.id
+  count = var.create_bucket ? 1 : 0
+
+  bucket = aws_s3_bucket.docker_sccache[0].id
 
   rule {
     apply_server_side_encryption_by_default {
@@ -37,14 +54,16 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "docker_sccache" {
 }
 
 resource "aws_s3_bucket_lifecycle_configuration" "docker_sccache" {
-  bucket = aws_s3_bucket.docker_sccache.id
+  count = local.manage_lifecycle ? 1 : 0
+
+  bucket = local.bucket_id
 
   rule {
     id     = "expire-docker-sccache"
     status = "Enabled"
 
     filter {
-      prefix = local.cache_prefix
+      prefix = local.docker_sccache_prefix
     }
 
     expiration {
@@ -66,14 +85,14 @@ data "aws_iam_policy_document" "docker_sccache" {
     ]
 
     resources = [
-      aws_s3_bucket.docker_sccache.arn,
+      local.bucket_arn,
     ]
 
     condition {
       test     = "StringLike"
       variable = "s3:prefix"
       values = [
-        "${local.cache_prefix}*",
+        "${local.docker_sccache_prefix}*",
       ]
     }
   }
@@ -89,7 +108,7 @@ data "aws_iam_policy_document" "docker_sccache" {
     ]
 
     resources = [
-      "${aws_s3_bucket.docker_sccache.arn}/${local.cache_prefix}*",
+      "${local.bucket_arn}/${local.docker_sccache_prefix}*",
     ]
   }
 }

--- a/ci/terraform/docker-sccache/main.tf
+++ b/ci/terraform/docker-sccache/main.tf
@@ -1,0 +1,131 @@
+locals {
+  cache_prefix = "docker/"
+}
+
+resource "aws_s3_bucket" "docker_sccache" {
+  bucket        = var.bucket_name
+  bucket_prefix = var.bucket_name == null ? var.bucket_name_prefix : null
+
+  tags = var.tags
+}
+
+resource "aws_s3_bucket_public_access_block" "docker_sccache" {
+  bucket = aws_s3_bucket.docker_sccache.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket_ownership_controls" "docker_sccache" {
+  bucket = aws_s3_bucket.docker_sccache.id
+
+  rule {
+    object_ownership = "BucketOwnerEnforced"
+  }
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "docker_sccache" {
+  bucket = aws_s3_bucket.docker_sccache.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "docker_sccache" {
+  bucket = aws_s3_bucket.docker_sccache.id
+
+  rule {
+    id     = "expire-docker-sccache"
+    status = "Enabled"
+
+    filter {
+      prefix = local.cache_prefix
+    }
+
+    expiration {
+      days = var.cache_retention_days
+    }
+
+    abort_incomplete_multipart_upload {
+      days_after_initiation = 7
+    }
+  }
+}
+
+data "aws_iam_policy_document" "docker_sccache" {
+  statement {
+    sid = "ListDockerSccachePrefix"
+
+    actions = [
+      "s3:ListBucket",
+    ]
+
+    resources = [
+      aws_s3_bucket.docker_sccache.arn,
+    ]
+
+    condition {
+      test     = "StringLike"
+      variable = "s3:prefix"
+      values = [
+        "${local.cache_prefix}*",
+      ]
+    }
+  }
+
+  statement {
+    sid = "ReadWriteDockerSccacheObjects"
+
+    actions = [
+      "s3:AbortMultipartUpload",
+      "s3:GetObject",
+      "s3:ListMultipartUploadParts",
+      "s3:PutObject",
+    ]
+
+    resources = [
+      "${aws_s3_bucket.docker_sccache.arn}/${local.cache_prefix}*",
+    ]
+  }
+}
+
+resource "aws_iam_policy" "docker_sccache" {
+  name_prefix = "docker-sccache-"
+  description = "Read/write access to the Docker sccache S3 prefix."
+  policy      = data.aws_iam_policy_document.docker_sccache.json
+  tags        = var.tags
+}
+
+data "aws_iam_policy_document" "assume_by_buildkite" {
+  count = length(var.buildkite_agent_role_arns) > 0 ? 1 : 0
+
+  statement {
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "AWS"
+      identifiers = var.buildkite_agent_role_arns
+    }
+  }
+}
+
+resource "aws_iam_role" "docker_sccache" {
+  count = length(var.buildkite_agent_role_arns) > 0 ? 1 : 0
+
+  name_prefix          = "docker-sccache-"
+  assume_role_policy   = data.aws_iam_policy_document.assume_by_buildkite[0].json
+  max_session_duration = var.max_session_duration_seconds
+  tags                 = var.tags
+}
+
+resource "aws_iam_role_policy_attachment" "docker_sccache" {
+  count = length(var.buildkite_agent_role_arns) > 0 ? 1 : 0
+
+  role       = aws_iam_role.docker_sccache[0].name
+  policy_arn = aws_iam_policy.docker_sccache.arn
+}

--- a/ci/terraform/docker-sccache/moved.tf
+++ b/ci/terraform/docker-sccache/moved.tf
@@ -1,0 +1,24 @@
+moved {
+  from = aws_s3_bucket.docker_sccache
+  to   = aws_s3_bucket.docker_sccache[0]
+}
+
+moved {
+  from = aws_s3_bucket_public_access_block.docker_sccache
+  to   = aws_s3_bucket_public_access_block.docker_sccache[0]
+}
+
+moved {
+  from = aws_s3_bucket_ownership_controls.docker_sccache
+  to   = aws_s3_bucket_ownership_controls.docker_sccache[0]
+}
+
+moved {
+  from = aws_s3_bucket_server_side_encryption_configuration.docker_sccache
+  to   = aws_s3_bucket_server_side_encryption_configuration.docker_sccache[0]
+}
+
+moved {
+  from = aws_s3_bucket_lifecycle_configuration.docker_sccache
+  to   = aws_s3_bucket_lifecycle_configuration.docker_sccache[0]
+}

--- a/ci/terraform/docker-sccache/outputs.tf
+++ b/ci/terraform/docker-sccache/outputs.tf
@@ -1,0 +1,28 @@
+output "bucket_name" {
+  description = "S3 bucket name for Docker sccache."
+  value       = aws_s3_bucket.docker_sccache.bucket
+}
+
+output "bucket_region" {
+  description = "S3 bucket region."
+  value       = var.aws_region
+}
+
+output "iam_policy_arn" {
+  description = "IAM policy ARN with scoped Docker sccache S3 permissions."
+  value       = aws_iam_policy.docker_sccache.arn
+}
+
+output "role_arn" {
+  description = "Role ARN for Buildkite agents to assume. Null when no agent roles were provided."
+  value       = try(aws_iam_role.docker_sccache[0].arn, null)
+}
+
+output "buildkite_environment" {
+  description = "Non-secret Buildkite environment values to set when enabling Docker sccache."
+  value = {
+    DOCKER_SCCACHE_BUCKET   = aws_s3_bucket.docker_sccache.bucket
+    DOCKER_SCCACHE_REGION   = var.aws_region
+    DOCKER_SCCACHE_ROLE_ARN = try(aws_iam_role.docker_sccache[0].arn, null)
+  }
+}

--- a/ci/terraform/docker-sccache/outputs.tf
+++ b/ci/terraform/docker-sccache/outputs.tf
@@ -1,6 +1,6 @@
 output "bucket_name" {
-  description = "S3 bucket name for Docker sccache."
-  value       = aws_s3_bucket.docker_sccache.bucket
+  description = "Shared build cache S3 bucket name."
+  value       = local.bucket_name
 }
 
 output "bucket_region" {
@@ -13,6 +13,11 @@ output "iam_policy_arn" {
   value       = aws_iam_policy.docker_sccache.arn
 }
 
+output "docker_sccache_prefix" {
+  description = "S3 key prefix reserved for Docker sccache objects."
+  value       = local.docker_sccache_prefix
+}
+
 output "role_arn" {
   description = "Role ARN for Buildkite agents to assume. Null when no agent roles were provided."
   value       = try(aws_iam_role.docker_sccache[0].arn, null)
@@ -21,8 +26,9 @@ output "role_arn" {
 output "buildkite_environment" {
   description = "Non-secret Buildkite environment values to set when enabling Docker sccache."
   value = {
-    DOCKER_SCCACHE_BUCKET   = aws_s3_bucket.docker_sccache.bucket
-    DOCKER_SCCACHE_REGION   = var.aws_region
-    DOCKER_SCCACHE_ROLE_ARN = try(aws_iam_role.docker_sccache[0].arn, null)
+    DOCKER_SCCACHE_BUCKET      = local.bucket_name
+    DOCKER_SCCACHE_REGION      = var.aws_region
+    DOCKER_SCCACHE_PREFIX_ROOT = trimsuffix(local.docker_sccache_prefix, "/")
+    DOCKER_SCCACHE_ROLE_ARN    = try(aws_iam_role.docker_sccache[0].arn, null)
   }
 }

--- a/ci/terraform/docker-sccache/variables.tf
+++ b/ci/terraform/docker-sccache/variables.tf
@@ -1,0 +1,50 @@
+variable "aws_profile" {
+  description = "AWS profile used for planning and applying these resources."
+  type        = string
+  default     = "rwc-cicd"
+}
+
+variable "aws_region" {
+  description = "AWS region for the Docker sccache bucket."
+  type        = string
+  default     = "us-east-2"
+}
+
+variable "bucket_name" {
+  description = "Optional fixed bucket name. Leave null to use bucket_name_prefix."
+  type        = string
+  default     = null
+}
+
+variable "bucket_name_prefix" {
+  description = "Bucket prefix used when bucket_name is null."
+  type        = string
+  default     = "rw-docker-sccache-"
+}
+
+variable "cache_retention_days" {
+  description = "How long to retain cached compiler objects under the docker/ prefix."
+  type        = number
+  default     = 60
+}
+
+variable "buildkite_agent_role_arns" {
+  description = "IAM role ARNs used by Buildkite agents that may assume the Docker sccache role."
+  type        = list(string)
+  default     = []
+}
+
+variable "max_session_duration_seconds" {
+  description = "Maximum STS session duration for the Docker sccache role."
+  type        = number
+  default     = 14400
+}
+
+variable "tags" {
+  description = "Tags to apply to created resources."
+  type        = map(string)
+  default = {
+    Service = "buildkite"
+    Purpose = "docker-sccache"
+  }
+}

--- a/ci/terraform/docker-sccache/variables.tf
+++ b/ci/terraform/docker-sccache/variables.tf
@@ -5,27 +5,38 @@ variable "aws_profile" {
 }
 
 variable "aws_region" {
-  description = "AWS region for the Docker sccache bucket."
+  description = "AWS region for the shared build cache bucket."
   type        = string
   default     = "us-east-2"
 }
 
 variable "bucket_name" {
-  description = "Optional fixed bucket name. Leave null to use bucket_name_prefix."
+  description = "Stable shared build cache bucket name. The module creates it when create_bucket is true, or reuses it when create_bucket is false."
   type        = string
-  default     = null
 }
 
-variable "bucket_name_prefix" {
-  description = "Bucket prefix used when bucket_name is null."
+variable "create_bucket" {
+  description = "Whether to create the shared build cache bucket. Set false to use an existing bucket."
+  type        = bool
+  default     = true
+}
+
+variable "docker_sccache_prefix" {
+  description = "S3 key prefix reserved for Docker sccache objects inside the shared build cache bucket."
   type        = string
-  default     = "rw-docker-sccache-"
+  default     = "sccache/docker/"
 }
 
 variable "cache_retention_days" {
-  description = "How long to retain cached compiler objects under the docker/ prefix."
+  description = "How long to retain cached compiler objects under the Docker sccache prefix."
   type        = number
   default     = 60
+}
+
+variable "manage_lifecycle_rules" {
+  description = "Whether this module should manage lifecycle rules for the Docker sccache prefix. Defaults to create_bucket when null."
+  type        = bool
+  default     = null
 }
 
 variable "buildkite_agent_role_arns" {
@@ -45,6 +56,6 @@ variable "tags" {
   type        = map(string)
   default = {
     Service = "buildkite"
-    Purpose = "docker-sccache"
+    Purpose = "build-cache"
   }
 }

--- a/ci/terraform/docker-sccache/versions.tf
+++ b/ci/terraform/docker-sccache/versions.tf
@@ -1,0 +1,15 @@
+terraform {
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
+provider "aws" {
+  profile = var.aws_profile
+  region  = var.aws_region
+}

--- a/ci/terraform/docker-sccache/versions.tf
+++ b/ci/terraform/docker-sccache/versions.tf
@@ -1,5 +1,11 @@
 terraform {
-  required_version = ">= 1.5.0"
+  required_version = ">= 1.10.0"
+
+  backend "s3" {
+    key          = "risingwave/docker-sccache/terraform.tfstate"
+    encrypt      = true
+    use_lockfile = true
+  }
 
   required_providers {
     aws = {

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -74,7 +74,7 @@ ENV CARGO_PROFILE=$CARGO_PROFILE
 ARG ENABLE_DOCKER_SCCACHE=false
 ARG DOCKER_SCCACHE_BUCKET
 ARG DOCKER_SCCACHE_REGION
-ARG DOCKER_SCCACHE_S3_KEY_PREFIX
+ARG DOCKER_SCCACHE_PREFIX
 ARG SCCACHE_VERSION=0.10.0
 
 COPY ./ /risingwave
@@ -94,7 +94,7 @@ RUN --mount=type=secret,id=aws_credentials,target=/root/.aws/credentials,require
     export RUSTC_WRAPPER=sccache; \
     export SCCACHE_BUCKET="${DOCKER_SCCACHE_BUCKET}"; \
     export SCCACHE_REGION="${DOCKER_SCCACHE_REGION}"; \
-    export SCCACHE_S3_KEY_PREFIX="${DOCKER_SCCACHE_S3_KEY_PREFIX}"; \
+    export SCCACHE_S3_KEY_PREFIX="${DOCKER_SCCACHE_PREFIX}"; \
     export SCCACHE_IDLE_TIMEOUT=0; \
     sccache --start-server; \
   fi && \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,3 +1,5 @@
+# syntax=docker/dockerfile:1.10
+
 FROM ubuntu:24.04 AS base
 
 ENV LANG en_US.utf8
@@ -69,14 +71,39 @@ ENV GIT_SHA=$GIT_SHA
 ARG CARGO_PROFILE
 ENV CARGO_PROFILE=$CARGO_PROFILE
 
+ARG ENABLE_DOCKER_SCCACHE=false
+ARG DOCKER_SCCACHE_BUCKET
+ARG DOCKER_SCCACHE_REGION
+ARG DOCKER_SCCACHE_S3_KEY_PREFIX
+ARG SCCACHE_VERSION=0.10.0
+
 COPY ./ /risingwave
 WORKDIR /risingwave
 
 ENV ENABLE_BUILD_DASHBOARD=1
 ENV OPENSSL_STATIC=1
 
-RUN cargo fetch && \
+RUN --mount=type=secret,id=aws_credentials,target=/root/.aws/credentials,required=false \
+  --mount=type=secret,id=aws_config,target=/root/.aws/config,required=false \
+  if [[ "${ENABLE_DOCKER_SCCACHE}" == "true" ]]; then \
+    if [[ -z "${DOCKER_SCCACHE_BUCKET}" ]]; then \
+      echo "DOCKER_SCCACHE_BUCKET must be set when ENABLE_DOCKER_SCCACHE=true" >&2; \
+      exit 1; \
+    fi; \
+    cargo install --locked "sccache@${SCCACHE_VERSION}"; \
+    export RUSTC_WRAPPER=sccache; \
+    export SCCACHE_BUCKET="${DOCKER_SCCACHE_BUCKET}"; \
+    export SCCACHE_REGION="${DOCKER_SCCACHE_REGION}"; \
+    export SCCACHE_S3_KEY_PREFIX="${DOCKER_SCCACHE_S3_KEY_PREFIX}"; \
+    export SCCACHE_IDLE_TIMEOUT=0; \
+    sccache --start-server; \
+  fi && \
+  cargo fetch && \
   cargo build -p risingwave_cmd_all --profile ${CARGO_PROFILE} --features "rw-static-link" --features udf --features datafusion && \
+  if [[ "${ENABLE_DOCKER_SCCACHE}" == "true" ]]; then \
+    sccache --show-stats; \
+    sccache --zero-stats; \
+  fi && \
   mkdir -p /risingwave/bin && \
   mv /risingwave/target/${CARGO_PROFILE}/risingwave /risingwave/bin/ && \
   mv /risingwave/target/${CARGO_PROFILE}/risingwave.dwp /risingwave/bin/ && \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -133,7 +133,7 @@ RUN mkdir -p /risingwave
 WORKDIR /risingwave/java
 
 # 1. copy only poms
-COPY --from=java-planner /risingwave/poms /risingwave/java/
+COPY --from=java-planner /risingwave/poms /risingwave/
 
 # 2. start downloading dependencies
 RUN mvn dependency:go-offline --fail-never

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -134,7 +134,7 @@ RUN mkdir -p /risingwave
 WORKDIR /risingwave/java
 
 # 1. copy only poms
-COPY --from=java-planner /risingwave/poms /risingwave/java/
+COPY --from=java-planner /risingwave/poms /risingwave/
 
 # 2. start downloading dependencies
 RUN mvn dependency:go-offline --fail-never

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -78,6 +78,12 @@ ARG DOCKER_SCCACHE_REGION
 ARG DOCKER_SCCACHE_PREFIX
 ARG SCCACHE_VERSION=0.10.0
 
+# Keep the sccache installation independent of the source tree so this layer can
+# be reused across commits.
+RUN if [[ "${ENABLE_DOCKER_SCCACHE}" == "true" ]]; then \
+    cargo install --locked "sccache@${SCCACHE_VERSION}"; \
+  fi
+
 COPY ./ /risingwave
 WORKDIR /risingwave
 
@@ -91,7 +97,6 @@ RUN --mount=type=secret,id=aws_credentials,target=/root/.aws/credentials,require
       echo "DOCKER_SCCACHE_BUCKET must be set when ENABLE_DOCKER_SCCACHE=true" >&2; \
       exit 1; \
     fi; \
-    cargo install --locked "sccache@${SCCACHE_VERSION}"; \
     export RUSTC_WRAPPER=sccache; \
     export SCCACHE_BUCKET="${DOCKER_SCCACHE_BUCKET}"; \
     export SCCACHE_REGION="${DOCKER_SCCACHE_REGION}"; \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -75,7 +75,7 @@ ENV CARGO_PROFILE=$CARGO_PROFILE
 ARG ENABLE_DOCKER_SCCACHE=false
 ARG DOCKER_SCCACHE_BUCKET
 ARG DOCKER_SCCACHE_REGION
-ARG DOCKER_SCCACHE_S3_KEY_PREFIX
+ARG DOCKER_SCCACHE_PREFIX
 ARG SCCACHE_VERSION=0.10.0
 
 COPY ./ /risingwave
@@ -95,7 +95,7 @@ RUN --mount=type=secret,id=aws_credentials,target=/root/.aws/credentials,require
     export RUSTC_WRAPPER=sccache; \
     export SCCACHE_BUCKET="${DOCKER_SCCACHE_BUCKET}"; \
     export SCCACHE_REGION="${DOCKER_SCCACHE_REGION}"; \
-    export SCCACHE_S3_KEY_PREFIX="${DOCKER_SCCACHE_S3_KEY_PREFIX}"; \
+    export SCCACHE_S3_KEY_PREFIX="${DOCKER_SCCACHE_PREFIX}"; \
     export SCCACHE_IDLE_TIMEOUT=0; \
     sccache --start-server; \
   fi && \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,3 +1,5 @@
+# syntax=docker/dockerfile:1.10
+
 FROM ubuntu:24.04 AS base
 
 ENV LANG en_US.utf8
@@ -70,14 +72,39 @@ ENV GIT_SHA=$GIT_SHA
 ARG CARGO_PROFILE
 ENV CARGO_PROFILE=$CARGO_PROFILE
 
+ARG ENABLE_DOCKER_SCCACHE=false
+ARG DOCKER_SCCACHE_BUCKET
+ARG DOCKER_SCCACHE_REGION
+ARG DOCKER_SCCACHE_S3_KEY_PREFIX
+ARG SCCACHE_VERSION=0.10.0
+
 COPY ./ /risingwave
 WORKDIR /risingwave
 
 ENV ENABLE_BUILD_DASHBOARD=1
 ENV OPENSSL_STATIC=1
 
-RUN cargo fetch && \
+RUN --mount=type=secret,id=aws_credentials,target=/root/.aws/credentials,required=false \
+  --mount=type=secret,id=aws_config,target=/root/.aws/config,required=false \
+  if [[ "${ENABLE_DOCKER_SCCACHE}" == "true" ]]; then \
+    if [[ -z "${DOCKER_SCCACHE_BUCKET}" ]]; then \
+      echo "DOCKER_SCCACHE_BUCKET must be set when ENABLE_DOCKER_SCCACHE=true" >&2; \
+      exit 1; \
+    fi; \
+    cargo install --locked "sccache@${SCCACHE_VERSION}"; \
+    export RUSTC_WRAPPER=sccache; \
+    export SCCACHE_BUCKET="${DOCKER_SCCACHE_BUCKET}"; \
+    export SCCACHE_REGION="${DOCKER_SCCACHE_REGION}"; \
+    export SCCACHE_S3_KEY_PREFIX="${DOCKER_SCCACHE_S3_KEY_PREFIX}"; \
+    export SCCACHE_IDLE_TIMEOUT=0; \
+    sccache --start-server; \
+  fi && \
+  cargo fetch && \
   cargo build -p risingwave_cmd_all --profile ${CARGO_PROFILE} --features "rw-static-link" --features udf --features datafusion && \
+  if [[ "${ENABLE_DOCKER_SCCACHE}" == "true" ]]; then \
+    sccache --show-stats; \
+    sccache --zero-stats; \
+  fi && \
   mkdir -p /risingwave/bin && \
   mv /risingwave/target/${CARGO_PROFILE}/risingwave /risingwave/bin/ && \
   mv /risingwave/target/${CARGO_PROFILE}/risingwave.dwp /risingwave/bin/ && \


### PR DESCRIPTION
## What changed

- Add opt-in S3-backed `sccache` support to Docker image builds via `ENABLE_DOCKER_SCCACHE=true`.
- Store Docker sccache objects in a shared build-cache bucket under the scoped `sccache/docker/` prefix.
- Pass AWS credentials to Docker BuildKit as temporary secrets instead of Docker build args or image layers.
- Add GitHub workflow inputs to forward the Docker sccache opt-in flag to Buildkite.
- Add Terraform for the required AWS resources: shared S3 build-cache bucket support, prefix-scoped lifecycle policy, prefix-scoped IAM policy, and optional Buildkite-assumable IAM role.
- Fix the Docker Java POM cache copy path hit by the Docker image build.
- Respect `PUSH_DOCKERHUB=false` in `ci/scripts/docker.sh`; the default remains `true`.

## Security notes

- No access keys, tokens, account IDs, bucket names, or role ARNs are committed.
- The recommended path uses STS assume-role from the Buildkite agent role, with no long-lived access keys.
- S3 access is scoped to the `sccache/docker/` object prefix inside the shared build-cache bucket.
- Docker BuildKit receives AWS credentials through secret mounts, not build args or image layers.

## Validation

- `bash -n ci/scripts/docker.sh`
- `git diff --check -- docker/Dockerfile ci/scripts/docker.sh ci/terraform/docker-sccache`
- `terraform -chdir=ci/terraform/docker-sccache fmt -check`
- Applied the Terraform locally with AWS profile `rwc-cicd` after switching to the shared-bucket prefix layout.
  - Plan/apply result: `0 added, 4 changed, 0 destroyed`.
  - Updated IAM policy and lifecycle rules in place for `sccache/docker/`.
  - Resource names and account identifiers are intentionally omitted here.

### Buildkite evidence

Initial Docker sccache validation before the shared-prefix Terraform update:

- Cold-cache amd64 Docker build: https://buildkite.com/risingwavelabs/docker/builds/18510
  - Build passed.
  - Rust `patch-production` build: 33m48s.
  - `sccache` hit rate: 0.43%; cache read/write/cache errors: 0.
- Hot-cache amd64 Docker build: https://buildkite.com/risingwavelabs/docker/builds/18511
  - Build passed.
  - Rust `patch-production` build: 27m04s.
  - `sccache` hit rate: 98.04%; Rust hit rate: 97.37%; cache read/write/cache errors: 0.
  - Confirmed `PUSH_DOCKERHUB=false` skips DockerHub push.

Shared-prefix validation after Terraform apply:

- Cold shared-prefix amd64 Docker build: https://buildkite.com/risingwavelabs/docker/builds/18512
  - `docker-build-push: amd64` passed: https://buildkite.com/risingwavelabs/docker/builds/18512#019f17ee-f1cb-4046-a626-ad10c0da9838
  - Job duration: 50m14s, from 2026-06-30T09:49:34Z to 2026-06-30T10:39:48Z.
  - Rust `patch-production` build: 34m18s.
  - `sccache` hit rate: 0.43%; cache read/write errors: 0.
  - Confirms the new `sccache/docker/` prefix is writable and usable.
- Hot exact rerun with the same commit and Docker context: https://buildkite.com/risingwavelabs/docker/builds/18513
  - `docker-build-push: amd64` passed: https://buildkite.com/risingwavelabs/docker/builds/18513#019f181d-bc3d-4a9b-b900-0feac2269148
  - Job duration: 38s, from 2026-06-30T10:40:41Z to 2026-06-30T10:41:19Z.
  - Docker build logs show the Rust builder layer was `CACHED`, so this measures the exact-rerun Docker registry layer cache path rather than the pure sccache hot path.
  - Confirmed `PUSH_DOCKERHUB=false` skips DockerHub push.