### PR TITLE
fix(meta): enable SQLite foreign-key enforcement via PRAGMA foreign_keys = ON

### DIFF
--- a/src/meta/src/controller/mod.rs
+++ b/src/meta/src/controller/mod.rs
@@ -90,10 +90,10 @@ impl SqlMetaStore {
 
         /// Enable SQLite foreign-key enforcement on an established connection.
         ///
-        /// SQLite disables foreign-key enforcement by default and requires
+        /// `SQLite` disables foreign-key enforcement by default and requires
         /// `PRAGMA foreign_keys = ON` to be issued on **every connection**.
         /// sea-orm 1.x `ConnectOptions` has no dedicated API for this, so we
-        /// run the statement once after the pool is created.  Because SQLite
+        /// run the statement once after the pool is created.  Because `SQLite`
         /// connections always use `max_connections(1)`, the single pooled
         /// connection retains the pragma for its lifetime.
         ///

--- a/src/meta/src/controller/mod.rs
+++ b/src/meta/src/controller/mod.rs
@@ -32,7 +32,7 @@ use risingwave_pb::catalog::{
     PbSchema, PbSecret, PbSink, PbSinkType, PbSource, PbStreamJobStatus, PbSubscription, PbTable,
     PbView,
 };
-use sea_orm::{ConnectOptions, DatabaseConnection, DbBackend, ModelTrait};
+use sea_orm::{ConnectOptions, ConnectionTrait, DatabaseConnection, DbBackend, ModelTrait, Statement};
 
 use crate::{MetaError, MetaResult, MetaStoreBackend};
 
@@ -86,6 +86,26 @@ impl SqlMetaStore {
             }
         }
 
+        /// Enable SQLite foreign-key enforcement on an established connection.
+        ///
+        /// SQLite disables foreign-key enforcement by default and requires
+        /// `PRAGMA foreign_keys = ON` to be issued on **every connection**.
+        /// sea-orm 1.x `ConnectOptions` has no dedicated API for this, so we
+        /// run the statement once after the pool is created.  Because SQLite
+        /// connections always use `max_connections(1)`, the single pooled
+        /// connection retains the pragma for its lifetime.
+        ///
+        /// See: <https://www.sqlite.org/foreignkeys.html#fk_enable>
+        async fn enable_sqlite_foreign_keys(conn: &DatabaseConnection) -> MetaResult<()> {
+            conn.execute(Statement::from_string(
+                DbBackend::Sqlite,
+                "PRAGMA foreign_keys = ON".to_owned(),
+            ))
+            .await
+            .context("failed to enable SQLite foreign-key enforcement")?;
+            Ok(())
+        }
+
         Ok(match backend {
             MetaStoreBackend::Mem => {
                 const IN_MEMORY_STORE: &str = "sqlite::memory:";
@@ -102,6 +122,7 @@ impl SqlMetaStore {
                     .max_lifetime(MAX_DURATION);
 
                 let conn = sea_orm::Database::connect(options).await?;
+                enable_sqlite_foreign_keys(&conn).await?;
                 Self {
                     conn,
                     endpoint: IN_MEMORY_STORE.to_owned(),
@@ -126,6 +147,9 @@ impl SqlMetaStore {
                 }
 
                 let conn = sea_orm::Database::connect(options).await?;
+                if DbBackend::Sqlite.is_prefix_of(&endpoint) {
+                    enable_sqlite_foreign_keys(&conn).await?;
+                }
                 Self { conn, endpoint }
             }
         })

--- a/src/meta/src/controller/mod.rs
+++ b/src/meta/src/controller/mod.rs
@@ -32,7 +32,9 @@ use risingwave_pb::catalog::{
     PbSchema, PbSecret, PbSink, PbSinkType, PbSource, PbStreamJobStatus, PbSubscription, PbTable,
     PbView,
 };
-use sea_orm::{ConnectOptions, ConnectionTrait, DatabaseConnection, DbBackend, ModelTrait, Statement};
+use sea_orm::{
+    ConnectOptions, ConnectionTrait, DatabaseConnection, DbBackend, ModelTrait, Statement,
+};
 
 use crate::{MetaError, MetaResult, MetaStoreBackend};
 


### PR DESCRIPTION
## Problem

SQLite disables foreign-key enforcement **by default** and requires `PRAGMA foreign_keys = ON` to be issued on **every connection**. The meta store never set this pragma, so every foreign key declared in our migrations was parsed and stored in the schema but silently ignored at runtime on the SQLite backend (`mem` and file-based `sql` modes):

- Orphan child rows could be inserted or left behind with no error.
- `ON DELETE CASCADE` rules were inert — cascade cleanup that works on Postgres/MySQL was a silent no-op on SQLite.

This caused SQLite to diverge in correctness from the production Postgres/MySQL backends. A concrete example: #26045 adds `pending_sink_state.sink_id → object(oid) ON DELETE CASCADE`; the constraint correctly cascades on PG/MySQL but was completely inert on SQLite.

Closes #26047.
Related: #26046 (migration atomicity on SQLite/MySQL).

## Root Cause

`sqlite_common()` in `src/meta/src/controller/mod.rs` configures pool settings (connections, timeouts) but never issues the FK pragma:

```rust
fn sqlite_common(&mut self) -> &mut Self {
    self
        .min_connections(1)
        .max_connections(1)
        .acquire_timeout(MAX_DURATION)
        .connect_timeout(MAX_DURATION)
    // <-- PRAGMA foreign_keys = ON never set
}
```

sea-orm 1.x `ConnectOptions` has no dedicated API for SQLite pragmas, so the pragma must be executed after the pool is created.

## Fix

After `sea_orm::Database::connect()` succeeds for either SQLite backend (`Mem` and `Sql` with a SQLite URL), execute `PRAGMA foreign_keys = ON` via `ConnectionTrait::execute`:

```rust
async fn enable_sqlite_foreign_keys(conn: &DatabaseConnection) -> MetaResult<()> {
    conn.execute(Statement::from_string(
        DbBackend::Sqlite,
        "PRAGMA foreign_keys = ON".to_owned(),
    ))
    .await
    .context("failed to enable SQLite foreign-key enforcement")?;
    Ok(())
}
```

This is safe because:
- SQLite connections always use `max_connections(1)`, so the single pooled connection retains the pragma for its lifetime.
- The pragma is set before migrations run (via `for_test()` → `connect()` → `Migrator::up`), ensuring FK constraints are enforced during the migration phase as well.
- The `up()` migrations do not use the recreate-table pattern (drop + rename) that would require temporarily disabling FK enforcement; only `down()` migrations use `drop_tables!`, and those are not run in normal operation.

## Testing

The existing meta unit and integration test suite exercises `SqlMetaStore::for_test()` (which uses the `Mem` / in-memory SQLite backend). With FK enforcement now active, any test that inserts a row violating a declared foreign key would now correctly fail — turning previously silent data-integrity bugs into test failures.

No new tests are added in this PR because the fix is a correctness hardening: the expected behaviour (FK constraints enforced) is already declared by the schema; enabling the pragma makes SQLite honour those declarations consistently with Postgres/MySQL.
