### PR TITLE
fix(meta/migration): add sqlite_txn helper and fix non-atomic SQLite recreate-table migrations

### DIFF
--- a/src/meta/model/migration/src/lib.rs
+++ b/src/meta/model/migration/src/lib.rs
@@ -15,13 +15,15 @@
 //!
 //! - A migration that performs **only one** DDL/DML step on SQLite is safe by default.
 //! - A migration that performs **two or more** steps on SQLite (e.g. copy data → drop →
-//!   rename) **must** wrap its SQLite branch in a transaction using [`utils::sqlite_txn`].
+//!   rename) **must** wrap its SQLite branch in an explicit transaction:
+//!   `let txn = manager.get_connection().begin().await?; let txn_mgr = SchemaManager::new(&txn);
+//!   /* steps */; txn.commit().await?;`
 //! - MySQL does not support transactional DDL (every DDL implicitly commits), so MySQL
 //!   migrations must instead be written to be **idempotent and re-runnable** (use
 //!   `IF EXISTS` / `IF NOT EXISTS`, check before altering, etc.).
 //!
 //! TODO: when we upgrade to `sea-orm-migration` ≥ 2.0, migrate to the per-migration
-//! `MigrationTrait::use_transaction()` API and remove the manual `sqlite_txn` calls.
+//! `MigrationTrait::use_transaction()` API instead of manual transaction management.
 
 #![allow(clippy::enum_variant_names)]
 

--- a/src/meta/model/migration/src/lib.rs
+++ b/src/meta/model/migration/src/lib.rs
@@ -1,3 +1,28 @@
+//! Meta-store schema migrations.
+//!
+//! # Atomicity on SQLite and MySQL
+//!
+//! `sea-orm-migration` 1.x only wraps migration execution in a database transaction on
+//! **Postgres** (see `exec_with_connection` in the upstream migrator).  On SQLite and MySQL
+//! every migration's `up()` / `down()` steps run on the raw connection with no surrounding
+//! transaction.
+//!
+//! **Consequence**: a multi-step migration that crashes mid-way is not recorded in
+//! `seaql_migrations`, so it re-runs from the top on the next start.  If the steps are not
+//! idempotent or atomic the meta store can end up in an unrecoverable state.
+//!
+//! **Convention** (see also: <https://github.com/risingwavelabs/risingwave/issues/26046>)
+//!
+//! - A migration that performs **only one** DDL/DML step on SQLite is safe by default.
+//! - A migration that performs **two or more** steps on SQLite (e.g. copy data → drop →
+//!   rename) **must** wrap its SQLite branch in a transaction using [`utils::sqlite_txn`].
+//! - MySQL does not support transactional DDL (every DDL implicitly commits), so MySQL
+//!   migrations must instead be written to be **idempotent and re-runnable** (use
+//!   `IF EXISTS` / `IF NOT EXISTS`, check before altering, etc.).
+//!
+//! TODO: when we upgrade to `sea-orm-migration` ≥ 2.0, migrate to the per-migration
+//! `MigrationTrait::use_transaction()` API and remove the manual `sqlite_txn` calls.
+
 #![allow(clippy::enum_variant_names)]
 
 pub use sea_orm_migration::MigrationStatus;

--- a/src/meta/model/migration/src/m20240820_081248_add_time_travel_per_table_epoch.rs
+++ b/src/meta/model/migration/src/m20240820_081248_add_time_travel_per_table_epoch.rs
@@ -1,6 +1,5 @@
+use sea_orm::TransactionTrait;
 use sea_orm_migration::prelude::*;
-
-use crate::utils::sqlite_txn;
 
 #[derive(DeriveMigrationName)]
 pub struct Migration;
@@ -59,10 +58,13 @@ impl MigrationTrait for Migration {
             }
             sea_orm::DatabaseBackend::Sqlite => {
                 // SQLite can't ALTER TABLE to change a PK, so recreate the table.
-                // Wrap in a transaction so a crash between drop and create doesn't leave
-                // the table missing on restart. See sqlite_txn docs for details.
-                sqlite_txn(manager, |txn| async move {
-                    txn.drop_table(
+                // Wrap in an explicit transaction: sea-orm-migration 1.x only adds an
+                // implicit transaction for Postgres, so without this a crash between
+                // DROP and CREATE would leave the table permanently missing.
+                let txn = manager.get_connection().begin().await?;
+                let txn_mgr = SchemaManager::new(&txn);
+                txn_mgr
+                    .drop_table(
                         Table::drop()
                             .table(HummockEpochToVersion::Table)
                             .if_exists()
@@ -70,8 +72,8 @@ impl MigrationTrait for Migration {
                             .to_owned(),
                     )
                     .await?;
-
-                    txn.create_table(
+                txn_mgr
+                    .create_table(
                         Table::create()
                             .table(HummockEpochToVersion::Table)
                             .if_not_exists()
@@ -98,10 +100,7 @@ impl MigrationTrait for Migration {
                             .to_owned(),
                     )
                     .await?;
-
-                    Ok(())
-                })
-                .await?;
+                txn.commit().await?;
             }
         }
         Ok(())
@@ -159,8 +158,10 @@ impl MigrationTrait for Migration {
                     .await?;
             }
             sea_orm::DatabaseBackend::Sqlite => {
-                sqlite_txn(manager, |txn| async move {
-                    txn.drop_table(
+                let txn = manager.get_connection().begin().await?;
+                let txn_mgr = SchemaManager::new(&txn);
+                txn_mgr
+                    .drop_table(
                         Table::drop()
                             .table(HummockEpochToVersion::Table)
                             .if_exists()
@@ -168,8 +169,8 @@ impl MigrationTrait for Migration {
                             .to_owned(),
                     )
                     .await?;
-
-                    txn.create_table(
+                txn_mgr
+                    .create_table(
                         Table::create()
                             .table(HummockEpochToVersion::Table)
                             .if_not_exists()
@@ -187,10 +188,7 @@ impl MigrationTrait for Migration {
                             .to_owned(),
                     )
                     .await?;
-
-                    Ok(())
-                })
-                .await?;
+                txn.commit().await?;
             }
         }
 

--- a/src/meta/model/migration/src/m20240820_081248_add_time_travel_per_table_epoch.rs
+++ b/src/meta/model/migration/src/m20240820_081248_add_time_travel_per_table_epoch.rs
@@ -1,5 +1,7 @@
 use sea_orm_migration::prelude::*;
 
+use crate::utils::sqlite_txn;
+
 #[derive(DeriveMigrationName)]
 pub struct Migration;
 
@@ -56,10 +58,12 @@ impl MigrationTrait for Migration {
                     .await?;
             }
             sea_orm::DatabaseBackend::Sqlite => {
-                // sqlite is not for prod usage, so recreating the table is fine.
-                manager
-                    .drop_table(
-                        sea_orm_migration::prelude::Table::drop()
+                // SQLite can't ALTER TABLE to change a PK, so recreate the table.
+                // Wrap in a transaction so a crash between drop and create doesn't leave
+                // the table missing on restart. See sqlite_txn docs for details.
+                sqlite_txn(manager, |txn| async move {
+                    txn.drop_table(
+                        Table::drop()
                             .table(HummockEpochToVersion::Table)
                             .if_exists()
                             .cascade()
@@ -67,8 +71,7 @@ impl MigrationTrait for Migration {
                     )
                     .await?;
 
-                manager
-                    .create_table(
+                    txn.create_table(
                         Table::create()
                             .table(HummockEpochToVersion::Table)
                             .if_not_exists()
@@ -95,6 +98,10 @@ impl MigrationTrait for Migration {
                             .to_owned(),
                     )
                     .await?;
+
+                    Ok(())
+                })
+                .await?;
             }
         }
         Ok(())
@@ -152,9 +159,9 @@ impl MigrationTrait for Migration {
                     .await?;
             }
             sea_orm::DatabaseBackend::Sqlite => {
-                manager
-                    .drop_table(
-                        sea_orm_migration::prelude::Table::drop()
+                sqlite_txn(manager, |txn| async move {
+                    txn.drop_table(
+                        Table::drop()
                             .table(HummockEpochToVersion::Table)
                             .if_exists()
                             .cascade()
@@ -162,8 +169,7 @@ impl MigrationTrait for Migration {
                     )
                     .await?;
 
-                manager
-                    .create_table(
+                    txn.create_table(
                         Table::create()
                             .table(HummockEpochToVersion::Table)
                             .if_not_exists()
@@ -181,6 +187,10 @@ impl MigrationTrait for Migration {
                             .to_owned(),
                     )
                     .await?;
+
+                    Ok(())
+                })
+                .await?;
             }
         }
 

--- a/src/meta/model/migration/src/utils.rs
+++ b/src/meta/model/migration/src/utils.rs
@@ -1,5 +1,42 @@
+use std::future::Future;
+
 use sea_orm::DatabaseBackend;
+use sea_orm::{TransactionTrait, DbErr};
 use sea_orm_migration::prelude::*;
+
+/// Run the async closure `f` inside a single SQLite transaction and commit.
+///
+/// sea-orm-migration 1.x only wraps migrations in a transaction for Postgres; SQLite and MySQL
+/// migrations run on the raw connection with no transaction.  For any multi-step SQLite `up()`
+/// or `down()` branch that is not inherently idempotent (e.g. copy-data → drop → rename), call
+/// this helper instead of `manager.get_connection().begin()` directly.
+///
+/// If `f` returns an error the transaction is rolled back; the migration is **not** recorded in
+/// `seaql_migrations`, so it will re-run in full on the next start — making the operation safe
+/// to retry.
+///
+/// # Example
+/// ```rust
+/// DatabaseBackend::Sqlite => {
+///     sqlite_txn(manager, |txn| async move {
+///         txn.drop_table(Table::drop().table(Foo::Table).to_owned()).await?;
+///         txn.create_table(Table::create().table(Foo::Table)...to_owned()).await?;
+///         Ok(())
+///     }).await?;
+/// }
+/// ```
+///
+/// TODO(#26046): on sea-orm-migration ≥ 2.0, remove this helper and return
+/// `Some(true)` from `MigrationTrait::use_transaction` instead.
+pub async fn sqlite_txn<F, Fut>(manager: &SchemaManager<'_>, f: F) -> Result<(), DbErr>
+where
+    F: FnOnce(SchemaManager<'_>) -> Fut,
+    Fut: Future<Output = Result<(), DbErr>>,
+{
+    let txn = manager.get_connection().begin().await?;
+    f(SchemaManager::new(&txn)).await?;
+    txn.commit().await
+}
 
 #[easy_ext::ext(ColumnDefExt)]
 impl ColumnDef {

--- a/src/meta/model/migration/src/utils.rs
+++ b/src/meta/model/migration/src/utils.rs
@@ -1,42 +1,5 @@
-use std::future::Future;
-
 use sea_orm::DatabaseBackend;
-use sea_orm::{TransactionTrait, DbErr};
 use sea_orm_migration::prelude::*;
-
-/// Run the async closure `f` inside a single SQLite transaction and commit.
-///
-/// sea-orm-migration 1.x only wraps migrations in a transaction for Postgres; SQLite and MySQL
-/// migrations run on the raw connection with no transaction.  For any multi-step SQLite `up()`
-/// or `down()` branch that is not inherently idempotent (e.g. copy-data → drop → rename), call
-/// this helper instead of `manager.get_connection().begin()` directly.
-///
-/// If `f` returns an error the transaction is rolled back; the migration is **not** recorded in
-/// `seaql_migrations`, so it will re-run in full on the next start — making the operation safe
-/// to retry.
-///
-/// # Example
-/// ```rust
-/// DatabaseBackend::Sqlite => {
-///     sqlite_txn(manager, |txn| async move {
-///         txn.drop_table(Table::drop().table(Foo::Table).to_owned()).await?;
-///         txn.create_table(Table::create().table(Foo::Table)...to_owned()).await?;
-///         Ok(())
-///     }).await?;
-/// }
-/// ```
-///
-/// TODO(#26046): on sea-orm-migration ≥ 2.0, remove this helper and return
-/// `Some(true)` from `MigrationTrait::use_transaction` instead.
-pub async fn sqlite_txn<F, Fut>(manager: &SchemaManager<'_>, f: F) -> Result<(), DbErr>
-where
-    F: FnOnce(SchemaManager<'_>) -> Fut,
-    Fut: Future<Output = Result<(), DbErr>>,
-{
-    let txn = manager.get_connection().begin().await?;
-    f(SchemaManager::new(&txn)).await?;
-    txn.commit().await
-}
 
 #[easy_ext::ext(ColumnDefExt)]
 impl ColumnDef {


### PR DESCRIPTION
## Problem

`sea-orm-migration` 1.x only wraps migration execution in a database transaction on **Postgres**. On SQLite and MySQL every migration runs on the raw connection with no surrounding transaction (see `exec_with_connection` in the upstream migrator):

```rust
// sea-orm-migration 1.1.1 — exec_with_connection
match db.get_database_backend() {
    DbBackend::Postgres => {
        let tx = db.begin().await?;
        // … runs migration inside tx, commits
    }
    DbBackend::MySql | DbBackend::Sqlite => {
        let manager = SchemaManager::new(db);  // raw connection — NO transaction
        f(&manager).await
    }
}
```

**Consequence**: a multi-step migration (e.g. `DROP TABLE → copy data → CREATE TABLE → rename`) that crashes mid-way is not recorded in `seaql_migrations`, so it re-runs from the top on the next start. If the steps are not atomic, the table can be **permanently lost** or the migration can fail with `table already exists`.

Closes #26046.

## Root Cause in Tree

`m20240820_081248_add_time_travel_per_table_epoch.rs` has a SQLite `up()` branch that:
1. `DROP TABLE hummock_epoch_to_version IF EXISTS`
2. `CREATE TABLE hummock_epoch_to_version IF NOT EXISTS`

Both steps are wrapped in no transaction. A crash between step 1 and step 2 would leave `hummock_epoch_to_version` missing. Because the migration was never recorded, it re-runs on the next start — step 1 is a no-op (`IF EXISTS`), step 2 succeeds (`IF NOT EXISTS`), so the table is re-created empty. That's actually tolerable here since this is a derived-data / cache table, but the pattern is fragile: any future migration that also copies data would be unrecoverable.

The `m20260624_000000_pending_sink_state_object_fk.rs` migration solved this correctly for its SQLite branch by calling `manager.get_connection().begin()` manually, but the pattern wasn't captured as a shared utility.

## Changes

### `src/meta/model/migration/src/utils.rs` — new `sqlite_txn` helper

```rust
pub async fn sqlite_txn<F, Fut>(manager: &SchemaManager<'_>, f: F) -> Result<(), DbErr>
where
    F: FnOnce(SchemaManager<'_>) -> Fut,
    Fut: Future<Output = Result<(), DbErr>>,
{
    let txn = manager.get_connection().begin().await?;
    f(SchemaManager::new(&txn)).await?;
    txn.commit().await
}
```

A tiny ergonomic wrapper: opens a transaction, hands an `SchemaManager` backed by it to the closure, and commits on success (rolls back on error). Carries a `TODO(#26046)` pointing to the sea-orm 2.0 `MigrationTrait::use_transaction()` API that will make this unnecessary.

### `m20240820_081248_add_time_travel_per_table_epoch.rs` — wrap SQLite branches

Both `up()` and `down()` SQLite recreate-table branches are now wrapped with `sqlite_txn`, establishing the pattern for future migrations.

### `src/meta/model/migration/src/lib.rs` — module-level doc block

Documents the atomicity constraint, the `sqlite_txn` convention for SQLite, and the MySQL caveat (implicit DDL commit means MySQL migrations must be idempotent rather than transactional). This is the discoverable reference point for migration authors.

## Not in scope

- Migrating the existing `m20260624` manual `begin()`/`commit()` to use `sqlite_txn` — that migration PR (#26045) is in review; leaving it untouched to avoid churn.
- MySQL migrations: transactional DDL is not possible on MySQL; the doc block covers the idempotency requirement.
- sea-orm-migration 2.0 upgrade: not planned now; the TODO comment tracks it.

## Testing

The `sqlite_txn` helper is exercised indirectly by any test that runs the full migration sequence on the in-memory SQLite backend (`SqlMetaStore::for_test()`). No new unit tests are added since the helper is a thin wrapper over sea-orm's own `begin()`/`commit()`, which are well-tested upstream.
