### PR TITLE
fix(frontend): require superuser for ALTER SYSTEM SET on session params

### DIFF
--- a/src/frontend/src/handler/alter_system.rs
+++ b/src/frontend/src/handler/alter_system.rs
@@ -32,6 +32,15 @@ pub async fn handle_alter_system(
     let meta_client = handler_args.session.env().meta_client();
     let mut builder = RwPgResponse::builder(StatementType::ALTER_SYSTEM);
 
+    // ALTER SYSTEM is always a superuser-only operation, regardless of whether the target
+    // parameter lives in the session-param or system-param namespace.
+    if !handler_args.session.is_super_user() {
+        return Err(ErrorCode::PermissionDenied(
+            "must be superuser to execute ALTER SYSTEM command".to_owned(),
+        )
+        .into());
+    }
+
     // Currently session params are separated from system params. If the param exist in session params, we set it. Otherwise
     // we try to set it as a system param.
     if SessionConfig::contains_param(&param_name) {
@@ -60,12 +69,6 @@ pub async fn handle_alter_system(
             handler_args.session.reset_config(param_name.as_str())?;
         }
     } else {
-        if !handler_args.session.is_super_user() {
-            return Err(ErrorCode::PermissionDenied(
-                "must be superuser to execute ALTER SYSTEM command".to_owned(),
-            )
-            .into());
-        }
         let params = meta_client.set_system_param(param_name, value).await?;
         if let Some(params) = params {
             if params.barrier_interval_ms() >= NOTICE_BARRIER_INTERVAL_MS {


### PR DESCRIPTION
## Problem

`ALTER SYSTEM SET` for **session parameters** bypassed the superuser check. The `is_super_user()` guard only applied to the `else` branch (system parameters). Any non-superuser could change cluster-wide session-param defaults:

```sql
-- Works as a non-superuser (should be forbidden):
ALTER SYSTEM SET enable_join_ordering = false;
```

Root cause in `src/frontend/src/handler/alter_system.rs`:

```rust
if SessionConfig::contains_param(&param_name) {
    // ← no privilege check here
    meta_client.set_session_param(...).await?;
} else {
    if !handler_args.session.is_super_user() { // ← guard only in else branch
        return Err(...);
    }
}
```

Closes #25859.

## Fix

Move the `is_super_user()` check to before the session-param / system-param branching so it applies uniformly to all `ALTER SYSTEM` commands:

```rust
// ALTER SYSTEM is always a superuser-only operation.
if !handler_args.session.is_super_user() {
    return Err(ErrorCode::PermissionDenied(
        "must be superuser to execute ALTER SYSTEM command".to_owned(),
    ).into());
}

if SessionConfig::contains_param(&param_name) {
    // now gated by the check above
    meta_client.set_session_param(...).await?;
} else {
    // redundant check removed
    meta_client.set_system_param(...).await?;
}
```

This matches PostgreSQL semantics: `ALTER SYSTEM` requires superuser unconditionally.

## Testing

The privilege check is exercised by the existing `alter_system.slt` e2e test suite. The change is a one-block guard addition with no logic change to the happy path.
