### PR TITLE
fix(meta): gate ALTER FRAGMENT SET RATE_LIMIT writes by ThrottleType; add Source/FsFetch support

### DIFF
--- a/src/meta/service/src/stream_service.rs
+++ b/src/meta/service/src/stream_service.rs
@@ -231,10 +231,13 @@ impl StreamManagerService for StreamServiceImpl {
                 jobs = [request.id.into()].into_iter().collect();
                 raw_object_id = request.id;
             }
-            // FIXME(kwannoel): specialize for throttle type x target
             (_, ThrottleTarget::Fragment) => {
                 self.metadata_manager
-                    .update_fragment_rate_limit_by_fragment_id(request.id.into(), request.rate)
+                    .update_fragment_rate_limit_by_fragment_id(
+                        request.id.into(),
+                        request.rate,
+                        throttle_type,
+                    )
                     .await?;
                 let fragment_id = request.id.into();
                 fragments = [fragment_id].into_iter().collect();

--- a/src/meta/src/controller/streaming_job.rs
+++ b/src/meta/src/controller/streaming_job.rs
@@ -51,6 +51,7 @@ use risingwave_meta_model::user_privilege::Action;
 use risingwave_meta_model::*;
 use risingwave_pb::catalog::table::PbEngine;
 use risingwave_pb::catalog::{PbConnection, PbCreateType, PbTable};
+use risingwave_pb::common::ThrottleType;
 use risingwave_pb::ddl_service::streaming_job_resource_type;
 use risingwave_pb::meta::alter_connector_props_request::AlterIcebergTableIds;
 use risingwave_pb::meta::list_rate_limits_response::RateLimitInfo;
@@ -65,7 +66,6 @@ use risingwave_pb::plan_common::source_refresh_mode::{
 };
 use risingwave_pb::secret::PbSecretRef;
 use risingwave_pb::stream_plan::stream_fragment_graph::Parallelism;
-use risingwave_pb::common::ThrottleType;
 use risingwave_pb::stream_plan::stream_node::PbNodeBody;
 use risingwave_pb::stream_plan::{PbSinkLogStoreType, PbStreamNode};
 use risingwave_pb::user::PbUserInfo;

--- a/src/meta/src/controller/streaming_job.rs
+++ b/src/meta/src/controller/streaming_job.rs
@@ -3274,55 +3274,55 @@ impl CatalogController {
         rate_limit: Option<u32>,
         throttle_type: ThrottleType,
     ) -> MetaResult<()> {
-        let update_rate_limit = move |_fragment_type_mask: FragmentTypeMask,
-                                      stream_node: &mut PbStreamNode| {
-            let mut found = false;
-            visit_stream_node_mut(stream_node, |node| match throttle_type {
-                ThrottleType::Source => {
-                    if let PbNodeBody::Source(node) = node
-                        && let Some(node_inner) = &mut node.source_inner
-                    {
-                        node_inner.rate_limit = rate_limit;
-                        found = true;
+        let update_rate_limit =
+            move |_fragment_type_mask: FragmentTypeMask, stream_node: &mut PbStreamNode| {
+                let mut found = false;
+                visit_stream_node_mut(stream_node, |node| match throttle_type {
+                    ThrottleType::Source => {
+                        if let PbNodeBody::Source(node) = node
+                            && let Some(node_inner) = &mut node.source_inner
+                        {
+                            node_inner.rate_limit = rate_limit;
+                            found = true;
+                        }
+                        if let PbNodeBody::StreamFsFetch(node) = node
+                            && let Some(node_inner) = &mut node.node_inner
+                        {
+                            node_inner.rate_limit = rate_limit;
+                            found = true;
+                        }
                     }
-                    if let PbNodeBody::StreamFsFetch(node) = node
-                        && let Some(node_inner) = &mut node.node_inner
-                    {
-                        node_inner.rate_limit = rate_limit;
-                        found = true;
+                    ThrottleType::Backfill => match node {
+                        PbNodeBody::StreamCdcScan(node) => {
+                            node.rate_limit = rate_limit;
+                            found = true;
+                        }
+                        PbNodeBody::StreamScan(node) => {
+                            node.rate_limit = rate_limit;
+                            found = true;
+                        }
+                        PbNodeBody::SourceBackfill(node) => {
+                            node.rate_limit = rate_limit;
+                            found = true;
+                        }
+                        _ => {}
+                    },
+                    ThrottleType::Sink => {
+                        if let PbNodeBody::Sink(node) = node {
+                            node.rate_limit = rate_limit;
+                            found = true;
+                        }
                     }
-                }
-                ThrottleType::Backfill => match node {
-                    PbNodeBody::StreamCdcScan(node) => {
-                        node.rate_limit = rate_limit;
-                        found = true;
+                    ThrottleType::Dml => {
+                        if let PbNodeBody::Dml(node) = node {
+                            node.rate_limit = rate_limit;
+                            found = true;
+                        }
                     }
-                    PbNodeBody::StreamScan(node) => {
-                        node.rate_limit = rate_limit;
-                        found = true;
-                    }
-                    PbNodeBody::SourceBackfill(node) => {
-                        node.rate_limit = rate_limit;
-                        found = true;
-                    }
-                    _ => {}
-                },
-                ThrottleType::Sink => {
-                    if let PbNodeBody::Sink(node) = node {
-                        node.rate_limit = rate_limit;
-                        found = true;
-                    }
-                }
-                ThrottleType::Dml => {
-                    if let PbNodeBody::Dml(node) = node {
-                        node.rate_limit = rate_limit;
-                        found = true;
-                    }
-                }
-                ThrottleType::Unspecified => {}
-            });
-            found
-        };
+                    ThrottleType::Unspecified => {}
+                });
+                found
+            };
         self.mutate_fragment_by_fragment_id(fragment_id, update_rate_limit, "fragment not found")
             .await
     }

--- a/src/meta/src/controller/streaming_job.rs
+++ b/src/meta/src/controller/streaming_job.rs
@@ -65,6 +65,7 @@ use risingwave_pb::plan_common::source_refresh_mode::{
 };
 use risingwave_pb::secret::PbSecretRef;
 use risingwave_pb::stream_plan::stream_fragment_graph::Parallelism;
+use risingwave_pb::common::ThrottleType;
 use risingwave_pb::stream_plan::stream_node::PbNodeBody;
 use risingwave_pb::stream_plan::{PbSinkLogStoreType, PbStreamNode};
 use risingwave_pb::user::PbUserInfo;
@@ -3271,39 +3272,55 @@ impl CatalogController {
         &self,
         fragment_id: FragmentId,
         rate_limit: Option<u32>,
+        throttle_type: ThrottleType,
     ) -> MetaResult<()> {
-        let update_rate_limit = |fragment_type_mask: FragmentTypeMask,
-                                 stream_node: &mut PbStreamNode| {
+        let update_rate_limit = move |_fragment_type_mask: FragmentTypeMask,
+                                      stream_node: &mut PbStreamNode| {
             let mut found = false;
-            if fragment_type_mask.contains_any(
-                FragmentTypeFlag::dml_rate_limit_fragments()
-                    .chain(FragmentTypeFlag::sink_rate_limit_fragments())
-                    .chain(FragmentTypeFlag::backfill_rate_limit_fragments())
-                    .chain(FragmentTypeFlag::source_rate_limit_fragments()),
-            ) {
-                visit_stream_node_mut(stream_node, |node| {
-                    if let PbNodeBody::Dml(node) = node {
+            visit_stream_node_mut(stream_node, |node| match throttle_type {
+                ThrottleType::Source => {
+                    if let PbNodeBody::Source(node) = node
+                        && let Some(node_inner) = &mut node.source_inner
+                    {
+                        node_inner.rate_limit = rate_limit;
+                        found = true;
+                    }
+                    if let PbNodeBody::StreamFsFetch(node) = node
+                        && let Some(node_inner) = &mut node.node_inner
+                    {
+                        node_inner.rate_limit = rate_limit;
+                        found = true;
+                    }
+                }
+                ThrottleType::Backfill => match node {
+                    PbNodeBody::StreamCdcScan(node) => {
                         node.rate_limit = rate_limit;
                         found = true;
                     }
+                    PbNodeBody::StreamScan(node) => {
+                        node.rate_limit = rate_limit;
+                        found = true;
+                    }
+                    PbNodeBody::SourceBackfill(node) => {
+                        node.rate_limit = rate_limit;
+                        found = true;
+                    }
+                    _ => {}
+                },
+                ThrottleType::Sink => {
                     if let PbNodeBody::Sink(node) = node {
                         node.rate_limit = rate_limit;
                         found = true;
                     }
-                    if let PbNodeBody::StreamCdcScan(node) = node {
+                }
+                ThrottleType::Dml => {
+                    if let PbNodeBody::Dml(node) = node {
                         node.rate_limit = rate_limit;
                         found = true;
                     }
-                    if let PbNodeBody::StreamScan(node) = node {
-                        node.rate_limit = rate_limit;
-                        found = true;
-                    }
-                    if let PbNodeBody::SourceBackfill(node) = node {
-                        node.rate_limit = rate_limit;
-                        found = true;
-                    }
-                });
-            }
+                }
+                ThrottleType::Unspecified => {}
+            });
             found
         };
         self.mutate_fragment_by_fragment_id(fragment_id, update_rate_limit, "fragment not found")

--- a/src/meta/src/manager/metadata.rs
+++ b/src/meta/src/manager/metadata.rs
@@ -23,7 +23,7 @@ use risingwave_meta_model::refresh_job::{self, RefreshState};
 use risingwave_meta_model::{SinkId, SourceId, WorkerId};
 use risingwave_pb::catalog::{PbSource, PbTable};
 use risingwave_pb::common::worker_node::{PbResource, Property as AddNodeProperty, State};
-use risingwave_pb::common::{HostAddress, PbWorkerNode, PbWorkerType, WorkerNode, WorkerType};
+use risingwave_pb::common::{HostAddress, PbWorkerNode, PbWorkerType, ThrottleType, WorkerNode, WorkerType};
 use risingwave_pb::meta::list_rate_limits_response::RateLimitInfo;
 use risingwave_pb::stream_plan::{PbDispatcherType, PbStreamScanType};
 use sea_orm::TransactionTrait;
@@ -601,9 +601,10 @@ impl MetadataManager {
         &self,
         fragment_id: FragmentId,
         rate_limit: Option<u32>,
+        throttle_type: ThrottleType,
     ) -> MetaResult<()> {
         self.catalog_controller
-            .update_fragment_rate_limit_by_fragment_id(fragment_id as _, rate_limit)
+            .update_fragment_rate_limit_by_fragment_id(fragment_id as _, rate_limit, throttle_type)
             .await
     }
 

--- a/src/meta/src/manager/metadata.rs
+++ b/src/meta/src/manager/metadata.rs
@@ -23,7 +23,9 @@ use risingwave_meta_model::refresh_job::{self, RefreshState};
 use risingwave_meta_model::{SinkId, SourceId, WorkerId};
 use risingwave_pb::catalog::{PbSource, PbTable};
 use risingwave_pb::common::worker_node::{PbResource, Property as AddNodeProperty, State};
-use risingwave_pb::common::{HostAddress, PbWorkerNode, PbWorkerType, ThrottleType, WorkerNode, WorkerType};
+use risingwave_pb::common::{
+    HostAddress, PbWorkerNode, PbWorkerType, ThrottleType, WorkerNode, WorkerType,
+};
 use risingwave_pb::meta::list_rate_limits_response::RateLimitInfo;
 use risingwave_pb::stream_plan::{PbDispatcherType, PbStreamScanType};
 use sea_orm::TransactionTrait;


### PR DESCRIPTION
## Problem

`ALTER FRAGMENT <id> SET RATE_LIMIT TO <v>` (via `risectl`) called `update_fragment_rate_limit_by_fragment_id`, which had two bugs:

### Bug 1 — wrong-target DB writes

The function unconditionally rewrote `rate_limit` on **every** rate-limit-capable node type (`Dml`, `Sink`, `StreamCdcScan`, `StreamScan`, `SourceBackfill`) regardless of which `ThrottleType` the caller specified. A user running:

```
risectl meta alter-rate-limit --fragment-id <dml_frag_id> --rate 0
```

would silently write `rate_limit = 0` to _all_ node types present in that fragment — not just the `Dml` node. The runtime barrier mutation (`ThrottleConfig`) correctly targets only the requested type, so after the next reschedule/recovery the actor would materialise with the wrong rate limit from the DB.

### Bug 2 — Source / FsFetch completely skipped

`PbNodeBody::Source` and `PbNodeBody::StreamFsFetch` were absent from the visitor, so targeting a source fragment was a silent no-op: DB state unchanged, running actor unchanged.

The `// FIXME(kwannoel): specialize for throttle type x target` comment in `stream_service.rs` already tracked this gap.

Closes #25561.

## Root Cause

`update_fragment_rate_limit_by_fragment_id` pre-dates the per-target helpers (`update_source_rate_limit_by_source_id`, `update_backfill_rate_limit_by_job_id`, etc.) and was written as a "best-effort, node-type-agnostic" updater. The `ThrottleType` discipline those helpers follow was never retrofitted onto it.

The runtime side (`barrier/info.rs`) already used the correct `ThrottleType`-gated `match` — this PR brings the DB side in line with it.

## Changes

**`src/meta/src/controller/streaming_job.rs`**

Add `throttle_type: ThrottleType` parameter. Replace the unconditional multi-node visitor with a `ThrottleType`-gated match:

```
Source     → Source.source_inner.rate_limit + StreamFsFetch.node_inner.rate_limit
Backfill   → StreamCdcScan / StreamScan / SourceBackfill .rate_limit
Sink       → Sink.rate_limit
Dml        → Dml.rate_limit
Unspecified → no-op
```

**`src/meta/src/manager/metadata.rs`**

Pass `ThrottleType` through to the controller.

**`src/meta/service/src/stream_service.rs`**

Pass `throttle_type` (already extracted from the request) to `update_fragment_rate_limit_by_fragment_id`. Remove the `// FIXME(kwannoel)` comment — the specialization is done.

## Testing

`ALTER FRAGMENT … SET RATE_LIMIT` is a `risectl` debugging hook. The change is a correctness fix with no behaviour change on the happy path when `ThrottleType` matches the target fragment's node type (which is the only case a user would ever trigger intentionally). No new unit tests are added; the existing rate-limit integration tests cover the per-target helpers.
