### PR TITLE
fix(frontend): skip cancel RPC for unscheduled tasks to prevent frontend panic

### DIFF
--- a/src/frontend/src/scheduler/distributed/stage.rs
+++ b/src/frontend/src/scheduler/distributed/stage.rs
@@ -892,7 +892,11 @@ impl StageRunner {
         for (task, task_status) in &*self.tasks {
             // 1. Collect task info and client.
             let loc = &task_status.get_status().location;
-            let addr = loc.as_ref().expect("Get address should not fail");
+            let Some(addr) = loc.as_ref() else {
+                // Task was inserted but never successfully scheduled to a worker (location is
+                // still None). There is nothing to cancel on the compute side; skip it.
+                continue;
+            };
             let client = self
                 .compute_client_pool
                 .get_by_addr(HostAddr::from(addr))


### PR DESCRIPTION
## Problem

Closes #26062

When a distributed batch query is cancelled (e.g. by `statement_timeout` or `pg_cancel_backend`), `cancel_all_scheduled_tasks` iterates every task entry and unwraps the task's `location`. Tasks that were inserted into `self.tasks` but never successfully assigned to a worker have `location = None`. The `expect("Get address should not fail")` on that `None` value panics the entire frontend process, dropping all client sessions with `SSL connection has been closed unexpectedly`.

Reproduced on `main` at `src/frontend/src/scheduler/distributed/stage.rs:895`.

## Solution

Replace `.expect()` with `let Some(addr) = loc.as_ref() else { continue; }`. Tasks with `location = None` were never scheduled to any compute node, so there is nothing to cancel on the compute side — silently skipping them is correct.

## Test plan

- [ ] Existing unit tests pass
- [ ] Manually reproduce: run a heavy distributed query, kill the compute node before scheduling completes, trigger `statement_timeout` — frontend should no longer panic

🤖 Generated with [Claude Code](https://claude.ai/claude-code)