### PR TITLE
fix(cdc): use microseconds for TIME columns when debezium.time.precision.mode=connect

### DIFF
--- a/src/stream/src/executor/backfill/cdc/cdc_backfill.rs
+++ b/src/stream/src/executor/backfill/cdc/cdc_backfill.rs
@@ -320,7 +320,9 @@ impl<S: StateStore> CdcBackfillExecutor<S> {
             .get("debezium.time.precision.mode")
             .map(|v| v == "connect")
             .unwrap_or(false)
-            .then_some(TimeHandling::Milli);
+            // Debezium `connect` mode encodes TIME columns in microseconds (not milliseconds).
+            // See https://debezium.io/documentation/reference/stable/connectors/mysql.html
+            .then_some(TimeHandling::Micro);
         let bigint_unsigned_handling: Option<BigintUnsignedHandlingMode> = self
             .properties
             .get("debezium.bigint.unsigned.handling.mode")


### PR DESCRIPTION
## Problem

Closes #26037

When `debezium.time.precision.mode = connect` is set for a MySQL CDC source, `CdcBackfillExecutor` used `TimeHandling::Milli` for TIME columns. However, per the [Debezium MySQL connector docs](https://debezium.io/documentation/reference/stable/connectors/mysql.html), `TIME[(M)]` values are encoded in **microseconds** when `time.precision.mode=connect`, not milliseconds.

This caused ingested TIME values to be off by 1000x (e.g. `12:00:00` ingested as `00:00:00.012` instead of `00:00:12`).

## Solution

Change `TimeHandling::Milli` → `TimeHandling::Micro` on the `time_handling` assignment in `cdc_backfill.rs`. Added a comment referencing the Debezium documentation.

Note: `TimestampHandling::Milli` and `TimestamptzHandling::Milli` for the same `connect` mode remain unchanged — TIMESTAMP and DATETIME are correctly milliseconds in Debezium connect mode; only TIME is microseconds.

## Test plan

- [ ] Existing CDC unit tests pass
- [ ] Manual: create MySQL CDC source with `debezium.time.precision.mode=connect`, verify TIME column values are correct

🤖 Generated with [Claude Code](https://claude.ai/claude-code)