### PR TITLE
fix(frontend): handle table-source definition in REFRESH SCHEMA to prevent panic

### DIFF
--- a/src/frontend/src/handler/alter_source_with_sr.rs
+++ b/src/frontend/src/handler/alter_source_with_sr.rs
@@ -194,11 +194,23 @@ pub async fn refresh_sr_and_get_columns_diff(
 
 fn get_format_encode_from_source(source: &SourceCatalog) -> Result<FormatEncodeOptions> {
     let stmt = source.create_sql_ast()?;
-    let Statement::CreateSource {
-        stmt: CreateSourceStatement { format_encode, .. },
-    } = stmt
-    else {
-        unreachable!()
+    let format_encode = match stmt {
+        Statement::CreateSource {
+            stmt: CreateSourceStatement { format_encode, .. },
+        } => format_encode,
+        // Sources that back a `CREATE TABLE … FORMAT … ENCODE …` statement store the
+        // original `CREATE TABLE` SQL as their definition.  Extract format_encode from it.
+        Statement::CreateTable {
+            format_encode: Some(format_encode),
+            ..
+        } => format_encode,
+        stmt => {
+            return Err(ErrorCode::InternalError(format!(
+                "expected CREATE SOURCE or CREATE TABLE with FORMAT/ENCODE, got: {:?}",
+                stmt
+            ))
+            .into());
+        }
     };
     Ok(format_encode.into_v2_with_warning())
 }


### PR DESCRIPTION
## Problem

Closes #25862

`ALTER SOURCE <name> REFRESH SCHEMA` (and `handler_refresh_schema`) calls `get_format_encode_from_source`, which parses the source's stored definition SQL and pattern-matches `Statement::CreateSource { … }`. For sources that were created implicitly by `CREATE TABLE … FORMAT … ENCODE …`, the stored definition is a `CREATE TABLE` statement. The match fell through to `unreachable!()`, panicking the frontend:

```
thread 'rw-main' panicked at src/frontend/src/handler/alter_source_with_sr.rs:201:9:
internal error: entered unreachable code
```

## Solution

Add a `Statement::CreateTable { format_encode: Some(format_encode), .. }` arm to `get_format_encode_from_source`, mirroring what `alter_definition_format_encode` (the function called later in the same flow) already handles. Truly unexpected statement kinds now return a proper `InternalError` instead of a panic.

## Test plan

- [ ] Existing alter-source tests pass  
- [ ] Manual: create a table with Avro/SR connector, then call `ALTER SOURCE … REFRESH SCHEMA` — should not panic

🤖 Generated with [Claude Code](https://claude.ai/claude-code)