### PR TITLE
fix(cdc): restart snapshot read correctly

### DIFF
--- a/e2e_test/source_inline/cdc/postgres/postgres_schema_check_and_schema_change.slt
+++ b/e2e_test/source_inline/cdc/postgres/postgres_schema_check_and_schema_change.slt
@@ -4,8 +4,8 @@ system ok
 psql -c "
     DROP TABLE IF EXISTS t;
     CREATE EXTENSION IF NOT EXISTS citext;
-    DROP TYPE IF EXISTS mood_enum;
-    CREATE TYPE mood_enum AS ENUM ('happy', 'sad', 'angry');
+    DROP TYPE IF EXISTS mood_enum_2;
+    CREATE TYPE mood_enum_2 AS ENUM ('happy', 'sad', 'angry');
     CREATE TABLE t (
         v1 bigserial PRIMARY KEY,
         v2 jsonb NOT NULL,
@@ -48,7 +48,7 @@ psql -c "
         v39 macaddr8,
         v40 int[],
         v41 bit(1),
-        v42 mood_enum,
+        v42 mood_enum_2,
         v43 smallserial,
         v44 serial,
         v45 bigserial,
@@ -427,7 +427,7 @@ psql -c "
     DROP TABLE IF EXISTS t_bit;
     DROP TABLE IF EXISTS t_hstore;
     DROP TABLE IF EXISTS t_bit8;
-    DROP TYPE IF EXISTS mood_enum;
+    DROP TYPE IF EXISTS mood_enum_2;
     DROP EXTENSION IF EXISTS citext;
     DROP EXTENSION IF EXISTS ltree;
     DROP EXTENSION IF EXISTS hstore;

--- a/src/stream/src/executor/backfill/cdc/cdc_backfill.rs
+++ b/src/stream/src/executor/backfill/cdc/cdc_backfill.rs
@@ -578,7 +578,7 @@ impl<S: StateStore> CdcBackfillExecutor<S> {
 
                                     // when processing a barrier, check whether can start a new snapshot
                                     // if the number of barriers reaches the snapshot interval
-                                    if can_start_new_snapshot {
+                                    if can_start_new_snapshot || needs_rebuild_snapshot {
                                         // staging the barrier
                                         pending_barrier = Some(barrier);
                                         tracing::debug!(
@@ -634,10 +634,6 @@ impl<S: StateStore> CdcBackfillExecutor<S> {
 
                                         // emit barrier and continue consume the backfill stream
                                         yield Message::Barrier(barrier);
-
-                                        if needs_rebuild_snapshot {
-                                            continue 'backfill_loop;
-                                        }
                                     }
                                 }
                                 Message::Chunk(chunk) => {

--- a/src/stream/src/executor/backfill/cdc/cdc_backfill.rs
+++ b/src/stream/src/executor/backfill/cdc/cdc_backfill.rs
@@ -265,7 +265,8 @@ impl<S: StateStore> CdcBackfillExecutor<S> {
         let first_barrier_epoch = first_barrier.epoch;
         // The first barrier message should be propagated.
         yield Message::Barrier(first_barrier);
-        let mut rate_limit_to_zero = self.rate_limit_rps.is_some_and(|val| val == 0);
+        let mut should_bypass_snapshot_stream_patch =
+            self.rate_limit_rps.is_some_and(|val| val == 0);
 
         // Check whether this parallelism has been assigned splits,
         // if not, we should bypass the backfill directly.
@@ -552,10 +553,12 @@ impl<S: StateStore> CdcBackfillExecutor<S> {
                                                         == ThrottleType::Backfill
                                                     && entry.rate_limit != self.rate_limit_rps
                                                 {
-                                                    self.rate_limit_rps = entry.rate_limit;
-                                                    rate_limit_to_zero = self
+                                                    // If self.rate_limit_rps is 0, the snapshot stream does not establish a snapshot_read.
+                                                    // Consequently, the later snapshot stream patch is bypassed.
+                                                    should_bypass_snapshot_stream_patch = self
                                                         .rate_limit_rps
                                                         .is_some_and(|val| val == 0);
+                                                    self.rate_limit_rps = entry.rate_limit;
                                                     needs_rebuild_snapshot = true;
                                                 }
                                             }
@@ -724,15 +727,17 @@ impl<S: StateStore> CdcBackfillExecutor<S> {
                 assert!(pending_barrier.is_some(), "pending_barrier must exist");
                 let pending_barrier = pending_barrier.unwrap();
 
+                // The snapshot stream patch:
                 // Here we have to ensure the snapshot stream is consumed at least once,
                 // since the barrier event can kick in anytime.
                 // Otherwise, the result set of the new snapshot stream may become empty.
                 // It maybe a cancellation bug of the mysql driver.
                 let (_, mut snapshot_stream) = backfill_stream.into_inner();
-
-                // skip consume the snapshot stream if it is paused or rate limit to 0
-                if !is_snapshot_paused
-                    && !rate_limit_to_zero
+                // Resume the snapshot stream so that the snapshot stream patch won't block.
+                if !should_bypass_snapshot_stream_patch && is_snapshot_paused {
+                    snapshot_valve.resume();
+                }
+                if !should_bypass_snapshot_stream_patch
                     && let Some(msg) = snapshot_stream
                         .next()
                         .instrument_await("consume_snapshot_stream_once")

--- a/src/stream/src/executor/backfill/cdc/cdc_backfill.rs
+++ b/src/stream/src/executor/backfill/cdc/cdc_backfill.rs
@@ -265,8 +265,6 @@ impl<S: StateStore> CdcBackfillExecutor<S> {
         let first_barrier_epoch = first_barrier.epoch;
         // The first barrier message should be propagated.
         yield Message::Barrier(first_barrier);
-        let mut should_bypass_snapshot_stream_patch =
-            self.rate_limit_rps.is_some_and(|val| val == 0);
 
         // Check whether this parallelism has been assigned splits,
         // if not, we should bypass the backfill directly.
@@ -490,6 +488,8 @@ impl<S: StateStore> CdcBackfillExecutor<S> {
             let mut upstream_chunk_buffer: Vec<StreamChunk> = vec![];
 
             'backfill_loop: loop {
+                let mut should_bypass_snapshot_stream_patch =
+                    self.rate_limit_rps.is_some_and(|val| val == 0);
                 let left_upstream = upstream.by_ref().map(Either::Left);
 
                 let mut snapshot_read_row_cnt: usize = 0;

--- a/src/stream/src/executor/backfill/cdc/cdc_backfill.rs
+++ b/src/stream/src/executor/backfill/cdc/cdc_backfill.rs
@@ -776,6 +776,9 @@ impl<S: StateStore> CdcBackfillExecutor<S> {
                             // end of backfill loop, since backfill has finished
                             break 'backfill_loop;
                         }
+                        Some(_) if is_snapshot_paused => {
+                            // Since the snapshot stream is paused, drop the chunk.
+                        }
                         Some(chunk) => {
                             // Raise the current pk position.
                             current_pk_pos = Some(get_new_pos(&chunk, &pk_indices));


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

In CdcBackfillExecutor it's required that "[the snapshot stream is consumed at least once](https://github.com/risingwavelabs/risingwave/blob/02a62d6a46f911c0456e57cf6ee55c50d8150712/src/stream/src/executor/backfill/cdc/cdc_backfill.rs#L622)" prior to recreating it.
This PR fixes a bug where altering the CDC backfill rate limit does not follow this rule, leading to potential correctness issues.

The issue has existed since introduction of CDC backfill rate limit.

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
