### PR TITLE
feat(frontend): support prepared statements in simple query mode

### DIFF
--- a/e2e_test/misc/prepared_statement.slt
+++ b/e2e_test/misc/prepared_statement.slt
@@ -1,0 +1,133 @@
+statement ok
+prepare ps_math(int) as select $1 + 1;
+
+query I
+execute ps_math(41);
+----
+42
+
+statement ok
+deallocate ps_math;
+
+statement ok
+deallocate ps_math;
+
+statement error prepared statement
+execute ps_math(41);
+
+statement ok
+create table t_prepare_simple_query(v int);
+
+statement ok
+prepare ps_insert(int) as insert into t_prepare_simple_query values ($1);
+
+statement ok
+execute ps_insert(7);
+
+statement ok
+flush;
+
+query I
+select v from t_prepare_simple_query order by v;
+----
+7
+
+statement ok
+prepare ps_update(int, int) as update t_prepare_simple_query set v = $1 where v = $2;
+
+statement ok
+execute ps_update(9, 7);
+
+statement ok
+flush;
+
+query I
+select v from t_prepare_simple_query order by v;
+----
+9
+
+statement ok
+prepare ps_delete(int) as delete from t_prepare_simple_query where v = $1;
+
+statement ok
+execute ps_delete(9);
+
+statement ok
+flush;
+
+query I
+select count(*)::int from t_prepare_simple_query;
+----
+0
+
+statement ok
+prepare ps_text(varchar) as select $1 || '-ok';
+
+query T
+execute ps_text('rw');
+----
+rw-ok
+
+statement ok
+prepare ps_null(int) as select $1 is null;
+
+query B
+execute ps_null(null);
+----
+t
+
+statement ok
+prepare ps_bool(bool) as select $1;
+
+query B
+execute ps_bool(false);
+----
+f
+
+statement ok
+prepare ps_date(date) as select $1::varchar;
+
+query T
+execute ps_date(date '2026-06-29');
+----
+2026-06-29
+
+statement ok
+prepare ps_negative(int) as select $1;
+
+query I
+execute ps_negative(-7);
+----
+-7
+
+statement ok
+start transaction read only;
+
+query I
+execute ps_negative(5);
+----
+5
+
+statement error read-only transaction
+execute ps_insert(8);
+
+statement ok
+commit;
+
+statement error already exists
+prepare ps_null(int) as select $1;
+
+statement error wrong number of parameters
+execute ps_null;
+
+statement error unsupported EXECUTE parameter expression
+execute ps_null(1 + 2);
+
+statement error not supported
+prepare ps_ddl as create table t_prepare_rejected(v int);
+
+statement ok
+deallocate all;
+
+statement ok
+drop table t_prepare_simple_query;

--- a/src/frontend/src/handler/mod.rs
+++ b/src/frontend/src/handler/mod.rs
@@ -1646,9 +1646,26 @@ pub async fn handle(
             name,
             data_types,
             statement,
-        } => prepared_statement::handle_prepare(name, data_types, statement),
+        } => {
+            prepared_statement::handle_prepare(
+                handler_args.session.clone(),
+                name,
+                data_types,
+                statement,
+            )
+            .await
+        }
+        Statement::Execute { name, parameters } => {
+            prepared_statement::handle_execute(
+                handler_args.session.clone(),
+                name,
+                parameters,
+                formats,
+            )
+            .await
+        }
         Statement::Deallocate { name, prepare } => {
-            prepared_statement::handle_deallocate(name, prepare)
+            prepared_statement::handle_deallocate(handler_args.session.clone(), name, prepare)
         }
         Statement::Vacuum { object_name, full } => {
             vacuum::handle_vacuum(handler_args, object_name, full).await

--- a/src/frontend/src/handler/prepared_statement.rs
+++ b/src/frontend/src/handler/prepared_statement.rs
@@ -12,34 +12,226 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::sync::Arc;
+
+use bytes::Bytes;
 use pgwire::pg_response::StatementType;
-use risingwave_sqlparser::ast::{DataType, Ident, Statement};
+use pgwire::types::Format;
+use risingwave_sqlparser::ast::{
+    DataType as AstDataType, Expr, Ident, Statement, UnaryOperator, Value,
+};
 
-use crate::handler::RwPgResponse;
+use crate::bind_data_type;
+use crate::error::{ErrorCode, Result};
+use crate::handler::extended_handle::{self, Portal, PrepareStatement};
+use crate::handler::{HandlerArgs, RwPgResponse, query};
+use crate::session::SessionImpl;
 
-pub fn handle_prepare(
-    _name: Ident,
-    _data_types: Vec<DataType>,
-    _statement: Box<Statement>,
-) -> crate::error::Result<RwPgResponse> {
-    const MESSAGE: &str = "\
-        `PREPARE` is not supported yet.\n\
-        For compatibility, this statement will still succeed but no changes are actually made.";
+pub async fn handle_prepare(
+    session: Arc<SessionImpl>,
+    name: Ident,
+    data_types: Vec<AstDataType>,
+    statement: Box<Statement>,
+) -> Result<RwPgResponse> {
+    let statement = *statement;
+    ensure_supported_prepare_statement(&statement)?;
 
-    Ok(RwPgResponse::builder(StatementType::PREPARE)
-        .notice(MESSAGE)
-        .into())
+    let specified_param_types = data_types
+        .iter()
+        .map(bind_data_type)
+        .map(|data_type| data_type.map(Some))
+        .collect::<Result<Vec<_>>>()?;
+    let prepare_statement =
+        extended_handle::handle_parse(session.clone(), statement, specified_param_types).await?;
+    if !matches!(prepare_statement, PrepareStatement::Prepared(_)) {
+        return Err(ErrorCode::NotSupported(
+            "SQL PREPARE only supports query, INSERT, UPDATE, and DELETE statements".into(),
+            "Use the extended query protocol for other prepared statement forms.".into(),
+        )
+        .into());
+    }
+
+    session.create_simple_query_prepared_statement(name.real_value(), prepare_statement)?;
+
+    Ok(RwPgResponse::builder(StatementType::PREPARE).into())
 }
 
 pub fn handle_deallocate(
-    _name: Option<Ident>,
+    session: Arc<SessionImpl>,
+    name: Option<Ident>,
     _prepare: bool,
-) -> crate::error::Result<RwPgResponse> {
-    const MESSAGE: &str = "\
-        `DEALLOCATE` is not supported yet.\n\
-        For compatibility, this statement will still succeed but no changes are actually made.";
+) -> Result<RwPgResponse> {
+    if let Some(name) = name {
+        session.drop_simple_query_prepared_statement(&name.real_value());
+    } else {
+        session.drop_all_simple_query_prepared_statements();
+    }
 
-    Ok(RwPgResponse::builder(StatementType::DEALLOCATE)
-        .notice(MESSAGE)
+    Ok(RwPgResponse::builder(StatementType::DEALLOCATE).into())
+}
+
+pub async fn handle_execute(
+    session: Arc<SessionImpl>,
+    name: Ident,
+    parameters: Vec<Expr>,
+    result_formats: Vec<Format>,
+) -> Result<RwPgResponse> {
+    let name = name.real_value();
+    let prepare_statement = session.get_simple_query_prepared_statement(&name)?;
+    let expected_parameter_count = match &prepare_statement {
+        PrepareStatement::Prepared(prepared) => prepared.bound_result.param_types.len(),
+        PrepareStatement::Empty | PrepareStatement::PureStatement(_) => {
+            return Err(ErrorCode::NotSupported(
+                "SQL EXECUTE only supports prepared query, INSERT, UPDATE, and DELETE statements"
+                    .into(),
+                "Pure prepared statements are not supported in simple query mode.".into(),
+            )
+            .into());
+        }
+    };
+    let params = convert_execute_parameters(&parameters, expected_parameter_count)?;
+    let portal = extended_handle::handle_bind(
+        prepare_statement,
+        params,
+        vec![Format::Text],
+        result_formats,
+    )?;
+
+    let Portal::Portal(portal) = portal else {
+        return Err(ErrorCode::NotSupported(
+            "SQL EXECUTE only supports prepared query, INSERT, UPDATE, and DELETE statements"
+                .into(),
+            "Pure prepared statements are not supported in simple query mode.".into(),
+        )
+        .into());
+    };
+
+    let sql = Arc::from(portal.statement.to_string());
+    let handler_args = HandlerArgs::new(session, &portal.statement, sql)?;
+    query::handle_execute(handler_args, portal).await
+}
+
+fn ensure_supported_prepare_statement(statement: &Statement) -> Result<()> {
+    if matches!(
+        statement,
+        Statement::Query(_)
+            | Statement::Insert { .. }
+            | Statement::Update { .. }
+            | Statement::Delete { .. }
+    ) {
+        Ok(())
+    } else {
+        Err(ErrorCode::NotSupported(
+            "SQL PREPARE only supports query, INSERT, UPDATE, and DELETE statements".into(),
+            "Other prepared statement forms are not supported in simple query mode.".into(),
+        )
         .into())
+    }
+}
+
+fn convert_execute_parameters(
+    parameters: &[Expr],
+    expected_parameter_count: usize,
+) -> Result<Vec<Option<Bytes>>> {
+    if parameters.len() != expected_parameter_count {
+        return Err(ErrorCode::BindError(format!(
+            "wrong number of parameters for prepared statement: expected {}, got {}",
+            expected_parameter_count,
+            parameters.len()
+        ))
+        .into());
+    }
+
+    parameters
+        .iter()
+        .map(execute_parameter_to_text)
+        .collect::<Result<Vec<_>>>()
+}
+
+fn execute_parameter_to_text(expr: &Expr) -> Result<Option<Bytes>> {
+    Ok(match expr {
+        Expr::Nested(inner) => return execute_parameter_to_text(inner),
+        Expr::Value(Value::Null) => None,
+        Expr::Value(Value::Number(value)) | Expr::Value(Value::SingleQuotedString(value)) => {
+            Some(Bytes::from(value.clone()))
+        }
+        Expr::Value(Value::Boolean(value)) => {
+            Some(Bytes::from(if *value { "true" } else { "false" }))
+        }
+        Expr::TypedString { value, .. } => Some(Bytes::from(value.clone())),
+        Expr::UnaryOp { op, expr } => match (op, expr.as_ref()) {
+            (UnaryOperator::Plus, Expr::Value(Value::Number(value))) => {
+                Some(Bytes::from(value.clone()))
+            }
+            (UnaryOperator::Minus, Expr::Value(Value::Number(value))) => {
+                Some(Bytes::from(format!("-{}", value)))
+            }
+            _ => return unsupported_execute_parameter(expr),
+        },
+        _ => return unsupported_execute_parameter(expr),
+    })
+}
+
+fn unsupported_execute_parameter<T>(expr: &Expr) -> Result<T> {
+    Err(ErrorCode::BindError(format!(
+        "unsupported EXECUTE parameter expression: {}",
+        expr
+    ))
+    .into())
+}
+
+#[cfg(test)]
+mod tests {
+    use risingwave_sqlparser::ast::{DataType, Expr, UnaryOperator, Value};
+
+    use super::convert_execute_parameters;
+
+    #[test]
+    fn convert_execute_parameters_accepts_supported_literals() {
+        let params = convert_execute_parameters(
+            &[
+                Expr::Value(Value::Number("42".into())),
+                Expr::Value(Value::SingleQuotedString("rw".into())),
+                Expr::Value(Value::Boolean(true)),
+                Expr::Value(Value::Null),
+                Expr::TypedString {
+                    data_type: DataType::Date,
+                    value: "2026-06-29".into(),
+                },
+                Expr::UnaryOp {
+                    op: UnaryOperator::Minus,
+                    expr: Box::new(Expr::Value(Value::Number("7".into()))),
+                },
+            ],
+            6,
+        )
+        .unwrap();
+
+        assert_eq!(params[0].as_ref().unwrap().as_ref(), b"42");
+        assert_eq!(params[1].as_ref().unwrap().as_ref(), b"rw");
+        assert_eq!(params[2].as_ref().unwrap().as_ref(), b"true");
+        assert!(params[3].is_none());
+        assert_eq!(params[4].as_ref().unwrap().as_ref(), b"2026-06-29");
+        assert_eq!(params[5].as_ref().unwrap().as_ref(), b"-7");
+    }
+
+    #[test]
+    fn convert_execute_parameters_rejects_wrong_arity_and_expressions() {
+        let wrong_arity = convert_execute_parameters(&[Expr::Value(Value::Number("1".into()))], 2)
+            .unwrap_err()
+            .to_string();
+        assert!(wrong_arity.contains("wrong number of parameters"));
+
+        let unsupported = convert_execute_parameters(
+            &[Expr::BinaryOp {
+                left: Box::new(Expr::Value(Value::Number("1".into()))),
+                op: risingwave_sqlparser::ast::BinaryOperator::Plus,
+                right: Box::new(Expr::Value(Value::Number("2".into()))),
+            }],
+            1,
+        )
+        .unwrap_err()
+        .to_string();
+        assert!(unsupported.contains("unsupported EXECUTE parameter expression"));
+    }
 }

--- a/src/frontend/src/session.rs
+++ b/src/frontend/src/session.rs
@@ -795,6 +795,9 @@ pub struct SessionImpl {
 
     /// staging catalogs for the current session
     staging_catalog_manager: Arc<Mutex<StagingCatalogManager>>,
+
+    /// SQL-level prepared statements for simple query mode.
+    simple_query_prepared_statement_manager: Arc<Mutex<SimpleQueryPreparedStatementManager>>,
 }
 
 /// If TEMPORARY or TEMP is specified, the source is created as a temporary source.
@@ -861,6 +864,39 @@ impl StagingCatalogManager {
     }
 }
 
+#[derive(Default, Clone)]
+struct SimpleQueryPreparedStatementManager {
+    statements: HashMap<String, PrepareStatement>,
+}
+
+impl SimpleQueryPreparedStatementManager {
+    fn insert(&mut self, name: String, statement: PrepareStatement) -> Result<()> {
+        if self.statements.contains_key(&name) {
+            return Err(ErrorCode::BindError(format!(
+                "prepared statement \"{}\" already exists",
+                name
+            ))
+            .into());
+        }
+        self.statements.insert(name, statement);
+        Ok(())
+    }
+
+    fn get(&self, name: &str) -> Result<PrepareStatement> {
+        self.statements.get(name).cloned().ok_or_else(|| {
+            ErrorCode::ItemNotFound(format!("prepared statement \"{}\"", name)).into()
+        })
+    }
+
+    fn remove(&mut self, name: &str) {
+        self.statements.remove(name);
+    }
+
+    fn clear(&mut self) {
+        self.statements.clear();
+    }
+}
+
 #[derive(Error, Debug)]
 pub enum CheckRelationError {
     #[error("{0}")]
@@ -906,6 +942,7 @@ impl SessionImpl {
             cursor_manager: Arc::new(CursorManager::new(cursor_metrics)),
             temporary_source_manager: Default::default(),
             staging_catalog_manager: Default::default(),
+            simple_query_prepared_statement_manager: Default::default(),
         }
     }
 
@@ -939,6 +976,7 @@ impl SessionImpl {
             cursor_manager: Arc::new(CursorManager::new(env.cursor_metrics)),
             temporary_source_manager: Default::default(),
             staging_catalog_manager: Default::default(),
+            simple_query_prepared_statement_manager: Default::default(),
         }
     }
 
@@ -1494,6 +1532,32 @@ impl SessionImpl {
 
     pub fn staging_catalog_manager(&self) -> StagingCatalogManager {
         self.staging_catalog_manager.lock().clone()
+    }
+
+    pub fn create_simple_query_prepared_statement(
+        &self,
+        name: String,
+        statement: PrepareStatement,
+    ) -> Result<()> {
+        self.simple_query_prepared_statement_manager
+            .lock()
+            .insert(name, statement)
+    }
+
+    pub fn get_simple_query_prepared_statement(&self, name: &str) -> Result<PrepareStatement> {
+        self.simple_query_prepared_statement_manager
+            .lock()
+            .get(name)
+    }
+
+    pub fn drop_simple_query_prepared_statement(&self, name: &str) {
+        self.simple_query_prepared_statement_manager
+            .lock()
+            .remove(name)
+    }
+
+    pub fn drop_all_simple_query_prepared_statements(&self) {
+        self.simple_query_prepared_statement_manager.lock().clear();
     }
 
     pub async fn check_cluster_limits(&self) -> Result<()> {


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

- Closes #21777
- Add real SQL-level prepared statement support for simple query mode.
- Store simple-query prepared statements in the session and reuse the existing extended-query parse/bind path for prepared `SELECT`, `INSERT`, `UPDATE`, and `DELETE`.
- Add SQL `EXECUTE` handling for supported literal parameters, including strings, numbers, booleans, nulls, typed strings, and signed numeric literals.
- Keep `DEALLOCATE name` idempotent for unknown names so existing driver cleanup compatibility is preserved, while `EXECUTE` of an unknown prepared statement still errors.
- Add SLT coverage for query and DML execution, deallocation, duplicate names, wrong arity, read-only transactions, unsupported expressions, and unsupported prepared statement targets.

## Checklist

- [ ] I have written necessary rustdoc comments.
- [x] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->

## Documentation

- [x] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

RisingWave now supports SQL-level `PREPARE`, `EXECUTE`, and `DEALLOCATE` in simple query mode for prepared `SELECT`, `INSERT`, `UPDATE`, and `DELETE` statements.

</details>

## Tests

- `cargo fmt -p risingwave_frontend`
- `git diff --check -- src/frontend/src/handler/mod.rs src/frontend/src/handler/prepared_statement.rs src/frontend/src/session.rs`
- `git diff --no-index --check /dev/null e2e_test/misc/prepared_statement.slt`
- `python3 e2e_test/check_slt_coverage.py -d`
- `./risedev c`
- `./risedev test -p risingwave_frontend prepared_statement --lib`
- `./risedev test -p risingwave_frontend`
- `./risedev d`
- `./risedev slt ./e2e_test/misc/prepared_statement.slt`
- `./risedev k`
