### PR TITLE
feat(iceberg): support pk-index sink on iceberg V2 tables

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13130,6 +13130,7 @@ dependencies = [
  "moka",
  "multimap",
  "parking_lot 0.12.5",
+ "parquet",
  "paste",
  "pin-project",
  "pretty_assertions",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -102,6 +102,9 @@ development = ["expect-test", "pretty_assertions"]
 libraries = [{ path = "./lints" }]
 
 [workspace.dependencies]
+
+adbc_core = { version = "0.23" }
+adbc_snowflake = { version = "0.23", default-features = false }
 apache-avro = { git = "https://github.com/risingwavelabs/avro-rs", rev = "1f2723802d4fb77b97fa084f7bb81e3b60b9e03f" }
 arc-swap = "1"
 arrow-udf-runtime = "0.9.0"
@@ -173,9 +176,6 @@ iceberg = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "c
 ] }
 iceberg-catalog-glue = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "c034b19105fa0f540256fbe4859be8121c5c0551" }
 iceberg-catalog-rest = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "c034b19105fa0f540256fbe4859be8121c5c0551" }
-
-adbc_core = { version = "0.23" }
-adbc_snowflake = { version = "0.23", default-features = false }
 indexmap = { version = "2.12.0", features = ["serde"] }
 itertools = "0.14.0"
 jni = { version = "0.21.1", features = ["invocation"] }

--- a/ci/scripts/e2e-iceberg-test.sh
+++ b/ci/scripts/e2e-iceberg-test.sh
@@ -42,7 +42,7 @@ poetry update --quiet
 poetry run python main.py
 
 echo "--- Running pure slt tests"
-risedev slt './e2e_test/iceberg/test_case/pure_slt/*.slt'
+risedev slt './e2e_test/iceberg/test_case/pure_slt/**/*.slt'
 
 # Run benchmarks separately (not parallelized)
 echo "--- Running benchmarks"

--- a/e2e_test/iceberg/test_case/pure_slt/datafusion/array.slt
+++ b/e2e_test/iceberg/test_case/pure_slt/datafusion/array.slt
@@ -157,12 +157,12 @@ NULL
 query I rowsort
 SELECT cardinality(arr_int) FROM t_array;
 ----
+0
 3
 3
 3
 4
 4
-NULL
 NULL
 NULL
 

--- a/e2e_test/iceberg/test_case/pure_slt/iceberg_v2_with_pk_index.slt
+++ b/e2e_test/iceberg/test_case/pure_slt/iceberg_v2_with_pk_index.slt
@@ -1,0 +1,141 @@
+statement ok
+create secret hosted_catalog_secret with (
+  backend = 'meta'
+) as 'hummockadmin';
+
+# Test hosted catalog connection using the warehouse created by risedev
+statement ok
+create connection hosted_catalog_conn
+with (
+    type = 'iceberg',
+    warehouse.path = 's3://hummock001/iceberg_v2_pk_index',
+    s3.access.key = secret hosted_catalog_secret,
+    s3.secret.key = secret hosted_catalog_secret,
+    s3.endpoint = 'http://127.0.0.1:9301',
+    s3.region = 'us-west-2',
+    hosted_catalog = true
+);
+
+statement ok
+set iceberg_engine_connection = 'public.hosted_catalog_conn';
+
+statement ok
+create table t_v2(id int primary key, name varchar, v1 int)
+with(
+    commit_checkpoint_interval = 3,
+    format_version = 2,
+    partition_by = 'id',
+    enable_pk_index = 'true'
+) engine = iceberg;
+
+statement ok
+insert into t_v2 values(1, 'alice', 100), (2, 'bob', 200), (3, 'charlie', 300);
+
+statement ok
+flush;
+
+statement ok
+update t_v2 set v1 = 150 where id = 1;
+
+statement ok
+delete from t_v2 where id = 2;
+
+statement ok
+FLUSH;
+
+# The pk-index path writes file-scoped position deletes. In V2 these are parquet
+# delete files (PositionDeletes), not puffin deletion vectors.
+query ?? retry 6 backoff 1s
+select count(*) > 0 from rw_iceberg_files
+where schema_name = 'public'
+  and source_name = '__iceberg_source_t_v2'
+  and content = 'PositionDeletes'
+  and file_format = 'parquet';
+----
+t
+
+# The pk-index path must never produce equality deletes.
+query ?? retry 6 backoff 1s
+select count(*) = 0 from rw_iceberg_files
+where schema_name = 'public'
+  and source_name = '__iceberg_source_t_v2'
+  and content = 'EqualityDeletes';
+----
+t
+
+query ??? rowsort retry 3 backoff 1s
+select * from t_v2;
+----
+1 alice 150
+3 charlie 300
+
+# Another delete across a new checkpoint should still only use position deletes.
+statement ok
+delete from t_v2 where id = 1;
+
+statement ok
+FLUSH;
+
+query ?? retry 6 backoff 1s
+select count(*) = 0 from rw_iceberg_files
+where schema_name = 'public'
+  and source_name = '__iceberg_source_t_v2'
+  and content = 'EqualityDeletes';
+----
+t
+
+query ??? rowsort retry 3 backoff 1s
+select * from t_v2;
+----
+3 charlie 300
+
+statement ok
+DROP TABLE t_v2;
+
+statement ok
+DROP CONNECTION hosted_catalog_conn;
+
+# Test storage catalog connection with format version 2
+statement ok
+create connection storage_catalog_conn
+with (
+    type = 'iceberg',
+    catalog.type = 'storage',
+    warehouse.path = 's3://hummock001/iceberg_v2_pk_index',
+    s3.access.key = secret hosted_catalog_secret,
+    s3.secret.key = secret hosted_catalog_secret,
+    s3.endpoint = 'http://127.0.0.1:9301',
+    s3.region = 'us-west-2'
+);
+
+statement ok
+set iceberg_engine_connection = 'public.storage_catalog_conn';
+
+statement ok
+create table t_v2_storage(id int primary key, name varchar)
+with(
+    commit_checkpoint_interval = 2,
+    format_version = 2,
+    enable_pk_index = 'true'
+) engine = iceberg;
+
+statement ok
+insert into t_v2_storage values(1, 'alice'), (2, 'bob');
+
+statement ok
+flush;
+
+query ??? rowsort retry 3 backoff 1s
+select * from t_v2_storage;
+----
+1 alice
+2 bob
+
+statement ok
+DROP TABLE t_v2_storage;
+
+statement ok
+DROP CONNECTION storage_catalog_conn;
+
+statement ok
+DROP SECRET hosted_catalog_secret;

--- a/proto/connector_service.proto
+++ b/proto/connector_service.proto
@@ -273,7 +273,7 @@ service SinkCoordinationService {
   rpc Coordinate(stream CoordinateRequest) returns (stream CoordinateResponse);
 }
 
-message IcebergV3PreCommitState {
+message IcebergPkIndexPreCommitState {
   bytes agg_result = 1;
   int64 snapshot_id = 2;
 }

--- a/proto/stream_plan.proto
+++ b/proto/stream_plan.proto
@@ -388,7 +388,7 @@ message IcebergWithPkIndexWriterNode {
   catalog.Table pk_index_table = 2;
 }
 
-message IcebergWithPkIndexDvMergerNode {
+message IcebergWithPkIndexPositionDeleteMergerNode {
   SinkDesc sink_desc = 1;
 }
 
@@ -1204,7 +1204,7 @@ message StreamNode {
     GapFillNode gap_fill = 154;
     VectorIndexLookupJoinNode vector_index_lookup_join = 155;
     IcebergWithPkIndexWriterNode iceberg_with_pk_index_writer = 156;
-    IcebergWithPkIndexDvMergerNode iceberg_with_pk_index_dv_merger = 157;
+    IcebergWithPkIndexPositionDeleteMergerNode iceberg_with_pk_index_position_delete_merger = 157;
   }
   // The id for the operator. This is local per mview.
   // TODO: should better be a uint32.

--- a/proto/stream_service.proto
+++ b/proto/stream_service.proto
@@ -11,10 +11,10 @@ import "stream_plan.proto";
 option java_package = "com.risingwave.proto";
 option optimize_for = SPEED;
 
-enum PbIcebergV3SinkRole {
-  PB_ICEBERG_V3_SINK_ROLE_UNSPECIFIED = 0;
-  PB_ICEBERG_V3_SINK_ROLE_WRITER = 1;
-  PB_ICEBERG_V3_SINK_ROLE_DV_MERGER = 2;
+enum PbIcebergPkIndexSinkRole {
+  PB_ICEBERG_PK_INDEX_SINK_ROLE_UNSPECIFIED = 0;
+  PB_ICEBERG_PK_INDEX_SINK_ROLE_WRITER = 1;
+  PB_ICEBERG_PK_INDEX_SINK_ROLE_POSITION_DELETE_MERGER = 2;
 }
 
 message InjectBarrierRequest {
@@ -134,14 +134,14 @@ message BarrierCompleteResponse {
     uint32 source_id = 2;
   }
   repeated CdcSourceOffsetUpdated cdc_source_offset_updated = 17;
-  message IcebergV3SinkMetadata {
+  message IcebergPkIndexSinkMetadata {
     uint32 reporter_actor_id = 1;
     uint32 sink_id = 2;
     uint64 prev_epoch = 3;
-    PbIcebergV3SinkRole role = 4;
+    PbIcebergPkIndexSinkRole role = 4;
     connector_service.SinkMetadata metadata = 5;
   }
-  repeated IcebergV3SinkMetadata iceberg_v3_sink_metadata = 18;
+  repeated IcebergPkIndexSinkMetadata iceberg_pk_index_sink_metadata = 18;
 }
 
 message StreamingControlStreamRequest {

--- a/src/bench/Cargo.toml
+++ b/src/bench/Cargo.toml
@@ -19,7 +19,7 @@ itertools = { workspace = true }
 plotters = { version = "0.3.5", default-features = false, features = [
     "svg_backend",
     "line_series",
-    "point_series"
+    "point_series",
 ] }
 risingwave_common = { workspace = true }
 risingwave_connector = { workspace = true }

--- a/src/connector/src/sink/iceberg/commit.rs
+++ b/src/connector/src/sink/iceberg/commit.rs
@@ -41,7 +41,7 @@ use tokio::sync::mpsc::UnboundedSender;
 use tracing::warn;
 
 use super::commit_retry::{self, CommitError};
-use super::{GLOBAL_SINK_METRICS, IcebergConfig, SinkError, commit_branch};
+use super::{GLOBAL_SINK_METRICS, IcebergConfig, SinkError, commit_branch, resolve_partition_type};
 use crate::connector_common::{IcebergCommittedSnapshot, IcebergSinkCompactionUpdate};
 use crate::sink::catalog::SinkId;
 use crate::sink::{Result, SinglePhaseCommitCoordinator, SinkParam, TwoPhaseCommitCoordinator};
@@ -159,14 +159,14 @@ impl<'a> TryFrom<&'a IcebergCommitResult> for Vec<u8> {
 }
 
 #[derive(Default, Clone, Serialize, Deserialize)]
-pub struct IcebergDvMergerCommitResult {
+pub struct IcebergPositionDeleteMergerCommitResult {
     pub schema_id: i32,
     pub partition_spec_id: i32,
     pub delete_files: Vec<SerializedDataFile>,
     pub overwrite_files: Vec<SerializedDataFile>,
 }
 
-impl<'a> TryFrom<&'a SinkMetadata> for IcebergDvMergerCommitResult {
+impl<'a> TryFrom<&'a SinkMetadata> for IcebergPositionDeleteMergerCommitResult {
     type Error = SinkError;
 
     fn try_from(value: &'a SinkMetadata) -> Result<Self> {
@@ -179,10 +179,10 @@ impl<'a> TryFrom<&'a SinkMetadata> for IcebergDvMergerCommitResult {
     }
 }
 
-impl<'a> TryFrom<&'a IcebergDvMergerCommitResult> for SinkMetadata {
+impl<'a> TryFrom<&'a IcebergPositionDeleteMergerCommitResult> for SinkMetadata {
     type Error = SinkError;
 
-    fn try_from(value: &'a IcebergDvMergerCommitResult) -> Result<SinkMetadata> {
+    fn try_from(value: &'a IcebergPositionDeleteMergerCommitResult) -> Result<SinkMetadata> {
         let bytes = serde_json::to_vec(value)
             .context("Can't serialize iceberg dv merger commit result to metadata")?;
         Ok(SinkMetadata {
@@ -532,21 +532,7 @@ impl IcebergSinkCommitter {
                 expect_schema_id
             )));
         };
-        let Some(partition_spec) = self
-            .table
-            .metadata()
-            .partition_spec_by_id(expect_partition_spec_id)
-        else {
-            return Err(SinkError::Iceberg(anyhow!(
-                "Can't find partition spec by id {}",
-                expect_partition_spec_id
-            )));
-        };
-        let partition_type = partition_spec
-            .as_ref()
-            .clone()
-            .partition_type(schema)
-            .map_err(|err| SinkError::Iceberg(anyhow!(err)))?;
+        let partition_type = resolve_partition_type(&self.table, expect_partition_spec_id, schema)?;
 
         let data_files = write_results
             .into_iter()

--- a/src/connector/src/sink/iceberg/config.rs
+++ b/src/connector/src/sink/iceberg/config.rs
@@ -130,8 +130,7 @@ pub const DEFAULT_COMPACTION_MAX_SNAPSHOTS_NUM: usize = 1000;
 pub const ICEBERG_DEFAULT_WRITE_PARQUET_MAX_ROW_GROUP_BYTES: usize = 128 * 1024 * 1024;
 pub const ENABLE_PK_INDEX: &str = "enable_pk_index";
 
-pub(super) const PARQUET_CREATED_BY: &str =
-    concat!("risingwave version ", env!("CARGO_PKG_VERSION"));
+pub const PARQUET_CREATED_BY: &str = concat!("risingwave version ", env!("CARGO_PKG_VERSION"));
 
 fn default_commit_retry_num() -> u32 {
     8
@@ -453,7 +452,8 @@ pub struct IcebergConfig {
     pub write_parquet_max_row_group_bytes: Option<usize>,
 
     /// Whether to enable PK index for upsert sink. Default is false.
-    /// It's used for V3 upsert iceberg sink to generate delete vectors.
+    /// For upsert iceberg sinks (V2/V3, merge-on-read): maintain a pk index and write
+    /// position deletes instead of equality deletes.
     #[serde(
         rename = "enable_pk_index",
         default,
@@ -510,9 +510,9 @@ impl IcebergConfig {
             )));
         }
 
-        if self.format_version < FormatVersion::V3 {
+        if self.format_version < FormatVersion::V2 {
             return Err(SinkError::Config(anyhow!(
-                "`enable_pk_index` is only supported for upsert iceberg sink with format version >= 3"
+                "`enable_pk_index` is only supported for upsert iceberg sink with format version >= 2"
             )));
         }
 

--- a/src/connector/src/sink/iceberg/create_table.rs
+++ b/src/connector/src/sink/iceberg/create_table.rs
@@ -19,7 +19,7 @@ use std::sync::LazyLock;
 use anyhow::{Context, anyhow};
 use iceberg::arrow::schema_to_arrow_schema;
 use iceberg::spec::{
-    NullOrder, SortDirection, SortField, SortOrder, TableProperties, Transform,
+    FormatVersion, NullOrder, SortDirection, SortField, SortOrder, TableProperties, Transform,
     UnboundPartitionField, UnboundPartitionSpec,
 };
 use iceberg::table::Table;
@@ -70,6 +70,17 @@ pub async fn create_and_validate_table_impl(
         .load_table()
         .await
         .map_err(|err| SinkError::Iceberg(anyhow!(err)))?;
+
+    if config.enable_pk_index {
+        let table_format_version = table.metadata().format_version();
+        if table_format_version < FormatVersion::V2 {
+            return Err(SinkError::Config(anyhow!(
+                "`enable_pk_index` requires an Iceberg table with format version >= 2, \
+                 but the target table is format version {}",
+                table_format_version
+            )));
+        }
+    }
 
     let sink_schema = param.schema();
     let iceberg_arrow_schema = schema_to_arrow_schema(table.metadata().current_schema())

--- a/src/connector/src/sink/iceberg/writer.rs
+++ b/src/connector/src/sink/iceberg/writer.rs
@@ -21,7 +21,8 @@ use iceberg::arrow::{
     RecordBatchPartitionSplitter, arrow_schema_to_schema, schema_to_arrow_schema,
 };
 use iceberg::spec::{
-    DataFile, FormatVersion, PartitionSpecRef, SchemaRef as IcebergSchemaRef, SerializedDataFile,
+    DataFile, FormatVersion, PartitionSpecRef, Schema, SchemaRef as IcebergSchemaRef,
+    SerializedDataFile, StructType,
 };
 use iceberg::table::Table;
 use iceberg::writer::base_writer::data_file_writer::DataFileWriterBuilder;
@@ -80,7 +81,9 @@ enum ProjectIdxVec {
 
 type DataFileWriterBuilderType =
     DataFileWriterBuilder<ParquetWriterBuilder, DefaultLocationGenerator, DefaultFileNameGenerator>;
-type PositionDeleteFileWriterBuilderType = PositionDeleteFileWriterBuilder<
+/// The concrete V2 position-delete Parquet writer builder type, shared by the
+/// iceberg sink writer and the pk-index position-delete merger.
+pub type PositionDeleteFileWriterBuilderType = PositionDeleteFileWriterBuilder<
     ParquetWriterBuilder,
     DefaultLocationGenerator,
     DefaultFileNameGenerator,
@@ -786,17 +789,7 @@ impl IcebergSinkWriterInner {
     }
 
     pub fn generate_commit_metadata(&self, data_files: Vec<DataFile>) -> Result<SinkMetadata> {
-        let format_version = self.table.metadata().format_version();
-        let partition_type = self.table.metadata().default_partition_type();
-        let serialized_data_files = data_files
-            .into_iter()
-            .map(|f| {
-                // Truncate large column statistics BEFORE serialization
-                let truncated = truncate_datafile(f);
-                let res = SerializedDataFile::try_from(truncated, partition_type, format_version)?;
-                Ok(res)
-            })
-            .collect::<Result<Vec<_>>>()?;
+        let serialized_data_files = serialize_data_files_default_spec(&self.table, data_files)?;
         SinkMetadata::try_from(&IcebergCommitResult {
             data_files: serialized_data_files,
             schema_id: self.table.metadata().current_schema_id(),
@@ -877,6 +870,54 @@ impl SinkWriter for IcebergSinkWriter {
 /// JSONB, TEXT, or BINARY fields, while still preserving statistics for small fields
 /// that benefit from query optimization.
 const MAX_COLUMN_STAT_SIZE: usize = 10240; // 10KB
+
+/// Serializes `files` against the table's current default partition spec, after
+/// truncating oversized column statistics. Shared by the iceberg sink writer's
+/// commit-metadata generation and the pk-index merger's delete-file serialization.
+///
+/// Only the DEFAULT-spec path is shared here; callers that must serialize each
+/// file against its own (potentially older) partition spec keep their own logic.
+pub fn serialize_data_files_default_spec(
+    table: &Table,
+    files: Vec<DataFile>,
+) -> Result<Vec<SerializedDataFile>> {
+    let format_version = table.metadata().format_version();
+    let partition_type = table.metadata().default_partition_type();
+    files
+        .into_iter()
+        .map(|f| {
+            // Truncate large column statistics BEFORE serialization.
+            let truncated = truncate_datafile(f);
+            Ok(SerializedDataFile::try_from(
+                truncated,
+                partition_type,
+                format_version,
+            )?)
+        })
+        .collect()
+}
+
+/// Resolves a partition spec by id from the table metadata, with a consolidated
+/// error message. Shared spec-lookup mechanic for the pk-index merger, commit
+/// coordinator, and sink commit paths.
+pub fn resolve_partition_spec(table: &Table, spec_id: i32) -> Result<PartitionSpecRef> {
+    table
+        .metadata()
+        .partition_spec_by_id(spec_id)
+        .cloned()
+        .ok_or_else(|| SinkError::Iceberg(anyhow!("partition spec {} not found", spec_id)))
+}
+
+/// Resolves the partition [`StructType`] for the given `spec_id` against `schema`.
+///
+/// `schema` is passed explicitly (rather than read from the table) so callers can
+/// preserve their chosen schema, and `spec_id` is passed explicitly so callers can
+/// preserve their chosen spec (e.g. a file's own spec vs. the default spec).
+pub fn resolve_partition_type(table: &Table, spec_id: i32, schema: &Schema) -> Result<StructType> {
+    resolve_partition_spec(table, spec_id)?
+        .partition_type(schema)
+        .map_err(|e| SinkError::Iceberg(anyhow!(e)))
+}
 
 /// Truncate large column statistics from `DataFile` BEFORE serialization.
 ///

--- a/src/connector/with_options_sink.yaml
+++ b/src/connector/with_options_sink.yaml
@@ -800,7 +800,8 @@ IcebergConfig:
     field_type: bool
     comments: |-
       Whether to enable PK index for upsert sink. Default is false.
-      It's used for V3 upsert iceberg sink to generate delete vectors.
+      For upsert iceberg sinks (V2/V3, merge-on-read): maintain a pk index and write
+      position deletes instead of equality deletes.
     required: false
     default: Default::default
 KafkaConfig:

--- a/src/frontend/Cargo.toml
+++ b/src/frontend/Cargo.toml
@@ -10,11 +10,7 @@ repository = { workspace = true }
 [features]
 default = []
 datafusion = ["dep:datafusion", "dep:datafusion-common"]
-datafusion-backtrace = [
-    "datafusion",
-    "datafusion/backtrace",
-    "datafusion-common/backtrace",
-]
+datafusion-backtrace = ["datafusion", "datafusion/backtrace", "datafusion-common/backtrace"]
 all-sources = ["source-adbc_snowflake"]
 source-adbc_snowflake = ["risingwave_connector/source-adbc_snowflake"]
 

--- a/src/frontend/planner_test/tests/testdata/output/sink.yaml
+++ b/src/frontend/planner_test/tests/testdata/output/sink.yaml
@@ -309,7 +309,7 @@
       enable_pk_index = 'true'
     );
   explain_output: |
-    StreamIcebergWithPkIndexDvMerger
+    StreamIcebergWithPkIndexPositionDeleteMerger
     └─StreamExchange { dist: HashShard(file_path) }
       └─StreamIcebergWithPkIndexWriter { columns: [v1, v2, v3, v4, t1._row_id], downstream_pk: [t1._row_id] }
         └─StreamExchange { dist: HashShard(t1._row_id) }
@@ -335,7 +335,7 @@
       enable_pk_index = 'true'
     );
   explain_output: |
-    StreamIcebergWithPkIndexDvMerger
+    StreamIcebergWithPkIndexPositionDeleteMerger
     └─StreamExchange { dist: HashShard(file_path) }
       └─StreamIcebergWithPkIndexWriter { columns: [v1, v2, v3, v4, t1._row_id], downstream_pk: [t1._row_id] }
         └─StreamExchange { dist: HashShard(t1._row_id) }
@@ -397,7 +397,7 @@
       enable_pk_index = 'true'
     );
   explain_output: |
-    StreamIcebergWithPkIndexDvMerger
+    StreamIcebergWithPkIndexPositionDeleteMerger
     └─StreamExchange { dist: HashShard(file_path) }
       └─StreamIcebergWithPkIndexWriter { columns: [v1, t.v2, t.v3], downstream_pk: [v1, t.v2, t.v3] }
         └─StreamExchange { dist: HashShard(t.v1, t.v2, t.v3) }
@@ -423,7 +423,7 @@
       enable_pk_index = 'true'
     );
   explain_output: |
-    StreamIcebergWithPkIndexDvMerger
+    StreamIcebergWithPkIndexPositionDeleteMerger
     └─StreamExchange { dist: HashShard(file_path) }
       └─StreamIcebergWithPkIndexWriter { columns: [v1, v2, v3, v4], downstream_pk: [v1, v2] }
         └─StreamExchange { dist: HashShard(u.v1, o.oid) }

--- a/src/frontend/src/optimizer/plan_node/mod.rs
+++ b/src/frontend/src/optimizer/plan_node/mod.rs
@@ -1091,7 +1091,7 @@ mod stream_group_topn;
 mod stream_hash_agg;
 mod stream_hash_join;
 mod stream_hop_window;
-mod stream_iceberg_with_pk_index_dv_merger;
+mod stream_iceberg_with_pk_index_position_delete_merger;
 mod stream_iceberg_with_pk_index_writer;
 mod stream_join_common;
 mod stream_local_approx_percentile;
@@ -1236,7 +1236,7 @@ pub use stream_group_topn::StreamGroupTopN;
 pub use stream_hash_agg::StreamHashAgg;
 pub use stream_hash_join::StreamHashJoin;
 pub use stream_hop_window::StreamHopWindow;
-pub use stream_iceberg_with_pk_index_dv_merger::StreamIcebergWithPkIndexDvMerger;
+pub use stream_iceberg_with_pk_index_position_delete_merger::StreamIcebergWithPkIndexPositionDeleteMerger;
 pub use stream_iceberg_with_pk_index_writer::StreamIcebergWithPkIndexWriter;
 use stream_join_common::StreamJoinCommon;
 pub use stream_local_approx_percentile::StreamLocalApproxPercentile;
@@ -1417,7 +1417,7 @@ macro_rules! for_all_plan_nodes {
             , { Stream, EowcGapFill }
             , { Stream, GapFill }
             , { Stream, IcebergWithPkIndexWriter }
-            , { Stream, IcebergWithPkIndexDvMerger }
+            , { Stream, IcebergWithPkIndexPositionDeleteMerger }
             $(,$rest)*
         }
     };

--- a/src/frontend/src/optimizer/plan_node/stream_iceberg_with_pk_index_position_delete_merger.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_iceberg_with_pk_index_position_delete_merger.rs
@@ -14,7 +14,7 @@
 
 use pretty_xmlish::XmlNode;
 use risingwave_connector::sink::catalog::desc::SinkDesc;
-use risingwave_pb::stream_plan::IcebergWithPkIndexDvMergerNode;
+use risingwave_pb::stream_plan::IcebergWithPkIndexPositionDeleteMergerNode;
 use risingwave_pb::stream_plan::stream_node::NodeBody;
 
 use super::stream::prelude::*;
@@ -26,20 +26,21 @@ use crate::optimizer::plan_node::{
 use crate::optimizer::property::RequiredDist;
 use crate::stream_fragmenter::BuildFragmentGraphState;
 
-/// `StreamIcebergWithPkIndexDvMerger` is the stateless singleton executor for the Iceberg
+/// `StreamIcebergWithPkIndexPositionDeleteMerger` is the stateless singleton executor for the Iceberg
 /// with pk index sink. It merges delete-position messages from the upstream `WriterExecutor`
-/// with historical deletion vectors and writes merged DV files.
+/// with existing position deletes and writes the resulting delete file (a V3 Puffin deletion
+/// vector or a V2 file-scoped Parquet position-delete file, depending on the table format version).
 ///
 /// This node shardes the input stream by `file_path` (the first column) to ensure all messages
 /// for the same file are processed by the same merger instance.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub struct StreamIcebergWithPkIndexDvMerger {
+pub struct StreamIcebergWithPkIndexPositionDeleteMerger {
     pub base: PlanBase<Stream>,
     pub input: PlanRef,
     pub sink_desc: SinkDesc,
 }
 
-impl StreamIcebergWithPkIndexDvMerger {
+impl StreamIcebergWithPkIndexPositionDeleteMerger {
     pub fn new(input: PlanRef, sink_desc: SinkDesc) -> Self {
         debug_assert_eq!(input.schema().len(), 2); // Expecting `[file_path, position]` from the Writer.
         let input = RequiredDist::shard_by_key(2, &[0])
@@ -65,13 +66,13 @@ impl StreamIcebergWithPkIndexDvMerger {
     }
 }
 
-impl Distill for StreamIcebergWithPkIndexDvMerger {
+impl Distill for StreamIcebergWithPkIndexPositionDeleteMerger {
     fn distill<'a>(&self) -> XmlNode<'a> {
-        childless_record("StreamIcebergWithPkIndexDvMerger", vec![])
+        childless_record("StreamIcebergWithPkIndexPositionDeleteMerger", vec![])
     }
 }
 
-impl PlanTreeNodeUnary<Stream> for StreamIcebergWithPkIndexDvMerger {
+impl PlanTreeNodeUnary<Stream> for StreamIcebergWithPkIndexPositionDeleteMerger {
     fn input(&self) -> PlanRef {
         self.input.clone()
     }
@@ -81,16 +82,18 @@ impl PlanTreeNodeUnary<Stream> for StreamIcebergWithPkIndexDvMerger {
     }
 }
 
-impl_plan_tree_node_for_unary! { Stream, StreamIcebergWithPkIndexDvMerger }
+impl_plan_tree_node_for_unary! { Stream, StreamIcebergWithPkIndexPositionDeleteMerger }
 
-impl StreamNode for StreamIcebergWithPkIndexDvMerger {
+impl StreamNode for StreamIcebergWithPkIndexPositionDeleteMerger {
     fn to_stream_prost_body(&self, _state: &mut BuildFragmentGraphState) -> NodeBody {
-        NodeBody::IcebergWithPkIndexDvMerger(Box::new(IcebergWithPkIndexDvMergerNode {
-            sink_desc: Some(self.sink_desc.to_proto()),
-        }))
+        NodeBody::IcebergWithPkIndexPositionDeleteMerger(Box::new(
+            IcebergWithPkIndexPositionDeleteMergerNode {
+                sink_desc: Some(self.sink_desc.to_proto()),
+            },
+        ))
     }
 }
 
-impl ExprRewritable<Stream> for StreamIcebergWithPkIndexDvMerger {}
+impl ExprRewritable<Stream> for StreamIcebergWithPkIndexPositionDeleteMerger {}
 
-impl ExprVisitable for StreamIcebergWithPkIndexDvMerger {}
+impl ExprVisitable for StreamIcebergWithPkIndexPositionDeleteMerger {}

--- a/src/frontend/src/optimizer/plan_node/stream_iceberg_with_pk_index_writer.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_iceberg_with_pk_index_writer.rs
@@ -37,7 +37,7 @@ use crate::stream_fragmenter::BuildFragmentGraphState;
 /// with pk index sink. It maintains a PK index and writes data files to Iceberg.
 ///
 /// Output schema: `[file_path: Varchar, position: Int64]` — delete-position info for
-/// the downstream `DvMerger`.
+/// the downstream `PositionDeleteMerger`.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct StreamIcebergWithPkIndexWriter {
     pub base: PlanBase<Stream>,

--- a/src/frontend/src/optimizer/plan_node/stream_sink.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_sink.rs
@@ -315,11 +315,11 @@ impl StreamSink {
                 .get(ENABLE_PK_INDEX)
                 .is_some_and(|v| v.eq_ignore_ascii_case("true"));
 
-        // For Iceberg V3 pk-index sinks, the iceberg primary key is derived entirely from the
+        // For Iceberg pk-index sinks, the iceberg primary key is derived entirely from the
         // upstream stream key, so the user must not specify `primary_key` explicitly.
         if is_iceberg_pk_index && properties.get(DOWNSTREAM_PK_KEY).is_some() {
             return Err(ErrorCode::InvalidInputSyntax(
-                "Iceberg V3 sink with `enable_pk_index='true'` does not allow a user-specified `primary_key`. \
+                "Iceberg sink with `enable_pk_index='true'` does not allow a user-specified `primary_key`. \
                 The primary key is automatically derived from the upstream stream key.".to_owned(),
             )
             .into());
@@ -369,7 +369,7 @@ impl StreamSink {
         {
             downstream_pk = Some(derived_pk.clone())
         } else if is_iceberg_pk_index {
-            // For Iceberg V3 pk-index sinks: derive the iceberg primary key entirely from the
+            // For Iceberg pk-index sinks: derive the iceberg primary key entirely from the
             // upstream stream key. Every stream-key column becomes a pk column; hidden ones are
             // promoted to visible so they are carried into the iceberg table verbatim.
             let (pk, promoted) = promote_iceberg_pk_index_stream_key(&input, &mut columns)?;
@@ -480,7 +480,7 @@ impl StreamSink {
                         RequiredDist::hash_shard(downstream_pk)
                     }
                     Some(s) if s == ICEBERG_SINK => {
-                        // V3 pk-index sinks shard by pk for state-table locality and never use the
+                        // pk-index sinks shard by pk for state-table locality and never use the
                         // partition-based shuffle, so skip computing the extra partition column
                         // entirely.
                         let partition_info = if is_iceberg_pk_index {
@@ -660,7 +660,7 @@ impl StreamSink {
         let sink = Self::new(input, sink_desc, log_store_type);
         if let Some(pk_names) = emit_pk_extension_notice {
             sink.base.ctx().session_ctx().notice_to_user(format!(
-                "Iceberg V3 sink `{}`: the iceberg primary key was automatically derived from \
+                "Iceberg pk-index sink `{}`: the iceberg primary key was automatically derived from \
                  the upstream stream key as ({}).",
                 sink.sink_desc.name, pk_names,
             ));
@@ -840,19 +840,19 @@ impl StreamSink {
     /// Convert this `StreamSink` into a `PlanRef`.
     ///
     /// For Iceberg pk index sinks, this rewrites the plan into
-    /// `Upstream → Writer → Exchange(Hash) → DvMerger` instead of a single `SinkNode`.
+    /// `Upstream → Writer → Exchange(Hash) → PositionDeleteMerger` instead of a single `SinkNode`.
     /// For all other sinks, returns `self` as-is.
     pub fn into_stream_plan(self) -> Result<PlanRef> {
-        use super::{StreamIcebergWithPkIndexDvMerger, StreamIcebergWithPkIndexWriter};
+        use super::{StreamIcebergWithPkIndexPositionDeleteMerger, StreamIcebergWithPkIndexWriter};
 
         if !is_iceberg_with_pk_index_sink(&self.sink_desc)? {
             return Ok(self.into());
         }
 
         let writer: PlanRef = StreamIcebergWithPkIndexWriter::from_stream_sink(&self)?.into();
-        let dv_merger: PlanRef =
-            StreamIcebergWithPkIndexDvMerger::new(writer, self.sink_desc).into();
-        Ok(dv_merger)
+        let position_delete_merger: PlanRef =
+            StreamIcebergWithPkIndexPositionDeleteMerger::new(writer, self.sink_desc).into();
+        Ok(position_delete_merger)
     }
 }
 
@@ -889,7 +889,7 @@ fn promote_iceberg_pk_index_stream_key(
     let stream_key = input.expect_stream_key();
     if stream_key.is_empty() {
         bail_invalid_input_syntax!(
-            "Iceberg V3 sink with `enable_pk_index='true'` requires a non-empty upstream stream key \
+            "Iceberg sink with `enable_pk_index='true'` requires a non-empty upstream stream key \
              to derive the primary key from."
         );
     }
@@ -911,7 +911,7 @@ fn promote_iceberg_pk_index_stream_key(
     // iceberg table.
     if let Some(col) = columns.iter().find(|c| c.is_hidden) {
         return Err(ErrorCode::InternalError(format!(
-            "iceberg V3 pk-index sink has a hidden column `{}` after stream-key promotion; \
+            "iceberg pk-index sink has a hidden column `{}` after stream-key promotion; \
              all sink columns must be visible",
             col.name()
         ))

--- a/src/meta/node/src/server.rs
+++ b/src/meta/node/src/server.rs
@@ -90,7 +90,7 @@ use crate::barrier::BarrierScheduler;
 use crate::controller::SqlMetaStore;
 use crate::controller::system_param::SystemParamsController;
 use crate::hummock::HummockManager;
-use crate::manager::iceberg_v3_sink::IcebergV3SinkManager;
+use crate::manager::iceberg_pk_index_sink::IcebergPkIndexSinkManager;
 use crate::manager::sink_coordination::SinkCoordinatorManager;
 use crate::manager::{IdleManager, MetaOpts, MetaSrvEnv};
 use crate::rpc::election::sql::{MySqlDriver, PostgresDriver, SqlBackendElectionClient};
@@ -465,8 +465,9 @@ pub async fn start_service_as_election_leader(
     // TODO(shutdown): remove this as there's no need to gracefully shutdown some of these sub-tasks.
     let mut sub_tasks = vec![shutdown_handle];
 
-    let iceberg_v3_sink_manager = IcebergV3SinkManager::new(env.meta_store_ref().conn.clone());
-    tracing::info!("IcebergV3SinkManager started");
+    let iceberg_pk_index_sink_manager =
+        IcebergPkIndexSinkManager::new(env.meta_store_ref().conn.clone());
+    tracing::info!("IcebergPkIndexSinkManager started");
 
     let iceberg_compactor_manager = Arc::new(IcebergCompactorManager::new());
 
@@ -511,7 +512,7 @@ pub async fn start_service_as_election_leader(
         hummock_manager.clone(),
         source_manager.clone(),
         sink_manager.clone(),
-        iceberg_v3_sink_manager.clone(),
+        iceberg_pk_index_sink_manager.clone(),
         scale_controller.clone(),
         barrier_scheduler.clone(),
         refresh_manager.clone(),
@@ -555,7 +556,7 @@ pub async fn start_service_as_election_leader(
         meta_metrics.clone(),
         iceberg_compaction_mgr.clone(),
         barrier_scheduler.clone(),
-        iceberg_v3_sink_manager.clone(),
+        iceberg_pk_index_sink_manager.clone(),
     )
     .await;
 

--- a/src/meta/service/src/ddl_service.rs
+++ b/src/meta/service/src/ddl_service.rs
@@ -57,7 +57,7 @@ use tonic::{Request, Response, Status};
 
 use crate::MetaError;
 use crate::barrier::BarrierManagerRef;
-use crate::manager::iceberg_v3_sink::IcebergV3SinkManager;
+use crate::manager::iceberg_pk_index_sink::IcebergPkIndexSinkManager;
 use crate::manager::sink_coordination::SinkCoordinatorManager;
 use crate::manager::{MetaSrvEnv, StreamingJob};
 use crate::rpc::ddl_controller::{
@@ -88,7 +88,7 @@ impl DdlServiceImpl {
         meta_metrics: Arc<MetaMetrics>,
         iceberg_compaction_manager: iceberg_compaction::IcebergCompactionManagerRef,
         barrier_scheduler: BarrierScheduler,
-        iceberg_v3_sink_manager: IcebergV3SinkManager,
+        iceberg_pk_index_sink_manager: IcebergPkIndexSinkManager,
     ) -> Self {
         let ddl_controller = DdlController::new(
             env.clone(),
@@ -98,7 +98,7 @@ impl DdlServiceImpl {
             barrier_manager,
             sink_manager.clone(),
             iceberg_compaction_manager.clone(),
-            iceberg_v3_sink_manager,
+            iceberg_pk_index_sink_manager,
         )
         .await;
         Self {

--- a/src/meta/src/barrier/command.rs
+++ b/src/meta/src/barrier/command.rs
@@ -853,7 +853,7 @@ impl Command {
             old_value_ssts,
             vector_index_adds,
             truncate_tables,
-            iceberg_v3_sink_metadata,
+            iceberg_pk_index_sink_metadata,
         ) = collect_resp_info(resps);
 
         let new_table_fragment_infos = match &barrier_info.post_collect_command {
@@ -942,8 +942,8 @@ impl Command {
                 .expect("non-duplicate");
         }
         info.truncate_tables.extend(truncate_tables);
-        task.iceberg_v3_sink_metadata
-            .extend(iceberg_v3_sink_metadata);
+        task.iceberg_pk_index_sink_metadata
+            .extend(iceberg_pk_index_sink_metadata);
     }
 }
 

--- a/src/meta/src/barrier/complete_task.rs
+++ b/src/meta/src/barrier/complete_task.rs
@@ -25,7 +25,7 @@ use risingwave_common::util::deployment::Deployment;
 use risingwave_pb::hummock::HummockVersionStats;
 use risingwave_pb::id::{DatabaseId, PartialGraphId};
 use risingwave_pb::stream_service::barrier_complete_response::{
-    PbIcebergV3SinkMetadata, PbListFinishedSource, PbLoadFinishedSource,
+    PbIcebergPkIndexSinkMetadata, PbListFinishedSource, PbLoadFinishedSource,
 };
 use tokio::task::JoinHandle;
 
@@ -71,8 +71,8 @@ pub(super) struct CompleteBarrierTask {
     pub(super) load_finished_source_ids: Vec<PbLoadFinishedSource>,
     /// Table IDs that have finished materialize refresh and need completion signaling
     pub(super) refresh_finished_table_job_ids: Vec<JobId>,
-    /// Iceberg V3 sink reports collected during this barrier
-    pub(super) iceberg_v3_sink_metadata: Vec<PbIcebergV3SinkMetadata>,
+    /// Iceberg pk-index sink reports collected during this barrier
+    pub(super) iceberg_pk_index_sink_metadata: Vec<PbIcebergPkIndexSinkMetadata>,
 }
 
 impl CompleteBarrierTask {
@@ -106,23 +106,23 @@ impl CompleteBarrierTask {
                 .barrier_wait_commit_latency
                 .start_timer();
 
-            // Iceberg V3 sink metadata reports are handled in three steps around hummock `commit_epoch`:
+            // Iceberg pk-index sink metadata reports are handled in three steps around hummock `commit_epoch`:
             //   1. pre_commit: persist pending rows under `pending_sink_state` (no iceberg I/O).
             //   2. commit_epoch: advance hummock.
             //   3. commit: drive iceberg overwrite_files for queued epochs.
-            let mut iceberg_v3_commit_sink_ids = Vec::new();
-            if !self.iceberg_v3_sink_metadata.is_empty() {
+            let mut iceberg_pk_index_commit_sink_ids = Vec::new();
+            if !self.iceberg_pk_index_sink_metadata.is_empty() {
                 let res = context
-                    .pre_commit_iceberg_v3_sink_metadata(self.iceberg_v3_sink_metadata)
+                    .pre_commit_iceberg_pk_index_sink_metadata(self.iceberg_pk_index_sink_metadata)
                     .await?;
-                iceberg_v3_commit_sink_ids = res;
+                iceberg_pk_index_commit_sink_ids = res;
             }
 
             let version_stats = context.commit_epoch(self.commit_info).await?;
 
-            if !iceberg_v3_commit_sink_ids.is_empty() {
+            if !iceberg_pk_index_commit_sink_ids.is_empty() {
                 context
-                    .commit_iceberg_v3_sink_metadata(iceberg_v3_commit_sink_ids)
+                    .commit_iceberg_pk_index_sink_metadata(iceberg_pk_index_commit_sink_ids)
                     .await?;
             }
 

--- a/src/meta/src/barrier/context/context_impl.rs
+++ b/src/meta/src/barrier/context/context_impl.rs
@@ -27,7 +27,7 @@ use risingwave_pb::common::WorkerNode;
 use risingwave_pb::hummock::HummockVersionStats;
 use risingwave_pb::id::SourceId;
 use risingwave_pb::stream_service::barrier_complete_response::{
-    PbIcebergV3SinkMetadata, PbListFinishedSource, PbLoadFinishedSource,
+    PbIcebergPkIndexSinkMetadata, PbListFinishedSource, PbLoadFinishedSource,
 };
 use risingwave_pb::stream_service::streaming_control_stream_request::PbInitRequest;
 use risingwave_rpc_client::StreamingControlHandle;
@@ -411,24 +411,22 @@ impl GlobalBarrierWorkerContext for GlobalBarrierWorkerContextImpl {
     }
 
     #[await_tree::instrument]
-    async fn pre_commit_iceberg_v3_sink_metadata(
+    async fn pre_commit_iceberg_pk_index_sink_metadata(
         &self,
-        reports: Vec<PbIcebergV3SinkMetadata>,
+        reports: Vec<PbIcebergPkIndexSinkMetadata>,
     ) -> MetaResult<Vec<SinkId>> {
-        let grouped = group_v3_reports_by_sink(reports)?;
+        let grouped = group_reports_by_sink(reports)?;
         let success_ids: Vec<SinkId> = grouped.keys().cloned().collect();
         let futs = FuturesUnordered::new();
         for (sink_id, (prev_epoch, reports)) in grouped {
             if reports.is_empty() {
                 continue;
             }
-            let manager = &self.iceberg_v3_sink_manager;
+            let manager = &self.iceberg_pk_index_sink_manager;
             futs.push(async move {
                 (
                     sink_id,
-                    manager
-                        .pre_commit_v3_epoch(sink_id, prev_epoch, reports)
-                        .await,
+                    manager.pre_commit_epoch(sink_id, prev_epoch, reports).await,
                 )
             });
         }
@@ -443,16 +441,16 @@ impl GlobalBarrierWorkerContext for GlobalBarrierWorkerContextImpl {
         if errs.is_empty() {
             Ok(success_ids)
         } else {
-            Err(aggregate_v3_sink_errors("pre-commit", errs).into())
+            Err(aggregate_sink_errors("pre-commit", errs).into())
         }
     }
 
     #[await_tree::instrument]
-    async fn commit_iceberg_v3_sink_metadata(&self, sink_ids: Vec<SinkId>) -> MetaResult<()> {
+    async fn commit_iceberg_pk_index_sink_metadata(&self, sink_ids: Vec<SinkId>) -> MetaResult<()> {
         let futs = FuturesUnordered::new();
         for sink_id in sink_ids {
-            let manager = &self.iceberg_v3_sink_manager;
-            futs.push(async move { (sink_id, manager.commit_v3_epoch(sink_id).await) });
+            let manager = &self.iceberg_pk_index_sink_manager;
+            futs.push(async move { (sink_id, manager.commit_epoch(sink_id).await) });
         }
 
         let results: Vec<(SinkId, anyhow::Result<()>)> = futs.collect().await;
@@ -463,7 +461,7 @@ impl GlobalBarrierWorkerContext for GlobalBarrierWorkerContextImpl {
         if errs.is_empty() {
             Ok(())
         } else {
-            Err(aggregate_v3_sink_errors("commit", errs).into())
+            Err(aggregate_sink_errors("commit", errs).into())
         }
     }
 }
@@ -471,7 +469,7 @@ impl GlobalBarrierWorkerContext for GlobalBarrierWorkerContextImpl {
 /// Combine per-sink errors from a fan-out into a single `anyhow::Error`. The first failing
 /// sink's error is used as the source so the original chain is preserved; the message lists
 /// every failing `sink_id` and its error stringified.
-fn aggregate_v3_sink_errors(
+fn aggregate_sink_errors(
     phase: &'static str,
     mut errs: Vec<(SinkId, anyhow::Error)>,
 ) -> anyhow::Error {
@@ -491,10 +489,10 @@ fn aggregate_v3_sink_errors(
     ))
 }
 
-fn group_v3_reports_by_sink(
-    reports: Vec<PbIcebergV3SinkMetadata>,
-) -> MetaResult<HashMap<SinkId, (u64, Vec<PbIcebergV3SinkMetadata>)>> {
-    let mut grouped: HashMap<SinkId, (u64, Vec<PbIcebergV3SinkMetadata>)> = HashMap::new();
+fn group_reports_by_sink(
+    reports: Vec<PbIcebergPkIndexSinkMetadata>,
+) -> MetaResult<HashMap<SinkId, (u64, Vec<PbIcebergPkIndexSinkMetadata>)>> {
+    let mut grouped: HashMap<SinkId, (u64, Vec<PbIcebergPkIndexSinkMetadata>)> = HashMap::new();
     for r in reports {
         let sink_id = r.sink_id;
         let prev_epoch = r.prev_epoch;

--- a/src/meta/src/barrier/context/mod.rs
+++ b/src/meta/src/barrier/context/mod.rs
@@ -25,7 +25,8 @@ use risingwave_meta_model::SinkId;
 use risingwave_pb::common::WorkerNode;
 use risingwave_pb::hummock::HummockVersionStats;
 use risingwave_pb::stream_service::barrier_complete_response::{
-    IcebergV3SinkMetadata as PbIcebergV3SinkMetadata, PbListFinishedSource, PbLoadFinishedSource,
+    IcebergPkIndexSinkMetadata as PbIcebergPkIndexSinkMetadata, PbListFinishedSource,
+    PbLoadFinishedSource,
 };
 use risingwave_pb::stream_service::streaming_control_stream_request::PbInitRequest;
 use risingwave_rpc_client::StreamingControlHandle;
@@ -41,7 +42,7 @@ use crate::barrier::{
     RecoveryReason, Scheduled, SnapshotBackfillInfo,
 };
 use crate::hummock::{CommitEpochInfo, HummockManagerRef};
-use crate::manager::iceberg_v3_sink::IcebergV3SinkManager;
+use crate::manager::iceberg_pk_index_sink::IcebergPkIndexSinkManager;
 use crate::manager::sink_coordination::SinkCoordinatorManager;
 use crate::manager::{MetaSrvEnv, MetadataManager};
 use crate::stream::source_manager::SplitAssignment;
@@ -160,12 +161,12 @@ pub(super) trait GlobalBarrierWorkerContext: Send + Sync + 'static {
         last_committed_epoch: u64,
     ) -> impl Future<Output = MetaResult<BatchRefreshJobTriggerContext>> + Send + '_;
 
-    fn pre_commit_iceberg_v3_sink_metadata(
+    fn pre_commit_iceberg_pk_index_sink_metadata(
         &self,
-        reports: Vec<PbIcebergV3SinkMetadata>,
+        reports: Vec<PbIcebergPkIndexSinkMetadata>,
     ) -> impl Future<Output = MetaResult<Vec<SinkId>>> + Send + '_;
 
-    fn commit_iceberg_v3_sink_metadata(
+    fn commit_iceberg_pk_index_sink_metadata(
         &self,
         sink_ids: Vec<SinkId>,
     ) -> impl Future<Output = MetaResult<()>> + Send + '_;
@@ -193,7 +194,7 @@ pub(super) struct GlobalBarrierWorkerContextImpl {
 
     sink_manager: SinkCoordinatorManager,
 
-    pub(super) iceberg_v3_sink_manager: IcebergV3SinkManager,
+    pub(super) iceberg_pk_index_sink_manager: IcebergPkIndexSinkManager,
 }
 
 impl GlobalBarrierWorkerContextImpl {
@@ -209,7 +210,7 @@ impl GlobalBarrierWorkerContextImpl {
         barrier_scheduler: BarrierScheduler,
         refresh_manager: GlobalRefreshManagerRef,
         sink_manager: SinkCoordinatorManager,
-        iceberg_v3_sink_manager: IcebergV3SinkManager,
+        iceberg_pk_index_sink_manager: IcebergPkIndexSinkManager,
     ) -> Self {
         Self {
             scheduled_barriers,
@@ -222,7 +223,7 @@ impl GlobalBarrierWorkerContextImpl {
             barrier_scheduler,
             refresh_manager,
             sink_manager,
-            iceberg_v3_sink_manager,
+            iceberg_pk_index_sink_manager,
         }
     }
 

--- a/src/meta/src/barrier/context/recovery.rs
+++ b/src/meta/src/barrier/context/recovery.rs
@@ -469,16 +469,20 @@ impl GlobalBarrierWorkerContextImpl {
             self.sink_manager
                 .stop_sink_coordinator(sink_ids.clone())
                 .await;
-            self.iceberg_v3_sink_manager.unregister_v3_sinks(sink_ids);
+            self.iceberg_pk_index_sink_manager
+                .unregister_sinks(sink_ids);
         } else {
             self.sink_manager.reset().await;
-            self.iceberg_v3_sink_manager.reset();
+            self.iceberg_pk_index_sink_manager.reset();
         }
         Ok(())
     }
 
-    /// Re-register iceberg V3 sink commit coordinators after recovery wipes them.
-    async fn reregister_iceberg_v3_sinks(&self, database_id: Option<DatabaseId>) -> MetaResult<()> {
+    /// Re-register iceberg pk-index sink commit coordinators after recovery wipes them.
+    async fn reregister_iceberg_pk_index_sinks(
+        &self,
+        database_id: Option<DatabaseId>,
+    ) -> MetaResult<()> {
         let pb_sinks = self
             .metadata_manager
             .catalog_controller
@@ -487,24 +491,21 @@ impl GlobalBarrierWorkerContextImpl {
         let mut futs = FuturesUnordered::new();
         for pb_sink in pb_sinks {
             if database_id.is_some_and(|db_id| pb_sink.database_id != db_id)
-                || !crate::manager::iceberg_v3_sink::is_iceberg_v3_sink(&pb_sink.properties)
+                || !crate::manager::iceberg_pk_index_sink::is_iceberg_pk_index_sink(
+                    &pb_sink.properties,
+                )
             {
                 continue;
             }
-            let config = crate::manager::iceberg_v3_sink::build_iceberg_config(&pb_sink)
+            let config = crate::manager::iceberg_pk_index_sink::build_iceberg_config(&pb_sink)
                 .with_context(|| {
                     format!(
                         "build iceberg config while re-registering v3 sink {}",
                         pb_sink.id
                     )
                 })?;
-            let manager = &self.iceberg_v3_sink_manager;
-            futs.push(async move {
-                (
-                    pb_sink.id,
-                    manager.register_v3_sink(pb_sink.id, config).await,
-                )
-            });
+            let manager = &self.iceberg_pk_index_sink_manager;
+            futs.push(async move { (pb_sink.id, manager.register_sink(pb_sink.id, config).await) });
         }
 
         while let Some((id, res)) = futs.next().await {
@@ -826,10 +827,10 @@ impl GlobalBarrierWorkerContextImpl {
                         .await
                         .context("abort dirty pending sink state")?;
 
-                    // We must abort dirty pending sink state before registering iceberg V3 sinks,
+                    // We must abort dirty pending sink state before registering iceberg pk-index sinks,
                     // otherwise recover_pending will take speculative (epoch > committed epoch) pending sink state
                     // as valid and cause duplicated iceberg commit.
-                    self.reregister_iceberg_v3_sinks(None)
+                    self.reregister_iceberg_pk_index_sinks(None)
                         .await
                         .context("re-register iceberg v3 sinks after recovery")?;
 
@@ -1004,7 +1005,7 @@ impl GlobalBarrierWorkerContextImpl {
         self.abort_dirty_pending_sink_state(Some(database_id))
             .await
             .context("abort dirty pending sink state")?;
-        self.reregister_iceberg_v3_sinks(Some(database_id))
+        self.reregister_iceberg_pk_index_sinks(Some(database_id))
             .await
             .context("re-register iceberg v3 sinks after recovery")?;
 

--- a/src/meta/src/barrier/manager.rs
+++ b/src/meta/src/barrier/manager.rs
@@ -39,7 +39,7 @@ use crate::barrier::{
     RecoveryReason, UpdateDatabaseBarrierRequest, schedule,
 };
 use crate::hummock::HummockManagerRef;
-use crate::manager::iceberg_v3_sink::IcebergV3SinkManager;
+use crate::manager::iceberg_pk_index_sink::IcebergPkIndexSinkManager;
 use crate::manager::sink_coordination::SinkCoordinatorManager;
 use crate::manager::{MetaSrvEnv, MetadataManager};
 use crate::stream::{GlobalRefreshManagerRef, ScaleControllerRef, SourceManagerRef};
@@ -200,7 +200,7 @@ impl GlobalBarrierManager {
         hummock_manager: HummockManagerRef,
         source_manager: SourceManagerRef,
         sink_manager: SinkCoordinatorManager,
-        iceberg_v3_sink_manager: IcebergV3SinkManager,
+        iceberg_pk_index_sink_manager: IcebergPkIndexSinkManager,
         scale_controller: ScaleControllerRef,
         barrier_scheduler: schedule::BarrierScheduler,
         refresh_manager: GlobalRefreshManagerRef,
@@ -215,7 +215,7 @@ impl GlobalBarrierManager {
             hummock_manager,
             source_manager,
             sink_manager,
-            iceberg_v3_sink_manager,
+            iceberg_pk_index_sink_manager,
             scale_controller,
             request_rx,
             barrier_scheduler,

--- a/src/meta/src/barrier/schedule.rs
+++ b/src/meta/src/barrier/schedule.rs
@@ -955,16 +955,16 @@ mod tests {
             unimplemented!()
         }
 
-        async fn pre_commit_iceberg_v3_sink_metadata(
+        async fn pre_commit_iceberg_pk_index_sink_metadata(
             &self,
             _reports: Vec<
-                risingwave_pb::stream_service::barrier_complete_response::IcebergV3SinkMetadata,
+                risingwave_pb::stream_service::barrier_complete_response::IcebergPkIndexSinkMetadata,
             >,
         ) -> MetaResult<Vec<risingwave_meta_model::SinkId>> {
             unimplemented!()
         }
 
-        async fn commit_iceberg_v3_sink_metadata(
+        async fn commit_iceberg_pk_index_sink_metadata(
             &self,
             _sink_ids: Vec<risingwave_meta_model::SinkId>,
         ) -> MetaResult<()> {

--- a/src/meta/src/barrier/tests/worker_crash_no_early_commit.rs
+++ b/src/meta/src/barrier/tests/worker_crash_no_early_commit.rs
@@ -179,16 +179,19 @@ impl GlobalBarrierWorkerContext for MockBarrierWorkerContext {
         unimplemented!()
     }
 
-    async fn pre_commit_iceberg_v3_sink_metadata(
+    async fn pre_commit_iceberg_pk_index_sink_metadata(
         &self,
         _reports: Vec<
-            risingwave_pb::stream_service::barrier_complete_response::IcebergV3SinkMetadata,
+            risingwave_pb::stream_service::barrier_complete_response::IcebergPkIndexSinkMetadata,
         >,
     ) -> MetaResult<Vec<SinkId>> {
         unimplemented!()
     }
 
-    async fn commit_iceberg_v3_sink_metadata(&self, _sink_ids: Vec<SinkId>) -> MetaResult<()> {
+    async fn commit_iceberg_pk_index_sink_metadata(
+        &self,
+        _sink_ids: Vec<SinkId>,
+    ) -> MetaResult<()> {
         unimplemented!()
     }
 }

--- a/src/meta/src/barrier/utils.rs
+++ b/src/meta/src/barrier/utils.rs
@@ -31,7 +31,7 @@ use risingwave_pb::catalog::table::PbTableType;
 use risingwave_pb::hummock::vector_index_delta::PbVectorIndexInit;
 use risingwave_pb::stream_plan::stream_node::NodeBody;
 use risingwave_pb::stream_service::BarrierCompleteResponse;
-use risingwave_pb::stream_service::barrier_complete_response::IcebergV3SinkMetadata;
+use risingwave_pb::stream_service::barrier_complete_response::IcebergPkIndexSinkMetadata;
 
 use crate::barrier::CreateStreamingJobCommandInfo;
 use crate::barrier::command::PostCollectCommand;
@@ -49,7 +49,7 @@ pub(super) fn collect_resp_info(
     Vec<SstableInfo>,
     HashMap<TableId, Vec<VectorIndexAdd>>,
     HashSet<TableId>,
-    Vec<IcebergV3SinkMetadata>,
+    Vec<IcebergPkIndexSinkMetadata>,
 ) {
     let mut sst_to_worker: HashMap<HummockSstableObjectId, _> = HashMap::new();
     let mut synced_ssts: Vec<LocalSstableInfo> = vec![];
@@ -57,7 +57,7 @@ pub(super) fn collect_resp_info(
     let mut old_value_ssts = Vec::with_capacity(resps.len());
     let mut vector_index_adds = HashMap::new();
     let mut truncate_tables: HashSet<TableId> = HashSet::new();
-    let mut iceberg_v3_sink_metadata = Vec::new();
+    let mut iceberg_pk_index_sink_metadata = Vec::new();
 
     for resp in resps {
         let ssts_iter = resp.synced_sstables.into_iter().map(|local_sst| {
@@ -85,7 +85,7 @@ pub(super) fn collect_resp_info(
                 .expect("non-duplicate");
         }
         truncate_tables.extend(resp.truncate_tables);
-        iceberg_v3_sink_metadata.extend(resp.iceberg_v3_sink_metadata);
+        iceberg_pk_index_sink_metadata.extend(resp.iceberg_pk_index_sink_metadata);
     }
 
     (
@@ -107,7 +107,7 @@ pub(super) fn collect_resp_info(
         old_value_ssts,
         vector_index_adds,
         truncate_tables,
-        iceberg_v3_sink_metadata,
+        iceberg_pk_index_sink_metadata,
     )
 }
 
@@ -146,7 +146,7 @@ pub(super) fn collect_independent_job_commit_epoch_info(
         old_value_sst,
         vector_index_adds,
         truncate_tables,
-        iceberg_v3_sink_metadata,
+        iceberg_pk_index_sink_metadata,
     ) = collect_resp_info(resps);
     assert!(old_value_sst.is_empty());
     let commit_info = &mut task.commit_info;
@@ -190,8 +190,8 @@ pub(super) fn collect_independent_job_commit_epoch_info(
                 .expect("non-duplicate");
         }
     };
-    task.iceberg_v3_sink_metadata
-        .extend(iceberg_v3_sink_metadata);
+    task.iceberg_pk_index_sink_metadata
+        .extend(iceberg_pk_index_sink_metadata);
 }
 
 pub(super) type NodeToCollect = HashSet<WorkerId>;

--- a/src/meta/src/barrier/worker.rs
+++ b/src/meta/src/barrier/worker.rs
@@ -57,7 +57,7 @@ use crate::barrier::{
 use crate::controller::scale::{materialize_actor_assignments, preview_actor_assignments};
 use crate::error::MetaErrorInner;
 use crate::hummock::HummockManagerRef;
-use crate::manager::iceberg_v3_sink::IcebergV3SinkManager;
+use crate::manager::iceberg_pk_index_sink::IcebergPkIndexSinkManager;
 use crate::manager::sink_coordination::SinkCoordinatorManager;
 use crate::manager::{
     ActiveStreamingWorkerChange, ActiveStreamingWorkerNodes, LocalNotification, MetaSrvEnv,
@@ -309,7 +309,7 @@ impl GlobalBarrierWorker<GlobalBarrierWorkerContextImpl> {
         hummock_manager: HummockManagerRef,
         source_manager: SourceManagerRef,
         sink_manager: SinkCoordinatorManager,
-        iceberg_v3_sink_manager: IcebergV3SinkManager,
+        iceberg_pk_index_sink_manager: IcebergPkIndexSinkManager,
         scale_controller: ScaleControllerRef,
         request_rx: mpsc::UnboundedReceiver<BarrierManagerRequest>,
         barrier_scheduler: schedule::BarrierScheduler,
@@ -328,7 +328,7 @@ impl GlobalBarrierWorker<GlobalBarrierWorkerContextImpl> {
             barrier_scheduler,
             refresh_manager,
             sink_manager,
-            iceberg_v3_sink_manager,
+            iceberg_pk_index_sink_manager,
         ));
 
         Self::new_inner(env, request_rx, context).await

--- a/src/meta/src/controller/catalog/drop_op.rs
+++ b/src/meta/src/controller/catalog/drop_op.rs
@@ -219,18 +219,20 @@ impl CatalogController {
             .map(|(sink, obj)| ObjectModel(sink, obj.unwrap(), None).into())
             .collect();
 
-        // Collect Iceberg V3 sink ids among dropped sinks so the V3 sink manager
+        // Collect Iceberg pk-index sink ids among dropped sinks so the pk-index sink manager
         // can tear down their per-sink commit workers. Unlike the iceberg-table
-        // cleanup above, V3 sinks are user-created with arbitrary names, so we
+        // cleanup above, pk-index sinks are user-created with arbitrary names, so we
         // identify them by inspecting properties rather than by name prefix.
-        let removed_iceberg_v3_sink_ids: Vec<SinkId> = Sink::find()
+        let removed_iceberg_pk_index_sink_ids: Vec<SinkId> = Sink::find()
             .filter(sink::Column::SinkId.is_in(removed_object_ids.clone()))
             .all(&txn)
             .await?
             .into_iter()
             .filter_map(|sink| {
-                crate::manager::iceberg_v3_sink::is_iceberg_v3_sink(sink.properties.inner_ref())
-                    .then_some(sink.sink_id)
+                crate::manager::iceberg_pk_index_sink::is_iceberg_pk_index_sink(
+                    sink.properties.inner_ref(),
+                )
+                .then_some(sink.sink_id)
             })
             .collect();
 
@@ -446,7 +448,7 @@ impl CatalogController {
                 removed_fragments,
                 removed_sink_fragment_by_targets,
                 removed_iceberg_table_sinks,
-                removed_iceberg_v3_sink_ids,
+                removed_iceberg_pk_index_sink_ids,
             },
             version,
         ))

--- a/src/meta/src/controller/catalog/mod.rs
+++ b/src/meta/src/controller/catalog/mod.rs
@@ -143,10 +143,10 @@ pub struct ReleaseContext {
     /// Dropped iceberg table sinks
     pub(crate) removed_iceberg_table_sinks: Vec<PbSink>,
 
-    /// Dropped Iceberg V3 sink ids. Used to unregister per-sink commit workers
-    /// owned by `IcebergV3SinkManager`. Filtered via `is_iceberg_v3_sink` on
-    /// the sink properties so user-created V3 sinks (any name) are included.
-    pub(crate) removed_iceberg_v3_sink_ids: Vec<SinkId>,
+    /// Dropped Iceberg pk-index sink ids. Used to unregister per-sink commit workers
+    /// owned by `IcebergPkIndexSinkManager`. Filtered via `is_iceberg_pk_index_sink` on
+    /// the sink properties so user-created pk-index sinks (any name) are included.
+    pub(crate) removed_iceberg_pk_index_sink_ids: Vec<SinkId>,
 }
 
 #[derive(Default)]

--- a/src/meta/src/manager/exactly_once_util.rs
+++ b/src/meta/src/manager/exactly_once_util.rs
@@ -22,7 +22,7 @@ use sea_orm::{
 use thiserror_ext::AsReport;
 
 // Helpers for accessing the `pending_sink_state` system table used by exactly-once sink coordinators
-// (both the generic sink coordinator and the Iceberg V3 sink coordinator).
+// (both the generic sink coordinator and the Iceberg pk-index sink coordinator).
 
 pub async fn persist_pre_commit_metadata(
     db: &DatabaseConnection,

--- a/src/meta/src/manager/iceberg_pk_index_sink/backfill.rs
+++ b/src/meta/src/manager/iceberg_pk_index_sink/backfill.rs
@@ -44,7 +44,7 @@ pub fn backfill_dv_partitions(
 
     if !waiting_delete_files.is_empty() {
         anyhow::bail!(
-            "backfill iceberg v3 sink delete files failed, missing referenced data files: {:?}",
+            "backfill iceberg pk-index sink delete files failed, missing referenced data files: {:?}",
             waiting_delete_files.keys().collect::<Vec<_>>()
         );
     }
@@ -116,7 +116,7 @@ mod tests {
     #[test]
     fn dv_referencing_older_snapshot_left_alone() -> Result<()> {
         // DV references a data file NOT in the uncommitted writer set — its
-        // partition was correctly populated by DvMerger from the older
+        // partition was correctly populated by PositionDeleteMerger from the older
         // snapshot and must not be overwritten.
         let writers = [writer_file("data/a.parquet", struct_with_int(1))];
         let dv_partition = struct_with_int(99);

--- a/src/meta/src/manager/iceberg_pk_index_sink/backfill.rs
+++ b/src/meta/src/manager/iceberg_pk_index_sink/backfill.rs
@@ -17,14 +17,14 @@ use std::collections::HashMap;
 use anyhow::Result;
 use iceberg::spec::DataFile;
 
-pub fn backfill_dv_partitions(
+pub fn backfill_delete_file_partitions(
     writer_files: &[DataFile],
-    dv_delete_files: &mut [DataFile],
+    delete_files: &mut [DataFile],
 ) -> Result<()> {
-    if dv_delete_files.is_empty() {
+    if delete_files.is_empty() {
         return Ok(());
     }
-    let mut waiting_delete_files = dv_delete_files
+    let mut waiting_delete_files = delete_files
         .iter_mut()
         .filter(|dv| dv.partition().fields().is_empty())
         .map(|dv| (dv.referenced_data_file().unwrap(), dv))
@@ -91,12 +91,12 @@ mod tests {
     #[test]
     fn empty_inputs_noop() -> Result<()> {
         let mut dvs: Vec<DataFile> = vec![];
-        backfill_dv_partitions(&[], &mut dvs)?;
+        backfill_delete_file_partitions(&[], &mut dvs)?;
         assert!(dvs.is_empty());
 
         let writers = [writer_file("data/a.parquet", struct_with_int(7))];
         let mut dvs: Vec<DataFile> = vec![];
-        backfill_dv_partitions(&writers, &mut dvs)?;
+        backfill_delete_file_partitions(&writers, &mut dvs)?;
 
         assert!(dvs.is_empty());
         Ok(())
@@ -107,7 +107,7 @@ mod tests {
         let writers = [writer_file("data/a.parquet", struct_with_int(42))];
         let mut dvs = vec![dv_file("dv/a.puff", "data/a.parquet", Struct::empty())];
 
-        backfill_dv_partitions(&writers, &mut dvs)?;
+        backfill_delete_file_partitions(&writers, &mut dvs)?;
 
         assert_eq!(dvs[0].partition(), &struct_with_int(42));
         Ok(())
@@ -126,7 +126,7 @@ mod tests {
             dv_partition.clone(),
         )];
 
-        backfill_dv_partitions(&writers, &mut dvs)?;
+        backfill_delete_file_partitions(&writers, &mut dvs)?;
 
         assert_eq!(dvs[0].partition(), &dv_partition, "must not overwrite");
         Ok(())
@@ -144,7 +144,7 @@ mod tests {
             dv_file("dv/b.puff", "data/b.parquet", Struct::empty()),
         ];
 
-        backfill_dv_partitions(&writers, &mut dvs)?;
+        backfill_delete_file_partitions(&writers, &mut dvs)?;
 
         assert_eq!(dvs[0].partition(), &struct_with_int(1));
         assert_eq!(

--- a/src/meta/src/manager/iceberg_pk_index_sink/coordinator.rs
+++ b/src/meta/src/manager/iceberg_pk_index_sink/coordinator.rs
@@ -58,7 +58,7 @@ use serde::{Deserialize, Serialize};
 use thiserror_ext::AsReport;
 use tokio::time::timeout;
 
-use super::backfill::backfill_dv_partitions;
+use super::backfill::backfill_delete_file_partitions;
 use crate::manager::exactly_once_util::{
     clean_aborted_records, commit_and_prune_epoch, list_sink_states_ordered_by_epoch,
     persist_pre_commit_metadata,
@@ -166,7 +166,7 @@ impl IcebergPkIndexSinkCoordinator {
                 prev_epoch
             );
         }
-        let (merged, materialized_add_files) = self.backfill_dv_partitions(merged)?;
+        let (merged, materialized_add_files) = self.backfill_delete_file_partitions(merged)?;
         let merged = Arc::new(merged);
 
         let snapshot_id = FastAppendAction::generate_snapshot_id(&self.table);
@@ -228,7 +228,7 @@ impl IcebergPkIndexSinkCoordinator {
     /// referenced data files. Returns the updated aggregate (with the backfilled delete files
     /// re-serialized for persistence) and, when backfill ran, the data + delete files already
     /// materialized as `DataFile`s so the commit can reuse them instead of deserializing again.
-    fn backfill_dv_partitions(
+    fn backfill_delete_file_partitions(
         &self,
         merged: IcebergPkIndexSinkAggResult,
     ) -> Result<(IcebergPkIndexSinkAggResult, Option<Vec<DataFile>>)> {
@@ -255,7 +255,7 @@ impl IcebergPkIndexSinkCoordinator {
             .into_iter()
             .map(|f| f.try_into(merged.partition_spec_id, &partition_type, schema))
             .try_collect::<Vec<DataFile>>()?;
-        backfill_dv_partitions(&data_files, &mut delete_files)?;
+        backfill_delete_file_partitions(&data_files, &mut delete_files)?;
 
         let format_version = self.table.metadata().format_version();
         let serialized_delete_files = delete_files

--- a/src/meta/src/manager/iceberg_pk_index_sink/coordinator.rs
+++ b/src/meta/src/manager/iceberg_pk_index_sink/coordinator.rs
@@ -12,13 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! Per-sink Iceberg V3 commit coordinator. This is a plain struct (no background task / mpsc): the
-//! [`crate::manager::iceberg_v3_sink::IcebergV3SinkManager`] holds one per registered sink behind a
-//! per-sink async mutex and calls [`IcebergV3Coordinator::pre_commit`] / [`IcebergV3Coordinator::commit`]
+//! Per-sink iceberg pk-index commit coordinator. This is a plain struct (no background task / mpsc): the
+//! [`crate::manager::iceberg_pk_index_sink::IcebergPkIndexSinkManager`] holds one per registered sink behind a
+//! per-sink async mutex and calls [`IcebergPkIndexSinkCoordinator::pre_commit`] / [`IcebergPkIndexSinkCoordinator::commit`]
 //! directly from the barrier-completion path. The barrier path already serializes pre-commit/commit per
 //! epoch, so the coordinator never needs its own request queue.
 //!
-//! [`IcebergV3Coordinator::init`] is synchronous with respect to registration: it loads the iceberg
+//! [`IcebergPkIndexSinkCoordinator::init`] is synchronous with respect to registration: it loads the iceberg
 //! catalog/table, reads `pending_sink_state`, and drains any recovered pending epoch via an iceberg
 //! `overwrite_files` transaction BEFORE returning a ready coordinator. Only once init completes does the
 //! sink start accepting live pre-commit/commit calls.
@@ -39,19 +39,20 @@ use std::time::Duration;
 
 use anyhow::{Context, Result, anyhow, bail};
 use iceberg::Catalog;
-use iceberg::spec::{DataFile, FormatVersion, SerializedDataFile};
+use iceberg::spec::{DataFile, SerializedDataFile};
 use iceberg::table::Table;
 use iceberg::transaction::{ApplyTransactionAction, FastAppendAction, Transaction};
 use prost::Message;
 use risingwave_connector::sink::catalog::SinkId;
 use risingwave_connector::sink::iceberg::commit_retry::{self, CommitError};
 use risingwave_connector::sink::iceberg::{
-    IcebergCommitResult, IcebergConfig, IcebergDvMergerCommitResult, commit_branch,
+    IcebergCommitResult, IcebergConfig, IcebergPositionDeleteMergerCommitResult, commit_branch,
+    resolve_partition_type,
 };
 use risingwave_meta_model::pending_sink_state::SinkState;
-use risingwave_pb::connector_service::PbIcebergV3PreCommitState;
-use risingwave_pb::stream_service::PbIcebergV3SinkRole;
-use risingwave_pb::stream_service::barrier_complete_response::PbIcebergV3SinkMetadata;
+use risingwave_pb::connector_service::PbIcebergPkIndexPreCommitState;
+use risingwave_pb::stream_service::PbIcebergPkIndexSinkRole;
+use risingwave_pb::stream_service::barrier_complete_response::PbIcebergPkIndexSinkMetadata;
 use sea_orm::DatabaseConnection;
 use serde::{Deserialize, Serialize};
 use thiserror_ext::AsReport;
@@ -68,18 +69,23 @@ use crate::manager::exactly_once_util::{
 const INIT_TIMEOUT: Duration = Duration::from_secs(60);
 
 /// One epoch's worth of pre-committed state queued inside the coordinator. Holds the decoded merged file
-/// list and the pre-generated `snapshot_id`. The blob form ([`PbIcebergV3PreCommitState`]) is only
+/// list and the pre-generated `snapshot_id`. The blob form ([`PbIcebergPkIndexPreCommitState`]) is only
 /// materialized when persisting to `pending_sink_state`; in-memory we keep the structured form.
 #[derive(Clone)]
 struct EpochCommit {
     epoch: u64,
-    merged: Arc<IcebergV3AggResult>,
+    merged: Arc<IcebergPkIndexSinkAggResult>,
     snapshot_id: i64,
+    /// Data + delete files already materialized during pre-commit backfill (partitioned tables
+    /// only), in the `add_data_files` order expected by the commit. Flows straight into the commit
+    /// so the files are not deserialized again. `None` on the recovery path (and for unpartitioned
+    /// tables that skip backfill), where the commit materializes them from `merged` once.
+    materialized_add_files: Option<Vec<DataFile>>,
 }
 
-/// Per-sink Iceberg V3 commit coordinator. Owns the loaded iceberg catalog/table (reused across commits)
+/// Per-sink iceberg pk-index commit coordinator. Owns the loaded iceberg catalog/table (reused across commits)
 /// and the meta SQL connection (used for `pending_sink_state` exactly-once persistence).
-pub struct IcebergV3Coordinator {
+pub struct IcebergPkIndexSinkCoordinator {
     sink_id: SinkId,
     db: DatabaseConnection,
     catalog: Arc<dyn Catalog>,
@@ -91,7 +97,7 @@ pub struct IcebergV3Coordinator {
     prev_committed_epoch: Option<u64>,
 }
 
-impl IcebergV3Coordinator {
+impl IcebergPkIndexSinkCoordinator {
     /// Build a ready-to-serve coordinator: load the iceberg catalog/table, recover any persisted pending
     /// state, and drain recovered pending epochs to iceberg. Returns only once recovery is complete, so a
     /// successful return means the sink is ready to accept live pre-commit/commit calls.
@@ -104,16 +110,20 @@ impl IcebergV3Coordinator {
             .await
             .map_err(|_| {
                 anyhow!(
-                    "iceberg v3 coordinator for sink {} timed out after {}s loading iceberg catalog/table",
+                    "iceberg pk-index sink coordinator for sink {} timed out after {}s loading iceberg catalog/table",
                     sink_id,
                     INIT_TIMEOUT.as_secs()
                 )
             })?
-            .with_context(|| format!("init iceberg v3 coordinator for sink {}", sink_id))?;
+            .with_context(|| format!("init iceberg pk-index sink coordinator for sink {}", sink_id))?;
 
-        let (prev_committed_epoch, recovered) = recovery(&db, sink_id)
-            .await
-            .with_context(|| format!("recover pending state for iceberg v3 sink {}", sink_id))?;
+        let (prev_committed_epoch, recovered) =
+            recovery(&db, sink_id).await.with_context(|| {
+                format!(
+                    "recover pending state for iceberg pk-index sink {}",
+                    sink_id
+                )
+            })?;
 
         let target_branch =
             commit_branch(iceberg_config.r#type.as_str(), iceberg_config.write_mode);
@@ -143,7 +153,7 @@ impl IcebergV3Coordinator {
     pub async fn pre_commit(
         &mut self,
         prev_epoch: u64,
-        reports: Vec<PbIcebergV3SinkMetadata>,
+        reports: Vec<PbIcebergPkIndexSinkMetadata>,
     ) -> Result<()> {
         if reports.iter().all(|r| r.metadata.is_none()) {
             return Ok(());
@@ -151,9 +161,13 @@ impl IcebergV3Coordinator {
 
         let merged = aggregate_reports(&reports)?;
         if merged.data_files.is_empty() && merged.delete_files.is_empty() {
-            bail!("v3 sink epoch {} has no data files to commit", prev_epoch);
+            bail!(
+                "pk-index sink epoch {} has no data files to commit",
+                prev_epoch
+            );
         }
-        let merged = Arc::new(self.backfill_dv_partitions(merged)?);
+        let (merged, materialized_add_files) = self.backfill_dv_partitions(merged)?;
+        let merged = Arc::new(merged);
 
         let snapshot_id = FastAppendAction::generate_snapshot_id(&self.table);
         let blob = encode_pre_commit_state(&merged, snapshot_id)?;
@@ -163,6 +177,7 @@ impl IcebergV3Coordinator {
             epoch: prev_epoch,
             merged,
             snapshot_id,
+            materialized_add_files,
         });
         Ok(())
     }
@@ -185,7 +200,7 @@ impl IcebergV3Coordinator {
                 CommitError::Commit(e) | CommitError::ReloadTable(e) => e,
             };
             anyhow!(err_report).context(format!(
-                "iceberg v3 commit failed for sink {} epoch {}",
+                "iceberg pk-index sink commit failed for sink {} epoch {}",
                 self.sink_id, commit.epoch
             ))
         })?;
@@ -200,7 +215,7 @@ impl IcebergV3Coordinator {
         .await
         .with_context(|| {
             format!(
-                "iceberg v3 mark_committed failed for sink {} epoch {}",
+                "iceberg pk-index sink mark_committed failed for sink {} epoch {}",
                 self.sink_id, commit.epoch
             )
         })?;
@@ -209,14 +224,22 @@ impl IcebergV3Coordinator {
         Ok(())
     }
 
-    fn backfill_dv_partitions(&self, merged: IcebergV3AggResult) -> Result<IcebergV3AggResult> {
+    /// Backfills missing partition values on the delete files (partitioned tables only) from the
+    /// referenced data files. Returns the updated aggregate (with the backfilled delete files
+    /// re-serialized for persistence) and, when backfill ran, the data + delete files already
+    /// materialized as `DataFile`s so the commit can reuse them instead of deserializing again.
+    fn backfill_dv_partitions(
+        &self,
+        merged: IcebergPkIndexSinkAggResult,
+    ) -> Result<(IcebergPkIndexSinkAggResult, Option<Vec<DataFile>>)> {
         let partition_spec = self
             .table
             .metadata()
             .partition_spec_by_id(merged.partition_spec_id)
-            .context("find partition spec for v3 commit")?;
+            .context("find partition spec for pk-index sink commit")?;
         if partition_spec.is_unpartitioned() {
-            return Ok(merged);
+            // No backfill needed; the commit materializes the files from serialized form once.
+            return Ok((merged, None));
         }
 
         let schema = self.table.metadata().current_schema();
@@ -226,25 +249,34 @@ impl IcebergV3Coordinator {
             .clone()
             .into_iter()
             .map(|f| f.try_into(merged.partition_spec_id, &partition_type, schema))
-            .try_collect::<Vec<_>>()?;
+            .try_collect::<Vec<DataFile>>()?;
         let mut delete_files = merged
             .delete_files
             .into_iter()
             .map(|f| f.try_into(merged.partition_spec_id, &partition_type, schema))
-            .try_collect::<Vec<_>>()?;
+            .try_collect::<Vec<DataFile>>()?;
         backfill_dv_partitions(&data_files, &mut delete_files)?;
-        let delete_files = delete_files
-            .into_iter()
-            .map(|f| SerializedDataFile::try_from(f, &partition_type, FormatVersion::V3))
+
+        let format_version = self.table.metadata().format_version();
+        let serialized_delete_files = delete_files
+            .iter()
+            .cloned()
+            .map(|f| SerializedDataFile::try_from(f, &partition_type, format_version))
             .try_collect()?;
 
-        Ok(IcebergV3AggResult {
+        let merged = IcebergPkIndexSinkAggResult {
             schema_id: merged.schema_id,
             partition_spec_id: merged.partition_spec_id,
             data_files: merged.data_files,
-            delete_files,
+            delete_files: serialized_delete_files,
             overwrite_files: merged.overwrite_files,
-        })
+        };
+
+        // `add_data_files` order in `commit_one_epoch` is data files followed by delete files.
+        let mut materialized_add_files = data_files;
+        materialized_add_files.extend(delete_files);
+
+        Ok((merged, Some(materialized_add_files)))
     }
 }
 
@@ -254,11 +286,11 @@ async fn load_catalog_and_table(
     let catalog = iceberg_config
         .create_catalog()
         .await
-        .map_err(|e| anyhow!(e).context("create iceberg catalog for v3 sink"))?;
+        .map_err(|e| anyhow!(e).context("create iceberg catalog for pk-index sink"))?;
     let table = iceberg_config
         .load_table()
         .await
-        .map_err(|e| anyhow!(e).context("load iceberg table for v3 sink"))?;
+        .map_err(|e| anyhow!(e).context("load iceberg table for pk-index sink"))?;
     Ok((catalog, table))
 }
 
@@ -272,7 +304,7 @@ async fn recovery(
     )));
     let rows = list_sink_states_ordered_by_epoch(db, sink_id)
         .await
-        .context("list pending sink states for v3 recovery")?;
+        .context("list pending sink states for pk-index sink recovery")?;
 
     let mut prev_committed_epoch = None;
     let mut pending = Vec::new();
@@ -284,14 +316,21 @@ async fn recovery(
             }
             SinkState::Pending => {
                 let blob = metadata.ok_or_else(|| {
-                    anyhow!("v3 pending row at epoch {} missing metadata blob", epoch)
+                    anyhow!(
+                        "pk-index sink pending row at epoch {} missing metadata blob",
+                        epoch
+                    )
                 })?;
-                let (merged, snapshot_id) = decode_pre_commit_state(&blob)
-                    .with_context(|| format!("decode v3 pre-commit state at epoch {}", epoch))?;
+                let (merged, snapshot_id) = decode_pre_commit_state(&blob).with_context(|| {
+                    format!("decode pk-index sink pre-commit state at epoch {}", epoch)
+                })?;
                 pending.push(EpochCommit {
                     epoch,
                     merged,
                     snapshot_id,
+                    // Recovered from the persisted blob; the commit materializes files from
+                    // `merged` once.
+                    materialized_add_files: None,
                 });
             }
             SinkState::Aborted => {
@@ -300,7 +339,7 @@ async fn recovery(
                 tracing::warn!(
                     sink_id = %sink_id,
                     epoch,
-                    "unexpected Aborted state in v3 recovery; cleaning up",
+                    "unexpected Aborted state in pk-index sink recovery; cleaning up",
                 );
                 aborted_epochs.push(epoch);
             }
@@ -313,7 +352,7 @@ async fn recovery(
         tracing::warn!(
             error = %e.as_report(),
             sink_id = %sink_id,
-            "failed to clean unexpected Aborted rows during v3 recovery",
+            "failed to clean unexpected Aborted rows during pk-index sink recovery",
         );
     }
     Ok((prev_committed_epoch, pending))
@@ -328,6 +367,7 @@ async fn commit_one_epoch(
 ) -> Result<Table, CommitError> {
     let merged = commit.merged.clone();
     let snapshot_id = commit.snapshot_id;
+    let materialized_add_files = commit.materialized_add_files.clone();
 
     commit_retry::run_with_retry(
         catalog.clone(),
@@ -339,6 +379,7 @@ async fn commit_one_epoch(
             let merged = merged.clone();
             let catalog = catalog.clone();
             let target_branch = target_branch.clone();
+            let materialized_add_files = materialized_add_files.clone();
             async move {
                 // Idempotency: if iceberg already saw this `snapshot_id`, skip the overwrite_files transaction.
                 if table
@@ -350,38 +391,39 @@ async fn commit_one_epoch(
                 }
 
                 let schema = table.metadata().current_schema();
-                let partition_spec = table
-                    .metadata()
-                    .partition_spec_by_id(merged.partition_spec_id)
-                    .ok_or_else(|| CommitError::Commit(anyhow!("partition spec not found")))?;
-                let partition_type = partition_spec
-                    .partition_type(schema)
-                    .map_err(|e| CommitError::Commit(anyhow!(e)))?;
+                let partition_type =
+                    resolve_partition_type(&table, merged.partition_spec_id, schema)
+                        .map_err(|e| CommitError::Commit(anyhow!(e)))?;
 
-                let mut add_files: Vec<DataFile> = Vec::new();
-                let mut overwrite_files: Vec<DataFile> = Vec::new();
-                for serialized in merged.data_files.iter().chain(merged.delete_files.iter()) {
-                    let f = serialized
-                        .clone()
-                        .try_into(merged.partition_spec_id, &partition_type, schema)
-                        .map_err(|err| {
-                            CommitError::Commit(
-                                anyhow!(err).context("materialize v3 SerializedDataFile"),
-                            )
-                        })?;
-                    add_files.push(f);
-                }
-                for serialized in &merged.overwrite_files {
-                    let f = serialized
-                        .clone()
-                        .try_into(merged.partition_spec_id, &partition_type, schema)
-                        .map_err(|err| {
-                            CommitError::Commit(
-                                anyhow!(err).context("materialize v3 SerializedDataFile"),
-                            )
-                        })?;
-                    overwrite_files.push(f);
-                }
+                let materialize =
+                    |serialized: &SerializedDataFile| -> Result<DataFile, CommitError> {
+                        serialized
+                            .clone()
+                            .try_into(merged.partition_spec_id, &partition_type, schema)
+                            .map_err(|err| {
+                                CommitError::Commit(
+                                    anyhow!(err)
+                                        .context("materialize pk-index sink SerializedDataFile"),
+                                )
+                            })
+                    };
+
+                // Reuse the files already materialized during pre-commit backfill when available;
+                // otherwise (recovery / unpartitioned) materialize from the persisted form once.
+                let add_files: Vec<DataFile> = match materialized_add_files {
+                    Some(add_files) => add_files,
+                    None => merged
+                        .data_files
+                        .iter()
+                        .chain(merged.delete_files.iter())
+                        .map(&materialize)
+                        .collect::<Result<Vec<_>, _>>()?,
+                };
+                let overwrite_files: Vec<DataFile> = merged
+                    .overwrite_files
+                    .iter()
+                    .map(&materialize)
+                    .collect::<Result<Vec<_>, _>>()?;
 
                 let txn = Transaction::new(&table);
                 let action = txn
@@ -392,11 +434,13 @@ async fn commit_one_epoch(
                     .delete_files(overwrite_files);
                 let txn = action.apply(txn).map_err(|err| {
                     CommitError::Commit(
-                        anyhow!(err).context("apply iceberg v3 overwrite_files action"),
+                        anyhow!(err).context("apply iceberg pk-index sink overwrite_files action"),
                     )
                 })?;
                 let table = txn.commit(catalog.as_ref()).await.map_err(|err| {
-                    CommitError::Commit(anyhow!(err).context("commit iceberg v3 transaction"))
+                    CommitError::Commit(
+                        anyhow!(err).context("commit iceberg pk-index sink transaction"),
+                    )
                 })?;
                 Ok(table)
             }
@@ -407,7 +451,7 @@ async fn commit_one_epoch(
 }
 
 #[derive(Clone, Serialize, Deserialize)]
-struct IcebergV3AggResult {
+struct IcebergPkIndexSinkAggResult {
     schema_id: i32,
     partition_spec_id: i32,
     data_files: Vec<SerializedDataFile>,
@@ -415,7 +459,9 @@ struct IcebergV3AggResult {
     overwrite_files: Vec<SerializedDataFile>,
 }
 
-fn aggregate_reports(reports: &[PbIcebergV3SinkMetadata]) -> Result<IcebergV3AggResult> {
+fn aggregate_reports(
+    reports: &[PbIcebergPkIndexSinkMetadata],
+) -> Result<IcebergPkIndexSinkAggResult> {
     let mut shared_schema_id: Option<i32> = None;
     let mut shared_partition_spec_id: Option<i32> = None;
 
@@ -424,22 +470,22 @@ fn aggregate_reports(reports: &[PbIcebergV3SinkMetadata]) -> Result<IcebergV3Agg
     let mut overwrite_files: Vec<SerializedDataFile> = Vec::new();
 
     if reports.is_empty() {
-        bail!("no reports to aggregate for iceberg v3 coordinator");
+        bail!("no reports to aggregate for iceberg pk-index sink coordinator");
     }
 
     for r in reports {
         let Some(meta) = &r.metadata else {
-            bail!("iceberg v3 sink report missing metadata in aggregate_reports");
+            bail!("iceberg pk-index sink report missing metadata in aggregate_reports");
         };
 
         // Validate role: explicitly-Unspecified is a wire-format bug.
-        let role = PbIcebergV3SinkRole::try_from(r.role)
+        let role = PbIcebergPkIndexSinkRole::try_from(r.role)
             .ok()
-            .filter(|r| !matches!(r, PbIcebergV3SinkRole::Unspecified))
-            .ok_or_else(|| anyhow!("iceberg v3 sink report has invalid role: {}", r.role))?;
+            .filter(|r| !matches!(r, PbIcebergPkIndexSinkRole::Unspecified))
+            .ok_or_else(|| anyhow!("iceberg pk-index sink report has invalid role: {}", r.role))?;
 
         match role {
-            PbIcebergV3SinkRole::Writer => {
+            PbIcebergPkIndexSinkRole::Writer => {
                 let commit_result = IcebergCommitResult::try_from(meta)?;
                 align_report_id(
                     commit_result.schema_id,
@@ -449,9 +495,11 @@ fn aggregate_reports(reports: &[PbIcebergV3SinkMetadata]) -> Result<IcebergV3Agg
                 )?;
                 data_files.extend(commit_result.data_files);
             }
-            PbIcebergV3SinkRole::DvMerger => {
-                let commit_result = IcebergDvMergerCommitResult::try_from(meta)
-                    .map_err(|e| anyhow!(e).context("decode v3 dv merger metadata"))?;
+            PbIcebergPkIndexSinkRole::PositionDeleteMerger => {
+                let commit_result = IcebergPositionDeleteMergerCommitResult::try_from(meta)
+                    .map_err(|e| {
+                        anyhow!(e).context("decode pk-index sink position-delete merger metadata")
+                    })?;
                 align_report_id(
                     commit_result.schema_id,
                     commit_result.partition_spec_id,
@@ -465,7 +513,7 @@ fn aggregate_reports(reports: &[PbIcebergV3SinkMetadata]) -> Result<IcebergV3Agg
         }
     }
 
-    Ok(IcebergV3AggResult {
+    Ok(IcebergPkIndexSinkAggResult {
         schema_id: shared_schema_id.unwrap(),
         partition_spec_id: shared_partition_spec_id.unwrap(),
         data_files,
@@ -483,7 +531,7 @@ fn align_report_id(
     match shared_schema_id {
         Some(prev) if *prev != schema_id => {
             bail!(
-                "iceberg v3 sink reports disagree on schema_id: {} vs {}",
+                "iceberg pk-index sink reports disagree on schema_id: {} vs {}",
                 prev,
                 schema_id
             );
@@ -494,7 +542,7 @@ fn align_report_id(
     match shared_partition_spec_id {
         Some(prev) if *prev != partition_spec_id => {
             bail!(
-                "iceberg v3 sink reports disagree on partition_spec_id: {} vs {}",
+                "iceberg pk-index sink reports disagree on partition_spec_id: {} vs {}",
                 prev,
                 partition_spec_id
             );
@@ -505,17 +553,20 @@ fn align_report_id(
     Ok(())
 }
 
-fn encode_pre_commit_state(agg_result: &IcebergV3AggResult, snapshot_id: i64) -> Result<Vec<u8>> {
+fn encode_pre_commit_state(
+    agg_result: &IcebergPkIndexSinkAggResult,
+    snapshot_id: i64,
+) -> Result<Vec<u8>> {
     let agg_result = serde_json::to_vec(agg_result)?;
-    Ok(PbIcebergV3PreCommitState {
+    Ok(PbIcebergPkIndexPreCommitState {
         agg_result,
         snapshot_id,
     }
     .encode_to_vec())
 }
 
-fn decode_pre_commit_state(blob: &[u8]) -> Result<(Arc<IcebergV3AggResult>, i64)> {
-    let state = PbIcebergV3PreCommitState::decode(blob)?;
+fn decode_pre_commit_state(blob: &[u8]) -> Result<(Arc<IcebergPkIndexSinkAggResult>, i64)> {
+    let state = PbIcebergPkIndexPreCommitState::decode(blob)?;
     let agg_result = Arc::new(serde_json::from_slice(&state.agg_result)?);
     Ok((agg_result, state.snapshot_id))
 }

--- a/src/meta/src/manager/iceberg_pk_index_sink/manager.rs
+++ b/src/meta/src/manager/iceberg_pk_index_sink/manager.rs
@@ -19,18 +19,18 @@ use anyhow::anyhow;
 use parking_lot::RwLock;
 use risingwave_connector::sink::catalog::SinkId;
 use risingwave_connector::sink::iceberg::IcebergConfig;
-use risingwave_pb::stream_service::barrier_complete_response::IcebergV3SinkMetadata as PbIcebergV3SinkMetadata;
+use risingwave_pb::stream_service::barrier_complete_response::IcebergPkIndexSinkMetadata as PbIcebergPkIndexSinkMetadata;
 use sea_orm::DatabaseConnection;
 use tokio::sync::Mutex;
 use tracing::warn;
 
-use super::coordinator::IcebergV3Coordinator;
+use super::coordinator::IcebergPkIndexSinkCoordinator;
 
-type CoordinatorRef = Arc<Mutex<IcebergV3Coordinator>>;
+type CoordinatorRef = Arc<Mutex<IcebergPkIndexSinkCoordinator>>;
 
-/// Manager for the Iceberg V3 sink path, cheap to clone.
+/// Manager for the Iceberg pk-index sink path, cheap to clone.
 #[derive(Clone)]
-pub struct IcebergV3SinkManager {
+pub struct IcebergPkIndexSinkManager {
     inner: Arc<ManagerInner>,
 }
 
@@ -41,9 +41,9 @@ struct ManagerInner {
     coordinators: RwLock<HashMap<SinkId, CoordinatorRef>>,
 }
 
-impl IcebergV3SinkManager {
+impl IcebergPkIndexSinkManager {
     pub fn new(db: DatabaseConnection) -> Self {
-        IcebergV3SinkManager {
+        IcebergPkIndexSinkManager {
             inner: Arc::new(ManagerInner {
                 db,
                 coordinators: RwLock::new(HashMap::new()),
@@ -51,18 +51,19 @@ impl IcebergV3SinkManager {
         }
     }
 
-    /// Register an Iceberg V3 sink so its commit coordinator is ready to receive epoch reports. Builds and
+    /// Register an Iceberg pk-index sink so its commit coordinator is ready to receive epoch reports. Builds and
     /// fully initializes the coordinator (loading the iceberg table and draining any recovered pending
     /// commits) BEFORE inserting it, so a successful return means the sink is ready to serve. Idempotent:
     /// registering the same `sink_id` replaces the existing coordinator.
-    pub async fn register_v3_sink(
+    pub async fn register_sink(
         &self,
         sink_id: SinkId,
         iceberg_config: IcebergConfig,
     ) -> anyhow::Result<()> {
         // Initialize (load + recover + drain) outside the map lock; this is the slow, fallible part.
         let coordinator =
-            IcebergV3Coordinator::init(sink_id, iceberg_config, self.inner.db.clone()).await?;
+            IcebergPkIndexSinkCoordinator::init(sink_id, iceberg_config, self.inner.db.clone())
+                .await?;
 
         let prev = self
             .inner
@@ -72,18 +73,18 @@ impl IcebergV3SinkManager {
         if prev.is_some() {
             // Replacing an existing coordinator. Any in-flight commit on the old one keeps it alive via its
             // own `Arc` until it finishes; the snapshot_id idempotency check guards against double-commit.
-            warn!(%sink_id, "iceberg v3 coordinator re-registered; replacing previous instance");
+            warn!(%sink_id, "iceberg pk-index sink coordinator re-registered; replacing previous instance");
         }
         Ok(())
     }
 
     /// Pre-commit phase for one epoch: persist the merged report under `pending_sink_state` (no iceberg IO).
     /// The barrier-complete path awaits this BEFORE issuing hummock `commit_epoch`.
-    pub async fn pre_commit_v3_epoch(
+    pub async fn pre_commit_epoch(
         &self,
         sink_id: SinkId,
         prev_epoch: u64,
-        reports: Vec<PbIcebergV3SinkMetadata>,
+        reports: Vec<PbIcebergPkIndexSinkMetadata>,
     ) -> anyhow::Result<()> {
         let coordinator = self.coordinator(sink_id)?;
         coordinator
@@ -95,14 +96,14 @@ impl IcebergV3SinkManager {
 
     /// Commit phase for one epoch: run an iceberg `overwrite_files` transaction and mark its pending row
     /// committed. The barrier-complete path awaits this AFTER hummock `commit_epoch`.
-    pub async fn commit_v3_epoch(&self, sink_id: SinkId) -> anyhow::Result<()> {
+    pub async fn commit_epoch(&self, sink_id: SinkId) -> anyhow::Result<()> {
         let coordinator = self.coordinator(sink_id)?;
         coordinator.lock().await.commit().await
     }
 
     /// Unregister the given `sink_id`(s)' coordinator(s) (e.g. at DROP SINK time). Unregistering an unknown
     /// `sink_id` is a no-op.
-    pub fn unregister_v3_sinks(&self, sink_ids: Vec<SinkId>) {
+    pub fn unregister_sinks(&self, sink_ids: Vec<SinkId>) {
         let mut coordinators = self.inner.coordinators.write();
         for sink_id in sink_ids {
             coordinators.remove(&sink_id);
@@ -122,7 +123,7 @@ impl IcebergV3SinkManager {
             .cloned()
             .ok_or_else(|| {
                 anyhow!(
-                    "iceberg v3 coordinator for sink {} is not registered",
+                    "iceberg pk-index sink coordinator for sink {} is not registered",
                     sink_id
                 )
             })

--- a/src/meta/src/manager/iceberg_pk_index_sink/mod.rs
+++ b/src/meta/src/manager/iceberg_pk_index_sink/mod.rs
@@ -12,12 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! Manager for the Iceberg V3 sink path. Owns per-sink commit coordinators that
+//! Manager for the Iceberg pk-index sink path. Owns per-sink commit coordinators that
 //! drive iceberg `commit_epoch` ahead of hummock `commit_epoch` and persist
 //! exactly-once state via `pending_sink_state`.
 //!
 //! This is intentionally separate from [`crate::manager::sink_coordination`]
-//! (which serves V1/V2 sinks via gRPC). Future V3 responsibilities such as
+//! (which serves V1/V2 sinks via gRPC). Future responsibilities such as
 //! per-sink compaction will live alongside the per-sink commit coordinator here.
 
 pub mod backfill;
@@ -27,15 +27,15 @@ mod manager;
 use std::collections::BTreeMap;
 
 use anyhow::anyhow;
-pub use manager::IcebergV3SinkManager;
+pub use manager::IcebergPkIndexSinkManager;
 use risingwave_common::secret::LocalSecretManager;
 use risingwave_connector::sink::iceberg::{ENABLE_PK_INDEX, IcebergConfig};
 use risingwave_connector::source::UPSTREAM_SOURCE_KEY;
 use risingwave_pb::catalog::PbSink;
 
-/// Returns true if the given sink properties identify a Iceberg V3 sink
+/// Returns true if the given sink properties identify a Iceberg pk-index sink
 /// (i.e. an iceberg sink with `enable_pk_index = 'true'`).
-pub fn is_iceberg_v3_sink(properties: &BTreeMap<String, String>) -> bool {
+pub fn is_iceberg_pk_index_sink(properties: &BTreeMap<String, String>) -> bool {
     let connector_match = properties
         .get(UPSTREAM_SOURCE_KEY)
         .map(|v| v.eq_ignore_ascii_case("iceberg"))
@@ -48,7 +48,7 @@ pub fn is_iceberg_v3_sink(properties: &BTreeMap<String, String>) -> bool {
 }
 
 /// Build an [`IcebergConfig`] from a [`PbSink`], filling secret refs along the
-/// way. Used at CREATE SINK time and during recovery to (re-)register the V3
+/// way. Used at CREATE SINK time and during recovery to (re-)register the
 /// commit coordinator.
 pub fn build_iceberg_config(pb_sink: &PbSink) -> anyhow::Result<IcebergConfig> {
     let properties: BTreeMap<String, String> = pb_sink.properties.clone().into_iter().collect();

--- a/src/meta/src/manager/mod.rs
+++ b/src/meta/src/manager/mod.rs
@@ -17,7 +17,7 @@ mod env;
 pub mod event_log;
 mod exactly_once_util;
 pub mod iceberg_compaction;
-pub mod iceberg_v3_sink;
+pub mod iceberg_pk_index_sink;
 mod idle;
 mod license;
 mod metadata;

--- a/src/meta/src/rpc/ddl_controller.rs
+++ b/src/meta/src/rpc/ddl_controller.rs
@@ -76,7 +76,7 @@ use crate::controller::streaming_job::{FinishAutoRefreshSchemaSinkContext, SinkI
 use crate::controller::utils::build_select_node_list;
 use crate::error::{MetaErrorInner, bail_invalid_parameter};
 use crate::manager::iceberg_compaction::IcebergCompactionManagerRef;
-use crate::manager::iceberg_v3_sink::IcebergV3SinkManager;
+use crate::manager::iceberg_pk_index_sink::IcebergPkIndexSinkManager;
 use crate::manager::sink_coordination::SinkCoordinatorManager;
 use crate::manager::{
     IGNORED_NOTIFICATION_VERSION, LocalNotification, MetaSrvEnv, MetadataManager,
@@ -287,7 +287,7 @@ pub struct DdlController {
     barrier_manager: BarrierManagerRef,
     sink_manager: SinkCoordinatorManager,
     iceberg_compaction_manager: IcebergCompactionManagerRef,
-    iceberg_v3_sink_manager: IcebergV3SinkManager,
+    iceberg_pk_index_sink_manager: IcebergPkIndexSinkManager,
 
     // The semaphore is used to limit the number of concurrent streaming job creation.
     pub(crate) creating_streaming_job_permits: Arc<CreatingStreamingJobPermit>,
@@ -410,7 +410,7 @@ impl DdlController {
         barrier_manager: BarrierManagerRef,
         sink_manager: SinkCoordinatorManager,
         iceberg_compaction_manager: IcebergCompactionManagerRef,
-        iceberg_v3_sink_manager: IcebergV3SinkManager,
+        iceberg_pk_index_sink_manager: IcebergPkIndexSinkManager,
     ) -> Self {
         let creating_streaming_job_permits = Arc::new(CreatingStreamingJobPermit::new(&env).await);
         Self {
@@ -421,7 +421,7 @@ impl DdlController {
             barrier_manager,
             sink_manager,
             iceberg_compaction_manager,
-            iceberg_v3_sink_manager,
+            iceberg_pk_index_sink_manager,
             creating_streaming_job_permits,
             seq: Arc::new(AtomicU64::new(0)),
         }
@@ -1335,15 +1335,16 @@ impl DdlController {
                 }
                 // Validate the sink on the connector node.
                 validate_sink(sink).await?;
-                // For Iceberg V3 sinks, spawn the per-sink commit worker now
+                // For Iceberg pk-index sinks, spawn the per-sink commit worker now
                 // so it's ready to receive epoch reports from the very first
                 // barrier instead of relying on lazy registration on every
                 // commit.
-                if crate::manager::iceberg_v3_sink::is_iceberg_v3_sink(&sink.properties) {
+                if crate::manager::iceberg_pk_index_sink::is_iceberg_pk_index_sink(&sink.properties)
+                {
                     let iceberg_config =
-                        crate::manager::iceberg_v3_sink::build_iceberg_config(sink)?;
-                    self.iceberg_v3_sink_manager
-                        .register_v3_sink(sink.id, iceberg_config)
+                        crate::manager::iceberg_pk_index_sink::build_iceberg_config(sink)?;
+                    self.iceberg_pk_index_sink_manager
+                        .register_sink(sink.id, iceberg_config)
                         .await
                         .map_err(|e| anyhow!(e).context("register v3 sink worker"))?;
                 }
@@ -1452,7 +1453,7 @@ impl DdlController {
             removed_fragments,
             removed_sink_fragment_by_targets,
             removed_iceberg_table_sinks,
-            removed_iceberg_v3_sink_ids,
+            removed_iceberg_pk_index_sink_ids,
         } = release_ctx;
 
         // Notify serving module about deleted fragments so it can clean up serving vnode mappings.
@@ -1538,12 +1539,12 @@ impl DdlController {
             }
         }
 
-        // Unregister per-sink commit coordinators for any dropped V3 iceberg sink,
+        // Unregister per-sink commit coordinators for any dropped pk-index iceberg sink,
         // including user-created sinks with arbitrary names (not just the
         // `__iceberg_sink_%` auto-created ones above).
-        if !removed_iceberg_v3_sink_ids.is_empty() {
-            self.iceberg_v3_sink_manager
-                .unregister_v3_sinks(removed_iceberg_v3_sink_ids);
+        if !removed_iceberg_pk_index_sink_ids.is_empty() {
+            self.iceberg_pk_index_sink_manager
+                .unregister_sinks(removed_iceberg_pk_index_sink_ids);
         }
 
         // remove secrets.

--- a/src/meta/src/stream/stream_graph/fragment.rs
+++ b/src/meta/src/stream/stream_graph/fragment.rs
@@ -167,7 +167,7 @@ impl BuildingFragment {
 
                 has_job = true;
             }
-            NodeBody::IcebergWithPkIndexDvMerger(merger_node) => {
+            NodeBody::IcebergWithPkIndexPositionDeleteMerger(merger_node) => {
                 merger_node.sink_desc.as_mut().unwrap().id = job_id.as_sink_id();
 
                 has_job = true;

--- a/src/prost/build.rs
+++ b/src/prost/build.rs
@@ -931,7 +931,7 @@ for_all_wrapped_id_fields! (
             backfill_actor_id: ActorId,
             fragment_id: FragmentId,
         }
-        BarrierCompleteResponse.IcebergV3SinkMetadata {
+        BarrierCompleteResponse.IcebergPkIndexSinkMetadata {
             reporter_actor_id: ActorId,
             sink_id: SinkId,
         }
@@ -1206,7 +1206,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .boxed(".stream_plan.StreamNode.node_body.gap_fill")
         .boxed(".stream_plan.StreamNode.node_body.vector_index_lookup_join")
         .boxed(".stream_plan.StreamNode.node_body.iceberg_with_pk_index_writer")
-        .boxed(".stream_plan.StreamNode.node_body.iceberg_with_pk_index_dv_merger")
+        .boxed(".stream_plan.StreamNode.node_body.iceberg_with_pk_index_position_delete_merger")
         // `Udf` is 248 bytes, while 2nd largest field is 32 bytes.
         .boxed(".expr.ExprNode.rex_node.udf")
         // prost-build 0.14+ only derives `Eq`/`Hash` for a subset of messages/oneofs.

--- a/src/stream/Cargo.toml
+++ b/src/stream/Cargo.toml
@@ -44,6 +44,7 @@ memcomparable = "0.2"
 moka = { version = "0.12.0", features = ["sync"] }
 multimap = "0.10"
 parking_lot = { workspace = true }
+parquet = { workspace = true }
 paste = "1"
 pin-project = "1"
 prometheus = { version = "0.14", features = ["process"] }
@@ -88,7 +89,7 @@ risingwave_connector = { workspace = true, features = ["test"] }
 risingwave_expr_impl = { workspace = true }
 risingwave_hummock_sdk = { workspace = true }
 risingwave_hummock_test = { path = "../storage/hummock_test", features = [
-  "test",
+    "test",
 ] }
 risingwave_stream = { workspace = true, features = ["test"] }
 serde_yaml = "0.9"

--- a/src/stream/src/executor/iceberg_with_pk_index/mod.rs
+++ b/src/stream/src/executor/iceberg_with_pk_index/mod.rs
@@ -12,24 +12,25 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! Iceberg V3 Sink with Primary Key Index
+//! pk-index sink (V2/V3)
 //!
-//! This module implements three core executors for the Iceberg V3 sink that uses
+//! This module implements three core executors for the Iceberg pk-index sink that uses
 //! Deletion Vectors (DVs) instead of Equality Delete files:
 //!
 //! 1. **Writer Executor** (Stateful): Maintains a PK index mapping primary keys to
 //!    (`file_path`, `position`). Writes data files for inserts and emits
 //!    (`file_path`, `position`) messages for deletes.
 //!
-//! 2. **DV Merger Executor** (Stateless): Consumes the Writer's (`file_path`, `position`) messages,
-//!    merges delete positions with historical DVs, and reports the resulting DV files to meta.
+//! 2. **Position-delete merger executor** (Stateless): Consumes the Writer's (`file_path`, `position`)
+//!    messages, merges delete positions with historical deletes, and reports the resulting delete
+//!    files to meta.
 
-mod dv_handler_impl;
-mod dv_merger;
+mod position_delete_handler_impl;
+mod position_delete_merger;
 mod writer;
 mod writer_impl;
 
-pub use dv_handler_impl::DvHandlerImpl;
-pub use dv_merger::DvMergerExecutor;
+pub use position_delete_handler_impl::PositionDeleteHandlerImpl;
+pub use position_delete_merger::PositionDeleteMergerExecutor;
 pub use writer::WriterExecutor;
 pub use writer_impl::IcebergWriterImpl;

--- a/src/stream/src/executor/iceberg_with_pk_index/position_delete_handler_impl.rs
+++ b/src/stream/src/executor/iceberg_with_pk_index/position_delete_handler_impl.rs
@@ -13,29 +13,44 @@
 // limitations under the License.
 
 use std::collections::{HashMap as StdHashMap, HashSet};
+use std::sync::Arc;
 
 use anyhow::Context;
+use futures::StreamExt;
 use hashbrown::HashMap;
 use hashbrown::hash_map::Entry;
+use iceberg::arrow::schema_to_arrow_schema;
 use iceberg::delete_vector::DeleteVector;
 use iceberg::io::FileIO;
 use iceberg::puffin::{CompressionCodec, PuffinReader, PuffinWriter};
 use iceberg::spec::{
-    DataContentType, DataFile, DataFileBuilder, DataFileFormat, ManifestContentType, ManifestList,
-    PartitionKey, SerializedDataFile,
+    DataContentType, DataFile, DataFileBuilder, DataFileFormat, FormatVersion, ManifestContentType,
+    ManifestList, PartitionKey, SerializedDataFile,
 };
 use iceberg::table::Table;
+use iceberg::writer::base_writer::position_delete_file_writer::POSITION_DELETE_SCHEMA;
 use iceberg::writer::file_writer::location_generator::{
     DefaultFileNameGenerator, DefaultLocationGenerator, FileNameGenerator, LocationGenerator,
 };
-use risingwave_connector::sink::iceberg::{
-    IcebergConfig, IcebergDvMergerCommitResult, truncate_datafile,
+use iceberg::writer::file_writer::{
+    FileWriter, FileWriterBuilder, ParquetWriter, ParquetWriterBuilder,
 };
+use parquet::arrow::{ParquetRecordBatchStreamBuilder, ProjectionMask};
+use parquet::file::properties::WriterProperties;
+use risingwave_common::array::arrow::arrow_array_iceberg::{
+    Array, ArrayRef, Int64Array, RecordBatch, StringArray,
+};
+use risingwave_common::array::arrow::arrow_schema_iceberg::SchemaRef as ArrowSchemaRef;
+use risingwave_connector::sink::iceberg::{
+    IcebergConfig, IcebergPositionDeleteMergerCommitResult, PARQUET_CREATED_BY,
+    resolve_partition_spec, resolve_partition_type, serialize_data_files_default_spec,
+};
+use risingwave_connector::source::iceberg::parquet_file_handler::ParquetFileReader;
 use risingwave_pb::connector_service::SinkMetadata;
 use risingwave_pb::id::{ActorId, SinkId};
 use uuid::Uuid;
 
-use super::dv_merger::DvHandler;
+use super::position_delete_merger::PositionDeleteHandler;
 use crate::executor::{StreamExecutorError, StreamExecutorResult};
 
 /// Puffin blob property for deletion vector cardinality.
@@ -43,6 +58,11 @@ const DELETION_VECTOR_PROPERTY_CARDINALITY: &str = "cardinality";
 /// Puffin blob property for referenced data file path.
 const DELETION_VECTOR_PROPERTY_REFERENCED_DATA_FILE: &str = "referenced-data-file";
 
+/// Per-data-file accumulator returned by [`load_delete_vectors`].
+///
+/// Holds the delete positions loaded from an existing delete file (a V3 Puffin deletion vector
+/// or a V2 Parquet position-delete file), the partition key for partitioned tables, and the
+/// existing delete file to be overwritten when the merged result is committed.
 #[derive(Debug, Default)]
 struct LoadedDeleteVectorEntry {
     delete_vector: Option<DeleteVector>,
@@ -50,16 +70,19 @@ struct LoadedDeleteVectorEntry {
     overwrite_file: Option<DataFile>,
 }
 
-/// Real implementation of [`DvHandler`] using the iceberg-rust crate.
-pub struct DvHandlerImpl {
+/// Real implementation of [`PositionDeleteHandler`] using the iceberg-rust crate.
+pub struct PositionDeleteHandlerImpl {
     config: IcebergConfig,
     location_generator: DefaultLocationGenerator,
+    /// File-name generator for V3 Puffin deletion vector files.
     file_name_generator: DefaultFileNameGenerator,
+    /// File-name generator for V2 Parquet position-delete files.
+    parquet_file_name_generator: DefaultFileNameGenerator,
     delete_vectors: HashMap<String, DeleteVector>,
     sink_id: SinkId,
 }
 
-impl DvHandlerImpl {
+impl PositionDeleteHandlerImpl {
     pub async fn new(
         config: IcebergConfig,
         actor_id: ActorId,
@@ -71,23 +94,30 @@ impl DvHandlerImpl {
             .map_err(|e| StreamExecutorError::sink_error(e, sink_id))?;
         let location_generator = DefaultLocationGenerator::new(table.metadata().clone())
             .map_err(|e| StreamExecutorError::sink_error(e, sink_id))?;
-        let unique_uuid_suffix = Uuid::now_v7();
+        let uuid_suffix = Uuid::now_v7();
         let file_name_generator = DefaultFileNameGenerator::new(
             actor_id.to_string(),
-            Some(unique_uuid_suffix.to_string()),
+            Some(format!("delvec-{}", uuid_suffix)),
             DataFileFormat::Puffin,
+        );
+        let parquet_file_name_generator = DefaultFileNameGenerator::new(
+            actor_id.to_string(),
+            Some(format!("pos-del-{}", uuid_suffix)),
+            DataFileFormat::Parquet,
         );
         Ok(Self {
             config,
             location_generator,
             file_name_generator,
+            parquet_file_name_generator,
             delete_vectors: HashMap::new(),
             sink_id,
         })
     }
 
     /// Merges `delete_vector` with any existing DV from `loaded`, writes the result
-    /// as a Puffin blob, and returns the resulting [`DataFile`] metadata.
+    /// as a single V3 Puffin deletion vector blob referencing `data_file_path`, and
+    /// returns its [`DataFile`] metadata with `referenced_data_file` set.
     async fn write_dv_puffin_file(
         &mut self,
         table: &Table,
@@ -167,10 +197,146 @@ impl DvHandlerImpl {
             )
         })
     }
+
+    /// Merges `delete_vector` with any existing positions from `loaded`, writes the result
+    /// as a single file-scoped V2 Parquet position-delete file, and returns the resulting
+    /// [`DataFile`] metadata. The produced file references exactly one data file
+    /// (`data_file_path`) via `referenced_data_file`.
+    ///
+    /// File-scoped deletes reference exactly one data file, so this writes the file
+    /// with a plain [`ParquetWriter`] rather than the sink's rolling position-delete
+    /// writer stack.
+    async fn write_parquet_position_delete_file(
+        &self,
+        table: &Table,
+        data_file_path: String,
+        mut delete_vector: DeleteVector,
+        loaded: LoadedDeleteVectorEntry,
+    ) -> StreamExecutorResult<DataFile> {
+        let LoadedDeleteVectorEntry {
+            delete_vector: existing_delete_vector,
+            partition_key,
+            ..
+        } = loaded;
+
+        if let Some(existing) = existing_delete_vector {
+            delete_vector |= existing;
+        }
+
+        let file_name = self.parquet_file_name_generator.generate_file_name();
+        let location = self
+            .location_generator
+            .generate_location(partition_key.as_ref(), &file_name);
+        let output_file = table
+            .file_io()
+            .new_output(&location)
+            .map_err(|e| StreamExecutorError::sink_error(e, self.sink_id))?;
+
+        let parquet_writer_properties = WriterProperties::builder()
+            .set_compression(self.config.get_parquet_compression())
+            .set_max_row_group_bytes(self.config.write_parquet_max_row_group_bytes())
+            .set_created_by(PARQUET_CREATED_BY.to_owned())
+            .build();
+        let mut writer = ParquetWriterBuilder::new(
+            parquet_writer_properties,
+            POSITION_DELETE_SCHEMA.clone().into(),
+        )
+        .build(output_file)
+        .await
+        .map_err(|e| StreamExecutorError::sink_error(e, self.sink_id))?;
+
+        // The position-delete schema is `(file_path, pos)` with reserved field IDs;
+        // derive the matching Arrow schema so the written column field IDs line up.
+        let arrow_schema: ArrowSchemaRef = Arc::new(
+            schema_to_arrow_schema(&POSITION_DELETE_SCHEMA)
+                .map_err(|e| StreamExecutorError::sink_error(e, self.sink_id))?,
+        );
+
+        const POSITION_DELETE_WRITE_CHUNK_SIZE: usize = 1024;
+        let mut positions: Vec<i64> = Vec::with_capacity(POSITION_DELETE_WRITE_CHUNK_SIZE);
+        for pos in delete_vector.iter() {
+            positions.push(pos as i64);
+            if positions.len() == POSITION_DELETE_WRITE_CHUNK_SIZE {
+                write_position_delete_chunk(
+                    &mut writer,
+                    &arrow_schema,
+                    &data_file_path,
+                    std::mem::take(&mut positions),
+                    self.sink_id,
+                )
+                .await?;
+                positions.reserve(POSITION_DELETE_WRITE_CHUNK_SIZE);
+            }
+        }
+        if !positions.is_empty() {
+            write_position_delete_chunk(
+                &mut writer,
+                &arrow_schema,
+                &data_file_path,
+                positions,
+                self.sink_id,
+            )
+            .await?;
+        }
+
+        let data_files = writer
+            .close()
+            .await
+            .map_err(|e| StreamExecutorError::sink_error(e, self.sink_id))?;
+        // `close` will yield exactly one builder here.
+        let [mut builder] = data_files.try_into().map_err(|_| {
+            StreamExecutorError::sink_error(
+                anyhow::anyhow!(
+                    "position-delete writer produced invalid file count for {data_file_path}"
+                ),
+                self.sink_id,
+            )
+        })?;
+
+        // `ParquetWriter` builds the file as `DataContentType::Data` with an empty
+        // partition; override those for a file-scoped V2 position-delete file and
+        // attach `referenced_data_file`.
+        builder
+            .content(DataContentType::PositionDeletes)
+            .referenced_data_file(Some(data_file_path));
+        if let Some(partition_key) = partition_key {
+            builder
+                .partition(partition_key.data().clone())
+                .partition_spec_id(partition_key.spec().spec_id());
+        }
+        builder.build().map_err(|err| {
+            StreamExecutorError::sink_error(
+                anyhow::anyhow!(err).context("Failed to build position-delete file metadata"),
+                self.sink_id,
+            )
+        })
+    }
+}
+
+/// Writes one chunk of `positions` as a `(file_path, pos)` batch into `writer`.
+/// Every row shares `data_file_path` because the delete file is file-scoped.
+async fn write_position_delete_chunk(
+    writer: &mut ParquetWriter,
+    arrow_schema: &ArrowSchemaRef,
+    data_file_path: &str,
+    positions: Vec<i64>,
+    sink_id: SinkId,
+) -> StreamExecutorResult<()> {
+    let path_column: ArrayRef = Arc::new(StringArray::from_iter_values(std::iter::repeat_n(
+        data_file_path,
+        positions.len(),
+    )));
+    let pos_column: ArrayRef = Arc::new(Int64Array::from(positions));
+    let batch = RecordBatch::try_new(arrow_schema.clone(), vec![path_column, pos_column])
+        .map_err(|e| StreamExecutorError::sink_error(anyhow::anyhow!(e), sink_id))?;
+    writer
+        .write(&batch)
+        .await
+        .map_err(|e| StreamExecutorError::sink_error(e, sink_id))
 }
 
 #[async_trait::async_trait]
-impl DvHandler for DvHandlerImpl {
+impl PositionDeleteHandler for PositionDeleteHandlerImpl {
     fn write(&mut self, path: &str, pos: i64) -> StreamExecutorResult<()> {
         let pos = pos.try_into().context("position should be non-negative")?;
         self.delete_vectors.entry_ref(path).or_default().insert(pos);
@@ -199,15 +365,29 @@ impl DvHandler for DvHandlerImpl {
             .filter_map(|entry| entry.overwrite_file.clone())
             .collect::<Vec<_>>();
 
+        // V3 tables use Puffin deletion vectors; V2 tables use file-scoped Parquet
+        // position-delete files. The internal representation is a roaring bitmap
+        // (`DeleteVector`) in both cases; only the on-disk format differs.
+        let use_puffin = table.metadata().format_version() >= FormatVersion::V3;
+
         let pending = std::mem::take(&mut self.delete_vectors);
         let mut delete_files = Vec::with_capacity(pending.len());
         for (data_file_path, delete_vector) in pending {
             let loaded = loaded_delete_vectors
                 .remove(&data_file_path)
                 .unwrap_or_default();
-            let file = self
-                .write_dv_puffin_file(&table, data_file_path, delete_vector, loaded)
-                .await?;
+            let file = if use_puffin {
+                self.write_dv_puffin_file(&table, data_file_path, delete_vector, loaded)
+                    .await?
+            } else {
+                self.write_parquet_position_delete_file(
+                    &table,
+                    data_file_path,
+                    delete_vector,
+                    loaded,
+                )
+                .await?
+            };
             delete_files.push(file);
         }
 
@@ -218,7 +398,7 @@ impl DvHandler for DvHandlerImpl {
         let delete_files = serialize_delete_files(&table, self.sink_id, delete_files)?;
         let overwrite_files = serialize_overwrite_files(&table, self.sink_id, overwrite_files)?;
 
-        let sink_metadata = SinkMetadata::try_from(&IcebergDvMergerCommitResult {
+        let sink_metadata = SinkMetadata::try_from(&IcebergPositionDeleteMergerCommitResult {
             schema_id: table.metadata().current_schema_id(),
             partition_spec_id: table.metadata().default_partition_spec_id(),
             delete_files,
@@ -236,17 +416,8 @@ fn serialize_delete_files(
     sink_id: SinkId,
     delete_files: Vec<DataFile>,
 ) -> StreamExecutorResult<Vec<SerializedDataFile>> {
-    let format_version = table.metadata().format_version();
-    let partition_type = table.metadata().default_partition_type();
-    delete_files
-        .into_iter()
-        .map(|f| {
-            // Truncate large column statistics BEFORE serialization
-            let truncated = truncate_datafile(f);
-            SerializedDataFile::try_from(truncated, partition_type, format_version)
-                .map_err(|e| StreamExecutorError::sink_error(e, sink_id))
-        })
-        .collect()
+    serialize_data_files_default_spec(table, delete_files)
+        .map_err(|e| StreamExecutorError::sink_error(e, sink_id))
 }
 
 /// Serializes the original DV puffin files that are being overwritten. Each
@@ -269,20 +440,10 @@ fn serialize_overwrite_files(
             let pt = match partition_type_cache.entry(spec_id) {
                 Entry::Occupied(entry) => entry.into_mut(),
                 Entry::Vacant(entry) => {
-                    let spec = table
-                        .metadata()
-                        .partition_spec_by_id(spec_id)
-                        .with_context(|| {
-                            format!(
-                                "failed to find partition spec {} for file {}",
-                                spec_id,
-                                f.file_path()
-                            )
-                        })
+                    // Resolve against the file's own (potentially older) partition spec, not the
+                    // table default, so the serialized form round-trips correctly.
+                    let pt = resolve_partition_type(table, spec_id, schema)
                         .map_err(|e| StreamExecutorError::sink_error(e, sink_id))?;
-                    let pt = spec.partition_type(schema).map_err(|e| {
-                        StreamExecutorError::sink_error(anyhow::anyhow!(e), sink_id)
-                    })?;
                     entry.insert(pt)
                 }
             };
@@ -293,18 +454,20 @@ fn serialize_overwrite_files(
         .collect()
 }
 
-/// Loads existing delete vectors for the given data file paths by scanning the
+/// Loads existing position deletes for the given data file paths by scanning the
 /// table's current snapshot. Returns a map from data file path to the loaded
-/// delete vector, partition key (if partitioned), and original data file (for overwrite).
+/// delete positions (as a [`DeleteVector`]), partition key (if partitioned), and
+/// original delete file (for overwrite). Handles both V3 Puffin deletion vectors
+/// and V2 file-scoped Parquet position-delete files.
 ///
 /// The lookup proceeds in two passes:
 /// 1. Scan delete manifests for entries matching the given data file paths. If found,
-///    load the DV, partition key (when partitioned), and the existing DV file (as the
-///    overwrite target) from the delete entry. This reflects the latest DV state for
-///    the data file as of the current snapshot.
+///    load the existing delete positions, partition key (when partitioned), and the
+///    existing delete file (as the overwrite target) from the manifest entry. This
+///    reflects the latest delete state for the data file as of the current snapshot.
 /// 2. For partitioned tables, scan data manifests for any data files still missing an
-///    entry after pass 1 (data files that have not yet accumulated any DV). Records
-///    the data file as the overwrite target and its partition key.
+///    entry after pass 1 (data files that have not yet accumulated any position deletes).
+///    Records the data file as the overwrite target and its partition key.
 async fn load_delete_vectors(
     table: &Table,
     sink_id: SinkId,
@@ -364,9 +527,14 @@ async fn scan_existing_dvs(
             .map_err(|e| StreamExecutorError::sink_error(e, sink_id))?;
 
         for entry in manifest.entries() {
+            // Accept both V3 Puffin deletion vectors and V2 Parquet position-delete
+            // files; the reader is selected by the entry's file format below.
             if !entry.is_alive()
                 || entry.content_type() != DataContentType::PositionDeletes
-                || entry.file_format() != DataFileFormat::Puffin
+                || !matches!(
+                    entry.file_format(),
+                    DataFileFormat::Puffin | DataFileFormat::Parquet
+                )
             {
                 continue;
             }
@@ -379,8 +547,14 @@ async fn scan_existing_dvs(
                 continue;
             }
 
-            let delete_vector =
-                read_dv_positions_from_data_file(table.file_io(), data_file, sink_id).await?;
+            let delete_vector = match data_file.file_format() {
+                DataFileFormat::Puffin => {
+                    read_dv_positions_from_data_file(table.file_io(), data_file, sink_id).await?
+                }
+                _ => {
+                    read_v2_positions_from_delete_file(table.file_io(), data_file, sink_id).await?
+                }
+            };
             let partition_key = if partitioned {
                 Some(build_partition_key_from_data_file(
                     table, data_file, sink_id,
@@ -504,22 +678,73 @@ async fn read_dv_positions_from_data_file(
     Ok(delete_vector)
 }
 
+/// Reads the positions stored in a V2 Parquet position-delete file into a
+/// [`DeleteVector`]. The file's schema is `(file_path, pos)`. Callers only invoke
+/// this after the entry's `referenced_data_file` already matched the target data
+/// file, and the files we write are file-scoped (every row shares one
+/// `file_path`), so the `file_path` column is redundant here: we project only the
+/// `pos` column and read every value.
+async fn read_v2_positions_from_delete_file(
+    file_io: &FileIO,
+    data_file: &DataFile,
+    sink_id: SinkId,
+) -> StreamExecutorResult<DeleteVector> {
+    let input_file = file_io
+        .new_input(data_file.file_path())
+        .map_err(|e| StreamExecutorError::sink_error(e, sink_id))?;
+    let metadata = input_file
+        .metadata()
+        .await
+        .map_err(|e| StreamExecutorError::sink_error(e, sink_id))?;
+    let reader = input_file
+        .reader()
+        .await
+        .map_err(|e| StreamExecutorError::sink_error(e, sink_id))?;
+    let parquet_reader = ParquetFileReader::new(metadata, reader);
+    let builder = ParquetRecordBatchStreamBuilder::new(parquet_reader)
+        .await
+        .map_err(|e| StreamExecutorError::sink_error(anyhow::anyhow!(e), sink_id))?;
+    // The position-delete schema fixes column order to (file_path, pos); project
+    // only the `pos` leaf (column index 1) so the file_path column is never decoded.
+    let projection = ProjectionMask::leaves(builder.parquet_schema(), [1]);
+    let mut stream = builder
+        .with_projection(projection)
+        .build()
+        .map_err(|e| StreamExecutorError::sink_error(anyhow::anyhow!(e), sink_id))?;
+
+    let mut delete_vector = DeleteVector::default();
+    while let Some(batch) = stream.next().await {
+        let batch =
+            batch.map_err(|e| StreamExecutorError::sink_error(anyhow::anyhow!(e), sink_id))?;
+        // Only the projected `pos` column is present in the batch.
+        let positions = batch.columns()[0]
+            .as_any()
+            .downcast_ref::<Int64Array>()
+            .context("position-delete pos column should be an Int64Array")?;
+
+        for pos in positions {
+            let Some(pos) = pos else {
+                return Err(StreamExecutorError::sink_error(
+                    anyhow::anyhow!(
+                        "null value in position-delete file {}",
+                        data_file.file_path()
+                    ),
+                    sink_id,
+                ));
+            };
+            delete_vector.insert(pos as u64);
+        }
+    }
+
+    Ok(delete_vector)
+}
+
 fn build_partition_key_from_data_file(
     table: &Table,
     data_file: &DataFile,
     sink_id: SinkId,
 ) -> StreamExecutorResult<PartitionKey> {
-    let partition_spec_id = data_file.partition_spec_id();
-    let partition_spec = table
-        .metadata()
-        .partition_spec_by_id(partition_spec_id)
-        .with_context(|| {
-            format!(
-                "failed to find partition spec {} for manifest file {}",
-                partition_spec_id,
-                data_file.file_path()
-            )
-        })
+    let partition_spec = resolve_partition_spec(table, data_file.partition_spec_id())
         .map_err(|e| StreamExecutorError::sink_error(e, sink_id))?;
 
     Ok(PartitionKey::new(

--- a/src/stream/src/executor/iceberg_with_pk_index/position_delete_handler_impl.rs
+++ b/src/stream/src/executor/iceberg_with_pk_index/position_delete_handler_impl.rs
@@ -486,7 +486,7 @@ async fn load_delete_vectors(
 
     let mut result: HashMap<String, LoadedDeleteVectorEntry> = HashMap::with_capacity(paths.len());
 
-    scan_existing_dvs(
+    scan_existing_delete_files(
         table,
         sink_id,
         partitioned,
@@ -504,11 +504,12 @@ async fn load_delete_vectors(
     Ok(result)
 }
 
-/// Pass 1: scan delete manifests for DV puffin files referencing any path in
-/// `paths`. On hit, removes the path from `paths`, loads the DV, captures the
-/// partition key (for partitioned tables), and records the existing DV file as
+/// Pass 1: scan delete manifests for existing position-delete files (V3 Puffin
+/// deletion vectors or V2 Parquet position-delete files) referencing any path in
+/// `paths`. On hit, removes the path from `paths`, loads the deletes, captures the
+/// partition key (for partitioned tables), and records the existing delete file as
 /// the overwrite target.
-async fn scan_existing_dvs(
+async fn scan_existing_delete_files(
     table: &Table,
     sink_id: SinkId,
     partitioned: bool,
@@ -551,8 +552,15 @@ async fn scan_existing_dvs(
                 DataFileFormat::Puffin => {
                     read_dv_positions_from_data_file(table.file_io(), data_file, sink_id).await?
                 }
-                _ => {
+                DataFileFormat::Parquet => {
                     read_v2_positions_from_delete_file(table.file_io(), data_file, sink_id).await?
+                }
+                // Unreachable: the guard above only admits Puffin/Parquet delete files.
+                other => {
+                    return Err(StreamExecutorError::sink_error(
+                        anyhow::anyhow!("unexpected delete file format {:?}", other),
+                        sink_id,
+                    ));
                 }
             };
             let partition_key = if partitioned {

--- a/src/stream/src/executor/iceberg_with_pk_index/position_delete_merger.rs
+++ b/src/stream/src/executor/iceberg_with_pk_index/position_delete_merger.rs
@@ -15,36 +15,39 @@
 use anyhow::Context;
 use risingwave_common::id::SinkId;
 use risingwave_pb::connector_service::SinkMetadata;
-use risingwave_pb::stream_service::PbIcebergV3SinkRole;
+use risingwave_pb::stream_service::PbIcebergPkIndexSinkRole;
 
 use crate::executor::prelude::*;
 use crate::task::LocalBarrierManager;
 
-/// Trait abstracting DV (Deletion Vector) file operations for testability.
+/// Trait abstracting position-delete file operations for testability.
 ///
-/// Implementations are responsible for reading existing DVs, merging new
-/// delete positions, writing DV files, and returning the metadata that should
-/// be committed on the current barrier.
+/// Implementations are responsible for reading existing position deletes
+/// (V3 Puffin deletion vectors or V2 Parquet position-delete files),
+/// merging new delete positions, writing the resulting delete file, and
+/// returning the commit metadata for the current barrier.
 #[async_trait::async_trait]
-pub trait DvHandler: Send + 'static {
+pub trait PositionDeleteHandler: Send + 'static {
     fn write(&mut self, path: &str, pos: i64) -> StreamExecutorResult<()>;
 
     async fn flush(&mut self) -> StreamExecutorResult<Option<SinkMetadata>>;
 }
 
-/// DV Merger Executor for Iceberg V3 Sink without Equality Delete.
+/// Position-delete merger executor for iceberg pk-index sink without Equality Delete.
 ///
 /// This stateless executor receives [`file_path`, `position`] messages from the Writer Executor,
-/// merges them with historical DVs, and reports the merged DV metadata to meta on each barrier.
+/// merges them with existing position deletes, and reports the merged delete-file metadata to
+/// meta on each barrier. Depending on the table format version, the written delete file is a
+/// V3 Puffin deletion vector or a V2 file-scoped Parquet position-delete file.
 ///
 /// The upstream plan shards messages by `file_path`, so each actor only merges delete
 /// positions for the files assigned to its shard.
 ///
 /// Input schema: [`file_path`: Varchar, `position`: int64]
 /// Output: Barriers and watermarks only; no data chunks (terminal executor in the stream graph).
-pub struct DvMergerExecutor<H>
+pub struct PositionDeleteMergerExecutor<H>
 where
-    H: DvHandler,
+    H: PositionDeleteHandler,
 {
     actor_id: ActorId,
     sink_id: SinkId,
@@ -53,9 +56,9 @@ where
     handler: H,
 }
 
-impl<H> DvMergerExecutor<H>
+impl<H> PositionDeleteMergerExecutor<H>
 where
-    H: DvHandler,
+    H: PositionDeleteHandler,
 {
     pub fn new(
         actor_id: ActorId,
@@ -107,13 +110,14 @@ where
                     if let Some(metadata) = metadata
                         && metadata.metadata.is_some()
                     {
-                        self.local_barrier_manager.report_iceberg_v3_sink_metadata(
-                            barrier.epoch,
-                            self.sink_id,
-                            self.actor_id,
-                            PbIcebergV3SinkRole::DvMerger,
-                            Some(metadata),
-                        );
+                        self.local_barrier_manager
+                            .report_iceberg_pk_index_sink_metadata(
+                                barrier.epoch,
+                                self.sink_id,
+                                self.actor_id,
+                                PbIcebergPkIndexSinkRole::PositionDeleteMerger,
+                                Some(metadata),
+                            );
                     }
 
                     yield Message::Barrier(barrier);
@@ -126,9 +130,9 @@ where
     }
 }
 
-impl<H> Execute for DvMergerExecutor<H>
+impl<H> Execute for PositionDeleteMergerExecutor<H>
 where
-    H: DvHandler,
+    H: PositionDeleteHandler,
 {
     fn execute(self: Box<Self>) -> BoxedMessageStream {
         self.execute_inner().boxed()
@@ -174,13 +178,13 @@ mod tests {
     }
 
     #[derive(Clone)]
-    struct DvHandlerMock {
+    struct PositionDeleteHandlerMock {
         existing_dvs: Arc<Mutex<HashMap<String, BTreeSet<i64>>>>,
         pending_dvs: Arc<Mutex<HashMap<String, BTreeSet<i64>>>>,
         written_dvs: Arc<Mutex<HashMap<String, BTreeSet<i64>>>>,
     }
 
-    impl DvHandlerMock {
+    impl PositionDeleteHandlerMock {
         fn new() -> Self {
             Self {
                 existing_dvs: Arc::new(Mutex::new(HashMap::new())),
@@ -199,7 +203,7 @@ mod tests {
     }
 
     #[async_trait::async_trait]
-    impl DvHandler for DvHandlerMock {
+    impl PositionDeleteHandler for PositionDeleteHandlerMock {
         fn write(&mut self, path: &str, pos: i64) -> StreamExecutorResult<()> {
             self.pending_dvs
                 .lock()
@@ -244,17 +248,18 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_dv_merger_basic() {
-        let handler = DvHandlerMock::new();
+    async fn test_position_delete_merger_basic() {
+        let handler = PositionDeleteHandlerMock::new();
         let written_dvs = handler.written_dvs.clone();
 
         let (mut tx, source) = MockSource::channel();
         let source = source.into_executor(input_schema(), vec![]);
 
         let lbm = LocalBarrierManager::for_test();
-        let mut executor = DvMergerExecutor::new(123.into(), SinkId::new(0), lbm, source, handler)
-            .boxed()
-            .execute();
+        let mut executor =
+            PositionDeleteMergerExecutor::new(123.into(), SinkId::new(0), lbm, source, handler)
+                .boxed()
+                .execute();
 
         tx.push_barrier(test_epoch(1), false);
         assert!(executor.next().await.unwrap().unwrap().is_barrier());
@@ -274,18 +279,19 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_dv_merger_merge_with_existing() {
-        let handler =
-            DvHandlerMock::new().with_existing_dv("file1.parquet", BTreeSet::from([0, 5, 10]));
+    async fn test_position_delete_merger_merge_with_existing() {
+        let handler = PositionDeleteHandlerMock::new()
+            .with_existing_dv("file1.parquet", BTreeSet::from([0, 5, 10]));
         let written_dvs = handler.written_dvs.clone();
 
         let (mut tx, source) = MockSource::channel();
         let source = source.into_executor(input_schema(), vec![]);
 
         let lbm = LocalBarrierManager::for_test();
-        let mut executor = DvMergerExecutor::new(123.into(), SinkId::new(0), lbm, source, handler)
-            .boxed()
-            .execute();
+        let mut executor =
+            PositionDeleteMergerExecutor::new(123.into(), SinkId::new(0), lbm, source, handler)
+                .boxed()
+                .execute();
 
         tx.push_barrier(test_epoch(1), false);
         assert!(executor.next().await.unwrap().unwrap().is_barrier());
@@ -307,17 +313,18 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_dv_merger_no_deletes() {
-        let handler = DvHandlerMock::new();
+    async fn test_position_delete_merger_no_deletes() {
+        let handler = PositionDeleteHandlerMock::new();
         let written_dvs = handler.written_dvs.clone();
 
         let (mut tx, source) = MockSource::channel();
         let source = source.into_executor(input_schema(), vec![]);
 
         let lbm = LocalBarrierManager::for_test();
-        let mut executor = DvMergerExecutor::new(123.into(), SinkId::new(0), lbm, source, handler)
-            .boxed()
-            .execute();
+        let mut executor =
+            PositionDeleteMergerExecutor::new(123.into(), SinkId::new(0), lbm, source, handler)
+                .boxed()
+                .execute();
 
         tx.push_barrier(test_epoch(1), false);
         assert!(executor.next().await.unwrap().unwrap().is_barrier());
@@ -329,17 +336,18 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_dv_merger_multiple_epochs() {
-        let handler = DvHandlerMock::new();
+    async fn test_position_delete_merger_multiple_epochs() {
+        let handler = PositionDeleteHandlerMock::new();
         let written_dvs = handler.written_dvs.clone();
 
         let (mut tx, source) = MockSource::channel();
         let source = source.into_executor(input_schema(), vec![]);
 
         let lbm = LocalBarrierManager::for_test();
-        let mut executor = DvMergerExecutor::new(123.into(), SinkId::new(0), lbm, source, handler)
-            .boxed()
-            .execute();
+        let mut executor =
+            PositionDeleteMergerExecutor::new(123.into(), SinkId::new(0), lbm, source, handler)
+                .boxed()
+                .execute();
 
         tx.push_barrier(test_epoch(1), false);
         assert!(executor.next().await.unwrap().unwrap().is_barrier());

--- a/src/stream/src/executor/iceberg_with_pk_index/writer.rs
+++ b/src/stream/src/executor/iceberg_with_pk_index/writer.rs
@@ -21,7 +21,7 @@ use risingwave_common::row::{Project, RowExt};
 use risingwave_common::util::chunk_coalesce::DataChunkBuilder;
 use risingwave_common::util::iter_util::ZipEqFast;
 use risingwave_pb::connector_service::SinkMetadata;
-use risingwave_pb::stream_service::PbIcebergV3SinkRole;
+use risingwave_pb::stream_service::PbIcebergPkIndexSinkRole;
 use risingwave_storage::StateStore;
 
 use crate::common::change_buffer::output_kind;
@@ -59,7 +59,7 @@ pub trait IcebergWriter: Send + 'static {
     async fn flush(&mut self) -> StreamExecutorResult<Option<SinkMetadata>>;
 }
 
-/// Writer Executor for Iceberg V3 Sink with PK index
+/// Writer Executor for iceberg pk-index sink with PK index
 ///
 /// This stateful executor maintains a PK index that maps primary key values to
 /// their position in data files (`file_path`, `position`). It processes change logs
@@ -68,7 +68,7 @@ pub trait IcebergWriter: Send + 'static {
 /// - **Insert**: Writes the row to a data file via [`IcebergWriter`], records the
 ///   position in the PK index state table.
 /// - **Delete**: Looks up the PK index to find the data file position, emits a
-///   delete position message downstream to the DV Merger, removes from index.
+///   delete position message downstream to the position-delete merger, removes from index.
 /// - **Update**: Treated as Delete + Insert. The planner guarantees the old and
 ///   new rows share the same PK, so the executor can reuse the projected PK from
 ///   the old row when updating the PK index.
@@ -276,13 +276,14 @@ where
                     if let Some(metadata) = metadata
                         && metadata.metadata.is_some()
                     {
-                        self.local_barrier_manager.report_iceberg_v3_sink_metadata(
-                            epoch,
-                            self.sink_id,
-                            self.ctx.id,
-                            PbIcebergV3SinkRole::Writer,
-                            Some(metadata),
-                        );
+                        self.local_barrier_manager
+                            .report_iceberg_pk_index_sink_metadata(
+                                epoch,
+                                self.sink_id,
+                                self.ctx.id,
+                                PbIcebergPkIndexSinkRole::Writer,
+                                Some(metadata),
+                            );
                     }
 
                     yield Message::Barrier(barrier);

--- a/src/stream/src/executor/mod.rs
+++ b/src/stream/src/executor/mod.rs
@@ -155,7 +155,7 @@ pub use gap_fill::{GapFillExecutor, GapFillExecutorArgs};
 pub use hash_join::*;
 pub use hop_window::HopWindowExecutor;
 pub use iceberg_with_pk_index::{
-    DvHandlerImpl, DvMergerExecutor, IcebergWriterImpl, WriterExecutor,
+    IcebergWriterImpl, PositionDeleteHandlerImpl, PositionDeleteMergerExecutor, WriterExecutor,
 };
 pub use join::asof_join::{AsOfCpuEncoding, AsOfMemoryEncoding};
 pub use join::row::{CachedJoinRow, CpuEncoding, JoinEncoding, MemoryEncoding};

--- a/src/stream/src/from_proto/iceberg_with_pk_index/mod.rs
+++ b/src/stream/src/from_proto/iceberg_with_pk_index/mod.rs
@@ -12,5 +12,5 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-mod dv_merger;
+mod position_delete_merger;
 mod writer;

--- a/src/stream/src/from_proto/iceberg_with_pk_index/position_delete_merger.rs
+++ b/src/stream/src/from_proto/iceberg_with_pk_index/position_delete_merger.rs
@@ -15,20 +15,22 @@
 use risingwave_common::secret::LocalSecretManager;
 use risingwave_connector::sink::iceberg::IcebergConfig;
 use risingwave_pb::id::SinkId;
-use risingwave_pb::stream_plan::IcebergWithPkIndexDvMergerNode;
+use risingwave_pb::stream_plan::IcebergWithPkIndexPositionDeleteMergerNode;
 use risingwave_storage::StateStore;
 
 use crate::error::StreamResult;
-use crate::executor::{DvHandlerImpl, DvMergerExecutor, Executor, StreamExecutorError};
+use crate::executor::{
+    Executor, PositionDeleteHandlerImpl, PositionDeleteMergerExecutor, StreamExecutorError,
+};
 use crate::from_proto::ExecutorBuilder;
 use crate::task::ExecutorParams;
 
-pub struct IcebergWithPkIndexDvMergerExecutorBuilder;
+pub struct IcebergWithPkIndexPositionDeleteMergerExecutorBuilder;
 
-impl_stream_node_body!(IcebergWithPkIndexDvMerger(IcebergWithPkIndexDvMergerNode) => IcebergWithPkIndexDvMergerExecutorBuilder);
+impl_stream_node_body!(IcebergWithPkIndexPositionDeleteMerger(IcebergWithPkIndexPositionDeleteMergerNode) => IcebergWithPkIndexPositionDeleteMergerExecutorBuilder);
 
-impl ExecutorBuilder for IcebergWithPkIndexDvMergerExecutorBuilder {
-    type Node = IcebergWithPkIndexDvMergerNode;
+impl ExecutorBuilder for IcebergWithPkIndexPositionDeleteMergerExecutorBuilder {
+    type Node = IcebergWithPkIndexPositionDeleteMergerNode;
 
     async fn new_boxed_executor(
         params: ExecutorParams,
@@ -46,9 +48,10 @@ impl ExecutorBuilder for IcebergWithPkIndexDvMergerExecutorBuilder {
         )?;
         let config = IcebergConfig::from_btreemap(properties_with_secret.clone())
             .map_err(|err| StreamExecutorError::from((err, sink_id)))?;
-        let handler = DvHandlerImpl::new(config, params.actor_context.id, sink_id).await?;
+        let handler =
+            PositionDeleteHandlerImpl::new(config, params.actor_context.id, sink_id).await?;
 
-        let exec = DvMergerExecutor::new(
+        let exec = PositionDeleteMergerExecutor::new(
             params.actor_context.id,
             sink_id,
             params.local_barrier_manager.clone(),

--- a/src/stream/src/task/barrier_manager/mod.rs
+++ b/src/stream/src/task/barrier_manager/mod.rs
@@ -22,7 +22,7 @@ use risingwave_common::id::{SourceId, TableId};
 use risingwave_common::util::epoch::EpochPair;
 use risingwave_pb::connector_service::SinkMetadata;
 use risingwave_pb::id::{FragmentId, PartialGraphId, SinkId};
-use risingwave_pb::stream_service::PbIcebergV3SinkRole;
+use risingwave_pb::stream_service::PbIcebergPkIndexSinkRole;
 use tokio::sync::mpsc;
 use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender, unbounded_channel};
 
@@ -86,11 +86,11 @@ pub(super) enum LocalBarrierEvent {
         actor_id: ActorId,
         source_id: SourceId,
     },
-    ReportIcebergV3SinkMetadata {
+    ReportIcebergPkIndexSinkMetadata {
         epoch: EpochPair,
         sink_id: SinkId,
         actor_id: ActorId,
-        role: PbIcebergV3SinkRole,
+        role: PbIcebergPkIndexSinkRole,
         metadata: Option<SinkMetadata>,
     },
 }
@@ -251,15 +251,15 @@ impl LocalBarrierManager {
         });
     }
 
-    pub fn report_iceberg_v3_sink_metadata(
+    pub fn report_iceberg_pk_index_sink_metadata(
         &self,
         epoch: EpochPair,
         sink_id: risingwave_common::id::SinkId,
         actor_id: ActorId,
-        role: PbIcebergV3SinkRole,
+        role: PbIcebergPkIndexSinkRole,
         metadata: Option<SinkMetadata>,
     ) {
-        self.send_event(LocalBarrierEvent::ReportIcebergV3SinkMetadata {
+        self.send_event(LocalBarrierEvent::ReportIcebergPkIndexSinkMetadata {
             epoch,
             sink_id,
             actor_id,

--- a/src/stream/src/task/barrier_worker/managed_state.rs
+++ b/src/stream/src/task/barrier_worker/managed_state.rs
@@ -31,7 +31,7 @@ use risingwave_common::util::epoch::EpochPair;
 use risingwave_pb::connector_service::SinkMetadata;
 use risingwave_pb::stream_plan::barrier::BarrierKind;
 use risingwave_pb::stream_service::barrier_complete_response::{
-    IcebergV3SinkMetadata as PbIcebergV3SinkMetadata, PbCdcSourceOffsetUpdated,
+    IcebergPkIndexSinkMetadata as PbIcebergPkIndexSinkMetadata, PbCdcSourceOffsetUpdated,
     PbCdcTableBackfillProgress, PbCreateMviewProgress, PbListFinishedSource, PbLoadFinishedSource,
 };
 use risingwave_storage::StateStoreImpl;
@@ -76,7 +76,7 @@ enum ManagedBarrierStateInner {
         load_finished_source_ids: Vec<PbLoadFinishedSource>,
         cdc_table_backfill_progress: Vec<PbCdcTableBackfillProgress>,
         cdc_source_offset_updated: Vec<PbCdcSourceOffsetUpdated>,
-        iceberg_v3_sink_metadata: Vec<PbIcebergV3SinkMetadata>,
+        iceberg_pk_index_sink_metadata: Vec<PbIcebergPkIndexSinkMetadata>,
         truncate_tables: Vec<TableId>,
         refresh_finished_tables: Vec<TableId>,
     },
@@ -92,7 +92,7 @@ struct BarrierState {
 
 use risingwave_common::must_match;
 use risingwave_pb::id::FragmentId;
-use risingwave_pb::stream_service::{InjectBarrierRequest, PbIcebergV3SinkRole};
+use risingwave_pb::stream_service::{InjectBarrierRequest, PbIcebergPkIndexSinkRole};
 
 use crate::executor::exchange::permit;
 use crate::task::barrier_worker::await_epoch_completed_future::AwaitEpochCompletedFuture;
@@ -322,8 +322,8 @@ pub(crate) struct PartialGraphManagedBarrierState {
     /// Used to track when CDC sources have updated their offset at least once.
     pub(crate) cdc_source_offset_updated: HashMap<u64, Vec<PbCdcSourceOffsetUpdated>>,
 
-    /// Record Iceberg V3 sink metadata reports per epoch for concurrent checkpoints.
-    pub(crate) iceberg_v3_sink_metadata: HashMap<u64, Vec<PbIcebergV3SinkMetadata>>,
+    /// Record Iceberg pk-index sink metadata reports per epoch for concurrent checkpoints.
+    pub(crate) iceberg_pk_index_sink_metadata: HashMap<u64, Vec<PbIcebergPkIndexSinkMetadata>>,
 
     /// Record the tables to truncate for each epoch of concurrent checkpoints.
     pub(crate) truncate_tables: HashMap<u64, HashSet<TableId>>,
@@ -353,7 +353,7 @@ impl PartialGraphManagedBarrierState {
             load_finished_source_ids: Default::default(),
             cdc_table_backfill_progress: Default::default(),
             cdc_source_offset_updated: Default::default(),
-            iceberg_v3_sink_metadata: Default::default(),
+            iceberg_pk_index_sink_metadata: Default::default(),
             truncate_tables: Default::default(),
             refresh_finished_tables: Default::default(),
             state_store,
@@ -957,14 +957,16 @@ impl PartialGraphState {
                 } => {
                     self.report_cdc_source_offset_updated(epoch, actor_id, source_id);
                 }
-                LocalBarrierEvent::ReportIcebergV3SinkMetadata {
+                LocalBarrierEvent::ReportIcebergPkIndexSinkMetadata {
                     epoch,
                     sink_id,
                     actor_id,
                     role,
                     metadata,
                 } => {
-                    self.report_iceberg_v3_sink_metadata(epoch, sink_id, actor_id, role, metadata);
+                    self.report_iceberg_pk_index_sink_metadata(
+                        epoch, sink_id, actor_id, role, metadata,
+                    );
                 }
             }
         }
@@ -1111,23 +1113,23 @@ impl PartialGraphState {
         }
     }
 
-    /// Record a Iceberg V3 sink metadata report.
-    pub(super) fn report_iceberg_v3_sink_metadata(
+    /// Record a Iceberg pk-index sink metadata report.
+    pub(super) fn report_iceberg_pk_index_sink_metadata(
         &mut self,
         epoch: EpochPair,
         sink_id: SinkId,
         actor_id: ActorId,
-        role: PbIcebergV3SinkRole,
+        role: PbIcebergPkIndexSinkRole,
         metadata: Option<SinkMetadata>,
     ) {
         if let Some(actor_state) = self.actor_states.get(&actor_id)
             && actor_state.inflight_barriers.contains(&epoch.prev)
         {
             self.graph_state
-                .iceberg_v3_sink_metadata
+                .iceberg_pk_index_sink_metadata
                 .entry(epoch.curr)
                 .or_default()
-                .push(PbIcebergV3SinkMetadata {
+                .push(PbIcebergPkIndexSinkMetadata {
                     sink_id,
                     reporter_actor_id: actor_id,
                     prev_epoch: epoch.prev,
@@ -1234,8 +1236,8 @@ impl PartialGraphManagedBarrierState {
                 .remove(&barrier_state.barrier.epoch.curr)
                 .unwrap_or_default();
 
-            let iceberg_v3_sink_metadata = self
-                .iceberg_v3_sink_metadata
+            let iceberg_pk_index_sink_metadata = self
+                .iceberg_pk_index_sink_metadata
                 .remove(&barrier_state.barrier.epoch.curr)
                 .unwrap_or_default();
 
@@ -1262,7 +1264,7 @@ impl PartialGraphManagedBarrierState {
                     refresh_finished_tables,
                     cdc_table_backfill_progress,
                     cdc_source_offset_updated,
-                    iceberg_v3_sink_metadata,
+                    iceberg_pk_index_sink_metadata,
                 },
             );
 
@@ -1292,7 +1294,7 @@ impl PartialGraphManagedBarrierState {
             load_finished_source_ids,
             cdc_table_backfill_progress,
             cdc_source_offset_updated,
-            iceberg_v3_sink_metadata,
+            iceberg_pk_index_sink_metadata,
             truncate_tables,
             refresh_finished_tables,
         ) = must_match!(barrier_state.inner, ManagedBarrierStateInner::AllCollected {
@@ -1303,9 +1305,9 @@ impl PartialGraphManagedBarrierState {
             refresh_finished_tables,
             cdc_table_backfill_progress,
             cdc_source_offset_updated,
-            iceberg_v3_sink_metadata,
+            iceberg_pk_index_sink_metadata,
         } => {
-            (create_mview_progress, list_finished_source_ids, load_finished_source_ids, cdc_table_backfill_progress, cdc_source_offset_updated, iceberg_v3_sink_metadata, truncate_tables, refresh_finished_tables)
+            (create_mview_progress, list_finished_source_ids, load_finished_source_ids, cdc_table_backfill_progress, cdc_source_offset_updated, iceberg_pk_index_sink_metadata, truncate_tables, refresh_finished_tables)
         });
         BarrierToComplete {
             barrier: barrier_state.barrier,
@@ -1317,7 +1319,7 @@ impl PartialGraphManagedBarrierState {
             refresh_finished_tables,
             cdc_table_backfill_progress,
             cdc_source_offset_updated,
-            iceberg_v3_sink_metadata,
+            iceberg_pk_index_sink_metadata,
         }
     }
 }
@@ -1332,7 +1334,7 @@ pub(crate) struct BarrierToComplete {
     pub refresh_finished_tables: Vec<TableId>,
     pub cdc_table_backfill_progress: Vec<PbCdcTableBackfillProgress>,
     pub cdc_source_offset_updated: Vec<PbCdcSourceOffsetUpdated>,
-    pub iceberg_v3_sink_metadata: Vec<PbIcebergV3SinkMetadata>,
+    pub iceberg_pk_index_sink_metadata: Vec<PbIcebergPkIndexSinkMetadata>,
 }
 
 impl PartialGraphManagedBarrierState {

--- a/src/stream/src/task/barrier_worker/mod.rs
+++ b/src/stream/src/task/barrier_worker/mod.rs
@@ -28,7 +28,7 @@ use itertools::Itertools;
 use risingwave_pb::stream_plan::barrier::BarrierKind;
 use risingwave_pb::stream_service::barrier_complete_response::{
     PbCdcSourceOffsetUpdated, PbCdcTableBackfillProgress, PbCreateMviewProgress,
-    PbIcebergV3SinkMetadata, PbListFinishedSource, PbLoadFinishedSource, PbLocalSstableInfo,
+    PbIcebergPkIndexSinkMetadata, PbListFinishedSource, PbLoadFinishedSource, PbLocalSstableInfo,
 };
 use risingwave_rpc_client::error::{ToTonicStatus, TonicStatusWrapper};
 use risingwave_storage::store_impl::AsHummock;
@@ -98,8 +98,8 @@ pub struct BarrierCompleteResult {
     /// CDC sources that have updated their offset at least once.
     pub cdc_source_offset_updated: Vec<PbCdcSourceOffsetUpdated>,
 
-    /// Iceberg V3 sink metadata reports collected during this barrier.
-    pub iceberg_v3_sink_metadata: Vec<PbIcebergV3SinkMetadata>,
+    /// Iceberg pk-index sink metadata reports collected during this barrier.
+    pub iceberg_pk_index_sink_metadata: Vec<PbIcebergPkIndexSinkMetadata>,
 
     /// The table IDs that should be truncated.
     pub truncate_tables: Vec<TableId>,
@@ -640,7 +640,7 @@ mod await_epoch_completed_future {
     use risingwave_hummock_sdk::SyncResult;
     use risingwave_pb::stream_service::barrier_complete_response::{
         PbCdcSourceOffsetUpdated, PbCdcTableBackfillProgress, PbCreateMviewProgress,
-        PbIcebergV3SinkMetadata, PbListFinishedSource, PbLoadFinishedSource,
+        PbIcebergPkIndexSinkMetadata, PbListFinishedSource, PbLoadFinishedSource,
     };
 
     use crate::error::StreamResult;
@@ -661,7 +661,7 @@ mod await_epoch_completed_future {
         load_finished_source_ids: Vec<PbLoadFinishedSource>,
         cdc_table_backfill_progress: Vec<PbCdcTableBackfillProgress>,
         cdc_source_offset_updated: Vec<PbCdcSourceOffsetUpdated>,
-        iceberg_v3_sink_metadata: Vec<PbIcebergV3SinkMetadata>,
+        iceberg_pk_index_sink_metadata: Vec<PbIcebergPkIndexSinkMetadata>,
         truncate_tables: Vec<TableId>,
         refresh_finished_tables: Vec<TableId>,
     ) -> AwaitEpochCompletedFuture {
@@ -684,7 +684,7 @@ mod await_epoch_completed_future {
                     load_finished_source_ids,
                     cdc_table_backfill_progress,
                     cdc_source_offset_updated,
-                    iceberg_v3_sink_metadata,
+                    iceberg_pk_index_sink_metadata,
                     truncate_tables,
                     refresh_finished_tables,
                 }),
@@ -761,7 +761,7 @@ impl LocalBarrierWorker {
                 load_finished_source_ids,
                 cdc_table_backfill_progress,
                 cdc_source_offset_updated,
-                iceberg_v3_sink_metadata,
+                iceberg_pk_index_sink_metadata,
                 truncate_tables,
                 refresh_finished_tables,
             } = graph_state.pop_barrier_to_complete(prev_epoch);
@@ -798,7 +798,7 @@ impl LocalBarrierWorker {
                         load_finished_source_ids,
                         cdc_table_backfill_progress,
                         cdc_source_offset_updated,
-                        iceberg_v3_sink_metadata,
+                        iceberg_pk_index_sink_metadata,
                         truncate_tables,
                         refresh_finished_tables,
                     )
@@ -819,7 +819,7 @@ impl LocalBarrierWorker {
             load_finished_source_ids,
             cdc_table_backfill_progress,
             cdc_source_offset_updated,
-            iceberg_v3_sink_metadata,
+            iceberg_pk_index_sink_metadata,
             truncate_tables,
             refresh_finished_tables,
         } = result;
@@ -884,7 +884,7 @@ impl LocalBarrierWorker {
                         cdc_table_backfill_progress,
                         truncate_tables,
                         refresh_finished_tables,
-                        iceberg_v3_sink_metadata,
+                        iceberg_pk_index_sink_metadata,
                     },
                 )
             }


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

Extends the Iceberg **pk-index sink** (`enable_pk_index='true'`) to support Iceberg **format-version 2** tables. Previously this sink mode only worked on format-version 3 tables.

Behavior:

- On **v2** tables, deletions are now materialized as **file-scoped position-delete files** (one Parquet position-delete file per referenced data file).
- On **v3** tables, behavior is unchanged: deletions continue to be written as deletion-vector (Puffin) blobs.
- The delete representation is chosen automatically from the target table's format version — no new sink option is introduced.

User-facing notices and error messages that previously read "Iceberg V3 sink" now read "Iceberg pk-index sink", since the mode is no longer v3-only.

### About protobuf breaking-change

These are **wire-compatible**: the field numbers and the message bodies are unchanged, only the type/field names differ. The meta store encodes these messages in protobuf binary (decoded by tag number, not by name), so persisted data decodes correctly across the upgrade.

## Checklist

- [x] I have written necessary rustdoc comments.
- [x] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [x] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->

## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>
</details>
