### PR TITLE
fix(stream): handle cross-db backfill creation stalls

### DIFF
--- a/e2e_test/backfill/cross_db/cross_db_mv.slt
+++ b/e2e_test/backfill/cross_db/cross_db_mv.slt
@@ -106,6 +106,13 @@ select count(*) from rw_ddl_progress;
 ----
 1
 
+sleep 2s
+
+query I
+select count(*) from mv_rate_limit;
+----
+0
+
 statement ok
 alter materialized view mv_rate_limit set backfill_rate_limit = 1000;
 

--- a/e2e_test/backfill/cross_db/cross_db_mv.slt
+++ b/e2e_test/backfill/cross_db/cross_db_mv.slt
@@ -99,7 +99,29 @@ select count(*) from mv1;
 10000
 
 statement ok
+create materialized view mv_rate_limit with (backfill_rate_limit = 0) as select * from d1.public.t1;
+
+query I retry 4 backoff 1s
+select count(*) from rw_ddl_progress;
+----
+1
+
+statement ok
+alter materialized view mv_rate_limit set backfill_rate_limit = 1000;
+
+statement ok
+wait
+
+query ok
+select count(*) from mv_rate_limit;
+----
+10000
+
+statement ok
 set database to d2;
+
+statement ok
+drop materialized view mv_rate_limit;
 
 statement ok
 drop materialized view mv1;

--- a/src/meta/node/src/server.rs
+++ b/src/meta/node/src/server.rs
@@ -661,8 +661,8 @@ pub async fn start_service_as_election_leader(
             Box::new(move || {
                 let barrier_manager = barrier_manager.clone();
                 Box::pin(async move {
-                    barrier_manager.may_snapshot_backfilling_job().await.unwrap_or_else(|e| {
-                        tracing::warn!(err = %e.as_report(), "failed to check having snapshot backfilling jobs. pause vacuum time travel");
+                    barrier_manager.may_have_creating_job().await.unwrap_or_else(|e| {
+                        tracing::warn!(err = %e.as_report(), "failed to check having creating jobs. pause vacuum time travel");
                         true
                     })
                 })

--- a/src/meta/src/barrier/checkpoint/control.rs
+++ b/src/meta/src/barrier/checkpoint/control.rs
@@ -231,10 +231,10 @@ impl CheckpointControl {
             .map(|database| &database.database_info)
     }
 
-    pub(crate) fn may_have_snapshot_backfilling_jobs(&self) -> bool {
+    pub(crate) fn may_have_creating_jobs(&self) -> bool {
         self.databases
             .values()
-            .any(|database| database.may_have_snapshot_backfilling_jobs())
+            .any(|database| database.may_have_creating_jobs())
     }
 
     /// return Some(failed `database_id` -> `err`)
@@ -706,13 +706,14 @@ impl DatabaseCheckpointControlStatus {
         }
     }
 
-    fn may_have_snapshot_backfilling_jobs(&self) -> bool {
+    fn may_have_creating_jobs(&self) -> bool {
         self.running_state()
             .map(|database| {
-                database
-                    .independent_checkpoint_job_controls
-                    .values()
-                    .any(|job| job.is_snapshot_backfilling())
+                database.database_info.has_creating_jobs()
+                    || database
+                        .independent_checkpoint_job_controls
+                        .values()
+                        .any(|job| job.is_snapshot_backfilling())
             })
             .unwrap_or(true) // there can be snapshot backfilling jobs when the database is recovering.
     }

--- a/src/meta/src/barrier/info.rs
+++ b/src/meta/src/barrier/info.rs
@@ -743,6 +743,11 @@ impl InflightDatabaseInfo {
             .any(|tracker| tracker.is_finished())
     }
 
+    pub(super) fn has_creating_jobs(&self) -> bool {
+        self.iter_creating_job_tracker()
+            .any(|tracker| !tracker.is_finished())
+    }
+
     pub(super) fn take_pending_backfill_nodes(&mut self) -> Vec<FragmentId> {
         self.iter_mut_creating_job_tracker()
             .flat_map(|tracker| tracker.take_pending_backfill_nodes())

--- a/src/meta/src/barrier/manager.rs
+++ b/src/meta/src/barrier/manager.rs
@@ -31,7 +31,7 @@ use tokio::task::JoinHandle;
 use tracing::warn;
 
 use crate::MetaResult;
-use crate::barrier::BarrierManagerRequest::MayHaveSnapshotBackfillingJob;
+use crate::barrier::BarrierManagerRequest::MayHaveCreatingJob;
 use crate::barrier::cdc_progress::CdcProgress;
 use crate::barrier::worker::GlobalBarrierWorker;
 use crate::barrier::{
@@ -153,14 +153,12 @@ impl GlobalBarrierManager {
         Ok(())
     }
 
-    pub async fn may_snapshot_backfilling_job(&self) -> MetaResult<bool> {
+    pub async fn may_have_creating_job(&self) -> MetaResult<bool> {
         let (tx, rx) = oneshot::channel();
         self.request_tx
-            .send(MayHaveSnapshotBackfillingJob(tx))
-            .context("failed to send has snapshot backfilling job request")?;
-        Ok(rx
-            .await
-            .context("failed to wait has snapshot backfilling job")?)
+            .send(MayHaveCreatingJob(tx))
+            .context("failed to send has creating job request")?;
+        Ok(rx.await.context("failed to wait has creating job")?)
     }
 
     pub async fn get_hummock_version_id(&self) -> HummockVersionId {

--- a/src/meta/src/barrier/mod.rs
+++ b/src/meta/src/barrier/mod.rs
@@ -134,7 +134,7 @@ pub(crate) enum BarrierManagerRequest {
     GetCdcProgress(Sender<MetaResult<HashMap<JobId, CdcProgress>>>),
     AdhocRecovery(Sender<()>),
     UpdateDatabaseBarrier(UpdateDatabaseBarrierRequest),
-    MayHaveSnapshotBackfillingJob(Sender<bool>),
+    MayHaveCreatingJob(Sender<bool>),
 }
 
 #[derive(Debug)]

--- a/src/meta/src/barrier/worker.rs
+++ b/src/meta/src/barrier/worker.rs
@@ -559,9 +559,9 @@ impl<C: GlobalBarrierWorkerContext> GlobalBarrierWorker<C> {
                                     warn!("failed to notify finish of update database barrier");
                                 }
                             }
-                            BarrierManagerRequest::MayHaveSnapshotBackfillingJob(tx) => {
-                                if tx.send(self.checkpoint_control.may_have_snapshot_backfilling_jobs()).is_err() {
-                                    warn!("failed to may have snapshot backfill job");
+                            BarrierManagerRequest::MayHaveCreatingJob(tx) => {
+                                if tx.send(self.checkpoint_control.may_have_creating_jobs()).is_err() {
+                                    warn!("failed to check whether there may be creating jobs");
                                 }
                             }
                         }
@@ -1362,8 +1362,8 @@ impl<C: GlobalBarrierWorkerContext> GlobalBarrierWorker<C> {
                         BarrierManagerRequest::UpdateDatabaseBarrier(request) => {
                             update_barrier_requests.push(request);
                         }
-                        BarrierManagerRequest::MayHaveSnapshotBackfillingJob(tx) => {
-                            // may recover snapshot backfill jobs
+                        BarrierManagerRequest::MayHaveCreatingJob(tx) => {
+                            // May recover creating jobs.
                             let _ = tx.send(true);
                         }
                     }

--- a/src/stream/src/executor/backfill/snapshot_backfill/consume_upstream/executor.rs
+++ b/src/stream/src/executor/backfill/snapshot_backfill/consume_upstream/executor.rs
@@ -32,6 +32,7 @@ use crate::executor::backfill::snapshot_backfill::consume_upstream::upstream_tab
 use crate::executor::backfill::snapshot_backfill::receive_next_barrier;
 use crate::executor::backfill::snapshot_backfill::state::{BackfillState, EpochBackfillProgress};
 use crate::executor::backfill::utils::mapping_message;
+use crate::executor::monitor::BackfillMetrics;
 use crate::executor::prelude::{StateTable, *};
 use crate::executor::{Barrier, Message, StreamExecutorError};
 use crate::task::CreateMviewProgressReporter;
@@ -48,6 +49,7 @@ pub struct UpstreamTableExecutor<T: UpstreamTable, S: StateStore> {
     barrier_rx: UnboundedReceiver<Barrier>,
     progress: CreateMviewProgressReporter,
     crossdb_last_consumed_min_epoch: LabelGuardedIntGauge,
+    metrics: BackfillMetrics,
 }
 
 impl<T: UpstreamTable, S: StateStore> UpstreamTableExecutor<T, S> {
@@ -77,6 +79,9 @@ impl<T: UpstreamTable, S: StateStore> UpstreamTableExecutor<T, S> {
                 actor_id_label.as_str(),
                 fragment_id_label.as_str(),
             ]);
+        let metrics = actor_ctx
+            .streaming_metrics
+            .new_backfill_metrics(upstream_table_id, actor_ctx.id);
         Self {
             upstream_table,
             progress_state_table,
@@ -88,6 +93,7 @@ impl<T: UpstreamTable, S: StateStore> UpstreamTableExecutor<T, S> {
             barrier_rx,
             progress,
             crossdb_last_consumed_min_epoch,
+            metrics,
         }
     }
 
@@ -198,6 +204,9 @@ impl<T: UpstreamTable, S: StateStore> UpstreamTableExecutor<T, S> {
                     }
                     // ensure that the reported row count is non-decreasing.
                     let row_count_to_report = std::cmp::max(prev_reported_row_count, row_count);
+                    self.metrics
+                        .backfill_snapshot_read_row_count
+                        .inc_by(row_count_to_report.saturating_sub(prev_reported_row_count) as _);
                     prev_reported_row_count = row_count_to_report;
 
                     if is_finished {

--- a/src/stream/src/executor/backfill/snapshot_backfill/consume_upstream/executor.rs
+++ b/src/stream/src/executor/backfill/snapshot_backfill/consume_upstream/executor.rs
@@ -240,6 +240,7 @@ impl<T: UpstreamTable, S: StateStore> UpstreamTableExecutor<T, S> {
                     let new_rate_limit = new_rate_limit.into();
                     let old_rate_limit = self.rate_limiter.update(new_rate_limit);
                     if old_rate_limit != new_rate_limit {
+                        stream.update_rate_limiter(new_rate_limit);
                         tracing::info!(
                             old_rate_limit = ?old_rate_limit,
                             new_rate_limit = ?new_rate_limit,

--- a/src/stream/src/executor/backfill/snapshot_backfill/consume_upstream/executor.rs
+++ b/src/stream/src/executor/backfill/snapshot_backfill/consume_upstream/executor.rs
@@ -23,6 +23,7 @@ use risingwave_common::metrics::LabelGuardedIntGauge;
 use risingwave_common_rate_limit::{
     MonitoredRateLimiter, RateLimit, RateLimiter, RateLimiterTrait,
 };
+use risingwave_pb::common::ThrottleType;
 use risingwave_storage::StateStore;
 use rw_futures_util::drop_either_future;
 use tokio::sync::mpsc::UnboundedReceiver;
@@ -34,10 +35,11 @@ use crate::executor::backfill::snapshot_backfill::state::{BackfillState, EpochBa
 use crate::executor::backfill::utils::mapping_message;
 use crate::executor::monitor::BackfillMetrics;
 use crate::executor::prelude::{StateTable, *};
-use crate::executor::{Barrier, Message, StreamExecutorError};
+use crate::executor::{Barrier, Message, Mutation, StreamExecutorError};
 use crate::task::CreateMviewProgressReporter;
 
 pub struct UpstreamTableExecutor<T: UpstreamTable, S: StateStore> {
+    upstream_table_id: TableId,
     upstream_table: T,
     progress_state_table: StateTable<S>,
     snapshot_epoch: u64,
@@ -83,6 +85,7 @@ impl<T: UpstreamTable, S: StateStore> UpstreamTableExecutor<T, S> {
             .streaming_metrics
             .new_backfill_metrics(upstream_table_id, actor_ctx.id);
         Self {
+            upstream_table_id,
             upstream_table,
             progress_state_table,
             snapshot_epoch,
@@ -224,6 +227,28 @@ impl<T: UpstreamTable, S: StateStore> UpstreamTableExecutor<T, S> {
 
                 let post_commit = progress_state.commit(barrier.epoch).await?;
                 let update_vnode_bitmap = barrier.as_update_vnode_bitmap(self.actor_ctx.id);
+                if let Some(new_rate_limit) = barrier.mutation.as_ref().and_then(|mutation| {
+                    if let Mutation::Throttle(config) = &**mutation
+                        && let Some(config) = config.get(&self.actor_ctx.fragment_id)
+                        && config.throttle_type() == ThrottleType::Backfill
+                    {
+                        Some(config.rate_limit)
+                    } else {
+                        None
+                    }
+                }) {
+                    let new_rate_limit = new_rate_limit.into();
+                    let old_rate_limit = self.rate_limiter.update(new_rate_limit);
+                    if old_rate_limit != new_rate_limit {
+                        tracing::info!(
+                            old_rate_limit = ?old_rate_limit,
+                            new_rate_limit = ?new_rate_limit,
+                            upstream_table_id = %self.upstream_table_id,
+                            actor_id = %self.actor_ctx.id,
+                            "cross-db backfill rate limit changed",
+                        );
+                    }
+                }
                 yield Message::Barrier(barrier);
                 if let Some(new_vnode_bitmap) =
                     post_commit.post_yield_barrier(update_vnode_bitmap).await?

--- a/src/stream/src/executor/backfill/snapshot_backfill/consume_upstream/executor.rs
+++ b/src/stream/src/executor/backfill/snapshot_backfill/consume_upstream/executor.rs
@@ -20,9 +20,7 @@ use futures::{FutureExt, TryStreamExt};
 use futures_async_stream::try_stream;
 use risingwave_common::catalog::TableId;
 use risingwave_common::metrics::LabelGuardedIntGauge;
-use risingwave_common_rate_limit::{
-    MonitoredRateLimiter, RateLimit, RateLimiter, RateLimiterTrait,
-};
+use risingwave_common_rate_limit::{MonitoredRateLimiter, RateLimit, RateLimiter};
 use risingwave_pb::common::ThrottleType;
 use risingwave_storage::StateStore;
 use rw_futures_util::drop_either_future;
@@ -146,12 +144,12 @@ impl<T: UpstreamTable, S: StateStore> UpstreamTableExecutor<T, S> {
         'on_new_stream: loop {
             loop {
                 let barrier = {
-                    let rate_limited_stream = rate_limit_stream(&mut stream, &self.rate_limiter);
-                    pin_mut!(rate_limited_stream);
-
                     loop {
+                        if self.rate_limiter.rate_limit().is_paused() {
+                            break receive_next_barrier(&mut self.barrier_rx).await?;
+                        }
                         let future1 = receive_next_barrier(&mut self.barrier_rx);
-                        let future2 = rate_limited_stream.try_next().map(|result| {
+                        let future2 = stream.try_next().map(|result| {
                             result
                                 .and_then(|opt| opt.ok_or_else(|| anyhow!("end of stream").into()))
                         });
@@ -162,6 +160,8 @@ impl<T: UpstreamTable, S: StateStore> UpstreamTableExecutor<T, S> {
                                 break barrier;
                             }
                             Either::Right(Ok(chunk)) => {
+                                assert!(!self.rate_limiter.rate_limit().is_paused());
+                                self.rate_limiter.wait(chunk.cardinality() as _).await;
                                 yield Message::Chunk(chunk);
                             }
                             Either::Left(Err(e)) | Either::Right(Err(e)) => {
@@ -172,6 +172,7 @@ impl<T: UpstreamTable, S: StateStore> UpstreamTableExecutor<T, S> {
                 };
 
                 if let Some(chunk) = stream.consume_builder() {
+                    self.rate_limiter.wait(chunk.cardinality() as _).await;
                     yield Message::Chunk(chunk);
                 }
                 stream
@@ -269,20 +270,6 @@ impl<T: UpstreamTable, S: StateStore> UpstreamTableExecutor<T, S> {
                 }
             }
         }
-    }
-}
-
-// The future returned by `.next()` is cancellation safe even if the whole stream is dropped.
-#[try_stream(ok = StreamChunk, error = StreamExecutorError)]
-async fn rate_limit_stream<'a>(
-    stream: &'a mut (impl Stream<Item = StreamExecutorResult<StreamChunk>> + Unpin),
-    rate_limiter: &'a RateLimiter,
-) {
-    while let Some(chunk) = stream.try_next().await? {
-        let quota = chunk.cardinality();
-        // the chunk is yielded immediately without any await point breaking in, so the stream is cancellation safe.
-        yield chunk;
-        rate_limiter.wait(quota as _).await;
     }
 }
 

--- a/src/stream/src/executor/backfill/snapshot_backfill/consume_upstream/stream.rs
+++ b/src/stream/src/executor/backfill/snapshot_backfill/consume_upstream/stream.rs
@@ -189,6 +189,26 @@ pub(super) struct ConsumeUpstreamStream<'a, T: UpstreamTable> {
 }
 
 impl<T: UpstreamTable> ConsumeUpstreamStream<'_, T> {
+    pub(super) fn update_rate_limiter(&mut self, new_rate_limit: RateLimit) {
+        self.rate_limit = new_rate_limit;
+        let chunk_size = self.chunk_size;
+        match &mut self.state {
+            ConsumeUpstreamStreamState::ConsumingSnapshotStream { stream, .. } => {
+                stream.update_rate_limiter(new_rate_limit, chunk_size);
+            }
+            ConsumeUpstreamStreamState::ConsumingChangeLogStream { stream, .. } => {
+                stream.update_rate_limiter(new_rate_limit, chunk_size);
+            }
+            ConsumeUpstreamStreamState::ResolvingNextEpoch { .. }
+            | ConsumeUpstreamStreamState::CreatingChangeLogStream { .. }
+            | ConsumeUpstreamStreamState::CreatingSnapshotStream { .. } => {}
+            ConsumeUpstreamStreamState::StoppedOnRetentionMiss => {}
+            ConsumeUpstreamStreamState::Err => {
+                unreachable!("should not be accessed on Err")
+            }
+        }
+    }
+
     pub(super) fn consume_builder(&mut self) -> Option<StreamChunk> {
         match &mut self.state {
             ConsumeUpstreamStreamState::ConsumingSnapshotStream { stream, .. } => {
@@ -266,13 +286,16 @@ impl<T: UpstreamTable> Stream for ConsumeUpstreamStream<'_, T> {
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         let result: Result<!, StreamExecutorError> = try {
             loop {
+                let rate_limit = self.rate_limit;
+                let chunk_size = self.chunk_size;
                 match &mut self.state {
                     ConsumeUpstreamStreamState::CreatingSnapshotStream {
                         future,
                         snapshot_epoch,
                         pre_finished_vnodes,
                     } => {
-                        let stream = ready!(future.as_mut().poll(cx))?;
+                        let mut stream = ready!(future.as_mut().poll(cx))?;
+                        stream.update_rate_limiter(rate_limit, chunk_size);
                         let snapshot_epoch = *snapshot_epoch;
                         let pre_finished_vnodes = take(pre_finished_vnodes);
                         self.state = ConsumeUpstreamStreamState::ConsumingSnapshotStream {
@@ -314,7 +337,8 @@ impl<T: UpstreamTable> Stream for ConsumeUpstreamStream<'_, T> {
                         pre_finished_vnodes,
                         ..
                     } => {
-                        let stream = ready!(future.as_mut().poll(cx))?;
+                        let mut stream = ready!(future.as_mut().poll(cx))?;
+                        stream.update_rate_limiter(rate_limit, chunk_size);
                         let epoch = *epoch;
                         let pre_finished_vnodes = take(pre_finished_vnodes);
                         self.state = ConsumeUpstreamStreamState::ConsumingChangeLogStream {


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

This PR fixes two cross-database backfill creation issues:

- Pause time-travel vacuum while any backfill creating job is active, instead of only snapshot backfill jobs. This prevents upstream table snapshots needed by cross-db backfill from being vacuumed before the consuming side finishes.
- Apply `ALTER MATERIALIZED VIEW ... SET backfill_rate_limit` updates to cross-db snapshot backfill executors by handling backfill throttle mutations on barriers.

It also adds SLT coverage for altering the cross-db backfill rate limit from `0` to a positive value and verifying the materialized view finishes.

## Checklist

- [ ] I have written necessary rustdoc comments.
- [x] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [x] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

Cross-database materialized view creation is more resilient when upstream time-travel vacuum runs, and cross-db backfill now respects runtime `backfill_rate_limit` changes.

</details>
