### PR TITLE
refactor(expr): split sync and async expression traits

### DIFF
--- a/src/batch/executors/src/executor/aggregation/filter.rs
+++ b/src/batch/executors/src/executor/aggregation/filter.rs
@@ -13,23 +13,22 @@
 // limitations under the License.
 
 use std::ops::Range;
-use std::sync::Arc;
 
 use risingwave_common::array::StreamChunk;
 use risingwave_common::types::{DataType, Datum};
 use risingwave_expr::Result;
 use risingwave_expr::aggregate::{AggregateFunction, AggregateState, BoxedAggregateFunction};
-use risingwave_expr::expr::Expression;
+use risingwave_expr::expr::BoxedExpression;
 
 /// A special aggregator that filters out rows that do not satisfy the given _condition_
 /// and feeds the rows that satisfy to the _inner_ aggregator.
 pub struct Filter {
-    condition: Arc<dyn Expression>,
+    condition: BoxedExpression,
     inner: BoxedAggregateFunction,
 }
 
 impl Filter {
-    pub fn new(condition: Arc<dyn Expression>, inner: BoxedAggregateFunction) -> Self {
+    pub fn new(condition: BoxedExpression, inner: BoxedAggregateFunction) -> Self {
         assert_eq!(condition.return_type(), DataType::Boolean);
         Self { condition, inner }
     }
@@ -75,7 +74,7 @@ impl AggregateFunction for Filter {
 mod tests {
     use risingwave_common::test_prelude::StreamChunkTestExt;
     use risingwave_expr::aggregate::{AggCall, build_append_only};
-    use risingwave_expr::expr::{ExpressionBoxExt, LiteralExpression, build_from_pretty};
+    use risingwave_expr::expr::{LiteralExpression, SyncExpressionBoxExt, build_from_pretty};
 
     use super::*;
 
@@ -83,7 +82,7 @@ mod tests {
     async fn test_selective_agg_always_true() -> Result<()> {
         let condition = LiteralExpression::new(DataType::Boolean, Some(true.into())).boxed();
         let agg = Filter::new(
-            condition.into(),
+            condition,
             build_append_only(&AggCall::from_pretty("(count:int8 $0:int8)")).unwrap(),
         );
         let mut state = agg.create_state()?;
@@ -112,7 +111,7 @@ mod tests {
     async fn test_selective_agg() -> Result<()> {
         let expr = build_from_pretty("(greater_than:boolean $0:int8 5:int8)");
         let agg = Filter::new(
-            expr.into(),
+            expr,
             build_append_only(&AggCall::from_pretty("(count:int8 $0:int8)")).unwrap(),
         );
         let mut state = agg.create_state()?;
@@ -144,7 +143,7 @@ mod tests {
     async fn test_selective_agg_null_condition() -> Result<()> {
         let expr = build_from_pretty("(equal:boolean $0:int8 null:int8)");
         let agg = Filter::new(
-            expr.into(),
+            expr,
             build_append_only(&AggCall::from_pretty("(count:int8 $0:int8)")).unwrap(),
         );
         let mut state = agg.create_state()?;

--- a/src/batch/executors/src/executor/join/hash_join.rs
+++ b/src/batch/executors/src/executor/join/hash_join.rs
@@ -31,7 +31,7 @@ use risingwave_common::types::{DataType, Datum, DefaultOrd};
 use risingwave_common::util::chunk_coalesce::DataChunkBuilder;
 use risingwave_common::util::iter_util::ZipEqFast;
 use risingwave_common_estimate_size::EstimateSize;
-use risingwave_expr::expr::{BoxedExpression, Expression, build_from_prost};
+use risingwave_expr::expr::{BoxedExpression, build_from_prost};
 use risingwave_pb::Message;
 use risingwave_pb::batch_plan::plan_node::NodeBody;
 use risingwave_pb::data::DataChunk as PbDataChunk;
@@ -987,7 +987,7 @@ impl<K: HashKey> HashJoinExecutor<K> {
                                 build_row_id_iter.peek().is_some();
                             yield Self::process_left_outer_join_non_equi_condition(
                                 spilled,
-                                cond.as_ref(),
+                                cond,
                                 &mut non_equi_state,
                             )
                             .await?
@@ -1010,7 +1010,7 @@ impl<K: HashKey> HashJoinExecutor<K> {
         if let Some(spilled) = chunk_builder.consume_all() {
             yield Self::process_left_outer_join_non_equi_condition(
                 spilled,
-                cond.as_ref(),
+                cond,
                 &mut non_equi_state,
             )
             .await?
@@ -1126,7 +1126,7 @@ impl<K: HashKey> HashJoinExecutor<K> {
                         ) {
                             yield Self::process_left_semi_anti_join_non_equi_condition::<false>(
                                 spilled,
-                                cond.as_ref(),
+                                cond,
                                 &mut non_equi_state,
                             )
                             .await?
@@ -1140,7 +1140,7 @@ impl<K: HashKey> HashJoinExecutor<K> {
         if let Some(spilled) = chunk_builder.consume_all() {
             yield Self::process_left_semi_anti_join_non_equi_condition::<false>(
                 spilled,
-                cond.as_ref(),
+                cond,
                 &mut non_equi_state,
             )
             .await?
@@ -1197,7 +1197,7 @@ impl<K: HashKey> HashJoinExecutor<K> {
                                 build_row_id_iter.peek().is_some();
                             yield Self::process_left_semi_anti_join_non_equi_condition::<true>(
                                 spilled,
-                                cond.as_ref(),
+                                cond,
                                 &mut non_equi_state,
                             )
                             .await?
@@ -1216,7 +1216,7 @@ impl<K: HashKey> HashJoinExecutor<K> {
         if let Some(spilled) = chunk_builder.consume_all() {
             yield Self::process_left_semi_anti_join_non_equi_condition::<true>(
                 spilled,
-                cond.as_ref(),
+                cond,
                 &mut non_equi_state,
             )
             .await?
@@ -1331,7 +1331,7 @@ impl<K: HashKey> HashJoinExecutor<K> {
                     ) {
                         yield Self::process_right_outer_join_non_equi_condition(
                             spilled,
-                            cond.as_ref(),
+                            cond,
                             &mut non_equi_state,
                         )
                         .await?
@@ -1342,7 +1342,7 @@ impl<K: HashKey> HashJoinExecutor<K> {
         if let Some(spilled) = chunk_builder.consume_all() {
             yield Self::process_right_outer_join_non_equi_condition(
                 spilled,
-                cond.as_ref(),
+                cond,
                 &mut non_equi_state,
             )
             .await?
@@ -1448,7 +1448,7 @@ impl<K: HashKey> HashJoinExecutor<K> {
                     ) {
                         Self::process_right_semi_anti_join_non_equi_condition(
                             spilled,
-                            cond.as_ref(),
+                            cond,
                             &mut non_equi_state,
                         )
                         .await?
@@ -1459,7 +1459,7 @@ impl<K: HashKey> HashJoinExecutor<K> {
         if let Some(spilled) = chunk_builder.consume_all() {
             Self::process_right_semi_anti_join_non_equi_condition(
                 spilled,
-                cond.as_ref(),
+                cond,
                 &mut non_equi_state,
             )
             .await?
@@ -1605,7 +1605,7 @@ impl<K: HashKey> HashJoinExecutor<K> {
                                 build_row_id_iter.peek().is_some();
                             yield Self::process_full_outer_join_non_equi_condition(
                                 spilled,
-                                cond.as_ref(),
+                                cond,
                                 &mut left_non_equi_state,
                                 &mut right_non_equi_state,
                             )
@@ -1629,7 +1629,7 @@ impl<K: HashKey> HashJoinExecutor<K> {
         if let Some(spilled) = chunk_builder.consume_all() {
             yield Self::process_full_outer_join_non_equi_condition(
                 spilled,
-                cond.as_ref(),
+                cond,
                 &mut left_non_equi_state,
                 &mut right_non_equi_state,
             )
@@ -1784,7 +1784,7 @@ impl<K: HashKey> HashJoinExecutor<K> {
     /// tests.
     async fn process_left_outer_join_non_equi_condition(
         chunk: DataChunk,
-        cond: &dyn Expression,
+        cond: &BoxedExpression,
         LeftNonEquiJoinState {
             probe_column_count,
             first_output_row_id,
@@ -1808,7 +1808,7 @@ impl<K: HashKey> HashJoinExecutor<K> {
     /// Removes duplicate rows.
     async fn process_left_semi_anti_join_non_equi_condition<const ANTI_JOIN: bool>(
         chunk: DataChunk,
-        cond: &dyn Expression,
+        cond: &BoxedExpression,
         LeftNonEquiJoinState {
             first_output_row_id,
             found_matched,
@@ -1829,7 +1829,7 @@ impl<K: HashKey> HashJoinExecutor<K> {
 
     async fn process_right_outer_join_non_equi_condition(
         chunk: DataChunk,
-        cond: &dyn Expression,
+        cond: &BoxedExpression,
         RightNonEquiJoinState {
             build_row_ids,
             build_row_matched,
@@ -1843,7 +1843,7 @@ impl<K: HashKey> HashJoinExecutor<K> {
 
     async fn process_right_semi_anti_join_non_equi_condition(
         chunk: DataChunk,
-        cond: &dyn Expression,
+        cond: &BoxedExpression,
         RightNonEquiJoinState {
             build_row_ids,
             build_row_matched,
@@ -1860,7 +1860,7 @@ impl<K: HashKey> HashJoinExecutor<K> {
 
     async fn process_full_outer_join_non_equi_condition(
         chunk: DataChunk,
-        cond: &dyn Expression,
+        cond: &BoxedExpression,
         left_non_equi_state: &mut LeftNonEquiJoinState,
         right_non_equi_state: &mut RightNonEquiJoinState,
     ) -> Result<DataChunk> {
@@ -3441,9 +3441,7 @@ mod tests {
         };
         assert!(compare_data_chunk_with_rowsort(
             &HashJoinExecutor::<Key32>::process_left_outer_join_non_equi_condition(
-                chunk,
-                cond.as_ref(),
-                &mut state
+                chunk, &cond, &mut state
             )
             .await
             .unwrap()
@@ -3471,9 +3469,7 @@ mod tests {
         state.has_more_output_rows = false;
         assert!(compare_data_chunk_with_rowsort(
             &HashJoinExecutor::<Key32>::process_left_outer_join_non_equi_condition(
-                chunk,
-                cond.as_ref(),
-                &mut state
+                chunk, &cond, &mut state
             )
             .await
             .unwrap()
@@ -3501,9 +3497,7 @@ mod tests {
         state.has_more_output_rows = false;
         assert!(compare_data_chunk_with_rowsort(
             &HashJoinExecutor::<Key32>::process_left_outer_join_non_equi_condition(
-                chunk,
-                cond.as_ref(),
-                &mut state
+                chunk, &cond, &mut state
             )
             .await
             .unwrap()
@@ -3541,9 +3535,7 @@ mod tests {
         };
         assert!(compare_data_chunk_with_rowsort(
             &HashJoinExecutor::<Key32>::process_left_semi_anti_join_non_equi_condition::<false>(
-                chunk,
-                cond.as_ref(),
-                &mut state
+                chunk, &cond, &mut state
             )
             .await
             .unwrap()
@@ -3568,9 +3560,7 @@ mod tests {
         state.first_output_row_id = vec![2, 3];
         assert!(compare_data_chunk_with_rowsort(
             &HashJoinExecutor::<Key32>::process_left_semi_anti_join_non_equi_condition::<false>(
-                chunk,
-                cond.as_ref(),
-                &mut state
+                chunk, &cond, &mut state
             )
             .await
             .unwrap()
@@ -3595,9 +3585,7 @@ mod tests {
         state.first_output_row_id = vec![2, 3];
         assert!(compare_data_chunk_with_rowsort(
             &HashJoinExecutor::<Key32>::process_left_semi_anti_join_non_equi_condition::<false>(
-                chunk,
-                cond.as_ref(),
-                &mut state
+                chunk, &cond, &mut state
             )
             .await
             .unwrap()
@@ -3636,9 +3624,7 @@ mod tests {
         };
         assert!(compare_data_chunk_with_rowsort(
             &HashJoinExecutor::<Key32>::process_left_semi_anti_join_non_equi_condition::<true>(
-                chunk,
-                cond.as_ref(),
-                &mut state
+                chunk, &cond, &mut state
             )
             .await
             .unwrap()
@@ -3665,9 +3651,7 @@ mod tests {
         state.has_more_output_rows = false;
         assert!(compare_data_chunk_with_rowsort(
             &HashJoinExecutor::<Key32>::process_left_semi_anti_join_non_equi_condition::<true>(
-                chunk,
-                cond.as_ref(),
-                &mut state
+                chunk, &cond, &mut state
             )
             .await
             .unwrap()
@@ -3694,9 +3678,7 @@ mod tests {
         state.has_more_output_rows = false;
         assert!(compare_data_chunk_with_rowsort(
             &HashJoinExecutor::<Key32>::process_left_semi_anti_join_non_equi_condition::<true>(
-                chunk,
-                cond.as_ref(),
-                &mut state
+                chunk, &cond, &mut state
             )
             .await
             .unwrap()
@@ -3757,9 +3739,7 @@ mod tests {
         };
         assert!(compare_data_chunk_with_rowsort(
             &HashJoinExecutor::<Key32>::process_right_outer_join_non_equi_condition(
-                chunk,
-                cond.as_ref(),
-                &mut state
+                chunk, &cond, &mut state
             )
             .await
             .unwrap()
@@ -3798,9 +3778,7 @@ mod tests {
         ];
         assert!(compare_data_chunk_with_rowsort(
             &HashJoinExecutor::<Key32>::process_right_outer_join_non_equi_condition(
-                chunk,
-                cond.as_ref(),
-                &mut state
+                chunk, &cond, &mut state
             )
             .await
             .unwrap()
@@ -3851,9 +3829,7 @@ mod tests {
 
         assert!(
             HashJoinExecutor::<Key32>::process_right_semi_anti_join_non_equi_condition(
-                chunk,
-                cond.as_ref(),
-                &mut state
+                chunk, &cond, &mut state
             )
             .await
             .is_ok()
@@ -3886,9 +3862,7 @@ mod tests {
         ];
         assert!(
             HashJoinExecutor::<Key32>::process_right_semi_anti_join_non_equi_condition(
-                chunk,
-                cond.as_ref(),
-                &mut state
+                chunk, &cond, &mut state
             )
             .await
             .is_ok()
@@ -3948,7 +3922,7 @@ mod tests {
         assert!(compare_data_chunk_with_rowsort(
             &HashJoinExecutor::<Key32>::process_full_outer_join_non_equi_condition(
                 chunk,
-                cond.as_ref(),
+                &cond,
                 &mut left_state,
                 &mut right_state,
             )
@@ -3996,7 +3970,7 @@ mod tests {
         assert!(compare_data_chunk_with_rowsort(
             &HashJoinExecutor::<Key32>::process_full_outer_join_non_equi_condition(
                 chunk,
-                cond.as_ref(),
+                &cond,
                 &mut left_state,
                 &mut right_state,
             )

--- a/src/batch/executors/src/executor/join/nested_loop_join.rs
+++ b/src/batch/executors/src/executor/join/nested_loop_join.rs
@@ -23,9 +23,7 @@ use risingwave_common::types::{DataType, Datum};
 use risingwave_common::util::chunk_coalesce::DataChunkBuilder;
 use risingwave_common::util::iter_util::ZipEqDebug;
 use risingwave_common_estimate_size::EstimateSize;
-use risingwave_expr::expr::{
-    BoxedExpression, Expression, build_from_prost as expr_build_from_prost,
-};
+use risingwave_expr::expr::{BoxedExpression, build_from_prost as expr_build_from_prost};
 use risingwave_pb::batch_plan::plan_node::NodeBody;
 
 use crate::error::{BatchError, Result};
@@ -144,7 +142,7 @@ impl NestedLoopJoinExecutor {
     /// Create a chunk by concatenating a row with a chunk and set its visibility according to the
     /// evaluation result of the expression.
     async fn concatenate_and_eval(
-        expr: &dyn Expression,
+        expr: &BoxedExpression,
         left_row_types: &[DataType],
         left_row: RowRef<'_>,
         right_chunk: &DataChunk,
@@ -260,7 +258,7 @@ impl NestedLoopJoinExecutor {
                 // 3. Concatenate the left row and right chunk into a single chunk and evaluate the
                 // expression on it.
                 let chunk = Self::concatenate_and_eval(
-                    join_expr.as_ref(),
+                    &join_expr,
                     &left_data_types,
                     left_row,
                     &right_chunk,
@@ -295,7 +293,7 @@ impl NestedLoopJoinExecutor {
             for (left_row_idx, left_row) in left.iter().flat_map(|chunk| chunk.rows()).enumerate() {
                 shutdown_rx.check()?;
                 let chunk = Self::concatenate_and_eval(
-                    join_expr.as_ref(),
+                    &join_expr,
                     &left_data_types,
                     left_row,
                     &right_chunk,
@@ -343,7 +341,7 @@ impl NestedLoopJoinExecutor {
                     continue;
                 }
                 let chunk = Self::concatenate_and_eval(
-                    join_expr.as_ref(),
+                    &join_expr,
                     &left_data_types,
                     left_row,
                     &right_chunk,
@@ -384,7 +382,7 @@ impl NestedLoopJoinExecutor {
             for left_row in left.iter().flat_map(|chunk| chunk.rows()) {
                 shutdown_rx.check()?;
                 let chunk = Self::concatenate_and_eval(
-                    join_expr.as_ref(),
+                    &join_expr,
                     &left_data_types,
                     left_row,
                     &right_chunk,
@@ -428,7 +426,7 @@ impl NestedLoopJoinExecutor {
             for left_row in left.iter().flat_map(|chunk| chunk.rows()) {
                 shutdown_rx.check()?;
                 let chunk = Self::concatenate_and_eval(
-                    join_expr.as_ref(),
+                    &join_expr,
                     &left_data_types,
                     left_row,
                     &right_chunk,
@@ -470,7 +468,7 @@ impl NestedLoopJoinExecutor {
             for (left_row_idx, left_row) in left.iter().flat_map(|chunk| chunk.rows()).enumerate() {
                 shutdown_rx.check()?;
                 let chunk = Self::concatenate_and_eval(
-                    join_expr.as_ref(),
+                    &join_expr,
                     &left_data_types,
                     left_row,
                     &right_chunk,

--- a/src/batch/executors/src/executor/project.rs
+++ b/src/batch/executors/src/executor/project.rs
@@ -12,13 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::sync::Arc;
-
 use futures::{Stream, StreamExt};
 use itertools::Itertools;
 use risingwave_common::array::DataChunk;
 use risingwave_common::catalog::{Field, Schema};
-use risingwave_expr::expr::{BoxedExpression, Expression, build_batch_expr_from_prost};
+use risingwave_expr::expr::{BoxedExpression, build_batch_expr_from_prost};
 use risingwave_pb::batch_plan::plan_node::NodeBody;
 
 use crate::error::{BatchError, Result};
@@ -50,7 +48,6 @@ impl Executor for ProjectExecutor {
 impl ProjectExecutor {
     fn do_execute(self) -> impl Stream<Item = Result<DataChunk>> + 'static {
         let Self { expr, child, .. } = self;
-        let expr: Arc<[Box<dyn Expression>]> = expr.into();
         child
             .execute()
             .map(move |data_chunk| {
@@ -132,7 +129,7 @@ mod tests {
         );
 
         let expr1 = InputRefExpression::new(DataType::Int32, 0);
-        let expr_vec = vec![Box::new(expr1) as BoxedExpression];
+        let expr_vec: Vec<BoxedExpression> = vec![expr1.into()];
 
         let schema = schema_unnamed! { DataType::Int32, DataType::Int32 };
         let mut mock_executor = MockExecutor::new(schema);
@@ -179,7 +176,7 @@ mod tests {
         ));
 
         let proj_executor = Box::new(ProjectExecutor {
-            expr: vec![Box::new(literal)],
+            expr: vec![literal.into()],
             child: values_executor2,
             schema: schema_unnamed!(DataType::Int32),
             identity: "ProjectExecutor2".to_owned(),

--- a/src/batch/executors/src/executor/project_set.rs
+++ b/src/batch/executors/src/executor/project_set.rs
@@ -230,7 +230,7 @@ mod tests {
     use futures::stream::StreamExt;
     use futures_async_stream::for_await;
     use risingwave_common::test_prelude::*;
-    use risingwave_expr::expr::{ExpressionBoxExt, InputRefExpression, LiteralExpression};
+    use risingwave_expr::expr::{InputRefExpression, LiteralExpression, SyncExpressionBoxExt};
     use risingwave_expr::table_function::repeat;
 
     use super::*;

--- a/src/batch/executors/src/executor/update.rs
+++ b/src/batch/executors/src/executor/update.rs
@@ -311,9 +311,9 @@ mod tests {
         ));
 
         // Update expressions, will swap two columns.
-        let exprs = vec![
-            Box::new(InputRefExpression::new(DataType::Int32, 1)) as BoxedExpression,
-            Box::new(InputRefExpression::new(DataType::Int32, 0)),
+        let exprs: Vec<BoxedExpression> = vec![
+            InputRefExpression::new(DataType::Int32, 1).into(),
+            InputRefExpression::new(DataType::Int32, 0).into(),
         ];
 
         // Create the table.

--- a/src/batch/executors/src/executor/values.rs
+++ b/src/batch/executors/src/executor/values.rs
@@ -151,23 +151,15 @@ mod tests {
     #[tokio::test]
     async fn test_values_executor() {
         let value = StructValue::new(vec![Some(1.into()), Some(2.into()), Some(3.into())]);
-        let exprs = vec![
-            Box::new(LiteralExpression::new(
-                DataType::Int16,
-                Some(ScalarImpl::Int16(1)),
-            )) as BoxedExpression,
-            Box::new(LiteralExpression::new(
-                DataType::Int32,
-                Some(ScalarImpl::Int32(2)),
-            )),
-            Box::new(LiteralExpression::new(
-                DataType::Int64,
-                Some(ScalarImpl::Int64(3)),
-            )),
-            Box::new(LiteralExpression::new(
+        let exprs: Vec<BoxedExpression> = vec![
+            LiteralExpression::new(DataType::Int16, Some(ScalarImpl::Int16(1))).into(),
+            LiteralExpression::new(DataType::Int32, Some(ScalarImpl::Int32(2))).into(),
+            LiteralExpression::new(DataType::Int64, Some(ScalarImpl::Int64(3))).into(),
+            LiteralExpression::new(
                 StructType::unnamed(vec![DataType::Int32, DataType::Int32, DataType::Int32]).into(),
                 Some(ScalarImpl::Struct(value)),
-            )) as BoxedExpression,
+            )
+            .into(),
         ];
 
         let fields = exprs
@@ -215,22 +207,10 @@ mod tests {
     #[tokio::test]
     async fn test_chunk_split_size() {
         let rows = [
-            Box::new(LiteralExpression::new(
-                DataType::Int32,
-                Some(ScalarImpl::Int32(1)),
-            )) as BoxedExpression,
-            Box::new(LiteralExpression::new(
-                DataType::Int32,
-                Some(ScalarImpl::Int32(2)),
-            )) as BoxedExpression,
-            Box::new(LiteralExpression::new(
-                DataType::Int32,
-                Some(ScalarImpl::Int32(3)),
-            )) as BoxedExpression,
-            Box::new(LiteralExpression::new(
-                DataType::Int32,
-                Some(ScalarImpl::Int32(4)),
-            )) as BoxedExpression,
+            LiteralExpression::new(DataType::Int32, Some(ScalarImpl::Int32(1))).into(),
+            LiteralExpression::new(DataType::Int32, Some(ScalarImpl::Int32(2))).into(),
+            LiteralExpression::new(DataType::Int32, Some(ScalarImpl::Int32(3))).into(),
+            LiteralExpression::new(DataType::Int32, Some(ScalarImpl::Int32(4))).into(),
         ]
         .into_iter()
         .map(|expr| vec![expr])

--- a/src/common/src/array/list_array.rs
+++ b/src/common/src/array/list_array.rs
@@ -274,6 +274,21 @@ impl ListArray {
 
     /// Apply the function on the underlying elements.
     /// e.g. `map_inner([[1,2,3],NULL,[4,5]], DOUBLE) = [[2,4,6],NULL,[8,10]]`
+    pub fn map_inner_sync<E, F>(self, f: F) -> std::result::Result<ListArray, E>
+    where
+        F: FnOnce(ArrayImpl) -> std::result::Result<ArrayImpl, E>,
+    {
+        let new_value = (f)(*self.value)?;
+
+        Ok(Self {
+            offsets: self.offsets,
+            bitmap: self.bitmap,
+            value: Box::new(new_value),
+        })
+    }
+
+    /// Apply the async function on the underlying elements.
+    /// e.g. `map_inner([[1,2,3],NULL,[4,5]], DOUBLE) = [[2,4,6],NULL,[8,10]]`
     pub async fn map_inner<E, Fut, F>(self, f: F) -> std::result::Result<ListArray, E>
     where
         F: FnOnce(ArrayImpl) -> Fut,

--- a/src/expr/core/src/aggregate/def.rs
+++ b/src/expr/core/src/aggregate/def.rs
@@ -17,7 +17,6 @@
 use std::fmt::Display;
 use std::iter::Peekable;
 use std::str::FromStr;
-use std::sync::Arc;
 
 use anyhow::Context;
 use enum_as_inner::EnumAsInner;
@@ -32,9 +31,7 @@ use risingwave_pb::expr::{
 };
 
 use crate::Result;
-use crate::expr::{
-    BoxedExpression, ExpectExt, Expression, LiteralExpression, Token, build_from_prost,
-};
+use crate::expr::{BoxedExpression, ExpectExt, LiteralExpression, Token, build_from_prost};
 
 /// Represents an aggregation function.
 // TODO(runji):
@@ -56,7 +53,7 @@ pub struct AggCall {
     pub column_orders: Vec<ColumnOrder>,
 
     /// Filter of aggregation.
-    pub filter: Option<Arc<dyn Expression>>,
+    pub filter: Option<BoxedExpression>,
 
     /// Should deduplicate the input before aggregation.
     pub distinct: bool,
@@ -83,7 +80,7 @@ impl AggCall {
             })
             .collect();
         let filter = match agg_call.filter {
-            Some(ref pb_filter) => Some(build_from_prost(pb_filter)?.into()), /* TODO: non-strict filter in streaming */
+            Some(ref pb_filter) => Some(build_from_prost(pb_filter)?), /* TODO: non-strict filter in streaming */
             None => None,
         };
         let direct_args = agg_call
@@ -121,7 +118,7 @@ impl AggCall {
     }
 
     pub fn with_filter(mut self, filter: BoxedExpression) -> Self {
-        self.filter = Some(filter.into());
+        self.filter = Some(filter);
         self
     }
 }

--- a/src/expr/core/src/aggregate/scalar_wrapper.rs
+++ b/src/expr/core/src/aggregate/scalar_wrapper.rs
@@ -16,7 +16,7 @@ use risingwave_common::array::{Array, ArrayBuilderImpl, DataChunk, ListArray};
 use risingwave_common::types::ListValue;
 
 use super::*;
-use crate::expr::{BoxedExpression, Expression};
+use crate::expr::BoxedExpression;
 
 /// Wraps a scalar function that takes a list as input as an aggregate function.
 #[derive(Debug)]

--- a/src/expr/core/src/expr/and_or.rs
+++ b/src/expr/core/src/expr/and_or.rs
@@ -112,7 +112,6 @@ impl<E: SyncExpression> SyncExpression for BinaryShortCircuitExpression<E> {
     }
 }
 
-#[async_trait::async_trait]
 impl<E: AsyncExpression> AsyncExpression for BinaryShortCircuitExpression<E> {
     async fn eval(&self, input: &DataChunk) -> Result<ArrayRef> {
         eval_short_circuit!(async, self, input)

--- a/src/expr/core/src/expr/and_or.rs
+++ b/src/expr/core/src/expr/and_or.rs
@@ -22,29 +22,33 @@ use risingwave_common::types::{DataType, Datum, Scalar};
 use risingwave_expr_macro::build_function;
 use risingwave_pb::expr::expr_node::Type;
 
-use super::{BoxedExpression, Expression};
+use super::{
+    AsyncExpression, AsyncExpressionBoxExt, BoxedExpression, ExpressionInfo, SyncExpression,
+    SyncExpressionBoxExt,
+};
 use crate::Result;
 
 /// This is just an implementation detail. The semantic is not guaranteed at SQL level because
 /// optimizer may have rearranged the boolean expressions. #6202
 #[derive(Debug)]
-pub struct BinaryShortCircuitExpression {
-    expr_ia1: BoxedExpression,
-    expr_ia2: BoxedExpression,
+pub struct BinaryShortCircuitExpression<E> {
+    expr_ia1: E,
+    expr_ia2: E,
     expr_type: Type,
 }
 
-#[async_trait::async_trait]
-impl Expression for BinaryShortCircuitExpression {
+impl<E: ExpressionInfo> ExpressionInfo for BinaryShortCircuitExpression<E> {
     fn return_type(&self) -> DataType {
         DataType::Boolean
     }
+}
 
-    async fn eval(&self, input: &DataChunk) -> Result<ArrayRef> {
-        let left = self.expr_ia1.eval(input).await?;
+macro_rules! eval_short_circuit {
+    ($mode:ident, $this:expr, $input:expr) => {{
+        let left = forward!($mode, $this.expr_ia1, eval($input))?;
         let left = left.as_bool();
 
-        let res_vis = match self.expr_type {
+        let res_vis = match $this.expr_type {
             // For `Or` operator, if res of left part is not null and is true, we do not want to
             // calculate right part because the result must be true.
             Type::Or => !left.to_bitmap(),
@@ -53,17 +57,17 @@ impl Expression for BinaryShortCircuitExpression {
             Type::And => left.data() | !left.null_bitmap(),
             _ => unimplemented!(),
         };
-        let new_vis = input.visibility() & res_vis;
-        let mut input1 = input.clone();
+        let new_vis = $input.visibility() & res_vis;
+        let mut input1 = $input.clone();
         input1.set_visibility(new_vis);
 
-        let right = self.expr_ia2.eval(&input1).await?;
+        let right = forward!($mode, $this.expr_ia2, eval(&input1))?;
         let right = right.as_bool();
         assert_eq!(left.len(), right.len());
 
-        let mut bitmap = input.visibility() & left.null_bitmap() & right.null_bitmap();
+        let mut bitmap = $input.visibility() & left.null_bitmap() & right.null_bitmap();
 
-        let c = match self.expr_type {
+        let c = match $this.expr_type {
             Type::Or => {
                 let data = left.to_bitmap() | right.to_bitmap();
                 bitmap |= &data; // is_true || is_true
@@ -78,42 +82,78 @@ impl Expression for BinaryShortCircuitExpression {
             _ => unimplemented!(),
         };
         Ok(Arc::new(c.into()))
-    }
+    }};
+}
 
-    async fn eval_row(&self, input: &OwnedRow) -> Result<Datum> {
-        let ret_ia1 = self.expr_ia1.eval_row(input).await?.map(|x| x.into_bool());
-        match self.expr_type {
+macro_rules! eval_row_short_circuit {
+    ($mode:ident, $this:expr, $input:expr) => {{
+        let ret_ia1 = forward!($mode, $this.expr_ia1, eval_row($input))?.map(|x| x.into_bool());
+        match $this.expr_type {
             Type::Or if ret_ia1 == Some(true) => return Ok(Some(true.to_scalar_value())),
             Type::And if ret_ia1 == Some(false) => return Ok(Some(false.to_scalar_value())),
             _ => {}
         }
-        let ret_ia2 = self.expr_ia2.eval_row(input).await?.map(|x| x.into_bool());
-        match self.expr_type {
+        let ret_ia2 = forward!($mode, $this.expr_ia2, eval_row($input))?.map(|x| x.into_bool());
+        match $this.expr_type {
             Type::Or => Ok(or(ret_ia1, ret_ia2).map(|x| x.to_scalar_value())),
             Type::And => Ok(and(ret_ia1, ret_ia2).map(|x| x.to_scalar_value())),
             _ => unimplemented!(),
         }
+    }};
+}
+
+impl<E: SyncExpression> SyncExpression for BinaryShortCircuitExpression<E> {
+    fn eval(&self, input: &DataChunk) -> Result<ArrayRef> {
+        eval_short_circuit!(sync, self, input)
+    }
+
+    fn eval_row(&self, input: &OwnedRow) -> Result<Datum> {
+        eval_row_short_circuit!(sync, self, input)
+    }
+}
+
+#[async_trait::async_trait]
+impl<E: AsyncExpression> AsyncExpression for BinaryShortCircuitExpression<E> {
+    async fn eval(&self, input: &DataChunk) -> Result<ArrayRef> {
+        eval_short_circuit!(async, self, input)
+    }
+
+    async fn eval_row(&self, input: &OwnedRow) -> Result<Datum> {
+        eval_row_short_circuit!(async, self, input)
     }
 }
 
 #[build_function("and(boolean, boolean) -> boolean")]
 fn build_and_expr(_: DataType, children: Vec<BoxedExpression>) -> Result<BoxedExpression> {
-    let mut iter = children.into_iter();
-    Ok(Box::new(BinaryShortCircuitExpression {
-        expr_ia1: iter.next().unwrap(),
-        expr_ia2: iter.next().unwrap(),
-        expr_type: Type::And,
-    }))
+    build_binary_short_circuit(children, Type::And)
 }
 
 #[build_function("or(boolean, boolean) -> boolean")]
 fn build_or_expr(_: DataType, children: Vec<BoxedExpression>) -> Result<BoxedExpression> {
-    let mut iter = children.into_iter();
-    Ok(Box::new(BinaryShortCircuitExpression {
-        expr_ia1: iter.next().unwrap(),
-        expr_ia2: iter.next().unwrap(),
-        expr_type: Type::Or,
-    }))
+    build_binary_short_circuit(children, Type::Or)
+}
+
+fn build_binary_short_circuit(
+    children: Vec<BoxedExpression>,
+    expr_type: Type,
+) -> Result<BoxedExpression> {
+    let [left, right]: [_; 2] = children.try_into().unwrap();
+    Ok(match (left, right) {
+        (BoxedExpression::Sync(left), BoxedExpression::Sync(right)) => {
+            BinaryShortCircuitExpression {
+                expr_ia1: left,
+                expr_ia2: right,
+                expr_type,
+            }
+            .boxed()
+        }
+        (left, right) => BinaryShortCircuitExpression {
+            expr_ia1: left,
+            expr_ia2: right,
+            expr_type,
+        }
+        .boxed(),
+    })
 }
 
 // #[function("and(boolean, boolean) -> boolean")]

--- a/src/expr/core/src/expr/build.rs
+++ b/src/expr/core/src/expr/build.rs
@@ -28,7 +28,8 @@ use super::wrapper::EvalErrorReport;
 use super::wrapper::checked::Checked;
 use super::wrapper::non_strict::NonStrict;
 use crate::expr::{
-    BoxedExpression, Expression, ExpressionBoxExt, InputRefExpression, LiteralExpression,
+    AsyncExpressionBoxExt, BoxedExpression, InputRefExpression, LiteralExpression, SyncExpression,
+    SyncExpressionBoxExt,
 };
 use crate::expr_context::strict_mode;
 use crate::sig::FUNCTION_REGISTRY;
@@ -37,7 +38,10 @@ use crate::{Result, bail};
 /// Build an expression from protobuf.
 pub fn build_from_prost(prost: &ExprNode) -> Result<BoxedExpression> {
     let expr = ExprBuilder::new_strict().build(prost)?;
-    Ok(Strict::new(expr).boxed())
+    Ok(match expr {
+        BoxedExpression::Sync(expr) => Strict::new(expr).boxed(),
+        BoxedExpression::Async(expr) => Strict::new(expr).boxed(),
+    })
 }
 
 /// Build an expression from protobuf in non-strict mode.
@@ -45,9 +49,11 @@ pub fn build_non_strict_from_prost(
     prost: &ExprNode,
     error_report: impl EvalErrorReport + 'static,
 ) -> Result<NonStrictExpression> {
-    ExprBuilder::new_non_strict(error_report)
-        .build(prost)
-        .map(NonStrictExpression)
+    let expr = ExprBuilder::new_non_strict(error_report).build(prost)?;
+    Ok(match expr {
+        BoxedExpression::Sync(expr) => NonStrictExpression::Sync(expr),
+        BoxedExpression::Async(expr) => NonStrictExpression::Async(expr),
+    })
 }
 
 /// Build a strict or non-strict expression according to expr context.
@@ -61,7 +67,7 @@ pub fn build_batch_expr_from_prost(prost: &ExprNode) -> Result<BoxedExpression> 
         build_from_prost(prost)
     } else {
         // TODO(eric): report errors to users via psql notice
-        Ok(ExprBuilder::new_non_strict(LogReport).build(prost)?.boxed())
+        Ok(ExprBuilder::new_non_strict(LogReport).build(prost)?)
     }
 }
 
@@ -93,17 +99,25 @@ where
     }
 
     /// Attach wrappers to an expression.
-    #[expect(clippy::let_and_return)]
-    fn wrap(&self, expr: impl Expression + 'static) -> BoxedExpression {
-        let checked = Checked(expr);
-
-        let may_non_strict = if let Some(error_report) = &self.error_report {
-            NonStrict::new(checked, error_report.clone()).boxed()
-        } else {
-            checked.boxed()
-        };
-
-        may_non_strict
+    fn wrap(&self, expr: BoxedExpression) -> BoxedExpression {
+        match expr {
+            BoxedExpression::Sync(expr) => {
+                let checked = Checked(expr);
+                if let Some(error_report) = &self.error_report {
+                    NonStrict::new(checked, error_report.clone()).boxed()
+                } else {
+                    checked.boxed()
+                }
+            }
+            BoxedExpression::Async(expr) => {
+                let checked = Checked(expr);
+                if let Some(error_report) = &self.error_report {
+                    NonStrict::new(checked, error_report.clone()).boxed()
+                } else {
+                    checked.boxed()
+                }
+            }
+        }
     }
 
     /// Build an expression with `build_inner` and attach some wrappers.
@@ -154,7 +168,7 @@ where
 }
 
 /// Manually build the expression `Self` from protobuf.
-pub(crate) trait Build: Expression + Sized {
+pub(crate) trait Build: SyncExpression + Sized {
     /// Build the expression `Self` from protobuf.
     ///
     /// To build children, call `build_child` on each child instead of [`build_from_prost`].
@@ -186,7 +200,7 @@ impl<E: Build + 'static> BuildBoxed for E {
         prost: &ExprNode,
         build_child: impl Fn(&ExprNode) -> Result<BoxedExpression>,
     ) -> Result<BoxedExpression> {
-        Self::build(prost, build_child).map(ExpressionBoxExt::boxed)
+        Self::build(prost, build_child).map(SyncExpressionBoxExt::boxed)
     }
 }
 
@@ -237,9 +251,11 @@ pub fn build_func_non_strict(
     error_report: impl EvalErrorReport + 'static,
 ) -> Result<NonStrictExpression> {
     let expr = build_func(func, ret_type, children)?;
-    let wrapped = NonStrictExpression(ExprBuilder::new_non_strict(error_report).wrap(expr));
-
-    Ok(wrapped)
+    let wrapped = ExprBuilder::new_non_strict(error_report).wrap(expr);
+    Ok(match wrapped {
+        BoxedExpression::Sync(expr) => NonStrictExpression::Sync(expr),
+        BoxedExpression::Async(expr) => NonStrictExpression::Async(expr),
+    })
 }
 
 pub(super) fn get_children_and_return_type(prost: &ExprNode) -> Result<(&[ExprNode], DataType)> {

--- a/src/expr/core/src/expr/expr_input_ref.rs
+++ b/src/expr/core/src/expr/expr_input_ref.rs
@@ -21,7 +21,7 @@ use risingwave_pb::expr::ExprNode;
 
 use super::{BoxedExpression, Build};
 use crate::Result;
-use crate::expr::Expression;
+use crate::expr::{ExpressionInfo, SyncExpression};
 
 /// A reference to a column in input relation.
 #[derive(Debug, Clone)]
@@ -30,23 +30,24 @@ pub struct InputRefExpression {
     idx: usize,
 }
 
-#[async_trait::async_trait]
-impl Expression for InputRefExpression {
+impl ExpressionInfo for InputRefExpression {
     fn return_type(&self) -> DataType {
         self.return_type.clone()
     }
 
-    async fn eval(&self, input: &DataChunk) -> Result<ArrayRef> {
+    fn input_ref_index(&self) -> Option<usize> {
+        Some(self.idx)
+    }
+}
+
+impl SyncExpression for InputRefExpression {
+    fn eval(&self, input: &DataChunk) -> Result<ArrayRef> {
         Ok(input.column_at(self.idx).clone())
     }
 
-    async fn eval_row(&self, input: &OwnedRow) -> Result<Datum> {
+    fn eval_row(&self, input: &OwnedRow) -> Result<Datum> {
         let cell = input.index(self.idx).as_ref().cloned();
         Ok(cell)
-    }
-
-    fn input_ref_index(&self) -> Option<usize> {
-        Some(self.idx)
     }
 }
 
@@ -91,7 +92,7 @@ mod tests {
     use risingwave_common::row::OwnedRow;
     use risingwave_common::types::{DataType, Datum};
 
-    use crate::expr::{Expression, InputRefExpression};
+    use crate::expr::{InputRefExpression, SyncExpression};
 
     #[tokio::test]
     async fn test_eval_row_input_ref() {
@@ -100,7 +101,7 @@ mod tests {
 
         for (i, expected) in datums.iter().enumerate() {
             let expr = InputRefExpression::new(DataType::Int32, i);
-            let result = expr.eval_row(&input_row).await.unwrap();
+            let result = expr.eval_row(&input_row).unwrap();
             assert_eq!(*expected, result);
         }
     }

--- a/src/expr/core/src/expr/expr_literal.rs
+++ b/src/expr/core/src/expr/expr_literal.rs
@@ -19,7 +19,7 @@ use risingwave_common::util::value_encoding::DatumFromProtoExt;
 use risingwave_pb::expr::ExprNode;
 
 use super::{Build, ValueImpl};
-use crate::expr::Expression;
+use crate::expr::{ExpressionInfo, SyncExpression};
 use crate::{ExprError, Result};
 
 /// A literal expression.
@@ -29,20 +29,21 @@ pub struct LiteralExpression {
     literal: Datum,
 }
 
-#[async_trait::async_trait]
-impl Expression for LiteralExpression {
+impl ExpressionInfo for LiteralExpression {
     fn return_type(&self) -> DataType {
         self.return_type.clone()
     }
+}
 
-    async fn eval_v2(&self, input: &DataChunk) -> Result<ValueImpl> {
+impl SyncExpression for LiteralExpression {
+    fn eval_v2(&self, input: &DataChunk) -> Result<ValueImpl> {
         Ok(ValueImpl::Scalar {
             value: self.literal.clone(),
             capacity: input.capacity(),
         })
     }
 
-    async fn eval_row(&self, _input: &OwnedRow) -> Result<Datum> {
+    fn eval_row(&self, _input: &OwnedRow) -> Result<Datum> {
         Ok(self.literal.as_ref().cloned())
     }
 
@@ -216,14 +217,14 @@ mod tests {
     #[tokio::test]
     async fn test_literal_eval_dummy_chunk() {
         let literal = LiteralExpression::new(DataType::Int32, Some(1.into()));
-        let result = literal.eval(&DataChunk::new_dummy(1)).await.unwrap();
+        let result = literal.eval(&DataChunk::new_dummy(1)).unwrap();
         assert_eq!(*result, I32Array::from_iter([1]).into());
     }
 
     #[tokio::test]
     async fn test_literal_eval_row_dummy_chunk() {
         let literal = LiteralExpression::new(DataType::Int32, Some(1.into()));
-        let result = literal.eval_row(&OwnedRow::new(vec![])).await.unwrap();
+        let result = literal.eval_row(&OwnedRow::new(vec![])).unwrap();
         assert_eq!(result, Some(1.into()))
     }
 }

--- a/src/expr/core/src/expr/expr_some_all.rs
+++ b/src/expr/core/src/expr/expr_some_all.rs
@@ -23,24 +23,22 @@ use risingwave_pb::expr::expr_node::{RexNode, Type};
 use risingwave_pb::expr::{ExprNode, FunctionCall};
 
 use super::build::get_children_and_return_type;
-use super::{BoxedExpression, Build, Expression};
+use super::{
+    AsyncExpression, AsyncExpressionBoxExt, BoxedExpression, BuildBoxed, ExpressionInfo,
+    SyncExpression, SyncExpressionBoxExt,
+};
 use crate::Result;
 
 #[derive(Debug)]
-pub struct SomeAllExpression {
-    left_expr: BoxedExpression,
-    right_expr: BoxedExpression,
+pub struct SomeAllExpression<E> {
+    left_expr: E,
+    right_expr: E,
     expr_type: Type,
-    func: BoxedExpression,
+    func: E,
 }
 
-impl SomeAllExpression {
-    pub fn new(
-        left_expr: BoxedExpression,
-        right_expr: BoxedExpression,
-        expr_type: Type,
-        func: BoxedExpression,
-    ) -> Self {
+impl<E> SomeAllExpression<E> {
+    pub fn new(left_expr: E, right_expr: E, expr_type: Type, func: E) -> Self {
         SomeAllExpression {
             left_expr,
             right_expr,
@@ -81,16 +79,17 @@ impl SomeAllExpression {
     }
 }
 
-#[async_trait::async_trait]
-impl Expression for SomeAllExpression {
+impl<E: ExpressionInfo> ExpressionInfo for SomeAllExpression<E> {
     fn return_type(&self) -> DataType {
         DataType::Boolean
     }
+}
 
-    async fn eval(&self, data_chunk: &DataChunk) -> Result<ArrayRef> {
-        let arr_left = self.left_expr.eval(data_chunk).await?;
-        let arr_right = self.right_expr.eval(data_chunk).await?;
-        let mut num_array = Vec::with_capacity(data_chunk.capacity());
+macro_rules! eval_some_all {
+    ($mode:ident, $this:expr, $data_chunk:expr) => {{
+        let arr_left = forward!($mode, $this.left_expr, eval($data_chunk))?;
+        let arr_right = forward!($mode, $this.right_expr, eval($data_chunk))?;
+        let mut num_array = Vec::with_capacity($data_chunk.capacity());
 
         let arr_right_inner = arr_right.as_list();
         let elem_type = arr_right_inner.data_type().into_list_elem();
@@ -118,7 +117,7 @@ impl Expression for SomeAllExpression {
                 }
             };
 
-        if data_chunk.is_vis_compacted() {
+        if $data_chunk.is_vis_compacted() {
             for (left, right) in arr_left.iter().zip_eq_fast(arr_right.iter()) {
                 unfolded_left_right(left, right, &mut num_array);
             }
@@ -126,7 +125,7 @@ impl Expression for SomeAllExpression {
             for ((left, right), visible) in arr_left
                 .iter()
                 .zip_eq_fast(arr_right.iter())
-                .zip_eq_fast(data_chunk.visibility().iter())
+                .zip_eq_fast($data_chunk.visibility().iter())
             {
                 if !visible {
                     num_array.push(None);
@@ -136,7 +135,7 @@ impl Expression for SomeAllExpression {
             }
         }
 
-        assert_eq!(num_array.len(), data_chunk.capacity());
+        assert_eq!(num_array.len(), $data_chunk.capacity());
 
         let unfolded_arr_left = unfolded_arr_left_builder.finish();
         let unfolded_arr_right = unfolded_arr_right_builder.finish();
@@ -151,7 +150,7 @@ impl Expression for SomeAllExpression {
             unfolded_compact_len,
         );
 
-        let func_results = self.func.eval(&data_chunk).await?;
+        let func_results = forward!($mode, $this.func, eval(&data_chunk))?;
         let bools = func_results.as_bool();
         let mut offset = 0;
         Ok(Arc::new(
@@ -161,18 +160,20 @@ impl Expression for SomeAllExpression {
                     Some(num) => {
                         let range = offset..offset + num;
                         offset += num;
-                        self.resolve_bools(range.map(|i| bools.value_at(i)))
+                        $this.resolve_bools(range.map(|i| bools.value_at(i)))
                     }
                     None => None,
                 })
                 .collect::<BoolArray>()
                 .into(),
         ))
-    }
+    }};
+}
 
-    async fn eval_row(&self, row: &OwnedRow) -> Result<Datum> {
-        let datum_left = self.left_expr.eval_row(row).await?;
-        let datum_right = self.right_expr.eval_row(row).await?;
+macro_rules! eval_row_some_all {
+    ($mode:ident, $this:expr, $row:expr) => {{
+        let datum_left = forward!($mode, $this.left_expr, eval_row($row))?;
+        let datum_right = forward!($mode, $this.right_expr, eval_row($row))?;
         let Some(array_right) = datum_right else {
             return Ok(None);
         };
@@ -181,21 +182,42 @@ impl Expression for SomeAllExpression {
 
         // expand left to array
         let array_left = {
-            let mut builder = self.left_expr.return_type().create_array_builder(len);
+            let mut builder = $this.left_expr.return_type().create_array_builder(len);
             builder.append_n(len, datum_left);
             builder.finish().into_ref()
         };
 
         let chunk = DataChunk::new(vec![array_left, Arc::new(array_right)], len);
-        let bools = self.func.eval(&chunk).await?;
+        let bools = forward!($mode, $this.func, eval(&chunk))?;
 
-        Ok(self
+        Ok($this
             .resolve_bools(bools.as_bool().iter())
             .map(|b| b.to_scalar_value()))
+    }};
+}
+
+impl<E: SyncExpression> SyncExpression for SomeAllExpression<E> {
+    fn eval(&self, data_chunk: &DataChunk) -> Result<ArrayRef> {
+        eval_some_all!(sync, self, data_chunk)
+    }
+
+    fn eval_row(&self, row: &OwnedRow) -> Result<Datum> {
+        eval_row_some_all!(sync, self, row)
     }
 }
 
-impl Build for SomeAllExpression {
+#[async_trait::async_trait]
+impl<E: AsyncExpression> AsyncExpression for SomeAllExpression<E> {
+    async fn eval(&self, data_chunk: &DataChunk) -> Result<ArrayRef> {
+        eval_some_all!(async, self, data_chunk)
+    }
+
+    async fn eval_row(&self, row: &OwnedRow) -> Result<Datum> {
+        eval_row_some_all!(async, self, row)
+    }
+}
+
+impl SomeAllExpression<BoxedExpression> {
     fn build(
         prost: &ExprNode,
         build_child: impl Fn(&ExprNode) -> Result<BoxedExpression>,
@@ -258,6 +280,25 @@ impl Build for SomeAllExpression {
             outer_expr_type,
             eval_func,
         ))
+    }
+}
+
+impl BuildBoxed for SomeAllExpression<BoxedExpression> {
+    fn build_boxed(
+        prost: &ExprNode,
+        build_child: impl Fn(&ExprNode) -> Result<BoxedExpression>,
+    ) -> Result<BoxedExpression> {
+        let expr = Self::build(prost, build_child)?;
+        Ok(match (expr.left_expr, expr.right_expr, expr.func) {
+            (
+                BoxedExpression::Sync(left_expr),
+                BoxedExpression::Sync(right_expr),
+                BoxedExpression::Sync(func),
+            ) => SomeAllExpression::new(left_expr, right_expr, expr.expr_type, func).boxed(),
+            (left_expr, right_expr, func) => {
+                SomeAllExpression::new(left_expr, right_expr, expr.expr_type, func).boxed()
+            }
+        })
     }
 }
 

--- a/src/expr/core/src/expr/expr_some_all.rs
+++ b/src/expr/core/src/expr/expr_some_all.rs
@@ -206,7 +206,6 @@ impl<E: SyncExpression> SyncExpression for SomeAllExpression<E> {
     }
 }
 
-#[async_trait::async_trait]
 impl<E: AsyncExpression> AsyncExpression for SomeAllExpression<E> {
     async fn eval(&self, data_chunk: &DataChunk) -> Result<ArrayRef> {
         eval_some_all!(async, self, data_chunk)

--- a/src/expr/core/src/expr/expr_udf.rs
+++ b/src/expr/core/src/expr/expr_udf.rs
@@ -51,7 +51,6 @@ impl ExpressionInfo for UserDefinedFunction {
     }
 }
 
-#[async_trait::async_trait]
 impl AsyncExpression for UserDefinedFunction {
     async fn eval(&self, input: &DataChunk) -> Result<ArrayRef> {
         if input.cardinality() == 0 {

--- a/src/expr/core/src/expr/expr_udf.rs
+++ b/src/expr/core/src/expr/expr_udf.rs
@@ -28,8 +28,8 @@ use risingwave_common::types::{DataType, Datum};
 use risingwave_expr::expr_context::FRAGMENT_ID;
 use risingwave_pb::expr::ExprNode;
 
-use super::{BoxedExpression, Build};
-use crate::expr::Expression;
+use super::{AsyncExpressionBoxExt, BoxedExpression, BuildBoxed};
+use crate::expr::{AsyncExpression, ExpressionInfo};
 use crate::sig::{BuildOptions, UdfImpl, UdfKind};
 use crate::{ExprError, Result, bail};
 
@@ -45,12 +45,14 @@ pub struct UserDefinedFunction {
     metrics: Metrics,
 }
 
-#[async_trait::async_trait]
-impl Expression for UserDefinedFunction {
+impl ExpressionInfo for UserDefinedFunction {
     fn return_type(&self) -> DataType {
         self.return_type.clone()
     }
+}
 
+#[async_trait::async_trait]
+impl AsyncExpression for UserDefinedFunction {
     async fn eval(&self, input: &DataChunk) -> Result<ArrayRef> {
         if input.cardinality() == 0 {
             // early return for empty input
@@ -161,8 +163,8 @@ impl UserDefinedFunction {
     }
 }
 
-impl Build for UserDefinedFunction {
-    fn build(
+impl UserDefinedFunction {
+    fn build_inner(
         prost: &ExprNode,
         build_child: impl Fn(&ExprNode) -> Result<BoxedExpression>,
     ) -> Result<Self> {
@@ -230,6 +232,15 @@ impl Build for UserDefinedFunction {
             span: await_tree::span!("udf_call({})", name),
             metrics,
         })
+    }
+}
+
+impl BuildBoxed for UserDefinedFunction {
+    fn build_boxed(
+        prost: &ExprNode,
+        build_child: impl Fn(&ExprNode) -> Result<BoxedExpression>,
+    ) -> Result<BoxedExpression> {
+        Self::build_inner(prost, build_child).map(AsyncExpressionBoxExt::boxed)
     }
 }
 

--- a/src/expr/core/src/expr/mod.rs
+++ b/src/expr/core/src/expr/mod.rs
@@ -14,7 +14,7 @@
 
 //! Expressions in RisingWave.
 //!
-//! All expressions are implemented under the [`Expression`] trait.
+//! All expressions are implemented under the [`SyncExpression`] or [`AsyncExpression`] trait.
 //!
 //! ## Construction
 //!
@@ -29,7 +29,17 @@
 //! Expressions can be evaluated using the [`eval`] function.
 //!
 //! [`ExprNode`]: risingwave_pb::expr::ExprNode
-//! [`eval`]: Expression::eval
+//! [`eval`]: BoxedExpression::eval
+
+#[macro_export]
+macro_rules! forward {
+    (sync, $expr:expr, $method:ident($($arg:expr),* $(,)?)) => {
+        ($expr).$method($($arg),*)
+    };
+    (async, $expr:expr, $method:ident($($arg:expr),* $(,)?)) => {
+        ($expr).$method($($arg),*).await
+    };
+}
 
 // These modules define concrete expression structures.
 mod and_or;
@@ -43,7 +53,8 @@ mod build;
 pub mod test_utils;
 mod value;
 
-use futures_util::TryFutureExt;
+use std::sync::Arc;
+
 use risingwave_common::array::{ArrayRef, DataChunk};
 use risingwave_common::row::OwnedRow;
 use risingwave_common::types::{DataType, Datum};
@@ -55,17 +66,61 @@ pub use self::value::{ValueImpl, ValueRef};
 pub use self::wrapper::*;
 pub use super::{ExprError, Result};
 
-/// Interface of an expression.
+/// Common metadata of an expression.
+#[auto_impl::auto_impl(&, Box, Arc)]
+pub trait ExpressionInfo: std::fmt::Debug + Sync + Send {
+    /// Get the return data type.
+    fn return_type(&self) -> DataType;
+
+    /// Get the index if the expression is an `InputRef`.
+    fn input_ref_index(&self) -> Option<usize> {
+        None
+    }
+}
+
+/// Interface of a synchronous expression.
 ///
 /// There're two functions to evaluate an expression: `eval` and `eval_v2`, exactly one of them
 /// should be implemented. Prefer calling and implementing `eval_v2` instead of `eval` if possible,
 /// to gain the performance benefit of scalar expression.
-#[async_trait::async_trait]
-#[auto_impl::auto_impl(&, Box)]
-pub trait Expression: std::fmt::Debug + Sync + Send {
-    /// Get the return data type.
-    fn return_type(&self) -> DataType;
+#[auto_impl::auto_impl(&, Box, Arc)]
+pub trait SyncExpression: ExpressionInfo {
+    /// Evaluate the expression in vectorized execution. Returns an array.
+    ///
+    /// The default implementation calls `eval_v2` and always converts the result to an array.
+    fn eval(&self, input: &DataChunk) -> Result<ArrayRef> {
+        let value = self.eval_v2(input)?;
+        Ok(match value {
+            ValueImpl::Array(array) => array,
+            ValueImpl::Scalar { value, capacity } => {
+                let mut builder = self.return_type().create_array_builder(capacity);
+                builder.append_n(capacity, value);
+                builder.finish().into()
+            }
+        })
+    }
 
+    /// Evaluate the expression in vectorized execution. Returns a value that can be either an
+    /// array, or a scalar if all values in the array are the same.
+    ///
+    /// The default implementation calls `eval` and puts the result into the `Array` variant.
+    fn eval_v2(&self, input: &DataChunk) -> Result<ValueImpl> {
+        self.eval(input).map(ValueImpl::Array)
+    }
+
+    /// Evaluate the expression in row-based execution. Returns a nullable scalar.
+    fn eval_row(&self, input: &OwnedRow) -> Result<Datum>;
+
+    /// Evaluate if the expression is constant.
+    fn eval_const(&self) -> Result<Datum> {
+        Err(ExprError::NotConstant)
+    }
+}
+
+/// Interface of an asynchronous expression.
+#[async_trait::async_trait]
+#[auto_impl::auto_impl(&, Box, Arc)]
+pub trait AsyncExpression: ExpressionInfo {
     /// Evaluate the expression in vectorized execution. Returns an array.
     ///
     /// The default implementation calls `eval_v2` and always converts the result to an array.
@@ -86,36 +141,177 @@ pub trait Expression: std::fmt::Debug + Sync + Send {
     ///
     /// The default implementation calls `eval` and puts the result into the `Array` variant.
     async fn eval_v2(&self, input: &DataChunk) -> Result<ValueImpl> {
-        self.eval(input).map_ok(ValueImpl::Array).await
+        self.eval(input).await.map(ValueImpl::Array)
     }
 
     /// Evaluate the expression in row-based execution. Returns a nullable scalar.
     async fn eval_row(&self, input: &OwnedRow) -> Result<Datum>;
+}
 
-    /// Evaluate if the expression is constant.
-    fn eval_const(&self) -> Result<Datum> {
-        Err(ExprError::NotConstant)
-    }
+/// An owned dynamically typed expression.
+#[derive(Clone, Debug)]
+pub enum BoxedExpression {
+    Sync(Arc<dyn SyncExpression>),
+    Async(Arc<dyn AsyncExpression>),
+}
 
-    /// Get the index if the expression is an `InputRef`.
-    fn input_ref_index(&self) -> Option<usize> {
-        None
+/// Try to unwrap boxed expressions into sync expressions.
+///
+/// Returns the original boxed expression list if any expression is async.
+pub fn try_into_sync_exprs(
+    exprs: Vec<BoxedExpression>,
+) -> std::result::Result<Vec<Arc<dyn SyncExpression>>, Vec<BoxedExpression>> {
+    try_convert_all(
+        exprs,
+        |expr| match expr {
+            BoxedExpression::Sync(expr) => Ok(expr),
+            expr @ BoxedExpression::Async(_) => Err(expr),
+        },
+        BoxedExpression::Sync,
+    )
+}
+
+/// Try to convert all items in a vector, or return the original vector if any conversion fails.
+pub fn try_convert_all<T, U>(
+    items: Vec<T>,
+    mut try_convert: impl FnMut(T) -> std::result::Result<U, T>,
+    recover: impl Fn(U) -> T,
+) -> std::result::Result<Vec<U>, Vec<T>> {
+    let mut converted = Vec::with_capacity(items.len());
+    let mut items = items.into_iter();
+    loop {
+        let Some(item) = items.next() else {
+            return Ok(converted);
+        };
+        match try_convert(item) {
+            Ok(item) => converted.push(item),
+            Err(item) => {
+                let items = converted
+                    .into_iter()
+                    .map(recover)
+                    .chain(std::iter::once(item))
+                    .chain(items)
+                    .collect();
+                return Err(items);
+            }
+        }
     }
 }
 
-/// An owned dynamically typed [`Expression`].
-pub type BoxedExpression = Box<dyn Expression>;
+impl BoxedExpression {
+    /// Wrap a synchronous expression.
+    pub fn new_sync(expr: impl SyncExpression + 'static) -> Self {
+        Self::Sync(Arc::new(expr))
+    }
+
+    /// Wrap an asynchronous expression.
+    pub fn new_async(expr: impl AsyncExpression + 'static) -> Self {
+        Self::Async(Arc::new(expr))
+    }
+
+    /// Get the return data type.
+    pub fn return_type(&self) -> DataType {
+        match self {
+            Self::Sync(expr) => expr.return_type(),
+            Self::Async(expr) => expr.return_type(),
+        }
+    }
+
+    /// Get the index if the expression is an `InputRef`.
+    pub fn input_ref_index(&self) -> Option<usize> {
+        match self {
+            Self::Sync(expr) => expr.input_ref_index(),
+            Self::Async(expr) => expr.input_ref_index(),
+        }
+    }
+
+    /// Evaluate if the expression is constant.
+    pub fn eval_const(&self) -> Result<Datum> {
+        match self {
+            Self::Sync(expr) => expr.eval_const(),
+            Self::Async(_) => Err(ExprError::NotConstant),
+        }
+    }
+
+    /// Evaluate the expression in vectorized execution. Returns an array.
+    pub async fn eval(&self, input: &DataChunk) -> Result<ArrayRef> {
+        match self {
+            Self::Sync(expr) => expr.eval(input),
+            Self::Async(expr) => expr.eval(input).await,
+        }
+    }
+
+    /// Evaluate the expression in vectorized execution. Returns a value that can be either an
+    /// array, or a scalar if all values in the array are the same.
+    pub async fn eval_v2(&self, input: &DataChunk) -> Result<ValueImpl> {
+        match self {
+            Self::Sync(expr) => expr.eval_v2(input),
+            Self::Async(expr) => expr.eval_v2(input).await,
+        }
+    }
+
+    /// Evaluate the expression in row-based execution. Returns a nullable scalar.
+    pub async fn eval_row(&self, input: &OwnedRow) -> Result<Datum> {
+        match self {
+            Self::Sync(expr) => expr.eval_row(input),
+            Self::Async(expr) => expr.eval_row(input).await,
+        }
+    }
+}
+
+impl<E> From<E> for BoxedExpression
+where
+    E: SyncExpression + 'static,
+{
+    fn from(expr: E) -> Self {
+        Self::new_sync(expr)
+    }
+}
+
+impl ExpressionInfo for BoxedExpression {
+    fn return_type(&self) -> DataType {
+        self.return_type()
+    }
+
+    fn input_ref_index(&self) -> Option<usize> {
+        self.input_ref_index()
+    }
+}
+
+#[async_trait::async_trait]
+impl AsyncExpression for BoxedExpression {
+    async fn eval(&self, input: &DataChunk) -> Result<ArrayRef> {
+        self.eval(input).await
+    }
+
+    async fn eval_v2(&self, input: &DataChunk) -> Result<ValueImpl> {
+        self.eval_v2(input).await
+    }
+
+    async fn eval_row(&self, input: &OwnedRow) -> Result<Datum> {
+        self.eval_row(input).await
+    }
+}
 
 /// Extension trait for boxing expressions.
 ///
-/// This is not directly made into [`Expression`] trait because...
+/// This is not directly made into expression traits because...
 /// - an expression does not have to be `'static`,
 /// - and for the ease of `auto_impl`.
-#[easy_ext::ext(ExpressionBoxExt)]
-impl<E: Expression + 'static> E {
-    /// Wrap the expression in a Box.
+#[easy_ext::ext(SyncExpressionBoxExt)]
+impl<E: SyncExpression + 'static> E {
+    /// Wrap the expression in a [`BoxedExpression::Sync`].
     pub fn boxed(self) -> BoxedExpression {
-        Box::new(self)
+        BoxedExpression::new_sync(self)
+    }
+}
+
+/// Extension trait for boxing async expressions.
+#[easy_ext::ext(AsyncExpressionBoxExt)]
+impl<E: AsyncExpression + 'static> E {
+    /// Wrap the expression in a [`BoxedExpression::Async`].
+    pub fn boxed(self) -> BoxedExpression {
+        BoxedExpression::new_async(self)
     }
 }
 
@@ -131,22 +327,22 @@ impl<E: Expression + 'static> E {
 /// Compared to [`crate::expr::wrapper::non_strict::NonStrict`], this is more like an indicator
 /// applied on the root of an expression tree, while the latter is a wrapper that can be applied on
 /// each node of the tree and actually changes the behavior. As a result, [`NonStrictExpression`]
-/// does not implement [`Expression`] trait and instead deals directly with developers.
+/// does not implement expression traits and instead deals directly with developers.
 #[derive(Debug)]
-pub struct NonStrictExpression<E = BoxedExpression>(E);
+pub enum NonStrictExpression {
+    Sync(Arc<dyn SyncExpression>),
+    Async(Arc<dyn AsyncExpression>),
+}
 
-impl<E> NonStrictExpression<E>
-where
-    E: Expression,
-{
+impl NonStrictExpression {
     /// Create a non-strict expression directly wrapping the given expression.
     ///
     /// Should only be used in tests as evaluation may panic.
-    pub fn for_test(inner: E) -> NonStrictExpression
-    where
-        E: 'static,
-    {
-        NonStrictExpression(inner.boxed())
+    pub fn for_test(inner: impl Into<BoxedExpression>) -> NonStrictExpression {
+        match inner.into() {
+            BoxedExpression::Sync(inner) => Self::Sync(inner),
+            BoxedExpression::Async(inner) => Self::Async(inner),
+        }
     }
 
     /// Create a non-strict expression from the given expression, where only the evaluation of the
@@ -155,23 +351,38 @@ where
     ///
     /// This should be used as a TODO.
     pub fn new_topmost(
-        inner: E,
-        error_report: impl EvalErrorReport,
-    ) -> NonStrictExpression<impl Expression> {
-        let inner = wrapper::non_strict::NonStrict::new(inner, error_report);
-        NonStrictExpression(inner)
+        inner: impl Into<BoxedExpression>,
+        error_report: impl EvalErrorReport + 'static,
+    ) -> NonStrictExpression {
+        match inner.into() {
+            BoxedExpression::Sync(inner) => {
+                let inner = wrapper::non_strict::NonStrict::new(inner, error_report);
+                Self::Sync(Arc::new(inner))
+            }
+            BoxedExpression::Async(inner) => {
+                let inner = wrapper::non_strict::NonStrict::new(inner, error_report);
+                Self::Async(Arc::new(inner))
+            }
+        }
     }
 
     /// Get the return data type.
     pub fn return_type(&self) -> DataType {
-        self.0.return_type()
+        match self {
+            Self::Sync(expr) => expr.return_type(),
+            Self::Async(expr) => expr.return_type(),
+        }
     }
 
     /// Evaluate the expression in vectorized execution and assert it succeeds. Returns an array.
     ///
     /// Use with expressions built in non-strict mode.
     pub async fn eval_infallible(&self, input: &DataChunk) -> ArrayRef {
-        self.0.eval(input).await.expect("evaluation failed")
+        match self {
+            Self::Sync(expr) => expr.eval(input),
+            Self::Async(expr) => expr.eval(input).await,
+        }
+        .expect("evaluation failed")
     }
 
     /// Evaluate the expression in row-based execution and assert it succeeds. Returns a nullable
@@ -179,17 +390,27 @@ where
     ///
     /// Use with expressions built in non-strict mode.
     pub async fn eval_row_infallible(&self, input: &OwnedRow) -> Datum {
-        self.0.eval_row(input).await.expect("evaluation failed")
+        match self {
+            Self::Sync(expr) => expr.eval_row(input),
+            Self::Async(expr) => expr.eval_row(input).await,
+        }
+        .expect("evaluation failed")
     }
 
     /// Unwrap the inner expression.
-    pub fn into_inner(self) -> E {
-        self.0
+    pub fn into_inner(self) -> BoxedExpression {
+        match self {
+            Self::Sync(expr) => BoxedExpression::Sync(expr),
+            Self::Async(expr) => BoxedExpression::Async(expr),
+        }
     }
 
     /// Get a reference to the inner expression.
-    pub fn inner(&self) -> &E {
-        &self.0
+    pub fn inner(&self) -> &dyn ExpressionInfo {
+        match self {
+            Self::Sync(expr) => expr.as_ref(),
+            Self::Async(expr) => expr.as_ref(),
+        }
     }
 }
 

--- a/src/expr/core/src/expr/mod.rs
+++ b/src/expr/core/src/expr/mod.rs
@@ -53,6 +53,7 @@ mod build;
 pub mod test_utils;
 mod value;
 
+use std::future::Future;
 use std::sync::Arc;
 
 use risingwave_common::array::{ArrayRef, DataChunk};
@@ -118,41 +119,96 @@ pub trait SyncExpression: ExpressionInfo {
 }
 
 /// Interface of an asynchronous expression.
-#[async_trait::async_trait]
-#[auto_impl::auto_impl(&, Box, Arc)]
 pub trait AsyncExpression: ExpressionInfo {
     /// Evaluate the expression in vectorized execution. Returns an array.
     ///
     /// The default implementation calls `eval_v2` and always converts the result to an array.
-    async fn eval(&self, input: &DataChunk) -> Result<ArrayRef> {
-        let value = self.eval_v2(input).await?;
-        Ok(match value {
-            ValueImpl::Array(array) => array,
-            ValueImpl::Scalar { value, capacity } => {
-                let mut builder = self.return_type().create_array_builder(capacity);
-                builder.append_n(capacity, value);
-                builder.finish().into()
-            }
-        })
+    fn eval<'a>(
+        &'a self,
+        input: &'a DataChunk,
+    ) -> impl Future<Output = Result<ArrayRef>> + Send + 'a {
+        async move {
+            let value = self.eval_v2(input).await?;
+            Ok(match value {
+                ValueImpl::Array(array) => array,
+                ValueImpl::Scalar { value, capacity } => {
+                    let mut builder = self.return_type().create_array_builder(capacity);
+                    builder.append_n(capacity, value);
+                    builder.finish().into()
+                }
+            })
+        }
     }
 
     /// Evaluate the expression in vectorized execution. Returns a value that can be either an
     /// array, or a scalar if all values in the array are the same.
     ///
     /// The default implementation calls `eval` and puts the result into the `Array` variant.
-    async fn eval_v2(&self, input: &DataChunk) -> Result<ValueImpl> {
-        self.eval(input).await.map(ValueImpl::Array)
+    fn eval_v2<'a>(
+        &'a self,
+        input: &'a DataChunk,
+    ) -> impl Future<Output = Result<ValueImpl>> + Send + 'a {
+        async move { self.eval(input).await.map(ValueImpl::Array) }
     }
 
     /// Evaluate the expression in row-based execution. Returns a nullable scalar.
+    fn eval_row<'a>(
+        &'a self,
+        input: &'a OwnedRow,
+    ) -> impl Future<Output = Result<Datum>> + Send + 'a;
+}
+
+/// Object-safe adapter for asynchronous expressions.
+#[async_trait::async_trait]
+pub trait AsyncDynExpression: ExpressionInfo {
+    /// Evaluate the expression in vectorized execution. Returns an array.
+    async fn eval(&self, input: &DataChunk) -> Result<ArrayRef>;
+
+    /// Evaluate the expression in vectorized execution. Returns a value that can be either an
+    /// array, or a scalar if all values in the array are the same.
+    async fn eval_v2(&self, input: &DataChunk) -> Result<ValueImpl>;
+
+    /// Evaluate the expression in row-based execution. Returns a nullable scalar.
     async fn eval_row(&self, input: &OwnedRow) -> Result<Datum>;
+}
+
+#[async_trait::async_trait]
+impl<E> AsyncDynExpression for E
+where
+    E: AsyncExpression,
+{
+    async fn eval(&self, input: &DataChunk) -> Result<ArrayRef> {
+        AsyncExpression::eval(self, input).await
+    }
+
+    async fn eval_v2(&self, input: &DataChunk) -> Result<ValueImpl> {
+        AsyncExpression::eval_v2(self, input).await
+    }
+
+    async fn eval_row(&self, input: &OwnedRow) -> Result<Datum> {
+        AsyncExpression::eval_row(self, input).await
+    }
+}
+
+impl AsyncExpression for Arc<dyn AsyncDynExpression> {
+    async fn eval(&self, input: &DataChunk) -> Result<ArrayRef> {
+        AsyncDynExpression::eval(self.as_ref(), input).await
+    }
+
+    async fn eval_v2(&self, input: &DataChunk) -> Result<ValueImpl> {
+        AsyncDynExpression::eval_v2(self.as_ref(), input).await
+    }
+
+    async fn eval_row(&self, input: &OwnedRow) -> Result<Datum> {
+        AsyncDynExpression::eval_row(self.as_ref(), input).await
+    }
 }
 
 /// An owned dynamically typed expression.
 #[derive(Clone, Debug)]
 pub enum BoxedExpression {
     Sync(Arc<dyn SyncExpression>),
-    Async(Arc<dyn AsyncExpression>),
+    Async(Arc<dyn AsyncDynExpression>),
 }
 
 /// Try to unwrap boxed expressions into sync expressions.
@@ -227,7 +283,7 @@ impl BoxedExpression {
     pub async fn eval(&self, input: &DataChunk) -> Result<ArrayRef> {
         match self {
             Self::Sync(expr) => expr.eval(input),
-            Self::Async(expr) => expr.eval(input).await,
+            Self::Async(expr) => AsyncDynExpression::eval(expr.as_ref(), input).await,
         }
     }
 
@@ -236,7 +292,7 @@ impl BoxedExpression {
     pub async fn eval_v2(&self, input: &DataChunk) -> Result<ValueImpl> {
         match self {
             Self::Sync(expr) => expr.eval_v2(input),
-            Self::Async(expr) => expr.eval_v2(input).await,
+            Self::Async(expr) => AsyncDynExpression::eval_v2(expr.as_ref(), input).await,
         }
     }
 
@@ -244,7 +300,7 @@ impl BoxedExpression {
     pub async fn eval_row(&self, input: &OwnedRow) -> Result<Datum> {
         match self {
             Self::Sync(expr) => expr.eval_row(input),
-            Self::Async(expr) => expr.eval_row(input).await,
+            Self::Async(expr) => AsyncDynExpression::eval_row(expr.as_ref(), input).await,
         }
     }
 }
@@ -268,18 +324,26 @@ impl ExpressionInfo for BoxedExpression {
     }
 }
 
-#[async_trait::async_trait]
 impl AsyncExpression for BoxedExpression {
     async fn eval(&self, input: &DataChunk) -> Result<ArrayRef> {
-        self.eval(input).await
+        match self {
+            Self::Sync(expr) => expr.eval(input),
+            Self::Async(expr) => AsyncDynExpression::eval(expr.as_ref(), input).await,
+        }
     }
 
     async fn eval_v2(&self, input: &DataChunk) -> Result<ValueImpl> {
-        self.eval_v2(input).await
+        match self {
+            Self::Sync(expr) => expr.eval_v2(input),
+            Self::Async(expr) => AsyncDynExpression::eval_v2(expr.as_ref(), input).await,
+        }
     }
 
     async fn eval_row(&self, input: &OwnedRow) -> Result<Datum> {
-        self.eval_row(input).await
+        match self {
+            Self::Sync(expr) => expr.eval_row(input),
+            Self::Async(expr) => expr.as_ref().eval_row(input).await,
+        }
     }
 }
 
@@ -321,7 +385,7 @@ impl<E: AsyncExpression + 'static> E {
 #[derive(Debug)]
 pub enum NonStrictExpression {
     Sync(Arc<dyn SyncExpression>),
-    Async(Arc<dyn AsyncExpression>),
+    Async(Arc<dyn AsyncDynExpression>),
 }
 
 impl NonStrictExpression {
@@ -370,7 +434,7 @@ impl NonStrictExpression {
     pub async fn eval_infallible(&self, input: &DataChunk) -> ArrayRef {
         match self {
             Self::Sync(expr) => expr.eval(input),
-            Self::Async(expr) => expr.eval(input).await,
+            Self::Async(expr) => AsyncDynExpression::eval(expr.as_ref(), input).await,
         }
         .expect("evaluation failed")
     }
@@ -382,7 +446,7 @@ impl NonStrictExpression {
     pub async fn eval_row_infallible(&self, input: &OwnedRow) -> Datum {
         match self {
             Self::Sync(expr) => expr.eval_row(input),
-            Self::Async(expr) => expr.eval_row(input).await,
+            Self::Async(expr) => AsyncDynExpression::eval_row(expr.as_ref(), input).await,
         }
         .expect("evaluation failed")
     }

--- a/src/expr/core/src/expr/mod.rs
+++ b/src/expr/core/src/expr/mod.rs
@@ -199,16 +199,6 @@ pub fn try_convert_all<T, U>(
 }
 
 impl BoxedExpression {
-    /// Wrap a synchronous expression.
-    pub fn new_sync(expr: impl SyncExpression + 'static) -> Self {
-        Self::Sync(Arc::new(expr))
-    }
-
-    /// Wrap an asynchronous expression.
-    pub fn new_async(expr: impl AsyncExpression + 'static) -> Self {
-        Self::Async(Arc::new(expr))
-    }
-
     /// Get the return data type.
     pub fn return_type(&self) -> DataType {
         match self {
@@ -264,7 +254,7 @@ where
     E: SyncExpression + 'static,
 {
     fn from(expr: E) -> Self {
-        Self::new_sync(expr)
+        Self::Sync(Arc::new(expr))
     }
 }
 
@@ -302,7 +292,7 @@ impl AsyncExpression for BoxedExpression {
 impl<E: SyncExpression + 'static> E {
     /// Wrap the expression in a [`BoxedExpression::Sync`].
     pub fn boxed(self) -> BoxedExpression {
-        BoxedExpression::new_sync(self)
+        BoxedExpression::Sync(Arc::new(self))
     }
 }
 
@@ -311,7 +301,7 @@ impl<E: SyncExpression + 'static> E {
 impl<E: AsyncExpression + 'static> E {
     /// Wrap the expression in a [`BoxedExpression::Async`].
     pub fn boxed(self) -> BoxedExpression {
-        BoxedExpression::new_async(self)
+        BoxedExpression::Async(Arc::new(self))
     }
 }
 

--- a/src/expr/core/src/expr/wrapper/checked.rs
+++ b/src/expr/core/src/expr/wrapper/checked.rs
@@ -59,7 +59,6 @@ impl<E: SyncExpression> SyncExpression for Checked<E> {
     }
 }
 
-#[async_trait::async_trait]
 impl<E: AsyncExpression> AsyncExpression for Checked<E> {
     async fn eval(&self, input: &DataChunk) -> Result<ArrayRef> {
         checked_eval!(async, self, input, eval)

--- a/src/expr/core/src/expr/wrapper/checked.rs
+++ b/src/expr/core/src/expr/wrapper/checked.rs
@@ -12,46 +12,64 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use async_trait::async_trait;
 use risingwave_common::array::{ArrayRef, DataChunk};
 use risingwave_common::row::OwnedRow;
 use risingwave_common::types::{DataType, Datum};
 
 use crate::error::Result;
-use crate::expr::{Expression, ValueImpl};
+use crate::expr::{AsyncExpression, ExpressionInfo, SyncExpression, ValueImpl};
 
-/// A wrapper of [`Expression`] that does extra checks after evaluation.
+/// A wrapper of an expression that does extra checks after evaluation.
 #[derive(Debug)]
 pub(crate) struct Checked<E>(pub E);
 
-// TODO: avoid the overhead of extra boxing.
-#[async_trait]
-impl<E: Expression> Expression for Checked<E> {
+impl<E: ExpressionInfo> ExpressionInfo for Checked<E> {
     fn return_type(&self) -> DataType {
         self.0.return_type()
     }
 
-    async fn eval(&self, input: &DataChunk) -> Result<ArrayRef> {
-        let res = self.0.eval(input).await?;
-        assert_eq!(res.len(), input.capacity());
+    fn input_ref_index(&self) -> Option<usize> {
+        self.0.input_ref_index()
+    }
+}
+
+macro_rules! checked_eval {
+    ($mode:ident, $this:expr, $input:expr, $method:ident) => {{
+        let res = forward!($mode, $this.0, $method($input))?;
+        assert_eq!(res.len(), $input.capacity());
         Ok(res)
+    }};
+}
+
+impl<E: SyncExpression> SyncExpression for Checked<E> {
+    fn eval(&self, input: &DataChunk) -> Result<ArrayRef> {
+        checked_eval!(sync, self, input, eval)
     }
 
-    async fn eval_v2(&self, input: &DataChunk) -> Result<ValueImpl> {
-        let res = self.0.eval_v2(input).await?;
-        assert_eq!(res.len(), input.capacity());
-        Ok(res)
+    fn eval_v2(&self, input: &DataChunk) -> Result<ValueImpl> {
+        checked_eval!(sync, self, input, eval_v2)
     }
 
-    async fn eval_row(&self, input: &OwnedRow) -> Result<Datum> {
-        self.0.eval_row(input).await
+    fn eval_row(&self, input: &OwnedRow) -> Result<Datum> {
+        self.0.eval_row(input)
     }
 
     fn eval_const(&self) -> Result<Datum> {
         self.0.eval_const()
     }
+}
 
-    fn input_ref_index(&self) -> Option<usize> {
-        self.0.input_ref_index()
+#[async_trait::async_trait]
+impl<E: AsyncExpression> AsyncExpression for Checked<E> {
+    async fn eval(&self, input: &DataChunk) -> Result<ArrayRef> {
+        checked_eval!(async, self, input, eval)
+    }
+
+    async fn eval_v2(&self, input: &DataChunk) -> Result<ValueImpl> {
+        checked_eval!(async, self, input, eval_v2)
+    }
+
+    async fn eval_row(&self, input: &OwnedRow) -> Result<Datum> {
+        self.0.eval_row(input).await
     }
 }

--- a/src/expr/core/src/expr/wrapper/non_strict.rs
+++ b/src/expr/core/src/expr/wrapper/non_strict.rs
@@ -178,7 +178,6 @@ where
     }
 }
 
-#[async_trait::async_trait]
 impl<E, R> AsyncExpression for NonStrict<E, R>
 where
     E: AsyncExpression,

--- a/src/expr/core/src/expr/wrapper/non_strict.rs
+++ b/src/expr/core/src/expr/wrapper/non_strict.rs
@@ -14,7 +14,6 @@
 
 use std::sync::LazyLock;
 
-use async_trait::async_trait;
 use auto_impl::auto_impl;
 use risingwave_common::array::{ArrayRef, DataChunk};
 use risingwave_common::log::LogSuppressor;
@@ -24,7 +23,7 @@ use thiserror_ext::AsReport;
 
 use crate::ExprError;
 use crate::error::Result;
-use crate::expr::{Expression, ValueImpl};
+use crate::expr::{AsyncExpression, ExpressionInfo, SyncExpression, ValueImpl};
 
 /// Report an error during evaluation.
 #[auto_impl(&, Arc)]
@@ -59,7 +58,7 @@ impl EvalErrorReport for LogReport {
     }
 }
 
-/// A wrapper of [`Expression`] that evaluates in a non-strict way. Basically...
+/// A wrapper of an expression that evaluates in a non-strict way. Basically...
 /// - When an error occurs during chunk-level evaluation, pad with NULL for each failed row.
 /// - Report all error occurred during row-level evaluation to the [`EvalErrorReport`].
 pub(crate) struct NonStrict<E, R> {
@@ -81,7 +80,7 @@ where
 
 impl<E, R> NonStrict<E, R>
 where
-    E: Expression,
+    E: ExpressionInfo,
     R: EvalErrorReport,
 {
     pub fn new(inner: E, report: R) -> Self {
@@ -89,70 +88,112 @@ where
     }
 }
 
-// TODO: avoid the overhead of extra boxing.
-#[async_trait]
-impl<E, R> Expression for NonStrict<E, R>
+impl<E, R> ExpressionInfo for NonStrict<E, R>
 where
-    E: Expression,
+    E: ExpressionInfo,
     R: EvalErrorReport,
 {
     fn return_type(&self) -> DataType {
         self.inner.return_type()
     }
 
-    async fn eval(&self, input: &DataChunk) -> Result<ArrayRef> {
-        Ok(match self.inner.eval(input).await {
+    fn input_ref_index(&self) -> Option<usize> {
+        self.inner.input_ref_index()
+    }
+}
+
+macro_rules! non_strict_eval_array {
+    ($mode:ident, $this:expr, $input:expr) => {{
+        Ok(match forward!($mode, $this.inner, eval($input)) {
             Ok(array) => array,
             Err(ExprError::Multiple(array, errors)) => {
                 for error in errors {
-                    self.report.report(error);
+                    $this.report.report(error);
                 }
                 array
             }
             Err(e) => {
-                self.report.report(e);
-                let mut builder = self.return_type().create_array_builder(input.capacity());
-                builder.append_n_null(input.capacity());
+                $this.report.report(e);
+                let mut builder = $this.return_type().create_array_builder($input.capacity());
+                builder.append_n_null($input.capacity());
                 builder.finish().into()
             }
         })
-    }
+    }};
+}
 
-    async fn eval_v2(&self, input: &DataChunk) -> Result<ValueImpl> {
-        Ok(match self.inner.eval_v2(input).await {
+macro_rules! non_strict_eval_value {
+    ($mode:ident, $this:expr, $input:expr) => {{
+        Ok(match forward!($mode, $this.inner, eval_v2($input)) {
             Ok(array) => array,
             Err(ExprError::Multiple(array, errors)) => {
                 for error in errors {
-                    self.report.report(error);
+                    $this.report.report(error);
                 }
                 array.into()
             }
             Err(e) => {
-                self.report.report(e);
+                $this.report.report(e);
                 ValueImpl::Scalar {
                     value: None,
-                    capacity: input.capacity(),
+                    capacity: $input.capacity(),
                 }
             }
         })
-    }
+    }};
+}
 
-    /// Evaluate expression on a single row, report error and return NULL if failed.
-    async fn eval_row(&self, input: &OwnedRow) -> Result<Datum> {
-        Ok(match self.inner.eval_row(input).await {
+macro_rules! non_strict_eval_row {
+    ($mode:ident, $this:expr, $input:expr) => {{
+        Ok(match forward!($mode, $this.inner, eval_row($input)) {
             Ok(datum) => datum,
             Err(error) => {
-                self.report.report(error);
+                $this.report.report(error);
                 None // NULL
             }
         })
+    }};
+}
+
+impl<E, R> SyncExpression for NonStrict<E, R>
+where
+    E: SyncExpression,
+    R: EvalErrorReport,
+{
+    fn eval(&self, input: &DataChunk) -> Result<ArrayRef> {
+        non_strict_eval_array!(sync, self, input)
+    }
+
+    fn eval_v2(&self, input: &DataChunk) -> Result<ValueImpl> {
+        non_strict_eval_value!(sync, self, input)
+    }
+
+    /// Evaluate expression on a single row, report error and return NULL if failed.
+    fn eval_row(&self, input: &OwnedRow) -> Result<Datum> {
+        non_strict_eval_row!(sync, self, input)
     }
 
     fn eval_const(&self) -> Result<Datum> {
         self.inner.eval_const() // do not handle error
     }
+}
 
-    fn input_ref_index(&self) -> Option<usize> {
-        self.inner.input_ref_index()
+#[async_trait::async_trait]
+impl<E, R> AsyncExpression for NonStrict<E, R>
+where
+    E: AsyncExpression,
+    R: EvalErrorReport,
+{
+    async fn eval(&self, input: &DataChunk) -> Result<ArrayRef> {
+        non_strict_eval_array!(async, self, input)
+    }
+
+    async fn eval_v2(&self, input: &DataChunk) -> Result<ValueImpl> {
+        non_strict_eval_value!(async, self, input)
+    }
+
+    /// Evaluate expression on a single row, report error and return NULL if failed.
+    async fn eval_row(&self, input: &OwnedRow) -> Result<Datum> {
+        non_strict_eval_row!(async, self, input)
     }
 }

--- a/src/expr/core/src/expr/wrapper/strict.rs
+++ b/src/expr/core/src/expr/wrapper/strict.rs
@@ -12,16 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use async_trait::async_trait;
 use risingwave_common::array::{ArrayRef, DataChunk};
 use risingwave_common::row::OwnedRow;
 use risingwave_common::types::{DataType, Datum};
 
 use crate::ExprError;
 use crate::error::Result;
-use crate::expr::{Expression, ValueImpl};
+use crate::expr::{AsyncExpression, ExpressionInfo, SyncExpression, ValueImpl};
 
-/// A wrapper of [`Expression`] that only keeps the first error if multiple errors are returned.
+/// A wrapper of an expression that only keeps the first error if multiple errors are returned.
 pub(crate) struct Strict<E> {
     inner: E,
 }
@@ -39,45 +38,70 @@ where
 
 impl<E> Strict<E>
 where
-    E: Expression,
+    E: ExpressionInfo,
 {
     pub fn new(inner: E) -> Self {
         Self { inner }
     }
 }
 
-#[async_trait]
-impl<E> Expression for Strict<E>
+impl<E> ExpressionInfo for Strict<E>
 where
-    E: Expression,
+    E: ExpressionInfo,
 {
     fn return_type(&self) -> DataType {
         self.inner.return_type()
     }
 
-    async fn eval(&self, input: &DataChunk) -> Result<ArrayRef> {
-        match self.inner.eval(input).await {
+    fn input_ref_index(&self) -> Option<usize> {
+        self.inner.input_ref_index()
+    }
+}
+
+macro_rules! strict_eval {
+    ($mode:ident, $this:expr, $input:expr, $method:ident) => {
+        match forward!($mode, $this.inner, $method($input)) {
             Err(ExprError::Multiple(_, errors)) => Err(errors.into_first()),
             res => res,
         }
+    };
+}
+
+impl<E> SyncExpression for Strict<E>
+where
+    E: SyncExpression,
+{
+    fn eval(&self, input: &DataChunk) -> Result<ArrayRef> {
+        strict_eval!(sync, self, input, eval)
     }
 
-    async fn eval_v2(&self, input: &DataChunk) -> Result<ValueImpl> {
-        match self.inner.eval_v2(input).await {
-            Err(ExprError::Multiple(_, errors)) => Err(errors.into_first()),
-            res => res,
-        }
+    fn eval_v2(&self, input: &DataChunk) -> Result<ValueImpl> {
+        strict_eval!(sync, self, input, eval_v2)
     }
 
-    async fn eval_row(&self, input: &OwnedRow) -> Result<Datum> {
-        self.inner.eval_row(input).await
+    fn eval_row(&self, input: &OwnedRow) -> Result<Datum> {
+        self.inner.eval_row(input)
     }
 
     fn eval_const(&self) -> Result<Datum> {
         self.inner.eval_const()
     }
+}
 
-    fn input_ref_index(&self) -> Option<usize> {
-        self.inner.input_ref_index()
+#[async_trait::async_trait]
+impl<E> AsyncExpression for Strict<E>
+where
+    E: AsyncExpression,
+{
+    async fn eval(&self, input: &DataChunk) -> Result<ArrayRef> {
+        strict_eval!(async, self, input, eval)
+    }
+
+    async fn eval_v2(&self, input: &DataChunk) -> Result<ValueImpl> {
+        strict_eval!(async, self, input, eval_v2)
+    }
+
+    async fn eval_row(&self, input: &OwnedRow) -> Result<Datum> {
+        self.inner.eval_row(input).await
     }
 }

--- a/src/expr/core/src/expr/wrapper/strict.rs
+++ b/src/expr/core/src/expr/wrapper/strict.rs
@@ -88,7 +88,6 @@ where
     }
 }
 
-#[async_trait::async_trait]
 impl<E> AsyncExpression for Strict<E>
 where
     E: AsyncExpression,

--- a/src/expr/core/src/window_function/range.rs
+++ b/src/expr/core/src/window_function/range.rs
@@ -18,7 +18,6 @@ use std::sync::Arc;
 
 use anyhow::Context;
 use educe::Educe;
-use futures_util::FutureExt;
 use risingwave_common::bail;
 use risingwave_common::row::OwnedRow;
 use risingwave_common::types::{
@@ -34,8 +33,7 @@ use super::FrameBound::{
 use super::FrameBoundsImpl;
 use crate::Result;
 use crate::expr::{
-    BoxedExpression, Expression, ExpressionBoxExt, InputRefExpression, LiteralExpression,
-    build_func,
+    InputRefExpression, LiteralExpression, SyncExpression, SyncExpressionBoxExt, build_func,
 };
 
 #[derive(Debug, Clone, Eq, PartialEq, Hash)]
@@ -313,10 +311,10 @@ pub struct RangeFrameOffset {
     offset: ScalarImpl,
     /// Built expression for `$0 + offset`.
     #[educe(PartialEq(ignore), Hash(ignore))]
-    add_expr: Option<Arc<BoxedExpression>>,
+    add_expr: Option<Arc<dyn SyncExpression>>,
     /// Built expression for `$0 - offset`.
     #[educe(PartialEq(ignore), Hash(ignore))]
-    sub_expr: Option<Arc<BoxedExpression>>,
+    sub_expr: Option<Arc<dyn SyncExpression>>,
 }
 
 impl RangeFrameOffset {
@@ -334,16 +332,25 @@ impl RangeFrameOffset {
         let input_expr = InputRefExpression::new(order_data_type.clone(), 0);
         let offset_expr =
             LiteralExpression::new(offset_data_type.clone(), Some(self.offset.clone()));
-        self.add_expr = Some(Arc::new(build_func(
+        let add_expr = build_func(
             PbExprType::Add,
             order_data_type.clone(),
             vec![input_expr.clone().boxed(), offset_expr.clone().boxed()],
-        )?));
-        self.sub_expr = Some(Arc::new(build_func(
+        )?;
+        let crate::expr::BoxedExpression::Sync(add_expr) = add_expr else {
+            bail!("range frame offset add expression must be sync");
+        };
+        self.add_expr = Some(add_expr);
+
+        let sub_expr = build_func(
             PbExprType::Subtract,
             order_data_type.clone(),
             vec![input_expr.boxed(), offset_expr.boxed()],
-        )?));
+        )?;
+        let crate::expr::BoxedExpression::Sync(sub_expr) = sub_expr else {
+            bail!("range frame offset subtract expression must be sync");
+        };
+        self.sub_expr = Some(sub_expr);
         Ok(())
     }
 
@@ -370,9 +377,9 @@ impl Deref for RangeFrameOffset {
 #[educe(Clone, Copy)]
 struct RangeFrameOffsetRef<'a> {
     /// Built expression for `$0 + offset`.
-    add_expr: &'a dyn Expression,
+    add_expr: &'a dyn SyncExpression,
     /// Built expression for `$0 - offset`.
-    sub_expr: &'a dyn Expression,
+    sub_expr: &'a dyn SyncExpression,
 }
 
 impl FrameBound<RangeFrameOffsetRef<'_>> {
@@ -395,8 +402,6 @@ impl FrameBound<RangeFrameOffsetRef<'_>> {
         let row = OwnedRow::new(vec![order_value.to_owned_datum()]);
         Sentinelled::Normal(
             expr.eval_row(&row)
-                .now_or_never()
-                .expect("frame bound calculation should finish immediately")
                 .expect("just simple calculation, should succeed"), // TODO(rc): handle overflow
         )
     }

--- a/src/expr/core/src/window_function/session.rs
+++ b/src/expr/core/src/window_function/session.rs
@@ -18,7 +18,6 @@ use std::sync::Arc;
 
 use anyhow::Context;
 use educe::Educe;
-use futures::FutureExt;
 use risingwave_common::bail;
 use risingwave_common::row::OwnedRow;
 use risingwave_common::types::{
@@ -31,8 +30,7 @@ use risingwave_pb::expr::window_frame::PbSessionFrameBounds;
 use super::FrameBoundsImpl;
 use crate::Result;
 use crate::expr::{
-    BoxedExpression, Expression, ExpressionBoxExt, InputRefExpression, LiteralExpression,
-    build_func,
+    InputRefExpression, LiteralExpression, SyncExpression, SyncExpressionBoxExt, build_func,
 };
 
 /// To implement Session Window in a similar way to Range Frame, we define a similar frame bounds
@@ -141,7 +139,7 @@ pub struct SessionFrameGap {
     gap: ScalarImpl,
     /// Built expression for `$0 + gap`.
     #[educe(PartialEq(ignore), Hash(ignore))]
-    add_expr: Option<Arc<BoxedExpression>>,
+    add_expr: Option<Arc<dyn SyncExpression>>,
 }
 
 impl Deref for SessionFrameGap {
@@ -165,11 +163,15 @@ impl SessionFrameGap {
 
         let input_expr = InputRefExpression::new(order_data_type.clone(), 0);
         let gap_expr = LiteralExpression::new(gap_data_type.clone(), Some(self.gap.clone()));
-        self.add_expr = Some(Arc::new(build_func(
+        let add_expr = build_func(
             PbExprType::Add,
             order_data_type.clone(),
             vec![input_expr.boxed(), gap_expr.boxed()],
-        )?));
+        )?;
+        let crate::expr::BoxedExpression::Sync(add_expr) = add_expr else {
+            bail!("session frame gap add expression must be sync");
+        };
+        self.add_expr = Some(add_expr);
         Ok(())
     }
 
@@ -193,7 +195,7 @@ impl SessionFrameGap {
 #[derive(Debug, Educe)]
 #[educe(Clone, Copy)]
 struct SessionFrameGapRef<'a> {
-    add_expr: &'a dyn Expression,
+    add_expr: &'a dyn SyncExpression,
 }
 
 impl SessionFrameGapRef<'_> {
@@ -201,8 +203,6 @@ impl SessionFrameGapRef<'_> {
         let row = OwnedRow::new(vec![end_order_value.to_owned_datum()]);
         self.add_expr
             .eval_row(&row)
-            .now_or_never()
-            .expect("frame bound calculation should finish immediately")
             .expect("just simple calculation, should succeed") // TODO(rc): handle overflow
     }
 }

--- a/src/expr/impl/benches/expr.rs
+++ b/src/expr/impl/benches/expr.rs
@@ -280,9 +280,7 @@ fn bench_expr(c: &mut Criterion) {
     });
     c.bench_function("constant", |bencher| {
         let constant = LiteralExpression::new(DataType::Int32, Some(1_i32.into()));
-        bencher
-            .to_async(FuturesExecutor)
-            .iter(|| constant.eval(&input))
+        bencher.iter(|| constant.eval(&input))
     });
     c.bench_function("extract(constant)", |bencher| {
         let extract = build_from_pretty(format!(

--- a/src/expr/impl/src/scalar/ai_model.rs
+++ b/src/expr/impl/src/scalar/ai_model.rs
@@ -22,7 +22,9 @@ use risingwave_common::array::{
 };
 use risingwave_common::row::OwnedRow;
 use risingwave_common::types::{DataType, Datum, F32, ScalarImpl};
-use risingwave_expr::expr::{BoxedExpression, Expression};
+use risingwave_expr::expr::{
+    AsyncExpression, AsyncExpressionBoxExt, BoxedExpression, ExpressionInfo,
+};
 use risingwave_expr::{ExprError, Result, build_function};
 use serde::Deserialize;
 use serde_json::Value;
@@ -114,12 +116,14 @@ impl OpenAiEmbedding {
     }
 }
 
-#[async_trait::async_trait]
-impl Expression for OpenAiEmbedding {
+impl ExpressionInfo for OpenAiEmbedding {
     fn return_type(&self) -> DataType {
         DataType::Float32.list()
     }
+}
 
+#[async_trait::async_trait]
+impl AsyncExpression for OpenAiEmbedding {
     async fn eval(&self, input: &DataChunk) -> Result<ArrayRef> {
         let text_array = self.text_expr.eval(input).await?;
         let text_array = text_array.as_utf8();
@@ -232,8 +236,9 @@ fn build_openai_embedding_expr(
 
     let context = OpenAiEmbeddingContext::from_config(config)?;
 
-    Ok(Box::new(OpenAiEmbedding {
+    Ok(OpenAiEmbedding {
         text_expr: children.pop().unwrap(), // Take the second expression
         context,
-    }))
+    }
+    .boxed())
 }

--- a/src/expr/impl/src/scalar/ai_model.rs
+++ b/src/expr/impl/src/scalar/ai_model.rs
@@ -122,7 +122,6 @@ impl ExpressionInfo for OpenAiEmbedding {
     }
 }
 
-#[async_trait::async_trait]
 impl AsyncExpression for OpenAiEmbedding {
     async fn eval(&self, input: &DataChunk) -> Result<ArrayRef> {
         let text_array = self.text_expr.eval(input).await?;

--- a/src/expr/impl/src/scalar/array_transform.rs
+++ b/src/expr/impl/src/scalar/array_transform.rs
@@ -14,25 +14,56 @@
 
 use std::sync::Arc;
 
-use async_trait::async_trait;
 use risingwave_common::array::{ArrayRef, DataChunk};
 use risingwave_common::row::OwnedRow;
 use risingwave_common::types::{DataType, Datum, ListValue, ScalarImpl};
-use risingwave_expr::expr::{BoxedExpression, Expression};
+use risingwave_expr::expr::{
+    AsyncExpression, AsyncExpressionBoxExt, BoxedExpression, ExpressionInfo, SyncExpression,
+    SyncExpressionBoxExt,
+};
 use risingwave_expr::{Result, build_function};
 
 #[derive(Debug)]
-struct ArrayTransformExpression {
-    array: BoxedExpression,
-    lambda: BoxedExpression,
+struct ArrayTransformExpression<E> {
+    array: E,
+    lambda: E,
 }
 
-#[async_trait]
-impl Expression for ArrayTransformExpression {
+impl<E: ExpressionInfo> ExpressionInfo for ArrayTransformExpression<E> {
     fn return_type(&self) -> DataType {
         DataType::list(self.lambda.return_type())
     }
+}
 
+impl<E: SyncExpression> SyncExpression for ArrayTransformExpression<E> {
+    fn eval(&self, input: &DataChunk) -> Result<ArrayRef> {
+        let lambda_input = self.array.eval(input)?;
+        let lambda_input = Arc::unwrap_or_clone(lambda_input).into_list();
+        let new_list = lambda_input.map_inner_sync(|flatten_input| {
+            let flatten_len = flatten_input.len();
+            let chunk = DataChunk::new(vec![Arc::new(flatten_input)], flatten_len);
+            self.lambda.eval(&chunk).map(Arc::unwrap_or_clone)
+        })?;
+        Ok(Arc::new(new_list.into()))
+    }
+
+    fn eval_row(&self, input: &OwnedRow) -> Result<Datum> {
+        let lambda_input = self.array.eval_row(input)?;
+        let lambda_input = lambda_input.map(ScalarImpl::into_list);
+        if let Some(lambda_input) = lambda_input {
+            let len = lambda_input.len();
+            let chunk = DataChunk::new(vec![Arc::new(lambda_input.into_array())], len);
+            let new_vals = self.lambda.eval(&chunk)?;
+            let new_list = ListValue::new(Arc::unwrap_or_clone(new_vals));
+            Ok(Some(new_list.into()))
+        } else {
+            Ok(None)
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl<E: AsyncExpression> AsyncExpression for ArrayTransformExpression<E> {
     async fn eval(&self, input: &DataChunk) -> Result<ArrayRef> {
         let lambda_input = self.array.eval(input).await?;
         let lambda_input = Arc::unwrap_or_clone(lambda_input).into_list();
@@ -64,7 +95,12 @@ impl Expression for ArrayTransformExpression {
 #[build_function("array_transform(anyarray, any) -> anyarray")]
 fn build(_: DataType, children: Vec<BoxedExpression>) -> Result<BoxedExpression> {
     let [array, lambda] = <[BoxedExpression; 2]>::try_from(children).unwrap();
-    Ok(Box::new(ArrayTransformExpression { array, lambda }))
+    Ok(match (array, lambda) {
+        (BoxedExpression::Sync(array), BoxedExpression::Sync(lambda)) => {
+            ArrayTransformExpression { array, lambda }.boxed()
+        }
+        (array, lambda) => ArrayTransformExpression { array, lambda }.boxed(),
+    })
 }
 
 #[cfg(test)]

--- a/src/expr/impl/src/scalar/array_transform.rs
+++ b/src/expr/impl/src/scalar/array_transform.rs
@@ -62,7 +62,6 @@ impl<E: SyncExpression> SyncExpression for ArrayTransformExpression<E> {
     }
 }
 
-#[async_trait::async_trait]
 impl<E: AsyncExpression> AsyncExpression for ArrayTransformExpression<E> {
     async fn eval(&self, input: &DataChunk) -> Result<ArrayRef> {
         let lambda_input = self.array.eval(input).await?;

--- a/src/expr/impl/src/scalar/case.rs
+++ b/src/expr/impl/src/scalar/case.rs
@@ -128,7 +128,6 @@ impl<E: SyncExpression> SyncExpression for CaseExpression<E> {
     }
 }
 
-#[async_trait::async_trait]
 impl<E: AsyncExpression> AsyncExpression for CaseExpression<E> {
     async fn eval(&self, input: &DataChunk) -> Result<ArrayRef> {
         eval_case!(async, self, input)
@@ -249,7 +248,6 @@ impl<E: SyncExpression> SyncExpression for ConstantLookupExpression<E> {
     }
 }
 
-#[async_trait::async_trait]
 impl<E: AsyncExpression> AsyncExpression for ConstantLookupExpression<E> {
     async fn eval(&self, input: &DataChunk) -> Result<ArrayRef> {
         eval_constant_lookup!(async, self, input)

--- a/src/expr/impl/src/scalar/case.rs
+++ b/src/expr/impl/src/scalar/case.rs
@@ -19,27 +19,30 @@ use risingwave_common::array::{ArrayRef, DataChunk};
 use risingwave_common::bail;
 use risingwave_common::row::{OwnedRow, Row};
 use risingwave_common::types::{DataType, Datum, ScalarImpl};
-use risingwave_expr::expr::{BoxedExpression, Expression};
+use risingwave_expr::expr::{
+    AsyncExpression, AsyncExpressionBoxExt, BoxedExpression, ExpressionInfo, SyncExpression,
+    SyncExpressionBoxExt, try_convert_all,
+};
 use risingwave_expr::{Result, build_function};
 
 #[derive(Debug)]
-struct WhenClause {
-    when: BoxedExpression,
-    then: BoxedExpression,
+struct WhenClause<E> {
+    when: E,
+    then: E,
 }
 
 #[derive(Debug)]
-struct CaseExpression {
+struct CaseExpression<E> {
     return_type: DataType,
-    when_clauses: Vec<WhenClause>,
-    else_clause: Option<BoxedExpression>,
+    when_clauses: Vec<WhenClause<E>>,
+    else_clause: Option<E>,
 }
 
-impl CaseExpression {
+impl<E> CaseExpression<E> {
     fn new(
         return_type: DataType,
-        when_clauses: Vec<WhenClause>,
-        else_clause: Option<BoxedExpression>,
+        when_clauses: Vec<WhenClause<E>>,
+        else_clause: Option<E>,
     ) -> Self {
         Self {
             return_type,
@@ -49,40 +52,44 @@ impl CaseExpression {
     }
 }
 
-#[async_trait::async_trait]
-impl Expression for CaseExpression {
+impl<E: ExpressionInfo> ExpressionInfo for CaseExpression<E> {
     fn return_type(&self) -> DataType {
         self.return_type.clone()
     }
+}
 
-    async fn eval(&self, input: &DataChunk) -> Result<ArrayRef> {
-        let mut input = input.clone();
+macro_rules! eval_case {
+    ($mode:ident, $this:expr, $input:expr) => {{
+        let mut input = $input.clone();
         let input_len = input.capacity();
         let mut selection = vec![None; input_len];
-        let when_len = self.when_clauses.len();
+        let when_len = $this.when_clauses.len();
         let mut result_array = Vec::with_capacity(when_len + 1);
-        for (when_idx, WhenClause { when, then }) in self.when_clauses.iter().enumerate() {
+        for (when_idx, WhenClause { when, then }) in $this.when_clauses.iter().enumerate() {
             let input_vis = input.visibility().clone();
             // note that evaluated result from when clause may contain bits that are not visible,
             // so we need to mask it with input visibility.
-            let calc_then_vis = when.eval(&input).await?.as_bool().to_bitmap() & &input_vis;
+            let calc_then_vis = risingwave_expr::forward!($mode, when, eval(&input))?
+                .as_bool()
+                .to_bitmap()
+                & &input_vis;
             input.set_visibility(calc_then_vis.clone());
-            let then_res = then.eval(&input).await?;
+            let then_res = risingwave_expr::forward!($mode, then, eval(&input))?;
             calc_then_vis
                 .iter_ones()
                 .for_each(|pos| selection[pos] = Some(when_idx));
             input.set_visibility(&input_vis & (!calc_then_vis));
             result_array.push(then_res);
         }
-        if let Some(ref else_expr) = self.else_clause {
-            let else_res = else_expr.eval(&input).await?;
+        if let Some(ref else_expr) = $this.else_clause {
+            let else_res = risingwave_expr::forward!($mode, else_expr, eval(&input))?;
             input
                 .visibility()
                 .iter_ones()
                 .for_each(|pos| selection[pos] = Some(when_len));
             result_array.push(else_res);
         }
-        let mut builder = self.return_type().create_array_builder(input.capacity());
+        let mut builder = $this.return_type().create_array_builder(input.capacity());
         for (i, sel) in selection.into_iter().enumerate() {
             if let Some(when_idx) = sel {
                 builder.append(result_array[when_idx].value_at(i));
@@ -91,19 +98,44 @@ impl Expression for CaseExpression {
             }
         }
         Ok(Arc::new(builder.finish()))
-    }
+    }};
+}
 
-    async fn eval_row(&self, input: &OwnedRow) -> Result<Datum> {
-        for WhenClause { when, then } in &self.when_clauses {
-            if when.eval_row(input).await?.is_some_and(|w| w.into_bool()) {
-                return then.eval_row(input).await;
+macro_rules! eval_row_case {
+    ($mode:ident, $this:expr, $input:expr) => {{
+        for WhenClause { when, then } in &$this.when_clauses {
+            if risingwave_expr::forward!($mode, when, eval_row($input))?
+                .is_some_and(|w| w.into_bool())
+            {
+                return risingwave_expr::forward!($mode, then, eval_row($input));
             }
         }
-        if let Some(ref else_expr) = self.else_clause {
-            else_expr.eval_row(input).await
+        if let Some(ref else_expr) = $this.else_clause {
+            risingwave_expr::forward!($mode, else_expr, eval_row($input))
         } else {
             Ok(None)
         }
+    }};
+}
+
+impl<E: SyncExpression> SyncExpression for CaseExpression<E> {
+    fn eval(&self, input: &DataChunk) -> Result<ArrayRef> {
+        eval_case!(sync, self, input)
+    }
+
+    fn eval_row(&self, input: &OwnedRow) -> Result<Datum> {
+        eval_row_case!(sync, self, input)
+    }
+}
+
+#[async_trait::async_trait]
+impl<E: AsyncExpression> AsyncExpression for CaseExpression<E> {
+    async fn eval(&self, input: &DataChunk) -> Result<ArrayRef> {
+        eval_case!(async, self, input)
+    }
+
+    async fn eval_row(&self, input: &OwnedRow) -> Result<Datum> {
+        eval_row_case!(async, self, input)
     }
 }
 
@@ -111,20 +143,20 @@ impl Expression for CaseExpression {
 /// we could optimize the `CaseExpression` to `ConstantLookupExpression`,
 /// which could significantly facilitate the evaluation of case-when.
 #[derive(Debug)]
-struct ConstantLookupExpression {
+struct ConstantLookupExpression<E> {
     return_type: DataType,
-    arms: HashMap<ScalarImpl, BoxedExpression>,
-    fallback: Option<BoxedExpression>,
+    arms: HashMap<ScalarImpl, E>,
+    fallback: Option<E>,
     /// `operand` must exist at present
-    operand: BoxedExpression,
+    operand: E,
 }
 
-impl ConstantLookupExpression {
+impl<E> ConstantLookupExpression<E> {
     fn new(
         return_type: DataType,
-        arms: HashMap<ScalarImpl, BoxedExpression>,
-        fallback: Option<BoxedExpression>,
-        operand: BoxedExpression,
+        arms: HashMap<ScalarImpl, E>,
+        fallback: Option<E>,
+        operand: E,
     ) -> Self {
         Self {
             return_type,
@@ -133,53 +165,56 @@ impl ConstantLookupExpression {
             operand,
         }
     }
-
-    /// Evaluate the fallback arm with the given input
-    async fn eval_fallback(&self, input: &OwnedRow) -> Result<Datum> {
-        let Some(ref fallback) = self.fallback else {
-            return Ok(None);
-        };
-        let Ok(res) = fallback.eval_row(input).await else {
-            bail!("failed to evaluate the input for fallback arm");
-        };
-        Ok(res)
-    }
-
-    /// The actual lookup & evaluation logic
-    /// used in both `eval_row` & `eval`
-    async fn lookup(&self, datum: Datum, input: &OwnedRow) -> Result<Datum> {
-        if datum.is_none() {
-            return self.eval_fallback(input).await;
-        }
-
-        if let Some(expr) = self.arms.get(datum.as_ref().unwrap()) {
-            let Ok(res) = expr.eval_row(input).await else {
-                bail!("failed to evaluate the input for normal arm");
-            };
-            Ok(res)
-        } else {
-            // Fallback arm goes here
-            self.eval_fallback(input).await
-        }
-    }
 }
 
-#[async_trait::async_trait]
-impl Expression for ConstantLookupExpression {
+impl<E: ExpressionInfo> ExpressionInfo for ConstantLookupExpression<E> {
     fn return_type(&self) -> DataType {
         self.return_type.clone()
     }
+}
 
-    async fn eval(&self, input: &DataChunk) -> Result<ArrayRef> {
-        let input_len = input.capacity();
-        let mut builder = self.return_type().create_array_builder(input_len);
+macro_rules! eval_fallback_lookup {
+    ($mode:ident, $this:expr, $input:expr) => {{
+        if let Some(ref fallback) = $this.fallback {
+            let Ok(res) = risingwave_expr::forward!($mode, fallback, eval_row($input)) else {
+                bail!("failed to evaluate the input for fallback arm");
+            };
+            Ok::<Datum, risingwave_expr::ExprError>(res)
+        } else {
+            Ok::<Datum, risingwave_expr::ExprError>(None)
+        }
+    }};
+}
+
+macro_rules! lookup {
+    ($mode:ident, $this:expr, $datum:expr, $input:expr) => {{
+        match $datum.as_ref() {
+            Some(datum) => {
+                if let Some(expr) = $this.arms.get(datum) {
+                    let Ok(res) = risingwave_expr::forward!($mode, expr, eval_row($input)) else {
+                        bail!("failed to evaluate the input for normal arm");
+                    };
+                    Ok(res)
+                } else {
+                    eval_fallback_lookup!($mode, $this, $input)
+                }
+            }
+            None => eval_fallback_lookup!($mode, $this, $input),
+        }
+    }};
+}
+
+macro_rules! eval_constant_lookup {
+    ($mode:ident, $this:expr, $input:expr) => {{
+        let input_len = $input.capacity();
+        let mut builder = $this.return_type().create_array_builder(input_len);
 
         // Evaluate the input DataChunk at first
-        let eval_result = self.operand.eval(input).await?;
+        let eval_result = risingwave_expr::forward!($mode, $this.operand, eval($input))?;
 
         for i in 0..input_len {
             let datum = eval_result.datum_at(i);
-            let (row, vis) = input.row_at(i);
+            let (row, vis) = $input.row_at(i);
 
             // Check for visibility
             if !vis {
@@ -192,7 +227,7 @@ impl Expression for ConstantLookupExpression {
             let owned_row = row.into_owned_row();
 
             // Lookup and evaluate the current input datum
-            if let Ok(datum) = self.lookup(datum, &owned_row).await {
+            if let Ok(datum) = lookup!($mode, $this, datum, &owned_row) {
                 builder.append(datum.as_ref());
             } else {
                 bail!("failed to lookup and evaluate the expression in `eval`");
@@ -200,11 +235,29 @@ impl Expression for ConstantLookupExpression {
         }
 
         Ok(Arc::new(builder.finish()))
+    }};
+}
+
+impl<E: SyncExpression> SyncExpression for ConstantLookupExpression<E> {
+    fn eval(&self, input: &DataChunk) -> Result<ArrayRef> {
+        eval_constant_lookup!(sync, self, input)
+    }
+
+    fn eval_row(&self, input: &OwnedRow) -> Result<Datum> {
+        let datum = self.operand.eval_row(input)?;
+        lookup!(sync, self, datum, input)
+    }
+}
+
+#[async_trait::async_trait]
+impl<E: AsyncExpression> AsyncExpression for ConstantLookupExpression<E> {
+    async fn eval(&self, input: &DataChunk) -> Result<ArrayRef> {
+        eval_constant_lookup!(async, self, input)
     }
 
     async fn eval_row(&self, input: &OwnedRow) -> Result<Datum> {
         let datum = self.operand.eval_row(input).await?;
-        self.lookup(datum, input).await
+        lookup!(async, self, datum, input)
     }
 }
 
@@ -241,12 +294,47 @@ fn build_constant_lookup_expr(
         None
     };
 
-    Ok(Box::new(ConstantLookupExpression::new(
-        return_type,
+    let BoxedExpression::Sync(operand) = operand else {
+        return Ok(ConstantLookupExpression::new(return_type, arms, fallback, operand).boxed());
+    };
+    let arms: Vec<_> = arms.into_iter().collect();
+    let sync_arms: HashMap<ScalarImpl, Arc<dyn SyncExpression>> = match try_convert_all(
         arms,
-        fallback,
-        operand,
-    )))
+        |(key, expr)| match expr {
+            BoxedExpression::Sync(expr) => Ok((key, expr)),
+            expr @ BoxedExpression::Async(_) => Err((key, expr)),
+        },
+        |(key, expr)| (key, BoxedExpression::Sync(expr)),
+    ) {
+        Ok(arms) => arms.into_iter().collect(),
+        Err(arms) => {
+            return Ok(ConstantLookupExpression::new(
+                return_type,
+                arms.into_iter().collect(),
+                fallback,
+                BoxedExpression::Sync(operand),
+            )
+            .boxed());
+        }
+    };
+    let fallback = match fallback {
+        Some(BoxedExpression::Sync(expr)) => Some(expr),
+        Some(expr @ BoxedExpression::Async(_)) => {
+            let arms = sync_arms
+                .into_iter()
+                .map(|(key, expr)| (key, BoxedExpression::Sync(expr)))
+                .collect();
+            return Ok(ConstantLookupExpression::new(
+                return_type,
+                arms,
+                Some(expr),
+                BoxedExpression::Sync(operand),
+            )
+            .boxed());
+        }
+        None => None,
+    };
+    Ok(ConstantLookupExpression::new(return_type, sync_arms, fallback, operand).boxed())
 }
 
 #[build_function("case(...) -> any", type_infer = "unreachable")]
@@ -276,11 +364,39 @@ fn build_case_expr(
         None
     };
 
-    Ok(Box::new(CaseExpression::new(
-        return_type,
+    let sync_when_clauses = match try_convert_all(
         when_clauses,
-        else_clause,
-    )))
+        |WhenClause { when, then }| match (when, then) {
+            (BoxedExpression::Sync(when), BoxedExpression::Sync(then)) => {
+                Ok(WhenClause { when, then })
+            }
+            (when, then) => Err(WhenClause { when, then }),
+        },
+        |WhenClause { when, then }| WhenClause {
+            when: BoxedExpression::Sync(when),
+            then: BoxedExpression::Sync(then),
+        },
+    ) {
+        Ok(when_clauses) => when_clauses,
+        Err(when_clauses) => {
+            return Ok(CaseExpression::new(return_type, when_clauses, else_clause).boxed());
+        }
+    };
+    let else_clause = match else_clause {
+        Some(BoxedExpression::Sync(expr)) => Some(expr),
+        Some(expr @ BoxedExpression::Async(_)) => {
+            let when_clauses = sync_when_clauses
+                .into_iter()
+                .map(|WhenClause { when, then }| WhenClause {
+                    when: BoxedExpression::Sync(when),
+                    then: BoxedExpression::Sync(then),
+                })
+                .collect();
+            return Ok(CaseExpression::new(return_type, when_clauses, Some(expr)).boxed());
+        }
+        None => None,
+    };
+    Ok(CaseExpression::new(return_type, sync_when_clauses, else_clause).boxed())
 }
 
 #[cfg(test)]

--- a/src/expr/impl/src/scalar/cast.rs
+++ b/src/expr/impl/src/scalar/cast.rs
@@ -25,7 +25,7 @@ use risingwave_common::types::{
 };
 use risingwave_common::util::iter_util::ZipEqFast;
 use risingwave_common::util::row_id::row_id_to_unix_millis;
-use risingwave_expr::expr::{Context, ExpressionBoxExt, InputRefExpression, build_func};
+use risingwave_expr::expr::{Context, InputRefExpression, SyncExpressionBoxExt, build_func};
 use risingwave_expr::{ExprError, Result, function};
 use risingwave_pb::expr::expr_node::PbType;
 use thiserror_ext::AsReport;

--- a/src/expr/impl/src/scalar/coalesce.rs
+++ b/src/expr/impl/src/scalar/coalesce.rs
@@ -90,7 +90,6 @@ impl<E: SyncExpression> SyncExpression for CoalesceExpression<E> {
     }
 }
 
-#[async_trait::async_trait]
 impl<E: AsyncExpression> AsyncExpression for CoalesceExpression<E> {
     async fn eval(&self, input: &DataChunk) -> Result<ArrayRef> {
         eval_coalesce!(async, self, input)

--- a/src/expr/impl/src/scalar/coalesce.rs
+++ b/src/expr/impl/src/scalar/coalesce.rs
@@ -18,29 +18,33 @@ use std::sync::Arc;
 use risingwave_common::array::{ArrayRef, DataChunk};
 use risingwave_common::row::OwnedRow;
 use risingwave_common::types::{DataType, Datum};
-use risingwave_expr::expr::{BoxedExpression, Expression};
+use risingwave_expr::expr::{
+    AsyncExpression, AsyncExpressionBoxExt, BoxedExpression, ExpressionInfo, SyncExpression,
+    SyncExpressionBoxExt, try_into_sync_exprs,
+};
 use risingwave_expr::{Result, build_function};
 
 #[derive(Debug)]
-pub struct CoalesceExpression {
+pub struct CoalesceExpression<E> {
     return_type: DataType,
-    children: Vec<BoxedExpression>,
+    children: Vec<E>,
 }
 
-#[async_trait::async_trait]
-impl Expression for CoalesceExpression {
+impl<E: ExpressionInfo> ExpressionInfo for CoalesceExpression<E> {
     fn return_type(&self) -> DataType {
         self.return_type.clone()
     }
+}
 
-    async fn eval(&self, input: &DataChunk) -> Result<ArrayRef> {
-        let init_vis = input.visibility();
-        let mut input = input.clone();
+macro_rules! eval_coalesce {
+    ($mode:ident, $this:expr, $input:expr) => {{
+        let init_vis = $input.visibility();
+        let mut input = $input.clone();
         let len = input.capacity();
         let mut selection: Vec<Option<usize>> = vec![None; len];
-        let mut children_array = Vec::with_capacity(self.children.len());
-        for (child_idx, child) in self.children.iter().enumerate() {
-            let res = child.eval(&input).await?;
+        let mut children_array = Vec::with_capacity($this.children.len());
+        for (child_idx, child) in $this.children.iter().enumerate() {
+            let res = risingwave_expr::forward!($mode, child, eval(&input))?;
             let res_bitmap = res.null_bitmap();
             let orig_vis = input.visibility();
             for pos in orig_vis.bitand(res_bitmap).iter_ones() {
@@ -50,7 +54,7 @@ impl Expression for CoalesceExpression {
             input.set_visibility(new_vis);
             children_array.push(res);
         }
-        let mut builder = self.return_type.create_array_builder(len);
+        let mut builder = $this.return_type.create_array_builder(len);
         for (i, sel) in selection.iter().enumerate() {
             if init_vis.is_set(i)
                 && let Some(child_idx) = sel
@@ -61,25 +65,56 @@ impl Expression for CoalesceExpression {
             }
         }
         Ok(Arc::new(builder.finish()))
-    }
+    }};
+}
 
-    async fn eval_row(&self, input: &OwnedRow) -> Result<Datum> {
-        for child in &self.children {
-            let datum = child.eval_row(input).await?;
+macro_rules! eval_row_coalesce {
+    ($mode:ident, $this:expr, $input:expr) => {{
+        for child in &$this.children {
+            let datum = risingwave_expr::forward!($mode, child, eval_row($input))?;
             if datum.is_some() {
                 return Ok(datum);
             }
         }
         Ok(None)
+    }};
+}
+
+impl<E: SyncExpression> SyncExpression for CoalesceExpression<E> {
+    fn eval(&self, input: &DataChunk) -> Result<ArrayRef> {
+        eval_coalesce!(sync, self, input)
+    }
+
+    fn eval_row(&self, input: &OwnedRow) -> Result<Datum> {
+        eval_row_coalesce!(sync, self, input)
+    }
+}
+
+#[async_trait::async_trait]
+impl<E: AsyncExpression> AsyncExpression for CoalesceExpression<E> {
+    async fn eval(&self, input: &DataChunk) -> Result<ArrayRef> {
+        eval_coalesce!(async, self, input)
+    }
+
+    async fn eval_row(&self, input: &OwnedRow) -> Result<Datum> {
+        eval_row_coalesce!(async, self, input)
     }
 }
 
 #[build_function("coalesce(...) -> any", type_infer = "unreachable")]
 fn build(return_type: DataType, children: Vec<BoxedExpression>) -> Result<BoxedExpression> {
-    Ok(Box::new(CoalesceExpression {
-        return_type,
-        children,
-    }))
+    match try_into_sync_exprs(children) {
+        Ok(children) => Ok(CoalesceExpression {
+            return_type,
+            children,
+        }
+        .boxed()),
+        Err(children) => Ok(CoalesceExpression {
+            return_type,
+            children,
+        }
+        .boxed()),
+    }
 }
 
 #[cfg(test)]

--- a/src/expr/impl/src/scalar/external/iceberg.rs
+++ b/src/expr/impl/src/scalar/external/iceberg.rs
@@ -26,12 +26,14 @@ use risingwave_common::array::{ArrayRef, DataChunk};
 use risingwave_common::ensure;
 use risingwave_common::row::OwnedRow;
 use risingwave_common::types::{DataType, Datum};
-use risingwave_expr::expr::BoxedExpression;
+use risingwave_expr::expr::{
+    BoxedExpression, ExpressionInfo, SyncExpression, SyncExpressionBoxExt,
+};
 use risingwave_expr::{ExprError, Result, build_function};
 use thiserror_ext::AsReport;
 
 pub struct IcebergTransform {
-    child: BoxedExpression,
+    child: Arc<dyn SyncExpression>,
     transform: BoxedTransformFunction,
     input_arrow_type: arrow_schema_iceberg::DataType,
     output_arrow_field: arrow_schema_iceberg::Field,
@@ -47,15 +49,15 @@ impl std::fmt::Debug for IcebergTransform {
     }
 }
 
-#[async_trait::async_trait]
-impl risingwave_expr::expr::Expression for IcebergTransform {
+impl ExpressionInfo for IcebergTransform {
     fn return_type(&self) -> DataType {
         self.return_type.clone()
     }
+}
 
-    async fn eval(&self, data_chunk: &DataChunk) -> Result<ArrayRef> {
-        // Get the child array
-        let array = self.child.eval(data_chunk).await?;
+impl SyncExpression for IcebergTransform {
+    fn eval(&self, data_chunk: &DataChunk) -> Result<ArrayRef> {
+        let array = self.child.eval(data_chunk)?;
         // Convert to arrow array
         let arrow_array = IcebergArrowConvert.to_arrow_array(&self.input_arrow_type, &array)?;
         // Transform
@@ -67,7 +69,7 @@ impl risingwave_expr::expr::Expression for IcebergTransform {
         )?))
     }
 
-    async fn eval_row(&self, _row: &OwnedRow) -> Result<Datum> {
+    fn eval_row(&self, _row: &OwnedRow) -> Result<Datum> {
         Err(ExprError::Internal(anyhow!(
             "eval_row in iceberg_transform is not supported yet"
         )))
@@ -153,14 +155,24 @@ fn build(return_type: DataType, mut children: Vec<BoxedExpression>) -> Result<Bo
         }
     );
 
-    Ok(Box::new(IcebergTransform {
-        child: children.remove(1),
-        transform: create_transform_function(&transform_type)
-            .map_err(|err| ExprError::Internal(err.into()))?,
+    let child = match children.remove(1) {
+        BoxedExpression::Sync(child) => child,
+        BoxedExpression::Async(_) => {
+            return Err(ExprError::Internal(anyhow!(
+                "async child in iceberg_transform is not supported"
+            )));
+        }
+    };
+    let transform = create_transform_function(&transform_type)
+        .map_err(|err| ExprError::Internal(err.into()))?;
+    Ok(IcebergTransform {
+        child,
+        transform,
         input_arrow_type,
         output_arrow_field,
         return_type,
-    }))
+    }
+    .boxed())
 }
 
 #[cfg(test)]

--- a/src/expr/impl/src/scalar/field.rs
+++ b/src/expr/impl/src/scalar/field.rs
@@ -16,41 +16,68 @@ use anyhow::anyhow;
 use risingwave_common::array::{ArrayImpl, ArrayRef, DataChunk};
 use risingwave_common::row::OwnedRow;
 use risingwave_common::types::{DataType, Datum, ScalarImpl};
-use risingwave_expr::expr::{BoxedExpression, Expression};
+use risingwave_expr::expr::{
+    AsyncExpression, AsyncExpressionBoxExt, BoxedExpression, ExpressionInfo, SyncExpression,
+    SyncExpressionBoxExt,
+};
 use risingwave_expr::{Result, build_function};
 
 /// `FieldExpression` access a field from a struct.
 #[derive(Debug)]
-pub struct FieldExpression {
+pub struct FieldExpression<E> {
     return_type: DataType,
-    input: BoxedExpression,
+    input: E,
     index: usize,
 }
 
-#[async_trait::async_trait]
-impl Expression for FieldExpression {
+impl<E: ExpressionInfo> ExpressionInfo for FieldExpression<E> {
     fn return_type(&self) -> DataType {
         self.return_type.clone()
     }
+}
 
-    async fn eval(&self, input: &DataChunk) -> Result<ArrayRef> {
-        let array = self.input.eval(input).await?;
+macro_rules! eval_field {
+    ($mode:ident, $this:expr, $input:expr) => {{
+        let array = risingwave_expr::forward!($mode, $this.input, eval($input))?;
         if let ArrayImpl::Struct(struct_array) = array.as_ref() {
-            Ok(struct_array.field_at(self.index).clone())
+            Ok(struct_array.field_at($this.index).clone())
         } else {
             Err(anyhow!("expects a struct array ref").into())
         }
-    }
+    }};
+}
 
-    async fn eval_row(&self, input: &OwnedRow) -> Result<Datum> {
-        let struct_datum = self.input.eval_row(input).await?;
+macro_rules! eval_row_field {
+    ($mode:ident, $this:expr, $input:expr) => {{
+        let struct_datum = risingwave_expr::forward!($mode, $this.input, eval_row($input))?;
         struct_datum
             .map(|s| match s {
-                ScalarImpl::Struct(v) => Ok(v.fields()[self.index].clone()),
+                ScalarImpl::Struct(v) => Ok(v.fields()[$this.index].clone()),
                 _ => Err(anyhow!("expects a struct array ref").into()),
             })
             .transpose()
             .map(|x| x.flatten())
+    }};
+}
+
+impl<E: SyncExpression> SyncExpression for FieldExpression<E> {
+    fn eval(&self, input: &DataChunk) -> Result<ArrayRef> {
+        eval_field!(sync, self, input)
+    }
+
+    fn eval_row(&self, input: &OwnedRow) -> Result<Datum> {
+        eval_row_field!(sync, self, input)
+    }
+}
+
+#[async_trait::async_trait]
+impl<E: AsyncExpression> AsyncExpression for FieldExpression<E> {
+    async fn eval(&self, input: &DataChunk) -> Result<ArrayRef> {
+        eval_field!(async, self, input)
+    }
+
+    async fn eval_row(&self, input: &OwnedRow) -> Result<Datum> {
+        eval_row_field!(async, self, input)
     }
 }
 
@@ -60,11 +87,20 @@ fn build(return_type: DataType, children: Vec<BoxedExpression>) -> Result<BoxedE
     // `InputRef`, the second is i32 `Literal`.
     let [input, index]: [_; 2] = children.try_into().unwrap();
     let index = index.eval_const()?.unwrap().into_int32() as usize;
-    Ok(Box::new(FieldExpression {
-        return_type,
-        input,
-        index,
-    }))
+    Ok(match input {
+        BoxedExpression::Sync(input) => FieldExpression {
+            return_type,
+            input,
+            index,
+        }
+        .boxed(),
+        input @ BoxedExpression::Async(_) => FieldExpression {
+            return_type,
+            input,
+            index,
+        }
+        .boxed(),
+    })
 }
 
 #[cfg(test)]

--- a/src/expr/impl/src/scalar/field.rs
+++ b/src/expr/impl/src/scalar/field.rs
@@ -70,7 +70,6 @@ impl<E: SyncExpression> SyncExpression for FieldExpression<E> {
     }
 }
 
-#[async_trait::async_trait]
 impl<E: AsyncExpression> AsyncExpression for FieldExpression<E> {
     async fn eval(&self, input: &DataChunk) -> Result<ArrayRef> {
         eval_field!(async, self, input)

--- a/src/expr/impl/src/scalar/in_.rs
+++ b/src/expr/impl/src/scalar/in_.rs
@@ -16,27 +16,26 @@ use std::collections::HashSet;
 use std::fmt::Debug;
 use std::sync::Arc;
 
-use futures_util::FutureExt;
 use risingwave_common::array::{ArrayBuilder, ArrayRef, BoolArrayBuilder, DataChunk};
+use risingwave_common::bail;
 use risingwave_common::row::OwnedRow;
 use risingwave_common::types::{DataType, Datum, Scalar, ToOwnedDatum};
 use risingwave_common::util::iter_util::ZipEqFast;
-use risingwave_expr::expr::{BoxedExpression, Expression};
+use risingwave_expr::expr::{
+    AsyncExpression, AsyncExpressionBoxExt, BoxedExpression, ExpressionInfo, SyncExpression,
+    SyncExpressionBoxExt,
+};
 use risingwave_expr::{Result, build_function};
 
 #[derive(Debug)]
-pub struct InExpression {
-    left: BoxedExpression,
+pub struct InExpression<E> {
+    left: E,
     set: HashSet<Datum>,
     return_type: DataType,
 }
 
-impl InExpression {
-    pub fn new(
-        left: BoxedExpression,
-        data: impl Iterator<Item = Datum>,
-        return_type: DataType,
-    ) -> Self {
+impl<E> InExpression<E> {
+    pub fn new(left: E, data: impl Iterator<Item = Datum>, return_type: DataType) -> Self {
         Self {
             left,
             set: data.collect(),
@@ -59,31 +58,55 @@ impl InExpression {
     }
 }
 
-#[async_trait::async_trait]
-impl Expression for InExpression {
+impl<E: ExpressionInfo> ExpressionInfo for InExpression<E> {
     fn return_type(&self) -> DataType {
         self.return_type.clone()
     }
+}
 
-    async fn eval(&self, input: &DataChunk) -> Result<ArrayRef> {
-        let input_array = self.left.eval(input).await?;
+macro_rules! eval_in {
+    ($mode:ident, $this:expr, $input:expr) => {{
+        let input_array = risingwave_expr::forward!($mode, $this.left, eval($input))?;
         let mut output_array = BoolArrayBuilder::new(input_array.len());
-        for (data, vis) in input_array.iter().zip_eq_fast(input.visibility().iter()) {
+        for (data, vis) in input_array.iter().zip_eq_fast($input.visibility().iter()) {
             if vis {
                 // TODO: avoid `to_owned_datum()`
-                let ret = self.exists(&data.to_owned_datum());
+                let ret = $this.exists(&data.to_owned_datum());
                 output_array.append(ret);
             } else {
                 output_array.append(None);
             }
         }
         Ok(Arc::new(output_array.finish().into()))
+    }};
+}
+
+macro_rules! eval_row_in {
+    ($mode:ident, $this:expr, $input:expr) => {{
+        let data = risingwave_expr::forward!($mode, $this.left, eval_row($input))?;
+        let ret = $this.exists(&data);
+        Ok(ret.map(|b| b.to_scalar_value()))
+    }};
+}
+
+impl<E: SyncExpression> SyncExpression for InExpression<E> {
+    fn eval(&self, input: &DataChunk) -> Result<ArrayRef> {
+        eval_in!(sync, self, input)
+    }
+
+    fn eval_row(&self, input: &OwnedRow) -> Result<Datum> {
+        eval_row_in!(sync, self, input)
+    }
+}
+
+#[async_trait::async_trait]
+impl<E: AsyncExpression> AsyncExpression for InExpression<E> {
+    async fn eval(&self, input: &DataChunk) -> Result<ArrayRef> {
+        eval_in!(async, self, input)
     }
 
     async fn eval_row(&self, input: &OwnedRow) -> Result<Datum> {
-        let data = self.left.eval_row(input).await?;
-        let ret = self.exists(&data);
-        Ok(ret.map(|b| b.to_scalar_value()))
+        eval_row_in!(async, self, input)
     }
 }
 
@@ -94,18 +117,21 @@ fn build(return_type: DataType, children: Vec<BoxedExpression>) -> Result<BoxedE
     let mut data = Vec::with_capacity(iter.size_hint().0);
     let data_chunk = DataChunk::new_dummy(1);
     for child in iter {
-        let array = child
-            .eval(&data_chunk)
-            .now_or_never()
-            .expect("constant expression should not be async")?;
+        let BoxedExpression::Sync(child) = child else {
+            bail!("IN set expression must be sync")
+        };
+        let array = child.eval(&data_chunk)?;
         let datum = array.value_at(0).to_owned_datum();
         data.push(datum);
     }
-    Ok(Box::new(InExpression::new(
-        left_expr,
-        data.into_iter(),
-        return_type,
-    )))
+    Ok(match left_expr {
+        BoxedExpression::Sync(left_expr) => {
+            InExpression::new(left_expr, data.into_iter(), return_type).boxed()
+        }
+        left_expr @ BoxedExpression::Async(_) => {
+            InExpression::new(left_expr, data.into_iter(), return_type).boxed()
+        }
+    })
 }
 
 #[cfg(test)]
@@ -115,7 +141,7 @@ mod tests {
     use risingwave_common::test_prelude::DataChunkTestExt;
     use risingwave_common::types::ToOwnedDatum;
     use risingwave_common::util::iter_util::ZipEqDebug;
-    use risingwave_expr::expr::{Expression, build_from_pretty};
+    use risingwave_expr::expr::build_from_pretty;
 
     #[tokio::test]
     async fn test_in_expr() {

--- a/src/expr/impl/src/scalar/in_.rs
+++ b/src/expr/impl/src/scalar/in_.rs
@@ -99,7 +99,6 @@ impl<E: SyncExpression> SyncExpression for InExpression<E> {
     }
 }
 
-#[async_trait::async_trait]
 impl<E: AsyncExpression> AsyncExpression for InExpression<E> {
     async fn eval(&self, input: &DataChunk) -> Result<ArrayRef> {
         eval_in!(async, self, input)

--- a/src/expr/impl/src/scalar/map_filter.rs
+++ b/src/expr/impl/src/scalar/map_filter.rs
@@ -183,7 +183,6 @@ impl<E: SyncExpression> SyncExpression for MapFilterExpression<E> {
     }
 }
 
-#[async_trait::async_trait]
 impl<E: AsyncExpression> AsyncExpression for MapFilterExpression<E> {
     async fn eval(&self, input: &DataChunk) -> Result<ArrayRef> {
         eval_map_filter!(async, self, input)

--- a/src/expr/impl/src/scalar/map_filter.rs
+++ b/src/expr/impl/src/scalar/map_filter.rs
@@ -14,35 +14,38 @@
 
 use std::sync::Arc;
 
-use async_trait::async_trait;
 use risingwave_common::array::{
     Array, ArrayBuilder, ArrayImpl, ArrayRef, DataChunk, ListValue, MapArrayBuilder, MapValue,
     StructValue,
 };
 use risingwave_common::row::OwnedRow;
 use risingwave_common::types::{DataType, Datum, Scalar, ScalarImpl, StructType, ToOwnedDatum};
-use risingwave_expr::expr::{BoxedExpression, ExprError, Expression};
+use risingwave_expr::expr::{
+    AsyncExpression, AsyncExpressionBoxExt, BoxedExpression, ExprError, ExpressionInfo,
+    SyncExpression, SyncExpressionBoxExt,
+};
 use risingwave_expr::{Result, build_function};
 
 #[derive(Debug)]
-struct MapFilterExpression {
-    map: BoxedExpression,
-    lambda: BoxedExpression,
+struct MapFilterExpression<E> {
+    map: E,
+    lambda: E,
     key_type: DataType,
     value_type: DataType,
 }
 
-#[async_trait]
-impl Expression for MapFilterExpression {
+impl<E: ExpressionInfo> ExpressionInfo for MapFilterExpression<E> {
     fn return_type(&self) -> DataType {
         self.map.return_type()
     }
+}
 
-    async fn eval(&self, input: &DataChunk) -> Result<ArrayRef> {
-        let map_input = self.map.eval(input).await?;
+macro_rules! eval_map_filter {
+    ($mode:ident, $this:expr, $input:expr) => {{
+        let map_input = risingwave_expr::forward!($mode, $this.map, eval($input))?;
         let map_array = map_input.as_map();
 
-        let mut builder = MapArrayBuilder::with_type(map_array.len(), self.return_type());
+        let mut builder = MapArrayBuilder::with_type(map_array.len(), $this.return_type());
 
         for idx in 0..map_array.len() {
             if map_array.is_null(idx) {
@@ -53,8 +56,8 @@ impl Expression for MapFilterExpression {
             let map_ref = unsafe { map_array.raw_value_at_unchecked(idx) };
             let kv_count = map_ref.len();
 
-            let mut key_builder = self.key_type.create_array_builder(kv_count);
-            let mut value_builder = self.value_type.create_array_builder(kv_count);
+            let mut key_builder = $this.key_type.create_array_builder(kv_count);
+            let mut value_builder = $this.value_type.create_array_builder(kv_count);
 
             let mut kv_pairs = Vec::with_capacity(kv_count);
 
@@ -68,7 +71,7 @@ impl Expression for MapFilterExpression {
             let value_array = value_builder.finish().into_ref();
             let chunk = DataChunk::new(vec![key_array.clone(), value_array.clone()], kv_count);
 
-            let conditions = self.lambda.eval(&chunk).await?;
+            let conditions = risingwave_expr::forward!($mode, $this.lambda, eval(&chunk))?;
             let bool_array = conditions.as_bool();
 
             let mut filtered_entries = Vec::new();
@@ -82,8 +85,8 @@ impl Expression for MapFilterExpression {
                 }
             }
             let elem_type = DataType::Struct(StructType::new(vec![
-                ("key", self.key_type.clone()),
-                ("value", self.value_type.clone()),
+                ("key", $this.key_type.clone()),
+                ("value", $this.value_type.clone()),
             ]));
 
             let map_value = if !filtered_entries.is_empty() {
@@ -104,10 +107,12 @@ impl Expression for MapFilterExpression {
         }
 
         Ok(Arc::new(ArrayImpl::Map(builder.finish())))
-    }
+    }};
+}
 
-    async fn eval_row(&self, input: &OwnedRow) -> Result<Datum> {
-        let map_datum = self.map.eval_row(input).await?;
+macro_rules! eval_row_map_filter {
+    ($mode:ident, $this:expr, $input:expr) => {{
+        let map_datum = risingwave_expr::forward!($mode, $this.map, eval_row($input))?;
         let map_value = match map_datum {
             Some(scalar) => scalar.into_map(),
             None => return Ok(None),
@@ -119,8 +124,8 @@ impl Expression for MapFilterExpression {
             ArrayImpl::Struct(arr) => arr,
             _ => return Err(ExprError::InvalidState("Expected StructArray".to_owned())),
         };
-        let mut key_builder = self.key_type.create_array_builder(struct_array.len());
-        let mut value_builder = self.value_type.create_array_builder(struct_array.len());
+        let mut key_builder = $this.key_type.create_array_builder(struct_array.len());
+        let mut value_builder = $this.value_type.create_array_builder(struct_array.len());
         for idx in 0..struct_array.len() {
             let struct_ref = unsafe { struct_array.raw_value_at_unchecked(idx) };
 
@@ -135,7 +140,7 @@ impl Expression for MapFilterExpression {
         let value_array = value_builder.finish().into_ref();
         let chunk = DataChunk::new(vec![key_array, value_array], struct_array.len());
 
-        let condition = self.lambda.eval(&chunk).await?;
+        let condition = risingwave_expr::forward!($mode, $this.lambda, eval(&chunk))?;
         let condition = condition.as_bool();
 
         let mut filtered_entries = Vec::new();
@@ -165,25 +170,55 @@ impl Expression for MapFilterExpression {
         );
         let new_map_value = MapValue::from_entries(new_list_value);
         Ok(Some(new_map_value.into()))
+    }};
+}
+
+impl<E: SyncExpression> SyncExpression for MapFilterExpression<E> {
+    fn eval(&self, input: &DataChunk) -> Result<ArrayRef> {
+        eval_map_filter!(sync, self, input)
+    }
+
+    fn eval_row(&self, input: &OwnedRow) -> Result<Datum> {
+        eval_row_map_filter!(sync, self, input)
+    }
+}
+
+#[async_trait::async_trait]
+impl<E: AsyncExpression> AsyncExpression for MapFilterExpression<E> {
+    async fn eval(&self, input: &DataChunk) -> Result<ArrayRef> {
+        eval_map_filter!(async, self, input)
+    }
+
+    async fn eval_row(&self, input: &OwnedRow) -> Result<Datum> {
+        eval_row_map_filter!(async, self, input)
     }
 }
 
 #[build_function("map_filter(anymap, any) -> anymap")]
 fn build(return_type: DataType, children: Vec<BoxedExpression>) -> Result<BoxedExpression> {
     let [map, lambda] = <[BoxedExpression; 2]>::try_from(children).unwrap();
-
     let DataType::Map(map_type) = return_type else {
         panic!("Expected map type");
     };
     let key_type = map_type.key().clone();
     let value_type = map_type.value().clone();
 
-    Ok(Box::new(MapFilterExpression {
-        map,
-        lambda,
-        key_type,
-        value_type,
-    }))
+    Ok(match (map, lambda) {
+        (BoxedExpression::Sync(map), BoxedExpression::Sync(lambda)) => MapFilterExpression {
+            map,
+            lambda,
+            key_type,
+            value_type,
+        }
+        .boxed(),
+        (map, lambda) => MapFilterExpression {
+            map,
+            lambda,
+            key_type,
+            value_type,
+        }
+        .boxed(),
+    })
 }
 
 #[cfg(test)]

--- a/src/expr/impl/src/scalar/vnode.rs
+++ b/src/expr/impl/src/scalar/vnode.rs
@@ -147,7 +147,6 @@ impl<E: SyncExpression> SyncExpression for VnodeExpression<E> {
     }
 }
 
-#[async_trait::async_trait]
 impl<E: AsyncExpression> AsyncExpression for VnodeExpression<E> {
     async fn eval(&self, input: &DataChunk) -> Result<ArrayRef> {
         eval_vnode!(async, self, input)

--- a/src/expr/impl/src/scalar/vnode.rs
+++ b/src/expr/impl/src/scalar/vnode.rs
@@ -20,17 +20,20 @@ use risingwave_common::array::{ArrayBuilder, ArrayImpl, ArrayRef, DataChunk, I16
 use risingwave_common::hash::VirtualNode;
 use risingwave_common::row::OwnedRow;
 use risingwave_common::types::{DataType, Datum};
-use risingwave_expr::expr::{BoxedExpression, Expression};
+use risingwave_expr::expr::{
+    AsyncExpression, AsyncExpressionBoxExt, BoxedExpression, ExpressionInfo, SyncExpression,
+    SyncExpressionBoxExt, try_into_sync_exprs,
+};
 use risingwave_expr::{Result, build_function, expr_context};
 
 #[derive(Debug)]
-struct VnodeExpression {
+struct VnodeExpression<E> {
     /// `Some` if it's from the first argument of user-facing function `VnodeUser` (`rw_vnode`),
     /// `None` if it's from the internal function `Vnode`.
     vnode_count: Option<usize>,
 
     /// A list of expressions to get the distribution key columns. Typically `InputRef`.
-    children: Vec<BoxedExpression>,
+    children: Vec<E>,
 
     /// Normally, we pass the distribution key indices to `VirtualNode::compute_xx` functions.
     /// But in this case, all children columns are used to compute vnode. So we cache a vector of
@@ -40,11 +43,21 @@ struct VnodeExpression {
 
 #[build_function("vnode(...) -> int2")]
 fn build(_: DataType, children: Vec<BoxedExpression>) -> Result<BoxedExpression> {
-    Ok(Box::new(VnodeExpression {
-        vnode_count: None,
-        all_indices: (0..children.len()).collect(),
-        children,
-    }))
+    let all_indices = (0..children.len()).collect();
+    match try_into_sync_exprs(children) {
+        Ok(children) => Ok(VnodeExpression {
+            vnode_count: None,
+            all_indices,
+            children,
+        }
+        .boxed()),
+        Err(children) => Ok(VnodeExpression {
+            vnode_count: None,
+            all_indices,
+            children,
+        }
+        .boxed()),
+    }
 }
 
 #[build_function("vnode_user(...) -> int2")]
@@ -68,51 +81,84 @@ fn build_user(_: DataType, children: Vec<BoxedExpression>) -> Result<BoxedExpres
     }
 
     let children = children.collect_vec();
-
-    Ok(Box::new(VnodeExpression {
-        vnode_count: Some(vnode_count.try_into().unwrap()),
-        all_indices: (0..children.len()).collect(),
-        children,
-    }))
+    let all_indices = (0..children.len()).collect();
+    match try_into_sync_exprs(children) {
+        Ok(children) => Ok(VnodeExpression {
+            vnode_count: Some(vnode_count.try_into().unwrap()),
+            all_indices,
+            children,
+        }
+        .boxed()),
+        Err(children) => Ok(VnodeExpression {
+            vnode_count: Some(vnode_count.try_into().unwrap()),
+            all_indices,
+            children,
+        }
+        .boxed()),
+    }
 }
 
-#[async_trait::async_trait]
-impl Expression for VnodeExpression {
+impl<E: ExpressionInfo> ExpressionInfo for VnodeExpression<E> {
     fn return_type(&self) -> DataType {
         DataType::Int16
     }
+}
 
-    async fn eval(&self, input: &DataChunk) -> Result<ArrayRef> {
-        let mut arrays = Vec::with_capacity(self.children.len());
-        for child in &self.children {
-            arrays.push(child.eval(input).await?);
+macro_rules! eval_vnode {
+    ($mode:ident, $this:expr, $input:expr) => {{
+        let mut arrays = Vec::with_capacity($this.children.len());
+        for child in &$this.children {
+            arrays.push(risingwave_expr::forward!($mode, child, eval($input))?);
         }
-        let input = DataChunk::new(arrays, input.visibility().clone());
+        let input = DataChunk::new(arrays, $input.visibility().clone());
 
-        let vnodes = VirtualNode::compute_chunk(&input, &self.all_indices, self.vnode_count()?);
+        let vnodes = VirtualNode::compute_chunk(&input, &$this.all_indices, $this.vnode_count()?);
         let mut builder = I16ArrayBuilder::new(input.capacity());
         vnodes
             .into_iter()
             .for_each(|vnode| builder.append(Some(vnode.to_scalar())));
         Ok(Arc::new(ArrayImpl::from(builder.finish())))
-    }
+    }};
+}
 
-    async fn eval_row(&self, input: &OwnedRow) -> Result<Datum> {
-        let mut datums = Vec::with_capacity(self.children.len());
-        for child in &self.children {
-            datums.push(child.eval_row(input).await?);
+macro_rules! eval_row_vnode {
+    ($mode:ident, $this:expr, $input:expr) => {{
+        let mut datums = Vec::with_capacity($this.children.len());
+        for child in &$this.children {
+            datums.push(risingwave_expr::forward!($mode, child, eval_row($input))?);
         }
         let input = OwnedRow::new(datums);
 
         Ok(Some(
-            VirtualNode::compute_row(input, &self.all_indices, self.vnode_count()?)
+            VirtualNode::compute_row(input, &$this.all_indices, $this.vnode_count()?)
                 .to_scalar()
                 .into(),
         ))
+    }};
+}
+
+impl<E: SyncExpression> SyncExpression for VnodeExpression<E> {
+    fn eval(&self, input: &DataChunk) -> Result<ArrayRef> {
+        eval_vnode!(sync, self, input)
+    }
+
+    fn eval_row(&self, input: &OwnedRow) -> Result<Datum> {
+        eval_row_vnode!(sync, self, input)
     }
 }
 
-impl VnodeExpression {
+#[async_trait::async_trait]
+impl<E: AsyncExpression> AsyncExpression for VnodeExpression<E> {
+    async fn eval(&self, input: &DataChunk) -> Result<ArrayRef> {
+        eval_vnode!(async, self, input)
+    }
+
+    async fn eval_row(&self, input: &OwnedRow) -> Result<Datum> {
+        eval_row_vnode!(async, self, input)
+    }
+}
+
+impl<E> VnodeExpression<E> {
     fn vnode_count(&self) -> Result<usize> {
         if let Some(vnode_count) = self.vnode_count {
             Ok(vnode_count)

--- a/src/expr/impl/src/table_function/generate_series.rs
+++ b/src/expr/impl/src/table_function/generate_series.rs
@@ -216,7 +216,7 @@ mod tests {
     use risingwave_common::array::DataChunk;
     use risingwave_common::types::test_utils::IntervalTestExt;
     use risingwave_common::types::{DataType, Decimal, Interval, ScalarImpl, Timestamp};
-    use risingwave_expr::expr::{BoxedExpression, ExpressionBoxExt, LiteralExpression};
+    use risingwave_expr::expr::{BoxedExpression, LiteralExpression, SyncExpressionBoxExt};
     use risingwave_expr::table_function::{build, check_error};
     use risingwave_pb::expr::table_function::PbType;
 

--- a/src/expr/macro/src/gen.rs
+++ b/src/expr/macro/src/gen.rs
@@ -207,6 +207,7 @@ impl FunctionAttr {
             true => format_ident!("{}OptimizeConst", utils::to_camel_case(&self.ident_name())),
             false => format_ident!("{}", utils::to_camel_case(&self.ident_name())),
         };
+        let async_struct_name = format_ident!("Async{}", struct_name);
 
         // we divide all arguments into two groups: prebuilt and non-prebuilt.
         // prebuilt arguments are collected from the "prebuild" field.
@@ -256,11 +257,13 @@ impl FunctionAttr {
         let arg_arrays = children_indices
             .iter()
             .map(|i| format_ident!("{}", types::array_type(&self.args[*i])));
+        let arg_arrays = arg_arrays.collect_vec();
         let arg_types = children_indices.iter().map(|i| {
             types::ref_type(&self.args[*i])
                 .parse::<TokenStream2>()
                 .unwrap()
         });
+        let arg_types = arg_types.collect_vec();
         let annotation: TokenStream2 = match user_fn.core_return_type.as_str() {
             // add type annotation for functions that return generic types
             "T" | "T1" | "T2" | "T3" => format!(": Option<{}>", types::owned_type(&self.ret))
@@ -299,10 +302,10 @@ impl FunctionAttr {
                     let #prebuilt_inputs = match &#prebuilt_inputs {
                         Some(s) => s.as_scalar_ref_impl().try_into()?,
                         // the function should always return null if any const argument is null
-                        None => return Ok(Box::new(risingwave_expr::expr::LiteralExpression::new(
+                        None => return Ok(risingwave_expr::expr::LiteralExpression::new(
                             return_type,
                             None,
-                        ))),
+                        ).boxed()),
                     };
                 )*
                 #prebuilt_arg_value
@@ -317,8 +320,18 @@ impl FunctionAttr {
             false => quote! { risingwave_expr::ensure!(children.len() == #num_args); },
         };
 
-        // evaluate variadic arguments in `eval`
-        let eval_variadic = variadic.then(|| {
+        // evaluate variadic arguments in sync `eval`
+        let eval_variadic_sync = variadic.then(|| {
+            quote! {
+                let mut columns = Vec::with_capacity(self.children.len() - #num_args);
+                for child in &self.children[#num_args..] {
+                    columns.push(child.eval(input)?);
+                }
+                let variadic_input = DataChunk::new(columns, input.visibility().clone());
+            }
+        });
+        // evaluate variadic arguments in async `eval`
+        let eval_variadic_async = variadic.then(|| {
             quote! {
                 let mut columns = Vec::with_capacity(self.children.len() - #num_args);
                 for child in &self.children[#num_args..] {
@@ -327,8 +340,18 @@ impl FunctionAttr {
                 let variadic_input = DataChunk::new(columns, input.visibility().clone());
             }
         });
-        // evaluate variadic arguments in `eval_row`
-        let eval_row_variadic = variadic.then(|| {
+        // evaluate variadic arguments in sync `eval_row`
+        let eval_row_variadic_sync = variadic.then(|| {
+            quote! {
+                let mut row = Vec::with_capacity(self.children.len() - #num_args);
+                for child in &self.children[#num_args..] {
+                    row.push(child.eval_row(input)?);
+                }
+                let variadic_row = OwnedRow::new(row);
+            }
+        });
+        // evaluate variadic arguments in async `eval_row`
+        let eval_row_variadic_async = variadic.then(|| {
             quote! {
                 let mut row = Vec::with_capacity(self.children.len() - #num_args);
                 for child in &self.children[#num_args..] {
@@ -597,6 +620,72 @@ impl FunctionAttr {
             }
         };
 
+        let sync_impl = if user_fn.async_ {
+            quote! {}
+        } else {
+            quote! {
+                #[derive(Debug)]
+                struct #struct_name {
+                    context: Context,
+                    children: Vec<Arc<dyn risingwave_expr::expr::SyncExpression>>,
+                    prebuilt_arg: #prebuilt_arg_type,
+                }
+                impl risingwave_expr::expr::ExpressionInfo for #struct_name {
+                    fn return_type(&self) -> DataType {
+                        self.context.return_type.clone()
+                    }
+                }
+                impl risingwave_expr::expr::SyncExpression for #struct_name {
+                    fn eval(&self, input: &DataChunk) -> Result<ArrayRef> {
+                        #(
+                            let #array_refs = self.children[#children_indices].eval(input)?;
+                            let #arrays: &#arg_arrays = #array_refs.as_ref().into();
+                        )*
+                        #eval_variadic_sync
+                        let mut errors = vec![];
+                        let array = { #eval };
+                        if errors.is_empty() {
+                            Ok(array)
+                        } else {
+                            Err(ExprError::Multiple(array, errors.into()))
+                        }
+                    }
+                    fn eval_row(&self, input: &OwnedRow) -> Result<Datum> {
+                        #(
+                            let #datums = self.children[#children_indices].eval_row(input)?;
+                            let #inputs: Option<#arg_types> = #datums.as_ref().map(|s| s.as_scalar_ref_impl().try_into().unwrap());
+                        )*
+                        #eval_row_variadic_sync
+                        let mut errors: Vec<ExprError> = vec![];
+                        let output = #row_output;
+                        if let Some(err) = errors.into_iter().next() {
+                            Err(err.into())
+                        } else {
+                            Ok(output)
+                        }
+                    }
+                }
+            }
+        };
+        let build_sync = if user_fn.async_ {
+            quote! {}
+        } else {
+            quote! {
+                use risingwave_expr::expr::try_into_sync_exprs;
+
+                let children = match try_into_sync_exprs(children) {
+                    Ok(children) => {
+                        return Ok(#struct_name {
+                            context,
+                            children,
+                            prebuilt_arg,
+                        }.boxed());
+                    }
+                    Err(children) => children,
+                };
+            }
+        };
+
         Ok(quote! {
             |return_type: DataType, children: Vec<risingwave_expr::expr::BoxedExpression>|
                 -> risingwave_expr::Result<risingwave_expr::expr::BoxedExpression>
@@ -608,7 +697,7 @@ impl FunctionAttr {
                 use risingwave_common::row::OwnedRow;
                 use risingwave_common::util::iter_util::ZipEqFast;
 
-                use risingwave_expr::expr::{Context, BoxedExpression};
+                use risingwave_expr::expr::{Context, BoxedExpression, SyncExpressionBoxExt, AsyncExpressionBoxExt};
                 use risingwave_expr::{ExprError, Result};
                 use risingwave_expr::codegen::*;
 
@@ -620,23 +709,27 @@ impl FunctionAttr {
                     variadic: #variadic,
                 };
 
+                #sync_impl
+
                 #[derive(Debug)]
-                struct #struct_name {
+                struct #async_struct_name {
                     context: Context,
                     children: Vec<BoxedExpression>,
                     prebuilt_arg: #prebuilt_arg_type,
                 }
-                #[async_trait]
-                impl risingwave_expr::expr::Expression for #struct_name {
+                impl risingwave_expr::expr::ExpressionInfo for #async_struct_name {
                     fn return_type(&self) -> DataType {
                         self.context.return_type.clone()
                     }
+                }
+                #[async_trait]
+                impl risingwave_expr::expr::AsyncExpression for #async_struct_name {
                     async fn eval(&self, input: &DataChunk) -> Result<ArrayRef> {
                         #(
                             let #array_refs = self.children[#children_indices].eval(input).await?;
                             let #arrays: &#arg_arrays = #array_refs.as_ref().into();
                         )*
-                        #eval_variadic
+                        #eval_variadic_async
                         let mut errors = vec![];
                         let array = { #eval };
                         if errors.is_empty() {
@@ -650,7 +743,7 @@ impl FunctionAttr {
                             let #datums = self.children[#children_indices].eval_row(input).await?;
                             let #inputs: Option<#arg_types> = #datums.as_ref().map(|s| s.as_scalar_ref_impl().try_into().unwrap());
                         )*
-                        #eval_row_variadic
+                        #eval_row_variadic_async
                         let mut errors: Vec<ExprError> = vec![];
                         let output = #row_output;
                         if let Some(err) = errors.into_iter().next() {
@@ -661,11 +754,13 @@ impl FunctionAttr {
                     }
                 }
 
-                Ok(Box::new(#struct_name {
+                #build_sync
+
+                Ok(#async_struct_name {
                     context,
                     children,
                     prebuilt_arg,
-                }))
+                }.boxed())
             }
         })
     }

--- a/src/expr/macro/src/gen.rs
+++ b/src/expr/macro/src/gen.rs
@@ -722,7 +722,6 @@ impl FunctionAttr {
                         self.context.return_type.clone()
                     }
                 }
-                #[async_trait]
                 impl risingwave_expr::expr::AsyncExpression for #async_struct_name {
                     async fn eval(&self, input: &DataChunk) -> Result<ArrayRef> {
                         #(

--- a/src/stream/clippy.toml
+++ b/src/stream/clippy.toml
@@ -3,8 +3,8 @@ disallowed-methods = [
 
     { path = "risingwave_expr::expr::build_from_prost", reason = "Expressions in streaming must be in non-strict mode. Please use `build_non_strict_from_prost` instead." },
     { path = "risingwave_expr::expr::build_func", reason = "Expressions in streaming must be in non-strict mode. Please use `build_func_non_strict` instead." },
-    { path = "risingwave_expr::expr::Expression::eval", reason = "Please use `NonStrictExpression::eval_infallible` instead." },
-    { path = "risingwave_expr::expr::Expression::eval_row", reason = "Please use `NonStrictExpression::eval_row_infallible` instead." },
+    { path = "risingwave_expr::expr::BoxedExpression::eval", reason = "Please use `NonStrictExpression::eval_infallible` instead." },
+    { path = "risingwave_expr::expr::BoxedExpression::eval_row", reason = "Please use `NonStrictExpression::eval_row_infallible` instead." },
 ]
 
 disallowed-types = [

--- a/src/stream/src/executor/aggregate/mod.rs
+++ b/src/stream/src/executor/aggregate/mod.rs
@@ -95,7 +95,7 @@ async fn agg_call_filter_res(
 
     if let Some(ref filter) = agg_call.filter {
         // TODO: should we build `filter` in non-strict mode?
-        if let Bool(filter_res) = NonStrictExpression::new_topmost(&**filter, LogReport)
+        if let Bool(filter_res) = NonStrictExpression::new_topmost(filter.clone(), LogReport)
             .eval_infallible(chunk)
             .await
             .as_ref()

--- a/src/stream/src/executor/dynamic_filter.rs
+++ b/src/stream/src/executor/dynamic_filter.rs
@@ -282,8 +282,8 @@ impl<S: StateStore> DynamicFilterExecutor<S> {
                         cmp,
                         DataType::Boolean,
                         vec![
-                            Box::new(InputRefExpression::new(l_data_type.clone(), self.key_l)),
-                            Box::new(LiteralExpression::new(r_data_type.clone(), Some(scalar))),
+                            InputRefExpression::new(l_data_type.clone(), self.key_l).into(),
+                            LiteralExpression::new(r_data_type.clone(), Some(scalar)).into(),
                         ],
                         eval_error_report.clone(),
                     )

--- a/src/stream/src/executor/mod.rs
+++ b/src/stream/src/executor/mod.rs
@@ -41,7 +41,7 @@ use risingwave_common::util::epoch::{Epoch, EpochPair};
 use risingwave_common::util::tracing::TracingContext;
 use risingwave_common::util::value_encoding::{DatumFromProtoExt, DatumToProtoExt};
 use risingwave_connector::source::SplitImpl;
-use risingwave_expr::expr::{Expression, NonStrictExpression};
+use risingwave_expr::expr::NonStrictExpression;
 use risingwave_pb::data::PbEpoch;
 use risingwave_pb::expr::PbInputRef;
 use risingwave_pb::stream_plan::add_mutation::PbNewUpstreamSink;
@@ -1269,7 +1269,7 @@ impl Watermark {
 
     pub async fn transform_with_expr(
         self,
-        expr: &NonStrictExpression<impl Expression>,
+        expr: &NonStrictExpression,
         new_col_idx: usize,
     ) -> Option<Self> {
         let Self { col_idx, val, .. } = self;

--- a/src/stream/src/executor/now.rs
+++ b/src/stream/src/executor/now.rs
@@ -18,8 +18,8 @@ use risingwave_common::row;
 use risingwave_common::types::{DefaultOrdered, Interval, Timestamptz, ToDatumRef};
 use risingwave_expr::capture_context;
 use risingwave_expr::expr::{
-    EvalErrorReport, ExpressionBoxExt, InputRefExpression, LiteralExpression, NonStrictExpression,
-    build_func_non_strict,
+    EvalErrorReport, InputRefExpression, LiteralExpression, NonStrictExpression,
+    SyncExpressionBoxExt, build_func_non_strict,
 };
 use risingwave_expr::expr_context::TIME_ZONE;
 use tokio::sync::mpsc::UnboundedReceiver;

--- a/src/stream/src/executor/project/project_scalar.rs
+++ b/src/stream/src/executor/project/project_scalar.rs
@@ -424,7 +424,7 @@ mod tests {
     use risingwave_common::config::StreamingConfig;
     use risingwave_common::types::DefaultOrd;
     use risingwave_common::util::epoch::test_epoch;
-    use risingwave_expr::expr::{self, Expression, ValueImpl};
+    use risingwave_expr::expr::{self, ExpressionInfo, SyncExpression, ValueImpl};
     use tokio::sync::Notify;
     use tokio::time::timeout;
 
@@ -937,13 +937,14 @@ mod tests {
     #[derive(Debug)]
     struct DummyNondecreasingExpr;
 
-    #[async_trait::async_trait]
-    impl Expression for DummyNondecreasingExpr {
+    impl ExpressionInfo for DummyNondecreasingExpr {
         fn return_type(&self) -> DataType {
             DataType::Int64
         }
+    }
 
-        async fn eval_v2(&self, input: &DataChunk) -> expr::Result<ValueImpl> {
+    impl SyncExpression for DummyNondecreasingExpr {
+        fn eval_v2(&self, input: &DataChunk) -> expr::Result<ValueImpl> {
             let value = DUMMY_COUNTER.fetch_add(1, atomic::Ordering::SeqCst);
             Ok(ValueImpl::Scalar {
                 value: Some(value.into()),
@@ -951,7 +952,7 @@ mod tests {
             })
         }
 
-        async fn eval_row(&self, _input: &OwnedRow) -> expr::Result<Datum> {
+        fn eval_row(&self, _input: &OwnedRow) -> expr::Result<Datum> {
             let value = DUMMY_COUNTER.fetch_add(1, atomic::Ordering::SeqCst);
             Ok(Some(value.into()))
         }

--- a/src/stream/src/executor/project/project_scalar.rs
+++ b/src/stream/src/executor/project/project_scalar.rs
@@ -424,7 +424,9 @@ mod tests {
     use risingwave_common::config::StreamingConfig;
     use risingwave_common::types::DefaultOrd;
     use risingwave_common::util::epoch::test_epoch;
-    use risingwave_expr::expr::{self, ExpressionInfo, SyncExpression, ValueImpl};
+    use risingwave_expr::expr::{
+        self, AsyncExpression, BoxedExpression, ExpressionInfo, SyncExpression, ValueImpl,
+    };
     use tokio::sync::Notify;
     use tokio::time::timeout;
 
@@ -566,11 +568,14 @@ mod tests {
     }
 
     #[async_trait::async_trait]
-    impl Expression for BlockingProjectExpr {
+    impl ExpressionInfo for BlockingProjectExpr {
         fn return_type(&self) -> DataType {
             DataType::Int64
         }
+    }
 
+    #[async_trait::async_trait]
+    impl AsyncExpression for BlockingProjectExpr {
         async fn eval_v2(&self, input: &DataChunk) -> expr::Result<ValueImpl> {
             let call_idx = self.started_count.fetch_add(1, atomic::Ordering::SeqCst);
             if call_idx == 0 {
@@ -612,11 +617,14 @@ mod tests {
     }
 
     #[async_trait::async_trait]
-    impl Expression for FirstProjectExprWaitsForStartedCount {
+    impl ExpressionInfo for FirstProjectExprWaitsForStartedCount {
         fn return_type(&self) -> DataType {
             DataType::Int64
         }
+    }
 
+    #[async_trait::async_trait]
+    impl AsyncExpression for FirstProjectExprWaitsForStartedCount {
         async fn eval_v2(&self, input: &DataChunk) -> expr::Result<ValueImpl> {
             let call_idx = self.started_count.fetch_add(1, atomic::Ordering::SeqCst);
             self.started_notify.notify_waiters();
@@ -657,13 +665,14 @@ mod tests {
         let release_first = Arc::new(AtomicBool::new(false));
         let release_first_notify = Arc::new(Notify::new());
 
-        let test_expr = NonStrictExpression::for_test(BlockingProjectExpr {
-            started_count,
-            second_started: second_started.clone(),
-            second_started_notify: second_started_notify.clone(),
-            release_first: release_first.clone(),
-            release_first_notify: release_first_notify.clone(),
-        });
+        let test_expr =
+            NonStrictExpression::for_test(BoxedExpression::new_async(BlockingProjectExpr {
+                started_count,
+                second_started: second_started.clone(),
+                second_started_notify: second_started_notify.clone(),
+                release_first: release_first.clone(),
+                release_first_notify: release_first_notify.clone(),
+            }));
 
         let proj = ProjectExecutor::new(
             actor_context_with_project_expr_concurrency(2),
@@ -741,11 +750,13 @@ mod tests {
 
         let started_count = Arc::new(AtomicUsize::new(0));
         let started_notify = Arc::new(Notify::new());
-        let test_expr = NonStrictExpression::for_test(FirstProjectExprWaitsForStartedCount {
-            started_count: started_count.clone(),
-            started_notify: started_notify.clone(),
-            unblock_first_at_started_count: 3,
-        });
+        let test_expr = NonStrictExpression::for_test(BoxedExpression::new_async(
+            FirstProjectExprWaitsForStartedCount {
+                started_count: started_count.clone(),
+                started_notify: started_notify.clone(),
+                unblock_first_at_started_count: 3,
+            },
+        ));
 
         let proj = ProjectExecutor::new(
             actor_context_with_project_expr_limits(3, 2),
@@ -838,11 +849,13 @@ mod tests {
 
         let started_count = Arc::new(AtomicUsize::new(0));
         let started_notify = Arc::new(Notify::new());
-        let test_expr = NonStrictExpression::for_test(FirstProjectExprWaitsForStartedCount {
-            started_count: started_count.clone(),
-            started_notify: started_notify.clone(),
-            unblock_first_at_started_count: 3,
-        });
+        let test_expr = NonStrictExpression::for_test(BoxedExpression::new_async(
+            FirstProjectExprWaitsForStartedCount {
+                started_count: started_count.clone(),
+                started_notify: started_notify.clone(),
+                unblock_first_at_started_count: 3,
+            },
+        ));
 
         let proj = ProjectExecutor::new(
             actor_context_with_project_expr_limits(3, 2),

--- a/src/stream/src/executor/project/project_scalar.rs
+++ b/src/stream/src/executor/project/project_scalar.rs
@@ -567,14 +567,12 @@ mod tests {
         release_first_notify: Arc<Notify>,
     }
 
-    #[async_trait::async_trait]
     impl ExpressionInfo for BlockingProjectExpr {
         fn return_type(&self) -> DataType {
             DataType::Int64
         }
     }
 
-    #[async_trait::async_trait]
     impl AsyncExpression for BlockingProjectExpr {
         async fn eval_v2(&self, input: &DataChunk) -> expr::Result<ValueImpl> {
             let call_idx = self.started_count.fetch_add(1, atomic::Ordering::SeqCst);
@@ -616,14 +614,12 @@ mod tests {
         unblock_first_at_started_count: usize,
     }
 
-    #[async_trait::async_trait]
     impl ExpressionInfo for FirstProjectExprWaitsForStartedCount {
         fn return_type(&self) -> DataType {
             DataType::Int64
         }
     }
 
-    #[async_trait::async_trait]
     impl AsyncExpression for FirstProjectExprWaitsForStartedCount {
         async fn eval_v2(&self, input: &DataChunk) -> expr::Result<ValueImpl> {
             let call_idx = self.started_count.fetch_add(1, atomic::Ordering::SeqCst);

--- a/src/stream/src/executor/project/project_scalar.rs
+++ b/src/stream/src/executor/project/project_scalar.rs
@@ -425,7 +425,7 @@ mod tests {
     use risingwave_common::types::DefaultOrd;
     use risingwave_common::util::epoch::test_epoch;
     use risingwave_expr::expr::{
-        self, AsyncExpression, BoxedExpression, ExpressionInfo, SyncExpression, ValueImpl,
+        self, AsyncExpression, AsyncExpressionBoxExt, ExpressionInfo, SyncExpression, ValueImpl,
     };
     use tokio::sync::Notify;
     use tokio::time::timeout;
@@ -665,14 +665,16 @@ mod tests {
         let release_first = Arc::new(AtomicBool::new(false));
         let release_first_notify = Arc::new(Notify::new());
 
-        let test_expr =
-            NonStrictExpression::for_test(BoxedExpression::new_async(BlockingProjectExpr {
+        let test_expr = NonStrictExpression::for_test(
+            BlockingProjectExpr {
                 started_count,
                 second_started: second_started.clone(),
                 second_started_notify: second_started_notify.clone(),
                 release_first: release_first.clone(),
                 release_first_notify: release_first_notify.clone(),
-            }));
+            }
+            .boxed(),
+        );
 
         let proj = ProjectExecutor::new(
             actor_context_with_project_expr_concurrency(2),
@@ -750,13 +752,14 @@ mod tests {
 
         let started_count = Arc::new(AtomicUsize::new(0));
         let started_notify = Arc::new(Notify::new());
-        let test_expr = NonStrictExpression::for_test(BoxedExpression::new_async(
+        let test_expr = NonStrictExpression::for_test(
             FirstProjectExprWaitsForStartedCount {
                 started_count: started_count.clone(),
                 started_notify: started_notify.clone(),
                 unblock_first_at_started_count: 3,
-            },
-        ));
+            }
+            .boxed(),
+        );
 
         let proj = ProjectExecutor::new(
             actor_context_with_project_expr_limits(3, 2),
@@ -849,13 +852,14 @@ mod tests {
 
         let started_count = Arc::new(AtomicUsize::new(0));
         let started_notify = Arc::new(Notify::new());
-        let test_expr = NonStrictExpression::for_test(BoxedExpression::new_async(
+        let test_expr = NonStrictExpression::for_test(
             FirstProjectExprWaitsForStartedCount {
                 started_count: started_count.clone(),
                 started_notify: started_notify.clone(),
                 unblock_first_at_started_count: 3,
-            },
-        ));
+            }
+            .boxed(),
+        );
 
         let proj = ProjectExecutor::new(
             actor_context_with_project_expr_limits(3, 2),

--- a/src/stream/src/executor/values.rs
+++ b/src/stream/src/executor/values.rs
@@ -163,27 +163,16 @@ mod tests {
         let actor_id = progress.actor_id();
         let (tx, barrier_receiver) = unbounded_channel();
         let value = StructValue::new(vec![Some(1.into()), Some(2.into()), Some(3.into())]);
-        let exprs = vec![
-            Box::new(LiteralExpression::new(
-                DataType::Int16,
-                Some(ScalarImpl::Int16(1)),
-            )) as BoxedExpression,
-            Box::new(LiteralExpression::new(
-                DataType::Int32,
-                Some(ScalarImpl::Int32(2)),
-            )),
-            Box::new(LiteralExpression::new(
-                DataType::Int64,
-                Some(ScalarImpl::Int64(3)),
-            )),
-            Box::new(LiteralExpression::new(
+        let exprs: Vec<BoxedExpression> = vec![
+            LiteralExpression::new(DataType::Int16, Some(ScalarImpl::Int16(1))).into(),
+            LiteralExpression::new(DataType::Int32, Some(ScalarImpl::Int32(2))).into(),
+            LiteralExpression::new(DataType::Int64, Some(ScalarImpl::Int64(3))).into(),
+            LiteralExpression::new(
                 StructType::unnamed(vec![DataType::Int32, DataType::Int32, DataType::Int32]).into(),
                 Some(ScalarImpl::Struct(value)),
-            )),
-            Box::new(LiteralExpression::new(
-                DataType::Int64,
-                Some(ScalarImpl::Int64(0)),
-            )),
+            )
+            .into(),
+            LiteralExpression::new(DataType::Int64, Some(ScalarImpl::Int64(0))).into(),
         ];
         let schema = exprs
             .iter() // for each column

--- a/src/stream/src/executor/watermark_filter.rs
+++ b/src/stream/src/executor/watermark_filter.rs
@@ -20,7 +20,7 @@ use risingwave_common::types::DefaultOrd;
 use risingwave_common::{bail, row};
 use risingwave_expr::Result as ExprResult;
 use risingwave_expr::expr::{
-    ExpressionBoxExt, InputRefExpression, LiteralExpression, NonStrictExpression,
+    InputRefExpression, LiteralExpression, NonStrictExpression, SyncExpressionBoxExt,
     build_func_non_strict,
 };
 use risingwave_hummock_sdk::HummockReadEpoch;

--- a/src/stream/tests/integration_tests/materialized_exprs.rs
+++ b/src/stream/tests/integration_tests/materialized_exprs.rs
@@ -18,7 +18,7 @@ use std::sync::atomic::Ordering;
 use risingwave_common::array::DataChunk;
 use risingwave_common::row::OwnedRow;
 use risingwave_common::types::Datum;
-use risingwave_expr::expr::{Expression, NonStrictExpression, ValueImpl};
+use risingwave_expr::expr::{ExpressionInfo, NonStrictExpression, SyncExpression, ValueImpl};
 use risingwave_stream::common::table::test_utils::gen_pbtable;
 use risingwave_stream::executor::project::{MaterializedExprsArgs, MaterializedExprsExecutor};
 
@@ -179,13 +179,14 @@ async fn test_materialize_pure_expressions() {
 #[derive(Debug)]
 struct Count(AtomicU64);
 
-#[async_trait::async_trait]
-impl Expression for Count {
+impl ExpressionInfo for Count {
     fn return_type(&self) -> DataType {
         DataType::Int64
     }
+}
 
-    async fn eval_v2(&self, input: &DataChunk) -> risingwave_expr::Result<ValueImpl> {
+impl SyncExpression for Count {
+    fn eval_v2(&self, input: &DataChunk) -> risingwave_expr::Result<ValueImpl> {
         let value = self.0.fetch_add(1, Ordering::Relaxed) as i64;
         Ok(ValueImpl::Scalar {
             value: Some(value.into()),
@@ -193,7 +194,7 @@ impl Expression for Count {
         })
     }
 
-    async fn eval_row(&self, _input: &OwnedRow) -> risingwave_expr::Result<Datum> {
+    fn eval_row(&self, _input: &OwnedRow) -> risingwave_expr::Result<Datum> {
         unimplemented!()
     }
 }


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

Refactor scalar expression execution to split common expression metadata, synchronous evaluation, native asynchronous evaluation, and object-safe asynchronous dispatch.

The motivation is to avoid paying the async-trait cost for CPU-only scalar expressions. Calling an async trait method creates a boxed future, so even simple expressions such as input refs and literals currently incur unnecessary allocation overhead. By distinguishing sync and async expression trees, pure sync expressions can evaluate directly without boxed future allocation, while UDF and external-IO expressions still use async evaluation.

This PR keeps `BoxedExpression` as the compatibility wrapper, but changes it to an enum over `Arc<dyn SyncExpression>` and `Arc<dyn AsyncDynExpression>`. `AsyncExpression` itself uses native async trait methods returning `impl Future + Send`, so concrete async wrappers and `BoxedExpression` avoid the `async_trait` boxed-future path. `AsyncDynExpression` remains object-safe via `async_trait` for the dynamic async boundary. Builders preserve sync expression trees when all children are sync, and fall back to async wrappers when any child is async.

Main changes:

- Add `ExpressionInfo`, `SyncExpression`, native `AsyncExpression`, and object-safe `AsyncDynExpression` traits.
- Convert `BoxedExpression` to `Sync` / `Async` enum variants with compatibility async methods for existing executor `.eval(...).await` call sites.
- Update expression builders, generated scalar functions, wrappers, literals, input refs, boolean expressions, `CASE`, `COALESCE`, `IN`, `SOME/ALL`, `array_transform`, map/filter, field access, vnode, UDF, OpenAI embedding, and Iceberg transform handling.
- Add shared helpers for sync-child conversion and sync list-array inner mapping.
- Keep async behavior for UDF/OpenAI/external IO and sync behavior for pure scalar trees.

- Closes #

## Checklist

- [x] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [x] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

Internal expression execution refactor. No user-visible SQL behavior changes are intended.

</details>

## Local verification

- `cargo fmt`
- `cargo check -p risingwave_expr --lib`
- `cargo check -p risingwave_expr_impl --lib`
- `cargo check -p risingwave_common --lib`
- `cargo check -p risingwave_stream --lib --tests`
- `cargo clippy --all-targets --all-features`

