### PR TITLE
fix(meta): never reap the single SQLite meta store connection

### DIFF
--- a/src/meta/src/controller/mod.rs
+++ b/src/meta/src/controller/mod.rs
@@ -83,6 +83,18 @@ impl SqlMetaStore {
                     //       same underlying setting in `sqlx` under current implementation.
                     .acquire_timeout(MAX_DURATION)
                     .connect_timeout(MAX_DURATION)
+                    // Never close the only connection due to idleness or age.
+                    // - For in-memory SQLite, releasing the connection clears the database.
+                    // - For file-backed SQLite, a finite `idle_timeout` keeps the pool's background
+                    //   reaper task running, which is subject to a `num_idle` underflow bug in `sqlx`
+                    //   (https://github.com/launchbadge/sqlx/issues/3645, fix pending in
+                    //   https://github.com/launchbadge/sqlx/pull/4289) that can spin the reaper
+                    //   without yielding and permanently wedge the single-connection pool, hanging
+                    //   the meta node (https://github.com/risingwavelabs/risingwave/issues/24991).
+                    // `sqlx` actually supports disabling these timeouts by passing a `None`, but
+                    // `sea-orm` does not expose this option.
+                    .idle_timeout(MAX_DURATION)
+                    .max_lifetime(MAX_DURATION)
             }
         }
 
@@ -92,14 +104,7 @@ impl SqlMetaStore {
 
                 let mut options = ConnectOptions::new(IN_MEMORY_STORE);
 
-                options
-                    .sqlite_common()
-                    // Releasing the connection to in-memory SQLite database is unacceptable
-                    // because it will clear the database. Set a large enough timeout to prevent it.
-                    // `sqlx` actually supports disabling these timeouts by passing a `None`, but
-                    // `sea-orm` does not expose this option.
-                    .idle_timeout(MAX_DURATION)
-                    .max_lifetime(MAX_DURATION);
+                options.sqlite_common();
 
                 let conn = sea_orm::Database::connect(options).await?;
                 Self {


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

Mitigation for the CI silent meta hang #24991 (full root-cause analysis: https://github.com/risingwavelabs/risingwave/issues/24991#issuecomment-4850297067).

The file-backed SQLite meta store previously kept the config default `idle_timeout_sec = 30` (only the in-memory branch overrode it with `MAX_DURATION`), which keeps sqlx's background pool-reaper task alive. sqlx 0.8.2 has a `num_idle` accounting race — `release()` publishes the connection and releases the semaphore permit **before** incrementing `num_idle`, so a concurrent `pop_idle` can decrement first — that transiently underflows the counter to ~2^64. If the reaper's 30s tick happens to sample the underflow as its sweep-loop bound (`for _ in 0..pool.num_idle()`), it spins `try_acquire` inside a single poll without ever yielding (the loop body has no await; `try_acquire` consumes no coop budget). During the spin, one `add_permits` hands the only permit to a queued waiter whose wakeup lands in the spinning worker's LIFO slot — not stealable on tokio 1.49 (tokio-rs/tokio#4941) — so the waiter never runs, the permit stays assigned forever, and the single-connection pool is permanently wedged. Every meta DB access then queues forever (`acquire_timeout` is effectively infinite per #18966), presenting as the silent hang: `commit_epoch` stuck ~150s+, DDL frozen, heartbeat timeouts.

Upstream status: the same bug is independently reported in launchbadge/sqlx#3645 ("100% CPU in `spawn_maintenance_tasks`") with a fix pending in launchbadge/sqlx#4289; it is unmerged and no released sqlx version contains it.

This PR removes the ignition site by never expiring the single SQLite connection: move `.idle_timeout(MAX_DURATION).max_lifetime(MAX_DURATION)` into `sqlite_common()` so both the in-memory and file-backed branches get them (the in-memory branch already did this for its own reason — releasing the connection clears the in-memory database). With `max_connections = 1` against a local SQLite file, idle/lifetime reaping serves no purpose anyway.

A follow-up will fix the underlying `num_idle` race in the pinned madsim sqlx fork (mirroring launchbadge/sqlx#4289).

Note: file-backed SQLite is also the meta store for standalone/single-node deployments, so this hazard is not CI-only; this change is a low-risk cherry-pick candidate for release branches.

- Related: #24991 (removes the trigger for the hang; leaving closure until CI soaks)

## Checklist

- [x] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [x] I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->

## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

</details>
