### PR TITLE
fix(meta): bump madsim sqlx fork to fix pool num_idle underflow livelock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14786,7 +14786,7 @@ dependencies = [
 [[package]]
 name = "sqlx"
 version = "0.8.2"
-source = "git+https://github.com/madsim-rs/sqlx.git?rev=3efe6d0065963db2a2b7f30dee69f647e28dec81#3efe6d0065963db2a2b7f30dee69f647e28dec81"
+source = "git+https://github.com/madsim-rs/sqlx.git?rev=d43f1f28c0a2ec28144d81fdf78706ce30002b59#d43f1f28c0a2ec28144d81fdf78706ce30002b59"
 dependencies = [
  "sqlx-core",
  "sqlx-macros",
@@ -14798,7 +14798,7 @@ dependencies = [
 [[package]]
 name = "sqlx-core"
 version = "0.8.2"
-source = "git+https://github.com/madsim-rs/sqlx.git?rev=3efe6d0065963db2a2b7f30dee69f647e28dec81#3efe6d0065963db2a2b7f30dee69f647e28dec81"
+source = "git+https://github.com/madsim-rs/sqlx.git?rev=d43f1f28c0a2ec28144d81fdf78706ce30002b59#d43f1f28c0a2ec28144d81fdf78706ce30002b59"
 dependencies = [
  "atoi",
  "bigdecimal 0.4.10",
@@ -14842,7 +14842,7 @@ dependencies = [
 [[package]]
 name = "sqlx-macros"
 version = "0.8.2"
-source = "git+https://github.com/madsim-rs/sqlx.git?rev=3efe6d0065963db2a2b7f30dee69f647e28dec81#3efe6d0065963db2a2b7f30dee69f647e28dec81"
+source = "git+https://github.com/madsim-rs/sqlx.git?rev=d43f1f28c0a2ec28144d81fdf78706ce30002b59#d43f1f28c0a2ec28144d81fdf78706ce30002b59"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -14854,7 +14854,7 @@ dependencies = [
 [[package]]
 name = "sqlx-macros-core"
 version = "0.8.2"
-source = "git+https://github.com/madsim-rs/sqlx.git?rev=3efe6d0065963db2a2b7f30dee69f647e28dec81#3efe6d0065963db2a2b7f30dee69f647e28dec81"
+source = "git+https://github.com/madsim-rs/sqlx.git?rev=d43f1f28c0a2ec28144d81fdf78706ce30002b59#d43f1f28c0a2ec28144d81fdf78706ce30002b59"
 dependencies = [
  "dotenvy",
  "either",
@@ -14879,7 +14879,7 @@ dependencies = [
 [[package]]
 name = "sqlx-mysql"
 version = "0.8.2"
-source = "git+https://github.com/madsim-rs/sqlx.git?rev=3efe6d0065963db2a2b7f30dee69f647e28dec81#3efe6d0065963db2a2b7f30dee69f647e28dec81"
+source = "git+https://github.com/madsim-rs/sqlx.git?rev=d43f1f28c0a2ec28144d81fdf78706ce30002b59#d43f1f28c0a2ec28144d81fdf78706ce30002b59"
 dependencies = [
  "atoi",
  "base64 0.22.1",
@@ -14925,7 +14925,7 @@ dependencies = [
 [[package]]
 name = "sqlx-postgres"
 version = "0.8.2"
-source = "git+https://github.com/madsim-rs/sqlx.git?rev=3efe6d0065963db2a2b7f30dee69f647e28dec81#3efe6d0065963db2a2b7f30dee69f647e28dec81"
+source = "git+https://github.com/madsim-rs/sqlx.git?rev=d43f1f28c0a2ec28144d81fdf78706ce30002b59#d43f1f28c0a2ec28144d81fdf78706ce30002b59"
 dependencies = [
  "atoi",
  "base64 0.22.1",
@@ -14968,7 +14968,7 @@ dependencies = [
 [[package]]
 name = "sqlx-sqlite"
 version = "0.8.2"
-source = "git+https://github.com/madsim-rs/sqlx.git?rev=3efe6d0065963db2a2b7f30dee69f647e28dec81#3efe6d0065963db2a2b7f30dee69f647e28dec81"
+source = "git+https://github.com/madsim-rs/sqlx.git?rev=d43f1f28c0a2ec28144d81fdf78706ce30002b59#d43f1f28c0a2ec28144d81fdf78706ce30002b59"
 dependencies = [
  "atoi",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -448,8 +448,8 @@ getrandom = { git = "https://github.com/madsim-rs/getrandom.git", rev = "e79a7ae
 tokio-retry = { git = "https://github.com/madsim-rs/rust-tokio-retry.git", rev = "95e2fd3" }
 tokio-postgres = { git = "https://github.com/madsim-rs/rust-postgres.git", rev = "ac00d88" }
 # sqlx version: v0.8.2
-# patch diffs: https://github.com/madsim-rs/sqlx/pull/4
-sqlx = { git = "https://github.com/madsim-rs/sqlx.git", rev = "3efe6d0065963db2a2b7f30dee69f647e28dec81" }
+# patch diffs: https://github.com/madsim-rs/sqlx/pull/4, https://github.com/madsim-rs/sqlx/pull/5
+sqlx = { git = "https://github.com/madsim-rs/sqlx.git", rev = "d43f1f28c0a2ec28144d81fdf78706ce30002b59" }
 # patch to remove preserve_order from serde_json
 bson = { git = "https://github.com/risingwavelabs/bson-rust", tag = "v2.15.0-json-no-preserve_order" }
 # patch to revert `Hash for StringRef` for compatibility with `&str` in vnode


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

Bump the pinned `madsim-rs/sqlx` fork to the current `madsim-v0.8.2` HEAD, which contains madsim-rs/sqlx#5: a fix for the connection pool `num_idle` underflow that can freeze the pool reaper in an infinite spin and permanently wedge the single-connection SQLite meta store (silent meta hang). Only `sqlx-core/src/pool/inner.rs` changed between the two revs.

Full RCA: https://github.com/risingwavelabs/risingwave/issues/24991#issuecomment-4850297067

- Closes #24991

## Checklist

- [x] I have added necessary unit tests and integration tests. (the regression test lives in the sqlx fork: madsim-rs/sqlx#5)

## Documentation

- [ ] My PR needs documentation updates.
