### PR TITLE
fix(connector): retry on Pulsar consumer termination

### DIFF
--- a/src/connector/src/source/pulsar/source/reader.rs
+++ b/src/connector/src/source/pulsar/source/reader.rs
@@ -336,6 +336,7 @@ impl PulsarBrokerReader {
             pulsar_reader: self.consumer,
             ack_rx,
             topic: self.split.topic.to_string(),
+            termination_reported: false,
         }
     }
 }
@@ -346,9 +347,32 @@ struct PulsarConsumeStream {
     pulsar_reader: Consumer<Vec<u8>, TokioExecutor>,
     ack_rx: tokio::sync::mpsc::UnboundedReceiver<Vec<u8>>,
     topic: String,
+    termination_reported: bool,
 }
 
 impl PulsarConsumeStream {
+    fn unexpected_termination_error(&self) -> pulsar::error::Error {
+        // Current RisingWave Pulsar sources are unbounded, so SDK consumer
+        // termination is unexpected and should trigger source retry. Future
+        // bounded Pulsar source mode must revisit this assumption.
+        pulsar::error::Error::Custom(format!(
+            "unexpected Pulsar consumer termination: source_id={}, source_name={}, actor_id={}, fragment_id={}, split_id={}, topic={}",
+            self.source_ctx.source_id,
+            self.source_ctx.source_name,
+            self.source_ctx.actor_id,
+            self.source_ctx.fragment_id,
+            self.split_id,
+            self.topic,
+        ))
+    }
+
+    fn report_unexpected_termination(
+        &mut self,
+    ) -> Poll<Option<Result<Message<Vec<u8>>, pulsar::error::Error>>> {
+        self.termination_reported = true;
+        Poll::Ready(Some(Err(self.unexpected_termination_error())))
+    }
+
     fn inc_ack_failure_count(&self, failure_type: ConnectorAckFailureType) {
         self.source_ctx.metrics.inc_connector_ack_failure_count(
             self.source_ctx.source_name.as_str(),
@@ -425,6 +449,10 @@ impl futures::Stream for PulsarConsumeStream {
         mut self: std::pin::Pin<&mut Self>,
         cx: &mut std::task::Context<'_>,
     ) -> std::task::Poll<Option<Self::Item>> {
+        if self.termination_reported {
+            return Poll::Ready(None);
+        }
+
         match (
             self.ack_rx.poll_recv(cx),
             self.pulsar_reader.poll_next_unpin(cx),
@@ -442,7 +470,9 @@ impl futures::Stream for PulsarConsumeStream {
                 Some(Err(e)) => {
                     return Poll::Ready(Some(Err(e)));
                 }
-                None => {}
+                None => {
+                    return self.report_unexpected_termination();
+                }
             },
             (Poll::Ready(some_ack), Poll::Ready(maybe_message)) => {
                 if let Some(ack_message_id) = some_ack {
@@ -455,7 +485,9 @@ impl futures::Stream for PulsarConsumeStream {
                     Some(Err(e)) => {
                         return Poll::Ready(Some(Err(e)));
                     }
-                    None => {}
+                    None => {
+                        return self.report_unexpected_termination();
+                    }
                 }
             }
         }


### PR DESCRIPTION
## What changed

This PR makes the Pulsar source reader surface unexpected Pulsar SDK consumer stream termination as an error instead of silently converting it into `Poll::Pending`.

Specifically, `PulsarConsumeStream::poll_next` now maps the first SDK `Ready(None)` to a contextual `pulsar::error::Error::Custom`, including source/split/topic context. After reporting that unexpected termination once, the wrapper stream returns `Ready(None)` before polling the ack channel or inner Pulsar consumer again, so it behaves as fused and does not repeatedly emit identical errors. The both-ready branch still processes a pending ack before reporting the termination.

## Why

A customer outage showed Pulsar SDK ping / DNS failures can leave the consumer stream terminated or unusable while RisingWave keeps the source reader pending forever. Because no stream error reaches `reader_stream.rs`, the existing source retry/rebuild loop is not triggered, and recovery may require manual `RECOVER`.

For the current RisingWave Pulsar source, the stream is unbounded, so SDK consumer termination is unexpected and should be retriable rather than treated as idleness or clean completion.

## User / operator impact

Instead of a hidden ingestion stall, unexpected Pulsar consumer termination should now become visible through the existing source reader error path and trigger the existing 1s retry/rebuild behavior. The error message includes context such as source id/name, actor id, fragment id, split id, and topic.

## Notes

A direct unit test for `PulsarConsumeStream::poll_next` with SDK `Ready(None)` would require faking or constructing `pulsar::Consumer`, whose inner state is private in `pulsar-6.7.1`. This PR intentionally avoids adding test-only abstraction or an error-message-only unit test that would not lock the changed `poll_next` behavior.

Future bounded Pulsar source semantics should revisit whether SDK `Ready(None)` can represent legitimate completion.

## Checks

- `cargo fmt --check`
- `cargo check -p risingwave_connector --lib`
- `git diff --check -- src/connector/src/source/pulsar/source/reader.rs`
