### PR TITLE
test(sink): retry ALTER SINK CONNECTOR in jdbc alter-props e2e to de-flake

### DIFF
--- a/e2e_test/sink/remote/jdbc.alter_connector_props.slt
+++ b/e2e_test/sink/remote/jdbc.alter_connector_props.slt
@@ -17,7 +17,8 @@ CREATE SINK s_jdbc_alter_props FROM t_jdbc_alter_src WITH (
     primary_key = 'id'
 );
 
-statement ok
+# See https://github.com/risingwavelabs/risingwave/issues/26159.
+statement ok retry 3 backoff 5s
 ALTER SINK s_jdbc_alter_props CONNECTOR WITH (
     jdbc.url = 'jdbc:postgresql://db:5432/test',
     user = 'test',


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

Test-level mitigation for the flaky `e2e_test/sink/remote/jdbc.alter_connector_props.slt` (#26159): add `retry 3 backoff 5s` to the `ALTER SINK ... CONNECTOR` statement.

Why it flakes (full RCA in #26159): with `sink_decouple = false` the sink uses the in-memory log store (`ALLOW_REWIND = false`), so `ALTER SINK ... CONNECTOR` applies the new config by intentionally erroring the sink actors to trigger recovery — while the `AlterConnectorProps` RPC is still waiting for the props-change barrier to be collected. The statement succeeds only if barrier collection + checkpoint sync completes before the intentionally-killed actors take the graph down. On a loaded CI host (5 s minio write timeouts in build 97788), the sync stalled, recovery won the race, and the pending command was aborted with `failed to collect barrier`.

Retrying is safe here: the catalog props are updated before the barrier command, so a retry re-applies the same props idempotently; it only needs recovery to finish, which `backoff 5s` accommodates.

This does not fix the underlying design race (tracked in #26159) nor the delayed failure-notification bug (#26158) — it only de-flakes the test.

- Mitigates #26159

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [x] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
