### PR TITLE
fix(meta): support large meta snapshot JSON lengths

### DIFF
--- a/src/storage/backup/src/meta_snapshot_v2.rs
+++ b/src/storage/backup/src/meta_snapshot_v2.rs
@@ -279,18 +279,106 @@ fn get_1<'a, T: Deserialize<'a>>(buf: &mut &'a [u8]) -> Result<T, serde_json::Er
 
 fn put_with_len_prefix<T: Serialize>(buf: &mut Vec<u8>, data: &T) -> Result<(), serde_json::Error> {
     let b = serde_json::to_vec(data)?;
-    buf.put_u32_le(
-        b.len()
-            .try_into()
-            .unwrap_or_else(|_| panic!("cannot convert {} into u32", b.len())),
-    );
+    // Any valid JSON value serialized by serde_json is non-empty, such as `null`, `{}`, or `[]`.
+    assert!(!b.is_empty());
+    if let Ok(len) = u32::try_from(b.len()) {
+        buf.put_u32_le(len);
+    } else {
+        buf.put_u32_le(0);
+        buf.put_u64_le(
+            b.len()
+                .try_into()
+                .unwrap_or_else(|_| panic!("cannot convert {} into u64", b.len())),
+        );
+    }
     buf.put_slice(&b);
     Ok(())
 }
 
 fn get_with_len_prefix<'a, T: Deserialize<'a>>(buf: &mut &'a [u8]) -> Result<T, serde_json::Error> {
-    let len = buf.get_u32_le() as usize;
+    let len = match buf.get_u32_le() {
+        0 => {
+            let len = buf.get_u64_le();
+            len.try_into()
+                .unwrap_or_else(|_| panic!("cannot convert {} into usize", len))
+        }
+        len => len as usize,
+    };
+    assert!(
+        buf.remaining() >= len,
+        "JSON payload length {} exceeds remaining buffer {}",
+        len,
+        buf.remaining()
+    );
     let d = serde_json::from_slice(&buf[..len])?;
     buf.advance(len);
     Ok(d)
+}
+
+#[cfg(test)]
+mod tests {
+    use bytes::BufMut;
+
+    use super::*;
+
+    #[test]
+    fn test_len_prefix_legacy_u32_round_trip() {
+        let mut buf = vec![];
+        put_with_len_prefix(&mut buf, &"hello").unwrap();
+
+        assert_ne!(u32::from_le_bytes(buf[..4].try_into().unwrap()), 0);
+
+        let decoded: String = get_with_len_prefix(&mut buf.as_slice()).unwrap();
+        assert_eq!(decoded, "hello");
+    }
+
+    #[test]
+    fn test_len_prefix_extended_u64_decoding() {
+        let payload = serde_json::to_vec("hello").unwrap();
+        let mut buf = vec![];
+        buf.put_u32_le(0);
+        buf.put_u64_le(payload.len() as u64);
+        buf.put_slice(&payload);
+
+        let decoded: String = get_with_len_prefix(&mut buf.as_slice()).unwrap();
+        assert_eq!(decoded, "hello");
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_len_prefix_panics_on_missing_extended_u64() {
+        let mut buf = vec![];
+        buf.put_u32_le(0);
+
+        let _ = get_with_len_prefix::<String>(&mut buf.as_slice());
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_len_prefix_panics_on_payload_shorter_than_declared_len() {
+        let mut buf = vec![];
+        buf.put_u32_le(100);
+        buf.put_slice(br#""hello""#);
+
+        let _ = get_with_len_prefix::<String>(&mut buf.as_slice());
+    }
+
+    #[test]
+    fn test_snapshot_v2_legacy_encoding_decoding() {
+        let raw = MetaSnapshotV2 {
+            format_version: 2,
+            id: 123,
+            metadata: MetadataV2::default(),
+        };
+
+        let encoded = raw.encode().unwrap();
+        let decoded = MetaSnapshotV2::decode(&encoded).unwrap();
+
+        assert_eq!(decoded.format_version, raw.format_version);
+        assert_eq!(decoded.id, raw.id);
+        assert_eq!(
+            decoded.metadata.hummock_version.id,
+            raw.metadata.hummock_version.id
+        );
+    }
 }


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

This PR updates the V2 meta snapshot binary format for per-item JSON payload lengths. Existing snapshots still use the legacy non-zero `u32le` length prefix. For JSON payloads larger than `u32::MAX`, the encoder now writes `u32le(0)` followed by a `u64le` payload length.

The decoder treats a zero `u32le` JSON length as the extended `u64le` path. Vector counts are unchanged and remain `u32le`, because zero is valid for section counts. Corrupt or truncated buffers still panic like the previous implementation; the new bounds assertion makes the oversized-length case explicit before slicing.

This avoids the meta backup panic when a single serialized metadata item, typically the Hummock version payload, exceeds the old `u32` JSON length limit.

## Checklist

- [ ] I have written necessary rustdoc comments.
- [x] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [x] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

Meta backup can now encode very large per-item metadata JSON payloads by using an extended length prefix when the payload exceeds the previous `u32` limit.

</details>