### PR TITLE
fix(meta): send notification service responses zstd-compressed

### DIFF
--- a/src/meta/node/src/server.rs
+++ b/src/meta/node/src/server.rs
@@ -777,7 +777,14 @@ pub async fn start_service_as_election_leader(
         .add_service(
             HummockManagerServiceServer::new(hummock_srv).max_decoding_message_size(usize::MAX),
         )
-        .add_service(NotificationServiceServer::new(notification_srv))
+        // Compress notifications with zstd for clients that accept it (older clients still
+        // get uncompressed responses). The initial `MetaSnapshot` carries the full hummock
+        // version; uncompressed messages larger than `i32::MAX` bytes are silently reset by
+        // hyper/h2, so compression keeps large snapshots deliverable.
+        .add_service(
+            NotificationServiceServer::new(notification_srv)
+                .send_compressed(tonic::codec::CompressionEncoding::Zstd),
+        )
         .add_service(MetaMemberServiceServer::new(meta_member_srv))
         .add_service(DdlServiceServer::new(ddl_srv).max_decoding_message_size(usize::MAX))
         .add_service(UserServiceServer::new(user_srv))

--- a/src/rpc_client/src/meta_client.rs
+++ b/src/rpc_client/src/meta_client.rs
@@ -2293,8 +2293,12 @@ impl GrpcMetaClientCore {
             DdlServiceClient::new(channel.clone()).max_decoding_message_size(usize::MAX);
         let hummock_client =
             HummockManagerServiceClient::new(channel.clone()).max_decoding_message_size(usize::MAX);
-        let notification_client =
-            NotificationServiceClient::new(channel.clone()).max_decoding_message_size(usize::MAX);
+        // Accept zstd-compressed notifications: the initial `MetaSnapshot` on `Subscribe`
+        // carries the full hummock version, and a single uncompressed gRPC message larger
+        // than `i32::MAX` bytes is silently reset by hyper/h2 and can never be delivered.
+        let notification_client = NotificationServiceClient::new(channel.clone())
+            .accept_compressed(tonic::codec::CompressionEncoding::Zstd)
+            .max_decoding_message_size(usize::MAX);
         let stream_client =
             StreamManagerServiceClient::new(channel.clone()).max_decoding_message_size(usize::MAX);
         let user_client = UserServiceClient::new(channel.clone());


### PR DESCRIPTION
## What's changed and what's your intention?

The initial `MetaSnapshot` sent on `NotificationService::Subscribe` contains the full hummock version. On clusters with large table change logs (e.g. many subscriptions with long retention), the serialized snapshot can exceed **`i32::MAX` bytes** — and such a message can never be delivered:

- tonic encodes one gRPC message as **one body chunk**; its own send-size check only rejects at `u32::MAX` (4 GiB).
- hyper/h2 rejects any single chunk larger than the HTTP/2 flow-control limit (`MAX_WINDOW_SIZE` = `i32::MAX`) with `PayloadTooBig`, and the stream is **silently reset** with `RST_STREAM(CANCEL)` — zero bytes on the wire, no error logged on either side.
- The subscribing node (compute/frontend/compactor) sees a clean stream end (`Ok(None)`), logs `Receives meta's notification err: notification channel closed`, re-subscribes 100ms later, and loops forever. Compute nodes never finish startup (port 5688 never opens), so the whole cluster is stuck in recovery.

We hit this in production: a cluster with 72 subscriptions (`retention='3D'`) accumulated enough table change log for the snapshot to cross `i32::MAX`; after a restart, all compute nodes crash-looped on the notification subscribe and the cluster could not recover.

This PR compresses notification responses with zstd, the same approach as #25208 took for `MonitorService`. The hummock version protobuf is highly repetitive and compresses well, keeping large snapshots far below the h2 limit.

### Verification

Bisected with a minimal tonic reproduction (vanilla tonic 0.12.3, single server-streaming message, `UnboundedReceiverStream` like meta):

| encoded message size | result |
|---|---|
| `i32::MAX - 6` | transfers fully |
| `i32::MAX + 4` | silent `RST_STREAM(CANCEL)`, zero bytes |

The same encode path and h2 check exist unchanged in tonic 0.14 / latest h2, so upgrading tonic does not help.

### Compatibility

`send_compressed` only compresses for clients that advertise `grpc-accept-encoding: zstd`, so mixed-version clusters keep working: older nodes still receive uncompressed responses; new clients against old meta simply don't get compression.

### Note

This buys headroom but is not the whole fix for unbounded snapshot growth — truncating stale table change logs (and chunking the snapshot into multiple messages) are follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)