### PR TITLE
refactor(connector): resolve Iceberg catalog config

### DIFF
--- a/e2e_test/iceberg/test_case/pure_slt/iceberg_engine.slt
+++ b/e2e_test/iceberg/test_case/pure_slt/iceberg_engine.slt
@@ -48,7 +48,7 @@ insert into t(id, name) values(2, 'yyy');
 statement ok
 FLUSH;
 
-query ?? retry 6 backoff 1s
+query ?? rowsort retry 6 backoff 1s
 select * from t;
 ----
 1 xxx

--- a/src/connector/src/connector_common/connection.rs
+++ b/src/connector/src/connector_common/connection.rs
@@ -178,14 +178,13 @@ impl EnforceSecret for IcebergConnection {
 impl Connection for IcebergConnection {
     async fn validate_connection(&self) -> ConnectorResult<()> {
         let common = &self.common;
+        let is_rest_catalog = common.is_rest_catalog()?;
 
         let info = match &common.warehouse_path {
             Some(warehouse_path) => {
                 let is_s3_tables = warehouse_path.starts_with("arn:aws:s3tables");
                 let url = Url::parse(warehouse_path);
-                if (url.is_err() || is_s3_tables)
-                    && matches!(common.catalog_type(), "rest" | "rest_rust")
-                {
+                if (url.is_err() || is_s3_tables) && is_rest_catalog {
                     // If the warehouse path is not a valid URL, it could be a warehouse name in rest catalog,
                     // Or it could be a s3tables path, which is not a valid URL but a valid warehouse path,
                     // so we allow it to pass here.
@@ -204,7 +203,7 @@ impl Connection for IcebergConnection {
                 }
             }
             None => {
-                if matches!(common.catalog_type(), "rest" | "rest_rust") {
+                if is_rest_catalog {
                     None
                 } else {
                     bail!("`warehouse.path` must be set");
@@ -303,7 +302,10 @@ impl Connection for IcebergConnection {
         if let Some(jdbc_password) = &self.jdbc_password {
             java_map.insert("jdbc.password".to_owned(), jdbc_password.to_owned());
         }
-        let catalog = iceberg_common.create_catalog(&java_map).await?;
+        let catalog = iceberg_common
+            .resolve_catalog_config(java_map)?
+            .create_catalog()
+            .await?;
         // test catalog by `table_exists` api
         let test_table_ident = IcebergTableIdentifier {
             database_name: Some("test_database".to_owned()),

--- a/src/connector/src/connector_common/iceberg/mod.rs
+++ b/src/connector/src/connector_common/iceberg/mod.rs
@@ -323,6 +323,8 @@ impl IcebergCatalogKind {
             "jdbc" => Self::Jdbc,
             "snowflake" => Self::Snowflake,
             "mock" => Self::Mock,
+            #[cfg(any(test, madsim))]
+            "mock_v3" => Self::Mock,
             _ => {
                 bail!(
                     "Unsupported catalog type: {}, only support `storage`, `rest`, `hive`, `jdbc`, `glue`, `snowflake`",
@@ -1282,6 +1284,16 @@ mod tests {
         assert_eq!(
             common.resolve_catalog_kind().unwrap(),
             IcebergCatalogKind::Rest(IcebergCatalogRuntime::JavaJni)
+        );
+    }
+
+    #[test]
+    fn test_mock_v3_resolves_to_mock_catalog_for_simulation_tests() {
+        let common = test_common("mock_v3");
+
+        assert_eq!(
+            common.resolve_catalog_kind().unwrap(),
+            IcebergCatalogKind::Mock
         );
     }
 

--- a/src/connector/src/connector_common/iceberg/mod.rs
+++ b/src/connector/src/connector_common/iceberg/mod.rs
@@ -292,18 +292,234 @@ impl IcebergTableIdentifier {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum IcebergCatalogRuntime {
+    NativeRust,
+    JavaJni,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum IcebergCatalogKind {
+    Storage,
+    Rest(IcebergCatalogRuntime),
+    Glue(IcebergCatalogRuntime),
+    Hive,
+    Jdbc,
+    Snowflake,
+    Mock,
+}
+
+impl IcebergCatalogKind {
+    fn resolve(common: &IcebergCommon) -> ConnectorResult<Self> {
+        let catalog_type = common.catalog_type();
+        let kind = match catalog_type {
+            "storage" => Self::Storage,
+            "rest" if common.vended_credentials() => Self::Rest(IcebergCatalogRuntime::NativeRust),
+            "rest" => Self::Rest(IcebergCatalogRuntime::JavaJni),
+            "rest_rust" => Self::Rest(IcebergCatalogRuntime::NativeRust),
+            "glue" => Self::Glue(IcebergCatalogRuntime::JavaJni),
+            "glue_rust" => Self::Glue(IcebergCatalogRuntime::NativeRust),
+            "hive" => Self::Hive,
+            "jdbc" => Self::Jdbc,
+            "snowflake" => Self::Snowflake,
+            "mock" => Self::Mock,
+            _ => {
+                bail!(
+                    "Unsupported catalog type: {}, only support `storage`, `rest`, `hive`, `jdbc`, `glue`, `snowflake`",
+                    catalog_type
+                )
+            }
+        };
+        Ok(kind)
+    }
+
+    pub fn is_rest(self) -> bool {
+        matches!(self, Self::Rest(_))
+    }
+
+    fn jni_impl(self) -> Option<JniCatalogImpl> {
+        match self {
+            Self::Rest(IcebergCatalogRuntime::JavaJni) => Some(JniCatalogImpl::Rest),
+            Self::Glue(IcebergCatalogRuntime::JavaJni) => Some(JniCatalogImpl::Glue),
+            Self::Hive => Some(JniCatalogImpl::Hive),
+            Self::Jdbc => Some(JniCatalogImpl::Jdbc),
+            Self::Snowflake => Some(JniCatalogImpl::Snowflake),
+            _ => None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum JniCatalogImpl {
+    Hive,
+    Jdbc,
+    Snowflake,
+    Rest,
+    Glue,
+}
+
+impl JniCatalogImpl {
+    fn catalog_type(self) -> &'static str {
+        match self {
+            Self::Hive => "hive",
+            Self::Jdbc => "jdbc",
+            Self::Snowflake => "snowflake",
+            Self::Rest => "rest",
+            Self::Glue => "glue",
+        }
+    }
+
+    fn class_name(self) -> &'static str {
+        match self {
+            Self::Hive => "org.apache.iceberg.hive.HiveCatalog",
+            Self::Jdbc => "org.apache.iceberg.jdbc.JdbcCatalog",
+            Self::Snowflake => "org.apache.iceberg.snowflake.SnowflakeCatalog",
+            Self::Rest => "org.apache.iceberg.rest.RESTCatalog",
+            Self::Glue => "org.apache.iceberg.aws.glue.GlueCatalog",
+        }
+    }
+}
+
+enum CatalogBuildPlan {
+    Storage(StorageCatalogConfig),
+    NativeRest(HashMap<String, String>),
+    NativeGlue(HashMap<String, String>),
+    Jni {
+        file_io_props: HashMap<String, String>,
+        catalog_name: String,
+        catalog_impl: JniCatalogImpl,
+        java_catalog_props: HashMap<String, String>,
+    },
+    Mock,
+}
+
+pub struct ResolvedIcebergCatalogConfig<'a> {
+    common: &'a IcebergCommon,
+    kind: IcebergCatalogKind,
+    java_catalog_props: HashMap<String, String>,
+}
+
+impl<'a> ResolvedIcebergCatalogConfig<'a> {
+    pub fn kind(&self) -> IcebergCatalogKind {
+        self.kind
+    }
+
+    fn build_plan(&self) -> ConnectorResult<CatalogBuildPlan> {
+        match self.kind {
+            IcebergCatalogKind::Storage => self.common.build_storage_catalog_config(),
+            IcebergCatalogKind::Rest(IcebergCatalogRuntime::NativeRust) => {
+                self.common.build_native_rest_catalog_props()
+            }
+            IcebergCatalogKind::Glue(IcebergCatalogRuntime::NativeRust) => {
+                self.common.build_native_glue_catalog_props()
+            }
+            IcebergCatalogKind::Mock => Ok(CatalogBuildPlan::Mock),
+            kind => {
+                let catalog_impl = kind.jni_impl().expect("java catalog kind has JNI impl");
+                let (file_io_props, java_catalog_props) = self
+                    .common
+                    .build_jni_catalog_configs(catalog_impl, &self.java_catalog_props)?;
+                Ok(CatalogBuildPlan::Jni {
+                    file_io_props,
+                    catalog_name: self.common.catalog_name(),
+                    catalog_impl,
+                    java_catalog_props,
+                })
+            }
+        }
+    }
+
+    pub async fn create_catalog(&self) -> ConnectorResult<Arc<dyn Catalog>> {
+        match self.build_plan()? {
+            CatalogBuildPlan::Storage(config) => {
+                let catalog = storage_catalog::StorageCatalog::new(config)?;
+                Ok(Arc::new(catalog))
+            }
+            CatalogBuildPlan::NativeRest(iceberg_configs) => {
+                let catalog = iceberg_catalog_rest::RestCatalogBuilder::default()
+                    .load("rest", iceberg_configs)
+                    .await
+                    .map_err(|e| anyhow!(IcebergError::from(e)))?;
+                Ok(Arc::new(catalog))
+            }
+            CatalogBuildPlan::NativeGlue(iceberg_configs) => {
+                let catalog = iceberg_catalog_glue::GlueCatalogBuilder::default()
+                    .load("glue", iceberg_configs)
+                    .await
+                    .map_err(|e| anyhow!(IcebergError::from(e)))?;
+                Ok(Arc::new(catalog))
+            }
+            CatalogBuildPlan::Jni {
+                file_io_props,
+                catalog_name,
+                catalog_impl,
+                java_catalog_props,
+            } => jni_catalog::JniCatalog::build_catalog(
+                file_io_props,
+                catalog_name,
+                catalog_impl.class_name(),
+                java_catalog_props,
+            ),
+            CatalogBuildPlan::Mock => Ok(Arc::new(mock_catalog::MockCatalog {})),
+        }
+    }
+
+    pub async fn load_table(&self, table: &IcebergTableIdentifier) -> ConnectorResult<Table> {
+        let catalog = self
+            .create_catalog()
+            .await
+            .context("Unable to load iceberg catalog")?;
+
+        let table_id = table
+            .to_table_ident()
+            .context("Unable to parse table name")?;
+
+        let table = catalog.load_table(&table_id).await?;
+        Ok(rebuild_table_with_shared_cache(table).await)
+    }
+}
+
+pub fn iceberg_java_catalog_props_from_options<'a>(
+    options: impl Iterator<Item = (&'a str, &'a str)>,
+) -> HashMap<String, String> {
+    options
+        .filter(|(k, _v)| {
+            k.starts_with("catalog.")
+                && k != &"catalog.uri"
+                && k != &"catalog.type"
+                && k != &"catalog.name"
+                && k != &"catalog.header"
+        })
+        .map(|(k, v)| (k[8..].to_owned(), v.to_owned()))
+        .collect()
+}
+
 impl IcebergCommon {
     pub fn catalog_type(&self) -> &str {
-        let catalog_type: &str = self.catalog_type.as_deref().unwrap_or("storage");
-        if self.vended_credentials() && catalog_type == "rest" {
-            "rest_rust"
-        } else {
-            catalog_type
-        }
+        self.catalog_type.as_deref().unwrap_or("storage")
     }
 
     pub fn vended_credentials(&self) -> bool {
         self.vended_credentials.unwrap_or(false)
+    }
+
+    pub fn resolve_catalog_kind(&self) -> ConnectorResult<IcebergCatalogKind> {
+        IcebergCatalogKind::resolve(self)
+    }
+
+    pub fn is_rest_catalog(&self) -> ConnectorResult<bool> {
+        Ok(self.resolve_catalog_kind()?.is_rest())
+    }
+
+    pub fn resolve_catalog_config(
+        &self,
+        java_catalog_props: HashMap<String, String>,
+    ) -> ConnectorResult<ResolvedIcebergCatalogConfig<'_>> {
+        Ok(ResolvedIcebergCatalogConfig {
+            common: self,
+            kind: self.resolve_catalog_kind()?,
+            java_catalog_props,
+        })
     }
 
     fn glue_access_key(&self) -> Option<&str> {
@@ -369,22 +585,175 @@ impl IcebergCommon {
         self.enable_config_load.unwrap_or(false)
     }
 
+    fn build_storage_catalog_config(&self) -> ConnectorResult<CatalogBuildPlan> {
+        let warehouse = self
+            .warehouse_path
+            .clone()
+            .ok_or_else(|| anyhow!("`warehouse.path` must be set in storage catalog"))?;
+        let url = Url::parse(warehouse.as_ref())
+            .map_err(|_| anyhow!("Invalid warehouse path: {}", warehouse))?;
+
+        let config = match url.scheme() {
+            "s3" | "s3a" => StorageCatalogConfig::S3(
+                storage_catalog::StorageCatalogS3Config::builder()
+                    .warehouse(warehouse)
+                    .access_key(self.s3_access_key.clone())
+                    .secret_key(self.s3_secret_key.clone())
+                    .region(self.s3_region.clone())
+                    .endpoint(self.s3_endpoint.clone())
+                    .path_style_access(self.s3_path_style_access)
+                    .enable_config_load(Some(self.enable_config_load()))
+                    .build(),
+            ),
+            "gs" | "gcs" => StorageCatalogConfig::Gcs(
+                storage_catalog::StorageCatalogGcsConfig::builder()
+                    .warehouse(warehouse)
+                    .credential(self.gcs_credential.clone())
+                    .enable_config_load(Some(self.enable_config_load()))
+                    .build(),
+            ),
+            "azblob" => StorageCatalogConfig::Azblob(
+                storage_catalog::StorageCatalogAzblobConfig::builder()
+                    .warehouse(warehouse)
+                    .account_name(self.azblob_account_name.clone())
+                    .account_key(self.azblob_account_key.clone())
+                    .endpoint(self.azblob_endpoint_url.clone())
+                    .build(),
+            ),
+            scheme => bail!("Unsupported warehouse scheme: {}", scheme),
+        };
+
+        Ok(CatalogBuildPlan::Storage(config))
+    }
+
+    fn build_native_rest_catalog_props(&self) -> ConnectorResult<CatalogBuildPlan> {
+        let mut iceberg_configs = HashMap::new();
+
+        // check gcs credential or s3 access key and secret key
+        if let Some(gcs_credential) = &self.gcs_credential {
+            iceberg_configs.insert(GCS_CREDENTIALS_JSON.to_owned(), gcs_credential.clone());
+        } else {
+            if let Some(region) = &self.s3_region {
+                iceberg_configs.insert(S3_REGION.to_owned(), region.clone());
+            }
+            if let Some(endpoint) = &self.s3_endpoint {
+                iceberg_configs.insert(S3_ENDPOINT.to_owned(), endpoint.clone());
+            }
+            if let Some(access_key) = &self.s3_access_key {
+                iceberg_configs.insert(S3_ACCESS_KEY_ID.to_owned(), access_key.clone());
+            }
+            if let Some(secret_key) = &self.s3_secret_key {
+                iceberg_configs.insert(S3_SECRET_ACCESS_KEY.to_owned(), secret_key.clone());
+            }
+            if let Some(path_style_access) = &self.s3_path_style_access {
+                iceberg_configs.insert(
+                    S3_PATH_STYLE_ACCESS.to_owned(),
+                    path_style_access.to_string(),
+                );
+            }
+        };
+
+        if let Some(credential) = &self.catalog_credential {
+            iceberg_configs.insert("credential".to_owned(), credential.clone());
+        }
+        if let Some(token) = &self.catalog_token {
+            iceberg_configs.insert("token".to_owned(), token.clone());
+        }
+        if let Some(oauth2_server_uri) = &self.catalog_oauth2_server_uri {
+            iceberg_configs.insert("oauth2-server-uri".to_owned(), oauth2_server_uri.clone());
+        }
+        if let Some(scope) = &self.catalog_scope {
+            iceberg_configs.insert("scope".to_owned(), scope.clone());
+        }
+
+        let headers = self.headers()?;
+        for (header_name, header_value) in headers {
+            iceberg_configs.insert(format!("header.{}", header_name), header_value);
+        }
+
+        iceberg_configs.insert(
+            iceberg_catalog_rest::REST_CATALOG_PROP_URI.to_owned(),
+            self.catalog_uri
+                .clone()
+                .with_context(|| "`catalog.uri` must be set in rest catalog".to_owned())?,
+        );
+        if let Some(warehouse_path) = &self.warehouse_path {
+            iceberg_configs.insert(
+                iceberg_catalog_rest::REST_CATALOG_PROP_WAREHOUSE.to_owned(),
+                warehouse_path.clone(),
+            );
+        }
+
+        Ok(CatalogBuildPlan::NativeRest(iceberg_configs))
+    }
+
+    fn build_native_glue_catalog_props(&self) -> ConnectorResult<CatalogBuildPlan> {
+        let mut iceberg_configs = HashMap::new();
+        // glue
+        if let Some(region) = self.glue_region() {
+            iceberg_configs.insert(AWS_REGION_NAME.to_owned(), region.to_owned());
+        }
+        if let Some(access_key) = self.glue_access_key() {
+            iceberg_configs.insert(AWS_ACCESS_KEY_ID.to_owned(), access_key.to_owned());
+        }
+        if let Some(secret_key) = self.glue_secret_key() {
+            iceberg_configs.insert(AWS_SECRET_ACCESS_KEY.to_owned(), secret_key.to_owned());
+        }
+        // s3
+        if let Some(region) = &self.s3_region {
+            iceberg_configs.insert(S3_REGION.to_owned(), region.clone());
+        }
+        if let Some(endpoint) = &self.s3_endpoint {
+            iceberg_configs.insert(S3_ENDPOINT.to_owned(), endpoint.clone());
+        }
+        if let Some(access_key) = &self.s3_access_key {
+            iceberg_configs.insert(S3_ACCESS_KEY_ID.to_owned(), access_key.clone());
+        }
+        if let Some(secret_key) = &self.s3_secret_key {
+            iceberg_configs.insert(S3_SECRET_ACCESS_KEY.to_owned(), secret_key.clone());
+        }
+        if let Some(role_arn) = &self.s3_iam_role_arn {
+            iceberg_configs.insert(S3_ASSUME_ROLE_ARN.to_owned(), role_arn.clone());
+        }
+        if let Some(path_style_access) = &self.s3_path_style_access {
+            iceberg_configs.insert(
+                S3_PATH_STYLE_ACCESS.to_owned(),
+                path_style_access.to_string(),
+            );
+        }
+        iceberg_configs.insert(
+            iceberg_catalog_glue::GLUE_CATALOG_PROP_WAREHOUSE.to_owned(),
+            self.warehouse_path
+                .clone()
+                .ok_or_else(|| anyhow!("`warehouse.path` must be set in glue catalog"))?,
+        );
+        if let Some(uri) = self.catalog_uri.as_deref() {
+            iceberg_configs.insert(
+                iceberg_catalog_glue::GLUE_CATALOG_PROP_URI.to_owned(),
+                uri.to_owned(),
+            );
+        }
+
+        Ok(CatalogBuildPlan::NativeGlue(iceberg_configs))
+    }
+
     /// For both V1 and V2.
     fn build_jni_catalog_configs(
         &self,
+        catalog_impl: JniCatalogImpl,
         java_catalog_props: &HashMap<String, String>,
     ) -> ConnectorResult<(HashMap<String, String>, HashMap<String, String>)> {
         let mut iceberg_configs = HashMap::new();
         let enable_config_load = self.enable_config_load();
         let file_io_props = {
-            let catalog_type = self.catalog_type().to_owned();
+            let catalog_type = catalog_impl.catalog_type();
 
             // Non-S3/Glue object-store backends only work with a REST catalog. This
             // function is only invoked for catalog_type in {hive, snowflake, jdbc, rest,
             // glue}, so the only accepted value here is "rest".
             let require_rest = |backend: &str| -> ConnectorResult<()> {
-                if catalog_type != "rest" {
-                    bail!("{} unsupported in {} catalog", backend, &catalog_type);
+                if catalog_impl != JniCatalogImpl::Rest {
+                    bail!("{} unsupported in {} catalog", backend, catalog_type);
                 }
                 Ok(())
             };
@@ -522,7 +891,7 @@ impl IcebergCommon {
                         let is_bq_catalog_federation = warehouse_path.starts_with("bq://");
                         let url = Url::parse(warehouse_path);
                         if (url.is_err() || is_s3_tables || is_bq_catalog_federation)
-                            && (catalog_type == "rest" || catalog_type == "rest_rust")
+                            && catalog_impl == JniCatalogImpl::Rest
                         {
                             // If the warehouse path is not a valid URL, it could be:
                             // - A warehouse name in REST catalog
@@ -553,8 +922,8 @@ impl IcebergCommon {
                     }
                 }
                 None => {
-                    if catalog_type != "rest" && catalog_type != "rest_rust" {
-                        bail!("`warehouse.path` must be set in {} catalog", &catalog_type);
+                    if catalog_impl != JniCatalogImpl::Rest {
+                        bail!("`warehouse.path` must be set in {} catalog", catalog_type);
                     }
                 }
             }
@@ -626,8 +995,8 @@ impl IcebergCommon {
                 java_catalog_configs.insert(format!("header.{}", header_name), header_value);
             }
 
-            match self.catalog_type() {
-                "rest" => {
+            match catalog_impl {
+                JniCatalogImpl::Rest => {
                     // Handle security type for REST catalog (Iceberg 1.10+)
                     if let Some(security) = &self.catalog_security {
                         match security.to_lowercase().as_str() {
@@ -718,7 +1087,7 @@ impl IcebergCommon {
                         }
                     }
                 }
-                "glue" => {
+                JniCatalogImpl::Glue => {
                     let glue_access_key = self.glue_access_key();
                     let glue_secret_key = self.glue_secret_key();
                     let has_glue_credentials =
@@ -778,7 +1147,7 @@ impl IcebergCommon {
                     }
                     self.apply_java_s3_file_io_assume_role_configs(&mut java_catalog_configs);
                 }
-                "jdbc" => {
+                JniCatalogImpl::Jdbc => {
                     self.apply_java_aws_client_assume_role_configs(&mut java_catalog_configs);
                 }
                 _ => {}
@@ -815,226 +1184,6 @@ impl IcebergCommon {
                 java_catalog_configs.insert("client.assume-role.region".to_owned(), region.clone());
             }
         }
-    }
-}
-
-impl IcebergCommon {
-    /// TODO: remove the arguments and put them into `IcebergCommon`. Currently the handling in source and sink are different, so pass them separately to be safer.
-    pub async fn create_catalog(
-        &self,
-        java_catalog_props: &HashMap<String, String>,
-    ) -> ConnectorResult<Arc<dyn Catalog>> {
-        match self.catalog_type() {
-            "storage" => {
-                let warehouse = self
-                    .warehouse_path
-                    .clone()
-                    .ok_or_else(|| anyhow!("`warehouse.path` must be set in storage catalog"))?;
-                let url = Url::parse(warehouse.as_ref())
-                    .map_err(|_| anyhow!("Invalid warehouse path: {}", warehouse))?;
-
-                let config = match url.scheme() {
-                    "s3" | "s3a" => StorageCatalogConfig::S3(
-                        storage_catalog::StorageCatalogS3Config::builder()
-                            .warehouse(warehouse)
-                            .access_key(self.s3_access_key.clone())
-                            .secret_key(self.s3_secret_key.clone())
-                            .region(self.s3_region.clone())
-                            .endpoint(self.s3_endpoint.clone())
-                            .path_style_access(self.s3_path_style_access)
-                            .enable_config_load(Some(self.enable_config_load()))
-                            .build(),
-                    ),
-                    "gs" | "gcs" => StorageCatalogConfig::Gcs(
-                        storage_catalog::StorageCatalogGcsConfig::builder()
-                            .warehouse(warehouse)
-                            .credential(self.gcs_credential.clone())
-                            .enable_config_load(Some(self.enable_config_load()))
-                            .build(),
-                    ),
-                    "azblob" => StorageCatalogConfig::Azblob(
-                        storage_catalog::StorageCatalogAzblobConfig::builder()
-                            .warehouse(warehouse)
-                            .account_name(self.azblob_account_name.clone())
-                            .account_key(self.azblob_account_key.clone())
-                            .endpoint(self.azblob_endpoint_url.clone())
-                            .build(),
-                    ),
-                    scheme => bail!("Unsupported warehouse scheme: {}", scheme),
-                };
-
-                let catalog = storage_catalog::StorageCatalog::new(config)?;
-                Ok(Arc::new(catalog))
-            }
-            "rest_rust" => {
-                let mut iceberg_configs = HashMap::new();
-
-                // check gcs credential or s3 access key and secret key
-                if let Some(gcs_credential) = &self.gcs_credential {
-                    iceberg_configs.insert(GCS_CREDENTIALS_JSON.to_owned(), gcs_credential.clone());
-                } else {
-                    if let Some(region) = &self.s3_region {
-                        iceberg_configs.insert(S3_REGION.to_owned(), region.clone());
-                    }
-                    if let Some(endpoint) = &self.s3_endpoint {
-                        iceberg_configs.insert(S3_ENDPOINT.to_owned(), endpoint.clone());
-                    }
-                    if let Some(access_key) = &self.s3_access_key {
-                        iceberg_configs.insert(S3_ACCESS_KEY_ID.to_owned(), access_key.clone());
-                    }
-                    if let Some(secret_key) = &self.s3_secret_key {
-                        iceberg_configs.insert(S3_SECRET_ACCESS_KEY.to_owned(), secret_key.clone());
-                    }
-                    if let Some(path_style_access) = &self.s3_path_style_access {
-                        iceberg_configs.insert(
-                            S3_PATH_STYLE_ACCESS.to_owned(),
-                            path_style_access.to_string(),
-                        );
-                    }
-                };
-
-                if let Some(credential) = &self.catalog_credential {
-                    iceberg_configs.insert("credential".to_owned(), credential.clone());
-                }
-                if let Some(token) = &self.catalog_token {
-                    iceberg_configs.insert("token".to_owned(), token.clone());
-                }
-                if let Some(oauth2_server_uri) = &self.catalog_oauth2_server_uri {
-                    iceberg_configs
-                        .insert("oauth2-server-uri".to_owned(), oauth2_server_uri.clone());
-                }
-                if let Some(scope) = &self.catalog_scope {
-                    iceberg_configs.insert("scope".to_owned(), scope.clone());
-                }
-
-                let headers = self.headers()?;
-                for (header_name, header_value) in headers {
-                    iceberg_configs.insert(format!("header.{}", header_name), header_value);
-                }
-
-                iceberg_configs.insert(
-                    iceberg_catalog_rest::REST_CATALOG_PROP_URI.to_owned(),
-                    self.catalog_uri
-                        .clone()
-                        .with_context(|| "`catalog.uri` must be set in rest catalog".to_owned())?,
-                );
-                if let Some(warehouse_path) = &self.warehouse_path {
-                    iceberg_configs.insert(
-                        iceberg_catalog_rest::REST_CATALOG_PROP_WAREHOUSE.to_owned(),
-                        warehouse_path.clone(),
-                    );
-                }
-                let catalog = iceberg_catalog_rest::RestCatalogBuilder::default()
-                    .load("rest", iceberg_configs)
-                    .await
-                    .map_err(|e| anyhow!(IcebergError::from(e)))?;
-                Ok(Arc::new(catalog))
-            }
-            "glue_rust" => {
-                let mut iceberg_configs = HashMap::new();
-                // glue
-                if let Some(region) = self.glue_region() {
-                    iceberg_configs.insert(AWS_REGION_NAME.to_owned(), region.to_owned());
-                }
-                if let Some(access_key) = self.glue_access_key() {
-                    iceberg_configs.insert(AWS_ACCESS_KEY_ID.to_owned(), access_key.to_owned());
-                }
-                if let Some(secret_key) = self.glue_secret_key() {
-                    iceberg_configs.insert(AWS_SECRET_ACCESS_KEY.to_owned(), secret_key.to_owned());
-                }
-                // s3
-                if let Some(region) = &self.s3_region {
-                    iceberg_configs.insert(S3_REGION.to_owned(), region.clone());
-                }
-                if let Some(endpoint) = &self.s3_endpoint {
-                    iceberg_configs.insert(S3_ENDPOINT.to_owned(), endpoint.clone());
-                }
-                if let Some(access_key) = &self.s3_access_key {
-                    iceberg_configs.insert(S3_ACCESS_KEY_ID.to_owned(), access_key.clone());
-                }
-                if let Some(secret_key) = &self.s3_secret_key {
-                    iceberg_configs.insert(S3_SECRET_ACCESS_KEY.to_owned(), secret_key.clone());
-                }
-                if let Some(role_arn) = &self.s3_iam_role_arn {
-                    iceberg_configs.insert(S3_ASSUME_ROLE_ARN.to_owned(), role_arn.clone());
-                }
-                if let Some(path_style_access) = &self.s3_path_style_access {
-                    iceberg_configs.insert(
-                        S3_PATH_STYLE_ACCESS.to_owned(),
-                        path_style_access.to_string(),
-                    );
-                }
-                iceberg_configs.insert(
-                    iceberg_catalog_glue::GLUE_CATALOG_PROP_WAREHOUSE.to_owned(),
-                    self.warehouse_path
-                        .clone()
-                        .ok_or_else(|| anyhow!("`warehouse.path` must be set in glue catalog"))?,
-                );
-                if let Some(uri) = self.catalog_uri.as_deref() {
-                    iceberg_configs.insert(
-                        iceberg_catalog_glue::GLUE_CATALOG_PROP_URI.to_owned(),
-                        uri.to_owned(),
-                    );
-                }
-                let catalog = iceberg_catalog_glue::GlueCatalogBuilder::default()
-                    .load("glue", iceberg_configs)
-                    .await
-                    .map_err(|e| anyhow!(IcebergError::from(e)))?;
-                Ok(Arc::new(catalog))
-            }
-            catalog_type
-                if catalog_type == "hive"
-                    || catalog_type == "snowflake"
-                    || catalog_type == "jdbc"
-                    || catalog_type == "rest"
-                    || catalog_type == "glue" =>
-            {
-                // Create java catalog
-                let (file_io_props, java_catalog_props) =
-                    self.build_jni_catalog_configs(java_catalog_props)?;
-                let catalog_impl = match catalog_type {
-                    "hive" => "org.apache.iceberg.hive.HiveCatalog",
-                    "jdbc" => "org.apache.iceberg.jdbc.JdbcCatalog",
-                    "snowflake" => "org.apache.iceberg.snowflake.SnowflakeCatalog",
-                    "rest" => "org.apache.iceberg.rest.RESTCatalog",
-                    "glue" => "org.apache.iceberg.aws.glue.GlueCatalog",
-                    _ => unreachable!(),
-                };
-
-                jni_catalog::JniCatalog::build_catalog(
-                    file_io_props,
-                    self.catalog_name(),
-                    catalog_impl,
-                    java_catalog_props,
-                )
-            }
-            "mock" => Ok(Arc::new(mock_catalog::MockCatalog {})),
-            _ => {
-                bail!(
-                    "Unsupported catalog type: {}, only support `storage`, `rest`, `hive`, `jdbc`, `glue`, `snowflake`",
-                    self.catalog_type()
-                )
-            }
-        }
-    }
-
-    /// TODO: remove the arguments and put them into `IcebergCommon`. Currently the handling in source and sink are different, so pass them separately to be safer.
-    pub async fn load_table(
-        &self,
-        table: &IcebergTableIdentifier,
-        java_catalog_props: &HashMap<String, String>,
-    ) -> ConnectorResult<Table> {
-        let catalog = self
-            .create_catalog(java_catalog_props)
-            .await
-            .context("Unable to load iceberg catalog")?;
-
-        let table_id = table
-            .to_table_ident()
-            .context("Unable to parse table name")?;
-
-        let table = catalog.load_table(&table_id).await?;
-        Ok(rebuild_table_with_shared_cache(table).await)
     }
 }
 
@@ -1113,13 +1262,67 @@ mod tests {
     }
 
     #[test]
+    fn test_vended_rest_resolves_to_native_runtime_without_rewriting_catalog_type() {
+        let common = IcebergCommon {
+            vended_credentials: Some(true),
+            ..test_common("rest")
+        };
+
+        assert_eq!(common.catalog_type(), "rest");
+        assert_eq!(
+            common.resolve_catalog_kind().unwrap(),
+            IcebergCatalogKind::Rest(IcebergCatalogRuntime::NativeRust)
+        );
+    }
+
+    #[test]
+    fn test_rest_without_vended_credentials_resolves_to_jni_runtime() {
+        let common = test_common("rest");
+
+        assert_eq!(
+            common.resolve_catalog_kind().unwrap(),
+            IcebergCatalogKind::Rest(IcebergCatalogRuntime::JavaJni)
+        );
+    }
+
+    #[test]
+    fn test_extract_java_catalog_props_keeps_wire_options_flat() {
+        let options = HashMap::from([
+            ("catalog.type".to_owned(), "rest".to_owned()),
+            ("catalog.uri".to_owned(), "http://localhost:8181".to_owned()),
+            ("catalog.name".to_owned(), "demo".to_owned()),
+            ("catalog.header".to_owned(), "x=y".to_owned()),
+            (
+                "catalog.rest.signing_region".to_owned(),
+                "us-east-1".to_owned(),
+            ),
+            ("catalog.jdbc.user".to_owned(), "rw".to_owned()),
+        ]);
+
+        let java_props = iceberg_java_catalog_props_from_options(
+            options
+                .iter()
+                .map(|(key, value)| (key.as_str(), value.as_str())),
+        );
+
+        assert_eq!(java_props.get("rest.signing_region").unwrap(), "us-east-1");
+        assert_eq!(java_props.get("jdbc.user").unwrap(), "rw");
+        assert!(!java_props.contains_key("type"));
+        assert!(!java_props.contains_key("uri"));
+        assert!(!java_props.contains_key("name"));
+        assert!(!java_props.contains_key("header"));
+    }
+
+    #[test]
     fn test_glue_jni_catalog_uses_s3_assume_role_for_file_io() {
         let common = IcebergCommon {
             s3_iam_role_arn: Some("arn:aws:iam::123456789012:role/risingwave-s3".to_owned()),
             ..test_common("glue")
         };
 
-        let (_, java_catalog_configs) = common.build_jni_catalog_configs(&HashMap::new()).unwrap();
+        let (_, java_catalog_configs) = common
+            .build_jni_catalog_configs(JniCatalogImpl::Glue, &HashMap::new())
+            .unwrap();
 
         assert_eq!(
             java_catalog_configs.get("s3.client-factory-impl").unwrap(),
@@ -1136,7 +1339,9 @@ mod tests {
     fn test_adlsgen2_service_principal_populates_file_io_configs_with_default_authority_host() {
         let common = test_adlsgen2_service_principal_common(None);
 
-        let (file_io_props, _) = common.build_jni_catalog_configs(&HashMap::new()).unwrap();
+        let (file_io_props, _) = common
+            .build_jni_catalog_configs(JniCatalogImpl::Rest, &HashMap::new())
+            .unwrap();
 
         assert_eq!(file_io_props.get(ADLS_TENANT_ID).unwrap(), "tenant-uuid");
         assert_eq!(file_io_props.get(ADLS_CLIENT_ID).unwrap(), "client-uuid");
@@ -1167,7 +1372,9 @@ mod tests {
         let common =
             test_adlsgen2_service_principal_common(Some("https://login.microsoftonline.us"));
 
-        let (file_io_props, _) = common.build_jni_catalog_configs(&HashMap::new()).unwrap();
+        let (file_io_props, _) = common
+            .build_jni_catalog_configs(JniCatalogImpl::Rest, &HashMap::new())
+            .unwrap();
 
         assert_eq!(
             file_io_props.get(ADLS_AUTHORITY_HOST).unwrap(),
@@ -1203,7 +1410,7 @@ mod tests {
         for (authority_host, expected_error) in cases {
             let common = test_adlsgen2_service_principal_common(Some(authority_host));
             let err = common
-                .build_jni_catalog_configs(&HashMap::new())
+                .build_jni_catalog_configs(JniCatalogImpl::Rest, &HashMap::new())
                 .unwrap_err();
             assert!(
                 format!("{:#}", err).contains(expected_error),
@@ -1217,7 +1424,9 @@ mod tests {
         let common =
             test_adlsgen2_service_principal_common(Some("https://login.microsoftonline.us/"));
 
-        let (file_io_props, _) = common.build_jni_catalog_configs(&HashMap::new()).unwrap();
+        let (file_io_props, _) = common
+            .build_jni_catalog_configs(JniCatalogImpl::Rest, &HashMap::new())
+            .unwrap();
 
         assert_eq!(
             file_io_props.get(ADLS_AUTHORITY_HOST).unwrap(),
@@ -1233,7 +1442,7 @@ mod tests {
         };
 
         let err = common
-            .build_jni_catalog_configs(&HashMap::new())
+            .build_jni_catalog_configs(JniCatalogImpl::Rest, &HashMap::new())
             .unwrap_err();
         assert!(
             format!("{:#}", err).contains("exactly one auth mode"),
@@ -1249,7 +1458,7 @@ mod tests {
         };
 
         let err = common
-            .build_jni_catalog_configs(&HashMap::new())
+            .build_jni_catalog_configs(JniCatalogImpl::Rest, &HashMap::new())
             .unwrap_err();
         assert!(
             format!("{:#}", err).contains("requires all three"),

--- a/src/connector/src/connector_common/mod.rs
+++ b/src/connector/src/connector_common/mod.rs
@@ -36,7 +36,10 @@ mod iceberg;
 mod maybe_tls_connector;
 pub mod postgres;
 
-pub use iceberg::{IcebergCommon, IcebergTableIdentifier};
+pub use iceberg::{
+    IcebergCatalogKind, IcebergCatalogRuntime, IcebergCommon, IcebergTableIdentifier,
+    ResolvedIcebergCatalogConfig, iceberg_java_catalog_props_from_options,
+};
 pub use postgres::{
     PostgresExternalTable, SslMode, create_pg_client, create_pg_client_from_properties,
     discover_pgvector_dimensions, pg_connection_config_from_properties,

--- a/src/connector/src/sink/iceberg/config.rs
+++ b/src/connector/src/sink/iceberg/config.rs
@@ -27,7 +27,10 @@ use serde_with::{DisplayFromStr, serde_as};
 use with_options::WithOptions;
 
 use super::{SINK_TYPE_APPEND_ONLY, SINK_TYPE_OPTION, SINK_TYPE_UPSERT, SinkError};
-use crate::connector_common::{IcebergCommon, IcebergTableIdentifier};
+use crate::connector_common::{
+    IcebergCatalogKind, IcebergCommon, IcebergTableIdentifier, ResolvedIcebergCatalogConfig,
+    iceberg_java_catalog_props_from_options,
+};
 use crate::enforce_secret::EnforceSecret;
 use crate::sink::Result;
 use crate::sink::decouple_checkpoint_log_sink::iceberg_default_commit_checkpoint_interval;
@@ -568,17 +571,11 @@ impl IcebergConfig {
         config.validate_enable_pk_index()?;
 
         // All configs start with "catalog." will be treated as java configs.
-        config.java_catalog_props = values
-            .iter()
-            .filter(|(k, _v)| {
-                k.starts_with("catalog.")
-                    && k != &"catalog.uri"
-                    && k != &"catalog.type"
-                    && k != &"catalog.name"
-                    && k != &"catalog.header"
-            })
-            .map(|(k, v)| (k[8..].to_string(), v.clone()))
-            .collect();
+        config.java_catalog_props = iceberg_java_catalog_props_from_options(
+            values
+                .iter()
+                .map(|(key, value)| (key.as_str(), value.as_str())),
+        );
 
         if config.commit_checkpoint_interval == 0 {
             return Err(SinkError::Config(anyhow!(
@@ -617,6 +614,18 @@ impl IcebergConfig {
         self.common.catalog_type()
     }
 
+    pub fn catalog_kind(&self) -> Result<IcebergCatalogKind> {
+        self.common
+            .resolve_catalog_kind()
+            .map_err(|err| SinkError::Config(anyhow!(err)))
+    }
+
+    fn resolved_catalog_config(&self) -> Result<ResolvedIcebergCatalogConfig<'_>> {
+        self.common
+            .resolve_catalog_config(self.java_catalog_props.clone())
+            .map_err(|err| SinkError::Config(anyhow!(err)))
+    }
+
     pub async fn load_table(&self) -> Result<Table> {
         #[cfg(any(test, madsim))]
         if self.catalog_type() == "mock_v3" {
@@ -636,8 +645,8 @@ impl IcebergConfig {
                 .map_err(|e| SinkError::Config(anyhow!(e).context("Failed to load mock table")))?;
             return Ok(table);
         }
-        self.common
-            .load_table(&self.table, &self.java_catalog_props)
+        self.resolved_catalog_config()?
+            .load_table(&self.table)
             .await
             .map_err(Into::into)
     }
@@ -651,8 +660,8 @@ impl IcebergConfig {
                 })?,
             );
         }
-        self.common
-            .create_catalog(&self.java_catalog_props)
+        self.resolved_catalog_config()?
+            .create_catalog()
             .await
             .map_err(Into::into)
     }

--- a/src/connector/src/sink/iceberg/create_table.rs
+++ b/src/connector/src/sink/iceberg/create_table.rs
@@ -130,8 +130,10 @@ pub(super) async fn create_table_if_not_exists_impl(
                     if url.is_err() || is_s3_tables || is_bq_catalog_federation {
                         // For rest catalog, the warehouse_path could be a warehouse name.
                         // In this case, we should specify the location when creating a table.
-                        if config.common.catalog_type() == "rest"
-                            || config.common.catalog_type() == "rest_rust"
+                        if config
+                            .common
+                            .is_rest_catalog()
+                            .map_err(|err| SinkError::Config(anyhow!(err)))?
                         {
                             None
                         } else {

--- a/src/connector/src/sink/iceberg/mod.rs
+++ b/src/connector/src/sink/iceberg/mod.rs
@@ -41,7 +41,7 @@ use super::{
     GLOBAL_SINK_METRICS, SINK_TYPE_APPEND_ONLY, SINK_TYPE_OPTION, SINK_TYPE_UPSERT, Sink,
     SinkError, SinkWriterParam,
 };
-use crate::connector_common::IcebergSinkCompactionUpdate;
+use crate::connector_common::{IcebergCatalogKind, IcebergSinkCompactionUpdate};
 use crate::enforce_secret::EnforceSecret;
 use crate::sink::coordinate::CoordinatedLogSinker;
 use crate::sink::{Result, SinkCommitCoordinator, SinkParam};
@@ -147,11 +147,12 @@ impl Sink for IcebergSink {
     const SINK_NAME: &'static str = ICEBERG_SINK;
 
     async fn validate(&self) -> Result<()> {
-        if "snowflake".eq_ignore_ascii_case(self.config.catalog_type()) {
+        let catalog_kind = self.config.catalog_kind()?;
+        if matches!(catalog_kind, IcebergCatalogKind::Snowflake) {
             bail!("Snowflake catalog only supports iceberg sources");
         }
 
-        if "glue".eq_ignore_ascii_case(self.config.catalog_type()) {
+        if matches!(catalog_kind, IcebergCatalogKind::Glue(_)) {
             risingwave_common::license::Feature::IcebergSinkWithGlue
                 .check_available()
                 .map_err(|e| anyhow::anyhow!(e))?;

--- a/src/connector/src/source/iceberg/mod.rs
+++ b/src/connector/src/source/iceberg/mod.rs
@@ -38,7 +38,9 @@ use risingwave_pb::batch_plan::iceberg_scan_node::IcebergScanType;
 use serde::{Deserialize, Serialize};
 
 pub use self::metrics::{GLOBAL_ICEBERG_SCAN_METRICS, IcebergScanMetrics};
-use crate::connector_common::{IcebergCommon, IcebergTableIdentifier};
+use crate::connector_common::{
+    IcebergCommon, IcebergTableIdentifier, iceberg_java_catalog_props_from_options,
+};
 use crate::enforce_secret::{EnforceSecret, EnforceSecretError};
 use crate::error::{ConnectorError, ConnectorResult};
 use crate::parser::ParserConfig;
@@ -86,29 +88,32 @@ impl EnforceSecret for IcebergProperties {
 }
 
 impl IcebergProperties {
-    pub async fn create_catalog(&self) -> ConnectorResult<Arc<dyn Catalog>> {
-        let mut java_catalog_props = HashMap::new();
+    fn java_catalog_props(&self) -> HashMap<String, String> {
+        let mut java_catalog_props = iceberg_java_catalog_props_from_options(
+            self.unknown_fields
+                .iter()
+                .map(|(key, value)| (key.as_str(), value.as_str())),
+        );
         if let Some(jdbc_user) = self.jdbc_user.clone() {
             java_catalog_props.insert("jdbc.user".to_owned(), jdbc_user);
         }
         if let Some(jdbc_password) = self.jdbc_password.clone() {
             java_catalog_props.insert("jdbc.password".to_owned(), jdbc_password);
         }
-        // TODO: support path_style_access and java_catalog_props for iceberg source
-        self.common.create_catalog(&java_catalog_props).await
+        java_catalog_props
+    }
+
+    pub async fn create_catalog(&self) -> ConnectorResult<Arc<dyn Catalog>> {
+        self.common
+            .resolve_catalog_config(self.java_catalog_props())?
+            .create_catalog()
+            .await
     }
 
     pub async fn load_table(&self) -> ConnectorResult<Table> {
-        let mut java_catalog_props = HashMap::new();
-        if let Some(jdbc_user) = self.jdbc_user.clone() {
-            java_catalog_props.insert("jdbc.user".to_owned(), jdbc_user);
-        }
-        if let Some(jdbc_password) = self.jdbc_password.clone() {
-            java_catalog_props.insert("jdbc.password".to_owned(), jdbc_password);
-        }
-        // TODO: support java_catalog_props for iceberg source
         self.common
-            .load_table(&self.table, &java_catalog_props)
+            .resolve_catalog_config(self.java_catalog_props())?
+            .load_table(&self.table)
             .await
     }
 }


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

This PR refactors Iceberg catalog construction so catalog semantics and runtime selection are resolved into typed Rust config before building the catalog.

- Keep the raw `IcebergCommon` options layer flat for `serde` / `WithOptions` compatibility.
- Add `IcebergCatalogKind`, `IcebergCatalogRuntime`, and `ResolvedIcebergCatalogConfig` as the parsed model used by downstream code.
- Move catalog construction from string-based `catalog.type` dispatch into typed build plans for storage, native REST, native Glue, Java JNI catalogs, and mock catalogs.
- Preserve existing compatibility: `catalog.type = rest` plus `vended_credentials = true` still uses the native Rust REST catalog, but no longer rewrites the raw catalog type to `rest_rust`.
- Keep deprecated runtime-as-catalog-type aliases (`rest_rust`, `glue_rust`) accepted through the resolver.
- Share Java catalog property extraction between Iceberg source and sink, and let source pass through flat `catalog.*` Java catalog props consistently with sink.
- Update connection validation, Iceberg sink validation, and table creation checks to use the resolved catalog kind instead of ad-hoc string checks.

The intent is to make future catalog work easier to extend without piling more special cases into `IcebergCommon` or scattering `&str` matches across source, sink, and connection paths.

No issue.

## Checklist

- [ ] I have written necessary rustdoc comments.
- [x] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

No user-facing behavior change. This is an internal refactor of Iceberg catalog config resolution and catalog construction.

</details>
