### PR TITLE
fix(meta): cascade drop subscriptions with upstream objects

### DIFF
--- a/e2e_test/ddl/subscription.slt
+++ b/e2e_test/ddl/subscription.slt
@@ -66,3 +66,47 @@ drop materialized view ddl_mv;
 
 statement ok
 drop table ddl_t;
+
+statement ok
+create table ddl_subscription_cascade_t (v1 int);
+
+statement ok
+create subscription ddl_subscription_cascade_from_table from ddl_subscription_cascade_t with(retention = '1D');
+
+query I
+select count(*) from rw_catalog.rw_subscriptions where name = 'ddl_subscription_cascade_from_table';
+----
+1
+
+statement ok
+drop table ddl_subscription_cascade_t cascade;
+
+query I
+select count(*) from rw_catalog.rw_subscriptions where name = 'ddl_subscription_cascade_from_table';
+----
+0
+
+statement ok
+create table ddl_subscription_cascade_base (v1 int);
+
+statement ok
+create materialized view ddl_subscription_cascade_mv as select v1 from ddl_subscription_cascade_base;
+
+statement ok
+create subscription ddl_subscription_cascade_from_mv from ddl_subscription_cascade_mv with(retention = '1D');
+
+query I
+select count(*) from rw_catalog.rw_subscriptions where name = 'ddl_subscription_cascade_from_mv';
+----
+1
+
+statement ok
+drop materialized view ddl_subscription_cascade_mv cascade;
+
+query I
+select count(*) from rw_catalog.rw_subscriptions where name = 'ddl_subscription_cascade_from_mv';
+----
+0
+
+statement ok
+drop table ddl_subscription_cascade_base;

--- a/src/meta/model/migration/src/lib.rs
+++ b/src/meta/model/migration/src/lib.rs
@@ -73,6 +73,7 @@ mod m20260312_000000_streaming_job_backfill_parallelism_strategy;
 mod m20260518_000000_disable_unused_read_prefix_hints;
 mod m20260519_000000_streaming_job_batch_refresh_seconds;
 mod m20260624_000000_pending_sink_state_object_fk;
+mod m20260705_000000_subscription_dependent_object_fk;
 mod utils;
 
 pub struct Migrator;
@@ -184,6 +185,7 @@ impl MigratorTrait for Migrator {
             Box::new(m20260518_000000_disable_unused_read_prefix_hints::Migration),
             Box::new(m20260519_000000_streaming_job_batch_refresh_seconds::Migration),
             Box::new(m20260624_000000_pending_sink_state_object_fk::Migration),
+            Box::new(m20260705_000000_subscription_dependent_object_fk::Migration),
         ]
     }
 }

--- a/src/meta/model/migration/src/m20260705_000000_subscription_dependent_object_fk.rs
+++ b/src/meta/model/migration/src/m20260705_000000_subscription_dependent_object_fk.rs
@@ -1,0 +1,167 @@
+use sea_orm_migration::prelude::*;
+
+use crate::m20230908_072257_init::Object;
+use crate::sea_orm::{ConnectionTrait, DatabaseBackend, Statement, TransactionTrait};
+use crate::utils::ColumnDefExt;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+const FK_NAME: &str = "FK_subscription_dependent_table_id";
+const NEW_TABLE: &str = "subscription_new";
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        // `dependent_table_id` stores the object oid of the upstream table/MV. Add the missing
+        // backend FK so deleting that object cascades stale subscription rows in the meta store.
+        let backend = manager.get_database_backend();
+        match backend {
+            DatabaseBackend::MySql | DatabaseBackend::Postgres => {
+                manager
+                    .get_connection()
+                    .execute(Statement::from_string(
+                        backend,
+                        "DELETE FROM object WHERE oid IN (\
+                         SELECT subscription_id FROM subscription \
+                         WHERE dependent_table_id NOT IN (SELECT oid FROM object))",
+                    ))
+                    .await?;
+                manager
+                    .alter_table(
+                        Table::alter()
+                            .table(Subscription::Table)
+                            .add_foreign_key(&dependent_object_foreign_key())
+                            .to_owned(),
+                    )
+                    .await?;
+            }
+            DatabaseBackend::Sqlite => {
+                recreate_table(manager, true).await?;
+            }
+        }
+        Ok(())
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        match manager.get_database_backend() {
+            DatabaseBackend::MySql | DatabaseBackend::Postgres => {
+                manager
+                    .alter_table(
+                        Table::alter()
+                            .table(Subscription::Table)
+                            .drop_foreign_key(Alias::new(FK_NAME))
+                            .to_owned(),
+                    )
+                    .await?;
+            }
+            DatabaseBackend::Sqlite => {
+                recreate_table(manager, false).await?;
+            }
+        }
+        Ok(())
+    }
+}
+
+fn dependent_object_foreign_key() -> TableForeignKey {
+    TableForeignKey::new()
+        .name(FK_NAME)
+        .from_tbl(Subscription::Table)
+        .from_col(Subscription::DependentTableId)
+        .to_tbl(Object::Table)
+        .to_col(Object::Oid)
+        .on_delete(ForeignKeyAction::Cascade)
+        .to_owned()
+}
+
+async fn recreate_table(manager: &SchemaManager<'_>, with_dependent_fk: bool) -> Result<(), DbErr> {
+    let backend = manager.get_database_backend();
+    let txn = manager.get_connection().begin().await?;
+    {
+        let txn_manager = SchemaManager::new(&txn);
+
+        if with_dependent_fk {
+            txn.execute(Statement::from_string(
+                backend,
+                "DELETE FROM object WHERE oid IN (\
+                 SELECT subscription_id FROM subscription \
+                 WHERE dependent_table_id NOT IN (SELECT oid FROM object))",
+            ))
+            .await?;
+        }
+
+        let mut create = Table::create();
+        create
+            .table(Alias::new(NEW_TABLE))
+            .col(
+                ColumnDef::new(Subscription::SubscriptionId)
+                    .integer()
+                    .primary_key(),
+            )
+            .col(ColumnDef::new(Subscription::Name).string().not_null())
+            .col(
+                ColumnDef::new(Subscription::Definition)
+                    .rw_long_text(&txn_manager)
+                    .not_null(),
+            )
+            .col(ColumnDef::new(Subscription::RetentionSeconds).big_integer())
+            .col(ColumnDef::new(Subscription::SubscriptionState).integer())
+            .col(
+                ColumnDef::new(Subscription::DependentTableId)
+                    .integer()
+                    .not_null(),
+            )
+            .foreign_key(
+                &mut ForeignKey::create()
+                    .name("FK_subscription_object_id")
+                    .from(Alias::new(NEW_TABLE), Subscription::SubscriptionId)
+                    .to(Object::Table, Object::Oid)
+                    .on_delete(ForeignKeyAction::Cascade)
+                    .to_owned(),
+            );
+        if with_dependent_fk {
+            create.foreign_key(
+                &mut ForeignKey::create()
+                    .name(FK_NAME)
+                    .from(Alias::new(NEW_TABLE), Subscription::DependentTableId)
+                    .to(Object::Table, Object::Oid)
+                    .on_delete(ForeignKeyAction::Cascade)
+                    .to_owned(),
+            );
+        }
+        txn_manager.create_table(create).await?;
+
+        txn.execute(Statement::from_string(
+            backend,
+            "INSERT INTO subscription_new \
+             (subscription_id, name, retention_seconds, definition, subscription_state, dependent_table_id) \
+             SELECT subscription_id, name, retention_seconds, definition, subscription_state, dependent_table_id \
+             FROM subscription WHERE dependent_table_id IN (SELECT oid FROM object)",
+        ))
+        .await?;
+
+        txn_manager
+            .drop_table(Table::drop().table(Subscription::Table).to_owned())
+            .await?;
+        txn_manager
+            .rename_table(
+                Table::rename()
+                    .table(Alias::new(NEW_TABLE), Subscription::Table)
+                    .to_owned(),
+            )
+            .await?;
+    }
+    txn.commit().await?;
+    Ok(())
+}
+
+#[derive(DeriveIden)]
+enum Subscription {
+    Table,
+    SubscriptionId,
+    Name,
+    Definition,
+    RetentionSeconds,
+    SubscriptionState,
+    DependentTableId,
+}

--- a/src/meta/model/src/subscription.rs
+++ b/src/meta/model/src/subscription.rs
@@ -42,6 +42,14 @@ pub enum Relation {
         on_delete = "Cascade"
     )]
     Object,
+    #[sea_orm(
+        belongs_to = "super::object::Entity",
+        from = "Column::DependentTableId",
+        to = "super::object::Column::Oid",
+        on_update = "NoAction",
+        on_delete = "Cascade"
+    )]
+    DependentObject,
 }
 
 impl Related<super::object::Entity> for Entity {

--- a/src/meta/src/controller/catalog/test.rs
+++ b/src/meta/src/controller/catalog/test.rs
@@ -564,4 +564,74 @@ mod tests {
 
         Ok(())
     }
+
+    #[tokio::test]
+    async fn test_drop_table_cascade_drops_dependent_subscription() -> MetaResult<()> {
+        let mgr = CatalogController::new(MetaSrvEnv::for_test().await).await?;
+
+        let inner = mgr.inner.write().await;
+        let txn = inner.db.begin().await?;
+        let table_obj = CatalogController::create_object(
+            &txn,
+            ObjectType::Table,
+            TEST_OWNER_ID,
+            Some(TEST_DATABASE_ID),
+            Some(TEST_SCHEMA_ID),
+        )
+        .await?;
+        let table_id = table_obj.oid.as_table_id();
+        insert_test_table(
+            &txn,
+            table_id,
+            "subscription_dep_table",
+            TableType::Table,
+            None,
+            "CREATE TABLE subscription_dep_table (v1 INT)",
+        )
+        .await?;
+        txn.commit().await?;
+        drop(inner);
+
+        let mut pb_subscription = PbSubscription {
+            name: "subscription_to_drop_with_table".to_owned(),
+            definition:
+                "CREATE SUBSCRIPTION subscription_to_drop_with_table FROM subscription_dep_table"
+                    .to_owned(),
+            retention_seconds: 86400,
+            database_id: TEST_DATABASE_ID,
+            schema_id: TEST_SCHEMA_ID,
+            dependent_table_id: table_id,
+            owner: TEST_OWNER_ID as _,
+            subscription_state: SubscriptionState::Created as _,
+            ..Default::default()
+        };
+        mgr.create_subscription_catalog(&mut pb_subscription)
+            .await?;
+
+        mgr.drop_object(ObjectType::Table, table_id, DropMode::Cascade)
+            .await?;
+
+        let db = &mgr.inner.read().await.db;
+        assert!(Table::find_by_id(table_id).one(db).await?.is_none());
+        assert!(
+            Object::find_by_id(table_id.as_object_id())
+                .one(db)
+                .await?
+                .is_none()
+        );
+        assert!(
+            Subscription::find_by_id(pb_subscription.id)
+                .one(db)
+                .await?
+                .is_none()
+        );
+        assert!(
+            Object::find_by_id(pb_subscription.id.as_object_id())
+                .one(db)
+                .await?
+                .is_none()
+        );
+
+        Ok(())
+    }
 }


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

This PR adds a meta-store foreign key from `subscription.dependent_table_id` to `object.oid` with `ON DELETE CASCADE`, so subscription rows are cleaned up by the SQL meta-store when their upstream table or materialized view object is deleted.

It also:

- Cleans up pre-existing orphaned subscription objects before adding the FK.
- Handles SQLite by recreating the subscription table because SQLite cannot add a foreign key in place.
- Adds the matching SeaORM relation metadata.
- Adds catalog and e2e SLT regression coverage that verifies `DROP TABLE ... CASCADE` and `DROP MATERIALIZED VIEW ... CASCADE` remove dependent subscription catalog rows and objects.

## Checklist

- [ ] I have written necessary rustdoc comments.
- [x] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [x] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

No user-facing documentation update is needed. This fixes internal meta-store cleanup for subscription catalog rows when the subscribed table or materialized view is dropped.

</details>
