### PR TITLE
refactor(connector): share iceberg source scan planning

### DIFF
--- a/src/batch/executors/src/executor/iceberg_scan.rs
+++ b/src/batch/executors/src/executor/iceberg_scan.rs
@@ -90,13 +90,7 @@ impl IcebergScanExecutor {
         let data_types = self.schema.data_types();
 
         let data_file_scan_tasks = match Option::take(&mut self.file_scan_tasks) {
-            Some(IcebergFileScanTask::Data(data_file_scan_tasks)) => data_file_scan_tasks,
-            Some(IcebergFileScanTask::EqualityDelete(equality_delete_file_scan_tasks)) => {
-                equality_delete_file_scan_tasks
-            }
-            Some(IcebergFileScanTask::PositionDelete(position_delete_file_scan_tasks)) => {
-                position_delete_file_scan_tasks
-            }
+            Some(file_scan_tasks) => file_scan_tasks.into_tasks(),
             None => {
                 bail!("file_scan_tasks must be Some")
             }
@@ -118,6 +112,9 @@ impl IcebergScanExecutor {
                     chunk_size: self.chunk_size,
                     need_seq_num: self.need_seq_num,
                     need_file_path_and_pos: self.need_file_path_and_pos,
+                    // Iceberg V2 scans expose delete files separately for delete-file scan nodes.
+                    // From V3 onward, deletion vectors are attached to data-file tasks and must be
+                    // applied by iceberg-rs during the data scan.
                     handle_delete_files: table.metadata().format_version()
                         >= iceberg::spec::FormatVersion::V3,
                 },

--- a/src/connector/src/source/iceberg/mod.rs
+++ b/src/connector/src/source/iceberg/mod.rs
@@ -41,6 +41,7 @@ use risingwave_common::types::JsonbVal;
 use risingwave_common_estimate_size::EstimateSize;
 use risingwave_pb::batch_plan::iceberg_scan_node::IcebergScanType;
 use serde::{Deserialize, Serialize};
+use thiserror_ext::AsReport;
 
 pub use self::metrics::{GLOBAL_ICEBERG_SCAN_METRICS, IcebergScanMetrics};
 use crate::connector_common::{
@@ -211,7 +212,7 @@ impl SplitMetaData for IcebergSplit {
     fn encode_to_json(&self) -> JsonbVal {
         serde_json::to_value(self.clone())
             .unwrap_or_else(|err| {
-                tracing::error!(error = %err, "failed to encode iceberg split");
+                tracing::error!(error = %err.as_report(), "failed to encode iceberg split");
                 serde_json::Value::Null
             })
             .into()

--- a/src/connector/src/source/iceberg/mod.rs
+++ b/src/connector/src/source/iceberg/mod.rs
@@ -41,7 +41,6 @@ use risingwave_common::types::JsonbVal;
 use risingwave_common_estimate_size::EstimateSize;
 use risingwave_pb::batch_plan::iceberg_scan_node::IcebergScanType;
 use serde::{Deserialize, Serialize};
-use thiserror_ext::AsReport;
 
 pub use self::metrics::{GLOBAL_ICEBERG_SCAN_METRICS, IcebergScanMetrics};
 use crate::connector_common::{
@@ -211,10 +210,7 @@ impl SplitMetaData for IcebergSplit {
 
     fn encode_to_json(&self) -> JsonbVal {
         serde_json::to_value(self.clone())
-            .unwrap_or_else(|err| {
-                tracing::error!(error = %err.as_report(), "failed to encode iceberg split");
-                serde_json::Value::Null
-            })
+            .expect("iceberg split serialization should not fail")
             .into()
     }
 

--- a/src/connector/src/source/iceberg/mod.rs
+++ b/src/connector/src/source/iceberg/mod.rs
@@ -13,9 +13,10 @@
 // limitations under the License.
 
 pub mod parquet_file_handler;
+pub mod planner;
 
 pub mod metrics;
-use std::collections::{BinaryHeap, HashMap, HashSet};
+use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
 use anyhow::anyhow;
@@ -29,6 +30,10 @@ use iceberg::spec::FormatVersion;
 use iceberg::table::Table;
 pub use parquet_file_handler::*;
 use phf::{Set, phf_set};
+pub use planner::{
+    IcebergIncrementalScan, IcebergScanMetricsLabels, IcebergScanPlan, IcebergScanPlanner,
+    IcebergScanProjection, IcebergScanTaskBatchMode, IcebergScanTaskPlanner, PersistedFileScanTask,
+};
 use risingwave_common::array::arrow::IcebergArrowConvert;
 use risingwave_common::array::{ArrayImpl, DataChunk, I64Array, Utf8Array};
 use risingwave_common::bail;
@@ -132,19 +137,6 @@ impl UnknownFields for IcebergProperties {
     }
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, Deserialize)]
-pub struct IcebergFileScanTaskJsonStr(String);
-
-impl IcebergFileScanTaskJsonStr {
-    pub fn deserialize(&self) -> FileScanTask {
-        serde_json::from_str(&self.0).unwrap()
-    }
-
-    pub fn serialize(task: &FileScanTask) -> Self {
-        Self(serde_json::to_string(task).unwrap())
-    }
-}
-
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub enum IcebergFileScanTask {
     Data(Vec<FileScanTask>),
@@ -187,12 +179,17 @@ pub struct IcebergSplit {
 }
 
 impl IcebergSplit {
+    #[allow(deprecated)]
     pub fn empty(iceberg_scan_type: IcebergScanType) -> Self {
         let task = match iceberg_scan_type {
             IcebergScanType::DataScan => IcebergFileScanTask::Data(vec![]),
             IcebergScanType::EqualityDeleteScan => IcebergFileScanTask::EqualityDelete(vec![]),
             IcebergScanType::PositionDeleteScan => IcebergFileScanTask::PositionDelete(vec![]),
-            _ => unimplemented!(),
+            IcebergScanType::Unspecified | IcebergScanType::CountStar => {
+                // These scan types do not carry file tasks. Keep the split serializable without
+                // introducing a new empty-task variant.
+                IcebergFileScanTask::Data(vec![])
+            }
         };
         Self {
             split_id: 0,
@@ -212,11 +209,18 @@ impl SplitMetaData for IcebergSplit {
     }
 
     fn encode_to_json(&self) -> JsonbVal {
-        serde_json::to_value(self.clone()).unwrap().into()
+        serde_json::to_value(self.clone())
+            .unwrap_or_else(|err| {
+                tracing::error!(error = %err, "failed to encode iceberg split");
+                serde_json::Value::Null
+            })
+            .into()
     }
 
     fn update_offset(&mut self, _last_seen_offset: String) -> ConnectorResult<()> {
-        unimplemented!()
+        // Iceberg source progress is tracked by persisted file tasks in the stream state table.
+        // A split does not carry an intra-file offset until partial-file reads are supported.
+        Ok(())
     }
 }
 
@@ -435,61 +439,7 @@ impl IcebergSplitEnumerator {
         file_scan_tasks: Vec<FileScanTask>,
         split_num: usize,
     ) -> Vec<Vec<FileScanTask>> {
-        use std::cmp::{Ordering, Reverse};
-
-        #[derive(Default)]
-        struct FileScanTaskGroup {
-            idx: usize,
-            tasks: Vec<FileScanTask>,
-            total_length: u64,
-        }
-
-        impl Ord for FileScanTaskGroup {
-            fn cmp(&self, other: &Self) -> Ordering {
-                // when total_length is the same, we will sort by index
-                if self.total_length == other.total_length {
-                    self.idx.cmp(&other.idx)
-                } else {
-                    self.total_length.cmp(&other.total_length)
-                }
-            }
-        }
-
-        impl PartialOrd for FileScanTaskGroup {
-            fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-                Some(self.cmp(other))
-            }
-        }
-
-        impl Eq for FileScanTaskGroup {}
-
-        impl PartialEq for FileScanTaskGroup {
-            fn eq(&self, other: &Self) -> bool {
-                self.total_length == other.total_length
-            }
-        }
-
-        let mut heap = BinaryHeap::new();
-        // push all groups into heap
-        for idx in 0..split_num {
-            heap.push(Reverse(FileScanTaskGroup {
-                idx,
-                tasks: vec![],
-                total_length: 0,
-            }));
-        }
-
-        for file_task in file_scan_tasks {
-            let mut group = heap.peek_mut().unwrap();
-            group.0.total_length += file_task.length;
-            group.0.tasks.push(file_task);
-        }
-
-        // convert heap into vec and extract tasks
-        heap.into_vec()
-            .into_iter()
-            .map(|reverse_group| reverse_group.0.tasks)
-            .collect()
+        IcebergScanTaskPlanner::split_n_vecs(file_scan_tasks, split_num)
     }
 }
 

--- a/src/connector/src/source/iceberg/planner.rs
+++ b/src/connector/src/source/iceberg/planner.rs
@@ -1,0 +1,677 @@
+// Copyright 2026 RisingWave Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::cmp::{Ordering, Reverse};
+use std::collections::BinaryHeap;
+use std::sync::Arc;
+use std::time::Duration;
+
+use futures::StreamExt;
+use futures::stream::BoxStream;
+use futures_async_stream::try_stream;
+use iceberg::expr::BoundPredicate;
+use iceberg::scan::FileScanTask;
+use iceberg::spec::{DataContentType, DataFileFormat, SchemaRef};
+use iceberg::table::Table;
+use risingwave_common::bail;
+use risingwave_common::catalog::ColumnCatalog;
+use risingwave_common::types::{JsonbRef, JsonbVal, ScalarRef};
+use risingwave_pb::batch_plan::iceberg_scan_node::IcebergScanType;
+use serde::{Deserialize, Serialize};
+
+use super::metrics::GLOBAL_ICEBERG_SCAN_METRICS;
+use super::{IcebergFileScanTask, IcebergProperties, IcebergScanOpts, IcebergSplit};
+use crate::error::ConnectorResult;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum IcebergScanTaskBatchMode {
+    /// Keep the requested parallelism by returning empty task batches when there are fewer files
+    /// than workers. This is used by the distributed RisingWave batch scheduler.
+    PreserveParallelism,
+    /// Avoid empty partitions. This is used by DataFusion's local physical plan.
+    Compact,
+}
+
+pub struct IcebergScanTaskPlanner;
+
+pub type IcebergScanTaskStream = BoxStream<'static, ConnectorResult<FileScanTask>>;
+
+#[derive(Debug, Clone, Default)]
+pub struct IcebergScanProjection {
+    columns: Option<Vec<String>>,
+}
+
+impl IcebergScanProjection {
+    pub fn all() -> Self {
+        Self { columns: None }
+    }
+
+    pub fn from_downstream_columns(columns: Option<&[ColumnCatalog]>) -> Self {
+        Self {
+            columns: columns.map(|columns| {
+                columns
+                    .iter()
+                    .filter_map(|col| {
+                        if col.is_hidden() {
+                            None
+                        } else {
+                            Some(col.name().to_owned())
+                        }
+                    })
+                    .collect()
+            }),
+        }
+    }
+
+    fn apply<'a>(
+        &self,
+        scan_builder: iceberg::scan::TableScanBuilder<'a>,
+    ) -> iceberg::scan::TableScanBuilder<'a> {
+        if let Some(columns) = &self.columns {
+            scan_builder.select(columns)
+        } else {
+            scan_builder.select_all()
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct IcebergScanMetricsLabels {
+    source_id: String,
+    source_name: String,
+    table_name: String,
+}
+
+impl IcebergScanMetricsLabels {
+    pub fn new(source_id: String, source_name: String, table_name: String) -> Self {
+        Self {
+            source_id,
+            source_name,
+            table_name,
+        }
+    }
+
+    pub fn record_scan_error(&self, error_kind: &str) {
+        GLOBAL_ICEBERG_SCAN_METRICS
+            .iceberg_source_scan_errors_total
+            .with_guarded_label_values(&[
+                self.source_id.as_str(),
+                self.source_name.as_str(),
+                self.table_name.as_str(),
+                error_kind,
+            ])
+            .inc();
+    }
+
+    pub fn record_snapshot_discovered(&self) {
+        GLOBAL_ICEBERG_SCAN_METRICS
+            .iceberg_source_snapshots_discovered_total
+            .with_guarded_label_values(&[
+                self.source_id.as_str(),
+                self.source_name.as_str(),
+                self.table_name.as_str(),
+            ])
+            .inc();
+    }
+
+    pub fn record_snapshot_lag(&self, lag_secs: i64) {
+        GLOBAL_ICEBERG_SCAN_METRICS
+            .iceberg_source_snapshot_lag_seconds
+            .with_guarded_label_values(&[
+                self.source_id.as_str(),
+                self.source_name.as_str(),
+                self.table_name.as_str(),
+            ])
+            .set(lag_secs);
+    }
+
+    pub fn record_caught_up(&self) {
+        self.record_snapshot_lag(0);
+    }
+
+    fn record_list_duration(&self, duration: Duration) {
+        GLOBAL_ICEBERG_SCAN_METRICS
+            .iceberg_source_list_duration_seconds
+            .with_guarded_label_values(&[
+                self.source_id.as_str(),
+                self.source_name.as_str(),
+                self.table_name.as_str(),
+            ])
+            .observe(duration.as_secs_f64());
+    }
+
+    fn record_delete_files_per_data_file(&self, delete_file_count: usize) {
+        GLOBAL_ICEBERG_SCAN_METRICS
+            .iceberg_source_delete_files_per_data_file
+            .with_guarded_label_values(&[
+                self.source_id.as_str(),
+                self.source_name.as_str(),
+                self.table_name.as_str(),
+            ])
+            .observe(delete_file_count as f64);
+    }
+
+    fn record_file_counts(&self, stats: &IcebergScanPlanStats) {
+        for (file_type, count) in [
+            ("data", stats.data_file_count),
+            ("eq_delete", stats.eq_delete_count),
+            ("pos_delete", stats.pos_delete_count),
+        ] {
+            if count > 0 {
+                GLOBAL_ICEBERG_SCAN_METRICS
+                    .iceberg_source_files_discovered_total
+                    .with_guarded_label_values(&[
+                        self.source_id.as_str(),
+                        self.source_name.as_str(),
+                        self.table_name.as_str(),
+                        file_type,
+                    ])
+                    .inc_by(count);
+            }
+        }
+    }
+}
+
+#[derive(Debug, Default)]
+struct IcebergScanPlanStats {
+    data_file_count: u64,
+    eq_delete_count: u64,
+    pos_delete_count: u64,
+}
+
+impl IcebergScanPlanStats {
+    fn record_task(&mut self, scan_task: &FileScanTask) {
+        self.data_file_count += 1;
+        for delete_task in &scan_task.deletes {
+            match delete_task.data_file_content {
+                DataContentType::EqualityDeletes => self.eq_delete_count += 1,
+                DataContentType::PositionDeletes => self.pos_delete_count += 1,
+                _ => {}
+            }
+        }
+    }
+}
+
+pub struct IcebergScanPlan {
+    pub snapshot_id: i64,
+    pub tasks: IcebergScanTaskStream,
+}
+
+pub enum IcebergIncrementalScan {
+    EmptyTable,
+    UpToDate { current_snapshot_id: i64 },
+    Planned(IcebergScanPlan),
+}
+
+#[derive(Clone)]
+pub struct IcebergScanPlanner {
+    properties: IcebergProperties,
+    projection: IcebergScanProjection,
+    metrics: Option<IcebergScanMetricsLabels>,
+}
+
+impl IcebergScanPlanner {
+    pub fn new(
+        properties: IcebergProperties,
+        projection: IcebergScanProjection,
+        metrics: Option<IcebergScanMetricsLabels>,
+    ) -> Self {
+        Self {
+            properties,
+            projection,
+            metrics,
+        }
+    }
+
+    pub async fn plan_current_snapshot(&self) -> ConnectorResult<Option<IcebergScanPlan>> {
+        let table = self.properties.load_table().await?;
+        let Some(current_snapshot) = table.metadata().current_snapshot() else {
+            return Ok(None);
+        };
+        self.plan_snapshot(&table, current_snapshot.snapshot_id())
+            .await
+            .map(Some)
+    }
+
+    pub async fn plan_incremental(
+        &self,
+        last_snapshot: Option<i64>,
+    ) -> ConnectorResult<IcebergIncrementalScan> {
+        let table = self.properties.load_table().await?;
+
+        let Some(current_snapshot) = table.metadata().current_snapshot() else {
+            tracing::info!("Skip incremental scan because table is empty");
+            return Ok(IcebergIncrementalScan::EmptyTable);
+        };
+
+        let current_snapshot_id = current_snapshot.snapshot_id();
+        if Some(current_snapshot_id) == last_snapshot {
+            if let Some(metrics) = &self.metrics {
+                metrics.record_caught_up();
+            }
+            tracing::info!(
+                "Current table snapshot is already enumerated: {}, no new snapshot available",
+                current_snapshot_id
+            );
+            return Ok(IcebergIncrementalScan::UpToDate {
+                current_snapshot_id,
+            });
+        }
+
+        if let Some(metrics) = &self.metrics {
+            if let Some(last_snapshot_id) = last_snapshot
+                && let Some(last_ingested_snapshot) = table
+                    .metadata()
+                    .snapshots()
+                    .find(|snapshot| snapshot.snapshot_id() == last_snapshot_id)
+            {
+                let lag_secs = (current_snapshot.timestamp_ms()
+                    - last_ingested_snapshot.timestamp_ms())
+                .max(0)
+                    / 1000;
+                metrics.record_snapshot_lag(lag_secs);
+            }
+            metrics.record_snapshot_discovered();
+        }
+
+        let mut scan_builder = table.scan().to_snapshot_id(current_snapshot_id);
+        if let Some(last_snapshot) = last_snapshot {
+            scan_builder = scan_builder.from_snapshot_id(last_snapshot);
+        }
+        let scan = self.projection.apply(scan_builder).build()?;
+        let tasks = self.instrument_scan_task_stream(scan.plan_files().await?);
+
+        Ok(IcebergIncrementalScan::Planned(IcebergScanPlan {
+            snapshot_id: current_snapshot_id,
+            tasks,
+        }))
+    }
+
+    pub fn record_caught_up(&self) {
+        if let Some(metrics) = &self.metrics {
+            metrics.record_caught_up();
+        }
+    }
+
+    async fn plan_snapshot(
+        &self,
+        table: &Table,
+        snapshot_id: i64,
+    ) -> ConnectorResult<IcebergScanPlan> {
+        let scan = self
+            .projection
+            .apply(table.scan().snapshot_id(snapshot_id))
+            .build()?;
+        let tasks = self.instrument_scan_task_stream(scan.plan_files().await?);
+
+        Ok(IcebergScanPlan { snapshot_id, tasks })
+    }
+
+    fn instrument_scan_task_stream(
+        &self,
+        scan_tasks: iceberg::scan::FileScanTaskStream,
+    ) -> IcebergScanTaskStream {
+        instrument_scan_task_stream(scan_tasks, self.metrics.clone())
+    }
+}
+
+#[try_stream(boxed, ok = FileScanTask, error = crate::error::ConnectorError)]
+async fn instrument_scan_task_stream(
+    scan_tasks: iceberg::scan::FileScanTaskStream,
+    metrics: Option<IcebergScanMetricsLabels>,
+) {
+    let list_start = std::time::Instant::now();
+    let mut stats = IcebergScanPlanStats::default();
+
+    let mut scan_tasks = scan_tasks;
+    while let Some(scan_task) = scan_tasks.next().await {
+        let scan_task = scan_task?;
+        if let Some(metrics) = &metrics {
+            stats.record_task(&scan_task);
+            metrics.record_delete_files_per_data_file(scan_task.deletes.len());
+        }
+        yield scan_task;
+    }
+
+    if let Some(metrics) = &metrics {
+        metrics.record_list_duration(list_start.elapsed());
+        metrics.record_file_counts(&stats);
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct PersistedFileScanTask {
+    pub start: u64,
+    pub length: u64,
+    pub record_count: Option<u64>,
+    pub data_file_path: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub referenced_data_file: Option<String>,
+    pub data_file_content: DataContentType,
+    pub data_file_format: DataFileFormat,
+    pub schema: SchemaRef,
+    pub project_field_ids: Vec<i32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub predicate: Option<BoundPredicate>,
+    pub deletes: Vec<PersistedFileScanTask>,
+    pub sequence_number: i64,
+    pub equality_ids: Option<Vec<i32>>,
+    pub file_size_in_bytes: u64,
+    #[serde(default = "default_case_sensitive")]
+    pub case_sensitive: bool,
+}
+
+fn default_case_sensitive() -> bool {
+    true
+}
+
+impl PersistedFileScanTask {
+    pub fn decode(jsonb_ref: JsonbRef<'_>) -> ConnectorResult<FileScanTask> {
+        let persisted_task: Self = serde_json::from_value(jsonb_ref.to_owned_scalar().take())?;
+        Ok(Self::to_task(persisted_task))
+    }
+
+    pub fn encode(task: FileScanTask) -> ConnectorResult<JsonbVal> {
+        let persisted_task = Self::from_task(task);
+        Ok(serde_json::to_value(persisted_task)?.into())
+    }
+
+    fn to_task(
+        Self {
+            start,
+            length,
+            record_count,
+            data_file_path,
+            referenced_data_file,
+            data_file_content,
+            data_file_format,
+            schema,
+            project_field_ids,
+            predicate,
+            deletes,
+            sequence_number,
+            equality_ids,
+            file_size_in_bytes,
+            case_sensitive,
+        }: Self,
+    ) -> FileScanTask {
+        FileScanTask {
+            start,
+            length,
+            record_count,
+            data_file_path,
+            referenced_data_file,
+            data_file_content,
+            data_file_format,
+            schema,
+            project_field_ids,
+            predicate,
+            deletes: deletes
+                .into_iter()
+                .map(|task| Arc::new(PersistedFileScanTask::to_task(task)))
+                .collect(),
+            sequence_number,
+            equality_ids,
+            file_size_in_bytes,
+            partition: None,
+            partition_spec: None,
+            name_mapping: None,
+            case_sensitive,
+        }
+    }
+
+    fn from_task(
+        FileScanTask {
+            start,
+            length,
+            record_count,
+            data_file_path,
+            referenced_data_file,
+            data_file_content,
+            data_file_format,
+            schema,
+            project_field_ids,
+            predicate,
+            deletes,
+            sequence_number,
+            equality_ids,
+            file_size_in_bytes,
+            case_sensitive,
+            ..
+        }: FileScanTask,
+    ) -> Self {
+        Self {
+            start,
+            length,
+            record_count,
+            data_file_path,
+            referenced_data_file,
+            data_file_content,
+            data_file_format,
+            schema,
+            project_field_ids,
+            predicate,
+            deletes: deletes
+                .into_iter()
+                .map(PersistedFileScanTask::from_task_ref)
+                .collect(),
+            sequence_number,
+            equality_ids,
+            file_size_in_bytes,
+            case_sensitive,
+        }
+    }
+
+    fn from_task_ref(task: Arc<FileScanTask>) -> Self {
+        Self {
+            start: task.start,
+            length: task.length,
+            record_count: task.record_count,
+            data_file_path: task.data_file_path.clone(),
+            referenced_data_file: task.referenced_data_file.clone(),
+            data_file_content: task.data_file_content,
+            data_file_format: task.data_file_format,
+            schema: task.schema.clone(),
+            project_field_ids: task.project_field_ids.clone(),
+            predicate: task.predicate.clone(),
+            deletes: task
+                .deletes
+                .iter()
+                .cloned()
+                .map(PersistedFileScanTask::from_task_ref)
+                .collect(),
+            sequence_number: task.sequence_number,
+            equality_ids: task.equality_ids.clone(),
+            file_size_in_bytes: task.file_size_in_bytes,
+            case_sensitive: task.case_sensitive,
+        }
+    }
+}
+
+impl IcebergFileScanTask {
+    pub fn scan_type(&self) -> IcebergScanType {
+        match self {
+            IcebergFileScanTask::Data(_) => IcebergScanType::DataScan,
+            IcebergFileScanTask::EqualityDelete(_) => IcebergScanType::EqualityDeleteScan,
+            IcebergFileScanTask::PositionDelete(_) => IcebergScanType::PositionDeleteScan,
+        }
+    }
+
+    pub fn from_tasks(
+        scan_type: IcebergScanType,
+        tasks: Vec<FileScanTask>,
+    ) -> ConnectorResult<Self> {
+        match scan_type {
+            IcebergScanType::DataScan => Ok(IcebergFileScanTask::Data(tasks)),
+            IcebergScanType::EqualityDeleteScan => Ok(IcebergFileScanTask::EqualityDelete(tasks)),
+            IcebergScanType::PositionDeleteScan => Ok(IcebergFileScanTask::PositionDelete(tasks)),
+            _ => {
+                bail!("unsupported Iceberg file scan task type: {:?}", scan_type)
+            }
+        }
+    }
+
+    pub fn into_tasks(self) -> Vec<FileScanTask> {
+        match self {
+            IcebergFileScanTask::Data(tasks)
+            | IcebergFileScanTask::EqualityDelete(tasks)
+            | IcebergFileScanTask::PositionDelete(tasks) => tasks,
+        }
+    }
+}
+
+impl IcebergScanOpts {
+    pub fn new(
+        chunk_size: usize,
+        need_seq_num: bool,
+        need_file_path_and_pos: bool,
+        handle_delete_files: bool,
+    ) -> Self {
+        Self {
+            chunk_size,
+            need_seq_num,
+            need_file_path_and_pos,
+            handle_delete_files,
+        }
+    }
+}
+
+impl IcebergScanTaskPlanner {
+    pub fn plan_splits(
+        task: IcebergFileScanTask,
+        split_num: usize,
+        limit: Option<u64>,
+    ) -> ConnectorResult<Vec<IcebergSplit>> {
+        let scan_type = task.scan_type();
+        if limit.is_some() && scan_type != IcebergScanType::DataScan {
+            bail!("Iceberg scan limit can only be planned for data scan tasks");
+        }
+
+        let task_batches = Self::plan_task_batches(
+            task,
+            split_num,
+            limit,
+            IcebergScanTaskBatchMode::PreserveParallelism,
+        );
+
+        task_batches
+            .into_iter()
+            .enumerate()
+            .map(|(id, tasks)| {
+                Ok(IcebergSplit {
+                    split_id: id.try_into().unwrap(),
+                    task: IcebergFileScanTask::from_tasks(scan_type, tasks)?,
+                    limit,
+                })
+            })
+            .collect()
+    }
+
+    pub fn plan_task_batches(
+        task: IcebergFileScanTask,
+        split_num: usize,
+        limit: Option<u64>,
+        mode: IcebergScanTaskBatchMode,
+    ) -> Vec<Vec<FileScanTask>> {
+        let tasks = task.into_tasks();
+        if limit.is_some() {
+            return vec![tasks];
+        }
+        Self::plan_file_task_batches(tasks, split_num, mode)
+    }
+
+    pub fn plan_file_task_batches(
+        file_scan_tasks: Vec<FileScanTask>,
+        split_num: usize,
+        mode: IcebergScanTaskBatchMode,
+    ) -> Vec<Vec<FileScanTask>> {
+        assert!(split_num > 0, "iceberg scan split number must be positive");
+        if mode == IcebergScanTaskBatchMode::Compact && file_scan_tasks.len() <= split_num {
+            return file_scan_tasks.into_iter().map(|task| vec![task]).collect();
+        }
+
+        Self::split_n_vecs(file_scan_tasks, split_num)
+    }
+
+    /// Uniformly distribute scan tasks to compute nodes.
+    /// It's deterministic so that it can best utilize the data locality.
+    ///
+    /// # Arguments
+    /// * `file_scan_tasks`: The file scan tasks to be split.
+    /// * `split_num`: The number of splits to be created.
+    ///
+    /// This algorithm is based on a min-heap. It will push all groups into the heap, and then pop the smallest group and add the file scan task to it.
+    /// Ensure that the total length of each group is as balanced as possible.
+    /// The time complexity is O(n log k), where n is the number of file scan tasks and k is the number of splits.
+    /// The space complexity is O(k), where k is the number of splits.
+    /// The algorithm is stable, so the order of the file scan tasks will be preserved.
+    pub fn split_n_vecs(
+        file_scan_tasks: Vec<FileScanTask>,
+        split_num: usize,
+    ) -> Vec<Vec<FileScanTask>> {
+        #[derive(Default)]
+        struct FileScanTaskGroup {
+            idx: usize,
+            tasks: Vec<FileScanTask>,
+            total_length: u64,
+        }
+
+        impl Ord for FileScanTaskGroup {
+            fn cmp(&self, other: &Self) -> Ordering {
+                // when total_length is the same, we will sort by index
+                if self.total_length == other.total_length {
+                    self.idx.cmp(&other.idx)
+                } else {
+                    self.total_length.cmp(&other.total_length)
+                }
+            }
+        }
+
+        impl PartialOrd for FileScanTaskGroup {
+            fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+                Some(self.cmp(other))
+            }
+        }
+
+        impl Eq for FileScanTaskGroup {}
+
+        impl PartialEq for FileScanTaskGroup {
+            fn eq(&self, other: &Self) -> bool {
+                self.total_length == other.total_length
+            }
+        }
+
+        let mut heap = BinaryHeap::new();
+        // push all groups into heap
+        for idx in 0..split_num {
+            heap.push(Reverse(FileScanTaskGroup {
+                idx,
+                tasks: vec![],
+                total_length: 0,
+            }));
+        }
+
+        for file_task in file_scan_tasks {
+            let mut group = heap.peek_mut().unwrap();
+            group.0.total_length += file_task.length;
+            group.0.tasks.push(file_task);
+        }
+
+        // convert heap into vec and extract tasks
+        heap.into_vec()
+            .into_iter()
+            .map(|reverse_group| reverse_group.0.tasks)
+            .collect()
+    }
+}

--- a/src/connector/src/source/iceberg/planner.rs
+++ b/src/connector/src/source/iceberg/planner.rs
@@ -17,6 +17,7 @@ use std::collections::BinaryHeap;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
+use anyhow::Context;
 use futures::StreamExt;
 use futures::stream::BoxStream;
 use futures_async_stream::try_stream;
@@ -382,7 +383,10 @@ fn default_case_sensitive() -> bool {
 
 impl PersistedFileScanTask {
     pub fn decode(jsonb_ref: JsonbRef<'_>) -> ConnectorResult<FileScanTask> {
-        let persisted_task: Self = serde_json::from_value(jsonb_ref.to_owned_scalar().take())?;
+        let json = jsonb_ref.to_owned_scalar().take();
+        let persisted_task: Self = serde_json::from_value(json.clone()).with_context(|| {
+            format!("failed to decode persisted iceberg file scan task from json `{json}`")
+        })?;
         Ok(Self::to_task(persisted_task))
     }
 
@@ -652,7 +656,7 @@ impl IcebergScanTaskPlanner {
 
         impl PartialEq for FileScanTaskGroup {
             fn eq(&self, other: &Self) -> bool {
-                self.total_length == other.total_length
+                self.total_length == other.total_length && self.idx == other.idx
             }
         }
 

--- a/src/connector/src/source/iceberg/planner.rs
+++ b/src/connector/src/source/iceberg/planner.rs
@@ -15,7 +15,7 @@
 use std::cmp::{Ordering, Reverse};
 use std::collections::BinaryHeap;
 use std::sync::Arc;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use futures::StreamExt;
 use futures::stream::BoxStream;
@@ -331,7 +331,8 @@ async fn instrument_scan_task_stream(
     scan_tasks: iceberg::scan::FileScanTaskStream,
     metrics: Option<IcebergScanMetricsLabels>,
 ) {
-    let list_start = std::time::Instant::now();
+    let mut list_duration = Duration::default();
+    let mut active_since = Instant::now();
     let mut stats = IcebergScanPlanStats::default();
 
     let mut scan_tasks = scan_tasks;
@@ -341,11 +342,14 @@ async fn instrument_scan_task_stream(
             stats.record_task(&scan_task);
             metrics.record_delete_files_per_data_file(scan_task.deletes.len());
         }
+        list_duration += active_since.elapsed();
         yield scan_task;
+        active_since = Instant::now();
     }
+    list_duration += active_since.elapsed();
 
     if let Some(metrics) = &metrics {
-        metrics.record_list_duration(list_start.elapsed());
+        metrics.record_list_duration(list_duration);
         metrics.record_file_counts(&stats);
     }
 }

--- a/src/frontend/src/datafusion/iceberg_executor.rs
+++ b/src/frontend/src/datafusion/iceberg_executor.rs
@@ -37,8 +37,9 @@ use risingwave_common::catalog::{
     ICEBERG_FILE_PATH_COLUMN_NAME, ICEBERG_FILE_POS_COLUMN_NAME, ICEBERG_SEQUENCE_NUM_COLUMN_NAME,
 };
 use risingwave_common::util::iter_util::ZipEqFast;
-use risingwave_connector::source::iceberg::IcebergFileScanTask;
-use risingwave_connector::source::prelude::IcebergSplitEnumerator;
+use risingwave_connector::source::iceberg::{
+    IcebergFileScanTask, IcebergScanTaskBatchMode, IcebergScanTaskPlanner,
+};
 
 use super::{IcebergTableProvider, to_datafusion_error};
 
@@ -202,15 +203,12 @@ impl IcebergScan {
         });
 
         let scan_tasks = provider.task.tasks();
-        let tasks = if limit.is_some() {
-            // A scan-local limit must be enforced globally. Keep the tasks in a single partition
-            // so execution can stop after enough rows without scanning all files.
-            vec![scan_tasks.to_vec()]
-        } else if scan_tasks.len() <= batch_parallelism {
-            scan_tasks.iter().map(|task| vec![task.clone()]).collect()
-        } else {
-            IcebergSplitEnumerator::split_n_vecs(scan_tasks.to_vec(), batch_parallelism)
-        };
+        let tasks = IcebergScanTaskPlanner::plan_task_batches(
+            provider.task.clone(),
+            batch_parallelism,
+            limit.map(|limit| limit.try_into().unwrap_or(u64::MAX)),
+            IcebergScanTaskBatchMode::Compact,
+        );
         let statistics = tasks
             .iter()
             .map(|tasks| calculate_statistics(tasks.iter(), &arrow_schema))

--- a/src/frontend/src/optimizer/plan_node/batch_iceberg_scan.rs
+++ b/src/frontend/src/optimizer/plan_node/batch_iceberg_scan.rs
@@ -83,11 +83,7 @@ impl BatchIcebergScan {
     }
 
     pub fn iceberg_scan_type(&self) -> IcebergScanType {
-        match &self.task {
-            IcebergFileScanTask::Data(_) => IcebergScanType::DataScan,
-            IcebergFileScanTask::EqualityDelete(_) => IcebergScanType::EqualityDeleteScan,
-            IcebergFileScanTask::PositionDelete(_) => IcebergScanType::PositionDeleteScan,
-        }
+        self.task.scan_type()
     }
 
     pub fn predicate(&self) -> Option<String> {

--- a/src/frontend/src/optimizer/plan_node/logical_iceberg_scan.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_iceberg_scan.rs
@@ -70,11 +70,7 @@ impl LogicalIcebergScan {
     }
 
     pub fn iceberg_scan_type(&self) -> IcebergScanType {
-        match &self.task {
-            IcebergFileScanTask::Data(_) => IcebergScanType::DataScan,
-            IcebergFileScanTask::EqualityDelete(_) => IcebergScanType::EqualityDeleteScan,
-            IcebergFileScanTask::PositionDelete(_) => IcebergScanType::PositionDeleteScan,
-        }
+        self.task.scan_type()
     }
 }
 

--- a/src/frontend/src/scheduler/plan_fragmenter.rs
+++ b/src/frontend/src/scheduler/plan_fragmenter.rs
@@ -35,9 +35,7 @@ use risingwave_connector::source::filesystem::opendal_source::opendal_enumerator
 use risingwave_connector::source::filesystem::opendal_source::{
     BatchPosixFsEnumerator, OpendalAzblob, OpendalGcs, OpendalS3,
 };
-use risingwave_connector::source::iceberg::{
-    IcebergFileScanTask, IcebergSplit, IcebergSplitEnumerator,
-};
+use risingwave_connector::source::iceberg::{IcebergFileScanTask, IcebergScanTaskPlanner};
 use risingwave_connector::source::kafka::KafkaSplitEnumerator;
 use risingwave_connector::source::prelude::DatagenSplitEnumerator;
 use risingwave_connector::source::reader::reader::build_opendal_fs_list_for_batch;
@@ -380,40 +378,13 @@ impl SourceScanInfo {
 
 impl UnpartitionedData {
     fn complete(self, batch_parallelism: usize) -> SchedulerResult<SourceScanInfo> {
-        macro_rules! iceberg_tasks {
-            ($tasks:expr, $variant:ident, $limit:expr) => {
-                if let Some(limit) = $limit {
-                    vec![SplitImpl::Iceberg(IcebergSplit {
-                        split_id: 0,
-                        task: IcebergFileScanTask::$variant($tasks),
-                        limit: Some(limit),
-                    })]
-                } else {
-                    IcebergSplitEnumerator::split_n_vecs($tasks, batch_parallelism)
-                        .into_iter()
-                        .enumerate()
-                        .map(|(id, tasks)| {
-                            SplitImpl::Iceberg(IcebergSplit {
-                                split_id: id.try_into().unwrap(),
-                                task: IcebergFileScanTask::$variant(tasks),
-                                limit: None,
-                            })
-                        })
-                        .collect()
-                }
-            };
-        }
-
         let splits = match self {
-            UnpartitionedData::Iceberg { task, limit } => match task {
-                IcebergFileScanTask::Data(tasks) => iceberg_tasks!(tasks, Data, limit),
-                IcebergFileScanTask::EqualityDelete(tasks) => {
-                    iceberg_tasks!(tasks, EqualityDelete, None)
-                }
-                IcebergFileScanTask::PositionDelete(tasks) => {
-                    iceberg_tasks!(tasks, PositionDelete, None)
-                }
-            },
+            UnpartitionedData::Iceberg { task, limit } => {
+                IcebergScanTaskPlanner::plan_splits(task, batch_parallelism, limit)?
+                    .into_iter()
+                    .map(SplitImpl::Iceberg)
+                    .collect()
+            }
         };
         Ok(SourceScanInfo::Complete(splits))
     }

--- a/src/stream/src/executor/source/batch_source/batch_iceberg_fetch.rs
+++ b/src/stream/src/executor/source/batch_source/batch_iceberg_fetch.rs
@@ -28,14 +28,14 @@ use risingwave_common::types::{JsonbVal, Scalar, ScalarRef};
 use risingwave_connector::source::iceberg::metrics::{
     GLOBAL_ICEBERG_SCAN_METRICS, IcebergScanMetrics,
 };
-use risingwave_connector::source::iceberg::{IcebergScanOpts, scan_task_to_chunk_with_deletes};
+use risingwave_connector::source::iceberg::{
+    IcebergScanOpts, PersistedFileScanTask, scan_task_to_chunk_with_deletes,
+};
 use risingwave_connector::source::reader::desc::SourceDesc;
 use thiserror_ext::AsReport;
 
 use crate::executor::prelude::*;
-use crate::executor::source::{
-    ChunksWithState, PersistedFileScanTask, StreamSourceCore, prune_additional_cols,
-};
+use crate::executor::source::{ChunksWithState, StreamSourceCore, prune_additional_cols};
 use crate::executor::stream_reader::StreamReaderWithPause;
 use crate::task::LocalBarrierManager;
 
@@ -528,12 +528,7 @@ impl<S: StateStore> BatchIcebergFetchExecutor<S> {
             for chunk_result in scan_task_to_chunk_with_deletes(
                 table.clone(),
                 task,
-                IcebergScanOpts {
-                    chunk_size,
-                    need_seq_num: true, // Keep for potential future usage
-                    need_file_path_and_pos: true,
-                    handle_delete_files: true,
-                },
+                IcebergScanOpts::new(chunk_size, true, true, true),
                 Some(metrics.clone()),
             ) {
                 let chunk = chunk_result?;

--- a/src/stream/src/executor/source/batch_source/batch_iceberg_list.rs
+++ b/src/stream/src/executor/source/batch_source/batch_iceberg_list.rs
@@ -12,23 +12,23 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use anyhow::{Context, anyhow};
+use anyhow::anyhow;
 use either::Either;
-use iceberg::scan::FileScanTask;
 use parking_lot::RwLock;
 use risingwave_common::array::Op;
 use risingwave_common::catalog::ColumnCatalog;
 use risingwave_common::id::TableId;
 use risingwave_common::metrics::GLOBAL_ERROR_METRICS;
 use risingwave_connector::source::ConnectorProperties;
-use risingwave_connector::source::iceberg::IcebergProperties;
-use risingwave_connector::source::iceberg::metrics::GLOBAL_ICEBERG_SCAN_METRICS;
+use risingwave_connector::source::iceberg::{
+    IcebergScanMetricsLabels, IcebergScanPlanner, IcebergScanProjection, PersistedFileScanTask,
+};
 use risingwave_connector::source::reader::desc::SourceDescBuilder;
 use thiserror_ext::AsReport;
 use tokio::sync::mpsc::UnboundedReceiver;
 
 use crate::executor::prelude::*;
-use crate::executor::source::{PersistedFileScanTask, StreamSourceCore, barrier_to_message_stream};
+use crate::executor::source::{StreamSourceCore, barrier_to_message_stream};
 use crate::executor::stream_reader::StreamReaderWithPause;
 use crate::task::LocalBarrierManager;
 
@@ -95,29 +95,16 @@ impl<S: StateStore> BatchIcebergListExecutor<S> {
             unreachable!()
         };
 
-        // Get consistent column names for schema stability across snapshots
-        let downstream_columns = self.downstream_columns.map(|columns| {
-            columns
-                .iter()
-                .filter_map(|col| {
-                    if col.is_hidden() {
-                        None
-                    } else {
-                        Some(col.name().to_owned())
-                    }
-                })
-                .collect::<Vec<_>>()
-        });
-        // Initialize metrics context.
-        let iceberg_metrics = &GLOBAL_ICEBERG_SCAN_METRICS;
         let iceberg_table_name = iceberg_properties.table.table_name().to_owned();
         let source_id_str = self.stream_source_core.source_id.to_string();
         let source_name_str = self.stream_source_core.source_name.clone();
-        let metrics_labels = [
-            source_id_str.as_str(),
-            source_name_str.as_str(),
-            iceberg_table_name.as_str(),
-        ];
+        let scan_metrics =
+            IcebergScanMetricsLabels::new(source_id_str, source_name_str, iceberg_table_name);
+        let scan_planner = IcebergScanPlanner::new(
+            (*iceberg_properties).clone(),
+            IcebergScanProjection::from_downstream_columns(self.downstream_columns.as_deref()),
+            Some(scan_metrics.clone()),
+        );
 
         yield Message::Barrier(first_barrier);
         let barrier_stream = barrier_to_message_stream(barrier_receiver).boxed();
@@ -141,15 +128,7 @@ impl<S: StateStore> BatchIcebergListExecutor<S> {
                         self.associated_table_id.to_string(),
                     ]);
 
-                    iceberg_metrics
-                        .iceberg_source_scan_errors_total
-                        .with_guarded_label_values(&[
-                            metrics_labels[0],
-                            metrics_labels[1],
-                            metrics_labels[2],
-                            "list_error",
-                        ])
-                        .inc();
+                    scan_metrics.record_scan_error("list_error");
 
                     if is_refreshing {
                         tracing::info!(
@@ -158,11 +137,8 @@ impl<S: StateStore> BatchIcebergListExecutor<S> {
                             "re-listing iceberg scan tasks due to error"
                         );
                         let iceberg_list_stream = Self::list_iceberg_scan_task(
-                            *iceberg_properties.clone(),
-                            downstream_columns.clone(),
+                            scan_planner.clone(),
                             is_list_finished.clone(),
-                            source_id_str.clone(),
-                            source_name_str.clone(),
                         )
                         .boxed();
                         stream.replace_data_stream(iceberg_list_stream);
@@ -197,11 +173,8 @@ impl<S: StateStore> BatchIcebergListExecutor<S> {
 
                                         // re-list iceberg scan tasks
                                         let iceberg_list_stream = Self::list_iceberg_scan_task(
-                                            *iceberg_properties.clone(),
-                                            downstream_columns.clone(),
+                                            scan_planner.clone(),
                                             is_list_finished.clone(),
-                                            source_id_str.clone(),
-                                            source_name_str.clone(),
                                         )
                                         .boxed();
                                         stream.replace_data_stream(iceberg_list_stream);
@@ -232,14 +205,14 @@ impl<S: StateStore> BatchIcebergListExecutor<S> {
                         _ => unreachable!(),
                     },
                     Either::Right(file_scan_task) => {
+                        let data_file_path = file_scan_task.data_file_path.clone();
+                        let persisted_task = PersistedFileScanTask::encode(file_scan_task)?;
                         let chunk = StreamChunk::from_rows(
                             &[(
                                 Op::Insert,
                                 OwnedRow::new(vec![
-                                    Some(ScalarImpl::Utf8(file_scan_task.data_file_path().into())),
-                                    Some(ScalarImpl::Jsonb(PersistedFileScanTask::encode(
-                                        file_scan_task,
-                                    ))),
+                                    Some(ScalarImpl::Utf8(data_file_path.into())),
+                                    Some(ScalarImpl::Jsonb(persisted_task)),
                                 ]),
                             )],
                             &[DataType::Varchar, DataType::Jsonb],
@@ -252,100 +225,24 @@ impl<S: StateStore> BatchIcebergListExecutor<S> {
         }
     }
 
-    #[try_stream(ok = FileScanTask, error = StreamExecutorError)]
+    #[try_stream(
+        ok = iceberg::scan::FileScanTask,
+        error = StreamExecutorError
+    )]
     async fn list_iceberg_scan_task(
-        iceberg_properties: IcebergProperties,
-        downstream_columns: Option<Vec<String>>,
+        scan_planner: IcebergScanPlanner,
         is_list_finished: Arc<RwLock<bool>>,
-        source_id: String,
-        source_name: String,
     ) {
-        let metrics = &GLOBAL_ICEBERG_SCAN_METRICS;
-        let table_name = iceberg_properties.table.table_name().to_owned();
-        let label_values = [
-            source_id.as_str(),
-            source_name.as_str(),
-            table_name.as_str(),
-        ];
-
-        let table = iceberg_properties.load_table().await?;
-        if let Some(start_snapshot) = table.metadata().current_snapshot() {
-            let latest_snapshot = start_snapshot.snapshot_id();
-            let snapshot_scan_builder = table.scan().snapshot_id(latest_snapshot);
-            let snapshot_scan = if let Some(ref downstream_columns) = downstream_columns {
-                snapshot_scan_builder.select(downstream_columns)
-            } else {
-                snapshot_scan_builder.select_all()
-            }
-            .build()
-            .context("failed to build iceberg scan")?;
-
-            let list_start = std::time::Instant::now();
-            let mut data_file_count: u64 = 0;
-            let mut eq_delete_count: u64 = 0;
-            let mut pos_delete_count: u64 = 0;
-
+        if let Some(snapshot_plan) = scan_planner.plan_current_snapshot().await? {
             #[for_await]
-            for scan_task in snapshot_scan
-                .plan_files()
-                .await
-                .context("failed to plan iceberg files")?
-            {
-                let scan_task = scan_task.context("failed to get scan task")?;
-                data_file_count += 1;
-                for delete_task in &scan_task.deletes {
-                    match delete_task.data_file_content {
-                        iceberg::spec::DataContentType::EqualityDeletes => eq_delete_count += 1,
-                        iceberg::spec::DataContentType::PositionDeletes => pos_delete_count += 1,
-                        _ => {}
-                    }
-                }
+            for scan_task in snapshot_plan.tasks {
+                let scan_task = scan_task?;
                 tracing::debug!(
                     "list_iceberg_scan_task: data_file_path={}, scan_task={:?}",
                     scan_task.data_file_path,
                     scan_task
                 );
                 yield scan_task;
-            }
-
-            let list_duration = list_start.elapsed();
-            metrics
-                .iceberg_source_list_duration_seconds
-                .with_guarded_label_values(&label_values)
-                .observe(list_duration.as_secs_f64());
-
-            if data_file_count > 0 {
-                metrics
-                    .iceberg_source_files_discovered_total
-                    .with_guarded_label_values(&[
-                        label_values[0],
-                        label_values[1],
-                        label_values[2],
-                        "data",
-                    ])
-                    .inc_by(data_file_count);
-            }
-            if eq_delete_count > 0 {
-                metrics
-                    .iceberg_source_files_discovered_total
-                    .with_guarded_label_values(&[
-                        label_values[0],
-                        label_values[1],
-                        label_values[2],
-                        "eq_delete",
-                    ])
-                    .inc_by(eq_delete_count);
-            }
-            if pos_delete_count > 0 {
-                metrics
-                    .iceberg_source_files_discovered_total
-                    .with_guarded_label_values(&[
-                        label_values[0],
-                        label_values[1],
-                        label_values[2],
-                        "pos_delete",
-                    ])
-                    .inc_by(pos_delete_count);
             }
         }
         *is_list_finished.write() = true;

--- a/src/stream/src/executor/source/iceberg_fetch_executor.rs
+++ b/src/stream/src/executor/source/iceberg_fetch_executor.rs
@@ -29,7 +29,9 @@ use risingwave_common::hash::VnodeBitmapExt;
 use risingwave_common::id::SourceId;
 use risingwave_common::types::{JsonbVal, ScalarRef, Serial, ToOwnedDatum};
 use risingwave_connector::source::iceberg::metrics::GLOBAL_ICEBERG_SCAN_METRICS;
-use risingwave_connector::source::iceberg::{IcebergScanOpts, scan_task_to_chunk_with_deletes};
+use risingwave_connector::source::iceberg::{
+    IcebergScanOpts, PersistedFileScanTask, scan_task_to_chunk_with_deletes,
+};
 use risingwave_connector::source::reader::desc::SourceDesc;
 use risingwave_connector::source::{SourceContext, SourceCtrlOpts};
 use risingwave_pb::common::ThrottleType;
@@ -77,205 +79,6 @@ pub(crate) struct ChunksWithState {
     /// The last read position in the file, used for checkpointing.
     #[expect(dead_code)]
     pub last_read_pos: Datum,
-}
-
-pub(super) use state::PersistedFileScanTask;
-mod state {
-    use std::sync::Arc;
-
-    use anyhow::Context;
-    use iceberg::expr::BoundPredicate;
-    use iceberg::scan::FileScanTask;
-    use iceberg::spec::{DataContentType, DataFileFormat, SchemaRef};
-    use risingwave_common::types::{JsonbRef, JsonbVal, ScalarRef};
-    use serde::{Deserialize, Serialize};
-
-    use crate::executor::StreamExecutorResult;
-
-    fn default_case_sensitive() -> bool {
-        true
-    }
-    /// This corresponds to the actually persisted `FileScanTask` in the state table.
-    ///
-    /// We introduce this in case the definition of [`FileScanTask`] changes in the iceberg-rs crate.
-    /// Currently, they have the same definition.
-    ///
-    /// We can handle possible compatibility issues in [`Self::from_task`] and [`Self::to_task`].
-    /// A version id needs to be introduced then.
-    #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-    pub struct PersistedFileScanTask {
-        /// The start offset of the file to scan.
-        pub start: u64,
-        /// The length of the file to scan.
-        pub length: u64,
-        /// The number of records in the file to scan.
-        ///
-        /// This is an optional field, and only available if we are
-        /// reading the entire data file.
-        pub record_count: Option<u64>,
-
-        /// The data file path corresponding to the task.
-        pub data_file_path: String,
-
-        /// The data file referenced by a deletion vector.
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        pub referenced_data_file: Option<String>,
-
-        /// The content type of the file to scan.
-        pub data_file_content: DataContentType,
-
-        /// The format of the file to scan.
-        pub data_file_format: DataFileFormat,
-
-        /// The schema of the file to scan.
-        pub schema: SchemaRef,
-        /// The field ids to project.
-        pub project_field_ids: Vec<i32>,
-        /// The predicate to filter.
-        #[serde(skip_serializing_if = "Option::is_none")]
-        pub predicate: Option<BoundPredicate>,
-
-        /// The list of delete files that may need to be applied to this data file
-        pub deletes: Vec<PersistedFileScanTask>,
-        /// sequence number
-        pub sequence_number: i64,
-        /// equality ids
-        pub equality_ids: Option<Vec<i32>>,
-
-        pub file_size_in_bytes: u64,
-
-        #[serde(default = "default_case_sensitive")]
-        pub case_sensitive: bool,
-    }
-
-    impl PersistedFileScanTask {
-        /// First decodes the json to the struct, then converts the struct to a [`FileScanTask`].
-        pub fn decode(jsonb_ref: JsonbRef<'_>) -> StreamExecutorResult<FileScanTask> {
-            let persisted_task: Self =
-                serde_json::from_value(jsonb_ref.to_owned_scalar().take())
-                    .with_context(|| format!("invalid state: {:?}", jsonb_ref))?;
-            Ok(Self::to_task(persisted_task))
-        }
-
-        /// First converts the [`FileScanTask`] to a persisted one, then encodes the persisted one to a jsonb value.
-        pub fn encode(task: FileScanTask) -> JsonbVal {
-            let persisted_task = Self::from_task(task);
-            serde_json::to_value(persisted_task).unwrap().into()
-        }
-
-        /// Converts a persisted task to a [`FileScanTask`].
-        fn to_task(
-            Self {
-                start,
-                length,
-                record_count,
-                data_file_path,
-                referenced_data_file,
-                data_file_content,
-                data_file_format,
-                schema,
-                project_field_ids,
-                predicate,
-                deletes,
-                sequence_number,
-                equality_ids,
-                file_size_in_bytes,
-                case_sensitive,
-            }: Self,
-        ) -> FileScanTask {
-            FileScanTask {
-                start,
-                length,
-                record_count,
-                data_file_path,
-                referenced_data_file,
-                data_file_content,
-                data_file_format,
-                schema,
-                project_field_ids,
-                predicate,
-                deletes: deletes
-                    .into_iter()
-                    .map(|task| Arc::new(PersistedFileScanTask::to_task(task)))
-                    .collect(),
-                sequence_number,
-                equality_ids,
-                file_size_in_bytes,
-                partition: None,
-                partition_spec: None,
-                name_mapping: None,
-                case_sensitive,
-            }
-        }
-
-        /// Changes a [`FileScanTask`] to a persisted one.
-        fn from_task(
-            FileScanTask {
-                start,
-                length,
-                record_count,
-                data_file_path,
-                referenced_data_file,
-                data_file_content,
-                data_file_format,
-                schema,
-                project_field_ids,
-                predicate,
-                deletes,
-                sequence_number,
-                equality_ids,
-                file_size_in_bytes,
-                case_sensitive,
-                ..
-            }: FileScanTask,
-        ) -> Self {
-            Self {
-                start,
-                length,
-                record_count,
-                data_file_path,
-                referenced_data_file,
-                data_file_content,
-                data_file_format,
-                schema,
-                project_field_ids,
-                predicate,
-                deletes: deletes
-                    .into_iter()
-                    .map(PersistedFileScanTask::from_task_ref)
-                    .collect(),
-                sequence_number,
-                equality_ids,
-                file_size_in_bytes,
-                case_sensitive,
-            }
-        }
-
-        fn from_task_ref(task: Arc<FileScanTask>) -> Self {
-            Self {
-                start: task.start,
-                length: task.length,
-                record_count: task.record_count,
-                data_file_path: task.data_file_path.clone(),
-                referenced_data_file: task.referenced_data_file.clone(),
-                data_file_content: task.data_file_content,
-                data_file_format: task.data_file_format,
-                schema: task.schema.clone(),
-                project_field_ids: task.project_field_ids.clone(),
-                predicate: task.predicate.clone(),
-                deletes: task
-                    .deletes
-                    .iter()
-                    .cloned()
-                    .map(PersistedFileScanTask::from_task_ref)
-                    .collect(),
-                sequence_number: task.sequence_number,
-                equality_ids: task.equality_ids.clone(),
-                file_size_in_bytes: task.file_size_in_bytes,
-                case_sensitive: task.case_sensitive,
-            }
-        }
-    }
 }
 
 impl<S: StateStore> IcebergFetchExecutor<S> {
@@ -395,6 +198,9 @@ impl<S: StateStore> IcebergFetchExecutor<S> {
                     chunk_size: streaming_config.developer.chunk_size,
                     need_seq_num: true, /* Although this column is unnecessary, we still keep it for potential usage in the future */
                     need_file_path_and_pos: true,
+                    // Iceberg V2 position/equality deletes are exposed as separate delete-file
+                    // tasks for table-engine reads. V3 deletion vectors should be applied by
+                    // iceberg-rs while scanning the data file.
                     handle_delete_files: table.metadata().format_version()
                         >= iceberg::spec::FormatVersion::V3,
                 },

--- a/src/stream/src/executor/source/iceberg_list_executor.rs
+++ b/src/stream/src/executor/source/iceberg_list_executor.rs
@@ -14,24 +14,24 @@
 
 use std::sync::Arc;
 
-use anyhow::{Context, anyhow};
+use anyhow::anyhow;
 use either::Either;
 use futures_async_stream::try_stream;
-use iceberg::scan::FileScanTask;
-use iceberg::spec::DataContentType;
 use parking_lot::Mutex;
 use risingwave_common::array::Op;
 use risingwave_common::catalog::ColumnCatalog;
 use risingwave_common::config::StreamingConfig;
 use risingwave_common::system_param::local_manager::SystemParamsReaderRef;
 use risingwave_connector::source::ConnectorProperties;
-use risingwave_connector::source::iceberg::IcebergProperties;
-use risingwave_connector::source::iceberg::metrics::GLOBAL_ICEBERG_SCAN_METRICS;
+use risingwave_connector::source::iceberg::{
+    IcebergIncrementalScan, IcebergScanMetricsLabels, IcebergScanPlanner, IcebergScanProjection,
+    PersistedFileScanTask,
+};
 use risingwave_connector::source::reader::desc::SourceDescBuilder;
 use thiserror_ext::AsReport;
 use tokio::sync::mpsc::UnboundedReceiver;
 
-use super::{PersistedFileScanTask, StreamSourceCore, barrier_to_message_stream};
+use super::{StreamSourceCore, barrier_to_message_stream};
 use crate::executor::prelude::*;
 use crate::executor::stream_reader::StreamReaderWithPause;
 
@@ -114,24 +114,27 @@ impl<S: StateStore> IcebergListExecutor<S> {
             unreachable!()
         };
 
-        // Get consistent column names for schema stability across snapshots
-        let downstream_columns = self.downstream_columns.map(|columns| {
-            columns
-                .iter()
-                .filter_map(|col| {
-                    if col.is_hidden() {
-                        None
-                    } else {
-                        Some(col.name().to_owned())
-                    }
-                })
-                .collect::<Vec<_>>()
-        });
+        let scan_projection =
+            IcebergScanProjection::from_downstream_columns(self.downstream_columns.as_deref());
 
-        tracing::debug!("downstream_columns: {:?}", downstream_columns);
+        tracing::debug!("scan_projection: {:?}", scan_projection);
 
         yield Message::Barrier(first_barrier);
         let barrier_stream = barrier_to_message_stream(barrier_receiver).boxed();
+
+        let source_id_str = self.stream_source_core.source_id.to_string();
+        let source_name_str = self.stream_source_core.source_name.clone();
+        let table_name = iceberg_properties.table.table_name().to_owned();
+        let scan_metrics = IcebergScanMetricsLabels::new(
+            source_id_str.clone(),
+            source_name_str.clone(),
+            table_name,
+        );
+        let scan_planner = IcebergScanPlanner::new(
+            (*iceberg_properties).clone(),
+            scan_projection,
+            Some(scan_metrics.clone()),
+        );
 
         let state_table = self.stream_source_core.split_state_store.state_table_mut();
         state_table.init_epoch(first_epoch).await?;
@@ -143,39 +146,23 @@ impl<S: StateStore> IcebergListExecutor<S> {
         if last_snapshot.is_none() {
             // do a regular scan, then switch to incremental scan
             // TODO: we may support starting from a specific snapshot/timestamp later
-            let table = iceberg_properties.load_table().await?;
-            // If current_snapshot is None (empty table), we go to incremental scan directly.
-            if let Some(start_snapshot) = table.metadata().current_snapshot() {
-                last_snapshot = Some(start_snapshot.snapshot_id());
-                let snapshot_scan_builder = table.scan().snapshot_id(start_snapshot.snapshot_id());
-
-                let snapshot_scan = if let Some(ref downstream_columns) = downstream_columns {
-                    snapshot_scan_builder.select(downstream_columns)
-                } else {
-                    // for backward compatibility
-                    snapshot_scan_builder.select_all()
-                }
-                .build()
-                .context("failed to build iceberg scan")?;
-
+            // If the current snapshot is None (empty table), go to incremental scan directly.
+            if let Some(snapshot_plan) = scan_planner.plan_current_snapshot().await? {
+                last_snapshot = Some(snapshot_plan.snapshot_id);
                 let mut chunk_builder = StreamChunkBuilder::new(
                     self.streaming_config.developer.chunk_size,
                     vec![DataType::Varchar, DataType::Jsonb],
                 );
                 #[for_await]
-                for scan_task in snapshot_scan
-                    .plan_files()
-                    .await
-                    .context("failed to plan iceberg files")?
-                {
-                    let scan_task = scan_task.context("failed to get scan task")?;
+                for scan_task in snapshot_plan.tasks {
+                    let scan_task = scan_task?;
+                    let data_file_path = scan_task.data_file_path.clone();
+                    let persisted_task = PersistedFileScanTask::encode(scan_task)?;
                     if let Some(chunk) = chunk_builder.append_row(
                         Op::Insert,
                         &[
-                            Some(ScalarImpl::Utf8(scan_task.data_file_path().into())),
-                            Some(ScalarImpl::Jsonb(
-                                serde_json::to_value(scan_task).unwrap().into(),
-                            )),
+                            Some(ScalarImpl::Utf8(data_file_path.into())),
+                            Some(ScalarImpl::Jsonb(persisted_task)),
                         ],
                     ) {
                         yield Message::Chunk(chunk);
@@ -187,28 +174,22 @@ impl<S: StateStore> IcebergListExecutor<S> {
             }
         }
 
-        let source_id_str = self.stream_source_core.source_id.to_string();
-        let source_name_str = self.stream_source_core.source_name.clone();
-        let list_table_name = iceberg_properties.table.table_name().to_owned();
-        let list_metrics = &GLOBAL_ICEBERG_SCAN_METRICS;
-
         let last_snapshot = Arc::new(Mutex::new(last_snapshot));
         let build_incremental_stream = || {
             incremental_scan_stream(
-                (*iceberg_properties).clone(),
+                scan_planner.clone(),
                 last_snapshot.clone(),
                 self.streaming_config.developer.iceberg_list_interval_sec,
-                downstream_columns.clone(),
-                source_id_str.clone(),
-                source_name_str.clone(),
             )
             .map(|res| match res {
                 Ok(scan_task) => {
+                    let data_file_path = scan_task.data_file_path.clone();
+                    let persisted_task = PersistedFileScanTask::encode(scan_task)?;
                     let row = (
                         Op::Insert,
                         OwnedRow::new(vec![
-                            Some(ScalarImpl::Utf8(scan_task.data_file_path().into())),
-                            Some(ScalarImpl::Jsonb(PersistedFileScanTask::encode(scan_task))),
+                            Some(ScalarImpl::Utf8(data_file_path.into())),
+                            Some(ScalarImpl::Jsonb(persisted_task)),
                         ]),
                     );
                     Ok(StreamChunk::from_rows(
@@ -232,15 +213,7 @@ impl<S: StateStore> IcebergListExecutor<S> {
                         error = %e.as_report(),
                         "incremental iceberg list stream errored, rebuilding"
                     );
-                    list_metrics
-                        .iceberg_source_scan_errors_total
-                        .with_guarded_label_values(&[
-                            source_id_str.as_str(),
-                            source_name_str.as_str(),
-                            list_table_name.as_str(),
-                            "list_error",
-                        ])
-                        .inc();
+                    scan_metrics.record_scan_error("list_error");
                     stream.replace_data_stream(build_incremental_stream());
                 }
                 Ok(msg) => match msg {
@@ -287,167 +260,33 @@ impl<S: StateStore> IcebergListExecutor<S> {
 }
 
 /// `last_snapshot` is EXCLUSIVE (i.e., already scanned)
-#[try_stream(boxed, ok = FileScanTask, error = StreamExecutorError)]
+#[try_stream(
+    boxed,
+    ok = iceberg::scan::FileScanTask,
+    error = StreamExecutorError
+)]
 async fn incremental_scan_stream(
-    iceberg_properties: IcebergProperties,
+    scan_planner: IcebergScanPlanner,
     last_snapshot_lock: Arc<Mutex<Option<i64>>>,
     list_interval_sec: u64,
-    downstream_columns: Option<Vec<String>>,
-    source_id: String,
-    source_name: String,
 ) {
-    let metrics = &GLOBAL_ICEBERG_SCAN_METRICS;
-    let table_name = iceberg_properties.table.table_name().to_owned();
-    let label_values = [
-        source_id.as_str(),
-        source_name.as_str(),
-        table_name.as_str(),
-    ];
-
     let mut last_snapshot: Option<i64> = *last_snapshot_lock.lock();
     loop {
         tokio::time::sleep(std::time::Duration::from_secs(list_interval_sec)).await;
 
-        // XXX: should we use sth like table.refresh() instead of reload the table every time?
-        // iceberg-java does this, but iceberg-rust doesn't have this API now.
-        let table = iceberg_properties.load_table().await?;
-
-        let Some(current_snapshot) = table.metadata().current_snapshot() else {
-            tracing::info!("Skip incremental scan because table is empty");
-            continue;
-        };
-
-        if Some(current_snapshot.snapshot_id()) == last_snapshot {
-            // Ingestion is caught up — lag is 0.
-            metrics
-                .iceberg_source_snapshot_lag_seconds
-                .with_guarded_label_values(&label_values)
-                .set(0);
-
-            tracing::info!(
-                "Current table snapshot is already enumerated: {}, no new snapshot available",
-                current_snapshot.snapshot_id()
-            );
-            continue;
-        }
-
-        if let Some(last_snapshot_id) = last_snapshot
-            && let Some(last_ingested_snapshot) = table
-                .metadata()
-                .snapshots()
-                .find(|snapshot| snapshot.snapshot_id() == last_snapshot_id)
-        {
-            let lag_secs =
-                (current_snapshot.timestamp_ms() - last_ingested_snapshot.timestamp_ms()).max(0)
-                    / 1000;
-            metrics
-                .iceberg_source_snapshot_lag_seconds
-                .with_guarded_label_values(&label_values)
-                .set(lag_secs);
-        }
-
-        // New snapshot discovered.
-        metrics
-            .iceberg_source_snapshots_discovered_total
-            .with_guarded_label_values(&label_values)
-            .inc();
-
-        let mut incremental_scan = table.scan().to_snapshot_id(current_snapshot.snapshot_id());
-        if let Some(last_snapshot) = last_snapshot {
-            incremental_scan = incremental_scan.from_snapshot_id(last_snapshot);
-        }
-        let incremental_scan = if let Some(ref downstream_columns) = downstream_columns {
-            incremental_scan.select(downstream_columns)
-        } else {
-            // for backward compatibility
-            incremental_scan.select_all()
-        }
-        .build()
-        .context("failed to build iceberg scan")?;
-
-        let mut list_duration = std::time::Duration::default();
-        let mut active_since = std::time::Instant::now();
-        let mut data_file_count: u64 = 0;
-        let mut eq_delete_count: u64 = 0;
-        let mut pos_delete_count: u64 = 0;
-
-        #[for_await]
-        for scan_task in incremental_scan
-            .plan_files()
-            .await
-            .context("failed to plan iceberg files")?
-        {
-            let scan_task = scan_task.context("failed to get scan task")?;
-
-            // Count file types: the main task is a data file, deletes are attached.
-            data_file_count += 1;
-            for delete_task in &scan_task.deletes {
-                match delete_task.data_file_content {
-                    DataContentType::EqualityDeletes => eq_delete_count += 1,
-                    DataContentType::PositionDeletes => pos_delete_count += 1,
-                    _ => {}
+        match scan_planner.plan_incremental(last_snapshot).await? {
+            IcebergIncrementalScan::EmptyTable | IcebergIncrementalScan::UpToDate { .. } => {}
+            IcebergIncrementalScan::Planned(plan) => {
+                #[for_await]
+                for scan_task in plan.tasks {
+                    yield scan_task?;
                 }
+
+                last_snapshot = Some(plan.snapshot_id);
+                *last_snapshot_lock.lock() = last_snapshot;
+                scan_planner.record_caught_up();
             }
-
-            // Record delete files per data file.
-            metrics
-                .iceberg_source_delete_files_per_data_file
-                .with_guarded_label_values(&label_values)
-                .observe(scan_task.deletes.len() as f64);
-
-            list_duration += active_since.elapsed();
-            yield scan_task;
-            active_since = std::time::Instant::now();
         }
-
-        list_duration += active_since.elapsed();
-        metrics
-            .iceberg_source_list_duration_seconds
-            .with_guarded_label_values(&label_values)
-            .observe(list_duration.as_secs_f64());
-
-        if data_file_count > 0 {
-            metrics
-                .iceberg_source_files_discovered_total
-                .with_guarded_label_values(&[
-                    label_values[0],
-                    label_values[1],
-                    label_values[2],
-                    "data",
-                ])
-                .inc_by(data_file_count);
-        }
-        if eq_delete_count > 0 {
-            metrics
-                .iceberg_source_files_discovered_total
-                .with_guarded_label_values(&[
-                    label_values[0],
-                    label_values[1],
-                    label_values[2],
-                    "eq_delete",
-                ])
-                .inc_by(eq_delete_count);
-        }
-        if pos_delete_count > 0 {
-            metrics
-                .iceberg_source_files_discovered_total
-                .with_guarded_label_values(&[
-                    label_values[0],
-                    label_values[1],
-                    label_values[2],
-                    "pos_delete",
-                ])
-                .inc_by(pos_delete_count);
-        }
-
-        // This scan has fully ingested the latest snapshot we observed, so lag returns to 0.
-        metrics
-            .iceberg_source_snapshot_lag_seconds
-            .with_guarded_label_values(&label_values)
-            .set(0);
-
-        last_snapshot = Some(current_snapshot.snapshot_id());
-        *last_snapshot_lock.lock() = last_snapshot;
     }
 }
 


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

This PR refactors Iceberg source scan planning into a shared connector-side planner so list/fetch/batch/stream paths use the same scan-task planning primitives.

- Add `src/connector/src/source/iceberg/planner.rs` for shared Iceberg scan planning, projection selection, scan metrics, persisted scan-task serde, and scan-task split batching.
- Reuse the shared planner from streaming list and batch refresh list executors for full scan, incremental scan, refresh listing, downstream column projection, and list metrics.
- Reuse the shared task planner from the batch scheduler and DataFusion executor so limit handling and split batching stay consistent across execution paths.
- Move persisted `FileScanTask` encode/decode out of the stream fetch executor and remove source split `unwrap()` / `unimplemented!()` paths from regular split metadata handling.
- Keep the Iceberg V2/V3 delete-file handling rationale at the fetch call sites where the version-specific scan option is selected.

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

Not required. This is an internal Iceberg source refactor with no intended user-visible behavior change.

</details>
