### PR TITLE
fix(meta): drop recovered streaming jobs without actor info

### DIFF
--- a/src/meta/src/barrier/schedule.rs
+++ b/src/meta/src/barrier/schedule.rs
@@ -785,7 +785,11 @@ impl ScheduledBarriers {
                         unreachable!("only drop and cancel streaming jobs should be buffered");
                     }
                 }
-                notifiers.into_iter().for_each(|notify| {
+                // `run_command` waits for both the started and collected notifications. These
+                // buffered commands are pre-applied during recovery without injecting a real
+                // barrier, so complete both waiters here.
+                notifiers.into_iter().for_each(|mut notify| {
+                    notify.notify_started();
                     notify.notify_collected();
                 });
             }

--- a/src/meta/src/controller/streaming_job.rs
+++ b/src/meta/src/controller/streaming_job.rs
@@ -857,39 +857,67 @@ impl CatalogController {
         Ok(())
     }
 
-    /// Builds a cancel command for the streaming job. If the sink (with target table) needs to be dropped, additional
-    /// information is required to build barrier mutation.
+    /// Builds a cancel command from persisted fragment metadata without reading `SharedActorInfos`.
+    ///
+    /// Returns `None` if the job no longer exists or has already been created.
     pub async fn build_cancel_command(
         &self,
-        table_fragments: &StreamJobFragments,
-    ) -> MetaResult<Command> {
+        job_id: JobId,
+    ) -> MetaResult<Option<(Command, Vec<TableId>)>> {
         let inner = self.inner.read().await;
         let txn = inner.db.begin().await?;
 
-        let dropped_sink_fragment_with_target =
-            if let Some(sink_fragment) = table_fragments.sink_fragment() {
-                let sink_fragment_id = sink_fragment.fragment_id as FragmentId;
-                let sink_target_fragment = fetch_target_fragments(&txn, [sink_fragment_id]).await?;
-                sink_target_fragment
-                    .get(&sink_fragment_id)
-                    .map(|target_fragments| {
-                        let target_fragment_id = *target_fragments
-                            .first()
-                            .expect("sink should have at least one downstream fragment");
-                        (sink_fragment_id, target_fragment_id)
-                    })
-            } else {
-                None
-            };
+        let Some(streaming_job) = StreamingJobModel::find_by_id(job_id).one(&txn).await? else {
+            tracing::warn!(
+                %job_id,
+                "streaming job not found when building cancel command, might be cancelled already"
+            );
+            return Ok(None);
+        };
+        if streaming_job.job_status == JobStatus::Created {
+            tracing::warn!(
+                "streaming job {} is already created, ignore cancel request",
+                job_id
+            );
+            return Ok(None);
+        }
 
-        Ok(Command::DropStreamingJobs {
-            streaming_job_ids: HashSet::from_iter([table_fragments.stream_job_id()]),
-            unregistered_state_table_ids: table_fragments.all_table_ids().collect(),
-            dropped_sink_fragment_by_targets: dropped_sink_fragment_with_target
-                .into_iter()
-                .map(|(sink, target)| (target as _, vec![sink as _]))
-                .collect(),
-        })
+        let fragments = Fragment::find()
+            .filter(fragment::Column::JobId.eq(job_id))
+            .all(&txn)
+            .await?;
+
+        let state_table_ids = fragments
+            .iter()
+            .flat_map(|fragment| fragment.state_table_ids.inner_ref().iter().copied())
+            .collect_vec();
+        let sink_fragment_ids = fragments
+            .iter()
+            .filter_map(|fragment| {
+                FragmentTypeMask::from(fragment.fragment_type_mask)
+                    .contains(FragmentTypeFlag::Sink)
+                    .then_some(fragment.fragment_id)
+            })
+            .collect_vec();
+
+        let sink_target_fragments = fetch_target_fragments(&txn, sink_fragment_ids).await?;
+        let dropped_sink_fragment_by_targets = sink_target_fragments
+            .into_iter()
+            .filter_map(|(sink_fragment, target_fragments)| {
+                target_fragments
+                    .first()
+                    .map(|target_fragment| (*target_fragment, vec![sink_fragment]))
+            })
+            .collect();
+
+        Ok(Some((
+            Command::DropStreamingJobs {
+                streaming_job_ids: HashSet::from_iter([job_id]),
+                unregistered_state_table_ids: state_table_ids.iter().copied().collect(),
+                dropped_sink_fragment_by_targets,
+            },
+            state_table_ids,
+        )))
     }
 
     /// `try_abort_creating_streaming_job` is used to abort the job that is under initial status or in `FOREGROUND` mode.

--- a/src/meta/src/controller/utils.rs
+++ b/src/meta/src/controller/utils.rs
@@ -1741,7 +1741,6 @@ pub fn rebuild_fragment_mapping(fragment: &SharedFragmentInfo) -> PbFragmentWork
 /// For the given streaming jobs, returns
 /// - All source fragments
 /// - All sink fragments
-/// - All actors
 /// - All fragments
 pub async fn get_fragments_for_jobs<C>(
     db: &C,

--- a/src/meta/src/stream/stream_manager.rs
+++ b/src/meta/src/stream/stream_manager.rs
@@ -449,11 +449,14 @@ impl GlobalStreamManager {
                             );
 
                             let cancel_result: MetaResult<()> = async {
-                                let cancel_command = self.metadata_manager.catalog_controller
-                                    .build_cancel_command(&job_fragments)
-                                    .await?;
-                                let cleanup_state_table_ids =
-                                    job_fragments.all_table_ids().collect_vec();
+                                let Some((cancel_command, cleanup_state_table_ids)) = self
+                                    .metadata_manager
+                                    .catalog_controller
+                                    .build_cancel_command(job_id)
+                                    .await?
+                                else {
+                                    return Ok(());
+                                };
                                 let abort_result = self.metadata_manager.catalog_controller
                                     .try_abort_creating_streaming_job(job_id, true)
                                     .await?;
@@ -864,27 +867,14 @@ impl GlobalStreamManager {
         // NOTE(kwannoel): For background_job_ids stream jobs that not tracked in streaming manager,
         // we can directly cancel them by running the barrier command.
         let futures = background_job_ids.into_iter().map(|id| async move {
-            let fragment = self.metadata_manager.get_job_fragments_by_id(id).await?;
-            if fragment.is_created() {
-                tracing::warn!(
-                    "streaming job {} is already created, ignore cancel request",
-                    id
-                );
-                return Ok(None);
-            }
-            if fragment.is_created() {
-                Err(MetaError::invalid_parameter(format!(
-                    "streaming job {} is already created",
-                    id
-                )))?;
-            }
-
-            let cancel_command = self
+            let Some((cancel_command, cleanup_state_table_ids)) = self
                 .metadata_manager
                 .catalog_controller
-                .build_cancel_command(&fragment)
-                .await?;
-            let cleanup_state_table_ids = fragment.all_table_ids().collect_vec();
+                .build_cancel_command(id)
+                .await?
+            else {
+                return Ok(None);
+            };
 
             let abort_result = self
                 .metadata_manager

--- a/src/tests/simulation/tests/integration_tests/recovery/drop_streaming_job.rs
+++ b/src/tests/simulation/tests/integration_tests/recovery/drop_streaming_job.rs
@@ -1,0 +1,154 @@
+// Copyright 2026 RisingWave Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::time::Duration;
+
+use anyhow::{Result, anyhow};
+use risingwave_common::error::AsReport;
+use risingwave_simulation::cluster::{Cluster, Configuration, Session};
+use tokio::time::sleep;
+
+use crate::utils::wait_jobs_running;
+
+const MAX_HEARTBEAT_INTERVAL_SEC: u64 = 5;
+
+async fn wait_until(session: &mut Session, sql: &str, target: &str) -> Result<()> {
+    for _ in 0..60 {
+        match session.run(sql).await {
+            Ok(result) if result == target => return Ok(()),
+            _ => sleep(Duration::from_secs(1)).await,
+        }
+    }
+    Err(anyhow!(
+        "timed out waiting for query `{}` to return `{}`",
+        sql,
+        target
+    ))
+}
+
+async fn run_until_meta_ready(session: &mut Session, sql: &str) -> Result<()> {
+    let mut last_error = None;
+    for _ in 0..60 {
+        match session.run(sql).await {
+            Ok(_) => return Ok(()),
+            Err(err) => {
+                let report = format!("{:#}", err.as_report());
+                if !report.contains("service is currently unavailable")
+                    && !report.contains("connection reset")
+                    && !report.contains("transport error")
+                {
+                    return Err(err);
+                }
+                last_error = Some(report);
+                sleep(Duration::from_secs(1)).await;
+            }
+        }
+    }
+    Err(anyhow!(
+        "timed out waiting for query `{}` to succeed, last error: {}",
+        sql,
+        last_error.unwrap_or_else(|| "none".to_owned())
+    ))
+}
+
+#[tokio::test]
+async fn test_drop_streaming_job_after_meta_restart_without_compute_node() -> Result<()> {
+    let mut config = Configuration::for_auto_parallelism(MAX_HEARTBEAT_INTERVAL_SEC, true);
+    config.compute_nodes = 3;
+    let mut cluster = Cluster::start(config).await?;
+    let mut session = cluster.start_session();
+
+    session.run("create table t (v int);").await?;
+    session
+        .run("create sink s as select count(*) from t with (connector = 'blackhole');")
+        .await?;
+    session.run("wait;").await?;
+
+    let compute_node_count_sql =
+        "select count(*) from rw_catalog.rw_worker_nodes where type = 'WORKER_TYPE_COMPUTE_NODE';";
+    wait_until(&mut session, compute_node_count_sql, "3").await?;
+
+    cluster
+        .simple_kill_nodes(["compute-1", "compute-2", "compute-3"])
+        .await;
+    sleep(Duration::from_secs(MAX_HEARTBEAT_INTERVAL_SEC * 2)).await;
+    wait_until(&mut session, compute_node_count_sql, "0").await?;
+
+    cluster.simple_kill_nodes(["meta-1"]).await;
+    cluster.simple_restart_nodes(["meta-1"]).await;
+    run_until_meta_ready(&mut session, "show jobs;").await?;
+
+    run_until_meta_ready(&mut session, "drop sink s;").await?;
+    wait_until(
+        &mut session,
+        "select count(*) from rw_catalog.rw_sinks where name = 's';",
+        "0",
+    )
+    .await?;
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_drop_creating_streaming_job_after_meta_restart_without_compute_node() -> Result<()> {
+    let mut config = Configuration::for_auto_parallelism(MAX_HEARTBEAT_INTERVAL_SEC, true);
+    config.compute_nodes = 3;
+    let mut cluster = Cluster::start(config).await?;
+    let mut session = cluster.start_session();
+
+    session.run("create table t (v int);").await?;
+    session
+        .run("insert into t select * from generate_series(1, 10000);")
+        .await?;
+    session.run("flush;").await?;
+
+    let mut create_session = cluster.start_session();
+    let create_handle = tokio::spawn(async move {
+        create_session.run("set streaming_parallelism = 1;").await?;
+        create_session.run("set backfill_rate_limit = 1;").await?;
+        create_session.run("set background_ddl = true;").await?;
+        create_session
+            .run("create sink s as select * from t with (connector = 'blackhole');")
+            .await
+    });
+
+    let running_jobs = wait_jobs_running(&mut session).await?;
+    tracing::info!("running jobs before killing compute nodes: {running_jobs}");
+
+    let compute_node_count_sql =
+        "select count(*) from rw_catalog.rw_worker_nodes where type = 'WORKER_TYPE_COMPUTE_NODE';";
+    wait_until(&mut session, compute_node_count_sql, "3").await?;
+
+    cluster
+        .simple_kill_nodes(["compute-1", "compute-2", "compute-3"])
+        .await;
+    sleep(Duration::from_secs(MAX_HEARTBEAT_INTERVAL_SEC * 2)).await;
+    wait_until(&mut session, compute_node_count_sql, "0").await?;
+
+    cluster.simple_kill_nodes(["meta-1"]).await;
+    cluster.simple_restart_nodes(["meta-1"]).await;
+    run_until_meta_ready(&mut session, "show jobs;").await?;
+
+    session.run("drop sink s;").await?;
+    wait_until(
+        &mut session,
+        "select count(*) from rw_catalog.rw_sinks where name = 's';",
+        "0",
+    )
+    .await?;
+
+    create_handle.abort();
+
+    Ok(())
+}

--- a/src/tests/simulation/tests/integration_tests/recovery/mod.rs
+++ b/src/tests/simulation/tests/integration_tests/recovery/mod.rs
@@ -16,6 +16,7 @@ mod backfill;
 mod background_ddl;
 mod batch_refresh;
 mod cross_db_retention;
+mod drop_streaming_job;
 mod event_log;
 mod locality_backfill;
 mod nexmark_recovery;


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

Backport the meta/barrier fix for dropping recovered streaming jobs when actor info is unavailable after meta recovery, for example after all compute nodes expire and meta restarts.

This PR:

- Builds cancel commands for creating jobs from persisted fragment metadata instead of `SharedActorInfos`.
- Removes the actor list from `DropStreamingJobs`; the barrier worker derives actors to stop from in-flight database info before removing the job from the recovered graph.
- Completes both `started` and `collected` notifiers for drop/cancel commands pre-applied during recovery, because no real barrier is injected for those buffered commands.
- Adds madsim coverage for dropping both created and creating streaming jobs after all CNs are removed and meta restarts.

## Checklist

- [ ] I have written necessary rustdoc comments.
- [x] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [x] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

Fixes an internal drop-job failure where a recovered streaming job could fail to drop after meta restart if compute nodes were gone and actor info could not be reconstructed.

</details>
