### PR TITLE
chore(iceberg): improve iceberg logging

### DIFF
--- a/src/connector/src/sink/iceberg/commit.rs
+++ b/src/connector/src/sink/iceberg/commit.rs
@@ -40,7 +40,7 @@ use thiserror_ext::AsReport;
 use tokio::sync::mpsc::UnboundedSender;
 use tracing::warn;
 
-use super::commit_retry::{self, CommitError};
+use super::commit_retry::{self, CommitError, CommitRetryLogContext};
 use super::{GLOBAL_SINK_METRICS, IcebergConfig, SinkError, commit_branch, resolve_partition_type};
 use crate::connector_common::{IcebergCommittedSnapshot, IcebergSinkCompactionUpdate};
 use crate::sink::catalog::SinkId;
@@ -266,11 +266,18 @@ impl IcebergSinkCommitter {
         let Some(iceberg_compact_stat_sender) = &self.iceberg_compact_stat_sender else {
             return;
         };
+        let branch = commit_branch(self.config.r#type.as_str(), self.config.write_mode);
 
         let Some(observed_snapshot) = self.latest_observed_snapshot() else {
             warn!(
+                iceberg_component = "sink_committer",
+                iceberg_operation = "notify_compaction",
                 sink_id = %self.sink_id,
-                "skip iceberg compaction update because no observed snapshot is available"
+                sink_name = %self.param.sink_name,
+                table = %self.table.identifier(),
+                branch = %branch,
+                force_compaction,
+                "iceberg_sink_compaction_update_skipped",
             );
             return;
         };
@@ -288,12 +295,16 @@ impl IcebergSinkCommitter {
             .is_err()
         {
             warn!(
+                iceberg_component = "sink_committer",
+                iceberg_operation = "notify_compaction",
                 sink_id = %self.sink_id,
+                sink_name = %self.param.sink_name,
+                table = %self.table.identifier(),
                 force_compaction,
                 observed_snapshot_id,
                 observed_snapshot_timestamp_ms,
                 observed_snapshot_branch = %observed_snapshot_branch,
-                "failed to send iceberg compaction update"
+                "iceberg_sink_compaction_update_send_failed",
             );
         }
     }
@@ -303,18 +314,38 @@ impl IcebergSinkCommitter {
 impl SinglePhaseCommitCoordinator for IcebergSinkCommitter {
     async fn init(&mut self) -> Result<()> {
         tracing::info!(
+            iceberg_component = "sink_committer",
+            iceberg_operation = "init",
             sink_id = %self.param.sink_id,
-            "Iceberg sink coordinator initialized",
+            sink_name = %self.param.sink_name,
+            table = %self.table.identifier(),
+            "iceberg_sink_committer_initialized",
         );
 
         Ok(())
     }
 
     async fn commit_data(&mut self, epoch: u64, metadata: Vec<SinkMetadata>) -> Result<()> {
-        tracing::debug!("Starting iceberg direct commit in epoch {epoch}");
+        tracing::debug!(
+            iceberg_component = "sink_committer",
+            iceberg_operation = "direct_commit",
+            sink_id = %self.sink_id,
+            sink_name = %self.param.sink_name,
+            table = %self.table.identifier(),
+            epoch,
+            metadata_count = metadata.len(),
+            "iceberg_sink_commit_started",
+        );
 
         if metadata.is_empty() {
-            tracing::debug!(?epoch, "No datafile to commit");
+            tracing::debug!(
+                iceberg_component = "sink_committer",
+                iceberg_operation = "direct_commit",
+                sink_id = %self.sink_id,
+                table = %self.table.identifier(),
+                epoch,
+                "iceberg_sink_commit_skipped_empty_metadata",
+            );
             return Ok(());
         }
 
@@ -333,12 +364,24 @@ impl SinglePhaseCommitCoordinator for IcebergSinkCommitter {
         schema_change: PbSinkSchemaChange,
     ) -> Result<()> {
         tracing::info!(
-            "Committing schema change {:?} in epoch {}",
-            schema_change,
-            epoch
+            iceberg_component = "sink_committer",
+            iceberg_operation = "schema_change",
+            sink_id = %self.sink_id,
+            sink_name = %self.param.sink_name,
+            table = %self.table.identifier(),
+            epoch,
+            schema_change = ?schema_change,
+            "iceberg_sink_schema_change_commit_started",
         );
         self.commit_schema_change_impl(schema_change).await?;
-        tracing::info!("Successfully committed schema change in epoch {}", epoch);
+        tracing::info!(
+            iceberg_component = "sink_committer",
+            iceberg_operation = "schema_change",
+            sink_id = %self.sink_id,
+            table = %self.table.identifier(),
+            epoch,
+            "iceberg_sink_schema_change_commit_succeeded",
+        );
 
         Ok(())
     }
@@ -348,8 +391,12 @@ impl SinglePhaseCommitCoordinator for IcebergSinkCommitter {
 impl TwoPhaseCommitCoordinator for IcebergSinkCommitter {
     async fn init(&mut self) -> Result<()> {
         tracing::info!(
+            iceberg_component = "sink_committer",
+            iceberg_operation = "init",
             sink_id = %self.param.sink_id,
-            "Iceberg sink coordinator initialized",
+            sink_name = %self.param.sink_name,
+            table = %self.table.identifier(),
+            "iceberg_sink_committer_initialized",
         );
 
         Ok(())
@@ -361,12 +408,28 @@ impl TwoPhaseCommitCoordinator for IcebergSinkCommitter {
         metadata: Vec<SinkMetadata>,
         _schema_change: Option<PbSinkSchemaChange>,
     ) -> Result<Option<Vec<u8>>> {
-        tracing::debug!("Starting iceberg pre commit in epoch {epoch}");
+        tracing::debug!(
+            iceberg_component = "sink_committer",
+            iceberg_operation = "pre_commit",
+            sink_id = %self.sink_id,
+            sink_name = %self.param.sink_name,
+            table = %self.table.identifier(),
+            epoch,
+            metadata_count = metadata.len(),
+            "iceberg_sink_pre_commit_started",
+        );
 
         let (write_results, snapshot_id) = match self.pre_commit_inner(epoch, metadata)? {
             Some((write_results, snapshot_id)) => (write_results, snapshot_id),
             None => {
-                tracing::debug!(?epoch, "no data to pre commit");
+                tracing::debug!(
+                    iceberg_component = "sink_committer",
+                    iceberg_operation = "pre_commit",
+                    sink_id = %self.sink_id,
+                    table = %self.table.identifier(),
+                    epoch,
+                    "iceberg_sink_pre_commit_skipped_no_data",
+                );
                 return Ok(None);
             }
         };
@@ -382,14 +445,40 @@ impl TwoPhaseCommitCoordinator for IcebergSinkCommitter {
         write_results_bytes.push(snapshot_id_bytes);
 
         let pre_commit_metadata_bytes: Vec<u8> = serialize_metadata(write_results_bytes);
+        tracing::debug!(
+            iceberg_component = "sink_committer",
+            iceberg_operation = "pre_commit",
+            sink_id = %self.sink_id,
+            table = %self.table.identifier(),
+            epoch,
+            snapshot_id,
+            pre_commit_metadata_bytes = pre_commit_metadata_bytes.len(),
+            "iceberg_sink_pre_commit_metadata_encoded",
+        );
         Ok(Some(pre_commit_metadata_bytes))
     }
 
     async fn commit_data(&mut self, epoch: u64, commit_metadata: Vec<u8>) -> Result<()> {
-        tracing::debug!("Starting iceberg commit in epoch {epoch}");
+        tracing::debug!(
+            iceberg_component = "sink_committer",
+            iceberg_operation = "commit",
+            sink_id = %self.sink_id,
+            sink_name = %self.param.sink_name,
+            table = %self.table.identifier(),
+            epoch,
+            commit_metadata_bytes = commit_metadata.len(),
+            "iceberg_sink_commit_started",
+        );
 
         if commit_metadata.is_empty() {
-            tracing::debug!(?epoch, "No datafile to commit");
+            tracing::debug!(
+                iceberg_component = "sink_committer",
+                iceberg_operation = "commit",
+                sink_id = %self.sink_id,
+                table = %self.table.identifier(),
+                epoch,
+                "iceberg_sink_commit_skipped_empty_metadata",
+            );
             return Ok(());
         }
 
@@ -423,8 +512,14 @@ impl TwoPhaseCommitCoordinator for IcebergSinkCommitter {
 
         if snapshot_committed {
             tracing::info!(
-                "Snapshot id {} already committed in iceberg table, skip committing again.",
-                snapshot_id
+                iceberg_component = "sink_committer",
+                iceberg_operation = "commit",
+                sink_id = %self.sink_id,
+                sink_name = %self.param.sink_name,
+                table = %self.table.identifier(),
+                epoch,
+                snapshot_id,
+                "iceberg_sink_commit_skipped_snapshot_already_committed",
             );
             return Ok(());
         }
@@ -440,24 +535,50 @@ impl TwoPhaseCommitCoordinator for IcebergSinkCommitter {
     ) -> Result<()> {
         let schema_updated = self.check_schema_change_applied(&schema_change)?;
         if schema_updated {
-            tracing::info!("Schema change already committed in epoch {}, skip", epoch);
+            tracing::info!(
+                iceberg_component = "sink_committer",
+                iceberg_operation = "schema_change",
+                sink_id = %self.sink_id,
+                table = %self.table.identifier(),
+                epoch,
+                "iceberg_sink_schema_change_skipped_already_applied",
+            );
             return Ok(());
         }
 
         tracing::info!(
-            "Committing schema change {:?} in epoch {}",
-            schema_change,
-            epoch
+            iceberg_component = "sink_committer",
+            iceberg_operation = "schema_change",
+            sink_id = %self.sink_id,
+            sink_name = %self.param.sink_name,
+            table = %self.table.identifier(),
+            epoch,
+            schema_change = ?schema_change,
+            "iceberg_sink_schema_change_commit_started",
         );
         self.commit_schema_change_impl(schema_change).await?;
-        tracing::info!("Successfully committed schema change in epoch {epoch}");
+        tracing::info!(
+            iceberg_component = "sink_committer",
+            iceberg_operation = "schema_change",
+            sink_id = %self.sink_id,
+            table = %self.table.identifier(),
+            epoch,
+            "iceberg_sink_schema_change_commit_succeeded",
+        );
 
         Ok(())
     }
 
-    async fn abort(&mut self, _epoch: u64, _commit_metadata: Vec<u8>) {
+    async fn abort(&mut self, epoch: u64, _commit_metadata: Vec<u8>) {
         // TODO: Files that have been written but not committed should be deleted.
-        tracing::debug!("Abort not implemented yet");
+        tracing::debug!(
+            iceberg_component = "sink_committer",
+            iceberg_operation = "abort",
+            sink_id = %self.sink_id,
+            table = %self.table.identifier(),
+            epoch,
+            "iceberg_sink_commit_abort_unimplemented",
+        );
     }
 }
 
@@ -465,13 +586,24 @@ impl TwoPhaseCommitCoordinator for IcebergSinkCommitter {
 impl IcebergSinkCommitter {
     fn pre_commit_inner(
         &mut self,
-        _epoch: u64,
+        epoch: u64,
         metadata: Vec<SinkMetadata>,
     ) -> Result<Option<(Vec<IcebergCommitResult>, i64)>> {
         let write_results: Vec<IcebergCommitResult> = metadata
             .iter()
             .map(IcebergCommitResult::try_from)
             .collect::<Result<Vec<IcebergCommitResult>>>()?;
+        let data_file_count: usize = write_results.iter().map(|r| r.data_files.len()).sum();
+        tracing::debug!(
+            iceberg_component = "sink_committer",
+            iceberg_operation = "pre_commit",
+            sink_id = %self.sink_id,
+            table = %self.table.identifier(),
+            epoch,
+            writer_result_count = write_results.len(),
+            data_file_count,
+            "iceberg_sink_pre_commit_metadata_decoded",
+        );
 
         // Skip if no data to commit
         if write_results.is_empty() || write_results.iter().all(|r| r.data_files.is_empty()) {
@@ -495,6 +627,18 @@ impl IcebergSinkCommitter {
         }
 
         let snapshot_id = FastAppendAction::generate_snapshot_id(&self.table);
+        tracing::debug!(
+            iceberg_component = "sink_committer",
+            iceberg_operation = "pre_commit",
+            sink_id = %self.sink_id,
+            table = %self.table.identifier(),
+            epoch,
+            snapshot_id,
+            schema_id = expect_schema_id,
+            partition_spec_id = expect_partition_spec_id,
+            data_file_count,
+            "iceberg_sink_pre_commit_snapshot_assigned",
+        );
 
         Ok(Some((write_results, snapshot_id)))
     }
@@ -515,6 +659,23 @@ impl IcebergSinkCommitter {
 
         let expect_schema_id = write_results[0].schema_id;
         let expect_partition_spec_id = write_results[0].partition_spec_id;
+        let data_file_count: usize = write_results.iter().map(|r| r.data_files.len()).sum();
+        let target_branch = commit_branch(self.config.r#type.as_str(), self.config.write_mode);
+        tracing::info!(
+            iceberg_component = "sink_committer",
+            iceberg_operation = "commit",
+            sink_id = %self.sink_id,
+            sink_name = %self.param.sink_name,
+            table = %self.table.identifier(),
+            branch = %target_branch,
+            epoch,
+            snapshot_id,
+            schema_id = expect_schema_id,
+            partition_spec_id = expect_partition_spec_id,
+            data_file_count,
+            retry_num = self.commit_retry_num,
+            "iceberg_sink_commit_applying",
+        );
 
         // Load the latest table to avoid concurrent modification with the best effort.
         self.table = commit_retry::reload_table(
@@ -549,8 +710,18 @@ impl IcebergSinkCommitter {
         // because retry logic involved reapply the commit metadata.
         // For now, we just retry the commit operation.
         let catalog = self.catalog.clone();
+        let sink_id = self.sink_id;
         let table_ident = self.table.identifier().clone();
-        let target_branch = commit_branch(self.config.r#type.as_str(), self.config.write_mode);
+        let table_name = table_ident.to_string();
+        let retry_log_context = CommitRetryLogContext::new(
+            "sink_committer",
+            "commit",
+            table_name.clone(),
+            target_branch.clone(),
+        )
+        .with_sink_id(sink_id)
+        .with_epoch(epoch)
+        .with_snapshot_id(snapshot_id);
 
         let table = commit_retry::run_with_retry(
             catalog.clone(),
@@ -558,7 +729,9 @@ impl IcebergSinkCommitter {
             expect_schema_id,
             expect_partition_spec_id,
             self.commit_retry_num as usize,
+            retry_log_context,
             |table| {
+                let table_name = table_name.clone();
                 let target_branch = target_branch.clone();
                 let data_files = data_files.clone();
                 let catalog = catalog.clone();
@@ -567,18 +740,40 @@ impl IcebergSinkCommitter {
                     let append_action = txn
                         .fast_append()
                         .set_snapshot_id(snapshot_id)
-                        .set_target_branch(target_branch)
+                        .set_target_branch(target_branch.clone())
                         .add_data_files(data_files);
 
                     let tx = append_action.apply(txn).map_err(|err| {
                         let err: IcebergError = err.into();
-                        tracing::error!(error = %err.as_report(), "Failed to apply iceberg fast_append action");
+                        tracing::error!(
+                            iceberg_component = "sink_committer",
+                            iceberg_operation = "commit",
+                            sink_id = %sink_id,
+                            table = %table_name,
+                            epoch,
+                            snapshot_id,
+                            branch = %target_branch,
+                            data_file_count,
+                            error = %err.as_report(),
+                            "iceberg_sink_commit_fast_append_apply_failed",
+                        );
                         CommitError::Commit(anyhow!(err).context("apply iceberg fast_append"))
                     })?;
 
                     let table = tx.commit(catalog.as_ref()).await.map_err(|err| {
                         let err: IcebergError = err.into();
-                        tracing::error!(error = %err.as_report(), "Failed to commit iceberg table");
+                        tracing::error!(
+                            iceberg_component = "sink_committer",
+                            iceberg_operation = "commit",
+                            sink_id = %sink_id,
+                            table = %table_name,
+                            epoch,
+                            snapshot_id,
+                            branch = %target_branch,
+                            data_file_count,
+                            error = %err.as_report(),
+                            "iceberg_sink_commit_transaction_failed",
+                        );
                         CommitError::Commit(anyhow!(err).context("commit iceberg transaction"))
                     })?;
                     Ok(table)
@@ -598,7 +793,19 @@ impl IcebergSinkCommitter {
             .with_guarded_label_values(&metrics_labels)
             .set(snapshot_num as i64);
 
-        tracing::debug!("Succeeded to commit to iceberg table in epoch {epoch}.");
+        tracing::debug!(
+            iceberg_component = "sink_committer",
+            iceberg_operation = "commit",
+            sink_id = %self.sink_id,
+            sink_name = %self.param.sink_name,
+            table = %self.table.identifier(),
+            branch = %target_branch,
+            epoch,
+            snapshot_id,
+            snapshot_num,
+            data_file_count,
+            "iceberg_sink_commit_succeeded",
+        );
 
         self.notify_iceberg_compaction_scheduler(false);
 

--- a/src/connector/src/sink/iceberg/commit_retry.rs
+++ b/src/connector/src/sink/iceberg/commit_retry.rs
@@ -28,6 +28,51 @@ use thiserror_ext::AsReport;
 use tokio_retry::RetryIf;
 use tokio_retry::strategy::{ExponentialBackoff, jitter};
 
+#[derive(Clone, Debug)]
+pub struct CommitRetryLogContext {
+    pub iceberg_component: &'static str,
+    pub iceberg_operation: &'static str,
+    pub table: String,
+    pub branch: String,
+    pub sink_id: Option<String>,
+    pub epoch: Option<u64>,
+    pub snapshot_id: Option<i64>,
+}
+
+impl CommitRetryLogContext {
+    pub fn new(
+        iceberg_component: &'static str,
+        iceberg_operation: &'static str,
+        table: impl Into<String>,
+        branch: impl Into<String>,
+    ) -> Self {
+        Self {
+            iceberg_component,
+            iceberg_operation,
+            table: table.into(),
+            branch: branch.into(),
+            sink_id: None,
+            epoch: None,
+            snapshot_id: None,
+        }
+    }
+
+    pub fn with_sink_id(mut self, sink_id: impl ToString) -> Self {
+        self.sink_id = Some(sink_id.to_string());
+        self
+    }
+
+    pub fn with_epoch(mut self, epoch: u64) -> Self {
+        self.epoch = Some(epoch);
+        self
+    }
+
+    pub fn with_snapshot_id(mut self, snapshot_id: i64) -> Self {
+        self.snapshot_id = Some(snapshot_id);
+        self
+    }
+}
+
 /// Distinguishes retriable from non-retriable errors inside [`run_with_retry`].
 pub enum CommitError {
     /// `reload_table` failed (table not found, schema mismatch, partition
@@ -81,6 +126,7 @@ pub async fn run_with_retry<F, Fut, Out>(
     schema_id: i32,
     partition_spec_id: i32,
     retry_num: usize,
+    log_context: CommitRetryLogContext,
     commit_action: F,
 ) -> Result<Out>
 where
@@ -109,15 +155,33 @@ where
         |err: &CommitError| match err {
             CommitError::Commit(e) => {
                 tracing::warn!(
+                    iceberg_component = log_context.iceberg_component,
+                    iceberg_operation = log_context.iceberg_operation,
+                    sink_id = log_context.sink_id.as_deref().unwrap_or("unknown"),
+                    epoch = ?log_context.epoch,
+                    snapshot_id = ?log_context.snapshot_id,
+                    table = %log_context.table,
+                    branch = %log_context.branch,
+                    schema_id,
+                    partition_spec_id,
                     error = %e.as_report(),
-                    "iceberg commit failed; will retry",
+                    "iceberg_commit_retryable_error",
                 );
                 true
             }
             CommitError::ReloadTable(e) => {
                 tracing::error!(
+                    iceberg_component = log_context.iceberg_component,
+                    iceberg_operation = log_context.iceberg_operation,
+                    sink_id = log_context.sink_id.as_deref().unwrap_or("unknown"),
+                    epoch = ?log_context.epoch,
+                    snapshot_id = ?log_context.snapshot_id,
+                    table = %log_context.table,
+                    branch = %log_context.branch,
+                    schema_id,
+                    partition_spec_id,
                     error = %e.as_report(),
-                    "iceberg reload_table failed; will not retry",
+                    "iceberg_commit_reload_table_non_retryable_error",
                 );
                 false
             }

--- a/src/connector/src/sink/iceberg/writer.rs
+++ b/src/connector/src/sink/iceberg/writer.rs
@@ -56,6 +56,7 @@ use risingwave_common::bitmap::Bitmap;
 use risingwave_common::metrics::{LabelGuardedHistogram, LabelGuardedIntCounter};
 use risingwave_common_estimate_size::EstimateSize;
 use risingwave_pb::connector_service::SinkMetadata;
+use thiserror_ext::AsReport;
 use uuid::Uuid;
 
 use super::prometheus::monitored_general_writer::MonitoredGeneralWriterBuilder;
@@ -238,6 +239,11 @@ pub struct IcebergSinkWriterInner {
     metrics: IcebergWriterMetrics,
     // State of iceberg table for this writer
     table: Table,
+    actor_id: String,
+    sink_id: String,
+    sink_name: String,
+    table_name: String,
+    writer_mode: &'static str,
     // For chunk with extra partition column, we should remove this column before write.
     // This project index vec is used to avoid create project idx each time.
     project_idx_vec: ProjectIdxVec,
@@ -354,8 +360,25 @@ impl IcebergSinkWriterInner {
         let schema = table.metadata().current_schema();
         let partition_spec = table.metadata().default_partition_spec();
         let fanout_enabled = !partition_spec.fields().is_empty();
+        let table_name = table.identifier().to_string();
         // To avoid duplicate file name, each time the sink created will generate a unique uuid as file name suffix.
         let unique_uuid_suffix = Uuid::now_v7();
+        tracing::info!(
+            iceberg_component = "sink_writer",
+            iceberg_operation = "build_writer",
+            actor_id = %actor_id,
+            sink_id = %sink_id,
+            sink_name = %sink_name,
+            table = %table_name,
+            writer_mode = "append_only",
+            schema_id = table.metadata().current_schema_id(),
+            partition_spec_id = table.metadata().default_partition_spec_id(),
+            format_version = ?table.metadata().format_version(),
+            fanout_enabled,
+            target_file_size_mb = config.target_file_size_mb(),
+            parquet_compression = ?config.get_parquet_compression(),
+            "iceberg_sink_writer_initialized",
+        );
 
         let parquet_writer_properties = WriterProperties::builder()
             .set_compression(config.get_parquet_compression())
@@ -410,6 +433,11 @@ impl IcebergSinkWriterInner {
                 writer_builder,
             },
             table,
+            actor_id: actor_id.to_string(),
+            sink_id: sink_id.to_string(),
+            sink_name: sink_name.clone(),
+            table_name,
+            writer_mode: "append_only",
             project_idx_vec: {
                 if let Some(extra_partition_col_idx) = extra_partition_col_idx {
                     ProjectIdxVec::Prepare(*extra_partition_col_idx)
@@ -462,9 +490,29 @@ impl IcebergSinkWriterInner {
         let partition_spec = table.metadata().default_partition_spec();
         let fanout_enabled = !partition_spec.fields().is_empty();
         let use_deletion_vectors = table.metadata().format_version() >= FormatVersion::V3;
+        let table_name = table.identifier().to_string();
 
         // To avoid duplicate file name, each time the sink created will generate a unique uuid as file name suffix.
         let unique_uuid_suffix = Uuid::now_v7();
+        tracing::info!(
+            iceberg_component = "sink_writer",
+            iceberg_operation = "build_writer",
+            actor_id = %actor_id,
+            sink_id = %sink_id,
+            sink_name = %sink_name,
+            table = %table_name,
+            writer_mode = "upsert",
+            schema_id = table.metadata().current_schema_id(),
+            partition_spec_id = table.metadata().default_partition_spec_id(),
+            format_version = ?table.metadata().format_version(),
+            primary_key_columns = ?primary_key_column_names,
+            equality_delete_field_ids = ?unique_column_ids,
+            use_deletion_vectors,
+            fanout_enabled,
+            target_file_size_mb = config.target_file_size_mb(),
+            parquet_compression = ?config.get_parquet_compression(),
+            "iceberg_sink_writer_initialized",
+        );
 
         let parquet_writer_properties = WriterProperties::builder()
             .set_compression(config.get_parquet_compression())
@@ -606,6 +654,11 @@ impl IcebergSinkWriterInner {
                     ProjectIdxVec::None
                 }
             },
+            actor_id: actor_id.to_string(),
+            sink_id: sink_id.to_string(),
+            sink_name: sink_name.clone(),
+            table_name,
+            writer_mode: "upsert",
         })
     }
 
@@ -706,10 +759,28 @@ impl IcebergSinkWriterInner {
         };
 
         let writer = self.writer.get_writer().unwrap();
+        let batch_rows = batch.num_rows();
+        let batch_columns = batch.num_columns();
         writer
             .write(batch)
             .instrument_await("iceberg_write")
-            .await?;
+            .await
+            .inspect_err(|err| {
+                tracing::error!(
+                    iceberg_component = "sink_writer",
+                    iceberg_operation = "write_batch",
+                    actor_id = %self.actor_id,
+                    sink_id = %self.sink_id,
+                    sink_name = %self.sink_name,
+                    table = %self.table_name,
+                    writer_mode = self.writer_mode,
+                    batch_rows,
+                    batch_columns,
+                    write_bytes = write_batch_size,
+                    error = %err.as_report(),
+                    "iceberg_sink_writer_write_failed",
+                );
+            })?;
         self.metrics.write_bytes.inc_by(write_batch_size as _);
         Ok(())
     }
@@ -729,10 +800,28 @@ impl IcebergSinkWriterInner {
         };
 
         let writer = self.writer.get_writer().unwrap();
+        let batch_rows = batch.num_rows();
+        let batch_columns = batch.num_columns();
         let positions = writer
             .write_with_position(batch)
             .instrument_await("iceberg_write")
-            .await?;
+            .await
+            .inspect_err(|err| {
+                tracing::error!(
+                    iceberg_component = "sink_writer",
+                    iceberg_operation = "write_batch_with_position",
+                    actor_id = %self.actor_id,
+                    sink_id = %self.sink_id,
+                    sink_name = %self.sink_name,
+                    table = %self.table_name,
+                    writer_mode = self.writer_mode,
+                    batch_rows,
+                    batch_columns,
+                    write_bytes = write_batch_size,
+                    error = %err.as_report(),
+                    "iceberg_sink_writer_write_with_position_failed",
+                );
+            })?;
         self.metrics.write_bytes.inc_by(write_batch_size as _);
         Ok(positions)
     }
@@ -745,7 +834,8 @@ impl IcebergSinkWriterInner {
             } => {
                 let close_result = match writer.take() {
                     Some(mut writer) => {
-                        Some(writer.close().instrument_await("iceberg_close").await?)
+                        let data_files = writer.close().instrument_await("iceberg_close").await?;
+                        Some(data_files)
                     }
                     _ => None,
                 };
@@ -753,10 +843,20 @@ impl IcebergSinkWriterInner {
                     Ok(new_writer) => {
                         *writer = Some(Box::new(new_writer));
                     }
-                    _ => {
+                    Err(err) => {
                         // In this case, the writer is closed and we can't build a new writer. But we can't return the error
                         // here because current writer may close successfully. So we just log the error.
-                        tracing::warn!("Failed to build new writer after close");
+                        tracing::warn!(
+                            iceberg_component = "sink_writer",
+                            iceberg_operation = "rebuild_writer",
+                            actor_id = %self.actor_id,
+                            sink_id = %self.sink_id,
+                            sink_name = %self.sink_name,
+                            table = %self.table_name,
+                            writer_mode = self.writer_mode,
+                            error = %err.as_report(),
+                            "iceberg_sink_writer_rebuild_failed_after_close",
+                        );
                     }
                 }
                 close_result
@@ -768,7 +868,8 @@ impl IcebergSinkWriterInner {
             } => {
                 let close_result = match writer.take() {
                     Some(mut writer) => {
-                        Some(writer.close().instrument_await("iceberg_close").await?)
+                        let data_files = writer.close().instrument_await("iceberg_close").await?;
+                        Some(data_files)
                     }
                     _ => None,
                 };
@@ -776,10 +877,20 @@ impl IcebergSinkWriterInner {
                     Ok(new_writer) => {
                         *writer = Some(Box::new(new_writer));
                     }
-                    _ => {
+                    Err(err) => {
                         // In this case, the writer is closed and we can't build a new writer. But we can't return the error
                         // here because current writer may close successfully. So we just log the error.
-                        tracing::warn!("Failed to build new writer after close");
+                        tracing::warn!(
+                            iceberg_component = "sink_writer",
+                            iceberg_operation = "rebuild_writer",
+                            actor_id = %self.actor_id,
+                            sink_id = %self.sink_id,
+                            sink_name = %self.sink_name,
+                            table = %self.table_name,
+                            writer_mode = self.writer_mode,
+                            error = %err.as_report(),
+                            "iceberg_sink_writer_rebuild_failed_after_close",
+                        );
                     }
                 }
                 close_result

--- a/src/meta/src/manager/iceberg_compaction/schedule.rs
+++ b/src/meta/src/manager/iceberg_compaction/schedule.rs
@@ -436,7 +436,13 @@ impl IcebergCompactionHandle {
             .get_sink_by_id(self.sink_id)
             .await?
         else {
-            tracing::warn!("Sink not found: {}", self.sink_id);
+            tracing::warn!(
+                iceberg_component = "compaction_scheduler",
+                iceberg_operation = "dispatch_task",
+                sink_id = %self.sink_id,
+                task_id,
+                "iceberg_compaction_dispatch_sink_not_found",
+            );
             return Ok(());
         };
         let sink_catalog = SinkCatalog::from(prost_sink_catalog);
@@ -464,9 +470,11 @@ impl IcebergCompactionHandle {
             if !dispatched {
                 should_cancel_sent_task = true;
                 tracing::warn!(
+                    iceberg_component = "compaction_scheduler",
+                    iceberg_operation = "dispatch_task",
                     sink_id = %self.sink_id,
                     task_id,
-                    "Iceberg compaction task send succeeded but track was no longer pending dispatch"
+                    "iceberg_compaction_dispatch_track_not_pending",
                 );
             }
             drop(guard);
@@ -482,10 +490,12 @@ impl IcebergCompactionHandle {
     fn cancel_sent_task(&self, compactor: &crate::hummock::IcebergCompactor, task_id: u64) {
         if let Err(e) = compactor.cancel_task(task_id) {
             tracing::warn!(
+                iceberg_component = "compaction_scheduler",
+                iceberg_operation = "cancel_task",
                 error = %e.as_report(),
                 sink_id = %self.sink_id,
                 task_id,
-                "Failed to cancel iceberg compaction task after schedule removal",
+                "iceberg_compaction_cancel_after_schedule_removal_failed",
             );
         }
     }
@@ -744,16 +754,20 @@ impl IcebergCompactionManager {
             Entry::Vacant(entry) => {
                 if !allow_track_initialization {
                     tracing::warn!(
+                        iceberg_component = "compaction_scheduler",
+                        iceberg_operation = "apply_sink_update",
                         sink_id = %sink_id,
-                        "Ignoring iceberg compaction update because track disappeared before apply"
+                        "iceberg_compaction_update_ignored_track_missing",
                     );
                     return false;
                 }
 
                 let Some(config) = loaded_config.as_ref() else {
                     tracing::warn!(
+                        iceberg_component = "compaction_scheduler",
+                        iceberg_operation = "apply_sink_update",
                         sink_id = %sink_id,
-                        "Ignoring iceberg compaction update because sink config is unavailable"
+                        "iceberg_compaction_update_ignored_config_unavailable",
                     );
                     return false;
                 };
@@ -893,7 +907,12 @@ impl IcebergCompactionManager {
         let mut timed_out_tasks = Vec::new();
         for (&sink_id, track) in &mut guard.sink_schedules {
             if track.is_report_timed_out(now) {
-                tracing::warn!(sink_id = %sink_id, "Iceberg compaction task report timed out");
+                tracing::warn!(
+                    iceberg_component = "compaction_scheduler",
+                    iceberg_operation = "report_timeout",
+                    sink_id = %sink_id,
+                    "iceberg_compaction_task_report_timed_out",
+                );
                 timed_out_tasks.push((sink_id, track.finish_failed(now)));
             }
         }
@@ -1096,10 +1115,13 @@ impl IcebergCompactionManager {
                         IcebergReportTaskStatus::Success => track.finish_success(now),
                         IcebergReportTaskStatus::Failed | IcebergReportTaskStatus::Unspecified => {
                             tracing::warn!(
+                                iceberg_component = "compaction_scheduler",
+                                iceberg_operation = "handle_report",
                                 sink_id = %sink_id,
                                 task_id,
-                                error_message = report.error_message.clone().unwrap_or_default(),
-                                "Iceberg compaction task reported failure"
+                                status = ?status,
+                                error_message = report.error_message.as_deref().unwrap_or_default(),
+                                "iceberg_compaction_task_reported_failure",
                             );
                             track.finish_failed(now)
                         }
@@ -1109,10 +1131,24 @@ impl IcebergCompactionManager {
                     waiter = guard.manual_compaction_waiters.remove(&sink_id);
                 }
                 Some(_) => {
-                    tracing::warn!(sink_id = %sink_id, task_id, "Ignoring stale iceberg compaction report");
+                    tracing::warn!(
+                        iceberg_component = "compaction_scheduler",
+                        iceberg_operation = "handle_report",
+                        sink_id = %sink_id,
+                        task_id,
+                        status = ?status,
+                        "iceberg_compaction_report_ignored_stale",
+                    );
                 }
                 None => {
-                    tracing::warn!(sink_id = %sink_id, task_id, "Received iceberg compaction report for unknown sink");
+                    tracing::warn!(
+                        iceberg_component = "compaction_scheduler",
+                        iceberg_operation = "handle_report",
+                        sink_id = %sink_id,
+                        task_id,
+                        status = ?status,
+                        "iceberg_compaction_report_unknown_sink",
+                    );
                 }
             }
 

--- a/src/meta/src/manager/iceberg_pk_index_sink/coordinator.rs
+++ b/src/meta/src/manager/iceberg_pk_index_sink/coordinator.rs
@@ -44,7 +44,7 @@ use iceberg::table::Table;
 use iceberg::transaction::{ApplyTransactionAction, FastAppendAction, Transaction};
 use prost::Message;
 use risingwave_connector::sink::catalog::SinkId;
-use risingwave_connector::sink::iceberg::commit_retry::{self, CommitError};
+use risingwave_connector::sink::iceberg::commit_retry::{self, CommitError, CommitRetryLogContext};
 use risingwave_connector::sink::iceberg::{
     IcebergCommitResult, IcebergConfig, IcebergPositionDeleteMergerCommitResult, commit_branch,
     resolve_partition_type,
@@ -191,6 +191,7 @@ impl IcebergPkIndexSinkCoordinator {
             self.catalog.clone(),
             self.table.identifier().clone(),
             self.target_branch.clone(),
+            self.sink_id,
             &commit,
             self.retry_num,
         )
@@ -362,6 +363,7 @@ async fn commit_one_epoch(
     catalog: Arc<dyn Catalog>,
     table_ident: iceberg::TableIdent,
     target_branch: String,
+    sink_id: SinkId,
     commit: &EpochCommit,
     retry_num: usize,
 ) -> Result<Table, CommitError> {
@@ -371,10 +373,19 @@ async fn commit_one_epoch(
 
     commit_retry::run_with_retry(
         catalog.clone(),
-        table_ident,
+        table_ident.clone(),
         merged.schema_id,
         merged.partition_spec_id,
         retry_num,
+        CommitRetryLogContext::new(
+            "iceberg_v3_sink_coordinator",
+            "commit_epoch",
+            table_ident.to_string(),
+            target_branch.clone(),
+        )
+        .with_sink_id(sink_id)
+        .with_epoch(commit.epoch)
+        .with_snapshot_id(snapshot_id),
         |table| {
             let merged = merged.clone();
             let catalog = catalog.clone();

--- a/src/storage/src/hummock/compactor/iceberg_compaction/iceberg_compactor_runner.rs
+++ b/src/storage/src/hummock/compactor/iceberg_compaction/iceberg_compactor_runner.rs
@@ -114,6 +114,7 @@ impl Debug for IcebergCompactionTaskStatistics {
 #[derive(Debug)]
 pub struct IcebergCompactionPlanRunner {
     pub task_id: u64,
+    pub sink_id: u32,
     pub plan_index: usize,
 
     pub catalog: Arc<dyn Catalog>,
@@ -179,6 +180,11 @@ impl IcebergCompactionPlanRunner {
 
     pub async fn compact(self, shutdown_rx: Receiver<()>) -> HummockResult<RewriteFilesStat> {
         let task_id = self.task_id;
+        let sink_id = self.sink_id;
+        let plan_index = self.plan_index;
+        let task_type = self.task_type;
+        let table_ident = self.table_ident.clone();
+        let branch = self.branch.clone();
         let unique_ident = self.unique_ident();
         let now = std::time::Instant::now();
 
@@ -198,9 +204,16 @@ impl IcebergCompactionPlanRunner {
         tokio::select! {
             _ = shutdown_rx => {
                 tracing::info!(
+                    iceberg_component = "compaction_worker",
+                    iceberg_operation = "execute_plan",
                     task_id = task_id,
+                    sink_id = sink_id,
+                    plan_index = plan_index,
+                    task_type = ?task_type,
+                    table = %table_ident,
+                    branch = %branch,
                     unique_ident = %unique_ident,
-                    "Plan cancelled"
+                    "iceberg_compaction_plan_cancelled",
                 );
                 Err(HummockError::compaction_executor("Plan cancelled"))
             }
@@ -208,19 +221,33 @@ impl IcebergCompactionPlanRunner {
                 match &result {
                     Ok(stats) => {
                         tracing::info!(
+                            iceberg_component = "compaction_worker",
+                            iceberg_operation = "execute_plan",
                             task_id = task_id,
+                            sink_id = sink_id,
+                            plan_index = plan_index,
+                            task_type = ?task_type,
+                            table = %table_ident,
+                            branch = %branch,
                             unique_ident = %unique_ident,
                             elapsed_millis = now.elapsed().as_millis(),
                             stats = ?stats,
-                            "Plan completed successfully"
+                            "iceberg_compaction_plan_succeeded",
                         );
                     }
                     Err(e) => {
                         tracing::warn!(
+                            iceberg_component = "compaction_worker",
+                            iceberg_operation = "execute_plan",
                             error = %e.as_report(),
                             task_id = task_id,
+                            sink_id = sink_id,
+                            plan_index = plan_index,
+                            task_type = ?task_type,
+                            table = %table_ident,
+                            branch = %branch,
                             unique_ident = %unique_ident,
-                            "Plan failed"
+                            "iceberg_compaction_plan_failed",
                         );
                     }
                 }
@@ -243,10 +270,14 @@ impl IcebergCompactionPlanRunner {
     ) -> HummockResult<RewriteFilesStat> {
         if !compaction_plan.has_files() {
             tracing::info!(
+                iceberg_component = "compaction_worker",
+                iceberg_operation = "plan_compaction",
                 task_id,
                 plan_index,
+                task_type = ?task_type,
                 table = %table_ident,
-                "skip empty iceberg compaction plan"
+                branch = %branch,
+                "iceberg_compaction_plan_skipped_empty",
             );
             return Ok(RewriteFilesStat::default());
         }
@@ -276,14 +307,17 @@ impl IcebergCompactionPlanRunner {
             })?;
 
         tracing::info!(
+            iceberg_component = "compaction_worker",
+            iceberg_operation = "execute_plan",
             task_id = task_id,
             plan_index = plan_index,
             task_type = ?task_type,
             table = %table_ident,
+            branch = %branch,
             input_parallelism = compaction_plan.recommended_executor_parallelism(),
             output_parallelism = compaction_plan.recommended_output_parallelism(),
             statistics = ?statistics,
-            "Iceberg compaction plan started"
+            "iceberg_compaction_plan_started",
         );
 
         let retry_config = CommitManagerRetryConfig::default();
@@ -572,9 +606,14 @@ pub async fn create_task_execution(
 
     if compaction_plans.is_empty() {
         tracing::info!(
+            iceberg_component = "compaction_worker",
+            iceberg_operation = "plan_task",
             task_id = task_id,
+            sink_id = sink_id,
+            task_type = ?parsed_task_type,
             table = %table_ident,
-            "No files to compact, skip the task"
+            branch = %branch,
+            "iceberg_compaction_task_skipped_no_files",
         );
         return Ok(IcebergTaskExecution {
             sink_id,
@@ -587,6 +626,7 @@ pub async fn create_task_execution(
     for (plan_index, compaction_plan) in compaction_plans.into_iter().enumerate() {
         runners.push(IcebergCompactionPlanRunner {
             task_id,
+            sink_id,
             plan_index,
             catalog: catalog.clone(),
             table_ident: table_ident.clone(),
@@ -600,10 +640,15 @@ pub async fn create_task_execution(
     }
 
     tracing::info!(
+        iceberg_component = "compaction_worker",
+        iceberg_operation = "plan_task",
         task_id = task_id,
+        sink_id = sink_id,
+        task_type = ?parsed_task_type,
         table = %table_ident,
+        branch = %branch,
         plan_count = runners.len(),
-        "Created plan runners for iceberg compaction task"
+        "iceberg_compaction_task_planned",
     );
 
     Ok(IcebergTaskExecution {

--- a/src/storage/src/hummock/compactor/iceberg_compaction/report.rs
+++ b/src/storage/src/hummock/compactor/iceberg_compaction/report.rs
@@ -38,8 +38,10 @@ pub(crate) enum ReportSendResult {
 
 pub(crate) struct IcebergTaskTracker {
     sink_id: u32,
+    total_plans: usize,
     remaining_plans: usize,
     successful_plans: usize,
+    failed_plans: usize,
     first_error: Option<String>,
 }
 
@@ -47,8 +49,10 @@ impl IcebergTaskTracker {
     pub(crate) fn new(sink_id: u32, remaining_plans: usize) -> Self {
         Self {
             sink_id,
+            total_plans: remaining_plans,
             remaining_plans,
             successful_plans: 0,
+            failed_plans: 0,
             first_error: None,
         }
     }
@@ -57,6 +61,7 @@ impl IcebergTaskTracker {
         debug_assert!(self.remaining_plans > 0);
         self.remaining_plans -= 1;
         if let Some(error_message) = error_message {
+            self.failed_plans += 1;
             if self.first_error.is_none() {
                 self.first_error = Some(error_message);
             }
@@ -67,6 +72,22 @@ impl IcebergTaskTracker {
 
     pub(crate) fn is_finished(&self) -> bool {
         self.remaining_plans == 0
+    }
+
+    pub(crate) fn sink_id(&self) -> u32 {
+        self.sink_id
+    }
+
+    pub(crate) fn total_plans(&self) -> usize {
+        self.total_plans
+    }
+
+    pub(crate) fn successful_plans(&self) -> usize {
+        self.successful_plans
+    }
+
+    pub(crate) fn failed_plans(&self) -> usize {
+        self.failed_plans
     }
 
     pub(crate) fn into_report(self, task_id: u64) -> IcebergTaskReport {
@@ -113,10 +134,12 @@ pub(crate) fn send_iceberg_task_report(
             .as_millis() as u64,
     }) {
         tracing::warn!(
+            iceberg_component = "compaction_worker",
+            iceberg_operation = "report_task",
             error = %e.as_report(),
             task_id = report_event.task_id,
             sink_id = report_event.sink_id,
-            "Failed to report iceberg compaction task result - will retry on stream restart"
+            "iceberg_compaction_task_report_send_failed",
         );
         return Err(report_event);
     }

--- a/src/storage/src/hummock/compactor/mod.rs
+++ b/src/storage/src/hummock/compactor/mod.rs
@@ -525,7 +525,13 @@ pub fn start_iceberg_compactor(
                             continue 'consume_stream;
                         }
 
-                        let report = tracker_entry.remove().into_report(completed_task_id);
+                        let tracker = tracker_entry.remove();
+                        let sink_id = tracker.sink_id();
+                        let total_plans = tracker.total_plans();
+                        let successful_plans = tracker.successful_plans();
+                        let failed_plans = tracker.failed_plans();
+                        let report = tracker.into_report(completed_task_id);
+                        let task_succeeded = report.error_message.is_none();
                         if matches!(
                             send_or_buffer_iceberg_task_report(
                                 &request_sender,
@@ -535,6 +541,18 @@ pub fn start_iceberg_compactor(
                             ReportSendResult::RestartStream
                         ) {
                             continue 'start_stream;
+                        }
+                        if task_succeeded {
+                            tracing::info!(
+                                iceberg_component = "compaction_worker",
+                                iceberg_operation = "report_task",
+                                task_id = completed_task_id,
+                                sink_id = sink_id,
+                                total_plans = total_plans,
+                                successful_plans = successful_plans,
+                                failed_plans = failed_plans,
+                                "iceberg_compaction_task_succeeded",
+                            );
                         }
                         continue 'consume_stream;
                     }
@@ -612,7 +630,14 @@ pub fn start_iceberg_compactor(
                                     .build() {
                                     Ok(config) => config,
                                     Err(e) => {
-                                        tracing::warn!(error = %e.as_report(), "Failed to build iceberg compactor runner config {}", task_id);
+                                        tracing::warn!(
+                                            iceberg_component = "compaction_worker",
+                                            iceberg_operation = "build_runner_config",
+                                            error = %e.as_report(),
+                                            task_id = task_id,
+                                            sink_id = sink_id,
+                                            "iceberg_compaction_runner_config_failed",
+                                        );
                                         let report = build_iceberg_task_report(
                                             task_id,
                                             sink_id,
@@ -643,7 +668,14 @@ pub fn start_iceberg_compactor(
                                 ).await {
                                     Ok(task_execution) => task_execution,
                                     Err(e) => {
-                                        tracing::warn!(error = %e.as_report(), task_id, "Failed to create plan runners");
+                                        tracing::warn!(
+                                            iceberg_component = "compaction_worker",
+                                            iceberg_operation = "plan_task",
+                                            error = %e.as_report(),
+                                            task_id = task_id,
+                                            sink_id = sink_id,
+                                            "iceberg_compaction_task_plan_failed",
+                                        );
                                         let report = build_iceberg_task_report(
                                             task_id,
                                             sink_id,
@@ -670,7 +702,13 @@ pub fn start_iceberg_compactor(
                                 let plan_runners = task_execution.plan_runners;
 
                                 if plan_runners.is_empty() {
-                                    tracing::info!(task_id, sink_id, "No plans to execute");
+                                    tracing::info!(
+                                        iceberg_component = "compaction_worker",
+                                        iceberg_operation = "enqueue_plan",
+                                        task_id = task_id,
+                                        sink_id = sink_id,
+                                        "iceberg_compaction_task_skipped_no_plans",
+                                    );
                                     let report = build_iceberg_task_report(task_id, sink_id, None);
                                     if matches!(
                                         send_or_buffer_iceberg_task_report(
@@ -693,50 +731,81 @@ pub fn start_iceberg_compactor(
                                     let meta = runner.to_meta();
                                     let plan_index = meta.plan_index;
                                     let required_parallelism = runner.required_parallelism();
+                                    let runner_sink_id = runner.sink_id;
+                                    let runner_task_type = runner.task_type;
+                                    let runner_table = runner.table_ident.to_string();
                                     let push_result = task_queue.push(meta, Some(runner));
 
                                     match push_result {
                                         PushResult::Added => {
                                             enqueued_count += 1;
                                             tracing::debug!(
+                                                iceberg_component = "compaction_worker",
+                                                iceberg_operation = "enqueue_plan",
                                                 task_id = task_id,
+                                                sink_id = runner_sink_id,
                                                 plan_index = plan_index,
+                                                task_type = ?runner_task_type,
+                                                table = %runner_table,
                                                 required_parallelism = required_parallelism,
-                                                "Iceberg plan runner added to queue"
+                                                "iceberg_compaction_plan_enqueued",
                                             );
                                         },
                                         PushResult::RejectedCapacity => {
                                             tracing::warn!(
+                                                iceberg_component = "compaction_worker",
+                                                iceberg_operation = "enqueue_plan",
                                                 task_id = task_id,
+                                                sink_id = runner_sink_id,
+                                                plan_index = plan_index,
+                                                task_type = ?runner_task_type,
+                                                table = %runner_table,
                                                 required_parallelism = required_parallelism,
                                                 pending_budget = pending_parallelism_budget,
                                                 enqueued_count = enqueued_count,
                                                 total_plans = total_plans,
-                                                "Iceberg plan runner rejected - queue capacity exceeded"
+                                                "iceberg_compaction_plan_rejected_capacity",
                                             );
                                             // Stop enqueuing remaining plans
                                             break;
                                         },
                                         PushResult::RejectedTooLarge => {
                                             tracing::error!(
+                                                iceberg_component = "compaction_worker",
+                                                iceberg_operation = "enqueue_plan",
                                                 task_id = task_id,
+                                                sink_id = runner_sink_id,
+                                                plan_index = plan_index,
+                                                task_type = ?runner_task_type,
+                                                table = %runner_table,
                                                 required_parallelism = required_parallelism,
                                                 max_parallelism = max_task_parallelism,
-                                                "Iceberg plan runner rejected - parallelism exceeds max"
+                                                "iceberg_compaction_plan_rejected_too_large",
                                             );
                                         },
                                         PushResult::RejectedInvalidParallelism => {
                                             tracing::error!(
+                                                iceberg_component = "compaction_worker",
+                                                iceberg_operation = "enqueue_plan",
                                                 task_id = task_id,
+                                                sink_id = runner_sink_id,
+                                                plan_index = plan_index,
+                                                task_type = ?runner_task_type,
+                                                table = %runner_table,
                                                 required_parallelism = required_parallelism,
-                                                "Iceberg plan runner rejected - invalid parallelism"
+                                                "iceberg_compaction_plan_rejected_invalid_parallelism",
                                             );
                                         },
                                         PushResult::RejectedDuplicate => {
                                             tracing::error!(
+                                                iceberg_component = "compaction_worker",
+                                                iceberg_operation = "enqueue_plan",
                                                 task_id = task_id,
+                                                sink_id = runner_sink_id,
                                                 plan_index = plan_index,
-                                                "Iceberg plan runner rejected - duplicate (task_id, plan_index)"
+                                                task_type = ?runner_task_type,
+                                                table = %runner_table,
+                                                "iceberg_compaction_plan_rejected_duplicate",
                                             );
                                         }
                                     }
@@ -766,13 +835,13 @@ pub fn start_iceberg_compactor(
                                 }
 
                                 tracing::info!(
+                                    iceberg_component = "compaction_worker",
+                                    iceberg_operation = "enqueue_plan",
                                     task_id = task_id,
                                     sink_id = sink_id,
                                     total_plans = total_plans,
                                     enqueued_count = enqueued_count,
-                                    "Enqueued {} of {} Iceberg plan runners",
-                                    enqueued_count,
-                                    total_plans
+                                    "iceberg_compaction_task_enqueue_finished",
                                 );
                             },
                             risingwave_pb::iceberg_compaction::subscribe_iceberg_compaction_event_response::Event::PullTaskAck(_) => {
@@ -1377,13 +1446,18 @@ fn schedule_queued_tasks(
 
         let Some(runner) = popped_task.runner else {
             tracing::error!(
+                iceberg_component = "compaction_worker",
+                iceberg_operation = "schedule_plan",
                 task_id = task_id,
                 plan_index = plan_index,
-                "Popped task missing runner - this should not happen"
+                "iceberg_compaction_plan_missing_runner",
             );
             task_queue.finish_running(task_key);
             continue;
         };
+        let runner_sink_id = runner.sink_id;
+        let runner_task_type = runner.task_type;
+        let runner_table = runner.table_ident.to_string();
 
         let executor = compactor_context.compaction_executor.clone();
         let shutdown_map_clone = shutdown_map.clone();
@@ -1396,11 +1470,16 @@ fn schedule_queued_tasks(
         }
 
         tracing::info!(
+            iceberg_component = "compaction_worker",
+            iceberg_operation = "schedule_plan",
             task_id = task_id,
+            sink_id = runner_sink_id,
             plan_index = plan_index,
+            task_type = ?runner_task_type,
+            table = %runner_table,
             unique_ident = ?unique_ident,
             required_parallelism = popped_task.meta.required_parallelism,
-            "Starting iceberg compaction task from queue"
+            "iceberg_compaction_plan_started_from_queue",
         );
 
         executor.spawn(async move {
@@ -1419,16 +1498,26 @@ fn schedule_queued_tasks(
                 Err(e) => {
                     if is_cancelled_iceberg_compaction_error(&e) {
                         tracing::info!(
+                            iceberg_component = "compaction_worker",
+                            iceberg_operation = "execute_plan",
                             task_id = task_key.0,
+                            sink_id = runner_sink_id,
                             plan_index = task_key.1,
-                            "Iceberg compaction plan cancelled"
+                            task_type = ?runner_task_type,
+                            table = %runner_table,
+                            "iceberg_compaction_plan_cancelled",
                         );
                     } else {
                         tracing::warn!(
+                            iceberg_component = "compaction_worker",
+                            iceberg_operation = "execute_plan",
                             error = %e.as_report(),
                             task_id = task_key.0,
+                            sink_id = runner_sink_id,
                             plan_index = task_key.1,
-                            "Failed to compact iceberg runner"
+                            task_type = ?runner_task_type,
+                            table = %runner_table,
+                            "iceberg_compaction_plan_failed",
                         );
                     }
                     IcebergPlanCompletion {
@@ -1440,9 +1529,14 @@ fn schedule_queued_tasks(
 
             if completion_tx_clone.send(completion).is_err() {
                 tracing::warn!(
+                    iceberg_component = "compaction_worker",
+                    iceberg_operation = "notify_plan_completion",
                     task_id = task_key.0,
+                    sink_id = runner_sink_id,
                     plan_index = task_key.1,
-                    "Failed to notify task completion - main loop may have shut down"
+                    task_type = ?runner_task_type,
+                    table = %runner_table,
+                    "iceberg_compaction_plan_completion_send_failed",
                 );
             }
         });


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

- Standardize Iceberg sink writer and committer logs with fixed event names and structured fields such as `iceberg_component`, `iceberg_operation`, `sink_id`, `sink_name`, `table`, `epoch`, `snapshot_id`, and `branch`.
- Add structured Iceberg compaction scheduler and worker logs across dispatch, planning, queueing, execution, cancellation, and task reporting.
- Add a task-level `iceberg_compaction_task_succeeded` log after the compactor successfully reports a completed Iceberg compaction task to Meta.
- Intention: make customer Iceberg sink and compaction incidents easier to debug by giving humans and agents stable log entry points and correlation fields.

- No related issue.

## Checklist

- [x] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwave/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwave/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

This PR improves internal logs for Iceberg sink and Iceberg compaction troubleshooting. It does not change user-facing behavior.

</details>

## Tests

- `RUSTUP_TOOLCHAIN=nightly-2026-06-11 cargo fmt --all -- --check`
- `git diff --check`
- `RUSTUP_TOOLCHAIN=nightly-2026-06-11 cargo check -p risingwave_storage` was started but interrupted per request.
