### PR TITLE
feat(iceberg): support batch refresh pk-index iceberg sink

### DIFF
--- a/e2e_test/iceberg/test_case/pure_slt/iceberg_v3/derive_pk.slt
+++ b/e2e_test/iceberg/test_case/pure_slt/iceberg_v3/derive_pk.slt
@@ -30,6 +30,7 @@ WITH (
     create_table_if_not_exists = 'true',
     write_mode = 'merge-on-read',
     format_version = '3',
+    refresh.interval.sec = '1',
     enable_pk_index = 'true'
 );
 
@@ -151,6 +152,7 @@ WITH (
     create_table_if_not_exists = 'true',
     write_mode = 'merge-on-read',
     format_version = '3',
+    refresh.interval.sec = '1',
     enable_pk_index = 'true'
 );
 
@@ -236,7 +238,31 @@ WITH (
     primary_key = 'item_id',
     write_mode = 'merge-on-read',
     format_version = '3',
+    refresh.interval.sec = '1',
     enable_pk_index = 'true'
+);
+
+statement error commit_checkpoint_interval
+CREATE SINK s_v3_derive_pk_commit_interval_reject FROM t_v3_derive_pk_reject
+WITH (
+    connector = 'iceberg',
+    type = 'upsert',
+    force_append_only = 'false',
+    catalog.name = 'demo',
+    database.name = 'public',
+    table.name = 'derive_pk_commit_interval_reject_v3_pk_index_table',
+    catalog.type = 'storage',
+    warehouse.path = 's3a://hummock001/iceberg_v3',
+    s3.endpoint = 'http://127.0.0.1:9301',
+    s3.region = 'us-east-1',
+    s3.access.key = 'hummockadmin',
+    s3.secret.key = 'hummockadmin',
+    create_table_if_not_exists = 'true',
+    write_mode = 'merge-on-read',
+    format_version = '3',
+    refresh.interval.sec = '1',
+    enable_pk_index = 'true',
+    commit_checkpoint_interval = '60'
 );
 
 statement ok

--- a/e2e_test/iceberg/test_case/pure_slt/iceberg_v3/sink_lakekeeper.slt
+++ b/e2e_test/iceberg/test_case/pure_slt/iceberg_v3/sink_lakekeeper.slt
@@ -39,6 +39,7 @@ WITH (
     create_table_if_not_exists = 'true',
     write_mode = 'merge-on-read',
     format_version = '3',
+    refresh.interval.sec = '1',
     enable_pk_index = 'true'
 );
 

--- a/e2e_test/iceberg/test_case/pure_slt/iceberg_v3/sink_no_partition.slt
+++ b/e2e_test/iceberg/test_case/pure_slt/iceberg_v3/sink_no_partition.slt
@@ -25,6 +25,7 @@ WITH (
     create_table_if_not_exists = 'true',
     write_mode = 'merge-on-read',
     format_version = '3',
+    refresh.interval.sec = '1',
     enable_pk_index = 'true'
 );
 
@@ -42,15 +43,6 @@ statement ok
 FLUSH;
 
 statement ok
-DELETE FROM t_v3_no_partition_pk_index WHERE v1 IN (2, 8);
-
-statement ok
-INSERT INTO t_v3_no_partition_pk_index VALUES (1, 1, 50, '1-50', '2022-03-11'), (1, 13, 130, '13-130', '2022-03-13');
-
-statement ok
-FLUSH;
-
-statement ok
 CREATE SOURCE iceberg_no_partition_v3_pk_index_source WITH (
     connector = 'iceberg',
     database.name = 'public',
@@ -63,6 +55,20 @@ CREATE SOURCE iceberg_no_partition_v3_pk_index_source WITH (
     s3.access.key = 'hummockadmin',
     s3.secret.key = 'hummockadmin'
 );
+
+query I retry 11 backoff 1s
+select count(*) from iceberg_no_partition_v3_pk_index_source;
+----
+7
+
+statement ok
+DELETE FROM t_v3_no_partition_pk_index WHERE v1 IN (2, 8);
+
+statement ok
+INSERT INTO t_v3_no_partition_pk_index VALUES (1, 1, 50, '1-50', '2022-03-11'), (1, 13, 130, '13-130', '2022-03-13');
+
+statement ok
+FLUSH;
 
 query ????? rowsort retry 11 backoff 1s
 select * from iceberg_no_partition_v3_pk_index_source;

--- a/e2e_test/iceberg/test_case/pure_slt/iceberg_v3/sink_range_partition.slt
+++ b/e2e_test/iceberg/test_case/pure_slt/iceberg_v3/sink_range_partition.slt
@@ -26,6 +26,7 @@ WITH (
     partition_by = 'day(v4)',
     write_mode = 'merge-on-read',
     format_version = '3',
+    refresh.interval.sec = '1',
     enable_pk_index = 'true'
 );
 
@@ -43,15 +44,6 @@ statement ok
 FLUSH;
 
 statement ok
-DELETE FROM t_v3_range_partition_pk_index WHERE v1 IN (2, 8);
-
-statement ok
-INSERT INTO t_v3_range_partition_pk_index VALUES (1, 1, 50, '1-50', '2022-03-11'), (1, 13, 130, '13-130', '2022-03-23');
-
-statement ok
-FLUSH;
-
-statement ok
 CREATE SOURCE iceberg_range_partition_v3_pk_index_source WITH (
     connector = 'iceberg',
     database.name = 'public',
@@ -64,6 +56,20 @@ CREATE SOURCE iceberg_range_partition_v3_pk_index_source WITH (
     s3.access.key = 'hummockadmin',
     s3.secret.key = 'hummockadmin'
 );
+
+query I retry 11 backoff 1s
+select count(*) from iceberg_range_partition_v3_pk_index_source;
+----
+7
+
+statement ok
+DELETE FROM t_v3_range_partition_pk_index WHERE v1 IN (2, 8);
+
+statement ok
+INSERT INTO t_v3_range_partition_pk_index VALUES (1, 1, 50, '1-50', '2022-03-11'), (1, 13, 130, '13-130', '2022-03-23');
+
+statement ok
+FLUSH;
 
 query ????? rowsort retry 11 backoff 1s
 select * from iceberg_range_partition_v3_pk_index_source;

--- a/e2e_test/iceberg/test_case/pure_slt/iceberg_v3/sink_sparse_partition.slt
+++ b/e2e_test/iceberg/test_case/pure_slt/iceberg_v3/sink_sparse_partition.slt
@@ -26,6 +26,7 @@ WITH (
     partition_by = 'v1,v2,truncate(2,v3)',
     write_mode = 'merge-on-read',
     format_version = '3',
+    refresh.interval.sec = '1',
     enable_pk_index = 'true'
 );
 
@@ -43,15 +44,6 @@ statement ok
 FLUSH;
 
 statement ok
-DELETE FROM t_v3_partition_pk_index WHERE v1 IN (2, 8);
-
-statement ok
-INSERT INTO t_v3_partition_pk_index VALUES (1, 1, 50, '1-50', '2022-03-11'), (1, 13, 130, '13-130', '2022-03-13');
-
-statement ok
-FLUSH;
-
-statement ok
 CREATE SOURCE iceberg_partition_v3_pk_index_source WITH (
     connector = 'iceberg',
     database.name = 'public',
@@ -64,6 +56,20 @@ CREATE SOURCE iceberg_partition_v3_pk_index_source WITH (
     s3.access.key = 'hummockadmin',
     s3.secret.key = 'hummockadmin'
 );
+
+query I retry 11 backoff 1s
+select count(*) from iceberg_partition_v3_pk_index_source;
+----
+7
+
+statement ok
+DELETE FROM t_v3_partition_pk_index WHERE v1 IN (2, 8);
+
+statement ok
+INSERT INTO t_v3_partition_pk_index VALUES (1, 1, 50, '1-50', '2022-03-11'), (1, 13, 130, '13-130', '2022-03-13');
+
+statement ok
+FLUSH;
 
 query ????? rowsort retry 11 backoff 1s
 select * from iceberg_partition_v3_pk_index_source;

--- a/e2e_test/streaming/batch_refresh_snapshot.slt
+++ b/e2e_test/streaming/batch_refresh_snapshot.slt
@@ -63,7 +63,7 @@ CREATE SOURCE src_test (v1 int) WITH (
     datagen.rows.per.second = '1'
 );
 
-statement error batch refresh materialized views must not depend on sources
+statement error batch refresh jobs must not depend on sources directly
 CREATE MATERIALIZED VIEW mv_batch_source_bad WITH (refresh.interval.sec = 5) AS
 SELECT v1 FROM src_test
 UNION ALL

--- a/proto/ddl_service.proto
+++ b/proto/ddl_service.proto
@@ -105,6 +105,7 @@ message CreateSinkRequest {
   bool if_not_exists = 5;
   StreamingJobResourceType resource_type = 6;
   optional uint64 since_timestamp_epoch = 7;
+  optional uint64 refresh_interval_sec = 8;
 }
 
 message CreateSinkResponse {

--- a/src/frontend/planner_test/src/lib.rs
+++ b/src/frontend/planner_test/src/lib.rs
@@ -886,6 +886,7 @@ impl TestCase {
                     false,
                     false,
                     false,
+                    false,
                     None,
                     None,
                     false,

--- a/src/frontend/planner_test/tests/testdata/input/sink.yaml
+++ b/src/frontend/planner_test/tests/testdata/input/sink.yaml
@@ -197,6 +197,7 @@
       write_mode = 'merge-on-read',
       format_version = '3',
       create_table_if_not_exists = 'true',
+      refresh.interval.sec = '60',
       enable_pk_index = 'true'
     );
   expected_outputs:
@@ -219,6 +220,7 @@
       write_mode = 'merge-on-read',
       format_version = '3',
       create_table_if_not_exists = 'true',
+      refresh.interval.sec = '60',
       enable_pk_index = 'true'
     );
   expected_outputs:
@@ -273,6 +275,7 @@
       write_mode = 'merge-on-read',
       format_version = '3',
       create_table_if_not_exists = 'true',
+      refresh.interval.sec = '60',
       enable_pk_index = 'true'
     );
   expected_outputs:
@@ -281,7 +284,8 @@
   sql: |
     create table u (v1 int primary key, name varchar);
     create table o (oid bigint primary key, v1 int, p varchar);
-    explain create sink s as select u.v1 as v1, o.oid as v2, u.name as v3, cast('00:00:00' as time) as v4 from u join o on u.v1 = o.v1 WITH (
+    create materialized view mv as select u.v1 as v1, o.oid as v2, u.name as v3, cast('00:00:00' as time) as v4 from u join o on u.v1 = o.v1;
+    explain create sink s from mv WITH (
       connector = 'iceberg',
       type = 'upsert',
       catalog.type = 'mock',
@@ -295,6 +299,7 @@
       s3.secret.key = 'hummockadmin',
       write_mode = 'merge-on-read',
       format_version = '3',
+      refresh.interval.sec = '60',
       enable_pk_index = 'true'
     );
   expected_outputs:

--- a/src/frontend/planner_test/tests/testdata/output/sink.yaml
+++ b/src/frontend/planner_test/tests/testdata/output/sink.yaml
@@ -306,6 +306,7 @@
       write_mode = 'merge-on-read',
       format_version = '3',
       create_table_if_not_exists = 'true',
+      refresh.interval.sec = '60',
       enable_pk_index = 'true'
     );
   explain_output: |
@@ -332,6 +333,7 @@
       write_mode = 'merge-on-read',
       format_version = '3',
       create_table_if_not_exists = 'true',
+      refresh.interval.sec = '60',
       enable_pk_index = 'true'
     );
   explain_output: |
@@ -394,6 +396,7 @@
       write_mode = 'merge-on-read',
       format_version = '3',
       create_table_if_not_exists = 'true',
+      refresh.interval.sec = '60',
       enable_pk_index = 'true'
     );
   explain_output: |
@@ -406,7 +409,8 @@
   sql: |
     create table u (v1 int primary key, name varchar);
     create table o (oid bigint primary key, v1 int, p varchar);
-    explain create sink s as select u.v1 as v1, o.oid as v2, u.name as v3, cast('00:00:00' as time) as v4 from u join o on u.v1 = o.v1 WITH (
+    create materialized view mv as select u.v1 as v1, o.oid as v2, u.name as v3, cast('00:00:00' as time) as v4 from u join o on u.v1 = o.v1;
+    explain create sink s from mv WITH (
       connector = 'iceberg',
       type = 'upsert',
       catalog.type = 'mock',
@@ -420,19 +424,15 @@
       s3.secret.key = 'hummockadmin',
       write_mode = 'merge-on-read',
       format_version = '3',
+      refresh.interval.sec = '60',
       enable_pk_index = 'true'
     );
   explain_output: |
     StreamIcebergWithPkIndexPositionDeleteMerger
     └─StreamExchange { dist: HashShard(file_path) }
       └─StreamIcebergWithPkIndexWriter { columns: [v1, v2, v3, v4], downstream_pk: [v1, v2] }
-        └─StreamExchange { dist: HashShard(u.v1, o.oid) }
-          └─StreamProject { exprs: [u.v1, o.oid, u.name, '00:00:00':Time] }
-            └─StreamHashJoin { type: Inner, predicate: u.v1 = o.v1 }
-              ├─StreamExchange { dist: HashShard(u.v1) }
-              │ └─StreamTableScan { table: u, columns: [v1, name] }
-              └─StreamExchange { dist: HashShard(o.v1) }
-                └─StreamTableScan { table: o, columns: [oid, v1] }
+        └─StreamExchange { dist: HashShard(mv.v1, mv.v2) }
+          └─StreamTableScan { table: mv, columns: [v1, v2, v3, v4] }
 - id: separate_aggregation_and_sink
   sql: |
     set streaming_separate_sink to true;

--- a/src/frontend/src/catalog/catalog_service.rs
+++ b/src/frontend/src/catalog/catalog_service.rs
@@ -149,6 +149,7 @@ pub trait CatalogWriter: Send + Sync {
         resource_type: streaming_job_resource_type::ResourceType,
         if_not_exists: bool,
         since_timestamp_epoch: Option<u64>,
+        refresh_interval_sec: Option<u64>,
     ) -> Result<()>;
 
     async fn replace_sink(
@@ -498,6 +499,7 @@ impl CatalogWriter for CatalogWriterImpl {
         resource_type: streaming_job_resource_type::ResourceType,
         if_not_exists: bool,
         since_timestamp_epoch: Option<u64>,
+        refresh_interval_sec: Option<u64>,
     ) -> Result<()> {
         let version = self
             .meta_client
@@ -508,6 +510,7 @@ impl CatalogWriter for CatalogWriterImpl {
                 resource_type,
                 if_not_exists,
                 since_timestamp_epoch,
+                refresh_interval_sec,
             )
             .await?;
         self.wait_version(version).await

--- a/src/frontend/src/handler/create_mv.rs
+++ b/src/frontend/src/handler/create_mv.rs
@@ -43,7 +43,7 @@ use crate::planner::Planner;
 use crate::scheduler::streaming_manager::CreatingStreamingJobInfo;
 use crate::session::SessionImpl;
 use crate::stream_fragmenter::{GraphJobType, build_graph_with_strategy};
-use crate::utils::{MV_REFRESH_INTERVAL_SEC_KEY, ordinal};
+use crate::utils::{BATCH_REFRESH_INTERVAL_SEC_KEY, ordinal};
 use crate::{TableCatalog, WithOptions};
 
 pub const RESOURCE_GROUP_KEY: &str = "resource_group";
@@ -357,7 +357,7 @@ pub(crate) fn gen_create_mv_graph(
 )> {
     let mut with_options = get_with_options(handler_args.clone());
     let refresh_interval_sec = with_options.refresh_interval_sec()?;
-    with_options.remove(MV_REFRESH_INTERVAL_SEC_KEY);
+    with_options.remove(BATCH_REFRESH_INTERVAL_SEC_KEY);
     let resource_type =
         resolve_streaming_job_resource_type(handler_args.session.as_ref(), &mut with_options)?;
 

--- a/src/frontend/src/handler/create_sink.rs
+++ b/src/frontend/src/handler/create_sink.rs
@@ -36,7 +36,7 @@ use risingwave_common::types::{DataType, Timestamptz};
 use risingwave_common::util::epoch::Epoch;
 use risingwave_connector::sink::catalog::{SinkCatalog, SinkFormatDesc};
 use risingwave_connector::sink::file_sink::s3::SnowflakeSink;
-use risingwave_connector::sink::iceberg::{ICEBERG_SINK, IcebergConfig};
+use risingwave_connector::sink::iceberg::{ENABLE_PK_INDEX, ICEBERG_SINK, IcebergConfig};
 use risingwave_connector::sink::kafka::KAFKA_SINK;
 use risingwave_connector::sink::snowflake_redshift::redshift::RedshiftSink;
 use risingwave_connector::sink::snowflake_redshift::snowflake::SnowflakeV2Sink;
@@ -55,6 +55,7 @@ use risingwave_sqlparser::ast::{
     ObjectName, Query, Statement,
 };
 use risingwave_sqlparser::parser::Parser;
+use thiserror_ext::AsReport;
 
 use super::RwPgResponse;
 use super::create_mv::get_column_names;
@@ -86,7 +87,10 @@ use crate::scheduler::streaming_manager::CreatingStreamingJobInfo;
 use crate::session::SessionImpl;
 use crate::session::current::notice_to_user;
 use crate::stream_fragmenter::{GraphJobType, build_graph_with_strategy};
-use crate::utils::{resolve_connection_ref_and_secret_ref, resolve_privatelink_in_with_option};
+use crate::utils::{
+    BATCH_REFRESH_INTERVAL_SEC_KEY, resolve_connection_ref_and_secret_ref,
+    resolve_privatelink_in_with_option,
+};
 use crate::{Explain, Planner, TableCatalog, WithOptions, WithOptionsSecResolved};
 
 static SINK_ALLOWED_CONNECTION_CONNECTOR: LazyLock<HashSet<PbConnectionType>> =
@@ -117,6 +121,7 @@ pub struct SinkPlanContext {
     pub target_table_catalog: Option<Arc<TableCatalog>>,
     pub dependencies: HashSet<ObjectId>,
     pub since_timestamp_epoch: Option<u64>,
+    pub refresh_interval_sec: Option<u64>,
 }
 
 pub async fn gen_sink_plan(
@@ -173,6 +178,10 @@ pub async fn gen_sink_plan(
     if since_timestamp_epoch.is_some() {
         Feature::SinkSinceTimestamp.check_available()?;
     }
+    let refresh_interval_sec = resolved_with_options
+        .remove(BATCH_REFRESH_INTERVAL_SEC_KEY)
+        .map(parse_batch_refresh_interval_sec)
+        .transpose()?;
 
     ensure_connection_type_allowed(connection_type, &SINK_ALLOWED_CONNECTION_CONNECTOR)?;
 
@@ -226,6 +235,24 @@ pub async fn gen_sink_plan(
         .get(CONNECTOR_TYPE_KEY)
         .cloned()
         .ok_or_else(|| ErrorCode::BindError(format!("missing field '{CONNECTOR_TYPE_KEY}'")))?;
+    let is_iceberg_pk_index_sink = connector.eq_ignore_ascii_case(ICEBERG_SINK)
+        && resolved_with_options
+            .get(ENABLE_PK_INDEX)
+            .is_some_and(|value| value.eq_ignore_ascii_case("true"));
+    if refresh_interval_sec.is_some() && !is_iceberg_pk_index_sink {
+        return Err(ErrorCode::InvalidInputSyntax(format!(
+            "`{BATCH_REFRESH_INTERVAL_SEC_KEY}` is only supported for Iceberg sinks with \
+             `enable_pk_index='true'`"
+        ))
+        .into());
+    }
+    if is_iceberg_pk_index_sink && !is_iceberg_engine_internal && refresh_interval_sec.is_none() {
+        return Err(ErrorCode::InvalidInputSyntax(format!(
+            "Iceberg sink with `enable_pk_index='true'` must be created as a batch refresh job. \
+             Please specify `{BATCH_REFRESH_INTERVAL_SEC_KEY}` in the WITH clause."
+        ))
+        .into());
+    }
     ensure_local_fs_connector_allowed(session, &connector)?;
 
     // Used for debezium's table name
@@ -332,6 +359,26 @@ pub async fn gen_sink_plan(
             }
         }
     }
+    if refresh_interval_sec.is_some() {
+        if since_timestamp_epoch.is_some() {
+            return Err(ErrorCode::BindError(format!(
+                "`{SINK_SINCE_TIMESTAMP_OPTION}` cannot be used with `{BATCH_REFRESH_INTERVAL_SEC_KEY}`"
+            ))
+            .into());
+        }
+        if sink_into_table_name.is_some() {
+            return Err(ErrorCode::BindError(format!(
+                "`{BATCH_REFRESH_INTERVAL_SEC_KEY}` does not support `CREATE SINK INTO TABLE`"
+            ))
+            .into());
+        }
+        if is_iceberg_engine_internal {
+            return Err(ErrorCode::BindError(format!(
+                "`{BATCH_REFRESH_INTERVAL_SEC_KEY}` does not support iceberg engine internal sinks"
+            ))
+            .into());
+        }
+    }
 
     let (
         dependent_relations,
@@ -386,6 +433,14 @@ pub async fn gen_sink_plan(
     };
 
     reject_internal_table_dependencies(session, &dependent_relations, "CREATE SINK")?;
+    if refresh_interval_sec.is_some() && dependent_relations.len() != 1 {
+        return Err(ErrorCode::NotSupported(
+            "Iceberg pk-index batch refresh sink requires exactly one direct upstream relation"
+                .to_owned(),
+            "Please create a materialized view for complex queries first, then create the sink from that materialized view.".to_owned(),
+        )
+        .into());
+    }
 
     let col_names = if sink_into_table_name.is_some() {
         parse_column_names(&stmt.columns)
@@ -436,6 +491,12 @@ pub async fn gen_sink_plan(
         resolved_with_options.remove(SINK_SNAPSHOT_OPTION),
         Some(flag) if flag.eq_ignore_ascii_case("false")
     );
+    if refresh_interval_sec.is_some() && without_snapshot {
+        return Err(ErrorCode::InvalidInputSyntax(format!(
+            "`{BATCH_REFRESH_INTERVAL_SEC_KEY}` requires snapshot backfill, but `snapshot=false` was specified"
+        ))
+        .into());
+    }
 
     if since_timestamp_epoch.is_some() && !without_snapshot {
         return Err(ErrorCode::BindError(format!(
@@ -489,6 +550,7 @@ pub async fn gen_sink_plan(
         format_desc,
         without_snapshot,
         since_timestamp_epoch.is_some(),
+        refresh_interval_sec.is_some(),
         is_iceberg_engine_internal,
         target_table_catalog.clone(),
         partition_info,
@@ -568,7 +630,25 @@ pub async fn gen_sink_plan(
         target_table_catalog,
         dependencies,
         since_timestamp_epoch,
+        refresh_interval_sec,
     })
+}
+
+fn parse_batch_refresh_interval_sec(value: String) -> Result<u64> {
+    let seconds = value.parse::<u64>().map_err(|err| {
+        ErrorCode::InvalidParameterValue(format!(
+            "`{BATCH_REFRESH_INTERVAL_SEC_KEY}` must be a positive integer, but got: {value} \
+             (error: {})",
+            err.as_report()
+        ))
+    })?;
+    if seconds == 0 {
+        return Err(ErrorCode::InvalidParameterValue(format!(
+            "`{BATCH_REFRESH_INTERVAL_SEC_KEY}` must be larger than 0, but got: {seconds}"
+        ))
+        .into());
+    }
+    Ok(seconds)
 }
 
 // This function is used to return partition compute info for a sink. More details refer in `PartitionComputeInfo`.
@@ -718,7 +798,7 @@ async fn create_sink_or_replace(
     let resource_type =
         resolve_streaming_job_resource_type(session.as_ref(), &mut handle_args.with_options)?;
 
-    let (sink, graph, dependencies, since_timestamp_epoch) = {
+    let (sink, graph, dependencies, since_timestamp_epoch, refresh_interval_sec) = {
         let backfill_order_strategy = handle_args.with_options.backfill_order_strategy();
         let SinkPlanContext {
             query,
@@ -727,6 +807,7 @@ async fn create_sink_or_replace(
             target_table_catalog,
             dependencies,
             since_timestamp_epoch,
+            refresh_interval_sec,
         } = gen_sink_plan(handle_args, stmt, None, is_iceberg_engine_internal).await?;
 
         let has_order_by = !query.order_by.is_empty();
@@ -744,6 +825,13 @@ async fn create_sink_or_replace(
                 }
             }
             SinkCreateMode::Replace { original_sink } => {
+                if refresh_interval_sec.is_some() {
+                    return Err(ErrorCode::NotSupported(
+                        "REPLACE SINK with batch refresh is not supported yet".to_owned(),
+                        "drop and recreate the sink instead".to_owned(),
+                    )
+                    .into());
+                }
                 if target_table_catalog.is_some() {
                     return Err(ErrorCode::NotSupported(
                         "REPLACE SINK INTO TABLE is not supported yet".to_owned(),
@@ -764,7 +852,13 @@ async fn create_sink_or_replace(
         let graph =
             build_graph_with_strategy(plan, Some(GraphJobType::Sink), Some(backfill_order))?;
 
-        (sink, graph, dependencies, since_timestamp_epoch)
+        (
+            sink,
+            graph,
+            dependencies,
+            since_timestamp_epoch,
+            refresh_interval_sec,
+        )
     };
 
     let statement_name = mode.statement_name();
@@ -788,6 +882,7 @@ async fn create_sink_or_replace(
                     resource_type,
                     if_not_exists,
                     since_timestamp_epoch,
+                    refresh_interval_sec,
                 ),
                 &session,
                 statement_name,

--- a/src/frontend/src/optimizer/mod.rs
+++ b/src/frontend/src/optimizer/mod.rs
@@ -93,7 +93,7 @@ use crate::optimizer::plan_visitor::{
 };
 use crate::optimizer::property::Distribution;
 use crate::utils::{
-    ColIndexMappingRewriteExt, MV_REFRESH_INTERVAL_SEC_KEY, WithOptionsSecResolved,
+    BATCH_REFRESH_INTERVAL_SEC_KEY, ColIndexMappingRewriteExt, WithOptionsSecResolved,
 };
 
 /// `PlanRoot` is used to describe a plan. planner will construct a `PlanRoot` with `LogicalNode`.
@@ -655,17 +655,17 @@ impl LogicalPlanRoot {
             && session_ctx.config().streaming_use_snapshot_backfill();
         if !snapshot_backfill_enabled {
             return Err(ErrorCode::NotSupported(
-                "Batch refresh materialized view requires snapshot backfill".to_owned(),
+                "Batch refresh job requires snapshot backfill".to_owned(),
                 format!(
                     "Please enable snapshot backfill or remove `{}` from the WITH clause.",
-                    MV_REFRESH_INTERVAL_SEC_KEY
+                    BATCH_REFRESH_INTERVAL_SEC_KEY
                 ),
             )
             .into());
         }
         if let Some(reason) = self.plan.forbid_snapshot_backfill() {
             return Err(ErrorCode::NotSupported(
-                format!("Batch refresh materialized view requires snapshot backfill, but {reason}"),
+                format!("Batch refresh job requires snapshot backfill, but {reason}"),
                 "Please rewrite the query to avoid operators that forbid snapshot backfill."
                     .to_owned(),
             )
@@ -1170,13 +1170,29 @@ impl LogicalPlanRoot {
         format_desc: Option<SinkFormatDesc>,
         without_snapshot: bool,
         since_timestamp: bool,
+        batch_refresh: bool,
         is_iceberg_engine_internal: bool,
         target_table: Option<Arc<TableCatalog>>,
         partition_info: Option<PartitionComputeInfo>,
         user_specified_columns: bool,
         auto_refresh_schema_from_table: Option<Arc<TableCatalog>>,
     ) -> Result<StreamSink> {
-        let backfill_type = if since_timestamp {
+        let backfill_type = if batch_refresh {
+            if since_timestamp {
+                return Err(ErrorCode::InvalidInputSyntax(
+                    "since_timestamp is not allowed for batch refresh sink".to_owned(),
+                )
+                .into());
+            }
+            if without_snapshot {
+                return Err(ErrorCode::InvalidInputSyntax(
+                    "batch refresh sink requires snapshot backfill".to_owned(),
+                )
+                .into());
+            }
+            self.require_snapshot_backfill_for_batch_refresh()?;
+            BackfillType::SnapshotBackfill
+        } else if since_timestamp {
             assert!(
                 target_table.is_none(),
                 "should not allow since_timestamp for sink-into-table"
@@ -1235,6 +1251,7 @@ impl LogicalPlanRoot {
             target_columns_to_plan_mapping,
             definition,
             properties,
+            batch_refresh,
             format_desc,
             partition_info,
             auto_refresh_schema_from_table,

--- a/src/frontend/src/optimizer/plan_node/stream_sink.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_sink.rs
@@ -26,6 +26,7 @@ use risingwave_common::types::{DataType, StructType};
 use risingwave_common::util::iter_util::ZipEqDebug;
 use risingwave_connector::sink::catalog::desc::SinkDesc;
 use risingwave_connector::sink::catalog::{SinkFormat, SinkFormatDesc, SinkId, SinkType};
+use risingwave_connector::sink::decouple_checkpoint_log_sink::COMMIT_CHECKPOINT_INTERVAL;
 use risingwave_connector::sink::file_sink::fs::FsSink;
 use risingwave_connector::sink::iceberg::{ENABLE_PK_INDEX, ICEBERG_SINK};
 use risingwave_connector::sink::trivial::TABLE_SINK;
@@ -293,6 +294,7 @@ impl StreamSink {
         target_table_mapping: Option<Vec<Option<usize>>>,
         definition: String,
         mut properties: WithOptionsSecResolved,
+        batch_refresh: bool,
         format_desc: Option<SinkFormatDesc>,
         partition_info: Option<PartitionComputeInfo>,
         auto_refresh_schema_from_table: Option<Arc<TableCatalog>>,
@@ -314,6 +316,19 @@ impl StreamSink {
             && properties
                 .get(ENABLE_PK_INDEX)
                 .is_some_and(|v| v.eq_ignore_ascii_case("true"));
+
+        if is_iceberg_pk_index && batch_refresh {
+            if properties.contains_key(COMMIT_CHECKPOINT_INTERVAL) {
+                return Err(ErrorCode::InvalidInputSyntax(
+                    "`commit_checkpoint_interval` does not apply to Iceberg sinks with \
+                     `enable_pk_index='true'`. Batch refresh controls the checkpoint cadence for \
+                     these sinks."
+                        .to_owned(),
+                )
+                .into());
+            }
+            properties.insert(COMMIT_CHECKPOINT_INTERVAL.to_owned(), "1".to_owned());
+        }
 
         // For Iceberg pk-index sinks, the iceberg primary key is derived entirely from the
         // upstream stream key, so the user must not specify `primary_key` explicitly.

--- a/src/frontend/src/test_utils.rs
+++ b/src/frontend/src/test_utils.rs
@@ -407,6 +407,7 @@ impl CatalogWriter for MockCatalogWriter {
         _resource_type: streaming_job_resource_type::ResourceType,
         _if_not_exists: bool,
         _since_timestamp_epoch: Option<u64>,
+        _refresh_interval_sec: Option<u64>,
     ) -> Result<()> {
         let sink_id = self.create_sink_inner(sink, graph)?;
         self.insert_object_dependencies(sink_id.as_object_id(), dependencies);

--- a/src/frontend/src/utils/with_options.rs
+++ b/src/frontend/src/utils/with_options.rs
@@ -51,7 +51,7 @@ pub mod options {
     pub const RETENTION_SECONDS: &str = "retention_seconds";
 }
 
-pub const MV_REFRESH_INTERVAL_SEC_KEY: &str = "refresh.interval.sec";
+pub const BATCH_REFRESH_INTERVAL_SEC_KEY: &str = "refresh.interval.sec";
 pub const SOURCE_REFRESH_MODE_KEY: &str = "refresh_mode";
 pub const SOURCE_REFRESH_INTERVAL_SEC_KEY: &str = "refresh_interval_sec";
 
@@ -157,12 +157,12 @@ impl WithOptions {
 
     pub fn refresh_interval_sec(&self) -> RwResult<Option<u64>> {
         self.inner
-            .get(MV_REFRESH_INTERVAL_SEC_KEY)
+            .get(BATCH_REFRESH_INTERVAL_SEC_KEY)
             .map(|seconds| {
                 let seconds = seconds.parse::<u64>().map_err(|e| {
                     RwError::from(ErrorCode::InvalidParameterValue(format!(
                         "`{}` must be a positive integer, but got: {} (error: {})",
-                        MV_REFRESH_INTERVAL_SEC_KEY,
+                        BATCH_REFRESH_INTERVAL_SEC_KEY,
                         seconds,
                         e.as_report()
                     )))
@@ -170,7 +170,7 @@ impl WithOptions {
                 if seconds == 0 {
                     return Err(RwError::from(ErrorCode::InvalidParameterValue(format!(
                         "`{}` must be larger than 0, but got: {}",
-                        MV_REFRESH_INTERVAL_SEC_KEY, seconds
+                        BATCH_REFRESH_INTERVAL_SEC_KEY, seconds
                     ))));
                 }
                 Ok(seconds)

--- a/src/meta/service/src/ddl_service.rs
+++ b/src/meta/service/src/ddl_service.rs
@@ -461,6 +461,7 @@ impl DdlService for DdlServiceImpl {
             .and_then(|resource_type| resource_type.resource_type)
             .unwrap_or_else(Self::default_streaming_job_resource_type);
         let since_timestamp_epoch = req.since_timestamp_epoch;
+        let refresh_interval_sec = req.refresh_interval_sec;
 
         let stream_job = StreamingJob::Sink(sink);
 
@@ -470,7 +471,7 @@ impl DdlService for DdlServiceImpl {
             dependencies,
             resource_type,
             if_not_exists: req.if_not_exists,
-            refresh_interval_sec: None,
+            refresh_interval_sec,
             replace_sink: None,
             since_timestamp_epoch,
         };

--- a/src/meta/src/controller/streaming_job.rs
+++ b/src/meta/src/controller/streaming_job.rs
@@ -417,7 +417,7 @@ impl CatalogController {
                     resource_type.clone(),
                     backfill_parallelism.clone(),
                     backfill_adaptive_parallelism_strategy,
-                    None, // refresh_interval_sec: only for MV
+                    refresh_interval_sec,
                 )
                 .await?;
                 sink.id = streaming_job_model.job_id.as_sink_id();
@@ -454,7 +454,7 @@ impl CatalogController {
                     resource_type.clone(),
                     backfill_parallelism.clone(),
                     backfill_adaptive_parallelism_strategy,
-                    None, // refresh_interval_sec: only for MV
+                    None, // refresh_interval_sec: only for batch refresh jobs
                 )
                 .await?;
                 let job_id = streaming_job_model.job_id;
@@ -519,7 +519,7 @@ impl CatalogController {
                     resource_type.clone(),
                     backfill_parallelism.clone(),
                     backfill_adaptive_parallelism_strategy,
-                    None, // refresh_interval_sec: only for MV
+                    None, // refresh_interval_sec: only for batch refresh jobs
                 )
                 .await?;
                 // to be compatible with old implementation.
@@ -557,7 +557,7 @@ impl CatalogController {
                     resource_type.clone(),
                     backfill_parallelism.clone(),
                     backfill_adaptive_parallelism_strategy,
-                    None, // refresh_interval_sec: only for MV
+                    None, // refresh_interval_sec: only for batch refresh jobs
                 )
                 .await?;
                 src.id = streaming_job_model.job_id.as_shared_source_id();

--- a/src/meta/src/stream/stream_manager.rs
+++ b/src/meta/src/stream/stream_manager.rs
@@ -651,9 +651,7 @@ impl GlobalStreamManager {
                 bail!("since_timestamp should not be specified when no snapshot backfill");
             }
             let snapshot_backfill_info = snapshot_backfill_info.ok_or_else(|| {
-                anyhow::anyhow!(
-                    "batch refresh materialized view must have snapshot backfill upstream"
-                )
+                anyhow::anyhow!("batch refresh job must have snapshot backfill upstream")
             })?;
             // Batch refresh jobs must not contain source or source-backfill nodes,
             // because we skip split assignment resolution for them.
@@ -663,7 +661,7 @@ impl GlobalStreamManager {
                     || mask.contains(FragmentTypeFlag::SourceScan)
                 {
                     bail!(
-                        "batch refresh materialized views must not depend on sources directly; \
+                        "batch refresh jobs must not depend on sources directly; \
                          fragment {} has source/source-backfill nodes",
                         fragment.fragment_id
                     );

--- a/src/rpc_client/src/meta_client.rs
+++ b/src/rpc_client/src/meta_client.rs
@@ -486,6 +486,7 @@ impl MetaClient {
         resource_type: streaming_job_resource_type::ResourceType,
         if_not_exists: bool,
         since_timestamp_epoch: Option<u64>,
+        refresh_interval_sec: Option<u64>,
     ) -> Result<WaitVersion> {
         let request = CreateSinkRequest {
             sink: Some(sink),
@@ -496,6 +497,7 @@ impl MetaClient {
                 resource_type: Some(resource_type),
             }),
             since_timestamp_epoch,
+            refresh_interval_sec,
         };
 
         let resp = self.inner.create_sink(request).await?;

--- a/src/tests/simulation/tests/integration_tests/sink/iceberg_v3_2pc/utils.rs
+++ b/src/tests/simulation/tests/integration_tests/sink/iceberg_v3_2pc/utils.rs
@@ -111,6 +111,7 @@ pub async fn start_v3_test_cluster_with_sink(parallelism: usize) -> Result<V3Tes
                table.name = 't', \
                is_exactly_once = 'true', \
                enable_pk_index = 'true', \
+               refresh.interval.sec = 1, \
                format_version = '3', \
                type = 'upsert' \
              )",


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).


## What changed and what is your intention?

- Add `refresh.interval.sec` support for Iceberg pk-index sinks (`enable_pk_index=true`) and plumb it through frontend, RPC, and meta catalog creation.
- Require Iceberg pk-index sinks to be batch refresh jobs, reject unsupported combinations, and reject user-specified `commit_checkpoint_interval` because meta controls checkpoint injection.
- Set the sink executor `commit_checkpoint_interval` to `1` for batch-refresh pk-index sinks so every meta-injected checkpoint is committed.
- Update Iceberg V3 pk-index SLTs and planner tests for the new batch-refresh requirement.
- Adjust the affected Iceberg V3 SLTs to wait until the initial snapshot is visible through Iceberg before testing row-level update/delete behavior.


## Checklist

- [ ] I have written necessary rustdoc comments.
- [x] I have added necessary integration/planner coverage.
- [x] I have added test labels as necessary.
- [ ] I have added fuzzing tests or opened an issue to track them.
- [ ] My PR contains breaking changes.
- [ ] My PR changes performance-critical code, so I will run (micro) benchmarks and present the results.
- [ ] I have checked the Release Timeline and Currently Supported Versions to determine which release branches I need to cherry-pick this PR into.


## Documentation

- [x] My PR needs documentation updates.

<details>
<summary><b>Release note</b></summary>

Iceberg sinks with pk-index are now created as batch refresh jobs using `refresh.interval.sec`. Unsupported manual `commit_checkpoint_interval` settings are rejected for this sink mode because checkpoint injection is controlled by meta.

</details>
