### PR TITLE
feat(meta): stream metadata snapshot backup and restore

### DIFF
--- a/src/meta/Cargo.toml
+++ b/src/meta/Cargo.toml
@@ -68,6 +68,7 @@ serde = { workspace = true }
 serde_json = "1.0.113"
 strum = { version = "0.28", features = ["derive"] }
 sync-point = { path = "../utils/sync-point" }
+tempfile = "3"
 thiserror = { workspace = true }
 thiserror-ext = { workspace = true }
 tokio = { workspace = true }

--- a/src/meta/src/backup_restore/backup_manager.rs
+++ b/src/meta/src/backup_restore/backup_manager.rs
@@ -353,18 +353,24 @@ impl BackupWorker {
                     .await
             };
             let meta_store = backup_manager_clone.env.meta_store();
-            let mut snapshot_builder =
-                meta_snapshot_builder::MetaSnapshotV2Builder::new(meta_store);
+            let snapshot_builder = meta_snapshot_builder::MetaSnapshotV2Builder::new(meta_store);
+            let backup_store = backup_manager_clone.backup_store.load().0.clone();
             // Reuse job id as snapshot id.
-            snapshot_builder
-                .build(job_id, hummock_version_builder)
+            let mut uploader = backup_store
+                .begin_snapshot_upload(job_id, meta_snapshot_builder::VERSION)
                 .await?;
-            let snapshot = snapshot_builder.finish()?;
-            backup_manager_clone
-                .backup_store
-                .load()
-                .0
-                .create(&snapshot, remarks)
+            let snapshot_info = snapshot_builder
+                .build_streaming(&mut uploader, hummock_version_builder)
+                .await?;
+            uploader.finish().await?;
+            backup_store
+                .commit_snapshot_metadata(
+                    job_id,
+                    &snapshot_info.hummock_version,
+                    meta_snapshot_builder::VERSION,
+                    remarks,
+                    snapshot_info.table_change_log_object_ids.into_iter(),
+                )
                 .await?;
             Ok(BackupJobResult::Succeeded)
         };

--- a/src/meta/src/backup_restore/meta_snapshot_builder.rs
+++ b/src/meta/src/backup_restore/meta_snapshot_builder.rs
@@ -12,64 +12,50 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::collections::HashSet;
 use std::future::Future;
 
-use itertools::Itertools;
-use risingwave_backup::MetaSnapshotId;
+use bytes::Bytes;
+use futures::TryStreamExt;
 use risingwave_backup::error::{BackupError, BackupResult};
-use risingwave_backup::meta_snapshot_v2::{MetaSnapshotV2, MetadataV2};
+use risingwave_backup::meta_snapshot_v2::HUMMOCK_VERSION_ENCODING_INDEX;
+use risingwave_backup::storage::MetaSnapshotStreamingUploader;
+use risingwave_hummock_sdk::HummockRawObjectId;
+use risingwave_hummock_sdk::change_log::EpochNewChangeLog;
 use risingwave_hummock_sdk::version::{HummockVersion, HummockVersionDelta};
 use risingwave_meta_model as model;
 use risingwave_pb::hummock::PbHummockVersionDelta;
-use sea_orm::{DbErr, EntityTrait, QueryOrder, TransactionTrait};
+use sea_orm::{DbErr, EntityTrait, PaginatorTrait, QueryOrder, TransactionTrait};
+use serde::Serialize;
 
 use crate::controller::SqlMetaStore;
+use crate::hummock::model::ext::to_table_change_log;
 
-const VERSION: u32 = 2;
+pub const VERSION: u32 = 2;
 
 fn map_db_err(e: DbErr) -> BackupError {
     BackupError::MetaStorage(e.into())
 }
 
-macro_rules! define_set_metadata {
-    ($( {$name:ident, $mod_path:ident::$mod_name:ident} ),*) => {
-        async fn set_metadata(
-            metadata: &mut MetadataV2,
-            txn: &sea_orm::DatabaseTransaction,
-        ) -> BackupResult<()> {
-          $(
-              metadata.$name = $mod_path::$mod_name::Entity::find()
-                                    .all(txn)
-                                    .await
-                                    .map_err(map_db_err)?;
-          )*
-          Ok(())
-        }
-    };
+pub struct MetaSnapshotV2Builder {
+    meta_store: SqlMetaStore,
 }
 
-risingwave_backup::for_all_metadata_models_v2!(define_set_metadata);
-
-pub struct MetaSnapshotV2Builder {
-    snapshot: MetaSnapshotV2,
-    meta_store: SqlMetaStore,
+pub struct StreamedMetaSnapshotInfo {
+    pub hummock_version: HummockVersion,
+    pub table_change_log_object_ids: HashSet<HummockRawObjectId>,
 }
 
 impl MetaSnapshotV2Builder {
     pub fn new(meta_store: SqlMetaStore) -> Self {
-        Self {
-            snapshot: MetaSnapshotV2::default(),
-            meta_store,
-        }
+        Self { meta_store }
     }
 
-    pub async fn build(
-        &mut self,
-        id: MetaSnapshotId,
+    pub async fn build_streaming(
+        &self,
+        writer: &mut MetaSnapshotStreamingUploader,
         hummock_version_builder: impl Future<Output = HummockVersion>,
-    ) -> BackupResult<()> {
-        self.snapshot.format_version = VERSION;
-        self.snapshot.id = id;
+    ) -> BackupResult<StreamedMetaSnapshotInfo> {
         // Get `hummock_version` before `meta_store_snapshot`.
         // We have ensure the required delta logs for replay is available, see
         // `HummockManager::delete_version_deltas`.
@@ -83,46 +69,240 @@ impl MetaSnapshotV2Builder {
             )
             .await
             .map_err(map_db_err)?;
-        let version_deltas = model::prelude::HummockVersionDelta::find()
-            .order_by_asc(model::hummock_version_delta::Column::Id)
-            .all(&txn)
-            .await
-            .map_err(map_db_err)?
-            .into_iter()
-            .map_into::<PbHummockVersionDelta>()
-            .map(HummockVersionDelta::from_persisted_protobuf_owned);
-        let hummock_version = {
-            let mut redo_state = hummock_version;
-            let mut max_log_id = None;
-            for version_delta in version_deltas {
-                if version_delta.prev_id == redo_state.id {
-                    redo_state.apply_version_delta(&version_delta);
-                }
-                max_log_id = Some(version_delta.id);
-            }
-            if let Some(max_log_id) = max_log_id
-                && max_log_id != redo_state.id
-            {
-                return Err(BackupError::Other(anyhow::anyhow!(format!(
-                    "inconsistent hummock version: expected {}, actual {}",
-                    max_log_id, redo_state.id
-                ))));
-            }
-            redo_state
-        };
-        let mut metadata = MetadataV2 {
-            hummock_version,
-            ..Default::default()
-        };
-        set_metadata(&mut metadata, &txn).await?;
+        let hummock_version = build_hummock_version_from_deltas(hummock_version, &txn).await?;
+        stream_metadata(&hummock_version, writer, &txn).await?;
+        let table_change_log_object_ids = collect_table_change_log_object_ids(&txn).await?;
 
         txn.commit().await.map_err(map_db_err)?;
-        self.snapshot.metadata = metadata;
-        Ok(())
+        Ok(StreamedMetaSnapshotInfo {
+            hummock_version,
+            table_change_log_object_ids,
+        })
+    }
+}
+
+async fn build_hummock_version_from_deltas(
+    hummock_version: HummockVersion,
+    txn: &sea_orm::DatabaseTransaction,
+) -> BackupResult<HummockVersion> {
+    let mut redo_state = hummock_version;
+    let mut max_log_id = None;
+    {
+        let mut version_delta_stream = model::prelude::HummockVersionDelta::find()
+            .order_by_asc(model::hummock_version_delta::Column::Id)
+            .stream(txn)
+            .await
+            .map_err(map_db_err)?;
+        while let Some(model) = version_delta_stream.try_next().await.map_err(map_db_err)? {
+            let version_delta = HummockVersionDelta::from_persisted_protobuf_owned(
+                PbHummockVersionDelta::from(model),
+            );
+            if version_delta.prev_id == redo_state.id {
+                redo_state.apply_version_delta(&version_delta);
+            }
+            max_log_id = Some(version_delta.id);
+        }
     }
 
-    pub fn finish(self) -> BackupResult<MetaSnapshotV2> {
-        // Any sanity check goes here.
-        Ok(self.snapshot)
+    if let Some(max_log_id) = max_log_id
+        && max_log_id != redo_state.id
+    {
+        return Err(BackupError::Other(anyhow::anyhow!(format!(
+            "inconsistent hummock version: expected {}, actual {}",
+            max_log_id, redo_state.id
+        ))));
+    }
+    Ok(redo_state)
+}
+
+macro_rules! define_stream_metadata {
+    ($( {$name:ident, $mod_path:ident::$mod_name:ident} ),*) => {
+        async fn stream_metadata(
+            hummock_version: &HummockVersion,
+            writer: &mut MetaSnapshotStreamingUploader,
+            txn: &sea_orm::DatabaseTransaction,
+        ) -> BackupResult<()> {
+            let mut _idx = 0;
+            $(
+                if _idx == HUMMOCK_VERSION_ENCODING_INDEX {
+                    let hummock_version_pb = hummock_version.to_protobuf();
+                    put_1_streaming(writer, &hummock_version_pb).await?;
+                }
+                put_model_streaming::<$mod_path::$mod_name::Entity>(writer, txn).await?;
+                _idx += 1;
+            )*
+            Ok(())
+        }
+    };
+}
+
+risingwave_backup::for_all_metadata_models_v2!(define_stream_metadata);
+
+async fn put_model_streaming<E>(
+    writer: &mut MetaSnapshotStreamingUploader,
+    txn: &sea_orm::DatabaseTransaction,
+) -> BackupResult<()>
+where
+    E: EntityTrait,
+    E::Model: Serialize + Send + Sync + 'static,
+{
+    let count = E::find().count(txn).await.map_err(map_db_err)?;
+    let count = u32::try_from(count)
+        .map_err(|_| BackupError::Other(anyhow::anyhow!("too many metadata rows: {}", count)))?;
+    writer.write_u32_le(count).await?;
+
+    let mut stream = E::find().stream(txn).await.map_err(map_db_err)?;
+    let mut actual_count = 0;
+    while let Some(model) = stream.try_next().await.map_err(map_db_err)? {
+        if actual_count == count {
+            return Err(BackupError::Other(anyhow::anyhow!(
+                "metadata row count changed while streaming {}: counted {}, streamed more",
+                std::any::type_name::<E>(),
+                count,
+            )));
+        }
+        put_with_len_prefix_streaming(writer, &model).await?;
+        actual_count += 1;
+    }
+    if actual_count != count {
+        return Err(BackupError::Other(anyhow::anyhow!(
+            "metadata row count changed while streaming {}: counted {}, streamed {}",
+            std::any::type_name::<E>(),
+            count,
+            actual_count,
+        )));
+    }
+    Ok(())
+}
+
+async fn put_1_streaming<T: Serialize>(
+    writer: &mut MetaSnapshotStreamingUploader,
+    data: &T,
+) -> BackupResult<()> {
+    writer.write_u32_le(1).await?;
+    put_with_len_prefix_streaming(writer, data).await
+}
+
+async fn put_with_len_prefix_streaming<T: Serialize>(
+    writer: &mut MetaSnapshotStreamingUploader,
+    data: &T,
+) -> BackupResult<()> {
+    let bytes = serde_json::to_vec(data)?;
+    assert!(!bytes.is_empty());
+    if let Ok(len) = u32::try_from(bytes.len()) {
+        writer.write_u32_le(len).await?;
+    } else {
+        writer.write_u32_le(0).await?;
+        writer
+            .write_u64_le(
+                bytes
+                    .len()
+                    .try_into()
+                    .unwrap_or_else(|_| panic!("cannot convert {} into u64", bytes.len())),
+            )
+            .await?;
+    }
+    writer.write_bytes(Bytes::from(bytes)).await
+}
+
+async fn collect_table_change_log_object_ids(
+    txn: &sea_orm::DatabaseTransaction,
+) -> BackupResult<HashSet<HummockRawObjectId>> {
+    let mut object_ids = HashSet::new();
+    let mut stream = model::hummock_table_change_log::Entity::find()
+        .stream(txn)
+        .await
+        .map_err(map_db_err)?;
+    while let Some(model) = stream.try_next().await.map_err(map_db_err)? {
+        let EpochNewChangeLog {
+            new_value,
+            old_value,
+            ..
+        } = to_table_change_log(model);
+        object_ids.extend(
+            new_value
+                .into_iter()
+                .chain(old_value)
+                .map(|t| t.object_id.as_raw()),
+        );
+    }
+    Ok(object_ids)
+}
+
+#[cfg(test)]
+mod tests {
+    use risingwave_backup::meta_snapshot_v2::{MetaSnapshotV2, MetadataV2};
+    use risingwave_backup::storage::{MetaSnapshotStorage, unused};
+    use risingwave_hummock_sdk::version::HummockVersion;
+    use sea_orm::{ActiveModelTrait, EntityTrait, Set};
+
+    use super::*;
+    use crate::controller::SqlMetaStore;
+
+    macro_rules! define_load_legacy_metadata {
+        ($( {$name:ident, $mod_path:ident::$mod_name:ident} ),*) => {
+            async fn load_legacy_metadata(
+                meta_store: &SqlMetaStore,
+                hummock_version: HummockVersion,
+            ) -> BackupResult<MetadataV2> {
+                let mut metadata = MetadataV2 {
+                    hummock_version,
+                    ..Default::default()
+                };
+                $(
+                    metadata.$name = $mod_path::$mod_name::Entity::find()
+                        .all(&meta_store.conn)
+                        .await
+                        .map_err(map_db_err)?;
+                )*
+                Ok(metadata)
+            }
+        };
+    }
+
+    risingwave_backup::for_all_metadata_models_v2!(define_load_legacy_metadata);
+
+    #[tokio::test]
+    async fn test_streaming_snapshot_export_matches_legacy_snapshot_with_non_empty_tables() {
+        let meta_store = SqlMetaStore::for_test().await;
+        risingwave_meta_model::hummock_sequence::ActiveModel {
+            name: Set("streaming_snapshot_export_test".to_owned()),
+            seq: Set(123),
+        }
+        .insert(&meta_store.conn)
+        .await
+        .unwrap();
+
+        let store = unused().await;
+        let snapshot_id = 45;
+        let mut uploader = store
+            .begin_snapshot_upload(snapshot_id, VERSION)
+            .await
+            .unwrap();
+        let snapshot_info = MetaSnapshotV2Builder::new(meta_store.clone())
+            .build_streaming(&mut uploader, std::future::ready(HummockVersion::default()))
+            .await
+            .unwrap();
+        uploader.finish().await.unwrap();
+
+        let expected_metadata =
+            load_legacy_metadata(&meta_store, snapshot_info.hummock_version.clone())
+                .await
+                .unwrap();
+        assert!(!expected_metadata.objects.is_empty());
+        assert!(
+            expected_metadata
+                .hummock_sequences
+                .iter()
+                .any(|seq| seq.name == "streaming_snapshot_export_test" && seq.seq == 123)
+        );
+
+        let expected = MetaSnapshotV2 {
+            format_version: VERSION,
+            id: snapshot_id,
+            metadata: expected_metadata,
+        };
+        let uploaded: MetaSnapshotV2 = store.get(snapshot_id).await.unwrap();
+        assert_eq!(uploaded.encode().unwrap(), expected.encode().unwrap());
     }
 }

--- a/src/meta/src/backup_restore/restore.rs
+++ b/src/meta/src/backup_restore/restore.rs
@@ -19,7 +19,6 @@ use anyhow::anyhow;
 use futures::TryStreamExt;
 use risingwave_backup::MetaSnapshotId;
 use risingwave_backup::error::{BackupError, BackupResult};
-use risingwave_backup::meta_snapshot::Metadata;
 use risingwave_backup::storage::{MetaSnapshotStorage, MetaSnapshotStorageRef};
 use risingwave_common::config::{MetaBackend, ObjectStoreConfig};
 use risingwave_hummock_sdk::version::HummockVersion;
@@ -31,8 +30,9 @@ use risingwave_object_store::object::object_metrics::ObjectStoreMetrics;
 use risingwave_pb::hummock::{PbHummockVersionCheckpoint, PbHummockVersionCheckpointEnvelope};
 use thiserror_ext::AsReport;
 
-use crate::backup_restore::restore_impl::v2::{LoaderV2, WriterModelV2ToMetaStoreV2};
-use crate::backup_restore::restore_impl::{Loader, Writer};
+use crate::backup_restore::restore_impl::v2::{
+    LoaderV2, RestoreOverwrite, WriterModelV2ToMetaStoreV2,
+};
 use crate::backup_restore::utils::{get_backup_store, get_meta_store};
 use crate::controller::SqlMetaStore;
 use crate::hummock::compress_payload;
@@ -202,11 +202,11 @@ async fn restore_impl(
     Ok(())
 }
 
-async fn dispatch<L: Loader<S>, W: Writer<S>, S: Metadata>(
+async fn dispatch(
     target_id: MetaSnapshotId,
     opts: &RestoreOpts,
-    loader: L,
-    writer: W,
+    loader: LoaderV2,
+    writer: WriterModelV2ToMetaStoreV2,
 ) -> BackupResult<()> {
     // Validate parameters.
     if opts.overwrite_hummock_storage_endpoint
@@ -217,7 +217,7 @@ async fn dispatch<L: Loader<S>, W: Writer<S>, S: Metadata>(
     }
 
     // Restore meta store.
-    let target_snapshot = loader.load(target_id).await?;
+    let mut target_snapshot = loader.load_spooled(target_id).await?;
     if !opts.overwrite_hummock_storage_endpoint {
         let storage_url = target_snapshot.metadata.storage_url()?;
         if storage_url != opts.hummock_storage_url {
@@ -241,18 +241,22 @@ async fn dispatch<L: Loader<S>, W: Writer<S>, S: Metadata>(
         tracing::info!("Complete dry run.");
         return Ok(());
     }
-    let hummock_version = target_snapshot.metadata.hummock_version_ref().clone();
-    writer.write(target_snapshot).await?;
-    if opts.overwrite_hummock_storage_endpoint {
-        writer
-            .overwrite(
-                &format!("hummock+{}", opts.hummock_storage_url),
-                &opts.hummock_storage_directory,
-                opts.overwrite_backup_storage_url.as_ref().unwrap(),
-                opts.overwrite_backup_storage_directory.as_ref().unwrap(),
-            )
-            .await?;
-    }
+    let hummock_version = target_snapshot.metadata.hummock_version.clone();
+    let new_storage_url;
+    let overwrite = if opts.overwrite_hummock_storage_endpoint {
+        new_storage_url = format!("hummock+{}", opts.hummock_storage_url);
+        Some(RestoreOverwrite {
+            new_storage_url: &new_storage_url,
+            new_storage_dir: &opts.hummock_storage_directory,
+            new_backup_url: opts.overwrite_backup_storage_url.as_ref().unwrap(),
+            new_backup_dir: opts.overwrite_backup_storage_directory.as_ref().unwrap(),
+        })
+    } else {
+        None
+    };
+    writer
+        .write_spooled(&mut target_snapshot.metadata, overwrite)
+        .await?;
 
     // Restore object store.
     restore_hummock_version(

--- a/src/meta/src/backup_restore/restore_impl/mod.rs
+++ b/src/meta/src/backup_restore/restore_impl/mod.rs
@@ -12,27 +12,4 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use risingwave_backup::MetaSnapshotId;
-use risingwave_backup::error::BackupResult;
-use risingwave_backup::meta_snapshot::{MetaSnapshot, Metadata};
-
 pub mod v2;
-
-/// `Loader` gets, validates and amends `MetaSnapshot`.
-#[async_trait::async_trait]
-pub trait Loader<S: Metadata> {
-    async fn load(&self, id: MetaSnapshotId) -> BackupResult<MetaSnapshot<S>>;
-}
-
-/// `Writer` writes `MetaSnapshot` to meta store.
-#[async_trait::async_trait]
-pub trait Writer<S: Metadata> {
-    async fn write(&self, s: MetaSnapshot<S>) -> BackupResult<()>;
-    async fn overwrite(
-        &self,
-        new_storage_url: &str,
-        new_storage_dir: &str,
-        new_backup_url: &str,
-        new_backup_dir: &str,
-    ) -> BackupResult<()>;
-}

--- a/src/meta/src/backup_restore/restore_impl/v2.rs
+++ b/src/meta/src/backup_restore/restore_impl/v2.rs
@@ -13,16 +13,27 @@
 // limitations under the License.
 
 use std::cmp;
+use std::io::{Read, Seek, SeekFrom, Write};
+use std::mem::size_of;
 
+use anyhow::anyhow;
 use itertools::Itertools;
 use risingwave_backup::MetaSnapshotId;
 use risingwave_backup::error::{BackupError, BackupResult};
-use risingwave_backup::meta_snapshot::MetaSnapshot;
-use risingwave_backup::meta_snapshot_v2::{MetaSnapshotV2, MetadataV2};
-use risingwave_backup::storage::{MetaSnapshotStorage, MetaSnapshotStorageRef};
-use sea_orm::{DbErr, EntityTrait};
+use risingwave_backup::meta_snapshot_v2::HUMMOCK_VERSION_ENCODING_INDEX;
+use risingwave_backup::storage::{
+    MetaSnapshotStorage, MetaSnapshotStorageRef, MetaSnapshotStreamingReader,
+};
+use risingwave_hummock_sdk::version::HummockVersion;
+use risingwave_pb::hummock::HummockVersion as PbHummockVersion;
+use sea_orm::sea_query::{Expr, Func};
+use sea_orm::{
+    ActiveModelTrait, DbErr, EntityTrait, IntoActiveModel, QuerySelect, TransactionTrait,
+};
+use serde::Serialize;
+use serde::de::DeserializeOwned;
+use tempfile::NamedTempFile;
 
-use crate::backup_restore::restore_impl::{Loader, Writer};
 use crate::controller::SqlMetaStore;
 
 pub struct LoaderV2 {
@@ -33,17 +44,18 @@ impl LoaderV2 {
     pub fn new(backup_store: MetaSnapshotStorageRef) -> Self {
         Self { backup_store }
     }
-}
 
-#[async_trait::async_trait]
-impl Loader<MetadataV2> for LoaderV2 {
-    async fn load(&self, target_id: MetaSnapshotId) -> BackupResult<MetaSnapshot<MetadataV2>> {
+    pub async fn load_spooled(
+        &self,
+        target_id: MetaSnapshotId,
+    ) -> BackupResult<SpooledMetaSnapshotV2> {
         let snapshot_list = &self.backup_store.manifest().await.snapshot_metadata;
-        let mut target_snapshot: MetaSnapshotV2 = self.backup_store.get(target_id).await?;
+        let mut target_snapshot =
+            SpooledMetaSnapshotV2::read_from(&self.backup_store, target_id).await?;
         tracing::debug!(
-            "snapshot {} before rewrite:\n{}",
-            target_id,
-            target_snapshot
+            snapshot_id = target_snapshot.id,
+            format_version = target_snapshot.format_version,
+            "loaded metadata snapshot into spooled rows"
         );
         let newest_id = snapshot_list
             .iter()
@@ -59,11 +71,18 @@ impl Loader<MetadataV2> for LoaderV2 {
 
         // validate and rewrite seq
         if newest_id > target_id {
-            let newest_snapshot: MetaSnapshotV2 = self.backup_store.get(newest_id).await?;
-            for seq in &target_snapshot.metadata.hummock_sequences {
-                let newest = newest_snapshot
-                    .metadata
-                    .hummock_sequences
+            let mut newest_snapshot =
+                SpooledMetaSnapshotV2::read_from(&self.backup_store, newest_id).await?;
+            let target_sequences = target_snapshot
+                .metadata
+                .hummock_sequences
+                .read_all::<risingwave_meta_model::hummock_sequence::Model>()?;
+            let newest_sequences = newest_snapshot
+                .metadata
+                .hummock_sequences
+                .read_all::<risingwave_meta_model::hummock_sequence::Model>()?;
+            for seq in &target_sequences {
+                let newest = newest_sequences
                     .iter()
                     .find(|s| s.name == seq.name)
                     .unwrap_or_else(|| {
@@ -74,16 +93,212 @@ impl Loader<MetadataV2> for LoaderV2 {
                     });
                 assert!(newest.seq >= seq.seq, "violate monotonicity requirement");
             }
-            target_snapshot.metadata.hummock_sequences = newest_snapshot.metadata.hummock_sequences;
+            target_snapshot.metadata.hummock_sequences = TableRows::from_models(newest_sequences)?;
             tracing::info!(
-                "snapshot {} is rewritten by snapshot {}:\n",
+                "snapshot {} is rewritten by snapshot {}",
                 target_id,
                 newest_id,
             );
-            tracing::debug!("{target_snapshot}");
         }
         Ok(target_snapshot)
     }
+}
+
+pub struct SpooledMetaSnapshotV2 {
+    pub format_version: u32,
+    pub id: MetaSnapshotId,
+    pub metadata: SpooledMetadataV2,
+}
+
+impl SpooledMetaSnapshotV2 {
+    async fn read_from(
+        backup_store: &MetaSnapshotStorageRef,
+        target_id: MetaSnapshotId,
+    ) -> BackupResult<Self> {
+        let mut reader = backup_store.begin_snapshot_read(target_id).await?;
+        let format_version = reader.read_u32_le().await?;
+        let id = reader.read_u64_le().await?;
+        if id != target_id {
+            return Err(BackupError::Decoding(
+                anyhow!("snapshot id mismatch: expected {}, got {}", target_id, id).into(),
+            ));
+        }
+        let metadata = SpooledMetadataV2::read_from(&mut reader).await?;
+        reader.finish().await?;
+        Ok(Self {
+            format_version,
+            id,
+            metadata,
+        })
+    }
+}
+
+pub struct TableRows {
+    file: NamedTempFile,
+    count: u32,
+}
+
+impl TableRows {
+    async fn read_from(reader: &mut MetaSnapshotStreamingReader) -> BackupResult<Self> {
+        let count = reader.read_u32_le().await?;
+        let mut rows = Self::empty(count)?;
+        for _ in 0..count {
+            let bytes = read_len_prefixed_json_bytes(reader).await?;
+            rows.write_row(&bytes)?;
+        }
+        rows.rewind()?;
+        Ok(rows)
+    }
+
+    fn from_models<T: Serialize>(models: Vec<T>) -> BackupResult<Self> {
+        let count = u32::try_from(models.len())
+            .map_err(|_| BackupError::Other(anyhow!("too many metadata rows").into()))?;
+        let mut rows = Self::empty(count)?;
+        for model in models {
+            let bytes = serde_json::to_vec(&model)?;
+            rows.write_row(&bytes)?;
+        }
+        rows.rewind()?;
+        Ok(rows)
+    }
+
+    fn empty(count: u32) -> BackupResult<Self> {
+        Ok(Self {
+            file: NamedTempFile::new().map_err(map_io_err)?,
+            count,
+        })
+    }
+
+    fn write_row(&mut self, bytes: &[u8]) -> BackupResult<()> {
+        let len = u64::try_from(bytes.len()).map_err(|_| {
+            BackupError::Other(anyhow!("cannot convert {} into u64", bytes.len()).into())
+        })?;
+        self.file
+            .as_file_mut()
+            .write_all(&len.to_le_bytes())
+            .map_err(map_io_err)?;
+        self.file
+            .as_file_mut()
+            .write_all(bytes)
+            .map_err(map_io_err)?;
+        Ok(())
+    }
+
+    fn rewind(&mut self) -> BackupResult<()> {
+        self.file
+            .as_file_mut()
+            .seek(SeekFrom::Start(0))
+            .map_err(map_io_err)?;
+        Ok(())
+    }
+
+    fn read_all<T: DeserializeOwned>(&mut self) -> BackupResult<Vec<T>> {
+        self.rewind()?;
+        let mut rows = Vec::with_capacity(self.count as usize);
+        for _ in 0..self.count {
+            rows.push(self.read_next()?);
+        }
+        Ok(rows)
+    }
+
+    fn read_next<T: DeserializeOwned>(&mut self) -> BackupResult<T> {
+        let mut len_bytes = [0; size_of::<u64>()];
+        self.file
+            .as_file_mut()
+            .read_exact(&mut len_bytes)
+            .map_err(map_io_err)?;
+        let len = usize::try_from(u64::from_le_bytes(len_bytes)).map_err(|_| {
+            BackupError::Other(anyhow!("cannot convert row length into usize").into())
+        })?;
+        let mut bytes = vec![0; len];
+        self.file
+            .as_file_mut()
+            .read_exact(&mut bytes)
+            .map_err(map_io_err)?;
+        Ok(serde_json::from_slice(&bytes)?)
+    }
+}
+
+macro_rules! define_spooled_metadata_v2 {
+    ($( {$name:ident, $mod_path:ident::$mod_name:ident} ),*) => {
+        pub struct SpooledMetadataV2 {
+            pub hummock_version: HummockVersion,
+            $(
+                pub $name: TableRows,
+            )*
+        }
+
+        impl SpooledMetadataV2 {
+            async fn read_from(reader: &mut MetaSnapshotStreamingReader) -> BackupResult<Self> {
+                let mut _idx = 0;
+                let mut hummock_version = None;
+                $(
+                    if _idx == HUMMOCK_VERSION_ENCODING_INDEX {
+                        hummock_version = Some(read_hummock_version(reader).await?);
+                    }
+                    let $name = TableRows::read_from(reader).await?;
+                    _idx += 1;
+                )*
+                Ok(Self {
+                    hummock_version: hummock_version
+                        .ok_or_else(|| BackupError::Decoding(anyhow!("missing hummock version").into()))?,
+                    $(
+                        $name,
+                    )*
+                })
+            }
+
+            pub fn storage_url(&mut self) -> BackupResult<String> {
+                storage_url_from_system_parameters(
+                    &self.system_parameters.read_all::<risingwave_meta_model::system_parameter::Model>()?,
+                )
+            }
+
+            pub fn storage_directory(&mut self) -> BackupResult<String> {
+                storage_directory_from_system_parameters(
+                    &self.system_parameters.read_all::<risingwave_meta_model::system_parameter::Model>()?,
+                )
+            }
+        }
+    };
+}
+
+risingwave_backup::for_all_metadata_models_v2!(define_spooled_metadata_v2);
+
+async fn read_hummock_version(
+    reader: &mut MetaSnapshotStreamingReader,
+) -> BackupResult<HummockVersion> {
+    let pb: PbHummockVersion = read_1_json(reader).await?;
+    Ok(HummockVersion::from_persisted_protobuf_owned(pb))
+}
+
+async fn read_1_json<T: DeserializeOwned>(
+    reader: &mut MetaSnapshotStreamingReader,
+) -> BackupResult<T> {
+    let count = reader.read_u32_le().await?;
+    if count != 1 {
+        return Err(BackupError::Decoding(
+            anyhow!("expected exactly one row, got {}", count).into(),
+        ));
+    }
+    let bytes = read_len_prefixed_json_bytes(reader).await?;
+    Ok(serde_json::from_slice(&bytes)?)
+}
+
+async fn read_len_prefixed_json_bytes(
+    reader: &mut MetaSnapshotStreamingReader,
+) -> BackupResult<Vec<u8>> {
+    let len = match reader.read_u32_le().await? {
+        0 => usize::try_from(reader.read_u64_le().await?).map_err(|_| {
+            BackupError::Other(anyhow!("cannot convert row length into usize").into())
+        })?,
+        len => len as usize,
+    };
+    Ok(reader.read_bytes(len).await?.to_vec())
+}
+
+fn map_io_err(e: std::io::Error) -> BackupError {
+    BackupError::Other(e.into())
 }
 
 pub struct WriterModelV2ToMetaStoreV2 {
@@ -94,114 +309,287 @@ impl WriterModelV2ToMetaStoreV2 {
     pub fn new(meta_store: SqlMetaStore) -> Self {
         Self { meta_store }
     }
-}
 
-#[async_trait::async_trait]
-impl Writer<MetadataV2> for WriterModelV2ToMetaStoreV2 {
-    async fn write(&self, target_snapshot: MetaSnapshot<MetadataV2>) -> BackupResult<()> {
-        let metadata = target_snapshot.metadata;
-        let db = &self.meta_store.conn;
-        ensure_all_meta_store_tables_are_empty(db).await?;
-        insert_models(metadata.seaql_migrations.clone(), db).await?;
-        insert_models(metadata.clusters.clone(), db).await?;
-        insert_models(metadata.version_stats.clone(), db).await?;
-        insert_models(metadata.compaction_configs.clone(), db).await?;
-        insert_models(metadata.hummock_sequences.clone(), db).await?;
-        insert_models(metadata.workers.clone(), db).await?;
-        insert_models(metadata.worker_properties.clone(), db).await?;
-        insert_models(metadata.users.clone(), db).await?;
-        // The sort is required to pass table's foreign key check.
-        use risingwave_meta_model::object::ObjectType;
-        insert_models(
-            metadata
-                .objects
-                .iter()
-                .sorted_by(|a, b| match (a.obj_type, b.obj_type) {
-                    (ObjectType::Database, ObjectType::Database) => a.oid.cmp(&b.oid),
-                    (ObjectType::Database, _) => cmp::Ordering::Less,
-                    (_, ObjectType::Database) => cmp::Ordering::Greater,
-                    (ObjectType::Schema, ObjectType::Schema) => a.oid.cmp(&b.oid),
-                    (ObjectType::Schema, _) => cmp::Ordering::Less,
-                    (_, ObjectType::Schema) => cmp::Ordering::Greater,
-                    (_, _) => a.oid.cmp(&b.oid),
-                })
-                .cloned(),
-            db,
-        )
-        .await?;
-        insert_models(
-            metadata
-                .user_privileges
-                .iter()
-                .sorted_by_key(|u| u.id)
-                .cloned(),
-            db,
-        )
-        .await?;
-        insert_models(metadata.object_dependencies.clone(), db).await?;
-        insert_models(metadata.databases.clone(), db).await?;
-        insert_models(metadata.schemas.clone(), db).await?;
-        insert_models(metadata.streaming_jobs.clone(), db).await?;
-        insert_models(metadata.fragments.clone(), db).await?;
-        insert_models(metadata.fragment_relation.clone(), db).await?;
-        insert_models(metadata.connections.clone(), db).await?;
-        insert_models(metadata.sources.clone(), db).await?;
-        insert_models(metadata.tables.clone(), db).await?;
-        insert_models(metadata.sinks.clone(), db).await?;
-        insert_models(metadata.views.clone(), db).await?;
-        insert_models(metadata.indexes.clone(), db).await?;
-        insert_models(metadata.functions.clone(), db).await?;
-        insert_models(metadata.system_parameters.clone(), db).await?;
-        insert_models(metadata.catalog_versions.clone(), db).await?;
-        insert_models(metadata.subscriptions.clone(), db).await?;
-        insert_models(metadata.session_parameters.clone(), db).await?;
-        insert_models(metadata.secrets.clone(), db).await?;
-        insert_models(metadata.exactly_once_iceberg_sinks.clone(), db).await?;
-        insert_models(metadata.iceberg_tables.clone(), db).await?;
-        insert_models(metadata.iceberg_namespace_properties.clone(), db).await?;
-        insert_models(metadata.user_default_privilege.clone(), db).await?;
-        insert_models(metadata.fragment_splits.clone(), db).await?;
-        insert_models(metadata.pending_sink_state.clone(), db).await?;
-        insert_models(metadata.refresh_jobs.clone(), db).await?;
-        insert_models(metadata.cdc_table_snapshot_splits.clone(), db).await?;
-        insert_models(metadata.hummock_table_change_logs.clone(), db).await?;
-        // update_auto_inc must be called last.
-        update_auto_inc(&metadata, db).await?;
+    pub async fn write_spooled(
+        &self,
+        metadata: &mut SpooledMetadataV2,
+        overwrite: Option<RestoreOverwrite<'_>>,
+    ) -> BackupResult<()> {
+        let txn = self.meta_store.conn.begin().await.map_err(map_db_err)?;
+        ensure_all_meta_store_tables_are_empty(&txn).await?;
+        insert_spooled_metadata(metadata, &txn).await?;
+        if let Some(overwrite) = overwrite {
+            overwrite_system_parameters(
+                &txn,
+                overwrite.new_storage_url,
+                overwrite.new_storage_dir,
+                overwrite.new_backup_url,
+                overwrite.new_backup_dir,
+            )
+            .await?;
+        }
+        txn.commit().await.map_err(map_db_err)?;
+        // MySQL `ALTER TABLE ... AUTO_INCREMENT` implicitly commits, so keep sequence repair
+        // outside the restore transaction. Failures here leave a complete restored metadata set,
+        // not a partially committed restore.
+        update_auto_inc_from_db(&self.meta_store.conn).await?;
         Ok(())
     }
+}
 
-    async fn overwrite(
-        &self,
-        new_storage_url: &str,
-        new_storage_dir: &str,
-        new_backup_url: &str,
-        new_backup_dir: &str,
-    ) -> BackupResult<()> {
-        let kvs = [
+pub struct RestoreOverwrite<'a> {
+    pub new_storage_url: &'a str,
+    pub new_storage_dir: &'a str,
+    pub new_backup_url: &'a str,
+    pub new_backup_dir: &'a str,
+}
+
+fn compare_object_restore_order(
+    a: &risingwave_meta_model::object::Model,
+    b: &risingwave_meta_model::object::Model,
+) -> cmp::Ordering {
+    use risingwave_meta_model::object::ObjectType;
+    match (a.obj_type, b.obj_type) {
+        (ObjectType::Database, ObjectType::Database) => a.oid.cmp(&b.oid),
+        (ObjectType::Database, _) => cmp::Ordering::Less,
+        (_, ObjectType::Database) => cmp::Ordering::Greater,
+        (ObjectType::Schema, ObjectType::Schema) => a.oid.cmp(&b.oid),
+        (ObjectType::Schema, _) => cmp::Ordering::Less,
+        (_, ObjectType::Schema) => cmp::Ordering::Greater,
+        (_, _) => a.oid.cmp(&b.oid),
+    }
+}
+
+async fn insert_spooled_metadata(
+    metadata: &mut SpooledMetadataV2,
+    db: &impl sea_orm::ConnectionTrait,
+) -> BackupResult<()> {
+    insert_spooled_models::<risingwave_meta_model::serde_seaql_migration::Entity>(
+        &mut metadata.seaql_migrations,
+        db,
+    )
+    .await?;
+    insert_spooled_models::<risingwave_meta_model::cluster::Entity>(&mut metadata.clusters, db)
+        .await?;
+    insert_spooled_models::<risingwave_meta_model::hummock_version_stats::Entity>(
+        &mut metadata.version_stats,
+        db,
+    )
+    .await?;
+    insert_spooled_models::<risingwave_meta_model::compaction_config::Entity>(
+        &mut metadata.compaction_configs,
+        db,
+    )
+    .await?;
+    insert_spooled_models::<risingwave_meta_model::hummock_sequence::Entity>(
+        &mut metadata.hummock_sequences,
+        db,
+    )
+    .await?;
+    insert_spooled_models::<risingwave_meta_model::worker::Entity>(&mut metadata.workers, db)
+        .await?;
+    insert_spooled_models::<risingwave_meta_model::worker_property::Entity>(
+        &mut metadata.worker_properties,
+        db,
+    )
+    .await?;
+    insert_spooled_models::<risingwave_meta_model::user::Entity>(&mut metadata.users, db).await?;
+
+    let mut objects = metadata
+        .objects
+        .read_all::<risingwave_meta_model::object::Model>()?;
+    objects.sort_by(compare_object_restore_order);
+    insert_models(objects, db).await?;
+
+    let mut user_privileges = metadata
+        .user_privileges
+        .read_all::<risingwave_meta_model::user_privilege::Model>()?;
+    user_privileges.sort_by_key(|u| u.id);
+    insert_models(user_privileges, db).await?;
+
+    insert_spooled_models::<risingwave_meta_model::object_dependency::Entity>(
+        &mut metadata.object_dependencies,
+        db,
+    )
+    .await?;
+    insert_spooled_models::<risingwave_meta_model::database::Entity>(&mut metadata.databases, db)
+        .await?;
+    insert_spooled_models::<risingwave_meta_model::schema::Entity>(&mut metadata.schemas, db)
+        .await?;
+    insert_spooled_models::<risingwave_meta_model::streaming_job::Entity>(
+        &mut metadata.streaming_jobs,
+        db,
+    )
+    .await?;
+    insert_spooled_models::<risingwave_meta_model::fragment::Entity>(&mut metadata.fragments, db)
+        .await?;
+    insert_spooled_models::<risingwave_meta_model::fragment_relation::Entity>(
+        &mut metadata.fragment_relation,
+        db,
+    )
+    .await?;
+    insert_spooled_models::<risingwave_meta_model::connection::Entity>(
+        &mut metadata.connections,
+        db,
+    )
+    .await?;
+    insert_spooled_models::<risingwave_meta_model::source::Entity>(&mut metadata.sources, db)
+        .await?;
+    insert_spooled_models::<risingwave_meta_model::table::Entity>(&mut metadata.tables, db).await?;
+    insert_spooled_models::<risingwave_meta_model::sink::Entity>(&mut metadata.sinks, db).await?;
+    insert_spooled_models::<risingwave_meta_model::view::Entity>(&mut metadata.views, db).await?;
+    insert_spooled_models::<risingwave_meta_model::index::Entity>(&mut metadata.indexes, db)
+        .await?;
+    insert_spooled_models::<risingwave_meta_model::function::Entity>(&mut metadata.functions, db)
+        .await?;
+    insert_spooled_models::<risingwave_meta_model::system_parameter::Entity>(
+        &mut metadata.system_parameters,
+        db,
+    )
+    .await?;
+    insert_spooled_models::<risingwave_meta_model::catalog_version::Entity>(
+        &mut metadata.catalog_versions,
+        db,
+    )
+    .await?;
+    insert_spooled_models::<risingwave_meta_model::subscription::Entity>(
+        &mut metadata.subscriptions,
+        db,
+    )
+    .await?;
+    insert_spooled_models::<risingwave_meta_model::session_parameter::Entity>(
+        &mut metadata.session_parameters,
+        db,
+    )
+    .await?;
+    insert_spooled_models::<risingwave_meta_model::secret::Entity>(&mut metadata.secrets, db)
+        .await?;
+    insert_spooled_models::<risingwave_meta_model::exactly_once_iceberg_sink::Entity>(
+        &mut metadata.exactly_once_iceberg_sinks,
+        db,
+    )
+    .await?;
+    insert_spooled_models::<risingwave_meta_model::iceberg_tables::Entity>(
+        &mut metadata.iceberg_tables,
+        db,
+    )
+    .await?;
+    insert_spooled_models::<risingwave_meta_model::iceberg_namespace_properties::Entity>(
+        &mut metadata.iceberg_namespace_properties,
+        db,
+    )
+    .await?;
+    insert_spooled_models::<risingwave_meta_model::user_default_privilege::Entity>(
+        &mut metadata.user_default_privilege,
+        db,
+    )
+    .await?;
+    insert_spooled_models::<risingwave_meta_model::fragment_splits::Entity>(
+        &mut metadata.fragment_splits,
+        db,
+    )
+    .await?;
+    insert_spooled_models::<risingwave_meta_model::pending_sink_state::Entity>(
+        &mut metadata.pending_sink_state,
+        db,
+    )
+    .await?;
+    insert_spooled_models::<risingwave_meta_model::refresh_job::Entity>(
+        &mut metadata.refresh_jobs,
+        db,
+    )
+    .await?;
+    insert_spooled_models::<risingwave_meta_model::cdc_table_snapshot_split::Entity>(
+        &mut metadata.cdc_table_snapshot_splits,
+        db,
+    )
+    .await?;
+    insert_spooled_models::<risingwave_meta_model::hummock_table_change_log::Entity>(
+        &mut metadata.hummock_table_change_logs,
+        db,
+    )
+    .await?;
+    Ok(())
+}
+
+async fn overwrite_system_parameters(
+    db: &impl sea_orm::ConnectionTrait,
+    new_storage_url: &str,
+    new_storage_dir: &str,
+    new_backup_url: &str,
+    new_backup_dir: &str,
+) -> BackupResult<()> {
+    overwrite_system_parameter_values(
+        db,
+        [
             ("state_store", new_storage_url),
             ("data_directory", new_storage_dir),
             ("backup_storage_url", new_backup_url),
             ("backup_storage_directory", new_backup_dir),
-        ];
-        for (k, v) in kvs {
-            let Some(model) = risingwave_meta_model::system_parameter::Entity::find_by_id(k)
-                .one(&self.meta_store.conn)
-                .await
-                .map_err(map_db_err)?
-            else {
-                return Err(BackupError::MetaStorage(
-                    anyhow::anyhow!("{k} not found in system_parameter table").into(),
-                ));
-            };
-            let mut kv: risingwave_meta_model::system_parameter::ActiveModel = model.into();
-            kv.value = sea_orm::ActiveValue::Set(v.to_owned());
-            risingwave_meta_model::system_parameter::Entity::update(kv)
-                .exec(&self.meta_store.conn)
-                .await
-                .map_err(map_db_err)?;
-        }
-        Ok(())
+        ],
+    )
+    .await
+}
+
+async fn overwrite_system_parameter_values<'a>(
+    db: &impl sea_orm::ConnectionTrait,
+    kvs: impl IntoIterator<Item = (&'a str, &'a str)>,
+) -> BackupResult<()> {
+    for (k, v) in kvs {
+        let Some(model) = risingwave_meta_model::system_parameter::Entity::find_by_id(k)
+            .one(db)
+            .await
+            .map_err(map_db_err)?
+        else {
+            return Err(BackupError::MetaStorage(
+                anyhow!("{k} not found in system_parameter table").into(),
+            ));
+        };
+        let mut kv: risingwave_meta_model::system_parameter::ActiveModel = model.into();
+        kv.value = sea_orm::ActiveValue::Set(v.to_owned());
+        risingwave_meta_model::system_parameter::Entity::update(kv)
+            .exec(db)
+            .await
+            .map_err(map_db_err)?;
     }
+    Ok(())
+}
+
+fn storage_url_from_system_parameters(
+    system_parameters: &[risingwave_meta_model::system_parameter::Model],
+) -> BackupResult<String> {
+    let storage_url_from_snapshot =
+        Itertools::exactly_one(system_parameters.iter().filter_map(|m| {
+            if m.name == "state_store" {
+                return Some(m.value.clone());
+            }
+            None
+        }))
+        .map_err(|_| BackupError::Other(anyhow!("expect state_store")))?;
+    storage_url_from_snapshot
+        .strip_prefix("hummock+")
+        .map(|s| s.to_owned())
+        .ok_or_else(|| {
+            BackupError::Other(
+                anyhow!(
+                    "invalid state_store from metadata snapshot: {}",
+                    storage_url_from_snapshot
+                )
+                .into(),
+            )
+        })
+}
+
+fn storage_directory_from_system_parameters(
+    system_parameters: &[risingwave_meta_model::system_parameter::Model],
+) -> BackupResult<String> {
+    Itertools::exactly_one(system_parameters.iter().filter_map(|m| {
+        if m.name == "data_directory" {
+            return Some(m.value.clone());
+        }
+        None
+    }))
+    .map_err(|_| BackupError::Other(anyhow!("expect data_directory")))
 }
 
 async fn ensure_all_meta_store_tables_are_empty(
@@ -230,33 +618,30 @@ fn map_db_err(e: DbErr) -> BackupError {
     BackupError::MetaStorage(e.into())
 }
 
-#[macro_export]
-macro_rules! for_all_auto_increment {
-    ($metadata:ident, $db:ident, $macro:ident) => {
-        $macro! ($metadata, $db,
-            {"worker", workers, worker_id},
-            {"object", objects, oid},
-            {"user", users, user_id},
-            {"user_privilege", user_privileges, id},
-            {"fragment", fragments, fragment_id},
-            {"object_dependency", object_dependencies, id}
-        )
-    };
-}
-
-macro_rules! reset_sql_sequence {
-    ($metadata:ident, $db:ident, $( {$table:expr, $model:ident, $id_field:ident} ),*) => {
+macro_rules! reset_sql_sequence_from_db {
+    ($db:ident, $( {$table:expr, $entity_mod:ident, $id_field:ident, $column:ident} ),*) => {
         $(
         match $db.get_database_backend() {
             sea_orm::DbBackend::MySql => {
-                if let Some(v) = $metadata.$model.iter().map(|w| w.$id_field + 1).max() {
-                    $db.execute(sea_orm::Statement::from_string(
-                        sea_orm::DatabaseBackend::MySql,
-                        format!("ALTER TABLE {} AUTO_INCREMENT = {};", $table, v),
+                let next_value: i32 = risingwave_meta_model::$entity_mod::Entity::find()
+                    .select_only()
+                    .expr(Func::if_null(
+                        Expr::col(risingwave_meta_model::$entity_mod::Column::$column)
+                            .max()
+                            .add(1),
+                        1,
                     ))
+                    .into_tuple()
+                    .one($db)
                     .await
-                    .map_err(map_db_err)?;
-                }
+                    .map_err(map_db_err)?
+                    .unwrap_or_default();
+                $db.execute(sea_orm::Statement::from_string(
+                    sea_orm::DatabaseBackend::MySql,
+                    format!("ALTER TABLE {} AUTO_INCREMENT = {};", $table, next_value),
+                ))
+                .await
+                .map_err(map_db_err)?;
             }
             sea_orm::DbBackend::Postgres => {
                 $db.execute(sea_orm::Statement::from_string(
@@ -272,12 +657,41 @@ macro_rules! reset_sql_sequence {
     };
 }
 
-/// Fixes `auto_increment` fields.
-async fn update_auto_inc(
-    metadata: &MetadataV2,
+async fn update_auto_inc_from_db(db: &impl sea_orm::ConnectionTrait) -> BackupResult<()> {
+    reset_sql_sequence_from_db!(
+        db,
+        {"worker", worker, worker_id, WorkerId},
+        {"object", object, oid, Oid},
+        {"user", user, user_id, UserId},
+        {"user_privilege", user_privilege, id, Id},
+        {"fragment", fragment, fragment_id, FragmentId},
+        {"object_dependency", object_dependency, id, Id}
+    );
+    Ok(())
+}
+
+async fn insert_spooled_models<E>(
+    rows: &mut TableRows,
     db: &impl sea_orm::ConnectionTrait,
-) -> BackupResult<()> {
-    for_all_auto_increment!(metadata, db, reset_sql_sequence);
+) -> BackupResult<()>
+where
+    E: sea_orm::EntityTrait,
+    E::Model: DeserializeOwned + Sync + Send + Sized + sea_orm::IntoActiveModel<E::ActiveModel>,
+    E::ActiveModel:
+        sea_orm::ActiveModelTrait<Entity = E> + sea_orm::ActiveModelBehavior + Send + Sync,
+{
+    if E::find().one(db).await.map_err(map_db_err)?.is_some() {
+        return Err(BackupError::NonemptyMetaStorage);
+    }
+    rows.rewind()?;
+    for _ in 0..rows.count {
+        let model: E::Model = rows.read_next()?;
+        model
+            .into_active_model()
+            .insert(db)
+            .await
+            .map_err(map_db_err)?;
+    }
     Ok(())
 }
 
@@ -291,7 +705,6 @@ where
     <<A as sea_orm::ActiveModelTrait>::Entity as sea_orm::EntityTrait>::Model:
         sea_orm::IntoActiveModel<A>,
 {
-    use sea_orm::EntityTrait;
     if <S as sea_orm::ModelTrait>::Entity::find()
         .one(db)
         .await
@@ -304,4 +717,43 @@ where
         m.into_active_model().insert(db).await.map_err(map_db_err)?;
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use risingwave_backup::meta_snapshot_v2::{MetaSnapshotV2, MetadataV2};
+    use risingwave_backup::storage::{MetaSnapshotStorage, unused};
+
+    use super::*;
+
+    #[tokio::test]
+    async fn test_spooled_snapshot_reader_matches_legacy_snapshot() {
+        let store = Arc::new(unused().await);
+        let snapshot = MetaSnapshotV2 {
+            format_version: 2,
+            id: 44,
+            metadata: MetadataV2::default(),
+        };
+        store.create(&snapshot, None).await.unwrap();
+
+        let mut spooled = SpooledMetaSnapshotV2::read_from(&store, snapshot.id)
+            .await
+            .unwrap();
+        assert_eq!(spooled.format_version, snapshot.format_version);
+        assert_eq!(spooled.id, snapshot.id);
+        assert_eq!(
+            spooled.metadata.hummock_version.id,
+            snapshot.metadata.hummock_version.id
+        );
+        assert!(
+            spooled
+                .metadata
+                .seaql_migrations
+                .read_all::<risingwave_meta_model::serde_seaql_migration::Model>()
+                .unwrap()
+                .is_empty()
+        );
+    }
 }

--- a/src/meta/src/backup_restore/restore_impl/v2.rs
+++ b/src/meta/src/backup_restore/restore_impl/v2.rs
@@ -152,7 +152,7 @@ impl TableRows {
 
     fn from_models<T: Serialize>(models: Vec<T>) -> BackupResult<Self> {
         let count = u32::try_from(models.len())
-            .map_err(|_| BackupError::Other(anyhow!("too many metadata rows").into()))?;
+            .map_err(|_| BackupError::Other(anyhow!("too many metadata rows")))?;
         let mut rows = Self::empty(count)?;
         for model in models {
             let bytes = serde_json::to_vec(&model)?;
@@ -170,9 +170,8 @@ impl TableRows {
     }
 
     fn write_row(&mut self, bytes: &[u8]) -> BackupResult<()> {
-        let len = u64::try_from(bytes.len()).map_err(|_| {
-            BackupError::Other(anyhow!("cannot convert {} into u64", bytes.len()).into())
-        })?;
+        let len = u64::try_from(bytes.len())
+            .map_err(|_| BackupError::Other(anyhow!("cannot convert {} into u64", bytes.len())))?;
         self.file
             .as_file_mut()
             .write_all(&len.to_le_bytes())
@@ -207,9 +206,8 @@ impl TableRows {
             .as_file_mut()
             .read_exact(&mut len_bytes)
             .map_err(map_io_err)?;
-        let len = usize::try_from(u64::from_le_bytes(len_bytes)).map_err(|_| {
-            BackupError::Other(anyhow!("cannot convert row length into usize").into())
-        })?;
+        let len = usize::try_from(u64::from_le_bytes(len_bytes))
+            .map_err(|_| BackupError::Other(anyhow!("cannot convert row length into usize")))?;
         let mut bytes = vec![0; len];
         self.file
             .as_file_mut()
@@ -289,9 +287,8 @@ async fn read_len_prefixed_json_bytes(
     reader: &mut MetaSnapshotStreamingReader,
 ) -> BackupResult<Vec<u8>> {
     let len = match reader.read_u32_le().await? {
-        0 => usize::try_from(reader.read_u64_le().await?).map_err(|_| {
-            BackupError::Other(anyhow!("cannot convert row length into usize").into())
-        })?,
+        0 => usize::try_from(reader.read_u64_le().await?)
+            .map_err(|_| BackupError::Other(anyhow!("cannot convert row length into usize")))?,
         len => len as usize,
     };
     Ok(reader.read_bytes(len).await?.to_vec())
@@ -570,13 +567,10 @@ fn storage_url_from_system_parameters(
         .strip_prefix("hummock+")
         .map(|s| s.to_owned())
         .ok_or_else(|| {
-            BackupError::Other(
-                anyhow!(
-                    "invalid state_store from metadata snapshot: {}",
-                    storage_url_from_snapshot
-                )
-                .into(),
-            )
+            BackupError::Other(anyhow!(
+                "invalid state_store from metadata snapshot: {}",
+                storage_url_from_snapshot
+            ))
         })
 }
 

--- a/src/meta/src/lib.rs
+++ b/src/meta/src/lib.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #![allow(clippy::derive_partial_eq_without_eq)]
+#![recursion_limit = "256"]
 #![feature(trait_alias)]
 #![feature(type_alias_impl_trait)]
 #![feature(map_try_insert)]

--- a/src/storage/backup/src/meta_snapshot_v2.rs
+++ b/src/storage/backup/src/meta_snapshot_v2.rs
@@ -79,6 +79,9 @@ macro_rules! for_all_metadata_models_v2 {
     };
 }
 
+/// Legacy v2 snapshot layout stores the singleton Hummock version after the first metadata table.
+pub const HUMMOCK_VERSION_ENCODING_INDEX: usize = 1;
+
 macro_rules! define_metadata_v2 {
     ($({ $name:ident, $mod_path:ident::$mod_name:ident }),*) => {
         #[derive(Default)]
@@ -101,7 +104,7 @@ macro_rules! define_encode_metadata {
         ) -> BackupResult<()> {
             let mut _idx = 0;
             $(
-                if _idx == 1 {
+                if _idx == HUMMOCK_VERSION_ENCODING_INDEX {
                     put_1(buf, &metadata.hummock_version.to_protobuf())?;
                 }
                 put_n(buf, &metadata.$name)?;
@@ -122,7 +125,7 @@ macro_rules! define_decode_metadata {
         ) -> BackupResult<()> {
             let mut _idx = 0;
             $(
-                if _idx == 1 {
+                if _idx == HUMMOCK_VERSION_ENCODING_INDEX {
                     metadata.hummock_version = HummockVersion::from_persisted_protobuf_owned(get_1(&mut buf)?);
                 }
                 metadata.$name = get_n(&mut buf)?;

--- a/src/storage/backup/src/storage.rs
+++ b/src/storage/backup/src/storage.rs
@@ -13,13 +13,20 @@
 // limitations under the License.
 
 use std::collections::HashSet;
+use std::hash::Hasher;
+use std::mem::size_of;
 use std::sync::Arc;
 
+use anyhow::anyhow;
+use bytes::{Buf, BufMut, Bytes, BytesMut};
 use itertools::Itertools;
 use risingwave_common::config::ObjectStoreConfig;
+use risingwave_hummock_sdk::HummockRawObjectId;
+use risingwave_hummock_sdk::version::HummockVersion;
 use risingwave_object_store::object::object_metrics::ObjectStoreMetrics;
 use risingwave_object_store::object::{
-    InMemObjectStore, MonitoredObjectStore, ObjectError, ObjectStoreImpl, ObjectStoreRef,
+    InMemObjectStore, MonitoredObjectStore, MonitoredStreamingReader, ObjectError, ObjectStoreImpl,
+    ObjectStoreRef, ObjectStreamingUploader,
 };
 use tokio::sync::RwLock;
 
@@ -29,6 +36,122 @@ use crate::{
 };
 
 pub type MetaSnapshotStorageRef = Arc<ObjectStoreMetaSnapshotStorage>;
+
+pub struct MetaSnapshotStreamingUploader {
+    inner: ObjectStreamingUploader,
+    checksum: twox_hash::XxHash64,
+}
+
+pub struct MetaSnapshotStreamingReader {
+    inner: MonitoredStreamingReader,
+    buffered: BytesMut,
+    checksum: twox_hash::XxHash64,
+    expected_checksum: u64,
+}
+
+impl MetaSnapshotStreamingUploader {
+    fn new(inner: ObjectStreamingUploader) -> Self {
+        Self {
+            inner,
+            checksum: twox_hash::XxHash64::with_seed(0),
+        }
+    }
+
+    pub async fn write_bytes(&mut self, data: Bytes) -> BackupResult<()> {
+        self.checksum.write(&data);
+        self.inner.write_bytes(data).await?;
+        Ok(())
+    }
+
+    pub async fn write_u32_le(&mut self, value: u32) -> BackupResult<()> {
+        let mut buf = Vec::with_capacity(size_of::<u32>());
+        buf.put_u32_le(value);
+        self.write_bytes(buf.into()).await
+    }
+
+    pub async fn write_u64_le(&mut self, value: u64) -> BackupResult<()> {
+        let mut buf = Vec::with_capacity(size_of::<u64>());
+        buf.put_u64_le(value);
+        self.write_bytes(buf.into()).await
+    }
+
+    pub async fn finish(mut self) -> BackupResult<()> {
+        let checksum = self.checksum.finish();
+        let mut buf = Vec::with_capacity(size_of::<u64>());
+        buf.put_u64_le(checksum);
+        self.inner.write_bytes(buf.into()).await?;
+        self.inner.finish().await?;
+        Ok(())
+    }
+}
+
+impl MetaSnapshotStreamingReader {
+    fn new(inner: MonitoredStreamingReader, expected_checksum: u64) -> Self {
+        Self {
+            inner,
+            buffered: BytesMut::new(),
+            checksum: twox_hash::XxHash64::with_seed(0),
+            expected_checksum,
+        }
+    }
+
+    pub async fn read_bytes(&mut self, len: usize) -> BackupResult<Bytes> {
+        while self.buffered.len() < len {
+            let bytes = match self.inner.read_bytes().await {
+                Some(Ok(bytes)) => bytes,
+                Some(Err(e)) => return Err(e.into()),
+                None => {
+                    return Err(BackupError::Decoding(
+                        anyhow!(
+                            "unexpected end of metadata snapshot: need {} bytes, buffered {}",
+                            len,
+                            self.buffered.len()
+                        )
+                        .into(),
+                    ));
+                }
+            };
+            self.checksum.write(&bytes);
+            self.buffered.extend_from_slice(&bytes);
+        }
+        Ok(self.buffered.split_to(len).freeze())
+    }
+
+    pub async fn read_u32_le(&mut self) -> BackupResult<u32> {
+        Ok(self.read_bytes(size_of::<u32>()).await?.get_u32_le())
+    }
+
+    pub async fn read_u64_le(&mut self) -> BackupResult<u64> {
+        Ok(self.read_bytes(size_of::<u64>()).await?.get_u64_le())
+    }
+
+    pub async fn finish(mut self) -> BackupResult<()> {
+        if !self.buffered.is_empty() {
+            return Err(BackupError::Decoding(
+                anyhow!(
+                    "metadata snapshot has {} trailing bytes before checksum",
+                    self.buffered.len()
+                )
+                .into(),
+            ));
+        }
+
+        if self.inner.read_bytes().await.transpose()?.is_some() {
+            return Err(BackupError::Decoding(
+                anyhow!("metadata snapshot has trailing bytes before checksum").into(),
+            ));
+        }
+
+        let found = self.checksum.finish();
+        if found != self.expected_checksum {
+            return Err(BackupError::ChecksumMismatch {
+                expected: self.expected_checksum,
+                found,
+            });
+        }
+        Ok(())
+    }
+}
 
 #[async_trait::async_trait]
 pub trait MetaSnapshotStorage: 'static + Sync + Send {
@@ -119,6 +242,68 @@ impl ObjectStoreMetaSnapshotStorage {
             .parse::<MetaSnapshotId>()
             .expect("valid meta snapshot id")
     }
+
+    pub async fn begin_snapshot_upload(
+        &self,
+        id: MetaSnapshotId,
+        format_version: u32,
+    ) -> BackupResult<MetaSnapshotStreamingUploader> {
+        let path = self.get_snapshot_path(id);
+        let mut uploader =
+            MetaSnapshotStreamingUploader::new(self.store.streaming_upload(&path).await?);
+        uploader.write_u32_le(format_version).await?;
+        uploader.write_u64_le(id).await?;
+        Ok(uploader)
+    }
+
+    pub async fn begin_snapshot_read(
+        &self,
+        id: MetaSnapshotId,
+    ) -> BackupResult<MetaSnapshotStreamingReader> {
+        let path = self.get_snapshot_path(id);
+        let object_metadata = self.store.metadata(&path).await?;
+        if object_metadata.total_size < size_of::<u32>() + size_of::<u64>() + size_of::<u64>() {
+            return Err(BackupError::Decoding(
+                anyhow!(
+                    "metadata snapshot {} is too small: {} bytes",
+                    id,
+                    object_metadata.total_size
+                )
+                .into(),
+            ));
+        }
+
+        let checksum_offset = object_metadata.total_size - size_of::<u64>();
+        let mut checksum_bytes = self
+            .store
+            .read(&path, checksum_offset..object_metadata.total_size)
+            .await?;
+        let expected_checksum = checksum_bytes.get_u64_le();
+        let reader = self.store.streaming_read(&path, 0..checksum_offset).await?;
+        Ok(MetaSnapshotStreamingReader::new(reader, expected_checksum))
+    }
+
+    pub async fn commit_snapshot_metadata(
+        &self,
+        id: MetaSnapshotId,
+        hummock_version: &HummockVersion,
+        format_version: u32,
+        remarks: Option<String>,
+        table_change_log_object_ids: impl Iterator<Item = HummockRawObjectId>,
+    ) -> BackupResult<()> {
+        self.update_manifest(|mut manifest: MetaSnapshotManifest| {
+            manifest.manifest_id += 1;
+            manifest.snapshot_metadata.push(MetaSnapshotMetadata::new(
+                id,
+                hummock_version,
+                format_version,
+                remarks,
+                table_change_log_object_ids,
+            ));
+            manifest
+        })
+        .await
+    }
 }
 
 #[async_trait::async_trait]
@@ -202,4 +387,59 @@ pub async fn unused() -> ObjectStoreMetaSnapshotStorage {
     )
     .await
     .unwrap()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::meta_snapshot::Metadata;
+    use crate::meta_snapshot_v2::{MetaSnapshotV2, MetadataV2};
+
+    #[tokio::test]
+    async fn test_streaming_snapshot_upload_matches_legacy_encode() {
+        let store = unused().await;
+        let snapshot = MetaSnapshotV2 {
+            format_version: 2,
+            id: 42,
+            metadata: MetadataV2::default(),
+        };
+
+        let mut uploader = store
+            .begin_snapshot_upload(snapshot.id, snapshot.format_version)
+            .await
+            .unwrap();
+        let mut metadata = Vec::new();
+        snapshot.metadata.encode_to(&mut metadata).unwrap();
+        uploader.write_bytes(metadata.into()).await.unwrap();
+        uploader.finish().await.unwrap();
+
+        let uploaded = store
+            .store
+            .read(&store.get_snapshot_path(snapshot.id), ..)
+            .await
+            .unwrap();
+        assert_eq!(uploaded.as_ref(), snapshot.encode().unwrap().as_slice());
+    }
+
+    #[tokio::test]
+    async fn test_streaming_snapshot_read_matches_legacy_encode() {
+        let store = unused().await;
+        let snapshot = MetaSnapshotV2 {
+            format_version: 2,
+            id: 43,
+            metadata: MetadataV2::default(),
+        };
+        store.create(&snapshot, None).await.unwrap();
+
+        let encoded = snapshot.encode().unwrap();
+        let mut reader = store.begin_snapshot_read(snapshot.id).await.unwrap();
+        assert_eq!(reader.read_u32_le().await.unwrap(), snapshot.format_version);
+        assert_eq!(reader.read_u64_le().await.unwrap(), snapshot.id);
+        let metadata_len = encoded.len() - size_of::<u32>() - size_of::<u64>() - size_of::<u64>();
+        assert_eq!(
+            reader.read_bytes(metadata_len).await.unwrap().as_ref(),
+            &encoded[size_of::<u32>() + size_of::<u64>()..encoded.len() - size_of::<u64>()],
+        );
+        reader.finish().await.unwrap();
+    }
 }

--- a/src/storage/backup/tests/metadata_models_v2.rs
+++ b/src/storage/backup/tests/metadata_models_v2.rs
@@ -68,7 +68,7 @@ fn for_all_metadata_models_v2_should_cover_all_required_meta_model_tables() {
     //
     // - If yes:
     //   1. append it to `for_all_metadata_models_v2` in `src/storage/backup/src/meta_snapshot_v2.rs`.
-    //   2. add `insert_models` before `update_auto_inc` in `src/meta/src/backup_restore/restore_impl/v2.rs`.
+    //   2. add its spooled insert in `src/meta/src/backup_restore/restore_impl/v2.rs`.
     // - If no (runtime/derived table): add it to the `excluded` set below with a short comment.
 
     let meta_model_lib_rs = include_str!("../../../meta/model/src/lib.rs");


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

This PR reduces peak memory usage in metadata backup and restore by streaming metadata snapshot I/O instead of materializing the full snapshot payload in memory.

- Metadata backup now writes the v2 snapshot header/body/checksum through `ObjectStore::streaming_upload`, so S3-compatible stores can use multipart upload for large snapshots.
- Metadata table rows are exported table by table in a serializable read-only meta-store transaction. The on-disk v2 format is preserved: row counts, JSON length-prefix encoding, Hummock version placement, and trailing xxhash checksum stay byte-for-byte compatible with the legacy encoder.
- Metadata restore now reads snapshots through object-store streaming/range reads, verifies the trailing checksum before writing meta store data, spools row JSON to temporary files, and writes rows back in the existing FK-safe restore order.
- Restore writes are wrapped in a meta-store transaction, with auto-increment sequence repair performed after commit to avoid MySQL implicit-commit DDL breaking rollback semantics.
- Added compatibility tests for streaming snapshot upload/read and a non-empty sqlite meta-store export path, plus a guard that `for_all_metadata_models_v2` stays in sync with metadata model tables.


## Checklist

- [x] I have written necessary rustdoc comments.
- [x] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

Metadata backup and restore now stream metadata snapshot data to and from backup object storage, reducing peak meta-node memory usage for large metadata snapshots while keeping the snapshot format compatible with existing restore logic.

</details>

