### PR TITLE
test: add Kafka OIDC e2e coverage

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -110,7 +110,10 @@ labels:
 - label: "ci/run-e2e-kafka-source-tests"
   files:
   - "ci\\/scripts\\/e2e-source-kafka-test\\.sh"
+  - "ci\\/scripts\\/e2e-kafka-oidc-test\\.sh"
+  - "ci\\/kafka-oidc\\/.*"
   - "e2e_test\\/debug_mode_only\\/debug_splits\\.slt"
+  - "e2e_test\\/kafka-oidc\\/.*"
   - "e2e_test\\/kafka-sasl\\/.*"
   - "e2e_test\\/source_inline\\/connection\\/.*"
   - "e2e_test\\/source_inline\\/kafka\\/.*"
@@ -156,7 +159,10 @@ labels:
 # Split sink connector tests
 - label: "ci/run-e2e-kafka-sink-tests"
   files:
+  - "ci\\/scripts\\/e2e-kafka-oidc-test\\.sh"
   - "ci\\/scripts\\/e2e-kafka-sink-test\\.sh"
+  - "ci\\/kafka-oidc\\/.*"
+  - "e2e_test\\/kafka-oidc\\/.*"
   - "e2e_test\\/sink\\/bug_fixes\\/issue_24367\\.slt"
   - "e2e_test\\/sink\\/kafka\\/.*"
   - "src\\/connector\\/src\\/sink\\/kafka\\.rs"

--- a/ci/docker-compose.yml
+++ b/ci/docker-compose.yml
@@ -154,6 +154,47 @@ services:
       timeout: 5s
       retries: 5
 
+  keycloak_oidc:
+    image: quay.io/keycloak/keycloak:26.3.3
+    command:
+      - start-dev
+      - --import-realm
+      - --hostname=http://keycloak_oidc:8080
+      - --http-enabled=true
+    environment:
+      KC_BOOTSTRAP_ADMIN_USERNAME: admin
+      KC_BOOTSTRAP_ADMIN_PASSWORD: admin
+      KC_HEALTH_ENABLED: "true"
+    expose:
+      - "8080"
+    volumes:
+      - ./kafka-oidc/keycloak/realms:/opt/keycloak/data/import:ro
+
+  message_queue_oidc:
+    image: quay.io/strimzi/kafka:0.47.0-kafka-4.0.0
+    depends_on:
+      - keycloak_oidc
+    entrypoint:
+      - /bin/bash
+      - /opt/kafka-oidc/start.sh
+    expose:
+      - "9091"
+      - "9092"
+    environment:
+      KEYCLOAK_HOST: keycloak_oidc
+      KEYCLOAK_URI: http://keycloak_oidc:8080
+      REALM: demo
+      LOG_DIR: /tmp/kafka-logs
+      KAFKA_LOG_DIRS: /tmp/kraft-combined-logs
+      OAUTH_CLIENT_ID: kafka-broker
+      OAUTH_CLIENT_SECRET: kafka-broker-secret
+      OAUTH_TOKEN_ENDPOINT_URI: http://keycloak_oidc:8080/realms/demo/protocol/openid-connect/token
+      OAUTH_VALID_ISSUER_URI: http://keycloak_oidc:8080/realms/demo
+      OAUTH_JWKS_ENDPOINT_URI: http://keycloak_oidc:8080/realms/demo/protocol/openid-connect/certs
+      OAUTH_USERNAME_CLAIM: preferred_username
+    volumes:
+      - ./kafka-oidc/kafka:/opt/kafka-oidc:ro
+
   rabbitmq-server:
     image: rabbitmq:3-management
     ports:
@@ -218,6 +259,15 @@ services:
       - vault-server
       - message_queue_sasl_1
       - message_queue_sasl_2
+    volumes:
+      - ..:/risingwave
+    stop_grace_period: 30s
+
+  kafka-oidc-test-env:
+    image: public.ecr.aws/w1p7b4n3/rw-build-env:${BUILD_ENV_VERSION:?}
+    depends_on:
+      - keycloak_oidc
+      - message_queue_oidc
     volumes:
       - ..:/risingwave
     stop_grace_period: 30s

--- a/ci/docker-compose.yml
+++ b/ci/docker-compose.yml
@@ -164,7 +164,6 @@ services:
     environment:
       KC_BOOTSTRAP_ADMIN_USERNAME: admin
       KC_BOOTSTRAP_ADMIN_PASSWORD: admin
-      KC_HEALTH_ENABLED: "true"
     expose:
       - "8080"
     volumes:

--- a/ci/kafka-oidc/kafka/functions.sh
+++ b/ci/kafka-oidc/kafka/functions.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+wait_for_url() {
+    local url="$1"
+    local message="$2"
+    local cmd
+
+    if [[ "$url" == https* ]]; then
+        cmd=(curl -k -sL -o /dev/null -w "%{http_code}" "$url")
+    else
+        cmd=(curl -sL -o /dev/null -w "%{http_code}" "$url")
+    fi
+
+    until [[ "$("${cmd[@]}")" == "200" ]]; do
+        echo "$message ($url)"
+        sleep 2
+    done
+}

--- a/ci/kafka-oidc/kafka/functions.sh
+++ b/ci/kafka-oidc/kafka/functions.sh
@@ -3,16 +3,26 @@
 wait_for_url() {
     local url="$1"
     local message="$2"
+    local max_attempts="${3:-60}"
+    local attempt
     local cmd
 
     if [[ "$url" == https* ]]; then
-        cmd=(curl -k -sL -o /dev/null -w "%{http_code}" "$url")
+        cmd=(curl -k -sL --max-time 2 -o /dev/null -w "%{http_code}" "$url")
     else
-        cmd=(curl -sL -o /dev/null -w "%{http_code}" "$url")
+        cmd=(curl -sL --max-time 2 -o /dev/null -w "%{http_code}" "$url")
     fi
 
-    until [[ "$("${cmd[@]}")" == "200" ]]; do
-        echo "$message ($url)"
-        sleep 2
+    for ((attempt = 1; attempt <= max_attempts; attempt++)); do
+        if [[ "$("${cmd[@]}")" == "200" ]]; then
+            return 0
+        fi
+        echo "$message ($url, attempt ${attempt}/${max_attempts})"
+        if ((attempt < max_attempts)); then
+            sleep 2
+        fi
     done
+
+    echo "Timed out: $message ($url)" 1>&2
+    return 1
 }

--- a/ci/kafka-oidc/kafka/start.sh
+++ b/ci/kafka-oidc/kafka/start.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${script_dir}/functions.sh"
+
+keycloak_uri="${KEYCLOAK_URI:-http://${KEYCLOAK_HOST:-keycloak_oidc}:8080}"
+realm="${REALM:-demo}"
+
+wait_for_url "${keycloak_uri}/realms/${realm}" "Waiting for realm '${realm}' to be available"
+
+cat > /tmp/strimzi.properties <<EOF
+process.roles=${KAFKA_PROCESS_ROLES:-broker,controller}
+node.id=${KAFKA_NODE_ID:-1}
+log.dirs=${KAFKA_LOG_DIRS:-/tmp/kraft-combined-logs}
+
+controller.quorum.voters=${KAFKA_CONTROLLER_QUORUM_VOTERS:-1@message_queue_oidc:9091}
+controller.listener.names=${KAFKA_CONTROLLER_LISTENER_NAMES:-CONTROLLER}
+listeners=${KAFKA_LISTENERS:-CONTROLLER://message_queue_oidc:9091,CLIENT://0.0.0.0:9092}
+advertised.listeners=${KAFKA_ADVERTISED_LISTENERS:-CLIENT://message_queue_oidc:9092}
+listener.security.protocol.map=${KAFKA_LISTENER_SECURITY_PROTOCOL_MAP:-CONTROLLER:SASL_PLAINTEXT,CLIENT:SASL_PLAINTEXT}
+
+num.network.threads=${KAFKA_NUM_NETWORK_THREADS:-3}
+num.io.threads=${KAFKA_NUM_IO_THREADS:-8}
+socket.send.buffer.bytes=${KAFKA_SOCKET_SEND_BUFFER_BYTES:-102400}
+socket.receive.buffer.bytes=${KAFKA_SOCKET_RECEIVE_BUFFER_BYTES:-102400}
+socket.request.max.bytes=${KAFKA_SOCKET_REQUEST_MAX_BYTES:-104857600}
+num.partitions=${KAFKA_NUM_PARTITIONS:-1}
+num.recovery.threads.per.data.dir=${KAFKA_NUM_RECOVERY_THREADS_PER_DATA_DIR:-1}
+offsets.topic.replication.factor=${KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR:-1}
+transaction.state.log.replication.factor=${KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR:-1}
+transaction.state.log.min.isr=${KAFKA_TRANSACTION_STATE_LOG_MIN_ISR:-1}
+log.retention.hours=${KAFKA_LOG_RETENTION_HOURS:-168}
+log.segment.bytes=${KAFKA_LOG_SEGMENT_BYTES:-1073741824}
+log.retention.check.interval.ms=${KAFKA_LOG_RETENTION_CHECK_INTERVAL_MS:-300000}
+
+sasl.enabled.mechanisms=${KAFKA_SASL_ENABLED_MECHANISMS:-OAUTHBEARER}
+inter.broker.listener.name=${KAFKA_INTER_BROKER_LISTENER_NAME:-CLIENT}
+sasl.mechanism.inter.broker.protocol=${KAFKA_SASL_MECHANISM_INTER_BROKER_PROTOCOL:-OAUTHBEARER}
+sasl.mechanism.controller.protocol=${KAFKA_SASL_MECHANISM_CONTROLLER_PROTOCOL:-SCRAM-SHA-512}
+listener.name.controller.sasl.enabled.mechanisms=${KAFKA_LISTENER_NAME_CONTROLLER_SASL_ENABLED_MECHANISMS:-SCRAM-SHA-512}
+listener.name.controller.scram-sha-512.sasl.jaas.config=${KAFKA_LISTENER_NAME_CONTROLLER_SCRAM_SHA_512_SASL_JAAS_CONFIG:-org.apache.kafka.common.security.scram.ScramLoginModule required username=\"admin\" password=\"admin-secret\" ;}
+listener.name.client.oauthbearer.sasl.jaas.config=${KAFKA_LISTENER_NAME_CLIENT_OAUTHBEARER_SASL_JAAS_CONFIG:-org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required;}
+listener.name.client.oauthbearer.sasl.login.callback.handler.class=${KAFKA_LISTENER_NAME_CLIENT_OAUTHBEARER_SASL_LOGIN_CALLBACK_HANDLER_CLASS:-io.strimzi.kafka.oauth.client.JaasClientOauthLoginCallbackHandler}
+listener.name.client.oauthbearer.sasl.server.callback.handler.class=${KAFKA_LISTENER_NAME_CLIENT_OAUTHBEARER_SASL_SERVER_CALLBACK_HANDLER_CLASS:-io.strimzi.kafka.oauth.server.JaasServerOauthValidatorCallbackHandler}
+super.users=${KAFKA_SUPER_USERS:-User:service-account-kafka-broker}
+EOF
+
+echo "Generated Kafka OIDC server properties:"
+cat /tmp/strimzi.properties
+
+kafka_cluster_id="$("/opt/kafka/bin/kafka-storage.sh" random-uuid)"
+"/opt/kafka/bin/kafka-storage.sh" format -t "${kafka_cluster_id}" -c /tmp/strimzi.properties \
+    --add-scram 'SCRAM-SHA-512=[name=admin,password=admin-secret]'
+
+exec /opt/kafka/bin/kafka-server-start.sh /tmp/strimzi.properties

--- a/ci/kafka-oidc/keycloak/realms/demo-realm.json
+++ b/ci/kafka-oidc/keycloak/realms/demo-realm.json
@@ -1,0 +1,39 @@
+{
+  "realm": "demo",
+  "enabled": true,
+  "clients": [
+    {
+      "clientId": "kafka-broker",
+      "enabled": true,
+      "protocol": "openid-connect",
+      "publicClient": false,
+      "standardFlowEnabled": false,
+      "directAccessGrantsEnabled": false,
+      "serviceAccountsEnabled": true,
+      "clientAuthenticatorType": "client-secret",
+      "secret": "kafka-broker-secret"
+    },
+    {
+      "clientId": "kafka-producer-client",
+      "enabled": true,
+      "protocol": "openid-connect",
+      "publicClient": false,
+      "standardFlowEnabled": false,
+      "directAccessGrantsEnabled": false,
+      "serviceAccountsEnabled": true,
+      "clientAuthenticatorType": "client-secret",
+      "secret": "kafka-producer-client-secret"
+    },
+    {
+      "clientId": "kafka-consumer-client",
+      "enabled": true,
+      "protocol": "openid-connect",
+      "publicClient": false,
+      "standardFlowEnabled": false,
+      "directAccessGrantsEnabled": false,
+      "serviceAccountsEnabled": true,
+      "clientAuthenticatorType": "client-secret",
+      "secret": "kafka-consumer-client-secret"
+    }
+  ]
+}

--- a/ci/scripts/e2e-kafka-oidc-test.sh
+++ b/ci/scripts/e2e-kafka-oidc-test.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+source ci/scripts/common.sh
+
+profile=""
+
+while getopts 'p:' opt; do
+    case ${opt} in
+        p )
+            profile=$OPTARG
+            ;;
+        \? )
+            echo "Invalid Option: -$OPTARG" 1>&2
+            exit 1
+            ;;
+        : )
+            echo "Invalid option: $OPTARG requires an argument" 1>&2
+            exit 1
+            ;;
+    esac
+done
+shift $((OPTIND - 1))
+
+if [[ -z "${profile}" ]]; then
+    echo "profile is required: -p ci-dev|ci-release" 1>&2
+    exit 1
+fi
+
+source_test_env_setup "$profile" --risedev-profile ci-kafka-oidc-test --need-python
+
+export KAFKA_OIDC_BOOTSTRAP_SERVERS="message_queue_oidc:9092"
+export KAFKA_OIDC_ISSUER_URL="http://keycloak_oidc:8080/realms/demo"
+export KAFKA_OIDC_TOKEN_ENDPOINT_URL="${KAFKA_OIDC_ISSUER_URL}/protocol/openid-connect/token"
+export KAFKA_OIDC_PRODUCER_CLIENT_ID="kafka-producer-client"
+export KAFKA_OIDC_PRODUCER_CLIENT_SECRET="kafka-producer-client-secret"
+export KAFKA_OIDC_CONSUMER_CLIENT_ID="kafka-consumer-client"
+export KAFKA_OIDC_CONSUMER_CLIENT_SECRET="kafka-consumer-client-secret"
+
+wait_for_command() {
+    local message="$1"
+    shift
+
+    echo "--- ${message}"
+    for _ in $(seq 1 60); do
+        if "$@"; then
+            return
+        fi
+        sleep 2
+    done
+
+    echo "Timed out: ${message}" 1>&2
+    exit 1
+}
+
+wait_for_command "Wait for Keycloak OIDC metadata" \
+    curl -fsS "${KAFKA_OIDC_ISSUER_URL}/.well-known/openid-configuration" -o /dev/null
+
+wait_for_command "Wait for Kafka OIDC broker" \
+    python3 e2e_test/kafka-oidc/kafka_oidc_admin.py metadata
+
+echo "--- Run Kafka OIDC tests"
+risedev slt './e2e_test/kafka-oidc/**/*.slt' -j1
+
+echo "--- Kill cluster"
+risedev ci-kill

--- a/ci/workflows/main-cron.yml
+++ b/ci/workflows/main-cron.yml
@@ -240,6 +240,24 @@ steps:
     timeout_in_minutes: 40
     retry: *auto-retry
 
+  - label: "end-to-end kafka oidc test"
+    key: "e2e-test-release-kafka-oidc"
+    command: "ci/scripts/e2e-kafka-oidc-test.sh -p ci-release"
+    if: |
+      !(build.pull_request.labels includes "ci/main-cron/run-selected") && build.env("CI_STEPS") == null
+      || build.pull_request.labels includes "ci/run-e2e-kafka-source-tests"
+      || build.pull_request.labels includes "ci/run-e2e-kafka-sink-tests"
+      || build.env("CI_STEPS") =~ /(^|,)e2e-kafka-oidc-tests?(,|$$)/
+    depends_on:
+      - "build"
+    plugins:
+      - docker-compose#v5.5.0:
+          <<: *docker-compose
+          run: kafka-oidc-test-env
+      - ./ci/plugins/upload-failure-logs
+    timeout_in_minutes: 30
+    retry: *auto-retry
+
   - label: "end-to-end cdc source test"
     key: "e2e-test-release-source-cdc"
     command: "ci/scripts/e2e-source-cdc-test.sh -p ci-release"

--- a/ci/workflows/pull-request.yml
+++ b/ci/workflows/pull-request.yml
@@ -248,6 +248,23 @@ steps:
     timeout_in_minutes: 25
     retry: *auto-retry
 
+  - label: "end-to-end kafka oidc test"
+    command: "ci/scripts/e2e-kafka-oidc-test.sh -p ci-dev"
+    if: |
+      !(build.pull_request.labels includes "ci/pr/run-selected") && build.env("CI_STEPS") == null
+      || build.pull_request.labels includes "ci/run-e2e-kafka-source-tests"
+      || build.pull_request.labels includes "ci/run-e2e-kafka-sink-tests"
+      || build.env("CI_STEPS") =~ /(^|,)e2e-kafka-oidc-tests?(,|$$)/
+    depends_on:
+      - "build"
+    plugins:
+      - docker-compose#v5.5.0:
+          <<: *docker-compose
+          run: kafka-oidc-test-env
+      - ./ci/plugins/upload-failure-logs
+    timeout_in_minutes: 20
+    retry: *auto-retry
+
 
   - label: "end-to-end cdc source test"
     command: "ci/scripts/e2e-source-cdc-test.sh -p ci-dev"

--- a/ci/workflows/pull-request.yml
+++ b/ci/workflows/pull-request.yml
@@ -265,7 +265,6 @@ steps:
     timeout_in_minutes: 20
     retry: *auto-retry
 
-
   - label: "end-to-end cdc source test"
     command: "ci/scripts/e2e-source-cdc-test.sh -p ci-dev"
     if: |

--- a/e2e_test/kafka-oidc/basic.slt
+++ b/e2e_test/kafka-oidc/basic.slt
@@ -1,0 +1,165 @@
+control substitution on
+
+statement ok
+DROP SINK IF EXISTS kafka_oidc_sink;
+
+statement ok
+DROP TABLE IF EXISTS kafka_oidc_sink_input;
+
+statement ok
+DROP TABLE IF EXISTS kafka_oidc_source_inline;
+
+statement ok
+DROP TABLE IF EXISTS kafka_oidc_source_conn;
+
+statement ok
+DROP CONNECTION IF EXISTS kafka_oidc_conn;
+
+statement ok
+DROP SECRET IF EXISTS kafka_oidc_producer_secret;
+
+statement ok
+DROP SECRET IF EXISTS kafka_oidc_consumer_secret;
+
+system ok
+python3 e2e_test/kafka-oidc/kafka_oidc_admin.py recreate-topic perf293_oidc_source 1
+
+
+system ok
+python3 e2e_test/kafka-oidc/kafka_oidc_admin.py recreate-topic perf293_oidc_sink 1
+
+
+system ok
+cat << EOF | python3 e2e_test/kafka-oidc/kafka_oidc_admin.py produce-lines perf293_oidc_source
+{"id":101,"payload":"rw_oidc_alpha"}
+{"id":102,"payload":"rw_oidc_beta"}
+{"id":103,"payload":"rw_oidc_gamma"}
+EOF
+
+
+statement ok
+CREATE SECRET kafka_oidc_consumer_secret WITH (backend = 'meta') AS '${KAFKA_OIDC_CONSUMER_CLIENT_SECRET}';
+
+statement ok
+CREATE SECRET kafka_oidc_producer_secret WITH (backend = 'meta') AS '${KAFKA_OIDC_PRODUCER_CLIENT_SECRET}';
+
+statement ok
+CREATE CONNECTION kafka_oidc_conn WITH (
+    type = 'kafka',
+    properties.bootstrap.server = '${KAFKA_OIDC_BOOTSTRAP_SERVERS}',
+    properties.security.protocol = 'SASL_PLAINTEXT',
+    properties.sasl.mechanism = 'OAUTHBEARER',
+    properties.sasl.oauthbearer.method = 'oidc',
+    properties.sasl.oauthbearer.client.id = '${KAFKA_OIDC_CONSUMER_CLIENT_ID}',
+    properties.sasl.oauthbearer.client.secret = SECRET kafka_oidc_consumer_secret,
+    properties.sasl.oauthbearer.token.endpoint.url = '${KAFKA_OIDC_TOKEN_ENDPOINT_URL}'
+);
+
+statement ok
+CREATE TABLE kafka_oidc_source_conn (
+    id int,
+    payload varchar
+) WITH (
+    connector = 'kafka',
+    connection = kafka_oidc_conn,
+    topic = 'perf293_oidc_source',
+    scan.startup.mode = 'earliest'
+) FORMAT PLAIN ENCODE JSON;
+
+statement ok
+CREATE TABLE kafka_oidc_source_inline (
+    id int,
+    payload varchar
+) WITH (
+    connector = 'kafka',
+    properties.bootstrap.server = '${KAFKA_OIDC_BOOTSTRAP_SERVERS}',
+    topic = 'perf293_oidc_source',
+    scan.startup.mode = 'earliest',
+    properties.security.protocol = 'SASL_PLAINTEXT',
+    properties.sasl.mechanism = 'OAUTHBEARER',
+    properties.sasl.oauthbearer.method = 'oidc',
+    properties.sasl.oauthbearer.client.id = '${KAFKA_OIDC_CONSUMER_CLIENT_ID}',
+    properties.sasl.oauthbearer.client.secret = SECRET kafka_oidc_consumer_secret,
+    properties.sasl.oauthbearer.token.endpoint.url = '${KAFKA_OIDC_TOKEN_ENDPOINT_URL}'
+) FORMAT PLAIN ENCODE JSON;
+
+sleep 2s
+
+query IT rowsort retry 10 backoff 2s
+SELECT id, payload FROM kafka_oidc_source_conn;
+----
+101 rw_oidc_alpha
+102 rw_oidc_beta
+103 rw_oidc_gamma
+
+
+query IT rowsort retry 10 backoff 2s
+SELECT id, payload FROM kafka_oidc_source_inline;
+----
+101 rw_oidc_alpha
+102 rw_oidc_beta
+103 rw_oidc_gamma
+
+
+statement ok
+CREATE TABLE kafka_oidc_sink_input (
+    id int primary key,
+    payload varchar
+);
+
+statement ok
+INSERT INTO kafka_oidc_sink_input VALUES (201, 'sink_alpha'), (202, 'sink_beta');
+
+statement ok
+FLUSH;
+
+statement ok
+CREATE SINK kafka_oidc_sink FROM kafka_oidc_sink_input WITH (
+    connector = 'kafka',
+    properties.bootstrap.server = '${KAFKA_OIDC_BOOTSTRAP_SERVERS}',
+    topic = 'perf293_oidc_sink',
+    type = 'append-only',
+    properties.security.protocol = 'SASL_PLAINTEXT',
+    properties.sasl.mechanism = 'OAUTHBEARER',
+    properties.sasl.oauthbearer.method = 'oidc',
+    properties.sasl.oauthbearer.client.id = '${KAFKA_OIDC_PRODUCER_CLIENT_ID}',
+    properties.sasl.oauthbearer.client.secret = SECRET kafka_oidc_producer_secret,
+    properties.sasl.oauthbearer.token.endpoint.url = '${KAFKA_OIDC_TOKEN_ENDPOINT_URL}'
+) FORMAT PLAIN ENCODE JSON (
+    force_append_only = 'true'
+);
+
+system ok
+python3 e2e_test/kafka-oidc/kafka_oidc_admin.py consume-values perf293_oidc_sink 2 20
+----
+{"id":201,"payload":"sink_alpha"}
+{"id":202,"payload":"sink_beta"}
+
+
+statement ok
+DROP SINK kafka_oidc_sink;
+
+statement ok
+DROP TABLE kafka_oidc_sink_input;
+
+statement ok
+DROP TABLE kafka_oidc_source_inline;
+
+statement ok
+DROP TABLE kafka_oidc_source_conn;
+
+statement ok
+DROP CONNECTION kafka_oidc_conn;
+
+statement ok
+DROP SECRET kafka_oidc_producer_secret;
+
+statement ok
+DROP SECRET kafka_oidc_consumer_secret;
+
+system ok
+python3 e2e_test/kafka-oidc/kafka_oidc_admin.py delete-topic perf293_oidc_source
+
+
+system ok
+python3 e2e_test/kafka-oidc/kafka_oidc_admin.py delete-topic perf293_oidc_sink

--- a/e2e_test/kafka-oidc/basic.slt
+++ b/e2e_test/kafka-oidc/basic.slt
@@ -130,7 +130,7 @@ CREATE SINK kafka_oidc_sink FROM kafka_oidc_sink_input WITH (
 );
 
 system ok
-python3 e2e_test/kafka-oidc/kafka_oidc_admin.py consume-values perf293_oidc_sink 2 20
+python3 e2e_test/kafka-oidc/kafka_oidc_admin.py consume-values perf293_oidc_sink 2 60
 ----
 {"id":201,"payload":"sink_alpha"}
 {"id":202,"payload":"sink_beta"}

--- a/e2e_test/kafka-oidc/kafka_oidc_admin.py
+++ b/e2e_test/kafka-oidc/kafka_oidc_admin.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env python3
+
+import os
+import sys
+import time
+import uuid
+
+from confluent_kafka import Consumer, KafkaError, KafkaException, Producer
+from confluent_kafka.admin import AdminClient, NewTopic
+
+
+def oidc_config(role: str) -> dict[str, str]:
+    role_prefix = role.upper()
+    return {
+        "bootstrap.servers": os.environ["KAFKA_OIDC_BOOTSTRAP_SERVERS"],
+        "security.protocol": "SASL_PLAINTEXT",
+        "sasl.mechanism": "OAUTHBEARER",
+        "sasl.oauthbearer.method": "oidc",
+        "sasl.oauthbearer.client.id": os.environ[
+            f"KAFKA_OIDC_{role_prefix}_CLIENT_ID"
+        ],
+        "sasl.oauthbearer.client.secret": os.environ[
+            f"KAFKA_OIDC_{role_prefix}_CLIENT_SECRET"
+        ],
+        "sasl.oauthbearer.token.endpoint.url": os.environ[
+            "KAFKA_OIDC_TOKEN_ENDPOINT_URL"
+        ],
+    }
+
+
+def admin_client() -> AdminClient:
+    return AdminClient(oidc_config("consumer"))
+
+
+def ignore_unknown_topic_error(exc: Exception) -> None:
+    if isinstance(exc, KafkaException):
+        error = exc.args[0]
+        if error.code() == KafkaError.UNKNOWN_TOPIC_OR_PART:
+            return
+    raise exc
+
+
+def wait_until_topic_absent(client: AdminClient, topic: str) -> None:
+    deadline = time.time() + 30
+    while time.time() < deadline:
+        metadata = client.list_topics(timeout=10)
+        if topic not in metadata.topics:
+            return
+        time.sleep(1)
+    raise TimeoutError(f"topic still exists after delete: {topic}")
+
+
+def delete_topic(client: AdminClient, topic: str) -> None:
+    futures = client.delete_topics([topic], operation_timeout=10)
+    try:
+        futures[topic].result(timeout=20)
+    except Exception as exc:
+        ignore_unknown_topic_error(exc)
+        return
+    wait_until_topic_absent(client, topic)
+
+
+def recreate_topic(client: AdminClient, topic: str, partitions: int) -> None:
+    delete_topic(client, topic)
+    futures = client.create_topics(
+        [NewTopic(topic, num_partitions=partitions, replication_factor=1)],
+        operation_timeout=10,
+    )
+    futures[topic].result(timeout=20)
+
+
+def produce_lines(topic: str) -> None:
+    producer = Producer(oidc_config("producer"))
+    errors = []
+
+    def delivery_report(error, message) -> None:
+        if error is not None:
+            errors.append(f"{message.topic()}: {error}")
+
+    for line in sys.stdin:
+        line = line.rstrip("\n")
+        if line:
+            producer.produce(topic, line.encode("utf-8"), callback=delivery_report)
+            producer.poll(0)
+    remaining = producer.flush(30)
+    if remaining or errors:
+        raise RuntimeError(
+            f"failed to produce all records: remaining={remaining}, errors={errors}"
+        )
+
+
+def consume_values(topic: str, count: int, timeout_seconds: int) -> None:
+    consumer = Consumer(
+        {
+            **oidc_config("consumer"),
+            "group.id": f"kafka-oidc-e2e-{uuid.uuid4()}",
+            "auto.offset.reset": "earliest",
+            "enable.partition.eof": True,
+        }
+    )
+    deadline = time.time() + timeout_seconds
+    values: list[str] = []
+
+    try:
+        consumer.subscribe([topic])
+        while len(values) < count and time.time() < deadline:
+            message = consumer.poll(1)
+            if message is None:
+                continue
+            if message.error():
+                if message.error().code() == KafkaError._PARTITION_EOF:
+                    continue
+                raise KafkaException(message.error())
+            values.append(message.value().decode("utf-8"))
+    finally:
+        consumer.close()
+
+    if len(values) != count:
+        raise TimeoutError(f"expected {count} messages from {topic}, got {len(values)}")
+
+    for value in sorted(values):
+        print(value)
+
+
+def fetch_metadata() -> None:
+    admin_client().list_topics(timeout=10)
+
+
+def main() -> None:
+    if len(sys.argv) < 2:
+        raise SystemExit(
+            "usage: kafka_oidc_admin.py metadata|recreate-topic|delete-topic|produce-lines|consume-values ..."
+        )
+
+    command = sys.argv[1]
+
+    if command == "metadata":
+        fetch_metadata()
+        return
+
+    if len(sys.argv) < 3:
+        raise SystemExit(f"{command} requires a topic argument")
+
+    topic = sys.argv[2]
+
+    if command == "recreate-topic":
+        partitions = int(sys.argv[3]) if len(sys.argv) > 3 else 1
+        recreate_topic(admin_client(), topic, partitions)
+    elif command == "delete-topic":
+        delete_topic(admin_client(), topic)
+    elif command == "produce-lines":
+        produce_lines(topic)
+    elif command == "consume-values":
+        if len(sys.argv) < 4:
+            raise SystemExit("consume-values requires a message count")
+        timeout_seconds = int(sys.argv[4]) if len(sys.argv) > 4 else 30
+        consume_values(topic, int(sys.argv[3]), timeout_seconds)
+    else:
+        raise SystemExit(f"unknown command: {command}")
+
+
+if __name__ == "__main__":
+    main()

--- a/e2e_test/kafka-oidc/kafka_oidc_admin.py
+++ b/e2e_test/kafka-oidc/kafka_oidc_admin.py
@@ -29,6 +29,7 @@ def oidc_config(role: str) -> dict[str, str]:
 
 
 def admin_client() -> AdminClient:
+    # The test realm does not require separate credentials for admin operations.
     return AdminClient(oidc_config("consumer"))
 
 

--- a/risedev.yml
+++ b/risedev.yml
@@ -876,6 +876,21 @@ profile:
         address: schemaregistry
         port: 8082
 
+  ci-kafka-oidc-test:
+    config-path: src/config/ci-recovery.toml
+    steps:
+      - use: minio
+      - use: meta-node
+        meta-backend: env
+      - use: compute-node
+        enable-tiered-cache: true
+      - use: frontend
+      - use: compactor
+      - use: kafka
+        user-managed: true
+        address: message_queue_oidc
+        port: 9092
+
   ci-source-cdc-test:
     config-path: src/config/ci-recovery.toml
     steps:

--- a/risedev.yml
+++ b/risedev.yml
@@ -886,10 +886,6 @@ profile:
         enable-tiered-cache: true
       - use: frontend
       - use: compactor
-      - use: kafka
-        user-managed: true
-        address: message_queue_oidc
-        port: 9092
 
   ci-source-cdc-test:
     config-path: src/config/ci-recovery.toml

--- a/src/connector/Cargo.toml
+++ b/src/connector/Cargo.toml
@@ -138,6 +138,7 @@ rdkafka = { workspace = true, features = [
     "ssl",
     "gssapi",
     "zstd",
+    "curl",
     "curl-static",
 ] }
 redis = { workspace = true, features = [

--- a/src/connector/Cargo.toml
+++ b/src/connector/Cargo.toml
@@ -138,7 +138,7 @@ rdkafka = { workspace = true, features = [
     "ssl",
     "gssapi",
     "zstd",
-    "curl",
+    "curl-static",
 ] }
 redis = { workspace = true, features = [
     "aio",

--- a/src/connector/Cargo.toml
+++ b/src/connector/Cargo.toml
@@ -138,6 +138,7 @@ rdkafka = { workspace = true, features = [
     "ssl",
     "gssapi",
     "zstd",
+    # Keep release builds from dynamically linking libssl through libcurl.
     "curl",
     "curl-static",
 ] }


### PR DESCRIPTION
## Summary

- Add a Keycloak + Strimzi Kafka OIDC CI environment for Kafka SASL/OAUTHBEARER OIDC login.
- Add an SLT covering Kafka OIDC source via CREATE CONNECTION, inline source options, CREATE SECRET client secrets, and Kafka sink.
- Wire the new Kafka OIDC lane into pull-request and main-cron Buildkite workflows, using the existing Kafka source/sink CI labels.

This is stacked on #25499. The PR base branch mirrors the current #25499 head so this PR diff stays focused on the e2e/CI coverage. After #25499 lands, this can be retargeted to main.

## Tests

- bash -n ci/scripts/e2e-kafka-oidc-test.sh ci/kafka-oidc/kafka/start.sh ci/kafka-oidc/kafka/functions.sh
- python3 -m py_compile e2e_test/kafka-oidc/kafka_oidc_admin.py
- python3 -m json.tool ci/kafka-oidc/keycloak/realms/demo-realm.json
- BUILD_ENV_VERSION=v20260614 docker compose -f ci/docker-compose.yml config --services
- python3 e2e_test/check_slt_coverage.py -d
- docker compose OIDC services smoke test: Keycloak import + Kafka broker startup
- Python confluent_kafka OIDC smoke test: metadata + topic recreate + produce + consume
- sqllogictest -p 4566 -d dev './e2e_test/kafka-oidc/basic.slt' with local Kafka OIDC services