### PR TITLE
fix(meta): partially decode backup hummock sequences

### DIFF
--- a/src/meta/src/backup_restore/restore_impl/v2.rs
+++ b/src/meta/src/backup_restore/restore_impl/v2.rs
@@ -18,7 +18,9 @@ use itertools::Itertools;
 use risingwave_backup::MetaSnapshotId;
 use risingwave_backup::error::{BackupError, BackupResult};
 use risingwave_backup::meta_snapshot::MetaSnapshot;
-use risingwave_backup::meta_snapshot_v2::{MetaSnapshotV2, MetadataV2};
+use risingwave_backup::meta_snapshot_v2::{
+    MetaSnapshotV2, MetadataV2, decode_hummock_sequences_from_snapshot,
+};
 use risingwave_backup::storage::{MetaSnapshotStorage, MetaSnapshotStorageRef};
 use sea_orm::{DbErr, EntityTrait};
 
@@ -59,11 +61,11 @@ impl Loader<MetadataV2> for LoaderV2 {
 
         // validate and rewrite seq
         if newest_id > target_id {
-            let newest_snapshot: MetaSnapshotV2 = self.backup_store.get(newest_id).await?;
+            let newest_hummock_sequences = decode_hummock_sequences_from_snapshot(
+                &self.backup_store.get_raw(newest_id).await?,
+            )?;
             for seq in &target_snapshot.metadata.hummock_sequences {
-                let newest = newest_snapshot
-                    .metadata
-                    .hummock_sequences
+                let newest = newest_hummock_sequences
                     .iter()
                     .find(|s| s.name == seq.name)
                     .unwrap_or_else(|| {
@@ -74,7 +76,7 @@ impl Loader<MetadataV2> for LoaderV2 {
                     });
                 assert!(newest.seq >= seq.seq, "violate monotonicity requirement");
             }
-            target_snapshot.metadata.hummock_sequences = newest_snapshot.metadata.hummock_sequences;
+            target_snapshot.metadata.hummock_sequences = newest_hummock_sequences;
             tracing::info!(
                 "snapshot {} is rewritten by snapshot {}:\n",
                 target_id,

--- a/src/storage/backup/src/meta_snapshot.rs
+++ b/src/storage/backup/src/meta_snapshot.rs
@@ -19,7 +19,7 @@ use bytes::{Buf, BufMut};
 use risingwave_hummock_sdk::HummockRawObjectId;
 use risingwave_hummock_sdk::version::HummockVersion;
 
-use crate::error::BackupResult;
+use crate::error::{BackupError, BackupResult};
 use crate::{MetaSnapshotId, xxhash64_checksum, xxhash64_verify};
 
 pub trait Metadata: Display + Send + Sync {
@@ -59,12 +59,12 @@ impl<T: Metadata> MetaSnapshot<T> {
         Ok(buf)
     }
 
-    pub fn decode(mut buf: &[u8]) -> BackupResult<Self> {
-        let checksum = (&buf[buf.len() - 8..]).get_u64_le();
-        xxhash64_verify(&buf[..buf.len() - 8], checksum)?;
-        let format_version = buf.get_u32_le();
-        let id = buf.get_u64_le();
-        let metadata = T::decode(buf)?;
+    pub fn decode(buf: &[u8]) -> BackupResult<Self> {
+        let payload = verify_checksum_and_strip(buf)?;
+        let mut payload = payload;
+        let format_version = read_u32_le(&mut payload)?;
+        let id = read_u64_le(&mut payload)?;
+        let metadata = T::decode(payload)?;
         Ok(Self {
             format_version,
             id,
@@ -72,12 +72,41 @@ impl<T: Metadata> MetaSnapshot<T> {
         })
     }
 
-    pub fn decode_format_version(mut buf: &[u8]) -> BackupResult<u32> {
-        let checksum = (&buf[buf.len() - 8..]).get_u64_le();
-        xxhash64_verify(&buf[..buf.len() - 8], checksum)?;
-        let format_version = buf.get_u32_le();
-        Ok(format_version)
+    pub fn decode_format_version(buf: &[u8]) -> BackupResult<u32> {
+        let mut payload = verify_checksum_and_strip(buf)?;
+        read_u32_le(&mut payload)
     }
+}
+
+pub(crate) fn verify_checksum_and_strip(snapshot: &[u8]) -> BackupResult<&[u8]> {
+    let payload_len = snapshot.len().checked_sub(8).ok_or_else(|| {
+        BackupError::Other(anyhow::anyhow!(
+            "metadata snapshot is too short: {} bytes",
+            snapshot.len()
+        ))
+    })?;
+    let mut checksum_buf = &snapshot[payload_len..];
+    let checksum = read_u64_le(&mut checksum_buf)?;
+    xxhash64_verify(&snapshot[..payload_len], checksum)?;
+    Ok(&snapshot[..payload_len])
+}
+
+pub(crate) fn read_u32_le(buf: &mut &[u8]) -> BackupResult<u32> {
+    if buf.remaining() < 4 {
+        return Err(BackupError::Other(anyhow::anyhow!(
+            "metadata snapshot is truncated while reading u32"
+        )));
+    }
+    Ok(buf.get_u32_le())
+}
+
+pub(crate) fn read_u64_le(buf: &mut &[u8]) -> BackupResult<u64> {
+    if buf.remaining() < 8 {
+        return Err(BackupError::Other(anyhow::anyhow!(
+            "metadata snapshot is truncated while reading u64"
+        )));
+    }
+    Ok(buf.get_u64_le())
 }
 
 impl<T: Metadata> Display for MetaSnapshot<T> {

--- a/src/storage/backup/src/meta_snapshot_v1.rs
+++ b/src/storage/backup/src/meta_snapshot_v1.rs
@@ -28,7 +28,7 @@ use risingwave_pb::meta::{SystemParams, TableFragments};
 use risingwave_pb::user::UserInfo;
 
 use crate::error::{BackupError, BackupResult};
-use crate::meta_snapshot::{MetaSnapshot, Metadata};
+use crate::meta_snapshot::{MetaSnapshot, Metadata, read_u32_le};
 
 // TODO: remove `ClusterMetadata` and even the trait, after applying model v2.
 pub type MetaSnapshotV1 = MetaSnapshot<ClusterMetadata>;
@@ -229,7 +229,14 @@ impl ClusterMetadata {
     where
         T: prost::Message + Default,
     {
-        let len = buf.get_u32_le() as usize;
+        let len = read_u32_le(buf)? as usize;
+        if buf.remaining() < len {
+            return Err(BackupError::Other(anyhow::anyhow!(
+                "prost payload length {} exceeds remaining buffer {}",
+                len,
+                buf.remaining()
+            )));
+        }
         let v = buf[..len].to_vec();
         buf.advance(len);
         T::decode(v.as_slice()).map_err(|e| BackupError::Decoding(e.into()))
@@ -246,7 +253,7 @@ impl ClusterMetadata {
     where
         T: prost::Message + Default,
     {
-        let vec_len = buf.get_u32_le() as usize;
+        let vec_len = read_u32_le(buf)? as usize;
         let mut result = vec![];
         for _ in 0..vec_len {
             let v: T = Self::decode_prost_message(buf)?;

--- a/src/storage/backup/src/meta_snapshot_v2.rs
+++ b/src/storage/backup/src/meta_snapshot_v2.rs
@@ -23,7 +23,9 @@ use risingwave_hummock_sdk::change_log::EpochNewChangeLog;
 use risingwave_hummock_sdk::version::HummockVersion;
 use serde::{Deserialize, Serialize};
 
-use crate::meta_snapshot::{MetaSnapshot, Metadata};
+use crate::meta_snapshot::{
+    MetaSnapshot, Metadata, read_u32_le, read_u64_le, verify_checksum_and_strip,
+};
 use crate::{BackupError, BackupResult};
 pub type MetaSnapshotV2 = MetaSnapshot<MetadataV2>;
 
@@ -134,6 +136,32 @@ macro_rules! define_decode_metadata {
 }
 
 for_all_metadata_models_v2!(define_decode_metadata);
+
+// Metadata V2 is encoded as a positional list of sections. The actual encoded order inserts
+// `hummock_version` before `version_stats`, so `hummock_sequences` is section 26:
+// 0 seaql_migrations, 1 hummock_version, 2 version_stats, ..., 26 hummock_sequences.
+//
+// Keep this as a fixed index so partial decoding can remain compatible with future formats that
+// only append sections after `hummock_sequences`.
+const HUMMOCK_SEQUENCES_METADATA_SECTION_INDEX: usize = 26;
+
+pub fn decode_hummock_sequences_from_snapshot(
+    snapshot: &[u8],
+) -> BackupResult<Vec<risingwave_meta_model::hummock_sequence::Model>> {
+    let mut buf = verify_checksum_and_strip(snapshot)?;
+    let format_version = read_u32_le(&mut buf)?;
+    if format_version < 2 {
+        return Err(BackupError::Other(anyhow!(
+            "unsupported metadata snapshot format version for hummock sequence partial decoding: {}",
+            format_version
+        )));
+    }
+    let _snapshot_id = read_u64_le(&mut buf)?;
+    for _ in 0..HUMMOCK_SEQUENCES_METADATA_SECTION_INDEX {
+        skip_metadata_list(&mut buf)?;
+    }
+    get_n(&mut buf)
+}
 
 impl Display for MetadataV2 {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
@@ -262,8 +290,8 @@ fn put_1<T: Serialize>(buf: &mut Vec<u8>, data: &T) -> Result<(), serde_json::Er
     put_n(buf, &[data])
 }
 
-fn get_n<'a, T: Deserialize<'a>>(buf: &mut &'a [u8]) -> Result<Vec<T>, serde_json::Error> {
-    let n = buf.get_u32_le() as usize;
+fn get_n<'a, T: Deserialize<'a>>(buf: &mut &'a [u8]) -> BackupResult<Vec<T>> {
+    let n = read_u32_le(buf)? as usize;
     let mut elements = Vec::with_capacity(n);
     for _ in 0..n {
         elements.push(get_with_len_prefix(buf)?);
@@ -271,45 +299,57 @@ fn get_n<'a, T: Deserialize<'a>>(buf: &mut &'a [u8]) -> Result<Vec<T>, serde_jso
     Ok(elements)
 }
 
-fn get_1<'a, T: Deserialize<'a>>(buf: &mut &'a [u8]) -> Result<T, serde_json::Error> {
+fn get_1<'a, T: Deserialize<'a>>(buf: &mut &'a [u8]) -> BackupResult<T> {
     let elements = get_n(buf)?;
     assert_eq!(elements.len(), 1);
     Ok(elements.into_iter().next().unwrap())
 }
 
+fn skip_metadata_list(buf: &mut &[u8]) -> BackupResult<()> {
+    let n = read_u32_le(buf)? as usize;
+    for _ in 0..n {
+        skip_with_len_prefix(buf)?;
+    }
+    Ok(())
+}
+
+fn skip_with_len_prefix(buf: &mut &[u8]) -> BackupResult<()> {
+    let len = read_u64_le(buf)?
+        .try_into()
+        .map_err(|_| BackupError::Other(anyhow!("metadata JSON payload length exceeds usize")))?;
+    if buf.remaining() < len {
+        return Err(BackupError::Other(anyhow!(
+            "metadata JSON payload length {} exceeds remaining buffer {}",
+            len,
+            buf.remaining()
+        )));
+    }
+    buf.advance(len);
+    Ok(())
+}
+
 fn put_with_len_prefix<T: Serialize>(buf: &mut Vec<u8>, data: &T) -> Result<(), serde_json::Error> {
     let b = serde_json::to_vec(data)?;
-    // Any valid JSON value serialized by serde_json is non-empty, such as `null`, `{}`, or `[]`.
-    assert!(!b.is_empty());
-    if let Ok(len) = u32::try_from(b.len()) {
-        buf.put_u32_le(len);
-    } else {
-        buf.put_u32_le(0);
-        buf.put_u64_le(
-            b.len()
-                .try_into()
-                .unwrap_or_else(|_| panic!("cannot convert {} into u64", b.len())),
-        );
-    }
+    buf.put_u64_le(
+        b.len()
+            .try_into()
+            .unwrap_or_else(|_| panic!("cannot convert {} into u64", b.len())),
+    );
     buf.put_slice(&b);
     Ok(())
 }
 
-fn get_with_len_prefix<'a, T: Deserialize<'a>>(buf: &mut &'a [u8]) -> Result<T, serde_json::Error> {
-    let len = match buf.get_u32_le() {
-        0 => {
-            let len = buf.get_u64_le();
-            len.try_into()
-                .unwrap_or_else(|_| panic!("cannot convert {} into usize", len))
-        }
-        len => len as usize,
-    };
-    assert!(
-        buf.remaining() >= len,
-        "JSON payload length {} exceeds remaining buffer {}",
-        len,
-        buf.remaining()
-    );
+fn get_with_len_prefix<'a, T: Deserialize<'a>>(buf: &mut &'a [u8]) -> BackupResult<T> {
+    let len = read_u64_le(buf)?
+        .try_into()
+        .map_err(|_| BackupError::Other(anyhow!("metadata JSON payload length exceeds usize")))?;
+    if buf.remaining() < len {
+        return Err(BackupError::Other(anyhow!(
+            "metadata JSON payload length {} exceeds remaining buffer {}",
+            len,
+            buf.remaining()
+        )));
+    }
     let d = serde_json::from_slice(&buf[..len])?;
     buf.advance(len);
     Ok(d)
@@ -318,25 +358,65 @@ fn get_with_len_prefix<'a, T: Deserialize<'a>>(buf: &mut &'a [u8]) -> Result<T, 
 #[cfg(test)]
 mod tests {
     use bytes::BufMut;
+    use risingwave_common::util::panic::rw_catch_unwind;
+    use risingwave_meta_model::hummock_sequence;
 
     use super::*;
 
+    fn encoded_snapshot_with_invalid_trailing_metadata_after_hummock_sequences(
+        metadata: &MetadataV2,
+    ) -> Vec<u8> {
+        let raw = MetaSnapshotV2 {
+            format_version: 2,
+            id: 123,
+            metadata: MetadataV2 {
+                hummock_sequences: metadata.hummock_sequences.clone(),
+                ..Default::default()
+            },
+        };
+        let encoded = raw.encode().unwrap();
+        let payload = &encoded[..encoded.len() - 8];
+        let mut metadata_buf = &payload[12..];
+
+        for _ in 0..=HUMMOCK_SEQUENCES_METADATA_SECTION_INDEX {
+            skip_metadata_list(&mut metadata_buf).unwrap();
+        }
+
+        let mut partial_payload = payload[..payload.len() - metadata_buf.len()].to_vec();
+        partial_payload.put_u32_le(1);
+        partial_payload.put_u64_le(100);
+        partial_payload.put_slice(br#""short""#);
+        let checksum = crate::xxhash64_checksum(&partial_payload);
+        partial_payload.put_u64_le(checksum);
+        partial_payload
+    }
+
+    fn append_future_metadata_section(mut encoded: Vec<u8>) -> Vec<u8> {
+        encoded.truncate(encoded.len() - 8);
+        put_n(&mut encoded, &["future section"]).unwrap();
+        let checksum = crate::xxhash64_checksum(&encoded);
+        encoded.put_u64_le(checksum);
+        encoded
+    }
+
     #[test]
-    fn test_len_prefix_legacy_u32_round_trip() {
+    fn test_len_prefix_u64_round_trip() {
         let mut buf = vec![];
         put_with_len_prefix(&mut buf, &"hello").unwrap();
 
-        assert_ne!(u32::from_le_bytes(buf[..4].try_into().unwrap()), 0);
+        assert_eq!(
+            u64::from_le_bytes(buf[..8].try_into().unwrap()),
+            serde_json::to_vec("hello").unwrap().len() as u64
+        );
 
         let decoded: String = get_with_len_prefix(&mut buf.as_slice()).unwrap();
         assert_eq!(decoded, "hello");
     }
 
     #[test]
-    fn test_len_prefix_extended_u64_decoding() {
+    fn test_len_prefix_u64_decoding() {
         let payload = serde_json::to_vec("hello").unwrap();
         let mut buf = vec![];
-        buf.put_u32_le(0);
         buf.put_u64_le(payload.len() as u64);
         buf.put_slice(&payload);
 
@@ -345,26 +425,21 @@ mod tests {
     }
 
     #[test]
-    #[should_panic]
-    fn test_len_prefix_panics_on_missing_extended_u64() {
-        let mut buf = vec![];
-        buf.put_u32_le(0);
-
-        let _ = get_with_len_prefix::<String>(&mut buf.as_slice());
+    fn test_len_prefix_errors_on_missing_u64() {
+        assert!(get_with_len_prefix::<String>(&mut [].as_slice()).is_err());
     }
 
     #[test]
-    #[should_panic]
-    fn test_len_prefix_panics_on_payload_shorter_than_declared_len() {
+    fn test_len_prefix_errors_on_payload_shorter_than_declared_len() {
         let mut buf = vec![];
-        buf.put_u32_le(100);
+        buf.put_u64_le(100);
         buf.put_slice(br#""hello""#);
 
-        let _ = get_with_len_prefix::<String>(&mut buf.as_slice());
+        assert!(get_with_len_prefix::<String>(&mut buf.as_slice()).is_err());
     }
 
     #[test]
-    fn test_snapshot_v2_legacy_encoding_decoding() {
+    fn test_snapshot_v2_encoding_decoding() {
         let raw = MetaSnapshotV2 {
             format_version: 2,
             id: 123,
@@ -380,5 +455,69 @@ mod tests {
             decoded.metadata.hummock_version.id,
             raw.metadata.hummock_version.id
         );
+    }
+
+    #[test]
+    fn test_partial_decode_hummock_sequences() {
+        let raw = MetaSnapshotV2 {
+            format_version: 2,
+            id: 123,
+            metadata: MetadataV2 {
+                hummock_sequences: vec![
+                    hummock_sequence::Model {
+                        name: "meta_backup".to_owned(),
+                        seq: 42,
+                    },
+                    hummock_sequence::Model {
+                        name: "sstable_object".to_owned(),
+                        seq: 100,
+                    },
+                ],
+                ..Default::default()
+            },
+        };
+
+        let decoded = decode_hummock_sequences_from_snapshot(&raw.encode().unwrap()).unwrap();
+        assert_eq!(decoded, raw.metadata.hummock_sequences);
+    }
+
+    #[test]
+    fn test_partial_decode_hummock_sequences_ignores_trailing_metadata() {
+        let metadata = MetadataV2 {
+            hummock_sequences: vec![hummock_sequence::Model {
+                name: "meta_backup".to_owned(),
+                seq: 42,
+            }],
+            ..Default::default()
+        };
+        let encoded =
+            encoded_snapshot_with_invalid_trailing_metadata_after_hummock_sequences(&metadata);
+
+        let decoded = decode_hummock_sequences_from_snapshot(&encoded).unwrap();
+        assert_eq!(decoded, metadata.hummock_sequences);
+        let full_decode_result = rw_catch_unwind(|| MetaSnapshotV2::decode(&encoded));
+        assert!(
+            full_decode_result.is_err() || full_decode_result.unwrap().is_err(),
+            "full metadata decoding should not accept the intentionally invalid trailing section"
+        );
+    }
+
+    #[test]
+    fn test_partial_decode_hummock_sequences_ignores_appended_future_sections() {
+        let raw = MetaSnapshotV2 {
+            format_version: 2,
+            id: 123,
+            metadata: MetadataV2 {
+                hummock_sequences: vec![hummock_sequence::Model {
+                    name: "meta_backup".to_owned(),
+                    seq: 42,
+                }],
+                ..Default::default()
+            },
+        };
+
+        let encoded = append_future_metadata_section(raw.encode().unwrap());
+        let decoded = decode_hummock_sequences_from_snapshot(&encoded).unwrap();
+        assert_eq!(decoded, raw.metadata.hummock_sequences);
     }
 }

--- a/src/storage/backup/src/meta_snapshot_v2.rs
+++ b/src/storage/backup/src/meta_snapshot_v2.rs
@@ -314,9 +314,7 @@ fn skip_metadata_list(buf: &mut &[u8]) -> BackupResult<()> {
 }
 
 fn skip_with_len_prefix(buf: &mut &[u8]) -> BackupResult<()> {
-    let len = read_u64_le(buf)?
-        .try_into()
-        .map_err(|_| BackupError::Other(anyhow!("metadata JSON payload length exceeds usize")))?;
+    let len = read_len_prefix(buf)?;
     if buf.remaining() < len {
         return Err(BackupError::Other(anyhow!(
             "metadata JSON payload length {} exceeds remaining buffer {}",
@@ -328,21 +326,35 @@ fn skip_with_len_prefix(buf: &mut &[u8]) -> BackupResult<()> {
     Ok(())
 }
 
+fn read_len_prefix(buf: &mut &[u8]) -> BackupResult<usize> {
+    match read_u32_le(buf)? {
+        0 => read_u64_le(buf)?
+            .try_into()
+            .map_err(|_| BackupError::Other(anyhow!("metadata JSON payload length exceeds usize"))),
+        len => Ok(len as usize),
+    }
+}
+
 fn put_with_len_prefix<T: Serialize>(buf: &mut Vec<u8>, data: &T) -> Result<(), serde_json::Error> {
     let b = serde_json::to_vec(data)?;
-    buf.put_u64_le(
-        b.len()
-            .try_into()
-            .unwrap_or_else(|_| panic!("cannot convert {} into u64", b.len())),
-    );
+    // Any valid JSON value serialized by serde_json is non-empty, such as `null`, `{}`, or `[]`.
+    assert!(!b.is_empty());
+    if let Ok(len) = u32::try_from(b.len()) {
+        buf.put_u32_le(len);
+    } else {
+        buf.put_u32_le(0);
+        buf.put_u64_le(
+            b.len()
+                .try_into()
+                .unwrap_or_else(|_| panic!("cannot convert {} into u64", b.len())),
+        );
+    }
     buf.put_slice(&b);
     Ok(())
 }
 
 fn get_with_len_prefix<'a, T: Deserialize<'a>>(buf: &mut &'a [u8]) -> BackupResult<T> {
-    let len = read_u64_le(buf)?
-        .try_into()
-        .map_err(|_| BackupError::Other(anyhow!("metadata JSON payload length exceeds usize")))?;
+    let len = read_len_prefix(buf)?;
     if buf.remaining() < len {
         return Err(BackupError::Other(anyhow!(
             "metadata JSON payload length {} exceeds remaining buffer {}",
@@ -384,7 +396,7 @@ mod tests {
 
         let mut partial_payload = payload[..payload.len() - metadata_buf.len()].to_vec();
         partial_payload.put_u32_le(1);
-        partial_payload.put_u64_le(100);
+        partial_payload.put_u32_le(100);
         partial_payload.put_slice(br#""short""#);
         let checksum = crate::xxhash64_checksum(&partial_payload);
         partial_payload.put_u64_le(checksum);
@@ -400,23 +412,21 @@ mod tests {
     }
 
     #[test]
-    fn test_len_prefix_u64_round_trip() {
+    fn test_len_prefix_legacy_u32_round_trip() {
         let mut buf = vec![];
         put_with_len_prefix(&mut buf, &"hello").unwrap();
 
-        assert_eq!(
-            u64::from_le_bytes(buf[..8].try_into().unwrap()),
-            serde_json::to_vec("hello").unwrap().len() as u64
-        );
+        assert_ne!(u32::from_le_bytes(buf[..4].try_into().unwrap()), 0);
 
         let decoded: String = get_with_len_prefix(&mut buf.as_slice()).unwrap();
         assert_eq!(decoded, "hello");
     }
 
     #[test]
-    fn test_len_prefix_u64_decoding() {
+    fn test_len_prefix_extended_u64_decoding() {
         let payload = serde_json::to_vec("hello").unwrap();
         let mut buf = vec![];
+        buf.put_u32_le(0);
         buf.put_u64_le(payload.len() as u64);
         buf.put_slice(&payload);
 
@@ -425,14 +435,17 @@ mod tests {
     }
 
     #[test]
-    fn test_len_prefix_errors_on_missing_u64() {
-        assert!(get_with_len_prefix::<String>(&mut [].as_slice()).is_err());
+    fn test_len_prefix_errors_on_missing_extended_u64() {
+        let mut buf = vec![];
+        buf.put_u32_le(0);
+
+        assert!(get_with_len_prefix::<String>(&mut buf.as_slice()).is_err());
     }
 
     #[test]
     fn test_len_prefix_errors_on_payload_shorter_than_declared_len() {
         let mut buf = vec![];
-        buf.put_u64_le(100);
+        buf.put_u32_le(100);
         buf.put_slice(br#""hello""#);
 
         assert!(get_with_len_prefix::<String>(&mut buf.as_slice()).is_err());

--- a/src/storage/backup/src/storage.rs
+++ b/src/storage/backup/src/storage.rs
@@ -42,6 +42,9 @@ pub trait MetaSnapshotStorage: 'static + Sync + Send {
     /// Gets a snapshot by id.
     async fn get<S: Metadata>(&self, id: MetaSnapshotId) -> BackupResult<MetaSnapshot<S>>;
 
+    /// Gets raw encoded snapshot bytes by id.
+    async fn get_raw(&self, id: MetaSnapshotId) -> BackupResult<Vec<u8>>;
+
     /// Gets local snapshot manifest.
     async fn manifest(&self) -> Arc<MetaSnapshotManifest>;
 
@@ -146,9 +149,13 @@ impl MetaSnapshotStorage for ObjectStoreMetaSnapshotStorage {
     }
 
     async fn get<S: Metadata>(&self, id: MetaSnapshotId) -> BackupResult<MetaSnapshot<S>> {
-        let path = self.get_snapshot_path(id);
-        let data = self.store.read(&path, ..).await?;
+        let data = self.get_raw(id).await?;
         MetaSnapshot::decode(&data)
+    }
+
+    async fn get_raw(&self, id: MetaSnapshotId) -> BackupResult<Vec<u8>> {
+        let path = self.get_snapshot_path(id);
+        Ok(self.store.read(&path, ..).await?.to_vec())
     }
 
     async fn manifest(&self) -> Arc<MetaSnapshotManifest> {


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

This PR avoids decoding the whole latest snapshot during backup restore when we only need its `hummock_sequences`.

- Add a raw snapshot read API and use it in v2 restore.
- Add shared checked helpers for checksum stripping and little-endian integer reads.
- Add `decode_hummock_sequences_from_snapshot`, which skips v2 metadata sections by position and decodes only the `hummock_sequences` section.
- Keep the existing v2 JSON payload length compatibility scheme: `u32` for normal payloads and `0 + u64` for large payloads.
- Add focused unit tests for length-prefix decoding and partial `hummock_sequences` decoding, including future appended sections and invalid trailing metadata.

Compatibility impact: the partial decoder uses the same length-prefix logic as full metadata decoding, so it can still read snapshots written with the previous v2 length-prefix format.

## Checklist

- [ ] I have written necessary rustdoc comments.
- [x] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [x] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

The backup restore path now partially decodes `hummock_sequences` from the latest snapshot instead of decoding the whole snapshot when rewriting sequence values.

</details>
