### PR TITLE
fix(frontend): correct strictness of mirrored iceberg comparison pushdown

### DIFF
--- a/src/frontend/src/utils/iceberg_predicate.rs
+++ b/src/frontend/src/utils/iceberg_predicate.rs
@@ -172,7 +172,7 @@ fn rw_expr_to_iceberg_predicate(expr: &ExprImpl, fields: &[Field]) -> Option<Ice
                             let column_name = &fields[lhs.index].name;
                             let reference = Reference::new(column_name);
                             let datum = rw_literal_to_iceberg_datum(rhs)?;
-                            Some(reference.less_than_or_equal_to(datum))
+                            Some(reference.less_than(datum))
                         }
                         _ => None,
                     }
@@ -189,7 +189,7 @@ fn rw_expr_to_iceberg_predicate(expr: &ExprImpl, fields: &[Field]) -> Option<Ice
                             let column_name = &fields[lhs.index].name;
                             let reference = Reference::new(column_name);
                             let datum = rw_literal_to_iceberg_datum(rhs)?;
-                            Some(reference.less_than(datum))
+                            Some(reference.less_than_or_equal_to(datum))
                         }
                         _ => None,
                     }
@@ -206,7 +206,7 @@ fn rw_expr_to_iceberg_predicate(expr: &ExprImpl, fields: &[Field]) -> Option<Ice
                             let column_name = &fields[lhs.index].name;
                             let reference = Reference::new(column_name);
                             let datum = rw_literal_to_iceberg_datum(rhs)?;
-                            Some(reference.greater_than_or_equal_to(datum))
+                            Some(reference.greater_than(datum))
                         }
                         _ => None,
                     }
@@ -223,7 +223,7 @@ fn rw_expr_to_iceberg_predicate(expr: &ExprImpl, fields: &[Field]) -> Option<Ice
                             let column_name = &fields[lhs.index].name;
                             let reference = Reference::new(column_name);
                             let datum = rw_literal_to_iceberg_datum(rhs)?;
-                            Some(reference.greater_than(datum))
+                            Some(reference.greater_than_or_equal_to(datum))
                         }
                         _ => None,
                     }
@@ -268,5 +268,41 @@ fn rw_expr_to_iceberg_predicate(expr: &ExprImpl, fields: &[Field]) -> Option<Ice
             }
         }
         _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use risingwave_common::types::DataType;
+
+    use super::*;
+    use crate::expr::{FunctionCall, InputRef};
+
+    #[test]
+    fn comparison_pushdown_mirrors_flipped_operators() {
+        let fields = vec![Field::new("x", DataType::Int64)];
+        let col = || InputRef::new(0, DataType::Int64).into();
+        let lit = || Literal::new(Some(ScalarImpl::Int64(5)), DataType::Int64).into();
+
+        let cases: [(ExprType, ExprImpl, ExprImpl, &str); 12] = [
+            (ExprType::Equal, col(), lit(), "x = 5"),
+            (ExprType::Equal, lit(), col(), "x = 5"),
+            (ExprType::NotEqual, col(), lit(), "x != 5"),
+            (ExprType::NotEqual, lit(), col(), "x != 5"),
+            (ExprType::GreaterThan, col(), lit(), "x > 5"),
+            (ExprType::GreaterThan, lit(), col(), "x < 5"),
+            (ExprType::GreaterThanOrEqual, col(), lit(), "x >= 5"),
+            (ExprType::GreaterThanOrEqual, lit(), col(), "x <= 5"),
+            (ExprType::LessThan, col(), lit(), "x < 5"),
+            (ExprType::LessThan, lit(), col(), "x > 5"),
+            (ExprType::LessThanOrEqual, col(), lit(), "x <= 5"),
+            (ExprType::LessThanOrEqual, lit(), col(), "x >= 5"),
+        ];
+        for (op, arg0, arg1, expected) in cases {
+            let expr = FunctionCall::new(op, vec![arg0, arg1]).unwrap().into();
+            let predicate = rw_expr_to_iceberg_predicate(&expr, &fields)
+                .unwrap_or_else(|| panic!("{op:?} should be pushable"));
+            assert_eq!(predicate.to_string(), expected);
+        }
     }
 }


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

Fix the strictness of mirrored comparisons in iceberg predicate pushdown. When the literal is on the left, the arms mirror the operator direction correctly but crossed the strictness:

| SQL | pushed (before) | pushed (after) |
|---|---|---|
| `lit > col` | `col <= lit` | `col < lit` |
| `lit >= col` | `col < lit` | `col <= lit` |
| `lit < col` | `col >= lit` | `col > lit` |
| `lit <= col` | `col > lit` | `col >= lit` |

The pushed-down conjunction is removed from the RisingWave-side filter and iceberg-rust evaluates it row-level, so results at the boundary are wrong: e.g. `WHERE 5 > x` on an iceberg source returns rows with `x = 5`, and `WHERE 5 >= x` drops rows with `x = 5`.

A unit test pins all 12 operator × operand-order combinations against the rendered iceberg predicate.

## Checklist

- [x] I have written necessary rustdoc comments.
- [x] I have added necessary unit tests and integration tests.
- [x] I have added test labels as necessary.
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them.
- [ ] <!-- OPTIONAL --> My PR contains breaking changes.
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results.
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into.

## Documentation

- [ ] My PR needs documentation updates.
