### PR TITLE
feat(sink): support turbopuffer num_shards

### DIFF
--- a/e2e_test/sink/turbopuffer_sink.slt
+++ b/e2e_test/sink/turbopuffer_sink.slt
@@ -33,6 +33,7 @@ CREATE SINK tpuf_e2e_sink FROM tpuf_e2e_items WITH (
     disable_backpressure = 'true',
     full_text_search_columns = 'body,note_contents',
     filterable_columns = '*',
+    num_shards = 8,
     write_batch_size = 2,
     max_linger_second = 1
 );

--- a/e2e_test/sink/turbopuffer_sink_check.py
+++ b/e2e_test/sink/turbopuffer_sink_check.py
@@ -78,6 +78,7 @@ def main():
     )
     assert_equal(schema_body["distance_metric"], "cosine_distance", "distance metric")
     assert_equal(schema_body["disable_backpressure"], True, "disable_backpressure")
+    assert_equal(schema_body["sharding"]["num_shards"], 8, "num_shards")
 
     schema = schema_body["schema"]
     assert_equal(schema["body"]["type"], "string", "body type")

--- a/src/connector/src/sink/turbopuffer.rs
+++ b/src/connector/src/sink/turbopuffer.rs
@@ -66,6 +66,8 @@ pub struct TurbopufferConfig {
     pub distance_metric: Option<String>,
     #[serde_as(as = "Option<DisplayFromStr>")]
     pub disable_backpressure: Option<bool>,
+    #[serde_as(as = "Option<DisplayFromStr>")]
+    pub num_shards: Option<usize>,
     pub full_text_search_columns: Option<String>,
     pub filterable_columns: Option<String>,
     #[serde(default = "default_write_batch_size")]
@@ -99,6 +101,11 @@ impl TurbopufferConfig {
         if config.max_linger_second == 0 {
             return Err(SinkError::Config(anyhow!(
                 "`max_linger_second` must be greater than 0"
+            )));
+        }
+        if config.num_shards == Some(0) {
+            return Err(SinkError::Config(anyhow!(
+                "`num_shards` must be greater than 0"
             )));
         }
         Ok(config)
@@ -410,6 +417,7 @@ pub struct TurbopufferSinkWriter {
     base_url: String,
     distance_metric: Option<String>,
     disable_backpressure: Option<bool>,
+    num_shards: Option<usize>,
     schema: Value,
     pk_index: usize,
     namespace: TurbopufferNamespace,
@@ -459,6 +467,7 @@ impl TurbopufferSinkWriter {
             base_url,
             distance_metric: config.distance_metric,
             disable_backpressure: config.disable_backpressure,
+            num_shards: config.num_shards,
             schema: generated_schema,
             pk_index,
             namespace,
@@ -541,6 +550,14 @@ impl TurbopufferSinkWriter {
                 "distance_metric".to_owned(),
                 Value::String(distance_metric.clone()),
             );
+        }
+        if let Some(num_shards) = self.num_shards {
+            let mut sharding = Map::new();
+            sharding.insert(
+                "num_shards".to_owned(),
+                serde_json::to_value(num_shards).expect("serialize num_shards"),
+            );
+            body.insert("sharding".to_owned(), Value::Object(sharding));
         }
         if !upsert_rows.is_empty() {
             if let Some(disable_backpressure) = self.disable_backpressure {
@@ -929,6 +946,7 @@ mod tests {
             api_key: "tpuf_test_key".to_owned(),
             distance_metric: None,
             disable_backpressure: Some(true),
+            num_shards: Some(8),
             full_text_search_columns: Some("body".to_owned()),
             filterable_columns: Some("*".to_owned()),
             write_batch_size: DEFAULT_WRITE_BATCH_SIZE,
@@ -965,6 +983,7 @@ mod tests {
         let body = request.split("\r\n\r\n").nth(1).unwrap();
         let body: Value = serde_json::from_str(body).unwrap();
         assert_eq!(body["disable_backpressure"], json!(true));
+        assert_eq!(body["sharding"]["num_shards"], json!(8));
         assert_eq!(body["schema"]["body"]["type"], json!("string"));
         assert_eq!(body["schema"]["body"]["filterable"], json!(true));
         assert_eq!(body["schema"]["body"]["full_text_search"], json!(true));
@@ -986,6 +1005,7 @@ mod tests {
         .unwrap();
         assert_eq!(config.write_batch_size, DEFAULT_WRITE_BATCH_SIZE);
         assert_eq!(config.max_linger_second, DEFAULT_MAX_LINGER_SECOND);
+        assert_eq!(config.num_shards, None);
 
         let err = TurbopufferConfig::from_btreemap(BTreeMap::from([
             ("base_url".to_owned(), "http://127.0.0.1:0".to_owned()),
@@ -1006,6 +1026,16 @@ mod tests {
         ]))
         .unwrap_err();
         assert!(err.to_string().contains("max_linger_second"));
+
+        let err = TurbopufferConfig::from_btreemap(BTreeMap::from([
+            ("base_url".to_owned(), "http://127.0.0.1:0".to_owned()),
+            ("namespace".to_owned(), "ns".to_owned()),
+            ("api_key".to_owned(), "key".to_owned()),
+            ("type".to_owned(), "upsert".to_owned()),
+            ("num_shards".to_owned(), "0".to_owned()),
+        ]))
+        .unwrap_err();
+        assert!(err.to_string().contains("num_shards"));
     }
 
     #[test]
@@ -1037,6 +1067,7 @@ mod tests {
             api_key: "tpuf_test_key".to_owned(),
             distance_metric: None,
             disable_backpressure: None,
+            num_shards: None,
             full_text_search_columns: None,
             filterable_columns: None,
             write_batch_size: 2,
@@ -1097,6 +1128,7 @@ mod tests {
             api_key: "tpuf_test_key".to_owned(),
             distance_metric: None,
             disable_backpressure: None,
+            num_shards: None,
             full_text_search_columns: None,
             filterable_columns: None,
             write_batch_size: DEFAULT_WRITE_BATCH_SIZE,
@@ -1358,6 +1390,7 @@ mod tests {
             api_key: "tpuf_test_key".to_owned(),
             distance_metric: Some("cosine_distance".to_owned()),
             disable_backpressure: Some(true),
+            num_shards: Some(32),
             full_text_search_columns: Some(
                 "content,content_segments,user_name,user_identifier,title".to_owned(),
             ),
@@ -1414,6 +1447,7 @@ mod tests {
 
         assert_eq!(body["distance_metric"], json!("cosine_distance"));
         assert_eq!(body["disable_backpressure"], json!(true));
+        assert_eq!(body["sharding"]["num_shards"], json!(32));
         assert_eq!(body["schema"], generated_schema);
         assert_eq!(body["upsert_rows"][0]["id"], json!("doc-1"));
         assert_eq!(body["upsert_rows"][0]["content"], json!("content text"));
@@ -1518,6 +1552,7 @@ mod tests {
             api_key: "tpuf_test_key".to_owned(),
             distance_metric: None,
             disable_backpressure: None,
+            num_shards: None,
             full_text_search_columns: None,
             filterable_columns: None,
             write_batch_size,

--- a/src/connector/with_options_sink.yaml
+++ b/src/connector/with_options_sink.yaml
@@ -1888,6 +1888,9 @@ TurbopufferConfig:
   - name: disable_backpressure
     field_type: bool
     required: false
+  - name: num_shards
+    field_type: usize
+    required: false
   - name: full_text_search_columns
     field_type: String
     required: false


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

This PR adds support for configuring turbopuffer namespace sharding from a RisingWave turbopuffer sink.

- Adds an optional `num_shards` sink option.
- Validates `num_shards > 0` when specified.
- Sends turbopuffer's write API payload as `sharding.num_shards` when configured.
- Keeps the option out of alter-on-fly metadata because turbopuffer only allows sharding to be configured on a namespace's inaugural write.
- Extends turbopuffer sink unit and mock-backed e2e checks to cover the generated write payload.

Turbopuffer rejects adding or changing sharding for an existing namespace. RisingWave passes the configured value through on writes and surfaces turbopuffer's error if the target namespace already exists with incompatible sharding.

## Checklist

- [ ] I have written necessary rustdoc comments.
- [x] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [x] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [x] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

Turbopuffer sinks now support a `num_shards` option for configuring turbopuffer namespace sharding on the namespace's first write.

</details>
