### PR TITLE
fix(optimizer): preserve asof left join left predicates

### DIFF
--- a/src/frontend/planner_test/tests/testdata/input/asof_join.yaml
+++ b/src/frontend/planner_test/tests/testdata/input/asof_join.yaml
@@ -38,13 +38,14 @@
     - stream_plan
     - batch_plan
 
-- sql:
+- name: asof left outer join should not push left-only on predicate
+  sql:
     CREATE TABLE t1(v1 varchar, v2 int, v3 int);
     CREATE TABLE t2(v1 varchar, v2 int, v3 int);
     SELECT t1.v1 t1_v1, t1.v2 t1_v2, t2.v1 t2_v1, t2.v2 t2_v2 FROM t1 ASOF LEFT JOIN t2 ON t1.v1 = t2.v1 and t1.v2 *2 < t2.v2 and t1.v2 < 10 and t2.v2 < 10;
   expected_outputs:
-    - stream_plan
-    - batch_plan
+    - stream_error
+    - batch_error
 
 - sql:
     CREATE TABLE t1(v1 varchar, v2 int, v3 int);

--- a/src/frontend/planner_test/tests/testdata/output/asof_join.yaml
+++ b/src/frontend/planner_test/tests/testdata/output/asof_join.yaml
@@ -78,27 +78,10 @@
         │     └─StreamTableScan { table: t1, columns: [t1.v1, t1.v2, t1._row_id], stream_scan_type: SnapshotBackfill, stream_key: [t1._row_id], pk: [_row_id], dist: UpstreamHashShard(t1._row_id) }
         └─StreamExchange { dist: HashShard(t2.v1) }
           └─StreamTableScan { table: t2, columns: [t2.v1, t2.v2, t2._row_id], stream_scan_type: SnapshotBackfill, stream_key: [t2._row_id], pk: [_row_id], dist: UpstreamHashShard(t2._row_id) }
-- sql: CREATE TABLE t1(v1 varchar, v2 int, v3 int); CREATE TABLE t2(v1 varchar, v2 int, v3 int); SELECT t1.v1 t1_v1, t1.v2 t1_v2, t2.v1 t2_v1, t2.v2 t2_v2 FROM t1 ASOF LEFT JOIN t2 ON t1.v1 = t2.v1 and t1.v2 *2 < t2.v2 and t1.v2 < 10 and t2.v2 < 10;
-  batch_plan: |-
-    BatchExchange { order: [], dist: Single }
-    └─BatchHashJoin { type: AsofLeftOuter, predicate: t1.v1 = t2.v1 AND ($expr1 < t2.v2), output: [t1.v1, t1.v2, t2.v1, t2.v2] }
-      ├─BatchExchange { order: [], dist: HashShard(t1.v1) }
-      │ └─BatchProject { exprs: [t1.v1, t1.v2, (t1.v2 * 2:Int32) as $expr1] }
-      │   └─BatchFilter { predicate: (t1.v2 < 10:Int32) }
-      │     └─BatchScan { table: t1, columns: [t1.v1, t1.v2], distribution: SomeShard }
-      └─BatchExchange { order: [], dist: HashShard(t2.v1) }
-        └─BatchFilter { predicate: (t2.v2 < 10:Int32) }
-          └─BatchScan { table: t2, columns: [t2.v1, t2.v2], distribution: SomeShard }
-  stream_plan: |-
-    StreamMaterialize { columns: [t1_v1, t1_v2, t2_v1, t2_v2, t1._row_id(hidden), t2._row_id(hidden)], stream_key: [t1._row_id, t2._row_id, t1_v1], pk_columns: [t1._row_id, t2._row_id, t1_v1], pk_conflict: NoCheck }
-    └─StreamAsOfJoin { type: AsofLeftOuter, predicate: t1.v1 = t2.v1 AND ($expr1 < t2.v2), output: [t1.v1, t1.v2, t2.v1, t2.v2, t1._row_id, t2._row_id] }
-      ├─StreamExchange { dist: HashShard(t1.v1) }
-      │ └─StreamProject { exprs: [t1.v1, t1.v2, (t1.v2 * 2:Int32) as $expr1, t1._row_id] }
-      │   └─StreamFilter { predicate: (t1.v2 < 10:Int32) }
-      │     └─StreamTableScan { table: t1, columns: [t1.v1, t1.v2, t1._row_id], stream_scan_type: SnapshotBackfill, stream_key: [t1._row_id], pk: [_row_id], dist: UpstreamHashShard(t1._row_id) }
-      └─StreamExchange { dist: HashShard(t2.v1) }
-        └─StreamFilter { predicate: (t2.v2 < 10:Int32) }
-          └─StreamTableScan { table: t2, columns: [t2.v1, t2.v2, t2._row_id], stream_scan_type: SnapshotBackfill, stream_key: [t2._row_id], pk: [_row_id], dist: UpstreamHashShard(t2._row_id) }
+- name: asof left outer join should not push left-only on predicate
+  sql: CREATE TABLE t1(v1 varchar, v2 int, v3 int); CREATE TABLE t2(v1 varchar, v2 int, v3 int); SELECT t1.v1 t1_v1, t1.v2 t1_v2, t2.v1 t2_v1, t2.v2 t2_v2 FROM t1 ASOF LEFT JOIN t2 ON t1.v1 = t2.v1 and t1.v2 *2 < t2.v2 and t1.v2 < 10 and t2.v2 < 10;
+  batch_error: 'Invalid input syntax: AsOf join requires exactly 1 ineuquality condition'
+  stream_error: 'Invalid input syntax: AsOf join requires exactly 1 ineuquality condition'
 - sql: CREATE TABLE t1(v1 varchar, v2 int, v3 int); CREATE TABLE t2(v1 varchar, v2 int, v3 int); SELECT t1.v1 t1_v1, t1.v2 t1_v2, t2.v1 t2_v1, t2.v2 t2_v2 FROM t1 ASOF JOIN t2 ON t1.v1 = t2.v1 and t1.v2 < t2.v2 and t1.v3 < t2.v3;
   batch_error: 'Invalid input syntax: AsOf join requires exactly 1 ineuquality condition'
   stream_error: 'Invalid input syntax: AsOf join requires exactly 1 ineuquality condition'

--- a/src/frontend/src/optimizer/plan_node/generic/join.rs
+++ b/src/frontend/src/optimizer/plan_node/generic/join.rs
@@ -768,11 +768,7 @@ pub fn can_push_on_from_filter(ty: JoinType) -> bool {
 pub fn can_push_left_from_on(ty: JoinType) -> bool {
     matches!(
         ty,
-        JoinType::Inner
-            | JoinType::RightOuter
-            | JoinType::LeftSemi
-            | JoinType::AsofInner
-            | JoinType::AsofLeftOuter
+        JoinType::Inner | JoinType::RightOuter | JoinType::LeftSemi | JoinType::AsofInner
     )
 }
 


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

- Prevent `can_push_left_from_on` from allowing left-only `ON` predicates to be pushed below `ASOF LEFT OUTER JOIN`.
- This preserves the left side of `ASOF LEFT OUTER JOIN`: a left-only `ON` predicate should decide whether the row matches the right side, not filter the preserved left row before the join.
- If the existing ASOF join lowering path cannot handle the retained predicate, returning an error is preferable to silently changing left outer join semantics.
- Add planner-test coverage so an `ASOF LEFT OUTER JOIN` with a left-only `ON` predicate now expects the existing ASOF residual-predicate error instead of a plan that filters the left input.

Verification:

- `git diff --check`
- Not run: planner test runner, to avoid triggering cargo compilation per request.

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

Fixes optimizer behavior for `ASOF LEFT OUTER JOIN` so preserved-side `ON` predicates are not pushed below the join and used to filter left rows before join matching.

</details>
