### PR TITLE
feat(connector): support ADLS deltalake sink

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4389,6 +4389,7 @@ dependencies = [
  "buoyant_kernel",
  "ctor 0.10.1",
  "deltalake-aws",
+ "deltalake-azure",
  "deltalake-core",
  "deltalake-gcp",
 ]
@@ -4418,6 +4419,20 @@ dependencies = [
  "typed-builder 0.23.0",
  "url",
  "uuid",
+]
+
+[[package]]
+name = "deltalake-azure"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1b7099351f8d452374d75eda599cd7633a50f4a36ec318532ec6c5d1f9d908d"
+dependencies = [
+ "bytes",
+ "deltalake-core",
+ "object_store",
+ "thiserror 2.0.17",
+ "tokio",
+ "url",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -153,7 +153,7 @@ axum-extra = "0.10"
 chrono = { version = "0.4.40", default-features = false }
 clap = { version = "4", features = ["cargo", "derive", "env"] }
 criterion = { version = "0.8", features = ["async_futures"] }
-deltalake = { version = "0.32.0", features = ["s3", "gcs"] }
+deltalake = { version = "0.32.0", features = ["s3", "gcs", "azure"] }
 faiss = { version = "0.12.2-alpha.0", features = ["static"] }
 foyer = { version = "0.21.2", features = ["serde", "tracing"] }
 futures-async-stream = "0.2.13"

--- a/ci/scripts/e2e-deltalake-sink-rust-test.sh
+++ b/ci/scripts/e2e-deltalake-sink-rust-test.sh
@@ -33,6 +33,16 @@ e2e_test/commands/deltalake_prepare
 
 echo "--- testing sinks"
 sqllogictest -p 4566 -d dev './e2e_test/sink/deltalake_rust_sink.slt'
+if [[ -n "${RISEDEV_DELTALAKE_ADLS_LOCATION:-}" ]]; then
+    : "${RISEDEV_DELTALAKE_ADLS_ACCOUNT_NAME:?missing}"
+    : "${RISEDEV_DELTALAKE_ADLS_ACCOUNT_KEY:?missing}"
+    : "${RISEDEV_DELTALAKE_ADLS_ENDPOINT:?missing}"
+
+    echo "--- testing ADLS deltalake sink"
+    sqllogictest -p 4566 -d dev './e2e_test/sink/deltalake_adls_sink.slt'
+else
+    echo "--- skipping ADLS deltalake sink test because RISEDEV_DELTALAKE_ADLS_LOCATION is not set"
+fi
 sleep 1
 
 SPARK_VERSION=4.0.2

--- a/e2e_test/sink/deltalake_adls_sink.slt
+++ b/e2e_test/sink/deltalake_adls_sink.slt
@@ -1,0 +1,45 @@
+control substitution on
+
+statement ok
+set sink_decouple = false;
+
+statement ok
+CREATE TABLE t_adls (v1 int primary key, v2 smallint, v3 bigint, v4 real, v5 float, v6 varchar, v7 date, v8 timestamptz, v9 boolean, v10 decimal, v11 decimal[]);
+
+statement ok
+CREATE MATERIALIZED VIEW mv_adls AS SELECT * FROM t_adls;
+
+statement ok
+CREATE SECRET deltalake_adls_account_key WITH (
+  backend = 'meta'
+) as '${RISEDEV_DELTALAKE_ADLS_ACCOUNT_KEY}';
+
+statement ok
+create sink s_adls as select * from mv_adls
+with (
+    connector = 'deltalake',
+    type = 'append-only',
+    force_append_only = 'true',
+    location = '${RISEDEV_DELTALAKE_ADLS_LOCATION}',
+    adlsgen2.account_name = '${RISEDEV_DELTALAKE_ADLS_ACCOUNT_NAME}',
+    adlsgen2.account_key = secret deltalake_adls_account_key,
+    adlsgen2.endpoint = '${RISEDEV_DELTALAKE_ADLS_ENDPOINT}'
+);
+
+statement ok
+INSERT INTO t_adls VALUES (1, 1, 1, 1.1, 1.2, 'test', '2013-01-01', '2013-01-01 01:01:01+00:00', false, 1, array[1]::decimal[]);
+
+statement ok
+FLUSH;
+
+statement ok
+DROP SINK s_adls;
+
+statement ok
+DROP SECRET deltalake_adls_account_key;
+
+statement ok
+DROP MATERIALIZED VIEW mv_adls;
+
+statement ok
+DROP TABLE t_adls;

--- a/src/connector/src/sink/deltalake.rs
+++ b/src/connector/src/sink/deltalake.rs
@@ -56,6 +56,7 @@ use crate::sink::{
 
 pub const DEFAULT_REGION: &str = "us-east-1";
 pub const GCS_SERVICE_ACCOUNT: &str = "service_account_key";
+const ADLS_DEFAULT_AUTHORITY_HOST: &str = "https://login.microsoftonline.com";
 
 pub const DELTALAKE_SINK: &str = "deltalake";
 
@@ -69,6 +70,21 @@ pub struct DeltaLakeCommon {
 
     #[serde(rename = "gcs.service.account")]
     pub gcs_service_account: Option<String>,
+
+    #[serde(rename = "adlsgen2.account_name")]
+    pub adlsgen2_account_name: Option<String>,
+    #[serde(rename = "adlsgen2.account_key")]
+    pub adlsgen2_account_key: Option<String>,
+    #[serde(rename = "adlsgen2.endpoint")]
+    pub adlsgen2_endpoint: Option<String>,
+    #[serde(rename = "adlsgen2.tenant_id")]
+    pub adlsgen2_tenant_id: Option<String>,
+    #[serde(rename = "adlsgen2.client_id")]
+    pub adlsgen2_client_id: Option<String>,
+    #[serde(rename = "adlsgen2.client_secret")]
+    pub adlsgen2_client_secret: Option<String>,
+    #[serde(rename = "adlsgen2.authority_host")]
+    pub adlsgen2_authority_host: Option<String>,
     /// Commit every n(>0) checkpoints, default is 10.
     #[serde(default = "default_commit_checkpoint_interval")]
     #[serde_as(as = "DisplayFromStr")]
@@ -79,6 +95,8 @@ pub struct DeltaLakeCommon {
 impl EnforceSecret for DeltaLakeCommon {
     const ENFORCE_SECRET_PROPERTIES: Set<&'static str> = phf_set! {
         "gcs.service.account",
+        "adlsgen2.account_key",
+        "adlsgen2.client_secret",
     };
 
     fn enforce_one(prop: &str) -> crate::error::ConnectorResult<()> {
@@ -122,6 +140,12 @@ impl DeltaLakeCommon {
                 let url = Url::parse(&gcs_path).map_err(|e| SinkError::DeltaLake(anyhow!(e)))?;
                 deltalake::open_table_with_storage_options(url, storage_options).await?
             }
+            DeltaTableUrl::Azure(azure_path) => {
+                let storage_options = self.build_delta_lake_config_for_adls()?;
+                deltalake::azure::register_handlers(None);
+                let url = Self::normalize_adls_url(&azure_path).map_err(SinkError::DeltaLake)?;
+                deltalake::open_table_with_storage_options(url, storage_options).await?
+            }
         };
         Ok(table)
     }
@@ -131,13 +155,170 @@ impl DeltaLakeCommon {
             Ok(DeltaTableUrl::S3(path.to_owned()))
         } else if path.starts_with("gs://") {
             Ok(DeltaTableUrl::Gcs(path.to_owned()))
+        } else if path.starts_with("abfs://")
+            || path.starts_with("abfss://")
+            || path.starts_with("az://")
+            || path.starts_with("adl://")
+            || path.starts_with("azure://")
+            || Self::is_adls_https_url(path)
+        {
+            Ok(DeltaTableUrl::Azure(path.to_owned()))
         } else if let Some(path) = path.strip_prefix("file://") {
             Ok(DeltaTableUrl::Local(path.to_owned()))
         } else {
             Err(SinkError::DeltaLake(anyhow!(
-                "path should start with 's3://','s3a://'(s3) ,gs://(gcs) or file://(local)"
+                "path should start with 's3://','s3a://'(s3), gs://(gcs), abfs:// or abfss://(adls), https://<account>.dfs.core.windows.net/<container>/...(adls), or file://(local)"
             )))
         }
+    }
+
+    fn is_adls_https_url(path: &str) -> bool {
+        Url::parse(path)
+            .ok()
+            .filter(|url| url.scheme() == "https")
+            .and_then(|url| url.host_str().map(str::to_owned))
+            .is_some_and(|host| {
+                host.ends_with(".dfs.core.windows.net")
+                    || host.ends_with(".blob.core.windows.net")
+                    || host.ends_with(".dfs.fabric.microsoft.com")
+                    || host.ends_with(".blob.fabric.microsoft.com")
+            })
+    }
+
+    fn normalize_adls_url(path: &str) -> std::result::Result<Url, anyhow::Error> {
+        let url = Url::parse(path)?;
+        if url.scheme() != "https" {
+            return Ok(url);
+        }
+
+        let host = url
+            .host_str()
+            .ok_or_else(|| anyhow!("ADLS HTTPS URL must include a host"))?;
+        let mut segments = url
+            .path_segments()
+            .ok_or_else(|| anyhow!("ADLS HTTPS URL must include a container path segment"))?
+            .filter(|segment| !segment.is_empty());
+        let container = segments
+            .next()
+            .ok_or_else(|| anyhow!("ADLS HTTPS URL must include a container path segment"))?;
+        if container.contains('.') {
+            return Err(anyhow!("ADLS container name must not contain '.'"));
+        }
+
+        let mut abfss_path = format!("abfss://{}@{}", container, host);
+        let rest: Vec<_> = segments.collect();
+        if !rest.is_empty() {
+            abfss_path.push('/');
+            abfss_path.push_str(&rest.join("/"));
+        }
+        if let Some(query) = url.query() {
+            abfss_path.push('?');
+            abfss_path.push_str(query);
+        }
+        Url::parse(&abfss_path).map_err(Into::into)
+    }
+
+    fn build_delta_lake_config_for_adls(&self) -> Result<HashMap<String, String>> {
+        fn nonempty(v: &Option<String>) -> Option<&str> {
+            v.as_deref().filter(|s| !s.trim().is_empty())
+        }
+
+        let account_name = nonempty(&self.adlsgen2_account_name);
+        let account_key = nonempty(&self.adlsgen2_account_key);
+        let endpoint = nonempty(&self.adlsgen2_endpoint);
+        let tenant_id = nonempty(&self.adlsgen2_tenant_id);
+        let client_id = nonempty(&self.adlsgen2_client_id);
+        let client_secret = nonempty(&self.adlsgen2_client_secret);
+        let authority_host = nonempty(&self.adlsgen2_authority_host);
+
+        let any_sp_field = tenant_id.is_some()
+            || client_id.is_some()
+            || client_secret.is_some()
+            || authority_host.is_some();
+        let all_sp_required = tenant_id.is_some() && client_id.is_some() && client_secret.is_some();
+
+        if account_key.is_some() && any_sp_field {
+            return Err(SinkError::Config(anyhow!(
+                "adlsgen2: cannot configure both shared-key auth \
+                 (adlsgen2.account_key) and service-principal auth \
+                 (adlsgen2.tenant_id / adlsgen2.client_id / adlsgen2.client_secret / \
+                 adlsgen2.authority_host) simultaneously. Specify exactly one auth mode."
+            )));
+        }
+        if any_sp_field && !all_sp_required {
+            return Err(SinkError::Config(anyhow!(
+                "adlsgen2: service-principal auth requires all three of \
+                 adlsgen2.tenant_id, adlsgen2.client_id, and adlsgen2.client_secret \
+                 to be set. (adlsgen2.authority_host is optional and defaults to the \
+                 public Azure AAD endpoint.)"
+            )));
+        }
+
+        if let Some(host) = authority_host {
+            let parsed = Url::parse(host).map_err(|_| {
+                SinkError::Config(anyhow!(
+                    "adlsgen2.authority_host does not parse as a URL ({} chars)",
+                    host.len()
+                ))
+            })?;
+            if parsed.scheme() != "https" {
+                return Err(SinkError::Config(anyhow!(
+                    "adlsgen2.authority_host must use the https scheme, got {}",
+                    parsed.scheme()
+                )));
+            }
+            if !parsed.username().is_empty() || parsed.password().is_some() {
+                return Err(SinkError::Config(anyhow!(
+                    "adlsgen2.authority_host must not contain userinfo"
+                )));
+            }
+            if parsed.query().is_some() || parsed.fragment().is_some() {
+                return Err(SinkError::Config(anyhow!(
+                    "adlsgen2.authority_host must not contain a query or fragment"
+                )));
+            }
+            if !matches!(parsed.path(), "" | "/") {
+                return Err(SinkError::Config(anyhow!(
+                    "adlsgen2.authority_host must not contain a path component"
+                )));
+            }
+        }
+
+        let mut storage_options = HashMap::new();
+        if let Some(account_name) = account_name {
+            storage_options.insert(
+                "azure_storage_account_name".to_owned(),
+                account_name.to_owned(),
+            );
+        }
+        if let Some(account_key) = account_key {
+            storage_options.insert(
+                "azure_storage_account_key".to_owned(),
+                account_key.to_owned(),
+            );
+        }
+        if let Some(endpoint) = endpoint {
+            storage_options.insert("azure_storage_endpoint".to_owned(), endpoint.to_owned());
+        }
+        if let (Some(tenant_id), Some(client_id), Some(client_secret)) =
+            (tenant_id, client_id, client_secret)
+        {
+            storage_options.insert("azure_storage_tenant_id".to_owned(), tenant_id.to_owned());
+            storage_options.insert("azure_storage_client_id".to_owned(), client_id.to_owned());
+            storage_options.insert(
+                "azure_storage_client_secret".to_owned(),
+                client_secret.to_owned(),
+            );
+            storage_options.insert(
+                "azure_storage_authority_host".to_owned(),
+                authority_host
+                    .unwrap_or(ADLS_DEFAULT_AUTHORITY_HOST)
+                    .trim_end_matches('/')
+                    .to_owned(),
+            );
+        }
+
+        Ok(storage_options)
     }
 
     async fn build_delta_lake_config_for_aws(&self) -> Result<HashMap<String, String>> {
@@ -188,6 +369,7 @@ enum DeltaTableUrl {
     S3(String),
     Local(String),
     Gcs(String),
+    Azure(String),
 }
 
 #[serde_as]
@@ -750,9 +932,125 @@ mod tests {
     use risingwave_common::catalog::{Field, Schema};
     use risingwave_common::types::DataType;
 
-    use super::{DeltaLakeConfig, DeltaLakeSinkCommitter, DeltaLakeSinkWriter};
+    use super::{DeltaLakeCommon, DeltaLakeConfig, DeltaLakeSinkCommitter, DeltaLakeSinkWriter};
     use crate::sink::writer::SinkWriter;
     use crate::sink::{SinglePhaseCommitCoordinator, TwoPhaseCommitCoordinator};
+
+    #[test]
+    fn test_adls_table_url_detection() {
+        assert!(matches!(
+            DeltaLakeCommon::get_table_url("abfss://standard@xxx.dfs.core.windows.net/yyy/abc")
+                .unwrap(),
+            super::DeltaTableUrl::Azure(_)
+        ));
+        assert!(matches!(
+            DeltaLakeCommon::get_table_url("https://xxx.dfs.core.windows.net/standard/yyy/abc")
+                .unwrap(),
+            super::DeltaTableUrl::Azure(_)
+        ));
+    }
+
+    #[test]
+    fn test_normalize_adls_https_url() {
+        let url = DeltaLakeCommon::normalize_adls_url(
+            "https://xxx.dfs.core.windows.net/standard/yyy/abc",
+        )
+        .unwrap();
+        assert_eq!(
+            url.as_str(),
+            "abfss://standard@xxx.dfs.core.windows.net/yyy/abc"
+        );
+
+        let url = DeltaLakeCommon::normalize_adls_url(
+            "abfss://standard@xxx.dfs.core.windows.net/yyy/abc",
+        )
+        .unwrap();
+        assert_eq!(
+            url.as_str(),
+            "abfss://standard@xxx.dfs.core.windows.net/yyy/abc"
+        );
+    }
+
+    #[test]
+    fn test_build_adls_shared_key_config() {
+        let properties = btreemap! {
+            "connector".to_owned() => "deltalake".to_owned(),
+            "type".to_owned() => "append-only".to_owned(),
+            "location".to_owned() => "abfss://standard@xxx.dfs.core.windows.net/yyy/abc".to_owned(),
+            "adlsgen2.account_name".to_owned() => "xxx".to_owned(),
+            "adlsgen2.account_key".to_owned() => "shared-key".to_owned(),
+            "adlsgen2.endpoint".to_owned() => "https://xxx.dfs.core.windows.net".to_owned(),
+        };
+
+        let config = DeltaLakeConfig::from_btreemap(properties).unwrap();
+        let storage_options = config.common.build_delta_lake_config_for_adls().unwrap();
+        assert_eq!(
+            storage_options.get("azure_storage_account_name").unwrap(),
+            "xxx"
+        );
+        assert_eq!(
+            storage_options.get("azure_storage_account_key").unwrap(),
+            "shared-key"
+        );
+        assert_eq!(
+            storage_options.get("azure_storage_endpoint").unwrap(),
+            "https://xxx.dfs.core.windows.net"
+        );
+    }
+
+    #[test]
+    fn test_build_adls_service_principal_config() {
+        let properties = btreemap! {
+            "connector".to_owned() => "deltalake".to_owned(),
+            "type".to_owned() => "append-only".to_owned(),
+            "location".to_owned() => "abfss://standard@xxx.dfs.core.windows.net/yyy/abc".to_owned(),
+            "adlsgen2.account_name".to_owned() => "xxx".to_owned(),
+            "adlsgen2.tenant_id".to_owned() => "tenant".to_owned(),
+            "adlsgen2.client_id".to_owned() => "client".to_owned(),
+            "adlsgen2.client_secret".to_owned() => "secret".to_owned(),
+            "adlsgen2.authority_host".to_owned() => "https://login.microsoftonline.us/".to_owned(),
+        };
+
+        let config = DeltaLakeConfig::from_btreemap(properties).unwrap();
+        let storage_options = config.common.build_delta_lake_config_for_adls().unwrap();
+        assert_eq!(
+            storage_options.get("azure_storage_tenant_id").unwrap(),
+            "tenant"
+        );
+        assert_eq!(
+            storage_options.get("azure_storage_client_id").unwrap(),
+            "client"
+        );
+        assert_eq!(
+            storage_options.get("azure_storage_client_secret").unwrap(),
+            "secret"
+        );
+        assert_eq!(
+            storage_options.get("azure_storage_authority_host").unwrap(),
+            "https://login.microsoftonline.us"
+        );
+    }
+
+    #[test]
+    fn test_adls_rejects_mixed_auth_config() {
+        let properties = btreemap! {
+            "connector".to_owned() => "deltalake".to_owned(),
+            "type".to_owned() => "append-only".to_owned(),
+            "location".to_owned() => "abfss://standard@xxx.dfs.core.windows.net/yyy/abc".to_owned(),
+            "adlsgen2.account_key".to_owned() => "shared-key".to_owned(),
+            "adlsgen2.tenant_id".to_owned() => "tenant".to_owned(),
+            "adlsgen2.client_id".to_owned() => "client".to_owned(),
+            "adlsgen2.client_secret".to_owned() => "secret".to_owned(),
+        };
+
+        let config = DeltaLakeConfig::from_btreemap(properties).unwrap();
+        let error = config
+            .common
+            .build_delta_lake_config_for_adls()
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("cannot configure both shared-key auth"));
+    }
 
     #[tokio::test]
     async fn test_deltalake() {

--- a/src/connector/with_options_sink.yaml
+++ b/src/connector/with_options_sink.yaml
@@ -202,6 +202,27 @@ DeltaLakeConfig:
   - name: gcs.service.account
     field_type: String
     required: false
+  - name: adlsgen2.account_name
+    field_type: String
+    required: false
+  - name: adlsgen2.account_key
+    field_type: String
+    required: false
+  - name: adlsgen2.endpoint
+    field_type: String
+    required: false
+  - name: adlsgen2.tenant_id
+    field_type: String
+    required: false
+  - name: adlsgen2.client_id
+    field_type: String
+    required: false
+  - name: adlsgen2.client_secret
+    field_type: String
+    required: false
+  - name: adlsgen2.authority_host
+    field_type: String
+    required: false
   - name: commit_checkpoint_interval
     field_type: u64
     comments: Commit every n(>0) checkpoints, default is 10.


### PR DESCRIPTION
## What changed

- Adds Azure ADLS Gen2 support to the DeltaLake sink by enabling the `deltalake` Azure feature and registering Azure handlers.
- Accepts native `abfs://` / `abfss://` Delta locations and HTTPS DFS/Blob/Fabric locations such as `https://<account>.dfs.core.windows.net/<container>/<path>`.
- Adds `adlsgen2.*` sink options for shared-key and service-principal authentication, with secret enforcement for sensitive fields.
- Normalizes HTTPS ADLS locations to ABFSS form before opening the Delta table.
- Adds focused unit coverage for ADLS URL detection, HTTPS normalization, auth option mapping, and mixed-auth rejection.

## Why

DeltaLake sink previously accepted only S3, GCS, and local file locations. Users could not sink Delta tables to ADLS locations even though the underlying Delta Lake crate supports Azure storage handlers.

## Validation

- `cargo check -p risingwave_connector --features sink-deltalake`
- `cargo test -p risingwave_connector --features sink-deltalake sink::deltalake::tests -- --nocapture`

## Notes

- The focused test run passed. It emitted existing macOS linker warnings from native dependencies, but no test failures.
