### PR TITLE
fix(meta): don't panic on hummock timer child cancellation during shutdown

### DIFF
--- a/src/meta/src/hummock/manager/timer_task.rs
+++ b/src/meta/src/hummock/manager/timer_task.rs
@@ -300,6 +300,20 @@ async fn supervise_child_loops(
                 Ok(()) => {
                     panic!("Hummock timer handler loop [{name}] exited unexpectedly");
                 }
+                // A cancellation means the runtime is aborting detached tasks during shutdown;
+                // treat it as a benign shutdown signal and drain the rest instead of failing.
+                Err(e) if e.is_cancelled() => {
+                    let _ = child_shutdown_tx.send(true);
+                    while let Some((name, result)) = child_handles.next().await {
+                        if let Err(e) = result {
+                            warn!(
+                                handler = name,
+                                error = %e.as_report(),
+                                "Hummock timer handler loop failed during shutdown"
+                            );
+                        }
+                    }
+                }
                 Err(e) => {
                     panic!("Hummock timer handler loop [{name}] failed: {}", e.as_report());
                 }


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

The Hummock timer task's per-handler supervisor (`supervise_child_loops` in `src/meta/src/hummock/manager/timer_task.rs`) treats **any** child loop that finishes before shutdown as a fatal partial failure and `panic!`s. This is wrong during graceful shutdown:

1. On ctrl-c the meta server returns from `start_service` and drops the timer's shutdown `oneshot::Sender` **without sending** (the `TODO(shutdown)` path), so the supervisor's `shutdown_rx` becomes ready.
2. `runtime.shutdown_background()` then **aborts** the still-running, detached child loops (they were `tokio::spawn`-ed, so dropping their `JoinHandle`s did not stop them). The aborted child's `handle.await` resolves to `Err(JoinError::Cancelled)`.
3. At that point **both** arms of the supervisor's top-level `tokio::select!` are ready. Since `select!` is unbiased, it can pick the child-completion arm and `panic!` on the `Cancelled` error — even though the exact same cancellation is tolerated (just `warn!`) in the shutdown arm.

The process still exits `0`, but the panic writes a `panicked at` line to `meta-node-*.log`, which trips CI's post-test `check-logs` step (`grep "panicked at"`) and intermittently fails otherwise-green e2e jobs. It is a flake, not a product regression, and it is unrelated to whatever PR happens to be running when it fires. Introduced by #24773 (`refactor(meta): split hummock timer task into per-handler loops`).

**Fix:** in the child-completion arm, classify a cancelled `JoinError` (`e.is_cancelled()`) as a benign shutdown signal — signal the remaining children and drain them instead of panicking. Genuine partial failures still fail fast: a child that exits on its own (`Ok(())`) or one that actually panicked (`is_panic()`) still triggers the `panic!`.

- Closes #26220

## Checklist

- [x] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

</details>
