### PR TITLE
feat(sink): support HTTP sink batch size

### DIFF
--- a/ci/scripts/e2e-sink-test.sh
+++ b/ci/scripts/e2e-sink-test.sh
@@ -71,8 +71,29 @@ grep -Fx '{"key":"value"}' "$HTTP_SINK_OUTPUT"
 grep -q '"event"' "$HTTP_SINK_OUTPUT"
 grep -Fx 'dynamic url payload' "$HTTP_SINK_OUTPUT"
 grep -Fx 'dynamic url as select payload' "$HTTP_SINK_OUTPUT"
-# Exactly 1 line from ignore_delete test + 2 from varchar test (NULL was skipped) + 1 from jsonb + 2 from dynamic URL tests
-test "$(wc -l < "$HTTP_SINK_OUTPUT")" -eq 6
+python3 - "$HTTP_SINK_OUTPUT" <<'PY'
+import json
+import sys
+
+batch_values = []
+with open(sys.argv[1]) as f:
+    for line in f:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            body = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if set(body) == {"batch"}:
+            batch_values.append(body["batch"])
+
+assert batch_values == [1, 2, 3], batch_values
+PY
+# Exactly 1 line from ignore_delete test + 2 from varchar test (NULL was skipped) + 1 from jsonb + 2 from dynamic URL tests + 3 from batched payload test
+test "$(wc -l < "$HTTP_SINK_OUTPUT")" -eq 9
+# The batched payload test writes 3 rows with batch_size = 2, producing 2 HTTP requests.
+test "$(wc -l < "$HTTP_SINK_HEADERS")" -eq 8
 # Verify the custom header set via header.x_test = 'rw-http-sink' was sent
 grep -q '"x_test": "rw-http-sink"' "$HTTP_SINK_HEADERS"
 # Verify inferred default content types for varchar and jsonb payloads

--- a/ci/scripts/e2e-sink-test.sh
+++ b/ci/scripts/e2e-sink-test.sh
@@ -88,7 +88,7 @@ with open(sys.argv[1]) as f:
         if set(body) == {"batch"}:
             batch_values.append(body["batch"])
 
-assert batch_values == [1, 2, 3], batch_values
+assert sorted(batch_values) == [1, 2, 3], batch_values
 PY
 # Exactly 1 line from ignore_delete test + 2 from varchar test (NULL was skipped) + 1 from jsonb + 2 from dynamic URL tests + 3 from batched payload test
 test "$(wc -l < "$HTTP_SINK_OUTPUT")" -eq 9

--- a/e2e_test/sink/http_sink.slt
+++ b/e2e_test/sink/http_sink.slt
@@ -136,6 +136,53 @@ CREATE SINK s_auto_schema_change FROM t_auto_schema_change WITH (
 statement ok
 DROP TABLE t_auto_schema_change;
 
+# ---- Validation: batch_size must be positive ----
+statement ok
+CREATE TABLE t_bad_batch_size (payload jsonb);
+
+statement error `batch_size` must be greater than 0
+CREATE SINK s_bad_batch_size FROM t_bad_batch_size WITH (
+    connector = 'http',
+    url = 'http://localhost:18081',
+    type = 'append-only',
+    force_append_only = 'true',
+    batch_size = '0'
+);
+
+statement ok
+DROP TABLE t_bad_batch_size;
+
+# ---- Validation: text payloads do not support batch_size ----
+statement ok
+CREATE TABLE t_text_batch_size (payload varchar);
+
+statement error HTTP sink batch_size option only supports jsonb payload
+CREATE SINK s_text_batch_size FROM t_text_batch_size WITH (
+    connector = 'http',
+    url = 'http://localhost:18081',
+    type = 'append-only',
+    force_append_only = 'true',
+    batch_size = '2'
+);
+
+statement ok
+DROP TABLE t_text_batch_size;
+
+# ---- Validation: batched payloads require static url ----
+statement ok
+CREATE TABLE t_dynamic_url_batch_size (payload jsonb, url varchar);
+
+statement error HTTP sink batch_size greater than 1 does not support dynamic url column
+CREATE SINK s_dynamic_url_batch_size FROM t_dynamic_url_batch_size WITH (
+    connector = 'http',
+    type = 'append-only',
+    force_append_only = 'true',
+    batch_size = '2'
+);
+
+statement ok
+DROP TABLE t_dynamic_url_batch_size;
+
 # ---- Success: ignore_delete allows non-append-only input ----
 statement ok
 CREATE TABLE t_ignore_delete_src (payload varchar);
@@ -273,3 +320,28 @@ DROP SINK s_dynamic_url_as_select;
 
 statement ok
 DROP TABLE t_dynamic_url_as_select_src;
+
+# ---- Success: batched payloads are line-separated ----
+statement ok
+CREATE TABLE t_batched_payload (payload jsonb);
+
+statement ok
+CREATE SINK s_batched_payload FROM t_batched_payload WITH (
+    connector = 'http',
+    url = 'http://localhost:18081',
+    type = 'append-only',
+    force_append_only = 'true',
+    batch_size = '2'
+);
+
+statement ok
+INSERT INTO t_batched_payload VALUES ('{"batch":1}'::jsonb), ('{"batch":2}'::jsonb), ('{"batch":3}'::jsonb);
+
+statement ok
+FLUSH;
+
+statement ok
+DROP SINK s_batched_payload;
+
+statement ok
+DROP TABLE t_batched_payload;

--- a/src/connector/src/sink/http.rs
+++ b/src/connector/src/sink/http.rs
@@ -21,6 +21,7 @@ use risingwave_common::catalog::Schema;
 use risingwave_common::row::Row;
 use risingwave_common::types::{DataType, JsonbRef, ScalarRefImpl};
 use serde::Deserialize;
+use serde_with::{DisplayFromStr, serde_as};
 use thiserror_ext::AsReport;
 use with_options::WithOptions;
 
@@ -34,7 +35,9 @@ use crate::sink::{Result, SINK_TYPE_APPEND_ONLY, Sink, SinkError, SinkParam, Sin
 pub const HTTP_SINK: &str = "http";
 const HTTP_SINK_PAYLOAD_COLUMN: &str = "payload";
 const HTTP_SINK_URL_COLUMN: &str = "url";
+const DEFAULT_HTTP_SINK_BATCH_SIZE: usize = 1;
 
+#[serde_as]
 #[derive(Clone, Debug, Deserialize, WithOptions)]
 pub struct HttpConfig {
     /// The endpoint URL to POST data to.
@@ -43,6 +46,10 @@ pub struct HttpConfig {
     /// Content-Type header value. Defaults to `text/plain` for `varchar` and `application/json`
     /// for `jsonb`.
     pub content_type: Option<String>,
+
+    /// Maximum number of JSON payload rows to include in one HTTP request.
+    #[serde_as(as = "Option<DisplayFromStr>")]
+    pub batch_size: Option<usize>,
 
     /// Sink type, must be "append-only".
     pub r#type: String,
@@ -78,6 +85,11 @@ impl HttpConfig {
                 "HTTP sink only supports append-only mode"
             )));
         }
+        if config.batch_size == Some(0) {
+            return Err(SinkError::Config(anyhow!(
+                "`batch_size` must be greater than 0"
+            )));
+        }
 
         Ok((config, headers))
     }
@@ -97,6 +109,7 @@ fn validate_http_sink(
     schema: &Schema,
     url: Option<&str>,
     content_type: Option<&str>,
+    batch_size: Option<usize>,
     headers: &BTreeMap<String, String>,
     unknown_fields: std::collections::HashMap<String, String>,
 ) -> Result<HttpSink> {
@@ -180,6 +193,17 @@ fn validate_http_sink(
             payload_type
         )));
     }
+    if payload_type != DataType::Jsonb && batch_size.is_some() {
+        return Err(SinkError::Config(anyhow!(
+            "HTTP sink batch_size option only supports jsonb payload"
+        )));
+    }
+    let batch_size = batch_size.unwrap_or(DEFAULT_HTTP_SINK_BATCH_SIZE);
+    if batch_size > 1 && matches!(url, HttpUrl::Dynamic { .. }) {
+        return Err(SinkError::Config(anyhow!(
+            "HTTP sink batch_size greater than 1 does not support dynamic url column"
+        )));
+    }
 
     let mut header_map = HeaderMap::new();
     header_map.insert(
@@ -210,6 +234,7 @@ fn validate_http_sink(
         url,
         payload_index,
         header_map,
+        batch_size,
         unknown_fields,
     })
 }
@@ -219,6 +244,7 @@ pub struct HttpSink {
     url: HttpUrl,
     payload_index: usize,
     header_map: HeaderMap,
+    batch_size: usize,
     unknown_fields: std::collections::HashMap<String, String>,
 }
 
@@ -245,6 +271,7 @@ impl TryFrom<SinkParam> for HttpSink {
             &schema,
             config.url.as_deref(),
             config.content_type.as_deref(),
+            config.batch_size,
             &headers,
             config.unknown_fields,
         )
@@ -269,6 +296,7 @@ impl Sink for HttpSink {
             self.url.clone(),
             self.payload_index,
             self.header_map.clone(),
+            self.batch_size,
         )?
         .into_log_sinker(usize::MAX))
     }
@@ -278,10 +306,16 @@ pub struct HttpSinkWriter {
     client: reqwest::Client,
     url: HttpUrl,
     payload_index: usize,
+    batch_size: usize,
 }
 
 impl HttpSinkWriter {
-    fn new(url: HttpUrl, payload_index: usize, header_map: HeaderMap) -> Result<Self> {
+    fn new(
+        url: HttpUrl,
+        payload_index: usize,
+        header_map: HeaderMap,
+        batch_size: usize,
+    ) -> Result<Self> {
         let client = reqwest::Client::builder()
             .default_headers(header_map)
             .build()
@@ -292,6 +326,7 @@ impl HttpSinkWriter {
             client,
             url,
             payload_index,
+            batch_size,
         })
     }
 
@@ -346,6 +381,29 @@ impl HttpSinkWriter {
             }
             None => None, // skip NULL rows
         })
+    }
+
+    async fn send_payload(&self, url: reqwest::Url, payload: String) -> Result<()> {
+        let resp = self
+            .client
+            .post(url)
+            .body(payload)
+            .send()
+            .await
+            .context("HTTP request failed")
+            .map_err(SinkError::Http)?;
+
+        if !resp.status().is_success() {
+            let status = resp.status();
+            let body = resp.text().await.unwrap_or_default();
+            return Err(SinkError::Http(anyhow!(
+                "HTTP sink received non-success response: {} {}",
+                status,
+                body
+            )));
+        }
+
+        Ok(())
     }
 }
 
@@ -416,35 +474,54 @@ impl AsyncTruncateSinkWriter for HttpSinkWriter {
         chunk: StreamChunk,
         _add_future: DeliveryFutureManagerAddFuture<'a, Self::DeliveryFuture>,
     ) -> Result<()> {
-        for (op, row) in chunk.rows() {
-            if op != Op::Insert {
-                continue;
+        if self.batch_size == 1 {
+            for (op, row) in chunk.rows() {
+                if op != Op::Insert {
+                    continue;
+                }
+
+                let Some(payload) = self.extract_payload(&row)? else {
+                    continue;
+                };
+                let Some(url) = self.extract_url(&row)? else {
+                    continue;
+                };
+
+                self.send_payload(url, payload).await?;
+            }
+        } else {
+            let HttpUrl::Static(url) = &self.url else {
+                return Err(SinkError::Http(anyhow!(
+                    "HTTP sink batch_size greater than 1 requires static url"
+                )));
+            };
+            let mut payload_buffer = String::new();
+            let mut payload_count = 0;
+
+            for (op, row) in chunk.rows() {
+                if op != Op::Insert {
+                    continue;
+                }
+
+                let Some(payload) = self.extract_payload(&row)? else {
+                    continue;
+                };
+
+                if payload_count > 0 {
+                    payload_buffer.push('\n');
+                }
+                payload_buffer.push_str(&payload);
+                payload_count += 1;
+
+                if payload_count >= self.batch_size {
+                    self.send_payload(url.clone(), std::mem::take(&mut payload_buffer))
+                        .await?;
+                    payload_count = 0;
+                }
             }
 
-            let Some(payload) = self.extract_payload(&row)? else {
-                continue;
-            };
-            let Some(url) = self.extract_url(&row)? else {
-                continue;
-            };
-
-            let resp = self
-                .client
-                .post(url)
-                .body(payload)
-                .send()
-                .await
-                .context("HTTP request failed")
-                .map_err(SinkError::Http)?;
-
-            if !resp.status().is_success() {
-                let status = resp.status();
-                let body = resp.text().await.unwrap_or_default();
-                return Err(SinkError::Http(anyhow!(
-                    "HTTP sink received non-success response: {} {}",
-                    status,
-                    body
-                )));
+            if payload_count > 0 {
+                self.send_payload(url.clone(), payload_buffer).await?;
             }
         }
 

--- a/src/connector/with_options_sink.yaml
+++ b/src/connector/with_options_sink.yaml
@@ -463,6 +463,10 @@ HttpConfig:
       Content-Type header value. Defaults to `text/plain` for `varchar` and `application/json`
       for `jsonb`.
     required: false
+  - name: batch_size
+    field_type: usize
+    comments: Maximum number of JSON payload rows to include in one HTTP request.
+    required: false
   - name: r#type
     field_type: String
     comments: Sink type, must be "append-only".


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

This PR adds `batch_size` support to the HTTP sink for JSON payloads. When `batch_size` is greater than 1, the sink sends multiple JSON payload rows in a single HTTP request body, separated by newlines.

The option is intentionally limited to static-URL JSONB payload sinks:

- text payloads reject explicit `batch_size`;
- dynamic URL sinks reject `batch_size > 1`;
- `batch_size = 1` preserves the existing single-row request path and dynamic URL behavior.

The HTTP sink SLT and sink CI assertions now cover invalid batch sizes, text payload rejection, dynamic URL rejection, and the line-separated JSON batch output.

## Checklist

- [ ] I have written necessary rustdoc comments.
- [x] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [x] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [x] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

HTTP sink now supports batching JSONB payload rows with the `batch_size` option. Batched request bodies contain one JSON payload per line.

</details>
