### PR TITLE
fix(meta): self-heal orphan iceberg maintenance entries for deleted sinks

### DIFF
--- a/src/meta/node/src/server.rs
+++ b/src/meta/node/src/server.rs
@@ -513,6 +513,7 @@ pub async fn start_service_as_election_leader(
         source_manager.clone(),
         sink_manager.clone(),
         iceberg_pk_index_sink_manager.clone(),
+        iceberg_compaction_mgr.clone(),
         scale_controller.clone(),
         barrier_scheduler.clone(),
         refresh_manager.clone(),
@@ -536,6 +537,7 @@ pub async fn start_service_as_election_leader(
             hummock_manager.clone(),
             source_manager.clone(),
             refresh_manager.clone(),
+            iceberg_compaction_mgr.clone(),
             scale_controller.clone(),
         )
         .unwrap(),

--- a/src/meta/src/barrier/context/mod.rs
+++ b/src/meta/src/barrier/context/mod.rs
@@ -42,6 +42,7 @@ use crate::barrier::{
     RecoveryReason, Scheduled, SnapshotBackfillInfo,
 };
 use crate::hummock::{CommitEpochInfo, HummockManagerRef};
+use crate::manager::iceberg_compaction::IcebergCompactionManagerRef;
 use crate::manager::iceberg_pk_index_sink::IcebergPkIndexSinkManager;
 use crate::manager::sink_coordination::SinkCoordinatorManager;
 use crate::manager::{MetaSrvEnv, MetadataManager};
@@ -195,6 +196,8 @@ pub(super) struct GlobalBarrierWorkerContextImpl {
     sink_manager: SinkCoordinatorManager,
 
     pub(super) iceberg_pk_index_sink_manager: IcebergPkIndexSinkManager,
+
+    pub(super) iceberg_compaction_manager: IcebergCompactionManagerRef,
 }
 
 impl GlobalBarrierWorkerContextImpl {
@@ -211,6 +214,7 @@ impl GlobalBarrierWorkerContextImpl {
         refresh_manager: GlobalRefreshManagerRef,
         sink_manager: SinkCoordinatorManager,
         iceberg_pk_index_sink_manager: IcebergPkIndexSinkManager,
+        iceberg_compaction_manager: IcebergCompactionManagerRef,
     ) -> Self {
         Self {
             scheduled_barriers,
@@ -224,6 +228,7 @@ impl GlobalBarrierWorkerContextImpl {
             refresh_manager,
             sink_manager,
             iceberg_pk_index_sink_manager,
+            iceberg_compaction_manager,
         }
     }
 

--- a/src/meta/src/barrier/context/recovery.rs
+++ b/src/meta/src/barrier/context/recovery.rs
@@ -432,6 +432,10 @@ impl GlobalBarrierWorkerContextImpl {
             .catalog_controller
             .clean_dirty_creating_jobs(database_id)
             .await?;
+        for sink_id in &cleaned_dirty_jobs.sink_ids {
+            self.iceberg_compaction_manager
+                .clear_iceberg_maintenance_by_sink_id(*sink_id);
+        }
         if database_id.is_some() {
             // Per-database recovery does not run the global Hummock purge below. Unregister the
             // dirty jobs cleaned in this database through the normal dropped-table cleanup path.

--- a/src/meta/src/barrier/manager.rs
+++ b/src/meta/src/barrier/manager.rs
@@ -39,6 +39,7 @@ use crate::barrier::{
     RecoveryReason, UpdateDatabaseBarrierRequest, schedule,
 };
 use crate::hummock::HummockManagerRef;
+use crate::manager::iceberg_compaction::IcebergCompactionManagerRef;
 use crate::manager::iceberg_pk_index_sink::IcebergPkIndexSinkManager;
 use crate::manager::sink_coordination::SinkCoordinatorManager;
 use crate::manager::{MetaSrvEnv, MetadataManager};
@@ -193,6 +194,7 @@ impl GlobalBarrierManager {
 }
 
 impl GlobalBarrierManager {
+    #[expect(clippy::too_many_arguments)]
     pub async fn start(
         scheduled_barriers: schedule::ScheduledBarriers,
         env: MetaSrvEnv,
@@ -201,6 +203,7 @@ impl GlobalBarrierManager {
         source_manager: SourceManagerRef,
         sink_manager: SinkCoordinatorManager,
         iceberg_pk_index_sink_manager: IcebergPkIndexSinkManager,
+        iceberg_compaction_manager: IcebergCompactionManagerRef,
         scale_controller: ScaleControllerRef,
         barrier_scheduler: schedule::BarrierScheduler,
         refresh_manager: GlobalRefreshManagerRef,
@@ -216,6 +219,7 @@ impl GlobalBarrierManager {
             source_manager,
             sink_manager,
             iceberg_pk_index_sink_manager,
+            iceberg_compaction_manager,
             scale_controller,
             request_rx,
             barrier_scheduler,

--- a/src/meta/src/barrier/worker.rs
+++ b/src/meta/src/barrier/worker.rs
@@ -57,6 +57,7 @@ use crate::barrier::{
 use crate::controller::scale::{materialize_actor_assignments, preview_actor_assignments};
 use crate::error::MetaErrorInner;
 use crate::hummock::HummockManagerRef;
+use crate::manager::iceberg_compaction::IcebergCompactionManagerRef;
 use crate::manager::iceberg_pk_index_sink::IcebergPkIndexSinkManager;
 use crate::manager::sink_coordination::SinkCoordinatorManager;
 use crate::manager::{
@@ -310,6 +311,7 @@ impl GlobalBarrierWorker<GlobalBarrierWorkerContextImpl> {
         source_manager: SourceManagerRef,
         sink_manager: SinkCoordinatorManager,
         iceberg_pk_index_sink_manager: IcebergPkIndexSinkManager,
+        iceberg_compaction_manager: IcebergCompactionManagerRef,
         scale_controller: ScaleControllerRef,
         request_rx: mpsc::UnboundedReceiver<BarrierManagerRequest>,
         barrier_scheduler: schedule::BarrierScheduler,
@@ -329,6 +331,7 @@ impl GlobalBarrierWorker<GlobalBarrierWorkerContextImpl> {
             refresh_manager,
             sink_manager,
             iceberg_pk_index_sink_manager,
+            iceberg_compaction_manager,
         ));
 
         Self::new_inner(env, request_rx, context).await

--- a/src/meta/src/controller/catalog/drop_op.rs
+++ b/src/meta/src/controller/catalog/drop_op.rs
@@ -219,22 +219,24 @@ impl CatalogController {
             .map(|(sink, obj)| ObjectModel(sink, obj.unwrap(), None).into())
             .collect();
 
-        // Collect Iceberg pk-index sink ids among dropped sinks so the pk-index sink manager
-        // can tear down their per-sink commit workers. Unlike the iceberg-table
-        // cleanup above, pk-index sinks are user-created with arbitrary names, so we
-        // identify them by inspecting properties rather than by name prefix.
-        let removed_iceberg_pk_index_sink_ids: Vec<SinkId> = Sink::find()
+        // Iceberg sinks (and the pk-index subset) can be user-created with arbitrary
+        // names, so unlike the iceberg-table cleanup above, identify them by
+        // inspecting properties rather than by name prefix.
+        let mut removed_iceberg_sink_ids: Vec<SinkId> = Vec::new();
+        let mut removed_iceberg_pk_index_sink_ids: Vec<SinkId> = Vec::new();
+        for sink in Sink::find()
             .filter(sink::Column::SinkId.is_in(removed_object_ids.clone()))
             .all(&txn)
             .await?
-            .into_iter()
-            .filter_map(|sink| {
-                crate::manager::iceberg_pk_index_sink::is_iceberg_pk_index_sink(
-                    sink.properties.inner_ref(),
-                )
-                .then_some(sink.sink_id)
-            })
-            .collect();
+        {
+            let properties = sink.properties.inner_ref();
+            if crate::manager::iceberg_compaction::is_iceberg_sink(properties) {
+                removed_iceberg_sink_ids.push(sink.sink_id);
+            }
+            if crate::manager::iceberg_pk_index_sink::is_iceberg_pk_index_sink(properties) {
+                removed_iceberg_pk_index_sink_ids.push(sink.sink_id);
+            }
+        }
 
         let removed_streaming_job_ids: Vec<JobId> = StreamingJob::find()
             .select_only()
@@ -448,6 +450,7 @@ impl CatalogController {
                 removed_fragments,
                 removed_sink_fragment_by_targets,
                 removed_iceberg_table_sinks,
+                removed_iceberg_sink_ids,
                 removed_iceberg_pk_index_sink_ids,
             },
             version,

--- a/src/meta/src/controller/catalog/mod.rs
+++ b/src/meta/src/controller/catalog/mod.rs
@@ -143,6 +143,10 @@ pub struct ReleaseContext {
     /// Dropped iceberg table sinks
     pub(crate) removed_iceberg_table_sinks: Vec<PbSink>,
 
+    /// Dropped iceberg sink ids. Used to clear iceberg maintenance (compaction
+    /// schedule and snapshot expiration) in `IcebergCompactionManager`.
+    pub(crate) removed_iceberg_sink_ids: Vec<SinkId>,
+
     /// Dropped Iceberg pk-index sink ids. Used to unregister per-sink commit workers
     /// owned by `IcebergPkIndexSinkManager`. Filtered via `is_iceberg_pk_index_sink` on
     /// the sink properties so user-created pk-index sinks (any name) are included.

--- a/src/meta/src/controller/catalog/mod.rs
+++ b/src/meta/src/controller/catalog/mod.rs
@@ -159,6 +159,8 @@ pub(crate) struct CleanedDirtyStreamingJobs {
     /// Only populated for per-database recovery.
     pub(crate) dropped_table_ids: Vec<TableId>,
     pub(crate) source_ids: Vec<SourceId>,
+    /// Cleaned dirty sink jobs, whose iceberg maintenance state must be cleared.
+    pub(crate) sink_ids: Vec<SinkId>,
 }
 
 impl CatalogController {
@@ -515,6 +517,11 @@ impl CatalogController {
             .iter()
             .map(|obj| obj.oid.as_job_id())
             .collect_vec();
+        let dirty_sink_ids = dirty_job_objs
+            .iter()
+            .filter(|obj| obj.obj_type == ObjectType::Sink)
+            .map(|obj| obj.oid.as_sink_id())
+            .collect_vec();
         let dirty_job_table_ids = dirty_job_ids
             .iter()
             .map(|job_id| job_id.as_mv_table_id())
@@ -663,6 +670,7 @@ impl CatalogController {
             streaming_job_ids: dirty_job_ids,
             dropped_table_ids,
             source_ids: dirty_associated_source_ids,
+            sink_ids: dirty_sink_ids,
         })
     }
 

--- a/src/meta/src/controller/catalog/test.rs
+++ b/src/meta/src/controller/catalog/test.rs
@@ -390,9 +390,9 @@ mod tests {
         txn.commit().await?;
         drop(inner);
 
-        let (aborted, database_id) = mgr.try_abort_creating_streaming_job(job_id, true).await?;
-        assert!(aborted);
-        assert_eq!(database_id, Some(TEST_DATABASE_ID));
+        let abort_result = mgr.try_abort_creating_streaming_job(job_id, true).await?;
+        assert!(abort_result.aborted);
+        assert_eq!(abort_result.database_id, Some(TEST_DATABASE_ID));
 
         let err = rx
             .await

--- a/src/meta/src/controller/streaming_job.rs
+++ b/src/meta/src/controller/streaming_job.rs
@@ -100,6 +100,18 @@ use crate::model::{
 use crate::stream::SplitAssignment;
 use crate::{MetaError, MetaResult};
 
+/// Result of [`CatalogController::try_abort_creating_streaming_job`].
+pub struct AbortCreatingJobResult {
+    /// The job was aborted by this call or already gone. `false` means a background job
+    /// that has progressed past the initial status was left untouched.
+    pub aborted: bool,
+    /// The database of the job, if the job was found.
+    pub database_id: Option<DatabaseId>,
+    /// The aborted sink, if the aborted job was a sink; the caller should clear its iceberg
+    /// maintenance state via `IcebergCompactionManager::clear_maintenance_for_aborted_job`.
+    pub aborted_sink_id: Option<SinkId>,
+}
+
 fn serverless_backfill_resource_group_placeholder(job_id: JobId) -> String {
     format!("SERVERLESS_BACKFILL_RESOURCE_GROUP_TBD_FOR_{job_id}")
 }
@@ -881,14 +893,12 @@ impl CatalogController {
     }
 
     /// `try_abort_creating_streaming_job` is used to abort the job that is under initial status or in `FOREGROUND` mode.
-    /// It returns (true, _) if the job is not found or aborted.
-    /// It returns (_, Some(`database_id`)) is the `database_id` of the `job_id` exists
     #[await_tree::instrument]
     pub async fn try_abort_creating_streaming_job(
         &self,
         mut job_id: JobId,
         is_cancelled: bool,
-    ) -> MetaResult<(bool, Option<DatabaseId>)> {
+    ) -> MetaResult<AbortCreatingJobResult> {
         let mut inner = self.inner.write().await;
         let txn = inner.db.begin().await?;
 
@@ -898,7 +908,11 @@ impl CatalogController {
                 id = %job_id,
                 "streaming job not found when aborting creating, might be cancelled already or cleaned by recovery"
             );
-            return Ok((true, None));
+            return Ok(AbortCreatingJobResult {
+                aborted: true,
+                database_id: None,
+                aborted_sink_id: None,
+            });
         };
         let database_id = obj
             .database_id
@@ -920,7 +934,11 @@ impl CatalogController {
                         id = %job_id,
                         "streaming job is created in background and still in creating status"
                     );
-                    return Ok((false, Some(database_id)));
+                    return Ok(AbortCreatingJobResult {
+                        aborted: false,
+                        database_id: Some(database_id),
+                        aborted_sink_id: None,
+                    });
                 }
             }
         }
@@ -1085,7 +1103,13 @@ impl CatalogController {
             self.notify_frontend(Operation::Delete, build_object_group_for_delete(objs))
                 .await;
         }
-        Ok((true, Some(database_id)))
+        let aborted_sink_id =
+            (original_obj_type == ObjectType::Sink).then(|| original_job_id.as_sink_id());
+        Ok(AbortCreatingJobResult {
+            aborted: true,
+            database_id: Some(database_id),
+            aborted_sink_id,
+        })
     }
 
     #[await_tree::instrument]

--- a/src/meta/src/manager/iceberg_compaction/gc.rs
+++ b/src/meta/src/manager/iceberg_compaction/gc.rs
@@ -87,7 +87,11 @@ impl IcebergCompactionManager {
     pub async fn check_and_expire_snapshots(&self, sink_id: SinkId) -> MetaResult<()> {
         let now = chrono::Utc::now().timestamp_millis();
 
-        let iceberg_config = self.load_iceberg_config(sink_id).await?;
+        let Some(iceberg_config) = self.load_iceberg_config(sink_id).await? else {
+            // The sink is gone but a removal path missed the maintenance cleanup.
+            self.remove_orphan_iceberg_maintenance(sink_id, "gc");
+            return Ok(());
+        };
         if !iceberg_config.enable_snapshot_expiration {
             let mut guard = self.inner.write();
             guard.snapshot_expiration_sink_ids.remove(&sink_id);

--- a/src/meta/src/manager/iceberg_compaction/mod.rs
+++ b/src/meta/src/manager/iceberg_compaction/mod.rs
@@ -21,7 +21,6 @@ use std::collections::{BTreeMap, HashMap, HashSet};
 use std::sync::Arc;
 use std::time::Duration;
 
-use anyhow::anyhow;
 use parking_lot::RwLock;
 use risingwave_common::id::WorkerId;
 use risingwave_connector::sink::SinkParam;
@@ -104,22 +103,46 @@ impl IcebergCompactionManager {
         )
     }
 
-    async fn get_sink_param(&self, sink_id: SinkId) -> MetaResult<SinkParam> {
-        let prost_sink_catalog = self
+    /// `Ok(None)` means the sink no longer exists in the catalog; transient
+    /// metastore errors are propagated as `Err`.
+    async fn get_sink_param(&self, sink_id: SinkId) -> MetaResult<Option<SinkParam>> {
+        let Some(prost_sink_catalog) = self
             .metadata_manager
             .catalog_controller
             .get_sink_by_id(sink_id)
             .await?
-            .ok_or_else(|| anyhow!("Sink not found: {}", sink_id))?;
+        else {
+            return Ok(None);
+        };
         let sink_catalog = SinkCatalog::from(prost_sink_catalog);
         let param = SinkParam::try_from_sink_catalog(sink_catalog)?;
-        Ok(param)
+        Ok(Some(param))
     }
 
-    async fn load_iceberg_config(&self, sink_id: SinkId) -> MetaResult<IcebergConfig> {
-        let sink_param = self.get_sink_param(sink_id).await?;
+    /// `Ok(None)` means the sink no longer exists in the catalog.
+    async fn load_iceberg_config(&self, sink_id: SinkId) -> MetaResult<Option<IcebergConfig>> {
+        let Some(sink_param) = self.get_sink_param(sink_id).await? else {
+            return Ok(None);
+        };
         let iceberg_config = IcebergConfig::from_btreemap(sink_param.properties)?;
-        Ok(iceberg_config)
+        Ok(Some(iceberg_config))
+    }
+
+    /// Removes maintenance entries for a sink that no longer exists in the
+    /// catalog, so a removal path that missed cleanup cannot leave permanent
+    /// orphans. Kept observable via an error log and a counter metric.
+    fn remove_orphan_iceberg_maintenance(&self, sink_id: SinkId, path: &str) {
+        tracing::error!(
+            iceberg_component = "compaction_scheduler",
+            iceberg_operation = path,
+            sink_id = %sink_id,
+            "iceberg_maintenance_orphan_sink_removed",
+        );
+        self.metrics
+            .iceberg_compaction_orphan_sink_removed_count
+            .with_label_values(&[path])
+            .inc();
+        self.clear_iceberg_maintenance_by_sink_id(sink_id);
     }
 
     /// Clear the iceberg maintenance state of the sink aborted by

--- a/src/meta/src/manager/iceberg_compaction/mod.rs
+++ b/src/meta/src/manager/iceberg_compaction/mod.rs
@@ -17,7 +17,7 @@ mod manual;
 mod schedule;
 mod stream;
 
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -26,7 +26,8 @@ use parking_lot::RwLock;
 use risingwave_common::id::WorkerId;
 use risingwave_connector::sink::SinkParam;
 use risingwave_connector::sink::catalog::{SinkCatalog, SinkId};
-use risingwave_connector::sink::iceberg::IcebergConfig;
+use risingwave_connector::sink::iceberg::{ICEBERG_SINK, IcebergConfig};
+use risingwave_connector::source::UPSTREAM_SOURCE_KEY;
 use risingwave_pb::iceberg_compaction::SubscribeIcebergCompactionEventRequest;
 use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender};
 use tonic::Streaming;
@@ -119,4 +120,12 @@ impl IcebergCompactionManager {
         let iceberg_config = IcebergConfig::from_btreemap(sink_param.properties)?;
         Ok(iceberg_config)
     }
+}
+
+/// User-created iceberg sinks have arbitrary names, so identify them by the
+/// connector property instead of the `__iceberg_sink_` name prefix.
+pub fn is_iceberg_sink(properties: &BTreeMap<String, String>) -> bool {
+    properties
+        .get(UPSTREAM_SOURCE_KEY)
+        .is_some_and(|connector| connector.eq_ignore_ascii_case(ICEBERG_SINK))
 }

--- a/src/meta/src/manager/iceberg_compaction/mod.rs
+++ b/src/meta/src/manager/iceberg_compaction/mod.rs
@@ -34,6 +34,7 @@ use tonic::Streaming;
 
 use super::MetaSrvEnv;
 use crate::MetaResult;
+use crate::controller::streaming_job::AbortCreatingJobResult;
 use crate::hummock::IcebergCompactorManagerRef;
 use crate::manager::MetadataManager;
 use crate::rpc::metrics::MetaMetrics;
@@ -119,6 +120,14 @@ impl IcebergCompactionManager {
         let sink_param = self.get_sink_param(sink_id).await?;
         let iceberg_config = IcebergConfig::from_btreemap(sink_param.properties)?;
         Ok(iceberg_config)
+    }
+
+    /// Clear the iceberg maintenance state of the sink aborted by
+    /// `try_abort_creating_streaming_job`, if any.
+    pub fn clear_maintenance_for_aborted_job(&self, abort_result: &AbortCreatingJobResult) {
+        if let Some(sink_id) = abort_result.aborted_sink_id {
+            self.clear_iceberg_maintenance_by_sink_id(sink_id);
+        }
     }
 }
 

--- a/src/meta/src/manager/iceberg_compaction/schedule.rs
+++ b/src/meta/src/manager/iceberg_compaction/schedule.rs
@@ -16,8 +16,8 @@ use std::collections::hash_map::Entry;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
+use anyhow::anyhow;
 use itertools::Itertools;
-use parking_lot::RwLock;
 use risingwave_connector::connector_common::{
     IcebergCommittedSnapshot, IcebergSinkCompactionUpdate,
 };
@@ -402,23 +402,16 @@ impl CompactionTrack {
 pub(crate) struct IcebergCompactionHandle {
     sink_id: SinkId,
     task_type: TaskType,
-    inner: Arc<RwLock<IcebergCompactionManagerInner>>,
-    metadata_manager: MetadataManager,
+    manager: IcebergCompactionManagerRef,
     handle_success: bool,
 }
 
 impl IcebergCompactionHandle {
-    fn new(
-        sink_id: SinkId,
-        task_type: TaskType,
-        inner: Arc<RwLock<IcebergCompactionManagerInner>>,
-        metadata_manager: MetadataManager,
-    ) -> Self {
+    fn new(sink_id: SinkId, task_type: TaskType, manager: IcebergCompactionManagerRef) -> Self {
         Self {
             sink_id,
             task_type,
-            inner,
-            metadata_manager,
+            manager,
             handle_success: false,
         }
     }
@@ -431,18 +424,18 @@ impl IcebergCompactionHandle {
         use risingwave_pb::iceberg_compaction::subscribe_iceberg_compaction_event_response::Event as IcebergResponseEvent;
 
         let Some(prost_sink_catalog) = self
+            .manager
             .metadata_manager
             .catalog_controller
             .get_sink_by_id(self.sink_id)
             .await?
         else {
-            tracing::warn!(
-                iceberg_component = "compaction_scheduler",
-                iceberg_operation = "dispatch_task",
-                sink_id = %self.sink_id,
-                task_id,
-                "iceberg_compaction_dispatch_sink_not_found",
-            );
+            // The sink is gone but a removal path missed the maintenance cleanup.
+            // Drop the orphan entries instead of reverting the track, so they
+            // cannot occupy dispatch slots forever.
+            self.handle_success = true;
+            self.manager
+                .remove_orphan_iceberg_maintenance(self.sink_id, "dispatch");
             return Ok(());
         };
         let sink_catalog = SinkCatalog::from(prost_sink_catalog);
@@ -458,7 +451,7 @@ impl IcebergCompactionHandle {
 
         if result.is_ok() {
             let mut should_cancel_sent_task = false;
-            let mut guard = self.inner.write();
+            let mut guard = self.manager.inner.write();
             let mut dispatched = false;
             if let Some(track) = guard.sink_schedules.get_mut(&self.sink_id)
                 && track.is_pending_dispatch()
@@ -504,7 +497,7 @@ impl IcebergCompactionHandle {
 impl Drop for IcebergCompactionHandle {
     fn drop(&mut self) {
         let waiter = {
-            let mut guard = self.inner.write();
+            let mut guard = self.manager.inner.write();
             if !self.handle_success
                 && let Some(track) = guard.sink_schedules.get_mut(&self.sink_id)
                 && track.is_pending_dispatch()
@@ -665,7 +658,11 @@ impl IcebergCompactionManager {
 
         let loaded_config = if should_refresh_config {
             match self.load_iceberg_config(sink_id).await {
-                Ok(config) => Some(config),
+                Ok(Some(config)) => Some(config),
+                Ok(None) => {
+                    tracing::warn!("Sink not found when loading iceberg config: {}", sink_id);
+                    None
+                }
                 Err(e) => {
                     tracing::warn!(
                         error = ?e.as_report(),
@@ -928,7 +925,7 @@ impl IcebergCompactionManager {
     }
 
     pub(crate) fn get_top_n_iceberg_commit_sink_ids(
-        &self,
+        self: &Arc<Self>,
         n: usize,
     ) -> Vec<IcebergCompactionHandle> {
         let now = Instant::now();
@@ -960,8 +957,7 @@ impl IcebergCompactionManager {
                     Some(IcebergCompactionHandle::new(
                         sink_id,
                         task_type,
-                        self.inner.clone(),
-                        self.metadata_manager.clone(),
+                        self.clone(),
                     ))
                 })
                 .collect();

--- a/src/meta/src/manager/iceberg_compaction/schedule/tests.rs
+++ b/src/meta/src/manager/iceberg_compaction/schedule/tests.rs
@@ -1061,8 +1061,7 @@ async fn test_pre_dispatch_failure_notifies_manual_waiter_and_removes_temporary_
     drop(IcebergCompactionHandle::new(
         sink_id,
         TaskType::Full,
-        manager.inner.clone(),
-        manager.metadata_manager.clone(),
+        manager.clone(),
     ));
 
     let error = rx.await.unwrap().unwrap_err();
@@ -1550,4 +1549,71 @@ async fn test_get_top_n_retries_timed_out_inflight_task() {
         track.state,
         CompactionTrackState::PendingDispatch { .. }
     ));
+}
+
+#[tokio::test]
+async fn test_send_compact_task_clears_orphan_maintenance() {
+    let manager = build_test_manager().await;
+    // Not present in the (empty) test catalog, simulating a leaked entry of a
+    // dropped sink.
+    let sink_id = SinkId::new(470);
+    let compactor_context_id = 1001.into();
+    let mut receiver = manager
+        .iceberg_compactor_manager
+        .add_compactor(compactor_context_id);
+    let now = Instant::now();
+    let track = new_track(now, 120, 2, 2);
+    let (tx, rx) = tokio::sync::oneshot::channel();
+    {
+        let mut guard = manager.inner.write();
+        guard.sink_schedules.insert(sink_id, track);
+        guard.snapshot_expiration_sink_ids.insert(sink_id);
+        guard.manual_compaction_waiters.insert(sink_id, tx);
+    }
+
+    let handles = manager.get_top_n_iceberg_commit_sink_ids(1);
+    assert_eq!(handles.len(), 1);
+    let compactor = manager
+        .iceberg_compactor_manager
+        .get_compactor(compactor_context_id)
+        .unwrap();
+    handles
+        .into_iter()
+        .next()
+        .unwrap()
+        .send_compact_task(compactor, 42)
+        .await
+        .unwrap();
+
+    {
+        let guard = manager.inner.read();
+        assert!(!guard.sink_schedules.contains_key(&sink_id));
+        assert!(!guard.snapshot_expiration_sink_ids.contains(&sink_id));
+        assert!(!guard.manual_compaction_waiters.contains_key(&sink_id));
+    }
+    rx.await.unwrap().unwrap_err();
+    // No task reached the compactor.
+    assert!(receiver.try_recv().is_err());
+    // The orphan is not re-selected on the next pull.
+    assert!(manager.get_top_n_iceberg_commit_sink_ids(1).is_empty());
+}
+
+#[tokio::test]
+async fn test_gc_clears_orphan_maintenance() {
+    let manager = build_test_manager().await;
+    let sink_id = SinkId::new(471);
+    let now = Instant::now();
+    {
+        let mut guard = manager.inner.write();
+        guard
+            .sink_schedules
+            .insert(sink_id, new_track(now, 120, 10, 0));
+        guard.snapshot_expiration_sink_ids.insert(sink_id);
+    }
+
+    manager.check_and_expire_snapshots(sink_id).await.unwrap();
+
+    let guard = manager.inner.read();
+    assert!(!guard.sink_schedules.contains_key(&sink_id));
+    assert!(!guard.snapshot_expiration_sink_ids.contains(&sink_id));
 }

--- a/src/meta/src/rpc/ddl_controller.rs
+++ b/src/meta/src/rpc/ddl_controller.rs
@@ -1239,12 +1239,14 @@ impl DdlController {
                 self.env.event_log_manager_ref().add_event_logs(vec![
                     risingwave_pb::meta::event_log::Event::CreateStreamJobFail(event),
                 ]);
-                let (aborted, _) = self
+                let abort_result = self
                     .metadata_manager
                     .catalog_controller
                     .try_abort_creating_streaming_job(job_id, is_cancelled)
                     .await?;
-                if aborted {
+                self.iceberg_compaction_manager
+                    .clear_maintenance_for_aborted_job(&abort_result);
+                if abort_result.aborted {
                     tracing::warn!(id = %job_id, is_cancelled, "aborted streaming job");
                     // FIXME: might also need other cleanup here
                     if let Some(source_id) = source_id {
@@ -1856,10 +1858,13 @@ impl DdlController {
             .await?;
         let version = match job_status {
             JobStatus::Initial => {
-                self.metadata_manager
+                let abort_result = self
+                    .metadata_manager
                     .catalog_controller
                     .try_abort_creating_streaming_job(job_id.id(), true)
                     .await?;
+                self.iceberg_compaction_manager
+                    .clear_maintenance_for_aborted_job(&abort_result);
                 IGNORED_NOTIFICATION_VERSION
             }
             JobStatus::Creating => {

--- a/src/meta/src/rpc/ddl_controller.rs
+++ b/src/meta/src/rpc/ddl_controller.rs
@@ -1453,6 +1453,7 @@ impl DdlController {
             removed_fragments,
             removed_sink_fragment_by_targets,
             removed_iceberg_table_sinks,
+            removed_iceberg_sink_ids,
             removed_iceberg_pk_index_sink_ids,
         } = release_ctx;
 
@@ -1530,13 +1531,15 @@ impl DdlController {
         // stop sink coordinators for iceberg table sinks
         if !iceberg_sink_ids.is_empty() {
             self.sink_manager
-                .stop_sink_coordinator(iceberg_sink_ids.clone())
+                .stop_sink_coordinator(iceberg_sink_ids)
                 .await;
+        }
 
-            for sink_id in iceberg_sink_ids {
-                self.iceberg_compaction_manager
-                    .clear_iceberg_maintenance_by_sink_id(sink_id);
-            }
+        // Covers user-created iceberg sinks dropped via CASCADE, which are not in
+        // `removed_iceberg_table_sinks` above.
+        for sink_id in removed_iceberg_sink_ids {
+            self.iceberg_compaction_manager
+                .clear_iceberg_maintenance_by_sink_id(sink_id);
         }
 
         // Unregister per-sink commit coordinators for any dropped pk-index iceberg sink,

--- a/src/meta/src/rpc/metrics.rs
+++ b/src/meta/src/rpc/metrics.rs
@@ -237,6 +237,11 @@ pub struct MetaMetrics {
     /// The number of compaction groups that have been triggered to move
     pub merge_compaction_group_count: IntCounterVec,
 
+    /// Orphan iceberg sink maintenance entries removed by self-healing, labeled
+    /// by the detection path ("dispatch" or "gc"). A non-zero rate means some
+    /// sink removal path failed to clean up iceberg maintenance.
+    pub iceberg_compaction_orphan_sink_removed_count: IntCounterVec,
+
     // ********************************** Auto Schema Change ************************************
     pub auto_schema_change_failure_cnt: LabelGuardedIntCounterVec,
     pub auto_schema_change_success_cnt: LabelGuardedIntCounterVec,
@@ -885,6 +890,14 @@ impl MetaMetrics {
         )
         .unwrap();
 
+        let iceberg_compaction_orphan_sink_removed_count = register_int_counter_vec_with_registry!(
+            "meta_iceberg_compaction_orphan_sink_removed_count",
+            "Count of orphan iceberg sink maintenance entries removed by self-healing",
+            &["path"],
+            registry
+        )
+        .unwrap();
+
         let opts = histogram_opts!(
             "storage_time_travel_version_replay_latency",
             "The latency(ms) of replaying a hummock version for time travel",
@@ -1042,6 +1055,7 @@ impl MetaMetrics {
             auto_schema_change_success_cnt,
             auto_schema_change_latency,
             merge_compaction_group_count,
+            iceberg_compaction_orphan_sink_removed_count,
             time_travel_version_replay_latency,
             compaction_group_count,
             compaction_group_size,

--- a/src/meta/src/stream/stream_manager.rs
+++ b/src/meta/src/stream/stream_manager.rs
@@ -51,6 +51,7 @@ use crate::controller::catalog::DropTableConnectorContext;
 use crate::controller::fragment::{InflightActorInfo, InflightFragmentInfo};
 use crate::error::bail_invalid_parameter;
 use crate::hummock::HummockManagerRef;
+use crate::manager::iceberg_compaction::IcebergCompactionManagerRef;
 use crate::manager::{
     MetaSrvEnv, MetadataManager, NotificationVersion, StreamingJob, StreamingJobType,
 };
@@ -318,6 +319,8 @@ pub struct GlobalStreamManager {
 
     pub refresh_manager: GlobalRefreshManagerRef,
 
+    pub iceberg_compaction_manager: IcebergCompactionManagerRef,
+
     /// Creating streaming job info.
     creating_job_info: CreatingStreamingJobInfoRef,
 
@@ -332,6 +335,7 @@ impl GlobalStreamManager {
         hummock_manager: HummockManagerRef,
         source_manager: SourceManagerRef,
         refresh_manager: GlobalRefreshManagerRef,
+        iceberg_compaction_manager: IcebergCompactionManagerRef,
         scale_controller: ScaleControllerRef,
     ) -> MetaResult<Self> {
         Ok(Self {
@@ -341,6 +345,7 @@ impl GlobalStreamManager {
             hummock_manager,
             source_manager,
             refresh_manager,
+            iceberg_compaction_manager,
             creating_job_info: Arc::new(CreatingStreamingJobInfo::default()),
             scale_controller,
         })
@@ -449,9 +454,11 @@ impl GlobalStreamManager {
                                     .await?;
                                 let cleanup_state_table_ids =
                                     job_fragments.all_table_ids().collect_vec();
-                                self.metadata_manager.catalog_controller
+                                let abort_result = self.metadata_manager.catalog_controller
                                     .try_abort_creating_streaming_job(job_id, true)
                                     .await?;
+                                self.iceberg_compaction_manager
+                                    .clear_maintenance_for_aborted_job(&abort_result);
 
                                 self.barrier_scheduler
                                     .run_command(database_id, cancel_command)
@@ -879,13 +886,15 @@ impl GlobalStreamManager {
                 .await?;
             let cleanup_state_table_ids = fragment.all_table_ids().collect_vec();
 
-            let (_, database_id) = self
+            let abort_result = self
                 .metadata_manager
                 .catalog_controller
                 .try_abort_creating_streaming_job(id, true)
                 .await?;
+            self.iceberg_compaction_manager
+                .clear_maintenance_for_aborted_job(&abort_result);
 
-            if let Some(database_id) = database_id {
+            if let Some(database_id) = abort_result.database_id {
                 self.barrier_scheduler
                     .run_command(database_id, cancel_command)
                     .await?;


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

Implements fix (c) of #26227 — self-heal for orphan iceberg maintenance entries. Stacked on #26228.

If any sink-removal path misses the explicit cleanup, the leaked entry previously logged `Sink not found` warns on every dispatch attempt and GC errors (with backtraces) on every round, forever. This makes the two consumers of the maintenance maps drop the entry once the sink is confirmed gone:

- `get_sink_param` / `load_iceberg_config` now return `MetaResult<Option<...>>`: `Ok(None)` means the sink no longer exists (sink ids are never reused), while transient metastore errors still propagate as `Err`.
- Dispatch path: on sink-not-found, `send_compact_task` clears both maps via `clear_iceberg_maintenance_by_sink_id` instead of warn + retry forever. `IcebergCompactionHandle` now holds `Arc<IcebergCompactionManager>` so the full clear (both maps, in-flight-task cancel, waiter notification) is reused; the clear runs without holding the lock, and the handle's `Drop` then finds no track and does not revert.
- GC path: `check_and_expire_snapshots` performs the same clear instead of erroring every round.
- Observability: ERROR log + new counter `meta_iceberg_compaction_orphan_sink_removed_count` (label `path` = `dispatch` | `gc`), so a removal path forgetting explicit cleanup surfaces instead of being silently absorbed.

Unit tests cover both paths.

- Part of #26227

## Checklist

- [x] I have written necessary rustdoc comments.
- [x] I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

</details>
