### PR TITLE
fix(meta): re-queue iceberg track at now on pre-dispatch failure

### DIFF
--- a/src/meta/src/manager/iceberg_compaction/schedule.rs
+++ b/src/meta/src/manager/iceberg_compaction/schedule.rs
@@ -52,7 +52,6 @@ enum CompactionTrackState {
     /// Task has been selected locally but not yet accepted by a compactor.
     PendingDispatch {
         task_type: TaskType,
-        next_compaction_time_on_failure: Instant,
         pending_commit_count_at_dispatch: usize,
         gc_watermark_snapshot: Option<IcebergCommittedSnapshot>,
     },
@@ -199,13 +198,12 @@ impl CompactionTrack {
     fn start_processing(&mut self) -> TaskType {
         match &mut self.state {
             CompactionTrackState::Idle {
-                next_compaction_time,
                 next_task_type_override,
+                ..
             } => {
                 let task_type = next_task_type_override.take().unwrap_or(self.task_type);
                 self.state = CompactionTrackState::PendingDispatch {
                     task_type,
-                    next_compaction_time_on_failure: *next_compaction_time,
                     pending_commit_count_at_dispatch: self.pending_commit_count,
                     gc_watermark_snapshot: self.latest_observed_snapshot.clone(),
                 };
@@ -353,19 +351,22 @@ impl CompactionTrack {
         }
     }
 
-    /// Restore the idle scheduling state after a pre-dispatch failure.
+    /// Re-queue the track as idle after a pre-dispatch failure.
     ///
     /// `pending_commit_count` is intentionally preserved so commits that arrive
     /// while the track is pending dispatch are not lost if task dispatch fails
     /// before the compactor accepts the task.
-    fn revert_pre_dispatch_failure(&mut self) -> CompactionTrackFinishAction {
+    ///
+    /// `next_compaction_time` is reset to `now` (like `finish_failed`) rather
+    /// than restored: candidates are dispatched in ascending order of this
+    /// field, so restoring a stale timestamp would let a repeatedly-failing
+    /// track sort ahead of every healthy sink and permanently monopolize
+    /// dispatch slots.
+    fn revert_pre_dispatch_failure(&mut self, now: Instant) -> CompactionTrackFinishAction {
         match &self.state {
-            CompactionTrackState::PendingDispatch {
-                next_compaction_time_on_failure,
-                ..
-            } => {
+            CompactionTrackState::PendingDispatch { .. } => {
                 self.state = CompactionTrackState::Idle {
-                    next_compaction_time: *next_compaction_time_on_failure,
+                    next_compaction_time: now,
                     next_task_type_override: None,
                 };
                 self.finish_action
@@ -509,7 +510,7 @@ impl Drop for IcebergCompactionHandle {
                 && let Some(track) = guard.sink_schedules.get_mut(&self.sink_id)
                 && track.is_pending_dispatch()
             {
-                let finish_action = track.revert_pre_dispatch_failure();
+                let finish_action = track.revert_pre_dispatch_failure(Instant::now());
                 let waiter = guard.manual_compaction_waiters.remove(&self.sink_id);
                 IcebergCompactionManager::apply_track_finish_action(
                     &mut guard,

--- a/src/meta/src/manager/iceberg_compaction/schedule/tests.rs
+++ b/src/meta/src/manager/iceberg_compaction/schedule/tests.rs
@@ -425,21 +425,22 @@ fn test_report_timeout_is_based_on_processing_deadline() {
 }
 
 #[test]
-fn test_revert_pre_dispatch_failure_restores_idle_without_losing_backlog() {
+fn test_revert_pre_dispatch_failure_requeues_at_now_without_losing_backlog() {
     let now = Instant::now();
     for additional_commits in [0, 3] {
         let mut track = new_track(now, 120, 10, 5);
         track.start_processing();
         record_commits(&mut track, additional_commits);
 
-        track.revert_pre_dispatch_failure();
+        let revert_at = now + Duration::from_secs(30);
+        track.revert_pre_dispatch_failure(revert_at);
 
         assert_eq!(track.pending_commit_count, 5 + additional_commits);
         match track.state {
             CompactionTrackState::Idle {
                 next_compaction_time,
                 ..
-            } => assert_eq!(next_compaction_time, now + Duration::from_secs(120)),
+            } => assert_eq!(next_compaction_time, revert_at),
             CompactionTrackState::PendingDispatch { .. }
             | CompactionTrackState::InFlight { .. } => {
                 panic!("track should be restored to idle")
@@ -1550,4 +1551,40 @@ async fn test_get_top_n_retries_timed_out_inflight_task() {
         track.state,
         CompactionTrackState::PendingDispatch { .. }
     ));
+}
+
+#[tokio::test]
+async fn test_pre_dispatch_failure_requeues_track_behind_overdue_candidates() {
+    let manager = build_test_manager().await;
+    let failing = SinkId::new(480);
+    let healthy = SinkId::new(481);
+    let now = Instant::now();
+    // The failing track is the most overdue, so it wins the only slot first.
+    let mut failing_track = new_track(now, 120, 10, 1);
+    failing_track.state = CompactionTrackState::Idle {
+        next_compaction_time: now - Duration::from_secs(100),
+        next_task_type_override: None,
+    };
+    let mut healthy_track = new_track(now, 120, 10, 1);
+    healthy_track.state = CompactionTrackState::Idle {
+        next_compaction_time: now - Duration::from_secs(50),
+        next_task_type_override: None,
+    };
+    {
+        let mut guard = manager.inner.write();
+        guard.sink_schedules.insert(failing, failing_track);
+        guard.sink_schedules.insert(healthy, healthy_track);
+    }
+
+    let handles = manager.get_top_n_iceberg_commit_sink_ids(1);
+    assert_eq!(handles.len(), 1);
+    assert_eq!(handles[0].sink_id, failing);
+    // Dropping the handle simulates a pre-dispatch failure.
+    drop(handles);
+
+    // The failing track is re-queued at the revert time, so the still-overdue
+    // healthy track wins the next slot instead of being starved.
+    let handles = manager.get_top_n_iceberg_commit_sink_ids(1);
+    assert_eq!(handles.len(), 1);
+    assert_eq!(handles[0].sink_id, healthy);
 }


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

Implements fix (b) of #26227 — dispatch-queue starvation. Stacked on #26229.

`next_compaction_time` is both "when to run next" and the dispatch queue's ascending sort key. `revert_pre_dispatch_failure` restored the track's old timestamp, freezing a repeatedly-failing track's sort key in the past, so it out-sorted every healthy sink and re-won a dispatch slot on every pull cycle; with `max_pull_task_count` such tracks, no live iceberg sink could be dispatched at all until meta restarted (see the issue for the production incident and why force compaction cannot preempt a frozen sort key).

Fix: re-queue the track at `now` on pre-dispatch failure, same as `finish_failed`. The failing track's sort key then advances on each revert while overdue healthy tracks keep older keys and win within one pull cycle. `pending_commit_count` is still preserved across the revert. The `next_compaction_time_on_failure` field existed solely to restore the old timestamp and is removed.

Adds a regression test asserting that after a pre-dispatch failure, the still-overdue healthy track wins the next slot. A backoff on repeated failures would compose with this but is not needed for correctness.

- Part of #26227

## Checklist

- [x] I have written necessary rustdoc comments.
- [x] I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

</details>
