### PR TITLE
fix(meta): remove last_committed_barrier_time series when database has no streaming job

### DIFF
--- a/src/meta/src/barrier/checkpoint/control.rs
+++ b/src/meta/src/barrier/checkpoint/control.rs
@@ -25,7 +25,7 @@ use itertools::Itertools;
 use risingwave_common::catalog::{DatabaseId, TableId};
 use risingwave_common::id::JobId;
 use risingwave_common::metrics::{LabelGuardedHistogram, LabelGuardedIntGauge};
-use risingwave_common::util::epoch::EpochPair;
+use risingwave_common::util::epoch::{Epoch, EpochPair};
 use risingwave_common::util::stream_graph_visitor::visit_stream_node_cont;
 use risingwave_meta_model::WorkerId;
 use risingwave_pb::common::WorkerNode;
@@ -774,10 +774,13 @@ pub(in crate::barrier) struct DatabaseCheckpointControl {
     finishing_jobs_collector:
         BarrierItemCollector<JobId, (Vec<BarrierCompleteResponse>, TrackingJob), ()>,
     /// The barrier that are completing.
-    /// Some(`prev_epoch`)
-    completing_barrier: Option<u64>,
+    completing_barrier: Option<EpochPair>,
 
     committed_epoch: Option<u64>,
+
+    /// `None` while the database has no streaming job, so that a frozen timestamp does not
+    /// render as an ever-growing barrier pending time.
+    last_committed_barrier_time: Option<LabelGuardedIntGauge>,
 
     pub(super) database_info: InflightDatabaseInfo,
     pub independent_checkpoint_job_controls: HashMap<JobId, IndependentCheckpointJobControl>,
@@ -792,6 +795,7 @@ impl DatabaseCheckpointControl {
             finishing_jobs_collector: BarrierItemCollector::new(false),
             completing_barrier: None,
             committed_epoch: None,
+            last_committed_barrier_time: None,
             database_info: InflightDatabaseInfo::empty(database_id, shared_actor_infos),
             independent_checkpoint_job_controls: Default::default(),
         }
@@ -811,6 +815,7 @@ impl DatabaseCheckpointControl {
             finishing_jobs_collector: BarrierItemCollector::new(false),
             completing_barrier: None,
             committed_epoch: Some(committed_epoch),
+            last_committed_barrier_time: None,
             database_info,
             independent_checkpoint_job_controls,
         }
@@ -1109,7 +1114,7 @@ impl DatabaseCheckpointControl {
                     resps_to_commit,
                     self.collect_backfill_pinned_upstream_log_epoch(),
                 );
-                self.completing_barrier = Some(info.barrier_info.prev_epoch());
+                self.completing_barrier = Some(info.barrier_info.epoch());
                 task.finished_jobs.extend(staging_commit_info.finished_jobs);
                 task.finished_cdc_table_backfill
                     .extend(staging_commit_info.finished_cdc_table_backfill);
@@ -1144,10 +1149,17 @@ impl DatabaseCheckpointControl {
         independent_job_epochs: Vec<(JobId, u64)>,
     ) {
         {
-            if let Some(prev_epoch) = self.completing_barrier.take() {
-                assert_eq!(command_prev_epoch, Some(prev_epoch));
-                self.committed_epoch = Some(prev_epoch);
-                partial_graph_manager.ack_completed(self.partial_graph_id, prev_epoch);
+            if let Some(epoch) = self.completing_barrier.take() {
+                assert_eq!(command_prev_epoch, Some(epoch.prev));
+                self.committed_epoch = Some(epoch.prev);
+                partial_graph_manager.ack_completed(self.partial_graph_id, epoch.prev);
+                self.last_committed_barrier_time
+                    .get_or_insert_with(|| {
+                        GLOBAL_META_METRICS
+                            .last_committed_barrier_time
+                            .with_guarded_label_values(&[&self.database_id.to_string()])
+                    })
+                    .set(Epoch(epoch.curr).as_unix_secs() as i64);
             } else {
                 assert_eq!(command_prev_epoch, None);
             };
@@ -1324,6 +1336,8 @@ impl DatabaseCheckpointControl {
                 self.independent_checkpoint_job_controls.is_empty(),
                 "should not have snapshot backfill job when there is no normal job in database"
             );
+            // Drop the guard to remove the metric series of this database.
+            self.last_committed_barrier_time = None;
             // skip the command when there is nothing to do with the barrier
             for mut notifier in notifiers {
                 notifier.notify_started();

--- a/src/meta/src/barrier/complete_task.rs
+++ b/src/meta/src/barrier/complete_task.rs
@@ -169,10 +169,6 @@ impl CompleteBarrierTask {
                         &info.barrier_info,
                         command_name,
                     );
-                    GLOBAL_META_METRICS
-                        .last_committed_barrier_time
-                        .with_label_values(&[database_id.to_string().as_str()])
-                        .set(info.barrier_info.curr_epoch.value().as_unix_secs() as i64);
                 }
             }
 

--- a/src/meta/src/rpc/metrics.rs
+++ b/src/meta/src/rpc/metrics.rs
@@ -95,7 +95,7 @@ pub struct MetaMetrics {
     /// The number of in-flight barriers
     pub in_flight_barrier_nums: LabelGuardedIntGaugeVec,
     /// The timestamp (UNIX epoch seconds) of the last committed barrier's epoch time.
-    pub last_committed_barrier_time: IntGaugeVec,
+    pub last_committed_barrier_time: LabelGuardedIntGaugeVec,
     /// The barrier interval of each database
     pub barrier_interval_by_database: GaugeVec,
 
@@ -316,7 +316,7 @@ impl MetaMetrics {
             registry
         )
         .unwrap();
-        let last_committed_barrier_time = register_int_gauge_vec_with_registry!(
+        let last_committed_barrier_time = register_guarded_int_gauge_vec_with_registry!(
             "last_committed_barrier_time",
             "The timestamp (UNIX epoch seconds) of the last committed barrier's epoch time.",
             &["database_id"],


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

`last_committed_barrier_time` is a plain `IntGaugeVec`, so a database's series is never removed. Once a database drops its last streaming job, the frozen timestamp makes the "Barrier pending time (secs)" panel (`timestamp(m) - m`) grow unboundedly and alert forever.

- Change the metric to `LabelGuardedIntGaugeVec`. The guard is owned by `DatabaseCheckpointControl` and dropped once the database has no streaming job, which removes the series.
- Move the gauge write from the spawned `complete_barrier` task to `ack_completed` on the barrier worker loop, next to the `committed_epoch` update. `completing_barrier` now carries the full `EpochPair`, so the written value is unchanged (`curr_epoch` of the committed barrier). Keeping create/set/release on the single worker loop avoids handing the guard across the spawned commit task.

Behavior note: the series now disappears while a database has no streaming job (and briefly during recovery until the first post-recovery commit), so `timestamp(m) - m` reads no data instead of a growing value.

- Closes #26226

## Checklist

- [x] I have written necessary rustdoc comments.

## Documentation

- [ ] My PR needs documentation updates.

<details>
<summary><b>Release note</b></summary>

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
