### PR TITLE
fix(optimizer): avoid rewriting LIKE ESCAPE as a binary expression

### DIFF
--- a/e2e_test/batch/functions/like.slt.part
+++ b/e2e_test/batch/functions/like.slt.part
@@ -20,3 +20,31 @@ statement ok
 drop table test_table;
 
 # End
+
+# Begin https://github.com/risingwavelabs/risingwave/issues/26196
+
+statement ok
+create table like_escape_trades(id varchar);
+
+statement ok
+insert into like_escape_trades values
+    ('abc_def'),
+    ('x_y'),
+    ('DROPFEED_1'),
+    ('abcdef'),
+    ('DROPFEEDabc');
+
+query T rowsort
+select id
+from like_escape_trades
+where id like '%\_%' escape '\'
+  and id not like 'DROPFEED%'
+limit 1000;
+----
+abc_def
+x_y
+
+statement ok
+drop table like_escape_trades;
+
+# End

--- a/src/frontend/planner_test/tests/testdata/input/index_selection.yaml
+++ b/src/frontend/planner_test/tests/testdata/input/index_selection.yaml
@@ -424,6 +424,14 @@
     select * from test_table where name like 'test\_table_2';
   expected_outputs:
   - batch_plan
+- name: restrict rewrite LIKE with ESCAPE as a binary expression
+  sql: |
+    create table some_trades(id varchar);
+    select * from some_trades
+    where id like '%\_%' escape '\'
+      and id not like 'DROPFEED%';
+  expected_outputs:
+  - batch_plan
 - sql: |
     create table t1 (k1 int primary key, v1 int);
     create table t2 (k2 int primary key, v2 int);

--- a/src/frontend/planner_test/tests/testdata/output/index_selection.yaml
+++ b/src/frontend/planner_test/tests/testdata/output/index_selection.yaml
@@ -752,6 +752,16 @@
     BatchExchange { order: [], dist: Single }
     └─BatchFilter { predicate: (test_table.name >= 'test_table':Varchar) AND (test_table.name < 'test_tablf':Varchar) AND Like(test_table.name, 'test\_table_2':Varchar) }
       └─BatchScan { table: test_table, columns: [test_table.name], distribution: SomeShard }
+- name: restrict rewrite LIKE with ESCAPE as a binary expression
+  sql: |
+    create table some_trades(id varchar);
+    select * from some_trades
+    where id like '%\_%' escape '\'
+      and id not like 'DROPFEED%';
+  batch_plan: |-
+    BatchExchange { order: [], dist: Single }
+    └─BatchFilter { predicate: Like(some_trades.id, '%\_%':Varchar, '\':Varchar) AND (Not((some_trades.id >= 'DROPFEED':Varchar)) OR Not((some_trades.id < 'DROPFEEE':Varchar))) }
+      └─BatchScan { table: some_trades, columns: [some_trades.id], distribution: SomeShard }
 - sql: |
     create table t1 (k1 int primary key, v1 int);
     create table t2 (k2 int primary key, v2 int);

--- a/src/frontend/src/optimizer/rule/rewrite_like_expr_rule.rs
+++ b/src/frontend/src/optimizer/rule/rewrite_like_expr_rule.rs
@@ -111,7 +111,7 @@ impl ExprRewriter for LikeExprRewriter {
             .collect();
         let func_call = FunctionCall::new_unchecked(func_type, inputs, ret.clone());
 
-        if func_call.func_type() != ExprType::Like {
+        if func_call.func_type() != ExprType::Like || func_call.inputs().len() != 2 {
             return func_call.into();
         }
 


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

<!--

**Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

- Closes #26196.

`RewriteLikeExprRule` only supports rewriting two-argument `LIKE`
expressions. However, when a filter contained both a simple two-argument
`LIKE` and a three-argument `LIKE ... ESCAPE`, the rule was activated for
the entire filter expression tree.

While traversing the tree, `LikeExprRewriter` attempted to handle the
three-argument `LIKE` with `decompose_as_binary()`. This triggered an
assertion failure because the expression had three inputs instead of two:

```text
assertion `left == right` failed
left: 3
right: 2
```

For example:
```
SELECT *
FROM some_trades
WHERE id LIKE '%\_%' ESCAPE '\'
  AND id NOT LIKE 'DROPFEED%';
```

With this change:
- Two-argument `LIKE` expressions continue to be optimized.
- Three-argument `LIKE ... ESCAPE` expressions are preserved unchanged.
- A filter containing both forms no longer panics.
- The remaining simple `LIKE` expressions in the same filter can still be
optimized independently.

## Checklist

- [ ] I have written necessary rustdoc comments.
- [x] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
