### PR TITLE
fix(connector): offload Iceberg JNI catalog operations

### DIFF
--- a/src/connector/src/connector_common/iceberg/jni_catalog.rs
+++ b/src/connector/src/connector_common/iceberg/jni_catalog.rs
@@ -604,18 +604,3 @@ impl JniCatalog {
         Ok(Arc::new(catalog) as Arc<dyn Catalog>)
     }
 }
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[tokio::test(flavor = "current_thread")]
-    async fn test_jni_operation_runs_off_async_worker() {
-        let async_worker = std::thread::current().id();
-        let jni_worker = execute_blocking_jni(|| Ok(std::thread::current().id()))
-            .await
-            .unwrap();
-
-        assert_ne!(async_worker, jni_worker);
-    }
-}

--- a/src/connector/src/connector_common/iceberg/jni_catalog.rs
+++ b/src/connector/src/connector_common/iceberg/jni_catalog.rs
@@ -113,10 +113,31 @@ fn namespace_to_string(namespace: &NamespaceIdent) -> String {
 }
 
 #[derive(Debug)]
-pub struct JniCatalog {
+struct JniCatalogInner {
     java_catalog: GlobalRef,
     jvm: Jvm,
-    file_io_props: HashMap<String, String>,
+}
+
+#[derive(Debug)]
+pub struct JniCatalog {
+    /// A blocking JNI operation can outlive its async caller after cancellation. Keep the Java
+    /// catalog alive until the last such operation finishes.
+    inner: Arc<JniCatalogInner>,
+    file_io_props: Arc<HashMap<String, String>>,
+}
+
+/// Iceberg's Java catalog API is synchronous and may perform remote catalog I/O. Running it
+/// directly in an async `Catalog` method would block a Tokio worker thread, so async JNI operations
+/// go through the runtime's blocking pool.
+async fn execute_blocking_jni<T>(
+    task: impl FnOnce() -> anyhow::Result<T> + Send + 'static,
+) -> anyhow::Result<T>
+where
+    T: Send + 'static,
+{
+    tokio::task::spawn_blocking(task)
+        .await
+        .context("Failed to join blocking Iceberg JNI catalog task")?
 }
 
 #[async_trait]
@@ -126,17 +147,21 @@ impl Catalog for JniCatalog {
         &self,
         _parent: Option<&NamespaceIdent>,
     ) -> iceberg::Result<Vec<NamespaceIdent>> {
-        execute_with_jni_env(self.jvm, |env| {
-            let result_json =
-                call_method!(env, self.java_catalog.as_obj(), {String listNamespaces()})
-                    .with_context(|| "Failed to list iceberg namespaces".to_owned())?;
+        let inner = self.inner.clone();
+        execute_blocking_jni(move || {
+            execute_with_jni_env(inner.jvm, |env| {
+                let result_json =
+                    call_method!(env, inner.java_catalog.as_obj(), {String listNamespaces()})
+                        .with_context(|| "Failed to list iceberg namespaces".to_owned())?;
 
-            let rust_json_str = jobj_to_str(env, result_json)?;
+                let rust_json_str = jobj_to_str(env, result_json)?;
 
-            let resp: ListNamespacesResponse = serde_json::from_str(&rust_json_str)?;
+                let resp: ListNamespacesResponse = serde_json::from_str(&rust_json_str)?;
 
-            Ok(resp.namespaces)
+                Ok(resp.namespaces)
+            })
         })
+        .await
         .map_err(|e| {
             iceberg::Error::new(
                 iceberg::ErrorKind::Unexpected,
@@ -152,16 +177,21 @@ impl Catalog for JniCatalog {
         namespace: &iceberg::NamespaceIdent,
         _properties: HashMap<String, String>,
     ) -> iceberg::Result<iceberg::Namespace> {
-        execute_with_jni_env(self.jvm, |env| {
-            let namespace_str = namespace_to_string(namespace);
-            let namespace_jstr = env.new_string(&namespace_str).unwrap();
+        let inner = self.inner.clone();
+        let namespace = namespace.clone();
+        execute_blocking_jni(move || {
+            execute_with_jni_env(inner.jvm, |env| {
+                let namespace_str = namespace_to_string(&namespace);
+                let namespace_jstr = env.new_string(&namespace_str).unwrap();
 
-            call_method!(env, self.java_catalog.as_obj(), {void createNamespace(String)},
-                &namespace_jstr)
-            .with_context(|| format!("Failed to create namespace: {namespace}"))?;
+                call_method!(env, inner.java_catalog.as_obj(), {void createNamespace(String)},
+                    &namespace_jstr)
+                .with_context(|| format!("Failed to create namespace: {namespace}"))?;
 
-            Ok(Namespace::new(namespace.clone()))
+                Ok(Namespace::new(namespace))
+            })
         })
+        .await
         .map_err(|e| {
             iceberg::Error::new(
                 iceberg::ErrorKind::Unexpected,
@@ -178,17 +208,22 @@ impl Catalog for JniCatalog {
 
     /// Check if namespace exists in catalog.
     async fn namespace_exists(&self, namespace: &NamespaceIdent) -> iceberg::Result<bool> {
-        execute_with_jni_env(self.jvm, |env| {
-            let namespace_str = namespace_to_string(namespace);
-            let namespace_jstr = env.new_string(&namespace_str).unwrap();
+        let inner = self.inner.clone();
+        let namespace = namespace.clone();
+        execute_blocking_jni(move || {
+            execute_with_jni_env(inner.jvm, |env| {
+                let namespace_str = namespace_to_string(&namespace);
+                let namespace_jstr = env.new_string(&namespace_str).unwrap();
 
-            let exists =
-                call_method!(env, self.java_catalog.as_obj(), {boolean namespaceExists(String)},
-                &namespace_jstr)
-                .with_context(|| format!("Failed to check namespace exists: {namespace}"))?;
+                let exists =
+                    call_method!(env, inner.java_catalog.as_obj(), {boolean namespaceExists(String)},
+                    &namespace_jstr)
+                    .with_context(|| format!("Failed to check namespace exists: {namespace}"))?;
 
-            Ok(exists)
+                Ok(exists)
+            })
         })
+        .await
         .map_err(|e| {
             iceberg::Error::new(
                 iceberg::ErrorKind::Unexpected,
@@ -205,23 +240,28 @@ impl Catalog for JniCatalog {
 
     /// List tables from namespace.
     async fn list_tables(&self, namespace: &NamespaceIdent) -> iceberg::Result<Vec<TableIdent>> {
-        execute_with_jni_env(self.jvm, |env| {
-            let namespace_str = namespace_to_string(namespace);
-            let namespace_jstr = env.new_string(&namespace_str).unwrap();
+        let inner = self.inner.clone();
+        let namespace = namespace.clone();
+        execute_blocking_jni(move || {
+            execute_with_jni_env(inner.jvm, |env| {
+                let namespace_str = namespace_to_string(&namespace);
+                let namespace_jstr = env.new_string(&namespace_str).unwrap();
 
-            let result_json =
-                call_method!(env, self.java_catalog.as_obj(), {String listTables(String)},
-                &namespace_jstr)
-                .with_context(|| {
-                    format!("Failed to list iceberg tables in namespace: {}", namespace)
-                })?;
+                let result_json =
+                    call_method!(env, inner.java_catalog.as_obj(), {String listTables(String)},
+                    &namespace_jstr)
+                    .with_context(|| {
+                        format!("Failed to list iceberg tables in namespace: {}", namespace)
+                    })?;
 
-            let rust_json_str = jobj_to_str(env, result_json)?;
+                let rust_json_str = jobj_to_str(env, result_json)?;
 
-            let resp: ListTablesResponse = serde_json::from_str(&rust_json_str)?;
+                let resp: ListTablesResponse = serde_json::from_str(&rust_json_str)?;
 
-            Ok(resp.identifiers)
+                Ok(resp.identifiers)
+            })
         })
+        .await
         .map_err(|e| {
             iceberg::Error::new(
                 iceberg::ErrorKind::Unexpected,
@@ -245,42 +285,50 @@ impl Catalog for JniCatalog {
         namespace: &NamespaceIdent,
         creation: TableCreation,
     ) -> iceberg::Result<Table> {
-        execute_with_jni_env(self.jvm, |env| {
-            let namespace_str = namespace_to_string(namespace);
-            let namespace_jstr = env.new_string(&namespace_str).unwrap();
+        let inner = self.inner.clone();
+        let file_io_props = self.file_io_props.clone();
+        let namespace = namespace.clone();
+        execute_blocking_jni(move || {
+            execute_with_jni_env(inner.jvm, |env| {
+                let namespace_str = namespace_to_string(&namespace);
+                let namespace_jstr = env.new_string(&namespace_str).unwrap();
 
-            let creation_str = serde_json::to_string(&CreateTableRequest::from(&creation))?;
+                let creation_str = serde_json::to_string(&CreateTableRequest::from(&creation))?;
 
-            let creation_jstr = env.new_string(&creation_str).unwrap();
+                let creation_jstr = env.new_string(&creation_str).unwrap();
 
-            let result_json =
-                call_method!(env, self.java_catalog.as_obj(), {String createTable(String, String)},
-                &namespace_jstr, &creation_jstr)
-                .with_context(|| format!("Failed to create iceberg table: {}", creation.name))?;
+                let result_json =
+                    call_method!(env, inner.java_catalog.as_obj(), {String createTable(String, String)},
+                    &namespace_jstr, &creation_jstr)
+                    .with_context(|| {
+                        format!("Failed to create iceberg table: {}", creation.name)
+                    })?;
 
-            let rust_json_str = jobj_to_str(env, result_json)?;
+                let rust_json_str = jobj_to_str(env, result_json)?;
 
-            let resp: LoadTableResponse = serde_json::from_str(&rust_json_str)?;
+                let resp: LoadTableResponse = serde_json::from_str(&rust_json_str)?;
 
-            let metadata_location = resp.metadata_location.ok_or_else(|| {
-                iceberg::Error::new(
-                    iceberg::ErrorKind::FeatureUnsupported,
-                    "Loading uncommitted table is not supported!",
-                )
-            })?;
+                let metadata_location = resp.metadata_location.ok_or_else(|| {
+                    iceberg::Error::new(
+                        iceberg::ErrorKind::FeatureUnsupported,
+                        "Loading uncommitted table is not supported!",
+                    )
+                })?;
 
-            let table_metadata = resp.metadata;
+                let table_metadata = resp.metadata;
 
-            let file_io = FileIO::from_path(&metadata_location)?
-                .with_props(self.file_io_props.iter())
-                .build()?;
+                let file_io = FileIO::from_path(&metadata_location)?
+                    .with_props(file_io_props.iter())
+                    .build()?;
 
-            Ok(Table::builder()
-                .file_io(file_io)
-                .identifier(TableIdent::new(namespace.clone(), creation.name))
-                .metadata(table_metadata)
-                .build())
+                Ok(Table::builder()
+                    .file_io(file_io)
+                    .identifier(TableIdent::new(namespace, creation.name))
+                    .metadata(table_metadata)
+                    .build())
+            })
         })
+        .await
         .map_err(|e| {
             iceberg::Error::new(
                 iceberg::ErrorKind::Unexpected,
@@ -292,41 +340,49 @@ impl Catalog for JniCatalog {
 
     /// Load table from the catalog.
     async fn load_table(&self, table: &TableIdent) -> iceberg::Result<Table> {
-        execute_with_jni_env(self.jvm, |env| {
-            let table_name_str = table.to_string();
+        let inner = self.inner.clone();
+        let file_io_props = self.file_io_props.clone();
+        let table = table.clone();
+        execute_blocking_jni(move || {
+            execute_with_jni_env(inner.jvm, |env| {
+                let table_name_str = table.to_string();
 
-            let table_name_jstr = env.new_string(&table_name_str).unwrap();
+                let table_name_jstr = env.new_string(&table_name_str).unwrap();
 
-            let result_json =
-                call_method!(env, self.java_catalog.as_obj(), {String loadTable(String)},
-                &table_name_jstr)
-                .with_context(|| format!("Failed to load iceberg table: {table_name_str}"))?;
+                let result_json =
+                    call_method!(env, inner.java_catalog.as_obj(), {String loadTable(String)},
+                    &table_name_jstr)
+                    .with_context(|| format!("Failed to load iceberg table: {table_name_str}"))?;
 
-            let rust_json_str = jobj_to_str(env, result_json)?;
+                let rust_json_str = jobj_to_str(env, result_json)?;
 
-            let resp: LoadTableResponse = serde_json::from_str(&rust_json_str)?;
+                let resp: LoadTableResponse = serde_json::from_str(&rust_json_str)?;
 
-            let metadata_location = resp.metadata_location.ok_or_else(|| {
-                iceberg::Error::new(
-                    iceberg::ErrorKind::FeatureUnsupported,
-                    "Loading uncommitted table is not supported!",
-                )
-            })?;
+                let metadata_location = resp.metadata_location.ok_or_else(|| {
+                    iceberg::Error::new(
+                        iceberg::ErrorKind::FeatureUnsupported,
+                        "Loading uncommitted table is not supported!",
+                    )
+                })?;
 
-            tracing::info!("Table metadata location of {table_name_str} is {metadata_location}");
+                tracing::info!(
+                    "Table metadata location of {table_name_str} is {metadata_location}"
+                );
 
-            let table_metadata = resp.metadata;
+                let table_metadata = resp.metadata;
 
-            let file_io = FileIO::from_path(&metadata_location)?
-                .with_props(self.file_io_props.iter())
-                .build()?;
+                let file_io = FileIO::from_path(&metadata_location)?
+                    .with_props(file_io_props.iter())
+                    .build()?;
 
-            Ok(Table::builder()
-                .file_io(file_io)
-                .identifier(table.clone())
-                .metadata(table_metadata)
-                .build())
+                Ok(Table::builder()
+                    .file_io(file_io)
+                    .identifier(table)
+                    .metadata(table_metadata)
+                    .build())
+            })
         })
+        .await
         .map_err(|e| {
             iceberg::Error::new(
                 iceberg::ErrorKind::Unexpected,
@@ -338,28 +394,19 @@ impl Catalog for JniCatalog {
 
     /// Drop a table from the catalog.
     async fn drop_table(&self, table: &TableIdent) -> iceberg::Result<()> {
-        let jvm = self.jvm;
+        let inner = self.inner.clone();
         let table = table.to_owned();
-        let java_catalog = self.java_catalog.clone();
-        // spawn blocking the drop table task, since dropping a table by default would purge the data which may take a long time.
-        tokio::task::spawn_blocking(move || -> iceberg::Result<()> {
-            execute_with_jni_env(jvm, |env| {
+        execute_blocking_jni(move || {
+            execute_with_jni_env(inner.jvm, |env| {
                 let table_name_str = table.to_string();
 
                 let table_name_jstr = env.new_string(&table_name_str).unwrap();
 
-                call_method!(env, java_catalog.as_obj(), {boolean dropTable(String)},
+                call_method!(env, inner.java_catalog.as_obj(), {boolean dropTable(String)},
                 &table_name_jstr)
                 .with_context(|| format!("Failed to drop iceberg table: {table_name_str}"))?;
 
                 Ok(())
-            })
-            .map_err(|e| {
-                iceberg::Error::new(
-                    iceberg::ErrorKind::Unexpected,
-                    "Failed to drop iceberg table.",
-                )
-                .with_source(e)
             })
         })
         .await
@@ -369,7 +416,7 @@ impl Catalog for JniCatalog {
                 "Failed to drop iceberg table.",
             )
             .with_source(e)
-        })?
+        })
     }
 
     async fn register_table(
@@ -385,20 +432,25 @@ impl Catalog for JniCatalog {
 
     /// Check if a table exists in the catalog.
     async fn table_exists(&self, table: &TableIdent) -> iceberg::Result<bool> {
-        execute_with_jni_env(self.jvm, |env| {
-            let table_name_str = table.to_string();
+        let inner = self.inner.clone();
+        let table = table.clone();
+        execute_blocking_jni(move || {
+            execute_with_jni_env(inner.jvm, |env| {
+                let table_name_str = table.to_string();
 
-            let table_name_jstr = env.new_string(&table_name_str).unwrap();
+                let table_name_jstr = env.new_string(&table_name_str).unwrap();
 
-            let exists =
-                call_method!(env, self.java_catalog.as_obj(), {boolean tableExists(String)},
-                &table_name_jstr)
-                .with_context(|| {
-                    format!("Failed to check iceberg table exists: {table_name_str}")
-                })?;
+                let exists =
+                    call_method!(env, inner.java_catalog.as_obj(), {boolean tableExists(String)},
+                    &table_name_jstr)
+                    .with_context(|| {
+                        format!("Failed to check iceberg table exists: {table_name_str}")
+                    })?;
 
-            Ok(exists)
+                Ok(exists)
+            })
         })
+        .await
         .map_err(|e| {
             iceberg::Error::new(
                 iceberg::ErrorKind::Unexpected,
@@ -415,49 +467,54 @@ impl Catalog for JniCatalog {
 
     /// Update a table to the catalog.
     async fn update_table(&self, mut commit: TableCommit) -> iceberg::Result<Table> {
-        execute_with_jni_env(self.jvm, |env| {
-            let requirements = commit.take_requirements();
-            let updates = commit.take_updates();
-            let request = CommitTableRequest {
-                identifier: commit.identifier().clone(),
-                requirements,
-                updates,
-            };
-            let request_str = serde_json::to_string(&request)?;
+        let inner = self.inner.clone();
+        let file_io_props = self.file_io_props.clone();
+        execute_blocking_jni(move || {
+            execute_with_jni_env(inner.jvm, |env| {
+                let requirements = commit.take_requirements();
+                let updates = commit.take_updates();
+                let request = CommitTableRequest {
+                    identifier: commit.identifier().clone(),
+                    requirements,
+                    updates,
+                };
+                let request_str = serde_json::to_string(&request)?;
 
-            let request_jni_str = env.new_string(&request_str).with_context(|| {
-                format!("Failed to create jni string from request json: {request_str}.")
-            })?;
-
-            let result_json =
-                call_method!(env, self.java_catalog.as_obj(), {String updateTable(String)},
-                &request_jni_str)
-                .with_context(|| {
-                    format!("Failed to update iceberg table: {}", commit.identifier())
+                let request_jni_str = env.new_string(&request_str).with_context(|| {
+                    format!("Failed to create jni string from request json: {request_str}.")
                 })?;
 
-            let rust_json_str = jobj_to_str(env, result_json)?;
+                let result_json =
+                    call_method!(env, inner.java_catalog.as_obj(), {String updateTable(String)},
+                    &request_jni_str)
+                    .with_context(|| {
+                        format!("Failed to update iceberg table: {}", commit.identifier())
+                    })?;
 
-            let response: CommitTableResponse = serde_json::from_str(&rust_json_str)?;
+                let rust_json_str = jobj_to_str(env, result_json)?;
 
-            tracing::info!(
-                "Table metadata location of {} is {}",
-                commit.identifier(),
-                response.metadata_location
-            );
+                let response: CommitTableResponse = serde_json::from_str(&rust_json_str)?;
 
-            let table_metadata = response.metadata;
+                tracing::info!(
+                    "Table metadata location of {} is {}",
+                    commit.identifier(),
+                    response.metadata_location
+                );
 
-            let file_io = FileIO::from_path(&response.metadata_location)?
-                .with_props(self.file_io_props.iter())
-                .build()?;
+                let table_metadata = response.metadata;
 
-            Ok(Table::builder()
-                .file_io(file_io)
-                .identifier(commit.identifier().clone())
-                .metadata(table_metadata)
-                .build()?)
+                let file_io = FileIO::from_path(&response.metadata_location)?
+                    .with_props(file_io_props.iter())
+                    .build()?;
+
+                Ok(Table::builder()
+                    .file_io(file_io)
+                    .identifier(commit.identifier().clone())
+                    .metadata(table_metadata)
+                    .build()?)
+            })
         })
+        .await
         .map_err(|e| {
             iceberg::Error::new(
                 iceberg::ErrorKind::Unexpected,
@@ -468,7 +525,7 @@ impl Catalog for JniCatalog {
     }
 }
 
-impl Drop for JniCatalog {
+impl Drop for JniCatalogInner {
     fn drop(&mut self) {
         let _ = execute_with_jni_env(self.jvm, |env| {
             call_method!(env, self.java_catalog.as_obj(), {void close()})
@@ -519,21 +576,46 @@ impl JniCatalog {
             let jni_catalog = env.new_global_ref(jni_catalog_wrapper.l().unwrap())?;
 
             Ok(Self {
-                java_catalog: jni_catalog,
-                jvm,
-                file_io_props,
+                inner: Arc::new(JniCatalogInner {
+                    java_catalog: jni_catalog,
+                    jvm,
+                }),
+                file_io_props: Arc::new(file_io_props),
             })
         })
             .map_err(Into::into)
     }
 
-    pub fn build_catalog(
+    pub async fn build_catalog(
         file_io_props: HashMap<String, String>,
-        name: impl ToString,
-        catalog_impl: impl ToString,
+        name: impl ToString + Send + 'static,
+        catalog_impl: impl ToString + Send + 'static,
         java_catalog_props: HashMap<String, String>,
     ) -> ConnectorResult<Arc<dyn Catalog>> {
-        let catalog = Self::build(file_io_props, name, catalog_impl, java_catalog_props)?;
+        let catalog = execute_blocking_jni(move || {
+            Ok(Self::build(
+                file_io_props,
+                name,
+                catalog_impl,
+                java_catalog_props,
+            )?)
+        })
+        .await?;
         Ok(Arc::new(catalog) as Arc<dyn Catalog>)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn test_jni_operation_runs_off_async_worker() {
+        let async_worker = std::thread::current().id();
+        let jni_worker = execute_blocking_jni(|| Ok(std::thread::current().id()))
+            .await
+            .unwrap();
+
+        assert_ne!(async_worker, jni_worker);
     }
 }

--- a/src/connector/src/connector_common/iceberg/mod.rs
+++ b/src/connector/src/connector_common/iceberg/mod.rs
@@ -458,12 +458,15 @@ impl<'a> ResolvedIcebergCatalogConfig<'a> {
                 catalog_name,
                 catalog_impl,
                 java_catalog_props,
-            } => jni_catalog::JniCatalog::build_catalog(
-                file_io_props,
-                catalog_name,
-                catalog_impl.class_name(),
-                java_catalog_props,
-            ),
+            } => {
+                jni_catalog::JniCatalog::build_catalog(
+                    file_io_props,
+                    catalog_name,
+                    catalog_impl.class_name(),
+                    java_catalog_props,
+                )
+                .await
+            }
             CatalogBuildPlan::Mock => Ok(Arc::new(mock_catalog::MockCatalog {})),
         }
     }

--- a/src/connector/src/sink/iceberg/commit.rs
+++ b/src/connector/src/sink/iceberg/commit.rs
@@ -506,9 +506,7 @@ impl TwoPhaseCommitCoordinator for IcebergSinkCommitter {
             .map(|p| IcebergCommitResult::try_from_serialized_bytes(&p))
             .collect::<Result<Vec<_>>>()?;
 
-        let snapshot_committed = self
-            .is_snapshot_id_in_iceberg(&self.config, snapshot_id)
-            .await?;
+        let snapshot_committed = self.is_snapshot_id_in_iceberg(snapshot_id).await?;
 
         if snapshot_committed {
             tracing::info!(
@@ -815,12 +813,12 @@ impl IcebergSinkCommitter {
     /// During pre-commit metadata, we record the `snapshot_id` corresponding to each batch of files.
     /// Therefore, the logic for checking whether all files in this batch are present in Iceberg
     /// has been changed to verifying if their corresponding `snapshot_id` exists in Iceberg.
-    async fn is_snapshot_id_in_iceberg(
-        &self,
-        iceberg_config: &IcebergConfig,
-        snapshot_id: i64,
-    ) -> Result<bool> {
-        let table = iceberg_config.load_table().await?;
+    async fn is_snapshot_id_in_iceberg(&self, snapshot_id: i64) -> Result<bool> {
+        let table = self
+            .catalog
+            .load_table(self.table.identifier())
+            .await
+            .map_err(|err| SinkError::Iceberg(anyhow!(err).context("reload iceberg table")))?;
         if table.metadata().snapshot_by_id(snapshot_id).is_some() {
             Ok(true)
         } else {
@@ -1076,7 +1074,10 @@ impl IcebergSinkCommitter {
                 tokio::time::sleep(Duration::from_secs(30)).await;
 
                 // Refresh table after the wait so the next check sees latest snapshots.
-                self.table = self.config.load_table().await?;
+                let table_ident = self.table.identifier().clone();
+                self.table = self.catalog.load_table(&table_ident).await.map_err(|err| {
+                    SinkError::Iceberg(anyhow!(err).context("reload iceberg table"))
+                })?;
             }
         }
         Ok(())


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

- Run synchronous Iceberg JNI catalog calls on Tokio's blocking pool instead of async workers.
- Reuse the committer's existing catalog when reloading an Iceberg table.

This prevents slow Java catalog calls from starving Meta's async runtime. It addresses the P0 path in #26242; the native REST path (`vended_credentials = true`) is unchanged.

Validation:

- `cargo test -p risingwave_connector iceberg --lib` (49 passed, 4 ignored)
- `cargo check -p risingwave_meta`
- `cargo fmt --all`
- `git diff --check`

## Checklist

- [x] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwave-labs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

Prevents slow Iceberg Java catalog calls from blocking Meta's async runtime.

</details>
