### PR TITLE
feat(sink): validate create sink options

### DIFF
--- a/e2e_test/sink/starrocks_sink.slt
+++ b/e2e_test/sink/starrocks_sink.slt
@@ -4,6 +4,23 @@ set sink_decouple = false;
 statement ok
 CREATE TABLE no_permission_table (v1 int primary key);
 
+statement error Unknown fields in the WITH clause
+CREATE SINK sink_invalid_starrocks_option
+FROM no_permission_table
+WITH (
+    connector = 'starrocks',
+    type = 'upsert',
+    starrocks.host = 'starrocks-fe-server',
+    starrocks.mysqlport = '9030',
+    starrocks.httpport = '8030',
+    starrocks.user = 'users',
+    starrocks.password = '123456',
+    starrocks.database = 'demo',
+    starrocks.table = 'demo_bhv_table',
+    primary_key = 'v1',
+    starrocks.unknown_option = '1'
+);
+
 statement error write permission on the target table
 CREATE SINK sink_no_permission_table
 FROM no_permission_table

--- a/src/connector/src/sink/big_query.rs
+++ b/src/connector/src/sink/big_query.rs
@@ -260,7 +260,12 @@ pub struct BigQueryConfig {
     #[serde(flatten)]
     pub aws_auth_props: AwsAuthProps,
     pub r#type: String, // accept "append-only" or "upsert"
+
+    #[serde(flatten)]
+    pub unknown_fields: std::collections::HashMap<String, String>,
 }
+
+crate::impl_sink_unknown_fields!(BigQueryConfig);
 
 impl EnforceSecret for BigQueryConfig {
     fn enforce_one(prop: &str) -> crate::error::ConnectorResult<()> {

--- a/src/connector/src/sink/big_query.rs
+++ b/src/connector/src/sink/big_query.rs
@@ -524,6 +524,8 @@ impl Sink for BigQuerySink {
 
     const SINK_NAME: &'static str = BIGQUERY_SINK;
 
+    crate::impl_validate_sink_unknown_fields!();
+
     async fn new_log_sinker(&self, _writer_param: SinkWriterParam) -> Result<Self::LogSinker> {
         let (writer, resp_stream) = BigQuerySinkWriter::new(
             self.config.clone(),
@@ -1134,6 +1136,7 @@ mod test {
                     msk_signer_timeout_sec: None,
                 },
                 r#type: "append-only".to_owned(),
+                unknown_fields: Default::default(),
             },
             schema: Schema {
                 fields: vec![Field::with_name(DataType::Decimal, "capitalizedcost")],

--- a/src/connector/src/sink/clickhouse.rs
+++ b/src/connector/src/sink/clickhouse.rs
@@ -537,6 +537,8 @@ impl Sink for ClickHouseSink {
 
     const SINK_NAME: &'static str = CLICKHOUSE_SINK;
 
+    crate::impl_validate_sink_unknown_fields!();
+
     async fn validate(&self) -> Result<()> {
         // For upsert clickhouse sink, the primary key must be defined.
         if !self.is_append_only && self.pk_indices.is_empty() {

--- a/src/connector/src/sink/clickhouse.rs
+++ b/src/connector/src/sink/clickhouse.rs
@@ -331,7 +331,12 @@ pub struct ClickHouseConfig {
     pub common: ClickHouseCommon,
 
     pub r#type: String, // accept "append-only" or "upsert"
+
+    #[serde(flatten)]
+    pub unknown_fields: std::collections::HashMap<String, String>,
 }
+
+crate::impl_sink_unknown_fields!(ClickHouseConfig);
 
 impl EnforceSecret for ClickHouseConfig {
     fn enforce_one(prop: &str) -> crate::error::ConnectorResult<()> {

--- a/src/connector/src/sink/deltalake.rs
+++ b/src/connector/src/sink/deltalake.rs
@@ -201,7 +201,12 @@ pub struct DeltaLakeConfig {
     /// Whether to use the Delta transaction log to deduplicate replayed epoch commits.
     #[serde_as(as = "Option<DisplayFromStr>")]
     pub is_exactly_once: Option<bool>,
+
+    #[serde(flatten)]
+    pub unknown_fields: std::collections::HashMap<String, String>,
 }
+
+crate::impl_sink_unknown_fields!(DeltaLakeConfig);
 
 impl EnforceSecret for DeltaLakeConfig {
     fn enforce_one(prop: &str) -> crate::error::ConnectorResult<()> {

--- a/src/connector/src/sink/deltalake.rs
+++ b/src/connector/src/sink/deltalake.rs
@@ -216,10 +216,41 @@ impl EnforceSecret for DeltaLakeConfig {
 
 impl DeltaLakeConfig {
     pub fn from_btreemap(properties: BTreeMap<String, String>) -> Result<Self> {
-        let config = serde_json::from_value::<DeltaLakeConfig>(
+        let mut config = serde_json::from_value::<DeltaLakeConfig>(
             serde_json::to_value(properties).map_err(|e| SinkError::DeltaLake(e.into()))?,
         )
         .map_err(|e| SinkError::Config(anyhow!(e)))?;
+        for key in [
+            "aws.credentials.access_key_id",
+            "aws.credentials.role.arn",
+            "aws.credentials.role.external_id",
+            "aws.credentials.secret_access_key",
+            "aws.credentials.session_token",
+            "aws.endpoint_url",
+            "aws.msk.signer_timeout_sec",
+            "aws.profile",
+            "aws.region",
+            "access_key",
+            "arn",
+            "commit_checkpoint_interval",
+            "endpoint",
+            "endpoint_url",
+            "external_id",
+            "gcs.service.account",
+            "is_exactly_once",
+            "location",
+            "profile",
+            "region",
+            "s3.access.key",
+            "s3.endpoint",
+            "s3.region",
+            "s3.secret.key",
+            "secret_key",
+            "session_token",
+            "type",
+        ] {
+            config.unknown_fields.remove(key);
+        }
         Ok(config)
     }
 }
@@ -345,6 +376,8 @@ impl Sink for DeltaLakeSink {
     type LogSinker = CoordinatedLogSinker<DeltaLakeSinkWriter>;
 
     const SINK_NAME: &'static str = DELTALAKE_SINK;
+
+    crate::impl_validate_sink_unknown_fields!();
 
     async fn new_log_sinker(&self, writer_param: SinkWriterParam) -> Result<Self::LogSinker> {
         let inner = DeltaLakeSinkWriter::new(

--- a/src/connector/src/sink/doris.rs
+++ b/src/connector/src/sink/doris.rs
@@ -253,6 +253,8 @@ impl Sink for DorisSink {
 
     const SINK_NAME: &'static str = DORIS_SINK;
 
+    crate::impl_validate_sink_unknown_fields!();
+
     async fn new_log_sinker(&self, writer_param: SinkWriterParam) -> Result<Self::LogSinker> {
         Ok(DorisSinkWriter::new(
             self.config.clone(),
@@ -576,14 +578,16 @@ mod tests {
 
     #[test]
     fn test_jsonb_can_write_to_variant() {
-        assert!(DorisSink::check_and_correct_column_type(&DataType::Jsonb, "VARIANT".into())
-            .unwrap());
+        assert!(
+            DorisSink::check_and_correct_column_type(&DataType::Jsonb, "VARIANT".into()).unwrap()
+        );
     }
 
     #[test]
     fn test_varchar_can_write_to_variant() {
-        assert!(DorisSink::check_and_correct_column_type(&DataType::Varchar, "VARIANT".into())
-            .unwrap());
+        assert!(
+            DorisSink::check_and_correct_column_type(&DataType::Varchar, "VARIANT".into()).unwrap()
+        );
     }
 }
 

--- a/src/connector/src/sink/doris.rs
+++ b/src/connector/src/sink/doris.rs
@@ -96,7 +96,12 @@ pub struct DorisConfig {
     #[serde_as(as = "DisplayFromStr")]
     #[with_option(allow_alter_on_fly)]
     pub stream_load_http_timeout_ms: u64,
+
+    #[serde(flatten)]
+    pub unknown_fields: std::collections::HashMap<String, String>,
 }
+
+crate::impl_sink_unknown_fields!(DorisConfig);
 
 impl EnforceSecret for DorisConfig {
     fn enforce_one(prop: &str) -> crate::error::ConnectorResult<()> {

--- a/src/connector/src/sink/dynamodb.rs
+++ b/src/connector/src/sink/dynamodb.rs
@@ -82,7 +82,12 @@ pub struct DynamoDbConfig {
     )]
     #[serde_as(as = "DisplayFromStr")]
     pub batch_write_retry_backoff_ms: u64,
+
+    #[serde(flatten)]
+    pub unknown_fields: std::collections::HashMap<String, String>,
 }
+
+crate::impl_sink_unknown_fields!(DynamoDbConfig);
 
 impl EnforceSecret for DynamoDbConfig {
     fn enforce_one(prop: &str) -> crate::error::ConnectorResult<()> {

--- a/src/connector/src/sink/dynamodb.rs
+++ b/src/connector/src/sink/dynamodb.rs
@@ -152,6 +152,8 @@ impl Sink for DynamoDbSink {
 
     const SINK_NAME: &'static str = DYNAMO_DB_SINK;
 
+    crate::impl_validate_sink_unknown_fields!();
+
     async fn validate(&self) -> Result<()> {
         risingwave_common::license::Feature::DynamoDbSink
             .check_available()

--- a/src/connector/src/sink/elasticsearch_opensearch/elasticsearch.rs
+++ b/src/connector/src/sink/elasticsearch_opensearch/elasticsearch.rs
@@ -65,6 +65,10 @@ impl Sink for ElasticSearchSink {
 
     const SINK_NAME: &'static str = ES_SINK;
 
+    fn validate_unknown_fields(&self) -> Result<()> {
+        crate::sink::validate_sink_unknown_fields(&self.config)
+    }
+
     fn support_schema_change() -> bool {
         true
     }

--- a/src/connector/src/sink/elasticsearch_opensearch/elasticsearch_opensearch_config.rs
+++ b/src/connector/src/sink/elasticsearch_opensearch/elasticsearch_opensearch_config.rs
@@ -42,14 +42,24 @@ pub const ES_OPTION_ROUTING_COLUMN: &str = "routing_column";
 pub struct ElasticSearchConfig {
     #[serde(flatten)]
     pub inner: ElasticSearchOpenSearchConfig,
+
+    #[serde(flatten)]
+    pub unknown_fields: std::collections::HashMap<String, String>,
 }
+
+crate::impl_sink_unknown_fields!(ElasticSearchConfig);
 
 #[serde_as]
 #[derive(Deserialize, Debug, Clone, WithOptions)]
 pub struct OpenSearchConfig {
     #[serde(flatten)]
     pub inner: ElasticSearchOpenSearchConfig,
+
+    #[serde(flatten)]
+    pub unknown_fields: std::collections::HashMap<String, String>,
 }
+
+crate::impl_sink_unknown_fields!(OpenSearchConfig);
 
 #[serde_as]
 #[derive(Deserialize, Debug, Clone, WithOptions)]

--- a/src/connector/src/sink/elasticsearch_opensearch/elasticsearch_opensearch_config.rs
+++ b/src/connector/src/sink/elasticsearch_opensearch/elasticsearch_opensearch_config.rs
@@ -42,24 +42,14 @@ pub const ES_OPTION_ROUTING_COLUMN: &str = "routing_column";
 pub struct ElasticSearchConfig {
     #[serde(flatten)]
     pub inner: ElasticSearchOpenSearchConfig,
-
-    #[serde(flatten)]
-    pub unknown_fields: std::collections::HashMap<String, String>,
 }
-
-crate::impl_sink_unknown_fields!(ElasticSearchConfig);
 
 #[serde_as]
 #[derive(Deserialize, Debug, Clone, WithOptions)]
 pub struct OpenSearchConfig {
     #[serde(flatten)]
     pub inner: ElasticSearchOpenSearchConfig,
-
-    #[serde(flatten)]
-    pub unknown_fields: std::collections::HashMap<String, String>,
 }
-
-crate::impl_sink_unknown_fields!(OpenSearchConfig);
 
 #[serde_as]
 #[derive(Deserialize, Debug, Clone, WithOptions)]
@@ -86,6 +76,9 @@ pub struct ElasticSearchOpenSearchConfig {
     #[serde(rename = "routing_column")]
     pub routing_column: Option<String>,
 
+    #[serde(flatten)]
+    pub unknown_fields: std::collections::HashMap<String, String>,
+
     #[serde(rename = "retry_on_conflict")]
     #[serde_as(as = "DisplayFromStr")]
     #[serde(default = "default_retry_on_conflict")]
@@ -109,6 +102,8 @@ pub struct ElasticSearchOpenSearchConfig {
     #[serde(default = "default_type")]
     pub r#type: String,
 }
+
+crate::impl_sink_unknown_fields!(ElasticSearchOpenSearchConfig);
 
 impl EnforceSecret for ElasticSearchOpenSearchConfig {
     const ENFORCE_SECRET_PROPERTIES: phf::Set<&'static str> = phf::phf_set! {

--- a/src/connector/src/sink/elasticsearch_opensearch/opensearch.rs
+++ b/src/connector/src/sink/elasticsearch_opensearch/opensearch.rs
@@ -66,6 +66,10 @@ impl Sink for OpenSearchSink {
 
     const SINK_NAME: &'static str = OPENSEARCH_SINK;
 
+    fn validate_unknown_fields(&self) -> Result<()> {
+        crate::sink::validate_sink_unknown_fields(&self.config)
+    }
+
     async fn validate(&self) -> Result<()> {
         risingwave_common::license::Feature::OpenSearchSink
             .check_available()

--- a/src/connector/src/sink/file_sink/azblob.rs
+++ b/src/connector/src/sink/file_sink/azblob.rs
@@ -101,6 +101,8 @@ impl UnknownFields for AzblobConfig {
     }
 }
 
+crate::impl_sink_unknown_fields!(AzblobConfig);
+
 impl OpendalSinkBackend for AzblobSink {
     type Properties = AzblobConfig;
 

--- a/src/connector/src/sink/file_sink/fs.rs
+++ b/src/connector/src/sink/file_sink/fs.rs
@@ -54,6 +54,8 @@ impl UnknownFields for FsConfig {
     }
 }
 
+crate::impl_sink_unknown_fields!(FsConfig);
+
 pub const FS_SINK: &str = "fs";
 
 impl<S: OpendalSinkBackend> FileSink<S> {

--- a/src/connector/src/sink/file_sink/gcs.rs
+++ b/src/connector/src/sink/file_sink/gcs.rs
@@ -66,6 +66,8 @@ impl UnknownFields for GcsConfig {
     }
 }
 
+crate::impl_sink_unknown_fields!(GcsConfig);
+
 pub const GCS_SINK: &str = "gcs";
 
 impl<S: OpendalSinkBackend> FileSink<S> {

--- a/src/connector/src/sink/file_sink/opendal_sink.rs
+++ b/src/connector/src/sink/file_sink/opendal_sink.rs
@@ -45,7 +45,7 @@ use crate::sink::encoder::{
     TimestamptzHandlingMode,
 };
 use crate::sink::file_sink::batching_log_sink::BatchingLogSinker;
-use crate::sink::{Result, Sink, SinkError, SinkFormatDesc, SinkParam};
+use crate::sink::{Result, Sink, SinkError, SinkFormatDesc, SinkParam, UnknownFields};
 use crate::source::TryFromBTreeMap;
 use crate::with_options::WithOptions;
 
@@ -77,6 +77,7 @@ pub struct FileSink<S: OpendalSinkBackend> {
     /// The description of the sink's format.
     pub(crate) format_desc: SinkFormatDesc,
     pub(crate) engine_type: EngineType,
+    pub(crate) unknown_fields: HashMap<String, String>,
     pub(crate) _marker: PhantomData<S>,
 }
 
@@ -99,7 +100,7 @@ impl<S: OpendalSinkBackend> EnforceSecret for FileSink<S> {}
 /// - `new_operator`: Creates a new operator using the provided backend properties.
 /// - `get_path`: Returns the path of the sink file specified by the user's create sink statement.
 pub trait OpendalSinkBackend: Send + Sync + 'static + Clone + PartialEq {
-    type Properties: TryFromBTreeMap + Send + Sync + Clone + WithOptions;
+    type Properties: TryFromBTreeMap + UnknownFields + Send + Sync + Clone + WithOptions;
     const SINK_NAME: &'static str;
 
     fn from_btreemap(btree_map: BTreeMap<String, String>) -> Result<Self::Properties>;
@@ -123,6 +124,10 @@ impl<S: OpendalSinkBackend> Sink for FileSink<S> {
     type LogSinker = BatchingLogSinker;
 
     const SINK_NAME: &'static str = S::SINK_NAME;
+
+    fn validate_unknown_fields(&self) -> Result<()> {
+        crate::sink::validate_sink_unknown_fields(&self.unknown_fields)
+    }
 
     async fn validate(&self) -> Result<()> {
         if matches!(self.engine_type, EngineType::Snowflake) {
@@ -176,6 +181,7 @@ impl<S: OpendalSinkBackend> TryFrom<SinkParam> for FileSink<S> {
     fn try_from(param: SinkParam) -> std::result::Result<Self, Self::Error> {
         let schema = param.schema();
         let config = S::from_btreemap(param.properties)?;
+        let unknown_fields = crate::sink::UnknownFields::unknown_fields(&config);
         let path = S::get_path(config.clone());
         let op = S::new_operator(config.clone())?;
         let batching_strategy = S::get_batching_strategy(config);
@@ -198,6 +204,7 @@ impl<S: OpendalSinkBackend> TryFrom<SinkParam> for FileSink<S> {
             batching_strategy,
             format_desc,
             engine_type,
+            unknown_fields,
             _marker: PhantomData,
         })
     }

--- a/src/connector/src/sink/file_sink/s3.rs
+++ b/src/connector/src/sink/file_sink/s3.rs
@@ -179,17 +179,6 @@ impl OpendalSinkBackend for S3Sink {
 pub struct SnowflakeConfig {
     #[serde(flatten)]
     pub inner: S3Config,
-
-    #[serde(flatten)]
-    pub unknown_fields: HashMap<String, String>,
-}
-
-impl crate::sink::UnknownFields for SnowflakeConfig {
-    fn unknown_fields(&self) -> HashMap<String, String> {
-        let mut unknown_fields = crate::sink::UnknownFields::unknown_fields(&self.inner);
-        unknown_fields.extend(self.unknown_fields.clone());
-        unknown_fields
-    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/src/connector/src/sink/file_sink/s3.rs
+++ b/src/connector/src/sink/file_sink/s3.rs
@@ -131,6 +131,8 @@ impl UnknownFields for S3Config {
     }
 }
 
+crate::impl_sink_unknown_fields!(S3Config);
+
 impl OpendalSinkBackend for S3Sink {
     type Properties = S3Config;
 
@@ -177,6 +179,17 @@ impl OpendalSinkBackend for S3Sink {
 pub struct SnowflakeConfig {
     #[serde(flatten)]
     pub inner: S3Config,
+
+    #[serde(flatten)]
+    pub unknown_fields: HashMap<String, String>,
+}
+
+impl crate::sink::UnknownFields for SnowflakeConfig {
+    fn unknown_fields(&self) -> HashMap<String, String> {
+        let mut unknown_fields = crate::sink::UnknownFields::unknown_fields(&self.inner);
+        unknown_fields.extend(self.unknown_fields.clone());
+        unknown_fields
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/src/connector/src/sink/file_sink/webhdfs.rs
+++ b/src/connector/src/sink/file_sink/webhdfs.rs
@@ -76,6 +76,8 @@ impl UnknownFields for WebhdfsConfig {
     }
 }
 
+crate::impl_sink_unknown_fields!(WebhdfsConfig);
+
 impl OpendalSinkBackend for WebhdfsSink {
     type Properties = WebhdfsConfig;
 

--- a/src/connector/src/sink/google_pubsub.rs
+++ b/src/connector/src/sink/google_pubsub.rs
@@ -97,7 +97,12 @@ pub struct GooglePubSubConfig {
     /// `pubsub.publisher` [role](https://cloud.google.com/pubsub/docs/access-control#roles)
     #[serde(rename = "pubsub.credentials")]
     pub credentials: Option<String>,
+
+    #[serde(flatten)]
+    pub unknown_fields: std::collections::HashMap<String, String>,
 }
+
+crate::impl_sink_unknown_fields!(GooglePubSubConfig);
 
 impl EnforceSecret for GooglePubSubConfig {
     const ENFORCE_SECRET_PROPERTIES: phf::Set<&'static str> = phf::phf_set! {

--- a/src/connector/src/sink/google_pubsub.rs
+++ b/src/connector/src/sink/google_pubsub.rs
@@ -16,6 +16,7 @@ use std::collections::BTreeMap;
 
 use anyhow::anyhow;
 use google_cloud_gax::conn::Environment;
+use google_cloud_gax::grpc::Status;
 use google_cloud_googleapis::pubsub::v1::PubsubMessage;
 use google_cloud_pubsub::apiv1;
 use google_cloud_pubsub::client::google_cloud_auth::credentials::CredentialsFile;
@@ -27,7 +28,6 @@ use risingwave_common::array::StreamChunk;
 use risingwave_common::catalog::Schema;
 use serde::Deserialize;
 use serde_with::serde_as;
-use google_cloud_gax::grpc::Status;
 use with_options::WithOptions;
 
 use super::catalog::SinkFormatDesc;
@@ -143,6 +143,8 @@ impl Sink for GooglePubSubSink {
     type LogSinker = AsyncTruncateLogSinkerOf<GooglePubSubSinkWriter>;
 
     const SINK_NAME: &'static str = PUBSUB_SINK;
+
+    crate::impl_validate_sink_unknown_fields!();
 
     async fn validate(&self) -> Result<()> {
         if !self.is_append_only {

--- a/src/connector/src/sink/http.rs
+++ b/src/connector/src/sink/http.rs
@@ -98,6 +98,7 @@ fn validate_http_sink(
     url: Option<&str>,
     content_type: Option<&str>,
     headers: &BTreeMap<String, String>,
+    unknown_fields: std::collections::HashMap<String, String>,
 ) -> Result<HttpSink> {
     if !is_append_only && !ignore_delete {
         return Err(SinkError::Config(anyhow!(
@@ -209,6 +210,7 @@ fn validate_http_sink(
         url,
         payload_index,
         header_map,
+        unknown_fields,
     })
 }
 
@@ -217,6 +219,7 @@ pub struct HttpSink {
     url: HttpUrl,
     payload_index: usize,
     header_map: HeaderMap,
+    unknown_fields: std::collections::HashMap<String, String>,
 }
 
 impl EnforceSecret for HttpSink {
@@ -243,6 +246,7 @@ impl TryFrom<SinkParam> for HttpSink {
             config.url.as_deref(),
             config.content_type.as_deref(),
             &headers,
+            config.unknown_fields,
         )
     }
 }
@@ -251,6 +255,10 @@ impl Sink for HttpSink {
     type LogSinker = AsyncTruncateLogSinkerOf<HttpSinkWriter>;
 
     const SINK_NAME: &'static str = HTTP_SINK;
+
+    fn validate_unknown_fields(&self) -> Result<()> {
+        crate::sink::validate_sink_unknown_fields(&self.unknown_fields)
+    }
 
     async fn validate(&self) -> Result<()> {
         Ok(())

--- a/src/connector/src/sink/http.rs
+++ b/src/connector/src/sink/http.rs
@@ -46,7 +46,12 @@ pub struct HttpConfig {
 
     /// Sink type, must be "append-only".
     pub r#type: String,
+
+    #[serde(flatten)]
+    pub unknown_fields: std::collections::HashMap<String, String>,
 }
+
+crate::impl_sink_unknown_fields!(HttpConfig);
 
 impl EnforceSecret for HttpConfig {}
 

--- a/src/connector/src/sink/iceberg/config.rs
+++ b/src/connector/src/sink/iceberg/config.rs
@@ -581,6 +581,9 @@ impl IcebergConfig {
                 .iter()
                 .map(|(key, value)| (key.as_str(), value.as_str())),
         );
+        config
+            .unknown_fields
+            .retain(|key, _| key != "connector" && !key.starts_with("catalog."));
 
         if config.commit_checkpoint_interval == 0 {
             return Err(SinkError::Config(anyhow!(

--- a/src/connector/src/sink/iceberg/config.rs
+++ b/src/connector/src/sink/iceberg/config.rs
@@ -463,7 +463,12 @@ pub struct IcebergConfig {
         deserialize_with = "deserialize_bool_from_string"
     )]
     pub enable_pk_index: bool,
+
+    #[serde(flatten)]
+    pub unknown_fields: std::collections::HashMap<String, String>,
 }
+
+crate::impl_sink_unknown_fields!(IcebergConfig);
 
 impl EnforceSecret for IcebergConfig {
     fn enforce_secret<'a>(

--- a/src/connector/src/sink/iceberg/mod.rs
+++ b/src/connector/src/sink/iceberg/mod.rs
@@ -146,6 +146,8 @@ impl Sink for IcebergSink {
 
     const SINK_NAME: &'static str = ICEBERG_SINK;
 
+    crate::impl_validate_sink_unknown_fields!();
+
     async fn validate(&self) -> Result<()> {
         let catalog_kind = self.config.catalog_kind()?;
         if matches!(catalog_kind, IcebergCatalogKind::Snowflake) {

--- a/src/connector/src/sink/iceberg/test.rs
+++ b/src/connector/src/sink/iceberg/test.rs
@@ -401,6 +401,7 @@ fn test_parse_iceberg_config() {
             write_parquet_max_row_group_rows: None,
             write_parquet_max_row_group_bytes: None,
             enable_pk_index: false,
+            unknown_fields: Default::default(),
         };
 
     assert_eq!(iceberg_config, expected_iceberg_config);

--- a/src/connector/src/sink/kafka.rs
+++ b/src/connector/src/sink/kafka.rs
@@ -347,6 +347,8 @@ impl Sink for KafkaSink {
 
     const SINK_NAME: &'static str = KAFKA_SINK;
 
+    crate::impl_validate_sink_unknown_fields!();
+
     async fn new_log_sinker(&self, _writer_param: SinkWriterParam) -> Result<Self::LogSinker> {
         let formatter = SinkFormatterImpl::new(
             &self.format_desc,

--- a/src/connector/src/sink/kafka.rs
+++ b/src/connector/src/sink/kafka.rs
@@ -252,7 +252,12 @@ pub struct KafkaConfig {
 
     #[serde(flatten)]
     pub aws_auth_props: AwsAuthProps,
+
+    #[serde(flatten)]
+    pub unknown_fields: std::collections::HashMap<String, String>,
 }
+
+crate::impl_sink_unknown_fields!(KafkaConfig);
 
 impl EnforceSecret for KafkaConfig {
     fn enforce_one(prop: &str) -> crate::error::ConnectorResult<()> {

--- a/src/connector/src/sink/kinesis.rs
+++ b/src/connector/src/sink/kinesis.rs
@@ -138,7 +138,12 @@ impl Sink for KinesisSink {
 pub struct KinesisSinkConfig {
     #[serde(flatten)]
     pub common: KinesisCommon,
+
+    #[serde(flatten)]
+    pub unknown_fields: std::collections::HashMap<String, String>,
 }
+
+crate::impl_sink_unknown_fields!(KinesisSinkConfig);
 
 impl EnforceSecret for KinesisSinkConfig {
     fn enforce_one(prop: &str) -> crate::error::ConnectorResult<()> {

--- a/src/connector/src/sink/kinesis.rs
+++ b/src/connector/src/sink/kinesis.rs
@@ -88,6 +88,8 @@ impl Sink for KinesisSink {
 
     const SINK_NAME: &'static str = KINESIS_SINK;
 
+    crate::impl_validate_sink_unknown_fields!();
+
     async fn validate(&self) -> Result<()> {
         // Kinesis requires partition key. There is no builtin support for round-robin as in kafka/pulsar.
         // https://docs.aws.amazon.com/kinesis/latest/APIReference/API_PutRecord.html#Streams-PutRecord-request-PartitionKey

--- a/src/connector/src/sink/mod.rs
+++ b/src/connector/src/sink/mod.rs
@@ -274,13 +274,35 @@ macro_rules! impl_sink_unknown_fields {
     };
 }
 
-fn validate_sink_options_with_config<C>(properties: BTreeMap<String, String>) -> Result<()>
+pub trait SinkConfig {
+    type Config: DeserializeOwned + UnknownFields;
+}
+
+macro_rules! impl_sink_config {
+    ({ $({ $variant_name:ident, $sink_type:ty, $config_type:ty }),* }) => {
+        $(
+            impl $crate::sink::SinkConfig for $sink_type {
+                type Config = $config_type;
+            }
+        )*
+    };
+}
+
+for_all_sinks! { impl_sink_config }
+
+pub fn validate_sink_options_with_config<C>(
+    properties: BTreeMap<String, String>,
+    deny_unknown_fields: bool,
+) -> Result<()>
 where
     C: DeserializeOwned + UnknownFields,
 {
     let config = serde_json::from_value::<C>(serde_json::to_value(properties).unwrap())
         .map_err(|e| SinkError::Config(anyhow!(e)))?;
     let mut unknown_fields = config.unknown_fields();
+    if !deny_unknown_fields {
+        return Ok(());
+    }
     // These options are consumed by the sink DDL/planner layer. They are valid for sink creation
     // even if a connector-specific config does not declare them.
     for key in [
@@ -301,40 +323,6 @@ where
             unknown_fields
         )))
     }
-}
-
-macro_rules! validate_sink_options_for_type {
-    ({$({$variant_name:ident, $sink_type:ty, $config_type:ty}),*}, $connector:expr, $properties:expr) => {{
-        match $connector {
-            $(
-                <$sink_type>::SINK_NAME => {
-                    validate_sink_options_with_config::<$config_type>($properties.clone())
-                },
-            )*
-            other => Err(SinkError::Config(anyhow!(
-                "unsupported sink connector {}",
-                other
-            ))),
-        }
-    }};
-}
-
-/// Validate raw `CREATE SINK` `WITH` options against the selected sink config.
-///
-/// Runtime and recovery paths intentionally keep using [`build_sink`] without this validation, so
-/// old catalog entries with unknown options remain compatible after upgrade.
-pub fn validate_sink_options_on_create(properties: &BTreeMap<String, String>) -> Result<()> {
-    let connector = properties
-        .get(CONNECTOR_TYPE_KEY)
-        .ok_or_else(|| SinkError::Config(anyhow!("missing config: {}", CONNECTOR_TYPE_KEY)))?
-        .to_lowercase();
-
-    let mut properties = properties.clone();
-    if connector == self::http::HTTP_SINK {
-        properties.retain(|key, _| !key.starts_with("header."));
-    }
-
-    for_all_sinks! { validate_sink_options_for_type, { connector.as_str() }, properties }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -1233,49 +1221,88 @@ mod tests {
     }
 
     #[test]
-    fn test_validate_sink_options_on_create() {
-        validate_sink_options_on_create(&btreemap([
-            (CONNECTOR_TYPE_KEY, "redis"),
-            (SINK_TYPE_OPTION, SINK_TYPE_APPEND_ONLY),
-            ("primary_key", "id"),
-            ("redis.url", "redis://127.0.0.1:6379"),
-        ]))
+    fn test_validate_sink_options_with_config() {
+        validate_sink_options_with_config::<crate::sink::redis::RedisConfig>(
+            btreemap([
+                (CONNECTOR_TYPE_KEY, "redis"),
+                (SINK_TYPE_OPTION, SINK_TYPE_APPEND_ONLY),
+                ("primary_key", "id"),
+                ("redis.url", "redis://127.0.0.1:6379"),
+            ]),
+            true,
+        )
         .unwrap();
 
-        let err = validate_sink_options_on_create(&btreemap([
-            (CONNECTOR_TYPE_KEY, "redis"),
-            (SINK_TYPE_OPTION, SINK_TYPE_APPEND_ONLY),
-            ("redis.url", "redis://127.0.0.1:6379"),
-            ("bogus_with", "1"),
-        ]))
+        let err = validate_sink_options_with_config::<crate::sink::redis::RedisConfig>(
+            btreemap([
+                (CONNECTOR_TYPE_KEY, "redis"),
+                (SINK_TYPE_OPTION, SINK_TYPE_APPEND_ONLY),
+                ("redis.url", "redis://127.0.0.1:6379"),
+                ("bogus_with", "1"),
+            ]),
+            true,
+        )
         .unwrap_err();
         let report = err.to_report_string();
         assert!(report.contains("bogus_with"), "{report}");
 
-        validate_sink_options_on_create(&btreemap([
-            (CONNECTOR_TYPE_KEY, "snowflake_v2"),
-            (SINK_TYPE_OPTION, SINK_TYPE_APPEND_ONLY),
-            (
-                "jdbc.url",
-                "jdbc:snowflake://account.snowflakecomputing.com",
-            ),
-            ("database", "db"),
-            ("schema", "public"),
-            ("warehouse", "wh"),
-            ("username", "user"),
-            ("password", "password"),
-            ("auto.schema.change", "true"),
-        ]))
+        validate_sink_options_with_config::<
+            crate::sink::snowflake_redshift::snowflake::SnowflakeV2Config,
+        >(
+            btreemap([
+                (CONNECTOR_TYPE_KEY, "snowflake_v2"),
+                (SINK_TYPE_OPTION, SINK_TYPE_APPEND_ONLY),
+                (
+                    "jdbc.url",
+                    "jdbc:snowflake://account.snowflakecomputing.com",
+                ),
+                ("database", "db"),
+                ("schema", "public"),
+                ("warehouse", "wh"),
+                ("username", "user"),
+                ("password", "password"),
+                ("auto.schema.change", "true"),
+            ]),
+            true,
+        )
         .unwrap();
 
-        let err = validate_sink_options_on_create(&btreemap([
-            (CONNECTOR_TYPE_KEY, "redis"),
-            (SINK_TYPE_OPTION, SINK_TYPE_APPEND_ONLY),
-            ("redis.url", "redis://127.0.0.1:6379"),
-            ("auto.schema.change", "true"),
-        ]))
+        let err = validate_sink_options_with_config::<crate::sink::redis::RedisConfig>(
+            btreemap([
+                (CONNECTOR_TYPE_KEY, "redis"),
+                (SINK_TYPE_OPTION, SINK_TYPE_APPEND_ONLY),
+                ("redis.url", "redis://127.0.0.1:6379"),
+                ("auto.schema.change", "true"),
+            ]),
+            true,
+        )
         .unwrap_err();
         assert!(err.to_report_string().contains("auto.schema.change"));
+
+        validate_sink_options_with_config::<crate::sink::redis::RedisConfig>(
+            btreemap([
+                (CONNECTOR_TYPE_KEY, "redis"),
+                (SINK_TYPE_OPTION, SINK_TYPE_APPEND_ONLY),
+                ("redis.url", "redis://127.0.0.1:6379"),
+                ("bogus_with", "1"),
+            ]),
+            false,
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn test_sink_config_associated_type_matches_registry() {
+        validate_sink_options_with_config::<<crate::sink::redis::RedisSink as SinkConfig>::Config>(
+            btreemap([
+                (CONNECTOR_TYPE_KEY, "redis"),
+                (SINK_TYPE_OPTION, SINK_TYPE_APPEND_ONLY),
+                ("primary_key", "id"),
+                ("redis.url", "redis://127.0.0.1:6379"),
+            ]),
+            true,
+        )
+        .unwrap();
     }
 }
 

--- a/src/connector/src/sink/mod.rs
+++ b/src/connector/src/sink/mod.rs
@@ -298,6 +298,7 @@ pub fn validate_sink_unknown_fields(config: &impl UnknownFields) -> Result<()> {
         SINK_SNAPSHOT_OPTION,
         SINK_USER_IGNORE_DELETE_OPTION,
         SINK_USER_FORCE_APPEND_ONLY_OPTION,
+        SINK_USER_FORCE_COMPACTION,
         "backfill_rate_limit",
         "primary_key",
         "sink_rate_limit",
@@ -1271,6 +1272,7 @@ mod tests {
             (CONNECTOR_TYPE_KEY, "redis"),
             (SINK_TYPE_OPTION, SINK_TYPE_APPEND_ONLY),
             ("primary_key", "id"),
+            (SINK_USER_FORCE_COMPACTION, "true"),
             ("redis.url", "redis://127.0.0.1:6379"),
         ]))
         .unwrap();

--- a/src/connector/src/sink/mod.rs
+++ b/src/connector/src/sink/mod.rs
@@ -95,7 +95,6 @@ use risingwave_pb::connector_service::{PbSinkParam, SinkMetadata, TableSchema};
 use risingwave_pb::id::ExecutorId;
 use risingwave_rpc_client::MetaClient;
 use risingwave_rpc_client::error::RpcError;
-use serde::de::DeserializeOwned;
 use starrocks::STARROCKS_SINK;
 use thiserror::Error;
 use thiserror_ext::AsReport;
@@ -263,6 +262,12 @@ impl UnknownFields for () {
     }
 }
 
+impl UnknownFields for HashMap<String, String> {
+    fn unknown_fields(&self) -> HashMap<String, String> {
+        self.clone()
+    }
+}
+
 #[macro_export]
 macro_rules! impl_sink_unknown_fields {
     ($config_type:ty) => {
@@ -274,35 +279,17 @@ macro_rules! impl_sink_unknown_fields {
     };
 }
 
-pub trait SinkConfig {
-    type Config: DeserializeOwned + UnknownFields;
-}
-
-macro_rules! impl_sink_config {
-    ({ $({ $variant_name:ident, $sink_type:ty, $config_type:ty }),* }) => {
-        $(
-            impl $crate::sink::SinkConfig for $sink_type {
-                type Config = $config_type;
-            }
-        )*
+#[macro_export]
+macro_rules! impl_validate_sink_unknown_fields {
+    () => {
+        fn validate_unknown_fields(&self) -> $crate::sink::Result<()> {
+            $crate::sink::validate_sink_unknown_fields(&self.config)
+        }
     };
 }
 
-for_all_sinks! { impl_sink_config }
-
-pub fn validate_sink_options_with_config<C>(
-    properties: BTreeMap<String, String>,
-    deny_unknown_fields: bool,
-) -> Result<()>
-where
-    C: DeserializeOwned + UnknownFields,
-{
-    let config = serde_json::from_value::<C>(serde_json::to_value(properties).unwrap())
-        .map_err(|e| SinkError::Config(anyhow!(e)))?;
+pub fn validate_sink_unknown_fields(config: &impl UnknownFields) -> Result<()> {
     let mut unknown_fields = config.unknown_fields();
-    if !deny_unknown_fields {
-        return Ok(());
-    }
     // These options are consumed by the sink DDL/planner layer. They are valid for sink creation
     // even if a connector-specific config does not declare them.
     for key in [
@@ -311,7 +298,9 @@ where
         SINK_SNAPSHOT_OPTION,
         SINK_USER_IGNORE_DELETE_OPTION,
         SINK_USER_FORCE_APPEND_ONLY_OPTION,
+        "backfill_rate_limit",
         "primary_key",
+        "sink_rate_limit",
     ] {
         unknown_fields.remove(key);
     }
@@ -844,6 +833,10 @@ pub trait Sink: TryFrom<SinkParam, Error = SinkError> {
         Ok(())
     }
 
+    fn validate_unknown_fields(&self) -> Result<()> {
+        Ok(())
+    }
+
     async fn validate(&self) -> Result<()>;
     async fn new_log_sinker(&self, writer_param: SinkWriterParam) -> Result<Self::LogSinker>;
 
@@ -1003,6 +996,10 @@ impl SinkImpl {
 
     pub fn is_coordinated_sink(&self) -> bool {
         dispatch_sink!(self, sink, sink.is_coordinated_sink())
+    }
+
+    pub fn validate_unknown_fields(&self) -> Result<()> {
+        dispatch_sink!(self, sink, sink.validate_unknown_fields())
     }
 }
 
@@ -1221,88 +1218,33 @@ mod tests {
     }
 
     #[test]
-    fn test_validate_sink_options_with_config() {
-        validate_sink_options_with_config::<crate::sink::redis::RedisConfig>(
-            btreemap([
-                (CONNECTOR_TYPE_KEY, "redis"),
-                (SINK_TYPE_OPTION, SINK_TYPE_APPEND_ONLY),
-                ("primary_key", "id"),
-                ("redis.url", "redis://127.0.0.1:6379"),
-            ]),
-            true,
-        )
+    fn test_validate_sink_unknown_fields() {
+        let config = crate::sink::redis::RedisConfig::from_btreemap(btreemap([
+            (CONNECTOR_TYPE_KEY, "redis"),
+            (SINK_TYPE_OPTION, SINK_TYPE_APPEND_ONLY),
+            ("primary_key", "id"),
+            ("redis.url", "redis://127.0.0.1:6379"),
+        ]))
         .unwrap();
+        validate_sink_unknown_fields(&config).unwrap();
 
-        let err = validate_sink_options_with_config::<crate::sink::redis::RedisConfig>(
-            btreemap([
-                (CONNECTOR_TYPE_KEY, "redis"),
-                (SINK_TYPE_OPTION, SINK_TYPE_APPEND_ONLY),
-                ("redis.url", "redis://127.0.0.1:6379"),
-                ("bogus_with", "1"),
-            ]),
-            true,
-        )
-        .unwrap_err();
+        let config = crate::sink::redis::RedisConfig::from_btreemap(btreemap([
+            (CONNECTOR_TYPE_KEY, "redis"),
+            (SINK_TYPE_OPTION, SINK_TYPE_APPEND_ONLY),
+            ("redis.url", "redis://127.0.0.1:6379"),
+            ("bogus_with", "1"),
+        ]))
+        .unwrap();
+        let err = validate_sink_unknown_fields(&config).unwrap_err();
         let report = err.to_report_string();
         assert!(report.contains("bogus_with"), "{report}");
 
-        validate_sink_options_with_config::<
-            crate::sink::snowflake_redshift::snowflake::SnowflakeV2Config,
-        >(
-            btreemap([
-                (CONNECTOR_TYPE_KEY, "snowflake_v2"),
-                (SINK_TYPE_OPTION, SINK_TYPE_APPEND_ONLY),
-                (
-                    "jdbc.url",
-                    "jdbc:snowflake://account.snowflakecomputing.com",
-                ),
-                ("database", "db"),
-                ("schema", "public"),
-                ("warehouse", "wh"),
-                ("username", "user"),
-                ("password", "password"),
-                ("auto.schema.change", "true"),
-            ]),
-            true,
-        )
-        .unwrap();
-
-        let err = validate_sink_options_with_config::<crate::sink::redis::RedisConfig>(
-            btreemap([
-                (CONNECTOR_TYPE_KEY, "redis"),
-                (SINK_TYPE_OPTION, SINK_TYPE_APPEND_ONLY),
-                ("redis.url", "redis://127.0.0.1:6379"),
-                ("auto.schema.change", "true"),
-            ]),
-            true,
-        )
+        let err = crate::sink::kafka::KafkaConfig::from_btreemap(btreemap([
+            (CONNECTOR_TYPE_KEY, "kafka"),
+            (SINK_TYPE_OPTION, SINK_TYPE_APPEND_ONLY),
+        ]))
         .unwrap_err();
-        assert!(err.to_report_string().contains("auto.schema.change"));
-
-        validate_sink_options_with_config::<crate::sink::redis::RedisConfig>(
-            btreemap([
-                (CONNECTOR_TYPE_KEY, "redis"),
-                (SINK_TYPE_OPTION, SINK_TYPE_APPEND_ONLY),
-                ("redis.url", "redis://127.0.0.1:6379"),
-                ("bogus_with", "1"),
-            ]),
-            false,
-        )
-        .unwrap();
-    }
-
-    #[test]
-    fn test_sink_config_associated_type_matches_registry() {
-        validate_sink_options_with_config::<<crate::sink::redis::RedisSink as SinkConfig>::Config>(
-            btreemap([
-                (CONNECTOR_TYPE_KEY, "redis"),
-                (SINK_TYPE_OPTION, SINK_TYPE_APPEND_ONLY),
-                ("primary_key", "id"),
-                ("redis.url", "redis://127.0.0.1:6379"),
-            ]),
-            true,
-        )
-        .unwrap();
+        assert!(err.to_report_string().contains("missing field `topic`"));
     }
 }
 

--- a/src/connector/src/sink/mod.rs
+++ b/src/connector/src/sink/mod.rs
@@ -1204,50 +1204,6 @@ impl From<OpendalError> for SinkError {
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use std::collections::BTreeMap;
-
-    use super::*;
-
-    fn btreemap<const N: usize>(entries: [(&str, &str); N]) -> BTreeMap<String, String> {
-        entries
-            .into_iter()
-            .map(|(key, value)| (key.to_owned(), value.to_owned()))
-            .collect()
-    }
-
-    #[test]
-    fn test_validate_sink_unknown_fields() {
-        let config = crate::sink::redis::RedisConfig::from_btreemap(btreemap([
-            (CONNECTOR_TYPE_KEY, "redis"),
-            (SINK_TYPE_OPTION, SINK_TYPE_APPEND_ONLY),
-            ("primary_key", "id"),
-            ("redis.url", "redis://127.0.0.1:6379"),
-        ]))
-        .unwrap();
-        validate_sink_unknown_fields(&config).unwrap();
-
-        let config = crate::sink::redis::RedisConfig::from_btreemap(btreemap([
-            (CONNECTOR_TYPE_KEY, "redis"),
-            (SINK_TYPE_OPTION, SINK_TYPE_APPEND_ONLY),
-            ("redis.url", "redis://127.0.0.1:6379"),
-            ("bogus_with", "1"),
-        ]))
-        .unwrap();
-        let err = validate_sink_unknown_fields(&config).unwrap_err();
-        let report = err.to_report_string();
-        assert!(report.contains("bogus_with"), "{report}");
-
-        let err = crate::sink::kafka::KafkaConfig::from_btreemap(btreemap([
-            (CONNECTOR_TYPE_KEY, "kafka"),
-            (SINK_TYPE_OPTION, SINK_TYPE_APPEND_ONLY),
-        ]))
-        .unwrap_err();
-        assert!(err.to_report_string().contains("missing field `topic`"));
-    }
-}
-
 impl From<parquet::errors::ParquetError> for SinkError {
     fn from(error: parquet::errors::ParquetError) -> Self {
         SinkError::File(error.to_report_string())
@@ -1293,5 +1249,49 @@ impl From<::opensearch::Error> for SinkError {
 impl From<tokio_postgres::Error> for SinkError {
     fn from(err: tokio_postgres::Error) -> Self {
         SinkError::Postgres(anyhow!(err))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+
+    use super::*;
+
+    fn btreemap<const N: usize>(entries: [(&str, &str); N]) -> BTreeMap<String, String> {
+        entries
+            .into_iter()
+            .map(|(key, value)| (key.to_owned(), value.to_owned()))
+            .collect()
+    }
+
+    #[test]
+    fn test_validate_sink_unknown_fields() {
+        let config = crate::sink::redis::RedisConfig::from_btreemap(btreemap([
+            (CONNECTOR_TYPE_KEY, "redis"),
+            (SINK_TYPE_OPTION, SINK_TYPE_APPEND_ONLY),
+            ("primary_key", "id"),
+            ("redis.url", "redis://127.0.0.1:6379"),
+        ]))
+        .unwrap();
+        validate_sink_unknown_fields(&config).unwrap();
+
+        let config = crate::sink::redis::RedisConfig::from_btreemap(btreemap([
+            (CONNECTOR_TYPE_KEY, "redis"),
+            (SINK_TYPE_OPTION, SINK_TYPE_APPEND_ONLY),
+            ("redis.url", "redis://127.0.0.1:6379"),
+            ("bogus_with", "1"),
+        ]))
+        .unwrap();
+        let err = validate_sink_unknown_fields(&config).unwrap_err();
+        let report = err.to_report_string();
+        assert!(report.contains("bogus_with"), "{report}");
+
+        let err = crate::sink::kafka::KafkaConfig::from_btreemap(btreemap([
+            (CONNECTOR_TYPE_KEY, "kafka"),
+            (SINK_TYPE_OPTION, SINK_TYPE_APPEND_ONLY),
+        ]))
+        .unwrap_err();
+        assert!(err.to_report_string().contains("missing field `topic`"));
     }
 }

--- a/src/connector/src/sink/mod.rs
+++ b/src/connector/src/sink/mod.rs
@@ -299,6 +299,7 @@ pub fn validate_sink_unknown_fields(config: &impl UnknownFields) -> Result<()> {
         SINK_USER_IGNORE_DELETE_OPTION,
         SINK_USER_FORCE_APPEND_ONLY_OPTION,
         SINK_USER_FORCE_COMPACTION,
+        SINK_USER_PRESERVE_ROW_LEVEL_CHANGES,
         "backfill_rate_limit",
         "primary_key",
         "sink_rate_limit",
@@ -1273,6 +1274,7 @@ mod tests {
             (SINK_TYPE_OPTION, SINK_TYPE_APPEND_ONLY),
             ("primary_key", "id"),
             (SINK_USER_FORCE_COMPACTION, "true"),
+            (SINK_USER_PRESERVE_ROW_LEVEL_CHANGES, "true"),
             ("redis.url", "redis://127.0.0.1:6379"),
         ]))
         .unwrap();

--- a/src/connector/src/sink/mod.rs
+++ b/src/connector/src/sink/mod.rs
@@ -59,7 +59,7 @@ pub mod prelude {
     };
 }
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashMap};
 use std::future::Future;
 use std::sync::{Arc, LazyLock};
 
@@ -95,6 +95,7 @@ use risingwave_pb::connector_service::{PbSinkParam, SinkMetadata, TableSchema};
 use risingwave_pb::id::ExecutorId;
 use risingwave_rpc_client::MetaClient;
 use risingwave_rpc_client::error::RpcError;
+use serde::de::DeserializeOwned;
 use starrocks::STARROCKS_SINK;
 use thiserror::Error;
 use thiserror_ext::AsReport;
@@ -250,6 +251,91 @@ pub const SINK_USER_FORCE_COMPACTION: &str = "force_compaction";
 /// same downstream primary key instead of compacting them into one final-state update within a
 /// barrier. Upstream changes under the same stream key may still be compacted earlier.
 pub const SINK_USER_PRESERVE_ROW_LEVEL_CHANGES: &str = "preserve_row_level_changes";
+
+pub trait UnknownFields {
+    /// Unrecognized fields in the `WITH` clause.
+    fn unknown_fields(&self) -> HashMap<String, String>;
+}
+
+impl UnknownFields for () {
+    fn unknown_fields(&self) -> HashMap<String, String> {
+        HashMap::new()
+    }
+}
+
+#[macro_export]
+macro_rules! impl_sink_unknown_fields {
+    ($config_type:ty) => {
+        impl $crate::sink::UnknownFields for $config_type {
+            fn unknown_fields(&self) -> std::collections::HashMap<String, String> {
+                self.unknown_fields.clone()
+            }
+        }
+    };
+}
+
+fn validate_sink_options_with_config<C>(properties: BTreeMap<String, String>) -> Result<()>
+where
+    C: DeserializeOwned + UnknownFields,
+{
+    let config = serde_json::from_value::<C>(serde_json::to_value(properties).unwrap())
+        .map_err(|e| SinkError::Config(anyhow!(e)))?;
+    let mut unknown_fields = config.unknown_fields();
+    // These options are consumed by the sink DDL/planner layer. They are valid for sink creation
+    // even if a connector-specific config does not declare them.
+    for key in [
+        CONNECTOR_TYPE_KEY,
+        SINK_TYPE_OPTION,
+        SINK_SNAPSHOT_OPTION,
+        SINK_USER_IGNORE_DELETE_OPTION,
+        SINK_USER_FORCE_APPEND_ONLY_OPTION,
+        "primary_key",
+    ] {
+        unknown_fields.remove(key);
+    }
+    if unknown_fields.is_empty() {
+        Ok(())
+    } else {
+        Err(SinkError::Config(anyhow!(
+            "Unknown fields in the WITH clause: {:?}",
+            unknown_fields
+        )))
+    }
+}
+
+macro_rules! validate_sink_options_for_type {
+    ({$({$variant_name:ident, $sink_type:ty, $config_type:ty}),*}, $connector:expr, $properties:expr) => {{
+        match $connector {
+            $(
+                <$sink_type>::SINK_NAME => {
+                    validate_sink_options_with_config::<$config_type>($properties.clone())
+                },
+            )*
+            other => Err(SinkError::Config(anyhow!(
+                "unsupported sink connector {}",
+                other
+            ))),
+        }
+    }};
+}
+
+/// Validate raw `CREATE SINK` `WITH` options against the selected sink config.
+///
+/// Runtime and recovery paths intentionally keep using [`build_sink`] without this validation, so
+/// old catalog entries with unknown options remain compatible after upgrade.
+pub fn validate_sink_options_on_create(properties: &BTreeMap<String, String>) -> Result<()> {
+    let connector = properties
+        .get(CONNECTOR_TYPE_KEY)
+        .ok_or_else(|| SinkError::Config(anyhow!("missing config: {}", CONNECTOR_TYPE_KEY)))?
+        .to_lowercase();
+
+    let mut properties = properties.clone();
+    if connector == self::http::HTTP_SINK {
+        properties.retain(|key, _| !key.starts_with("header."));
+    }
+
+    for_all_sinks! { validate_sink_options_for_type, { connector.as_str() }, properties }
+}
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SinkParam {
@@ -1130,6 +1216,66 @@ impl From<sea_orm::DbErr> for SinkError {
 impl From<OpendalError> for SinkError {
     fn from(error: OpendalError) -> Self {
         SinkError::File(error.to_report_string())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+
+    use super::*;
+
+    fn btreemap<const N: usize>(entries: [(&str, &str); N]) -> BTreeMap<String, String> {
+        entries
+            .into_iter()
+            .map(|(key, value)| (key.to_owned(), value.to_owned()))
+            .collect()
+    }
+
+    #[test]
+    fn test_validate_sink_options_on_create() {
+        validate_sink_options_on_create(&btreemap([
+            (CONNECTOR_TYPE_KEY, "redis"),
+            (SINK_TYPE_OPTION, SINK_TYPE_APPEND_ONLY),
+            ("primary_key", "id"),
+            ("redis.url", "redis://127.0.0.1:6379"),
+        ]))
+        .unwrap();
+
+        let err = validate_sink_options_on_create(&btreemap([
+            (CONNECTOR_TYPE_KEY, "redis"),
+            (SINK_TYPE_OPTION, SINK_TYPE_APPEND_ONLY),
+            ("redis.url", "redis://127.0.0.1:6379"),
+            ("bogus_with", "1"),
+        ]))
+        .unwrap_err();
+        let report = err.to_report_string();
+        assert!(report.contains("bogus_with"), "{report}");
+
+        validate_sink_options_on_create(&btreemap([
+            (CONNECTOR_TYPE_KEY, "snowflake_v2"),
+            (SINK_TYPE_OPTION, SINK_TYPE_APPEND_ONLY),
+            (
+                "jdbc.url",
+                "jdbc:snowflake://account.snowflakecomputing.com",
+            ),
+            ("database", "db"),
+            ("schema", "public"),
+            ("warehouse", "wh"),
+            ("username", "user"),
+            ("password", "password"),
+            ("auto.schema.change", "true"),
+        ]))
+        .unwrap();
+
+        let err = validate_sink_options_on_create(&btreemap([
+            (CONNECTOR_TYPE_KEY, "redis"),
+            (SINK_TYPE_OPTION, SINK_TYPE_APPEND_ONLY),
+            ("redis.url", "redis://127.0.0.1:6379"),
+            ("auto.schema.change", "true"),
+        ]))
+        .unwrap_err();
+        assert!(err.to_report_string().contains("auto.schema.change"));
     }
 }
 

--- a/src/connector/src/sink/mongodb.rs
+++ b/src/connector/src/sink/mongodb.rs
@@ -149,7 +149,12 @@ pub struct MongodbConfig {
     #[serde_as(as = "DisplayFromStr")]
     #[deprecated]
     pub bulk_write_max_entries: usize,
+
+    #[serde(flatten)]
+    pub unknown_fields: std::collections::HashMap<String, String>,
 }
+
+crate::impl_sink_unknown_fields!(MongodbConfig);
 
 impl EnforceSecret for MongodbConfig {
     fn enforce_one(prop: &str) -> crate::error::ConnectorResult<()> {

--- a/src/connector/src/sink/mongodb.rs
+++ b/src/connector/src/sink/mongodb.rs
@@ -266,6 +266,8 @@ impl Sink for MongodbSink {
 
     const SINK_NAME: &'static str = MONGODB_SINK;
 
+    crate::impl_validate_sink_unknown_fields!();
+
     async fn validate(&self) -> Result<()> {
         if !self.is_append_only {
             if self.pk_indices.is_empty() {

--- a/src/connector/src/sink/mqtt.rs
+++ b/src/connector/src/sink/mqtt.rs
@@ -187,6 +187,8 @@ impl Sink for MqttSink {
 
     const SINK_NAME: &'static str = MQTT_SINK;
 
+    crate::impl_validate_sink_unknown_fields!();
+
     async fn validate(&self) -> Result<()> {
         if !self.is_append_only {
             return Err(SinkError::Mqtt(anyhow!(

--- a/src/connector/src/sink/mqtt.rs
+++ b/src/connector/src/sink/mqtt.rs
@@ -65,7 +65,12 @@ pub struct MqttConfig {
     // if set, will use a field value as the topic name, if topic is also set it will be used as a fallback
     #[serde(rename = "topic.field")]
     pub topic_field: Option<String>,
+
+    #[serde(flatten)]
+    pub unknown_fields: std::collections::HashMap<String, String>,
 }
+
+crate::impl_sink_unknown_fields!(MqttConfig);
 
 impl EnforceSecret for MqttConfig {
     fn enforce_one(prop: &str) -> crate::error::ConnectorResult<()> {

--- a/src/connector/src/sink/nats.rs
+++ b/src/connector/src/sink/nats.rs
@@ -127,6 +127,8 @@ impl Sink for NatsSink {
 
     const SINK_NAME: &'static str = NATS_SINK;
 
+    crate::impl_validate_sink_unknown_fields!();
+
     async fn validate(&self) -> Result<()> {
         if !self.is_append_only {
             return Err(SinkError::Nats(anyhow!(

--- a/src/connector/src/sink/nats.rs
+++ b/src/connector/src/sink/nats.rs
@@ -53,7 +53,12 @@ pub struct NatsConfig {
     pub common: NatsCommon,
     // accept "append-only"
     pub r#type: String,
+
+    #[serde(flatten)]
+    pub unknown_fields: std::collections::HashMap<String, String>,
 }
+
+crate::impl_sink_unknown_fields!(NatsConfig);
 
 #[derive(Clone, Debug)]
 pub struct NatsSink {

--- a/src/connector/src/sink/postgres.rs
+++ b/src/connector/src/sink/postgres.rs
@@ -222,6 +222,8 @@ impl Sink for PostgresSink {
 
     const SINK_NAME: &'static str = POSTGRES_SINK;
 
+    crate::impl_validate_sink_unknown_fields!();
+
     async fn validate(&self) -> Result<()> {
         if !self.is_append_only && self.pk_indices.is_empty() {
             return Err(SinkError::Config(anyhow!(

--- a/src/connector/src/sink/postgres.rs
+++ b/src/connector/src/sink/postgres.rs
@@ -81,7 +81,12 @@ pub struct PostgresConfig {
 
     #[serde(flatten)]
     pub tcp_keepalive: Option<TcpKeepaliveConfig>,
+
+    #[serde(flatten)]
+    pub unknown_fields: std::collections::HashMap<String, String>,
 }
+
+crate::impl_sink_unknown_fields!(PostgresConfig);
 
 impl EnforceSecret for PostgresConfig {
     const ENFORCE_SECRET_PROPERTIES: phf::Set<&'static str> = phf_set! {

--- a/src/connector/src/sink/pulsar.rs
+++ b/src/connector/src/sink/pulsar.rs
@@ -195,6 +195,8 @@ impl Sink for PulsarSink {
 
     const SINK_NAME: &'static str = PULSAR_SINK;
 
+    crate::impl_validate_sink_unknown_fields!();
+
     async fn new_log_sinker(&self, _writer_param: SinkWriterParam) -> Result<Self::LogSinker> {
         // Reduce async state machine size (see `clippy::large_futures`).
         let writer = Box::pin(PulsarSinkWriter::new(

--- a/src/connector/src/sink/pulsar.rs
+++ b/src/connector/src/sink/pulsar.rs
@@ -126,7 +126,12 @@ pub struct PulsarConfig {
 
     #[serde(flatten)]
     pub producer_properties: PulsarPropertiesProducer,
+
+    #[serde(flatten)]
+    pub unknown_fields: std::collections::HashMap<String, String>,
 }
+
+crate::impl_sink_unknown_fields!(PulsarConfig);
 
 impl EnforceSecret for PulsarConfig {
     fn enforce_one(prop: &str) -> crate::error::ConnectorResult<()> {

--- a/src/connector/src/sink/redis.rs
+++ b/src/connector/src/sink/redis.rs
@@ -234,7 +234,12 @@ impl RedisCommon {
 pub struct RedisConfig {
     #[serde(flatten)]
     pub common: RedisCommon,
+
+    #[serde(flatten)]
+    pub unknown_fields: std::collections::HashMap<String, String>,
 }
+
+crate::impl_sink_unknown_fields!(RedisConfig);
 
 impl EnforceSecret for RedisConfig {
     fn enforce_secret<'a>(prop_iter: impl Iterator<Item = &'a str>) -> ConnectorResult<()> {

--- a/src/connector/src/sink/redis.rs
+++ b/src/connector/src/sink/redis.rs
@@ -307,6 +307,8 @@ impl Sink for RedisSink {
 
     const SINK_NAME: &'static str = "redis";
 
+    crate::impl_validate_sink_unknown_fields!();
+
     async fn new_log_sinker(&self, _writer_param: SinkWriterParam) -> Result<Self::LogSinker> {
         Ok(RedisSinkWriter::new(
             self.config.clone(),

--- a/src/connector/src/sink/snowflake_redshift/redshift.rs
+++ b/src/connector/src/sink/snowflake_redshift/redshift.rs
@@ -122,7 +122,12 @@ pub struct RedShiftConfig {
 
     #[serde(flatten)]
     pub s3_inner: Option<S3Common>,
+
+    #[serde(flatten)]
+    pub unknown_fields: std::collections::HashMap<String, String>,
 }
+
+crate::impl_sink_unknown_fields!(RedShiftConfig);
 
 fn default_target_interval_schedule() -> u64 {
     3600 // Default to 1 hour

--- a/src/connector/src/sink/snowflake_redshift/redshift.rs
+++ b/src/connector/src/sink/snowflake_redshift/redshift.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use core::num::NonZero;
+use std::collections::BTreeMap;
 use std::fmt::Write;
 use std::time::Duration;
 
@@ -146,6 +147,11 @@ fn default_with_s3() -> bool {
 }
 
 impl RedShiftConfig {
+    pub fn from_btreemap(properties: BTreeMap<String, String>) -> Result<Self> {
+        serde_json::from_value::<RedShiftConfig>(serde_json::to_value(properties).unwrap())
+            .map_err(|e| SinkError::Config(anyhow!(e)))
+    }
+
     pub fn build_client(&self) -> Result<JdbcJniClient> {
         let mut jdbc_url = self.jdbc_url.clone();
         if let Some(username) = &self.username {
@@ -178,10 +184,7 @@ impl TryFrom<SinkParam> for RedshiftSink {
     type Error = SinkError;
 
     fn try_from(param: SinkParam) -> std::result::Result<Self, Self::Error> {
-        let config = serde_json::from_value::<RedShiftConfig>(
-            serde_json::to_value(param.properties.clone()).unwrap(),
-        )
-        .map_err(|e| SinkError::Config(anyhow!(e)))?;
+        let config = RedShiftConfig::from_btreemap(param.properties.clone())?;
         let is_append_only = param.sink_type.is_append_only();
         let schema = param.schema();
         let pk_indices = param.downstream_pk_or_empty();
@@ -199,6 +202,8 @@ impl Sink for RedshiftSink {
     type LogSinker = CoordinatedLogSinker<RedShiftSinkWriter>;
 
     const SINK_NAME: &'static str = REDSHIFT_SINK;
+
+    crate::impl_validate_sink_unknown_fields!();
 
     async fn validate(&self) -> Result<()> {
         if self.config.create_table_if_not_exists {

--- a/src/connector/src/sink/snowflake_redshift/snowflake.rs
+++ b/src/connector/src/sink/snowflake_redshift/snowflake.rs
@@ -492,6 +492,8 @@ impl Sink for SnowflakeV2Sink {
 
     const SINK_NAME: &'static str = SNOWFLAKE_SINK_V2;
 
+    crate::impl_validate_sink_unknown_fields!();
+
     async fn validate(&self) -> Result<()> {
         risingwave_common::license::Feature::SnowflakeSink
             .check_available()

--- a/src/connector/src/sink/snowflake_redshift/snowflake.rs
+++ b/src/connector/src/sink/snowflake_redshift/snowflake.rs
@@ -149,7 +149,12 @@ pub struct SnowflakeV2Config {
 
     #[serde(rename = "stage")]
     pub stage: Option<String>,
+
+    #[serde(flatten)]
+    pub unknown_fields: std::collections::HashMap<String, String>,
 }
+
+crate::impl_sink_unknown_fields!(SnowflakeV2Config);
 
 fn default_target_interval_schedule() -> u64 {
     3600 // Default to 1 hour

--- a/src/connector/src/sink/sqlserver.rs
+++ b/src/connector/src/sink/sqlserver.rs
@@ -68,7 +68,12 @@ pub struct SqlServerConfig {
     #[serde_as(as = "DisplayFromStr")]
     pub max_batch_rows: usize,
     pub r#type: String, // accept "append-only" or "upsert"
+
+    #[serde(flatten)]
+    pub unknown_fields: std::collections::HashMap<String, String>,
 }
+
+crate::impl_sink_unknown_fields!(SqlServerConfig);
 
 pub fn sql_server_default_schema() -> String {
     "dbo".to_owned()

--- a/src/connector/src/sink/sqlserver.rs
+++ b/src/connector/src/sink/sqlserver.rs
@@ -176,6 +176,8 @@ impl Sink for SqlServerSink {
 
     const SINK_NAME: &'static str = SQLSERVER_SINK;
 
+    crate::impl_validate_sink_unknown_fields!();
+
     async fn validate(&self) -> Result<()> {
         risingwave_common::license::Feature::SqlServerSink
             .check_available()

--- a/src/connector/src/sink/starrocks.rs
+++ b/src/connector/src/sink/starrocks.rs
@@ -129,7 +129,12 @@ pub struct StarrocksConfig {
     pub partial_update: Option<String>,
 
     pub r#type: String, // accept "append-only" or "upsert"
+
+    #[serde(flatten)]
+    pub unknown_fields: std::collections::HashMap<String, String>,
 }
+
+crate::impl_sink_unknown_fields!(StarrocksConfig);
 
 impl EnforceSecret for StarrocksConfig {
     fn enforce_one(prop: &str) -> crate::error::ConnectorResult<()> {

--- a/src/connector/src/sink/starrocks.rs
+++ b/src/connector/src/sink/starrocks.rs
@@ -318,6 +318,8 @@ impl Sink for StarrocksSink {
 
     const SINK_NAME: &'static str = STARROCKS_SINK;
 
+    crate::impl_validate_sink_unknown_fields!();
+
     async fn validate(&self) -> Result<()> {
         if !self.is_append_only && self.pk_indices.is_empty() {
             return Err(SinkError::Config(anyhow!(

--- a/src/connector/src/sink/turbopuffer.rs
+++ b/src/connector/src/sink/turbopuffer.rs
@@ -77,7 +77,12 @@ pub struct TurbopufferConfig {
     #[with_option(allow_alter_on_fly)]
     pub max_linger_second: u64,
     pub r#type: String, // accept "append-only" or "upsert"
+
+    #[serde(flatten)]
+    pub unknown_fields: std::collections::HashMap<String, String>,
 }
+
+crate::impl_sink_unknown_fields!(TurbopufferConfig);
 
 impl EnforceSecret for TurbopufferConfig {
     const ENFORCE_SECRET_PROPERTIES: phf::Set<&'static str> = phf::phf_set! {
@@ -254,6 +259,8 @@ impl Sink for TurbopufferSink {
     type LogSinker = TurbopufferLogSinker;
 
     const SINK_NAME: &'static str = TURBOPUFFER_SINK;
+
+    crate::impl_validate_sink_unknown_fields!();
 
     async fn validate(&self) -> Result<()> {
         Ok(())
@@ -934,6 +941,7 @@ mod tests {
             write_batch_size: DEFAULT_WRITE_BATCH_SIZE,
             max_linger_second: DEFAULT_MAX_LINGER_SECOND,
             r#type: "upsert".to_owned(),
+            unknown_fields: Default::default(),
         };
         let mut writer = TurbopufferSinkWriter::new(
             config,
@@ -1042,6 +1050,7 @@ mod tests {
             write_batch_size: 2,
             max_linger_second: DEFAULT_MAX_LINGER_SECOND,
             r#type: "upsert".to_owned(),
+            unknown_fields: Default::default(),
         };
         let mut writer = TurbopufferSinkWriter::new(
             config,
@@ -1102,6 +1111,7 @@ mod tests {
             write_batch_size: DEFAULT_WRITE_BATCH_SIZE,
             max_linger_second: DEFAULT_MAX_LINGER_SECOND,
             r#type: "upsert".to_owned(),
+            unknown_fields: Default::default(),
         };
         let mut writer = TurbopufferSinkWriter::new(
             config,
@@ -1365,6 +1375,7 @@ mod tests {
             write_batch_size: DEFAULT_WRITE_BATCH_SIZE,
             max_linger_second: DEFAULT_MAX_LINGER_SECOND,
             r#type: "upsert".to_owned(),
+            unknown_fields: Default::default(),
         };
         let writer = TurbopufferSinkWriter::new(
             config,
@@ -1523,6 +1534,7 @@ mod tests {
             write_batch_size,
             max_linger_second: DEFAULT_MAX_LINGER_SECOND,
             r#type: "upsert".to_owned(),
+            unknown_fields: Default::default(),
         };
         TurbopufferSinkWriter::new(
             config,

--- a/src/connector/src/sink/utils.rs
+++ b/src/connector/src/sink/utils.rs
@@ -155,7 +155,16 @@ macro_rules! feature_gated_sink_mod {
             #[doc = "A dummy sink that always returns an error, as the feature `sink-" $sink_name "` is currently not enabled."]
             pub type [<$struct_prefix:camel Sink>] = FeatureNotEnabledSink<[<$struct_prefix:camel NotEnabled>]>;
             #[doc = "A dummy sink config that is empty, as the feature `sink-" $sink_name "` is currently not enabled."]
-            pub struct [<$struct_prefix:camel Config>];
+            #[derive(serde::Deserialize)]
+            pub struct [<$struct_prefix:camel Config>] {
+                #[serde(flatten)]
+                pub unknown_fields: std::collections::HashMap<String, String>,
+            }
+            impl crate::sink::UnknownFields for [<$struct_prefix:camel Config>] {
+                fn unknown_fields(&self) -> std::collections::HashMap<String, String> {
+                    std::collections::HashMap::new()
+                }
+            }
         }
         }
     };

--- a/src/frontend/src/handler/create_sink.rs
+++ b/src/frontend/src/handler/create_sink.rs
@@ -42,7 +42,7 @@ use risingwave_connector::sink::snowflake_redshift::redshift::RedshiftSink;
 use risingwave_connector::sink::snowflake_redshift::snowflake::SnowflakeV2Sink;
 use risingwave_connector::sink::{
     CONNECTOR_TYPE_KEY, SINK_SNAPSHOT_OPTION, SINK_TYPE_OPTION, SINK_USER_FORCE_APPEND_ONLY_OPTION,
-    SINK_USER_IGNORE_DELETE_OPTION, Sink, enforce_secret_sink,
+    SINK_USER_IGNORE_DELETE_OPTION, Sink, enforce_secret_sink, validate_sink_options_on_create,
 };
 use risingwave_connector::{
     AUTO_SCHEMA_CHANGE_KEY, SINK_CREATE_TABLE_IF_NOT_EXISTS_KEY, SINK_INTERMEDIATE_TABLE_NAME,
@@ -194,6 +194,10 @@ pub async fn gen_sink_plan(
     } else {
         OptimizerContext::from_handler_args(handler_args.clone())
     };
+    let sink_options_for_validation = resolved_with_options.as_plaintext().clone();
+    if sink_options_for_validation.contains_key(CONNECTOR_TYPE_KEY) {
+        validate_sink_options_on_create(&sink_options_for_validation)?;
+    }
 
     let is_auto_schema_change = resolved_with_options
         .remove(AUTO_SCHEMA_CHANGE_KEY)

--- a/src/frontend/src/handler/create_sink.rs
+++ b/src/frontend/src/handler/create_sink.rs
@@ -42,7 +42,7 @@ use risingwave_connector::sink::snowflake_redshift::redshift::RedshiftSink;
 use risingwave_connector::sink::snowflake_redshift::snowflake::SnowflakeV2Sink;
 use risingwave_connector::sink::{
     CONNECTOR_TYPE_KEY, SINK_SNAPSHOT_OPTION, SINK_TYPE_OPTION, SINK_USER_FORCE_APPEND_ONLY_OPTION,
-    SINK_USER_IGNORE_DELETE_OPTION, Sink, enforce_secret_sink, validate_sink_options_on_create,
+    SINK_USER_IGNORE_DELETE_OPTION, Sink, enforce_secret_sink,
 };
 use risingwave_connector::{
     AUTO_SCHEMA_CHANGE_KEY, SINK_CREATE_TABLE_IF_NOT_EXISTS_KEY, SINK_INTERMEDIATE_TABLE_NAME,
@@ -194,13 +194,8 @@ pub async fn gen_sink_plan(
     } else {
         OptimizerContext::from_handler_args(handler_args.clone())
     };
-    let sink_options_for_validation = resolved_with_options.as_plaintext().clone();
-    if sink_options_for_validation.contains_key(CONNECTOR_TYPE_KEY) {
-        validate_sink_options_on_create(&sink_options_for_validation)?;
-    }
-
     let is_auto_schema_change = resolved_with_options
-        .remove(AUTO_SCHEMA_CHANGE_KEY)
+        .get(AUTO_SCHEMA_CHANGE_KEY)
         .map(|value| {
             value.parse::<bool>().map_err(|_| {
                 ErrorCode::InvalidInputSyntax(format!(

--- a/src/frontend/src/optimizer/plan_node/stream_sink.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_sink.rs
@@ -27,14 +27,16 @@ use risingwave_common::util::iter_util::ZipEqDebug;
 use risingwave_connector::sink::catalog::desc::SinkDesc;
 use risingwave_connector::sink::catalog::{SinkFormat, SinkFormatDesc, SinkId, SinkType};
 use risingwave_connector::sink::file_sink::fs::FsSink;
+use risingwave_connector::sink::http::HTTP_SINK;
 use risingwave_connector::sink::iceberg::{ENABLE_PK_INDEX, ICEBERG_SINK};
 use risingwave_connector::sink::trivial::TABLE_SINK;
 use risingwave_connector::sink::{
     CONNECTOR_TYPE_KEY, SINK_TYPE_APPEND_ONLY, SINK_TYPE_DEBEZIUM, SINK_TYPE_OPTION,
     SINK_TYPE_RETRACT, SINK_TYPE_UPSERT, SINK_USER_FORCE_APPEND_ONLY_OPTION,
-    SINK_USER_IGNORE_DELETE_OPTION, SINK_USER_PRESERVE_ROW_LEVEL_CHANGES,
+    SINK_USER_IGNORE_DELETE_OPTION, SinkConfig, validate_sink_options_with_config,
+    SINK_USER_PRESERVE_ROW_LEVEL_CHANGES,
 };
-use risingwave_connector::{WithPropertiesExt, match_sink_name_str};
+use risingwave_connector::{AUTO_SCHEMA_CHANGE_KEY, WithPropertiesExt, match_sink_name_str};
 use risingwave_pb::expr::expr_node::Type;
 use risingwave_pb::stream_plan::SinkLogStoreType;
 use risingwave_pb::stream_plan::stream_node::PbNodeBody;
@@ -605,6 +607,14 @@ impl StreamSink {
                         if connector == TABLE_SINK && sink_desc.target_table.is_none() {
                             unsupported_sink(TABLE_SINK)
                         } else {
+                            let mut properties = sink_desc.properties.clone();
+                            if connector_type == HTTP_SINK {
+                                properties.retain(|key, _| !key.starts_with("header."));
+                            }
+                            validate_sink_options_with_config::<<SinkType as SinkConfig>::Config>(
+                                properties, true,
+                            )?;
+                            sink_desc.properties.remove(AUTO_SCHEMA_CHANGE_KEY);
                             SinkType::set_default_commit_checkpoint_interval(
                                 &mut sink_desc,
                                 &input.ctx().session_ctx().config().sink_decouple(),

--- a/src/frontend/src/optimizer/plan_node/stream_sink.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_sink.rs
@@ -27,14 +27,12 @@ use risingwave_common::util::iter_util::ZipEqDebug;
 use risingwave_connector::sink::catalog::desc::SinkDesc;
 use risingwave_connector::sink::catalog::{SinkFormat, SinkFormatDesc, SinkId, SinkType};
 use risingwave_connector::sink::file_sink::fs::FsSink;
-use risingwave_connector::sink::http::HTTP_SINK;
 use risingwave_connector::sink::iceberg::{ENABLE_PK_INDEX, ICEBERG_SINK};
 use risingwave_connector::sink::trivial::TABLE_SINK;
 use risingwave_connector::sink::{
     CONNECTOR_TYPE_KEY, SINK_TYPE_APPEND_ONLY, SINK_TYPE_DEBEZIUM, SINK_TYPE_OPTION,
     SINK_TYPE_RETRACT, SINK_TYPE_UPSERT, SINK_USER_FORCE_APPEND_ONLY_OPTION,
-    SINK_USER_IGNORE_DELETE_OPTION, SinkConfig, validate_sink_options_with_config,
-    SINK_USER_PRESERVE_ROW_LEVEL_CHANGES,
+    SINK_USER_IGNORE_DELETE_OPTION, SINK_USER_PRESERVE_ROW_LEVEL_CHANGES,
 };
 use risingwave_connector::{AUTO_SCHEMA_CHANGE_KEY, WithPropertiesExt, match_sink_name_str};
 use risingwave_pb::expr::expr_node::Type;
@@ -607,13 +605,6 @@ impl StreamSink {
                         if connector == TABLE_SINK && sink_desc.target_table.is_none() {
                             unsupported_sink(TABLE_SINK)
                         } else {
-                            let mut properties = sink_desc.properties.clone();
-                            if connector_type == HTTP_SINK {
-                                properties.retain(|key, _| !key.starts_with("header."));
-                            }
-                            validate_sink_options_with_config::<<SinkType as SinkConfig>::Config>(
-                                properties, true,
-                            )?;
                             sink_desc.properties.remove(AUTO_SCHEMA_CHANGE_KEY);
                             SinkType::set_default_commit_checkpoint_interval(
                                 &mut sink_desc,

--- a/src/meta/src/stream/sink.rs
+++ b/src/meta/src/stream/sink.rs
@@ -26,6 +26,7 @@ pub async fn validate_sink(prost_sink_catalog: &PbSink) -> MetaResult<()> {
     let param = SinkParam::try_from_sink_catalog(sink_catalog)?;
 
     let sink = build_sink(param)?;
+    sink.validate_unknown_fields()?;
 
     dispatch_sink!(
         sink,


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

This PR adds unknown-field validation for sink `WITH` options. It is split out from #25750 because this validation is generic sink behavior, not StarRocks-specific batch-size logic.

The change keeps connector-specific configs deserialized with flattened `unknown_fields`, then validates those fields after building the sink. Common sink options that are consumed outside connector configs, such as `connector`, `type`, `primary_key`, `sink_rate_limit`, `backfill_rate_limit`, and `force_compaction`, are allowlisted before reporting unknown fields.

It also adds coverage for:
- common sink option allowlisting in `test_validate_sink_unknown_fields`
- a connector-specific unknown option in the StarRocks sink e2e test

## Checklist

- [ ] I have written necessary rustdoc comments.
- [x] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

N/A

</details>

