### PR TITLE
fix(meta): delete replaced sink internal table objects

### DIFF
--- a/e2e_test/sink/blackhole_sink.slt
+++ b/e2e_test/sink/blackhole_sink.slt
@@ -85,3 +85,33 @@ DROP SCHEMA show_acl_sink;
 
 statement ok
 DROP USER show_acl_sink_user;
+
+# Replacing a sink must remove the old sink's internal-table object rows. Otherwise,
+# cascading schema cleanup tries to drop table IDs that no longer exist.
+statement ok
+CREATE SCHEMA replace_sink_catalog_cleanup;
+
+statement ok
+CREATE TABLE replace_sink_catalog_cleanup.t (v1 int);
+
+statement ok
+CREATE SINK replace_sink_catalog_cleanup.s
+FROM replace_sink_catalog_cleanup.t WITH (
+    connector = 'blackhole',
+    type = 'append-only',
+    force_append_only = 'true'
+);
+
+statement ok
+REPLACE SINK replace_sink_catalog_cleanup.s
+FROM replace_sink_catalog_cleanup.t WITH (
+    connector = 'blackhole',
+    type = 'append-only',
+    force_append_only = 'true'
+);
+
+statement ok
+WAIT;
+
+statement ok
+DROP SCHEMA replace_sink_catalog_cleanup CASCADE;

--- a/src/meta/src/controller/streaming_job.rs
+++ b/src/meta/src/controller/streaming_job.rs
@@ -1237,7 +1237,13 @@ impl CatalogController {
                 .all(&txn)
                 .await?;
 
-            let res = Object::delete_by_id(old_sink_id).exec(&txn).await?;
+            // Deleting only the sink object cascades the internal `table` rows through
+            // `belongs_to_job_id`, but leaves their corresponding `object` rows behind.
+            // Delete the complete object set to keep the catalog hierarchy consistent.
+            let res = Object::delete_many()
+                .filter(object::Column::Oid.is_in(old_object_ids))
+                .exec(&txn)
+                .await?;
             if res.rows_affected == 0 {
                 return Err(MetaError::catalog_id_not_found("sink", old_sink_id));
             }


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

Fix catalog cleanup after `REPLACE SINK`.

The replace path previously deleted only the old sink object. The `belongs_to_job_id` foreign key then cascaded deletion to the old internal-table rows, but their corresponding object rows remained. A later `DROP SCHEMA ... CASCADE` traversed those stale objects and failed with `table id not found`.

This PR deletes the old sink object and all of its internal-table objects together, and adds an end-to-end regression that replaces a blackhole sink and then drops its schema.

Related to #26039.

## Checklist

- [x] I have written necessary rustdoc comments.
- [x] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [x] <!-- OPTIONAL --> I have added test labels as necessary.
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them.
- [ ] <!-- OPTIONAL --> My PR contains breaking changes.
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results.
- [ ] <!-- OPTIONAL --> I have checked the Release Timeline and Currently Supported Versions to determine which release branches I need to cherry-pick this PR into.

## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates.

<details>
<summary><b>Release note</b></summary>

Fixed `DROP SCHEMA ... CASCADE` failures after replacing a sink.

</details>
