### PR TITLE
feat(storage): stream meta snapshot backup payload

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11389,6 +11389,7 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 2.0.17",
+ "tracing",
  "twox-hash",
 ]
 
@@ -12753,11 +12754,13 @@ dependencies = [
  "crc32fast",
  "fail",
  "futures",
+ "futures-async-stream",
  "itertools 0.14.0",
  "madsim",
  "madsim-aws-sdk-s3",
  "madsim-tokio",
  "opendal",
+ "pin-project-lite",
  "prometheus",
  "reqwest 0.12.25",
  "risingwave_common",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11378,6 +11378,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "bytes",
+ "futures",
  "itertools 0.14.0",
  "madsim-tokio",
  "prost 0.14.3",

--- a/src/meta/src/backup_restore/restore_impl/v2.rs
+++ b/src/meta/src/backup_restore/restore_impl/v2.rs
@@ -19,7 +19,7 @@ use risingwave_backup::MetaSnapshotId;
 use risingwave_backup::error::{BackupError, BackupResult};
 use risingwave_backup::meta_snapshot::MetaSnapshot;
 use risingwave_backup::meta_snapshot_v2::{
-    MetaSnapshotV2, MetadataV2, decode_hummock_sequences_from_snapshot,
+    MetaSnapshotV2, MetadataV2, decode_hummock_sequences_from_stream,
 };
 use risingwave_backup::storage::{MetaSnapshotStorage, MetaSnapshotStorageRef};
 use sea_orm::{DbErr, EntityTrait};
@@ -61,9 +61,10 @@ impl Loader<MetadataV2> for LoaderV2 {
 
         // validate and rewrite seq
         if newest_id > target_id {
-            let newest_hummock_sequences = decode_hummock_sequences_from_snapshot(
-                &self.backup_store.get_raw(newest_id).await?,
-            )?;
+            let newest_hummock_sequences = decode_hummock_sequences_from_stream(
+                self.backup_store.get_bytes_stream(newest_id).await?,
+            )
+            .await?;
             for seq in &target_snapshot.metadata.hummock_sequences {
                 let newest = newest_hummock_sequences
                     .iter()

--- a/src/object_store/Cargo.toml
+++ b/src/object_store/Cargo.toml
@@ -40,8 +40,8 @@ opendal = { workspace = true, features = [
     "services-webhdfs",
     "services-azfile",
 ] }
-prometheus = { version = "0.14", features = ["process"] }
 pin-project-lite = { workspace = true }
+prometheus = { version = "0.14", features = ["process"] }
 reqwest = "0.12.2" # required by opendal
 risingwave_common = { workspace = true }
 spin = "0.10"

--- a/src/object_store/Cargo.toml
+++ b/src/object_store/Cargo.toml
@@ -25,6 +25,7 @@ bytes = { version = "1", features = ["serde"] }
 crc32fast = "1"
 fail = "0.5"
 futures = { version = "0.3", default-features = false, features = ["alloc"] }
+futures-async-stream = { workspace = true }
 itertools = { workspace = true }
 madsim = { workspace = true }
 opendal = { workspace = true, features = [
@@ -40,6 +41,7 @@ opendal = { workspace = true, features = [
     "services-azfile",
 ] }
 prometheus = { version = "0.14", features = ["process"] }
+pin-project-lite = { workspace = true }
 reqwest = "0.12.2" # required by opendal
 risingwave_common = { workspace = true }
 spin = "0.10"

--- a/src/object_store/src/lib.rs
+++ b/src/object_store/src/lib.rs
@@ -14,5 +14,6 @@
 
 #![feature(trait_alias)]
 #![feature(error_generic_member_access)]
+#![feature(coroutines)]
 
 pub mod object;

--- a/src/object_store/src/object/mem.rs
+++ b/src/object_store/src/object/mem.rs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 use std::collections::{HashMap, VecDeque};
-use std::ops::Range;
 use std::pin::Pin;
 use std::sync::{Arc, LazyLock};
 use std::task::{Context, Poll};
@@ -142,7 +141,7 @@ impl ObjectStore for InMemObjectStore {
     async fn streaming_read(
         &self,
         path: &str,
-        read_range: Range<usize>,
+        read_range: impl ObjectRangeBounds,
     ) -> ObjectResult<ObjectDataStream> {
         fail_point!("mem_streaming_read_err", |_| Err(ObjectError::internal(
             "mem streaming read error"

--- a/src/object_store/src/object/mod.rs
+++ b/src/object_store/src/object/mod.rs
@@ -523,8 +523,12 @@ impl MonitoredStreamingReader {
         res
     }
 
+    pub fn into_stream(self) -> ObjectDataStream {
+        Self::into_stream_inner(self).boxed()
+    }
+
     #[try_stream(ok = Bytes, error = ObjectError)]
-    pub async fn into_stream(mut self) {
+    async fn into_stream_inner(mut self) {
         while let Some(bytes) = self.read_bytes().await.transpose()? {
             yield bytes;
         }
@@ -1094,6 +1098,22 @@ where
         Self {
             stream,
             pending: Bytes::new(),
+        }
+    }
+}
+
+impl ObjectDataStreamReader<ObjectDataStream> {
+    pub fn into_bytes_stream(self) -> ObjectDataStream {
+        Self::into_bytes_stream_inner(self).boxed()
+    }
+
+    #[try_stream(ok = Bytes, error = ObjectError)]
+    async fn into_bytes_stream_inner(mut self) {
+        if self.pending.has_remaining() {
+            yield std::mem::take(&mut self.pending);
+        }
+        while let Some(bytes) = self.stream.next().await.transpose()? {
+            yield bytes;
         }
     }
 }

--- a/src/object_store/src/object/mod.rs
+++ b/src/object_store/src/object/mod.rs
@@ -18,11 +18,14 @@
 )]
 
 pub mod sim;
-use std::ops::{Range, RangeBounds};
+use std::io;
+use std::ops::RangeBounds;
+use std::pin::Pin;
 use std::sync::Arc;
+use std::task::{Context, Poll, ready};
 use std::time::Duration;
 
-use bytes::Bytes;
+use bytes::{Buf, Bytes};
 
 pub mod mem;
 pub use mem::*;
@@ -33,7 +36,9 @@ pub use opendal_engine::*;
 pub mod s3;
 use await_tree::{InstrumentAwait, SpanExt};
 use futures::stream::BoxStream;
-use futures::{Future, StreamExt};
+use futures::{Future, Stream, StreamExt};
+use futures_async_stream::try_stream;
+use pin_project_lite::pin_project;
 pub use risingwave_common::config::ObjectStoreConfig;
 pub use s3::*;
 
@@ -45,6 +50,7 @@ pub mod prefix;
 pub use error::*;
 use object_metrics::ObjectStoreMetrics;
 use thiserror_ext::AsReport;
+use tokio::io::{AsyncRead, ReadBuf};
 use tokio_retry::strategy::{ExponentialBackoff, jitter};
 
 #[cfg(madsim)]
@@ -97,7 +103,7 @@ pub trait ObjectStore: Send + Sync {
     async fn streaming_read(
         &self,
         path: &str,
-        read_range: Range<usize>,
+        read_range: impl ObjectRangeBounds,
     ) -> ObjectResult<ObjectDataStream>;
 
     /// Obtains the object metadata.
@@ -313,7 +319,7 @@ impl ObjectStoreImpl {
     pub async fn streaming_read(
         &self,
         path: &str,
-        start_loc: Range<usize>,
+        start_loc: impl ObjectRangeBounds,
     ) -> ObjectResult<MonitoredStreamingReader> {
         object_store_impl_method_body!(self, streaming_read(path, start_loc).await)
     }
@@ -516,6 +522,13 @@ impl MonitoredStreamingReader {
         }
         res
     }
+
+    #[try_stream(ok = Bytes, error = ObjectError)]
+    pub async fn into_stream(mut self) {
+        while let Some(bytes) = self.read_bytes().await.transpose()? {
+            yield bytes;
+        }
+    }
 }
 
 impl Drop for MonitoredStreamingReader {
@@ -693,7 +706,7 @@ impl<OS: ObjectStore> MonitoredObjectStore<OS> {
     async fn streaming_read(
         &self,
         path: &str,
-        range: Range<usize>,
+        range: impl ObjectRangeBounds,
     ) -> ObjectResult<MonitoredStreamingReader> {
         let operation_type = OperationType::StreamingReadInit;
         let operation_type_str = operation_type.as_str();
@@ -1064,6 +1077,98 @@ fn get_retry_strategy(
 
 pub type ObjectMetadataIter = BoxStream<'static, ObjectResult<ObjectMetadata>>;
 pub type ObjectDataStream = BoxStream<'static, ObjectResult<Bytes>>;
+
+pin_project! {
+    pub struct ObjectDataStreamReader<S> {
+        #[pin]
+        stream: S,
+        pending: Bytes,
+    }
+}
+
+impl<S> ObjectDataStreamReader<S>
+where
+    S: Stream<Item = ObjectResult<Bytes>>,
+{
+    pub fn new(stream: S) -> Self {
+        Self {
+            stream,
+            pending: Bytes::new(),
+        }
+    }
+}
+
+impl<S> AsyncRead for ObjectDataStreamReader<S>
+where
+    S: Stream<Item = ObjectResult<Bytes>>,
+{
+    fn poll_read(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut ReadBuf<'_>,
+    ) -> Poll<io::Result<()>> {
+        if buf.remaining() == 0 {
+            return Poll::Ready(Ok(()));
+        }
+
+        let mut this = self.project();
+        loop {
+            if this.pending.has_remaining() {
+                let len = this.pending.remaining().min(buf.remaining());
+                buf.put_slice(&this.pending[..len]);
+                this.pending.advance(len);
+                return Poll::Ready(Ok(()));
+            }
+
+            match ready!(this.stream.as_mut().poll_next(cx)) {
+                Some(Ok(bytes)) => {
+                    *this.pending = bytes;
+                }
+                Some(Err(err)) => return Poll::Ready(Err(io::Error::other(err))),
+                None => return Poll::Ready(Ok(())),
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use futures::stream;
+    use tokio::io::AsyncReadExt;
+
+    use super::{Bytes, ObjectDataStreamReader, ObjectError};
+
+    #[tokio::test]
+    async fn test_object_data_stream_reader_reads_across_chunks() {
+        let stream = stream::iter([
+            Ok(Bytes::from_static(b"ab")),
+            Ok(Bytes::from_static(b"cdef")),
+            Ok(Bytes::from_static(b"g")),
+        ]);
+        let mut reader = ObjectDataStreamReader::new(stream);
+
+        let mut first = [0; 3];
+        reader.read_exact(&mut first).await.unwrap();
+        assert_eq!(&first, b"abc");
+
+        let mut rest = vec![];
+        reader.read_to_end(&mut rest).await.unwrap();
+        assert_eq!(&rest, b"defg");
+    }
+
+    #[tokio::test]
+    async fn test_object_data_stream_reader_returns_stream_error() {
+        let stream = stream::iter([
+            Ok(Bytes::from_static(b"ab")),
+            Err(ObjectError::internal("injected stream error")),
+        ]);
+        let mut reader = ObjectDataStreamReader::new(stream);
+
+        let mut output = vec![];
+        let err = reader.read_to_end(&mut output).await.unwrap_err();
+        assert!(err.to_string().contains("injected stream error"));
+    }
+}
 
 #[derive(Debug, Clone, Copy)]
 enum OperationType {

--- a/src/object_store/src/object/opendal_engine/opendal_object_store.rs
+++ b/src/object_store/src/object/opendal_engine/opendal_object_store.rs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::ops::Range;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -166,12 +165,12 @@ impl ObjectStore for OpendalObjectStore {
     async fn streaming_read(
         &self,
         path: &str,
-        range: Range<usize>,
+        range: impl ObjectRangeBounds,
     ) -> ObjectResult<ObjectDataStream> {
         fail_point!("opendal_streaming_read_err", |_| Err(
             ObjectError::internal("opendal streaming read error")
         ));
-        let range: Range<u64> = (range.start as u64)..(range.end as u64);
+        let range = range.map(|v| *v as u64);
 
         // The layer specified first will be executed first.
         // `TimeoutLayer` must be specified before `RetryLayer`.

--- a/src/object_store/src/object/s3.rs
+++ b/src/object_store/src/object/s3.rs
@@ -15,7 +15,6 @@
 use std::borrow::BorrowMut;
 use std::cmp;
 use std::collections::VecDeque;
-use std::ops::Range;
 use std::pin::Pin;
 use std::sync::Arc;
 use std::task::{Context, Poll, ready};
@@ -539,7 +538,7 @@ impl ObjectStore for S3ObjectStore {
     async fn streaming_read(
         &self,
         path: &str,
-        range: Range<usize>,
+        range: impl ObjectRangeBounds,
     ) -> ObjectResult<ObjectDataStream> {
         fail_point!("s3_streaming_read_init_err", |_| Err(
             ObjectError::internal("s3 streaming read init error")

--- a/src/object_store/src/object/sim/mod.rs
+++ b/src/object_store/src/object/sim/mod.rs
@@ -24,7 +24,7 @@ pub use rpc_server::SimServer;
 mod service;
 
 use std::net::SocketAddr;
-use std::ops::{Range, RangeBounds};
+use std::ops::RangeBounds;
 use std::pin::Pin;
 use std::task::{Context, Poll};
 
@@ -180,7 +180,7 @@ impl ObjectStore for SimObjectStore {
     async fn streaming_read(
         &self,
         path: &str,
-        range: Range<usize>,
+        range: impl ObjectRangeBounds,
     ) -> ObjectResult<ObjectDataStream> {
         let path = path.to_string();
         let resp = self

--- a/src/storage/backup/Cargo.toml
+++ b/src/storage/backup/Cargo.toml
@@ -22,6 +22,7 @@ serde = { workspace = true }
 serde_json = "1"
 thiserror = { workspace = true }
 tokio = { workspace = true }
+tracing = "0.1"
 twox-hash = "2"
 
 [dev-dependencies]

--- a/src/storage/backup/Cargo.toml
+++ b/src/storage/backup/Cargo.toml
@@ -11,6 +11,7 @@ repository = { workspace = true }
 anyhow = "1"
 async-trait = "0.1"
 bytes = { version = "1", features = ["serde"] }
+futures = { version = "0.3", default-features = false, features = ["alloc"] }
 itertools = { workspace = true }
 prost = { workspace = true }
 risingwave_common = { workspace = true }

--- a/src/storage/backup/src/error.rs
+++ b/src/storage/backup/src/error.rs
@@ -60,3 +60,13 @@ pub enum BackupError {
         anyhow::Error,
     ),
 }
+
+impl From<std::io::Error> for BackupError {
+    fn from(err: std::io::Error) -> Self {
+        if err.kind() == std::io::ErrorKind::UnexpectedEof {
+            Self::Decoding(anyhow::anyhow!("unexpected EOF while decoding meta snapshot").into())
+        } else {
+            Self::BackupStorage(err.into())
+        }
+    }
+}

--- a/src/storage/backup/src/meta_snapshot.rs
+++ b/src/storage/backup/src/meta_snapshot.rs
@@ -18,30 +18,30 @@ use std::future::Future;
 use std::hash::Hasher;
 use std::mem::size_of;
 
-use bytes::{BufMut, Bytes, BytesMut};
+use bytes::{Buf, BufMut, Bytes, BytesMut};
+use futures::StreamExt;
 use risingwave_hummock_sdk::HummockRawObjectId;
 use risingwave_hummock_sdk::version::HummockVersion;
 use risingwave_object_store::object::{
-    MonitoredStreamingReader, ObjectDataStreamReader, ObjectStreamingUploader,
+    MonitoredStreamingReader, ObjectDataStream, ObjectDataStreamReader, ObjectStreamingUploader,
 };
-use tokio::io::{AsyncRead, AsyncReadExt};
+use tokio::io::AsyncReadExt;
 use twox_hash::XxHash64;
 
 use crate::MetaSnapshotId;
 use crate::error::{BackupError, BackupResult};
 
 pub trait Metadata: Display + Send + Sync {
-    fn encode_to_writer<'a>(
-        &'a self,
-        writer: &'a mut SnapshotPayloadWriter,
-    ) -> impl Future<Output = BackupResult<()>> + Send + 'a;
+    fn encode_to_writer(
+        &self,
+        writer: SnapshotPayloadWriter,
+    ) -> impl Future<Output = BackupResult<()>> + Send;
 
-    fn decode_from_reader<R>(
-        reader: SnapshotPayloadReader<R>,
+    fn decode_from_reader(
+        reader: SnapshotPayloadReader,
     ) -> impl Future<Output = BackupResult<Self>> + Send
     where
-        Self: Sized,
-        R: AsyncRead + Send;
+        Self: Sized;
 
     fn hummock_version_ref(&self) -> &HummockVersion;
 
@@ -71,8 +71,7 @@ impl<T: Metadata> MetaSnapshot<T> {
         header.put_u64_le(self.id);
         writer.write_snapshot_bytes(header.freeze()).await?;
 
-        self.metadata.encode_to_writer(&mut writer).await?;
-        writer.finish().await
+        self.metadata.encode_to_writer(writer).await
     }
 
     pub async fn decode_from_stream(reader: MonitoredStreamingReader) -> BackupResult<Self> {
@@ -110,30 +109,28 @@ impl SnapshotPayloadWriter {
         Ok(())
     }
 
-    pub fn size(&self) -> usize {
-        self.size
-    }
-
-    pub async fn finish(mut self) -> BackupResult<()> {
+    pub async fn finish(mut self) -> BackupResult<usize> {
         let mut checksum = BytesMut::with_capacity(size_of::<u64>());
         checksum.put_u64_le(self.hasher.finish());
         let checksum = checksum.freeze();
         self.size += checksum.len();
         self.uploader.write_bytes(checksum).await?;
         self.uploader.finish().await?;
-        Ok(())
+        Ok(self.size)
     }
 }
 
-pub struct SnapshotPayloadReader<R> {
-    reader: std::pin::Pin<Box<R>>,
+type SnapshotPayloadStreamReader = ObjectDataStreamReader<ObjectDataStream>;
+
+pub struct SnapshotPayloadReader {
+    reader: SnapshotPayloadStreamReader,
     hasher: XxHash64,
 }
 
-impl<R: AsyncRead> SnapshotPayloadReader<R> {
-    pub fn new(reader: R) -> Self {
+impl SnapshotPayloadReader {
+    pub fn new(reader: SnapshotPayloadStreamReader) -> Self {
         Self {
-            reader: Box::pin(reader),
+            reader,
             hasher: XxHash64::with_seed(0),
         }
     }
@@ -161,20 +158,17 @@ impl<R: AsyncRead> SnapshotPayloadReader<R> {
     pub async fn read_exact(&mut self, len: usize) -> BackupResult<BytesMut> {
         let mut bytes = BytesMut::with_capacity(len);
         bytes.resize(len, 0);
-        self.reader.as_mut().read_exact(&mut bytes).await?;
+        self.reader.read_exact(&mut bytes).await?;
         self.hasher.write(&bytes);
         Ok(bytes)
     }
 
     pub async fn skip_exact(&mut self, mut len: usize) -> BackupResult<()> {
-        const BUFFER_SIZE: usize = 8 * 1024;
+        const BUFFER_SIZE: usize = 1024;
         let mut buf = [0; BUFFER_SIZE];
         while len > 0 {
             let read_len = len.min(BUFFER_SIZE);
-            self.reader
-                .as_mut()
-                .read_exact(&mut buf[..read_len])
-                .await?;
+            self.reader.read_exact(&mut buf[..read_len]).await?;
             self.hasher.write(&buf[..read_len]);
             len -= read_len;
         }
@@ -183,7 +177,7 @@ impl<R: AsyncRead> SnapshotPayloadReader<R> {
 
     pub async fn read_to_end(mut self) -> BackupResult<Vec<u8>> {
         let mut data = vec![];
-        self.reader.as_mut().read_to_end(&mut data).await?;
+        self.reader.read_to_end(&mut data).await?;
         if data.len() < size_of::<u64>() {
             return Err(BackupError::Decoding(
                 anyhow::anyhow!("meta snapshot is missing checksum").into(),
@@ -196,22 +190,29 @@ impl<R: AsyncRead> SnapshotPayloadReader<R> {
         Ok(data)
     }
 
-    pub async fn finish_after_skipping_to_end(mut self) -> BackupResult<()> {
-        const BUFFER_SIZE: usize = 8 * 1024;
-        let mut tail = Vec::with_capacity(size_of::<u64>());
-        let mut buf = [0; BUFFER_SIZE];
+    pub async fn finish_after_skipping_to_end(self) -> BackupResult<()> {
+        let Self { reader, mut hasher } = self;
+        let mut bytes_stream = reader.into_bytes_stream();
+        let mut tail = BytesMut::with_capacity(size_of::<u64>());
 
-        loop {
-            let n = self.reader.as_mut().read(&mut buf).await?;
-            if n == 0 {
-                break;
+        while let Some(bytes) = bytes_stream.next().await.transpose()? {
+            let payload_len = tail.len() + bytes.len();
+            if payload_len <= size_of::<u64>() {
+                tail.extend_from_slice(&bytes);
+                continue;
             }
 
-            tail.extend_from_slice(&buf[..n]);
-            if tail.len() > size_of::<u64>() {
-                let payload_len = tail.len() - size_of::<u64>();
-                self.hasher.write(&tail[..payload_len]);
-                tail.drain(..payload_len);
+            let payload_len = payload_len - size_of::<u64>();
+            if payload_len <= tail.len() {
+                hasher.write(&tail[..payload_len]);
+                tail.advance(payload_len);
+                tail.extend_from_slice(&bytes);
+            } else {
+                let bytes_payload_len = payload_len - tail.len();
+                hasher.write(&tail);
+                hasher.write(&bytes[..bytes_payload_len]);
+                tail.clear();
+                tail.extend_from_slice(&bytes[bytes_payload_len..]);
             }
         }
 
@@ -220,16 +221,16 @@ impl<R: AsyncRead> SnapshotPayloadReader<R> {
                 anyhow::anyhow!("meta snapshot is missing checksum").into(),
             ));
         }
-        self.verify_checksum(&tail)
+        Self::verify_checksum_with_hasher(&hasher, &tail)
     }
 
     pub async fn finish(mut self) -> BackupResult<()> {
         let mut checksum = [0; size_of::<u64>()];
-        self.reader.as_mut().read_exact(&mut checksum).await?;
+        self.reader.read_exact(&mut checksum).await?;
         self.verify_checksum(&checksum)?;
 
         let mut trailing = [0; 1];
-        let n = self.reader.as_mut().read(&mut trailing).await?;
+        let n = self.reader.read(&mut trailing).await?;
         if n != 0 {
             return Err(BackupError::Decoding(
                 anyhow::anyhow!("unexpected bytes after meta snapshot checksum").into(),
@@ -239,13 +240,26 @@ impl<R: AsyncRead> SnapshotPayloadReader<R> {
     }
 
     fn verify_checksum(&self, checksum: &[u8]) -> BackupResult<()> {
+        Self::verify_checksum_with_hasher(&self.hasher, checksum)
+    }
+
+    fn verify_checksum_with_hasher(hasher: &XxHash64, checksum: &[u8]) -> BackupResult<()> {
         let expected = u64::from_le_bytes(checksum.try_into().expect("u64 length"));
-        let found = self.hasher.finish();
+        let found = hasher.finish();
         if expected != found {
             return Err(BackupError::ChecksumMismatch { expected, found });
         }
         Ok(())
     }
+}
+
+pub(crate) fn read_u32_le(buf: &mut &[u8]) -> BackupResult<u32> {
+    if buf.remaining() < 4 {
+        return Err(BackupError::Other(anyhow::anyhow!(
+            "metadata snapshot is truncated while reading u32"
+        )));
+    }
+    Ok(buf.get_u32_le())
 }
 
 impl<T: Metadata> Display for MetaSnapshot<T> {

--- a/src/storage/backup/src/meta_snapshot.rs
+++ b/src/storage/backup/src/meta_snapshot.rs
@@ -14,20 +14,34 @@
 
 use std::collections::HashSet;
 use std::fmt::{Display, Formatter};
+use std::future::Future;
+use std::hash::Hasher;
+use std::mem::size_of;
 
-use bytes::{Buf, BufMut};
+use bytes::{BufMut, Bytes, BytesMut};
 use risingwave_hummock_sdk::HummockRawObjectId;
 use risingwave_hummock_sdk::version::HummockVersion;
+use risingwave_object_store::object::{
+    MonitoredStreamingReader, ObjectDataStreamReader, ObjectStreamingUploader,
+};
+use tokio::io::{AsyncRead, AsyncReadExt};
+use twox_hash::XxHash64;
 
+use crate::MetaSnapshotId;
 use crate::error::{BackupError, BackupResult};
-use crate::{MetaSnapshotId, xxhash64_checksum, xxhash64_verify};
 
 pub trait Metadata: Display + Send + Sync {
-    fn encode_to(&self, buf: &mut Vec<u8>) -> BackupResult<()>;
+    fn encode_to_writer<'a>(
+        &'a self,
+        writer: &'a mut SnapshotPayloadWriter,
+    ) -> impl Future<Output = BackupResult<()>> + Send + 'a;
 
-    fn decode(buf: &[u8]) -> BackupResult<Self>
+    fn decode_from_reader<R>(
+        reader: SnapshotPayloadReader<R>,
+    ) -> impl Future<Output = BackupResult<Self>> + Send
     where
-        Self: Sized;
+        Self: Sized,
+        R: AsyncRead + Send;
 
     fn hummock_version_ref(&self) -> &HummockVersion;
 
@@ -49,64 +63,189 @@ pub struct MetaSnapshot<T: Metadata> {
 }
 
 impl<T: Metadata> MetaSnapshot<T> {
-    pub fn encode(&self) -> BackupResult<Vec<u8>> {
-        let mut buf = vec![];
-        buf.put_u32_le(self.format_version);
-        buf.put_u64_le(self.id);
-        self.metadata.encode_to(&mut buf)?;
-        let checksum = xxhash64_checksum(&buf);
-        buf.put_u64_le(checksum);
-        Ok(buf)
+    pub async fn encode_to_uploader(&self, uploader: ObjectStreamingUploader) -> BackupResult<()> {
+        let mut writer = SnapshotPayloadWriter::new(uploader);
+
+        let mut header = BytesMut::with_capacity(size_of::<u32>() + size_of::<u64>());
+        header.put_u32_le(self.format_version);
+        header.put_u64_le(self.id);
+        writer.write_snapshot_bytes(header.freeze()).await?;
+
+        self.metadata.encode_to_writer(&mut writer).await?;
+        writer.finish().await
     }
 
-    pub fn decode(buf: &[u8]) -> BackupResult<Self> {
-        let payload = verify_checksum_and_strip(buf)?;
-        let mut payload = payload;
-        let format_version = read_u32_le(&mut payload)?;
-        let id = read_u64_le(&mut payload)?;
-        let metadata = T::decode(payload)?;
+    pub async fn decode_from_stream(reader: MonitoredStreamingReader) -> BackupResult<Self> {
+        let mut reader =
+            SnapshotPayloadReader::new(ObjectDataStreamReader::new(reader.into_stream()));
+        let (format_version, id) = reader.read_snapshot_header().await?;
+        let metadata = T::decode_from_reader(reader).await?;
         Ok(Self {
             format_version,
             id,
             metadata,
         })
     }
+}
 
-    pub fn decode_format_version(buf: &[u8]) -> BackupResult<u32> {
-        let mut payload = verify_checksum_and_strip(buf)?;
-        read_u32_le(&mut payload)
+pub struct SnapshotPayloadWriter {
+    uploader: ObjectStreamingUploader,
+    hasher: XxHash64,
+    size: usize,
+}
+
+impl SnapshotPayloadWriter {
+    pub fn new(uploader: ObjectStreamingUploader) -> Self {
+        Self {
+            uploader,
+            hasher: XxHash64::with_seed(0),
+            size: 0,
+        }
+    }
+
+    pub async fn write_snapshot_bytes(&mut self, data: Bytes) -> BackupResult<()> {
+        self.hasher.write(data.as_ref());
+        self.size += data.len();
+        self.uploader.write_bytes(data).await?;
+        Ok(())
+    }
+
+    pub fn size(&self) -> usize {
+        self.size
+    }
+
+    pub async fn finish(mut self) -> BackupResult<()> {
+        let mut checksum = BytesMut::with_capacity(size_of::<u64>());
+        checksum.put_u64_le(self.hasher.finish());
+        let checksum = checksum.freeze();
+        self.size += checksum.len();
+        self.uploader.write_bytes(checksum).await?;
+        self.uploader.finish().await?;
+        Ok(())
     }
 }
 
-pub(crate) fn verify_checksum_and_strip(snapshot: &[u8]) -> BackupResult<&[u8]> {
-    let payload_len = snapshot.len().checked_sub(8).ok_or_else(|| {
-        BackupError::Other(anyhow::anyhow!(
-            "metadata snapshot is too short: {} bytes",
-            snapshot.len()
+pub struct SnapshotPayloadReader<R> {
+    reader: std::pin::Pin<Box<R>>,
+    hasher: XxHash64,
+}
+
+impl<R: AsyncRead> SnapshotPayloadReader<R> {
+    pub fn new(reader: R) -> Self {
+        Self {
+            reader: Box::pin(reader),
+            hasher: XxHash64::with_seed(0),
+        }
+    }
+
+    pub async fn read_snapshot_header(&mut self) -> BackupResult<(u32, MetaSnapshotId)> {
+        let format_version = self.read_u32_le().await?;
+        let id = self.read_u64_le().await?;
+        Ok((format_version, id))
+    }
+
+    pub async fn read_u32_le(&mut self) -> BackupResult<u32> {
+        let bytes = self.read_exact(size_of::<u32>()).await?;
+        Ok(u32::from_le_bytes(
+            bytes[..].try_into().expect("u32 length"),
         ))
-    })?;
-    let mut checksum_buf = &snapshot[payload_len..];
-    let checksum = read_u64_le(&mut checksum_buf)?;
-    xxhash64_verify(&snapshot[..payload_len], checksum)?;
-    Ok(&snapshot[..payload_len])
-}
-
-pub(crate) fn read_u32_le(buf: &mut &[u8]) -> BackupResult<u32> {
-    if buf.remaining() < 4 {
-        return Err(BackupError::Other(anyhow::anyhow!(
-            "metadata snapshot is truncated while reading u32"
-        )));
     }
-    Ok(buf.get_u32_le())
-}
 
-pub(crate) fn read_u64_le(buf: &mut &[u8]) -> BackupResult<u64> {
-    if buf.remaining() < 8 {
-        return Err(BackupError::Other(anyhow::anyhow!(
-            "metadata snapshot is truncated while reading u64"
-        )));
+    pub async fn read_u64_le(&mut self) -> BackupResult<u64> {
+        let bytes = self.read_exact(size_of::<u64>()).await?;
+        Ok(u64::from_le_bytes(
+            bytes[..].try_into().expect("u64 length"),
+        ))
     }
-    Ok(buf.get_u64_le())
+
+    pub async fn read_exact(&mut self, len: usize) -> BackupResult<BytesMut> {
+        let mut bytes = BytesMut::with_capacity(len);
+        bytes.resize(len, 0);
+        self.reader.as_mut().read_exact(&mut bytes).await?;
+        self.hasher.write(&bytes);
+        Ok(bytes)
+    }
+
+    pub async fn skip_exact(&mut self, mut len: usize) -> BackupResult<()> {
+        const BUFFER_SIZE: usize = 8 * 1024;
+        let mut buf = [0; BUFFER_SIZE];
+        while len > 0 {
+            let read_len = len.min(BUFFER_SIZE);
+            self.reader
+                .as_mut()
+                .read_exact(&mut buf[..read_len])
+                .await?;
+            self.hasher.write(&buf[..read_len]);
+            len -= read_len;
+        }
+        Ok(())
+    }
+
+    pub async fn read_to_end(mut self) -> BackupResult<Vec<u8>> {
+        let mut data = vec![];
+        self.reader.as_mut().read_to_end(&mut data).await?;
+        if data.len() < size_of::<u64>() {
+            return Err(BackupError::Decoding(
+                anyhow::anyhow!("meta snapshot is missing checksum").into(),
+            ));
+        }
+
+        let checksum = data.split_off(data.len() - size_of::<u64>());
+        self.hasher.write(&data);
+        self.verify_checksum(&checksum)?;
+        Ok(data)
+    }
+
+    pub async fn finish_after_skipping_to_end(mut self) -> BackupResult<()> {
+        const BUFFER_SIZE: usize = 8 * 1024;
+        let mut tail = Vec::with_capacity(size_of::<u64>());
+        let mut buf = [0; BUFFER_SIZE];
+
+        loop {
+            let n = self.reader.as_mut().read(&mut buf).await?;
+            if n == 0 {
+                break;
+            }
+
+            tail.extend_from_slice(&buf[..n]);
+            if tail.len() > size_of::<u64>() {
+                let payload_len = tail.len() - size_of::<u64>();
+                self.hasher.write(&tail[..payload_len]);
+                tail.drain(..payload_len);
+            }
+        }
+
+        if tail.len() != size_of::<u64>() {
+            return Err(BackupError::Decoding(
+                anyhow::anyhow!("meta snapshot is missing checksum").into(),
+            ));
+        }
+        self.verify_checksum(&tail)
+    }
+
+    pub async fn finish(mut self) -> BackupResult<()> {
+        let mut checksum = [0; size_of::<u64>()];
+        self.reader.as_mut().read_exact(&mut checksum).await?;
+        self.verify_checksum(&checksum)?;
+
+        let mut trailing = [0; 1];
+        let n = self.reader.as_mut().read(&mut trailing).await?;
+        if n != 0 {
+            return Err(BackupError::Decoding(
+                anyhow::anyhow!("unexpected bytes after meta snapshot checksum").into(),
+            ));
+        }
+        Ok(())
+    }
+
+    fn verify_checksum(&self, checksum: &[u8]) -> BackupResult<()> {
+        let expected = u64::from_le_bytes(checksum.try_into().expect("u64 length"));
+        let found = self.hasher.finish();
+        if expected != found {
+            return Err(BackupError::ChecksumMismatch { expected, found });
+        }
+        Ok(())
+    }
 }
 
 impl<T: Metadata> Display for MetaSnapshot<T> {

--- a/src/storage/backup/src/meta_snapshot_v1.rs
+++ b/src/storage/backup/src/meta_snapshot_v1.rs
@@ -26,10 +26,11 @@ use risingwave_pb::catalog::{
 use risingwave_pb::hummock::{CompactionGroup, HummockVersionStats, PbHummockVersion};
 use risingwave_pb::meta::{SystemParams, TableFragments};
 use risingwave_pb::user::UserInfo;
-use tokio::io::AsyncRead;
 
 use crate::error::{BackupError, BackupResult};
-use crate::meta_snapshot::{MetaSnapshot, Metadata, SnapshotPayloadReader, SnapshotPayloadWriter};
+use crate::meta_snapshot::{
+    MetaSnapshot, Metadata, SnapshotPayloadReader, SnapshotPayloadWriter, read_u32_le,
+};
 
 // TODO: remove `ClusterMetadata` and even the trait, after applying model v2.
 pub type MetaSnapshotV1 = MetaSnapshot<ClusterMetadata>;
@@ -82,17 +83,15 @@ impl Display for ClusterMetadata {
 }
 
 impl Metadata for ClusterMetadata {
-    async fn encode_to_writer(&self, writer: &mut SnapshotPayloadWriter) -> BackupResult<()> {
+    async fn encode_to_writer(&self, mut writer: SnapshotPayloadWriter) -> BackupResult<()> {
         let mut buf = BytesMut::new();
         self.encode_to(&mut buf)?;
-        writer.write_snapshot_bytes(buf.freeze()).await
+        writer.write_snapshot_bytes(buf.freeze()).await?;
+        writer.finish().await?;
+        Ok(())
     }
 
-    async fn decode_from_reader<R>(reader: SnapshotPayloadReader<R>) -> BackupResult<Self>
-    where
-        Self: Sized,
-        R: AsyncRead + Send,
-    {
+    async fn decode_from_reader(reader: SnapshotPayloadReader) -> BackupResult<Self> {
         let data = reader.read_to_end().await?;
         ClusterMetadata::decode(&data)
     }
@@ -234,7 +233,14 @@ impl ClusterMetadata {
     where
         T: prost::Message + Default,
     {
-        let len = buf.get_u32_le() as usize;
+        let len = read_u32_le(buf)? as usize;
+        if buf.remaining() < len {
+            return Err(BackupError::Other(anyhow::anyhow!(
+                "prost payload length {} exceeds remaining buffer {}",
+                len,
+                buf.remaining()
+            )));
+        }
         let v = buf[..len].to_vec();
         buf.advance(len);
         T::decode(v.as_slice()).map_err(|e| BackupError::Decoding(e.into()))
@@ -251,7 +257,7 @@ impl ClusterMetadata {
     where
         T: prost::Message + Default,
     {
-        let vec_len = buf.get_u32_le() as usize;
+        let vec_len = read_u32_le(buf)? as usize;
         let mut result = vec![];
         for _ in 0..vec_len {
             let v: T = Self::decode_prost_message(buf)?;

--- a/src/storage/backup/src/meta_snapshot_v1.rs
+++ b/src/storage/backup/src/meta_snapshot_v1.rs
@@ -15,7 +15,7 @@
 use std::collections::{HashMap, HashSet};
 use std::fmt::{Display, Formatter};
 
-use bytes::{Buf, BufMut};
+use bytes::{Buf, BufMut, BytesMut};
 use itertools::Itertools;
 use risingwave_common::util::iter_util::ZipEqFast;
 use risingwave_hummock_sdk::HummockRawObjectId;
@@ -26,9 +26,10 @@ use risingwave_pb::catalog::{
 use risingwave_pb::hummock::{CompactionGroup, HummockVersionStats, PbHummockVersion};
 use risingwave_pb::meta::{SystemParams, TableFragments};
 use risingwave_pb::user::UserInfo;
+use tokio::io::AsyncRead;
 
 use crate::error::{BackupError, BackupResult};
-use crate::meta_snapshot::{MetaSnapshot, Metadata, read_u32_le};
+use crate::meta_snapshot::{MetaSnapshot, Metadata, SnapshotPayloadReader, SnapshotPayloadWriter};
 
 // TODO: remove `ClusterMetadata` and even the trait, after applying model v2.
 pub type MetaSnapshotV1 = MetaSnapshot<ClusterMetadata>;
@@ -81,15 +82,19 @@ impl Display for ClusterMetadata {
 }
 
 impl Metadata for ClusterMetadata {
-    fn encode_to(&self, buf: &mut Vec<u8>) -> BackupResult<()> {
-        self.encode_to(buf)
+    async fn encode_to_writer(&self, writer: &mut SnapshotPayloadWriter) -> BackupResult<()> {
+        let mut buf = BytesMut::new();
+        self.encode_to(&mut buf)?;
+        writer.write_snapshot_bytes(buf.freeze()).await
     }
 
-    fn decode(buf: &[u8]) -> BackupResult<Self>
+    async fn decode_from_reader<R>(reader: SnapshotPayloadReader<R>) -> BackupResult<Self>
     where
         Self: Sized,
+        R: AsyncRead + Send,
     {
-        ClusterMetadata::decode(buf)
+        let data = reader.read_to_end().await?;
+        ClusterMetadata::decode(&data)
     }
 
     fn hummock_version_ref(&self) -> &HummockVersion {
@@ -141,7 +146,7 @@ pub struct ClusterMetadata {
 }
 
 impl ClusterMetadata {
-    pub fn encode_to(&self, buf: &mut Vec<u8>) -> BackupResult<()> {
+    pub fn encode_to(&self, buf: &mut impl BufMut) -> BackupResult<()> {
         let default_cf_keys = self.default_cf.keys().collect_vec();
         let default_cf_values = self.default_cf.values().collect_vec();
         Self::encode_prost_message_list(&default_cf_keys, buf);
@@ -219,7 +224,7 @@ impl ClusterMetadata {
         })
     }
 
-    fn encode_prost_message(message: &impl prost::Message, buf: &mut Vec<u8>) {
+    fn encode_prost_message(message: &impl prost::Message, buf: &mut impl BufMut) {
         let encoded_message = message.encode_to_vec();
         buf.put_u32_le(encoded_message.len() as u32);
         buf.put_slice(&encoded_message);
@@ -229,20 +234,13 @@ impl ClusterMetadata {
     where
         T: prost::Message + Default,
     {
-        let len = read_u32_le(buf)? as usize;
-        if buf.remaining() < len {
-            return Err(BackupError::Other(anyhow::anyhow!(
-                "prost payload length {} exceeds remaining buffer {}",
-                len,
-                buf.remaining()
-            )));
-        }
+        let len = buf.get_u32_le() as usize;
         let v = buf[..len].to_vec();
         buf.advance(len);
         T::decode(v.as_slice()).map_err(|e| BackupError::Decoding(e.into()))
     }
 
-    fn encode_prost_message_list(messages: &[&impl prost::Message], buf: &mut Vec<u8>) {
+    fn encode_prost_message_list(messages: &[&impl prost::Message], buf: &mut impl BufMut) {
         buf.put_u32_le(messages.len() as u32);
         for message in messages {
             Self::encode_prost_message(*message, buf);
@@ -253,7 +251,7 @@ impl ClusterMetadata {
     where
         T: prost::Message + Default,
     {
-        let vec_len = read_u32_le(buf)? as usize;
+        let vec_len = buf.get_u32_le() as usize;
         let mut result = vec![];
         for _ in 0..vec_len {
             let v: T = Self::decode_prost_message(buf)?;
@@ -275,47 +273,32 @@ impl ClusterMetadata {
 
 #[cfg(test)]
 mod tests {
+    use bytes::BytesMut;
     use risingwave_hummock_sdk::HummockVersionId;
     use risingwave_pb::hummock::{CompactionGroup, TableStats};
 
-    use crate::meta_snapshot_v1::{ClusterMetadata, MetaSnapshotV1};
-
-    type MetaSnapshot = MetaSnapshotV1;
-
-    #[test]
-    fn test_snapshot_encoding_decoding() {
-        let mut metadata = ClusterMetadata::default();
-        metadata.hummock_version.id = HummockVersionId::new(321);
-        let raw = MetaSnapshot {
-            format_version: 0,
-            id: 123,
-            metadata,
-        };
-        let encoded = raw.encode().unwrap();
-        let decoded = MetaSnapshot::decode(&encoded).unwrap();
-        assert_eq!(raw, decoded);
-    }
+    use crate::meta_snapshot_v1::ClusterMetadata;
 
     #[test]
     fn test_metadata_encoding_decoding() {
-        let mut buf = vec![];
-        let mut raw = ClusterMetadata::default();
-        raw.default_cf.insert(vec![0, 1, 2], vec![3, 4, 5]);
-        raw.hummock_version.id = HummockVersionId::new(1);
-        raw.version_stats.hummock_version_id = 10.into();
-        raw.version_stats.table_stats.insert(
+        let mut buf = BytesMut::new();
+        let mut metadata = ClusterMetadata::default();
+        metadata.hummock_version.id = HummockVersionId::new(321);
+        metadata.default_cf.insert(vec![0, 1, 2], vec![3, 4, 5]);
+        metadata.version_stats.hummock_version_id = 10.into();
+        metadata.version_stats.table_stats.insert(
             200.into(),
             TableStats {
                 total_key_count: 1000,
                 ..Default::default()
             },
         );
-        raw.compaction_groups.push(CompactionGroup {
+        metadata.compaction_groups.push(CompactionGroup {
             id: 3000.into(),
             ..Default::default()
         });
-        raw.encode_to(&mut buf).unwrap();
-        let decoded = ClusterMetadata::decode(buf.as_slice()).unwrap();
-        assert_eq!(raw, decoded);
+        metadata.encode_to(&mut buf).unwrap();
+        let decoded = ClusterMetadata::decode(&buf).unwrap();
+        assert_eq!(metadata, decoded);
     }
 }

--- a/src/storage/backup/src/meta_snapshot_v2.rs
+++ b/src/storage/backup/src/meta_snapshot_v2.rs
@@ -14,18 +14,21 @@
 
 use std::collections::HashSet;
 use std::fmt::{Display, Formatter};
+use std::mem::size_of;
 
 use anyhow::anyhow;
-use bytes::{Buf, BufMut};
+use bytes::{BufMut, BytesMut};
 use itertools::Itertools;
 use risingwave_hummock_sdk::HummockRawObjectId;
 use risingwave_hummock_sdk::change_log::EpochNewChangeLog;
 use risingwave_hummock_sdk::version::HummockVersion;
-use serde::{Deserialize, Serialize};
+use risingwave_object_store::object::{MonitoredStreamingReader, ObjectDataStreamReader};
+use serde::Serialize;
+use serde::de::DeserializeOwned;
+use tokio::io::AsyncRead;
+use tracing::info;
 
-use crate::meta_snapshot::{
-    MetaSnapshot, Metadata, read_u32_le, read_u64_le, verify_checksum_and_strip,
-};
+use crate::meta_snapshot::{MetaSnapshot, Metadata, SnapshotPayloadReader, SnapshotPayloadWriter};
 use crate::{BackupError, BackupResult};
 pub type MetaSnapshotV2 = MetaSnapshot<MetadataV2>;
 
@@ -95,18 +98,18 @@ macro_rules! define_metadata_v2 {
 
 for_all_metadata_models_v2!(define_metadata_v2);
 
-macro_rules! define_encode_metadata {
+macro_rules! define_encode_metadata_to_writer {
     ($( {$name:ident, $mod_path:ident::$mod_name:ident} ),*) => {
-        fn encode_metadata(
-          metadata: &MetadataV2,
-          buf: &mut Vec<u8>,
+        async fn encode_metadata_to_writer(
+            metadata: &MetadataV2,
+            writer: &mut SnapshotPayloadWriter,
         ) -> BackupResult<()> {
             let mut _idx = 0;
             $(
                 if _idx == 1 {
-                    put_1(buf, &metadata.hummock_version.to_protobuf())?;
+                    write_1(writer, &metadata.hummock_version.to_protobuf()).await?;
                 }
-                put_n(buf, &metadata.$name)?;
+                write_n(writer, &metadata.$name).await?;
                 _idx += 1;
             )*
             Ok(())
@@ -114,20 +117,23 @@ macro_rules! define_encode_metadata {
     };
 }
 
-for_all_metadata_models_v2!(define_encode_metadata);
+for_all_metadata_models_v2!(define_encode_metadata_to_writer);
 
 macro_rules! define_decode_metadata {
     ($( {$name:ident, $mod_path:ident::$mod_name:ident} ),*) => {
-        fn decode_metadata(
-          metadata: &mut MetadataV2,
-          mut buf: &[u8],
-        ) -> BackupResult<()> {
+        async fn decode_metadata_from_reader<R>(
+            metadata: &mut MetadataV2,
+            reader: &mut SnapshotPayloadReader<R>,
+        ) -> BackupResult<()>
+        where
+            R: AsyncRead + Send,
+        {
             let mut _idx = 0;
             $(
                 if _idx == 1 {
-                    metadata.hummock_version = HummockVersion::from_persisted_protobuf_owned(get_1(&mut buf)?);
+                    metadata.hummock_version = HummockVersion::from_persisted_protobuf_owned(read_1(reader).await?);
                 }
-                metadata.$name = get_n(&mut buf)?;
+                metadata.$name = read_n(reader).await?;
                 _idx += 1;
             )*
             Ok(())
@@ -145,22 +151,23 @@ for_all_metadata_models_v2!(define_decode_metadata);
 // only append sections after `hummock_sequences`.
 const HUMMOCK_SEQUENCES_METADATA_SECTION_INDEX: usize = 26;
 
-pub fn decode_hummock_sequences_from_snapshot(
-    snapshot: &[u8],
+pub async fn decode_hummock_sequences_from_stream(
+    stream: MonitoredStreamingReader,
 ) -> BackupResult<Vec<risingwave_meta_model::hummock_sequence::Model>> {
-    let mut buf = verify_checksum_and_strip(snapshot)?;
-    let format_version = read_u32_le(&mut buf)?;
+    let mut reader = SnapshotPayloadReader::new(ObjectDataStreamReader::new(stream.into_stream()));
+    let (format_version, _snapshot_id) = reader.read_snapshot_header().await?;
     if format_version < 2 {
         return Err(BackupError::Other(anyhow!(
             "unsupported metadata snapshot format version for hummock sequence partial decoding: {}",
             format_version
         )));
     }
-    let _snapshot_id = read_u64_le(&mut buf)?;
     for _ in 0..HUMMOCK_SEQUENCES_METADATA_SECTION_INDEX {
-        skip_metadata_list(&mut buf)?;
+        skip_metadata_list(&mut reader).await?;
     }
-    get_n(&mut buf)
+    let hummock_sequences = read_n(&mut reader).await?;
+    reader.finish_after_skipping_to_end().await?;
+    Ok(hummock_sequences)
 }
 
 impl Display for MetadataV2 {
@@ -178,16 +185,21 @@ impl Display for MetadataV2 {
 }
 
 impl Metadata for MetadataV2 {
-    fn encode_to(&self, buf: &mut Vec<u8>) -> BackupResult<()> {
-        encode_metadata(self, buf)
+    async fn encode_to_writer(&self, writer: &mut SnapshotPayloadWriter) -> BackupResult<()> {
+        encode_metadata_to_writer(self, writer).await?;
+        let snapshot_size_bytes = writer.size() + size_of::<u64>();
+        info!(snapshot_size_bytes, "encoded v2 meta snapshot backup file");
+        Ok(())
     }
 
-    fn decode(buf: &[u8]) -> BackupResult<Self>
+    async fn decode_from_reader<R>(mut reader: SnapshotPayloadReader<R>) -> BackupResult<Self>
     where
         Self: Sized,
+        R: AsyncRead + Send,
     {
         let mut metadata = Self::default();
-        decode_metadata(&mut metadata, buf)?;
+        decode_metadata_from_reader(&mut metadata, &mut reader).await?;
+        reader.finish().await?;
         Ok(metadata)
     }
 
@@ -274,71 +286,63 @@ fn to_table_change_log(
     }
 }
 
-fn put_n<T: Serialize>(buf: &mut Vec<u8>, data: &[T]) -> Result<(), serde_json::Error> {
+async fn write_len(writer: &mut SnapshotPayloadWriter, len: usize) -> BackupResult<()> {
+    let mut buf = BytesMut::with_capacity(size_of::<u32>());
     buf.put_u32_le(
-        data.len()
-            .try_into()
-            .unwrap_or_else(|_| panic!("cannot convert {} into u32", data.len())),
+        len.try_into()
+            .unwrap_or_else(|_| panic!("cannot convert {} into u32", len)),
     );
+    writer.write_snapshot_bytes(buf.freeze()).await
+}
+
+async fn write_n<T: Serialize>(writer: &mut SnapshotPayloadWriter, data: &[T]) -> BackupResult<()> {
+    write_len(writer, data.len()).await?;
     for d in data {
-        put_with_len_prefix(buf, d)?;
+        write_with_len_prefix(writer, d).await?;
     }
     Ok(())
 }
 
-fn put_1<T: Serialize>(buf: &mut Vec<u8>, data: &T) -> Result<(), serde_json::Error> {
-    put_n(buf, &[data])
+async fn write_1<T: Serialize>(writer: &mut SnapshotPayloadWriter, data: &T) -> BackupResult<()> {
+    write_n(writer, &[data]).await
 }
 
-fn get_n<'a, T: Deserialize<'a>>(buf: &mut &'a [u8]) -> BackupResult<Vec<T>> {
-    let n = read_u32_le(buf)? as usize;
+async fn read_n<R, T>(reader: &mut SnapshotPayloadReader<R>) -> BackupResult<Vec<T>>
+where
+    R: AsyncRead + Send,
+    T: DeserializeOwned,
+{
+    let n = reader.read_u32_le().await? as usize;
     let mut elements = Vec::with_capacity(n);
     for _ in 0..n {
-        elements.push(get_with_len_prefix(buf)?);
+        elements.push(read_with_len_prefix(reader).await?);
     }
     Ok(elements)
 }
 
-fn get_1<'a, T: Deserialize<'a>>(buf: &mut &'a [u8]) -> BackupResult<T> {
-    let elements = get_n(buf)?;
+async fn read_1<R, T>(reader: &mut SnapshotPayloadReader<R>) -> BackupResult<T>
+where
+    R: AsyncRead + Send,
+    T: DeserializeOwned,
+{
+    let elements = read_n(reader).await?;
     assert_eq!(elements.len(), 1);
     Ok(elements.into_iter().next().unwrap())
 }
 
-fn skip_metadata_list(buf: &mut &[u8]) -> BackupResult<()> {
-    let n = read_u32_le(buf)? as usize;
-    for _ in 0..n {
-        skip_with_len_prefix(buf)?;
-    }
-    Ok(())
-}
-
-fn skip_with_len_prefix(buf: &mut &[u8]) -> BackupResult<()> {
-    let len = read_len_prefix(buf)?;
-    if buf.remaining() < len {
-        return Err(BackupError::Other(anyhow!(
-            "metadata JSON payload length {} exceeds remaining buffer {}",
-            len,
-            buf.remaining()
-        )));
-    }
-    buf.advance(len);
-    Ok(())
-}
-
-fn read_len_prefix(buf: &mut &[u8]) -> BackupResult<usize> {
-    match read_u32_le(buf)? {
-        0 => read_u64_le(buf)?
-            .try_into()
-            .map_err(|_| BackupError::Other(anyhow!("metadata JSON payload length exceeds usize"))),
-        len => Ok(len as usize),
-    }
-}
-
-fn put_with_len_prefix<T: Serialize>(buf: &mut Vec<u8>, data: &T) -> Result<(), serde_json::Error> {
+async fn write_with_len_prefix<T: Serialize>(
+    writer: &mut SnapshotPayloadWriter,
+    data: &T,
+) -> BackupResult<()> {
     let b = serde_json::to_vec(data)?;
     // Any valid JSON value serialized by serde_json is non-empty, such as `null`, `{}`, or `[]`.
     assert!(!b.is_empty());
+    let len_prefix_len = if u32::try_from(b.len()).is_ok() {
+        size_of::<u32>()
+    } else {
+        size_of::<u32>() + size_of::<u64>()
+    };
+    let mut buf = BytesMut::with_capacity(len_prefix_len + b.len());
     if let Ok(len) = u32::try_from(b.len()) {
         buf.put_u32_le(len);
     } else {
@@ -350,187 +354,48 @@ fn put_with_len_prefix<T: Serialize>(buf: &mut Vec<u8>, data: &T) -> Result<(), 
         );
     }
     buf.put_slice(&b);
+    writer.write_snapshot_bytes(buf.freeze()).await
+}
+
+async fn read_with_len_prefix<R, T>(reader: &mut SnapshotPayloadReader<R>) -> BackupResult<T>
+where
+    R: AsyncRead + Send,
+    T: DeserializeOwned,
+{
+    let len = read_len_prefix(reader).await?;
+    let bytes = reader.read_exact(len).await?;
+    Ok(serde_json::from_slice(&bytes)?)
+}
+
+async fn skip_metadata_list<R>(reader: &mut SnapshotPayloadReader<R>) -> BackupResult<()>
+where
+    R: AsyncRead + Send,
+{
+    let n = reader.read_u32_le().await? as usize;
+    for _ in 0..n {
+        skip_with_len_prefix(reader).await?;
+    }
     Ok(())
 }
 
-fn get_with_len_prefix<'a, T: Deserialize<'a>>(buf: &mut &'a [u8]) -> BackupResult<T> {
-    let len = read_len_prefix(buf)?;
-    if buf.remaining() < len {
-        return Err(BackupError::Other(anyhow!(
-            "metadata JSON payload length {} exceeds remaining buffer {}",
-            len,
-            buf.remaining()
-        )));
-    }
-    let d = serde_json::from_slice(&buf[..len])?;
-    buf.advance(len);
-    Ok(d)
+async fn skip_with_len_prefix<R>(reader: &mut SnapshotPayloadReader<R>) -> BackupResult<()>
+where
+    R: AsyncRead + Send,
+{
+    let len = read_len_prefix(reader).await?;
+    reader.skip_exact(len).await
 }
 
-#[cfg(test)]
-mod tests {
-    use bytes::BufMut;
-    use risingwave_common::util::panic::rw_catch_unwind;
-    use risingwave_meta_model::hummock_sequence;
-
-    use super::*;
-
-    fn encoded_snapshot_with_invalid_trailing_metadata_after_hummock_sequences(
-        metadata: &MetadataV2,
-    ) -> Vec<u8> {
-        let raw = MetaSnapshotV2 {
-            format_version: 2,
-            id: 123,
-            metadata: MetadataV2 {
-                hummock_sequences: metadata.hummock_sequences.clone(),
-                ..Default::default()
-            },
-        };
-        let encoded = raw.encode().unwrap();
-        let payload = &encoded[..encoded.len() - 8];
-        let mut metadata_buf = &payload[12..];
-
-        for _ in 0..=HUMMOCK_SEQUENCES_METADATA_SECTION_INDEX {
-            skip_metadata_list(&mut metadata_buf).unwrap();
+async fn read_len_prefix<R>(reader: &mut SnapshotPayloadReader<R>) -> BackupResult<usize>
+where
+    R: AsyncRead + Send,
+{
+    match reader.read_u32_le().await? {
+        0 => {
+            reader.read_u64_le().await?.try_into().map_err(|_| {
+                BackupError::Other(anyhow!("metadata JSON payload length exceeds usize"))
+            })
         }
-
-        let mut partial_payload = payload[..payload.len() - metadata_buf.len()].to_vec();
-        partial_payload.put_u32_le(1);
-        partial_payload.put_u32_le(100);
-        partial_payload.put_slice(br#""short""#);
-        let checksum = crate::xxhash64_checksum(&partial_payload);
-        partial_payload.put_u64_le(checksum);
-        partial_payload
-    }
-
-    fn append_future_metadata_section(mut encoded: Vec<u8>) -> Vec<u8> {
-        encoded.truncate(encoded.len() - 8);
-        put_n(&mut encoded, &["future section"]).unwrap();
-        let checksum = crate::xxhash64_checksum(&encoded);
-        encoded.put_u64_le(checksum);
-        encoded
-    }
-
-    #[test]
-    fn test_len_prefix_legacy_u32_round_trip() {
-        let mut buf = vec![];
-        put_with_len_prefix(&mut buf, &"hello").unwrap();
-
-        assert_ne!(u32::from_le_bytes(buf[..4].try_into().unwrap()), 0);
-
-        let decoded: String = get_with_len_prefix(&mut buf.as_slice()).unwrap();
-        assert_eq!(decoded, "hello");
-    }
-
-    #[test]
-    fn test_len_prefix_extended_u64_decoding() {
-        let payload = serde_json::to_vec("hello").unwrap();
-        let mut buf = vec![];
-        buf.put_u32_le(0);
-        buf.put_u64_le(payload.len() as u64);
-        buf.put_slice(&payload);
-
-        let decoded: String = get_with_len_prefix(&mut buf.as_slice()).unwrap();
-        assert_eq!(decoded, "hello");
-    }
-
-    #[test]
-    fn test_len_prefix_errors_on_missing_extended_u64() {
-        let mut buf = vec![];
-        buf.put_u32_le(0);
-
-        assert!(get_with_len_prefix::<String>(&mut buf.as_slice()).is_err());
-    }
-
-    #[test]
-    fn test_len_prefix_errors_on_payload_shorter_than_declared_len() {
-        let mut buf = vec![];
-        buf.put_u32_le(100);
-        buf.put_slice(br#""hello""#);
-
-        assert!(get_with_len_prefix::<String>(&mut buf.as_slice()).is_err());
-    }
-
-    #[test]
-    fn test_snapshot_v2_encoding_decoding() {
-        let raw = MetaSnapshotV2 {
-            format_version: 2,
-            id: 123,
-            metadata: MetadataV2::default(),
-        };
-
-        let encoded = raw.encode().unwrap();
-        let decoded = MetaSnapshotV2::decode(&encoded).unwrap();
-
-        assert_eq!(decoded.format_version, raw.format_version);
-        assert_eq!(decoded.id, raw.id);
-        assert_eq!(
-            decoded.metadata.hummock_version.id,
-            raw.metadata.hummock_version.id
-        );
-    }
-
-    #[test]
-    fn test_partial_decode_hummock_sequences() {
-        let raw = MetaSnapshotV2 {
-            format_version: 2,
-            id: 123,
-            metadata: MetadataV2 {
-                hummock_sequences: vec![
-                    hummock_sequence::Model {
-                        name: "meta_backup".to_owned(),
-                        seq: 42,
-                    },
-                    hummock_sequence::Model {
-                        name: "sstable_object".to_owned(),
-                        seq: 100,
-                    },
-                ],
-                ..Default::default()
-            },
-        };
-
-        let decoded = decode_hummock_sequences_from_snapshot(&raw.encode().unwrap()).unwrap();
-        assert_eq!(decoded, raw.metadata.hummock_sequences);
-    }
-
-    #[test]
-    fn test_partial_decode_hummock_sequences_ignores_trailing_metadata() {
-        let metadata = MetadataV2 {
-            hummock_sequences: vec![hummock_sequence::Model {
-                name: "meta_backup".to_owned(),
-                seq: 42,
-            }],
-            ..Default::default()
-        };
-        let encoded =
-            encoded_snapshot_with_invalid_trailing_metadata_after_hummock_sequences(&metadata);
-
-        let decoded = decode_hummock_sequences_from_snapshot(&encoded).unwrap();
-        assert_eq!(decoded, metadata.hummock_sequences);
-        let full_decode_result = rw_catch_unwind(|| MetaSnapshotV2::decode(&encoded));
-        assert!(
-            full_decode_result.is_err() || full_decode_result.unwrap().is_err(),
-            "full metadata decoding should not accept the intentionally invalid trailing section"
-        );
-    }
-
-    #[test]
-    fn test_partial_decode_hummock_sequences_ignores_appended_future_sections() {
-        let raw = MetaSnapshotV2 {
-            format_version: 2,
-            id: 123,
-            metadata: MetadataV2 {
-                hummock_sequences: vec![hummock_sequence::Model {
-                    name: "meta_backup".to_owned(),
-                    seq: 42,
-                }],
-                ..Default::default()
-            },
-        };
-
-        let encoded = append_future_metadata_section(raw.encode().unwrap());
-        let decoded = decode_hummock_sequences_from_snapshot(&encoded).unwrap();
-        assert_eq!(decoded, raw.metadata.hummock_sequences);
+        len => Ok(len as usize),
     }
 }

--- a/src/storage/backup/src/meta_snapshot_v2.rs
+++ b/src/storage/backup/src/meta_snapshot_v2.rs
@@ -190,7 +190,7 @@ impl Metadata for MetadataV2 {
     async fn decode_from_reader(mut reader: SnapshotPayloadReader) -> BackupResult<Self> {
         let mut metadata = Self::default();
         decode_metadata_from_reader(&mut metadata, &mut reader).await?;
-        reader.finish().await?;
+        reader.finish_after_skipping_to_end().await?;
         Ok(metadata)
     }
 
@@ -692,5 +692,17 @@ mod tests {
         .await
         .unwrap();
         assert_eq!(decoded, raw.metadata.hummock_sequences);
+
+        let decoded = MetaSnapshotV2::decode_from_stream(
+            store.streaming_read("future-section", ..).await.unwrap(),
+        )
+        .await
+        .unwrap();
+        assert_eq!(decoded.format_version, raw.format_version);
+        assert_eq!(decoded.id, raw.id);
+        assert_eq!(
+            decoded.metadata.hummock_sequences,
+            raw.metadata.hummock_sequences
+        );
     }
 }

--- a/src/storage/backup/src/meta_snapshot_v2.rs
+++ b/src/storage/backup/src/meta_snapshot_v2.rs
@@ -25,7 +25,6 @@ use risingwave_hummock_sdk::version::HummockVersion;
 use risingwave_object_store::object::{MonitoredStreamingReader, ObjectDataStreamReader};
 use serde::Serialize;
 use serde::de::DeserializeOwned;
-use tokio::io::AsyncRead;
 use tracing::info;
 
 use crate::meta_snapshot::{MetaSnapshot, Metadata, SnapshotPayloadReader, SnapshotPayloadWriter};
@@ -121,13 +120,10 @@ for_all_metadata_models_v2!(define_encode_metadata_to_writer);
 
 macro_rules! define_decode_metadata {
     ($( {$name:ident, $mod_path:ident::$mod_name:ident} ),*) => {
-        async fn decode_metadata_from_reader<R>(
+        async fn decode_metadata_from_reader(
             metadata: &mut MetadataV2,
-            reader: &mut SnapshotPayloadReader<R>,
-        ) -> BackupResult<()>
-        where
-            R: AsyncRead + Send,
-        {
+            reader: &mut SnapshotPayloadReader,
+        ) -> BackupResult<()> {
             let mut _idx = 0;
             $(
                 if _idx == 1 {
@@ -147,8 +143,7 @@ for_all_metadata_models_v2!(define_decode_metadata);
 // `hummock_version` before `version_stats`, so `hummock_sequences` is section 26:
 // 0 seaql_migrations, 1 hummock_version, 2 version_stats, ..., 26 hummock_sequences.
 //
-// Keep this as a fixed index so partial decoding can remain compatible with future formats that
-// only append sections after `hummock_sequences`.
+// Keep this as a fixed index so partial decoding can skip directly to `hummock_sequences`.
 const HUMMOCK_SEQUENCES_METADATA_SECTION_INDEX: usize = 26;
 
 pub async fn decode_hummock_sequences_from_stream(
@@ -185,18 +180,14 @@ impl Display for MetadataV2 {
 }
 
 impl Metadata for MetadataV2 {
-    async fn encode_to_writer(&self, writer: &mut SnapshotPayloadWriter) -> BackupResult<()> {
-        encode_metadata_to_writer(self, writer).await?;
-        let snapshot_size_bytes = writer.size() + size_of::<u64>();
+    async fn encode_to_writer(&self, mut writer: SnapshotPayloadWriter) -> BackupResult<()> {
+        encode_metadata_to_writer(self, &mut writer).await?;
+        let snapshot_size_bytes = writer.finish().await?;
         info!(snapshot_size_bytes, "encoded v2 meta snapshot backup file");
         Ok(())
     }
 
-    async fn decode_from_reader<R>(mut reader: SnapshotPayloadReader<R>) -> BackupResult<Self>
-    where
-        Self: Sized,
-        R: AsyncRead + Send,
-    {
+    async fn decode_from_reader(mut reader: SnapshotPayloadReader) -> BackupResult<Self> {
         let mut metadata = Self::default();
         decode_metadata_from_reader(&mut metadata, &mut reader).await?;
         reader.finish().await?;
@@ -307,9 +298,8 @@ async fn write_1<T: Serialize>(writer: &mut SnapshotPayloadWriter, data: &T) -> 
     write_n(writer, &[data]).await
 }
 
-async fn read_n<R, T>(reader: &mut SnapshotPayloadReader<R>) -> BackupResult<Vec<T>>
+async fn read_n<T>(reader: &mut SnapshotPayloadReader) -> BackupResult<Vec<T>>
 where
-    R: AsyncRead + Send,
     T: DeserializeOwned,
 {
     let n = reader.read_u32_le().await? as usize;
@@ -320,14 +310,37 @@ where
     Ok(elements)
 }
 
-async fn read_1<R, T>(reader: &mut SnapshotPayloadReader<R>) -> BackupResult<T>
+async fn read_1<T>(reader: &mut SnapshotPayloadReader) -> BackupResult<T>
 where
-    R: AsyncRead + Send,
     T: DeserializeOwned,
 {
     let elements = read_n(reader).await?;
     assert_eq!(elements.len(), 1);
     Ok(elements.into_iter().next().unwrap())
+}
+
+async fn skip_metadata_list(reader: &mut SnapshotPayloadReader) -> BackupResult<()> {
+    let n = reader.read_u32_le().await? as usize;
+    for _ in 0..n {
+        skip_with_len_prefix(reader).await?;
+    }
+    Ok(())
+}
+
+async fn skip_with_len_prefix(reader: &mut SnapshotPayloadReader) -> BackupResult<()> {
+    let len = read_len_prefix(reader).await?;
+    reader.skip_exact(len).await
+}
+
+async fn read_len_prefix(reader: &mut SnapshotPayloadReader) -> BackupResult<usize> {
+    match reader.read_u32_le().await? {
+        0 => {
+            reader.read_u64_le().await?.try_into().map_err(|_| {
+                BackupError::Other(anyhow!("metadata JSON payload length exceeds usize"))
+            })
+        }
+        len => Ok(len as usize),
+    }
 }
 
 async fn write_with_len_prefix<T: Serialize>(
@@ -357,9 +370,8 @@ async fn write_with_len_prefix<T: Serialize>(
     writer.write_snapshot_bytes(buf.freeze()).await
 }
 
-async fn read_with_len_prefix<R, T>(reader: &mut SnapshotPayloadReader<R>) -> BackupResult<T>
+async fn read_with_len_prefix<T>(reader: &mut SnapshotPayloadReader) -> BackupResult<T>
 where
-    R: AsyncRead + Send,
     T: DeserializeOwned,
 {
     let len = read_len_prefix(reader).await?;
@@ -367,35 +379,318 @@ where
     Ok(serde_json::from_slice(&bytes)?)
 }
 
-async fn skip_metadata_list<R>(reader: &mut SnapshotPayloadReader<R>) -> BackupResult<()>
-where
-    R: AsyncRead + Send,
-{
-    let n = reader.read_u32_le().await? as usize;
-    for _ in 0..n {
-        skip_with_len_prefix(reader).await?;
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use bytes::{Buf, BufMut, Bytes};
+    use risingwave_common::config::ObjectStoreConfig;
+    use risingwave_hummock_sdk::HummockVersionId;
+    use risingwave_meta_model::hummock_sequence;
+    use risingwave_object_store::object::object_metrics::ObjectStoreMetrics;
+    use risingwave_object_store::object::{
+        InMemObjectStore, MonitoredObjectStore, ObjectStoreImpl,
+    };
+
+    use super::*;
+    use crate::meta_snapshot::read_u32_le;
+
+    fn test_store() -> ObjectStoreImpl {
+        ObjectStoreImpl::InMem(MonitoredObjectStore::new(
+            InMemObjectStore::for_test(),
+            Arc::new(ObjectStoreMetrics::unused()),
+            Arc::new(ObjectStoreConfig::default()),
+        ))
     }
-    Ok(())
-}
 
-async fn skip_with_len_prefix<R>(reader: &mut SnapshotPayloadReader<R>) -> BackupResult<()>
-where
-    R: AsyncRead + Send,
-{
-    let len = read_len_prefix(reader).await?;
-    reader.skip_exact(len).await
-}
+    async fn upload_bytes(store: &ObjectStoreImpl, path: &str, bytes: Vec<u8>) {
+        let mut uploader = store.streaming_upload(path).await.unwrap();
+        uploader.write_bytes(Bytes::from(bytes)).await.unwrap();
+        uploader.finish().await.unwrap();
+    }
 
-async fn read_len_prefix<R>(reader: &mut SnapshotPayloadReader<R>) -> BackupResult<usize>
-where
-    R: AsyncRead + Send,
-{
-    match reader.read_u32_le().await? {
-        0 => {
-            reader.read_u64_le().await?.try_into().map_err(|_| {
-                BackupError::Other(anyhow!("metadata JSON payload length exceeds usize"))
-            })
+    async fn read_bytes(store: &ObjectStoreImpl, path: &str) -> Vec<u8> {
+        store.read(path, ..).await.unwrap().to_vec()
+    }
+
+    async fn upload_snapshot(store: &ObjectStoreImpl, path: &str, snapshot: &MetaSnapshotV2) {
+        let uploader = store.streaming_upload(path).await.unwrap();
+        snapshot.encode_to_uploader(uploader).await.unwrap();
+    }
+
+    async fn snapshot_reader(store: &ObjectStoreImpl, path: &str) -> SnapshotPayloadReader {
+        SnapshotPayloadReader::new(ObjectDataStreamReader::new(
+            store.streaming_read(path, ..).await.unwrap().into_stream(),
+        ))
+    }
+
+    fn append_checksum(mut payload: Vec<u8>) -> Vec<u8> {
+        let checksum = crate::xxhash64_checksum(&payload);
+        payload.put_u64_le(checksum);
+        payload
+    }
+
+    fn read_u64_le(buf: &mut &[u8]) -> BackupResult<u64> {
+        if buf.remaining() < size_of::<u64>() {
+            return Err(BackupError::Other(anyhow!(
+                "metadata snapshot is truncated while reading u64"
+            )));
         }
-        len => Ok(len as usize),
+        Ok(buf.get_u64_le())
+    }
+
+    fn read_len_prefix_from_slice(buf: &mut &[u8]) -> BackupResult<usize> {
+        match read_u32_le(buf)? {
+            0 => read_u64_le(buf)?.try_into().map_err(|_| {
+                BackupError::Other(anyhow!("metadata JSON payload length exceeds usize"))
+            }),
+            len => Ok(len as usize),
+        }
+    }
+
+    fn skip_with_len_prefix_from_slice(buf: &mut &[u8]) -> BackupResult<()> {
+        let len = read_len_prefix_from_slice(buf)?;
+        if buf.remaining() < len {
+            return Err(BackupError::Other(anyhow!(
+                "metadata JSON payload length {} exceeds remaining buffer {}",
+                len,
+                buf.remaining()
+            )));
+        }
+        buf.advance(len);
+        Ok(())
+    }
+
+    fn skip_metadata_list_from_slice(buf: &mut &[u8]) -> BackupResult<()> {
+        let n = read_u32_le(buf)? as usize;
+        for _ in 0..n {
+            skip_with_len_prefix_from_slice(buf)?;
+        }
+        Ok(())
+    }
+
+    fn put_with_len_prefix(buf: &mut Vec<u8>, data: &impl Serialize) {
+        let payload = serde_json::to_vec(data).unwrap();
+        if let Ok(len) = u32::try_from(payload.len()) {
+            buf.put_u32_le(len);
+        } else {
+            buf.put_u32_le(0);
+            buf.put_u64_le(payload.len() as u64);
+        }
+        buf.put_slice(&payload);
+    }
+
+    fn put_n(buf: &mut Vec<u8>, data: &[impl Serialize]) {
+        buf.put_u32_le(data.len() as u32);
+        for item in data {
+            put_with_len_prefix(buf, item);
+        }
+    }
+
+    async fn encoded_snapshot_with_invalid_trailing_metadata_after_hummock_sequences(
+        metadata: &MetadataV2,
+    ) -> Vec<u8> {
+        let store = test_store();
+        let snapshot = MetaSnapshotV2 {
+            format_version: 2,
+            id: 123,
+            metadata: MetadataV2 {
+                hummock_sequences: metadata.hummock_sequences.clone(),
+                ..Default::default()
+            },
+        };
+        upload_snapshot(&store, "snapshot", &snapshot).await;
+        let encoded = read_bytes(&store, "snapshot").await;
+        let payload = &encoded[..encoded.len() - size_of::<u64>()];
+        let mut metadata_buf = &payload[size_of::<u32>() + size_of::<u64>()..];
+
+        for _ in 0..=HUMMOCK_SEQUENCES_METADATA_SECTION_INDEX {
+            skip_metadata_list_from_slice(&mut metadata_buf).unwrap();
+        }
+
+        let mut partial_payload = payload[..payload.len() - metadata_buf.len()].to_vec();
+        partial_payload.put_u32_le(1);
+        partial_payload.put_u32_le(100);
+        partial_payload.put_slice(br#""short""#);
+        append_checksum(partial_payload)
+    }
+
+    async fn append_future_metadata_section(store: &ObjectStoreImpl, path: &str) -> Vec<u8> {
+        let mut encoded = read_bytes(store, path).await;
+        encoded.truncate(encoded.len() - size_of::<u64>());
+        put_n(&mut encoded, &["future section"]);
+        append_checksum(encoded)
+    }
+
+    #[tokio::test]
+    async fn test_len_prefix_legacy_u32_round_trip() {
+        let store = test_store();
+        let uploader = store.streaming_upload("len-prefix").await.unwrap();
+        let mut writer = SnapshotPayloadWriter::new(uploader);
+        write_with_len_prefix(&mut writer, &"hello").await.unwrap();
+        writer.finish().await.unwrap();
+
+        let encoded = read_bytes(&store, "len-prefix").await;
+        assert_ne!(u32::from_le_bytes(encoded[..4].try_into().unwrap()), 0);
+
+        let mut reader = snapshot_reader(&store, "len-prefix").await;
+        let decoded: String = read_with_len_prefix(&mut reader).await.unwrap();
+        reader.finish().await.unwrap();
+        assert_eq!(decoded, "hello");
+    }
+
+    #[tokio::test]
+    async fn test_len_prefix_extended_u64_decoding() {
+        let payload = serde_json::to_vec("hello").unwrap();
+        let mut bytes = vec![];
+        bytes.put_u32_le(0);
+        bytes.put_u64_le(payload.len() as u64);
+        bytes.put_slice(&payload);
+
+        let store = test_store();
+        upload_bytes(&store, "extended-len-prefix", append_checksum(bytes)).await;
+
+        let mut reader = snapshot_reader(&store, "extended-len-prefix").await;
+        let decoded: String = read_with_len_prefix(&mut reader).await.unwrap();
+        reader.finish().await.unwrap();
+        assert_eq!(decoded, "hello");
+    }
+
+    #[tokio::test]
+    async fn test_len_prefix_errors_on_missing_extended_u64() {
+        let store = test_store();
+        let mut bytes = vec![];
+        bytes.put_u32_le(0);
+        upload_bytes(&store, "missing-extended-len", bytes).await;
+
+        let mut reader = snapshot_reader(&store, "missing-extended-len").await;
+        assert!(read_with_len_prefix::<String>(&mut reader).await.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_len_prefix_errors_on_payload_shorter_than_declared_len() {
+        let store = test_store();
+        let mut bytes = vec![];
+        bytes.put_u32_le(100);
+        bytes.put_slice(br#""hello""#);
+        upload_bytes(&store, "short-payload", bytes).await;
+
+        let mut reader = snapshot_reader(&store, "short-payload").await;
+        assert!(read_with_len_prefix::<String>(&mut reader).await.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_snapshot_v2_encoding_decoding() {
+        let store = test_store();
+        let mut metadata = MetadataV2::default();
+        metadata.hummock_version.id = HummockVersionId::new(123);
+        let raw = MetaSnapshotV2 {
+            format_version: 2,
+            id: 123,
+            metadata,
+        };
+
+        upload_snapshot(&store, "snapshot-v2", &raw).await;
+        let decoded = MetaSnapshotV2::decode_from_stream(
+            store.streaming_read("snapshot-v2", ..).await.unwrap(),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(decoded.format_version, raw.format_version);
+        assert_eq!(decoded.id, raw.id);
+        assert_eq!(
+            decoded.metadata.hummock_version.id,
+            raw.metadata.hummock_version.id
+        );
+    }
+
+    #[tokio::test]
+    async fn test_partial_decode_hummock_sequences() {
+        let store = test_store();
+        let raw = MetaSnapshotV2 {
+            format_version: 2,
+            id: 123,
+            metadata: MetadataV2 {
+                hummock_sequences: vec![
+                    hummock_sequence::Model {
+                        name: "meta_backup".to_owned(),
+                        seq: 42,
+                    },
+                    hummock_sequence::Model {
+                        name: "sstable_object".to_owned(),
+                        seq: 100,
+                    },
+                ],
+                ..Default::default()
+            },
+        };
+
+        upload_snapshot(&store, "partial-decode", &raw).await;
+        let decoded = decode_hummock_sequences_from_stream(
+            store.streaming_read("partial-decode", ..).await.unwrap(),
+        )
+        .await
+        .unwrap();
+        assert_eq!(decoded, raw.metadata.hummock_sequences);
+    }
+
+    #[tokio::test]
+    async fn test_partial_decode_hummock_sequences_ignores_trailing_metadata() {
+        let metadata = MetadataV2 {
+            hummock_sequences: vec![hummock_sequence::Model {
+                name: "meta_backup".to_owned(),
+                seq: 42,
+            }],
+            ..Default::default()
+        };
+        let encoded =
+            encoded_snapshot_with_invalid_trailing_metadata_after_hummock_sequences(&metadata)
+                .await;
+        let store = test_store();
+        upload_bytes(&store, "invalid-trailing", encoded).await;
+
+        let decoded = decode_hummock_sequences_from_stream(
+            store.streaming_read("invalid-trailing", ..).await.unwrap(),
+        )
+        .await
+        .unwrap();
+        assert_eq!(decoded, metadata.hummock_sequences);
+
+        let full_decode_result = MetaSnapshotV2::decode_from_stream(
+            store.streaming_read("invalid-trailing", ..).await.unwrap(),
+        )
+        .await;
+        assert!(
+            full_decode_result.is_err(),
+            "full metadata decoding should not accept the intentionally invalid trailing section"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_partial_decode_hummock_sequences_ignores_appended_future_sections() {
+        let store = test_store();
+        let raw = MetaSnapshotV2 {
+            format_version: 2,
+            id: 123,
+            metadata: MetadataV2 {
+                hummock_sequences: vec![hummock_sequence::Model {
+                    name: "meta_backup".to_owned(),
+                    seq: 42,
+                }],
+                ..Default::default()
+            },
+        };
+
+        upload_snapshot(&store, "future-section-source", &raw).await;
+        let encoded = append_future_metadata_section(&store, "future-section-source").await;
+        upload_bytes(&store, "future-section", encoded).await;
+
+        let decoded = decode_hummock_sequences_from_stream(
+            store.streaming_read("future-section", ..).await.unwrap(),
+        )
+        .await
+        .unwrap();
+        assert_eq!(decoded, raw.metadata.hummock_sequences);
     }
 }

--- a/src/storage/backup/src/storage.rs
+++ b/src/storage/backup/src/storage.rs
@@ -19,7 +19,8 @@ use itertools::Itertools;
 use risingwave_common::config::ObjectStoreConfig;
 use risingwave_object_store::object::object_metrics::ObjectStoreMetrics;
 use risingwave_object_store::object::{
-    InMemObjectStore, MonitoredObjectStore, ObjectError, ObjectStoreImpl, ObjectStoreRef,
+    InMemObjectStore, MonitoredObjectStore, MonitoredStreamingReader, ObjectError, ObjectStoreImpl,
+    ObjectStoreRef,
 };
 use tokio::sync::RwLock;
 
@@ -42,8 +43,8 @@ pub trait MetaSnapshotStorage: 'static + Sync + Send {
     /// Gets a snapshot by id.
     async fn get<S: Metadata>(&self, id: MetaSnapshotId) -> BackupResult<MetaSnapshot<S>>;
 
-    /// Gets raw encoded snapshot bytes by id.
-    async fn get_raw(&self, id: MetaSnapshotId) -> BackupResult<Vec<u8>>;
+    /// Gets encoded snapshot bytes stream by id.
+    async fn get_bytes_stream(&self, id: MetaSnapshotId) -> BackupResult<MonitoredStreamingReader>;
 
     /// Gets local snapshot manifest.
     async fn manifest(&self) -> Arc<MetaSnapshotManifest>;
@@ -132,7 +133,8 @@ impl MetaSnapshotStorage for ObjectStoreMetaSnapshotStorage {
         remarks: Option<String>,
     ) -> BackupResult<()> {
         let path = self.get_snapshot_path(snapshot.id);
-        self.store.upload(&path, snapshot.encode()?.into()).await?;
+        let uploader = self.store.streaming_upload(&path).await?;
+        snapshot.encode_to_uploader(uploader).await?;
         self.update_manifest(|mut manifest: MetaSnapshotManifest| {
             manifest.manifest_id += 1;
             manifest.snapshot_metadata.push(MetaSnapshotMetadata::new(
@@ -149,13 +151,13 @@ impl MetaSnapshotStorage for ObjectStoreMetaSnapshotStorage {
     }
 
     async fn get<S: Metadata>(&self, id: MetaSnapshotId) -> BackupResult<MetaSnapshot<S>> {
-        let data = self.get_raw(id).await?;
-        MetaSnapshot::decode(&data)
+        let reader = self.get_bytes_stream(id).await?;
+        MetaSnapshot::decode_from_stream(reader).await
     }
 
-    async fn get_raw(&self, id: MetaSnapshotId) -> BackupResult<Vec<u8>> {
+    async fn get_bytes_stream(&self, id: MetaSnapshotId) -> BackupResult<MonitoredStreamingReader> {
         let path = self.get_snapshot_path(id);
-        Ok(self.store.read(&path, ..).await?.to_vec())
+        Ok(self.store.streaming_read(&path, ..).await?)
     }
 
     async fn manifest(&self) -> Arc<MetaSnapshotManifest> {
@@ -209,4 +211,67 @@ pub async fn unused() -> ObjectStoreMetaSnapshotStorage {
     )
     .await
     .unwrap()
+}
+
+#[cfg(test)]
+mod tests {
+    use risingwave_hummock_sdk::HummockVersionId;
+    use risingwave_meta_model::hummock_sequence;
+
+    use super::{MetaSnapshotStorage, unused};
+    use crate::meta_snapshot::MetaSnapshot;
+    use crate::meta_snapshot_v2::{MetadataV2, decode_hummock_sequences_from_stream};
+
+    #[tokio::test]
+    async fn test_create_v2_snapshot_with_streaming_upload() {
+        let storage = unused().await;
+        let mut metadata = MetadataV2::default();
+        metadata.hummock_version.id = HummockVersionId::new(321);
+        let snapshot = MetaSnapshot {
+            format_version: 2,
+            id: 123,
+            metadata,
+        };
+
+        storage.create(&snapshot, None).await.unwrap();
+        let decoded: MetaSnapshot<MetadataV2> = storage.get(snapshot.id).await.unwrap();
+
+        assert_eq!(snapshot.format_version, decoded.format_version);
+        assert_eq!(snapshot.id, decoded.id);
+        assert_eq!(
+            snapshot.metadata.hummock_version.id,
+            decoded.metadata.hummock_version.id
+        );
+    }
+
+    #[tokio::test]
+    async fn test_decode_hummock_sequences_with_streaming_read() {
+        let storage = unused().await;
+        let snapshot = MetaSnapshot {
+            format_version: 2,
+            id: 456,
+            metadata: MetadataV2 {
+                hummock_sequences: vec![
+                    hummock_sequence::Model {
+                        name: "meta_backup".to_owned(),
+                        seq: 42,
+                    },
+                    hummock_sequence::Model {
+                        name: "sstable_object".to_owned(),
+                        seq: 100,
+                    },
+                ],
+                ..Default::default()
+            },
+        };
+
+        storage.create(&snapshot, None).await.unwrap();
+        let decoded = decode_hummock_sequences_from_stream(
+            storage.get_bytes_stream(snapshot.id).await.unwrap(),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(decoded, snapshot.metadata.hummock_sequences);
+    }
 }


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

This PR reduces memory usage when creating and restoring meta snapshot backups.

- Stream meta snapshot backup payloads into object storage with `ObjectStreamingUploader` instead of building the whole payload in memory before upload.
- Replace raw backup payload fetches with streaming reads, including partial decoding of the `hummock_sequences` section from a byte stream.
- Add `ObjectDataStreamReader::into_bytes_stream()` so checksum verification can drain remaining bytes without reimplementing its normal `AsyncRead` behavior.
- Log the final v2 meta snapshot backup file size after the streaming writer finishes.
- Restore and update V2 snapshot/len-prefix/partial-decode tests to exercise the streaming encode/decode path.

- Closes N/A

## Checklist

- [ ] I have written necessary rustdoc comments.
- [x] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [x] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

</details>
