### PR TITLE
fix(meta): handle partial graph reset during recovery

### DIFF
--- a/src/meta/src/barrier/worker.rs
+++ b/src/meta/src/barrier/worker.rs
@@ -1246,7 +1246,17 @@ impl<C: GlobalBarrierWorkerContext> GlobalBarrierWorker<C> {
                                     unreachable!("no barrier collected event on initializing")
                                 }
                                 PartialGraphEvent::Reset(_) => {
-                                    unreachable!("no partial graph reset on initializing")
+                                    // Reset responses only carry diagnostic root errors. Recovery
+                                    // itself only needs to track the partial graphs still resetting.
+                                    let (database_id, _) =
+                                        from_partial_graph_id(partial_graph_id);
+                                    let resetting_partial_graphs = failed_databases
+                                        .get_mut(&database_id)
+                                        .expect("reset partial graph should belong to a failed database");
+                                    assert!(
+                                        resetting_partial_graphs.remove(&partial_graph_id),
+                                        "partial graph {partial_graph_id} should be resetting"
+                                    );
                                 }
                                 PartialGraphEvent::Error(worker_id) => {
                                     let (database_id, _) = from_partial_graph_id(partial_graph_id);


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

During global recovery, resetting a failed database's partial graphs broadcasts reset requests to all connected workers. A worker for another database can return a reset response while the global recovery loop is still initializing databases. This was previously treated as unreachable and panicked, potentially leaving the meta node in a crash loop.

This change accepts reset events during initialization. It verifies that the partial graph belongs to a failed database, removes the completed partial graph from that database's resetting set, and keeps the database entry even when the set becomes empty so per-database recovery can still proceed.

The reset response itself is not retained because it only carries diagnostic root errors; recovery only needs to know which partial graphs are still resetting.

## Checklist

- [x] I have written necessary rustdoc comments.
- [ ] I have added necessary unit tests and integration tests.
- [x] I have added test labels as necessary.
- [ ] I have added fuzzing tests or opened an issue to track them.
- [ ] My PR contains breaking changes.
- [ ] My PR changes performance-critical code, so I will run (micro) benchmarks and present the results.
- [ ] I have checked the Release Timeline and Currently Supported Versions to determine which release branches I need to cherry-pick this PR into.

## Testing

- `cargo fmt --all`
- `git diff --check`
- `cargo clippy --all-targets --all-features`

## Documentation

- [ ] My PR needs documentation updates.

<details>
<summary><b>Release note</b></summary>

Fix a meta-node crash loop during recovery when partial-graph resets from multiple databases overlap.

</details>
