### PR TITLE
fix(storage): support streaming upload fallback

### DIFF
--- a/src/object_store/src/object/mod.rs
+++ b/src/object_store/src/object/mod.rs
@@ -129,10 +129,6 @@ pub trait ObjectStore: Send + Sync {
     ) -> ObjectResult<ObjectMetadataIter>;
 
     fn store_media_type(&self) -> &'static str;
-
-    fn support_streaming_upload(&self) -> bool {
-        true
-    }
 }
 
 #[cfg(not(madsim))]
@@ -344,10 +340,6 @@ impl ObjectStoreImpl {
         dispatch_object_store_enum!(self, |store| store
             .inner
             .get_object_prefix(obj_id, use_new_object_prefix_strategy))
-    }
-
-    pub fn support_streaming_upload(&self) -> bool {
-        dispatch_object_store_enum!(self, |store| store.inner.support_streaming_upload())
     }
 
     pub fn media_type(&self) -> &'static str {

--- a/src/object_store/src/object/opendal_engine/opendal_object_store.rs
+++ b/src/object_store/src/object/opendal_engine/opendal_object_store.rs
@@ -29,8 +29,8 @@ use thiserror_ext::AsReport;
 
 use crate::object::object_metrics::ObjectStoreMetrics;
 use crate::object::{
-    ObjectDataStream, ObjectError, ObjectMetadata, ObjectMetadataIter, ObjectRangeBounds,
-    ObjectResult, ObjectStore, OperationType, StreamingUploader, prefix,
+    MonitoredObjectStore, ObjectDataStream, ObjectError, ObjectMetadata, ObjectMetadataIter,
+    ObjectRangeBounds, ObjectResult, ObjectStore, OperationType, StreamingUploader, prefix,
 };
 
 /// Opendal object storage.
@@ -138,7 +138,11 @@ impl ObjectStore for OpendalObjectStore {
             )))
         } else {
             Ok(OpendalStreamingUploader::Buffered(
-                OpendalBufferedStreamingUploader::new(self.op.clone(), path.to_owned()),
+                OpendalBufferedStreamingUploader::new(
+                    self.clone()
+                        .monitored(self.metrics.clone(), self.config.clone()),
+                    path.to_owned(),
+                ),
             ))
         }
     }
@@ -458,15 +462,15 @@ impl StreamingUploader for OpendalNativeStreamingUploader {
 }
 
 pub struct OpendalBufferedStreamingUploader {
-    op: Operator,
+    store: MonitoredObjectStore<OpendalObjectStore>,
     path: String,
     buf: BytesMut,
 }
 
 impl OpendalBufferedStreamingUploader {
-    fn new(op: Operator, path: String) -> Self {
+    fn new(store: MonitoredObjectStore<OpendalObjectStore>, path: String) -> Self {
         Self {
-            op,
+            store,
             path,
             buf: BytesMut::new(),
         }
@@ -480,12 +484,7 @@ impl StreamingUploader for OpendalBufferedStreamingUploader {
     }
 
     async fn finish(self) -> ObjectResult<()> {
-        if self.buf.is_empty() {
-            return Err(ObjectError::internal("upload empty object"));
-        }
-
-        self.op.write(&self.path, self.buf.freeze()).await?;
-        Ok(())
+        self.store.upload(&self.path, self.buf.freeze()).await
     }
 
     fn get_memory_usage(&self) -> u64 {
@@ -578,8 +577,12 @@ mod tests {
     #[tokio::test]
     async fn test_buffered_streaming_upload() {
         let store = OpendalObjectStore::test_new_memory_engine().unwrap();
-        let mut uploader =
-            OpendalBufferedStreamingUploader::new(store.op.clone(), "/abc".to_owned());
+        let mut uploader = OpendalBufferedStreamingUploader::new(
+            store
+                .clone()
+                .monitored(store.metrics.clone(), store.config.clone()),
+            "/abc".to_owned(),
+        );
 
         uploader.write_bytes(Bytes::from("123")).await.unwrap();
         assert_eq!(uploader.get_memory_usage(), 3);
@@ -594,7 +597,12 @@ mod tests {
     #[tokio::test]
     async fn test_empty_buffered_streaming_upload() {
         let store = OpendalObjectStore::test_new_memory_engine().unwrap();
-        let uploader = OpendalBufferedStreamingUploader::new(store.op.clone(), "/abc".to_owned());
+        let uploader = OpendalBufferedStreamingUploader::new(
+            store
+                .clone()
+                .monitored(store.metrics.clone(), store.config.clone()),
+            "/abc".to_owned(),
+        );
 
         uploader.finish().await.unwrap_err();
     }

--- a/src/object_store/src/object/opendal_engine/opendal_object_store.rs
+++ b/src/object_store/src/object/opendal_engine/opendal_object_store.rs
@@ -16,7 +16,7 @@ use std::ops::Range;
 use std::sync::Arc;
 use std::time::Duration;
 
-use bytes::Bytes;
+use bytes::{Bytes, BytesMut};
 use fail::fail_point;
 use futures::{StreamExt, stream};
 use opendal::layers::{RetryLayer, TimeoutLayer};
@@ -125,14 +125,22 @@ impl ObjectStore for OpendalObjectStore {
     }
 
     async fn streaming_upload(&self, path: &str) -> ObjectResult<Self::StreamingUploader> {
-        Ok(OpendalStreamingUploader::new(
-            self.op.clone(),
-            path.to_owned(),
-            self.config.clone(),
-            self.metrics.clone(),
-            self.store_media_type(),
-        )
-        .await?)
+        if self.op.info().native_capability().write_can_multi {
+            Ok(OpendalStreamingUploader::Native(Box::new(
+                OpendalNativeStreamingUploader::new(
+                    self.op.clone(),
+                    path.to_owned(),
+                    self.config.clone(),
+                    self.metrics.clone(),
+                    self.store_media_type(),
+                )
+                .await?,
+            )))
+        } else {
+            Ok(OpendalStreamingUploader::Buffered(
+                OpendalBufferedStreamingUploader::new(self.op.clone(), path.to_owned()),
+            ))
+        }
     }
 
     async fn read(&self, path: &str, range: impl ObjectRangeBounds) -> ObjectResult<Bytes> {
@@ -289,10 +297,6 @@ impl ObjectStore for OpendalObjectStore {
     fn store_media_type(&self) -> &'static str {
         self.media_type.as_str()
     }
-
-    fn support_streaming_upload(&self) -> bool {
-        self.op.info().native_capability().write_can_multi
-    }
 }
 
 impl OpendalObjectStore {
@@ -336,8 +340,13 @@ impl Execute for OpendalStreamingUploaderExecute {
     }
 }
 
+pub enum OpendalStreamingUploader {
+    Native(Box<OpendalNativeStreamingUploader>),
+    Buffered(OpendalBufferedStreamingUploader),
+}
+
 /// Store multiple parts in a map, and concatenate them on finish.
-pub struct OpendalStreamingUploader {
+pub struct OpendalNativeStreamingUploader {
     writer: Writer,
     /// Buffer for data. It will store at least `UPLOAD_BUFFER_SIZE` bytes of data before wrapping itself
     /// into a stream and upload to object store as a part.
@@ -352,7 +361,7 @@ pub struct OpendalStreamingUploader {
     upload_part_size: usize,
 }
 
-impl OpendalStreamingUploader {
+impl OpendalNativeStreamingUploader {
     pub async fn new(
         op: Operator,
         path: String,
@@ -408,7 +417,7 @@ impl OpendalStreamingUploader {
     }
 }
 
-impl StreamingUploader for OpendalStreamingUploader {
+impl StreamingUploader for OpendalNativeStreamingUploader {
     async fn write_bytes(&mut self, data: Bytes) -> ObjectResult<()> {
         assert!(self.is_valid);
         self.not_uploaded_len += data.len();
@@ -445,6 +454,65 @@ impl StreamingUploader for OpendalStreamingUploader {
     // Not absolutely accurate. Some bytes may be in the infight request.
     fn get_memory_usage(&self) -> u64 {
         self.not_uploaded_len as u64
+    }
+}
+
+pub struct OpendalBufferedStreamingUploader {
+    op: Operator,
+    path: String,
+    buf: BytesMut,
+}
+
+impl OpendalBufferedStreamingUploader {
+    fn new(op: Operator, path: String) -> Self {
+        Self {
+            op,
+            path,
+            buf: BytesMut::new(),
+        }
+    }
+}
+
+impl StreamingUploader for OpendalBufferedStreamingUploader {
+    async fn write_bytes(&mut self, data: Bytes) -> ObjectResult<()> {
+        self.buf.extend_from_slice(&data);
+        Ok(())
+    }
+
+    async fn finish(self) -> ObjectResult<()> {
+        if self.buf.is_empty() {
+            return Err(ObjectError::internal("upload empty object"));
+        }
+
+        self.op.write(&self.path, self.buf.freeze()).await?;
+        Ok(())
+    }
+
+    fn get_memory_usage(&self) -> u64 {
+        self.buf.len() as u64
+    }
+}
+
+impl StreamingUploader for OpendalStreamingUploader {
+    async fn write_bytes(&mut self, data: Bytes) -> ObjectResult<()> {
+        match self {
+            Self::Native(uploader) => uploader.write_bytes(data).await,
+            Self::Buffered(uploader) => uploader.write_bytes(data).await,
+        }
+    }
+
+    async fn finish(self) -> ObjectResult<()> {
+        match self {
+            Self::Native(uploader) => (*uploader).finish().await,
+            Self::Buffered(uploader) => uploader.finish().await,
+        }
+    }
+
+    fn get_memory_usage(&self) -> u64 {
+        match self {
+            Self::Native(uploader) => uploader.get_memory_usage(),
+            Self::Buffered(uploader) => uploader.get_memory_usage(),
+        }
     }
 }
 
@@ -505,6 +573,30 @@ mod tests {
         let metadata = obj_store.metadata("/abc").await.unwrap();
         assert_eq!(metadata.total_size, 6);
         obj_store.delete(&path).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_buffered_streaming_upload() {
+        let store = OpendalObjectStore::test_new_memory_engine().unwrap();
+        let mut uploader =
+            OpendalBufferedStreamingUploader::new(store.op.clone(), "/abc".to_owned());
+
+        uploader.write_bytes(Bytes::from("123")).await.unwrap();
+        assert_eq!(uploader.get_memory_usage(), 3);
+        uploader.write_bytes(Bytes::from("456")).await.unwrap();
+        assert_eq!(uploader.get_memory_usage(), 6);
+        uploader.finish().await.unwrap();
+
+        let read_obj = store.read("/abc", ..).await.unwrap();
+        assert_eq!(read_obj, Bytes::from("123456"));
+    }
+
+    #[tokio::test]
+    async fn test_empty_buffered_streaming_upload() {
+        let store = OpendalObjectStore::test_new_memory_engine().unwrap();
+        let uploader = OpendalBufferedStreamingUploader::new(store.op.clone(), "/abc".to_owned());
+
+        uploader.finish().await.unwrap_err();
     }
 
     #[tokio::test]

--- a/src/storage/src/hummock/compactor/fast_compactor_runner.rs
+++ b/src/storage/src/hummock/compactor/fast_compactor_runner.rs
@@ -52,7 +52,7 @@ use crate::hummock::value::HummockValue;
 use crate::hummock::{
     Block, BlockBuilder, BlockHolder, BlockIterator, BlockMeta, BlockedXor16FilterBuilder,
     CachePolicy, CompressionAlgorithm, FilterBuilder, GetObjectId, HummockResult,
-    SstableBuilderOptions, TableHolder, UnifiedSstableWriterFactory,
+    SstableBuilderOptions, StreamingSstableWriterFactory, TableHolder,
 };
 use crate::monitor::{CompactorMetrics, StoreLocalStatistic};
 
@@ -360,7 +360,7 @@ pub struct CompactorRunner<
     left: Box<ConcatSstableIterator>,
     right: Box<ConcatSstableIterator>,
     task_id: u64,
-    executor: CompactTaskExecutor<RemoteBuilderFactory<UnifiedSstableWriterFactory, B>, C>,
+    executor: CompactTaskExecutor<RemoteBuilderFactory<StreamingSstableWriterFactory, B>, C>,
     compression_algorithm: CompressionAlgorithm,
     metrics: Arc<CompactorMetrics>,
 }
@@ -401,7 +401,7 @@ impl<B: FilterBuilder, C: CompactionFilter> CompactorRunner<B, C> {
             table_schemas: Default::default(),
             disable_drop_column_optimization: false,
         };
-        let factory = UnifiedSstableWriterFactory::new(context.sstable_store.clone());
+        let factory = StreamingSstableWriterFactory::new(context.sstable_store.clone());
 
         let builder_factory = RemoteBuilderFactory::<_, B> {
             object_id_getter,

--- a/src/storage/src/hummock/compactor/mod.rs
+++ b/src/storage/src/hummock/compactor/mod.rs
@@ -102,7 +102,7 @@ use crate::hummock::compactor::iceberg_compaction::TaskKey;
 use crate::hummock::iterator::{Forward, HummockIterator};
 use crate::hummock::{
     BlockedXor8FilterBuilder, BlockedXor16FilterBuilder, FilterBuilder, NoneFilterBuilder,
-    SharedComapctorObjectIdManager, SstableWriterFactory, UnifiedSstableWriterFactory,
+    SharedComapctorObjectIdManager, SstableWriterFactory, StreamingSstableWriterFactory,
     validate_ssts,
 };
 use crate::monitor::CompactorMetrics;
@@ -213,7 +213,7 @@ impl Compactor {
         };
 
         let (split_table_outputs, table_stats_map) = {
-            let factory = UnifiedSstableWriterFactory::new(self.context.sstable_store.clone());
+            let factory = StreamingSstableWriterFactory::new(self.context.sstable_store.clone());
             match (
                 self.task_config.sstable_filter_type,
                 self.task_config.sstable_filter_layout,

--- a/src/storage/src/hummock/sstable/writer.rs
+++ b/src/storage/src/hummock/sstable/writer.rs
@@ -277,11 +277,6 @@ impl StreamingUploadWriter {
     }
 }
 
-pub enum UnifiedSstableWriter {
-    StreamingSstableWriter(StreamingUploadWriter),
-    BatchSstableWriter(BatchUploadWriter),
-}
-
 #[async_trait::async_trait]
 impl SstableWriter for StreamingUploadWriter {
     type Output = JoinHandle<HummockResult<()>>;
@@ -366,48 +361,6 @@ impl StreamingSstableWriterFactory {
         StreamingSstableWriterFactory { sstable_store }
     }
 }
-pub struct UnifiedSstableWriterFactory {
-    sstable_store: SstableStoreRef,
-}
-
-impl UnifiedSstableWriterFactory {
-    pub fn new(sstable_store: SstableStoreRef) -> Self {
-        UnifiedSstableWriterFactory { sstable_store }
-    }
-}
-
-#[async_trait::async_trait]
-impl SstableWriterFactory for UnifiedSstableWriterFactory {
-    type Writer = UnifiedSstableWriter;
-
-    async fn create_sst_writer(
-        &mut self,
-        object_id: impl Into<HummockSstableObjectId> + Send,
-        options: SstableWriterOptions,
-    ) -> HummockResult<Self::Writer> {
-        let object_id = object_id.into();
-        if self.sstable_store.store().support_streaming_upload() {
-            let path = self.sstable_store.get_sst_data_path(object_id);
-            let uploader = self.sstable_store.create_streaming_uploader(&path).await?;
-            let streaming_uploader_writer = StreamingUploadWriter::new(
-                object_id,
-                self.sstable_store.clone(),
-                uploader,
-                options,
-            );
-
-            Ok(UnifiedSstableWriter::StreamingSstableWriter(
-                streaming_uploader_writer,
-            ))
-        } else {
-            let batch_uploader_writer =
-                BatchUploadWriter::new(object_id, self.sstable_store.clone(), options);
-            Ok(UnifiedSstableWriter::BatchSstableWriter(
-                batch_uploader_writer,
-            ))
-        }
-    }
-}
 
 #[async_trait::async_trait]
 impl SstableWriterFactory for StreamingSstableWriterFactory {
@@ -427,47 +380,6 @@ impl SstableWriterFactory for StreamingSstableWriterFactory {
             uploader,
             options,
         ))
-    }
-}
-
-#[async_trait::async_trait]
-impl SstableWriter for UnifiedSstableWriter {
-    type Output = JoinHandle<HummockResult<()>>;
-
-    async fn write_block(&mut self, block_data: &[u8], meta: &BlockMeta) -> HummockResult<()> {
-        match self {
-            UnifiedSstableWriter::StreamingSstableWriter(stream) => {
-                stream.write_block(block_data, meta).await
-            }
-            UnifiedSstableWriter::BatchSstableWriter(batch) => {
-                batch.write_block(block_data, meta).await
-            }
-        }
-    }
-
-    async fn write_block_bytes(&mut self, block: Bytes, meta: &BlockMeta) -> HummockResult<()> {
-        match self {
-            UnifiedSstableWriter::StreamingSstableWriter(stream) => {
-                stream.write_block_bytes(block, meta).await
-            }
-            UnifiedSstableWriter::BatchSstableWriter(batch) => {
-                batch.write_block_bytes(block, meta).await
-            }
-        }
-    }
-
-    async fn finish(self, meta: SstableMeta) -> HummockResult<UploadJoinHandle> {
-        match self {
-            UnifiedSstableWriter::StreamingSstableWriter(stream) => stream.finish(meta).await,
-            UnifiedSstableWriter::BatchSstableWriter(batch) => batch.finish(meta).await,
-        }
-    }
-
-    fn data_len(&self) -> usize {
-        match self {
-            UnifiedSstableWriter::StreamingSstableWriter(stream) => stream.data_len(),
-            UnifiedSstableWriter::BatchSstableWriter(batch) => batch.data_len(),
-        }
     }
 }
 


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

This PR makes `ObjectStore::streaming_upload()` usable unconditionally for Opendal-backed object stores, including backends that do not support native multipart writes.

- Split the Opendal streaming uploader into native and buffered variants.
- Keep using the native OpenDAL writer when `write_can_multi` is available.
- Add a buffered fallback that accumulates chunks and writes the full object with normal `op.write()` on `finish()`.
- Remove the `support_streaming_upload()` object-store API and the SST writer-side fallback branch, so callers do not need to duplicate object-store capability checks.
- Switch compaction paths to use `StreamingSstableWriterFactory` directly after removing the now-unused unified writer wrapper.

This is a follow-up to #26267 and addresses the metadata-backup review concern that unconditional `streaming_upload()` could regress on non-multipart Opendal backends.

- Closes N/A

## Checklist

- [ ] I have written necessary rustdoc comments.
- [x] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [x] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

No user-facing release note.

</details>
