### PR TITLE
fix(meta): don't hold source worker split lock across enumerator on_tick

### DIFF
--- a/src/meta/src/stream/source_manager/worker.rs
+++ b/src/meta/src/stream/source_manager/worker.rs
@@ -352,14 +352,19 @@ impl ConnectorSourceWorker {
 
         source_is_up(1);
         self.fail_cnt = 0;
-        let mut current_splits = self.current_splits.lock().await;
-        current_splits.splits.replace(
-            splits
-                .into_iter()
-                .map(|split| (split.id(), split))
-                .collect(),
-        );
-        // Call enumerator's `on_tick` method for monitoring tasks
+        {
+            let mut current_splits = self.current_splits.lock().await;
+            current_splits.splits.replace(
+                splits
+                    .into_iter()
+                    .map(|split| (split.id(), split))
+                    .collect(),
+            );
+        }
+
+        // Call enumerator's `on_tick` method for monitoring tasks.
+        // `on_tick` may do unbounded network I/O, so it must not run under
+        // `current_splits` (#26275).
         if let Err(e) = self.enumerator.on_tick().await {
             tracing::error!(
                 "Failed to execute enumerator `on_tick` for source {}: {}",


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

`ConnectorSourceWorker::tick()` held the `current_splits` mutex guard from the split replacement all the way through the trailing `enumerator.on_tick().await` call. `on_tick` is a monitoring-only hook that, for CDC sources, opens a **fresh connection to the upstream database every tick with no connect timeout anywhere in the path**. When the upstream host is unreachable, that connect blocks for the full OS TCP connect timeout (~127s) — and the worker keeps `current_splits` locked the whole time.

That lock is on the hot path of split assignment:

- `discovered_splits()` reads `current_splits`.
- `reassign_splits()` awaits `discovered_splits()` **while holding the global `SourceManager::core` lock**.
- The barrier completion task's `apply_source_change` then needs `core` too.

So a **single unreachable CDC source — even one that is completely unused — stalls barrier completion and epoch commit cluster-wide**, dragging every DDL out to minutes per round.

This PR is the root fix of that chain. `on_tick` is monitoring-only and does not touch `current_splits`, so scoping the guard to just the split replacement changes no behavior other than not holding the lock across the await:

```rust
{
    let mut current_splits = self.current_splits.lock().await;
    current_splits.splits.replace(/* unchanged */);
}

// on_tick now runs lock-free
if let Err(e) = self.enumerator.on_tick().await { ... }
```

**Affected versions:** the trigger has existed since v2.7 (postgres/mysql CDC monitors) and v2.8.3 (sqlserver CDC monitor backport). This fix is worth backporting to `release-2.8` and `release-3.0`.

**Part of #26275.** This is only the lock-scoping root fix; follow-ups remain (periodic/force-tick connect timeouts, emptiness gating so no-source jobs skip the monitor, and structural decoupling of monitoring from split discovery).

- Part of #26275

## Checklist

- [x] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [x] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) --> (candidates: `release-2.8`, `release-3.0`)


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

Fixed an issue where a single unreachable CDC source could stall barrier completion and epoch commits cluster-wide, drastically slowing all DDL.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
