### PR TITLE
test(sim): actually wait for recovery in kill-and-recover test helpers

### DIFF
--- a/src/tests/simulation/tests/integration_tests/backfill_tests.rs
+++ b/src/tests/simulation/tests/integration_tests/backfill_tests.rs
@@ -271,7 +271,7 @@ async fn test_arrangement_backfill_progress() -> Result<()> {
     );
 
     // Trigger recovery and test it again.
-    kill_cn_and_wait_recover(&cluster).await;
+    kill_cn_and_wait_recover(&mut cluster).await;
     let prev_progress = progress;
     let progress = session
         .run("SELECT progress FROM rw_catalog.rw_ddl_progress")

--- a/src/tests/simulation/tests/integration_tests/recovery/background_ddl.rs
+++ b/src/tests/simulation/tests/integration_tests/recovery/background_ddl.rs
@@ -364,7 +364,7 @@ async fn test_background_mv_barrier_recovery() -> Result<()> {
 
     // If the CN is killed before first barrier pass for the MV, the MV will be dropped.
     // This is because it's table fragments will NOT be committed until first barrier pass.
-    kill_cn_and_wait_recover(&cluster).await;
+    kill_cn_and_wait_recover(&mut cluster).await;
 
     // Send some upstream updates.
     session
@@ -372,7 +372,7 @@ async fn test_background_mv_barrier_recovery() -> Result<()> {
         .await?;
     session.flush().await?;
 
-    kill_random_and_wait_recover(&cluster).await;
+    kill_random_and_wait_recover(&mut cluster).await;
 
     // Now just wait for it to complete.
     session.run(WAIT).await?;
@@ -421,7 +421,7 @@ async fn test_background_join_mv_recovery() -> Result<()> {
         .await?;
     sleep(Duration::from_secs(2)).await;
 
-    kill_cn_and_meta_and_wait_recover(&cluster).await;
+    kill_cn_and_meta_and_wait_recover(&mut cluster).await;
 
     // Now just wait for it to complete.
     session.run(WAIT).await?;
@@ -461,7 +461,7 @@ async fn test_ddl_cancel() -> Result<()> {
     create_mv(&mut session).await?;
 
     // Test cancel after kill cn
-    kill_cn_and_wait_recover(&cluster).await;
+    kill_cn_and_wait_recover(&mut cluster).await;
     let ids = cancel_stream_jobs(&mut session).await?;
     assert_eq!(ids.len(), 1);
     tracing::info!("tested cancel background_ddl after recovery");
@@ -471,7 +471,7 @@ async fn test_ddl_cancel() -> Result<()> {
     create_mv(&mut session).await?;
 
     // Test cancel after kill random nodes
-    kill_random_and_wait_recover(&cluster).await;
+    kill_random_and_wait_recover(&mut cluster).await;
     let ids = cancel_stream_jobs(&mut session).await?;
     assert_eq!(ids.len(), 1);
     tracing::info!("tested cancel background_ddl after recovery from random node kill");
@@ -696,7 +696,7 @@ async fn test_high_barrier_latency_cancel(config: Configuration) -> Result<()> {
         });
 
         sleep(Duration::from_millis(500)).await;
-        kill_cn_and_wait_recover(&cluster).await;
+        kill_cn_and_wait_recover(&mut cluster).await;
         tracing::info!("restarted cn: cancel should take effect");
 
         handle.await.unwrap();
@@ -755,7 +755,7 @@ async fn test_foreground_ddl_no_recovery() -> Result<()> {
     sleep(Duration::from_secs(2)).await;
 
     // Kill CN should stop the job
-    kill_cn_and_wait_recover(&cluster).await;
+    kill_cn_and_wait_recover(&mut cluster).await;
 
     // Create MV should succeed, since the previous foreground job should be cancelled.
     session.run(SET_RATE_LIMIT_2).await?;
@@ -848,7 +848,7 @@ async fn test_background_agg_mv_recovery() -> Result<()> {
         .await?;
     sleep(Duration::from_secs(2)).await;
 
-    kill_cn_and_meta_and_wait_recover(&cluster).await;
+    kill_cn_and_meta_and_wait_recover(&mut cluster).await;
 
     // Now just wait for it to complete.
     session.run(WAIT).await?;
@@ -884,7 +884,7 @@ async fn test_background_index_creation() -> Result<()> {
     session.run("CREATE INDEX idx_v1 ON t(v1);").await?;
 
     // Kill CN and recover to test background index recovery
-    kill_cn_and_wait_recover(&cluster).await;
+    kill_cn_and_wait_recover(&mut cluster).await;
 
     // Add more data
     session

--- a/src/tests/simulation/tests/integration_tests/recovery/batch_refresh.rs
+++ b/src/tests/simulation/tests/integration_tests/recovery/batch_refresh.rs
@@ -78,7 +78,7 @@ async fn test_batch_refresh_recovery() -> Result<()> {
 
     // Step 4: Trigger recovery and verify progress survives.
     eprintln!("=== Step 4: triggering recovery during backfill...");
-    kill_cn_and_wait_recover(&cluster).await;
+    kill_cn_and_wait_recover(&mut cluster).await;
     eprintln!("=== Step 4: recovery done");
 
     let progress_after = session
@@ -127,7 +127,7 @@ async fn test_batch_refresh_recovery() -> Result<()> {
 
     // Step 9: Trigger another recovery while the batch refresh job is idle.
     eprintln!("=== Step 9: triggering recovery while idle...");
-    kill_cn_and_wait_recover(&cluster).await;
+    kill_cn_and_wait_recover(&mut cluster).await;
     eprintln!("=== Step 9: recovery done");
 
     // Step 10: Verify that the MV is still queryable after idle recovery.
@@ -197,7 +197,7 @@ async fn test_batch_refresh_periodic_update() -> Result<()> {
     wait_for_batch_mv_count(&mut session, "100", "first periodic refresh").await?;
 
     // ── Recover while job is idle / between refresh cycles. ──────────────────
-    kill_cn_and_wait_recover(&cluster).await;
+    kill_cn_and_wait_recover(&mut cluster).await;
 
     // ── Second cycle: changes after recovery must still be picked up. ────────
     session
@@ -207,7 +207,7 @@ async fn test_batch_refresh_periodic_update() -> Result<()> {
     wait_for_batch_mv_count(&mut session, "200", "periodic refresh after CN recovery").await?;
 
     // ── Recover using meta + CN together, then run another cycle. ────────────
-    kill_cn_and_meta_and_wait_recover(&cluster).await;
+    kill_cn_and_meta_and_wait_recover(&mut cluster).await;
 
     session.run("DELETE FROM t WHERE v1 <= 50;").await?;
     session.flush().await?;

--- a/src/tests/simulation/tests/integration_tests/utils.rs
+++ b/src/tests/simulation/tests/integration_tests/utils.rs
@@ -20,27 +20,31 @@ use risingwave_simulation::cluster::{Cluster, KillOpts, Session};
 use serde::Deserialize;
 use tokio::time::{Instant, sleep};
 
-pub(crate) async fn kill_cn_and_wait_recover(cluster: &Cluster) {
+pub(crate) async fn kill_cn_and_wait_recover(cluster: &mut Cluster) {
     cluster
         .kill_nodes(["compute-1", "compute-2", "compute-3"], 0)
         .await;
+    // Keep the sleep: probing too early can read a stale RUNNING before the kill lands.
     sleep(Duration::from_secs(10)).await;
+    cluster.wait_for_recovery().await.unwrap();
 }
 
-pub(crate) async fn kill_cn_and_meta_and_wait_recover(cluster: &Cluster) {
+pub(crate) async fn kill_cn_and_meta_and_wait_recover(cluster: &mut Cluster) {
     cluster
         .kill_nodes(["compute-1", "compute-2", "compute-3", "meta-1"], 0)
         .await;
     sleep(Duration::from_secs(10)).await;
+    cluster.wait_for_recovery().await.unwrap();
 }
 
-pub(crate) async fn kill_random_and_wait_recover(cluster: &Cluster) {
+pub(crate) async fn kill_random_and_wait_recover(cluster: &mut Cluster) {
     // Kill it again
     for _ in 0..3 {
         sleep(Duration::from_secs(2)).await;
         cluster.kill_node(&KillOpts::ALL_FAST).await;
     }
     sleep(Duration::from_secs(10)).await;
+    cluster.wait_for_recovery().await.unwrap();
 }
 
 pub(crate) async fn kill_cn_meta_and_wait_full_recovery(cluster: &mut Cluster) {


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

The `kill_cn_and_wait_recover` / `kill_cn_and_meta_and_wait_recover` / `kill_random_and_wait_recover` helpers in the simulation integration tests only sleep a fixed 10 s after killing nodes. Under some madsim schedules recovery takes longer than that, and the next batch statement fails with:

```
Scheduler error: Streaming vnode mapping not found for fragment 2
```

(observed in `recovery::batch_refresh::test_batch_refresh_periodic_update`).

Evidence that this is a pre-existing, schedule-dependent flake: the outcome is deterministic per binary+seed — it fails at seed 3 on PR #26277's binary (Buildkite build 98233) and at seed 47 on unmodified main (`2bdeee0adb`), and each binary passes the other's seed. The error signature is already in the sim framework's own retry allowlist (`src/tests/simulation/src/slt.rs`) and matches closed flaky issue #23393 — the SLT path retries it, but raw `session.run()` calls in integration tests do not.

Fix: after the existing sleep, poll `Cluster::wait_for_recovery()` (`rw_recovery_status() == 'RUNNING'`, 200 s cap) — the same pattern the log_store recovery tests already use. Helper signatures change `&Cluster` → `&mut Cluster`; all call sites updated (`backfill_tests.rs`, `recovery/background_ddl.rs`, `recovery/batch_refresh.rs`).

Validation (deterministic simulation, provenance-verified builds):
- On `2bdeee0adb`: seed 47 fails before this change, passes after.
- On this branch (rebased on latest main): seeds 1-10, 3, and 47 all pass.

## Checklist

- [ ] I have written necessary rustdoc comments.
- [x] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->

## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
