### PR TITLE
fix: avoid panic on invalid index lookup selection

### DIFF
--- a/e2e_test/ddl/index.slt
+++ b/e2e_test/ddl/index.slt
@@ -150,3 +150,17 @@ select * from idx;
 
 statement ok
 drop table t;
+
+statement ok
+create materialized view issue_26286_mc as select 1 as id, 'a' as val, 'x' as tag;
+
+statement ok
+create index issue_26286_mc_idx on issue_26286_mc (id) include (val);
+
+query I
+select 1 from issue_26286_mc where id = 1 and tag = 'x';
+----
+1
+
+statement ok
+drop materialized view issue_26286_mc;

--- a/src/frontend/planner_test/tests/testdata/input/index_selection.yaml
+++ b/src/frontend/planner_test/tests/testdata/input/index_selection.yaml
@@ -351,6 +351,14 @@
   expected_outputs:
   - batch_plan
   - batch_local_plan
+- name: covering index with residual predicate outside the index
+  sql: |
+    create materialized view mc as select 1 as id, 'a' as val, 'x' as tag;
+    create index mc_idx on mc (id) include (val);
+    select 1 from mc where id = 1 and tag = 'x';
+  expected_outputs:
+  - batch_plan
+  - batch_local_plan
 - name: create index to include all columns by default
   sql: |
     create table t1 (a int, b numeric, c bigint);

--- a/src/frontend/planner_test/tests/testdata/output/index_selection.yaml
+++ b/src/frontend/planner_test/tests/testdata/output/index_selection.yaml
@@ -651,6 +651,21 @@
     └─BatchLookupJoin { type: Inner, predicate: d.t1._row_id IS NOT DISTINCT FROM t1._row_id AND (t1.d > 9:Int32), output: [], lookup table: t1 }
       └─BatchExchange { order: [], dist: Single }
         └─BatchScan { table: d, columns: [d.t1._row_id], scan_ranges: [d.a = Int32(1)], distribution: SomeShard }
+- name: covering index with residual predicate outside the index
+  sql: |
+    create materialized view mc as select 1 as id, 'a' as val, 'x' as tag;
+    create index mc_idx on mc (id) include (val);
+    select 1 from mc where id = 1 and tag = 'x';
+  batch_plan: |-
+    BatchExchange { order: [], dist: Single }
+    └─BatchProject { exprs: [1:Int32] }
+      └─BatchFilter { predicate: (mc.id = 1:Int32) AND (mc.tag = 'x':Varchar) }
+        └─BatchScan { table: mc, columns: [mc.id, mc.tag], distribution: Single }
+  batch_local_plan: |-
+    BatchExchange { order: [], dist: Single }
+    └─BatchProject { exprs: [1:Int32] }
+      └─BatchFilter { predicate: (mc.id = 1:Int32) AND (mc.tag = 'x':Varchar) }
+        └─BatchScan { table: mc, columns: [mc.id, mc.tag], distribution: SomeShard }
 - name: create index to include all columns by default
   sql: |
     create table t1 (a int, b numeric, c bigint);

--- a/src/frontend/src/optimizer/plan_node/logical_join.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_join.rs
@@ -1449,7 +1449,7 @@ impl LogicalJoin {
         }
     }
 
-    pub fn index_lookup_join_to_batch_lookup_join(&self) -> Result<BatchPlanRef> {
+    pub fn index_lookup_join_to_batch_lookup_join(&self) -> Result<Option<BatchPlanRef>> {
         let predicate = EqJoinPredicate::create(
             self.left().schema().len(),
             self.right().schema().len(),
@@ -1461,10 +1461,7 @@ impl LogicalJoin {
             .core
             .clone_with_inputs(self.core.left.to_batch()?, self.core.right.to_batch()?);
 
-        Ok(self
-            .to_batch_lookup_join(predicate, join)?
-            .expect("Fail to convert to lookup join")
-            .into())
+        Ok(self.to_batch_lookup_join(predicate, join)?.map(Into::into))
     }
 
     fn to_stream_asof_join(

--- a/src/frontend/src/optimizer/plan_node/logical_scan.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_scan.rs
@@ -598,16 +598,19 @@ impl ToBatch for LogicalScan {
                     return required_order.enforce_if_not_satisfies(scan.to_batch()?);
                 } else if let Some(join) = applied.as_logical_join() {
                     // index lookup join
-                    return required_order
-                        .enforce_if_not_satisfies(join.index_lookup_join_to_batch_lookup_join()?);
+                    if let Some(lookup_join) = join.index_lookup_join_to_batch_lookup_join()? {
+                        return required_order.enforce_if_not_satisfies(lookup_join);
+                    }
                 } else {
                     unreachable!();
                 }
-            } else {
-                // Try to make use of index if it satisfies the required order
-                if let Some(plan_ref) = new.use_index_scan_if_order_is_satisfied(required_order) {
-                    return plan_ref;
-                }
+            }
+
+            // Try to make use of index if it satisfies the required order.
+            // Also reach here when a cost-selected non-covering index candidate cannot be
+            // converted to a physical lookup join.
+            if let Some(plan_ref) = new.use_index_scan_if_order_is_satisfied(required_order) {
+                return plan_ref;
             }
         }
         new.to_batch_inner_with_required(required_order)


### PR DESCRIPTION
## What

Fixes #26286.

Avoid forcing a cost-selected non-covering index candidate into a physical lookup join when the lookup conversion is not legal. Instead, the index lookup conversion now returns `None`, and `LogicalScan` falls back to the normal scan path.

> ERROR:  Panicked when handling the request: Fail to convert to lookup join

## Root cause

For `CREATE INDEX ... INCLUDE (...)`, index selection can choose a non-covering index lookup path because the key predicate makes the index access look cheap. In the reported MV case, predicate pushdown leaves a logical index lookup join that cannot satisfy the physical lookup join requirements for the primary table. The conversion path used `expect("Fail to convert to lookup join")`, causing the frontend panic and dropped session.

## Tests

- Reproduced with Docker image `ghcr.io/risingwavelabs/risingwave:latest` (`3.0.1`, `7f2a49c16fe3bd16df25c2c1ff31fd02497ddb7e`): the query panicked with `Fail to convert to lookup join`.
- `cargo fmt`
- `./risedev run-planner-test index_selection`
- `./risedev d`
- `./risedev slt ./e2e_test/ddl/index.slt`
- Direct patched-cluster SQL repro returned one row.
- `git diff --check`

## Notes

The new planner regression shows this query falls back to scanning the primary MV instead of using an invalid lookup join. The e2e regression asserts the user-visible result for the original repro.