### PR TITLE
feat: add table change log latency metrics

### DIFF
--- a/src/meta/src/hummock/manager/versioning.rs
+++ b/src/meta/src/hummock/manager/versioning.rs
@@ -388,6 +388,7 @@ impl HummockManager {
         exclude_empty: bool,
         limit: Option<u32>,
     ) -> TableChangeLogs {
+        let _timer = self.metrics.table_change_log_get_latency.start_timer();
         self.on_current_version_and_table_change_log(|_, table_change_logs| {
             table_change_logs
                 .iter()

--- a/src/meta/src/rpc/metrics.rs
+++ b/src/meta/src/rpc/metrics.rs
@@ -170,6 +170,8 @@ pub struct MetaMetrics {
     pub table_change_log_object_size: IntGaugeVec,
     /// Min epoch currently retained in table change log.
     pub table_change_log_min_epoch: IntGaugeVec,
+    /// Latency of serving table change log requests.
+    pub table_change_log_get_latency: Histogram,
     /// The number of hummock version delta log.
     pub delta_log_count: IntGauge,
     /// latency of version checkpoint
@@ -565,6 +567,14 @@ impl MetaMetrics {
             registry
         )
         .unwrap();
+
+        let opts = histogram_opts!(
+            "storage_table_change_log_get_latency",
+            "latency of serving table change log requests",
+            exponential_buckets(0.001, 5.0, 7).unwrap()
+        );
+        let table_change_log_get_latency =
+            register_histogram_with_registry!(opts, registry).unwrap();
 
         let time_travel_object_count = register_int_gauge_with_registry!(
             "storage_time_travel_object_count",
@@ -1021,6 +1031,7 @@ impl MetaMetrics {
             table_change_log_object_count,
             table_change_log_object_size,
             table_change_log_min_epoch,
+            table_change_log_get_latency,
             delta_log_count,
             version_checkpoint_latency,
             current_version_id,

--- a/src/storage/src/hummock/store/hummock_storage.rs
+++ b/src/storage/src/hummock/store/hummock_storage.rs
@@ -226,6 +226,7 @@ impl HummockStorage {
         let table_change_log_manager = Arc::new(TableChangeLogManager::new(
             options.table_change_log_cache_capacity,
             hummock_meta_client.clone(),
+            state_store_metrics.clone(),
         ));
         let instance = Self {
             context: compactor_context,

--- a/src/storage/src/hummock/store/table_change_log_manager.rs
+++ b/src/storage/src/hummock/store/table_change_log_manager.rs
@@ -25,6 +25,7 @@ use risingwave_hummock_sdk::change_log::TableChangeLogs;
 use risingwave_rpc_client::HummockMetaClient;
 
 use crate::hummock::{HummockError, HummockResult};
+use crate::monitor::HummockStateStoreMetrics;
 
 type InflightResult = Shared<Pin<Box<dyn Future<Output = HummockResult<TableChangeLogs>> + Send>>>;
 
@@ -40,14 +41,20 @@ struct CacheKey {
 pub struct TableChangeLogManager {
     cache: Cache<CacheKey, InflightResult>,
     hummock_meta_client: Arc<dyn HummockMetaClient>,
+    metrics: Arc<HummockStateStoreMetrics>,
 }
 
 impl TableChangeLogManager {
-    pub fn new(capacity: u64, hummock_meta_client: Arc<dyn HummockMetaClient>) -> Self {
+    pub fn new(
+        capacity: u64,
+        hummock_meta_client: Arc<dyn HummockMetaClient>,
+        metrics: Arc<HummockStateStoreMetrics>,
+    ) -> Self {
         let cache = Cache::builder().max_capacity(capacity).build();
         Self {
             cache,
             hummock_meta_client,
+            metrics,
         }
     }
 
@@ -99,6 +106,7 @@ impl TableChangeLogManager {
         include_epoch_only: bool,
         limit: Option<u32>,
     ) -> HummockResult<TableChangeLogs> {
+        let _timer = self.metrics.table_change_log_fetch_latency.start_timer();
         let hummock_meta_client = self.hummock_meta_client.clone();
         let fetch = async move {
             hummock_meta_client

--- a/src/storage/src/hummock/store/table_change_log_manager.rs
+++ b/src/storage/src/hummock/store/table_change_log_manager.rs
@@ -66,7 +66,8 @@ impl TableChangeLogManager {
         limit: Option<u32>,
         fetch: impl Future<Output = HummockResult<TableChangeLogs>> + Send + 'static,
     ) -> HummockResult<TableChangeLogs> {
-        self.cache
+        let entry = self
+            .cache
             .entry(CacheKey {
                 table_id,
                 epoch_range,
@@ -81,10 +82,13 @@ impl TableChangeLogManager {
                     }
                     false
                 },
-            )
-            .value()
-            .clone()
-            .await
+            );
+        if entry.is_fresh() {
+            self.metrics.table_change_log_cache_miss.inc();
+        } else {
+            self.metrics.table_change_log_cache_hit.inc();
+        }
+        entry.value().clone().await
     }
 
     /// Fetches table change logs for the given `table_id` and `epoch_range`.

--- a/src/storage/src/monitor/hummock_state_store_metrics.rs
+++ b/src/storage/src/monitor/hummock_state_store_metrics.rs
@@ -97,6 +97,8 @@ pub struct HummockStateStoreMetrics {
     pub safe_version_hit: GenericCounter<AtomicU64>,
     pub safe_version_miss: GenericCounter<AtomicU64>,
     pub table_change_log_fetch_latency: Histogram,
+    pub table_change_log_cache_hit: GenericCounter<AtomicU64>,
+    pub table_change_log_cache_miss: GenericCounter<AtomicU64>,
 }
 
 pub static GLOBAL_HUMMOCK_STATE_STORE_METRICS: OnceLock<HummockStateStoreMetrics> = OnceLock::new();
@@ -256,6 +258,17 @@ impl HummockStateStoreMetrics {
         );
         let table_change_log_fetch_latency =
             register_histogram_with_registry!(opts, registry).unwrap();
+
+        let table_change_log_cache_counts = register_int_counter_vec_with_registry!(
+            "state_store_table_change_log_cache_counts",
+            "Total number of table change log cache lookups",
+            &["result"],
+            registry
+        )
+        .unwrap();
+        let table_change_log_cache_hit = table_change_log_cache_counts.with_label_values(&["hit"]);
+        let table_change_log_cache_miss =
+            table_change_log_cache_counts.with_label_values(&["miss"]);
 
         // ----- vector -----
         let vector_object_request_counts = register_guarded_int_counter_vec_with_registry!(
@@ -648,6 +661,8 @@ impl HummockStateStoreMetrics {
             safe_version_hit,
             safe_version_miss,
             table_change_log_fetch_latency,
+            table_change_log_cache_hit,
+            table_change_log_cache_miss,
         }
     }
 

--- a/src/storage/src/monitor/hummock_state_store_metrics.rs
+++ b/src/storage/src/monitor/hummock_state_store_metrics.rs
@@ -96,6 +96,7 @@ pub struct HummockStateStoreMetrics {
 
     pub safe_version_hit: GenericCounter<AtomicU64>,
     pub safe_version_miss: GenericCounter<AtomicU64>,
+    pub table_change_log_fetch_latency: Histogram,
 }
 
 pub static GLOBAL_HUMMOCK_STATE_STORE_METRICS: OnceLock<HummockStateStoreMetrics> = OnceLock::new();
@@ -224,7 +225,7 @@ impl HummockStateStoreMetrics {
         let opts = histogram_opts!(
             "state_store_iter_fetch_meta_duration",
             "Histogram of iterator fetch SST meta time that have been issued to state store",
-            state_store_read_time_buckets,
+            state_store_read_time_buckets.clone(),
         );
         let iter_fetch_meta_duration =
             register_guarded_histogram_vec_with_registry!(opts, &["table_id"], registry).unwrap();
@@ -247,6 +248,14 @@ impl HummockStateStoreMetrics {
             registry
         )
         .unwrap();
+
+        let opts = histogram_opts!(
+            "state_store_table_change_log_fetch_latency",
+            "Latency of fetching table change logs",
+            state_store_read_time_buckets,
+        );
+        let table_change_log_fetch_latency =
+            register_histogram_with_registry!(opts, registry).unwrap();
 
         // ----- vector -----
         let vector_object_request_counts = register_guarded_int_counter_vec_with_registry!(
@@ -638,6 +647,7 @@ impl HummockStateStoreMetrics {
             event_handler_latency,
             safe_version_hit,
             safe_version_miss,
+            table_change_log_fetch_latency,
         }
     }
 


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

This PR adds metrics for table change log fetching on both the storage and meta paths.
It records `state_store_table_change_log_fetch_latency` around `TableChangeLogManager::fetch_table_change_logs` and `storage_table_change_log_get_latency` around `HummockManager::get_table_change_logs`.
It also records `state_store_table_change_log_cache_counts{result="hit|miss"}` in `TableChangeLogManager::get_or_insert` to track cache effectiveness.
The storage table change log manager now receives `HummockStateStoreMetrics` so the fetch path can report method latency consistently with the existing Hummock state store metrics.

## Checklist

- [x] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

Adds Prometheus latency and cache hit/miss metrics for table change log fetch requests.

</details>
