### PR TITLE
feat(connector): support Pulsar sink routing mode

### DIFF
--- a/ci/scripts/e2e-pulsar-sink-test.sh
+++ b/ci/scripts/e2e-pulsar-sink-test.sh
@@ -38,6 +38,7 @@ set -e
 
 echo "--- testing pulsar sink"
 sqllogictest -p 4566 -d dev './e2e_test/sink/pulsar_sink.slt'
+sqllogictest -p 4566 -d dev './e2e_test/sink/pulsar_sink_roundrobin.slt'
 
 sleep 1
 

--- a/e2e_test/sink/pulsar_sink_roundrobin.slt
+++ b/e2e_test/sink/pulsar_sink_roundrobin.slt
@@ -1,0 +1,99 @@
+statement ok
+set sink_decouple = false;
+
+system ok
+curl -s -o /dev/null -X DELETE 'http://pulsar-server:8080/admin/v2/persistent/public/default/rw_roundrobin/partitions?force=true' || true
+
+system ok
+curl -sSf -X PUT -H 'Content-Type: application/json' --data '3' 'http://pulsar-server:8080/admin/v2/persistent/public/default/rw_roundrobin/partitions'
+
+statement ok
+CREATE TABLE pulsar_roundrobin (
+    id BIGINT,
+    content VARCHAR,
+    PRIMARY KEY (id)
+);
+
+statement ok
+CREATE SINK pulsar_roundrobin_sink FROM pulsar_roundrobin
+WITH (
+    connector='pulsar',
+    primary_key='id',
+    topic='persistent://public/default/rw_roundrobin',
+    service.url='pulsar://pulsar-server:6650',
+    routing_mode='roundrobin'
+) FORMAT UPSERT ENCODE JSON KEY ENCODE TEXT;
+
+statement ok
+CREATE TABLE pulsar_roundrobin_source (
+    id BIGINT,
+    content VARCHAR
+)
+INCLUDE KEY AS pulsar_key
+INCLUDE PARTITION AS pulsar_partition
+WITH (
+   connector='pulsar',
+   topic='persistent://public/default/rw_roundrobin',
+   service.url='pulsar://pulsar-server:6650',
+   scan.startup.mode='earliest'
+) FORMAT PLAIN ENCODE JSON;
+
+statement ok
+INSERT INTO pulsar_roundrobin VALUES
+    (1, 'first-1'),
+    (2, 'first-2'),
+    (3, 'first-3'),
+    (4, 'first-4'),
+    (5, 'first-5'),
+    (6, 'first-6');
+
+statement ok
+UPDATE pulsar_roundrobin
+SET content = 'second-' || id::VARCHAR;
+
+statement ok
+FLUSH;
+
+query I retry 10 backoff 1s
+SELECT count(*) FROM pulsar_roundrobin_source;
+----
+12
+
+query I retry 10 backoff 1s
+SELECT count(*)
+FROM pulsar_roundrobin_source
+WHERE convert_from(pulsar_key, 'UTF-8') <> id::VARCHAR;
+----
+0
+
+query TI rowsort retry 10 backoff 1s
+SELECT convert_from(pulsar_key, 'UTF-8'), count(DISTINCT pulsar_partition)
+FROM pulsar_roundrobin_source
+GROUP BY pulsar_key;
+----
+1 1
+2 1
+3 1
+4 1
+5 1
+6 1
+
+query I retry 10 backoff 1s
+SELECT count(*) FROM (
+    SELECT 1
+    WHERE (SELECT count(DISTINCT pulsar_partition) FROM pulsar_roundrobin_source) > 1
+);
+----
+1
+
+statement ok
+DROP TABLE pulsar_roundrobin_source;
+
+statement ok
+DROP SINK pulsar_roundrobin_sink;
+
+statement ok
+DROP TABLE pulsar_roundrobin;
+
+system ok
+curl -s -o /dev/null -X DELETE 'http://pulsar-server:8080/admin/v2/persistent/public/default/rw_roundrobin/partitions?force=true' || true

--- a/e2e_test/sink/pulsar_sink_roundrobin.slt
+++ b/e2e_test/sink/pulsar_sink_roundrobin.slt
@@ -48,6 +48,14 @@ INSERT INTO pulsar_roundrobin VALUES
     (6, 'first-6');
 
 statement ok
+FLUSH;
+
+query I retry 10 backoff 1s
+SELECT count(*) FROM pulsar_roundrobin_source;
+----
+6
+
+statement ok
 UPDATE pulsar_roundrobin
 SET content = 'second-' || id::VARCHAR;
 

--- a/src/connector/src/allow_alter_on_fly_fields.rs
+++ b/src/connector/src/allow_alter_on_fly_fields.rs
@@ -292,6 +292,19 @@ pub static SINK_ALLOW_ALTER_ON_FLY_FIELDS: LazyLock<HashMap<String, HashSet<Stri
             "properties.request.required.acks".to_owned(),
         ].into_iter().collect(),
     ).unwrap();
+    // PulsarConfig
+    map.try_insert(
+        std::any::type_name::<PulsarConfig>().to_owned(),
+        [
+            "properties.routing.mode".to_owned(),
+            "properties.routing_mode".to_owned(),
+            "routing_mode".to_owned(),
+            "pulsar.routing_mode".to_owned(),
+            "pulsar.routing.mode".to_owned(),
+            "pulsar.properties.routing.mode".to_owned(),
+            "pulsar.properties.routing_mode".to_owned(),
+        ].into_iter().collect(),
+    ).unwrap();
     // SnowflakeV2Config
     map.try_insert(
         std::any::type_name::<SnowflakeV2Config>().to_owned(),

--- a/src/connector/src/sink/pulsar.rs
+++ b/src/connector/src/sink/pulsar.rs
@@ -72,6 +72,8 @@ async fn build_pulsar_producer(
     pulsar: &Pulsar<TokioExecutor>,
     config: &PulsarConfig,
 ) -> Result<Producer<TokioExecutor>> {
+    let routing_policy = pulsar_producer_routing_policy(config.producer_properties.routing_mode);
+
     // Reduce async state machine size (see `clippy::large_futures`).
     Box::pin(
         pulsar
@@ -79,7 +81,7 @@ async fn build_pulsar_producer(
             .with_options(ProducerOptions {
                 batch_size: Some(config.producer_properties.batch_size),
                 batch_byte_size: Some(config.producer_properties.batch_byte_size),
-                routing_policy: config.producer_properties.routing_mode.map(Into::into),
+                routing_policy: Some(routing_policy),
                 ..Default::default()
             })
             .with_topic(&config.common.topic)
@@ -87,6 +89,12 @@ async fn build_pulsar_producer(
             .map_err(pulsar_to_sink_err),
     )
     .await
+}
+
+fn pulsar_producer_routing_policy(routing_mode: Option<PulsarRoutingMode>) -> RoutingPolicy {
+    routing_mode
+        .map(Into::into)
+        .unwrap_or(RoutingPolicy::RoundRobin)
 }
 
 #[derive(Debug, Copy, Clone, Display, Deserialize, EnumString)]
@@ -501,6 +509,26 @@ mod tests {
         let config = parse_config_with([]);
 
         assert!(config.producer_properties.routing_mode.is_none());
+    }
+
+    #[test]
+    fn test_pulsar_producer_routing_policy_defaults_to_round_robin() {
+        let config = parse_config_with([]);
+
+        assert!(matches!(
+            pulsar_producer_routing_policy(config.producer_properties.routing_mode),
+            RoutingPolicy::RoundRobin
+        ));
+    }
+
+    #[test]
+    fn test_pulsar_producer_routing_policy_preserves_configured_mode() {
+        let config = parse_config_with([("properties.routing.mode", "SinglePartition")]);
+
+        assert!(matches!(
+            pulsar_producer_routing_policy(config.producer_properties.routing_mode),
+            RoutingPolicy::Single
+        ));
     }
 
     #[test]

--- a/src/connector/src/sink/pulsar.rs
+++ b/src/connector/src/sink/pulsar.rs
@@ -19,11 +19,13 @@ use std::time::Duration;
 use anyhow::anyhow;
 use futures::{FutureExt, TryFuture, TryFutureExt};
 use pulsar::producer::{Message, SendFuture};
+use pulsar::routing_policy::RoutingPolicy;
 use pulsar::{Producer, ProducerOptions, Pulsar, TokioExecutor};
 use risingwave_common::array::StreamChunk;
 use risingwave_common::catalog::Schema;
 use serde::Deserialize;
 use serde_with::{DisplayFromStr, serde_as};
+use strum_macros::{Display, EnumString};
 use with_options::WithOptions;
 
 use super::catalog::{SinkFormat, SinkFormatDesc};
@@ -77,6 +79,7 @@ async fn build_pulsar_producer(
             .with_options(ProducerOptions {
                 batch_size: Some(config.producer_properties.batch_size),
                 batch_byte_size: Some(config.producer_properties.batch_byte_size),
+                routing_policy: config.producer_properties.routing_mode.map(Into::into),
                 ..Default::default()
             })
             .with_topic(&config.common.topic)
@@ -84,6 +87,38 @@ async fn build_pulsar_producer(
             .map_err(pulsar_to_sink_err),
     )
     .await
+}
+
+#[derive(Debug, Copy, Clone, Display, Deserialize, EnumString)]
+#[strum(serialize_all = "snake_case", ascii_case_insensitive)]
+pub enum PulsarRoutingMode {
+    #[strum(
+        serialize = "round_robin",
+        serialize = "roundrobin",
+        serialize = "roundrobinpartition",
+        serialize = "round_robin_partition",
+        serialize = "round-robin",
+        serialize = "round-robin-partition",
+        serialize = "RoundRobinPartition"
+    )]
+    RoundRobin,
+    #[strum(
+        serialize = "single",
+        serialize = "singlepartition",
+        serialize = "single_partition",
+        serialize = "single-partition",
+        serialize = "SinglePartition"
+    )]
+    Single,
+}
+
+impl From<PulsarRoutingMode> for RoutingPolicy {
+    fn from(mode: PulsarRoutingMode) -> Self {
+        match mode {
+            PulsarRoutingMode::RoundRobin => RoutingPolicy::RoundRobin,
+            PulsarRoutingMode::Single => RoutingPolicy::Single,
+        }
+    }
 }
 
 #[serde_as]
@@ -99,6 +134,18 @@ pub struct PulsarPropertiesProducer {
     )]
     #[serde_as(as = "DisplayFromStr")]
     batch_byte_size: usize,
+
+    #[serde(
+        rename = "properties.routing.mode",
+        alias = "properties.routing_mode",
+        alias = "routing_mode",
+        alias = "pulsar.routing_mode",
+        alias = "pulsar.routing.mode",
+        alias = "pulsar.properties.routing.mode",
+        alias = "pulsar.properties.routing_mode"
+    )]
+    #[serde_as(as = "Option<DisplayFromStr>")]
+    routing_mode: Option<PulsarRoutingMode>,
 }
 
 #[serde_as]
@@ -417,5 +464,66 @@ impl AsyncTruncateSinkWriter for PulsarSinkWriter {
         }
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+
+    use super::*;
+
+    fn base_properties() -> BTreeMap<String, String> {
+        BTreeMap::from([
+            (
+                "service.url".to_owned(),
+                "pulsar://localhost:6650".to_owned(),
+            ),
+            ("topic".to_owned(), "test-topic".to_owned()),
+        ])
+    }
+
+    fn parse_config_with(
+        extra: impl IntoIterator<Item = (&'static str, &'static str)>,
+    ) -> PulsarConfig {
+        let mut props = base_properties();
+        props.extend(
+            extra
+                .into_iter()
+                .map(|(key, value)| (key.to_owned(), value.to_owned())),
+        );
+        PulsarConfig::from_btreemap(props).unwrap()
+    }
+
+    #[test]
+    fn test_pulsar_routing_mode_default_is_unset() {
+        let config = parse_config_with([]);
+
+        assert!(config.producer_properties.routing_mode.is_none());
+    }
+
+    #[test]
+    fn test_parse_pulsar_routing_mode() {
+        let config = parse_config_with([("properties.routing.mode", "round_robin")]);
+        assert!(matches!(
+            config.producer_properties.routing_mode,
+            Some(PulsarRoutingMode::RoundRobin)
+        ));
+
+        let config = parse_config_with([("properties.routing.mode", "SinglePartition")]);
+        assert!(matches!(
+            config.producer_properties.routing_mode,
+            Some(PulsarRoutingMode::Single)
+        ));
+    }
+
+    #[test]
+    fn test_parse_pulsar_routing_mode_alias() {
+        let config = parse_config_with([("routing_mode", "single")]);
+
+        assert!(matches!(
+            config.producer_properties.routing_mode,
+            Some(PulsarRoutingMode::Single)
+        ));
     }
 }

--- a/src/connector/src/sink/pulsar.rs
+++ b/src/connector/src/sink/pulsar.rs
@@ -72,8 +72,6 @@ async fn build_pulsar_producer(
     pulsar: &Pulsar<TokioExecutor>,
     config: &PulsarConfig,
 ) -> Result<Producer<TokioExecutor>> {
-    let routing_policy = pulsar_producer_routing_policy(config.producer_properties.routing_mode);
-
     // Reduce async state machine size (see `clippy::large_futures`).
     Box::pin(
         pulsar
@@ -81,7 +79,9 @@ async fn build_pulsar_producer(
             .with_options(ProducerOptions {
                 batch_size: Some(config.producer_properties.batch_size),
                 batch_byte_size: Some(config.producer_properties.batch_byte_size),
-                routing_policy: Some(routing_policy),
+                routing_policy: pulsar_producer_routing_policy(
+                    config.producer_properties.routing_mode,
+                ),
                 ..Default::default()
             })
             .with_topic(&config.common.topic)
@@ -91,10 +91,10 @@ async fn build_pulsar_producer(
     .await
 }
 
-fn pulsar_producer_routing_policy(routing_mode: Option<PulsarRoutingMode>) -> RoutingPolicy {
-    routing_mode
-        .map(Into::into)
-        .unwrap_or(RoutingPolicy::RoundRobin)
+fn pulsar_producer_routing_policy(
+    routing_mode: Option<PulsarRoutingMode>,
+) -> Option<RoutingPolicy> {
+    routing_mode.map(Into::into)
 }
 
 #[derive(Debug, Copy, Clone, Display, Deserialize, EnumString)]
@@ -512,13 +512,10 @@ mod tests {
     }
 
     #[test]
-    fn test_pulsar_producer_routing_policy_defaults_to_round_robin() {
+    fn test_pulsar_producer_routing_policy_preserves_unset_default() {
         let config = parse_config_with([]);
 
-        assert!(matches!(
-            pulsar_producer_routing_policy(config.producer_properties.routing_mode),
-            RoutingPolicy::RoundRobin
-        ));
+        assert!(pulsar_producer_routing_policy(config.producer_properties.routing_mode).is_none());
     }
 
     #[test]
@@ -527,7 +524,7 @@ mod tests {
 
         assert!(matches!(
             pulsar_producer_routing_policy(config.producer_properties.routing_mode),
-            RoutingPolicy::Single
+            Some(RoutingPolicy::Single)
         ));
     }
 

--- a/src/connector/src/sink/pulsar.rs
+++ b/src/connector/src/sink/pulsar.rs
@@ -145,6 +145,7 @@ pub struct PulsarPropertiesProducer {
         alias = "pulsar.properties.routing_mode"
     )]
     #[serde_as(as = "Option<DisplayFromStr>")]
+    #[with_option(allow_alter_on_fly)]
     routing_mode: Option<PulsarRoutingMode>,
 }
 

--- a/src/connector/src/with_options.rs
+++ b/src/connector/src/with_options.rs
@@ -75,6 +75,7 @@ impl WithOptions for std::time::Duration {}
 impl WithOptions for crate::connector_common::MqttQualityOfService {}
 impl WithOptions for crate::sink::file_sink::opendal_sink::PathPartitionPrefix {}
 impl WithOptions for crate::sink::kafka::CompressionCodec {}
+impl WithOptions for crate::sink::pulsar::PulsarRoutingMode {}
 impl WithOptions for crate::source::filesystem::file_common::CompressionFormat {}
 impl WithOptions for nexmark::config::RateShape {}
 impl WithOptions for nexmark::event::EventType {}

--- a/src/connector/with_options_sink.yaml
+++ b/src/connector/with_options_sink.yaml
@@ -1517,6 +1517,7 @@ PulsarConfig:
     - pulsar.routing.mode
     - pulsar.properties.routing.mode
     - pulsar.properties.routing_mode
+    allow_alter_on_fly: true
 RedShiftConfig:
   fields:
   - name: jdbc.url

--- a/src/connector/with_options_sink.yaml
+++ b/src/connector/with_options_sink.yaml
@@ -1507,6 +1507,16 @@ PulsarConfig:
     field_type: usize
     required: false
     default: 1 << 20
+  - name: properties.routing.mode
+    field_type: PulsarRoutingMode
+    required: false
+    alias:
+    - properties.routing_mode
+    - routing_mode
+    - pulsar.routing_mode
+    - pulsar.routing.mode
+    - pulsar.properties.routing.mode
+    - pulsar.properties.routing_mode
 RedShiftConfig:
   fields:
   - name: jdbc.url


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

The Pulsar library only respects partition keys when the RoutingPolicy is set to [RoundRobin](https://github.com/streamnative/pulsar-rs/blob/95a0d73290d56be5d24eb3ed0d5d7d73f3a44343/src/producer.rs#L550). However, RisingWave currently hardcodes RoutingPolicy to None, **which ignores partition keys.** 

- Set default RoutingPolicy to RoundRobin in RisingWave.
- Add `properties.routing.mode` for Pulsar sink producers, mapping `round_robin` and `single` to pulsar-rs `ProducerOptions.routing_policy` while leaving the default unset for backward compatibility.
- Mark the routing mode option as `allow_alter_on_fly`, including its aliases, so it can be updated through sink connector property alteration.
- Register the new option in generated sink option metadata and cover default, canonical, Pulsar-style, and alias parsing with unit tests.
- Closes: N/A

## Checklist

- [ ] I have written necessary rustdoc comments.
- [x] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [x] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [x] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

Pulsar sink users can now configure and alter producer routing with `properties.routing.mode` without changing the existing default behavior.

</details>