### PR TITLE
fix(frontend): keep parameterized IN lists flat

### DIFF
--- a/src/frontend/planner_test/tests/testdata/input/parameters.yaml
+++ b/src/frontend/planner_test/tests/testdata/input/parameters.yaml
@@ -15,3 +15,9 @@
     explain select * from t where id in($1, 123)
   expected_outputs:
     - explain_output
+- id: explain multiple parameters in in-expr
+  sql: |
+    create table t (id int primary key, a int);
+    explain select * from t where id in($1, $2, $3, 123)
+  expected_outputs:
+    - explain_output

--- a/src/frontend/planner_test/tests/testdata/output/parameters.yaml
+++ b/src/frontend/planner_test/tests/testdata/output/parameters.yaml
@@ -11,7 +11,7 @@
     explain select * from t where id in($1)
   explain_output: |
     BatchExchange { order: [], dist: Single }
-    └─BatchFilter { predicate: (t.id = Parameter(index: 1, type: Some(Int32))) }
+    └─BatchFilter { predicate: In(t.id, Parameter(index: 1, type: Some(Int32))) }
       └─BatchScan { table: t, columns: [id, a] }
 - id: explain parameters in in-expr
   sql: |
@@ -19,5 +19,13 @@
     explain select * from t where id in($1, 123)
   explain_output: |
     BatchExchange { order: [], dist: Single }
-    └─BatchFilter { predicate: (In(t.id, 123:Int32) OR (t.id = Parameter(index: 1, type: Some(Int32)))) }
+    └─BatchFilter { predicate: In(t.id, Parameter(index: 1, type: Some(Int32)), 123:Int32) }
+      └─BatchScan { table: t, columns: [id, a] }
+- id: explain multiple parameters in in-expr
+  sql: |
+    create table t (id int primary key, a int);
+    explain select * from t where id in($1, $2, $3, 123)
+  explain_output: |
+    BatchExchange { order: [], dist: Single }
+    └─BatchFilter { predicate: In(t.id, Parameter(index: 1, type: Some(Int32)), Parameter(index: 2, type: Some(Int32)), Parameter(index: 3, type: Some(Int32)), 123:Int32) }
       └─BatchScan { table: t, columns: [id, a] }

--- a/src/frontend/src/binder/bind_param.rs
+++ b/src/frontend/src/binder/bind_param.rs
@@ -190,6 +190,39 @@ mod test {
     }
 
     #[tokio::test]
+    async fn in_list_parameters_stay_flat_after_binding() {
+        expect_actual_eq(
+            create_expect_bound("select 1::int4 in (2::int4, 3::int4)"),
+            create_actual_bound(
+                "select 1::int4 in ($1::int4, $2::int4)",
+                vec![],
+                vec![Some("2".into()), Some("3".into())],
+                vec![Format::Text, Format::Text],
+            ),
+        );
+    }
+
+    #[tokio::test]
+    async fn large_in_list_parameters_do_not_recurse() {
+        let param_count = 4096;
+        let params = (1..=param_count)
+            .map(|index| format!("${index}::int4"))
+            .collect::<Vec<_>>()
+            .join(", ");
+        let sql = format!("select 0::int4 in ({params})");
+
+        let mut binder = mock_binder();
+        let stmt = parse_sql_statements(&sql).unwrap().remove(0);
+        let bound = binder.bind(stmt).unwrap();
+        bound
+            .bind_parameter(
+                vec![Some("1".into()); param_count],
+                vec![Format::Text; param_count],
+            )
+            .unwrap();
+    }
+
+    #[tokio::test]
     async fn cast_after_specific() {
         expect_actual_eq(
             create_expect_bound("select 1::varchar"),

--- a/src/frontend/src/binder/expr/mod.rs
+++ b/src/frontend/src/binder/expr/mod.rs
@@ -269,22 +269,23 @@ impl Binder {
         negated: bool,
     ) -> Result<ExprImpl> {
         let left = self.bind_expr_inner(expr)?;
-        let mut bound_expr_list = vec![left.clone()];
+        let mut in_list_exprs = vec![left.clone()];
         let mut non_const_exprs = vec![];
         for elem in list {
             let expr = self.bind_expr_inner(elem)?;
-            match expr.is_const() {
-                true => bound_expr_list.push(expr),
+            match expr.is_const() || matches!(&expr, ExprImpl::Parameter(_)) {
+                true => in_list_exprs.push(expr),
                 false => non_const_exprs.push(expr),
             }
         }
 
-        let mut ret = if bound_expr_list.len() == 1 {
+        let mut ret = if in_list_exprs.len() == 1 {
             None
         } else {
-            Some(FunctionCall::new(ExprType::In, bound_expr_list)?.into())
+            Some(FunctionCall::new(ExprType::In, in_list_exprs)?.into())
         };
-        // Non-const exprs are not part of IN-expr in backend and rewritten into OR-Equal-exprs.
+        // Row-dependent list items are not part of IN-expr in backend and rewritten into
+        // OR-Equal-exprs.
         for expr in non_const_exprs {
             if let Some(inner_ret) = ret {
                 ret = Some(

--- a/src/frontend/src/expr/mod.rs
+++ b/src/frontend/src/expr/mod.rs
@@ -927,9 +927,7 @@ impl ExprImpl {
         if let ExprImpl::FunctionCall(function_call) = self
             && function_call.func_type() == ExprType::In
         {
-            let Some((input, list)) = function_call.inputs().split_first() else {
-                return None;
-            };
+            let (input, list) = function_call.inputs().split_first()?;
             let input_ref = match input {
                 ExprImpl::InputRef(i) => i.as_ref().clone(),
                 _ => return None,

--- a/src/frontend/src/expr/mod.rs
+++ b/src/frontend/src/expr/mod.rs
@@ -932,12 +932,10 @@ impl ExprImpl {
                 ExprImpl::InputRef(i) => *i,
                 _ => return None,
             };
-            let list: Vec<_> = inputs
-                .inspect(|expr| {
-                    // Non constant IN will be bound to OR
-                    assert!(expr.is_const());
-                })
-                .collect();
+            let list: Vec<_> = inputs.collect();
+            if !list.iter().all(ExprImpl::is_const) {
+                return None;
+            }
 
             Some((input_ref, list))
         } else {

--- a/src/frontend/src/expr/mod.rs
+++ b/src/frontend/src/expr/mod.rs
@@ -927,17 +927,18 @@ impl ExprImpl {
         if let ExprImpl::FunctionCall(function_call) = self
             && function_call.func_type() == ExprType::In
         {
-            let mut inputs = function_call.inputs().iter().cloned();
-            let input_ref = match inputs.next().unwrap() {
-                ExprImpl::InputRef(i) => *i,
+            let Some((input, list)) = function_call.inputs().split_first() else {
+                return None;
+            };
+            let input_ref = match input {
+                ExprImpl::InputRef(i) => i.as_ref().clone(),
                 _ => return None,
             };
-            let list: Vec<_> = inputs.collect();
             if !list.iter().all(ExprImpl::is_const) {
                 return None;
             }
 
-            Some((input_ref, list))
+            Some((input_ref, list.to_vec()))
         } else {
             None
         }


### PR DESCRIPTION
## Summary

### Issue:

A single query containing a large **parameterized** `IN` list crashes the RisingWave frontend node.

### Reproduction

```sql
-- Sent via the extended query protocol with N bind parameters (psycopg3 default):
SELECT count(*) FROM t WHERE id IN ($1, $2, …, $N);
```

N = 3,456 → succeeds; **N = 3,457 → frontend crash.

### Fix:
- keep direct bind parameters inside the flat `ExprType::In` representation instead of lowering them to a left-deep OR/equality tree
- make `as_in_const_list` return `None` for unbound parameters instead of asserting, while still recognizing the list after bind parameters are rewritten to literals
- add planner and binder regressions, including a 4096-parameter IN-list bind case above the reported crash threshold

## Tests

- `cargo fmt --check`
- `cargo test -p risingwave_frontend binder::bind_param::test:: -- --nocapture`
- `cargo test -p risingwave_planner_test --test planner_test_runner -- parameters`