### PR TITLE
feat(optimizer): use expression indexes for projections

### DIFF
--- a/src/frontend/planner_test/tests/testdata/input/index_selection.yaml
+++ b/src/frontend/planner_test/tests/testdata/input/index_selection.yaml
@@ -465,6 +465,34 @@
     select * from t where j->>'k1' = 'abc';
   expected_outputs:
   - batch_plan
+- name: narrow expression index covers projection
+  sql: |
+    create table t (j jsonb, v1 int, v2 int, payload1 jsonb, payload2 jsonb);
+    create index idx1 on t(j->>'k1') include(v1);
+    select j->>'k1' from t;
+  expected_outputs:
+  - batch_plan
+- name: expression index projection still respects cost
+  sql: |
+    create table t (j jsonb, v1 int, v2 int);
+    create index idx1 on t(j->>'k1') include(v1);
+    select j->>'k1' from t;
+  expected_outputs:
+  - batch_plan
+- name: expression index covers projection and predicate
+  sql: |
+    create table t (j jsonb, v1 int, v2 int);
+    create index idx1 on t(j->>'k1') include(v1);
+    select j->>'k1' from t where j->>'k1' = 'abc';
+  expected_outputs:
+  - batch_plan
+- name: expression index does not cover another projected column
+  sql: |
+    create table t (j jsonb, v1 int, v2 int);
+    create index idx1 on t(j->>'k1') include(v1);
+    select j->>'k1', v2 from t where j->>'k1' = 'abc';
+  expected_outputs:
+  - batch_plan
 - sql: |
     create table t (j jsonb, v1 int, v2 int);
     create index idx1 on t(j->>'k1') include(v1);

--- a/src/frontend/planner_test/tests/testdata/output/index_selection.yaml
+++ b/src/frontend/planner_test/tests/testdata/output/index_selection.yaml
@@ -815,6 +815,44 @@
     └─BatchLookupJoin { type: Inner, predicate: idx1.t._row_id IS NOT DISTINCT FROM t._row_id, output: [t.j, t.v1, t.v2], lookup table: t }
       └─BatchExchange { order: [], dist: UpstreamHashShard(idx1.t._row_id) }
         └─BatchScan { table: idx1, columns: [idx1.t._row_id], scan_ranges: [idx1.JSONB_ACCESS_STR = Utf8("abc")], distribution: SomeShard }
+- name: narrow expression index covers projection
+  sql: |
+    create table t (j jsonb, v1 int, v2 int, payload1 jsonb, payload2 jsonb);
+    create index idx1 on t(j->>'k1') include(v1);
+    select j->>'k1' from t;
+  batch_plan: |-
+    BatchExchange { order: [], dist: Single }
+    └─BatchProject { exprs: [idx1.JSONB_ACCESS_STR] }
+      └─BatchScan { table: idx1, columns: [idx1.JSONB_ACCESS_STR], distribution: UpstreamHashShard(idx1.JSONB_ACCESS_STR) }
+- name: expression index projection still respects cost
+  sql: |
+    create table t (j jsonb, v1 int, v2 int);
+    create index idx1 on t(j->>'k1') include(v1);
+    select j->>'k1' from t;
+  batch_plan: |-
+    BatchExchange { order: [], dist: Single }
+    └─BatchProject { exprs: [JsonbAccessStr(t.j, 'k1':Varchar) as $expr1] }
+      └─BatchScan { table: t, columns: [t.j], distribution: SomeShard }
+- name: expression index covers projection and predicate
+  sql: |
+    create table t (j jsonb, v1 int, v2 int);
+    create index idx1 on t(j->>'k1') include(v1);
+    select j->>'k1' from t where j->>'k1' = 'abc';
+  batch_plan: |-
+    BatchExchange { order: [], dist: Single }
+    └─BatchProject { exprs: [idx1.JSONB_ACCESS_STR] }
+      └─BatchScan { table: idx1, columns: [idx1.JSONB_ACCESS_STR], scan_ranges: [idx1.JSONB_ACCESS_STR = Utf8("abc")], distribution: UpstreamHashShard(idx1.JSONB_ACCESS_STR) }
+- name: expression index does not cover another projected column
+  sql: |
+    create table t (j jsonb, v1 int, v2 int);
+    create index idx1 on t(j->>'k1') include(v1);
+    select j->>'k1', v2 from t where j->>'k1' = 'abc';
+  batch_plan: |-
+    BatchExchange { order: [], dist: Single }
+    └─BatchProject { exprs: [JsonbAccessStr(t.j, 'k1':Varchar) as $expr1, t.v2] }
+      └─BatchLookupJoin { type: Inner, predicate: idx1.t._row_id IS NOT DISTINCT FROM t._row_id, output: [t.j, t.v2], lookup table: t }
+        └─BatchExchange { order: [], dist: UpstreamHashShard(idx1.t._row_id) }
+          └─BatchScan { table: idx1, columns: [idx1.t._row_id], scan_ranges: [idx1.JSONB_ACCESS_STR = Utf8("abc")], distribution: SomeShard }
 - sql: |
     create table t (j jsonb, v1 int, v2 int);
     create index idx1 on t(j->>'k1') include(v1);
@@ -870,8 +908,8 @@
     select ts::timestamptz from t where ts > now();
   batch_plan: |-
     BatchExchange { order: [], dist: Single }
-    └─BatchProject { exprs: [AtTimeZone(i.ts, 'UTC':Varchar) as $expr1] }
-      └─BatchScan { table: i, columns: [i.ts], scan_ranges: [i.AT_TIME_ZONE > Timestamptz(Timestamptz(1617235200000000))], distribution: SomeShard }
+    └─BatchProject { exprs: [i.AT_TIME_ZONE] }
+      └─BatchScan { table: i, columns: [i.AT_TIME_ZONE], scan_ranges: [i.AT_TIME_ZONE > Timestamptz(Timestamptz(1617235200000000))], distribution: UpstreamHashShard(i.AT_TIME_ZONE) }
 - name: funtional index with timezone2
   sql: |
     create table t (a int, ts timestamp without time zone);

--- a/src/frontend/src/optimizer/plan_node/generic/table_scan.rs
+++ b/src/frontend/src/optimizer/plan_node/generic/table_scan.rs
@@ -65,6 +65,100 @@ pub struct TableScan {
     pub ctx: OptimizerContextRef,
 }
 
+#[derive(Clone, Copy)]
+enum UnmappedInputRefBehavior {
+    Panic,
+    RewriteWithOffset(usize),
+}
+
+/// Rewrites expressions from primary-table column indices to index-table column indices.
+pub(crate) struct IndexExprRewriter<'a> {
+    primary_to_secondary_mapping: &'a BTreeMap<usize, usize>,
+    function_mapping: &'a HashMap<FunctionCall, usize>,
+    unmapped_input_ref_behavior: UnmappedInputRefBehavior,
+    covered_by_index: bool,
+    used_materialized_expression: bool,
+}
+
+impl<'a> IndexExprRewriter<'a> {
+    pub(crate) fn new_strict(
+        primary_to_secondary_mapping: &'a BTreeMap<usize, usize>,
+        function_mapping: &'a HashMap<FunctionCall, usize>,
+    ) -> Self {
+        Self::new(
+            primary_to_secondary_mapping,
+            function_mapping,
+            UnmappedInputRefBehavior::Panic,
+        )
+    }
+
+    pub(crate) fn new_with_unmapped_input_offset(
+        primary_to_secondary_mapping: &'a BTreeMap<usize, usize>,
+        function_mapping: &'a HashMap<FunctionCall, usize>,
+        offset: usize,
+    ) -> Self {
+        Self::new(
+            primary_to_secondary_mapping,
+            function_mapping,
+            UnmappedInputRefBehavior::RewriteWithOffset(offset),
+        )
+    }
+
+    fn new(
+        primary_to_secondary_mapping: &'a BTreeMap<usize, usize>,
+        function_mapping: &'a HashMap<FunctionCall, usize>,
+        unmapped_input_ref_behavior: UnmappedInputRefBehavior,
+    ) -> Self {
+        Self {
+            primary_to_secondary_mapping,
+            function_mapping,
+            unmapped_input_ref_behavior,
+            covered_by_index: true,
+            used_materialized_expression: false,
+        }
+    }
+
+    pub(crate) fn covered_by_index(&self) -> bool {
+        self.covered_by_index
+    }
+
+    pub(crate) fn used_materialized_expression(&self) -> bool {
+        self.used_materialized_expression
+    }
+}
+
+impl ExprRewriter for IndexExprRewriter<'_> {
+    fn rewrite_input_ref(&mut self, input_ref: InputRef) -> ExprImpl {
+        let index = match self.primary_to_secondary_mapping.get(&input_ref.index()) {
+            Some(index) => *index,
+            None => match self.unmapped_input_ref_behavior {
+                UnmappedInputRefBehavior::Panic => {
+                    panic!("primary column must be covered by index")
+                }
+                UnmappedInputRefBehavior::RewriteWithOffset(offset) => {
+                    self.covered_by_index = false;
+                    input_ref.index() + offset
+                }
+            },
+        };
+        InputRef::new(index, input_ref.return_type()).into()
+    }
+
+    fn rewrite_function_call(&mut self, func_call: FunctionCall) -> ExprImpl {
+        if let Some(index) = self.function_mapping.get(&func_call) {
+            self.used_materialized_expression = true;
+            return InputRef::new(*index, func_call.return_type()).into();
+        }
+
+        let (func_type, inputs, ret) = func_call.decompose();
+        let inputs = inputs
+            .into_iter()
+            .map(|expr| self.rewrite_expr(expr))
+            .collect();
+        FunctionCall::new_unchecked(func_type, inputs, ret).into()
+    }
+}
+
 impl TableScan {
     pub(crate) fn rewrite_exprs(&mut self, r: &mut dyn ExprRewriter) {
         self.predicate = self.predicate.clone().rewrite_expr(r);
@@ -247,39 +341,8 @@ impl TableScan {
             .map(|col_idx| *primary_to_secondary_mapping.get(col_idx).unwrap())
             .collect();
 
-        struct Rewriter<'a> {
-            primary_to_secondary_mapping: &'a BTreeMap<usize, usize>,
-            function_mapping: &'a HashMap<FunctionCall, usize>,
-        }
-        impl ExprRewriter for Rewriter<'_> {
-            fn rewrite_input_ref(&mut self, input_ref: InputRef) -> ExprImpl {
-                InputRef::new(
-                    *self
-                        .primary_to_secondary_mapping
-                        .get(&input_ref.index)
-                        .unwrap(),
-                    input_ref.return_type(),
-                )
-                .into()
-            }
-
-            fn rewrite_function_call(&mut self, func_call: FunctionCall) -> ExprImpl {
-                if let Some(index) = self.function_mapping.get(&func_call) {
-                    return InputRef::new(*index, func_call.return_type()).into();
-                }
-
-                let (func_type, inputs, ret) = func_call.decompose();
-                let inputs = inputs
-                    .into_iter()
-                    .map(|expr| self.rewrite_expr(expr))
-                    .collect();
-                FunctionCall::new_unchecked(func_type, inputs, ret).into()
-            }
-        }
-        let mut rewriter = Rewriter {
-            primary_to_secondary_mapping,
-            function_mapping,
-        };
+        let mut rewriter =
+            IndexExprRewriter::new_strict(primary_to_secondary_mapping, function_mapping);
 
         let new_predicate = self.predicate.clone().rewrite_expr(&mut rewriter);
 

--- a/src/frontend/src/optimizer/plan_node/logical_project.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_project.rs
@@ -33,6 +33,7 @@ use crate::optimizer::plan_node::{
     ColumnPruningContext, PredicatePushdownContext, RewriteStreamContext, ToStreamContext,
 };
 use crate::optimizer::property::{Distribution, Order, RequiredDist, StreamKind};
+use crate::optimizer::rule::IndexSelectionRule;
 use crate::session::current;
 use crate::utils::{ColIndexMapping, ColIndexMappingRewriteExt, Condition, Substitute};
 
@@ -101,6 +102,23 @@ impl LogicalProject {
 
     pub fn decompose(self) -> (Vec<ExprImpl>, PlanRef) {
         self.core.decompose()
+    }
+
+    pub(crate) fn clone_with_input_and_exprs(&self, input: PlanRef, exprs: Vec<ExprImpl>) -> Self {
+        let mut core = self.core.clone_with_input(input);
+        core.exprs = exprs;
+        // Replacing a computed expression with an input ref must not rename the output to the
+        // physical index column.
+        core.field_names = self
+            .schema()
+            .fields()
+            .iter()
+            .enumerate()
+            .map(|(index, field)| (index, field.name.clone()))
+            .collect();
+        let project = Self::with_core(core);
+        debug_assert_eq!(project.schema(), self.schema());
+        project
     }
 
     pub fn is_all_inputref(&self) -> bool {
@@ -225,6 +243,20 @@ impl ToBatch for LogicalProject {
     }
 
     fn to_batch_with_order_required(&self, required_order: &Order) -> Result<BatchPlanRef> {
+        if self
+            .base
+            .ctx()
+            .session_ctx()
+            .config()
+            .enable_index_selection()
+        {
+            if let Some(project) = IndexSelectionRule::select_expression_index_for_project(self) {
+                // The rewritten input is an index-table scan without its own indexes, so the
+                // recursive conversion cannot select another expression index.
+                return project.to_batch_with_order_required(required_order);
+            }
+        }
+
         let input_order = self
             .o2i_col_mapping()
             .rewrite_provided_order(required_order);

--- a/src/frontend/src/optimizer/plan_node/logical_project.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_project.rs
@@ -249,12 +249,11 @@ impl ToBatch for LogicalProject {
             .session_ctx()
             .config()
             .enable_index_selection()
+            && let Some(project) = IndexSelectionRule::select_expression_index_for_project(self)
         {
-            if let Some(project) = IndexSelectionRule::select_expression_index_for_project(self) {
-                // The rewritten input is an index-table scan without its own indexes, so the
-                // recursive conversion cannot select another expression index.
-                return project.to_batch_with_order_required(required_order);
-            }
+            // The rewritten input is an index-table scan without its own indexes, so the
+            // recursive conversion cannot select another expression index.
+            return project.to_batch_with_order_required(required_order);
         }
 
         let input_order = self

--- a/src/frontend/src/optimizer/rule/index_selection_rule.rs
+++ b/src/frontend/src/optimizer/rule/index_selection_rule.rs
@@ -47,8 +47,8 @@
 //! For index order key length > 5, we just ignore the rest.
 
 use std::cmp::min;
+use std::collections::HashMap;
 use std::collections::hash_map::Entry::{Occupied, Vacant};
-use std::collections::{BTreeMap, HashMap};
 use std::sync::Arc;
 
 use itertools::Itertools;
@@ -64,16 +64,16 @@ use risingwave_sqlparser::ast::AsOf;
 use super::prelude::{PlanRef, *};
 use crate::catalog::index_catalog::TableIndex;
 use crate::expr::{
-    Expr, ExprImpl, ExprRewriter, ExprType, ExprVisitor, FunctionCall, InputRef, to_conjunctions,
-    to_disjunctions,
+    Expr, ExprImpl, ExprRewriter, ExprType, ExprVisitor, FunctionCall, InputRef,
+    collect_input_refs, to_conjunctions, to_disjunctions,
 };
 use crate::optimizer::optimizer_context::OptimizerContextRef;
 use crate::optimizer::plan_node::generic::GenericPlanRef;
 use crate::optimizer::plan_node::{
-    ColumnPruningContext, LogicalJoin, LogicalScan, LogicalUnion, PlanTreeNode, PlanTreeNodeBinary,
-    PredicatePushdown, PredicatePushdownContext, generic,
+    ColumnPruningContext, LogicalJoin, LogicalProject, LogicalScan, LogicalUnion, PlanTreeNode,
+    PlanTreeNodeBinary, PlanTreeNodeUnary, PredicatePushdown, PredicatePushdownContext, generic,
 };
-use crate::utils::Condition;
+use crate::utils::{ColIndexMapping, Condition};
 
 const INDEX_MAX_LEN: usize = 5;
 const INDEX_COST_MATRIX: [[usize; INDEX_MAX_LEN]; 5] = [
@@ -92,9 +92,21 @@ pub struct IndexSelectionRule {}
 impl Rule<Logical> for IndexSelectionRule {
     fn apply(&self, plan: PlanRef) -> Option<PlanRef> {
         let logical_scan: &LogicalScan = plan.as_logical_scan()?;
+        self.select_index_access_path(logical_scan).0
+    }
+}
+
+impl IndexSelectionRule {
+    fn select_index_access_path(&self, logical_scan: &LogicalScan) -> (Option<PlanRef>, IndexCost) {
         let indexes = logical_scan.table_indexes();
         if indexes.is_empty() {
-            return None;
+            return (
+                None,
+                self.estimate_table_scan_cost(
+                    logical_scan,
+                    TableScanIoEstimator::estimate_row_size(logical_scan),
+                ),
+            );
         }
         let primary_table_row_size = TableScanIoEstimator::estimate_row_size(logical_scan);
         let primary_cost = min(
@@ -104,10 +116,10 @@ impl Rule<Logical> for IndexSelectionRule {
 
         // If it is a primary lookup plan, avoid checking other indexes.
         if primary_cost.primary_lookup {
-            return None;
+            return (None, primary_cost);
         }
 
-        let mut final_plan: PlanRef = logical_scan.clone().into();
+        let mut final_plan = None;
         let mut min_cost = primary_cost.clone();
 
         for index in indexes {
@@ -119,14 +131,14 @@ impl Rule<Logical> for IndexSelectionRule {
 
                 if index_cost.le(&min_cost) {
                     min_cost = index_cost;
-                    final_plan = index_scan.into();
+                    final_plan = Some(index_scan.into());
                 }
             } else {
                 // non-covering index selection
                 let (index_lookup, lookup_cost) = self.gen_index_lookup(logical_scan, index);
                 if lookup_cost.le(&min_cost) {
                     min_cost = lookup_cost;
-                    final_plan = index_lookup;
+                    final_plan = Some(index_lookup);
                 }
             }
         }
@@ -135,69 +147,110 @@ impl Rule<Logical> for IndexSelectionRule {
             && merge_index_cost.le(&min_cost)
         {
             min_cost = merge_index_cost;
-            final_plan = merge_index;
+            final_plan = Some(merge_index);
         }
 
-        if min_cost == primary_cost {
-            None
-        } else {
-            Some(final_plan)
+        (final_plan, min_cost)
+    }
+
+    pub(crate) fn select_expression_index_for_project(
+        logical_project: &LogicalProject,
+    ) -> Option<LogicalProject> {
+        // Scan-level index selection can only rewrite the predicate. Consider a covering index
+        // access path here so expressions materialized by an expression index can also replace
+        // matching function calls in the projection.
+        let input = logical_project.input();
+        let logical_scan = input.as_logical_scan()?;
+        if logical_scan.table_indexes().is_empty() {
+            return None;
         }
-    }
-}
 
-struct IndexPredicateRewriter<'a> {
-    p2s_mapping: &'a BTreeMap<usize, usize>,
-    function_mapping: &'a HashMap<FunctionCall, usize>,
-    offset: usize,
-    covered_by_index: bool,
-}
+        let rule = Self {};
+        let (_, mut min_cost) = rule.select_index_access_path(logical_scan);
+        let mut output_to_primary = ColIndexMapping::new(
+            logical_scan
+                .output_col_idx()
+                .iter()
+                .map(|index| Some(*index))
+                .collect(),
+            logical_scan.table().columns.len(),
+        );
+        let primary_exprs = logical_project
+            .exprs()
+            .iter()
+            .cloned()
+            .map(|expr| output_to_primary.rewrite_expr(expr))
+            .collect_vec();
 
-impl<'a> IndexPredicateRewriter<'a> {
-    fn new(
-        p2s_mapping: &'a BTreeMap<usize, usize>,
-        function_mapping: &'a HashMap<FunctionCall, usize>,
-        offset: usize,
-    ) -> Self {
-        Self {
-            p2s_mapping,
-            function_mapping,
-            offset,
-            covered_by_index: true,
-        }
-    }
+        let mut selected_project = None;
+        for index in logical_scan.table_indexes() {
+            let mut project_rewriter = generic::IndexExprRewriter::new_with_unmapped_input_offset(
+                index.primary_to_secondary_mapping(),
+                index.function_mapping(),
+                0,
+            );
+            let index_exprs = primary_exprs
+                .iter()
+                .cloned()
+                .map(|expr| project_rewriter.rewrite_expr(expr))
+                .collect_vec();
+            if !project_rewriter.covered_by_index()
+                || !project_rewriter.used_materialized_expression()
+            {
+                continue;
+            }
 
-    fn covered_by_index(&self) -> bool {
-        self.covered_by_index
-    }
-}
+            let mut predicate_rewriter = generic::IndexExprRewriter::new_with_unmapped_input_offset(
+                index.primary_to_secondary_mapping(),
+                index.function_mapping(),
+                0,
+            );
+            let index_predicate = logical_scan
+                .predicate()
+                .clone()
+                .rewrite_expr(&mut predicate_rewriter);
+            if !predicate_rewriter.covered_by_index() {
+                continue;
+            }
 
-impl ExprRewriter for IndexPredicateRewriter<'_> {
-    fn rewrite_input_ref(&mut self, input_ref: InputRef) -> ExprImpl {
-        // transform primary predicate to index predicate if it can
-        if self.p2s_mapping.contains_key(&input_ref.index) {
-            InputRef::new(
-                *self.p2s_mapping.get(&input_ref.index()).unwrap(),
-                input_ref.return_type(),
+            let output_col_idx =
+                collect_input_refs(index.index_table.columns.len(), index_exprs.iter())
+                    .ones()
+                    .collect_vec();
+            let mut index_to_output = ColIndexMapping::with_remaining_columns(
+                &output_col_idx,
+                index.index_table.columns.len(),
+            );
+            let project_exprs = index_exprs
+                .into_iter()
+                .map(|expr| index_to_output.rewrite_expr(expr))
+                .collect_vec();
+            let index_scan: LogicalScan = generic::TableScan::new(
+                output_col_idx,
+                index.index_table.clone(),
+                vec![],
+                vec![],
+                logical_scan.ctx(),
+                index_predicate,
+                logical_scan.as_of(),
             )
-            .into()
-        } else {
-            self.covered_by_index = false;
-            InputRef::new(input_ref.index() + self.offset, input_ref.return_type()).into()
-        }
-    }
+            .into();
 
-    fn rewrite_function_call(&mut self, func_call: FunctionCall) -> ExprImpl {
-        if let Some(index) = self.function_mapping.get(&func_call) {
-            return InputRef::new(*index, func_call.return_type()).into();
+            let index_cost = rule.estimate_table_scan_cost(
+                &index_scan,
+                TableScanIoEstimator::estimate_row_size(&index_scan),
+            );
+            if index_cost.le(&min_cost)
+                || (index_cost.same_cost(&min_cost) && selected_project.is_none())
+            {
+                min_cost = index_cost;
+                selected_project = Some(
+                    logical_project.clone_with_input_and_exprs(index_scan.into(), project_exprs),
+                );
+            }
         }
 
-        let (func_type, inputs, ret) = func_call.decompose();
-        let inputs = inputs
-            .into_iter()
-            .map(|expr| self.rewrite_expr(expr))
-            .collect();
-        FunctionCall::new_unchecked(func_type, inputs, ret).into()
+        selected_project
     }
 }
 
@@ -226,7 +279,7 @@ impl IndexSelectionRule {
         );
 
         let predicate = logical_scan.predicate().clone();
-        let mut rewriter = IndexPredicateRewriter::new(
+        let mut rewriter = generic::IndexExprRewriter::new_with_unmapped_input_offset(
             index.primary_to_secondary_mapping(),
             index.function_mapping(),
             offset,
@@ -613,7 +666,7 @@ impl IndexSelectionRule {
         ctx: OptimizerContextRef,
         as_of: Option<AsOf>,
     ) -> Option<PlanRef> {
-        let mut rewriter = IndexPredicateRewriter::new(
+        let mut rewriter = generic::IndexExprRewriter::new_with_unmapped_input_offset(
             index.primary_to_secondary_mapping(),
             index.function_mapping(),
             0,
@@ -959,6 +1012,10 @@ impl IndexCost {
 
     pub(crate) fn le(&self, other: &IndexCost) -> bool {
         self.cost < other.cost
+    }
+
+    fn same_cost(&self, other: &IndexCost) -> bool {
+        self.cost == other.cost
     }
 }
 

--- a/src/frontend/src/optimizer/rule/index_selection_rule.rs
+++ b/src/frontend/src/optimizer/rule/index_selection_rule.rs
@@ -120,7 +120,7 @@ impl IndexSelectionRule {
         }
 
         let mut final_plan = None;
-        let mut min_cost = primary_cost.clone();
+        let mut min_cost = primary_cost;
 
         for index in indexes {
             if let Some(index_scan) = logical_scan.to_index_scan_if_index_covered(index) {


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

This PR allows the batch optimizer to use materialized expression-index columns for matching expressions in a `SELECT` projection.

- Consider expression-index candidates for a `LogicalProject` directly above a `LogicalScan`.
- Rewrite matching projection expressions and scan predicates to the materialized index column while preserving the query's output schema.
- Keep the existing cost comparison and only select a covering expression index when it is competitive with the best existing access path.
- Share primary-to-secondary expression rewriting across covering scans, projections, lookup joins, and index merge.

This can avoid both recomputing an indexed expression and an unnecessary lookup back to the primary table. The optimization is currently limited to batch queries and exact expression matches.

Tests:

- `cargo +nightly-2026-06-11 check -p risingwave_frontend`
- `RUSTUP_TOOLCHAIN=nightly-2026-06-11 ./risedev run-planner-test index_selection`
- `RUSTUP_TOOLCHAIN=nightly-2026-06-11 ./risedev run-planner-test`

## Checklist

- [x] I have written necessary rustdoc comments.
- [x] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [x] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->

## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

Batch queries can now reuse materialized expression-index values in matching `SELECT` projections when the index is a cost-effective covering access path, avoiding redundant expression evaluation and primary-table lookups.

</details>
