### PR TITLE
fix(frontend): count(*) on iceberg tables must not ignore delete files

### DIFF
--- a/e2e_test/iceberg/test_case/pure_slt/iceberg_v3/iceberg_count_star_with_deletes.slt
+++ b/e2e_test/iceberg/test_case/pure_slt/iceberg_v3/iceberg_count_star_with_deletes.slt
@@ -1,0 +1,113 @@
+statement ok
+create secret count_star_secret with (
+  backend = 'meta'
+) as 'hummockadmin';
+
+statement ok
+create connection count_star_conn
+with (
+    type = 'iceberg',
+    warehouse.path = 's3://hummock001/iceberg_count_star_deletes',
+    s3.access.key = secret count_star_secret,
+    s3.secret.key = secret count_star_secret,
+    s3.endpoint = 'http://127.0.0.1:9301',
+    s3.region = 'us-west-2',
+    hosted_catalog = true
+);
+
+statement ok
+set iceberg_engine_connection = 'public.count_star_conn';
+
+# ---- Case 1: deletion vectors (V3 pk-index) -- the case that folds ----
+
+statement ok
+create table t_count_star_dv(id int primary key, v int)
+with(
+    commit_checkpoint_interval = 1,
+    format_version = 3,
+    enable_pk_index = 'true'
+) engine = iceberg;
+
+statement ok
+insert into t_count_star_dv select i, i from generate_series(1, 10) as t(i);
+
+statement ok
+flush;
+
+# No delete files yet: the metadata fast path (sum of data-file record_count) is correct.
+query I retry 6 backoff 1s
+select count(*) from t_count_star_dv;
+----
+10
+
+statement ok
+delete from t_count_star_dv where id % 2 = 0;
+
+statement ok
+flush;
+
+# The 5 deleted rows must NOT be counted. Before the fix this returned 10 (the pre-delete
+# data-file record_count).
+query I retry 6 backoff 1s
+select count(*) from t_count_star_dv;
+----
+5
+
+# count(*) must agree with count(id), a predicated count, and an actual row scan.
+query I
+select count(id) from t_count_star_dv;
+----
+5
+
+query I
+select count(*) from t_count_star_dv where id > 0;
+----
+5
+
+query I
+select count(*) from (select id from t_count_star_dv order by id) x;
+----
+5
+
+statement ok
+drop table t_count_star_dv;
+
+# ---- Case 2 (sanity): equality deletes read via anti-join, never folded ----
+
+statement ok
+create table t_count_star_eq(id int primary key, v int)
+with(
+    commit_checkpoint_interval = 1,
+    format_version = 3
+) engine = iceberg;
+
+statement ok
+insert into t_count_star_eq select i, i from generate_series(1, 10) as t(i);
+
+statement ok
+flush;
+
+statement ok
+delete from t_count_star_eq where id % 2 = 0;
+
+statement ok
+flush;
+
+query I retry 6 backoff 1s
+select count(*) from t_count_star_eq;
+----
+5
+
+query I
+select count(id) from t_count_star_eq;
+----
+5
+
+statement ok
+drop table t_count_star_eq;
+
+statement ok
+drop connection count_star_conn;
+
+statement ok
+drop secret count_star_secret;

--- a/src/frontend/src/optimizer/rule/iceberg_count_star_rule.rs
+++ b/src/frontend/src/optimizer/rule/iceberg_count_star_rule.rs
@@ -38,6 +38,14 @@ impl Rule<Logical> for IcebergCountStarRule {
             if iceberg_scan.task.predicate().is_some() {
                 return None;
             }
+            if iceberg_scan
+                .task
+                .tasks()
+                .iter()
+                .any(|task| !task.deletes.is_empty())
+            {
+                return None;
+            }
             let count: i64 = iceberg_scan
                 .task
                 .tasks()


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

<!--

**Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

Iceberg sources that only include position delete files (no eq delete) will return incorrect `select count(*)` values. This PR fixes it.

Most iceberg V2 table will use eq delete, so this bug will only affect few cases.

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
