### PR TITLE
fix(common): store jsonb array values independently

### DIFF
--- a/src/common/src/array/jsonb_array.rs
+++ b/src/common/src/array/jsonb_array.rs
@@ -17,23 +17,22 @@ use std::mem::size_of;
 use risingwave_common_estimate_size::EstimateSize;
 use risingwave_pb::data::{PbArray, PbArrayType};
 
-use super::{Array, ArrayBuilder, ArrayError, ArrayImpl, ArrayResult};
-use crate::bitmap::{Bitmap, BitmapBuilder};
-use crate::types::{DataType, JsonbRef, JsonbVal, Scalar};
-use crate::util::iter_util::ZipEqDebug;
+use super::{
+    Array, ArrayBuilder, ArrayError, ArrayImpl, ArrayResult, BytesArray, BytesArrayBuilder,
+};
+use crate::bitmap::Bitmap;
+use crate::types::{DataType, JsonbRef, JsonbVal};
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, EstimateSize)]
 pub struct JsonbArrayBuilder {
-    bitmap: BitmapBuilder,
-    /// Each row is an independent JSONB value. In particular, the internal offsets of a JSONB
-    /// value are never shared by multiple rows.
-    data: Vec<Option<JsonbVal>>,
+    bytes: BytesArrayBuilder,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, EstimateSize)]
 pub struct JsonbArray {
-    bitmap: Bitmap,
-    data: Box<[Option<JsonbVal>]>,
+    /// Each row is an independently encoded JSONB value in a contiguous byte buffer. In
+    /// particular, the internal offsets of a JSONB value are never shared by multiple rows.
+    bytes: BytesArray,
 }
 
 impl ArrayBuilder for JsonbArrayBuilder {
@@ -41,8 +40,7 @@ impl ArrayBuilder for JsonbArrayBuilder {
 
     fn new(capacity: usize) -> Self {
         Self {
-            bitmap: BitmapBuilder::with_capacity(capacity),
-            data: Vec::with_capacity(capacity),
+            bytes: BytesArrayBuilder::new(capacity),
         }
     }
 
@@ -52,51 +50,32 @@ impl ArrayBuilder for JsonbArrayBuilder {
     }
 
     fn append_n(&mut self, n: usize, value: Option<<Self::ArrayType as Array>::RefItem<'_>>) {
-        if n == 0 {
-            return;
+        match value {
+            Some(value) => {
+                for _ in 0..n {
+                    self.append_value(value);
+                }
+            }
+            None => self.bytes.append_n(n, None),
         }
-        self.bitmap.append_n(n, value.is_some());
-        self.data
-            .extend(std::iter::repeat_n(value.map(JsonbVal::from), n));
-    }
-
-    fn append_owned(&mut self, value: Option<<Self::ArrayType as Array>::OwnedItem>) {
-        self.bitmap.append(value.is_some());
-        self.data.push(value);
     }
 
     fn append_array(&mut self, other: &Self::ArrayType) {
-        self.bitmap.append_bitmap(&other.bitmap);
-        self.data.extend_from_slice(&other.data);
+        self.bytes.append_array(&other.bytes);
     }
 
     fn pop(&mut self) -> Option<()> {
-        self.bitmap.pop()?;
-        self.data.pop().unwrap();
-        Some(())
+        self.bytes.pop()
     }
 
     fn len(&self) -> usize {
-        self.bitmap.len()
+        self.bytes.len()
     }
 
     fn finish(self) -> Self::ArrayType {
         Self::ArrayType {
-            bitmap: self.bitmap.finish(),
-            data: self.data.into_boxed_slice(),
+            bytes: self.bytes.finish(),
         }
-    }
-}
-
-impl EstimateSize for JsonbArrayBuilder {
-    fn estimated_heap_size(&self) -> usize {
-        self.bitmap.estimated_heap_size()
-            + self.data.capacity() * size_of::<Option<JsonbVal>>()
-            + self
-                .data
-                .iter()
-                .map(EstimateSize::estimated_heap_size)
-                .sum::<usize>()
     }
 }
 
@@ -104,55 +83,37 @@ impl JsonbArrayBuilder {
     pub fn writer(&mut self) -> JsonbWriter<'_> {
         JsonbWriter::new(self)
     }
+
+    fn append_value(&mut self, value: JsonbRef<'_>) {
+        let (entry, data) = value.0.to_raw_parts();
+        let mut writer = self.bytes.writer();
+        writer.write_ref(data);
+        writer.write_ref(entry.as_bytes());
+        writer.finish();
+    }
+
+    fn append_encoded(&mut self, encoded: &[u8]) {
+        self.bytes.append(Some(encoded));
+    }
 }
 
 impl JsonbArray {
     /// Loads a `JsonbArray` from a protobuf array.
     ///
-    /// The two-buffer encoding stores independent JSONB values. The one-buffer encoding is kept
-    /// for compatibility with payloads produced when the whole column was one JSONB array.
-    ///
     /// See also `JsonbArray::to_protobuf`.
     pub fn from_protobuf(array: &PbArray, cardinality: usize) -> ArrayResult<ArrayImpl> {
         let bitmap: Bitmap = array.get_null_bitmap()?.into();
         ensure_eq!(bitmap.len(), cardinality);
+        ensure_eq!(array.values.len(), 2);
 
-        let data = match array.values.as_slice() {
-            [legacy] => Self::decode_legacy_values(&legacy.body, &bitmap, cardinality)?,
-            [offsets, values] => Self::decode_values(&offsets.body, &values.body, &bitmap)?,
-            _ => {
-                return Err(ArrayError::internal(
-                    "Must have exactly 1 or 2 buffers in a jsonb array",
-                ));
-            }
-        };
-
-        Ok(JsonbArray { bitmap, data }.into())
-    }
-
-    fn decode_legacy_values(
-        encoded: &[u8],
-        bitmap: &Bitmap,
-        cardinality: usize,
-    ) -> ArrayResult<Box<[Option<JsonbVal>]>> {
-        let value = jsonbb::Value::from_bytes(encoded);
-        let values = value
-            .as_array()
-            .ok_or_else(|| ArrayError::internal("legacy jsonb array is not an array"))?;
-        ensure_eq!(values.len(), cardinality);
-
-        Ok(bitmap
-            .iter()
-            .zip_eq_debug(values.iter())
-            .map(|(not_null, value)| not_null.then(|| JsonbVal::from(JsonbRef(value))))
-            .collect())
+        Self::decode_values(&array.values[0].body, &array.values[1].body, &bitmap)
     }
 
     fn decode_values(
         encoded_offsets: &[u8],
         encoded_values: &[u8],
         bitmap: &Bitmap,
-    ) -> ArrayResult<Box<[Option<JsonbVal>]>> {
+    ) -> ArrayResult<ArrayImpl> {
         let expected_offset_count = bitmap.count_ones() + 1;
         ensure_eq!(
             encoded_offsets.len(),
@@ -166,10 +127,10 @@ impl JsonbArray {
         let mut previous = offsets.next().unwrap();
         ensure_eq!(previous, 0);
 
-        let mut data = Vec::with_capacity(bitmap.len());
+        let mut builder = JsonbArrayBuilder::new(bitmap.len());
         for not_null in bitmap.iter() {
             if !not_null {
-                data.push(None);
+                builder.append_null();
                 continue;
             }
 
@@ -180,9 +141,8 @@ impl JsonbArray {
             let end = usize::try_from(next)
                 .map_err(|_| ArrayError::internal("jsonb offset does not fit usize"))?;
             ensure!(end <= encoded_values.len(), "jsonb offset is out of bounds");
-            data.push(Some(JsonbVal::from(jsonbb::Value::from_bytes(
-                &encoded_values[start..end],
-            ))));
+            ensure!(end - start >= size_of::<u32>(), "jsonb value is too short");
+            builder.append_encoded(&encoded_values[start..end]);
             previous = next;
         }
 
@@ -190,19 +150,7 @@ impl JsonbArray {
         let final_offset = usize::try_from(previous)
             .map_err(|_| ArrayError::internal("jsonb offset does not fit usize"))?;
         ensure_eq!(final_offset, encoded_values.len());
-        Ok(data.into_boxed_slice())
-    }
-}
-
-impl EstimateSize for JsonbArray {
-    fn estimated_heap_size(&self) -> usize {
-        self.bitmap.estimated_heap_size()
-            + self.data.len() * size_of::<Option<JsonbVal>>()
-            + self
-                .data
-                .iter()
-                .map(EstimateSize::estimated_heap_size)
-                .sum::<usize>()
+        Ok(builder.finish().into())
     }
 }
 
@@ -212,64 +160,38 @@ impl Array for JsonbArray {
     type RefItem<'a> = JsonbRef<'a>;
 
     unsafe fn raw_value_at_unchecked(&self, idx: usize) -> Self::RefItem<'_> {
-        match unsafe { self.data.get_unchecked(idx) } {
-            Some(value) => value.as_scalar_ref(),
-            None => JsonbRef::null(),
+        let encoded = unsafe { self.bytes.raw_value_at_unchecked(idx) };
+        if encoded.is_empty() {
+            // The raw value for a SQL NULL is the default JSONB value.
+            JsonbRef::null()
+        } else {
+            JsonbRef(jsonbb::ValueRef::from_bytes(encoded))
         }
     }
 
     fn len(&self) -> usize {
-        self.bitmap.len()
+        self.bytes.len()
     }
 
     fn to_protobuf(&self) -> PbArray {
-        // Each non-null value is encoded separately. This prevents jsonbb's per-value offset limit
-        // from applying to the whole column.
-        use risingwave_pb::common::Buffer;
-        use risingwave_pb::common::buffer::CompressionType;
-
-        let mut offset_buffer =
-            Vec::with_capacity((self.bitmap.count_ones() + 1) * size_of::<u64>());
-        let mut data_buffer = Vec::new();
-        let jsonb_null = JsonbVal::null();
-
-        for (value, not_null) in self.data.iter().zip_eq_debug(self.bitmap.iter()) {
-            if !not_null {
-                continue;
-            }
-            offset_buffer.extend_from_slice(&(data_buffer.len() as u64).to_be_bytes());
-            data_buffer.extend_from_slice(value.as_ref().unwrap_or(&jsonb_null).0.as_bytes());
-        }
-        offset_buffer.extend_from_slice(&(data_buffer.len() as u64).to_be_bytes());
-
+        // The byte-array offsets delimit independently encoded JSONB values. Therefore jsonbb's
+        // per-value offset limit does not apply to the whole column.
         PbArray {
-            null_bitmap: Some(self.null_bitmap().to_protobuf()),
-            values: vec![
-                Buffer {
-                    compression: CompressionType::None as i32,
-                    body: offset_buffer,
-                },
-                Buffer {
-                    compression: CompressionType::None as i32,
-                    body: data_buffer,
-                },
-            ],
             array_type: PbArrayType::Jsonb as i32,
-            struct_array_data: None,
-            list_array_data: None,
+            ..self.bytes.to_protobuf()
         }
     }
 
     fn null_bitmap(&self) -> &Bitmap {
-        &self.bitmap
+        self.bytes.null_bitmap()
     }
 
     fn into_null_bitmap(self) -> Bitmap {
-        self.bitmap
+        self.bytes.into_null_bitmap()
     }
 
     fn set_bitmap(&mut self, bitmap: Bitmap) {
-        self.bitmap = bitmap;
+        self.bytes.set_bitmap(bitmap);
     }
 
     fn data_type(&self) -> DataType {
@@ -319,7 +241,8 @@ impl JsonbWriter<'_> {
             array_builder,
             builder,
         } = self;
-        array_builder.append_owned(Some(JsonbVal::from(builder.finish())));
+        let value = builder.finish();
+        array_builder.append_encoded(value.as_bytes());
     }
 
     /// Discards the partially built value.
@@ -328,10 +251,8 @@ impl JsonbWriter<'_> {
 
 #[cfg(test)]
 mod tests {
-    use risingwave_pb::common::Buffer;
-    use risingwave_pb::common::buffer::CompressionType;
-
     use super::*;
+    use crate::types::Scalar;
 
     fn json(value: &str) -> JsonbVal {
         value.parse().unwrap()
@@ -347,8 +268,16 @@ mod tests {
         ]);
 
         assert_eq!(array.len(), 4);
+        assert_eq!(
+            array.value_at(0).unwrap(),
+            json(r#"{"a": 1}"#).as_scalar_ref()
+        );
         assert!(array.value_at(1).is_none());
         assert!(array.value_at(2).unwrap().is_jsonb_null());
+        assert_eq!(
+            array.value_at(3).unwrap(),
+            json(r#"[1, 2, 3]"#).as_scalar_ref()
+        );
 
         let protobuf = array.to_protobuf();
         assert_eq!(protobuf.values.len(), 2);
@@ -356,36 +285,6 @@ mod tests {
 
         let decoded = JsonbArray::from_protobuf(&protobuf, array.len()).unwrap();
         assert_eq!(decoded.as_jsonb(), &array);
-    }
-
-    #[test]
-    fn test_decode_legacy_single_jsonb_array() {
-        let expected =
-            JsonbArray::from_iter([Some(json(r#"{"a": 1}"#)), None, Some(JsonbVal::null())]);
-
-        let mut legacy_builder = jsonbb::Builder::<Vec<u8>>::new();
-        legacy_builder.begin_array();
-        for value in &expected.data {
-            match value {
-                Some(value) => legacy_builder.add_value(value.as_scalar_ref().0),
-                None => legacy_builder.add_null(),
-            }
-        }
-        legacy_builder.end_array();
-
-        let protobuf = PbArray {
-            null_bitmap: Some(expected.null_bitmap().to_protobuf()),
-            values: vec![Buffer {
-                compression: CompressionType::None as i32,
-                body: legacy_builder.finish().as_bytes().to_vec(),
-            }],
-            array_type: PbArrayType::Jsonb as i32,
-            struct_array_data: None,
-            list_array_data: None,
-        };
-
-        let decoded = JsonbArray::from_protobuf(&protobuf, expected.len()).unwrap();
-        assert_eq!(decoded.as_jsonb(), &expected);
     }
 
     #[test]

--- a/src/common/src/array/jsonb_array.rs
+++ b/src/common/src/array/jsonb_array.rs
@@ -80,10 +80,6 @@ impl ArrayBuilder for JsonbArrayBuilder {
 }
 
 impl JsonbArrayBuilder {
-    pub fn writer(&mut self) -> JsonbWriter<'_> {
-        JsonbWriter::new(self)
-    }
-
     /// Appends the standalone jsonbb encoding of `value`.
     ///
     /// A jsonbb value is encoded as its data followed by a four-byte root entry. `to_raw_parts`
@@ -221,39 +217,6 @@ impl FromIterator<JsonbVal> for JsonbArray {
     }
 }
 
-/// Builds one independent JSONB value for a row. Dropping or rolling back an unfinished writer
-/// simply discards that value and cannot affect previously appended rows.
-pub struct JsonbWriter<'a> {
-    array_builder: &'a mut JsonbArrayBuilder,
-    builder: jsonbb::Builder,
-}
-
-impl JsonbWriter<'_> {
-    pub fn new(array_builder: &mut JsonbArrayBuilder) -> JsonbWriter<'_> {
-        JsonbWriter {
-            array_builder,
-            builder: jsonbb::Builder::<Vec<u8>>::new(),
-        }
-    }
-
-    pub fn inner(&mut self) -> &mut jsonbb::Builder {
-        &mut self.builder
-    }
-
-    /// Commits the completed value as one row.
-    pub fn finish(self) {
-        let JsonbWriter {
-            array_builder,
-            builder,
-        } = self;
-        let value = builder.finish();
-        array_builder.append_value(JsonbRef(value.as_ref()));
-    }
-
-    /// Discards the partially built value.
-    pub fn rollback(self) {}
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -310,33 +273,5 @@ mod tests {
 
         let array = JsonbArray::from_iter(values);
         assert_eq!(array.to_protobuf().values[1].body, expected);
-    }
-
-    #[test]
-    fn test_writer_commit_and_rollback_are_isolated() {
-        let mut builder = JsonbArrayBuilder::new(3);
-        {
-            let mut writer = builder.writer();
-            writer.inner().add_string("committed");
-            writer.finish();
-        }
-        {
-            let mut writer = builder.writer();
-            writer.inner().add_string("rolled back");
-            writer.rollback();
-        }
-        builder.append_null();
-        {
-            let mut writer = builder.writer();
-            writer.inner().add_string("dropped");
-        }
-
-        let array = builder.finish();
-        assert_eq!(array.len(), 2);
-        assert_eq!(
-            array.value_at(0).unwrap(),
-            json(r#""committed""#).as_scalar_ref()
-        );
-        assert!(array.value_at(1).is_none());
     }
 }

--- a/src/common/src/array/jsonb_array.rs
+++ b/src/common/src/array/jsonb_array.rs
@@ -12,37 +12,37 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::mem::ManuallyDrop;
+use std::mem::size_of;
 
 use risingwave_common_estimate_size::EstimateSize;
 use risingwave_pb::data::{PbArray, PbArrayType};
 
-use super::{Array, ArrayBuilder, ArrayImpl, ArrayResult};
+use super::{Array, ArrayBuilder, ArrayError, ArrayImpl, ArrayResult};
 use crate::bitmap::{Bitmap, BitmapBuilder};
 use crate::types::{DataType, JsonbRef, JsonbVal, Scalar};
+use crate::util::iter_util::ZipEqDebug;
 
-#[derive(Debug, Clone, EstimateSize)]
+#[derive(Debug, Clone)]
 pub struct JsonbArrayBuilder {
     bitmap: BitmapBuilder,
-    builder: jsonbb::Builder,
+    /// Each row is an independent JSONB value. In particular, the internal offsets of a JSONB
+    /// value are never shared by multiple rows.
+    data: Vec<Option<JsonbVal>>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, EstimateSize)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct JsonbArray {
     bitmap: Bitmap,
-    /// Elements are stored as a single JSONB array value.
-    data: jsonbb::Value,
+    data: Box<[Option<JsonbVal>]>,
 }
 
 impl ArrayBuilder for JsonbArrayBuilder {
     type ArrayType = JsonbArray;
 
     fn new(capacity: usize) -> Self {
-        let mut builder = jsonbb::Builder::with_capacity(capacity);
-        builder.begin_array();
         Self {
             bitmap: BitmapBuilder::with_capacity(capacity),
-            builder,
+            data: Vec::with_capacity(capacity),
         }
     }
 
@@ -52,34 +52,27 @@ impl ArrayBuilder for JsonbArrayBuilder {
     }
 
     fn append_n(&mut self, n: usize, value: Option<<Self::ArrayType as Array>::RefItem<'_>>) {
-        match value {
-            Some(x) => {
-                self.bitmap.append_n(n, true);
-                for _ in 0..n {
-                    self.builder.add_value(x.0);
-                }
-            }
-            None => {
-                self.bitmap.append_n(n, false);
-                for _ in 0..n {
-                    self.builder.add_null();
-                }
-            }
+        if n == 0 {
+            return;
         }
+        self.bitmap.append_n(n, value.is_some());
+        self.data
+            .extend(std::iter::repeat_n(value.map(JsonbVal::from), n));
+    }
+
+    fn append_owned(&mut self, value: Option<<Self::ArrayType as Array>::OwnedItem>) {
+        self.bitmap.append(value.is_some());
+        self.data.push(value);
     }
 
     fn append_array(&mut self, other: &Self::ArrayType) {
-        for bit in other.bitmap.iter() {
-            self.bitmap.append(bit);
-        }
-        for value in other.data.as_array().unwrap().iter() {
-            self.builder.add_value(value);
-        }
+        self.bitmap.append_bitmap(&other.bitmap);
+        self.data.extend_from_slice(&other.data);
     }
 
     fn pop(&mut self) -> Option<()> {
         self.bitmap.pop()?;
-        self.builder.pop();
+        self.data.pop().unwrap();
         Some(())
     }
 
@@ -87,12 +80,23 @@ impl ArrayBuilder for JsonbArrayBuilder {
         self.bitmap.len()
     }
 
-    fn finish(mut self) -> Self::ArrayType {
-        self.builder.end_array();
+    fn finish(self) -> Self::ArrayType {
         Self::ArrayType {
             bitmap: self.bitmap.finish(),
-            data: self.builder.finish(),
+            data: self.data.into_boxed_slice(),
         }
+    }
+}
+
+impl EstimateSize for JsonbArrayBuilder {
+    fn estimated_heap_size(&self) -> usize {
+        self.bitmap.estimated_heap_size()
+            + self.data.capacity() * size_of::<Option<JsonbVal>>()
+            + self
+                .data
+                .iter()
+                .map(EstimateSize::estimated_heap_size)
+                .sum::<usize>()
     }
 }
 
@@ -105,17 +109,100 @@ impl JsonbArrayBuilder {
 impl JsonbArray {
     /// Loads a `JsonbArray` from a protobuf array.
     ///
+    /// The two-buffer encoding stores independent JSONB values. The one-buffer encoding is kept
+    /// for compatibility with payloads produced when the whole column was one JSONB array.
+    ///
     /// See also `JsonbArray::to_protobuf`.
-    pub fn from_protobuf(array: &PbArray) -> ArrayResult<ArrayImpl> {
-        ensure!(
-            array.values.len() == 1,
-            "Must have exactly 1 buffer in a jsonb array"
-        );
-        let arr = JsonbArray {
-            bitmap: array.get_null_bitmap()?.into(),
-            data: jsonbb::Value::from_bytes(&array.values[0].body),
+    pub fn from_protobuf(array: &PbArray, cardinality: usize) -> ArrayResult<ArrayImpl> {
+        let bitmap: Bitmap = array.get_null_bitmap()?.into();
+        ensure_eq!(bitmap.len(), cardinality);
+
+        let data = match array.values.as_slice() {
+            [legacy] => Self::decode_legacy_values(&legacy.body, &bitmap, cardinality)?,
+            [offsets, values] => Self::decode_values(&offsets.body, &values.body, &bitmap)?,
+            _ => {
+                return Err(ArrayError::internal(
+                    "Must have exactly 1 or 2 buffers in a jsonb array",
+                ));
+            }
         };
-        Ok(arr.into())
+
+        Ok(JsonbArray { bitmap, data }.into())
+    }
+
+    fn decode_legacy_values(
+        encoded: &[u8],
+        bitmap: &Bitmap,
+        cardinality: usize,
+    ) -> ArrayResult<Box<[Option<JsonbVal>]>> {
+        let value = jsonbb::Value::from_bytes(encoded);
+        let values = value
+            .as_array()
+            .ok_or_else(|| ArrayError::internal("legacy jsonb array is not an array"))?;
+        ensure_eq!(values.len(), cardinality);
+
+        Ok(bitmap
+            .iter()
+            .zip_eq_debug(values.iter())
+            .map(|(not_null, value)| not_null.then(|| JsonbVal::from(JsonbRef(value))))
+            .collect())
+    }
+
+    fn decode_values(
+        encoded_offsets: &[u8],
+        encoded_values: &[u8],
+        bitmap: &Bitmap,
+    ) -> ArrayResult<Box<[Option<JsonbVal>]>> {
+        let expected_offset_count = bitmap.count_ones() + 1;
+        ensure_eq!(
+            encoded_offsets.len(),
+            expected_offset_count * size_of::<u64>()
+        );
+
+        let mut offsets = encoded_offsets.chunks_exact(size_of::<u64>()).map(|bytes| {
+            let bytes: [u8; size_of::<u64>()] = bytes.try_into().unwrap();
+            u64::from_be_bytes(bytes)
+        });
+        let mut previous = offsets.next().unwrap();
+        ensure_eq!(previous, 0);
+
+        let mut data = Vec::with_capacity(bitmap.len());
+        for not_null in bitmap.iter() {
+            if !not_null {
+                data.push(None);
+                continue;
+            }
+
+            let next = offsets.next().unwrap();
+            ensure!(previous <= next, "jsonb offsets must be non-decreasing");
+            let start = usize::try_from(previous)
+                .map_err(|_| ArrayError::internal("jsonb offset does not fit usize"))?;
+            let end = usize::try_from(next)
+                .map_err(|_| ArrayError::internal("jsonb offset does not fit usize"))?;
+            ensure!(end <= encoded_values.len(), "jsonb offset is out of bounds");
+            data.push(Some(JsonbVal::from(jsonbb::Value::from_bytes(
+                &encoded_values[start..end],
+            ))));
+            previous = next;
+        }
+
+        ensure!(offsets.next().is_none(), "too many jsonb offsets");
+        let final_offset = usize::try_from(previous)
+            .map_err(|_| ArrayError::internal("jsonb offset does not fit usize"))?;
+        ensure_eq!(final_offset, encoded_values.len());
+        Ok(data.into_boxed_slice())
+    }
+}
+
+impl EstimateSize for JsonbArray {
+    fn estimated_heap_size(&self) -> usize {
+        self.bitmap.estimated_heap_size()
+            + self.data.len() * size_of::<Option<JsonbVal>>()
+            + self
+                .data
+                .iter()
+                .map(EstimateSize::estimated_heap_size)
+                .sum::<usize>()
     }
 }
 
@@ -125,7 +212,10 @@ impl Array for JsonbArray {
     type RefItem<'a> = JsonbRef<'a>;
 
     unsafe fn raw_value_at_unchecked(&self, idx: usize) -> Self::RefItem<'_> {
-        JsonbRef(self.data.as_array().unwrap().get(idx).unwrap())
+        match unsafe { self.data.get_unchecked(idx) } {
+            Some(value) => value.as_scalar_ref(),
+            None => JsonbRef::null(),
+        }
     }
 
     fn len(&self) -> usize {
@@ -133,15 +223,37 @@ impl Array for JsonbArray {
     }
 
     fn to_protobuf(&self) -> PbArray {
+        // Each non-null value is encoded separately. This prevents jsonbb's per-value offset limit
+        // from applying to the whole column.
         use risingwave_pb::common::Buffer;
         use risingwave_pb::common::buffer::CompressionType;
 
+        let mut offset_buffer =
+            Vec::with_capacity((self.bitmap.count_ones() + 1) * size_of::<u64>());
+        let mut data_buffer = Vec::new();
+        let jsonb_null = JsonbVal::null();
+
+        for (value, not_null) in self.data.iter().zip_eq_debug(self.bitmap.iter()) {
+            if !not_null {
+                continue;
+            }
+            offset_buffer.extend_from_slice(&(data_buffer.len() as u64).to_be_bytes());
+            data_buffer.extend_from_slice(value.as_ref().unwrap_or(&jsonb_null).0.as_bytes());
+        }
+        offset_buffer.extend_from_slice(&(data_buffer.len() as u64).to_be_bytes());
+
         PbArray {
             null_bitmap: Some(self.null_bitmap().to_protobuf()),
-            values: vec![Buffer {
-                compression: CompressionType::None as i32,
-                body: self.data.as_bytes().to_vec(),
-            }],
+            values: vec![
+                Buffer {
+                    compression: CompressionType::None as i32,
+                    body: offset_buffer,
+                },
+                Buffer {
+                    compression: CompressionType::None as i32,
+                    body: data_buffer,
+                },
+            ],
             array_type: PbArrayType::Jsonb as i32,
             struct_array_data: None,
             list_array_data: None,
@@ -169,11 +281,8 @@ impl FromIterator<Option<JsonbVal>> for JsonbArray {
     fn from_iter<I: IntoIterator<Item = Option<JsonbVal>>>(iter: I) -> Self {
         let iter = iter.into_iter();
         let mut builder = <Self as Array>::Builder::new(iter.size_hint().0);
-        for i in iter {
-            match i {
-                Some(x) => builder.append(Some(x.as_scalar_ref())),
-                None => builder.append(None),
-            }
+        for value in iter {
+            builder.append_owned(value);
         }
         builder.finish()
     }
@@ -185,47 +294,125 @@ impl FromIterator<JsonbVal> for JsonbArray {
     }
 }
 
-/// Note: Dropping an unfinished `JsonbWriter` will roll back any partially
-/// written elements to the saved checkpoint. Callers must not pop entries
-/// beyond the checkpoint captured when the writer was created; doing so may
-/// leave the array in an inconsistent state.
+/// Builds one independent JSONB value for a row. Dropping or rolling back an unfinished writer
+/// simply discards that value and cannot affect previously appended rows.
 pub struct JsonbWriter<'a> {
     array_builder: &'a mut JsonbArrayBuilder,
-    checkpoint: jsonbb::Checkpoint,
+    builder: jsonbb::Builder,
 }
 
 impl JsonbWriter<'_> {
     pub fn new(array_builder: &mut JsonbArrayBuilder) -> JsonbWriter<'_> {
-        let checkpoint = array_builder.builder.checkpoint();
         JsonbWriter {
             array_builder,
-            checkpoint,
+            builder: jsonbb::Builder::<Vec<u8>>::new(),
         }
     }
 
     pub fn inner(&mut self) -> &mut jsonbb::Builder {
-        &mut self.array_builder.builder
+        &mut self.builder
     }
 
-    /// `finish` will be called when the entire record is successfully written.
-    /// The partial data was committed and the `builder` can no longer be used.
+    /// Commits the completed value as one row.
     pub fn finish(self) {
-        self.array_builder.bitmap.append(true);
-        let _ = ManuallyDrop::new(self); // Prevent drop
+        let JsonbWriter {
+            array_builder,
+            builder,
+        } = self;
+        array_builder.append_owned(Some(JsonbVal::from(builder.finish())));
     }
 
-    /// `rollback` will be called while the entire record is abandoned.
-    /// The partial data was cleaned and the `builder` can be safely used.
-    pub fn rollback(self) {
-        self.array_builder.builder.rollback_to(&self.checkpoint);
-        let _ = ManuallyDrop::new(self); // Prevent drop
-    }
+    /// Discards the partially built value.
+    pub fn rollback(self) {}
 }
 
-impl Drop for JsonbWriter<'_> {
-    /// If the writer is dropped without calling `finish` or `rollback`,
-    /// we rollback the partial data by default.
-    fn drop(&mut self) {
-        self.array_builder.builder.rollback_to(&self.checkpoint);
+#[cfg(test)]
+mod tests {
+    use risingwave_pb::common::Buffer;
+    use risingwave_pb::common::buffer::CompressionType;
+
+    use super::*;
+
+    fn json(value: &str) -> JsonbVal {
+        value.parse().unwrap()
+    }
+
+    #[test]
+    fn test_independent_values_and_protobuf_roundtrip() {
+        let array = JsonbArray::from_iter([
+            Some(json(r#"{"a": 1}"#)),
+            None,
+            Some(JsonbVal::null()),
+            Some(json(r#"[1, 2, 3]"#)),
+        ]);
+
+        assert_eq!(array.len(), 4);
+        assert!(array.value_at(1).is_none());
+        assert!(array.value_at(2).unwrap().is_jsonb_null());
+
+        let protobuf = array.to_protobuf();
+        assert_eq!(protobuf.values.len(), 2);
+        assert_eq!(protobuf.values[0].body.len(), 4 * size_of::<u64>());
+
+        let decoded = JsonbArray::from_protobuf(&protobuf, array.len()).unwrap();
+        assert_eq!(decoded.as_jsonb(), &array);
+    }
+
+    #[test]
+    fn test_decode_legacy_single_jsonb_array() {
+        let expected =
+            JsonbArray::from_iter([Some(json(r#"{"a": 1}"#)), None, Some(JsonbVal::null())]);
+
+        let mut legacy_builder = jsonbb::Builder::<Vec<u8>>::new();
+        legacy_builder.begin_array();
+        for value in &expected.data {
+            match value {
+                Some(value) => legacy_builder.add_value(value.as_scalar_ref().0),
+                None => legacy_builder.add_null(),
+            }
+        }
+        legacy_builder.end_array();
+
+        let protobuf = PbArray {
+            null_bitmap: Some(expected.null_bitmap().to_protobuf()),
+            values: vec![Buffer {
+                compression: CompressionType::None as i32,
+                body: legacy_builder.finish().as_bytes().to_vec(),
+            }],
+            array_type: PbArrayType::Jsonb as i32,
+            struct_array_data: None,
+            list_array_data: None,
+        };
+
+        let decoded = JsonbArray::from_protobuf(&protobuf, expected.len()).unwrap();
+        assert_eq!(decoded.as_jsonb(), &expected);
+    }
+
+    #[test]
+    fn test_writer_commit_and_rollback_are_isolated() {
+        let mut builder = JsonbArrayBuilder::new(3);
+        {
+            let mut writer = builder.writer();
+            writer.inner().add_string("committed");
+            writer.finish();
+        }
+        {
+            let mut writer = builder.writer();
+            writer.inner().add_string("rolled back");
+            writer.rollback();
+        }
+        builder.append_null();
+        {
+            let mut writer = builder.writer();
+            writer.inner().add_string("dropped");
+        }
+
+        let array = builder.finish();
+        assert_eq!(array.len(), 2);
+        assert_eq!(
+            array.value_at(0).unwrap(),
+            json(r#""committed""#).as_scalar_ref()
+        );
+        assert!(array.value_at(1).is_none());
     }
 }

--- a/src/common/src/array/jsonb_array.rs
+++ b/src/common/src/array/jsonb_array.rs
@@ -84,6 +84,11 @@ impl JsonbArrayBuilder {
         JsonbWriter::new(self)
     }
 
+    /// Appends the standalone jsonbb encoding of `value`.
+    ///
+    /// A jsonbb value is encoded as its data followed by a four-byte root entry. `to_raw_parts`
+    /// rebuilds that entry relative to the returned data slice, which also makes a nested
+    /// `JsonbRef` independent from the value it was extracted from.
     fn append_value(&mut self, value: JsonbRef<'_>) {
         let (entry, data) = value.0.to_raw_parts();
         let mut writer = self.bytes.writer();
@@ -242,7 +247,7 @@ impl JsonbWriter<'_> {
             builder,
         } = self;
         let value = builder.finish();
-        array_builder.append_encoded(value.as_bytes());
+        array_builder.append_value(JsonbRef(value.as_ref()));
     }
 
     /// Discards the partially built value.
@@ -285,6 +290,26 @@ mod tests {
 
         let decoded = JsonbArray::from_protobuf(&protobuf, array.len()).unwrap();
         assert_eq!(decoded.as_jsonb(), &array);
+    }
+
+    #[test]
+    fn test_append_value_matches_jsonbb_encoding() {
+        let values = [
+            json("null"),
+            json("true"),
+            json("42"),
+            json(r#""text""#),
+            json("[1, 2, 3]"),
+            json(r#"{"a": [1, true]}"#),
+        ];
+        let expected = values
+            .iter()
+            .flat_map(|value| value.0.as_bytes())
+            .copied()
+            .collect::<Vec<_>>();
+
+        let array = JsonbArray::from_iter(values);
+        assert_eq!(array.to_protobuf().values[1].body, expected);
     }
 
     #[test]

--- a/src/common/src/array/proto_reader.rs
+++ b/src/common/src/array/proto_reader.rs
@@ -38,7 +38,7 @@ impl ArrayImpl {
             PbArrayType::Timestamp => read_primitive_array::<Timestamp>(array, cardinality)?,
             PbArrayType::Timestamptz => read_primitive_array::<Timestamptz>(array, cardinality)?,
             PbArrayType::Interval => read_primitive_array::<Interval>(array, cardinality)?,
-            PbArrayType::Jsonb => JsonbArray::from_protobuf(array)?,
+            PbArrayType::Jsonb => JsonbArray::from_protobuf(array, cardinality)?,
             PbArrayType::Struct => StructArray::from_protobuf(array)?,
             PbArrayType::List => ListArray::from_protobuf(array)?,
             PbArrayType::Bytea => read_string_array::<BytesValueReader>(array, cardinality)?,

--- a/src/expr/macro/src/gen.rs
+++ b/src/expr/macro/src/gen.rs
@@ -495,12 +495,10 @@ impl FunctionAttr {
                 }
             }},
             Some(WriterTypeKind::JsonbbBuilder) => quote! {{
-                let mut writer_wrapper = builder.writer();
-                let mut writer = writer_wrapper.inner();
+                let mut writer = jsonbb::Builder::<Vec<u8>>::new();
                 if #output.is_some() {
-                    writer_wrapper.finish();
+                    builder.append_owned(Some(JsonbVal::from(writer.finish())));
                 } else {
-                    writer_wrapper.rollback();
                     builder.append_null();
                 }
             }},


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

`JsonbArray` previously encoded the entire column as one `jsonbb` array value. As a result, the JSONB offset limit was shared by all rows in a chunk, so a chunk could fail even when every row was individually within the limit.

This PR makes `JsonbArray` follow the same layout as `Utf8Array` by wrapping `BytesArray`:

- each row is encoded as an independent JSONB value;
- offsets, the null bitmap, and one contiguous data buffer store the column without per-row heap allocations;
- each row is decoded from its own byte slice, so jsonbb's internal offset limit remains per value rather than per chunk;
- SQL `NULL` remains distinct from JSON `null`;
- a row-local JSONB builder keeps `finish`, `rollback`, and drop isolated from previously appended rows.

Unit tests cover the contiguous-buffer protobuf round trip, SQL `NULL` versus JSON `null`, and writer commit/rollback/drop isolation.

## Checklist

- [x] I have written necessary rustdoc comments.
- [x] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->

## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

None.

</details>
