### PR TITLE
fix(meta): refresh serving mapping after role change

### DIFF
--- a/src/meta/src/serving/mod.rs
+++ b/src/meta/src/serving/mod.rs
@@ -211,8 +211,19 @@ pub fn start_serving_vnode_mapping_worker(
                     match notification {
                         Some(notification) => {
                             match notification {
-                                LocalNotification::WorkerNodeActivated(w) | LocalNotification::WorkerNodeDeleted(w) =>  {
-                                    if w.r#type() != WorkerType::ComputeNode || !w.property.as_ref().is_some_and(|p| p.is_serving) {
+                                LocalNotification::WorkerNodeActivated(w) => {
+                                    // An activation can update an existing worker from serving to
+                                    // non-serving, so the new property alone cannot determine whether
+                                    // the serving worker set changed.
+                                    if w.r#type() != WorkerType::ComputeNode {
+                                        continue;
+                                    }
+                                    reset().await;
+                                }
+                                LocalNotification::WorkerNodeDeleted(w) => {
+                                    if w.r#type() != WorkerType::ComputeNode
+                                        || !w.property.as_ref().is_some_and(|p| p.is_serving)
+                                    {
                                         continue;
                                     }
                                     reset().await;
@@ -272,4 +283,104 @@ pub fn start_serving_vnode_mapping_worker(
         }
     });
     (join_handle, shutdown_tx)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use risingwave_pb::common::HostAddress;
+    use risingwave_pb::common::worker_node::{PbProperty, PbResource};
+    use risingwave_pb::meta::SubscribeType;
+    use tokio::time::timeout;
+
+    use super::*;
+    use crate::controller::catalog::CatalogController;
+    use crate::controller::cluster::ClusterController;
+    use crate::error::MetaResult;
+    use crate::manager::{MetaSrvEnv, WorkerKey};
+
+    #[tokio::test]
+    async fn test_reset_serving_vnode_mapping_when_worker_stops_serving() -> MetaResult<()> {
+        let env = MetaSrvEnv::for_test().await;
+        let cluster_controller =
+            Arc::new(ClusterController::new(env.clone(), Duration::from_secs(1)).await?);
+        let host = HostAddress {
+            host: "localhost".to_owned(),
+            port: 5001,
+        };
+        let property = PbProperty {
+            parallelism: 1,
+            is_streaming: true,
+            is_serving: true,
+            ..Default::default()
+        };
+        let worker_id = cluster_controller
+            .add_worker(
+                WorkerType::ComputeNode,
+                host.clone(),
+                property.clone(),
+                PbResource::default(),
+            )
+            .await?;
+        cluster_controller.activate_worker(worker_id).await?;
+
+        let notification_manager = env.notification_manager_ref();
+        let (join_handle, shutdown_tx) = start_serving_vnode_mapping_worker(
+            notification_manager.clone(),
+            MetadataManager::new(
+                cluster_controller.clone(),
+                Arc::new(CatalogController::new(env.clone()).await?),
+            ),
+            Arc::new(ServingVnodeMapping::default()),
+            env.session_params_manager_impl_ref(),
+        );
+        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+        notification_manager.insert_sender(
+            SubscribeType::Frontend,
+            WorkerKey(HostAddress::default()),
+            tx,
+        );
+
+        let mut property = property;
+        property.is_serving = false;
+        let reregistered_worker_id = cluster_controller
+            .add_worker(
+                WorkerType::ComputeNode,
+                host,
+                property,
+                PbResource::default(),
+            )
+            .await?;
+        assert_eq!(reregistered_worker_id, worker_id);
+        assert!(
+            cluster_controller
+                .list_active_serving_workers()
+                .await?
+                .is_empty()
+        );
+        cluster_controller
+            .activate_worker(reregistered_worker_id)
+            .await?;
+
+        timeout(Duration::from_secs(5), async {
+            loop {
+                let notification = rx
+                    .recv()
+                    .await
+                    .expect("notification channel closed")
+                    .expect("failed to receive frontend notification");
+                if matches!(notification.info, Some(Info::ServingWorkerSlotMappings(_))) {
+                    assert_eq!(notification.operation, Operation::Snapshot as i32);
+                    break;
+                }
+            }
+        })
+        .await
+        .expect("serving mapping was not refreshed after worker role demotion");
+
+        shutdown_tx.send(()).unwrap();
+        join_handle.await.unwrap();
+        Ok(())
+    }
 }


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

An existing compute worker can re-register with `is_serving` changed from `true` to `false`. Its activation notification contains only the new property, so the serving vnode mapping worker previously treated the event as irrelevant and left mappings assigned to the removed serving worker stale.

This PR:

- refreshes serving vnode mappings for every compute worker activation, including an in-place serving role demotion;
- keeps deletion refreshes limited to workers that were serving before deletion;
- adds a regression test that re-registers the same worker ID from serving to non-serving and verifies that a fresh mapping snapshot is sent.

## Checklist

- [x] I have written necessary rustdoc comments.
- [x] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [x] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->

## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

</details>
