### PR TITLE
feat(meta): pin backfill snapshots during time travel vacuum (#26326)

### DIFF
--- a/e2e_test/backfill/cross_db/cross_db_mv.slt
+++ b/e2e_test/backfill/cross_db/cross_db_mv.slt
@@ -99,16 +99,41 @@ select count(*) from mv1;
 10000
 
 statement ok
-create materialized view mv_rate_limit with (backfill_rate_limit = 0) as select * from d1.public.t1;
+set database to d1;
 
-query I retry 4 backoff 1s
-select count(*) from rw_ddl_progress;
-----
-1
+statement ok
+create table t_rate_limit(v1 int);
 
-sleep 2s
+statement ok
+create subscription sub_rate_limit from t_rate_limit with(retention = '1D');
 
-query I
+statement ok
+set database to d2;
+
+statement ok
+create materialized view mv_rate_limit as select * from d1.public.t_rate_limit;
+
+statement ok
+wait
+
+statement ok
+alter materialized view mv_rate_limit set backfill_rate_limit = 0;
+
+statement ok
+set database to d1;
+
+statement ok
+insert into t_rate_limit select * from generate_series(1, 10000);
+
+sleep 5s
+
+statement ok
+flush;
+
+statement ok
+set database to d2;
+
+query ok
 select count(*) from mv_rate_limit;
 ----
 0
@@ -117,9 +142,9 @@ statement ok
 alter materialized view mv_rate_limit set backfill_rate_limit = 1000;
 
 statement ok
-wait
+flush;
 
-query ok
+query ok retry 10 backoff 1s
 select count(*) from mv_rate_limit;
 ----
 10000
@@ -143,6 +168,9 @@ statement ok
 drop subscription sub_order;
 
 statement ok
+drop subscription sub_rate_limit;
+
+statement ok
 drop subscription sub;
 
 statement ok
@@ -150,6 +178,9 @@ drop materialized view mv_order_src;
 
 statement ok
 drop table t_order;
+
+statement ok
+drop table t_rate_limit;
 
 statement ok
 drop table t1;

--- a/e2e_test/backfill/sink/create_sink.slt
+++ b/e2e_test/backfill/sink/create_sink.slt
@@ -23,7 +23,7 @@ with (
     properties.bootstrap.server='message_queue:29092',
     topic='s_kafka',
     primary_key='v1',
-    allow.auto.create.topics=true,
+    properties.allow.auto.create.topics=true,
 )
 FORMAT DEBEZIUM ENCODE JSON;
 

--- a/e2e_test/time_travel/syntax.slt
+++ b/e2e_test/time_travel/syntax.slt
@@ -11,40 +11,16 @@ query I
 SELECT *  FROM t;
 ----
 
-query error
+query error Time-travel version expired: table [0-9]+, epoch 0
 SELECT * FROM t FOR SYSTEM_TIME AS OF 963716300;
-----
-db error: ERROR: Failed to run the query
-
-Caused by these errors (recent errors listed first):
-  1: gRPC request to batch service failed: Internal error
-  2: Storage error
-  3: Hummock error
-  4: Meta error: gRPC request to hummock service (call `/hummock.HummockManagerService/GetVersionByEpoch`) failed: Internal error: time travel: version not found for epoch 0
 
 
-query error
+query error Time-travel version expired: table [0-9]+, epoch 0
 SELECT * FROM t FOR SYSTEM_TIME AS OF '2000-02-20T12:13:14-08:30';
-----
-db error: ERROR: Failed to run the query
-
-Caused by these errors (recent errors listed first):
-  1: gRPC request to batch service failed: Internal error
-  2: Storage error
-  3: Hummock error
-  4: Meta error: gRPC request to hummock service (call `/hummock.HummockManagerService/GetVersionByEpoch`) failed: Internal error: time travel: version not found for epoch 0
 
 
-query error
+query error Time-travel version expired: table [0-9]+, epoch 0
 SELECT * FROM t FOR SYSTEM_TIME AS OF NOW() - '100' YEAR;
-----
-db error: ERROR: Failed to run the query
-
-Caused by these errors (recent errors listed first):
-  1: gRPC request to batch service failed: Internal error
-  2: Storage error
-  3: Hummock error
-  4: Meta error: gRPC request to hummock service (call `/hummock.HummockManagerService/GetVersionByEpoch`) failed: Internal error: time travel: version not found for epoch 0
 
 
 query I

--- a/src/meta/node/src/server.rs
+++ b/src/meta/node/src/server.rs
@@ -652,17 +652,21 @@ pub async fn start_service_as_election_leader(
         backup_manager.clone(),
         &env.opts,
         {
-            let barrier_manager = barrier_manager.clone();
+            let catalog_controller = metadata_manager.catalog_controller.clone();
             Box::new(move || {
-                let barrier_manager = barrier_manager.clone();
+                let catalog_controller = catalog_controller.clone();
                 Box::pin(async move {
-                    barrier_manager.may_have_creating_job().await.unwrap_or_else(|e| {
-                        tracing::warn!(err = %e.as_report(), "failed to check having creating jobs. pause vacuum time travel");
-                        true
-                    })
+                    catalog_controller
+                        .get_pinned_snapshot_epochs()
+                        .await
+                        .map(Some)
+                        .unwrap_or_else(|e| {
+                            tracing::warn!(err = %e.as_report(), "failed to collect pinned snapshot epochs. pause vacuum time travel");
+                            None
+                        })
                 })
             })
-        }
+        },
     ));
     sub_tasks.push(start_worker_info_monitor(
         metadata_manager.clone(),

--- a/src/meta/src/barrier/checkpoint/control.rs
+++ b/src/meta/src/barrier/checkpoint/control.rs
@@ -228,12 +228,6 @@ impl CheckpointControl {
             .map(|database| &database.database_info)
     }
 
-    pub(crate) fn may_have_creating_jobs(&self) -> bool {
-        self.databases
-            .values()
-            .any(|database| database.may_have_creating_jobs())
-    }
-
     /// return Some(failed `database_id` -> `err`)
     pub(crate) fn handle_new_barrier(
         &mut self,
@@ -592,18 +586,6 @@ impl DatabaseCheckpointControlStatus {
             DatabaseCheckpointControlStatus::Running(state) => Some(state),
             DatabaseCheckpointControlStatus::Recovering(_) => None,
         }
-    }
-
-    fn may_have_creating_jobs(&self) -> bool {
-        self.running_state()
-            .map(|database| {
-                database.database_info.has_creating_jobs()
-                    || database
-                        .independent_checkpoint_job_controls
-                        .values()
-                        .any(|job| job.is_snapshot_backfilling())
-            })
-            .unwrap_or(true) // there can be snapshot backfilling jobs when the database is recovering.
     }
 
     fn expect_running(&mut self, reason: &'static str) -> &mut DatabaseCheckpointControl {

--- a/src/meta/src/barrier/checkpoint/independent_job/creating_job/mod.rs
+++ b/src/meta/src/barrier/checkpoint/independent_job/creating_job/mod.rs
@@ -359,7 +359,6 @@ impl CreatingStreamingJobControl {
             &mut pending_non_checkpoint_barriers,
             PbBarrierKind::Initial,
         );
-
         Ok((
             CreatingStreamingJobStatus::ConsumingSnapshot {
                 prev_epoch_fake_physical_time,

--- a/src/meta/src/barrier/checkpoint/independent_job/mod.rs
+++ b/src/meta/src/barrier/checkpoint/independent_job/mod.rs
@@ -76,18 +76,6 @@ impl IndependentCheckpointJobControl {
         }
     }
 
-    /// Returns `true` if this job is actively consuming a snapshot.
-    ///
-    /// For creating streaming jobs this is always `true` (they exist only while
-    /// backfilling). Batch refresh jobs are only snapshot-backfilling while in
-    /// `ConsumingSnapshot` or `FinishingSnapshot`; once they transition to `Idle`
-    /// they no longer pin upstream log epochs.
-    pub(crate) fn is_snapshot_backfilling(&self) -> bool {
-        match self {
-            Self::CreatingStreamingJob(_) => true,
-        }
-    }
-
     /// Collect a barrier and return whether a checkpoint should be forced in the next barrier.
     pub(crate) fn collect(&mut self, collected_barrier: CollectedBarrier<'_>) -> bool {
         match self {

--- a/src/meta/src/barrier/info.rs
+++ b/src/meta/src/barrier/info.rs
@@ -743,11 +743,6 @@ impl InflightDatabaseInfo {
             .any(|tracker| tracker.is_finished())
     }
 
-    pub(super) fn has_creating_jobs(&self) -> bool {
-        self.iter_creating_job_tracker()
-            .any(|tracker| !tracker.is_finished())
-    }
-
     pub(super) fn take_pending_backfill_nodes(&mut self) -> Vec<FragmentId> {
         self.iter_mut_creating_job_tracker()
             .flat_map(|tracker| tracker.take_pending_backfill_nodes())

--- a/src/meta/src/barrier/manager.rs
+++ b/src/meta/src/barrier/manager.rs
@@ -31,7 +31,6 @@ use tokio::task::JoinHandle;
 use tracing::warn;
 
 use crate::MetaResult;
-use crate::barrier::BarrierManagerRequest::MayHaveCreatingJob;
 use crate::barrier::cdc_progress::CdcProgress;
 use crate::barrier::worker::GlobalBarrierWorker;
 use crate::barrier::{
@@ -151,14 +150,6 @@ impl GlobalBarrierManager {
             .context("failed to send update database barrier request")?;
         rx.await.context("failed to wait update database barrier")?;
         Ok(())
-    }
-
-    pub async fn may_have_creating_job(&self) -> MetaResult<bool> {
-        let (tx, rx) = oneshot::channel();
-        self.request_tx
-            .send(MayHaveCreatingJob(tx))
-            .context("failed to send has creating job request")?;
-        Ok(rx.await.context("failed to wait has creating job")?)
     }
 
     pub async fn get_hummock_version_id(&self) -> HummockVersionId {

--- a/src/meta/src/barrier/mod.rs
+++ b/src/meta/src/barrier/mod.rs
@@ -133,7 +133,6 @@ pub(crate) enum BarrierManagerRequest {
     GetCdcProgress(Sender<MetaResult<HashMap<JobId, CdcProgress>>>),
     AdhocRecovery(Sender<()>),
     UpdateDatabaseBarrier(UpdateDatabaseBarrierRequest),
-    MayHaveCreatingJob(Sender<bool>),
 }
 
 #[derive(Debug)]

--- a/src/meta/src/barrier/progress.rs
+++ b/src/meta/src/barrier/progress.rs
@@ -437,45 +437,43 @@ impl CreateMviewProgressTracker {
         backfill_order_state: BackfillOrderState,
         version_stats: &HummockVersionStats,
     ) -> Self {
-        {
-            let tracking_job = TrackingJob::recovered(creating_job_id, fragment_infos);
-            let actors = InflightStreamingJobInfo::tracking_progress_actor_ids(fragment_infos);
-            let status = if actors.is_empty() {
-                CreateMviewStatus::Finished {
-                    table_ids_to_truncate: vec![],
-                }
-            } else {
-                let mut states = HashMap::new();
-                let mut backfill_upstream_types = HashMap::new();
-
-                for (actor, backfill_upstream_type) in actors {
-                    states.insert(actor, BackfillState::ConsumingUpstream(Epoch(0), 0, 0));
-                    backfill_upstream_types.insert(actor, backfill_upstream_type);
-                }
-
-                let progress = Self::recover_progress(
-                    creating_job_id,
-                    states,
-                    backfill_upstream_types,
-                    StreamJobFragments::upstream_table_counts_impl(
-                        fragment_infos.values().map(|fragment| &fragment.nodes),
-                    ),
-                    version_stats,
-                    backfill_order_state,
-                );
-                let pending_backfill_nodes = progress
-                    .backfill_order_state
-                    .current_backfill_node_fragment_ids();
-                CreateMviewStatus::Backfilling {
-                    progress,
-                    pending_backfill_nodes,
-                    table_ids_to_truncate: vec![],
-                }
-            };
-            Self {
-                tracking_job,
-                status,
+        let tracking_job = TrackingJob::recovered(creating_job_id, fragment_infos);
+        let actors = InflightStreamingJobInfo::tracking_progress_actor_ids(fragment_infos);
+        let status = if actors.is_empty() {
+            CreateMviewStatus::Finished {
+                table_ids_to_truncate: vec![],
             }
+        } else {
+            let mut states = HashMap::new();
+            let mut backfill_upstream_types = HashMap::new();
+
+            for (actor, backfill_upstream_type) in actors {
+                states.insert(actor, BackfillState::ConsumingUpstream(Epoch(0), 0, 0));
+                backfill_upstream_types.insert(actor, backfill_upstream_type);
+            }
+
+            let progress = Self::recover_progress(
+                creating_job_id,
+                states,
+                backfill_upstream_types,
+                StreamJobFragments::upstream_table_counts_impl(
+                    fragment_infos.values().map(|fragment| &fragment.nodes),
+                ),
+                version_stats,
+                backfill_order_state,
+            );
+            let pending_backfill_nodes = progress
+                .backfill_order_state
+                .current_backfill_node_fragment_ids();
+            CreateMviewStatus::Backfilling {
+                progress,
+                pending_backfill_nodes,
+                table_ids_to_truncate: vec![],
+            }
+        };
+        Self {
+            tracking_job,
+            status,
         }
     }
 

--- a/src/meta/src/barrier/worker.rs
+++ b/src/meta/src/barrier/worker.rs
@@ -493,11 +493,6 @@ impl<C: GlobalBarrierWorkerContext> GlobalBarrierWorker<C> {
                                     warn!("failed to notify finish of update database barrier");
                                 }
                             }
-                            BarrierManagerRequest::MayHaveCreatingJob(tx) => {
-                                if tx.send(self.checkpoint_control.may_have_creating_jobs()).is_err() {
-                                    warn!("failed to check whether there may be creating jobs");
-                                }
-                            }
                         }
                     } else {
                         tracing::info!("end of request stream. meta node may be shutting down. Stop global barrier manager");
@@ -1244,10 +1239,6 @@ impl<C: GlobalBarrierWorkerContext> GlobalBarrierWorker<C> {
                         }
                         BarrierManagerRequest::UpdateDatabaseBarrier(request) => {
                             update_barrier_requests.push(request);
-                        }
-                        BarrierManagerRequest::MayHaveCreatingJob(tx) => {
-                            // May recover creating jobs.
-                            let _ = tx.send(true);
                         }
                     }
                 }

--- a/src/meta/src/controller/streaming_job.rs
+++ b/src/meta/src/controller/streaming_job.rs
@@ -30,7 +30,7 @@ use risingwave_common::system_param::AdaptiveParallelismStrategy;
 use risingwave_common::system_param::adaptive_parallelism_strategy::parse_strategy;
 use risingwave_common::util::iter_util::ZipEqDebug;
 use risingwave_common::util::stream_graph_visitor::{
-    visit_stream_node_body, visit_stream_node_mut,
+    visit_stream_node_body, visit_stream_node_mut, visit_stream_node_stream_scan,
 };
 use risingwave_common::{bail, current_cluster_version};
 use risingwave_connector::allow_alter_on_fly_fields::check_sink_allow_alter_on_fly_fields;
@@ -66,7 +66,7 @@ use risingwave_pb::plan_common::source_refresh_mode::{
 use risingwave_pb::secret::PbSecretRef;
 use risingwave_pb::stream_plan::stream_fragment_graph::Parallelism;
 use risingwave_pb::stream_plan::stream_node::PbNodeBody;
-use risingwave_pb::stream_plan::{PbSinkLogStoreType, PbStreamNode};
+use risingwave_pb::stream_plan::{PbSinkLogStoreType, PbStreamNode, StreamScanType};
 use risingwave_pb::user::PbUserInfo;
 use risingwave_sqlparser::ast::{Engine, SqlOption, Statement};
 use risingwave_sqlparser::parser::{Parser, ParserError};
@@ -179,6 +179,64 @@ impl From<streaming_job::Model> for ReplaceOriginalJobInfo {
 }
 
 impl CatalogController {
+    pub async fn get_pinned_snapshot_epochs(&self) -> MetaResult<HashMap<TableId, HashSet<u64>>> {
+        // Hold the catalog read lock across both queries so a job cannot transition out of
+        // `Creating` while its fragments are being inspected.
+        let inner = self.inner.read().await;
+        let creating_job_ids = StreamingJobModel::find()
+            .select_only()
+            .column(streaming_job::Column::JobId)
+            .filter(streaming_job::Column::JobStatus.eq(JobStatus::Creating))
+            .into_tuple::<JobId>()
+            .all(&inner.db)
+            .await?;
+        if creating_job_ids.is_empty() {
+            return Ok(HashMap::new());
+        }
+        let fragments = Fragment::find()
+            .filter(fragment::Column::JobId.is_in(creating_job_ids))
+            .all(&inner.db)
+            .await?;
+        let mut pinned_snapshot_epochs: HashMap<TableId, HashSet<u64>> = HashMap::new();
+        for fragment in fragments {
+            visit_stream_node_stream_scan(&fragment.stream_node.to_protobuf(), |stream_scan| {
+                let scan_type = match StreamScanType::try_from(stream_scan.stream_scan_type) {
+                    Ok(scan_type) => scan_type,
+                    Err(err) => {
+                        tracing::warn!(
+                            job_id = %fragment.job_id,
+                            fragment_id = %fragment.fragment_id,
+                            stream_scan_type = stream_scan.stream_scan_type,
+                            error = %err.as_report(),
+                            "invalid persisted stream scan type, skip collecting snapshot pin"
+                        );
+                        return;
+                    }
+                };
+                if !matches!(
+                    scan_type,
+                    StreamScanType::SnapshotBackfill | StreamScanType::CrossDbSnapshotBackfill
+                ) {
+                    return;
+                }
+                let Some(epoch) = stream_scan.snapshot_backfill_epoch else {
+                    tracing::warn!(
+                        job_id = %fragment.job_id,
+                        fragment_id = %fragment.fragment_id,
+                        table_id = %stream_scan.table_id,
+                        "persisted snapshot backfill epoch is not set, skip collecting snapshot pin"
+                    );
+                    return;
+                };
+                pinned_snapshot_epochs
+                    .entry(stream_scan.table_id)
+                    .or_default()
+                    .insert(epoch);
+            });
+        }
+        Ok(pinned_snapshot_epochs)
+    }
+
     #[expect(clippy::too_many_arguments)]
     pub async fn create_streaming_job_obj(
         txn: &DatabaseTransaction,

--- a/src/meta/src/hummock/manager/gc.rs
+++ b/src/meta/src/hummock/manager/gc.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use std::cmp;
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::ops::DerefMut;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::{Duration, Instant, SystemTime};
@@ -22,11 +22,12 @@ use chrono::DateTime;
 use futures::future::try_join_all;
 use futures::{StreamExt, TryStreamExt, future};
 use itertools::Itertools;
+use risingwave_common::catalog::TableId;
 use risingwave_common::system_param::reader::SystemParamsRead;
 use risingwave_common::util::epoch::Epoch;
 use risingwave_hummock_sdk::{
-    HummockObjectId, HummockRawObjectId, VALID_OBJECT_ID_SUFFIXES, get_object_data_path,
-    get_object_id_from_path,
+    HummockEpoch, HummockObjectId, HummockRawObjectId, VALID_OBJECT_ID_SUFFIXES,
+    get_object_data_path, get_object_id_from_path,
 };
 use risingwave_meta_model::hummock_sequence::HUMMOCK_NOW;
 use risingwave_meta_model::{hummock_gc_history, hummock_sequence, hummock_version_delta};
@@ -461,7 +462,10 @@ impl HummockManager {
         Ok(())
     }
 
-    pub async fn delete_time_travel_metadata(&self) -> MetaResult<()> {
+    pub async fn delete_time_travel_metadata(
+        &self,
+        pinned_snapshot_epochs: HashMap<TableId, HashSet<HummockEpoch>>,
+    ) -> MetaResult<()> {
         let current_epoch_time = Epoch::now().physical_time();
         let epoch_watermark = Epoch::from_physical_time(
             current_epoch_time.saturating_sub(
@@ -472,7 +476,8 @@ impl HummockManager {
             ),
         )
         .0;
-        self.truncate_time_travel_metadata(epoch_watermark).await?;
+        self.truncate_time_travel_metadata(epoch_watermark, pinned_snapshot_epochs)
+            .await?;
         Ok(())
     }
 

--- a/src/meta/src/hummock/manager/tests.rs
+++ b/src/meta/src/hummock/manager/tests.rs
@@ -3679,3 +3679,225 @@ async fn test_schedule_group_split_with_normalize_disabled() {
     let ranges = compaction_group_ranges(&current_version);
     assert_eq!(ranges, vec![(64, 80), (65, 81)]);
 }
+
+#[tokio::test]
+async fn test_time_travel_vacuum_pins_snapshot_epoch() {
+    use risingwave_hummock_sdk::level::Levels;
+    use risingwave_meta_model::hummock_sstable_info::SstableInfoV2Backend;
+    use risingwave_meta_model::{
+        hummock_epoch_to_version, hummock_sstable_info, hummock_time_travel_delta,
+        hummock_time_travel_version,
+    };
+    use sea_orm::ActiveValue::Set;
+    use sea_orm::{EntityTrait, PaginatorTrait, QueryOrder, QuerySelect};
+
+    async fn insert_version(env: &MetaSrvEnv, id: u64, sst: Option<SstableInfo>) {
+        let mut version = HummockVersion::default();
+        version.id = id.into();
+        if let Some(sst) = sst {
+            version.levels.insert(
+                1.into(),
+                Levels {
+                    levels: vec![Level {
+                        table_infos: vec![sst],
+                        ..Default::default()
+                    }],
+                    ..Default::default()
+                },
+            );
+        }
+        hummock_time_travel_version::Entity::insert(hummock_time_travel_version::ActiveModel {
+            version_id: Set(version.id),
+            version: Set((&version.to_protobuf()).into()),
+        })
+        .exec(&env.meta_store_ref().conn)
+        .await
+        .unwrap();
+    }
+
+    async fn insert_sstable_info(env: &MetaSrvEnv, sst: &SstableInfo) {
+        hummock_sstable_info::Entity::insert(hummock_sstable_info::ActiveModel {
+            sst_id: Set(sst.sst_id),
+            object_id: Set(sst.object_id),
+            sstable_info: Set(SstableInfoV2Backend::from(&sst.to_protobuf())),
+        })
+        .exec(&env.meta_store_ref().conn)
+        .await
+        .unwrap();
+    }
+
+    async fn insert_delta(env: &MetaSrvEnv, id: u64, prev_id: u64) {
+        let mut delta = risingwave_hummock_sdk::version::HummockVersionDelta::default();
+        delta.id = id.into();
+        delta.prev_id = prev_id.into();
+        hummock_time_travel_delta::Entity::insert(hummock_time_travel_delta::ActiveModel {
+            version_id: Set(delta.id),
+            version_delta: Set((&delta.to_protobuf()).into()),
+        })
+        .exec(&env.meta_store_ref().conn)
+        .await
+        .unwrap();
+    }
+
+    async fn insert_epoch_mapping(env: &MetaSrvEnv, table_id: TableId, epoch: u64, version: u64) {
+        hummock_epoch_to_version::Entity::insert(hummock_epoch_to_version::ActiveModel {
+            epoch: Set(epoch.try_into().unwrap()),
+            table_id: Set(i64::from(table_id.as_raw_id())),
+            version_id: Set(version.into()),
+        })
+        .exec(&env.meta_store_ref().conn)
+        .await
+        .unwrap();
+    }
+
+    let mut opts = MetaOpts::test(false);
+    opts.time_travel_vacuum_max_version_count = Some(1);
+    let (env, hummock_manager, _, _) = setup_compute_env_with_meta_opts(80, opts).await;
+    let table_id = TableId::new(1);
+    let pinned_sst = gen_sstable_info(10, vec![table_id.as_raw_id()], test_epoch(1));
+    insert_sstable_info(&env, &pinned_sst).await;
+    insert_version(&env, 1, Some(pinned_sst)).await;
+    insert_delta(&env, 2, 1).await;
+    insert_delta(&env, 3, 2).await;
+    insert_version(&env, 4, None).await;
+    insert_version(&env, 5, None).await;
+    insert_epoch_mapping(&env, table_id, 100, 2).await;
+    insert_epoch_mapping(&env, table_id, 150, 3).await;
+    insert_epoch_mapping(&env, table_id, 175, 3).await;
+    insert_epoch_mapping(&env, table_id, 200, 4).await;
+    insert_epoch_mapping(&env, table_id, 300, 5).await;
+    insert_epoch_mapping(&env, TableId::new(2), 50, 6).await;
+
+    hummock_manager
+        .truncate_time_travel_metadata(
+            250,
+            HashMap::from([
+                (table_id, HashSet::from([100, 125, 150])),
+                (TableId::new(2), HashSet::from([50])),
+                (TableId::new(999), HashSet::from([100, 250, 300])),
+            ]),
+        )
+        .await
+        .unwrap();
+
+    let epoch_rows = hummock_epoch_to_version::Entity::find()
+        .order_by_asc(hummock_epoch_to_version::Column::Epoch)
+        .all(&env.meta_store_ref().conn)
+        .await
+        .unwrap();
+    assert_eq!(
+        epoch_rows
+            .iter()
+            .map(|row| u64::try_from(row.epoch).unwrap())
+            .collect_vec(),
+        vec![50, 100, 150, 300]
+    );
+    let version_ids: Vec<risingwave_meta_model::HummockVersionId> =
+        hummock_time_travel_version::Entity::find()
+            .select_only()
+            .column(hummock_time_travel_version::Column::VersionId)
+            .order_by_asc(hummock_time_travel_version::Column::VersionId)
+            .into_tuple()
+            .all(&env.meta_store_ref().conn)
+            .await
+            .unwrap();
+    assert_eq!(
+        version_ids.iter().map(|id| id.as_raw_id()).collect_vec(),
+        vec![1, 4, 5]
+    );
+    let delta_ids: Vec<risingwave_meta_model::HummockVersionId> =
+        hummock_time_travel_delta::Entity::find()
+            .select_only()
+            .column(hummock_time_travel_delta::Column::VersionId)
+            .order_by_asc(hummock_time_travel_delta::Column::VersionId)
+            .into_tuple()
+            .all(&env.meta_store_ref().conn)
+            .await
+            .unwrap();
+    assert_eq!(
+        delta_ids.iter().map(|id| id.as_raw_id()).collect_vec(),
+        vec![2, 3]
+    );
+    assert_eq!(
+        hummock_sstable_info::Entity::find()
+            .count(&env.meta_store_ref().conn)
+            .await
+            .unwrap(),
+        1
+    );
+    assert!(
+        hummock_manager
+            .gc_manager
+            .try_take_may_delete_object_ids(1)
+            .is_none()
+    );
+    assert_eq!(
+        hummock_manager
+            .epoch_to_version(100, table_id)
+            .await
+            .unwrap()
+            .id
+            .as_raw_id(),
+        2
+    );
+    assert_eq!(
+        hummock_manager
+            .epoch_to_version(150, table_id)
+            .await
+            .unwrap()
+            .id
+            .as_raw_id(),
+        3
+    );
+    assert_eq!(
+        hummock_manager
+            .epoch_to_version(300, table_id)
+            .await
+            .unwrap()
+            .id
+            .as_raw_id(),
+        5
+    );
+
+    hummock_manager
+        .truncate_time_travel_metadata(350, HashMap::new())
+        .await
+        .unwrap();
+    assert!(
+        hummock_manager
+            .epoch_to_version(100, table_id)
+            .await
+            .is_err()
+    );
+    assert_eq!(
+        hummock_time_travel_version::Entity::find()
+            .count(&env.meta_store_ref().conn)
+            .await
+            .unwrap(),
+        2
+    );
+    assert_eq!(
+        hummock_time_travel_delta::Entity::find()
+            .count(&env.meta_store_ref().conn)
+            .await
+            .unwrap(),
+        0
+    );
+    assert_eq!(
+        hummock_sstable_info::Entity::find()
+            .count(&env.meta_store_ref().conn)
+            .await
+            .unwrap(),
+        0
+    );
+    assert_eq!(
+        hummock_manager
+            .gc_manager
+            .try_take_may_delete_object_ids(1)
+            .unwrap()
+            .into_iter()
+            .map(|object_id| object_id.as_raw().as_raw_id())
+            .collect_vec(),
+        vec![10]
+    );
+}

--- a/src/meta/src/hummock/manager/time_travel.rs
+++ b/src/meta/src/hummock/manager/time_travel.rs
@@ -34,8 +34,8 @@ use risingwave_meta_model::{
 use risingwave_pb::hummock::{PbHummockVersion, PbHummockVersionDelta};
 use sea_orm::ActiveValue::Set;
 use sea_orm::{
-    ColumnTrait, Condition, DatabaseTransaction, EntityTrait, PaginatorTrait, QueryFilter,
-    QueryOrder, QuerySelect, TransactionTrait,
+    ColumnTrait, Condition, ConnectionTrait, DatabaseTransaction, EntityTrait, PaginatorTrait,
+    QueryFilter, QueryOrder, QuerySelect, TransactionTrait,
 };
 use tracing::info;
 
@@ -67,6 +67,7 @@ impl HummockManager {
     pub(crate) async fn truncate_time_travel_metadata(
         &self,
         epoch_watermark: HummockEpoch,
+        pinned_snapshot_epochs: HashMap<TableId, HashSet<HummockEpoch>>,
     ) -> Result<()> {
         let _timer = self
             .metrics
@@ -75,11 +76,63 @@ impl HummockManager {
         let min_pinned_version_id = self.context_info.read().await.min_pinned_version_id();
         let sql_store = self.env.meta_store_ref();
         let txn = sql_store.conn.begin().await?;
+
+        let epoch_watermark_model =
+            risingwave_meta_model::Epoch::try_from(epoch_watermark).unwrap();
+        let mut pinned_epoch_rows = HashSet::new();
+        let mut pinned_snapshot_version_ids = HashSet::new();
+        for (table_id, pinned_epochs) in pinned_snapshot_epochs {
+            for pinned_epoch in pinned_epochs {
+                if pinned_epoch >= epoch_watermark {
+                    continue;
+                }
+                let pinned_epoch_model =
+                    risingwave_meta_model::Epoch::try_from(pinned_epoch).unwrap();
+                let epoch_to_version = hummock_epoch_to_version::Entity::find_by_id((
+                    pinned_epoch_model,
+                    i64::from(table_id.as_raw_id()),
+                ))
+                .one(&txn)
+                .await?;
+                let Some(epoch_to_version) = epoch_to_version else {
+                    tracing::warn!(
+                        %table_id,
+                        pinned_epoch,
+                        "pinned snapshot epoch mapping not found, skip pinning"
+                    );
+                    continue;
+                };
+                pinned_epoch_rows.insert((epoch_to_version.epoch, epoch_to_version.table_id));
+                pinned_snapshot_version_ids.insert(epoch_to_version.version_id);
+            }
+        }
+
+        let mut pinned_replay_version_ids = HashSet::new();
+        let mut pinned_delta_ids = HashSet::new();
+        let mut pinned_snapshot_sst_ids = HashSet::new();
+        let mut pinned_snapshot_object_ids = HashSet::new();
+        for pinned_snapshot_version_id in pinned_snapshot_version_ids {
+            let Some(resolved) =
+                resolve_time_travel_version(&txn, pinned_snapshot_version_id).await?
+            else {
+                tracing::warn!(
+                    %pinned_snapshot_version_id,
+                    "time travel version before pinned version not found, skip pinning"
+                );
+                continue;
+            };
+            pinned_replay_version_ids.insert(resolved.replay_version.id);
+            pinned_snapshot_sst_ids.extend(resolved.replay_version.get_sst_ids());
+            pinned_snapshot_object_ids.extend(resolved.replay_version.get_object_ids());
+            for delta in resolved.deltas {
+                pinned_delta_ids.insert(delta.id);
+                pinned_snapshot_sst_ids.extend(delta.newly_added_sst_ids(true));
+                pinned_snapshot_object_ids.extend(delta.newly_added_object_ids(true));
+            }
+        }
+
         let version_watermark = hummock_epoch_to_version::Entity::find()
-            .filter(
-                hummock_epoch_to_version::Column::Epoch
-                    .lt(risingwave_meta_model::Epoch::try_from(epoch_watermark).unwrap()),
-            )
+            .filter(hummock_epoch_to_version::Column::Epoch.lt(epoch_watermark_model))
             .order_by_desc(hummock_epoch_to_version::Column::Epoch)
             .order_by_asc(hummock_epoch_to_version::Column::VersionId)
             .one(&txn)
@@ -92,14 +145,20 @@ impl HummockManager {
         let mut watermark_version_id =
             std::cmp::min(version_watermark.version_id, min_pinned_version_id);
         if let Some(max_version_count) = self.env.opts.time_travel_vacuum_max_version_count {
-            let earliest2_version_ids = hummock_time_travel_version::Entity::find()
+            let mut query = hummock_time_travel_version::Entity::find()
                 .select_only()
                 .column(hummock_time_travel_version::Column::VersionId)
                 .order_by_asc(hummock_time_travel_version::Column::VersionId)
-                .limit(2)
-                .into_tuple::<HummockVersionId>()
-                .all(&txn)
-                .await?;
+                .limit(2);
+            // A replay version can be pinned for arbitrarily long. Counting it would keep selecting
+            // the same two earliest versions and prevent incremental vacuum from advancing.
+            if !pinned_replay_version_ids.is_empty() {
+                query = query.filter(
+                    hummock_time_travel_version::Column::VersionId
+                        .is_not_in(pinned_replay_version_ids.iter().copied()),
+                );
+            }
+            let earliest2_version_ids = query.into_tuple::<HummockVersionId>().all(&txn).await?;
             // Ensure at least 1 version BELOW watermark_version_id if applying time_travel_vacuum_max_version_count.
             if earliest2_version_ids.len() == 2 {
                 watermark_version_id = std::cmp::min(
@@ -113,13 +172,16 @@ impl HummockManager {
                 );
             }
         }
-        let res = hummock_epoch_to_version::Entity::delete_many()
-            .filter(
-                hummock_epoch_to_version::Column::Epoch
-                    .lt(risingwave_meta_model::Epoch::try_from(epoch_watermark).unwrap()),
-            )
-            .exec(&txn)
-            .await?;
+        let mut delete_epoch_rows = hummock_epoch_to_version::Entity::delete_many()
+            .filter(hummock_epoch_to_version::Column::Epoch.lt(epoch_watermark_model));
+        for (epoch, table_id) in &pinned_epoch_rows {
+            delete_epoch_rows = delete_epoch_rows.filter(
+                Condition::any()
+                    .add(hummock_epoch_to_version::Column::Epoch.ne(*epoch))
+                    .add(hummock_epoch_to_version::Column::TableId.ne(*table_id)),
+            );
+        }
+        let res = delete_epoch_rows.exec(&txn).await?;
         tracing::info!(
             epoch_watermark,
             "Delete {} rows from hummock_epoch_to_version.",
@@ -137,34 +199,44 @@ impl HummockManager {
             txn.commit().await?;
             return Ok(());
         };
-        let (
-            latest_valid_version_id,
-            latest_valid_version_sst_ids,
-            latest_valid_version_object_ids,
-        ) = {
-            (
-                latest_valid_version.id,
-                latest_valid_version.get_sst_ids(),
-                latest_valid_version
-                    .get_object_ids()
-                    .collect::<HashSet<_>>(),
-            )
-        };
+        let latest_valid_version_id = latest_valid_version.id;
+        let mut retained_snapshot_sst_ids = latest_valid_version.get_sst_ids();
+        let mut retained_snapshot_object_ids = latest_valid_version
+            .get_object_ids()
+            .collect::<HashSet<_>>();
+        retained_snapshot_sst_ids.extend(pinned_snapshot_sst_ids);
+        retained_snapshot_object_ids.extend(pinned_snapshot_object_ids);
         let mut object_ids_to_delete: HashSet<_> = HashSet::default();
+        let mut version_delete_condition = Condition::all()
+            .add(hummock_time_travel_version::Column::VersionId.lt(latest_valid_version_id));
+        if !pinned_replay_version_ids.is_empty() {
+            version_delete_condition = version_delete_condition.add(
+                hummock_time_travel_version::Column::VersionId
+                    .is_not_in(pinned_replay_version_ids.iter().copied()),
+            );
+        }
         let version_ids_to_delete: Vec<risingwave_meta_model::HummockVersionId> =
             hummock_time_travel_version::Entity::find()
                 .select_only()
                 .column(hummock_time_travel_version::Column::VersionId)
-                .filter(hummock_time_travel_version::Column::VersionId.lt(latest_valid_version_id))
+                .filter(version_delete_condition.clone())
                 .order_by_desc(hummock_time_travel_version::Column::VersionId)
                 .into_tuple()
                 .all(&txn)
                 .await?;
+        let mut delta_delete_condition = Condition::all()
+            .add(hummock_time_travel_delta::Column::VersionId.lt(latest_valid_version_id));
+        if !pinned_delta_ids.is_empty() {
+            delta_delete_condition = delta_delete_condition.add(
+                hummock_time_travel_delta::Column::VersionId
+                    .is_not_in(pinned_delta_ids.iter().copied()),
+            );
+        }
         let delta_ids_to_delete: Vec<risingwave_meta_model::HummockVersionId> =
             hummock_time_travel_delta::Entity::find()
                 .select_only()
                 .column(hummock_time_travel_delta::Column::VersionId)
-                .filter(hummock_time_travel_delta::Column::VersionId.lt(latest_valid_version_id))
+                .filter(delta_delete_condition.clone())
                 .into_tuple()
                 .all(&txn)
                 .await?;
@@ -226,7 +298,7 @@ impl HummockManager {
                 );
                 let new_sst_ids = delta_to_delete.newly_added_sst_ids(true);
                 // The SST ids added and then deleted by compaction between the 2 versions.
-                sst_ids_to_delete.extend(&new_sst_ids - &latest_valid_version_sst_ids);
+                sst_ids_to_delete.extend(&new_sst_ids - &retained_snapshot_sst_ids);
                 if sst_ids_to_delete.len() >= delete_sst_batch_size {
                     delete_sst_in_batch(
                         &txn,
@@ -236,10 +308,9 @@ impl HummockManager {
                     .await?;
                 }
                 let new_object_ids = delta_to_delete.newly_added_object_ids(true);
-                object_ids_to_delete.extend(&new_object_ids - &latest_valid_version_object_ids);
+                object_ids_to_delete.extend(&new_object_ids - &retained_snapshot_object_ids);
             }
         }
-        let mut next_version_sst_ids = latest_valid_version_sst_ids;
         for prev_version_id in version_ids_to_delete {
             let prev_version = {
                 let prev_version = hummock_time_travel_version::Entity::find_by_id(prev_version_id)
@@ -256,8 +327,7 @@ impl HummockManager {
                 )
             };
             let sst_ids = prev_version.get_sst_ids();
-            // The SST ids deleted by compaction between the 2 versions.
-            sst_ids_to_delete.extend(&sst_ids - &next_version_sst_ids);
+            sst_ids_to_delete.extend(&sst_ids - &retained_snapshot_sst_ids);
             if sst_ids_to_delete.len() >= delete_sst_batch_size {
                 delete_sst_in_batch(
                     &txn,
@@ -267,8 +337,7 @@ impl HummockManager {
                 .await?;
             }
             let new_object_ids: HashSet<_> = prev_version.get_object_ids().collect();
-            object_ids_to_delete.extend(&new_object_ids - &latest_valid_version_object_ids);
-            next_version_sst_ids = sst_ids;
+            object_ids_to_delete.extend(&new_object_ids - &retained_snapshot_object_ids);
         }
         if !sst_ids_to_delete.is_empty() {
             delete_sst_in_batch(&txn, sst_ids_to_delete, delete_sst_batch_size).await?;
@@ -282,7 +351,7 @@ impl HummockManager {
         }
 
         let res = hummock_time_travel_version::Entity::delete_many()
-            .filter(hummock_time_travel_version::Column::VersionId.lt(latest_valid_version_id))
+            .filter(version_delete_condition)
             .exec(&txn)
             .await?;
         tracing::info!(
@@ -293,7 +362,7 @@ impl HummockManager {
         );
 
         let res = hummock_time_travel_delta::Entity::delete_many()
-            .filter(hummock_time_travel_delta::Column::VersionId.lt(latest_valid_version_id))
+            .filter(delta_delete_condition)
             .exec(&txn)
             .await?;
         tracing::info!(
@@ -492,27 +561,26 @@ impl HummockManager {
             "convert query epoch"
         );
 
-        let replay_version = hummock_time_travel_version::Entity::find()
-            .filter(hummock_time_travel_version::Column::VersionId.lte(actual_version_id))
-            .order_by_desc(hummock_time_travel_version::Column::VersionId)
-            .one(&sql_store.conn)
-            .await?
-            .ok_or_else(|| Error::TimeTravelVersionExpired {
+        let Some(resolved) =
+            resolve_time_travel_version(&sql_store.conn, actual_version_id).await?
+        else {
+            return Err(Error::TimeTravelVersionExpired {
                 table_id,
                 epoch: query_epoch,
-            })?;
-        let deltas = hummock_time_travel_delta::Entity::find()
-            .filter(hummock_time_travel_delta::Column::VersionId.gt(replay_version.version_id))
-            .filter(hummock_time_travel_delta::Column::VersionId.lte(actual_version_id))
-            .order_by_asc(hummock_time_travel_delta::Column::VersionId)
-            .all(&sql_store.conn)
-            .await?;
-        // SstableInfo in actual_version is incomplete before refill_version.
+            });
+        };
         let mut actual_version = replay_archive(
-            replay_version.version.to_protobuf(),
-            deltas.into_iter().map(|d| d.version_delta.to_protobuf()),
-        );
+            resolved.replay_version.to_protobuf(),
+            resolved.deltas.into_iter().map(|delta| delta.to_protobuf()),
+        )?;
+        if actual_version.id != actual_version_id {
+            return Err(Error::TimeTravelVersionExpired {
+                table_id,
+                epoch: query_epoch,
+            });
+        }
 
+        // SstableInfo in actual_version is incomplete before refill_version.
         let mut sst_ids = actual_version
             .get_sst_ids()
             .into_iter()
@@ -706,11 +774,49 @@ impl HummockManager {
     }
 }
 
+struct ResolvedTimeTravelVersion {
+    replay_version: IncompleteHummockVersion,
+    deltas: Vec<IncompleteHummockVersionDelta>,
+}
+
+async fn resolve_time_travel_version(
+    conn: &impl ConnectionTrait,
+    actual_version_id: HummockVersionId,
+) -> Result<Option<ResolvedTimeTravelVersion>> {
+    let Some(replay_version) = hummock_time_travel_version::Entity::find()
+        .filter(hummock_time_travel_version::Column::VersionId.lte(actual_version_id))
+        .order_by_desc(hummock_time_travel_version::Column::VersionId)
+        .one(conn)
+        .await?
+    else {
+        return Ok(None);
+    };
+    let deltas = hummock_time_travel_delta::Entity::find()
+        .filter(hummock_time_travel_delta::Column::VersionId.gt(replay_version.version_id))
+        .filter(hummock_time_travel_delta::Column::VersionId.lte(actual_version_id))
+        .order_by_asc(hummock_time_travel_delta::Column::VersionId)
+        .all(conn)
+        .await?;
+    Ok(Some(ResolvedTimeTravelVersion {
+        replay_version: IncompleteHummockVersion::from_persisted_protobuf_owned(
+            replay_version.version.to_protobuf(),
+        ),
+        deltas: deltas
+            .into_iter()
+            .map(|delta| {
+                IncompleteHummockVersionDelta::from_persisted_protobuf_owned(
+                    delta.version_delta.to_protobuf(),
+                )
+            })
+            .collect(),
+    }))
+}
+
 /// The `HummockVersion` is actually `InHummockVersion`. It requires `refill_version`.
 fn replay_archive(
     version: PbHummockVersion,
     deltas: impl Iterator<Item = PbHummockVersionDelta>,
-) -> HummockVersion {
+) -> Result<HummockVersion> {
     // The pb version ann pb version delta are actually written by InHummockVersion and InHummockVersionDelta, respectively.
     // Using HummockVersion make it easier for `refill_version` later.
     let mut last_version = HummockVersion::from_persisted_protobuf_owned(version);
@@ -721,14 +827,18 @@ fn replay_archive(
             "unexpected time travel delta {:?}",
             d
         );
-        // Need to work around the assertion in `apply_version_delta`.
-        // Because compaction deltas are not included in time travel archive.
-        while last_version.id < d.prev_id {
-            last_version.id += 1;
+        if d.prev_id < last_version.id {
+            return Err(Error::TimeTravel(anyhow!(format!(
+                "invalid time travel delta chain: delta {} has prev version {}, but replay has reached {}",
+                d.id, d.prev_id, last_version.id
+            ))));
         }
+        // Compaction deltas are not included in the time travel archive, so there may be gaps
+        // between the last replayed version and this delta's previous version.
+        last_version.id = d.prev_id;
         last_version.apply_version_delta(&d);
     }
-    last_version
+    Ok(last_version)
 }
 
 pub fn require_sql_meta_store_err() -> Error {
@@ -743,4 +853,30 @@ pub fn should_mark_next_time_travel_version_snapshot(delta: &HummockVersionDelta
             .iter()
             .any(|d| !matches!(d, GroupDeltaCommon::NewL0SubLevel(_)))
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn version(id: u64) -> PbHummockVersion {
+        let mut version = HummockVersion::default();
+        version.id = id.into();
+        version.to_protobuf()
+    }
+
+    fn delta(id: u64, prev_id: u64) -> PbHummockVersionDelta {
+        let mut delta = HummockVersionDelta::default();
+        delta.id = id.into();
+        delta.prev_id = prev_id.into();
+        delta.to_protobuf()
+    }
+
+    #[test]
+    fn test_replay_archive_delta_chain() {
+        let replayed = replay_archive(version(1), [delta(4, 3), delta(5, 4)].into_iter()).unwrap();
+        assert_eq!(replayed.id, HummockVersionId::new(5));
+
+        assert!(replay_archive(version(3), [delta(4, 2)].into_iter()).is_err());
+    }
 }

--- a/src/meta/src/hummock/mod.rs
+++ b/src/meta/src/hummock/mod.rs
@@ -26,24 +26,29 @@ mod metrics_utils;
 pub mod mock_hummock_meta_client;
 pub mod model;
 pub mod test_utils;
+use std::collections::{HashMap, HashSet};
 use std::time::Duration;
 
 pub use compactor_manager::*;
 use futures::future::BoxFuture;
 #[cfg(any(test, feature = "test"))]
 pub use mock_hummock_meta_client::MockHummockMetaClient;
+use risingwave_common::catalog::TableId;
 use tokio::sync::oneshot::Sender;
 use tokio::task::JoinHandle;
 
 use crate::MetaOpts;
 use crate::backup_restore::BackupManagerRef;
 
+type PinnedSnapshotEpochsFetcher =
+    Box<dyn Fn() -> BoxFuture<'static, Option<HashMap<TableId, HashSet<u64>>>> + Send>;
+
 /// Start hummock's asynchronous tasks.
 pub fn start_hummock_workers(
     hummock_manager: HummockManagerRef,
     backup_manager: BackupManagerRef,
     meta_opts: &MetaOpts,
-    should_pause_vacuum_time_travel: Box<dyn Fn() -> BoxFuture<'static, bool> + Send>,
+    get_pinned_snapshot_epochs: PinnedSnapshotEpochsFetcher,
 ) -> Vec<(JoinHandle<()>, Sender<()>)> {
     // These critical tasks are put in their own timer loop deliberately, to avoid long-running ones
     // from blocking others.
@@ -61,7 +66,7 @@ pub fn start_hummock_workers(
         start_vacuum_time_travel_metadata_loop(
             hummock_manager,
             Duration::from_secs(meta_opts.time_travel_vacuum_interval_sec),
-            should_pause_vacuum_time_travel,
+            get_pinned_snapshot_epochs,
         ),
     ];
     workers
@@ -97,7 +102,7 @@ pub fn start_vacuum_metadata_loop(
 pub fn start_vacuum_time_travel_metadata_loop(
     hummock_manager: HummockManagerRef,
     interval: Duration,
-    should_pause_vacuum_time_travel: Box<dyn Fn() -> BoxFuture<'static, bool> + Send>,
+    get_pinned_snapshot_epochs: PinnedSnapshotEpochsFetcher,
 ) -> (JoinHandle<()>, Sender<()>) {
     let (shutdown_tx, mut shutdown_rx) = tokio::sync::oneshot::channel();
     let join_handle = tokio::spawn(async move {
@@ -113,11 +118,16 @@ pub fn start_vacuum_time_travel_metadata_loop(
                     return;
                 }
             }
-            if should_pause_vacuum_time_travel().await {
-                tracing::warn!("time travel vacuum paused");
+            let Some(pinned_snapshot_epochs) = get_pinned_snapshot_epochs().await else {
+                tracing::warn!(
+                    "time travel vacuum paused because pinned snapshots are unavailable"
+                );
                 continue;
-            }
-            if let Err(err) = hummock_manager.delete_time_travel_metadata().await {
+            };
+            if let Err(err) = hummock_manager
+                .delete_time_travel_metadata(pinned_snapshot_epochs)
+                .await
+            {
                 tracing::warn!(error = %err.as_report(), "Vacuum time travel metadata error");
             }
         }


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

Cherry-pick #26326 to `release-3.0`.

Snapshot backfill currently pauses time-travel vacuum globally, retaining every archived epoch after the backfill snapshot and causing metadata growth during long-running jobs.

This PR replaces the global pause with explicit snapshot pins:

- Collect snapshot-backfill and cross-database backfill `(table_id, epoch)` pins from persisted fragments of jobs in the `Creating` state.
- Resolve pins through the catalog controller while holding its read lock, so job-state transitions cannot race with fragment inspection.
- Preserve independently pinned versions, epoch mappings, SST metadata, and objects while allowing expired intervening time-travel metadata to be vacuumed.
- Deduplicate identical pins while retaining multiple epochs required by concurrent backfills.
- Keep pinned versions out of incremental vacuum progress accounting.
- Log and skip malformed persisted scan metadata; catalog query failures pause the current vacuum iteration.

Original PR: #26326

## Checklist

- [ ] I have written necessary rustdoc comments.
- [x] I have added necessary unit tests and integration tests.
- [x] I have added test labels as necessary.
- [ ] I have added fuzzing tests or opened an issue to track them.
- [ ] My PR contains breaking changes.
- [ ] My PR changes performance-critical code, so I will run (micro) benchmarks and present the results.
- [x] I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into.

## Testing

- `cargo test -p risingwave_meta test_time_travel_vacuum_pins_snapshot_epoch --all-features`
- `cargo clippy --all-targets --all-features`

## Documentation

- [ ] My PR needs documentation updates.

<details>
<summary><b>Release note</b></summary>

Not applicable; this changes internal time-travel metadata retention behavior.

</details>
