### PR TITLE
feat(connector): support Pulsar schema registry for Avro

### DIFF
--- a/src/connector/src/parser/avro/mod.rs
+++ b/src/connector/src/parser/avro/mod.rs
@@ -15,7 +15,9 @@
 mod confluent_resolver;
 mod glue_resolver;
 mod parser;
+mod pulsar_resolver;
 
 pub use confluent_resolver::ConfluentSchemaCache;
 pub use glue_resolver::{GlueSchemaCache, GlueSchemaCacheImpl};
 pub use parser::{AvroAccessBuilder, AvroParserConfig};
+pub use pulsar_resolver::PulsarSchemaCache;

--- a/src/connector/src/parser/avro/parser.rs
+++ b/src/connector/src/parser/avro/parser.rs
@@ -24,13 +24,14 @@ use risingwave_connector_codec::decoder::avro::{
     AvroAccess, AvroParseOptions, ResolvedAvroSchema, avro_schema_to_fields,
 };
 
-use super::{ConfluentSchemaCache, GlueSchemaCache as _, GlueSchemaCacheImpl};
+use super::{ConfluentSchemaCache, GlueSchemaCache as _, GlueSchemaCacheImpl, PulsarSchemaCache};
 use crate::error::ConnectorResult;
 use crate::parser::unified::AccessImpl;
 use crate::parser::utils::bytes_from_url;
 use crate::parser::{
     AccessBuilder, AvroProperties, EncodingProperties, MapHandling, SchemaLocation,
 };
+use crate::schema::pulsar::pulsar_schema_version_to_i64;
 use crate::schema::schema_registry::{
     Client, extract_schema_id, get_subject_by_strategy, handle_sr_list,
 };
@@ -96,7 +97,7 @@ impl AvroAccessBuilder {
     async fn parse_avro_value(
         &self,
         payload: &[u8],
-        _source_meta: &SourceMeta,
+        source_meta: &SourceMeta,
     ) -> ConnectorResult<Option<Value>> {
         // parse payload to avro value
         // if use confluent schema, get writer schema from confluent schema registry
@@ -118,6 +119,26 @@ impl AvroAccessBuilder {
                     Some(Err(e)) => Err(e)?,
                     None => bail!("avro parse unexpected eof"),
                 }
+            }
+            WriterSchemaCache::Pulsar(resolver) => {
+                let schema_version = match source_meta {
+                    SourceMeta::Pulsar(meta) => meta.schema_version.as_deref(),
+                    _ => None,
+                };
+                let writer_schema = match schema_version
+                    .map(pulsar_schema_version_to_i64)
+                    .transpose()?
+                    .flatten()
+                {
+                    Some(version) => resolver.get_by_version(version).await?,
+                    None => resolver.get_latest().await?,
+                };
+                let mut raw_payload = payload;
+                Ok(Some(from_avro_datum(
+                    writer_schema.as_ref(),
+                    &mut raw_payload,
+                    Some(&self.schema.original_schema),
+                )?))
             }
             WriterSchemaCache::Glue(resolver) => {
                 // <https://github.com/awslabs/aws-glue-schema-registry/blob/v1.1.20/common/src/main/java/com/amazonaws/services/schemaregistry/utils/AWSSchemaRegistryConstants.java#L59-L61>
@@ -164,6 +185,7 @@ pub struct AvroParserConfig {
 enum WriterSchemaCache {
     Confluent(Arc<ConfluentSchemaCache>),
     Glue(Arc<GlueSchemaCacheImpl>),
+    Pulsar(Arc<PulsarSchemaCache>),
     File,
 }
 
@@ -231,6 +253,15 @@ impl AvroParserConfig {
                 Ok(Self {
                     schema: Arc::new(ResolvedAvroSchema::create(schema)?),
                     writer_schema_cache: WriterSchemaCache::Glue(Arc::new(resolver)),
+                    map_handling,
+                })
+            }
+            SchemaLocation::Pulsar(config) => {
+                let resolver = PulsarSchemaCache::new(config)?;
+                let schema = resolver.get_latest().await?;
+                Ok(Self {
+                    schema: Arc::new(ResolvedAvroSchema::create(schema)?),
+                    writer_schema_cache: WriterSchemaCache::Pulsar(Arc::new(resolver)),
                     map_handling,
                 })
             }

--- a/src/connector/src/parser/avro/pulsar_resolver.rs
+++ b/src/connector/src/parser/avro/pulsar_resolver.rs
@@ -1,0 +1,68 @@
+// Copyright 2024 RisingWave Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+
+use anyhow::{Context, ensure};
+use apache_avro::Schema;
+use moka::future::Cache;
+
+use crate::error::ConnectorResult;
+use crate::schema::pulsar::{PulsarSchema, PulsarSchemaClient, PulsarSchemaRegistryConfig};
+
+#[derive(Debug)]
+pub struct PulsarSchemaCache {
+    writer_schemas: Cache<i64, Arc<Schema>>,
+    pulsar_client: PulsarSchemaClient,
+}
+
+impl PulsarSchemaCache {
+    pub fn new(config: PulsarSchemaRegistryConfig) -> ConnectorResult<Self> {
+        Ok(Self {
+            writer_schemas: Cache::new(u64::MAX),
+            pulsar_client: PulsarSchemaClient::new(config)?,
+        })
+    }
+
+    async fn parse_and_cache_schema(
+        &self,
+        raw_schema: PulsarSchema,
+    ) -> ConnectorResult<Arc<Schema>> {
+        ensure!(
+            raw_schema.schema_type.eq_ignore_ascii_case("AVRO"),
+            "expected Pulsar AVRO schema, got {}",
+            raw_schema.schema_type
+        );
+        let schema =
+            Schema::parse_str(&raw_schema.data).context("failed to parse Pulsar avro schema")?;
+        let schema = Arc::new(schema);
+        self.writer_schemas
+            .insert(raw_schema.version, Arc::clone(&schema))
+            .await;
+        Ok(schema)
+    }
+
+    pub async fn get_latest(&self) -> ConnectorResult<Arc<Schema>> {
+        self.parse_and_cache_schema(self.pulsar_client.get_latest_schema().await?)
+            .await
+    }
+
+    pub async fn get_by_version(&self, version: i64) -> ConnectorResult<Arc<Schema>> {
+        if let Some(schema) = self.writer_schemas.get(&version).await {
+            return Ok(schema);
+        }
+        self.parse_and_cache_schema(self.pulsar_client.get_schema_by_version(version).await?)
+            .await
+    }
+}

--- a/src/connector/src/parser/config.rs
+++ b/src/connector/src/parser/config.rs
@@ -22,14 +22,18 @@ use risingwave_pb::catalog::{PbSchemaRegistryNameStrategy, StreamSourceInfo};
 use super::unified::json::BigintUnsignedHandlingMode;
 use super::utils::get_kafka_topic;
 use super::{DebeziumProps, TimeHandling, TimestampHandling, TimestamptzHandling};
-use crate::WithOptionsSecResolved;
 use crate::connector_common::AwsAuthProps;
 use crate::error::ConnectorResult;
 use crate::parser::PROTOBUF_MESSAGES_AS_JSONB;
-use crate::schema::AWS_GLUE_SCHEMA_ARN_KEY;
+use crate::schema::pulsar::PulsarSchemaRegistryConfig;
 use crate::schema::schema_registry::SchemaRegistryConfig;
+use crate::schema::{AWS_GLUE_SCHEMA_ARN_KEY, SCHEMA_REGISTRY_TYPE_KEY};
 use crate::source::cdc::CDC_MONGODB_STRONG_SCHEMA_KEY;
 use crate::source::{SourceColumnDesc, SourceEncode, SourceFormat, extract_source_struct};
+use crate::{WithOptionsSecResolved, WithPropertiesExt};
+
+const SCHEMA_REGISTRY_TYPE_PULSAR: &str = "pulsar";
+const SCHEMA_REGISTRY_TYPE_CONFLUENT: &str = "confluent";
 
 pub const PARQUET_CASE_INSENSITIVE_KEY: &str = "parquet.case_insensitive";
 
@@ -55,6 +59,59 @@ fn parse_parquet_case_insensitive_option(
         ),
     };
     Ok(parsed)
+}
+
+fn use_pulsar_schema_registry(options: &BTreeMap<String, String>) -> bool {
+    options
+        .get(SCHEMA_REGISTRY_TYPE_KEY)
+        .is_some_and(|value| value.eq_ignore_ascii_case(SCHEMA_REGISTRY_TYPE_PULSAR))
+}
+
+fn validate_schema_registry_type(
+    format_options: &BTreeMap<String, String>,
+    source_options: &BTreeMap<String, String>,
+) -> ConnectorResult<()> {
+    let Some(value) = format_options.get(SCHEMA_REGISTRY_TYPE_KEY) else {
+        return Ok(());
+    };
+    if value.eq_ignore_ascii_case(SCHEMA_REGISTRY_TYPE_CONFLUENT) {
+        return Ok(());
+    }
+    if value.eq_ignore_ascii_case(SCHEMA_REGISTRY_TYPE_PULSAR) {
+        if source_options.is_pulsar_connector() {
+            return Ok(());
+        }
+        bail!("schema registry type `pulsar` can only be used with Pulsar sources");
+    }
+    bail!(
+        "unsupported schema registry type `{}`, expected `{}` or `{}`",
+        value,
+        SCHEMA_REGISTRY_TYPE_CONFLUENT,
+        SCHEMA_REGISTRY_TYPE_PULSAR
+    );
+}
+
+fn get_pulsar_auth_token(options: &BTreeMap<String, String>) -> Option<String> {
+    options
+        .get("auth.token")
+        .or_else(|| options.get("pulsar.auth.token"))
+        .cloned()
+}
+
+fn get_pulsar_schema_registry_config(
+    admin_url: String,
+    options: &BTreeMap<String, String>,
+) -> ConnectorResult<PulsarSchemaRegistryConfig> {
+    let topic = options
+        .get("pulsar.topic")
+        .or_else(|| options.get("topic"))
+        .ok_or_else(|| anyhow::anyhow!("Must specify 'pulsar.topic' or 'topic'"))?
+        .clone();
+    Ok(PulsarSchemaRegistryConfig {
+        admin_url,
+        topic,
+        auth_token: get_pulsar_auth_token(options),
+    })
 }
 
 impl ParserConfig {
@@ -138,6 +195,7 @@ impl SpecificParserConfig {
             LocalSecretManager::global().fill_secrets(options, secret_refs)?;
         let format = source_struct.format;
         let encode = source_struct.encode;
+        validate_schema_registry_type(&format_encode_options_with_secret, &options_with_secret)?;
         // this transformation is needed since there may be config for the protocol
         // in the future
         let protocol_config = match format {
@@ -194,6 +252,13 @@ impl SpecificParserConfig {
                             .get("aws.glue.mock_config")
                             .cloned(),
                     }
+                } else if info.use_schema_registry
+                    && use_pulsar_schema_registry(&format_encode_options_with_secret)
+                {
+                    SchemaLocation::Pulsar(get_pulsar_schema_registry_config(
+                        info.row_schema_location.clone(),
+                        &options_with_secret,
+                    )?)
                 } else if info.use_schema_registry {
                     SchemaLocation::Confluent {
                         urls: info.row_schema_location.clone(),
@@ -237,7 +302,14 @@ impl SpecificParserConfig {
                     messages_as_jsonb,
                     ..Default::default()
                 };
-                config.schema_location = if info.use_schema_registry {
+                config.schema_location = if info.use_schema_registry
+                    && use_pulsar_schema_registry(&format_encode_options_with_secret)
+                {
+                    SchemaLocation::Pulsar(get_pulsar_schema_registry_config(
+                        info.row_schema_location.clone(),
+                        &options_with_secret,
+                    )?)
+                } else if info.use_schema_registry {
                     SchemaLocation::Confluent {
                         urls: info.row_schema_location.clone(),
                         client_config: SchemaRegistryConfig::from(
@@ -348,6 +420,8 @@ pub enum SchemaLocation {
         // When `Some(_)`, ignore AWS and load schemas from provided config
         mock_config: Option<String>,
     },
+    /// Pulsar admin schema endpoint.
+    Pulsar(PulsarSchemaRegistryConfig),
 }
 
 // TODO: `SpecificParserConfig` shall not `impl`/`derive` a `Default`

--- a/src/connector/src/parser/protobuf/parser.rs
+++ b/src/connector/src/parser/protobuf/parser.rs
@@ -95,6 +95,9 @@ impl TryFrom<&SchemaLocation> for WireType {
             SchemaLocation::Glue { .. } => bail_invalid_option_error!(
                 "encode protobuf from aws glue schema registry not supported yet"
             ),
+            SchemaLocation::Pulsar(_) => bail_invalid_option_error!(
+                "encode protobuf from Pulsar schema registry not supported yet"
+            ),
         }
     }
 }
@@ -150,6 +153,9 @@ impl ProtobufParserConfig {
             }
             SchemaLocation::Glue { .. } => bail_invalid_option_error!(
                 "encode protobuf from aws glue schema registry not supported yet"
+            ),
+            SchemaLocation::Pulsar(_) => bail_invalid_option_error!(
+                "encode protobuf from Pulsar schema registry not supported yet"
             ),
         };
 

--- a/src/connector/src/schema/mod.rs
+++ b/src/connector/src/schema/mod.rs
@@ -17,6 +17,7 @@ use crate::error::ConnectorError;
 pub mod avro;
 mod loader;
 pub mod protobuf;
+pub mod pulsar;
 pub mod schema_registry;
 
 pub use loader::{ConfluentSchemaLoader, SchemaLoader, SchemaVersion};
@@ -26,6 +27,7 @@ const KEY_MESSAGE_NAME_KEY: &str = "key.message";
 const SCHEMA_LOCATION_KEY: &str = "schema.location";
 const SCHEMA_REGISTRY_KEY: &str = "schema.registry";
 const NAME_STRATEGY_KEY: &str = "schema.registry.name.strategy";
+pub const SCHEMA_REGISTRY_TYPE_KEY: &str = "schema.registry.type";
 pub const AWS_GLUE_SCHEMA_ARN_KEY: &str = "aws.glue.schema_arn";
 
 #[derive(Debug, thiserror::Error, thiserror_ext::Macro)]

--- a/src/connector/src/schema/pulsar.rs
+++ b/src/connector/src/schema/pulsar.rs
@@ -1,0 +1,191 @@
+// Copyright 2024 RisingWave Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use anyhow::{Context, ensure};
+use reqwest::header::{AUTHORIZATION, HeaderMap, HeaderValue};
+use reqwest::{Client, Method, Url};
+use serde::Deserialize;
+use serde::de::DeserializeOwned;
+
+use crate::error::ConnectorResult;
+use crate::schema::schema_registry::handle_sr_list;
+use crate::source::pulsar::topic::parse_topic;
+
+#[derive(Debug, Clone)]
+pub struct PulsarSchemaRegistryConfig {
+    pub admin_url: String,
+    pub topic: String,
+    pub auth_token: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct PulsarSchemaClient {
+    inner: Client,
+    admin_url: Url,
+    topic_path: Vec<String>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct PulsarSchema {
+    pub version: i64,
+    #[serde(rename = "type")]
+    pub schema_type: String,
+    pub data: String,
+}
+
+impl PulsarSchemaClient {
+    pub fn new(config: PulsarSchemaRegistryConfig) -> ConnectorResult<Self> {
+        let admin_url = handle_sr_list(&config.admin_url)?
+            .into_iter()
+            .next()
+            .context("pulsar schema registry URL is empty")?;
+        ensure!(
+            !admin_url.cannot_be_a_base(),
+            "Pulsar admin URL must be a base URL"
+        );
+        let topic = parse_topic(&config.topic)?;
+        let mut headers = HeaderMap::new();
+        if let Some(token) = config.auth_token {
+            let token = token.strip_prefix("token:").unwrap_or(&token);
+            let value = HeaderValue::from_str(&format!("Bearer {token}"))
+                .context("invalid Pulsar auth token header")?;
+            headers.insert(AUTHORIZATION, value);
+        }
+        let inner = Client::builder()
+            .default_headers(headers)
+            .build()
+            .context("failed to build Pulsar schema client")?;
+        let topic_name = topic.topic_str_without_partition()?;
+
+        Ok(Self {
+            inner,
+            admin_url,
+            topic_path: vec![topic.domain, topic.tenant, topic.namespace, topic_name],
+        })
+    }
+
+    pub async fn get_latest_schema(&self) -> ConnectorResult<PulsarSchema> {
+        self.request(&["schema"]).await
+    }
+
+    pub async fn get_schema_by_version(&self, version: i64) -> ConnectorResult<PulsarSchema> {
+        let version = version.to_string();
+        self.request(&["schema", version.as_str()]).await
+    }
+
+    fn schema_url(&self, suffix: &[&str]) -> Url {
+        let mut url = self.admin_url.clone();
+        url.path_segments_mut()
+            .expect("constructor validates Pulsar admin URL can be a base")
+            .extend(["admin", "v2", "schemas"])
+            .extend(self.topic_path.iter().map(String::as_str))
+            .extend(suffix);
+        url
+    }
+
+    async fn request<T>(&self, suffix: &[&str]) -> ConnectorResult<T>
+    where
+        T: DeserializeOwned,
+    {
+        let url = self.schema_url(suffix);
+        let response = self
+            .inner
+            .request(Method::GET, url.clone())
+            .send()
+            .await
+            .with_context(|| format!("failed to fetch Pulsar schema from {url}"))?
+            .error_for_status()
+            .with_context(|| format!("Pulsar schema request failed for {url}"))?;
+        Ok(response
+            .json()
+            .await
+            .with_context(|| format!("failed to parse Pulsar schema response from {url}"))?)
+    }
+}
+
+pub fn pulsar_schema_version_to_i64(version: &[u8]) -> ConnectorResult<Option<i64>> {
+    if version.is_empty() {
+        return Ok(None);
+    }
+    let bytes: [u8; 8] = version.try_into().with_context(|| {
+        format!(
+            "expected 8-byte Pulsar LongSchemaVersion, got {} bytes",
+            version.len()
+        )
+    })?;
+    Ok(Some(i64::from_be_bytes(bytes)))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_config(topic: &str) -> PulsarSchemaRegistryConfig {
+        PulsarSchemaRegistryConfig {
+            admin_url: "http://localhost:8080".to_owned(),
+            topic: topic.to_owned(),
+            auth_token: Some("token:test-token".to_owned()),
+        }
+    }
+
+    #[test]
+    fn test_pulsar_schema_url_from_full_topic() {
+        let client = PulsarSchemaClient::new(test_config("persistent://tenant/ns/events")).unwrap();
+
+        assert_eq!(
+            client.schema_url(&["schema"]).as_str(),
+            "http://localhost:8080/admin/v2/schemas/persistent/tenant/ns/events/schema"
+        );
+        assert_eq!(
+            client.schema_url(&["schema", "42"]).as_str(),
+            "http://localhost:8080/admin/v2/schemas/persistent/tenant/ns/events/schema/42"
+        );
+    }
+
+    #[test]
+    fn test_pulsar_schema_url_from_short_topic() {
+        let client = PulsarSchemaClient::new(test_config("events")).unwrap();
+
+        assert_eq!(
+            client.schema_url(&["schema"]).as_str(),
+            "http://localhost:8080/admin/v2/schemas/persistent/public/default/events/schema"
+        );
+    }
+
+    #[test]
+    fn test_pulsar_schema_url_from_partition_topic() {
+        let client =
+            PulsarSchemaClient::new(test_config("persistent://tenant/ns/events-partition-1"))
+                .unwrap();
+
+        assert_eq!(
+            client.schema_url(&["schema"]).as_str(),
+            "http://localhost:8080/admin/v2/schemas/persistent/tenant/ns/events/schema"
+        );
+    }
+
+    #[test]
+    fn test_pulsar_schema_version_to_i64() {
+        assert_eq!(pulsar_schema_version_to_i64(&[]).unwrap(), None);
+        assert_eq!(
+            pulsar_schema_version_to_i64(&1_i64.to_be_bytes()).unwrap(),
+            Some(1)
+        );
+        assert_eq!(
+            pulsar_schema_version_to_i64(&(-1_i64).to_be_bytes()).unwrap(),
+            Some(-1)
+        );
+        assert!(pulsar_schema_version_to_i64(&[1, 2, 3]).is_err());
+    }
+}

--- a/src/frontend/src/handler/create_source.rs
+++ b/src/frontend/src/handler/create_source.rs
@@ -44,13 +44,13 @@ use risingwave_connector::parser::{
     SchemaLocation, SpecificParserConfig, TimestamptzHandling,
     fetch_json_schema_and_map_to_columns,
 };
-use risingwave_connector::schema::AWS_GLUE_SCHEMA_ARN_KEY;
 use risingwave_connector::schema::schema_registry::{
     SCHEMA_REGISTRY_BACKOFF_DURATION_KEY, SCHEMA_REGISTRY_BACKOFF_FACTOR_KEY,
     SCHEMA_REGISTRY_CA_PEM_PATH, SCHEMA_REGISTRY_MAX_DELAY_KEY, SCHEMA_REGISTRY_PASSWORD,
     SCHEMA_REGISTRY_RETRIES_MAX_KEY, SCHEMA_REGISTRY_USERNAME, SchemaRegistryConfig,
     name_strategy_from_str,
 };
+use risingwave_connector::schema::{AWS_GLUE_SCHEMA_ARN_KEY, SCHEMA_REGISTRY_TYPE_KEY};
 use risingwave_connector::source::cdc::{
     CDC_MONGODB_STRONG_SCHEMA_KEY, CDC_SHARING_MODE_KEY, CDC_SNAPSHOT_BACKFILL,
     CDC_SNAPSHOT_MODE_KEY, CDC_TRANSACTIONAL_KEY, CDC_WAIT_FOR_STREAMING_START_TIMEOUT,
@@ -151,6 +151,7 @@ fn try_consume_schema_registry_config_from_options(
         SCHEMA_REGISTRY_BACKOFF_DURATION_KEY,
         SCHEMA_REGISTRY_BACKOFF_FACTOR_KEY,
         SCHEMA_REGISTRY_RETRIES_MAX_KEY,
+        SCHEMA_REGISTRY_TYPE_KEY,
     ]
     .iter()
     .for_each(|key| {

--- a/src/frontend/src/handler/create_source/validate.rs
+++ b/src/frontend/src/handler/create_source/validate.rs
@@ -123,6 +123,25 @@ fn validate_license(connector: &str) -> Result<()> {
     Ok(())
 }
 
+fn uses_schema_registry(format_encode: &FormatEncodeOptions) -> Result<bool> {
+    match (&format_encode.format, &format_encode.row_encode) {
+        (Format::Plain, Encode::Protobuf) | (Format::Plain, Encode::Avro) => {
+            let mut options = WithOptions::try_from(format_encode.row_options())?;
+            let (_, use_schema_registry) = get_schema_location(options.inner_mut())?;
+            Ok(use_schema_registry)
+        }
+        (Format::Debezium, Encode::Avro) => Ok(true),
+        (_, _) => Ok(false),
+    }
+}
+
+fn uses_pulsar_schema_registry(format_encode: &FormatEncodeOptions) -> Result<bool> {
+    let options = WithOptions::try_from(format_encode.row_options())?;
+    Ok(options
+        .get(SCHEMA_REGISTRY_TYPE_KEY)
+        .is_some_and(|value| value.eq_ignore_ascii_case("pulsar")))
+}
+
 pub fn validate_compatibility(
     format_encode: &FormatEncodeOptions,
     props: &mut BTreeMap<String, String>,
@@ -157,19 +176,10 @@ pub fn validate_compatibility(
         })?;
 
     validate_license(&connector)?;
-    if connector != KAFKA_CONNECTOR {
-        let res = match (&format_encode.format, &format_encode.row_encode) {
-            (Format::Plain, Encode::Protobuf) | (Format::Plain, Encode::Avro) => {
-                let mut options = WithOptions::try_from(format_encode.row_options())?;
-                let (_, use_schema_registry) = get_schema_location(options.inner_mut())?;
-                use_schema_registry
-            }
-            (Format::Debezium, Encode::Avro) => true,
-            (_, _) => false,
-        };
-        if res {
+    if connector != KAFKA_CONNECTOR && uses_schema_registry(format_encode)? {
+        if !(connector == PULSAR_CONNECTOR && uses_pulsar_schema_registry(format_encode)?) {
             return Err(RwError::from(ProtocolError(format!(
-                "The {} must be kafka when schema registry is used",
+                "The {} must be kafka when schema registry is used, or pulsar when schema.registry.type is 'pulsar'",
                 UPSTREAM_SOURCE_KEY
             ))));
         }


### PR DESCRIPTION
## Motivation
RisingWave's Pulsar Avro source path currently requires schemas to come from a file-like location or a non-Pulsar schema registry. Native Pulsar producers store schema metadata in Pulsar and attach a schema version to messages, so users need a way for RisingWave to fetch the writer schema from the Pulsar admin schema endpoint and decode messages by version.

This adds an explicit Pulsar schema registry mode for Pulsar sources while preserving the existing Confluent default behavior for `schema.registry`.

## Modifications
- Add `schema.registry.type = 'pulsar'` to route Pulsar sources to the Pulsar admin schema endpoint.
- Add a Pulsar schema client/cache for latest and versioned Avro schemas, including token auth and partition-topic normalization.
- Decode Pulsar Avro payloads using the schema version from Pulsar source metadata.
- Update frontend validation and option consumption for `schema.registry.type`.
- Return an explicit unsupported error for Protobuf with Pulsar schema registry.

## Testing
- `cargo +nightly-2026-06-11 fmt --check`
- `git diff --cached --check`
- `RUSTFLAGS='--cfg tokio_unstable -Zhigher-ranked-assumptions' CARGO_NET_GIT_FETCH_WITH_CLI=true CXX=/usr/bin/clang++ cargo +nightly-2026-06-11 test -p risingwave_connector pulsar_schema --lib` blocked locally before reaching this change: `faiss-sys` hardcodes missing `/opt/homebrew/opt/llvm/bin/clang++`, and Homebrew `llvm` is not installed on this machine.
