### PR TITLE
test(iceberg): de-flake position-delete assertion and always clean up

### DIFF
--- a/e2e_test/iceberg/main.py
+++ b/e2e_test/iceberg/main.py
@@ -28,6 +28,7 @@ def run_test_case(test_file: str, args: dict) -> TestResult:
     start_time = datetime.now()
     error = None
     success = True
+    drop_sqls = None
 
     try:
         with open(test_file, "rb") as f:
@@ -55,8 +56,6 @@ def run_test_case(test_file: str, args: dict) -> TestResult:
                 compare_sql(args, cmp_sqls)
             if verify_slt:
                 execute_slt(args, verify_slt)
-            if drop_sqls:
-                drop_table(args, drop_sqls)
     except KeyboardInterrupt:
         log(f"test case {test_file} interrupted by user", level=LogLevel.ERROR)
         error = "Interrupted by user"
@@ -70,6 +69,16 @@ def run_test_case(test_file: str, args: dict) -> TestResult:
         success = False
         raise e
     finally:
+        # Clean up even when the case failed: a leftover table keeps the shared
+        # namespace non-empty and fails every later case's DROP SCHEMA.
+        if drop_sqls:
+            try:
+                drop_table(args, drop_sqls)
+            except Exception as e:
+                # drop_table already logged the cause; don't mask an earlier failure.
+                if success:
+                    error = e
+                    success = False
         duration = datetime.now() - start_time
         return TestResult(test_file, success, duration, error)
 

--- a/e2e_test/iceberg/test_case/iceberg_source_position_delete.slt
+++ b/e2e_test/iceberg/test_case/iceberg_source_position_delete.slt
@@ -1,4 +1,7 @@
-# Deletions in a single commit are posistion delete, deletions across multiple commits are equail delete. sink_decouple = default(true), so we'll commit every 10s.
+# A delete is encoded as a position delete only when it shares an iceberg commit with the
+# insert it deletes, and as an equality delete otherwise. The sink commits every
+# commit_checkpoint_interval checkpoints counted from sink startup, so the interval has to be
+# comfortably larger than the number of checkpoints the statements below can consume.
 statement ok
 set streaming_parallelism=4;
 
@@ -22,7 +25,7 @@ CREATE SINK sink1 AS select * from mv1 WITH (
     s3.access.key = 'hummockadmin',
     s3.secret.key = 'hummockadmin',
     create_table_if_not_exists = 'true',
-    commit_checkpoint_interval = 5,
+    commit_checkpoint_interval = 20,
     primary_key = 'i1,i2',
     partition_by = 'i1'
 );
@@ -36,8 +39,10 @@ flush
 statement ok
 DELETE FROM s1 WHERE i1 < 3;
 
-sleep 20s
-
+# DELETE does not flush implicitly; flushing keeps it in the checkpoint right after the
+# insert's instead of leaving it to the next periodic barrier.
+statement ok
+flush
 
 statement ok
 CREATE SOURCE iceberg_t1_source
@@ -53,9 +58,9 @@ WITH (
     table.name = 'test_position_delete',
 );
 
-# check there should be at least one PositionDeletes
-query T
-select count(*) >= 1 from rw_iceberg_files where content = 'PositionDeletes';
+# Wait for the sink's first commit instead of sleeping for a fixed guess of the interval.
+query T retry 20 backoff 3s
+select count(*) >= 1 from rw_iceberg_files where source_name = 'iceberg_t1_source' and content = 'PositionDeletes';
 ----
 t
 


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

Fixes the flaky `iceberg_source_position_delete.slt` assertion, and the namespace poisoning that turned that single flaky assertion into four red test cases.

### 1. The flaky assertion

A delete is encoded as a **position** delete only when it shares an iceberg commit with the insert it deletes; otherwise it becomes an equality delete. The sink commits every `commit_checkpoint_interval` checkpoints, counted from sink startup (`src/connector/src/sink/coordinate.rs`).

With `commit_checkpoint_interval = 5` and ~1s checkpoints, the sequence `CREATE SINK → INSERT → flush → DELETE` already consumes 3-4 checkpoints, leaving only **1-2 checkpoints of slack**. Under CI load a commit boundary lands between the insert and the delete, the insert's data file is already committed when the delete arrives, and the sink emits an equality delete.

Two changes:

- `commit_checkpoint_interval` 5 → 20, so the failure now requires the sequence to consume 20 checkpoints instead of 5.
- The fixed `sleep 20s` becomes `retry 20 backoff 3s` on the delete-file assertion, so the test waits for the commit rather than guessing when it happens. The `CREATE SOURCE` moves ahead of the wait; it succeeds against the zero-snapshot table the sink has created by then, and the iceberg source re-reads table metadata per query, so the poll observes the later commit.

A `flush` is also added after the `DELETE` — `DELETE` has no implicit flush, so this keeps it in the checkpoint right after the insert's instead of leaving it to the next periodic barrier.

Verified locally against the real harness: **4/4 passes, ~21s per run** (down from 29-32s — the poll returns as soon as the commit lands instead of always sleeping 20s), with `PositionDeletes 2` / `EqualityDeletes 0` and the retry budget running ~3x the observed commit latency.

**This is a wider margin, not an invariant.** A sequence that consumes 20 checkpoints still breaks it. Pinning the flavor deterministically needs a unit test over `iceberg_scan.rs` driven with a hand-built position-delete file, which is worth a follow-up.

### 2. The cascade

`drop_sqls` ran after `execute_slt` inside the same `try`, so a failing case skipped cleanup entirely and leaked `demo_db.test_position_delete`. Every later case in the shard then failed its `DROP SCHEMA IF EXISTS demo_db` with `NamespaceNotEmptyException` — one flaky assertion produced four failures (`Total Tests: 10, Passed: 6, Failed: 4`).

Cleanup now runs in a `finally`. A cleanup error no longer masks the failure that triggered it, and a cleanup-only failure still surfaces.

Verified by driving `run_test_case` with stubbed helpers across all four paths:

| slt | cleanup | before | after |
|---|---|---|---|
| ok | ok | drop ran, pass | drop ran, pass |
| **fails** | ok | **drop skipped** | **drop ran**, reports slt error |
| **fails** | fails | **drop skipped** | **drop ran**, reports slt error (not masked) |
| ok | fails | drop ran, fail | drop ran, fail |

Observed occurrences: Buildkite `pull-request` build 98417 (job "end-to-end iceberg test", on #26323) and build 98070.

Note: `release-3.0` hits this same flake, so this is probably worth cherry-picking there.

### Side finding (not fixed here)

While testing, `DROP SINK` was tried as a way to force-commit the pending window. It does not work, and the reason looks like a real bug: a decoupled sink's uncommitted window is **silently discarded** on drop. `should_force_commit_on_checkpoint_barrier` has an `is_stop` arm, but the stop barrier does not make the sink executor wait for the log store to drain (`should_flush_sink_log_store` is only set on `Mutation::Add`), so the actor tears down with the log consumer before it commits. Reproduced with `commit_checkpoint_interval = 100`: after `DROP SINK`, the iceberg table had zero snapshots and zero rows, and `coordinated log sinker stops` never appeared in the log. `ALTER SINK ... SET PARALLELISM` is affected the same way. Filing separately.

- Closes #26205

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [x] <!-- OPTIONAL --> I have added test labels as necessary.
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them.
- [ ] <!-- OPTIONAL --> My PR contains breaking changes.
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results.
- [x] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into.

## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates.

<details>
<summary><b>Release note</b></summary>

Not applicable; this only changes e2e test assertions and the iceberg e2e test runner's cleanup.

</details>
