### PR TITLE
feat(connector): allow altering OpenSearch sink batching

### DIFF
--- a/src/connector/src/allow_alter_on_fly_fields.rs
+++ b/src/connector/src/allow_alter_on_fly_fields.rs
@@ -229,6 +229,15 @@ pub static SINK_ALLOW_ALTER_ON_FLY_FIELDS: LazyLock<HashMap<String, HashSet<Stri
             "doris.stream_load.http.timeout.ms".to_owned(),
         ].into_iter().collect(),
     ).unwrap();
+    // ElasticSearchConfig
+    map.try_insert(
+        std::any::type_name::<ElasticSearchConfig>().to_owned(),
+        [
+            "batch_num_messages".to_owned(),
+            "batch_size_kb".to_owned(),
+            "concurrent_requests".to_owned(),
+        ].into_iter().collect(),
+    ).unwrap();
     // IcebergConfig
     map.try_insert(
         std::any::type_name::<IcebergConfig>().to_owned(),
@@ -290,6 +299,15 @@ pub static SINK_ALLOW_ALTER_ON_FLY_FIELDS: LazyLock<HashMap<String, HashSet<Stri
             "properties.message.timeout.ms".to_owned(),
             "properties.max.in.flight.requests.per.connection".to_owned(),
             "properties.request.required.acks".to_owned(),
+        ].into_iter().collect(),
+    ).unwrap();
+    // OpenSearchConfig
+    map.try_insert(
+        std::any::type_name::<OpenSearchConfig>().to_owned(),
+        [
+            "batch_num_messages".to_owned(),
+            "batch_size_kb".to_owned(),
+            "concurrent_requests".to_owned(),
         ].into_iter().collect(),
     ).unwrap();
     // PulsarConfig

--- a/src/connector/src/sink/elasticsearch_opensearch/elasticsearch.rs
+++ b/src/connector/src/sink/elasticsearch_opensearch/elasticsearch.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::collections::BTreeMap;
+
 use risingwave_common::catalog::Schema;
 use tonic::async_trait;
 
@@ -77,6 +79,11 @@ impl Sink for ElasticSearchSink {
         self.config.validate_config(&self.schema)?;
         let client = self.config.build_client(Self::SINK_NAME)?;
         client.ping().await?;
+        Ok(())
+    }
+
+    fn validate_alter_config(config: &BTreeMap<String, String>) -> Result<()> {
+        ElasticSearchConfig::from_btreemap(config.clone())?;
         Ok(())
     }
 

--- a/src/connector/src/sink/elasticsearch_opensearch/elasticsearch_opensearch_config.rs
+++ b/src/connector/src/sink/elasticsearch_opensearch/elasticsearch_opensearch_config.rs
@@ -87,16 +87,19 @@ pub struct ElasticSearchOpenSearchConfig {
     #[serde(rename = "batch_num_messages")]
     #[serde_as(as = "DisplayFromStr")]
     #[serde(default = "default_batch_num_messages")]
+    #[with_option(allow_alter_on_fly)]
     pub batch_num_messages: usize,
 
     #[serde(rename = "batch_size_kb")]
     #[serde_as(as = "DisplayFromStr")]
     #[serde(default = "default_batch_size_kb")]
+    #[with_option(allow_alter_on_fly)]
     pub batch_size_kb: usize,
 
     #[serde(rename = "concurrent_requests")]
     #[serde_as(as = "DisplayFromStr")]
     #[serde(default = "default_concurrent_requests")]
+    #[with_option(allow_alter_on_fly)]
     pub concurrent_requests: usize,
 
     #[serde(default = "default_type")]

--- a/src/connector/src/sink/elasticsearch_opensearch/opensearch.rs
+++ b/src/connector/src/sink/elasticsearch_opensearch/opensearch.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::collections::BTreeMap;
+
 use anyhow::anyhow;
 use risingwave_common::catalog::Schema;
 use risingwave_common::session_config::sink_decouple::SinkDecouple;
@@ -77,6 +79,11 @@ impl Sink for OpenSearchSink {
         self.config.validate_config(&self.schema)?;
         let client = self.config.build_client(Self::SINK_NAME)?;
         client.ping().await?;
+        Ok(())
+    }
+
+    fn validate_alter_config(config: &BTreeMap<String, String>) -> Result<()> {
+        OpenSearchConfig::from_btreemap(config.clone())?;
         Ok(())
     }
 

--- a/src/connector/with_options_sink.yaml
+++ b/src/connector/with_options_sink.yaml
@@ -356,12 +356,15 @@ ElasticSearchConfig:
   - name: batch_num_messages
     field_type: usize
     required: true
+    allow_alter_on_fly: true
   - name: batch_size_kb
     field_type: usize
     required: true
+    allow_alter_on_fly: true
   - name: concurrent_requests
     field_type: usize
     required: true
+    allow_alter_on_fly: true
   - name: r#type
     field_type: String
     required: false
@@ -1404,12 +1407,15 @@ OpenSearchConfig:
   - name: batch_num_messages
     field_type: usize
     required: true
+    allow_alter_on_fly: true
   - name: batch_size_kb
     field_type: usize
     required: true
+    allow_alter_on_fly: true
   - name: concurrent_requests
     field_type: usize
     required: true
+    allow_alter_on_fly: true
   - name: r#type
     field_type: String
     required: false


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

Excessive opensearch buffer may cause OOM: the default batch_num_messages x batch_size_kb x concurrent_requests is way too large.

This PR allows `ALTER SINK ... SET` to update `batch_num_messages`, `batch_size_kb`, and `concurrent_requests` for OpenSearch sinks. Since OpenSearch and Elasticsearch share the same sink config and writer, the same generated alter-on-fly metadata is also enabled for Elasticsearch, with alter-config parsing validation added for both sink types.

- Closes #

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [x] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [x] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

OpenSearch and Elasticsearch sinks can now update `batch_num_messages`, `batch_size_kb`, and `concurrent_requests` online with `ALTER SINK ... SET`.

</details>
