### PR TITLE
fix(sqlparser): report unexpected WITH in CTE list

### DIFF
--- a/src/sqlparser/src/parser.rs
+++ b/src/sqlparser/src/parser.rs
@@ -4964,6 +4964,11 @@ impl Parser<'_> {
 
     /// Parse a CTE (`alias [( col1, col2, ... )] AS (subquery)`)
     fn parse_cte(&mut self) -> ModalResult<Cte> {
+        let token = self.peek_token();
+        if matches!(token.token, Token::Word(ref word) if word.keyword == Keyword::WITH) {
+            parser_err!("syntax error at or near {token}");
+        }
+
         let name = self.parse_identifier_non_reserved()?;
         let cte = if self.parse_keyword(Keyword::AS) {
             let cte_inner = self.parse_cte_inner()?;

--- a/src/sqlparser/tests/testdata/select.yaml
+++ b/src/sqlparser/tests/testdata/select.yaml
@@ -91,6 +91,16 @@
     sql parser error: syntax error at or near WHERE at line 1, column 11
     LINE 1: SELECT 1, WHERE true
                             ^
+- input: |-
+    WITH arr AS (SELECT 1),
+      WITH unnested AS (SELECT 2)
+    SELECT * FROM unnested
+  error_msg: |-
+    sql parser error: syntax error at or near WITH at line 2, column 3
+    LINE 2:   WITH unnested AS (SELECT 2)
+              ^
+- input: SELECT (WITH a AS (SELECT 1) SELECT 1)
+  formatted_sql: SELECT (WITH a AS (SELECT 1) SELECT 1)
 - input: SELECT timestamp with time zone '2022-10-01 12:00:00Z' AT TIME ZONE 'US/Pacific'
   formatted_sql: SELECT TIMESTAMP WITH TIME ZONE '2022-10-01 12:00:00Z' AT TIME ZONE 'US/Pacific'
   formatted_ast: 'Query(Query { with: None, body: Select(Select { distinct: All, projection: [UnnamedExpr(AtTimeZone { timestamp: TypedString { data_type: Timestamp(true), value: "2022-10-01 12:00:00Z" }, time_zone: Value(SingleQuotedString("US/Pacific")) })], from: [], lateral_views: [], selection: None, group_by: [], having: None, window: [] }), order_by: [], limit: None, offset: None, fetch: None })'


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

- Closes #17458.
- Reject an unquoted `WITH` token when the parser expects the next CTE name. Previously it was consumed as an identifier, so the parser failed later at `AS` and pointed users to the wrong token.
- Keep the check local to CTE names, preserving valid nested `WITH` queries and avoiding a global reserved-keyword behavior change.

## Checklist

- [x] I have written necessary rustdoc comments.
- [x] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [x] <!-- OPTIONAL --> I have added test labels as necessary.
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them.
- [ ] <!-- OPTIONAL --> My PR contains breaking changes.
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results.
- [ ] <!-- OPTIONAL --> I have checked the Release Timeline and Currently Supported Versions to determine which release branches I need to cherry-pick this PR into.

## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates.

<details>
<summary><b>Release note</b></summary>

Malformed CTE lists that repeat `WITH` now report the syntax error at the unexpected keyword instead of at a later `AS` token.

</details>

## Tests

- `cargo test --locked` against the `risingwave_sqlparser` crate source (254 tests passed)
- `rust-analyzer parse src/sqlparser/src/parser.rs`
- `rust-analyzer analysis-stats . -o src/parser.rs`
- `rustfmt --check --edition 2024 src/sqlparser/src/parser.rs`
