### PR TITLE
feat(connector): decode protobuf with writer schema

### DIFF
--- a/e2e_test/source_inline/kafka/protobuf/alter_source.slt
+++ b/e2e_test/source_inline/kafka/protobuf/alter_source.slt
@@ -119,7 +119,7 @@ ALTER TABLE t_user REFRESH SCHEMA;
 query ???? retry 3 backoff 5s
 SELECT COUNT(*), MAX(age), MIN(age), SUM(age) FROM mv_user_more;
 ----
-25	104	0	510
+25	104	100	510
 
 query ????
 SELECT COUNT(*), MAX(age), MIN(age), SUM(age) FROM t_user;

--- a/e2e_test/source_inline/kafka/protobuf/alter_source.slt
+++ b/e2e_test/source_inline/kafka/protobuf/alter_source.slt
@@ -116,15 +116,17 @@ CREATE MATERIALIZED VIEW mv_user_gen_more AS SELECT id, t, age FROM src_user_gen
 statement ok
 ALTER TABLE t_user REFRESH SCHEMA;
 
-query ???? retry 3 backoff 5s
-SELECT COUNT(*), MAX(age), MIN(age), SUM(age) FROM mv_user_more;
+# The refreshed source decodes each record with its writer schema: the original 20 records have
+# no age field and remain NULL, while the 5 records from the evolved schema contain ages 100..104.
+query ????? retry 3 backoff 5s
+SELECT COUNT(*), COUNT(age), MAX(age), MIN(age), SUM(age) FROM mv_user_more;
 ----
-25	104	0	510
+25	5	104	100	510
 
-query ????
-SELECT COUNT(*), MAX(age), MIN(age), SUM(age) FROM t_user;
+query ?????
+SELECT COUNT(*), COUNT(age), MAX(age), MIN(age), SUM(age) FROM t_user;
 ----
-25	NULL	NULL	NULL
+25	0	NULL	NULL	NULL
 
 # Verify generated column still works correctly after schema refresh
 query III retry 3 backoff 5s
@@ -136,10 +138,10 @@ SELECT COUNT(*), MIN(t), MAX(t) FROM mv_user_gen_more WHERE t = id + 1;
 system ok
 python3 e2e_test/source_inline/kafka/protobuf/pb.py "${RISEDEV_KAFKA_BOOTSTRAP_SERVERS}" "${RISEDEV_SCHEMA_REGISTRY_URL}" "pb_alter_source_test" 5 user_with_more_fields
 
-query ???? retry 3 backoff 5s
-SELECT COUNT(*), MAX(age), MIN(age), SUM(age) FROM t_user;
+query ????? retry 3 backoff 5s
+SELECT COUNT(*), COUNT(age), MAX(age), MIN(age), SUM(age) FROM t_user;
 ----
-30	104	100	510
+30	5	104	100	510
 
 # Final verification that generated column still works
 query III retry 3 backoff 5s

--- a/e2e_test/source_inline/kafka/protobuf/alter_source_shared.slt
+++ b/e2e_test/source_inline/kafka/protobuf/alter_source_shared.slt
@@ -85,7 +85,7 @@ SELECT COUNT(*) FROM mv_user_2;
 query ????
 SELECT COUNT(*), MAX(age), MIN(age), SUM(age) FROM mv_user_more;
 ----
-25	104	0	510
+25	104	100	510
 
 # Push more events with extended fields
 system ok
@@ -106,7 +106,7 @@ SELECT COUNT(*) FROM mv_user_2;
 query ????
 SELECT COUNT(*), MAX(age), MIN(age), SUM(age) FROM mv_user_more;
 ----
-30	104	0	1020
+30	104	100	1020
 
 
 statement ok

--- a/e2e_test/source_inline/kafka/protobuf/alter_source_shared.slt
+++ b/e2e_test/source_inline/kafka/protobuf/alter_source_shared.slt
@@ -82,10 +82,12 @@ SELECT COUNT(*) FROM mv_user_2;
 ----
 25
 
-query ????
-SELECT COUNT(*), MAX(age), MIN(age), SUM(age) FROM mv_user_more;
+# The refreshed source decodes each record with its writer schema: the original 20 records have
+# no age field and remain NULL, while the 5 records from the evolved schema contain ages 100..104.
+query ?????
+SELECT COUNT(*), COUNT(age), MAX(age), MIN(age), SUM(age) FROM mv_user_more;
 ----
-25	104	0	510
+25	5	104	100	510
 
 # Push more events with extended fields
 system ok
@@ -103,10 +105,10 @@ SELECT COUNT(*) FROM mv_user_2;
 ----
 30
 
-query ????
-SELECT COUNT(*), MAX(age), MIN(age), SUM(age) FROM mv_user_more;
+query ?????
+SELECT COUNT(*), COUNT(age), MAX(age), MIN(age), SUM(age) FROM mv_user_more;
 ----
-30	104	0	1020
+30	10	104	100	1020
 
 
 statement ok

--- a/e2e_test/source_inline/kafka/protobuf/writer_schema.slt
+++ b/e2e_test/source_inline/kafka/protobuf/writer_schema.slt
@@ -1,0 +1,80 @@
+control substitution on
+
+# Verify that each record is decoded with its writer schema ID and message indexes.
+
+statement ok
+drop source if exists pb_writer_schema_source;
+
+system ok
+rpk topic delete 'test-pb-writer-schema' || true; \
+(rpk sr subject delete 'test-pb-writer-schema-value' && rpk sr subject delete 'test-pb-writer-schema-value' --permanent) || true;
+
+system ok
+rpk topic create 'test-pb-writer-schema'
+
+# Event is deliberately the second top-level message, so its Confluent index array is [1].
+system ok
+sr_register test-pb-writer-schema-value PROTOBUF << EOF
+syntax = "proto3";
+package test;
+message Metadata { string source = 1; }
+message Event {
+  int32 id = 1;
+  Status status = 2;
+}
+enum Status {
+  STATUS_UNSPECIFIED = 0;
+  STARTED = 1;
+}
+EOF
+
+statement ok
+create source pb_writer_schema_source with (
+  ${RISEDEV_KAFKA_WITH_OPTIONS_COMMON},
+  topic = 'test-pb-writer-schema',
+  scan.startup.mode = 'earliest')
+format plain encode protobuf (
+  schema.registry = '${RISEDEV_SCHEMA_REGISTRY_URL}',
+  message = 'test.Event');
+
+system ok
+echo '{"id":1,"status":"STARTED"}' | rpk topic produce 'test-pb-writer-schema' --schema-id=topic --schema-type='test.Event'
+
+query IT retry 10 backoff 1s
+select id, status from pb_writer_schema_source order by id;
+----
+1 STARTED
+
+# Add a writer-only enum value after the source decoder has already consumed version 1.
+system ok
+sr_register test-pb-writer-schema-value PROTOBUF << EOF
+syntax = "proto3";
+package test;
+message Metadata { string source = 1; }
+message Event {
+  int32 id = 1;
+  Status status = 2;
+}
+enum Status {
+  STATUS_UNSPECIFIED = 0;
+  STARTED = 1;
+  FINISHED = 2;
+}
+EOF
+
+system ok
+echo '{"id":2,"status":"FINISHED"}' | rpk topic produce 'test-pb-writer-schema' --schema-id=topic --schema-type='test.Event'
+
+query IT retry 10 backoff 1s
+select id, status from pb_writer_schema_source order by id;
+----
+1 STARTED
+2 FINISHED
+
+statement ok
+drop source pb_writer_schema_source;
+
+system ok
+rpk topic delete 'test-pb-writer-schema'; \
+rpk sr subject delete 'test-pb-writer-schema-value'; \
+rpk sr subject delete 'test-pb-writer-schema-value' --permanent;

--- a/e2e_test/source_inline/kafka/protobuf/writer_schema.slt
+++ b/e2e_test/source_inline/kafka/protobuf/writer_schema.slt
@@ -1,33 +1,52 @@
 control substitution on
 
-# Verify that each record is decoded with its writer schema ID and message indexes.
+# Verify that every record is decoded with its exact writer schema, references,
+# and message indexes rather than the schema loaded when the source starts.
 
 statement ok
 drop source if exists pb_writer_schema_source;
 
+statement ok
+drop source if exists pb_writer_schema_latest_source;
+
 system ok
 rpk topic delete 'test-pb-writer-schema' || true; \
-(rpk sr subject delete 'test-pb-writer-schema-value' && rpk sr subject delete 'test-pb-writer-schema-value' --permanent) || true;
+curl --silent --request DELETE "$RISEDEV_SCHEMA_REGISTRY_URL/subjects/test-pb-writer-schema-value" > /dev/null; \
+curl --silent --request DELETE "$RISEDEV_SCHEMA_REGISTRY_URL/subjects/test-pb-writer-schema-value?permanent=true" > /dev/null; \
+curl --silent --request DELETE "$RISEDEV_SCHEMA_REGISTRY_URL/subjects/test-pb-writer-schema-common.proto" > /dev/null; \
+curl --silent --request DELETE "$RISEDEV_SCHEMA_REGISTRY_URL/subjects/test-pb-writer-schema-common.proto?permanent=true" > /dev/null;
 
 system ok
 rpk topic create 'test-pb-writer-schema'
 
-# Event is deliberately the second top-level message, so its Confluent index array is [1].
+# Register reference version 1.
 system ok
-sr_register test-pb-writer-schema-value PROTOBUF << EOF
+rpk registry schema create 'test-pb-writer-schema-common.proto' --schema /dev/stdin --type protobuf << EOF
 syntax = "proto3";
-package test;
-message Metadata { string source = 1; }
-message Event {
-  int32 id = 1;
-  Status status = 2;
-}
+package writer_schema_common;
 enum Status {
   STATUS_UNSPECIFIED = 0;
   STARTED = 1;
 }
 EOF
 
+# Envelope is the second top-level message and Event is its first nested message,
+# so the Confluent message-index array for test.Envelope.Event is [1, 0].
+system ok
+rpk registry schema create 'test-pb-writer-schema-value' --schema /dev/stdin --type protobuf --references 'test-pb-writer-schema-common.proto:test-pb-writer-schema-common.proto:1' << EOF
+syntax = "proto3";
+package test;
+import "test-pb-writer-schema-common.proto";
+message Metadata { string source = 1; }
+message Envelope {
+  message Event {
+    int32 id = 1;
+    writer_schema_common.Status status = 2;
+  }
+}
+EOF
+
+# The source starts with root schema version 1 and reference version 1 in its cache.
 statement ok
 create source pb_writer_schema_source with (
   ${RISEDEV_KAFKA_WITH_OPTIONS_COMMON},
@@ -35,26 +54,21 @@ create source pb_writer_schema_source with (
   scan.startup.mode = 'earliest')
 format plain encode protobuf (
   schema.registry = '${RISEDEV_SCHEMA_REGISTRY_URL}',
-  message = 'test.Event');
+  message = 'test.Envelope.Event');
 
 system ok
-echo '{"id":1,"status":"STARTED"}' | rpk topic produce 'test-pb-writer-schema' --schema-id=topic --schema-type='test.Event'
+echo '{"id":1,"status":"STARTED"}' | rpk topic produce 'test-pb-writer-schema' --schema-id=topic --schema-type='test.Envelope.Event'
 
 query IT retry 10 backoff 1s
 select id, status from pb_writer_schema_source order by id;
 ----
 1 STARTED
 
-# Add a writer-only enum value after the source decoder has already consumed version 1.
+# Evolve the referenced enum and register root version 2 against reference version 2.
 system ok
-sr_register test-pb-writer-schema-value PROTOBUF << EOF
+rpk registry schema create 'test-pb-writer-schema-common.proto' --schema /dev/stdin --type protobuf << EOF
 syntax = "proto3";
-package test;
-message Metadata { string source = 1; }
-message Event {
-  int32 id = 1;
-  Status status = 2;
-}
+package writer_schema_common;
 enum Status {
   STATUS_UNSPECIFIED = 0;
   STARTED = 1;
@@ -63,18 +77,66 @@ enum Status {
 EOF
 
 system ok
-echo '{"id":2,"status":"FINISHED"}' | rpk topic produce 'test-pb-writer-schema' --schema-id=topic --schema-type='test.Event'
+rpk registry schema create 'test-pb-writer-schema-value' --schema /dev/stdin --type protobuf --references 'test-pb-writer-schema-common.proto:test-pb-writer-schema-common.proto:2' << EOF
+syntax = "proto3";
+package test;
+import "test-pb-writer-schema-common.proto";
+message Metadata { string source = 1; }
+message Envelope {
+  message Event {
+    int32 id = 1;
+    writer_schema_common.Status status = 2;
+  }
+}
+EOF
+
+# The first version-2 record causes a cache miss and loads the exact root and reference versions.
+# The second one reuses the newly cached writer schema.
+system ok
+echo '{"id":2,"status":"FINISHED"}' | rpk topic produce 'test-pb-writer-schema' --schema-id=topic --schema-type='test.Envelope.Event'; \
+echo '{"id":3,"status":"FINISHED"}' | rpk topic produce 'test-pb-writer-schema' --schema-id=topic --schema-type='test.Envelope.Event'
+
+# Produce another version-1 record after version 2 is latest. This verifies that writer schema
+# selection is per record and that the initially cached schema remains usable.
+system ok
+writer_schema_id=$(curl --silent "$RISEDEV_SCHEMA_REGISTRY_URL/subjects/test-pb-writer-schema-value/versions/1" | jq -r '.id'); \
+echo '{"id":4,"status":"STARTED"}' | rpk topic produce 'test-pb-writer-schema' --schema-id="$writer_schema_id" --schema-type='test.Envelope.Event'
 
 query IT retry 10 backoff 1s
 select id, status from pb_writer_schema_source order by id;
 ----
 1 STARTED
 2 FINISHED
+3 FINISHED
+4 STARTED
+
+# A source initialized from version 2 must also decode historical version-1 records.
+statement ok
+create source pb_writer_schema_latest_source with (
+  ${RISEDEV_KAFKA_WITH_OPTIONS_COMMON},
+  topic = 'test-pb-writer-schema',
+  scan.startup.mode = 'earliest')
+format plain encode protobuf (
+  schema.registry = '${RISEDEV_SCHEMA_REGISTRY_URL}',
+  message = 'test.Envelope.Event');
+
+query IT retry 10 backoff 1s
+select id, status from pb_writer_schema_latest_source order by id;
+----
+1 STARTED
+2 FINISHED
+3 FINISHED
+4 STARTED
 
 statement ok
 drop source pb_writer_schema_source;
 
+statement ok
+drop source pb_writer_schema_latest_source;
+
 system ok
 rpk topic delete 'test-pb-writer-schema'; \
-rpk sr subject delete 'test-pb-writer-schema-value'; \
-rpk sr subject delete 'test-pb-writer-schema-value' --permanent;
+curl --silent --request DELETE "$RISEDEV_SCHEMA_REGISTRY_URL/subjects/test-pb-writer-schema-value" > /dev/null; \
+curl --silent --request DELETE "$RISEDEV_SCHEMA_REGISTRY_URL/subjects/test-pb-writer-schema-value?permanent=true" > /dev/null; \
+curl --silent --request DELETE "$RISEDEV_SCHEMA_REGISTRY_URL/subjects/test-pb-writer-schema-common.proto" > /dev/null; \
+curl --silent --request DELETE "$RISEDEV_SCHEMA_REGISTRY_URL/subjects/test-pb-writer-schema-common.proto?permanent=true" > /dev/null;

--- a/src/connector/codec/src/decoder/protobuf/mod.rs
+++ b/src/connector/codec/src/decoder/protobuf/mod.rs
@@ -16,7 +16,7 @@ pub mod parser;
 use std::collections::HashSet;
 use std::sync::LazyLock;
 
-use prost_reflect::{DynamicMessage, ReflectMessage};
+use prost_reflect::{DynamicMessage, MessageDescriptor, ReflectMessage};
 use risingwave_common::log::LogSuppressor;
 use risingwave_common::types::{DataType, DatumCow};
 use thiserror_ext::AsReport;
@@ -25,13 +25,19 @@ use super::{Access, AccessResult, uncategorized};
 
 pub struct ProtobufAccess<'a> {
     message: DynamicMessage,
+    reader_descriptor: MessageDescriptor,
     messages_as_jsonb: &'a HashSet<String>,
 }
 
 impl<'a> ProtobufAccess<'a> {
-    pub fn new(message: DynamicMessage, messages_as_jsonb: &'a HashSet<String>) -> Self {
+    pub fn new(
+        message: DynamicMessage,
+        reader_descriptor: MessageDescriptor,
+        messages_as_jsonb: &'a HashSet<String>,
+    ) -> Self {
         Self {
             message,
+            reader_descriptor,
             messages_as_jsonb,
         }
     }
@@ -45,21 +51,34 @@ impl<'a> ProtobufAccess<'a> {
 impl Access for ProtobufAccess<'_> {
     fn access<'a>(&'a self, path: &[&str], type_expected: &DataType) -> AccessResult<DatumCow<'a>> {
         debug_assert_eq!(1, path.len());
-        let field_desc = self
-            .message
-            .descriptor()
-            .get_field_by_name(path[0])
-            .ok_or_else(|| uncategorized!("protobuf schema don't have field {}", path[0]))
-            .inspect_err(|e| {
+        let reader_field = self.reader_descriptor.get_field_by_name(path[0]);
+        let writer_descriptor = self.message.descriptor();
+        let writer_field = match &reader_field {
+            Some(reader_field) => writer_descriptor.get_field(reader_field.number()),
+            // The catalog and the descriptor loaded when the parser starts can temporarily be
+            // out of sync. Preserve the previous name-based behavior when there is no reader field
+            // to provide a stable field number.
+            None => writer_descriptor.get_field_by_name(path[0]),
+        };
+
+        let Some(writer_field) = writer_field else {
+            if reader_field.is_some() {
+                return Ok(DatumCow::NULL);
+            }
+            let error = uncategorized!("protobuf schema don't have field {}", path[0]);
+            {
                 static LOG_SUPPRESSOR: LazyLock<LogSuppressor> =
                     LazyLock::new(LogSuppressor::default);
                 if let Ok(suppressed_count) = LOG_SUPPRESSOR.check() {
-                    tracing::error!(suppressed_count, "{}", e.as_report());
+                    tracing::error!(suppressed_count, "{}", error.as_report());
                 }
-            })?;
+            }
+            return Err(error);
+        };
 
         parser::from_protobuf_message_field(
-            &field_desc,
+            &writer_field,
+            reader_field.as_ref(),
             &self.message,
             type_expected,
             self.messages_as_jsonb,

--- a/src/connector/codec/src/decoder/protobuf/parser.rs
+++ b/src/connector/codec/src/decoder/protobuf/parser.rs
@@ -78,6 +78,7 @@ fn detect_loop_and_push(
 /// handling presence, then call [`from_protobuf_value`].
 pub fn from_protobuf_message_field<'a>(
     field_desc: &FieldDescriptor,
+    reader_field_desc: Option<&FieldDescriptor>,
     message: &'a DynamicMessage,
     type_expected: &DataType,
     messages_as_jsonb: &'a HashSet<String>,
@@ -92,19 +93,28 @@ pub fn from_protobuf_message_field<'a>(
     };
 
     match value {
-        Cow::Borrowed(value) => {
-            from_protobuf_value(field_desc, value, type_expected, messages_as_jsonb)
-        }
-        Cow::Owned(value) => {
-            from_protobuf_value(field_desc, &value, type_expected, messages_as_jsonb)
-                .map(|d| d.to_owned_datum().into())
-        }
+        Cow::Borrowed(value) => from_protobuf_value(
+            field_desc,
+            reader_field_desc,
+            value,
+            type_expected,
+            messages_as_jsonb,
+        ),
+        Cow::Owned(value) => from_protobuf_value(
+            field_desc,
+            reader_field_desc,
+            &value,
+            type_expected,
+            messages_as_jsonb,
+        )
+        .map(|d| d.to_owned_datum().into()),
     }
 }
 
 /// Converts a protobuf value to a datum.
 fn from_protobuf_value<'a>(
     field_desc: &FieldDescriptor,
+    reader_field_desc: Option<&FieldDescriptor>,
     value: &'a Value,
     type_expected: &DataType,
     messages_as_jsonb: &'a HashSet<String>,
@@ -144,6 +154,10 @@ fn from_protobuf_value<'a>(
                 ))
             } else {
                 let desc = dyn_msg.descriptor();
+                let reader_desc = reader_field_desc.and_then(|field| match field.kind() {
+                    Kind::Message(message) => Some(message),
+                    _ => None,
+                });
                 let DataType::Struct(st) = type_expected else {
                     return Err(AccessError::TypeError {
                         expected: type_expected.to_string(),
@@ -154,13 +168,22 @@ fn from_protobuf_value<'a>(
 
                 let mut datums = Vec::with_capacity(st.len());
                 for (name, expected_field_type) in st.iter() {
-                    let Some(field_desc) = desc.get_field_by_name(name) else {
-                        // Field deleted in protobuf. Fallback to SQL NULL (of proper RW type).
+                    let reader_field = reader_desc
+                        .as_ref()
+                        .and_then(|descriptor| descriptor.get_field_by_name(name));
+                    let writer_field = match &reader_field {
+                        Some(reader_field) => desc.get_field(reader_field.number()),
+                        None => desc.get_field_by_name(name),
+                    };
+                    let Some(writer_field) = writer_field else {
+                        // The field does not exist in the writer schema. Use SQL NULL instead of a
+                        // default from the reader schema.
                         datums.push(None);
                         continue;
                     };
                     let datum = from_protobuf_message_field(
-                        &field_desc,
+                        &writer_field,
+                        reader_field.as_ref(),
                         dyn_msg,
                         expected_field_type,
                         messages_as_jsonb,
@@ -183,6 +206,7 @@ fn from_protobuf_value<'a>(
             for value in values {
                 builder.append(from_protobuf_value(
                     field_desc,
+                    reader_field_desc,
                     value,
                     elem_type,
                     messages_as_jsonb,
@@ -207,6 +231,16 @@ fn from_protobuf_value<'a>(
                 return Err(err());
             }
             let map_desc = kind.as_message().ok_or_else(err)?;
+            let reader_map_desc = reader_field_desc.and_then(|field| match field.kind() {
+                Kind::Message(message) if message.is_map_entry() => Some(message),
+                _ => None,
+            });
+            let reader_key_field = reader_map_desc
+                .as_ref()
+                .map(MessageDescriptor::map_entry_key_field);
+            let reader_value_field = reader_map_desc
+                .as_ref()
+                .map(MessageDescriptor::map_entry_value_field);
 
             let mut key_builder = map_type.key().create_array_builder(map.len());
             let mut value_builder = map_type.value().create_array_builder(map.len());
@@ -217,12 +251,14 @@ fn from_protobuf_value<'a>(
             for (key, value) in map.iter().sorted_by_key(|(k, _v)| *k) {
                 key_builder.append(from_protobuf_value(
                     &map_desc.map_entry_key_field(),
+                    reader_key_field.as_ref(),
                     &key.clone().into(),
                     map_type.key(),
                     messages_as_jsonb,
                 )?);
                 value_builder.append(from_protobuf_value(
                     &map_desc.map_entry_value_field(),
+                    reader_value_field.as_ref(),
                     value,
                     map_type.value(),
                     messages_as_jsonb,

--- a/src/connector/codec/tests/integration_tests/protobuf.rs
+++ b/src/connector/codec/tests/integration_tests/protobuf.rs
@@ -22,7 +22,11 @@ use std::collections::{HashMap, HashSet};
 
 use anyhow::Context;
 use prost::Message;
-use prost_reflect::{DescriptorPool, DynamicMessage, MessageDescriptor};
+use prost_reflect::{DescriptorPool, DynamicMessage, MapKey, MessageDescriptor, Value};
+use risingwave_common::array::StructValue;
+use risingwave_common::types::{
+    DataType, ListValue, MapType, MapValue, ScalarImpl, StructType, ToOwnedDatum,
+};
 use risingwave_connector_codec::common::protobuf::compile_pb;
 use risingwave_connector_codec::decoder::Access;
 use risingwave_connector_codec::decoder::protobuf::ProtobufAccess;
@@ -61,6 +65,7 @@ fn check(
     for data in pb_data {
         let access = ProtobufAccess::new(
             DynamicMessage::decode(pb_schema.clone(), *data).unwrap(),
+            pb_schema.clone(),
             &messages_as_jsonb,
         );
         let mut row = vec![];
@@ -107,6 +112,226 @@ fn load_message_descriptor(
             message_name, location,
         )
     })
+}
+
+fn compile_message_descriptor(schema: &str, message_name: &str) -> MessageDescriptor {
+    let descriptor_set = compile_pb(
+        ("test.proto".to_owned(), schema.to_owned()),
+        std::iter::empty::<(String, String)>(),
+    )
+    .unwrap();
+    DescriptorPool::from_file_descriptor_set(descriptor_set)
+        .unwrap()
+        .get_message_by_name(message_name)
+        .unwrap()
+}
+
+#[test]
+fn test_reader_writer_fields_are_matched_by_number() {
+    let writer_descriptor = compile_message_descriptor(
+        r#"
+            syntax = "proto3";
+            package test;
+
+            enum Status {
+                STATUS_UNSPECIFIED = 0;
+                STATUS_ACTIVE = 1;
+            }
+
+            message Address {
+                string old_city = 1;
+            }
+
+            message Event {
+                int32 old_age = 1;
+                string old_name = 2;
+                bool old_enabled = 3;
+                int64 old_count = 4;
+                double old_ratio = 5;
+                Status old_status = 6;
+                bytes old_payload = 7;
+                repeated int32 old_scores = 8;
+                Address old_address = 9;
+                repeated Address old_addresses = 10;
+                map<string, Address> old_locations = 11;
+                optional string old_note = 12;
+                optional string old_unset_note = 13;
+            }
+        "#,
+        "test.Event",
+    );
+    let reader_descriptor = compile_message_descriptor(
+        r#"
+            syntax = "proto3";
+            package test;
+
+            enum Status {
+                STATUS_UNSPECIFIED = 0;
+                STATUS_ACTIVE = 1;
+            }
+
+            message Address {
+                string city = 1;
+                string country = 2;
+            }
+
+            message Event {
+                int32 age = 1;
+                string name = 2;
+                bool enabled = 3;
+                int64 count = 4;
+                double ratio = 5;
+                Status status = 6;
+                bytes payload = 7;
+                repeated int32 scores = 8;
+                Address address = 9;
+                repeated Address addresses = 10;
+                map<string, Address> locations = 11;
+                optional string note = 12;
+                optional string unset_note = 13;
+                int32 added_field = 14;
+            }
+        "#,
+        "test.Event",
+    );
+
+    let address_descriptor = writer_descriptor
+        .parent_pool()
+        .get_message_by_name("test.Address")
+        .unwrap();
+    let address = |city: &str| {
+        let mut address = DynamicMessage::new(address_descriptor.clone());
+        address.set_field_by_name("old_city", Value::String(city.to_owned()));
+        address
+    };
+
+    let mut message = DynamicMessage::new(writer_descriptor);
+    message.set_field_by_name("old_age", Value::I32(42));
+    message.set_field_by_name("old_name", Value::String("Alice".to_owned()));
+    message.set_field_by_name("old_enabled", Value::Bool(true));
+    message.set_field_by_name("old_count", Value::I64(123456789));
+    message.set_field_by_name("old_ratio", Value::F64(1.25));
+    message.set_field_by_name("old_status", Value::EnumNumber(1));
+    message.set_field_by_name("old_payload", Value::Bytes(vec![0, 1, 2, 255].into()));
+    message.set_field_by_name(
+        "old_scores",
+        Value::List(vec![Value::I32(7), Value::I32(9)]),
+    );
+    message.set_field_by_name("old_address", Value::Message(address("Paris")));
+    message.set_field_by_name(
+        "old_addresses",
+        Value::List(vec![
+            Value::Message(address("Paris")),
+            Value::Message(address("Tokyo")),
+        ]),
+    );
+    message.set_field_by_name(
+        "old_locations",
+        Value::Map(HashMap::from([(
+            MapKey::String("home".to_owned()),
+            Value::Message(address("Berlin")),
+        )])),
+    );
+    message.set_field_by_name("old_note", Value::String("present".to_owned()));
+
+    let messages_as_jsonb = HashSet::new();
+    let access = ProtobufAccess::new(message, reader_descriptor, &messages_as_jsonb);
+
+    let scalar_cases = [
+        ("age", DataType::Int32, Some(ScalarImpl::Int32(42))),
+        (
+            "name",
+            DataType::Varchar,
+            Some(ScalarImpl::Utf8("Alice".into())),
+        ),
+        ("enabled", DataType::Boolean, Some(ScalarImpl::Bool(true))),
+        ("count", DataType::Int64, Some(ScalarImpl::Int64(123456789))),
+        (
+            "ratio",
+            DataType::Float64,
+            Some(ScalarImpl::Float64(1.25.into())),
+        ),
+        (
+            "status",
+            DataType::Varchar,
+            Some(ScalarImpl::Utf8("STATUS_ACTIVE".into())),
+        ),
+        (
+            "payload",
+            DataType::Bytea,
+            Some(ScalarImpl::Bytea(vec![0, 1, 2, 255].into())),
+        ),
+        (
+            "note",
+            DataType::Varchar,
+            Some(ScalarImpl::Utf8("present".into())),
+        ),
+        ("unset_note", DataType::Varchar, None),
+        ("added_field", DataType::Int32, None),
+    ];
+    for (name, data_type, expected) in scalar_cases {
+        assert_eq!(
+            access.access(&[name], &data_type).unwrap().to_owned_datum(),
+            expected,
+            "field {name}"
+        );
+    }
+
+    assert_eq!(
+        access
+            .access(&["scores"], &DataType::list(DataType::Int32))
+            .unwrap()
+            .to_owned_datum(),
+        Some(ScalarImpl::List(ListValue::from_iter([7, 9])))
+    );
+
+    let address_type = DataType::Struct(StructType::new(vec![
+        ("city".to_owned(), DataType::Varchar),
+        ("country".to_owned(), DataType::Varchar),
+    ]));
+    let address_value = |city: &str| {
+        ScalarImpl::Struct(StructValue::new(vec![
+            Some(ScalarImpl::Utf8(city.into())),
+            None,
+        ]))
+    };
+    assert_eq!(
+        access
+            .access(&["address"], &address_type)
+            .unwrap()
+            .to_owned_datum(),
+        Some(address_value("Paris"))
+    );
+
+    let addresses_type = DataType::list(address_type.clone());
+    assert_eq!(
+        access
+            .access(&["addresses"], &addresses_type)
+            .unwrap()
+            .to_owned_datum(),
+        Some(ScalarImpl::List(ListValue::from_datum_iter(
+            &address_type,
+            [Some(address_value("Paris")), Some(address_value("Tokyo")),],
+        )))
+    );
+
+    let locations_type = DataType::Map(MapType::from_kv(DataType::Varchar, address_type.clone()));
+    assert_eq!(
+        access
+            .access(&["locations"], &locations_type)
+            .unwrap()
+            .to_owned_datum(),
+        Some(ScalarImpl::Map(
+            MapValue::try_from_kv(
+                ListValue::from_datum_iter(
+                    &DataType::Varchar,
+                    [Some(ScalarImpl::Utf8("home".into()))],
+                ),
+                ListValue::from_datum_iter(&address_type, [Some(address_value("Berlin"))]),
+            )
+            .unwrap()
+        ))
+    );
 }
 
 #[test]

--- a/src/connector/src/parser/protobuf/decoder.rs
+++ b/src/connector/src/parser/protobuf/decoder.rs
@@ -1,0 +1,162 @@
+// Copyright 2026 RisingWave Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use anyhow::Context;
+use prost_reflect::{DynamicMessage, FileDescriptor, MessageDescriptor};
+use risingwave_common::bail;
+
+use super::message::parse_confluent_protobuf_message;
+use super::schema_cache::ProtobufSchemaCache;
+use crate::error::ConnectorResult;
+use crate::schema::ConfluentSchemaLoader;
+
+#[derive(Debug)]
+pub(super) enum ProtobufDecoder {
+    Static(MessageDescriptor),
+    Confluent(ConfluentProtobufDecoder),
+}
+
+impl ProtobufDecoder {
+    pub async fn confluent(
+        message_name: String,
+        loader: ConfluentSchemaLoader,
+        initial_schema: (i32, FileDescriptor),
+    ) -> Self {
+        Self::Confluent(ConfluentProtobufDecoder {
+            message_name,
+            schemas: ProtobufSchemaCache::new(loader, initial_schema).await,
+        })
+    }
+
+    pub async fn decode(&self, payload: &[u8]) -> ConnectorResult<DynamicMessage> {
+        let (descriptor, payload) = match self {
+            Self::Static(descriptor) => (descriptor.clone(), payload),
+            Self::Confluent(decoder) => return decoder.decode(payload).await,
+        };
+        DynamicMessage::decode(descriptor, payload)
+            .context("failed to parse protobuf message")
+            .map_err(Into::into)
+    }
+}
+
+#[derive(Debug)]
+pub(super) struct ConfluentProtobufDecoder {
+    message_name: String,
+    schemas: ProtobufSchemaCache,
+}
+
+impl ConfluentProtobufDecoder {
+    async fn decode(&self, payload: &[u8]) -> ConnectorResult<DynamicMessage> {
+        let message = parse_confluent_protobuf_message(payload)?;
+        let root_file = self.schemas.get(message.schema_id).await?;
+        let descriptor = resolve_message_descriptor(&root_file, &message.message_indexes)?;
+
+        if descriptor.full_name() != self.message_name {
+            bail!(
+                "protobuf writer message `{}` does not match configured message `{}`",
+                descriptor.full_name(),
+                self.message_name
+            );
+        }
+
+        DynamicMessage::decode(descriptor, message.payload)
+            .with_context(|| {
+                format!(
+                    "failed to parse protobuf message with writer schema ID {}",
+                    message.schema_id
+                )
+            })
+            .map_err(Into::into)
+    }
+}
+
+fn resolve_message_descriptor(
+    root_file: &FileDescriptor,
+    message_indexes: &[u32],
+) -> ConnectorResult<MessageDescriptor> {
+    let Some((&top_level_index, nested_indexes)) = message_indexes.split_first() else {
+        bail!("protobuf message index array must not be empty");
+    };
+    let mut descriptor = root_file
+        .messages()
+        .nth(top_level_index as usize)
+        .with_context(|| {
+            format!(
+                "protobuf top-level message index {top_level_index} is out of bounds in `{}`",
+                root_file.name()
+            )
+        })?;
+
+    for &index in nested_indexes {
+        let parent_name = descriptor.full_name().to_owned();
+        let child = descriptor.child_messages().nth(index as usize);
+        descriptor = child.with_context(|| {
+            format!("protobuf nested message index {index} is out of bounds in `{parent_name}`")
+        })?;
+    }
+    Ok(descriptor)
+}
+
+#[cfg(test)]
+mod tests {
+    use prost_reflect::DescriptorPool;
+    use prost_types::{DescriptorProto, FileDescriptorProto, FileDescriptorSet};
+
+    use super::*;
+
+    fn test_file_descriptor() -> FileDescriptor {
+        let nested = DescriptorProto {
+            name: Some("Nested".into()),
+            ..Default::default()
+        };
+        let parent = DescriptorProto {
+            name: Some("Parent".into()),
+            nested_type: vec![nested],
+            ..Default::default()
+        };
+        let event = DescriptorProto {
+            name: Some("Event".into()),
+            ..Default::default()
+        };
+        let pool = DescriptorPool::from_file_descriptor_set(FileDescriptorSet {
+            file: vec![FileDescriptorProto {
+                name: Some("test.proto".into()),
+                package: Some("test".into()),
+                message_type: vec![event, parent],
+                syntax: Some("proto3".into()),
+                ..Default::default()
+            }],
+        })
+        .unwrap();
+        pool.get_file_by_name("test.proto").unwrap()
+    }
+
+    #[test]
+    fn test_resolve_message_descriptor() {
+        let file = test_file_descriptor();
+        assert_eq!(
+            resolve_message_descriptor(&file, &[0]).unwrap().full_name(),
+            "test.Event"
+        );
+        assert_eq!(
+            resolve_message_descriptor(&file, &[1, 0])
+                .unwrap()
+                .full_name(),
+            "test.Parent.Nested"
+        );
+        assert!(resolve_message_descriptor(&file, &[]).is_err());
+        assert!(resolve_message_descriptor(&file, &[2]).is_err());
+        assert!(resolve_message_descriptor(&file, &[1, 1]).is_err());
+    }
+}

--- a/src/connector/src/parser/protobuf/decoder.rs
+++ b/src/connector/src/parser/protobuf/decoder.rs
@@ -1,0 +1,202 @@
+// Copyright 2026 RisingWave Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use anyhow::Context;
+use prost_reflect::{DynamicMessage, FileDescriptor, MessageDescriptor};
+use risingwave_common::bail;
+
+use super::message::parse_confluent_protobuf_message;
+use super::schema_cache::ProtobufSchemaCache;
+use crate::error::ConnectorResult;
+use crate::schema::ConfluentSchemaLoader;
+
+#[derive(Debug)]
+pub(super) enum ProtobufDecoder {
+    Static(MessageDescriptor),
+    Confluent(ConfluentProtobufDecoder),
+    // Glue
+    // Pulsar
+}
+
+impl ProtobufDecoder {
+    pub async fn confluent(
+        message_name: String,
+        loader: ConfluentSchemaLoader,
+        initial_schema: (i32, FileDescriptor),
+    ) -> Self {
+        let schemas = ProtobufSchemaCache::new(loader);
+        let (schema_id, file_descriptor) = initial_schema;
+        schemas.load(schema_id, file_descriptor).await;
+
+        Self::Confluent(ConfluentProtobufDecoder {
+            message_name,
+            schemas,
+        })
+    }
+
+    pub async fn decode(&self, payload: &[u8]) -> ConnectorResult<DynamicMessage> {
+        match self {
+            Self::Static(descriptor) => DynamicMessage::decode(descriptor.clone(), payload)
+                .context("failed to parse protobuf message")
+                .map_err(Into::into),
+            Self::Confluent(decoder) => decoder.decode(payload).await,
+        }
+    }
+}
+
+#[derive(Debug)]
+pub(super) struct ConfluentProtobufDecoder {
+    message_name: String,
+    schemas: ProtobufSchemaCache,
+}
+
+impl ConfluentProtobufDecoder {
+    async fn decode(&self, payload: &[u8]) -> ConnectorResult<DynamicMessage> {
+        let message = parse_confluent_protobuf_message(payload).map_err(anyhow::Error::new)?;
+        let root_file = self.schemas.get(message.schema_id).await?;
+        let descriptor = resolve_message_descriptor(&root_file, &message.message_indexes)?;
+
+        if descriptor.full_name() != self.message_name {
+            bail!(
+                "protobuf writer message `{}` does not match configured message `{}`",
+                descriptor.full_name(),
+                self.message_name
+            );
+        }
+
+        DynamicMessage::decode(descriptor, message.payload)
+            .with_context(|| {
+                format!(
+                    "failed to parse protobuf message with writer schema ID {}",
+                    message.schema_id
+                )
+            })
+            .map_err(Into::into)
+    }
+}
+
+fn resolve_message_descriptor(
+    root_file: &FileDescriptor,
+    message_indexes: &[u32],
+) -> ConnectorResult<MessageDescriptor> {
+    let Some((&top_level_index, nested_indexes)) = message_indexes.split_first() else {
+        bail!("protobuf message index array must not be empty");
+    };
+    let mut descriptor = root_file
+        .messages()
+        .nth(top_level_index as usize)
+        .with_context(|| {
+            format!(
+                "protobuf top-level message index {top_level_index} is out of bounds in `{}`",
+                root_file.name()
+            )
+        })?;
+
+    for &index in nested_indexes {
+        let parent_name = descriptor.full_name().to_owned();
+        let child = descriptor.child_messages().nth(index as usize);
+        descriptor = child.with_context(|| {
+            format!("protobuf nested message index {index} is out of bounds in `{parent_name}`")
+        })?;
+    }
+    Ok(descriptor)
+}
+
+#[cfg(test)]
+mod tests {
+    use prost_reflect::{DescriptorPool, ReflectMessage, Value};
+    use prost_types::field_descriptor_proto::{Label, Type};
+    use prost_types::{
+        DescriptorProto, FieldDescriptorProto, FileDescriptorProto, FileDescriptorSet,
+    };
+
+    use super::*;
+    use crate::schema::schema_registry::{Client, SchemaRegistryConfig};
+
+    fn test_file_descriptor() -> FileDescriptor {
+        let nested = DescriptorProto {
+            name: Some("Nested".into()),
+            ..Default::default()
+        };
+        let parent = DescriptorProto {
+            name: Some("Parent".into()),
+            nested_type: vec![nested],
+            ..Default::default()
+        };
+        let event = DescriptorProto {
+            name: Some("Event".into()),
+            field: vec![FieldDescriptorProto {
+                name: Some("id".into()),
+                number: Some(1),
+                label: Some(Label::Optional as i32),
+                r#type: Some(Type::Int32 as i32),
+                json_name: Some("id".into()),
+                ..Default::default()
+            }],
+            ..Default::default()
+        };
+        let pool = DescriptorPool::from_file_descriptor_set(FileDescriptorSet {
+            file: vec![FileDescriptorProto {
+                name: Some("test.proto".into()),
+                package: Some("test".into()),
+                message_type: vec![event, parent],
+                syntax: Some("proto3".into()),
+                ..Default::default()
+            }],
+        })
+        .unwrap();
+        pool.get_file_by_name("test.proto").unwrap()
+    }
+
+    #[test]
+    fn test_resolve_message_descriptor() {
+        let file = test_file_descriptor();
+        assert_eq!(
+            resolve_message_descriptor(&file, &[0]).unwrap().full_name(),
+            "test.Event"
+        );
+        assert_eq!(
+            resolve_message_descriptor(&file, &[1, 0])
+                .unwrap()
+                .full_name(),
+            "test.Parent.Nested"
+        );
+        assert!(resolve_message_descriptor(&file, &[]).is_err());
+        assert!(resolve_message_descriptor(&file, &[2]).is_err());
+        assert!(resolve_message_descriptor(&file, &[1, 1]).is_err());
+    }
+
+    #[tokio::test]
+    async fn test_decode_confluent_message_with_cached_writer_schema() {
+        let file = test_file_descriptor();
+        let loader = ConfluentSchemaLoader {
+            client: Client::new(
+                vec!["http://127.0.0.1:1".parse().unwrap()],
+                &SchemaRegistryConfig::default(),
+            )
+            .unwrap(),
+            name_strategy: Default::default(),
+            topic: "unused".into(),
+            key_record_name: None,
+            val_record_name: Some("test.Event".into()),
+        };
+        let decoder = ProtobufDecoder::confluent("test.Event".into(), loader, (7, file)).await;
+
+        // schema ID 7, optimized message indexes [0], and Event { id: 42 }.
+        let message = decoder.decode(&[0, 0, 0, 0, 7, 0, 8, 42]).await.unwrap();
+        assert_eq!(message.descriptor().full_name(), "test.Event");
+        let id = message.descriptor().get_field_by_name("id").unwrap();
+        assert_eq!(message.get_field(&id).as_ref(), &Value::I32(42));
+    }
+}

--- a/src/connector/src/parser/protobuf/message.rs
+++ b/src/connector/src/parser/protobuf/message.rs
@@ -1,0 +1,181 @@
+// Copyright 2026 RisingWave Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use risingwave_common::bail;
+
+use crate::error::ConnectorResult;
+use crate::schema::schema_registry::{WireFormatError, extract_schema_id};
+
+/// A Protobuf message split into its Confluent metadata and encoded payload.
+#[derive(Debug, PartialEq, Eq)]
+pub(super) struct ConfluentProtobufMessage<'a> {
+    pub schema_id: i32,
+    pub message_indexes: Vec<u32>,
+    pub payload: &'a [u8],
+}
+
+/// A port of Confluent's signed varint (zig-zag) decoding.
+fn decode_varint_zigzag(buffer: &[u8]) -> ConnectorResult<(i32, usize)> {
+    let mut value = 0u32;
+
+    for (offset, &byte) in buffer.iter().take(5).enumerate() {
+        if offset == 4 && byte & 0xf0 != 0 {
+            return Err(WireFormatError::ParseMessageIndexes.into());
+        }
+        value |= ((byte & 0x7f) as u32) << (offset * 7);
+        if byte & 0x80 == 0 {
+            let decoded = ((value >> 1) as i32) ^ -((value & 1) as i32);
+            return Ok((decoded, offset + 1));
+        }
+    }
+
+    Err(WireFormatError::ParseMessageIndexes.into())
+}
+
+/// Parses the Protobuf-specific part of the Confluent wire format.
+///
+/// The message-index array locates a top-level message and then zero or more nested messages.
+/// A single zero byte is the optimized encoding of the common index array `[0]`.
+pub(super) fn parse_confluent_protobuf_message(
+    payload: &[u8],
+) -> ConnectorResult<ConfluentProtobufMessage<'_>> {
+    let (schema_id, remained) = extract_schema_id(payload)?;
+    if schema_id < 0 {
+        bail!("protobuf schema ID must be non-negative, got {schema_id}");
+    }
+    let Some(&first) = remained.first() else {
+        bail!("protobuf message indexes are missing");
+    };
+
+    if first == 0 {
+        return Ok(ConfluentProtobufMessage {
+            schema_id,
+            message_indexes: vec![0],
+            payload: &remained[1..],
+        });
+    }
+
+    let (index_count, mut offset) = decode_varint_zigzag(remained)?;
+    if index_count <= 0 {
+        bail!("protobuf message index count must be positive, got {index_count}");
+    }
+    if index_count as usize > remained.len().saturating_sub(offset) {
+        return Err(WireFormatError::ParseMessageIndexes.into());
+    }
+
+    let mut message_indexes = Vec::with_capacity(index_count as usize);
+    for _ in 0..index_count {
+        let Some(index_bytes) = remained.get(offset..) else {
+            return Err(WireFormatError::ParseMessageIndexes.into());
+        };
+        let (index, encoded_len) = decode_varint_zigzag(index_bytes)?;
+        if index < 0 {
+            bail!("protobuf message index must be non-negative, got {index}");
+        }
+        message_indexes.push(index as u32);
+        offset += encoded_len;
+    }
+
+    Ok(ConfluentProtobufMessage {
+        schema_id,
+        message_indexes,
+        payload: &remained[offset..],
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn framed(indexes: &[u8], payload: &[u8]) -> Vec<u8> {
+        [&[0, 0, 0, 0, 7][..], indexes, payload].concat()
+    }
+
+    #[test]
+    fn test_decode_varint_zigzag() {
+        // 1. Positive number
+        let buffer = vec![0x02];
+        let (value, len) = decode_varint_zigzag(&buffer).unwrap();
+        assert_eq!(value, 1);
+        assert_eq!(len, 1);
+
+        // 2. Negative number
+        let buffer = vec![0x01];
+        let (value, len) = decode_varint_zigzag(&buffer).unwrap();
+        assert_eq!(value, -1);
+        assert_eq!(len, 1);
+
+        // 3. Larger positive number
+        let buffer = vec![0x9e, 0x03];
+        let (value, len) = decode_varint_zigzag(&buffer).unwrap();
+        assert_eq!(value, 207);
+        assert_eq!(len, 2);
+
+        // 4. Larger negative number
+        let buffer = vec![0xbf, 0x07];
+        let (value, len) = decode_varint_zigzag(&buffer).unwrap();
+        assert_eq!(value, -480);
+        assert_eq!(len, 2);
+
+        // 5. Maximum positive number
+        let buffer = vec![0xfe, 0xff, 0xff, 0xff, 0x0f];
+        let (value, len) = decode_varint_zigzag(&buffer).unwrap();
+        assert_eq!(value, i32::MAX);
+        assert_eq!(len, 5);
+
+        // 6. Maximum negative number
+        let buffer = vec![0xff, 0xff, 0xff, 0xff, 0x0f];
+        let (value, len) = decode_varint_zigzag(&buffer).unwrap();
+        assert_eq!(value, i32::MIN);
+        assert_eq!(len, 5);
+
+        // 7. More than 32 bits
+        let buffer = vec![0xff, 0xff, 0xff, 0xff, 0x7f];
+        assert!(decode_varint_zigzag(&buffer).is_err());
+
+        // 8. Invalid input (more than 5 bytes)
+        let buffer = vec![0xff, 0xff, 0xff, 0xff, 0xff, 0xff];
+        assert!(decode_varint_zigzag(&buffer).is_err());
+    }
+
+    #[test]
+    fn test_optimized_first_message_index() {
+        let bytes = framed(&[0], &[8, 1]);
+        let message = parse_confluent_protobuf_message(&bytes).unwrap();
+        assert_eq!(message.schema_id, 7);
+        assert_eq!(message.message_indexes, [0]);
+        assert_eq!(message.payload, [8, 1]);
+    }
+
+    #[test]
+    fn test_top_level_and_nested_message_indexes() {
+        // Zig-zag encoded [count = 2, indexes = 1, 0].
+        let bytes = framed(&[4, 2, 0], &[8, 1]);
+        let message = parse_confluent_protobuf_message(&bytes).unwrap();
+        assert_eq!(message.message_indexes, [1, 0]);
+        assert_eq!(message.payload, [8, 1]);
+    }
+
+    #[test]
+    fn test_invalid_message_indexes() {
+        assert!(parse_confluent_protobuf_message(&framed(&[], &[])).is_err());
+        assert!(parse_confluent_protobuf_message(&framed(&[1], &[])).is_err());
+        assert!(parse_confluent_protobuf_message(&framed(&[2, 1], &[])).is_err());
+        assert!(parse_confluent_protobuf_message(&framed(&[2, 0x80], &[])).is_err());
+        assert!(
+            parse_confluent_protobuf_message(&framed(&[0xfe, 0xff, 0xff, 0xff, 0x7f], &[]))
+                .is_err()
+        );
+    }
+}

--- a/src/connector/src/parser/protobuf/message.rs
+++ b/src/connector/src/parser/protobuf/message.rs
@@ -1,0 +1,196 @@
+// Copyright 2026 RisingWave Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::schema::schema_registry::{WireFormatError, extract_schema_id};
+
+#[derive(Debug, thiserror::Error)]
+pub(super) enum ConfluentProtobufMessageError {
+    #[error(transparent)]
+    WireFormat(#[from] WireFormatError),
+    #[error("protobuf schema ID must be non-negative, got {0}")]
+    NegativeSchemaId(i32),
+    #[error("protobuf message indexes are missing")]
+    MissingMessageIndexes,
+    #[error("protobuf message index count must be positive, got {0}")]
+    NonPositiveMessageIndexCount(i32),
+    #[error("protobuf message index must be non-negative, got {0}")]
+    NegativeMessageIndex(i32),
+}
+
+/// A Protobuf message split into its Confluent metadata and encoded payload.
+#[derive(Debug, PartialEq, Eq)]
+pub(super) struct ConfluentProtobufMessage<'a> {
+    pub schema_id: i32,
+    pub message_indexes: Vec<u32>,
+    pub payload: &'a [u8],
+}
+
+/// A port of Confluent's signed varint (zig-zag) decoding.
+fn decode_varint_zigzag(buffer: &[u8]) -> Result<(i32, usize), ConfluentProtobufMessageError> {
+    let mut value = 0u32;
+
+    for (offset, &byte) in buffer.iter().take(5).enumerate() {
+        if offset == 4 && byte & 0xf0 != 0 {
+            return Err(WireFormatError::ParseMessageIndexes.into());
+        }
+        value |= ((byte & 0x7f) as u32) << (offset * 7);
+        if byte & 0x80 == 0 {
+            let decoded = ((value >> 1) as i32) ^ -((value & 1) as i32);
+            return Ok((decoded, offset + 1));
+        }
+    }
+
+    Err(WireFormatError::ParseMessageIndexes.into())
+}
+
+/// Parses the Protobuf-specific part of the Confluent wire format.
+///
+/// The Confluent Protobuf wire format is:
+///
+/// ```text
+/// | byte 0     | bytes 1-4              | bytes 5..N      | remaining bytes  |
+/// | magic byte | schema ID (big-endian) | message indexes | protobuf payload |
+/// ```
+pub(super) fn parse_confluent_protobuf_message(
+    payload: &[u8],
+) -> Result<ConfluentProtobufMessage<'_>, ConfluentProtobufMessageError> {
+    let (schema_id, remained) = extract_schema_id(payload)?;
+    if schema_id < 0 {
+        return Err(ConfluentProtobufMessageError::NegativeSchemaId(schema_id));
+    }
+    let Some(&first) = remained.first() else {
+        return Err(ConfluentProtobufMessageError::MissingMessageIndexes);
+    };
+
+    // Confluent encodes the common message-index array `[0]` as a single zero byte,
+    // without an explicit array length, so the Protobuf payload starts after this byte.
+    if first == 0 {
+        return Ok(ConfluentProtobufMessage {
+            schema_id,
+            message_indexes: vec![0],
+            payload: &remained[1..],
+        });
+    }
+
+    let (index_count, mut offset) = decode_varint_zigzag(remained)?;
+    if index_count <= 0 {
+        return Err(ConfluentProtobufMessageError::NonPositiveMessageIndexCount(
+            index_count,
+        ));
+    }
+    if index_count as usize > remained.len().saturating_sub(offset) {
+        return Err(WireFormatError::ParseMessageIndexes.into());
+    }
+
+    let mut message_indexes = Vec::with_capacity(index_count as usize);
+    for _ in 0..index_count {
+        let Some(index_bytes) = remained.get(offset..) else {
+            return Err(WireFormatError::ParseMessageIndexes.into());
+        };
+        let (index, encoded_len) = decode_varint_zigzag(index_bytes)?;
+        if index < 0 {
+            return Err(ConfluentProtobufMessageError::NegativeMessageIndex(index));
+        }
+        message_indexes.push(index as u32);
+        offset += encoded_len;
+    }
+
+    Ok(ConfluentProtobufMessage {
+        schema_id,
+        message_indexes,
+        payload: &remained[offset..],
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn framed(indexes: &[u8], payload: &[u8]) -> Vec<u8> {
+        [&[0, 0, 0, 0, 7][..], indexes, payload].concat()
+    }
+
+    #[test]
+    fn test_decode_varint_zigzag() {
+        assert_eq!(decode_varint_zigzag(&[0x02]).unwrap(), (1, 1));
+        assert_eq!(decode_varint_zigzag(&[0x01]).unwrap(), (-1, 1));
+        assert_eq!(decode_varint_zigzag(&[0x9e, 0x03]).unwrap(), (207, 2));
+        assert_eq!(decode_varint_zigzag(&[0xbf, 0x07]).unwrap(), (-480, 2));
+        assert_eq!(
+            decode_varint_zigzag(&[0xfe, 0xff, 0xff, 0xff, 0x0f]).unwrap(),
+            (i32::MAX, 5)
+        );
+        assert_eq!(
+            decode_varint_zigzag(&[0xff, 0xff, 0xff, 0xff, 0x0f]).unwrap(),
+            (i32::MIN, 5)
+        );
+        assert!(decode_varint_zigzag(&[0xff, 0xff, 0xff, 0xff, 0x7f]).is_err());
+        assert!(decode_varint_zigzag(&[0xff, 0xff, 0xff, 0xff, 0xff, 0xff]).is_err());
+    }
+
+    #[test]
+    fn test_optimized_first_message_index() {
+        let bytes = framed(&[0], &[8, 1]);
+        let message = parse_confluent_protobuf_message(&bytes).unwrap();
+        assert_eq!(message.schema_id, 7);
+        assert_eq!(message.message_indexes, [0]);
+        assert_eq!(message.payload, [8, 1]);
+    }
+
+    #[test]
+    fn test_top_level_and_nested_message_indexes() {
+        // Zig-zag encoded [count = 2, indexes = 1, 0].
+        let bytes = framed(&[4, 2, 0], &[8, 1]);
+        let message = parse_confluent_protobuf_message(&bytes).unwrap();
+        assert_eq!(message.message_indexes, [1, 0]);
+        assert_eq!(message.payload, [8, 1]);
+    }
+
+    #[test]
+    fn test_invalid_message_indexes() {
+        assert!(matches!(
+            parse_confluent_protobuf_message(&framed(&[], &[])),
+            Err(ConfluentProtobufMessageError::MissingMessageIndexes)
+        ));
+        assert!(matches!(
+            parse_confluent_protobuf_message(&framed(&[1], &[])),
+            Err(ConfluentProtobufMessageError::NonPositiveMessageIndexCount(
+                -1
+            ))
+        ));
+        assert!(matches!(
+            parse_confluent_protobuf_message(&framed(&[2, 1], &[])),
+            Err(ConfluentProtobufMessageError::NegativeMessageIndex(-1))
+        ));
+        assert!(matches!(
+            parse_confluent_protobuf_message(&framed(&[2, 0x80], &[])),
+            Err(ConfluentProtobufMessageError::WireFormat(
+                WireFormatError::ParseMessageIndexes
+            ))
+        ));
+        assert!(
+            parse_confluent_protobuf_message(&framed(&[0xfe, 0xff, 0xff, 0xff, 0x7f], &[]))
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn test_negative_schema_id() {
+        let bytes = [0, 0xff, 0xff, 0xff, 0xff, 0];
+        assert!(matches!(
+            parse_confluent_protobuf_message(&bytes),
+            Err(ConfluentProtobufMessageError::NegativeSchemaId(-1))
+        ));
+    }
+}

--- a/src/connector/src/parser/protobuf/mod.rs
+++ b/src/connector/src/parser/protobuf/mod.rs
@@ -12,5 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+mod decoder;
+mod message;
 mod parser;
+mod schema_cache;
 pub use parser::*;

--- a/src/connector/src/parser/protobuf/mod.rs
+++ b/src/connector/src/parser/protobuf/mod.rs
@@ -12,5 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+mod message;
 mod parser;
 pub use parser::*;

--- a/src/connector/src/parser/protobuf/mod.rs
+++ b/src/connector/src/parser/protobuf/mod.rs
@@ -12,11 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+mod decoder;
 mod message;
 mod parser;
-#[allow(
-    dead_code,
-    reason = "used by the Confluent Protobuf decoder introduced in the follow-up change"
-)]
 mod schema_cache;
 pub use parser::*;

--- a/src/connector/src/parser/protobuf/mod.rs
+++ b/src/connector/src/parser/protobuf/mod.rs
@@ -14,4 +14,9 @@
 
 mod message;
 mod parser;
+#[allow(
+    dead_code,
+    reason = "used by the Confluent Protobuf decoder introduced in the follow-up change"
+)]
+mod schema_cache;
 pub use parser::*;

--- a/src/connector/src/parser/protobuf/parser.rs
+++ b/src/connector/src/parser/protobuf/parser.rs
@@ -15,25 +15,25 @@
 use std::collections::HashSet;
 
 use anyhow::Context;
-use prost_reflect::{DescriptorPool, DynamicMessage, FileDescriptor, MessageDescriptor};
+use prost_reflect::{DescriptorPool, FileDescriptor, MessageDescriptor};
 use risingwave_common::catalog::Field;
 use risingwave_common::{bail, try_match_expand};
 use risingwave_connector_codec::decoder::protobuf::ProtobufAccess;
 pub use risingwave_connector_codec::decoder::protobuf::parser::{PROTOBUF_MESSAGES_AS_JSONB, *};
 
+use super::decoder::ProtobufDecoder;
 use crate::error::ConnectorResult;
 use crate::parser::unified::AccessImpl;
 use crate::parser::utils::bytes_from_url;
 use crate::parser::{AccessBuilder, EncodingProperties, SchemaLocation};
-use crate::schema::schema_registry::{Client, WireFormatError, extract_schema_id, handle_sr_list};
+use crate::schema::schema_registry::{Client, handle_sr_list};
 use crate::schema::{
-    ConfluentSchemaLoader, InvalidOptionError, SchemaLoader, bail_invalid_option_error,
+    ConfluentSchemaLoader, InvalidOptionError, SchemaVersion, bail_invalid_option_error,
 };
 
 #[derive(Debug)]
 pub struct ProtobufAccessBuilder {
-    wire_type: WireType,
-    message_descriptor: MessageDescriptor,
+    decoder: ProtobufDecoder,
 
     // A HashSet containing protobuf message type full names (e.g. "google.protobuf.Any")
     // that should be mapped to JSONB type when storing in RisingWave
@@ -46,13 +46,7 @@ impl AccessBuilder for ProtobufAccessBuilder {
         payload: Vec<u8>,
         _: &crate::source::SourceMeta,
     ) -> ConnectorResult<AccessImpl<'_>> {
-        let payload = match self.wire_type {
-            WireType::Confluent => resolve_pb_header(&payload)?,
-            WireType::None => &payload,
-        };
-
-        let message = DynamicMessage::decode(self.message_descriptor.clone(), payload)
-            .context("failed to parse message")?;
+        let message = self.decoder.decode(&payload).await?;
 
         Ok(AccessImpl::Protobuf(ProtobufAccess::new(
             message,
@@ -64,44 +58,21 @@ impl AccessBuilder for ProtobufAccessBuilder {
 impl ProtobufAccessBuilder {
     pub fn new(config: ProtobufParserConfig) -> ConnectorResult<Self> {
         let ProtobufParserConfig {
-            wire_type,
-            message_descriptor,
+            decoder,
             messages_as_jsonb,
+            ..
         } = config;
 
         Ok(Self {
-            wire_type,
-            message_descriptor,
+            decoder,
             messages_as_jsonb,
         })
     }
 }
 
-#[derive(Debug, Clone)]
-enum WireType {
-    None,
-    Confluent,
-    // Glue,
-    // Pulsar,
-}
-
-impl TryFrom<&SchemaLocation> for WireType {
-    type Error = InvalidOptionError;
-
-    fn try_from(value: &SchemaLocation) -> Result<Self, Self::Error> {
-        match value {
-            SchemaLocation::File { .. } => Ok(Self::None),
-            SchemaLocation::Confluent { .. } => Ok(Self::Confluent),
-            SchemaLocation::Glue { .. } => bail_invalid_option_error!(
-                "encode protobuf from aws glue schema registry not supported yet"
-            ),
-        }
-    }
-}
-
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct ProtobufParserConfig {
-    wire_type: WireType,
+    decoder: ProtobufDecoder,
     pub(crate) message_descriptor: MessageDescriptor,
     messages_as_jsonb: HashSet<String>,
 }
@@ -109,14 +80,12 @@ pub struct ProtobufParserConfig {
 impl ProtobufParserConfig {
     pub async fn new(encoding_properties: EncodingProperties) -> ConnectorResult<Self> {
         let protobuf_config = try_match_expand!(encoding_properties, EncodingProperties::Protobuf)?;
-        let message_name = &protobuf_config.message_name;
-
-        let wire_type = (&protobuf_config.schema_location).try_into()?;
         if protobuf_config.key_message_name.is_some() {
             // https://docs.confluent.io/platform/7.5/control-center/topics/schema.html#c3-schemas-best-practices-key-value-pairs
             bail!("protobuf key is not supported");
         }
-        let pool = match protobuf_config.schema_location {
+        let message_name = protobuf_config.message_name;
+        let (message_descriptor, decoder) = match protobuf_config.schema_location {
             SchemaLocation::Confluent {
                 urls,
                 client_config,
@@ -125,18 +94,33 @@ impl ProtobufParserConfig {
             } => {
                 let url = handle_sr_list(urls.as_str())?;
                 let client = Client::new(url, &client_config)?;
-                let loader = SchemaLoader::Confluent(ConfluentSchemaLoader {
+                let loader = ConfluentSchemaLoader {
                     client,
                     name_strategy,
                     topic,
                     key_record_name: None,
                     val_record_name: Some(message_name.clone()),
-                });
-                let (_schema_id, root_file_descriptor) = loader
+                };
+                let (schema_version, root_file_descriptor) = loader
                     .load_val_schema::<FileDescriptor>()
                     .await
                     .context("load schema failed")?;
-                root_file_descriptor.parent_pool().clone()
+                let SchemaVersion::Confluent(schema_id) = schema_version else {
+                    unreachable!("ConfluentSchemaLoader must return a Confluent schema version")
+                };
+                let message_descriptor = root_file_descriptor
+                    .parent_pool()
+                    .get_message_by_name(&message_name)
+                    .with_context(|| format!("cannot find message `{message_name}` in schema"))?;
+
+                let decoder = ProtobufDecoder::confluent(
+                    message_name.clone(),
+                    loader,
+                    (schema_id, root_file_descriptor),
+                )
+                .await;
+
+                (message_descriptor, decoder)
             }
             SchemaLocation::File {
                 url,
@@ -145,21 +129,24 @@ impl ProtobufParserConfig {
                 let url = handle_sr_list(url.as_str())?;
                 let url = url.first().unwrap();
                 let schema_bytes = bytes_from_url(url, aws_auth_props.as_ref()).await?;
-                DescriptorPool::decode(schema_bytes.as_slice())
-                    .with_context(|| format!("cannot build descriptor pool from schema `{url}`"))?
+                let pool = DescriptorPool::decode(schema_bytes.as_slice())
+                    .with_context(|| format!("cannot build descriptor pool from schema `{url}`"))?;
+                let message_descriptor = pool
+                    .get_message_by_name(&message_name)
+                    .with_context(|| format!("cannot find message `{message_name}` in schema"))?;
+                (
+                    message_descriptor.clone(),
+                    ProtobufDecoder::Static(message_descriptor),
+                )
             }
             SchemaLocation::Glue { .. } => bail_invalid_option_error!(
                 "encode protobuf from aws glue schema registry not supported yet"
             ),
         };
 
-        let message_descriptor = pool
-            .get_message_by_name(message_name)
-            .with_context(|| format!("cannot find message `{message_name}` in schema"))?;
-
         Ok(Self {
             message_descriptor,
-            wire_type,
+            decoder,
             messages_as_jsonb: protobuf_config.messages_as_jsonb,
         })
     }
@@ -167,113 +154,5 @@ impl ProtobufParserConfig {
     /// Maps the protobuf schema to relational schema.
     pub fn map_to_columns(&self) -> ConnectorResult<Vec<Field>> {
         pb_schema_to_fields(&self.message_descriptor, &self.messages_as_jsonb).map_err(|e| e.into())
-    }
-}
-
-/// A port from the implementation of confluent's Varint Zig-zag deserialization.
-/// See `ReadVarint` in <https://github.com/apache/kafka/blob/trunk/clients/src/main/java/org/apache/kafka/common/utils/ByteUtils.java>
-fn decode_varint_zigzag(buffer: &[u8]) -> ConnectorResult<(i32, usize)> {
-    // We expect the decoded number to be 4 bytes.
-    let mut value = 0u32;
-    let mut shift = 0;
-    let mut len = 0usize;
-
-    for &byte in buffer {
-        len += 1;
-        // The Varint encoding is limited to 5 bytes.
-        if len > 5 {
-            break;
-        }
-        // The byte is cast to u32 to avoid shifting overflow.
-        let byte_ext = byte as u32;
-        // In Varint encoding, the lowest 7 bits are used to represent number,
-        // while the highest zero bit indicates the end of the number with Varint encoding.
-        value |= (byte_ext & 0x7F) << shift;
-        if byte_ext & 0x80 == 0 {
-            return Ok((((value >> 1) as i32) ^ -((value & 1) as i32), len));
-        }
-
-        shift += 7;
-    }
-
-    Err(WireFormatError::ParseMessageIndexes.into())
-}
-
-/// Reference: <https://docs.confluent.io/platform/current/schema-registry/fundamentals/serdes-develop/index.html#wire-format>
-/// Wire format for Confluent pb header is:
-/// | 0          | 1-4        | 5-x             | x+1-end
-/// | magic-byte | schema-id  | message-indexes | protobuf-payload
-pub(crate) fn resolve_pb_header(payload: &[u8]) -> ConnectorResult<&[u8]> {
-    // there's a message index array at the front of payload
-    // if it is the first message in proto def, the array is just and `0`
-    let (_, remained) = extract_schema_id(payload)?;
-    // The message indexes are encoded as int using variable-length zig-zag encoding,
-    // prefixed by the length of the array.
-    // Note that if the first byte is 0, it is equivalent to (1, 0) as an optimization.
-    match remained.first() {
-        Some(0) => Ok(&remained[1..]),
-        Some(_) => {
-            let (index_len, mut offset) = decode_varint_zigzag(remained)?;
-            for _ in 0..index_len {
-                offset += decode_varint_zigzag(&remained[offset..])?.1;
-            }
-            Ok(&remained[offset..])
-        }
-        None => bail!("The proto payload is empty"),
-    }
-}
-
-#[cfg(test)]
-mod test {
-    use super::*;
-
-    #[test]
-    fn test_decode_varint_zigzag() {
-        // 1. Positive number
-        let buffer = vec![0x02];
-        let (value, len) = decode_varint_zigzag(&buffer).unwrap();
-        assert_eq!(value, 1);
-        assert_eq!(len, 1);
-
-        // 2. Negative number
-        let buffer = vec![0x01];
-        let (value, len) = decode_varint_zigzag(&buffer).unwrap();
-        assert_eq!(value, -1);
-        assert_eq!(len, 1);
-
-        // 3. Larger positive number
-        let buffer = vec![0x9E, 0x03];
-        let (value, len) = decode_varint_zigzag(&buffer).unwrap();
-        assert_eq!(value, 207);
-        assert_eq!(len, 2);
-
-        // 4. Larger negative number
-        let buffer = vec![0xBF, 0x07];
-        let (value, len) = decode_varint_zigzag(&buffer).unwrap();
-        assert_eq!(value, -480);
-        assert_eq!(len, 2);
-
-        // 5. Maximum positive number
-        let buffer = vec![0xFE, 0xFF, 0xFF, 0xFF, 0x0F];
-        let (value, len) = decode_varint_zigzag(&buffer).unwrap();
-        assert_eq!(value, i32::MAX);
-        assert_eq!(len, 5);
-
-        // 6. Maximum negative number
-        let buffer = vec![0xFF, 0xFF, 0xFF, 0xFF, 0x0F];
-        let (value, len) = decode_varint_zigzag(&buffer).unwrap();
-        assert_eq!(value, i32::MIN);
-        assert_eq!(len, 5);
-
-        // 7. More than 32 bits
-        let buffer = vec![0xFF, 0xFF, 0xFF, 0xFF, 0x7F];
-        let (value, len) = decode_varint_zigzag(&buffer).unwrap();
-        assert_eq!(value, i32::MIN);
-        assert_eq!(len, 5);
-
-        // 8. Invalid input (more than 5 bytes)
-        let buffer = vec![0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF];
-        let result = decode_varint_zigzag(&buffer);
-        assert!(result.is_err());
     }
 }

--- a/src/connector/src/parser/protobuf/parser.rs
+++ b/src/connector/src/parser/protobuf/parser.rs
@@ -34,6 +34,7 @@ use crate::schema::{
 #[derive(Debug)]
 pub struct ProtobufAccessBuilder {
     decoder: ProtobufDecoder,
+    reader_descriptor: MessageDescriptor,
 
     // A HashSet containing protobuf message type full names (e.g. "google.protobuf.Any")
     // that should be mapped to JSONB type when storing in RisingWave
@@ -50,6 +51,7 @@ impl AccessBuilder for ProtobufAccessBuilder {
 
         Ok(AccessImpl::Protobuf(ProtobufAccess::new(
             message,
+            self.reader_descriptor.clone(),
             &self.messages_as_jsonb,
         )))
     }
@@ -59,12 +61,13 @@ impl ProtobufAccessBuilder {
     pub fn new(config: ProtobufParserConfig) -> ConnectorResult<Self> {
         let ProtobufParserConfig {
             decoder,
+            message_descriptor,
             messages_as_jsonb,
-            ..
         } = config;
 
         Ok(Self {
             decoder,
+            reader_descriptor: message_descriptor,
             messages_as_jsonb,
         })
     }

--- a/src/connector/src/parser/protobuf/parser.rs
+++ b/src/connector/src/parser/protobuf/parser.rs
@@ -15,26 +15,25 @@
 use std::collections::HashSet;
 
 use anyhow::Context;
-use prost_reflect::{DescriptorPool, DynamicMessage, FileDescriptor, MessageDescriptor};
+use prost_reflect::{DescriptorPool, FileDescriptor, MessageDescriptor};
 use risingwave_common::catalog::Field;
 use risingwave_common::{bail, try_match_expand};
 use risingwave_connector_codec::decoder::protobuf::ProtobufAccess;
 pub use risingwave_connector_codec::decoder::protobuf::parser::{PROTOBUF_MESSAGES_AS_JSONB, *};
 
-use super::message::parse_confluent_protobuf_message;
+use super::decoder::ProtobufDecoder;
 use crate::error::ConnectorResult;
 use crate::parser::unified::AccessImpl;
 use crate::parser::utils::bytes_from_url;
 use crate::parser::{AccessBuilder, EncodingProperties, SchemaLocation};
 use crate::schema::schema_registry::{Client, handle_sr_list};
 use crate::schema::{
-    ConfluentSchemaLoader, InvalidOptionError, SchemaLoader, bail_invalid_option_error,
+    ConfluentSchemaLoader, InvalidOptionError, SchemaVersion, bail_invalid_option_error,
 };
 
 #[derive(Debug)]
 pub struct ProtobufAccessBuilder {
-    wire_type: WireType,
-    message_descriptor: MessageDescriptor,
+    decoder: ProtobufDecoder,
 
     // A HashSet containing protobuf message type full names (e.g. "google.protobuf.Any")
     // that should be mapped to JSONB type when storing in RisingWave
@@ -47,17 +46,7 @@ impl AccessBuilder for ProtobufAccessBuilder {
         payload: Vec<u8>,
         _: &crate::source::SourceMeta,
     ) -> ConnectorResult<AccessImpl<'_>> {
-        let payload = match self.wire_type {
-            WireType::Confluent => {
-                parse_confluent_protobuf_message(&payload)
-                    .map_err(anyhow::Error::new)?
-                    .payload
-            }
-            WireType::None => &payload,
-        };
-
-        let message = DynamicMessage::decode(self.message_descriptor.clone(), payload)
-            .context("failed to parse message")?;
+        let message = self.decoder.decode(&payload).await?;
 
         Ok(AccessImpl::Protobuf(ProtobufAccess::new(
             message,
@@ -69,44 +58,21 @@ impl AccessBuilder for ProtobufAccessBuilder {
 impl ProtobufAccessBuilder {
     pub fn new(config: ProtobufParserConfig) -> ConnectorResult<Self> {
         let ProtobufParserConfig {
-            wire_type,
-            message_descriptor,
+            decoder,
             messages_as_jsonb,
+            ..
         } = config;
 
         Ok(Self {
-            wire_type,
-            message_descriptor,
+            decoder,
             messages_as_jsonb,
         })
     }
 }
 
-#[derive(Debug, Clone)]
-enum WireType {
-    None,
-    Confluent,
-    // Glue,
-    // Pulsar,
-}
-
-impl TryFrom<&SchemaLocation> for WireType {
-    type Error = InvalidOptionError;
-
-    fn try_from(value: &SchemaLocation) -> Result<Self, Self::Error> {
-        match value {
-            SchemaLocation::File { .. } => Ok(Self::None),
-            SchemaLocation::Confluent { .. } => Ok(Self::Confluent),
-            SchemaLocation::Glue { .. } => bail_invalid_option_error!(
-                "encode protobuf from aws glue schema registry not supported yet"
-            ),
-        }
-    }
-}
-
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct ProtobufParserConfig {
-    wire_type: WireType,
+    decoder: ProtobufDecoder,
     pub(crate) message_descriptor: MessageDescriptor,
     messages_as_jsonb: HashSet<String>,
 }
@@ -114,14 +80,12 @@ pub struct ProtobufParserConfig {
 impl ProtobufParserConfig {
     pub async fn new(encoding_properties: EncodingProperties) -> ConnectorResult<Self> {
         let protobuf_config = try_match_expand!(encoding_properties, EncodingProperties::Protobuf)?;
-        let message_name = &protobuf_config.message_name;
-
-        let wire_type = (&protobuf_config.schema_location).try_into()?;
         if protobuf_config.key_message_name.is_some() {
             // https://docs.confluent.io/platform/7.5/control-center/topics/schema.html#c3-schemas-best-practices-key-value-pairs
             bail!("protobuf key is not supported");
         }
-        let pool = match protobuf_config.schema_location {
+        let message_name = protobuf_config.message_name;
+        let (message_descriptor, decoder) = match protobuf_config.schema_location {
             SchemaLocation::Confluent {
                 urls,
                 client_config,
@@ -130,18 +94,32 @@ impl ProtobufParserConfig {
             } => {
                 let url = handle_sr_list(urls.as_str())?;
                 let client = Client::new(url, &client_config)?;
-                let loader = SchemaLoader::Confluent(ConfluentSchemaLoader {
+                let loader = ConfluentSchemaLoader {
                     client,
                     name_strategy,
                     topic,
                     key_record_name: None,
                     val_record_name: Some(message_name.clone()),
-                });
-                let (_schema_id, root_file_descriptor) = loader
+                };
+                let (schema_version, root_file_descriptor) = loader
                     .load_val_schema::<FileDescriptor>()
                     .await
                     .context("load schema failed")?;
-                root_file_descriptor.parent_pool().clone()
+                let SchemaVersion::Confluent(schema_id) = schema_version else {
+                    unreachable!("ConfluentSchemaLoader must return a Confluent schema version")
+                };
+                let message_descriptor = root_file_descriptor
+                    .parent_pool()
+                    .get_message_by_name(&message_name)
+                    .with_context(|| format!("cannot find message `{message_name}` in schema"))?;
+                let decoder = ProtobufDecoder::confluent(
+                    message_name.clone(),
+                    loader,
+                    (schema_id, root_file_descriptor),
+                )
+                .await;
+
+                (message_descriptor, decoder)
             }
             SchemaLocation::File {
                 url,
@@ -150,21 +128,24 @@ impl ProtobufParserConfig {
                 let url = handle_sr_list(url.as_str())?;
                 let url = url.first().unwrap();
                 let schema_bytes = bytes_from_url(url, aws_auth_props.as_ref()).await?;
-                DescriptorPool::decode(schema_bytes.as_slice())
-                    .with_context(|| format!("cannot build descriptor pool from schema `{url}`"))?
+                let pool = DescriptorPool::decode(schema_bytes.as_slice())
+                    .with_context(|| format!("cannot build descriptor pool from schema `{url}`"))?;
+                let message_descriptor = pool
+                    .get_message_by_name(&message_name)
+                    .with_context(|| format!("cannot find message `{message_name}` in schema"))?;
+                (
+                    message_descriptor.clone(),
+                    ProtobufDecoder::Static(message_descriptor),
+                )
             }
             SchemaLocation::Glue { .. } => bail_invalid_option_error!(
                 "encode protobuf from aws glue schema registry not supported yet"
             ),
         };
 
-        let message_descriptor = pool
-            .get_message_by_name(message_name)
-            .with_context(|| format!("cannot find message `{message_name}` in schema"))?;
-
         Ok(Self {
             message_descriptor,
-            wire_type,
+            decoder,
             messages_as_jsonb: protobuf_config.messages_as_jsonb,
         })
     }

--- a/src/connector/src/parser/protobuf/parser.rs
+++ b/src/connector/src/parser/protobuf/parser.rs
@@ -21,11 +21,12 @@ use risingwave_common::{bail, try_match_expand};
 use risingwave_connector_codec::decoder::protobuf::ProtobufAccess;
 pub use risingwave_connector_codec::decoder::protobuf::parser::{PROTOBUF_MESSAGES_AS_JSONB, *};
 
+use super::message::parse_confluent_protobuf_message;
 use crate::error::ConnectorResult;
 use crate::parser::unified::AccessImpl;
 use crate::parser::utils::bytes_from_url;
 use crate::parser::{AccessBuilder, EncodingProperties, SchemaLocation};
-use crate::schema::schema_registry::{Client, WireFormatError, extract_schema_id, handle_sr_list};
+use crate::schema::schema_registry::{Client, handle_sr_list};
 use crate::schema::{
     ConfluentSchemaLoader, InvalidOptionError, SchemaLoader, bail_invalid_option_error,
 };
@@ -47,7 +48,11 @@ impl AccessBuilder for ProtobufAccessBuilder {
         _: &crate::source::SourceMeta,
     ) -> ConnectorResult<AccessImpl<'_>> {
         let payload = match self.wire_type {
-            WireType::Confluent => resolve_pb_header(&payload)?,
+            WireType::Confluent => {
+                parse_confluent_protobuf_message(&payload)
+                    .map_err(anyhow::Error::new)?
+                    .payload
+            }
             WireType::None => &payload,
         };
 
@@ -167,113 +172,5 @@ impl ProtobufParserConfig {
     /// Maps the protobuf schema to relational schema.
     pub fn map_to_columns(&self) -> ConnectorResult<Vec<Field>> {
         pb_schema_to_fields(&self.message_descriptor, &self.messages_as_jsonb).map_err(|e| e.into())
-    }
-}
-
-/// A port from the implementation of confluent's Varint Zig-zag deserialization.
-/// See `ReadVarint` in <https://github.com/apache/kafka/blob/trunk/clients/src/main/java/org/apache/kafka/common/utils/ByteUtils.java>
-fn decode_varint_zigzag(buffer: &[u8]) -> ConnectorResult<(i32, usize)> {
-    // We expect the decoded number to be 4 bytes.
-    let mut value = 0u32;
-    let mut shift = 0;
-    let mut len = 0usize;
-
-    for &byte in buffer {
-        len += 1;
-        // The Varint encoding is limited to 5 bytes.
-        if len > 5 {
-            break;
-        }
-        // The byte is cast to u32 to avoid shifting overflow.
-        let byte_ext = byte as u32;
-        // In Varint encoding, the lowest 7 bits are used to represent number,
-        // while the highest zero bit indicates the end of the number with Varint encoding.
-        value |= (byte_ext & 0x7F) << shift;
-        if byte_ext & 0x80 == 0 {
-            return Ok((((value >> 1) as i32) ^ -((value & 1) as i32), len));
-        }
-
-        shift += 7;
-    }
-
-    Err(WireFormatError::ParseMessageIndexes.into())
-}
-
-/// Reference: <https://docs.confluent.io/platform/current/schema-registry/fundamentals/serdes-develop/index.html#wire-format>
-/// Wire format for Confluent pb header is:
-/// | 0          | 1-4        | 5-x             | x+1-end
-/// | magic-byte | schema-id  | message-indexes | protobuf-payload
-pub(crate) fn resolve_pb_header(payload: &[u8]) -> ConnectorResult<&[u8]> {
-    // there's a message index array at the front of payload
-    // if it is the first message in proto def, the array is just and `0`
-    let (_, remained) = extract_schema_id(payload)?;
-    // The message indexes are encoded as int using variable-length zig-zag encoding,
-    // prefixed by the length of the array.
-    // Note that if the first byte is 0, it is equivalent to (1, 0) as an optimization.
-    match remained.first() {
-        Some(0) => Ok(&remained[1..]),
-        Some(_) => {
-            let (index_len, mut offset) = decode_varint_zigzag(remained)?;
-            for _ in 0..index_len {
-                offset += decode_varint_zigzag(&remained[offset..])?.1;
-            }
-            Ok(&remained[offset..])
-        }
-        None => bail!("The proto payload is empty"),
-    }
-}
-
-#[cfg(test)]
-mod test {
-    use super::*;
-
-    #[test]
-    fn test_decode_varint_zigzag() {
-        // 1. Positive number
-        let buffer = vec![0x02];
-        let (value, len) = decode_varint_zigzag(&buffer).unwrap();
-        assert_eq!(value, 1);
-        assert_eq!(len, 1);
-
-        // 2. Negative number
-        let buffer = vec![0x01];
-        let (value, len) = decode_varint_zigzag(&buffer).unwrap();
-        assert_eq!(value, -1);
-        assert_eq!(len, 1);
-
-        // 3. Larger positive number
-        let buffer = vec![0x9E, 0x03];
-        let (value, len) = decode_varint_zigzag(&buffer).unwrap();
-        assert_eq!(value, 207);
-        assert_eq!(len, 2);
-
-        // 4. Larger negative number
-        let buffer = vec![0xBF, 0x07];
-        let (value, len) = decode_varint_zigzag(&buffer).unwrap();
-        assert_eq!(value, -480);
-        assert_eq!(len, 2);
-
-        // 5. Maximum positive number
-        let buffer = vec![0xFE, 0xFF, 0xFF, 0xFF, 0x0F];
-        let (value, len) = decode_varint_zigzag(&buffer).unwrap();
-        assert_eq!(value, i32::MAX);
-        assert_eq!(len, 5);
-
-        // 6. Maximum negative number
-        let buffer = vec![0xFF, 0xFF, 0xFF, 0xFF, 0x0F];
-        let (value, len) = decode_varint_zigzag(&buffer).unwrap();
-        assert_eq!(value, i32::MIN);
-        assert_eq!(len, 5);
-
-        // 7. More than 32 bits
-        let buffer = vec![0xFF, 0xFF, 0xFF, 0xFF, 0x7F];
-        let (value, len) = decode_varint_zigzag(&buffer).unwrap();
-        assert_eq!(value, i32::MIN);
-        assert_eq!(len, 5);
-
-        // 8. Invalid input (more than 5 bytes)
-        let buffer = vec![0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF];
-        let result = decode_varint_zigzag(&buffer);
-        assert!(result.is_err());
     }
 }

--- a/src/connector/src/parser/protobuf/schema_cache.rs
+++ b/src/connector/src/parser/protobuf/schema_cache.rs
@@ -1,0 +1,93 @@
+// Copyright 2026 RisingWave Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use anyhow::Context;
+use moka::future::Cache;
+use prost_reflect::FileDescriptor;
+
+use crate::error::{ConnectorError, ConnectorResult};
+use crate::schema::ConfluentSchemaLoader;
+
+const DEFAULT_PROTOBUF_SCHEMA_CACHE_CAPACITY: u64 = 128;
+
+#[derive(Debug)]
+pub(super) struct ProtobufSchemaCache {
+    loader: ConfluentSchemaLoader,
+    schemas: Cache<i32, FileDescriptor>,
+}
+
+impl ProtobufSchemaCache {
+    pub async fn new(loader: ConfluentSchemaLoader, initial_schema: (i32, FileDescriptor)) -> Self {
+        let schemas = Cache::builder()
+            .max_capacity(DEFAULT_PROTOBUF_SCHEMA_CACHE_CAPACITY)
+            .build();
+        let (schema_id, file_descriptor) = initial_schema;
+        schemas.insert(schema_id, file_descriptor).await;
+
+        Self { loader, schemas }
+    }
+
+    pub async fn get(&self, schema_id: i32) -> ConnectorResult<FileDescriptor> {
+        self.schemas
+            .try_get_with(schema_id, async {
+                self.loader
+                    .load_val_schema_by_id(schema_id)
+                    .await
+                    .with_context(|| {
+                        format!("failed to load protobuf writer schema ID {schema_id}")
+                    })
+                    .map_err(ConnectorError::from)
+            })
+            .await
+            .map_err(ConnectorError::from)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use prost_reflect::DescriptorPool;
+    use prost_types::{FileDescriptorProto, FileDescriptorSet};
+
+    use super::*;
+    use crate::schema::schema_registry::{Client, SchemaRegistryConfig};
+
+    #[tokio::test]
+    async fn test_initial_schema_is_cached() {
+        let pool = DescriptorPool::from_file_descriptor_set(FileDescriptorSet {
+            file: vec![FileDescriptorProto {
+                name: Some("initial.proto".into()),
+                syntax: Some("proto3".into()),
+                ..Default::default()
+            }],
+        })
+        .unwrap();
+        let file_descriptor = pool.get_file_by_name("initial.proto").unwrap();
+        let loader = ConfluentSchemaLoader {
+            client: Client::new(
+                vec!["http://127.0.0.1:1".parse().unwrap()],
+                &SchemaRegistryConfig::default(),
+            )
+            .unwrap(),
+            name_strategy: Default::default(),
+            topic: "unused".into(),
+            key_record_name: None,
+            val_record_name: Some("test.Event".into()),
+        };
+
+        let cache = ProtobufSchemaCache::new(loader, (42, file_descriptor.clone())).await;
+        let cached = cache.get(42).await.unwrap();
+
+        assert_eq!(cached, file_descriptor);
+    }
+}

--- a/src/connector/src/parser/protobuf/schema_cache.rs
+++ b/src/connector/src/parser/protobuf/schema_cache.rs
@@ -1,0 +1,97 @@
+// Copyright 2026 RisingWave Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use anyhow::Context;
+use moka::future::Cache;
+use prost_reflect::FileDescriptor;
+
+use crate::error::{ConnectorError, ConnectorResult};
+use crate::schema::ConfluentSchemaLoader;
+
+const DEFAULT_PROTOBUF_SCHEMA_CACHE_CAPACITY: u64 = 128;
+
+#[derive(Debug)]
+pub(super) struct ProtobufSchemaCache {
+    loader: ConfluentSchemaLoader,
+    schemas: Cache<i32, FileDescriptor>,
+}
+
+impl ProtobufSchemaCache {
+    pub fn new(loader: ConfluentSchemaLoader) -> Self {
+        let schemas = Cache::builder()
+            .max_capacity(DEFAULT_PROTOBUF_SCHEMA_CACHE_CAPACITY)
+            .build();
+
+        Self { loader, schemas }
+    }
+
+    /// Inserts an already loaded schema into the cache without contacting Schema Registry.
+    pub async fn load(&self, schema_id: i32, file_descriptor: FileDescriptor) {
+        self.schemas.insert(schema_id, file_descriptor).await;
+    }
+
+    pub async fn get(&self, schema_id: i32) -> ConnectorResult<FileDescriptor> {
+        self.schemas
+            .try_get_with(schema_id, async {
+                self.loader
+                    .load_val_schema_by_id(schema_id)
+                    .await
+                    .with_context(|| {
+                        format!("failed to load protobuf writer schema ID {schema_id}")
+                    })
+                    .map_err(ConnectorError::from)
+            })
+            .await
+            .map_err(ConnectorError::from)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use prost_reflect::DescriptorPool;
+    use prost_types::{FileDescriptorProto, FileDescriptorSet};
+
+    use super::*;
+    use crate::schema::schema_registry::{Client, SchemaRegistryConfig};
+
+    #[tokio::test]
+    async fn test_schema_is_cached() {
+        let pool = DescriptorPool::from_file_descriptor_set(FileDescriptorSet {
+            file: vec![FileDescriptorProto {
+                name: Some("initial.proto".into()),
+                syntax: Some("proto3".into()),
+                ..Default::default()
+            }],
+        })
+        .unwrap();
+        let file_descriptor = pool.get_file_by_name("initial.proto").unwrap();
+        let loader = ConfluentSchemaLoader {
+            client: Client::new(
+                vec!["http://127.0.0.1:1".parse().unwrap()],
+                &SchemaRegistryConfig::default(),
+            )
+            .unwrap(),
+            name_strategy: Default::default(),
+            topic: "unused".into(),
+            key_record_name: None,
+            val_record_name: Some("test.Event".into()),
+        };
+
+        let cache = ProtobufSchemaCache::new(loader);
+        cache.load(42, file_descriptor.clone()).await;
+        let cached = cache.get(42).await.unwrap();
+
+        assert_eq!(cached, file_descriptor);
+    }
+}

--- a/src/connector/src/schema/loader.rs
+++ b/src/connector/src/schema/loader.rs
@@ -31,6 +31,7 @@ pub enum SchemaLoader {
     Glue(GlueSchemaLoader),
 }
 
+#[derive(Debug)]
 pub struct ConfluentSchemaLoader {
     pub client: Client,
     pub name_strategy: PbSchemaRegistryNameStrategy,
@@ -56,6 +57,20 @@ pub enum SchemaVersion {
 }
 
 impl ConfluentSchemaLoader {
+    fn subject<const IS_KEY: bool>(&self) -> Result<String, SchemaFetchError> {
+        let record = if IS_KEY {
+            self.key_record_name.as_deref()
+        } else {
+            self.val_record_name.as_deref()
+        };
+        Ok(get_subject_by_strategy(
+            &self.name_strategy,
+            &self.topic,
+            record,
+            IS_KEY,
+        )?)
+    }
+
     pub fn from_format_options(
         topic: &str,
         format_options: &BTreeMap<String, String>,
@@ -90,16 +105,54 @@ impl ConfluentSchemaLoader {
     async fn load_schema<Out: LoadedSchema, const IS_KEY: bool>(
         &self,
     ) -> Result<(SchemaVersion, Out), SchemaFetchError> {
-        let record = match IS_KEY {
-            true => self.key_record_name.as_deref(),
-            false => self.val_record_name.as_deref(),
-        };
-        let subject = get_subject_by_strategy(&self.name_strategy, &self.topic, record, IS_KEY)?;
+        let subject = self.subject::<IS_KEY>()?;
         let (primary_subject, dependency_subjects) =
             self.client.get_subject_and_references(&subject).await?;
         let schema_id = primary_subject.schema.id;
         let out = Out::compile(primary_subject, dependency_subjects)?;
         Ok((SchemaVersion::Confluent(schema_id), out))
+    }
+
+    async fn load_schema_by_id<Out: LoadedSchema, const IS_KEY: bool>(
+        &self,
+        schema_id: i32,
+    ) -> Result<Out, SchemaFetchError> {
+        let subject = self.subject::<IS_KEY>()?;
+        let versions = self.client.get_schema_versions_by_id(schema_id).await?;
+        let version = versions
+            .into_iter()
+            .find(|candidate| candidate.subject == subject)
+            .ok_or_else(|| {
+                malformed_response_error!(
+                    "schema ID {schema_id} is not registered under subject `{subject}`"
+                )
+            })?
+            .version;
+        let (primary, references) = self
+            .client
+            .get_subject_and_references_by_version(&subject, version)
+            .await?;
+        if primary.schema.id != schema_id {
+            return Err(malformed_response_error!(
+                "subject `{subject}` version {version} returned schema ID {}, expected {schema_id}",
+                primary.schema.id
+            )
+            .into());
+        }
+        Out::compile(primary, references)
+    }
+
+    pub async fn load_val_schema_by_id<Out: LoadedSchema>(
+        &self,
+        schema_id: i32,
+    ) -> Result<Out, SchemaFetchError> {
+        self.load_schema_by_id::<Out, false>(schema_id).await
+    }
+
+    pub async fn load_val_schema<Out: LoadedSchema>(
+        &self,
+    ) -> Result<(SchemaVersion, Out), SchemaFetchError> {
+        self.load_schema::<Out, false>().await
     }
 }
 

--- a/src/connector/src/schema/loader.rs
+++ b/src/connector/src/schema/loader.rs
@@ -31,6 +31,7 @@ pub enum SchemaLoader {
     Glue(GlueSchemaLoader),
 }
 
+#[derive(Debug)]
 pub struct ConfluentSchemaLoader {
     pub client: Client,
     pub name_strategy: PbSchemaRegistryNameStrategy,
@@ -56,6 +57,22 @@ pub enum SchemaVersion {
 }
 
 impl ConfluentSchemaLoader {
+    /// Resolves the key or value subject using the configured naming strategy.
+    fn subject<const IS_KEY: bool>(&self) -> Result<String, SchemaFetchError> {
+        let record = if IS_KEY {
+            self.key_record_name.as_deref()
+        } else {
+            self.val_record_name.as_deref()
+        };
+        Ok(get_subject_by_strategy(
+            &self.name_strategy,
+            &self.topic,
+            record,
+            IS_KEY,
+        )?)
+    }
+
+    /// Creates a loader from connector format options.
     pub fn from_format_options(
         topic: &str,
         format_options: &BTreeMap<String, String>,
@@ -88,19 +105,43 @@ impl ConfluentSchemaLoader {
         })
     }
 
+    /// Loads and compiles the latest key or value schema and its references.
     async fn load_schema<Out: LoadedSchema, const IS_KEY: bool>(
         &self,
     ) -> Result<(SchemaVersion, Out), SchemaFetchError> {
-        let record = match IS_KEY {
-            true => self.key_record_name.as_deref(),
-            false => self.val_record_name.as_deref(),
-        };
-        let subject = get_subject_by_strategy(&self.name_strategy, &self.topic, record, IS_KEY)?;
+        let subject = self.subject::<IS_KEY>()?;
         let (primary_subject, dependency_subjects) =
             self.client.get_subject_and_references(&subject).await?;
         let schema_id = primary_subject.schema.id;
         let out = Out::compile(primary_subject, dependency_subjects)?;
         Ok((SchemaVersion::Confluent(schema_id), out))
+    }
+
+    /// Loads and compiles a schema and its references by global schema ID.
+    async fn load_schema_by_id<Out: LoadedSchema>(
+        &self,
+        schema_id: i32,
+    ) -> Result<Out, SchemaFetchError> {
+        let (primary, references) = self
+            .client
+            .get_schema_and_references_by_id(schema_id)
+            .await?;
+        Out::compile(primary, references)
+    }
+
+    /// Loads and compiles a value schema by global schema ID.
+    pub async fn load_val_schema_by_id<Out: LoadedSchema>(
+        &self,
+        schema_id: i32,
+    ) -> Result<Out, SchemaFetchError> {
+        self.load_schema_by_id::<Out>(schema_id).await
+    }
+
+    /// Loads and compiles the latest value schema.
+    pub async fn load_val_schema<Out: LoadedSchema>(
+        &self,
+    ) -> Result<(SchemaVersion, Out), SchemaFetchError> {
+        self.load_schema::<Out, false>().await
     }
 }
 

--- a/src/connector/src/schema/schema_registry/client.rs
+++ b/src/connector/src/schema/schema_registry/client.rs
@@ -275,6 +275,18 @@ impl Client {
         })
     }
 
+    /// Get all subject versions associated with a schema ID.
+    pub(crate) async fn get_schema_versions_by_id(
+        &self,
+        id: i32,
+    ) -> SrResult<Vec<SchemaIdVersion>> {
+        self.concurrent_req(
+            Method::GET,
+            &["schemas", "ids", &id.to_string(), "versions"],
+        )
+        .await
+    }
+
     /// get the latest schema of the subject
     pub async fn get_schema_by_subject(&self, subject: &str) -> SrResult<ConfluentSchema> {
         self.get_subject(subject).await.map(|s| s.schema)
@@ -294,8 +306,18 @@ impl Client {
 
     /// get the latest version of the subject
     pub async fn get_subject(&self, subject: &str) -> SrResult<Subject> {
+        self.get_subject_by_version(subject, "latest").await
+    }
+
+    /// Get an exact version of a subject.
+    pub async fn get_subject_by_version(
+        &self,
+        subject: &str,
+        version: impl ToString,
+    ) -> SrResult<Subject> {
+        let version = version.to_string();
         let res: GetBySubjectResp = self
-            .concurrent_req(Method::GET, &["subjects", subject, "versions", "latest"])
+            .concurrent_req(Method::GET, &["subjects", subject, "versions", &version])
             .await?;
         tracing::debug!("update schema: {:?}", res);
         Ok(Subject {
@@ -313,11 +335,24 @@ impl Client {
         &self,
         subject: &str,
     ) -> SrResult<(Subject, Vec<Subject>)> {
+        self.get_subject_and_references_by_version(subject, "latest")
+            .await
+    }
+
+    /// Get an exact subject version and recursively load the exact versions of its references.
+    pub async fn get_subject_and_references_by_version(
+        &self,
+        subject: &str,
+        version: impl ToString,
+    ) -> SrResult<(Subject, Vec<Subject>)> {
         let mut subjects = vec![];
         let mut visited = HashSet::new();
-        let mut queue = vec![(subject.to_owned(), "latest".to_owned())];
-        // use bfs to get all references
+        let mut queue = vec![(subject.to_owned(), version.to_string())];
+        // Traverse the complete reference graph while preserving exact versions.
         while let Some((subject, version)) = queue.pop() {
+            if !visited.insert((subject.clone(), version.clone())) {
+                continue;
+            }
             let res: GetBySubjectResp = self
                 .concurrent_req(Method::GET, &["subjects", &subject, "versions", &version])
                 .await?;
@@ -330,11 +365,10 @@ impl Client {
                 name: res.subject.clone(),
             };
             subjects.push(ref_subject);
-            visited.insert(res.subject);
             queue.extend(
                 res.references
                     .into_iter()
-                    .filter(|r| !visited.contains(&r.subject))
+                    .filter(|r| !visited.contains(&(r.subject.clone(), r.version.to_string())))
                     .map(|r| (r.subject, r.version.to_string())),
             );
         }

--- a/src/connector/src/schema/schema_registry/client.rs
+++ b/src/connector/src/schema/schema_registry/client.rs
@@ -269,13 +269,34 @@ impl Client {
 
     /// get schema by id
     pub async fn get_schema_by_id(&self, id: i32) -> SrResult<ConfluentSchema> {
-        let res: GetByIdResp = self
-            .concurrent_req(Method::GET, &["schemas", "ids", &id.to_string()])
-            .await?;
+        let res = self.get_schema_response_by_id(id).await?;
         Ok(ConfluentSchema {
             id,
             content: res.schema,
         })
+    }
+
+    async fn get_schema_response_by_id(&self, id: i32) -> SrResult<GetByIdResp> {
+        self.concurrent_req(Method::GET, &["schemas", "ids", &id.to_string()])
+            .await
+    }
+
+    /// Get a schema by its global ID and recursively load the exact versions of its references.
+    pub(crate) async fn get_schema_and_references_by_id(
+        &self,
+        id: i32,
+    ) -> SrResult<(Subject, Vec<Subject>)> {
+        let response = self.get_schema_response_by_id(id).await?;
+        let references = self.get_referenced_subjects(response.references).await?;
+        let primary = Subject {
+            version: 0,
+            name: format!("schema-{id}.proto"),
+            schema: ConfluentSchema {
+                id,
+                content: response.schema,
+            },
+        };
+        Ok((primary, references))
     }
 
     /// get the latest schema of the subject
@@ -297,8 +318,18 @@ impl Client {
 
     /// get the latest version of the subject
     pub async fn get_subject(&self, subject: &str) -> SrResult<Subject> {
+        self.get_subject_by_version(subject, "latest").await
+    }
+
+    /// Get an exact version of a subject.
+    pub async fn get_subject_by_version(
+        &self,
+        subject: &str,
+        version: impl ToString,
+    ) -> SrResult<Subject> {
+        let version = version.to_string();
         let res: GetBySubjectResp = self
-            .concurrent_req(Method::GET, &["subjects", subject, "versions", "latest"])
+            .concurrent_req(Method::GET, &["subjects", subject, "versions", &version])
             .await?;
         tracing::debug!("update schema: {:?}", res);
         Ok(Subject {
@@ -316,13 +347,56 @@ impl Client {
         &self,
         subject: &str,
     ) -> SrResult<(Subject, Vec<Subject>)> {
+        self.get_subject_and_references_by_version(subject, "latest")
+            .await
+    }
+
+    /// Get an exact subject version and recursively load the exact versions of its references.
+    pub async fn get_subject_and_references_by_version(
+        &self,
+        subject: &str,
+        version: impl ToString,
+    ) -> SrResult<(Subject, Vec<Subject>)> {
+        let version = version.to_string();
+        let response: GetBySubjectResp = self
+            .concurrent_req(Method::GET, &["subjects", subject, "versions", &version])
+            .await?;
+        let references = self.get_referenced_subjects(response.references).await?;
+        let primary = Subject {
+            schema: ConfluentSchema {
+                id: response.id,
+                content: response.schema,
+            },
+            version: response.version,
+            name: response.subject,
+        };
+        Ok((primary, references))
+    }
+
+    async fn get_referenced_subjects(
+        &self,
+        references: Vec<SchemaReference>,
+    ) -> SrResult<Vec<Subject>> {
         let mut subjects = vec![];
         let mut visited = HashSet::new();
-        let mut queue = vec![(subject.to_owned(), "latest".to_owned())];
-        // use bfs to get all references
-        while let Some((subject, version)) = queue.pop() {
+        let mut queue = references;
+
+        while let Some(reference) = queue.pop() {
+            let identity = (
+                reference.name.clone(),
+                reference.subject.clone(),
+                reference.version,
+            );
+            if !visited.insert(identity) {
+                continue;
+            }
+
+            let version = reference.version.to_string();
             let res: GetBySubjectResp = self
-                .concurrent_req(Method::GET, &["subjects", &subject, "versions", &version])
+                .concurrent_req(
+                    Method::GET,
+                    &["subjects", &reference.subject, "versions", &version],
+                )
                 .await?;
             let ref_subject = Subject {
                 schema: ConfluentSchema {
@@ -330,19 +404,12 @@ impl Client {
                     content: res.schema,
                 },
                 version: res.version,
-                name: res.subject.clone(),
+                name: reference.name,
             };
             subjects.push(ref_subject);
-            visited.insert(res.subject);
-            queue.extend(
-                res.references
-                    .into_iter()
-                    .filter(|r| !visited.contains(&r.subject))
-                    .map(|r| (r.subject, r.version.to_string())),
-            );
+            queue.extend(res.references);
         }
-        let origin_subject = subjects.remove(0);
 
-        Ok((origin_subject, subjects))
+        Ok(subjects)
     }
 }

--- a/src/connector/src/schema/schema_registry/client.rs
+++ b/src/connector/src/schema/schema_registry/client.rs
@@ -252,7 +252,7 @@ impl Client {
             let (result, _index, remaining) = select_all(fut_req).await;
             match result {
                 Ok(Ok(res)) => {
-                    let _ = remaining.iter().map(|ele| ele.abort());
+                    let _ = remaining.iter().for_each(|task| task.abort());
                     return Ok(res);
                 }
                 Ok(Err(e)) => errs.push(itertools::Either::Left(e)),

--- a/src/connector/src/schema/schema_registry/util.rs
+++ b/src/connector/src/schema/schema_registry/util.rs
@@ -166,6 +166,13 @@ pub struct GetByIdResp {
     pub schema: String,
 }
 
+/// A subject and version pair associated with a schema ID.
+#[derive(Debug, Deserialize)]
+pub struct SchemaIdVersion {
+    pub subject: String,
+    pub version: i32,
+}
+
 #[derive(Debug, Deserialize)]
 pub struct GetBySubjectResp {
     pub id: i32,

--- a/src/connector/src/schema/schema_registry/util.rs
+++ b/src/connector/src/schema/schema_registry/util.rs
@@ -153,7 +153,6 @@ pub struct Subject {
 #[derive(Debug, Deserialize)]
 pub struct SchemaReference {
     /// The name of the reference.
-    #[expect(dead_code)]
     pub name: String,
     /// The subject that the referenced schema belongs to
     pub subject: String,
@@ -164,6 +163,8 @@ pub struct SchemaReference {
 #[derive(Debug, Deserialize)]
 pub struct GetByIdResp {
     pub schema: String,
+    #[serde(default)]
+    pub references: Vec<SchemaReference>,
 }
 
 #[derive(Debug, Deserialize)]


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

<!--

**Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

- Closes #22082.

Previously, Confluent Protobuf messages were decoded directly with the latest reader schema configured for the source. This works for some compatible schema changes, such as adding or removing fields, but fails when the writer schema contains information unavailable to the reader schema—for example, a newly added enum value.

This PR decodes every Confluent Protobuf record with the exact writer schema identified by the schema ID in its wire-format header, and then projects the decoded message onto the current reader schema.

The decoding flow is now:

1. Parse the Confluent Protobuf wire format into:
   - schema ID
   - message-index array
   - Protobuf payload
2. Load the schema and the exact versions of its references from Schema Registry.
3. Cache compiled writer `FileDescriptor`s by schema ID.
   - The initially loaded reader schema is used to prewarm the cache.
   - Concurrent cache misses for the same schema ID are deduplicated.
   - The cache is bounded to 128 entries.
4. Resolve the concrete writer `MessageDescriptor` using the message-index array.
5. Decode the payload into a `DynamicMessage` using that writer descriptor.
6. Project writer fields onto the reader/catalog schema by Protobuf field number.

Matching fields by number is necessary because field names may differ between writer and reader schemas while still representing the same Protobuf field. The mapping is also applied recursively to nested messages, repeated messages, and map values.

If a field exists in the reader schema but not in the writer schema, it is converted to SQL `NULL` instead of using the reader schema's Protobuf default value.

The Schema Registry client is also extended to:

- load schemas by global schema ID;
- load an exact subject version;
- recursively load the exact versions of schema references;
- abort redundant requests after one Schema Registry endpoint succeeds.

Static Protobuf schemas loaded from files keep their existing decoding behavior.

## Checklist

- [x] I have written necessary rustdoc comments.
- [x] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->
Kafka sources using Confluent Protobuf now decode each record with the writer schema identified by its embedded schema ID. This improves schema-evolution compatibility, including support for enum values introduced by newer writer schemas and correct `NULL` handling for fields absent from older schemas.

</details>
