### PR TITLE
fix(meta): preserve pending forced checkpoints

### DIFF
--- a/src/meta/src/barrier/schedule.rs
+++ b/src/meta/src/barrier/schedule.rs
@@ -509,7 +509,7 @@ impl PeriodicBarriers {
         &mut self,
         context: &impl GlobalBarrierWorkerContext,
     ) -> NewBarrier {
-        let force_checkpoint_database = self.force_checkpoint_databases.drain().next();
+        let force_checkpoint_database = self.force_checkpoint_databases.extract_if(|_| true).next();
         let new_barrier = if let Some(database_id) = force_checkpoint_database {
             self.reset_database_timer(database_id);
             NewBarrier {
@@ -1135,6 +1135,34 @@ mod tests {
         assert!(barrier.checkpoint);
         assert_eq!(barrier.database_id, DatabaseId::from(1));
         assert!(barrier.command.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_next_barrier_multiple_force_checkpoints() {
+        let databases = vec![
+            create_test_database(1, Some(100), Some(10)),
+            create_test_database(2, Some(100), Some(10)),
+        ];
+
+        let mut periodic = PeriodicBarriers::new(Duration::from_millis(100), 10, databases);
+
+        let (context, _tx) = MockGlobalBarrierWorkerContext::new();
+
+        periodic.force_checkpoint_in_next_barrier(DatabaseId::from(1));
+        periodic.force_checkpoint_in_next_barrier(DatabaseId::from(2));
+
+        let barrier1 = periodic.next_barrier(&context).now_or_never().unwrap();
+        let barrier2 = periodic.next_barrier(&context).now_or_never().unwrap();
+
+        assert!(barrier1.checkpoint);
+        assert!(barrier1.command.is_none());
+        assert!(barrier2.checkpoint);
+        assert!(barrier2.command.is_none());
+        assert_eq!(
+            HashSet::from([barrier1.database_id, barrier2.database_id]),
+            HashSet::from([DatabaseId::from(1), DatabaseId::from(2)])
+        );
+        assert!(periodic.force_checkpoint_databases.is_empty());
     }
 
     #[tokio::test]


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

Fix a forced checkpoint scheduling bug caused by partially consuming `HashSet::drain()`.

`force_checkpoint_databases` may contain multiple database IDs, but `drain().next()` clears the entire set while yielding only one database. This could drop pending forced checkpoints for the other databases. Replace it with `extract_if(|_| true).next()`, which removes one pending database while retaining the rest when the iterator is dropped.

Add a regression test that forces checkpoints for two databases and verifies both are emitted by consecutive barriers.

Drain audit notes:

- Checked the local std implementation/contract for `Vec::drain`, `VecDeque::drain`, `HashMap::drain`, `HashSet::drain`, and `BinaryHeap::drain`. Full/container drains remove the drained contents from the source at iterator creation, so partially consuming the returned iterator can still clear more than the consumed items.
- Checked `HashSet::extract_if`; unlike `drain`, unexhausted `ExtractIf` retains remaining elements, which is why it is used here to pop one pending forced checkpoint.
- Audited repo `.drain(` usages and inspected the suspicious partial-consumption patterns. The real issue was `force_checkpoint_databases.drain().next()`.
- Other suspicious sites were intentional or safe: sqlsmith drains a vector after `split_off(1)` leaves exactly one item; plan fragmentation uses `drain().take(1).collect()` to intentionally keep one partition; explain-analyze drains a one-job fragment map and checks there is no second entry; returned “take/consume” drain APIs are fully collected by their callers.

## Checklist

- [ ] I have written necessary rustdoc comments.
- [x] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [x] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

Not user-facing.

</details>
