### PR TITLE
fix(ci): allow longer snapshot backfill merge lag

### DIFF
--- a/src/config/ci.toml
+++ b/src/config/ci.toml
@@ -10,7 +10,7 @@ max_vnode_key_range_bytes = 214748364800
 
 [streaming]
 in_flight_barrier_nums = 10
-snapshot_backfill_finish_max_lagged_barriers = 5
+snapshot_backfill_finish_max_lagged_barriers = 200
 
 [streaming.developer]
 stream_exchange_concurrent_barriers = 10


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

Raise `streaming.snapshot_backfill_finish_max_lagged_barriers` from 5 to 200 in the CI configuration.

CI injects barriers every 250 ms, so the old value allowed only about 1.25 seconds of lag before a snapshot-backfill job could merge. Slow creating graphs can stay permanently above that threshold and make `CREATE MATERIALIZED VIEW` time out. A value of 200 gives CI a 50-second lag budget while remaining stricter than the default configuration's 100 barriers at a 1-second interval.

This changes only the CI override; the product default remains unchanged.

- Closes #26333

## Checklist

- [x] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [x] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->

## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

Not applicable: this only adjusts the repository's CI configuration.

</details>

## Testing

- `git diff --check`
- Main-cron release end-to-end suites requested with `ci/main-cron/run-selected` and `ci/run-e2e-tests`
