### PR TITLE
test(backfill): update cross-db MV SLT expectations

### DIFF
--- a/e2e_test/backfill/cross_db/cross_db_mv.slt
+++ b/e2e_test/backfill/cross_db/cross_db_mv.slt
@@ -99,16 +99,41 @@ select count(*) from mv1;
 10000
 
 statement ok
-create materialized view mv_rate_limit with (backfill_rate_limit = 0) as select * from d1.public.t1;
+set database to d1;
 
-query I retry 4 backoff 1s
-select count(*) from rw_ddl_progress;
-----
-1
+statement ok
+create table t_rate_limit(v1 int);
 
-sleep 2s
+statement ok
+create subscription sub_rate_limit from t_rate_limit with(retention = '1D');
 
-query I
+statement ok
+set database to d2;
+
+statement ok
+create materialized view mv_rate_limit as select * from d1.public.t_rate_limit;
+
+statement ok
+wait
+
+statement ok
+alter materialized view mv_rate_limit set backfill_rate_limit = 0;
+
+statement ok
+set database to d1;
+
+statement ok
+insert into t_rate_limit select * from generate_series(1, 10000);
+
+sleep 5s
+
+statement ok
+flush;
+
+statement ok
+set database to d2;
+
+query ok
 select count(*) from mv_rate_limit;
 ----
 0
@@ -117,9 +142,9 @@ statement ok
 alter materialized view mv_rate_limit set backfill_rate_limit = 1000;
 
 statement ok
-wait
+flush;
 
-query ok
+query ok retry 10 backoff 1s
 select count(*) from mv_rate_limit;
 ----
 10000
@@ -143,6 +168,9 @@ statement ok
 drop subscription sub_order;
 
 statement ok
+drop subscription sub_rate_limit;
+
+statement ok
 drop subscription sub;
 
 statement ok
@@ -150,6 +178,9 @@ drop materialized view mv_order_src;
 
 statement ok
 drop table t_order;
+
+statement ok
+drop table t_rate_limit;
 
 statement ok
 drop table t1;


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

- Update the cross-db MV backfill SLT to use a dedicated `t_rate_limit` source table and `sub_rate_limit` subscription for the rate-limit case.
- Insert test rows only after `mv_rate_limit` is created and its backfill rate limit is set to `0`, then flush and verify the MV remains empty.
- Raise the backfill rate limit, flush again, and retry the final row-count assertion until the backfill reaches `10000`.
- Picked the SLT expectation fix from release branch commit `23054b13e4` because `main` had the same incorrect rate-limit test.

## Checklist

- [ ] I have written necessary rustdoc comments.
- [x] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [x] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

No user-facing changes.

</details>
