### PR TITLE
fix(stream): handle invisible rows in replicated state table

### DIFF
--- a/src/stream/src/common/table/state_table.rs
+++ b/src/stream/src/common/table/state_table.rs
@@ -2507,15 +2507,15 @@ fn fill_non_output_indices(
     data_types: &[DataType],
     chunk: StreamChunk,
 ) -> StreamChunk {
-    let cardinality = chunk.cardinality();
     let (ops, columns, vis) = chunk.into_inner();
+    let capacity = vis.len();
     let mut full_columns = Vec::with_capacity(data_types.len());
     for (i, data_type) in data_types.iter().enumerate() {
         if let Some(j) = i2o_mapping.try_map(i) {
             full_columns.push(columns[j].clone());
         } else {
-            let mut column_builder = ArrayImplBuilder::with_type(cardinality, data_type.clone());
-            column_builder.append_n_null(cardinality);
+            let mut column_builder = ArrayImplBuilder::with_type(capacity, data_type.clone());
+            column_builder.append_n_null(capacity);
             let column: ArrayRef = column_builder.finish().into();
             full_columns.push(column)
         }
@@ -2557,6 +2557,32 @@ mod tests {
             +---+---+---+-----+
             | + | 2 |   | 222 |
             +---+---+---+-----+
+             }"#]],
+        );
+    }
+
+    #[test]
+    fn test_fill_non_output_indices_with_invisible_rows() {
+        let data_types = vec![DataType::Int32, DataType::Int32, DataType::Int32];
+        let replicated_chunk = [
+            OwnedRow::new(vec![Some(222_i32.into()), Some(2_i32.into())]),
+            OwnedRow::new(vec![Some(333_i32.into()), Some(3_i32.into())]),
+        ];
+        let (columns, _) =
+            DataChunk::from_rows(&replicated_chunk, &[DataType::Int32, DataType::Int32])
+                .into_parts();
+        let replicated_chunk = StreamChunk::with_visibility(
+            vec![Op::Insert, Op::Insert],
+            columns,
+            Bitmap::from_iter([false, false]),
+        );
+        let i2o_mapping = ColIndexMapping::new(vec![Some(1), None, Some(0)], 2);
+        let filled_chunk = fill_non_output_indices(&i2o_mapping, &data_types, replicated_chunk);
+        check(
+            filled_chunk,
+            expect![[r#"
+            StreamChunk { cardinality: 0, capacity: 2, data:
+            (empty)
              }"#]],
         );
     }


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

Fix a panic in replicated state table writes when a projected chunk contains invisible rows.

`fill_non_output_indices` is used by replicated state tables to synthesize NULL arrays for table columns pruned from upstream output. It previously sized those synthesized arrays by chunk cardinality, while `DataChunk::new` requires every physical column length to match the visibility bitmap length. If a chunk had capacity greater than cardinality, for example capacity 2 and cardinality 0, this produced the `DataChunk::new` length assertion reported in temporal join.

This PR changes the helper to size synthesized arrays by physical capacity (`vis.len()`) and adds a regression unit test for an all-invisible projected chunk.

- Closes #26252

## Checklist

- [ ] I have written necessary rustdoc comments.
- [x] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

Fix a temporal join crash that could occur when replicated state table writes received a projected chunk with invisible rows.

</details>
