### PR TITLE
fix(stream): prioritize barriers during snapshot backfill

### DIFF
--- a/e2e_test/backfill/backfill_progress/create_materialized_view_snapshot.slt
+++ b/e2e_test/backfill/backfill_progress/create_materialized_view_snapshot.slt
@@ -10,7 +10,7 @@ create materialized view m1 as
       join t2 on x.v1 = t2.v1
       join t3 on t3.v1 = t2.v1
 
-query ? retry 3 backoff 1s
+query ? retry 6 backoff 1s
 select
   case when regexp_match(progress, '([0-9]+?\.?[0-9]+)%')[1]::numeric
     >= (99::numeric / 1000::numeric)
@@ -51,7 +51,7 @@ create materialized view m1 as
 ' >/dev/null 2>&1 &
 
 
-query ? retry 3 backoff 1s
+query ? retry 6 backoff 1s
 select
   case when regexp_match(progress, '([0-9]+?\.?[0-9]+)%')[1]::numeric
     >= (2::numeric * 50::numeric / 1000::numeric)

--- a/src/stream/src/executor/backfill/snapshot_backfill/executor.rs
+++ b/src/stream/src/executor/backfill/snapshot_backfill/executor.rs
@@ -1045,14 +1045,16 @@ async fn make_consume_snapshot_stream<'a, S: StateStore>(
         throttle_snapshot_stream: bool,
         backfill_paused: bool,
     ) -> StreamExecutorResult<Either<Barrier, Option<StreamChunk>>> {
-        select!(
+        select! {
+            biased;
+
             result = receive_next_barrier(barrier_rx) => {
                 Ok(Either::Left(result?))
             },
             result = snapshot_stream.try_next(), if !throttle_snapshot_stream && !backfill_paused => {
                 Ok(Either::Right(result?))
             }
-        )
+        }
     }
 
     let mut backfill_paused = initial_backfill_paused;


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

- Prioritize queued barriers over ready snapshot chunks in snapshot backfill. This prevents rate-limited snapshot chunks from repeatedly winning `tokio::select!` while checkpoint barriers wait to commit and report progress.
- Extend the two snapshot-backfill progress assertions from 3 to 6 one-second retries. A selected chunk still completes its in-flight rate-limit wait before the executor polls another barrier.
- Closes #26336

Validation:

- `cargo test -p risingwave_stream --lib test_snapshot_backfill_without_upstream_on_hummock -- --nocapture`
- `cargo clippy --all-targets --all-features`

## Checklist

- [ ] I have written necessary rustdoc comments.
- [x] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [x] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

</details>
