### PR TITLE
fix(mysql-cdc): use first database from comma-separated list in enumerator (fixes #26344)

### DIFF
--- a/src/connector/src/source/cdc/enumerator/mod.rs
+++ b/src/connector/src/source/cdc/enumerator/mod.rs
@@ -504,10 +504,20 @@ impl DebeziumSplitEnumerator<Mysql> {
             .properties
             .get("password")
             .ok_or_else(|| anyhow::anyhow!("password not found in CDC properties"))?;
-        let database = self
+        // `database.name` may be a comma-separated list of databases (see #19038).
+        // `SHOW BINARY LOGS` is a global command that does not require a default database,
+        // but `build_mysql_connection_pool` requires a valid db name for the JDBC connection.
+        // Use the first database from the list (mirroring MySqlValidator.java's fix in #19038).
+        let database_raw = self
             .properties
             .get("database.name")
             .ok_or_else(|| anyhow::anyhow!("database.name not found in CDC properties"))?;
+        let database = database_raw
+            .split(',')
+            .next()
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .ok_or_else(|| anyhow::anyhow!("database.name is empty"))?;
 
         // Get SSL mode configuration (default to Disabled if not specified)
         let ssl_mode = self


### PR DESCRIPTION
Closes #26344.

## What's changed and what's your intention?

Follow-up fix for #19038 (support mysql source capture multiple databases). The Java-side `MySqlValidator` was updated to handle comma-separated `database.name` correctly by splitting and validating each database individually, but the Rust-side enumerator at [`enumerator/mod.rs:521`](https://github.com/risingwavelabs/risingwave/blob/main/src/connector/src/source/cdc/enumerator/mod.rs#L521) was left passing the full comma-separated string as the JDBC default database.

**Symptom** (before this fix):
- `CREATE SOURCE ... database.name = 'db1,db2'` succeeds (validator passes, following #19038)
- `CREATE TABLE ... FROM src TABLE 'db1.some_table'` succeeds
- Initial backfill completes with correct row counts
- **But** the enumerator's binlog file query loop fails every 30 seconds:
  ```
  ERROR risingwave_connector::source::cdc::enumerator:
    Failed to query binlog files for MySQL CDC source X:
    Failed to connect to MySQL: Server error:
    `ERROR 42000 (1049): Unknown database 'db1,db2'`
  ```
  This error repeats indefinitely; CDC progress cannot be monitored.

**Root cause**: `SHOW BINARY LOGS` (used by `query_binlog_files`) is a global command that does not require a default database, but `build_mysql_connection_pool` requires a valid db name for the JDBC connection. The full comma-separated string was passed verbatim, so MySQL returned `Unknown database 'db1,db2'`.

**Fix**: Split by `,` and use the first database, mirroring the pattern established by `MySqlValidator.java` in #19038.

## Verification

Verified end-to-end on a production OceanBase (MySQL-protocol) instance:

**Setup**:
```sql
CREATE SOURCE test_multi WITH (
  connector = 'mysql-cdc',
  hostname = '<host>', port = '<port>',
  username = '<user>', password = '<pw>',
  database.name = 'erp_finance,external_access',
  server.id = '9001'
);
CREATE TABLE t1 (id BIGINT, PRIMARY KEY(id))
  FROM test_multi TABLE 'erp_finance.some_table';
CREATE TABLE t2 (id BIGINT, PRIMARY KEY(id))
  FROM test_multi TABLE 'external_access.other_table';
```

**Before fix**:
- ✅ `CREATE SOURCE` succeeds
- ✅ Backfill: `t1` 308 rows / `t2` 125 rows (matches upstream)
- 🔴 `Failed to query binlog files ... Unknown database 'erp_finance,external_access'` every 30s

**After fix**:
- ✅ `CREATE SOURCE` succeeds
- ✅ Backfill: `t1` 308 rows / `t2` 125 rows (matches upstream)
- ✅ **No enumerator errors** (verified over 3+ minutes of continuous CDC operation)

## Checklist

- [x] I have written necessary rustdoc comments (inline explanation of the split-first-element pattern).
- [ ] I have added necessary unit tests and integration tests.
- [ ] My PR contains breaking changes.
- [ ] My PR changes performance-critical code.

## Refs

- Issue: #26344
- Original multi-DB feature PR: #19038
- Cherry-picks of #19038: #19125 (2.1), #19317 (2.0)