### PR TITLE
fix(meta): reconcile stale serving vnode mappings

### DIFF
--- a/src/meta/node/src/server.rs
+++ b/src/meta/node/src/server.rs
@@ -465,6 +465,15 @@ pub async fn start_service_as_election_leader(
     // TODO(shutdown): remove this as there's no need to gracefully shutdown some of these sub-tasks.
     let mut sub_tasks = vec![shutdown_handle];
 
+    // Register before the barrier manager starts recovery. Dirty creating-job cleanup emits local
+    // serving mapping deletes, which must not be dropped during bootstrap.
+    sub_tasks.push(serving::start_serving_vnode_mapping_worker(
+        env.notification_manager_ref(),
+        metadata_manager.clone(),
+        serving_vnode_mapping.clone(),
+        env.session_params_manager_impl_ref(),
+    ));
+
     let iceberg_pk_index_sink_manager =
         IcebergPkIndexSinkManager::new(env.meta_store_ref().conn.clone());
     tracing::info!("IcebergPkIndexSinkManager started");
@@ -703,13 +712,6 @@ pub async fn start_service_as_election_leader(
     sub_tasks.extend(IcebergCompactionManager::iceberg_compaction_event_loop(
         iceberg_compaction_mgr.clone(),
         iceberg_compactor_event_rx,
-    ));
-
-    sub_tasks.push(serving::start_serving_vnode_mapping_worker(
-        env.notification_manager_ref(),
-        metadata_manager.clone(),
-        serving_vnode_mapping,
-        env.session_params_manager_impl_ref(),
     ));
 
     {

--- a/src/meta/src/controller/catalog/mod.rs
+++ b/src/meta/src/controller/catalog/mod.rs
@@ -526,6 +526,15 @@ impl CatalogController {
             .iter()
             .map(|job_id| job_id.as_mv_table_id())
             .collect_vec();
+        // Object deletion cascades to the fragments of the dirty streaming jobs. Keep their IDs
+        // before the transaction deletes them so the serving mapping can be notified after commit.
+        let dirty_fragment_ids: Vec<FragmentId> = Fragment::find()
+            .select_only()
+            .column(fragment::Column::FragmentId)
+            .filter(fragment::Column::JobId.is_in(dirty_job_ids.iter().copied()))
+            .into_tuple()
+            .all(&txn)
+            .await?;
 
         // Filter out dummy objs for replacement.
         // todo: we'd better introduce a new dummy object type for replacement.
@@ -654,6 +663,10 @@ impl CatalogController {
         inner
             .dropped_tables
             .extend(dropped_tables.into_iter().map(|t| (t.id, t)));
+
+        self.env
+            .notification_manager()
+            .notify_serving_fragment_mapping_delete(dirty_fragment_ids);
 
         let object_group = build_object_group_for_delete(
             to_notify_objs

--- a/src/meta/src/controller/catalog/test.rs
+++ b/src/meta/src/controller/catalog/test.rs
@@ -14,12 +14,15 @@
 
 #[cfg(test)]
 mod tests {
+    use risingwave_meta_model::FragmentId;
+    use risingwave_meta_model::fragment::DistributionType;
     use risingwave_meta_model::table::HandleConflictBehavior;
     use risingwave_pb::catalog::StreamSourceInfo;
     use risingwave_pb::catalog::subscription::SubscriptionState;
-    use tokio::sync::oneshot;
+    use tokio::sync::{mpsc, oneshot};
 
     use crate::controller::catalog::*;
+    use crate::manager::LocalNotification;
 
     const TEST_DATABASE_ID: DatabaseId = DatabaseId::new(1);
     const TEST_SCHEMA_ID: SchemaId = SchemaId::new(2);
@@ -511,6 +514,116 @@ mod tests {
                 .await?
                 .is_none()
         );
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_clean_dirty_creating_jobs_notifies_serving_mapping_fragment_delete()
+    -> MetaResult<()> {
+        let env = MetaSrvEnv::for_test().await;
+        let (local_notification_tx, mut local_notification_rx) = mpsc::unbounded_channel();
+        env.notification_manager()
+            .insert_local_sender(local_notification_tx);
+        let mgr = CatalogController::new(env).await?;
+
+        let inner = mgr.inner.write().await;
+        let txn = inner.db.begin().await?;
+        let mv_obj = CatalogController::create_object(
+            &txn,
+            ObjectType::Table,
+            TEST_OWNER_ID,
+            Some(TEST_DATABASE_ID),
+            Some(TEST_SCHEMA_ID),
+        )
+        .await?;
+        let job_id = mv_obj.oid.as_job_id();
+        let mv_table_id = job_id.as_mv_table_id();
+        insert_test_table(
+            &txn,
+            mv_table_id,
+            "mv_dirty_serving_mapping",
+            TableType::MaterializedView,
+            None,
+            "CREATE MATERIALIZED VIEW mv_dirty_serving_mapping AS SELECT 1",
+        )
+        .await?;
+        streaming_job::ActiveModel {
+            job_id: Set(job_id),
+            job_status: Set(JobStatus::Creating),
+            create_type: Set(CreateType::Foreground),
+            timezone: Set(None),
+            config_override: Set(None),
+            adaptive_parallelism_strategy: Set(None),
+            parallelism: Set(StreamingParallelism::Adaptive),
+            backfill_parallelism: Set(None),
+            backfill_adaptive_parallelism_strategy: Set(None),
+            backfill_orders: Set(None),
+            max_parallelism: Set(1),
+            specific_resource_group: Set(None),
+            is_serverless_backfill: Set(false),
+            refresh_interval_sec: Set(None),
+        }
+        .insert(&txn)
+        .await?;
+        let fragment_id = FragmentId::new(3);
+        fragment::ActiveModel {
+            fragment_id: Set(fragment_id),
+            job_id: Set(job_id),
+            fragment_type_mask: Set(0),
+            distribution_type: Set(DistributionType::Hash),
+            stream_node: Set(StreamNode::default()),
+            state_table_ids: Set(Vec::<TableId>::new().into()),
+            upstream_fragment_id: Set(Vec::<i32>::new().into()),
+            vnode_count: Set(1),
+            parallelism: Set(None),
+        }
+        .insert(&txn)
+        .await?;
+        txn.commit().await?;
+        drop(inner);
+
+        assert!(
+            mgr.fragment_parallelisms()
+                .await?
+                .contains_key(&fragment_id)
+        );
+
+        let cleaned = mgr
+            .clean_dirty_creating_jobs(Some(TEST_DATABASE_ID))
+            .await?;
+        assert_eq!(cleaned.streaming_job_ids, vec![job_id]);
+
+        let inner = mgr.inner.read().await;
+        assert!(Object::find_by_id(job_id).one(&inner.db).await?.is_none());
+        assert!(
+            StreamingJob::find_by_id(job_id)
+                .one(&inner.db)
+                .await?
+                .is_none()
+        );
+        assert!(
+            Table::find_by_id(mv_table_id)
+                .one(&inner.db)
+                .await?
+                .is_none()
+        );
+        drop(inner);
+        assert!(
+            !mgr.fragment_parallelisms()
+                .await?
+                .contains_key(&fragment_id)
+        );
+
+        let notification = local_notification_rx.try_recv().expect(
+            "dirty-job cleanup must notify the serving mapping worker about deleted fragments",
+        );
+        match notification {
+            LocalNotification::ServingFragmentMappingsDelete(fragment_ids) => {
+                assert_eq!(fragment_ids, vec![fragment_id]);
+            }
+            notification => panic!("unexpected local notification: {notification:?}"),
+        }
 
         Ok(())
     }

--- a/src/meta/src/controller/catalog/test.rs
+++ b/src/meta/src/controller/catalog/test.rs
@@ -14,15 +14,18 @@
 
 #[cfg(test)]
 mod tests {
+    use risingwave_common::hash::VirtualNode;
     use risingwave_meta_model::FragmentId;
     use risingwave_meta_model::fragment::DistributionType;
     use risingwave_meta_model::table::HandleConflictBehavior;
     use risingwave_pb::catalog::StreamSourceInfo;
     use risingwave_pb::catalog::subscription::SubscriptionState;
+    use risingwave_pb::common::{HostAddress, WorkerNode, WorkerType, worker_node};
     use tokio::sync::{mpsc, oneshot};
 
     use crate::controller::catalog::*;
     use crate::manager::LocalNotification;
+    use crate::serving::ServingVnodeMapping;
 
     const TEST_DATABASE_ID: DatabaseId = DatabaseId::new(1);
     const TEST_SCHEMA_ID: SchemaId = SchemaId::new(2);
@@ -75,6 +78,114 @@ mod tests {
         }
         .insert(txn)
         .await?;
+        Ok(())
+    }
+
+    async fn insert_dirty_creating_job_with_fragment(
+        mgr: &CatalogController,
+        fragment_id: FragmentId,
+        vnode_count: i32,
+    ) -> MetaResult<(JobId, TableId)> {
+        let inner = mgr.inner.write().await;
+        let txn = inner.db.begin().await?;
+        let job_obj = CatalogController::create_object(
+            &txn,
+            ObjectType::Table,
+            TEST_OWNER_ID,
+            Some(TEST_DATABASE_ID),
+            Some(TEST_SCHEMA_ID),
+        )
+        .await?;
+        let job_id = job_obj.oid.as_job_id();
+        let table_id = job_id.as_mv_table_id();
+        insert_test_table(
+            &txn,
+            table_id,
+            "mv_dirty_serving_mapping",
+            TableType::MaterializedView,
+            None,
+            "CREATE MATERIALIZED VIEW mv_dirty_serving_mapping AS SELECT 1",
+        )
+        .await?;
+        streaming_job::ActiveModel {
+            job_id: Set(job_id),
+            job_status: Set(JobStatus::Creating),
+            create_type: Set(CreateType::Foreground),
+            timezone: Set(None),
+            config_override: Set(None),
+            adaptive_parallelism_strategy: Set(None),
+            parallelism: Set(StreamingParallelism::Adaptive),
+            backfill_parallelism: Set(None),
+            backfill_adaptive_parallelism_strategy: Set(None),
+            backfill_orders: Set(None),
+            max_parallelism: Set(1),
+            specific_resource_group: Set(None),
+            is_serverless_backfill: Set(false),
+            refresh_interval_sec: Set(None),
+        }
+        .insert(&txn)
+        .await?;
+        fragment::ActiveModel {
+            fragment_id: Set(fragment_id),
+            job_id: Set(job_id),
+            fragment_type_mask: Set(0),
+            distribution_type: Set(DistributionType::Hash),
+            stream_node: Set(StreamNode::default()),
+            state_table_ids: Set(Vec::<TableId>::new().into()),
+            upstream_fragment_id: Set(Vec::<i32>::new().into()),
+            vnode_count: Set(vnode_count),
+            parallelism: Set(None),
+        }
+        .insert(&txn)
+        .await?;
+        txn.commit().await?;
+        drop(inner);
+
+        Ok((job_id, table_id))
+    }
+
+    #[tokio::test]
+    async fn test_dirty_cleanup_reconcile_removes_stale_serving_vnode_mapping() -> MetaResult<()> {
+        let mgr = CatalogController::new(MetaSrvEnv::for_test().await).await?;
+        let fragment_id = FragmentId::new(42);
+        insert_dirty_creating_job_with_fragment(
+            &mgr,
+            fragment_id,
+            VirtualNode::COUNT_FOR_TEST as i32,
+        )
+        .await?;
+
+        let worker = WorkerNode {
+            id: WorkerId::new(1),
+            r#type: WorkerType::ComputeNode.into(),
+            host: Some(HostAddress {
+                host: "localhost".to_owned(),
+                port: 1,
+            }),
+            state: worker_node::State::Running as i32,
+            property: Some(worker_node::Property {
+                is_serving: true,
+                parallelism: 1,
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let serving_vnode_mapping = ServingVnodeMapping::default();
+        serving_vnode_mapping.upsert(
+            mgr.fragment_parallelisms().await?,
+            std::slice::from_ref(&worker),
+            None,
+        );
+        assert!(serving_vnode_mapping.all().contains_key(&fragment_id));
+
+        mgr.clean_dirty_creating_jobs(Some(TEST_DATABASE_ID))
+            .await?;
+        let current_snapshot = mgr.fragment_parallelisms().await?;
+        assert!(!current_snapshot.contains_key(&fragment_id));
+
+        serving_vnode_mapping.reconcile(current_snapshot, &[worker], None);
+        assert!(!serving_vnode_mapping.all().contains_key(&fragment_id));
+
         Ok(())
     }
 
@@ -526,62 +637,9 @@ mod tests {
         env.notification_manager()
             .insert_local_sender(local_notification_tx);
         let mgr = CatalogController::new(env).await?;
-
-        let inner = mgr.inner.write().await;
-        let txn = inner.db.begin().await?;
-        let mv_obj = CatalogController::create_object(
-            &txn,
-            ObjectType::Table,
-            TEST_OWNER_ID,
-            Some(TEST_DATABASE_ID),
-            Some(TEST_SCHEMA_ID),
-        )
-        .await?;
-        let job_id = mv_obj.oid.as_job_id();
-        let mv_table_id = job_id.as_mv_table_id();
-        insert_test_table(
-            &txn,
-            mv_table_id,
-            "mv_dirty_serving_mapping",
-            TableType::MaterializedView,
-            None,
-            "CREATE MATERIALIZED VIEW mv_dirty_serving_mapping AS SELECT 1",
-        )
-        .await?;
-        streaming_job::ActiveModel {
-            job_id: Set(job_id),
-            job_status: Set(JobStatus::Creating),
-            create_type: Set(CreateType::Foreground),
-            timezone: Set(None),
-            config_override: Set(None),
-            adaptive_parallelism_strategy: Set(None),
-            parallelism: Set(StreamingParallelism::Adaptive),
-            backfill_parallelism: Set(None),
-            backfill_adaptive_parallelism_strategy: Set(None),
-            backfill_orders: Set(None),
-            max_parallelism: Set(1),
-            specific_resource_group: Set(None),
-            is_serverless_backfill: Set(false),
-            refresh_interval_sec: Set(None),
-        }
-        .insert(&txn)
-        .await?;
         let fragment_id = FragmentId::new(3);
-        fragment::ActiveModel {
-            fragment_id: Set(fragment_id),
-            job_id: Set(job_id),
-            fragment_type_mask: Set(0),
-            distribution_type: Set(DistributionType::Hash),
-            stream_node: Set(StreamNode::default()),
-            state_table_ids: Set(Vec::<TableId>::new().into()),
-            upstream_fragment_id: Set(Vec::<i32>::new().into()),
-            vnode_count: Set(1),
-            parallelism: Set(None),
-        }
-        .insert(&txn)
-        .await?;
-        txn.commit().await?;
-        drop(inner);
+        let (job_id, mv_table_id) =
+            insert_dirty_creating_job_with_fragment(&mgr, fragment_id, 1).await?;
 
         assert!(
             mgr.fragment_parallelisms()

--- a/src/meta/src/serving/mod.rs
+++ b/src/meta/src/serving/mod.rs
@@ -51,6 +51,40 @@ impl ServingVnodeMapping {
         max_serving_parallelism: Option<u64>,
     ) -> (HashMap<FragmentId, WorkerSlotMapping>, Vec<FragmentId>) {
         let mut serving_vnode_mappings = self.serving_vnode_mappings.write();
+        Self::upsert_locked(
+            &mut serving_vnode_mappings,
+            streaming_parallelisms,
+            workers,
+            max_serving_parallelism,
+        )
+    }
+
+    /// Rebuild mappings from a complete catalog snapshot.
+    ///
+    /// Unlike [`Self::upsert`], this removes mappings for fragments absent from the snapshot.
+    pub(crate) fn reconcile(
+        &self,
+        streaming_parallelisms: HashMap<FragmentId, FragmentParallelismInfo>,
+        workers: &[WorkerNode],
+        max_serving_parallelism: Option<u64>,
+    ) -> (HashMap<FragmentId, WorkerSlotMapping>, Vec<FragmentId>) {
+        let mut serving_vnode_mappings = self.serving_vnode_mappings.write();
+        serving_vnode_mappings
+            .retain(|fragment_id, _| streaming_parallelisms.contains_key(fragment_id));
+        Self::upsert_locked(
+            &mut serving_vnode_mappings,
+            streaming_parallelisms,
+            workers,
+            max_serving_parallelism,
+        )
+    }
+
+    fn upsert_locked(
+        serving_vnode_mappings: &mut HashMap<FragmentId, WorkerSlotMapping>,
+        streaming_parallelisms: HashMap<FragmentId, FragmentParallelismInfo>,
+        workers: &[WorkerNode],
+        max_serving_parallelism: Option<u64>,
+    ) -> (HashMap<FragmentId, WorkerSlotMapping>, Vec<FragmentId>) {
         let mut upserted: HashMap<FragmentId, WorkerSlotMapping> = HashMap::default();
         let mut failed: Vec<FragmentId> = vec![];
         for (fragment_id, info) in streaming_parallelisms {
@@ -118,7 +152,7 @@ pub async fn on_meta_start(
 ) {
     let (serving_compute_nodes, streaming_parallelisms) =
         fetch_serving_infos(metadata_manager).await;
-    let (mappings, failed) = serving_vnode_mapping.upsert(
+    let (mappings, failed) = serving_vnode_mapping.reconcile(
         streaming_parallelisms,
         &serving_compute_nodes,
         max_serving_parallelism,
@@ -183,7 +217,7 @@ pub fn start_serving_vnode_mapping_worker(
                 .await
                 .batch_parallelism()
                 .map(|p| p.get());
-            let (mappings, failed) = serving_vnode_mapping.upsert(
+            let (mappings, failed) = serving_vnode_mapping.reconcile(
                 streaming_parallelisms,
                 &workers,
                 max_serving_parallelism,
@@ -272,4 +306,109 @@ pub fn start_serving_vnode_mapping_worker(
         }
     });
     (join_handle, shutdown_tx)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use risingwave_common::hash::VirtualNode;
+    use risingwave_common::id::WorkerId;
+    use risingwave_pb::common::{WorkerNode, WorkerType, worker_node};
+    use risingwave_pb::meta::table_fragments::fragment::FragmentDistributionType;
+
+    use super::ServingVnodeMapping;
+    use crate::controller::fragment::FragmentParallelismInfo;
+    use crate::model::FragmentId;
+
+    fn serving_worker() -> WorkerNode {
+        WorkerNode {
+            id: WorkerId::new(1),
+            r#type: WorkerType::ComputeNode.into(),
+            property: Some(worker_node::Property {
+                is_serving: true,
+                parallelism: 1,
+                ..Default::default()
+            }),
+            ..Default::default()
+        }
+    }
+
+    fn hash_parallelism() -> FragmentParallelismInfo {
+        FragmentParallelismInfo {
+            distribution_type: FragmentDistributionType::Hash,
+            vnode_count: VirtualNode::COUNT_FOR_TEST,
+        }
+    }
+
+    #[test]
+    fn test_reconcile_exactly_matches_full_snapshot_and_removes_failed_placements() {
+        let mapping = ServingVnodeMapping::default();
+        let worker = serving_worker();
+        let stale_fragment = FragmentId::new(1);
+        let retained_fragment = FragmentId::new(2);
+        let added_fragment = FragmentId::new(3);
+
+        mapping.upsert(
+            HashMap::from([
+                (stale_fragment, hash_parallelism()),
+                (retained_fragment, hash_parallelism()),
+            ]),
+            std::slice::from_ref(&worker),
+            None,
+        );
+        assert!(mapping.all().contains_key(&stale_fragment));
+        let retained_mapping = mapping.all()[&retained_fragment].clone();
+
+        let (reconciled, failed) = mapping.reconcile(
+            HashMap::from([
+                (retained_fragment, hash_parallelism()),
+                (added_fragment, hash_parallelism()),
+            ]),
+            &[worker],
+            None,
+        );
+        assert!(failed.is_empty());
+        assert_eq!(reconciled.len(), 2);
+        assert!(reconciled.contains_key(&retained_fragment));
+        assert!(reconciled.contains_key(&added_fragment));
+
+        let mappings = mapping.all();
+        assert_eq!(mappings.len(), 2);
+        assert!(mappings.contains_key(&retained_fragment));
+        assert!(mappings.contains_key(&added_fragment));
+        assert_eq!(mappings[&retained_fragment], retained_mapping);
+
+        let (reconciled, failed) = mapping.reconcile(
+            HashMap::from([(retained_fragment, hash_parallelism())]),
+            &[],
+            None,
+        );
+        assert!(reconciled.is_empty());
+        assert_eq!(failed, vec![retained_fragment]);
+        assert!(mapping.all().is_empty());
+    }
+
+    #[test]
+    fn test_upsert_keeps_fragments_absent_from_incremental_update() {
+        let mapping = ServingVnodeMapping::default();
+        let worker = serving_worker();
+        let first_fragment = FragmentId::new(1);
+        let second_fragment = FragmentId::new(2);
+
+        mapping.upsert(
+            HashMap::from([(first_fragment, hash_parallelism())]),
+            std::slice::from_ref(&worker),
+            None,
+        );
+        mapping.upsert(
+            HashMap::from([(second_fragment, hash_parallelism())]),
+            &[worker],
+            None,
+        );
+
+        let mappings = mapping.all();
+        assert!(mappings.contains_key(&first_fragment));
+        assert!(mappings.contains_key(&second_fragment));
+    }
 }


### PR DESCRIPTION
## What changed

- notify the serving mapping worker after dirty creating-job cleanup commits fragment deletions
- register the serving mapping worker before barrier bootstrap recovery
- exactly reconcile startup/reset snapshots while preserving incremental upsert semantics
- add focused regression coverage for deletion notification, snapshot reconciliation, and incremental updates

## Validation

- focused `risingwave_meta` serving and dirty-cleanup regression tests
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo fmt --check` and `git diff --check`