### PR TITLE
fix(iceberg): preserve partition column when pruning hidden sink columns

### DIFF
--- a/e2e_test/iceberg/test_case/iceberg_sink_partition_upsert_with_hidden_column.slt
+++ b/e2e_test/iceberg/test_case/iceberg_sink_partition_upsert_with_hidden_column.slt
@@ -1,0 +1,78 @@
+statement ok
+set sink_decouple = false;
+
+statement ok
+set streaming_parallelism = 4;
+
+statement ok
+DROP SINK IF EXISTS events_sink;
+
+statement ok
+DROP MATERIALIZED VIEW IF EXISTS source_view;
+
+statement ok
+DROP TABLE IF EXISTS source_events;
+
+statement ok
+CREATE TABLE source_events (
+    category varchar NOT NULL,
+    event_id varchar NOT NULL,
+    event_time timestamp NOT NULL,
+    snapshot_time timestamp NOT NULL,
+    data varchar,
+    PRIMARY KEY (category, event_id, snapshot_time)
+);
+
+statement ok
+CREATE MATERIALIZED VIEW source_view AS
+SELECT * FROM source_events;
+
+statement ok
+CREATE SINK events_sink AS
+SELECT
+    category,
+    event_id,
+    event_time AT TIME ZONE 'UTC' AS event_time,
+    snapshot_time AT TIME ZONE 'UTC' AS snapshot_time,
+    data
+FROM source_view
+WITH (
+    connector = 'iceberg',
+    type = 'upsert',
+    force_append_only = 'false',
+    catalog.name = 'demo',
+    catalog.type = 'storage',
+    warehouse.path = 's3a://icebergdata/demo',
+    database.name = 'demo_db',
+    table.name = 'partition_upsert_with_hidden_column_table',
+    primary_key = 'category,event_id,snapshot_time',
+    s3.endpoint = 'http://127.0.0.1:9301',
+    s3.region = 'us-east-1',
+    s3.access.key = 'hummockadmin',
+    s3.secret.key = 'hummockadmin'
+);
+
+statement ok
+INSERT INTO source_events VALUES (
+    'click',
+    'e1',
+    '2025-11-07 10:00:00',
+    '2025-11-07 10:00:00',
+    'payload'
+);
+
+sleep 15s
+
+statement ok
+FLUSH;
+
+sleep 5s
+
+statement ok
+DROP SINK events_sink;
+
+statement ok
+DROP MATERIALIZED VIEW source_view;
+
+statement ok
+DROP TABLE source_events;

--- a/e2e_test/iceberg/test_case/partition_upsert_with_hidden_column.toml
+++ b/e2e_test/iceberg/test_case/partition_upsert_with_hidden_column.toml
@@ -1,0 +1,34 @@
+init_sqls = [
+    'CREATE SCHEMA IF NOT EXISTS demo_db',
+    'DROP TABLE IF EXISTS demo_db.partition_upsert_with_hidden_column_table PURGE',
+    '''
+    CREATE TABLE demo_db.partition_upsert_with_hidden_column_table (
+        category string NOT NULL,
+        event_id string NOT NULL,
+        event_time timestamp NOT NULL,
+        snapshot_time timestamp NOT NULL,
+        data string
+    ) USING iceberg
+    PARTITIONED BY (category, days(snapshot_time))
+    TBLPROPERTIES ('format-version'='2')
+    ''',
+]
+
+slt = 'test_case/iceberg_sink_partition_upsert_with_hidden_column.slt'
+
+verify_schema = ['string', 'string', 'timestamp', 'timestamp', 'string']
+
+verify_sql = '''
+SELECT category, event_id, event_time, snapshot_time, data
+FROM demo_db.partition_upsert_with_hidden_column_table
+ORDER BY category, event_id
+'''
+
+verify_data = """
+click,e1,2025-11-07 10:00:00+00:00,2025-11-07 10:00:00+00:00,payload
+"""
+
+drop_sqls = [
+    'DROP TABLE IF EXISTS demo_db.partition_upsert_with_hidden_column_table PURGE',
+    'DROP SCHEMA IF EXISTS demo_db',
+]

--- a/src/stream/src/executor/sink.rs
+++ b/src/stream/src/executor/sink.rs
@@ -705,11 +705,22 @@ impl<F: LogStoreFactory> SinkExecutor<F> {
         rate_limit_rx: UnboundedReceiver<RateLimit>,
         mut rebuild_sink_rx: UnboundedReceiver<RebuildSinkMessage>,
     ) -> StreamExecutorResult<!> {
-        let visible_columns = columns
+        let mut visible_columns = columns
             .iter()
             .enumerate()
             .filter_map(|(idx, column)| (!column.is_hidden).then_some(idx))
             .collect_vec();
+
+        let needs_projection = visible_columns.len() != columns.len();
+
+        if needs_projection
+            && let Some(extra_partition_col_idx) = sink_writer_param.extra_partition_col_idx
+        {
+            // The extra partition column is appended after all normal sink columns.
+            debug_assert_eq!(extra_partition_col_idx, columns.len());
+            sink_writer_param.extra_partition_col_idx = Some(visible_columns.len());
+            visible_columns.push(extra_partition_col_idx);
+        }
 
         let labels = [
             &actor_context.id.to_string(),
@@ -757,7 +768,7 @@ impl<F: LogStoreFactory> SinkExecutor<F> {
                 } else {
                     chunk
                 };
-                if visible_columns.len() != columns.len() {
+                if needs_projection {
                     // Do projection here because we may have columns that aren't visible to
                     // the downstream.
                     chunk.project(&visible_columns)


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

<!--

**Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

- Closes #23719.

This issue can be reproduced under the following conditions:

1. The target Iceberg table is created externally and uses a partition spec.
2. The partition spec contains identity, bucket, or truncate transforms.
3. The sink applies expression transformations to the stream key / primary key columns. For example, in the issue, `primary_key = 'category,event_id,snapshot_time'` is transformed into a hidden column.

The user-visible output columns of the sink are:
```
0 category,
1 event_id,
2 event_time AT TIME ZONE 'UTC' AS event_time,
3 snapshot_time AT TIME ZONE 'UTC' AS snapshot_time,
4 data
```
After appending the transformed primary key as a hidden column, the internal column layout becomes:
```
0 category,
...
4 data
5 category,event_id,snapshot_time (hidden column)
```

As a result, the column indices stored by the extra partition columns are shifted (e.g. from index 5 to index 6). When the hidden column is later removed during projection, those indices are no longer updated accordingly, causing the extra partition columns to reference incorrect positions.

This PR fixes the projection logic by remapping the column indices referenced by the extra partition columns after the hidden columns are removed.

## Checklist

- [x] I have written necessary rustdoc comments.
- [x] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
