### PR TITLE
fix(meta): clean up cdc_table_snapshot_splits on DROP TABLE

### DIFF
--- a/src/meta/src/controller/catalog/drop_op.rs
+++ b/src/meta/src/controller/catalog/drop_op.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use risingwave_common::catalog::{ICEBERG_SINK_PREFIX, ICEBERG_SOURCE_PREFIX};
+use risingwave_meta_model::cdc_table_snapshot_split;
 use risingwave_pb::catalog::PbTable;
 use risingwave_pb::catalog::subscription::PbSubscriptionState;
 use risingwave_pb::telemetry::PbTelemetryDatabaseObject;
@@ -384,6 +385,21 @@ impl CatalogController {
             .await?
             .into_iter()
             .map(|(table, obj)| PbTable::from(ObjectModel(table, obj.unwrap(), None)));
+        // Clean up CDC backfill state (cdc_table_snapshot_splits) for removed streaming jobs.
+        //
+        // Without this, dropping a CDC-sourced table and recreating one with the same name on
+        // the same source would silently skip snapshot backfill, because the leftover state
+        // makes CdcBackfill believe backfill has already finished. See issue #26355.
+        if !removed_streaming_job_ids.is_empty() {
+            cdc_table_snapshot_split::Entity::delete_many()
+                .filter(
+                    cdc_table_snapshot_split::Column::TableId
+                        .is_in(removed_streaming_job_ids.clone()),
+                )
+                .exec(&txn)
+                .await?;
+        }
+
         // delete all in to_drop_objects.
         let res = Object::delete_many()
             .filter(object::Column::Oid.is_in(removed_objects.keys().cloned()))


### PR DESCRIPTION
## Summary

Fix a silent data-loss bug where dropping a CDC-sourced table (or an iceberg engine table) and recreating one with the same name on the same source causes the recreated table to skip snapshot backfill entirely, resulting in the table remaining empty (or only receiving post-recreation CDC events).

Fixes #26355.

## Root cause

`cdc_table_snapshot_splits` entries are only cleaned up on natural backfill completion via `finish_cdc_table_backfill()` → `mark_complete_job()` (`src/meta/src/barrier/cdc_progress.rs:84-88`).

The `drop_object` path in `src/meta/src/controller/catalog/drop_op.rs` never touched this table. When a recreated table inherits a `table_id` that already has completed-state records in `cdc_table_snapshot_splits`, `CdcBackfill` reads those records and concludes backfill is already finished, forwarding messages directly to the downstream — resulting in permanent data loss for the pre-existing upstream rows.

## Fix

Delete matching `cdc_table_snapshot_splits` rows in the same transaction as the object drop, gated on there being at least one removed streaming job to keep the DELETE cheap when no CDC jobs are involved.

```rust
if !removed_streaming_job_ids.is_empty() {
    cdc_table_snapshot_split::Entity::delete_many()
        .filter(
            cdc_table_snapshot_split::Column::TableId
                .is_in(removed_streaming_job_ids.clone()),
        )
        .exec(&txn)
        .await?;
}
```

## Validation

Built a custom image from this branch (`v3.0.1-trial-mysqlpbf-multidbfix-dropfix`) and deployed to a test cluster on TKE.

Before the patch, on `v3.0.1`:

```
Upstream OceanBase `external_access.rw_cdc_probe`: 1 row
RisingWave `ods_external_access__rw_cdc_probe`: 0 rows (silently)

Compute log:
CdcBackfill has already finished and will forward messages directly to the downstream 
    table_id=553 upstream_table_name="external_access.rw_cdc_probe"
```

After the patch, repeated `DROP TABLE` → `CREATE TABLE` (same name, same source) cycles all produce the correct row count. Each new `table_id` (777, later cycles further ids) starts backfill from a clean state, and iceberg data lands as expected.

## Checklist

- [x] I have written necessary docs and comments
- [ ] N/A: I have added necessary unit tests and integration tests (behavioral fix; would need a new e2e test scaffolding to cover the drop-recreate scenario; happy to add if reviewers prefer)
- [x] All checks passed in `./risedev check` (locally: `cargo check -p risingwave_meta` passes; full CI will run on this PR)

## Documentation

N/A: fixes a hidden bug without user-facing surface change.
