### PR TITLE
feat: support postgres_query IP version selection

### DIFF
--- a/e2e_test/commands/pg_tcp_proxy.py
+++ b/e2e_test/commands/pg_tcp_proxy.py
@@ -1,0 +1,170 @@
+#!/usr/bin/env python3
+
+import argparse
+import os
+import signal
+import socket
+import subprocess
+import sys
+import threading
+import time
+
+
+def forward(left, right):
+    try:
+        while True:
+            data = left.recv(65536)
+            if not data:
+                break
+            right.sendall(data)
+    except OSError:
+        pass
+    finally:
+        for sock in (left, right):
+            try:
+                sock.shutdown(socket.SHUT_RDWR)
+            except OSError:
+                pass
+            try:
+                sock.close()
+            except OSError:
+                pass
+
+
+def handle_client(client, target_host, target_port):
+    try:
+        upstream = socket.create_connection((target_host, target_port), timeout=10)
+    except OSError:
+        client.close()
+        return
+
+    threading.Thread(target=forward, args=(client, upstream), daemon=True).start()
+    threading.Thread(target=forward, args=(upstream, client), daemon=True).start()
+
+
+def listen(family, host, listen_port, target_host, target_port):
+    server = socket.socket(family, socket.SOCK_STREAM)
+    server.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    if family == socket.AF_INET6:
+        server.setsockopt(socket.IPPROTO_IPV6, socket.IPV6_V6ONLY, 1)
+    server.bind((host, listen_port))
+    server.listen(128)
+
+    while True:
+        client, _ = server.accept()
+        threading.Thread(
+            target=handle_client,
+            args=(client, target_host, target_port),
+            daemon=True,
+        ).start()
+
+
+def serve(args):
+    target_port = int(args.target_port)
+    listen_port = int(args.listen_port)
+    threads = [
+        threading.Thread(
+            target=listen,
+            args=(socket.AF_INET, "127.0.0.1", listen_port, args.target_host, target_port),
+            daemon=True,
+        ),
+        threading.Thread(
+            target=listen,
+            args=(socket.AF_INET6, "::1", listen_port, args.target_host, target_port),
+            daemon=True,
+        ),
+    ]
+    for thread in threads:
+        thread.start()
+    while True:
+        time.sleep(3600)
+
+
+def stop_pid(pid_file):
+    try:
+        with open(pid_file) as f:
+            pid = int(f.read().strip())
+    except FileNotFoundError:
+        return
+
+    try:
+        os.kill(pid, signal.SIGTERM)
+    except ProcessLookupError:
+        pass
+    finally:
+        try:
+            os.remove(pid_file)
+        except FileNotFoundError:
+            pass
+
+
+def wait_ready(port):
+    deadline = time.time() + 10
+    while time.time() < deadline:
+        try:
+            with socket.create_connection(("127.0.0.1", port), timeout=1):
+                pass
+            with socket.create_connection(("::1", port), timeout=1):
+                pass
+            return
+        except OSError:
+            time.sleep(0.1)
+    raise TimeoutError(f"proxy on port {port} did not become ready")
+
+
+def start(args):
+    stop_pid(args.pid_file)
+
+    log = open(args.log_file, "ab", buffering=0)
+    cmd = [
+        sys.executable,
+        __file__,
+        "serve",
+        "--target-host",
+        args.target_host,
+        "--target-port",
+        args.target_port,
+        "--listen-port",
+        args.listen_port,
+    ]
+    proc = subprocess.Popen(cmd, stdout=log, stderr=log, close_fds=True)
+    with open(args.pid_file, "w") as f:
+        f.write(str(proc.pid))
+
+    try:
+        wait_ready(int(args.listen_port))
+    except Exception:
+        proc.terminate()
+        raise
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    start_parser = subparsers.add_parser("start")
+    start_parser.add_argument("--target-host", required=True)
+    start_parser.add_argument("--target-port", required=True)
+    start_parser.add_argument("--listen-port", required=True)
+    start_parser.add_argument("--pid-file", required=True)
+    start_parser.add_argument("--log-file", required=True)
+
+    serve_parser = subparsers.add_parser("serve")
+    serve_parser.add_argument("--target-host", required=True)
+    serve_parser.add_argument("--target-port", required=True)
+    serve_parser.add_argument("--listen-port", required=True)
+
+    stop_parser = subparsers.add_parser("stop")
+    stop_parser.add_argument("--pid-file", required=True)
+
+    args = parser.parse_args()
+    if args.command == "start":
+        start(args)
+    elif args.command == "serve":
+        serve(args)
+    elif args.command == "stop":
+        stop_pid(args.pid_file)
+
+
+if __name__ == "__main__":
+    main()

--- a/e2e_test/commands/pg_tcp_proxy.py
+++ b/e2e_test/commands/pg_tcp_proxy.py
@@ -42,14 +42,7 @@ def handle_client(client, target_host, target_port):
     threading.Thread(target=forward, args=(upstream, client), daemon=True).start()
 
 
-def listen(family, host, listen_port, target_host, target_port):
-    server = socket.socket(family, socket.SOCK_STREAM)
-    server.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-    if family == socket.AF_INET6:
-        server.setsockopt(socket.IPPROTO_IPV6, socket.IPV6_V6ONLY, 1)
-    server.bind((host, listen_port))
-    server.listen(128)
-
+def accept_loop(server, target_host, target_port):
     while True:
         client, _ = server.accept()
         threading.Thread(
@@ -59,23 +52,39 @@ def listen(family, host, listen_port, target_host, target_port):
         ).start()
 
 
+def bind_listener(family, host, listen_port):
+    server = socket.socket(family, socket.SOCK_STREAM)
+    server.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    if family == socket.AF_INET6:
+        server.setsockopt(socket.IPPROTO_IPV6, socket.IPV6_V6ONLY, 1)
+    server.bind((host, listen_port))
+    server.listen(128)
+    return server
+
+
+def listen_specs(listen_hosts):
+    hosts = listen_hosts or ["127.0.0.1", "::1"]
+    return [
+        (socket.AF_INET6 if ":" in host else socket.AF_INET, host) for host in hosts
+    ]
+
+
 def serve(args):
     target_port = int(args.target_port)
     listen_port = int(args.listen_port)
-    threads = [
+    servers = []
+    for family, host in listen_specs(args.listen_host):
+        try:
+            servers.append(bind_listener(family, host, listen_port))
+        except OSError as e:
+            raise RuntimeError(f"failed to listen on {host}:{listen_port}: {e}") from e
+
+    for server in servers:
         threading.Thread(
-            target=listen,
-            args=(socket.AF_INET, "127.0.0.1", listen_port, args.target_host, target_port),
+            target=accept_loop,
+            args=(server, args.target_host, target_port),
             daemon=True,
-        ),
-        threading.Thread(
-            target=listen,
-            args=(socket.AF_INET6, "::1", listen_port, args.target_host, target_port),
-            daemon=True,
-        ),
-    ]
-    for thread in threads:
-        thread.start()
+        ).start()
     while True:
         time.sleep(3600)
 
@@ -98,18 +107,36 @@ def stop_pid(pid_file):
             pass
 
 
-def wait_ready(port):
+def read_log_tail(log_file):
+    try:
+        with open(log_file, "rb") as f:
+            tail = f.read()[-4096:]
+            return tail.decode(errors="replace")
+    except OSError:
+        return ""
+
+
+def wait_ready(port, listen_hosts, proc, log_file):
     deadline = time.time() + 10
+    hosts = listen_hosts or ["127.0.0.1", "::1"]
+    last_error = None
     while time.time() < deadline:
+        if proc.poll() is not None:
+            raise RuntimeError(
+                f"proxy process exited before becoming ready:\n{read_log_tail(log_file)}"
+            )
         try:
-            with socket.create_connection(("127.0.0.1", port), timeout=1):
-                pass
-            with socket.create_connection(("::1", port), timeout=1):
-                pass
+            for host in hosts:
+                with socket.create_connection((host, port), timeout=1):
+                    pass
             return
-        except OSError:
+        except OSError as e:
+            last_error = e
             time.sleep(0.1)
-    raise TimeoutError(f"proxy on port {port} did not become ready")
+    raise TimeoutError(
+        f"proxy on {','.join(hosts)}:{port} did not become ready: {last_error}\n"
+        f"{read_log_tail(log_file)}"
+    )
 
 
 def start(args):
@@ -127,12 +154,14 @@ def start(args):
         "--listen-port",
         args.listen_port,
     ]
+    for listen_host in args.listen_host or []:
+        cmd.extend(["--listen-host", listen_host])
     proc = subprocess.Popen(cmd, stdout=log, stderr=log, close_fds=True)
     with open(args.pid_file, "w") as f:
         f.write(str(proc.pid))
 
     try:
-        wait_ready(int(args.listen_port))
+        wait_ready(int(args.listen_port), args.listen_host, proc, args.log_file)
     except Exception:
         proc.terminate()
         raise
@@ -146,6 +175,7 @@ def main():
     start_parser.add_argument("--target-host", required=True)
     start_parser.add_argument("--target-port", required=True)
     start_parser.add_argument("--listen-port", required=True)
+    start_parser.add_argument("--listen-host", action="append")
     start_parser.add_argument("--pid-file", required=True)
     start_parser.add_argument("--log-file", required=True)
 
@@ -153,6 +183,7 @@ def main():
     serve_parser.add_argument("--target-host", required=True)
     serve_parser.add_argument("--target-port", required=True)
     serve_parser.add_argument("--listen-port", required=True)
+    serve_parser.add_argument("--listen-host", action="append")
 
     stop_parser = subparsers.add_parser("stop")
     stop_parser.add_argument("--pid-file", required=True)

--- a/e2e_test/sink/postgres_sink.slt
+++ b/e2e_test/sink/postgres_sink.slt
@@ -15,6 +15,72 @@ PGDATABASE=sink_test createdb
 statement ok
 set sink_decouple = false;
 
+################### test ip.version
+
+system ok
+python3 e2e_test/commands/pg_tcp_proxy.py start --target-host "$PGHOST" --target-port "$PGPORT" --listen-host 127.0.0.1 --listen-port 28433 --pid-file /tmp/rw_pg_tcp_proxy_28433.pid --log-file /tmp/rw_pg_tcp_proxy_28433.log
+
+system ok
+PGDATABASE=sink_test psql -c "CREATE TABLE pg_ip_version_sink_table (id BIGINT PRIMARY KEY, v BIGINT)"
+
+statement ok
+CREATE TABLE rw_ip_version_sink_table (
+    id BIGINT PRIMARY KEY,
+    v BIGINT
+);
+
+statement ok
+CREATE SINK postgres_ip_version_sink_ipv4 FROM rw_ip_version_sink_table WITH (
+    connector='postgres',
+    host='localhost',
+    port='28433',
+    user='$PGUSER',
+    password='$PGPASSWORD',
+    database='sink_test',
+    table='pg_ip_version_sink_table',
+    type='upsert',
+    primary_key='id',
+    ip.version='ipv4',
+);
+
+statement ok
+INSERT INTO rw_ip_version_sink_table VALUES (1, 10), (2, 20);
+
+statement ok
+flush;
+
+query II retry 4 backoff 1s
+select * from postgres_query('$PGHOST', '$PGPORT', '$PGUSER', '${PGPASSWORD:postgres}', 'sink_test', 'select * from pg_ip_version_sink_table order by id;');
+----
+1 10
+2 20
+
+statement error .*((did not resolve to any ipv6 address)|([Cc]onnection refused)|(Cannot assign requested address)|(Network is unreachable)).*
+CREATE SINK postgres_ip_version_sink_ipv6_on_ipv4 FROM rw_ip_version_sink_table WITH (
+    connector='postgres',
+    host='localhost',
+    port='28433',
+    user='$PGUSER',
+    password='$PGPASSWORD',
+    database='sink_test',
+    table='pg_ip_version_sink_table',
+    type='upsert',
+    primary_key='id',
+    ip.version='ipv6',
+);
+
+statement ok
+DROP SINK postgres_ip_version_sink_ipv4;
+
+statement ok
+DROP TABLE rw_ip_version_sink_table;
+
+system ok
+PGDATABASE=sink_test psql -c "DROP TABLE pg_ip_version_sink_table"
+
+system ok
+python3 e2e_test/commands/pg_tcp_proxy.py stop --pid-file /tmp/rw_pg_tcp_proxy_28433.pid
+
 ################### test table pk can mismatch
 
 system ok

--- a/e2e_test/sink/remote/jdbc.load.slt
+++ b/e2e_test/sink/remote/jdbc.load.slt
@@ -63,6 +63,63 @@ create materialized view mv_remote_0 as select * from t_remote_0;
 statement ok
 create materialized view mv_remote_1 as select * from t_remote_1;
 
+system ok
+python3 e2e_test/commands/pg_tcp_proxy.py start --target-host db --target-port 5432 --listen-host 127.0.0.1 --listen-port 28434 --pid-file /tmp/rw_pg_tcp_proxy_28434.pid --log-file /tmp/rw_pg_tcp_proxy_28434.log
+
+system ok
+PGPASSWORD=connector psql -h db -U test -d test -c "CREATE TABLE t_jdbc_ip_version (id BIGINT PRIMARY KEY, v BIGINT)"
+
+statement ok
+CREATE TABLE rw_jdbc_ip_version (
+    id BIGINT PRIMARY KEY,
+    v BIGINT
+);
+
+statement ok
+CREATE SINK s_jdbc_ip_version_ipv4 FROM rw_jdbc_ip_version WITH (
+    connector='jdbc',
+    jdbc.url='jdbc:postgresql://localhost:28434/test',
+    user='test',
+    password='connector',
+    table.name='t_jdbc_ip_version',
+    primary_key='id',
+    type='upsert',
+    ip.version='ipv4'
+);
+
+statement ok
+INSERT INTO rw_jdbc_ip_version VALUES (1, 10), (2, 20);
+
+statement ok
+FLUSH;
+
+system ok retry 4 backoff 1s
+bash -c 'PGPASSWORD=connector psql -h db -U test -d test -At -c "SELECT id, v FROM t_jdbc_ip_version ORDER BY id" | grep -Fx "1|10" && PGPASSWORD=connector psql -h db -U test -d test -At -c "SELECT id, v FROM t_jdbc_ip_version ORDER BY id" | grep -Fx "2|20"'
+
+statement error .*((did not resolve to any ipv6 address)|([Cc]onnection refused)|(Cannot assign requested address)|(Network is unreachable)).*
+CREATE SINK s_jdbc_ip_version_ipv6_on_ipv4 FROM rw_jdbc_ip_version WITH (
+    connector='jdbc',
+    jdbc.url='jdbc:postgresql://localhost:28434/test',
+    user='test',
+    password='connector',
+    table.name='t_jdbc_ip_version',
+    primary_key='id',
+    type='upsert',
+    ip.version='ipv6'
+);
+
+statement ok
+DROP SINK s_jdbc_ip_version_ipv4;
+
+statement ok
+DROP TABLE rw_jdbc_ip_version;
+
+system ok
+PGPASSWORD=connector psql -h db -U test -d test -c "DROP TABLE t_jdbc_ip_version"
+
+system ok
+python3 e2e_test/commands/pg_tcp_proxy.py stop --pid-file /tmp/rw_pg_tcp_proxy_28434.pid
+
 statement ok
 CREATE SINK s_postgres_0 FROM mv_remote_0 WITH (
     connector='jdbc',

--- a/e2e_test/source_inline/tvf/postgres_query.slt
+++ b/e2e_test/source_inline/tvf/postgres_query.slt
@@ -36,6 +36,9 @@ INSERT INTO test SELECT generate_series(1, 100), true, 1, 1, 1, 1.0, 1.0, 1.0, '
 system ok
 python3 e2e_test/commands/pg_tcp_proxy.py start --target-host "$PGHOST" --target-port "$PGPORT" --listen-host 127.0.0.1 --listen-port 28432 --pid-file /tmp/rw_pg_tcp_proxy_28432.pid --log-file /tmp/rw_pg_tcp_proxy_28432.log
 
+system ok
+python3 e2e_test/commands/pg_tcp_proxy.py start --target-host "$PGHOST" --target-port "$PGPORT" --listen-host ::1 --listen-port 28433 --pid-file /tmp/rw_pg_tcp_proxy_28433.pid --log-file /tmp/rw_pg_tcp_proxy_28433.log
+
 statement ok
 create source postgres_cdc_source with (
   ${RISEDEV_POSTGRES_WITH_OPTIONS_COMMON},
@@ -96,7 +99,7 @@ select * from postgres_query('postgres_cdc_source_ipv4', 'select count(*) from t
 5
 
 statement error .*[Cc]onnection refused.*
-create source postgres_cdc_source_ipv6 with (
+create source postgres_cdc_source_ipv6_on_ipv4 with (
   connector = 'postgres-cdc',
   hostname = 'localhost',
   port = '28432',
@@ -107,6 +110,36 @@ create source postgres_cdc_source_ipv6 with (
 );
 
 statement ok
+create source postgres_cdc_source_ipv6 with (
+  connector = 'postgres-cdc',
+  hostname = 'localhost',
+  port = '28433',
+  username = '$PGUSER',
+  password = '$PGPASSWORD',
+  database.name = 'source_test',
+  ip.version = 'ipv6'
+);
+
+query I retry 4 backoff 1s
+select * from postgres_query('postgres_cdc_source_ipv6', 'select count(*) from test where id > 95;');
+----
+5
+
+statement error .*[Cc]onnection refused.*
+create source postgres_cdc_source_ipv4_on_ipv6 with (
+  connector = 'postgres-cdc',
+  hostname = 'localhost',
+  port = '28433',
+  username = '$PGUSER',
+  password = '$PGPASSWORD',
+  database.name = 'source_test',
+  ip.version = 'ipv4'
+);
+
+statement ok
+drop source postgres_cdc_source_ipv6;
+
+statement ok
 drop source postgres_cdc_source_ipv4;
 
 statement ok
@@ -114,6 +147,9 @@ drop source postgres_cdc_source;
 
 system ok
 python3 e2e_test/commands/pg_tcp_proxy.py stop --pid-file /tmp/rw_pg_tcp_proxy_28432.pid
+
+system ok
+python3 e2e_test/commands/pg_tcp_proxy.py stop --pid-file /tmp/rw_pg_tcp_proxy_28433.pid
 
 system ok retry 10 backoff 1s
 PGDATABASE=postgres psql -v ON_ERROR_STOP=1 -c "SELECT pg_terminate_backend(active_pid) FROM pg_replication_slots WHERE database = 'source_test' AND active_pid IS NOT NULL" -c "SELECT pg_drop_replication_slot(slot_name) FROM pg_replication_slots WHERE database = 'source_test'" -c "DROP DATABASE IF EXISTS source_test WITH (FORCE)"

--- a/e2e_test/source_inline/tvf/postgres_query.slt
+++ b/e2e_test/source_inline/tvf/postgres_query.slt
@@ -95,7 +95,7 @@ select * from postgres_query('postgres_cdc_source_ipv4', 'select count(*) from t
 ----
 5
 
-statement ok
+statement error .*((did not resolve to any ipv6 address)|([Cc]onnection refused)|(Cannot assign requested address)|(Network is unreachable)).*
 create source postgres_cdc_source_ipv6_on_ipv4 with (
   connector = 'postgres-cdc',
   hostname = 'localhost',
@@ -105,12 +105,6 @@ create source postgres_cdc_source_ipv6_on_ipv4 with (
   database.name = 'source_test',
   ip.version = 'ipv6'
 );
-
-query error .*((did not resolve to any ipv6 address)|([Cc]onnection refused)|(Cannot assign requested address)|(Network is unreachable)).*
-select * from postgres_query('postgres_cdc_source_ipv6_on_ipv4', 'select count(*) from test where id > 95;');
-
-statement ok
-drop source postgres_cdc_source_ipv6_on_ipv4;
 
 statement ok
 drop source postgres_cdc_source_ipv4;

--- a/e2e_test/source_inline/tvf/postgres_query.slt
+++ b/e2e_test/source_inline/tvf/postgres_query.slt
@@ -34,10 +34,7 @@ INSERT INTO test SELECT generate_series(1, 100), true, 1, 1, 1, 1.0, 1.0, 1.0, '
 "
 
 system ok
-python3 e2e_test/commands/pg_tcp_proxy.py start --target-host "$PGHOST" --target-port "$PGPORT" --listen-port 28432 --pid-file /tmp/rw_pg_tcp_proxy_28432.pid --log-file /tmp/rw_pg_tcp_proxy_28432.log
-
-system ok
-python3 e2e_test/commands/pg_tcp_proxy.py start --target-host "$PGHOST" --target-port "$PGPORT" --listen-port 28433 --pid-file /tmp/rw_pg_tcp_proxy_28433.pid --log-file /tmp/rw_pg_tcp_proxy_28433.log
+python3 e2e_test/commands/pg_tcp_proxy.py start --target-host "$PGHOST" --target-port "$PGPORT" --listen-host 127.0.0.1 --listen-port 28432 --pid-file /tmp/rw_pg_tcp_proxy_28432.pid --log-file /tmp/rw_pg_tcp_proxy_28432.log
 
 statement ok
 create source postgres_cdc_source with (
@@ -101,33 +98,14 @@ select * from postgres_query('postgres_cdc_source_ipv4', 'select count(*) from t
 statement ok
 drop source postgres_cdc_source_ipv4;
 
-statement ok
-create source postgres_cdc_source_ipv6 with (
-  connector = 'postgres-cdc',
-  hostname = 'localhost',
-  port = '28433',
-  username = '$PGUSER',
-  password = '$PGPASSWORD',
-  database.name = 'source_test',
-  ip.version = 'ipv6'
-);
-
-query I retry 4 backoff 1s
-select * from postgres_query('postgres_cdc_source_ipv6', 'select count(*) from test where id > 95;');
-----
-5
-
-statement ok
-drop source postgres_cdc_source_ipv6;
+query error
+select * from postgres_query('localhost', '28432', '$PGUSER', '$PGPASSWORD', 'source_test', 'select count(*) from test where id > 95;', 'ipv6');
 
 statement ok
 drop source postgres_cdc_source;
 
 system ok
 python3 e2e_test/commands/pg_tcp_proxy.py stop --pid-file /tmp/rw_pg_tcp_proxy_28432.pid
-
-system ok
-python3 e2e_test/commands/pg_tcp_proxy.py stop --pid-file /tmp/rw_pg_tcp_proxy_28433.pid
 
 system ok retry 10 backoff 1s
 PGDATABASE=postgres psql -v ON_ERROR_STOP=1 -c "SELECT pg_terminate_backend(active_pid) FROM pg_replication_slots WHERE database = 'source_test' AND active_pid IS NOT NULL" -c "SELECT pg_drop_replication_slot(slot_name) FROM pg_replication_slots WHERE database = 'source_test'" -c "DROP DATABASE IF EXISTS source_test WITH (FORCE)"

--- a/e2e_test/source_inline/tvf/postgres_query.slt
+++ b/e2e_test/source_inline/tvf/postgres_query.slt
@@ -95,7 +95,7 @@ select * from postgres_query('postgres_cdc_source_ipv4', 'select count(*) from t
 ----
 5
 
-statement error .*[Cc]onnection refused.*
+statement ok
 create source postgres_cdc_source_ipv6_on_ipv4 with (
   connector = 'postgres-cdc',
   hostname = 'localhost',
@@ -105,6 +105,12 @@ create source postgres_cdc_source_ipv6_on_ipv4 with (
   database.name = 'source_test',
   ip.version = 'ipv6'
 );
+
+query error .*((did not resolve to any ipv6 address)|([Cc]onnection refused)|(Cannot assign requested address)|(Network is unreachable)).*
+select * from postgres_query('postgres_cdc_source_ipv6_on_ipv4', 'select count(*) from test where id > 95;');
+
+statement ok
+drop source postgres_cdc_source_ipv6_on_ipv4;
 
 statement ok
 drop source postgres_cdc_source_ipv4;

--- a/e2e_test/source_inline/tvf/postgres_query.slt
+++ b/e2e_test/source_inline/tvf/postgres_query.slt
@@ -36,9 +36,6 @@ INSERT INTO test SELECT generate_series(1, 100), true, 1, 1, 1, 1.0, 1.0, 1.0, '
 system ok
 python3 e2e_test/commands/pg_tcp_proxy.py start --target-host "$PGHOST" --target-port "$PGPORT" --listen-host 127.0.0.1 --listen-port 28432 --pid-file /tmp/rw_pg_tcp_proxy_28432.pid --log-file /tmp/rw_pg_tcp_proxy_28432.log
 
-system ok
-python3 e2e_test/commands/pg_tcp_proxy.py start --target-host "$PGHOST" --target-port "$PGPORT" --listen-host ::1 --listen-port 28433 --pid-file /tmp/rw_pg_tcp_proxy_28433.pid --log-file /tmp/rw_pg_tcp_proxy_28433.log
-
 statement ok
 create source postgres_cdc_source with (
   ${RISEDEV_POSTGRES_WITH_OPTIONS_COMMON},
@@ -110,36 +107,6 @@ create source postgres_cdc_source_ipv6_on_ipv4 with (
 );
 
 statement ok
-create source postgres_cdc_source_ipv6 with (
-  connector = 'postgres-cdc',
-  hostname = 'localhost',
-  port = '28433',
-  username = '$PGUSER',
-  password = '$PGPASSWORD',
-  database.name = 'source_test',
-  ip.version = 'ipv6'
-);
-
-query I retry 4 backoff 1s
-select * from postgres_query('postgres_cdc_source_ipv6', 'select count(*) from test where id > 95;');
-----
-5
-
-statement error .*[Cc]onnection refused.*
-create source postgres_cdc_source_ipv4_on_ipv6 with (
-  connector = 'postgres-cdc',
-  hostname = 'localhost',
-  port = '28433',
-  username = '$PGUSER',
-  password = '$PGPASSWORD',
-  database.name = 'source_test',
-  ip.version = 'ipv4'
-);
-
-statement ok
-drop source postgres_cdc_source_ipv6;
-
-statement ok
 drop source postgres_cdc_source_ipv4;
 
 statement ok
@@ -147,9 +114,6 @@ drop source postgres_cdc_source;
 
 system ok
 python3 e2e_test/commands/pg_tcp_proxy.py stop --pid-file /tmp/rw_pg_tcp_proxy_28432.pid
-
-system ok
-python3 e2e_test/commands/pg_tcp_proxy.py stop --pid-file /tmp/rw_pg_tcp_proxy_28433.pid
 
 system ok retry 10 backoff 1s
 PGDATABASE=postgres psql -v ON_ERROR_STOP=1 -c "SELECT pg_terminate_backend(active_pid) FROM pg_replication_slots WHERE database = 'source_test' AND active_pid IS NOT NULL" -c "SELECT pg_drop_replication_slot(slot_name) FROM pg_replication_slots WHERE database = 'source_test'" -c "DROP DATABASE IF EXISTS source_test WITH (FORCE)"

--- a/e2e_test/source_inline/tvf/postgres_query.slt
+++ b/e2e_test/source_inline/tvf/postgres_query.slt
@@ -1,5 +1,8 @@
 control substitution on
 
+system ok retry 10 backoff 1s
+PGDATABASE=postgres psql -v ON_ERROR_STOP=1 -c "SELECT pg_terminate_backend(active_pid) FROM pg_replication_slots WHERE database = 'source_test' AND active_pid IS NOT NULL" -c "SELECT pg_drop_replication_slot(slot_name) FROM pg_replication_slots WHERE database = 'source_test'" -c "DROP DATABASE IF EXISTS source_test WITH (FORCE)"
+
 system ok
 PGDATABASE=source_test createdb
 
@@ -29,6 +32,12 @@ system ok
 PGDATABASE=source_test psql -c "
 INSERT INTO test SELECT generate_series(1, 100), true, 1, 1, 1, 1.0, 1.0, 1.0, '2021-01-01', '00:00:00', '2021-01-01 00:00:00', '2021-01-01 00:00:00 pst', 'text', 'varchar', '1 day', '{}', '\x01';
 "
+
+system ok
+python3 e2e_test/commands/pg_tcp_proxy.py start --target-host "$PGHOST" --target-port "$PGPORT" --listen-port 28432 --pid-file /tmp/rw_pg_tcp_proxy_28432.pid --log-file /tmp/rw_pg_tcp_proxy_28432.log
+
+system ok
+python3 e2e_test/commands/pg_tcp_proxy.py start --target-host "$PGHOST" --target-port "$PGPORT" --listen-port 28433 --pid-file /tmp/rw_pg_tcp_proxy_28433.pid --log-file /tmp/rw_pg_tcp_proxy_28433.log
 
 statement ok
 create source postgres_cdc_source with (
@@ -74,4 +83,51 @@ select * from postgres_query('postgres_cdc_source', 'select * from test where id
 100 t 1 1 1 1 1 1.0 2021-01-01 00:00:00 2021-01-01 00:00:00 2021-01-01 08:00:00+00:00 text varchar 1 day {} \x01
 
 statement ok
+create source postgres_cdc_source_ipv4 with (
+  connector = 'postgres-cdc',
+  hostname = 'localhost',
+  port = '28432',
+  username = '$PGUSER',
+  password = '$PGPASSWORD',
+  database.name = 'source_test',
+  ip.version = 'ipv4'
+);
+
+query I retry 4 backoff 1s
+select * from postgres_query('postgres_cdc_source_ipv4', 'select count(*) from test where id > 95;');
+----
+5
+
+statement ok
+drop source postgres_cdc_source_ipv4;
+
+statement ok
+create source postgres_cdc_source_ipv6 with (
+  connector = 'postgres-cdc',
+  hostname = 'localhost',
+  port = '28433',
+  username = '$PGUSER',
+  password = '$PGPASSWORD',
+  database.name = 'source_test',
+  ip.version = 'ipv6'
+);
+
+query I retry 4 backoff 1s
+select * from postgres_query('postgres_cdc_source_ipv6', 'select count(*) from test where id > 95;');
+----
+5
+
+statement ok
+drop source postgres_cdc_source_ipv6;
+
+statement ok
 drop source postgres_cdc_source;
+
+system ok
+python3 e2e_test/commands/pg_tcp_proxy.py stop --pid-file /tmp/rw_pg_tcp_proxy_28432.pid
+
+system ok
+python3 e2e_test/commands/pg_tcp_proxy.py stop --pid-file /tmp/rw_pg_tcp_proxy_28433.pid
+
+system ok retry 10 backoff 1s
+PGDATABASE=postgres psql -v ON_ERROR_STOP=1 -c "SELECT pg_terminate_backend(active_pid) FROM pg_replication_slots WHERE database = 'source_test' AND active_pid IS NOT NULL" -c "SELECT pg_drop_replication_slot(slot_name) FROM pg_replication_slots WHERE database = 'source_test'" -c "DROP DATABASE IF EXISTS source_test WITH (FORCE)"

--- a/e2e_test/source_inline/tvf/postgres_query.slt
+++ b/e2e_test/source_inline/tvf/postgres_query.slt
@@ -95,11 +95,19 @@ select * from postgres_query('postgres_cdc_source_ipv4', 'select count(*) from t
 ----
 5
 
+statement error .*[Cc]onnection refused.*
+create source postgres_cdc_source_ipv6 with (
+  connector = 'postgres-cdc',
+  hostname = 'localhost',
+  port = '28432',
+  username = '$PGUSER',
+  password = '$PGPASSWORD',
+  database.name = 'source_test',
+  ip.version = 'ipv6'
+);
+
 statement ok
 drop source postgres_cdc_source_ipv4;
-
-query error
-select * from postgres_query('localhost', '28432', '$PGUSER', '$PGPASSWORD', 'source_test', 'select count(*) from test where id > 95;', 'ipv6');
 
 statement ok
 drop source postgres_cdc_source;

--- a/java/connector-node/risingwave-connector-service/src/main/java/com/risingwave/connector/source/common/DbzConnectorConfig.java
+++ b/java/connector-node/risingwave-connector-service/src/main/java/com/risingwave/connector/source/common/DbzConnectorConfig.java
@@ -244,6 +244,7 @@ public class DbzConnectorConfig {
                 postgresProps.setProperty("database.sslmode", sslMode);
             }
 
+            PostgresIpVersion.applyToDebeziumPostgresProperties(postgresProps, userProps);
             dbzProps.putAll(postgresProps);
 
             if (isCdcSourceJob) {
@@ -277,6 +278,7 @@ public class DbzConnectorConfig {
                 postgresProps.setProperty(
                         ConfigurableOffsetBackingStore.OFFSET_STATE_VALUE, startOffset);
             }
+            PostgresIpVersion.applyToDebeziumPostgresProperties(postgresProps, userProps);
             dbzProps.putAll(postgresProps);
         } else if (source == SourceTypeE.MONGODB) {
             var mongodbProps = initiateDbConfig(MONGODB_CONFIG_FILE, substitutor);

--- a/java/connector-node/risingwave-connector-service/src/main/java/com/risingwave/connector/source/common/PostgresIpVersion.java
+++ b/java/connector-node/risingwave-connector-service/src/main/java/com/risingwave/connector/source/common/PostgresIpVersion.java
@@ -22,6 +22,7 @@ import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.util.Arrays;
 import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Properties;
@@ -33,7 +34,8 @@ enum PostgresIpVersion {
 
     static final String PROPERTY_NAME = "ip.version";
 
-    private static final String DBZ_HOSTNAME_PROPERTY = "database.hostname";
+    private static final String DBZ_SOCKET_FACTORY_PROPERTY = "database.socketFactory";
+    private static final String DBZ_SOCKET_FACTORY_ARG_PROPERTY = "database.socketFactoryArg";
 
     private final String displayName;
 
@@ -73,6 +75,27 @@ enum PostgresIpVersion {
             return host;
         }
 
+        return toJdbcUrlHost(resolveAddresses(host).getFirst());
+    }
+
+    static String resolveHostForJdbcUrl(Map<String, String> props) {
+        var host = props.get(DbzConnectorConfig.HOST);
+        return fromProperties(props).resolveHostForJdbcUrl(host);
+    }
+
+    static void applyToDebeziumPostgresProperties(
+            Properties postgresProps, Map<String, String> userProps) {
+        var ipVersion = fromProperties(userProps);
+        if (ipVersion == ANY) {
+            return;
+        }
+
+        postgresProps.setProperty(
+                DBZ_SOCKET_FACTORY_PROPERTY, PostgresIpVersionSocketFactory.class.getName());
+        postgresProps.setProperty(DBZ_SOCKET_FACTORY_ARG_PROPERTY, ipVersion.toString());
+    }
+
+    List<InetAddress> resolveAddresses(String host) {
         var addresses = new LinkedHashSet<InetAddress>();
         try {
             Arrays.stream(InetAddress.getAllByName(host))
@@ -92,23 +115,7 @@ enum PostgresIpVersion {
                             host, displayName));
         }
 
-        return toJdbcUrlHost(addresses.iterator().next());
-    }
-
-    static String resolveHostForJdbcUrl(Map<String, String> props) {
-        var host = props.get(DbzConnectorConfig.HOST);
-        return fromProperties(props).resolveHostForJdbcUrl(host);
-    }
-
-    static void applyToDebeziumPostgresProperties(
-            Properties postgresProps, Map<String, String> userProps) {
-        var ipVersion = fromProperties(userProps);
-        if (ipVersion == ANY) {
-            return;
-        }
-
-        var host = userProps.get(DbzConnectorConfig.HOST);
-        postgresProps.setProperty(DBZ_HOSTNAME_PROPERTY, ipVersion.resolveHostForJdbcUrl(host));
+        return List.copyOf(addresses);
     }
 
     private static String toJdbcUrlHost(InetAddress address) {

--- a/java/connector-node/risingwave-connector-service/src/main/java/com/risingwave/connector/source/common/PostgresIpVersion.java
+++ b/java/connector-node/risingwave-connector-service/src/main/java/com/risingwave/connector/source/common/PostgresIpVersion.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2026 RisingWave Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.risingwave.connector.source.common;
+
+import java.net.Inet4Address;
+import java.net.Inet6Address;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.Arrays;
+import java.util.LinkedHashSet;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Properties;
+
+enum PostgresIpVersion {
+    ANY("any"),
+    IPV4("ipv4"),
+    IPV6("ipv6");
+
+    static final String PROPERTY_NAME = "ip.version";
+
+    private static final String DBZ_HOSTNAME_PROPERTY = "database.hostname";
+
+    private final String displayName;
+
+    PostgresIpVersion(String displayName) {
+        this.displayName = displayName;
+    }
+
+    static PostgresIpVersion fromProperties(Map<String, String> props) {
+        return fromUserValue(props.get(PROPERTY_NAME));
+    }
+
+    static PostgresIpVersion fromUserValue(String value) {
+        if (value == null || value.isBlank()) {
+            return ANY;
+        }
+
+        return switch (value.toLowerCase(Locale.ROOT)) {
+            case "any" -> ANY;
+            case "4", "v4", "ipv4" -> IPV4;
+            case "6", "v6", "ipv6" -> IPV6;
+            default ->
+                    throw ValidatorUtils.invalidArgument(
+                            String.format("invalid postgres ip.version `%s`", value));
+        };
+    }
+
+    boolean matches(InetAddress address) {
+        return switch (this) {
+            case ANY -> true;
+            case IPV4 -> address instanceof Inet4Address;
+            case IPV6 -> address instanceof Inet6Address;
+        };
+    }
+
+    String resolveHostForJdbcUrl(String host) {
+        if (this == ANY) {
+            return host;
+        }
+
+        var addresses = new LinkedHashSet<InetAddress>();
+        try {
+            Arrays.stream(InetAddress.getAllByName(host))
+                    .filter(this::matches)
+                    .forEach(addresses::add);
+        } catch (UnknownHostException e) {
+            throw ValidatorUtils.invalidArgument(
+                    String.format(
+                            "failed to resolve postgres host `%s` for %s: %s",
+                            host, displayName, e.getMessage()));
+        }
+
+        if (addresses.isEmpty()) {
+            throw ValidatorUtils.invalidArgument(
+                    String.format(
+                            "postgres host `%s` did not resolve to any %s address",
+                            host, displayName));
+        }
+
+        return toJdbcUrlHost(addresses.iterator().next());
+    }
+
+    static String resolveHostForJdbcUrl(Map<String, String> props) {
+        var host = props.get(DbzConnectorConfig.HOST);
+        return fromProperties(props).resolveHostForJdbcUrl(host);
+    }
+
+    static void applyToDebeziumPostgresProperties(
+            Properties postgresProps, Map<String, String> userProps) {
+        var ipVersion = fromProperties(userProps);
+        if (ipVersion == ANY) {
+            return;
+        }
+
+        var host = userProps.get(DbzConnectorConfig.HOST);
+        postgresProps.setProperty(DBZ_HOSTNAME_PROPERTY, ipVersion.resolveHostForJdbcUrl(host));
+    }
+
+    private static String toJdbcUrlHost(InetAddress address) {
+        var host = address.getHostAddress();
+        if (address instanceof Inet6Address) {
+            return "[" + host.replace("%", "%25") + "]";
+        }
+        return host;
+    }
+
+    @Override
+    public String toString() {
+        return displayName;
+    }
+}

--- a/java/connector-node/risingwave-connector-service/src/main/java/com/risingwave/connector/source/common/PostgresIpVersionSocketFactory.java
+++ b/java/connector-node/risingwave-connector-service/src/main/java/com/risingwave/connector/source/common/PostgresIpVersionSocketFactory.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2026 RisingWave Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.risingwave.connector.source.common;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.Socket;
+import java.net.SocketAddress;
+import javax.net.SocketFactory;
+
+public class PostgresIpVersionSocketFactory extends SocketFactory {
+    private final PostgresIpVersion ipVersion;
+
+    public PostgresIpVersionSocketFactory() {
+        this(PostgresIpVersion.ANY.toString());
+    }
+
+    public PostgresIpVersionSocketFactory(String ipVersion) {
+        this.ipVersion = PostgresIpVersion.fromUserValue(ipVersion);
+    }
+
+    @Override
+    public Socket createSocket() {
+        return new AddressFamilySocket(ipVersion);
+    }
+
+    @Override
+    public Socket createSocket(String host, int port) throws IOException {
+        var socket = createSocket();
+        socket.connect(InetSocketAddress.createUnresolved(host, port));
+        return socket;
+    }
+
+    @Override
+    public Socket createSocket(String host, int port, java.net.InetAddress localHost, int localPort)
+            throws IOException {
+        var socket = createSocket();
+        socket.bind(new InetSocketAddress(localHost, localPort));
+        socket.connect(InetSocketAddress.createUnresolved(host, port));
+        return socket;
+    }
+
+    @Override
+    public Socket createSocket(java.net.InetAddress host, int port) throws IOException {
+        var socket = createSocket();
+        socket.connect(new InetSocketAddress(host, port));
+        return socket;
+    }
+
+    @Override
+    public Socket createSocket(
+            java.net.InetAddress address,
+            int port,
+            java.net.InetAddress localAddress,
+            int localPort)
+            throws IOException {
+        var socket = createSocket();
+        socket.bind(new InetSocketAddress(localAddress, localPort));
+        socket.connect(new InetSocketAddress(address, port));
+        return socket;
+    }
+
+    private static class AddressFamilySocket extends Socket {
+        private final PostgresIpVersion ipVersion;
+
+        AddressFamilySocket(PostgresIpVersion ipVersion) {
+            this.ipVersion = ipVersion;
+        }
+
+        @Override
+        public void connect(SocketAddress endpoint, int timeout) throws IOException {
+            if (ipVersion == PostgresIpVersion.ANY || !(endpoint instanceof InetSocketAddress)) {
+                super.connect(endpoint, timeout);
+                return;
+            }
+
+            var inetEndpoint = (InetSocketAddress) endpoint;
+            var host = inetEndpoint.getHostString();
+            var port = inetEndpoint.getPort();
+            try {
+                var address = ipVersion.resolveAddresses(host).getFirst();
+                super.connect(new InetSocketAddress(address, port), timeout);
+            } catch (RuntimeException e) {
+                throw new IOException(e.getMessage(), e);
+            }
+        }
+    }
+}

--- a/java/connector-node/risingwave-connector-service/src/main/java/com/risingwave/connector/source/common/PostgresValidator.java
+++ b/java/connector-node/risingwave-connector-service/src/main/java/com/risingwave/connector/source/common/PostgresValidator.java
@@ -74,7 +74,8 @@ public class PostgresValidator extends DatabaseValidator implements AutoCloseabl
         var dbHost = userProps.get(DbzConnectorConfig.HOST);
         var dbPort = userProps.get(DbzConnectorConfig.PORT);
         var dbName = userProps.get(DbzConnectorConfig.DB_NAME);
-        var jdbcUrl = ValidatorUtils.getJdbcUrl(SourceTypeE.POSTGRES, dbHost, dbPort, dbName);
+        var jdbcHost = PostgresIpVersion.resolveHostForJdbcUrl(userProps);
+        var jdbcUrl = ValidatorUtils.getJdbcUrl(SourceTypeE.POSTGRES, jdbcHost, dbPort, dbName);
 
         var user = userProps.get(DbzConnectorConfig.USER);
         var password = userProps.get(DbzConnectorConfig.PASSWORD);

--- a/java/connector-node/risingwave-connector-service/src/main/java/com/risingwave/connector/source/core/DbzCdcEngine.java
+++ b/java/connector-node/risingwave-connector-service/src/main/java/com/risingwave/connector/source/core/DbzCdcEngine.java
@@ -23,9 +23,15 @@ import com.risingwave.connector.api.source.SourceTypeE;
 import com.risingwave.proto.ConnectorServiceProto;
 import io.debezium.embedded.Connect;
 import io.debezium.engine.DebeziumEngine;
+import io.debezium.openlineage.ConnectorContext;
+import io.debezium.openlineage.DebeziumOpenLineageEmitter;
+import java.util.Locale;
+import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 public class DbzCdcEngine implements Runnable {
     static final int DEFAULT_QUEUE_CAPACITY = 16;
@@ -33,6 +39,7 @@ public class DbzCdcEngine implements Runnable {
     private final DebeziumEngine<?> engine;
     private final DbzChangeEventConsumer changeEventConsumer;
     private final long id;
+    private final ConnectorContext openLineageContext;
 
     /** If config is not valid will throw exceptions */
     public DbzCdcEngine(
@@ -51,6 +58,12 @@ public class DbzCdcEngine implements Runnable {
                         transactionTopic,
                         topicPrefix,
                         new ArrayBlockingQueue<>(DEFAULT_QUEUE_CAPACITY));
+
+        var openLineageConfig = toStringMap(config);
+        var connectorTypeName = toDebeziumConnectorTypeName(connector);
+        DebeziumOpenLineageEmitter.init(openLineageConfig, connectorTypeName);
+        this.openLineageContext =
+                DebeziumOpenLineageEmitter.connectorContext(openLineageConfig, connectorTypeName);
 
         // Builds a debezium engine but not start it
         this.id = sourceId;
@@ -74,7 +87,11 @@ public class DbzCdcEngine implements Runnable {
     }
 
     public void stop() throws Exception {
-        engine.close();
+        try {
+            engine.close();
+        } finally {
+            DebeziumOpenLineageEmitter.cleanup(openLineageContext);
+        }
     }
 
     public BlockingQueue<ConnectorServiceProto.GetEventStreamResponse> getOutputChannel() {
@@ -83,5 +100,18 @@ public class DbzCdcEngine implements Runnable {
 
     public DbzChangeEventConsumer getChangeEventConsumer() {
         return changeEventConsumer;
+    }
+
+    private static Map<String, String> toStringMap(Properties config) {
+        return config.stringPropertyNames().stream()
+                .collect(Collectors.toMap(Function.identity(), config::getProperty));
+    }
+
+    private static String toDebeziumConnectorTypeName(SourceTypeE connector) {
+        return switch (connector) {
+            case CITUS, POSTGRES -> "postgres";
+            case SQL_SERVER -> "sqlserver";
+            default -> connector.name().toLowerCase(Locale.ROOT);
+        };
     }
 }

--- a/java/connector-node/risingwave-connector-service/src/main/java/com/risingwave/connector/source/core/DbzCdcEngine.java
+++ b/java/connector-node/risingwave-connector-service/src/main/java/com/risingwave/connector/source/core/DbzCdcEngine.java
@@ -23,15 +23,9 @@ import com.risingwave.connector.api.source.SourceTypeE;
 import com.risingwave.proto.ConnectorServiceProto;
 import io.debezium.embedded.Connect;
 import io.debezium.engine.DebeziumEngine;
-import io.debezium.openlineage.ConnectorContext;
-import io.debezium.openlineage.DebeziumOpenLineageEmitter;
-import java.util.Locale;
-import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
-import java.util.function.Function;
-import java.util.stream.Collectors;
 
 public class DbzCdcEngine implements Runnable {
     static final int DEFAULT_QUEUE_CAPACITY = 16;
@@ -39,7 +33,6 @@ public class DbzCdcEngine implements Runnable {
     private final DebeziumEngine<?> engine;
     private final DbzChangeEventConsumer changeEventConsumer;
     private final long id;
-    private final ConnectorContext openLineageContext;
 
     /** If config is not valid will throw exceptions */
     public DbzCdcEngine(
@@ -58,12 +51,6 @@ public class DbzCdcEngine implements Runnable {
                         transactionTopic,
                         topicPrefix,
                         new ArrayBlockingQueue<>(DEFAULT_QUEUE_CAPACITY));
-
-        var openLineageConfig = toStringMap(config);
-        var connectorTypeName = toDebeziumConnectorTypeName(connector);
-        DebeziumOpenLineageEmitter.init(openLineageConfig, connectorTypeName);
-        this.openLineageContext =
-                DebeziumOpenLineageEmitter.connectorContext(openLineageConfig, connectorTypeName);
 
         // Builds a debezium engine but not start it
         this.id = sourceId;
@@ -87,11 +74,7 @@ public class DbzCdcEngine implements Runnable {
     }
 
     public void stop() throws Exception {
-        try {
-            engine.close();
-        } finally {
-            DebeziumOpenLineageEmitter.cleanup(openLineageContext);
-        }
+        engine.close();
     }
 
     public BlockingQueue<ConnectorServiceProto.GetEventStreamResponse> getOutputChannel() {
@@ -100,18 +83,5 @@ public class DbzCdcEngine implements Runnable {
 
     public DbzChangeEventConsumer getChangeEventConsumer() {
         return changeEventConsumer;
-    }
-
-    private static Map<String, String> toStringMap(Properties config) {
-        return config.stringPropertyNames().stream()
-                .collect(Collectors.toMap(Function.identity(), config::getProperty));
-    }
-
-    private static String toDebeziumConnectorTypeName(SourceTypeE connector) {
-        return switch (connector) {
-            case CITUS, POSTGRES -> "postgres";
-            case SQL_SERVER -> "sqlserver";
-            default -> connector.name().toLowerCase(Locale.ROOT);
-        };
     }
 }

--- a/java/connector-node/risingwave-connector-service/src/test/java/com/risingwave/connector/source/common/PostgresIpVersionTest.java
+++ b/java/connector-node/risingwave-connector-service/src/test/java/com/risingwave/connector/source/common/PostgresIpVersionTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2026 RisingWave Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.risingwave.connector.source.common;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+
+import io.grpc.StatusRuntimeException;
+import java.util.Map;
+import java.util.Properties;
+import org.junit.Test;
+
+public class PostgresIpVersionTest {
+    @Test
+    public void testParseIpVersion() {
+        assertEquals(PostgresIpVersion.ANY, PostgresIpVersion.fromUserValue(null));
+        assertEquals(PostgresIpVersion.ANY, PostgresIpVersion.fromUserValue(""));
+        assertEquals(PostgresIpVersion.ANY, PostgresIpVersion.fromUserValue("any"));
+        assertEquals(PostgresIpVersion.IPV4, PostgresIpVersion.fromUserValue("ipv4"));
+        assertEquals(PostgresIpVersion.IPV4, PostgresIpVersion.fromUserValue("4"));
+        assertEquals(PostgresIpVersion.IPV6, PostgresIpVersion.fromUserValue("ipv6"));
+        assertEquals(PostgresIpVersion.IPV6, PostgresIpVersion.fromUserValue("6"));
+        assertThrows(
+                StatusRuntimeException.class, () -> PostgresIpVersion.fromUserValue("invalid"));
+    }
+
+    @Test
+    public void testResolveLiteralAddress() {
+        assertEquals("127.0.0.1", PostgresIpVersion.IPV4.resolveHostForJdbcUrl("127.0.0.1"));
+        assertEquals("[0:0:0:0:0:0:0:1]", PostgresIpVersion.IPV6.resolveHostForJdbcUrl("::1"));
+        assertThrows(
+                StatusRuntimeException.class,
+                () -> PostgresIpVersion.IPV6.resolveHostForJdbcUrl("127.0.0.1"));
+    }
+
+    @Test
+    public void testApplyToDebeziumPostgresProperties() {
+        var postgresProps = new Properties();
+        PostgresIpVersion.applyToDebeziumPostgresProperties(
+                postgresProps,
+                Map.of(
+                        DbzConnectorConfig.HOST,
+                        "127.0.0.1",
+                        PostgresIpVersion.PROPERTY_NAME,
+                        "ipv4"));
+
+        assertEquals("127.0.0.1", postgresProps.getProperty("database.hostname"));
+    }
+}

--- a/java/connector-node/risingwave-connector-service/src/test/java/com/risingwave/connector/source/common/PostgresIpVersionTest.java
+++ b/java/connector-node/risingwave-connector-service/src/test/java/com/risingwave/connector/source/common/PostgresIpVersionTest.java
@@ -17,9 +17,12 @@
 package com.risingwave.connector.source.common;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThrows;
 
 import io.grpc.StatusRuntimeException;
+import java.io.IOException;
+import java.net.InetSocketAddress;
 import java.util.Map;
 import java.util.Properties;
 import org.junit.Test;
@@ -48,7 +51,7 @@ public class PostgresIpVersionTest {
     }
 
     @Test
-    public void testApplyToDebeziumPostgresProperties() {
+    public void testApplyToDebeziumPostgresPropertiesKeepsHostnameDynamic() {
         var postgresProps = new Properties();
         PostgresIpVersion.applyToDebeziumPostgresProperties(
                 postgresProps,
@@ -58,6 +61,20 @@ public class PostgresIpVersionTest {
                         PostgresIpVersion.PROPERTY_NAME,
                         "ipv4"));
 
-        assertEquals("127.0.0.1", postgresProps.getProperty("database.hostname"));
+        assertNull(postgresProps.getProperty("database.hostname"));
+        assertEquals(
+                PostgresIpVersionSocketFactory.class.getName(),
+                postgresProps.getProperty("database.socketFactory"));
+        assertEquals("ipv4", postgresProps.getProperty("database.socketFactoryArg"));
+    }
+
+    @Test
+    public void testSocketFactoryRejectsMismatchedLiteralAddressBeforeConnect() throws IOException {
+        var socketFactory = new PostgresIpVersionSocketFactory("ipv6");
+        var socket = socketFactory.createSocket();
+
+        assertThrows(
+                IOException.class,
+                () -> socket.connect(InetSocketAddress.createUnresolved("127.0.0.1", 5432), 1));
     }
 }

--- a/java/connector-node/risingwave-sink-jdbc/src/main/java/com/risingwave/connector/JDBCPostgresIpVersion.java
+++ b/java/connector-node/risingwave-sink-jdbc/src/main/java/com/risingwave/connector/JDBCPostgresIpVersion.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2026 RisingWave Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.risingwave.connector;
+
+import java.net.Inet4Address;
+import java.net.Inet6Address;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.sql.SQLException;
+import java.util.Arrays;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Locale;
+
+enum JDBCPostgresIpVersion {
+    ANY("any"),
+    IPV4("ipv4"),
+    IPV6("ipv6");
+
+    private final String displayName;
+
+    JDBCPostgresIpVersion(String displayName) {
+        this.displayName = displayName;
+    }
+
+    static JDBCPostgresIpVersion fromUserValue(String value) throws SQLException {
+        if (value == null || value.isBlank()) {
+            return ANY;
+        }
+
+        return switch (value.toLowerCase(Locale.ROOT)) {
+            case "any" -> ANY;
+            case "4", "v4", "ipv4" -> IPV4;
+            case "6", "v6", "ipv6" -> IPV6;
+            default ->
+                    throw new SQLException(
+                            String.format("invalid postgres ip.version `%s`", value));
+        };
+    }
+
+    boolean matches(InetAddress address) {
+        return switch (this) {
+            case ANY -> true;
+            case IPV4 -> address instanceof Inet4Address;
+            case IPV6 -> address instanceof Inet6Address;
+        };
+    }
+
+    List<InetAddress> resolveAddresses(String host) throws SQLException {
+        var addresses = new LinkedHashSet<InetAddress>();
+        try {
+            Arrays.stream(InetAddress.getAllByName(host))
+                    .filter(this::matches)
+                    .forEach(addresses::add);
+        } catch (UnknownHostException e) {
+            throw new SQLException(
+                    String.format(
+                            "failed to resolve postgres host `%s` for %s: %s",
+                            host, displayName, e.getMessage()),
+                    e);
+        }
+
+        if (addresses.isEmpty()) {
+            throw new SQLException(
+                    String.format(
+                            "postgres host `%s` did not resolve to any %s address",
+                            host, displayName));
+        }
+
+        return List.copyOf(addresses);
+    }
+
+    @Override
+    public String toString() {
+        return displayName;
+    }
+}

--- a/java/connector-node/risingwave-sink-jdbc/src/main/java/com/risingwave/connector/JDBCSinkConfig.java
+++ b/java/connector-node/risingwave-sink-jdbc/src/main/java/com/risingwave/connector/JDBCSinkConfig.java
@@ -49,6 +49,9 @@ public class JDBCSinkConfig extends CommonSinkConfig {
     @JsonProperty(value = "database.name")
     private String databaseName;
 
+    @JsonProperty(value = "ip.version")
+    private String ipVersion = "any";
+
     // Only applicable for redshift BatchAppendOnlyJDBCSink
     @JsonProperty(value = "batch.insert.rows")
     private int batchInsertRows = 0;
@@ -119,6 +122,10 @@ public class JDBCSinkConfig extends CommonSinkConfig {
 
     public int getBatchInsertRows() {
         return batchInsertRows;
+    }
+
+    public String getIpVersion() {
+        return ipVersion;
     }
 
     public boolean isKeepaliveEnabled() {

--- a/java/connector-node/risingwave-sink-jdbc/src/main/java/com/risingwave/connector/JDBCSocketFactory.java
+++ b/java/connector-node/risingwave-sink-jdbc/src/main/java/com/risingwave/connector/JDBCSocketFactory.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright 2026 RisingWave Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.risingwave.connector;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.Socket;
+import java.net.SocketAddress;
+import javax.net.SocketFactory;
+import jdk.net.ExtendedSocketOptions;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class JDBCSocketFactory extends SocketFactory {
+    private static final Logger LOG = LoggerFactory.getLogger(JDBCSocketFactory.class);
+
+    private static class SocketConfig {
+        boolean keepaliveEnabled = false;
+        int idleSeconds = 60;
+        int intervalSeconds = 10;
+        int count = 3;
+        JDBCPostgresIpVersion ipVersion = JDBCPostgresIpVersion.ANY;
+
+        SocketConfig() {}
+
+        SocketConfig(
+                boolean keepaliveEnabled,
+                int idle,
+                int interval,
+                int count,
+                JDBCPostgresIpVersion ipVersion) {
+            this.keepaliveEnabled = keepaliveEnabled;
+            this.idleSeconds = idle;
+            this.intervalSeconds = interval;
+            this.count = count;
+            this.ipVersion = ipVersion;
+        }
+    }
+
+    private static final ThreadLocal<SocketConfig> socketConfig =
+            ThreadLocal.withInitial(SocketConfig::new);
+
+    static void configure(
+            boolean keepaliveEnabled,
+            int idle,
+            int interval,
+            int count,
+            JDBCPostgresIpVersion ipVersion) {
+        socketConfig.set(new SocketConfig(keepaliveEnabled, idle, interval, count, ipVersion));
+    }
+
+    static void clearConfig() {
+        socketConfig.remove();
+    }
+
+    @Override
+    public Socket createSocket() {
+        return configureSocket(new AddressFamilySocket(socketConfig.get()));
+    }
+
+    @Override
+    public Socket createSocket(String host, int port) throws IOException {
+        var socket = createSocket();
+        socket.connect(InetSocketAddress.createUnresolved(host, port));
+        return socket;
+    }
+
+    @Override
+    public Socket createSocket(String host, int port, InetAddress localHost, int localPort)
+            throws IOException {
+        var socket = createSocket();
+        socket.bind(new InetSocketAddress(localHost, localPort));
+        socket.connect(InetSocketAddress.createUnresolved(host, port));
+        return socket;
+    }
+
+    @Override
+    public Socket createSocket(InetAddress host, int port) throws IOException {
+        var socket = createSocket();
+        socket.connect(new InetSocketAddress(host, port));
+        return socket;
+    }
+
+    @Override
+    public Socket createSocket(
+            InetAddress address, int port, InetAddress localAddress, int localPort)
+            throws IOException {
+        var socket = createSocket();
+        socket.bind(new InetSocketAddress(localAddress, localPort));
+        socket.connect(new InetSocketAddress(address, port));
+        return socket;
+    }
+
+    private Socket configureSocket(Socket socket) {
+        var config = socketConfig.get();
+        if (!config.keepaliveEnabled) {
+            return socket;
+        }
+
+        try {
+            socket.setKeepAlive(true);
+            socket.setOption(ExtendedSocketOptions.TCP_KEEPIDLE, config.idleSeconds);
+            socket.setOption(ExtendedSocketOptions.TCP_KEEPINTERVAL, config.intervalSeconds);
+            socket.setOption(ExtendedSocketOptions.TCP_KEEPCOUNT, config.count);
+        } catch (Exception e) {
+            LOG.warn(
+                    "Failed to set TCP keep-alive extended options, "
+                            + "falling back to basic keep-alive only: {}",
+                    e.getMessage());
+        }
+        return socket;
+    }
+
+    private static class AddressFamilySocket extends Socket {
+        private final SocketConfig config;
+
+        AddressFamilySocket(SocketConfig config) {
+            this.config = config;
+        }
+
+        @Override
+        public void connect(SocketAddress endpoint, int timeout) throws IOException {
+            if (config.ipVersion == JDBCPostgresIpVersion.ANY
+                    || !(endpoint instanceof InetSocketAddress)) {
+                super.connect(endpoint, timeout);
+                return;
+            }
+
+            var inetEndpoint = (InetSocketAddress) endpoint;
+            var host = inetEndpoint.getHostString();
+            var port = inetEndpoint.getPort();
+            try {
+                var address = config.ipVersion.resolveAddresses(host).getFirst();
+                super.connect(new InetSocketAddress(address, port), timeout);
+            } catch (RuntimeException | java.sql.SQLException e) {
+                throw new IOException(e.getMessage(), e);
+            }
+        }
+    }
+}

--- a/java/connector-node/risingwave-sink-jdbc/src/main/java/com/risingwave/connector/JdbcUtils.java
+++ b/java/connector-node/risingwave-sink-jdbc/src/main/java/com/risingwave/connector/JdbcUtils.java
@@ -93,6 +93,7 @@ public abstract class JdbcUtils {
     static Connection getConnectionDefault(JDBCSinkConfig config) throws SQLException {
         String jdbcUrl = config.getJdbcUrl();
         var props = createBaseProperties(jdbcUrl, config.getUser());
+        boolean isPg = jdbcUrl.startsWith("jdbc:postgresql");
 
         // Default password authentication
         if (config.getPassword() != null) {
@@ -105,21 +106,29 @@ public abstract class JdbcUtils {
                     "reWriteBatchedInsertsSize", String.valueOf(config.getBatchInsertRows()));
         }
         // Configure TCP keep-alive with custom SocketFactory if enabled
-        boolean keepaliveConfigured = false;
+        boolean socketFactoryConfigured = false;
         try {
-            if (config.isKeepaliveEnabled()) {
+            JDBCPostgresIpVersion ipVersion =
+                    isPg
+                            ? JDBCPostgresIpVersion.fromUserValue(config.getIpVersion())
+                            : JDBCPostgresIpVersion.ANY;
+            if (config.isKeepaliveEnabled() || ipVersion != JDBCPostgresIpVersion.ANY) {
                 LOG.info(
-                        "Enabling TCP keep-alive: idle={}s, interval={}s, count={}",
+                        "Enabling JDBC socket factory: keepalive={}, idle={}s, interval={}s, count={}, ip.version={}",
+                        config.isKeepaliveEnabled(),
                         config.getKeepaliveIdleSeconds(),
                         config.getKeepaliveIntervalSeconds(),
-                        config.getKeepaliveCount());
+                        config.getKeepaliveCount(),
+                        ipVersion);
                 // Configure the ThreadLocal factory parameters
-                JDBCKeepaliveSocketFactory.configure(
+                JDBCSocketFactory.configure(
+                        config.isKeepaliveEnabled(),
                         config.getKeepaliveIdleSeconds(),
                         config.getKeepaliveIntervalSeconds(),
-                        config.getKeepaliveCount());
-                keepaliveConfigured = true;
-                props.setProperty("socketFactory", JDBCKeepaliveSocketFactory.class.getName());
+                        config.getKeepaliveCount(),
+                        ipVersion);
+                socketFactoryConfigured = true;
+                props.setProperty("socketFactory", JDBCSocketFactory.class.getName());
             }
 
             var conn = DriverManager.getConnection(jdbcUrl, props);
@@ -133,8 +142,8 @@ public abstract class JdbcUtils {
             return conn;
         } finally {
             // Clean up ThreadLocal to prevent memory leak
-            if (keepaliveConfigured) {
-                JDBCKeepaliveSocketFactory.clearConfig();
+            if (socketFactoryConfigured) {
+                JDBCSocketFactory.clearConfig();
             }
         }
     }

--- a/java/connector-node/risingwave-sink-jdbc/src/test/java/com/risingwave/connector/JDBCPostgresIpVersionTest.java
+++ b/java/connector-node/risingwave-sink-jdbc/src/test/java/com/risingwave/connector/JDBCPostgresIpVersionTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2026 RisingWave Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.risingwave.connector;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.sql.SQLException;
+import org.junit.Test;
+
+public class JDBCPostgresIpVersionTest {
+    @Test
+    public void testParseIpVersion() throws SQLException {
+        assertEquals(JDBCPostgresIpVersion.ANY, JDBCPostgresIpVersion.fromUserValue(null));
+        assertEquals(JDBCPostgresIpVersion.ANY, JDBCPostgresIpVersion.fromUserValue(""));
+        assertEquals(JDBCPostgresIpVersion.ANY, JDBCPostgresIpVersion.fromUserValue("any"));
+        assertEquals(JDBCPostgresIpVersion.IPV4, JDBCPostgresIpVersion.fromUserValue("ipv4"));
+        assertEquals(JDBCPostgresIpVersion.IPV4, JDBCPostgresIpVersion.fromUserValue("4"));
+        assertEquals(JDBCPostgresIpVersion.IPV6, JDBCPostgresIpVersion.fromUserValue("ipv6"));
+        assertEquals(JDBCPostgresIpVersion.IPV6, JDBCPostgresIpVersion.fromUserValue("6"));
+        assertThrows(SQLException.class, () -> JDBCPostgresIpVersion.fromUserValue("invalid"));
+    }
+
+    @Test
+    public void testSocketFactoryRejectsMismatchedLiteralAddressBeforeConnect()
+            throws SQLException {
+        JDBCSocketFactory.configure(false, 60, 10, 3, JDBCPostgresIpVersion.fromUserValue("ipv6"));
+        try {
+            var socketFactory = new JDBCSocketFactory();
+            var socket = socketFactory.createSocket();
+
+            assertThrows(
+                    IOException.class,
+                    () -> socket.connect(InetSocketAddress.createUnresolved("127.0.0.1", 5432), 1));
+        } finally {
+            JDBCSocketFactory.clearConfig();
+        }
+    }
+}

--- a/proto/batch_plan.proto
+++ b/proto/batch_plan.proto
@@ -142,6 +142,7 @@ message PostgresQueryNode {
   string query = 7;
   string ssl_mode = 8;
   string ssl_root_cert = 9;
+  string ip_version = 10;
 }
 
 // NOTE(kwannoel): This will only be used in batch mode. We can change the definition as needed.

--- a/src/batch/executors/src/executor/postgres_query.rs
+++ b/src/batch/executors/src/executor/postgres_query.rs
@@ -20,7 +20,7 @@ use risingwave_common::catalog::{Field, Schema};
 use risingwave_common::row::OwnedRow;
 use risingwave_common::types::{DataType, Datum, Decimal, ScalarImpl};
 use risingwave_common::util::chunk_coalesce::DataChunkBuilder;
-use risingwave_connector::connector_common::{PgConnectionConfig, create_pg_client};
+use risingwave_connector::connector_common::{IpVersion, PgConnectionConfig, create_pg_client};
 use risingwave_pb::batch_plan::plan_node::NodeBody;
 use tokio_postgres;
 
@@ -177,6 +177,19 @@ impl BoxedExecutorBuilder for PostgresQueryExecutorBuilder {
                     None
                 } else {
                     Some(postgres_query_node.ssl_root_cert.clone())
+                },
+                ip_version: if postgres_query_node.ip_version.is_empty() {
+                    IpVersion::default()
+                } else {
+                    postgres_query_node
+                        .ip_version
+                        .parse::<IpVersion>()
+                        .with_context(|| {
+                            format!(
+                                "invalid postgres ip.version `{}`",
+                                postgres_query_node.ip_version
+                            )
+                        })?
                 },
             },
             postgres_query_node.query.clone(),

--- a/src/connector/src/connector_common/mod.rs
+++ b/src/connector/src/connector_common/mod.rs
@@ -43,7 +43,7 @@ pub use iceberg::{
 pub use postgres::{
     IpVersion, PgConnectionConfig, PostgresExternalTable, SslMode, TcpKeepaliveConfig,
     create_pg_client, create_pg_client_from_properties, discover_pgvector_dimensions,
-    pg_connection_config_from_properties,
+    pg_connection_config_from_properties, postgres_ip_version_from_properties,
 };
 
 #[cfg(test)]

--- a/src/connector/src/connector_common/mod.rs
+++ b/src/connector/src/connector_common/mod.rs
@@ -41,8 +41,8 @@ pub use iceberg::{
     ResolvedIcebergCatalogConfig, iceberg_java_catalog_props_from_options,
 };
 pub use postgres::{
-    PgConnectionConfig, PostgresExternalTable, SslMode, TcpKeepaliveConfig, create_pg_client,
-    create_pg_client_from_properties, discover_pgvector_dimensions,
+    IpVersion, PgConnectionConfig, PostgresExternalTable, SslMode, TcpKeepaliveConfig,
+    create_pg_client, create_pg_client_from_properties, discover_pgvector_dimensions,
     pg_connection_config_from_properties,
 };
 

--- a/src/connector/src/connector_common/postgres.rs
+++ b/src/connector/src/connector_common/postgres.rs
@@ -465,11 +465,11 @@ pub enum IpVersion {
     #[default]
     #[serde(alias = "")]
     Any,
-    /// Connect only to IPv4 addresses.
+    /// Connect only to `IPv4` addresses.
     #[serde(alias = "4")]
     #[serde(alias = "v4")]
     Ipv4,
-    /// Connect only to IPv6 addresses.
+    /// Connect only to `IPv6` addresses.
     #[serde(alias = "6")]
     #[serde(alias = "v6")]
     Ipv6,

--- a/src/connector/src/connector_common/postgres.rs
+++ b/src/connector/src/connector_common/postgres.rs
@@ -87,6 +87,7 @@ pub struct PgConnectionConfig {
     pub database: String,
     pub ssl_mode: SslMode,
     pub ssl_root_cert: Option<String>,
+    /// Address family to use when resolving and connecting to the Postgres host.
     pub ip_version: IpVersion,
 }
 
@@ -456,15 +457,19 @@ impl std::str::FromStr for SslMode {
     }
 }
 
+/// Address family preference for Postgres connections.
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize, Default)]
 #[serde(rename_all = "lowercase")]
 pub enum IpVersion {
+    /// Use the addresses returned by DNS resolution without filtering by family.
     #[default]
     #[serde(alias = "")]
     Any,
+    /// Connect only to IPv4 addresses.
     #[serde(alias = "4")]
     #[serde(alias = "v4")]
     Ipv4,
+    /// Connect only to IPv6 addresses.
     #[serde(alias = "6")]
     #[serde(alias = "v6")]
     Ipv6,

--- a/src/connector/src/connector_common/postgres.rs
+++ b/src/connector/src/connector_common/postgres.rs
@@ -176,7 +176,7 @@ pub fn pg_connection_config_from_properties(
     })
 }
 
-fn postgres_ip_version_from_properties(
+pub fn postgres_ip_version_from_properties(
     props: &BTreeMap<String, String>,
 ) -> ConnectorResult<IpVersion> {
     props

--- a/src/connector/src/connector_common/postgres.rs
+++ b/src/connector/src/connector_common/postgres.rs
@@ -179,8 +179,6 @@ pub fn pg_connection_config_from_properties(
 fn postgres_ip_version_from_properties(props: &BTreeMap<String, String>) -> IpVersion {
     props
         .get("ip.version")
-        .or_else(|| props.get("ip.family"))
-        .or_else(|| props.get("address.family"))
         .and_then(|v| v.parse::<IpVersion>().ok())
         .unwrap_or_default()
 }

--- a/src/connector/src/connector_common/postgres.rs
+++ b/src/connector/src/connector_common/postgres.rs
@@ -172,15 +172,23 @@ pub fn pg_connection_config_from_properties(
             .and_then(|v| v.parse::<SslMode>().ok())
             .unwrap_or_default(),
         ssl_root_cert: props.get("ssl.root.cert").cloned(),
-        ip_version: postgres_ip_version_from_properties(props),
+        ip_version: postgres_ip_version_from_properties(props)?,
     })
 }
 
-fn postgres_ip_version_from_properties(props: &BTreeMap<String, String>) -> IpVersion {
+fn postgres_ip_version_from_properties(
+    props: &BTreeMap<String, String>,
+) -> ConnectorResult<IpVersion> {
     props
         .get("ip.version")
-        .and_then(|v| v.parse::<IpVersion>().ok())
-        .unwrap_or_default()
+        .filter(|v| !v.is_empty())
+        .map(|v| {
+            v.parse::<IpVersion>()
+                .with_context(|| format!("invalid postgres ip.version `{}`", v))
+                .map_err(Into::into)
+        })
+        .transpose()
+        .map(Option::unwrap_or_default)
 }
 
 pub async fn create_pg_client_from_properties(
@@ -841,6 +849,7 @@ mod tests {
         assert_eq!("4".parse::<IpVersion>().unwrap(), IpVersion::Ipv4);
         assert_eq!("ipv6".parse::<IpVersion>().unwrap(), IpVersion::Ipv6);
         assert_eq!("6".parse::<IpVersion>().unwrap(), IpVersion::Ipv6);
+        assert!("invalid".parse::<IpVersion>().is_err());
     }
 
     #[test]

--- a/src/connector/src/connector_common/postgres.rs
+++ b/src/connector/src/connector_common/postgres.rs
@@ -14,6 +14,7 @@
 
 use std::collections::{BTreeMap, HashMap};
 use std::fmt;
+use std::net::IpAddr;
 
 use anyhow::{Context, anyhow};
 use openssl::ssl::{SslConnector, SslMethod, SslVerifyMode};
@@ -86,6 +87,7 @@ pub struct PgConnectionConfig {
     pub database: String,
     pub ssl_mode: SslMode,
     pub ssl_root_cert: Option<String>,
+    pub ip_version: IpVersion,
 }
 
 impl PgConnectionConfig {
@@ -170,7 +172,17 @@ pub fn pg_connection_config_from_properties(
             .and_then(|v| v.parse::<SslMode>().ok())
             .unwrap_or_default(),
         ssl_root_cert: props.get("ssl.root.cert").cloned(),
+        ip_version: postgres_ip_version_from_properties(props),
     })
+}
+
+fn postgres_ip_version_from_properties(props: &BTreeMap<String, String>) -> IpVersion {
+    props
+        .get("ip.version")
+        .or_else(|| props.get("ip.family"))
+        .or_else(|| props.get("address.family"))
+        .and_then(|v| v.parse::<IpVersion>().ok())
+        .unwrap_or_default()
 }
 
 pub async fn create_pg_client_from_properties(
@@ -438,6 +450,78 @@ impl std::str::FromStr for SslMode {
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Default)]
+#[serde(rename_all = "lowercase")]
+pub enum IpVersion {
+    #[default]
+    #[serde(alias = "")]
+    Any,
+    #[serde(alias = "4")]
+    #[serde(alias = "v4")]
+    Ipv4,
+    #[serde(alias = "6")]
+    #[serde(alias = "v6")]
+    Ipv6,
+}
+
+impl fmt::Display for IpVersion {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(match self {
+            IpVersion::Any => "any",
+            IpVersion::Ipv4 => "ipv4",
+            IpVersion::Ipv6 => "ipv6",
+        })
+    }
+}
+
+impl std::str::FromStr for IpVersion {
+    type Err = serde_json::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        serde_json::from_value(serde_json::Value::String(s.to_owned()))
+    }
+}
+
+fn filter_ip_version(
+    addrs: impl IntoIterator<Item = IpAddr>,
+    ip_version: &IpVersion,
+) -> Vec<IpAddr> {
+    let mut filtered = vec![];
+    for addr in addrs {
+        if match ip_version {
+            IpVersion::Any => true,
+            IpVersion::Ipv4 => addr.is_ipv4(),
+            IpVersion::Ipv6 => addr.is_ipv6(),
+        } && !filtered.contains(&addr)
+        {
+            filtered.push(addr);
+        }
+    }
+    filtered
+}
+
+async fn resolve_pg_hostaddrs(config: &PgConnectionConfig) -> anyhow::Result<Vec<IpAddr>> {
+    let addrs = tokio::net::lookup_host((config.host.as_str(), config.port))
+        .await
+        .with_context(|| {
+            format!(
+                "failed to resolve postgres host `{}` for {}",
+                config.host, config.ip_version
+            )
+        })?
+        .map(|addr| addr.ip());
+
+    let addrs = filter_ip_version(addrs, &config.ip_version);
+    if addrs.is_empty() {
+        bail!(
+            "postgres host `{}` did not resolve to any {} address",
+            config.host,
+            config.ip_version
+        );
+    }
+    Ok(addrs)
+}
+
 pub async fn create_pg_client(
     config: &PgConnectionConfig,
     tcp_keepalive: Option<TcpKeepaliveConfig>,
@@ -446,9 +530,19 @@ pub async fn create_pg_client(
     pg_config
         .user(&config.user)
         .password(&config.password)
-        .host(&config.host)
         .port(config.port)
         .dbname(&config.database);
+
+    match &config.ip_version {
+        IpVersion::Any => {
+            pg_config.host(&config.host);
+        }
+        IpVersion::Ipv4 | IpVersion::Ipv6 => {
+            for addr in resolve_pg_hostaddrs(config).await? {
+                pg_config.host(&config.host).hostaddr(addr);
+            }
+        }
+    }
 
     // Configure TCP keepalive if provided
     if let Some(keepalive) = tcp_keepalive {
@@ -724,7 +818,9 @@ fn sea_type_to_pg_type(sea_type: &SeaType) -> ConnectorResult<tokio_postgres::ty
 
 #[cfg(test)]
 mod tests {
-    use super::parse_pgvector_dimension;
+    use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+
+    use super::{IpVersion, filter_ip_version, parse_pgvector_dimension};
 
     #[test]
     fn test_parse_pgvector_dimension() {
@@ -737,5 +833,29 @@ mod tests {
     fn test_parse_pgvector_dimension_requires_size() {
         let err = parse_pgvector_dimension("vector").unwrap_err();
         assert!(err.to_string().contains("missing dimension"));
+    }
+
+    #[test]
+    fn test_parse_ip_version() {
+        assert_eq!("".parse::<IpVersion>().unwrap(), IpVersion::Any);
+        assert_eq!("any".parse::<IpVersion>().unwrap(), IpVersion::Any);
+        assert_eq!("ipv4".parse::<IpVersion>().unwrap(), IpVersion::Ipv4);
+        assert_eq!("4".parse::<IpVersion>().unwrap(), IpVersion::Ipv4);
+        assert_eq!("ipv6".parse::<IpVersion>().unwrap(), IpVersion::Ipv6);
+        assert_eq!("6".parse::<IpVersion>().unwrap(), IpVersion::Ipv6);
+    }
+
+    #[test]
+    fn test_filter_ip_version() {
+        let v4 = IpAddr::V4(Ipv4Addr::LOCALHOST);
+        let v6 = IpAddr::V6(Ipv6Addr::LOCALHOST);
+        let addrs = vec![v4, v6, v4];
+
+        assert_eq!(
+            filter_ip_version(addrs.clone(), &IpVersion::Any),
+            vec![v4, v6]
+        );
+        assert_eq!(filter_ip_version(addrs.clone(), &IpVersion::Ipv4), vec![v4]);
+        assert_eq!(filter_ip_version(addrs, &IpVersion::Ipv6), vec![v6]);
     }
 }

--- a/src/connector/src/sink/postgres.rs
+++ b/src/connector/src/sink/postgres.rs
@@ -34,7 +34,8 @@ use super::{
     LogSinker, SINK_TYPE_APPEND_ONLY, SINK_TYPE_OPTION, SINK_TYPE_UPSERT, SinkError, SinkLogReader,
 };
 use crate::connector_common::{
-    PgConnectionConfig, PostgresExternalTable, SslMode, TcpKeepaliveConfig, create_pg_client,
+    IpVersion, PgConnectionConfig, PostgresExternalTable, SslMode, TcpKeepaliveConfig,
+    create_pg_client,
 };
 use crate::enforce_secret::EnforceSecret;
 use crate::parser::scalar_adapter::{ScalarAdapter, validate_pg_type_to_rw_type};
@@ -71,6 +72,10 @@ pub struct PostgresConfig {
     pub ssl_mode: SslMode,
     #[serde(rename = "ssl.root.cert")]
     pub ssl_root_cert: Option<String>,
+    #[serde(default, rename = "ip.version")]
+    #[serde(alias = "ip.family")]
+    #[serde(alias = "address.family")]
+    pub ip_version: IpVersion,
     #[serde(default = "default_max_batch_rows")]
     #[serde_as(as = "DisplayFromStr")]
     pub max_batch_rows: usize,
@@ -167,6 +172,7 @@ impl PostgresConfig {
             database: self.database.clone(),
             ssl_mode: self.ssl_mode.clone(),
             ssl_root_cert: self.ssl_root_cert.clone(),
+            ip_version: self.ip_version.clone(),
         }
     }
 }

--- a/src/connector/src/sink/postgres.rs
+++ b/src/connector/src/sink/postgres.rs
@@ -73,8 +73,6 @@ pub struct PostgresConfig {
     #[serde(rename = "ssl.root.cert")]
     pub ssl_root_cert: Option<String>,
     #[serde(default, rename = "ip.version")]
-    #[serde(alias = "ip.family")]
-    #[serde(alias = "address.family")]
     pub ip_version: IpVersion,
     #[serde(default = "default_max_batch_rows")]
     #[serde_as(as = "DisplayFromStr")]

--- a/src/connector/src/source/cdc/external/mod.rs
+++ b/src/connector/src/source/cdc/external/mod.rs
@@ -302,8 +302,6 @@ pub struct ExternalTableConfig {
     pub ssl_root_cert: Option<String>,
 
     #[serde(default, rename = "ip.version")]
-    #[serde(alias = "ip.family")]
-    #[serde(alias = "address.family")]
     pub ip_version: IpVersion,
 
     /// `encrypt` specifies whether connect to SQL Server using SSL.

--- a/src/connector/src/source/cdc/external/mod.rs
+++ b/src/connector/src/source/cdc/external/mod.rs
@@ -33,7 +33,7 @@ use risingwave_pb::secret::PbSecretRef;
 use serde::{Deserialize, Serialize};
 
 use crate::WithPropertiesExt;
-use crate::connector_common::{PgConnectionConfig, PostgresExternalTable, SslMode};
+use crate::connector_common::{IpVersion, PgConnectionConfig, PostgresExternalTable, SslMode};
 use crate::error::{ConnectorError, ConnectorResult};
 use crate::parser::mysql_row_to_owned_row;
 use crate::source::CdcTableSnapshotSplit;
@@ -301,6 +301,11 @@ pub struct ExternalTableConfig {
     #[serde(alias = "debezium.database.sslrootcert")]
     pub ssl_root_cert: Option<String>,
 
+    #[serde(default, rename = "ip.version")]
+    #[serde(alias = "ip.family")]
+    #[serde(alias = "address.family")]
+    pub ip_version: IpVersion,
+
     /// `encrypt` specifies whether connect to SQL Server using SSL.
     /// Only "true" means using SSL. All other values are treated as "false".
     #[serde(rename = "database.encrypt", default = "Default::default")]
@@ -340,6 +345,7 @@ impl ExternalTableConfig {
             database: self.database.clone(),
             ssl_mode: self.ssl_mode.clone(),
             ssl_root_cert: self.ssl_root_cert.clone(),
+            ip_version: self.ip_version.clone(),
         })
     }
 }

--- a/src/connector/src/source/cdc/external/mysql.rs
+++ b/src/connector/src/source/cdc/external/mysql.rs
@@ -820,6 +820,7 @@ mod tests {
             table: "part".to_owned(),
             ssl_mode: Default::default(),
             ssl_root_cert: None,
+            ip_version: Default::default(),
             encrypt: "false".to_owned(),
         };
 

--- a/src/connector/src/source/cdc/external/postgres.rs
+++ b/src/connector/src/source/cdc/external/postgres.rs
@@ -976,6 +976,7 @@ mod tests {
             table: "mytest".to_owned(),
             ssl_mode: Default::default(),
             ssl_root_cert: None,
+            ip_version: Default::default(),
             encrypt: "false".to_owned(),
         };
 

--- a/src/connector/src/source/cdc/mod.rs
+++ b/src/connector/src/source/cdc/mod.rs
@@ -21,7 +21,6 @@ pub mod split;
 use std::collections::{BTreeMap, HashMap};
 use std::marker::PhantomData;
 
-use anyhow::Context;
 pub use enumerator::*;
 use itertools::Itertools;
 use risingwave_common::id::{ActorId, SourceId};
@@ -34,7 +33,7 @@ use risingwave_pb::stream_plan::StreamCdcScanOptions;
 use simd_json::prelude::ArrayTrait;
 pub use source::*;
 
-use crate::connector_common::IpVersion;
+use crate::connector_common::postgres_ip_version_from_properties;
 use crate::enforce_secret::EnforceSecret;
 use crate::error::ConnectorResult;
 use crate::source::{CdcTableSnapshotSplitRaw, SourceProperties, SplitImpl, TryFromBTreeMap};
@@ -161,11 +160,8 @@ impl<T: CdcSourceTypeTrait> TryFromBTreeMap for CdcProperties<T> {
         if matches!(
             T::source_type(),
             CdcSourceType::Postgres | CdcSourceType::Citus
-        ) && let Some(ip_version) = properties.get("ip.version").filter(|v| !v.is_empty())
-        {
-            ip_version
-                .parse::<IpVersion>()
-                .with_context(|| format!("invalid postgres ip.version `{}`", ip_version))?;
+        ) {
+            postgres_ip_version_from_properties(&properties)?;
         }
 
         let is_share_source: bool = properties

--- a/src/connector/src/source/cdc/mod.rs
+++ b/src/connector/src/source/cdc/mod.rs
@@ -21,6 +21,7 @@ pub mod split;
 use std::collections::{BTreeMap, HashMap};
 use std::marker::PhantomData;
 
+use anyhow::Context;
 pub use enumerator::*;
 use itertools::Itertools;
 use risingwave_common::id::{ActorId, SourceId};
@@ -33,6 +34,7 @@ use risingwave_pb::stream_plan::StreamCdcScanOptions;
 use simd_json::prelude::ArrayTrait;
 pub use source::*;
 
+use crate::connector_common::IpVersion;
 use crate::enforce_secret::EnforceSecret;
 use crate::error::ConnectorResult;
 use crate::source::{CdcTableSnapshotSplitRaw, SourceProperties, SplitImpl, TryFromBTreeMap};
@@ -156,6 +158,16 @@ impl<T: CdcSourceTypeTrait> TryFromBTreeMap for CdcProperties<T> {
         properties: BTreeMap<String, String>,
         _deny_unknown_fields: bool,
     ) -> ConnectorResult<Self> {
+        if matches!(
+            T::source_type(),
+            CdcSourceType::Postgres | CdcSourceType::Citus
+        ) && let Some(ip_version) = properties.get("ip.version").filter(|v| !v.is_empty())
+        {
+            ip_version
+                .parse::<IpVersion>()
+                .with_context(|| format!("invalid postgres ip.version `{}`", ip_version))?;
+        }
+
         let is_share_source: bool = properties
             .get(CDC_SHARING_MODE_KEY)
             .is_some_and(|v| v == "true");

--- a/src/frontend/src/expr/table_function.rs
+++ b/src/frontend/src/expr/table_function.rs
@@ -40,7 +40,6 @@ use crate::utils::FRONTEND_RUNTIME;
 
 const INLINE_ARG_LEN: usize = 6;
 const CDC_SOURCE_ARG_LEN: usize = 2;
-const POSTGRES_QUERY_CDC_ARG_LEN: usize = 9;
 
 /// A table function takes a row as input and returns a table. It is also known as Set-Returning
 /// Function.
@@ -357,8 +356,6 @@ impl TableFunction {
                     args_vec.push(ExprImpl::literal_varchar(
                         secret_resolved
                             .get("ip.version")
-                            .or_else(|| secret_resolved.get("ip.family"))
-                            .or_else(|| secret_resolved.get("address.family"))
                             .cloned()
                             .unwrap_or_default(),
                     ));
@@ -727,7 +724,7 @@ impl TableFunction {
 fn postgres_query_ip_version_arg(evaled_args: &[String]) -> anyhow::Result<IpVersion> {
     evaled_args
         .get(8)
-        .filter(|s| evaled_args.len() == POSTGRES_QUERY_CDC_ARG_LEN && !s.is_empty())
+        .filter(|s| !s.is_empty())
         .map(|s| {
             s.parse::<IpVersion>()
                 .with_context(|| format!("invalid postgres ip.version `{}`", s))

--- a/src/frontend/src/expr/table_function.rs
+++ b/src/frontend/src/expr/table_function.rs
@@ -21,7 +21,7 @@ use mysql_async::prelude::*;
 use risingwave_common::array::arrow::IcebergArrowConvert;
 use risingwave_common::secret::LocalSecretManager;
 use risingwave_common::types::{DataType, ScalarImpl, StructType};
-use risingwave_connector::connector_common::{PgConnectionConfig, create_pg_client};
+use risingwave_connector::connector_common::{IpVersion, PgConnectionConfig, create_pg_client};
 use risingwave_connector::source::iceberg::{
     FileScanBackend, extract_bucket_and_file_name, get_parquet_fields, list_data_directory,
     new_azblob_operator, new_gcs_operator, new_s3_operator,
@@ -40,6 +40,8 @@ use crate::utils::FRONTEND_RUNTIME;
 
 const INLINE_ARG_LEN: usize = 6;
 const CDC_SOURCE_ARG_LEN: usize = 2;
+const POSTGRES_QUERY_ARG_LEN_WITH_IP_VERSION: usize = 7;
+const POSTGRES_QUERY_CDC_ARG_LEN: usize = 9;
 
 /// A table function takes a row as input and returns a table. It is also known as Set-Returning
 /// Function.
@@ -306,8 +308,11 @@ impl TableFunction {
         expect_connector_name: &str,
     ) -> RwResult<Vec<ExprImpl>> {
         let cast_args = match args.len() {
-            INLINE_ARG_LEN => {
-                let mut cast_args = Vec::with_capacity(INLINE_ARG_LEN);
+            len if len == INLINE_ARG_LEN
+                || (expect_connector_name.eq_ignore_ascii_case("postgres-cdc")
+                    && len == POSTGRES_QUERY_ARG_LEN_WITH_IP_VERSION) =>
+            {
+                let mut cast_args = Vec::with_capacity(args.len());
                 for arg in args {
                     let arg = arg.cast_implicit(&DataType::Varchar)?;
                     cast_args.push(arg);
@@ -352,12 +357,20 @@ impl TableFunction {
                             .cloned()
                             .unwrap_or_default(),
                     ));
+                    args_vec.push(ExprImpl::literal_varchar(
+                        secret_resolved
+                            .get("ip.version")
+                            .or_else(|| secret_resolved.get("ip.family"))
+                            .or_else(|| secret_resolved.get("address.family"))
+                            .cloned()
+                            .unwrap_or_default(),
+                    ));
                 }
 
                 args_vec
             }
             _ => {
-                return Err(BindError("postgres_query function and mysql_query function accept either 2 arguments: (cdc_source_name varchar, query varchar) or 6 arguments: (hostname varchar, port varchar, username varchar, password varchar, database_name varchar, query varchar)".to_owned()).into());
+                return Err(BindError("postgres_query function accepts either 2 arguments: (cdc_source_name varchar, query varchar), 6 arguments: (hostname varchar, port varchar, username varchar, password varchar, database_name varchar, query varchar), or 7 arguments with ip_version appended; mysql_query accepts either 2 or 6 arguments".to_owned()).into());
             }
         };
 
@@ -403,6 +416,8 @@ impl TableFunction {
                         .get(7)
                         .and_then(|s| if s.is_empty() { None } else { Some(s.clone()) });
 
+                    let ip_version = postgres_query_ip_version_arg(&evaled_args)?;
+
                     let port = evaled_args[1]
                         .parse::<u16>()
                         .with_context(|| format!("invalid postgres port `{}`", evaled_args[1]))?;
@@ -414,6 +429,7 @@ impl TableFunction {
                         database: evaled_args[4].clone(),
                         ssl_mode,
                         ssl_root_cert,
+                        ip_version,
                     };
                     let client = create_pg_client(&pg_conn, None).await?;
 
@@ -704,6 +720,22 @@ impl TableFunction {
             ..self
         }
     }
+}
+
+fn postgres_query_ip_version_arg(evaled_args: &[String]) -> anyhow::Result<IpVersion> {
+    let raw = match evaled_args.len() {
+        POSTGRES_QUERY_ARG_LEN_WITH_IP_VERSION => evaled_args.get(6),
+        POSTGRES_QUERY_CDC_ARG_LEN => evaled_args.get(8),
+        _ => None,
+    };
+
+    raw.filter(|s| !s.is_empty())
+        .map(|s| {
+            s.parse::<IpVersion>()
+                .with_context(|| format!("invalid postgres ip.version `{}`", s))
+        })
+        .transpose()
+        .map(Option::unwrap_or_default)
 }
 
 impl std::fmt::Debug for TableFunction {

--- a/src/frontend/src/expr/table_function.rs
+++ b/src/frontend/src/expr/table_function.rs
@@ -40,7 +40,6 @@ use crate::utils::FRONTEND_RUNTIME;
 
 const INLINE_ARG_LEN: usize = 6;
 const CDC_SOURCE_ARG_LEN: usize = 2;
-const POSTGRES_QUERY_ARG_LEN_WITH_IP_VERSION: usize = 7;
 const POSTGRES_QUERY_CDC_ARG_LEN: usize = 9;
 
 /// A table function takes a row as input and returns a table. It is also known as Set-Returning
@@ -309,11 +308,8 @@ impl TableFunction {
         function_name: &str,
     ) -> RwResult<Vec<ExprImpl>> {
         let cast_args = match args.len() {
-            len if len == INLINE_ARG_LEN
-                || (expect_connector_name.eq_ignore_ascii_case("postgres-cdc")
-                    && len == POSTGRES_QUERY_ARG_LEN_WITH_IP_VERSION) =>
-            {
-                let mut cast_args = Vec::with_capacity(args.len());
+            INLINE_ARG_LEN => {
+                let mut cast_args = Vec::with_capacity(INLINE_ARG_LEN);
                 for arg in args {
                     let arg = arg.cast_implicit(&DataType::Varchar)?;
                     cast_args.push(arg);
@@ -371,15 +367,9 @@ impl TableFunction {
                 args_vec
             }
             _ => {
-                let message = if expect_connector_name.eq_ignore_ascii_case("postgres-cdc") {
-                    format!(
-                        "{function_name} function accepts either 2 arguments: (cdc_source_name varchar, query varchar), 6 arguments: (hostname varchar, port varchar, username varchar, password varchar, database_name varchar, query varchar), or 7 arguments with ip_version appended"
-                    )
-                } else {
-                    format!(
-                        "{function_name} function accepts either 2 arguments: (cdc_source_name varchar, query varchar) or 6 arguments: (hostname varchar, port varchar, username varchar, password varchar, database_name varchar, query varchar)"
-                    )
-                };
+                let message = format!(
+                    "{function_name} function accepts either 2 arguments: (cdc_source_name varchar, query varchar) or 6 arguments: (hostname varchar, port varchar, username varchar, password varchar, database_name varchar, query varchar)"
+                );
                 return Err(BindError(message).into());
             }
         };
@@ -735,13 +725,9 @@ impl TableFunction {
 }
 
 fn postgres_query_ip_version_arg(evaled_args: &[String]) -> anyhow::Result<IpVersion> {
-    let raw = match evaled_args.len() {
-        POSTGRES_QUERY_ARG_LEN_WITH_IP_VERSION => evaled_args.get(6),
-        POSTGRES_QUERY_CDC_ARG_LEN => evaled_args.get(8),
-        _ => None,
-    };
-
-    raw.filter(|s| !s.is_empty())
+    evaled_args
+        .get(8)
+        .filter(|s| evaled_args.len() == POSTGRES_QUERY_CDC_ARG_LEN && !s.is_empty())
         .map(|s| {
             s.parse::<IpVersion>()
                 .with_context(|| format!("invalid postgres ip.version `{}`", s))

--- a/src/frontend/src/expr/table_function.rs
+++ b/src/frontend/src/expr/table_function.rs
@@ -306,6 +306,7 @@ impl TableFunction {
         schema_path: SchemaPath<'_>,
         args: Vec<ExprImpl>,
         expect_connector_name: &str,
+        function_name: &str,
     ) -> RwResult<Vec<ExprImpl>> {
         let cast_args = match args.len() {
             len if len == INLINE_ARG_LEN
@@ -370,7 +371,16 @@ impl TableFunction {
                 args_vec
             }
             _ => {
-                return Err(BindError("postgres_query function accepts either 2 arguments: (cdc_source_name varchar, query varchar), 6 arguments: (hostname varchar, port varchar, username varchar, password varchar, database_name varchar, query varchar), or 7 arguments with ip_version appended; mysql_query accepts either 2 or 6 arguments".to_owned()).into());
+                let message = if expect_connector_name.eq_ignore_ascii_case("postgres-cdc") {
+                    format!(
+                        "{function_name} function accepts either 2 arguments: (cdc_source_name varchar, query varchar), 6 arguments: (hostname varchar, port varchar, username varchar, password varchar, database_name varchar, query varchar), or 7 arguments with ip_version appended"
+                    )
+                } else {
+                    format!(
+                        "{function_name} function accepts either 2 arguments: (cdc_source_name varchar, query varchar) or 6 arguments: (hostname varchar, port varchar, username varchar, password varchar, database_name varchar, query varchar)"
+                    )
+                };
+                return Err(BindError(message).into());
             }
         };
 
@@ -389,6 +399,7 @@ impl TableFunction {
             schema_path,
             args,
             "postgres-cdc",
+            "postgres_query",
         )?;
         let evaled_args = args
             .iter()
@@ -491,6 +502,7 @@ impl TableFunction {
             schema_path,
             args,
             "mysql-cdc",
+            "mysql_query",
         )?;
         let evaled_args = args
             .iter()
@@ -500,7 +512,7 @@ impl TableFunction {
         #[cfg(madsim)]
         {
             return Err(crate::error::ErrorCode::BindError(
-                "postgres_query can't be used in the madsim mode".to_string(),
+                "mysql_query can't be used in the madsim mode".to_string(),
             )
             .into());
         }

--- a/src/frontend/src/optimizer/plan_node/batch_postgres_query.rs
+++ b/src/frontend/src/optimizer/plan_node/batch_postgres_query.rs
@@ -90,6 +90,7 @@ impl ToBatchPb for BatchPostgresQuery {
             query: self.core.query.clone(),
             ssl_mode: self.core.ssl_mode.clone().unwrap_or_default(),
             ssl_root_cert: self.core.ssl_root_cert.clone().unwrap_or_default(),
+            ip_version: self.core.ip_version.clone().unwrap_or_default(),
         })
     }
 }

--- a/src/frontend/src/optimizer/plan_node/generic/postgres_query.rs
+++ b/src/frontend/src/optimizer/plan_node/generic/postgres_query.rs
@@ -31,6 +31,7 @@ pub struct PostgresQuery {
     pub query: String,
     pub ssl_mode: Option<String>,
     pub ssl_root_cert: Option<String>,
+    pub ip_version: Option<String>,
 
     #[educe(PartialEq(ignore))]
     #[educe(Hash(ignore))]

--- a/src/frontend/src/optimizer/plan_node/logical_postgres_query.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_postgres_query.rs
@@ -50,6 +50,7 @@ impl LogicalPostgresQuery {
         query: String,
         ssl_mode: Option<String>,
         ssl_root_cert: Option<String>,
+        ip_version: Option<String>,
     ) -> Self {
         let core = generic::PostgresQuery {
             schema,
@@ -61,6 +62,7 @@ impl LogicalPostgresQuery {
             query,
             ssl_mode,
             ssl_root_cert,
+            ip_version,
             ctx,
         };
 

--- a/src/frontend/src/optimizer/plan_node/logical_postgres_query.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_postgres_query.rs
@@ -14,7 +14,6 @@
 
 use pretty_xmlish::XmlNode;
 use risingwave_common::bail;
-use risingwave_common::catalog::Schema;
 
 use super::generic::GenericPlanRef;
 use super::utils::{Distill, childless_record};
@@ -22,7 +21,6 @@ use super::{
     BatchPostgresQuery, ColPrunable, ExprRewritable, Logical, LogicalPlanRef as PlanRef,
     LogicalProject, PlanBase, PredicatePushdown, ToBatch, ToStream, generic,
 };
-use crate::OptimizerContextRef;
 use crate::error::Result;
 use crate::optimizer::plan_node::expr_visitable::ExprVisitable;
 use crate::optimizer::plan_node::utils::column_names_pretty;
@@ -39,33 +37,7 @@ pub struct LogicalPostgresQuery {
 }
 
 impl LogicalPostgresQuery {
-    pub fn new(
-        ctx: OptimizerContextRef,
-        schema: Schema,
-        hostname: String,
-        port: String,
-        username: String,
-        password: String,
-        database: String,
-        query: String,
-        ssl_mode: Option<String>,
-        ssl_root_cert: Option<String>,
-        ip_version: Option<String>,
-    ) -> Self {
-        let core = generic::PostgresQuery {
-            schema,
-            hostname,
-            port,
-            username,
-            password,
-            database,
-            query,
-            ssl_mode,
-            ssl_root_cert,
-            ip_version,
-            ctx,
-        };
-
+    pub fn new(core: generic::PostgresQuery) -> Self {
         let base = PlanBase::new_logical_with_core(&core);
 
         LogicalPostgresQuery { base, core }

--- a/src/frontend/src/optimizer/rule/table_function_to_postgres_query_rule.rs
+++ b/src/frontend/src/optimizer/rule/table_function_to_postgres_query_rule.rs
@@ -60,15 +60,9 @@ impl Rule<Logical> for TableFunctionToPostgresQueryRule {
             let password = eval_args[3].clone();
             let database = eval_args[4].clone();
             let query = eval_args[5].clone();
-            let (ssl_mode, ssl_root_cert, ip_version) = match eval_args.len() {
-                7 => (None, None, eval_args.get(6).cloned()),
-                9 => (
-                    eval_args.get(6).cloned(),
-                    eval_args.get(7).cloned(),
-                    eval_args.get(8).cloned(),
-                ),
-                _ => (None, None, None),
-            };
+            let ssl_mode = eval_args.get(6).cloned();
+            let ssl_root_cert = eval_args.get(7).cloned();
+            let ip_version = eval_args.get(8).cloned();
 
             Some(
                 LogicalPostgresQuery::new(generic::PostgresQuery {

--- a/src/frontend/src/optimizer/rule/table_function_to_postgres_query_rule.rs
+++ b/src/frontend/src/optimizer/rule/table_function_to_postgres_query_rule.rs
@@ -60,8 +60,15 @@ impl Rule<Logical> for TableFunctionToPostgresQueryRule {
             let password = eval_args[3].clone();
             let database = eval_args[4].clone();
             let query = eval_args[5].clone();
-            let ssl_mode = eval_args.get(6).cloned();
-            let ssl_root_cert = eval_args.get(7).cloned();
+            let (ssl_mode, ssl_root_cert, ip_version) = match eval_args.len() {
+                7 => (None, None, eval_args.get(6).cloned()),
+                9 => (
+                    eval_args.get(6).cloned(),
+                    eval_args.get(7).cloned(),
+                    eval_args.get(8).cloned(),
+                ),
+                _ => (None, None, None),
+            };
 
             Some(
                 LogicalPostgresQuery::new(
@@ -75,6 +82,7 @@ impl Rule<Logical> for TableFunctionToPostgresQueryRule {
                     query,
                     ssl_mode,
                     ssl_root_cert,
+                    ip_version,
                 )
                 .into(),
             )

--- a/src/frontend/src/optimizer/rule/table_function_to_postgres_query_rule.rs
+++ b/src/frontend/src/optimizer/rule/table_function_to_postgres_query_rule.rs
@@ -19,7 +19,7 @@ use risingwave_common::types::{DataType, ScalarImpl};
 use super::prelude::{PlanRef, *};
 use crate::expr::{Expr, TableFunctionType};
 use crate::optimizer::plan_node::generic::GenericPlanRef;
-use crate::optimizer::plan_node::{LogicalPostgresQuery, LogicalTableFunction};
+use crate::optimizer::plan_node::{LogicalPostgresQuery, LogicalTableFunction, generic};
 
 /// Transform a special `TableFunction` (with `POSTGRES_QUERY` table function type) into a `LogicalPostgresQuery`
 pub struct TableFunctionToPostgresQueryRule {}
@@ -71,8 +71,7 @@ impl Rule<Logical> for TableFunctionToPostgresQueryRule {
             };
 
             Some(
-                LogicalPostgresQuery::new(
-                    logical_table_function.ctx(),
+                LogicalPostgresQuery::new(generic::PostgresQuery {
                     schema,
                     hostname,
                     port,
@@ -83,7 +82,8 @@ impl Rule<Logical> for TableFunctionToPostgresQueryRule {
                     ssl_mode,
                     ssl_root_cert,
                     ip_version,
-                )
+                    ctx: logical_table_function.ctx(),
+                })
                 .into(),
             )
         } else {


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

context: https://risingwave-labs.slack.com/archives/C03DFGV6L2W/p1784606433841089

This PR adds an `ip.version` option for Postgres connections used by `postgres_query`, Postgres CDC-derived `postgres_query`, and the shared Postgres sink/source connection config.
The connection helper resolves the configured host, filters addresses to `ipv4` or `ipv6` when requested, and passes the selected addresses through `hostaddr` while preserving the original host for TLS verification.
The setting is carried through frontend table-function binding, batch plan protobuf serialization, and the batch executor.

## Checklist

- [x] I have written necessary rustdoc comments.
- [x] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [x] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [x] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

Users can set `ip.version` to `ipv4` or `ipv6` to force Postgres-backed `postgres_query` connections to use only that IP address family.

</details>