### PR TITLE
test(backfill): flush slow UDF input before sink backfill

### DIFF
--- a/e2e_test/slow_tests/backfill/rate_limit/slow-udf.slt
+++ b/e2e_test/slow_tests/backfill/rate_limit/slow-udf.slt
@@ -2,7 +2,10 @@ statement ok
 create table t(v1 int);
 
 statement ok
-insert into t select 2 from generate_series(1, 1000000);
+insert into t select 2 from generate_series(1, 100000);
+
+statement ok
+flush;
 
 statement ok
 set backfill_rate_limit=1;


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

This PR fixes `e2e_test/slow_tests/backfill/rate_limit/slow-udf.slt` so the initial rows are flushed before creating the sink.

Without the flush, the sink can be created before the table has enough persisted data for snapshot backfill, so the backfill may finish too quickly and the later `DROP SINK` waits behind many chunks without the intended rate limit behavior. The test now inserts fewer rows and checkpoints them explicitly before enabling the slow backfill path.

## Checklist

- [ ] I have written necessary rustdoc comments.
- [x] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [x] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

Not user-facing.

</details>