### PR TITLE
fix(optimizer): stop propagating sync log store watermarks

### DIFF
--- a/src/frontend/src/optimizer/plan_node/stream_sync_log_store.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_sync_log_store.rs
@@ -27,6 +27,7 @@ use crate::optimizer::plan_node::{
     StreamPlanRef as PlanRef,
 };
 use crate::optimizer::plan_rewriter::PlanRewriter;
+use crate::optimizer::property::WatermarkColumns;
 use crate::stream_fragmenter::BuildFragmentGraphState;
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -45,7 +46,8 @@ impl StreamSyncLogStore {
             input.distribution().clone(),
             input.stream_kind(),
             input.emit_on_window_close(),
-            input.watermark_columns().clone(),
+            // Sync log store executors currently drop watermark messages.
+            WatermarkColumns::new(),
             input.columns_monotonicity().clone(),
         );
 
@@ -115,5 +117,22 @@ impl PlanRewriter<Stream> for EnsureSyncLogStoreFragmentRootRewriter {
         }
 
         plan.clone_root_with_inputs(&inputs)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::OptimizerContext;
+    use crate::optimizer::plan_node::{StreamNow, generic};
+
+    #[test]
+    fn does_not_propagate_watermark_columns() {
+        let input: PlanRef =
+            StreamNow::new(generic::Now::update_current(OptimizerContext::mock())).into();
+        assert!(!input.watermark_columns().is_empty());
+
+        let log_store = StreamSyncLogStore::new(input);
+        assert!(log_store.watermark_columns().is_empty());
     }
 }


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

`StreamSyncLogStore` currently advertises its input watermark columns, while both sync log store executor paths drop watermark messages. This inconsistent contract can make downstream planning rely on watermarks that will never arrive.

This PR aligns the optimizer property with the existing runtime behavior:

- clear the output watermark columns on `StreamSyncLogStore`;
- preserve its other stream properties, including `emit_on_window_close`;
- add a unit test using a watermark-producing input.

No executor, log-store format, or recovery behavior is changed.

## Checklist

- [ ] I have written necessary rustdoc comments.
- [x] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

None.

</details>

## Verification

- `RUSTUP_TOOLCHAIN=nightly-2026-06-11 cargo test -p risingwave_frontend does_not_propagate_watermark_columns --lib`
- `RUSTUP_TOOLCHAIN=nightly-2026-06-11 cargo fmt --all -- --check`
- `git diff --check`
