### PR TITLE
fix(meta): pin backfill snapshot version regardless of epoch watermark

### DIFF
--- a/src/meta/src/hummock/manager/tests.rs
+++ b/src/meta/src/hummock/manager/tests.rs
@@ -3698,8 +3698,7 @@ async fn test_schedule_group_split_with_normalize_disabled() {
     assert_eq!(ranges, vec![(64, 80), (65, 81)]);
 }
 
-#[tokio::test]
-async fn test_time_travel_vacuum_pins_snapshot_epoch() {
+mod time_travel_vacuum_test_utils {
     use risingwave_hummock_sdk::level::Levels;
     use risingwave_meta_model::hummock_sstable_info::SstableInfoV2Backend;
     use risingwave_meta_model::{
@@ -3707,9 +3706,11 @@ async fn test_time_travel_vacuum_pins_snapshot_epoch() {
         hummock_time_travel_version,
     };
     use sea_orm::ActiveValue::Set;
-    use sea_orm::{EntityTrait, PaginatorTrait, QueryOrder, QuerySelect};
+    use sea_orm::EntityTrait;
 
-    async fn insert_version(env: &MetaSrvEnv, id: u64, sst: Option<SstableInfo>) {
+    use super::*;
+
+    pub(super) async fn insert_version(env: &MetaSrvEnv, id: u64, sst: Option<SstableInfo>) {
         let mut version = HummockVersion::default();
         version.id = id.into();
         if let Some(sst) = sst {
@@ -3733,7 +3734,7 @@ async fn test_time_travel_vacuum_pins_snapshot_epoch() {
         .unwrap();
     }
 
-    async fn insert_sstable_info(env: &MetaSrvEnv, sst: &SstableInfo) {
+    pub(super) async fn insert_sstable_info(env: &MetaSrvEnv, sst: &SstableInfo) {
         hummock_sstable_info::Entity::insert(hummock_sstable_info::ActiveModel {
             sst_id: Set(sst.sst_id),
             object_id: Set(sst.object_id),
@@ -3744,7 +3745,7 @@ async fn test_time_travel_vacuum_pins_snapshot_epoch() {
         .unwrap();
     }
 
-    async fn insert_delta(env: &MetaSrvEnv, id: u64, prev_id: u64) {
+    pub(super) async fn insert_delta(env: &MetaSrvEnv, id: u64, prev_id: u64) {
         let mut delta = risingwave_hummock_sdk::version::HummockVersionDelta::default();
         delta.id = id.into();
         delta.prev_id = prev_id.into();
@@ -3757,7 +3758,12 @@ async fn test_time_travel_vacuum_pins_snapshot_epoch() {
         .unwrap();
     }
 
-    async fn insert_epoch_mapping(env: &MetaSrvEnv, table_id: TableId, epoch: u64, version: u64) {
+    pub(super) async fn insert_epoch_mapping(
+        env: &MetaSrvEnv,
+        table_id: TableId,
+        epoch: u64,
+        version: u64,
+    ) {
         hummock_epoch_to_version::Entity::insert(hummock_epoch_to_version::ActiveModel {
             epoch: Set(epoch.try_into().unwrap()),
             table_id: Set(i64::from(table_id.as_raw_id())),
@@ -3767,6 +3773,17 @@ async fn test_time_travel_vacuum_pins_snapshot_epoch() {
         .await
         .unwrap();
     }
+}
+
+#[tokio::test]
+async fn test_time_travel_vacuum_pins_snapshot_epoch() {
+    use risingwave_meta_model::{
+        hummock_epoch_to_version, hummock_sstable_info, hummock_time_travel_delta,
+        hummock_time_travel_version,
+    };
+    use sea_orm::{EntityTrait, PaginatorTrait, QueryOrder, QuerySelect};
+
+    use self::time_travel_vacuum_test_utils::*;
 
     let mut opts = MetaOpts::test(false);
     opts.time_travel_vacuum_max_version_count = Some(1);
@@ -3917,5 +3934,87 @@ async fn test_time_travel_vacuum_pins_snapshot_epoch() {
             .map(|object_id| object_id.as_raw().as_raw_id())
             .collect_vec(),
         vec![10]
+    );
+}
+
+/// A snapshot backfill that has just started pins an epoch still inside the retention window. Its
+/// epoch row is above the epoch watermark and thus never deleted, but the version that row resolves
+/// to is vacuumed on an independent threshold and must be pinned too.
+#[tokio::test]
+async fn test_time_travel_vacuum_pins_snapshot_epoch_above_watermark() {
+    use risingwave_meta_model::{
+        hummock_epoch_to_version, hummock_sstable_info, hummock_time_travel_version,
+    };
+    use sea_orm::{EntityTrait, PaginatorTrait, QueryOrder, QuerySelect};
+
+    use self::time_travel_vacuum_test_utils::*;
+
+    let (env, hummock_manager, _, _) =
+        setup_compute_env_with_meta_opts(80, MetaOpts::test(false)).await;
+    let table_id = TableId::new(1);
+    let pinned_sst = gen_sstable_info(10, vec![table_id.as_raw_id()], test_epoch(1));
+    insert_sstable_info(&env, &pinned_sst).await;
+    insert_version(&env, 1, Some(pinned_sst)).await;
+    insert_delta(&env, 2, 1).await;
+    insert_version(&env, 3, None).await;
+    insert_version(&env, 4, None).await;
+    // Drives the version watermark to 4, so versions below it are vacuumed.
+    insert_epoch_mapping(&env, table_id, 100, 4).await;
+    // The backfill snapshot: above the epoch watermark, but resolving to version 2.
+    insert_epoch_mapping(&env, table_id, 300, 2).await;
+
+    hummock_manager
+        .truncate_time_travel_metadata(200, HashMap::from([(table_id, HashSet::from([300]))]))
+        .await
+        .unwrap();
+
+    assert_eq!(
+        hummock_manager
+            .epoch_to_version(300, table_id)
+            .await
+            .unwrap()
+            .id
+            .as_raw_id(),
+        2
+    );
+    // Pinning the version must not hold back the rest of the vacuum: the epoch row below the
+    // watermark, and the version that is neither pinned nor the latest valid one, are still gone.
+    let epoch_rows = hummock_epoch_to_version::Entity::find()
+        .order_by_asc(hummock_epoch_to_version::Column::Epoch)
+        .all(&env.meta_store_ref().conn)
+        .await
+        .unwrap();
+    assert_eq!(
+        epoch_rows
+            .iter()
+            .map(|row| u64::try_from(row.epoch).unwrap())
+            .collect_vec(),
+        vec![300]
+    );
+    let version_ids: Vec<risingwave_meta_model::HummockVersionId> =
+        hummock_time_travel_version::Entity::find()
+            .select_only()
+            .column(hummock_time_travel_version::Column::VersionId)
+            .order_by_asc(hummock_time_travel_version::Column::VersionId)
+            .into_tuple()
+            .all(&env.meta_store_ref().conn)
+            .await
+            .unwrap();
+    assert_eq!(
+        version_ids.iter().map(|id| id.as_raw_id()).collect_vec(),
+        vec![1, 4]
+    );
+    assert_eq!(
+        hummock_sstable_info::Entity::find()
+            .count(&env.meta_store_ref().conn)
+            .await
+            .unwrap(),
+        1
+    );
+    assert!(
+        hummock_manager
+            .gc_manager
+            .try_take_may_delete_object_ids(1)
+            .is_none()
     );
 }

--- a/src/meta/src/hummock/manager/time_travel.rs
+++ b/src/meta/src/hummock/manager/time_travel.rs
@@ -83,9 +83,6 @@ impl HummockManager {
         let mut pinned_snapshot_version_ids = HashSet::new();
         for (table_id, pinned_epochs) in pinned_snapshot_epochs {
             for pinned_epoch in pinned_epochs {
-                if pinned_epoch >= epoch_watermark {
-                    continue;
-                }
                 let pinned_epoch_model =
                     risingwave_meta_model::Epoch::try_from(pinned_epoch).unwrap();
                 let epoch_to_version = hummock_epoch_to_version::Entity::find_by_id((
@@ -102,7 +99,12 @@ impl HummockManager {
                     );
                     continue;
                 };
-                pinned_epoch_rows.insert((epoch_to_version.epoch, epoch_to_version.table_id));
+                // Only rows below the epoch watermark are subject to deletion.
+                if pinned_epoch < epoch_watermark {
+                    pinned_epoch_rows.insert((epoch_to_version.epoch, epoch_to_version.table_id));
+                }
+                // The version is vacuumed by a threshold independent of the epoch watermark, so it
+                // must be pinned regardless of where the epoch sits.
                 pinned_snapshot_version_ids.insert(epoch_to_version.version_id);
             }
         }


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

`truncate_time_travel_metadata` skipped a pinned snapshot epoch outright when it sat at or above `epoch_watermark`:

```rust
if pinned_epoch >= epoch_watermark {
    continue;
}
```

That guard only answers *"will this epoch row be deleted?"*. Versions, deltas and SSTs are vacuumed on a **separate** threshold derived from `min(version_watermark, min_pinned_version_id)`, and the `continue` also skipped populating `pinned_snapshot_version_ids` — the only thing that protects them.

Because `epoch_watermark = now - time_travel_retention_ms`, a snapshot backfill's epoch is **always** above the watermark for the first `time_travel_retention_ms` of the job. The pin was therefore inert exactly when it was needed, and only became effective once the epoch had aged out — by which time the version could already be gone.

Failure mode when that happens:

- vacuum deletes the version an in-progress snapshot backfill still needs;
- the `StreamScan` actor fails with `Time-travel version expired: table <id>, epoch <E>`;
- the snapshot epoch is persisted in the fragment's stream node, so every recovery replays the same read;
- the database enters a **non-self-healing recovery loop** and the job never leaves `Creating`.

Observed on [build 98540](https://buildkite.com/risingwavelabs/pull-request/builds/98540#019f83fa-2ff5-4b94-a681-cf1cfc99b075) (`MADSIM_TEST_SEED=3`, `recovery::background_ddl::test_background_mv_barrier_recovery`): 4582 recovery cycles and 23330 identical errors over 2h of simulated time, all on the same epoch, until `WAIT;` hit the 2h RPC timeout. Meta never panicked — it looked like healthy recovery throughout.

### Fix

Always resolve the pinned epoch to its version and pin it. Keep the watermark check only for the epoch-row exemption, which is the one thing it was ever valid for.

### Why this does not undo #26326

The pinned set is one replay version plus the deltas up to the snapshot — fixed in size, and independent of how long the backfill runs. Deletion of `hummock_epoch_to_version` rows is untouched (`pinned_epoch_rows` is still gated by the watermark), so the unbounded growth of #26269 does not come back. This only changes *when* the pin takes effect, not how much it retains: after the epoch ages past the watermark the existing code already pins the same set.

### Regression scope

Introduced by #26326, which replaced the blanket "pause vacuum while any job is creating" guard from #24602 with fine-grained pinning. That direction is right — the blanket pause caused #26269 — the guard was just placed one line too high. Present on `main` and `release-3.0`.

The existing unit test missed it because every pinned epoch that resolved to a real version was below the watermark; the above-watermark entries were on a table with no epoch mapping, so they returned early without consequence. The new test covers that case.

## Checklist

- [x] I have written necessary rustdoc comments.
- [x] I have added necessary unit tests and integration tests.
- [ ] I have added test labels as necessary.
- [ ] I have added fuzzing tests or opened an issue to track them.
- [ ] My PR contains breaking changes.
- [ ] My PR changes performance-critical code, so I will run (micro) benchmarks and present the results.
- [x] I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into.

## Documentation

- [ ] My PR needs documentation updates.
