### PR TITLE
fix(stream): propagate sync log store watermarks

### DIFF
--- a/src/stream/src/executor/dispatch/dispatch_sync_log_store.rs
+++ b/src/stream/src/executor/dispatch/dispatch_sync_log_store.rs
@@ -227,10 +227,12 @@ impl ConsumerFuture {
                         pending().await
                     }
 
-                    let chunk = read_future
-                        .next_chunk(progress, read_state, buffer, metrics)
+                    let message = read_future
+                        .next_message(progress, read_state, buffer, metrics)
                         .await?;
-                    metrics.total_read_count.inc_by(chunk.cardinality() as _);
+                    if let Message::Chunk(chunk) = &message {
+                        metrics.total_read_count.inc_by(chunk.cardinality() as _);
+                    }
 
                     let clean_state_reached =
                         read_future.mark_clean_state(clean_state, buffer, metrics);
@@ -238,7 +240,7 @@ impl ConsumerFuture {
                         self.as_mut().project_replace(ConsumerFuture::PlaceHolder),
                         ConsumerFutureProjReplace::ReadingChunk { inner } => inner
                     );
-                    self.set(Self::dispatch(inner, Message::Chunk(chunk)));
+                    self.set(Self::dispatch(inner, message));
 
                     if clean_state_reached {
                         return Ok(ConsumerFutureEvent::CleanStateReached);
@@ -466,8 +468,8 @@ impl<S: StateStore> StreamConsumer for SyncLogStoreDispatchExecutor<S> {
                                         consumer_future_state.as_mut().push_barrier(barrier);
                                     }
                                 }
-                                // TODO: handle upstream watermark in sync log store dispatch.
-                                Message::Watermark(_watermark) => {
+                                Message::Watermark(watermark) => {
+                                    buffer.add_watermark(write_state.epoch().curr, watermark);
                                     write_future_state =
                                         WriteFuture::receive_from_upstream(stream, write_state);
                                 }
@@ -642,12 +644,22 @@ mod tests {
         assert_eq!(barriers[0].epoch.curr, test_epoch(1));
 
         input_tx.push_chunk(chunk_1.clone());
+        input_tx.push_int64_watermark(0, 7);
         input_tx.push_chunk(chunk_2.clone());
         let msg = timeout(Duration::from_secs(1), down_rx.recv())
             .await
             .unwrap()
             .expect("downstream should receive chunk(1)");
         assert_stream_chunk_eq!(msg.as_chunk().unwrap(), chunk_1);
+
+        let msg = timeout(Duration::from_secs(1), down_rx.recv())
+            .await
+            .unwrap()
+            .expect("downstream should receive watermark");
+        assert_eq!(
+            msg.as_watermark().unwrap(),
+            &Watermark::new(0, DataType::Int64, 7_i64.into())
+        );
 
         let msg = timeout(Duration::from_secs(1), down_rx.recv())
             .await

--- a/src/stream/src/executor/mod.rs
+++ b/src/stream/src/executor/mod.rs
@@ -40,6 +40,7 @@ use risingwave_common::types::{DataType, Datum, DefaultOrd, ScalarImpl};
 use risingwave_common::util::epoch::{Epoch, EpochPair};
 use risingwave_common::util::tracing::TracingContext;
 use risingwave_common::util::value_encoding::{DatumFromProtoExt, DatumToProtoExt};
+use risingwave_common_estimate_size::EstimateSize;
 use risingwave_connector::source::SplitImpl;
 use risingwave_expr::expr::NonStrictExpression;
 use risingwave_pb::data::PbEpoch;
@@ -1229,9 +1230,10 @@ impl Barrier {
     }
 }
 
-#[derive(Debug, PartialEq, Eq, Clone)]
+#[derive(Debug, PartialEq, Eq, Clone, EstimateSize)]
 pub struct Watermark {
     pub col_idx: usize,
+    #[estimate_size(ignore)]
     pub data_type: DataType,
     pub val: ScalarImpl,
 }

--- a/src/stream/src/executor/sync_kv_log_store.rs
+++ b/src/stream/src/executor/sync_kv_log_store.rs
@@ -60,7 +60,7 @@
 
 use std::collections::VecDeque;
 use std::future::pending;
-use std::mem::{replace, size_of};
+use std::mem::replace;
 use std::pin::Pin;
 
 use anyhow::anyhow;
@@ -1134,19 +1134,10 @@ impl<S: StateStore> SyncedKvLogStoreExecutor<S> {
     }
 }
 
+#[derive(EstimateSize)]
 enum SyncedLogStoreBufferItem {
     LogStore(LogStoreBufferItem),
     Watermark(Watermark),
-}
-
-impl SyncedLogStoreBufferItem {
-    fn estimated_size(&self) -> usize {
-        size_of::<Self>()
-            + match self {
-                Self::LogStore(item) => item.estimated_heap_size(),
-                Self::Watermark(watermark) => watermark.val.estimated_heap_size(),
-            }
-    }
 }
 
 pub(crate) struct SyncedLogStoreBuffer {
@@ -1651,9 +1642,15 @@ mod tests {
             U+ 10  10",
         );
 
+        let chunk_3 = StreamChunk::from_pretty(
+            "   I   T
+            +  11  12",
+        );
+
         tx.push_chunk(chunk_1.clone());
-        tx.push_int64_watermark(0, 7);
         tx.push_chunk(chunk_2.clone());
+        tx.push_int64_watermark(0, 7);
+        tx.push_chunk(chunk_3.clone());
 
         tx.push_barrier(test_epoch(2), false);
 
@@ -1670,7 +1667,20 @@ mod tests {
 
         match stream.next().await {
             Some(Ok(Message::Chunk(actual))) => {
-                assert_stream_chunk_eq!(actual, chunk_1);
+                let expected = StreamChunk::from_pretty(
+                    "   I   T
+                    +   5  10
+                    +   6  10
+                    +   8  10
+                    +   9  10
+                    +  10  11
+                    -   5  10
+                    -   6  10
+                    -   8  10
+                    U- 10  11
+                    U+ 10  10",
+                );
+                assert_stream_chunk_eq!(actual, expected);
             }
             other => panic!("Expected a chunk message, got {:?}", other),
         }
@@ -1684,7 +1694,7 @@ mod tests {
 
         match stream.next().await {
             Some(Ok(Message::Chunk(actual))) => {
-                assert_stream_chunk_eq!(actual, chunk_2);
+                assert_stream_chunk_eq!(actual, chunk_3);
             }
             other => panic!("Expected a chunk message, got {:?}", other),
         }

--- a/src/stream/src/executor/sync_kv_log_store.rs
+++ b/src/stream/src/executor/sync_kv_log_store.rs
@@ -56,12 +56,11 @@
 //! TODO(kwannoel):
 //! - [] Add dedicated metrics for sync log store, namespace according to the upstream.
 //! - [] Add tests
-//! - [] Handle watermark r/w
 //! - [] Handle paused stream
 
 use std::collections::VecDeque;
 use std::future::pending;
-use std::mem::replace;
+use std::mem::{replace, size_of};
 use std::pin::Pin;
 
 use anyhow::anyhow;
@@ -101,7 +100,7 @@ use crate::common::log_store_impl::kv_log_store::{
 use crate::executor::prelude::*;
 use crate::executor::sync_kv_log_store::metrics::SyncedKvLogStoreMetrics;
 use crate::executor::{
-    Barrier, BoxedMessageStream, Message, StreamExecutorError, StreamExecutorResult,
+    Barrier, BoxedMessageStream, Message, StreamExecutorError, StreamExecutorResult, Watermark,
 };
 
 pub mod metrics {
@@ -806,7 +805,7 @@ impl<S: StateStore> SyncedKvLogStoreExecutor<S> {
                         pending().await
                     } else {
                         read_future_state
-                            .next_chunk(
+                            .next_message(
                                 &mut progress,
                                 &read_state,
                                 &mut buffer,
@@ -874,8 +873,8 @@ impl<S: StateStore> SyncedKvLogStoreExecutor<S> {
                                 seq_id = new_seq_id;
                                 write_future_state = next_write_future;
                             }
-                            // TODO: handle upstream watermark in sync log store.
-                            Message::Watermark(_watermark) => {
+                            Message::Watermark(watermark) => {
+                                buffer.add_watermark(write_state.epoch().curr, watermark);
                                 write_future_state =
                                     WriteFuture::receive_from_upstream(stream, write_state);
                             }
@@ -906,13 +905,15 @@ impl<S: StateStore> SyncedKvLogStoreExecutor<S> {
                             *sleep_future = None;
                         }
                     }
-                    let chunk = result?;
-                    self.logstore_context
-                        .metrics
-                        .total_read_count
-                        .inc_by(chunk.cardinality() as _);
+                    let message = result?;
+                    if let Message::Chunk(chunk) = &message {
+                        self.logstore_context
+                            .metrics
+                            .total_read_count
+                            .inc_by(chunk.cardinality() as _);
+                    }
 
-                    yield Message::Chunk(chunk);
+                    yield message;
                 }
             }
         }
@@ -948,13 +949,13 @@ impl<S: StateStoreRead> ReadFuture<S> {
         }
     }
 
-    pub(crate) async fn next_chunk(
+    pub(crate) async fn next_message(
         &mut self,
         progress: &mut LogStoreVnodeProgress,
         read_state: &LogStoreReadState<S>,
         buffer: &mut SyncedLogStoreBuffer,
         metrics: &SyncedKvLogStoreMetrics,
-    ) -> StreamExecutorResult<StreamChunk> {
+    ) -> StreamExecutorResult<Message> {
         match self {
             ReadFuture::ReadingPersistedStream(stream) => {
                 while let Some((epoch, item)) = stream.try_next().await? {
@@ -971,7 +972,7 @@ impl<S: StateStoreRead> ReadFuture<S> {
                         } => {
                             tracing::trace!("read logstore chunk of size: {}", chunk.cardinality());
                             progress.apply_per_vnode(epoch, chunk_progress);
-                            return Ok(chunk);
+                            return Ok(Message::Chunk(chunk));
                         }
                     }
                 }
@@ -989,13 +990,13 @@ impl<S: StateStoreRead> ReadFuture<S> {
                     return pending().await;
                 };
                 match item {
-                    LogStoreBufferItem::StreamChunk {
+                    SyncedLogStoreBufferItem::LogStore(LogStoreBufferItem::StreamChunk {
                         chunk,
                         start_seq_id,
                         end_seq_id,
                         flushed,
                         ..
-                    } => {
+                    }) => {
                         metrics.buffer_read_count.inc_by(chunk.cardinality() as _);
                         tracing::trace!(
                             start_seq_id,
@@ -1009,14 +1010,14 @@ impl<S: StateStoreRead> ReadFuture<S> {
                             item_epoch,
                             Some(end_seq_id),
                         );
-                        return Ok(chunk);
+                        return Ok(Message::Chunk(chunk));
                     }
-                    LogStoreBufferItem::Flushed {
+                    SyncedLogStoreBufferItem::LogStore(LogStoreBufferItem::Flushed {
                         vnode_bitmap,
                         start_seq_id,
                         end_seq_id,
                         chunk_id,
-                    } => {
+                    }) => {
                         tracing::trace!(start_seq_id, end_seq_id, chunk_id, "read flushed chunk");
                         let read_metrics = metrics.flushed_buffer_read_metrics.clone();
                         let future = read_state
@@ -1032,10 +1033,13 @@ impl<S: StateStoreRead> ReadFuture<S> {
                         *self = ReadFuture::ReadingFlushedChunk { future, end_seq_id };
                         break;
                     }
-                    LogStoreBufferItem::Barrier { .. } => {
+                    SyncedLogStoreBufferItem::LogStore(LogStoreBufferItem::Barrier { .. }) => {
                         tracing::trace!(item_epoch, "read buffer barrier");
                         progress.apply_aligned(read_state.vnodes().clone(), item_epoch, None);
                         continue;
+                    }
+                    SyncedLogStoreBufferItem::Watermark(watermark) => {
+                        return Ok(Message::Watermark(watermark));
                     }
                 }
             },
@@ -1056,7 +1060,7 @@ impl<S: StateStoreRead> ReadFuture<S> {
             chunk.cardinality()
         );
         *self = ReadFuture::Idle;
-        Ok(chunk)
+        Ok(Message::Chunk(chunk))
     }
 }
 
@@ -1081,13 +1085,13 @@ impl<S: StateStore> SyncedKvLogStoreExecutor<S> {
         if barrier.is_checkpoint() {
             for (epoch, item) in buffer.buffer.iter_mut().rev() {
                 match item {
-                    LogStoreBufferItem::StreamChunk {
+                    SyncedLogStoreBufferItem::LogStore(LogStoreBufferItem::StreamChunk {
                         chunk,
                         start_seq_id,
                         end_seq_id,
                         flushed,
                         ..
-                    } => {
+                    }) => {
                         if !*flushed {
                             writer.write_chunk(chunk, *epoch, *start_seq_id, *end_seq_id)?;
                             *flushed = true;
@@ -1095,7 +1099,10 @@ impl<S: StateStore> SyncedKvLogStoreExecutor<S> {
                             break;
                         }
                     }
-                    LogStoreBufferItem::Flushed { .. } | LogStoreBufferItem::Barrier { .. } => {}
+                    SyncedLogStoreBufferItem::LogStore(
+                        LogStoreBufferItem::Flushed { .. } | LogStoreBufferItem::Barrier { .. },
+                    )
+                    | SyncedLogStoreBufferItem::Watermark(_) => {}
                 }
             }
         }
@@ -1113,12 +1120,12 @@ impl<S: StateStore> SyncedKvLogStoreExecutor<S> {
         // Add to buffer
         buffer.buffer.push_back((
             epoch,
-            LogStoreBufferItem::Barrier {
+            SyncedLogStoreBufferItem::LogStore(LogStoreBufferItem::Barrier {
                 is_checkpoint: barrier.is_checkpoint(),
                 next_epoch: barrier.epoch.curr,
                 schema_change: None,
                 is_stop: false,
-            },
+            }),
         ));
         buffer.next_chunk_id = 0;
         buffer.update_buffer_metrics();
@@ -1127,8 +1134,23 @@ impl<S: StateStore> SyncedKvLogStoreExecutor<S> {
     }
 }
 
+enum SyncedLogStoreBufferItem {
+    LogStore(LogStoreBufferItem),
+    Watermark(Watermark),
+}
+
+impl SyncedLogStoreBufferItem {
+    fn estimated_size(&self) -> usize {
+        size_of::<Self>()
+            + match self {
+                Self::LogStore(item) => item.estimated_heap_size(),
+                Self::Watermark(watermark) => watermark.val.estimated_heap_size(),
+            }
+    }
+}
+
 pub(crate) struct SyncedLogStoreBuffer {
-    buffer: VecDeque<(u64, LogStoreBufferItem)>,
+    buffer: VecDeque<(u64, SyncedLogStoreBufferItem)>,
     current_size: usize,
     max_size: usize,
     max_chunk_size: usize,
@@ -1202,12 +1224,12 @@ impl SyncedLogStoreBuffer {
 
         if let Some((
             item_epoch,
-            LogStoreBufferItem::Flushed {
+            SyncedLogStoreBufferItem::LogStore(LogStoreBufferItem::Flushed {
                 start_seq_id: prev_start_seq_id,
                 end_seq_id: prev_end_seq_id,
                 vnode_bitmap,
                 ..
-            },
+            }),
         )) = self.buffer.back_mut()
             && let flushed_chunk_size = (*prev_end_seq_id - *prev_start_seq_id + 1) as usize
             && let projected_flushed_chunk_size = flushed_chunk_size + new_chunk_size
@@ -1230,12 +1252,12 @@ impl SyncedLogStoreBuffer {
             self.next_chunk_id += 1;
             self.buffer.push_back((
                 epoch,
-                LogStoreBufferItem::Flushed {
+                SyncedLogStoreBufferItem::LogStore(LogStoreBufferItem::Flushed {
                     start_seq_id,
                     end_seq_id,
                     vnode_bitmap: new_vnode_bitmap,
                     chunk_id,
-                },
+                }),
             ));
             self.flushed_count += 1;
             tracing::trace!(
@@ -1258,24 +1280,35 @@ impl SyncedLogStoreBuffer {
         self.current_size += chunk.cardinality();
         self.buffer.push_back((
             epoch,
-            LogStoreBufferItem::StreamChunk {
+            SyncedLogStoreBufferItem::LogStore(LogStoreBufferItem::StreamChunk {
                 chunk,
                 start_seq_id,
                 end_seq_id,
                 flushed: false,
                 chunk_id,
-            },
+            }),
         ));
         self.update_buffer_metrics();
     }
 
-    fn pop_front(&mut self) -> Option<(u64, LogStoreBufferItem)> {
+    pub(crate) fn add_watermark(&mut self, epoch: u64, watermark: Watermark) {
+        self.buffer
+            .push_back((epoch, SyncedLogStoreBufferItem::Watermark(watermark)));
+        self.update_buffer_metrics();
+    }
+
+    fn pop_front(&mut self) -> Option<(u64, SyncedLogStoreBufferItem)> {
         let item = self.buffer.pop_front();
         match &item {
-            Some((_, LogStoreBufferItem::Flushed { .. })) => {
+            Some((_, SyncedLogStoreBufferItem::LogStore(LogStoreBufferItem::Flushed { .. }))) => {
                 self.flushed_count -= 1;
             }
-            Some((_, LogStoreBufferItem::StreamChunk { chunk, .. })) => {
+            Some((
+                _,
+                SyncedLogStoreBufferItem::LogStore(LogStoreBufferItem::StreamChunk {
+                    chunk, ..
+                }),
+            )) => {
                 self.current_size -= chunk.cardinality();
             }
             _ => {}
@@ -1290,19 +1323,23 @@ impl SyncedLogStoreBuffer {
         let mut memory_bytes = 0;
         for (_, item) in &self.buffer {
             match item {
-                LogStoreBufferItem::StreamChunk { chunk, .. } => {
+                SyncedLogStoreBufferItem::LogStore(LogStoreBufferItem::StreamChunk {
+                    chunk,
+                    ..
+                }) => {
                     row_count += chunk.cardinality();
                 }
-                LogStoreBufferItem::Flushed {
+                SyncedLogStoreBufferItem::LogStore(LogStoreBufferItem::Flushed {
                     start_seq_id,
                     end_seq_id,
                     ..
-                } => {
+                }) => {
                     row_count += (end_seq_id - start_seq_id) as usize;
                 }
-                LogStoreBufferItem::Barrier { .. } => {
+                SyncedLogStoreBufferItem::LogStore(LogStoreBufferItem::Barrier { .. }) => {
                     epoch_count += 1;
                 }
+                SyncedLogStoreBufferItem::Watermark(_) => {}
             }
             memory_bytes += item.estimated_size();
         }
@@ -1412,6 +1449,7 @@ mod tests {
         );
 
         tx.push_chunk(chunk_1.clone());
+        tx.push_int64_watermark(0, 7);
         tx.push_chunk(chunk_2.clone());
 
         let mut stream = log_store_executor.execute();
@@ -1428,6 +1466,13 @@ mod tests {
                 assert_stream_chunk_eq!(chunk, chunk_1);
             }
             other => panic!("Expected a chunk message, got {:?}", other),
+        }
+
+        match stream.next().await {
+            Some(Ok(Message::Watermark(watermark))) => {
+                assert_eq!(watermark, Watermark::new(0, DataType::Int64, 7_i64.into()));
+            }
+            other => panic!("Expected a watermark message, got {:?}", other),
         }
 
         match stream.next().await {
@@ -1450,7 +1495,7 @@ mod tests {
     // test barrier persisted read
     //
     // sequence of events (earliest -> latest):
-    // barrier(1) -> chunk(1) -> chunk(2) -> poll(3) items -> barrier(2) -> poll(1) item
+    // barrier(1) -> chunk(1) -> watermark -> chunk(2) -> poll(4) items -> barrier(2)
     // * poll just means we read from the executor stream.
     #[tokio::test]
     async fn test_barrier_persisted_read() {
@@ -1507,6 +1552,7 @@ mod tests {
         );
 
         tx.push_chunk(chunk_1.clone());
+        tx.push_int64_watermark(0, 7);
         tx.push_chunk(chunk_2.clone());
 
         tx.push_barrier(test_epoch(2), false);
@@ -1525,6 +1571,13 @@ mod tests {
                 assert_stream_chunk_eq!(chunk, chunk_1);
             }
             other => panic!("Expected a chunk message, got {:?}", other),
+        }
+
+        match stream.next().await {
+            Some(Ok(Message::Watermark(watermark))) => {
+                assert_eq!(watermark, Watermark::new(0, DataType::Int64, 7_i64.into()));
+            }
+            other => panic!("Expected a watermark message, got {:?}", other),
         }
 
         match stream.next().await {
@@ -1599,6 +1652,7 @@ mod tests {
         );
 
         tx.push_chunk(chunk_1.clone());
+        tx.push_int64_watermark(0, 7);
         tx.push_chunk(chunk_2.clone());
 
         tx.push_barrier(test_epoch(2), false);
@@ -1616,20 +1670,21 @@ mod tests {
 
         match stream.next().await {
             Some(Ok(Message::Chunk(actual))) => {
-                let expected = StreamChunk::from_pretty(
-                    "   I   T
-                    +   5  10
-                    +   6  10
-                    +   8  10
-                    +   9  10
-                    +  10  11
-                    -   5  10
-                    -   6  10
-                    -   8  10
-                    U- 10  11
-                    U+ 10  10",
-                );
-                assert_stream_chunk_eq!(actual, expected);
+                assert_stream_chunk_eq!(actual, chunk_1);
+            }
+            other => panic!("Expected a chunk message, got {:?}", other),
+        }
+
+        match stream.next().await {
+            Some(Ok(Message::Watermark(watermark))) => {
+                assert_eq!(watermark, Watermark::new(0, DataType::Int64, 7_i64.into()));
+            }
+            other => panic!("Expected a watermark message, got {:?}", other),
+        }
+
+        match stream.next().await {
+            Some(Ok(Message::Chunk(actual))) => {
+                assert_stream_chunk_eq!(actual, chunk_2);
             }
             other => panic!("Expected a chunk message, got {:?}", other),
         }


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

Follow-up to #26370 and the executor-side approach suggested in https://github.com/risingwavelabs/risingwave/pull/26370#issuecomment-5042268402.

- Buffer watermarks as in-memory-only sync log store items and emit them in FIFO order with buffered or flushed chunks.
- Support both the regular sync log store executor and the colocated dispatch path. The aligned paths continue to propagate live watermarks directly.
- Do not persist or replay watermarks, so recovery discards them and the persisted log-store format is unchanged.
- Prevent flushed chunk placeholders from being coalesced across a watermark.

## Tests

- `RUSTUP_TOOLCHAIN=nightly-2026-06-11 cargo test -p risingwave_stream sync_kv_log_store --lib`
- `RUSTUP_TOOLCHAIN=nightly-2026-06-11 cargo test -p risingwave_stream barrier_chunk_ordering_in_dispatch --lib`
- `RUSTUP_TOOLCHAIN=nightly-2026-06-11 cargo clippy -p risingwave_stream --lib -- -D warnings`
- `RUSTUP_TOOLCHAIN=nightly-2026-06-11 cargo fmt --all -- --check`
- `git diff --check`

## Checklist

- [ ] I have written necessary rustdoc comments.
- [x] I have added necessary unit tests and integration tests.
- [x] I have added test labels as necessary.
- [ ] I have added fuzzing tests or opened an issue to track them.
- [ ] My PR contains breaking changes.
- [ ] My PR changes performance-critical code, so I will run (micro) benchmarks and present the results.
- [ ] I have checked the Release Timeline and Currently Supported Versions to determine which release branches I need to cherry-pick this PR into.

## Documentation

- [ ] My PR needs documentation updates.

<details>
<summary><b>Release note</b></summary>

Sync log store now propagates live watermarks downstream while retaining its decoupled buffering behavior. Watermarks are not persisted across recovery.

</details>