### PR TITLE
chore(frontend): remove legacy gap fill constructors

### DIFF
--- a/src/frontend/src/optimizer/plan_node/stream_eowc_gap_fill.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_eowc_gap_fill.rs
@@ -86,23 +86,6 @@ impl StreamEowcGapFill {
         Self { base, core }
     }
 
-    // Legacy constructor for backward compatibility
-    pub fn new_with_args(
-        input: PlanRef<Stream>,
-        time_col: InputRef,
-        interval: ExprImpl,
-        fill_strategies: Vec<BoundFillStrategy>,
-    ) -> Self {
-        let core = generic::GapFill {
-            input,
-            time_col,
-            interval,
-            fill_strategies,
-            partition_by_cols: vec![],
-        };
-        Self::new(core)
-    }
-
     pub fn time_col(&self) -> &InputRef {
         &self.core.time_col
     }

--- a/src/frontend/src/optimizer/plan_node/stream_gap_fill.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_gap_fill.rs
@@ -78,23 +78,6 @@ impl StreamGapFill {
         Self { base, core }
     }
 
-    // Legacy constructor for backward compatibility
-    pub fn new_with_args(
-        input: PlanRef<Stream>,
-        time_col: InputRef,
-        interval: ExprImpl,
-        fill_strategies: Vec<BoundFillStrategy>,
-    ) -> Self {
-        let core = generic::GapFill {
-            input,
-            time_col,
-            interval,
-            fill_strategies,
-            partition_by_cols: vec![],
-        };
-        Self::new(core)
-    }
-
     pub fn time_col(&self) -> &InputRef {
         &self.core.time_col
     }


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

- Remove the unused `new_with_args` constructors from `StreamGapFill` and `StreamEowcGapFill`.
- Both planner paths already construct `generic::GapFill` and call `new(core)` directly, so these compatibility shims no longer have callers.
- This is a dead-code cleanup with no planner or runtime behavior change.

## Checklist

- [x] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [x] <!-- OPTIONAL --> I have added test labels as necessary.
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them.
- [ ] <!-- OPTIONAL --> My PR contains breaking changes.
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results.
- [ ] <!-- OPTIONAL --> I have checked the Release Timeline and Currently Supported Versions to determine which release branches I need to cherry-pick this PR into.

## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates.

<details>
<summary><b>Release note</b></summary>

None. This removes unused internal constructors without changing behavior.

</details>
