### PR TITLE
fix(meta): preserve retained time travel versions during vacuum

### DIFF
--- a/src/meta/src/hummock/manager/tests.rs
+++ b/src/meta/src/hummock/manager/tests.rs
@@ -3699,6 +3699,138 @@ async fn test_schedule_group_split_with_normalize_disabled() {
 }
 
 #[tokio::test]
+async fn test_time_travel_vacuum_with_cross_database_epoch_order() {
+    use risingwave_meta_model::{hummock_epoch_to_version, hummock_time_travel_version};
+    use sea_orm::ActiveValue::Set;
+    use sea_orm::{EntityTrait, PaginatorTrait};
+
+    let (env, hummock_manager, _, _) = setup_compute_env(80).await;
+    let table_a = TableId::new(1);
+    let table_b = TableId::new(2);
+
+    let mut version_10 = HummockVersion::default();
+    version_10.id = 10.into();
+    version_10.state_table_info =
+        HummockVersionStateTableInfo::from_protobuf_owned(HashMap::from([
+            (
+                table_a,
+                StateTableInfo {
+                    committed_epoch: 300,
+                    compaction_group_id: 1.into(),
+                },
+            ),
+            (
+                table_b,
+                StateTableInfo {
+                    committed_epoch: 100,
+                    compaction_group_id: 1.into(),
+                },
+            ),
+        ]));
+    let mut version_11 = version_10.clone();
+    version_11.id = 11.into();
+    version_11.state_table_info =
+        HummockVersionStateTableInfo::from_protobuf_owned(HashMap::from([
+            (
+                table_a,
+                StateTableInfo {
+                    committed_epoch: 300,
+                    compaction_group_id: 1.into(),
+                },
+            ),
+            (
+                table_b,
+                StateTableInfo {
+                    committed_epoch: 200,
+                    compaction_group_id: 1.into(),
+                },
+            ),
+        ]));
+    for version in [&version_10, &version_11] {
+        hummock_time_travel_version::Entity::insert(hummock_time_travel_version::ActiveModel {
+            version_id: Set(version.id),
+            version: Set((&version.to_protobuf()).into()),
+        })
+        .exec(&env.meta_store_ref().conn)
+        .await
+        .unwrap();
+    }
+    for (table_id, epoch, version_id) in [
+        (table_b, 100_u64, 10_u64),
+        (table_b, 200, 11),
+        (table_a, 300, 10),
+    ] {
+        hummock_epoch_to_version::Entity::insert(hummock_epoch_to_version::ActiveModel {
+            epoch: Set(epoch.try_into().unwrap()),
+            table_id: Set(i64::from(table_id.as_raw_id())),
+            version_id: Set(version_id.into()),
+        })
+        .exec(&env.meta_store_ref().conn)
+        .await
+        .unwrap();
+    }
+
+    hummock_manager
+        .truncate_time_travel_metadata(50, HashMap::new())
+        .await
+        .unwrap();
+    assert_eq!(
+        hummock_epoch_to_version::Entity::find()
+            .count(&env.meta_store_ref().conn)
+            .await
+            .unwrap(),
+        3
+    );
+    assert_eq!(
+        hummock_time_travel_version::Entity::find()
+            .count(&env.meta_store_ref().conn)
+            .await
+            .unwrap(),
+        2
+    );
+
+    hummock_manager
+        .truncate_time_travel_metadata(250, HashMap::new())
+        .await
+        .unwrap();
+
+    assert_eq!(
+        hummock_time_travel_version::Entity::find()
+            .count(&env.meta_store_ref().conn)
+            .await
+            .unwrap(),
+        2
+    );
+    assert_eq!(
+        hummock_manager
+            .epoch_to_version(300, table_a)
+            .await
+            .unwrap()
+            .id,
+        version_10.id
+    );
+
+    hummock_manager
+        .truncate_time_travel_metadata(350, HashMap::new())
+        .await
+        .unwrap();
+    assert_eq!(
+        hummock_time_travel_version::Entity::find()
+            .count(&env.meta_store_ref().conn)
+            .await
+            .unwrap(),
+        1
+    );
+    assert!(
+        hummock_time_travel_version::Entity::find_by_id(version_11.id)
+            .one(&env.meta_store_ref().conn)
+            .await
+            .unwrap()
+            .is_some()
+    );
+}
+
+#[tokio::test]
 async fn test_time_travel_vacuum_pins_snapshot_epoch() {
     use risingwave_hummock_sdk::level::Levels;
     use risingwave_meta_model::hummock_sstable_info::SstableInfoV2Backend;
@@ -3821,7 +3953,7 @@ async fn test_time_travel_vacuum_pins_snapshot_epoch() {
             .unwrap();
     assert_eq!(
         version_ids.iter().map(|id| id.as_raw_id()).collect_vec(),
-        vec![1, 4, 5]
+        vec![1, 5]
     );
     let delta_ids: Vec<risingwave_meta_model::HummockVersionId> =
         hummock_time_travel_delta::Entity::find()
@@ -3892,7 +4024,7 @@ async fn test_time_travel_vacuum_pins_snapshot_epoch() {
             .count(&env.meta_store_ref().conn)
             .await
             .unwrap(),
-        2
+        1
     );
     assert_eq!(
         hummock_time_travel_delta::Entity::find()

--- a/src/meta/src/hummock/manager/time_travel.rs
+++ b/src/meta/src/hummock/manager/time_travel.rs
@@ -79,6 +79,19 @@ impl HummockManager {
 
         let epoch_watermark_model =
             risingwave_meta_model::Epoch::try_from(epoch_watermark).unwrap();
+        let has_expired_epoch = hummock_epoch_to_version::Entity::find()
+            .filter(hummock_epoch_to_version::Column::Epoch.lt(epoch_watermark_model))
+            .select_only()
+            .column(hummock_epoch_to_version::Column::VersionId)
+            .into_tuple::<HummockVersionId>()
+            .one(&txn)
+            .await?
+            .is_some();
+        if !has_expired_epoch {
+            txn.commit().await?;
+            return Ok(());
+        }
+
         let mut pinned_epoch_rows = HashSet::new();
         let mut pinned_snapshot_version_ids = HashSet::new();
         for (table_id, pinned_epochs) in pinned_snapshot_epochs {
@@ -131,19 +144,22 @@ impl HummockManager {
             }
         }
 
+        // Version ids follow global commit order, while epochs are only monotonic per table.
+        // Use the earliest version needed by any retained mapping as the watermark so its replay
+        // metadata cannot be truncated. If no mapping is retained, only version pins and vacuum
+        // throttling need to constrain the watermark.
         let version_watermark = hummock_epoch_to_version::Entity::find()
-            .filter(hummock_epoch_to_version::Column::Epoch.lt(epoch_watermark_model))
-            .order_by_desc(hummock_epoch_to_version::Column::Epoch)
+            .filter(hummock_epoch_to_version::Column::Epoch.gte(epoch_watermark_model))
+            .select_only()
+            .column(hummock_epoch_to_version::Column::VersionId)
             .order_by_asc(hummock_epoch_to_version::Column::VersionId)
+            .into_tuple::<HummockVersionId>()
             .one(&txn)
             .await?;
-        let Some(version_watermark) = version_watermark else {
-            txn.commit().await?;
-            return Ok(());
-        };
         // metadata BELOW watermark_version_id will be truncated.
-        let mut watermark_version_id =
-            std::cmp::min(version_watermark.version_id, min_pinned_version_id);
+        let mut watermark_version_id = version_watermark.map_or(min_pinned_version_id, |id| {
+            std::cmp::min(id, min_pinned_version_id)
+        });
         if let Some(max_version_count) = self.env.opts.time_travel_vacuum_max_version_count {
             let mut query = hummock_time_travel_version::Entity::find()
                 .select_only()

--- a/src/tests/simulation/tests/integration_tests/recovery/mod.rs
+++ b/src/tests/simulation/tests/integration_tests/recovery/mod.rs
@@ -21,3 +21,4 @@ mod event_log;
 mod locality_backfill;
 mod nexmark_recovery;
 mod serving_mapping;
+mod time_travel;

--- a/src/tests/simulation/tests/integration_tests/recovery/time_travel.rs
+++ b/src/tests/simulation/tests/integration_tests/recovery/time_travel.rs
@@ -1,0 +1,136 @@
+// Copyright 2026 RisingWave Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::io::Write;
+use std::time::Duration;
+
+use anyhow::Result;
+use risingwave_simulation::cluster::{Cluster, ConfigPath, Configuration};
+use tokio::time::sleep;
+
+// The system parameter enforces a minimum time travel retention of ten minutes.
+const TIME_TRAVEL_RETENTION_MS: u64 = 10 * 60 * 1000;
+const INSERT_INTERVAL: Duration = Duration::from_secs(60);
+
+fn init_logger() {
+    let _ = tracing_subscriber::fmt()
+        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .with_ansi(false)
+        .try_init();
+}
+
+fn cluster_config() -> Configuration {
+    let config_path = {
+        let mut file = tempfile::NamedTempFile::new().expect("failed to create temp config file");
+        file.write_all(
+            br#"
+[server]
+telemetry_enabled = false
+metrics_level = "Disabled"
+
+[meta]
+hummock_time_travel_snapshot_interval = 10
+
+[meta.developer]
+time_travel_vacuum_interval_sec = 5
+
+[streaming.developer]
+stream_chunk_size = 1
+
+[system]
+barrier_interval_ms = 1000
+max_concurrent_creating_streaming_jobs = 4
+"#,
+        )
+        .expect("failed to write config file");
+        file.into_temp_path()
+    };
+
+    Configuration {
+        config_path: ConfigPath::Temp(config_path.into()),
+        frontend_nodes: 1,
+        compute_nodes: 1,
+        meta_nodes: 1,
+        compactor_nodes: 2,
+        compute_node_cores: 1,
+        ..Default::default()
+    }
+}
+
+#[tokio::test]
+async fn test_time_travel_vacuum_during_snapshot_backfill() -> Result<()> {
+    init_logger();
+
+    let mut cluster = Cluster::start(cluster_config()).await?;
+    let mut session = cluster.start_session();
+
+    session
+        .run(format!(
+            "alter system set time_travel_retention_ms = {TIME_TRAVEL_RETENTION_MS};"
+        ))
+        .await?;
+    session.run("set rw_implicit_flush = true;").await?;
+    session.run("create table healthy_t(id int);").await?;
+    session
+        .run("create table backfill_t(id int primary key);")
+        .await?;
+    session
+        .run("insert into backfill_t select * from generate_series(1, 300);")
+        .await?;
+    session.run("flush;").await?;
+
+    session.run("set streaming_parallelism = 1;").await?;
+    session
+        .run("set streaming_use_snapshot_backfill = true;")
+        .await?;
+    session.run("set background_ddl = true;").await?;
+    session.run("set backfill_rate_limit = 1;").await?;
+    session
+        .run("create materialized view backfill_mv as select * from backfill_t;")
+        .await?;
+
+    // Snapshot backfill can commit a lower table epoch at a later global version. Keep the job
+    // active while creating several retained wall-clock mappings that precede those versions.
+    for id in 1..=3 {
+        session
+            .run(format!("insert into healthy_t values ({id});"))
+            .await?;
+        sleep(INSERT_INTERVAL).await;
+    }
+
+    assert_eq!(
+        session
+            .run("select count(*) from rw_catalog.rw_ddl_progress;")
+            .await?,
+        "1"
+    );
+    session.run("wait;").await?;
+    // Once the job's version pin is released, give vacuum time to process the mixed epoch order.
+    sleep(Duration::from_secs(10)).await;
+
+    // Drop compute-side recent-version and time-travel caches before validating the archived
+    // metadata path.
+    cluster.simple_kill_nodes(["compute-1"]).await;
+    cluster.simple_restart_nodes(["compute-1"]).await;
+    sleep(Duration::from_secs(10)).await;
+
+    session
+        .run(
+            "select count(*) from healthy_t \
+             for system_time as of now() - '3' minute;",
+        )
+        .await?;
+
+    Ok(())
+}


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

Time-travel vacuum inferred its version boundary from the greatest epoch below the retention watermark. That assumes epochs and global Hummock version IDs have the same ordering across all tables. Snapshot backfill breaks this assumption: it can commit a low/fake table epoch in a later global version, causing vacuum to advance past versions still needed by an ordinary table within the configured retention window.

This PR:

- derives the version boundary from the earliest global version referenced by any retained (`epoch >= epoch_watermark`) epoch mapping;
- keeps the existing pinned-version and per-round vacuum limits as additional bounds;
- returns early when no epoch mapping is old enough to vacuum;
- adds unit coverage for cross-table epoch/version ordering and the no-op path;
- adds a deterministic simulation test with a rate-limited snapshot backfill, ongoing writes to a healthy table, vacuum, and a compute-node restart to clear recent-version caches before the final time-travel query.

The madsim test is also a negative check for [#26377](https://github.com/risingwavelabs/risingwave/pull/26377): applying that PR's snapshot-pin-only fix while retaining the old watermark inference still fails this test with `Time-travel version expired`. The pin protects the snapshot while the backfill is active, but after the job completes and releases the pin, the incorrect global watermark can still vacuum an in-retention version needed by the healthy table. This PR therefore replaces #26377 by fixing the underlying watermark inference.

- Closes #26380
- Replaces #26377

## Checklist

- [x] I have written necessary rustdoc comments.
- [x] I have added necessary unit tests and integration tests.
- [x] I have added test labels as necessary.
- [ ] I have added fuzzing tests or opened an issue to track them.
- [ ] My PR contains breaking changes.
- [ ] My PR changes performance-critical code, so I will run (micro) benchmarks and present the results.
- [ ] I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into.

## Tests

- `cargo clippy --all-targets --all-features`
- `cargo test -p risingwave_meta test_time_travel_vacuum --no-fail-fast`
- `recovery::time_travel::test_time_travel_vacuum_during_snapshot_backfill` with madsim seeds 1 through 5
- The madsim test fails with the old watermark inference plus #26377's pin-only fix, and passes with this PR.

## Documentation

- [ ] My PR needs documentation updates.

<details>
<summary><b>Release note</b></summary>

Fix time-travel vacuum incorrectly expiring versions that are still within the configured retention window while snapshot backfill jobs commit epochs from a different epoch domain.

</details>
