### PR TITLE
chore(lints): detect temporary guarded metric updates

### DIFF
--- a/lints/Cargo.toml
+++ b/lints/Cargo.toml
@@ -29,3 +29,7 @@ tracing = "0.1"
 [[example]]
 name = "format_error"
 path = "ui/format_error.rs"
+
+[[example]]
+name = "temporary_guarded_metric"
+path = "ui/temporary_guarded_metric.rs"

--- a/lints/README.md
+++ b/lints/README.md
@@ -16,6 +16,14 @@ To run all lints, run `cargo dylint --all` in the root of the repository.
 
 If you find there are some compile errors, try updating the `cargo-dylint` binary by installing it again.
 
+Some lints are allow-by-default because the existing codebase still has known
+violations. To also run these development checks locally, use the `rw_all`
+group, for example:
+
+```bash
+DYLINT_RUSTFLAGS="-A warnings -D rw_all" cargo dylint --all
+```
+
 ## Add new lints
 
 To add a new lint, add a new file in the `src` directory to declare the lint, then register it in `fn register_lints(..)` in `lib.rs`.

--- a/lints/src/format_error.rs
+++ b/lints/src/format_error.rs
@@ -19,14 +19,14 @@ use clippy_utils::macros::{
     FormatArgsStorage, find_format_arg_expr, is_format_macro, macro_backtrace,
 };
 use clippy_utils::paths::{PathLookup, PathNS};
-use clippy_utils::ty::implements_trait;
 use clippy_utils::sym::{Error, ToString};
+use clippy_utils::ty::implements_trait;
 use clippy_utils::{is_in_cfg_test, is_in_test_function};
 use rustc_ast::FormatArgsPiece;
 use rustc_hir::{Expr, ExprKind};
 use rustc_lint::{LateContext, LateLintPass};
 use rustc_session::{declare_tool_lint, impl_lint_pass};
-use rustc_span::{Span, sym};
+use rustc_span::Span;
 
 use crate::utils::path::def_path_lookup;
 
@@ -155,10 +155,13 @@ impl<'tcx> LateLintPass<'tcx> for FormatError {
 
         // `err.to_string()`
         if let ExprKind::MethodCall(_, receiver, [], to_string_span) = expr.kind
-            && cx.typeck_results()
+            && cx
+                .typeck_results()
                 .type_dependent_def_id(expr.hir_id)
                 .is_some_and(|did| {
-                    let Some(trait_id) = cx.tcx.trait_of_assoc(did) else { return false };
+                    let Some(trait_id) = cx.tcx.trait_of_assoc(did) else {
+                        return false;
+                    };
                     cx.tcx.is_diagnostic_item(ToString, trait_id)
                 })
         {

--- a/lints/src/lib.rs
+++ b/lints/src/lib.rs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 #![feature(rustc_private)]
-
 #![warn(unused_extern_crates)]
 
 extern crate rustc_ast;
@@ -25,6 +24,7 @@ extern crate rustc_session;
 extern crate rustc_span;
 
 mod format_error;
+mod temporary_guarded_metric;
 mod utils;
 
 dylint_linting::dylint_library!();
@@ -45,9 +45,11 @@ pub fn register_lints(_sess: &rustc_session::Session, lint_store: &mut rustc_lin
 
     // Actual lints.
     lint_store.register_lints(&[format_error::FORMAT_ERROR]);
+    lint_store.register_lints(&[temporary_guarded_metric::TEMPORARY_GUARDED_METRIC]);
     let format_args = format_args_storage.clone();
     lint_store
         .register_late_pass(move |_| Box::new(format_error::FormatError::new(format_args.clone())));
+    lint_store.register_late_pass(|_| Box::new(temporary_guarded_metric::TemporaryGuardedMetric));
 
     // --  End lint registration  --
 

--- a/lints/src/temporary_guarded_metric.rs
+++ b/lints/src/temporary_guarded_metric.rs
@@ -1,0 +1,93 @@
+// Copyright 2026 RisingWave Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use clippy_utils::diagnostics::span_lint_and_help;
+use rustc_hir::{Expr, ExprKind};
+use rustc_lint::{LateContext, LateLintPass};
+use rustc_session::{declare_tool_lint, impl_lint_pass};
+use rustc_span::Symbol;
+
+declare_tool_lint! {
+    /// ### What it does
+    /// Checks for updating a metric directly on a temporary returned from
+    /// `with_guarded_label_values`.
+    ///
+    /// ### Why is this bad?
+    /// `with_guarded_label_values` returns a guarded metric. The guard keeps
+    /// the label values registered while the returned value is alive. Updating
+    /// the metric through a temporary, such as
+    /// `metrics.with_guarded_label_values(...).set(value)`, immediately drops
+    /// the guard and may remove/reset the label series before Prometheus can
+    /// scrape it.
+    ///
+    /// ### Known problems
+    /// This lint intentionally only checks common metric update methods. It
+    /// does not reject conversions such as `.local()` when the converted metric
+    /// is stored.
+    ///
+    /// ### Example
+    /// ```no_run
+    /// metrics.with_guarded_label_values(&labels).set(value);
+    /// ```
+    /// Use instead:
+    /// ```no_run
+    /// let metric = metrics.with_guarded_label_values(&labels);
+    /// metric.set(value);
+    /// ```
+    pub rw::TEMPORARY_GUARDED_METRIC,
+    Allow,
+    "updating a temporary guarded metric"
+}
+
+#[derive(Default)]
+pub struct TemporaryGuardedMetric;
+
+impl_lint_pass!(TemporaryGuardedMetric => [TEMPORARY_GUARDED_METRIC]);
+
+impl<'tcx> LateLintPass<'tcx> for TemporaryGuardedMetric {
+    fn check_expr(&mut self, cx: &LateContext<'tcx>, expr: &'tcx Expr<'_>) {
+        let ExprKind::MethodCall(update_method, receiver, _, update_span) = expr.kind else {
+            return;
+        };
+
+        if !is_metric_update_method(update_method.ident.name) {
+            return;
+        }
+
+        if let ExprKind::MethodCall(guarded_method, _, _, _) = receiver.kind
+            && guarded_method.ident.name.as_str() == "with_guarded_label_values"
+        {
+            span_lint_and_help(
+                cx,
+                TEMPORARY_GUARDED_METRIC,
+                expr.span,
+                "should not update a temporary guarded metric",
+                Some(update_span),
+                "store the value returned by `with_guarded_label_values` so the label guard lives long enough",
+            );
+        }
+    }
+}
+
+fn is_metric_update_method(method: Symbol) -> bool {
+    matches!(
+        method.as_str(),
+        "add" | "dec" | "dec_by" | "inc" | "inc_by" | "observe" | "set" | "start_timer" | "sub"
+    )
+}
+
+#[test]
+fn ui() {
+    dylint_testing::ui_test_example(env!("CARGO_PKG_NAME"), "temporary_guarded_metric");
+}

--- a/lints/src/temporary_guarded_metric.rs
+++ b/lints/src/temporary_guarded_metric.rs
@@ -20,16 +20,19 @@ use rustc_span::Symbol;
 
 declare_tool_lint! {
     /// ### What it does
-    /// Checks for updating a metric directly on a temporary returned from
-    /// `with_guarded_label_values`.
+    /// Checks for cumulatively updating a metric directly on a temporary
+    /// returned from `with_guarded_label_values`.
     ///
     /// ### Why is this bad?
     /// `with_guarded_label_values` returns a guarded metric. The guard keeps
     /// the label values registered while the returned value is alive. Updating
-    /// the metric through a temporary, such as
-    /// `metrics.with_guarded_label_values(...).set(value)`, immediately drops
-    /// the guard and may remove/reset the label series before Prometheus can
-    /// scrape it.
+    /// a counter or histogram through a temporary, such as
+    /// `metrics.with_guarded_label_values(...).inc()`, immediately drops the
+    /// guard and may reset cumulative state between Prometheus scrapes.
+    ///
+    /// Gauges updated with `set` are intentionally ignored. Collection observes
+    /// a dropped label once before removing it, and a later `set` replaces the
+    /// full gauge value.
     ///
     /// ### Known problems
     /// This lint intentionally only checks common metric update methods. It
@@ -38,12 +41,12 @@ declare_tool_lint! {
     ///
     /// ### Example
     /// ```no_run
-    /// metrics.with_guarded_label_values(&labels).set(value);
+    /// metrics.with_guarded_label_values(&labels).inc();
     /// ```
     /// Use instead:
     /// ```no_run
     /// let metric = metrics.with_guarded_label_values(&labels);
-    /// metric.set(value);
+    /// metric.inc();
     /// ```
     pub rw::TEMPORARY_GUARDED_METRIC,
     Allow,
@@ -83,7 +86,7 @@ impl<'tcx> LateLintPass<'tcx> for TemporaryGuardedMetric {
 fn is_metric_update_method(method: Symbol) -> bool {
     matches!(
         method.as_str(),
-        "add" | "dec" | "dec_by" | "inc" | "inc_by" | "observe" | "set" | "start_timer" | "sub"
+        "add" | "dec" | "dec_by" | "inc" | "inc_by" | "observe" | "start_timer" | "sub"
     )
 }
 

--- a/lints/ui/temporary_guarded_metric.rs
+++ b/lints/ui/temporary_guarded_metric.rs
@@ -1,0 +1,42 @@
+#![feature(register_tool)]
+#![register_tool(rw)]
+#![warn(rw::temporary_guarded_metric)]
+
+struct MetricVec;
+
+struct GuardedMetric;
+
+impl MetricVec {
+    fn with_guarded_label_values(&self, _labels: &[&str]) -> GuardedMetric {
+        GuardedMetric
+    }
+}
+
+impl GuardedMetric {
+    fn set(&self, _value: i64) {}
+
+    fn inc(&self) {}
+
+    fn observe(&self, _value: f64) {}
+
+    fn local(&self) -> GuardedMetric {
+        GuardedMetric
+    }
+}
+
+fn main() {
+    let labels = ["source_id"];
+    let metrics = MetricVec;
+
+    metrics.with_guarded_label_values(&labels).set(1);
+
+    metrics.with_guarded_label_values(&labels).inc();
+
+    metrics.with_guarded_label_values(&labels).observe(1.0);
+
+    let metric = metrics.with_guarded_label_values(&labels);
+    metric.set(1);
+
+    let local_metric = metrics.with_guarded_label_values(&labels).local();
+    local_metric.inc();
+}

--- a/lints/ui/temporary_guarded_metric.stderr
+++ b/lints/ui/temporary_guarded_metric.stderr
@@ -1,0 +1,43 @@
+warning: should not update a temporary guarded metric
+  --> $DIR/temporary_guarded_metric.rs:31:5
+   |
+LL |     metrics.with_guarded_label_values(&labels).set(1);
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: store the value returned by `with_guarded_label_values` so the label guard lives long enough
+  --> $DIR/temporary_guarded_metric.rs:31:48
+   |
+LL |     metrics.with_guarded_label_values(&labels).set(1);
+   |                                                ^^^^^^
+note: the lint level is defined here
+  --> $DIR/temporary_guarded_metric.rs:3:9
+   |
+LL | #![warn(rw::temporary_guarded_metric)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+warning: should not update a temporary guarded metric
+  --> $DIR/temporary_guarded_metric.rs:33:5
+   |
+LL |     metrics.with_guarded_label_values(&labels).inc();
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: store the value returned by `with_guarded_label_values` so the label guard lives long enough
+  --> $DIR/temporary_guarded_metric.rs:33:48
+   |
+LL |     metrics.with_guarded_label_values(&labels).inc();
+   |                                                ^^^^^
+
+warning: should not update a temporary guarded metric
+  --> $DIR/temporary_guarded_metric.rs:35:5
+   |
+LL |     metrics.with_guarded_label_values(&labels).observe(1.0);
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: store the value returned by `with_guarded_label_values` so the label guard lives long enough
+  --> $DIR/temporary_guarded_metric.rs:35:48
+   |
+LL |     metrics.with_guarded_label_values(&labels).observe(1.0);
+   |                                                ^^^^^^^^^^^^
+
+warning: 3 warnings emitted
+

--- a/lints/ui/temporary_guarded_metric.stderr
+++ b/lints/ui/temporary_guarded_metric.stderr
@@ -1,21 +1,4 @@
 warning: should not update a temporary guarded metric
-  --> $DIR/temporary_guarded_metric.rs:31:5
-   |
-LL |     metrics.with_guarded_label_values(&labels).set(1);
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-help: store the value returned by `with_guarded_label_values` so the label guard lives long enough
-  --> $DIR/temporary_guarded_metric.rs:31:48
-   |
-LL |     metrics.with_guarded_label_values(&labels).set(1);
-   |                                                ^^^^^^
-note: the lint level is defined here
-  --> $DIR/temporary_guarded_metric.rs:3:9
-   |
-LL | #![warn(rw::temporary_guarded_metric)]
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-warning: should not update a temporary guarded metric
   --> $DIR/temporary_guarded_metric.rs:33:5
    |
 LL |     metrics.with_guarded_label_values(&labels).inc();
@@ -26,6 +9,11 @@ help: store the value returned by `with_guarded_label_values` so the label guard
    |
 LL |     metrics.with_guarded_label_values(&labels).inc();
    |                                                ^^^^^
+note: the lint level is defined here
+  --> $DIR/temporary_guarded_metric.rs:3:9
+   |
+LL | #![warn(rw::temporary_guarded_metric)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: should not update a temporary guarded metric
   --> $DIR/temporary_guarded_metric.rs:35:5
@@ -39,5 +27,5 @@ help: store the value returned by `with_guarded_label_values` so the label guard
 LL |     metrics.with_guarded_label_values(&labels).observe(1.0);
    |                                                ^^^^^^^^^^^^
 
-warning: 3 warnings emitted
+warning: 2 warnings emitted
 


### PR DESCRIPTION
## Summary
- add a default-warning Dylint rule `rw::temporary_guarded_metric`
- detect cumulative metric updates chained from `with_guarded_label_values(...)`, where the guard is immediately dropped
- allow short-lived gauge updates through `set`: collection observes the dropped series once, and the next `set` replaces the full value
- keep the two intentional connection error event counters with narrow method-level allows
- enable the rule in the default `rw_warnings` flow now that #26735 fixed the auto-schema-change metric ownership

Gauge `set` calls are intentionally excluded; `inc`, `inc_by`, `observe`, timer updates, and other cumulative operations remain checked.

Related to #26301, #26408, and #26735.

## Tests
- `cargo fmt --all -- --check`
- `DYLINT_RUSTFLAGS="-A warnings -D rw_warnings" cargo dylint --all -- --all-targets --all-features --locked`
- `cargo test` in `lints/`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a lint warning when guarded metrics are updated through temporary values.
  * Warnings recommend storing the guarded metric before performing updates.
  * Added coverage for increments, decrements, observations, and timers.

* **Documentation**
  * Clarified cases where the warning does not apply, including gauge value assignments and local metric conversions.

* **Refactor**
  * Reformatted existing lint code without changing its behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->