### PR TITLE
fix(common): return errors instead of panicking on out-of-range Arrow temporal values

### DIFF
--- a/src/common/src/array/arrow/arrow_impl.rs
+++ b/src/common/src/array/arrow/arrow_impl.rs
@@ -169,7 +169,7 @@ pub trait ToArrow {
 
     #[inline]
     fn date_to_arrow(&self, array: &DateArray) -> Result<arrow_array::ArrayRef, ArrayError> {
-        Ok(Arc::new(arrow_array::Date32Array::from(array)))
+        Ok(Arc::new(arrow_array::Date32Array::try_from(array)?))
     }
 
     #[inline]
@@ -202,9 +202,9 @@ pub trait ToArrow {
         &self,
         array: &IntervalArray,
     ) -> Result<arrow_array::ArrayRef, ArrayError> {
-        Ok(Arc::new(arrow_array::IntervalMonthDayNanoArray::from(
+        Ok(Arc::new(arrow_array::IntervalMonthDayNanoArray::try_from(
             array,
-        )))
+        )?))
     }
 
     #[inline]
@@ -824,7 +824,7 @@ pub trait FromArrow {
     }
 
     fn from_date32_array(&self, array: &arrow_array::Date32Array) -> Result<ArrayImpl, ArrayError> {
-        Ok(ArrayImpl::Date(array.into()))
+        Ok(ArrayImpl::Date(array.try_into()?))
     }
 
     fn from_time32s_array(
@@ -914,7 +914,7 @@ pub trait FromArrow {
         &self,
         array: &arrow_array::IntervalMonthDayNanoArray,
     ) -> Result<ArrayImpl, ArrayError> {
-        Ok(ArrayImpl::Interval(array.into()))
+        Ok(ArrayImpl::Interval(array.try_into()?))
     }
 
     fn from_utf8_array(&self, array: &arrow_array::StringArray) -> Result<ArrayImpl, ArrayError> {
@@ -1134,6 +1134,38 @@ macro_rules! converts {
             }
         }
     };
+    // convert values using TryFromIntoArrow
+    ($ArrayType:ty, $ArrowType:ty, @try_map) => {
+        impl TryFrom<&$ArrayType> for $ArrowType {
+            type Error = ArrayError;
+
+            fn try_from(array: &$ArrayType) -> Result<Self, Self::Error> {
+                // Collecting `Result`s loses the iterator's size hint, so build with an
+                // explicit capacity instead.
+                let mut builder = <$ArrowType>::builder(array.len());
+                for o in array.iter() {
+                    builder.append_option(o.map(|v| v.try_into_arrow()).transpose()?);
+                }
+                Ok(builder.finish())
+            }
+        }
+        impl TryFrom<&$ArrowType> for $ArrayType {
+            type Error = ArrayError;
+
+            fn try_from(array: &$ArrowType) -> Result<Self, Self::Error> {
+                use arrow_array::Array as _;
+
+                let mut builder = <$ArrayType as Array>::Builder::new(array.len());
+                for o in array.iter() {
+                    builder.append(
+                        o.map(<<$ArrayType as Array>::RefItem<'_> as TryFromIntoArrow>::try_from_arrow)
+                            .transpose()?,
+                    );
+                }
+                Ok(builder.finish())
+            }
+        }
+    };
 }
 
 /// Used to convert different types.
@@ -1217,8 +1249,8 @@ converts!(BytesArray, arrow_array::LargeBinaryArray);
 converts!(Utf8Array, arrow_array::StringArray);
 converts!(Utf8Array, arrow_array::LargeStringArray);
 converts!(Utf8Array, arrow_array::StringViewArray);
-converts!(DateArray, arrow_array::Date32Array, @map);
-converts!(IntervalArray, arrow_array::IntervalMonthDayNanoArray, @map);
+converts!(DateArray, arrow_array::Date32Array, @try_map);
+converts!(IntervalArray, arrow_array::IntervalMonthDayNanoArray, @try_map);
 converts!(SerialArray, arrow_array::Int64Array, @map);
 
 converts_with_type!(I16Array, arrow_array::Int8Array, i16, i8);
@@ -1247,6 +1279,15 @@ trait FromIntoArrow {
     type ArrowType;
     fn from_arrow(value: Self::ArrowType) -> Self;
     fn into_arrow(self) -> Self::ArrowType;
+}
+
+/// Like [`FromIntoArrow`], for values whose Arrow representation does not cover the whole
+/// RisingWave domain, or vice versa.
+trait TryFromIntoArrow: Sized {
+    /// The corresponding element type in the Arrow array.
+    type ArrowType;
+    fn try_from_arrow(value: Self::ArrowType) -> Result<Self, ArrayError>;
+    fn try_into_arrow(self) -> Result<Self::ArrowType, ArrayError>;
 }
 
 /// Converts a RisingWave temporal scalar to and from Arrow's physical primitive
@@ -1312,16 +1353,18 @@ impl FromIntoArrow for F64 {
     }
 }
 
-impl FromIntoArrow for Date {
+impl TryFromIntoArrow for Date {
     type ArrowType = i32;
 
     #[allow(deprecated)]
-    fn from_arrow(value: Self::ArrowType) -> Self {
-        Date(arrow_array::types::Date32Type::to_naive_date(value))
+    fn try_from_arrow(value: Self::ArrowType) -> Result<Self, ArrayError> {
+        arrow_array::types::Date32Type::to_naive_date_opt(value)
+            .map(Date)
+            .ok_or_else(|| ArrayError::from_arrow(format!("invalid Arrow date {value}")))
     }
 
-    fn into_arrow(self) -> Self::ArrowType {
-        arrow_array::types::Date32Type::from_naive_date(self.0)
+    fn try_into_arrow(self) -> Result<Self::ArrowType, ArrayError> {
+        Ok(arrow_array::types::Date32Type::from_naive_date(self.0))
     }
 }
 
@@ -1367,14 +1410,8 @@ impl TemporalArrowConvert<i64> for Time {
 
     fn into_arrow_with_time_unit(self, time_unit: TimeUnit) -> i64 {
         match time_unit {
-            TimeUnit::Microsecond => {
-                self.0.num_seconds_from_midnight() as i64 * 1_000_000
-                    + self.0.nanosecond() as i64 / 1_000
-            }
-            TimeUnit::Nanosecond => {
-                self.0.num_seconds_from_midnight() as i64 * 1_000_000_000
-                    + self.0.nanosecond() as i64
-            }
+            TimeUnit::Microsecond => self.micros_of_day() as i64,
+            TimeUnit::Nanosecond => self.nanos_of_day() as i64,
             unit => unreachable!("{unit:?} is not a Time64 unit"),
         }
     }
@@ -1389,10 +1426,7 @@ impl TemporalArrowConvert<i64> for Timestamp {
                 .map_err(|_| invalid_arrow_temporal_value(value, time_unit)),
             TimeUnit::Microsecond => Timestamp::with_micros(value)
                 .map_err(|_| invalid_arrow_temporal_value(value, time_unit)),
-            // Every `i64` nanosecond count is representable, so there is nothing to check.
-            TimeUnit::Nanosecond => {
-                Ok(Timestamp(DateTime::from_timestamp_nanos(value).naive_utc()))
-            }
+            TimeUnit::Nanosecond => Ok(Timestamp::with_nanos(value)),
         }
     }
 
@@ -1413,9 +1447,11 @@ impl TemporalArrowConvert<i64> for Timestamptz {
                 .ok_or_else(|| invalid_arrow_temporal_value(value, time_unit)),
             TimeUnit::Millisecond => Timestamptz::from_millis(value)
                 .ok_or_else(|| invalid_arrow_temporal_value(value, time_unit)),
-            TimeUnit::Microsecond => Ok(Timestamptz::from_micros(value)),
-            TimeUnit::Nanosecond => Timestamptz::from_nanos(value)
+            // `Timestamptz::from_micros` does not validate; see #26397.
+            TimeUnit::Microsecond => DateTime::from_timestamp_micros(value)
+                .map(Timestamptz::from)
                 .ok_or_else(|| invalid_arrow_temporal_value(value, time_unit)),
+            TimeUnit::Nanosecond => Ok(Timestamptz::from_nanos(value)),
         }
     }
 
@@ -1435,20 +1471,29 @@ fn invalid_arrow_temporal_value<T: std::fmt::Display>(value: T, time_unit: TimeU
     ))
 }
 
-impl FromIntoArrow for Interval {
+impl TryFromIntoArrow for Interval {
     type ArrowType = ArrowIntervalType;
 
-    fn from_arrow(value: Self::ArrowType) -> Self {
-        Interval::from_month_day_usec(value.months, value.days, value.nanoseconds / 1000)
+    /// RisingWave's `interval` is microsecond-precision, so nanoseconds are truncated.
+    fn try_from_arrow(value: Self::ArrowType) -> Result<Self, ArrayError> {
+        Ok(Interval::from_month_day_usec(
+            value.months,
+            value.days,
+            value.nanoseconds / 1_000,
+        ))
     }
 
-    fn into_arrow(self) -> Self::ArrowType {
-        ArrowIntervalType {
+    fn try_into_arrow(self) -> Result<Self::ArrowType, ArrayError> {
+        Ok(ArrowIntervalType {
             months: self.months(),
             days: self.days(),
-            // TODO: this may overflow and we need `try_into`
-            nanoseconds: self.usecs() * 1000,
-        }
+            nanoseconds: self.usecs().checked_mul(1_000).ok_or_else(|| {
+                ArrayError::to_arrow(format!(
+                    "interval with {} microseconds is out of range for Arrow",
+                    self.usecs()
+                ))
+            })?,
+        })
     }
 }
 
@@ -2082,8 +2127,8 @@ mod tests {
             Date::with_days_since_ce(12345).ok(),
             Date::with_days_since_ce(-12345).ok(),
         ]);
-        let arrow = arrow_array::Date32Array::from(&array);
-        assert_eq!(DateArray::from(&arrow), array);
+        let arrow = arrow_array::Date32Array::try_from(&array).unwrap();
+        assert_eq!(DateArray::try_from(&arrow).unwrap(), array);
     }
 
     #[test]
@@ -2317,9 +2362,53 @@ mod tests {
         let invalid_second = arrow_array::TimestampSecondArray::from(vec![Some(i64::MAX)]);
         let invalid_millisecond =
             arrow_array::TimestampMillisecondArray::from(vec![Some(i64::MAX)]);
+        let invalid_microsecond =
+            arrow_array::TimestampMicrosecondArray::from(vec![Some(i64::MAX)]);
+        // Within `checked_mul` range, but past what chrono can represent.
+        let unrepresentable_second =
+            arrow_array::TimestampSecondArray::from(vec![Some(9_000_000_000_000)]);
 
         assert_from_arrow_error(TimestamptzArray::try_from(&invalid_second));
         assert_from_arrow_error(TimestamptzArray::try_from(&invalid_millisecond));
+        assert_from_arrow_error(TimestamptzArray::try_from(&invalid_microsecond));
+        assert_from_arrow_error(TimestamptzArray::try_from(&unrepresentable_second));
+    }
+
+    #[test]
+    fn date_rejects_out_of_range_arrow_value() {
+        let valid = arrow_array::Date32Array::from(vec![Some(0), None]);
+        assert_eq!(
+            DateArray::try_from(&valid).unwrap(),
+            DateArray::from_iter([Date::with_days_since_unix_epoch(0).ok(), None])
+        );
+
+        // chrono's `NaiveDate` tops out well below `i32::MAX` days from the epoch.
+        let out_of_range = arrow_array::Date32Array::from(vec![Some(1_000_000_000)]);
+        assert_from_arrow_error(DateArray::try_from(&out_of_range));
+    }
+
+    #[test]
+    fn interval_rejects_out_of_range_microseconds() {
+        let array = IntervalArray::from_iter([Interval::from_month_day_usec(0, 0, i64::MAX)]);
+        let err = arrow_array::IntervalMonthDayNanoArray::try_from(&array).unwrap_err();
+        assert!(matches!(err, ArrayError::ToArrow(_)), "got {err:?}");
+    }
+
+    #[test]
+    fn interval_truncates_sub_microsecond_nanos() {
+        let arrow = arrow_array::IntervalMonthDayNanoArray::from(vec![
+            Some(ArrowIntervalType::new(0, 0, 1_999)),
+            Some(ArrowIntervalType::new(0, 0, -1)),
+            Some(ArrowIntervalType::new(0, 0, -1_999)),
+        ]);
+        assert_eq!(
+            IntervalArray::try_from(&arrow).unwrap(),
+            IntervalArray::from_iter([
+                Interval::from_month_day_usec(0, 0, 1),
+                Interval::from_month_day_usec(0, 0, 0),
+                Interval::from_month_day_usec(0, 0, -1),
+            ])
+        );
     }
 
     fn assert_from_arrow_error<T>(result: Result<T, ArrayError>) {
@@ -2345,8 +2434,8 @@ mod tests {
                 -1_000_000_000,
             )),
         ]);
-        let arrow = arrow_array::IntervalMonthDayNanoArray::from(&array);
-        assert_eq!(IntervalArray::from(&arrow), array);
+        let arrow = arrow_array::IntervalMonthDayNanoArray::try_from(&array).unwrap();
+        assert_eq!(IntervalArray::try_from(&arrow).unwrap(), array);
     }
 
     #[test]

--- a/src/common/src/types/datetime.rs
+++ b/src/common/src/types/datetime.rs
@@ -254,6 +254,8 @@ enum ErrorKind {
     TimeOfDay { value: u64, unit: &'static str },
     #[error("Invalid datetime: seconds: {secs}, nanoseconds: {nsecs}")]
     DateTime { secs: i64, nsecs: u32 },
+    #[error("Invalid datetime: {value} {unit} is out of range")]
+    Timestamp { value: i64, unit: &'static str },
     #[error("Can't cast string to date (expected format is YYYY-MM-DD)")]
     ParseDate,
     #[error(
@@ -285,6 +287,10 @@ impl InvalidParamsError {
 
     pub fn datetime(secs: i64, nsecs: u32) -> Self {
         ErrorKind::DateTime { secs, nsecs }.into()
+    }
+
+    pub fn timestamp(value: i64, unit: &'static str) -> Self {
+        ErrorKind::Timestamp { value, unit }.into()
     }
 }
 
@@ -452,11 +458,7 @@ impl Time {
 
     pub fn to_protobuf<T: Write>(self, output: &mut T) -> ArrayResult<usize> {
         output
-            .write(
-                &(self.0.num_seconds_from_midnight() as u64 * 1_000_000_000
-                    + self.0.nanosecond() as u64)
-                    .to_be_bytes(),
-            )
+            .write(&self.nanos_of_day().to_be_bytes())
             .map_err(Into::into)
     }
 
@@ -476,6 +478,16 @@ impl Time {
             (micro / 1_000_000) as u32,
             ((micro % 1_000_000) * 1_000) as u32,
         )
+    }
+
+    /// Nanoseconds since midnight, the inverse of [`Time::with_nano`].
+    pub fn nanos_of_day(self) -> u64 {
+        self.0.num_seconds_from_midnight() as u64 * 1_000_000_000 + self.0.nanosecond() as u64
+    }
+
+    /// Microseconds since midnight, truncating sub-microsecond precision.
+    pub fn micros_of_day(self) -> u64 {
+        self.0.num_seconds_from_midnight() as u64 * 1_000_000 + self.0.nanosecond() as u64 / 1_000
     }
 
     pub fn with_milli(milli: u32) -> Result<Self> {
@@ -539,11 +551,9 @@ impl FirstI64 {
 
 impl Timestamp {
     pub fn with_secs_nsecs(secs: i64, nsecs: u32) -> Result<Self> {
-        Ok(Timestamp::new({
-            DateTime::from_timestamp(secs, nsecs)
-                .map(|t| t.naive_utc())
-                .ok_or_else(|| InvalidParamsError::datetime(secs, nsecs))?
-        }))
+        DateTime::from_timestamp(secs, nsecs)
+            .map(|t| Timestamp(t.naive_utc()))
+            .ok_or_else(|| InvalidParamsError::datetime(secs, nsecs))
     }
 
     pub fn from_protobuf(cur: &mut Cursor<&[u8]>) -> ArrayResult<Timestamp> {
@@ -582,15 +592,20 @@ impl Timestamp {
     }
 
     pub fn with_millis(timestamp_millis: i64) -> Result<Self> {
-        let secs = timestamp_millis.div_euclid(1_000);
-        let nsecs = timestamp_millis.rem_euclid(1_000) * 1_000_000;
-        Self::with_secs_nsecs(secs, nsecs as u32)
+        DateTime::from_timestamp_millis(timestamp_millis)
+            .map(|t| Timestamp(t.naive_utc()))
+            .ok_or_else(|| InvalidParamsError::timestamp(timestamp_millis, "milliseconds"))
     }
 
     pub fn with_micros(timestamp_micros: i64) -> Result<Self> {
-        let secs = timestamp_micros.div_euclid(1_000_000);
-        let nsecs = timestamp_micros.rem_euclid(1_000_000) * 1000;
-        Self::with_secs_nsecs(secs, nsecs as u32)
+        DateTime::from_timestamp_micros(timestamp_micros)
+            .map(|t| Timestamp(t.naive_utc()))
+            .ok_or_else(|| InvalidParamsError::timestamp(timestamp_micros, "microseconds"))
+    }
+
+    /// An `i64` nanosecond count is always representable, so this cannot fail.
+    pub fn with_nanos(timestamp_nanos: i64) -> Self {
+        Timestamp(DateTime::from_timestamp_nanos(timestamp_nanos).naive_utc())
     }
 
     pub fn from_timestamp_uncheck(secs: i64, nsecs: u32) -> Self {

--- a/src/common/src/types/interval.rs
+++ b/src/common/src/types/interval.rs
@@ -898,12 +898,10 @@ impl From<&'_ PbInterval> for Interval {
 
 impl From<Time> for Interval {
     fn from(time: Time) -> Self {
-        let mut usecs: i64 = (time.0.num_seconds_from_midnight() as i64) * USECS_PER_SEC;
-        usecs += (time.0.nanosecond() / 1000) as i64;
         Self {
             months: 0,
             days: 0,
-            usecs,
+            usecs: time.micros_of_day() as i64,
         }
     }
 }

--- a/src/common/src/types/timestamptz.rs
+++ b/src/common/src/types/timestamptz.rs
@@ -88,23 +88,37 @@ impl Timestamptz {
 
     /// Creates a `Timestamptz` from seconds. Returns `None` if the given timestamp is out of range.
     pub fn from_secs(timestamp_secs: i64) -> Option<Self> {
-        timestamp_secs.checked_mul(1_000_000).map(Self)
+        timestamp_secs
+            .checked_mul(1_000_000)
+            .and_then(Self::checked)
     }
 
     /// Creates a `Timestamptz` from milliseconds. Returns `None` if the given timestamp is out of
     /// range.
     pub fn from_millis(timestamp_millis: i64) -> Option<Self> {
-        timestamp_millis.checked_mul(1000).map(Self)
+        timestamp_millis.checked_mul(1000).and_then(Self::checked)
     }
 
-    /// Creates a `Timestamptz` from microseconds.
+    /// Creates a `Timestamptz` from microseconds, the internal representation, verbatim.
+    ///
+    /// Unlike the other constructors, this does not validate that the value is representable.
+    /// See #26397.
     pub fn from_micros(timestamp_micros: i64) -> Self {
         Self(timestamp_micros)
     }
 
-    /// Creates a `Timestamptz` from microseconds.
-    pub fn from_nanos(timestamp_nanos: i64) -> Option<Self> {
-        timestamp_nanos.checked_div(1_000).map(Self)
+    /// Creates a `Timestamptz` from nanoseconds, flooring to microseconds.
+    ///
+    /// An `i64` nanosecond count spans only ±292 years around the epoch, well within the
+    /// representable range, so this cannot fail.
+    pub fn from_nanos(timestamp_nanos: i64) -> Self {
+        Self(timestamp_nanos.div_euclid(1_000))
+    }
+
+    /// Returns `Some` only if the value converts to [`chrono::DateTime`], which formatting and
+    /// time zone operations require.
+    fn checked(timestamp_micros: i64) -> Option<Self> {
+        DateTime::from_timestamp_micros(timestamp_micros).map(|_| Self(timestamp_micros))
     }
 
     /// Returns the number of non-leap-microseconds since January 1, 1970 UTC.


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

- Closes #26396

Follow-up to #26224, closing the remaining panic / silent-accept gaps on the Arrow decode path (parquet source, `file_scan`, iceberg source, UDF returns):

- `Date`/`Interval` move to a new fallible `TryFromIntoArrow` trait: `Date32Type::to_naive_date` panics on large day counts; interval-to-Arrow `usecs * 1000` could overflow (now `checked_mul`). Sub-microsecond interval nanos keep truncating toward zero, now pinned by a test.
- `Timestamptz::from_secs`/`from_millis` validate chrono representability instead of only `i64` overflow, honoring their documented "`None` if out of range". This also covers non-Arrow callers (JSON/Avro/Kafka/CDC second/millisecond fields). The microsecond leg is validated at the Arrow call site; `from_micros` stays unchecked — see #26397.
- `Timestamptz::from_nanos` returns `Self` instead of a never-`None` `Option` (an `i64` nanosecond count spans only ±292 years, always in range), and floors (`div_euclid`) like the type's other unit accessors.

Drive-by dedup:

- `Timestamp::with_millis`/`with_micros` call chrono's constructors directly; add infallible `with_nanos`.
- `Time::nanos_of_day`/`micros_of_day` replace three hand-rolled copies of the same arithmetic.

## Checklist

- [x] I have written necessary rustdoc comments.
- [x] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->

## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates.

<details>
<summary><b>Release note</b></summary>

Out-of-range temporal values (`date`, `interval`, `timestamptz`) decoded from external sources — Parquet / `file_scan` / Iceberg / UDF returns, plus second/millisecond timestamp fields in JSON/Avro/Kafka/CDC — now fail with a conversion error instead of panicking the compute node. Writing an out-of-range `interval` to an Arrow-based sink or UDF errors instead of silently overflowing.

</details>
