### PR TITLE
fix(common): make Timestamptz representability a construction-time invariant

### DIFF
--- a/src/common/src/array/arrow/arrow_impl.rs
+++ b/src/common/src/array/arrow/arrow_impl.rs
@@ -177,9 +177,9 @@ pub trait ToArrow {
         &self,
         array: &TimestampArray,
     ) -> Result<arrow_array::ArrayRef, ArrayError> {
-        Ok(Arc::new(arrow_array::TimestampMicrosecondArray::from(
+        Ok(Arc::new(arrow_array::TimestampMicrosecondArray::try_from(
             array,
-        )))
+        )?))
     }
 
     #[inline]
@@ -188,13 +188,15 @@ pub trait ToArrow {
         array: &TimestamptzArray,
     ) -> Result<arrow_array::ArrayRef, ArrayError> {
         Ok(Arc::new(
-            arrow_array::TimestampMicrosecondArray::from(array).with_timezone_utc(),
+            arrow_array::TimestampMicrosecondArray::try_from(array)?.with_timezone_utc(),
         ))
     }
 
     #[inline]
     fn time_to_arrow(&self, array: &TimeArray) -> Result<arrow_array::ArrayRef, ArrayError> {
-        Ok(Arc::new(arrow_array::Time64MicrosecondArray::from(array)))
+        Ok(Arc::new(arrow_array::Time64MicrosecondArray::try_from(
+            array,
+        )?))
     }
 
     #[inline]
@@ -1215,12 +1217,18 @@ macro_rules! converts_with_type {
 
 macro_rules! converts_with_time_unit {
     ($ArrayType:ty, $ArrowType:ident, $time_unit:ident) => {
-        impl From<&$ArrayType> for arrow_array::$ArrowType {
-            fn from(array: &$ArrayType) -> Self {
-                array
-                    .iter()
-                    .map(|o| o.map(|v| into_arrow_temporal_value(v, TimeUnit::$time_unit)))
-                    .collect()
+        impl TryFrom<&$ArrayType> for arrow_array::$ArrowType {
+            type Error = ArrayError;
+
+            fn try_from(array: &$ArrayType) -> Result<Self, Self::Error> {
+                let mut builder = arrow_array::$ArrowType::builder(array.len());
+                for o in array.iter() {
+                    builder.append_option(
+                        o.map(|v| into_arrow_temporal_value(v, TimeUnit::$time_unit))
+                            .transpose()?,
+                    );
+                }
+                Ok(builder.finish())
             }
         }
 
@@ -1311,7 +1319,7 @@ trait TemporalArrowConvert<ArrowNative>: Sized {
         value: ArrowNative,
         time_unit: TimeUnit,
     ) -> Result<Self, ArrayError>;
-    fn into_arrow_with_time_unit(self, time_unit: TimeUnit) -> ArrowNative;
+    fn into_arrow_with_time_unit(self, time_unit: TimeUnit) -> Result<ArrowNative, ArrayError>;
 }
 
 fn try_from_arrow_temporal_value<Value, ArrowNative>(
@@ -1324,7 +1332,10 @@ where
     Value::try_from_arrow_with_time_unit(value, time_unit)
 }
 
-fn into_arrow_temporal_value<Value, ArrowNative>(value: Value, time_unit: TimeUnit) -> ArrowNative
+fn into_arrow_temporal_value<Value, ArrowNative>(
+    value: Value,
+    time_unit: TimeUnit,
+) -> Result<ArrowNative, ArrayError>
 where
     Value: TemporalArrowConvert<ArrowNative>,
 {
@@ -1395,15 +1406,15 @@ impl TemporalArrowConvert<i32> for Time {
             .ok_or_else(|| invalid_arrow_temporal_value(value, time_unit))
     }
 
-    fn into_arrow_with_time_unit(self, time_unit: TimeUnit) -> i32 {
-        match time_unit {
+    fn into_arrow_with_time_unit(self, time_unit: TimeUnit) -> Result<i32, ArrayError> {
+        Ok(match time_unit {
             TimeUnit::Second => self.0.num_seconds_from_midnight() as i32,
             TimeUnit::Millisecond => {
                 (self.0.num_seconds_from_midnight() * 1_000 + self.0.nanosecond() / 1_000_000)
                     as i32
             }
             unit => unreachable!("{unit:?} is not a Time32 unit"),
-        }
+        })
     }
 }
 
@@ -1422,12 +1433,12 @@ impl TemporalArrowConvert<i64> for Time {
             .ok_or_else(|| invalid_arrow_temporal_value(value, time_unit))
     }
 
-    fn into_arrow_with_time_unit(self, time_unit: TimeUnit) -> i64 {
-        match time_unit {
+    fn into_arrow_with_time_unit(self, time_unit: TimeUnit) -> Result<i64, ArrayError> {
+        Ok(match time_unit {
             TimeUnit::Microsecond => self.micros_of_day() as i64,
             TimeUnit::Nanosecond => self.nanos_of_day() as i64,
             unit => unreachable!("{unit:?} is not a Time64 unit"),
-        }
+        })
     }
 }
 
@@ -1444,12 +1455,16 @@ impl TemporalArrowConvert<i64> for Timestamp {
         }
     }
 
-    fn into_arrow_with_time_unit(self, time_unit: TimeUnit) -> i64 {
+    fn into_arrow_with_time_unit(self, time_unit: TimeUnit) -> Result<i64, ArrayError> {
         match time_unit {
-            TimeUnit::Second => self.0.and_utc().timestamp(),
-            TimeUnit::Millisecond => self.0.and_utc().timestamp_millis(),
-            TimeUnit::Microsecond => self.0.and_utc().timestamp_micros(),
-            TimeUnit::Nanosecond => self.0.and_utc().timestamp_nanos_opt().unwrap(),
+            TimeUnit::Second => Ok(self.0.and_utc().timestamp()),
+            TimeUnit::Millisecond => Ok(self.0.and_utc().timestamp_millis()),
+            TimeUnit::Microsecond => Ok(self.0.and_utc().timestamp_micros()),
+            TimeUnit::Nanosecond => self
+                .0
+                .and_utc()
+                .timestamp_nanos_opt()
+                .ok_or_else(|| arrow_temporal_value_overflow(self, time_unit)),
         }
     }
 }
@@ -1461,20 +1476,20 @@ impl TemporalArrowConvert<i64> for Timestamptz {
                 .ok_or_else(|| invalid_arrow_temporal_value(value, time_unit)),
             TimeUnit::Millisecond => Timestamptz::from_millis(value)
                 .ok_or_else(|| invalid_arrow_temporal_value(value, time_unit)),
-            // `Timestamptz::from_micros` does not validate; see #26397.
-            TimeUnit::Microsecond => DateTime::from_timestamp_micros(value)
-                .map(Timestamptz::from)
+            TimeUnit::Microsecond => Timestamptz::from_micros(value)
                 .ok_or_else(|| invalid_arrow_temporal_value(value, time_unit)),
             TimeUnit::Nanosecond => Ok(Timestamptz::from_nanos(value)),
         }
     }
 
-    fn into_arrow_with_time_unit(self, time_unit: TimeUnit) -> i64 {
+    fn into_arrow_with_time_unit(self, time_unit: TimeUnit) -> Result<i64, ArrayError> {
         match time_unit {
-            TimeUnit::Second => self.timestamp(),
-            TimeUnit::Millisecond => self.timestamp_millis(),
-            TimeUnit::Microsecond => self.timestamp_micros(),
-            TimeUnit::Nanosecond => self.timestamp_nanos().unwrap(),
+            TimeUnit::Second => Ok(self.timestamp()),
+            TimeUnit::Millisecond => Ok(self.timestamp_millis()),
+            TimeUnit::Microsecond => Ok(self.timestamp_micros()),
+            TimeUnit::Nanosecond => self
+                .timestamp_nanos()
+                .ok_or_else(|| arrow_temporal_value_overflow(self, time_unit)),
         }
     }
 }
@@ -1482,6 +1497,15 @@ impl TemporalArrowConvert<i64> for Timestamptz {
 fn invalid_arrow_temporal_value<T: std::fmt::Display>(value: T, time_unit: TimeUnit) -> ArrayError {
     ArrayError::from_arrow(format!(
         "invalid Arrow temporal value {value} for unit {time_unit:?}"
+    ))
+}
+
+fn arrow_temporal_value_overflow<T: std::fmt::Display>(
+    value: T,
+    time_unit: TimeUnit,
+) -> ArrayError {
+    ArrayError::to_arrow(format!(
+        "temporal value {value} overflows Arrow unit {time_unit:?}"
     ))
 }
 
@@ -2599,7 +2623,7 @@ mod tests {
     #[test]
     fn time() {
         let array = TimeArray::from_iter([None, Time::with_micro(24 * 3600 * 1_000_000 - 1).ok()]);
-        let arrow = arrow_array::Time64MicrosecondArray::from(&array);
+        let arrow = arrow_array::Time64MicrosecondArray::try_from(&array).unwrap();
         assert_eq!(TimeArray::try_from(&arrow).unwrap(), array);
     }
 
@@ -2610,7 +2634,7 @@ mod tests {
             Time::with_secs_nano(1, 0).ok(),
             Time::with_secs_nano(2, 0).ok(),
         ]);
-        let arrow = arrow_array::Time32SecondArray::from(&second_array);
+        let arrow = arrow_array::Time32SecondArray::try_from(&second_array).unwrap();
         assert_eq!(
             arrow,
             arrow_array::Time32SecondArray::from(vec![None, Some(1), Some(2)])
@@ -2622,7 +2646,7 @@ mod tests {
             Time::with_secs_nano(1, 0).ok(),
             Time::with_secs_nano(2, 123_000_000).ok(),
         ]);
-        let arrow = arrow_array::Time32MillisecondArray::from(&millisecond_array);
+        let arrow = arrow_array::Time32MillisecondArray::try_from(&millisecond_array).unwrap();
         assert_eq!(
             arrow,
             arrow_array::Time32MillisecondArray::from(vec![None, Some(1_000), Some(2_123)])
@@ -2634,7 +2658,7 @@ mod tests {
             Time::with_secs_nano(1, 0).ok(),
             Time::with_secs_nano(2, 123_456_000).ok(),
         ]);
-        let arrow = arrow_array::Time64MicrosecondArray::from(&microsecond_array);
+        let arrow = arrow_array::Time64MicrosecondArray::try_from(&microsecond_array).unwrap();
         assert_eq!(
             arrow,
             arrow_array::Time64MicrosecondArray::from(vec![None, Some(1_000_000), Some(2_123_456)])
@@ -2646,7 +2670,7 @@ mod tests {
             Time::with_secs_nano(1, 0).ok(),
             Time::with_secs_nano(2, 123_456_000).ok(),
         ]);
-        let arrow = arrow_array::Time64NanosecondArray::from(&nanosecond_array);
+        let arrow = arrow_array::Time64NanosecondArray::try_from(&nanosecond_array).unwrap();
         assert_eq!(
             arrow,
             arrow_array::Time64NanosecondArray::from(vec![
@@ -2663,15 +2687,15 @@ mod tests {
         let array = TimeArray::from_iter([Time::with_secs_nano(2, 123_456_789).ok()]);
 
         assert_eq!(
-            arrow_array::Time32SecondArray::from(&array),
+            arrow_array::Time32SecondArray::try_from(&array).unwrap(),
             arrow_array::Time32SecondArray::from(vec![Some(2)])
         );
         assert_eq!(
-            arrow_array::Time32MillisecondArray::from(&array),
+            arrow_array::Time32MillisecondArray::try_from(&array).unwrap(),
             arrow_array::Time32MillisecondArray::from(vec![Some(2_123)])
         );
         assert_eq!(
-            arrow_array::Time64MicrosecondArray::from(&array),
+            arrow_array::Time64MicrosecondArray::try_from(&array).unwrap(),
             arrow_array::Time64MicrosecondArray::from(vec![Some(2_123_456)])
         );
 
@@ -2805,8 +2829,22 @@ mod tests {
     fn timestamp() {
         let array =
             TimestampArray::from_iter([None, Timestamp::with_micros(123456789012345678).ok()]);
-        let arrow = arrow_array::TimestampMicrosecondArray::from(&array);
+        let arrow = arrow_array::TimestampMicrosecondArray::try_from(&array).unwrap();
         assert_eq!(TimestampArray::try_from(&arrow).unwrap(), array);
+    }
+
+    #[test]
+    fn timestamp_nanosecond_export_rejects_out_of_range_values() {
+        // Beyond ±year 2262, the value does not fit in `i64` nanoseconds.
+        let timestamp_array =
+            TimestampArray::from_iter([Timestamp::with_micros(9_300_000_000_000_000).ok()]);
+        let err = arrow_array::TimestampNanosecondArray::try_from(&timestamp_array).unwrap_err();
+        assert!(matches!(err, ArrayError::ToArrow(_)), "got {err:?}");
+
+        let timestamptz_array =
+            TimestamptzArray::from_iter([Timestamptz::from_micros(9_300_000_000_000_000).unwrap()]);
+        let err = arrow_array::TimestampNanosecondArray::try_from(&timestamptz_array).unwrap_err();
+        assert!(matches!(err, ArrayError::ToArrow(_)), "got {err:?}");
     }
 
     #[test]

--- a/src/common/src/cast/mod.rs
+++ b/src/common/src/cast/mod.rs
@@ -66,8 +66,8 @@ pub fn i64_to_timestamptz(t: i64) -> Result<Timestamptz> {
     match t.abs_diff(0) {
         0..E11 => Ok(Timestamptz::from_secs(t).unwrap()), // s
         E11..E14 => Ok(Timestamptz::from_millis(t).unwrap()), // ms
-        E14..E17 => Ok(Timestamptz::from_micros(t)),      // us
-        E17.. => Ok(Timestamptz::from_micros(t / 1000)),  // ns
+        E14..E17 => Ok(Timestamptz::from_micros(t).unwrap()), // us
+        E17.. => Ok(Timestamptz::from_micros(t / 1000).unwrap()), // ns
     }
 }
 

--- a/src/common/src/hash/key.rs
+++ b/src/common/src/hash/key.rs
@@ -615,7 +615,7 @@ impl HashKeySer<'_> for Timestamptz {
 
 impl HashKeyDe for Timestamptz {
     fn deserialize(_data_type: &DataType, mut buf: impl Buf) -> Self {
-        Timestamptz::from_micros(buf.get_i64_ne())
+        Timestamptz::from_micros_uncheck(buf.get_i64_ne())
     }
 }
 

--- a/src/common/src/test_utils/rand_array.rs
+++ b/src/common/src/test_utils/rand_array.rs
@@ -114,7 +114,7 @@ impl RandValue for Timestamp {
 
 impl RandValue for Timestamptz {
     fn rand_value<R: Rng>(rand: &mut R) -> Self {
-        Timestamptz::from_micros(rand.random())
+        Timestamp::rand_value(rand).0.and_utc().into()
     }
 }
 

--- a/src/common/src/types/mod.rs
+++ b/src/common/src/types/mod.rs
@@ -1501,7 +1501,7 @@ mod tests {
                     DataType::Timestamp,
                 ),
                 DataTypeName::Timestamptz => (
-                    ScalarImpl::Timestamptz(Timestamptz::from_micros(233333333)),
+                    ScalarImpl::Timestamptz(Timestamptz::from_micros(233333333).unwrap()),
                     DataType::Timestamptz,
                 ),
                 DataTypeName::Interval => (

--- a/src/common/src/types/timestamptz.rs
+++ b/src/common/src/types/timestamptz.rs
@@ -84,26 +84,37 @@ impl ToText for Timestamptz {
 }
 
 impl Timestamptz {
-    pub const MIN: Self = Self(i64::MIN);
-
     /// Creates a `Timestamptz` from seconds. Returns `None` if the given timestamp is out of range.
     pub fn from_secs(timestamp_secs: i64) -> Option<Self> {
         timestamp_secs
             .checked_mul(1_000_000)
-            .and_then(Self::checked)
+            .and_then(Self::from_micros)
     }
 
     /// Creates a `Timestamptz` from milliseconds. Returns `None` if the given timestamp is out of
     /// range.
     pub fn from_millis(timestamp_millis: i64) -> Option<Self> {
-        timestamp_millis.checked_mul(1000).and_then(Self::checked)
+        timestamp_millis
+            .checked_mul(1000)
+            .and_then(Self::from_micros)
     }
 
-    /// Creates a `Timestamptz` from microseconds, the internal representation, verbatim.
+    /// Creates a `Timestamptz` from microseconds. Returns `None` if the value does not convert to
+    /// [`chrono::DateTime`], which formatting and time zone operations require.
+    pub fn from_micros(timestamp_micros: i64) -> Option<Self> {
+        // Exactly the values `DateTime::from_timestamp_micros` accepts, as a cheap range check.
+        const MIN_MICROS: i64 = DateTime::<Utc>::MIN_UTC.timestamp_micros();
+        const MAX_MICROS: i64 = DateTime::<Utc>::MAX_UTC.timestamp_micros();
+        (MIN_MICROS..=MAX_MICROS)
+            .contains(&timestamp_micros)
+            .then_some(Self(timestamp_micros))
+    }
+
+    /// Creates a `Timestamptz` from microseconds without checking representability.
     ///
-    /// Unlike the other constructors, this does not validate that the value is representable.
-    /// See #26397.
-    pub fn from_micros(timestamp_micros: i64) -> Self {
+    /// For values provably in range (e.g. derived from a [`chrono::DateTime`]), or for decode
+    /// paths that must stay infallible and knowingly tolerate legacy out-of-range values.
+    pub fn from_micros_uncheck(timestamp_micros: i64) -> Self {
         Self(timestamp_micros)
     }
 
@@ -113,12 +124,6 @@ impl Timestamptz {
     /// representable range, so this cannot fail.
     pub fn from_nanos(timestamp_nanos: i64) -> Self {
         Self(timestamp_nanos.div_euclid(1_000))
-    }
-
-    /// Returns `Some` only if the value converts to [`chrono::DateTime`], which formatting and
-    /// time zone operations require.
-    fn checked(timestamp_micros: i64) -> Option<Self> {
-        DateTime::from_timestamp_micros(timestamp_micros).map(|_| Self(timestamp_micros))
     }
 
     /// Returns the number of non-leap-microseconds since January 1, 1970 UTC.
@@ -180,6 +185,9 @@ impl<Tz: TimeZone> From<chrono::DateTime<Tz>> for Timestamptz {
 
 impl From<Timestamptz> for chrono::DateTime<Utc> {
     fn from(tz: Timestamptz) -> Self {
+        // Every fallible constructor validates representability, so this can fail only for
+        // values built by `from_micros_uncheck`: a contract violation, or a legacy out-of-range
+        // value read back from storage (#26397).
         Utc.timestamp_opt(tz.timestamp(), tz.timestamp_subsec_nanos())
             .unwrap()
     }
@@ -254,6 +262,26 @@ mod test {
     use super::*;
 
     #[test]
+    fn from_micros_checks_representability() {
+        // The range check must accept exactly what `DateTime::from_timestamp_micros` accepts.
+        for micros in [
+            0,
+            i64::MAX,
+            i64::MIN,
+            8_210_266_876_799_999_999,  // chrono max
+            8_210_266_876_800_000_000,  // chrono max + 1
+            -8_334_601_228_800_000_000, // chrono min
+            -8_334_601_228_800_000_001, // chrono min - 1
+        ] {
+            assert_eq!(
+                Timestamptz::from_micros(micros).is_some(),
+                DateTime::from_timestamp_micros(micros).is_some(),
+                "mismatch at {micros}"
+            );
+        }
+    }
+
+    #[test]
     fn parse() {
         assert!("1999-01-08 04:05:06".parse::<Timestamptz>().is_err());
         assert_eq!(
@@ -261,7 +289,7 @@ mod test {
             "2022-08-03 02:34:02-08:00".parse::<Timestamptz>().unwrap()
         );
 
-        let expected = Ok(Timestamptz::from_micros(1689130892000000));
+        let expected = Ok(Timestamptz::from_micros(1689130892000000).unwrap());
         // Most standard: ISO 8601 & RFC 3339
         assert_eq!("2023-07-12T03:01:32Z".parse(), expected);
         assert_eq!("2023-07-12T03:01:32+00:00".parse(), expected);

--- a/src/common/src/util/value_encoding/mod.rs
+++ b/src/common/src/util/value_encoding/mod.rs
@@ -15,6 +15,8 @@
 //! Value encoding is an encoding format which converts the data into a binary form (not
 //! memcomparable, i.e., Key encoding).
 
+use std::sync::LazyLock;
+
 use bytes::{Buf, BufMut};
 use chrono::{Datelike, Timelike};
 use either::{Either, for_both};
@@ -22,6 +24,7 @@ use enum_as_inner::EnumAsInner;
 use risingwave_pb::data::PbDatum;
 
 use crate::array::ArrayImpl;
+use crate::log::LogSuppressor;
 use crate::row::Row;
 use crate::types::*;
 
@@ -360,7 +363,18 @@ fn deserialize_value(ty: &DataType, data: &mut impl Buf) -> Result<ScalarImpl> {
         DataType::Time => ScalarImpl::Time(deserialize_time(data)?),
         DataType::Timestamp => ScalarImpl::Timestamp(deserialize_timestamp(data)?),
         DataType::Timestamptz => {
-            ScalarImpl::Timestamptz(Timestamptz::from_micros(data.get_i64_le()))
+            let micros = data.get_i64_le();
+            let tz = Timestamptz::from_micros(micros).unwrap_or_else(|| {
+                // Values written before validation existed may be out of range (#26397). Keep
+                // them readable and report, so the row can still be read and deleted.
+                static LOG_SUPPRESSOR: LazyLock<LogSuppressor> =
+                    LazyLock::new(LogSuppressor::default);
+                if let Ok(suppressed_count) = LOG_SUPPRESSOR.check() {
+                    tracing::error!(suppressed_count, micros, "decoded out-of-range timestamptz");
+                }
+                Timestamptz::from_micros_uncheck(micros)
+            });
+            ScalarImpl::Timestamptz(tz)
         }
         DataType::Date => ScalarImpl::Date(deserialize_date(data)?),
         DataType::Jsonb => ScalarImpl::Jsonb(

--- a/src/connector/codec/src/decoder/avro/mod.rs
+++ b/src/connector/codec/src/decoder/avro/mod.rs
@@ -245,9 +245,11 @@ impl<'a> AvroParseOptionsInner<'a> {
                     uncategorized!("timestamptz with milliseconds {ms} * 1000 is out of range")
                 })?
                 .into(),
-            (DataType::Timestamptz, Value::TimestampMicros(us)) => {
-                Timestamptz::from_micros(*us).into()
-            }
+            (DataType::Timestamptz, Value::TimestampMicros(us)) => Timestamptz::from_micros(*us)
+                .ok_or_else(|| {
+                    uncategorized!("timestamptz with microseconds {us} is out of range")
+                })?
+                .into(),
 
             // ---- Interval -----
             (DataType::Interval, Value::Duration(duration)) => {

--- a/src/connector/src/parser/mysql.rs
+++ b/src/connector/src/parser/mysql.rs
@@ -200,7 +200,9 @@ pub fn mysql_datum_to_rw_datum(
                     mysql_datum_index
                 ),
                 Some(Ok(val)) => Ok(val.map(|v| {
-                    ScalarImpl::from(Timestamptz::from_micros(v.and_utc().timestamp_micros()))
+                    ScalarImpl::from(Timestamptz::from_micros_uncheck(
+                        v.and_utc().timestamp_micros(),
+                    ))
                 })),
                 Some(Err(err)) => Err(anyhow::Error::new(err)
                     .context("failed to deserialize MySQL value into rust value")

--- a/src/connector/src/parser/sql_server.rs
+++ b/src/connector/src/parser/sql_server.rs
@@ -202,18 +202,17 @@ impl<'a> tiberius::FromSql<'a> for TimestamptzTiberiusWrapper {
         let instant = time::OffsetDateTime::from_sql(value)?;
         instant
             .map(|instant| {
-                let micros = instant
+                let timestamptz = instant
                     .unix_timestamp_nanos()
                     .checked_div(1000)
                     .and_then(|micros| i64::try_from(micros).ok())
+                    .and_then(Timestamptz::from_micros)
                     .ok_or_else(|| {
                         tiberius::error::Error::Conversion(
                             "datetimeoffset is out of range for RisingWave timestamptz".into(),
                         )
                     })?;
-                Ok(TimestamptzTiberiusWrapper::from(Timestamptz::from_micros(
-                    micros,
-                )))
+                Ok(TimestamptzTiberiusWrapper::from(timestamptz))
             })
             .transpose()
     }

--- a/src/connector/src/parser/unified/json.rs
+++ b/src/connector/src/parser/unified/json.rs
@@ -596,7 +596,7 @@ impl JsonParseOptions {
                     .unwrap()
                     .parse::<Timestamp>()
                     .map(|naive_utc| {
-                        Timestamptz::from_micros(naive_utc.0.and_utc().timestamp_micros())
+                        Timestamptz::from_micros_uncheck(naive_utc.0.and_utc().timestamp_micros())
                     })
                     .map_err(|_| create_error())?
                     .into(),
@@ -615,7 +615,7 @@ impl JsonParseOptions {
                 .as_i64()
                 .and_then(|num| match self.timestamptz_handling {
                     TimestamptzHandling::GuessNumberUnit => i64_to_timestamptz(num).ok(),
-                    TimestamptzHandling::Micro => Some(Timestamptz::from_micros(num)),
+                    TimestamptzHandling::Micro => Timestamptz::from_micros(num),
                     TimestamptzHandling::Milli => Timestamptz::from_millis(num),
                     // When explicitly requested string format, number without units are rejected.
                     TimestamptzHandling::UtcString | TimestamptzHandling::UtcWithoutSuffix => None,

--- a/src/connector/src/sink/encoder/avro.rs
+++ b/src/connector/src/sink/encoder/avro.rs
@@ -1246,7 +1246,9 @@ mod tests {
     #[test]
     fn test_encode_avro_union() {
         let t = &DataType::Timestamptz;
-        let datum = Some(ScalarImpl::Timestamptz(Timestamptz::from_micros(1500)));
+        let datum = Some(ScalarImpl::Timestamptz(
+            Timestamptz::from_micros(1500).unwrap(),
+        ));
         let opt_micros = r#"["null", {"type": "long", "logicalType": "timestamp-micros"}]"#;
         let opt_millis = r#"["null", {"type": "long", "logicalType": "timestamp-millis"}]"#;
         let both = r#"[{"type": "long", "logicalType": "timestamp-millis"}, {"type": "long", "logicalType": "timestamp-micros"}]"#;

--- a/src/connector/src/sink/encoder/proto.rs
+++ b/src/connector/src/sink/encoder/proto.rs
@@ -540,7 +540,9 @@ mod tests {
                 Some(ScalarImpl::Utf8("".into())),
             ]))),
             Some(ScalarImpl::List(ListValue::from_iter([4, 0, 4]))),
-            Some(ScalarImpl::Timestamptz(Timestamptz::from_micros(3))),
+            Some(ScalarImpl::Timestamptz(
+                Timestamptz::from_micros(3).unwrap(),
+            )),
             Some(ScalarImpl::Map(
                 MapValue::try_from_kv(
                     ListValue::from_iter(["a", "b"]),

--- a/src/connector/src/sink/turbopuffer.rs
+++ b/src/connector/src/sink/turbopuffer.rs
@@ -1408,9 +1408,9 @@ mod tests {
                 1_781_582_706,
                 123_456_789,
             ))),
-            Some(ScalarImpl::Timestamptz(Timestamptz::from_micros(
-                1_781_598_707_000_000,
-            ))),
+            Some(ScalarImpl::Timestamptz(
+                Timestamptz::from_micros(1_781_598_707_000_000).unwrap(),
+            )),
             Some(ScalarImpl::Int64(12345)),
             Some(ScalarImpl::Int64(67890)),
             Some(ScalarImpl::List(ListValue::from_iter([

--- a/src/connector/src/source/cdc/source/message.rs
+++ b/src/connector/src/source/cdc/source/message.rs
@@ -67,9 +67,8 @@ pub struct DebeziumCdcMeta {
 impl DebeziumCdcMeta {
     // These `extract_xxx` methods are used to support the `INCLUDE TIMESTAMP/DATABASE_NAME/TABLE_NAME` feature
     pub fn extract_timestamp(&self) -> DatumRef<'_> {
-        Some(ScalarRefImpl::Timestamptz(
-            Timestamptz::from_millis(self.source_ts_ms).unwrap(),
-        ))
+        // Yield NULL rather than panicking on an out-of-range upstream `source.ts_ms`.
+        Timestamptz::from_millis(self.source_ts_ms).map(ScalarRefImpl::Timestamptz)
     }
 
     pub fn extract_database_name(&self) -> DatumRef<'_> {

--- a/src/expr/impl/src/scalar/date_bin.rs
+++ b/src/expr/impl/src/scalar/date_bin.rs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use chrono::DateTime;
 use risingwave_common::types::{Interval, Timestamp, Timestamptz};
 use risingwave_expr::{ExprError, Result, function};
 
@@ -22,11 +21,7 @@ pub fn date_bin_ts(stride: Interval, source: Timestamp, origin: Timestamp) -> Re
     let origin_us = origin.0.and_utc().timestamp_micros(); // origin to microseconds
 
     let binned_source_us = date_bin_inner(stride, source_us, origin_us)?;
-    Ok(Timestamp(
-        DateTime::from_timestamp_micros(binned_source_us)
-            .unwrap()
-            .naive_utc(),
-    ))
+    Timestamp::with_micros(binned_source_us).map_err(|_| ExprError::NumericOutOfRange)
 }
 
 #[function("date_bin(interval, timestamptz, timestamptz) -> timestamptz")]
@@ -39,7 +34,7 @@ pub fn date_bin_tstz(
     let origin_us = origin.timestamp_micros(); // origin to microseconds
 
     let binned_source_us = date_bin_inner(stride, source_us, origin_us)?;
-    Ok(Timestamptz::from_micros(binned_source_us))
+    Timestamptz::from_micros(binned_source_us).ok_or(ExprError::NumericOutOfRange)
 }
 
 fn date_bin_inner(stride: Interval, source_us: i64, origin_us: i64) -> Result<i64> {

--- a/src/expr/impl/src/scalar/date_trunc.rs
+++ b/src/expr/impl/src/scalar/date_trunc.rs
@@ -79,7 +79,9 @@ pub fn date_trunc_timestamptz_at_timezone(
             let fixed = instant_local.offset().fix();
             // `unwrap` is okay because `FixedOffset` always returns single unique conversion result.
             let truncated_local = truncated_naive.0.and_local_timezone(fixed).unwrap();
-            Ok(Timestamptz::from_micros(truncated_local.timestamp_micros()))
+            Ok(Timestamptz::from_micros_uncheck(
+                truncated_local.timestamp_micros(),
+            ))
         }
         _ => timestamp_at_time_zone(truncated_naive, timezone),
     }

--- a/src/expr/impl/src/scalar/timestamptz.rs
+++ b/src/expr/impl/src/scalar/timestamptz.rs
@@ -46,7 +46,7 @@ pub fn f64_sec_to_timestamptz(elem: F64) -> Result<Timestamptz> {
         .into_ordered()
         .try_into()
         .map_err(|_| ExprError::NumericOutOfRange)?;
-    Ok(Timestamptz::from_micros(micros))
+    Timestamptz::from_micros(micros).ok_or(ExprError::NumericOutOfRange)
 }
 
 #[function("at_time_zone(timestamptz, varchar) -> timestamp")]
@@ -93,7 +93,7 @@ pub fn timestamp_at_time_zone_internal(input: Timestamp, time_zone: Tz) -> Resul
         LocalResult::Ambiguous(_, latest) => latest,
     };
     let usec = instant_local.timestamp_micros();
-    Ok(Timestamptz::from_micros(usec))
+    Ok(Timestamptz::from_micros_uncheck(usec))
 }
 
 #[function("cast_with_time_zone(timestamptz, varchar) -> varchar")]
@@ -214,7 +214,7 @@ fn timestamptz_interval_quantitative(
     }
     let delta_usecs = r.usecs();
     let usecs = f(l.timestamp_micros(), delta_usecs).ok_or(ExprError::NumericOutOfRange)?;
-    Ok(Timestamptz::from_micros(usecs))
+    Timestamptz::from_micros(usecs).ok_or(ExprError::NumericOutOfRange)
 }
 
 #[cfg(test)]

--- a/src/expr/impl/src/scalar/tumble.rs
+++ b/src/expr/impl/src/scalar/tumble.rs
@@ -40,15 +40,13 @@ pub fn tumble_start_date(timestamp: Date, window_size: Interval) -> Result<Times
 pub fn tumble_start_date_time(timestamp: Timestamp, window_size: Interval) -> Result<Timestamp> {
     let timestamp_micro_second = timestamp.0.and_utc().timestamp_micros();
     let window_start_micro_second = get_window_start(timestamp_micro_second, window_size)?;
-    Ok(Timestamp::from_timestamp_uncheck(
-        window_start_micro_second / 1_000_000,
-        (window_start_micro_second % 1_000_000 * 1000) as u32,
-    ))
+    Timestamp::with_micros(window_start_micro_second).map_err(|_| ExprError::NumericOutOfRange)
 }
 
 #[function("tumble_start(timestamptz, interval) -> timestamptz")]
 pub fn tumble_start_timestamptz(tz: Timestamptz, window_size: Interval) -> Result<Timestamptz> {
-    get_window_start(tz.timestamp_micros(), window_size).map(Timestamptz::from_micros)
+    get_window_start(tz.timestamp_micros(), window_size)
+        .and_then(|us| Timestamptz::from_micros(us).ok_or(ExprError::NumericOutOfRange))
 }
 
 /// The common part of PostgreSQL function `timestamp_bin` and `timestamptz_bin`.
@@ -76,10 +74,7 @@ pub fn tumble_start_offset_date_time(
     let window_start_micro_second =
         get_window_start_with_offset(timestamp_micro_second, window_size, offset)?;
 
-    Ok(Timestamp::from_timestamp_uncheck(
-        window_start_micro_second / 1_000_000,
-        (window_start_micro_second % 1_000_000 * 1000) as u32,
-    ))
+    Timestamp::with_micros(window_start_micro_second).map_err(|_| ExprError::NumericOutOfRange)
 }
 
 #[inline(always)]
@@ -115,14 +110,14 @@ pub fn tumble_start_offset_timestamptz(
     offset: Interval,
 ) -> Result<Timestamptz> {
     get_window_start_with_offset(tz.timestamp_micros(), window_size, offset)
-        .map(Timestamptz::from_micros)
+        .and_then(|us| Timestamptz::from_micros(us).ok_or(ExprError::NumericOutOfRange))
 }
 
 #[cfg(test)]
 mod tests {
     use chrono::{Datelike, Timelike};
     use risingwave_common::types::test_utils::IntervalTestExt;
-    use risingwave_common::types::{Date, Interval};
+    use risingwave_common::types::{Date, Interval, Timestamp};
 
     use super::tumble_start_offset_date_time;
     use crate::scalar::tumble::{
@@ -140,6 +135,14 @@ mod tests {
         assert_eq!(w.hour(), 22);
         assert_eq!(w.minute(), 0);
         assert_eq!(w.second(), 0);
+    }
+
+    #[test]
+    fn test_tumble_start_negative_fractional() {
+        // A pre-1970 sub-second window start used to wrap `as u32` and panic.
+        let dt = "1969-12-31 23:59:58.450".parse::<Timestamp>().unwrap();
+        let w = tumble_start_date_time(dt, Interval::from_millis(100)).unwrap();
+        assert_eq!(w, "1969-12-31 23:59:58.400".parse::<Timestamp>().unwrap());
     }
 
     #[test]

--- a/src/frontend/src/handler/util.rs
+++ b/src/frontend/src/handler/util.rs
@@ -625,7 +625,7 @@ mod tests {
         assert_eq!(
             &f(
                 &T::Timestamptz,
-                S::Timestamptz(Timestamptz::from_micros(-1)),
+                S::Timestamptz(Timestamptz::from_micros(-1).unwrap()),
                 Format::Text
             ),
             "1969-12-31 23:59:59.999999+00:00"

--- a/src/jni_core/src/lib.rs
+++ b/src/jni_core/src/lib.rs
@@ -1258,7 +1258,7 @@ mod tests {
     fn test_timestamptz_to_i64() {
         assert_eq!(
             "2023-06-01 09:45:00+08:00".parse::<Timestamptz>().unwrap(),
-            Timestamptz::from_micros(1_685_583_900_000_000)
+            Timestamptz::from_micros(1_685_583_900_000_000).unwrap()
         );
     }
 }

--- a/src/stream/src/executor/eowc/eowc_gap_fill.rs
+++ b/src/stream/src/executor/eowc/eowc_gap_fill.rs
@@ -198,7 +198,7 @@ impl<S: StateStore> ExecutorInner<S> {
                         ScalarRefImpl::Timestamptz(_) => {
                             let micros = fill_time.0.and_utc().timestamp_micros();
                             ScalarImpl::Timestamptz(
-                                risingwave_common::types::Timestamptz::from_micros(micros),
+                                risingwave_common::types::Timestamptz::from_micros_uncheck(micros),
                             )
                         }
                         _ => unreachable!("Time column should be Timestamp or Timestamptz"),

--- a/src/stream/src/executor/gap_fill.rs
+++ b/src/stream/src/executor/gap_fill.rs
@@ -388,7 +388,7 @@ impl<S: StateStore> GapFillExecutor<S> {
                         ScalarRefImpl::Timestamptz(_) => {
                             let micros = fill_time.0.and_utc().timestamp_micros();
                             ScalarImpl::Timestamptz(
-                                risingwave_common::types::Timestamptz::from_micros(micros),
+                                risingwave_common::types::Timestamptz::from_micros_uncheck(micros),
                             )
                         }
                         _ => unreachable!("Time column should be Timestamp or Timestamptz"),


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

- Closes #26397

Stacked on #26398. `Timestamptz` stores `i64` microseconds but every calendar operation (formatting, `AT TIME ZONE`, `extract`, …) converts through `chrono::DateTime` and panics on values chrono cannot represent. Constructors disagreed on whether that is allowed; this PR makes representability a construction-time invariant.

- `from_micros` returns `Option`, validating like its siblings; new `from_micros_uncheck` (naming per `Timestamp::from_timestamp_uncheck`) for values provably in range — chrono round-trips, magnitude-dispatched casts, storage read-back.
- Remove unused `Timestamptz::MIN` (`Self(i64::MIN)` itself violated the invariant).
- Untrusted / arithmetic call sites propagate errors instead of silently accepting values that panic on read: `sec_to_timestamptz`, `timestamptz ± interval`, `tumble_start`, `date_bin`, Avro/JSON/SQL Server microsecond decode. CDC `INCLUDE TIMESTAMP` yields NULL instead of unwrapping on a bad upstream `source.ts_ms`.
- `value_encoding` decode reports (rate-limited) when it reads an out-of-range `timestamptz` instead of erroring: rows written before validation existed stay readable — and deletable, which a hard decode error would prevent (`DELETE` needs to read the old row).
- Naive `tumble_start` builds the window start via `Timestamp::with_micros` instead of hand-rolled secs/nsecs splitting: a pre-1970 timestamp with a sub-second window made the negative remainder wrap `as u32` and panic (`tumble_start('1969-12-31 23:59:58.45'::timestamp, interval '100' millisecond)`); it now returns the correct window start, and truly out-of-range results error.
- Arrow export (`into_arrow_with_time_unit`) becomes fallible: a valid timestamp beyond ±year 2262 exported to a nanosecond-unit Arrow schema returns `ArrayError::ToArrow` instead of hitting `timestamp_nanos().unwrap()` (introduced by #19221; today only reachable through tests, since production `ToArrow` uses microseconds — this defuses it before anyone wires nanosecond schemas). Export arrays now use pre-sized builders.

With this, the `.unwrap()` in `From<Timestamptz> for DateTime<Utc>` is backed by a real invariant: fallible constructors validate, and `_uncheck`/storage paths are trusted by contract.

## Checklist

- [x] I have written necessary rustdoc comments.
- [x] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->

## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates.

<details>
<summary><b>Release note</b></summary>

Operations that could previously store a `timestamptz` value outside the representable range (roughly ±262,000 years) — `sec_to_timestamptz`, `timestamptz ± interval`, `tumble_start`, `date_bin` with extreme inputs, and microsecond-unit timestamp fields from JSON/Avro/SQL Server sources — now return an out-of-range error at the point of computation or decode, instead of accepting a value that crashed the compute node the first time it was read.

</details>
