### PR TITLE
fix: preserve time travel epoch anchors

### DIFF
--- a/src/meta/src/hummock/manager/tests.rs
+++ b/src/meta/src/hummock/manager/tests.rs
@@ -3831,6 +3831,160 @@ async fn test_time_travel_vacuum_with_cross_database_epoch_order() {
 }
 
 #[tokio::test]
+async fn test_time_travel_vacuum_preserves_live_table_epoch_anchor() {
+    use chrono::Utc;
+    use risingwave_meta_model::object::ObjectType;
+    use risingwave_meta_model::table::{HandleConflictBehavior, TableType};
+    use risingwave_meta_model::{
+        hummock_epoch_to_version, hummock_time_travel_version, object, table,
+    };
+    use sea_orm::ActiveValue::Set;
+    use sea_orm::{EntityTrait, QueryOrder, QuerySelect};
+
+    async fn insert_live_table(env: &MetaSrvEnv, table_id: TableId) {
+        let now = Utc::now().naive_utc();
+        object::Entity::insert(object::ActiveModel {
+            oid: Set(table_id.as_object_id()),
+            obj_type: Set(ObjectType::Table),
+            owner_id: Set(1.into()),
+            schema_id: Set(None),
+            database_id: Set(None),
+            initialized_at: Set(now),
+            created_at: Set(now),
+            initialized_at_cluster_version: Set(None),
+            created_at_cluster_version: Set(None),
+        })
+        .exec(&env.meta_store_ref().conn)
+        .await
+        .unwrap();
+        table::Entity::insert(table::ActiveModel {
+            table_id: Set(table_id),
+            name: Set(format!("t{}", table_id.as_raw_id())),
+            optional_associated_source_id: Set(None),
+            table_type: Set(TableType::Table),
+            belongs_to_job_id: Set(None),
+            columns: Set(vec![].into()),
+            pk: Set(vec![].into()),
+            distribution_key: Set(Vec::<i32>::new().into()),
+            stream_key: Set(Vec::<i32>::new().into()),
+            append_only: Set(false),
+            fragment_id: Set(None),
+            vnode_col_index: Set(None),
+            row_id_index: Set(None),
+            value_indices: Set(Vec::<i32>::new().into()),
+            definition: Set(format!("CREATE TABLE t{}()", table_id.as_raw_id())),
+            handle_pk_conflict_behavior: Set(HandleConflictBehavior::NoCheck),
+            version_column_indices: Set(None),
+            read_prefix_len_hint: Set(0),
+            watermark_indices: Set(Vec::<i32>::new().into()),
+            dist_key_in_pk: Set(Vec::<i32>::new().into()),
+            dml_fragment_id: Set(None),
+            cardinality: Set(None),
+            cleaned_by_watermark: Set(false),
+            description: Set(None),
+            version: Set(None),
+            retention_seconds: Set(None),
+            cdc_table_id: Set(None),
+            vnode_count: Set(1),
+            webhook_info: Set(None),
+            engine: Set(None),
+            clean_watermark_index_in_pk: Set(None),
+            clean_watermark_indices: Set(None),
+            refreshable: Set(false),
+            vector_index_info: Set(None),
+            cdc_table_type: Set(None),
+        })
+        .exec(&env.meta_store_ref().conn)
+        .await
+        .unwrap();
+    }
+
+    async fn insert_version(env: &MetaSrvEnv, id: u64) {
+        let mut version = HummockVersion::default();
+        version.id = id.into();
+        hummock_time_travel_version::Entity::insert(hummock_time_travel_version::ActiveModel {
+            version_id: Set(version.id),
+            version: Set((&version.to_protobuf()).into()),
+        })
+        .exec(&env.meta_store_ref().conn)
+        .await
+        .unwrap();
+    }
+
+    async fn insert_epoch_mapping(env: &MetaSrvEnv, table_id: TableId, epoch: u64, version: u64) {
+        hummock_epoch_to_version::Entity::insert(hummock_epoch_to_version::ActiveModel {
+            epoch: Set(epoch.try_into().unwrap()),
+            table_id: Set(i64::from(table_id.as_raw_id())),
+            version_id: Set(version.into()),
+        })
+        .exec(&env.meta_store_ref().conn)
+        .await
+        .unwrap();
+    }
+
+    let (env, hummock_manager, _, _) = setup_compute_env(80).await;
+    let live_table = TableId::new(10_001);
+    let dropped_table = TableId::new(10_002);
+    insert_live_table(&env, live_table).await;
+    insert_version(&env, 10).await;
+    insert_version(&env, 11).await;
+    insert_version(&env, 12).await;
+    insert_epoch_mapping(&env, live_table, 100, 10).await;
+    insert_epoch_mapping(&env, dropped_table, 150, 10).await;
+
+    hummock_manager
+        .truncate_time_travel_metadata(250, HashMap::new())
+        .await
+        .unwrap();
+
+    let epoch_rows = hummock_epoch_to_version::Entity::find()
+        .order_by_asc(hummock_epoch_to_version::Column::Epoch)
+        .all(&env.meta_store_ref().conn)
+        .await
+        .unwrap();
+    assert_eq!(
+        epoch_rows
+            .iter()
+            .map(|row| {
+                (
+                    TableId::new(row.table_id as _),
+                    u64::try_from(row.epoch).unwrap(),
+                )
+            })
+            .collect_vec(),
+        vec![(live_table, 100)]
+    );
+    let version_ids: Vec<risingwave_meta_model::HummockVersionId> =
+        hummock_time_travel_version::Entity::find()
+            .select_only()
+            .column(hummock_time_travel_version::Column::VersionId)
+            .order_by_asc(hummock_time_travel_version::Column::VersionId)
+            .into_tuple()
+            .all(&env.meta_store_ref().conn)
+            .await
+            .unwrap();
+    assert_eq!(
+        version_ids.iter().map(|id| id.as_raw_id()).collect_vec(),
+        vec![10, 11, 12]
+    );
+    assert_eq!(
+        hummock_manager
+            .epoch_to_version(225, live_table)
+            .await
+            .unwrap()
+            .id
+            .as_raw_id(),
+        10
+    );
+    assert!(
+        hummock_manager
+            .epoch_to_version(225, dropped_table)
+            .await
+            .is_err()
+    );
+}
+
+#[tokio::test]
 async fn test_time_travel_vacuum_pins_snapshot_epoch() {
     use risingwave_hummock_sdk::level::Levels;
     use risingwave_meta_model::hummock_sstable_info::SstableInfoV2Backend;

--- a/src/meta/src/hummock/manager/time_travel.rs
+++ b/src/meta/src/hummock/manager/time_travel.rs
@@ -75,6 +75,15 @@ impl HummockManager {
             .start_timer();
         let min_pinned_version_id = self.context_info.read().await.min_pinned_version_id();
         let sql_store = self.env.meta_store_ref();
+        let live_time_travel_table_ids: Vec<_> = self
+            .metadata_manager
+            .catalog_controller
+            .list_time_travel_table_ids()
+            .await
+            .map_err(|e| Error::Internal(e.into()))?
+            .into_iter()
+            .map(|table_id| i64::from(table_id.as_raw_id()))
+            .collect();
         let txn = sql_store.conn.begin().await?;
 
         let epoch_watermark_model =
@@ -119,6 +128,39 @@ impl HummockManager {
                 pinned_snapshot_version_ids.insert(epoch_to_version.version_id);
             }
         }
+        let mut anchor_epoch_rows = HashSet::new();
+        let mut anchor_version_ids = HashSet::new();
+        if !live_time_travel_table_ids.is_empty() {
+            let anchor_epochs: Vec<(i64, risingwave_meta_model::Epoch)> =
+                hummock_epoch_to_version::Entity::find()
+                    .filter(hummock_epoch_to_version::Column::Epoch.lt(epoch_watermark_model))
+                    .filter(
+                        hummock_epoch_to_version::Column::TableId.is_in(live_time_travel_table_ids),
+                    )
+                    .select_only()
+                    .column(hummock_epoch_to_version::Column::TableId)
+                    .column_as(hummock_epoch_to_version::Column::Epoch.max(), "epoch")
+                    .group_by(hummock_epoch_to_version::Column::TableId)
+                    .into_tuple()
+                    .all(&txn)
+                    .await?;
+            for (table_id, epoch) in anchor_epochs {
+                let Some(epoch_to_version) =
+                    hummock_epoch_to_version::Entity::find_by_id((epoch, table_id))
+                        .one(&txn)
+                        .await?
+                else {
+                    tracing::warn!(
+                        table_id,
+                        ?epoch,
+                        "time travel anchor epoch mapping not found, skip anchoring"
+                    );
+                    continue;
+                };
+                anchor_epoch_rows.insert((epoch_to_version.epoch, epoch_to_version.table_id));
+                anchor_version_ids.insert(epoch_to_version.version_id);
+            }
+        }
 
         let mut pinned_replay_version_ids = HashSet::new();
         let mut pinned_delta_ids = HashSet::new();
@@ -156,6 +198,16 @@ impl HummockManager {
             .into_tuple::<HummockVersionId>()
             .one(&txn)
             .await?;
+        let version_watermark = anchor_version_ids.iter().copied().min().map_or(
+            version_watermark,
+            |anchor_version_id| {
+                Some(
+                    version_watermark.map_or(anchor_version_id, |version_watermark| {
+                        std::cmp::min(version_watermark, anchor_version_id)
+                    }),
+                )
+            },
+        );
         // metadata BELOW watermark_version_id will be truncated.
         let mut watermark_version_id = version_watermark.map_or(min_pinned_version_id, |id| {
             std::cmp::min(id, min_pinned_version_id)
@@ -190,7 +242,7 @@ impl HummockManager {
         }
         let mut delete_epoch_rows = hummock_epoch_to_version::Entity::delete_many()
             .filter(hummock_epoch_to_version::Column::Epoch.lt(epoch_watermark_model));
-        for (epoch, table_id) in &pinned_epoch_rows {
+        for (epoch, table_id) in pinned_epoch_rows.iter().chain(anchor_epoch_rows.iter()) {
             delete_epoch_rows = delete_epoch_rows.filter(
                 Condition::any()
                     .add(hummock_epoch_to_version::Column::Epoch.ne(*epoch))


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

- Closes #26393
- Preserve the newest expired `hummock_epoch_to_version` row per live time-travel table as an anchor during time-travel metadata vacuum.
- Include anchor version IDs in the version watermark so replay metadata needed by stalled live tables is not deleted.
- Scope anchors to live catalog tables so dropped tables do not pin old metadata, and add a regression test for the live-table anchor path.

## Checklist

- [ ] I have written necessary rustdoc comments.
- [x] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [x] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

Fixes time-travel reads for live tables whose streams stop committing longer than the retention watermark; in-retention `FOR SYSTEM_TIME AS OF` queries can continue resolving to the table's latest retained mapping.

</details>