### PR TITLE
fix(frontend): apply ACL filtering to rw_sources

### DIFF
--- a/e2e_test/ddl/show_object_privilege.slt
+++ b/e2e_test/ddl/show_object_privilege.slt
@@ -66,6 +66,10 @@ bash -c 'set -euo pipefail; out=$(PGPASSWORD=password psql -h "$SLT_HOST" -p "$S
 
 skipif madsim
 system ok
+bash -c 'set -euo pipefail; out=$(PGPASSWORD=password psql -h "$SLT_HOST" -p "$SLT_PORT" -U show_acl_user -d "$SLT_DB" -Atc "SELECT name, connector_props FROM rw_catalog.rw_sources WHERE schema_id = (SELECT id FROM rw_catalog.rw_schemas WHERE name = '\''show_acl'\'');"); ! grep -q "hidden_source" <<<"$out"; ! grep -q "datagen.rows.per.second" <<<"$out"'
+
+skipif madsim
+system ok
 bash -c 'set -euo pipefail; out=$(PGPASSWORD=password psql -h "$SLT_HOST" -p "$SLT_PORT" -U show_acl_user -d "$SLT_DB" -Atc "SHOW INTERNAL TABLES FROM show_acl;"); test -z "$out"'
 
 # Known-name probes should not return metadata for hidden tables.
@@ -113,6 +117,10 @@ GRANT SELECT ON SOURCE show_acl.hidden_source TO show_acl_user;
 skipif madsim
 system ok
 bash -c 'set -euo pipefail; for i in {1..20}; do out=$(PGPASSWORD=password psql -h "$SLT_HOST" -p "$SLT_PORT" -U show_acl_user -d "$SLT_DB" -Atc "SHOW SOURCES FROM show_acl;"); grep -q "show_acl.hidden_source" <<<"$out" && exit 0; sleep 1; done; echo "$out"; exit 1'
+
+skipif madsim
+system ok
+bash -c 'set -euo pipefail; for i in {1..20}; do out=$(PGPASSWORD=password psql -h "$SLT_HOST" -p "$SLT_PORT" -U show_acl_user -d "$SLT_DB" -Atc "SELECT name, connector_props FROM rw_catalog.rw_sources WHERE schema_id = (SELECT id FROM rw_catalog.rw_schemas WHERE name = '\''show_acl'\'');"); grep -q "hidden_source" <<<"$out" && grep -q "datagen.rows.per.second" <<<"$out" && exit 0; sleep 1; done; echo "$out"; exit 1'
 
 statement ok
 DROP SECRET show_acl.hidden_secret;

--- a/src/frontend/src/catalog/system_catalog/rw_catalog/rw_sources.rs
+++ b/src/frontend/src/catalog/system_catalog/rw_catalog/rw_sources.rs
@@ -55,12 +55,15 @@ fn read_rw_sources_info(reader: &SysCatalogReaderImpl) -> Result<Vec<RwSource>> 
     let catalog_reader = reader.catalog_reader.read_guard();
     let schemas = catalog_reader.iter_schemas(&reader.auth_context.database)?;
     let user_reader = reader.user_info_reader.read_guard();
+    let current_user = user_reader
+        .get_user_by_name(&reader.auth_context.user_name)
+        .expect("user not found");
     let users = user_reader.get_all_users();
     let username_map = user_reader.get_user_name_map();
 
     Ok(schemas
         .flat_map(|schema| {
-            schema.iter_source().map(|source| {
+            schema.iter_source_with_acl(current_user).map(|source| {
                 let format_encode_props_with_secrets = WithOptionsSecResolved::new(
                     source.info.format_encode_options.clone(),
                     source.info.format_encode_secret_refs.clone(),


### PR DESCRIPTION
## Summary
- apply ACL-aware source iteration in `rw_catalog.rw_sources`
- add regression coverage for source visibility before and after `SELECT` grants

## Tests
- `cargo fmt --check`
- `git diff --check`
- `cargo check -p risingwave_frontend --lib --locked`