### PR TITLE
fix(metrics): retain guarded metrics locally

### DIFF
--- a/src/common/metrics/src/guarded_metrics.rs
+++ b/src/common/metrics/src/guarded_metrics.rs
@@ -161,6 +161,69 @@ pub type LabelGuardedGauge = LabelGuardedMetric<Gauge>;
 pub type LabelGuardedLocalHistogram = LabelGuardedMetric<LocalHistogram>;
 pub type LabelGuardedLocalIntCounter = LabelGuardedMetric<LocalIntCounter>;
 
+pub type CachedLabelGuardedHistogramVec = CachedLabelGuardedMetricVec<VecBuilderOfHistogram>;
+pub type CachedLabelGuardedIntCounterVec =
+    CachedLabelGuardedMetricVec<VecBuilderOfCounter<AtomicU64>>;
+pub type CachedLabelGuardedIntGaugeVec = CachedLabelGuardedMetricVec<VecBuilderOfGauge<AtomicI64>>;
+pub type CachedLabelGuardedUintGaugeVec = CachedLabelGuardedMetricVec<VecBuilderOfGauge<AtomicU64>>;
+pub type CachedLabelGuardedGaugeVec = CachedLabelGuardedMetricVec<VecBuilderOfGauge<AtomicF64>>;
+
+#[derive(Clone)]
+pub struct CachedLabelGuardedMetricVec<T: MetricVecBuilder> {
+    metric_vec: LabelGuardedMetricVec<T>,
+    metrics: Arc<Mutex<HashMap<Box<[String]>, LabelGuardedMetric<T::M>>>>,
+}
+
+impl<T: MetricVecBuilder> CachedLabelGuardedMetricVec<T> {
+    pub fn new(metric_vec: LabelGuardedMetricVec<T>) -> Self {
+        Self {
+            metric_vec,
+            metrics: Default::default(),
+        }
+    }
+
+    pub fn with_metric<V, R>(
+        &self,
+        labels: &[V],
+        update: impl FnOnce(&LabelGuardedMetric<T::M>) -> R,
+    ) -> R
+    where
+        V: AsRef<str> + std::fmt::Debug,
+    {
+        let key = labels
+            .iter()
+            .map(|label| label.as_ref().to_owned())
+            .collect::<Box<[_]>>();
+        let mut metrics = self.metrics.lock();
+        let metric = metrics
+            .entry(key)
+            .or_insert_with(|| self.metric_vec.with_guarded_label_values(labels));
+        update(metric)
+    }
+
+    pub fn with_guarded_label_values<V: AsRef<str> + std::fmt::Debug>(
+        &self,
+        labels: &[V],
+    ) -> LabelGuardedMetric<T::M> {
+        self.metric_vec.with_guarded_label_values(labels)
+    }
+}
+
+impl<T: MetricVecBuilder> From<LabelGuardedMetricVec<T>> for CachedLabelGuardedMetricVec<T> {
+    fn from(metric_vec: LabelGuardedMetricVec<T>) -> Self {
+        Self::new(metric_vec)
+    }
+}
+
+impl<T: MetricVecBuilder> Debug for CachedLabelGuardedMetricVec<T> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct(format!("CachedLabelGuardedMetricVec<{}>", type_name::<T>()).as_str())
+            .field("metric_vec", &self.metric_vec)
+            .field("metrics", &self.metrics)
+            .finish()
+    }
+}
+
 fn gen_test_label<const N: usize>() -> [&'static str; N] {
     const TEST_LABELS: [&str; 5] = ["test1", "test2", "test3", "test4", "test5"];
     (0..N)

--- a/src/common/metrics/src/monitor/connection.rs
+++ b/src/common/metrics/src/monitor/connection.rs
@@ -41,7 +41,7 @@ use tower_service::Service;
 use tracing::{trace, warn};
 
 use crate::monitor::GLOBAL_METRICS_REGISTRY;
-use crate::{LabelGuardedIntCounterVec, register_guarded_int_counter_vec_with_registry};
+use crate::{CachedLabelGuardedIntCounterVec, register_guarded_int_counter_vec_with_registry};
 
 #[auto_impl::auto_impl(&mut)]
 pub trait MonitorAsyncReadWrite {
@@ -340,7 +340,7 @@ pub struct ConnectionMetrics {
     write_rate: IntCounterVec,
     writer_count: IntGaugeVec,
 
-    io_err_rate: LabelGuardedIntCounterVec,
+    io_err_rate: CachedLabelGuardedIntCounterVec,
 }
 
 pub static GLOBAL_CONNECTION_METRICS: LazyLock<ConnectionMetrics> =
@@ -411,7 +411,8 @@ impl ConnectionMetrics {
             &["connection_type", "uri", "op_type", "error_kind"],
             registry,
         )
-        .unwrap();
+        .unwrap()
+        .into();
 
         Self {
             connection_count,
@@ -797,17 +798,15 @@ impl MonitorAsyncReadWrite for MonitorAsyncReadWriteImpl {
     }
 
     fn on_read_err(&mut self, err: &Error) {
-        // No need to store the value returned from `with_guarded_label_values`
-        // because it is reporting a single error.
-        GLOBAL_CONNECTION_METRICS
-            .io_err_rate
-            .with_guarded_label_values(&[
+        GLOBAL_CONNECTION_METRICS.io_err_rate.with_metric(
+            &[
                 self.connection_type.as_str(),
                 self.endpoint.as_str(),
                 "read",
                 err.kind().to_string().as_str(),
-            ])
-            .inc();
+            ],
+            |metric| metric.inc(),
+        );
     }
 
     fn on_write(&mut self, size: usize) {
@@ -828,16 +827,14 @@ impl MonitorAsyncReadWrite for MonitorAsyncReadWriteImpl {
     }
 
     fn on_write_err(&mut self, err: &Error) {
-        // No need to store the value returned from `with_guarded_label_values`
-        // because it is reporting a single error.
-        GLOBAL_CONNECTION_METRICS
-            .io_err_rate
-            .with_guarded_label_values(&[
+        GLOBAL_CONNECTION_METRICS.io_err_rate.with_metric(
+            &[
                 self.connection_type.as_str(),
                 self.endpoint.as_str(),
                 "write",
                 err.kind().to_string().as_str(),
-            ])
-            .inc();
+            ],
+            |metric| metric.inc(),
+        );
     }
 }

--- a/src/connector/src/sink/iceberg/commit.rs
+++ b/src/connector/src/sink/iceberg/commit.rs
@@ -788,8 +788,7 @@ impl IcebergSinkCommitter {
         let metrics_labels = [&self.param.sink_name, &catalog_name, &table_name];
         GLOBAL_SINK_METRICS
             .iceberg_snapshot_num
-            .with_guarded_label_values(&metrics_labels)
-            .set(snapshot_num as i64);
+            .with_metric(&metrics_labels, |metric| metric.set(snapshot_num as i64));
 
         tracing::debug!(
             iceberg_component = "sink_committer",

--- a/src/connector/src/sink/mod.rs
+++ b/src/connector/src/sink/mod.rs
@@ -80,8 +80,8 @@ use risingwave_common::catalog::{ColumnDesc, Field, Schema};
 use risingwave_common::config::StreamingConfig;
 use risingwave_common::hash::ActorId;
 use risingwave_common::metrics::{
-    LabelGuardedHistogram, LabelGuardedHistogramVec, LabelGuardedIntCounter,
-    LabelGuardedIntCounterVec, LabelGuardedIntGaugeVec,
+    CachedLabelGuardedIntGaugeVec, LabelGuardedHistogram, LabelGuardedHistogramVec,
+    LabelGuardedIntCounter, LabelGuardedIntCounterVec, LabelGuardedIntGaugeVec,
 };
 use risingwave_common::monitor::GLOBAL_METRICS_REGISTRY;
 use risingwave_common::secret::{LocalSecretManager, SecretError};
@@ -490,7 +490,7 @@ pub struct SinkMetrics {
     pub iceberg_position_delete_cache_num: LabelGuardedIntGaugeVec,
     pub iceberg_partition_num: LabelGuardedIntGaugeVec,
     pub iceberg_write_bytes: LabelGuardedIntCounterVec,
-    pub iceberg_snapshot_num: LabelGuardedIntGaugeVec,
+    pub iceberg_snapshot_num: CachedLabelGuardedIntGaugeVec,
 }
 
 impl SinkMetrics {
@@ -622,7 +622,8 @@ impl SinkMetrics {
             &["sink_name", "catalog_name", "table_name"],
             registry
         )
-        .unwrap();
+        .unwrap()
+        .into();
 
         Self {
             sink_commit_duration,

--- a/src/connector/src/source/iceberg/metrics.rs
+++ b/src/connector/src/source/iceberg/metrics.rs
@@ -16,7 +16,7 @@ use std::sync::{Arc, LazyLock};
 
 use prometheus::{Registry, exponential_buckets, histogram_opts};
 use risingwave_common::metrics::{
-    LabelGuardedHistogramVec, LabelGuardedIntCounterVec, LabelGuardedIntGaugeVec,
+    CachedLabelGuardedHistogramVec, CachedLabelGuardedIntCounterVec, CachedLabelGuardedIntGaugeVec,
 };
 use risingwave_common::monitor::GLOBAL_METRICS_REGISTRY;
 use risingwave_common::{
@@ -27,45 +27,45 @@ use risingwave_common::{
 #[derive(Clone)]
 pub struct IcebergScanMetrics {
     // -- Existing --
-    pub iceberg_read_bytes: LabelGuardedIntCounterVec,
+    pub iceberg_read_bytes: CachedLabelGuardedIntCounterVec,
 
     // -- Snapshot & Discovery (List Executor) --
     /// Time difference (seconds) between the latest available snapshot and
     /// the last ingested snapshot.
-    pub iceberg_source_snapshot_lag_seconds: LabelGuardedIntGaugeVec,
+    pub iceberg_source_snapshot_lag_seconds: CachedLabelGuardedIntGaugeVec,
 
     /// Total number of snapshots discovered via incremental scan.
-    pub iceberg_source_snapshots_discovered_total: LabelGuardedIntCounterVec,
+    pub iceberg_source_snapshots_discovered_total: CachedLabelGuardedIntCounterVec,
 
     /// Time spent planning files from a snapshot (metadata operation).
-    pub iceberg_source_list_duration_seconds: LabelGuardedHistogramVec,
+    pub iceberg_source_list_duration_seconds: CachedLabelGuardedHistogramVec,
 
     /// Files discovered per scan, labeled by `file_type` (data, `eq_delete`, `pos_delete`).
-    pub iceberg_source_files_discovered_total: LabelGuardedIntCounterVec,
+    pub iceberg_source_files_discovered_total: CachedLabelGuardedIntCounterVec,
 
     // -- Data Reading (used in scan_task_to_chunk_with_deletes, labeled by table_name) --
     /// Per-file read duration.
-    pub iceberg_source_file_read_duration_seconds: LabelGuardedHistogramVec,
+    pub iceberg_source_file_read_duration_seconds: CachedLabelGuardedHistogramVec,
 
     /// Total rows read from Iceberg source.
-    pub iceberg_source_rows_read_total: LabelGuardedIntCounterVec,
+    pub iceberg_source_rows_read_total: CachedLabelGuardedIntCounterVec,
 
     /// Total files read from Iceberg source, labeled by `file_type`.
-    pub iceberg_source_files_read_total: LabelGuardedIntCounterVec,
+    pub iceberg_source_files_read_total: CachedLabelGuardedIntCounterVec,
 
     // -- Delete Handling --
     /// Rows removed by delete processing, labeled by `delete_type`.
-    pub iceberg_source_delete_rows_applied_total: LabelGuardedIntCounterVec,
+    pub iceberg_source_delete_rows_applied_total: CachedLabelGuardedIntCounterVec,
 
     /// Histogram of delete files attached per data file scan task.
-    pub iceberg_source_delete_files_per_data_file: LabelGuardedHistogramVec,
+    pub iceberg_source_delete_files_per_data_file: CachedLabelGuardedHistogramVec,
 
     // -- Operational Health --
     /// Number of files currently being fetched by the active reader.
-    pub iceberg_source_inflight_file_count: LabelGuardedIntGaugeVec,
+    pub iceberg_source_inflight_file_count: CachedLabelGuardedIntGaugeVec,
 
     /// Categorized scan error counter.
-    pub iceberg_source_scan_errors_total: LabelGuardedIntCounterVec,
+    pub iceberg_source_scan_errors_total: CachedLabelGuardedIntCounterVec,
 }
 
 impl IcebergScanMetrics {
@@ -76,7 +76,8 @@ impl IcebergScanMetrics {
             &["table_name"],
             registry
         )
-        .unwrap();
+        .unwrap()
+        .into();
 
         let iceberg_source_snapshot_lag_seconds = register_guarded_int_gauge_vec_with_registry!(
             "iceberg_source_snapshot_lag_seconds",
@@ -84,7 +85,8 @@ impl IcebergScanMetrics {
             &["source_id", "source_name", "table_name"],
             registry
         )
-        .unwrap();
+        .unwrap()
+        .into();
 
         let iceberg_source_snapshots_discovered_total =
             register_guarded_int_counter_vec_with_registry!(
@@ -93,13 +95,14 @@ impl IcebergScanMetrics {
                 &["source_id", "source_name", "table_name"],
                 registry
             )
-            .unwrap();
+            .unwrap()
+            .into();
 
         let iceberg_source_list_duration_seconds = register_guarded_histogram_vec_with_registry!(
             histogram_opts!(
                 "iceberg_source_list_duration_seconds",
                 "Time spent planning files from a snapshot",
-                exponential_buckets(0.01, 2.0, 15).unwrap() // 10ms to ~164s
+                exponential_buckets(0.01, 2.0, 15).unwrap().into() // 10ms to ~164s
             ),
             &["source_id", "source_name", "table_name"],
             registry
@@ -113,7 +116,8 @@ impl IcebergScanMetrics {
                 &["source_id", "source_name", "table_name", "file_type"],
                 registry
             )
-            .unwrap();
+            .unwrap()
+            .into();
 
         // Note: file-read metrics use ["table_name"] labels (matching iceberg_read_bytes)
         // because the scan function doesn't have source-level context.
@@ -122,7 +126,7 @@ impl IcebergScanMetrics {
                 histogram_opts!(
                     "iceberg_source_file_read_duration_seconds",
                     "Per-file read duration",
-                    exponential_buckets(0.01, 2.0, 15).unwrap() // 10ms to ~164s
+                    exponential_buckets(0.01, 2.0, 15).unwrap().into() // 10ms to ~164s
                 ),
                 &["table_name"],
                 registry
@@ -135,7 +139,8 @@ impl IcebergScanMetrics {
             &["table_name"],
             registry
         )
-        .unwrap();
+        .unwrap()
+        .into();
 
         let iceberg_source_files_read_total = register_guarded_int_counter_vec_with_registry!(
             "iceberg_source_files_read_total",
@@ -143,7 +148,8 @@ impl IcebergScanMetrics {
             &["table_name", "file_type"],
             registry
         )
-        .unwrap();
+        .unwrap()
+        .into();
 
         let iceberg_source_delete_rows_applied_total =
             register_guarded_int_counter_vec_with_registry!(
@@ -152,7 +158,8 @@ impl IcebergScanMetrics {
                 &["table_name", "delete_type"],
                 registry
             )
-            .unwrap();
+            .unwrap()
+            .into();
 
         let iceberg_source_delete_files_per_data_file =
             register_guarded_histogram_vec_with_registry!(
@@ -160,7 +167,7 @@ impl IcebergScanMetrics {
                     "iceberg_source_delete_files_per_data_file",
                     "Number of delete files attached per data file scan task",
                     // 1, 2, 4, 8, 16, 32, 64, 128
-                    exponential_buckets(1.0, 2.0, 8).unwrap()
+                    exponential_buckets(1.0, 2.0, 8).unwrap().into()
                 ),
                 &["source_id", "source_name", "table_name"],
                 registry
@@ -173,7 +180,8 @@ impl IcebergScanMetrics {
             &["source_id", "source_name", "table_name"],
             registry
         )
-        .unwrap();
+        .unwrap()
+        .into();
 
         let iceberg_source_scan_errors_total = register_guarded_int_counter_vec_with_registry!(
             "iceberg_source_scan_errors_total",
@@ -181,19 +189,22 @@ impl IcebergScanMetrics {
             &["source_id", "source_name", "table_name", "error_type"],
             registry
         )
-        .unwrap();
+        .unwrap()
+        .into();
 
         Self {
             iceberg_read_bytes,
             iceberg_source_snapshot_lag_seconds,
             iceberg_source_snapshots_discovered_total,
-            iceberg_source_list_duration_seconds,
+            iceberg_source_list_duration_seconds: iceberg_source_list_duration_seconds.into(),
             iceberg_source_files_discovered_total,
-            iceberg_source_file_read_duration_seconds,
+            iceberg_source_file_read_duration_seconds: iceberg_source_file_read_duration_seconds
+                .into(),
             iceberg_source_rows_read_total,
             iceberg_source_files_read_total,
             iceberg_source_delete_rows_applied_total,
-            iceberg_source_delete_files_per_data_file,
+            iceberg_source_delete_files_per_data_file: iceberg_source_delete_files_per_data_file
+                .into(),
             iceberg_source_inflight_file_count,
             iceberg_source_scan_errors_total,
         }

--- a/src/connector/src/source/iceberg/mod.rs
+++ b/src/connector/src/source/iceberg/mod.rs
@@ -470,8 +470,7 @@ pub async fn scan_task_to_chunk_with_deletes(
         if let Some(metrics) = metrics.clone() {
             metrics
                 .iceberg_read_bytes
-                .with_guarded_label_values(&[&table_name])
-                .inc_by(read_bytes as _);
+                .with_metric(&[&table_name], |metric| metric.inc_by(read_bytes as _));
         }
     });
 
@@ -547,22 +546,21 @@ pub async fn scan_task_to_chunk_with_deletes(
         // File read duration.
         metrics
             .iceberg_source_file_read_duration_seconds
-            .with_guarded_label_values(&label_values)
-            .observe(file_start.elapsed().as_secs_f64());
+            .with_metric(&label_values, |metric| {
+                metric.observe(file_start.elapsed().as_secs_f64())
+            });
 
         // Rows read.
         if total_rows_read > 0 {
             metrics
                 .iceberg_source_rows_read_total
-                .with_guarded_label_values(&label_values)
-                .inc_by(total_rows_read);
+                .with_metric(&label_values, |metric| metric.inc_by(total_rows_read));
         }
 
         // File read count.
         metrics
             .iceberg_source_files_read_total
-            .with_guarded_label_values(&[table_name.as_str(), "data"])
-            .inc();
+            .with_metric(&[table_name.as_str(), "data"], |metric| metric.inc());
 
         // APPROXIMATE: Estimate delete rows applied. The delta between expected_record_count
         // and actual rows read may also include predicate pushdown / row-group pruning effects,
@@ -576,8 +574,9 @@ pub async fn scan_task_to_chunk_with_deletes(
             if deleted > 0 {
                 metrics
                     .iceberg_source_delete_rows_applied_total
-                    .with_guarded_label_values(&[table_name.as_str(), "sdk_applied_approx"])
-                    .inc_by(deleted);
+                    .with_metric(&[table_name.as_str(), "sdk_applied_approx"], |metric| {
+                        metric.inc_by(deleted)
+                    });
             }
         }
     }

--- a/src/connector/src/source/iceberg/planner.rs
+++ b/src/connector/src/source/iceberg/planner.rs
@@ -106,35 +106,41 @@ impl IcebergScanMetricsLabels {
     pub fn record_scan_error(&self, error_kind: &str) {
         GLOBAL_ICEBERG_SCAN_METRICS
             .iceberg_source_scan_errors_total
-            .with_guarded_label_values(&[
-                self.source_id.as_str(),
-                self.source_name.as_str(),
-                self.table_name.as_str(),
-                error_kind,
-            ])
-            .inc();
+            .with_metric(
+                &[
+                    self.source_id.as_str(),
+                    self.source_name.as_str(),
+                    self.table_name.as_str(),
+                    error_kind,
+                ],
+                |metric| metric.inc(),
+            );
     }
 
     pub fn record_snapshot_discovered(&self) {
         GLOBAL_ICEBERG_SCAN_METRICS
             .iceberg_source_snapshots_discovered_total
-            .with_guarded_label_values(&[
-                self.source_id.as_str(),
-                self.source_name.as_str(),
-                self.table_name.as_str(),
-            ])
-            .inc();
+            .with_metric(
+                &[
+                    self.source_id.as_str(),
+                    self.source_name.as_str(),
+                    self.table_name.as_str(),
+                ],
+                |metric| metric.inc(),
+            );
     }
 
     pub fn record_snapshot_lag(&self, lag_secs: i64) {
         GLOBAL_ICEBERG_SCAN_METRICS
             .iceberg_source_snapshot_lag_seconds
-            .with_guarded_label_values(&[
-                self.source_id.as_str(),
-                self.source_name.as_str(),
-                self.table_name.as_str(),
-            ])
-            .set(lag_secs);
+            .with_metric(
+                &[
+                    self.source_id.as_str(),
+                    self.source_name.as_str(),
+                    self.table_name.as_str(),
+                ],
+                |metric| metric.set(lag_secs),
+            );
     }
 
     pub fn record_caught_up(&self) {
@@ -144,23 +150,27 @@ impl IcebergScanMetricsLabels {
     fn record_list_duration(&self, duration: Duration) {
         GLOBAL_ICEBERG_SCAN_METRICS
             .iceberg_source_list_duration_seconds
-            .with_guarded_label_values(&[
-                self.source_id.as_str(),
-                self.source_name.as_str(),
-                self.table_name.as_str(),
-            ])
-            .observe(duration.as_secs_f64());
+            .with_metric(
+                &[
+                    self.source_id.as_str(),
+                    self.source_name.as_str(),
+                    self.table_name.as_str(),
+                ],
+                |metric| metric.observe(duration.as_secs_f64()),
+            );
     }
 
     fn record_delete_files_per_data_file(&self, delete_file_count: usize) {
         GLOBAL_ICEBERG_SCAN_METRICS
             .iceberg_source_delete_files_per_data_file
-            .with_guarded_label_values(&[
-                self.source_id.as_str(),
-                self.source_name.as_str(),
-                self.table_name.as_str(),
-            ])
-            .observe(delete_file_count as f64);
+            .with_metric(
+                &[
+                    self.source_id.as_str(),
+                    self.source_name.as_str(),
+                    self.table_name.as_str(),
+                ],
+                |metric| metric.observe(delete_file_count as f64),
+            );
     }
 
     fn record_file_counts(&self, stats: &IcebergScanPlanStats) {
@@ -172,13 +182,15 @@ impl IcebergScanMetricsLabels {
             if count > 0 {
                 GLOBAL_ICEBERG_SCAN_METRICS
                     .iceberg_source_files_discovered_total
-                    .with_guarded_label_values(&[
-                        self.source_id.as_str(),
-                        self.source_name.as_str(),
-                        self.table_name.as_str(),
-                        file_type,
-                    ])
-                    .inc_by(count);
+                    .with_metric(
+                        &[
+                            self.source_id.as_str(),
+                            self.source_name.as_str(),
+                            self.table_name.as_str(),
+                            file_type,
+                        ],
+                        |metric| metric.inc_by(count),
+                    );
             }
         }
     }

--- a/src/connector/src/source/kafka/stats.rs
+++ b/src/connector/src/source/kafka/stats.rs
@@ -15,7 +15,7 @@
 use prometheus::Registry;
 use rdkafka::Statistics;
 use rdkafka::statistics::{Broker, ConsumerGroup, Partition, Topic, Window};
-use risingwave_common::metrics::{LabelGuardedIntGaugeVec, LabelGuardedUintGaugeVec};
+use risingwave_common::metrics::{CachedLabelGuardedIntGaugeVec, CachedLabelGuardedUintGaugeVec};
 use risingwave_common::{
     register_guarded_int_gauge_vec_with_registry, register_guarded_uint_gauge_vec_with_registry,
 };
@@ -24,24 +24,24 @@ use risingwave_common::{
 pub struct RdKafkaStats {
     pub registry: Registry,
 
-    pub ts: LabelGuardedIntGaugeVec,
-    pub time: LabelGuardedIntGaugeVec,
-    pub age: LabelGuardedIntGaugeVec,
-    pub replyq: LabelGuardedIntGaugeVec,
-    pub msg_cnt: LabelGuardedUintGaugeVec,
-    pub msg_size: LabelGuardedUintGaugeVec,
-    pub msg_max: LabelGuardedUintGaugeVec,
-    pub msg_size_max: LabelGuardedUintGaugeVec,
-    pub tx: LabelGuardedIntGaugeVec,
-    pub tx_bytes: LabelGuardedIntGaugeVec,
-    pub rx: LabelGuardedIntGaugeVec,
-    pub rx_bytes: LabelGuardedIntGaugeVec,
-    pub tx_msgs: LabelGuardedIntGaugeVec,
-    pub tx_msgs_bytes: LabelGuardedIntGaugeVec,
-    pub rx_msgs: LabelGuardedIntGaugeVec,
-    pub rx_msgs_bytes: LabelGuardedIntGaugeVec,
-    pub simple_cnt: LabelGuardedIntGaugeVec,
-    pub metadata_cache_cnt: LabelGuardedIntGaugeVec,
+    pub ts: CachedLabelGuardedIntGaugeVec,
+    pub time: CachedLabelGuardedIntGaugeVec,
+    pub age: CachedLabelGuardedIntGaugeVec,
+    pub replyq: CachedLabelGuardedIntGaugeVec,
+    pub msg_cnt: CachedLabelGuardedUintGaugeVec,
+    pub msg_size: CachedLabelGuardedUintGaugeVec,
+    pub msg_max: CachedLabelGuardedUintGaugeVec,
+    pub msg_size_max: CachedLabelGuardedUintGaugeVec,
+    pub tx: CachedLabelGuardedIntGaugeVec,
+    pub tx_bytes: CachedLabelGuardedIntGaugeVec,
+    pub rx: CachedLabelGuardedIntGaugeVec,
+    pub rx_bytes: CachedLabelGuardedIntGaugeVec,
+    pub tx_msgs: CachedLabelGuardedIntGaugeVec,
+    pub tx_msgs_bytes: CachedLabelGuardedIntGaugeVec,
+    pub rx_msgs: CachedLabelGuardedIntGaugeVec,
+    pub rx_msgs_bytes: CachedLabelGuardedIntGaugeVec,
+    pub simple_cnt: CachedLabelGuardedIntGaugeVec,
+    pub metadata_cache_cnt: CachedLabelGuardedIntGaugeVec,
 
     pub broker_stats: BrokerStats,
     pub topic_stats: TopicStats,
@@ -52,29 +52,29 @@ pub struct RdKafkaStats {
 pub struct BrokerStats {
     pub registry: Registry,
 
-    pub state_age: LabelGuardedIntGaugeVec,
-    pub outbuf_cnt: LabelGuardedIntGaugeVec,
-    pub outbuf_msg_cnt: LabelGuardedIntGaugeVec,
-    pub waitresp_cnt: LabelGuardedIntGaugeVec,
-    pub waitresp_msg_cnt: LabelGuardedIntGaugeVec,
-    pub tx: LabelGuardedUintGaugeVec,
-    pub tx_bytes: LabelGuardedUintGaugeVec,
-    pub tx_errs: LabelGuardedUintGaugeVec,
-    pub tx_retries: LabelGuardedUintGaugeVec,
-    pub tx_idle: LabelGuardedIntGaugeVec,
-    pub req_timeouts: LabelGuardedUintGaugeVec,
-    pub rx: LabelGuardedUintGaugeVec,
-    pub rx_bytes: LabelGuardedUintGaugeVec,
-    pub rx_errs: LabelGuardedUintGaugeVec,
-    pub rx_corriderrs: LabelGuardedUintGaugeVec,
-    pub rx_partial: LabelGuardedUintGaugeVec,
-    pub rx_idle: LabelGuardedIntGaugeVec,
-    pub req: LabelGuardedIntGaugeVec,
-    pub zbuf_grow: LabelGuardedUintGaugeVec,
-    pub buf_grow: LabelGuardedUintGaugeVec,
-    pub wakeups: LabelGuardedUintGaugeVec,
-    pub connects: LabelGuardedIntGaugeVec,
-    pub disconnects: LabelGuardedIntGaugeVec,
+    pub state_age: CachedLabelGuardedIntGaugeVec,
+    pub outbuf_cnt: CachedLabelGuardedIntGaugeVec,
+    pub outbuf_msg_cnt: CachedLabelGuardedIntGaugeVec,
+    pub waitresp_cnt: CachedLabelGuardedIntGaugeVec,
+    pub waitresp_msg_cnt: CachedLabelGuardedIntGaugeVec,
+    pub tx: CachedLabelGuardedUintGaugeVec,
+    pub tx_bytes: CachedLabelGuardedUintGaugeVec,
+    pub tx_errs: CachedLabelGuardedUintGaugeVec,
+    pub tx_retries: CachedLabelGuardedUintGaugeVec,
+    pub tx_idle: CachedLabelGuardedIntGaugeVec,
+    pub req_timeouts: CachedLabelGuardedUintGaugeVec,
+    pub rx: CachedLabelGuardedUintGaugeVec,
+    pub rx_bytes: CachedLabelGuardedUintGaugeVec,
+    pub rx_errs: CachedLabelGuardedUintGaugeVec,
+    pub rx_corriderrs: CachedLabelGuardedUintGaugeVec,
+    pub rx_partial: CachedLabelGuardedUintGaugeVec,
+    pub rx_idle: CachedLabelGuardedIntGaugeVec,
+    pub req: CachedLabelGuardedIntGaugeVec,
+    pub zbuf_grow: CachedLabelGuardedUintGaugeVec,
+    pub buf_grow: CachedLabelGuardedUintGaugeVec,
+    pub wakeups: CachedLabelGuardedUintGaugeVec,
+    pub connects: CachedLabelGuardedIntGaugeVec,
+    pub disconnects: CachedLabelGuardedIntGaugeVec,
     pub int_latency: StatsWindow,
     pub outbuf_latency: StatsWindow,
     pub rtt: StatsWindow,
@@ -85,7 +85,7 @@ pub struct BrokerStats {
 pub struct TopicStats {
     pub registry: Registry,
 
-    pub metadata_age: LabelGuardedIntGaugeVec,
+    pub metadata_age: CachedLabelGuardedIntGaugeVec,
     pub batch_size: StatsWindow,
     pub batch_cnt: StatsWindow,
     pub partitions: PartitionStats,
@@ -95,32 +95,32 @@ pub struct TopicStats {
 pub struct StatsWindow {
     pub registry: Registry,
 
-    pub min: LabelGuardedIntGaugeVec,
-    pub max: LabelGuardedIntGaugeVec,
-    pub avg: LabelGuardedIntGaugeVec,
-    pub sum: LabelGuardedIntGaugeVec,
-    pub cnt: LabelGuardedIntGaugeVec,
-    pub stddev: LabelGuardedIntGaugeVec,
-    pub hdr_size: LabelGuardedIntGaugeVec,
-    pub p50: LabelGuardedIntGaugeVec,
-    pub p75: LabelGuardedIntGaugeVec,
-    pub p90: LabelGuardedIntGaugeVec,
-    pub p95: LabelGuardedIntGaugeVec,
-    pub p99: LabelGuardedIntGaugeVec,
-    pub p99_99: LabelGuardedIntGaugeVec,
-    pub out_of_range: LabelGuardedIntGaugeVec,
+    pub min: CachedLabelGuardedIntGaugeVec,
+    pub max: CachedLabelGuardedIntGaugeVec,
+    pub avg: CachedLabelGuardedIntGaugeVec,
+    pub sum: CachedLabelGuardedIntGaugeVec,
+    pub cnt: CachedLabelGuardedIntGaugeVec,
+    pub stddev: CachedLabelGuardedIntGaugeVec,
+    pub hdr_size: CachedLabelGuardedIntGaugeVec,
+    pub p50: CachedLabelGuardedIntGaugeVec,
+    pub p75: CachedLabelGuardedIntGaugeVec,
+    pub p90: CachedLabelGuardedIntGaugeVec,
+    pub p95: CachedLabelGuardedIntGaugeVec,
+    pub p99: CachedLabelGuardedIntGaugeVec,
+    pub p99_99: CachedLabelGuardedIntGaugeVec,
+    pub out_of_range: CachedLabelGuardedIntGaugeVec,
 }
 
 #[derive(Debug, Clone)]
 pub struct ConsumerGroupStats {
     pub registry: Registry,
 
-    pub state_age: LabelGuardedIntGaugeVec,
+    pub state_age: CachedLabelGuardedIntGaugeVec,
     // todo: (do not know value set) join_state: IntGaugeVec,
-    pub rebalance_age: LabelGuardedIntGaugeVec,
-    pub rebalance_cnt: LabelGuardedIntGaugeVec,
+    pub rebalance_age: CachedLabelGuardedIntGaugeVec,
+    pub rebalance_cnt: CachedLabelGuardedIntGaugeVec,
     // todo: (cannot handle string) rebalance_reason,
-    pub assignment_size: LabelGuardedIntGaugeVec,
+    pub assignment_size: CachedLabelGuardedIntGaugeVec,
 }
 
 impl ConsumerGroupStats {
@@ -131,28 +131,32 @@ impl ConsumerGroupStats {
             &["id", "client_id", "state"],
             registry
         )
-        .unwrap();
+        .unwrap()
+        .into();
         let rebalance_age = register_guarded_int_gauge_vec_with_registry!(
             "rdkafka_consumer_group_rebalance_age",
             "Age of the last rebalance in seconds",
             &["id", "client_id", "state"],
             registry
         )
-        .unwrap();
+        .unwrap()
+        .into();
         let rebalance_cnt = register_guarded_int_gauge_vec_with_registry!(
             "rdkafka_consumer_group_rebalance_cnt",
             "Number of rebalances",
             &["id", "client_id", "state"],
             registry
         )
-        .unwrap();
+        .unwrap()
+        .into();
         let assignment_size = register_guarded_int_gauge_vec_with_registry!(
             "rdkafka_consumer_group_assignment_size",
             "Number of assigned partitions",
             &["id", "client_id", "state"],
             registry
         )
-        .unwrap();
+        .unwrap()
+        .into();
 
         Self {
             registry,
@@ -166,17 +170,19 @@ impl ConsumerGroupStats {
     pub fn report(&self, id: &str, client_id: &str, stats: &ConsumerGroup) {
         let state = stats.state.as_str();
         self.state_age
-            .with_guarded_label_values(&[id, client_id, state])
-            .set(stats.stateage);
+            .with_metric(&[id, client_id, state], |metric| metric.set(stats.stateage));
         self.rebalance_age
-            .with_guarded_label_values(&[id, client_id, state])
-            .set(stats.rebalance_age);
+            .with_metric(&[id, client_id, state], |metric| {
+                metric.set(stats.rebalance_age)
+            });
         self.rebalance_cnt
-            .with_guarded_label_values(&[id, client_id, state])
-            .set(stats.rebalance_cnt);
+            .with_metric(&[id, client_id, state], |metric| {
+                metric.set(stats.rebalance_cnt)
+            });
         self.assignment_size
-            .with_guarded_label_values(&[id, client_id, state])
-            .set(stats.assignment_size as i64);
+            .with_metric(&[id, client_id, state], |metric| {
+                metric.set(stats.assignment_size as i64)
+            });
     }
 }
 
@@ -189,98 +195,112 @@ impl StatsWindow {
             &["id", "client_id", "broker", "topic"],
             registry
         )
-        .unwrap();
+        .unwrap()
+        .into();
         let max = register_guarded_int_gauge_vec_with_registry!(
             get_metric_name("max"),
             "Maximum value",
             &["id", "client_id", "broker", "topic"],
             registry
         )
-        .unwrap();
+        .unwrap()
+        .into();
         let avg = register_guarded_int_gauge_vec_with_registry!(
             get_metric_name("avg"),
             "Average value",
             &["id", "client_id", "broker", "topic"],
             registry
         )
-        .unwrap();
+        .unwrap()
+        .into();
         let sum = register_guarded_int_gauge_vec_with_registry!(
             get_metric_name("sum"),
             "Sum of values",
             &["id", "client_id", "broker", "topic"],
             registry
         )
-        .unwrap();
+        .unwrap()
+        .into();
         let cnt = register_guarded_int_gauge_vec_with_registry!(
             get_metric_name("cnt"),
             "Count of values",
             &["id", "client_id", "broker", "topic"],
             registry
         )
-        .unwrap();
+        .unwrap()
+        .into();
         let stddev = register_guarded_int_gauge_vec_with_registry!(
             get_metric_name("stddev"),
             "Standard deviation",
             &["id", "client_id", "broker", "topic"],
             registry
         )
-        .unwrap();
+        .unwrap()
+        .into();
         let hdr_size = register_guarded_int_gauge_vec_with_registry!(
             get_metric_name("hdrsize"),
             "Size of the histogram header",
             &["id", "client_id", "broker", "topic"],
             registry
         )
-        .unwrap();
+        .unwrap()
+        .into();
         let p50 = register_guarded_int_gauge_vec_with_registry!(
             get_metric_name("p50"),
             "50th percentile",
             &["id", "client_id", "broker", "topic"],
             registry
         )
-        .unwrap();
+        .unwrap()
+        .into();
         let p75 = register_guarded_int_gauge_vec_with_registry!(
             get_metric_name("p75"),
             "75th percentile",
             &["id", "client_id", "broker", "topic"],
             registry
         )
-        .unwrap();
+        .unwrap()
+        .into();
         let p90 = register_guarded_int_gauge_vec_with_registry!(
             get_metric_name("p90"),
             "90th percentile",
             &["id", "client_id", "broker", "topic"],
             registry
         )
-        .unwrap();
+        .unwrap()
+        .into();
         let p95 = register_guarded_int_gauge_vec_with_registry!(
             get_metric_name("p95"),
             "95th percentile",
             &["id", "client_id", "broker", "topic"],
             registry
         )
-        .unwrap();
+        .unwrap()
+        .into();
         let p99 = register_guarded_int_gauge_vec_with_registry!(
             get_metric_name("p99"),
             "99th percentile",
             &["id", "client_id", "broker", "topic"],
             registry
         )
-        .unwrap();
+        .unwrap()
+        .into();
         let p99_99 = register_guarded_int_gauge_vec_with_registry!(
             get_metric_name("p99_99"),
             "99.99th percentile",
             &["id", "client_id", "broker", "topic"],
             registry
         )
-        .unwrap();
+        .unwrap()
+        .into();
         let out_of_range = register_guarded_int_gauge_vec_with_registry!(
             get_metric_name("out_of_range"),
             "Out of range values",
             &["id", "client_id", "broker", "topic"],
             registry
         )
-        .unwrap();
+        .unwrap()
+        .into();
 
         Self {
             registry,
@@ -304,26 +324,30 @@ impl StatsWindow {
     pub fn report(&self, id: &str, client_id: &str, broker: &str, topic: &str, stats: &Window) {
         let labels = [id, client_id, broker, topic];
 
-        self.min.with_guarded_label_values(&labels).set(stats.min);
-        self.max.with_guarded_label_values(&labels).set(stats.max);
-        self.avg.with_guarded_label_values(&labels).set(stats.avg);
-        self.sum.with_guarded_label_values(&labels).set(stats.sum);
-        self.cnt.with_guarded_label_values(&labels).set(stats.cnt);
+        self.min
+            .with_metric(&labels, |metric| metric.set(stats.min));
+        self.max
+            .with_metric(&labels, |metric| metric.set(stats.max));
+        self.avg
+            .with_metric(&labels, |metric| metric.set(stats.avg));
+        self.sum
+            .with_metric(&labels, |metric| metric.set(stats.sum));
+        self.cnt
+            .with_metric(&labels, |metric| metric.set(stats.cnt));
         self.stddev
-            .with_guarded_label_values(&labels)
-            .set(stats.stddev);
+            .with_metric(&labels, |metric| metric.set(stats.stddev));
         self.hdr_size
-            .with_guarded_label_values(&labels)
-            .set(stats.hdrsize);
-        self.p50.with_guarded_label_values(&labels).set(stats.p50);
-        self.p75.with_guarded_label_values(&labels).set(stats.p75);
-        self.p90.with_guarded_label_values(&labels).set(stats.p90);
+            .with_metric(&labels, |metric| metric.set(stats.hdrsize));
+        self.p50
+            .with_metric(&labels, |metric| metric.set(stats.p50));
+        self.p75
+            .with_metric(&labels, |metric| metric.set(stats.p75));
+        self.p90
+            .with_metric(&labels, |metric| metric.set(stats.p90));
         self.p99_99
-            .with_guarded_label_values(&labels)
-            .set(stats.p99_99);
+            .with_metric(&labels, |metric| metric.set(stats.p99_99));
         self.out_of_range
-            .with_guarded_label_values(&labels)
-            .set(stats.outofrange);
+            .with_metric(&labels, |metric| metric.set(stats.outofrange));
     }
 }
 
@@ -335,7 +359,8 @@ impl TopicStats {
             &["id", "client_id", "topic"],
             registry
         )
-        .unwrap();
+        .unwrap()
+        .into();
         let batch_size = StatsWindow::new(registry.clone(), "topic_batchsize");
         let batch_cnt = StatsWindow::new(registry.clone(), "topic_batchcnt");
         let partitions = PartitionStats::new(registry.clone());
@@ -356,8 +381,9 @@ impl TopicStats {
 
     fn report_inner(&self, id: &str, client_id: &str, topic: &str, stats: &Topic) {
         self.metadata_age
-            .with_guarded_label_values(&[id, client_id, topic])
-            .set(stats.metadata_age);
+            .with_metric(&[id, client_id, topic], |metric| {
+                metric.set(stats.metadata_age)
+            });
         self.batch_size
             .report(id, client_id, "", topic, &stats.batchsize);
         self.batch_cnt
@@ -370,32 +396,32 @@ impl TopicStats {
 pub struct PartitionStats {
     pub registry: Registry,
 
-    pub msgq_cnt: LabelGuardedIntGaugeVec,
-    pub msgq_bytes: LabelGuardedUintGaugeVec,
-    pub xmit_msgq_cnt: LabelGuardedIntGaugeVec,
-    pub xmit_msgq_bytes: LabelGuardedUintGaugeVec,
-    pub fetchq_cnt: LabelGuardedIntGaugeVec,
-    pub fetchq_size: LabelGuardedUintGaugeVec,
-    pub query_offset: LabelGuardedIntGaugeVec,
-    pub next_offset: LabelGuardedIntGaugeVec,
-    pub app_offset: LabelGuardedIntGaugeVec,
-    pub stored_offset: LabelGuardedIntGaugeVec,
-    pub committed_offset: LabelGuardedIntGaugeVec,
-    pub eof_offset: LabelGuardedIntGaugeVec,
-    pub lo_offset: LabelGuardedIntGaugeVec,
-    pub hi_offset: LabelGuardedIntGaugeVec,
-    pub consumer_lag: LabelGuardedIntGaugeVec,
-    pub consumer_lag_store: LabelGuardedIntGaugeVec,
-    pub txmsgs: LabelGuardedUintGaugeVec,
-    pub txbytes: LabelGuardedUintGaugeVec,
-    pub rxmsgs: LabelGuardedUintGaugeVec,
-    pub rxbytes: LabelGuardedUintGaugeVec,
-    pub msgs: LabelGuardedUintGaugeVec,
-    pub rx_ver_drops: LabelGuardedUintGaugeVec,
-    pub msgs_inflight: LabelGuardedIntGaugeVec,
-    pub next_ack_seq: LabelGuardedIntGaugeVec,
-    pub next_err_seq: LabelGuardedIntGaugeVec,
-    pub acked_msgid: LabelGuardedUintGaugeVec,
+    pub msgq_cnt: CachedLabelGuardedIntGaugeVec,
+    pub msgq_bytes: CachedLabelGuardedUintGaugeVec,
+    pub xmit_msgq_cnt: CachedLabelGuardedIntGaugeVec,
+    pub xmit_msgq_bytes: CachedLabelGuardedUintGaugeVec,
+    pub fetchq_cnt: CachedLabelGuardedIntGaugeVec,
+    pub fetchq_size: CachedLabelGuardedUintGaugeVec,
+    pub query_offset: CachedLabelGuardedIntGaugeVec,
+    pub next_offset: CachedLabelGuardedIntGaugeVec,
+    pub app_offset: CachedLabelGuardedIntGaugeVec,
+    pub stored_offset: CachedLabelGuardedIntGaugeVec,
+    pub committed_offset: CachedLabelGuardedIntGaugeVec,
+    pub eof_offset: CachedLabelGuardedIntGaugeVec,
+    pub lo_offset: CachedLabelGuardedIntGaugeVec,
+    pub hi_offset: CachedLabelGuardedIntGaugeVec,
+    pub consumer_lag: CachedLabelGuardedIntGaugeVec,
+    pub consumer_lag_store: CachedLabelGuardedIntGaugeVec,
+    pub txmsgs: CachedLabelGuardedUintGaugeVec,
+    pub txbytes: CachedLabelGuardedUintGaugeVec,
+    pub rxmsgs: CachedLabelGuardedUintGaugeVec,
+    pub rxbytes: CachedLabelGuardedUintGaugeVec,
+    pub msgs: CachedLabelGuardedUintGaugeVec,
+    pub rx_ver_drops: CachedLabelGuardedUintGaugeVec,
+    pub msgs_inflight: CachedLabelGuardedIntGaugeVec,
+    pub next_ack_seq: CachedLabelGuardedIntGaugeVec,
+    pub next_err_seq: CachedLabelGuardedIntGaugeVec,
+    pub acked_msgid: CachedLabelGuardedUintGaugeVec,
 }
 
 impl PartitionStats {
@@ -406,182 +432,208 @@ impl PartitionStats {
             &["id", "client_id", "topic", "partition"],
             registry
         )
-        .unwrap();
+        .unwrap()
+        .into();
         let msgq_bytes = register_guarded_uint_gauge_vec_with_registry!(
             "rdkafka_topic_partition_msgq_bytes",
             "Size of messages in the producer queue",
             &["id", "client_id", "topic", "partition"],
             registry
         )
-        .unwrap();
+        .unwrap()
+        .into();
         let xmit_msgq_cnt = register_guarded_int_gauge_vec_with_registry!(
             "rdkafka_topic_partition_xmit_msgq_cnt",
             "Number of messages in the transmit queue",
             &["id", "client_id", "topic", "partition"],
             registry
         )
-        .unwrap();
+        .unwrap()
+        .into();
         let xmit_msgq_bytes = register_guarded_uint_gauge_vec_with_registry!(
             "rdkafka_topic_partition_xmit_msgq_bytes",
             "Size of messages in the transmit queue",
             &["id", "client_id", "topic", "partition"],
             registry
         )
-        .unwrap();
+        .unwrap()
+        .into();
         let fetchq_cnt = register_guarded_int_gauge_vec_with_registry!(
             "rdkafka_topic_partition_fetchq_cnt",
             "Number of messages in the fetch queue",
             &["id", "client_id", "topic", "partition"],
             registry
         )
-        .unwrap();
+        .unwrap()
+        .into();
         let fetchq_size = register_guarded_uint_gauge_vec_with_registry!(
             "rdkafka_topic_partition_fetchq_size",
             "Size of messages in the fetch queue",
             &["id", "client_id", "topic", "partition"],
             registry
         )
-        .unwrap();
+        .unwrap()
+        .into();
         let query_offset = register_guarded_int_gauge_vec_with_registry!(
             "rdkafka_topic_partition_query_offset",
             "Current query offset",
             &["id", "client_id", "topic", "partition"],
             registry
         )
-        .unwrap();
+        .unwrap()
+        .into();
         let next_offset = register_guarded_int_gauge_vec_with_registry!(
             "rdkafka_topic_partition_next_offset",
             "Next offset to query",
             &["id", "client_id", "topic", "partition"],
             registry
         )
-        .unwrap();
+        .unwrap()
+        .into();
         let app_offset = register_guarded_int_gauge_vec_with_registry!(
             "rdkafka_topic_partition_app_offset",
             "Last acknowledged offset",
             &["id", "client_id", "topic", "partition"],
             registry
         )
-        .unwrap();
+        .unwrap()
+        .into();
         let stored_offset = register_guarded_int_gauge_vec_with_registry!(
             "rdkafka_topic_partition_stored_offset",
             "Last stored offset",
             &["id", "client_id", "topic", "partition"],
             registry
         )
-        .unwrap();
+        .unwrap()
+        .into();
         let committed_offset = register_guarded_int_gauge_vec_with_registry!(
             "rdkafka_topic_partition_committed_offset",
             "Last committed offset",
             &["id", "client_id", "topic", "partition"],
             registry
         )
-        .unwrap();
+        .unwrap()
+        .into();
         let eof_offset = register_guarded_int_gauge_vec_with_registry!(
             "rdkafka_topic_partition_eof_offset",
             "Last offset in broker log",
             &["id", "client_id", "topic", "partition"],
             registry
         )
-        .unwrap();
+        .unwrap()
+        .into();
         let lo_offset = register_guarded_int_gauge_vec_with_registry!(
             "rdkafka_topic_partition_lo_offset",
             "Low offset",
             &["id", "client_id", "topic", "partition"],
             registry
         )
-        .unwrap();
+        .unwrap()
+        .into();
         let hi_offset = register_guarded_int_gauge_vec_with_registry!(
             "rdkafka_topic_partition_hi_offset",
             "High offset",
             &["id", "client_id", "topic", "partition"],
             registry
         )
-        .unwrap();
+        .unwrap()
+        .into();
         let consumer_lag = register_guarded_int_gauge_vec_with_registry!(
             "rdkafka_topic_partition_consumer_lag",
             "Consumer lag",
             &["id", "client_id", "topic", "partition"],
             registry
         )
-        .unwrap();
+        .unwrap()
+        .into();
         let consumer_lag_store = register_guarded_int_gauge_vec_with_registry!(
             "rdkafka_topic_partition_consumer_lag_store",
             "Consumer lag stored",
             &["id", "client_id", "topic", "partition"],
             registry
         )
-        .unwrap();
+        .unwrap()
+        .into();
         let txmsgs = register_guarded_uint_gauge_vec_with_registry!(
             "rdkafka_topic_partition_txmsgs",
             "Number of transmitted messages",
             &["id", "client_id", "topic", "partition"],
             registry
         )
-        .unwrap();
+        .unwrap()
+        .into();
         let txbytes = register_guarded_uint_gauge_vec_with_registry!(
             "rdkafka_topic_partition_txbytes",
             "Number of transmitted bytes",
             &["id", "client_id", "topic", "partition"],
             registry
         )
-        .unwrap();
+        .unwrap()
+        .into();
         let rxmsgs = register_guarded_uint_gauge_vec_with_registry!(
             "rdkafka_topic_partition_rxmsgs",
             "Number of received messages",
             &["id", "client_id", "topic", "partition"],
             registry
         )
-        .unwrap();
+        .unwrap()
+        .into();
         let rxbytes = register_guarded_uint_gauge_vec_with_registry!(
             "rdkafka_topic_partition_rxbytes",
             "Number of received bytes",
             &["id", "client_id", "topic", "partition"],
             registry
         )
-        .unwrap();
+        .unwrap()
+        .into();
         let msgs = register_guarded_uint_gauge_vec_with_registry!(
             "rdkafka_topic_partition_msgs",
             "Number of messages in partition",
             &["id", "client_id", "topic", "partition"],
             registry
         )
-        .unwrap();
+        .unwrap()
+        .into();
         let rx_ver_drops = register_guarded_uint_gauge_vec_with_registry!(
             "rdkafka_topic_partition_rx_ver_drops",
             "Number of received messages dropped due to version mismatch",
             &["id", "client_id", "topic", "partition"],
             registry
         )
-        .unwrap();
+        .unwrap()
+        .into();
         let msgs_inflight = register_guarded_int_gauge_vec_with_registry!(
             "rdkafka_topic_partition_msgs_inflight",
             "Number of messages in-flight",
             &["id", "client_id", "topic", "partition"],
             registry
         )
-        .unwrap();
+        .unwrap()
+        .into();
         let next_ack_seq = register_guarded_int_gauge_vec_with_registry!(
             "rdkafka_topic_partition_next_ack_seq",
             "Next ack sequence number",
             &["id", "client_id", "topic", "partition"],
             registry
         )
-        .unwrap();
+        .unwrap()
+        .into();
         let next_err_seq = register_guarded_int_gauge_vec_with_registry!(
             "rdkafka_topic_partition_next_err_seq",
             "Next error sequence number",
             &["id", "client_id", "topic", "partition"],
             registry
         )
-        .unwrap();
+        .unwrap()
+        .into();
         let acked_msgid = register_guarded_uint_gauge_vec_with_registry!(
             "rdkafka_topic_partition_acked_msgid",
             "Acknowledged message ID",
             &["id", "client_id", "topic", "partition"],
             registry
         )
-        .unwrap();
+        .unwrap()
+        .into();
 
         Self {
             registry,
@@ -624,81 +676,57 @@ impl PartitionStats {
         let labels = [id, client_id, topic, &stats.partition.to_string()];
 
         self.msgq_cnt
-            .with_guarded_label_values(&labels)
-            .set(stats.msgq_cnt);
+            .with_metric(&labels, |metric| metric.set(stats.msgq_cnt));
         self.msgq_bytes
-            .with_guarded_label_values(&labels)
-            .set(stats.msgq_bytes);
+            .with_metric(&labels, |metric| metric.set(stats.msgq_bytes));
         self.xmit_msgq_cnt
-            .with_guarded_label_values(&labels)
-            .set(stats.xmit_msgq_cnt);
+            .with_metric(&labels, |metric| metric.set(stats.xmit_msgq_cnt));
         self.xmit_msgq_bytes
-            .with_guarded_label_values(&labels)
-            .set(stats.xmit_msgq_bytes);
+            .with_metric(&labels, |metric| metric.set(stats.xmit_msgq_bytes));
         self.fetchq_cnt
-            .with_guarded_label_values(&labels)
-            .set(stats.fetchq_cnt);
+            .with_metric(&labels, |metric| metric.set(stats.fetchq_cnt));
         self.fetchq_size
-            .with_guarded_label_values(&labels)
-            .set(stats.fetchq_size);
+            .with_metric(&labels, |metric| metric.set(stats.fetchq_size));
         self.query_offset
-            .with_guarded_label_values(&labels)
-            .set(stats.query_offset);
+            .with_metric(&labels, |metric| metric.set(stats.query_offset));
         self.next_offset
-            .with_guarded_label_values(&labels)
-            .set(stats.next_offset);
+            .with_metric(&labels, |metric| metric.set(stats.next_offset));
         self.app_offset
-            .with_guarded_label_values(&labels)
-            .set(stats.app_offset);
+            .with_metric(&labels, |metric| metric.set(stats.app_offset));
         self.stored_offset
-            .with_guarded_label_values(&labels)
-            .set(stats.stored_offset);
+            .with_metric(&labels, |metric| metric.set(stats.stored_offset));
         self.committed_offset
-            .with_guarded_label_values(&labels)
-            .set(stats.committed_offset);
+            .with_metric(&labels, |metric| metric.set(stats.committed_offset));
         self.eof_offset
-            .with_guarded_label_values(&labels)
-            .set(stats.eof_offset);
+            .with_metric(&labels, |metric| metric.set(stats.eof_offset));
         self.lo_offset
-            .with_guarded_label_values(&labels)
-            .set(stats.lo_offset);
+            .with_metric(&labels, |metric| metric.set(stats.lo_offset));
         self.hi_offset
-            .with_guarded_label_values(&labels)
-            .set(stats.hi_offset);
+            .with_metric(&labels, |metric| metric.set(stats.hi_offset));
         self.consumer_lag
-            .with_guarded_label_values(&labels)
-            .set(stats.consumer_lag);
+            .with_metric(&labels, |metric| metric.set(stats.consumer_lag));
         self.consumer_lag_store
-            .with_guarded_label_values(&labels)
-            .set(stats.consumer_lag_stored);
+            .with_metric(&labels, |metric| metric.set(stats.consumer_lag_stored));
         self.txmsgs
-            .with_guarded_label_values(&labels)
-            .set(stats.txmsgs);
+            .with_metric(&labels, |metric| metric.set(stats.txmsgs));
         self.txbytes
-            .with_guarded_label_values(&labels)
-            .set(stats.txbytes);
+            .with_metric(&labels, |metric| metric.set(stats.txbytes));
         self.rxmsgs
-            .with_guarded_label_values(&labels)
-            .set(stats.rxmsgs);
+            .with_metric(&labels, |metric| metric.set(stats.rxmsgs));
         self.rxbytes
-            .with_guarded_label_values(&labels)
-            .set(stats.rxbytes);
-        self.msgs.with_guarded_label_values(&labels).set(stats.msgs);
+            .with_metric(&labels, |metric| metric.set(stats.rxbytes));
+        self.msgs
+            .with_metric(&labels, |metric| metric.set(stats.msgs));
         self.rx_ver_drops
-            .with_guarded_label_values(&labels)
-            .set(stats.rx_ver_drops);
+            .with_metric(&labels, |metric| metric.set(stats.rx_ver_drops));
         self.msgs_inflight
-            .with_guarded_label_values(&labels)
-            .set(stats.msgs_inflight);
+            .with_metric(&labels, |metric| metric.set(stats.msgs_inflight));
         self.next_ack_seq
-            .with_guarded_label_values(&labels)
-            .set(stats.next_ack_seq);
+            .with_metric(&labels, |metric| metric.set(stats.next_ack_seq));
         self.next_err_seq
-            .with_guarded_label_values(&labels)
-            .set(stats.next_err_seq);
+            .with_metric(&labels, |metric| metric.set(stats.next_err_seq));
         self.acked_msgid
-            .with_guarded_label_values(&labels)
-            .set(stats.acked_msgid);
+            .with_metric(&labels, |metric| metric.set(stats.acked_msgid));
     }
 }
 
@@ -712,126 +740,144 @@ impl RdKafkaStats {
             &["id", "client_id"],
             registry
         )
-        .unwrap();
+        .unwrap()
+        .into();
         let time = register_guarded_int_gauge_vec_with_registry!(
             "rdkafka_top_time",
             "Wall clock time in seconds since the epoch",
             &["id", "client_id"],
             registry
         )
-        .unwrap();
+        .unwrap()
+        .into();
         let age = register_guarded_int_gauge_vec_with_registry!(
             "rdkafka_top_age",
             "Age of the topic metadata in milliseconds",
             &["id", "client_id"],
             registry
         )
-        .unwrap();
+        .unwrap()
+        .into();
         let replyq = register_guarded_int_gauge_vec_with_registry!(
             "rdkafka_top_replyq",
             "Number of replies waiting to be served",
             &["id", "client_id"],
             registry
         )
-        .unwrap();
+        .unwrap()
+        .into();
         let msg_cnt = register_guarded_uint_gauge_vec_with_registry!(
             "rdkafka_top_msg_cnt",
             "Number of messages in all topics",
             &["id", "client_id"],
             registry
         )
-        .unwrap();
+        .unwrap()
+        .into();
         let msg_size = register_guarded_uint_gauge_vec_with_registry!(
             "rdkafka_top_msg_size",
             "Size of messages in all topics",
             &["id", "client_id"],
             registry
         )
-        .unwrap();
+        .unwrap()
+        .into();
         let msg_max = register_guarded_uint_gauge_vec_with_registry!(
             "rdkafka_top_msg_max",
             "Maximum message size in all topics",
             &["id", "client_id"],
             registry
         )
-        .unwrap();
+        .unwrap()
+        .into();
         let msg_size_max = register_guarded_uint_gauge_vec_with_registry!(
             "rdkafka_top_msg_size_max",
             "Maximum message size in all topics",
             &["id", "client_id"],
             registry
         )
-        .unwrap();
+        .unwrap()
+        .into();
         let tx = register_guarded_int_gauge_vec_with_registry!(
             "rdkafka_top_tx",
             "Number of transmitted messages",
             &["id", "client_id"],
             registry
         )
-        .unwrap();
+        .unwrap()
+        .into();
         let tx_bytes = register_guarded_int_gauge_vec_with_registry!(
             "rdkafka_top_tx_bytes",
             "Number of transmitted bytes",
             &["id", "client_id"],
             registry
         )
-        .unwrap();
+        .unwrap()
+        .into();
         let rx = register_guarded_int_gauge_vec_with_registry!(
             "rdkafka_top_rx",
             "Number of received messages",
             &["id", "client_id"],
             registry
         )
-        .unwrap();
+        .unwrap()
+        .into();
         let rx_bytes = register_guarded_int_gauge_vec_with_registry!(
             "rdkafka_top_rx_bytes",
             "Number of received bytes",
             &["id", "client_id"],
             registry
         )
-        .unwrap();
+        .unwrap()
+        .into();
         let tx_msgs = register_guarded_int_gauge_vec_with_registry!(
             "rdkafka_top_tx_msgs",
             "Number of transmitted messages",
             &["id", "client_id"],
             registry
         )
-        .unwrap();
+        .unwrap()
+        .into();
         let tx_msgs_bytes = register_guarded_int_gauge_vec_with_registry!(
             "rdkafka_top_tx_msgs_bytes",
             "Number of transmitted bytes",
             &["id", "client_id"],
             registry
         )
-        .unwrap();
+        .unwrap()
+        .into();
         let rx_msgs = register_guarded_int_gauge_vec_with_registry!(
             "rdkafka_top_rx_msgs",
             "Number of received messages",
             &["id", "client_id"],
             registry
         )
-        .unwrap();
+        .unwrap()
+        .into();
         let rx_msgs_bytes = register_guarded_int_gauge_vec_with_registry!(
             "rdkafka_top_rx_msgs_bytes",
             "Number of received bytes",
             &["id", "client_id"],
             registry
         )
-        .unwrap();
+        .unwrap()
+        .into();
         let simple_cnt = register_guarded_int_gauge_vec_with_registry!(
             "rdkafka_top_simple_cnt",
             "Number of simple consumer queues",
             &["id", "client_id"],
             registry
         )
-        .unwrap();
+        .unwrap()
+        .into();
         let metadata_cache_cnt = register_guarded_int_gauge_vec_with_registry!(
             "rdkafka_top_metadata_cache_cnt",
             "Number of entries in the metadata cache",
             &["id", "client_id"],
             registry
         )
-        .unwrap();
+        .unwrap()
+        .into();
 
         let broker_stats = BrokerStats::new(registry.clone());
         let topic_stats = TopicStats::new(registry.clone());
@@ -865,59 +911,43 @@ impl RdKafkaStats {
     pub fn report(&self, id: &str, stats: &Statistics) {
         let client_id = stats.name.as_str();
         self.ts
-            .with_guarded_label_values(&[id, client_id])
-            .set(stats.ts);
+            .with_metric(&[id, client_id], |metric| metric.set(stats.ts));
         self.time
-            .with_guarded_label_values(&[id, client_id])
-            .set(stats.time);
+            .with_metric(&[id, client_id], |metric| metric.set(stats.time));
         self.age
-            .with_guarded_label_values(&[id, client_id])
-            .set(stats.age);
+            .with_metric(&[id, client_id], |metric| metric.set(stats.age));
         self.replyq
-            .with_guarded_label_values(&[id, client_id])
-            .set(stats.replyq);
+            .with_metric(&[id, client_id], |metric| metric.set(stats.replyq));
         self.msg_cnt
-            .with_guarded_label_values(&[id, client_id])
-            .set(stats.msg_cnt);
+            .with_metric(&[id, client_id], |metric| metric.set(stats.msg_cnt));
         self.msg_size
-            .with_guarded_label_values(&[id, client_id])
-            .set(stats.msg_size);
+            .with_metric(&[id, client_id], |metric| metric.set(stats.msg_size));
         self.msg_max
-            .with_guarded_label_values(&[id, client_id])
-            .set(stats.msg_max);
+            .with_metric(&[id, client_id], |metric| metric.set(stats.msg_max));
         self.msg_size_max
-            .with_guarded_label_values(&[id, client_id])
-            .set(stats.msg_size_max);
+            .with_metric(&[id, client_id], |metric| metric.set(stats.msg_size_max));
         self.tx
-            .with_guarded_label_values(&[id, client_id])
-            .set(stats.tx);
+            .with_metric(&[id, client_id], |metric| metric.set(stats.tx));
         self.tx_bytes
-            .with_guarded_label_values(&[id, client_id])
-            .set(stats.tx_bytes);
+            .with_metric(&[id, client_id], |metric| metric.set(stats.tx_bytes));
         self.rx
-            .with_guarded_label_values(&[id, client_id])
-            .set(stats.rx);
+            .with_metric(&[id, client_id], |metric| metric.set(stats.rx));
         self.rx_bytes
-            .with_guarded_label_values(&[id, client_id])
-            .set(stats.rx_bytes);
+            .with_metric(&[id, client_id], |metric| metric.set(stats.rx_bytes));
         self.tx_msgs
-            .with_guarded_label_values(&[id, client_id])
-            .set(stats.txmsgs);
+            .with_metric(&[id, client_id], |metric| metric.set(stats.txmsgs));
         self.tx_msgs_bytes
-            .with_guarded_label_values(&[id, client_id])
-            .set(stats.txmsg_bytes);
+            .with_metric(&[id, client_id], |metric| metric.set(stats.txmsg_bytes));
         self.rx_msgs
-            .with_guarded_label_values(&[id, client_id])
-            .set(stats.rxmsgs);
+            .with_metric(&[id, client_id], |metric| metric.set(stats.rxmsgs));
         self.rx_msgs_bytes
-            .with_guarded_label_values(&[id, client_id])
-            .set(stats.rxmsg_bytes);
+            .with_metric(&[id, client_id], |metric| metric.set(stats.rxmsg_bytes));
         self.simple_cnt
-            .with_guarded_label_values(&[id, client_id])
-            .set(stats.simple_cnt);
+            .with_metric(&[id, client_id], |metric| metric.set(stats.simple_cnt));
         self.metadata_cache_cnt
-            .with_guarded_label_values(&[id, client_id])
-            .set(stats.metadata_cache_cnt);
+            .with_metric(&[id, client_id], |metric| {
+                metric.set(stats.metadata_cache_cnt)
+            });
 
         self.broker_stats.report(id, client_id, stats);
         self.topic_stats.report(id, client_id, stats);
@@ -935,161 +965,184 @@ impl BrokerStats {
             &["id", "client_id", "broker", "state"],
             registry
         )
-        .unwrap();
+        .unwrap()
+        .into();
         let outbuf_cnt = register_guarded_int_gauge_vec_with_registry!(
             "rdkafka_broker_outbuf_cnt",
             "Number of messages waiting to be sent to broker",
             &["id", "client_id", "broker", "state"],
             registry
         )
-        .unwrap();
+        .unwrap()
+        .into();
         let outbuf_msg_cnt = register_guarded_int_gauge_vec_with_registry!(
             "rdkafka_broker_outbuf_msg_cnt",
             "Number of messages waiting to be sent to broker",
             &["id", "client_id", "broker", "state"],
             registry
         )
-        .unwrap();
+        .unwrap()
+        .into();
         let waitresp_cnt = register_guarded_int_gauge_vec_with_registry!(
             "rdkafka_broker_waitresp_cnt",
             "Number of requests waiting for response",
             &["id", "client_id", "broker", "state"],
             registry
         )
-        .unwrap();
+        .unwrap()
+        .into();
         let waitresp_msg_cnt = register_guarded_int_gauge_vec_with_registry!(
             "rdkafka_broker_waitresp_msg_cnt",
             "Number of messages waiting for response",
             &["id", "client_id", "broker", "state"],
             registry
         )
-        .unwrap();
+        .unwrap()
+        .into();
         let tx = register_guarded_uint_gauge_vec_with_registry!(
             "rdkafka_broker_tx",
             "Number of transmitted messages",
             &["id", "client_id", "broker", "state"],
             registry
         )
-        .unwrap();
+        .unwrap()
+        .into();
         let tx_bytes = register_guarded_uint_gauge_vec_with_registry!(
             "rdkafka_broker_tx_bytes",
             "Number of transmitted bytes",
             &["id", "client_id", "broker", "state"],
             registry
         )
-        .unwrap();
+        .unwrap()
+        .into();
         let tx_errs = register_guarded_uint_gauge_vec_with_registry!(
             "rdkafka_broker_tx_errs",
             "Number of failed transmitted messages",
             &["id", "client_id", "broker", "state"],
             registry
         )
-        .unwrap();
+        .unwrap()
+        .into();
         let tx_retries = register_guarded_uint_gauge_vec_with_registry!(
             "rdkafka_broker_tx_retries",
             "Number of message retries",
             &["id", "client_id", "broker", "state"],
             registry
         )
-        .unwrap();
+        .unwrap()
+        .into();
         let tx_idle = register_guarded_int_gauge_vec_with_registry!(
             "rdkafka_broker_tx_idle",
             "Number of idle transmit connections",
             &["id", "client_id", "broker", "state"],
             registry
         )
-        .unwrap();
+        .unwrap()
+        .into();
         let req_timeouts = register_guarded_uint_gauge_vec_with_registry!(
             "rdkafka_broker_req_timeouts",
             "Number of request timeouts",
             &["id", "client_id", "broker", "state"],
             registry
         )
-        .unwrap();
+        .unwrap()
+        .into();
         let rx = register_guarded_uint_gauge_vec_with_registry!(
             "rdkafka_broker_rx",
             "Number of received messages",
             &["id", "client_id", "broker", "state"],
             registry
         )
-        .unwrap();
+        .unwrap()
+        .into();
         let rx_bytes = register_guarded_uint_gauge_vec_with_registry!(
             "rdkafka_broker_rx_bytes",
             "Number of received bytes",
             &["id", "client_id", "broker", "state"],
             registry
         )
-        .unwrap();
+        .unwrap()
+        .into();
         let rx_errs = register_guarded_uint_gauge_vec_with_registry!(
             "rdkafka_broker_rx_errs",
             "Number of failed received messages",
             &["id", "client_id", "broker", "state"],
             registry
         )
-        .unwrap();
+        .unwrap()
+        .into();
         let rx_corriderrs = register_guarded_uint_gauge_vec_with_registry!(
             "rdkafka_broker_rx_corriderrs",
             "Number of received messages with invalid correlation id",
             &["id", "client_id", "broker", "state"],
             registry
         )
-        .unwrap();
+        .unwrap()
+        .into();
         let rx_partial = register_guarded_uint_gauge_vec_with_registry!(
             "rdkafka_broker_rx_partial",
             "Number of partial messages received",
             &["id", "client_id", "broker", "state"],
             registry
         )
-        .unwrap();
+        .unwrap()
+        .into();
         let rx_idle = register_guarded_int_gauge_vec_with_registry!(
             "rdkafka_broker_rx_idle",
             "Number of idle receive connections",
             &["id", "client_id", "broker", "state"],
             registry
         )
-        .unwrap();
+        .unwrap()
+        .into();
         let req = register_guarded_int_gauge_vec_with_registry!(
             "rdkafka_broker_req",
             "Number of requests in flight",
             &["id", "client_id", "broker", "state", "type"],
             registry
         )
-        .unwrap();
+        .unwrap()
+        .into();
         let zbuf_grow = register_guarded_uint_gauge_vec_with_registry!(
             "rdkafka_broker_zbuf_grow",
             "Number of times the broker's output buffer has been reallocated",
             &["id", "client_id", "broker", "state"],
             registry
         )
-        .unwrap();
+        .unwrap()
+        .into();
         let buf_grow = register_guarded_uint_gauge_vec_with_registry!(
             "rdkafka_broker_buf_grow",
             "Number of times the broker's input buffer has been reallocated",
             &["id", "client_id", "broker", "state"],
             registry
         )
-        .unwrap();
+        .unwrap()
+        .into();
         let wakeups = register_guarded_uint_gauge_vec_with_registry!(
             "rdkafka_broker_wakeups",
             "Number of wakeups",
             &["id", "client_id", "broker", "state"],
             registry
         )
-        .unwrap();
+        .unwrap()
+        .into();
         let connects = register_guarded_int_gauge_vec_with_registry!(
             "rdkafka_broker_connects",
             "Number of connection attempts",
             &["id", "client_id", "broker", "state"],
             registry
         )
-        .unwrap();
+        .unwrap()
+        .into();
         let disconnects = register_guarded_int_gauge_vec_with_registry!(
             "rdkafka_broker_disconnects",
             "Number of disconnects",
             &["id", "client_id", "broker", "state"],
             registry
         )
-        .unwrap();
+        .unwrap()
+        .into();
         let int_latency = StatsWindow::new(registry.clone(), "broker_intlatency");
         let outbuf_latency = StatsWindow::new(registry.clone(), "broker_outbuflatency");
         let rtt = StatsWindow::new(registry.clone(), "broker_rtt");
@@ -1139,75 +1192,58 @@ impl BrokerStats {
         let labels = [id, client_id, broker, state];
 
         self.state_age
-            .with_guarded_label_values(&labels)
-            .set(stats.stateage);
+            .with_metric(&labels, |metric| metric.set(stats.stateage));
         self.outbuf_cnt
-            .with_guarded_label_values(&labels)
-            .set(stats.outbuf_cnt);
+            .with_metric(&labels, |metric| metric.set(stats.outbuf_cnt));
         self.outbuf_msg_cnt
-            .with_guarded_label_values(&labels)
-            .set(stats.outbuf_msg_cnt);
+            .with_metric(&labels, |metric| metric.set(stats.outbuf_msg_cnt));
         self.waitresp_cnt
-            .with_guarded_label_values(&labels)
-            .set(stats.waitresp_cnt);
+            .with_metric(&labels, |metric| metric.set(stats.waitresp_cnt));
         self.waitresp_msg_cnt
-            .with_guarded_label_values(&labels)
-            .set(stats.waitresp_msg_cnt);
-        self.tx.with_guarded_label_values(&labels).set(stats.tx);
+            .with_metric(&labels, |metric| metric.set(stats.waitresp_msg_cnt));
+        self.tx.with_metric(&labels, |metric| metric.set(stats.tx));
         self.tx_bytes
-            .with_guarded_label_values(&labels)
-            .set(stats.txbytes);
+            .with_metric(&labels, |metric| metric.set(stats.txbytes));
         self.tx_errs
-            .with_guarded_label_values(&labels)
-            .set(stats.txerrs);
+            .with_metric(&labels, |metric| metric.set(stats.txerrs));
         self.tx_retries
-            .with_guarded_label_values(&labels)
-            .set(stats.txretries);
+            .with_metric(&labels, |metric| metric.set(stats.txretries));
         self.tx_idle
-            .with_guarded_label_values(&labels)
-            .set(stats.txidle);
+            .with_metric(&labels, |metric| metric.set(stats.txidle));
         self.req_timeouts
-            .with_guarded_label_values(&labels)
-            .set(stats.req_timeouts);
-        self.rx.with_guarded_label_values(&labels).set(stats.rx);
+            .with_metric(&labels, |metric| metric.set(stats.req_timeouts));
+        self.rx.with_metric(&labels, |metric| metric.set(stats.rx));
         self.rx_bytes
-            .with_guarded_label_values(&labels)
-            .set(stats.rxbytes);
+            .with_metric(&labels, |metric| metric.set(stats.rxbytes));
         self.rx_errs
-            .with_guarded_label_values(&labels)
-            .set(stats.rxerrs);
+            .with_metric(&labels, |metric| metric.set(stats.rxerrs));
         self.rx_corriderrs
-            .with_guarded_label_values(&labels)
-            .set(stats.rxcorriderrs);
+            .with_metric(&labels, |metric| metric.set(stats.rxcorriderrs));
         self.rx_partial
-            .with_guarded_label_values(&labels)
-            .set(stats.rxpartial);
+            .with_metric(&labels, |metric| metric.set(stats.rxpartial));
         self.rx_idle
-            .with_guarded_label_values(&labels)
-            .set(stats.rxidle);
+            .with_metric(&labels, |metric| metric.set(stats.rxidle));
         for (req_type, req_cnt) in &stats.req {
             self.req
-                .with_guarded_label_values(&[id, client_id, broker, state, req_type])
-                .set(*req_cnt);
+                .with_metric(&[id, client_id, broker, state, req_type], |metric| {
+                    metric.set(*req_cnt)
+                });
         }
         self.zbuf_grow
-            .with_guarded_label_values(&labels)
-            .set(stats.zbuf_grow);
+            .with_metric(&labels, |metric| metric.set(stats.zbuf_grow));
         self.buf_grow
-            .with_guarded_label_values(&labels)
-            .set(stats.buf_grow);
+            .with_metric(&labels, |metric| metric.set(stats.buf_grow));
         if let Some(wakeups) = stats.wakeups {
-            self.wakeups.with_guarded_label_values(&labels).set(wakeups);
+            self.wakeups
+                .with_metric(&labels, |metric| metric.set(wakeups));
         }
         if let Some(connects) = stats.connects {
             self.connects
-                .with_guarded_label_values(&labels)
-                .set(connects);
+                .with_metric(&labels, |metric| metric.set(connects));
         }
         if let Some(disconnects) = stats.disconnects {
             self.disconnects
-                .with_guarded_label_values(&labels)
-                .set(disconnects);
+                .with_metric(&labels, |metric| metric.set(disconnects));
         }
         if let Some(int_latency) = &stats.int_latency {
             self.int_latency

--- a/src/connector/src/source/kinesis/source/reader.rs
+++ b/src/connector/src/source/kinesis/source/reader.rs
@@ -163,8 +163,9 @@ impl KinesisSplitReader {
                     self.source_ctx
                         .metrics
                         .kinesis_lag_latency_ms
-                        .with_guarded_label_values(&self.metrics_labels)
-                        .observe(resp.millis_behind_latest().unwrap_or(0) as f64);
+                        .with_metric(&self.metrics_labels, |metric| {
+                            metric.observe(resp.millis_behind_latest().unwrap_or(0) as f64)
+                        });
 
                     self.shard_iter = resp.next_shard_iterator().map(String::from);
                     let chunk = (resp.records().iter())
@@ -200,8 +201,7 @@ impl KinesisSplitReader {
                         self.source_ctx
                             .metrics
                             .kinesis_early_terminate_shard_count
-                            .with_guarded_label_values(&self.metrics_labels)
-                            .inc();
+                            .with_metric(&self.metrics_labels, |metric| metric.inc());
 
                         break;
                     }
@@ -240,8 +240,7 @@ impl KinesisSplitReader {
                     self.source_ctx
                         .metrics
                         .kinesis_throughput_exceeded_count
-                        .with_guarded_label_values(&self.metrics_labels)
-                        .inc();
+                        .with_metric(&self.metrics_labels, |metric| metric.inc());
 
                     if let Some(start_time) = provisioned_throughput_exceeded_start_time
                         && start_time.elapsed() > Duration::from_secs(5)
@@ -284,8 +283,7 @@ impl KinesisSplitReader {
                     self.source_ctx
                         .metrics
                         .kinesis_timeout_count
-                        .with_guarded_label_values(&self.metrics_labels)
-                        .inc();
+                        .with_metric(&self.metrics_labels, |metric| metric.inc());
 
                     // according to sdk doc:
                     // The request failed due to a timeout. The request MAY have been sent and received.
@@ -382,8 +380,7 @@ impl KinesisSplitReader {
         self.source_ctx
             .metrics
             .kinesis_rebuild_shard_iter_count
-            .with_guarded_label_values(&self.metrics_labels)
-            .inc();
+            .with_metric(&self.metrics_labels, |metric| metric.inc());
 
         tracing::info!(
             "resetting kinesis to: stream {:?} shard {:?} starting from {:?}",

--- a/src/connector/src/source/monitor/metrics.rs
+++ b/src/connector/src/source/monitor/metrics.rs
@@ -19,7 +19,8 @@ use prometheus::{
     register_int_counter_vec_with_registry,
 };
 use risingwave_common::metrics::{
-    LabelGuardedHistogramVec, LabelGuardedIntCounterVec, LabelGuardedIntGaugeVec,
+    CachedLabelGuardedHistogramVec, CachedLabelGuardedIntCounterVec, LabelGuardedHistogramVec,
+    LabelGuardedIntCounterVec, LabelGuardedIntGaugeVec,
 };
 use risingwave_common::monitor::GLOBAL_METRICS_REGISTRY;
 use risingwave_common::{
@@ -90,7 +91,8 @@ impl EnumeratorMetrics {
             &["source_id", "partition"],
             registry,
         )
-        .unwrap();
+        .unwrap()
+        .into();
 
         let kafka_consumer_group_delete_failure_count = register_int_counter_vec_with_registry!(
             "source_kafka_consumer_group_delete_failure_count",
@@ -106,7 +108,8 @@ impl EnumeratorMetrics {
             &["source_id", "slot_name"],
             registry,
         )
-        .unwrap();
+        .unwrap()
+        .into();
 
         let pg_cdc_upstream_max_lsn = register_guarded_int_gauge_vec_with_registry!(
             "pg_cdc_upstream_max_lsn",
@@ -114,7 +117,8 @@ impl EnumeratorMetrics {
             &["source_id", "slot_name"],
             registry,
         )
-        .unwrap();
+        .unwrap()
+        .into();
 
         let mysql_cdc_binlog_file_seq_min = register_guarded_int_gauge_vec_with_registry!(
             "mysql_cdc_binlog_file_seq_min",
@@ -122,7 +126,8 @@ impl EnumeratorMetrics {
             &["hostname", "port"],
             registry,
         )
-        .unwrap();
+        .unwrap()
+        .into();
 
         let mysql_cdc_binlog_file_seq_max = register_guarded_int_gauge_vec_with_registry!(
             "mysql_cdc_binlog_file_seq_max",
@@ -130,7 +135,8 @@ impl EnumeratorMetrics {
             &["hostname", "port"],
             registry,
         )
-        .unwrap();
+        .unwrap()
+        .into();
 
         let sqlserver_cdc_upstream_min_lsn = register_guarded_int_gauge_vec_with_registry!(
             "sqlserver_cdc_upstream_min_lsn",
@@ -138,7 +144,8 @@ impl EnumeratorMetrics {
             &["source_id"],
             registry,
         )
-        .unwrap();
+        .unwrap()
+        .into();
 
         let sqlserver_cdc_upstream_max_lsn = register_guarded_int_gauge_vec_with_registry!(
             "sqlserver_cdc_upstream_max_lsn",
@@ -146,7 +153,8 @@ impl EnumeratorMetrics {
             &["source_id"],
             registry,
         )
-        .unwrap();
+        .unwrap()
+        .into();
 
         EnumeratorMetrics {
             high_watermark,
@@ -192,11 +200,11 @@ pub struct SourceMetrics {
     pub file_source_failed_split_count: LabelGuardedIntCounterVec,
 
     // kinesis source
-    pub kinesis_throughput_exceeded_count: LabelGuardedIntCounterVec,
-    pub kinesis_timeout_count: LabelGuardedIntCounterVec,
-    pub kinesis_rebuild_shard_iter_count: LabelGuardedIntCounterVec,
-    pub kinesis_early_terminate_shard_count: LabelGuardedIntCounterVec,
-    pub kinesis_lag_latency_ms: LabelGuardedHistogramVec,
+    pub kinesis_throughput_exceeded_count: CachedLabelGuardedIntCounterVec,
+    pub kinesis_timeout_count: CachedLabelGuardedIntCounterVec,
+    pub kinesis_rebuild_shard_iter_count: CachedLabelGuardedIntCounterVec,
+    pub kinesis_early_terminate_shard_count: CachedLabelGuardedIntCounterVec,
+    pub kinesis_lag_latency_ms: CachedLabelGuardedHistogramVec,
 
     /// Total connector ack failures after checkpoint commit by bounded failure category.
     connector_ack_failure_count: IntCounterVec,
@@ -238,7 +246,8 @@ impl SourceMetrics {
             ],
             registry
         )
-        .unwrap();
+        .unwrap()
+        .into();
         let partition_input_bytes = register_guarded_int_counter_vec_with_registry!(
             "source_partition_input_bytes",
             "Total bytes that have been input from specific partition",
@@ -251,28 +260,32 @@ impl SourceMetrics {
             ],
             registry
         )
-        .unwrap();
+        .unwrap()
+        .into();
         let latest_message_id = register_guarded_int_gauge_vec_with_registry!(
             "source_latest_message_id",
             "Latest message id for a exec per partition",
             &["source_id", "actor_id", "partition"],
             registry,
         )
-        .unwrap();
+        .unwrap()
+        .into();
         let partition_eof_count = register_guarded_int_counter_vec_with_registry!(
             "source_partition_eof_count",
             "Total number of EOF events received from specific partition",
             &["source_id", "partition", "source_name", "fragment_id"],
             registry
         )
-        .unwrap();
+        .unwrap()
+        .into();
         let partition_eof_offset = register_guarded_int_gauge_vec_with_registry!(
             "source_partition_eof_offset",
             "Latest resolved EOF offset for specific partition",
             &["source_id", "partition", "source_name", "fragment_id"],
             registry
         )
-        .unwrap();
+        .unwrap()
+        .into();
 
         let opts = histogram_opts!(
             "source_cdc_event_lag_duration_milliseconds",
@@ -286,10 +299,13 @@ impl SourceMetrics {
             &["actor_id", "source_id", "source_name", "fragment_id"],
             registry
         )
-        .unwrap();
+        .unwrap()
+        .into();
 
         let direct_cdc_event_lag_latency =
-            register_guarded_histogram_vec_with_registry!(opts, &["table_name"], registry).unwrap();
+            register_guarded_histogram_vec_with_registry!(opts, &["table_name"], registry)
+                .unwrap()
+                .into();
 
         let rdkafka_native_metric = Arc::new(RdKafkaStats::new(registry.clone()));
 
@@ -299,21 +315,24 @@ impl SourceMetrics {
             &["source_id", "source_name", "actor_id", "fragment_id"],
             registry
         )
-        .unwrap();
+        .unwrap()
+        .into();
         let file_source_dirty_split_count = register_guarded_int_gauge_vec_with_registry!(
             "file_source_dirty_split_count",
             "Current number of dirty file splits in file source",
             &["source_id", "source_name", "actor_id", "fragment_id"],
             registry
         )
-        .unwrap();
+        .unwrap()
+        .into();
         let file_source_failed_split_count = register_guarded_int_counter_vec_with_registry!(
             "file_source_failed_split_count",
             "Total number of file splits marked dirty in file source",
             &["source_id", "source_name", "actor_id", "fragment_id"],
             registry
         )
-        .unwrap();
+        .unwrap()
+        .into();
 
         let kinesis_throughput_exceeded_count = register_guarded_int_counter_vec_with_registry!(
             "kinesis_throughput_exceeded_count",
@@ -321,7 +340,8 @@ impl SourceMetrics {
             &["source_id", "source_name", "fragment_id", "shard_id"],
             registry
         )
-        .unwrap();
+        .unwrap()
+        .into();
 
         let kinesis_timeout_count = register_guarded_int_counter_vec_with_registry!(
             "kinesis_timeout_count",
@@ -329,7 +349,8 @@ impl SourceMetrics {
             &["source_id", "source_name", "fragment_id", "shard_id"],
             registry
         )
-        .unwrap();
+        .unwrap()
+        .into();
 
         let kinesis_rebuild_shard_iter_count = register_guarded_int_counter_vec_with_registry!(
             "kinesis_rebuild_shard_iter_count",
@@ -337,7 +358,8 @@ impl SourceMetrics {
             &["source_id", "source_name", "fragment_id", "shard_id"],
             registry
         )
-        .unwrap();
+        .unwrap()
+        .into();
 
         let kinesis_early_terminate_shard_count = register_guarded_int_counter_vec_with_registry!(
             "kinesis_early_terminate_shard_count",
@@ -345,7 +367,8 @@ impl SourceMetrics {
             &["source_id", "source_name", "fragment_id", "shard_id"],
             registry
         )
-        .unwrap();
+        .unwrap()
+        .into();
 
         let kinesis_lag_latency_ms = register_guarded_histogram_vec_with_registry!(
             "kinesis_lag_latency_ms",
@@ -353,7 +376,8 @@ impl SourceMetrics {
             &["source_id", "source_name", "fragment_id", "shard_id"],
             registry
         )
-        .unwrap();
+        .unwrap()
+        .into();
 
         let connector_ack_failure_count = register_int_counter_vec_with_registry!(
             "source_connector_ack_failure_count",

--- a/src/meta/service/src/ddl_service.rs
+++ b/src/meta/service/src/ddl_service.rs
@@ -1470,8 +1470,9 @@ impl DdlService for DdlServiceImpl {
                 let latency_timer = self
                     .meta_metrics
                     .auto_schema_change_latency
-                    .with_guarded_label_values(&[&table.id.to_string(), &table.name])
-                    .start_timer();
+                    .with_metric(&[&table.id.to_string(), &table.name], |metric| {
+                        metric.start_timer()
+                    });
                 // send a request to the frontend to get the ReplaceJobPlan
                 // will retry with exponential backoff if the request fails
                 let resp = client
@@ -1511,11 +1512,10 @@ impl DdlService for DdlServiceImpl {
 
                                     self.meta_metrics
                                         .auto_schema_change_success_cnt
-                                        .with_guarded_label_values(&[
-                                            &table.id.to_string(),
-                                            &table.name,
-                                        ])
-                                        .inc();
+                                        .with_metric(
+                                            &[&table.id.to_string(), &table.name],
+                                            |metric| metric.inc(),
+                                        );
                                     latency_timer.observe_duration();
                                 }
                                 Err(e) => {
@@ -1928,8 +1928,7 @@ fn add_auto_schema_change_fail_event_log(
 ) {
     meta_metrics
         .auto_schema_change_failure_cnt
-        .with_guarded_label_values(&[&table_id.to_string(), &table_name])
-        .inc();
+        .with_metric(&[&table_id.to_string(), &table_name], |metric| metric.inc());
     let event = event_log::EventAutoSchemaChangeFail {
         table_id,
         table_name,

--- a/src/meta/src/rpc/metrics.rs
+++ b/src/meta/src/rpc/metrics.rs
@@ -27,8 +27,9 @@ use prometheus::{
 };
 use risingwave_common::catalog::{FragmentTypeFlag, TableId};
 use risingwave_common::metrics::{
-    LabelGuardedHistogramVec, LabelGuardedIntCounterVec, LabelGuardedIntGaugeVec,
-    LabelGuardedUintGaugeVec,
+    CachedLabelGuardedHistogramVec, CachedLabelGuardedIntCounterVec,
+    CachedLabelGuardedUintGaugeVec, LabelGuardedHistogramVec, LabelGuardedIntCounterVec,
+    LabelGuardedIntGaugeVec,
 };
 use risingwave_common::monitor::GLOBAL_METRICS_REGISTRY;
 use risingwave_common::system_param::reader::SystemParamsRead;
@@ -244,9 +245,9 @@ pub struct MetaMetrics {
     pub merge_compaction_group_count: IntCounterVec,
 
     // ********************************** Auto Schema Change ************************************
-    pub auto_schema_change_failure_cnt: LabelGuardedIntCounterVec,
-    pub auto_schema_change_success_cnt: LabelGuardedIntCounterVec,
-    pub auto_schema_change_latency: LabelGuardedHistogramVec,
+    pub auto_schema_change_failure_cnt: CachedLabelGuardedIntCounterVec,
+    pub auto_schema_change_success_cnt: CachedLabelGuardedIntCounterVec,
+    pub auto_schema_change_latency: CachedLabelGuardedHistogramVec,
 
     pub time_travel_version_replay_latency: Histogram,
 
@@ -256,10 +257,10 @@ pub struct MetaMetrics {
     pub compaction_group_throughput: IntGaugeVec,
 
     // ********************************** Refresh Manager ************************************
-    pub refresh_job_duration: LabelGuardedUintGaugeVec,
-    pub refresh_job_finish_cnt: LabelGuardedIntCounterVec,
-    pub refresh_cron_job_trigger_cnt: LabelGuardedIntCounterVec,
-    pub refresh_cron_job_miss_cnt: LabelGuardedIntCounterVec,
+    pub refresh_job_duration: CachedLabelGuardedUintGaugeVec,
+    pub refresh_job_finish_cnt: CachedLabelGuardedIntCounterVec,
+    pub refresh_cron_job_trigger_cnt: CachedLabelGuardedIntCounterVec,
+    pub refresh_cron_job_miss_cnt: CachedLabelGuardedIntCounterVec,
 }
 
 pub static GLOBAL_META_METRICS: LazyLock<MetaMetrics> =
@@ -282,7 +283,8 @@ impl MetaMetrics {
         );
         let barrier_latency =
             register_guarded_histogram_vec_with_registry!(opts, &["database_id"], registry)
-                .unwrap();
+                .unwrap()
+                .into();
 
         let opts = histogram_opts!(
             "meta_barrier_wait_commit_duration_seconds",
@@ -299,7 +301,8 @@ impl MetaMetrics {
         );
         let barrier_send_latency =
             register_guarded_histogram_vec_with_registry!(opts, &["database_id"], registry)
-                .unwrap();
+                .unwrap()
+                .into();
         let barrier_interval_by_database = register_gauge_vec_with_registry!(
             "meta_barrier_interval_by_database",
             "barrier interval of each database",
@@ -314,21 +317,24 @@ impl MetaMetrics {
             &["database_id"],
             registry
         )
-        .unwrap();
+        .unwrap()
+        .into();
         let in_flight_barrier_nums = register_guarded_int_gauge_vec_with_registry!(
             "in_flight_barrier_nums",
             "num of of in_flight_barrier",
             &["database_id"],
             registry
         )
-        .unwrap();
+        .unwrap()
+        .into();
         let last_committed_barrier_time = register_guarded_int_gauge_vec_with_registry!(
             "last_committed_barrier_time",
             "The timestamp (UNIX epoch seconds) of the last committed barrier's epoch time.",
             &["database_id"],
             registry
         )
-        .unwrap();
+        .unwrap()
+        .into();
 
         // snapshot backfill metrics
         let opts = histogram_opts!(
@@ -341,7 +347,8 @@ impl MetaMetrics {
             &["table_id", "barrier_type"],
             registry
         )
-        .unwrap();
+        .unwrap()
+        .into();
 
         let snapshot_backfill_lag = register_guarded_int_gauge_vec_with_registry!(
             "meta_snapshot_backfill_upstream_lag",
@@ -349,14 +356,16 @@ impl MetaMetrics {
             &["table_id"],
             registry
         )
-        .unwrap();
+        .unwrap()
+        .into();
         let snapshot_backfill_inflight_barrier_num = register_guarded_int_gauge_vec_with_registry!(
             "meta_snapshot_backfill_inflight_barrier_num",
             "snapshot backfill inflight_barrier_num",
             &["table_id"],
             registry
         )
-        .unwrap();
+        .unwrap()
+        .into();
 
         let max_committed_epoch = register_int_gauge_with_registry!(
             "storage_max_committed_epoch",
@@ -697,7 +706,8 @@ impl MetaMetrics {
             &["table_id", "table_name"],
             registry
         )
-        .unwrap();
+        .unwrap()
+        .into();
 
         let auto_schema_change_success_cnt = register_guarded_int_counter_vec_with_registry!(
             "auto_schema_change_success_cnt",
@@ -705,7 +715,8 @@ impl MetaMetrics {
             &["table_id", "table_name"],
             registry
         )
-        .unwrap();
+        .unwrap()
+        .into();
 
         let opts = histogram_opts!(
             "auto_schema_change_latency",
@@ -717,7 +728,8 @@ impl MetaMetrics {
             &["table_id", "table_name"],
             registry
         )
-        .unwrap();
+        .unwrap()
+        .into();
 
         let source_is_up = register_guarded_int_gauge_vec_with_registry!(
             "source_status_is_up",
@@ -725,7 +737,8 @@ impl MetaMetrics {
             &["source_id", "source_name"],
             registry
         )
-        .unwrap();
+        .unwrap()
+        .into();
         let opts = histogram_opts!(
             "source_worker_tick_duration_seconds",
             "Duration of a source worker tick (list_splits + on_tick) in seconds",
@@ -736,7 +749,8 @@ impl MetaMetrics {
             &["source_id", "source_name"],
             registry
         )
-        .unwrap();
+        .unwrap()
+        .into();
         let source_enumerator_monitor_error_count =
             register_guarded_int_counter_vec_with_registry!(
                 "source_enumerator_monitor_error_count",
@@ -744,7 +758,8 @@ impl MetaMetrics {
                 &["source_id", "source_name"],
                 registry
             )
-            .unwrap();
+            .unwrap()
+            .into();
         let source_enumerator_metrics = Arc::new(SourceEnumeratorMetrics::default());
 
         let actor_info = register_int_gauge_vec_with_registry!(
@@ -971,28 +986,32 @@ impl MetaMetrics {
             &["table_id", "status"],
             registry
         )
-        .unwrap();
+        .unwrap()
+        .into();
         let refresh_job_finish_cnt = register_guarded_int_counter_vec_with_registry!(
             "meta_refresh_job_finish_cnt",
             "The number of finished refresh jobs",
             &["table_id", "status"],
             registry
         )
-        .unwrap();
+        .unwrap()
+        .into();
         let refresh_cron_job_trigger_cnt = register_guarded_int_counter_vec_with_registry!(
             "meta_refresh_cron_job_trigger_cnt",
             "The number of cron refresh jobs triggered",
             &["table_id"],
             registry
         )
-        .unwrap();
+        .unwrap()
+        .into();
         let refresh_cron_job_miss_cnt = register_guarded_int_counter_vec_with_registry!(
             "meta_refresh_cron_job_miss_cnt",
             "The number of cron refresh jobs missed",
             &["table_id"],
             registry
         )
-        .unwrap();
+        .unwrap()
+        .into();
 
         Self {
             grpc_latency,

--- a/src/meta/src/stream/refresh_manager.rs
+++ b/src/meta/src/stream/refresh_manager.rs
@@ -198,8 +198,7 @@ impl GlobalRefreshManager {
         if job.current_status != RefreshState::Idle {
             GLOBAL_META_METRICS
                 .refresh_cron_job_miss_cnt
-                .with_guarded_label_values(&[&job.table_id.to_string()])
-                .inc();
+                .with_metric(&[&job.table_id.to_string()], |metric| metric.inc());
             tracing::warn!(table_id = %job.table_id, "skip scheduled refresh: current status is not idle: {:?}", job.current_status);
             return Ok(());
         }
@@ -260,8 +259,7 @@ impl GlobalRefreshManager {
         let table_id_str = job.table_id.to_string();
         GLOBAL_META_METRICS
             .refresh_cron_job_trigger_cnt
-            .with_guarded_label_values(&[&table_id_str])
-            .inc();
+            .with_metric(&[&table_id_str], |metric| metric.inc());
         tracing::info!(table_id = %job.table_id, "trigger scheduled refresh at interval {:?}", interval);
 
         self.ensure_refreshable(job.table_id, associated_source_id)
@@ -428,12 +426,12 @@ impl GlobalRefreshManager {
             let status = status.to_owned();
             GLOBAL_META_METRICS
                 .refresh_job_duration
-                .with_guarded_label_values(&[&table_id.to_string(), &status])
-                .set(entry.start_time.elapsed().as_secs());
+                .with_metric(&[&table_id.to_string(), &status], |metric| {
+                    metric.set(entry.start_time.elapsed().as_secs())
+                });
             GLOBAL_META_METRICS
                 .refresh_job_finish_cnt
-                .with_guarded_label_values(&[&table_id.to_string(), &status])
-                .inc();
+                .with_metric(&[&table_id.to_string(), &status], |metric| metric.inc());
         }
         guard.table_id_by_database_id.values_mut().for_each(|set| {
             set.remove(&table_id);

--- a/src/stream/src/executor/monitor/streaming_stats.rs
+++ b/src/stream/src/executor/monitor/streaming_stats.rs
@@ -22,8 +22,8 @@ use prometheus::{
 use risingwave_common::catalog::TableId;
 use risingwave_common::config::MetricLevel;
 use risingwave_common::metrics::{
-    LabelGuardedHistogramVec, LabelGuardedIntCounter, LabelGuardedIntCounterVec,
-    LabelGuardedIntGauge, LabelGuardedIntGaugeVec, MetricVecRelabelExt,
+    CachedLabelGuardedIntGaugeVec, LabelGuardedHistogramVec, LabelGuardedIntCounter,
+    LabelGuardedIntCounterVec, LabelGuardedIntGauge, LabelGuardedIntGaugeVec, MetricVecRelabelExt,
     RelabeledGuardedHistogramVec, RelabeledGuardedIntCounterVec, RelabeledGuardedIntGaugeVec,
 };
 use risingwave_common::monitor::GLOBAL_METRICS_REGISTRY;
@@ -217,17 +217,17 @@ pub struct StreamingMetrics {
     pub materialize_current_epoch: RelabeledGuardedIntGaugeVec,
 
     // PostgreSQL CDC LSN monitoring
-    pub pg_cdc_state_table_lsn: LabelGuardedIntGaugeVec,
-    pub pg_cdc_jni_commit_offset_lsn: LabelGuardedIntGaugeVec,
+    pub pg_cdc_state_table_lsn: CachedLabelGuardedIntGaugeVec,
+    pub pg_cdc_jni_commit_offset_lsn: CachedLabelGuardedIntGaugeVec,
 
     // MySQL CDC binlog monitoring
-    pub mysql_cdc_state_binlog_file_seq: LabelGuardedIntGaugeVec,
-    pub mysql_cdc_state_binlog_position: LabelGuardedIntGaugeVec,
+    pub mysql_cdc_state_binlog_file_seq: CachedLabelGuardedIntGaugeVec,
+    pub mysql_cdc_state_binlog_position: CachedLabelGuardedIntGaugeVec,
 
     // SQL Server CDC LSN monitoring
-    pub sqlserver_cdc_state_change_lsn: LabelGuardedIntGaugeVec,
-    pub sqlserver_cdc_state_commit_lsn: LabelGuardedIntGaugeVec,
-    pub sqlserver_cdc_jni_commit_offset_lsn: LabelGuardedIntGaugeVec,
+    pub sqlserver_cdc_state_change_lsn: CachedLabelGuardedIntGaugeVec,
+    pub sqlserver_cdc_state_commit_lsn: CachedLabelGuardedIntGaugeVec,
+    pub sqlserver_cdc_jni_commit_offset_lsn: CachedLabelGuardedIntGaugeVec,
 
     // Gap Fill
     pub gap_fill_generated_rows_count: RelabeledGuardedIntCounterVec,
@@ -267,7 +267,8 @@ impl StreamingMetrics {
             &["source_id", "source_name", "actor_id", "fragment_id"],
             registry
         )
-        .unwrap();
+        .unwrap()
+        .into();
 
         let source_split_change_count = register_guarded_int_counter_vec_with_registry!(
             "stream_source_split_change_event_count",
@@ -275,7 +276,8 @@ impl StreamingMetrics {
             &["source_id", "source_name", "actor_id", "fragment_id"],
             registry
         )
-        .unwrap();
+        .unwrap()
+        .into();
 
         let source_backfill_row_count = register_guarded_int_counter_vec_with_registry!(
             "stream_source_backfill_rows_counts",
@@ -283,7 +285,8 @@ impl StreamingMetrics {
             &["source_id", "source_name", "actor_id", "fragment_id"],
             registry
         )
-        .unwrap();
+        .unwrap()
+        .into();
 
         let sink_input_row_count = register_guarded_int_counter_vec_with_registry!(
             "stream_sink_input_row_count",
@@ -291,7 +294,8 @@ impl StreamingMetrics {
             &["sink_id", "actor_id", "fragment_id"],
             registry
         )
-        .unwrap();
+        .unwrap()
+        .into();
 
         let sink_input_bytes = register_guarded_int_counter_vec_with_registry!(
             "stream_sink_input_bytes",
@@ -299,7 +303,8 @@ impl StreamingMetrics {
             &["sink_id", "actor_id", "fragment_id"],
             registry
         )
-        .unwrap();
+        .unwrap()
+        .into();
 
         let materialize_input_row_count = register_guarded_int_counter_vec_with_registry!(
             "stream_mview_input_row_count",
@@ -325,7 +330,8 @@ impl StreamingMetrics {
             &["source_id"],
             registry,
         )
-        .unwrap();
+        .unwrap()
+        .into();
 
         let pg_cdc_jni_commit_offset_lsn = register_guarded_int_gauge_vec_with_registry!(
             "stream_pg_cdc_jni_commit_offset_lsn",
@@ -333,7 +339,8 @@ impl StreamingMetrics {
             &["source_id"],
             registry,
         )
-        .unwrap();
+        .unwrap()
+        .into();
 
         let mysql_cdc_state_binlog_file_seq = register_guarded_int_gauge_vec_with_registry!(
             "stream_mysql_cdc_state_binlog_file_seq",
@@ -341,7 +348,8 @@ impl StreamingMetrics {
             &["source_id"],
             registry,
         )
-        .unwrap();
+        .unwrap()
+        .into();
 
         let mysql_cdc_state_binlog_position = register_guarded_int_gauge_vec_with_registry!(
             "stream_mysql_cdc_state_binlog_position",
@@ -349,7 +357,8 @@ impl StreamingMetrics {
             &["source_id"],
             registry,
         )
-        .unwrap();
+        .unwrap()
+        .into();
 
         let sqlserver_cdc_state_change_lsn = register_guarded_int_gauge_vec_with_registry!(
             "stream_sqlserver_cdc_state_change_lsn",
@@ -357,7 +366,8 @@ impl StreamingMetrics {
             &["source_id"],
             registry,
         )
-        .unwrap();
+        .unwrap()
+        .into();
 
         let sqlserver_cdc_state_commit_lsn = register_guarded_int_gauge_vec_with_registry!(
             "stream_sqlserver_cdc_state_commit_lsn",
@@ -365,7 +375,8 @@ impl StreamingMetrics {
             &["source_id"],
             registry,
         )
-        .unwrap();
+        .unwrap()
+        .into();
 
         let sqlserver_cdc_jni_commit_offset_lsn = register_guarded_int_gauge_vec_with_registry!(
             "stream_sqlserver_cdc_jni_commit_offset_lsn",
@@ -373,7 +384,8 @@ impl StreamingMetrics {
             &["source_id"],
             registry,
         )
-        .unwrap();
+        .unwrap()
+        .into();
 
         let sink_chunk_buffer_size = register_guarded_int_gauge_vec_with_registry!(
             "stream_sink_chunk_buffer_size",
@@ -381,7 +393,8 @@ impl StreamingMetrics {
             &["sink_id", "actor_id", "fragment_id"],
             registry
         )
-        .unwrap();
+        .unwrap()
+        .into();
         let actor_output_buffer_blocking_duration_ns =
             register_guarded_int_counter_vec_with_registry!(
                 "stream_actor_output_buffer_blocking_duration_ns",
@@ -410,7 +423,8 @@ impl StreamingMetrics {
             &["fragment_id"],
             registry
         )
-        .unwrap();
+        .unwrap()
+        .into();
 
         let exchange_frag_recv_size = register_guarded_int_counter_vec_with_registry!(
             "stream_exchange_frag_recv_size",
@@ -418,7 +432,8 @@ impl StreamingMetrics {
             &["up_fragment_id", "down_fragment_id"],
             registry
         )
-        .unwrap();
+        .unwrap()
+        .into();
 
         let actor_poll_duration = register_guarded_int_counter_vec_with_registry!(
             "stream_actor_poll_duration",
@@ -507,7 +522,8 @@ impl StreamingMetrics {
             &["actor_id", "fragment_id"],
             registry
         )
-        .unwrap();
+        .unwrap()
+        .into();
 
         let actor_count = register_guarded_int_gauge_vec_with_registry!(
             "stream_actor_count",
@@ -515,7 +531,8 @@ impl StreamingMetrics {
             &["fragment_id"],
             registry
         )
-        .unwrap();
+        .unwrap()
+        .into();
 
         let merge_barrier_align_duration = register_guarded_int_counter_vec_with_registry!(
             "stream_merge_barrier_align_duration_ns",
@@ -532,7 +549,8 @@ impl StreamingMetrics {
             &["side", "join_table_id", "actor_id", "fragment_id"],
             registry
         )
-        .unwrap();
+        .unwrap()
+        .into();
 
         let join_lookup_total_count = register_guarded_int_counter_vec_with_registry!(
             "stream_join_lookup_total_count",
@@ -540,7 +558,8 @@ impl StreamingMetrics {
             &["side", "join_table_id", "actor_id", "fragment_id"],
             registry
         )
-        .unwrap();
+        .unwrap()
+        .into();
 
         let join_insert_cache_miss_count = register_guarded_int_counter_vec_with_registry!(
             "stream_join_insert_cache_miss_count",
@@ -548,7 +567,8 @@ impl StreamingMetrics {
             &["side", "join_table_id", "actor_id", "fragment_id"],
             registry
         )
-        .unwrap();
+        .unwrap()
+        .into();
 
         let join_actor_input_waiting_duration_ns = register_guarded_int_counter_vec_with_registry!(
             "stream_join_actor_input_waiting_duration_ns",
@@ -556,7 +576,8 @@ impl StreamingMetrics {
             &["actor_id", "fragment_id"],
             registry
         )
-        .unwrap();
+        .unwrap()
+        .into();
 
         let join_match_duration_ns = register_guarded_int_counter_vec_with_registry!(
             "stream_join_match_duration_ns",
@@ -564,7 +585,8 @@ impl StreamingMetrics {
             &["actor_id", "fragment_id", "side"],
             registry
         )
-        .unwrap();
+        .unwrap()
+        .into();
 
         let barrier_align_duration = register_guarded_int_counter_vec_with_registry!(
             "stream_barrier_align_duration_ns",
@@ -581,7 +603,8 @@ impl StreamingMetrics {
             &["actor_id", "fragment_id", "side"],
             registry
         )
-        .unwrap();
+        .unwrap()
+        .into();
 
         let join_matched_join_keys_opts = histogram_opts!(
             "stream_join_matched_join_keys",
@@ -603,7 +626,8 @@ impl StreamingMetrics {
             &["table_id", "actor_id", "fragment_id"],
             registry
         )
-        .unwrap();
+        .unwrap()
+        .into();
 
         let agg_total_lookup_count = register_guarded_int_counter_vec_with_registry!(
             "stream_agg_lookup_total_count",
@@ -611,7 +635,8 @@ impl StreamingMetrics {
             &["table_id", "actor_id", "fragment_id"],
             registry
         )
-        .unwrap();
+        .unwrap()
+        .into();
 
         let agg_distinct_cache_miss_count = register_guarded_int_counter_vec_with_registry!(
             "stream_agg_distinct_cache_miss_count",
@@ -619,7 +644,8 @@ impl StreamingMetrics {
             &["table_id", "actor_id", "fragment_id"],
             registry
         )
-        .unwrap();
+        .unwrap()
+        .into();
 
         let agg_distinct_total_cache_count = register_guarded_int_counter_vec_with_registry!(
             "stream_agg_distinct_total_cache_count",
@@ -627,7 +653,8 @@ impl StreamingMetrics {
             &["table_id", "actor_id", "fragment_id"],
             registry
         )
-        .unwrap();
+        .unwrap()
+        .into();
 
         let agg_distinct_cached_entry_count = register_guarded_int_gauge_vec_with_registry!(
             "stream_agg_distinct_cached_entry_count",
@@ -635,7 +662,8 @@ impl StreamingMetrics {
             &["table_id", "actor_id", "fragment_id"],
             registry
         )
-        .unwrap();
+        .unwrap()
+        .into();
 
         let agg_dirty_groups_count = register_guarded_int_gauge_vec_with_registry!(
             "stream_agg_dirty_groups_count",
@@ -643,7 +671,8 @@ impl StreamingMetrics {
             &["table_id", "actor_id", "fragment_id"],
             registry
         )
-        .unwrap();
+        .unwrap()
+        .into();
 
         let agg_dirty_groups_heap_size = register_guarded_int_gauge_vec_with_registry!(
             "stream_agg_dirty_groups_heap_size",
@@ -651,7 +680,8 @@ impl StreamingMetrics {
             &["table_id", "actor_id", "fragment_id"],
             registry
         )
-        .unwrap();
+        .unwrap()
+        .into();
 
         let agg_state_cache_lookup_count = register_guarded_int_counter_vec_with_registry!(
             "stream_agg_state_cache_lookup_count",
@@ -659,7 +689,8 @@ impl StreamingMetrics {
             &["table_id", "actor_id", "fragment_id"],
             registry
         )
-        .unwrap();
+        .unwrap()
+        .into();
 
         let agg_state_cache_miss_count = register_guarded_int_counter_vec_with_registry!(
             "stream_agg_state_cache_miss_count",
@@ -667,7 +698,8 @@ impl StreamingMetrics {
             &["table_id", "actor_id", "fragment_id"],
             registry
         )
-        .unwrap();
+        .unwrap()
+        .into();
 
         let group_top_n_cache_miss_count = register_guarded_int_counter_vec_with_registry!(
             "stream_group_top_n_cache_miss_count",
@@ -675,7 +707,8 @@ impl StreamingMetrics {
             &["table_id", "actor_id", "fragment_id"],
             registry
         )
-        .unwrap();
+        .unwrap()
+        .into();
 
         let group_top_n_total_query_cache_count = register_guarded_int_counter_vec_with_registry!(
             "stream_group_top_n_total_query_cache_count",
@@ -683,7 +716,8 @@ impl StreamingMetrics {
             &["table_id", "actor_id", "fragment_id"],
             registry
         )
-        .unwrap();
+        .unwrap()
+        .into();
 
         let group_top_n_cached_entry_count = register_guarded_int_gauge_vec_with_registry!(
             "stream_group_top_n_cached_entry_count",
@@ -691,7 +725,8 @@ impl StreamingMetrics {
             &["table_id", "actor_id", "fragment_id"],
             registry
         )
-        .unwrap();
+        .unwrap()
+        .into();
 
         let group_top_n_appendonly_cache_miss_count =
             register_guarded_int_counter_vec_with_registry!(
@@ -700,7 +735,8 @@ impl StreamingMetrics {
                 &["table_id", "actor_id", "fragment_id"],
                 registry
             )
-            .unwrap();
+            .unwrap()
+            .into();
 
         let group_top_n_appendonly_total_query_cache_count =
             register_guarded_int_counter_vec_with_registry!(
@@ -709,7 +745,8 @@ impl StreamingMetrics {
                 &["table_id", "actor_id", "fragment_id"],
                 registry
             )
-            .unwrap();
+            .unwrap()
+            .into();
 
         let group_top_n_appendonly_cached_entry_count =
             register_guarded_int_gauge_vec_with_registry!(
@@ -718,7 +755,8 @@ impl StreamingMetrics {
                 &["table_id", "actor_id", "fragment_id"],
                 registry
             )
-            .unwrap();
+            .unwrap()
+            .into();
 
         let lookup_cache_miss_count = register_guarded_int_counter_vec_with_registry!(
             "stream_lookup_cache_miss_count",
@@ -726,7 +764,8 @@ impl StreamingMetrics {
             &["table_id", "actor_id", "fragment_id"],
             registry
         )
-        .unwrap();
+        .unwrap()
+        .into();
 
         let lookup_total_query_cache_count = register_guarded_int_counter_vec_with_registry!(
             "stream_lookup_total_query_cache_count",
@@ -734,7 +773,8 @@ impl StreamingMetrics {
             &["table_id", "actor_id", "fragment_id"],
             registry
         )
-        .unwrap();
+        .unwrap()
+        .into();
 
         let lookup_cached_entry_count = register_guarded_int_gauge_vec_with_registry!(
             "stream_lookup_cached_entry_count",
@@ -742,7 +782,8 @@ impl StreamingMetrics {
             &["table_id", "actor_id", "fragment_id"],
             registry
         )
-        .unwrap();
+        .unwrap()
+        .into();
 
         let temporal_join_cache_miss_count = register_guarded_int_counter_vec_with_registry!(
             "stream_temporal_join_cache_miss_count",
@@ -750,7 +791,8 @@ impl StreamingMetrics {
             &["table_id", "actor_id", "fragment_id"],
             registry
         )
-        .unwrap();
+        .unwrap()
+        .into();
 
         let temporal_join_total_query_cache_count =
             register_guarded_int_counter_vec_with_registry!(
@@ -759,7 +801,8 @@ impl StreamingMetrics {
                 &["table_id", "actor_id", "fragment_id"],
                 registry
             )
-            .unwrap();
+            .unwrap()
+            .into();
 
         let temporal_join_cached_entry_count = register_guarded_int_gauge_vec_with_registry!(
             "stream_temporal_join_cached_entry_count",
@@ -767,7 +810,8 @@ impl StreamingMetrics {
             &["table_id", "actor_id", "fragment_id"],
             registry
         )
-        .unwrap();
+        .unwrap()
+        .into();
 
         let agg_cached_entry_count = register_guarded_int_gauge_vec_with_registry!(
             "stream_agg_cached_entry_count",
@@ -775,7 +819,8 @@ impl StreamingMetrics {
             &["table_id", "actor_id", "fragment_id"],
             registry
         )
-        .unwrap();
+        .unwrap()
+        .into();
 
         let agg_chunk_lookup_miss_count = register_guarded_int_counter_vec_with_registry!(
             "stream_agg_chunk_lookup_miss_count",
@@ -783,7 +828,8 @@ impl StreamingMetrics {
             &["table_id", "actor_id", "fragment_id"],
             registry
         )
-        .unwrap();
+        .unwrap()
+        .into();
 
         let agg_chunk_total_lookup_count = register_guarded_int_counter_vec_with_registry!(
             "stream_agg_chunk_lookup_total_count",
@@ -791,7 +837,8 @@ impl StreamingMetrics {
             &["table_id", "actor_id", "fragment_id"],
             registry
         )
-        .unwrap();
+        .unwrap()
+        .into();
 
         let backfill_snapshot_read_row_count = register_guarded_int_counter_vec_with_registry!(
             "stream_backfill_snapshot_read_row_count",
@@ -799,7 +846,8 @@ impl StreamingMetrics {
             &["table_id", "actor_id"],
             registry
         )
-        .unwrap();
+        .unwrap()
+        .into();
 
         let backfill_upstream_output_row_count = register_guarded_int_counter_vec_with_registry!(
             "stream_backfill_upstream_output_row_count",
@@ -807,7 +855,8 @@ impl StreamingMetrics {
             &["table_id", "actor_id"],
             registry
         )
-        .unwrap();
+        .unwrap()
+        .into();
 
         let cdc_backfill_snapshot_read_row_count = register_guarded_int_counter_vec_with_registry!(
             "stream_cdc_backfill_snapshot_read_row_count",
@@ -815,7 +864,8 @@ impl StreamingMetrics {
             &["table_id", "actor_id"],
             registry
         )
-        .unwrap();
+        .unwrap()
+        .into();
 
         let cdc_backfill_upstream_output_row_count =
             register_guarded_int_counter_vec_with_registry!(
@@ -824,7 +874,8 @@ impl StreamingMetrics {
                 &["table_id", "actor_id"],
                 registry
             )
-            .unwrap();
+            .unwrap()
+            .into();
 
         let snapshot_backfill_consume_row_count = register_guarded_int_counter_vec_with_registry!(
             "stream_snapshot_backfill_consume_snapshot_row_count",
@@ -832,7 +883,8 @@ impl StreamingMetrics {
             &["table_id", "actor_id", "stage"],
             registry
         )
-        .unwrap();
+        .unwrap()
+        .into();
 
         let over_window_cached_entry_count = register_guarded_int_gauge_vec_with_registry!(
             "stream_over_window_cached_entry_count",
@@ -840,7 +892,8 @@ impl StreamingMetrics {
             &["table_id", "actor_id", "fragment_id"],
             registry
         )
-        .unwrap();
+        .unwrap()
+        .into();
 
         let over_window_cache_lookup_count = register_guarded_int_counter_vec_with_registry!(
             "stream_over_window_cache_lookup_count",
@@ -848,7 +901,8 @@ impl StreamingMetrics {
             &["table_id", "actor_id", "fragment_id"],
             registry
         )
-        .unwrap();
+        .unwrap()
+        .into();
 
         let over_window_cache_miss_count = register_guarded_int_counter_vec_with_registry!(
             "stream_over_window_cache_miss_count",
@@ -856,7 +910,8 @@ impl StreamingMetrics {
             &["table_id", "actor_id", "fragment_id"],
             registry
         )
-        .unwrap();
+        .unwrap()
+        .into();
 
         let over_window_range_cache_entry_count = register_guarded_int_gauge_vec_with_registry!(
             "stream_over_window_range_cache_entry_count",
@@ -864,7 +919,8 @@ impl StreamingMetrics {
             &["table_id", "actor_id", "fragment_id"],
             registry,
         )
-        .unwrap();
+        .unwrap()
+        .into();
 
         let over_window_range_cache_lookup_count = register_guarded_int_counter_vec_with_registry!(
             "stream_over_window_range_cache_lookup_count",
@@ -872,7 +928,8 @@ impl StreamingMetrics {
             &["table_id", "actor_id", "fragment_id"],
             registry
         )
-        .unwrap();
+        .unwrap()
+        .into();
 
         let over_window_range_cache_left_miss_count =
             register_guarded_int_counter_vec_with_registry!(
@@ -881,7 +938,8 @@ impl StreamingMetrics {
                 &["table_id", "actor_id", "fragment_id"],
                 registry
             )
-            .unwrap();
+            .unwrap()
+            .into();
 
         let over_window_range_cache_right_miss_count =
             register_guarded_int_counter_vec_with_registry!(
@@ -890,7 +948,8 @@ impl StreamingMetrics {
                 &["table_id", "actor_id", "fragment_id"],
                 registry
             )
-            .unwrap();
+            .unwrap()
+            .into();
 
         let over_window_accessed_entry_count = register_guarded_int_counter_vec_with_registry!(
             "stream_over_window_accessed_entry_count",
@@ -898,7 +957,8 @@ impl StreamingMetrics {
             &["table_id", "actor_id", "fragment_id"],
             registry
         )
-        .unwrap();
+        .unwrap()
+        .into();
 
         let over_window_compute_count = register_guarded_int_counter_vec_with_registry!(
             "stream_over_window_compute_count",
@@ -906,7 +966,8 @@ impl StreamingMetrics {
             &["table_id", "actor_id", "fragment_id"],
             registry
         )
-        .unwrap();
+        .unwrap()
+        .into();
 
         let over_window_same_output_count = register_guarded_int_counter_vec_with_registry!(
             "stream_over_window_same_output_count",
@@ -914,7 +975,8 @@ impl StreamingMetrics {
             &["table_id", "actor_id", "fragment_id"],
             registry
         )
-        .unwrap();
+        .unwrap()
+        .into();
 
         let opts = histogram_opts!(
             "stream_barrier_inflight_duration_seconds",
@@ -950,7 +1012,8 @@ impl StreamingMetrics {
             &["actor_id", "target", "fragment_id", "relation"],
             registry
         )
-        .unwrap();
+        .unwrap()
+        .into();
 
         let sync_kv_log_store_read_count = register_guarded_int_counter_vec_with_registry!(
             "sync_kv_log_store_read_count",
@@ -958,7 +1021,8 @@ impl StreamingMetrics {
             &["type", "actor_id", "target", "fragment_id", "relation"],
             registry
         )
-        .unwrap();
+        .unwrap()
+        .into();
 
         let sync_kv_log_store_read_size = register_guarded_int_counter_vec_with_registry!(
             "sync_kv_log_store_read_size",
@@ -966,7 +1030,8 @@ impl StreamingMetrics {
             &["type", "actor_id", "target", "fragment_id", "relation"],
             registry
         )
-        .unwrap();
+        .unwrap()
+        .into();
 
         let sync_kv_log_store_write_pause_duration_ns =
             register_guarded_int_counter_vec_with_registry!(
@@ -975,7 +1040,8 @@ impl StreamingMetrics {
                 &["actor_id", "target", "fragment_id", "relation"],
                 registry
             )
-            .unwrap();
+            .unwrap()
+            .into();
 
         let sync_kv_log_store_state = register_guarded_int_counter_vec_with_registry!(
             "sync_kv_log_store_state",
@@ -983,7 +1049,8 @@ impl StreamingMetrics {
             &["state", "actor_id", "target", "fragment_id", "relation"],
             registry
         )
-        .unwrap();
+        .unwrap()
+        .into();
 
         let sync_kv_log_store_storage_write_count =
             register_guarded_int_counter_vec_with_registry!(
@@ -992,7 +1059,8 @@ impl StreamingMetrics {
                 &["actor_id", "target", "fragment_id", "relation"],
                 registry
             )
-            .unwrap();
+            .unwrap()
+            .into();
 
         let sync_kv_log_store_storage_write_size = register_guarded_int_counter_vec_with_registry!(
             "sync_kv_log_store_storage_write_size",
@@ -1000,7 +1068,8 @@ impl StreamingMetrics {
             &["actor_id", "target", "fragment_id", "relation"],
             registry
         )
-        .unwrap();
+        .unwrap()
+        .into();
 
         let sync_kv_log_store_buffer_unconsumed_item_count =
             register_guarded_int_gauge_vec_with_registry!(
@@ -1009,7 +1078,8 @@ impl StreamingMetrics {
                 &["actor_id", "target", "fragment_id", "relation"],
                 registry
             )
-            .unwrap();
+            .unwrap()
+            .into();
 
         let sync_kv_log_store_buffer_unconsumed_row_count =
             register_guarded_int_gauge_vec_with_registry!(
@@ -1018,7 +1088,8 @@ impl StreamingMetrics {
                 &["actor_id", "target", "fragment_id", "relation"],
                 registry
             )
-            .unwrap();
+            .unwrap()
+            .into();
 
         let sync_kv_log_store_buffer_unconsumed_epoch_count =
             register_guarded_int_gauge_vec_with_registry!(
@@ -1027,7 +1098,8 @@ impl StreamingMetrics {
                 &["actor_id", "target", "fragment_id", "relation"],
                 registry
             )
-            .unwrap();
+            .unwrap()
+            .into();
 
         let sync_kv_log_store_buffer_unconsumed_min_epoch =
             register_guarded_int_gauge_vec_with_registry!(
@@ -1036,7 +1108,8 @@ impl StreamingMetrics {
                 &["actor_id", "target", "fragment_id", "relation"],
                 registry
             )
-            .unwrap();
+            .unwrap()
+            .into();
         let sync_kv_log_store_buffer_memory_bytes =
             register_guarded_int_gauge_vec_with_registry!(
                 "sync_kv_log_store_buffer_memory_bytes",
@@ -1044,7 +1117,7 @@ impl StreamingMetrics {
                 &["actor_id", "target", "fragment_id", "relation"],
                 registry
             )
-            .unwrap();
+            .unwrap().into();
 
         let kv_log_store_storage_write_count = register_guarded_int_counter_vec_with_registry!(
             "kv_log_store_storage_write_count",
@@ -1052,7 +1125,8 @@ impl StreamingMetrics {
             &["actor_id", "connector", "sink_id", "sink_name"],
             registry
         )
-        .unwrap();
+        .unwrap()
+        .into();
 
         let kv_log_store_storage_write_size = register_guarded_int_counter_vec_with_registry!(
             "kv_log_store_storage_write_size",
@@ -1060,7 +1134,8 @@ impl StreamingMetrics {
             &["actor_id", "connector", "sink_id", "sink_name"],
             registry
         )
-        .unwrap();
+        .unwrap()
+        .into();
 
         let kv_log_store_storage_read_count = register_guarded_int_counter_vec_with_registry!(
             "kv_log_store_storage_read_count",
@@ -1068,7 +1143,8 @@ impl StreamingMetrics {
             &["actor_id", "connector", "sink_id", "sink_name", "read_type"],
             registry
         )
-        .unwrap();
+        .unwrap()
+        .into();
 
         let kv_log_store_storage_read_size = register_guarded_int_counter_vec_with_registry!(
             "kv_log_store_storage_read_size",
@@ -1076,7 +1152,8 @@ impl StreamingMetrics {
             &["actor_id", "connector", "sink_id", "sink_name", "read_type"],
             registry
         )
-        .unwrap();
+        .unwrap()
+        .into();
 
         let kv_log_store_rewind_count = register_guarded_int_counter_vec_with_registry!(
             "kv_log_store_rewind_count",
@@ -1084,7 +1161,8 @@ impl StreamingMetrics {
             &["actor_id", "connector", "sink_id", "sink_name"],
             registry
         )
-        .unwrap();
+        .unwrap()
+        .into();
 
         let kv_log_store_rewind_delay_opts = {
             assert_eq!(2, REWIND_BACKOFF_FACTOR);
@@ -1109,7 +1187,8 @@ impl StreamingMetrics {
             &["actor_id", "connector", "sink_id", "sink_name"],
             registry
         )
-        .unwrap();
+        .unwrap()
+        .into();
 
         let kv_log_store_buffer_unconsumed_item_count =
             register_guarded_int_gauge_vec_with_registry!(
@@ -1118,7 +1197,8 @@ impl StreamingMetrics {
                 &["actor_id", "connector", "sink_id", "sink_name"],
                 registry
             )
-            .unwrap();
+            .unwrap()
+            .into();
 
         let kv_log_store_buffer_unconsumed_row_count =
             register_guarded_int_gauge_vec_with_registry!(
@@ -1127,7 +1207,8 @@ impl StreamingMetrics {
                 &["actor_id", "connector", "sink_id", "sink_name"],
                 registry
             )
-            .unwrap();
+            .unwrap()
+            .into();
 
         let kv_log_store_buffer_unconsumed_epoch_count =
             register_guarded_int_gauge_vec_with_registry!(
@@ -1136,7 +1217,8 @@ impl StreamingMetrics {
                 &["actor_id", "connector", "sink_id", "sink_name"],
                 registry
             )
-            .unwrap();
+            .unwrap()
+            .into();
 
         let kv_log_store_buffer_unconsumed_min_epoch =
             register_guarded_int_gauge_vec_with_registry!(
@@ -1145,7 +1227,8 @@ impl StreamingMetrics {
                 &["actor_id", "connector", "sink_id", "sink_name"],
                 registry
             )
-            .unwrap();
+            .unwrap()
+            .into();
 
         let crossdb_last_consumed_min_epoch = register_guarded_int_gauge_vec_with_registry!(
             "crossdb_last_consumed_min_epoch",
@@ -1153,7 +1236,8 @@ impl StreamingMetrics {
             &["table_id", "actor_id", "fragment_id"],
             registry
         )
-        .unwrap();
+        .unwrap()
+        .into();
 
         let kv_log_store_buffer_memory_bytes =
             register_guarded_int_gauge_vec_with_registry!(
@@ -1162,7 +1246,7 @@ impl StreamingMetrics {
                 &["actor_id", "connector", "sink_id", "sink_name"],
                 registry
             )
-            .unwrap();
+            .unwrap().into();
 
         let lru_runtime_loop_count = register_int_counter_with_registry!(
             "lru_runtime_loop_count",

--- a/src/stream/src/executor/source/batch_source/batch_iceberg_fetch.rs
+++ b/src/stream/src/executor/source/batch_source/batch_iceberg_fetch.rs
@@ -293,13 +293,15 @@ impl<S: StateStore> BatchIcebergFetchExecutor<S> {
 
                     iceberg_metrics
                         .iceberg_source_scan_errors_total
-                        .with_guarded_label_values(&[
-                            metrics_labels[0],
-                            metrics_labels[1],
-                            metrics_labels[2],
-                            "fetch_error",
-                        ])
-                        .inc();
+                        .with_metric(
+                            &[
+                                metrics_labels[0],
+                                metrics_labels[1],
+                                metrics_labels[2],
+                                "fetch_error",
+                            ],
+                            |metric| metric.inc(),
+                        );
 
                     let in_flight_count = state.in_flight_files.len();
                     state.handle_error_recovery();
@@ -364,8 +366,9 @@ impl<S: StateStore> BatchIcebergFetchExecutor<S> {
 
                             iceberg_metrics
                                 .iceberg_source_inflight_file_count
-                                .with_guarded_label_values(&metrics_labels)
-                                .set(state.splits_on_fetch as i64);
+                                .with_metric(&metrics_labels, |metric| {
+                                    metric.set(state.splits_on_fetch as i64)
+                                });
                         }
                     }
 
@@ -384,8 +387,9 @@ impl<S: StateStore> BatchIcebergFetchExecutor<S> {
 
                     iceberg_metrics
                         .iceberg_source_inflight_file_count
-                        .with_guarded_label_values(&metrics_labels)
-                        .set(state.splits_on_fetch as i64);
+                        .with_metric(&metrics_labels, |metric| {
+                            metric.set(state.splits_on_fetch as i64)
+                        });
 
                     for chunk in &chunks {
                         let pruned = prune_additional_cols(

--- a/src/stream/src/executor/source/iceberg_fetch_executor.rs
+++ b/src/stream/src/executor/source/iceberg_fetch_executor.rs
@@ -356,8 +356,7 @@ impl<S: StateStore> IcebergFetchExecutor<S> {
         .await?;
         iceberg_metrics
             .iceberg_source_inflight_file_count
-            .with_guarded_label_values(&metrics_labels)
-            .set(splits_on_fetch as i64);
+            .with_metric(&metrics_labels, |metric| metric.set(splits_on_fetch as i64));
 
         while let Some(msg) = stream.next().await {
             match msg {
@@ -365,18 +364,19 @@ impl<S: StateStore> IcebergFetchExecutor<S> {
                     tracing::error!(error = %e.as_report(), "Fetch Error");
                     iceberg_metrics
                         .iceberg_source_scan_errors_total
-                        .with_guarded_label_values(&[
-                            metrics_labels[0],
-                            metrics_labels[1],
-                            metrics_labels[2],
-                            "fetch_error",
-                        ])
-                        .inc();
+                        .with_metric(
+                            &[
+                                metrics_labels[0],
+                                metrics_labels[1],
+                                metrics_labels[2],
+                                "fetch_error",
+                            ],
+                            |metric| metric.inc(),
+                        );
                     splits_on_fetch = 0;
                     iceberg_metrics
                         .iceberg_source_inflight_file_count
-                        .with_guarded_label_values(&metrics_labels)
-                        .set(0);
+                        .with_metric(&metrics_labels, |metric| metric.set(0));
                 }
                 Ok(msg) => {
                     match msg {
@@ -447,8 +447,9 @@ impl<S: StateStore> IcebergFetchExecutor<S> {
                                         .await?;
                                         iceberg_metrics
                                             .iceberg_source_inflight_file_count
-                                            .with_guarded_label_values(&metrics_labels)
-                                            .set(splits_on_fetch as i64);
+                                            .with_metric(&metrics_labels, |metric| {
+                                                metric.set(splits_on_fetch as i64)
+                                            });
                                     }
                                 }
                                 // Receiving file assignments from upstream list executor,
@@ -481,8 +482,9 @@ impl<S: StateStore> IcebergFetchExecutor<S> {
                                 state_store_handler.delete(&data_file_path).await?;
                                 iceberg_metrics
                                     .iceberg_source_inflight_file_count
-                                    .with_guarded_label_values(&metrics_labels)
-                                    .set(splits_on_fetch as i64);
+                                    .with_metric(&metrics_labels, |metric| {
+                                        metric.set(splits_on_fetch as i64)
+                                    });
                             }
 
                             for chunk in &chunks {

--- a/src/stream/src/executor/source/source_executor.rs
+++ b/src/stream/src/executor/source/source_executor.rs
@@ -461,35 +461,34 @@ impl<S: StateStore> SourceExecutor<S> {
                         if let Some(lsn_value) = pg_split.pg_lsn() {
                             self.metrics
                                 .pg_cdc_state_table_lsn
-                                .with_guarded_label_values(&[&source_id])
-                                .set(lsn_value as i64);
+                                .with_metric(&[&source_id], |metric| metric.set(lsn_value as i64));
                         }
                     }
                     SplitImpl::MysqlCdc(mysql_split) => {
                         if let Some((file_seq, position)) = mysql_split.mysql_binlog_offset() {
                             self.metrics
                                 .mysql_cdc_state_binlog_file_seq
-                                .with_guarded_label_values(&[&source_id])
-                                .set(file_seq as i64);
+                                .with_metric(&[&source_id], |metric| metric.set(file_seq as i64));
 
                             self.metrics
                                 .mysql_cdc_state_binlog_position
-                                .with_guarded_label_values(&[&source_id])
-                                .set(position as i64);
+                                .with_metric(&[&source_id], |metric| metric.set(position as i64));
                         }
                     }
                     SplitImpl::SqlServerCdc(sqlserver_split) => {
                         if let Some(lsn) = sqlserver_split.sql_server_change_lsn() {
                             self.metrics
                                 .sqlserver_cdc_state_change_lsn
-                                .with_guarded_label_values(&[&source_id])
-                                .set(lsn_u128_to_i64(lsn));
+                                .with_metric(&[&source_id], |metric| {
+                                    metric.set(lsn_u128_to_i64(lsn))
+                                });
                         }
                         if let Some(lsn) = sqlserver_split.sql_server_commit_lsn() {
                             self.metrics
                                 .sqlserver_cdc_state_commit_lsn
-                                .with_guarded_label_values(&[&source_id])
-                                .set(lsn_u128_to_i64(lsn));
+                                .with_metric(&[&source_id], |metric| {
+                                    metric.set(lsn_u128_to_i64(lsn))
+                                });
                         }
                     }
                     _ => {}
@@ -1236,16 +1235,18 @@ impl<S: StateStore> WaitCheckpointWorker<S> {
                                     {
                                         self.metrics
                                             .pg_cdc_jni_commit_offset_lsn
-                                            .with_guarded_label_values(&[&source_id.to_string()])
-                                            .set(lsn_value as i64);
+                                            .with_metric(&[&source_id.to_string()], |metric| {
+                                                metric.set(lsn_value as i64)
+                                            });
                                     }
                                     if let Some(lsn_value) =
                                         extract_sql_server_commit_lsn_from_offset_str(offset)
                                     {
                                         self.metrics
                                             .sqlserver_cdc_jni_commit_offset_lsn
-                                            .with_guarded_label_values(&[&source_id.to_string()])
-                                            .set(lsn_u128_to_i64(lsn_value));
+                                            .with_metric(&[&source_id.to_string()], |metric| {
+                                                metric.set(lsn_u128_to_i64(lsn_value))
+                                            });
                                     }
                                 },
                             )


### PR DESCRIPTION
## What

- Retain values returned by `with_guarded_label_values` in local variables or owning structs at the affected metric update sites.
- Fix the `rw::temporary_guarded_metric` hits from https://github.com/risingwavelabs/risingwave/pull/26391#issuecomment-5054523148 without adding a shared cache or mutex.
- Apply the same local-guard pattern to auto-schema-change metrics in `risingwave_meta_service`.

## Verification

- `cargo fmt --check && git diff --check`
- `CARGO_INCREMENTAL=0 cargo check -p risingwave_common_metrics -p risingwave_connector -p risingwave_stream -p risingwave_meta -p risingwave_meta_service --all-targets --all-features --locked`
- `CARGO_INCREMENTAL=0 DYLINT_RUSTFLAGS="-A warnings -D rw_all" cargo dylint --all --no-deps --keep-going -- -p risingwave_common_metrics -p risingwave_connector -p risingwave_stream -p risingwave_meta -p risingwave_meta_service --all-targets --all-features --locked`