### PR TITLE
fix(storage): collect point get iterator stats

### DIFF
--- a/src/storage/Cargo.toml
+++ b/src/storage/Cargo.toml
@@ -13,6 +13,7 @@ repository = { workspace = true }
 test = ["risingwave_hummock_sdk/test"]
 failpoints = ["fail/failpoints"]
 hm-trace = []
+sync_point = ["sync-point/sync_point"]
 
 [dependencies]
 ahash = "0.8"

--- a/src/storage/hummock_test/Cargo.toml
+++ b/src/storage/hummock_test/Cargo.toml
@@ -9,7 +9,7 @@ repository = { workspace = true }
 
 [features]
 failpoints = ["risingwave_storage/failpoints"]
-sync_point = ["sync-point/sync_point", "serial_test"]
+sync_point = ["risingwave_storage/sync_point", "sync-point/sync_point", "serial_test"]
 test = []
 
 [dependencies]

--- a/src/storage/hummock_test/src/sync_point_tests.rs
+++ b/src/storage/hummock_test/src/sync_point_tests.rs
@@ -34,8 +34,13 @@ use risingwave_storage::StateStore;
 use risingwave_storage::compaction_catalog_manager::CompactionCatalogAgentRef;
 use risingwave_storage::hummock::compactor::CompactorContext;
 use risingwave_storage::hummock::compactor::compactor_runner::compact_with_agent;
+use risingwave_storage::hummock::iterator::test_utils::mock_sstable_store;
 use risingwave_storage::hummock::test_utils::{ReadOptions, *};
-use risingwave_storage::hummock::{CachePolicy, GetObjectId, ObjectIdManager};
+use risingwave_storage::hummock::value::HummockValue;
+use risingwave_storage::hummock::{
+    CachePolicy, GetObjectId, ObjectIdManager, get_from_sstable_info,
+};
+use risingwave_storage::monitor::StoreLocalStatistic;
 use risingwave_storage::store::*;
 use serial_test::serial;
 
@@ -44,6 +49,53 @@ use crate::compactor_tests::tests::{flush_and_commit, get_compactor_context};
 use crate::get_notification_client_for_test;
 use crate::local_state_store_test_utils::LocalStateStoreTestExt;
 use crate::test_utils::gen_key_from_bytes;
+
+#[tokio::test]
+#[cfg(feature = "sync_point")]
+#[serial]
+async fn test_get_from_sstable_info_cancellation_settles_nested_stats() {
+    const PAUSE: &str = "SSTABLE_ITERATOR::SEEK::BEFORE_NEXT_BLOCK";
+
+    sync_point::reset();
+    let paused = Arc::new(tokio::sync::Notify::new());
+    let paused_hook = paused.clone();
+    sync_point::hook(PAUSE, move || {
+        let paused = paused_hook.clone();
+        async move {
+            paused.notify_one();
+            futures::future::pending::<()>().await;
+        }
+    });
+
+    let sstable_store = mock_sstable_store().await;
+    let (_sstable, sstable_info) = gen_test_sstable(
+        default_builder_opt_for_test(),
+        0,
+        (0..10).map(|idx| (test_key_of(idx), HummockValue::put(test_value_of(idx)))),
+        sstable_store.clone(),
+    )
+    .await;
+    let mut parent_stats = StoreLocalStatistic::default();
+    let full_key = test_key_of(10);
+    let read_options = risingwave_storage::store::ReadOptions::default();
+    let mut get = Box::pin(get_from_sstable_info(
+        sstable_store,
+        &sstable_info,
+        full_key.to_ref(),
+        &read_options,
+        None,
+        &mut parent_stats,
+    ));
+
+    tokio::select! {
+        () = paused.notified() => {}
+        _ = get.as_mut() => panic!("GET completed before cancellation"),
+    }
+    drop(get);
+    sync_point::remove_action(PAUSE);
+
+    assert_eq!(parent_stats.cache_data_block_total, 1);
+}
 
 #[tokio::test]
 #[cfg(feature = "sync_point")]

--- a/src/storage/hummock_test/src/sync_point_tests.rs
+++ b/src/storage/hummock_test/src/sync_point_tests.rs
@@ -50,22 +50,62 @@ use crate::get_notification_client_for_test;
 use crate::local_state_store_test_utils::LocalStateStoreTestExt;
 use crate::test_utils::gen_key_from_bytes;
 
+#[cfg(feature = "sync_point")]
+struct SyncPointActionGuard(sync_point::SyncPoint);
+
+#[cfg(feature = "sync_point")]
+impl Drop for SyncPointActionGuard {
+    fn drop(&mut self) {
+        sync_point::remove_action(self.0);
+    }
+}
+
+#[tokio::test]
+async fn test_get_from_sstable_info_success_settles_nested_stats_once() {
+    let sstable_store = mock_sstable_store().await;
+    let (_sstable, sstable_info) = gen_test_sstable(
+        default_builder_opt_for_test(),
+        0,
+        (0..10).map(|idx| (test_key_of(idx), HummockValue::put(test_value_of(idx)))),
+        sstable_store.clone(),
+    )
+    .await;
+    let mut parent_stats = StoreLocalStatistic {
+        cache_data_block_total: 7,
+        ..Default::default()
+    };
+    let full_key = test_key_of(0);
+    let read_options = risingwave_storage::store::ReadOptions::default();
+
+    let iter = get_from_sstable_info(
+        sstable_store,
+        &sstable_info,
+        full_key.to_ref(),
+        &read_options,
+        None,
+        &mut parent_stats,
+    )
+    .await
+    .unwrap()
+    .unwrap();
+    drop(iter);
+
+    assert_eq!(parent_stats.cache_data_block_total, 8);
+}
+
 #[tokio::test]
 #[cfg(feature = "sync_point")]
 #[serial]
 async fn test_get_from_sstable_info_cancellation_settles_nested_stats() {
     const PAUSE: &str = "SSTABLE_ITERATOR::SEEK::BEFORE_NEXT_BLOCK";
+    const PAUSED: &str = "SSTABLE_ITERATOR::SEEK::BEFORE_NEXT_BLOCK::PAUSED";
 
     sync_point::reset();
-    let paused = Arc::new(tokio::sync::Notify::new());
-    let paused_hook = paused.clone();
-    sync_point::hook(PAUSE, move || {
-        let paused = paused_hook.clone();
-        async move {
-            paused.notify_one();
-            futures::future::pending::<()>().await;
-        }
+    sync_point::hook(PAUSE, || async {
+        sync_point::on(PAUSED).await;
+        futures::future::pending::<()>().await;
     });
+    let _pause_cleanup = SyncPointActionGuard(PAUSE);
 
     let sstable_store = mock_sstable_store().await;
     let (_sstable, sstable_info) = gen_test_sstable(
@@ -88,11 +128,12 @@ async fn test_get_from_sstable_info_cancellation_settles_nested_stats() {
     ));
 
     tokio::select! {
-        () = paused.notified() => {}
+        result = sync_point::wait_timeout(PAUSED, Duration::from_secs(10)) => {
+            result.expect("GET did not reach the cancellation hook");
+        }
         _ = get.as_mut() => panic!("GET completed before cancellation"),
     }
     drop(get);
-    sync_point::remove_action(PAUSE);
 
     assert_eq!(parent_stats.cache_data_block_total, 1);
 }

--- a/src/storage/src/hummock/iterator/concat_inner.rs
+++ b/src/storage/src/hummock/iterator/concat_inner.rs
@@ -15,6 +15,7 @@
 use std::cmp::Ordering::{Equal, Greater, Less};
 use std::sync::Arc;
 
+use fail::fail_point;
 use risingwave_hummock_sdk::key::FullKey;
 use risingwave_hummock_sdk::sstable_info::SstableInfo;
 
@@ -23,7 +24,7 @@ use crate::hummock::iterator::{
 };
 use crate::hummock::sstable::SstableIteratorReadOptions;
 use crate::hummock::value::HummockValue;
-use crate::hummock::{HummockResult, SstableIteratorType, SstableStoreRef};
+use crate::hummock::{HummockResult, IteratorStatsGuard, SstableIteratorType, SstableStoreRef};
 use crate::monitor::StoreLocalStatistic;
 
 fn smallest_key(sstable_info: &SstableInfo) -> &[u8] {
@@ -86,23 +87,29 @@ impl<TI: SstableIteratorType> ConcatIteratorInner<TI> {
                 .sstable_store
                 .sstable(&self.sstable_infos[idx], &mut self.stats)
                 .await?;
-            let mut sstable_iter = TI::create(
+            let sstable_iter = TI::create(
                 table,
                 self.sstable_store.clone(),
                 self.read_options.clone(),
                 &self.sstable_infos[idx],
             );
 
+            let mut pending = IteratorStatsGuard::new(sstable_iter, &mut self.stats);
             if let Some(key) = seek_key {
-                sstable_iter.seek(key).await?;
+                pending.iter_mut().seek(key).await?;
             } else {
-                sstable_iter.rewind().await?;
+                pending.iter_mut().rewind().await?;
             }
+            fail_point!("concat_iter_after_seek_before_init_complete", |_| Err(
+                crate::hummock::HummockError::meta_error(
+                    "test error after concat iterator seek before initialization completes"
+                )
+            ));
 
+            let sstable_iter = pending.handoff();
             if let Some(old_iter) = self.sstable_iter.take() {
                 old_iter.collect_local_statistic(&mut self.stats);
             }
-
             self.sstable_iter = Some(sstable_iter);
             self.cur_idx = idx;
         }

--- a/src/storage/src/hummock/iterator/forward_concat.rs
+++ b/src/storage/src/hummock/iterator/forward_concat.rs
@@ -22,13 +22,20 @@ pub type ConcatIterator = ConcatIteratorInner<SstableIterator>;
 mod tests {
     use std::sync::Arc;
 
+    #[cfg(feature = "failpoints")]
+    use foyer::Hint;
+
     use super::*;
+    #[cfg(feature = "failpoints")]
+    use crate::hummock::CachePolicy;
     use crate::hummock::iterator::HummockIterator;
     use crate::hummock::iterator::test_utils::{
         TEST_KEYS_COUNT, default_builder_opt_for_test, gen_iterator_test_sstable_info,
         iterator_test_key_of, iterator_test_value_of, mock_sstable_store,
     };
     use crate::hummock::sstable::SstableIteratorReadOptions;
+    #[cfg(feature = "failpoints")]
+    use crate::monitor::StoreLocalStatistic;
 
     #[tokio::test]
     async fn test_concat_iterator() {
@@ -222,6 +229,73 @@ mod tests {
         assert_eq!(
             val.into_user_value().unwrap(),
             iterator_test_value_of(TEST_KEYS_COUNT * 4).as_slice()
+        );
+    }
+
+    #[tokio::test]
+    #[cfg(feature = "failpoints")]
+    async fn test_concat_init_error_retains_current_iterator_and_candidate_stats() {
+        let sstable_store = mock_sstable_store().await;
+        let table0 = gen_iterator_test_sstable_info(
+            0,
+            default_builder_opt_for_test(),
+            |x| x,
+            sstable_store.clone(),
+            TEST_KEYS_COUNT,
+        )
+        .await;
+        let table1 = gen_iterator_test_sstable_info(
+            1,
+            default_builder_opt_for_test(),
+            |x| TEST_KEYS_COUNT + x,
+            sstable_store.clone(),
+            TEST_KEYS_COUNT,
+        )
+        .await;
+
+        // Warm the candidate's first block so its initialization records a cache hit.
+        let mut warmup_stats = StoreLocalStatistic::default();
+        let sstable = sstable_store
+            .sstable(&table1, &mut warmup_stats)
+            .await
+            .unwrap();
+        sstable_store
+            .get(
+                &sstable,
+                0,
+                CachePolicy::Fill(Hint::Normal),
+                &mut warmup_stats,
+            )
+            .await
+            .unwrap();
+        warmup_stats.discard();
+
+        let mut iter = ConcatIterator::new(
+            vec![table0, table1],
+            sstable_store,
+            Arc::new(SstableIteratorReadOptions::default()),
+        );
+        iter.rewind().await.unwrap();
+
+        let mut before = StoreLocalStatistic::default();
+        iter.collect_local_statistic(&mut before);
+
+        fail::cfg("concat_iter_after_seek_before_init_complete", "return").unwrap();
+        let result = iter
+            .seek(iterator_test_key_of(TEST_KEYS_COUNT).to_ref())
+            .await;
+        fail::remove("concat_iter_after_seek_before_init_complete");
+
+        assert!(result.is_err());
+        assert!(iter.is_valid());
+        assert_eq!(iter.key(), iterator_test_key_of(0).to_ref());
+
+        let mut after = StoreLocalStatistic::default();
+        iter.collect_local_statistic(&mut after);
+        assert_eq!(
+            after.cache_data_block_total,
+            before.cache_data_block_total + 1,
+            "failed candidate initialization must settle its cache-hit statistic"
         );
     }
 }

--- a/src/storage/src/hummock/iterator/forward_merge.rs
+++ b/src/storage/src/hummock/iterator/forward_merge.rs
@@ -23,7 +23,6 @@ mod test {
     use risingwave_hummock_sdk::EpochWithGap;
     use risingwave_hummock_sdk::key::{FullKey, TableKey, UserKey};
 
-    use crate::hummock::HummockResult;
     use crate::hummock::iterator::test_utils::{
         TEST_KEYS_COUNT, default_builder_opt_for_test, gen_iterator_test_sstable_info,
         gen_merge_iterator_interleave_test_sstable_iters, iterator_test_key_of,
@@ -34,6 +33,7 @@ mod test {
         SstableIterator, SstableIteratorReadOptions, SstableIteratorType,
     };
     use crate::hummock::value::HummockValue;
+    use crate::hummock::{HummockError, HummockResult};
     use crate::monitor::StoreLocalStatistic;
 
     #[tokio::test]
@@ -160,6 +160,92 @@ mod test {
             iter.next().await.unwrap();
         }
         assert_eq!(count, TEST_KEYS_COUNT * 2);
+    }
+
+    struct ErrorStatsTestIterator {
+        key: &'static [u8],
+        fail_on_next: bool,
+        valid: bool,
+        work: u64,
+    }
+
+    impl ErrorStatsTestIterator {
+        fn new(key: &'static [u8], fail_on_next: bool) -> Self {
+            Self {
+                key,
+                fail_on_next,
+                valid: false,
+                work: 0,
+            }
+        }
+    }
+
+    impl HummockIterator for ErrorStatsTestIterator {
+        type Direction = Forward;
+
+        async fn next(&mut self) -> HummockResult<()> {
+            if self.fail_on_next {
+                Err(HummockError::meta_error("test merge child next error"))
+            } else {
+                self.valid = false;
+                Ok(())
+            }
+        }
+
+        fn key(&self) -> FullKey<&[u8]> {
+            FullKey {
+                user_key: UserKey {
+                    table_id: Default::default(),
+                    table_key: TableKey(self.key),
+                },
+                epoch_with_gap: EpochWithGap::new_from_epoch(0),
+            }
+        }
+
+        fn value(&self) -> HummockValue<&[u8]> {
+            HummockValue::delete()
+        }
+
+        fn is_valid(&self) -> bool {
+            self.valid
+        }
+
+        async fn rewind(&mut self) -> HummockResult<()> {
+            self.valid = true;
+            self.work += 1;
+            Ok(())
+        }
+
+        async fn seek<'a>(&'a mut self, _key: FullKey<&'a [u8]>) -> HummockResult<()> {
+            self.rewind().await
+        }
+
+        fn collect_local_statistic(&self, stats: &mut StoreLocalStatistic) {
+            stats.cache_data_block_total += self.work;
+        }
+
+        fn value_meta(&self) -> ValueMeta {
+            ValueMeta::default()
+        }
+    }
+
+    #[tokio::test]
+    async fn test_merge_error_retains_current_and_remaining_statistics() {
+        let mut merge = MergeIterator::new([
+            ErrorStatsTestIterator::new(b"a", true),
+            ErrorStatsTestIterator::new(b"b", false),
+        ]);
+        merge.rewind().await.unwrap();
+
+        assert!(merge.next().await.is_err());
+        assert!(!merge.is_valid());
+
+        let mut stats = StoreLocalStatistic::default();
+        merge.collect_local_statistic(&mut stats);
+        assert_eq!(
+            stats.cache_data_block_total, 2,
+            "error cleanup must retain both the popped current node and remaining heap nodes"
+        );
     }
 
     struct CancellationTestIterator {}

--- a/src/storage/src/hummock/iterator/forward_merge.rs
+++ b/src/storage/src/hummock/iterator/forward_merge.rs
@@ -240,6 +240,12 @@ mod test {
         assert!(merge.next().await.is_err());
         assert!(!merge.is_valid());
 
+        merge.seek(iterator_test_key_of(0).to_ref()).await.unwrap();
+        assert!(
+            !merge.is_valid(),
+            "error-retired children must not be retried by a later seek"
+        );
+
         let mut stats = StoreLocalStatistic::default();
         merge.collect_local_statistic(&mut stats);
         assert_eq!(

--- a/src/storage/src/hummock/iterator/merge_inner.rs
+++ b/src/storage/src/hummock/iterator/merge_inner.rs
@@ -65,10 +65,14 @@ pub struct MergeIterator<I: HummockIterator> {
 
     /// The heap for merge sort.
     heap: BinaryHeap<Node<I>>,
+
+    /// Statistics collected from iterators discarded after an error.
+    retired_stats: StoreLocalStatistic,
 }
 
 impl<I: HummockIterator> MergeIterator<I> {
     fn collect_local_statistic_impl(&self, stats: &mut StoreLocalStatistic) {
+        stats.add(&self.retired_stats);
         for node in &self.heap {
             node.iter.collect_local_statistic(stats);
         }
@@ -91,6 +95,7 @@ impl<I: HummockIterator> MergeIterator<I> {
         Self {
             unused_iters: iterators.into_iter().map(|iter| Node { iter }).collect(),
             heap: BinaryHeap::new(),
+            retired_stats: StoreLocalStatistic::default(),
         }
     }
 }
@@ -202,10 +207,13 @@ where
             Ok(_) => {}
             Err(e) => {
                 // If the iterator returns error, we should clear the heap, so that this
-                // iterator becomes invalid.
+                // iterator becomes invalid. Collect their work before dropping them, but do not
+                // retain the failed/current heap iterators for a later seek or rewind.
                 let node = node.pop();
-                self.unused_iters.push_back(node);
-                self.unused_iters.extend(self.heap.drain());
+                node.iter.collect_local_statistic(&mut self.retired_stats);
+                for node in self.heap.drain() {
+                    node.iter.collect_local_statistic(&mut self.retired_stats);
+                }
                 return Err(e);
             }
         }

--- a/src/storage/src/hummock/iterator/merge_inner.rs
+++ b/src/storage/src/hummock/iterator/merge_inner.rs
@@ -203,8 +203,9 @@ where
             Err(e) => {
                 // If the iterator returns error, we should clear the heap, so that this
                 // iterator becomes invalid.
-                node.pop();
-                self.heap.clear();
+                let node = node.pop();
+                self.unused_iters.push_back(node);
+                self.unused_iters.extend(self.heap.drain());
                 return Err(e);
             }
         }

--- a/src/storage/src/hummock/iterator/merge_inner.rs
+++ b/src/storage/src/hummock/iterator/merge_inner.rs
@@ -67,12 +67,14 @@ pub struct MergeIterator<I: HummockIterator> {
     heap: BinaryHeap<Node<I>>,
 
     /// Statistics collected from iterators discarded after an error.
-    retired_stats: StoreLocalStatistic,
+    retired_stats: Option<Box<StoreLocalStatistic>>,
 }
 
 impl<I: HummockIterator> MergeIterator<I> {
     fn collect_local_statistic_impl(&self, stats: &mut StoreLocalStatistic) {
-        stats.add(&self.retired_stats);
+        if let Some(retired_stats) = &self.retired_stats {
+            stats.add(retired_stats);
+        }
         for node in &self.heap {
             node.iter.collect_local_statistic(stats);
         }
@@ -95,7 +97,7 @@ impl<I: HummockIterator> MergeIterator<I> {
         Self {
             unused_iters: iterators.into_iter().map(|iter| Node { iter }).collect(),
             heap: BinaryHeap::new(),
-            retired_stats: StoreLocalStatistic::default(),
+            retired_stats: None,
         }
     }
 }
@@ -210,9 +212,12 @@ where
                 // iterator becomes invalid. Collect their work before dropping them, but do not
                 // retain the failed/current heap iterators for a later seek or rewind.
                 let node = node.pop();
-                node.iter.collect_local_statistic(&mut self.retired_stats);
+                let retired_stats = self
+                    .retired_stats
+                    .get_or_insert_with(|| Box::new(StoreLocalStatistic::default()));
+                node.iter.collect_local_statistic(retired_stats);
                 for node in self.heap.drain() {
-                    node.iter.collect_local_statistic(&mut self.retired_stats);
+                    node.iter.collect_local_statistic(retired_stats);
                 }
                 return Err(e);
             }

--- a/src/storage/src/hummock/mod.rs
+++ b/src/storage/src/hummock/mod.rs
@@ -69,6 +69,45 @@ use crate::mem_table::ImmutableMemtable;
 use crate::monitor::StoreLocalStatistic;
 use crate::store::ReadOptions;
 
+struct GetSstableIteratorStatsGuard<'a> {
+    iter: Option<SstableIterator>,
+    local_stats: &'a mut StoreLocalStatistic,
+}
+
+impl<'a> GetSstableIteratorStatsGuard<'a> {
+    fn new(iter: SstableIterator, local_stats: &'a mut StoreLocalStatistic) -> Self {
+        Self {
+            iter: Some(iter),
+            local_stats,
+        }
+    }
+
+    fn iter(&self) -> &SstableIterator {
+        self.iter.as_ref().expect("iterator must be present")
+    }
+
+    fn iter_mut(&mut self) -> &mut SstableIterator {
+        self.iter.as_mut().expect("iterator must be present")
+    }
+
+    fn collect(&mut self) {
+        if let Some(iter) = &self.iter {
+            iter.collect_local_statistic(self.local_stats);
+        }
+    }
+
+    fn into_inner(mut self) -> SstableIterator {
+        self.collect();
+        self.iter.take().expect("iterator must be present")
+    }
+}
+
+impl Drop for GetSstableIteratorStatsGuard<'_> {
+    fn drop(&mut self) {
+        self.collect();
+    }
+}
+
 pub async fn get_from_sstable_info(
     sstable_store_ref: SstableStoreRef,
     sstable_info: &SstableInfo,
@@ -95,24 +134,25 @@ pub async fn get_from_sstable_info(
         return Ok(None);
     }
 
-    let mut iter = SstableIterator::create(
-        sstable,
-        sstable_store_ref.clone(),
-        Arc::new(SstableIteratorReadOptions::from_read_options(read_options)),
-        sstable_info,
+    let mut iter = GetSstableIteratorStatsGuard::new(
+        SstableIterator::create(
+            sstable,
+            sstable_store_ref.clone(),
+            Arc::new(SstableIteratorReadOptions::from_read_options(read_options)),
+            sstable_info,
+        ),
+        local_stats,
     );
-    iter.seek(full_key).await?;
+    iter.iter_mut().seek(full_key).await?;
     // Iterator has sought passed the borders.
-    if !iter.is_valid() {
+    if !iter.iter().is_valid() {
         return Ok(None);
     }
 
-    iter.collect_local_statistic(local_stats);
-
     // Iterator gets us the key, we tell if it's the key we want
     // or key next to it.
-    let value = if iter.key().user_key == full_key.user_key {
-        Some(iter)
+    let value = if iter.iter().key().user_key == full_key.user_key {
+        Some(iter.into_inner())
     } else {
         None
     };
@@ -145,4 +185,49 @@ pub fn get_from_batch<'a>(
     imm.get(table_key, read_epoch, read_options).inspect(|_| {
         local_stats.get_shared_buffer_hit_counts += 1;
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::get_from_sstable_info;
+    use crate::hummock::iterator::test_utils::{iterator_test_key_of, mock_sstable_store};
+    use crate::hummock::test_utils::{default_builder_opt_for_test, gen_test_sstable_info};
+    use crate::hummock::value::HummockValue;
+    use crate::monitor::StoreLocalStatistic;
+    use crate::store::ReadOptions;
+
+    #[tokio::test]
+    async fn test_get_collects_stats_when_seek_passes_sst_end() {
+        let sstable_store = mock_sstable_store().await;
+        let sstable_info = gen_test_sstable_info(
+            default_builder_opt_for_test(),
+            1,
+            (0..10).map(|idx| {
+                (
+                    iterator_test_key_of(idx),
+                    HummockValue::put(format!("value_{idx}").into_bytes()),
+                )
+            }),
+            sstable_store.clone(),
+        )
+        .await;
+        let mut stats = StoreLocalStatistic::default();
+        let key = iterator_test_key_of(10);
+        let read_options = ReadOptions::default();
+
+        let result = get_from_sstable_info(
+            sstable_store,
+            &sstable_info,
+            key.to_ref(),
+            &read_options,
+            None,
+            &mut stats,
+        )
+        .await
+        .unwrap();
+
+        assert!(result.is_none());
+        drop(result);
+        assert_eq!(stats.cache_data_block_total, 1);
+    }
 }

--- a/src/storage/src/hummock/mod.rs
+++ b/src/storage/src/hummock/mod.rs
@@ -69,40 +69,44 @@ use crate::mem_table::ImmutableMemtable;
 use crate::monitor::StoreLocalStatistic;
 use crate::store::ReadOptions;
 
-struct GetSstableIteratorStatsGuard<'a> {
-    iter: Option<SstableIterator>,
-    local_stats: &'a mut StoreLocalStatistic,
+pub(in crate::hummock) struct IteratorStatsGuard<'a, TI: HummockIterator> {
+    iter: Option<TI>,
+    parent_stats: &'a mut StoreLocalStatistic,
 }
 
-impl<'a> GetSstableIteratorStatsGuard<'a> {
-    fn new(iter: SstableIterator, local_stats: &'a mut StoreLocalStatistic) -> Self {
+impl<'a, TI: HummockIterator> IteratorStatsGuard<'a, TI> {
+    pub(in crate::hummock) fn new(iter: TI, parent_stats: &'a mut StoreLocalStatistic) -> Self {
         Self {
             iter: Some(iter),
-            local_stats,
+            parent_stats,
         }
     }
 
-    fn iter(&self) -> &SstableIterator {
+    pub(in crate::hummock) fn iter(&self) -> &TI {
         self.iter.as_ref().expect("iterator must be present")
     }
 
-    fn iter_mut(&mut self) -> &mut SstableIterator {
+    pub(in crate::hummock) fn iter_mut(&mut self) -> &mut TI {
         self.iter.as_mut().expect("iterator must be present")
     }
 
     fn collect(&mut self) {
         if let Some(iter) = &self.iter {
-            iter.collect_local_statistic(self.local_stats);
+            iter.collect_local_statistic(self.parent_stats);
         }
     }
 
-    fn into_inner(mut self) -> SstableIterator {
+    pub(in crate::hummock) fn handoff(mut self) -> TI {
+        self.iter.take().expect("iterator must be present")
+    }
+
+    pub(in crate::hummock) fn collect_and_take(mut self) -> TI {
         self.collect();
         self.iter.take().expect("iterator must be present")
     }
 }
 
-impl Drop for GetSstableIteratorStatsGuard<'_> {
+impl<TI: HummockIterator> Drop for IteratorStatsGuard<'_, TI> {
     fn drop(&mut self) {
         self.collect();
     }
@@ -134,7 +138,7 @@ pub async fn get_from_sstable_info(
         return Ok(None);
     }
 
-    let mut iter = GetSstableIteratorStatsGuard::new(
+    let mut iter = IteratorStatsGuard::new(
         SstableIterator::create(
             sstable,
             sstable_store_ref.clone(),
@@ -152,7 +156,7 @@ pub async fn get_from_sstable_info(
     // Iterator gets us the key, we tell if it's the key we want
     // or key next to it.
     let value = if iter.iter().key().user_key == full_key.user_key {
-        Some(iter.into_inner())
+        Some(iter.collect_and_take())
     } else {
         None
     };

--- a/src/storage/src/hummock/sstable/forward_sstable_iterator.rs
+++ b/src/storage/src/hummock/sstable/forward_sstable_iterator.rs
@@ -18,6 +18,7 @@ use std::sync::Arc;
 use await_tree::{InstrumentAwait, SpanExt};
 use risingwave_hummock_sdk::key::FullKey;
 use risingwave_hummock_sdk::sstable_info::SstableInfo;
+use sync_point::sync_point;
 use thiserror_ext::AsReport;
 
 use super::super::{HummockResult, HummockValue};
@@ -385,6 +386,7 @@ impl HummockIterator for SstableIterator {
         self.seek_idx(block_idx, Some(key)).await?;
         if !self.is_valid() {
             // seek to next block
+            sync_point!("SSTABLE_ITERATOR::SEEK::BEFORE_NEXT_BLOCK");
             self.seek_idx(block_idx + 1, None).await?;
         }
         Ok(())


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

Point GET creates an `SstableIterator` and seeks to the requested key. The
iterator statistics were collected only after checking whether the iterator was
valid. When the seek passed the end of an SST, the function returned `None`
before collecting cache and I/O work already performed by the seek. The same
ordering also skipped collection when the seek returned an error.

This PR collects the iterator statistics immediately after the seek future
completes, before propagating the seek result or returning for an invalid
iterator. Successful point GET behavior is unchanged.

A focused regression queries past the SST upper bound and verifies that the
data-block read is transferred to the request statistics even though the result
is `None`.

## Checklist

- [ ] I have written necessary rustdoc comments.
- [x] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->

## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

</details>
