### PR TITLE
fix(metrics): retain guarded metrics locally

### DIFF
--- a/src/common/metrics/src/monitor/connection.rs
+++ b/src/common/metrics/src/monitor/connection.rs
@@ -797,17 +797,15 @@ impl MonitorAsyncReadWrite for MonitorAsyncReadWriteImpl {
     }
 
     fn on_read_err(&mut self, err: &Error) {
-        // No need to store the value returned from `with_guarded_label_values`
-        // because it is reporting a single error.
-        GLOBAL_CONNECTION_METRICS
+        let io_err_rate = GLOBAL_CONNECTION_METRICS
             .io_err_rate
             .with_guarded_label_values(&[
                 self.connection_type.as_str(),
                 self.endpoint.as_str(),
                 "read",
                 err.kind().to_string().as_str(),
-            ])
-            .inc();
+            ]);
+        io_err_rate.inc();
     }
 
     fn on_write(&mut self, size: usize) {
@@ -828,16 +826,14 @@ impl MonitorAsyncReadWrite for MonitorAsyncReadWriteImpl {
     }
 
     fn on_write_err(&mut self, err: &Error) {
-        // No need to store the value returned from `with_guarded_label_values`
-        // because it is reporting a single error.
-        GLOBAL_CONNECTION_METRICS
+        let io_err_rate = GLOBAL_CONNECTION_METRICS
             .io_err_rate
             .with_guarded_label_values(&[
                 self.connection_type.as_str(),
                 self.endpoint.as_str(),
                 "write",
                 err.kind().to_string().as_str(),
-            ])
-            .inc();
+            ]);
+        io_err_rate.inc();
     }
 }

--- a/src/connector/src/sink/iceberg/commit.rs
+++ b/src/connector/src/sink/iceberg/commit.rs
@@ -786,10 +786,10 @@ impl IcebergSinkCommitter {
         let catalog_name = self.config.common.catalog_name();
         let table_name = self.table.identifier().to_string();
         let metrics_labels = [&self.param.sink_name, &catalog_name, &table_name];
-        GLOBAL_SINK_METRICS
+        let iceberg_snapshot_num = GLOBAL_SINK_METRICS
             .iceberg_snapshot_num
-            .with_guarded_label_values(&metrics_labels)
-            .set(snapshot_num as i64);
+            .with_guarded_label_values(&metrics_labels);
+        iceberg_snapshot_num.set(snapshot_num as i64);
 
         tracing::debug!(
             iceberg_component = "sink_committer",

--- a/src/connector/src/source/iceberg/mod.rs
+++ b/src/connector/src/source/iceberg/mod.rs
@@ -468,10 +468,10 @@ pub async fn scan_task_to_chunk_with_deletes(
 
     let mut read_bytes = scopeguard::guard(0u64, |read_bytes| {
         if let Some(metrics) = metrics.clone() {
-            metrics
+            let iceberg_read_bytes = metrics
                 .iceberg_read_bytes
-                .with_guarded_label_values(&[&table_name])
-                .inc_by(read_bytes as _);
+                .with_guarded_label_values(&[&table_name]);
+            iceberg_read_bytes.inc_by(read_bytes as _);
         }
     });
 
@@ -545,24 +545,24 @@ pub async fn scan_task_to_chunk_with_deletes(
         let label_values = [table_name.as_str()];
 
         // File read duration.
-        metrics
+        let file_read_duration_seconds = metrics
             .iceberg_source_file_read_duration_seconds
-            .with_guarded_label_values(&label_values)
-            .observe(file_start.elapsed().as_secs_f64());
+            .with_guarded_label_values(&label_values);
+        file_read_duration_seconds.observe(file_start.elapsed().as_secs_f64());
 
         // Rows read.
         if total_rows_read > 0 {
-            metrics
+            let rows_read_total = metrics
                 .iceberg_source_rows_read_total
-                .with_guarded_label_values(&label_values)
-                .inc_by(total_rows_read);
+                .with_guarded_label_values(&label_values);
+            rows_read_total.inc_by(total_rows_read);
         }
 
         // File read count.
-        metrics
+        let files_read_total = metrics
             .iceberg_source_files_read_total
-            .with_guarded_label_values(&[table_name.as_str(), "data"])
-            .inc();
+            .with_guarded_label_values(&[table_name.as_str(), "data"]);
+        files_read_total.inc();
 
         // APPROXIMATE: Estimate delete rows applied. The delta between expected_record_count
         // and actual rows read may also include predicate pushdown / row-group pruning effects,
@@ -574,10 +574,10 @@ pub async fn scan_task_to_chunk_with_deletes(
         {
             let deleted = expected.saturating_sub(total_rows_read);
             if deleted > 0 {
-                metrics
+                let delete_rows_applied_total = metrics
                     .iceberg_source_delete_rows_applied_total
-                    .with_guarded_label_values(&[table_name.as_str(), "sdk_applied_approx"])
-                    .inc_by(deleted);
+                    .with_guarded_label_values(&[table_name.as_str(), "sdk_applied_approx"]);
+                delete_rows_applied_total.inc_by(deleted);
             }
         }
     }

--- a/src/connector/src/source/iceberg/planner.rs
+++ b/src/connector/src/source/iceberg/planner.rs
@@ -104,37 +104,37 @@ impl IcebergScanMetricsLabels {
     }
 
     pub fn record_scan_error(&self, error_kind: &str) {
-        GLOBAL_ICEBERG_SCAN_METRICS
+        let scan_errors_total = GLOBAL_ICEBERG_SCAN_METRICS
             .iceberg_source_scan_errors_total
             .with_guarded_label_values(&[
                 self.source_id.as_str(),
                 self.source_name.as_str(),
                 self.table_name.as_str(),
                 error_kind,
-            ])
-            .inc();
+            ]);
+        scan_errors_total.inc();
     }
 
     pub fn record_snapshot_discovered(&self) {
-        GLOBAL_ICEBERG_SCAN_METRICS
+        let snapshots_discovered_total = GLOBAL_ICEBERG_SCAN_METRICS
             .iceberg_source_snapshots_discovered_total
             .with_guarded_label_values(&[
                 self.source_id.as_str(),
                 self.source_name.as_str(),
                 self.table_name.as_str(),
-            ])
-            .inc();
+            ]);
+        snapshots_discovered_total.inc();
     }
 
     pub fn record_snapshot_lag(&self, lag_secs: i64) {
-        GLOBAL_ICEBERG_SCAN_METRICS
+        let snapshot_lag_seconds = GLOBAL_ICEBERG_SCAN_METRICS
             .iceberg_source_snapshot_lag_seconds
             .with_guarded_label_values(&[
                 self.source_id.as_str(),
                 self.source_name.as_str(),
                 self.table_name.as_str(),
-            ])
-            .set(lag_secs);
+            ]);
+        snapshot_lag_seconds.set(lag_secs);
     }
 
     pub fn record_caught_up(&self) {
@@ -142,25 +142,25 @@ impl IcebergScanMetricsLabels {
     }
 
     fn record_list_duration(&self, duration: Duration) {
-        GLOBAL_ICEBERG_SCAN_METRICS
+        let list_duration_seconds = GLOBAL_ICEBERG_SCAN_METRICS
             .iceberg_source_list_duration_seconds
             .with_guarded_label_values(&[
                 self.source_id.as_str(),
                 self.source_name.as_str(),
                 self.table_name.as_str(),
-            ])
-            .observe(duration.as_secs_f64());
+            ]);
+        list_duration_seconds.observe(duration.as_secs_f64());
     }
 
     fn record_delete_files_per_data_file(&self, delete_file_count: usize) {
-        GLOBAL_ICEBERG_SCAN_METRICS
+        let delete_files_per_data_file = GLOBAL_ICEBERG_SCAN_METRICS
             .iceberg_source_delete_files_per_data_file
             .with_guarded_label_values(&[
                 self.source_id.as_str(),
                 self.source_name.as_str(),
                 self.table_name.as_str(),
-            ])
-            .observe(delete_file_count as f64);
+            ]);
+        delete_files_per_data_file.observe(delete_file_count as f64);
     }
 
     fn record_file_counts(&self, stats: &IcebergScanPlanStats) {
@@ -170,15 +170,15 @@ impl IcebergScanMetricsLabels {
             ("pos_delete", stats.pos_delete_count),
         ] {
             if count > 0 {
-                GLOBAL_ICEBERG_SCAN_METRICS
+                let files_discovered_total = GLOBAL_ICEBERG_SCAN_METRICS
                     .iceberg_source_files_discovered_total
                     .with_guarded_label_values(&[
                         self.source_id.as_str(),
                         self.source_name.as_str(),
                         self.table_name.as_str(),
                         file_type,
-                    ])
-                    .inc_by(count);
+                    ]);
+                files_discovered_total.inc_by(count);
             }
         }
     }

--- a/src/connector/src/source/kafka/stats.rs
+++ b/src/connector/src/source/kafka/stats.rs
@@ -20,6 +20,13 @@ use risingwave_common::{
     register_guarded_int_gauge_vec_with_registry, register_guarded_uint_gauge_vec_with_registry,
 };
 
+macro_rules! set_guarded_metric {
+    ($metric_vec:expr, $labels:expr, $value:expr $(,)?) => {{
+        let metric = $metric_vec.with_guarded_label_values($labels);
+        metric.set($value);
+    }};
+}
+
 #[derive(Debug, Clone)]
 pub struct RdKafkaStats {
     pub registry: Registry,
@@ -165,18 +172,11 @@ impl ConsumerGroupStats {
 
     pub fn report(&self, id: &str, client_id: &str, stats: &ConsumerGroup) {
         let state = stats.state.as_str();
-        self.state_age
-            .with_guarded_label_values(&[id, client_id, state])
-            .set(stats.stateage);
-        self.rebalance_age
-            .with_guarded_label_values(&[id, client_id, state])
-            .set(stats.rebalance_age);
-        self.rebalance_cnt
-            .with_guarded_label_values(&[id, client_id, state])
-            .set(stats.rebalance_cnt);
-        self.assignment_size
-            .with_guarded_label_values(&[id, client_id, state])
-            .set(stats.assignment_size as i64);
+        let labels = [id, client_id, state];
+        set_guarded_metric!(self.state_age, &labels, stats.stateage);
+        set_guarded_metric!(self.rebalance_age, &labels, stats.rebalance_age);
+        set_guarded_metric!(self.rebalance_cnt, &labels, stats.rebalance_cnt);
+        set_guarded_metric!(self.assignment_size, &labels, stats.assignment_size as i64,);
     }
 }
 
@@ -304,26 +304,18 @@ impl StatsWindow {
     pub fn report(&self, id: &str, client_id: &str, broker: &str, topic: &str, stats: &Window) {
         let labels = [id, client_id, broker, topic];
 
-        self.min.with_guarded_label_values(&labels).set(stats.min);
-        self.max.with_guarded_label_values(&labels).set(stats.max);
-        self.avg.with_guarded_label_values(&labels).set(stats.avg);
-        self.sum.with_guarded_label_values(&labels).set(stats.sum);
-        self.cnt.with_guarded_label_values(&labels).set(stats.cnt);
-        self.stddev
-            .with_guarded_label_values(&labels)
-            .set(stats.stddev);
-        self.hdr_size
-            .with_guarded_label_values(&labels)
-            .set(stats.hdrsize);
-        self.p50.with_guarded_label_values(&labels).set(stats.p50);
-        self.p75.with_guarded_label_values(&labels).set(stats.p75);
-        self.p90.with_guarded_label_values(&labels).set(stats.p90);
-        self.p99_99
-            .with_guarded_label_values(&labels)
-            .set(stats.p99_99);
-        self.out_of_range
-            .with_guarded_label_values(&labels)
-            .set(stats.outofrange);
+        set_guarded_metric!(self.min, &labels, stats.min);
+        set_guarded_metric!(self.max, &labels, stats.max);
+        set_guarded_metric!(self.avg, &labels, stats.avg);
+        set_guarded_metric!(self.sum, &labels, stats.sum);
+        set_guarded_metric!(self.cnt, &labels, stats.cnt);
+        set_guarded_metric!(self.stddev, &labels, stats.stddev);
+        set_guarded_metric!(self.hdr_size, &labels, stats.hdrsize);
+        set_guarded_metric!(self.p50, &labels, stats.p50);
+        set_guarded_metric!(self.p75, &labels, stats.p75);
+        set_guarded_metric!(self.p90, &labels, stats.p90);
+        set_guarded_metric!(self.p99_99, &labels, stats.p99_99);
+        set_guarded_metric!(self.out_of_range, &labels, stats.outofrange);
     }
 }
 
@@ -355,9 +347,11 @@ impl TopicStats {
     }
 
     fn report_inner(&self, id: &str, client_id: &str, topic: &str, stats: &Topic) {
-        self.metadata_age
-            .with_guarded_label_values(&[id, client_id, topic])
-            .set(stats.metadata_age);
+        set_guarded_metric!(
+            self.metadata_age,
+            &[id, client_id, topic],
+            stats.metadata_age
+        );
         self.batch_size
             .report(id, client_id, "", topic, &stats.batchsize);
         self.batch_cnt
@@ -623,82 +617,32 @@ impl PartitionStats {
     fn report_inner(&self, id: &str, client_id: &str, topic: &str, stats: &Partition) {
         let labels = [id, client_id, topic, &stats.partition.to_string()];
 
-        self.msgq_cnt
-            .with_guarded_label_values(&labels)
-            .set(stats.msgq_cnt);
-        self.msgq_bytes
-            .with_guarded_label_values(&labels)
-            .set(stats.msgq_bytes);
-        self.xmit_msgq_cnt
-            .with_guarded_label_values(&labels)
-            .set(stats.xmit_msgq_cnt);
-        self.xmit_msgq_bytes
-            .with_guarded_label_values(&labels)
-            .set(stats.xmit_msgq_bytes);
-        self.fetchq_cnt
-            .with_guarded_label_values(&labels)
-            .set(stats.fetchq_cnt);
-        self.fetchq_size
-            .with_guarded_label_values(&labels)
-            .set(stats.fetchq_size);
-        self.query_offset
-            .with_guarded_label_values(&labels)
-            .set(stats.query_offset);
-        self.next_offset
-            .with_guarded_label_values(&labels)
-            .set(stats.next_offset);
-        self.app_offset
-            .with_guarded_label_values(&labels)
-            .set(stats.app_offset);
-        self.stored_offset
-            .with_guarded_label_values(&labels)
-            .set(stats.stored_offset);
-        self.committed_offset
-            .with_guarded_label_values(&labels)
-            .set(stats.committed_offset);
-        self.eof_offset
-            .with_guarded_label_values(&labels)
-            .set(stats.eof_offset);
-        self.lo_offset
-            .with_guarded_label_values(&labels)
-            .set(stats.lo_offset);
-        self.hi_offset
-            .with_guarded_label_values(&labels)
-            .set(stats.hi_offset);
-        self.consumer_lag
-            .with_guarded_label_values(&labels)
-            .set(stats.consumer_lag);
-        self.consumer_lag_store
-            .with_guarded_label_values(&labels)
-            .set(stats.consumer_lag_stored);
-        self.txmsgs
-            .with_guarded_label_values(&labels)
-            .set(stats.txmsgs);
-        self.txbytes
-            .with_guarded_label_values(&labels)
-            .set(stats.txbytes);
-        self.rxmsgs
-            .with_guarded_label_values(&labels)
-            .set(stats.rxmsgs);
-        self.rxbytes
-            .with_guarded_label_values(&labels)
-            .set(stats.rxbytes);
-        self.msgs.with_guarded_label_values(&labels).set(stats.msgs);
-        self.rx_ver_drops
-            .with_guarded_label_values(&labels)
-            .set(stats.rx_ver_drops);
-        self.msgs_inflight
-            .with_guarded_label_values(&labels)
-            .set(stats.msgs_inflight);
-        self.next_ack_seq
-            .with_guarded_label_values(&labels)
-            .set(stats.next_ack_seq);
-        self.next_err_seq
-            .with_guarded_label_values(&labels)
-            .set(stats.next_err_seq);
-        self.acked_msgid
-            .with_guarded_label_values(&labels)
-            .set(stats.acked_msgid);
+        set_guarded_metric!(self.msgq_cnt, &labels, stats.msgq_cnt);
+        set_guarded_metric!(self.msgq_bytes, &labels, stats.msgq_bytes);
+        set_guarded_metric!(self.xmit_msgq_cnt, &labels, stats.xmit_msgq_cnt);
+        set_guarded_metric!(self.xmit_msgq_bytes, &labels, stats.xmit_msgq_bytes);
+        set_guarded_metric!(self.fetchq_cnt, &labels, stats.fetchq_cnt);
+        set_guarded_metric!(self.fetchq_size, &labels, stats.fetchq_size);
+        set_guarded_metric!(self.query_offset, &labels, stats.query_offset);
+        set_guarded_metric!(self.next_offset, &labels, stats.next_offset);
+        set_guarded_metric!(self.app_offset, &labels, stats.app_offset);
+        set_guarded_metric!(self.stored_offset, &labels, stats.stored_offset);
+        set_guarded_metric!(self.committed_offset, &labels, stats.committed_offset);
+        set_guarded_metric!(self.eof_offset, &labels, stats.eof_offset);
+        set_guarded_metric!(self.lo_offset, &labels, stats.lo_offset);
+        set_guarded_metric!(self.hi_offset, &labels, stats.hi_offset);
+        set_guarded_metric!(self.consumer_lag, &labels, stats.consumer_lag);
+        set_guarded_metric!(self.consumer_lag_store, &labels, stats.consumer_lag_stored);
+        set_guarded_metric!(self.txmsgs, &labels, stats.txmsgs);
+        set_guarded_metric!(self.txbytes, &labels, stats.txbytes);
+        set_guarded_metric!(self.rxmsgs, &labels, stats.rxmsgs);
+        set_guarded_metric!(self.rxbytes, &labels, stats.rxbytes);
+        set_guarded_metric!(self.msgs, &labels, stats.msgs);
+        set_guarded_metric!(self.rx_ver_drops, &labels, stats.rx_ver_drops);
+        set_guarded_metric!(self.msgs_inflight, &labels, stats.msgs_inflight);
+        set_guarded_metric!(self.next_ack_seq, &labels, stats.next_ack_seq);
+        set_guarded_metric!(self.next_err_seq, &labels, stats.next_err_seq);
+        set_guarded_metric!(self.acked_msgid, &labels, stats.acked_msgid);
     }
 }
 
@@ -864,60 +808,25 @@ impl RdKafkaStats {
 
     pub fn report(&self, id: &str, stats: &Statistics) {
         let client_id = stats.name.as_str();
-        self.ts
-            .with_guarded_label_values(&[id, client_id])
-            .set(stats.ts);
-        self.time
-            .with_guarded_label_values(&[id, client_id])
-            .set(stats.time);
-        self.age
-            .with_guarded_label_values(&[id, client_id])
-            .set(stats.age);
-        self.replyq
-            .with_guarded_label_values(&[id, client_id])
-            .set(stats.replyq);
-        self.msg_cnt
-            .with_guarded_label_values(&[id, client_id])
-            .set(stats.msg_cnt);
-        self.msg_size
-            .with_guarded_label_values(&[id, client_id])
-            .set(stats.msg_size);
-        self.msg_max
-            .with_guarded_label_values(&[id, client_id])
-            .set(stats.msg_max);
-        self.msg_size_max
-            .with_guarded_label_values(&[id, client_id])
-            .set(stats.msg_size_max);
-        self.tx
-            .with_guarded_label_values(&[id, client_id])
-            .set(stats.tx);
-        self.tx_bytes
-            .with_guarded_label_values(&[id, client_id])
-            .set(stats.tx_bytes);
-        self.rx
-            .with_guarded_label_values(&[id, client_id])
-            .set(stats.rx);
-        self.rx_bytes
-            .with_guarded_label_values(&[id, client_id])
-            .set(stats.rx_bytes);
-        self.tx_msgs
-            .with_guarded_label_values(&[id, client_id])
-            .set(stats.txmsgs);
-        self.tx_msgs_bytes
-            .with_guarded_label_values(&[id, client_id])
-            .set(stats.txmsg_bytes);
-        self.rx_msgs
-            .with_guarded_label_values(&[id, client_id])
-            .set(stats.rxmsgs);
-        self.rx_msgs_bytes
-            .with_guarded_label_values(&[id, client_id])
-            .set(stats.rxmsg_bytes);
-        self.simple_cnt
-            .with_guarded_label_values(&[id, client_id])
-            .set(stats.simple_cnt);
-        self.metadata_cache_cnt
-            .with_guarded_label_values(&[id, client_id])
-            .set(stats.metadata_cache_cnt);
+        let labels = [id, client_id];
+        set_guarded_metric!(self.ts, &labels, stats.ts);
+        set_guarded_metric!(self.time, &labels, stats.time);
+        set_guarded_metric!(self.age, &labels, stats.age);
+        set_guarded_metric!(self.replyq, &labels, stats.replyq);
+        set_guarded_metric!(self.msg_cnt, &labels, stats.msg_cnt);
+        set_guarded_metric!(self.msg_size, &labels, stats.msg_size);
+        set_guarded_metric!(self.msg_max, &labels, stats.msg_max);
+        set_guarded_metric!(self.msg_size_max, &labels, stats.msg_size_max);
+        set_guarded_metric!(self.tx, &labels, stats.tx);
+        set_guarded_metric!(self.tx_bytes, &labels, stats.tx_bytes);
+        set_guarded_metric!(self.rx, &labels, stats.rx);
+        set_guarded_metric!(self.rx_bytes, &labels, stats.rx_bytes);
+        set_guarded_metric!(self.tx_msgs, &labels, stats.txmsgs);
+        set_guarded_metric!(self.tx_msgs_bytes, &labels, stats.txmsg_bytes);
+        set_guarded_metric!(self.rx_msgs, &labels, stats.rxmsgs);
+        set_guarded_metric!(self.rx_msgs_bytes, &labels, stats.rxmsg_bytes);
+        set_guarded_metric!(self.simple_cnt, &labels, stats.simple_cnt);
+        set_guarded_metric!(self.metadata_cache_cnt, &labels, stats.metadata_cache_cnt);
 
         self.broker_stats.report(id, client_id, stats);
         self.topic_stats.report(id, client_id, stats);
@@ -1138,76 +1047,40 @@ impl BrokerStats {
         let state = stats.state.as_str();
         let labels = [id, client_id, broker, state];
 
-        self.state_age
-            .with_guarded_label_values(&labels)
-            .set(stats.stateage);
-        self.outbuf_cnt
-            .with_guarded_label_values(&labels)
-            .set(stats.outbuf_cnt);
-        self.outbuf_msg_cnt
-            .with_guarded_label_values(&labels)
-            .set(stats.outbuf_msg_cnt);
-        self.waitresp_cnt
-            .with_guarded_label_values(&labels)
-            .set(stats.waitresp_cnt);
-        self.waitresp_msg_cnt
-            .with_guarded_label_values(&labels)
-            .set(stats.waitresp_msg_cnt);
-        self.tx.with_guarded_label_values(&labels).set(stats.tx);
-        self.tx_bytes
-            .with_guarded_label_values(&labels)
-            .set(stats.txbytes);
-        self.tx_errs
-            .with_guarded_label_values(&labels)
-            .set(stats.txerrs);
-        self.tx_retries
-            .with_guarded_label_values(&labels)
-            .set(stats.txretries);
-        self.tx_idle
-            .with_guarded_label_values(&labels)
-            .set(stats.txidle);
-        self.req_timeouts
-            .with_guarded_label_values(&labels)
-            .set(stats.req_timeouts);
-        self.rx.with_guarded_label_values(&labels).set(stats.rx);
-        self.rx_bytes
-            .with_guarded_label_values(&labels)
-            .set(stats.rxbytes);
-        self.rx_errs
-            .with_guarded_label_values(&labels)
-            .set(stats.rxerrs);
-        self.rx_corriderrs
-            .with_guarded_label_values(&labels)
-            .set(stats.rxcorriderrs);
-        self.rx_partial
-            .with_guarded_label_values(&labels)
-            .set(stats.rxpartial);
-        self.rx_idle
-            .with_guarded_label_values(&labels)
-            .set(stats.rxidle);
+        set_guarded_metric!(self.state_age, &labels, stats.stateage);
+        set_guarded_metric!(self.outbuf_cnt, &labels, stats.outbuf_cnt);
+        set_guarded_metric!(self.outbuf_msg_cnt, &labels, stats.outbuf_msg_cnt);
+        set_guarded_metric!(self.waitresp_cnt, &labels, stats.waitresp_cnt);
+        set_guarded_metric!(self.waitresp_msg_cnt, &labels, stats.waitresp_msg_cnt);
+        set_guarded_metric!(self.tx, &labels, stats.tx);
+        set_guarded_metric!(self.tx_bytes, &labels, stats.txbytes);
+        set_guarded_metric!(self.tx_errs, &labels, stats.txerrs);
+        set_guarded_metric!(self.tx_retries, &labels, stats.txretries);
+        set_guarded_metric!(self.tx_idle, &labels, stats.txidle);
+        set_guarded_metric!(self.req_timeouts, &labels, stats.req_timeouts);
+        set_guarded_metric!(self.rx, &labels, stats.rx);
+        set_guarded_metric!(self.rx_bytes, &labels, stats.rxbytes);
+        set_guarded_metric!(self.rx_errs, &labels, stats.rxerrs);
+        set_guarded_metric!(self.rx_corriderrs, &labels, stats.rxcorriderrs);
+        set_guarded_metric!(self.rx_partial, &labels, stats.rxpartial);
+        set_guarded_metric!(self.rx_idle, &labels, stats.rxidle);
         for (req_type, req_cnt) in &stats.req {
-            self.req
-                .with_guarded_label_values(&[id, client_id, broker, state, req_type])
-                .set(*req_cnt);
+            set_guarded_metric!(
+                self.req,
+                &[id, client_id, broker, state, req_type],
+                *req_cnt
+            );
         }
-        self.zbuf_grow
-            .with_guarded_label_values(&labels)
-            .set(stats.zbuf_grow);
-        self.buf_grow
-            .with_guarded_label_values(&labels)
-            .set(stats.buf_grow);
+        set_guarded_metric!(self.zbuf_grow, &labels, stats.zbuf_grow);
+        set_guarded_metric!(self.buf_grow, &labels, stats.buf_grow);
         if let Some(wakeups) = stats.wakeups {
-            self.wakeups.with_guarded_label_values(&labels).set(wakeups);
+            set_guarded_metric!(self.wakeups, &labels, wakeups);
         }
         if let Some(connects) = stats.connects {
-            self.connects
-                .with_guarded_label_values(&labels)
-                .set(connects);
+            set_guarded_metric!(self.connects, &labels, connects);
         }
         if let Some(disconnects) = stats.disconnects {
-            self.disconnects
-                .with_guarded_label_values(&labels)
-                .set(disconnects);
+            set_guarded_metric!(self.disconnects, &labels, disconnects);
         }
         if let Some(int_latency) = &stats.int_latency {
             self.int_latency

--- a/src/connector/src/source/kinesis/source/reader.rs
+++ b/src/connector/src/source/kinesis/source/reader.rs
@@ -23,6 +23,7 @@ use aws_sdk_kinesis::primitives::DateTime;
 use aws_sdk_kinesis::types::ShardIteratorType;
 use futures_async_stream::try_stream;
 use risingwave_common::bail;
+use risingwave_common::metrics::{LabelGuardedHistogram, LabelGuardedIntCounter};
 use thiserror_ext::AsReport;
 
 use crate::error::ConnectorResult as Result;
@@ -53,7 +54,11 @@ pub struct KinesisSplitReader {
     eof_retry_interval: Duration,
     error_retry_interval: Duration,
 
-    metrics_labels: [String; 4],
+    kinesis_throughput_exceeded_count: LabelGuardedIntCounter,
+    kinesis_timeout_count: LabelGuardedIntCounter,
+    kinesis_rebuild_shard_iter_count: LabelGuardedIntCounter,
+    kinesis_early_terminate_shard_count: LabelGuardedIntCounter,
+    kinesis_lag_latency_ms: LabelGuardedHistogram,
 }
 
 #[async_trait]
@@ -112,6 +117,26 @@ impl SplitReader for KinesisSplitReader {
             source_ctx.fragment_id.to_string(),
             split.shard_id.to_string(),
         ];
+        let kinesis_throughput_exceeded_count = source_ctx
+            .metrics
+            .kinesis_throughput_exceeded_count
+            .with_guarded_label_values(&metrics_labels);
+        let kinesis_timeout_count = source_ctx
+            .metrics
+            .kinesis_timeout_count
+            .with_guarded_label_values(&metrics_labels);
+        let kinesis_rebuild_shard_iter_count = source_ctx
+            .metrics
+            .kinesis_rebuild_shard_iter_count
+            .with_guarded_label_values(&metrics_labels);
+        let kinesis_early_terminate_shard_count = source_ctx
+            .metrics
+            .kinesis_early_terminate_shard_count
+            .with_guarded_label_values(&metrics_labels);
+        let kinesis_lag_latency_ms = source_ctx
+            .metrics
+            .kinesis_lag_latency_ms
+            .with_guarded_label_values(&metrics_labels);
 
         let split_id = split.id();
         Ok(Self {
@@ -131,7 +156,11 @@ impl SplitReader for KinesisSplitReader {
             error_retry_interval: Duration::from_millis(
                 properties.reader_config.error_retry_interval_ms,
             ),
-            metrics_labels,
+            kinesis_throughput_exceeded_count,
+            kinesis_timeout_count,
+            kinesis_rebuild_shard_iter_count,
+            kinesis_early_terminate_shard_count,
+            kinesis_lag_latency_ms,
         })
     }
 
@@ -160,10 +189,7 @@ impl KinesisSplitReader {
             }
             match self.get_records().await {
                 Ok(resp) => {
-                    self.source_ctx
-                        .metrics
-                        .kinesis_lag_latency_ms
-                        .with_guarded_label_values(&self.metrics_labels)
+                    self.kinesis_lag_latency_ms
                         .observe(resp.millis_behind_latest().unwrap_or(0) as f64);
 
                     self.shard_iter = resp.next_shard_iterator().map(String::from);
@@ -197,11 +223,7 @@ impl KinesisSplitReader {
                             "shard {:?} reaches the end and is inactive, stop reading",
                             self.shard_id
                         );
-                        self.source_ctx
-                            .metrics
-                            .kinesis_early_terminate_shard_count
-                            .with_guarded_label_values(&self.metrics_labels)
-                            .inc();
+                        self.kinesis_early_terminate_shard_count.inc();
 
                         break;
                     }
@@ -237,11 +259,7 @@ impl KinesisSplitReader {
                 Err(SdkError::ServiceError(e))
                     if e.err().is_provisioned_throughput_exceeded_exception() =>
                 {
-                    self.source_ctx
-                        .metrics
-                        .kinesis_throughput_exceeded_count
-                        .with_guarded_label_values(&self.metrics_labels)
-                        .inc();
+                    self.kinesis_throughput_exceeded_count.inc();
 
                     if let Some(start_time) = provisioned_throughput_exceeded_start_time
                         && start_time.elapsed() > Duration::from_secs(5)
@@ -281,11 +299,7 @@ impl KinesisSplitReader {
                     continue;
                 }
                 Err(SdkError::TimeoutError(_)) => {
-                    self.source_ctx
-                        .metrics
-                        .kinesis_timeout_count
-                        .with_guarded_label_values(&self.metrics_labels)
-                        .inc();
+                    self.kinesis_timeout_count.inc();
 
                     // according to sdk doc:
                     // The request failed due to a timeout. The request MAY have been sent and received.
@@ -379,11 +393,7 @@ impl KinesisSplitReader {
             .await?,
         );
 
-        self.source_ctx
-            .metrics
-            .kinesis_rebuild_shard_iter_count
-            .with_guarded_label_values(&self.metrics_labels)
-            .inc();
+        self.kinesis_rebuild_shard_iter_count.inc();
 
         tracing::info!(
             "resetting kinesis to: stream {:?} shard {:?} starting from {:?}",

--- a/src/meta/service/src/ddl_service.rs
+++ b/src/meta/service/src/ddl_service.rs
@@ -1467,11 +1467,11 @@ impl DdlService for DdlServiceImpl {
                     continue;
                 }
 
-                let latency_timer = self
+                let auto_schema_change_latency = self
                     .meta_metrics
                     .auto_schema_change_latency
-                    .with_guarded_label_values(&[&table.id.to_string(), &table.name])
-                    .start_timer();
+                    .with_guarded_label_values(&[&table.id.to_string(), &table.name]);
+                let latency_timer = auto_schema_change_latency.start_timer();
                 // send a request to the frontend to get the ReplaceJobPlan
                 // will retry with exponential backoff if the request fails
                 let resp = client
@@ -1509,13 +1509,14 @@ impl DdlService for DdlServiceImpl {
                                         cdc_table_id = table.cdc_table_id,
                                         "Table replaced success");
 
-                                    self.meta_metrics
+                                    let auto_schema_change_success_cnt = self
+                                        .meta_metrics
                                         .auto_schema_change_success_cnt
                                         .with_guarded_label_values(&[
                                             &table.id.to_string(),
                                             &table.name,
-                                        ])
-                                        .inc();
+                                        ]);
+                                    auto_schema_change_success_cnt.inc();
                                     latency_timer.observe_duration();
                                 }
                                 Err(e) => {
@@ -1926,10 +1927,10 @@ fn add_auto_schema_change_fail_event_log(
     event_log_manager: &EventLogManagerRef,
     fail_info: String,
 ) {
-    meta_metrics
+    let auto_schema_change_failure_cnt = meta_metrics
         .auto_schema_change_failure_cnt
-        .with_guarded_label_values(&[&table_id.to_string(), &table_name])
-        .inc();
+        .with_guarded_label_values(&[&table_id.to_string(), &table_name]);
+    auto_schema_change_failure_cnt.inc();
     let event = event_log::EventAutoSchemaChangeFail {
         table_id,
         table_name,

--- a/src/meta/src/stream/refresh_manager.rs
+++ b/src/meta/src/stream/refresh_manager.rs
@@ -196,10 +196,10 @@ impl GlobalRefreshManager {
         job: &refresh_job::Model,
     ) -> MetaResult<()> {
         if job.current_status != RefreshState::Idle {
-            GLOBAL_META_METRICS
+            let refresh_cron_job_miss_cnt = GLOBAL_META_METRICS
                 .refresh_cron_job_miss_cnt
-                .with_guarded_label_values(&[&job.table_id.to_string()])
-                .inc();
+                .with_guarded_label_values(&[&job.table_id.to_string()]);
+            refresh_cron_job_miss_cnt.inc();
             tracing::warn!(table_id = %job.table_id, "skip scheduled refresh: current status is not idle: {:?}", job.current_status);
             return Ok(());
         }
@@ -258,10 +258,10 @@ impl GlobalRefreshManager {
 
         // Increment cron job trigger counter
         let table_id_str = job.table_id.to_string();
-        GLOBAL_META_METRICS
+        let refresh_cron_job_trigger_cnt = GLOBAL_META_METRICS
             .refresh_cron_job_trigger_cnt
-            .with_guarded_label_values(&[&table_id_str])
-            .inc();
+            .with_guarded_label_values(&[&table_id_str]);
+        refresh_cron_job_trigger_cnt.inc();
         tracing::info!(table_id = %job.table_id, "trigger scheduled refresh at interval {:?}", interval);
 
         self.ensure_refreshable(job.table_id, associated_source_id)
@@ -426,14 +426,15 @@ impl GlobalRefreshManager {
         let mut guard = self.progress_trackers.lock();
         if let Some(entry) = guard.inner.remove(&table_id) {
             let status = status.to_owned();
-            GLOBAL_META_METRICS
+            let table_id = table_id.to_string();
+            let refresh_job_duration = GLOBAL_META_METRICS
                 .refresh_job_duration
-                .with_guarded_label_values(&[&table_id.to_string(), &status])
-                .set(entry.start_time.elapsed().as_secs());
-            GLOBAL_META_METRICS
+                .with_guarded_label_values(&[&table_id, &status]);
+            refresh_job_duration.set(entry.start_time.elapsed().as_secs());
+            let refresh_job_finish_cnt = GLOBAL_META_METRICS
                 .refresh_job_finish_cnt
-                .with_guarded_label_values(&[&table_id.to_string(), &status])
-                .inc();
+                .with_guarded_label_values(&[&table_id, &status]);
+            refresh_job_finish_cnt.inc();
         }
         guard.table_id_by_database_id.values_mut().for_each(|set| {
             set.remove(&table_id);

--- a/src/stream/src/executor/source/batch_source/batch_iceberg_fetch.rs
+++ b/src/stream/src/executor/source/batch_source/batch_iceberg_fetch.rs
@@ -269,6 +269,17 @@ impl<S: StateStore> BatchIcebergFetchExecutor<S> {
             source_name_str.as_str(),
             iceberg_table_name.as_str(),
         ];
+        let inflight_file_count = iceberg_metrics
+            .iceberg_source_inflight_file_count
+            .with_guarded_label_values(&metrics_labels);
+        let scan_errors_total = iceberg_metrics
+            .iceberg_source_scan_errors_total
+            .with_guarded_label_values(&[
+                metrics_labels[0],
+                metrics_labels[1],
+                metrics_labels[2],
+                "fetch_error",
+            ]);
 
         // Initialize state and stream reader
         let mut state = FetchState::new();
@@ -291,15 +302,7 @@ impl<S: StateStore> BatchIcebergFetchExecutor<S> {
                         self.associated_table_id.to_string(),
                     ]);
 
-                    iceberg_metrics
-                        .iceberg_source_scan_errors_total
-                        .with_guarded_label_values(&[
-                            metrics_labels[0],
-                            metrics_labels[1],
-                            metrics_labels[2],
-                            "fetch_error",
-                        ])
-                        .inc();
+                    scan_errors_total.inc();
 
                     let in_flight_count = state.in_flight_files.len();
                     state.handle_error_recovery();
@@ -362,10 +365,7 @@ impl<S: StateStore> BatchIcebergFetchExecutor<S> {
                                 &self.streaming_config,
                             )?;
 
-                            iceberg_metrics
-                                .iceberg_source_inflight_file_count
-                                .with_guarded_label_values(&metrics_labels)
-                                .set(state.splits_on_fetch as i64);
+                            inflight_file_count.set(state.splits_on_fetch as i64);
                         }
                     }
 
@@ -382,10 +382,7 @@ impl<S: StateStore> BatchIcebergFetchExecutor<S> {
                 Ok(Either::Right(ChunksWithState { chunks, .. })) => {
                     state.mark_file_fetched();
 
-                    iceberg_metrics
-                        .iceberg_source_inflight_file_count
-                        .with_guarded_label_values(&metrics_labels)
-                        .set(state.splits_on_fetch as i64);
+                    inflight_file_count.set(state.splits_on_fetch as i64);
 
                     for chunk in &chunks {
                         let pruned = prune_additional_cols(

--- a/src/stream/src/executor/source/iceberg_fetch_executor.rs
+++ b/src/stream/src/executor/source/iceberg_fetch_executor.rs
@@ -329,6 +329,17 @@ impl<S: StateStore> IcebergFetchExecutor<S> {
             source_name_str.as_str(),
             iceberg_table_name.as_str(),
         ];
+        let inflight_file_count = iceberg_metrics
+            .iceberg_source_inflight_file_count
+            .with_guarded_label_values(&metrics_labels);
+        let scan_errors_total = iceberg_metrics
+            .iceberg_source_scan_errors_total
+            .with_guarded_label_values(&[
+                metrics_labels[0],
+                metrics_labels[1],
+                metrics_labels[2],
+                "fetch_error",
+            ]);
 
         let mut splits_on_fetch: usize = 0;
         let mut stream = StreamReaderWithPause::<true, ChunksWithState>::new(
@@ -354,29 +365,15 @@ impl<S: StateStore> IcebergFetchExecutor<S> {
             self.streaming_config.clone(),
         )
         .await?;
-        iceberg_metrics
-            .iceberg_source_inflight_file_count
-            .with_guarded_label_values(&metrics_labels)
-            .set(splits_on_fetch as i64);
+        inflight_file_count.set(splits_on_fetch as i64);
 
         while let Some(msg) = stream.next().await {
             match msg {
                 Err(e) => {
                     tracing::error!(error = %e.as_report(), "Fetch Error");
-                    iceberg_metrics
-                        .iceberg_source_scan_errors_total
-                        .with_guarded_label_values(&[
-                            metrics_labels[0],
-                            metrics_labels[1],
-                            metrics_labels[2],
-                            "fetch_error",
-                        ])
-                        .inc();
+                    scan_errors_total.inc();
                     splits_on_fetch = 0;
-                    iceberg_metrics
-                        .iceberg_source_inflight_file_count
-                        .with_guarded_label_values(&metrics_labels)
-                        .set(0);
+                    inflight_file_count.set(0);
                 }
                 Ok(msg) => {
                     match msg {
@@ -445,10 +442,7 @@ impl<S: StateStore> IcebergFetchExecutor<S> {
                                             self.streaming_config.clone(),
                                         )
                                         .await?;
-                                        iceberg_metrics
-                                            .iceberg_source_inflight_file_count
-                                            .with_guarded_label_values(&metrics_labels)
-                                            .set(splits_on_fetch as i64);
+                                        inflight_file_count.set(splits_on_fetch as i64);
                                     }
                                 }
                                 // Receiving file assignments from upstream list executor,
@@ -479,10 +473,7 @@ impl<S: StateStore> IcebergFetchExecutor<S> {
                             if true {
                                 splits_on_fetch = splits_on_fetch.saturating_sub(1);
                                 state_store_handler.delete(&data_file_path).await?;
-                                iceberg_metrics
-                                    .iceberg_source_inflight_file_count
-                                    .with_guarded_label_values(&metrics_labels)
-                                    .set(splits_on_fetch as i64);
+                                inflight_file_count.set(splits_on_fetch as i64);
                             }
 
                             for chunk in &chunks {

--- a/src/stream/src/executor/source/source_executor.rs
+++ b/src/stream/src/executor/source/source_executor.rs
@@ -459,37 +459,42 @@ impl<S: StateStore> SourceExecutor<S> {
                 match split_impl {
                     SplitImpl::PostgresCdc(pg_split) => {
                         if let Some(lsn_value) = pg_split.pg_lsn() {
-                            self.metrics
+                            let pg_cdc_state_table_lsn = self
+                                .metrics
                                 .pg_cdc_state_table_lsn
-                                .with_guarded_label_values(&[&source_id])
-                                .set(lsn_value as i64);
+                                .with_guarded_label_values(&[&source_id]);
+                            pg_cdc_state_table_lsn.set(lsn_value as i64);
                         }
                     }
                     SplitImpl::MysqlCdc(mysql_split) => {
                         if let Some((file_seq, position)) = mysql_split.mysql_binlog_offset() {
-                            self.metrics
+                            let mysql_cdc_state_binlog_file_seq = self
+                                .metrics
                                 .mysql_cdc_state_binlog_file_seq
-                                .with_guarded_label_values(&[&source_id])
-                                .set(file_seq as i64);
+                                .with_guarded_label_values(&[&source_id]);
+                            mysql_cdc_state_binlog_file_seq.set(file_seq as i64);
 
-                            self.metrics
+                            let mysql_cdc_state_binlog_position = self
+                                .metrics
                                 .mysql_cdc_state_binlog_position
-                                .with_guarded_label_values(&[&source_id])
-                                .set(position as i64);
+                                .with_guarded_label_values(&[&source_id]);
+                            mysql_cdc_state_binlog_position.set(position as i64);
                         }
                     }
                     SplitImpl::SqlServerCdc(sqlserver_split) => {
                         if let Some(lsn) = sqlserver_split.sql_server_change_lsn() {
-                            self.metrics
+                            let sqlserver_cdc_state_change_lsn = self
+                                .metrics
                                 .sqlserver_cdc_state_change_lsn
-                                .with_guarded_label_values(&[&source_id])
-                                .set(lsn_u128_to_i64(lsn));
+                                .with_guarded_label_values(&[&source_id]);
+                            sqlserver_cdc_state_change_lsn.set(lsn_u128_to_i64(lsn));
                         }
                         if let Some(lsn) = sqlserver_split.sql_server_commit_lsn() {
-                            self.metrics
+                            let sqlserver_cdc_state_commit_lsn = self
+                                .metrics
                                 .sqlserver_cdc_state_commit_lsn
-                                .with_guarded_label_values(&[&source_id])
-                                .set(lsn_u128_to_i64(lsn));
+                                .with_guarded_label_values(&[&source_id]);
+                            sqlserver_cdc_state_commit_lsn.set(lsn_u128_to_i64(lsn));
                         }
                     }
                     _ => {}
@@ -1234,17 +1239,22 @@ impl<S: StateStore> WaitCheckpointWorker<S> {
                                     if let Some(lsn_value) =
                                         extract_postgres_lsn_from_offset_str(offset)
                                     {
-                                        self.metrics
+                                        let source_id = source_id.to_string();
+                                        let pg_cdc_jni_commit_offset_lsn = self
+                                            .metrics
                                             .pg_cdc_jni_commit_offset_lsn
-                                            .with_guarded_label_values(&[&source_id.to_string()])
-                                            .set(lsn_value as i64);
+                                            .with_guarded_label_values(&[&source_id]);
+                                        pg_cdc_jni_commit_offset_lsn.set(lsn_value as i64);
                                     }
                                     if let Some(lsn_value) =
                                         extract_sql_server_commit_lsn_from_offset_str(offset)
                                     {
-                                        self.metrics
+                                        let source_id = source_id.to_string();
+                                        let sqlserver_cdc_jni_commit_offset_lsn = self
+                                            .metrics
                                             .sqlserver_cdc_jni_commit_offset_lsn
-                                            .with_guarded_label_values(&[&source_id.to_string()])
+                                            .with_guarded_label_values(&[&source_id]);
+                                        sqlserver_cdc_jni_commit_offset_lsn
                                             .set(lsn_u128_to_i64(lsn_value));
                                     }
                                 },


### PR DESCRIPTION
## What

- Retain values returned by `with_guarded_label_values` in local variables or owning structs at the affected metric update sites.
- Fix the `rw::temporary_guarded_metric` hits from https://github.com/risingwavelabs/risingwave/pull/26391#issuecomment-5054523148 without adding a shared cache or mutex.
- Apply the same local-guard pattern to auto-schema-change metrics in `risingwave_meta_service`.

## Verification

- `cargo fmt --check && git diff --check`
- `CARGO_INCREMENTAL=0 cargo check -p risingwave_common_metrics -p risingwave_connector -p risingwave_stream -p risingwave_meta -p risingwave_meta_service --all-targets --all-features --locked`
- `CARGO_INCREMENTAL=0 DYLINT_RUSTFLAGS="-A warnings -D rw_all" cargo dylint --all --no-deps --keep-going -- -p risingwave_common_metrics -p risingwave_connector -p risingwave_stream -p risingwave_meta -p risingwave_meta_service --all-targets --all-features --locked`