### PR TITLE
fix(mysql-cdc): map MySQL SERIAL to decimal

### DIFF
--- a/src/connector/src/source/cdc/external/mysql.rs
+++ b/src/connector/src/source/cdc/external/mysql.rs
@@ -347,7 +347,7 @@ fn mysql_type_is_unsigned_bigint(col_type: &ColumnType) -> bool {
 
 pub fn mysql_type_to_rw_type(col_type: &ColumnType) -> ConnectorResult<DataType> {
     let dtype = match col_type {
-        ColumnType::Serial => DataType::Int32,
+        ColumnType::Serial => DataType::Decimal,
         ColumnType::Bit(attr) => {
             if let Some(1) = attr.maximum {
                 DataType::Boolean
@@ -842,7 +842,7 @@ mod tests {
     use risingwave_common::types::DataType;
     use sea_schema::mysql::def::ColumnType;
 
-    use super::{mysql_type_is_unsigned_bigint, type_name_to_mysql_type};
+    use super::{mysql_type_is_unsigned_bigint, mysql_type_to_rw_type, type_name_to_mysql_type};
     use crate::source::cdc::external::mysql::MySqlExternalTable;
     use crate::source::cdc::external::{
         CdcOffset, ExternalTableConfig, ExternalTableReader, MySqlExternalTableReader, MySqlOffset,
@@ -931,6 +931,12 @@ mod tests {
     fn test_mysql_serial_maps_as_unsigned_bigint() {
         let col_type = parse_mysql_type_name("SERIAL");
         assert!(mysql_type_is_unsigned_bigint(&col_type));
+
+        let serial_type = mysql_type_to_rw_type(&col_type).unwrap();
+        let unsigned_bigint_type =
+            mysql_type_to_rw_type(&parse_mysql_type_name("BIGINT UNSIGNED")).unwrap();
+        assert_eq!(serial_type, DataType::Decimal);
+        assert_eq!(serial_type, unsigned_bigint_type);
     }
 
     #[ignore]


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

MySQL defines `SERIAL` as an alias for `BIGINT UNSIGNED NOT NULL AUTO_INCREMENT UNIQUE`, but CDC schema inference mapped it to `Int32`. That type cannot represent the full MySQL range and disagrees with the existing `BIGINT UNSIGNED` mapping.

Map `ColumnType::Serial` to `DataType::Decimal`, the same type used for `BIGINT UNSIGNED`. The existing MySQL type test now checks the concrete RisingWave type and verifies that both MySQL declarations map identically.

Closes #26381

## Checklist

- [x] I have written necessary rustdoc comments.
- [x] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->

## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

MySQL CDC now infers `SERIAL` columns as `DECIMAL`, matching `BIGINT UNSIGNED` and avoiding a narrower `INTEGER` schema.

</details>

## Verification

- `CARGO_PROFILE_DEV_DEBUG=0 CARGO_PROFILE_TEST_DEBUG=0 CARGO_INCREMENTAL=0 CARGO_BUILD_JOBS=2 cargo test -p risingwave_connector --lib source::cdc::external::mysql::tests`
- `cargo fmt --all -- --check`
- `git diff --check`
