### PR TITLE
fix(stream): rewind log reader on no-op sink config update

### DIFF
--- a/src/stream/src/executor/sink.rs
+++ b/src/stream/src/executor/sink.rs
@@ -834,23 +834,26 @@ impl<F: LogStoreFactory> SinkExecutor<F> {
                             log_reader.init().await?;
                         },
                         RebuildSinkMessage::UpdateConfig(config) => {
-                            if !sink_config_has_changes(&sink_param.properties, &config) {
-                                info!(
-                                    executor_id = %sink_writer_param.executor_id,
-                                    sink_id = %sink_param.sink_id,
-                                    "skip alter sink config because properties are unchanged"
-                                );
-                                Ok(())
-                            } else if F::ALLOW_REWIND {
+                            let config_has_changes =
+                                sink_config_has_changes(&sink_param.properties, &config);
+                            if F::ALLOW_REWIND {
                                 match log_reader.rewind().await {
                                     Ok(()) => {
-                                        sink_param.properties.extend(config.into_iter());
-                                        sink = TryFrom::try_from(sink_param.clone()).map_err(|e| StreamExecutorError::from((e, sink_param.sink_id)))?;
-                                        info!(
-                                            executor_id = %sink_writer_param.executor_id,
-                                            sink_id = %sink_param.sink_id,
-                                            "alter sink config successfully with rewind"
-                                        );
+                                        if config_has_changes {
+                                            sink_param.properties.extend(config.into_iter());
+                                            sink = TryFrom::try_from(sink_param.clone()).map_err(|e| StreamExecutorError::from((e, sink_param.sink_id)))?;
+                                            info!(
+                                                executor_id = %sink_writer_param.executor_id,
+                                                sink_id = %sink_param.sink_id,
+                                                "alter sink config successfully with rewind"
+                                            );
+                                        } else {
+                                            info!(
+                                                executor_id = %sink_writer_param.executor_id,
+                                                sink_id = %sink_param.sink_id,
+                                                "skip alter sink config because properties are unchanged"
+                                            );
+                                        }
                                         Ok(())
                                     }
                                     Err(rewind_err) => {
@@ -858,9 +861,16 @@ impl<F: LogStoreFactory> SinkExecutor<F> {
                                             error = %rewind_err.as_report(),
                                             "fail to rewind log reader for alter sink config "
                                         );
-                                        Err(anyhow!("fail to rewind log after alter table").into())
+                                        Err(anyhow!("fail to rewind log reader after alter sink config notification").into())
                                     }
                                 }
+                            } else if !config_has_changes {
+                                info!(
+                                    executor_id = %sink_writer_param.executor_id,
+                                    sink_id = %sink_param.sink_id,
+                                    "skip alter sink config because properties are unchanged"
+                                );
+                                Ok(())
                             } else {
                                 sink_param.properties.extend(config.into_iter());
                                 sink = TryFrom::try_from(sink_param.clone()).map_err(|e| StreamExecutorError::from((e, sink_param.sink_id)))?;
@@ -897,13 +907,97 @@ impl<F: LogStoreFactory> Execute for SinkExecutor<F> {
 
 #[cfg(test)]
 mod test {
+    use std::future::pending;
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::time::Duration;
+
     use risingwave_common::catalog::{ColumnDesc, ColumnId};
     use risingwave_common::util::epoch::test_epoch;
     use risingwave_connector::sink::build_sink;
+    use risingwave_connector::sink::log_store::{LogStoreReadItem, LogStoreResult, TruncateOffset};
+    use risingwave_connector::sink::trivial::BlackHoleSink;
+    use tokio::sync::Notify;
 
     use super::*;
-    use crate::common::log_store_impl::in_mem::BoundedInMemLogStoreFactory;
+    use crate::common::log_store_impl::in_mem::{
+        BoundedInMemLogStoreFactory, BoundedInMemLogStoreWriter,
+    };
     use crate::executor::test_utils::*;
+
+    #[derive(Default)]
+    struct RewindRequiredLogReaderState {
+        start_count: AtomicUsize,
+        rewind_count: AtomicUsize,
+        started: Notify,
+    }
+
+    impl RewindRequiredLogReaderState {
+        async fn wait_for_start_count(&self, expected: usize) {
+            tokio::time::timeout(Duration::from_secs(5), async {
+                loop {
+                    let started = self.started.notified();
+                    if self.start_count.load(Ordering::SeqCst) >= expected {
+                        break;
+                    }
+                    started.await;
+                }
+            })
+            .await
+            .unwrap_or_else(|_| panic!("log reader was not started {expected} times"));
+        }
+    }
+
+    struct RewindRequiredLogReader {
+        is_reset: bool,
+        state: Arc<RewindRequiredLogReaderState>,
+    }
+
+    impl LogReader for RewindRequiredLogReader {
+        async fn init(&mut self) -> LogStoreResult<()> {
+            self.is_reset = true;
+            Ok(())
+        }
+
+        async fn start_from(&mut self, _start_offset: Option<u64>) -> LogStoreResult<()> {
+            assert!(
+                self.is_reset,
+                "log reader must be rewound before restarting"
+            );
+            self.is_reset = false;
+            self.state.start_count.fetch_add(1, Ordering::SeqCst);
+            self.state.started.notify_waiters();
+            Ok(())
+        }
+
+        async fn next_item(&mut self) -> LogStoreResult<(u64, LogStoreReadItem)> {
+            pending().await
+        }
+
+        fn truncate(&mut self, _offset: TruncateOffset) -> LogStoreResult<()> {
+            Ok(())
+        }
+
+        async fn rewind(&mut self) -> LogStoreResult<()> {
+            self.is_reset = true;
+            self.state.rewind_count.fetch_add(1, Ordering::SeqCst);
+            Ok(())
+        }
+    }
+
+    struct RewindableTestLogStoreFactory;
+
+    impl LogStoreFactory for RewindableTestLogStoreFactory {
+        type Reader = RewindRequiredLogReader;
+        type Writer = BoundedInMemLogStoreWriter;
+
+        const ALLOW_REWIND: bool = true;
+        const REBUILD_SINK_ON_UPDATE_VNODE_BITMAP: bool = false;
+
+        async fn build(self) -> (Self::Reader, Self::Writer) {
+            unreachable!()
+        }
+    }
 
     #[test]
     fn test_sink_config_has_changes() {
@@ -924,6 +1018,67 @@ mod test {
             &current,
             &HashMap::from([("force_append_only".to_owned(), "true".to_owned())])
         ));
+    }
+
+    #[tokio::test]
+    async fn test_no_op_sink_config_update_rewinds_log_reader() {
+        let properties = BTreeMap::from([
+            ("connector".to_owned(), "blackhole".to_owned()),
+            ("commit_checkpoint_interval".to_owned(), "1".to_owned()),
+        ]);
+        let sink_param = SinkParam {
+            sink_id: 0.into(),
+            sink_name: "test".into(),
+            properties,
+            columns: vec![],
+            downstream_pk: None,
+            sink_type: SinkType::AppendOnly,
+            ignore_delete: false,
+            format_desc: None,
+            db_name: "test".into(),
+            sink_from_name: "test".into(),
+        };
+        let sink = BlackHoleSink::try_from(sink_param.clone()).unwrap();
+        let state = Arc::new(RewindRequiredLogReaderState::default());
+        let log_reader = RewindRequiredLogReader {
+            is_reset: false,
+            state: state.clone(),
+        };
+        let (rate_limit_tx, rate_limit_rx) = unbounded_channel();
+        let (rebuild_sink_tx, rebuild_sink_rx) = unbounded_channel();
+
+        let consume_log = SinkExecutor::<RewindableTestLogStoreFactory>::execute_consume_log(
+            sink,
+            log_reader,
+            vec![],
+            sink_param,
+            SinkWriterParam::for_test(),
+            None,
+            ActorContext::for_test(0),
+            rate_limit_rx,
+            rebuild_sink_rx,
+        );
+        tokio::pin!(consume_log);
+
+        tokio::select! {
+            result = &mut consume_log => panic!("log consumer exited unexpectedly: {result:?}"),
+            () = state.wait_for_start_count(1) => {},
+        }
+
+        rebuild_sink_tx
+            .send(RebuildSinkMessage::UpdateConfig(HashMap::from([(
+                "commit_checkpoint_interval".to_owned(),
+                "1".to_owned(),
+            )])))
+            .unwrap();
+
+        tokio::select! {
+            result = &mut consume_log => panic!("log consumer exited unexpectedly: {result:?}"),
+            () = state.wait_for_start_count(2) => {},
+        }
+
+        assert_eq!(state.rewind_count.load(Ordering::SeqCst), 1);
+        drop(rate_limit_tx);
     }
 
     #[tokio::test]

--- a/src/stream/src/executor/sink.rs
+++ b/src/stream/src/executor/sink.rs
@@ -864,16 +864,17 @@ impl<F: LogStoreFactory> SinkExecutor<F> {
                                         Err(anyhow!("fail to rewind log reader after alter sink config notification").into())
                                     }
                                 }
-                            } else if !config_has_changes {
-                                info!(
-                                    executor_id = %sink_writer_param.executor_id,
-                                    sink_id = %sink_param.sink_id,
-                                    "skip alter sink config because properties are unchanged"
-                                );
-                                Ok(())
                             } else {
-                                sink_param.properties.extend(config.into_iter());
-                                sink = TryFrom::try_from(sink_param.clone()).map_err(|e| StreamExecutorError::from((e, sink_param.sink_id)))?;
+                                if config_has_changes {
+                                    sink_param.properties.extend(config.into_iter());
+                                    sink = TryFrom::try_from(sink_param.clone()).map_err(|e| StreamExecutorError::from((e, sink_param.sink_id)))?;
+                                } else {
+                                    info!(
+                                        executor_id = %sink_writer_param.executor_id,
+                                        sink_id = %sink_param.sink_id,
+                                        "skip rebuilding sink because properties are unchanged"
+                                    );
+                                }
                                 Err(anyhow!("This is not an actual error condition. The system is intentionally triggering recovery procedures to ensure ALTER SINK CONFIG are fully applied.").into())
                             }
                             .map_err(|e| StreamExecutorError::from((e, sink_param.sink_id)))?;
@@ -985,17 +986,35 @@ mod test {
         }
     }
 
-    struct RewindableTestLogStoreFactory;
+    struct TestLogStoreFactory<const CAN_REWIND: bool>;
 
-    impl LogStoreFactory for RewindableTestLogStoreFactory {
+    impl<const CAN_REWIND: bool> LogStoreFactory for TestLogStoreFactory<CAN_REWIND> {
         type Reader = RewindRequiredLogReader;
         type Writer = BoundedInMemLogStoreWriter;
 
-        const ALLOW_REWIND: bool = true;
+        const ALLOW_REWIND: bool = CAN_REWIND;
         const REBUILD_SINK_ON_UPDATE_VNODE_BITMAP: bool = false;
 
         async fn build(self) -> (Self::Reader, Self::Writer) {
             unreachable!()
+        }
+    }
+
+    fn sink_param_for_config_update_test() -> SinkParam {
+        SinkParam {
+            sink_id: 0.into(),
+            sink_name: "test".into(),
+            properties: BTreeMap::from([
+                ("connector".to_owned(), "blackhole".to_owned()),
+                ("commit_checkpoint_interval".to_owned(), "1".to_owned()),
+            ]),
+            columns: vec![],
+            downstream_pk: None,
+            sink_type: SinkType::AppendOnly,
+            ignore_delete: false,
+            format_desc: None,
+            db_name: "test".into(),
+            sink_from_name: "test".into(),
         }
     }
 
@@ -1022,22 +1041,7 @@ mod test {
 
     #[tokio::test]
     async fn test_no_op_sink_config_update_rewinds_log_reader() {
-        let properties = BTreeMap::from([
-            ("connector".to_owned(), "blackhole".to_owned()),
-            ("commit_checkpoint_interval".to_owned(), "1".to_owned()),
-        ]);
-        let sink_param = SinkParam {
-            sink_id: 0.into(),
-            sink_name: "test".into(),
-            properties,
-            columns: vec![],
-            downstream_pk: None,
-            sink_type: SinkType::AppendOnly,
-            ignore_delete: false,
-            format_desc: None,
-            db_name: "test".into(),
-            sink_from_name: "test".into(),
-        };
+        let sink_param = sink_param_for_config_update_test();
         let sink = BlackHoleSink::try_from(sink_param.clone()).unwrap();
         let state = Arc::new(RewindRequiredLogReaderState::default());
         let log_reader = RewindRequiredLogReader {
@@ -1047,7 +1051,7 @@ mod test {
         let (rate_limit_tx, rate_limit_rx) = unbounded_channel();
         let (rebuild_sink_tx, rebuild_sink_rx) = unbounded_channel();
 
-        let consume_log = SinkExecutor::<RewindableTestLogStoreFactory>::execute_consume_log(
+        let consume_log = SinkExecutor::<TestLogStoreFactory<true>>::execute_consume_log(
             sink,
             log_reader,
             vec![],
@@ -1078,6 +1082,52 @@ mod test {
         }
 
         assert_eq!(state.rewind_count.load(Ordering::SeqCst), 1);
+        drop(rate_limit_tx);
+    }
+
+    #[tokio::test]
+    async fn test_no_op_sink_config_update_triggers_recovery_without_rewind() {
+        let sink_param = sink_param_for_config_update_test();
+        let sink = BlackHoleSink::try_from(sink_param.clone()).unwrap();
+        let state = Arc::new(RewindRequiredLogReaderState::default());
+        let log_reader = RewindRequiredLogReader {
+            is_reset: false,
+            state: state.clone(),
+        };
+        let (rate_limit_tx, rate_limit_rx) = unbounded_channel();
+        let (rebuild_sink_tx, rebuild_sink_rx) = unbounded_channel();
+
+        let consume_log = SinkExecutor::<TestLogStoreFactory<false>>::execute_consume_log(
+            sink,
+            log_reader,
+            vec![],
+            sink_param,
+            SinkWriterParam::for_test(),
+            None,
+            ActorContext::for_test(0),
+            rate_limit_rx,
+            rebuild_sink_rx,
+        );
+        tokio::pin!(consume_log);
+
+        tokio::select! {
+            result = &mut consume_log => panic!("log consumer exited unexpectedly: {result:?}"),
+            () = state.wait_for_start_count(1) => {},
+        }
+
+        rebuild_sink_tx
+            .send(RebuildSinkMessage::UpdateConfig(HashMap::from([(
+                "commit_checkpoint_interval".to_owned(),
+                "1".to_owned(),
+            )])))
+            .unwrap();
+
+        tokio::time::timeout(Duration::from_secs(5), consume_log)
+            .await
+            .expect("log consumer should trigger recovery")
+            .expect_err("log consumer should return an error");
+        assert_eq!(state.start_count.load(Ordering::SeqCst), 1);
+        assert_eq!(state.rewind_count.load(Ordering::SeqCst), 0);
         drop(rate_limit_tx);
     }
 


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

An unchanged `ALTER SINK ... CONNECTOR WITH (...)` notification cancels the active sink consumer through `select!`. For commit-decoupled sinks, the old no-op path then restarted consumption without rewinding the KV log reader, causing `KvLogStoreReader::start_from` to panic because its state was not `Reset`.

This PR:

- rewinds rewind-capable log readers whenever a sink config notification cancels the consumer, including when the incoming properties are unchanged;
- rebuilds the sink only when the properties actually changed;
- triggers actor recovery when the log reader does not support rewind, including for an unchanged notification; and
- adds a regression test whose reader rejects a second `start_from` unless it was rewound.

- Closes #26409

## Checklist

- [x] I have written necessary rustdoc comments.
- [x] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [x] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

Prevent an unchanged `ALTER SINK ... CONNECTOR WITH (...)` from crashing a compute node when the sink uses a commit-decoupled KV log store.

</details>
