### PR TITLE
fix(meta): clean dropped table change logs and watermarks

### DIFF
--- a/src/meta/src/hummock/manager/transaction.rs
+++ b/src/meta/src/hummock/manager/transaction.rs
@@ -338,25 +338,36 @@ where
             }
 
             let delete_batch_size = self.opts.table_change_log_delete_batch_size as usize;
+            // `None` means deleting the whole table change log. Do not encode this as
+            // `u64::MAX`: the meta store epoch type is signed, so casting the sentinel would
+            // overflow and make the SQL predicate match nothing.
             let delete_iter = deltas
                 .iter()
                 .flat_map(|i| i.change_log_delta.iter())
-                .map(|(table_id, change_log_delta)| (*table_id, change_log_delta.truncate_epoch))
+                .map(|(table_id, change_log_delta)| {
+                    (*table_id, Some(change_log_delta.truncate_epoch))
+                })
                 .chain(
                     gc_change_log_deltas
                         .iter()
-                        .map(|table_id| (*table_id, u64::MAX)),
+                        .map(|table_id| (*table_id, None)),
                 );
 
             let mut stream = stream::iter(delete_iter).chunks(delete_batch_size);
             while let Some(change_log_batch) = stream.next().await {
                 let mut condition = Condition::any();
                 for (table_id, truncate_epoch) in change_log_batch {
-                    condition = condition.add(
-                        Condition::all()
-                            .add(risingwave_meta_model::hummock_table_change_log::Column::TableId.eq(table_id))
-                            .add(risingwave_meta_model::hummock_table_change_log::Column::CheckpointEpoch.lt(truncate_epoch as Epoch))
+                    let mut table_condition = Condition::all().add(
+                        risingwave_meta_model::hummock_table_change_log::Column::TableId
+                            .eq(table_id),
                     );
+                    if let Some(truncate_epoch) = truncate_epoch {
+                        table_condition = table_condition.add(
+                            risingwave_meta_model::hummock_table_change_log::Column::CheckpointEpoch
+                                .lt(truncate_epoch as Epoch),
+                        );
+                    }
+                    condition = condition.add(table_condition);
                 }
                 risingwave_meta_model::hummock_table_change_log::Entity::delete_many()
                     .filter(condition)

--- a/src/storage/hummock_sdk/src/compaction_group/hummock_version_ext.rs
+++ b/src/storage/hummock_sdk/src/compaction_group/hummock_version_ext.rs
@@ -723,6 +723,9 @@ impl<L: Clone> HummockVersionCommon<SstableInfo, L> {
                 modified_table_watermarks.insert(*table_id, Some(table_watermarks.clone()));
             }
         }
+        for table_id in &version_delta.removed_table_ids {
+            modified_table_watermarks.insert(*table_id, None);
+        }
         for (table_id, table_watermarks) in &self.table_watermarks {
             let safe_epoch = if let Some(state_table_info) =
                 self.state_table_info.info().get(table_id)
@@ -1638,8 +1641,10 @@ pub fn validate_version(version: &HummockVersion) -> Vec<String> {
 #[cfg(test)]
 mod tests {
     use std::collections::{HashMap, HashSet};
+    use std::sync::Arc;
 
     use bytes::Bytes;
+    use risingwave_common::bitmap::Bitmap;
     use risingwave_common::catalog::TableId;
     use risingwave_common::hash::VirtualNode;
     use risingwave_common::util::epoch::test_epoch;
@@ -1655,6 +1660,9 @@ mod tests {
     use crate::key_range::KeyRange;
     use crate::level::{Level, Levels, OverlappingLevel};
     use crate::sstable_info::{SstableInfo, SstableInfoInner};
+    use crate::table_watermark::{
+        TableWatermarks, VnodeWatermark, WatermarkDirection, WatermarkSerdeType,
+    };
     use crate::version::{
         GroupDelta, GroupDeltas, HummockVersion, HummockVersionDelta, HummockVersionStateTableInfo,
         IntraLevelDelta,
@@ -3085,6 +3093,38 @@ mod tests {
         assert_eq!(cg.levels[0].uncompressed_file_size, 160);
 
         assert_eq!(cg.compaction_group_version_id, 1);
+    }
+
+    #[test]
+    fn test_apply_version_delta_removes_dropped_table_watermark() {
+        let table_id = TableId::new(100);
+        let mut version = HummockVersion {
+            id: HummockVersionId::new(0),
+            table_watermarks: HashMap::from([(
+                table_id,
+                Arc::new(TableWatermarks::single_epoch(
+                    test_epoch(1),
+                    vec![VnodeWatermark::new(
+                        Arc::new(Bitmap::ones(VirtualNode::COUNT_FOR_TEST)),
+                        Bytes::from_static(b"watermark"),
+                    )],
+                    WatermarkDirection::Ascending,
+                    WatermarkSerdeType::PkPrefix,
+                )),
+            )]),
+            ..Default::default()
+        };
+
+        let version_delta = HummockVersionDelta {
+            id: HummockVersionId::new(1),
+            prev_id: HummockVersionId::new(0),
+            removed_table_ids: HashSet::from([table_id]),
+            ..Default::default()
+        };
+
+        version.apply_version_delta(&version_delta);
+
+        assert!(!version.table_watermarks.contains_key(&table_id));
     }
 
     #[test]


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

Dropping a subscription can mark its table change log for complete garbage
collection. The meta-store deletion path previously represented this operation
with `u64::MAX`, then cast it to the signed meta-model `Epoch` type. The cast
produced `-1`, so the resulting `checkpoint_epoch < -1` predicate matched no
rows and left the table's change log permanently orphaned.

This PR:

- Represents complete table change-log deletion explicitly and deletes all rows
  for the affected table, while preserving epoch-based truncation for active
  tables.
- Removes table watermarks for every table in `removed_table_ids`, including
  drops that carry no new watermark update.
- Adds a unit test covering watermark removal when applying a Hummock version
  delta.

- Closes #26011

## Validation

- `cargo fmt --check`
- `git diff --check main...HEAD`
- `CARGO_PROFILE_DEV_DEBUG=0 CARGO_BUILD_JOBS=1 cargo test -p risingwave_hummock_sdk --lib test_apply_version_delta_removes_dropped_table_watermark`
- `CARGO_PROFILE_DEV_DEBUG=0 CARGO_BUILD_JOBS=1 cargo clippy --all-targets --all-features`

## Checklist

- [x] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [x] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->

## Documentation

No user documentation update is required. The operational impact is covered by
the release note below.

<details>
<summary><b>Release note</b></summary>

Dropping subscriptions and watermark-bearing materialized views now cleans up
their associated Hummock change-log and watermark metadata, preventing orphaned
metadata from accumulating in the meta database.

</details>
