### PR TITLE
fix(binder): resolve qualified wildcards for schema-qualified relations

### DIFF
--- a/src/frontend/planner_test/tests/testdata/input/basic_query.yaml
+++ b/src/frontend/planner_test/tests/testdata/input/basic_query.yaml
@@ -123,6 +123,12 @@
     select * from t;
   expected_outputs:
   - logical_plan
+- name: qualified wildcard on zero-column subquery
+  sql: |
+    create table t ();
+    select q.* from (select * from t) q;
+  expected_outputs:
+  - logical_plan
 - name: disallow subquery in values
   sql: |
     values(1, (select 1));

--- a/src/frontend/planner_test/tests/testdata/input/select_except.yaml
+++ b/src/frontend/planner_test/tests/testdata/input/select_except.yaml
@@ -26,6 +26,31 @@
   expected_outputs:
   - batch_plan
   - stream_plan
+- name: qualified wildcard on schema-qualified relation
+  sql: |
+    create schema s;
+    create table s.t (v1 int, v2 int, v3 int);
+    select t.* except (t.v2) from s.t;
+  expected_outputs:
+  - batch_plan
+  - stream_plan
+- name: qualified wildcard on schema-qualified relation with join using
+  sql: |
+    create schema s;
+    create table s.names (id int, name varchar);
+    create table s.people (id int, version int, age int);
+    select names.name, people.* except (people.version) from s.names join s.people using (id);
+  expected_outputs:
+  - batch_plan
+  - stream_plan
+- name: qualified wildcard argument on schema-qualified relation
+  sql: |
+    create schema s;
+    create table s.t (v1 int, v2 int);
+    select jsonb_agg(t.*) from s.t;
+  expected_outputs:
+  - batch_plan
+  - stream_plan
 - name: except with unknown column
   sql: |
     create table t (v1 int, v2 int, v3 int);

--- a/src/frontend/planner_test/tests/testdata/output/basic_query.yaml
+++ b/src/frontend/planner_test/tests/testdata/output/basic_query.yaml
@@ -22,7 +22,7 @@
 - sql: |
     create table t (v1 bigint, v2 double precision);
     select t2.* from t;
-  binder_error: 'Item not found: relation "t2"'
+  binder_error: 'Item not found: missing FROM-clause entry for table "t2"'
 - sql: |
     create table t ();
     select * from t where 1>2 and 1=1 and 3<1 and 4<>1 or 1=1 and 2>=1 and 1<=2;
@@ -165,6 +165,14 @@
   logical_plan: |-
     LogicalProject { exprs: [] }
     └─LogicalScan { table: t, columns: [t._row_id, t._rw_timestamp] }
+- name: qualified wildcard on zero-column subquery
+  sql: |
+    create table t ();
+    select q.* from (select * from t) q;
+  logical_plan: |-
+    LogicalProject { exprs: [] }
+    └─LogicalProject { exprs: [] }
+      └─LogicalScan { table: t, columns: [t._row_id, t._rw_timestamp] }
 - name: disallow subquery in values
   sql: |
     values(1, (select 1));

--- a/src/frontend/planner_test/tests/testdata/output/select_except.yaml
+++ b/src/frontend/planner_test/tests/testdata/output/select_except.yaml
@@ -59,6 +59,55 @@
         │ └─StreamTableScan { table: t, columns: [t.v1, t._row_id], stream_scan_type: SnapshotBackfill, stream_key: [t._row_id], pk: [_row_id], dist: UpstreamHashShard(t._row_id) }
         └─StreamExchange { dist: HashShard(t.v1) }
           └─StreamTableScan { table: t, columns: [t.v1, t.v2, t.v3, t._row_id], stream_scan_type: SnapshotBackfill, stream_key: [t._row_id], pk: [_row_id], dist: UpstreamHashShard(t._row_id) }
+- name: qualified wildcard on schema-qualified relation
+  sql: |
+    create schema s;
+    create table s.t (v1 int, v2 int, v3 int);
+    select t.* except (t.v2) from s.t;
+  batch_plan: |-
+    BatchExchange { order: [], dist: Single }
+    └─BatchScan { table: t, columns: [t.v1, t.v3], distribution: SomeShard }
+  stream_plan: |-
+    StreamMaterialize { columns: [v1, v3, t._row_id(hidden)], stream_key: [t._row_id], pk_columns: [t._row_id], pk_conflict: NoCheck }
+    └─StreamTableScan { table: t, columns: [t.v1, t.v3, t._row_id], stream_scan_type: SnapshotBackfill, stream_key: [t._row_id], pk: [_row_id], dist: UpstreamHashShard(t._row_id) }
+- name: qualified wildcard on schema-qualified relation with join using
+  sql: |
+    create schema s;
+    create table s.names (id int, name varchar);
+    create table s.people (id int, version int, age int);
+    select names.name, people.* except (people.version) from s.names join s.people using (id);
+  batch_plan: |-
+    BatchExchange { order: [], dist: Single }
+    └─BatchHashJoin { type: Inner, predicate: names.id = people.id, output: [names.name, people.id, people.age] }
+      ├─BatchExchange { order: [], dist: HashShard(names.id) }
+      │ └─BatchScan { table: names, columns: [names.id, names.name], distribution: SomeShard }
+      └─BatchExchange { order: [], dist: HashShard(people.id) }
+        └─BatchScan { table: people, columns: [people.id, people.age], distribution: SomeShard }
+  stream_plan: |-
+    StreamMaterialize { columns: [name, id, age, names._row_id(hidden), names.id(hidden), people._row_id(hidden)], stream_key: [names._row_id, people._row_id, names.id], pk_columns: [names._row_id, people._row_id, names.id], pk_conflict: NoCheck }
+    └─StreamExchange { dist: HashShard(names._row_id, names.id, people._row_id) }
+      └─StreamHashJoin { type: Inner, predicate: names.id = people.id, output: [names.name, people.id, people.age, names._row_id, names.id, people._row_id] }
+        ├─StreamExchange { dist: HashShard(names.id) }
+        │ └─StreamTableScan { table: names, columns: [names.id, names.name, names._row_id], stream_scan_type: SnapshotBackfill, stream_key: [names._row_id], pk: [_row_id], dist: UpstreamHashShard(names._row_id) }
+        └─StreamExchange { dist: HashShard(people.id) }
+          └─StreamTableScan { table: people, columns: [people.id, people.age, people._row_id], stream_scan_type: SnapshotBackfill, stream_key: [people._row_id], pk: [_row_id], dist: UpstreamHashShard(people._row_id) }
+- name: qualified wildcard argument on schema-qualified relation
+  sql: |
+    create schema s;
+    create table s.t (v1 int, v2 int);
+    select jsonb_agg(t.*) from s.t;
+  batch_plan: |-
+    BatchSimpleAgg { aggs: [jsonb_agg($expr1)] }
+    └─BatchExchange { order: [], dist: Single }
+      └─BatchProject { exprs: [Row(t.v1, t.v2) as $expr1] }
+        └─BatchScan { table: t, columns: [t.v1, t.v2], distribution: SomeShard }
+  stream_plan: |-
+    StreamMaterialize { columns: [jsonb_agg], stream_key: [], pk_columns: [], pk_conflict: NoCheck }
+    └─StreamProject { exprs: [jsonb_agg($expr1)] }
+      └─StreamSimpleAgg { aggs: [jsonb_agg($expr1), count] }
+        └─StreamExchange { dist: Single }
+          └─StreamProject { exprs: [Row(t.v1, t.v2) as $expr1, t._row_id] }
+            └─StreamTableScan { table: t, columns: [t.v1, t.v2, t._row_id], stream_scan_type: SnapshotBackfill, stream_key: [t._row_id], pk: [_row_id], dist: UpstreamHashShard(t._row_id) }
 - name: except with unknown column
   sql: |
     create table t (v1 int, v2 int, v3 int);

--- a/src/frontend/src/binder/bind_context.rs
+++ b/src/frontend/src/binder/bind_context.rs
@@ -413,15 +413,26 @@ impl BindContext {
         let mut alias_ranges = Vec::new();
         let mut base_ranges = Vec::new();
 
-        for ((_, _), range) in self.range_of.iter().filter(|((rel_schema, rel_name), _)| {
-            rel_name == table_name
-                && schema_name
+        for ((rel_schema, rel_name), range) in &self.range_of {
+            if rel_name != table_name
+                || !schema_name
                     .as_deref()
                     .is_none_or(|s| rel_schema.as_deref() == Some(s))
-        }) {
-            match self.columns[range.0].table_alias {
-                Some(_) => alias_ranges.push(*range),
-                None => base_ranges.push(*range),
+            {
+                continue;
+            }
+
+            // Empty ranges have no column binding from which to read `table_alias`. Explicit
+            // aliases are stored without a schema in `range_of`.
+            let is_alias = if range.0 == range.1 {
+                rel_schema.is_none()
+            } else {
+                self.columns[range.0].table_alias.is_some()
+            };
+            if is_alias {
+                alias_ranges.push(*range);
+            } else {
+                base_ranges.push(*range);
             }
         }
 

--- a/src/frontend/src/binder/bind_context.rs
+++ b/src/frontend/src/binder/bind_context.rs
@@ -405,7 +405,7 @@ impl BindContext {
     /// Resolve the relation range for a `table_name` in the current bind scope.
     ///
     /// Alias matches are prioritized over base relation name matches.
-    fn resolve_relation_range(
+    pub(super) fn resolve_relation_range(
         &self,
         table_name: &String,
         schema_name: &Option<String>,

--- a/src/frontend/src/binder/expr/function/mod.rs
+++ b/src/frontend/src/binder/expr/function/mod.rs
@@ -869,19 +869,14 @@ impl Binder {
     fn bind_jsonb_agg_arg(&mut self, arg: &FunctionArg) -> Result<Vec<ExprImpl>> {
         match arg {
             FunctionArg::Unnamed(FunctionArgExpr::QualifiedWildcard(prefix, except)) => {
-                let relation_name = prefix.to_string();
                 let (schema_name, table_name) =
                     Binder::resolve_schema_qualified_name(&self.db_name, prefix)?;
                 let except_indices = self.generate_except_indices(except.as_deref())?;
                 let (begin, end) = self
                     .context
-                    .range_of
-                    .get(&(schema_name, table_name))
-                    .ok_or_else(|| {
-                        ErrorCode::ItemNotFound(format!("relation \"{}\"", relation_name))
-                    })?;
+                    .resolve_relation_range(&table_name, &schema_name)?;
                 let (exprs, names) = Self::iter_bound_columns(
-                    self.context.columns[*begin..*end]
+                    self.context.columns[begin..end]
                         .iter()
                         .filter(|c| !c.is_hidden && !except_indices.contains(&c.index)),
                 );

--- a/src/frontend/src/binder/select.rs
+++ b/src/frontend/src/binder/select.rs
@@ -364,13 +364,9 @@ impl Binder {
                     let except_indices = self.generate_except_indices(except.as_deref())?;
                     let (begin, end) = self
                         .context
-                        .range_of
-                        .get(&(schema_name, table_name.clone()))
-                        .ok_or_else(|| {
-                            ErrorCode::ItemNotFound(format!("relation \"{}\"", table_name))
-                        })?;
+                        .resolve_relation_range(&table_name, &schema_name)?;
                     let (exprs, names) = Self::iter_bound_columns(
-                        self.context.columns[*begin..*end]
+                        self.context.columns[begin..end]
                             .iter()
                             .filter(|c| !c.is_hidden && !except_indices.contains(&c.index)),
                     );


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

- Resolve qualified wildcards through `BindContext::resolve_relation_range`, matching ordinary qualified column references.
- Restore PostgreSQL-compatible `table.*` lookup for unaliased schema-qualified relations such as `SELECT people.* FROM intermediate.people`.
- Apply the same resolution to `jsonb_agg(table.*)`.
- Add planner regressions for a simple schema-qualified relation, `JOIN ... USING`, wildcard `EXCEPT`, and `jsonb_agg(table.*)`.

The regression was introduced by #24628: wildcard binding performed an exact `(schema, table)` map lookup, so `(None, "people")` could not find the relation stored as `(Some("intermediate"), "people")`.

Fixes #26418

## Checklist

- [x] I have written necessary rustdoc comments.
- [x] I have added necessary unit tests and integration tests.
- [x] I have added test labels as necessary.
- [ ] I have added fuzzing tests or opened an issue to track them. Not needed for this targeted compatibility fix.
- [ ] My PR contains breaking changes.
- [ ] My PR changes performance-critical code, so I will run (micro) benchmarks and present the results.
- [ ] I have checked the Release Timeline and Currently Supported Versions to determine which release branches I need to cherry-pick this PR into.

## Documentation

- [ ] My PR needs documentation updates. This restores documented PostgreSQL-compatible relation lookup and does not introduce new syntax.

<details>
<summary><b>Release note</b></summary>

Fixed qualified wildcard binding so an unaliased schema-qualified relation can be referenced by its table name, for example `SELECT people.* FROM intermediate.people`.

</details>

## Tests

- `./risedev run-planner-test select_except`
- `cargo clippy -p risingwave_frontend --lib -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`
