### PR TITLE
fix(meta): preserve pending barriers for since timestamp sinks

### DIFF
--- a/src/meta/src/barrier/checkpoint/independent_job/creating_job/mod.rs
+++ b/src/meta/src/barrier/checkpoint/independent_job/creating_job/mod.rs
@@ -385,13 +385,13 @@ impl CreatingStreamingJobControl {
     /// ```text
     /// snapshot epoch: 60
     /// changelog after snapshot: [61, 62, 63, 64] + 65
-    /// pending upstream barriers: 65 -> 66 checkpoint, 66 -> 67 barrier,
-    ///                            67 -> 68 barrier, 68 -> 69 barrier,
-    ///                            69 -> 70 barrier
+    /// pending upstream barriers: 66 -> 67 barrier, 67 -> 68 barrier,
+    ///                            68 -> 69 barrier, 69 -> 70 barrier
     /// new create barrier: 70 -> 71
     ///
     /// injected: 60 -> 61 checkpoint, 61 -> 62 barrier, ..., 64 -> 65 barrier,
-    ///           65 -> 66 checkpoint, 66 -> 67 barrier, ..., 69 -> 70 barrier
+    ///           65 -> 66 checkpoint, 66 -> 67 barrier, 67 -> 68 barrier, ...,
+    ///           69 -> 70 barrier
     /// current create barrier later injects: 70 -> 71 checkpoint
     /// ```
     ///
@@ -472,18 +472,29 @@ impl CreatingStreamingJobControl {
                 },
             );
         } else {
-            for (index, pending_barrier) in pending_upstream_barriers.enumerate() {
+            let first_pending_barrier = pending_upstream_barriers
+                .peek()
+                .expect("first pending upstream barrier should exist after peek");
+            assert!(
+                first_pending_barrier.prev_epoch() > prev_epoch,
+                "first pending upstream barrier should be newer than the latest resolved changelog epoch"
+            );
+            emit_barrier(
+                &mut initial_barrier,
+                &mut barriers,
+                BarrierInfo {
+                    prev_epoch: TracedEpoch::new(Epoch(prev_epoch)),
+                    curr_epoch: TracedEpoch::new(Epoch(first_pending_barrier.prev_epoch())),
+                    kind: BarrierKind::Checkpoint(take(&mut pending_non_checkpoint_barriers)),
+                },
+            );
+            prev_epoch = first_pending_barrier.prev_epoch();
+            for pending_barrier in pending_upstream_barriers {
                 assert_eq!(
                     pending_barrier.prev_epoch(),
                     prev_epoch,
                     "pending upstream barriers should continue from resolved changelog epochs"
                 );
-                if index == 0 {
-                    assert!(
-                        pending_barrier.kind.is_checkpoint(),
-                        "first pending upstream barrier should checkpoint from the latest resolved changelog epoch"
-                    );
-                }
                 pending_non_checkpoint_barriers.push(prev_epoch);
                 emit_barrier(
                     &mut initial_barrier,
@@ -1155,14 +1166,14 @@ mod tests {
         let upstream_log_epochs = vec![(vec![45, 50], 55)];
         let pending_upstream_barriers = [
             BarrierInfo {
-                prev_epoch: TracedEpoch::new(Epoch(55)),
-                curr_epoch: TracedEpoch::new(Epoch(60)),
-                kind: BarrierKind::Checkpoint(vec![55]),
+                prev_epoch: TracedEpoch::new(Epoch(60)),
+                curr_epoch: TracedEpoch::new(Epoch(65)),
+                kind: BarrierKind::Barrier,
             },
             BarrierInfo {
-                prev_epoch: TracedEpoch::new(Epoch(60)),
+                prev_epoch: TracedEpoch::new(Epoch(65)),
                 curr_epoch: TracedEpoch::new(Epoch(70)),
-                kind: BarrierKind::Barrier,
+                kind: BarrierKind::Checkpoint(vec![60, 65]),
             },
         ];
 
@@ -1185,14 +1196,17 @@ mod tests {
                 .iter()
                 .map(|barrier| (barrier.prev_epoch(), barrier.curr_epoch()))
                 .collect::<Vec<_>>(),
-            vec![(45, 50), (50, 55), (55, 60), (60, 70)]
+            vec![(45, 50), (50, 55), (55, 60), (60, 65), (65, 70)]
         );
         assert_eq!(
             barriers
                 .iter()
-                .map(|barrier| barrier.kind.is_checkpoint())
+                .map(|barrier| match &barrier.kind {
+                    BarrierKind::Checkpoint(epochs) => Some(epochs.clone()),
+                    _ => None,
+                })
                 .collect::<Vec<_>>(),
-            vec![false, false, true, false]
+            vec![None, None, Some(vec![45, 50]), None, Some(vec![60, 65])]
         );
     }
 
@@ -1200,11 +1214,6 @@ mod tests {
     fn test_resolve_since_timestamp_upstream_log_epochs_with_gap_before_pending_barriers() {
         let upstream_log_epochs = vec![(vec![61, 62, 63, 64], 65)];
         let pending_upstream_barriers = [
-            BarrierInfo {
-                prev_epoch: TracedEpoch::new(Epoch(65)),
-                curr_epoch: TracedEpoch::new(Epoch(66)),
-                kind: BarrierKind::Checkpoint(vec![65]),
-            },
             BarrierInfo {
                 prev_epoch: TracedEpoch::new(Epoch(66)),
                 curr_epoch: TracedEpoch::new(Epoch(67)),
@@ -1261,9 +1270,22 @@ mod tests {
         assert_eq!(
             barriers
                 .iter()
-                .map(|barrier| barrier.kind.is_checkpoint())
+                .map(|barrier| match &barrier.kind {
+                    BarrierKind::Checkpoint(epochs) => Some(epochs.clone()),
+                    _ => None,
+                })
                 .collect::<Vec<_>>(),
-            vec![false, false, false, false, true, false, false, false, false]
+            vec![
+                None,
+                None,
+                None,
+                None,
+                Some(vec![61, 62, 63, 64]),
+                None,
+                None,
+                None,
+                None
+            ]
         );
     }
 

--- a/src/meta/src/barrier/checkpoint/independent_job/creating_job/mod.rs
+++ b/src/meta/src/barrier/checkpoint/independent_job/creating_job/mod.rs
@@ -457,6 +457,7 @@ impl CreatingStreamingJobControl {
         }
 
         let mut pending_upstream_barriers = pending_upstream_barriers.peekable();
+        pending_non_checkpoint_barriers.push(prev_epoch);
         if pending_upstream_barriers.peek().is_none() {
             assert!(
                 new_upstream_barrier_prev_epoch > prev_epoch,
@@ -1155,9 +1156,12 @@ mod tests {
         assert_eq!(
             barriers
                 .iter()
-                .map(|barrier| barrier.kind.is_checkpoint())
+                .map(|barrier| match &barrier.kind {
+                    BarrierKind::Checkpoint(epochs) => Some(epochs.clone()),
+                    _ => None,
+                })
                 .collect::<Vec<_>>(),
-            vec![false, false, true]
+            vec![None, None, Some(vec![45, 50, 55])]
         );
     }
 
@@ -1206,7 +1210,7 @@ mod tests {
                     _ => None,
                 })
                 .collect::<Vec<_>>(),
-            vec![None, None, Some(vec![45, 50]), None, Some(vec![60, 65])]
+            vec![None, None, Some(vec![45, 50, 55]), None, Some(vec![60, 65])]
         );
     }
 
@@ -1280,7 +1284,7 @@ mod tests {
                 None,
                 None,
                 None,
-                Some(vec![61, 62, 63, 64]),
+                Some(vec![61, 62, 63, 64, 65]),
                 None,
                 None,
                 None,
@@ -1317,9 +1321,12 @@ mod tests {
         assert_eq!(
             barriers
                 .iter()
-                .map(|barrier| barrier.kind.is_checkpoint())
+                .map(|barrier| match &barrier.kind {
+                    BarrierKind::Checkpoint(epochs) => Some(epochs.clone()),
+                    _ => None,
+                })
                 .collect::<Vec<_>>(),
-            vec![false, false, false, false, true]
+            vec![None, None, None, None, Some(vec![61, 62, 63, 64, 65])]
         );
     }
 }

--- a/src/tests/simulation/tests/integration_tests/sink/basic.rs
+++ b/src/tests/simulation/tests/integration_tests/sink/basic.rs
@@ -13,9 +13,11 @@
 // limitations under the License.
 
 use std::sync::atomic::Ordering::Relaxed;
+use std::time::Duration;
 
 use anyhow::Result;
 use itertools::Itertools;
+use tokio::time::sleep;
 
 use crate::sink::utils::*;
 use crate::{assert_eq_with_err_returned as assert_eq, assert_with_err_returned as assert};
@@ -278,6 +280,66 @@ async fn test_sink_since_timestamp_starts_from_changelog() -> Result<()> {
     session.run("drop sink test_sink").await?;
     session.run("drop subscription sub_since_sink").await?;
     session.run("drop table t_since_sink").await?;
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_sink_since_timestamp_with_pending_upstream_barriers() -> Result<()> {
+    const BARRIER_DELAY: Duration = Duration::from_secs(1);
+
+    let mut cluster = start_sink_test_cluster().await?;
+    let test_sink = SimulationTestSink::register_new(TestSinkType::SlowBarrier(BARRIER_DELAY));
+
+    let mut session = cluster.start_session();
+    session.run("set streaming_parallelism = 1").await?;
+    session.run("set sink_decouple = false").await?;
+    session
+        .run("create table t_since_sink_pending (id int primary key, name varchar)")
+        .await?;
+    session
+        .run(
+            "create subscription sub_since_sink_pending from t_since_sink_pending \
+             with (retention = '1D')",
+        )
+        .await?;
+    session.flush().await?;
+
+    session
+        .run(
+            "create sink slow_sink from t_since_sink_pending with (\
+             connector = 'test', \
+             type = 'upsert')",
+        )
+        .await?;
+    test_sink.wait_initial_parallelism(1).await?;
+
+    session
+        .run("insert into t_since_sink_pending values (1, 'name-1')")
+        .await?;
+    session.flush().await?;
+    let since_timestamp = session.run("select now()::varchar").await?;
+
+    session
+        .run("insert into t_since_sink_pending values (2, 'name-2')")
+        .await?;
+    session.flush().await?;
+
+    // The simulation barrier interval is 250 ms. Keep the sink blocked long enough for several
+    // later barriers to accumulate behind the checkpoint currently being completed.
+    test_sink.enable_barrier_delay();
+    sleep(BARRIER_DELAY * 3).await;
+
+    session
+        .run(format!(
+            "create sink since_sink from t_since_sink_pending with (\
+             connector = 'test', \
+             type = 'upsert', \
+             snapshot = 'false', \
+             since_timestamp = '{}')",
+            since_timestamp.trim()
+        ))
+        .await?;
 
     Ok(())
 }

--- a/src/tests/simulation/tests/integration_tests/sink/utils.rs
+++ b/src/tests/simulation/tests/integration_tests/sink/utils.rs
@@ -18,7 +18,7 @@ use std::iter::once;
 use std::mem::take;
 use std::num::NonZero;
 use std::sync::atomic::Ordering::Relaxed;
-use std::sync::atomic::{AtomicU32, AtomicUsize};
+use std::sync::atomic::{AtomicU32, AtomicU64, AtomicUsize};
 use std::sync::{Arc, Mutex, MutexGuard};
 use std::time::{Duration, Instant};
 
@@ -196,6 +196,7 @@ pub struct TestWriter {
     store: TestSinkStore,
     parallelism_counter: Arc<AtomicUsize>,
     err_rate: Arc<AtomicU32>,
+    barrier_delay_ms: Option<Arc<AtomicU64>>,
 }
 
 #[async_trait]
@@ -225,7 +226,12 @@ impl SinkWriter for TestWriter {
         &mut self,
         is_checkpoint: bool,
     ) -> risingwave_connector::sink::Result<Self::CommitMetadata> {
-        if is_checkpoint {
+        if let Some(barrier_delay_ms) = &self.barrier_delay_ms {
+            let barrier_delay_ms = barrier_delay_ms.load(Relaxed);
+            if barrier_delay_ms > 0 {
+                sleep(Duration::from_millis(barrier_delay_ms)).await;
+            }
+        } else if is_checkpoint {
             self.store.inc_checkpoint();
             sleep(Duration::from_millis(100)).await;
         }
@@ -504,10 +510,12 @@ pub struct SimulationTestSink {
     pub store: TestSinkStore,
     pub parallelism_counter: Arc<AtomicUsize>,
     pub err_rate: Arc<AtomicU32>,
+    barrier_delay_ms: Option<(Arc<AtomicU64>, u64)>,
 }
 
 pub enum TestSinkType {
     SinkWriter,
+    SlowBarrier(Duration),
     SinglePhaseCoordinatedSink,
     TwoPhaseCoordinatedSink,
     AsyncTruncate,
@@ -531,6 +539,13 @@ impl SimulationTestSink {
         let parallelism_counter = Arc::new(AtomicUsize::new(0));
         let err_rate = Arc::new(AtomicU32::new(0));
         let store = TestSinkStore::new();
+        let barrier_delay_ms = match &test_type {
+            TestSinkType::SlowBarrier(delay) => Some((
+                Arc::new(AtomicU64::new(0)),
+                delay.as_millis().try_into().unwrap(),
+            )),
+            _ => None,
+        };
 
         let _sink_guard = match test_type {
             TestSinkType::SinglePhaseCoordinatedSink => {
@@ -649,6 +664,29 @@ impl SimulationTestSink {
                             store: store.clone(),
                             parallelism_counter: parallelism_counter.clone(),
                             err_rate: err_rate.clone(),
+                            barrier_delay_ms: None,
+                        }
+                        .into_log_sinker(metrics),
+                    );
+                    async move { Ok(log_sinker) }.boxed()
+                }
+            }),
+            TestSinkType::SlowBarrier(_) => register_build_sink({
+                let parallelism_counter = parallelism_counter.clone();
+                let err_rate = err_rate.clone();
+                let store = store.clone();
+                let barrier_delay_ms = barrier_delay_ms.as_ref().unwrap().0.clone();
+                use risingwave_connector::sink::SinkWriterMetrics;
+                use risingwave_connector::sink::writer::SinkWriterExt;
+                move |_, writer_param| {
+                    parallelism_counter.fetch_add(1, Relaxed);
+                    let metrics = SinkWriterMetrics::new(&writer_param);
+                    let log_sinker = risingwave_connector::sink::boxed::boxed_log_sinker(
+                        TestWriter {
+                            store: store.clone(),
+                            parallelism_counter: parallelism_counter.clone(),
+                            err_rate: err_rate.clone(),
+                            barrier_delay_ms: Some(barrier_delay_ms.clone()),
                         }
                         .into_log_sinker(metrics),
                     );
@@ -740,7 +778,13 @@ impl SimulationTestSink {
             parallelism_counter,
             store,
             err_rate,
+            barrier_delay_ms,
         }
+    }
+
+    pub fn enable_barrier_delay(&self) {
+        let (barrier_delay_ms, delay) = self.barrier_delay_ms.as_ref().unwrap();
+        barrier_delay_ms.store(*delay, Relaxed);
     }
 
     pub fn set_err_rate(&self, err_rate: f64) {


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

Fix since-timestamp sink creation when an upstream checkpoint barrier has already moved out of the pending queue for completion.

The resolved table changelog can end before the first remaining pending barrier. Insert a checkpoint barrier to bridge that gap, then replay every pending upstream barrier without collapsing epoch boundaries.

Add unit coverage for the reconstructed barrier sequence and checkpoint epoch lists. Add a deterministic simulation regression test using a non-decoupled test sink that delays barrier handling long enough to accumulate pending upstream barriers.

## Checklist

- [x] I have written necessary rustdoc comments.
- [x] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [x] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove it in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

Fix creating a sink with `since_timestamp` when upstream barriers are pending.

</details>
