### PR TITLE
fix(backfill): avoid one-row-per-barrier starvation in ArrangementBackfill

### DIFF
--- a/src/stream/src/executor/backfill/arrangement_backfill.rs
+++ b/src/stream/src/executor/backfill/arrangement_backfill.rs
@@ -411,9 +411,15 @@ where
                                             chunk,
                                         );
                                         yield Message::Chunk(chunk);
+                                        // Only break once a full chunk has been produced, so a
+                                        // barrier period advances a whole chunk instead of a
+                                        // single row. Otherwise, when the upstream keeps the
+                                        // `PollNext::Left` branch permanently ready, this fallback
+                                        // block is entered every barrier and reads exactly one row,
+                                        // degrading the backfill to one-row-per-barrier.
+                                        break;
                                     }
-
-                                    break;
+                                    // Not a full chunk yet: keep reading to fill it.
                                 }
                             }
                         }


### PR DESCRIPTION
## What's changed

Fixes the one-row-per-barrier starvation in `ArrangementBackfill` described in #26421.

The backfill loop uses `select_with_strategy(left_upstream, right_snapshot, |_| PollNext::Left)`, always preferring upstream. When the upstream keeps producing data/barriers (e.g. an iceberg-engine `__iceberg_sink` backfilling a table under active CDC ingestion, while other large tables keep the global barrier rate high), the `right_snapshot` branch is never polled, so `has_snapshot_read` stays `false` and every barrier period enters the "read at least one row" fallback block.

That fallback used to `break` after a **single row**:

```rust
Some((vnode, row)) => {
    let builder = builders.get_mut(&vnode).unwrap();
    if let Some(chunk) = builder.append_one_row(row) {
        ... yield Message::Chunk(chunk);
    }
    break;   // <-- one row per barrier
}
```

so the backfill advanced by one row per barrier, flushing each row as its own tiny data file and effectively never finishing for actively-written tables. For iceberg-engine tables this means the historical (backfill) rows silently never make it into the committed iceberg table.

This PR moves the `break` inside the `if let Some(chunk)` branch, so the fallback only exits once a full chunk has been produced — advancing a whole chunk per pass instead of a single row.

## Verification

Built a v3.0.1-based image and created 48 iceberg-engine tables concurrently from a MySQL CDC source (mixed sizes, so large-table backfills keep barriers frequent).

- **Before the fix:** `snapshot_rows_this_barrier` was a constant `1` for actively-written small tables; their iceberg `data/` dirs filled with single-row (~8 KB) parquet files that were never added to a snapshot; iceberg `total-records` stayed at the tiny post-backfill increment count.
- **After the fix:** `snapshot_rows_this_barrier` = `50 / 119 / 1189 / 4712 / 6268 ...`; the 3 previously-truncated tables backfilled completely — iceberg `total-records` = full counts `1481 / 903 / 10058`, matching hummock and the upstream, confirmed via Doris reads.

## Checklist

- [x] Reproduced the bug and verified the fix end-to-end
- [ ] I have written necessary rustdoc comments (inline comment added explaining the invariant)
- [ ] I have added necessary unit tests and integration tests

Closes #26421
