### PR TITLE
fix(stream): fix panic when shrinking emptied over-window partition cache

### DIFF
--- a/src/stream/src/executor/over_window/range_cache.rs
+++ b/src/stream/src/executor/over_window/range_cache.rs
@@ -191,6 +191,12 @@ impl PartitionCache {
         const MAGIC_CACHE_SIZE: usize = 1024;
         const MAGIC_JITTER_PREVENTION: usize = MAGIC_CACHE_SIZE / 8;
 
+        // The cache can have zero entry (not even sentinels), e.g., after all rows of the
+        // fully-cached partition are deleted. The `Recent` branch below can't handle this.
+        if self.is_empty() {
+            return;
+        }
+
         tracing::trace!(
             partition=?deduped_part_key,
             cache_policy=?cache_policy,

--- a/src/stream/tests/integration_tests/over_window.rs
+++ b/src/stream/tests/integration_tests/over_window.rs
@@ -507,6 +507,68 @@ async fn test_over_window_evict_between_chunks() {
     assert_eq!(ow_metrics.over_window_cache_miss_count.get(), 4);
 }
 
+/// Regression test: deleting all rows of a fully-cached partition (no sentinels in the
+/// cache) leaves the range cache with zero entries. `PartitionCache::shrink` with
+/// `CachePolicy::Recent` used to panic on such an empty cache at the next barrier.
+///
+/// Note that the insert and the delete must happen within the same barrier interval:
+/// `shrink` only runs for partitions registered in `recently_accessed_ranges`, and a
+/// chunk that deletes all rows of a partition doesn't register it (empty affected
+/// ranges), so the registration must come from the insert chunk.
+#[tokio::test]
+async fn test_over_window_delete_all_rows_of_partition() {
+    let store = MemoryStateStore::new();
+    let calls = vec![
+        // lag(x, 1), doesn't force `CachePolicy::Full`
+        WindowFuncCall {
+            kind: WindowFuncKind::Aggregate(PbAggKind::FirstValue.into()),
+            return_type: DataType::Int32,
+            args: AggArgs::from_iter([(DataType::Int32, 3)]),
+            ignore_nulls: false,
+            frame: Frame::rows(FrameBound::Preceding(1), FrameBound::Preceding(1)),
+        },
+    ];
+    let (mut tx, mut stream) = create_executor(calls, store).await;
+
+    tx.push_barrier(test_epoch(1), false);
+    stream.expect_barrier().await;
+
+    tx.push_chunk(StreamChunk::from_pretty(
+        " I T  I   i
+        + 1 p1 100 10
+        + 2 p1 101 16",
+    ));
+    assert_eq!(
+        stream.expect_chunk().await,
+        StreamChunk::from_pretty(
+            " I T  I   i  i
+            + 1 p1 100 10 .
+            + 2 p1 101 16 10",
+        )
+    );
+
+    // Delete all rows of `p1` in the same epoch, emptying the range cache.
+    tx.push_chunk(StreamChunk::from_pretty(
+        " I T  I   i
+        - 1 p1 100 10
+        - 2 p1 101 16",
+    ));
+    assert_eq!(
+        stream.expect_chunk().await,
+        StreamChunk::from_pretty(
+            " I T  I   i  i
+            - 1 p1 100 10 .
+            - 2 p1 101 16 10",
+        )
+    );
+
+    tx.push_barrier(test_epoch(2), false);
+    stream.expect_barrier().await;
+    // Poll once more to run the post-barrier cache shrinking, which used to panic on
+    // the emptied `p1` cache.
+    stream.next_unwrap_pending();
+}
+
 #[tokio::test]
 async fn test_over_window_sum() {
     let store = MemoryStateStore::new();


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

Fix a panic in the over-window executor observed in production with `streaming.developer.over_window_cache_policy = 'recent'`:

```
src/stream/src/executor/over_window/range_cache.rs:221:63: called `Option::unwrap()` on a `None` value
```

- When all rows of a fully-cached partition (no sentinels in the range cache) are deleted, the cache is left with zero entries. This is a legal state (the `(Normal)*` form documented on `PartitionCache`) meaning "fully cached, empty partition", and all other consumers handle it fine.
- However, the `Recent` branch of `PartitionCache::shrink` assumes a non-empty cache: its `first_key_value().unwrap()` fallback panics at the next barrier. Since the panic recurs on replay after recovery, it can cause a crash loop.
- Trigger conditions: within one barrier interval, a partition is first touched by a normal change (which registers it in `recently_accessed_ranges` — a pure whole-partition delete alone doesn't) and then has all its rows deleted.

Fix: return early from `shrink()` when the cache is empty — there is nothing to shrink. With the non-empty precondition, the remaining `first/last_key_value().unwrap()` fallbacks in all policy branches become provably safe.

Added `test_over_window_delete_all_rows_of_partition`, which reproduces the exact panic (`range_cache.rs:221:63`) without the fix.

## Checklist

- [x] I have written necessary rustdoc comments.
- [x] I have added necessary unit tests and integration tests.
- [ ] I have added test labels as necessary.
- [ ] I have added fuzzing tests or opened an issue to track them.
- [ ] My PR contains breaking changes.
- [ ] My PR changes performance-critical code, so I will run (micro) benchmarks and present the results.
- [x] I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into.


## Documentation

- [ ] My PR needs documentation updates.

<details>
<summary><b>Release note</b></summary>

</details>
