### PR TITLE
ci: increase single-node e2e timeout

### DIFF
--- a/ci/workflows/main-cron.yml
+++ b/ci/workflows/main-cron.yml
@@ -945,7 +945,7 @@ steps:
     plugins:
       - docker-compose#v5.5.0: *docker-compose
       - ./ci/plugins/upload-failure-logs
-    timeout_in_minutes: 40
+    timeout_in_minutes: 45
     retry: *auto-retry
 
   - label: "end-to-end test for opendal storage backend (parallel)"


### PR DESCRIPTION
## What changed

- Increase the main-cron `e2e single-node binary test` timeout from 40 to 45 minutes.

## Why

Buildkite main-cron build 9691 timed out with exit status 143 while entering the final extended-query phase. The test suite itself was progressing normally, but cold-worker Docker image setup consumed the small amount of headroom left by a job that already takes about 39–40 minutes.

Build 9666 showed the same cold-worker timeout pattern, while build 9525 passed on a warm worker with less than a minute of remaining headroom.

## Impact

This gives the existing single-node e2e suite enough startup headroom on cold workers. It does not change test selection or product behavior.

## Validation

- `git diff --check`
- Parsed `ci/workflows/main-cron.yml` with `yq`
- Compared Buildkite job logs for builds 9691, 9666, and 9525
