### PR TITLE
refactor(connector): centralize Iceberg engine options

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -1535,6 +1535,7 @@ description = "This command extracts WITH options from the Rust code and maintai
 script = '''
 UPDATE_EXPECT=1 cargo test -p risingwave_connector tests::test_with_options_yaml_up_to_date
 UPDATE_EXPECT=1 cargo test -p risingwave_connector tests::test_allow_alter_on_fly_fields_rust_up_to_date
+UPDATE_EXPECT=1 cargo test -p risingwave_connector tests::test_iceberg_engine_fields_rust_up_to_date
 '''
 
 [tasks.backwards-compat-test]

--- a/src/connector/src/allow_alter_on_fly_fields.rs
+++ b/src/connector/src/allow_alter_on_fly_fields.rs
@@ -18,9 +18,10 @@
 // `UPDATE_EXPECT=1`.
 // To update content, change source/sink/connection WITH options definitions (for example,
 // `#[with_option(allow_alter_on_fly)]` on struct fields), then run `./risedev generate-with-options`.
-// `./risedev generate-with-options` runs two UPDATE_EXPECT tests:
+// `./risedev generate-with-options` runs three UPDATE_EXPECT tests:
 // 1) refresh `with_options_{source,sink,connection}.yaml`;
-// 2) regenerate this file from those YAML files.
+// 2) regenerate this file from those YAML files;
+// 3) regenerate the Iceberg Engine option classifier.
 
 #![rustfmt::skip]
 

--- a/src/connector/src/lib.rs
+++ b/src/connector/src/lib.rs
@@ -190,8 +190,9 @@ mod tests {
     use expect_test::expect_file;
 
     use crate::with_options_test::{
-        generate_allow_alter_on_fly_fields_combined, generate_with_options_yaml_connection,
-        generate_with_options_yaml_sink, generate_with_options_yaml_source,
+        generate_allow_alter_on_fly_fields_combined, generate_iceberg_engine_fields,
+        generate_with_options_yaml_connection, generate_with_options_yaml_sink,
+        generate_with_options_yaml_source,
     };
 
     /// This test ensures that `src/connector/with_options.yaml` is up-to-date with the default values specified
@@ -212,6 +213,13 @@ mod tests {
     fn test_allow_alter_on_fly_fields_rust_up_to_date() {
         expect_file!("../src/allow_alter_on_fly_fields.rs")
             .assert_eq(&generate_allow_alter_on_fly_fields_combined());
+    }
+
+    /// This test ensures that Iceberg Engine sink fields are up-to-date.
+    #[test]
+    fn test_iceberg_engine_fields_rust_up_to_date() {
+        expect_file!("../src/sink/iceberg/engine_options.rs")
+            .assert_eq(&generate_iceberg_engine_fields());
     }
 
     /// Test some serde behavior we rely on.

--- a/src/connector/src/sink/iceberg/config.rs
+++ b/src/connector/src/sink/iceberg/config.rs
@@ -313,15 +313,17 @@ pub struct IcebergConfig {
     pub java_catalog_props: HashMap<String, String>,
 
     #[serde(default)]
+    #[with_option(iceberg_engine)]
     pub partition_by: Option<String>,
 
     #[serde(default)]
+    #[with_option(iceberg_engine)]
     pub order_key: Option<String>,
 
     /// Commit every n(>0) checkpoints, default is 60.
     #[serde(default = "iceberg_default_commit_checkpoint_interval")]
     #[serde_as(as = "DisplayFromStr")]
-    #[with_option(allow_alter_on_fly)]
+    #[with_option(allow_alter_on_fly, iceberg_engine)]
     pub commit_checkpoint_interval: u64,
 
     #[serde(default, deserialize_with = "deserialize_bool_from_string")]
@@ -344,13 +346,13 @@ pub struct IcebergConfig {
         default,
         deserialize_with = "deserialize_bool_from_string"
     )]
-    #[with_option(allow_alter_on_fly)]
+    #[with_option(allow_alter_on_fly, iceberg_engine)]
     pub enable_compaction: bool,
 
     /// The interval of iceberg compaction
     #[serde(rename = "compaction_interval_sec", default)]
     #[serde_as(as = "Option<DisplayFromStr>")]
-    #[with_option(allow_alter_on_fly)]
+    #[with_option(allow_alter_on_fly, iceberg_engine)]
     pub compaction_interval_sec: Option<u64>,
 
     /// Whether to enable iceberg expired snapshots.
@@ -359,11 +361,12 @@ pub struct IcebergConfig {
         default = "default_true",
         deserialize_with = "deserialize_bool_from_string"
     )]
-    #[with_option(allow_alter_on_fly)]
+    #[with_option(allow_alter_on_fly, iceberg_engine)]
     pub enable_snapshot_expiration: bool,
 
     /// The iceberg write mode, can be `merge-on-read` or `copy-on-write`.
     #[serde(rename = "write_mode", default = "default_iceberg_write_mode")]
+    #[with_option(iceberg_engine)]
     pub write_mode: IcebergWriteMode,
 
     /// Iceberg format version for table creation.
@@ -372,19 +375,20 @@ pub struct IcebergConfig {
         default = "default_iceberg_format_version",
         deserialize_with = "deserialize_format_version"
     )]
+    #[with_option(iceberg_engine)]
     pub format_version: FormatVersion,
 
     /// The maximum age (in milliseconds) for snapshots before they expire
     /// For example, if set to 3600000, snapshots older than 1 hour will be expired
     #[serde(rename = "snapshot_expiration_max_age_millis", default)]
     #[serde_as(as = "Option<DisplayFromStr>")]
-    #[with_option(allow_alter_on_fly)]
+    #[with_option(allow_alter_on_fly, iceberg_engine)]
     pub snapshot_expiration_max_age_millis: Option<i64>,
 
     /// The number of snapshots to retain
     #[serde(rename = "snapshot_expiration_retain_last", default)]
     #[serde_as(as = "Option<DisplayFromStr>")]
-    #[with_option(allow_alter_on_fly)]
+    #[with_option(allow_alter_on_fly, iceberg_engine)]
     pub snapshot_expiration_retain_last: Option<i32>,
 
     #[serde(
@@ -392,7 +396,7 @@ pub struct IcebergConfig {
         default = "default_true",
         deserialize_with = "deserialize_bool_from_string"
     )]
-    #[with_option(allow_alter_on_fly)]
+    #[with_option(allow_alter_on_fly, iceberg_engine)]
     pub snapshot_expiration_clear_expired_files: bool,
 
     #[serde(
@@ -400,7 +404,7 @@ pub struct IcebergConfig {
         default = "default_true",
         deserialize_with = "deserialize_bool_from_string"
     )]
-    #[with_option(allow_alter_on_fly)]
+    #[with_option(allow_alter_on_fly, iceberg_engine)]
     pub snapshot_expiration_clear_expired_meta_data: bool,
 
     /// Whether to periodically rewrite fragmented Iceberg data manifests.
@@ -409,19 +413,19 @@ pub struct IcebergConfig {
         default,
         deserialize_with = "deserialize_bool_from_string"
     )]
-    #[with_option(allow_alter_on_fly)]
+    #[with_option(allow_alter_on_fly, iceberg_engine)]
     pub enable_manifest_rewrite: bool,
 
     /// Target size in bytes for rewritten Iceberg data manifests.
     #[serde(rename = "manifest_rewrite_target_size_bytes", default)]
     #[serde_as(as = "Option<DisplayFromStr>")]
-    #[with_option(allow_alter_on_fly)]
+    #[with_option(allow_alter_on_fly, iceberg_engine)]
     pub manifest_rewrite_target_size_bytes: Option<u64>,
 
     /// Minimum number of manifests required to rewrite an under-filled batch.
     #[serde(rename = "manifest_rewrite_min_count_to_merge", default)]
     #[serde_as(as = "Option<DisplayFromStr>")]
-    #[with_option(allow_alter_on_fly)]
+    #[with_option(allow_alter_on_fly, iceberg_engine)]
     pub manifest_rewrite_min_count_to_merge: Option<usize>,
 
     /// The maximum number of snapshots allowed since the last rewrite operation
@@ -429,54 +433,54 @@ pub struct IcebergConfig {
     /// If unset, defaults to 1000 only when compaction is enabled
     #[serde(rename = "compaction.max_snapshots_num", default)]
     #[serde_as(as = "Option<DisplayFromStr>")]
-    #[with_option(allow_alter_on_fly)]
+    #[with_option(allow_alter_on_fly, iceberg_engine)]
     pub max_snapshots_num_before_compaction: Option<usize>,
 
     #[serde(rename = "compaction.small_files_threshold_mb", default)]
     #[serde_as(as = "Option<DisplayFromStr>")]
-    #[with_option(allow_alter_on_fly)]
+    #[with_option(allow_alter_on_fly, iceberg_engine)]
     pub small_files_threshold_mb: Option<u64>,
 
     #[serde(rename = "compaction.delete_files_count_threshold", default)]
     #[serde_as(as = "Option<DisplayFromStr>")]
-    #[with_option(allow_alter_on_fly)]
+    #[with_option(allow_alter_on_fly, iceberg_engine)]
     pub delete_files_count_threshold: Option<usize>,
 
     #[serde(rename = "compaction.trigger_snapshot_count", default)]
     #[serde_as(as = "Option<DisplayFromStr>")]
-    #[with_option(allow_alter_on_fly)]
+    #[with_option(allow_alter_on_fly, iceberg_engine)]
     pub trigger_snapshot_count: Option<usize>,
 
     #[serde(rename = "compaction.target_file_size_mb", default)]
     #[serde_as(as = "Option<DisplayFromStr>")]
-    #[with_option(allow_alter_on_fly)]
+    #[with_option(allow_alter_on_fly, iceberg_engine)]
     pub target_file_size_mb: Option<u64>,
 
     /// Compaction type: `full`, `small-files`, or `files-with-delete`
     /// If not set, will default to `full`
     #[serde(rename = "compaction.type", default)]
-    #[with_option(allow_alter_on_fly)]
+    #[with_option(allow_alter_on_fly, iceberg_engine)]
     pub compaction_type: Option<CompactionType>,
 
     /// Parquet compression codec
     /// Supported values: uncompressed, snappy, gzip, lzo, brotli, lz4, zstd
     /// Default is zstd
     #[serde(rename = "compaction.write_parquet_compression", default)]
-    #[with_option(allow_alter_on_fly)]
+    #[with_option(allow_alter_on_fly, iceberg_engine)]
     pub write_parquet_compression: Option<String>,
 
     /// Deprecated: maximum number of rows in a Parquet row group.
     /// Accepted for backward compatibility, but ignored by the writer.
     #[serde(rename = "compaction.write_parquet_max_row_group_rows", default)]
     #[serde_as(as = "Option<DisplayFromStr>")]
-    #[with_option(allow_alter_on_fly)]
+    #[with_option(allow_alter_on_fly, iceberg_engine)]
     pub write_parquet_max_row_group_rows: Option<usize>,
 
     /// Maximum size of a Parquet row group in bytes
     /// Default is 128 `MiB`, matching Iceberg defaults.
     #[serde(rename = "compaction.write_parquet_max_row_group_bytes", default)]
     #[serde_as(as = "Option<DisplayFromStr>")]
-    #[with_option(allow_alter_on_fly)]
+    #[with_option(allow_alter_on_fly, iceberg_engine)]
     pub write_parquet_max_row_group_bytes: Option<usize>,
 
     /// Whether to enable PK index for upsert sink. Default is false.
@@ -487,6 +491,7 @@ pub struct IcebergConfig {
         default,
         deserialize_with = "deserialize_bool_from_string"
     )]
+    #[with_option(iceberg_engine)]
     pub enable_pk_index: bool,
 
     #[serde(flatten)]
@@ -617,6 +622,12 @@ impl IcebergConfig {
             )));
         }
 
+        if config.compaction_interval_sec == Some(0) {
+            return Err(SinkError::Config(anyhow!(
+                "`compaction_interval_sec` must be greater than 0"
+            )));
+        }
+
         if config.trigger_snapshot_count == Some(0) {
             return Err(SinkError::Config(anyhow!(
                 "`compaction.trigger_snapshot_count` must be greater than 0"
@@ -626,6 +637,36 @@ impl IcebergConfig {
         if config.max_snapshots_num_before_compaction == Some(0) {
             return Err(SinkError::Config(anyhow!(
                 "`compaction.max_snapshots_num` must be greater than 0"
+            )));
+        }
+
+        if config.small_files_threshold_mb == Some(0) {
+            return Err(SinkError::Config(anyhow!(
+                "`compaction.small_files_threshold_mb` must be greater than 0"
+            )));
+        }
+
+        if config.delete_files_count_threshold == Some(0) {
+            return Err(SinkError::Config(anyhow!(
+                "`compaction.delete_files_count_threshold` must be greater than 0"
+            )));
+        }
+
+        if config.target_file_size_mb == Some(0) {
+            return Err(SinkError::Config(anyhow!(
+                "`compaction.target_file_size_mb` must be greater than 0"
+            )));
+        }
+
+        if config.write_parquet_max_row_group_rows == Some(0) {
+            return Err(SinkError::Config(anyhow!(
+                "`compaction.write_parquet_max_row_group_rows` must be greater than 0"
+            )));
+        }
+
+        if config.write_parquet_max_row_group_bytes == Some(0) {
+            return Err(SinkError::Config(anyhow!(
+                "`compaction.write_parquet_max_row_group_bytes` must be greater than 0"
             )));
         }
 

--- a/src/connector/src/sink/iceberg/engine_options.rs
+++ b/src/connector/src/sink/iceberg/engine_options.rs
@@ -1,0 +1,48 @@
+// Copyright 2026 RisingWave Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// THIS FILE IS AUTO_GENERATED. DO NOT EDIT.
+// UPDATE WITH: ./risedev generate-with-options
+
+pub const ICEBERG_ENGINE_OPTION_KEYS: &[&str] = &[
+    "partition_by",
+    "order_key",
+    "commit_checkpoint_interval",
+    "enable_compaction",
+    "compaction_interval_sec",
+    "enable_snapshot_expiration",
+    "write_mode",
+    "format_version",
+    "snapshot_expiration_max_age_millis",
+    "snapshot_expiration_retain_last",
+    "snapshot_expiration_clear_expired_files",
+    "snapshot_expiration_clear_expired_meta_data",
+    "enable_manifest_rewrite",
+    "manifest_rewrite_target_size_bytes",
+    "manifest_rewrite_min_count_to_merge",
+    "compaction.max_snapshots_num",
+    "compaction.small_files_threshold_mb",
+    "compaction.delete_files_count_threshold",
+    "compaction.trigger_snapshot_count",
+    "compaction.target_file_size_mb",
+    "compaction.type",
+    "compaction.write_parquet_compression",
+    "compaction.write_parquet_max_row_group_rows",
+    "compaction.write_parquet_max_row_group_bytes",
+    "enable_pk_index",
+];
+
+pub fn is_iceberg_engine_option(key: &str) -> bool {
+    ICEBERG_ENGINE_OPTION_KEYS.contains(&key)
+}

--- a/src/connector/src/sink/iceberg/mod.rs
+++ b/src/connector/src/sink/iceberg/mod.rs
@@ -19,6 +19,7 @@ mod commit;
 pub mod commit_retry;
 mod config;
 mod create_table;
+mod engine_options;
 #[cfg(any(test, madsim))]
 pub mod mock_v3_catalog_registry;
 mod prometheus;
@@ -32,6 +33,7 @@ use anyhow::{Context, anyhow};
 pub use commit::*;
 pub use config::*;
 pub use create_table::*;
+pub use engine_options::*;
 use iceberg::table::Table;
 use risingwave_common::bail;
 use tokio::sync::mpsc::UnboundedSender;

--- a/src/connector/src/sink/iceberg/test.rs
+++ b/src/connector/src/sink/iceberg/test.rs
@@ -948,6 +948,39 @@ fn test_reject_zero_max_snapshots_num() {
     );
 }
 
+#[test]
+fn test_reject_zero_compaction_size_settings() {
+    for option in [
+        "compaction_interval_sec",
+        "compaction.small_files_threshold_mb",
+        "compaction.delete_files_count_threshold",
+        "compaction.target_file_size_mb",
+        "compaction.write_parquet_max_row_group_rows",
+        "compaction.write_parquet_max_row_group_bytes",
+    ] {
+        let mut values: BTreeMap<String, String> = [
+            ("connector", "iceberg"),
+            ("type", "append-only"),
+            ("catalog.name", "test-catalog"),
+            ("catalog.type", "storage"),
+            ("warehouse.path", "s3://my-bucket/warehouse"),
+            ("database.name", "test_db"),
+            ("table.name", "test_table"),
+        ]
+        .into_iter()
+        .map(|(k, v)| (k.to_owned(), v.to_owned()))
+        .collect();
+        values.insert(option.to_owned(), "0".to_owned());
+
+        let err = IcebergConfig::from_btreemap(values).unwrap_err();
+        assert!(
+            err.to_string()
+                .contains(&format!("`{option}` must be greater than 0")),
+            "unexpected error for {option}: {err}"
+        );
+    }
+}
+
 /// Test parquet compression parsing.
 #[test]
 fn test_parse_parquet_compression() {

--- a/src/connector/src/with_options_test.rs
+++ b/src/connector/src/with_options_test.rs
@@ -100,6 +100,13 @@ pub fn generate_allow_alter_on_fly_fields_combined() -> String {
     generate_rust_allow_alter_on_fly_fields_code_separate(source_info, sink_info, connection_info)
 }
 
+pub fn generate_iceberg_engine_fields() -> String {
+    let fields = extract_iceberg_engine_fields_from_yaml(
+        &connector_crate_path().join("with_options_sink.yaml"),
+    );
+    generate_rust_iceberg_engine_fields_code(fields)
+}
+
 /// Collect all structs with `#[derive(WithOptions)]` in the `.rs` files in `path` (plus `common.rs`),
 /// and generate a YAML file.
 ///
@@ -159,7 +166,8 @@ fn generate_with_options_yaml_inner(path: &Path) -> BTreeMap<String, StructInfo>
                     alias,
                 } = extract_serde_properties(&field);
 
-                let allow_alter_on_fly = extract_with_option_allow_alter_on_fly(&field);
+                let allow_alter_on_fly = extract_with_option_flag(&field, "allow_alter_on_fly");
+                let iceberg_engine = extract_with_option_flag(&field, "iceberg_engine");
 
                 let field_type = field.ty;
                 let mut required = match extract_type_name(&field_type).as_str() {
@@ -198,6 +206,7 @@ fn generate_with_options_yaml_inner(path: &Path) -> BTreeMap<String, StructInfo>
                     default,
                     alias,
                     allow_alter_on_fly,
+                    iceberg_engine,
                 });
             } else {
                 panic!("Unexpected tuple struct: {}", struct_name);
@@ -236,6 +245,9 @@ struct FieldInfo {
 
     #[serde(skip_serializing_if = "std::ops::Not::not")]
     allow_alter_on_fly: bool,
+
+    #[serde(skip_serializing_if = "std::ops::Not::not")]
+    iceberg_engine: bool,
 }
 
 #[derive(Default)]
@@ -260,6 +272,8 @@ struct YamlFieldInfo {
     name: String,
     #[serde(default)]
     allow_alter_on_fly: bool,
+    #[serde(default)]
+    iceberg_engine: bool,
     #[serde(default)]
     alias: Vec<String>,
 }
@@ -438,13 +452,13 @@ fn extract_function_body(func: ItemFn) -> (String, FunctionInfo) {
     (func.sig.ident.to_string(), FunctionInfo { body })
 }
 
-fn extract_with_option_allow_alter_on_fly(field: &Field) -> bool {
+fn extract_with_option_flag(field: &Field, flag: &str) -> bool {
     field.attrs.iter().any(|attr| {
         if let Meta::List(meta_list) = &attr.meta {
             return meta_list.path.is_ident("with_option")
                 && meta_list.tokens.clone().into_iter().any(|token| {
                     if let TokenTree::Ident(ident) = token {
-                        ident == "allow_alter_on_fly"
+                        ident == flag
                     } else {
                         false
                     }
@@ -481,6 +495,59 @@ fn extract_allow_alter_on_fly_fields_from_yaml(yaml_path: &Path) -> BTreeMap<Str
     }
 
     allow_alter_on_fly_fields
+}
+
+fn extract_iceberg_engine_fields_from_yaml(yaml_path: &Path) -> Vec<String> {
+    let content = fs::read_to_string(yaml_path)
+        .unwrap_or_else(|_| panic!("Failed to read YAML file: {}", yaml_path.display()));
+
+    let yaml_data: BTreeMap<String, YamlStructInfo> = serde_yaml::from_str(&content)
+        .unwrap_or_else(|_| panic!("Failed to parse YAML file: {}", yaml_path.display()));
+
+    yaml_data
+        .get("IcebergConfig")
+        .expect("IcebergConfig must exist in sink WITH options")
+        .fields
+        .iter()
+        .filter(|field| field.iceberg_engine)
+        .flat_map(|field| std::iter::once(&field.name).chain(field.alias.iter()))
+        .cloned()
+        .collect()
+}
+
+fn generate_rust_iceberg_engine_fields_code(fields: Vec<String>) -> String {
+    let fields = fields
+        .iter()
+        .map(|field| format!("    \"{field}\","))
+        .join("\n");
+
+    format!(
+        r#"// Copyright 2026 RisingWave Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// THIS FILE IS AUTO_GENERATED. DO NOT EDIT.
+// UPDATE WITH: ./risedev generate-with-options
+
+pub const ICEBERG_ENGINE_OPTION_KEYS: &[&str] = &[
+{fields}
+];
+
+pub fn is_iceberg_engine_option(key: &str) -> bool {{
+    ICEBERG_ENGINE_OPTION_KEYS.contains(&key)
+}}
+"#
+    )
 }
 
 fn generate_rust_allow_alter_on_fly_fields_code_separate(
@@ -536,9 +603,10 @@ fn generate_rust_allow_alter_on_fly_fields_code_separate(
 // `UPDATE_EXPECT=1`.
 // To update content, change source/sink/connection WITH options definitions (for example,
 // `#[with_option(allow_alter_on_fly)]` on struct fields), then run `./risedev generate-with-options`.
-// `./risedev generate-with-options` runs two UPDATE_EXPECT tests:
+// `./risedev generate-with-options` runs three UPDATE_EXPECT tests:
 // 1) refresh `with_options_{{source,sink,connection}}.yaml`;
-// 2) regenerate this file from those YAML files.
+// 2) regenerate this file from those YAML files;
+// 3) regenerate the Iceberg Engine option classifier.
 
 #![rustfmt::skip]
 

--- a/src/connector/with_options/src/lib.rs
+++ b/src/connector/with_options/src/lib.rs
@@ -56,6 +56,12 @@ use syn::{DeriveInput, parse_macro_input};
 ///     pub endpoint: String,  // not allow_alter_on_fly
 /// }
 /// ```
+///
+/// ### Iceberg Engine fields
+///
+/// Use `#[with_option(iceberg_engine)]` to mark Iceberg sink fields that can be specified
+/// in `CREATE TABLE ... ENGINE = ICEBERG`. The frontend uses the generated field list to route
+/// these options from the table or source properties to the internal Iceberg sink.
 #[proc_macro_derive(WithOptions, attributes(with_option))]
 pub fn derive_helper_attr(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);

--- a/src/connector/with_options_sink.yaml
+++ b/src/connector/with_options_sink.yaml
@@ -679,16 +679,19 @@ IcebergConfig:
     field_type: String
     required: false
     default: Default::default
+    iceberg_engine: true
   - name: order_key
     field_type: String
     required: false
     default: Default::default
+    iceberg_engine: true
   - name: commit_checkpoint_interval
     field_type: u64
     comments: Commit every n(>0) checkpoints, default is 60.
     required: false
     default: ICEBERG_DEFAULT_COMMIT_CHECKPOINT_INTERVAL
     allow_alter_on_fly: true
+    iceberg_engine: true
   - name: create_table_if_not_exists
     field_type: bool
     required: false
@@ -708,28 +711,33 @@ IcebergConfig:
     required: false
     default: Default::default
     allow_alter_on_fly: true
+    iceberg_engine: true
   - name: compaction_interval_sec
     field_type: u64
     comments: The interval of iceberg compaction
     required: false
     default: Default::default
     allow_alter_on_fly: true
+    iceberg_engine: true
   - name: enable_snapshot_expiration
     field_type: bool
     comments: Whether to enable iceberg expired snapshots.
     required: false
     default: 'true'
     allow_alter_on_fly: true
+    iceberg_engine: true
   - name: write_mode
     field_type: IcebergWriteMode
     comments: The iceberg write mode, can be `merge-on-read` or `copy-on-write`.
     required: false
     default: 'IcebergWriteMode :: MergeOnRead'
+    iceberg_engine: true
   - name: format_version
     field_type: FormatVersion
     comments: Iceberg format version for table creation.
     required: false
     default: 'FormatVersion :: V2'
+    iceberg_engine: true
   - name: snapshot_expiration_max_age_millis
     field_type: i64
     comments: |-
@@ -738,40 +746,47 @@ IcebergConfig:
     required: false
     default: Default::default
     allow_alter_on_fly: true
+    iceberg_engine: true
   - name: snapshot_expiration_retain_last
     field_type: i32
     comments: The number of snapshots to retain
     required: false
     default: Default::default
     allow_alter_on_fly: true
+    iceberg_engine: true
   - name: snapshot_expiration_clear_expired_files
     field_type: bool
     required: false
     default: 'true'
     allow_alter_on_fly: true
+    iceberg_engine: true
   - name: snapshot_expiration_clear_expired_meta_data
     field_type: bool
     required: false
     default: 'true'
     allow_alter_on_fly: true
+    iceberg_engine: true
   - name: enable_manifest_rewrite
     field_type: bool
     comments: Whether to periodically rewrite fragmented Iceberg data manifests.
     required: false
     default: Default::default
     allow_alter_on_fly: true
+    iceberg_engine: true
   - name: manifest_rewrite_target_size_bytes
     field_type: u64
     comments: Target size in bytes for rewritten Iceberg data manifests.
     required: false
     default: Default::default
     allow_alter_on_fly: true
+    iceberg_engine: true
   - name: manifest_rewrite_min_count_to_merge
     field_type: usize
     comments: Minimum number of manifests required to rewrite an under-filled batch.
     required: false
     default: Default::default
     allow_alter_on_fly: true
+    iceberg_engine: true
   - name: compaction.max_snapshots_num
     field_type: usize
     comments: |-
@@ -781,26 +796,31 @@ IcebergConfig:
     required: false
     default: Default::default
     allow_alter_on_fly: true
+    iceberg_engine: true
   - name: compaction.small_files_threshold_mb
     field_type: u64
     required: false
     default: Default::default
     allow_alter_on_fly: true
+    iceberg_engine: true
   - name: compaction.delete_files_count_threshold
     field_type: usize
     required: false
     default: Default::default
     allow_alter_on_fly: true
+    iceberg_engine: true
   - name: compaction.trigger_snapshot_count
     field_type: usize
     required: false
     default: Default::default
     allow_alter_on_fly: true
+    iceberg_engine: true
   - name: compaction.target_file_size_mb
     field_type: u64
     required: false
     default: Default::default
     allow_alter_on_fly: true
+    iceberg_engine: true
   - name: compaction.type
     field_type: CompactionType
     comments: |-
@@ -809,6 +829,7 @@ IcebergConfig:
     required: false
     default: Default::default
     allow_alter_on_fly: true
+    iceberg_engine: true
   - name: compaction.write_parquet_compression
     field_type: String
     comments: |-
@@ -818,6 +839,7 @@ IcebergConfig:
     required: false
     default: Default::default
     allow_alter_on_fly: true
+    iceberg_engine: true
   - name: compaction.write_parquet_max_row_group_rows
     field_type: usize
     comments: |-
@@ -826,6 +848,7 @@ IcebergConfig:
     required: false
     default: Default::default
     allow_alter_on_fly: true
+    iceberg_engine: true
   - name: compaction.write_parquet_max_row_group_bytes
     field_type: usize
     comments: |-
@@ -834,6 +857,7 @@ IcebergConfig:
     required: false
     default: Default::default
     allow_alter_on_fly: true
+    iceberg_engine: true
   - name: enable_pk_index
     field_type: bool
     comments: |-
@@ -842,6 +866,7 @@ IcebergConfig:
       position deletes instead of equality deletes.
     required: false
     default: Default::default
+    iceberg_engine: true
 KafkaConfig:
   fields:
   - name: topic

--- a/src/frontend/src/handler/create_table.rs
+++ b/src/frontend/src/handler/create_table.rs
@@ -36,7 +36,6 @@ use risingwave_common::session_config::sink_decouple::SinkDecouple;
 use risingwave_common::util::sort_util::{ColumnOrder, OrderType};
 use risingwave_common::util::value_encoding::DatumToProtoExt;
 use risingwave_common::{bail, bail_not_implemented};
-use risingwave_connector::sink::decouple_checkpoint_log_sink::COMMIT_CHECKPOINT_INTERVAL;
 use risingwave_connector::source::cdc::external::{
     DATABASE_NAME_KEY, ExternalCdcTableType, ExternalTableConfig, ExternalTableImpl,
     SCHEMA_NAME_KEY, SchemaTableName, TABLE_NAME_KEY,
@@ -101,16 +100,8 @@ mod col_id_gen;
 pub use col_id_gen::*;
 use risingwave_connector::sink::SinkParam;
 use risingwave_connector::sink::iceberg::{
-    COMPACTION_DELETE_FILES_COUNT_THRESHOLD, COMPACTION_INTERVAL_SEC, COMPACTION_MAX_SNAPSHOTS_NUM,
-    COMPACTION_SMALL_FILES_THRESHOLD_MB, COMPACTION_TARGET_FILE_SIZE_MB,
-    COMPACTION_TRIGGER_SNAPSHOT_COUNT, COMPACTION_TYPE, COMPACTION_WRITE_PARQUET_COMPRESSION,
-    COMPACTION_WRITE_PARQUET_MAX_ROW_GROUP_BYTES, COMPACTION_WRITE_PARQUET_MAX_ROW_GROUP_ROWS,
-    CompactionType, ENABLE_COMPACTION, ENABLE_PK_INDEX, ENABLE_SNAPSHOT_EXPIRATION, FORMAT_VERSION,
-    ICEBERG_WRITE_MODE_COPY_ON_WRITE, ICEBERG_WRITE_MODE_MERGE_ON_READ, IcebergSink,
-    IcebergWriteMode, ORDER_KEY, SNAPSHOT_EXPIRATION_CLEAR_EXPIRED_FILES,
-    SNAPSHOT_EXPIRATION_CLEAR_EXPIRED_META_DATA, SNAPSHOT_EXPIRATION_MAX_AGE_MILLIS,
-    SNAPSHOT_EXPIRATION_RETAIN_LAST, WRITE_MODE, parse_partition_by_exprs,
-    validate_order_key_columns,
+    ENABLE_COMPACTION, IcebergConfig, IcebergSink, is_iceberg_engine_option,
+    parse_partition_by_exprs, validate_order_key_columns,
 };
 use risingwave_pb::ddl_service::create_iceberg_table_request::{PbSinkJobInfo, PbTableJobInfo};
 
@@ -1782,6 +1773,82 @@ pub async fn handle_create_table(
     Ok(PgResponse::empty_result(StatementType::CREATE_TABLE))
 }
 
+fn build_iceberg_engine_sink_options(
+    mut sink_options: BTreeMap<String, String>,
+    user_options: &WithOptions,
+    table: &TableCatalog,
+    primary_key: &[String],
+) -> Result<BTreeMap<String, String>> {
+    sink_options.extend(
+        user_options
+            .iter()
+            .filter(|(key, _)| is_iceberg_engine_option(key))
+            .map(|(key, value)| (key.clone(), value.clone())),
+    );
+
+    sink_options
+        .entry(ENABLE_COMPACTION.to_owned())
+        .or_insert_with(|| "true".to_owned());
+    sink_options.insert(
+        "type".to_owned(),
+        if table.append_only {
+            "append-only"
+        } else {
+            "upsert"
+        }
+        .to_owned(),
+    );
+
+    // Supply the table primary key while parsing the typed config. In PK-index mode the
+    // planner derives it from the upstream stream key, so it is removed again below.
+    if !table.append_only {
+        sink_options.insert("primary_key".to_owned(), primary_key.join(","));
+    }
+
+    sink_options.insert("create_table_if_not_exists".to_owned(), "true".to_owned());
+    sink_options.insert("is_exactly_once".to_owned(), "true".to_owned());
+
+    let config = IcebergConfig::from_btreemap(sink_options.clone())?;
+
+    if let Some(partition_by) = &config.partition_by {
+        let mut partition_columns = vec![];
+        for (column, _) in parse_partition_by_exprs(partition_by.clone())? {
+            table
+                .columns()
+                .iter()
+                .find(|col| col.name().eq_ignore_ascii_case(&column))
+                .ok_or_else(|| {
+                    ErrorCode::InvalidInputSyntax(format!(
+                        "Partition source column does not exist in schema: {}",
+                        column
+                    ))
+                })?;
+
+            partition_columns.push(column);
+        }
+
+        ensure_partition_columns_are_prefix_of_primary_key(&partition_columns, primary_key)
+            .map_err(|_| {
+                ErrorCode::InvalidInputSyntax(
+                    "The partition columns should be the prefix of the primary key".to_owned(),
+                )
+            })?;
+    }
+
+    if let Some(order_key) = &config.order_key {
+        validate_order_key_columns(order_key, table.columns().iter().map(|col| col.name()))
+            .map_err(|err| ErrorCode::InvalidInputSyntax(err.to_report_string()))?;
+    }
+
+    if config.enable_pk_index {
+        sink_options.remove("primary_key");
+    } else {
+        sink_options.insert(AUTO_SCHEMA_CHANGE_KEY.to_owned(), "true".to_owned());
+    }
+
+    Ok(sink_options)
+}
+
 /// Iceberg table engine is composed of hummock table, iceberg sink and iceberg source.
 ///
 /// 1. fetch iceberg engine options from the meta node. Or use iceberg engine connection provided by users.
@@ -1978,26 +2045,19 @@ pub async fn create_iceberg_engine_table(
 
     let mut sink_handler_args = handler_args.clone();
 
-    let mut sink_with = with_common.clone();
+    let sink_with = build_iceberg_engine_sink_options(
+        with_common.clone(),
+        &handler_args.with_options,
+        &table,
+        &pks,
+    )?;
 
-    let enable_pk_index = handler_args
-        .with_options
-        .get(ENABLE_PK_INDEX)
-        .is_some_and(|val| val.eq_ignore_ascii_case("true"));
-
-    // Iceberg with pk index does not support auto schema change yet.
-    if !enable_pk_index {
-        sink_with.insert(AUTO_SCHEMA_CHANGE_KEY.to_owned(), "true".to_owned());
+    if let Some(source) = source.as_mut() {
+        source
+            .with_properties
+            .retain(|key, _| !is_iceberg_engine_option(key));
     }
 
-    if table.append_only {
-        sink_with.insert("type".to_owned(), "append-only".to_owned());
-    } else {
-        sink_with.insert("type".to_owned(), "upsert".to_owned());
-        if !enable_pk_index {
-            sink_with.insert("primary_key".to_owned(), pks.join(","));
-        }
-    }
     // sink_with.insert(SINK_SNAPSHOT_OPTION.to_owned(), "false".to_owned());
     //
     // Note: in theory, we don't need to backfill from the table to the sink,
@@ -2016,541 +2076,6 @@ pub async fn create_iceberg_engine_table(
     // - For table with an upstream job: Specifically, CDC table from shared CDC source.
     //   + Data may come from both upstream connector, and CDC table backfill, so we need to pause both of them.
     //   + For now we don't support APPEND ONLY CDC table, so it's safe.
-    let commit_checkpoint_interval = handler_args
-        .with_options
-        .get(COMMIT_CHECKPOINT_INTERVAL)
-        .map(|v| v.to_owned())
-        .unwrap_or_else(|| "60".to_owned());
-    let commit_checkpoint_interval = commit_checkpoint_interval.parse::<u32>().map_err(|_| {
-        ErrorCode::InvalidInputSyntax(format!(
-            "commit_checkpoint_interval must be greater than 0: {}",
-            commit_checkpoint_interval
-        ))
-    })?;
-
-    if commit_checkpoint_interval == 0 {
-        bail!("commit_checkpoint_interval must be greater than 0");
-    }
-
-    // remove commit_checkpoint_interval from source options, otherwise it will be considered as an unknown field.
-    source
-        .as_mut()
-        .map(|x| x.with_properties.remove(COMMIT_CHECKPOINT_INTERVAL));
-
-    let sink_decouple = session.config().sink_decouple();
-    if matches!(sink_decouple, SinkDecouple::Disable) && commit_checkpoint_interval > 1 {
-        bail!(
-            "config conflict: `commit_checkpoint_interval` larger than 1 means that sink decouple must be enabled, but session config sink_decouple is disabled"
-        )
-    }
-
-    sink_with.insert(
-        COMMIT_CHECKPOINT_INTERVAL.to_owned(),
-        commit_checkpoint_interval.to_string(),
-    );
-    sink_with.insert("create_table_if_not_exists".to_owned(), "true".to_owned());
-
-    sink_with.insert("is_exactly_once".to_owned(), "true".to_owned());
-
-    if let Some(enable_compaction) = handler_args.with_options.get(ENABLE_COMPACTION) {
-        match enable_compaction.to_lowercase().as_str() {
-            "true" => {
-                sink_with.insert(ENABLE_COMPACTION.to_owned(), "true".to_owned());
-            }
-            "false" => {
-                sink_with.insert(ENABLE_COMPACTION.to_owned(), "false".to_owned());
-            }
-            _ => {
-                return Err(ErrorCode::InvalidInputSyntax(format!(
-                    "enable_compaction must be true or false: {}",
-                    enable_compaction
-                ))
-                .into());
-            }
-        }
-
-        // remove enable_compaction from source options, otherwise it will be considered as an unknown field.
-        source
-            .as_mut()
-            .map(|x| x.with_properties.remove("enable_compaction"));
-    } else {
-        sink_with.insert(ENABLE_COMPACTION.to_owned(), "true".to_owned());
-    }
-
-    if let Some(compaction_interval_sec) = handler_args.with_options.get(COMPACTION_INTERVAL_SEC) {
-        let compaction_interval_sec = compaction_interval_sec.parse::<u64>().map_err(|_| {
-            ErrorCode::InvalidInputSyntax(format!(
-                "compaction_interval_sec must be greater than 0: {}",
-                commit_checkpoint_interval
-            ))
-        })?;
-        if compaction_interval_sec == 0 {
-            bail!("compaction_interval_sec must be greater than 0");
-        }
-        sink_with.insert(
-            "compaction_interval_sec".to_owned(),
-            compaction_interval_sec.to_string(),
-        );
-        // remove compaction_interval_sec from source options, otherwise it will be considered as an unknown field.
-        source
-            .as_mut()
-            .map(|x| x.with_properties.remove("compaction_interval_sec"));
-    }
-
-    let has_enabled_snapshot_expiration = if let Some(enable_snapshot_expiration) =
-        handler_args.with_options.get(ENABLE_SNAPSHOT_EXPIRATION)
-    {
-        // remove enable_snapshot_expiration from source options, otherwise it will be considered as an unknown field.
-        source
-            .as_mut()
-            .map(|x| x.with_properties.remove(ENABLE_SNAPSHOT_EXPIRATION));
-        match enable_snapshot_expiration.to_lowercase().as_str() {
-            "true" => {
-                sink_with.insert(ENABLE_SNAPSHOT_EXPIRATION.to_owned(), "true".to_owned());
-                true
-            }
-            "false" => {
-                sink_with.insert(ENABLE_SNAPSHOT_EXPIRATION.to_owned(), "false".to_owned());
-                false
-            }
-            _ => {
-                return Err(ErrorCode::InvalidInputSyntax(format!(
-                    "enable_snapshot_expiration must be true or false: {}",
-                    enable_snapshot_expiration
-                ))
-                .into());
-            }
-        }
-    } else {
-        sink_with.insert(ENABLE_SNAPSHOT_EXPIRATION.to_owned(), "true".to_owned());
-        true
-    };
-
-    if has_enabled_snapshot_expiration {
-        // configuration for snapshot expiration
-        if let Some(snapshot_expiration_retain_last) = handler_args
-            .with_options
-            .get(SNAPSHOT_EXPIRATION_RETAIN_LAST)
-        {
-            sink_with.insert(
-                SNAPSHOT_EXPIRATION_RETAIN_LAST.to_owned(),
-                snapshot_expiration_retain_last.to_owned(),
-            );
-            // remove snapshot_expiration_retain_last from source options, otherwise it will be considered as an unknown field.
-            source
-                .as_mut()
-                .map(|x| x.with_properties.remove(SNAPSHOT_EXPIRATION_RETAIN_LAST));
-        }
-
-        if let Some(snapshot_expiration_max_age) = handler_args
-            .with_options
-            .get(SNAPSHOT_EXPIRATION_MAX_AGE_MILLIS)
-        {
-            sink_with.insert(
-                SNAPSHOT_EXPIRATION_MAX_AGE_MILLIS.to_owned(),
-                snapshot_expiration_max_age.to_owned(),
-            );
-            // remove snapshot_expiration_max_age from source options, otherwise it will be considered as an unknown field.
-            source
-                .as_mut()
-                .map(|x| x.with_properties.remove(SNAPSHOT_EXPIRATION_MAX_AGE_MILLIS));
-        }
-
-        if let Some(snapshot_expiration_clear_expired_files) = handler_args
-            .with_options
-            .get(SNAPSHOT_EXPIRATION_CLEAR_EXPIRED_FILES)
-        {
-            sink_with.insert(
-                SNAPSHOT_EXPIRATION_CLEAR_EXPIRED_FILES.to_owned(),
-                snapshot_expiration_clear_expired_files.to_owned(),
-            );
-            // remove snapshot_expiration_clear_expired_files from source options, otherwise it will be considered as an unknown field.
-            source.as_mut().map(|x| {
-                x.with_properties
-                    .remove(SNAPSHOT_EXPIRATION_CLEAR_EXPIRED_FILES)
-            });
-        }
-
-        if let Some(snapshot_expiration_clear_expired_meta_data) = handler_args
-            .with_options
-            .get(SNAPSHOT_EXPIRATION_CLEAR_EXPIRED_META_DATA)
-        {
-            sink_with.insert(
-                SNAPSHOT_EXPIRATION_CLEAR_EXPIRED_META_DATA.to_owned(),
-                snapshot_expiration_clear_expired_meta_data.to_owned(),
-            );
-            // remove snapshot_expiration_clear_expired_meta_data from source options, otherwise it will be considered as an unknown field.
-            source.as_mut().map(|x| {
-                x.with_properties
-                    .remove(SNAPSHOT_EXPIRATION_CLEAR_EXPIRED_META_DATA)
-            });
-        }
-    }
-
-    if let Some(format_version) = handler_args.with_options.get(FORMAT_VERSION) {
-        let format_version = format_version.parse::<u8>().map_err(|_| {
-            ErrorCode::InvalidInputSyntax(format!(
-                "format_version must be 1, 2 or 3: {}",
-                format_version
-            ))
-        })?;
-        if format_version != 1 && format_version != 2 && format_version != 3 {
-            bail!("format_version must be 1, 2 or 3");
-        }
-        sink_with.insert(FORMAT_VERSION.to_owned(), format_version.to_string());
-
-        // remove format_version from source options, otherwise it will be considered as an unknown field.
-        source
-            .as_mut()
-            .map(|x| x.with_properties.remove(FORMAT_VERSION));
-    }
-
-    if let Some(write_mode) = handler_args.with_options.get(WRITE_MODE) {
-        let write_mode = IcebergWriteMode::try_from(write_mode.as_str()).map_err(|_| {
-            ErrorCode::InvalidInputSyntax(format!(
-                "invalid write_mode: {}, must be one of: {}, {}",
-                write_mode, ICEBERG_WRITE_MODE_MERGE_ON_READ, ICEBERG_WRITE_MODE_COPY_ON_WRITE
-            ))
-        })?;
-
-        match write_mode {
-            IcebergWriteMode::MergeOnRead => {
-                sink_with.insert(WRITE_MODE.to_owned(), write_mode.as_str().to_owned());
-            }
-
-            IcebergWriteMode::CopyOnWrite => {
-                if table.append_only {
-                    return Err(ErrorCode::NotSupported(
-                        "COPY ON WRITE is not supported for append-only iceberg table".to_owned(),
-                        "Please use MERGE ON READ instead".to_owned(),
-                    )
-                    .into());
-                }
-
-                sink_with.insert(WRITE_MODE.to_owned(), write_mode.as_str().to_owned());
-            }
-        }
-
-        // remove write_mode from source options, otherwise it will be considered as an unknown field.
-        source
-            .as_mut()
-            .map(|x| x.with_properties.remove("write_mode"));
-    } else {
-        sink_with.insert(
-            WRITE_MODE.to_owned(),
-            ICEBERG_WRITE_MODE_MERGE_ON_READ.to_owned(),
-        );
-    }
-
-    if let Some(enable_pk_index) = handler_args.with_options.get(ENABLE_PK_INDEX) {
-        match enable_pk_index.to_lowercase().as_str() {
-            "true" => {
-                sink_with.insert(ENABLE_PK_INDEX.to_owned(), "true".to_owned());
-            }
-            "false" => {
-                sink_with.insert(ENABLE_PK_INDEX.to_owned(), "false".to_owned());
-            }
-            _ => {
-                return Err(ErrorCode::InvalidInputSyntax(format!(
-                    "enable_pk_index must be true or false: {}",
-                    enable_pk_index
-                ))
-                .into());
-            }
-        }
-
-        // remove enable_pk_index from source options, otherwise it will be considered as an unknown field.
-        source
-            .as_mut()
-            .map(|x| x.with_properties.remove(ENABLE_PK_INDEX));
-    }
-
-    if let Some(max_snapshots_num_before_compaction) =
-        handler_args.with_options.get(COMPACTION_MAX_SNAPSHOTS_NUM)
-    {
-        let max_snapshots_num_before_compaction = max_snapshots_num_before_compaction
-            .parse::<u32>()
-            .map_err(|_| {
-                ErrorCode::InvalidInputSyntax(format!(
-                    "{} must be greater than 0: {}",
-                    COMPACTION_MAX_SNAPSHOTS_NUM, max_snapshots_num_before_compaction
-                ))
-            })?;
-
-        if max_snapshots_num_before_compaction == 0 {
-            bail!(format!(
-                "{} must be greater than 0",
-                COMPACTION_MAX_SNAPSHOTS_NUM
-            ));
-        }
-
-        sink_with.insert(
-            COMPACTION_MAX_SNAPSHOTS_NUM.to_owned(),
-            max_snapshots_num_before_compaction.to_string(),
-        );
-
-        // remove from source options, otherwise it will be considered as an unknown field.
-        source
-            .as_mut()
-            .map(|x| x.with_properties.remove(COMPACTION_MAX_SNAPSHOTS_NUM));
-    }
-
-    if let Some(small_files_threshold_mb) = handler_args
-        .with_options
-        .get(COMPACTION_SMALL_FILES_THRESHOLD_MB)
-    {
-        let small_files_threshold_mb = small_files_threshold_mb.parse::<u64>().map_err(|_| {
-            ErrorCode::InvalidInputSyntax(format!(
-                "{} must be greater than 0: {}",
-                COMPACTION_SMALL_FILES_THRESHOLD_MB, small_files_threshold_mb
-            ))
-        })?;
-        if small_files_threshold_mb == 0 {
-            bail!(format!(
-                "{} must be a greater than 0",
-                COMPACTION_SMALL_FILES_THRESHOLD_MB
-            ));
-        }
-        sink_with.insert(
-            COMPACTION_SMALL_FILES_THRESHOLD_MB.to_owned(),
-            small_files_threshold_mb.to_string(),
-        );
-
-        // remove from source options, otherwise it will be considered as an unknown field.
-        source.as_mut().map(|x| {
-            x.with_properties
-                .remove(COMPACTION_SMALL_FILES_THRESHOLD_MB)
-        });
-    }
-
-    if let Some(delete_files_count_threshold) = handler_args
-        .with_options
-        .get(COMPACTION_DELETE_FILES_COUNT_THRESHOLD)
-    {
-        let delete_files_count_threshold =
-            delete_files_count_threshold.parse::<usize>().map_err(|_| {
-                ErrorCode::InvalidInputSyntax(format!(
-                    "{} must be greater than 0: {}",
-                    COMPACTION_DELETE_FILES_COUNT_THRESHOLD, delete_files_count_threshold
-                ))
-            })?;
-        if delete_files_count_threshold == 0 {
-            bail!(format!(
-                "{} must be greater than 0",
-                COMPACTION_DELETE_FILES_COUNT_THRESHOLD
-            ));
-        }
-        sink_with.insert(
-            COMPACTION_DELETE_FILES_COUNT_THRESHOLD.to_owned(),
-            delete_files_count_threshold.to_string(),
-        );
-
-        // remove from source options, otherwise it will be considered as an unknown field.
-        source.as_mut().map(|x| {
-            x.with_properties
-                .remove(COMPACTION_DELETE_FILES_COUNT_THRESHOLD)
-        });
-    }
-
-    if let Some(trigger_snapshot_count) = handler_args
-        .with_options
-        .get(COMPACTION_TRIGGER_SNAPSHOT_COUNT)
-    {
-        let trigger_snapshot_count = trigger_snapshot_count.parse::<usize>().map_err(|_| {
-            ErrorCode::InvalidInputSyntax(format!(
-                "{} must be greater than 0: {}",
-                COMPACTION_TRIGGER_SNAPSHOT_COUNT, trigger_snapshot_count
-            ))
-        })?;
-        if trigger_snapshot_count == 0 {
-            bail!(format!(
-                "{} must be greater than 0",
-                COMPACTION_TRIGGER_SNAPSHOT_COUNT
-            ));
-        }
-        sink_with.insert(
-            COMPACTION_TRIGGER_SNAPSHOT_COUNT.to_owned(),
-            trigger_snapshot_count.to_string(),
-        );
-
-        // remove from source options, otherwise it will be considered as an unknown field.
-        source
-            .as_mut()
-            .map(|x| x.with_properties.remove(COMPACTION_TRIGGER_SNAPSHOT_COUNT));
-    }
-
-    if let Some(target_file_size_mb) = handler_args
-        .with_options
-        .get(COMPACTION_TARGET_FILE_SIZE_MB)
-    {
-        let target_file_size_mb = target_file_size_mb.parse::<u64>().map_err(|_| {
-            ErrorCode::InvalidInputSyntax(format!(
-                "{} must be greater than 0: {}",
-                COMPACTION_TARGET_FILE_SIZE_MB, target_file_size_mb
-            ))
-        })?;
-        if target_file_size_mb == 0 {
-            bail!(format!(
-                "{} must be greater than 0",
-                COMPACTION_TARGET_FILE_SIZE_MB
-            ));
-        }
-        sink_with.insert(
-            COMPACTION_TARGET_FILE_SIZE_MB.to_owned(),
-            target_file_size_mb.to_string(),
-        );
-        // remove from source options, otherwise it will be considered as an unknown field.
-        source
-            .as_mut()
-            .map(|x| x.with_properties.remove(COMPACTION_TARGET_FILE_SIZE_MB));
-    }
-
-    if let Some(compaction_type) = handler_args.with_options.get(COMPACTION_TYPE) {
-        let compaction_type = CompactionType::try_from(compaction_type.as_str()).map_err(|_| {
-            ErrorCode::InvalidInputSyntax(format!(
-                "invalid compaction_type: {}, must be one of {:?}",
-                compaction_type,
-                [
-                    CompactionType::Full,
-                    CompactionType::SmallFiles,
-                    CompactionType::FilesWithDelete
-                ]
-            ))
-        })?;
-
-        sink_with.insert(
-            COMPACTION_TYPE.to_owned(),
-            compaction_type.as_str().to_owned(),
-        );
-
-        // remove from source options, otherwise it will be considered as an unknown field.
-        source
-            .as_mut()
-            .map(|x| x.with_properties.remove(COMPACTION_TYPE));
-    }
-
-    if let Some(write_parquet_compression) = handler_args
-        .with_options
-        .get(COMPACTION_WRITE_PARQUET_COMPRESSION)
-    {
-        sink_with.insert(
-            COMPACTION_WRITE_PARQUET_COMPRESSION.to_owned(),
-            write_parquet_compression.to_owned(),
-        );
-        // remove from source options, otherwise it will be considered as an unknown field.
-        source.as_mut().map(|x| {
-            x.with_properties
-                .remove(COMPACTION_WRITE_PARQUET_COMPRESSION)
-        });
-    }
-
-    if let Some(write_parquet_max_row_group_rows) = handler_args
-        .with_options
-        .get(COMPACTION_WRITE_PARQUET_MAX_ROW_GROUP_ROWS)
-    {
-        let write_parquet_max_row_group_rows = write_parquet_max_row_group_rows
-            .parse::<usize>()
-            .map_err(|_| {
-                ErrorCode::InvalidInputSyntax(format!(
-                    "{} must be a positive integer: {}",
-                    COMPACTION_WRITE_PARQUET_MAX_ROW_GROUP_ROWS, write_parquet_max_row_group_rows
-                ))
-            })?;
-        if write_parquet_max_row_group_rows == 0 {
-            bail!(format!(
-                "{} must be greater than 0",
-                COMPACTION_WRITE_PARQUET_MAX_ROW_GROUP_ROWS
-            ));
-        }
-        sink_with.insert(
-            COMPACTION_WRITE_PARQUET_MAX_ROW_GROUP_ROWS.to_owned(),
-            write_parquet_max_row_group_rows.to_string(),
-        );
-        // remove from source options, otherwise it will be considered as an unknown field.
-        source.as_mut().map(|x| {
-            x.with_properties
-                .remove(COMPACTION_WRITE_PARQUET_MAX_ROW_GROUP_ROWS)
-        });
-    }
-
-    if let Some(write_parquet_max_row_group_bytes) = handler_args
-        .with_options
-        .get(COMPACTION_WRITE_PARQUET_MAX_ROW_GROUP_BYTES)
-    {
-        let write_parquet_max_row_group_bytes = write_parquet_max_row_group_bytes
-            .parse::<usize>()
-            .map_err(|_| {
-                ErrorCode::InvalidInputSyntax(format!(
-                    "{} must be a positive integer: {}",
-                    COMPACTION_WRITE_PARQUET_MAX_ROW_GROUP_BYTES, write_parquet_max_row_group_bytes
-                ))
-            })?;
-        if write_parquet_max_row_group_bytes == 0 {
-            bail!(format!(
-                "{} must be greater than 0",
-                COMPACTION_WRITE_PARQUET_MAX_ROW_GROUP_BYTES
-            ));
-        }
-        sink_with.insert(
-            COMPACTION_WRITE_PARQUET_MAX_ROW_GROUP_BYTES.to_owned(),
-            write_parquet_max_row_group_bytes.to_string(),
-        );
-        source.as_mut().map(|x| {
-            x.with_properties
-                .remove(COMPACTION_WRITE_PARQUET_MAX_ROW_GROUP_BYTES)
-        });
-    }
-
-    let partition_by = handler_args
-        .with_options
-        .get("partition_by")
-        .map(|v| v.to_owned());
-
-    if let Some(partition_by) = &partition_by {
-        let mut partition_columns = vec![];
-        for (column, _) in parse_partition_by_exprs(partition_by.clone())? {
-            table
-                .columns()
-                .iter()
-                .find(|col| col.name().eq_ignore_ascii_case(&column))
-                .ok_or_else(|| {
-                    ErrorCode::InvalidInputSyntax(format!(
-                        "Partition source column does not exist in schema: {}",
-                        column
-                    ))
-                })?;
-
-            partition_columns.push(column);
-        }
-
-        ensure_partition_columns_are_prefix_of_primary_key(&partition_columns, &pks).map_err(
-            |_| {
-                ErrorCode::InvalidInputSyntax(
-                    "The partition columns should be the prefix of the primary key".to_owned(),
-                )
-            },
-        )?;
-
-        sink_with.insert("partition_by".to_owned(), partition_by.to_owned());
-
-        // remove partition_by from source options, otherwise it will be considered as an unknown field.
-        source
-            .as_mut()
-            .map(|x| x.with_properties.remove("partition_by"));
-    }
-
-    let order_key = handler_args
-        .with_options
-        .get(ORDER_KEY)
-        .map(|v| v.to_owned());
-    if let Some(order_key) = &order_key {
-        validate_order_key_columns(order_key, table.columns().iter().map(|col| col.name()))
-            .map_err(|err| ErrorCode::InvalidInputSyntax(err.to_report_string()))?;
-
-        sink_with.insert(ORDER_KEY.to_owned(), order_key.to_owned());
-
-        source.as_mut().map(|x| x.with_properties.remove(ORDER_KEY));
-    }
 
     sink_handler_args.with_options =
         WithOptions::new(sink_with, Default::default(), connection_ref.clone());


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What changed and why

- Add `#[with_option(iceberg_engine)]` metadata to Iceberg sink fields that users may configure through `CREATE TABLE ... ENGINE = ICEBERG`.
- Generate the Iceberg Engine option classifier from the existing WITH-option schema, keeping the routing list colocated with `IcebergConfig`.
- Replace the frontend manual copy, parse, default, and removal logic with one generated whitelist and `IcebergConfig::from_btreemap` validation.
- Keep Engine-derived properties such as sink type, primary key, table identity, exactly-once mode, and auto schema change under frontend control.
- Move the positive-value checks previously enforced only by the Engine frontend into the typed Iceberg config, and add regression coverage.
- Route the manifest rewrite settings through the same Engine option path.

This removes roughly 560 lines of duplicated option handling from `create_iceberg_engine_table` and makes future Engine option changes originate from the Iceberg config definition.

Related to #21586.

## Checklist

- [x] I have written necessary rustdoc comments.
- [x] I have added necessary unit tests.
- [x] I have added test labels as necessary.
- [ ] My PR contains breaking changes.
- [ ] My PR changes performance-critical code.

## Documentation

- [x] My PR needs documentation updates.

<details>
<summary><b>Release note</b></summary>

Iceberg Engine table options now share the Iceberg sink configuration schema. Engine tables can also configure manifest rewrite settings through their `WITH` clause.

</details>