### PR TITLE
feat(meta): backport DDL resource groups and hummock reliability improvements to release-2.8

### DIFF
--- a/e2e_test/ddl/alter_resource_group.slt
+++ b/e2e_test/ddl/alter_resource_group.slt
@@ -13,6 +13,60 @@ create materialized view m2 with ( resource_group = 'default' ) as select * from
 statement ok
 alter materialized view m1 set resource_group to default;
 
+statement ok
+create index idx_resource_group on t(v);
+
+statement ok
+alter index idx_resource_group set resource_group to default;
+
+query T
+select resource_group from rw_streaming_jobs where name = 'idx_resource_group';
+----
+default
+
+statement ok
+alter index idx_resource_group set resource_group to test deferred;
+
+query T
+select resource_group from rw_streaming_jobs where name = 'idx_resource_group';
+----
+test
+
+statement ok
+alter index idx_resource_group reset resource_group deferred;
+
+query T
+select resource_group from rw_streaming_jobs where name = 'idx_resource_group';
+----
+default
+
+statement ok
+create sink s_resource_group as select * from t with (connector = 'blackhole');
+
+statement ok
+alter sink s_resource_group set resource_group = default;
+
+query T
+select resource_group from rw_streaming_jobs where name = 's_resource_group';
+----
+default
+
+statement ok
+alter sink s_resource_group set resource_group = test deferred;
+
+query T
+select resource_group from rw_streaming_jobs where name = 's_resource_group';
+----
+test
+
+statement ok
+alter sink s_resource_group reset resource_group deferred;
+
+query T
+select resource_group from rw_streaming_jobs where name = 's_resource_group';
+----
+default
+
 
 statement ok
 alter system set license_key to '';

--- a/e2e_test/ddl/alter_resource_group.slt
+++ b/e2e_test/ddl/alter_resource_group.slt
@@ -25,14 +25,6 @@ select resource_group from rw_streaming_jobs where name = 'idx_resource_group';
 default
 
 statement ok
-alter index idx_resource_group set resource_group to test deferred;
-
-query T
-select resource_group from rw_streaming_jobs where name = 'idx_resource_group';
-----
-test
-
-statement ok
 alter index idx_resource_group reset resource_group deferred;
 
 query T
@@ -50,14 +42,6 @@ query T
 select resource_group from rw_streaming_jobs where name = 's_resource_group';
 ----
 default
-
-statement ok
-alter sink s_resource_group set resource_group = test deferred;
-
-query T
-select resource_group from rw_streaming_jobs where name = 's_resource_group';
-----
-test
 
 statement ok
 alter sink s_resource_group reset resource_group deferred;

--- a/e2e_test/ddl/database.slt
+++ b/e2e_test/ddl/database.slt
@@ -63,6 +63,30 @@ select resource_group from rw_databases where name = 'db_with_resource_group';
 test
 
 statement ok
+alter database db_with_resource_group set resource_group to default deferred;
+
+query T
+select resource_group from rw_databases where name = 'db_with_resource_group';
+----
+default
+
+statement ok
+alter database db_with_resource_group set resource_group = test deferred;
+
+query T
+select resource_group from rw_databases where name = 'db_with_resource_group';
+----
+test
+
+statement ok
+alter database db_with_resource_group reset resource_group deferred;
+
+query T
+select resource_group from rw_databases where name = 'db_with_resource_group';
+----
+default
+
+statement ok
 drop database db_with_resource_group;
 
 statement ok

--- a/e2e_test/ddl/serverless_backfill.slt
+++ b/e2e_test/ddl/serverless_backfill.slt
@@ -4,5 +4,16 @@ create table t(id int, name string);
 statement error Serverless Backfill is disabled
 create materialized view serverless_backfill_mv with (cloud.serverless_backfill_enabled = true) as select * from t;
 
+statement error Serverless Backfill is disabled
+create sink serverless_backfill_sink as select * from t with (
+    connector = 'blackhole',
+    cloud.serverless_backfill_enabled = true
+);
+
+statement error Serverless Backfill is disabled
+create index serverless_backfill_idx on t(id) with (
+    cloud.serverless_backfill_enabled = true
+);
+
 statement ok
 drop table t;

--- a/proto/ddl_service.proto
+++ b/proto/ddl_service.proto
@@ -343,12 +343,23 @@ message AlterCdcTableBackfillParallelismRequest {
 message AlterCdcTableBackfillParallelismResponse {}
 
 message AlterResourceGroupRequest {
-  uint32 table_id = 1;
+  uint32 job_id = 1;
   optional string resource_group = 2;
   bool deferred = 3;
 }
 
 message AlterResourceGroupResponse {}
+
+message AlterDatabaseResourceGroupRequest {
+  uint32 database_id = 1;
+  optional string resource_group = 2;
+  bool deferred = 3;
+}
+
+message AlterDatabaseResourceGroupResponse {
+  common.Status status = 1;
+  WaitVersion version = 2;
+}
 
 message AlterOwnerResponse {
   common.Status status = 1;
@@ -702,6 +713,7 @@ service DdlService {
   rpc AlterParallelism(AlterParallelismRequest) returns (AlterParallelismResponse);
   rpc AlterFragmentParallelism(AlterFragmentParallelismRequest) returns (AlterFragmentParallelismResponse);
   rpc AlterResourceGroup(AlterResourceGroupRequest) returns (AlterResourceGroupResponse);
+  rpc AlterDatabaseResourceGroup(AlterDatabaseResourceGroupRequest) returns (AlterDatabaseResourceGroupResponse);
   rpc DropTable(DropTableRequest) returns (DropTableResponse);
   rpc RisectlListStateTables(RisectlListStateTablesRequest) returns (RisectlListStateTablesResponse);
   rpc RisectlResumeBackfill(RisectlResumeBackfillRequest) returns (RisectlResumeBackfillResponse);

--- a/proto/ddl_service.proto
+++ b/proto/ddl_service.proto
@@ -103,6 +103,7 @@ message CreateSinkRequest {
   // The list of object IDs that this sink depends on.
   repeated uint32 dependencies = 4;
   bool if_not_exists = 5;
+  StreamingJobResourceType resource_type = 6;
 }
 
 message CreateSinkResponse {
@@ -430,6 +431,7 @@ message CreateIndexRequest {
   catalog.Table index_table = 2;
   stream_plan.StreamFragmentGraph fragment_graph = 3;
   bool if_not_exists = 4;
+  StreamingJobResourceType resource_type = 5;
 }
 
 message CreateIndexResponse {

--- a/src/common/metrics/src/monitor/rwlock.rs
+++ b/src/common/metrics/src/monitor/rwlock.rs
@@ -12,38 +12,115 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use prometheus::HistogramVec;
+use std::ops::{Deref, DerefMut};
+use std::time::Instant;
+
+use prometheus::{Histogram, HistogramVec};
 use tokio::sync::{RwLock, RwLockReadGuard, RwLockWriteGuard};
+
+const UNNAMED_PROCESS: &str = "unnamed";
 
 pub struct MonitoredRwLock<T> {
     // labels: [lock_name, lock_type]
     metrics: HistogramVec,
+    // labels: [method, lock_name]
+    process_metrics: HistogramVec,
     inner: RwLock<T>,
     lock_name: &'static str,
 }
 
 impl<T> MonitoredRwLock<T> {
-    pub fn new(metrics: HistogramVec, val: T, lock_name: &'static str) -> Self {
+    pub fn new(
+        metrics: HistogramVec,
+        process_metrics: HistogramVec,
+        val: T,
+        lock_name: &'static str,
+    ) -> Self {
         Self {
             metrics,
+            process_metrics,
             inner: RwLock::new(val),
             lock_name,
         }
     }
 
-    pub async fn read(&self) -> RwLockReadGuard<'_, T> {
+    pub async fn read(&self) -> MonitoredRwLockGuard<RwLockReadGuard<'_, T>> {
+        self.read_with_process_name(UNNAMED_PROCESS).await
+    }
+
+    pub async fn write(&self) -> MonitoredRwLockGuard<RwLockWriteGuard<'_, T>> {
+        self.write_with_process_name(UNNAMED_PROCESS).await
+    }
+
+    pub async fn read_with_process_name(
+        &self,
+        func_name: &'static str,
+    ) -> MonitoredRwLockGuard<RwLockReadGuard<'_, T>> {
         let _timer = self
             .metrics
             .with_label_values(&[self.lock_name, "read"])
             .start_timer();
-        self.inner.read().await
+        let guard = self.inner.read().await;
+        MonitoredRwLockGuard::new(guard, self.process_metric(func_name))
     }
 
-    pub async fn write(&self) -> RwLockWriteGuard<'_, T> {
+    pub async fn write_with_process_name(
+        &self,
+        func_name: &'static str,
+    ) -> MonitoredRwLockGuard<RwLockWriteGuard<'_, T>> {
         let _timer = self
             .metrics
             .with_label_values(&[self.lock_name, "write"])
             .start_timer();
-        self.inner.write().await
+        let guard = self.inner.write().await;
+        MonitoredRwLockGuard::new(guard, self.process_metric(func_name))
+    }
+
+    fn process_metric(&self, func_name: &'static str) -> Histogram {
+        self.process_metrics
+            .with_label_values(&[func_name, self.lock_name])
+    }
+}
+
+pub struct MonitoredRwLockGuard<G> {
+    guard: G,
+    process_metric: Histogram,
+    process_start: Instant,
+}
+
+impl<G> MonitoredRwLockGuard<G> {
+    fn new(guard: G, process_metric: Histogram) -> Self {
+        Self {
+            guard,
+            process_metric,
+            process_start: Instant::now(),
+        }
+    }
+}
+
+impl<G> Deref for MonitoredRwLockGuard<G>
+where
+    G: Deref,
+{
+    type Target = G::Target;
+
+    fn deref(&self) -> &Self::Target {
+        &self.guard
+    }
+}
+
+impl<G> DerefMut for MonitoredRwLockGuard<G>
+where
+    G: DerefMut,
+{
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.guard
+    }
+}
+
+impl<G> Drop for MonitoredRwLockGuard<G> {
+    fn drop(&mut self) {
+        self.process_metric
+            .observe(self.process_start.elapsed().as_secs_f64());
     }
 }

--- a/src/frontend/src/catalog/catalog_service.rs
+++ b/src/frontend/src/catalog/catalog_service.rs
@@ -128,6 +128,7 @@ pub trait CatalogWriter: Send + Sync {
         index: PbIndex,
         table: PbTable,
         graph: StreamFragmentGraph,
+        resource_type: streaming_job_resource_type::ResourceType,
         if_not_exists: bool,
     ) -> Result<()>;
 
@@ -143,6 +144,7 @@ pub trait CatalogWriter: Send + Sync {
         sink: PbSink,
         graph: StreamFragmentGraph,
         dependencies: HashSet<ObjectId>,
+        resource_type: streaming_job_resource_type::ResourceType,
         if_not_exists: bool,
     ) -> Result<()>;
 
@@ -368,11 +370,12 @@ impl CatalogWriter for CatalogWriterImpl {
         index: PbIndex,
         table: PbTable,
         graph: StreamFragmentGraph,
+        resource_type: streaming_job_resource_type::ResourceType,
         if_not_exists: bool,
     ) -> Result<()> {
         let version = self
             .meta_client
-            .create_index(index, table, graph, if_not_exists)
+            .create_index(index, table, graph, resource_type, if_not_exists)
             .await?;
         self.wait_version(version).await
     }
@@ -445,11 +448,12 @@ impl CatalogWriter for CatalogWriterImpl {
         sink: PbSink,
         graph: StreamFragmentGraph,
         dependencies: HashSet<ObjectId>,
+        resource_type: streaming_job_resource_type::ResourceType,
         if_not_exists: bool,
     ) -> Result<()> {
         let version = self
             .meta_client
-            .create_sink(sink, graph, dependencies, if_not_exists)
+            .create_sink(sink, graph, dependencies, resource_type, if_not_exists)
             .await?;
         self.wait_version(version).await
     }

--- a/src/frontend/src/catalog/catalog_service.rs
+++ b/src/frontend/src/catalog/catalog_service.rs
@@ -241,7 +241,14 @@ pub trait CatalogWriter: Send + Sync {
 
     async fn alter_resource_group(
         &self,
-        table_id: TableId,
+        job_id: JobId,
+        resource_group: Option<String>,
+        deferred: bool,
+    ) -> Result<()>;
+
+    async fn alter_database_resource_group(
+        &self,
+        database_id: DatabaseId,
         resource_group: Option<String>,
         deferred: bool,
     ) -> Result<()>;
@@ -680,16 +687,30 @@ impl CatalogWriter for CatalogWriterImpl {
 
     async fn alter_resource_group(
         &self,
-        table_id: TableId,
+        job_id: JobId,
         resource_group: Option<String>,
         deferred: bool,
     ) -> Result<()> {
         self.meta_client
-            .alter_resource_group(table_id, resource_group, deferred)
+            .alter_resource_group(job_id, resource_group, deferred)
             .await
             .map_err(|e| anyhow!(e))?;
 
         Ok(())
+    }
+
+    async fn alter_database_resource_group(
+        &self,
+        database_id: DatabaseId,
+        resource_group: Option<String>,
+        deferred: bool,
+    ) -> Result<()> {
+        let version = self
+            .meta_client
+            .alter_database_resource_group(database_id, resource_group, deferred)
+            .await
+            .map_err(|e| anyhow!(e))?;
+        self.wait_version(version).await
     }
 
     async fn alter_database_param(

--- a/src/frontend/src/catalog/root_catalog.rs
+++ b/src/frontend/src/catalog/root_catalog.rs
@@ -342,12 +342,16 @@ impl Catalog {
             let mut database = self.database_by_name.remove(&old_database_name).unwrap();
             database.name.clone_from(&name);
             database.owner = proto.owner;
+            database.resource_group.clone_from(&proto.resource_group);
+            database.barrier_interval_ms = proto.barrier_interval_ms;
+            database.checkpoint_frequency = proto.checkpoint_frequency;
             self.database_by_name.insert(name.clone(), database);
             self.db_name_by_id.insert(id, name);
         } else {
             let database = self.get_database_mut(id).unwrap();
             database.name = name;
             database.owner = proto.owner;
+            database.resource_group = proto.resource_group.clone();
             database.barrier_interval_ms = proto.barrier_interval_ms;
             database.checkpoint_frequency = proto.checkpoint_frequency;
         }

--- a/src/frontend/src/handler/alter_database_param.rs
+++ b/src/frontend/src/handler/alter_database_param.rs
@@ -15,11 +15,12 @@
 use pgwire::pg_response::StatementType;
 use risingwave_common::catalog::AlterDatabaseParam;
 use risingwave_common::system_param::{NOTICE_BARRIER_INTERVAL_MS, NOTICE_CHECKPOINT_FREQUENCY};
-use risingwave_sqlparser::ast::ObjectName;
+use risingwave_sqlparser::ast::{ObjectName, SetVariableValue};
 
 use super::{HandlerArgs, RwPgResponse};
 use crate::Binder;
 use crate::error::Result;
+use crate::handler::alter_resource_group::resolve_resource_group;
 
 pub async fn handle_alter_database_param(
     handler_args: HandlerArgs,
@@ -73,8 +74,53 @@ pub async fn handle_alter_database_param(
     Ok(builder.into())
 }
 
+pub async fn handle_alter_database_resource_group(
+    handler_args: HandlerArgs,
+    database_name: ObjectName,
+    resource_group: Option<SetVariableValue>,
+    _deferred: bool,
+) -> Result<RwPgResponse> {
+    let mut builder = RwPgResponse::builder(StatementType::ALTER_DATABASE);
+
+    let session = handler_args.session;
+
+    let database_name = Binder::resolve_database_name(database_name)?;
+    let database_id = {
+        let catalog_reader = session.env().catalog_reader().read_guard();
+        let database = catalog_reader.get_database_by_name(&database_name)?;
+
+        // The user should be super user or owner to alter the database.
+        session.check_privilege_for_drop_alter_db_schema(database)?;
+
+        database.id()
+    };
+
+    let resource_group = resource_group
+        .map(resolve_resource_group)
+        .transpose()?
+        .flatten();
+
+    if resource_group.is_some() {
+        risingwave_common::license::Feature::ResourceGroup.check_available()?;
+    }
+
+    let catalog_writer = session.catalog_writer()?;
+    catalog_writer
+        .alter_database_resource_group(database_id, resource_group, _deferred)
+        .await?;
+
+    builder = builder.notice(
+        "The database resource group metadata has been updated, but it will not take effect immediately. Manually trigger recovery for inherited streaming jobs to use the new database resource group."
+            .to_owned(),
+    );
+
+    Ok(builder.into())
+}
+
 #[cfg(test)]
 mod tests {
+    use risingwave_common::util::worker_util::DEFAULT_RESOURCE_GROUP;
+
     use crate::test_utils::LocalFrontend;
 
     #[tokio::test]
@@ -134,5 +180,43 @@ mod tests {
             assert!(db.barrier_interval_ms.is_none());
             assert!(db.checkpoint_frequency.is_none());
         }
+    }
+
+    #[tokio::test]
+    async fn test_alter_resource_group() {
+        let frontend = LocalFrontend::new(Default::default()).await;
+        let session = frontend.session_ref();
+        let catalog_reader = session.env().catalog_reader();
+
+        frontend.run_sql("CREATE DATABASE test_db").await.unwrap();
+
+        frontend
+            .run_sql("ALTER DATABASE test_db SET RESOURCE_GROUP = DEFAULT DEFERRED")
+            .await
+            .unwrap();
+        {
+            let reader = catalog_reader.read_guard();
+            let db = reader.get_database_by_name("test_db").unwrap();
+            assert_eq!(db.resource_group, DEFAULT_RESOURCE_GROUP);
+        }
+
+        frontend
+            .run_sql("ALTER DATABASE test_db RESET RESOURCE_GROUP DEFERRED")
+            .await
+            .unwrap();
+        {
+            let reader = catalog_reader.read_guard();
+            let db = reader.get_database_by_name("test_db").unwrap();
+            assert_eq!(db.resource_group, DEFAULT_RESOURCE_GROUP);
+        }
+
+        let err = frontend
+            .run_sql("ALTER DATABASE test_db SET RESOURCE_GROUP = 1 DEFERRED")
+            .await
+            .unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("target resource group must be a valid string or default")
+        );
     }
 }

--- a/src/frontend/src/handler/alter_resource_group.rs
+++ b/src/frontend/src/handler/alter_resource_group.rs
@@ -13,14 +13,11 @@
 // limitations under the License.
 
 use pgwire::pg_response::StatementType;
-use risingwave_common::bail;
 use risingwave_common::util::worker_util::DEFAULT_RESOURCE_GROUP;
 use risingwave_sqlparser::ast::{ObjectName, SetVariableValue, SetVariableValueSingle, Value};
 
+use super::alter_utils::resolve_streaming_job_id_for_alter_parallelism;
 use super::{HandlerArgs, RwPgResponse};
-use crate::Binder;
-use crate::catalog::root_catalog::SchemaPath;
-use crate::catalog::table_catalog::TableType;
 use crate::error::{ErrorCode, Result};
 
 pub async fn handle_alter_resource_group(
@@ -31,45 +28,15 @@ pub async fn handle_alter_resource_group(
     deferred: bool,
 ) -> Result<RwPgResponse> {
     let session = handler_args.session;
-    let db_name = session.database();
-    let (schema_name, real_table_name) =
-        Binder::resolve_schema_qualified_name(&db_name, &obj_name)?;
-    let search_path = session.config().search_path();
-    let user_name = &session.auth_context().user_name;
-    let schema_path = SchemaPath::new(schema_name.as_deref(), &search_path, user_name);
 
     risingwave_common::license::Feature::ResourceGroup.check_available()?;
 
-    let table_id = {
-        let reader = session.env().catalog_reader().read_guard();
-
-        match stmt_type {
-            StatementType::ALTER_MATERIALIZED_VIEW => {
-                let (table, schema_name) =
-                    reader.get_created_table_by_name(&db_name, schema_path, &real_table_name)?;
-
-                match (table.table_type(), stmt_type) {
-                    (TableType::MaterializedView, StatementType::ALTER_MATERIALIZED_VIEW) => {}
-                    _ => {
-                        return Err(ErrorCode::InvalidInputSyntax(format!(
-                            "cannot alter resource group of {} {} by {}",
-                            table.table_type().to_prost().as_str_name(),
-                            table.name(),
-                            stmt_type,
-                        ))
-                        .into());
-                    }
-                }
-
-                session.check_privilege_for_drop_alter(schema_name, &**table)?;
-                table.id
-            }
-            _ => bail!(
-                "invalid statement type for alter resource group: {:?}",
-                stmt_type
-            ),
-        }
-    };
+    let job_id = resolve_streaming_job_id_for_alter_parallelism(
+        &session,
+        obj_name,
+        stmt_type,
+        "resource group",
+    )?;
 
     let resource_group = resource_group
         .map(resolve_resource_group)
@@ -80,7 +47,7 @@ pub async fn handle_alter_resource_group(
 
     let catalog_writer = session.catalog_writer()?;
     catalog_writer
-        .alter_resource_group(table_id, resource_group, deferred)
+        .alter_resource_group(job_id, resource_group, deferred)
         .await?;
 
     if deferred {

--- a/src/frontend/src/handler/create_index.rs
+++ b/src/frontend/src/handler/create_index.rs
@@ -41,6 +41,8 @@ use crate::catalog::{DatabaseId, SchemaId};
 use crate::error::{ErrorCode, Result};
 use crate::expr::{Expr, ExprImpl, ExprRewriter, ExprVisitor, InputRef, is_impure_func_call};
 use crate::handler::HandlerArgs;
+use crate::handler::create_mv::resolve_streaming_job_resource_type;
+use crate::handler::util::{LongRunningNotificationAction, execute_with_long_running_notification};
 use crate::optimizer::plan_expr_rewriter::ConstEvalRewriter;
 use crate::optimizer::plan_node::utils::plan_can_use_background_ddl;
 use crate::optimizer::plan_node::{
@@ -637,7 +639,7 @@ fn assemble_materialize(
 }
 
 pub async fn handle_create_index(
-    handler_args: HandlerArgs,
+    mut handler_args: HandlerArgs,
     if_not_exists: bool,
     index_name: ObjectName,
     table_name: ObjectName,
@@ -647,6 +649,9 @@ pub async fn handle_create_index(
     distributed_by: Vec<ast::Expr>,
 ) -> Result<RwPgResponse> {
     let session = handler_args.session.clone();
+    let resource_type =
+        resolve_streaming_job_resource_type(session.as_ref(), &mut handler_args.with_options)
+            .await?;
 
     let (graph, index_table, index) = {
         let (schema_name, table, index_table_name) =
@@ -698,9 +703,19 @@ pub async fn handle_create_index(
             ));
 
     let catalog_writer = session.catalog_writer()?;
-    catalog_writer
-        .create_index(index, index_table.to_prost(), graph, if_not_exists)
-        .await?;
+    execute_with_long_running_notification(
+        catalog_writer.create_index(
+            index,
+            index_table.to_prost(),
+            graph,
+            resource_type,
+            if_not_exists,
+        ),
+        &session,
+        "CREATE INDEX",
+        LongRunningNotificationAction::MonitorBackfillJob,
+    )
+    .await?;
 
     Ok(PgResponse::empty_result(StatementType::CREATE_INDEX))
 }

--- a/src/frontend/src/handler/create_mv.rs
+++ b/src/frontend/src/handler/create_mv.rs
@@ -18,6 +18,7 @@ use either::Either;
 use itertools::Itertools;
 use pgwire::pg_response::{PgResponse, StatementType};
 use risingwave_common::catalog::{FunctionId, ObjectId};
+use risingwave_common::license::Feature;
 use risingwave_pb::ddl_service::streaming_job_resource_type;
 use risingwave_pb::serverless_backfill_controller::{
     ProvisionRequest, node_group_controller_service_client,
@@ -46,6 +47,22 @@ use crate::{TableCatalog, WithOptions};
 
 pub const RESOURCE_GROUP_KEY: &str = "resource_group";
 pub const CLOUD_SERVERLESS_BACKFILL_ENABLED: &str = "cloud.serverless_backfill_enabled";
+
+pub(crate) struct StreamingJobResourceOptions {
+    pub resource_group: Option<String>,
+    pub serverless_backfill_enabled: Option<bool>,
+}
+
+pub(crate) fn extract_streaming_job_resource_options(
+    with_options: &mut WithOptions,
+) -> StreamingJobResourceOptions {
+    StreamingJobResourceOptions {
+        resource_group: with_options.remove(RESOURCE_GROUP_KEY),
+        serverless_backfill_enabled: with_options
+            .remove(CLOUD_SERVERLESS_BACKFILL_ENABLED)
+            .map(|value| value.parse::<bool>().unwrap_or(false)),
+    }
+}
 
 pub(super) fn parse_column_names(columns: &[Ident]) -> Option<Vec<String>> {
     if columns.is_empty() {
@@ -210,6 +227,80 @@ pub async fn provision_resource_group(sbc_addr: String) -> Result<String> {
     }
 }
 
+pub(crate) async fn resolve_streaming_job_resource_type(
+    session: &SessionImpl,
+    with_options: &mut WithOptions,
+) -> Result<streaming_job_resource_type::ResourceType> {
+    let StreamingJobResourceOptions {
+        resource_group,
+        serverless_backfill_enabled,
+    } = extract_streaming_job_resource_options(with_options);
+
+    if resource_group.is_some() {
+        Feature::ResourceGroup.check_available()?;
+    }
+
+    let is_serverless_backfill = match serverless_backfill_enabled {
+        Some(value) => value,
+        None => {
+            if resource_group.is_some() {
+                false
+            } else {
+                session.config().enable_serverless_backfill()
+            }
+        }
+    };
+
+    if resource_group.is_some() && is_serverless_backfill {
+        return Err(RwError::from(InvalidInputSyntax(
+            "Please do not specify serverless backfilling and resource group together".to_owned(),
+        )));
+    }
+
+    let sbc_addr = match SESSION_MANAGER.get() {
+        Some(manager) => manager.env().sbc_address(),
+        None => "",
+    }
+    .to_owned();
+
+    if is_serverless_backfill && sbc_addr.is_empty() {
+        return Err(RwError::from(InvalidInputSyntax(
+            "Serverless Backfill is disabled. Use RisingWave cloud at https://cloud.risingwave.com/auth/signup to try this feature".to_owned(),
+        )));
+    }
+
+    let resource_type = if is_serverless_backfill {
+        assert_eq!(resource_group, None);
+        match provision_resource_group(sbc_addr).await {
+            Err(e) => {
+                return Err(RwError::from(ProtocolError(format!(
+                    "failed to provision serverless backfill nodes: {}",
+                    e.as_report()
+                ))));
+            }
+            Ok(group) => {
+                tracing::info!(
+                    resource_group = group,
+                    "provisioning serverless backfill resource group"
+                );
+                streaming_job_resource_type::ResourceType::ServerlessBackfillResourceGroup(group)
+            }
+        }
+    } else if let Some(group) = resource_group {
+        streaming_job_resource_type::ResourceType::SpecificResourceGroup(group)
+    } else {
+        streaming_job_resource_type::ResourceType::Regular(true)
+    };
+
+    if resource_type.resource_group().is_some()
+        && !session.config().streaming_use_arrangement_backfill()
+    {
+        return Err(RwError::from(ProtocolError("The session config arrangement backfill must be enabled to use the resource_group option".to_owned())));
+    }
+
+    Ok(resource_type)
+}
+
 fn get_with_options(handler_args: HandlerArgs) -> WithOptions {
     let context = OptimizerContext::from_handler_args(handler_args);
     context.with_options().clone()
@@ -298,31 +389,9 @@ pub(crate) async fn gen_create_mv_graph(
     streaming_job_resource_type::ResourceType,
 )> {
     let mut with_options = get_with_options(handler_args.clone());
-    let resource_group = with_options.remove(&RESOURCE_GROUP_KEY.to_owned());
-
-    if resource_group.is_some() {
-        risingwave_common::license::Feature::ResourceGroup.check_available()?;
-    }
-
-    let serverless_backfill_from_with = with_options
-        .remove(&CLOUD_SERVERLESS_BACKFILL_ENABLED.to_owned())
-        .map(|value| value.parse::<bool>().unwrap_or(false));
-    let is_serverless_backfill = match serverless_backfill_from_with {
-        Some(value) => value,
-        None => {
-            if resource_group.is_some() {
-                false
-            } else {
-                handler_args.session.config().enable_serverless_backfill()
-            }
-        }
-    };
-
-    if resource_group.is_some() && is_serverless_backfill {
-        return Err(RwError::from(InvalidInputSyntax(
-            "Please do not specify serverless backfilling and resource group together".to_owned(),
-        )));
-    }
+    let resource_type =
+        resolve_streaming_job_resource_type(handler_args.session.as_ref(), &mut with_options)
+            .await?;
 
     if !with_options.is_empty() {
         // get other useful fields by `remove`, the logic here is to reject unknown options.
@@ -332,55 +401,12 @@ pub(crate) async fn gen_create_mv_graph(
         ))));
     }
 
-    let sbc_addr = match SESSION_MANAGER.get() {
-        Some(manager) => manager.env().sbc_address(),
-        None => "",
-    }
-    .to_owned();
-
-    if is_serverless_backfill && sbc_addr.is_empty() {
-        return Err(RwError::from(InvalidInputSyntax(
-            "Serverless Backfill is disabled. Use RisingWave cloud at https://cloud.risingwave.com/auth/signup to try this feature".to_owned(),
-        )));
-    }
-
-    let resource_type = if is_serverless_backfill {
-        assert_eq!(resource_group, None);
-        match provision_resource_group(sbc_addr).await {
-            Err(e) => {
-                return Err(RwError::from(ProtocolError(format!(
-                    "failed to provision serverless backfill nodes: {}",
-                    e.as_report()
-                ))));
-            }
-            Ok(group) => {
-                tracing::info!(
-                    resource_group = group,
-                    "provisioning serverless backfill resource group"
-                );
-                streaming_job_resource_type::ResourceType::ServerlessBackfillResourceGroup(group)
-            }
-        }
-    } else if let Some(group) = resource_group {
-        streaming_job_resource_type::ResourceType::SpecificResourceGroup(group)
-    } else {
-        streaming_job_resource_type::ResourceType::Regular(true)
-    };
     let context = OptimizerContext::from_handler_args(handler_args);
     let has_order_by = !query.order.is_empty();
     if has_order_by {
         context.warn_to_user(r#"The ORDER BY clause in the CREATE MATERIALIZED VIEW statement does not guarantee that the rows selected out of this materialized view is returned in this order.
 It only indicates the physical clustering of the data, which may improve the performance of queries issued against this materialized view.
 "#.to_owned());
-    }
-
-    if resource_type.resource_group().is_some()
-        && !context
-            .session_ctx()
-            .config()
-            .streaming_use_arrangement_backfill()
-    {
-        return Err(RwError::from(ProtocolError("The session config arrangement backfill must be enabled to use the resource_group option".to_owned())));
     }
 
     let context: OptimizerContextRef = context.into();

--- a/src/frontend/src/handler/create_sink.rs
+++ b/src/frontend/src/handler/create_sink.rs
@@ -60,7 +60,9 @@ use crate::error::{ErrorCode, Result, RwError};
 use crate::expr::{ExprImpl, InputRef, rewrite_now_to_proctime};
 use crate::handler::HandlerArgs;
 use crate::handler::alter_table_column::fetch_table_catalog_for_alter;
-use crate::handler::create_mv::parse_column_names;
+use crate::handler::create_mv::{
+    extract_streaming_job_resource_options, parse_column_names, resolve_streaming_job_resource_type,
+};
 use crate::handler::util::{
     LongRunningNotificationAction, check_connector_match_connection_type,
     ensure_connection_type_allowed, execute_with_long_running_notification,
@@ -119,6 +121,9 @@ pub async fn gen_sink_plan(
         Binder::resolve_schema_qualified_name(db_name, &stmt.sink_name)?;
 
     let mut with_options = handler_args.with_options.clone();
+    // These are frontend-level streaming job options. They must not be passed to connector
+    // property validation.
+    extract_streaming_job_resource_options(&mut with_options);
 
     if session
         .env()
@@ -565,7 +570,7 @@ async fn get_partition_compute_info_for_iceberg(
 }
 
 pub async fn handle_create_sink(
-    handle_args: HandlerArgs,
+    mut handle_args: HandlerArgs,
     stmt: CreateSinkStatement,
     is_iceberg_engine_internal: bool,
 ) -> Result<RwPgResponse> {
@@ -588,6 +593,10 @@ pub async fn handle_create_sink(
             ICEBERG_SINK_PREFIX
         ))));
     }
+
+    let resource_type =
+        resolve_streaming_job_resource_type(session.as_ref(), &mut handle_args.with_options)
+            .await?;
 
     let (mut sink, graph, target_table_catalog, dependencies) = {
         let backfill_order_strategy = handle_args.with_options.backfill_order_strategy();
@@ -634,7 +643,13 @@ pub async fn handle_create_sink(
 
     let catalog_writer = session.catalog_writer()?;
     execute_with_long_running_notification(
-        catalog_writer.create_sink(sink.to_proto(), graph, dependencies, if_not_exists),
+        catalog_writer.create_sink(
+            sink.to_proto(),
+            graph,
+            dependencies,
+            resource_type,
+            if_not_exists,
+        ),
         &session,
         "CREATE SINK",
         LongRunningNotificationAction::MonitorBackfillJob,

--- a/src/frontend/src/handler/mod.rs
+++ b/src/frontend/src/handler/mod.rs
@@ -780,6 +780,18 @@ pub async fn handle(
                 )
                 .await
             }
+            AlterDatabaseOperation::SetResourceGroup {
+                resource_group,
+                deferred,
+            } => {
+                alter_database_param::handle_alter_database_resource_group(
+                    handler_args,
+                    name,
+                    resource_group,
+                    deferred,
+                )
+                .await
+            }
         },
         Statement::AlterSchema { name, operation } => match operation {
             AlterSchemaOperation::RenameSchema { schema_name } => {
@@ -949,6 +961,19 @@ pub async fn handle(
                     name,
                     entries,
                     StatementType::ALTER_INDEX,
+                )
+                .await
+            }
+            AlterIndexOperation::SetResourceGroup {
+                resource_group,
+                deferred,
+            } => {
+                alter_resource_group::handle_alter_resource_group(
+                    handler_args,
+                    name,
+                    resource_group,
+                    StatementType::ALTER_INDEX,
+                    deferred,
                 )
                 .await
             }
@@ -1140,6 +1165,19 @@ pub async fn handle(
                     handler_args,
                     name,
                     parallelism,
+                    StatementType::ALTER_SINK,
+                    deferred,
+                )
+                .await
+            }
+            AlterSinkOperation::SetResourceGroup {
+                resource_group,
+                deferred,
+            } => {
+                alter_resource_group::handle_alter_resource_group(
+                    handler_args,
+                    name,
+                    resource_group,
                     StatementType::ALTER_SINK,
                     deferred,
                 )

--- a/src/frontend/src/test_utils.rs
+++ b/src/frontend/src/test_utils.rs
@@ -727,11 +727,28 @@ impl CatalogWriter for MockCatalogWriter {
 
     async fn alter_resource_group(
         &self,
-        _table_id: TableId,
+        _job_id: JobId,
         _resource_group: Option<String>,
         _deferred: bool,
     ) -> Result<()> {
         todo!()
+    }
+
+    async fn alter_database_resource_group(
+        &self,
+        database_id: DatabaseId,
+        resource_group: Option<String>,
+        _deferred: bool,
+    ) -> Result<()> {
+        let mut pb_database = {
+            let reader = self.catalog.read();
+            let database = reader.get_database_by_id(database_id)?.to_owned();
+            database.to_prost()
+        };
+        pb_database.resource_group =
+            resource_group.unwrap_or_else(|| DEFAULT_RESOURCE_GROUP.to_owned());
+        self.catalog.write().update_database(&pb_database);
+        Ok(())
     }
 
     async fn alter_database_param(

--- a/src/frontend/src/test_utils.rs
+++ b/src/frontend/src/test_utils.rs
@@ -388,6 +388,7 @@ impl CatalogWriter for MockCatalogWriter {
         sink: PbSink,
         graph: StreamFragmentGraph,
         _dependencies: HashSet<ObjectId>,
+        _resource_type: streaming_job_resource_type::ResourceType,
         _if_not_exists: bool,
     ) -> Result<()> {
         self.create_sink_inner(sink, graph)
@@ -402,6 +403,7 @@ impl CatalogWriter for MockCatalogWriter {
         mut index: PbIndex,
         mut index_table: PbTable,
         _graph: StreamFragmentGraph,
+        _resource_type: streaming_job_resource_type::ResourceType,
         _if_not_exists: bool,
     ) -> Result<()> {
         index_table.id = self.gen_id();

--- a/src/meta/Cargo.toml
+++ b/src/meta/Cargo.toml
@@ -8,7 +8,7 @@ license = { workspace = true }
 repository = { workspace = true }
 
 [features]
-test = []
+test = ["risingwave_hummock_sdk/test"]
 failpoints = ["fail/failpoints"]
 
 [dependencies]

--- a/src/meta/node/Cargo.toml
+++ b/src/meta/node/Cargo.toml
@@ -10,6 +10,9 @@ repository = { workspace = true }
 [lib]
 test = false
 
+[features]
+test = ["risingwave_meta/test", "risingwave_meta_service/test"]
+
 [dependencies]
 clap = { workspace = true }
 educe = "0.6"

--- a/src/meta/service/Cargo.toml
+++ b/src/meta/service/Cargo.toml
@@ -7,6 +7,9 @@ keywords = { workspace = true }
 license = { workspace = true }
 repository = { workspace = true }
 
+[features]
+test = ["risingwave_meta/test"]
+
 [dependencies]
 anyhow = "1"
 async-trait = "0.1"

--- a/src/meta/service/src/ddl_service.rs
+++ b/src/meta/service/src/ddl_service.rs
@@ -1441,19 +1441,40 @@ impl DdlService for DdlServiceImpl {
     ) -> Result<Response<AlterResourceGroupResponse>, Status> {
         let req = request.into_inner();
 
-        let table_id = req.get_table_id();
+        let job_id = req.get_job_id();
         let deferred = req.get_deferred();
         let resource_group = req.resource_group;
 
         self.ddl_controller
             .reschedule_streaming_job(
-                table_id.as_job_id(),
+                job_id,
                 ReschedulePolicy::ResourceGroup(ResourceGroupPolicy { resource_group }),
                 deferred,
             )
             .await?;
 
         Ok(Response::new(AlterResourceGroupResponse {}))
+    }
+
+    async fn alter_database_resource_group(
+        &self,
+        request: Request<AlterDatabaseResourceGroupRequest>,
+    ) -> Result<Response<AlterDatabaseResourceGroupResponse>, Status> {
+        let req = request.into_inner();
+
+        let version = self
+            .ddl_controller
+            .run_command(DdlCommand::AlterDatabaseResourceGroup(
+                req.database_id,
+                req.resource_group,
+                req.deferred,
+            ))
+            .await?;
+
+        Ok(Response::new(AlterDatabaseResourceGroupResponse {
+            status: None,
+            version,
+        }))
     }
 
     async fn alter_database_param(

--- a/src/meta/service/src/ddl_service.rs
+++ b/src/meta/service/src/ddl_service.rs
@@ -444,6 +444,10 @@ impl DdlService for DdlServiceImpl {
         let sink = req.get_sink()?.clone();
         let fragment_graph = req.get_fragment_graph()?.clone();
         let dependencies = req.get_dependencies().iter().copied().collect();
+        let resource_type = req
+            .resource_type
+            .and_then(|resource_type| resource_type.resource_type)
+            .unwrap_or_else(Self::default_streaming_job_resource_type);
 
         let stream_job = StreamingJob::Sink(sink);
 
@@ -451,7 +455,7 @@ impl DdlService for DdlServiceImpl {
             stream_job,
             fragment_graph,
             dependencies,
-            resource_type: Self::default_streaming_job_resource_type(),
+            resource_type,
             if_not_exists: req.if_not_exists,
         };
 
@@ -591,6 +595,10 @@ impl DdlService for DdlServiceImpl {
         let index = req.get_index()?.clone();
         let index_table = req.get_index_table()?.clone();
         let fragment_graph = req.get_fragment_graph()?.clone();
+        let resource_type = req
+            .resource_type
+            .and_then(|resource_type| resource_type.resource_type)
+            .unwrap_or_else(Self::default_streaming_job_resource_type);
 
         let stream_job = StreamingJob::Index(index, index_table);
         let version = self
@@ -599,7 +607,7 @@ impl DdlService for DdlServiceImpl {
                 stream_job,
                 fragment_graph,
                 dependencies: HashSet::new(),
-                resource_type: Self::default_streaming_job_resource_type(),
+                resource_type,
                 if_not_exists: req.if_not_exists,
             })
             .await?;

--- a/src/meta/service/src/hummock_service.rs
+++ b/src/meta/service/src/hummock_service.rs
@@ -108,17 +108,27 @@ impl HummockManagerService for HummockServiceImpl {
         &self,
         request: Request<ReplayVersionDeltaRequest>,
     ) -> Result<Response<ReplayVersionDeltaResponse>, Status> {
-        let req = request.into_inner();
-        let (version, compaction_groups) = self
-            .hummock_manager
-            .replay_version_delta(HummockVersionDelta::from_rpc_protobuf(
-                &req.version_delta.unwrap(),
+        #[cfg(any(test, feature = "test"))]
+        {
+            let req = request.into_inner();
+            let (version, compaction_groups) = self
+                .hummock_manager
+                .replay_version_delta(HummockVersionDelta::from_rpc_protobuf(
+                    &req.version_delta.unwrap(),
+                ))
+                .await?;
+            Ok(Response::new(ReplayVersionDeltaResponse {
+                version: Some(version.into()),
+                modified_compaction_groups: compaction_groups,
+            }))
+        }
+        #[cfg(not(any(test, feature = "test")))]
+        {
+            let _ = request;
+            Err(Status::unimplemented(
+                "replay_version_delta is only available in test builds",
             ))
-            .await?;
-        Ok(Response::new(ReplayVersionDeltaResponse {
-            version: Some(version.into()),
-            modified_compaction_groups: compaction_groups,
-        }))
+        }
     }
 
     async fn trigger_compaction_deterministic(
@@ -138,7 +148,7 @@ impl HummockManagerService for HummockServiceImpl {
     ) -> Result<Response<DisableCommitEpochResponse>, Status> {
         let version = self.hummock_manager.disable_commit_epoch().await;
         Ok(Response::new(DisableCommitEpochResponse {
-            current_version: Some(version.into()),
+            current_version: Some(PbHummockVersion::from(&*version)),
         }))
     }
 
@@ -339,7 +349,7 @@ impl HummockManagerService for HummockServiceImpl {
         let req = request.into_inner();
         let version = self.hummock_manager.pin_version(req.context_id).await?;
         Ok(Response::new(PinVersionResponse {
-            pinned_version: Some(version.into()),
+            pinned_version: Some(PbHummockVersion::from(&*version)),
         }))
     }
 
@@ -386,7 +396,7 @@ impl HummockManagerService for HummockServiceImpl {
     ) -> Result<Response<RiseCtlGetCheckpointVersionResponse>, Status> {
         let checkpoint_version = self.hummock_manager.get_checkpoint_version().await;
         Ok(Response::new(RiseCtlGetCheckpointVersionResponse {
-            checkpoint_version: Some(checkpoint_version.into()),
+            checkpoint_version: Some(PbHummockVersion::from(&*checkpoint_version)),
         }))
     }
 

--- a/src/meta/src/barrier/schedule.rs
+++ b/src/meta/src/barrier/schedule.rs
@@ -785,7 +785,11 @@ impl ScheduledBarriers {
                         unreachable!("only drop and cancel streaming jobs should be buffered");
                     }
                 }
-                notifiers.into_iter().for_each(|notify| {
+                // `run_command` waits for both the started and collected notifications. These
+                // buffered commands are pre-applied during recovery without injecting a real
+                // barrier, so complete both waiters here.
+                notifiers.into_iter().for_each(|mut notify| {
+                    notify.notify_started();
                     notify.notify_collected();
                 });
             }

--- a/src/meta/src/controller/catalog/alter_op.rs
+++ b/src/meta/src/controller/catalog/alter_op.rs
@@ -19,6 +19,7 @@ use risingwave_common::config::mutate::TomlTableMutateExt as _;
 use risingwave_common::config::{StreamingConfig, merge_streaming_config_section};
 use risingwave_common::id::JobId;
 use risingwave_common::system_param::{OverrideValidate, Validate};
+use risingwave_common::util::worker_util::DEFAULT_RESOURCE_GROUP;
 use risingwave_meta_model::refresh_job::{self, RefreshState};
 use sea_orm::ActiveValue::{NotSet, Set};
 use sea_orm::prelude::DateTime;
@@ -1064,6 +1065,41 @@ impl CatalogController {
             )
             .await;
         Ok((version, database))
+    }
+
+    pub async fn alter_database_resource_group(
+        &self,
+        database_id: DatabaseId,
+        resource_group: Option<String>,
+    ) -> MetaResult<NotificationVersion> {
+        let inner = self.inner.write().await;
+        let txn = inner.db.begin().await?;
+
+        let database =
+            database::ActiveModel {
+                database_id: Set(database_id),
+                resource_group: Set(
+                    resource_group.unwrap_or_else(|| DEFAULT_RESOURCE_GROUP.to_owned())
+                ),
+                ..Default::default()
+            }
+            .update(&txn)
+            .await?;
+
+        let obj = Object::find_by_id(database_id)
+            .one(&txn)
+            .await?
+            .ok_or_else(|| MetaError::catalog_id_not_found("database", database_id))?;
+
+        txn.commit().await?;
+
+        let version = self
+            .notify_frontend(
+                NotificationOperation::Update,
+                NotificationInfo::Database(ObjectModel(database, obj, None).into()),
+            )
+            .await;
+        Ok(version)
     }
 
     pub async fn alter_streaming_job_config(

--- a/src/meta/src/controller/streaming_job.rs
+++ b/src/meta/src/controller/streaming_job.rs
@@ -698,40 +698,68 @@ impl CatalogController {
         Ok(())
     }
 
-    /// Builds a cancel command for the streaming job. If the sink (with target table) needs to be dropped, additional
-    /// information is required to build barrier mutation.
+    /// Builds a cancel command from persisted fragment metadata without reading `SharedActorInfos`.
+    ///
+    /// Returns `None` if the job no longer exists or has already been created.
     pub async fn build_cancel_command(
         &self,
-        table_fragments: &StreamJobFragments,
-    ) -> MetaResult<Command> {
+        job_id: JobId,
+    ) -> MetaResult<Option<(Command, Vec<TableId>)>> {
         let inner = self.inner.read().await;
         let txn = inner.db.begin().await?;
 
-        let dropped_sink_fragment_with_target =
-            if let Some(sink_fragment) = table_fragments.sink_fragment() {
-                let sink_fragment_id = sink_fragment.fragment_id as FragmentId;
-                let sink_target_fragment = fetch_target_fragments(&txn, [sink_fragment_id]).await?;
-                sink_target_fragment
-                    .get(&sink_fragment_id)
-                    .map(|target_fragments| {
-                        let target_fragment_id = *target_fragments
-                            .first()
-                            .expect("sink should have at least one downstream fragment");
-                        (sink_fragment_id, target_fragment_id)
-                    })
-            } else {
-                None
-            };
+        let Some(streaming_job) = StreamingJobModel::find_by_id(job_id).one(&txn).await? else {
+            tracing::warn!(
+                %job_id,
+                "streaming job not found when building cancel command, might be cancelled already"
+            );
+            return Ok(None);
+        };
+        if streaming_job.job_status == JobStatus::Created {
+            tracing::warn!(
+                "streaming job {} is already created, ignore cancel request",
+                job_id
+            );
+            return Ok(None);
+        }
 
-        Ok(Command::DropStreamingJobs {
-            streaming_job_ids: HashSet::from_iter([table_fragments.stream_job_id()]),
-            actors: table_fragments.actor_ids().collect(),
-            unregistered_state_table_ids: table_fragments.all_table_ids().collect(),
-            dropped_sink_fragment_by_targets: dropped_sink_fragment_with_target
-                .into_iter()
-                .map(|(sink, target)| (target as _, vec![sink as _]))
-                .collect(),
-        })
+        let fragments = Fragment::find()
+            .filter(fragment::Column::JobId.eq(job_id))
+            .all(&txn)
+            .await?;
+
+        let state_table_ids = fragments
+            .iter()
+            .flat_map(|fragment| fragment.state_table_ids.inner_ref().iter().copied())
+            .collect_vec();
+        let sink_fragment_ids = fragments
+            .iter()
+            .filter_map(|fragment| {
+                FragmentTypeMask::from(fragment.fragment_type_mask)
+                    .contains(FragmentTypeFlag::Sink)
+                    .then_some(fragment.fragment_id)
+            })
+            .collect_vec();
+
+        let sink_target_fragments = fetch_target_fragments(&txn, sink_fragment_ids).await?;
+        let dropped_sink_fragment_by_targets = sink_target_fragments
+            .into_iter()
+            .filter_map(|(sink_fragment, target_fragments)| {
+                target_fragments
+                    .first()
+                    .map(|target_fragment| (*target_fragment, vec![sink_fragment]))
+            })
+            .collect();
+
+        Ok(Some((
+            Command::DropStreamingJobs {
+                streaming_job_ids: HashSet::from_iter([job_id]),
+                actors: vec![],
+                unregistered_state_table_ids: state_table_ids.iter().copied().collect(),
+                dropped_sink_fragment_by_targets,
+            },
+            state_table_ids,
+        )))
     }
 
     /// `try_abort_creating_streaming_job` is used to abort the job that is under initial status or in `FOREGROUND` mode.

--- a/src/meta/src/controller/utils.rs
+++ b/src/meta/src/controller/utils.rs
@@ -1581,7 +1581,6 @@ pub fn rebuild_fragment_mapping(fragment: &SharedFragmentInfo) -> PbFragmentWork
 /// For the given streaming jobs, returns
 /// - All source fragments
 /// - All sink fragments
-/// - All actors
 /// - All fragments
 pub async fn get_fragments_for_jobs<C>(
     db: &C,

--- a/src/meta/src/hummock/manager/checkpoint.rs
+++ b/src/meta/src/hummock/manager/checkpoint.rs
@@ -15,6 +15,7 @@
 use std::collections::{HashMap, HashSet};
 use std::ops::Bound::{Excluded, Included};
 use std::ops::{Deref, DerefMut};
+use std::sync::Arc;
 use std::sync::atomic::Ordering;
 
 use risingwave_hummock_sdk::compaction_group::hummock_version_ext::object_size_map;
@@ -31,11 +32,11 @@ use tracing::warn;
 use crate::hummock::HummockManager;
 use crate::hummock::error::Result;
 use crate::hummock::manager::versioning::Versioning;
-use crate::hummock::metrics_utils::{trigger_gc_stat, trigger_split_stat};
+use crate::hummock::metrics_utils::{gc_stale_object_stats, trigger_gc_stat, trigger_split_stat};
 
 #[derive(Default)]
 pub struct HummockVersionCheckpoint {
-    pub version: HummockVersion,
+    pub version: Arc<HummockVersion>,
 
     /// stale objects of versions before the current checkpoint.
     ///
@@ -48,7 +49,9 @@ pub struct HummockVersionCheckpoint {
 impl HummockVersionCheckpoint {
     pub fn from_protobuf(checkpoint: &PbHummockVersionCheckpoint) -> Self {
         Self {
-            version: HummockVersion::from_persisted_protobuf(checkpoint.version.as_ref().unwrap()),
+            version: Arc::new(HummockVersion::from_persisted_protobuf(
+                checkpoint.version.as_ref().unwrap(),
+            )),
             stale_objects: checkpoint
                 .stale_objects
                 .iter()
@@ -59,7 +62,7 @@ impl HummockVersionCheckpoint {
 
     pub fn to_protobuf(&self) -> PbHummockVersionCheckpoint {
         PbHummockVersionCheckpoint {
-            version: Some(PbHummockVersion::from(&self.version)),
+            version: Some(PbHummockVersion::from(self.version.as_ref())),
             stale_objects: self
                 .stale_objects
                 .iter()
@@ -125,36 +128,63 @@ impl HummockManager {
     /// lock throughout the method.
     pub async fn create_version_checkpoint(&self, min_delta_log_num: u64) -> Result<u64> {
         let timer = self.metrics.version_checkpoint_latency.start_timer();
-        // 1. hold read lock and create new checkpoint
-        let versioning_guard = self.versioning.read().await;
-        let versioning: &Versioning = versioning_guard.deref();
-        let current_version: &HummockVersion = &versioning.current_version;
-        let old_checkpoint: &HummockVersionCheckpoint = &versioning.checkpoint;
-        let new_checkpoint_id = current_version.id;
-        let old_checkpoint_id = old_checkpoint.version.id;
-        if new_checkpoint_id < old_checkpoint_id + min_delta_log_num {
-            return Ok(0);
-        }
-        if cfg!(test) && new_checkpoint_id == old_checkpoint_id {
-            drop(versioning_guard);
-            let versioning = self.versioning.read().await;
-            let context_info = self.context_info.read().await;
-            let min_pinned_version_id = context_info.min_pinned_version_id();
-            trigger_gc_stat(&self.metrics, &versioning.checkpoint, min_pinned_version_id);
-            return Ok(0);
-        }
+        // 1. hold read lock briefly and snapshot checkpoint inputs.
+        let (
+            current_version,
+            old_checkpoint_version,
+            mut stale_objects,
+            version_deltas,
+            new_checkpoint_id,
+            old_checkpoint_id,
+        ) = {
+            let versioning_guard = self.versioning.read().await;
+            let versioning: &Versioning = versioning_guard.deref();
+            let current_version = versioning.current_version.clone();
+            let old_checkpoint: &HummockVersionCheckpoint = &versioning.checkpoint;
+            let new_checkpoint_id = current_version.id;
+            let old_checkpoint_id = old_checkpoint.version.id;
+            if new_checkpoint_id < old_checkpoint_id + min_delta_log_num {
+                return Ok(0);
+            }
+            if cfg!(test) && new_checkpoint_id == old_checkpoint_id {
+                drop(versioning_guard);
+                let versioning = self.versioning.read().await;
+                let context_info = self.context_info.read().await;
+                let min_pinned_version_id = context_info.min_pinned_version_id();
+                let stale_object_stats = gc_stale_object_stats(
+                    &versioning.checkpoint.stale_objects,
+                    min_pinned_version_id,
+                );
+                trigger_gc_stat(
+                    &self.metrics,
+                    versioning.checkpoint.version.as_ref(),
+                    stale_object_stats,
+                );
+                return Ok(0);
+            }
+            let old_checkpoint_version = old_checkpoint.version.clone();
+            let version_deltas = versioning
+                .hummock_version_deltas
+                .range((Excluded(old_checkpoint_id), Included(new_checkpoint_id)))
+                .map(|(_, version_delta)| version_delta.clone())
+                .collect::<Vec<_>>();
+            (
+                current_version,
+                old_checkpoint_version,
+                old_checkpoint.stale_objects.clone(),
+                version_deltas,
+                new_checkpoint_id,
+                old_checkpoint_id,
+            )
+        };
         assert!(new_checkpoint_id > old_checkpoint_id);
         let mut archive: Option<PbHummockVersionArchive> = None;
-        let mut stale_objects = old_checkpoint.stale_objects.clone();
         // `object_sizes` is used to calculate size of stale objects.
-        let mut object_sizes = object_size_map(&old_checkpoint.version);
+        let mut object_sizes = object_size_map(old_checkpoint_version.as_ref());
         // The set of object ids that once exist in any hummock version
         let mut versions_object_ids: HashSet<_> =
-            old_checkpoint.version.get_object_ids(false).collect();
-        for (_, version_delta) in versioning
-            .hummock_version_deltas
-            .range((Excluded(old_checkpoint_id), Included(new_checkpoint_id)))
-        {
+            old_checkpoint_version.get_object_ids(false).collect();
+        for version_delta in &version_deltas {
             // DO NOT REMOVE THIS LINE
             // This is to ensure that when adding new variant to `HummockObjectId`,
             // the compiler will warn us if we forget to handle it here.
@@ -218,11 +248,10 @@ impl HummockManager {
         });
         if self.env.opts.enable_hummock_data_archive {
             archive = Some(PbHummockVersionArchive {
-                version: Some(PbHummockVersion::from(&old_checkpoint.version)),
-                version_deltas: versioning
-                    .hummock_version_deltas
-                    .range((Excluded(old_checkpoint_id), Included(new_checkpoint_id)))
-                    .map(|(_, version_delta)| version_delta.into())
+                version: Some(PbHummockVersion::from(old_checkpoint_version.as_ref())),
+                version_deltas: version_deltas
+                    .iter()
+                    .map(|version_delta| version_delta.into())
                     .collect(),
             });
         }
@@ -242,7 +271,6 @@ impl HummockManager {
             version: current_version.clone(),
             stale_objects,
         };
-        drop(versioning_guard);
         // 2. persist the new checkpoint without holding lock
         self.write_checkpoint(&new_checkpoint).await?;
         if let Some(archive) = archive
@@ -254,15 +282,19 @@ impl HummockManager {
                 archive.version.as_ref().unwrap().id
             );
         }
-        // 3. hold write lock and update in memory state
-        let mut versioning_guard = self.versioning.write().await;
-        let versioning = versioning_guard.deref_mut();
-        assert!(new_checkpoint.version.id > versioning.checkpoint.version.id);
-        versioning.checkpoint = new_checkpoint;
         let min_pinned_version_id = self.context_info.read().await.min_pinned_version_id();
-        trigger_gc_stat(&self.metrics, &versioning.checkpoint, min_pinned_version_id);
-        trigger_split_stat(&self.metrics, &versioning.current_version);
-        drop(versioning_guard);
+        let stale_object_stats =
+            gc_stale_object_stats(&new_checkpoint.stale_objects, min_pinned_version_id);
+        // 3. hold write lock briefly and update in memory state
+        let current_version_for_metrics = {
+            let mut versioning_guard = self.versioning.write().await;
+            let versioning = versioning_guard.deref_mut();
+            assert!(new_checkpoint.version.id > versioning.checkpoint.version.id);
+            versioning.checkpoint = new_checkpoint;
+            versioning.current_version.clone()
+        };
+        trigger_gc_stat(&self.metrics, current_version.as_ref(), stale_object_stats);
+        trigger_split_stat(&self.metrics, current_version_for_metrics.as_ref());
         timer.observe_duration();
         self.metrics
             .checkpoint_version_id
@@ -286,7 +318,7 @@ impl HummockManager {
         self.pause_version_checkpoint.load(Ordering::Relaxed)
     }
 
-    pub async fn get_checkpoint_version(&self) -> HummockVersion {
+    pub async fn get_checkpoint_version(&self) -> Arc<HummockVersion> {
         let versioning_guard = self.versioning.read().await;
         versioning_guard.checkpoint.version.clone()
     }

--- a/src/meta/src/hummock/manager/checkpoint.rs
+++ b/src/meta/src/hummock/manager/checkpoint.rs
@@ -137,7 +137,10 @@ impl HummockManager {
             new_checkpoint_id,
             old_checkpoint_id,
         ) = {
-            let versioning_guard = self.versioning.read().await;
+            let versioning_guard = self
+                .versioning
+                .read_with_process_name("version_checkpoint_build")
+                .await;
             let versioning: &Versioning = versioning_guard.deref();
             let current_version = versioning.current_version.clone();
             let old_checkpoint: &HummockVersionCheckpoint = &versioning.checkpoint;
@@ -287,7 +290,10 @@ impl HummockManager {
             gc_stale_object_stats(&new_checkpoint.stale_objects, min_pinned_version_id);
         // 3. hold write lock briefly and update in memory state
         let current_version_for_metrics = {
-            let mut versioning_guard = self.versioning.write().await;
+            let mut versioning_guard = self
+                .versioning
+                .write_with_process_name("version_checkpoint_install")
+                .await;
             let versioning = versioning_guard.deref_mut();
             assert!(new_checkpoint.version.id > versioning.checkpoint.version.id);
             versioning.checkpoint = new_checkpoint;

--- a/src/meta/src/hummock/manager/commit_epoch.rs
+++ b/src/meta/src/hummock/manager/commit_epoch.rs
@@ -47,9 +47,7 @@ use crate::hummock::metrics_utils::{
 use crate::hummock::model::CompactionGroup;
 use crate::hummock::sequence::{next_compaction_group_id, next_sstable_id};
 use crate::hummock::time_travel::should_mark_next_time_travel_version_snapshot;
-use crate::hummock::{
-    HummockManager, commit_multi_var_with_provided_txn, start_measure_real_process_timer,
-};
+use crate::hummock::{HummockManager, commit_multi_var_with_provided_txn};
 
 pub struct NewTableFragmentInfo {
     pub table_ids: HashSet<TableId>,
@@ -83,8 +81,10 @@ impl HummockManager {
             tables_to_commit,
             truncate_tables,
         } = commit_info;
-        let mut versioning_guard = self.versioning.write().await;
-        let _timer = start_measure_real_process_timer!(self, "commit_epoch");
+        let mut versioning_guard = self
+            .versioning
+            .write_with_process_name("commit_epoch")
+            .await;
         // Prevent commit new epochs if this flag is set
         if versioning_guard.disable_commit_epochs {
             return Ok(());

--- a/src/meta/src/hummock/manager/commit_epoch.rs
+++ b/src/meta/src/hummock/manager/commit_epoch.rs
@@ -116,6 +116,7 @@ impl HummockManager {
             self.env.notification_manager(),
             Some(&self.table_committed_epoch_notifiers),
             &self.metrics,
+            &self.version_stat_tx,
         );
 
         let state_table_info = &version.latest_version().state_table_info;

--- a/src/meta/src/hummock/manager/compaction/compaction_group_manager.rs
+++ b/src/meta/src/hummock/manager/compaction/compaction_group_manager.rs
@@ -195,6 +195,7 @@ impl HummockManager {
             self.env.notification_manager(),
             None,
             &self.metrics,
+            &self.version_stat_tx,
         );
         let mut new_version_delta = version.new_delta();
 
@@ -292,6 +293,7 @@ impl HummockManager {
             self.env.notification_manager(),
             None,
             &self.metrics,
+            &self.version_stat_tx,
         );
         let mut new_version_delta = version.new_delta();
         struct UnregisterGroupChange {

--- a/src/meta/src/hummock/manager/compaction/compaction_group_schedule.rs
+++ b/src/meta/src/hummock/manager/compaction/compaction_group_schedule.rs
@@ -370,6 +370,7 @@ impl HummockManager {
             self.env.notification_manager(),
             None,
             &self.metrics,
+            &self.version_stat_tx,
         );
         let mut new_version_delta = version.new_delta();
 
@@ -683,6 +684,7 @@ impl HummockManager {
             self.env.notification_manager(),
             None,
             &self.metrics,
+            &self.version_stat_tx,
         );
         let mut new_version_delta = version.new_delta();
 
@@ -1011,6 +1013,7 @@ impl HummockManager {
                 self.env.notification_manager(),
                 None,
                 &self.metrics,
+                &self.version_stat_tx,
             );
             let mut new_version_delta = version.new_delta();
             let split_key = plan.split_key();

--- a/src/meta/src/hummock/manager/compaction/mod.rs
+++ b/src/meta/src/hummock/manager/compaction/mod.rs
@@ -322,6 +322,7 @@ impl HummockManager {
             self.env.notification_manager(),
             None,
             &self.metrics,
+            &self.version_stat_tx,
         );
         // Apply stats changes.
         let mut version_stats = HummockVersionStatsTransaction::new(
@@ -779,6 +780,7 @@ impl HummockManager {
             self.env.notification_manager(),
             None,
             &self.metrics,
+            &self.version_stat_tx,
         );
 
         if deterministic_mode {

--- a/src/meta/src/hummock/manager/compaction/mod.rs
+++ b/src/meta/src/hummock/manager/compaction/mod.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use std::collections::{BTreeMap, HashMap, HashSet};
+use std::ops::DerefMut;
 use std::sync::{Arc, LazyLock};
 use std::time::Instant;
 
@@ -51,7 +52,6 @@ use risingwave_pb::hummock::{
     SubscribeCompactionEventRequest, TableOption, compact_task,
 };
 use thiserror_ext::AsReport;
-use tokio::sync::RwLockWriteGuard;
 use tokio::sync::mpsc::UnboundedReceiver;
 use tokio::sync::oneshot::Sender;
 use tokio::task::JoinHandle;
@@ -82,7 +82,7 @@ use crate::hummock::metrics_utils::{
 };
 use crate::hummock::model::CompactionGroup;
 use crate::hummock::sequence::next_compaction_task_id;
-use crate::hummock::{HummockManager, commit_multi_var, start_measure_real_process_timer};
+use crate::hummock::{HummockManager, commit_multi_var};
 use crate::manager::META_NODE_ID;
 use crate::model::BTreeMapTransaction;
 
@@ -303,12 +303,16 @@ impl HummockManager {
     ) -> Result<(Vec<CompactTask>, Vec<CompactionGroupId>)> {
         let deterministic_mode = self.env.opts.compaction_deterministic_test;
 
-        let mut compaction_guard = self.compaction.write().await;
+        let mut compaction_guard = self
+            .compaction
+            .write_with_process_name("get_compact_tasks_impl")
+            .await;
+        let mut versioning_guard = self
+            .versioning
+            .write_with_process_name("get_compact_tasks_impl")
+            .await;
         let compaction: &mut Compaction = &mut compaction_guard;
-        let mut versioning_guard = self.versioning.write().await;
         let versioning: &mut Versioning = &mut versioning_guard;
-
-        let _timer = start_measure_real_process_timer!(self, "get_compact_tasks_impl");
 
         let start_time = Instant::now();
         let mut compaction_statuses = BTreeMapTransaction::new(&mut compaction.compaction_statuses);
@@ -734,8 +738,14 @@ impl HummockManager {
     }
 
     pub async fn report_compact_tasks(&self, report_tasks: Vec<ReportTask>) -> Result<Vec<bool>> {
-        let compaction_guard = self.compaction.write().await;
-        let versioning_guard = self.versioning.write().await;
+        let compaction_guard = self
+            .compaction
+            .write_with_process_name("report_compact_tasks")
+            .await;
+        let versioning_guard = self
+            .versioning
+            .write_with_process_name("report_compact_tasks")
+            .await;
 
         self.report_compact_tasks_impl(report_tasks, compaction_guard, versioning_guard)
             .await
@@ -751,8 +761,8 @@ impl HummockManager {
     pub async fn report_compact_tasks_impl(
         &self,
         report_tasks: Vec<ReportTask>,
-        mut compaction_guard: RwLockWriteGuard<'_, Compaction>,
-        mut versioning_guard: RwLockWriteGuard<'_, Versioning>,
+        mut compaction_guard: impl DerefMut<Target = Compaction>,
+        mut versioning_guard: impl DerefMut<Target = Versioning>,
     ) -> Result<Vec<bool>> {
         let deterministic_mode = self.env.opts.compaction_deterministic_test;
         let compaction: &mut Compaction = &mut compaction_guard;
@@ -764,7 +774,6 @@ impl HummockManager {
             BTreeMapTransaction::new(&mut compaction.compact_task_assignment);
         // The compaction task is finished.
         let versioning: &mut Versioning = &mut versioning_guard;
-        let _timer = start_measure_real_process_timer!(self, "report_compact_tasks");
 
         // purge stale compact_status
         for group_id in original_keys {

--- a/src/meta/src/hummock/manager/context.rs
+++ b/src/meta/src/hummock/manager/context.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use std::collections::{BTreeMap, HashMap, HashSet};
+use std::sync::Arc;
 
 use fail::fail_point;
 use futures::{StreamExt, stream};
@@ -30,8 +31,8 @@ use sea_orm::{DatabaseConnection, EntityTrait};
 use crate::controller::SqlMetaStore;
 use crate::hummock::HummockManager;
 use crate::hummock::error::{Error, Result};
+use crate::hummock::manager::commit_multi_var;
 use crate::hummock::manager::worker::{HummockManagerEvent, HummockManagerEventSender};
-use crate::hummock::manager::{commit_multi_var, start_measure_real_process_timer};
 use crate::hummock::metrics_utils::trigger_pin_unpin_version_state;
 use crate::manager::{META_NODE_ID, MetadataManager};
 use crate::model::BTreeMapTransaction;
@@ -161,7 +162,6 @@ impl HummockManager {
         let (active_context_ids, mut context_info) = {
             let compaction_guard = self.compaction.read().await;
             let context_info = self.context_info.write().await;
-            let _timer = start_measure_real_process_timer!(self, "release_invalid_contexts");
             let mut active_context_ids = HashSet::new();
             active_context_ids.extend(
                 compaction_guard
@@ -353,12 +353,11 @@ async fn check_gc_history(
 impl HummockManager {
     /// Pin the current greatest hummock version. The pin belongs to `context_id`
     /// and will be unpinned when `context_id` is invalidated.
-    pub async fn pin_version(&self, context_id: HummockContextId) -> Result<HummockVersion> {
+    pub async fn pin_version(&self, context_id: HummockContextId) -> Result<Arc<HummockVersion>> {
         let versioning = self.versioning.read().await;
         let mut context_info = self.context_info.write().await;
         self.check_context_with_meta_node(context_id, &context_info)
             .await?;
-        let _timer = start_measure_real_process_timer!(self, "pin_version");
         let mut pinned_versions = BTreeMapTransaction::new(&mut context_info.pinned_versions);
         let mut context_pinned_version = pinned_versions.new_entry_txn_or_default(
             context_id,
@@ -398,7 +397,6 @@ impl HummockManager {
         let mut context_info = self.context_info.write().await;
         self.check_context_with_meta_node(context_id, &context_info)
             .await?;
-        let _timer = start_measure_real_process_timer!(self, "unpin_version_before");
         let mut pinned_versions = BTreeMapTransaction::new(&mut context_info.pinned_versions);
         let mut context_pinned_version = pinned_versions.new_entry_txn_or_default(
             context_id,

--- a/src/meta/src/hummock/manager/mod.rs
+++ b/src/meta/src/hummock/manager/mod.rs
@@ -159,17 +159,6 @@ pub type HummockManagerRef = Arc<HummockManager>;
 use risingwave_object_store::object::{ObjectError, ObjectStoreRef, build_remote_object_store};
 use risingwave_pb::catalog::Table;
 
-macro_rules! start_measure_real_process_timer {
-    ($hummock_mgr:expr, $func_name:literal) => {
-        $hummock_mgr
-            .metrics
-            .hummock_manager_real_process_time
-            .with_label_values(&[$func_name])
-            .start_timer()
-    };
-}
-pub(crate) use start_measure_real_process_timer;
-
 use super::IcebergCompactorManager;
 use crate::controller::SqlMetaStore;
 use crate::hummock::manager::compaction_group_manager::CompactionGroupManager;
@@ -303,21 +292,25 @@ impl HummockManager {
             env,
             versioning: MonitoredRwLock::new(
                 metrics.hummock_manager_lock_time.clone(),
+                metrics.hummock_manager_real_process_time.clone(),
                 Default::default(),
                 "hummock_manager::versioning",
             ),
             compaction: MonitoredRwLock::new(
                 metrics.hummock_manager_lock_time.clone(),
+                metrics.hummock_manager_real_process_time.clone(),
                 Default::default(),
                 "hummock_manager::compaction",
             ),
             compaction_group_manager: MonitoredRwLock::new(
                 metrics.hummock_manager_lock_time.clone(),
+                metrics.hummock_manager_real_process_time.clone(),
                 compaction_group_manager,
                 "hummock_manager::compaction_group_manager",
             ),
             context_info: MonitoredRwLock::new(
                 metrics.hummock_manager_lock_time.clone(),
+                metrics.hummock_manager_real_process_time.clone(),
                 Default::default(),
                 "hummock_manager::context_info",
             ),

--- a/src/meta/src/hummock/manager/mod.rs
+++ b/src/meta/src/hummock/manager/mod.rs
@@ -19,7 +19,7 @@ use std::sync::atomic::AtomicBool;
 
 use anyhow::anyhow;
 use bytes::Bytes;
-use itertools::Itertools;
+use futures::FutureExt;
 use parking_lot::lock_api::RwLock;
 use risingwave_common::catalog::{TableId, TableOption};
 use risingwave_common::monitor::MonitoredRwLock;
@@ -135,6 +135,7 @@ pub struct HummockManager {
     table_write_throughput_statistic_manager:
         parking_lot::RwLock<TableWriteThroughputStatisticManager>,
     table_committed_epoch_notifiers: parking_lot::Mutex<TableCommittedEpochNotifiers>,
+    version_stat_tx: UnboundedSender<Arc<HummockVersion>>,
 
     // for compactor
     // `compactor_streams_change_tx` is used to pass the mapping from `context_id` to event_stream
@@ -283,6 +284,7 @@ impl HummockManager {
         let version_checkpoint_path = version_checkpoint_path(state_store_dir);
         let version_archive_dir = version_archive_dir(state_store_dir);
         let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
+        let (version_stat_tx, mut version_stat_rx) = tokio::sync::mpsc::unbounded_channel();
         let inflight_time_travel_query = env.opts.max_inflight_time_travel_query;
         let gc_manager = GcManager::new(
             object_store.clone(),
@@ -336,6 +338,7 @@ impl HummockManager {
                     txs: Default::default(),
                 },
             ),
+            version_stat_tx,
             compactor_streams_change_tx,
             compaction_state: CompactionState::new(),
             full_gc_state: FullGcState::new().into(),
@@ -345,6 +348,15 @@ impl HummockManager {
             table_id_to_table_option: RwLock::new(HashMap::new()),
         };
         let instance = Arc::new(instance);
+        let version_stat_metrics = instance.metrics.clone();
+        tokio::spawn(async move {
+            while let Some(mut version) = version_stat_rx.recv().await {
+                while let Some(Some(next_version)) = version_stat_rx.recv().now_or_never() {
+                    version = next_version;
+                }
+                transaction::trigger_version_stat(&version_stat_metrics, version.as_ref());
+            }
+        });
         instance.init_time_travel_state().await?;
         instance.start_worker(rx);
         instance.load_meta_store_state().await?;
@@ -425,7 +437,7 @@ impl HummockManager {
         let checkpoint = self.try_read_checkpoint().await?;
         let mut redo_state = if let Some(c) = checkpoint {
             versioning_guard.checkpoint = c;
-            versioning_guard.checkpoint.version.clone()
+            versioning_guard.checkpoint.version.as_ref().clone()
         } else {
             let default_compaction_config = self
                 .compaction_group_manager
@@ -435,7 +447,7 @@ impl HummockManager {
             let checkpoint_version = HummockVersion::create_init_version(default_compaction_config);
             tracing::info!("init hummock version checkpoint");
             versioning_guard.checkpoint = HummockVersionCheckpoint {
-                version: checkpoint_version.clone(),
+                version: Arc::new(checkpoint_version.clone()),
                 stale_objects: Default::default(),
             };
             self.write_checkpoint(&versioning_guard.checkpoint).await?;
@@ -483,7 +495,7 @@ impl HummockManager {
                 ..Default::default()
             });
 
-        versioning_guard.current_version = redo_state;
+        versioning_guard.current_version = Arc::new(redo_state);
         versioning_guard.hummock_version_deltas = hummock_version_deltas;
 
         context_info.pinned_versions = hummock_pinned_version::Entity::find()
@@ -514,6 +526,7 @@ impl HummockManager {
     /// Replay a version delta to current hummock version.
     /// Returns the `version_id`, `max_committed_epoch` of the new version and the modified
     /// compaction groups
+    #[cfg(any(test, feature = "test"))]
     pub async fn replay_version_delta(
         &self,
         mut version_delta: HummockVersionDelta,
@@ -522,16 +535,15 @@ impl HummockManager {
         // ensure the version id is ascending after replay
         version_delta.id = versioning_guard.current_version.next_version_id();
         version_delta.prev_id = versioning_guard.current_version.id;
-        versioning_guard
-            .current_version
-            .apply_version_delta(&version_delta);
+        let mut version_new = versioning_guard.current_version.as_ref().clone();
+        version_new.apply_version_delta(&version_delta);
 
-        let version_new = versioning_guard.current_version.clone();
-        let compaction_group_ids = version_delta.group_deltas.keys().cloned().collect_vec();
+        let compaction_group_ids = version_delta.group_deltas.keys().cloned().collect();
+        versioning_guard.current_version = Arc::new(version_new.clone());
         Ok((version_new, compaction_group_ids))
     }
 
-    pub async fn disable_commit_epoch(&self) -> HummockVersion {
+    pub async fn disable_commit_epoch(&self) -> Arc<HummockVersion> {
         let mut versioning_guard = self.versioning.write().await;
         versioning_guard.disable_commit_epochs = true;
         versioning_guard.current_version.clone()

--- a/src/meta/src/hummock/manager/tests.rs
+++ b/src/meta/src/hummock/manager/tests.rs
@@ -1373,7 +1373,7 @@ async fn test_extend_objects_to_delete() {
             .len(),
         orphan_sst_num
     );
-    let pinned_version2: HummockVersion = hummock_manager.pin_version(context_id).await.unwrap();
+    let pinned_version2 = hummock_manager.pin_version(context_id).await.unwrap();
     hummock_manager
         .unpin_version_before(context_id, pinned_version2.id)
         .await
@@ -1399,7 +1399,7 @@ async fn test_extend_objects_to_delete() {
         )
         .await
         .unwrap();
-    let pinned_version3: HummockVersion = hummock_manager.pin_version(context_id).await.unwrap();
+    let pinned_version3 = hummock_manager.pin_version(context_id).await.unwrap();
     assert_eq!(new_epoch, version_max_committed_epoch(&pinned_version3));
     hummock_manager
         .unpin_version_before(context_id, pinned_version3.id)
@@ -3029,7 +3029,7 @@ async fn test_old_version_dropped_table_sst_does_not_make_new_compaction_fail() 
     // will pass the stale read set to catalog acquire and fail before compaction can run.
     initial_manager
         .write_checkpoint(&HummockVersionCheckpoint {
-            version: dirty_version,
+            version: Arc::new(dirty_version),
             stale_objects: Default::default(),
         })
         .await

--- a/src/meta/src/hummock/manager/tests.rs
+++ b/src/meta/src/hummock/manager/tests.rs
@@ -3671,42 +3671,40 @@ async fn test_time_travel_vacuum_with_cross_database_epoch_order() {
 
     let mut version_10 = HummockVersion::default();
     version_10.id = 10.into();
-    version_10.state_table_info =
-        HummockVersionStateTableInfo::from_protobuf(&HashMap::from([
-            (
-                table_a,
-                StateTableInfo {
-                    committed_epoch: 300,
-                    compaction_group_id: 1.into(),
-                },
-            ),
-            (
-                table_b,
-                StateTableInfo {
-                    committed_epoch: 100,
-                    compaction_group_id: 1.into(),
-                },
-            ),
-        ]));
+    version_10.state_table_info = HummockVersionStateTableInfo::from_protobuf(&HashMap::from([
+        (
+            table_a,
+            StateTableInfo {
+                committed_epoch: 300,
+                compaction_group_id: 1.into(),
+            },
+        ),
+        (
+            table_b,
+            StateTableInfo {
+                committed_epoch: 100,
+                compaction_group_id: 1.into(),
+            },
+        ),
+    ]));
     let mut version_11 = version_10.clone();
     version_11.id = 11.into();
-    version_11.state_table_info =
-        HummockVersionStateTableInfo::from_protobuf(&HashMap::from([
-            (
-                table_a,
-                StateTableInfo {
-                    committed_epoch: 300,
-                    compaction_group_id: 1.into(),
-                },
-            ),
-            (
-                table_b,
-                StateTableInfo {
-                    committed_epoch: 200,
-                    compaction_group_id: 1.into(),
-                },
-            ),
-        ]));
+    version_11.state_table_info = HummockVersionStateTableInfo::from_protobuf(&HashMap::from([
+        (
+            table_a,
+            StateTableInfo {
+                committed_epoch: 300,
+                compaction_group_id: 1.into(),
+            },
+        ),
+        (
+            table_b,
+            StateTableInfo {
+                committed_epoch: 200,
+                compaction_group_id: 1.into(),
+            },
+        ),
+    ]));
     for version in [&version_10, &version_11] {
         hummock_time_travel_version::Entity::insert(hummock_time_travel_version::ActiveModel {
             version_id: Set(version.id),

--- a/src/meta/src/hummock/manager/tests.rs
+++ b/src/meta/src/hummock/manager/tests.rs
@@ -3660,6 +3660,138 @@ async fn test_schedule_group_split_with_normalize_disabled() {
 }
 
 #[tokio::test]
+async fn test_time_travel_vacuum_with_cross_database_epoch_order() {
+    use risingwave_meta_model::{hummock_epoch_to_version, hummock_time_travel_version};
+    use sea_orm::ActiveValue::Set;
+    use sea_orm::{EntityTrait, PaginatorTrait};
+
+    let (env, hummock_manager, _, _) = setup_compute_env(80).await;
+    let table_a = TableId::new(1);
+    let table_b = TableId::new(2);
+
+    let mut version_10 = HummockVersion::default();
+    version_10.id = 10.into();
+    version_10.state_table_info =
+        HummockVersionStateTableInfo::from_protobuf(&HashMap::from([
+            (
+                table_a,
+                StateTableInfo {
+                    committed_epoch: 300,
+                    compaction_group_id: 1.into(),
+                },
+            ),
+            (
+                table_b,
+                StateTableInfo {
+                    committed_epoch: 100,
+                    compaction_group_id: 1.into(),
+                },
+            ),
+        ]));
+    let mut version_11 = version_10.clone();
+    version_11.id = 11.into();
+    version_11.state_table_info =
+        HummockVersionStateTableInfo::from_protobuf(&HashMap::from([
+            (
+                table_a,
+                StateTableInfo {
+                    committed_epoch: 300,
+                    compaction_group_id: 1.into(),
+                },
+            ),
+            (
+                table_b,
+                StateTableInfo {
+                    committed_epoch: 200,
+                    compaction_group_id: 1.into(),
+                },
+            ),
+        ]));
+    for version in [&version_10, &version_11] {
+        hummock_time_travel_version::Entity::insert(hummock_time_travel_version::ActiveModel {
+            version_id: Set(version.id),
+            version: Set((&version.to_protobuf()).into()),
+        })
+        .exec(&env.meta_store_ref().conn)
+        .await
+        .unwrap();
+    }
+    for (table_id, epoch, version_id) in [
+        (table_b, 100_u64, 10_u64),
+        (table_b, 200, 11),
+        (table_a, 300, 10),
+    ] {
+        hummock_epoch_to_version::Entity::insert(hummock_epoch_to_version::ActiveModel {
+            epoch: Set(epoch.try_into().unwrap()),
+            table_id: Set(i64::from(table_id.as_raw_id())),
+            version_id: Set(version_id.into()),
+        })
+        .exec(&env.meta_store_ref().conn)
+        .await
+        .unwrap();
+    }
+
+    hummock_manager
+        .truncate_time_travel_metadata(50, HashMap::new())
+        .await
+        .unwrap();
+    assert_eq!(
+        hummock_epoch_to_version::Entity::find()
+            .count(&env.meta_store_ref().conn)
+            .await
+            .unwrap(),
+        3
+    );
+    assert_eq!(
+        hummock_time_travel_version::Entity::find()
+            .count(&env.meta_store_ref().conn)
+            .await
+            .unwrap(),
+        2
+    );
+
+    hummock_manager
+        .truncate_time_travel_metadata(250, HashMap::new())
+        .await
+        .unwrap();
+
+    assert_eq!(
+        hummock_time_travel_version::Entity::find()
+            .count(&env.meta_store_ref().conn)
+            .await
+            .unwrap(),
+        2
+    );
+    assert_eq!(
+        hummock_manager
+            .epoch_to_version(300, table_a)
+            .await
+            .unwrap()
+            .id,
+        version_10.id
+    );
+
+    hummock_manager
+        .truncate_time_travel_metadata(350, HashMap::new())
+        .await
+        .unwrap();
+    assert_eq!(
+        hummock_time_travel_version::Entity::find()
+            .count(&env.meta_store_ref().conn)
+            .await
+            .unwrap(),
+        1
+    );
+    assert!(
+        hummock_time_travel_version::Entity::find_by_id(version_11.id)
+            .one(&env.meta_store_ref().conn)
+            .await
+            .unwrap()
+            .is_some()
+    );
+}
+
+#[tokio::test]
 async fn test_time_travel_vacuum_pins_snapshot_epoch() {
     use risingwave_hummock_sdk::level::Levels;
     use risingwave_meta_model::hummock_sstable_info::SstableInfoV2Backend;
@@ -3782,7 +3914,7 @@ async fn test_time_travel_vacuum_pins_snapshot_epoch() {
             .unwrap();
     assert_eq!(
         version_ids.iter().map(|id| id.as_raw_id()).collect_vec(),
-        vec![1, 4, 5]
+        vec![1, 5]
     );
     let delta_ids: Vec<risingwave_meta_model::HummockVersionId> =
         hummock_time_travel_delta::Entity::find()
@@ -3853,7 +3985,7 @@ async fn test_time_travel_vacuum_pins_snapshot_epoch() {
             .count(&env.meta_store_ref().conn)
             .await
             .unwrap(),
-        2
+        1
     );
     assert_eq!(
         hummock_time_travel_delta::Entity::find()

--- a/src/meta/src/hummock/manager/time_travel.rs
+++ b/src/meta/src/hummock/manager/time_travel.rs
@@ -77,6 +77,19 @@ impl HummockManager {
 
         let epoch_watermark_model =
             risingwave_meta_model::Epoch::try_from(epoch_watermark).unwrap();
+        let has_expired_epoch = hummock_epoch_to_version::Entity::find()
+            .filter(hummock_epoch_to_version::Column::Epoch.lt(epoch_watermark_model))
+            .select_only()
+            .column(hummock_epoch_to_version::Column::VersionId)
+            .into_tuple::<HummockVersionId>()
+            .one(&txn)
+            .await?
+            .is_some();
+        if !has_expired_epoch {
+            txn.commit().await?;
+            return Ok(());
+        }
+
         let mut pinned_epoch_rows = HashSet::new();
         let mut pinned_snapshot_version_ids = HashSet::new();
         for (table_id, pinned_epochs) in pinned_snapshot_epochs {
@@ -129,18 +142,22 @@ impl HummockManager {
             }
         }
 
+        // Version ids follow global commit order, while epochs are only monotonic per table.
+        // Use the earliest version needed by any retained mapping as the watermark so its replay
+        // metadata cannot be truncated. If no mapping is retained, only version pins and vacuum
+        // throttling need to constrain the watermark.
         let version_watermark = hummock_epoch_to_version::Entity::find()
-            .filter(hummock_epoch_to_version::Column::Epoch.lt(epoch_watermark_model))
-            .order_by_desc(hummock_epoch_to_version::Column::Epoch)
+            .filter(hummock_epoch_to_version::Column::Epoch.gte(epoch_watermark_model))
+            .select_only()
+            .column(hummock_epoch_to_version::Column::VersionId)
             .order_by_asc(hummock_epoch_to_version::Column::VersionId)
+            .into_tuple::<HummockVersionId>()
             .one(&txn)
             .await?;
-        let Some(version_watermark) = version_watermark else {
-            txn.commit().await?;
-            return Ok(());
-        };
-        let mut watermark_version_id =
-            std::cmp::min(version_watermark.version_id, min_pinned_version_id);
+        // metadata BELOW watermark_version_id will be truncated.
+        let mut watermark_version_id = version_watermark.map_or(min_pinned_version_id, |id| {
+            std::cmp::min(id, min_pinned_version_id)
+        });
         if let Some(max_version_count) = self.env.opts.time_travel_vacuum_max_version_count {
             let mut query = hummock_time_travel_version::Entity::find()
                 .select_only()

--- a/src/meta/src/hummock/manager/transaction.rs
+++ b/src/meta/src/hummock/manager/transaction.rs
@@ -14,6 +14,7 @@
 
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::ops::{Deref, DerefMut};
+use std::sync::Arc;
 
 use parking_lot::Mutex;
 use risingwave_common::catalog::TableId;
@@ -44,7 +45,7 @@ fn trigger_delta_log_stats(metrics: &MetaMetrics, total_number: usize) {
     metrics.delta_log_count.set(total_number as _);
 }
 
-fn trigger_version_stat(metrics: &MetaMetrics, current_version: &HummockVersion) {
+pub(super) fn trigger_version_stat(metrics: &MetaMetrics, current_version: &HummockVersion) {
     metrics
         .version_size
         .set(current_version.estimated_encode_len() as i64);
@@ -54,11 +55,12 @@ fn trigger_version_stat(metrics: &MetaMetrics, current_version: &HummockVersion)
 }
 
 pub(super) struct HummockVersionTransaction<'a> {
-    orig_version: &'a mut HummockVersion,
+    orig_version: &'a mut Arc<HummockVersion>,
     orig_deltas: &'a mut BTreeMap<HummockVersionId, HummockVersionDelta>,
     notification_manager: &'a NotificationManager,
     table_committed_epoch_notifiers: Option<&'a Mutex<TableCommittedEpochNotifiers>>,
     meta_metrics: &'a MetaMetrics,
+    version_stat_tx: &'a tokio::sync::mpsc::UnboundedSender<Arc<HummockVersion>>,
 
     pre_applied_version: Option<(HummockVersion, Vec<HummockVersionDelta>)>,
     disable_apply_to_txn: bool,
@@ -66,11 +68,12 @@ pub(super) struct HummockVersionTransaction<'a> {
 
 impl<'a> HummockVersionTransaction<'a> {
     pub(super) fn new(
-        version: &'a mut HummockVersion,
+        version: &'a mut Arc<HummockVersion>,
         deltas: &'a mut BTreeMap<HummockVersionId, HummockVersionDelta>,
         notification_manager: &'a NotificationManager,
         table_committed_epoch_notifiers: Option<&'a Mutex<TableCommittedEpochNotifiers>>,
         meta_metrics: &'a MetaMetrics,
+        version_stat_tx: &'a tokio::sync::mpsc::UnboundedSender<Arc<HummockVersion>>,
     ) -> Self {
         Self {
             orig_version: version,
@@ -80,6 +83,7 @@ impl<'a> HummockVersionTransaction<'a> {
             notification_manager,
             table_committed_epoch_notifiers,
             meta_metrics,
+            version_stat_tx,
         }
     }
 
@@ -95,7 +99,7 @@ impl<'a> HummockVersionTransaction<'a> {
         if let Some((version, _)) = &self.pre_applied_version {
             version
         } else {
-            self.orig_version
+            self.orig_version.as_ref()
         }
     }
 
@@ -110,7 +114,7 @@ impl<'a> HummockVersionTransaction<'a> {
     fn pre_apply(&mut self, delta: HummockVersionDelta) {
         let (version, deltas) = self
             .pre_applied_version
-            .get_or_insert_with(|| (self.orig_version.clone(), Vec::with_capacity(1)));
+            .get_or_insert_with(|| (self.orig_version.as_ref().clone(), Vec::with_capacity(1)));
         version.apply_version_delta(&delta);
         deltas.push(delta);
     }
@@ -223,7 +227,7 @@ impl<'a> HummockVersionTransaction<'a> {
 impl InMemValTransaction for HummockVersionTransaction<'_> {
     fn commit(self) {
         if let Some((version, deltas)) = self.pre_applied_version {
-            *self.orig_version = version;
+            *self.orig_version = Arc::new(version);
             if !self.disable_apply_to_txn {
                 let pb_deltas = deltas.iter().map(|delta| delta.to_protobuf()).collect();
                 self.notification_manager.notify_hummock_without_version(
@@ -255,7 +259,7 @@ impl InMemValTransaction for HummockVersionTransaction<'_> {
             }
 
             trigger_delta_log_stats(self.meta_metrics, self.orig_deltas.len());
-            trigger_version_stat(self.meta_metrics, self.orig_version);
+            let _ = self.version_stat_tx.send(self.orig_version.clone());
         }
     }
 }

--- a/src/meta/src/hummock/manager/versioning.rs
+++ b/src/meta/src/hummock/manager/versioning.rs
@@ -15,6 +15,7 @@
 use std::cmp;
 use std::collections::Bound::{Excluded, Included};
 use std::collections::{BTreeMap, HashMap, HashSet};
+use std::sync::Arc;
 
 use itertools::Itertools;
 use risingwave_hummock_sdk::change_log::{EpochNewChangeLog, TableChangeLog, TableChangeLogs};
@@ -56,7 +57,7 @@ pub struct Versioning {
     /// Don't persist compaction version delta to meta store
     pub disable_commit_epochs: bool,
     /// Latest hummock version
-    pub current_version: HummockVersion,
+    pub current_version: Arc<HummockVersion>,
     pub local_metrics: HashMap<TableId, LocalTableMetrics>,
     pub time_travel_snapshot_interval_counter: u64,
     /// Used to avoid the attempts to rewrite the same SST to meta store
@@ -156,7 +157,7 @@ impl HummockManager {
     }
 
     pub async fn on_current_version<T>(&self, mut f: impl FnMut(&HummockVersion) -> T) -> T {
-        f(&self.versioning.read().await.current_version)
+        f(self.versioning.read().await.current_version.as_ref())
     }
 
     pub async fn get_version_id(&self) -> HummockVersionId {
@@ -268,6 +269,7 @@ impl HummockManager {
                 self.env.notification_manager(),
                 None,
                 &self.metrics,
+                &self.version_stat_tx,
             );
             let mut new_version_delta = version.new_delta();
             new_version_delta.with_latest_version(|version, delta| {

--- a/src/meta/src/hummock/metrics_utils.rs
+++ b/src/meta/src/hummock/metrics_utils.rs
@@ -27,6 +27,7 @@ use risingwave_hummock_sdk::level::Levels;
 use risingwave_hummock_sdk::table_stats::PbTableStatsMap;
 use risingwave_hummock_sdk::version::HummockVersion;
 use risingwave_hummock_sdk::{CompactionGroupId, HummockContextId, HummockVersionId};
+use risingwave_pb::hummock::hummock_version_checkpoint::PbStaleObjects;
 use risingwave_pb::hummock::write_limits::WriteLimit;
 use risingwave_pb::hummock::{
     CompactionConfig, HummockPinnedVersion, HummockVersionStats, LevelType,
@@ -34,7 +35,6 @@ use risingwave_pb::hummock::{
 
 use super::compaction::selector::DynamicLevelSelectorCore;
 use super::compaction::{CompactionDeveloperConfig, get_compression_algorithm};
-use crate::hummock::checkpoint::HummockVersionCheckpoint;
 use crate::hummock::compaction::CompactStatus;
 use crate::rpc::metrics::MetaMetrics;
 
@@ -517,19 +517,22 @@ pub fn trigger_pin_unpin_version_state(
     }
 }
 
-pub fn trigger_gc_stat(
-    metrics: &MetaMetrics,
-    checkpoint: &HummockVersionCheckpoint,
+pub struct GcStaleObjectStats {
+    old_version_object_size: u64,
+    old_version_object_count: u64,
+    stale_object_size: u64,
+    stale_object_count: u64,
+}
+
+pub fn gc_stale_object_stats(
+    stale_objects: &HashMap<HummockVersionId, PbStaleObjects>,
     min_pinned_version_id: HummockVersionId,
-) {
-    let current_version_object_size_map = object_size_map(&checkpoint.version);
-    let current_version_object_size = current_version_object_size_map.values().sum::<u64>();
-    let current_version_object_count = current_version_object_size_map.len();
+) -> GcStaleObjectStats {
     let mut old_version_object_size = 0;
     let mut old_version_object_count = 0;
     let mut stale_object_size = 0;
     let mut stale_object_count = 0;
-    checkpoint.stale_objects.iter().for_each(|(id, objects)| {
+    stale_objects.iter().for_each(|(id, objects)| {
         if *id <= min_pinned_version_id {
             stale_object_size += objects.total_file_size;
             stale_object_count += objects.id.len() as u64;
@@ -538,6 +541,28 @@ pub fn trigger_gc_stat(
             old_version_object_count += objects.id.len() as u64;
         }
     });
+    GcStaleObjectStats {
+        old_version_object_size,
+        old_version_object_count,
+        stale_object_size,
+        stale_object_count,
+    }
+}
+
+pub fn trigger_gc_stat(
+    metrics: &MetaMetrics,
+    checkpoint_version: &HummockVersion,
+    stale_object_stats: GcStaleObjectStats,
+) {
+    let GcStaleObjectStats {
+        old_version_object_size,
+        old_version_object_count,
+        stale_object_size,
+        stale_object_count,
+    } = stale_object_stats;
+    let current_version_object_size_map = object_size_map(checkpoint_version);
+    let current_version_object_size = current_version_object_size_map.values().sum::<u64>();
+    let current_version_object_count = current_version_object_size_map.len();
     metrics
         .current_version_object_size
         .set(current_version_object_size as _);
@@ -553,7 +578,7 @@ pub fn trigger_gc_stat(
     metrics.stale_object_size.set(stale_object_size as _);
     metrics.stale_object_count.set(stale_object_count as _);
     // table change log
-    for (table_id, logs) in &checkpoint.version.table_change_log {
+    for (table_id, logs) in &checkpoint_version.table_change_log {
         let table_id_label = table_id.to_string();
         let labels = [table_id_label.as_str()];
         let object_count = logs

--- a/src/meta/src/rpc/ddl_controller.rs
+++ b/src/meta/src/rpc/ddl_controller.rs
@@ -187,6 +187,7 @@ pub enum DdlCommand {
     CreateSubscription(Subscription),
     DropSubscription(SubscriptionId, DropMode),
     AlterDatabaseParam(DatabaseId, AlterDatabaseParam),
+    AlterDatabaseResourceGroup(DatabaseId, Option<String>, bool),
     AlterStreamingJobConfig(JobId, HashMap<String, String>, Vec<String>),
 }
 
@@ -223,6 +224,7 @@ impl DdlCommand {
             DdlCommand::CreateSubscription(subscription) => Left(subscription.name.clone()),
             DdlCommand::DropSubscription(id, _) => Right(id.as_object_id()),
             DdlCommand::AlterDatabaseParam(id, _) => Right(id.as_object_id()),
+            DdlCommand::AlterDatabaseResourceGroup(id, _, _) => Right(id.as_object_id()),
             DdlCommand::AlterStreamingJobConfig(job_id, _, _) => Right(job_id.as_object_id()),
         }
     }
@@ -251,6 +253,7 @@ impl DdlCommand {
             | DdlCommand::AlterSecret(_)
             | DdlCommand::AlterSwapRename(_)
             | DdlCommand::AlterDatabaseParam(_, _)
+            | DdlCommand::AlterDatabaseResourceGroup(_, _, _)
             | DdlCommand::AlterStreamingJobConfig(_, _, _) => true,
             DdlCommand::CreateStreamingJob { .. }
             | DdlCommand::CreateNonSharedSource(_)
@@ -461,6 +464,10 @@ impl DdlController {
                 DdlCommand::AlterSwapRename(objects) => ctrl.alter_swap_rename(objects).await,
                 DdlCommand::AlterDatabaseParam(database_id, param) => {
                     ctrl.alter_database_param(database_id, param).await
+                }
+                DdlCommand::AlterDatabaseResourceGroup(database_id, resource_group, deferred) => {
+                    ctrl.alter_database_resource_group(database_id, resource_group, deferred)
+                        .await
                 }
                 DdlCommand::AlterStreamingJobConfig(job_id, entries_to_add, keys_to_remove) => {
                     ctrl.alter_streaming_job_config(job_id, entries_to_add, keys_to_remove)
@@ -702,6 +709,21 @@ impl DdlController {
                 updated_db.checkpoint_frequency.map(|v| v as u64),
             )
             .await?;
+        Ok(version)
+    }
+
+    async fn alter_database_resource_group(
+        &self,
+        database_id: DatabaseId,
+        resource_group: Option<String>,
+        _deferred: bool,
+    ) -> MetaResult<NotificationVersion> {
+        let version = self
+            .metadata_manager
+            .catalog_controller
+            .alter_database_resource_group(database_id, resource_group)
+            .await?;
+
         Ok(version)
     }
 

--- a/src/meta/src/rpc/metrics.rs
+++ b/src/meta/src/rpc/metrics.rs
@@ -590,21 +590,23 @@ impl MetaMetrics {
         );
         let version_checkpoint_latency = register_histogram_with_registry!(opts, registry).unwrap();
 
-        let hummock_manager_lock_time = register_histogram_vec_with_registry!(
+        let opts = histogram_opts!(
             "hummock_manager_lock_time",
             "latency for hummock manager to acquire the rwlock",
-            &["lock_name", "lock_type"],
-            registry
-        )
-        .unwrap();
+            exponential_buckets(0.02, 2.5, 10).unwrap() // max 76s
+        );
+        let hummock_manager_lock_time =
+            register_histogram_vec_with_registry!(opts, &["lock_name", "lock_type"], registry)
+                .unwrap();
 
-        let hummock_manager_real_process_time = register_histogram_vec_with_registry!(
+        let opts = histogram_opts!(
             "meta_hummock_manager_real_process_time",
             "latency for hummock manager to really process the request",
-            &["method"],
-            registry
-        )
-        .unwrap();
+            exponential_buckets(0.02, 2.5, 10).unwrap() // max 76s
+        );
+        let hummock_manager_real_process_time =
+            register_histogram_vec_with_registry!(opts, &["method", "lock_name"], registry)
+                .unwrap();
 
         let worker_num = register_int_gauge_vec_with_registry!(
             "worker_num",

--- a/src/meta/src/stream/stream_manager.rs
+++ b/src/meta/src/stream/stream_manager.rs
@@ -430,11 +430,14 @@ impl GlobalStreamManager {
                             );
 
                             let cancel_result: MetaResult<()> = async {
-                                let cancel_command = self.metadata_manager.catalog_controller
-                                    .build_cancel_command(&job_fragments)
-                                    .await?;
-                                let cleanup_state_table_ids =
-                                    job_fragments.all_table_ids().collect_vec();
+                                let Some((cancel_command, cleanup_state_table_ids)) = self
+                                    .metadata_manager
+                                    .catalog_controller
+                                    .build_cancel_command(job_id)
+                                    .await?
+                                else {
+                                    return Ok(());
+                                };
                                 let abort_result = self.metadata_manager.catalog_controller
                                     .try_abort_creating_streaming_job(job_id, true)
                                     .await?;
@@ -747,27 +750,14 @@ impl GlobalStreamManager {
         // NOTE(kwannoel): For background_job_ids stream jobs that not tracked in streaming manager,
         // we can directly cancel them by running the barrier command.
         let futures = background_job_ids.into_iter().map(|id| async move {
-            let fragment = self.metadata_manager.get_job_fragments_by_id(id).await?;
-            if fragment.is_created() {
-                tracing::warn!(
-                    "streaming job {} is already created, ignore cancel request",
-                    id
-                );
-                return Ok(None);
-            }
-            if fragment.is_created() {
-                Err(MetaError::invalid_parameter(format!(
-                    "streaming job {} is already created",
-                    id
-                )))?;
-            }
-
-            let cancel_command = self
+            let Some((cancel_command, cleanup_state_table_ids)) = self
                 .metadata_manager
                 .catalog_controller
-                .build_cancel_command(&fragment)
-                .await?;
-            let cleanup_state_table_ids = fragment.all_table_ids().collect_vec();
+                .build_cancel_command(id)
+                .await?
+            else {
+                return Ok(None);
+            };
 
             let abort_result = self
                 .metadata_manager

--- a/src/prost/build.rs
+++ b/src/prost/build.rs
@@ -180,6 +180,9 @@ for_all_wrapped_id_fields! (
         AlterDatabaseParamRequest {
             database_id: DatabaseId,
         }
+        AlterDatabaseResourceGroupRequest {
+            database_id: DatabaseId,
+        }
         AlterFragmentParallelismRequest {
             fragment_ids: FragmentId,
         }
@@ -187,7 +190,7 @@ for_all_wrapped_id_fields! (
             table_id: JobId,
         }
         AlterResourceGroupRequest {
-            table_id: TableId,
+            job_id: JobId,
         }
         AlterSecretRequest {
             database_id: DatabaseId,

--- a/src/rpc_client/src/meta_client.rs
+++ b/src/rpc_client/src/meta_client.rs
@@ -477,6 +477,7 @@ impl MetaClient {
         sink: PbSink,
         graph: StreamFragmentGraph,
         dependencies: HashSet<ObjectId>,
+        resource_type: streaming_job_resource_type::ResourceType,
         if_not_exists: bool,
     ) -> Result<WaitVersion> {
         let request = CreateSinkRequest {
@@ -484,6 +485,9 @@ impl MetaClient {
             fragment_graph: Some(graph),
             dependencies: dependencies.into_iter().collect(),
             if_not_exists,
+            resource_type: Some(PbStreamingJobResourceType {
+                resource_type: Some(resource_type),
+            }),
         };
 
         let resp = self.inner.create_sink(request).await?;
@@ -793,6 +797,7 @@ impl MetaClient {
         index: PbIndex,
         table: PbTable,
         graph: StreamFragmentGraph,
+        resource_type: streaming_job_resource_type::ResourceType,
         if_not_exists: bool,
     ) -> Result<WaitVersion> {
         let request = CreateIndexRequest {
@@ -800,6 +805,9 @@ impl MetaClient {
             index_table: Some(table),
             fragment_graph: Some(graph),
             if_not_exists,
+            resource_type: Some(PbStreamingJobResourceType {
+                resource_type: Some(resource_type),
+            }),
         };
         let resp = self.inner.create_index(request).await?;
         // TODO: handle error in `resp.status` here

--- a/src/rpc_client/src/meta_client.rs
+++ b/src/rpc_client/src/meta_client.rs
@@ -700,18 +700,36 @@ impl MetaClient {
 
     pub async fn alter_resource_group(
         &self,
-        table_id: TableId,
+        job_id: JobId,
         resource_group: Option<String>,
         deferred: bool,
     ) -> Result<()> {
         let request = AlterResourceGroupRequest {
-            table_id,
+            job_id,
             resource_group,
             deferred,
         };
 
         self.inner.alter_resource_group(request).await?;
         Ok(())
+    }
+
+    pub async fn alter_database_resource_group(
+        &self,
+        database_id: DatabaseId,
+        resource_group: Option<String>,
+        deferred: bool,
+    ) -> Result<WaitVersion> {
+        let request = AlterDatabaseResourceGroupRequest {
+            database_id,
+            resource_group,
+            deferred,
+        };
+
+        let resp = self.inner.alter_database_resource_group(request).await?;
+        Ok(resp
+            .version
+            .ok_or_else(|| anyhow!("wait version not set"))?)
     }
 
     pub async fn alter_swap_rename(
@@ -2666,6 +2684,7 @@ macro_rules! for_all_meta_rpc {
             ,{ ddl_client, alter_fragment_parallelism, AlterFragmentParallelismRequest, AlterFragmentParallelismResponse }
             ,{ ddl_client, alter_cdc_table_backfill_parallelism, AlterCdcTableBackfillParallelismRequest, AlterCdcTableBackfillParallelismResponse }
             ,{ ddl_client, alter_resource_group, AlterResourceGroupRequest, AlterResourceGroupResponse }
+            ,{ ddl_client, alter_database_resource_group, AlterDatabaseResourceGroupRequest, AlterDatabaseResourceGroupResponse }
             ,{ ddl_client, alter_database_param, AlterDatabaseParamRequest, AlterDatabaseParamResponse }
             ,{ ddl_client, create_materialized_view, CreateMaterializedViewRequest, CreateMaterializedViewResponse }
             ,{ ddl_client, create_view, CreateViewRequest, CreateViewResponse }

--- a/src/sqlparser/src/ast/ddl.rs
+++ b/src/sqlparser/src/ast/ddl.rs
@@ -24,9 +24,19 @@ use crate::tokenizer::Token;
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum AlterDatabaseOperation {
-    ChangeOwner { new_owner_name: Ident },
-    RenameDatabase { database_name: ObjectName },
+    ChangeOwner {
+        new_owner_name: Ident,
+    },
+    RenameDatabase {
+        database_name: ObjectName,
+    },
     SetParam(ConfigParam),
+    /// `SET RESOURCE_GROUP TO 'RESOURCE GROUP' [ DEFERRED ]`
+    /// `RESET RESOURCE_GROUP [ DEFERRED ]`
+    SetResourceGroup {
+        resource_group: Option<SetVariableValue>,
+        deferred: bool,
+    },
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -140,6 +150,12 @@ pub enum AlterIndexOperation {
         parallelism: SetVariableValue,
         deferred: bool,
     },
+    /// `SET RESOURCE_GROUP TO 'RESOURCE GROUP' [ DEFERRED ]`
+    /// `RESET RESOURCE_GROUP [ DEFERRED ]`
+    SetResourceGroup {
+        resource_group: Option<SetVariableValue>,
+        deferred: bool,
+    },
     /// `SET CONFIG (key = value, ...)`
     SetConfig {
         entries: Vec<SqlOption>,
@@ -211,6 +227,12 @@ pub enum AlterSinkOperation {
     /// `SET PARALLELISM TO <parallelism> [ DEFERRED ]`
     SetParallelism {
         parallelism: SetVariableValue,
+        deferred: bool,
+    },
+    /// `SET RESOURCE_GROUP TO 'RESOURCE GROUP' [ DEFERRED ]`
+    /// `RESET RESOURCE_GROUP [ DEFERRED ]`
+    SetResourceGroup {
+        resource_group: Option<SetVariableValue>,
         deferred: bool,
     },
     /// `SET CONFIG (key = value, ...)`
@@ -332,6 +354,18 @@ impl fmt::Display for AlterDatabaseOperation {
             }
             AlterDatabaseOperation::SetParam(ConfigParam { param, value }) => {
                 write!(f, "SET {} TO {}", param, value)
+            }
+            AlterDatabaseOperation::SetResourceGroup {
+                resource_group,
+                deferred,
+            } => {
+                let deferred = if *deferred { " DEFERRED" } else { "" };
+
+                if let Some(resource_group) = resource_group {
+                    write!(f, "SET RESOURCE_GROUP TO {}{}", resource_group, deferred)
+                } else {
+                    write!(f, "RESET RESOURCE_GROUP{}", deferred)
+                }
             }
         }
     }
@@ -471,6 +505,18 @@ impl fmt::Display for AlterIndexOperation {
                     if *deferred { " DEFERRED" } else { "" }
                 )
             }
+            AlterIndexOperation::SetResourceGroup {
+                resource_group,
+                deferred,
+            } => {
+                let deferred = if *deferred { " DEFERRED" } else { "" };
+
+                if let Some(resource_group) = resource_group {
+                    write!(f, "SET RESOURCE_GROUP TO {}{}", resource_group, deferred)
+                } else {
+                    write!(f, "RESET RESOURCE_GROUP{}", deferred)
+                }
+            }
             AlterIndexOperation::SetConfig { entries } => {
                 write!(f, "SET CONFIG ({})", display_comma_separated(entries))
             }
@@ -517,9 +563,9 @@ impl fmt::Display for AlterViewOperation {
                 let deferred = if *deferred { " DEFERRED" } else { "" };
 
                 if let Some(resource_group) = resource_group {
-                    write!(f, "SET RESOURCE_GROUP TO {} {}", resource_group, deferred)
+                    write!(f, "SET RESOURCE_GROUP TO {}{}", resource_group, deferred)
                 } else {
-                    write!(f, "RESET RESOURCE_GROUP {}", deferred)
+                    write!(f, "RESET RESOURCE_GROUP{}", deferred)
                 }
             }
             AlterViewOperation::SetStreamingEnableUnalignedJoin { enable } => {
@@ -560,6 +606,18 @@ impl fmt::Display for AlterSinkOperation {
                     parallelism,
                     if *deferred { " DEFERRED" } else { "" }
                 )
+            }
+            AlterSinkOperation::SetResourceGroup {
+                resource_group,
+                deferred,
+            } => {
+                let deferred = if *deferred { " DEFERRED" } else { "" };
+
+                if let Some(resource_group) = resource_group {
+                    write!(f, "SET RESOURCE_GROUP TO {}{}", resource_group, deferred)
+                } else {
+                    write!(f, "RESET RESOURCE_GROUP{}", deferred)
+                }
             }
             AlterSinkOperation::SetConfig { entries } => {
                 write!(f, "SET CONFIG ({})", display_comma_separated(entries))

--- a/src/sqlparser/src/parser.rs
+++ b/src/sqlparser/src/parser.rs
@@ -3176,10 +3176,40 @@ impl Parser<'_> {
                 return self.expected("TO after RENAME");
             }
         } else if self.parse_keyword(Keyword::SET) {
-            // check will be delayed to frontend
-            AlterDatabaseOperation::SetParam(self.parse_config_param()?)
+            if self.parse_keyword(Keyword::RESOURCE_GROUP) {
+                if self.expect_keyword(Keyword::TO).is_err()
+                    && self.expect_token(&Token::Eq).is_err()
+                {
+                    return self.expected("TO or = after ALTER DATABASE SET RESOURCE_GROUP");
+                }
+                let value = self.parse_set_variable()?;
+                if !self.parse_keyword(Keyword::DEFERRED) {
+                    return self.expected("DEFERRED after ALTER DATABASE SET RESOURCE_GROUP");
+                }
+
+                AlterDatabaseOperation::SetResourceGroup {
+                    resource_group: Some(value),
+                    deferred: true,
+                }
+            } else {
+                // check will be delayed to frontend
+                AlterDatabaseOperation::SetParam(self.parse_config_param()?)
+            }
+        } else if self.parse_keyword(Keyword::RESET) {
+            if self.parse_keyword(Keyword::RESOURCE_GROUP) {
+                if !self.parse_keyword(Keyword::DEFERRED) {
+                    return self.expected("DEFERRED after ALTER DATABASE RESET RESOURCE_GROUP");
+                }
+
+                AlterDatabaseOperation::SetResourceGroup {
+                    resource_group: None,
+                    deferred: true,
+                }
+            } else {
+                return self.expected("RESOURCE_GROUP after RESET");
+            }
         } else {
-            return self.expected("RENAME, OWNER TO, OR SET after ALTER DATABASE");
+            return self.expected("RENAME, OWNER TO, SET, OR RESET after ALTER DATABASE");
         };
 
         Ok(Statement::AlterDatabase {
@@ -3449,18 +3479,38 @@ impl Parser<'_> {
                     parallelism: value,
                     deferred,
                 }
+            } else if self.parse_keyword(Keyword::RESOURCE_GROUP) {
+                if self.expect_keyword(Keyword::TO).is_err()
+                    && self.expect_token(&Token::Eq).is_err()
+                {
+                    return self.expected("TO or = after ALTER INDEX SET RESOURCE_GROUP");
+                }
+                let value = self.parse_set_variable()?;
+                let deferred = self.parse_keyword(Keyword::DEFERRED);
+
+                AlterIndexOperation::SetResourceGroup {
+                    resource_group: Some(value),
+                    deferred,
+                }
             } else if self.parse_keyword(Keyword::CONFIG) {
                 let entries = self.parse_options()?;
                 AlterIndexOperation::SetConfig { entries }
             } else {
-                return self.expected("PARALLELISM or CONFIG after SET");
+                return self.expected("PARALLELISM/RESOURCE_GROUP or CONFIG after SET");
             }
         } else if self.parse_keyword(Keyword::RESET) {
-            if self.parse_keyword(Keyword::CONFIG) {
+            if self.parse_keyword(Keyword::RESOURCE_GROUP) {
+                let deferred = self.parse_keyword(Keyword::DEFERRED);
+
+                AlterIndexOperation::SetResourceGroup {
+                    resource_group: None,
+                    deferred,
+                }
+            } else if self.parse_keyword(Keyword::CONFIG) {
                 let keys = self.parse_parenthesized_object_name_list()?;
                 AlterIndexOperation::ResetConfig { keys }
             } else {
-                return self.expected("CONFIG after RESET");
+                return self.expected("RESOURCE_GROUP or CONFIG after RESET");
             }
         } else {
             return self.expected("RENAME, SET, or RESET after ALTER INDEX");
@@ -3643,15 +3693,33 @@ impl Parser<'_> {
                 AlterSinkOperation::SetConfig { entries }
             } else {
                 return self.expected(
-                    "SCHEMA/PARALLELISM/SINK_RATE_LIMIT/BACKFILL_RATE_LIMIT/STREAMING_ENABLE_UNALIGNED_JOIN/CONFIG after SET",
+                    "SCHEMA/PARALLELISM/SINK_RATE_LIMIT/BACKFILL_RATE_LIMIT/STREAMING_ENABLE_UNALIGNED_JOIN/CONFIG/RESOURCE_GROUP after SET",
                 );
             }
+        } else if self.parse_keyword(Keyword::RESOURCE_GROUP) {
+            if self.expect_keyword(Keyword::TO).is_err() && self.expect_token(&Token::Eq).is_err() {
+                return self.expected("TO or = after ALTER SINK SET RESOURCE_GROUP");
+            }
+            let value = self.parse_set_variable()?;
+            let deferred = self.parse_keyword(Keyword::DEFERRED);
+
+            AlterSinkOperation::SetResourceGroup {
+                resource_group: Some(value),
+                deferred,
+            }
         } else if self.parse_keyword(Keyword::RESET) {
-            if self.parse_keyword(Keyword::CONFIG) {
+            if self.parse_keyword(Keyword::RESOURCE_GROUP) {
+                let deferred = self.parse_keyword(Keyword::DEFERRED);
+
+                AlterSinkOperation::SetResourceGroup {
+                    resource_group: None,
+                    deferred,
+                }
+            } else if self.parse_keyword(Keyword::CONFIG) {
                 let keys = self.parse_parenthesized_object_name_list()?;
                 AlterSinkOperation::ResetConfig { keys }
             } else {
-                return self.expected("CONFIG after RESET");
+                return self.expected("RESOURCE_GROUP or CONFIG after RESET");
             }
         } else if self.parse_keywords(&[Keyword::SWAP, Keyword::WITH]) {
             let target_sink = self.parse_object_name()?;

--- a/src/sqlparser/src/parser.rs
+++ b/src/sqlparser/src/parser.rs
@@ -3684,6 +3684,19 @@ impl Parser<'_> {
                     parallelism: value,
                     deferred,
                 }
+            } else if self.parse_keyword(Keyword::RESOURCE_GROUP) {
+                if self.expect_keyword(Keyword::TO).is_err()
+                    && self.expect_token(&Token::Eq).is_err()
+                {
+                    return self.expected("TO or = after ALTER SINK SET RESOURCE_GROUP");
+                }
+                let value = self.parse_set_variable()?;
+                let deferred = self.parse_keyword(Keyword::DEFERRED);
+
+                AlterSinkOperation::SetResourceGroup {
+                    resource_group: Some(value),
+                    deferred,
+                }
             } else if let Some(rate_limit) = self.parse_alter_sink_rate_limit()? {
                 AlterSinkOperation::SetSinkRateLimit { rate_limit }
             } else if let Some(rate_limit) = self.parse_alter_backfill_rate_limit()? {
@@ -3693,19 +3706,8 @@ impl Parser<'_> {
                 AlterSinkOperation::SetConfig { entries }
             } else {
                 return self.expected(
-                    "SCHEMA/PARALLELISM/SINK_RATE_LIMIT/BACKFILL_RATE_LIMIT/STREAMING_ENABLE_UNALIGNED_JOIN/CONFIG/RESOURCE_GROUP after SET",
+                    "SCHEMA/PARALLELISM/RESOURCE_GROUP/SINK_RATE_LIMIT/BACKFILL_RATE_LIMIT/STREAMING_ENABLE_UNALIGNED_JOIN/CONFIG after SET",
                 );
-            }
-        } else if self.parse_keyword(Keyword::RESOURCE_GROUP) {
-            if self.expect_keyword(Keyword::TO).is_err() && self.expect_token(&Token::Eq).is_err() {
-                return self.expected("TO or = after ALTER SINK SET RESOURCE_GROUP");
-            }
-            let value = self.parse_set_variable()?;
-            let deferred = self.parse_keyword(Keyword::DEFERRED);
-
-            AlterSinkOperation::SetResourceGroup {
-                resource_group: Some(value),
-                deferred,
             }
         } else if self.parse_keyword(Keyword::RESET) {
             if self.parse_keyword(Keyword::RESOURCE_GROUP) {

--- a/src/sqlparser/tests/testdata/alter.yaml
+++ b/src/sqlparser/tests/testdata/alter.yaml
@@ -17,6 +17,33 @@
   formatted_sql: ALTER SYSTEM SET a = 'abc'
 - input: ALTER SYSTEM SET a = DEFAULT
   formatted_sql: ALTER SYSTEM SET a = DEFAULT
+- input: ALTER DATABASE dev SET RESOURCE_GROUP TO 'rg'
+  error_msg: |-
+    sql parser error: expected DEFERRED after ALTER DATABASE SET RESOURCE_GROUP, found: EOF
+    LINE 1: ALTER DATABASE dev SET RESOURCE_GROUP TO 'rg'
+                                                         ^
+- input: ALTER DATABASE dev SET RESOURCE_GROUP = default
+  error_msg: |-
+    sql parser error: expected DEFERRED after ALTER DATABASE SET RESOURCE_GROUP, found: EOF
+    LINE 1: ALTER DATABASE dev SET RESOURCE_GROUP = default
+                                                           ^
+- input: ALTER DATABASE dev SET RESOURCE_GROUP TO 'rg' DEFERRED
+  formatted_sql: ALTER DATABASE dev SET RESOURCE_GROUP TO 'rg' DEFERRED
+- input: ALTER DATABASE dev RESET RESOURCE_GROUP
+  error_msg: |-
+    sql parser error: expected DEFERRED after ALTER DATABASE RESET RESOURCE_GROUP, found: EOF
+    LINE 1: ALTER DATABASE dev RESET RESOURCE_GROUP
+                                                   ^
+- input: ALTER DATABASE dev RESET RESOURCE_GROUP DEFERRED
+  formatted_sql: ALTER DATABASE dev RESET RESOURCE_GROUP DEFERRED
+- input: ALTER INDEX idx SET RESOURCE_GROUP TO 'rg'
+  formatted_sql: ALTER INDEX idx SET RESOURCE_GROUP TO 'rg'
+- input: ALTER INDEX idx RESET RESOURCE_GROUP DEFERRED
+  formatted_sql: ALTER INDEX idx RESET RESOURCE_GROUP DEFERRED
+- input: ALTER SINK snk SET RESOURCE_GROUP = default
+  formatted_sql: ALTER SINK snk SET RESOURCE_GROUP TO DEFAULT
+- input: ALTER SINK snk RESET RESOURCE_GROUP
+  formatted_sql: ALTER SINK snk RESET RESOURCE_GROUP
 - input: ALTER SOURCE t ADD COLUMN id INT;
   formatted_sql: ALTER SOURCE t ADD COLUMN id INT
 - input: ALTER SINK t_sink CONNECTOR WITH (properties.allow.auto.create.topics = 'true');

--- a/src/tests/compaction_test/Cargo.toml
+++ b/src/tests/compaction_test/Cargo.toml
@@ -15,7 +15,7 @@ foyer = { workspace = true }
 risingwave_common = { workspace = true }
 risingwave_compactor = { workspace = true }
 risingwave_hummock_sdk = { workspace = true }
-risingwave_meta_node = { workspace = true }
+risingwave_meta_node = { workspace = true, features = ["test"] }
 risingwave_pb = { workspace = true }
 risingwave_rpc_client = { workspace = true }
 risingwave_rt = { workspace = true }

--- a/src/tests/simulation/tests/integration_tests/recovery/drop_streaming_job.rs
+++ b/src/tests/simulation/tests/integration_tests/recovery/drop_streaming_job.rs
@@ -1,0 +1,154 @@
+// Copyright 2026 RisingWave Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::time::Duration;
+
+use anyhow::{Result, anyhow};
+use risingwave_common::error::AsReport;
+use risingwave_simulation::cluster::{Cluster, Configuration, Session};
+use tokio::time::sleep;
+
+use crate::utils::wait_jobs_running;
+
+const MAX_HEARTBEAT_INTERVAL_SEC: u64 = 5;
+
+async fn wait_until(session: &mut Session, sql: &str, target: &str) -> Result<()> {
+    for _ in 0..60 {
+        match session.run(sql).await {
+            Ok(result) if result == target => return Ok(()),
+            _ => sleep(Duration::from_secs(1)).await,
+        }
+    }
+    Err(anyhow!(
+        "timed out waiting for query `{}` to return `{}`",
+        sql,
+        target
+    ))
+}
+
+async fn run_until_meta_ready(session: &mut Session, sql: &str) -> Result<()> {
+    let mut last_error = None;
+    for _ in 0..60 {
+        match session.run(sql).await {
+            Ok(_) => return Ok(()),
+            Err(err) => {
+                let report = format!("{:#}", err.as_report());
+                if !report.contains("service is currently unavailable")
+                    && !report.contains("connection reset")
+                    && !report.contains("transport error")
+                {
+                    return Err(err);
+                }
+                last_error = Some(report);
+                sleep(Duration::from_secs(1)).await;
+            }
+        }
+    }
+    Err(anyhow!(
+        "timed out waiting for query `{}` to succeed, last error: {}",
+        sql,
+        last_error.unwrap_or_else(|| "none".to_owned())
+    ))
+}
+
+#[tokio::test]
+async fn test_drop_streaming_job_after_meta_restart_without_compute_node() -> Result<()> {
+    let mut config = Configuration::for_auto_parallelism(MAX_HEARTBEAT_INTERVAL_SEC, true);
+    config.compute_nodes = 3;
+    let mut cluster = Cluster::start(config).await?;
+    let mut session = cluster.start_session();
+
+    session.run("create table t (v int);").await?;
+    session
+        .run("create sink s as select count(*) from t with (connector = 'blackhole');")
+        .await?;
+    session.run("wait;").await?;
+
+    let compute_node_count_sql =
+        "select count(*) from rw_catalog.rw_worker_nodes where type = 'WORKER_TYPE_COMPUTE_NODE';";
+    wait_until(&mut session, compute_node_count_sql, "3").await?;
+
+    cluster
+        .simple_kill_nodes(["compute-1", "compute-2", "compute-3"])
+        .await;
+    sleep(Duration::from_secs(MAX_HEARTBEAT_INTERVAL_SEC * 2)).await;
+    wait_until(&mut session, compute_node_count_sql, "0").await?;
+
+    cluster.simple_kill_nodes(["meta-1"]).await;
+    cluster.simple_restart_nodes(["meta-1"]).await;
+    run_until_meta_ready(&mut session, "show jobs;").await?;
+
+    run_until_meta_ready(&mut session, "drop sink s;").await?;
+    wait_until(
+        &mut session,
+        "select count(*) from rw_catalog.rw_sinks where name = 's';",
+        "0",
+    )
+    .await?;
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_drop_creating_streaming_job_after_meta_restart_without_compute_node() -> Result<()> {
+    let mut config = Configuration::for_auto_parallelism(MAX_HEARTBEAT_INTERVAL_SEC, true);
+    config.compute_nodes = 3;
+    let mut cluster = Cluster::start(config).await?;
+    let mut session = cluster.start_session();
+
+    session.run("create table t (v int);").await?;
+    session
+        .run("insert into t select * from generate_series(1, 10000);")
+        .await?;
+    session.run("flush;").await?;
+
+    let mut create_session = cluster.start_session();
+    let create_handle = tokio::spawn(async move {
+        create_session.run("set streaming_parallelism = 1;").await?;
+        create_session.run("set backfill_rate_limit = 1;").await?;
+        create_session.run("set background_ddl = true;").await?;
+        create_session
+            .run("create sink s as select * from t with (connector = 'blackhole');")
+            .await
+    });
+
+    let running_jobs = wait_jobs_running(&mut session).await?;
+    tracing::info!("running jobs before killing compute nodes: {running_jobs}");
+
+    let compute_node_count_sql =
+        "select count(*) from rw_catalog.rw_worker_nodes where type = 'WORKER_TYPE_COMPUTE_NODE';";
+    wait_until(&mut session, compute_node_count_sql, "3").await?;
+
+    cluster
+        .simple_kill_nodes(["compute-1", "compute-2", "compute-3"])
+        .await;
+    sleep(Duration::from_secs(MAX_HEARTBEAT_INTERVAL_SEC * 2)).await;
+    wait_until(&mut session, compute_node_count_sql, "0").await?;
+
+    cluster.simple_kill_nodes(["meta-1"]).await;
+    cluster.simple_restart_nodes(["meta-1"]).await;
+    run_until_meta_ready(&mut session, "show jobs;").await?;
+
+    session.run("drop sink s;").await?;
+    wait_until(
+        &mut session,
+        "select count(*) from rw_catalog.rw_sinks where name = 's';",
+        "0",
+    )
+    .await?;
+
+    create_handle.abort();
+
+    Ok(())
+}

--- a/src/tests/simulation/tests/integration_tests/recovery/mod.rs
+++ b/src/tests/simulation/tests/integration_tests/recovery/mod.rs
@@ -15,6 +15,7 @@
 mod backfill;
 mod background_ddl;
 mod cross_db_retention;
+mod drop_streaming_job;
 mod event_log;
 mod locality_backfill;
 mod nexmark_recovery;

--- a/src/tests/simulation/tests/integration_tests/recovery/mod.rs
+++ b/src/tests/simulation/tests/integration_tests/recovery/mod.rs
@@ -19,3 +19,4 @@ mod drop_streaming_job;
 mod event_log;
 mod locality_backfill;
 mod nexmark_recovery;
+mod time_travel;

--- a/src/tests/simulation/tests/integration_tests/recovery/time_travel.rs
+++ b/src/tests/simulation/tests/integration_tests/recovery/time_travel.rs
@@ -1,0 +1,136 @@
+// Copyright 2026 RisingWave Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::io::Write;
+use std::time::Duration;
+
+use anyhow::Result;
+use risingwave_simulation::cluster::{Cluster, ConfigPath, Configuration};
+use tokio::time::sleep;
+
+// The system parameter enforces a minimum time travel retention of ten minutes.
+const TIME_TRAVEL_RETENTION_MS: u64 = 10 * 60 * 1000;
+const INSERT_INTERVAL: Duration = Duration::from_secs(60);
+
+fn init_logger() {
+    let _ = tracing_subscriber::fmt()
+        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .with_ansi(false)
+        .try_init();
+}
+
+fn cluster_config() -> Configuration {
+    let config_path = {
+        let mut file = tempfile::NamedTempFile::new().expect("failed to create temp config file");
+        file.write_all(
+            br#"
+[server]
+telemetry_enabled = false
+metrics_level = "Disabled"
+
+[meta]
+hummock_time_travel_snapshot_interval = 10
+
+[meta.developer]
+time_travel_vacuum_interval_sec = 5
+
+[streaming.developer]
+stream_chunk_size = 1
+
+[system]
+barrier_interval_ms = 1000
+max_concurrent_creating_streaming_jobs = 4
+"#,
+        )
+        .expect("failed to write config file");
+        file.into_temp_path()
+    };
+
+    Configuration {
+        config_path: ConfigPath::Temp(config_path.into()),
+        frontend_nodes: 1,
+        compute_nodes: 1,
+        meta_nodes: 1,
+        compactor_nodes: 2,
+        compute_node_cores: 1,
+        ..Default::default()
+    }
+}
+
+#[tokio::test]
+async fn test_time_travel_vacuum_during_snapshot_backfill() -> Result<()> {
+    init_logger();
+
+    let mut cluster = Cluster::start(cluster_config()).await?;
+    let mut session = cluster.start_session();
+
+    session
+        .run(format!(
+            "alter system set time_travel_retention_ms = {TIME_TRAVEL_RETENTION_MS};"
+        ))
+        .await?;
+    session.run("set rw_implicit_flush = true;").await?;
+    session.run("create table healthy_t(id int);").await?;
+    session
+        .run("create table backfill_t(id int primary key);")
+        .await?;
+    session
+        .run("insert into backfill_t select * from generate_series(1, 300);")
+        .await?;
+    session.run("flush;").await?;
+
+    session.run("set streaming_parallelism = 1;").await?;
+    session
+        .run("set streaming_use_snapshot_backfill = true;")
+        .await?;
+    session.run("set background_ddl = true;").await?;
+    session.run("set backfill_rate_limit = 1;").await?;
+    session
+        .run("create materialized view backfill_mv as select * from backfill_t;")
+        .await?;
+
+    // Snapshot backfill can commit a lower table epoch at a later global version. Keep the job
+    // active while creating several retained wall-clock mappings that precede those versions.
+    for id in 1..=3 {
+        session
+            .run(format!("insert into healthy_t values ({id});"))
+            .await?;
+        sleep(INSERT_INTERVAL).await;
+    }
+
+    assert_eq!(
+        session
+            .run("select count(*) from rw_catalog.rw_ddl_progress;")
+            .await?,
+        "1"
+    );
+    session.run("wait;").await?;
+    // Once the job's version pin is released, give vacuum time to process the mixed epoch order.
+    sleep(Duration::from_secs(10)).await;
+
+    // Drop compute-side recent-version and time-travel caches before validating the archived
+    // metadata path.
+    cluster.simple_kill_nodes(["compute-1"]).await;
+    cluster.simple_restart_nodes(["compute-1"]).await;
+    sleep(Duration::from_secs(10)).await;
+
+    session
+        .run(
+            "select count(*) from healthy_t \
+             for system_time as of now() - '3' minute;",
+        )
+        .await?;
+
+    Ok(())
+}


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

This PR backports the grouped DDL, barrier recovery, and Hummock improvements to `release-2.8` from:

- #25953: support serverless backfill for sinks and indexes
- #25954: support resource-group changes for databases, sinks, and indexes
- #26175: drop recovered streaming jobs without depending on shared actor information
- #26076: reduce Hummock versioning lock contention, using the release-2.8 adaptation from the Nectar branch
- #26071: add Hummock lock timing metrics
- #26390: preserve retained time-travel versions during vacuum

#26162 is not included as a separate commit because `release-2.8` already contains its extended snapshot-length behavior through the newer streaming/protobuf snapshot implementation.

The backport includes DDL end-to-end coverage and a deterministic recovery regression test for dropping streaming jobs after meta recovery.

Local verification:

- `cargo clippy --all-targets --all-features`
- `cargo clippy -p risingwave_meta --all-targets --all-features` after adapting #26390 to the release-2.8 protobuf API
- `cargo fmt --all`
- Regenerated Grafana dashboards

## Checklist

- [x] I have written necessary rustdoc comments.
- [x] I have added necessary unit tests and integration tests.
- [x] I have added test labels as necessary.
- [ ] I have added fuzzing tests or opened an issue to track them.
- [ ] My PR contains breaking changes.
- [ ] My PR changes performance-critical code, so I will run (micro) benchmarks and present the results.
- [x] I have checked the Release Timeline and Currently Supported Versions to determine which release branches I need to cherry-pick this PR into.

## Documentation

- [ ] My PR needs documentation updates.

<details>
<summary><b>Release note</b></summary>

Backports serverless sink/index backfill, resource-group alteration, safer streaming-job cleanup after meta recovery, Hummock lock-contention improvements, and retained time-travel version preservation during vacuum to release 2.8.

</details>
