### PR TITLE
ci: optionally trigger main-cron from Docker image workflow

### DIFF
--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -18,6 +18,11 @@ on:
         required: false
         type: boolean
         default: false
+      run_main_cron:
+        description: 'Whether to trigger Buildkite main-cron'
+        required: false
+        type: boolean
+        default: false
 
 jobs:
   build_image:
@@ -78,6 +83,7 @@ jobs:
           echo "PUSH_DOCKERHUB=$PUSH_DOCKERHUB"
           echo "PUSH_DOCKERHUB=$PUSH_DOCKERHUB" >> $GITHUB_ENV
       - name: 'Trigger Docker build Workflow via Buildkite'
+        id: trigger_docker
         uses: buildkite/trigger-pipeline-action@v2.3.0
         with:
           buildkite_api_access_token: ${{ secrets.BUILDKITE_TOKEN }}
@@ -86,3 +92,34 @@ jobs:
           commit: HEAD
           message: ':github: Triggering Docker build with image tag: ${{ env.IMAGE_TAG }}'
           build_env_vars: '{ "IMAGE_TAG": "${{ env.IMAGE_TAG }}", "PUSH_DOCKERHUB": "${{ env.PUSH_DOCKERHUB }}", "SKIP_TARGET_AMD64": "${{ env.SKIP_TARGET_AMD64 }}", "CARGO_PROFILE": "${{ env.CARGO_PROFILE }}" }'
+      - name: 'Trigger main-cron Workflow via Buildkite'
+        id: trigger_main_cron
+        if: ${{ inputs.run_main_cron }}
+        uses: buildkite/trigger-pipeline-action@v2.3.0
+        with:
+          buildkite_api_access_token: ${{ secrets.BUILDKITE_TOKEN }}
+          pipeline: 'risingwavelabs/main-cron'
+          branch: ${{ env.BRANCH_NAME }}
+          commit: HEAD
+          message: ':github: Triggering main-cron for branch: ${{ env.BRANCH_NAME }}'
+          wait: false
+      - name: 'Summarize Buildkite builds'
+        if: ${{ always() }}
+        env:
+          DOCKER_BUILD_URL: ${{ steps.trigger_docker.outputs.url }}
+          RUN_MAIN_CRON: ${{ inputs.run_main_cron }}
+          MAIN_CRON_BUILD_URL: ${{ steps.trigger_main_cron.outputs.url }}
+        run: |
+          if [[ -n "$DOCKER_BUILD_URL" ]]; then
+            echo "- [Docker build]($DOCKER_BUILD_URL)" >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "- Docker build: URL unavailable (trigger failed before returning one)." >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+          if [[ "$RUN_MAIN_CRON" == "true" ]]; then
+            if [[ -n "$MAIN_CRON_BUILD_URL" ]]; then
+              echo "- [Main-cron build]($MAIN_CRON_BUILD_URL)" >> "$GITHUB_STEP_SUMMARY"
+            else
+              echo "- Main-cron build: URL unavailable (trigger failed before returning one)." >> "$GITHUB_STEP_SUMMARY"
+            fi
+          fi

--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -102,6 +102,7 @@ jobs:
           branch: ${{ env.BRANCH_NAME }}
           commit: HEAD
           message: ':github: Triggering main-cron for branch: ${{ env.BRANCH_NAME }}'
+          ignore_pipeline_branch_filter: true
           wait: false
       - name: 'Summarize Buildkite builds'
         if: ${{ always() }}


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

Add an optional `run_main_cron` input to the manually dispatched Docker image workflow. When enabled, the workflow triggers `risingwavelabs/main-cron` for the selected branch with the existing Buildkite token while leaving the option disabled by default. The trigger explicitly ignores the pipeline's branch filter because this workflow is intended to dispatch manually selected branches.

The workflow now also publishes named Docker and optional main-cron Buildkite links in the GitHub Actions job summary, with an explicit fallback when a requested trigger does not return a URL.

### Verification

- `cargo clippy --all-targets --all-features`
- Parsed the workflow as YAML and verified the default, opt-in, and failed-trigger summary paths.
- Demo workflow: [successful Build Docker Image run #30331508656](https://github.com/risingwavelabs/risingwave/actions/runs/30331508656)
  - Triggered [Docker build #18584](https://buildkite.com/risingwavelabs/docker/builds/18584).
  - Triggered [main-cron build #9711](https://buildkite.com/risingwavelabs/main-cron/builds/9711).

## Checklist

- [x] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [x] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

Not applicable; this changes an internal CI workflow.

</details>
