### PR TITLE
fix(meta): notify hummock for cache refill config

### DIFF
--- a/src/frontend/src/handler/alter_streaming_config.rs
+++ b/src/frontend/src/handler/alter_streaming_config.rs
@@ -27,6 +27,16 @@ use crate::handler::{HandlerArgs, RwPgResponse};
 /// A diff of a TOML map. `None` means the key should be removed.
 type TomlMapDiff = TomlMap<String, Option<TomlValue>>;
 
+const STREAMING_CACHE_REFILL_POLICY_CONFIG_PATH: &str = "streaming.developer.cache_refill_policy";
+const ALTER_CONFIG_RECOVER_NOTICE: &str =
+    "ALTER CONFIG requires a RECOVER on the specified streaming job to take effect.";
+
+fn alter_config_requires_recover(map_diff: &TomlMapDiff) -> bool {
+    map_diff
+        .keys()
+        .any(|key| key != STREAMING_CACHE_REFILL_POLICY_CONFIG_PATH)
+}
+
 fn collect_options(entries: Vec<SqlOption>) -> Result<TomlMapDiff> {
     let mut map = TomlMap::new();
 
@@ -73,6 +83,7 @@ pub async fn handle_alter_streaming_set_config(
 
     let job_id = resolve_streaming_job_id_for_alter(&session, obj_name, stmt_type, "config")?;
     let map_diff = collect_options(entries)?;
+    let requires_recover = alter_config_requires_recover(&map_diff);
 
     let mut entries_to_add = HashMap::new();
     let mut keys_to_remove = Vec::new();
@@ -90,9 +101,11 @@ pub async fn handle_alter_streaming_set_config(
         .alter_config(job_id, entries_to_add, keys_to_remove)
         .await?;
 
-    Ok(RwPgResponse::builder(stmt_type)
-        .notice("ALTER CONFIG requires a RECOVER on the specified streaming job to take effect.")
-        .into())
+    let mut builder = RwPgResponse::builder(stmt_type);
+    if requires_recover {
+        builder = builder.notice(ALTER_CONFIG_RECOVER_NOTICE);
+    }
+    Ok(builder.into())
 }
 
 pub async fn handle_alter_streaming_reset_config(
@@ -111,4 +124,50 @@ pub async fn handle_alter_streaming_reset_config(
 
     // Simply delegate to `handle_alter_streaming_set_config` with all values set to `NULL`.
     handle_alter_streaming_set_config(handler_args, obj_name, entries, stmt_type).await
+}
+
+#[cfg(test)]
+mod tests {
+    use toml::Value as TomlValue;
+
+    use super::{
+        STREAMING_CACHE_REFILL_POLICY_CONFIG_PATH, TomlMapDiff, alter_config_requires_recover,
+    };
+
+    #[test]
+    fn test_cache_refill_policy_config_does_not_require_recover() {
+        let mut map_diff = TomlMapDiff::new();
+        map_diff.insert(
+            STREAMING_CACHE_REFILL_POLICY_CONFIG_PATH.to_owned(),
+            Some(TomlValue::String("both".to_owned())),
+        );
+        assert!(!alter_config_requires_recover(&map_diff));
+
+        map_diff.insert(STREAMING_CACHE_REFILL_POLICY_CONFIG_PATH.to_owned(), None);
+        assert!(!alter_config_requires_recover(&map_diff));
+    }
+
+    #[test]
+    fn test_other_streaming_config_still_requires_recover() {
+        let mut map_diff = TomlMapDiff::new();
+        map_diff.insert(
+            "streaming.developer.some_other_config".to_owned(),
+            Some(TomlValue::Boolean(true)),
+        );
+        assert!(alter_config_requires_recover(&map_diff));
+    }
+
+    #[test]
+    fn test_mixed_streaming_config_requires_recover() {
+        let mut map_diff = TomlMapDiff::new();
+        map_diff.insert(
+            STREAMING_CACHE_REFILL_POLICY_CONFIG_PATH.to_owned(),
+            Some(TomlValue::String("both".to_owned())),
+        );
+        map_diff.insert(
+            "streaming.developer.some_other_config".to_owned(),
+            Some(TomlValue::Boolean(true)),
+        );
+        assert!(alter_config_requires_recover(&map_diff));
+    }
 }

--- a/src/meta/src/controller/catalog/alter_op.rs
+++ b/src/meta/src/controller/catalog/alter_op.rs
@@ -1152,6 +1152,12 @@ impl CatalogController {
         entries_to_add: HashMap<String, String>,
         keys_to_remove: Vec<String>,
     ) -> MetaResult<NotificationVersion> {
+        let updates_cache_refill_policy = entries_to_add
+            .contains_key(STREAMING_CACHE_REFILL_POLICY_CONFIG_PATH)
+            || keys_to_remove
+                .iter()
+                .any(|key| key == STREAMING_CACHE_REFILL_POLICY_CONFIG_PATH);
+
         let inner = self.inner.write().await;
         let txn = inner.db.begin().await?;
 
@@ -1208,6 +1214,21 @@ impl CatalogController {
         .await?;
 
         txn.commit().await?;
+        drop(inner);
+
+        if updates_cache_refill_policy {
+            let policies = self.table_cache_refill_policies_snapshot().await?;
+            self.env
+                .notification_manager()
+                .notify_hummock(
+                    NotificationOperation::Update,
+                    NotificationInfo::TableRefillRuntimeConfig(PbTableRefillRuntimeConfig {
+                        table_cache_refill_policies: Some(policies),
+                        ..Default::default()
+                    }),
+                )
+                .await;
+        }
 
         Ok(IGNORED_NOTIFICATION_VERSION)
     }

--- a/src/meta/src/controller/catalog/mod.rs
+++ b/src/meta/src/controller/catalog/mod.rs
@@ -62,7 +62,9 @@ use risingwave_pb::meta::subscribe_response::{
     Info as NotificationInfo, Info, Operation as NotificationOperation, Operation,
 };
 use risingwave_pb::meta::table_cache_refill_policies::PbTableCacheRefillPolicy;
-use risingwave_pb::meta::{PbObject, PbObjectGroup, PbTableCacheRefillPolicies};
+use risingwave_pb::meta::{
+    PbObject, PbObjectGroup, PbTableCacheRefillPolicies, PbTableRefillRuntimeConfig,
+};
 use risingwave_pb::stream_plan::stream_node::NodeBody;
 use risingwave_pb::telemetry::PbTelemetryEventStage;
 use risingwave_pb::user::PbUserInfo;
@@ -108,6 +110,8 @@ pub type Catalog = (
 );
 
 pub type CatalogControllerRef = Arc<CatalogController>;
+
+const STREAMING_CACHE_REFILL_POLICY_CONFIG_PATH: &str = "streaming.developer.cache_refill_policy";
 
 /// `CatalogController` is the controller for catalog related operations, including database, schema, table, view, etc.
 pub struct CatalogController {

--- a/src/meta/src/controller/catalog/test.rs
+++ b/src/meta/src/controller/catalog/test.rs
@@ -21,11 +21,12 @@ mod tests {
     use risingwave_pb::catalog::StreamSourceInfo;
     use risingwave_pb::catalog::subscription::SubscriptionState;
     use risingwave_pb::common::{HostAddress, WorkerNode, WorkerType, worker_node};
+    use risingwave_pb::meta::SubscribeType;
     use risingwave_pb::stream_plan::PbStreamNode;
     use tokio::sync::{mpsc, oneshot};
 
     use crate::controller::catalog::*;
-    use crate::manager::LocalNotification;
+    use crate::manager::{LocalNotification, WorkerKey};
     use crate::serving::ServingVnodeMapping;
 
     const TEST_DATABASE_ID: DatabaseId = DatabaseId::new(1);
@@ -254,6 +255,80 @@ mod tests {
                     CacheRefillPolicy::Streaming.to_protobuf() as i32,
                 ),
             ])
+        );
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_alter_streaming_job_cache_refill_policy_notifies_hummock() -> MetaResult<()> {
+        let env = MetaSrvEnv::for_test().await;
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        env.notification_manager().insert_sender(
+            SubscribeType::Hummock,
+            WorkerKey(HostAddress {
+                host: "localhost".to_owned(),
+                port: 1234,
+            }),
+            tx,
+        );
+        let mgr = CatalogController::new(env).await?;
+
+        let inner = mgr.inner.write().await;
+        let txn = inner.db.begin().await?;
+        let (_job, Some(result_table_id), internal_table_id) =
+            insert_test_streaming_job(&txn, "mv_cache_refill", true, None).await?
+        else {
+            unreachable!()
+        };
+        txn.commit().await?;
+        drop(inner);
+
+        mgr.alter_streaming_job_config(
+            result_table_id.as_job_id(),
+            HashMap::from([(
+                STREAMING_CACHE_REFILL_POLICY_CONFIG_PATH.to_owned(),
+                "\"both\"".to_owned(),
+            )]),
+            vec![],
+        )
+        .await?;
+
+        let response = rx
+            .recv()
+            .await
+            .expect("should receive hummock notification")
+            .expect("notification should be ok");
+        assert_eq!(response.operation(), NotificationOperation::Update);
+        let info = response.info;
+        let Some(NotificationInfo::TableRefillRuntimeConfig(config)) = info else {
+            panic!("unexpected notification: {:?}", info);
+        };
+        assert!(config.serving_table_vnode_mappings.is_none());
+        let policies = config
+            .table_cache_refill_policies
+            .expect("policy snapshot should be present");
+        assert_eq!(
+            policies
+                .table_policies
+                .into_iter()
+                .map(|policy| (policy.table_id, policy.policy))
+                .collect::<HashMap<_, _>>(),
+            HashMap::from([(
+                result_table_id.as_raw_id(),
+                CacheRefillPolicy::Both.to_protobuf() as i32,
+            )])
+        );
+        assert_eq!(
+            policies
+                .internal_table_policies
+                .into_iter()
+                .map(|policy| (policy.table_id, policy.policy))
+                .collect::<HashMap<_, _>>(),
+            HashMap::from([(
+                internal_table_id.as_raw_id(),
+                CacheRefillPolicy::Both.to_protobuf() as i32,
+            )])
         );
 
         Ok(())

--- a/src/tests/simulation/tests/integration_tests/table_cache_refill.rs
+++ b/src/tests/simulation/tests/integration_tests/table_cache_refill.rs
@@ -126,7 +126,7 @@ async fn refill_state_rebuilt_after_database_recovery() -> Result<()> {
         &cluster,
         &surviving_worker,
         result_table_id,
-        None,
+        Some("both"),
         Some(&before.streaming),
         Some(&before.serving),
     )


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

- Notify Hummock subscribers with `Info::TableRefillRuntimeConfig` after `ALTER ... SET/RESET CONFIG` changes `streaming.developer.cache_refill_policy`.
- Send a refreshed cache-refill policy snapshot after the catalog update commits, while preserving the ignored DDL wait version for `ALTER CONFIG`.
- Add a meta unit test that verifies a Hummock subscriber receives result-table and internal-table policies.
- No issue.

## Checklist

- [ ] I have written necessary rustdoc comments.
- [x] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [x] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

No release note.

</details>
