### PR TITLE
fix(meta): enforce subscription namespace and lifecycle

### DIFF
--- a/e2e_test/ddl/alter_set_schema.slt
+++ b/e2e_test/ddl/alter_set_schema.slt
@@ -98,12 +98,12 @@ WHERE nspname = 'test_schema';
 test_sink test_schema
 
 statement ok
-CREATE SUBSCRIPTION test_subscription FROM test_schema.test_table WITH (
+CREATE SUBSCRIPTION test_schema.test_subscription FROM test_schema.test_table WITH (
     retention = '1D'
 );
 
-statement ok
-ALTER SUBSCRIPTION test_subscription SET SCHEMA test_schema;
+statement error ALTER SUBSCRIPTION SET SCHEMA is not supported
+ALTER SUBSCRIPTION test_schema.test_subscription SET SCHEMA test_schema;
 
 query TT
 SELECT name, schema_name
@@ -116,13 +116,16 @@ statement ok
 DROP SINK test_schema.test_sink;
 
 statement ok
-DROP SUBSCRIPTION test_schema.test_subscription;
-
-statement ok
 DROP SOURCE test_schema.test_source;
 
 statement ok
-DROP TABLE test_schema.test_table cascade;
+DROP MATERIALIZED VIEW test_schema.test_mv;
+
+statement ok
+DROP TABLE test_schema.test_table;
+
+statement error
+DROP SUBSCRIPTION test_schema.test_subscription;
 
 statement ok
 DROP SCHEMA test_schema;

--- a/e2e_test/ddl/subscription.slt
+++ b/e2e_test/ddl/subscription.slt
@@ -28,6 +28,9 @@ create schema test_schema;
 statement ok
 create table test_schema.t1(v1 int, v2 int);
 
+statement error subscription and its dependent table must be in the same database and schema
+create subscription invalid_schema_subscription from test_schema.t1 with(retention = '1d');
+
 statement ok
 create subscription test_schema.test_subscription from test_schema.t1 with(retention = '1d');
 
@@ -42,6 +45,30 @@ drop table test_schema.t1;
 
 statement ok
 drop schema test_schema;
+
+statement ok
+create table auto_drop_subscription_table(v1 int);
+
+statement ok
+create subscription auto_drop_subscription from auto_drop_subscription_table with(retention = '1d');
+
+statement ok
+drop table auto_drop_subscription_table;
+
+statement error
+drop subscription auto_drop_subscription;
+
+statement ok
+create materialized view auto_drop_subscription_mv as select 1 as v1;
+
+statement ok
+create subscription auto_drop_mv_subscription from auto_drop_subscription_mv with(retention = '1d');
+
+statement ok
+drop materialized view auto_drop_subscription_mv;
+
+statement error
+drop subscription auto_drop_mv_subscription;
 
 statement ok
 drop subscription ddl_subscription_table;

--- a/e2e_test/subscription/check_sql_statement.slt
+++ b/e2e_test/subscription/check_sql_statement.slt
@@ -11,7 +11,10 @@ statement ok
 create schema s1;
 
 statement ok
-create subscription s1.sub1 from t1 with(retention = '1D');
+create table s1.t1 (v1 int, v2 int, v3 int);
+
+statement ok
+create subscription s1.sub1 from s1.t1 with(retention = '1D');
 
 statement ok
 declare cur subscription cursor for sub;
@@ -62,6 +65,9 @@ close cur7;
 
 statement ok
 drop subscription s1.sub1;
+
+statement ok
+drop table s1.t1;
 
 statement ok
 drop schema s1;

--- a/src/frontend/src/handler/alter_set_schema.rs
+++ b/src/frontend/src/handler/alter_set_schema.rs
@@ -108,21 +108,10 @@ pub async fn handle_alter_set_schema(
                 sink.id.into()
             }
             StatementType::ALTER_SUBSCRIPTION => {
-                let (subscription, old_schema_name) = catalog_reader.get_subscription_by_name(
-                    db_name,
-                    schema_path,
-                    &real_obj_name,
-                )?;
-                if old_schema_name == new_schema_name {
-                    return Ok(RwPgResponse::empty_result(stmt_type));
-                }
-                session.check_privilege_for_drop_alter(old_schema_name, &**subscription)?;
-                catalog_reader.check_relation_name_duplicated(
-                    db_name,
-                    &new_schema_name,
-                    &subscription.name,
-                )?;
-                subscription.id.into()
+                return Err(ErrorCode::InvalidInputSyntax(
+                    "ALTER SUBSCRIPTION SET SCHEMA is not supported".to_owned(),
+                )
+                .into());
             }
             StatementType::ALTER_CONNECTION => {
                 let (connection, old_schema_name) =

--- a/src/frontend/src/handler/create_subscription.rs
+++ b/src/frontend/src/handler/create_subscription.rs
@@ -22,7 +22,7 @@ use super::{HandlerArgs, RwPgResponse};
 use crate::catalog::subscription_catalog::{
     SubscriptionCatalog, SubscriptionId, SubscriptionState,
 };
-use crate::error::Result;
+use crate::error::{ErrorCode, Result};
 use crate::handler::util::reject_internal_table_dependency;
 use crate::scheduler::streaming_manager::CreatingStreamingJobInfo;
 use crate::session::SessionImpl;
@@ -49,6 +49,15 @@ pub fn create_subscription_catalog(
         table_schema_id,
     )?;
     reject_internal_table_dependency(dependent_table.as_ref(), "CREATE SUBSCRIPTION")?;
+    if subscription_database_id != dependent_table.database_id
+        || subscription_schema_id != dependent_table.schema_id
+    {
+        return Err(ErrorCode::InvalidInputSyntax(
+            "subscription and its dependent table must be in the same database and schema"
+                .to_owned(),
+        )
+        .into());
+    }
     let dependent_table_id = dependent_table.id;
 
     let mut subscription_catalog = SubscriptionCatalog {

--- a/src/meta/model/migration/src/lib.rs
+++ b/src/meta/model/migration/src/lib.rs
@@ -73,6 +73,7 @@ mod m20260312_000000_streaming_job_backfill_parallelism_strategy;
 mod m20260518_000000_disable_unused_read_prefix_hints;
 mod m20260519_000000_streaming_job_batch_refresh_seconds;
 mod m20260624_000000_pending_sink_state_object_fk;
+mod m20260728_000000_subscription_schema;
 mod utils;
 
 pub struct Migrator;
@@ -184,6 +185,7 @@ impl MigratorTrait for Migrator {
             Box::new(m20260518_000000_disable_unused_read_prefix_hints::Migration),
             Box::new(m20260519_000000_streaming_job_batch_refresh_seconds::Migration),
             Box::new(m20260624_000000_pending_sink_state_object_fk::Migration),
+            Box::new(m20260728_000000_subscription_schema::Migration),
         ]
     }
 }

--- a/src/meta/model/migration/src/m20260728_000000_subscription_schema.rs
+++ b/src/meta/model/migration/src/m20260728_000000_subscription_schema.rs
@@ -1,0 +1,117 @@
+use sea_orm_migration::prelude::*;
+
+use crate::sea_orm::{ConnectionTrait, DatabaseBackend, Statement};
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        let backend = manager.get_database_backend();
+        let connection = manager.get_connection();
+
+        // Moving two same-named subscriptions into one schema would make the frontend catalog
+        // ambiguous. Stop the upgrade instead of silently renaming or deleting either object.
+        let conflicts = connection
+            .query_one(Statement::from_string(
+                backend,
+                "SELECT COUNT(*) FROM (\
+                    SELECT s.name, upstream.database_id, upstream.schema_id \
+                    FROM subscription AS s \
+                    JOIN object AS upstream ON upstream.oid = s.dependent_table_id \
+                    GROUP BY s.name, upstream.database_id, upstream.schema_id \
+                    HAVING COUNT(*) > 1\
+                ) AS conflicts",
+            ))
+            .await?
+            .expect("COUNT always returns one row");
+        let conflict_count: i64 = conflicts.try_get_by(0)?;
+        if conflict_count != 0 {
+            return Err(DbErr::Custom(
+                "cannot move subscriptions to their dependent tables' schemas because duplicate subscription names would result; rename or drop the conflicting subscriptions before upgrading"
+                    .to_owned(),
+            ));
+        }
+
+        // Subscriptions also share a namespace with relations at the SQL layer. Although the
+        // catalog stores their names in separate tables, do not create an ambiguous namespace by
+        // moving a subscription on top of an existing relation.
+        let quote = match backend {
+            DatabaseBackend::MySql => '`',
+            DatabaseBackend::Postgres | DatabaseBackend::Sqlite => '"',
+        };
+        let relation_names = ["table", "source", "sink", "index", "view"]
+            .map(|relation| {
+                format!(
+                    "SELECT relation.name, relation_object.database_id, \
+                     relation_object.schema_id \
+                     FROM {quote}{relation}{quote} AS relation \
+                     JOIN {quote}object{quote} AS relation_object \
+                       ON relation_object.oid = relation.{relation}_id"
+                )
+            })
+            .join(" UNION ALL ");
+        let relation_conflicts = connection
+            .query_one(Statement::from_string(
+                backend,
+                format!(
+                    "SELECT COUNT(*) \
+                     FROM subscription AS s \
+                     JOIN object AS upstream ON upstream.oid = s.dependent_table_id \
+                     JOIN ({relation_names}) AS relation \
+                       ON relation.name = s.name \
+                      AND relation.database_id = upstream.database_id \
+                      AND relation.schema_id = upstream.schema_id"
+                ),
+            ))
+            .await?
+            .expect("COUNT always returns one row");
+        let relation_conflict_count: i64 = relation_conflicts.try_get_by(0)?;
+        if relation_conflict_count != 0 {
+            return Err(DbErr::Custom(
+                "cannot move subscriptions to their dependent tables' schemas because relation name conflicts would result; rename or drop the conflicting objects before upgrading"
+                    .to_owned(),
+            ));
+        }
+
+        let sql = match backend {
+            DatabaseBackend::MySql => {
+                "UPDATE object AS subscription_object \
+                 JOIN subscription AS s ON s.subscription_id = subscription_object.oid \
+                 JOIN object AS upstream ON upstream.oid = s.dependent_table_id \
+                 SET subscription_object.schema_id = upstream.schema_id"
+            }
+            DatabaseBackend::Postgres => {
+                "UPDATE object AS subscription_object \
+                 SET schema_id = upstream.schema_id \
+                 FROM subscription AS s \
+                 JOIN object AS upstream ON upstream.oid = s.dependent_table_id \
+                 WHERE s.subscription_id = subscription_object.oid"
+            }
+            DatabaseBackend::Sqlite => {
+                "UPDATE object \
+                 SET schema_id = (\
+                     SELECT upstream.schema_id \
+                     FROM subscription AS s \
+                     JOIN object AS upstream ON upstream.oid = s.dependent_table_id \
+                     WHERE s.subscription_id = object.oid\
+                 ) \
+                 WHERE oid IN (SELECT subscription_id FROM subscription)"
+            }
+        };
+        connection
+            .execute(Statement::from_string(backend, sql))
+            .await?;
+
+        // Object privileges and ownership reference the object ID, so changing the containing
+        // schema neither grants privileges to new users nor drops existing object-level grants.
+        Ok(())
+    }
+
+    async fn down(&self, _manager: &SchemaManager) -> Result<(), DbErr> {
+        // The previous schema was not stored, and restoring the invalid layout would violate the
+        // catalog invariant enforced by the corresponding release.
+        Ok(())
+    }
+}

--- a/src/meta/src/controller/catalog/alter_op.rs
+++ b/src/meta/src/controller/catalog/alter_op.rs
@@ -630,6 +630,12 @@ impl CatalogController {
         object_id: ObjectId,
         new_schema: SchemaId,
     ) -> MetaResult<NotificationVersion> {
+        if object_type == ObjectType::Subscription {
+            return Err(MetaError::invalid_parameter(
+                "ALTER SUBSCRIPTION SET SCHEMA is not supported",
+            ));
+        }
+
         let inner = self.inner.write().await;
         let txn = inner.db.begin().await?;
         ensure_object_id(ObjectType::Schema, new_schema, &txn).await?;
@@ -781,6 +787,65 @@ impl CatalogController {
                         ));
                     }
                 }
+                // Subscriptions share the namespace of their dependent table, just like indexes.
+                let subscription_objs = Subscription::find()
+                    .find_also_related(Object)
+                    .filter(subscription::Column::DependentTableId.eq(object_id))
+                    .all(&txn)
+                    .await?;
+                if !subscription_objs.is_empty() {
+                    let subscription_ids: Vec<_> = subscription_objs
+                        .iter()
+                        .map(|(subscription, _)| subscription.subscription_id)
+                        .collect();
+                    for (subscription, _) in &subscription_objs {
+                        check_relation_name_duplicate(
+                            &subscription.name,
+                            database_id,
+                            new_schema,
+                            &txn,
+                        )
+                        .await?;
+
+                        let duplicate = Subscription::find()
+                            .inner_join(Object)
+                            .filter(
+                                subscription::Column::Name.eq(&subscription.name).and(
+                                    object::Column::DatabaseId.eq(database_id).and(
+                                        object::Column::SchemaId.eq(new_schema).and(
+                                            subscription::Column::SubscriptionId
+                                                .is_not_in(subscription_ids.clone()),
+                                        ),
+                                    ),
+                                ),
+                            )
+                            .count(&txn)
+                            .await?;
+                        if duplicate != 0 {
+                            return Err(MetaError::catalog_duplicated(
+                                "subscription",
+                                &subscription.name,
+                            ));
+                        }
+                    }
+
+                    Object::update_many()
+                        .col_expr(object::Column::SchemaId, new_schema.into())
+                        .filter(
+                            object::Column::Oid
+                                .is_in(subscription_ids.iter().copied().map(ObjectId::from)),
+                        )
+                        .exec(&txn)
+                        .await?;
+
+                    for (subscription, subscription_obj) in subscription_objs {
+                        let mut subscription_obj = subscription_obj.unwrap();
+                        subscription_obj.schema_id = Some(new_schema);
+                        objects.push(PbObjectInfo::Subscription(
+                            ObjectModel(subscription, subscription_obj, None).into(),
+                        ));
+                    }
+                }
             }
             ObjectType::Source => {
                 let source = Source::find_by_id(object_id.as_source_id())
@@ -832,19 +897,7 @@ impl CatalogController {
                 .await?;
             }
             ObjectType::Subscription => {
-                let subscription = Subscription::find_by_id(object_id.as_subscription_id())
-                    .one(&txn)
-                    .await?
-                    .ok_or_else(|| MetaError::catalog_id_not_found("subscription", object_id))?;
-                check_relation_name_duplicate(&subscription.name, database_id, new_schema, &txn)
-                    .await?;
-
-                let mut obj = obj.into_active_model();
-                obj.schema_id = Set(Some(new_schema));
-                let obj = obj.update(&txn).await?;
-                objects.push(PbObjectInfo::Subscription(
-                    ObjectModel(subscription, obj, None).into(),
-                ));
+                unreachable!("ALTER SUBSCRIPTION SET SCHEMA is rejected above")
             }
             ObjectType::View => {
                 let view = View::find_by_id(object_id.as_view_id())

--- a/src/meta/src/controller/catalog/create_op.rs
+++ b/src/meta/src/controller/catalog/create_op.rs
@@ -151,6 +151,19 @@ impl CatalogController {
         ensure_user_id(pb_subscription.owner as _, &txn).await?;
         ensure_object_id(ObjectType::Database, pb_subscription.database_id, &txn).await?;
         ensure_object_id(ObjectType::Schema, pb_subscription.schema_id, &txn).await?;
+        let dependent_obj = Object::find_by_id(pb_subscription.dependent_table_id)
+            .one(&txn)
+            .await?
+            .ok_or_else(|| {
+                MetaError::catalog_id_not_found("table", pb_subscription.dependent_table_id)
+            })?;
+        if dependent_obj.database_id != Some(pb_subscription.database_id)
+            || dependent_obj.schema_id != Some(pb_subscription.schema_id)
+        {
+            return Err(MetaError::invalid_parameter(
+                "subscription and its dependent table must be in the same database and schema",
+            ));
+        }
         check_subscription_name_duplicate(pb_subscription, &txn).await?;
 
         let obj = Self::create_object(

--- a/src/meta/src/controller/catalog/drop_op.rs
+++ b/src/meta/src/controller/catalog/drop_op.rs
@@ -68,9 +68,11 @@ impl CatalogController {
                         report_drop_object(obj.obj_type, obj.oid, &txn).await;
                     }
                     assert!(
-                        objects.iter().all(|obj| obj.obj_type == ObjectType::Index
-                            || obj.obj_type == ObjectType::Sink),
-                        "only index and iceberg sink could be dropped in restrict mode"
+                        objects.iter().all(|obj| matches!(
+                            obj.obj_type,
+                            ObjectType::Index | ObjectType::Sink | ObjectType::Subscription
+                        )),
+                        "only index, subscription and iceberg sink could be dropped in restrict mode"
                     );
                     for obj in &objects {
                         check_object_refer_for_drop(obj.obj_type, obj.oid, &txn).await?;

--- a/src/meta/src/controller/catalog/test.rs
+++ b/src/meta/src/controller/catalog/test.rs
@@ -862,6 +862,87 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_subscription_follows_dependent_table_schema_and_drop() -> MetaResult<()> {
+        let mgr = CatalogController::new(MetaSrvEnv::for_test().await).await?;
+        mgr.create_schema(PbSchema {
+            database_id: TEST_DATABASE_ID,
+            name: "subscription_target_schema".to_owned(),
+            owner: TEST_OWNER_ID as _,
+            ..Default::default()
+        })
+        .await?;
+        let target_schema_id: SchemaId = Schema::find()
+            .select_only()
+            .column(schema::Column::SchemaId)
+            .filter(schema::Column::Name.eq("subscription_target_schema"))
+            .into_tuple()
+            .one(&mgr.inner.read().await.db)
+            .await?
+            .unwrap();
+
+        let inner = mgr.inner.write().await;
+        let txn = inner.db.begin().await?;
+        let (_, Some(table_id), _) =
+            insert_test_streaming_job(&txn, "subscription_upstream", true, None).await?
+        else {
+            unreachable!()
+        };
+        txn.commit().await?;
+        drop(inner);
+
+        let subscription = PbSubscription {
+            name: "subscription".to_owned(),
+            definition: "CREATE SUBSCRIPTION subscription FROM subscription_upstream".to_owned(),
+            retention_seconds: 86400,
+            database_id: TEST_DATABASE_ID,
+            schema_id: target_schema_id,
+            dependent_table_id: table_id,
+            owner: TEST_OWNER_ID as _,
+            subscription_state: SubscriptionState::Init as _,
+            ..Default::default()
+        };
+        assert!(
+            mgr.create_subscription_catalog(&mut subscription.clone())
+                .await
+                .is_err()
+        );
+
+        let mut subscription = PbSubscription {
+            schema_id: TEST_SCHEMA_ID,
+            ..subscription
+        };
+        mgr.create_subscription_catalog(&mut subscription).await?;
+
+        mgr.alter_schema(ObjectType::Table, table_id.as_object_id(), target_schema_id)
+            .await?;
+        let moved_subscription_obj = Object::find_by_id(subscription.id)
+            .one(&mgr.inner.read().await.db)
+            .await?
+            .unwrap();
+        assert_eq!(moved_subscription_obj.schema_id, Some(target_schema_id));
+        assert!(
+            mgr.alter_schema(
+                ObjectType::Subscription,
+                subscription.id.into(),
+                target_schema_id,
+            )
+            .await
+            .is_err()
+        );
+
+        mgr.drop_object(ObjectType::Table, table_id, DropMode::Restrict)
+            .await?;
+        assert!(
+            Subscription::find_by_id(subscription.id)
+                .one(&mgr.inner.read().await.db)
+                .await?
+                .is_none()
+        );
+
+        Ok(())
+    }
+
+    #[tokio::test]
     async fn test_abort_creating_subscription_commits_delete() -> MetaResult<()> {
         let mgr = CatalogController::new(MetaSrvEnv::for_test().await).await?;
         let pb_view = PbView {

--- a/src/meta/src/controller/utils.rs
+++ b/src/meta/src/controller/utils.rs
@@ -762,7 +762,8 @@ where
     Ok(())
 }
 
-/// `check_object_refer_for_drop` checks whether the object is used by other objects except indexes.
+/// `check_object_refer_for_drop` checks whether the object is used by other objects except indexes
+/// and subscriptions.
 /// It returns an error that contains the details of the referring objects if it is used by others.
 pub async fn check_object_refer_for_drop<C>(
     object_type: ObjectType,
@@ -772,7 +773,7 @@ pub async fn check_object_refer_for_drop<C>(
 where
     C: ConnectionTrait,
 {
-    // Ignore indexes.
+    // Indexes and subscriptions are owned by the upstream table and are dropped with it.
     let count = if object_type == ObjectType::Table {
         ObjectDependency::find()
             .join(
@@ -780,9 +781,11 @@ where
                 object_dependency::Relation::Object1.def(),
             )
             .filter(
-                object_dependency::Column::Oid
-                    .eq(object_id)
-                    .and(object::Column::ObjType.ne(ObjectType::Index)),
+                object_dependency::Column::Oid.eq(object_id).and(
+                    object::Column::ObjType
+                        .ne(ObjectType::Index)
+                        .and(object::Column::ObjType.ne(ObjectType::Subscription)),
+                ),
             )
             .count(db)
             .await?
@@ -797,7 +800,7 @@ where
         let referring_objects = get_referring_objects(object_id, db).await?;
         let referring_objs_map = referring_objects
             .into_iter()
-            .filter(|o| o.obj_type != ObjectType::Index)
+            .filter(|o| o.obj_type != ObjectType::Index && o.obj_type != ObjectType::Subscription)
             .into_group_map_by(|o| o.obj_type);
         let mut details = vec![];
         for (obj_type, objs) in referring_objs_map {


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

This PR makes subscriptions follow the namespace and lifecycle of their upstream table or materialized view:

- `CREATE SUBSCRIPTION` now requires the subscription and its upstream relation to be in the same database and schema.
- `ALTER SUBSCRIPTION ... SET SCHEMA` is no longer supported. Moving a table or materialized view to another schema moves its subscriptions together with its indexes and internal tables.
- Dropping a table or materialized view automatically drops its subscriptions in restrict mode, matching index ownership semantics.
- A metadata migration moves existing subscriptions into their upstream relation's schema without changing object IDs, owners, or object-level ACL grants.
- The migration stops before making changes if moving subscriptions would create duplicate subscription names or relation-name conflicts.

This is a **user-facing breaking change**. SQL that creates a subscription in a different schema, or directly alters a subscription's schema, will be rejected. An upgrade can also be blocked until pre-existing naming conflicts are resolved.

### Pre-upgrade conflict check

Run the following query as a superuser in **every database** before upgrading. If it returns no rows, the database has no naming conflict detected by this migration. If it returns rows, rename or drop the reported conflicting subscriptions or relations before upgrading.

```sql
WITH subscription_targets AS (
    SELECT
        s.id AS subscription_id,
        s.name AS subscription_name,
        s.schema_name AS current_schema,
        upstream.name AS upstream_name,
        upstream.relation_type AS upstream_type,
        upstream.schema_id AS target_schema_id,
        target_schema.name AS target_schema
    FROM rw_catalog.rw_subscriptions AS s
    JOIN rw_catalog.rw_depend AS d
      ON d.objid = s.id
    JOIN rw_catalog.rw_relations AS upstream
      ON upstream.id = d.refobjid
    JOIN rw_catalog.rw_schemas AS target_schema
      ON target_schema.id = upstream.schema_id
    WHERE upstream.relation_type IN ('table', 'materialized view')
),
migration_conflicts AS (
    SELECT
        'duplicate subscriptions in target schema' AS conflict_type,
        a.current_schema || '.' || a.subscription_name AS subscription,
        a.target_schema,
        a.upstream_type || ' ' || a.target_schema || '.' || a.upstream_name AS upstream,
        b.current_schema || '.' || b.subscription_name AS conflicts_with
    FROM subscription_targets AS a
    JOIN subscription_targets AS b
      ON a.subscription_id < b.subscription_id
     AND a.subscription_name = b.subscription_name
     AND a.target_schema_id = b.target_schema_id

    UNION ALL

    SELECT
        'relation in target schema' AS conflict_type,
        t.current_schema || '.' || t.subscription_name AS subscription,
        t.target_schema,
        t.upstream_type || ' ' || t.target_schema || '.' || t.upstream_name AS upstream,
        r.relation_type || ' ' || t.target_schema || '.' || r.name AS conflicts_with
    FROM subscription_targets AS t
    JOIN rw_catalog.rw_relations AS r
      ON r.schema_id = t.target_schema_id
     AND r.name = t.subscription_name
    WHERE r.relation_type IN (
        'table',
        'source',
        'sink',
        'index',
        'materialized view',
        'view'
    )

    UNION ALL

    SELECT
        'internal table in target schema' AS conflict_type,
        t.current_schema || '.' || t.subscription_name AS subscription,
        t.target_schema,
        t.upstream_type || ' ' || t.target_schema || '.' || t.upstream_name AS upstream,
        'internal table ' || i.schema_name || '.' || i.name AS conflicts_with
    FROM subscription_targets AS t
    JOIN rw_catalog.rw_internal_table_info AS i
      ON i.schema_name = t.target_schema
     AND i.name = t.subscription_name
)
SELECT *
FROM migration_conflicts
ORDER BY conflict_type, target_schema, subscription, conflicts_with;
```

## Checklist

- [x] I have written necessary rustdoc comments.
- [x] I have added necessary unit tests and integration tests.
- [x] I have added test labels as necessary.
- [ ] I have added fuzzing tests or opened an issue to track them.
- [x] My PR contains breaking changes.
- [ ] My PR changes performance-critical code, so I will run (micro) benchmarks and present the results.
- [ ] I have checked the Release Timeline and Currently Supported Versions to determine which release branches I need to cherry-pick this PR into.


## Documentation

- [x] My PR needs documentation updates.

<details>
<summary><b>Release note</b></summary>

Subscriptions must now be created in the same database and schema as their upstream table or materialized view. `ALTER SUBSCRIPTION ... SET SCHEMA` is no longer supported. Moving or dropping the upstream relation moves or drops its subscriptions automatically.

This is a **breaking change** for clusters that have subscriptions in a different schema from their upstream relation. During upgrade, existing subscriptions are moved to the upstream schema while retaining their object IDs, owners, and object-level grants. The upgrade stops if this would create a naming conflict.

Run this query as a superuser in **every database** before upgrading. No returned rows means the database has no naming conflict detected by the migration:

```sql
WITH subscription_targets AS (
    SELECT
        s.id AS subscription_id,
        s.name AS subscription_name,
        s.schema_name AS current_schema,
        upstream.name AS upstream_name,
        upstream.relation_type AS upstream_type,
        upstream.schema_id AS target_schema_id,
        target_schema.name AS target_schema
    FROM rw_catalog.rw_subscriptions AS s
    JOIN rw_catalog.rw_depend AS d
      ON d.objid = s.id
    JOIN rw_catalog.rw_relations AS upstream
      ON upstream.id = d.refobjid
    JOIN rw_catalog.rw_schemas AS target_schema
      ON target_schema.id = upstream.schema_id
    WHERE upstream.relation_type IN ('table', 'materialized view')
),
migration_conflicts AS (
    SELECT
        'duplicate subscriptions in target schema' AS conflict_type,
        a.current_schema || '.' || a.subscription_name AS subscription,
        a.target_schema,
        a.upstream_type || ' ' || a.target_schema || '.' || a.upstream_name AS upstream,
        b.current_schema || '.' || b.subscription_name AS conflicts_with
    FROM subscription_targets AS a
    JOIN subscription_targets AS b
      ON a.subscription_id < b.subscription_id
     AND a.subscription_name = b.subscription_name
     AND a.target_schema_id = b.target_schema_id

    UNION ALL

    SELECT
        'relation in target schema' AS conflict_type,
        t.current_schema || '.' || t.subscription_name AS subscription,
        t.target_schema,
        t.upstream_type || ' ' || t.target_schema || '.' || t.upstream_name AS upstream,
        r.relation_type || ' ' || t.target_schema || '.' || r.name AS conflicts_with
    FROM subscription_targets AS t
    JOIN rw_catalog.rw_relations AS r
      ON r.schema_id = t.target_schema_id
     AND r.name = t.subscription_name
    WHERE r.relation_type IN (
        'table',
        'source',
        'sink',
        'index',
        'materialized view',
        'view'
    )

    UNION ALL

    SELECT
        'internal table in target schema' AS conflict_type,
        t.current_schema || '.' || t.subscription_name AS subscription,
        t.target_schema,
        t.upstream_type || ' ' || t.target_schema || '.' || t.upstream_name AS upstream,
        'internal table ' || i.schema_name || '.' || i.name AS conflicts_with
    FROM subscription_targets AS t
    JOIN rw_catalog.rw_internal_table_info AS i
      ON i.schema_name = t.target_schema
     AND i.name = t.subscription_name
)
SELECT *
FROM migration_conflicts
ORDER BY conflict_type, target_schema, subscription, conflicts_with;
```

Rename or drop every reported conflicting subscription or relation before upgrading.

</details>
