### PR TITLE
feat(storage): add partitioned sstable writer path

### DIFF
--- a/src/storage/src/hummock/sstable/builder.rs
+++ b/src/storage/src/hummock/sstable/builder.rs
@@ -14,6 +14,7 @@
 
 use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::mem;
+use std::num::NonZeroUsize;
 use std::sync::Arc;
 use std::time::SystemTime;
 
@@ -21,6 +22,7 @@ use await_tree::{InstrumentAwait, SpanExt};
 use bytes::{Bytes, BytesMut};
 use risingwave_common::catalog::TableId;
 use risingwave_common::hash::VirtualNode;
+use risingwave_common::util::iter_util::ZipEqFast;
 use risingwave_common::util::row_serde::OrderedRowSerde;
 use risingwave_hummock_sdk::key::{FullKey, MAX_KEY_LEN, TABLE_PREFIX_LEN, UserKey, user_key};
 use risingwave_hummock_sdk::key_range::KeyRange;
@@ -29,6 +31,7 @@ use risingwave_hummock_sdk::table_stats::{TableStats, TableStatsMap};
 use risingwave_hummock_sdk::{HummockEpoch, HummockSstableObjectId, LocalSstableInfo};
 use risingwave_pb::hummock::{PbSstableFilterLayout, PbSstableFilterType};
 
+use super::meta::v3::{append_meta_partition_index, append_meta_shard};
 use super::utils::CompressionAlgorithm;
 use super::{
     BlockBuilder, BlockBuilderOptions, BlockMeta, DEFAULT_BLOCK_SIZE, DEFAULT_ENTRY_SIZE,
@@ -161,12 +164,25 @@ pub struct SstableBuilder<W: SstableWriter, F: FilterBuilder> {
     last_table_stats: TableStats,
 
     filter_builder: F,
+    v3_builder_state: Option<V3BuilderState>,
 
     epoch_set: BTreeSet<u64>,
     memory_limiter: Option<Arc<MemoryLimiter>>,
 
     block_size_vec: Vec<usize>, // for statistics
     vnode_range_collector: Option<VnodeUserKeyRangeCollector>,
+}
+
+struct V3BuilderState {
+    blocks_per_shard: NonZeroUsize,
+    finished_filters: Vec<Vec<u8>>,
+    finished_filter_bytes: usize,
+}
+
+struct V3MetadataSuffix {
+    bytes: Vec<u8>,
+    index_offset: usize,
+    filter_size: usize,
 }
 
 impl<W: SstableWriter> SstableBuilder<W, Xor16FilterBuilder> {
@@ -226,6 +242,7 @@ impl<W: SstableWriter, F: FilterBuilder> SstableBuilder<W, F> {
                 compression_algorithm: options.compression_algorithm,
             }),
             filter_builder,
+            v3_builder_state: None,
             block_metas: Vec::with_capacity(options.capacity / options.block_capacity + 1),
             table_ids: BTreeSet::new(),
             last_table_id: None,
@@ -240,6 +257,31 @@ impl<W: SstableWriter, F: FilterBuilder> SstableBuilder<W, F> {
             memory_limiter,
             block_size_vec: Vec::new(),
         }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn enable_v3_for_test(&mut self, blocks_per_shard: NonZeroUsize) {
+        assert!(self.v3_builder_state.is_none());
+        assert!(self.block_metas.is_empty());
+        assert!(self.block_builder.is_empty());
+        self.filter_builder = F::create(self.v3_filter_builder_options(blocks_per_shard));
+        self.v3_builder_state = Some(V3BuilderState {
+            blocks_per_shard,
+            finished_filters: Vec::new(),
+            finished_filter_bytes: 0,
+        });
+    }
+
+    fn v3_filter_builder_options(&self, blocks_per_shard: NonZeroUsize) -> FilterBuilderOptions {
+        let mut options = self.options.filter_builder_options();
+        let estimated_block_count = blocks_per_shard.get().min(options.estimated_block_count);
+        options.estimated_key_count = options
+            .estimated_key_count
+            .saturating_mul(estimated_block_count)
+            .div_ceil(options.estimated_block_count)
+            .max(1);
+        options.estimated_block_count = estimated_block_count;
+        options
     }
 
     /// Add kv pair to sstable.
@@ -478,6 +520,53 @@ impl<W: SstableWriter, F: FilterBuilder> SstableBuilder<W, F> {
         Ok(())
     }
 
+    fn build_v3_metadata_suffix(&mut self, mut state: V3BuilderState) -> V3MetadataSuffix {
+        assert!(!self.block_metas.is_empty());
+
+        // Finish the final partial shard filter, if block flushing did not finish it already.
+        if !self
+            .block_metas
+            .len()
+            .is_multiple_of(state.blocks_per_shard.get())
+        {
+            let filter = self
+                .filter_builder
+                .finish(self.memory_limiter.clone())
+                .unwrap_or_default();
+            state.finished_filter_bytes += filter.len();
+            state.finished_filters.push(filter);
+        }
+        assert_eq!(
+            state.finished_filters.len(),
+            self.block_metas
+                .len()
+                .div_ceil(state.blocks_per_shard.get())
+        );
+
+        let blocks_per_shard = state.blocks_per_shard;
+        let filter_size = state.finished_filter_bytes;
+        let finished_filters = state.finished_filters;
+
+        // Append contiguous shard bodies first, then append the partition index after them.
+        let mut bytes = Vec::new();
+        let mut shards = Vec::with_capacity(finished_filters.len());
+        for (block_metas, filter) in self
+            .block_metas
+            .chunks(blocks_per_shard.get())
+            .zip_eq_fast(finished_filters)
+        {
+            shards.push(append_meta_shard(&mut bytes, block_metas, &filter));
+        }
+        let index_offset = bytes.len();
+        append_meta_partition_index(&mut bytes, shards);
+
+        V3MetadataSuffix {
+            bytes,
+            index_offset,
+            filter_size,
+        }
+    }
+
     /// Finish building sst.
     ///
     /// # Format
@@ -504,28 +593,17 @@ impl<W: SstableWriter, F: FilterBuilder> SstableBuilder<W, F> {
             self.table_ids.len()
         );
 
+        // Complete the data region before deriving any metadata offsets.
         self.build_block()
             .instrument_await("sstable_finish_build_block".verbose())
             .await?;
         let right_exclusive = false;
-        let meta_offset = self.writer.data_len() as u64;
-
-        let filter_data = self.filter_builder.finish(self.memory_limiter.clone());
-        let (filter_type, filter_layout) = if filter_data.is_none() {
-            (
-                PbSstableFilterType::SstableFilterNone,
-                PbSstableFilterLayout::Unspecified,
-            )
-        } else if self.filter_builder.support_blocked_raw_data() {
-            (
-                self.filter_builder.filter_type(),
-                PbSstableFilterLayout::Blocked,
-            )
-        } else {
-            (
-                self.filter_builder.filter_type(),
-                PbSstableFilterLayout::Plain,
-            )
+        let data_end = self.writer.data_len() as u64;
+        let meta_offset;
+        let key_range = KeyRange {
+            left: Bytes::from(smallest_key.clone()),
+            right: Bytes::from(largest_key.clone()),
+            right_exclusive,
         };
 
         let total_key_count = self
@@ -544,45 +622,128 @@ impl<W: SstableWriter, F: FilterBuilder> SstableBuilder<W, F> {
             .map(|block_meta| block_meta.uncompressed_size as u64)
             .sum::<u64>();
 
-        #[expect(deprecated)]
-        let mut meta = SstableMeta {
-            block_metas: self.block_metas,
-            bloom_filter: filter_data.unwrap_or_default(),
-            estimated_size: 0,
-            key_count: utils::checked_into_u32(total_key_count).unwrap_or_else(|_| {
-                panic!(
-                    "WARN overflow can't convert total_key_count {} into u32 tables {:?}",
-                    total_key_count, self.table_ids,
-                )
-            }),
-            smallest_key,
-            largest_key,
-            version: VERSION,
-            meta_offset,
-            monotonic_tombstone_events: vec![],
-        };
+        if !self.block_metas.is_empty() {
+            // fill total_compressed_size
+            let mut last_table_id = self.block_metas[0].table_id();
+            let mut last_table_stats = self.table_stats.get_mut(&last_table_id).unwrap();
+            for block_meta in &self.block_metas {
+                let block_table_id = block_meta.table_id();
+                if last_table_id != block_table_id {
+                    last_table_id = block_table_id;
+                    last_table_stats = self.table_stats.get_mut(&last_table_id).unwrap();
+                }
 
-        let meta_encode_size = meta.encoded_size();
-        let encoded_size_u32 = utils::checked_into_u32(meta_encode_size).unwrap_or_else(|_| {
-            panic!(
-                "WARN overflow can't convert meta_encoded_size {} into u32 tables {:?}",
-                meta_encode_size, self.table_ids,
-            )
-        });
-        let meta_offset_u32 = utils::checked_into_u32(meta_offset).unwrap_or_else(|_| {
-            panic!(
-                "WARN overflow can't convert meta_offset {} into u32 tables {:?}",
-                meta_offset, self.table_ids,
-            )
-        });
-        meta.estimated_size = encoded_size_u32
-            .checked_add(meta_offset_u32)
-            .unwrap_or_else(|| {
-                panic!(
-                    "WARN overflow encoded_size_u32 {} meta_offset_u32 {} table_id {:?} table_ids {:?}",
-                    encoded_size_u32, meta_offset_u32, self.last_table_id, self.table_ids
+                last_table_stats.total_compressed_size += block_meta.len as u64;
+            }
+        }
+
+        let (writer_payload, metadata_size, file_size, filter_size, filter_type, filter_layout) =
+            if let Some(state) = self.v3_builder_state.take() {
+                let suffix = self.build_v3_metadata_suffix(state);
+                meta_offset = data_end
+                    .checked_add(suffix.index_offset as u64)
+                    .unwrap_or_else(|| {
+                        panic!(
+                            "WARN overflow data_end {} shard_bytes {} table_ids {:?}",
+                            data_end, suffix.index_offset, self.table_ids
+                        )
+                    });
+
+                let metadata_size = suffix.bytes.len() as u64;
+                let file_size = data_end.checked_add(metadata_size).unwrap_or_else(|| {
+                    panic!(
+                        "WARN overflow data_end {} metadata_size {} table_ids {:?}",
+                        data_end, metadata_size, self.table_ids
+                    )
+                });
+                let filter_type = self.filter_builder.filter_type();
+                let filter_layout = if filter_type == PbSstableFilterType::SstableFilterNone {
+                    PbSstableFilterLayout::Unspecified
+                } else if self.filter_builder.support_blocked_raw_data() {
+                    PbSstableFilterLayout::Blocked
+                } else {
+                    PbSstableFilterLayout::Plain
+                };
+                (
+                    SstableWriterPayload::V3(Bytes::from(suffix.bytes)),
+                    metadata_size,
+                    file_size,
+                    suffix.filter_size,
+                    filter_type,
+                    filter_layout,
                 )
-            });
+            } else {
+                let filter_data = self.filter_builder.finish(self.memory_limiter.clone());
+                let (filter_type, filter_layout) = if filter_data.is_none() {
+                    (
+                        PbSstableFilterType::SstableFilterNone,
+                        PbSstableFilterLayout::Unspecified,
+                    )
+                } else if self.filter_builder.support_blocked_raw_data() {
+                    (
+                        self.filter_builder.filter_type(),
+                        PbSstableFilterLayout::Blocked,
+                    )
+                } else {
+                    (
+                        self.filter_builder.filter_type(),
+                        PbSstableFilterLayout::Plain,
+                    )
+                };
+
+                meta_offset = data_end;
+
+                #[expect(deprecated)]
+                let mut meta = SstableMeta {
+                    block_metas: self.block_metas,
+                    bloom_filter: filter_data.unwrap_or_default(),
+                    estimated_size: 0,
+                    key_count: utils::checked_into_u32(total_key_count).unwrap_or_else(|_| {
+                        panic!(
+                            "WARN overflow can't convert total_key_count {} into u32 tables {:?}",
+                            total_key_count, self.table_ids,
+                        )
+                    }),
+                    smallest_key,
+                    largest_key,
+                    version: VERSION,
+                    meta_offset,
+                    monotonic_tombstone_events: vec![],
+                };
+
+                let meta_encode_size = meta.encoded_size();
+                let encoded_size_u32 =
+                    utils::checked_into_u32(meta_encode_size).unwrap_or_else(|_| {
+                        panic!(
+                            "WARN overflow can't convert meta_encoded_size {} into u32 tables {:?}",
+                            meta_encode_size, self.table_ids,
+                        )
+                    });
+                let meta_offset_u32 = utils::checked_into_u32(meta_offset).unwrap_or_else(|_| {
+                    panic!(
+                        "WARN overflow can't convert meta_offset {} into u32 tables {:?}",
+                        meta_offset, self.table_ids,
+                    )
+                });
+                meta.estimated_size = encoded_size_u32
+                    .checked_add(meta_offset_u32)
+                    .unwrap_or_else(|| {
+                        panic!(
+                            "WARN overflow encoded_size_u32 {} meta_offset_u32 {} table_id {:?} table_ids {:?}",
+                            encoded_size_u32, meta_offset_u32, self.last_table_id, self.table_ids
+                        )
+                    });
+                let file_size = meta.estimated_size as u64;
+                let filter_size = meta.bloom_filter.len();
+                (
+                    SstableWriterPayload::V2(meta),
+                    meta_encode_size as u64,
+                    file_size,
+                    filter_size,
+                    filter_type,
+                    filter_layout,
+                )
+            };
 
         let (avg_key_size, avg_value_size) = if self.table_stats.is_empty() {
             (0, 0)
@@ -631,21 +792,17 @@ impl<W: SstableWriter, F: FilterBuilder> SstableBuilder<W, F> {
             object_id: self.sst_object_id,
             // use the same sst_id as object_id for initial sst
             sst_id: self.sst_object_id.as_raw_id().into(),
-            key_range: KeyRange {
-                left: Bytes::from(meta.smallest_key.clone()),
-                right: Bytes::from(meta.largest_key.clone()),
-                right_exclusive,
-            },
-            file_size: meta.estimated_size as u64,
+            key_range,
+            file_size,
             table_ids: self.table_ids.into_iter().collect(),
-            meta_offset: meta.meta_offset,
+            meta_offset,
             stale_key_count,
             total_key_count,
-            uncompressed_file_size: uncompressed_file_size + meta.encoded_size() as u64,
+            uncompressed_file_size: uncompressed_file_size + metadata_size,
             min_epoch,
             max_epoch,
             range_tombstone_count: 0,
-            sst_size: meta.estimated_size as u64,
+            sst_size: file_size,
             filter_type,
             filter_layout,
             vnode_statistics: vnode_user_key_ranges,
@@ -654,37 +811,22 @@ impl<W: SstableWriter, F: FilterBuilder> SstableBuilder<W, F> {
 
         tracing::trace!(
             "meta_size {} filter_size {} add_key_counts {} stale_key_count {} min_epoch {} max_epoch {} epoch_count {}",
-            meta.encoded_size(),
-            meta.bloom_filter.len(),
+            metadata_size,
+            filter_size,
             total_key_count,
             stale_key_count,
             min_epoch,
             max_epoch,
             self.epoch_set.len()
         );
-        let filter_size = meta.bloom_filter.len();
         let sstable_file_size = sst_info.file_size as usize;
-
-        if !meta.block_metas.is_empty() {
-            // fill total_compressed_size
-            let mut last_table_id = meta.block_metas[0].table_id();
-            let mut last_table_stats = self.table_stats.get_mut(&last_table_id).unwrap();
-            for block_meta in &meta.block_metas {
-                let block_table_id = block_meta.table_id();
-                if last_table_id != block_table_id {
-                    last_table_id = block_table_id;
-                    last_table_stats = self.table_stats.get_mut(&last_table_id).unwrap();
-                }
-
-                last_table_stats.total_compressed_size += block_meta.len as u64;
-            }
-        }
 
         let writer_output = self
             .writer
-            .finish(SstableWriterPayload::V2(meta))
+            .finish(writer_payload)
             .instrument_await("sstable_writer_finish".verbose())
             .await?;
+
         // The timestamp is only used during full GC.
         //
         // Ideally object store object's last_modified should be used.
@@ -715,6 +857,10 @@ impl<W: SstableWriter, F: FilterBuilder> SstableBuilder<W, F> {
         self.writer.data_len()
             + self.block_builder.approximate_len()
             + self.filter_builder.approximate_len()
+            + self
+                .v3_builder_state
+                .as_ref()
+                .map_or(0, |state| state.finished_filter_bytes)
     }
 
     pub async fn build_block(&mut self) -> HummockResult<()> {
@@ -755,6 +901,23 @@ impl<W: SstableWriter, F: FilterBuilder> SstableBuilder<W, F> {
 
         self.filter_builder
             .switch_block(self.memory_limiter.clone());
+
+        let blocks_per_shard = self.v3_builder_state.as_ref().and_then(|state| {
+            self.block_metas
+                .len()
+                .is_multiple_of(state.blocks_per_shard.get())
+                .then_some(state.blocks_per_shard)
+        });
+        if let Some(blocks_per_shard) = blocks_per_shard {
+            let filter = self
+                .filter_builder
+                .finish(self.memory_limiter.clone())
+                .unwrap_or_default();
+            let state = self.v3_builder_state.as_mut().unwrap();
+            state.finished_filter_bytes += filter.len();
+            state.finished_filters.push(filter);
+            self.filter_builder = F::create(self.v3_filter_builder_options(blocks_per_shard));
+        }
 
         if data_len as usize > self.options.capacity * 2 {
             tracing::warn!(

--- a/src/storage/src/hummock/sstable/builder.rs
+++ b/src/storage/src/hummock/sstable/builder.rs
@@ -32,7 +32,7 @@ use risingwave_pb::hummock::{PbSstableFilterLayout, PbSstableFilterType};
 use super::utils::CompressionAlgorithm;
 use super::{
     BlockBuilder, BlockBuilderOptions, BlockMeta, DEFAULT_BLOCK_SIZE, DEFAULT_ENTRY_SIZE,
-    DEFAULT_RESTART_INTERVAL, SstableMeta, SstableWriter, VERSION,
+    DEFAULT_RESTART_INTERVAL, SstableMeta, SstableWriter, SstableWriterPayload, VERSION,
 };
 use crate::compaction_catalog_manager::{
     CompactionCatalogAgent, CompactionCatalogAgentRef, FilterKeyExtractorImpl,
@@ -682,7 +682,7 @@ impl<W: SstableWriter, F: FilterBuilder> SstableBuilder<W, F> {
 
         let writer_output = self
             .writer
-            .finish(meta)
+            .finish(SstableWriterPayload::V2(meta))
             .instrument_await("sstable_writer_finish".verbose())
             .await?;
         // The timestamp is only used during full GC.
@@ -1271,11 +1271,10 @@ pub(super) mod tests {
             test_key_of(TEST_KEYS_COUNT - 1).encode(),
             info.key_range.right
         );
-        let (data, meta) = output.writer_output;
-        assert_eq!(info.file_size, meta.estimated_size as u64);
+        let data = output.writer_output;
         let offset = info.meta_offset as usize;
-        let meta2 = SstableMeta::decode(&data[offset..]).unwrap();
-        assert_eq!(meta2, meta);
+        let meta = SstableMeta::decode(&data[offset..]).unwrap();
+        assert_eq!(info.file_size, meta.estimated_size as u64);
     }
 
     async fn test_with_xor_filter_builder<F: FilterBuilder>(

--- a/src/storage/src/hummock/sstable/meta/v3.rs
+++ b/src/storage/src/hummock/sstable/meta/v3.rs
@@ -477,12 +477,24 @@ fn decode_block_meta_checked(buf: &mut &[u8]) -> HummockResult<BlockMeta> {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashMap;
+    use std::num::NonZeroUsize;
+    use std::ops::Bound;
+
+    use bytes::Bytes;
     use risingwave_common::catalog::TableId;
+    use risingwave_common::hash::VirtualNode;
     use risingwave_common::util::epoch::test_epoch;
     use risingwave_common::util::panic::rw_catch_unwind;
-    use risingwave_hummock_sdk::key::FullKey;
+    use risingwave_hummock_sdk::key::{FullKey, user_key};
+    use risingwave_hummock_sdk::sstable_info::SstableInfo;
 
     use super::*;
+    use crate::hummock::sstable::{
+        Sstable, SstableBuilder, SstableBuilderOptions, Xor16FilterBuilder, XorFilterReader,
+    };
+    use crate::hummock::test_utils::{mock_sst_writer, test_key_of};
+    use crate::hummock::{HummockValue, SstableMeta};
 
     fn test_key(idx: usize) -> Vec<u8> {
         FullKey::for_test(
@@ -801,6 +813,173 @@ mod tests {
         };
 
         assert!(desc.decode_body(&body).is_err());
+    }
+
+    #[tokio::test]
+    async fn test_v3_writer_raw_byte_oracle() {
+        let cases = [
+            ("partial", OracleCase::MoreThanBlocks),
+            ("singleton", OracleCase::One),
+            ("mixed", OracleCase::OneLessThanBlocks),
+            ("same-user-epochs", OracleCase::SameUserEpochs),
+        ];
+
+        for (name, case) in cases {
+            let entries = oracle_entries(case);
+            let (v2_bytes, v2_info) = build_oracle_sst(&entries, None).await;
+            let v2_meta = SstableMeta::decode(&v2_bytes[v2_info.meta_offset as usize..]).unwrap();
+            let block_count = v2_meta.block_metas.len();
+            assert!(block_count >= 3, "{name} needs at least three data blocks");
+
+            let blocks_per_shard = match case {
+                OracleCase::MoreThanBlocks => block_count + 1,
+                OracleCase::One => 1,
+                OracleCase::OneLessThanBlocks => block_count - 1,
+                OracleCase::SameUserEpochs => 2,
+            };
+            if matches!(case, OracleCase::SameUserEpochs) {
+                assert_eq!(
+                    user_key(&v2_meta.block_metas[blocks_per_shard - 1].smallest_key),
+                    user_key(&v2_meta.block_metas[blocks_per_shard].smallest_key),
+                    "{name}: shard boundary must split epochs of one user key"
+                );
+            }
+            let (v3_bytes, v3_info) =
+                build_oracle_sst(&entries, Some(NonZeroUsize::new(blocks_per_shard).unwrap()))
+                    .await;
+
+            let data_end = v2_info.meta_offset as usize;
+            assert_eq!(
+                &v2_bytes[..data_end],
+                &v3_bytes[..data_end],
+                "{name}: data prefix differs"
+            );
+            assert_eq!(
+                v3_bytes.len() as u64,
+                v3_info.file_size,
+                "{name}: file size"
+            );
+            assert_eq!(v3_info.file_size, v3_info.sst_size, "{name}: SST size");
+
+            let meta_offset = v3_info.meta_offset as usize;
+            let index =
+                MetaPartitionIndex::decode(&v3_bytes[meta_offset..], v3_info.meta_offset).unwrap();
+            let mut body_start = data_end;
+            assert_eq!(
+                index.shards.len(),
+                block_count.div_ceil(blocks_per_shard),
+                "{name}: shard count"
+            );
+            let mut flattened = Vec::with_capacity(block_count);
+            for desc in &index.shards {
+                let body_end = body_start + desc.len as usize;
+                assert!(
+                    body_end <= meta_offset,
+                    "{name}: shard body must stay before index"
+                );
+                let shard = desc.decode_body(&v3_bytes[body_start..body_end]).unwrap();
+                let expected_block_count = (block_count - flattened.len()).min(blocks_per_shard);
+                assert_eq!(
+                    desc.block_count as usize, expected_block_count,
+                    "{name}: descriptor block count"
+                );
+                assert_eq!(
+                    shard.block_metas.len(),
+                    expected_block_count,
+                    "{name}: decoded shard block count"
+                );
+                let first_full_key = &shard.block_metas[0].smallest_key;
+                let full_key = FullKey::decode(first_full_key);
+                let hash = Sstable::hash_for_filter(
+                    user_key(first_full_key),
+                    full_key.user_key.table_id.as_raw_id(),
+                );
+                let first_user_key = full_key.user_key;
+                let filter_reader = XorFilterReader::new(&shard.filter, &shard.block_metas);
+                assert!(
+                    filter_reader.may_match(
+                        &shard.block_metas,
+                        &(
+                            Bound::Included(first_user_key),
+                            Bound::Included(first_user_key),
+                        ),
+                        hash,
+                    ),
+                    "{name}: shard filter misses its first user key"
+                );
+                flattened.extend(shard.block_metas);
+                body_start = body_end;
+            }
+            assert_eq!(
+                body_start, meta_offset,
+                "{name}: shards must end at the index"
+            );
+            assert_eq!(
+                flattened, v2_meta.block_metas,
+                "{name}: flattened block metas"
+            );
+        }
+    }
+
+    #[derive(Clone, Copy)]
+    enum OracleCase {
+        MoreThanBlocks,
+        One,
+        OneLessThanBlocks,
+        SameUserEpochs,
+    }
+
+    fn oracle_entries(case: OracleCase) -> Vec<(FullKey<Vec<u8>>, Vec<u8>)> {
+        match case {
+            OracleCase::SameUserEpochs => (0..4)
+                .flat_map(|user_idx| {
+                    [3, 2, 1].into_iter().map(move |epoch| {
+                        (
+                            FullKey::for_test(
+                                TableId::default(),
+                                test_key_of(user_idx).user_key.table_key.to_vec(),
+                                test_epoch(epoch),
+                            ),
+                            vec![user_idx as u8; 256],
+                        )
+                    })
+                })
+                .collect(),
+            _ => (0..6)
+                .map(|idx| (test_key_of(idx), vec![idx as u8; 256]))
+                .collect(),
+        }
+    }
+
+    async fn build_oracle_sst(
+        entries: &[(FullKey<Vec<u8>>, Vec<u8>)],
+        blocks_per_shard: Option<NonZeroUsize>,
+    ) -> (Bytes, SstableInfo) {
+        let options = SstableBuilderOptions {
+            capacity: 4 * 1024,
+            block_capacity: 128,
+            restart_interval: 1,
+            bloom_false_positive: 0.1,
+            ..Default::default()
+        };
+        let mut builder = SstableBuilder::<_, Xor16FilterBuilder>::for_test(
+            1,
+            mock_sst_writer(&options),
+            options,
+            HashMap::from([(TableId::default(), VirtualNode::COUNT_FOR_TEST)]),
+            HashMap::from([(TableId::default(), None)]),
+        );
+        if let Some(blocks_per_shard) = blocks_per_shard {
+            builder.enable_v3_for_test(blocks_per_shard);
+        }
+        for (key, value) in entries {
+            builder
+                .add_for_test(key.to_ref(), HummockValue::put(value))
+                .await
+                .unwrap();
+        }
+        let output = builder.finish().await.unwrap();
+        (output.writer_output, output.sst_info.sst_info)
     }
 
     fn assert_decode_returns_err_without_panicking<T>(f: impl FnOnce() -> HummockResult<T>) {

--- a/src/storage/src/hummock/sstable/writer.rs
+++ b/src/storage/src/hummock/sstable/writer.rs
@@ -41,10 +41,15 @@ pub trait SstableWriter: Send {
     async fn write_block_bytes(&mut self, block: Bytes, meta: &BlockMeta) -> HummockResult<()>;
 
     /// Finish writing the SST.
-    async fn finish(self, meta: SstableMeta) -> HummockResult<Self::Output>;
+    async fn finish(self, payload: SstableWriterPayload) -> HummockResult<Self::Output>;
 
     /// Get the length of data that has already been written.
     fn data_len(&self) -> usize;
+}
+
+pub enum SstableWriterPayload {
+    V2(SstableMeta),
+    V3(Bytes),
 }
 
 /// Append SST data to a buffer. Used for tests and benchmarks.
@@ -68,7 +73,7 @@ impl From<&SstableBuilderOptions> for InMemWriter {
 
 #[async_trait::async_trait]
 impl SstableWriter for InMemWriter {
-    type Output = (Bytes, SstableMeta);
+    type Output = Bytes;
 
     async fn write_block(&mut self, block: &[u8], _meta: &BlockMeta) -> HummockResult<()> {
         self.buf.extend_from_slice(block);
@@ -80,9 +85,12 @@ impl SstableWriter for InMemWriter {
         Ok(())
     }
 
-    async fn finish(mut self, meta: SstableMeta) -> HummockResult<Self::Output> {
-        meta.encode_to(&mut self.buf);
-        Ok((Bytes::from(self.buf), meta))
+    async fn finish(mut self, payload: SstableWriterPayload) -> HummockResult<Self::Output> {
+        match payload {
+            SstableWriterPayload::V2(meta) => meta.encode_to(&mut self.buf),
+            SstableWriterPayload::V3(metadata) => self.buf.extend_from_slice(&metadata),
+        }
+        Ok(Bytes::from(self.buf))
     }
 
     fn data_len(&self) -> usize {
@@ -196,10 +204,19 @@ impl SstableWriter for BatchUploadWriter {
         Ok(())
     }
 
-    async fn finish(mut self, meta: SstableMeta) -> HummockResult<Self::Output> {
+    async fn finish(mut self, payload: SstableWriterPayload) -> HummockResult<Self::Output> {
         fail_point!("data_upload_err");
         let join_handle = tokio::spawn(async move {
-            meta.encode_to(&mut self.buf);
+            let meta = match payload {
+                SstableWriterPayload::V2(meta) => {
+                    meta.encode_to(&mut self.buf);
+                    Some(meta)
+                }
+                SstableWriterPayload::V3(metadata) => {
+                    self.buf.extend_from_slice(&metadata);
+                    None
+                }
+            };
             let data = Bytes::from(self.buf);
             let _tracker = self.tracker.map(|mut t| {
                 if !t.try_increase_memory(data.capacity() as u64) {
@@ -214,7 +231,9 @@ impl SstableWriter for BatchUploadWriter {
                 .clone()
                 .put_sst_data(self.object_id, data)
                 .await?;
-            self.sstable_store.insert_meta_cache(self.object_id, meta);
+            if let Some(meta) = meta {
+                self.sstable_store.insert_meta_cache(self.object_id, meta);
+            }
 
             // Only update recent filter with sst obj id is okay here, for l0 is only filter by sst obj id with recent filter.
             self.sstable_store
@@ -306,8 +325,11 @@ impl SstableWriter for StreamingUploadWriter {
             .map_err(Into::into)
     }
 
-    async fn finish(mut self, meta: SstableMeta) -> HummockResult<UploadJoinHandle> {
-        let metadata = Bytes::from(meta.encode_to_bytes());
+    async fn finish(mut self, payload: SstableWriterPayload) -> HummockResult<UploadJoinHandle> {
+        let (metadata, meta) = match payload {
+            SstableWriterPayload::V2(meta) => (Bytes::from(meta.encode_to_bytes()), Some(meta)),
+            SstableWriterPayload::V3(metadata) => (metadata, None),
+        };
 
         self.object_uploader.write_bytes(metadata).await?;
         let join_handle = tokio::spawn(async move {
@@ -320,12 +342,15 @@ impl SstableWriter for StreamingUploadWriter {
                     t
                 });
 
-            assert!(!meta.block_metas.is_empty());
-
+            if let Some(meta) = meta.as_ref() {
+                assert!(!meta.block_metas.is_empty());
+            }
             // Upload data to object store.
             self.object_uploader.finish().await?;
             // Add meta cache.
-            self.sstable_store.insert_meta_cache(self.object_id, meta);
+            if let Some(meta) = meta {
+                self.sstable_store.insert_meta_cache(self.object_id, meta);
+            }
 
             // Add block cache.
             if let CachePolicy::Fill(hint) = self.policy
@@ -391,7 +416,9 @@ mod tests {
     use risingwave_common::util::iter_util::ZipEqFast;
 
     use crate::hummock::sstable::VERSION;
-    use crate::hummock::{BlockMeta, InMemWriter, SstableMeta, SstableWriter};
+    use crate::hummock::{
+        BlockMeta, InMemWriter, SstableMeta, SstableWriter, SstableWriterPayload,
+    };
 
     fn get_sst() -> (Bytes, Vec<Bytes>, SstableMeta) {
         let mut rng = rand::rngs::StdRng::seed_from_u64(0);
@@ -436,7 +463,12 @@ mod tests {
         }
 
         let meta_offset = meta.meta_offset as usize;
-        let (output_data, _) = writer.finish(meta).await.unwrap();
+        let data_end = writer.data_len();
+        let output_data = writer
+            .finish(SstableWriterPayload::V2(meta.clone()))
+            .await
+            .unwrap();
         assert_eq!(output_data.slice(0..meta_offset), data);
+        assert_eq!(SstableMeta::decode(&output_data[data_end..]).unwrap(), meta);
     }
 }

--- a/src/storage/src/hummock/test_utils.rs
+++ b/src/storage/src/hummock/test_utils.rs
@@ -37,6 +37,7 @@ use risingwave_hummock_sdk::{
 use super::iterator::test_utils::iterator_test_table_key_of;
 use super::{
     DEFAULT_RESTART_INTERVAL, HummockResult, InMemWriter, SstableMeta, SstableWriterOptions,
+    SstableWriterPayload,
 };
 use crate::StateStore;
 use crate::compaction_catalog_manager::{
@@ -183,7 +184,10 @@ pub async fn gen_test_sstable_data(
             .unwrap();
     }
     let output = b.finish().await.unwrap();
-    output.writer_output
+    let data = output.writer_output;
+    let meta_offset = output.sst_info.sst_info.meta_offset as usize;
+    let meta = SstableMeta::decode(&data[meta_offset..]).unwrap();
+    (data, meta)
 }
 
 /// Write the data and meta to `sstable_store`.
@@ -238,7 +242,7 @@ pub async fn put_sst(
         ..Default::default()
     }
     .into();
-    let writer_output = writer.finish(meta).await?;
+    let writer_output = writer.finish(SstableWriterPayload::V2(meta)).await?;
     writer_output.await.unwrap()?;
     Ok(sst)
 }


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

This PR adds the dormant Hummock V3 partitioned SST metadata writer path on top of the codec introduced by #26219.

- Introduce a writer payload that lets the existing in-memory, batch, and streaming writers handle either V2 full metadata or an encoded V3 metadata suffix without duplicating the data-block write path.
- Add a private V3 builder mode that rotates shard-local filters at a fixed block count, appends independently checksummed metadata shards, and writes the partition index after the shard bodies.
- Add a table-driven raw-byte oracle covering partial shards, exact single-block shards, full-plus-partial shards, and same-user-key epochs crossing a shard boundary.
- Preserve the existing V2 behavior and metadata-cache side effects.

The V3 path is only enabled by a test-private constructor in this PR. It does not add a production selector, configuration, mixed-format reader/cache integration, fast raw-copy support, or production rollout.

Related to #26156.

## Checklist

- [x] I have written necessary rustdoc comments.
- [x] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

No user-facing behavior change. The V3 writer path remains test-only and is not production-enabled by this PR.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for V3 SSTable metadata with shard-level filters and partition indexes.
  * Improved metadata handling across V2 and V3 SSTable formats.
* **Bug Fixes**
  * Improved SSTable size, offset, filter, and compression statistics across supported metadata formats.
  * Ensured metadata remains consistent across shard boundaries and writer output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->