### PR TITLE
fix(meta): reject inverted table change log epoch ranges

### DIFF
--- a/src/frontend/src/session.rs
+++ b/src/frontend/src/session.rs
@@ -1330,13 +1330,14 @@ impl SessionImpl {
         Ok(secret.clone())
     }
 
+    /// Returns `None` when the table's committed epoch has not reached `min_epoch`.
     pub async fn list_change_log_epochs(
         &self,
         table_id: TableId,
         min_epoch: u64,
         max_count: u32,
-    ) -> Result<Vec<u64>> {
-        let Some(max_epoch) = self
+    ) -> Result<Option<Vec<u64>>> {
+        let committed_epoch = self
             .env
             .hummock_snapshot_manager()
             .acquire()
@@ -1345,28 +1346,31 @@ impl SessionImpl {
             .info()
             .get(&table_id)
             .map(|s| s.committed_epoch)
-        else {
-            return Ok(vec![]);
-        };
+            .ok_or_else(|| anyhow!("table id {table_id} has been dropped"))?;
+        if min_epoch > committed_epoch {
+            return Ok(None);
+        }
         let ret = self
             .env
             .meta_client_ref()
             .get_hummock_table_change_log(
                 Some(min_epoch),
-                Some(max_epoch),
+                Some(committed_epoch),
                 Some(iter::once(table_id).collect()),
                 true,
                 Some(max_count),
             )
             .await?;
         let Some(e) = ret.get(&table_id) else {
-            return Ok(vec![]);
+            return Ok(Some(vec![]));
         };
-        Ok(e.iter()
-            .flat_map(|l| l.epochs())
-            .filter(|e| *e >= min_epoch && *e <= max_epoch)
-            .take(max_count as usize)
-            .collect())
+        Ok(Some(
+            e.iter()
+                .flat_map(|l| l.epochs())
+                .filter(|e| *e >= min_epoch && *e <= committed_epoch)
+                .take(max_count as usize)
+                .collect(),
+        ))
     }
 
     pub fn clear_cancel_query_flag(&self) {

--- a/src/frontend/src/session/cursor_manager.rs
+++ b/src/frontend/src/session/cursor_manager.rs
@@ -757,9 +757,12 @@ impl SubscriptionCursor {
         )?;
 
         // The epoch here must be pulled every time, otherwise there will be cache consistency issues
-        let new_epochs = session
+        let Some(new_epochs) = session
             .list_change_log_epochs(table_id, seek_timestamp, 2)
-            .await?;
+            .await?
+        else {
+            return Ok((None, None));
+        };
         if let Some(expected_timestamp) = expected_timestamp
             && (new_epochs.is_empty() || &expected_timestamp != new_epochs.first().unwrap())
         {

--- a/src/meta/service/src/hummock_service.rs
+++ b/src/meta/service/src/hummock_service.rs
@@ -708,7 +708,7 @@ impl HummockManagerService for HummockServiceImpl {
                 exclude_empty,
                 limit,
             )
-            .await
+            .await?
             .into_iter()
             .map(|(i, l)| (i.as_raw_id(), l.to_protobuf()))
             .collect();

--- a/src/meta/src/hummock/error.rs
+++ b/src/meta/src/hummock/error.rs
@@ -47,6 +47,8 @@ pub enum Error {
     InvalidSst(HummockSstableObjectId),
     #[error("invalid manual compaction option: {0}")]
     InvalidManualCompactionOption(String),
+    #[error("invalid epoch range: {start_epoch}..={end_epoch}")]
+    InvalidEpochRange { start_epoch: u64, end_epoch: u64 },
     #[error("time-travel version expired: table {table_id}, epoch {epoch}")]
     TimeTravelVersionExpired { table_id: TableId, epoch: u64 },
     #[error("time travel")]
@@ -84,7 +86,9 @@ impl From<sea_orm::DbErr> for Error {
 impl From<Error> for tonic::Status {
     fn from(err: Error) -> Self {
         let code = match &err {
-            Error::InvalidManualCompactionOption(_) => tonic::Code::InvalidArgument,
+            Error::InvalidManualCompactionOption(_) | Error::InvalidEpochRange { .. } => {
+                tonic::Code::InvalidArgument
+            }
             Error::TimeTravelVersionExpired { .. } => tonic::Code::OutOfRange,
             _ => tonic::Code::Internal,
         };

--- a/src/meta/src/hummock/manager/tests.rs
+++ b/src/meta/src/hummock/manager/tests.rs
@@ -26,6 +26,7 @@ use prometheus::proto::MetricFamily;
 use risingwave_common::catalog::TableId;
 use risingwave_common::hash::VirtualNode;
 use risingwave_common::util::epoch::{EpochExt, test_epoch};
+use risingwave_hummock_sdk::change_log::{EpochNewChangeLog, TableChangeLog};
 use risingwave_hummock_sdk::compact::compact_task_to_string;
 use risingwave_hummock_sdk::compact_task::CompactTask;
 use risingwave_hummock_sdk::compaction_group::StaticCompactionGroupId;
@@ -140,6 +141,54 @@ fn gen_local_sstable_info(sst_id: u64, table_ids: Vec<u32>, epoch: u64) -> Local
         table_stats: Default::default(),
         created_at: u64::MAX,
     }
+}
+
+#[tokio::test]
+async fn test_get_table_change_logs_with_inverted_epoch_range() {
+    let (_env, hummock_manager, _, _) = setup_compute_env(80).await;
+    let table_id = TableId::new(1);
+    hummock_manager
+        .versioning
+        .write()
+        .await
+        .table_change_log
+        .insert(
+            table_id,
+            TableChangeLog::new([
+                EpochNewChangeLog {
+                    new_value: vec![],
+                    old_value: vec![],
+                    non_checkpoint_epochs: vec![3],
+                    checkpoint_epoch: 4,
+                },
+                EpochNewChangeLog {
+                    new_value: vec![],
+                    old_value: vec![],
+                    non_checkpoint_epochs: vec![],
+                    checkpoint_epoch: 6,
+                },
+            ]),
+        );
+
+    let error = hummock_manager
+        .get_table_change_logs(
+            true,
+            Some(7),
+            Some(5),
+            Some(HashSet::from([table_id])),
+            false,
+            None,
+        )
+        .await
+        .unwrap_err();
+
+    assert!(matches!(
+        error,
+        Error::InvalidEpochRange {
+            start_epoch: 7,
+            end_epoch: 5
+        }
+    ));
 }
 fn get_compaction_group_object_ids(
     version: &HummockVersion,

--- a/src/meta/src/hummock/manager/versioning.rs
+++ b/src/meta/src/hummock/manager/versioning.rs
@@ -43,7 +43,7 @@ use sea_orm::{EntityTrait, QuerySelect, TransactionTrait};
 use super::GroupStateValidator;
 use crate::MetaResult;
 use crate::hummock::HummockManager;
-use crate::hummock::error::Result;
+use crate::hummock::error::{Error, Result};
 use crate::hummock::manager::checkpoint::HummockVersionCheckpoint;
 use crate::hummock::manager::commit_multi_var;
 use crate::hummock::manager::context::ContextInfo;
@@ -387,49 +387,58 @@ impl HummockManager {
         table_ids: Option<HashSet<TableId>>,
         exclude_empty: bool,
         limit: Option<u32>,
-    ) -> TableChangeLogs {
+    ) -> Result<TableChangeLogs> {
         let _timer = self.metrics.table_change_log_get_latency.start_timer();
-        self.on_current_version_and_table_change_log(|_, table_change_logs| {
-            table_change_logs
-                .iter()
-                .filter_map(|(id, change_log)| {
-                    if let Some(table_filter) = &table_ids
-                        && !table_filter.contains(id)
-                    {
-                        return None;
-                    }
-                    let filtered_change_logs = change_log
-                        .filter_epoch((
-                            start_epoch_inclusive.unwrap_or(0),
-                            end_epoch_inclusive.unwrap_or(u64::MAX),
-                        ))
-                        .filter(|change_log| {
-                            if exclude_empty
-                                && change_log.new_value.is_empty()
-                                && change_log.old_value.is_empty()
-                            {
-                                return false;
-                            }
-                            true
-                        })
-                        .take(limit.map(|l| l as usize).unwrap_or(usize::MAX))
-                        .map(|change_log| {
-                            if epoch_only {
-                                EpochNewChangeLog {
-                                    new_value: vec![],
-                                    old_value: vec![],
-                                    non_checkpoint_epochs: change_log.non_checkpoint_epochs.clone(),
-                                    checkpoint_epoch: change_log.checkpoint_epoch,
+        let start_epoch = start_epoch_inclusive.unwrap_or(0);
+        let end_epoch = end_epoch_inclusive.unwrap_or(u64::MAX);
+        if start_epoch > end_epoch {
+            return Err(Error::InvalidEpochRange {
+                start_epoch,
+                end_epoch,
+            });
+        }
+        let table_change_logs = self
+            .on_current_version_and_table_change_log(|_, table_change_logs| {
+                table_change_logs
+                    .iter()
+                    .filter_map(|(id, change_log)| {
+                        if let Some(table_filter) = &table_ids
+                            && !table_filter.contains(id)
+                        {
+                            return None;
+                        }
+                        let filtered_change_logs = change_log
+                            .filter_epoch((start_epoch, end_epoch))
+                            .filter(|change_log| {
+                                if exclude_empty
+                                    && change_log.new_value.is_empty()
+                                    && change_log.old_value.is_empty()
+                                {
+                                    return false;
                                 }
-                            } else {
-                                change_log.clone()
-                            }
-                        });
-                    Some((id.to_owned(), TableChangeLog::new(filtered_change_logs)))
-                })
-                .collect()
-        })
-        .await
+                                true
+                            })
+                            .take(limit.map(|l| l as usize).unwrap_or(usize::MAX))
+                            .map(|change_log| {
+                                if epoch_only {
+                                    EpochNewChangeLog {
+                                        new_value: vec![],
+                                        old_value: vec![],
+                                        non_checkpoint_epochs: change_log
+                                            .non_checkpoint_epochs
+                                            .clone(),
+                                        checkpoint_epoch: change_log.checkpoint_epoch,
+                                    }
+                                } else {
+                                    change_log.clone()
+                                }
+                            });
+                        Some((id.to_owned(), TableChangeLog::new(filtered_change_logs)))
+                    })
+                    .collect()
+            })
+            .await;
+        Ok(table_change_logs)
     }
 }
 

--- a/src/meta/src/hummock/mock_hummock_meta_client.rs
+++ b/src/meta/src/hummock/mock_hummock_meta_client.rs
@@ -402,8 +402,7 @@ impl HummockMetaClient for MockHummockMetaClient {
         exclude_empty: bool,
         limit: Option<u32>,
     ) -> Result<TableChangeLogs> {
-        Ok(self
-            .hummock_manager
+        self.hummock_manager
             .get_table_change_logs(
                 epoch_only,
                 start_epoch_inclusive,
@@ -412,7 +411,8 @@ impl HummockMetaClient for MockHummockMetaClient {
                 exclude_empty,
                 limit,
             )
-            .await)
+            .await
+            .map_err(mock_err)
     }
 }
 

--- a/src/storage/hummock_sdk/src/change_log.rs
+++ b/src/storage/hummock_sdk/src/change_log.rs
@@ -212,6 +212,10 @@ impl<T> TableChangeLogCommon<T> {
         &self,
         (min_epoch, max_epoch): (u64, u64),
     ) -> impl Iterator<Item = &EpochNewChangeLogCommon<T>> + '_ {
+        assert!(
+            min_epoch <= max_epoch,
+            "invalid epoch range: {min_epoch}..={max_epoch}"
+        );
         let start = self
             .0
             .partition_point(|epoch_change_log| epoch_change_log.checkpoint_epoch < min_epoch);


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

Root cause: after a subscription cursor finishes reading committed epoch `E`, it advances
its seek epoch to `E + 1`. If the table's committed epoch has not bumped and is still
`E`, `list_change_log_epochs` previously sent a table change log request with
`min_epoch = E + 1` and `max_epoch = E`. This inverted range could make
`TableChangeLogCommon::filter_epoch` compute a start index greater than its end index
and panic while slicing the retained `VecDeque`.

- Prevent subscription cursors from requesting table change logs when the table's committed epoch has not reached the cursor's seek epoch.
- Make `list_change_log_epochs` distinguish this not-yet-committed state from an empty change log, while returning an error when the table has been dropped.
- Reject any remaining inverted table change log epoch ranges in the Hummock manager and expose them as gRPC `INVALID_ARGUMENT`.
- Keep `TableChangeLogCommon::filter_epoch`'s epoch ordering invariant explicit.
- Add a regression test covering the retained-log range that previously panicked in `VecDeque::range`.

- Closes #26475

## Checklist

- [x] I have written necessary rustdoc comments.
- [x] I have added necessary unit tests and integration tests.
- [x] I have added test labels as necessary.
- [ ] I have added fuzzing tests or opened an issue to track them.
- [ ] My PR contains breaking changes.
- [ ] My PR changes performance-critical code, so I will run (micro) benchmarks and present the results.
- [ ] I have checked the Release Timeline and Currently Supported Versions to determine which release branches I need to cherry-pick this PR into.

## Documentation

- [ ] My PR needs documentation updates.

<details>
<summary><b>Release note</b></summary>

Fixed a meta-node crash that could occur while fetching from a subscription cursor when its requested epoch was ahead of the table's current committed epoch or had fallen outside the retained change log. The cursor now waits for a newer committed epoch instead of sending an invalid change-log request.

</details>
