### PR TITLE
fix(storage): enforce scan range in forward SST iterator

### DIFF
--- a/src/storage/benches/bench_compactor.rs
+++ b/src/storage/benches/bench_compactor.rs
@@ -354,9 +354,8 @@ fn bench_merge_iterator_compactor(c: &mut Criterion) {
     let level2 = vec![info1, info2];
     let read_options = Arc::new(SstableIteratorReadOptions {
         cache_policy: CachePolicy::Fill(Hint::Normal),
-        prefetch_for_large_query: false,
         scan_end_user_key: None,
-        must_iterated_end_user_key: None,
+        prefetch: false,
         max_preload_retry_times: 0,
     });
     c.bench_function("bench_union_merge_iterator", |b| {

--- a/src/storage/benches/bench_compactor.rs
+++ b/src/storage/benches/bench_compactor.rs
@@ -355,6 +355,7 @@ fn bench_merge_iterator_compactor(c: &mut Criterion) {
     let read_options = Arc::new(SstableIteratorReadOptions {
         cache_policy: CachePolicy::Fill(Hint::Normal),
         prefetch_for_large_query: false,
+        scan_end_user_key: None,
         must_iterated_end_user_key: None,
         max_preload_retry_times: 0,
     });

--- a/src/storage/src/hummock/sstable/forward_sstable_iterator.rs
+++ b/src/storage/src/hummock/sstable/forward_sstable_iterator.rs
@@ -54,7 +54,9 @@ pub struct SstableIterator {
     stats: StoreLocalStatistic,
     options: Arc<SstableIteratorReadOptions>,
 
-    // used for checking if the block is valid, filter out the block that is not in the table-id range
+    // The readable block window is first restricted by table IDs and then by `scan_end_user_key`.
+    // Included/Excluded bounds set its exclusive block end; outer iterators still filter keys
+    // precisely inside the boundary block.
     block_start_idx_inclusive: usize,
     block_end_idx_exclusive: usize,
 }
@@ -178,40 +180,13 @@ impl SstableIterator {
         );
 
         self.preload_end_block_idx = 0;
-        if let Some(bound) = self.options.must_iterated_end_user_key.as_ref() {
-            let block_metas = &self.sst.meta.block_metas
-                [self.block_start_idx_inclusive..self.block_end_idx_exclusive];
-            let next_to_start_idx = start_idx + 1;
-            if next_to_start_idx < self.block_end_idx_exclusive {
-                let end_idx = match bound {
-                    Unbounded => self.block_end_idx_exclusive,
-                    Included(dest_key) => {
-                        let dest_key = dest_key.as_ref();
-                        self.block_start_idx_inclusive
-                            + block_metas.partition_point(|block_meta| {
-                                FullKey::decode(&block_meta.smallest_key).user_key <= dest_key
-                            })
-                    }
-                    Excluded(end_key) => {
-                        let end_key = end_key.as_ref();
-                        self.block_start_idx_inclusive
-                            + block_metas.partition_point(|block_meta| {
-                                FullKey::decode(&block_meta.smallest_key).user_key < end_key
-                            })
-                    }
-                };
+        if !self.options.prefetch {
+            return;
+        }
 
-                if next_to_start_idx < end_idx {
-                    assert!(
-                        end_idx <= self.block_end_idx_exclusive,
-                        "end_idx {} > block_end_idx_exclusive {} next_to_start_idx {}",
-                        end_idx,
-                        self.block_end_idx_exclusive,
-                        next_to_start_idx
-                    );
-                    self.preload_end_block_idx = end_idx;
-                }
-            }
+        // Prefetch never extends beyond the block window already clipped by the scan hard bound.
+        if start_idx + 1 < self.block_end_idx_exclusive {
+            self.preload_end_block_idx = self.block_end_idx_exclusive;
         }
     }
 
@@ -615,10 +590,9 @@ mod tests {
         );
         let options = Arc::new(SstableIteratorReadOptions {
             cache_policy: CachePolicy::Fill(Hint::Normal),
-            scan_end_user_key: None,
-            must_iterated_end_user_key: Some(Bound::Included(uk.clone())),
+            scan_end_user_key: Some(Bound::Included(uk.clone())),
+            prefetch: true,
             max_preload_retry_times: 0,
-            prefetch_for_large_query: false,
         });
         let mut stats = StoreLocalStatistic::default();
         let mut sstable_iter = SstableIterator::create(
@@ -664,7 +638,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_scan_end_and_prefetch_end_are_independent() {
+    async fn test_scan_end_with_prefetch_on_or_off() {
         let sstable_store = mock_sstable_store().await;
         let mut builder_options = default_builder_opt_for_test();
         builder_options.block_capacity = 128;
@@ -713,21 +687,12 @@ mod tests {
         assert!(table_2_block_start + 2 < table_3_block_start);
 
         let table_3_start = UserKey::new(TableId::new(3), TableKey(Bytes::from_static(b"")));
-        let short_prefetch_end: UserKey<Bytes> =
-            FullKey::decode(&sstable.meta.block_metas[table_2_block_start + 2].smallest_key)
-                .user_key
-                .copy_into();
-        for (case, prefetch_end_user_key) in [
-            ("no prefetch", None),
-            ("prefetch to scan end", Some(table_3_start.clone())),
-            ("prefetch shorter than scan", Some(short_prefetch_end)),
-        ] {
+        for (case, prefetch) in [("prefetch off", false), ("prefetch on", true)] {
             let options = Arc::new(SstableIteratorReadOptions {
                 cache_policy: CachePolicy::Disable,
                 scan_end_user_key: Some(Bound::Excluded(table_3_start.clone())),
-                must_iterated_end_user_key: prefetch_end_user_key.map(Bound::Excluded),
+                prefetch,
                 max_preload_retry_times: 0,
-                prefetch_for_large_query: false,
             });
             let mut sstable_iter = SstableIterator::create(
                 sstable.clone(),
@@ -738,6 +703,14 @@ mod tests {
 
             assert_eq!(sstable_iter.block_end_idx_exclusive, table_3_block_start);
             sstable_iter.seek(test_key(2, 0).to_ref()).await.unwrap();
+            if prefetch {
+                assert_eq!(
+                    sstable_iter.preload_end_block_idx, sstable_iter.block_end_idx_exclusive,
+                    "{case}"
+                );
+            } else {
+                assert_eq!(sstable_iter.preload_end_block_idx, 0, "{case}");
+            }
             let mut key_count = 0;
             while sstable_iter.is_valid() {
                 assert_eq!(
@@ -757,13 +730,10 @@ mod tests {
                 (table_3_block_start - table_2_block_start) as u64,
                 "{case}"
             );
-            match case {
-                "no prefetch" => assert_eq!(stats.cache_data_prefetch_block_count, 0),
-                "prefetch shorter than scan" => {
-                    assert!(stats.cache_data_prefetch_block_count > 0);
-                    assert!(stats.cache_data_block_total > 0);
-                }
-                _ => {}
+            if prefetch {
+                assert!(stats.cache_data_prefetch_block_count > 0, "{case}");
+            } else {
+                assert_eq!(stats.cache_data_prefetch_block_count, 0, "{case}");
             }
         }
 
@@ -777,9 +747,8 @@ mod tests {
         let options = Arc::new(SstableIteratorReadOptions {
             cache_policy: CachePolicy::Disable,
             scan_end_user_key: Some(Bound::Excluded(table_2_start)),
-            must_iterated_end_user_key: None,
+            prefetch: false,
             max_preload_retry_times: 0,
-            prefetch_for_large_query: false,
         });
         let mut sstable_iter =
             SstableIterator::create(sstable, sstable_store, options, &table_2_sstable_info);

--- a/src/storage/src/hummock/sstable/forward_sstable_iterator.rs
+++ b/src/storage/src/hummock/sstable/forward_sstable_iterator.rs
@@ -56,7 +56,7 @@ pub struct SstableIterator {
 
     // used for checking if the block is valid, filter out the block that is not in the table-id range
     block_start_idx_inclusive: usize,
-    block_end_idx_inclusive: usize,
+    block_end_idx_exclusive: usize,
 }
 
 impl SstableIterator {
@@ -67,7 +67,7 @@ impl SstableIterator {
         sstable_info_ref: &SstableInfo,
     ) -> Self {
         let mut block_start_idx_inclusive = 0;
-        let mut block_end_idx_inclusive = sstable.meta.block_metas.len() - 1;
+        let mut block_end_idx_exclusive = sstable.meta.block_metas.len();
         assert!(
             !sstable_info_ref.table_ids.is_empty(),
             "SstableIterator: SST {} (object {}) has empty table_ids",
@@ -128,18 +128,34 @@ impl SstableIterator {
                 .collect::<Vec<_>>()
         );
 
-        while block_end_idx_inclusive > block_start_idx_inclusive
-            && sstable.meta.block_metas[block_end_idx_inclusive].table_id() > read_table_id_range.1
+        while block_end_idx_exclusive > block_start_idx_inclusive
+            && sstable.meta.block_metas[block_end_idx_exclusive - 1].table_id()
+                > read_table_id_range.1
         {
-            block_end_idx_inclusive -= 1;
+            block_end_idx_exclusive -= 1;
         }
         assert!(
-            block_end_idx_inclusive >= block_start_idx_inclusive,
-            "block_end_idx_inclusive {} < block_start_idx_inclusive {} block_meta_count {}",
-            block_end_idx_inclusive,
+            block_end_idx_exclusive > block_start_idx_inclusive,
+            "block_end_idx_exclusive {} <= block_start_idx_inclusive {} block_meta_count {}",
+            block_end_idx_exclusive,
             block_start_idx_inclusive,
             block_meta_count
         );
+
+        if let Some(end_bound) = options.scan_end_user_key.as_ref() {
+            let block_metas =
+                &sstable.meta.block_metas[block_start_idx_inclusive..block_end_idx_exclusive];
+            let range_end_idx_exclusive = match end_bound {
+                Unbounded => block_metas.len(),
+                Included(end_key) => block_metas.partition_point(|block_meta| {
+                    FullKey::decode(&block_meta.smallest_key).user_key <= end_key.as_ref()
+                }),
+                Excluded(end_key) => block_metas.partition_point(|block_meta| {
+                    FullKey::decode(&block_meta.smallest_key).user_key < end_key.as_ref()
+                }),
+            };
+            block_end_idx_exclusive = block_start_idx_inclusive + range_end_idx_exclusive;
+        }
 
         Self {
             block_iter: None,
@@ -152,24 +168,23 @@ impl SstableIterator {
             preload_end_block_idx: 0,
             preload_retry_times: 0,
             block_start_idx_inclusive,
-            block_end_idx_inclusive,
+            block_end_idx_exclusive,
         }
     }
 
     fn init_block_prefetch_range(&mut self, start_idx: usize) {
         assert!(
-            start_idx >= self.block_start_idx_inclusive
-                && start_idx <= self.block_end_idx_inclusive
+            start_idx >= self.block_start_idx_inclusive && start_idx < self.block_end_idx_exclusive
         );
 
         self.preload_end_block_idx = 0;
         if let Some(bound) = self.options.must_iterated_end_user_key.as_ref() {
             let block_metas = &self.sst.meta.block_metas
-                [self.block_start_idx_inclusive..=self.block_end_idx_inclusive];
+                [self.block_start_idx_inclusive..self.block_end_idx_exclusive];
             let next_to_start_idx = start_idx + 1;
-            if next_to_start_idx <= self.block_end_idx_inclusive {
+            if next_to_start_idx < self.block_end_idx_exclusive {
                 let end_idx = match bound {
-                    Unbounded => self.block_end_idx_inclusive + 1,
+                    Unbounded => self.block_end_idx_exclusive,
                     Included(dest_key) => {
                         let dest_key = dest_key.as_ref();
                         self.block_start_idx_inclusive
@@ -186,13 +201,12 @@ impl SstableIterator {
                     }
                 };
 
-                // `preload_end_block_idx` is exclusive
                 if next_to_start_idx < end_idx {
                     assert!(
-                        end_idx <= self.block_end_idx_inclusive + 1,
-                        "end_idx {} > block_end_idx_inclusive {} next_to_start_idx {}",
+                        end_idx <= self.block_end_idx_exclusive,
+                        "end_idx {} > block_end_idx_exclusive {} next_to_start_idx {}",
                         end_idx,
-                        self.block_end_idx_inclusive,
+                        self.block_end_idx_exclusive,
                         next_to_start_idx
                     );
                     self.preload_end_block_idx = end_idx;
@@ -220,7 +234,7 @@ impl SstableIterator {
         tokio::task::consume_budget().await;
 
         let mut hit_cache = false;
-        if idx > self.block_end_idx_inclusive {
+        if idx >= self.block_end_idx_exclusive {
             self.block_iter = None;
             return Ok(());
         }
@@ -332,7 +346,7 @@ impl SstableIterator {
     fn calculate_block_idx_by_key(&self, key: FullKey<&[u8]>) -> usize {
         self.block_start_idx_inclusive
             + self.sst.meta.block_metas
-                [self.block_start_idx_inclusive..=self.block_end_idx_inclusive]
+                [self.block_start_idx_inclusive..self.block_end_idx_exclusive]
                 .partition_point(|block_meta| {
                     // compare by version comparator
                     // Note: we are comparing against the `smallest_key` of the `block`, thus the
@@ -372,6 +386,10 @@ impl HummockIterator for SstableIterator {
     }
 
     async fn rewind(&mut self) -> HummockResult<()> {
+        if self.block_start_idx_inclusive >= self.block_end_idx_exclusive {
+            self.block_iter = None;
+            return Ok(());
+        }
         self.init_block_prefetch_range(self.block_start_idx_inclusive);
         // seek_idx will update the current block iter state
         self.seek_idx(self.block_start_idx_inclusive, None).await?;
@@ -379,6 +397,10 @@ impl HummockIterator for SstableIterator {
     }
 
     async fn seek<'a>(&'a mut self, key: FullKey<&'a [u8]>) -> HummockResult<()> {
+        if self.block_start_idx_inclusive >= self.block_end_idx_exclusive {
+            self.block_iter = None;
+            return Ok(());
+        }
         let block_idx = self.calculate_block_idx_by_key(key);
         self.init_block_prefetch_range(block_idx);
 
@@ -593,6 +615,7 @@ mod tests {
         );
         let options = Arc::new(SstableIteratorReadOptions {
             cache_policy: CachePolicy::Fill(Hint::Normal),
+            scan_end_user_key: None,
             must_iterated_end_user_key: Some(Bound::Included(uk.clone())),
             max_preload_retry_times: 0,
             prefetch_for_large_query: false,
@@ -638,6 +661,139 @@ mod tests {
             sstable_iter.next().await.unwrap();
         }
         assert_eq!(cnt, TEST_KEYS_COUNT);
+    }
+
+    #[tokio::test]
+    async fn test_scan_end_and_prefetch_end_are_independent() {
+        let sstable_store = mock_sstable_store().await;
+        let mut builder_options = default_builder_opt_for_test();
+        builder_options.block_capacity = 128;
+
+        let test_user_key = |table_id, idx| {
+            UserKey::new(
+                TableId::new(table_id),
+                TableKey(Bytes::from(
+                    [
+                        VirtualNode::ZERO.to_be_bytes().as_slice(),
+                        format!("key_{idx:05}").as_bytes(),
+                    ]
+                    .concat(),
+                )),
+            )
+        };
+        let test_key = |table_id, idx| FullKey {
+            user_key: test_user_key(table_id, idx),
+            epoch_with_gap: EpochWithGap::new_from_epoch(test_epoch(1)),
+        };
+        let kv_pairs = (1..=3).flat_map(|table_id| {
+            (0..8).map(move |idx| {
+                (
+                    test_key(table_id, idx),
+                    HummockValue::put(Bytes::from(test_value_of(idx))),
+                )
+            })
+        });
+        let (sstable, sstable_info) = gen_test_sstable_with_table_ids(
+            builder_options,
+            10,
+            kv_pairs,
+            sstable_store.clone(),
+            vec![1, 2, 3],
+        )
+        .await;
+
+        let table_2_block_start = sstable
+            .meta
+            .block_metas
+            .partition_point(|block_meta| block_meta.table_id() < TableId::new(2));
+        let table_3_block_start = sstable
+            .meta
+            .block_metas
+            .partition_point(|block_meta| block_meta.table_id() < TableId::new(3));
+        assert!(table_2_block_start + 2 < table_3_block_start);
+
+        let table_3_start = UserKey::new(TableId::new(3), TableKey(Bytes::from_static(b"")));
+        let short_prefetch_end: UserKey<Bytes> =
+            FullKey::decode(&sstable.meta.block_metas[table_2_block_start + 2].smallest_key)
+                .user_key
+                .copy_into();
+        for (case, prefetch_end_user_key) in [
+            ("no prefetch", None),
+            ("prefetch to scan end", Some(table_3_start.clone())),
+            ("prefetch shorter than scan", Some(short_prefetch_end)),
+        ] {
+            let options = Arc::new(SstableIteratorReadOptions {
+                cache_policy: CachePolicy::Disable,
+                scan_end_user_key: Some(Bound::Excluded(table_3_start.clone())),
+                must_iterated_end_user_key: prefetch_end_user_key.map(Bound::Excluded),
+                max_preload_retry_times: 0,
+                prefetch_for_large_query: false,
+            });
+            let mut sstable_iter = SstableIterator::create(
+                sstable.clone(),
+                sstable_store.clone(),
+                options,
+                &sstable_info,
+            );
+
+            assert_eq!(sstable_iter.block_end_idx_exclusive, table_3_block_start);
+            sstable_iter.seek(test_key(2, 0).to_ref()).await.unwrap();
+            let mut key_count = 0;
+            while sstable_iter.is_valid() {
+                assert_eq!(
+                    sstable_iter.key().user_key.table_id,
+                    TableId::new(2),
+                    "{case}"
+                );
+                key_count += 1;
+                sstable_iter.next().await.unwrap();
+            }
+            assert_eq!(key_count, 8, "{case}");
+
+            let mut stats = StoreLocalStatistic::default();
+            sstable_iter.collect_local_statistic(&mut stats);
+            assert_eq!(
+                stats.cache_data_block_total + stats.cache_data_prefetch_block_count,
+                (table_3_block_start - table_2_block_start) as u64,
+                "{case}"
+            );
+            match case {
+                "no prefetch" => assert_eq!(stats.cache_data_prefetch_block_count, 0),
+                "prefetch shorter than scan" => {
+                    assert!(stats.cache_data_prefetch_block_count > 0);
+                    assert!(stats.cache_data_block_total > 0);
+                }
+                _ => {}
+            }
+        }
+
+        let mut table_2_sstable_info = sstable_info.get_inner();
+        table_2_sstable_info.table_ids = vec![TableId::new(2)];
+        let table_2_sstable_info = SstableInfo::from(table_2_sstable_info);
+        let table_2_start: UserKey<Bytes> =
+            FullKey::decode(&sstable.meta.block_metas[table_2_block_start].smallest_key)
+                .user_key
+                .copy_into();
+        let options = Arc::new(SstableIteratorReadOptions {
+            cache_policy: CachePolicy::Disable,
+            scan_end_user_key: Some(Bound::Excluded(table_2_start)),
+            must_iterated_end_user_key: None,
+            max_preload_retry_times: 0,
+            prefetch_for_large_query: false,
+        });
+        let mut sstable_iter =
+            SstableIterator::create(sstable, sstable_store, options, &table_2_sstable_info);
+
+        assert_eq!(
+            sstable_iter.block_start_idx_inclusive,
+            sstable_iter.block_end_idx_exclusive
+        );
+        sstable_iter.seek(test_key(2, 0).to_ref()).await.unwrap();
+        assert!(!sstable_iter.is_valid());
+        let mut stats = StoreLocalStatistic::default();
+        sstable_iter.collect_local_statistic(&mut stats);
+        assert_eq!(stats.cache_data_block_total, 0);
+        assert_eq!(stats.cache_data_prefetch_block_count, 0);
     }
 
     #[tokio::test]

--- a/src/storage/src/hummock/sstable/mod.rs
+++ b/src/storage/src/hummock/sstable/mod.rs
@@ -512,20 +512,22 @@ impl SstableMeta {
 #[derive(Default)]
 pub struct SstableIteratorReadOptions {
     pub cache_policy: CachePolicy,
+    /// The only hard upper bound of this scan. It limits the iterator's block window.
     pub scan_end_user_key: Option<Bound<UserKey<KeyPayloadType>>>,
-    pub must_iterated_end_user_key: Option<Bound<UserKey<KeyPayloadType>>>,
+    /// Whether to prefetch blocks within the already-bounded scan window.
+    pub prefetch: bool,
     pub max_preload_retry_times: usize,
-    pub prefetch_for_large_query: bool,
 }
 
 impl SstableIteratorReadOptions {
+    /// Builds options with prefetch disabled. Range scans enable it explicitly after setting the
+    /// scan bound, while point gets retain the default to avoid creating a prefetch stream.
     pub fn from_read_options(read_options: &ReadOptions) -> Self {
         Self {
             cache_policy: read_options.cache_policy,
             scan_end_user_key: None,
-            must_iterated_end_user_key: None,
+            prefetch: false,
             max_preload_retry_times: 0,
-            prefetch_for_large_query: read_options.prefetch_options.for_large_query,
         }
     }
 }
@@ -538,6 +540,19 @@ mod tests {
         default_builder_opt_for_test, iterator_test_key_of,
     };
     use crate::hummock::test_utils::gen_test_sstable_data;
+    use crate::store::PrefetchOptions;
+
+    #[test]
+    fn test_iterator_read_options_do_not_enable_prefetch_for_point_get() {
+        let read_options = ReadOptions {
+            prefetch_options: PrefetchOptions::prefetch_for_large_range_scan(),
+            ..Default::default()
+        };
+
+        let iterator_options = SstableIteratorReadOptions::from_read_options(&read_options);
+        assert!(!iterator_options.prefetch);
+        assert!(iterator_options.scan_end_user_key.is_none());
+    }
 
     #[test]
     fn test_sstable_meta_enc_dec() {

--- a/src/storage/src/hummock/sstable/mod.rs
+++ b/src/storage/src/hummock/sstable/mod.rs
@@ -512,6 +512,7 @@ impl SstableMeta {
 #[derive(Default)]
 pub struct SstableIteratorReadOptions {
     pub cache_policy: CachePolicy,
+    pub scan_end_user_key: Option<Bound<UserKey<KeyPayloadType>>>,
     pub must_iterated_end_user_key: Option<Bound<UserKey<KeyPayloadType>>>,
     pub max_preload_retry_times: usize,
     pub prefetch_for_large_query: bool,
@@ -521,6 +522,7 @@ impl SstableIteratorReadOptions {
     pub fn from_read_options(read_options: &ReadOptions) -> Self {
         Self {
             cache_policy: read_options.cache_policy,
+            scan_end_user_key: None,
             must_iterated_end_user_key: None,
             max_preload_retry_times: 0,
             prefetch_for_large_query: read_options.prefetch_options.for_large_query,

--- a/src/storage/src/hummock/store/version.rs
+++ b/src/storage/src/hummock/store/version.rs
@@ -1043,9 +1043,8 @@ impl HummockVersionReader {
             .map(|hint| Sstable::hash_for_filter(hint, table_id.as_raw_id()));
         let mut sst_read_options = SstableIteratorReadOptions::from_read_options(&read_options);
         sst_read_options.scan_end_user_key = Some(user_key_range.1.map(|key| key.cloned()));
-        if read_options.prefetch_options.prefetch {
-            sst_read_options.must_iterated_end_user_key =
-                sst_read_options.scan_end_user_key.clone();
+        sst_read_options.prefetch = read_options.prefetch_options.prefetch;
+        if sst_read_options.prefetch {
             sst_read_options.max_preload_retry_times = self.preload_retry_times;
         }
         let sst_read_options = Arc::new(sst_read_options);
@@ -1214,9 +1213,8 @@ impl HummockVersionReader {
         let read_options = Arc::new(SstableIteratorReadOptions {
             cache_policy: Default::default(),
             scan_end_user_key: None,
-            must_iterated_end_user_key: None,
+            prefetch: false,
             max_preload_retry_times: 0,
-            prefetch_for_large_query: false,
         });
 
         async fn make_iter(

--- a/src/storage/src/hummock/store/version.rs
+++ b/src/storage/src/hummock/store/version.rs
@@ -1042,9 +1042,10 @@ impl HummockVersionReader {
             .as_ref()
             .map(|hint| Sstable::hash_for_filter(hint, table_id.as_raw_id()));
         let mut sst_read_options = SstableIteratorReadOptions::from_read_options(&read_options);
+        sst_read_options.scan_end_user_key = Some(user_key_range.1.map(|key| key.cloned()));
         if read_options.prefetch_options.prefetch {
             sst_read_options.must_iterated_end_user_key =
-                Some(user_key_range.1.map(|key| key.cloned()));
+                sst_read_options.scan_end_user_key.clone();
             sst_read_options.max_preload_retry_times = self.preload_retry_times;
         }
         let sst_read_options = Arc::new(sst_read_options);
@@ -1212,6 +1213,7 @@ impl HummockVersionReader {
         }
         let read_options = Arc::new(SstableIteratorReadOptions {
             cache_policy: Default::default(),
+            scan_end_user_key: None,
             must_iterated_end_user_key: None,
             max_preload_retry_times: 0,
             prefetch_for_large_query: false,

--- a/src/storage/src/hummock/validator.rs
+++ b/src/storage/src/hummock/validator.rs
@@ -60,17 +60,14 @@ pub async fn validate_ssts(task: ValidationTask, sstable_store: SstableStoreRef)
             }
         };
 
-        // TODO: to use `prefetch: false` after `prefetch` be supported by
-        // SstableIteratorReadOptions
         let mut iter = SstableIterator::new(
             holder,
             sstable_store.clone(),
             Arc::new(SstableIteratorReadOptions {
                 cache_policy: CachePolicy::NotFill,
                 scan_end_user_key: None,
-                must_iterated_end_user_key: None,
+                prefetch: false,
                 max_preload_retry_times: 0,
-                prefetch_for_large_query: false,
             }),
             &sstable_info,
         );

--- a/src/storage/src/hummock/validator.rs
+++ b/src/storage/src/hummock/validator.rs
@@ -67,6 +67,7 @@ pub async fn validate_ssts(task: ValidationTask, sstable_store: SstableStoreRef)
             sstable_store.clone(),
             Arc::new(SstableIteratorReadOptions {
                 cache_policy: CachePolicy::NotFill,
+                scan_end_user_key: None,
                 must_iterated_end_user_key: None,
                 max_preload_retry_times: 0,
                 prefetch_for_large_query: false,

--- a/src/storage/src/store.rs
+++ b/src/storage/src/store.rs
@@ -453,13 +453,13 @@ pub trait StateStoreReadVector: StaticSendSync {
     ) -> impl StorageFuture<'a, Vec<O>>;
 }
 
-/// If `prefetch` is true, prefetch will be enabled. Prefetching may increase the memory
-/// footprint of the CN process because the prefetched blocks cannot be evicted.
-/// Since the streaming-read of object-storage may hung in some case, we still use sync short read
-/// for both batch-query and streaming process. So this configure is unused.
+/// Controls block-stream prefetch for range scans. Prefetching may increase the memory footprint
+/// of the CN process because the prefetched blocks cannot be evicted.
 #[derive(Default, Clone, Copy)]
 pub struct PrefetchOptions {
+    /// Enables prefetch for range-scan iterators. Point gets do not inherit this setting.
     pub prefetch: bool,
+    /// Caller and tracing classification for large queries. Leaf SST iterators do not consume it.
     pub for_large_query: bool,
 }
 


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

Forward SST iterators previously used the scan's user-key end bound only to limit
prefetch. After prefetch completed, `next` could fall back to a single-block
`get` using the SST's broader table-id block range. For a multi-table SST, this
fetched the first block of the following table before the outer iterator rejected
its key. On serving nodes with cache refill, that unrelated boundary block was
not part of the queried table's refill set and caused a persistent data-cache
miss for each new SST.

This PR:

- passes the logical user-key right end from `HummockVersionReader` to every
  forward SST iterator, independent of whether prefetch is enabled;
- computes one exclusive hard block end from block smallest keys when the
  iterator is created;
- rejects block indices at or beyond that end before both prefetch and fallback
  `get`;
- removes the independent prefetch end: `scan_end_user_key` is the only scan
  hard bound, while `prefetch` only controls preloading within that window;
- keeps point-get adapters with prefetch disabled, so point gets do not create
  a range-scan block stream.

The same `HummockVersionReader` path creates committed and uncommitted SST
children for serving and streaming reads, so both paths share the bound.

## Checklist

- [x] I have written necessary rustdoc comments.
- [x] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md#release) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

Serving and streaming Hummock scans no longer read the first data block outside
their user-key range, avoiding unrelated object-store reads and cache misses at
table boundaries.

</details>
