### PR TITLE
fix(stream): keep consuming on a no-op sink config update

### DIFF
--- a/src/stream/src/executor/sink.rs
+++ b/src/stream/src/executor/sink.rs
@@ -770,7 +770,8 @@ impl<F: LogStoreFactory> SinkExecutor<F> {
 
         log_reader.init().await?;
         loop {
-            let future = async {
+            // Boxed so that `drop` below releases its borrows on `log_reader` and `sink`.
+            let mut future = Box::pin(async {
                 loop {
                     let Err(e) = sink
                         .new_log_sinker(sink_writer_param.clone())
@@ -818,68 +819,67 @@ impl<F: LogStoreFactory> SinkExecutor<F> {
                     }
                     .map_err(|e| StreamExecutorError::from((e, sink_param.sink_id)))?;
                 }
-            };
-            select! {
-                result = future => {
-                    let Err(e): StreamExecutorResult<!> = result;
-                    return Err(e);
-                }
-                result = rebuild_sink_rx.recv() => {
-                    match result.ok_or_else(|| anyhow!("failed to receive rebuild sink notify"))? {
-                        RebuildSinkMessage::RebuildSink(new_vnode, notify) => {
-                            sink_writer_param.vnode_bitmap = Some((*new_vnode).clone());
-                            if notify.send(()).is_err() {
-                                warn!("failed to notify rebuild sink");
-                            }
-                            log_reader.init().await?;
-                        },
-                        RebuildSinkMessage::UpdateConfig(config) => {
-                            let config_has_changes =
-                                sink_config_has_changes(&sink_param.properties, &config);
-                            if F::ALLOW_REWIND {
-                                match log_reader.rewind().await {
-                                    Ok(()) => {
-                                        if config_has_changes {
-                                            sink_param.properties.extend(config.into_iter());
-                                            sink = TryFrom::try_from(sink_param.clone()).map_err(|e| StreamExecutorError::from((e, sink_param.sink_id)))?;
-                                            info!(
-                                                executor_id = %sink_writer_param.executor_id,
-                                                sink_id = %sink_param.sink_id,
-                                                "alter sink config successfully with rewind"
-                                            );
-                                        } else {
-                                            info!(
-                                                executor_id = %sink_writer_param.executor_id,
-                                                sink_id = %sink_param.sink_id,
-                                                "skip alter sink config because properties are unchanged"
-                                            );
-                                        }
-                                        Ok(())
-                                    }
-                                    Err(rewind_err) => {
-                                        error!(
-                                            error = %rewind_err.as_report(),
-                                            "fail to rewind log reader for alter sink config "
-                                        );
-                                        Err(anyhow!("fail to rewind log reader after alter sink config notification").into())
-                                    }
-                                }
-                            } else {
-                                if config_has_changes {
-                                    sink_param.properties.extend(config.into_iter());
-                                    sink = TryFrom::try_from(sink_param.clone()).map_err(|e| StreamExecutorError::from((e, sink_param.sink_id)))?;
-                                } else {
-                                    info!(
-                                        executor_id = %sink_writer_param.executor_id,
-                                        sink_id = %sink_param.sink_id,
-                                        "skip rebuilding sink because properties are unchanged"
-                                    );
-                                }
-                                Err(anyhow!("This is not an actual error condition. The system is intentionally triggering recovery procedures to ensure ALTER SINK CONFIG are fully applied.").into())
-                            }
-                            .map_err(|e| StreamExecutorError::from((e, sink_param.sink_id)))?;
-                        },
+            });
+            let message = loop {
+                select! {
+                    result = &mut future => {
+                        let Err(e): StreamExecutorResult<!> = result;
+                        return Err(e);
                     }
+                    result = rebuild_sink_rx.recv() => {
+                        let message = result.ok_or_else(|| anyhow!("failed to receive rebuild sink notify"))?;
+                        // Dropping the consumer costs a rewind, or a recovery when the log
+                        // reader cannot rewind. Not worth it for an update that changes nothing.
+                        if let RebuildSinkMessage::UpdateConfig(config) = &message
+                            && !sink_config_has_changes(&sink_param.properties, config)
+                        {
+                            info!(
+                                executor_id = %sink_writer_param.executor_id,
+                                sink_id = %sink_param.sink_id,
+                                "skip alter sink config because properties are unchanged"
+                            );
+                            continue;
+                        }
+                        break message;
+                    }
+                }
+            };
+            drop(future);
+            match message {
+                RebuildSinkMessage::RebuildSink(new_vnode, notify) => {
+                    sink_writer_param.vnode_bitmap = Some((*new_vnode).clone());
+                    if notify.send(()).is_err() {
+                        warn!("failed to notify rebuild sink");
+                    }
+                    log_reader.init().await?;
+                }
+                RebuildSinkMessage::UpdateConfig(config) => {
+                    if F::ALLOW_REWIND {
+                        match log_reader.rewind().await {
+                            Ok(()) => {
+                                sink_param.properties.extend(config);
+                                sink = TryFrom::try_from(sink_param.clone()).map_err(|e| StreamExecutorError::from((e, sink_param.sink_id)))?;
+                                info!(
+                                    executor_id = %sink_writer_param.executor_id,
+                                    sink_id = %sink_param.sink_id,
+                                    "alter sink config successfully with rewind"
+                                );
+                                Ok(())
+                            }
+                            Err(rewind_err) => {
+                                error!(
+                                    error = %rewind_err.as_report(),
+                                    "fail to rewind log reader for alter sink config "
+                                );
+                                Err(anyhow!("fail to rewind log reader after alter sink config notification").into())
+                            }
+                        }
+                    } else {
+                        sink_param.properties.extend(config);
+                        sink = TryFrom::try_from(sink_param.clone()).map_err(|e| StreamExecutorError::from((e, sink_param.sink_id)))?;
+                        Err(anyhow!("This is not an actual error condition. The system is intentionally triggering recovery procedures to ensure ALTER SINK CONFIG are fully applied.").into())
+                    }
+                    .map_err(|e| StreamExecutorError::from((e, sink_param.sink_id)))?;
                 }
             }
         }
@@ -1039,8 +1039,81 @@ mod test {
         ));
     }
 
+    fn no_op_config_update() -> RebuildSinkMessage {
+        RebuildSinkMessage::UpdateConfig(HashMap::from([(
+            "commit_checkpoint_interval".to_owned(),
+            "1".to_owned(),
+        )]))
+    }
+
+    fn changed_config_update() -> RebuildSinkMessage {
+        RebuildSinkMessage::UpdateConfig(HashMap::from([(
+            "commit_checkpoint_interval".to_owned(),
+            "2".to_owned(),
+        )]))
+    }
+
+    async fn assert_no_op_config_update_keeps_consuming<const CAN_REWIND: bool>() {
+        let sink_param = sink_param_for_config_update_test();
+        let sink = BlackHoleSink::try_from(sink_param.clone()).unwrap();
+        let state = Arc::new(RewindRequiredLogReaderState::default());
+        let log_reader = RewindRequiredLogReader {
+            is_reset: false,
+            state: state.clone(),
+        };
+        let (rate_limit_tx, rate_limit_rx) = unbounded_channel();
+        let (rebuild_sink_tx, rebuild_sink_rx) = unbounded_channel();
+
+        let consume_log = SinkExecutor::<TestLogStoreFactory<CAN_REWIND>>::execute_consume_log(
+            sink,
+            log_reader,
+            vec![],
+            sink_param,
+            SinkWriterParam::for_test(),
+            None,
+            ActorContext::for_test(0),
+            rate_limit_rx,
+            rebuild_sink_rx,
+        );
+        tokio::pin!(consume_log);
+
+        tokio::select! {
+            result = &mut consume_log => panic!("log consumer exited unexpectedly: {result:?}"),
+            () = state.wait_for_start_count(1) => {},
+        }
+
+        rebuild_sink_tx.send(no_op_config_update()).unwrap();
+
+        // Messages are handled in order, so an acknowledged rebuild proves the consumer survived
+        // the no-op update.
+        let (notify_tx, notify_rx) = oneshot::channel();
+        rebuild_sink_tx
+            .send(RebuildSinkMessage::RebuildSink(
+                Arc::new(Bitmap::ones(1)),
+                notify_tx,
+            ))
+            .unwrap();
+        tokio::select! {
+            result = &mut consume_log => panic!("log consumer exited unexpectedly: {result:?}"),
+            result = notify_rx => result.expect("rebuild sink should be acknowledged"),
+        }
+
+        assert_eq!(state.rewind_count.load(Ordering::SeqCst), 0);
+        drop(rate_limit_tx);
+    }
+
     #[tokio::test]
-    async fn test_no_op_sink_config_update_rewinds_log_reader() {
+    async fn test_no_op_sink_config_update_keeps_consuming_with_rewind() {
+        assert_no_op_config_update_keeps_consuming::<true>().await;
+    }
+
+    #[tokio::test]
+    async fn test_no_op_sink_config_update_keeps_consuming_without_rewind() {
+        assert_no_op_config_update_keeps_consuming::<false>().await;
+    }
+
+    #[tokio::test]
+    async fn test_sink_config_update_rewinds_log_reader() {
         let sink_param = sink_param_for_config_update_test();
         let sink = BlackHoleSink::try_from(sink_param.clone()).unwrap();
         let state = Arc::new(RewindRequiredLogReaderState::default());
@@ -1069,12 +1142,7 @@ mod test {
             () = state.wait_for_start_count(1) => {},
         }
 
-        rebuild_sink_tx
-            .send(RebuildSinkMessage::UpdateConfig(HashMap::from([(
-                "commit_checkpoint_interval".to_owned(),
-                "1".to_owned(),
-            )])))
-            .unwrap();
+        rebuild_sink_tx.send(changed_config_update()).unwrap();
 
         tokio::select! {
             result = &mut consume_log => panic!("log consumer exited unexpectedly: {result:?}"),
@@ -1086,7 +1154,7 @@ mod test {
     }
 
     #[tokio::test]
-    async fn test_no_op_sink_config_update_triggers_recovery_without_rewind() {
+    async fn test_sink_config_update_triggers_recovery_without_rewind() {
         let sink_param = sink_param_for_config_update_test();
         let sink = BlackHoleSink::try_from(sink_param.clone()).unwrap();
         let state = Arc::new(RewindRequiredLogReaderState::default());
@@ -1115,12 +1183,7 @@ mod test {
             () = state.wait_for_start_count(1) => {},
         }
 
-        rebuild_sink_tx
-            .send(RebuildSinkMessage::UpdateConfig(HashMap::from([(
-                "commit_checkpoint_interval".to_owned(),
-                "1".to_owned(),
-            )])))
-            .unwrap();
+        rebuild_sink_tx.send(changed_config_update()).unwrap();
 
         tokio::time::timeout(Duration::from_secs(5), consume_log)
             .await


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

A sink config notification cancels the in-flight consumer through `select!`. Restarting it requires a rewound log reader, and when the log reader cannot rewind (`sink_decouple = false`, in-memory log store) the only way back is recovery. Since #26412 that price is paid even when the incoming properties already equal the current ones.

So an `ALTER SINK ... CONNECTOR` that changes nothing:

- drags the whole database through a recovery, restarting every streaming job in it;
- panics meta where recovery is disabled — `database N failure reported from M but recovery not enabled` (`barrier/worker.rs:763`). That is what CI runs, so `end-to-end clickhouse sink test` and `end-to-end starrocks sink test` have been red on `main` since 2026-07-24.

This PR detects the no-op **before** the consumer is dropped and keeps it running — no cancellation, no rewind, no recovery. Everything reaching the handler now really did change, so the branches there no longer repeat the check. #26409's fix is preserved: a real change on a rewind-capable reader still rewinds.

The consumer future is `Box::pin`ned so `drop` releases its borrows on `log_reader` / `sink` before the change path mutates them.

### Why exactly those two e2e tests

Both start with `set sink_decouple = false` and then run `ALTER SINK s6 CONNECTOR WITH (commit_checkpoint_interval = '1')`. `set_default_commit_checkpoint_interval` already persisted `commit_checkpoint_interval = 1` at CREATE time, so the ALTER is a pure no-op — they only ever passed because of the pre-#26412 short-circuit.

### Tests

The two existing `test_no_op_*` tests encoded the old semantics and are rewritten; the two "config actually changed" cases they were missing are added.

- `test_no_op_sink_config_update_keeps_consuming_{with,without}_rewind` — consumer survives, no rewind. Liveness is asserted deterministically: a following `RebuildSink` gets acknowledged, no sleeps.
- `test_sink_config_update_rewinds_log_reader` — a real change still rewinds and restarts (regression guard for #26409).
- `test_sink_config_update_triggers_recovery_without_rewind` — a real change without rewind still errors to trigger recovery.

`./risedev check` clean; `./risedev test executor::sink` 12/12.

### Limitation

A *real* `ALTER SINK ... CONNECTOR` on a non-decoupled sink still forces recovery and therefore still cannot run under `disable_recovery`. Unchanged here.

- Closes #26483

## Checklist

- [x] I have written necessary rustdoc comments.
- [x] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [x] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [x] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->

#26412 landed on 2026-07-23 and has not shipped in a release branch, so no cherry-pick is needed.

## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

</details>
