### PR TITLE
fix(frontend): resolve fixed backfill order for index scans

### DIFF
--- a/e2e_test/backfill/locality_backfill/fixed_backfill_order_index_selection.slt
+++ b/e2e_test/backfill/locality_backfill/fixed_backfill_order_index_selection.slt
@@ -1,0 +1,36 @@
+statement ok
+set enable_index_selection = true;
+
+statement ok
+drop table if exists backfill_order_fact cascade;
+
+statement ok
+drop table if exists backfill_order_dim cascade;
+
+statement ok
+create table backfill_order_fact(v1 int);
+
+statement ok
+create table backfill_order_dim(v1 int, v2 int);
+
+statement ok
+create index idx_backfill_order_dim_v1 on backfill_order_dim(v1);
+
+statement ok
+create materialized view mv_fixed_backfill_order_index
+    with (backfill_order = FIXED(backfill_order_fact -> backfill_order_dim))
+    as
+      select count(*)
+      from backfill_order_fact
+      join backfill_order_dim
+        on backfill_order_fact.v1 = backfill_order_dim.v1
+      group by backfill_order_fact.v1;
+
+statement ok
+drop materialized view mv_fixed_backfill_order_index;
+
+statement ok
+drop table backfill_order_fact;
+
+statement ok
+drop table backfill_order_dim cascade;

--- a/src/frontend/planner_test/tests/testdata/input/backfill.yaml
+++ b/src/frontend/planner_test/tests/testdata/input/backfill.yaml
@@ -195,6 +195,20 @@
     select * from t where b = 1;
   expected_outputs:
     - stream_plan
+- name: fixed backfill order with selected index
+  sql: |
+    set enable_index_selection = true;
+    create table fact(v1 int);
+    create table dim(v1 int, v2 int);
+    create index idx_dim_v1 on dim(v1);
+    explain (backfill, format dot) create materialized view mv
+    with (backfill_order = FIXED(fact -> dim))
+    as
+      select count(*)
+      from fact join dim on fact.v1 = dim.v1
+      group by fact.v1;
+  expected_outputs:
+    - explain_output
 - name: |
     Test backfill order, auto, stream share cycle.
     For auto derived backfill order with cycle, it should not return any order plan, and return a NOTICE

--- a/src/frontend/planner_test/tests/testdata/output/backfill.yaml
+++ b/src/frontend/planner_test/tests/testdata/output/backfill.yaml
@@ -417,6 +417,22 @@
     StreamMaterialize { columns: [a, b, c], stream_key: [b, a], pk_columns: [b, a], pk_conflict: NoCheck }
     └─StreamFilter { predicate: (idx_b.b = 1:Int32) }
       └─StreamTableScan { table: idx_b, columns: [idx_b.a, idx_b.b, idx_b.c], pk_scan_range: b = Some(Int32(1)), stream_scan_type: SnapshotBackfill, stream_key: [idx_b.b, idx_b.a], pk: [b, a], dist: UpstreamHashShard(idx_b.b) }
+- name: fixed backfill order with selected index
+  sql: |
+    set enable_index_selection = true;
+    create table fact(v1 int);
+    create table dim(v1 int, v2 int);
+    create index idx_dim_v1 on dim(v1);
+    explain (backfill, format dot) create materialized view mv
+    with (backfill_order = FIXED(fact -> dim))
+    as
+      select count(*)
+      from fact join dim on fact.v1 = dim.v1
+      group by fact.v1;
+  explain_output: |
+    digraph G {
+      "public.fact" -> "public.idx_dim_v1";
+    }
 - name: |
     Test backfill order, auto, stream share cycle.
     For auto derived backfill order with cycle, it should not return any order plan, and return a NOTICE

--- a/src/frontend/src/optimizer/backfill_order_strategy.rs
+++ b/src/frontend/src/optimizer/backfill_order_strategy.rs
@@ -240,32 +240,65 @@ mod fixed {
     use crate::optimizer::plan_node::{StreamPlanNodeType, StreamPlanRef};
     use crate::session::SessionImpl;
 
-    /// Collect all relation IDs (tables and sources) that are scanned in the plan.
-    fn collect_scanned_relation_ids(plan: StreamPlanRef) -> HashSet<RelationId> {
-        let mut relation_ids = HashSet::new();
+    /// Collect a mapping from bindable relation IDs to relation IDs actually scanned in the plan.
+    ///
+    /// Index selection may replace a scan on a base table with a scan on one of its index tables.
+    /// In that case, both the base table ID and the index table ID map to the actual index table
+    /// ID, so a user can still specify the base table in a fixed backfill order.
+    fn collect_scanned_relation_ids(
+        session: &SessionImpl,
+        plan: StreamPlanRef,
+    ) -> HashMap<RelationId, HashSet<RelationId>> {
+        let mut relation_ids: HashMap<RelationId, HashSet<RelationId>> = HashMap::new();
 
-        fn visit(plan: StreamPlanRef, relation_ids: &mut HashSet<RelationId>) {
+        fn visit(
+            session: &SessionImpl,
+            plan: StreamPlanRef,
+            relation_ids: &mut HashMap<RelationId, HashSet<RelationId>>,
+        ) {
             match plan.node_type() {
                 StreamPlanNodeType::StreamTableScan => {
                     let table_scan = plan.as_stream_table_scan().expect("table scan");
-                    let relation_id = table_scan.core().table_catalog.id().as_relation_id();
-                    relation_ids.insert(relation_id);
+                    let table_catalog = &table_scan.core().table_catalog;
+                    let scanned_relation_id = table_catalog.id().as_relation_id();
+                    relation_ids
+                        .entry(scanned_relation_id)
+                        .or_default()
+                        .insert(scanned_relation_id);
+
+                    if table_catalog.is_index() {
+                        let reader = session.env().catalog_reader().read_guard();
+                        let schema_catalog = reader
+                            .get_schema_by_id(table_catalog.database_id, table_catalog.schema_id)
+                            .expect("schema of an index table should exist");
+                        let index_catalog = schema_catalog
+                            .iter_index()
+                            .find(|index| index.index_table().id == table_catalog.id)
+                            .expect("index catalog of an index table should exist");
+                        relation_ids
+                            .entry(index_catalog.primary_table.id().as_relation_id())
+                            .or_default()
+                            .insert(scanned_relation_id);
+                    }
                 }
                 StreamPlanNodeType::StreamSourceScan => {
                     let source_scan = plan.as_stream_source_scan().expect("source scan");
                     let relation_id = source_scan.source_catalog().id.as_relation_id();
-                    relation_ids.insert(relation_id);
+                    relation_ids
+                        .entry(relation_id)
+                        .or_default()
+                        .insert(relation_id);
                 }
                 _ => {}
             }
 
             // Recursively visit all inputs
             for child in plan.inputs() {
-                visit(child, relation_ids);
+                visit(session, child, relation_ids);
             }
         }
 
-        visit(plan, &mut relation_ids);
+        visit(session, plan, &mut relation_ids);
         relation_ids
     }
 
@@ -274,8 +307,8 @@ mod fixed {
         orders: Vec<(ObjectName, ObjectName)>,
         plan: StreamPlanRef,
     ) -> Result<HashMap<RelationId, HashSet<RelationId>>> {
-        // Collect all scanned relation IDs from the plan
-        let scanned_relation_ids = collect_scanned_relation_ids(plan);
+        // Collect all scanned relation IDs from the plan.
+        let scanned_relation_ids = collect_scanned_relation_ids(session, plan);
 
         let mut order: HashMap<RelationId, HashSet<RelationId>> = HashMap::new();
         for (start_name, end_name) in orders {
@@ -283,23 +316,26 @@ mod fixed {
             let end_relation_id = bind_backfill_relation_id_by_name(session, end_name.clone())?;
 
             // Validate that both relations are present in the query plan
-            if !scanned_relation_ids.contains(&start_relation_id) {
+            let Some(start_scanned_relation_ids) = scanned_relation_ids.get(&start_relation_id)
+            else {
                 bail!(
                     "Table or source '{}' specified in backfill_order is not used in the query",
                     start_name
                 );
-            }
-            if !scanned_relation_ids.contains(&end_relation_id) {
+            };
+            let Some(end_scanned_relation_ids) = scanned_relation_ids.get(&end_relation_id) else {
                 bail!(
                     "Table or source '{}' specified in backfill_order is not used in the query",
                     end_name
                 );
-            }
+            };
 
-            order
-                .entry(start_relation_id)
-                .or_default()
-                .insert(end_relation_id);
+            for start_scanned_relation_id in start_scanned_relation_ids {
+                order
+                    .entry(*start_scanned_relation_id)
+                    .or_default()
+                    .extend(end_scanned_relation_ids.iter().copied());
+            }
         }
         if has_cycle(&order) {
             bail!("Backfill order strategy has a cycle");


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

- Preserve user-facing base table names when validating a fixed backfill order after index selection.
- Translate fixed backfill dependencies to the relation IDs actually scanned by the optimized plan, so meta can map them to the correct fragments.
- Add planner and end-to-end regression coverage for a base table scan replaced by an index scan.

Closes #25755

## Checklist

- [x] I have written necessary rustdoc comments.
- [x] I have added necessary unit tests and integration tests.
- [x] I have added test labels as necessary.
- [ ] I have added fuzzing tests or opened an issue to track them.
- [ ] My PR contains breaking changes.
- [ ] My PR changes performance-critical code, so I will run (micro) benchmarks and present the results.
- [ ] I have checked the Release Timeline and Currently Supported Versions to determine which release branches I need to cherry-pick this PR into.

## Documentation

- [ ] My PR needs documentation updates.

<details>
<summary><b>Release note</b></summary>

Fixed `CREATE MATERIALIZED VIEW ... WITH (backfill_order = FIXED(...))` when index selection replaces a referenced base table scan with an index scan.

</details>
