### PR TITLE
fix(test): update meta backup state store expectation

### DIFF
--- a/src/storage/backup/integration_tests/common.sh
+++ b/src/storage/backup/integration_tests/common.sh
@@ -195,7 +195,7 @@ function execute_sql_and_expect() {
   echo "expected string in result: ${expected}"
   query_result=$(execute_sql "${sql}")
   printf "actual result:\n%s\n" "${query_result}"
-  result=$(echo "${query_result}" | grep "${expected}")
+  result=$(echo "${query_result}" | grep -F "${expected}")
   [ -n "${result}" ]
 }
 

--- a/src/storage/backup/integration_tests/test_overwrite_endpoint.sh
+++ b/src/storage/backup/integration_tests/test_overwrite_endpoint.sh
@@ -12,7 +12,7 @@ execute_sql "FLUSH;"
 
 execute_sql_and_expect \
 "SHOW parameters;" \
-"state_store                            | hummock+minio://hummockadmin:hummockadmin@127.0.0.1:9301/hummock001"
+"state_store                            | hummock+minio://****:****@127.0.0.1:9301/hummock001"
 
 execute_sql_and_expect \
 "SHOW parameters;" \
@@ -40,7 +40,7 @@ start_cluster
 
 execute_sql_and_expect \
 "SHOW parameters;" \
-"state_store                            | hummock+${overwrite_hummock_storage_url}"
+"state_store                            | hummock+minio://****:****@127.0.0.1:9301/hummock002"
 
 execute_sql_and_expect \
 "SHOW parameters;" \


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

Update the meta backup overwrite-endpoint integration test to match the current `SHOW parameters` display behavior for `state_store`, which redacts embedded credentials. The backup integration helper now uses fixed-string matching so expected output snippets with characters like `*` are matched literally. This fixes the main-cron meta backup failure while preserving the backup storage URL checks.

## Checklist

- [ ] I have written necessary rustdoc comments.
- [x] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [x] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

</details>
