### PR TITLE
fix(frontend): avoid catalog-user lock order inversion

### DIFF
--- a/src/frontend/src/handler/alter_rename.rs
+++ b/src/frontend/src/handler/alter_rename.rs
@@ -240,8 +240,8 @@ pub async fn handle_rename_schema(
     let new_schema_name = Binder::resolve_schema_name(new_schema_name)?;
 
     let schema_id = {
-        let user_reader = session.env().user_info_reader().read_guard();
         let catalog_reader = session.env().catalog_reader().read_guard();
+        let user_reader = session.env().user_info_reader().read_guard();
         let schema = catalog_reader.get_schema_by_name(db_name, &schema_name)?;
         let db_id = catalog_reader.get_database_by_name(db_name)?.id();
 
@@ -289,8 +289,8 @@ pub async fn handle_rename_database(
     let new_database_name = Binder::resolve_database_name(new_database_name)?;
 
     let database_id = {
-        let user_reader = session.env().user_info_reader().read_guard();
         let catalog_reader = session.env().catalog_reader().read_guard();
+        let user_reader = session.env().user_info_reader().read_guard();
         let database = catalog_reader.get_database_by_name(&database_name)?;
 
         // The user should be super user or owner to alter the database.

--- a/src/frontend/src/observer/observer_manager.rs
+++ b/src/frontend/src/observer/observer_manager.rs
@@ -43,6 +43,7 @@ pub struct FrontendObserverNode {
     worker_node_manager: WorkerNodeManagerRef,
     version: CatalogVersion,
     catalog_updated_tx: Sender<CatalogVersion>,
+    // When both locks are needed, always acquire `catalog` before `user_info_manager`.
     catalog: Arc<RwLock<Catalog>>,
     user_info_manager: Arc<RwLock<UserInfoManager>>,
     hummock_snapshot_manager: HummockSnapshotManagerRef,
@@ -124,8 +125,6 @@ impl ObserverState for FrontendObserverNode {
     }
 
     fn handle_initialization_notification(&mut self, resp: SubscribeResponse) {
-        // Always acquire the catalog lock before the user lock to avoid an ABBA deadlock with
-        // frontend readers that need both.
         let mut catalog_guard = self.catalog.write();
         let mut user_guard = self.user_info_manager.write();
         catalog_guard.clear();

--- a/src/frontend/src/observer/observer_manager.rs
+++ b/src/frontend/src/observer/observer_manager.rs
@@ -124,6 +124,8 @@ impl ObserverState for FrontendObserverNode {
     }
 
     fn handle_initialization_notification(&mut self, resp: SubscribeResponse) {
+        // Always acquire the catalog lock before the user lock to avoid an ABBA deadlock with
+        // frontend readers that need both.
         let mut catalog_guard = self.catalog.write();
         let mut user_guard = self.user_info_manager.write();
         catalog_guard.clear();


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What changed and what is your intention?

- Make `ALTER SCHEMA RENAME` and `ALTER DATABASE RENAME` acquire the catalog read lock before the user read lock.
- Match the frontend observer snapshot initialization order, avoiding a possible ABBA deadlock during notification resubscription.
- Document the canonical lock order at the writer site.

## Test

- `cargo fmt --all -- --check`
- `cargo test -p risingwave_frontend --lib handler::alter_rename::tests`
- `git diff --check`

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [x] <!-- OPTIONAL --> I have added test labels as necessary.
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them.
- [ ] <!-- OPTIONAL --> My PR contains breaking changes.
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run benchmarks and present the results.
- [ ] <!-- OPTIONAL --> I have checked the release timeline and currently supported versions to determine which release branches need a cherry-pick.

## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates.