### PR TITLE
feat(meta): model catalog object belong-to relations

### DIFF
--- a/e2e_test/iceberg/test_case/pure_slt/iceberg_engine_set_schema.slt
+++ b/e2e_test/iceberg/test_case/pure_slt/iceberg_engine_set_schema.slt
@@ -1,0 +1,79 @@
+# Regression test for moving an Iceberg table engine and objects that belong to it.
+
+statement ok
+CREATE SECRET iceberg_set_schema_secret WITH (
+  backend = 'meta'
+) AS 'hummockadmin';
+
+statement ok
+CREATE CONNECTION iceberg_set_schema_connection WITH (
+  type = 'iceberg',
+  warehouse.path = 's3://hummock001/iceberg_engine_set_schema',
+  s3.access.key = SECRET iceberg_set_schema_secret,
+  s3.secret.key = SECRET iceberg_set_schema_secret,
+  s3.endpoint = 'http://127.0.0.1:9301',
+  s3.region = 'us-west-2',
+  catalog.type = 'storage'
+);
+
+statement ok
+SET iceberg_engine_connection = 'public.iceberg_set_schema_connection';
+
+statement ok
+CREATE SCHEMA iceberg_set_schema_target;
+
+statement ok
+CREATE TABLE iceberg_set_schema_table (
+  id INT PRIMARY KEY,
+  name VARCHAR
+) WITH (
+  commit_checkpoint_interval = 1
+) ENGINE = ICEBERG;
+
+statement ok
+ALTER TABLE iceberg_set_schema_table SET SCHEMA iceberg_set_schema_target;
+
+query TT rowsort
+SELECT object_type, schema_name
+FROM (
+  SELECT 'table' AS object_type, schemaname AS schema_name
+  FROM pg_tables
+  WHERE tablename = 'iceberg_set_schema_table'
+  UNION ALL
+  SELECT 'source', nspname
+  FROM rw_catalog.rw_sources
+  JOIN pg_namespace ON pg_namespace.oid = rw_sources.schema_id
+  WHERE rw_sources.name = '__iceberg_source_iceberg_set_schema_table'
+  UNION ALL
+  SELECT 'sink', nspname
+  FROM rw_catalog.rw_sinks
+  JOIN pg_namespace ON pg_namespace.oid = rw_sinks.schema_id
+  WHERE rw_sinks.name = '__iceberg_sink_iceberg_set_schema_table'
+);
+----
+sink iceberg_set_schema_target
+source iceberg_set_schema_target
+table iceberg_set_schema_target
+
+statement ok
+INSERT INTO iceberg_set_schema_target.iceberg_set_schema_table VALUES (1, 'moved');
+
+statement ok
+FLUSH;
+
+query IT retry 6 backoff 1s
+SELECT * FROM iceberg_set_schema_target.iceberg_set_schema_table;
+----
+1 moved
+
+statement ok
+DROP TABLE iceberg_set_schema_target.iceberg_set_schema_table;
+
+statement ok
+DROP SCHEMA iceberg_set_schema_target;
+
+statement ok
+DROP CONNECTION iceberg_set_schema_connection;
+
+statement ok
+DROP SECRET iceberg_set_schema_secret;

--- a/src/frontend/src/handler/mod.rs
+++ b/src/frontend/src/handler/mod.rs
@@ -1781,13 +1781,6 @@ fn check_ban_alter_table_operation_for_iceberg_engine_table(
                 table_name
             );
         }
-        AlterTableOperation::SetSchema { .. } => {
-            bail!(
-                "ALTER TABLE SET SCHEMA is not supported for iceberg table: {}.{}",
-                schema_name,
-                table_name
-            );
-        }
         AlterTableOperation::RefreshSchema => {
             bail!(
                 "ALTER TABLE REFRESH SCHEMA is not supported for iceberg table: {}.{}",

--- a/src/meta/model/migration/src/lib.rs
+++ b/src/meta/model/migration/src/lib.rs
@@ -75,6 +75,7 @@ mod m20260519_000000_streaming_job_batch_refresh_seconds;
 mod m20260624_000000_pending_sink_state_object_fk;
 mod m20260705_000000_subscription_dependent_object_fk;
 mod m20260804_000000_worker_property_resource;
+mod m20260805_000000_object_belong_to_oid;
 mod utils;
 
 pub struct Migrator;
@@ -188,6 +189,7 @@ impl MigratorTrait for Migrator {
             Box::new(m20260624_000000_pending_sink_state_object_fk::Migration),
             Box::new(m20260705_000000_subscription_dependent_object_fk::Migration),
             Box::new(m20260804_000000_worker_property_resource::Migration),
+            Box::new(m20260805_000000_object_belong_to_oid::Migration),
         ]
     }
 }

--- a/src/meta/model/migration/src/m20260805_000000_object_belong_to_oid.rs
+++ b/src/meta/model/migration/src/m20260805_000000_object_belong_to_oid.rs
@@ -18,41 +18,51 @@ enum ObjectColumn {
 impl MigrationTrait for Migration {
     async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
         let backend = manager.get_database_backend();
-        match backend {
-            DatabaseBackend::MySql | DatabaseBackend::Postgres => {
-                manager
-                    .alter_table(
-                        Table::alter()
-                            .table(Object::Table)
-                            .add_column(ColumnDef::new(ObjectColumn::BelongToOid).integer().null())
-                            .to_owned(),
-                    )
-                    .await?;
-            }
-            DatabaseBackend::Sqlite => {
-                // SQLite cannot add a foreign key constraint to an existing table separately,
-                // but it allows REFERENCES on a newly added nullable column.
-                manager
-                    .get_connection()
-                    .execute(Statement::from_string(
-                        backend,
-                        r#"ALTER TABLE "object" ADD COLUMN "belong_to_oid" INTEGER REFERENCES "object" ("oid") ON DELETE CASCADE"#,
-                    ))
-                    .await?;
+        // The migrator records the version only after `up` returns, while MySQL DDL implicitly
+        // commits. Guard every DDL step so a new Meta leader can retry a partially run migration.
+        if !manager.has_column("object", "belong_to_oid").await? {
+            match backend {
+                DatabaseBackend::MySql | DatabaseBackend::Postgres => {
+                    manager
+                        .alter_table(
+                            Table::alter()
+                                .table(Object::Table)
+                                .add_column(
+                                    ColumnDef::new(ObjectColumn::BelongToOid).integer().null(),
+                                )
+                                .to_owned(),
+                        )
+                        .await?;
+                }
+                DatabaseBackend::Sqlite => {
+                    // SQLite cannot add a foreign key constraint to an existing table separately,
+                    // but it allows REFERENCES on a newly added nullable column.
+                    manager
+                        .get_connection()
+                        .execute(Statement::from_string(
+                            backend,
+                            r#"ALTER TABLE "object" ADD COLUMN "belong_to_oid" INTEGER REFERENCES "object" ("oid") ON DELETE CASCADE"#,
+                        ))
+                        .await?;
+                }
             }
         }
 
-        manager
-            .create_index(
-                Index::create()
-                    .name(INDEX_NAME)
-                    .table(Object::Table)
-                    .col(ObjectColumn::BelongToOid)
-                    .to_owned(),
-            )
-            .await?;
+        if !manager.has_index("object", INDEX_NAME).await? {
+            manager
+                .create_index(
+                    Index::create()
+                        .name(INDEX_NAME)
+                        .table(Object::Table)
+                        .col(ObjectColumn::BelongToOid)
+                        .to_owned(),
+                )
+                .await?;
+        }
 
-        if matches!(backend, DatabaseBackend::MySql | DatabaseBackend::Postgres) {
+        if matches!(backend, DatabaseBackend::MySql | DatabaseBackend::Postgres)
+            && !has_foreign_key(manager).await?
+        {
             manager
                 .alter_table(
                     Table::alter()
@@ -110,6 +120,28 @@ impl MigrationTrait for Migration {
 
         Ok(())
     }
+}
+
+async fn has_foreign_key(manager: &SchemaManager<'_>) -> Result<bool, DbErr> {
+    let backend = manager.get_database_backend();
+    let statement = match backend {
+        DatabaseBackend::MySql => format!(
+            "SELECT 1 FROM information_schema.TABLE_CONSTRAINTS \
+             WHERE CONSTRAINT_SCHEMA = DATABASE() AND TABLE_NAME = 'object' \
+             AND CONSTRAINT_NAME = '{FK_NAME}' AND CONSTRAINT_TYPE = 'FOREIGN KEY' LIMIT 1"
+        ),
+        DatabaseBackend::Postgres => format!(
+            "SELECT 1 FROM information_schema.table_constraints \
+             WHERE constraint_schema = current_schema() AND table_name = 'object' \
+             AND constraint_name = '{FK_NAME}' AND constraint_type = 'FOREIGN KEY' LIMIT 1"
+        ),
+        DatabaseBackend::Sqlite => unreachable!("SQLite defines the foreign key with the column"),
+    };
+    Ok(manager
+        .get_connection()
+        .query_one(Statement::from_string(backend, statement))
+        .await?
+        .is_some())
 }
 
 async fn backfill_belong_to_oid(manager: &SchemaManager<'_>) -> Result<(), DbErr> {
@@ -240,5 +272,59 @@ mod tests {
             .unwrap()
             .unwrap();
         assert_eq!(i64::try_get(&remaining, "", "count").unwrap(), 4);
+    }
+
+    #[tokio::test]
+    async fn test_sqlite_partial_run_retry() {
+        let db = Database::connect("sqlite::memory:").await.unwrap();
+        for sql in [
+            r#"CREATE TABLE "object" ("oid" INTEGER PRIMARY KEY, "schema_id" INTEGER, "database_id" INTEGER)"#,
+            r#"CREATE TABLE "table" ("table_id" INTEGER PRIMARY KEY, "name" TEXT, "engine" TEXT, "belongs_to_job_id" INTEGER, "optional_associated_source_id" INTEGER)"#,
+            r#"CREATE TABLE "sink" ("sink_id" INTEGER PRIMARY KEY, "name" TEXT)"#,
+            r#"CREATE TABLE "source" ("source_id" INTEGER PRIMARY KEY, "name" TEXT)"#,
+            r#"CREATE TABLE "object_dependency" ("oid" INTEGER, "used_by" INTEGER)"#,
+            r#"INSERT INTO "object" ("oid", "schema_id", "database_id") VALUES (1, NULL, NULL), (2, NULL, 1), (3, 2, 1), (4, 2, 1)"#,
+            r#"INSERT INTO "table" ("table_id", "name", "engine", "belongs_to_job_id", "optional_associated_source_id") VALUES (3, 'table', 'HUMMOCK', NULL, NULL), (4, 'internal', 'HUMMOCK', 3, NULL)"#,
+            // Simulate Meta exiting after the first DDL statement but before recording the
+            // migration version.
+            r#"ALTER TABLE "object" ADD COLUMN "belong_to_oid" INTEGER REFERENCES "object" ("oid") ON DELETE CASCADE"#,
+        ] {
+            db.execute(Statement::from_string(DatabaseBackend::Sqlite, sql))
+                .await
+                .unwrap();
+        }
+
+        let manager = SchemaManager::new(&db);
+        Migration.up(&manager).await.unwrap();
+        // Simulate another exit after all migration statements but before recording the version.
+        Migration.up(&manager).await.unwrap();
+
+        assert!(manager.has_column("object", "belong_to_oid").await.unwrap());
+        assert!(manager.has_index("object", INDEX_NAME).await.unwrap());
+        let internal = db
+            .query_one(Statement::from_string(
+                DatabaseBackend::Sqlite,
+                r#"SELECT "belong_to_oid" FROM "object" WHERE "oid" = 4"#,
+            ))
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(i32::try_get(&internal, "", "belong_to_oid").unwrap(), 3);
+
+        db.execute(Statement::from_string(
+            DatabaseBackend::Sqlite,
+            r#"DELETE FROM "object" WHERE "oid" = 3"#,
+        ))
+        .await
+        .unwrap();
+        assert!(
+            db.query_one(Statement::from_string(
+                DatabaseBackend::Sqlite,
+                r#"SELECT "oid" FROM "object" WHERE "oid" = 4"#,
+            ))
+            .await
+            .unwrap()
+            .is_none()
+        );
     }
 }

--- a/src/meta/model/migration/src/m20260805_000000_object_belong_to_oid.rs
+++ b/src/meta/model/migration/src/m20260805_000000_object_belong_to_oid.rs
@@ -1,0 +1,242 @@
+use sea_orm_migration::prelude::*;
+
+use crate::m20230908_072257_init::Object;
+use crate::sea_orm::{ConnectionTrait, DatabaseBackend, Statement};
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+const FK_NAME: &str = "FK_object_belong_to_oid";
+const INDEX_NAME: &str = "IDX_object_belong_to_oid";
+
+#[derive(DeriveIden)]
+enum ObjectColumn {
+    BelongToOid,
+}
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        let backend = manager.get_database_backend();
+        match backend {
+            DatabaseBackend::MySql | DatabaseBackend::Postgres => {
+                manager
+                    .alter_table(
+                        Table::alter()
+                            .table(Object::Table)
+                            .add_column(ColumnDef::new(ObjectColumn::BelongToOid).integer().null())
+                            .to_owned(),
+                    )
+                    .await?;
+            }
+            DatabaseBackend::Sqlite => {
+                // SQLite cannot add a foreign key constraint to an existing table separately,
+                // but it allows REFERENCES on a newly added nullable column.
+                manager
+                    .get_connection()
+                    .execute(Statement::from_string(
+                        backend,
+                        r#"ALTER TABLE "object" ADD COLUMN "belong_to_oid" INTEGER REFERENCES "object" ("oid") ON DELETE CASCADE"#,
+                    ))
+                    .await?;
+            }
+        }
+
+        manager
+            .create_index(
+                Index::create()
+                    .name(INDEX_NAME)
+                    .table(Object::Table)
+                    .col(ObjectColumn::BelongToOid)
+                    .to_owned(),
+            )
+            .await?;
+
+        if matches!(backend, DatabaseBackend::MySql | DatabaseBackend::Postgres) {
+            manager
+                .alter_table(
+                    Table::alter()
+                        .table(Object::Table)
+                        .add_foreign_key(
+                            TableForeignKey::new()
+                                .name(FK_NAME)
+                                .from_tbl(Object::Table)
+                                .from_col(ObjectColumn::BelongToOid)
+                                .to_tbl(Object::Table)
+                                .to_col(Object::Oid)
+                                .on_delete(ForeignKeyAction::Cascade),
+                        )
+                        .to_owned(),
+                )
+                .await?;
+        }
+
+        backfill_belong_to_oid(manager).await?;
+
+        Ok(())
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        if matches!(
+            manager.get_database_backend(),
+            DatabaseBackend::MySql | DatabaseBackend::Postgres
+        ) {
+            manager
+                .alter_table(
+                    Table::alter()
+                        .table(Object::Table)
+                        .drop_foreign_key(Alias::new(FK_NAME))
+                        .to_owned(),
+                )
+                .await?;
+        }
+
+        manager
+            .drop_index(
+                Index::drop()
+                    .name(INDEX_NAME)
+                    .table(Object::Table)
+                    .to_owned(),
+            )
+            .await?;
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(Object::Table)
+                    .drop_column(ObjectColumn::BelongToOid)
+                    .to_owned(),
+            )
+            .await?;
+
+        Ok(())
+    }
+}
+
+async fn backfill_belong_to_oid(manager: &SchemaManager<'_>) -> Result<(), DbErr> {
+    let backend = manager.get_database_backend();
+    // Start with namespace parents, then overwrite them with more specific belong-to relations:
+    // internal table -> job and associated source -> table. Indexes and subscriptions are named
+    // objects, so they continue to belong to their schemas; their references to upstream tables
+    // remain represented by the `index`, `subscription`, and `object_dependency` tables.
+    //
+    // For implicit Iceberg objects, reconstruct the associations that catalog operations used
+    // before `belong_to_oid` was persisted. A generated sink belongs to the unique Iceberg table in
+    // its object dependencies. A generated source belongs to the same-schema Iceberg table
+    // identified by its `__iceberg_source_<table>` name, because no source-to-table dependency is
+    // persisted.
+    let statements = match backend {
+        DatabaseBackend::MySql => vec![
+            "UPDATE `object` SET `belong_to_oid` = COALESCE(`schema_id`, `database_id`)",
+            "UPDATE `object` AS o JOIN `table` AS t ON t.`table_id` = o.`oid` SET o.`belong_to_oid` = t.`belongs_to_job_id` WHERE t.`belongs_to_job_id` IS NOT NULL",
+            "UPDATE `object` AS o JOIN `table` AS t ON t.`optional_associated_source_id` = o.`oid` SET o.`belong_to_oid` = t.`table_id`",
+            "UPDATE `object` AS o JOIN `sink` AS s ON s.`sink_id` = o.`oid` JOIN (SELECT d.`used_by`, MIN(t.`table_id`) AS `table_id` FROM `object_dependency` AS d JOIN `table` AS t ON t.`table_id` = d.`oid` AND t.`engine` = 'ICEBERG' GROUP BY d.`used_by` HAVING COUNT(*) = 1) AS parent ON parent.`used_by` = o.`oid` SET o.`belong_to_oid` = parent.`table_id` WHERE s.`name` LIKE '__iceberg_sink_%'",
+            "UPDATE `object` AS o JOIN `source` AS s ON s.`source_id` = o.`oid` JOIN `object` AS parent ON parent.`database_id` = o.`database_id` AND parent.`schema_id` = o.`schema_id` JOIN `table` AS t ON t.`table_id` = parent.`oid` AND t.`engine` = 'ICEBERG' SET o.`belong_to_oid` = parent.`oid` WHERE s.`name` = CONCAT('__iceberg_source_', t.`name`)",
+        ],
+        DatabaseBackend::Postgres => vec![
+            r#"UPDATE "object" SET "belong_to_oid" = COALESCE("schema_id", "database_id")"#,
+            r#"UPDATE "object" AS o SET "belong_to_oid" = t."belongs_to_job_id" FROM "table" AS t WHERE t."table_id" = o."oid" AND t."belongs_to_job_id" IS NOT NULL"#,
+            r#"UPDATE "object" AS o SET "belong_to_oid" = t."table_id" FROM "table" AS t WHERE t."optional_associated_source_id" = o."oid""#,
+            r#"UPDATE "object" AS o SET "belong_to_oid" = parent."table_id" FROM "sink" AS s, (SELECT d."used_by", MIN(t."table_id") AS "table_id" FROM "object_dependency" AS d JOIN "table" AS t ON t."table_id" = d."oid" AND t."engine" = 'ICEBERG' GROUP BY d."used_by" HAVING COUNT(*) = 1) AS parent WHERE s."sink_id" = o."oid" AND parent."used_by" = o."oid" AND s."name" LIKE '__iceberg_sink_%'"#,
+            r#"UPDATE "object" AS o SET "belong_to_oid" = parent."oid" FROM "source" AS s, "object" AS parent, "table" AS t WHERE s."source_id" = o."oid" AND parent."database_id" = o."database_id" AND parent."schema_id" = o."schema_id" AND t."table_id" = parent."oid" AND t."engine" = 'ICEBERG' AND s."name" = '__iceberg_source_' || t."name""#,
+        ],
+        DatabaseBackend::Sqlite => vec![
+            r#"UPDATE "object" SET "belong_to_oid" = COALESCE("schema_id", "database_id")"#,
+            r#"UPDATE "object" SET "belong_to_oid" = (SELECT t."belongs_to_job_id" FROM "table" AS t WHERE t."table_id" = "object"."oid") WHERE EXISTS (SELECT 1 FROM "table" AS t WHERE t."table_id" = "object"."oid" AND t."belongs_to_job_id" IS NOT NULL)"#,
+            r#"UPDATE "object" SET "belong_to_oid" = (SELECT t."table_id" FROM "table" AS t WHERE t."optional_associated_source_id" = "object"."oid") WHERE EXISTS (SELECT 1 FROM "table" AS t WHERE t."optional_associated_source_id" = "object"."oid")"#,
+            r#"UPDATE "object" SET "belong_to_oid" = (SELECT MIN(t."table_id") FROM "object_dependency" AS d JOIN "table" AS t ON t."table_id" = d."oid" AND t."engine" = 'ICEBERG' WHERE d."used_by" = "object"."oid") WHERE EXISTS (SELECT 1 FROM "sink" AS s WHERE s."sink_id" = "object"."oid" AND s."name" LIKE '__iceberg_sink_%') AND (SELECT COUNT(*) FROM "object_dependency" AS d JOIN "table" AS t ON t."table_id" = d."oid" AND t."engine" = 'ICEBERG' WHERE d."used_by" = "object"."oid") = 1"#,
+            r#"UPDATE "object" SET "belong_to_oid" = (SELECT parent."oid" FROM "source" AS s JOIN "object" AS parent ON parent."database_id" = "object"."database_id" AND parent."schema_id" = "object"."schema_id" JOIN "table" AS t ON t."table_id" = parent."oid" AND t."engine" = 'ICEBERG' WHERE s."source_id" = "object"."oid" AND s."name" = '__iceberg_source_' || t."name") WHERE EXISTS (SELECT 1 FROM "source" AS s JOIN "object" AS parent ON parent."database_id" = "object"."database_id" AND parent."schema_id" = "object"."schema_id" JOIN "table" AS t ON t."table_id" = parent."oid" AND t."engine" = 'ICEBERG' WHERE s."source_id" = "object"."oid" AND s."name" = '__iceberg_source_' || t."name")"#,
+        ],
+    };
+
+    for statement in statements {
+        manager
+            .get_connection()
+            .execute(Statement::from_string(backend, statement))
+            .await?;
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use sea_orm::{Database, TryGetable};
+
+    use super::*;
+
+    #[tokio::test]
+    async fn test_sqlite_backfill_and_cascade() {
+        let db = Database::connect("sqlite::memory:").await.unwrap();
+        for sql in [
+            r#"CREATE TABLE "object" ("oid" INTEGER PRIMARY KEY, "schema_id" INTEGER, "database_id" INTEGER)"#,
+            r#"CREATE TABLE "table" ("table_id" INTEGER PRIMARY KEY, "name" TEXT, "engine" TEXT, "belongs_to_job_id" INTEGER, "optional_associated_source_id" INTEGER)"#,
+            r#"CREATE TABLE "index" ("index_id" INTEGER PRIMARY KEY, "primary_table_id" INTEGER)"#,
+            r#"CREATE TABLE "subscription" ("subscription_id" INTEGER PRIMARY KEY, "dependent_table_id" INTEGER)"#,
+            r#"CREATE TABLE "sink" ("sink_id" INTEGER PRIMARY KEY, "name" TEXT)"#,
+            r#"CREATE TABLE "source" ("source_id" INTEGER PRIMARY KEY, "name" TEXT)"#,
+            r#"CREATE TABLE "object_dependency" ("oid" INTEGER, "used_by" INTEGER)"#,
+            r#"INSERT INTO "object" ("oid", "schema_id", "database_id") VALUES (1, NULL, NULL), (2, NULL, 1), (3, 2, 1), (4, 2, 1), (5, 2, 1), (6, 2, 1), (7, 2, 1), (8, 2, 1), (9, 2, 1), (10, 2, 1), (11, 2, 1)"#,
+            r#"INSERT INTO "table" ("table_id", "name", "engine", "belongs_to_job_id", "optional_associated_source_id") VALUES (3, 'iceberg_table', 'ICEBERG', NULL, 5), (4, 'table_internal', 'HUMMOCK', 3, NULL), (8, 'sink_internal', 'HUMMOCK', 6, NULL), (10, 'index_internal', 'HUMMOCK', 9, NULL)"#,
+            r#"INSERT INTO "index" ("index_id", "primary_table_id") VALUES (9, 3)"#,
+            r#"INSERT INTO "subscription" ("subscription_id", "dependent_table_id") VALUES (11, 3)"#,
+            r#"INSERT INTO "source" ("source_id", "name") VALUES (5, 'table_source'), (7, '__iceberg_source_iceberg_table')"#,
+            r#"INSERT INTO "sink" ("sink_id", "name") VALUES (6, '__iceberg_sink_renamed')"#,
+            r#"INSERT INTO "object_dependency" ("oid", "used_by") VALUES (3, 6)"#,
+        ] {
+            db.execute(Statement::from_string(DatabaseBackend::Sqlite, sql))
+                .await
+                .unwrap();
+        }
+
+        Migration.up(&SchemaManager::new(&db)).await.unwrap();
+
+        let rows = db
+            .query_all(Statement::from_string(
+                DatabaseBackend::Sqlite,
+                r#"SELECT "oid", "belong_to_oid" FROM "object" ORDER BY "oid""#,
+            ))
+            .await
+            .unwrap();
+        let belong_to_oids = rows
+            .into_iter()
+            .map(|row| {
+                (
+                    i32::try_get(&row, "", "oid").unwrap(),
+                    Option::<i32>::try_get(&row, "", "belong_to_oid").unwrap(),
+                )
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(
+            belong_to_oids,
+            vec![
+                (1, None),
+                (2, Some(1)),
+                (3, Some(2)),
+                (4, Some(3)),
+                (5, Some(3)),
+                (6, Some(3)),
+                (7, Some(3)),
+                (8, Some(6)),
+                (9, Some(2)),
+                (10, Some(9)),
+                (11, Some(2)),
+            ]
+        );
+
+        db.execute(Statement::from_string(
+            DatabaseBackend::Sqlite,
+            r#"DELETE FROM "object" WHERE "oid" = 3"#,
+        ))
+        .await
+        .unwrap();
+        let remaining = db
+            .query_one(Statement::from_string(
+                DatabaseBackend::Sqlite,
+                r#"SELECT COUNT(*) AS "count" FROM "object" WHERE "oid" IN (3, 4, 5, 6, 7, 8, 9, 10, 11)"#,
+            ))
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(i64::try_get(&remaining, "", "count").unwrap(), 3);
+    }
+}

--- a/src/meta/model/migration/src/m20260805_000000_object_belong_to_oid.rs
+++ b/src/meta/model/migration/src/m20260805_000000_object_belong_to_oid.rs
@@ -120,8 +120,9 @@ async fn backfill_belong_to_oid(manager: &SchemaManager<'_>) -> Result<(), DbErr
     // remain represented by the `index`, `subscription`, and `object_dependency` tables.
     //
     // For implicit Iceberg objects, reconstruct the associations that catalog operations used
-    // before `belong_to_oid` was persisted. A generated sink belongs to the unique Iceberg table in
-    // its object dependencies. A generated source belongs to the same-schema Iceberg table
+    // before `belong_to_oid` was persisted. A sink with the literal `__iceberg_sink_` prefix belongs
+    // to the unique Iceberg table in its object dependencies. A generated source belongs to the
+    // same-schema Iceberg table
     // identified by its `__iceberg_source_<table>` name, because no source-to-table dependency is
     // persisted.
     let statements = match backend {
@@ -129,21 +130,21 @@ async fn backfill_belong_to_oid(manager: &SchemaManager<'_>) -> Result<(), DbErr
             "UPDATE `object` SET `belong_to_oid` = COALESCE(`schema_id`, `database_id`)",
             "UPDATE `object` AS o JOIN `table` AS t ON t.`table_id` = o.`oid` SET o.`belong_to_oid` = t.`belongs_to_job_id` WHERE t.`belongs_to_job_id` IS NOT NULL",
             "UPDATE `object` AS o JOIN `table` AS t ON t.`optional_associated_source_id` = o.`oid` SET o.`belong_to_oid` = t.`table_id`",
-            "UPDATE `object` AS o JOIN `sink` AS s ON s.`sink_id` = o.`oid` JOIN (SELECT d.`used_by`, MIN(t.`table_id`) AS `table_id` FROM `object_dependency` AS d JOIN `table` AS t ON t.`table_id` = d.`oid` AND t.`engine` = 'ICEBERG' GROUP BY d.`used_by` HAVING COUNT(*) = 1) AS parent ON parent.`used_by` = o.`oid` SET o.`belong_to_oid` = parent.`table_id` WHERE s.`name` LIKE '__iceberg_sink_%'",
+            "UPDATE `object` AS o JOIN `sink` AS s ON s.`sink_id` = o.`oid` JOIN (SELECT d.`used_by`, MIN(t.`table_id`) AS `table_id` FROM `object_dependency` AS d JOIN `table` AS t ON t.`table_id` = d.`oid` AND t.`engine` = 'ICEBERG' GROUP BY d.`used_by` HAVING COUNT(*) = 1) AS parent ON parent.`used_by` = o.`oid` SET o.`belong_to_oid` = parent.`table_id` WHERE s.`name` LIKE '!_!_iceberg!_sink!_%' ESCAPE '!'",
             "UPDATE `object` AS o JOIN `source` AS s ON s.`source_id` = o.`oid` JOIN `object` AS parent ON parent.`database_id` = o.`database_id` AND parent.`schema_id` = o.`schema_id` JOIN `table` AS t ON t.`table_id` = parent.`oid` AND t.`engine` = 'ICEBERG' SET o.`belong_to_oid` = parent.`oid` WHERE s.`name` = CONCAT('__iceberg_source_', t.`name`)",
         ],
         DatabaseBackend::Postgres => vec![
             r#"UPDATE "object" SET "belong_to_oid" = COALESCE("schema_id", "database_id")"#,
             r#"UPDATE "object" AS o SET "belong_to_oid" = t."belongs_to_job_id" FROM "table" AS t WHERE t."table_id" = o."oid" AND t."belongs_to_job_id" IS NOT NULL"#,
             r#"UPDATE "object" AS o SET "belong_to_oid" = t."table_id" FROM "table" AS t WHERE t."optional_associated_source_id" = o."oid""#,
-            r#"UPDATE "object" AS o SET "belong_to_oid" = parent."table_id" FROM "sink" AS s, (SELECT d."used_by", MIN(t."table_id") AS "table_id" FROM "object_dependency" AS d JOIN "table" AS t ON t."table_id" = d."oid" AND t."engine" = 'ICEBERG' GROUP BY d."used_by" HAVING COUNT(*) = 1) AS parent WHERE s."sink_id" = o."oid" AND parent."used_by" = o."oid" AND s."name" LIKE '__iceberg_sink_%'"#,
+            r#"UPDATE "object" AS o SET "belong_to_oid" = parent."table_id" FROM "sink" AS s, (SELECT d."used_by", MIN(t."table_id") AS "table_id" FROM "object_dependency" AS d JOIN "table" AS t ON t."table_id" = d."oid" AND t."engine" = 'ICEBERG' GROUP BY d."used_by" HAVING COUNT(*) = 1) AS parent WHERE s."sink_id" = o."oid" AND parent."used_by" = o."oid" AND s."name" LIKE '!_!_iceberg!_sink!_%' ESCAPE '!'"#,
             r#"UPDATE "object" AS o SET "belong_to_oid" = parent."oid" FROM "source" AS s, "object" AS parent, "table" AS t WHERE s."source_id" = o."oid" AND parent."database_id" = o."database_id" AND parent."schema_id" = o."schema_id" AND t."table_id" = parent."oid" AND t."engine" = 'ICEBERG' AND s."name" = '__iceberg_source_' || t."name""#,
         ],
         DatabaseBackend::Sqlite => vec![
             r#"UPDATE "object" SET "belong_to_oid" = COALESCE("schema_id", "database_id")"#,
             r#"UPDATE "object" SET "belong_to_oid" = (SELECT t."belongs_to_job_id" FROM "table" AS t WHERE t."table_id" = "object"."oid") WHERE EXISTS (SELECT 1 FROM "table" AS t WHERE t."table_id" = "object"."oid" AND t."belongs_to_job_id" IS NOT NULL)"#,
             r#"UPDATE "object" SET "belong_to_oid" = (SELECT t."table_id" FROM "table" AS t WHERE t."optional_associated_source_id" = "object"."oid") WHERE EXISTS (SELECT 1 FROM "table" AS t WHERE t."optional_associated_source_id" = "object"."oid")"#,
-            r#"UPDATE "object" SET "belong_to_oid" = (SELECT MIN(t."table_id") FROM "object_dependency" AS d JOIN "table" AS t ON t."table_id" = d."oid" AND t."engine" = 'ICEBERG' WHERE d."used_by" = "object"."oid") WHERE EXISTS (SELECT 1 FROM "sink" AS s WHERE s."sink_id" = "object"."oid" AND s."name" LIKE '__iceberg_sink_%') AND (SELECT COUNT(*) FROM "object_dependency" AS d JOIN "table" AS t ON t."table_id" = d."oid" AND t."engine" = 'ICEBERG' WHERE d."used_by" = "object"."oid") = 1"#,
+            r#"UPDATE "object" SET "belong_to_oid" = (SELECT MIN(t."table_id") FROM "object_dependency" AS d JOIN "table" AS t ON t."table_id" = d."oid" AND t."engine" = 'ICEBERG' WHERE d."used_by" = "object"."oid") WHERE EXISTS (SELECT 1 FROM "sink" AS s WHERE s."sink_id" = "object"."oid" AND s."name" LIKE '!_!_iceberg!_sink!_%' ESCAPE '!') AND (SELECT COUNT(*) FROM "object_dependency" AS d JOIN "table" AS t ON t."table_id" = d."oid" AND t."engine" = 'ICEBERG' WHERE d."used_by" = "object"."oid") = 1"#,
             r#"UPDATE "object" SET "belong_to_oid" = (SELECT parent."oid" FROM "source" AS s JOIN "object" AS parent ON parent."database_id" = "object"."database_id" AND parent."schema_id" = "object"."schema_id" JOIN "table" AS t ON t."table_id" = parent."oid" AND t."engine" = 'ICEBERG' WHERE s."source_id" = "object"."oid" AND s."name" = '__iceberg_source_' || t."name") WHERE EXISTS (SELECT 1 FROM "source" AS s JOIN "object" AS parent ON parent."database_id" = "object"."database_id" AND parent."schema_id" = "object"."schema_id" JOIN "table" AS t ON t."table_id" = parent."oid" AND t."engine" = 'ICEBERG' WHERE s."source_id" = "object"."oid" AND s."name" = '__iceberg_source_' || t."name")"#,
         ],
     };
@@ -175,13 +176,13 @@ mod tests {
             r#"CREATE TABLE "sink" ("sink_id" INTEGER PRIMARY KEY, "name" TEXT)"#,
             r#"CREATE TABLE "source" ("source_id" INTEGER PRIMARY KEY, "name" TEXT)"#,
             r#"CREATE TABLE "object_dependency" ("oid" INTEGER, "used_by" INTEGER)"#,
-            r#"INSERT INTO "object" ("oid", "schema_id", "database_id") VALUES (1, NULL, NULL), (2, NULL, 1), (3, 2, 1), (4, 2, 1), (5, 2, 1), (6, 2, 1), (7, 2, 1), (8, 2, 1), (9, 2, 1), (10, 2, 1), (11, 2, 1)"#,
+            r#"INSERT INTO "object" ("oid", "schema_id", "database_id") VALUES (1, NULL, NULL), (2, NULL, 1), (3, 2, 1), (4, 2, 1), (5, 2, 1), (6, 2, 1), (7, 2, 1), (8, 2, 1), (9, 2, 1), (10, 2, 1), (11, 2, 1), (12, 2, 1)"#,
             r#"INSERT INTO "table" ("table_id", "name", "engine", "belongs_to_job_id", "optional_associated_source_id") VALUES (3, 'iceberg_table', 'ICEBERG', NULL, 5), (4, 'table_internal', 'HUMMOCK', 3, NULL), (8, 'sink_internal', 'HUMMOCK', 6, NULL), (10, 'index_internal', 'HUMMOCK', 9, NULL)"#,
             r#"INSERT INTO "index" ("index_id", "primary_table_id") VALUES (9, 3)"#,
             r#"INSERT INTO "subscription" ("subscription_id", "dependent_table_id") VALUES (11, 3)"#,
             r#"INSERT INTO "source" ("source_id", "name") VALUES (5, 'table_source'), (7, '__iceberg_source_iceberg_table')"#,
-            r#"INSERT INTO "sink" ("sink_id", "name") VALUES (6, '__iceberg_sink_renamed')"#,
-            r#"INSERT INTO "object_dependency" ("oid", "used_by") VALUES (3, 6)"#,
+            r#"INSERT INTO "sink" ("sink_id", "name") VALUES (6, '__iceberg_sink_renamed'), (12, 'myiceberg_sink_output')"#,
+            r#"INSERT INTO "object_dependency" ("oid", "used_by") VALUES (3, 6), (3, 12)"#,
         ] {
             db.execute(Statement::from_string(DatabaseBackend::Sqlite, sql))
                 .await
@@ -220,6 +221,7 @@ mod tests {
                 (9, Some(2)),
                 (10, Some(9)),
                 (11, Some(2)),
+                (12, Some(2)),
             ]
         );
 
@@ -232,11 +234,11 @@ mod tests {
         let remaining = db
             .query_one(Statement::from_string(
                 DatabaseBackend::Sqlite,
-                r#"SELECT COUNT(*) AS "count" FROM "object" WHERE "oid" IN (3, 4, 5, 6, 7, 8, 9, 10, 11)"#,
+                r#"SELECT COUNT(*) AS "count" FROM "object" WHERE "oid" IN (3, 4, 5, 6, 7, 8, 9, 10, 11, 12)"#,
             ))
             .await
             .unwrap()
             .unwrap();
-        assert_eq!(i64::try_get(&remaining, "", "count").unwrap(), 3);
+        assert_eq!(i64::try_get(&remaining, "", "count").unwrap(), 4);
     }
 }

--- a/src/meta/model/src/object.rs
+++ b/src/meta/model/src/object.rs
@@ -95,6 +95,23 @@ pub struct Model {
     pub owner_id: UserId,
     pub schema_id: Option<SchemaId>,
     pub database_id: Option<DatabaseId>,
+    /// The parent object this object belongs to. The self foreign key uses `ON DELETE CASCADE`.
+    ///
+    /// This is distinct from `object_dependency`, which records semantic references used for
+    /// dependency checks and `DROP ... CASCADE`. The belong-to rules are:
+    ///
+    /// - database: no parent;
+    /// - schema: its database;
+    /// - named schema objects, including indexes and subscriptions: their schema;
+    /// - associated sources: the relation they belong to;
+    /// - internal tables: their streaming job;
+    /// - implicit Iceberg sinks and sources: their Iceberg table.
+    ///
+    /// New objects derive `database_id` and `schema_id` from this parent in
+    /// `CatalogController::create_object`.
+    ///
+    /// Object-type validation and cycle prevention remain application responsibilities.
+    pub belong_to_oid: Option<ObjectId>,
     pub initialized_at: DateTime,
     pub created_at: DateTime,
     pub initialized_at_cluster_version: Option<String>,
@@ -129,6 +146,14 @@ pub enum Relation {
         on_delete = "Cascade"
     )]
     SelfRef1,
+    #[sea_orm(
+        belongs_to = "Entity",
+        from = "Column::BelongToOid",
+        to = "Column::Oid",
+        on_update = "NoAction",
+        on_delete = "Cascade"
+    )]
+    SelfRef3,
     #[sea_orm(
         belongs_to = "super::database::Entity",
         from = "Column::DatabaseId",

--- a/src/meta/service/src/ddl_service.rs
+++ b/src/meta/service/src/ddl_service.rs
@@ -374,7 +374,7 @@ impl DdlService for DdlServiceImpl {
             None => {
                 let version = self
                     .ddl_controller
-                    .run_command(DdlCommand::CreateNonSharedSource(source))
+                    .run_command(DdlCommand::CreateNonSharedSource(source, None))
                     .await?;
                 Ok(Response::new(CreateSourceResponse {
                     status: None,
@@ -464,7 +464,7 @@ impl DdlService for DdlServiceImpl {
             .unwrap_or_else(Self::default_streaming_job_resource_type);
         let since_timestamp_epoch = req.since_timestamp_epoch;
 
-        let stream_job = StreamingJob::Sink(sink);
+        let stream_job = StreamingJob::Sink(sink, None);
 
         let command = DdlCommand::CreateStreamingJob {
             stream_job,
@@ -881,7 +881,7 @@ impl DdlService for DdlServiceImpl {
                     resource_type,
                 } = replace_sink;
                 DdlCommand::CreateStreamingJob {
-                    stream_job: StreamingJob::Sink(sink.unwrap()),
+                    stream_job: StreamingJob::Sink(sink.unwrap(), None),
                     fragment_graph: fragment_graph.unwrap(),
                     dependencies: dependencies.into_iter().collect::<HashSet<_>>(),
                     resource_type: resource_type
@@ -1873,7 +1873,7 @@ impl DdlService for DdlServiceImpl {
 
         let table_id = table_catalog.id;
         let dependencies = HashSet::from_iter([table_id.into(), schema_id.into()]);
-        let stream_job = StreamingJob::Sink(sink);
+        let stream_job = StreamingJob::Sink(sink, Some(table_id));
         let res = self
             .ddl_controller
             .run_command(DdlCommand::CreateStreamingJob {
@@ -1932,7 +1932,10 @@ impl DdlService for DdlServiceImpl {
         let iceberg_source = iceberg_source.unwrap();
         let res = self
             .ddl_controller
-            .run_command(DdlCommand::CreateNonSharedSource(iceberg_source))
+            .run_command(DdlCommand::CreateNonSharedSource(
+                iceberg_source,
+                Some(table_id),
+            ))
             .await;
         if res.is_err() {
             let _ = self

--- a/src/meta/src/controller/catalog/alter_op.rs
+++ b/src/meta/src/controller/catalog/alter_op.rs
@@ -638,297 +638,79 @@ impl CatalogController {
             .one(&txn)
             .await?
             .ok_or_else(|| MetaError::catalog_id_not_found(object_type.as_str(), object_id))?;
+        if obj.obj_type != object_type {
+            return Err(MetaError::catalog_id_not_found(
+                object_type.as_str(),
+                object_id,
+            ));
+        }
         if obj.schema_id == Some(new_schema) {
             return Ok(IGNORED_NOTIFICATION_VERSION);
         }
-        let streaming_job = StreamingJob::find_by_id(object_id.as_job_id())
-            .one(&txn)
-            .await?;
-        let database_id = obj.database_id.unwrap();
+        let database_id = obj
+            .database_id
+            .ok_or_else(|| anyhow!("catalog object {} has no database", object_id))?;
 
-        let mut objects = vec![];
-        match object_type {
-            ObjectType::Table => {
-                let table = Table::find_by_id(object_id.as_table_id())
-                    .one(&txn)
-                    .await?
-                    .ok_or_else(|| MetaError::catalog_id_not_found("table", object_id))?;
-                check_relation_name_duplicate(&table.name, database_id, new_schema, &txn).await?;
-                let associated_src_id = table.optional_associated_source_id;
-
-                let mut obj = obj.into_active_model();
-                obj.schema_id = Set(Some(new_schema));
-                let obj = obj.update(&txn).await?;
-
-                objects.push(PbObjectInfo::Table(
-                    ObjectModel(table, obj, streaming_job).into(),
-                ));
-
-                // associated source.
-                if let Some(associated_source_id) = associated_src_id {
-                    let src_obj = object::ActiveModel {
-                        oid: Set(associated_source_id.as_object_id()),
-                        schema_id: Set(Some(new_schema)),
-                        ..Default::default()
-                    }
-                    .update(&txn)
-                    .await?;
-                    let source = Source::find_by_id(associated_source_id)
-                        .one(&txn)
-                        .await?
-                        .ok_or_else(|| {
-                            MetaError::catalog_id_not_found("source", associated_source_id)
-                        })?;
-                    objects.push(PbObjectInfo::Source(
-                        ObjectModel(source, src_obj, None).into(),
-                    ));
-                }
-
-                // indexes.
-                let (index_ids, (index_names, mut table_ids)): (
-                    Vec<IndexId>,
-                    (Vec<String>, Vec<TableId>),
-                ) = Index::find()
-                    .select_only()
-                    .columns([
-                        index::Column::IndexId,
-                        index::Column::Name,
-                        index::Column::IndexTableId,
-                    ])
-                    .filter(index::Column::PrimaryTableId.eq(object_id))
-                    .into_tuple::<(IndexId, String, TableId)>()
-                    .all(&txn)
-                    .await?
-                    .into_iter()
-                    .map(|(id, name, t_id)| (id, (name, t_id)))
-                    .unzip();
-
-                // internal tables.
-                let internal_tables: Vec<TableId> = Table::find()
-                    .select_only()
-                    .column(table::Column::TableId)
+        // Indexes are named schema objects rather than objects belonging to their primary table.
+        // Move them with a table explicitly, while subscriptions remain in their own schemas.
+        let mut objects = vec![obj];
+        if object_type == ObjectType::Table {
+            let index_ids = Index::find()
+                .select_only()
+                .column(index::Column::IndexId)
+                .filter(index::Column::PrimaryTableId.eq(object_id.as_table_id()))
+                .into_tuple::<IndexId>()
+                .all(&txn)
+                .await?;
+            objects.extend(
+                Object::find()
                     .filter(
-                        table::Column::BelongsToJobId.is_in(
-                            table_ids
-                                .iter()
-                                .map(|table_id| table_id.as_job_id())
-                                .chain(std::iter::once(object_id.as_job_id())),
-                        ),
+                        object::Column::Oid
+                            .is_in(index_ids.into_iter().map(|id| id.as_object_id())),
                     )
-                    .into_tuple()
                     .all(&txn)
-                    .await?;
-                table_ids.extend(internal_tables);
-
-                if !index_ids.is_empty() || !table_ids.is_empty() {
-                    for index_name in index_names {
-                        check_relation_name_duplicate(&index_name, database_id, new_schema, &txn)
-                            .await?;
-                    }
-
-                    Object::update_many()
-                        .col_expr(object::Column::SchemaId, new_schema.into())
-                        .filter(
-                            object::Column::Oid.is_in::<ObjectId, _>(
-                                index_ids
-                                    .iter()
-                                    .copied()
-                                    .map_into()
-                                    .chain(table_ids.iter().copied().map_into()),
-                            ),
-                        )
-                        .exec(&txn)
-                        .await?;
-                }
-
-                if !table_ids.is_empty() {
-                    let table_objs = Table::find()
-                        .find_also_related(Object)
-                        .filter(table::Column::TableId.is_in(table_ids))
-                        .all(&txn)
-                        .await?;
-                    let streaming_jobs = load_streaming_jobs_by_ids(
-                        &txn,
-                        table_objs.iter().map(|(table, _)| table.job_id()),
-                    )
-                    .await?;
-                    for (table, table_obj) in table_objs {
-                        let job_id = table.job_id();
-                        let streaming_job = streaming_jobs.get(&job_id).cloned();
-                        objects.push(PbObjectInfo::Table(
-                            ObjectModel(table, table_obj.unwrap(), streaming_job).into(),
-                        ));
-                    }
-                }
-                if !index_ids.is_empty() {
-                    let index_objs = Index::find()
-                        .find_also_related(Object)
-                        .filter(index::Column::IndexId.is_in(index_ids))
-                        .all(&txn)
-                        .await?;
-                    let streaming_jobs = load_streaming_jobs_by_ids(
-                        &txn,
-                        index_objs
-                            .iter()
-                            .map(|(index, _)| index.index_id.as_job_id()),
-                    )
-                    .await?;
-                    for (index, index_obj) in index_objs {
-                        let streaming_job =
-                            streaming_jobs.get(&index.index_id.as_job_id()).cloned();
-                        objects.push(PbObjectInfo::Index(
-                            ObjectModel(index, index_obj.unwrap(), streaming_job).into(),
-                        ));
-                    }
-                }
-            }
-            ObjectType::Source => {
-                let source = Source::find_by_id(object_id.as_source_id())
-                    .one(&txn)
-                    .await?
-                    .ok_or_else(|| MetaError::catalog_id_not_found("source", object_id))?;
-                check_relation_name_duplicate(&source.name, database_id, new_schema, &txn).await?;
-                let is_shared = source.is_shared();
-
-                let mut obj = obj.into_active_model();
-                obj.schema_id = Set(Some(new_schema));
-                let obj = obj.update(&txn).await?;
-                objects.push(PbObjectInfo::Source(ObjectModel(source, obj, None).into()));
-
-                // Note: For non-shared source, we don't update their state tables, which
-                // belongs to the MV.
-                if is_shared {
-                    update_internal_tables(
-                        &txn,
-                        object_id,
-                        object::Column::SchemaId,
-                        new_schema,
-                        &mut objects,
-                    )
-                    .await?;
-                }
-            }
-            ObjectType::Sink => {
-                let sink = Sink::find_by_id(object_id.as_sink_id())
-                    .one(&txn)
-                    .await?
-                    .ok_or_else(|| MetaError::catalog_id_not_found("sink", object_id))?;
-                check_relation_name_duplicate(&sink.name, database_id, new_schema, &txn).await?;
-
-                let mut obj = obj.into_active_model();
-                obj.schema_id = Set(Some(new_schema));
-                let obj = obj.update(&txn).await?;
-                objects.push(PbObjectInfo::Sink(
-                    ObjectModel(sink, obj, streaming_job).into(),
-                ));
-
-                update_internal_tables(
-                    &txn,
-                    object_id,
-                    object::Column::SchemaId,
-                    new_schema,
-                    &mut objects,
-                )
-                .await?;
-            }
-            ObjectType::Subscription => {
-                let subscription = Subscription::find_by_id(object_id.as_subscription_id())
-                    .one(&txn)
-                    .await?
-                    .ok_or_else(|| MetaError::catalog_id_not_found("subscription", object_id))?;
-                check_relation_name_duplicate(&subscription.name, database_id, new_schema, &txn)
-                    .await?;
-
-                let mut obj = obj.into_active_model();
-                obj.schema_id = Set(Some(new_schema));
-                let obj = obj.update(&txn).await?;
-                objects.push(PbObjectInfo::Subscription(
-                    ObjectModel(subscription, obj, None).into(),
-                ));
-            }
-            ObjectType::View => {
-                let view = View::find_by_id(object_id.as_view_id())
-                    .one(&txn)
-                    .await?
-                    .ok_or_else(|| MetaError::catalog_id_not_found("view", object_id))?;
-                check_relation_name_duplicate(&view.name, database_id, new_schema, &txn).await?;
-
-                let mut obj = obj.into_active_model();
-                obj.schema_id = Set(Some(new_schema));
-                let obj = obj.update(&txn).await?;
-                objects.push(PbObjectInfo::View(ObjectModel(view, obj, None).into()));
-            }
-            ObjectType::Function => {
-                let function = Function::find_by_id(object_id.as_function_id())
-                    .one(&txn)
-                    .await?
-                    .ok_or_else(|| MetaError::catalog_id_not_found("function", object_id))?;
-
-                let mut pb_function: PbFunction = ObjectModel(function, obj, None).into();
-                pb_function.schema_id = new_schema;
-                check_function_signature_duplicate(&pb_function, &txn).await?;
-
-                Object::update(object::ActiveModel {
-                    oid: Set(object_id),
-                    schema_id: Set(Some(new_schema)),
-                    ..Default::default()
-                })
-                .exec(&txn)
-                .await?;
-
-                txn.commit().await?;
-                let version = self
-                    .notify_frontend(
-                        NotificationOperation::Update,
-                        NotificationInfo::Function(pb_function),
-                    )
-                    .await;
-                return Ok(version);
-            }
-            ObjectType::Connection => {
-                let connection = Connection::find_by_id(object_id.as_connection_id())
-                    .one(&txn)
-                    .await?
-                    .ok_or_else(|| MetaError::catalog_id_not_found("connection", object_id))?;
-
-                let mut pb_connection: PbConnection = ObjectModel(connection, obj, None).into();
-                pb_connection.schema_id = new_schema;
-                check_connection_name_duplicate(&pb_connection, &txn).await?;
-
-                Object::update(object::ActiveModel {
-                    oid: Set(object_id),
-                    schema_id: Set(Some(new_schema)),
-                    ..Default::default()
-                })
-                .exec(&txn)
-                .await?;
-
-                txn.commit().await?;
-                let version = self
-                    .notify_frontend(
-                        NotificationOperation::Update,
-                        NotificationInfo::Connection(pb_connection),
-                    )
-                    .await;
-                return Ok(version);
-            }
-            _ => unreachable!("not supported object type: {:?}", object_type),
+                    .await?,
+            );
         }
+
+        let object_ids = objects.iter().map(|object| object.oid).collect_vec();
+        let belonging_objects = get_belong_objects_by_ids(&txn, object_ids.iter().copied()).await?;
+        objects.extend(belonging_objects.iter().cloned());
+        let mut object_models = load_object_models(&txn, &objects).await?;
+
+        prepare_object_models_for_schema_change(&txn, &mut object_models, database_id, new_schema)
+            .await?;
+        Object::update_many()
+            .col_expr(object::Column::SchemaId, new_schema.into())
+            .col_expr(
+                object::Column::BelongToOid,
+                new_schema.as_object_id().into(),
+            )
+            .filter(object::Column::Oid.is_in(object_ids))
+            .exec(&txn)
+            .await?;
+        if !belonging_objects.is_empty() {
+            Object::update_many()
+                .col_expr(object::Column::SchemaId, new_schema.into())
+                .filter(
+                    object::Column::Oid.is_in(belonging_objects.iter().map(|object| object.oid)),
+                )
+                .exec(&txn)
+                .await?;
+        }
+        let notification = NotificationInfo::ObjectGroup(PbObjectGroup {
+            objects: object_models
+                .into_iter()
+                .map(|object_info| PbObject {
+                    object_info: Some(object_info),
+                })
+                .collect(),
+            dependencies: vec![],
+        });
 
         txn.commit().await?;
         let version = self
-            .notify_frontend(
-                Operation::Update,
-                Info::ObjectGroup(PbObjectGroup {
-                    objects: objects
-                        .into_iter()
-                        .map(|relation_info| PbObject {
-                            object_info: Some(relation_info),
-                        })
-                        .collect_vec(),
-                    dependencies: vec![],
-                }),
-            )
+            .notify_frontend(NotificationOperation::Update, notification)
             .await;
         Ok(version)
     }

--- a/src/meta/src/controller/catalog/create_op.rs
+++ b/src/meta/src/controller/catalog/create_op.rs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 use risingwave_common::cast::datetime_to_timestamp_millis;
-use risingwave_common::catalog::{ICEBERG_SINK_PREFIX, ICEBERG_SOURCE_PREFIX};
 use risingwave_common::system_param::{OverrideValidate, Validate};
 use risingwave_common::util::epoch::Epoch;
 use risingwave_pb::common::PbObjectType;
@@ -27,15 +26,56 @@ impl CatalogController {
         txn: &DatabaseTransaction,
         obj_type: ObjectType,
         owner_id: UserId,
-        database_id: Option<DatabaseId>,
-        schema_id: Option<SchemaId>,
+        belong_to_oid: Option<ObjectId>,
     ) -> MetaResult<object::Model> {
+        let (database_id, schema_id) = match (obj_type, belong_to_oid) {
+            (ObjectType::Database, None) => (None, None),
+            (ObjectType::Database, Some(_)) => {
+                return Err(MetaError::invalid_parameter(
+                    "database object must not have a parent",
+                ));
+            }
+            (ObjectType::Schema, Some(database_oid)) => {
+                let database = Object::find_by_id(database_oid)
+                    .one(txn)
+                    .await?
+                    .ok_or_else(|| MetaError::catalog_id_not_found("database", database_oid))?;
+                if database.obj_type != ObjectType::Database {
+                    return Err(MetaError::invalid_parameter(
+                        "schema object must belong to a database",
+                    ));
+                }
+                (Some(database_oid.as_database_id()), None)
+            }
+            (ObjectType::Schema, None) => {
+                return Err(MetaError::invalid_parameter(
+                    "schema object must belong to a database",
+                ));
+            }
+            (_, Some(parent_oid)) => {
+                let parent = Object::find_by_id(parent_oid)
+                    .one(txn)
+                    .await?
+                    .ok_or_else(|| MetaError::catalog_id_not_found("parent object", parent_oid))?;
+                if parent.obj_type == ObjectType::Schema {
+                    (parent.database_id, Some(parent.oid.as_schema_id()))
+                } else {
+                    (parent.database_id, parent.schema_id)
+                }
+            }
+            (_, None) => {
+                return Err(MetaError::invalid_parameter(
+                    "non-database object must have a parent",
+                ));
+            }
+        };
         let active_db = object::ActiveModel {
             oid: Default::default(),
             obj_type: Set(obj_type),
             owner_id: Set(owner_id),
             schema_id: Set(schema_id),
             database_id: Set(database_id),
+            belong_to_oid: Set(belong_to_oid),
             initialized_at: Default::default(),
             created_at: Default::default(),
             initialized_at_cluster_version: Set(Some(current_cluster_version())),
@@ -62,21 +102,15 @@ impl CatalogController {
         ensure_user_id(owner_id, &txn).await?;
         check_database_name_duplicate(&db.name, &txn).await?;
 
-        let db_obj = Self::create_object(&txn, ObjectType::Database, owner_id, None, None).await?;
+        let db_obj = Self::create_object(&txn, ObjectType::Database, owner_id, None).await?;
         let mut db: database::ActiveModel = db.into();
         db.database_id = Set(db_obj.oid.as_database_id());
         let db = db.insert(&txn).await?;
 
         let mut schemas = vec![];
         for schema_name in iter::once(DEFAULT_SCHEMA_NAME).chain(SYSTEM_SCHEMAS) {
-            let schema_obj = Self::create_object(
-                &txn,
-                ObjectType::Schema,
-                owner_id,
-                Some(db_obj.oid.as_database_id()),
-                None,
-            )
-            .await?;
+            let schema_obj =
+                Self::create_object(&txn, ObjectType::Schema, owner_id, Some(db_obj.oid)).await?;
             let schema = schema::ActiveModel {
                 schema_id: Set(schema_obj.oid.as_schema_id()),
                 name: Set(schema_name.into()),
@@ -113,8 +147,7 @@ impl CatalogController {
             &txn,
             ObjectType::Schema,
             owner_id,
-            Some(schema.database_id),
-            None,
+            Some(schema.database_id.as_object_id()),
         )
         .await?;
         let mut schema: schema::ActiveModel = schema.into();
@@ -157,8 +190,7 @@ impl CatalogController {
             &txn,
             ObjectType::Subscription,
             pb_subscription.owner as _,
-            Some(pb_subscription.database_id),
-            Some(pb_subscription.schema_id),
+            Some(pb_subscription.schema_id.as_object_id()),
         )
         .await?;
         pb_subscription.id = obj.oid.as_subscription_id();
@@ -180,6 +212,7 @@ impl CatalogController {
     pub async fn create_source(
         &self,
         mut pb_source: PbSource,
+        iceberg_table_id: Option<TableId>,
     ) -> MetaResult<(SourceId, NotificationVersion)> {
         let mut inner = self.inner.write().await;
         let owner_id = pb_source.owner as _;
@@ -203,8 +236,9 @@ impl CatalogController {
             &txn,
             ObjectType::Source,
             owner_id,
-            Some(pb_source.database_id),
-            Some(pb_source.schema_id),
+            iceberg_table_id
+                .map(TableId::as_object_id)
+                .or(Some(pb_source.schema_id.as_object_id())),
         )
         .await?;
         let source_id = source_obj.oid.as_source_id();
@@ -248,44 +282,29 @@ impl CatalogController {
         let mut job_notifications = vec![];
         let mut updated_user_info = vec![];
         // check if it belongs to iceberg table
-        if pb_source.name.starts_with(ICEBERG_SOURCE_PREFIX) {
+        if let Some(table_id) = iceberg_table_id {
             // 1. finish iceberg table job.
-            let table_name = pb_source.name.trim_start_matches(ICEBERG_SOURCE_PREFIX);
-            let table_id = Table::find()
-                .select_only()
-                .column(table::Column::TableId)
-                .join(JoinType::InnerJoin, table::Relation::Object1.def())
-                .filter(
-                    object::Column::DatabaseId
-                        .eq(pb_source.database_id)
-                        .and(object::Column::SchemaId.eq(pb_source.schema_id))
-                        .and(table::Column::Name.eq(table_name)),
-                )
-                .into_tuple::<TableId>()
-                .one(&txn)
-                .await?
-                .ok_or(MetaError::from(anyhow!("table {} not found", table_name)))?;
             let table_notifications = self
                 .finish_streaming_job_inner(&txn, table_id.as_job_id())
                 .await?;
             job_notifications.push((table_id.as_job_id(), table_notifications));
 
             // 2. finish iceberg sink job.
-            let sink_name = format!("{}{}", ICEBERG_SINK_PREFIX, table_name);
             let sink_id = Sink::find()
                 .select_only()
                 .column(sink::Column::SinkId)
                 .join(JoinType::InnerJoin, sink::Relation::Object.def())
                 .filter(
-                    object::Column::DatabaseId
-                        .eq(pb_source.database_id)
-                        .and(object::Column::SchemaId.eq(pb_source.schema_id))
-                        .and(sink::Column::Name.eq(&sink_name)),
+                    object::Column::BelongToOid
+                        .eq(table_id)
+                        .and(object::Column::ObjType.eq(ObjectType::Sink)),
                 )
                 .into_tuple::<SinkId>()
                 .one(&txn)
                 .await?
-                .ok_or(MetaError::from(anyhow!("sink {} not found", sink_name)))?;
+                .ok_or_else(|| {
+                    MetaError::catalog_id_not_found("iceberg sink for table", table_id)
+                })?;
             let sink_job_id = sink_id.as_job_id();
             let sink_notifications = self.finish_streaming_job_inner(&txn, sink_job_id).await?;
             job_notifications.push((sink_job_id, sink_notifications));
@@ -356,8 +375,7 @@ impl CatalogController {
             &txn,
             ObjectType::Function,
             owner_id,
-            Some(pb_function.database_id),
-            Some(pb_function.schema_id),
+            Some(pb_function.schema_id.as_object_id()),
         )
         .await?;
         pb_function.id = function_obj.oid.as_function_id();
@@ -414,8 +432,7 @@ impl CatalogController {
             &txn,
             ObjectType::Connection,
             owner_id,
-            Some(pb_connection.database_id),
-            Some(pb_connection.schema_id),
+            Some(pb_connection.schema_id.as_object_id()),
         )
         .await?;
         pb_connection.id = conn_obj.oid.as_connection_id();
@@ -499,8 +516,7 @@ impl CatalogController {
             &txn,
             ObjectType::Secret,
             owner_id,
-            Some(pb_secret.database_id),
-            Some(pb_secret.schema_id),
+            Some(pb_secret.schema_id.as_object_id()),
         )
         .await?;
         pb_secret.id = secret_obj.oid.as_secret_id();
@@ -557,8 +573,7 @@ impl CatalogController {
             &txn,
             ObjectType::View,
             owner_id,
-            Some(pb_view.database_id),
-            Some(pb_view.schema_id),
+            Some(pb_view.schema_id.as_object_id()),
         )
         .await?;
         pb_view.id = view_obj.oid.as_view_id();

--- a/src/meta/src/controller/catalog/drop_op.rs
+++ b/src/meta/src/controller/catalog/drop_op.rs
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use risingwave_common::catalog::{ICEBERG_SINK_PREFIX, ICEBERG_SOURCE_PREFIX};
-use risingwave_pb::catalog::PbTable;
+use risingwave_common::catalog::ICEBERG_SINK_PREFIX;
 use risingwave_pb::catalog::subscription::PbSubscriptionState;
 use risingwave_pb::telemetry::PbTelemetryDatabaseObject;
 use sea_orm::{ColumnTrait, DatabaseTransaction, EntityTrait, ModelTrait, QueryFilter};
@@ -38,7 +37,6 @@ impl CatalogController {
             .await?
             .ok_or_else(|| MetaError::catalog_id_not_found(object_type.as_str(), object_id))?;
         assert_eq!(obj.obj_type, object_type);
-        let drop_database = object_type == ObjectType::Database;
         let database_id = if object_type == ObjectType::Database {
             object_id.as_database_id()
         } else {
@@ -94,34 +92,6 @@ impl CatalogController {
                 }
             },
         };
-
-        // check iceberg source.
-        if obj.obj_type == ObjectType::Table {
-            let table_name = Table::find_by_id(object_id.as_table_id())
-                .select_only()
-                .column(table::Column::Name)
-                .into_tuple::<String>()
-                .one(&txn)
-                .await?
-                .ok_or_else(|| MetaError::catalog_id_not_found("table", object_id))?;
-            let iceberg_source = Source::find()
-                .inner_join(Object)
-                .filter(
-                    object::Column::DatabaseId
-                        .eq(database_id)
-                        .and(object::Column::SchemaId.eq(obj.schema_id.unwrap()))
-                        .and(
-                            source::Column::Name
-                                .eq(format!("{}{}", ICEBERG_SOURCE_PREFIX, table_name)),
-                        ),
-                )
-                .into_partial_model()
-                .one(&txn)
-                .await?;
-            if let Some(iceberg_source) = iceberg_source {
-                removed_objects.push(iceberg_source);
-            }
-        }
 
         removed_objects.push(obj);
         let mut removed_object_ids: HashSet<_> =
@@ -181,42 +151,38 @@ impl CatalogController {
             }
         }
 
-        // 1. Detect when an Iceberg table is part of the dependencies.
-        // 2. Drop database with iceberg tables in it is not supported.
-        if object_type != ObjectType::Table || drop_database {
-            for obj in &removed_objects {
-                // if the obj is iceberg engine table, bail out
-                if obj.obj_type == ObjectType::Table {
-                    let table = Table::find_by_id(obj.oid.as_table_id())
-                        .one(&txn)
-                        .await?
-                        .ok_or_else(|| MetaError::catalog_id_not_found("table", obj.oid))?;
-                    if matches!(table.engine, Some(table::Engine::Iceberg)) {
-                        return Err(MetaError::permission_denied(format!(
-                            "Found iceberg table in dependency: {}, please drop it manually",
-                            table.name,
-                        )));
-                    }
-                }
-            }
-        }
+        // Load all objects that belong to the dropped objects before deletion. Cascaded rows are
+        // still needed for notifications and resource cleanup.
+        let root_objects = Object::find()
+            .filter(object::Column::Oid.is_in(removed_object_ids.iter().copied()))
+            .all(&txn)
+            .await?;
+        let belonging_objects =
+            get_belong_objects_by_ids(&txn, removed_objects.iter().map(|obj| obj.oid)).await?;
+        removed_object_ids.extend(belonging_objects.iter().map(|obj| obj.oid));
+        let mut objects_to_remove = root_objects.clone();
+        objects_to_remove.extend(belonging_objects.iter().cloned());
+        let removed_catalog_models = load_object_models(&txn, &objects_to_remove).await?;
+        removed_objects.extend(belonging_objects.into_iter().map(|obj| PartialObject {
+            oid: obj.oid,
+            obj_type: obj.obj_type,
+            schema_id: obj.schema_id,
+            database_id: obj.database_id,
+        }));
 
         let removed_table_ids = removed_objects
             .iter()
             .filter(|obj| obj.obj_type == ObjectType::Table || obj.obj_type == ObjectType::Index)
             .map(|obj| obj.oid.as_table_id());
 
-        let removed_iceberg_table_sinks: Vec<PbSink> = Sink::find()
-            .find_also_related(Object)
-            .filter(
-                sink::Column::SinkId
-                    .is_in(removed_object_ids.clone())
-                    .and(sink::Column::Name.like(format!("{}%", ICEBERG_SINK_PREFIX))),
-            )
-            .all(&txn)
-            .await?
-            .into_iter()
-            .map(|(sink, obj)| ObjectModel(sink, obj.unwrap(), None).into())
+        let removed_iceberg_table_sinks: Vec<PbSink> = removed_catalog_models
+            .iter()
+            .filter_map(|object_info| match object_info {
+                PbObjectInfo::Sink(sink) if sink.name.starts_with(ICEBERG_SINK_PREFIX) => {
+                    Some(sink.clone())
+                }
+                _ => None,
+            })
             .collect();
 
         // Iceberg sinks (and the pk-index subset) can be user-created with arbitrary
@@ -224,17 +190,15 @@ impl CatalogController {
         // inspecting properties rather than by name prefix.
         let mut removed_iceberg_sink_ids: Vec<SinkId> = Vec::new();
         let mut removed_iceberg_pk_index_sink_ids: Vec<SinkId> = Vec::new();
-        for sink in Sink::find()
-            .filter(sink::Column::SinkId.is_in(removed_object_ids.clone()))
-            .all(&txn)
-            .await?
-        {
-            let properties = sink.properties.inner_ref();
-            if crate::manager::iceberg_compaction::is_iceberg_sink(properties) {
-                removed_iceberg_sink_ids.push(sink.sink_id);
-            }
-            if crate::manager::iceberg_pk_index_sink::is_iceberg_pk_index_sink(properties) {
-                removed_iceberg_pk_index_sink_ids.push(sink.sink_id);
+        for object_info in &removed_catalog_models {
+            if let PbObjectInfo::Sink(sink) = object_info {
+                if crate::manager::iceberg_compaction::is_iceberg_sink(&sink.properties) {
+                    removed_iceberg_sink_ids.push(sink.id);
+                }
+                if crate::manager::iceberg_pk_index_sink::is_iceberg_pk_index_sink(&sink.properties)
+                {
+                    removed_iceberg_pk_index_sink_ids.push(sink.id);
+                }
             }
         }
 
@@ -267,28 +231,7 @@ impl CatalogController {
             }
         }
 
-        let mut removed_state_table_ids: HashSet<_> = removed_table_ids.clone().collect();
-
-        if !drop_database {
-            // Add associated sources.
-            let removed_source_ids: Vec<SourceId> = Table::find()
-                .select_only()
-                .column(table::Column::OptionalAssociatedSourceId)
-                .filter(
-                    table::Column::TableId
-                        .is_in(removed_table_ids)
-                        .and(table::Column::OptionalAssociatedSourceId.is_not_null()),
-                )
-                .into_tuple()
-                .all(&txn)
-                .await?;
-            let removed_source_objs: Vec<PartialObject> = Object::find()
-                .filter(object::Column::Oid.is_in(removed_source_ids))
-                .into_partial_model()
-                .all(&txn)
-                .await?;
-            removed_objects.extend(removed_source_objs);
-        }
+        let removed_state_table_ids: HashSet<_> = removed_table_ids.clone().collect();
 
         let removed_source_ids: HashSet<_> = removed_objects
             .iter()
@@ -301,29 +244,6 @@ impl CatalogController {
             .filter(|obj| obj.obj_type == ObjectType::Secret)
             .map(|obj| obj.oid.as_secret_id())
             .collect();
-
-        if !removed_streaming_job_ids.is_empty() {
-            let removed_internal_table_objs: Vec<PartialObject> = Object::find()
-                .select_only()
-                .columns([
-                    object::Column::Oid,
-                    object::Column::ObjType,
-                    object::Column::SchemaId,
-                    object::Column::DatabaseId,
-                ])
-                .join(JoinType::InnerJoin, object::Relation::Table.def())
-                .filter(table::Column::BelongsToJobId.is_in(removed_streaming_job_ids.clone()))
-                .into_partial_model()
-                .all(&txn)
-                .await?;
-
-            removed_state_table_ids.extend(
-                removed_internal_table_objs
-                    .iter()
-                    .map(|obj| obj.oid.as_table_id()),
-            );
-            removed_objects.extend(removed_internal_table_objs);
-        }
 
         let removed_objects: HashMap<_, _> = removed_objects
             .into_iter()
@@ -370,23 +290,18 @@ impl CatalogController {
             .into_tuple()
             .all(&txn)
             .await?;
-        let dropped_tables = Table::find()
-            .find_also_related(Object)
-            .filter(
-                table::Column::TableId.is_in(
-                    removed_state_table_ids
-                        .iter()
-                        .copied()
-                        .collect::<HashSet<TableId>>(),
-                ),
-            )
-            .all(&txn)
-            .await?
+        let dropped_tables = removed_catalog_models
             .into_iter()
-            .map(|(table, obj)| PbTable::from(ObjectModel(table, obj.unwrap(), None)));
-        // delete all in to_drop_objects.
+            .filter_map(|object_info| match object_info {
+                PbObjectInfo::Table(table) if removed_state_table_ids.contains(&table.id) => {
+                    Some(table)
+                }
+                _ => None,
+            });
+        // Delete the explicitly selected objects. The self foreign key cascades to every object
+        // that belongs to them.
         let res = Object::delete_many()
-            .filter(object::Column::Oid.is_in(removed_objects.keys().cloned()))
+            .filter(object::Column::Oid.is_in(root_objects.iter().map(|obj| obj.oid)))
             .exec(&txn)
             .await?;
         if res.rows_affected == 0 {

--- a/src/meta/src/controller/catalog/mod.rs
+++ b/src/meta/src/controller/catalog/mod.rs
@@ -51,7 +51,7 @@ use risingwave_meta_model::{
 };
 use risingwave_pb::catalog::connection::Info as ConnectionInfo;
 use risingwave_pb::catalog::subscription::SubscriptionState;
-use risingwave_pb::catalog::table::PbTableType;
+use risingwave_pb::catalog::table::{OptionalAssociatedSourceId, PbTableType};
 use risingwave_pb::catalog::{
     PbComment, PbConnection, PbDatabase, PbFunction, PbIndex, PbSchema, PbSecret, PbSink, PbSource,
     PbSubscription, PbTable, PbView,
@@ -79,12 +79,15 @@ use tokio::sync::oneshot::Sender;
 use tokio::sync::{RwLock, RwLockReadGuard, RwLockWriteGuard};
 use tracing::info;
 
+pub(crate) use self::util::load_object_models;
 use super::utils::{
     check_subscription_name_duplicate, get_internal_tables_by_id, load_streaming_jobs_by_ids,
     rename_relation, rename_relation_refer,
 };
 use crate::controller::ObjectModel;
-use crate::controller::catalog::util::update_internal_tables;
+use crate::controller::catalog::util::{
+    prepare_object_models_for_schema_change, update_internal_tables,
+};
 use crate::controller::fragment::FragmentTypeMaskExt;
 use crate::controller::utils::*;
 use crate::manager::{
@@ -626,18 +629,29 @@ impl CatalogController {
 
         self.log_cleaned_dirty_jobs(&dirty_job_objs, &txn).await?;
 
-        let dirty_job_ids = dirty_job_objs
+        let mut dirty_objects = Object::find()
+            .filter(object::Column::Oid.is_in(dirty_job_objs.iter().map(|obj| obj.oid)))
+            .all(&txn)
+            .await?;
+        dirty_objects.extend(
+            get_belong_objects_by_ids(&txn, dirty_job_objs.iter().map(|obj| obj.oid)).await?,
+        );
+        let dirty_object_ids = dirty_objects
             .iter()
-            .map(|obj| obj.oid.as_job_id())
-            .collect_vec();
-        let dirty_sink_ids = dirty_job_objs
+            .map(|object| object.oid)
+            .collect::<HashSet<_>>();
+        let dirty_catalog_models = load_object_models(&txn, &dirty_objects).await?;
+        let dirty_job_ids = StreamingJob::find()
+            .select_only()
+            .column(streaming_job::Column::JobId)
+            .filter(streaming_job::Column::JobId.is_in(dirty_object_ids.iter().copied()))
+            .into_tuple()
+            .all(&txn)
+            .await?;
+        let dirty_sink_ids = dirty_objects
             .iter()
-            .filter(|obj| obj.obj_type == ObjectType::Sink)
-            .map(|obj| obj.oid.as_sink_id())
-            .collect_vec();
-        let dirty_job_table_ids = dirty_job_ids
-            .iter()
-            .map(|job_id| job_id.as_mv_table_id())
+            .filter(|object| object.obj_type == ObjectType::Sink)
+            .map(|object| object.oid.as_sink_id())
             .collect_vec();
         // Object deletion cascades to the fragments of the dirty streaming jobs. Keep their IDs
         // before the transaction deletes them so the serving mapping can be notified after commit.
@@ -651,92 +665,38 @@ impl CatalogController {
         // Frontend deletion is idempotent, so notify every dirty job even if frontend did not
         // observe its creating catalog or it is a temporary replacement object.
         let to_notify_objs = dirty_job_objs.clone();
+        let mut objects_to_notify = to_notify_objs.clone();
+        objects_to_notify.extend(
+            get_belong_objects_by_ids(&txn, to_notify_objs.iter().map(|obj| obj.oid))
+                .await?
+                .into_iter()
+                .map(PartialObject::from),
+        );
 
         // The source ids for dirty tables with connector.
         // FIXME: we should also clean dirty sources.
-        let dirty_associated_source_ids: Vec<SourceId> = Table::find()
-            .select_only()
-            .column(table::Column::OptionalAssociatedSourceId)
-            .filter(
-                table::Column::TableId
-                    .is_in(dirty_job_table_ids)
-                    .and(table::Column::OptionalAssociatedSourceId.is_not_null()),
-            )
-            .into_tuple()
-            .all(&txn)
-            .await?;
-        let dirty_associated_source_objs = Object::find()
-            .select_only()
-            .columns([
-                object::Column::Oid,
-                object::Column::ObjType,
-                object::Column::SchemaId,
-                object::Column::DatabaseId,
-            ])
-            .filter(
-                object::Column::Oid.is_in(
-                    dirty_associated_source_ids
-                        .iter()
-                        .map(|source_id| source_id.as_object_id()),
-                ),
-            )
-            .into_partial_model()
-            .all(&txn)
-            .await?;
-
-        let dirty_internal_state_table_ids: Vec<TableId> = Table::find()
-            .select_only()
-            .column(table::Column::TableId)
-            .filter(table::Column::BelongsToJobId.is_in(dirty_job_ids.iter().copied()))
-            .into_tuple()
-            .all(&txn)
-            .await?;
-        let dirty_state_table_ids = dirty_job_ids
+        let dirty_associated_source_ids: Vec<SourceId> = dirty_catalog_models
             .iter()
-            .map(|job_id| job_id.as_mv_table_id())
-            .chain(dirty_internal_state_table_ids.iter().copied())
+            .filter_map(|object_info| match object_info {
+                PbObjectInfo::Table(table) => {
+                    table
+                        .optional_associated_source_id
+                        .map(|source_id| match source_id {
+                            OptionalAssociatedSourceId::AssociatedSourceId(source_id) => source_id,
+                        })
+                }
+                _ => None,
+            })
             .collect_vec();
-
-        let dirty_internal_table_objs = Object::find()
-            .select_only()
-            .columns([
-                object::Column::Oid,
-                object::Column::ObjType,
-                object::Column::SchemaId,
-                object::Column::DatabaseId,
-            ])
-            .join(JoinType::InnerJoin, object::Relation::Table.def())
-            .filter(table::Column::BelongsToJobId.is_in(to_notify_objs.iter().map(|obj| obj.oid)))
-            .into_partial_model()
-            .all(&txn)
-            .await?;
-
-        let to_delete_objs: HashSet<ObjectId> = dirty_job_ids
-            .iter()
-            .map(|job_id| job_id.as_object_id())
-            .chain(
-                dirty_state_table_ids
-                    .iter()
-                    .copied()
-                    .map(|table_id| table_id.as_object_id()),
-            )
-            .chain(
-                dirty_associated_source_ids
-                    .iter()
-                    .map(|source_id| source_id.as_object_id()),
-            )
-            .collect();
-
         // Per-database recovery does not run the global Hummock purge. Keep table catalogs so the
         // caller can reuse the normal dropped-table cleanup path after the catalog rows are deleted.
         let dropped_tables = if database_id.is_some() {
-            Table::find()
-                .find_also_related(Object)
-                .filter(table::Column::TableId.is_in(dirty_state_table_ids.iter().copied()))
-                .all(&txn)
-                .await?
-                .into_iter()
-                .map(|(table, obj)| PbTable::from(ObjectModel(table, obj.unwrap(), None)))
+            dirty_catalog_models
+                .iter()
+                .filter_map(|object_info| match object_info {
+                    PbObjectInfo::Table(table) => Some(table.clone()),
+                    _ => None,
+                })
                 .collect_vec()
         } else {
             vec![]
@@ -744,7 +704,7 @@ impl CatalogController {
         let dropped_table_ids = dropped_tables.iter().map(|table| table.id).collect_vec();
 
         let res = Object::delete_many()
-            .filter(object::Column::Oid.is_in(to_delete_objs))
+            .filter(object::Column::Oid.is_in(dirty_job_objs.iter().map(|obj| obj.oid)))
             .exec(&txn)
             .await?;
         assert!(res.rows_affected > 0);
@@ -758,13 +718,7 @@ impl CatalogController {
             .notification_manager()
             .notify_serving_fragment_mapping_delete(dirty_fragment_ids);
 
-        let object_group = build_object_group_for_delete(
-            to_notify_objs
-                .into_iter()
-                .chain(dirty_internal_table_objs)
-                .chain(dirty_associated_source_objs)
-                .collect_vec(),
-        );
+        let object_group = build_object_group_for_delete(objects_to_notify);
 
         let _version = self
             .notify_frontend(NotificationOperation::Delete, object_group)

--- a/src/meta/src/controller/catalog/test.rs
+++ b/src/meta/src/controller/catalog/test.rs
@@ -1761,8 +1761,7 @@ mod tests {
             &txn,
             ObjectType::Table,
             TEST_OWNER_ID,
-            Some(TEST_DATABASE_ID),
-            Some(TEST_SCHEMA_ID),
+            Some(TEST_SCHEMA_ID.as_object_id()),
         )
         .await?;
         let table_id = table_obj.oid.as_table_id();

--- a/src/meta/src/controller/catalog/test.rs
+++ b/src/meta/src/controller/catalog/test.rs
@@ -1363,11 +1363,19 @@ mod tests {
 
         let mut inner = mgr.inner.write().await;
         let txn = inner.db.begin().await?;
+        let obj = CatalogController::create_object(
+            &txn,
+            ObjectType::Table,
+            TEST_OWNER_ID,
+            Some(TEST_SCHEMA_ID.as_object_id()),
+        )
+        .await?;
+        let job_id = obj.oid.as_job_id();
         let source_obj = CatalogController::create_object(
             &txn,
             ObjectType::Source,
             TEST_OWNER_ID,
-            Some(TEST_SCHEMA_ID.as_object_id()),
+            Some(job_id.as_object_id()),
         )
         .await?;
         Source::insert(source::ActiveModel::from(PbSource {
@@ -1380,14 +1388,6 @@ mod tests {
         }))
         .exec(&txn)
         .await?;
-        let obj = CatalogController::create_object(
-            &txn,
-            ObjectType::Table,
-            TEST_OWNER_ID,
-            Some(TEST_SCHEMA_ID.as_object_id()),
-        )
-        .await?;
-        let job_id = obj.oid.as_job_id();
 
         table::ActiveModel {
             table_id: Set(obj.oid.as_table_id()),

--- a/src/meta/src/controller/catalog/test.rs
+++ b/src/meta/src/controller/catalog/test.rs
@@ -121,8 +121,7 @@ mod tests {
             txn,
             object_type,
             TEST_OWNER_ID,
-            Some(TEST_DATABASE_ID),
-            Some(TEST_SCHEMA_ID),
+            Some(TEST_SCHEMA_ID.as_object_id()),
         )
         .await?
         .oid
@@ -136,8 +135,7 @@ mod tests {
             txn,
             ObjectType::Table,
             TEST_OWNER_ID,
-            Some(TEST_DATABASE_ID),
-            Some(TEST_SCHEMA_ID),
+            Some(job_id.as_object_id()),
         )
         .await?
         .oid
@@ -297,8 +295,7 @@ mod tests {
             &txn,
             ObjectType::Source,
             TEST_OWNER_ID,
-            Some(TEST_DATABASE_ID),
-            Some(TEST_SCHEMA_ID),
+            Some(TEST_SCHEMA_ID.as_object_id()),
         )
         .await?
         .oid
@@ -344,8 +341,7 @@ mod tests {
             &txn,
             ObjectType::Index,
             TEST_OWNER_ID,
-            Some(TEST_DATABASE_ID),
-            Some(TEST_SCHEMA_ID),
+            Some(TEST_SCHEMA_ID.as_object_id()),
         )
         .await?
         .oid
@@ -385,8 +381,7 @@ mod tests {
             &txn,
             ObjectType::Source,
             TEST_OWNER_ID,
-            Some(TEST_DATABASE_ID),
-            Some(TEST_SCHEMA_ID),
+            Some(TEST_SCHEMA_ID.as_object_id()),
         )
         .await?
         .oid
@@ -418,8 +413,7 @@ mod tests {
             &txn,
             ObjectType::Sink,
             TEST_OWNER_ID,
-            Some(TEST_DATABASE_ID),
-            Some(TEST_SCHEMA_ID),
+            Some(TEST_SCHEMA_ID.as_object_id()),
         )
         .await?
         .oid
@@ -647,8 +641,7 @@ mod tests {
             &txn,
             ObjectType::Table,
             TEST_OWNER_ID,
-            Some(TEST_DATABASE_ID),
-            Some(TEST_SCHEMA_ID),
+            Some(TEST_SCHEMA_ID.as_object_id()),
         )
         .await?;
         let job_id = job_obj.oid.as_job_id();
@@ -768,6 +761,65 @@ mod tests {
             .unwrap();
         assert_eq!(database.name, "db2");
 
+        let schema_id: SchemaId = Schema::find()
+            .inner_join(Object)
+            .select_only()
+            .column(schema::Column::SchemaId)
+            .filter(object::Column::DatabaseId.eq(database_id))
+            .into_tuple()
+            .one(&mgr.inner.read().await.db)
+            .await?
+            .unwrap();
+        mgr.create_view(
+            PbView {
+                schema_id,
+                database_id,
+                name: "cross_db_upstream".to_owned(),
+                owner: TEST_OWNER_ID as _,
+                sql: "CREATE VIEW cross_db_upstream AS SELECT 1".to_owned(),
+                ..Default::default()
+            },
+            HashSet::new(),
+        )
+        .await?;
+        let upstream_id: ViewId = View::find()
+            .inner_join(Object)
+            .select_only()
+            .column(view::Column::ViewId)
+            .filter(
+                object::Column::DatabaseId
+                    .eq(database_id)
+                    .and(view::Column::Name.eq("cross_db_upstream")),
+            )
+            .into_tuple()
+            .one(&mgr.inner.read().await.db)
+            .await?
+            .unwrap();
+
+        let inner = mgr.inner.write().await;
+        let txn = inner.db.begin().await?;
+        let (dependent_job_id, Some(dependent_table_id), _) =
+            insert_test_streaming_job(&txn, "cross_db_dependent", true, None).await?
+        else {
+            unreachable!()
+        };
+        ObjectDependency::insert(object_dependency::ActiveModel {
+            oid: Set(upstream_id.as_object_id()),
+            used_by: Set(dependent_job_id.as_object_id()),
+            ..Default::default()
+        })
+        .exec(&txn)
+        .await?;
+        txn.commit().await?;
+        drop(inner);
+
+        assert!(
+            mgr.drop_object(ObjectType::Database, database_id, DropMode::Cascade)
+                .await
+                .is_err()
+        );
+        mgr.drop_object(ObjectType::Table, dependent_table_id, DropMode::Cascade)
+            .await?;
         mgr.drop_object(ObjectType::Database, database_id, DropMode::Cascade)
             .await?;
 
@@ -836,6 +888,295 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_object_belong_to_cascade() -> MetaResult<()> {
+        let mgr = CatalogController::new(MetaSrvEnv::for_test().await).await?;
+        mgr.create_schema(PbSchema {
+            database_id: TEST_DATABASE_ID,
+            name: "belong_to_target".to_owned(),
+            owner: TEST_OWNER_ID as _,
+            ..Default::default()
+        })
+        .await?;
+        let target_schema_id: SchemaId = Schema::find()
+            .select_only()
+            .column(schema::Column::SchemaId)
+            .filter(schema::Column::Name.eq("belong_to_target"))
+            .into_tuple()
+            .one(&mgr.inner.read().await.db)
+            .await?
+            .unwrap();
+        let txn = mgr.inner.read().await.db.begin().await?;
+
+        let mv_obj = CatalogController::create_object(
+            &txn,
+            ObjectType::Table,
+            TEST_OWNER_ID,
+            Some(TEST_SCHEMA_ID.as_object_id()),
+        )
+        .await?;
+        assert_eq!(mv_obj.belong_to_oid, Some(TEST_SCHEMA_ID.as_object_id()));
+        assert_eq!(mv_obj.database_id, Some(TEST_DATABASE_ID));
+        assert_eq!(mv_obj.schema_id, Some(TEST_SCHEMA_ID));
+        let job_id = mv_obj.oid.as_job_id();
+        let mv_table_id = job_id.as_mv_table_id();
+        insert_test_table(
+            &txn,
+            mv_table_id,
+            "mv_belong_to",
+            TableType::MaterializedView,
+            None,
+            "CREATE MATERIALIZED VIEW mv_belong_to AS SELECT 1",
+        )
+        .await?;
+
+        let internal_obj = CatalogController::create_object(
+            &txn,
+            ObjectType::Table,
+            TEST_OWNER_ID,
+            Some(job_id.as_object_id()),
+        )
+        .await?;
+        assert_eq!(internal_obj.belong_to_oid, Some(job_id.as_object_id()));
+        assert_eq!(internal_obj.database_id, Some(TEST_DATABASE_ID));
+        assert_eq!(internal_obj.schema_id, Some(TEST_SCHEMA_ID));
+        let internal_table_id = internal_obj.oid.as_table_id();
+        insert_test_table(
+            &txn,
+            internal_table_id,
+            "__internal_mv_belong_to",
+            TableType::Internal,
+            Some(job_id),
+            "",
+        )
+        .await?;
+        let nested_obj = CatalogController::create_object(
+            &txn,
+            ObjectType::Table,
+            TEST_OWNER_ID,
+            Some(internal_table_id.as_object_id()),
+        )
+        .await?;
+        txn.commit().await?;
+
+        assert!(
+            mgr.alter_schema(ObjectType::Sink, job_id.as_object_id(), target_schema_id,)
+                .await
+                .is_err()
+        );
+        mgr.alter_schema(ObjectType::Table, job_id.as_object_id(), target_schema_id)
+            .await?;
+
+        let db = &mgr.inner.read().await.db;
+        let belonging_object_ids = get_belong_objects(db, job_id.as_object_id())
+            .await?
+            .into_iter()
+            .map(|object| object.oid)
+            .collect::<HashSet<_>>();
+        assert_eq!(
+            belonging_object_ids,
+            HashSet::from([internal_table_id.as_object_id(), nested_obj.oid])
+        );
+        let moved_objects = Object::find()
+            .filter(object::Column::Oid.is_in([
+                job_id.as_object_id(),
+                internal_table_id.as_object_id(),
+                nested_obj.oid,
+            ]))
+            .all(db)
+            .await?;
+        assert!(
+            moved_objects
+                .iter()
+                .all(|object| object.schema_id == Some(target_schema_id))
+        );
+        assert_eq!(
+            Object::find_by_id(internal_table_id)
+                .one(db)
+                .await?
+                .unwrap()
+                .belong_to_oid,
+            Some(job_id.as_object_id())
+        );
+        assert_eq!(
+            Object::find_by_id(nested_obj.oid)
+                .one(db)
+                .await?
+                .unwrap()
+                .belong_to_oid,
+            Some(internal_table_id.as_object_id())
+        );
+
+        Object::delete_by_id(job_id).exec(db).await?;
+
+        assert!(Object::find_by_id(job_id).one(db).await?.is_none());
+        assert!(
+            Object::find_by_id(internal_table_id)
+                .one(db)
+                .await?
+                .is_none()
+        );
+        assert!(Table::find_by_id(mv_table_id).one(db).await?.is_none());
+        assert!(
+            Table::find_by_id(internal_table_id)
+                .one(db)
+                .await?
+                .is_none()
+        );
+        assert!(Object::find_by_id(nested_obj.oid).one(db).await?.is_none());
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_alter_table_schema_moves_indexes_but_not_subscriptions() -> MetaResult<()> {
+        let mgr = CatalogController::new(MetaSrvEnv::for_test().await).await?;
+        mgr.create_schema(PbSchema {
+            database_id: TEST_DATABASE_ID,
+            name: "alter_table_target".to_owned(),
+            owner: TEST_OWNER_ID as _,
+            ..Default::default()
+        })
+        .await?;
+        let target_schema_id: SchemaId = Schema::find()
+            .select_only()
+            .column(schema::Column::SchemaId)
+            .filter(schema::Column::Name.eq("alter_table_target"))
+            .into_tuple()
+            .one(&mgr.inner.read().await.db)
+            .await?
+            .unwrap();
+
+        let txn = mgr.inner.read().await.db.begin().await?;
+        let table_obj = CatalogController::create_object(
+            &txn,
+            ObjectType::Table,
+            TEST_OWNER_ID,
+            Some(TEST_SCHEMA_ID.as_object_id()),
+        )
+        .await?;
+        let table_id = table_obj.oid.as_table_id();
+        insert_test_table(
+            &txn,
+            table_id,
+            "mv_with_index_and_subscription",
+            TableType::MaterializedView,
+            None,
+            "CREATE MATERIALIZED VIEW mv_with_index_and_subscription AS SELECT 1",
+        )
+        .await?;
+
+        let index_obj = CatalogController::create_object(
+            &txn,
+            ObjectType::Index,
+            TEST_OWNER_ID,
+            Some(TEST_SCHEMA_ID.as_object_id()),
+        )
+        .await?;
+        let index_id = index_obj.oid.as_index_id();
+        let index_table_id = index_id.as_object_id().as_table_id();
+        insert_test_table(
+            &txn,
+            index_table_id,
+            "idx_mv_with_index_and_subscription_table",
+            TableType::Index,
+            None,
+            "",
+        )
+        .await?;
+        index::ActiveModel {
+            index_id: Set(index_id),
+            name: Set("idx_mv_with_index_and_subscription".to_owned()),
+            index_table_id: Set(index_table_id),
+            primary_table_id: Set(table_id),
+            index_items: Set(Vec::<risingwave_pb::expr::ExprNode>::new().into()),
+            index_column_properties: Set(None),
+            index_columns_len: Set(0),
+        }
+        .insert(&txn)
+        .await?;
+
+        let index_internal_obj = CatalogController::create_object(
+            &txn,
+            ObjectType::Table,
+            TEST_OWNER_ID,
+            Some(index_id.as_object_id()),
+        )
+        .await?;
+        let index_internal_table_id = index_internal_obj.oid.as_table_id();
+        insert_test_table(
+            &txn,
+            index_internal_table_id,
+            "__internal_idx_mv_with_index_and_subscription",
+            TableType::Internal,
+            Some(index_id.as_job_id()),
+            "",
+        )
+        .await?;
+        txn.commit().await?;
+
+        let mut subscription = PbSubscription {
+            name: "subscription_in_original_schema".to_owned(),
+            definition: "CREATE SUBSCRIPTION subscription_in_original_schema FROM mv_with_index_and_subscription".to_owned(),
+            retention_seconds: 86400,
+            database_id: TEST_DATABASE_ID,
+            schema_id: TEST_SCHEMA_ID,
+            dependent_table_id: table_id,
+            owner: TEST_OWNER_ID as _,
+            subscription_state: SubscriptionState::Created as _,
+            ..Default::default()
+        };
+        mgr.create_subscription_catalog(&mut subscription).await?;
+
+        {
+            let inner = mgr.inner.read().await;
+            assert_eq!(
+                Object::find_by_id(index_id)
+                    .one(&inner.db)
+                    .await?
+                    .unwrap()
+                    .belong_to_oid,
+                Some(TEST_SCHEMA_ID.as_object_id())
+            );
+            assert_eq!(
+                Object::find_by_id(subscription.id)
+                    .one(&inner.db)
+                    .await?
+                    .unwrap()
+                    .belong_to_oid,
+                Some(TEST_SCHEMA_ID.as_object_id())
+            );
+        }
+
+        mgr.alter_schema(ObjectType::Table, table_id.as_object_id(), target_schema_id)
+            .await?;
+
+        let db = &mgr.inner.read().await.db;
+        for object_id in [table_id.as_object_id(), index_id.as_object_id()] {
+            let object = Object::find_by_id(object_id).one(db).await?.unwrap();
+            assert_eq!(object.schema_id, Some(target_schema_id));
+            assert_eq!(object.belong_to_oid, Some(target_schema_id.as_object_id()));
+        }
+        let index_internal_object = Object::find_by_id(index_internal_table_id)
+            .one(db)
+            .await?
+            .unwrap();
+        assert_eq!(index_internal_object.schema_id, Some(target_schema_id));
+        assert_eq!(
+            index_internal_object.belong_to_oid,
+            Some(index_id.as_object_id())
+        );
+
+        let subscription_object = Object::find_by_id(subscription.id).one(db).await?.unwrap();
+        assert_eq!(subscription_object.schema_id, Some(TEST_SCHEMA_ID));
+        assert_eq!(
+            subscription_object.belong_to_oid,
+            Some(TEST_SCHEMA_ID.as_object_id())
+        );
+
+        Ok(())
+    }
+
+    #[tokio::test]
     async fn test_create_function() -> MetaResult<()> {
         let mgr = CatalogController::new(MetaSrvEnv::for_test().await).await?;
         let test_data_type = risingwave_pb::data::DataType {
@@ -874,6 +1215,36 @@ mod tests {
         assert_eq!(function.arg_types.to_protobuf().len(), 1);
         assert_eq!(function.language, "python");
 
+        mgr.create_schema(PbSchema {
+            database_id: TEST_DATABASE_ID,
+            name: "function_target".to_owned(),
+            owner: TEST_OWNER_ID as _,
+            ..Default::default()
+        })
+        .await?;
+        let target_schema_id: SchemaId = Schema::find()
+            .select_only()
+            .column(schema::Column::SchemaId)
+            .filter(schema::Column::Name.eq("function_target"))
+            .into_tuple()
+            .one(&mgr.inner.read().await.db)
+            .await?
+            .unwrap();
+        mgr.alter_schema(
+            ObjectType::Function,
+            function.function_id.as_object_id(),
+            target_schema_id,
+        )
+        .await?;
+        assert_eq!(
+            Object::find_by_id(function.function_id)
+                .one(&mgr.inner.read().await.db)
+                .await?
+                .unwrap()
+                .schema_id,
+            Some(target_schema_id)
+        );
+
         mgr.drop_object(
             ObjectType::Function,
             function.function_id,
@@ -910,7 +1281,7 @@ mod tests {
             }),
             ..Default::default()
         };
-        mgr.create_source(pb_source).await?;
+        mgr.create_source(pb_source, None).await?;
         let source_id: SourceId = Source::find()
             .select_only()
             .column(source::Column::SourceId)
@@ -996,8 +1367,7 @@ mod tests {
             &txn,
             ObjectType::Source,
             TEST_OWNER_ID,
-            Some(TEST_DATABASE_ID),
-            Some(TEST_SCHEMA_ID),
+            Some(TEST_SCHEMA_ID.as_object_id()),
         )
         .await?;
         Source::insert(source::ActiveModel::from(PbSource {
@@ -1014,8 +1384,7 @@ mod tests {
             &txn,
             ObjectType::Table,
             TEST_OWNER_ID,
-            Some(TEST_DATABASE_ID),
-            Some(TEST_SCHEMA_ID),
+            Some(TEST_SCHEMA_ID.as_object_id()),
         )
         .await?;
         let job_id = obj.oid.as_job_id();
@@ -1058,6 +1427,24 @@ mod tests {
             cdc_table_type: Set(None),
         }
         .insert(&txn)
+        .await?;
+
+        let internal_obj = CatalogController::create_object(
+            &txn,
+            ObjectType::Table,
+            TEST_OWNER_ID,
+            Some(job_id.as_object_id()),
+        )
+        .await?;
+        let internal_table_id = internal_obj.oid.as_table_id();
+        insert_test_table(
+            &txn,
+            internal_table_id,
+            "__internal_mv_abort_initial",
+            TableType::Internal,
+            Some(job_id),
+            "",
+        )
         .await?;
 
         streaming_job::ActiveModel {
@@ -1104,6 +1491,25 @@ mod tests {
                 .is_none()
         );
         assert!(
+            Object::find_by_id(internal_table_id)
+                .one(db)
+                .await?
+                .is_none()
+        );
+        assert!(
+            Table::find_by_id(internal_table_id)
+                .one(db)
+                .await?
+                .is_none()
+        );
+        assert!(
+            mgr.inner
+                .read()
+                .await
+                .dropped_tables
+                .contains_key(&internal_table_id)
+        );
+        assert!(
             Source::find_by_id(source_obj.oid.as_source_id())
                 .one(db)
                 .await?
@@ -1143,8 +1549,7 @@ mod tests {
             &txn,
             ObjectType::Table,
             TEST_OWNER_ID,
-            Some(TEST_DATABASE_ID),
-            Some(TEST_SCHEMA_ID),
+            Some(TEST_SCHEMA_ID.as_object_id()),
         )
         .await?;
         let job_id = mv_obj.oid.as_job_id();
@@ -1163,8 +1568,7 @@ mod tests {
             &txn,
             ObjectType::Table,
             TEST_OWNER_ID,
-            Some(TEST_DATABASE_ID),
-            Some(TEST_SCHEMA_ID),
+            Some(job_id.as_object_id()),
         )
         .await?;
         let internal_table_id = internal_obj.oid.as_table_id();
@@ -1212,6 +1616,12 @@ mod tests {
         assert!(inner.dropped_tables.contains_key(&mv_table_id));
         assert!(inner.dropped_tables.contains_key(&internal_table_id));
         assert!(Object::find_by_id(job_id).one(&inner.db).await?.is_none());
+        assert!(
+            Object::find_by_id(internal_table_id)
+                .one(&inner.db)
+                .await?
+                .is_none()
+        );
         assert!(
             StreamingJob::find_by_id(job_id)
                 .one(&inner.db)

--- a/src/meta/src/controller/catalog/test.rs
+++ b/src/meta/src/controller/catalog/test.rs
@@ -25,6 +25,7 @@ mod tests {
     use risingwave_pb::stream_plan::PbStreamNode;
     use tokio::sync::{mpsc, oneshot};
 
+    use crate::barrier::Command;
     use crate::controller::catalog::*;
     use crate::manager::{LocalNotification, WorkerKey};
     use crate::model::FragmentDownstreamRelation;
@@ -183,6 +184,142 @@ mod tests {
         }
         .insert(txn)
         .await?;
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_cancel_creating_job_includes_belonging_streaming_jobs() -> MetaResult<()> {
+        let mgr = CatalogController::new(MetaSrvEnv::for_test().await).await?;
+        let mut inner = mgr.inner.write().await;
+        let txn = inner.db.begin().await?;
+
+        let table_job_id = CatalogController::create_object(
+            &txn,
+            ObjectType::Table,
+            TEST_OWNER_ID,
+            Some(TEST_SCHEMA_ID.as_object_id()),
+        )
+        .await?
+        .oid
+        .as_job_id();
+        insert_test_table(
+            &txn,
+            table_job_id.as_mv_table_id(),
+            "cancel_table",
+            TableType::Table,
+            None,
+            "",
+        )
+        .await?;
+        let sink_job_id = CatalogController::create_object(
+            &txn,
+            ObjectType::Sink,
+            TEST_OWNER_ID,
+            Some(table_job_id.as_object_id()),
+        )
+        .await?
+        .oid
+        .as_job_id();
+        Sink::insert(sink::ActiveModel::from(PbSink {
+            id: sink_job_id.as_sink_id(),
+            schema_id: TEST_SCHEMA_ID,
+            database_id: TEST_DATABASE_ID,
+            name: "cancel_sink".to_owned(),
+            owner: TEST_OWNER_ID as _,
+            sink_type: PbSinkType::AppendOnly as i32,
+            ..Default::default()
+        }))
+        .exec(&txn)
+        .await?;
+        for job_id in [table_job_id, sink_job_id] {
+            insert_test_streaming_job_model(&txn, job_id, None).await?;
+            StreamingJob::update(streaming_job::ActiveModel {
+                job_id: Set(job_id),
+                job_status: Set(JobStatus::Creating),
+                ..Default::default()
+            })
+            .exec(&txn)
+            .await?;
+        }
+
+        let table_state_id = TableId::new(1000);
+        let sink_state_id = TableId::new(1001);
+        insert_test_fragment(
+            &txn,
+            FragmentId::new(100),
+            table_job_id,
+            TableIdArray(vec![table_state_id]),
+        )
+        .await?;
+        insert_test_fragment(
+            &txn,
+            FragmentId::new(101),
+            sink_job_id,
+            TableIdArray(vec![sink_state_id]),
+        )
+        .await?;
+        let (table_finish_tx, table_finish_rx) = oneshot::channel();
+        inner.register_finish_notifier(TEST_DATABASE_ID, table_job_id, table_finish_tx);
+        let (sink_finish_tx, sink_finish_rx) = oneshot::channel();
+        inner.register_finish_notifier(TEST_DATABASE_ID, sink_job_id, sink_finish_tx);
+        txn.commit().await?;
+        drop(inner);
+
+        let abort_result = mgr
+            .try_abort_creating_streaming_job(table_job_id, true)
+            .await?;
+        assert!(abort_result.aborted);
+        assert_eq!(
+            abort_result.aborted_sink_ids,
+            vec![sink_job_id.as_sink_id()]
+        );
+        let cancel_info = abort_result
+            .cancel_info
+            .expect("cancelled table job should have cleanup information");
+        assert_eq!(
+            cancel_info
+                .streaming_job_ids
+                .iter()
+                .copied()
+                .collect::<HashSet<_>>(),
+            HashSet::from([table_job_id, sink_job_id])
+        );
+        assert_eq!(
+            cancel_info
+                .state_table_ids
+                .iter()
+                .copied()
+                .collect::<HashSet<_>>(),
+            HashSet::from([table_state_id, sink_state_id])
+        );
+        let Command::DropStreamingJobs {
+            streaming_job_ids,
+            unregistered_state_table_ids,
+            ..
+        } = cancel_info.command
+        else {
+            unreachable!()
+        };
+        assert_eq!(
+            streaming_job_ids,
+            HashSet::from([table_job_id, sink_job_id])
+        );
+        assert_eq!(
+            unregistered_state_table_ids,
+            HashSet::from([table_state_id, sink_state_id])
+        );
+
+        for finish_rx in [table_finish_rx, sink_finish_rx] {
+            let err = finish_rx
+                .await
+                .expect("aborted job should notify its finish waiter")
+                .expect_err("aborted job should not finish successfully");
+            assert!(err.contains("cancelled"));
+        }
+        let db = &mgr.inner.read().await.db;
+        assert!(Object::find_by_id(table_job_id).one(db).await?.is_none());
+        assert!(Object::find_by_id(sink_job_id).one(db).await?.is_none());
 
         Ok(())
     }

--- a/src/meta/src/controller/catalog/util.rs
+++ b/src/meta/src/controller/catalog/util.rs
@@ -18,6 +18,289 @@ use super::*;
 use crate::controller::fragment::FragmentTypeMaskExt;
 use crate::controller::utils::load_streaming_jobs_by_ids;
 
+pub(crate) async fn prepare_object_models_for_schema_change(
+    txn: &DatabaseTransaction,
+    object_models: &mut [PbObjectInfo],
+    database_id: DatabaseId,
+    new_schema: SchemaId,
+) -> MetaResult<()> {
+    // Names live in the type-specific catalog tables, not in `object`. Relations also share a
+    // namespace across object types, so preserve the existing type-specific duplicate checks.
+    let index_ids = object_models
+        .iter()
+        .filter_map(|object_info| match object_info {
+            PbObjectInfo::Index(index) => Some(index.id.as_object_id().as_table_id()),
+            _ => None,
+        })
+        .collect::<HashSet<_>>();
+
+    for object_info in object_models {
+        match object_info {
+            PbObjectInfo::Table(table) => table.schema_id = new_schema,
+            PbObjectInfo::Source(source) => source.schema_id = new_schema,
+            PbObjectInfo::Sink(sink) => sink.schema_id = new_schema,
+            PbObjectInfo::View(view) => view.schema_id = new_schema,
+            PbObjectInfo::Index(index) => index.schema_id = new_schema,
+            PbObjectInfo::Function(function) => function.schema_id = new_schema,
+            PbObjectInfo::Connection(connection) => connection.schema_id = new_schema,
+            PbObjectInfo::Subscription(subscription) => subscription.schema_id = new_schema,
+            PbObjectInfo::Secret(secret) => secret.schema_id = new_schema,
+            PbObjectInfo::Database(_) | PbObjectInfo::Schema(_) => {}
+        }
+
+        match object_info {
+            PbObjectInfo::Table(table) if !index_ids.contains(&table.id) => {
+                check_relation_name_duplicate(&table.name, database_id, new_schema, txn).await?;
+            }
+            PbObjectInfo::Source(source) => {
+                check_relation_name_duplicate(&source.name, database_id, new_schema, txn).await?;
+            }
+            PbObjectInfo::Sink(sink) => {
+                check_relation_name_duplicate(&sink.name, database_id, new_schema, txn).await?;
+            }
+            PbObjectInfo::Index(index) => {
+                check_relation_name_duplicate(&index.name, database_id, new_schema, txn).await?;
+            }
+            PbObjectInfo::View(view) => {
+                check_relation_name_duplicate(&view.name, database_id, new_schema, txn).await?;
+            }
+            PbObjectInfo::Subscription(subscription) => {
+                check_relation_name_duplicate(&subscription.name, database_id, new_schema, txn)
+                    .await?;
+                check_subscription_name_duplicate(subscription, txn).await?;
+            }
+            PbObjectInfo::Function(function) => {
+                check_function_signature_duplicate(function, txn).await?;
+            }
+            PbObjectInfo::Connection(connection) => {
+                check_connection_name_duplicate(connection, txn).await?;
+            }
+            PbObjectInfo::Secret(secret) => {
+                check_secret_name_duplicate(secret, txn).await?;
+            }
+            PbObjectInfo::Database(_) | PbObjectInfo::Schema(_) | PbObjectInfo::Table(_) => {}
+        }
+    }
+
+    Ok(())
+}
+
+pub(crate) async fn load_object_models(
+    txn: &DatabaseTransaction,
+    objects: &[object::Model],
+) -> MetaResult<Vec<PbObjectInfo>> {
+    let mut object_infos = vec![];
+
+    let table_ids = objects
+        .iter()
+        .filter(|object| object.obj_type == ObjectType::Table)
+        .map(|object| object.oid.as_table_id())
+        .collect_vec();
+    let table_objs = Table::find()
+        .find_also_related(Object)
+        .filter(table::Column::TableId.is_in(table_ids))
+        .all(txn)
+        .await?;
+    let streaming_jobs =
+        load_streaming_jobs_by_ids(txn, table_objs.iter().map(|(table, _)| table.job_id())).await?;
+    for (table, table_obj) in table_objs {
+        let streaming_job = streaming_jobs.get(&table.job_id()).cloned();
+        object_infos.push(PbObjectInfo::Table(
+            ObjectModel(table, table_obj.unwrap(), streaming_job).into(),
+        ));
+    }
+
+    let index_ids = objects
+        .iter()
+        .filter(|object| object.obj_type == ObjectType::Index)
+        .map(|object| object.oid.as_index_id())
+        .collect_vec();
+    let index_table_objs = Table::find()
+        .find_also_related(Object)
+        .filter(
+            table::Column::TableId
+                .is_in(index_ids.iter().map(|id| id.as_object_id().as_table_id())),
+        )
+        .all(txn)
+        .await?;
+    let index_streaming_jobs = load_streaming_jobs_by_ids(
+        txn,
+        index_table_objs.iter().map(|(table, _)| table.job_id()),
+    )
+    .await?;
+    for (table, table_obj) in index_table_objs {
+        let streaming_job = index_streaming_jobs.get(&table.job_id()).cloned();
+        object_infos.push(PbObjectInfo::Table(
+            ObjectModel(table, table_obj.unwrap(), streaming_job).into(),
+        ));
+    }
+    let index_objs = Index::find()
+        .find_also_related(Object)
+        .filter(index::Column::IndexId.is_in(index_ids))
+        .all(txn)
+        .await?;
+    for (index, index_obj) in index_objs {
+        let streaming_job = index_streaming_jobs
+            .get(&index.index_id.as_job_id())
+            .cloned();
+        object_infos.push(PbObjectInfo::Index(
+            ObjectModel(index, index_obj.unwrap(), streaming_job).into(),
+        ));
+    }
+
+    let source_ids = objects
+        .iter()
+        .filter(|object| object.obj_type == ObjectType::Source)
+        .map(|object| object.oid.as_source_id())
+        .collect_vec();
+    for (source, source_obj) in Source::find()
+        .find_also_related(Object)
+        .filter(source::Column::SourceId.is_in(source_ids))
+        .all(txn)
+        .await?
+    {
+        object_infos.push(PbObjectInfo::Source(
+            ObjectModel(source, source_obj.unwrap(), None).into(),
+        ));
+    }
+
+    let sink_ids = objects
+        .iter()
+        .filter(|object| object.obj_type == ObjectType::Sink)
+        .map(|object| object.oid.as_sink_id())
+        .collect_vec();
+    let sink_objs = Sink::find()
+        .find_also_related(Object)
+        .filter(sink::Column::SinkId.is_in(sink_ids))
+        .all(txn)
+        .await?;
+    let sink_streaming_jobs = load_streaming_jobs_by_ids(
+        txn,
+        sink_objs.iter().map(|(sink, _)| sink.sink_id.as_job_id()),
+    )
+    .await?;
+    for (sink, sink_obj) in sink_objs {
+        let streaming_job = sink_streaming_jobs.get(&sink.sink_id.as_job_id()).cloned();
+        object_infos.push(PbObjectInfo::Sink(
+            ObjectModel(sink, sink_obj.unwrap(), streaming_job).into(),
+        ));
+    }
+
+    let subscription_ids = objects
+        .iter()
+        .filter(|object| object.obj_type == ObjectType::Subscription)
+        .map(|object| object.oid.as_subscription_id())
+        .collect_vec();
+    for (subscription, subscription_obj) in Subscription::find()
+        .find_also_related(Object)
+        .filter(subscription::Column::SubscriptionId.is_in(subscription_ids))
+        .all(txn)
+        .await?
+    {
+        object_infos.push(PbObjectInfo::Subscription(
+            ObjectModel(subscription, subscription_obj.unwrap(), None).into(),
+        ));
+    }
+
+    let view_ids = objects
+        .iter()
+        .filter(|object| object.obj_type == ObjectType::View)
+        .map(|object| object.oid.as_view_id())
+        .collect_vec();
+    for (view, view_obj) in View::find()
+        .find_also_related(Object)
+        .filter(view::Column::ViewId.is_in(view_ids))
+        .all(txn)
+        .await?
+    {
+        object_infos.push(PbObjectInfo::View(
+            ObjectModel(view, view_obj.unwrap(), None).into(),
+        ));
+    }
+
+    let function_ids = objects
+        .iter()
+        .filter(|object| object.obj_type == ObjectType::Function)
+        .map(|object| object.oid.as_function_id())
+        .collect_vec();
+    for (function, function_obj) in Function::find()
+        .find_also_related(Object)
+        .filter(function::Column::FunctionId.is_in(function_ids))
+        .all(txn)
+        .await?
+    {
+        object_infos.push(PbObjectInfo::Function(
+            ObjectModel(function, function_obj.unwrap(), None).into(),
+        ));
+    }
+
+    let connection_ids = objects
+        .iter()
+        .filter(|object| object.obj_type == ObjectType::Connection)
+        .map(|object| object.oid.as_connection_id())
+        .collect_vec();
+    for (connection, connection_obj) in Connection::find()
+        .find_also_related(Object)
+        .filter(connection::Column::ConnectionId.is_in(connection_ids))
+        .all(txn)
+        .await?
+    {
+        object_infos.push(PbObjectInfo::Connection(
+            ObjectModel(connection, connection_obj.unwrap(), None).into(),
+        ));
+    }
+
+    let secret_ids = objects
+        .iter()
+        .filter(|object| object.obj_type == ObjectType::Secret)
+        .map(|object| object.oid.as_secret_id())
+        .collect_vec();
+    for (secret, secret_obj) in Secret::find()
+        .find_also_related(Object)
+        .filter(secret::Column::SecretId.is_in(secret_ids))
+        .all(txn)
+        .await?
+    {
+        object_infos.push(PbObjectInfo::Secret(
+            ObjectModel(secret, secret_obj.unwrap(), None).into(),
+        ));
+    }
+
+    let database_ids = objects
+        .iter()
+        .filter(|object| object.obj_type == ObjectType::Database)
+        .map(|object| object.oid.as_database_id())
+        .collect_vec();
+    for (database, database_obj) in Database::find()
+        .find_also_related(Object)
+        .filter(database::Column::DatabaseId.is_in(database_ids))
+        .all(txn)
+        .await?
+    {
+        object_infos.push(PbObjectInfo::Database(
+            ObjectModel(database, database_obj.unwrap(), None).into(),
+        ));
+    }
+
+    let schema_ids = objects
+        .iter()
+        .filter(|object| object.obj_type == ObjectType::Schema)
+        .map(|object| object.oid.as_schema_id())
+        .collect_vec();
+    for (schema, schema_obj) in Schema::find()
+        .find_also_related(Object)
+        .filter(schema::Column::SchemaId.is_in(schema_ids))
+        .all(txn)
+        .await?
+    {
+        object_infos.push(PbObjectInfo::Schema(
+            ObjectModel(schema, schema_obj.unwrap(), None).into(),
+        ));
+    }
+
+    Ok(object_infos)
+}
+
 pub(crate) async fn update_internal_tables(
     txn: &DatabaseTransaction,
     object_id: ObjectId,

--- a/src/meta/src/controller/streaming_job.rs
+++ b/src/meta/src/controller/streaming_job.rs
@@ -108,9 +108,22 @@ pub struct AbortCreatingJobResult {
     pub aborted: bool,
     /// The database of the job, if the job was found.
     pub database_id: Option<DatabaseId>,
-    /// The aborted sink, if the aborted job was a sink; the caller should clear its iceberg
-    /// maintenance state via `IcebergCompactionManager::clear_maintenance_for_aborted_job`.
-    pub aborted_sink_id: Option<SinkId>,
+    /// The aborted sinks; the caller should clear their iceberg maintenance state via
+    /// `IcebergCompactionManager::clear_maintenance_for_aborted_job`.
+    pub aborted_sink_ids: Vec<SinkId>,
+    /// Runtime and state cleanup information captured before deleting the catalog rows.
+    /// This is returned only when handling an explicit cancellation.
+    pub cancel_info: Option<CancelStreamingJobInfo>,
+}
+
+/// Runtime and state cleanup information for canceling a creating streaming job.
+pub struct CancelStreamingJobInfo {
+    /// Barrier command that stops every affected streaming job.
+    pub command: Command,
+    /// Streaming jobs included in `command`.
+    pub streaming_job_ids: Vec<JobId>,
+    /// State tables to unregister after the barrier is collected.
+    pub state_table_ids: Vec<TableId>,
 }
 
 fn serverless_backfill_resource_group_placeholder(job_id: JobId) -> String {
@@ -873,69 +886,6 @@ impl CatalogController {
         Ok(())
     }
 
-    /// Builds a cancel command from persisted fragment metadata without reading `SharedActorInfos`.
-    ///
-    /// Returns `None` if the job no longer exists or has already been created.
-    pub async fn build_cancel_command(
-        &self,
-        job_id: JobId,
-    ) -> MetaResult<Option<(Command, Vec<TableId>)>> {
-        let inner = self.inner.read().await;
-        let txn = inner.db.begin().await?;
-
-        let Some(streaming_job) = StreamingJobModel::find_by_id(job_id).one(&txn).await? else {
-            tracing::warn!(
-                %job_id,
-                "streaming job not found when building cancel command, might be cancelled already"
-            );
-            return Ok(None);
-        };
-        if streaming_job.job_status == JobStatus::Created {
-            tracing::warn!(
-                "streaming job {} is already created, ignore cancel request",
-                job_id
-            );
-            return Ok(None);
-        }
-
-        let fragments = Fragment::find()
-            .filter(fragment::Column::JobId.eq(job_id))
-            .all(&txn)
-            .await?;
-
-        let state_table_ids = fragments
-            .iter()
-            .flat_map(|fragment| fragment.state_table_ids.inner_ref().iter().copied())
-            .collect_vec();
-        let sink_fragment_ids = fragments
-            .iter()
-            .filter_map(|fragment| {
-                FragmentTypeMask::from(fragment.fragment_type_mask)
-                    .contains(FragmentTypeFlag::Sink)
-                    .then_some(fragment.fragment_id)
-            })
-            .collect_vec();
-
-        let sink_target_fragments = fetch_target_fragments(&txn, sink_fragment_ids).await?;
-        let dropped_sink_fragment_by_targets = sink_target_fragments
-            .into_iter()
-            .filter_map(|(sink_fragment, target_fragments)| {
-                target_fragments
-                    .first()
-                    .map(|target_fragment| (*target_fragment, vec![sink_fragment]))
-            })
-            .collect();
-
-        Ok(Some((
-            Command::DropStreamingJobs {
-                streaming_job_ids: HashSet::from_iter([job_id]),
-                unregistered_state_table_ids: state_table_ids.iter().copied().collect(),
-                dropped_sink_fragment_by_targets,
-            },
-            state_table_ids,
-        )))
-    }
-
     /// `try_abort_creating_streaming_job` is used to abort the job that is under initial status or in `FOREGROUND` mode.
     #[await_tree::instrument]
     pub async fn try_abort_creating_streaming_job(
@@ -955,7 +905,8 @@ impl CatalogController {
             return Ok(AbortCreatingJobResult {
                 aborted: true,
                 database_id: None,
-                aborted_sink_id: None,
+                aborted_sink_ids: vec![],
+                cancel_info: None,
             });
         };
         let database_id = obj
@@ -963,9 +914,19 @@ impl CatalogController {
             .ok_or_else(|| anyhow!("obj has no database id: {:?}", obj))?;
         let streaming_job = streaming_job::Entity::find_by_id(job_id).one(&txn).await?;
 
-        if !is_cancelled && let Some(streaming_job) = &streaming_job {
-            assert_ne!(streaming_job.job_status, JobStatus::Created);
-            if streaming_job.create_type == CreateType::Background
+        if let Some(streaming_job) = &streaming_job {
+            if streaming_job.job_status == JobStatus::Created {
+                tracing::warn!(%job_id, "streaming job is already created, ignore abort request");
+                return Ok(AbortCreatingJobResult {
+                    aborted: false,
+                    database_id: Some(database_id),
+                    aborted_sink_ids: vec![],
+                    cancel_info: None,
+                });
+            }
+
+            if !is_cancelled
+                && streaming_job.create_type == CreateType::Background
                 && streaming_job.job_status == JobStatus::Creating
             {
                 if (obj.obj_type == ObjectType::Table || obj.obj_type == ObjectType::Sink)
@@ -982,20 +943,75 @@ impl CatalogController {
                     return Ok(AbortCreatingJobResult {
                         aborted: false,
                         database_id: Some(database_id),
-                        aborted_sink_id: None,
+                        aborted_sink_ids: vec![],
+                        cancel_info: None,
                     });
                 }
             }
         }
 
-        let obj_type = obj.obj_type;
         let mut objects_to_abort = vec![obj];
         objects_to_abort.extend(get_belong_objects(&txn, job_id.as_object_id()).await?);
         let object_ids_to_abort = objects_to_abort
             .iter()
             .map(|object| object.oid)
             .collect_vec();
+        let streaming_job_ids_to_abort: Vec<JobId> = StreamingJobModel::find()
+            .select_only()
+            .column(streaming_job::Column::JobId)
+            .filter(streaming_job::Column::JobId.is_in(object_ids_to_abort.iter().copied()))
+            .into_tuple()
+            .all(&txn)
+            .await?;
         let object_models = load_object_models(&txn, &objects_to_abort).await?;
+
+        let fragments: Vec<(FragmentId, i32, TableIdArray)> = Fragment::find()
+            .select_only()
+            .columns([
+                fragment::Column::FragmentId,
+                fragment::Column::FragmentTypeMask,
+                fragment::Column::StateTableIds,
+            ])
+            .filter(fragment::Column::JobId.is_in(streaming_job_ids_to_abort.iter().copied()))
+            .into_tuple()
+            .all(&txn)
+            .await?;
+        let cancel_info = if is_cancelled {
+            let state_table_ids: HashSet<_> = fragments
+                .iter()
+                .flat_map(|(_, _, state_table_ids)| state_table_ids.inner_ref().iter().copied())
+                .collect();
+            let sink_fragment_ids = fragments
+                .iter()
+                .filter_map(|(fragment_id, fragment_type_mask, _)| {
+                    FragmentTypeMask::from(*fragment_type_mask)
+                        .contains(FragmentTypeFlag::Sink)
+                        .then_some(*fragment_id)
+                })
+                .collect_vec();
+            let sink_target_fragments = fetch_target_fragments(&txn, sink_fragment_ids).await?;
+            let mut dropped_sink_fragment_by_targets = HashMap::new();
+            for (sink_fragment, target_fragments) in sink_target_fragments {
+                if let Some(target_fragment) = target_fragments.first() {
+                    dropped_sink_fragment_by_targets
+                        .entry(*target_fragment)
+                        .or_insert_with(Vec::new)
+                        .push(sink_fragment);
+                }
+            }
+
+            Some(CancelStreamingJobInfo {
+                command: Command::DropStreamingJobs {
+                    streaming_job_ids: streaming_job_ids_to_abort.iter().copied().collect(),
+                    unregistered_state_table_ids: state_table_ids.clone(),
+                    dropped_sink_fragment_by_targets,
+                },
+                streaming_job_ids: streaming_job_ids_to_abort.clone(),
+                state_table_ids: state_table_ids.into_iter().collect(),
+            })
+        } else {
+            None
+        };
 
         // A job becomes visible to frontend only after it enters the creating status.
         let need_notify = streaming_job
@@ -1028,15 +1044,10 @@ impl CatalogController {
         };
 
         // Query fragment IDs before cascade-deleting them, for serving mapping cleanup.
-        let abort_fragment_ids: Vec<FragmentId> = Fragment::find()
-            .select_only()
-            .column(fragment::Column::FragmentId)
-            .filter(
-                fragment::Column::JobId.is_in(object_ids_to_abort.iter().map(|id| id.as_job_id())),
-            )
-            .into_tuple()
-            .all(&txn)
-            .await?;
+        let abort_fragment_ids = fragments
+            .iter()
+            .map(|(fragment_id, _, _)| *fragment_id)
+            .collect_vec();
 
         // Do not walk from an implicit Iceberg sink to its parent table here. The Iceberg table
         // creation error path drops the table explicitly, which then cascades to all objects that
@@ -1049,15 +1060,17 @@ impl CatalogController {
             MetaError::catalog_id_not_found("stream job", format!("streaming job {job_id} failed"))
         };
         let abort_reason = format!("streaming job aborted {}", err.as_report());
-        for tx in inner
-            .creating_table_finish_notifier
-            .get_mut(&database_id)
-            .map(|creating_tables| creating_tables.remove(&job_id).into_iter())
-            .into_iter()
-            .flatten()
-            .flatten()
-        {
-            let _ = tx.send(Err(abort_reason.clone()));
+        for aborted_job_id in streaming_job_ids_to_abort {
+            for tx in inner
+                .creating_table_finish_notifier
+                .get_mut(&database_id)
+                .map(|creating_tables| creating_tables.remove(&aborted_job_id).into_iter())
+                .into_iter()
+                .flatten()
+                .flatten()
+            {
+                let _ = tx.send(Err(abort_reason.clone()));
+            }
         }
         txn.commit().await?;
 
@@ -1074,11 +1087,16 @@ impl CatalogController {
             self.notify_frontend(Operation::Delete, build_object_group_for_delete(objs))
                 .await;
         }
-        let aborted_sink_id = (obj_type == ObjectType::Sink).then(|| job_id.as_sink_id());
+        let aborted_sink_ids = objects_to_abort
+            .iter()
+            .filter(|object| object.obj_type == ObjectType::Sink)
+            .map(|object| object.oid.as_sink_id())
+            .collect();
         Ok(AbortCreatingJobResult {
             aborted: true,
             database_id: Some(database_id),
-            aborted_sink_id,
+            aborted_sink_ids,
+            cancel_info,
         })
     }
 

--- a/src/meta/src/controller/streaming_job.rs
+++ b/src/meta/src/controller/streaming_job.rs
@@ -81,15 +81,16 @@ use thiserror_ext::AsReport;
 use super::rename::IndexItemRewriter;
 use crate::barrier::Command;
 use crate::controller::ObjectModel;
-use crate::controller::catalog::{CatalogController, DropTableConnectorContext};
+use crate::controller::catalog::{
+    CatalogController, DropTableConnectorContext, load_object_models,
+};
 use crate::controller::fragment::FragmentTypeMaskExt;
 use crate::controller::utils::{
     PartialObject, build_object_group_for_delete, check_if_belongs_to_iceberg_table,
     check_relation_name_duplicate, check_sink_into_table_cycle, ensure_job_not_canceled,
-    ensure_object_id, ensure_user_id, fetch_target_fragments, get_internal_tables_by_id,
-    get_table_columns, grant_default_privileges_automatically, insert_fragment_relations,
-    list_object_dependencies_by_object_id, list_user_info_by_ids,
-    try_get_iceberg_table_by_downstream_sink,
+    ensure_object_id, ensure_user_id, fetch_target_fragments, get_belong_objects,
+    get_belong_objects_by_ids, get_table_columns, grant_default_privileges_automatically,
+    insert_fragment_relations, list_object_dependencies_by_object_id, list_user_info_by_ids,
 };
 use crate::error::MetaErrorInner;
 use crate::manager::{NotificationVersion, StreamingJob, StreamingJobType};
@@ -275,8 +276,7 @@ impl CatalogController {
         txn: &DatabaseTransaction,
         obj_type: ObjectType,
         owner_id: UserId,
-        database_id: Option<DatabaseId>,
-        schema_id: Option<SchemaId>,
+        belong_to_oid: Option<ObjectId>,
         create_type: PbCreateType,
         ctx: StreamContext,
         adaptive_parallelism_strategy: Option<AdaptiveParallelismStrategy>,
@@ -287,7 +287,7 @@ impl CatalogController {
         backfill_adaptive_parallelism_strategy: Option<AdaptiveParallelismStrategy>,
         refresh_interval_sec: Option<u64>,
     ) -> MetaResult<streaming_job::Model> {
-        let obj = Self::create_object(txn, obj_type, owner_id, database_id, schema_id).await?;
+        let obj = Self::create_object(txn, obj_type, owner_id, belong_to_oid).await?;
         let job_id = obj.oid.as_job_id();
         let is_serverless_backfill = matches!(
             &resource_type,
@@ -362,7 +362,7 @@ impl CatalogController {
         ensure_object_id(ObjectType::Database, streaming_job.database_id(), &txn).await?;
         ensure_object_id(ObjectType::Schema, streaming_job.schema_id(), &txn).await?;
         if let Some(old_sink_id) = replace_sink {
-            let StreamingJob::Sink(sink) = streaming_job else {
+            let StreamingJob::Sink(sink, _) = streaming_job else {
                 bail!("replacement sink catalog requires a sink job")
             };
             let (old_sink, old_object) = Sink::find_by_id(*old_sink_id)
@@ -456,8 +456,7 @@ impl CatalogController {
                     &txn,
                     ObjectType::Table,
                     table.owner as _,
-                    Some(table.database_id),
-                    Some(table.schema_id),
+                    Some(table.schema_id.as_object_id()),
                     create_type,
                     ctx.clone(),
                     adaptive_parallelism_strategy,
@@ -474,7 +473,7 @@ impl CatalogController {
                 Table::insert(table_model).exec(&txn).await?;
                 streaming_job_model
             }
-            StreamingJob::Sink(sink) => {
+            StreamingJob::Sink(sink, belong_to_table_id) => {
                 if let Some(target_table_id) = sink.target_table
                     && check_sink_into_table_cycle(
                         target_table_id.into(),
@@ -490,8 +489,11 @@ impl CatalogController {
                     &txn,
                     ObjectType::Sink,
                     sink.owner as _,
-                    Some(sink.database_id),
-                    Some(sink.schema_id),
+                    Some(
+                        belong_to_table_id
+                            .map(|table_id| table_id.as_object_id())
+                            .unwrap_or(sink.schema_id.as_object_id()),
+                    ),
                     create_type,
                     ctx.clone(),
                     adaptive_parallelism_strategy,
@@ -527,8 +529,7 @@ impl CatalogController {
                     &txn,
                     ObjectType::Table,
                     table.owner as _,
-                    Some(table.database_id),
-                    Some(table.schema_id),
+                    Some(table.schema_id.as_object_id()),
                     create_type,
                     ctx.clone(),
                     adaptive_parallelism_strategy,
@@ -547,8 +548,7 @@ impl CatalogController {
                         &txn,
                         ObjectType::Source,
                         src.owner as _,
-                        Some(src.database_id),
-                        Some(src.schema_id),
+                        Some(job_id.as_object_id()),
                     )
                     .await?;
                     src.id = src_obj.oid.as_source_id();
@@ -592,8 +592,7 @@ impl CatalogController {
                     &txn,
                     ObjectType::Index,
                     index.owner as _,
-                    Some(index.database_id),
-                    Some(index.schema_id),
+                    Some(index.schema_id.as_object_id()),
                     create_type,
                     ctx.clone(),
                     adaptive_parallelism_strategy,
@@ -630,8 +629,7 @@ impl CatalogController {
                     &txn,
                     ObjectType::Source,
                     src.owner as _,
-                    Some(src.database_id),
-                    Some(src.schema_id),
+                    Some(src.schema_id.as_object_id()),
                     create_type,
                     ctx.clone(),
                     adaptive_parallelism_strategy,
@@ -708,8 +706,7 @@ impl CatalogController {
                 &txn,
                 ObjectType::Table,
                 table.owner as _,
-                Some(table.database_id),
-                Some(table.schema_id),
+                Some(job_id.as_object_id()),
             )
             .await?
             .oid
@@ -943,7 +940,7 @@ impl CatalogController {
     #[await_tree::instrument]
     pub async fn try_abort_creating_streaming_job(
         &self,
-        mut job_id: JobId,
+        job_id: JobId,
         is_cancelled: bool,
     ) -> MetaResult<AbortCreatingJobResult> {
         let mut inner = self.inner.write().await;
@@ -974,9 +971,10 @@ impl CatalogController {
                 if (obj.obj_type == ObjectType::Table || obj.obj_type == ObjectType::Sink)
                     && check_if_belongs_to_iceberg_table(&txn, job_id).await?
                 {
-                    // If the job belongs to an iceberg table, we still need to clean it.
+                    // If the job belongs to an Iceberg table, we still need to clean it.
                 } else {
-                    // If the job is created in background and still in creating status, we should not abort it and let recovery handle it.
+                    // If the job is created in background and still in creating status, we should
+                    // not abort it and let recovery handle it.
                     tracing::warn!(
                         id = %job_id,
                         "streaming job is created in background and still in creating status"
@@ -990,143 +988,60 @@ impl CatalogController {
             }
         }
 
-        // Record original job info before any potential job id rewrite (e.g. iceberg sink).
-        let original_job_id = job_id;
-        let original_obj_type = obj.obj_type;
-
-        let iceberg_table_id =
-            try_get_iceberg_table_by_downstream_sink(&txn, job_id.as_sink_id()).await?;
-        if let Some(iceberg_table_id) = iceberg_table_id {
-            // If the job is iceberg sink, we need to clean the iceberg table as well.
-            // Here we will drop the sink objects directly.
-            let internal_tables = get_internal_tables_by_id(job_id, &txn).await?;
-            Object::delete_many()
-                .filter(
-                    object::Column::Oid
-                        .eq(job_id)
-                        .or(object::Column::Oid.is_in(internal_tables)),
-                )
-                .exec(&txn)
-                .await?;
-            job_id = iceberg_table_id.as_job_id();
-        };
-
-        let internal_table_ids = get_internal_tables_by_id(job_id, &txn).await?;
+        let obj_type = obj.obj_type;
+        let mut objects_to_abort = vec![obj];
+        objects_to_abort.extend(get_belong_objects(&txn, job_id.as_object_id()).await?);
+        let object_ids_to_abort = objects_to_abort
+            .iter()
+            .map(|object| object.oid)
+            .collect_vec();
+        let object_models = load_object_models(&txn, &objects_to_abort).await?;
 
         // A job becomes visible to frontend only after it enters the creating status.
-        let mut objs = vec![];
-        let table_obj = Table::find_by_id(job_id.as_mv_table_id()).one(&txn).await?;
         let need_notify = streaming_job
             .as_ref()
             .is_some_and(|job| job.job_status != JobStatus::Initial);
 
         if is_cancelled {
-            let dropped_tables = Table::find()
-                .find_also_related(Object)
-                .filter(
-                    table::Column::TableId.is_in(
-                        internal_table_ids
-                            .iter()
-                            .cloned()
-                            .chain(table_obj.iter().map(|t| t.table_id as _)),
-                    ),
-                )
-                .all(&txn)
-                .await?
-                .into_iter()
-                .map(|(table, obj)| PbTable::from(ObjectModel(table, obj.unwrap(), None)));
-            inner
-                .dropped_tables
-                .extend(dropped_tables.map(|t| (t.id, t)));
-        }
-
-        if need_notify {
-            // Special handling for iceberg sinks: the `job_id` may have been rewritten to the table id.
-            // Ensure we still notify the frontend to delete the original sink object.
-            if original_obj_type == ObjectType::Sink && original_job_id != job_id {
-                let orig_obj: Option<PartialObject> = Object::find_by_id(original_job_id)
-                    .select_only()
-                    .columns([
-                        object::Column::Oid,
-                        object::Column::ObjType,
-                        object::Column::SchemaId,
-                        object::Column::DatabaseId,
-                    ])
-                    .into_partial_model()
-                    .one(&txn)
-                    .await?;
-                if let Some(orig_obj) = orig_obj {
-                    objs.push(orig_obj);
+            let dropped_tables = object_models.iter().filter_map(|object_info| {
+                if let PbObjectInfo::Table(table) = object_info {
+                    Some((table.id, table.clone()))
+                } else {
+                    None
                 }
-            }
-
-            let obj: Option<PartialObject> = Object::find_by_id(job_id)
-                .select_only()
-                .columns([
-                    object::Column::Oid,
-                    object::Column::ObjType,
-                    object::Column::SchemaId,
-                    object::Column::DatabaseId,
-                ])
-                .into_partial_model()
-                .one(&txn)
-                .await?;
-            let obj =
-                obj.ok_or_else(|| MetaError::catalog_id_not_found("streaming job", job_id))?;
-            objs.push(obj);
-            if let Some(table) = &table_obj
-                && let Some(source_id) = table.optional_associated_source_id
-                && let Some(source_obj) = Object::find_by_id(source_id)
-                    .select_only()
-                    .columns([
-                        object::Column::Oid,
-                        object::Column::ObjType,
-                        object::Column::SchemaId,
-                        object::Column::DatabaseId,
-                    ])
-                    .into_partial_model()
-                    .one(&txn)
-                    .await?
-            {
-                objs.push(source_obj);
-            }
-            let internal_table_objs: Vec<PartialObject> = Object::find()
-                .select_only()
-                .columns([
-                    object::Column::Oid,
-                    object::Column::ObjType,
-                    object::Column::SchemaId,
-                    object::Column::DatabaseId,
-                ])
-                .join(JoinType::InnerJoin, object::Relation::Table.def())
-                .filter(table::Column::BelongsToJobId.eq(job_id))
-                .into_partial_model()
-                .all(&txn)
-                .await?;
-            objs.extend(internal_table_objs);
+            });
+            inner.dropped_tables.extend(dropped_tables);
         }
+
+        let objs = if need_notify {
+            objects_to_abort
+                .iter()
+                .map(|object| PartialObject {
+                    oid: object.oid,
+                    obj_type: object.obj_type,
+                    schema_id: object.schema_id,
+                    database_id: object.database_id,
+                })
+                .collect_vec()
+        } else {
+            vec![]
+        };
 
         // Query fragment IDs before cascade-deleting them, for serving mapping cleanup.
         let abort_fragment_ids: Vec<FragmentId> = Fragment::find()
             .select_only()
             .column(fragment::Column::FragmentId)
-            .filter(fragment::Column::JobId.eq(job_id))
+            .filter(
+                fragment::Column::JobId.is_in(object_ids_to_abort.iter().map(|id| id.as_job_id())),
+            )
             .into_tuple()
             .all(&txn)
             .await?;
 
+        // Do not walk from an implicit Iceberg sink to its parent table here. The Iceberg table
+        // creation error path drops the table explicitly, which then cascades to all objects that
+        // belong to it.
         Object::delete_by_id(job_id).exec(&txn).await?;
-        if !internal_table_ids.is_empty() {
-            Object::delete_many()
-                .filter(object::Column::Oid.is_in(internal_table_ids))
-                .exec(&txn)
-                .await?;
-        }
-        if let Some(t) = &table_obj
-            && let Some(source_id) = t.optional_associated_source_id
-        {
-            Object::delete_by_id(source_id).exec(&txn).await?;
-        }
 
         let err = if is_cancelled {
             MetaError::cancelled(format!("streaming job {job_id} is cancelled"))
@@ -1159,8 +1074,7 @@ impl CatalogController {
             self.notify_frontend(Operation::Delete, build_object_group_for_delete(objs))
                 .await;
         }
-        let aborted_sink_id =
-            (original_obj_type == ObjectType::Sink).then(|| original_job_id.as_sink_id());
+        let aborted_sink_id = (obj_type == ObjectType::Sink).then(|| job_id.as_sink_id());
         Ok(AbortCreatingJobResult {
             aborted: true,
             database_id: Some(database_id),
@@ -1318,7 +1232,6 @@ impl CatalogController {
 
         if let Some(old_sink_id) = replace_sink {
             let old_sink_id = *old_sink_id;
-            let old_job_id = old_sink_id.as_job_id();
 
             let (old_sink, old_sink_object) = Sink::find_by_id(old_sink_id)
                 .find_also_related(Object)
@@ -1326,48 +1239,41 @@ impl CatalogController {
                 .await?
                 .and_then(|(sink, object)| object.map(|object| (sink, object)))
                 .ok_or_else(|| MetaError::catalog_id_not_found("sink", old_sink_id))?;
-            let old_sink_object = PartialObject {
-                oid: old_sink_object.oid,
-                obj_type: old_sink_object.obj_type,
-                schema_id: old_sink_object.schema_id,
-                database_id: old_sink_object.database_id,
-            };
             if old_sink_object.obj_type != ObjectType::Sink {
                 bail!("object {} is not a sink", old_sink_id);
             }
             let final_sink_name = old_sink.name.clone();
 
-            let old_internal_table_objs: Vec<PartialObject> = Object::find()
-                .select_only()
-                .columns([
-                    object::Column::Oid,
-                    object::Column::ObjType,
-                    object::Column::SchemaId,
-                    object::Column::DatabaseId,
-                ])
-                .join(JoinType::InnerJoin, object::Relation::Table.def())
-                .filter(table::Column::BelongsToJobId.eq(old_job_id))
-                .into_partial_model()
-                .all(&txn)
-                .await?;
-            let old_state_table_ids = old_internal_table_objs
+            let mut old_objects_to_delete = vec![old_sink_object];
+            old_objects_to_delete
+                .extend(get_belong_objects(&txn, old_sink_id.as_object_id()).await?);
+            let old_object_models = load_object_models(&txn, &old_objects_to_delete).await?;
+            let old_state_table_ids = old_object_models
                 .iter()
-                .map(|obj| obj.oid.as_table_id())
+                .filter_map(|object_info| match object_info {
+                    PbObjectInfo::Table(table) => Some(table.id),
+                    _ => None,
+                })
                 .collect_vec();
             let old_fragment_ids: Vec<FragmentId> = Fragment::find()
                 .select_only()
                 .column(fragment::Column::FragmentId)
-                .filter(fragment::Column::JobId.eq(old_job_id))
+                .filter(
+                    fragment::Column::JobId.is_in(
+                        old_objects_to_delete
+                            .iter()
+                            .map(|object| object.oid.as_job_id()),
+                    ),
+                )
                 .into_tuple()
                 .all(&txn)
                 .await?;
-            let dropped_tables = Table::find()
-                .find_also_related(Object)
-                .filter(table::Column::TableId.is_in(old_state_table_ids.iter().copied()))
-                .all(&txn)
-                .await?
-                .into_iter()
-                .map(|(table, obj)| PbTable::from(ObjectModel(table, obj.unwrap(), None)))
+            let dropped_tables = old_object_models
+                .iter()
+                .filter_map(|object_info| match object_info {
+                    PbObjectInfo::Table(table) => Some(table.clone()),
+                    _ => None,
+                })
                 .collect_vec();
 
             Sink::update(sink::ActiveModel {
@@ -1378,8 +1284,9 @@ impl CatalogController {
             .exec(&txn)
             .await?;
 
-            let old_objects = std::iter::once(old_sink_object)
-                .chain(old_internal_table_objs)
+            let old_objects = old_objects_to_delete
+                .into_iter()
+                .map(PartialObject::from)
                 .collect_vec();
             let old_object_ids = old_objects.iter().map(|obj| obj.oid).collect_vec();
             let updated_user_ids: Vec<UserId> = UserPrivilege::find()
@@ -1391,40 +1298,25 @@ impl CatalogController {
                 .all(&txn)
                 .await?;
 
-            // Deleting only the sink object cascades the internal `table` rows through
-            // `belongs_to_job_id`, but leaves their corresponding `object` rows behind.
-            // Delete the complete object set to keep the catalog hierarchy consistent.
-            let res = Object::delete_many()
-                .filter(object::Column::Oid.is_in(old_object_ids))
-                .exec(&txn)
-                .await?;
+            // Internal objects and their catalog rows follow the old sink's belong-to cascade.
+            let res = Object::delete_by_id(old_sink_id).exec(&txn).await?;
             if res.rows_affected == 0 {
                 return Err(MetaError::catalog_id_not_found("sink", old_sink_id));
             }
 
-            let (new_sink, new_obj) = Sink::find_by_id(job_id.as_sink_id())
-                .find_also_related(Object)
+            let new_root_object = Object::find_by_id(job_id)
                 .one(&txn)
                 .await?
                 .ok_or_else(|| MetaError::catalog_id_not_found("sink", job_id))?;
-            let streaming_job = StreamingJobModel::find_by_id(job_id).one(&txn).await?;
-            let mut new_objects = Table::find()
-                .find_also_related(Object)
-                .filter(table::Column::BelongsToJobId.eq(job_id))
-                .all(&txn)
+            let mut new_objects_to_notify = vec![new_root_object];
+            new_objects_to_notify.extend(get_belong_objects(&txn, job_id.as_object_id()).await?);
+            let new_objects = load_object_models(&txn, &new_objects_to_notify)
                 .await?
                 .into_iter()
-                .map(|(table, obj)| PbObject {
-                    object_info: Some(PbObjectInfo::Table(
-                        ObjectModel(table, obj.unwrap(), streaming_job.clone()).into(),
-                    )),
+                .map(|object_info| PbObject {
+                    object_info: Some(object_info),
                 })
                 .collect_vec();
-            new_objects.push(PbObject {
-                object_info: Some(PbObjectInfo::Sink(
-                    ObjectModel(new_sink, new_obj.unwrap(), streaming_job).into(),
-                )),
-            });
             let dependencies =
                 list_object_dependencies_by_object_id(&txn, job_id.as_object_id()).await?;
             let updated_user_info = list_user_info_by_ids(updated_user_ids, &txn).await?;
@@ -1592,14 +1484,20 @@ impl CatalogController {
             .as_deref()
             .map(|s| parse_strategy(s).expect("strategy should be validated before persisting"));
         let resource_type = original_job.resource_type();
+        let belong_to_oid = Object::find_by_id(id)
+            .select_only()
+            .column(object::Column::BelongToOid)
+            .into_tuple::<Option<ObjectId>>()
+            .one(&txn)
+            .await?
+            .ok_or_else(|| MetaError::catalog_id_not_found(streaming_job.job_type_str(), id))?;
 
         // 4. create streaming object for new replace table.
         let tmp_model = Self::create_streaming_job_obj(
             &txn,
             streaming_job.object_type(),
             streaming_job.owner() as _,
-            Some(streaming_job.database_id() as _),
-            Some(streaming_job.schema_id() as _),
+            belong_to_oid,
             streaming_job.create_type(),
             ctx,
             adaptive_parallelism_strategy,
@@ -2393,25 +2291,36 @@ impl CatalogController {
         let inner = self.inner.write().await;
         let txn = inner.db.begin().await?;
 
-        // Query fragment IDs of the temp job and temp sinks before cascade-deleting them.
-        let mut all_job_ids: Vec<ObjectId> = vec![tmp_job_id.into()];
-        if let Some(ref sink_ids) = tmp_sink_ids {
-            all_job_ids.extend(sink_ids.iter().copied());
+        let mut root_ids: Vec<ObjectId> = vec![tmp_job_id.into()];
+        if let Some(sink_ids) = &tmp_sink_ids {
+            root_ids.extend(sink_ids.iter().copied());
         }
+        let mut temporary_objects = Object::find()
+            .filter(object::Column::Oid.is_in(root_ids.iter().copied()))
+            .all(&txn)
+            .await?;
+        temporary_objects.extend(get_belong_objects_by_ids(&txn, root_ids.iter().copied()).await?);
+
+        // Query fragment IDs before cascade-deleting the temporary jobs and objects that belong to
+        // them.
         let abort_fragment_ids: Vec<FragmentId> = Fragment::find()
             .select_only()
             .column(fragment::Column::FragmentId)
-            .filter(fragment::Column::JobId.is_in(all_job_ids))
+            .filter(
+                fragment::Column::JobId.is_in(
+                    temporary_objects
+                        .iter()
+                        .map(|object| object.oid.as_job_id()),
+                ),
+            )
             .into_tuple()
             .all(&txn)
             .await?;
 
-        Object::delete_by_id(tmp_job_id).exec(&txn).await?;
-        if let Some(tmp_sink_ids) = tmp_sink_ids {
-            for tmp_sink_id in tmp_sink_ids {
-                Object::delete_by_id(tmp_sink_id).exec(&txn).await?;
-            }
-        }
+        Object::delete_many()
+            .filter(object::Column::Oid.is_in(root_ids))
+            .exec(&txn)
+            .await?;
         txn.commit().await?;
 
         // Notify serving module about deleted fragments from the aborted replace job.

--- a/src/meta/src/controller/utils.rs
+++ b/src/meta/src/controller/utils.rs
@@ -399,6 +399,54 @@ pub struct PartialObject {
     pub database_id: Option<DatabaseId>,
 }
 
+impl From<object::Model> for PartialObject {
+    fn from(object: object::Model) -> Self {
+        Self {
+            oid: object.oid,
+            obj_type: object.obj_type,
+            schema_id: object.schema_id,
+            database_id: object.database_id,
+        }
+    }
+}
+
+pub async fn get_belong_objects<C>(db: &C, object_id: ObjectId) -> MetaResult<Vec<object::Model>>
+where
+    C: ConnectionTrait,
+{
+    get_belong_objects_by_ids(db, [object_id]).await
+}
+
+/// Returns all objects that transitively belong to `object_ids`, excluding `object_ids`.
+pub async fn get_belong_objects_by_ids<C>(
+    db: &C,
+    object_ids: impl IntoIterator<Item = ObjectId>,
+) -> MetaResult<Vec<object::Model>>
+where
+    C: ConnectionTrait,
+{
+    let mut parents = object_ids.into_iter().collect_vec();
+    let mut visited = parents.iter().copied().collect::<HashSet<_>>();
+    let mut objects = vec![];
+    loop {
+        let children = Object::find()
+            .filter(object::Column::BelongToOid.is_in(parents))
+            .all(db)
+            .await?
+            .into_iter()
+            .filter(|object| visited.insert(object.oid))
+            .collect_vec();
+        if children.is_empty() {
+            break;
+        }
+
+        parents = children.iter().map(|object| object.oid).collect();
+        objects.extend(children);
+    }
+
+    Ok(objects)
+}
+
 #[derive(Clone, DerivePartialModel, FromQueryResult)]
 #[sea_orm(entity = "Fragment")]
 pub struct PartialFragmentStateTables {
@@ -2333,47 +2381,6 @@ where
     Ok(migrated)
 }
 
-pub async fn try_get_iceberg_table_by_downstream_sink<C>(
-    txn: &C,
-    sink_id: SinkId,
-) -> MetaResult<Option<TableId>>
-where
-    C: ConnectionTrait,
-{
-    let sink = Sink::find_by_id(sink_id).one(txn).await?;
-    let Some(sink) = sink else {
-        return Ok(None);
-    };
-
-    if sink.name.starts_with(ICEBERG_SINK_PREFIX) {
-        let object_ids: Vec<ObjectId> = ObjectDependency::find()
-            .select_only()
-            .column(object_dependency::Column::Oid)
-            .filter(object_dependency::Column::UsedBy.eq(sink_id))
-            .into_tuple()
-            .all(txn)
-            .await?;
-        let mut iceberg_table_ids = vec![];
-        for object_id in object_ids {
-            let table_id = object_id.as_table_id();
-            if let Some(table_engine) = Table::find_by_id(table_id)
-                .select_only()
-                .column(table::Column::Engine)
-                .into_tuple::<table::Engine>()
-                .one(txn)
-                .await?
-                && table_engine == table::Engine::Iceberg
-            {
-                iceberg_table_ids.push(table_id);
-            }
-        }
-        if iceberg_table_ids.len() == 1 {
-            return Ok(Some(iceberg_table_ids[0]));
-        }
-    }
-    Ok(None)
-}
-
 pub async fn check_if_belongs_to_iceberg_table<C>(txn: &C, job_id: JobId) -> MetaResult<bool>
 where
     C: ConnectionTrait,
@@ -2388,13 +2395,18 @@ where
     {
         return Ok(true);
     }
-    if let Some(sink_name) = Sink::find_by_id(job_id.as_sink_id())
+    if let Some(parent_oid) = Object::find_by_id(job_id)
         .select_only()
-        .column(sink::Column::Name)
-        .into_tuple::<String>()
+        .column(object::Column::BelongToOid)
+        .into_tuple::<Option<ObjectId>>()
         .one(txn)
         .await?
-        && sink_name.starts_with(ICEBERG_SINK_PREFIX)
+        .flatten()
+        && Table::find_by_id(parent_oid.as_table_id())
+            .filter(table::Column::Engine.eq(table::Engine::Iceberg))
+            .one(txn)
+            .await?
+            .is_some()
     {
         return Ok(true);
     }

--- a/src/meta/src/manager/iceberg_compaction/mod.rs
+++ b/src/meta/src/manager/iceberg_compaction/mod.rs
@@ -128,7 +128,7 @@ impl IcebergCompactionManager {
     /// Clear the iceberg maintenance state of the sink aborted by
     /// `try_abort_creating_streaming_job`, if any.
     pub fn clear_maintenance_for_aborted_job(&self, abort_result: &AbortCreatingJobResult) {
-        if let Some(sink_id) = abort_result.aborted_sink_id {
+        for &sink_id in &abort_result.aborted_sink_ids {
             self.clear_iceberg_maintenance_by_sink_id(sink_id);
         }
     }

--- a/src/meta/src/manager/streaming_job.rs
+++ b/src/meta/src/manager/streaming_job.rs
@@ -16,7 +16,7 @@ use std::collections::HashSet;
 
 use risingwave_common::bail_not_implemented;
 use risingwave_common::catalog::TableVersionId;
-use risingwave_common::id::{ConnectionId, DatabaseId, JobId, SchemaId, SecretId, UserId};
+use risingwave_common::id::{ConnectionId, DatabaseId, JobId, SchemaId, SecretId, TableId, UserId};
 use risingwave_meta_model::object::ObjectType;
 use risingwave_meta_model::prelude::{SourceModel, TableModel};
 use risingwave_meta_model::{TableVersion, source, table};
@@ -38,7 +38,7 @@ use crate::{MetaError, MetaResult};
 #[derive(Debug, Clone, EnumIs, EnumTryAs)]
 pub enum StreamingJob {
     MaterializedView(Table),
-    Sink(Sink),
+    Sink(Sink, Option<TableId>),
     Table(Option<PbSource>, Table, TableJobType),
     Index(Index, Table),
     Source(PbSource),
@@ -50,7 +50,7 @@ impl std::fmt::Display for StreamingJob {
             StreamingJob::MaterializedView(table) => {
                 write!(f, "MaterializedView: {}({})", table.name, table.id)
             }
-            StreamingJob::Sink(sink) => write!(f, "Sink: {}({})", sink.name, sink.id),
+            StreamingJob::Sink(sink, _) => write!(f, "Sink: {}({})", sink.name, sink.id),
             StreamingJob::Table(_, table, _) => write!(f, "Table: {}({})", table.name, table.id),
             StreamingJob::Index(index, _) => write!(f, "Index: {}({})", index.name, index.id),
             StreamingJob::Source(source) => write!(f, "Source: {}({})", source.name, source.id),
@@ -71,7 +71,7 @@ impl From<&StreamingJob> for StreamingJobType {
     fn from(job: &StreamingJob) -> Self {
         match job {
             StreamingJob::MaterializedView(_) => StreamingJobType::MaterializedView,
-            StreamingJob::Sink(_) => StreamingJobType::Sink,
+            StreamingJob::Sink(..) => StreamingJobType::Sink,
             StreamingJob::Table(_, _, ty) => StreamingJobType::Table(*ty),
             StreamingJob::Index(_, _) => StreamingJobType::Index,
             StreamingJob::Source(_) => StreamingJobType::Source,
@@ -100,7 +100,7 @@ impl StreamingJob {
             Self::MaterializedView(table) | Self::Index(_, table) | Self::Table(_, table, ..) => {
                 table.maybe_vnode_count = Some(vnode_count as u32);
             }
-            Self::Sink(_) | Self::Source(_) => {}
+            Self::Sink(..) | Self::Source(_) => {}
         }
     }
 
@@ -114,14 +114,14 @@ impl StreamingJob {
             Self::MaterializedView(table) | Self::Index(_, table) => {
                 table.fragment_id = graph.table_fragment_id();
             }
-            Self::Sink(_) | Self::Source(_) => {}
+            Self::Sink(..) | Self::Source(_) => {}
         }
     }
 
     pub fn id(&self) -> JobId {
         match self {
             Self::MaterializedView(table) => table.id.as_job_id(),
-            Self::Sink(sink) => sink.id.as_job_id(),
+            Self::Sink(sink, _) => sink.id.as_job_id(),
             Self::Table(_, table, ..) => table.id.as_job_id(),
             Self::Index(index, _) => index.id.as_job_id(),
             Self::Source(source) => source.id.as_share_source_job_id(),
@@ -134,14 +134,14 @@ impl StreamingJob {
             Self::MaterializedView(table) | Self::Index(_, table) | Self::Table(_, table, ..) => {
                 Some(table)
             }
-            Self::Sink(_) | Self::Source(_) => None,
+            Self::Sink(..) | Self::Source(_) => None,
         }
     }
 
     pub fn schema_id(&self) -> SchemaId {
         match self {
             Self::MaterializedView(table) => table.schema_id,
-            Self::Sink(sink) => sink.schema_id,
+            Self::Sink(sink, _) => sink.schema_id,
             Self::Table(_, table, ..) => table.schema_id,
             Self::Index(index, _) => index.schema_id,
             Self::Source(source) => source.schema_id,
@@ -151,7 +151,7 @@ impl StreamingJob {
     pub fn database_id(&self) -> DatabaseId {
         match self {
             Self::MaterializedView(table) => table.database_id,
-            Self::Sink(sink) => sink.database_id,
+            Self::Sink(sink, _) => sink.database_id,
             Self::Table(_, table, ..) => table.database_id,
             Self::Index(index, _) => index.database_id,
             Self::Source(source) => source.database_id,
@@ -161,7 +161,7 @@ impl StreamingJob {
     pub fn name(&self) -> String {
         match self {
             Self::MaterializedView(table) => table.name.clone(),
-            Self::Sink(sink) => sink.name.clone(),
+            Self::Sink(sink, _) => sink.name.clone(),
             Self::Table(_, table, ..) => table.name.clone(),
             Self::Index(index, _) => index.name.clone(),
             Self::Source(source) => source.name.clone(),
@@ -171,7 +171,7 @@ impl StreamingJob {
     pub fn owner(&self) -> UserId {
         match self {
             StreamingJob::MaterializedView(mv) => mv.owner,
-            StreamingJob::Sink(sink) => sink.owner,
+            StreamingJob::Sink(sink, _) => sink.owner,
             StreamingJob::Table(_, table, ..) => table.owner,
             StreamingJob::Index(index, _) => index.owner,
             StreamingJob::Source(source) => source.owner,
@@ -185,7 +185,7 @@ impl StreamingJob {
     pub fn job_type_str(&self) -> &'static str {
         match self {
             StreamingJob::MaterializedView(_) => "materialized view",
-            StreamingJob::Sink(_) => "sink",
+            StreamingJob::Sink(..) => "sink",
             StreamingJob::Table(_, _, _) => "table",
             StreamingJob::Index(_, _) => "index",
             StreamingJob::Source(_) => "source",
@@ -197,7 +197,7 @@ impl StreamingJob {
             Self::MaterializedView(table) => table.definition.clone(),
             Self::Table(_, table, ..) => table.definition.clone(),
             Self::Index(_, table) => table.definition.clone(),
-            Self::Sink(sink) => sink.definition.clone(),
+            Self::Sink(sink, _) => sink.definition.clone(),
             Self::Source(source) => source.definition.clone(),
         }
     }
@@ -205,7 +205,7 @@ impl StreamingJob {
     pub fn object_type(&self) -> ObjectType {
         match self {
             Self::MaterializedView(_) => ObjectType::Table, // Note MV is special.
-            Self::Sink(_) => ObjectType::Sink,
+            Self::Sink(..) => ObjectType::Sink,
             Self::Table(_, _, _) => ObjectType::Table,
             Self::Index(_, _) => ObjectType::Index,
             Self::Source(_) => ObjectType::Source,
@@ -232,7 +232,7 @@ impl StreamingJob {
             Self::MaterializedView(table) => {
                 table.get_create_type().unwrap_or(CreateType::Foreground)
             }
-            Self::Sink(s) => s.get_create_type().unwrap_or(CreateType::Foreground),
+            Self::Sink(s, _) => s.get_create_type().unwrap_or(CreateType::Foreground),
             Self::Index(index, _) => {
                 CreateType::try_from(index.create_type).unwrap_or(CreateType::Foreground)
             }
@@ -250,7 +250,7 @@ impl StreamingJob {
                     Ok(HashSet::new())
                 }
             }
-            StreamingJob::Sink(sink) => Ok(get_referred_connection_ids_from_sink(sink)),
+            StreamingJob::Sink(sink, _) => Ok(get_referred_connection_ids_from_sink(sink)),
             StreamingJob::MaterializedView(_) | StreamingJob::Index(_, _) => Ok(HashSet::new()),
         }
     }
@@ -258,7 +258,7 @@ impl StreamingJob {
     // Get the secret ids that are referenced by this job.
     pub fn dependent_secret_ids(&self) -> MetaResult<HashSet<SecretId>> {
         match self {
-            StreamingJob::Sink(sink) => Ok(get_referred_secret_ids_from_sink(sink)),
+            StreamingJob::Sink(sink, _) => Ok(get_referred_secret_ids_from_sink(sink)),
             StreamingJob::Table(source, _, _) => {
                 if let Some(source) = source {
                     get_referred_secret_ids_from_source(source)
@@ -312,7 +312,7 @@ impl StreamingJob {
                 // No version check for materialized view, since `ALTER MATERIALIZED VIEW AS QUERY`
                 // is a full rewrite.
             }
-            StreamingJob::Sink(_) => {
+            StreamingJob::Sink(..) => {
                 // No version check for sink, since sink fragment altering is triggered along with Table
             }
             StreamingJob::Index(_, _) => {
@@ -323,6 +323,6 @@ impl StreamingJob {
     }
 
     pub fn is_sink_into_table(&self) -> bool {
-        matches!(self, Self::Sink(sink) if sink.target_table.is_some())
+        matches!(self, Self::Sink(sink, _) if sink.target_table.is_some())
     }
 }

--- a/src/meta/src/rpc/ddl_controller.rs
+++ b/src/meta/src/rpc/ddl_controller.rs
@@ -155,7 +155,7 @@ pub enum DdlCommand {
     DropDatabase(DatabaseId),
     CreateSchema(Schema),
     DropSchema(SchemaId, DropMode),
-    CreateNonSharedSource(Source),
+    CreateNonSharedSource(Source, Option<TableId>),
     DropSource(SourceId, DropMode),
     ResetSource(SourceId),
     CreateFunction(Function),
@@ -209,7 +209,7 @@ impl DdlCommand {
             DdlCommand::DropDatabase(id) => Right(id.as_object_id()),
             DdlCommand::CreateSchema(schema) => Left(schema.name.clone()),
             DdlCommand::DropSchema(id, _) => Right(id.as_object_id()),
-            DdlCommand::CreateNonSharedSource(source) => Left(source.name.clone()),
+            DdlCommand::CreateNonSharedSource(source, _) => Left(source.name.clone()),
             DdlCommand::DropSource(id, _) => Right(id.as_object_id()),
             DdlCommand::ResetSource(id) => Right(id.as_object_id()),
             DdlCommand::CreateFunction(function) => Left(function.name.clone()),
@@ -269,7 +269,7 @@ impl DdlCommand {
             | DdlCommand::AlterStreamingJobConfig(_, _, _)
             | DdlCommand::AlterSubscriptionRetention { .. } => true,
             DdlCommand::CreateStreamingJob { .. }
-            | DdlCommand::CreateNonSharedSource(_)
+            | DdlCommand::CreateNonSharedSource(_, _)
             | DdlCommand::ReplaceStreamJob(_)
             | DdlCommand::AlterNonSharedSource(_)
             | DdlCommand::ResetSource(_)
@@ -457,8 +457,9 @@ impl DdlController {
                 DdlCommand::DropSchema(schema_id, drop_mode) => {
                     ctrl.drop_schema(schema_id, drop_mode).await
                 }
-                DdlCommand::CreateNonSharedSource(source) => {
-                    ctrl.create_non_shared_source(source).await
+                DdlCommand::CreateNonSharedSource(source, iceberg_table_id) => {
+                    ctrl.create_non_shared_source(source, iceberg_table_id)
+                        .await
                 }
                 DdlCommand::DropSource(source_id, drop_mode) => {
                     ctrl.drop_source(source_id, drop_mode).await
@@ -682,7 +683,11 @@ impl DdlController {
     }
 
     /// Shared source is handled in [`Self::create_streaming_job`]
-    async fn create_non_shared_source(&self, source: Source) -> MetaResult<NotificationVersion> {
+    async fn create_non_shared_source(
+        &self,
+        source: Source,
+        iceberg_table_id: Option<TableId>,
+    ) -> MetaResult<NotificationVersion> {
         let handle = create_source_worker(
             &source,
             self.source_manager.metrics.clone(),
@@ -694,7 +699,7 @@ impl DdlController {
         let (source_id, version) = self
             .metadata_manager
             .catalog_controller
-            .create_source(source)
+            .create_source(source, iceberg_table_id)
             .await?;
         self.source_manager
             .register_source_with_handle(source_id, handle)
@@ -1106,7 +1111,7 @@ impl DdlController {
         since_timestamp_epoch: Option<u64>,
     ) -> MetaResult<NotificationVersion> {
         let replace_sink_info = if let Some(old_sink_id) = replace_sink {
-            let StreamingJob::Sink(sink) = &streaming_job else {
+            let StreamingJob::Sink(sink, _) = &streaming_job else {
                 bail!("replace sink requires a sink job")
             };
             if sink.target_table.is_some() {
@@ -1115,7 +1120,7 @@ impl DdlController {
 
             Some(old_sink_id)
         } else {
-            if let StreamingJob::Sink(sink) = &streaming_job
+            if let StreamingJob::Sink(sink, _) = &streaming_job
                 && let Some(target_table) = sink.target_table
             {
                 self.validate_table_for_sink(target_table).await?;
@@ -1336,7 +1341,7 @@ impl DdlController {
                     attr,
                 );
             }
-            StreamingJob::Sink(sink) => {
+            StreamingJob::Sink(sink, _) => {
                 if sink.auto_refresh_schema_from_table.is_some() {
                     check_sink_fragments_support_refresh_schema(&stream_job_fragments.fragments)?;
                 }
@@ -1666,7 +1671,7 @@ impl DdlController {
                             self.env.id_gen_manager(),
                         )?;
 
-                    let streaming_job = StreamingJob::Sink(sink);
+                    let streaming_job = StreamingJob::Sink(sink, None);
 
                     let tmp_sink_model = self
                         .metadata_manager
@@ -1674,7 +1679,7 @@ impl DdlController {
                         .create_job_catalog_for_replace(&streaming_job, None, None, None)
                         .await?;
                     let tmp_sink_id = tmp_sink_model.job_id.as_sink_id();
-                    let StreamingJob::Sink(sink) = streaming_job else {
+                    let StreamingJob::Sink(sink, _) = streaming_job else {
                         unreachable!()
                     };
 
@@ -1954,7 +1959,7 @@ impl DdlController {
         if snapshot_backfill_info.is_some() {
             match stream_job {
                 StreamingJob::MaterializedView(_)
-                | StreamingJob::Sink(_)
+                | StreamingJob::Sink(..)
                 | StreamingJob::Index(_, _) => {}
                 StreamingJob::Table(_, _, _) | StreamingJob::Source(_) => {
                     return Err(
@@ -2002,7 +2007,7 @@ impl DdlController {
             stream_job.set_table_vnode_count(mview_fragment.vnode_count());
         }
 
-        let new_upstream_sink = if let StreamingJob::Sink(sink) = &stream_job
+        let new_upstream_sink = if let StreamingJob::Sink(sink, _) = &stream_job
             && let Ok(table_id) = sink.get_target_table()
         {
             let tables = self

--- a/src/meta/src/stream/stream_manager.rs
+++ b/src/meta/src/stream/stream_manager.rs
@@ -449,29 +449,27 @@ impl GlobalStreamManager {
                             );
 
                             let cancel_result: MetaResult<()> = async {
-                                let Some((cancel_command, cleanup_state_table_ids)) = self
-                                    .metadata_manager
-                                    .catalog_controller
-                                    .build_cancel_command(job_id)
-                                    .await?
-                                else {
-                                    return Ok(());
-                                };
-                                let abort_result = self.metadata_manager.catalog_controller
-                                    .try_abort_creating_streaming_job(job_id, true)
-                                    .await?;
+                                let abort_result = Box::pin(
+                                    self.metadata_manager
+                                        .catalog_controller
+                                        .try_abort_creating_streaming_job(job_id, true),
+                                )
+                                .await?;
                                 self.iceberg_compaction_manager
                                     .clear_maintenance_for_aborted_job(&abort_result);
+                                let Some(cancel_info) = abort_result.cancel_info else {
+                                    return Ok(());
+                                };
 
                                 self.barrier_scheduler
-                                    .run_command(database_id, cancel_command)
+                                    .run_command(database_id, cancel_info.command)
                                     .await?;
                                 cleanup_dropped_streaming_jobs(
                                     &self.refresh_manager,
                                     &self.hummock_manager,
                                     &self.metadata_manager,
-                                    [job_id],
-                                    cleanup_state_table_ids,
+                                    cancel_info.streaming_job_ids,
+                                    cancel_info.state_table_ids,
                                     "cancel_streaming_job",
                                 )
                                 .await?;
@@ -867,15 +865,6 @@ impl GlobalStreamManager {
         // NOTE(kwannoel): For background_job_ids stream jobs that not tracked in streaming manager,
         // we can directly cancel them by running the barrier command.
         let futures = background_job_ids.into_iter().map(|id| async move {
-            let Some((cancel_command, cleanup_state_table_ids)) = self
-                .metadata_manager
-                .catalog_controller
-                .build_cancel_command(id)
-                .await?
-            else {
-                return Ok(None);
-            };
-
             let abort_result = self
                 .metadata_manager
                 .catalog_controller
@@ -883,17 +872,20 @@ impl GlobalStreamManager {
                 .await?;
             self.iceberg_compaction_manager
                 .clear_maintenance_for_aborted_job(&abort_result);
+            let Some(cancel_info) = abort_result.cancel_info else {
+                return Ok(None);
+            };
 
             if let Some(database_id) = abort_result.database_id {
                 self.barrier_scheduler
-                    .run_command(database_id, cancel_command)
+                    .run_command(database_id, cancel_info.command)
                     .await?;
                 cleanup_dropped_streaming_jobs(
                     &self.refresh_manager,
                     &self.hummock_manager,
                     &self.metadata_manager,
-                    [id],
-                    cleanup_state_table_ids,
+                    cancel_info.streaming_job_ids,
+                    cancel_info.state_table_ids,
                     "cancel_streaming_job",
                 )
                 .await?;


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

This PR adds an explicit lifetime relation to catalog objects so deleting a referenced object can cascade through objects that belong to it without application code enumerating every object row for deletion.

- Add nullable `object.belong_to_oid` with a self foreign key using `ON DELETE CASCADE` and an index for belong-to lookups.
- Backfill belong-to relations for databases, schemas, named schema objects, internal tables, associated sources, and implicit Iceberg table-engine objects on PostgreSQL, MySQL, and SQLite meta-store backends.
- Keep indexes and subscriptions as named objects belonging to their schemas. Their upstream references remain represented by the `index`, `subscription`, and `object_dependency` tables.
- Derive `database_id` and `schema_id` from `belong_to_oid` when creating catalog objects.
- Refactor drop, dirty-job cleanup, cancellation, and replacement cleanup to load belonging objects before deletion for notifications and resource cleanup, while deleting only the explicitly selected objects. Cancellation resolves all belonging streaming jobs in the same catalog transaction before cascade deletion and includes their fragments and state tables in the stop barrier and Hummock cleanup.
- When changing an MV or table schema, resolve its indexes into the root object-ID list first, then move those roots and their belonging objects. Subscriptions remain in their existing schemas and may differ from their upstream relation's schema.
- Allow `ALTER TABLE ... SET SCHEMA` for Iceberg table-engine tables and move their implicit source and sink with the table.

`belong_to_oid` represents lifetime, not semantic dependency. `object_dependency` remains responsible for dependency checks and `DROP ... CASCADE`. Object-type validation and cycle prevention remain application responsibilities.

### Migration details

The `m20260805_000000_object_belong_to_oid` migration performs these operations in order:

1. Add the nullable `object.belong_to_oid` column if it is missing. SQLite declares its self foreign key inline because SQLite cannot add the constraint separately.
2. Create `IDX_object_belong_to_oid` for belong-to lookups if it is missing.
3. Add `FK_object_belong_to_oid` on PostgreSQL and MySQL if backend metadata shows it is missing. The relation uses `object.belong_to_oid -> object.oid ON DELETE CASCADE`; at this point all three backends have the constraint installed before backfill.
4. Initialize namespace relations with `belong_to_oid = COALESCE(schema_id, database_id)`. This maps schemas to databases and named catalog objects to schemas while leaving database objects without a value.
5. Override internal table objects with `table.belongs_to_job_id` and associated source objects with the referencing table ID.
6. Resolve implicit Iceberg sinks from their unique Iceberg table dependency, restricted to the literal `__iceberg_sink_` prefix using `LIKE '!_!_iceberg!_sink!_%' ESCAPE '!'` on every backend.
7. Resolve implicit Iceberg sources to the same-schema Iceberg table whose generated source name is exactly `__iceberg_source_<table_name>`.

Indexes and subscriptions are intentionally not overridden during backfill, so their `belong_to_oid` remains the schema ID. Column, index, and PostgreSQL/MySQL foreign-key creation are guarded so a new Meta leader can restart after non-transactional DDL without hitting duplicate-object errors. The overwrite-style backfill is repeatable. Migration tests cover all backfill categories, cascade deletion, a normal sink named `myiceberg_sink_output` that must not be treated as an implicit Iceberg sink, and retry from a partial SQLite run plus a complete replay.

Local verification:

- `cargo clippy --all-targets --all-features`
- `cargo fmt --all`
- `cargo test -p risingwave_meta_model_migration m20260805_000000_object_belong_to_oid`
- `cargo test -p risingwave_meta --lib controller::catalog::test::tests::test_cancel_`
- `cargo test -p risingwave_meta test_alter_table_schema_moves_indexes_but_not_subscriptions --lib`
- `cargo test -p risingwave_meta test_object_belong_to_cascade --lib`
- `cargo test -p risingwave_meta test_create_function --lib`
- `git diff --check`

The Iceberg SQLLogicTest is included in the Iceberg CI lane but was not run locally because the RisingWave and MinIO fixtures were not running.

## Checklist

- [x] I have written necessary rustdoc comments.
- [x] I have added necessary unit tests and integration tests.
- [x] I have added test labels as necessary.
- [ ] I have added fuzzing tests or opened an issue to track them.
- [ ] My PR contains breaking changes.
- [ ] My PR changes performance-critical code, so I will run (micro) benchmarks and present the results.
- [ ] I have checked the Release Timeline and Currently Supported Versions to determine which release branches I need to cherry-pick this PR into.

## Documentation

- [ ] My PR needs documentation updates.

<details>
<summary><b>Release note</b></summary>

`ALTER TABLE ... SET SCHEMA` now supports Iceberg table-engine tables. RisingWave moves the table's implicit source and sink to the target schema together with the table. Indexes move with their primary table, while subscriptions remain in their existing schemas.

</details>

