### PR TITLE
fix(sink): align coordinated sink writers' initial epochs even with a rewind epoch

### DIFF
--- a/src/connector/src/sink/coordinate.rs
+++ b/src/connector/src/sink/coordinate.rs
@@ -80,9 +80,8 @@ impl<W: SinkWriter<CommitMetadata = Option<SinkMetadata>>> LogSinker for Coordin
         let mut sink_writer = self.writer;
         log_reader.start_from(log_store_rewind_start_epoch).await?;
         let mut first_item = log_reader.next_item().await?;
-        if let (Some(log_store_rewind_start_epoch), (first_epoch, _)) =
-            (log_store_rewind_start_epoch, &first_item)
-        {
+        if let Some(log_store_rewind_start_epoch) = log_store_rewind_start_epoch {
+            let (first_epoch, _) = &first_item;
             if log_store_rewind_start_epoch >= *first_epoch {
                 bail!(
                     "log_store_rewind_start_epoch {} not later than first_epoch {}",
@@ -90,7 +89,12 @@ impl<W: SinkWriter<CommitMetadata = Option<SinkMetadata>>> LogSinker for Coordin
                     first_epoch
                 );
             }
-        } else {
+        }
+        {
+            // Align the initial epoch across parallel writers even when a rewind epoch is
+            // provided: the rewind epoch is only a lower bound of the read range, and unevenly
+            // truncated log stores may still give writers different first epochs, which would
+            // make their commit epochs diverge forever.
             let &(initial_epoch, _) = &first_item;
             let aligned_initial_epoch = coordinator_stream_handle
                 .align_initial_epoch(initial_epoch)
@@ -102,6 +106,8 @@ impl<W: SinkWriter<CommitMetadata = Option<SinkMetadata>>> LogSinker for Coordin
                     sink_id = %self.param.sink_id,
                     "initial epoch not matched aligned initial epoch"
                 );
+                // Items below the aligned epoch belong to already-acked commits, so skipping
+                // them loses no data.
                 let mut peeked_first = Some(first_item);
                 first_item = loop {
                     let (epoch, item) = if let Some(peeked_first) = peeked_first.take() {

--- a/src/meta/src/manager/sink_coordination/coordinator_worker.rs
+++ b/src/meta/src/manager/sink_coordination/coordinator_worker.rs
@@ -294,8 +294,19 @@ impl CoordinationHandleManager {
         Ok(())
     }
 
-    fn ack_aligned_initial_epoch(&mut self, aligned_initial_epoch: u64) -> anyhow::Result<()> {
-        for (handle_id, handle) in &mut self.writer_handles {
+    fn ack_aligned_initial_epoch(
+        &mut self,
+        aligned_initial_epoch: u64,
+        handle_ids: impl IntoIterator<Item = HandleId>,
+    ) -> anyhow::Result<()> {
+        for handle_id in handle_ids {
+            let handle = self.writer_handles.get_mut(&handle_id).ok_or_else(|| {
+                anyhow!(
+                    "fail to find handle for {} to ack aligned initial epoch {}",
+                    handle_id,
+                    aligned_initial_epoch
+                )
+            })?;
             handle
                 .ack_aligned_initial_epoch(aligned_initial_epoch)
                 .map_err(|_| {
@@ -480,11 +491,9 @@ impl CoordinationHandleManager {
                     );
                 }
                 CoordinationHandleManagerEvent::AlignInitialEpoch(epoch) => {
-                    bail!(
-                        "receive AlignInitialEpoch on epoch {} from handle {} during alter parallelism",
-                        epoch,
-                        handle_id
-                    );
+                    // From a writer started in a non-cold-start round; it consumes the live
+                    // stream and needs no cross-writer alignment.
+                    self.ack_aligned_initial_epoch(epoch, [handle_id])?;
                 }
             }
         }
@@ -499,7 +508,8 @@ impl CoordinationHandleManager {
 ///   ensures new sink executors load the correct schema.
 enum CoordinatorWorkerState {
     Running,
-    WaitingForFlushed(HashSet<HandleId>),
+    /// The bool indicates whether the pending init requests are from a cold start.
+    WaitingForFlushed(HashSet<HandleId>, bool),
 }
 
 pub struct CoordinatorWorker {
@@ -586,14 +596,16 @@ impl CoordinatorWorker {
     async fn try_handle_init_requests(
         &mut self,
         pending_handle_ids: &HashSet<HandleId>,
+        cold_start: bool,
         two_phase_handler: &mut TwoPhaseCommitHandler,
     ) -> anyhow::Result<()> {
         assert!(matches!(self.curr_state, CoordinatorWorkerState::Running));
         if two_phase_handler.has_uncommitted_schema_change() {
             // Delay handling init requests until all pending epochs are flushed.
-            self.curr_state = CoordinatorWorkerState::WaitingForFlushed(pending_handle_ids.clone());
+            self.curr_state =
+                CoordinatorWorkerState::WaitingForFlushed(pending_handle_ids.clone(), cold_start);
         } else {
-            self.handle_init_requests_impl(pending_handle_ids.clone())
+            self.handle_init_requests_impl(pending_handle_ids.clone(), cold_start)
                 .await?;
         }
         Ok(())
@@ -602,11 +614,19 @@ impl CoordinatorWorker {
     async fn handle_init_requests_impl(
         &mut self,
         pending_handle_ids: impl IntoIterator<Item = HandleId>,
+        cold_start: bool,
     ) -> anyhow::Result<()> {
         let log_store_rewind_start_epoch = self.last_writer_acked_epoch;
         self.handle_manager
             .start(log_store_rewind_start_epoch, pending_handle_ids)?;
-        if log_store_rewind_start_epoch.is_none() {
+        if cold_start {
+            // On cold start, writers rebuild log readers from log stores that may have been
+            // truncated unevenly (e.g. an acked commit with empty metadata leaves no durable
+            // trace, making the recovered rewind epoch staler than some writer's truncation
+            // watermark), so their first epochs may differ even with a rewind epoch. Align them
+            // to the max, otherwise their commit epochs would diverge forever. In non-cold-start
+            // rounds, existing writers are position-locked by the forced commit on the
+            // reschedule barrier and do not report initial epochs.
             let mut align_requests = AligningRequests::default();
             while !align_requests.aligned() {
                 let (handle_id, event) = self.handle_manager.next_event().await?;
@@ -623,13 +643,14 @@ impl CoordinatorWorker {
                     }
                 }
             }
-            let aligned_initial_epoch = align_requests
-                .requests
-                .into_iter()
-                .max()
-                .expect("non-empty");
+            let AligningRequests {
+                requests,
+                handle_ids,
+                ..
+            } = align_requests;
+            let aligned_initial_epoch = requests.into_iter().max().expect("non-empty");
             self.handle_manager
-                .ack_aligned_initial_epoch(aligned_initial_epoch)?;
+                .ack_aligned_initial_epoch(aligned_initial_epoch, handle_ids)?;
         }
         Ok(())
     }
@@ -638,11 +659,14 @@ impl CoordinatorWorker {
         &mut self,
         two_phase_handler: &mut TwoPhaseCommitHandler,
     ) -> anyhow::Result<CoordinatorWorkerEvent> {
-        if let CoordinatorWorkerState::WaitingForFlushed(pending_handle_ids) = &self.curr_state
+        if let CoordinatorWorkerState::WaitingForFlushed(pending_handle_ids, cold_start) =
+            &self.curr_state
             && two_phase_handler.is_empty()
         {
             let pending_handle_ids = pending_handle_ids.clone();
-            self.handle_init_requests_impl(pending_handle_ids).await?;
+            let cold_start = *cold_start;
+            self.handle_init_requests_impl(pending_handle_ids, cold_start)
+                .await?;
             self.curr_state = CoordinatorWorkerState::Running;
         }
 
@@ -676,7 +700,7 @@ impl CoordinatorWorker {
         }
 
         let mut running_handles = self.handle_manager.wait_init_handles().await?;
-        self.try_handle_init_requests(&running_handles, &mut two_phase_handler)
+        self.try_handle_init_requests(&running_handles, true, &mut two_phase_handler)
             .await?;
 
         let mut pending_epochs: BTreeMap<u64, AligningRequests<_>> = BTreeMap::new();
@@ -694,8 +718,12 @@ impl CoordinatorWorker {
                             .handle_manager
                             .alter_parallelisms(pending_new_handles.drain(..).chain([handle_id]))
                             .await?;
-                        self.try_handle_init_requests(&running_handles, &mut two_phase_handler)
-                            .await?;
+                        self.try_handle_init_requests(
+                            &running_handles,
+                            false,
+                            &mut two_phase_handler,
+                        )
+                        .await?;
                         continue;
                     }
                     CoordinationHandleManagerEvent::Stop => {
@@ -704,8 +732,12 @@ impl CoordinatorWorker {
                             .handle_manager
                             .alter_parallelisms(pending_new_handles.drain(..))
                             .await?;
-                        self.try_handle_init_requests(&running_handles, &mut two_phase_handler)
-                            .await?;
+                        self.try_handle_init_requests(
+                            &running_handles,
+                            false,
+                            &mut two_phase_handler,
+                        )
+                        .await?;
 
                         continue;
                     }
@@ -714,8 +746,12 @@ impl CoordinatorWorker {
                         metadata,
                         schema_change,
                     } => (handle_id, epoch, (metadata, schema_change)),
-                    CoordinationHandleManagerEvent::AlignInitialEpoch(_) => {
-                        bail!("receive AlignInitialEpoch after initialization")
+                    CoordinationHandleManagerEvent::AlignInitialEpoch(epoch) => {
+                        // From a writer started in a non-cold-start round; it consumes the live
+                        // stream and needs no cross-writer alignment.
+                        self.handle_manager
+                            .ack_aligned_initial_epoch(epoch, [handle_id])?;
+                        continue;
                     }
                 },
                 CoordinatorWorkerEvent::ReadyToCommit(epoch, metadata, schema_change) => {
@@ -794,6 +830,16 @@ impl CoordinatorWorker {
                 commit_request,
                 self.handle_manager.vnode_bitmap(handle_id),
             )?;
+            if pending_epochs.len() > 1 {
+                // Writers commit on the same sequence of epochs (initial epochs aligned on
+                // start, later boundaries anchored to the shared barrier stream), so requests on
+                // two different epochs can never both align; fail fast instead of waiting
+                // forever.
+                bail!(
+                    "commit requests landed on different epochs {:?}; writers' commit boundaries have diverged",
+                    pending_epochs.keys().collect_vec()
+                );
+            }
             if pending_epochs
                 .first_key_value()
                 .expect("non-empty")

--- a/src/meta/src/manager/sink_coordination/manager.rs
+++ b/src/meta/src/manager/sink_coordination/manager.rs
@@ -1690,7 +1690,7 @@ mod tests {
                 }
             });
 
-        let (_client, log_store_rewind_start_epoch) =
+        let (mut client, log_store_rewind_start_epoch) =
             CoordinatorStreamHandle::new_with_init_stream(param.to_proto(), vnode, |rx| async {
                 Ok(tonic::Response::new(
                     manager
@@ -1703,6 +1703,10 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(log_store_rewind_start_epoch, Some(epoch1));
+
+        // The recovered pending epoch is recommitted only after initial epoch alignment.
+        let aligned_epoch = client.align_initial_epoch(epoch1 + 1).await.unwrap();
+        assert_eq!(aligned_epoch, epoch1 + 1);
 
         for _ in 0..50 {
             tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
@@ -1720,6 +1724,215 @@ mod tests {
         let rows = list_rows(&db).await;
         assert_eq!(rows.len(), 1);
         assert_eq!(rows[0].1, epoch1 as i64);
+        assert_eq!(rows[0].2, "COMMITTED");
+    }
+
+    /// Writers whose log stores were truncated unevenly observe different first epochs on
+    /// recovery. They must be aligned even when a rewind epoch is provided; otherwise their
+    /// commit epochs diverge forever and no commit can ever align.
+    #[tokio::test]
+    async fn test_align_initial_epoch_with_rewind() {
+        let db = prepare_db_backend().await;
+
+        let param = SinkParam {
+            sink_id: SinkId::from(1),
+            sink_name: "test".into(),
+            properties: Default::default(),
+            columns: vec![],
+            downstream_pk: None,
+            sink_type: SinkType::AppendOnly,
+            ignore_delete: false,
+            format_desc: None,
+            db_name: "test".into(),
+            sink_from_name: "test".into(),
+        };
+
+        let epoch0 = 100;
+        let epoch1 = 133;
+        let epoch2 = 233;
+        let epoch3 = 300;
+
+        // A committed epoch in the meta store makes the coordinator provide `Some(rewind)`.
+        let sql = format!(
+            "INSERT INTO pending_sink_state (sink_id, epoch, sink_state, metadata) VALUES ({}, {}, 'COMMITTED', x'0102')",
+            param.sink_id, epoch0
+        );
+        db.execute(sea_orm::Statement::from_string(
+            db.get_database_backend(),
+            sql,
+        ))
+        .await
+        .unwrap();
+
+        let mut all_vnode = (0..VirtualNode::COUNT_FOR_TEST).collect_vec();
+        all_vnode.shuffle(&mut rand::rng());
+        let (first, second) = all_vnode.split_at(VirtualNode::COUNT_FOR_TEST / 2);
+        let build_bitmap = |indexes: &[usize]| {
+            let mut builder = BitmapBuilder::zeroed(VirtualNode::COUNT_FOR_TEST);
+            for i in indexes {
+                builder.set(*i, true);
+            }
+            builder.finish()
+        };
+        let vnode1 = build_bitmap(first);
+        let vnode2 = build_bitmap(second);
+
+        let metadata = [vec![1u8, 2u8], vec![3u8, 4u8]];
+        let pre_commit_metadata = vec![9u8];
+
+        let sender = Arc::new(tokio::sync::Mutex::new(None));
+        let mock_subscriber: SinkCommittedEpochSubscriber = {
+            let captured_sender = sender.clone();
+            Arc::new(move |_sink_id: SinkId| {
+                let (epoch_sender, receiver) = unbounded_channel();
+                let captured_sender = captured_sender.clone();
+                async move {
+                    let mut guard = captured_sender.lock().await;
+                    *guard = Some(epoch_sender);
+                    Ok((epoch3, receiver))
+                }
+                .boxed()
+            })
+        };
+
+        let commit_attempt = Arc::new(AtomicI32::new(0));
+        let (manager, (_join_handle, _stop_tx)) =
+            SinkCoordinatorManager::start_worker_with_spawn_worker({
+                let expected_param = param.clone();
+                let db = db.clone();
+                let metadata = metadata.clone();
+                let pre_commit_metadata = pre_commit_metadata.clone();
+                let commit_attempt = commit_attempt.clone();
+                move |param, new_writer_rx| {
+                    let expected_param = expected_param.clone();
+                    let db = db.clone();
+                    let metadata = metadata.clone();
+                    let pre_commit_metadata = pre_commit_metadata.clone();
+                    let expected_commit_metadata = pre_commit_metadata.clone();
+                    let commit_attempt = commit_attempt.clone();
+                    tokio::spawn({
+                        let subscriber = mock_subscriber.clone();
+                        async move {
+                            assert_eq!(param, expected_param);
+                            CoordinatorWorker::execute_coordinator(
+                                db,
+                                param.clone(),
+                                new_writer_rx,
+                                MockTwoPhaseCoordinator::new_coordinator(
+                                    move |epoch, metadata_list, schema_change| {
+                                        assert_eq!(epoch, epoch3);
+                                        assert!(schema_change.is_none());
+                                        let mut metadata_list =
+                                            metadata_list
+                                                .into_iter()
+                                                .map(|metadata| match metadata {
+                                                    SinkMetadata {
+                                                        metadata:
+                                                            Some(Metadata::Serialized(
+                                                                SerializedMetadata { metadata },
+                                                            )),
+                                                    } => metadata,
+                                                    _ => unreachable!(),
+                                                })
+                                                .collect_vec();
+                                        metadata_list.sort();
+                                        assert_eq!(metadata[0], metadata_list[0]);
+                                        assert_eq!(metadata[1], metadata_list[1]);
+                                        Ok(Some(pre_commit_metadata.clone()))
+                                    },
+                                    move |epoch, commit_metadata| {
+                                        assert_eq!(epoch, epoch3);
+                                        assert_eq!(commit_metadata, expected_commit_metadata);
+                                        commit_attempt
+                                            .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                                        Ok(())
+                                    },
+                                    move |_epoch, _schema_change| unreachable!(),
+                                ),
+                                subscriber.clone(),
+                            )
+                            .await;
+                        }
+                    })
+                }
+            });
+
+        let build_client = |vnode| async {
+            CoordinatorStreamHandle::new_with_init_stream(param.to_proto(), vnode, |rx| async {
+                Ok(tonic::Response::new(
+                    manager
+                        .handle_new_request(ReceiverStream::new(rx).map(Ok).boxed())
+                        .await
+                        .unwrap()
+                        .boxed(),
+                ))
+            })
+            .await
+            .unwrap()
+        };
+
+        let ((mut client1, rewind1), (mut client2, rewind2)) =
+            join(build_client(vnode1), pin!(build_client(vnode2))).await;
+        assert_eq!(rewind1, Some(epoch0));
+        assert_eq!(rewind2, Some(epoch0));
+
+        // The two writers report different first epochs and both get the max.
+        let (aligned_epoch1, aligned_epoch2) = try_join(
+            client1.align_initial_epoch(epoch1),
+            client2.align_initial_epoch(epoch2),
+        )
+        .await
+        .unwrap();
+        assert_eq!(aligned_epoch1, epoch2);
+        assert_eq!(aligned_epoch2, epoch2);
+
+        // After alignment both writers commit on the same epoch.
+        let mut commit_future = pin!(
+            client1
+                .commit(
+                    epoch3,
+                    SinkMetadata {
+                        metadata: Some(Metadata::Serialized(SerializedMetadata {
+                            metadata: metadata[0].clone(),
+                        })),
+                    },
+                    None,
+                )
+                .map(|result| result.unwrap())
+        );
+        assert!(
+            poll_fn(|cx| Poll::Ready(commit_future.as_mut().poll(cx)))
+                .await
+                .is_pending()
+        );
+        join(
+            commit_future,
+            client2
+                .commit(
+                    epoch3,
+                    SinkMetadata {
+                        metadata: Some(Metadata::Serialized(SerializedMetadata {
+                            metadata: metadata[1].clone(),
+                        })),
+                    },
+                    None,
+                )
+                .map(|result| result.unwrap()),
+        )
+        .await;
+
+        for _ in 0..50 {
+            tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+            let rows = list_rows(&db).await;
+            if rows.len() == 1 && rows[0].2 == "COMMITTED" {
+                break;
+            }
+        }
+
+        assert_eq!(commit_attempt.load(std::sync::atomic::Ordering::SeqCst), 1);
+        let rows = list_rows(&db).await;
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].1, epoch3 as i64);
         assert_eq!(rows[0].2, "COMMITTED");
     }
 


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

Fix a permanent, silent commit deadlock of coordinated (exactly-once) sinks after recovery. Full production analysis in #26492.

Root cause: the initial-epoch alignment from #21213 only runs when the coordinator provides no rewind epoch, but the recovered rewind epoch can be staler than a writer's truncation watermark — an acked commit with empty metadata (`pre_commit` → `None`) truncates the log stores without leaving any durable trace. After such a recovery, parallel writers replay from different epochs, their local commit counters request commits on different epochs forever, and the coordinator (which pops `pending_epochs` only when the smallest epoch covers the full vnode bitmap) waits silently forever. Restarts reproduce the same state deterministically.

Changes:

- Writer: always align the initial epoch with the coordinator; the rewind epoch is only a lower bound of the read range. Items skipped below the aligned epoch belong to already-acked commits, so no data is lost. This also self-heals sinks already stuck in the diverged state.
- Coordinator: collect and align initial epochs on cold start regardless of the rewind epoch. Non-cold-start rounds (vnode bitmap update / scale-in) are unchanged — existing writers are position-locked by the forced commit on the reschedule barrier; a stray `AlignInitialEpoch` from a writer started in such a round is acked back as-is instead of erroring.
- Fail fast when commit requests land on two different epochs (previously an unbounded silent wait), so any future divergence surfaces as a sink error and rewind instead of a hang.
- Regression test `test_align_initial_epoch_with_rewind`: two writers with `Some(rewind)` and diverged first epochs get aligned to the max and commit on the same epoch.

Note: during a rolling upgrade, a mixed old-writer/new-meta (or reverse) pair may bounce with a visible error until both sides are upgraded — the same transient as when #21213 landed.

- Closes #26492

## Checklist

- [x] I have written necessary rustdoc comments.
- [x] I have added necessary unit tests and integration tests.
- [x] I have added test labels as necessary.
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them.
- [ ] <!-- OPTIONAL --> My PR contains breaking changes.
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results.
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into.

## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates.

<details>
<summary><b>Release note</b></summary>

</details>
