### PR TITLE
fix(storage): bound SST iterator by read table id

### DIFF
--- a/src/meta/src/barrier/context/mod.rs
+++ b/src/meta/src/barrier/context/mod.rs
@@ -151,6 +151,7 @@ pub(super) struct GlobalBarrierWorkerContextImpl {
 }
 
 impl GlobalBarrierWorkerContextImpl {
+    #[expect(clippy::too_many_arguments)]
     pub(super) fn new(
         scheduled_barriers: ScheduledBarriers,
         status: Arc<ArcSwap<BarrierManagerStatus>>,

--- a/src/meta/src/barrier/manager.rs
+++ b/src/meta/src/barrier/manager.rs
@@ -193,7 +193,6 @@ impl GlobalBarrierManager {
 }
 
 impl GlobalBarrierManager {
-    #[expect(clippy::too_many_arguments)]
     pub async fn start(
         scheduled_barriers: schedule::ScheduledBarriers,
         env: MetaSrvEnv,

--- a/src/meta/src/barrier/worker.rs
+++ b/src/meta/src/barrier/worker.rs
@@ -139,6 +139,7 @@ impl<C: GlobalBarrierWorkerContext> GlobalBarrierWorker<C> {
 
 impl GlobalBarrierWorker<GlobalBarrierWorkerContextImpl> {
     /// Create a new [`crate::barrier::worker::GlobalBarrierWorker`].
+    #[expect(clippy::too_many_arguments)]
     pub async fn new(
         scheduled_barriers: schedule::ScheduledBarriers,
         env: MetaSrvEnv,

--- a/src/storage/benches/bench_compactor.rs
+++ b/src/storage/benches/bench_compactor.rs
@@ -354,6 +354,7 @@ fn bench_merge_iterator_compactor(c: &mut Criterion) {
     let level2 = vec![info1, info2];
     let read_options = Arc::new(SstableIteratorReadOptions {
         cache_policy: CachePolicy::Fill(Hint::Normal),
+        read_table_id: None,
         scan_end_user_key: None,
         prefetch: false,
         max_preload_retry_times: 0,

--- a/src/storage/src/hummock/event_handler/hummock_event_handler.rs
+++ b/src/storage/src/hummock/event_handler/hummock_event_handler.rs
@@ -1326,7 +1326,7 @@ mod tests {
         let storage_opt = default_opts_for_test();
         let (spawn_upload_task, _) = prepare_uploader_order_test_spawn_task_fn(false);
         let pinned_version = PinnedVersion::new(
-            LocalHummockVersion::from_rpc_protobuf(&PbHummockVersion {
+            HummockVersion::from_rpc_protobuf(&PbHummockVersion {
                 id: 1.into(),
                 ..Default::default()
             }),

--- a/src/storage/src/hummock/event_handler/refiller.rs
+++ b/src/storage/src/hummock/event_handler/refiller.rs
@@ -1076,7 +1076,7 @@ mod tests {
     use risingwave_hummock_sdk::compaction_group::group_split::split_sst_with_table_ids;
     use risingwave_hummock_sdk::key::{FullKey, UserKey, prefix_slice_with_vnode};
     use risingwave_hummock_sdk::sstable_info::{SstableInfo, SstableInfoInner};
-    use risingwave_hummock_sdk::version::LocalHummockVersion;
+    use risingwave_hummock_sdk::version::HummockVersion;
     use risingwave_hummock_sdk::{EpochWithGap, HummockSstableObjectId};
     use risingwave_pb::hummock::PbHummockVersion;
     use risingwave_pb::id::TableId;
@@ -1113,7 +1113,7 @@ mod tests {
 
     fn pinned_version_for_test() -> PinnedVersion {
         PinnedVersion::new(
-            LocalHummockVersion::from_rpc_protobuf(&PbHummockVersion::default()),
+            HummockVersion::from_rpc_protobuf(&PbHummockVersion::default()),
             unbounded_channel().0,
         )
     }

--- a/src/storage/src/hummock/observer_manager.rs
+++ b/src/storage/src/hummock/observer_manager.rs
@@ -130,13 +130,11 @@ impl ObserverState for HummockObserverNode {
         let _ = self
             .observer_event_sender
             .send(HummockObserverEvent::VersionUpdate(
-                HummockVersionUpdate::PinnedVersion(Box::new(
-                    HummockVersion::from_rpc_protobuf(
-                        &snapshot
-                            .hummock_version
-                            .expect("should get hummock version"),
-                    ),
-                )),
+                HummockVersionUpdate::PinnedVersion(Box::new(HummockVersion::from_rpc_protobuf(
+                    &snapshot
+                        .hummock_version
+                        .expect("should get hummock version"),
+                ))),
             ))
             .inspect_err(|e| {
                 tracing::error!(event = ?e.0, "unable to send full version");

--- a/src/storage/src/hummock/sstable/forward_sstable_iterator.rs
+++ b/src/storage/src/hummock/sstable/forward_sstable_iterator.rs
@@ -76,10 +76,24 @@ impl SstableIterator {
             sstable_info_ref.sst_id,
             sstable_info_ref.object_id,
         );
-        let read_table_id_range = (
-            *sstable_info_ref.table_ids.first().unwrap(),
-            *sstable_info_ref.table_ids.last().unwrap(),
-        );
+        let read_table_id_range = if let Some(read_table_id) = options.read_table_id {
+            assert!(
+                sstable_info_ref
+                    .table_ids
+                    .binary_search(&read_table_id)
+                    .is_ok(),
+                "read table id {} not found in SST {} table_ids {:?}",
+                read_table_id,
+                sstable_info_ref.sst_id,
+                sstable_info_ref.table_ids
+            );
+            (read_table_id, read_table_id)
+        } else {
+            (
+                *sstable_info_ref.table_ids.first().unwrap(),
+                *sstable_info_ref.table_ids.last().unwrap(),
+            )
+        };
         assert!(
             read_table_id_range.0 <= read_table_id_range.1,
             "invalid table id range {} - {}",
@@ -590,6 +604,7 @@ mod tests {
         );
         let options = Arc::new(SstableIteratorReadOptions {
             cache_policy: CachePolicy::Fill(Hint::Normal),
+            read_table_id: None,
             scan_end_user_key: Some(Bound::Included(uk.clone())),
             prefetch: true,
             max_preload_retry_times: 0,
@@ -690,6 +705,7 @@ mod tests {
         for (case, prefetch) in [("prefetch off", false), ("prefetch on", true)] {
             let options = Arc::new(SstableIteratorReadOptions {
                 cache_policy: CachePolicy::Disable,
+                read_table_id: None,
                 scan_end_user_key: Some(Bound::Excluded(table_3_start.clone())),
                 prefetch,
                 max_preload_retry_times: 0,
@@ -737,6 +753,28 @@ mod tests {
             }
         }
 
+        let options = Arc::new(SstableIteratorReadOptions {
+            cache_policy: CachePolicy::Disable,
+            read_table_id: Some(TableId::new(2)),
+            scan_end_user_key: None,
+            prefetch: false,
+            max_preload_retry_times: 0,
+        });
+        let mut sstable_iter = SstableIterator::create(
+            sstable.clone(),
+            sstable_store.clone(),
+            options,
+            &sstable_info,
+        );
+        assert_eq!(sstable_iter.block_start_idx_inclusive, table_2_block_start);
+        assert_eq!(sstable_iter.block_end_idx_exclusive, table_3_block_start);
+        sstable_iter.rewind().await.unwrap();
+        assert!(sstable_iter.is_valid());
+        while sstable_iter.is_valid() {
+            assert_eq!(sstable_iter.key().user_key.table_id, TableId::new(2));
+            sstable_iter.next().await.unwrap();
+        }
+
         let mut table_2_sstable_info = sstable_info.get_inner();
         table_2_sstable_info.table_ids = vec![TableId::new(2)];
         let table_2_sstable_info = SstableInfo::from(table_2_sstable_info);
@@ -746,6 +784,7 @@ mod tests {
                 .copy_into();
         let options = Arc::new(SstableIteratorReadOptions {
             cache_policy: CachePolicy::Disable,
+            read_table_id: None,
             scan_end_user_key: Some(Bound::Excluded(table_2_start)),
             prefetch: false,
             max_preload_retry_times: 0,

--- a/src/storage/src/hummock/sstable/mod.rs
+++ b/src/storage/src/hummock/sstable/mod.rs
@@ -490,6 +490,9 @@ impl SstableMeta {
 #[derive(Default)]
 pub struct SstableIteratorReadOptions {
     pub cache_policy: CachePolicy,
+    /// The table being read by the state-store request. When present, SST iterators can avoid
+    /// blocks for other tables that are colocated in the same physical SST.
+    pub read_table_id: Option<TableId>,
     /// The only hard upper bound of this scan. It limits the iterator's block window.
     pub scan_end_user_key: Option<Bound<UserKey<KeyPayloadType>>>,
     /// Whether to prefetch blocks within the already-bounded scan window.
@@ -503,6 +506,7 @@ impl SstableIteratorReadOptions {
     pub fn from_read_options(read_options: &ReadOptions) -> Self {
         Self {
             cache_policy: read_options.cache_policy,
+            read_table_id: None,
             scan_end_user_key: None,
             prefetch: false,
             max_preload_retry_times: 0,

--- a/src/storage/src/hummock/store/version.rs
+++ b/src/storage/src/hummock/store/version.rs
@@ -1001,6 +1001,7 @@ impl HummockVersionReader {
             .as_ref()
             .map(|hint| Sstable::hash_for_bloom_filter(hint, table_id.as_raw_id()));
         let mut sst_read_options = SstableIteratorReadOptions::from_read_options(&read_options);
+        sst_read_options.read_table_id = Some(table_id);
         sst_read_options.scan_end_user_key = Some(user_key_range.1.map(|key| key.cloned()));
         sst_read_options.prefetch = read_options.prefetch_options.prefetch;
         if sst_read_options.prefetch {
@@ -1166,6 +1167,7 @@ impl HummockVersionReader {
         }
         let read_options = Arc::new(SstableIteratorReadOptions {
             cache_policy: Default::default(),
+            read_table_id: Some(options.table_id),
             scan_end_user_key: None,
             prefetch: false,
             max_preload_retry_times: 0,

--- a/src/storage/src/hummock/validator.rs
+++ b/src/storage/src/hummock/validator.rs
@@ -65,6 +65,7 @@ pub async fn validate_ssts(task: ValidationTask, sstable_store: SstableStoreRef)
             sstable_store.clone(),
             Arc::new(SstableIteratorReadOptions {
                 cache_policy: CachePolicy::NotFill,
+                read_table_id: None,
                 scan_end_user_key: None,
                 prefetch: false,
                 max_preload_retry_times: 0,


### PR DESCRIPTION
## Summary
- pass table-specific read context into SST iterator options
- restrict colocated SST block windows to the requested table id when available
- add iterator coverage for table-id-bounded reads

## Tests
- `git diff --check -- src/storage/src/hummock/sstable/forward_sstable_iterator.rs src/storage/src/hummock/sstable/mod.rs src/storage/src/hummock/store/version.rs src/storage/src/hummock/validator.rs`
- `cargo test -p risingwave_storage hummock::sstable::forward_sstable_iterator::tests::test_read_table_id_range` *(fails before running target test: existing unresolved `LocalHummockVersion::from_rpc_protobuf` references in Hummock event handler/refiller test code)*