### PR TITLE
fix(sink): persist empty pre-commit epochs

### DIFF
--- a/src/meta/src/manager/sink_coordination/coordinator_worker.rs
+++ b/src/meta/src/manager/sink_coordination/coordinator_worker.rs
@@ -857,21 +857,24 @@ impl CoordinatorWorker {
                                 epoch,
                             ))
                             .await?;
-                        if commit_metadata.is_some() || first_schema_change.is_some() {
-                            persist_pre_commit_metadata(
-                                &db,
-                                sink_id as _,
-                                epoch,
-                                commit_metadata.clone(),
-                                first_schema_change.as_ref(),
-                            )
-                            .await?;
-                            two_phase_handler.push_new_item(
-                                epoch,
-                                commit_metadata,
-                                first_schema_change,
-                            );
-                        }
+                        // Persist every acknowledged epoch, even when there is no metadata or
+                        // schema change. Writers may truncate the epoch as soon as they receive
+                        // the acknowledgement, so recovery must retain the same progress. The
+                        // commit handler treats a `None`/`None` item as an external no-op before
+                        // marking it committed, and recovery re-enqueues it through the same path.
+                        persist_pre_commit_metadata(
+                            &db,
+                            sink_id as _,
+                            epoch,
+                            commit_metadata.clone(),
+                            first_schema_change.as_ref(),
+                        )
+                        .await?;
+                        two_phase_handler.push_new_item(
+                            epoch,
+                            commit_metadata,
+                            first_schema_change,
+                        );
                     }
                 }
 

--- a/src/meta/src/manager/sink_coordination/manager.rs
+++ b/src/meta/src/manager/sink_coordination/manager.rs
@@ -1530,7 +1530,7 @@ mod tests {
                 sink_id i32 NOT NULL,
                 epoch i64 NOT NULL,
                 sink_state STRING NOT NULL,
-                metadata BLOB NOT NULL,
+                metadata BLOB,
                 schema_change BLOB,
                 PRIMARY KEY (sink_id, epoch)
             )
@@ -1546,7 +1546,13 @@ mod tests {
 
     async fn list_rows(
         db: &DatabaseConnection,
-    ) -> Vec<(i32, i64, String, Vec<u8>, Option<PbSinkSchemaChange>)> {
+    ) -> Vec<(
+        i32,
+        i64,
+        String,
+        Option<Vec<u8>>,
+        Option<PbSinkSchemaChange>,
+    )> {
         let sql =
             "SELECT sink_id, epoch, sink_state, metadata, schema_change FROM pending_sink_state";
         let rows = db
@@ -1585,7 +1591,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_init_response_skips_recovered_pending_epoch() {
+    async fn test_init_response_skips_recovered_empty_pending_epoch() {
         let db = prepare_db_backend().await;
 
         let param = SinkParam {
@@ -1602,10 +1608,9 @@ mod tests {
         };
 
         let epoch1 = 233;
-        let metadata = vec![1u8, 2u8];
 
         let sql = format!(
-            "INSERT INTO pending_sink_state (sink_id, epoch, sink_state, metadata) VALUES ({}, {}, 'PENDING', x'0102')",
+            "INSERT INTO pending_sink_state (sink_id, epoch, sink_state) VALUES ({}, {}, 'PENDING')",
             param.sink_id, epoch1
         );
         db.execute(sea_orm::Statement::from_string(
@@ -1646,13 +1651,11 @@ mod tests {
             SinkCoordinatorManager::start_worker_with_spawn_worker({
                 let expected_param = param.clone();
                 let db = db.clone();
-                let metadata = metadata.clone();
                 let pre_commit_attempt = pre_commit_attempt.clone();
                 let commit_attempt = commit_attempt.clone();
                 move |param, new_writer_rx| {
                     let expected_param = expected_param.clone();
                     let db = db.clone();
-                    let metadata = metadata.clone();
                     let pre_commit_attempt = pre_commit_attempt.clone();
                     let commit_attempt = commit_attempt.clone();
                     tokio::spawn({
@@ -1673,9 +1676,7 @@ mod tests {
                                             "pre_commit should not be called for a known pending epoch"
                                         )))
                                     },
-                                    move |epoch, commit_metadata| {
-                                        assert_eq!(epoch, epoch1);
-                                        assert_eq!(commit_metadata, metadata);
+                                    move |_epoch, _commit_metadata| {
                                         commit_attempt
                                             .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
                                         Ok(())
@@ -1716,11 +1717,12 @@ mod tests {
             pre_commit_attempt.load(std::sync::atomic::Ordering::SeqCst),
             0
         );
-        assert_eq!(commit_attempt.load(std::sync::atomic::Ordering::SeqCst), 1);
+        assert_eq!(commit_attempt.load(std::sync::atomic::Ordering::SeqCst), 0);
         let rows = list_rows(&db).await;
         assert_eq!(rows.len(), 1);
         assert_eq!(rows[0].1, epoch1 as i64);
         assert_eq!(rows[0].2, "COMMITTED");
+        assert_eq!(rows[0].3, None);
     }
 
     #[tokio::test]
@@ -1837,7 +1839,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_waiting_on_checkpoint() {
+    async fn test_empty_pre_commit_waiting_on_checkpoint() {
         let db = prepare_db_backend().await;
 
         let param = SinkParam {
@@ -1886,10 +1888,8 @@ mod tests {
         let (manager, (_join_handle, _stop_tx)) =
             SinkCoordinatorManager::start_worker_with_spawn_worker({
                 let expected_param = param.clone();
-                let metadata = metadata.clone();
                 let db = db.clone();
                 move |param, new_writer_rx| {
-                    let metadata = metadata.clone();
                     let expected_param = expected_param.clone();
                     let db = db.clone();
                     tokio::spawn({
@@ -1903,20 +1903,10 @@ mod tests {
                                 new_writer_rx,
                                 MockTwoPhaseCoordinator::new_coordinator(
                                     move |_epoch, metadata_list, _schema_change| {
-                                        let metadata =
-                                            Itertools::exactly_one(metadata_list.into_iter())
-                                                .unwrap();
-                                        Ok(match metadata.metadata {
-                                            Some(Metadata::Serialized(SerializedMetadata {
-                                                metadata,
-                                            })) => Some(metadata),
-                                            _ => unreachable!(),
-                                        })
+                                        assert_eq!(metadata_list.len(), 1);
+                                        Ok(None)
                                     },
-                                    move |_epoch, commit_metadata| {
-                                        assert_eq!(commit_metadata, metadata);
-                                        Ok(())
-                                    },
+                                    move |_epoch, _commit_metadata| unreachable!(),
                                     move |_epoch, _schema_change| unreachable!(),
                                 ),
                                 subscriber.clone(),
@@ -1965,10 +1955,11 @@ mod tests {
             assert_eq!(rows.len(), 1);
             assert_eq!(rows[0].1, epoch1 as i64);
             assert_eq!(rows[0].2, "PENDING");
+            assert_eq!(rows[0].3, None);
 
             let guard = sender.lock().await;
             let sender = guard.as_ref().unwrap().clone();
-            sender.send(233).unwrap();
+            sender.send(epoch1).unwrap();
         }
 
         // wait max 5 seconds for the commit to be processed
@@ -1985,6 +1976,7 @@ mod tests {
             assert_eq!(rows.len(), 1);
             assert_eq!(rows[0].1, epoch1 as i64);
             assert_eq!(rows[0].2, "COMMITTED");
+            assert_eq!(rows[0].3, None);
         }
     }
 


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

Exactly-once coordinated sink writers truncate their log stores after the coordinator acknowledges a pre-commit epoch. Previously, when a two-phase coordinator returned no commit metadata and there was no schema change, the coordinator acknowledged the epoch without persisting it. After uneven truncation became durable across parallel writers, recovery could therefore return a stale rewind epoch and permanently misalign their commit boundaries.

This change restores the persist-before-ack invariant:

- Persist every successful two-phase pre-commit epoch, including an epoch-only record with `NULL` commit metadata and schema change.
- Enqueue the epoch-only record in the existing two-phase handler. After Hummock commits the epoch, the handler performs no external connector commit, marks the record committed, and prunes the previous record.
- Recover nullable pending records through the same handler and use their epoch as the writer rewind point.
- Update the coordinator test schema to match the nullable production schema and cover both the normal empty pre-commit lifecycle and recovery from an empty pending record.

This prevents new occurrences of the deadlock. It does not automatically repair a sink whose log-store truncation was already split before upgrading; temporarily scaling that sink to parallelism 1 remains the operational recovery.

- Closes #26492

## Checklist

- [x] I have written necessary rustdoc comments.
- [x] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [x] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

Fix exactly-once coordinated sinks getting stuck after recovery when an empty pre-commit epoch had no durable coordinator record.

</details>
