### PR TITLE
perf(storage): prune irrelevant SSTs before cache refill

### DIFF
--- a/src/storage/src/hummock/event_handler/refiller.rs
+++ b/src/storage/src/hummock/event_handler/refiller.rs
@@ -440,10 +440,58 @@ impl CacheRefiller {
 
     pub(crate) fn start_cache_refill(
         &mut self,
-        deltas: Vec<SstDeltaInfo>,
+        mut deltas: Vec<SstDeltaInfo>,
         pinned_version: PinnedVersion,
         new_pinned_version: PinnedVersion,
     ) {
+        for delta in &mut deltas {
+            let for_serving = self.role.for_serving();
+            // Writer-appended L0 SSTs are already warm on the streaming side. Their data refill
+            // may therefore only be needed by serving workers.
+            let for_streaming =
+                self.role.for_streaming() && !delta.delete_sst_object_ids.is_empty();
+
+            if !for_serving && !for_streaming {
+                delta.insert_sst_infos.clear();
+                continue;
+            }
+
+            // This is deliberately a whole-SST admission check before Meta load. The serving
+            // mapping key set identifies result tables, but bitmap contents remain for the exact
+            // block/vnode decision in DataCacheRefillTaskGenerator after Meta load. An SST stays
+            // when any contained table matches either the serving or streaming refill lane.
+            delta.insert_sst_infos.retain(|sst| {
+                sst.table_ids.iter().any(|table_id| {
+                    // A missing entry means there is no table override, not that the table is
+                    // absent. Preserve the configured legacy/default policy in that case.
+                    let policy = self
+                        .table_cache_refill_policies
+                        .get(table_id)
+                        .copied()
+                        .unwrap_or(self.default_policy);
+
+                    // Enabled preserves legacy full refill. For scoped policies, mapping keys are
+                    // only a whole-SST coarse gate; bitmap bits still filter blocks post-Meta.
+                    match policy {
+                        CacheRefillPolicy::Enabled => for_streaming || for_serving,
+                        CacheRefillPolicy::Disabled => false,
+                        CacheRefillPolicy::Streaming => {
+                            for_streaming
+                                && self.streaming_table_vnode_mapping.contains_key(table_id)
+                        }
+                        CacheRefillPolicy::Serving => {
+                            for_serving && self.serving_table_vnode_mapping.contains_key(table_id)
+                        }
+                        CacheRefillPolicy::Both => {
+                            (for_streaming
+                                && self.streaming_table_vnode_mapping.contains_key(table_id))
+                                || (for_serving
+                                    && self.serving_table_vnode_mapping.contains_key(table_id))
+                        }
+                    }
+                })
+            });
+        }
         let context = self.new_cache_refill_context(&deltas);
         let handle = (self.spawn_refill_task)(
             deltas,
@@ -1418,6 +1466,276 @@ mod tests {
             .unwrap();
         assert_eq!(context.policy, CacheRefillPolicy::Serving);
         assert_eq!(context.serving_vnode_bitmap.as_ref(), Some(&old_vnodes));
+    }
+
+    #[tokio::test]
+    async fn test_cache_refill_prunes_whole_ssts_before_meta_load() {
+        let streaming_table = TableId::from(1);
+        let serving_table = TableId::from(2);
+        let disabled_table = TableId::from(3);
+        let internal_table = TableId::from(4);
+        let fallback_table = TableId::from(5);
+        let serving_vnodes = Bitmap::ones(VirtualNode::COUNT_FOR_TEST);
+        let sstable_store = mock_sstable_store().await;
+        let sst_info = |table_ids: Vec<TableId>| {
+            SstableInfo::from(SstableInfoInner {
+                table_ids,
+                ..Default::default()
+            })
+        };
+        let capture_pruned_table_ids = |role,
+                                        default_policy,
+                                        policies: HashMap<TableId, CacheRefillPolicy>,
+                                        streaming_table_vnodes: HashMap<TableId, Bitmap>,
+                                        serving_table_vnodes: HashMap<TableId, Bitmap>,
+                                        delta| {
+            let captured_deltas = Arc::new(Mutex::new(None::<Vec<SstDeltaInfo>>));
+            let captured_deltas_clone = captured_deltas.clone();
+            let spawn_refill_task: SpawnRefillTask = Arc::new(move |deltas, _, _, _| {
+                *captured_deltas_clone.lock() = Some(deltas);
+                tokio::spawn(async {})
+            });
+            let mut refiller = CacheRefiller::new(
+                role,
+                test_refill_config(default_policy),
+                sstable_store.clone(),
+                spawn_refill_task,
+            );
+            refiller.replace_table_cache_refill_policies(policies);
+            for (table_id, vnodes) in streaming_table_vnodes {
+                refiller.update_streaming_table_vnodes(table_id, Some(vnodes));
+            }
+            refiller.replace_serving_table_vnode_mapping(serving_table_vnodes);
+            refiller.start_cache_refill(
+                vec![delta],
+                pinned_version_for_test(),
+                pinned_version_for_test(),
+            );
+            captured_deltas
+                .lock()
+                .take()
+                .unwrap()
+                .pop()
+                .unwrap()
+                .insert_sst_infos
+                .into_iter()
+                .map(|sst| sst.table_ids.clone())
+                .collect::<Vec<_>>()
+        };
+
+        let normal_delta = |insert_sst_infos| SstDeltaInfo {
+            insert_sst_infos,
+            delete_sst_object_ids: vec![1.into()],
+            insert_sst_level: 1,
+        };
+        let insert_only_delta = |insert_sst_infos| SstDeltaInfo {
+            insert_sst_infos,
+            delete_sst_object_ids: vec![],
+            insert_sst_level: 0,
+        };
+
+        assert_eq!(
+            capture_pruned_table_ids(
+                Role::Both,
+                CacheRefillPolicy::Disabled,
+                HashMap::from([
+                    (disabled_table, CacheRefillPolicy::Disabled),
+                    (streaming_table, CacheRefillPolicy::Enabled),
+                ]),
+                HashMap::new(),
+                HashMap::new(),
+                normal_delta(vec![
+                    sst_info(vec![disabled_table]),
+                    sst_info(vec![streaming_table]),
+                ]),
+            ),
+            vec![vec![streaming_table]],
+        );
+
+        assert_eq!(
+            capture_pruned_table_ids(
+                Role::Both,
+                CacheRefillPolicy::Disabled,
+                HashMap::from([
+                    (streaming_table, CacheRefillPolicy::Streaming),
+                    (internal_table, CacheRefillPolicy::Serving),
+                ]),
+                HashMap::from([(streaming_table, serving_vnodes.clone())]),
+                HashMap::new(),
+                normal_delta(vec![
+                    sst_info(vec![streaming_table]),
+                    sst_info(vec![internal_table]),
+                ]),
+            ),
+            vec![vec![streaming_table]],
+        );
+
+        assert_eq!(
+            capture_pruned_table_ids(
+                Role::Both,
+                CacheRefillPolicy::Disabled,
+                HashMap::from([
+                    (streaming_table, CacheRefillPolicy::Streaming),
+                    (serving_table, CacheRefillPolicy::Serving),
+                    (internal_table, CacheRefillPolicy::Serving),
+                ]),
+                HashMap::from([(streaming_table, serving_vnodes.clone())]),
+                HashMap::from([(serving_table, serving_vnodes.clone())]),
+                insert_only_delta(vec![
+                    sst_info(vec![streaming_table]),
+                    sst_info(vec![serving_table]),
+                    sst_info(vec![internal_table]),
+                ]),
+            ),
+            vec![vec![serving_table]],
+        );
+
+        assert_eq!(
+            capture_pruned_table_ids(
+                Role::Serving,
+                CacheRefillPolicy::Disabled,
+                HashMap::from([
+                    (streaming_table, CacheRefillPolicy::Streaming),
+                    (serving_table, CacheRefillPolicy::Serving),
+                ]),
+                HashMap::new(),
+                HashMap::from([(serving_table, serving_vnodes.clone())]),
+                normal_delta(vec![
+                    sst_info(vec![streaming_table]),
+                    sst_info(vec![serving_table]),
+                ]),
+            ),
+            vec![vec![serving_table]],
+        );
+
+        assert_eq!(
+            capture_pruned_table_ids(
+                Role::Serving,
+                CacheRefillPolicy::Disabled,
+                HashMap::from([
+                    (streaming_table, CacheRefillPolicy::Enabled),
+                    (serving_table, CacheRefillPolicy::Enabled),
+                ]),
+                HashMap::new(),
+                HashMap::from([(serving_table, serving_vnodes.clone())]),
+                normal_delta(vec![
+                    sst_info(vec![streaming_table]),
+                    sst_info(vec![serving_table]),
+                    sst_info(vec![streaming_table, serving_table]),
+                ]),
+            ),
+            vec![
+                vec![streaming_table],
+                vec![serving_table],
+                vec![streaming_table, serving_table],
+            ],
+        );
+
+        assert_eq!(
+            capture_pruned_table_ids(
+                Role::Both,
+                CacheRefillPolicy::Disabled,
+                HashMap::from([
+                    (streaming_table, CacheRefillPolicy::Both),
+                    (serving_table, CacheRefillPolicy::Both),
+                ]),
+                HashMap::new(),
+                HashMap::new(),
+                normal_delta(vec![
+                    sst_info(vec![streaming_table]),
+                    sst_info(vec![serving_table]),
+                ]),
+            ),
+            Vec::<Vec<TableId>>::new(),
+        );
+
+        assert_eq!(
+            capture_pruned_table_ids(
+                Role::Both,
+                CacheRefillPolicy::Disabled,
+                HashMap::from([
+                    (streaming_table, CacheRefillPolicy::Both),
+                    (serving_table, CacheRefillPolicy::Both),
+                ]),
+                HashMap::from([(streaming_table, serving_vnodes.clone())]),
+                HashMap::new(),
+                normal_delta(vec![
+                    sst_info(vec![streaming_table]),
+                    sst_info(vec![serving_table]),
+                ]),
+            ),
+            vec![vec![streaming_table]],
+        );
+
+        assert_eq!(
+            capture_pruned_table_ids(
+                Role::Both,
+                CacheRefillPolicy::Disabled,
+                HashMap::from([
+                    (streaming_table, CacheRefillPolicy::Both),
+                    (serving_table, CacheRefillPolicy::Both),
+                ]),
+                HashMap::new(),
+                HashMap::from([(serving_table, serving_vnodes.clone())]),
+                normal_delta(vec![
+                    sst_info(vec![streaming_table]),
+                    sst_info(vec![serving_table]),
+                ]),
+            ),
+            vec![vec![serving_table]],
+        );
+
+        assert_eq!(
+            capture_pruned_table_ids(
+                Role::Streaming,
+                CacheRefillPolicy::Disabled,
+                HashMap::from([
+                    (streaming_table, CacheRefillPolicy::Streaming),
+                    (serving_table, CacheRefillPolicy::Serving),
+                ]),
+                HashMap::new(),
+                HashMap::new(),
+                normal_delta(vec![
+                    sst_info(vec![streaming_table]),
+                    sst_info(vec![serving_table]),
+                ]),
+            ),
+            Vec::<Vec<TableId>>::new(),
+        );
+
+        assert_eq!(
+            capture_pruned_table_ids(
+                Role::Streaming,
+                CacheRefillPolicy::Disabled,
+                HashMap::from([
+                    (streaming_table, CacheRefillPolicy::Streaming),
+                    (serving_table, CacheRefillPolicy::Serving),
+                ]),
+                HashMap::new(),
+                HashMap::new(),
+                insert_only_delta(vec![
+                    sst_info(vec![streaming_table]),
+                    sst_info(vec![serving_table]),
+                ]),
+            ),
+            Vec::<Vec<TableId>>::new(),
+        );
+
+        assert_eq!(
+            capture_pruned_table_ids(
+                Role::Both,
+                CacheRefillPolicy::Enabled,
+                HashMap::from([(disabled_table, CacheRefillPolicy::Disabled)]),
+                HashMap::new(),
+                HashMap::new(),
+                normal_delta(vec![
+                    sst_info(vec![disabled_table]),
+                    sst_info(vec![fallback_table]),
+                    sst_info(vec![disabled_table, fallback_table]),
+                ]),
+            ),
+            vec![vec![fallback_table], vec![disabled_table, fallback_table]],
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

This PR cherry-picks `d505d79` into `patch/v2.8.5-refill`. The change prunes SSTs that cannot be relevant before cache refill, reducing unnecessary refill work while preserving the existing refill behavior for relevant key ranges.

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

</details>
