### PR TITLE
fix(test): query join state table counts directly

### DIFF
--- a/e2e_test/streaming/join/hash_join_watermark.slt.part
+++ b/e2e_test/streaming/join/hash_join_watermark.slt.part
@@ -151,17 +151,13 @@ SELECT hwm_left_ts, _degree FROM ${left_degree_tname};
 ----
 2024-01-01 00:00:10+00:00 1
 
-query I retry 21 backoff 1s
-SELECT total_key_count
-FROM rw_catalog.rw_table_stats
-WHERE id = ${right_state_tid};
+query I
+SELECT count(*) FROM ${right_state_tname};
 ----
 1
 
-query I retry 21 backoff 1s
-SELECT total_key_count
-FROM rw_catalog.rw_table_stats
-WHERE id = ${left_degree_tid};
+query I
+SELECT count(*) FROM ${left_degree_tname};
 ----
 1
 

--- a/e2e_test/streaming/join/interval_join.slt.part
+++ b/e2e_test/streaming/join/interval_join.slt.part
@@ -190,17 +190,13 @@ SELECT right_table_id, right_table_ts FROM ${right_state_table};
 1 2024-01-01 00:00:05+00:00
 2 2024-01-01 00:00:25+00:00
 
-query I retry 21 backoff 1s
-SELECT total_key_count
-FROM rw_catalog.rw_table_stats
-WHERE id = ${left_state_table_id};
+query I
+SELECT count(*) FROM ${left_state_table};
 ----
 1
 
-query I retry 21 backoff 1s
-SELECT total_key_count
-FROM rw_catalog.rw_table_stats
-WHERE id = ${right_state_table_id};
+query I
+SELECT count(*) FROM ${right_state_table};
 ----
 2
 
@@ -457,10 +453,8 @@ SELECT stream_b_id, stream_b_ts FROM ${between_right_state_tname} ORDER BY strea
 ----
 3 2024-01-01 00:00:55+00:00
 
-query I retry 21 backoff 1s
-SELECT total_key_count
-FROM rw_catalog.rw_table_stats
-WHERE id = ${between_left_state_tid};
+query I
+SELECT count(*) FROM ${between_left_state_tname};
 ----
 1
 


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

Replace join state-cleaning SLT assertions against the eventually updated `rw_table_stats` catalog with direct `count(*)` queries against the internal state tables.

The tests already resolve the internal state table names through `rw_internal_table_info`. Reusing those names avoids the flaky catalog propagation path while preserving the same row-count assertions.

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [x] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->

## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

Not applicable; this changes test implementation only.

</details>

## Tests

- `cargo clippy --all-targets --all-features`
- SLT parser formatting smoke check for both modified test parts
- `python3 e2e_test/check_slt_coverage.py -d`
- `git diff --check`
