### PR TITLE
fix(storage): restrict point get SST blocks by table id

### DIFF
--- a/src/storage/benches/bench_block_iter.rs
+++ b/src/storage/benches/bench_block_iter.rs
@@ -16,7 +16,7 @@ use std::sync::LazyLock;
 
 use bytes::{BufMut, Bytes, BytesMut};
 use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
-use risingwave_hummock_sdk::key::FullKey;
+use risingwave_hummock_sdk::key::{FullKey, TABLE_PREFIX_LEN};
 use risingwave_storage::hummock::{
     Block, BlockBuilder, BlockBuilderOptions, BlockHolder, BlockIterator, CompressionAlgorithm,
 };
@@ -148,7 +148,13 @@ fn build_block_data(t: u32, i: u64) -> Bytes {
                 (k_ext, v_ext) = (&DATA_LEN_SET[ext_index].0, &DATA_LEN_SET[ext_index].1);
             }
 
-            builder.add_for_test(FullKey::decode(&key(tt, ii, k_ext)), &value(ii, v_ext));
+            let encoded_key = key(tt, ii, k_ext);
+            let full_key = FullKey::decode(&encoded_key);
+            builder.add(
+                full_key.user_key.table_id,
+                &encoded_key[TABLE_PREFIX_LEN..],
+                &value(ii, v_ext),
+            );
         }
     }
     Bytes::from(builder.build().to_vec())

--- a/src/storage/src/hummock/mod.rs
+++ b/src/storage/src/hummock/mod.rs
@@ -95,10 +95,13 @@ pub async fn get_from_sstable_info(
         return Ok(None);
     }
 
+    let mut iterator_read_options = SstableIteratorReadOptions::from_read_options(read_options);
+    iterator_read_options.read_table_id = Some(full_key.user_key.table_id);
+
     let mut iter = SstableIterator::create(
         sstable,
         sstable_store_ref.clone(),
-        Arc::new(SstableIteratorReadOptions::from_read_options(read_options)),
+        Arc::new(iterator_read_options),
         sstable_info,
     );
     iter.seek(full_key).await?;
@@ -145,4 +148,87 @@ pub fn get_from_batch<'a>(
     imm.get(table_key, read_epoch, read_options).inspect(|_| {
         local_stats.get_shared_buffer_hit_counts += 1;
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use bytes::Bytes;
+    use risingwave_common::catalog::TableId;
+    use risingwave_common::hash::VirtualNode;
+    use risingwave_common::util::epoch::test_epoch;
+    use risingwave_hummock_sdk::EpochWithGap;
+    use risingwave_hummock_sdk::key::{FullKey, TableKey, UserKey};
+
+    use super::{CachePolicy, HummockValue, get_from_sstable_info};
+    use crate::hummock::iterator::test_utils::mock_sstable_store;
+    use crate::hummock::test_utils::{
+        default_builder_opt_for_test, gen_test_sstable_with_table_ids, test_value_of,
+    };
+    use crate::monitor::StoreLocalStatistic;
+    use crate::store::ReadOptions;
+
+    #[tokio::test]
+    async fn test_point_get_reads_only_requested_table_blocks() {
+        let sstable_store = mock_sstable_store().await;
+        let mut builder_options = default_builder_opt_for_test();
+        builder_options.block_capacity = 128;
+
+        let test_user_key = |table_id, key: &str| {
+            UserKey::new(
+                TableId::new(table_id),
+                TableKey(Bytes::from(
+                    [VirtualNode::ZERO.to_be_bytes().as_slice(), key.as_bytes()].concat(),
+                )),
+            )
+        };
+        let test_key = |table_id, key: &str| FullKey {
+            user_key: test_user_key(table_id, key),
+            epoch_with_gap: EpochWithGap::new_from_epoch(test_epoch(1)),
+        };
+        let kv_pairs = (1..=2).flat_map(|table_id| {
+            (0..8).map(move |idx| {
+                (
+                    test_key(table_id, &format!("key_{idx:05}")),
+                    HummockValue::put(Bytes::from(test_value_of(idx))),
+                )
+            })
+        });
+        let (sstable, sstable_info) = gen_test_sstable_with_table_ids(
+            builder_options,
+            10,
+            kv_pairs,
+            sstable_store.clone(),
+            vec![1, 2],
+        )
+        .await;
+        let table_2_block_start = sstable
+            .meta
+            .block_metas
+            .partition_point(|block_meta| block_meta.table_id() < TableId::new(2));
+        assert!(table_2_block_start > 0);
+
+        // The queried table-2 key sorts before the first table-2 block. Without a point-get table
+        // id filter, the SST iterator seeks to the previous table-1 block first.
+        let full_key = test_key(2, "key");
+        let mut local_stats = StoreLocalStatistic::default();
+        let read_options = ReadOptions {
+            cache_policy: CachePolicy::Disable,
+            ..Default::default()
+        };
+
+        {
+            let result = get_from_sstable_info(
+                sstable_store,
+                &sstable_info,
+                full_key.to_ref(),
+                &read_options,
+                None,
+                &mut local_stats,
+            )
+            .await
+            .unwrap();
+            assert!(result.is_none());
+        }
+        assert_eq!(local_stats.cache_data_block_total, 1);
+    }
 }


### PR DESCRIPTION
## What
- Set `read_table_id` for point-get SST iterators so they only seek/read blocks for the requested table within a colocated SST.
- Update `bench_block_iter` to use the public `BlockBuilder::add` API so storage clippy `--all-targets` can compile benches.
- Add a regression test for point get avoiding blocks from another table in the same SST.

## Tests
- `cargo fmt --check`
- `cargo clippy -p risingwave_storage --all-targets -- -D warnings`
- `cargo test -p risingwave_storage test_point_get_reads_only_requested_table_blocks --lib`
- `cargo test -p risingwave_storage test_get_skips_sst_by_table_id_filter --lib`