### PR TITLE
fix(sink): persist empty pre-commit epochs (#26498)

### DIFF
--- a/src/meta/src/manager/sink_coordination/coordinator_worker.rs
+++ b/src/meta/src/manager/sink_coordination/coordinator_worker.rs
@@ -858,21 +858,24 @@ impl CoordinatorWorker {
                                 epoch,
                             ))
                             .await?;
-                        if commit_metadata.is_some() || first_schema_change.is_some() {
-                            persist_pre_commit_metadata(
-                                &db,
-                                sink_id as _,
-                                epoch,
-                                commit_metadata.clone(),
-                                first_schema_change.as_ref(),
-                            )
-                            .await?;
-                            two_phase_handler.push_new_item(
-                                epoch,
-                                commit_metadata,
-                                first_schema_change,
-                            );
-                        }
+                        // Persist every acknowledged epoch, even when there is no metadata or
+                        // schema change. Writers may truncate the epoch as soon as they receive
+                        // the acknowledgement, so recovery must retain the same progress. The
+                        // commit handler treats a `None`/`None` item as an external no-op before
+                        // marking it committed, and recovery re-enqueues it through the same path.
+                        persist_pre_commit_metadata(
+                            &db,
+                            sink_id as _,
+                            epoch,
+                            commit_metadata.clone(),
+                            first_schema_change.as_ref(),
+                        )
+                        .await?;
+                        two_phase_handler.push_new_item(
+                            epoch,
+                            commit_metadata,
+                            first_schema_change,
+                        );
                     }
                 }
 

--- a/src/meta/src/manager/sink_coordination/manager.rs
+++ b/src/meta/src/manager/sink_coordination/manager.rs
@@ -1531,7 +1531,7 @@ mod tests {
                 sink_id i32 NOT NULL,
                 epoch i64 NOT NULL,
                 sink_state STRING NOT NULL,
-                metadata BLOB NOT NULL,
+                metadata BLOB,
                 schema_change BLOB,
                 PRIMARY KEY (sink_id, epoch)
             )
@@ -1547,7 +1547,13 @@ mod tests {
 
     async fn list_rows(
         db: &DatabaseConnection,
-    ) -> Vec<(i32, i64, String, Vec<u8>, Option<PbSinkSchemaChange>)> {
+    ) -> Vec<(
+        i32,
+        i64,
+        String,
+        Option<Vec<u8>>,
+        Option<PbSinkSchemaChange>,
+    )> {
         let sql =
             "SELECT sink_id, epoch, sink_state, metadata, schema_change FROM pending_sink_state";
         let rows = db
@@ -1586,7 +1592,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_init_response_skips_recovered_pending_epoch() {
+    async fn test_init_response_skips_recovered_empty_pending_epoch() {
         let db = prepare_db_backend().await;
 
         let param = SinkParam {
@@ -1603,10 +1609,9 @@ mod tests {
         };
 
         let epoch1 = 233;
-        let metadata = vec![1u8, 2u8];
 
         let sql = format!(
-            "INSERT INTO pending_sink_state (sink_id, epoch, sink_state, metadata) VALUES ({}, {}, 'PENDING', x'0102')",
+            "INSERT INTO pending_sink_state (sink_id, epoch, sink_state) VALUES ({}, {}, 'PENDING')",
             param.sink_id, epoch1
         );
         db.execute(sea_orm::Statement::from_string(
@@ -1647,13 +1652,11 @@ mod tests {
             SinkCoordinatorManager::start_worker_with_spawn_worker({
                 let expected_param = param.clone();
                 let db = db.clone();
-                let metadata = metadata.clone();
                 let pre_commit_attempt = pre_commit_attempt.clone();
                 let commit_attempt = commit_attempt.clone();
                 move |param, new_writer_rx| {
                     let expected_param = expected_param.clone();
                     let db = db.clone();
-                    let metadata = metadata.clone();
                     let pre_commit_attempt = pre_commit_attempt.clone();
                     let commit_attempt = commit_attempt.clone();
                     tokio::spawn({
@@ -1674,9 +1677,7 @@ mod tests {
                                             "pre_commit should not be called for a known pending epoch"
                                         )))
                                     },
-                                    move |epoch, commit_metadata| {
-                                        assert_eq!(epoch, epoch1);
-                                        assert_eq!(commit_metadata, metadata);
+                                    move |_epoch, _commit_metadata| {
                                         commit_attempt
                                             .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
                                         Ok(())
@@ -1717,11 +1718,12 @@ mod tests {
             pre_commit_attempt.load(std::sync::atomic::Ordering::SeqCst),
             0
         );
-        assert_eq!(commit_attempt.load(std::sync::atomic::Ordering::SeqCst), 1);
+        assert_eq!(commit_attempt.load(std::sync::atomic::Ordering::SeqCst), 0);
         let rows = list_rows(&db).await;
         assert_eq!(rows.len(), 1);
         assert_eq!(rows[0].1, epoch1 as i64);
         assert_eq!(rows[0].2, "COMMITTED");
+        assert_eq!(rows[0].3, None);
     }
 
     #[tokio::test]
@@ -1838,7 +1840,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_waiting_on_checkpoint() {
+    async fn test_empty_pre_commit_waiting_on_checkpoint() {
         let db = prepare_db_backend().await;
 
         let param = SinkParam {
@@ -1887,10 +1889,8 @@ mod tests {
         let (manager, (_join_handle, _stop_tx)) =
             SinkCoordinatorManager::start_worker_with_spawn_worker({
                 let expected_param = param.clone();
-                let metadata = metadata.clone();
                 let db = db.clone();
                 move |param, new_writer_rx| {
-                    let metadata = metadata.clone();
                     let expected_param = expected_param.clone();
                     let db = db.clone();
                     tokio::spawn({
@@ -1904,19 +1904,10 @@ mod tests {
                                 new_writer_rx,
                                 MockTwoPhaseCoordinator::new_coordinator(
                                     move |_epoch, metadata_list, _schema_change| {
-                                        let metadata =
-                                            metadata_list.into_iter().exactly_one().unwrap();
-                                        Ok(match metadata.metadata {
-                                            Some(Metadata::Serialized(SerializedMetadata {
-                                                metadata,
-                                            })) => Some(metadata),
-                                            _ => unreachable!(),
-                                        })
+                                        assert_eq!(metadata_list.len(), 1);
+                                        Ok(None)
                                     },
-                                    move |_epoch, commit_metadata| {
-                                        assert_eq!(commit_metadata, metadata);
-                                        Ok(())
-                                    },
+                                    move |_epoch, _commit_metadata| unreachable!(),
                                     move |_epoch, _schema_change| unreachable!(),
                                 ),
                                 subscriber.clone(),
@@ -1965,10 +1956,11 @@ mod tests {
             assert_eq!(rows.len(), 1);
             assert_eq!(rows[0].1, epoch1 as i64);
             assert_eq!(rows[0].2, "PENDING");
+            assert_eq!(rows[0].3, None);
 
             let guard = sender.lock().await;
             let sender = guard.as_ref().unwrap().clone();
-            sender.send(233).unwrap();
+            sender.send(epoch1).unwrap();
         }
 
         // wait max 5 seconds for the commit to be processed
@@ -1985,6 +1977,7 @@ mod tests {
             assert_eq!(rows.len(), 1);
             assert_eq!(rows[0].1, epoch1 as i64);
             assert_eq!(rows[0].2, "COMMITTED");
+            assert_eq!(rows[0].3, None);
         }
     }
 


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

Manual cherry-pick of #26498 onto `release-3.0`. The automated cherry-pick action hit a conflict and opened #26506 instead.

Original-PR: risingwavelabs/risingwave#26498
Cherry-picked from commit 27fc54ea3223d974a814ba9b4154656d0c2bb748.

### Conflict resolution

One conflict, in the test `test_empty_pre_commit_waiting_on_checkpoint` in `manager.rs`. It is not a semantic divergence: `main` rewrote `metadata_list.into_iter().exactly_one().unwrap()` into `Itertools::exactly_one(metadata_list.into_iter()).unwrap()` in a10c7cdc13 (toolchain bump, not backported), so the removed context did not match here.

Resolved by taking the upstream side of the conflicting hunk only. The three other `exactly_one` call sites and the rest of the file keep their `release-3.0` form, so the diff stays equal to the original commit.

The production change in `coordinator_worker.rs` applied cleanly and is unmodified. `release-3.0` already handles a `None` metadata / `None` schema change item as a commit-time no-op, and `pending_sink_state.metadata` is already nullable there, so no prerequisite commit is missing.

- Closes #26506

## Checklist

- [x] I have written necessary rustdoc comments.
- [x] I have added necessary unit tests and integration tests.
- [x] I have added test labels as necessary.

## Documentation

- [ ] My PR needs documentation updates.
