### PR TITLE
fix(cdc): fail initial backfill on invalid primary keys

### DIFF
--- a/src/connector/src/parser/mod.rs
+++ b/src/connector/src/parser/mod.rs
@@ -16,6 +16,7 @@ use std::collections::HashMap;
 use std::fmt::Debug;
 use std::sync::LazyLock;
 
+use anyhow::{Context, bail};
 use auto_enums::auto_enum;
 pub use avro::AvroParserConfig;
 pub use canal::*;
@@ -27,18 +28,29 @@ use futures_async_stream::try_stream;
 pub use json_parser::*;
 pub use parquet_parser::ParquetParser;
 pub use protobuf::*;
-use risingwave_common::catalog::{CDC_TABLE_NAME_COLUMN_NAME, KAFKA_TIMESTAMP_COLUMN_NAME};
+use risingwave_common::catalog::{
+    CDC_TABLE_NAME_COLUMN_NAME, Field, KAFKA_TIMESTAMP_COLUMN_NAME, Schema,
+};
 use risingwave_common::log::LogSuppressor;
 use risingwave_common::metrics::GLOBAL_ERROR_METRICS;
-use risingwave_common::types::{DatumCow, DatumRef};
+use risingwave_common::row::OwnedRow;
+use risingwave_common::types::{Datum, DatumCow, DatumRef};
 use risingwave_common::util::tracing::InstrumentStream;
 use risingwave_connector_codec::decoder::avro::MapHandling;
 use thiserror_ext::AsReport;
 
-pub use self::mysql::{mysql_datum_to_rw_datum, mysql_row_to_owned_row};
+pub use self::mysql::{
+    mysql_datum_to_rw_datum, mysql_row_to_owned_row, mysql_row_to_owned_row_with_strict_pk,
+};
 use self::plain_parser::PlainParser;
-pub use self::postgres::{postgres_cell_to_scalar_impl, postgres_row_to_owned_row};
-pub use self::sql_server::{ScalarImplTiberiusWrapper, sql_server_row_to_owned_row};
+pub use self::postgres::{
+    postgres_cell_to_scalar_impl, postgres_cell_to_scalar_impl_strict, postgres_row_to_owned_row,
+    postgres_row_to_owned_row_with_strict_pk,
+};
+pub use self::sql_server::{
+    ScalarImplTiberiusWrapper, sql_server_row_to_owned_row,
+    sql_server_row_to_owned_row_with_strict_pk,
+};
 pub use self::unified::Access;
 pub use self::unified::json::{
     BigintUnsignedHandlingMode, JsonAccess, TimeHandling, TimestampHandling, TimestamptzHandling,
@@ -53,6 +65,132 @@ use crate::source::{
     SourceContext, SourceContextRef, SourceCtrlOpts, SourceMessageEvent, SourceMeta,
     SourceReaderEvent,
 };
+
+fn decode_row_with_strict_pk(
+    connector_name: &str,
+    schema: &Schema,
+    pk_indices: &[usize],
+    mut decode: impl FnMut(usize, &Field) -> anyhow::Result<Datum>,
+    mut log_non_pk_error: impl FnMut(&str, anyhow::Error),
+) -> anyhow::Result<OwnedRow> {
+    if let Some(index) = pk_indices
+        .iter()
+        .copied()
+        .find(|index| *index >= schema.fields.len())
+    {
+        bail!(
+            "{connector_name} snapshot primary-key index {index} is out of bounds for {} columns",
+            schema.fields.len()
+        );
+    }
+
+    let mut datums = Vec::with_capacity(schema.fields.len());
+    for (index, field) in schema.fields.iter().enumerate() {
+        let is_pk = pk_indices.contains(&index);
+        let decode_result = decode(index, field);
+        let datum = if is_pk {
+            decode_result.with_context(|| {
+                format!(
+                    "failed to decode {connector_name} snapshot primary key `{}`",
+                    field.name
+                )
+            })?
+        } else {
+            match decode_result {
+                Ok(datum) => datum,
+                Err(err) => {
+                    log_non_pk_error(&field.name, err);
+                    None
+                }
+            }
+        };
+        if is_pk && datum.is_none() {
+            bail!(
+                "{connector_name} snapshot primary key `{}` cannot be NULL",
+                field.name
+            );
+        }
+        datums.push(datum);
+    }
+    Ok(OwnedRow::new(datums))
+}
+
+#[cfg(test)]
+mod strict_pk_tests {
+    use anyhow::anyhow;
+    use risingwave_common::row::Row;
+    use risingwave_common::types::{DataType, ScalarImpl};
+
+    use super::*;
+
+    fn test_schema() -> Schema {
+        Schema::new(vec![
+            Field::with_name(DataType::Int32, "id"),
+            Field::with_name(DataType::Int32, "payload"),
+        ])
+    }
+
+    #[test]
+    fn strict_pk_propagates_decode_error() {
+        let err = decode_row_with_strict_pk(
+            "test",
+            &test_schema(),
+            &[0],
+            |index, _| {
+                if index == 0 {
+                    Err(anyhow!("malformed integer"))
+                } else {
+                    Ok(Some(ScalarImpl::Int32(1)))
+                }
+            },
+            |_, _| unreachable!(),
+        )
+        .unwrap_err();
+
+        assert!(err.to_string().contains("snapshot primary key `id`"));
+        assert!(format!("{err:#}").contains("malformed integer"));
+    }
+
+    #[test]
+    fn strict_pk_rejects_decoded_null() {
+        let err = decode_row_with_strict_pk(
+            "test",
+            &test_schema(),
+            &[0],
+            |_, _| Ok(None),
+            |_, _| unreachable!(),
+        )
+        .unwrap_err();
+
+        assert!(
+            err.to_string()
+                .contains("snapshot primary key `id` cannot be NULL")
+        );
+    }
+
+    #[test]
+    fn strict_pk_keeps_non_pk_decode_lenient() {
+        let mut logged_columns = Vec::new();
+        let row = decode_row_with_strict_pk(
+            "test",
+            &test_schema(),
+            &[0],
+            |index, _| {
+                if index == 0 {
+                    Ok(Some(ScalarImpl::Int32(1)))
+                } else {
+                    Err(anyhow!("malformed payload"))
+                }
+            },
+            |name, _| logged_columns.push(name.to_owned()),
+        )
+        .unwrap();
+
+        assert!(row.datum_at(0).is_some());
+        assert!(row.datum_at(1).is_none());
+        assert_eq!(logged_columns, ["payload"]);
+    }
+}
 
 mod access_builder;
 pub mod additional_columns;

--- a/src/connector/src/parser/mysql.rs
+++ b/src/connector/src/parser/mysql.rs
@@ -266,18 +266,97 @@ pub fn mysql_row_to_owned_row(mysql_row: &mut MysqlRow, schema: &Schema) -> Owne
     OwnedRow::new(datums)
 }
 
+/// Decode primary-key columns strictly while preserving the legacy lenient behavior for all
+/// other columns in a MySQL CDC snapshot row.
+pub fn mysql_row_to_owned_row_with_strict_pk(
+    mysql_row: &mut MysqlRow,
+    schema: &Schema,
+    pk_indices: &[usize],
+) -> anyhow::Result<OwnedRow> {
+    super::decode_row_with_strict_pk(
+        "MySQL",
+        schema,
+        pk_indices,
+        |index, field| mysql_datum_to_rw_datum(mysql_row, index, &field.name, &field.data_type),
+        |name, err| log_error!(name, err, "parse column failed"),
+    )
+}
+
 #[cfg(test)]
 mod tests {
+
+    use std::sync::Arc;
 
     use futures::pin_mut;
     use mysql_async::Row as MySqlRow;
     use mysql_async::prelude::*;
+    use mysql_common::constants::ColumnType;
+    use mysql_common::packets::Column;
+    use mysql_common::row::new_row;
+    use mysql_common::value::Value;
     use risingwave_common::catalog::{Field, Schema};
     use risingwave_common::row::Row;
     use risingwave_common::types::DataType;
     use tokio_stream::StreamExt;
 
-    use crate::parser::mysql_row_to_owned_row;
+    use crate::parser::{mysql_row_to_owned_row, mysql_row_to_owned_row_with_strict_pk};
+
+    fn mysql_row(values: Vec<Value>, names: &[&str]) -> MySqlRow {
+        let columns = names
+            .iter()
+            .map(|name| Column::new(ColumnType::MYSQL_TYPE_VAR_STRING).with_name(name.as_bytes()))
+            .collect::<Vec<_>>();
+        new_row(values, Arc::from(columns))
+    }
+
+    #[test]
+    fn strict_pk_decode_rejects_malformed_value() {
+        let schema = Schema::new(vec![
+            Field::with_name(DataType::Int32, "id"),
+            Field::with_name(DataType::Varchar, "payload"),
+        ]);
+        let mut row = mysql_row(
+            vec![
+                Value::Bytes(b"not-an-int".to_vec()),
+                Value::Bytes(b"ok".to_vec()),
+            ],
+            &["id", "payload"],
+        );
+
+        let err = mysql_row_to_owned_row_with_strict_pk(&mut row, &schema, &[0]).unwrap_err();
+        assert!(err.to_string().contains("primary key `id`"));
+    }
+
+    #[test]
+    fn strict_pk_decode_rejects_null_value() {
+        let schema = Schema::new(vec![
+            Field::with_name(DataType::Int32, "id"),
+            Field::with_name(DataType::Varchar, "payload"),
+        ]);
+        let mut row = mysql_row(
+            vec![Value::NULL, Value::Bytes(b"ok".to_vec())],
+            &["id", "payload"],
+        );
+
+        let err = mysql_row_to_owned_row_with_strict_pk(&mut row, &schema, &[0]).unwrap_err();
+        assert!(err.to_string().contains("primary key `id` cannot be NULL"));
+    }
+
+    #[test]
+    fn strict_pk_decode_keeps_non_pk_conversion_lenient() {
+        let schema = Schema::new(vec![
+            Field::with_name(DataType::Int32, "id"),
+            Field::with_name(DataType::Int32, "payload"),
+        ]);
+        let mut row = mysql_row(
+            vec![Value::Int(1), Value::Bytes(b"not-an-int".to_vec())],
+            &["id", "payload"],
+        );
+
+        let row = mysql_row_to_owned_row_with_strict_pk(&mut row, &schema, &[0]).unwrap();
+        assert!(row.datum_at(0).is_some());
+        assert!(row.datum_at(1).is_none());
+    }
 
     // manual test case
     #[ignore]

--- a/src/connector/src/parser/postgres.rs
+++ b/src/connector/src/parser/postgres.rs
@@ -14,12 +14,13 @@
 
 use std::sync::LazyLock;
 
+use anyhow::{Context, anyhow, bail};
 use bytes::Buf;
 use risingwave_common::array::Finite32;
 use risingwave_common::catalog::Schema;
 use risingwave_common::log::LogSuppressor;
 use risingwave_common::row::OwnedRow;
-use risingwave_common::types::{DataType, Decimal, ScalarImpl, VectorVal};
+use risingwave_common::types::{DataType, Datum, Decimal, ScalarImpl, VectorVal};
 use thiserror_ext::AsReport;
 use tokio_postgres::types::{FromSql, Type};
 
@@ -66,16 +67,17 @@ impl PgVectorAdapter {
     }
 }
 
-macro_rules! handle_data_type {
+macro_rules! try_handle_data_type {
     ($row:expr, $i:expr, $name:expr, $type:ty) => {{
-        let res = $row.try_get::<_, Option<$type>>($i);
-        match res {
-            Ok(val) => val.map(|v| ScalarImpl::from(v)),
-            Err(err) => {
-                log_error!($name, err, "parse column failed");
-                None
-            }
-        }
+        $row.try_get::<_, Option<$type>>($i)
+            .map(|value| value.map(ScalarImpl::from))
+            .with_context(|| {
+                format!(
+                    "failed to decode PostgreSQL snapshot column `{}` as {}",
+                    $name,
+                    stringify!($type)
+                )
+            })
     }};
 }
 
@@ -90,12 +92,45 @@ pub fn postgres_row_to_owned_row(row: tokio_postgres::Row, schema: &Schema) -> O
     OwnedRow::new(datums)
 }
 
+/// Decode primary-key columns strictly while preserving the legacy lenient behavior for all
+/// other columns in a PostgreSQL CDC snapshot row.
+pub fn postgres_row_to_owned_row_with_strict_pk(
+    row: tokio_postgres::Row,
+    schema: &Schema,
+    pk_indices: &[usize],
+) -> anyhow::Result<OwnedRow> {
+    super::decode_row_with_strict_pk(
+        "PostgreSQL",
+        schema,
+        pk_indices,
+        |index, field| {
+            postgres_cell_to_scalar_impl_strict(&row, &field.data_type, index, &field.name)
+        },
+        |name, err| log_error!(name, err, "parse column failed"),
+    )
+}
+
 pub fn postgres_cell_to_scalar_impl(
     row: &tokio_postgres::Row,
     data_type: &DataType,
     i: usize,
     name: &str,
 ) -> Option<ScalarImpl> {
+    match postgres_cell_to_scalar_impl_strict(row, data_type, i, name) {
+        Ok(datum) => datum,
+        Err(err) => {
+            log_error!(name, err, "parse column failed");
+            None
+        }
+    }
+}
+
+pub fn postgres_cell_to_scalar_impl_strict(
+    row: &tokio_postgres::Row,
+    data_type: &DataType,
+    i: usize,
+    name: &str,
+) -> anyhow::Result<Datum> {
     // We observe several incompatibility issue in Debezium's Postgres connector. We summarize them here:
     // Issue #1. The null of enum list is not supported in Debezium. An enum list contains `NULL` will fallback to `NULL`.
     // Issue #2. In our parser, when there's inf, -inf, nan or invalid item in a list, the whole list will fallback null.
@@ -114,89 +149,76 @@ pub fn postgres_cell_to_scalar_impl(
         | DataType::Interval
         | DataType::Bytea => {
             // ScalarAdapter is also fine. But ScalarImpl is more efficient
-            let res = row.try_get::<_, Option<ScalarImpl>>(i);
-            match res {
-                Ok(val) => val,
-                Err(err) => {
-                    log_error!(name, err, "parse column failed");
-                    None
-                }
-            }
+            row.try_get::<_, Option<ScalarImpl>>(i)
+                .with_context(|| format!("failed to decode PostgreSQL snapshot column `{name}`"))
         }
         DataType::Decimal => {
             // Decimal is more efficient than PgNumeric in ScalarAdapter
-            handle_data_type!(row, i, name, Decimal)
+            try_handle_data_type!(row, i, name, Decimal)
         }
         DataType::Varchar | DataType::Int256 => {
-            let res = row.try_get::<_, Option<ScalarAdapter>>(i);
-            match res {
-                Ok(val) => val.and_then(|v| v.into_scalar(data_type)),
-                Err(err) => {
-                    log_error!(name, err, "parse column failed");
-                    None
-                }
+            match row
+                .try_get::<_, Option<ScalarAdapter>>(i)
+                .with_context(|| format!("failed to decode PostgreSQL snapshot column `{name}`"))?
+            {
+                Some(value) => value.into_scalar(data_type).map(Some).ok_or_else(|| {
+                    anyhow!("failed to convert PostgreSQL snapshot column `{name}` to {data_type}")
+                }),
+                None => Ok(None),
             }
         }
         DataType::Vector(expected_size) => {
-            let res = row.try_get::<_, Option<PgVectorAdapter>>(i);
-            match res {
-                Ok(Some(PgVectorAdapter(v))) => {
+            match row
+                .try_get::<_, Option<PgVectorAdapter>>(i)
+                .with_context(|| format!("failed to decode PostgreSQL snapshot column `{name}`"))?
+            {
+                Some(PgVectorAdapter(v)) => {
                     if v.len() != *expected_size {
-                        log_error!(
-                            name,
-                            anyhow::anyhow!(
-                                "vector dimension mismatch: expected {}, got {}",
-                                expected_size,
-                                v.len()
-                            ),
-                            "parse column failed"
+                        bail!(
+                            "PostgreSQL snapshot column `{name}` vector dimension mismatch: \
+                             expected {}, got {}",
+                            expected_size,
+                            v.len()
                         );
-                        return None;
                     }
                     let finite = v
                         .into_iter()
                         .map(Finite32::try_from)
-                        .collect::<Result<Vec<_>, _>>();
-                    match finite {
-                        Ok(finite) => Some(ScalarImpl::Vector(VectorVal::from(finite))),
-                        Err(err) => {
-                            log_error!(name, anyhow::anyhow!(err), "parse column failed");
-                            None
-                        }
-                    }
+                        .collect::<Result<Vec<_>, _>>()
+                        .map_err(anyhow::Error::msg)
+                        .with_context(|| {
+                            format!(
+                                "PostgreSQL snapshot column `{name}` contains a non-finite vector \
+                                 element"
+                            )
+                        })?;
+                    Ok(Some(ScalarImpl::Vector(VectorVal::from(finite))))
                 }
-                Ok(None) => None,
-                Err(err) => {
-                    log_error!(name, err, "parse column failed");
-                    None
-                }
+                None => Ok(None),
             }
         }
         DataType::List(list) => match list.elem() {
             // TODO(Kexiang): allow DataType::List(_)
             elem @ (DataType::Struct(_) | DataType::List(_) | DataType::Serial) => {
-                tracing::warn!(
-                    "unsupported List data type {:?}, set the List to empty",
-                    elem
-                );
-                None
+                bail!("unsupported PostgreSQL snapshot list element type {elem}")
             }
             _ => {
-                let res = row.try_get::<_, Option<ScalarAdapter>>(i);
-                match res {
-                    Ok(val) => val.and_then(|v| v.into_scalar(data_type)),
-                    Err(err) => {
-                        log_error!(name, err, "parse list column failed");
-                        None
-                    }
+                match row
+                    .try_get::<_, Option<ScalarAdapter>>(i)
+                    .with_context(|| {
+                        format!("failed to decode PostgreSQL snapshot list column `{name}`")
+                    })? {
+                    Some(value) => value.into_scalar(data_type).map(Some).ok_or_else(|| {
+                        anyhow!(
+                            "failed to convert PostgreSQL snapshot column `{name}` to {data_type}"
+                        )
+                    }),
+                    None => Ok(None),
                 }
             }
         },
         DataType::Struct(_) | DataType::Serial | DataType::Map(_) | DataType::Variant => {
-            // Is this branch reachable?
-            // Struct and Serial are not supported
-            tracing::warn!(name, ?data_type, "unsupported data type, set to null");
-            None
+            bail!("unsupported PostgreSQL snapshot data type {data_type} for column `{name}`")
         }
     }
 }

--- a/src/connector/src/parser/sql_server.rs
+++ b/src/connector/src/parser/sql_server.rs
@@ -16,11 +16,14 @@ use std::collections::HashSet;
 use std::str::FromStr;
 use std::sync::LazyLock;
 
+use anyhow::{Context, bail};
 use chrono::{NaiveDate, NaiveDateTime, NaiveTime};
 use risingwave_common::catalog::Schema;
 use risingwave_common::log::LogSuppressor;
 use risingwave_common::row::OwnedRow;
-use risingwave_common::types::{DataType, Date, Decimal, ScalarImpl, Time, Timestamp, Timestamptz};
+use risingwave_common::types::{
+    DataType, Date, Datum, Decimal, ScalarImpl, Time, Timestamp, Timestamptz,
+};
 use rust_decimal::Decimal as RustDecimal;
 use thiserror_ext::AsReport;
 use tiberius::Row;
@@ -32,40 +35,84 @@ use crate::parser::utils::log_error;
 static LOG_SUPPRESSOR: LazyLock<LogSuppressor> = LazyLock::new(LogSuppressor::default);
 
 pub fn sql_server_row_to_owned_row(row: &mut Row, schema: &Schema) -> OwnedRow {
-    let mut datums: Vec<Option<ScalarImpl>> = vec![];
-    let mut money_fields: HashSet<&str> = HashSet::new();
-    // Special handling of the money field, as the third-party library Tiberius converts the money type to i64.
-    for (column, _) in row.cells() {
-        if column.column_type() == tiberius::ColumnType::Money {
-            money_fields.insert(column.name());
-        }
-    }
-    for i in 0..schema.fields.len() {
-        let rw_field = &schema.fields[i];
+    let money_fields = sql_server_money_fields(row);
+    let mut datums = Vec::with_capacity(schema.fields.len());
+    for (i, rw_field) in schema.fields.iter().enumerate() {
         let name = rw_field.name.as_str();
-        let datum = match money_fields.contains(name) {
-            true => match row.try_get::<i64, usize>(i) {
-                Ok(Some(value)) => Some(convert_money_i64_to_type(value, &rw_field.data_type)),
-                Ok(None) => None,
-                Err(err) => {
-                    log_error!(name, err, "parse column failed");
-                    None
-                }
-            },
-            false => match row.try_get::<ScalarImplTiberiusWrapper, usize>(i) {
-                Ok(datum) => datum
-                    .map(|d| d.0)
-                    .map(|scalar| coerce_scalar_to_target_type(scalar, &rw_field.data_type)),
-                Err(err) => {
-                    log_error!(name, err, "parse column failed");
-                    None
-                }
-            },
+        let datum = match sql_server_cell_to_rw_datum(
+            row,
+            i,
+            name,
+            &rw_field.data_type,
+            money_fields.contains(name),
+        ) {
+            Ok(datum) => datum,
+            Err(err) => {
+                log_error!(name, err, "parse column failed");
+                None
+            }
         };
-
         datums.push(datum);
     }
     OwnedRow::new(datums)
+}
+
+/// Decode primary-key columns strictly while preserving the legacy lenient behavior for all
+/// other columns in a SQL Server CDC snapshot row.
+pub fn sql_server_row_to_owned_row_with_strict_pk(
+    row: &mut Row,
+    schema: &Schema,
+    pk_indices: &[usize],
+) -> anyhow::Result<OwnedRow> {
+    let money_fields = sql_server_money_fields(row);
+    super::decode_row_with_strict_pk(
+        "SQL Server",
+        schema,
+        pk_indices,
+        |index, field| {
+            sql_server_cell_to_rw_datum(
+                row,
+                index,
+                &field.name,
+                &field.data_type,
+                money_fields.contains(&field.name),
+            )
+        },
+        |name, err| log_error!(name, err, "parse column failed"),
+    )
+}
+
+fn sql_server_money_fields(row: &Row) -> HashSet<String> {
+    let mut money_fields = HashSet::new();
+    // Special handling of the money field, as the third-party library Tiberius converts the money type to i64.
+    for (column, _) in row.cells() {
+        if column.column_type() == tiberius::ColumnType::Money {
+            money_fields.insert(column.name().to_owned());
+        }
+    }
+    money_fields
+}
+
+fn sql_server_cell_to_rw_datum(
+    row: &Row,
+    index: usize,
+    name: &str,
+    data_type: &DataType,
+    is_money: bool,
+) -> anyhow::Result<Datum> {
+    if is_money {
+        return row
+            .try_get::<i64, usize>(index)
+            .with_context(|| format!("failed to decode SQL Server money column `{name}`"))?
+            .map(|value| try_convert_money_i64_to_type(value, data_type))
+            .transpose();
+    }
+
+    Ok(row
+        .try_get::<ScalarImplTiberiusWrapper, usize>(index)
+        .with_context(|| format!("failed to decode SQL Server snapshot column `{name}`"))?
+        .map(|datum| datum.0)
+        .map(|scalar| coerce_scalar_to_target_type(scalar, data_type)))
 }
 
 fn coerce_scalar_to_target_type(scalar: ScalarImpl, target_type: &DataType) -> ScalarImpl {
@@ -81,17 +128,12 @@ fn coerce_scalar_to_target_type(scalar: ScalarImpl, target_type: &DataType) -> S
     }
 }
 
-pub fn convert_money_i64_to_type(value: i64, data_type: &DataType) -> ScalarImpl {
+fn try_convert_money_i64_to_type(value: i64, data_type: &DataType) -> anyhow::Result<ScalarImpl> {
     match data_type {
-        DataType::Decimal => {
-            ScalarImpl::Decimal(Decimal::from(value) / Decimal::from_str("10000").unwrap())
-        }
-        _ => {
-            panic!(
-                "Conversion of Money type to {:?} is not supported",
-                data_type
-            );
-        }
+        DataType::Decimal => Ok(ScalarImpl::Decimal(
+            Decimal::from(value) / Decimal::from_str("10000").unwrap(),
+        )),
+        _ => bail!("conversion of SQL Server money to {data_type} is not supported"),
     }
 }
 

--- a/src/connector/src/source/cdc/external/mod.rs
+++ b/src/connector/src/source/cdc/external/mod.rs
@@ -35,7 +35,6 @@ use serde::{Deserialize, Serialize};
 use crate::WithPropertiesExt;
 use crate::connector_common::{PgConnectionConfig, PostgresExternalTable, SslMode};
 use crate::error::{ConnectorError, ConnectorResult};
-use crate::parser::mysql_row_to_owned_row;
 use crate::source::CdcTableSnapshotSplit;
 use crate::source::cdc::CdcSourceType;
 use crate::source::cdc::external::mock_external_table::MockExternalTableReader;
@@ -91,7 +90,7 @@ impl ExternalCdcTableType {
     ) -> ConnectorResult<ExternalTableReaderImpl> {
         match self {
             Self::MySql => Ok(ExternalTableReaderImpl::MySql(
-                MySqlExternalTableReader::new(config, schema).await?,
+                MySqlExternalTableReader::new(config, schema, pk_indices).await?,
             )),
             Self::Postgres => Ok(ExternalTableReaderImpl::Postgres(
                 PostgresExternalTableReader::new(config, schema, pk_indices, schema_table_name)

--- a/src/connector/src/source/cdc/external/mysql.rs
+++ b/src/connector/src/source/cdc/external/mysql.rs
@@ -41,10 +41,11 @@ use crate::connector_common::SslMode;
 // Re-export SslMode for convenience
 pub use crate::connector_common::SslMode as MySqlSslMode;
 use crate::error::{ConnectorError, ConnectorResult};
+use crate::parser::mysql_row_to_owned_row_with_strict_pk;
 use crate::source::CdcTableSnapshotSplit;
 use crate::source::cdc::external::{
     CdcOffset, CdcOffsetParseFunc, CdcTableSnapshotSplitOption, DebeziumOffset,
-    ExternalTableConfig, ExternalTableReader, SchemaTableName, mysql_row_to_owned_row,
+    ExternalTableConfig, ExternalTableReader, SchemaTableName,
 };
 
 /// Build MySQL connection pool with proper SSL configuration.
@@ -442,6 +443,7 @@ pub fn mysql_type_to_rw_type(col_type: &ColumnType) -> ConnectorResult<DataType>
 
 pub struct MySqlExternalTableReader {
     rw_schema: Schema,
+    pk_indices: Vec<usize>,
     field_names: String,
     pool: mysql_async::Pool,
     upstream_mysql_pk_infos: Vec<(String, ColumnType)>, // (column_name, column_type)
@@ -539,7 +541,11 @@ impl MySqlExternalTableReader {
         major > 8 || (major == 8 && minor >= 4)
     }
 
-    pub async fn new(config: ExternalTableConfig, rw_schema: Schema) -> ConnectorResult<Self> {
+    pub async fn new(
+        config: ExternalTableConfig,
+        rw_schema: Schema,
+        pk_indices: Vec<usize>,
+    ) -> ConnectorResult<Self> {
         let database = config.database.clone();
         let table = config.table.clone();
         let pool = build_mysql_connection_pool(
@@ -573,6 +579,7 @@ impl MySqlExternalTableReader {
 
         Ok(Self {
             rw_schema,
+            pk_indices,
             field_names,
             pool,
             upstream_mysql_pk_infos,
@@ -757,7 +764,8 @@ impl MySqlExternalTableReader {
             let row_stream = rs_stream.map(|row| {
                 // convert mysql row into OwnedRow
                 let mut row = row?;
-                Ok::<_, ConnectorError>(mysql_row_to_owned_row(&mut row, &self.rw_schema))
+                mysql_row_to_owned_row_with_strict_pk(&mut row, &self.rw_schema, &self.pk_indices)
+                    .map_err(ConnectorError::from)
             });
             pin_mut!(row_stream);
             #[for_await]
@@ -770,7 +778,8 @@ impl MySqlExternalTableReader {
             let row_stream = rs_stream.map(|row| {
                 // convert mysql row into OwnedRow
                 let mut row = row?;
-                Ok::<_, ConnectorError>(mysql_row_to_owned_row(&mut row, &self.rw_schema))
+                mysql_row_to_owned_row_with_strict_pk(&mut row, &self.rw_schema, &self.pk_indices)
+                    .map_err(ConnectorError::from)
             });
             pin_mut!(row_stream);
             #[for_await]
@@ -1019,7 +1028,7 @@ mod tests {
         let config =
             serde_json::from_value::<ExternalTableConfig>(serde_json::to_value(props).unwrap())
                 .unwrap();
-        let reader = MySqlExternalTableReader::new(config, rw_schema)
+        let reader = MySqlExternalTableReader::new(config, rw_schema, vec![0])
             .await
             .unwrap();
         let offset = reader.current_cdc_offset().await.unwrap();

--- a/src/connector/src/source/cdc/external/postgres.rs
+++ b/src/connector/src/source/cdc/external/postgres.rs
@@ -32,7 +32,9 @@ use tokio_postgres::types::{PgLsn, Type as PgType};
 use crate::connector_common::create_pg_client;
 use crate::error::{ConnectorError, ConnectorResult};
 use crate::parser::scalar_adapter::ScalarAdapter;
-use crate::parser::{postgres_cell_to_scalar_impl, postgres_row_to_owned_row};
+use crate::parser::{
+    postgres_cell_to_scalar_impl_strict, postgres_row_to_owned_row_with_strict_pk,
+};
 use crate::source::CdcTableSnapshotSplit;
 use crate::source::cdc::external::{
     CDC_TABLE_SPLIT_ID_START, CdcOffset, CdcOffsetParseFunc, CdcTableSnapshotSplitOption,
@@ -389,7 +391,8 @@ impl PostgresExternalTableReader {
 
         let row_stream = stream.map(|row| {
             let row = row?;
-            Ok::<_, crate::error::ConnectorError>(postgres_row_to_owned_row(row, &self.rw_schema))
+            postgres_row_to_owned_row_with_strict_pk(row, &self.rw_schema, &self.pk_indices)
+                .map_err(ConnectorError::from)
         });
 
         pin_mut!(row_stream);
@@ -489,10 +492,18 @@ impl PostgresExternalTableReader {
             Ok(None)
         } else {
             let row = &rows[0];
-            let min =
-                postgres_cell_to_scalar_impl(row, &split_column.data_type, 0, &split_column.name);
-            let max =
-                postgres_cell_to_scalar_impl(row, &split_column.data_type, 1, &split_column.name);
+            let min = postgres_cell_to_scalar_impl_strict(
+                row,
+                &split_column.data_type,
+                0,
+                &split_column.name,
+            )?;
+            let max = postgres_cell_to_scalar_impl_strict(
+                row,
+                &split_column.data_type,
+                1,
+                &split_column.name,
+            )?;
             match (min, max) {
                 (Some(min), Some(max)) => Ok(Some((min, max))),
                 _ => Ok(None),
@@ -532,12 +543,12 @@ impl PostgresExternalTableReader {
         let stream = client.query_raw(&prepared_stmt, &params).await?;
         let datum_stream = stream.map(|row| {
             let row = row?;
-            Ok::<_, ConnectorError>(postgres_cell_to_scalar_impl(
+            Ok::<_, ConnectorError>(postgres_cell_to_scalar_impl_strict(
                 &row,
                 &split_column.data_type,
                 0,
                 &split_column.name,
-            ))
+            )?)
         });
         pin_mut!(datum_stream);
         #[for_await]
@@ -576,12 +587,12 @@ impl PostgresExternalTableReader {
         let stream = client.query_raw(&prepared_stmt, &params).await?;
         let datum_stream = stream.map(|row| {
             let row = row?;
-            Ok::<_, ConnectorError>(postgres_cell_to_scalar_impl(
+            Ok::<_, ConnectorError>(postgres_cell_to_scalar_impl_strict(
                 &row,
                 &split_column.data_type,
                 0,
                 &split_column.name,
-            ))
+            )?)
         });
         pin_mut!(datum_stream);
         #[for_await]
@@ -657,7 +668,8 @@ impl PostgresExternalTableReader {
         let stream = client.query_raw(&prepared_scan_stmt, &params).await?;
         let row_stream = stream.map(|row| {
             let row = row?;
-            Ok::<_, crate::error::ConnectorError>(postgres_row_to_owned_row(row, &self.rw_schema))
+            postgres_row_to_owned_row_with_strict_pk(row, &self.rw_schema, &self.pk_indices)
+                .map_err(ConnectorError::from)
         });
 
         pin_mut!(row_stream);

--- a/src/connector/src/source/cdc/external/sql_server.rs
+++ b/src/connector/src/source/cdc/external/sql_server.rs
@@ -27,7 +27,7 @@ use serde::{Deserialize, Serialize};
 use tiberius::{Config, Query, QueryItem};
 
 use crate::error::{ConnectorError, ConnectorResult};
-use crate::parser::{ScalarImplTiberiusWrapper, sql_server_row_to_owned_row};
+use crate::parser::{ScalarImplTiberiusWrapper, sql_server_row_to_owned_row_with_strict_pk};
 use crate::sink::sqlserver::SqlServerClient;
 use crate::source::CdcTableSnapshotSplit;
 use crate::source::cdc::external::{
@@ -216,6 +216,7 @@ fn mssql_type_to_rw_type(col_type: &str, col_name: &str) -> ConnectorResult<Data
 #[derive(Debug)]
 pub struct SqlServerExternalTableReader {
     rw_schema: Schema,
+    pk_indices: Vec<usize>,
     field_names: String,
     client: tokio::sync::Mutex<SqlServerClient>,
 }
@@ -332,6 +333,7 @@ impl SqlServerExternalTableReader {
 
         Ok(Self {
             rw_schema,
+            pk_indices,
             field_names,
             client: tokio::sync::Mutex::new(client),
         })
@@ -380,9 +382,13 @@ impl SqlServerExternalTableReader {
         // FIXME(kexiang): Set session timezone to UTC
         if let Some(pk_row) = start_pk_row {
             let params: Vec<Option<ScalarImpl>> = pk_row.into_iter().collect();
-            for param in params {
-                // primary key should not be null, so it's safe to unwrap
-                sql.bind(ScalarImplTiberiusWrapper::from(param.unwrap()));
+            for (index, param) in params.into_iter().enumerate() {
+                let param = param.with_context(|| {
+                    format!(
+                        "SQL Server snapshot primary-key position at index {index} cannot be NULL"
+                    )
+                })?;
+                sql.bind(ScalarImplTiberiusWrapper::from(param));
             }
         }
 
@@ -391,7 +397,8 @@ impl SqlServerExternalTableReader {
         let row_stream = stream.map(|res| {
             // convert sql server row into OwnedRow
             let mut row = res?;
-            Ok::<_, ConnectorError>(sql_server_row_to_owned_row(&mut row, &self.rw_schema))
+            sql_server_row_to_owned_row_with_strict_pk(&mut row, &self.rw_schema, &self.pk_indices)
+                .map_err(ConnectorError::from)
         });
 
         pin_mut!(row_stream);

--- a/src/stream/src/executor/backfill/cdc/upstream_table/snapshot.rs
+++ b/src/stream/src/executor/backfill/cdc/upstream_table/snapshot.rs
@@ -403,7 +403,7 @@ mod tests {
         let config =
             serde_json::from_value::<ExternalTableConfig>(serde_json::to_value(props).unwrap())
                 .unwrap();
-        let reader = MySqlExternalTableReader::new(config, rw_schema.clone())
+        let reader = MySqlExternalTableReader::new(config, rw_schema.clone(), vec![0])
             .await
             .unwrap();
 


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

Initial CDC backfill previously converted snapshot decoding failures to `NULL` for every column. For primary-key columns, this could silently admit malformed or null keys and then produce incorrect pagination or progress state.

This PR:

- adds a shared snapshot-row decoder that strictly propagates primary-key decoding failures and rejects decoded `NULL` primary keys;
- keeps the existing error-to-`NULL` compatibility behavior for non-primary-key columns;
- applies strict primary-key decoding to MySQL, PostgreSQL, and SQL Server snapshot readers, including PostgreSQL parallel split bounds;
- replaces an SQL Server empty-progress `unwrap` with an explicit error; and
- adds regression tests for malformed and null primary keys, plus lenient non-primary-key decoding.

- Closes #26509

## Checklist

- [ ] I have written necessary rustdoc comments.
- [x] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [x] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->

## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

Initial snapshot/backfill for MySQL, PostgreSQL, and SQL Server CDC sources now fails instead of silently accepting an invalid or `NULL` primary-key value.

</details>
