### PR TITLE
feat(streaming): improve await-tree visibility for common waits

### DIFF
--- a/src/connector/src/sink/writer.rs
+++ b/src/connector/src/sink/writer.rs
@@ -17,6 +17,7 @@ use std::pin::pin;
 use std::time::Instant;
 
 use async_trait::async_trait;
+use await_tree::InstrumentAwait;
 use futures::TryFuture;
 use futures::future::{Either, select};
 use risingwave_common::array::StreamChunk;
@@ -142,7 +143,10 @@ impl<W: SinkWriter<CommitMetadata = ()>> LogSinker for LogSinkerOf<W> {
             // begin_epoch when not previously began
             state = match state {
                 LogConsumerState::Uninitialized => {
-                    sink_writer.begin_epoch(epoch).await?;
+                    sink_writer
+                        .begin_epoch(epoch)
+                        .instrument_await(await_tree::span!("sink_begin_epoch epoch={epoch}"))
+                        .await?;
                     LogConsumerState::EpochBegun { curr_epoch: epoch }
                 }
                 LogConsumerState::EpochBegun { curr_epoch } => {
@@ -161,14 +165,21 @@ impl<W: SinkWriter<CommitMetadata = ()>> LogSinker for LogSinkerOf<W> {
                         epoch,
                         prev_epoch
                     );
-                    sink_writer.begin_epoch(epoch).await?;
+                    sink_writer
+                        .begin_epoch(epoch)
+                        .instrument_await(await_tree::span!("sink_begin_epoch epoch={epoch}"))
+                        .await?;
                     LogConsumerState::EpochBegun { curr_epoch: epoch }
                 }
             };
             match item {
                 LogStoreReadItem::StreamChunk { chunk, .. } => {
-                    if let Err(e) = sink_writer.write_batch(chunk).await {
-                        sink_writer.abort().await?;
+                    if let Err(e) = sink_writer
+                        .write_batch(chunk)
+                        .instrument_await(await_tree::span!("sink_write_batch").verbose())
+                        .await
+                    {
+                        sink_writer.abort().instrument_await("sink_abort").await?;
                         return Err(e);
                     }
                 }
@@ -183,14 +194,24 @@ impl<W: SinkWriter<CommitMetadata = ()>> LogSinker for LogSinkerOf<W> {
                     };
                     if is_checkpoint {
                         let start_time = Instant::now();
-                        sink_writer.barrier(true).await?;
+                        sink_writer
+                            .barrier(true)
+                            .instrument_await(await_tree::span!(
+                                "sink_barrier checkpoint=true epoch={epoch}"
+                            ))
+                            .await?;
                         metrics
                             .sink_commit_duration
                             .observe(start_time.elapsed().as_secs_f64());
                         log_reader.truncate(TruncateOffset::Barrier { epoch })?;
                     } else {
                         assert!(new_vnode_bitmap.is_none());
-                        sink_writer.barrier(false).await?;
+                        sink_writer
+                            .barrier(false)
+                            .instrument_await(await_tree::span!(
+                                "sink_barrier checkpoint=false epoch={epoch}"
+                            ))
+                            .await?;
                     }
                     state = LogConsumerState::BarrierReceived { prev_epoch }
                 }
@@ -231,12 +252,12 @@ impl<W: AsyncTruncateSinkWriter> LogSinker for AsyncTruncateLogSinkerOf<W> {
     async fn consume_log_and_sink(mut self, mut log_reader: impl SinkLogReader) -> Result<!> {
         log_reader.start_from(None).await?;
         loop {
+            let next_truncate_offset = self
+                .future_manager
+                .next_truncate_offset()
+                .instrument_await("sink_wait_delivery");
             let select_result = drop_either_future(
-                select(
-                    pin!(log_reader.next_item()),
-                    pin!(self.future_manager.next_truncate_offset()),
-                )
-                .await,
+                select(pin!(log_reader.next_item()), pin!(next_truncate_offset)).await,
             );
             match select_result {
                 Either::Left(item_result) => {
@@ -244,10 +265,18 @@ impl<W: AsyncTruncateSinkWriter> LogSinker for AsyncTruncateLogSinkerOf<W> {
                     match item {
                         LogStoreReadItem::StreamChunk { chunk_id, chunk } => {
                             let add_future = self.future_manager.start_write_chunk(epoch, chunk_id);
-                            self.writer.write_chunk(chunk, add_future).await?;
+                            self.writer
+                                .write_chunk(chunk, add_future)
+                                .instrument_await(await_tree::span!("sink_write_batch").verbose())
+                                .await?;
                         }
                         LogStoreReadItem::Barrier { is_checkpoint, .. } => {
-                            self.writer.barrier(is_checkpoint).await?;
+                            self.writer
+                                .barrier(is_checkpoint)
+                                .instrument_await(await_tree::span!(
+                                    "sink_barrier checkpoint={is_checkpoint} epoch={epoch}"
+                                ))
+                                .await?;
                             self.future_manager.add_barrier(epoch);
                         }
                     }

--- a/src/stream/src/common/table/state_table.rs
+++ b/src/stream/src/common/table/state_table.rs
@@ -20,6 +20,7 @@ use std::sync::Arc;
 use std::time::Instant;
 
 use anyhow::anyhow;
+use await_tree::InstrumentAwait;
 use bytes::Bytes;
 use educe::Educe;
 use either::Either;
@@ -1781,6 +1782,11 @@ where
         let table_watermarks = self.commit_pending_watermark();
         self.row_store
             .seal_current_epoch(new_epoch.curr, table_watermarks, switch_consistent_op)
+            .instrument_await(await_tree::span!(
+                "state_table_commit table_id={} epoch={}",
+                self.table_id,
+                new_epoch.curr
+            ))
             .await?;
         self.epoch = Some(new_epoch);
 

--- a/src/stream/src/executor/barrier_align.rs
+++ b/src/stream/src/executor/barrier_align.rs
@@ -16,6 +16,7 @@ use std::sync::Arc;
 use std::time::Instant;
 
 use anyhow::Context;
+use await_tree::InstrumentAwait;
 use enum_as_inner::EnumAsInner;
 use futures::StreamExt;
 use futures::future::{Either, select};
@@ -107,11 +108,15 @@ pub async fn barrier_align(
             Either::Left((Some(msg), _)) => match msg? {
                 Message::Watermark(watermark) => yield AlignedMessage::WatermarkLeft(watermark),
                 Message::Chunk(chunk) => yield AlignedMessage::Left(chunk),
-                Message::Barrier(_) => loop {
+                Message::Barrier(barrier) => loop {
                     let start_time = Instant::now();
                     // received left barrier, waiting for right barrier
                     match right
                         .next()
+                        .instrument_await(await_tree::span!(
+                            "barrier_align_wait_right epoch={}",
+                            barrier.epoch.curr
+                        ))
                         .await
                         .context("failed to poll right message, stream closed unexpectedly")??
                     {
@@ -131,11 +136,15 @@ pub async fn barrier_align(
             Either::Right((Some(msg), _)) => match msg? {
                 Message::Watermark(watermark) => yield AlignedMessage::WatermarkRight(watermark),
                 Message::Chunk(chunk) => yield AlignedMessage::Right(chunk),
-                Message::Barrier(_) => loop {
+                Message::Barrier(barrier) => loop {
                     let start_time = Instant::now();
                     // received right barrier, waiting for left barrier
                     match left
                         .next()
+                        .instrument_await(await_tree::span!(
+                            "barrier_align_wait_left epoch={}",
+                            barrier.epoch.curr
+                        ))
                         .await
                         .context("failed to poll left message, stream closed unexpectedly")??
                     {


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

Streaming executors already have a generic await-tree node, but several high-value waits inside them were still opaque. This PR adds semantic spans for three common paths:

- State table commit, including the table ID and epoch.
- Common sink writer lifecycle calls. Batch writes are verbose, while epoch, barrier, abort, and async delivery waits remain visible in normal dumps.
- Barrier alignment waits, including the side being awaited and the barrier epoch.

These spans make barrier-stuck dumps distinguish storage commit, sink I/O, and left/right input alignment without instrumenting per-row storage reads. The change only adds diagnostics and does not alter execution semantics.

## Checklist

- [x] I have written necessary rustdoc comments.
- [x] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [x] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->

## Tests

- `cargo fmt --all -- --check`
- `cargo check -p risingwave_connector -p risingwave_stream`
- `cargo clippy -p risingwave_connector -p risingwave_stream --lib -- -D warnings`
- `cargo test -p risingwave_stream barrier_align --lib` (3 passed)

## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

Await-tree dumps for streaming actors now identify state table commits, sink writer lifecycle waits, and side-specific barrier alignment waits, making barrier stalls easier to diagnose.

</details>
