### PR TITLE
doc: tighten user-facing PR label guidance

### DIFF
--- a/.agents/PR_LABELING.md
+++ b/.agents/PR_LABELING.md
@@ -34,7 +34,7 @@ When opening or updating a PR:
 4. Validate every chosen label against the live GitHub label list.
 5. Drop any chosen label that does not exist remotely.
 6. Add only missing, valid, additive labels.
-7. Do not remove existing labels, especially auto-applied labels, unless explicitly instructed by a maintainer.
+7. Do not remove labels that predate the current agent operation, especially auto-applied or maintainer-applied labels, unless explicitly instructed by a maintainer. If the agent added a label during the current operation and then determines that it was a mistake, remove it immediately and report the correction.
 8. In the PR report, list labels added, labels intentionally not added, and the local/CI verification already run or requested.
 
 ## CI coverage labels
@@ -82,7 +82,23 @@ Use `type/flaky-test` only when the primary purpose is fixing flaky tests.
 
 ## User-facing and documentation labels
 
-Add `user-facing-changes` when the PR changes behavior visible to users, including SQL syntax or semantics, connector options, configuration defaults, error messages, public APIs, system catalog output, compatibility behavior, observability or operational workflows, or documented behavior.
+`user-facing-changes` triggers documentation follow-up after merge. Add it only when both of these conditions are true:
+
+1. The PR changes a supported external product interface or behavior.
+2. The change warrants release-note or product-documentation follow-up.
+
+Qualifying changes include SQL syntax or semantics, documented connector options, user-configurable defaults or semantics, client-visible API or SQL behavior, stable system catalog output, compatibility behavior, and supported operational workflows that require users to act differently.
+
+Do not add `user-facing-changes` merely because some output is technically observable. In particular, do not add it for:
+
+- Internal tracing logs, log wording changes, or internal-only diagnostics.
+- Development-only metrics, dashboards, or observability tooling.
+- Internal Rust `pub` APIs or other implementation interfaces.
+- Refactoring, recovery, scheduling, or performance work that does not change a supported user or operator workflow.
+- Comment, formatting, test-only, CI-only, or documentation wording changes that do not change product behavior.
+- Typo or wording improvements that do not change the meaning of a supported error or response.
+
+When the impact is ambiguous, do not add the label. Explain the possible user-facing impact in the final PR report and ask a maintainer to confirm whether documentation follow-up is needed. The threshold is whether documentation or release-note follow-up is appropriate, not whether a user could conceivably observe the diff.
 
 Add `breaking-change` only for real compatibility-breaking or migration-impacting changes, and explain the impact in the PR body.
 
@@ -93,5 +109,5 @@ Add `breaking-change` only for real compatibility-breaking or migration-impactin
 - Do not add `ci/pr/run-selected` to a non-draft PR.
 - Do not use `ci/pr/run-selected` as an extra-test label.
 - Do not add labels that are absent from `gh label list --repo risingwavelabs/risingwave`.
-- Do not remove auto-added labels unless explicitly instructed by a maintainer.
+- Do not remove labels that existed before the current operation unless explicitly instructed by a maintainer.
 - Do not use unrelated expensive labels just to be safe.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,7 +75,7 @@ When opening or updating a pull request, changing PR labels, or marking a PR rea
 1. Read `.agents/PR_LABELING.md`.
 2. Inspect the current PR labels and draft state before adding anything:
    `gh pr view <PR> --json isDraft,labels,title,body,files`
-3. Add only validated missing labels. Do not remove existing labels unless explicitly instructed by a maintainer.
+3. Add only validated missing labels. Do not remove labels that existed before the current agent operation unless explicitly instructed by a maintainer. An agent may remove a label it just added if validation shows it was a mistake, but it must report the correction.
 4. In the final PR report, list labels added, labels intentionally not added, local tests run, and CI labels requested.
 
 ## Connector Development


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

The agent PR-labeling guide currently treats broad categories such as error messages, observability, operational workflows, and public APIs as user-facing without distinguishing supported product behavior from internal implementation details. This can cause agents to add `user-facing-changes` to changes that do not need documentation follow-up.

This PR:

- Requires both a supported external behavior change and a need for release-note or product-documentation follow-up before adding `user-facing-changes`.
- Adds explicit non-qualifying examples, including internal logs, dev-only metrics, internal Rust APIs, and internal recovery/refactoring work.
- Directs agents to leave ambiguous PRs unlabeled and ask maintainers for confirmation.
- Lets an agent remove a label it added during the current operation when it detects its own mistake, without allowing removal of pre-existing or maintainer-applied labels.

## Checklist

- [x] I have written necessary rustdoc comments. (Not applicable; documentation-only change.)
- [x] I have added necessary unit tests and integration tests. (Not applicable; validated with `git diff --check`.)
- [x] I have added test labels as necessary. (No additional CI labels are needed.)
- [ ] I have added fuzzing tests or opened an issue to track them.
- [ ] My PR contains breaking changes.
- [ ] My PR changes performance-critical code, so I will run (micro) benchmarks and present the results.
- [ ] I have checked the Release Timeline and Currently Supported Versions to determine which release branches I need to cherry-pick this PR into.

## Documentation

- [ ] My PR needs documentation updates.

<details>
<summary><b>Release note</b></summary>

None. This changes repository instructions for coding agents, not RisingWave product behavior.

</details>
