### PR TITLE
chore: disposable Jarvis webhook smoke 20260731T100712Z-26318

### DIFF
--- a/.github/jarvis-webhook-smoke-20260731T100712Z-26318.md
+++ b/.github/jarvis-webhook-smoke-20260731T100712Z-26318.md
@@ -1,0 +1,3 @@
+# Jarvis GitHub webhook smoke
+
+Disposable live ingress check 20260731T100712Z-26318; this branch and draft PR must never merge.


### PR DESCRIPTION
Disposable GitHub App ingress smoke. Never merge.\n\nCollaborated with Jarvis (OpenAI Codex).