### PR TITLE
feat(cdc): add resnapshot plan and catalog state

### DIFF
--- a/proto/stream_plan.proto
+++ b/proto/stream_plan.proto
@@ -887,6 +887,10 @@ message StreamCdcScanNode {
   bool disable_backfill = 7;
 
   StreamCdcScanOptions options = 8;
+
+  // The real materialized CDC table desc used to read existing table state during resnapshot diff.
+  // Old fragments may not have this field and are repaired by meta before recovery.
+  plan_common.StorageTableDesc resnapshot_table_desc = 9;
 }
 
 // BatchPlanNode is used for mv on mv snapshot read.

--- a/src/frontend/src/optimizer/plan_node/mod.rs
+++ b/src/frontend/src/optimizer/plan_node/mod.rs
@@ -925,12 +925,19 @@ impl dyn StreamPlanNode {
                 return stream_share.adhoc_to_stream_prost(state);
             }
 
+            let previous_cdc_resnapshot_table_desc = state.cdc_resnapshot_table_desc().cloned();
+            if let Some(stream_materialize) = self.as_stream_materialize() {
+                state.set_cdc_resnapshot_table_desc(Some(
+                    stream_materialize.table().table_desc().try_to_protobuf()?,
+                ));
+            }
             let node = Some(self.try_to_stream_prost_body(state)?);
             let input = self
                 .inputs()
                 .into_iter()
                 .map(|plan| plan.to_stream_prost(state))
                 .try_collect()?;
+            state.set_cdc_resnapshot_table_desc(previous_cdc_resnapshot_table_desc);
             // TODO: support pk_indices and operator_id
             Ok(PbStreamPlan {
                 input,

--- a/src/frontend/src/optimizer/plan_node/stream_cdc_table_scan.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_cdc_table_scan.rs
@@ -280,6 +280,7 @@ impl StreamCdcTableScan {
             rate_limit: self.base.ctx().overwrite_options().backfill_rate_limit,
             disable_backfill: options.disable_backfill,
             options: Some(options),
+            resnapshot_table_desc: state.cdc_resnapshot_table_desc().cloned(),
         }));
 
         // plan: merge -> filter -> exchange(simple) -> stream_scan

--- a/src/frontend/src/stream_fragmenter/mod.rs
+++ b/src/frontend/src/stream_fragmenter/mod.rs
@@ -34,7 +34,7 @@ use risingwave_common::types::DataType;
 use risingwave_common::util::stream_graph_visitor::visit_stream_node_internal_tables;
 use risingwave_connector::source::cdc::CdcScanOptions;
 use risingwave_pb::id::{LocalOperatorId, StreamNodeLocalOperatorId};
-use risingwave_pb::plan_common::JoinType;
+use risingwave_pb::plan_common::{JoinType, StorageTableDesc};
 use risingwave_pb::stream_plan::{
     BackfillOrder, DispatchStrategy, DispatcherType, ExchangeNode, NoOpNode,
     PbDispatchOutputMapping, StreamContext, StreamFragmentGraph as StreamFragmentGraphProto,
@@ -81,6 +81,8 @@ pub struct BuildFragmentGraphState {
     has_snapshot_backfill: bool,
     has_cross_db_snapshot_backfill: bool,
     has_any_backfill: bool,
+
+    cdc_resnapshot_table_desc: Option<StorageTableDesc>,
 }
 
 impl BuildFragmentGraphState {
@@ -107,6 +109,14 @@ impl BuildFragmentGraphState {
     /// Generate an table id
     pub fn gen_table_id_wrapped(&mut self) -> TableId {
         TableId::new(self.gen_table_id())
+    }
+
+    pub fn cdc_resnapshot_table_desc(&self) -> Option<&StorageTableDesc> {
+        self.cdc_resnapshot_table_desc.as_ref()
+    }
+
+    pub fn set_cdc_resnapshot_table_desc(&mut self, table_desc: Option<StorageTableDesc>) {
+        self.cdc_resnapshot_table_desc = table_desc;
     }
 
     pub fn add_share_stream_node(

--- a/src/meta/src/controller/catalog/mod.rs
+++ b/src/meta/src/controller/catalog/mod.rs
@@ -28,14 +28,17 @@ use std::sync::Arc;
 use anyhow::{Context, anyhow};
 use itertools::Itertools;
 use risingwave_common::catalog::{
-    DEFAULT_SCHEMA_NAME, FragmentTypeFlag, FragmentTypeMask, SYSTEM_SCHEMAS, TableOption,
+    DEFAULT_SCHEMA_NAME, FragmentTypeFlag, FragmentTypeMask, SYSTEM_SCHEMAS, TableDesc, TableOption,
 };
 use risingwave_common::config::streaming::CacheRefillPolicy;
 use risingwave_common::config::{StreamingConfig, merge_streaming_config_section};
 use risingwave_common::current_cluster_version;
+use risingwave_common::hash::VnodeCountCompat;
 use risingwave_common::id::JobId;
 use risingwave_common::secret::LocalSecretManager;
-use risingwave_common::util::stream_graph_visitor::visit_stream_node_cont_mut;
+use risingwave_common::util::stream_graph_visitor::{
+    visit_stream_node_cont, visit_stream_node_cont_mut,
+};
 use risingwave_connector::source::UPSTREAM_SOURCE_KEY;
 use risingwave_connector::source::cdc::build_cdc_table_id;
 use risingwave_meta_model::object::ObjectType;
@@ -65,6 +68,7 @@ use risingwave_pb::meta::table_cache_refill_policies::PbTableCacheRefillPolicy;
 use risingwave_pb::meta::{
     PbObject, PbObjectGroup, PbTableCacheRefillPolicies, PbTableRefillRuntimeConfig,
 };
+use risingwave_pb::plan_common::StorageTableDesc;
 use risingwave_pb::stream_plan::stream_node::NodeBody;
 use risingwave_pb::telemetry::PbTelemetryEventStage;
 use risingwave_pb::user::PbUserInfo;

--- a/src/meta/src/controller/catalog/test.rs
+++ b/src/meta/src/controller/catalog/test.rs
@@ -17,12 +17,14 @@ mod tests {
     use risingwave_common::hash::VirtualNode;
     use risingwave_meta_model::FragmentId;
     use risingwave_meta_model::fragment::DistributionType;
-    use risingwave_meta_model::table::HandleConflictBehavior;
+    use risingwave_meta_model::table::{CdcTableType, HandleConflictBehavior};
     use risingwave_pb::catalog::subscription::SubscriptionState;
     use risingwave_pb::catalog::{PbSinkType, StreamSourceInfo};
     use risingwave_pb::common::{HostAddress, WorkerNode, WorkerType, worker_node};
     use risingwave_pb::meta::SubscribeType;
-    use risingwave_pb::stream_plan::PbStreamNode;
+    use risingwave_pb::plan_common::StorageTableDesc;
+    use risingwave_pb::stream_plan::stream_node::NodeBody;
+    use risingwave_pb::stream_plan::{MaterializeNode, PbStreamNode, StreamCdcScanNode};
     use tokio::sync::{mpsc, oneshot};
 
     use crate::controller::catalog::*;
@@ -90,12 +92,31 @@ mod tests {
         job_id: JobId,
         state_table_ids: TableIdArray,
     ) -> MetaResult<()> {
+        insert_test_fragment_with_node(
+            txn,
+            fragment_id,
+            job_id,
+            0,
+            PbStreamNode::default(),
+            state_table_ids,
+        )
+        .await
+    }
+
+    async fn insert_test_fragment_with_node(
+        txn: &DatabaseTransaction,
+        fragment_id: FragmentId,
+        job_id: JobId,
+        fragment_type_mask: i32,
+        stream_node: PbStreamNode,
+        state_table_ids: TableIdArray,
+    ) -> MetaResult<()> {
         fragment::ActiveModel {
             fragment_id: Set(fragment_id),
             job_id: Set(job_id),
-            fragment_type_mask: Set(0),
+            fragment_type_mask: Set(fragment_type_mask),
             distribution_type: Set(fragment::DistributionType::Hash),
-            stream_node: Set(StreamNode::from(&PbStreamNode::default())),
+            stream_node: Set(StreamNode::from(&stream_node)),
             state_table_ids: Set(state_table_ids),
             upstream_fragment_id: Set(I32Array::default()),
             vnode_count: Set(1),
@@ -104,6 +125,20 @@ mod tests {
         .insert(txn)
         .await?;
         Ok(())
+    }
+
+    fn legacy_cdc_scan_node(
+        upstream_table_id: TableId,
+        resnapshot_table_desc: Option<StorageTableDesc>,
+    ) -> PbStreamNode {
+        PbStreamNode {
+            node_body: Some(NodeBody::StreamCdcScan(Box::new(StreamCdcScanNode {
+                table_id: upstream_table_id,
+                resnapshot_table_desc,
+                ..Default::default()
+            }))),
+            ..Default::default()
+        }
     }
 
     async fn insert_test_streaming_job(
@@ -633,6 +668,199 @@ mod tests {
             )])
         );
 
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_init_migrates_legacy_cdc_resnapshot_table_desc() -> MetaResult<()> {
+        let env = MetaSrvEnv::for_test().await;
+        let mgr = CatalogController::new(env.clone()).await?;
+        let inner = mgr.inner.write().await;
+        let txn = inner.db.begin().await?;
+        let (job_id, Some(result_table_id), _internal_table_id) =
+            insert_test_streaming_job(&txn, "legacy_cdc", true, None).await?
+        else {
+            unreachable!()
+        };
+        Table::update(table::ActiveModel {
+            table_id: Set(result_table_id),
+            table_type: Set(TableType::Table),
+            cdc_table_type: Set(Some(CdcTableType::Postgres)),
+            ..Default::default()
+        })
+        .exec(&txn)
+        .await?;
+        StreamingJob::update(streaming_job::ActiveModel {
+            job_id: Set(job_id),
+            job_status: Set(JobStatus::Creating),
+            create_type: Set(CreateType::Background),
+            ..Default::default()
+        })
+        .exec(&txn)
+        .await?;
+
+        let upstream_table_id = TableId::new(99_001);
+        let singleton_fragment_id = FragmentId::new(201);
+        let parallel_fragment_id = FragmentId::new(202);
+        let existing_fragment_id = FragmentId::new(203);
+        let materialize_fragment_id = FragmentId::new(204);
+        for (fragment_id, fragment_type_mask) in [
+            (singleton_fragment_id, FragmentTypeFlag::StreamScan as i32),
+            (parallel_fragment_id, FragmentTypeFlag::StreamCdcScan as i32),
+        ] {
+            insert_test_fragment_with_node(
+                &txn,
+                fragment_id,
+                job_id,
+                fragment_type_mask,
+                legacy_cdc_scan_node(upstream_table_id, None),
+                TableIdArray::default(),
+            )
+            .await?;
+        }
+
+        let existing_desc = StorageTableDesc {
+            table_id: TableId::new(99_002),
+            ..Default::default()
+        };
+        insert_test_fragment_with_node(
+            &txn,
+            existing_fragment_id,
+            job_id,
+            FragmentTypeFlag::StreamCdcScan as i32,
+            legacy_cdc_scan_node(upstream_table_id, Some(existing_desc.clone())),
+            TableIdArray::default(),
+        )
+        .await?;
+        insert_test_fragment_with_node(
+            &txn,
+            materialize_fragment_id,
+            job_id,
+            FragmentTypeFlag::Mview as i32,
+            PbStreamNode {
+                node_body: Some(NodeBody::Materialize(Box::new(MaterializeNode {
+                    table_id: result_table_id,
+                    ..Default::default()
+                }))),
+                ..Default::default()
+            },
+            TableIdArray::default(),
+        )
+        .await?;
+        txn.commit().await?;
+        drop(inner);
+        drop(mgr);
+
+        // Recreating the controller simulates a new meta leader. Its init migration must persist
+        // the descriptor before bootstrap recovery renders actors.
+        let mgr = CatalogController::new(env).await?;
+        let expected_desc = TableDesc::from_pb_table(&mgr.get_table_by_id(result_table_id).await?)
+            .try_to_protobuf()?;
+        for fragment_id in [singleton_fragment_id, parallel_fragment_id] {
+            let fragment = Fragment::find_by_id(fragment_id)
+                .one(&mgr.inner.read().await.db)
+                .await?
+                .unwrap();
+            let stream_node = fragment.stream_node.to_protobuf();
+            let Some(NodeBody::StreamCdcScan(cdc_scan)) = stream_node.node_body else {
+                unreachable!()
+            };
+            assert_eq!(cdc_scan.table_id, upstream_table_id);
+            assert_eq!(cdc_scan.resnapshot_table_desc, Some(expected_desc.clone()));
+        }
+
+        let fragment = Fragment::find_by_id(existing_fragment_id)
+            .one(&mgr.inner.read().await.db)
+            .await?
+            .unwrap();
+        let stream_node = fragment.stream_node.to_protobuf();
+        let Some(NodeBody::StreamCdcScan(cdc_scan)) = stream_node.node_body else {
+            unreachable!()
+        };
+        assert_eq!(cdc_scan.resnapshot_table_desc, Some(existing_desc));
+
+        // The repair is idempotent and does not rewrite already-populated descriptors.
+        assert!(mgr.cdc_resnapshot_table_desc_update().await?.is_empty());
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_init_skips_dirty_legacy_cdc_job_without_result_table() -> MetaResult<()> {
+        let env = MetaSrvEnv::for_test().await;
+        let mgr = CatalogController::new(env.clone()).await?;
+        let inner = mgr.inner.write().await;
+        let txn = inner.db.begin().await?;
+        let job_id = CatalogController::create_object(
+            &txn,
+            ObjectType::Table,
+            TEST_OWNER_ID,
+            Some(TEST_DATABASE_ID),
+            Some(TEST_SCHEMA_ID),
+        )
+        .await?
+        .oid
+        .as_job_id();
+        StreamingJob::insert(streaming_job::ActiveModel {
+            job_id: Set(job_id),
+            job_status: Set(JobStatus::Initial),
+            create_type: Set(CreateType::Foreground),
+            timezone: Set(None),
+            config_override: Set(None),
+            adaptive_parallelism_strategy: Set(None),
+            parallelism: Set(StreamingParallelism::Adaptive),
+            backfill_parallelism: Set(None),
+            backfill_adaptive_parallelism_strategy: Set(None),
+            backfill_orders: Set(None),
+            max_parallelism: Set(1),
+            specific_resource_group: Set(None),
+            is_serverless_backfill: Set(false),
+            refresh_interval_sec: Set(None),
+        })
+        .exec(&txn)
+        .await?;
+        let fragment_id = FragmentId::new(205);
+        insert_test_fragment_with_node(
+            &txn,
+            fragment_id,
+            job_id,
+            FragmentTypeFlag::StreamCdcScan as i32,
+            legacy_cdc_scan_node(TableId::new(99_003), None),
+            TableIdArray::default(),
+        )
+        .await?;
+        let incomplete_fragment_id = FragmentId::new(206);
+        insert_test_fragment_with_node(
+            &txn,
+            incomplete_fragment_id,
+            job_id,
+            FragmentTypeFlag::StreamCdcScan as i32,
+            PbStreamNode::default(),
+            TableIdArray::default(),
+        )
+        .await?;
+        txn.commit().await?;
+        drop(inner);
+        drop(mgr);
+
+        // Dirty foreground/Initial jobs are cleaned by bootstrap recovery. Their deliberately
+        // incomplete catalogs, including a missing node body, must not make meta startup fail
+        // before cleanup can run.
+        let mgr = CatalogController::new(env).await?;
+        let fragment = Fragment::find_by_id(fragment_id)
+            .one(&mgr.inner.read().await.db)
+            .await?
+            .unwrap();
+        let stream_node = fragment.stream_node.to_protobuf();
+        let Some(NodeBody::StreamCdcScan(cdc_scan)) = stream_node.node_body else {
+            unreachable!()
+        };
+        assert!(cdc_scan.resnapshot_table_desc.is_none());
+        assert!(
+            Fragment::find_by_id(incomplete_fragment_id)
+                .one(&mgr.inner.read().await.db)
+                .await?
+                .is_some()
+        );
         Ok(())
     }
 

--- a/src/meta/src/controller/catalog/util.rs
+++ b/src/meta/src/controller/catalog/util.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use risingwave_common::catalog::FragmentTypeMask;
+use risingwave_pb::stream_plan::PbStreamNode;
 
 use super::*;
 use crate::controller::fragment::FragmentTypeMaskExt;
@@ -56,7 +57,224 @@ pub(crate) async fn update_internal_tables(
 impl CatalogController {
     pub(crate) async fn init(&self) -> MetaResult<()> {
         self.table_catalog_cdc_table_id_update().await?;
+        let migrated_jobs = self.cdc_resnapshot_table_desc_update().await?;
+        if !migrated_jobs.is_empty() {
+            info!(
+                ?migrated_jobs,
+                "filled missing CDC resnapshot table descriptors before recovery"
+            );
+        }
         Ok(())
+    }
+
+    /// Fill the materialized result-table descriptor added to `StreamCdcScanNode` for legacy CDC
+    /// jobs. This must run before bootstrap recovery renders actors: unfinished parallel initial
+    /// backfills need the descriptor to diff already-committed output after a restart.
+    ///
+    /// The migration is intentionally idempotent and only fills missing fields. A future old meta
+    /// leader may decode and re-encode the plan without the new protobuf field, so this startup
+    /// repair must not be a one-shot schema migration.
+    pub(crate) async fn cdc_resnapshot_table_desc_update(&self) -> MetaResult<Vec<JobId>> {
+        fn has_missing_desc(stream_node: &PbStreamNode) -> bool {
+            let mut missing = false;
+            visit_stream_node_cont(stream_node, |node| {
+                if let Some(NodeBody::StreamCdcScan(node)) = &node.node_body
+                    && node.resnapshot_table_desc.is_none()
+                {
+                    missing = true;
+                }
+                true
+            });
+            missing
+        }
+
+        fn fill_missing_desc(
+            stream_node: &mut PbStreamNode,
+            table_desc: &StorageTableDesc,
+        ) -> bool {
+            let mut changed = false;
+            visit_stream_node_cont_mut(stream_node, |node| {
+                if let Some(NodeBody::StreamCdcScan(cdc_scan)) = &mut node.node_body
+                    && cdc_scan.resnapshot_table_desc.is_none()
+                {
+                    cdc_scan.resnapshot_table_desc = Some(table_desc.clone());
+                    changed = true;
+                }
+                true
+            });
+            changed
+        }
+
+        let inner = self.inner.read().await;
+        let txn = inner.db.begin().await?;
+
+        // Historical singleton CDC scans use StreamScan, while parallel scans use
+        // StreamCdcScan. Filter by both flags and then inspect the actual recursive node body.
+        let scan_fragments: Vec<(FragmentId, JobId, StreamNode)> = Fragment::find()
+            .select_only()
+            .columns([
+                fragment::Column::FragmentId,
+                fragment::Column::JobId,
+                fragment::Column::StreamNode,
+            ])
+            .filter(FragmentTypeMask::intersects_any([
+                FragmentTypeFlag::StreamScan,
+                FragmentTypeFlag::StreamCdcScan,
+            ]))
+            .into_tuple()
+            .all(&txn)
+            .await?;
+
+        let mut legacy_fragments = Vec::new();
+        let mut candidate_job_ids = HashSet::new();
+        for (fragment_id, job_id, stream_node) in scan_fragments {
+            let stream_node = stream_node.to_protobuf();
+            if has_missing_desc(&stream_node) {
+                candidate_job_ids.insert(job_id);
+                legacy_fragments.push((fragment_id, job_id, stream_node));
+            }
+        }
+        if legacy_fragments.is_empty() {
+            return Ok(vec![]);
+        }
+
+        // Dirty foreground/Initial jobs are removed later by bootstrap recovery and may
+        // legitimately have fragments without a result-table catalog row. Only jobs that recovery
+        // can retain should participate in this migration.
+        let recoverable_job_ids: HashSet<JobId> = StreamingJob::find()
+            .filter(streaming_job::Column::JobId.is_in(candidate_job_ids))
+            .all(&txn)
+            .await?
+            .into_iter()
+            .filter_map(|job| {
+                (job.job_status == JobStatus::Created
+                    || job.job_status == JobStatus::Creating
+                        && job.create_type == CreateType::Background)
+                    .then_some(job.job_id)
+            })
+            .collect();
+        legacy_fragments.retain(|(_, job_id, _)| recoverable_job_ids.contains(job_id));
+        if legacy_fragments.is_empty() {
+            return Ok(vec![]);
+        }
+
+        // Resolve the real result table through each job's unique Materialize result-table ID. In
+        // particular, StreamCdcScan.table_id identifies the upstream external table and must not
+        // be used as the RisingWave storage table id.
+        let job_fragments: Vec<(JobId, StreamNode)> = Fragment::find()
+            .select_only()
+            .columns([fragment::Column::JobId, fragment::Column::StreamNode])
+            .filter(fragment::Column::JobId.is_in(recoverable_job_ids.clone()))
+            .into_tuple()
+            .all(&txn)
+            .await?;
+        let mut materialized_table_ids: HashMap<JobId, HashSet<TableId>> = HashMap::new();
+        for (job_id, stream_node) in job_fragments {
+            let stream_node = stream_node.to_protobuf();
+            visit_stream_node_cont(&stream_node, |stream_node| {
+                if let Some(NodeBody::Materialize(node)) = &stream_node.node_body {
+                    materialized_table_ids
+                        .entry(job_id)
+                        .or_default()
+                        .insert(node.table_id);
+                }
+                true
+            });
+        }
+
+        let migrated_job_ids: HashSet<JobId> = legacy_fragments
+            .iter()
+            .map(|(_, job_id, _)| *job_id)
+            .collect();
+        let mut result_table_by_job = HashMap::new();
+        for job_id in &migrated_job_ids {
+            let table_ids = materialized_table_ids.get(job_id).ok_or_else(|| {
+                anyhow!(
+                    "recoverable legacy CDC job {} has no materialized result table",
+                    job_id
+                )
+            })?;
+            if table_ids.len() != 1 {
+                return Err(anyhow!(
+                    "recoverable legacy CDC job {} has {} materialized result tables: {:?}",
+                    job_id,
+                    table_ids.len(),
+                    table_ids
+                )
+                .into());
+            }
+            result_table_by_job.insert(*job_id, *table_ids.iter().next().unwrap());
+        }
+
+        let result_table_ids = result_table_by_job.values().copied().collect_vec();
+        let table_objs = Table::find()
+            .find_also_related(Object)
+            .filter(table::Column::TableId.is_in(result_table_ids))
+            .all(&txn)
+            .await?;
+        let streaming_jobs =
+            load_streaming_jobs_by_ids(&txn, table_objs.iter().map(|(table, _)| table.job_id()))
+                .await?;
+        let mut table_descs = HashMap::new();
+        for (table, object) in table_objs {
+            if table.table_type != TableType::Table {
+                return Err(anyhow!(
+                    "legacy CDC result table {} has unexpected table type {:?}",
+                    table.table_id,
+                    table.table_type
+                )
+                .into());
+            }
+            let table_id = table.table_id;
+            let table_job = streaming_jobs.get(&table.job_id()).cloned();
+            let pb_table: PbTable = ObjectModel(
+                table,
+                object.ok_or_else(|| {
+                    anyhow!("legacy CDC result table {} has no catalog object", table_id)
+                })?,
+                table_job,
+            )
+            .into();
+            if pb_table.vnode_count_inner().value_opt().is_none() {
+                return Err(anyhow!(
+                    "legacy CDC result table {} still has a placeholder vnode count",
+                    table_id
+                )
+                .into());
+            }
+            let table_desc = TableDesc::from_pb_table(&pb_table)
+                .try_to_protobuf()
+                .with_context(|| {
+                    format!(
+                        "failed to build resnapshot descriptor for legacy CDC result table {}",
+                        table_id
+                    )
+                })?;
+            table_descs.insert(table_id, table_desc);
+        }
+
+        for (fragment_id, job_id, mut stream_node) in legacy_fragments {
+            let table_id = result_table_by_job[&job_id];
+            let table_desc = table_descs.get(&table_id).ok_or_else(|| {
+                anyhow!(
+                    "recoverable legacy CDC job {} refers to missing result table {}",
+                    job_id,
+                    table_id
+                )
+            })?;
+            if fill_missing_desc(&mut stream_node, table_desc) {
+                Fragment::update(fragment::ActiveModel {
+                    fragment_id: Set(fragment_id),
+                    stream_node: Set(StreamNode::from(&stream_node)),
+                    ..Default::default()
+                })
+                .exec(&txn)
+                .await?;
+            }
+        }
+
+        txn.commit().await?;
+        Ok(migrated_job_ids.into_iter().sorted_unstable().collect())
     }
 
     /// Fill in the `cdc_table_id` field for Table with empty `cdc_table_id` and parent Source job.

--- a/src/meta/src/rpc/ddl_controller.rs
+++ b/src/meta/src/rpc/ddl_controller.rs
@@ -24,7 +24,7 @@ use await_tree::InstrumentAwait;
 use either::Either;
 use itertools::Itertools;
 use risingwave_common::catalog::{
-    AlterDatabaseParam, ColumnCatalog, ColumnId, Field, FragmentTypeFlag,
+    AlterDatabaseParam, ColumnCatalog, ColumnId, Field, FragmentTypeFlag, TableDesc,
 };
 use risingwave_common::hash::VnodeCountCompat;
 use risingwave_common::id::{JobId, TableId};
@@ -1995,12 +1995,14 @@ impl DdlController {
         // and the context that contains all information needed for building the
         // actors on the compute nodes.
 
-        let stream_job_fragments =
+        let mut stream_job_fragments =
             StreamJobFragments::new(id, graph, stream_ctx.clone(), max_parallelism.get());
 
         if let Some(mview_fragment) = stream_job_fragments.mview_fragment() {
             stream_job.set_table_vnode_count(mview_fragment.vnode_count());
         }
+
+        Self::fill_cdc_resnapshot_table_desc(&stream_job, &mut stream_job_fragments)?;
 
         let new_upstream_sink = if let StreamingJob::Sink(sink) = &stream_job
             && let Ok(table_id) = sink.get_target_table()
@@ -2250,8 +2252,10 @@ impl DdlController {
         // 3. Build the table fragments structure that will be persisted in the stream manager, and
         // the context that contains all information needed for building the actors on the compute
         // nodes.
-        let stream_job_fragments =
+        let mut stream_job_fragments =
             StreamJobFragments::new(tmp_job_id, graph, stream_ctx, old_fragments.max_parallelism);
+
+        Self::fill_cdc_resnapshot_table_desc(stream_job, &mut stream_job_fragments)?;
 
         if let Some(sinks) = &auto_refresh_schema_sinks {
             for sink in sinks {
@@ -2283,6 +2287,24 @@ impl DdlController {
                 downstreams: downstream_fragment_relations,
             },
         ))
+    }
+
+    fn fill_cdc_resnapshot_table_desc(
+        stream_job: &StreamingJob,
+        stream_job_fragments: &mut StreamJobFragments,
+    ) -> MetaResult<()> {
+        if let StreamingJob::Table(None, table, TableJobType::SharedCdcSource) = stream_job {
+            let table_desc = TableDesc::from_pb_table(table).try_to_protobuf()?;
+            for fragment in stream_job_fragments.fragments.values_mut() {
+                visit_stream_node_cont_mut(&mut fragment.nodes, |node| {
+                    if let Some(NodeBody::StreamCdcScan(stream_cdc_scan)) = &mut node.node_body {
+                        stream_cdc_scan.resnapshot_table_desc = Some(table_desc.clone());
+                    }
+                    true
+                });
+            }
+        }
+        Ok(())
     }
 
     async fn alter_name(


### PR DESCRIPTION
Tracking issue: #26481
Stacked on: #26482

Persist the dormant plan and catalog state required by later CDC RESNAPSHOT runtime layers.

- Embed the actual RisingWave materialized-table descriptor in each `StreamCdcScan` plan for pinned storage reads.
- Repair missing descriptors in recoverable legacy jobs during meta startup while skipping incomplete plans that are not safe to recover.
- Preserve the new plan field through stream-plan traversal and replacement.

This PR only adds and migrates plan/catalog metadata. It does not expose `ALTER TABLE ... RESNAPSHOT`, activate the ordered diff reader, or change the existing CDC backfill runtime.

Testing:

- Added catalog migration coverage for recoverable legacy plans and incomplete jobs.
- Passed targeted meta catalog tests, formatting and diff checks, plus stack-wide stream/meta/frontend compilation and CDC executor/meta unit tests on the restacked head.