### PR TITLE
perf(expr): prebuild variant access paths

### DIFF
--- a/e2e_test/streaming/variant.slt
+++ b/e2e_test/streaming/variant.slt
@@ -56,6 +56,99 @@ drop materialized view variant_state_mv;
 statement ok
 drop table variant_stream_t;
 
+# Malformed dynamic paths must only null out the failing row in non-strict evaluation.
+# Use one actor and one multi-row insert to exercise valid and invalid paths in the same chunk.
+statement ok
+set streaming_parallelism = 1;
+
+statement ok
+create table variant_dynamic_path_t (
+    id int primary key,
+    payload variant,
+    path varchar
+);
+
+statement ok
+create materialized view variant_dynamic_path_mv as
+select
+    id,
+    variant_get(payload, path) as value,
+    try_variant_get(payload, path) as try_value
+from variant_dynamic_path_t;
+
+statement ok
+insert into variant_dynamic_path_t values
+    (1, '{"a":[{"b":7},{"b":8}],"x.y":9}'::variant, '$.a[0].b'),
+    (2, '{"a":[{"b":7},{"b":8}],"x.y":9}'::variant, '$.'),
+    (3, '{"a":[{"b":7},{"b":8}],"x.y":9}'::variant, '$.a[-1].b');
+
+query ITT rowsort
+select id, value::varchar, try_value::varchar from variant_dynamic_path_mv;
+----
+1 7 7
+2 NULL NULL
+3 8 8
+
+statement ok
+drop materialized view variant_dynamic_path_mv;
+
+statement ok
+drop table variant_dynamic_path_t;
+
+statement ok
+set streaming_parallelism = default;
+
+# A malformed constant path must not fail expression building or bypass SQL NULL short-circuiting.
+statement ok
+create table variant_constant_path_t (
+    id int primary key,
+    payload variant
+);
+
+statement ok
+insert into variant_constant_path_t values (1, NULL);
+
+query ITT
+select id, variant_get(payload, '.')::varchar, try_variant_get(payload, '.')::varchar
+from variant_constant_path_t;
+----
+1 NULL NULL
+
+statement ok
+create materialized view variant_constant_path_mv as
+select
+    id,
+    variant_get(payload, '.') as value,
+    try_variant_get(payload, '.') as try_value
+from variant_constant_path_t;
+
+statement ok
+insert into variant_constant_path_t values (2, NULL);
+
+query ITT rowsort
+select id, value::varchar, try_value::varchar from variant_constant_path_mv;
+----
+1 NULL NULL
+2 NULL NULL
+
+statement ok
+drop materialized view variant_constant_path_mv;
+
+# Non-NULL input must still report the cached parse error in strict batch evaluation.
+statement ok
+update variant_constant_path_t set payload = '{}'::variant where id = 1;
+
+statement error invalid variant path
+select variant_get(payload, '.') from variant_constant_path_t where id = 1;
+
+query T
+select try_variant_get(payload, '.')::varchar from variant_constant_path_t where id = 1;
+----
+NULL
+
+statement ok
+drop table variant_constant_path_t;
+
 # Nested VARIANT must not reach a streaming operator's storage key.
 statement ok
 create table variant_nested_t (

--- a/src/common/src/types/mod.rs
+++ b/src/common/src/types/mod.rs
@@ -100,7 +100,7 @@ pub use self::struct_type::StructType;
 pub use self::successor::Successor;
 pub use self::timestamptz::*;
 pub use self::to_text::ToText;
-pub use self::variant::{VariantRef, VariantVal};
+pub use self::variant::{VariantPath, VariantRef, VariantVal};
 pub use self::with_data_type::WithDataType;
 
 /// A 32-bit floating point type with total order.

--- a/src/common/src/types/variant.rs
+++ b/src/common/src/types/variant.rs
@@ -55,6 +55,22 @@ pub struct VariantRef<'a> {
     data: &'a [u8],
 }
 
+/// A parsed path for accessing nested fields in a [`VariantRef`].
+///
+/// Parsing a path once and reusing it avoids repeated string parsing and allocations when the same
+/// path is applied to multiple values.
+#[derive(Debug)]
+pub struct VariantPath {
+    tokens: Vec<PathToken>,
+}
+
+impl VariantPath {
+    /// Parses a variant path.
+    pub fn parse(path: &str) -> anyhow::Result<Self> {
+        parse_path(path).map(|tokens| Self { tokens })
+    }
+}
+
 impl EstimateSize for VariantVal {
     fn estimated_heap_size(&self) -> usize {
         self.data.len()
@@ -379,18 +395,23 @@ impl<'a> VariantRef<'a> {
     }
 
     pub fn access_path_strict(self, path: &str) -> anyhow::Result<Option<VariantVal>> {
+        self.access_path_parsed(&VariantPath::parse(path)?)
+    }
+
+    /// Accesses a nested value using a pre-parsed path.
+    pub fn access_path_parsed(self, path: &VariantPath) -> anyhow::Result<Option<VariantVal>> {
         // Walk the whole path on borrowed variants sharing the same metadata, and canonicalize
         // (re-encode) only the final leaf.
         let mut variant = self.parquet_variant();
-        for token in parse_path(path)? {
+        for token in &path.tokens {
             let next = match token {
-                PathToken::Field(field) => variant.get_object_field(&field),
+                PathToken::Field(field) => variant.get_object_field(field),
                 // Pattern-match instead of `as_list`, whose `&'m self` receiver would keep
                 // `variant` borrowed and forbid the reassignment below.
                 PathToken::Index(index) => match &variant {
                     ParquetVariant::List(list) => {
-                        let index = if index >= 0 {
-                            Some(index as usize)
+                        let index = if *index >= 0 {
+                            Some(*index as usize)
                         } else {
                             list.len().checked_sub(index.unsigned_abs() as usize)
                         };
@@ -899,6 +920,7 @@ fn append_decimal(value: Decimal, builder: &mut impl VariantBuilderExt) -> anyho
     Ok(())
 }
 
+#[derive(Debug)]
 enum PathToken {
     Field(String),
     Index(i32),
@@ -1014,6 +1036,15 @@ mod tests {
     #[test]
     fn path_access_supports_dot_and_bracket() {
         let v: VariantVal = r#"{"a":[{"b":7}]}"#.parse().unwrap();
+        let path = VariantPath::parse("$.a[0].b").unwrap();
+        assert_eq!(
+            v.as_scalar_ref()
+                .access_path_parsed(&path)
+                .unwrap()
+                .unwrap()
+                .to_string(),
+            "7"
+        );
         assert_eq!(
             v.as_scalar_ref()
                 .access_path("$.a[0].b")

--- a/src/common/src/types/variant.rs
+++ b/src/common/src/types/variant.rs
@@ -1034,7 +1034,7 @@ mod tests {
     }
 
     #[test]
-    fn path_access_supports_dot_and_bracket() {
+    fn access_path_with_preparsed_path() {
         let v: VariantVal = r#"{"a":[{"b":7}]}"#.parse().unwrap();
         let path = VariantPath::parse("$.a[0].b").unwrap();
         assert_eq!(
@@ -1045,6 +1045,11 @@ mod tests {
                 .to_string(),
             "7"
         );
+    }
+
+    #[test]
+    fn path_access_supports_dot_and_bracket() {
+        let v: VariantVal = r#"{"a":[{"b":7}]}"#.parse().unwrap();
         assert_eq!(
             v.as_scalar_ref()
                 .access_path("$.a[0].b")

--- a/src/expr/impl/src/scalar/variant.rs
+++ b/src/expr/impl/src/scalar/variant.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use risingwave_common::types::{ScalarRefImpl, VariantRef, VariantVal};
+use risingwave_common::types::{ScalarRefImpl, VariantPath, VariantRef, VariantVal};
 use risingwave_expr::expr::Context;
 use risingwave_expr::{ExprError, Result, function};
 use thiserror_ext::AsReport;
@@ -25,19 +25,38 @@ fn to_variant(input: Option<ScalarRefImpl<'_>>, ctx: &Context) -> Result<Variant
     })
 }
 
-#[function("variant_get(variant, varchar) -> variant")]
-fn variant_get(value: VariantRef<'_>, path: &str) -> Result<Option<VariantVal>> {
-    value
-        .access_path_strict(path)
-        .map_err(|e| ExprError::InvalidParam {
-            name: "variant_get",
-            reason: e.to_report_string().into(),
-        })
+#[function(
+    "variant_get(variant, varchar) -> variant",
+    prebuild = "VariantPath::parse($1).map_err(variant_get_error)?"
+)]
+fn variant_get(value: VariantRef<'_>, path: &VariantPath) -> Result<Option<VariantVal>> {
+    value.access_path_parsed(path).map_err(variant_get_error)
 }
 
-#[function("try_variant_get(variant, varchar) -> variant")]
-fn try_variant_get(value: VariantRef<'_>, path: &str) -> Option<VariantVal> {
-    value.access_path(path)
+fn variant_get_error(e: anyhow::Error) -> ExprError {
+    ExprError::InvalidParam {
+        name: "variant_get",
+        reason: e.to_report_string().into(),
+    }
+}
+
+#[derive(Debug)]
+struct TryVariantPath(Option<VariantPath>);
+
+impl TryVariantPath {
+    fn parse(path: &str) -> Self {
+        Self(VariantPath::parse(path).ok())
+    }
+}
+
+#[function(
+    "try_variant_get(variant, varchar) -> variant",
+    prebuild = "TryVariantPath::parse($1)"
+)]
+fn try_variant_get(value: VariantRef<'_>, path: &TryVariantPath) -> Option<VariantVal> {
+    path.0
+        .as_ref()
+        .and_then(|path| value.access_path_parsed(path).ok().flatten())
 }
 
 #[function("variant_typeof(variant) -> varchar")]

--- a/src/expr/impl/src/scalar/variant.rs
+++ b/src/expr/impl/src/scalar/variant.rs
@@ -27,13 +27,16 @@ fn to_variant(input: Option<ScalarRefImpl<'_>>, ctx: &Context) -> Result<Variant
 
 #[function(
     "variant_get(variant, varchar) -> variant",
-    prebuild = "VariantPath::parse($1).map_err(variant_get_error)?"
+    prebuild = "PrebuiltVariantPath::parse($1)"
 )]
-fn variant_get(value: VariantRef<'_>, path: &VariantPath) -> Result<Option<VariantVal>> {
-    value.access_path_parsed(path).map_err(variant_get_error)
+fn variant_get(value: VariantRef<'_>, path: &PrebuiltVariantPath) -> Result<Option<VariantVal>> {
+    let path = path.0.as_ref().map_err(variant_get_error)?;
+    value
+        .access_path_parsed(path)
+        .map_err(|e| variant_get_error(&e))
 }
 
-fn variant_get_error(e: anyhow::Error) -> ExprError {
+fn variant_get_error(e: &anyhow::Error) -> ExprError {
     ExprError::InvalidParam {
         name: "variant_get",
         reason: e.to_report_string().into(),
@@ -41,21 +44,22 @@ fn variant_get_error(e: anyhow::Error) -> ExprError {
 }
 
 #[derive(Debug)]
-struct TryVariantPath(Option<VariantPath>);
+struct PrebuiltVariantPath(anyhow::Result<VariantPath>);
 
-impl TryVariantPath {
+impl PrebuiltVariantPath {
     fn parse(path: &str) -> Self {
-        Self(VariantPath::parse(path).ok())
+        Self(VariantPath::parse(path))
     }
 }
 
 #[function(
     "try_variant_get(variant, varchar) -> variant",
-    prebuild = "TryVariantPath::parse($1)"
+    prebuild = "PrebuiltVariantPath::parse($1)"
 )]
-fn try_variant_get(value: VariantRef<'_>, path: &TryVariantPath) -> Option<VariantVal> {
+fn try_variant_get(value: VariantRef<'_>, path: &PrebuiltVariantPath) -> Option<VariantVal> {
     path.0
         .as_ref()
+        .ok()
         .and_then(|path| value.access_path_parsed(path).ok().flatten())
 }
 


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

<!--

**Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

- Closes #26438.

`variant_get` and `try_variant_get` currently parse their path argument once per input row. In typical queries, the path is a constant, so this repeatedly scans the same string and allocates an identical token vector and field strings.

This PR prebuilds constant variant paths:

- Introduces an opaque, reusable `VariantPath` type in `risingwave_common::types`.
- Adds `VariantRef::access_path_parsed` for accessing values with a pre-parsed path.
- Uses the expression macro's `prebuild` support in `variant_get` and `try_variant_get`.
- Keeps the existing string-based access methods for dynamic-path callers.
- Preserves the existing error semantics:
  - `variant_get` reports malformed paths as errors.
  - `try_variant_get` returns `NULL` for malformed paths.
- Preserves support for negative array indices.

When the path argument is constant, it is now parsed once while building the expression. Non-constant path arguments continue to be parsed per row.

This is a performance-only change with no SQL semantics changes.

## Checklist

- [x] I have written necessary rustdoc comments.
- [x] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved VARIANT path handling for malformed dynamic and constant paths.
  - Invalid paths now correctly produce row-level `NULL` results during non-strict evaluation without affecting other rows.
  - Strict evaluation continues to report path parsing errors when applicable.
  - SQL `NULL` short-circuit behavior is preserved for invalid constant paths.

- **Improvements**
  - Added support for pre-parsed VARIANT paths, improving consistency and efficiency for repeated path access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->