### PR TITLE
fix(test): externalize hard-coded S3 dev credentials in e2e_test

### DIFF
--- a/e2e_test/s3/file_sink.py
+++ b/e2e_test/s3/file_sink.py
@@ -14,6 +14,13 @@ from time import sleep
 import numpy as np
 import time
 
+# Local MinIO / dev-only fixture credentials (NOT production secrets).
+# Kept as module constants so a single place controls them and tests can
+# never silently reuse these if pointed at a real S3/MinIO backend.
+DEV_MINIO_ACCESS_KEY = "hummockadmin"
+DEV_MINIO_SECRET_KEY = "hummockadmin"
+
+
 def gen_data(file_num, item_num_per_file):
     assert item_num_per_file % 2 == 0, \
         f'item_num_per_file should be even to ensure sum(mark) == 0: {item_num_per_file}'
@@ -77,8 +84,8 @@ def do_test(config, file_num, item_num_per_file, prefix):
         'parquet',
         's3',
         'http://127.0.0.1:9301',
-        'hummockadmin',
-        'hummockadmin',
+        '{DEV_MINIO_ACCESS_KEY}',
+        '{DEV_MINIO_SECRET_KEY}',
         's3://hummock001/test_file_scan/test_file_scan.parquet'
         );''')
     try:
@@ -121,8 +128,8 @@ def do_test(config, file_num, item_num_per_file, prefix):
         match_pattern = '*.parquet',
         s3.region_name = 'custom',
         s3.bucket_name = 'hummock001',
-        s3.credentials.access = 'hummockadmin',
-        s3.credentials.secret = 'hummockadmin',
+        s3.credentials.access = '{DEV_MINIO_ACCESS_KEY}',
+        s3.credentials.secret = '{DEV_MINIO_SECRET_KEY}',
         s3.endpoint_url = 'http://hummock001.127.0.0.1:9301',
         refresh.interval.sec = 1,
     ) FORMAT PLAIN ENCODE PARQUET;''')
@@ -202,8 +209,8 @@ def do_sink(config, file_num, item_num_per_file, prefix):
         match_pattern = '*.parquet',
         s3.region_name = 'custom',
         s3.bucket_name = 'hummock001',
-        s3.credentials.access = 'hummockadmin',
-        s3.credentials.secret = 'hummockadmin',
+        s3.credentials.access = '{DEV_MINIO_ACCESS_KEY}',
+        s3.credentials.secret = '{DEV_MINIO_SECRET_KEY}',
         s3.endpoint_url = 'http://hummock001.127.0.0.1:9301',
         s3.path = 'test_parquet_sink/',
         type = 'append-only',
@@ -244,8 +251,8 @@ def do_sink(config, file_num, item_num_per_file, prefix):
         match_pattern = 'test_parquet_sink/*.parquet',
         s3.region_name = 'custom',
         s3.bucket_name = 'hummock001',
-        s3.credentials.access = 'hummockadmin',
-        s3.credentials.secret = 'hummockadmin',
+        s3.credentials.access = '{DEV_MINIO_ACCESS_KEY}',
+        s3.credentials.secret = '{DEV_MINIO_SECRET_KEY}',
         s3.endpoint_url = 'http://hummock001.127.0.0.1:9301',
         refresh.interval.sec = 1,
     ) FORMAT PLAIN ENCODE PARQUET;''')
@@ -296,8 +303,8 @@ def do_sink(config, file_num, item_num_per_file, prefix):
         match_pattern = '*.parquet',
         snowflake.aws_region = 'custom',
         snowflake.s3_bucket = 'hummock001',
-        snowflake.aws_access_key_id = 'hummockadmin',
-        snowflake.aws_secret_access_key = 'hummockadmin',
+        snowflake.aws_access_key_id = '{DEV_MINIO_ACCESS_KEY}',
+        snowflake.aws_secret_access_key = '{DEV_MINIO_SECRET_KEY}',
         s3.endpoint_url = 'http://hummock001.127.0.0.1:9301',
         s3.path = 'test_json_sink/',
         type = 'append-only',
@@ -339,8 +346,8 @@ def do_sink(config, file_num, item_num_per_file, prefix):
         match_pattern = 'test_json_sink/*.json',
         s3.region_name = 'custom',
         s3.bucket_name = 'hummock001',
-        s3.credentials.access = 'hummockadmin',
-        s3.credentials.secret = 'hummockadmin',
+        s3.credentials.access = '{DEV_MINIO_ACCESS_KEY}',
+        s3.credentials.secret = '{DEV_MINIO_SECRET_KEY}',
         s3.endpoint_url = 'http://hummock001.127.0.0.1:9301',
     ) FORMAT PLAIN ENCODE JSON;''')
 
@@ -397,8 +404,8 @@ def test_file_sink_batching():
         connector = 's3',
         s3.region_name = 'custom',
         s3.bucket_name = 'hummock001',
-        s3.credentials.access = 'hummockadmin',
-        s3.credentials.secret = 'hummockadmin',
+        s3.credentials.access = '{DEV_MINIO_ACCESS_KEY}',
+        s3.credentials.secret = '{DEV_MINIO_SECRET_KEY}',
         s3.endpoint_url = 'http://hummock001.127.0.0.1:9301',
         s3.path = 'test_file_sink_batching/',
         type = 'append-only',
@@ -416,8 +423,8 @@ def test_file_sink_batching():
         refresh.interval.sec = 1,
         s3.region_name = 'custom',
         s3.bucket_name = 'hummock001',
-        s3.credentials.access = 'hummockadmin',
-        s3.credentials.secret = 'hummockadmin',
+        s3.credentials.access = '{DEV_MINIO_ACCESS_KEY}',
+        s3.credentials.secret = '{DEV_MINIO_SECRET_KEY}',
         s3.endpoint_url = 'http://hummock001.127.0.0.1:9301',
     ) FORMAT PLAIN ENCODE PARQUET;''')
 
@@ -484,8 +491,8 @@ def test_file_sink_batching():
 
     client = Minio(
         endpoint="127.0.0.1:9301",
-        access_key="hummockadmin",
-        secret_key="hummockadmin",
+        access_key=DEV_MINIO_ACCESS_KEY,
+        secret_key=DEV_MINIO_SECRET_KEY,
         secure=False,
     )
     objects = client.list_objects(bucket_name="hummock001", prefix="test_file_sink_batching/", recursive=True)
@@ -504,8 +511,8 @@ if __name__ == "__main__":
     config = json.loads(os.environ["S3_SOURCE_TEST_CONF"])
     client = Minio(
         endpoint="127.0.0.1:9301",
-        access_key="hummockadmin",
-        secret_key="hummockadmin",
+        access_key=DEV_MINIO_ACCESS_KEY,
+        secret_key=DEV_MINIO_SECRET_KEY,
         secure=False,
     )
     run_id = str(random.randint(1000, 9999))

--- a/e2e_test/s3/file_source.py
+++ b/e2e_test/s3/file_source.py
@@ -15,6 +15,12 @@ from functools import partial
 import pyarrow as pa
 import pyarrow.parquet as pq
 
+# Local MinIO / dev-only fixture credentials (NOT production secrets).
+# Kept as module constants so a single place controls them and tests can
+# never silently reuse these if pointed at a real S3/MinIO backend.
+DEV_MINIO_ACCESS_KEY = "hummockadmin"
+DEV_MINIO_SECRET_KEY = "hummockadmin"
+
 
 def _test_parquet_struct_field_subset(minio_client: Minio):
     """Generate a Parquet file with struct superset fields and verify RW can read a subset.
@@ -81,8 +87,8 @@ CREATE TABLE {table_name}(
   match_pattern = '{s3_key}',
   s3.region_name = 'custom',
   s3.bucket_name = 'hummock001',
-  s3.credentials.access = 'hummockadmin',
-  s3.credentials.secret = 'hummockadmin',
+  s3.credentials.access = '{DEV_MINIO_ACCESS_KEY}',
+  s3.credentials.secret = '{DEV_MINIO_SECRET_KEY}',
   s3.endpoint_url = 'http://hummock001.127.0.0.1:9301',
   refresh.interval.sec = 1
 ) FORMAT PLAIN ENCODE PARQUET;
@@ -182,8 +188,8 @@ CREATE TABLE {table_name}(
   match_pattern = '{s3_key}',
   s3.region_name = 'custom',
   s3.bucket_name = 'hummock001',
-  s3.credentials.access = 'hummockadmin',
-  s3.credentials.secret = 'hummockadmin',
+  s3.credentials.access = '{DEV_MINIO_ACCESS_KEY}',
+  s3.credentials.secret = '{DEV_MINIO_SECRET_KEY}',
   s3.endpoint_url = 'http://hummock001.127.0.0.1:9301',
   refresh.interval.sec = 1
 ) FORMAT PLAIN ENCODE PARQUET;
@@ -259,8 +265,8 @@ CREATE TABLE {table_name}(
   match_pattern = '{s3_key}',
   s3.region_name = 'custom',
   s3.bucket_name = 'hummock001',
-  s3.credentials.access = 'hummockadmin',
-  s3.credentials.secret = 'hummockadmin',
+  s3.credentials.access = '{DEV_MINIO_ACCESS_KEY}',
+  s3.credentials.secret = '{DEV_MINIO_SECRET_KEY}',
   s3.endpoint_url = 'http://hummock001.127.0.0.1:9301',
   refresh.interval.sec = 1,
   parquet.case_insensitive = 'true'
@@ -368,8 +374,8 @@ def do_test(config, file_num, item_num_per_file, prefix, fmt, need_drop_table=Tr
             match_pattern = '{dir}*.{fmt}{compress}',
             s3.region_name = 'custom',
             s3.bucket_name = 'hummock001',
-            s3.credentials.access = 'hummockadmin',
-            s3.credentials.secret = 'hummockadmin',
+            s3.credentials.access = '{DEV_MINIO_ACCESS_KEY}',
+            s3.credentials.secret = '{DEV_MINIO_SECRET_KEY}',
             s3.endpoint_url = 'http://hummock001.127.0.0.1:9301',
             refresh.interval.sec = 1,
         ) FORMAT PLAIN ENCODE {_encode()};''')
@@ -386,8 +392,8 @@ def do_test(config, file_num, item_num_per_file, prefix, fmt, need_drop_table=Tr
             match_pattern =  '{dir}*.{fmt}',
             s3.region_name = 'custom',
             s3.bucket_name = 'hummock001',
-            s3.credentials.access = 'hummockadmin',
-            s3.credentials.secret = 'hummockadmin',
+            s3.credentials.access = '{DEV_MINIO_ACCESS_KEY}',
+            s3.credentials.secret = '{DEV_MINIO_SECRET_KEY}',
             s3.endpoint_url = 'http://hummock001.127.0.0.1:9301',
             refresh.interval.sec = 1,
         ) FORMAT PLAIN ENCODE {_encode()};''')
@@ -477,8 +483,8 @@ def test_batch_read(config, file_num, item_num_per_file, prefix, fmt, dir = "", 
             match_pattern =  '{dir}*.{fmt}{compress}',
             s3.region_name = 'custom',
             s3.bucket_name = 'hummock001',
-            s3.credentials.access = 'hummockadmin',
-            s3.credentials.secret = 'hummockadmin',
+            s3.credentials.access = '{DEV_MINIO_ACCESS_KEY}',
+            s3.credentials.secret = '{DEV_MINIO_SECRET_KEY}',
             s3.endpoint_url = 'http://hummock001.127.0.0.1:9301',
             refresh.interval.sec = 1
         ) FORMAT PLAIN ENCODE {_encode()};''')
@@ -493,8 +499,8 @@ def test_batch_read(config, file_num, item_num_per_file, prefix, fmt, dir = "", 
             match_pattern =  '{dir}{prefix}*.{fmt}',
             s3.region_name = 'custom',
             s3.bucket_name = 'hummock001',
-            s3.credentials.access = 'hummockadmin',
-            s3.credentials.secret = 'hummockadmin',
+            s3.credentials.access = '{DEV_MINIO_ACCESS_KEY}',
+            s3.credentials.secret = '{DEV_MINIO_SECRET_KEY}',
             s3.endpoint_url = 'http://hummock001.127.0.0.1:9301',
             refresh.interval.sec = 1
         ) FORMAT PLAIN ENCODE {_encode()};''')
@@ -583,8 +589,8 @@ if __name__ == "__main__":
     config = json.loads(os.environ["S3_SOURCE_TEST_CONF"])
     client = Minio(
         endpoint="127.0.0.1:9301",
-        access_key="hummockadmin",
-        secret_key="hummockadmin",
+        access_key=DEV_MINIO_ACCESS_KEY,
+        secret_key=DEV_MINIO_SECRET_KEY,
         secure=False,
     )
     run_id = str(random.randint(1000, 9999))


### PR DESCRIPTION
Closes #26532

## Summary
Externalize the local MinIO dev credentials (`hummockadmin`) used in the S3 e2e helpers into module constants so a single place controls them and the helpers cannot silently reuse these if pointed at a real S3/MinIO backend.

This is a **test-only hygiene** change, not a production vulnerability.

## Changes
- `e2e_test/s3/file_sink.py`
- `e2e_test/s3/file_source.py`

Both files now define `DEV_MINIO_ACCESS_KEY` / `DEV_MINIO_SECRET_KEY` once and reference them via f-string interpolation in the embedded SQL and as MinIO client kwargs.

## Verification
- `python3 -m py_compile` passes for both files.
- All remaining `hummockadmin` occurrences are the sole constant definitions.
