### PR TITLE
fix(frontend): gate Iceberg engine schema changes by license

### DIFF
--- a/src/frontend/src/handler/alter_table_column.rs
+++ b/src/frontend/src/handler/alter_table_column.rs
@@ -18,6 +18,7 @@ use itertools::Itertools;
 use pgwire::pg_response::{PgResponse, StatementType};
 use risingwave_common::catalog::ColumnCatalog;
 use risingwave_common::hash::VnodeCount;
+use risingwave_common::license::Feature;
 use risingwave_common::{bail, bail_not_implemented};
 use risingwave_pb::ddl_service::TableJobType;
 use risingwave_pb::stream_plan::StreamFragmentGraph;
@@ -122,6 +123,15 @@ pub async fn handle_alter_table_column(
     let session = handler_args.session;
     let (original_catalog, has_incoming_sinks) =
         fetch_table_catalog_for_alter(session.as_ref(), &table_name)?;
+
+    if original_catalog.is_iceberg_engine_table()
+        && matches!(
+            &operation,
+            AlterTableOperation::AddColumn { .. } | AlterTableOperation::DropColumn { .. }
+        )
+    {
+        Feature::SinkAutoSchemaChange.check_available()?;
+    }
 
     if original_catalog.webhook_info.is_some() {
         return Err(RwError::from(ErrorCode::BindError(

--- a/src/frontend/src/handler/create_sink.rs
+++ b/src/frontend/src/handler/create_sink.rs
@@ -207,7 +207,7 @@ pub async fn gen_sink_plan(
         .transpose()?
         .unwrap_or(false);
 
-    if is_auto_schema_change {
+    if is_auto_schema_change && !is_iceberg_engine_internal {
         Feature::SinkAutoSchemaChange.check_available()?;
     }
 


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

Iceberg Engine uses a hidden sink with auto schema refresh so that table schema changes can be propagated to Iceberg. That internal sink was previously treated like a user-created sink with `auto.schema.change=true`, which made the `SinkAutoSchemaChange` license a prerequisite for creating the table.

This PR:

- exempts the Iceberg Engine hidden sink from the creation-time license check;
- checks the current license when an Iceberg Engine table executes `ALTER TABLE ADD/DROP COLUMN`;
- leaves the creation-time license check unchanged for user-created sinks that explicitly enable `auto.schema.change`.

It reuses the existing `is_iceberg_engine_internal` planning signal and `auto_refresh_schema_from_table` catalog field. No new planning model, catalog field, or migration is introduced.

## Behavior

- With or without the license, an Iceberg Engine table can be created and its `enable_compaction` setting is preserved.
- For a non-PK-index Iceberg Engine table:
  - with the license, `ALTER TABLE ADD/DROP COLUMN` can propagate the schema change;
  - without the license, these ALTER statements return a license error.
- A PK-index Iceberg Engine table has no auto-schema-refresh sink, so ADD/DROP COLUMN remains unsupported regardless of the license.
- A user-created sink with `auto.schema.change=true` still requires the license when the sink is created.
- The ALTER check uses the current license state, so adding or removing a license takes effect without recreating the table.

Related customer report: CF-4261.

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [x] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results.
- [x] <!-- OPTIONAL --> I have checked the Release Timeline and provided the independent release-3.0 fix in #26545.

## Documentation

- [x] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

Creating an Iceberg Engine table no longer requires the `SinkAutoSchemaChange` licensed feature. Without that feature, the table remains usable but schema-changing ALTER statements are rejected. User-created sinks that enable `auto.schema.change` still require the feature when the sink is created.

</details>
