### PR TITLE
ci: shard main-cron recovery simulation tests

### DIFF
--- a/ci/workflows/main-cron.yml
+++ b/ci/workflows/main-cron.yml
@@ -533,6 +533,7 @@ steps:
       - docker-compose#v5.5.0: *docker-compose
       - ./ci/plugins/upload-failure-logs
     timeout_in_minutes: 70
+    parallelism: 6
     retry: *auto-retry
 
   - label: "integration test (madsim) - backfill"


### PR DESCRIPTION
## What changed

- Run the main-cron `integration test (madsim) - recovery` step with Buildkite parallelism 6.
- Reuse the existing `NEXTEST_PARTITION_ARG` support in `deterministic-it-test.sh` so each job receives a disjoint hash partition of recovery tests while preserving all 60 seeds per test.

## Why

The recovery step has timed out in all 20 recent scheduled main-cron builds. In [build 9732](https://buildkite.com/risingwavelabs/main-cron/builds/9732), it reached the 70-minute step limit and exited 143. The adjacent scale simulation step already uses the same six-way Buildkite partitioning.

## Validation

- `git diff --check`
- Parsed `ci/workflows/main-cron.yml` with PyYAML
- Requested the selected main-cron deterministic integration lane

## Documentation

No user-facing behavior changes.