### PR TITLE
test(stream): assert over-window metric deltas

### DIFF
--- a/src/stream/tests/integration_tests/over_window.rs
+++ b/src/stream/tests/integration_tests/over_window.rs
@@ -415,6 +415,9 @@ async fn test_over_window_evict_between_chunks() {
     let store = MemoryStateStore::new();
     let watermark = Arc::new(AtomicU64::new(0));
     let metrics = Arc::new(StreamingMetrics::unused());
+    let ow_metrics = metrics.new_over_window_metrics(TableId::new(1), 123.into(), 0.into());
+    let initial_lookup_count = ow_metrics.over_window_cache_lookup_count.get();
+    let initial_miss_count = ow_metrics.over_window_cache_miss_count.get();
     let calls = vec![
         // sum(x) over (partition by .. order by .. rows unbounded preceding)
         WindowFuncCall {
@@ -502,9 +505,14 @@ async fn test_over_window_evict_between_chunks() {
     // 4 partition lookups (p1, p2, p1, p1), all missing the cache: `p1` was evicted at
     // each chunk boundary in the second epoch. Without chunk-boundary eviction, the
     // last two lookups would hit the cache and the miss count would be 2.
-    let ow_metrics = metrics.new_over_window_metrics(TableId::new(1), 123.into(), 0.into());
-    assert_eq!(ow_metrics.over_window_cache_lookup_count.get(), 4);
-    assert_eq!(ow_metrics.over_window_cache_miss_count.get(), 4);
+    assert_eq!(
+        ow_metrics.over_window_cache_lookup_count.get(),
+        initial_lookup_count + 4
+    );
+    assert_eq!(
+        ow_metrics.over_window_cache_miss_count.get(),
+        initial_miss_count + 4
+    );
 }
 
 /// Regression test: deleting all rows of a fully-cached partition (no sentinels in the


### PR DESCRIPTION
## What changed

Capture the over-window cache lookup and miss counters before `test_over_window_evict_between_chunks` runs, then assert that the test increments each counter by four.

## Why

`StreamingMetrics::unused()` is reused by repeated madsim runs. The main-cron unit test sets `MADSIM_TEST_NUM=100`, so the old absolute-value assertion passed once and then observed 8 instead of 4 on the second run. This made `unit test (madsim)` fail deterministically in [build 9732](https://buildkite.com/risingwavelabs/main-cron/builds/9732).

The test still verifies the same cache behavior; it no longer assumes a fresh process-global counter.

## Validation

- `cargo fmt --check`
- `CARGO_TARGET_DIR=/tmp/rw-cidx-over-window-target MADSIM_TEST_NUM=2 cargo nextest run --config "target.'cfg(all())'.rustflags = ['--cfg=madsim']" -p risingwave_stream -E 'test(test_over_window_evict_between_chunks)'`
- `git diff --check`
- Requested the selected main-cron deterministic unit-test lane

## Documentation

No user-facing behavior changes.