### PR TITLE
ci: increase standalone e2e timeout

### DIFF
--- a/ci/workflows/main-cron.yml
+++ b/ci/workflows/main-cron.yml
@@ -930,7 +930,7 @@ steps:
     plugins:
       - docker-compose#v5.5.0: *docker-compose
       - ./ci/plugins/upload-failure-logs
-    timeout_in_minutes: 40
+    timeout_in_minutes: 50
     retry: *auto-retry
 
   - label: "e2e single-node binary test"


### PR DESCRIPTION
## What changed

Increase the main-cron `e2e standalone binary test` timeout from 40 to 50 minutes.

## Why

The step timed out in 15 of the 20 recent scheduled builds, generally while the suite was still progressing through the final standalone restart and option checks. The current 40-minute limit has no headroom for cold-worker setup or the final persistence checks.

This does not change test selection or product behavior.

## Validation

- `git diff --check`
- Parsed `ci/workflows/main-cron.yml` with PyYAML
- Requested the selected main-cron standalone lane

## Documentation

No user-facing behavior changes.