### PR TITLE
test: reduce backfill test log verbosity

### DIFF
--- a/ci/scripts/run-backfill-tests.sh
+++ b/ci/scripts/run-backfill-tests.sh
@@ -34,7 +34,7 @@ else
   RUNTIME_CLUSTER_PROFILE='ci-backfill-3cn-1fe-with-monitoring'
   MINIO_RATE_LIMIT_CLUSTER_PROFILE='ci-backfill-3cn-1fe-with-monitoring-and-minio-rate-limit'
 fi
-export RUST_LOG="info,risingwave_stream=info,risingwave_stream::executor::backfill=debug,risingwave_batch=info,risingwave_storage=info,risingwave_meta::barrier=debug,risingwave_stream::executor::stream_reader=warn" \
+export RUST_LOG="info,risingwave_stream=info,risingwave_batch=info,risingwave_storage=info,risingwave_stream::executor::stream_reader=warn" \
 
 run_sql_file() {
   psql -h localhost -p 4566 -d dev -U root -f "$@"


### PR DESCRIPTION
## What changed

Stop overriding the backfill executor and meta barrier modules to debug level in `run-backfill-tests.sh`. Both now inherit the existing info-level filters.

## Why

The main-cron `Backfill tests` step frequently completed its test cases but failed the shared `check-logs` guard because combined logs reached roughly 12 to 15 MB, above the 8 MB limit. The two debug overrides are diagnostic noise for routine runs and dominate the log volume.

Warnings and info-level progress remain available, and failure artifacts are still uploaded.

## Validation

- `git diff --check`
- `bash -n ci/scripts/run-backfill-tests.sh`
- Requested the selected main-cron backfill lane

## Documentation

No user-facing behavior changes.