### PR TITLE
feat(connector): support ENCODE AUTO for Pulsar sources

### DIFF
--- a/src/connector/src/parser/avro/mod.rs
+++ b/src/connector/src/parser/avro/mod.rs
@@ -15,7 +15,9 @@
 mod confluent_resolver;
 mod glue_resolver;
 mod parser;
+mod pulsar_resolver;
 
 pub use confluent_resolver::ConfluentSchemaCache;
 pub use glue_resolver::{GlueSchemaCache, GlueSchemaCacheImpl};
 pub use parser::{AvroAccessBuilder, AvroParserConfig};
+pub use pulsar_resolver::PulsarSchemaCache;

--- a/src/connector/src/parser/avro/parser.rs
+++ b/src/connector/src/parser/avro/parser.rs
@@ -24,13 +24,14 @@ use risingwave_connector_codec::decoder::avro::{
     AvroAccess, AvroParseOptions, ResolvedAvroSchema, avro_schema_to_fields,
 };
 
-use super::{ConfluentSchemaCache, GlueSchemaCache as _, GlueSchemaCacheImpl};
+use super::{ConfluentSchemaCache, GlueSchemaCache as _, GlueSchemaCacheImpl, PulsarSchemaCache};
 use crate::error::ConnectorResult;
 use crate::parser::unified::AccessImpl;
 use crate::parser::utils::bytes_from_url;
 use crate::parser::{
     AccessBuilder, AvroProperties, EncodingProperties, MapHandling, SchemaLocation,
 };
+use crate::schema::pulsar::pulsar_schema_version_to_i64;
 use crate::schema::schema_registry::{
     Client, extract_schema_id, get_subject_by_strategy, handle_sr_list,
 };
@@ -96,10 +97,10 @@ impl AvroAccessBuilder {
     async fn parse_avro_value(
         &self,
         payload: &[u8],
-        _source_meta: &SourceMeta,
+        source_meta: &SourceMeta,
     ) -> ConnectorResult<Option<Value>> {
-        // parse payload to avro value
-        // if use confluent schema, get writer schema from confluent schema registry
+        // Parse payload to an Avro value. Each schema backend has its own wire-format contract,
+        // so keep the payload framing logic close to the writer-schema lookup.
         match &self.writer_schema_cache {
             WriterSchemaCache::Confluent(resolver) => {
                 let (schema_id, mut raw_payload) = extract_schema_id(payload)?;
@@ -118,6 +119,28 @@ impl AvroAccessBuilder {
                     Some(Err(e)) => Err(e)?,
                     None => bail!("avro parse unexpected eof"),
                 }
+            }
+            WriterSchemaCache::Pulsar(resolver) => {
+                // Pulsar Avro payloads are raw Avro datum bytes. The writer schema version is
+                // carried by Pulsar message metadata instead of a Confluent-style payload header.
+                let schema_version = match source_meta {
+                    SourceMeta::Pulsar(meta) => meta.schema_version.as_deref(),
+                    _ => None,
+                };
+                let writer_schema = match schema_version
+                    .map(pulsar_schema_version_to_i64)
+                    .transpose()?
+                    .flatten()
+                {
+                    Some(version) => resolver.get_by_version(version).await?,
+                    None => resolver.get_latest().await?,
+                };
+                let mut raw_payload = payload;
+                Ok(Some(from_avro_datum(
+                    writer_schema.as_ref(),
+                    &mut raw_payload,
+                    Some(&self.schema.original_schema),
+                )?))
             }
             WriterSchemaCache::Glue(resolver) => {
                 // <https://github.com/awslabs/aws-glue-schema-registry/blob/v1.1.20/common/src/main/java/com/amazonaws/services/schemaregistry/utils/AWSSchemaRegistryConstants.java#L59-L61>
@@ -164,6 +187,7 @@ pub struct AvroParserConfig {
 enum WriterSchemaCache {
     Confluent(Arc<ConfluentSchemaCache>),
     Glue(Arc<GlueSchemaCacheImpl>),
+    Pulsar(Arc<PulsarSchemaCache>),
     File,
 }
 
@@ -231,6 +255,15 @@ impl AvroParserConfig {
                 Ok(Self {
                     schema: Arc::new(ResolvedAvroSchema::create(schema)?),
                     writer_schema_cache: WriterSchemaCache::Glue(Arc::new(resolver)),
+                    map_handling,
+                })
+            }
+            SchemaLocation::Pulsar(config) => {
+                let resolver = PulsarSchemaCache::new(config)?;
+                let schema = resolver.get_latest().await?;
+                Ok(Self {
+                    schema: Arc::new(ResolvedAvroSchema::create(schema)?),
+                    writer_schema_cache: WriterSchemaCache::Pulsar(Arc::new(resolver)),
                     map_handling,
                 })
             }

--- a/src/connector/src/parser/avro/pulsar_resolver.rs
+++ b/src/connector/src/parser/avro/pulsar_resolver.rs
@@ -1,0 +1,70 @@
+// Copyright 2024 RisingWave Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+
+use anyhow::Context;
+use apache_avro::Schema;
+use moka::future::Cache;
+use risingwave_common::bail;
+
+use crate::error::ConnectorResult;
+use crate::schema::pulsar::{PulsarSchema, PulsarSchemaClient, PulsarSchemaRegistryConfig};
+
+#[derive(Debug)]
+pub struct PulsarSchemaCache {
+    writer_schemas: Cache<i64, Arc<Schema>>,
+    pulsar_client: PulsarSchemaClient,
+}
+
+impl PulsarSchemaCache {
+    pub fn new(config: PulsarSchemaRegistryConfig) -> ConnectorResult<Self> {
+        Ok(Self {
+            writer_schemas: Cache::new(u64::MAX),
+            pulsar_client: PulsarSchemaClient::new(config)?,
+        })
+    }
+
+    async fn parse_and_cache_schema(
+        &self,
+        raw_schema: PulsarSchema,
+    ) -> ConnectorResult<Arc<Schema>> {
+        if !raw_schema.schema_type.eq_ignore_ascii_case("AVRO") {
+            bail!(
+                "expected Pulsar AVRO schema, got {}",
+                raw_schema.schema_type
+            );
+        }
+        let schema =
+            Schema::parse_str(&raw_schema.data).context("failed to parse Pulsar avro schema")?;
+        let schema = Arc::new(schema);
+        self.writer_schemas
+            .insert(raw_schema.version, Arc::clone(&schema))
+            .await;
+        Ok(schema)
+    }
+
+    pub async fn get_latest(&self) -> ConnectorResult<Arc<Schema>> {
+        self.parse_and_cache_schema(self.pulsar_client.get_latest_schema().await?)
+            .await
+    }
+
+    pub async fn get_by_version(&self, version: i64) -> ConnectorResult<Arc<Schema>> {
+        if let Some(schema) = self.writer_schemas.get(&version).await {
+            return Ok(schema);
+        }
+        self.parse_and_cache_schema(self.pulsar_client.get_schema_by_version(version).await?)
+            .await
+    }
+}

--- a/src/connector/src/parser/config.rs
+++ b/src/connector/src/parser/config.rs
@@ -22,14 +22,15 @@ use risingwave_pb::catalog::{PbSchemaRegistryNameStrategy, StreamSourceInfo};
 use super::unified::json::BigintUnsignedHandlingMode;
 use super::utils::get_kafka_topic;
 use super::{DebeziumProps, TimeHandling, TimestampHandling, TimestamptzHandling};
-use crate::WithOptionsSecResolved;
 use crate::connector_common::AwsAuthProps;
 use crate::error::ConnectorResult;
 use crate::parser::PROTOBUF_MESSAGES_AS_JSONB;
 use crate::schema::AWS_GLUE_SCHEMA_ARN_KEY;
+use crate::schema::pulsar::PulsarSchemaRegistryConfig;
 use crate::schema::schema_registry::SchemaRegistryConfig;
 use crate::source::cdc::CDC_MONGODB_STRONG_SCHEMA_KEY;
 use crate::source::{SourceColumnDesc, SourceEncode, SourceFormat, extract_source_struct};
+use crate::{WithOptionsSecResolved, WithPropertiesExt};
 
 pub const PARQUET_CASE_INSENSITIVE_KEY: &str = "parquet.case_insensitive";
 
@@ -194,6 +195,11 @@ impl SpecificParserConfig {
                             .get("aws.glue.mock_config")
                             .cloned(),
                     }
+                } else if info.use_schema_registry && options_with_secret.is_pulsar_connector() {
+                    SchemaLocation::Pulsar(PulsarSchemaRegistryConfig::from_source_options(
+                        info.row_schema_location.clone(),
+                        &options_with_secret,
+                    )?)
                 } else if info.use_schema_registry {
                     SchemaLocation::Confluent {
                         urls: info.row_schema_location.clone(),
@@ -237,7 +243,14 @@ impl SpecificParserConfig {
                     messages_as_jsonb,
                     ..Default::default()
                 };
-                config.schema_location = if info.use_schema_registry {
+                config.schema_location = if info.use_schema_registry
+                    && options_with_secret.is_pulsar_connector()
+                {
+                    SchemaLocation::Pulsar(PulsarSchemaRegistryConfig::from_source_options(
+                        info.row_schema_location.clone(),
+                        &options_with_secret,
+                    )?)
+                } else if info.use_schema_registry {
                     SchemaLocation::Confluent {
                         urls: info.row_schema_location.clone(),
                         client_config: SchemaRegistryConfig::from(
@@ -348,6 +361,9 @@ pub enum SchemaLocation {
         // When `Some(_)`, ignore AWS and load schemas from provided config
         mock_config: Option<String>,
     },
+    /// Pulsar admin schema endpoint. The URL still comes from `schema.registry`, but the API and
+    /// payload framing are Pulsar-specific rather than Confluent-compatible.
+    Pulsar(PulsarSchemaRegistryConfig),
 }
 
 // TODO: `SpecificParserConfig` shall not `impl`/`derive` a `Default`

--- a/src/connector/src/parser/protobuf/parser.rs
+++ b/src/connector/src/parser/protobuf/parser.rs
@@ -95,6 +95,9 @@ impl TryFrom<&SchemaLocation> for WireType {
             SchemaLocation::Glue { .. } => bail_invalid_option_error!(
                 "encode protobuf from aws glue schema registry not supported yet"
             ),
+            SchemaLocation::Pulsar(_) => bail_invalid_option_error!(
+                "encode protobuf from Pulsar schema registry not supported yet"
+            ),
         }
     }
 }
@@ -150,6 +153,9 @@ impl ProtobufParserConfig {
             }
             SchemaLocation::Glue { .. } => bail_invalid_option_error!(
                 "encode protobuf from aws glue schema registry not supported yet"
+            ),
+            SchemaLocation::Pulsar(_) => bail_invalid_option_error!(
+                "encode protobuf from Pulsar schema registry not supported yet"
             ),
         };
 

--- a/src/connector/src/schema/mod.rs
+++ b/src/connector/src/schema/mod.rs
@@ -17,6 +17,7 @@ use crate::error::ConnectorError;
 pub mod avro;
 mod loader;
 pub mod protobuf;
+pub mod pulsar;
 pub mod schema_registry;
 
 pub use loader::{ConfluentSchemaLoader, SchemaLoader, SchemaVersion};

--- a/src/connector/src/schema/pulsar.rs
+++ b/src/connector/src/schema/pulsar.rs
@@ -1,0 +1,267 @@
+// Copyright 2024 RisingWave Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::BTreeMap;
+
+use anyhow::Context;
+use reqwest::header::{AUTHORIZATION, HeaderMap, HeaderValue};
+use reqwest::{Client, Method, Url};
+use risingwave_common::bail;
+use serde::Deserialize;
+use serde::de::DeserializeOwned;
+
+use crate::error::ConnectorResult;
+use crate::schema::schema_registry::handle_sr_list;
+use crate::source::pulsar::topic::parse_topic;
+
+#[derive(Debug, Clone)]
+pub struct PulsarSchemaRegistryConfig {
+    pub admin_url: String,
+    pub topic: String,
+    pub auth_token: Option<String>,
+}
+
+impl PulsarSchemaRegistryConfig {
+    pub fn from_source_options(
+        admin_url: String,
+        options: &BTreeMap<String, String>,
+    ) -> ConnectorResult<Self> {
+        let topic = options
+            .get("pulsar.topic")
+            .or_else(|| options.get("topic"))
+            .context("Must specify 'pulsar.topic' or 'topic'")?
+            .clone();
+        let auth_token = options
+            .get("auth.token")
+            .or_else(|| options.get("pulsar.auth.token"))
+            .cloned();
+        Ok(Self {
+            admin_url,
+            topic,
+            auth_token,
+        })
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct PulsarSchemaClient {
+    inner: Client,
+    admin_url: Url,
+    schema_path: Vec<String>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct PulsarSchema {
+    pub version: i64,
+    #[serde(rename = "type")]
+    pub schema_type: String,
+    pub data: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PulsarSchemaType {
+    Avro,
+    Json,
+    Protobuf,
+    ProtobufNative,
+    Other(String),
+}
+
+impl std::fmt::Display for PulsarSchemaType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Avro => f.write_str("AVRO"),
+            Self::Json => f.write_str("JSON"),
+            Self::Protobuf => f.write_str("PROTOBUF"),
+            Self::ProtobufNative => f.write_str("PROTOBUF_NATIVE"),
+            Self::Other(schema_type) => f.write_str(schema_type),
+        }
+    }
+}
+
+impl PulsarSchema {
+    pub fn schema_type(&self) -> PulsarSchemaType {
+        match self.schema_type.to_ascii_uppercase().as_str() {
+            "AVRO" => PulsarSchemaType::Avro,
+            "JSON" => PulsarSchemaType::Json,
+            "PROTOBUF" => PulsarSchemaType::Protobuf,
+            "PROTOBUF_NATIVE" => PulsarSchemaType::ProtobufNative,
+            _ => PulsarSchemaType::Other(self.schema_type.clone()),
+        }
+    }
+}
+
+impl PulsarSchemaClient {
+    pub fn new(config: PulsarSchemaRegistryConfig) -> ConnectorResult<Self> {
+        let admin_url = handle_sr_list(&config.admin_url)?
+            .into_iter()
+            .next()
+            .context("pulsar schema registry URL is empty")?;
+        if admin_url.cannot_be_a_base() {
+            bail!("Pulsar admin URL must be a base URL");
+        }
+        let topic = parse_topic(&config.topic)?;
+        let mut headers = HeaderMap::new();
+        if let Some(token) = config.auth_token {
+            let token = token.strip_prefix("token:").unwrap_or(&token);
+            let value = HeaderValue::from_str(&format!("Bearer {token}"))
+                .context("invalid Pulsar auth token header")?;
+            headers.insert(AUTHORIZATION, value);
+        }
+        let inner = Client::builder()
+            .default_headers(headers)
+            .build()
+            .context("failed to build Pulsar schema client")?;
+        let topic_name = topic.topic_str_without_partition()?;
+
+        Ok(Self {
+            inner,
+            admin_url,
+            schema_path: vec![topic.tenant, topic.namespace, topic_name],
+        })
+    }
+
+    pub async fn get_latest_schema(&self) -> ConnectorResult<PulsarSchema> {
+        self.request(&["schema"]).await
+    }
+
+    pub async fn get_schema_by_version(&self, version: i64) -> ConnectorResult<PulsarSchema> {
+        let version = version.to_string();
+        self.request(&["schema", version.as_str()]).await
+    }
+
+    fn schema_url(&self, suffix: &[&str]) -> Url {
+        let mut url = self.admin_url.clone();
+        url.path_segments_mut()
+            .expect("constructor validates Pulsar admin URL can be a base")
+            .extend(["admin", "v2", "schemas"])
+            .extend(self.schema_path.iter().map(String::as_str))
+            .extend(suffix);
+        url
+    }
+
+    async fn request<T>(&self, suffix: &[&str]) -> ConnectorResult<T>
+    where
+        T: DeserializeOwned,
+    {
+        let url = self.schema_url(suffix);
+        let response = self
+            .inner
+            .request(Method::GET, url.clone())
+            .send()
+            .await
+            .with_context(|| format!("failed to fetch Pulsar schema from {url}"))?
+            .error_for_status()
+            .with_context(|| format!("Pulsar schema request failed for {url}"))?;
+        Ok(response
+            .json()
+            .await
+            .with_context(|| format!("failed to parse Pulsar schema response from {url}"))?)
+    }
+}
+
+pub fn pulsar_schema_version_to_i64(version: &[u8]) -> ConnectorResult<Option<i64>> {
+    if version.is_empty() {
+        return Ok(None);
+    }
+    let bytes: [u8; 8] = version.try_into().with_context(|| {
+        format!(
+            "expected 8-byte Pulsar LongSchemaVersion, got {} bytes",
+            version.len()
+        )
+    })?;
+    Ok(Some(i64::from_be_bytes(bytes)))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_config(topic: &str) -> PulsarSchemaRegistryConfig {
+        PulsarSchemaRegistryConfig {
+            admin_url: "http://localhost:8080".to_owned(),
+            topic: topic.to_owned(),
+            auth_token: Some("token:test-token".to_owned()),
+        }
+    }
+
+    #[test]
+    fn test_pulsar_schema_url_from_full_topic() {
+        let client = PulsarSchemaClient::new(test_config("persistent://tenant/ns/events")).unwrap();
+
+        assert_eq!(
+            client.schema_url(&["schema"]).as_str(),
+            "http://localhost:8080/admin/v2/schemas/tenant/ns/events/schema"
+        );
+        assert_eq!(
+            client.schema_url(&["schema", "42"]).as_str(),
+            "http://localhost:8080/admin/v2/schemas/tenant/ns/events/schema/42"
+        );
+    }
+
+    #[test]
+    fn test_pulsar_schema_url_from_short_topic() {
+        let client = PulsarSchemaClient::new(test_config("events")).unwrap();
+
+        assert_eq!(
+            client.schema_url(&["schema"]).as_str(),
+            "http://localhost:8080/admin/v2/schemas/public/default/events/schema"
+        );
+    }
+
+    #[test]
+    fn test_pulsar_schema_url_from_partition_topic() {
+        let client =
+            PulsarSchemaClient::new(test_config("persistent://tenant/ns/events-partition-1"))
+                .unwrap();
+
+        assert_eq!(
+            client.schema_url(&["schema"]).as_str(),
+            "http://localhost:8080/admin/v2/schemas/tenant/ns/events/schema"
+        );
+    }
+
+    #[test]
+    fn test_pulsar_schema_version_to_i64() {
+        assert_eq!(pulsar_schema_version_to_i64(&[]).unwrap(), None);
+        assert_eq!(
+            pulsar_schema_version_to_i64(&1_i64.to_be_bytes()).unwrap(),
+            Some(1)
+        );
+        assert_eq!(
+            pulsar_schema_version_to_i64(&(-1_i64).to_be_bytes()).unwrap(),
+            Some(-1)
+        );
+        assert!(pulsar_schema_version_to_i64(&[1, 2, 3]).is_err());
+    }
+
+    #[test]
+    fn test_pulsar_schema_type() {
+        let schema = |schema_type: &str| PulsarSchema {
+            version: 0,
+            schema_type: schema_type.to_owned(),
+            data: String::new(),
+        };
+
+        assert_eq!(schema("Avro").schema_type(), PulsarSchemaType::Avro);
+        assert_eq!(
+            schema("PROTOBUF_NATIVE").schema_type(),
+            PulsarSchemaType::ProtobufNative
+        );
+        assert_eq!(
+            schema("STRING").schema_type(),
+            PulsarSchemaType::Other("STRING".to_owned())
+        );
+    }
+}

--- a/src/frontend/src/handler/create_sink.rs
+++ b/src/frontend/src/handler/create_sink.rs
@@ -1056,7 +1056,7 @@ fn bind_sink_format_desc(
         E::Template => SinkEncode::Template,
         E::Parquet => SinkEncode::Parquet,
         E::Bytes => SinkEncode::Bytes,
-        e @ (E::Native | E::Csv | E::None | E::Text) => {
+        e @ (E::Auto | E::Native | E::Csv | E::None | E::Text) => {
             return Err(ErrorCode::BindError(format!("sink encode unsupported: {e}")).into());
         }
     };

--- a/src/frontend/src/handler/create_source.rs
+++ b/src/frontend/src/handler/create_source.rs
@@ -78,8 +78,9 @@ use risingwave_pb::plan_common::{EncodeType, FormatType, SourceRefreshMode};
 use risingwave_pb::stream_plan::PbStreamFragmentGraph;
 use risingwave_pb::telemetry::TelemetryDatabaseObject;
 use risingwave_sqlparser::ast::{
-    AstString, ColumnDef, ColumnOption, CreateSourceStatement, Encode, Format, FormatEncodeOptions,
-    ObjectName, SourceWatermark, SqlOptionValue, TableConstraint, Value, get_delimiter,
+    AstString, ColumnDef, ColumnOption, CompatibleFormatEncode, CreateSourceStatement, Encode,
+    Format, FormatEncodeOptions, ObjectName, SourceWatermark, SqlOptionValue, Statement,
+    TableConstraint, Value, get_delimiter,
 };
 use risingwave_sqlparser::parser::{IncludeOption, IncludeOptionItem};
 use thiserror_ext::AsReport;
@@ -111,6 +112,7 @@ use crate::utils::{
 use crate::{OptimizerContext, WithOptions, WithOptionsSecResolved, bind_data_type, build_graph};
 
 mod external_schema;
+use external_schema::resolve_pulsar_auto_encode;
 pub use external_schema::{
     bind_columns_from_source, get_schema_location, schema_has_schema_registry,
 };
@@ -1181,7 +1183,18 @@ pub async fn handle_create_source(
         )));
     }
 
-    let format_encode = stmt.format_encode.into_v2_with_warning();
+    let mut resolved_stmt = stmt.clone();
+    let mut format_encode = stmt.format_encode.into_v2_with_warning();
+    let was_auto = format_encode.row_encode == Encode::Auto;
+    resolve_pulsar_auto_encode(&session, &mut format_encode, &handler_args.with_options).await?;
+    if was_auto {
+        resolved_stmt.if_not_exists = false;
+        resolved_stmt.format_encode = CompatibleFormatEncode::V2(format_encode.clone());
+        handler_args.normalized_sql = Statement::CreateSource {
+            stmt: resolved_stmt,
+        }
+        .to_string();
+    }
     let (with_properties, refresh_mode) =
         bind_connector_props(&handler_args, &format_encode, true)?;
     if let Some(connector) = with_properties.get_connector() {

--- a/src/frontend/src/handler/create_source/external_schema.rs
+++ b/src/frontend/src/handler/create_source/external_schema.rs
@@ -14,6 +14,9 @@
 
 //! bind columns from external schema
 
+use risingwave_connector::schema::pulsar::{
+    PulsarSchemaClient, PulsarSchemaRegistryConfig, PulsarSchemaType,
+};
 use risingwave_connector::source::ADBC_SNOWFLAKE_CONNECTOR;
 
 use super::*;
@@ -63,6 +66,88 @@ feature_gated_function!(
         with_properties: &WithOptionsSecResolved,
     ) -> anyhow::Result<Vec<ColumnCatalog>>
 );
+
+fn validate_pulsar_auto_encode_schema_type(schema_type: PulsarSchemaType) -> Result<()> {
+    match schema_type {
+        PulsarSchemaType::Avro => Ok(()),
+        schema_type => Err(RwError::from(ProtocolError(format!(
+            "Pulsar schema type `{schema_type}` is not supported by `ENCODE AUTO`; currently only `AVRO` is supported"
+        )))),
+    }
+}
+
+pub(super) async fn resolve_pulsar_auto_encode(
+    session: &SessionImpl,
+    format_encode: &mut FormatEncodeOptions,
+    source_options: &WithOptions,
+) -> Result<()> {
+    if format_encode.row_encode != Encode::Auto {
+        return Ok(());
+    }
+    if format_encode.format != Format::Plain {
+        return Err(RwError::from(ProtocolError(
+            "ENCODE AUTO is only supported with FORMAT PLAIN".to_owned(),
+        )));
+    }
+    if !source_options.is_pulsar_connector() {
+        return Err(RwError::from(ProtocolError(
+            "ENCODE AUTO is only supported for Pulsar sources".to_owned(),
+        )));
+    }
+
+    let (resolved_source_options, connection_type, _) = resolve_connection_ref_and_secret_ref(
+        source_options.clone(),
+        session,
+        Some(TelemetryDatabaseObject::Source),
+    )?;
+    if !SOURCE_ALLOWED_CONNECTION_CONNECTOR.contains(&connection_type) {
+        return Err(RwError::from(ProtocolError(format!(
+            "connection type {:?} is not allowed, allowed types: {:?}",
+            connection_type, SOURCE_ALLOWED_CONNECTION_CONNECTOR
+        ))));
+    }
+    let (source_options, source_secret_refs) = resolved_source_options.into_parts();
+    let source_options =
+        LocalSecretManager::global().fill_secrets(source_options, source_secret_refs)?;
+
+    let (resolved_format_options, connection_type, _) = resolve_connection_ref_and_secret_ref(
+        WithOptions::try_from(format_encode.row_options())?,
+        session,
+        Some(TelemetryDatabaseObject::Source),
+    )?;
+    ensure_connection_type_allowed(connection_type, &SOURCE_ALLOWED_CONNECTION_SCHEMA_REGISTRY)?;
+    let (format_options, format_secret_refs) = resolved_format_options.into_parts();
+    let format_options =
+        LocalSecretManager::global().fill_secrets(format_options, format_secret_refs)?;
+
+    let registry_url = format_options.get("schema.registry").ok_or_else(|| {
+        RwError::from(ProtocolError(
+            "missing `schema.registry` for Pulsar ENCODE AUTO".to_owned(),
+        ))
+    })?;
+    let config =
+        PulsarSchemaRegistryConfig::from_source_options(registry_url.clone(), &source_options)?;
+    let schema = PulsarSchemaClient::new(config)?.get_latest_schema().await?;
+    validate_pulsar_auto_encode_schema_type(schema.schema_type())?;
+
+    format_encode.row_encode = Encode::Avro;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_validate_pulsar_auto_encode_schema_type() {
+        validate_pulsar_auto_encode_schema_type(PulsarSchemaType::Avro).unwrap();
+
+        let error = validate_pulsar_auto_encode_schema_type(PulsarSchemaType::ProtobufNative)
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("currently only `AVRO` is supported"));
+    }
+}
 
 /// Resolves the schema of the source from external schema file.
 /// See <https://docs.risingwave.com/sql/commands/sql-create-source> for more information.
@@ -433,6 +518,7 @@ fn format_to_prost(format: &Format) -> FormatType {
 }
 fn row_encode_to_prost(row_encode: &Encode) -> EncodeType {
     match row_encode {
+        Encode::Auto => unreachable!("ENCODE AUTO must be resolved before source binding"),
         Encode::Native => EncodeType::Native,
         Encode::Json => EncodeType::Json,
         Encode::Avro => EncodeType::Avro,

--- a/src/frontend/src/handler/create_source/validate.rs
+++ b/src/frontend/src/handler/create_source/validate.rs
@@ -157,7 +157,7 @@ pub fn validate_compatibility(
         })?;
 
     validate_license(&connector)?;
-    if connector != KAFKA_CONNECTOR {
+    if connector != KAFKA_CONNECTOR && connector != PULSAR_CONNECTOR {
         let res = match (&format_encode.format, &format_encode.row_encode) {
             (Format::Plain, Encode::Protobuf) | (Format::Plain, Encode::Avro) => {
                 let mut options = WithOptions::try_from(format_encode.row_options())?;
@@ -169,7 +169,7 @@ pub fn validate_compatibility(
         };
         if res {
             return Err(RwError::from(ProtocolError(format!(
-                "The {} must be kafka when schema registry is used",
+                "The {} must be kafka or pulsar when schema registry is used",
                 UPSTREAM_SOURCE_KEY
             ))));
         }

--- a/src/sqlparser/src/ast/statement.rs
+++ b/src/sqlparser/src/ast/statement.rs
@@ -155,6 +155,9 @@ impl Format {
 /// Check `CONNECTORS_COMPATIBLE_FORMATS` for what `FORMAT ... ENCODE ...` combinations are allowed.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum Encode {
+    /// Resolve the encoding from external metadata before binding.
+    /// This is transient AST state and must not be stored in the catalog.
+    Auto,
     Avro,     // Keyword::Avro
     Csv,      // Keyword::CSV
     Protobuf, // Keyword::PROTOBUF
@@ -177,6 +180,7 @@ impl fmt::Display for Encode {
             f,
             "{}",
             match self {
+                Encode::Auto => "AUTO",
                 Encode::Avro => "AVRO",
                 Encode::Csv => "CSV",
                 Encode::Protobuf => "PROTOBUF",
@@ -195,6 +199,7 @@ impl fmt::Display for Encode {
 impl Encode {
     pub fn from_keyword(s: &str) -> ModalResult<Self> {
         Ok(match s {
+            "AUTO" => Encode::Auto,
             "AVRO" => Encode::Avro,
             "TEXT" => Encode::Text,
             "BYTES" => Encode::Bytes,
@@ -206,7 +211,7 @@ impl Encode {
             "NATIVE" => Encode::Native,
             "NONE" => Encode::None,
             _ => parser_err!(
-                "expected AVRO | BYTES | CSV | PROTOBUF | JSON | NATIVE | TEMPLATE | PARQUET | NONE after Encode"
+                "expected AUTO | AVRO | BYTES | CSV | PROTOBUF | JSON | NATIVE | TEMPLATE | PARQUET | NONE after Encode"
             ),
         })
     }
@@ -235,6 +240,7 @@ impl Parser<'_> {
         &mut self,
         connector: &str,
         cdc_source_job: bool,
+        allow_auto: bool,
     ) -> ModalResult<CompatibleFormatEncode> {
         // row format for cdc source must be debezium json
         // row format for nexmark source must be native
@@ -273,7 +279,14 @@ impl Parser<'_> {
             Ok(expected.into())
         } else if connector.contains("datagen") {
             Ok(if self.peek_format_encode_format() {
-                parse_format_encode(self)?
+                let format_encode = parse_format_encode(self)?;
+                if matches!(
+                    &format_encode,
+                    CompatibleFormatEncode::V2(options) if options.row_encode == Encode::Auto
+                ) {
+                    parser_err!("ENCODE AUTO is only supported for Pulsar sources");
+                }
+                format_encode
             } else {
                 FormatEncodeOptions::native().into()
             })
@@ -295,7 +308,25 @@ impl Parser<'_> {
                  Please use the `CREATE TABLE ... WITH ...` statement instead.",
             );
         } else {
-            Ok(parse_format_encode(self)?)
+            let format_encode = parse_format_encode(self)?;
+            if matches!(
+                &format_encode,
+                CompatibleFormatEncode::V2(options) if options.row_encode == Encode::Auto
+            ) {
+                if !allow_auto {
+                    parser_err!("ENCODE AUTO is only supported for CREATE SOURCE");
+                }
+                if !connector.contains("pulsar") {
+                    parser_err!("ENCODE AUTO is only supported for Pulsar sources");
+                }
+                if !matches!(
+                    &format_encode,
+                    CompatibleFormatEncode::V2(options) if options.format == Format::Plain
+                ) {
+                    parser_err!("ENCODE AUTO is only supported with FORMAT PLAIN");
+                }
+            }
+            Ok(format_encode)
         }
     }
 
@@ -569,6 +600,12 @@ impl CreateSinkStatement {
         }
 
         let sink_schema = p.parse_schema()?;
+        if sink_schema
+            .as_ref()
+            .is_some_and(|format_encode| format_encode.row_encode == Encode::Auto)
+        {
+            parser_err!("ENCODE AUTO is only supported for CREATE SOURCE");
+        }
 
         Ok(Self {
             or_replace,

--- a/src/sqlparser/src/parser.rs
+++ b/src/sqlparser/src/parser.rs
@@ -2149,7 +2149,8 @@ impl Parser<'_> {
 
         // row format for nexmark source must be native
         // default row format for datagen source is native
-        let format_encode = self.parse_format_encode_with_connector(&connector, cdc_source_job)?;
+        let format_encode =
+            self.parse_format_encode_with_connector(&connector, cdc_source_job, true)?;
 
         let stmt = CreateSourceStatement {
             temporary,
@@ -2588,7 +2589,7 @@ impl Parser<'_> {
         let format_encode = if let Some(connector) = connector
             && !contain_webhook
         {
-            Some(self.parse_format_encode_with_connector(&connector, false)?)
+            Some(self.parse_format_encode_with_connector(&connector, false, false)?)
         } else {
             None // Table is NOT created with an external connector.
         };
@@ -3931,6 +3932,9 @@ impl Parser<'_> {
             }
         } else if self.peek_nth_any_of_keywords(0, &[Keyword::FORMAT]) {
             let format_encode = self.parse_schema()?.unwrap();
+            if format_encode.row_encode == Encode::Auto {
+                parser_err!("ENCODE AUTO is only supported for CREATE SOURCE");
+            }
             if format_encode.key_encode.is_some() {
                 parser_err!("key encode clause is not supported in source schema");
             }
@@ -6415,7 +6419,62 @@ impl Word {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::ast::{CompatibleFormatEncode, Encode, Format, Statement};
     use crate::test_utils::run_parser_method;
+
+    #[test]
+    fn test_pulsar_source_encode_auto() {
+        let statements = Parser::parse_sql(
+            "CREATE SOURCE s WITH (connector = 'pulsar', topic = 'persistent://public/default/t') FORMAT PLAIN ENCODE AUTO (schema.registry = 'http://localhost:8080')",
+        )
+        .unwrap();
+        let Statement::CreateSource { stmt } = &statements[0] else {
+            panic!("expected CREATE SOURCE");
+        };
+        let CompatibleFormatEncode::V2(format_encode) = &stmt.format_encode else {
+            panic!("expected v2 source format");
+        };
+        assert_eq!(format_encode.format, Format::Plain);
+        assert_eq!(format_encode.row_encode, Encode::Auto);
+        assert_eq!(format_encode.row_options.len(), 1);
+        assert_eq!(
+            format_encode.row_options[0].name.real_value(),
+            "schema.registry"
+        );
+        assert_eq!(
+            format_encode.row_options[0].value.to_string(),
+            "'http://localhost:8080'"
+        );
+        assert!(
+            statements[0]
+                .to_string()
+                .contains("FORMAT PLAIN ENCODE AUTO")
+        );
+        assert!(
+            Parser::parse_sql(
+                "CREATE SOURCE s WITH (connector = 'pulsar', topic = 'persistent://public/default/t')"
+            )
+            .is_err()
+        );
+        assert!(
+            Parser::parse_sql(
+                "CREATE SOURCE s WITH (connector = 'kafka') FORMAT PLAIN ENCODE AUTO (schema.registry = 'http://localhost:8080')"
+            )
+            .is_err()
+        );
+        assert!(
+            Parser::parse_sql(
+                "CREATE TABLE t WITH (connector = 'pulsar') FORMAT PLAIN ENCODE AUTO (schema.registry = 'http://localhost:8080')"
+            )
+            .is_err()
+        );
+        assert!(
+            Parser::parse_sql(
+                "CREATE SOURCE s WITH (connector = 'pulsar') FORMAT UPSERT ENCODE AUTO (schema.registry = 'http://localhost:8080')"
+            )
+            .is_err()
+        );
+    }
 
     #[test]
     fn test_parse_integer_min() {


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## Motivation

Pulsar Schema Registry already reports the schema type for a topic, but RisingWave currently requires users to repeat that type in source DDL. This adds `FORMAT PLAIN ENCODE AUTO` for Pulsar sources so RisingWave can inspect the registry before binding the source. The initial implementation supports AVRO and rejects other reported schema types explicitly.

## Modifications

- Add transient `Encode::Auto` syntax for Pulsar `CREATE SOURCE` statements using `FORMAT PLAIN`.
- Fetch Pulsar SchemaInfo during source creation, validate that the type is AVRO, and store the normalized source definition as concrete `ENCODE AVRO`.
- Infer the Pulsar registry backend from `connector = 'pulsar'`; no additional registry-type option is introduced.
- Add Pulsar Avro writer-schema lookup and caching using the schema version attached to each Pulsar message.

Example:

```sql
FORMAT PLAIN ENCODE AUTO (
  schema.registry = 'http://localhost:8080'
)
```

## Testing

- `cargo +nightly-2026-06-11 check -p risingwave_frontend`
- `cargo +nightly-2026-06-11 test -p risingwave_sqlparser test_pulsar_source_encode_auto`
- `cargo +nightly-2026-06-11 test -p risingwave_connector pulsar_schema`
- `cargo +nightly-2026-06-11 test -p risingwave_frontend test_validate_pulsar_auto_encode_schema_type`

A live Pulsar Schema Registry end-to-end test was not run locally.

## Checklist

- [x] I have written necessary rustdoc comments.
- [x] I have added necessary unit tests.
- [x] I have added test labels as necessary.
- [ ] My PR contains breaking changes.
- [ ] My PR changes performance-critical code.

## Documentation

- [x] My PR needs documentation updates.

<details>
<summary><b>Release note</b></summary>

Pulsar sources can use `FORMAT PLAIN ENCODE AUTO` with `schema.registry` to infer AVRO encoding from Pulsar Schema Registry. Other Pulsar schema types are rejected until their decoders are supported.

</details>
