### PR TITLE
fix(frontend): decouple Iceberg Engine schema change from compaction

### DIFF
--- a/src/frontend/src/handler/alter_table_column.rs
+++ b/src/frontend/src/handler/alter_table_column.rs
@@ -18,6 +18,7 @@ use itertools::Itertools;
 use pgwire::pg_response::{PgResponse, StatementType};
 use risingwave_common::catalog::ColumnCatalog;
 use risingwave_common::hash::VnodeCount;
+use risingwave_common::license::Feature;
 use risingwave_common::{bail, bail_not_implemented};
 use risingwave_pb::ddl_service::TableJobType;
 use risingwave_pb::stream_plan::StreamFragmentGraph;
@@ -122,6 +123,12 @@ pub async fn handle_alter_table_column(
     let session = handler_args.session;
     let (original_catalog, has_incoming_sinks) =
         fetch_table_catalog_for_alter(session.as_ref(), &table_name)?;
+
+    if original_catalog.is_iceberg_engine_table()
+        && matches!(&operation, AlterTableOperation::AddColumn { .. })
+    {
+        Feature::SinkAutoSchemaChange.check_available()?;
+    }
 
     if original_catalog.webhook_info.is_some() {
         return Err(RwError::from(ErrorCode::BindError(

--- a/src/frontend/src/handler/create_sink.rs
+++ b/src/frontend/src/handler/create_sink.rs
@@ -183,7 +183,7 @@ pub async fn gen_sink_plan(
         .transpose()?
         .unwrap_or(false);
 
-    if is_auto_schema_change {
+    if is_auto_schema_change && !is_iceberg_engine_internal {
         Feature::SinkAutoSchemaChange.check_available()?;
     }
 

--- a/src/frontend/src/handler/create_table.rs
+++ b/src/frontend/src/handler/create_table.rs
@@ -1857,14 +1857,7 @@ pub async fn create_iceberg_engine_table(
 
     let mut sink_with = with_common.clone();
 
-    // TODO: Iceberg with pk index doesn't support auto schema change
-    if !handler_args
-        .with_options
-        .get(ENABLE_COMPACTION)
-        .is_some_and(|val| val.eq_ignore_ascii_case("true"))
-    {
-        sink_with.insert(AUTO_SCHEMA_CHANGE_KEY.to_owned(), "true".to_owned());
-    }
+    sink_with.insert(AUTO_SCHEMA_CHANGE_KEY.to_owned(), "true".to_owned());
 
     if table.append_only {
         sink_with.insert("type".to_owned(), "append-only".to_owned());


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

The release-3.0 Iceberg Engine path accidentally used `enable_compaction` to decide whether the hidden sink should enable auto schema refresh. Consequently, a user without the `SinkAutoSchemaChange` license could only create the table by explicitly enabling compaction.

This PR:

- enables the existing auto-schema path for the hidden sink independently from `enable_compaction`;
- exempts the hidden sink from the creation-time license check;
- checks the current license when an Iceberg Engine table executes `ALTER TABLE ADD COLUMN`;
- leaves the creation-time license check unchanged for user-created sinks that explicitly enable `auto.schema.change`.

This is the minimal release-3.0 adaptation of #26536. `DROP COLUMN` remains unsupported on this branch.

## Behavior

- With or without the license, an Iceberg Engine table can be created with either `enable_compaction=true` or `false`; the configured value is preserved.
- With the license, `ALTER TABLE ADD COLUMN` can propagate the schema change to Iceberg.
- Without the license, `ALTER TABLE ADD COLUMN` returns a license error.
- `ALTER TABLE DROP COLUMN` remains unsupported by release-3.0 independently of the license.
- A user-created sink with `auto.schema.change=true` still requires the license when the sink is created.
- The ALTER check uses the current license state, so adding or removing a license takes effect without recreating the table.

Related customer report: CF-4261.

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [x] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results.
- [x] <!-- OPTIONAL --> This PR directly targets `release-3.0`.

## Documentation

- [x] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

Iceberg Engine tables can now be created with `enable_compaction=false` when the cluster does not have the `SinkAutoSchemaChange` feature. Without that feature, the table remains usable but `ALTER TABLE ADD COLUMN` is rejected. User-created sinks that enable `auto.schema.change` still require the feature when the sink is created.

</details>
