### PR TITLE
feat(connector): support WebSocket source connector

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12108,6 +12108,7 @@ dependencies = [
  "tokio-postgres",
  "tokio-retry",
  "tokio-stream 0.1.15",
+ "tokio-tungstenite",
  "tokio-util",
  "tracing",
  "tracing-subscriber",
@@ -15814,7 +15815,11 @@ checksum = "d25a406cddcc431a75d3d9afc6a7c0f7428d4891dd973e4d54c56b46127bf857"
 dependencies = [
  "futures-util",
  "log",
+ "rustls 0.23.35",
+ "rustls-native-certs 0.8.1",
+ "rustls-pki-types",
  "tokio",
+ "tokio-rustls 0.26.4",
  "tungstenite",
 ]
 
@@ -16278,6 +16283,8 @@ dependencies = [
  "httparse",
  "log",
  "rand 0.9.2",
+ "rustls 0.23.35",
+ "rustls-pki-types",
  "sha1",
  "thiserror 2.0.17",
  "utf-8",

--- a/ci/scripts/e2e-source-test.sh
+++ b/ci/scripts/e2e-source-test.sh
@@ -42,6 +42,7 @@ risedev slt './e2e_test/source_inline/fs/parquet_duplicate_field_names.slt'
 risedev slt './e2e_test/source_inline/fs/parquet_nested_smallint.slt'
 risedev slt './e2e_test/source_inline/refresh/refresh_table.slt'
 risedev slt './e2e_test/source_inline/vault/vault_secret_ddl.slt'
+risedev slt './e2e_test/source_inline/websocket/websocket_source.slt.serial'
 
 echo "--- Run webhook source tests"
 sleep 5

--- a/e2e_test/source_inline/requirements.txt
+++ b/e2e_test/source_inline/requirements.txt
@@ -2,3 +2,4 @@ nats-py==2.9.0
 psycopg[binary]
 psycopg2-binary==2.9.10
 paho-mqtt==2.1.0
+websockets==16.1.1

--- a/e2e_test/source_inline/websocket/websocket_source.slt.serial
+++ b/e2e_test/source_inline/websocket/websocket_source.slt.serial
@@ -1,0 +1,113 @@
+# Test the `websocket` source connector against a local WebSocket server fixture.
+# The fixture is spawned as a background process and binds fixed local ports,
+# hence the `.slt.serial` suffix.
+
+control substitution on
+
+# Test 1: basic ingestion with an init (subscribe) message.
+
+system ok
+python3 e2e_test/source_inline/websocket/ws_server.py start --port 18765 --count 100 --require-init 'SUBSCRIBE'
+
+statement ok
+create table t_websocket (
+  id int,
+  value varchar
+) with (
+  connector = 'websocket',
+  url = 'ws://127.0.0.1:18765',
+  init.message = 'SUBSCRIBE'
+) format plain encode json;
+
+# The server sends exactly 100 messages per connection and then keeps the
+# connection open, so at least 100 rows are expected. WebSocket is at-least-once:
+# a reader reconnect would redeliver the full batch, so use `>=` rather than `=`.
+query T retry 10 backoff 1s
+select count(*) >= 100 from t_websocket;
+----
+t
+
+query T
+select count(distinct id) = 100 from t_websocket;
+----
+t
+
+query T
+select count(*) > 0 from t_websocket where id = 0 and value = 'message_0';
+----
+t
+
+query T
+select count(*) > 0 from t_websocket where id = 99 and value = 'message_99';
+----
+t
+
+statement ok
+drop table t_websocket;
+
+# Test 2: invalid properties are rejected at creation time.
+
+statement error must be prefixed with `ws://` or `wss://`
+create table t_websocket_bad_scheme (
+  id int
+) with (
+  connector = 'websocket',
+  url = 'http://127.0.0.1:18765'
+) format plain encode json;
+
+statement error failed to connect to WebSocket server
+create table t_websocket_unreachable (
+  id int
+) with (
+  connector = 'websocket',
+  url = 'ws://127.0.0.1:18999'
+) format plain encode json;
+
+# Test 3: custom handshake headers (bearer auth) and INCLUDE offset.
+
+system ok
+python3 e2e_test/source_inline/websocket/ws_server.py start --port 18766 --count 50 --auth-token 'test-token'
+
+# Without the required header the handshake is rejected.
+statement error failed to connect to WebSocket server
+create table t_websocket_no_auth (
+  id int,
+  value varchar
+) with (
+  connector = 'websocket',
+  url = 'ws://127.0.0.1:18766'
+) format plain encode json;
+
+statement ok
+create table t_websocket_auth (
+  id int,
+  value varchar
+)
+include offset as msg_offset
+with (
+  connector = 'websocket',
+  url = 'ws://127.0.0.1:18766',
+  headers = '{"Authorization": "Bearer test-token"}'
+) format plain encode json;
+
+query T retry 10 backoff 1s
+select count(*) >= 50 from t_websocket_auth;
+----
+t
+
+# The offset column is a per-reader message counter, monotonic across reconnections.
+query T
+select count(distinct msg_offset) >= 50 from t_websocket_auth;
+----
+t
+
+statement ok
+drop table t_websocket_auth;
+
+# Cleanup.
+
+system ok
+python3 e2e_test/source_inline/websocket/ws_server.py stop --port 18765
+
+system ok
+python3 e2e_test/source_inline/websocket/ws_server.py stop --port 18766

--- a/e2e_test/source_inline/websocket/ws_server.py
+++ b/e2e_test/source_inline/websocket/ws_server.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python3
+"""Ad-hoc WebSocket server fixture for the `websocket` source e2e test.
+
+Per accepted connection the server optionally validates an `Authorization` header
+and an init (subscribe) message, then sends `--count` JSON text messages of the
+form `{"id": <i>, "value": "message_<i>"}` and keeps the connection open, replying
+to client pings automatically.
+
+Modes:
+  serve  Run the server in the foreground.
+  start  Spawn `serve` in the background, wait until the port accepts
+         connections, write a pid file, and return.
+  stop   Terminate the background server via its pid file.
+"""
+
+import argparse
+import asyncio
+import http
+import json
+import os
+import signal
+import socket
+import subprocess
+import sys
+import time
+
+PID_FILE_TEMPLATE = "/tmp/rw_e2e_ws_server_{port}.pid"
+LOG_FILE_TEMPLATE = "/tmp/rw_e2e_ws_server_{port}.log"
+
+
+def pid_file(port: int) -> str:
+    return PID_FILE_TEMPLATE.format(port=port)
+
+
+async def run_server(args) -> None:
+    from websockets.asyncio.server import serve
+
+    def process_request(connection, request):
+        """Reject the handshake when the expected Authorization header is missing."""
+        if args.auth_token:
+            expected = f"Bearer {args.auth_token}"
+            if request.headers.get("Authorization") != expected:
+                return connection.respond(
+                    http.HTTPStatus.UNAUTHORIZED, "unauthorized\n"
+                )
+        return None
+
+    async def handler(connection):
+        if args.require_init:
+            init = await connection.recv()
+            if init != args.require_init:
+                await connection.close(code=1008, reason="unexpected init message")
+                return
+        for i in range(args.count):
+            await connection.send(json.dumps({"id": i, "value": f"message_{i}"}))
+        # Keep the connection open so that the reader does not reconnect (which
+        # would deliver duplicate messages). Client pings are answered by the
+        # library; incoming frames are drained and ignored.
+        async for _ in connection:
+            pass
+
+    async with serve(handler, "127.0.0.1", args.port, process_request=process_request):
+        await asyncio.get_running_loop().create_future()  # run forever
+
+
+def wait_for_port(port: int, timeout_secs: float = 10.0) -> bool:
+    deadline = time.monotonic() + timeout_secs
+    while time.monotonic() < deadline:
+        try:
+            with socket.create_connection(("127.0.0.1", port), timeout=1):
+                return True
+        except OSError:
+            time.sleep(0.1)
+    return False
+
+
+def start(args) -> None:
+    stop(args, quiet=True)  # make retries idempotent
+
+    log_path = LOG_FILE_TEMPLATE.format(port=args.port)
+    cmd = [
+        sys.executable,
+        os.path.abspath(__file__),
+        "serve",
+        "--port",
+        str(args.port),
+        "--count",
+        str(args.count),
+    ]
+    if args.require_init:
+        cmd += ["--require-init", args.require_init]
+    if args.auth_token:
+        cmd += ["--auth-token", args.auth_token]
+
+    with open(log_path, "ab") as log:
+        process = subprocess.Popen(
+            cmd, stdout=log, stderr=log, stdin=subprocess.DEVNULL
+        )
+
+    if not wait_for_port(args.port):
+        process.terminate()
+        print(
+            f"server failed to listen on port {args.port}, see {log_path}",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    with open(pid_file(args.port), "w") as f:
+        f.write(str(process.pid))
+    print(f"started ws server on port {args.port} (pid {process.pid})")
+
+
+def stop(args, quiet: bool = False) -> None:
+    path = pid_file(args.port)
+    if not os.path.exists(path):
+        if not quiet:
+            print(f"no pid file for port {args.port}, nothing to stop")
+        return
+    with open(path) as f:
+        pid = int(f.read().strip())
+    try:
+        os.kill(pid, signal.SIGTERM)
+    except ProcessLookupError:
+        pass
+    os.remove(path)
+    if not quiet:
+        print(f"stopped ws server on port {args.port} (pid {pid})")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("mode", choices=["serve", "start", "stop"])
+    parser.add_argument("--port", type=int, required=True)
+    parser.add_argument(
+        "--count", type=int, default=100, help="messages sent per connection"
+    )
+    parser.add_argument(
+        "--require-init",
+        default=None,
+        help="require this exact init message before sending data",
+    )
+    parser.add_argument(
+        "--auth-token",
+        default=None,
+        help="require header `Authorization: Bearer <token>` during the handshake",
+    )
+    args = parser.parse_args()
+
+    if args.mode == "serve":
+        asyncio.run(run_server(args))
+    elif args.mode == "start":
+        start(args)
+    else:
+        stop(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/connector/Cargo.toml
+++ b/src/connector/Cargo.toml
@@ -196,6 +196,7 @@ tokio = { workspace = true, features = ["fs"] }
 tokio-postgres = { version = "0.7", features = ["with-uuid-1"] }
 tokio-retry = "0.3"
 tokio-stream = { workspace = true }
+tokio-tungstenite = { version = "0.28", features = ["rustls-tls-native-roots"] }
 tokio-util = { workspace = true, features = ["codec", "io"] }
 tonic = { workspace = true }
 tracing = "0.1"

--- a/src/connector/src/error.rs
+++ b/src/connector/src/error.rs
@@ -81,6 +81,7 @@ def_anyhow_newtype! {
     rumqttc::v5::OptionError => "MQTT Option error",
     rumqttc::v5::ConnectionError => "MQTT Connection error",
     MqttError => "MQTT Source error",
+    tokio_tungstenite::tungstenite::Error => "WebSocket error",
     mongodb::error::Error => "Mongodb error",
 
     openssl::error::ErrorStack => "OpenSSL error",

--- a/src/connector/src/macros.rs
+++ b/src/connector/src/macros.rs
@@ -34,6 +34,7 @@ macro_rules! for_all_classified_sources {
                 { Datagen, $crate::source::datagen::DatagenProperties, $crate::source::datagen::DatagenSplit },
                 { GooglePubsub, $crate::source::google_pubsub::PubsubProperties, $crate::source::google_pubsub::PubsubSplit },
                 { Mqtt, $crate::source::mqtt::MqttProperties, $crate::source::mqtt::split::MqttSplit },
+                { Websocket, $crate::source::websocket::WebsocketProperties, $crate::source::websocket::split::WebsocketSplit },
                 { Nats, $crate::source::nats::NatsProperties, $crate::source::nats::split::NatsSplit },
                 { S3, $crate::source::filesystem::LegacyS3Properties, $crate::source::filesystem::LegacyFsSplit },
                 { Gcs, $crate::source::filesystem::opendal_source::GcsProperties , $crate::source::filesystem::OpendalFsSplit<$crate::source::filesystem::opendal_source::OpendalGcs> },

--- a/src/connector/src/parser/additional_columns.rs
+++ b/src/connector/src/parser/additional_columns.rs
@@ -32,6 +32,7 @@ use crate::source::cdc::MONGODB_CDC_CONNECTOR;
 use crate::source::{
     AZBLOB_CONNECTOR, GCS_CONNECTOR, KAFKA_CONNECTOR, KINESIS_CONNECTOR, MQTT_CONNECTOR,
     NATS_CONNECTOR, OPENDAL_S3_CONNECTOR, POSIX_FS_CONNECTOR, PULSAR_CONNECTOR,
+    WEBSOCKET_CONNECTOR,
 };
 
 // Hidden additional columns connectors which do not support `include` syntax.
@@ -96,6 +97,7 @@ pub static COMPATIBLE_ADDITIONAL_COLUMNS: LazyLock<HashMap<&'static str, HashSet
                 ]),
             ),
             (MQTT_CONNECTOR, HashSet::from(["offset", "partition"])),
+            (WEBSOCKET_CONNECTOR, HashSet::from(["offset", "partition"])),
         ])
     });
 

--- a/src/connector/src/source/mod.rs
+++ b/src/connector/src/source/mod.rs
@@ -26,6 +26,7 @@ pub mod prelude {
     pub use crate::source::nexmark::NexmarkSplitEnumerator;
     pub use crate::source::pulsar::PulsarSplitEnumerator;
     pub use crate::source::test_source::TestSourceSplitEnumerator as TestSplitEnumerator;
+    pub use crate::source::websocket::WebsocketSplitEnumerator;
     pub type AzblobSplitEnumerator =
         OpendalEnumerator<crate::source::filesystem::opendal_source::OpendalAzblob>;
     pub type GcsSplitEnumerator =
@@ -58,6 +59,7 @@ pub mod nats;
 pub mod nexmark;
 pub mod pulsar;
 pub mod utils;
+pub mod websocket;
 
 mod util;
 use std::future::IntoFuture;
@@ -74,6 +76,7 @@ use monitor::{ConnectorAckFailureType, GLOBAL_SOURCE_METRICS};
 pub use mqtt::MQTT_CONNECTOR;
 pub use nats::NATS_CONNECTOR;
 use utils::feature_gated_source_mod;
+pub use websocket::WEBSOCKET_CONNECTOR;
 
 pub use self::adbc_snowflake::ADBC_SNOWFLAKE_CONNECTOR;
 mod common;

--- a/src/connector/src/source/websocket/enumerator/mod.rs
+++ b/src/connector/src/source/websocket/enumerator/mod.rs
@@ -83,11 +83,15 @@ impl SplitEnumerator for WebsocketSplitEnumerator {
 
 #[cfg(test)]
 mod tests {
+    #[cfg(not(madsim))]
     use futures::StreamExt;
+    #[cfg(not(madsim))]
     use tokio::net::TcpListener;
 
     use super::*;
-    use crate::source::{SourceEnumeratorContext, SplitMetaData};
+    #[cfg(not(madsim))]
+    use crate::source::SplitMetaData;
+    use crate::source::SourceEnumeratorContext;
 
     fn test_properties(url: String) -> WebsocketProperties {
         WebsocketProperties {
@@ -100,6 +104,10 @@ mod tests {
         }
     }
 
+    // These tests dial a local TCP server via `tokio_tungstenite`, which drives the
+    // connection with the real `tokio` runtime. They are therefore incompatible with the
+    // madsim simulation runtime, where no real reactor is running.
+    #[cfg(not(madsim))]
     #[tokio::test]
     async fn test_list_splits_checks_connectivity_once() {
         let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
@@ -130,6 +138,7 @@ mod tests {
         assert_eq!(splits.len(), 1);
     }
 
+    #[cfg(not(madsim))]
     #[tokio::test]
     async fn test_list_splits_unreachable_server() {
         // Bind and drop a listener to obtain an address that refuses connections.

--- a/src/connector/src/source/websocket/enumerator/mod.rs
+++ b/src/connector/src/source/websocket/enumerator/mod.rs
@@ -1,0 +1,159 @@
+// Copyright 2026 RisingWave Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::time::Duration;
+
+use anyhow::Context;
+use async_trait::async_trait;
+
+use super::WebsocketProperties;
+use super::split::WebsocketSplit;
+use crate::error::ConnectorResult;
+use crate::source::{SourceEnumeratorContextRef, SplitEnumerator};
+
+const CONNECT_CHECK_TIMEOUT: Duration = Duration::from_secs(10);
+
+pub struct WebsocketSplitEnumerator {
+    properties: WebsocketProperties,
+    /// Whether the connectivity to the server has been verified. The check is only
+    /// performed once per enumerator (i.e. essentially on source creation), since
+    /// `list_splits` is called periodically and dialing a rate-limited endpoint on
+    /// every tick could get the client throttled or banned.
+    connectivity_checked: bool,
+}
+
+#[async_trait]
+impl SplitEnumerator for WebsocketSplitEnumerator {
+    type Properties = WebsocketProperties;
+    type Split = WebsocketSplit;
+
+    async fn new(
+        properties: Self::Properties,
+        _context: SourceEnumeratorContextRef,
+    ) -> ConnectorResult<WebsocketSplitEnumerator> {
+        // Validate the url and headers eagerly to fail fast on malformed properties.
+        properties.build_client_request()?;
+        Ok(Self {
+            properties,
+            connectivity_checked: false,
+        })
+    }
+
+    async fn list_splits(&mut self) -> ConnectorResult<Vec<WebsocketSplit>> {
+        if !self.connectivity_checked {
+            let request = self.properties.build_client_request()?;
+            let (mut stream, _resp) = tokio::time::timeout(
+                CONNECT_CHECK_TIMEOUT,
+                tokio_tungstenite::connect_async(request),
+            )
+            .await
+            .with_context(|| {
+                format!(
+                    "timeout connecting to WebSocket server {} after {} seconds",
+                    self.properties.url,
+                    CONNECT_CHECK_TIMEOUT.as_secs()
+                )
+            })?
+            .with_context(|| {
+                format!(
+                    "failed to connect to WebSocket server {}",
+                    self.properties.url
+                )
+            })?;
+            // Close the probe connection gracefully; ignore errors since the
+            // connectivity has already been verified.
+            let _ = stream.close(None).await;
+            self.connectivity_checked = true;
+        }
+
+        Ok(vec![WebsocketSplit::new()])
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use futures::StreamExt;
+    use tokio::net::TcpListener;
+
+    use super::*;
+    use crate::source::{SourceEnumeratorContext, SplitMetaData};
+
+    fn test_properties(url: String) -> WebsocketProperties {
+        WebsocketProperties {
+            url,
+            init_message: None,
+            headers: None,
+            ping_interval_secs: 30,
+            idle_timeout_secs: None,
+            unknown_fields: Default::default(),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_list_splits_checks_connectivity_once() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            // Serve exactly one connection: subsequent `list_splits` calls must not
+            // dial again.
+            let (stream, _) = listener.accept().await.unwrap();
+            let mut ws = tokio_tungstenite::accept_async(stream).await.unwrap();
+            while ws.next().await.is_some() {}
+            drop(listener);
+        });
+
+        let mut enumerator = WebsocketSplitEnumerator::new(
+            test_properties(format!("ws://{}", addr)),
+            SourceEnumeratorContext::dummy().into(),
+        )
+        .await
+        .unwrap();
+
+        let splits = enumerator.list_splits().await.unwrap();
+        assert_eq!(splits.len(), 1);
+        assert_eq!(splits[0].id().as_ref(), "websocket");
+
+        // The probe connection has been closed and the listener no longer accepts
+        // connections, so this only passes if no new dial happens.
+        let splits = enumerator.list_splits().await.unwrap();
+        assert_eq!(splits.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_list_splits_unreachable_server() {
+        // Bind and drop a listener to obtain an address that refuses connections.
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        drop(listener);
+
+        let mut enumerator = WebsocketSplitEnumerator::new(
+            test_properties(format!("ws://{}", addr)),
+            SourceEnumeratorContext::dummy().into(),
+        )
+        .await
+        .unwrap();
+
+        enumerator.list_splits().await.unwrap_err();
+    }
+
+    #[tokio::test]
+    async fn test_new_rejects_malformed_properties() {
+        let res = WebsocketSplitEnumerator::new(
+            test_properties("http://example.com".to_owned()),
+            SourceEnumeratorContext::dummy().into(),
+        )
+        .await;
+        assert!(res.is_err());
+    }
+}

--- a/src/connector/src/source/websocket/enumerator/mod.rs
+++ b/src/connector/src/source/websocket/enumerator/mod.rs
@@ -89,9 +89,9 @@ mod tests {
     use tokio::net::TcpListener;
 
     use super::*;
+    use crate::source::SourceEnumeratorContext;
     #[cfg(not(madsim))]
     use crate::source::SplitMetaData;
-    use crate::source::SourceEnumeratorContext;
 
     fn test_properties(url: String) -> WebsocketProperties {
         WebsocketProperties {

--- a/src/connector/src/source/websocket/mod.rs
+++ b/src/connector/src/source/websocket/mod.rs
@@ -1,0 +1,197 @@
+// Copyright 2026 RisingWave Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+pub mod enumerator;
+pub mod source;
+pub use enumerator::WebsocketSplitEnumerator;
+pub mod split;
+
+use std::collections::HashMap;
+
+use anyhow::Context;
+use phf::{Set, phf_set};
+use serde::Deserialize;
+use serde_with::{DisplayFromStr, serde_as};
+use tokio_tungstenite::tungstenite::client::ClientRequestBuilder;
+use tokio_tungstenite::tungstenite::http::Uri;
+use with_options::WithOptions;
+
+use crate::enforce_secret::EnforceSecret;
+use crate::error::ConnectorResult;
+use crate::source::SourceProperties;
+use crate::source::websocket::source::{WebsocketSplit, WebsocketSplitReader};
+
+pub const WEBSOCKET_CONNECTOR: &str = "websocket";
+
+fn default_ping_interval_secs() -> u64 {
+    30
+}
+
+#[serde_as]
+#[derive(Clone, Debug, Deserialize, WithOptions)]
+pub struct WebsocketProperties {
+    /// The `WebSocket` server URL to connect to,
+    /// e.g. `ws://localhost:8080/stream` or `wss://example.com/feed`.
+    /// Must be prefixed with either `ws://` or `wss://`.
+    pub url: String,
+
+    /// Optional text message sent to the server right after the connection is
+    /// established, e.g. a subscribe request. It is sent again after every reconnection.
+    #[serde(rename = "init.message")]
+    pub init_message: Option<String>,
+
+    /// Optional additional HTTP headers for the connection handshake request,
+    /// encoded as a JSON object of string pairs,
+    /// e.g. `{"Authorization": "Bearer secret-token"}`.
+    pub headers: Option<String>,
+
+    /// Interval in seconds between keep-alive pings sent to the server.
+    /// Defaults to 30. Set to 0 to disable pings.
+    #[serde(rename = "ping.interval.secs", default = "default_ping_interval_secs")]
+    #[serde_as(as = "DisplayFromStr")]
+    pub ping_interval_secs: u64,
+
+    /// If no data message is received within this many seconds, the connection is
+    /// considered stale and is re-established (the init message is sent again).
+    /// This guards against servers that silently stop delivering subscription data
+    /// while keeping the underlying connection (and ping/pong) alive.
+    /// Disabled by default. Control frames do not reset the timer.
+    #[serde(rename = "idle.timeout.secs")]
+    #[serde_as(as = "Option<DisplayFromStr>")]
+    pub idle_timeout_secs: Option<u64>,
+
+    #[serde(flatten)]
+    pub unknown_fields: HashMap<String, String>,
+}
+
+impl WebsocketProperties {
+    /// Validate the properties and build the client handshake request.
+    pub(crate) fn build_client_request(&self) -> ConnectorResult<ClientRequestBuilder> {
+        let uri: Uri = self
+            .url
+            .parse()
+            .with_context(|| format!("failed to parse WebSocket url: {}", self.url))?;
+        if !matches!(uri.scheme_str(), Some("ws") | Some("wss")) {
+            return Err(anyhow::anyhow!(
+                "invalid WebSocket url: {}, must be prefixed with `ws://` or `wss://`",
+                self.url
+            )
+            .into());
+        }
+
+        let mut request = ClientRequestBuilder::new(uri);
+        if let Some(headers) = &self.headers {
+            let headers: HashMap<String, String> = serde_json::from_str(headers)
+                .context("failed to parse `headers`, expect a JSON object of string pairs")?;
+            for (name, value) in headers {
+                request = request.with_header(name, value);
+            }
+        }
+        Ok(request)
+    }
+}
+
+impl EnforceSecret for WebsocketProperties {
+    const ENFORCE_SECRET_PROPERTIES: Set<&'static str> = phf_set! {
+        "headers",
+    };
+}
+
+impl SourceProperties for WebsocketProperties {
+    type Split = WebsocketSplit;
+    type SplitEnumerator = WebsocketSplitEnumerator;
+    type SplitReader = WebsocketSplitReader;
+
+    const SOURCE_NAME: &'static str = WEBSOCKET_CONNECTOR;
+}
+
+impl crate::source::UnknownFields for WebsocketProperties {
+    fn unknown_fields(&self) -> HashMap<String, String> {
+        self.unknown_fields.clone()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+
+    use super::*;
+    use crate::source::TryFromBTreeMap;
+
+    #[test]
+    fn test_parse_properties() {
+        let props: BTreeMap<String, String> = [
+            ("url".to_owned(), "ws://localhost:8080/stream".to_owned()),
+            (
+                "init.message".to_owned(),
+                r#"{"op":"subscribe"}"#.to_owned(),
+            ),
+            (
+                "headers".to_owned(),
+                r#"{"Authorization": "Bearer foo"}"#.to_owned(),
+            ),
+            ("ping.interval.secs".to_owned(), "15".to_owned()),
+            ("idle.timeout.secs".to_owned(), "120".to_owned()),
+        ]
+        .into_iter()
+        .collect();
+
+        let props = WebsocketProperties::try_from_btreemap(props, true).unwrap();
+        assert_eq!(props.url, "ws://localhost:8080/stream");
+        assert_eq!(props.init_message.as_deref(), Some(r#"{"op":"subscribe"}"#));
+        assert_eq!(props.ping_interval_secs, 15);
+        assert_eq!(props.idle_timeout_secs, Some(120));
+        props.build_client_request().unwrap();
+    }
+
+    #[test]
+    fn test_parse_properties_default() {
+        let props: BTreeMap<String, String> =
+            [("url".to_owned(), "wss://example.com/feed".to_owned())]
+                .into_iter()
+                .collect();
+
+        let props = WebsocketProperties::try_from_btreemap(props, true).unwrap();
+        assert_eq!(props.ping_interval_secs, 30);
+        assert!(props.idle_timeout_secs.is_none());
+        assert!(props.init_message.is_none());
+        assert!(props.headers.is_none());
+        props.build_client_request().unwrap();
+    }
+
+    #[test]
+    fn test_invalid_url_scheme() {
+        let props: BTreeMap<String, String> =
+            [("url".to_owned(), "http://example.com/feed".to_owned())]
+                .into_iter()
+                .collect();
+
+        let props = WebsocketProperties::try_from_btreemap(props, true).unwrap();
+        let err = props.build_client_request().unwrap_err();
+        assert!(err.to_string().contains("ws://"), "{}", err);
+    }
+
+    #[test]
+    fn test_invalid_headers() {
+        let props: BTreeMap<String, String> = [
+            ("url".to_owned(), "ws://example.com/feed".to_owned()),
+            ("headers".to_owned(), "not-a-json-object".to_owned()),
+        ]
+        .into_iter()
+        .collect();
+
+        let props = WebsocketProperties::try_from_btreemap(props, true).unwrap();
+        props.build_client_request().unwrap_err();
+    }
+}

--- a/src/connector/src/source/websocket/source/message.rs
+++ b/src/connector/src/source/websocket/source/message.rs
@@ -1,0 +1,38 @@
+// Copyright 2026 RisingWave Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::source::base::SourceMessage;
+use crate::source::{SourceMeta, SplitId};
+
+#[derive(Clone, Debug)]
+pub struct WebsocketMessage {
+    pub split_id: SplitId,
+    /// A per-reader counter of received messages, used as the message offset.
+    /// A `WebSocket` stream has no server-side offsets and cannot be replayed.
+    pub sequence_number: u64,
+    /// Payload of a text or binary frame.
+    pub payload: Vec<u8>,
+}
+
+impl From<WebsocketMessage> for SourceMessage {
+    fn from(message: WebsocketMessage) -> Self {
+        SourceMessage {
+            key: None,
+            payload: Some(message.payload),
+            offset: message.sequence_number.to_string(),
+            split_id: message.split_id,
+            meta: SourceMeta::Empty,
+        }
+    }
+}

--- a/src/connector/src/source/websocket/source/mod.rs
+++ b/src/connector/src/source/websocket/source/mod.rs
@@ -1,0 +1,20 @@
+// Copyright 2026 RisingWave Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+mod message;
+mod reader;
+
+pub use reader::*;
+
+pub use crate::source::websocket::split::*;

--- a/src/connector/src/source/websocket/source/reader.rs
+++ b/src/connector/src/source/websocket/source/reader.rs
@@ -1,0 +1,536 @@
+// Copyright 2026 RisingWave Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::time::Duration;
+
+use async_trait::async_trait;
+use futures::{SinkExt, Stream, StreamExt};
+use futures_async_stream::try_stream;
+use thiserror_ext::AsReport;
+use tokio_tungstenite::connect_async;
+use tokio_tungstenite::tungstenite::{Bytes, Error as WsError, Message};
+
+use super::WebsocketSplit;
+use super::message::WebsocketMessage;
+use crate::error::ConnectorResult as Result;
+use crate::parser::ParserConfig;
+use crate::source::common::into_chunk_stream;
+use crate::source::websocket::WebsocketProperties;
+use crate::source::{
+    BoxSourceChunkStream, Column, SourceContextRef, SourceMessage, SplitId, SplitMetaData,
+    SplitReader,
+};
+
+const RECONNECT_BACKOFF_MIN: Duration = Duration::from_secs(1);
+const RECONNECT_BACKOFF_MAX: Duration = Duration::from_secs(60);
+
+pub struct WebsocketSplitReader {
+    properties: WebsocketProperties,
+    split_id: SplitId,
+    parser_config: ParserConfig,
+    source_ctx: SourceContextRef,
+}
+
+#[async_trait]
+impl SplitReader for WebsocketSplitReader {
+    type Properties = WebsocketProperties;
+    type Split = WebsocketSplit;
+
+    async fn new(
+        properties: WebsocketProperties,
+        splits: Vec<WebsocketSplit>,
+        parser_config: ParserConfig,
+        source_ctx: SourceContextRef,
+        _columns: Option<Vec<Column>>,
+    ) -> Result<Self> {
+        // Validate the url and headers eagerly to fail fast on malformed properties.
+        // The actual connection is established lazily in the data stream, which handles
+        // reconnection with backoff.
+        properties.build_client_request()?;
+
+        let split_id = splits
+            .first()
+            .map(|split| split.id())
+            .unwrap_or_else(|| WebsocketSplit::new().id());
+
+        Ok(Self {
+            properties,
+            split_id,
+            parser_config,
+            source_ctx,
+        })
+    }
+
+    fn into_stream(self) -> BoxSourceChunkStream {
+        let parser_config = self.parser_config.clone();
+        let source_context = self.source_ctx.clone();
+        into_chunk_stream(self.into_data_stream(), parser_config, source_context)
+    }
+}
+
+/// An event selected from the `WebSocket` stream or the ping ticker.
+enum Event {
+    /// An item from the `WebSocket` stream, `None` means the stream has ended.
+    Message(Option<std::result::Result<Message, WsError>>),
+    /// Time to send a keep-alive ping.
+    PingTick,
+    /// No data message arrived before the idle deadline.
+    IdleTimeout,
+}
+
+/// Wait for the next event on the connection.
+///
+/// This is a separate function because `tokio::select!` expands to `.await`s that
+/// `#[try_stream]` cannot rewrite inside the stream body.
+async fn next_event<S>(
+    ws_stream: &mut S,
+    ping_ticker: &mut tokio::time::Interval,
+    ping_enabled: bool,
+    idle_deadline: Option<tokio::time::Instant>,
+) -> Event
+where
+    S: Stream<Item = std::result::Result<Message, WsError>> + Unpin,
+{
+    tokio::select! {
+        biased;
+        message = ws_stream.next() => Event::Message(message),
+        _ = ping_ticker.tick(), if ping_enabled => Event::PingTick,
+        _ = async { tokio::time::sleep_until(idle_deadline.unwrap()).await },
+            if idle_deadline.is_some() => Event::IdleTimeout,
+    }
+}
+
+impl WebsocketSplitReader {
+    /// Connect to the `WebSocket` server and stream messages, reconnecting with a capped
+    /// exponential backoff whenever the connection is lost. `WebSocket` servers routinely
+    /// drop long-lived connections (e.g. periodic forced disconnects or idle timeouts),
+    /// so transient failures must not bubble up as stream errors.
+    ///
+    /// A `WebSocket` stream cannot be replayed, so messages sent by the server while the
+    /// connection is down are lost. This is inherent to the protocol.
+    #[try_stream(ok = Vec<SourceMessage>, error = crate::error::ConnectorError)]
+    async fn into_data_stream(self) {
+        let url = self.properties.url.clone();
+        // A per-reader counter used as the message offset, increasing monotonically
+        // across reconnections.
+        let mut sequence_number: u64 = 0;
+        let mut backoff = RECONNECT_BACKOFF_MIN;
+        let mut first_attempt = true;
+
+        loop {
+            if !first_attempt {
+                tokio::time::sleep(backoff).await;
+                backoff = (backoff * 2).min(RECONNECT_BACKOFF_MAX);
+            }
+            first_attempt = false;
+
+            // Property validation errors are fatal; they have already been checked in
+            // `SplitReader::new`, so an error here is unreachable in practice.
+            let request = self.properties.build_client_request()?;
+            let mut ws_stream = match connect_async(request).await {
+                Ok((ws_stream, _resp)) => {
+                    tracing::info!(url, "connected to WebSocket server");
+                    ws_stream
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        url,
+                        error = %e.as_report(),
+                        "failed to connect to WebSocket server, will retry in {:?}",
+                        backoff,
+                    );
+                    continue;
+                }
+            };
+
+            if let Some(init_message) = &self.properties.init_message
+                && let Err(e) = ws_stream.send(Message::text(init_message.clone())).await
+            {
+                tracing::warn!(
+                    url,
+                    error = %e.as_report(),
+                    "failed to send init message, will reconnect in {:?}",
+                    backoff,
+                );
+                continue;
+            }
+
+            let ping_interval_secs = self.properties.ping_interval_secs;
+            let ping_enabled = ping_interval_secs > 0;
+            // The interval is unused when pings are disabled, but `tokio::time::interval`
+            // panics on a zero duration, hence the `max(1)`.
+            let mut ping_ticker =
+                tokio::time::interval(Duration::from_secs(ping_interval_secs.max(1)));
+            ping_ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+
+            // Deadline for receiving the next data message. Some servers keep the
+            // connection (and ping/pong) alive but silently stop delivering
+            // subscription data; reconnecting re-sends the init message and resumes
+            // the subscription.
+            let idle_timeout = self
+                .properties
+                .idle_timeout_secs
+                .filter(|secs| *secs > 0)
+                .map(Duration::from_secs);
+            let mut idle_deadline = idle_timeout.map(|timeout| tokio::time::Instant::now() + timeout);
+
+            // Read messages until the connection is lost, then reconnect.
+            loop {
+                let event =
+                    next_event(&mut ws_stream, &mut ping_ticker, ping_enabled, idle_deadline)
+                        .await;
+
+                match event {
+                    Event::Message(Some(Ok(message))) => match message {
+                        Message::Text(_) | Message::Binary(_) => {
+                            let payload = match message {
+                                Message::Text(text) => text.as_bytes().to_vec(),
+                                Message::Binary(binary) => binary.to_vec(),
+                                _ => unreachable!(),
+                            };
+                            // Skip empty frames, which some servers send as keep-alives.
+                            if payload.is_empty() {
+                                continue;
+                            }
+                            let message = WebsocketMessage {
+                                split_id: self.split_id.clone(),
+                                sequence_number,
+                                payload,
+                            };
+                            sequence_number += 1;
+                            // The connection proved to be healthy, reset the backoff
+                            // and push out the idle deadline.
+                            backoff = RECONNECT_BACKOFF_MIN;
+                            idle_deadline = idle_timeout.map(|t| tokio::time::Instant::now() + t);
+                            yield vec![SourceMessage::from(message)];
+                        }
+                        Message::Close(close_frame) => {
+                            tracing::info!(
+                                url,
+                                ?close_frame,
+                                "WebSocket connection closed by server, will reconnect in {:?}",
+                                backoff,
+                            );
+                            break;
+                        }
+                        // Ping frames are answered automatically by tungstenite.
+                        Message::Ping(_) | Message::Pong(_) | Message::Frame(_) => {}
+                    },
+                    Event::Message(Some(Err(e))) => {
+                        tracing::warn!(
+                            url,
+                            error = %e.as_report(),
+                            "WebSocket connection error, will reconnect in {:?}",
+                            backoff,
+                        );
+                        break;
+                    }
+                    Event::Message(None) => {
+                        tracing::info!(
+                            url,
+                            "WebSocket stream ended, will reconnect in {:?}",
+                            backoff
+                        );
+                        break;
+                    }
+                    Event::PingTick => {
+                        if let Err(e) = ws_stream.send(Message::Ping(Bytes::new())).await {
+                            tracing::warn!(
+                                url,
+                                error = %e.as_report(),
+                                "failed to send ping, will reconnect in {:?}",
+                                backoff,
+                            );
+                            break;
+                        }
+                    }
+                    Event::IdleTimeout => {
+                        tracing::warn!(
+                            url,
+                            timeout_secs = self.properties.idle_timeout_secs,
+                            "no data received within the idle timeout, reconnecting to \
+                             refresh the subscription",
+                        );
+                        // Reconnect immediately: the transport is typically still
+                        // healthy here, only the subscription went quiet, so backoff
+                        // (reset on the next received message) would just add latency.
+                        break;
+                    }
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use futures::StreamExt;
+    use tokio::net::TcpListener;
+    use tokio_tungstenite::accept_async;
+    use tokio_tungstenite::tungstenite::handshake::server::{
+        Request as HandshakeRequest, Response as HandshakeResponse,
+    };
+
+    use super::*;
+    use crate::source::SourceContext;
+    use crate::source::websocket::split::WEBSOCKET_SPLIT_ID;
+
+    async fn create_reader(
+        url: String,
+        init_message: Option<String>,
+        headers: Option<String>,
+        ping_interval_secs: u64,
+    ) -> WebsocketSplitReader {
+        create_reader_with_idle_timeout(url, init_message, headers, ping_interval_secs, None).await
+    }
+
+    async fn create_reader_with_idle_timeout(
+        url: String,
+        init_message: Option<String>,
+        headers: Option<String>,
+        ping_interval_secs: u64,
+        idle_timeout_secs: Option<u64>,
+    ) -> WebsocketSplitReader {
+        let properties = WebsocketProperties {
+            url,
+            init_message,
+            headers,
+            ping_interval_secs,
+            idle_timeout_secs,
+            unknown_fields: Default::default(),
+        };
+        WebsocketSplitReader::new(
+            properties,
+            vec![WebsocketSplit::new()],
+            ParserConfig::default(),
+            SourceContext::dummy().into(),
+            None,
+        )
+        .await
+        .unwrap()
+    }
+
+    #[tokio::test]
+    async fn test_receive_text_and_binary_messages() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            let (stream, _) = listener.accept().await.unwrap();
+            let mut ws = accept_async(stream).await.unwrap();
+            ws.send(Message::text(r#"{"v1":1}"#)).await.unwrap();
+            ws.send(Message::Binary(vec![1u8, 2, 3].into()))
+                .await
+                .unwrap();
+            // Empty frames should be skipped by the reader.
+            ws.send(Message::text("")).await.unwrap();
+            ws.send(Message::text("last")).await.unwrap();
+            // Keep the connection open until the client is dropped.
+            while ws.next().await.is_some() {}
+        });
+
+        let reader = create_reader(format!("ws://{}", addr), None, None, 0).await;
+        let mut stream = Box::pin(reader.into_data_stream());
+
+        let batch = stream.next().await.unwrap().unwrap();
+        assert_eq!(batch.len(), 1);
+        assert_eq!(batch[0].payload.as_deref(), Some(r#"{"v1":1}"#.as_bytes()));
+        assert_eq!(batch[0].offset, "0");
+        assert_eq!(batch[0].split_id.as_ref(), WEBSOCKET_SPLIT_ID);
+
+        let batch = stream.next().await.unwrap().unwrap();
+        assert_eq!(batch[0].payload.as_deref(), Some([1u8, 2, 3].as_slice()));
+        assert_eq!(batch[0].offset, "1");
+
+        // The empty frame is skipped, so the next message is "last".
+        let batch = stream.next().await.unwrap().unwrap();
+        assert_eq!(batch[0].payload.as_deref(), Some(b"last".as_slice()));
+        assert_eq!(batch[0].offset, "2");
+    }
+
+    #[tokio::test]
+    async fn test_init_message_and_reconnect() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            // First connection: echo the init message back, then close, forcing the
+            // client to reconnect.
+            let (stream, _) = listener.accept().await.unwrap();
+            let mut ws = accept_async(stream).await.unwrap();
+            let init = ws.next().await.unwrap().unwrap();
+            ws.send(Message::text(format!(
+                "conn-1:{}",
+                init.into_text().unwrap().as_str()
+            )))
+            .await
+            .unwrap();
+            ws.close(None).await.unwrap();
+
+            // Second connection: the init message must be sent again.
+            let (stream, _) = listener.accept().await.unwrap();
+            let mut ws = accept_async(stream).await.unwrap();
+            let init = ws.next().await.unwrap().unwrap();
+            ws.send(Message::text(format!(
+                "conn-2:{}",
+                init.into_text().unwrap().as_str()
+            )))
+            .await
+            .unwrap();
+            while ws.next().await.is_some() {}
+        });
+
+        let reader = create_reader(
+            format!("ws://{}", addr),
+            Some("SUBSCRIBE".to_owned()),
+            None,
+            0,
+        )
+        .await;
+        let mut stream = Box::pin(reader.into_data_stream());
+
+        let batch = stream.next().await.unwrap().unwrap();
+        assert_eq!(
+            batch[0].payload.as_deref(),
+            Some(b"conn-1:SUBSCRIBE".as_slice())
+        );
+        assert_eq!(batch[0].offset, "0");
+
+        // The reader reconnects transparently (after the minimal backoff) and re-sends
+        // the init message; the sequence number continues to increase.
+        let batch = stream.next().await.unwrap().unwrap();
+        assert_eq!(
+            batch[0].payload.as_deref(),
+            Some(b"conn-2:SUBSCRIBE".as_slice())
+        );
+        assert_eq!(batch[0].offset, "1");
+    }
+
+    #[tokio::test]
+    async fn test_keep_alive_ping() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            let (stream, _) = listener.accept().await.unwrap();
+            let mut ws = accept_async(stream).await.unwrap();
+            // Notify the client when its keep-alive ping is received.
+            while let Some(Ok(message)) = ws.next().await {
+                if let Message::Ping(_) = message {
+                    ws.send(Message::text("got-ping")).await.unwrap();
+                }
+            }
+        });
+
+        // The first ping is sent immediately after connecting.
+        let reader = create_reader(format!("ws://{}", addr), None, None, 1).await;
+        let mut stream = Box::pin(reader.into_data_stream());
+
+        let batch = stream.next().await.unwrap().unwrap();
+        assert_eq!(batch[0].payload.as_deref(), Some(b"got-ping".as_slice()));
+    }
+
+    #[tokio::test]
+    async fn test_idle_timeout_reconnects_and_resubscribes() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            // First connection: acknowledge the subscription with one message, then go
+            // silent WITHOUT closing — the transport stays open (answering pings is
+            // handled by tungstenite on the client automatically). This models servers
+            // that silently expire subscriptions.
+            let (stream, _) = listener.accept().await.unwrap();
+            let mut ws = accept_async(stream).await.unwrap();
+            let init = ws.next().await.unwrap().unwrap();
+            assert_eq!(init.into_text().unwrap().as_str(), "SUBSCRIBE");
+            ws.send(Message::text("data-1")).await.unwrap();
+            // Keep the connection open, ignore everything, send nothing.
+            let silent = async move { while ws.next().await.is_some() {} };
+
+            // Second connection (after the client's idle timeout): the init message
+            // must be sent again, then data flows again.
+            let resubscribed = async {
+                let (stream, _) = listener.accept().await.unwrap();
+                let mut ws = accept_async(stream).await.unwrap();
+                let init = ws.next().await.unwrap().unwrap();
+                assert_eq!(init.into_text().unwrap().as_str(), "SUBSCRIBE");
+                ws.send(Message::text("data-2")).await.unwrap();
+                while ws.next().await.is_some() {}
+            };
+            tokio::join!(silent, resubscribed);
+        });
+
+        let reader = create_reader_with_idle_timeout(
+            format!("ws://{}", addr),
+            Some("SUBSCRIBE".to_owned()),
+            None,
+            0,
+            Some(1),
+        )
+        .await;
+        let mut stream = Box::pin(reader.into_data_stream());
+
+        let batch = stream.next().await.unwrap().unwrap();
+        assert_eq!(batch[0].payload.as_deref(), Some(b"data-1".as_slice()));
+
+        // After ~1s of silence the reader must reconnect on its own and re-subscribe.
+        let batch = tokio::time::timeout(Duration::from_secs(10), stream.next())
+            .await
+            .expect("reader should recover from a silent subscription within the idle timeout")
+            .unwrap()
+            .unwrap();
+        assert_eq!(batch[0].payload.as_deref(), Some(b"data-2".as_slice()));
+        assert_eq!(batch[0].offset, "1", "sequence number continues across reconnects");
+    }
+
+    #[tokio::test]
+    async fn test_custom_handshake_headers() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let (header_tx, header_rx) = tokio::sync::oneshot::channel();
+        tokio::spawn(async move {
+            let (stream, _) = listener.accept().await.unwrap();
+            let mut ws = tokio_tungstenite::accept_hdr_async(
+                stream,
+                |req: &HandshakeRequest, resp: HandshakeResponse| {
+                    let auth = req
+                        .headers()
+                        .get("authorization")
+                        .and_then(|v| v.to_str().ok())
+                        .map(|v| v.to_owned());
+                    header_tx.send(auth).ok();
+                    Ok(resp)
+                },
+            )
+            .await
+            .unwrap();
+            ws.send(Message::text("hello")).await.unwrap();
+            while ws.next().await.is_some() {}
+        });
+
+        let reader = create_reader(
+            format!("ws://{}", addr),
+            None,
+            Some(r#"{"Authorization": "Bearer foo"}"#.to_owned()),
+            0,
+        )
+        .await;
+        let mut stream = Box::pin(reader.into_data_stream());
+
+        let batch = stream.next().await.unwrap().unwrap();
+        assert_eq!(batch[0].payload.as_deref(), Some(b"hello".as_slice()));
+        assert_eq!(
+            header_rx.await.unwrap(),
+            Some("Bearer foo".to_owned()),
+            "the custom header should be sent in the handshake request"
+        );
+    }
+}

--- a/src/connector/src/source/websocket/source/reader.rs
+++ b/src/connector/src/source/websocket/source/reader.rs
@@ -183,13 +183,18 @@ impl WebsocketSplitReader {
                 .idle_timeout_secs
                 .filter(|secs| *secs > 0)
                 .map(Duration::from_secs);
-            let mut idle_deadline = idle_timeout.map(|timeout| tokio::time::Instant::now() + timeout);
+            let mut idle_deadline = idle_timeout
+                .map(|timeout| tokio::time::Instant::now() + timeout);
 
             // Read messages until the connection is lost, then reconnect.
             loop {
-                let event =
-                    next_event(&mut ws_stream, &mut ping_ticker, ping_enabled, idle_deadline)
-                        .await;
+                let event = next_event(
+                    &mut ws_stream,
+                    &mut ping_ticker,
+                    ping_enabled,
+                    idle_deadline,
+                )
+                .await;
 
                 match event {
                     Event::Message(Some(Ok(message))) => match message {

--- a/src/connector/src/source/websocket/source/reader.rs
+++ b/src/connector/src/source/websocket/source/reader.rs
@@ -273,7 +273,10 @@ impl WebsocketSplitReader {
     }
 }
 
-#[cfg(test)]
+// These tests run a local TCP server and drive the reader via `tokio_tungstenite`, which
+// uses the real `tokio` runtime. They are therefore incompatible with the madsim
+// simulation runtime, where no real reactor is running.
+#[cfg(all(test, not(madsim)))]
 mod tests {
     use futures::StreamExt;
     use tokio::net::TcpListener;

--- a/src/connector/src/source/websocket/source/reader.rs
+++ b/src/connector/src/source/websocket/source/reader.rs
@@ -183,8 +183,8 @@ impl WebsocketSplitReader {
                 .idle_timeout_secs
                 .filter(|secs| *secs > 0)
                 .map(Duration::from_secs);
-            let mut idle_deadline = idle_timeout
-                .map(|timeout| tokio::time::Instant::now() + timeout);
+            let mut idle_deadline =
+                idle_timeout.map(|timeout| tokio::time::Instant::now() + timeout);
 
             // Read messages until the connection is lost, then reconnect.
             loop {
@@ -496,7 +496,10 @@ mod tests {
             .unwrap()
             .unwrap();
         assert_eq!(batch[0].payload.as_deref(), Some(b"data-2".as_slice()));
-        assert_eq!(batch[0].offset, "1", "sequence number continues across reconnects");
+        assert_eq!(
+            batch[0].offset, "1",
+            "sequence number continues across reconnects"
+        );
     }
 
     #[tokio::test]

--- a/src/connector/src/source/websocket/split.rs
+++ b/src/connector/src/source/websocket/split.rs
@@ -1,0 +1,84 @@
+// Copyright 2026 RisingWave Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use risingwave_common::types::JsonbVal;
+use serde::{Deserialize, Serialize};
+
+use crate::error::ConnectorResult;
+use crate::source::{SplitId, SplitMetaData};
+
+/// The fixed id of the single split of a `WebSocket` source.
+pub const WEBSOCKET_SPLIT_ID: &str = "websocket";
+
+/// A `WebSocket` source always has exactly one split, since a `WebSocket` connection is a
+/// single ordered stream of messages without any partitioning or replay capability.
+///
+/// The split is persisted to the checkpoint, but there is no offset to restore: on
+/// recovery the reader simply reconnects and consumes messages from that point on.
+#[derive(Clone, Serialize, Deserialize, Debug, PartialEq, Hash)]
+pub struct WebsocketSplit {}
+
+impl SplitMetaData for WebsocketSplit {
+    fn id(&self) -> SplitId {
+        WEBSOCKET_SPLIT_ID.into()
+    }
+
+    fn restore_from_json(value: JsonbVal) -> ConnectorResult<Self> {
+        serde_json::from_value(value.take()).map_err(Into::into)
+    }
+
+    fn encode_to_json(&self) -> JsonbVal {
+        serde_json::to_value(self.clone()).unwrap().into()
+    }
+
+    fn update_offset(&mut self, _last_seen_offset: String) -> ConnectorResult<()> {
+        // A WebSocket stream cannot be replayed from an offset, so there is nothing to
+        // persist here. The offset attached to messages is a per-reader counter only
+        // used for observability.
+        Ok(())
+    }
+}
+
+impl WebsocketSplit {
+    pub fn new() -> Self {
+        Self {}
+    }
+}
+
+impl Default for WebsocketSplit {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_split_json_round_trip() {
+        let split = WebsocketSplit::new();
+        let json = split.encode_to_json();
+        let restored = WebsocketSplit::restore_from_json(json).unwrap();
+        assert_eq!(split, restored);
+        assert_eq!(restored.id().as_ref(), WEBSOCKET_SPLIT_ID);
+    }
+
+    #[test]
+    fn test_update_offset_is_noop() {
+        let mut split = WebsocketSplit::new();
+        split.update_offset("42".to_owned()).unwrap();
+        assert_eq!(split, WebsocketSplit::new());
+    }
+}

--- a/src/connector/with_options_source.yaml
+++ b/src/connector/with_options_source.yaml
@@ -1460,3 +1460,41 @@ TestSourceProperties:
   - name: properties
     field_type: BTreeMap<String,String>
     required: true
+WebsocketProperties:
+  fields:
+  - name: url
+    field_type: String
+    comments: |-
+      The `WebSocket` server URL to connect to,
+      e.g. `ws://localhost:8080/stream` or `wss://example.com/feed`.
+      Must be prefixed with either `ws://` or `wss://`.
+    required: true
+  - name: init.message
+    field_type: String
+    comments: |-
+      Optional text message sent to the server right after the connection is
+      established, e.g. a subscribe request. It is sent again after every reconnection.
+    required: false
+  - name: headers
+    field_type: String
+    comments: |-
+      Optional additional HTTP headers for the connection handshake request,
+      encoded as a JSON object of string pairs,
+      e.g. `{"Authorization": "Bearer secret-token"}`.
+    required: false
+  - name: ping.interval.secs
+    field_type: u64
+    comments: |-
+      Interval in seconds between keep-alive pings sent to the server.
+      Defaults to 30. Set to 0 to disable pings.
+    required: false
+    default: '30'
+  - name: idle.timeout.secs
+    field_type: u64
+    comments: |-
+      If no data message is received within this many seconds, the connection is
+      considered stale and is re-established (the init message is sent again).
+      This guards against servers that silently stop delivering subscription data
+      while keeping the underlying connection (and ping/pong) alive.
+      Disabled by default. Control frames do not reset the timer.
+    required: false

--- a/src/frontend/src/handler/create_source.rs
+++ b/src/frontend/src/handler/create_source.rs
@@ -67,7 +67,7 @@ pub use risingwave_connector::source::{
 use risingwave_connector::source::{
     AZBLOB_CONNECTOR, ConnectorProperties, GCS_CONNECTOR, GOOGLE_PUBSUB_CONNECTOR, KAFKA_CONNECTOR,
     KINESIS_CONNECTOR, LEGACY_S3_CONNECTOR, MQTT_CONNECTOR, NATS_CONNECTOR, NEXMARK_CONNECTOR,
-    OPENDAL_S3_CONNECTOR, POSIX_FS_CONNECTOR, PULSAR_CONNECTOR,
+    OPENDAL_S3_CONNECTOR, POSIX_FS_CONNECTOR, PULSAR_CONNECTOR, WEBSOCKET_CONNECTOR,
 };
 use risingwave_connector::{AUTO_SCHEMA_CHANGE_KEY, WithPropertiesExt};
 use risingwave_pb::catalog::connection_params::PbConnectionType;

--- a/src/frontend/src/handler/create_source/validate.rs
+++ b/src/frontend/src/handler/create_source/validate.rs
@@ -99,6 +99,9 @@ static CONNECTORS_COMPATIBLE_FORMATS: LazyLock<HashMap<String, HashMap<Format, V
                 MQTT_CONNECTOR => hashmap!(
                     Format::Plain => vec![Encode::Json, Encode::Protobuf, Encode::Bytes],
                 ),
+                WEBSOCKET_CONNECTOR => hashmap!(
+                    Format::Plain => vec![Encode::Json, Encode::Protobuf, Encode::Bytes],
+                ),
                 TEST_CONNECTOR => hashmap!(
                     Format::Plain => vec![Encode::Json],
                 ),


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).


## What's changed and what's your intention?

**Summary**

This PR adds a new `websocket` source connector that lets RisingWave ingest messages directly from a WebSocket server (e.g. an IoT sensor telemetry feed, an event stream, or a subscribe-style push API), in both plain `ws://` and TLS `wss://` modes.

**How it works**

- A `websocket` source/table is configured with a `url` (`ws://...` or `wss://...`, scheme validated at creation time) plus optional connection options. It has exactly one split: a WebSocket connection is a single ordered, non-partitionable, non-replayable message stream.
- The reader connects with `tokio-tungstenite` (TLS via `rustls` + native root CAs), streams `text`/`binary` frames, skips empty keep-alive frames, and feeds each message through the standard parsing pipeline (`format plain`, `encode json` / `protobuf` / `bytes`).
- **Reconnection**: WebSocket servers routinely drop long-lived connections, so the reader transparently reconnects with a capped exponential backoff (1s up to 60s) instead of erroring out. The optional `init.message` (e.g. a subscribe request) is re-sent on every (re)connect.
- **Keep-alive**: `ping.interval.secs` (default `30`, set to `0` to disable) sends WebSocket pings; pong handling is done by `tungstenite`.
- **Stale-subscription guard**: `idle.timeout.secs` forces a reconnect (and re-subscribe) when no data message arrives for the given period. This covers servers that silently expire subscriptions while keeping the transport (and ping/pong) alive. Disabled by default.
- **Offset semantics**: because a WebSocket stream cannot be replayed, the message offset is a per-reader sequence counter used for observability only (exposed via `INCLUDE offset`); it is not persisted, and on recovery the reader reconnects and consumes from that point on.

**New connector options**

| option                | required | default | description |
|-----------------------|----------|---------|-------------|
| `url`                 | yes      | –       | server URL, must be `ws://` or `wss://` |
| `init.message`        | no       | –       | text sent right after (re)connect, e.g. subscribe request |
| `headers`             | no       | –       | JSON object of string pairs added to the handshake, e.g. `{"Authorization": "Bearer ..."}`. Enforced as a `SECRET` on RisingWave Cloud (`enforce_secret`). |
| `ping.interval.secs`  | no       | `30`    | keep-alive ping interval; `0` disables |
| `idle.timeout.secs`   | no       | –       | reconnect if no data message arrives in this many seconds |

**Tests**

- Unit tests: connector properties parsing/validation, split JSON round-trip, and reader behavior against a real in-process server — text/binary ingestion and empty-frame skipping, `init.message` re-sent across reconnects, keep-alive pings, idle-timeout reconnect + re-subscribe, custom handshake headers.
- End-to-end: `e2e_test/source_inline/websocket/websocket_source.slt.serial` runs against a local `ws_server.py` fixture, covering basic ingestion, creation-time validation, bearer-auth headers, and `INCLUDE offset`.

**Limitations**

- WebSocket is not replayable: messages the server sends while the connection is down are lost (inherent to the protocol; no offset-based recovery).
- A single split — no partitioning.
- TLS uses system-trusted native root CAs; no custom CA/client-cert options in this PR.



Closes issue https://github.com/risingwavelabs/risingwave/issues/21555

## Checklist

- [x] I have written necessary rustdoc comments.
- [x] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- Add `ci/run-e2e-source-tests` when opening the PR. The websocket SLT is already wired into ci/scripts/e2e-source-test.sh. See .agents/PR_LABELING.md and docs/dev/src/ci.md. -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [x] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->

<!-- [PLACEHOLDER] If docs for the new connector are added to risingwave-docs, check this box. -->


## Documentation

- [x] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

RisingWave now supports ingesting data from WebSocket servers via a new `websocket` source connector. For example, IoT sensor telemetry can be consumed directly from a device gateway:

```sql
create table sensor_telemetry (
  device_id varchar,
  temperature decimal,
  humidity decimal
) with (
  connector = 'websocket',
  url = 'wss://iot.example.com/devices/stream',
  init.message = '{"op": "subscribe", "topic": "telemetry"}',
  headers = '{"Authorization": "Bearer <token>"}'
) format plain encode json;
```

The connector supports plain `ws://` and TLS `wss://` URLs, custom handshake headers, keep-alive pings, automatic reconnection with re-subscription, and an optional idle timeout to recover from silently-expired subscriptions. Note that WebSocket streams cannot be replayed, so messages sent while the connection is down are lost.
</details>
