### PR TITLE
feat(iceberg): support coordinator-driven size-based commit trigger for Iceberg sink

### DIFF
--- a/proto/connector_service.proto
+++ b/proto/connector_service.proto
@@ -243,12 +243,18 @@ message CoordinateRequest {
     common.Buffer vnode_bitmap = 1;
   }
 
+  message ReportBytesRequest {
+    uint64 epoch = 1;
+    uint64 buffered_bytes = 2;
+  }
+
   oneof msg {
     StartCoordinationRequest start_request = 1;
     CommitRequest commit_request = 2;
     UpdateVnodeBitmapRequest update_vnode_request = 3;
     bool stop = 4;
     uint64 align_initial_epoch_request = 5;
+    ReportBytesRequest report_bytes_request = 6;
   }
 }
 
@@ -261,11 +267,17 @@ message CoordinateResponse {
     uint64 epoch = 1;
   }
 
+  message ReportBytesResponse {
+    uint64 epoch = 1;
+    bool should_commit = 2;
+  }
+
   oneof msg {
     StartCoordinationResponse start_response = 1;
     CommitResponse commit_response = 2;
     bool stopped = 3;
     uint64 align_initial_epoch_response = 4;
+    ReportBytesResponse report_bytes_response = 5;
   }
 }
 

--- a/src/connector/src/allow_alter_on_fly_fields.rs
+++ b/src/connector/src/allow_alter_on_fly_fields.rs
@@ -244,6 +244,7 @@ pub static SINK_ALLOW_ALTER_ON_FLY_FIELDS: LazyLock<HashMap<String, HashSet<Stri
         std::any::type_name::<IcebergConfig>().to_owned(),
         [
             "commit_checkpoint_interval".to_owned(),
+            "commit_checkpoint_size_threshold_mb".to_owned(),
             "enable_compaction".to_owned(),
             "compaction_interval_sec".to_owned(),
             "enable_snapshot_expiration".to_owned(),

--- a/src/connector/src/sink/coordinate.rs
+++ b/src/connector/src/sink/coordinate.rs
@@ -268,36 +268,36 @@ impl<W: SinkWriter<CommitMetadata = Option<SinkMetadata>>> LogSinker for Coordin
                             log_reader.truncate(TruncateOffset::Barrier { epoch })?;
                         } else if self.commit_checkpoint_size_threshold_bytes.is_some() {
                             let buffered_bytes = sink_writer.buffered_bytes();
-                            // Skip the RPC round-trip when there is no buffered data
-                            if buffered_bytes == 0 {
-                                sink_writer.barrier(false).await?;
-                            } else {
-                                let should_commit = coordinator_stream_handle
-                                    .report_bytes(epoch, buffered_bytes)
+                            // Always report, even when there is no buffered data: the
+                            // coordinator responds to an epoch only after every writer has
+                            // reported for it, so skipping the report would leave the epoch
+                            // unaligned forever and deadlock all other writers awaiting the
+                            // response.
+                            let should_commit = coordinator_stream_handle
+                                .report_bytes(epoch, buffered_bytes)
+                                .await?;
+
+                            if should_commit {
+                                let start_time = Instant::now();
+                                let metadata = sink_writer.barrier(true).await?;
+                                let metadata = metadata.ok_or_else(|| {
+                                    SinkError::Coordinator(anyhow!(
+                                        "should get metadata on checkpoint barrier"
+                                    ))
+                                })?;
+                                coordinator_stream_handle
+                                    .commit(epoch, metadata, None)
                                     .await?;
+                                sink_writer_metrics
+                                    .sink_commit_duration
+                                    .observe(start_time.elapsed().as_secs_f64());
 
-                                if should_commit {
-                                    let start_time = Instant::now();
-                                    let metadata = sink_writer.barrier(true).await?;
-                                    let metadata = metadata.ok_or_else(|| {
-                                        SinkError::Coordinator(anyhow!(
-                                            "should get metadata on checkpoint barrier"
-                                        ))
-                                    })?;
-                                    coordinator_stream_handle
-                                        .commit(epoch, metadata, None)
-                                        .await?;
-                                    sink_writer_metrics
-                                        .sink_commit_duration
-                                        .observe(start_time.elapsed().as_secs_f64());
-
-                                    current_checkpoint = 0;
-                                    log_reader.truncate(TruncateOffset::Barrier { epoch })?;
-                                } else {
-                                    let metadata = sink_writer.barrier(false).await?;
-                                    if let Some(metadata) = metadata {
-                                        warn!(?metadata, "get metadata on non-checkpoint barrier");
-                                    }
+                                current_checkpoint = 0;
+                                log_reader.truncate(TruncateOffset::Barrier { epoch })?;
+                            } else {
+                                let metadata = sink_writer.barrier(false).await?;
+                                if let Some(metadata) = metadata {
+                                    warn!(?metadata, "get metadata on non-checkpoint barrier");
                                 }
                             }
                         } else {

--- a/src/connector/src/sink/coordinate.rs
+++ b/src/connector/src/sink/coordinate.rs
@@ -28,6 +28,7 @@ use super::{
     LogSinker, SinkCoordinationRpcClientEnum, SinkLogReader, SinkWriterMetrics, SinkWriterParam,
 };
 use crate::sink::decouple_checkpoint_log_sink::should_force_commit_on_checkpoint_barrier;
+use crate::sink::iceberg::COMMIT_CHECKPOINT_SIZE_THRESHOLD_MB;
 use crate::sink::writer::SinkWriter;
 use crate::sink::{LogStoreReadItem, Result, SinkError, SinkParam, TruncateOffset};
 
@@ -37,6 +38,7 @@ pub struct CoordinatedLogSinker<W: SinkWriter<CommitMetadata = Option<SinkMetada
     param: SinkParam,
     vnode_bitmap: Bitmap,
     commit_checkpoint_interval: NonZeroU64,
+    commit_checkpoint_size_threshold_bytes: Option<u64>,
     sink_writer_metrics: SinkWriterMetrics,
 }
 
@@ -47,6 +49,11 @@ impl<W: SinkWriter<CommitMetadata = Option<SinkMetadata>>> CoordinatedLogSinker<
         writer: W,
         commit_checkpoint_interval: NonZeroU64,
     ) -> Result<Self> {
+        let commit_checkpoint_size_threshold_bytes =
+            param.properties.get(COMMIT_CHECKPOINT_SIZE_THRESHOLD_MB)
+                .and_then(|v| v.parse::<u64>().ok())
+                .filter(|&mb| mb > 0)
+                .map(|mb| mb.saturating_mul(1024 * 1024));
         Ok(Self {
             writer,
             sink_coordinate_client: writer_param
@@ -65,6 +72,7 @@ impl<W: SinkWriter<CommitMetadata = Option<SinkMetadata>>> CoordinatedLogSinker<
                 })?
                 .clone(),
             commit_checkpoint_interval,
+            commit_checkpoint_size_threshold_bytes,
             sink_writer_metrics: SinkWriterMetrics::new(writer_param),
         })
     }
@@ -258,6 +266,40 @@ impl<W: SinkWriter<CommitMetadata = Option<SinkMetadata>>> LogSinker for Coordin
                                 return pending().await;
                             }
                             log_reader.truncate(TruncateOffset::Barrier { epoch })?;
+                        } else if self.commit_checkpoint_size_threshold_bytes.is_some() {
+                            let buffered_bytes = sink_writer.buffered_bytes();
+                            // Skip the RPC round-trip when there is no buffered data
+                            if buffered_bytes == 0 {
+                                sink_writer.barrier(false).await?;
+                            } else {
+                                let should_commit = coordinator_stream_handle
+                                    .report_bytes(epoch, buffered_bytes)
+                                    .await?;
+
+                                if should_commit {
+                                    let start_time = Instant::now();
+                                    let metadata = sink_writer.barrier(true).await?;
+                                    let metadata = metadata.ok_or_else(|| {
+                                        SinkError::Coordinator(anyhow!(
+                                            "should get metadata on checkpoint barrier"
+                                        ))
+                                    })?;
+                                    coordinator_stream_handle
+                                        .commit(epoch, metadata, None)
+                                        .await?;
+                                    sink_writer_metrics
+                                        .sink_commit_duration
+                                        .observe(start_time.elapsed().as_secs_f64());
+
+                                    current_checkpoint = 0;
+                                    log_reader.truncate(TruncateOffset::Barrier { epoch })?;
+                                } else {
+                                    let metadata = sink_writer.barrier(false).await?;
+                                    if let Some(metadata) = metadata {
+                                        warn!(?metadata, "get metadata on non-checkpoint barrier");
+                                    }
+                                }
+                            }
                         } else {
                             let metadata = sink_writer.barrier(false).await?;
                             if let Some(metadata) = metadata {

--- a/src/connector/src/sink/coordinate.rs
+++ b/src/connector/src/sink/coordinate.rs
@@ -49,11 +49,12 @@ impl<W: SinkWriter<CommitMetadata = Option<SinkMetadata>>> CoordinatedLogSinker<
         writer: W,
         commit_checkpoint_interval: NonZeroU64,
     ) -> Result<Self> {
-        let commit_checkpoint_size_threshold_bytes =
-            param.properties.get(COMMIT_CHECKPOINT_SIZE_THRESHOLD_MB)
-                .and_then(|v| v.parse::<u64>().ok())
-                .filter(|&mb| mb > 0)
-                .map(|mb| mb.saturating_mul(1024 * 1024));
+        let commit_checkpoint_size_threshold_bytes = param
+            .properties
+            .get(COMMIT_CHECKPOINT_SIZE_THRESHOLD_MB)
+            .and_then(|v| v.parse::<u64>().ok())
+            .filter(|&mb| mb > 0)
+            .map(|mb| mb.saturating_mul(1024 * 1024));
         Ok(Self {
             writer,
             sink_coordinate_client: writer_param

--- a/src/connector/src/sink/decouple_checkpoint_log_sink.rs
+++ b/src/connector/src/sink/decouple_checkpoint_log_sink.rs
@@ -27,20 +27,12 @@ pub const DEFAULT_COMMIT_CHECKPOINT_INTERVAL_WITHOUT_SINK_DECOUPLE: u64 = 1;
 pub const ICEBERG_DEFAULT_COMMIT_CHECKPOINT_INTERVAL: u64 = 60;
 pub const COMMIT_CHECKPOINT_INTERVAL: &str = "commit_checkpoint_interval";
 
-/// 512 MiB default balances Iceberg's recommended on-disk file size (128-512 MiB)
-/// against the ~3-10x in-memory-to-columnar-compressed ratio.
-pub const ICEBERG_DEFAULT_COMMIT_CHECKPOINT_SIZE_THRESHOLD_MB: u64 = 512;
-
 pub fn default_commit_checkpoint_interval() -> u64 {
     DEFAULT_COMMIT_CHECKPOINT_INTERVAL_WITH_SINK_DECOUPLE
 }
 
 pub fn iceberg_default_commit_checkpoint_interval() -> u64 {
     ICEBERG_DEFAULT_COMMIT_CHECKPOINT_INTERVAL
-}
-
-pub fn default_commit_checkpoint_size_threshold_mb() -> u64 {
-    ICEBERG_DEFAULT_COMMIT_CHECKPOINT_SIZE_THRESHOLD_MB
 }
 
 /// The `LogSinker` implementation used for commit-decoupled sinks (such as `Iceberg`, `DeltaLake` and `StarRocks`).

--- a/src/connector/src/sink/decouple_checkpoint_log_sink.rs
+++ b/src/connector/src/sink/decouple_checkpoint_log_sink.rs
@@ -27,12 +27,20 @@ pub const DEFAULT_COMMIT_CHECKPOINT_INTERVAL_WITHOUT_SINK_DECOUPLE: u64 = 1;
 pub const ICEBERG_DEFAULT_COMMIT_CHECKPOINT_INTERVAL: u64 = 60;
 pub const COMMIT_CHECKPOINT_INTERVAL: &str = "commit_checkpoint_interval";
 
+/// 512 MiB default balances Iceberg's recommended on-disk file size (128-512 MiB)
+/// against the ~3-10x in-memory-to-columnar-compressed ratio.
+pub const ICEBERG_DEFAULT_COMMIT_CHECKPOINT_SIZE_THRESHOLD_MB: u64 = 512;
+
 pub fn default_commit_checkpoint_interval() -> u64 {
     DEFAULT_COMMIT_CHECKPOINT_INTERVAL_WITH_SINK_DECOUPLE
 }
 
 pub fn iceberg_default_commit_checkpoint_interval() -> u64 {
     ICEBERG_DEFAULT_COMMIT_CHECKPOINT_INTERVAL
+}
+
+pub fn default_commit_checkpoint_size_threshold_mb() -> u64 {
+    ICEBERG_DEFAULT_COMMIT_CHECKPOINT_SIZE_THRESHOLD_MB
 }
 
 /// The `LogSinker` implementation used for commit-decoupled sinks (such as `Iceberg`, `DeltaLake` and `StarRocks`).

--- a/src/connector/src/sink/iceberg/config.rs
+++ b/src/connector/src/sink/iceberg/config.rs
@@ -328,15 +328,18 @@ pub struct IcebergConfig {
     pub commit_checkpoint_interval: u64,
 
     /// Commit on the next checkpoint barrier after total buffered write size across
-    /// all writers exceeds this threshold in MiB. The coordinator sums per-writer
+    /// all writers exceeds this threshold in `MiB`. The coordinator sums per-writer
     /// byte reports and broadcasts the same commit decision to all writers, ensuring
     /// vnode-aligned commits at the same epoch.
     ///
     /// Size-based commits are opt-in: leaving this unset (or setting it to `0`)
     /// disables them, and commits are driven solely by `commit_checkpoint_interval`.
-    /// A value around 512 MiB is a good starting point, balancing Iceberg's
-    /// recommended on-disk file size (128-512 MiB) against the ~3-10x
-    /// in-memory-to-columnar-compressed ratio.
+    /// The threshold applies to the *sum* across all parallel writers, not any
+    /// single writer, so each writer's own output file will typically be around
+    /// `threshold / sink_parallelism` once the aggregate crosses the threshold.
+    /// Size accordingly to land in Iceberg's recommended on-disk file size range
+    /// (128-512 `MiB`), accounting for the ~3-10x in-memory-to-columnar-compressed
+    /// ratio and the sink's parallelism.
     #[serde(default)]
     #[serde_as(as = "Option<DisplayFromStr>")]
     #[with_option(allow_alter_on_fly, iceberg_engine)]

--- a/src/connector/src/sink/iceberg/config.rs
+++ b/src/connector/src/sink/iceberg/config.rs
@@ -34,7 +34,10 @@ use crate::connector_common::{
 };
 use crate::enforce_secret::EnforceSecret;
 use crate::sink::Result;
-use crate::sink::decouple_checkpoint_log_sink::iceberg_default_commit_checkpoint_interval;
+use crate::sink::decouple_checkpoint_log_sink::{
+    iceberg_default_commit_checkpoint_interval,
+    default_commit_checkpoint_size_threshold_mb,
+};
 use crate::{deserialize_bool_from_string, deserialize_optional_string_seq_from_string};
 
 pub const ICEBERG_COW_BRANCH: &str = "ingestion";
@@ -106,6 +109,7 @@ pub const ENABLE_COMPACTION: &str = "enable_compaction";
 pub const COMPACTION_INTERVAL_SEC: &str = "compaction_interval_sec";
 pub const ENABLE_SNAPSHOT_EXPIRATION: &str = "enable_snapshot_expiration";
 pub const WRITE_MODE: &str = "write_mode";
+pub const COMMIT_CHECKPOINT_SIZE_THRESHOLD_MB: &str = "commit_checkpoint_size_threshold_mb";
 pub const FORMAT_VERSION: &str = "format_version";
 pub const SNAPSHOT_EXPIRATION_RETAIN_LAST: &str = "snapshot_expiration_retain_last";
 pub const SNAPSHOT_EXPIRATION_MAX_AGE_MILLIS: &str = "snapshot_expiration_max_age_millis";
@@ -325,6 +329,20 @@ pub struct IcebergConfig {
     #[serde_as(as = "DisplayFromStr")]
     #[with_option(allow_alter_on_fly, iceberg_engine)]
     pub commit_checkpoint_interval: u64,
+
+    /// Commit on the next checkpoint barrier after total buffered write size across
+    /// all writers exceeds this threshold in MiB. The coordinator sums per-writer
+    /// byte reports and broadcasts the same commit decision to all writers, ensuring
+    /// vnode-aligned commits at the same epoch.
+    ///
+    /// Default 512 MiB balances Iceberg's recommended file size (128-512 MiB on disk)
+    /// against the ~3-10x in-memory-to-columnar-compressed ratio. At 512 MiB in
+    /// memory, each commit produces ~50-170 MiB Parquet files — within the healthy
+    /// range for analytical queries.
+    #[serde(default = "default_commit_checkpoint_size_threshold_mb")]
+    #[serde_as(as = "DisplayFromStr")]
+    #[with_option(allow_alter_on_fly, iceberg_engine)]
+    pub commit_checkpoint_size_threshold_mb: u64,
 
     #[serde(default, deserialize_with = "deserialize_bool_from_string")]
     pub create_table_if_not_exists: bool,

--- a/src/connector/src/sink/iceberg/config.rs
+++ b/src/connector/src/sink/iceberg/config.rs
@@ -34,10 +34,7 @@ use crate::connector_common::{
 };
 use crate::enforce_secret::EnforceSecret;
 use crate::sink::Result;
-use crate::sink::decouple_checkpoint_log_sink::{
-    iceberg_default_commit_checkpoint_interval,
-    default_commit_checkpoint_size_threshold_mb,
-};
+use crate::sink::decouple_checkpoint_log_sink::iceberg_default_commit_checkpoint_interval;
 use crate::{deserialize_bool_from_string, deserialize_optional_string_seq_from_string};
 
 pub const ICEBERG_COW_BRANCH: &str = "ingestion";
@@ -335,14 +332,15 @@ pub struct IcebergConfig {
     /// byte reports and broadcasts the same commit decision to all writers, ensuring
     /// vnode-aligned commits at the same epoch.
     ///
-    /// Default 512 MiB balances Iceberg's recommended file size (128-512 MiB on disk)
-    /// against the ~3-10x in-memory-to-columnar-compressed ratio. At 512 MiB in
-    /// memory, each commit produces ~50-170 MiB Parquet files — within the healthy
-    /// range for analytical queries.
-    #[serde(default = "default_commit_checkpoint_size_threshold_mb")]
-    #[serde_as(as = "DisplayFromStr")]
+    /// Size-based commits are opt-in: leaving this unset (or setting it to `0`)
+    /// disables them, and commits are driven solely by `commit_checkpoint_interval`.
+    /// A value around 512 MiB is a good starting point, balancing Iceberg's
+    /// recommended on-disk file size (128-512 MiB) against the ~3-10x
+    /// in-memory-to-columnar-compressed ratio.
+    #[serde(default)]
+    #[serde_as(as = "Option<DisplayFromStr>")]
     #[with_option(allow_alter_on_fly, iceberg_engine)]
-    pub commit_checkpoint_size_threshold_mb: u64,
+    pub commit_checkpoint_size_threshold_mb: Option<u64>,
 
     #[serde(default, deserialize_with = "deserialize_bool_from_string")]
     pub create_table_if_not_exists: bool,

--- a/src/connector/src/sink/iceberg/engine_options.rs
+++ b/src/connector/src/sink/iceberg/engine_options.rs
@@ -19,6 +19,7 @@ pub const ICEBERG_ENGINE_OPTION_KEYS: &[&str] = &[
     "partition_by",
     "order_key",
     "commit_checkpoint_interval",
+    "commit_checkpoint_size_threshold_mb",
     "enable_compaction",
     "compaction_interval_sec",
     "enable_snapshot_expiration",

--- a/src/connector/src/sink/iceberg/test.rs
+++ b/src/connector/src/sink/iceberg/test.rs
@@ -27,10 +27,7 @@ use risingwave_common::catalog::{Field, Schema};
 use risingwave_common::types::{DataType, MapType, StructType};
 
 use crate::connector_common::{IcebergCommon, IcebergTableIdentifier};
-use crate::sink::decouple_checkpoint_log_sink::{
-    ICEBERG_DEFAULT_COMMIT_CHECKPOINT_INTERVAL,
-    ICEBERG_DEFAULT_COMMIT_CHECKPOINT_SIZE_THRESHOLD_MB,
-};
+use crate::sink::decouple_checkpoint_log_sink::ICEBERG_DEFAULT_COMMIT_CHECKPOINT_INTERVAL;
 use crate::sink::iceberg::{
     CompactionType, DEFAULT_COMPACTION_MAX_SNAPSHOTS_NUM,
     ICEBERG_DEFAULT_WRITE_PARQUET_MAX_ROW_GROUP_BYTES, IcebergConfig, IcebergOrderKeyField,
@@ -379,7 +376,7 @@ fn test_parse_iceberg_config() {
                 .map(|(k, v)| (k.to_owned(), v.to_owned()))
                 .collect(),
             commit_checkpoint_interval: ICEBERG_DEFAULT_COMMIT_CHECKPOINT_INTERVAL,
-            commit_checkpoint_size_threshold_mb: ICEBERG_DEFAULT_COMMIT_CHECKPOINT_SIZE_THRESHOLD_MB,
+            commit_checkpoint_size_threshold_mb: None,
             create_table_if_not_exists: false,
             is_exactly_once: Some(true),
             commit_retry_num: 8,

--- a/src/connector/src/sink/iceberg/test.rs
+++ b/src/connector/src/sink/iceberg/test.rs
@@ -27,7 +27,10 @@ use risingwave_common::catalog::{Field, Schema};
 use risingwave_common::types::{DataType, MapType, StructType};
 
 use crate::connector_common::{IcebergCommon, IcebergTableIdentifier};
-use crate::sink::decouple_checkpoint_log_sink::ICEBERG_DEFAULT_COMMIT_CHECKPOINT_INTERVAL;
+use crate::sink::decouple_checkpoint_log_sink::{
+    ICEBERG_DEFAULT_COMMIT_CHECKPOINT_INTERVAL,
+    ICEBERG_DEFAULT_COMMIT_CHECKPOINT_SIZE_THRESHOLD_MB,
+};
 use crate::sink::iceberg::{
     CompactionType, DEFAULT_COMPACTION_MAX_SNAPSHOTS_NUM,
     ICEBERG_DEFAULT_WRITE_PARQUET_MAX_ROW_GROUP_BYTES, IcebergConfig, IcebergOrderKeyField,
@@ -376,6 +379,7 @@ fn test_parse_iceberg_config() {
                 .map(|(k, v)| (k.to_owned(), v.to_owned()))
                 .collect(),
             commit_checkpoint_interval: ICEBERG_DEFAULT_COMMIT_CHECKPOINT_INTERVAL,
+            commit_checkpoint_size_threshold_mb: ICEBERG_DEFAULT_COMMIT_CHECKPOINT_SIZE_THRESHOLD_MB,
             create_table_if_not_exists: false,
             is_exactly_once: Some(true),
             commit_retry_num: 8,

--- a/src/connector/src/sink/iceberg/writer.rs
+++ b/src/connector/src/sink/iceberg/writer.rs
@@ -247,6 +247,7 @@ pub struct IcebergSinkWriterInner {
     // For chunk with extra partition column, we should remove this column before write.
     // This project index vec is used to avoid create project idx each time.
     project_idx_vec: ProjectIdxVec,
+    uncommitted_write_bytes: u64,
 }
 
 enum IcebergWriterDispatch {
@@ -445,6 +446,7 @@ impl IcebergSinkWriterInner {
                     ProjectIdxVec::None
                 }
             },
+            uncommitted_write_bytes: 0,
         })
     }
 
@@ -659,6 +661,7 @@ impl IcebergSinkWriterInner {
             sink_name: sink_name.clone(),
             table_name,
             writer_mode: "upsert",
+            uncommitted_write_bytes: 0,
         })
     }
 
@@ -781,6 +784,7 @@ impl IcebergSinkWriterInner {
                     "iceberg_sink_writer_write_failed",
                 );
             })?;
+        self.uncommitted_write_bytes += write_batch_size as u64;
         self.metrics.write_bytes.inc_by(write_batch_size as _);
         Ok(())
     }
@@ -822,6 +826,7 @@ impl IcebergSinkWriterInner {
                     "iceberg_sink_writer_write_with_position_failed",
                 );
             })?;
+        self.uncommitted_write_bytes += write_batch_size as u64;
         self.metrics.write_bytes.inc_by(write_batch_size as _);
         Ok(positions)
     }
@@ -896,6 +901,10 @@ impl IcebergSinkWriterInner {
                 close_result
             }
         };
+        // All buffered data has been flushed to data files, so reset the uncommitted byte
+        // counter. `close()` is the single flush point shared by both the coordinated-sink
+        // barrier path and the V3 writer-executor flush path.
+        self.uncommitted_write_bytes = 0;
         Ok(res)
     }
 
@@ -946,6 +955,13 @@ impl SinkWriter for IcebergSinkWriter {
             unreachable!("IcebergSinkWriter should be initialized before barrier");
         };
         inner.write_batch(chunk).await
+    }
+
+    fn buffered_bytes(&self) -> u64 {
+        match self {
+            Self::Initialized(inner) => inner.uncommitted_write_bytes,
+            Self::Created(_) => 0,
+        }
     }
 
     /// Receive a barrier and mark the end of current epoch. When `is_checkpoint` is true, the sink

--- a/src/connector/src/sink/writer.rs
+++ b/src/connector/src/sink/writer.rs
@@ -43,6 +43,12 @@ pub trait SinkWriter: Send + 'static {
     /// writer should commit the current epoch.
     async fn barrier(&mut self, is_checkpoint: bool) -> Result<Self::CommitMetadata>;
 
+    /// Return the number of uncommitted write bytes buffered by this writer.
+    /// Defaults to 0 for sinks that don't track buffered bytes.
+    fn buffered_bytes(&self) -> u64 {
+        0
+    }
+
     /// Clean up
     async fn abort(&mut self) -> Result<()> {
         Ok(())

--- a/src/connector/with_options_sink.yaml
+++ b/src/connector/with_options_sink.yaml
@@ -697,10 +697,10 @@ IcebergConfig:
     comments: |-
       Commit on the next checkpoint barrier after total buffered write size across all
       writers exceeds this threshold in MiB. The coordinator sums per-writer byte reports
-      and broadcasts the same commit decision to all writers. Default 512 MiB.
-      Set to 0 to disable size-based early commits.
+      and broadcasts the same commit decision to all writers. Size-based commits are
+      opt-in: leaving this unset (or setting it to 0) disables them.
     required: false
-    default: ICEBERG_DEFAULT_COMMIT_CHECKPOINT_SIZE_THRESHOLD_MB
+    default: Default::default
     allow_alter_on_fly: true
     iceberg_engine: true
   - name: create_table_if_not_exists

--- a/src/connector/with_options_sink.yaml
+++ b/src/connector/with_options_sink.yaml
@@ -692,6 +692,17 @@ IcebergConfig:
     default: ICEBERG_DEFAULT_COMMIT_CHECKPOINT_INTERVAL
     allow_alter_on_fly: true
     iceberg_engine: true
+  - name: commit_checkpoint_size_threshold_mb
+    field_type: u64
+    comments: |-
+      Commit on the next checkpoint barrier after total buffered write size across all
+      writers exceeds this threshold in MiB. The coordinator sums per-writer byte reports
+      and broadcasts the same commit decision to all writers. Default 512 MiB.
+      Set to 0 to disable size-based early commits.
+    required: false
+    default: ICEBERG_DEFAULT_COMMIT_CHECKPOINT_SIZE_THRESHOLD_MB
+    allow_alter_on_fly: true
+    iceberg_engine: true
   - name: create_table_if_not_exists
     field_type: bool
     required: false

--- a/src/connector/with_options_sink.yaml
+++ b/src/connector/with_options_sink.yaml
@@ -695,10 +695,19 @@ IcebergConfig:
   - name: commit_checkpoint_size_threshold_mb
     field_type: u64
     comments: |-
-      Commit on the next checkpoint barrier after total buffered write size across all
-      writers exceeds this threshold in MiB. The coordinator sums per-writer byte reports
-      and broadcasts the same commit decision to all writers. Size-based commits are
-      opt-in: leaving this unset (or setting it to 0) disables them.
+      Commit on the next checkpoint barrier after total buffered write size across
+      all writers exceeds this threshold in `MiB`. The coordinator sums per-writer
+      byte reports and broadcasts the same commit decision to all writers, ensuring
+      vnode-aligned commits at the same epoch.
+
+      Size-based commits are opt-in: leaving this unset (or setting it to `0`)
+      disables them, and commits are driven solely by `commit_checkpoint_interval`.
+      The threshold applies to the *sum* across all parallel writers, not any
+      single writer, so each writer's own output file will typically be around
+      `threshold / sink_parallelism` once the aggregate crosses the threshold.
+      Size accordingly to land in Iceberg's recommended on-disk file size range
+      (128-512 `MiB`), accounting for the ~3-10x in-memory-to-columnar-compressed
+      ratio and the sink's parallelism.
     required: false
     default: Default::default
     allow_alter_on_fly: true

--- a/src/meta/src/manager/sink_coordination/coordinator_worker.rs
+++ b/src/meta/src/manager/sink_coordination/coordinator_worker.rs
@@ -114,7 +114,8 @@ impl<R> AligningRequests<R> {
             !self.requests.iter().any(|(hid, _, _)| *hid == handle_id),
             "handle {handle_id} already has a pending request for this epoch"
         );
-        self.requests.push((handle_id, vnode_bitmap.clone(), request));
+        self.requests
+            .push((handle_id, vnode_bitmap.clone(), request));
         Ok(())
     }
 
@@ -142,10 +143,7 @@ impl<R> AligningRequests<R> {
         };
     }
 
-    fn sync_with_running_handles(
-        &mut self,
-        get_vnode_bitmap: impl Fn(HandleId) -> Option<Bitmap>,
-    ) {
+    fn sync_with_running_handles(&mut self, get_vnode_bitmap: impl Fn(HandleId) -> Option<Bitmap>) {
         for (hid, bitmap, _) in &mut self.requests {
             if let Some(current) = get_vnode_bitmap(*hid) {
                 *bitmap = current;
@@ -392,13 +390,15 @@ impl CoordinationHandleManager {
                     epoch
                 )
             })?;
-            handle.send_report_bytes_response(epoch, should_commit).map_err(|_| {
-                anyhow!(
-                    "fail to send report bytes response on epoch {} for handle {}",
-                    epoch,
-                    handle_id
-                )
-            })?;
+            handle
+                .send_report_bytes_response(epoch, should_commit)
+                .map_err(|_| {
+                    anyhow!(
+                        "fail to send report bytes response on epoch {} for handle {}",
+                        epoch,
+                        handle_id
+                    )
+                })?;
         }
         Ok(())
     }
@@ -768,11 +768,14 @@ impl CoordinatorWorker {
         self.try_handle_init_requests(&running_handles, &mut two_phase_handler)
             .await?;
 
-        let commit_checkpoint_size_threshold_bytes: Option<u64> =
-            self.handle_manager.param.properties.get(COMMIT_CHECKPOINT_SIZE_THRESHOLD_MB)
-                .and_then(|v| v.parse::<u64>().ok())
-                .filter(|&mb| mb > 0)
-                .map(|mb| mb.saturating_mul(1024 * 1024));
+        let commit_checkpoint_size_threshold_bytes: Option<u64> = self
+            .handle_manager
+            .param
+            .properties
+            .get(COMMIT_CHECKPOINT_SIZE_THRESHOLD_MB)
+            .and_then(|v| v.parse::<u64>().ok())
+            .filter(|&mb| mb > 0)
+            .map(|mb| mb.saturating_mul(1024 * 1024));
 
         let mut pending_epochs: BTreeMap<u64, AligningRequests<_>> = BTreeMap::new();
         let mut pending_byte_reports: BTreeMap<u64, AligningRequests<u64>> = BTreeMap::new();
@@ -875,7 +878,8 @@ impl CoordinatorWorker {
                         {
                             let (report_epoch, reports) =
                                 pending_byte_reports.pop_first().expect("non-empty");
-                            let total_bytes: u64 = reports.requests.iter().map(|(_, _, b)| *b).sum();
+                            let total_bytes: u64 =
+                                reports.requests.iter().map(|(_, _, b)| *b).sum();
                             let should_commit =
                                 commit_checkpoint_size_threshold_bytes.is_some_and(|threshold| {
                                     total_bytes > 0 && total_bytes >= threshold
@@ -1051,8 +1055,7 @@ impl CoordinatorWorker {
                     }
                 }
 
-                self.handle_manager
-                    .ack_commit(epoch, handle_ids)?;
+                self.handle_manager.ack_commit(epoch, handle_ids)?;
                 self.last_writer_acked_epoch = Some(epoch);
             }
         }

--- a/src/meta/src/manager/sink_coordination/coordinator_worker.rs
+++ b/src/meta/src/manager/sink_coordination/coordinator_worker.rs
@@ -29,6 +29,7 @@ use risingwave_common::bitmap::Bitmap;
 use risingwave_connector::connector_common::IcebergSinkCompactionUpdate;
 use risingwave_connector::dispatch_sink;
 use risingwave_connector::sink::catalog::SinkId;
+use risingwave_connector::sink::iceberg::COMMIT_CHECKPOINT_SIZE_THRESHOLD_MB;
 use risingwave_connector::sink::{
     Sink, SinkCommitCoordinator, SinkCommittedEpochSubscriber, SinkError, SinkParam, build_sink,
 };
@@ -68,11 +69,18 @@ async fn run_future_with_periodic_fn<F: Future>(
 
 type HandleId = usize;
 
-#[derive(Default)]
 struct AligningRequests<R> {
-    requests: Vec<R>,
-    handle_ids: HashSet<HandleId>,
+    requests: Vec<(HandleId, Bitmap, R)>,
     committed_bitmap: Option<Bitmap>, // lazy-initialized on first request
+}
+
+impl<R> Default for AligningRequests<R> {
+    fn default() -> Self {
+        Self {
+            requests: Vec::default(),
+            committed_bitmap: None,
+        }
+    }
 }
 
 impl<R> AligningRequests<R> {
@@ -97,18 +105,55 @@ impl<R> AligningRequests<R> {
                 check_bitmap.iter_ones().collect_vec(),
                 vnode_bitmap,
                 committed_bitmap,
-                self.requests,
+                self.requests.iter().map(|(_, _, r)| r).collect::<Vec<_>>(),
                 request
             ));
         }
         *committed_bitmap |= vnode_bitmap;
-        self.requests.push(request);
-        assert!(self.handle_ids.insert(handle_id));
+        assert!(
+            !self.requests.iter().any(|(hid, _, _)| *hid == handle_id),
+            "handle {handle_id} already has a pending request for this epoch"
+        );
+        self.requests.push((handle_id, vnode_bitmap.clone(), request));
         Ok(())
     }
 
     fn aligned(&self) -> bool {
         self.committed_bitmap.as_ref().is_some_and(|b| b.all())
+    }
+
+    fn handle_ids(&self) -> impl Iterator<Item = HandleId> + '_ {
+        self.requests.iter().map(|(hid, _, _)| *hid)
+    }
+
+    fn is_empty(&self) -> bool {
+        self.requests.is_empty()
+    }
+
+    fn recompute_committed_bitmap(&mut self) {
+        self.committed_bitmap = if self.requests.is_empty() {
+            None
+        } else {
+            let mut bitmap = self.requests[0].1.clone();
+            for (_, b, _) in &self.requests[1..] {
+                bitmap |= b;
+            }
+            Some(bitmap)
+        };
+    }
+
+    fn sync_with_running_handles(
+        &mut self,
+        get_vnode_bitmap: impl Fn(HandleId) -> Option<Bitmap>,
+    ) {
+        for (hid, bitmap, _) in &mut self.requests {
+            if let Some(current) = get_vnode_bitmap(*hid) {
+                *bitmap = current;
+            }
+        }
+        self.requests
+            .retain(|(hid, _, _)| get_vnode_bitmap(*hid).is_some());
+        self.recompute_committed_bitmap();
     }
 }
 
@@ -333,6 +378,31 @@ impl CoordinationHandleManager {
         Ok(())
     }
 
+    fn send_report_bytes_response(
+        &mut self,
+        epoch: u64,
+        should_commit: bool,
+        handle_ids: impl IntoIterator<Item = HandleId>,
+    ) -> anyhow::Result<()> {
+        for handle_id in handle_ids {
+            let handle = self.writer_handles.get_mut(&handle_id).ok_or_else(|| {
+                anyhow!(
+                    "fail to find handle for {} when sending report bytes response on epoch {}",
+                    handle_id,
+                    epoch
+                )
+            })?;
+            handle.send_report_bytes_response(epoch, should_commit).map_err(|_| {
+                anyhow!(
+                    "fail to send report bytes response on epoch {} for handle {}",
+                    epoch,
+                    handle_id
+                )
+            })?;
+        }
+        Ok(())
+    }
+
     async fn next_request_inner(
         writer_handles: &mut HashMap<HandleId, SinkWriterCoordinationHandle>,
     ) -> anyhow::Result<(HandleId, coordinate_request::Msg)> {
@@ -357,6 +427,10 @@ enum CoordinationHandleManagerEvent {
         metadata: SinkMetadata,
         schema_change: Option<PbSinkSchemaChange>,
     },
+    ReportBytes {
+        epoch: u64,
+        buffered_bytes: u64,
+    },
     AlignInitialEpoch(u64),
 }
 
@@ -367,6 +441,7 @@ impl CoordinationHandleManagerEvent {
             CoordinationHandleManagerEvent::UpdateVnodeBitmap => "UpdateVnodeBitmap",
             CoordinationHandleManagerEvent::Stop => "Stop",
             CoordinationHandleManagerEvent::CommitRequest { .. } => "CommitRequest",
+            CoordinationHandleManagerEvent::ReportBytes { .. } => "ReportBytes",
             CoordinationHandleManagerEvent::AlignInitialEpoch(_) => "AlignInitialEpoch",
         }
     }
@@ -391,8 +466,14 @@ impl CoordinationHandleManager {
                     coordinate_request::Msg::CommitRequest(request) => {
                         CoordinationHandleManagerEvent::CommitRequest {
                             epoch: request.epoch,
-                            metadata: request.metadata.ok_or_else(|| anyhow!("empty sink metadata"))?,
+                            metadata: request.metadata.unwrap(),
                             schema_change: request.schema_change,
+                        }
+                    }
+                    coordinate_request::Msg::ReportBytesRequest(request) => {
+                        CoordinationHandleManagerEvent::ReportBytes {
+                            epoch: request.epoch,
+                            buffered_bytes: request.buffered_bytes,
                         }
                     }
                     coordinate_request::Msg::AlignInitialEpochRequest(epoch) => {
@@ -441,7 +522,7 @@ impl CoordinationHandleManager {
                 unexpected_event
             ));
         }
-        Ok(init_requests.handle_ids)
+        Ok(init_requests.handle_ids().collect())
     }
 
     async fn alter_parallelisms(
@@ -455,7 +536,7 @@ impl CoordinationHandleManager {
         let mut remaining_handles: HashSet<_> = self
             .writer_handles
             .keys()
-            .filter(|handle_id| !requests.handle_ids.contains(handle_id))
+            .filter(|handle_id| !requests.handle_ids().any(|h| h == **handle_id))
             .cloned()
             .collect();
         while !remaining_handles.is_empty() || !requests.aligned() {
@@ -479,6 +560,13 @@ impl CoordinationHandleManager {
                         handle_id
                     );
                 }
+                CoordinationHandleManagerEvent::ReportBytes { epoch, .. } => {
+                    bail!(
+                        "receive ReportBytes on epoch {} from handle {} during alter parallelism",
+                        epoch,
+                        handle_id
+                    );
+                }
                 CoordinationHandleManagerEvent::AlignInitialEpoch(epoch) => {
                     bail!(
                         "receive AlignInitialEpoch on epoch {} from handle {} during alter parallelism",
@@ -488,7 +576,7 @@ impl CoordinationHandleManager {
                 }
             }
         }
-        Ok(requests.handle_ids)
+        Ok(requests.handle_ids().collect())
     }
 }
 
@@ -626,6 +714,7 @@ impl CoordinatorWorker {
             let aligned_initial_epoch = align_requests
                 .requests
                 .into_iter()
+                .map(|(_, _, epoch)| epoch)
                 .max()
                 .expect("non-empty");
             self.handle_manager
@@ -679,7 +768,14 @@ impl CoordinatorWorker {
         self.try_handle_init_requests(&running_handles, &mut two_phase_handler)
             .await?;
 
+        let commit_checkpoint_size_threshold_bytes: Option<u64> =
+            self.handle_manager.param.properties.get(COMMIT_CHECKPOINT_SIZE_THRESHOLD_MB)
+                .and_then(|v| v.parse::<u64>().ok())
+                .filter(|&mb| mb > 0)
+                .map(|mb| mb.saturating_mul(1024 * 1024));
+
         let mut pending_epochs: BTreeMap<u64, AligningRequests<_>> = BTreeMap::new();
+        let mut pending_byte_reports: BTreeMap<u64, AligningRequests<u64>> = BTreeMap::new();
         let mut pending_new_handles = vec![];
         loop {
             let event = self.next_event(&mut two_phase_handler).await?;
@@ -696,6 +792,24 @@ impl CoordinatorWorker {
                             .await?;
                         self.try_handle_init_requests(&running_handles, &mut two_phase_handler)
                             .await?;
+                        pending_epochs.retain(|_, align_req| {
+                            align_req.sync_with_running_handles(|hid| {
+                                self.handle_manager
+                                    .writer_handles
+                                    .get(&hid)
+                                    .map(|h| h.vnode_bitmap().clone())
+                            });
+                            !align_req.is_empty()
+                        });
+                        pending_byte_reports.retain(|_, align_req| {
+                            align_req.sync_with_running_handles(|hid| {
+                                self.handle_manager
+                                    .writer_handles
+                                    .get(&hid)
+                                    .map(|h| h.vnode_bitmap().clone())
+                            });
+                            !align_req.is_empty()
+                        });
                         continue;
                     }
                     CoordinationHandleManagerEvent::Stop => {
@@ -706,7 +820,24 @@ impl CoordinatorWorker {
                             .await?;
                         self.try_handle_init_requests(&running_handles, &mut two_phase_handler)
                             .await?;
-
+                        pending_epochs.retain(|_, align_req| {
+                            align_req.sync_with_running_handles(|hid| {
+                                self.handle_manager
+                                    .writer_handles
+                                    .get(&hid)
+                                    .map(|h| h.vnode_bitmap().clone())
+                            });
+                            !align_req.is_empty()
+                        });
+                        pending_byte_reports.retain(|_, align_req| {
+                            align_req.sync_with_running_handles(|hid| {
+                                self.handle_manager
+                                    .writer_handles
+                                    .get(&hid)
+                                    .map(|h| h.vnode_bitmap().clone())
+                            });
+                            !align_req.is_empty()
+                        });
                         continue;
                     }
                     CoordinationHandleManagerEvent::CommitRequest {
@@ -716,6 +847,46 @@ impl CoordinatorWorker {
                     } => (handle_id, epoch, (metadata, schema_change)),
                     CoordinationHandleManagerEvent::AlignInitialEpoch(_) => {
                         bail!("receive AlignInitialEpoch after initialization")
+                    }
+                    CoordinationHandleManagerEvent::ReportBytes {
+                        epoch,
+                        buffered_bytes,
+                    } => {
+                        if !running_handles.contains(&handle_id) {
+                            bail!(
+                                "receiving report bytes from non-running handle {}, running handles: {:?}",
+                                handle_id,
+                                running_handles
+                            );
+                        }
+                        pending_byte_reports
+                            .entry(epoch)
+                            .or_default()
+                            .add_new_request(
+                                handle_id,
+                                buffered_bytes,
+                                self.handle_manager.vnode_bitmap(handle_id),
+                            )?;
+                        if pending_byte_reports
+                            .first_key_value()
+                            .expect("non-empty")
+                            .1
+                            .aligned()
+                        {
+                            let (report_epoch, reports) =
+                                pending_byte_reports.pop_first().expect("non-empty");
+                            let total_bytes: u64 = reports.requests.iter().map(|(_, _, b)| *b).sum();
+                            let should_commit =
+                                commit_checkpoint_size_threshold_bytes.is_some_and(|threshold| {
+                                    total_bytes > 0 && total_bytes >= threshold
+                                });
+                            self.handle_manager.send_report_bytes_response(
+                                report_epoch,
+                                should_commit,
+                                reports.handle_ids(),
+                            )?;
+                        }
+                        continue;
                     }
                 },
                 CoordinatorWorkerEvent::ReadyToCommit(epoch, metadata, schema_change) => {
@@ -802,10 +973,12 @@ impl CoordinatorWorker {
             {
                 let (epoch, commit_requests) = pending_epochs.pop_first().expect("non-empty");
                 let mut metadatas = Vec::with_capacity(commit_requests.requests.len());
+                let handle_ids: Vec<HandleId> = commit_requests.handle_ids().collect();
                 let mut requests = commit_requests.requests.into_iter();
-                let (first_metadata, first_schema_change) = requests.next().expect("non-empty");
+                let (_, _, (first_metadata, first_schema_change)) =
+                    requests.next().expect("non-empty");
                 metadatas.push(first_metadata);
-                for (metadata, schema_change) in requests {
+                for (_, _, (metadata, schema_change)) in requests {
                     if first_schema_change != schema_change {
                         return Err(anyhow!(
                             "got different schema change {:?} to prev schema change {:?}",
@@ -879,7 +1052,7 @@ impl CoordinatorWorker {
                 }
 
                 self.handle_manager
-                    .ack_commit(epoch, commit_requests.handle_ids)?;
+                    .ack_commit(epoch, handle_ids)?;
                 self.last_writer_acked_epoch = Some(epoch);
             }
         }

--- a/src/meta/src/manager/sink_coordination/handle.rs
+++ b/src/meta/src/manager/sink_coordination/handle.rs
@@ -102,6 +102,23 @@ impl SinkWriterCoordinationHandle {
             .map_err(|_| anyhow!("fail to send commit response of epoch {}", epoch))
     }
 
+    pub(super) fn send_report_bytes_response(
+        &mut self,
+        epoch: u64,
+        should_commit: bool,
+    ) -> anyhow::Result<()> {
+        self.response_tx
+            .send(Ok(CoordinateResponse {
+                msg: Some(coordinate_response::Msg::ReportBytesResponse(
+                    coordinate_response::ReportBytesResponse {
+                        epoch,
+                        should_commit,
+                    },
+                )),
+            }))
+            .map_err(|_| anyhow!("fail to send report bytes response"))
+    }
+
     pub(super) fn stop(&mut self) -> anyhow::Result<()> {
         self.response_tx
             .send(Ok(CoordinateResponse {
@@ -122,7 +139,8 @@ impl SinkWriterCoordinationHandle {
             match &request {
                 coordinate_request::Msg::StartRequest(_)
                 | coordinate_request::Msg::Stop(_)
-                | coordinate_request::Msg::AlignInitialEpochRequest(_) => {}
+                | coordinate_request::Msg::AlignInitialEpochRequest(_)
+                | coordinate_request::Msg::ReportBytesRequest(_) => {}
                 coordinate_request::Msg::CommitRequest(request) => {
                     if let Some(prev_epoch) = self.prev_epoch
                         && request.epoch < prev_epoch

--- a/src/meta/src/manager/sink_coordination/manager.rs
+++ b/src/meta/src/manager/sink_coordination/manager.rs
@@ -403,6 +403,7 @@ impl ManagerWorker {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::BTreeMap;
     use std::future::{Future, poll_fn};
     use std::pin::pin;
     use std::sync::Arc;
@@ -418,6 +419,7 @@ mod tests {
     use risingwave_common::bitmap::BitmapBuilder;
     use risingwave_common::hash::VirtualNode;
     use risingwave_connector::sink::catalog::{SinkId, SinkType};
+    use risingwave_connector::sink::iceberg::COMMIT_CHECKPOINT_SIZE_THRESHOLD_MB;
     use risingwave_connector::sink::{
         SinglePhaseCommitCoordinator, SinkCommitCoordinator, SinkError, SinkParam,
         TwoPhaseCommitCoordinator,
@@ -955,6 +957,262 @@ mod tests {
         );
         drop(client2);
         assert!(commit_future.await.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_size_based_commit_via_coordinator() {
+        let db = prepare_db_backend().await;
+
+        let mut properties = BTreeMap::new();
+        properties.insert(
+            COMMIT_CHECKPOINT_SIZE_THRESHOLD_MB.to_owned(),
+            "1".to_owned(),
+        );
+
+        let param = SinkParam {
+            sink_id: SinkId::from(1),
+            sink_name: "test".into(),
+            properties,
+            columns: vec![],
+            downstream_pk: None,
+            sink_type: SinkType::AppendOnly,
+            ignore_delete: false,
+            format_desc: None,
+            db_name: "test".into(),
+            sink_from_name: "test".into(),
+        };
+
+        let epoch1 = 233;
+        let epoch2 = 234;
+        let epoch3 = 235;
+
+        let mut all_vnode = (0..VirtualNode::COUNT_FOR_TEST).collect_vec();
+        all_vnode.shuffle(&mut rand::rng());
+        let (first, second) = all_vnode.split_at(VirtualNode::COUNT_FOR_TEST / 2);
+        let build_bitmap = |indexes: &[usize]| {
+            let mut builder = BitmapBuilder::zeroed(VirtualNode::COUNT_FOR_TEST);
+            for i in indexes {
+                builder.set(*i, true);
+            }
+            builder.finish()
+        };
+        let vnode1 = build_bitmap(first);
+        let vnode2 = build_bitmap(second);
+
+        let metadata = [
+            [vec![1u8, 2u8], vec![3u8, 4u8]],
+            [vec![5u8, 6u8], vec![]],
+        ];
+        let sender = Arc::new(tokio::sync::Mutex::new(None));
+        let mock_subscriber: SinkCommittedEpochSubscriber = {
+            let captured_sender = sender.clone();
+            Arc::new(move |_sink_id: SinkId| {
+                let (sender, receiver) = unbounded_channel();
+                let captured_sender = captured_sender.clone();
+                async move {
+                    let mut guard = captured_sender.lock().await;
+                    *guard = Some(sender);
+                    Ok((1, receiver))
+                }
+                .boxed()
+            })
+        };
+
+        let (manager, (_join_handle, _stop_tx)) =
+            SinkCoordinatorManager::start_worker_with_spawn_worker({
+                let expected_param = param.clone();
+                let metadata = metadata.clone();
+                let db = db.clone();
+                move |param, new_writer_rx| {
+                    let metadata = metadata.clone();
+                    let expected_param = expected_param.clone();
+                    let db = db.clone();
+                    tokio::spawn({
+                        let subscriber = mock_subscriber.clone();
+                        async move {
+                            assert_eq!(param, expected_param);
+                            CoordinatorWorker::execute_coordinator(
+                                db,
+                                param.clone(),
+                                new_writer_rx,
+                                MockSinglePhaseCoordinator::new_coordinator(
+                                    0,
+                                    move |epoch, metadata_list, count: &mut usize| {
+                                        *count += 1;
+                                        let mut metadata_list =
+                                            metadata_list
+                                                .into_iter()
+                                                .map(|m| match m {
+                                                    SinkMetadata {
+                                                        metadata:
+                                                            Some(Metadata::Serialized(
+                                                                SerializedMetadata { metadata },
+                                                            )),
+                                                    } => metadata,
+                                                    _ => unreachable!(),
+                                                })
+                                                .collect_vec();
+                                        metadata_list.sort();
+                                        match *count {
+                                            1 => {
+                                                assert_eq!(epoch, epoch2);
+                                                assert_eq!(2, metadata_list.len());
+                                                assert_eq!(metadata[0][0], metadata_list[0]);
+                                                assert_eq!(metadata[0][1], metadata_list[1]);
+                                            }
+                                            2 => {
+                                                assert_eq!(epoch, epoch3);
+                                                assert_eq!(2, metadata_list.len());
+                                                assert_eq!(metadata[1][1], metadata_list[0]);
+                                                assert_eq!(metadata[1][0], metadata_list[1]);
+                                            }
+                                            _ => unreachable!(),
+                                        }
+                                        Ok(())
+                                    },
+                                ),
+                                subscriber.clone(),
+                            )
+                            .await;
+                        }
+                    })
+                }
+            });
+
+        let build_client = |vnode| async {
+            CoordinatorStreamHandle::new_with_init_stream(param.to_proto(), vnode, |rx| async {
+                Ok(tonic::Response::new(
+                    manager
+                        .handle_new_request(ReceiverStream::new(rx).map(Ok).boxed())
+                        .await
+                        .unwrap()
+                        .boxed(),
+                ))
+            })
+            .await
+            .unwrap()
+            .0
+        };
+
+        let (mut client1, mut client2) =
+            join(build_client(vnode1), pin!(build_client(vnode2))).await;
+
+        let (aligned_epoch1, aligned_epoch2) = try_join(
+            client1.align_initial_epoch(epoch1),
+            client2.align_initial_epoch(epoch1),
+        )
+        .await
+        .unwrap();
+        assert_eq!(aligned_epoch1, epoch1);
+        assert_eq!(aligned_epoch2, epoch1);
+
+        // Report bytes below the 1MB threshold: each writer reports 400KB,
+        // total 800KB < 1MB → should_commit=false
+        {
+            let mut report_future1 = pin!(client1.report_bytes(epoch1, 409600));
+            assert!(
+                poll_fn(|cx| Poll::Ready(report_future1.as_mut().poll(cx)))
+                    .await
+                    .is_pending()
+            );
+            let (result1, result2) = join(
+                report_future1,
+                client2.report_bytes(epoch1, 409600),
+            )
+            .await;
+            assert!(!result1.unwrap());
+            assert!(!result2.unwrap());
+        }
+
+        // Report bytes exceeding the 1MB threshold: each writer reports 600KB,
+        // total 1.2MB ≥ 1MB → should_commit=true
+        {
+            let mut report_future1 = pin!(client1.report_bytes(epoch2, 614400));
+            assert!(
+                poll_fn(|cx| Poll::Ready(report_future1.as_mut().poll(cx)))
+                    .await
+                    .is_pending()
+            );
+            let (result1, result2) = join(
+                report_future1,
+                client2.report_bytes(epoch2, 614400),
+            )
+            .await;
+            assert!(result1.unwrap());
+            assert!(result2.unwrap());
+        }
+
+        // Both writers commit at the same epoch after should_commit=true
+        {
+            let mut commit_future = pin!(
+                client2
+                    .commit(
+                        epoch2,
+                        SinkMetadata {
+                            metadata: Some(Metadata::Serialized(SerializedMetadata {
+                                metadata: metadata[0][1].clone(),
+                            })),
+                        },
+                        None,
+                    )
+                    .map(|result| result.unwrap())
+            );
+            assert!(
+                poll_fn(|cx| Poll::Ready(commit_future.as_mut().poll(cx)))
+                    .await
+                    .is_pending()
+            );
+            join(
+                commit_future,
+                client1
+                    .commit(
+                        epoch2,
+                        SinkMetadata {
+                            metadata: Some(Metadata::Serialized(SerializedMetadata {
+                                metadata: metadata[0][0].clone(),
+                            })),
+                        },
+                        None,
+                    )
+                    .map(|result| result.unwrap()),
+            )
+            .await;
+        }
+
+        // Next round: report bytes above threshold again and commit at epoch3
+        {
+            let (result1, result2) = join(
+                client1.report_bytes(epoch3, 2_000_000),
+                client2.report_bytes(epoch3, 2_000_000),
+            )
+            .await;
+            assert!(result1.unwrap());
+            assert!(result2.unwrap());
+
+            let (result1, result2) = join(
+                client1.commit(
+                    epoch3,
+                    SinkMetadata {
+                        metadata: Some(Metadata::Serialized(SerializedMetadata {
+                            metadata: metadata[1][0].clone(),
+                        })),
+                    },
+                    None,
+                ),
+                client2.commit(
+                    epoch3,
+                    SinkMetadata {
+                        metadata: Some(Metadata::Serialized(SerializedMetadata {
+                            metadata: metadata[1][1].clone(),
+                        })),
+                    },
+                    None,
+                ),
+            )
+            .await;
+            result1.unwrap();
+            result2.unwrap();
+        }
     }
 
     #[tokio::test]

--- a/src/meta/src/manager/sink_coordination/manager.rs
+++ b/src/meta/src/manager/sink_coordination/manager.rs
@@ -1215,6 +1215,206 @@ mod tests {
         }
     }
 
+    /// Regression test: a writer with an empty buffer must still report zero bytes,
+    /// and the coordinator must align the epoch with such zero-byte reports included.
+    /// Skipping the report on the writer side used to leave the epoch unaligned
+    /// forever, head-of-line-blocking all subsequent epochs and deadlocking the sink.
+    #[tokio::test]
+    async fn test_size_based_commit_with_zero_byte_report() {
+        let db = prepare_db_backend().await;
+
+        let mut properties = BTreeMap::new();
+        properties.insert(
+            COMMIT_CHECKPOINT_SIZE_THRESHOLD_MB.to_owned(),
+            "1".to_owned(),
+        );
+
+        let param = SinkParam {
+            sink_id: SinkId::from(1),
+            sink_name: "test".into(),
+            properties,
+            columns: vec![],
+            downstream_pk: None,
+            sink_type: SinkType::AppendOnly,
+            ignore_delete: false,
+            format_desc: None,
+            db_name: "test".into(),
+            sink_from_name: "test".into(),
+        };
+
+        let epoch1 = 233;
+        let epoch2 = 234;
+
+        let mut all_vnode = (0..VirtualNode::COUNT_FOR_TEST).collect_vec();
+        all_vnode.shuffle(&mut rand::rng());
+        let (first, second) = all_vnode.split_at(VirtualNode::COUNT_FOR_TEST / 2);
+        let build_bitmap = |indexes: &[usize]| {
+            let mut builder = BitmapBuilder::zeroed(VirtualNode::COUNT_FOR_TEST);
+            for i in indexes {
+                builder.set(*i, true);
+            }
+            builder.finish()
+        };
+        let vnode1 = build_bitmap(first);
+        let vnode2 = build_bitmap(second);
+
+        // client1 has no buffered data and commits empty metadata
+        let metadata = [vec![], vec![1u8, 2u8]];
+        let sender = Arc::new(tokio::sync::Mutex::new(None));
+        let mock_subscriber: SinkCommittedEpochSubscriber = {
+            let captured_sender = sender.clone();
+            Arc::new(move |_sink_id: SinkId| {
+                let (sender, receiver) = unbounded_channel();
+                let captured_sender = captured_sender.clone();
+                async move {
+                    let mut guard = captured_sender.lock().await;
+                    *guard = Some(sender);
+                    Ok((1, receiver))
+                }
+                .boxed()
+            })
+        };
+
+        let (manager, (_join_handle, _stop_tx)) =
+            SinkCoordinatorManager::start_worker_with_spawn_worker({
+                let expected_param = param.clone();
+                let metadata = metadata.clone();
+                let db = db.clone();
+                move |param, new_writer_rx| {
+                    let metadata = metadata.clone();
+                    let expected_param = expected_param.clone();
+                    let db = db.clone();
+                    tokio::spawn({
+                        let subscriber = mock_subscriber.clone();
+                        async move {
+                            assert_eq!(param, expected_param);
+                            CoordinatorWorker::execute_coordinator(
+                                db,
+                                param.clone(),
+                                new_writer_rx,
+                                MockSinglePhaseCoordinator::new_coordinator(
+                                    0,
+                                    move |epoch, metadata_list, count: &mut usize| {
+                                        *count += 1;
+                                        let mut metadata_list =
+                                            metadata_list
+                                                .into_iter()
+                                                .map(|m| match m {
+                                                    SinkMetadata {
+                                                        metadata:
+                                                            Some(Metadata::Serialized(
+                                                                SerializedMetadata { metadata },
+                                                            )),
+                                                    } => metadata,
+                                                    _ => unreachable!(),
+                                                })
+                                                .collect_vec();
+                                        metadata_list.sort();
+                                        match *count {
+                                            1 => {
+                                                assert_eq!(epoch, epoch2);
+                                                assert_eq!(2, metadata_list.len());
+                                                assert_eq!(metadata[0], metadata_list[0]);
+                                                assert_eq!(metadata[1], metadata_list[1]);
+                                            }
+                                            _ => unreachable!(),
+                                        }
+                                        Ok(())
+                                    },
+                                ),
+                                subscriber.clone(),
+                            )
+                            .await;
+                        }
+                    })
+                }
+            });
+
+        let build_client = |vnode| async {
+            CoordinatorStreamHandle::new_with_init_stream(param.to_proto(), vnode, |rx| async {
+                Ok(tonic::Response::new(
+                    manager
+                        .handle_new_request(ReceiverStream::new(rx).map(Ok).boxed())
+                        .await
+                        .unwrap()
+                        .boxed(),
+                ))
+            })
+            .await
+            .unwrap()
+            .0
+        };
+
+        let (mut client1, mut client2) =
+            join(build_client(vnode1), pin!(build_client(vnode2))).await;
+
+        let (aligned_epoch1, aligned_epoch2) = try_join(
+            client1.align_initial_epoch(epoch1),
+            client2.align_initial_epoch(epoch1),
+        )
+        .await
+        .unwrap();
+        assert_eq!(aligned_epoch1, epoch1);
+        assert_eq!(aligned_epoch2, epoch1);
+
+        // client1 has an empty buffer and reports 0 bytes. The epoch must still
+        // align, and total 500KB < 1MB → should_commit=false for both writers.
+        {
+            let mut report_future1 = pin!(client1.report_bytes(epoch1, 0));
+            assert!(
+                poll_fn(|cx| Poll::Ready(report_future1.as_mut().poll(cx)))
+                    .await
+                    .is_pending()
+            );
+            let (result1, result2) = join(
+                report_future1,
+                client2.report_bytes(epoch1, 512000),
+            )
+            .await;
+            assert!(!result1.unwrap());
+            assert!(!result2.unwrap());
+        }
+
+        // client1 still has an empty buffer, but client2 alone exceeds the
+        // threshold → should_commit=true for both writers.
+        {
+            let (result1, result2) = join(
+                client1.report_bytes(epoch2, 0),
+                client2.report_bytes(epoch2, 2_000_000),
+            )
+            .await;
+            assert!(result1.unwrap());
+            assert!(result2.unwrap());
+        }
+
+        // Both writers commit at epoch2; client1 commits empty metadata.
+        {
+            let (result1, result2) = join(
+                client1.commit(
+                    epoch2,
+                    SinkMetadata {
+                        metadata: Some(Metadata::Serialized(SerializedMetadata {
+                            metadata: metadata[0].clone(),
+                        })),
+                    },
+                    None,
+                ),
+                client2.commit(
+                    epoch2,
+                    SinkMetadata {
+                        metadata: Some(Metadata::Serialized(SerializedMetadata {
+                            metadata: metadata[1].clone(),
+                        })),
+                    },
+                    None,
+                ),
+            )
+            .await;
+            result1.unwrap();
+            result2.unwrap();
+        }
+    }
+
     #[tokio::test]
     async fn test_fail_commit() {
         let db = prepare_db_backend().await;

--- a/src/meta/src/manager/sink_coordination/manager.rs
+++ b/src/meta/src/manager/sink_coordination/manager.rs
@@ -999,10 +999,7 @@ mod tests {
         let vnode1 = build_bitmap(first);
         let vnode2 = build_bitmap(second);
 
-        let metadata = [
-            [vec![1u8, 2u8], vec![3u8, 4u8]],
-            [vec![5u8, 6u8], vec![]],
-        ];
+        let metadata = [[vec![1u8, 2u8], vec![3u8, 4u8]], [vec![5u8, 6u8], vec![]]];
         let sender = Arc::new(tokio::sync::Mutex::new(None));
         let mock_subscriber: SinkCommittedEpochSubscriber = {
             let captured_sender = sender.clone();
@@ -1115,11 +1112,8 @@ mod tests {
                     .await
                     .is_pending()
             );
-            let (result1, result2) = join(
-                report_future1,
-                client2.report_bytes(epoch1, 409600),
-            )
-            .await;
+            let (result1, result2) =
+                join(report_future1, client2.report_bytes(epoch1, 409600)).await;
             assert!(!result1.unwrap());
             assert!(!result2.unwrap());
         }
@@ -1133,11 +1127,8 @@ mod tests {
                     .await
                     .is_pending()
             );
-            let (result1, result2) = join(
-                report_future1,
-                client2.report_bytes(epoch2, 614400),
-            )
-            .await;
+            let (result1, result2) =
+                join(report_future1, client2.report_bytes(epoch2, 614400)).await;
             assert!(result1.unwrap());
             assert!(result2.unwrap());
         }
@@ -1366,11 +1357,8 @@ mod tests {
                     .await
                     .is_pending()
             );
-            let (result1, result2) = join(
-                report_future1,
-                client2.report_bytes(epoch1, 512000),
-            )
-            .await;
+            let (result1, result2) =
+                join(report_future1, client2.report_bytes(epoch1, 512000)).await;
             assert!(!result1.unwrap());
             assert!(!result2.unwrap());
         }

--- a/src/rpc_client/src/sink_coordinate_client.rs
+++ b/src/rpc_client/src/sink_coordinate_client.rs
@@ -115,6 +115,36 @@ impl CoordinatorStreamHandle {
         }
     }
 
+    pub async fn report_bytes(
+        &mut self,
+        epoch: u64,
+        buffered_bytes: u64,
+    ) -> anyhow::Result<bool> {
+        self.send_request(CoordinateRequest {
+            msg: Some(coordinate_request::Msg::ReportBytesRequest(
+                coordinate_request::ReportBytesRequest {
+                    epoch,
+                    buffered_bytes,
+                },
+            )),
+        })
+        .await?;
+        match self.next_response().await? {
+            CoordinateResponse {
+                msg: Some(coordinate_response::Msg::ReportBytesResponse(
+                    coordinate_response::ReportBytesResponse {
+                        should_commit,
+                        ..
+                    },
+                )),
+            } => Ok(should_commit),
+            msg => Err(anyhow!(
+                "should get report bytes response but get {:?}",
+                msg
+            )),
+        }
+    }
+
     pub async fn update_vnode_bitmap(&mut self, vnode_bitmap: &Bitmap) -> anyhow::Result<u64> {
         self.send_request(CoordinateRequest {
             msg: Some(coordinate_request::Msg::UpdateVnodeRequest(

--- a/src/rpc_client/src/sink_coordinate_client.rs
+++ b/src/rpc_client/src/sink_coordinate_client.rs
@@ -115,11 +115,7 @@ impl CoordinatorStreamHandle {
         }
     }
 
-    pub async fn report_bytes(
-        &mut self,
-        epoch: u64,
-        buffered_bytes: u64,
-    ) -> anyhow::Result<bool> {
+    pub async fn report_bytes(&mut self, epoch: u64, buffered_bytes: u64) -> anyhow::Result<bool> {
         self.send_request(CoordinateRequest {
             msg: Some(coordinate_request::Msg::ReportBytesRequest(
                 coordinate_request::ReportBytesRequest {
@@ -131,12 +127,10 @@ impl CoordinatorStreamHandle {
         .await?;
         match self.next_response().await? {
             CoordinateResponse {
-                msg: Some(coordinate_response::Msg::ReportBytesResponse(
-                    coordinate_response::ReportBytesResponse {
-                        should_commit,
-                        ..
-                    },
-                )),
+                msg:
+                    Some(coordinate_response::Msg::ReportBytesResponse(
+                        coordinate_response::ReportBytesResponse { should_commit, .. },
+                    )),
             } => Ok(should_commit),
             msg => Err(anyhow!(
                 "should get report bytes response but get {:?}",


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

Close #25058 

## What's changed and what's your intention?

Iceberg sinks currently only commit after a fixed number of checkpoints (`commit_checkpoint_interval`), regardless of how much data has accumulated. Under bursty or variable-rate workloads, this leads to either too many small files or too much memory held between commits.

**This was already attempted once** in #25058 (`commit_checkpoint_size_threshold_mb`, merged), but reverted in #25614 because the implementation could hang commits indefinitely. That version made the commit decision **locally per writer**: each writer independently checked its own buffered bytes and decided whether to force a commit on the checkpoint barrier. Under hash skew across parallel writers, one writer can cross the threshold and request a commit for an epoch while its peers, still under threshold, send nothing for that same epoch. The coordinator only finalizes a commit once every writer's vnodes are represented for that epoch — so the lone request never completes, and since epochs commit in order, every later epoch queues up behind the stuck one.

This PR re-implements the feature with the decision moved **out of the writer and into the coordinator**, structurally avoiding that failure mode:

- Each writer tracks its own uncommitted buffered bytes and *reports* them to the sink coordinator every checkpoint barrier (new `ReportBytes` gRPC message) — it no longer decides anything on its own.
- The coordinator collects reports across all writers for an epoch (reusing the existing vnode-bitmap alignment already used for commits), sums the total, and makes **one** `should_commit` decision, broadcast back to every writer for that epoch. No writer can unilaterally trigger a commit the others aren't ready for — the whole cohort commits together or not at all.
- Writers always report, even when buffered bytes are zero. Skipping the report for an idle writer would leave that epoch permanently unaligned and stall everything behind it — this was caught in internal testing as a silent production stall after a parallelism rescale, with no error surfaced.

**Behavior:**
- Off by default (`Option<u64>`, unset). Set `commit_checkpoint_size_threshold_mb` to enable; `0` disables it explicitly.
- Works via the existing `iceberg_engine` option passthrough, so `CREATE TABLE ... WITH (commit_checkpoint_size_threshold_mb = ...) ENGINE = iceberg` and `ALTER ... SET commit_checkpoint_size_threshold_mb = ...` just work — no extra frontend wiring needed.

**Known limitation:** the threshold measures in-memory buffered bytes, not on-disk Parquet size — actual file size is typically 3–10x smaller after compression, so size it accordingly.

Related to #25058 (reverted in #25614).

## Checklist

- [x] I have written necessary rustdoc comments.
- [x] I have added necessary unit tests and integration tests. <!-- test_size_based_commit_via_coordinator, test_size_based_commit_with_zero_byte_report -->
- [ ] I have added test labels as necessary.
- [ ] I have added fuzzing tests or opened an issue to track them.
- [ ] My PR contains breaking changes. <!-- opt-in, off by default -->
- [ ] My PR changes performance-critical code, so I will run (micro) benchmarks and present the results.
- [ ] I have checked the Release Timeline and Currently Supported Versions to determine which release branches I need to cherry-pick this PR into.

## Documentation

- [x] My PR needs documentation updates. <!-- new Iceberg sink WITH option -->

<details>
<summary><b>Release note</b></summary>

Added a new Iceberg sink/table option, `commit_checkpoint_size_threshold_mb`, that triggers an early commit once total buffered write bytes across all writers exceeds the given threshold (in MiB). Opt-in and off by default. This supersedes the earlier attempt in #25058 (reverted in #25614 due to a commit-hang bug); the commit decision is now made by the coordinator across all writers instead of by each writer independently, avoiding that failure mode.

</details>