### PR TITLE
feat(frontend): support await-tree dump

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12368,6 +12368,7 @@ dependencies = [
  "async-trait",
  "auto_enums",
  "auto_impl",
+ "await-tree",
  "axum",
  "axum-server",
  "base64 0.22.1",

--- a/proto/monitor_service.proto
+++ b/proto/monitor_service.proto
@@ -27,6 +27,8 @@ message StackTraceResponse {
   map<uint32, string> node_errors = 8;
   // Key: batch task id in the format of "{query_id}-{stage_id}-{task_id}".
   map<string, string> batch_traces = 9;
+  // Key: frontend query id, optionally followed by "/stage/{stage_id}".
+  map<string, string> frontend_traces = 10;
 }
 
 // CPU profiling

--- a/src/batch/src/execution/grpc_exchange.rs
+++ b/src/batch/src/execution/grpc_exchange.rs
@@ -63,9 +63,17 @@ impl GrpcExchangeSource {
                     tracing_context: plan.tracing_context,
                     expr_context: Some(capture_expr_context()?),
                 };
-                client.execute(execute_request).await?
+                client
+                    .execute(execute_request)
+                    .instrument_await("execute_task")
+                    .await?
             }
-            None => client.get_data(task_output_id.clone()).await?,
+            None => {
+                client
+                    .get_data(task_output_id.clone())
+                    .instrument_await("get_task_data")
+                    .await?
+            }
         };
         let source = Self {
             stream,

--- a/src/common/src/util/prost.rs
+++ b/src/common/src/util/prost.rs
@@ -70,6 +70,13 @@ impl Display for StackTraceResponseOutput<'_> {
                 writeln!(s, "{trace}")?;
             }
         }
+        if !self.frontend_traces.is_empty() {
+            writeln!(s, "--- Frontend Traces ---")?;
+            for (name, trace) in &self.frontend_traces {
+                writeln!(s, ">> Frontend Query {name}")?;
+                writeln!(s, "{trace}")?;
+            }
+        }
         if !self.compaction_task_traces.is_empty() {
             writeln!(s, "--- Compactor Traces ---")?;
             for (name, trace) in &self.compaction_task_traces {
@@ -118,6 +125,7 @@ impl StackTraceResponse {
         self.actor_traces.extend(b.actor_traces);
         self.rpc_traces.extend(b.rpc_traces);
         self.batch_traces.extend(b.batch_traces);
+        self.frontend_traces.extend(b.frontend_traces);
         self.compaction_task_traces.extend(b.compaction_task_traces);
         self.inflight_barrier_traces
             .extend(b.inflight_barrier_traces);

--- a/src/compute/src/rpc/service/monitor_service.rs
+++ b/src/compute/src/rpc/service/monitor_service.rs
@@ -186,6 +186,7 @@ impl MonitorService for MonitorServiceImpl {
             meta_traces: Default::default(),
             node_errors: Default::default(),
             batch_traces,
+            frontend_traces: Default::default(),
         }))
     }
 

--- a/src/ctl/src/cmd_impl/await_tree.rs
+++ b/src/ctl/src/cmd_impl/await_tree.rs
@@ -39,6 +39,7 @@ pub async fn dump(context: &CtlContext, actor_traces_format: Option<String>) -> 
     if all.actor_traces.is_empty()
         && all.rpc_traces.is_empty()
         && all.batch_traces.is_empty()
+        && all.frontend_traces.is_empty()
         && all.compaction_task_traces.is_empty()
         && all.inflight_barrier_traces.is_empty()
     {

--- a/src/frontend/Cargo.toml
+++ b/src/frontend/Cargo.toml
@@ -21,6 +21,7 @@ async-recursion = "1.1.0"
 async-trait = "0.1"
 auto_enums = { workspace = true }
 auto_impl = "1"
+await-tree = { workspace = true }
 axum = { workspace = true }
 axum-server = { version = "0.8", features = ["tls-openssl"] }
 base64 = "0.22"

--- a/src/frontend/src/rpc/monitor_service.rs
+++ b/src/frontend/src/rpc/monitor_service.rs
@@ -24,15 +24,19 @@ use risingwave_pb::monitor_service::{
 };
 use tonic::{Request, Response, Status};
 
+use crate::scheduler::await_tree_key::FrontendTask;
+
 /// Frontend implementation of monitor RPCs, currently reusing the profile service only.
 pub struct MonitorServiceImpl {
     profile_service: ProfileServiceImpl,
+    await_tree_reg: Option<await_tree::Registry>,
 }
 
 impl MonitorServiceImpl {
-    pub fn new(server_config: ServerConfig) -> Self {
+    pub fn new(server_config: ServerConfig, await_tree_reg: Option<await_tree::Registry>) -> Self {
         Self {
             profile_service: ProfileServiceImpl::new(server_config),
+            await_tree_reg,
         }
     }
 }
@@ -43,7 +47,19 @@ impl MonitorService for MonitorServiceImpl {
         &self,
         _request: Request<StackTraceRequest>,
     ) -> Result<Response<StackTraceResponse>, Status> {
-        Err(Status::unimplemented("not implemented in frontend node"))
+        let frontend_traces = if let Some(reg) = &self.await_tree_reg {
+            reg.collect::<FrontendTask>()
+                .into_iter()
+                .map(|(key, trace)| (key.to_string(), trace.to_string()))
+                .collect()
+        } else {
+            Default::default()
+        };
+
+        Ok(Response::new(StackTraceResponse {
+            frontend_traces,
+            ..Default::default()
+        }))
     }
 
     async fn profiling(

--- a/src/frontend/src/scheduler/distributed/query.rs
+++ b/src/frontend/src/scheduler/distributed/query.rs
@@ -18,6 +18,7 @@ use std::mem;
 use std::sync::Arc;
 
 use anyhow::Context;
+use await_tree::InstrumentAwait;
 use futures::executor::block_on;
 use petgraph::Graph;
 use petgraph::dot::{Config, Dot};
@@ -35,6 +36,7 @@ use tracing::{Instrument, debug, error, info, warn};
 
 use super::{DistributedQueryMetrics, QueryExecutionInfoRef, QueryResultFetcher, StageEvent};
 use crate::catalog::catalog_service::CatalogReader;
+use crate::scheduler::await_tree_key::FrontendTask;
 use crate::scheduler::distributed::StageEvent::Scheduled;
 use crate::scheduler::distributed::StageExecution;
 use crate::scheduler::distributed::query::QueryMessage::Stage;
@@ -184,7 +186,17 @@ impl QueryExecution {
                 tracing::trace!("Starting query: {:?}", self.query.query_id);
 
                 // Not trace the error here, it will be processed in scheduler.
-                tokio::spawn(async move { runner.run().instrument(span).await });
+                let runner = runner.run().instrument(span);
+                if let Some(reg) = context.session().env().await_tree_reg().cloned() {
+                    let query_id = self.query.query_id.clone();
+                    let span = await_tree::span!("Distributed Query ({})", query_id.id);
+                    tokio::spawn(
+                        reg.register(FrontendTask::Query(query_id), span)
+                            .instrument(runner),
+                    );
+                } else {
+                    tokio::spawn(runner);
+                }
 
                 let root_stage = root_stage_receiver
                     .await
@@ -307,7 +319,12 @@ impl QueryRunner {
         let has_lookup_join_stage = self.query.has_lookup_join_stage();
 
         let mut finished_stage_cnt = 0usize;
-        while let Some(msg_inner) = self.msg_receiver.recv().await {
+        while let Some(msg_inner) = self
+            .msg_receiver
+            .recv()
+            .instrument_await("wait_stage_event")
+            .await
+        {
             match msg_inner {
                 Stage(Scheduled(stage_id)) => {
                     tracing::trace!(

--- a/src/frontend/src/scheduler/distributed/stage.rs
+++ b/src/frontend/src/scheduler/distributed/stage.rs
@@ -21,9 +21,9 @@ use std::{assert_matches, mem};
 use StageEvent::Failed;
 use anyhow::anyhow;
 use arc_swap::ArcSwap;
+use await_tree::InstrumentAwait;
 use futures::stream::Fuse;
 use futures::{StreamExt, TryStreamExt, stream};
-use futures_async_stream::for_await;
 use itertools::Itertools;
 use risingwave_batch::error::BatchError;
 use risingwave_batch::executor::ExecutorBuilder;
@@ -57,6 +57,7 @@ use crate::catalog::catalog_service::CatalogReader;
 use crate::catalog::{FragmentId, TableId};
 use crate::optimizer::plan_node::BatchPlanNodeType;
 use crate::scheduler::SchedulerError::{TaskExecutionError, TaskRunningOutOfMemory};
+use crate::scheduler::await_tree_key::FrontendTask;
 use crate::scheduler::distributed::QueryMessage;
 use crate::scheduler::distributed::stage::StageState::Pending;
 use crate::scheduler::plan_fragmenter::{
@@ -219,11 +220,22 @@ impl StageExecution {
                     query_id = self.query.query_id.id,
                     stage_id = %self.stage_id,
                 );
-                self.ctx
-                    .session()
-                    .env()
-                    .compute_runtime()
-                    .spawn(async move { runner.run(receiver).instrument(span).await });
+                let env = self.ctx.session().env();
+                let compute_runtime = env.compute_runtime();
+                let await_tree_reg = env.await_tree_reg().cloned();
+                let query_id = self.query.query_id.clone();
+                let stage_id = self.stage_id;
+                let runner = async move { runner.run(receiver).instrument(span).await };
+                if let Some(reg) = await_tree_reg {
+                    let span =
+                        await_tree::span!("Distributed Stage ({}-{})", query_id.id, stage_id);
+                    compute_runtime.spawn(
+                        reg.register(FrontendTask::Stage { query_id, stage_id }, span)
+                            .instrument(runner),
+                    );
+                } else {
+                    compute_runtime.spawn(runner);
+                }
 
                 tracing::trace!(
                     "Stage {:?}-{:?} started.",
@@ -466,7 +478,10 @@ impl StageRunner {
 
         // Await each future and convert them into a set of streams.
         let buffered = stream::iter(futures).buffer_unordered(TASK_SCHEDULING_PARALLELISM);
-        let buffered_streams = buffered.try_collect::<Vec<_>>().await?;
+        let buffered_streams = buffered
+            .try_collect::<Vec<_>>()
+            .instrument_await("create_batch_tasks")
+            .await?;
 
         // Merge different task streams into a single stream.
         let cancelled = pin!(shutdown_rx.cancelled());
@@ -477,7 +492,11 @@ impl StageRunner {
         let mut finished_task_cnt = 0;
         let mut sent_signal_to_next = false;
 
-        while let Some(status_res_inner) = all_streams.next().await {
+        while let Some(status_res_inner) = all_streams
+            .next()
+            .instrument_await("wait_task_status")
+            .await
+        {
             match status_res_inner {
                 Ok(status) => {
                     use risingwave_pb::task_service::task_info_response::TaskStatus as PbTaskStatus;
@@ -594,7 +613,7 @@ impl StageRunner {
                 self.stage_id
             );
             // Waiting for shutdown signal.
-            shutdown.await;
+            shutdown.instrument_await("wait_shutdown").await;
         }
 
         // Received shutdown signal from query runner, should send abort RPC to all CNs.
@@ -607,7 +626,9 @@ impl StageRunner {
             self.stage_id,
             self.tasks.len()
         );
-        self.cancel_all_scheducancled_tasks().await?;
+        self.cancel_all_scheducancled_tasks()
+            .instrument_await("cancel_tasks")
+            .await?;
 
         tracing::trace!(
             "Stage runner [{:?}-{:?}] exited.",
@@ -655,11 +676,18 @@ impl StageRunner {
         let shutdown_rx0 = shutdown_rx.clone();
 
         let result = expr_context_scope(expr_context, async {
-            let executor = executor.build().await?;
+            let executor = executor
+                .build()
+                .instrument_await("build_root_executor")
+                .await?;
             let chunk_stream = executor.execute();
             let cancelled = pin!(shutdown_rx.cancelled());
-            #[for_await]
-            for chunk in chunk_stream.take_until(cancelled) {
+            let mut chunk_stream = pin!(chunk_stream.take_until(cancelled));
+            while let Some(chunk) = chunk_stream
+                .next()
+                .instrument_await("next_root_chunk")
+                .await
+            {
                 if let Err(ref e) = chunk {
                     if shutdown_rx0.is_cancelled() {
                         break;
@@ -668,14 +696,22 @@ impl StageRunner {
                     // This is possible if The Query Runner drop early before schedule the root
                     // executor. Detail described in https://github.com/risingwavelabs/risingwave/issues/6883#issuecomment-1348102037.
                     // The error format is just channel closed so no care.
-                    if let Err(_e) = result_tx.send(chunk.map_err(|e| e.into())).await {
+                    if let Err(_e) = result_tx
+                        .send(chunk.map_err(|e| e.into()))
+                        .instrument_await("send_root_chunk")
+                        .await
+                    {
                         warn!("Root executor has been dropped before receive any events so the send is failed");
                     }
                     // Different from below, return this function and report error.
                     return Err(TaskExecutionError(err_str));
                 } else {
                     // Same for below.
-                    if let Err(_e) = result_tx.send(chunk.map_err(|e| e.into())).await {
+                    if let Err(_e) = result_tx
+                        .send(chunk.map_err(|e| e.into()))
+                        .instrument_await("send_root_chunk")
+                        .await
+                    {
                         warn!("Root executor has been dropped before receive any events so the send is failed");
                     }
                 }

--- a/src/frontend/src/scheduler/local.rs
+++ b/src/frontend/src/scheduler/local.rs
@@ -19,6 +19,7 @@ use std::sync::atomic::{AtomicU32, Ordering};
 use std::time::Duration;
 
 use anyhow::anyhow;
+use await_tree::InstrumentAwait;
 use futures::stream::BoxStream;
 use futures::{FutureExt, StreamExt};
 use futures_async_stream::try_stream;
@@ -50,6 +51,7 @@ use super::plan_fragmenter::{PartitionInfo, QueryStage};
 use crate::catalog::{FragmentId, TableId};
 use crate::error::RwError;
 use crate::optimizer::plan_node::BatchPlanNodeType;
+use crate::scheduler::await_tree_key::FrontendTask;
 use crate::scheduler::plan_fragmenter::{ExecutionPlanNode, Query, StageId};
 use crate::scheduler::task_context::FrontendBatchTaskContext;
 use crate::scheduler::{SchedulerError, SchedulerResult};
@@ -106,14 +108,18 @@ impl LocalQueryExecution {
         let plan_node = plan_fragment.root.unwrap();
 
         let executor = ExecutorBuilder::new(&plan_node, &task_id, context, self.shutdown_rx());
-        let executor = executor.build().await?;
+        let executor = executor.build().instrument_await("build_executor").await?;
         // The following loop can be slow.
         // Release potential large object in Query and PlanNode early.
         drop(plan_node);
         drop(self);
 
-        #[for_await]
-        for chunk in executor.execute() {
+        let mut data_stream = executor.execute();
+        while let Some(chunk) = data_stream
+            .next()
+            .instrument_await("next_executor_chunk")
+            .await
+        {
             yield chunk?;
         }
     }
@@ -125,6 +131,8 @@ impl LocalQueryExecution {
 
     pub fn stream_rows(self) -> LocalQueryStream {
         let compute_runtime = self.front_env.compute_runtime();
+        let await_tree_reg = self.front_env.await_tree_reg().cloned();
+        let query_id = self.query.query_id.clone();
         let (sender, receiver) = mpsc::channel(10);
         let shutdown_rx = self.shutdown_rx();
 
@@ -141,14 +149,23 @@ impl LocalQueryExecution {
         let sender1 = sender.clone();
         let exec = async move {
             let mut data_stream = self.run().map(|r| r.map_err(|e| Box::new(e) as BoxedError));
-            while let Some(mut r) = data_stream.next().await {
+            while let Some(mut r) = data_stream
+                .next()
+                .instrument_await("next_query_chunk")
+                .await
+            {
                 // append a query cancelled error if the query is cancelled.
                 if r.is_err() && shutdown_rx.is_cancelled() {
                     r = Err(Box::new(SchedulerError::QueryCancelled(
                         "Cancelled by user".to_owned(),
                     )) as BoxedError);
                 }
-                if sender1.send(r).await.is_err() {
+                if sender1
+                    .send(r)
+                    .instrument_await("send_query_chunk")
+                    .await
+                    .is_err()
+                {
                     tracing::info!("Receiver closed.");
                     return;
                 }
@@ -171,8 +188,8 @@ impl LocalQueryExecution {
         let exec = async move { STRICT_MODE::scope(strict_mode, exec).await }.boxed();
         let exec = async move { META_CLIENT::scope(meta_client, exec).await }.boxed();
 
-        if let Some(timeout) = timeout {
-            let exec = async move {
+        let exec = async move {
+            if let Some(timeout) = timeout {
                 if let Err(_e) = tokio::time::timeout(timeout, exec).await {
                     tracing::error!(
                         "Local query execution timeout after {} seconds",
@@ -189,8 +206,17 @@ impl LocalQueryExecution {
                         tracing::info!("Receiver closed.");
                     }
                 }
-            };
-            compute_runtime.spawn(exec);
+            } else {
+                exec.await;
+            }
+        };
+
+        if let Some(reg) = await_tree_reg {
+            let span = await_tree::span!("Local Query ({})", query_id.id);
+            compute_runtime.spawn(
+                reg.register(FrontendTask::Query(query_id), span)
+                    .instrument(exec),
+            );
         } else {
             compute_runtime.spawn(exec);
         }

--- a/src/frontend/src/scheduler/mod.rs
+++ b/src/frontend/src/scheduler/mod.rs
@@ -28,6 +28,34 @@ mod distributed;
 pub use distributed::*;
 pub mod plan_fragmenter;
 pub use plan_fragmenter::BatchPlanFragmenter;
+
+pub mod await_tree_key {
+    use std::fmt::{Display, Formatter};
+
+    use super::plan_fragmenter::{QueryId, StageId};
+
+    /// Await-tree key type for query and stage tasks driven by the frontend.
+    #[derive(Debug, Clone, PartialEq, Eq, Hash)]
+    pub enum FrontendTask {
+        Query(QueryId),
+        Stage {
+            query_id: QueryId,
+            stage_id: StageId,
+        },
+    }
+
+    impl Display for FrontendTask {
+        fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Query(query_id) => write!(f, "{}", query_id.id),
+                Self::Stage { query_id, stage_id } => {
+                    write!(f, "{}/stage/{}", query_id.id, stage_id)
+                }
+            }
+        }
+    }
+}
+
 mod snapshot;
 pub use snapshot::*;
 mod local;

--- a/src/frontend/src/session.rs
+++ b/src/frontend/src/session.rs
@@ -50,8 +50,8 @@ use risingwave_common::catalog::{
     DEFAULT_DATABASE_NAME, DEFAULT_SUPER_USER, DEFAULT_SUPER_USER_ID,
 };
 use risingwave_common::config::{
-    AuthMethod, BatchConfig, ConnectionType, FrontendConfig, MetaConfig, MetricLevel,
-    RpcClientConfig, StreamingConfig, UdfConfig, load_config,
+    AsyncStackTraceOption, AuthMethod, BatchConfig, ConnectionType, FrontendConfig, MetaConfig,
+    MetricLevel, RpcClientConfig, StreamingConfig, UdfConfig, load_config,
 };
 use risingwave_common::id::WorkerId;
 use risingwave_common::memory::MemoryContext;
@@ -152,6 +152,7 @@ pub(crate) struct FrontendEnv {
     user_info_reader: UserInfoReader,
     worker_node_manager: WorkerNodeManagerRef,
     query_manager: QueryManager,
+    await_tree_reg: Option<await_tree::Registry>,
     hummock_snapshot_manager: HummockSnapshotManagerRef,
     system_params_manager: LocalSystemParamsManagerRef,
     session_params: Arc<RwLock<SessionConfig>>,
@@ -269,6 +270,7 @@ impl FrontendEnv {
             user_info_reader,
             worker_node_manager,
             query_manager,
+            await_tree_reg: None,
             hummock_snapshot_manager,
             system_params_manager,
             session_params: Default::default(),
@@ -374,6 +376,14 @@ impl FrontendEnv {
             config.batch.developer.frontend_client_config.clone(),
         ));
         let monitor_client_pool = Arc::new(MonitorClientPool::new(1, RpcClientConfig::default()));
+        let await_tree_reg = match config.streaming.async_stack_trace {
+            AsyncStackTraceOption::Off => None,
+            option => await_tree::ConfigBuilder::default()
+                .verbose(option.is_verbose().unwrap())
+                .build()
+                .ok()
+                .map(await_tree::Registry::new),
+        };
         let query_manager = QueryManager::new(
             worker_node_manager.clone(),
             compute_client_pool.clone(),
@@ -432,7 +442,7 @@ impl FrontendEnv {
 
         let health_srv = HealthServiceImpl::new();
         let frontend_srv = FrontendServiceImpl::new(sessions_map.clone());
-        let monitor_srv = MonitorServiceImpl::new(config.server.clone());
+        let monitor_srv = MonitorServiceImpl::new(config.server.clone(), await_tree_reg.clone());
         let frontend_rpc_addr = opts.frontend_rpc_listener_addr.parse().unwrap();
 
         let telemetry_manager = TelemetryManager::new(
@@ -560,6 +570,7 @@ impl FrontendEnv {
                 worker_node_manager,
                 meta_client: frontend_meta_client,
                 query_manager,
+                await_tree_reg,
                 hummock_snapshot_manager,
                 system_params_manager,
                 session_params,
@@ -630,6 +641,10 @@ impl FrontendEnv {
 
     pub fn query_manager(&self) -> &QueryManager {
         &self.query_manager
+    }
+
+    pub fn await_tree_reg(&self) -> Option<&await_tree::Registry> {
+        self.await_tree_reg.as_ref()
     }
 
     pub fn hummock_snapshot_manager(&self) -> &HummockSnapshotManagerRef {

--- a/src/meta/src/rpc/await_tree.rs
+++ b/src/meta/src/rpc/await_tree.rs
@@ -22,8 +22,8 @@ use thiserror_ext::AsReport as _;
 use crate::MetaResult;
 use crate::manager::MetadataManager;
 
-/// Dump the await tree of all nodes in the cluster, including compute nodes, compactor nodes,
-/// and the current meta node.
+/// Dump the await tree of all nodes in the cluster, including compute nodes, frontend nodes,
+/// compactor nodes, and the current meta node.
 pub async fn dump_cluster_await_tree(
     metadata_manager: &MetadataManager,
     meta_node_registry: &await_tree::Registry,
@@ -36,6 +36,12 @@ pub async fn dump_cluster_await_tree(
         .await?;
     let compute_traces = dump_worker_node_await_tree(&compute_nodes, actor_traces_format).await?;
     all.merge_other(compute_traces);
+
+    let frontend_nodes = metadata_manager
+        .list_worker_node(Some(WorkerType::Frontend), None)
+        .await?;
+    let frontend_traces = dump_worker_node_await_tree(&frontend_nodes, actor_traces_format).await?;
+    all.merge_other(frontend_traces);
 
     let compactor_nodes = metadata_manager
         .list_worker_node(Some(WorkerType::Compactor), None)
@@ -66,7 +72,7 @@ pub fn dump_meta_node_await_tree(
     })
 }
 
-/// Dump the await tree of the given worker nodes (compute nodes or compactor nodes).
+/// Dump the await tree of the given worker nodes.
 pub async fn dump_worker_node_await_tree(
     worker_nodes: impl IntoIterator<Item = &WorkerNode>,
     actor_traces_format: ActorTracesFormat,


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

This is stacked on #26515, which adds await-tree roots for batch tasks on compute nodes. This PR completes the frontend side of the dump path so `risectl await-tree dump` can show the query driver and local-mode frontend execution as well.

- Create an optional frontend await-tree registry using the existing `streaming.async_stack_trace` setting; no new configuration is introduced.
- Register the full local query execution future as a `Local Query` root. Await spans from the local executor, including local exchange waits added by #26515, are therefore attached to the same tree.
- Register the distributed query scheduler driver as a `Distributed Query` root.
- Implement `MonitorService::stack_trace` on frontend nodes and return the active query trees in a new `frontend_traces` field.
- Have meta enumerate frontend workers, collect their monitor responses through the existing frontend internal RPC address, and merge them into the cluster dump.
- Render the result as a new `--- Frontend Traces ---` section in `risectl await-tree dump`.

When async stack tracing is disabled, the frontend monitor service returns an empty trace map.

## Testing

- `cargo check -p risingwave_pb`
- `cargo check -p risingwave_frontend -p risingwave_meta -p risingwave_ctl`
- `cargo check -p risingwave_compute`
- `cargo clippy -p risingwave_frontend -p risingwave_meta -p risingwave_ctl -p risingwave_compute --lib -- -D warnings`
- `cargo sort --check --workspace --grouped`
- `cargo fmt --all`
- `git diff --check`

## Checklist

- [x] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary.
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them.
- [ ] <!-- OPTIONAL --> My PR contains breaking changes.
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results.
- [ ] <!-- OPTIONAL --> I have checked the Release Timeline and Currently Supported Versions to determine which release branches I need to cherry-pick this PR into.

## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates.

<details>
<summary><b>Release note</b></summary>

</details>
