### PR TITLE
fix(stream): count join matched rows directly

### DIFF
--- a/src/stream/src/executor/asof_join.rs
+++ b/src/stream/src/executor/asof_join.rs
@@ -164,7 +164,6 @@ struct EqJoinArgs<'a, S: StateStore, E: AsOfRowEncoding> {
     join_cache_evict_interval_rows: u32,
     high_join_amplification_threshold: usize,
     /// Bound at executor scope so the guard isn't dropped between chunks (which resets the series).
-    /// Only observed by [`AsOfJoinExecutor::eq_join_right`].
     join_matched_join_keys: &'a LabelGuardedHistogram,
 }
 
@@ -565,7 +564,7 @@ impl<S: StateStore, const T: AsOfJoinTypePrimitive, E: AsOfRowEncoding> AsOfJoin
     #[try_stream(ok = StreamChunk, error = StreamExecutorError)]
     async fn eq_join_left(args: EqJoinArgs<'_, S, E>) {
         let EqJoinArgs {
-            ctx: _,
+            ctx,
             side_l,
             side_r,
             null_safe,
@@ -575,8 +574,8 @@ impl<S: StateStore, const T: AsOfJoinTypePrimitive, E: AsOfRowEncoding> AsOfJoin
             chunk_size,
             cnt_rows_received,
             join_cache_evict_interval_rows,
-            high_join_amplification_threshold: _,
-            join_matched_join_keys: _,
+            high_join_amplification_threshold,
+            join_matched_join_keys,
         } = args;
 
         let (side_update, side_match) = (side_l, side_r);
@@ -635,6 +634,8 @@ impl<S: StateStore, const T: AsOfJoinTypePrimitive, E: AsOfRowEncoding> AsOfJoin
             let inequal_key_is_null = side_update.ht.check_inequal_key_null(&row);
             let inequal_key = row.project(&inequal_key_idx_update);
 
+            let mut join_matched_rows_cnt = 0;
+
             if !inequal_key_is_null {
                 let matched_row_by_inequality = match asof_desc.inequality_type {
                     AsOfInequalityType::Lt => {
@@ -678,6 +679,7 @@ impl<S: StateStore, const T: AsOfJoinTypePrimitive, E: AsOfRowEncoding> AsOfJoin
                 match op {
                     Op::Insert | Op::UpdateInsert => {
                         if let Some(matched_row) = matched_row_by_inequality {
+                            join_matched_rows_cnt += 1;
                             if let Some(chunk) =
                                 join_chunk_builder.with_match_on_insert(&row, &matched_row)
                             {
@@ -692,6 +694,7 @@ impl<S: StateStore, const T: AsOfJoinTypePrimitive, E: AsOfRowEncoding> AsOfJoin
                     }
                     Op::Delete | Op::UpdateDelete => {
                         if let Some(matched_row) = matched_row_by_inequality {
+                            join_matched_rows_cnt += 1;
                             if let Some(chunk) =
                                 join_chunk_builder.with_match_on_delete(&row, &matched_row)
                             {
@@ -724,6 +727,18 @@ impl<S: StateStore, const T: AsOfJoinTypePrimitive, E: AsOfRowEncoding> AsOfJoin
                         }
                     }
                 }
+            }
+            join_matched_join_keys.observe(join_matched_rows_cnt as _);
+            if join_matched_rows_cnt > high_join_amplification_threshold {
+                tracing::warn!(target: "high_join_amplification",
+                    matched_rows_len = join_matched_rows_cnt,
+                    update_table_id = %side_update.ht.table_id(),
+                    match_table_id = %side_match.ht.table_id(),
+                    join_key = ?join_key,
+                    actor_id = %ctx.id,
+                    fragment_id = %ctx.fragment_id,
+                    "large rows matched for join key when AsOf join updating left side",
+                );
             }
         }
         if let Some(chunk) = join_chunk_builder.take() {

--- a/src/stream/src/executor/asof_join.rs
+++ b/src/stream/src/executor/asof_join.rs
@@ -376,8 +376,17 @@ impl<S: StateStore, const T: AsOfJoinTypePrimitive, E: AsOfRowEncoding> AsOfJoin
             .with_guarded_label_values(&[actor_id_str.as_str(), fragment_id_str.as_str(), "right"]);
 
         // Bind at executor scope: a per-chunk guard would be dropped between chunks and reset the series.
+        let left_table_id_str = self.side_l.ht.table_id().to_string();
         let right_table_id_str = self.side_r.ht.table_id().to_string();
-        let join_matched_join_keys = self
+        let left_join_matched_join_keys = self
+            .metrics
+            .join_matched_join_keys
+            .with_guarded_label_values(&[
+                actor_id_str.as_str(),
+                fragment_id_str.as_str(),
+                left_table_id_str.as_str(),
+            ]);
+        let right_join_matched_join_keys = self
             .metrics
             .join_matched_join_keys
             .with_guarded_label_values(&[
@@ -421,7 +430,7 @@ impl<S: StateStore, const T: AsOfJoinTypePrimitive, E: AsOfRowEncoding> AsOfJoin
                         cnt_rows_received: &mut self.cnt_rows_received,
                         join_cache_evict_interval_rows: self.join_cache_evict_interval_rows,
                         high_join_amplification_threshold: self.high_join_amplification_threshold,
-                        join_matched_join_keys: &join_matched_join_keys,
+                        join_matched_join_keys: &left_join_matched_join_keys,
                     }) {
                         left_time += left_start_time.elapsed();
                         yield Message::Chunk(chunk?);
@@ -447,7 +456,7 @@ impl<S: StateStore, const T: AsOfJoinTypePrimitive, E: AsOfRowEncoding> AsOfJoin
                         cnt_rows_received: &mut self.cnt_rows_received,
                         join_cache_evict_interval_rows: self.join_cache_evict_interval_rows,
                         high_join_amplification_threshold: self.high_join_amplification_threshold,
-                        join_matched_join_keys: &join_matched_join_keys,
+                        join_matched_join_keys: &right_join_matched_join_keys,
                     }) {
                         right_time += right_start_time.elapsed();
                         yield Message::Chunk(chunk?);
@@ -626,6 +635,7 @@ impl<S: StateStore, const T: AsOfJoinTypePrimitive, E: AsOfRowEncoding> AsOfJoin
                         }
                     }
                 }
+                join_matched_join_keys.observe(0.0);
                 continue;
             }
 
@@ -798,6 +808,7 @@ impl<S: StateStore, const T: AsOfJoinTypePrimitive, E: AsOfRowEncoding> AsOfJoin
                 .zip_eq(null_safe.iter())
                 .any(|(idx, ns)| !ns && row.datum_at(*idx).is_none());
             if join_key_null_not_safe {
+                join_matched_join_keys.observe(0.0);
                 continue;
             }
 
@@ -997,8 +1008,11 @@ impl<S: StateStore, const T: AsOfJoinTypePrimitive, E: AsOfRowEncoding> AsOfJoin
 mod tests {
     use std::sync::atomic::AtomicU64;
 
+    use prometheus::Registry;
     use risingwave_common::array::*;
     use risingwave_common::catalog::{ColumnDesc, ColumnId, Field, TableId};
+    use risingwave_common::config::MetricLevel;
+    use risingwave_common::metrics::get_label;
     use risingwave_common::util::epoch::test_epoch;
     use risingwave_common::util::sort_util::OrderType;
     use risingwave_storage::memory::MemoryStateStore;
@@ -1036,6 +1050,19 @@ mod tests {
     async fn create_executor<const T: AsOfJoinTypePrimitive>(
         asof_desc: AsOfDesc,
         use_cache: bool,
+    ) -> (MessageSender, MessageSender, BoxedMessageStream) {
+        create_executor_with_metrics::<T>(
+            asof_desc,
+            use_cache,
+            Arc::new(StreamingMetrics::unused()),
+        )
+        .await
+    }
+
+    async fn create_executor_with_metrics<const T: AsOfJoinTypePrimitive>(
+        asof_desc: AsOfDesc,
+        use_cache: bool,
+        metrics: Arc<StreamingMetrics>,
     ) -> (MessageSender, MessageSender, BoxedMessageStream) {
         let schema = Schema {
             fields: vec![
@@ -1098,13 +1125,62 @@ mod tests {
             state_l,
             state_r,
             Arc::new(AtomicU64::new(0)),
-            Arc::new(StreamingMetrics::unused()),
+            metrics,
             1024,
             asof_desc,
             use_cache,
             2048, // high_join_amplification_threshold
         );
         (tx_l, tx_r, executor.boxed().execute())
+    }
+
+    fn join_matched_sample_count(registry: &Registry, table_id: &str) -> u64 {
+        registry
+            .gather()
+            .iter()
+            .find(|metric_family| metric_family.name() == "stream_join_matched_join_keys")
+            .and_then(|metric_family| {
+                metric_family.get_metric().iter().find(|metric| {
+                    get_label::<String>(metric, "table_id").as_deref() == Some(table_id)
+                })
+            })
+            .map(|metric| metric.get_histogram().get_sample_count())
+            .unwrap_or(0)
+    }
+
+    #[tokio::test]
+    async fn test_asof_join_records_null_equi_key_probe_metrics() -> StreamExecutorResult<()> {
+        let asof_desc = AsOfDesc {
+            left_idx: 1,
+            right_idx: 1,
+            inequality_type: AsOfInequalityType::Lt,
+        };
+        let registry = Registry::new();
+        let metrics = Arc::new(StreamingMetrics::new(&registry, MetricLevel::Debug));
+        let (mut tx_l, mut tx_r, mut hash_join) =
+            create_executor_with_metrics::<{ AsOfJoinType::Inner }>(asof_desc, false, metrics)
+                .await;
+
+        tx_l.push_barrier(test_epoch(1), false);
+        tx_r.push_barrier(test_epoch(1), false);
+        hash_join.next_unwrap_ready_barrier()?;
+
+        tx_l.push_chunk(StreamChunk::from_pretty(
+            "  I I I
+             + . 10 1",
+        ));
+        hash_join.next_unwrap_pending();
+
+        tx_r.push_chunk(StreamChunk::from_pretty(
+            "  I I I
+             + . 20 2",
+        ));
+        hash_join.next_unwrap_pending();
+
+        assert_eq!(join_matched_sample_count(&registry, "0"), 1);
+        assert_eq!(join_matched_sample_count(&registry, "1"), 1);
+
+        Ok(())
     }
 
     #[tokio::test]

--- a/src/stream/src/executor/hash_join.rs
+++ b/src/stream/src/executor/hash_join.rs
@@ -1027,6 +1027,7 @@ impl<K: HashKey, S: StateStore, const T: JoinTypePrimitive, E: JoinEncoding>
                         side_update,
                         &useful_state_clean_columns,
                         cond,
+                        &mut total_matches,
                         append_only_optimize,
                         entry_state_max_rows,
                     )
@@ -1039,7 +1040,6 @@ impl<K: HashKey, S: StateStore, const T: JoinTypePrimitive, E: JoinEncoding>
                     #[for_await]
                     for chunk in match_rows!(Insert) {
                         let chunk = chunk?;
-                        total_matches += chunk.cardinality();
                         yield chunk;
                     }
                 }
@@ -1048,7 +1048,6 @@ impl<K: HashKey, S: StateStore, const T: JoinTypePrimitive, E: JoinEncoding>
                     #[for_await]
                     for chunk in match_rows!(Delete) {
                         let chunk = chunk?;
-                        total_matches += chunk.cardinality();
                         yield chunk;
                     }
                 }
@@ -1098,6 +1097,7 @@ impl<K: HashKey, S: StateStore, const T: JoinTypePrimitive, E: JoinEncoding>
         side_update: &'a mut JoinSide<K, S, E>,
         useful_state_clean_columns: &'a [(usize, &'a Watermark)],
         cond: &'a mut Option<NonStrictExpression>,
+        total_matches: &'a mut usize,
         append_only_optimize: bool,
         entry_state_max_rows: usize,
     ) {
@@ -1130,6 +1130,7 @@ impl<K: HashKey, S: StateStore, const T: JoinTypePrimitive, E: JoinEncoding>
                     cond,
                     &mut degree,
                     useful_state_clean_columns,
+                    total_matches,
                     append_only_optimize,
                     &mut append_only_matched_row,
                     &mut matched_rows_to_clean,
@@ -1279,6 +1280,7 @@ impl<K: HashKey, S: StateStore, const T: JoinTypePrimitive, E: JoinEncoding>
         cond: &Option<NonStrictExpression>,
         update_row_degree: &mut u64,
         useful_state_clean_columns: &[(usize, &'a Watermark)],
+        total_matches: &mut usize,
         append_only_optimize: bool,
         append_only_matched_row: &mut Option<JoinRow<RO>>,
         matched_rows_to_clean: &mut Vec<JoinRow<RO>>,
@@ -1299,6 +1301,7 @@ impl<K: HashKey, S: StateStore, const T: JoinTypePrimitive, E: JoinEncoding>
         .await;
 
         if join_condition_satisfied {
+            *total_matches += 1;
             // update degree
             *update_row_degree += 1;
             // send matched row downstream


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

Fix join matched-row observability so counters and high-amplification warnings measure actual matched rows per probe row instead of output chunk flushes.
Hash join now increments `total_matches` when a matched row satisfies the join condition, independent of `JoinChunkBuilder` buffering.
As-of join now observes and logs matched-row counts for left-side updates as well as the existing right-side path.

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

No user-facing release note is needed.

</details>
