### PR TITLE
fix(storage): retain iterator local statistics

### DIFF
--- a/src/storage/src/hummock/mod.rs
+++ b/src/storage/src/hummock/mod.rs
@@ -14,7 +14,7 @@
 
 //! Hummock is the state store of the streaming system.
 
-use std::ops::Bound;
+use std::ops::{Bound, Deref, DerefMut};
 use std::sync::Arc;
 
 use bytes::Bytes;
@@ -69,6 +69,48 @@ use crate::mem_table::ImmutableMemtable;
 use crate::monitor::StoreLocalStatistic;
 use crate::store::ReadOptions;
 
+struct HummockIteratorLocalStatisticGuard<'a, I: HummockIterator> {
+    iterator: Option<I>,
+    local_stats: &'a mut StoreLocalStatistic,
+}
+
+impl<'a, I: HummockIterator> HummockIteratorLocalStatisticGuard<'a, I> {
+    fn new(iterator: I, local_stats: &'a mut StoreLocalStatistic) -> Self {
+        Self {
+            iterator: Some(iterator),
+            local_stats,
+        }
+    }
+
+    fn into_inner(mut self) -> I {
+        let iterator = std::mem::take(&mut self.iterator).unwrap();
+        iterator.collect_local_statistic(self.local_stats);
+        iterator
+    }
+}
+
+impl<I: HummockIterator> Deref for HummockIteratorLocalStatisticGuard<'_, I> {
+    type Target = I;
+
+    fn deref(&self) -> &Self::Target {
+        self.iterator.as_ref().unwrap()
+    }
+}
+
+impl<I: HummockIterator> DerefMut for HummockIteratorLocalStatisticGuard<'_, I> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        self.iterator.as_mut().unwrap()
+    }
+}
+
+impl<I: HummockIterator> Drop for HummockIteratorLocalStatisticGuard<'_, I> {
+    fn drop(&mut self) {
+        if let Some(iterator) = self.iterator.take() {
+            iterator.collect_local_statistic(self.local_stats);
+        }
+    }
+}
+
 pub async fn get_from_sstable_info(
     sstable_store_ref: SstableStoreRef,
     sstable_info: &SstableInfo,
@@ -95,11 +137,14 @@ pub async fn get_from_sstable_info(
         return Ok(None);
     }
 
-    let mut iter = SstableIterator::create(
-        sstable,
-        sstable_store_ref.clone(),
-        Arc::new(SstableIteratorReadOptions::from_read_options(read_options)),
-        sstable_info,
+    let mut iter = HummockIteratorLocalStatisticGuard::new(
+        SstableIterator::create(
+            sstable,
+            sstable_store_ref.clone(),
+            Arc::new(SstableIteratorReadOptions::from_read_options(read_options)),
+            sstable_info,
+        ),
+        local_stats,
     );
     iter.seek(full_key).await?;
     // Iterator has sought passed the borders.
@@ -107,12 +152,10 @@ pub async fn get_from_sstable_info(
         return Ok(None);
     }
 
-    iter.collect_local_statistic(local_stats);
-
     // Iterator gets us the key, we tell if it's the key we want
     // or key next to it.
     let value = if iter.key().user_key == full_key.user_key {
-        Some(iter)
+        Some(iter.into_inner())
     } else {
         None
     };


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

<!--

**Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

`get_from_sstable_info` collects local `SstableIterator` statistics only on successful key hits; the iterator is discarded directly upon seeking out of bounds, key mismatches, or asynchronous errors, leading to debug mode output of "local stats lost!" accumulating.

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
