### PR TITLE
fix(meta): unify creating job catalog notifications

### DIFF
--- a/src/frontend/src/catalog/schema_catalog.rs
+++ b/src/frontend/src/catalog/schema_catalog.rs
@@ -206,7 +206,13 @@ impl SchemaCatalog {
     }
 
     pub fn drop_index(&mut self, id: IndexId) {
-        let index_ref = self.index_by_id.remove(&id).unwrap();
+        let Some(index_ref) = self.index_by_id.remove(&id) else {
+            tracing::warn!(
+                %id,
+                "index not found when dropping, frontend might not be notified yet"
+            );
+            return;
+        };
         self.index_by_name.remove(&index_ref.name).unwrap();
         match self.indexes_by_table_id.entry(index_ref.primary_table.id) {
             Occupied(mut entry) => {
@@ -241,7 +247,13 @@ impl SchemaCatalog {
     }
 
     pub fn drop_source(&mut self, id: SourceId) {
-        let source_ref = self.source_by_id.remove(&id).unwrap();
+        let Some(source_ref) = self.source_by_id.remove(&id) else {
+            tracing::warn!(
+                %id,
+                "source not found when dropping, frontend might not be notified yet"
+            );
+            return;
+        };
         self.source_by_name.remove(&source_ref.name).unwrap();
         if let Some(connection_id) = source_ref.connection_id
             && let Occupied(mut e) = self.connection_source_ref.entry(connection_id)
@@ -1143,5 +1155,19 @@ impl From<&PbSchema> for SchemaCatalog {
             subscription_by_name: HashMap::new(),
             subscription_by_id: HashMap::new(),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use risingwave_pb::catalog::PbSchema;
+
+    use super::SchemaCatalog;
+
+    #[test]
+    fn test_drop_missing_relation_is_idempotent() {
+        let mut schema = SchemaCatalog::from(&PbSchema::default());
+        schema.drop_index(1.into());
+        schema.drop_source(2.into());
     }
 }

--- a/src/meta/src/barrier/context/context_impl.rs
+++ b/src/meta/src/barrier/context/context_impl.rs
@@ -903,6 +903,7 @@ impl PostCollectCommand {
                         new_sink_downstream,
                         Some(&resolved_split_assignment),
                         replace_sink.as_ref(),
+                        replace_sink.is_none(),
                     )
                     .await?;
 
@@ -971,6 +972,7 @@ impl PostCollectCommand {
                         None,
                         Some(&resolved_split_assignment),
                         None,
+                        false,
                     )
                     .await?;
 
@@ -985,6 +987,7 @@ impl PostCollectCommand {
                                 None, // no replace plan
                                 None, // no init split assignment
                                 None,
+                                false,
                             )
                             .await?;
                     }

--- a/src/meta/src/controller/catalog/mod.rs
+++ b/src/meta/src/controller/catalog/mod.rs
@@ -648,50 +648,9 @@ impl CatalogController {
             .into_tuple()
             .all(&txn)
             .await?;
-
-        // Filter out dummy objs for replacement.
-        // todo: we'd better introduce a new dummy object type for replacement.
-        let all_dirty_table_ids = dirty_job_objs
-            .iter()
-            .filter(|obj| obj.obj_type == ObjectType::Table)
-            .map(|obj| obj.oid)
-            .collect_vec();
-        let dirty_table_type_map: HashMap<ObjectId, TableType> = Table::find()
-            .select_only()
-            .column(table::Column::TableId)
-            .column(table::Column::TableType)
-            .filter(table::Column::TableId.is_in(all_dirty_table_ids))
-            .into_tuple::<(ObjectId, TableType)>()
-            .all(&txn)
-            .await?
-            .into_iter()
-            .collect();
-
-        let dirty_background_jobs: HashSet<JobId> = streaming_job::Entity::find()
-            .select_only()
-            .column(streaming_job::Column::JobId)
-            .filter(
-                streaming_job::Column::JobId
-                    .is_in(dirty_job_ids.iter().copied())
-                    .and(streaming_job::Column::CreateType.eq(CreateType::Background)),
-            )
-            .into_tuple()
-            .all(&txn)
-            .await?
-            .into_iter()
-            .collect();
-
-        // notify delete for failed materialized views and background jobs.
-        let to_notify_objs = dirty_job_objs
-            .iter()
-            .filter(|obj| {
-                matches!(
-                    dirty_table_type_map.get(&obj.oid),
-                    Some(TableType::MaterializedView)
-                ) || dirty_background_jobs.contains(&obj.oid.as_job_id())
-            })
-            .cloned()
-            .collect_vec();
+        // Frontend deletion is idempotent, so notify every dirty job even if frontend did not
+        // observe its creating catalog or it is a temporary replacement object.
+        let to_notify_objs = dirty_job_objs.clone();
 
         // The source ids for dirty tables with connector.
         // FIXME: we should also clean dirty sources.
@@ -704,6 +663,24 @@ impl CatalogController {
                     .and(table::Column::OptionalAssociatedSourceId.is_not_null()),
             )
             .into_tuple()
+            .all(&txn)
+            .await?;
+        let dirty_associated_source_objs = Object::find()
+            .select_only()
+            .columns([
+                object::Column::Oid,
+                object::Column::ObjType,
+                object::Column::SchemaId,
+                object::Column::DatabaseId,
+            ])
+            .filter(
+                object::Column::Oid.is_in(
+                    dirty_associated_source_ids
+                        .iter()
+                        .map(|source_id| source_id.as_object_id()),
+                ),
+            )
+            .into_partial_model()
             .all(&txn)
             .await?;
 
@@ -785,6 +762,7 @@ impl CatalogController {
             to_notify_objs
                 .into_iter()
                 .chain(dirty_internal_table_objs)
+                .chain(dirty_associated_source_objs)
                 .collect_vec(),
         );
 
@@ -1129,7 +1107,7 @@ impl CatalogControllerInner {
             .collect())
     }
 
-    /// `list_tables` return all `CREATED` tables, `CREATING` materialized views/ `BACKGROUND` jobs and internal tables that belong to them and sinks.
+    /// `list_tables` returns all streaming-job tables and their internal tables.
     async fn list_tables(&self) -> MetaResult<Vec<PbTable>> {
         let mut table_objs = Table::find()
             .find_also_related(Object)
@@ -1142,38 +1120,10 @@ impl CatalogControllerInner {
             .into_iter()
             .map(|job| (job.job_id, job))
             .collect();
-
-        let sink_ids: HashSet<SinkId> = Sink::find()
-            .select_only()
-            .column(sink::Column::SinkId)
-            .into_tuple::<SinkId>()
-            .all(&self.db)
-            .await?
-            .into_iter()
-            .collect();
-
-        let mview_job_ids: HashSet<JobId> = table_objs
-            .iter()
-            .filter_map(|(table, _)| {
-                if table.table_type == TableType::MaterializedView {
-                    Some(table.table_id.as_job_id())
-                } else {
-                    None
-                }
-            })
-            .collect();
-
         table_objs.retain(|(table, _)| {
-            let job_id = table.job_id();
-
-            if sink_ids.contains(&job_id.as_sink_id()) || mview_job_ids.contains(&job_id) {
-                return true;
-            }
-            if let Some(streaming_job) = all_streaming_jobs.get(&job_id) {
-                return streaming_job.job_status == JobStatus::Created
-                    || (streaming_job.create_type == CreateType::Background);
-            }
-            false
+            all_streaming_jobs
+                .get(&table.job_id())
+                .is_some_and(|job| job.job_status != JobStatus::Initial)
         });
 
         let mut tables = Vec::with_capacity(table_objs.len());
@@ -1186,7 +1136,8 @@ impl CatalogControllerInner {
         Ok(tables)
     }
 
-    /// `list_sources` return all sources and `CREATED` ones if contains any streaming jobs.
+    /// `list_sources` returns all sources, including shared and associated sources whose streaming
+    /// jobs are still being created.
     async fn list_sources(&self) -> MetaResult<Vec<PbSource>> {
         let mut source_objs = Source::find()
             .find_also_related(Object)
@@ -1194,30 +1145,30 @@ impl CatalogControllerInner {
             .filter(
                 streaming_job::Column::JobStatus
                     .is_null()
-                    .or(streaming_job::Column::JobStatus.eq(JobStatus::Created)),
+                    .or(streaming_job::Column::JobStatus.ne(JobStatus::Initial)),
             )
             .all(&self.db)
             .await?;
 
-        // filter out inner connector sources that are still under creating.
-        let created_table_ids: HashSet<TableId> = Table::find()
+        let visible_table_ids: HashSet<TableId> = Table::find()
             .select_only()
             .column(table::Column::TableId)
             .join(JoinType::InnerJoin, table::Relation::Object1.def())
-            .join(JoinType::LeftJoin, object::Relation::StreamingJob.def())
+            .join(JoinType::InnerJoin, object::Relation::StreamingJob.def())
             .filter(
                 table::Column::OptionalAssociatedSourceId
                     .is_not_null()
-                    .and(streaming_job::Column::JobStatus.eq(JobStatus::Created)),
+                    .and(streaming_job::Column::JobStatus.ne(JobStatus::Initial)),
             )
             .into_tuple()
             .all(&self.db)
             .await?
             .into_iter()
             .collect();
-        source_objs.retain_mut(|(source, _)| {
-            source.optional_associated_table_id.is_none()
-                || created_table_ids.contains(&source.optional_associated_table_id.unwrap())
+        source_objs.retain(|(source, _)| {
+            source
+                .optional_associated_table_id
+                .is_none_or(|table_id| visible_table_ids.contains(&table_id))
         });
 
         Ok(source_objs
@@ -1231,6 +1182,11 @@ impl CatalogControllerInner {
         let sink_objs = Sink::find()
             .find_also_related(Object)
             .join(JoinType::LeftJoin, object::Relation::StreamingJob.def())
+            .filter(
+                streaming_job::Column::JobStatus
+                    .is_null()
+                    .or(streaming_job::Column::JobStatus.ne(JobStatus::Initial)),
+            )
             .all(&self.db)
             .await?;
         let streaming_jobs = load_streaming_jobs_by_ids(
@@ -1271,16 +1227,12 @@ impl CatalogControllerInner {
             .collect())
     }
 
-    /// `list_indexes` return all `CREATED` and `BACKGROUND` indexes.
+    /// `list_indexes` returns all streaming indexes.
     async fn list_indexes(&self) -> MetaResult<Vec<PbIndex>> {
         let index_objs = Index::find()
             .find_also_related(Object)
-            .join(JoinType::LeftJoin, object::Relation::StreamingJob.def())
-            .filter(
-                streaming_job::Column::JobStatus
-                    .eq(JobStatus::Created)
-                    .or(streaming_job::Column::CreateType.eq(CreateType::Background)),
-            )
+            .join(JoinType::InnerJoin, object::Relation::StreamingJob.def())
+            .filter(streaming_job::Column::JobStatus.ne(JobStatus::Initial))
             .all(&self.db)
             .await?;
         let streaming_jobs = load_streaming_jobs_by_ids(
@@ -1290,7 +1242,6 @@ impl CatalogControllerInner {
                 .map(|(index, _)| index.index_id.as_job_id()),
         )
         .await?;
-
         Ok(index_objs
             .into_iter()
             .map(|(index, obj)| {

--- a/src/meta/src/controller/catalog/test.rs
+++ b/src/meta/src/controller/catalog/test.rs
@@ -18,8 +18,8 @@ mod tests {
     use risingwave_meta_model::FragmentId;
     use risingwave_meta_model::fragment::DistributionType;
     use risingwave_meta_model::table::HandleConflictBehavior;
-    use risingwave_pb::catalog::StreamSourceInfo;
     use risingwave_pb::catalog::subscription::SubscriptionState;
+    use risingwave_pb::catalog::{PbSinkType, StreamSourceInfo};
     use risingwave_pb::common::{HostAddress, WorkerNode, WorkerType, worker_node};
     use risingwave_pb::meta::SubscribeType;
     use risingwave_pb::stream_plan::PbStreamNode;
@@ -27,6 +27,7 @@ mod tests {
 
     use crate::controller::catalog::*;
     use crate::manager::{LocalNotification, WorkerKey};
+    use crate::model::FragmentDownstreamRelation;
     use crate::serving::ServingVnodeMapping;
 
     const TEST_DATABASE_ID: DatabaseId = DatabaseId::new(1);
@@ -151,6 +152,16 @@ mod tests {
         )
         .await?;
 
+        insert_test_streaming_job_model(txn, job_id, policy).await?;
+
+        Ok((job_id, result_table_id, internal_table_id))
+    }
+
+    async fn insert_test_streaming_job_model(
+        txn: &DatabaseTransaction,
+        job_id: JobId,
+        policy: Option<CacheRefillPolicy>,
+    ) -> MetaResult<()> {
         streaming_job::ActiveModel {
             job_id: Set(job_id),
             job_status: Set(JobStatus::Created),
@@ -175,7 +186,7 @@ mod tests {
         .insert(txn)
         .await?;
 
-        Ok((job_id, result_table_id, internal_table_id))
+        Ok(())
     }
 
     #[tokio::test]
@@ -256,6 +267,297 @@ mod tests {
                 ),
             ])
         );
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_foreground_creating_catalog_lifecycle() -> MetaResult<()> {
+        let env = MetaSrvEnv::for_test().await;
+        let (tx, mut notification_rx) = mpsc::unbounded_channel();
+        env.notification_manager().insert_sender(
+            SubscribeType::Frontend,
+            WorkerKey(HostAddress {
+                host: "localhost".to_owned(),
+                port: 1234,
+            }),
+            tx,
+        );
+        let mgr = CatalogController::new(env).await?;
+        let inner = mgr.inner.write().await;
+        let txn = inner.db.begin().await?;
+
+        // A foreground table and its internal table are both visible while creating.
+        let (job_id, Some(table_id), internal_table_id) =
+            insert_test_streaming_job(&txn, "creating_table", true, None).await?
+        else {
+            unreachable!()
+        };
+        let associated_source_id = CatalogController::create_object(
+            &txn,
+            ObjectType::Source,
+            TEST_OWNER_ID,
+            Some(TEST_DATABASE_ID),
+            Some(TEST_SCHEMA_ID),
+        )
+        .await?
+        .oid
+        .as_source_id();
+        Source::insert(source::ActiveModel::from(PbSource {
+            id: associated_source_id,
+            schema_id: TEST_SCHEMA_ID,
+            database_id: TEST_DATABASE_ID,
+            name: "creating_table_source".to_owned(),
+            owner: TEST_OWNER_ID as _,
+            optional_associated_table_id: Some(
+                risingwave_pb::catalog::source::OptionalAssociatedTableId::AssociatedTableId(
+                    table_id,
+                ),
+            ),
+            ..Default::default()
+        }))
+        .exec(&txn)
+        .await?;
+        table::ActiveModel {
+            table_id: Set(table_id),
+            table_type: Set(TableType::Table),
+            optional_associated_source_id: Set(Some(associated_source_id)),
+            ..Default::default()
+        }
+        .update(&txn)
+        .await?;
+        streaming_job::ActiveModel {
+            job_id: Set(job_id),
+            job_status: Set(JobStatus::Initial),
+            ..Default::default()
+        }
+        .update(&txn)
+        .await?;
+
+        // A foreground index and its index table are both visible while creating.
+        let (_primary_job_id, Some(primary_table_id), _) =
+            insert_test_streaming_job(&txn, "primary_table", true, None).await?
+        else {
+            unreachable!()
+        };
+        let index_job_id = CatalogController::create_object(
+            &txn,
+            ObjectType::Index,
+            TEST_OWNER_ID,
+            Some(TEST_DATABASE_ID),
+            Some(TEST_SCHEMA_ID),
+        )
+        .await?
+        .oid
+        .as_job_id();
+        let index_table_id = index_job_id.as_mv_table_id();
+        insert_test_table(
+            &txn,
+            index_table_id,
+            "creating_index",
+            TableType::Index,
+            None,
+            "",
+        )
+        .await?;
+        index::ActiveModel {
+            index_id: Set(index_job_id.as_index_id()),
+            name: Set("creating_index".to_owned()),
+            index_table_id: Set(index_table_id),
+            primary_table_id: Set(primary_table_id),
+            index_items: Set(vec![].into()),
+            index_column_properties: Set(None),
+            index_columns_len: Set(0),
+        }
+        .insert(&txn)
+        .await?;
+        insert_test_streaming_job_model(&txn, index_job_id, None).await?;
+        streaming_job::ActiveModel {
+            job_id: Set(index_job_id),
+            job_status: Set(JobStatus::Initial),
+            ..Default::default()
+        }
+        .update(&txn)
+        .await?;
+
+        // A creating shared source is included in restart snapshots as well.
+        let source_job_id = CatalogController::create_object(
+            &txn,
+            ObjectType::Source,
+            TEST_OWNER_ID,
+            Some(TEST_DATABASE_ID),
+            Some(TEST_SCHEMA_ID),
+        )
+        .await?
+        .oid
+        .as_job_id();
+        Source::insert(source::ActiveModel::from(PbSource {
+            id: source_job_id.as_shared_source_id(),
+            schema_id: TEST_SCHEMA_ID,
+            database_id: TEST_DATABASE_ID,
+            name: "creating_shared_source".to_owned(),
+            owner: TEST_OWNER_ID as _,
+            info: Some(StreamSourceInfo {
+                cdc_source_job: true,
+                ..Default::default()
+            }),
+            ..Default::default()
+        }))
+        .exec(&txn)
+        .await?;
+        insert_test_streaming_job_model(&txn, source_job_id, None).await?;
+        streaming_job::ActiveModel {
+            job_id: Set(source_job_id),
+            job_status: Set(JobStatus::Initial),
+            ..Default::default()
+        }
+        .update(&txn)
+        .await?;
+
+        let sink_job_id = CatalogController::create_object(
+            &txn,
+            ObjectType::Sink,
+            TEST_OWNER_ID,
+            Some(TEST_DATABASE_ID),
+            Some(TEST_SCHEMA_ID),
+        )
+        .await?
+        .oid
+        .as_job_id();
+        Sink::insert(sink::ActiveModel::from(PbSink {
+            id: sink_job_id.as_sink_id(),
+            schema_id: TEST_SCHEMA_ID,
+            database_id: TEST_DATABASE_ID,
+            name: "creating_sink".to_owned(),
+            owner: TEST_OWNER_ID as _,
+            sink_type: PbSinkType::AppendOnly as i32,
+            ..Default::default()
+        }))
+        .exec(&txn)
+        .await?;
+        insert_test_streaming_job_model(&txn, sink_job_id, None).await?;
+        streaming_job::ActiveModel {
+            job_id: Set(sink_job_id),
+            job_status: Set(JobStatus::Initial),
+            ..Default::default()
+        }
+        .update(&txn)
+        .await?;
+
+        txn.commit().await?;
+
+        let (catalog, _) = inner.snapshot().await?;
+        assert!(!catalog.2.iter().any(|table| table.id == table_id));
+        assert!(!catalog.2.iter().any(|table| table.id == internal_table_id));
+        assert!(!catalog.2.iter().any(|table| table.id == index_table_id));
+        assert!(
+            !catalog
+                .3
+                .iter()
+                .any(|source| source.id == associated_source_id)
+        );
+        assert!(
+            !catalog
+                .3
+                .iter()
+                .any(|source| source.id == source_job_id.as_shared_source_id())
+        );
+        assert!(
+            !catalog
+                .6
+                .iter()
+                .any(|index| index.id == index_job_id.as_index_id())
+        );
+        assert!(
+            !catalog
+                .4
+                .iter()
+                .any(|sink| sink.id == sink_job_id.as_sink_id())
+        );
+
+        drop(inner);
+
+        let downstreams = FragmentDownstreamRelation::new();
+        let mut add_notifications = vec![];
+        for creating_job_id in [job_id, index_job_id, source_job_id, sink_job_id] {
+            mgr.post_collect_job_fragments(creating_job_id, &downstreams, None, None, None, true)
+                .await?;
+            let notification = notification_rx
+                .recv()
+                .await
+                .expect("frontend should receive a creating notification")
+                .expect("creating notification should be valid");
+            assert_eq!(notification.operation(), NotificationOperation::Add);
+            let object_group = match notification.info {
+                Some(NotificationInfo::ObjectGroup(object_group)) => object_group,
+                other => panic!("unexpected notification: {other:?}"),
+            };
+            add_notifications.push(object_group);
+        }
+
+        assert!(add_notifications[0].objects.iter().any(|object| matches!(
+            &object.object_info,
+            Some(PbObjectInfo::Table(table)) if table.id == table_id
+        )));
+        assert!(add_notifications[0].objects.iter().any(|object| matches!(
+            &object.object_info,
+            Some(PbObjectInfo::Table(table)) if table.id == internal_table_id
+        )));
+        assert!(add_notifications[0].objects.iter().any(|object| matches!(
+            &object.object_info,
+            Some(PbObjectInfo::Source(source)) if source.id == associated_source_id
+        )));
+        assert!(add_notifications[1].objects.iter().any(|object| matches!(
+            &object.object_info,
+            Some(PbObjectInfo::Table(table)) if table.id == index_table_id
+        )));
+        assert!(add_notifications[1].objects.iter().any(|object| matches!(
+            &object.object_info,
+            Some(PbObjectInfo::Index(index)) if index.id == index_job_id.as_index_id()
+        )));
+        assert!(add_notifications[2].objects.iter().any(|object| matches!(
+            &object.object_info,
+            Some(PbObjectInfo::Source(source)) if source.id == source_job_id.as_shared_source_id()
+        )));
+        assert!(add_notifications[3].objects.iter().any(|object| matches!(
+            &object.object_info,
+            Some(PbObjectInfo::Sink(sink)) if sink.id == sink_job_id.as_sink_id()
+        )));
+
+        let inner = mgr.inner.write().await;
+        let (catalog, _) = inner.snapshot().await?;
+        assert!(catalog.2.iter().any(|table| table.id == table_id));
+        assert!(catalog.2.iter().any(|table| table.id == internal_table_id));
+        assert!(catalog.2.iter().any(|table| table.id == index_table_id));
+        assert!(
+            catalog
+                .3
+                .iter()
+                .any(|source| source.id == source_job_id.as_shared_source_id())
+        );
+        assert!(
+            catalog
+                .6
+                .iter()
+                .any(|index| index.id == index_job_id.as_index_id())
+        );
+        assert!(
+            catalog
+                .4
+                .iter()
+                .any(|sink| sink.id == sink_job_id.as_sink_id())
+        );
+
+        let txn = inner.db.begin().await?;
+        let (operation, _, _, _) = mgr.finish_streaming_job_inner(&txn, job_id).await?;
+        assert_eq!(operation, NotificationOperation::Update);
+        let (operation, _, _, _) = mgr.finish_streaming_job_inner(&txn, index_job_id).await?;
+        assert_eq!(operation, NotificationOperation::Update);
+        let (operation, _, _, _) = mgr.finish_streaming_job_inner(&txn, source_job_id).await?;
+        assert_eq!(operation, NotificationOperation::Update);
+        let (operation, _, _, _) = mgr.finish_streaming_job_inner(&txn, sink_job_id).await?;
+        assert_eq!(operation, NotificationOperation::Update);
+        txn.commit().await?;
 
         Ok(())
     }
@@ -675,11 +977,39 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_abort_initial_materialized_view_reports_cancellation() -> MetaResult<()> {
-        let mgr = CatalogController::new(MetaSrvEnv::for_test().await).await?;
+    async fn test_cancel_creating_table_deletes_associated_source() -> MetaResult<()> {
+        let env = MetaSrvEnv::for_test().await;
+        let (tx, mut notification_rx) = mpsc::unbounded_channel();
+        env.notification_manager().insert_sender(
+            SubscribeType::Frontend,
+            WorkerKey(HostAddress {
+                host: "localhost".to_owned(),
+                port: 1234,
+            }),
+            tx,
+        );
+        let mgr = CatalogController::new(env).await?;
 
         let mut inner = mgr.inner.write().await;
         let txn = inner.db.begin().await?;
+        let source_obj = CatalogController::create_object(
+            &txn,
+            ObjectType::Source,
+            TEST_OWNER_ID,
+            Some(TEST_DATABASE_ID),
+            Some(TEST_SCHEMA_ID),
+        )
+        .await?;
+        Source::insert(source::ActiveModel::from(PbSource {
+            id: source_obj.oid.as_source_id(),
+            schema_id: TEST_SCHEMA_ID,
+            database_id: TEST_DATABASE_ID,
+            name: "source_abort_initial".to_owned(),
+            owner: TEST_OWNER_ID as _,
+            ..Default::default()
+        }))
+        .exec(&txn)
+        .await?;
         let obj = CatalogController::create_object(
             &txn,
             ObjectType::Table,
@@ -692,9 +1022,9 @@ mod tests {
 
         table::ActiveModel {
             table_id: Set(obj.oid.as_table_id()),
-            name: Set("mv_abort_initial".to_owned()),
-            optional_associated_source_id: Set(None),
-            table_type: Set(TableType::MaterializedView),
+            name: Set("table_abort_initial".to_owned()),
+            optional_associated_source_id: Set(Some(source_obj.oid.as_source_id())),
+            table_type: Set(TableType::Table),
             belongs_to_job_id: Set(None),
             columns: Set(vec![].into()),
             pk: Set(vec![].into()),
@@ -705,7 +1035,7 @@ mod tests {
             vnode_col_index: Set(None),
             row_id_index: Set(None),
             value_indices: Set(Vec::<i32>::new().into()),
-            definition: Set("CREATE MATERIALIZED VIEW mv_abort_initial AS SELECT 1".to_owned()),
+            definition: Set("CREATE TABLE table_abort_initial (v1 INT)".to_owned()),
             handle_pk_conflict_behavior: Set(HandleConflictBehavior::NoCheck),
             version_column_indices: Set(None),
             read_prefix_len_hint: Set(0),
@@ -732,7 +1062,7 @@ mod tests {
 
         streaming_job::ActiveModel {
             job_id: Set(job_id),
-            job_status: Set(JobStatus::Initial),
+            job_status: Set(JobStatus::Creating),
             create_type: Set(CreateType::Foreground),
             timezone: Set(None),
             config_override: Set(None),
@@ -761,7 +1091,7 @@ mod tests {
         let err = rx
             .await
             .expect("finish notifier should be notified")
-            .expect_err("initial job drop should cancel the create wait");
+            .expect_err("creating job cancellation should fail the create wait");
         assert!(err.contains("cancelled"));
 
         let db = &mgr.inner.read().await.db;
@@ -773,6 +1103,31 @@ mod tests {
                 .await?
                 .is_none()
         );
+        assert!(
+            Source::find_by_id(source_obj.oid.as_source_id())
+                .one(db)
+                .await?
+                .is_none()
+        );
+
+        let notification = notification_rx
+            .recv()
+            .await
+            .expect("frontend should receive an abort notification")
+            .expect("abort notification should be valid");
+        assert_eq!(notification.operation(), NotificationOperation::Delete);
+        let object_group = match notification.info {
+            Some(NotificationInfo::ObjectGroup(object_group)) => object_group,
+            other => panic!("unexpected notification: {other:?}"),
+        };
+        assert!(object_group.objects.iter().any(|object| matches!(
+            &object.object_info,
+            Some(PbObjectInfo::Table(table)) if table.id == job_id.as_mv_table_id()
+        )));
+        assert!(object_group.objects.iter().any(|object| matches!(
+            &object.object_info,
+            Some(PbObjectInfo::Source(source)) if source.id == source_obj.oid.as_source_id()
+        )));
 
         Ok(())
     }

--- a/src/meta/src/controller/streaming_job.rs
+++ b/src/meta/src/controller/streaming_job.rs
@@ -46,7 +46,6 @@ use risingwave_meta_model::object::ObjectType;
 use risingwave_meta_model::prelude::{StreamingJob as StreamingJobModel, *};
 use risingwave_meta_model::refresh_job::RefreshState;
 use risingwave_meta_model::streaming_job::BackfillOrders;
-use risingwave_meta_model::table::TableType;
 use risingwave_meta_model::user_privilege::Action;
 use risingwave_meta_model::*;
 use risingwave_pb::catalog::table::PbEngine;
@@ -57,7 +56,7 @@ use risingwave_pb::meta::alter_connector_props_request::AlterIcebergTableIds;
 use risingwave_pb::meta::list_rate_limits_response::RateLimitInfo;
 use risingwave_pb::meta::object::PbObjectInfo;
 use risingwave_pb::meta::subscribe_response::{
-    Info as NotificationInfo, Info, Operation as NotificationOperation, Operation,
+    Info as NotificationInfo, Operation as NotificationOperation, Operation,
 };
 use risingwave_pb::meta::{ObjectDependency as PbObjectDependency, PbObject, PbObjectGroup};
 use risingwave_pb::plan_common::PbColumnCatalog;
@@ -320,11 +319,11 @@ impl CatalogController {
         Ok(model)
     }
 
-    /// Create catalogs for the streaming job, then notify frontend about them if the job is a
-    /// materialized view.
+    /// Create the initial catalogs for the streaming job.
     ///
     /// Some of the fields in the given streaming job are placeholders, which will
-    /// be updated later in `prepare_streaming_job` and notify again in `finish_streaming_job`.
+    /// be updated later in `prepare_streaming_job`. The catalogs become visible to frontend after
+    /// the first barrier is collected in `post_collect_job_fragments`.
     #[expect(clippy::too_many_arguments)]
     #[await_tree::instrument]
     pub async fn create_job_catalog(
@@ -684,11 +683,11 @@ impl CatalogController {
         Ok(streaming_job_model)
     }
 
-    /// Create catalogs for internal tables, then notify frontend about them if the job is a
-    /// materialized view.
+    /// Create the initial catalogs for internal tables.
     ///
     /// Some of the fields in the given "incomplete" internal tables are placeholders, which will
-    /// be updated later in `prepare_streaming_job` and notify again in `finish_streaming_job`.
+    /// be updated later in `prepare_streaming_job`. The catalogs become visible to frontend after
+    /// the first barrier is collected in `post_collect_job_fragments`.
     ///
     /// Returns a mapping from the temporary table id to the actual global table id.
     pub async fn create_internal_table_catalog(
@@ -775,7 +774,8 @@ impl CatalogController {
     // TODO: In this function, we also update the `Table` model in the meta store.
     // Given that we've ensured the tables inside `TableFragments` are complete, shall we consider
     // making them the source of truth and performing a full replacement for those in the meta store?
-    /// Insert fragments and actors to meta store. Used both for creating new jobs and replacing jobs.
+    /// Insert fragments and actors into the meta store. Used both for creating new jobs and
+    /// replacing jobs. This does not make a new job visible to frontend.
     #[await_tree::instrument("prepare_streaming_job_for_{}", if for_replace { "replace" } else { "create" }
     )]
     pub async fn prepare_streaming_job<'a, I: Iterator<Item = &'a crate::model::Fragment> + 'a>(
@@ -791,12 +791,6 @@ impl CatalogController {
 
         let inner = self.inner.write().await;
 
-        let need_notify = creating_streaming_job
-            .map(|job| job.should_notify_creating())
-            .unwrap_or(false);
-        let definition = creating_streaming_job.map(|job| job.definition());
-
-        let mut objects_to_notify = vec![];
         let txn = inner.db.begin().await?;
 
         // Ensure the job exists.
@@ -852,39 +846,6 @@ impl CatalogController {
                 })
                 .exec(&txn)
                 .await?;
-
-                if need_notify {
-                    let mut table = table.clone();
-                    // In production, definition was replaced but still needed for notification.
-                    if cfg!(not(debug_assertions)) && table.id == job_id.as_raw_id() {
-                        table.definition = definition.clone().unwrap();
-                    }
-                    objects_to_notify.push(PbObject {
-                        object_info: Some(PbObjectInfo::Table(table)),
-                    });
-                }
-            }
-        }
-
-        // Add streaming job objects to notification
-        if need_notify {
-            match creating_streaming_job.unwrap() {
-                StreamingJob::Table(Some(source), ..) => {
-                    objects_to_notify.push(PbObject {
-                        object_info: Some(PbObjectInfo::Source(source.clone())),
-                    });
-                }
-                StreamingJob::Sink(sink) => {
-                    objects_to_notify.push(PbObject {
-                        object_info: Some(PbObjectInfo::Sink(sink.clone())),
-                    });
-                }
-                StreamingJob::Index(index, _) => {
-                    objects_to_notify.push(PbObject {
-                        object_info: Some(PbObjectInfo::Index(index.clone())),
-                    });
-                }
-                _ => {}
             }
         }
 
@@ -911,20 +872,6 @@ impl CatalogController {
         self.env
             .notification_manager()
             .notify_serving_fragment_mapping_update(inserted_fragment_ids);
-
-        // FIXME: there's a gap between the catalog creation and notification, which may lead to
-        // frontend receiving duplicate notifications if the frontend restarts right in this gap. We
-        // need to either forward the notification or filter catalogs without any fragments in the metastore.
-        if !objects_to_notify.is_empty() {
-            self.notify_frontend(
-                Operation::Add,
-                Info::ObjectGroup(PbObjectGroup {
-                    objects: objects_to_notify,
-                    dependencies: vec![],
-                }),
-            )
-            .await;
-        }
 
         Ok(())
     }
@@ -1066,19 +1013,12 @@ impl CatalogController {
 
         let internal_table_ids = get_internal_tables_by_id(job_id, &txn).await?;
 
-        // Get the notification info if the job is a materialized view or created in the background.
+        // A job becomes visible to frontend only after it enters the creating status.
         let mut objs = vec![];
         let table_obj = Table::find_by_id(job_id.as_mv_table_id()).one(&txn).await?;
-
-        let mut need_notify =
-            streaming_job.is_some_and(|job| job.create_type == CreateType::Background);
-        if !need_notify {
-            if let Some(table) = &table_obj {
-                need_notify = table.table_type == TableType::MaterializedView;
-            } else if original_obj_type == ObjectType::Sink {
-                need_notify = true;
-            }
-        }
+        let need_notify = streaming_job
+            .as_ref()
+            .is_some_and(|job| job.job_status != JobStatus::Initial);
 
         if is_cancelled {
             let dropped_tables = Table::find()
@@ -1134,6 +1074,22 @@ impl CatalogController {
             let obj =
                 obj.ok_or_else(|| MetaError::catalog_id_not_found("streaming job", job_id))?;
             objs.push(obj);
+            if let Some(table) = &table_obj
+                && let Some(source_id) = table.optional_associated_source_id
+                && let Some(source_obj) = Object::find_by_id(source_id)
+                    .select_only()
+                    .columns([
+                        object::Column::Oid,
+                        object::Column::ObjType,
+                        object::Column::SchemaId,
+                        object::Column::DatabaseId,
+                    ])
+                    .into_partial_model()
+                    .one(&txn)
+                    .await?
+            {
+                objs.push(source_obj);
+            }
             let internal_table_objs: Vec<PartialObject> = Object::find()
                 .select_only()
                 .columns([
@@ -1212,6 +1168,103 @@ impl CatalogController {
         })
     }
 
+    async fn build_creating_streaming_job_objects(
+        txn: &DatabaseTransaction,
+        job_id: JobId,
+    ) -> MetaResult<Vec<PbObject>> {
+        let job_type = Object::find_by_id(job_id)
+            .select_only()
+            .column(object::Column::ObjType)
+            .into_tuple()
+            .one(txn)
+            .await?
+            .ok_or_else(|| MetaError::catalog_id_not_found("streaming job", job_id))?;
+        let streaming_job = StreamingJobModel::find_by_id(job_id)
+            .one(txn)
+            .await?
+            .ok_or_else(|| MetaError::catalog_id_not_found("streaming job", job_id))?;
+
+        let table_objs = Table::find()
+            .find_also_related(Object)
+            .filter(
+                table::Column::BelongsToJobId
+                    .eq(job_id)
+                    .or(table::Column::TableId.eq(job_id.as_mv_table_id())),
+            )
+            .all(txn)
+            .await?;
+        let associated_source_id = table_objs
+            .iter()
+            .find(|(table, _)| table.table_id == job_id.as_mv_table_id())
+            .and_then(|(table, _)| table.optional_associated_source_id);
+        let mut objects = table_objs
+            .into_iter()
+            .map(|(table, obj)| PbObject {
+                object_info: Some(PbObjectInfo::Table(
+                    ObjectModel(table, obj.unwrap(), Some(streaming_job.clone())).into(),
+                )),
+            })
+            .collect_vec();
+
+        match job_type {
+            ObjectType::Table => {
+                if let Some(source_id) = associated_source_id {
+                    let (source, obj) = Source::find_by_id(source_id)
+                        .find_also_related(Object)
+                        .one(txn)
+                        .await?
+                        .ok_or_else(|| MetaError::catalog_id_not_found("source", source_id))?;
+                    objects.push(PbObject {
+                        object_info: Some(PbObjectInfo::Source(
+                            ObjectModel(source, obj.unwrap(), None).into(),
+                        )),
+                    });
+                }
+            }
+            ObjectType::Sink => {
+                let (sink, obj) = Sink::find_by_id(job_id.as_sink_id())
+                    .find_also_related(Object)
+                    .one(txn)
+                    .await?
+                    .ok_or_else(|| MetaError::catalog_id_not_found("sink", job_id))?;
+                objects.push(PbObject {
+                    object_info: Some(PbObjectInfo::Sink(
+                        ObjectModel(sink, obj.unwrap(), Some(streaming_job)).into(),
+                    )),
+                });
+            }
+            ObjectType::Index => {
+                let (index, obj) = Index::find_by_id(job_id.as_index_id())
+                    .find_also_related(Object)
+                    .one(txn)
+                    .await?
+                    .ok_or_else(|| MetaError::catalog_id_not_found("index", job_id))?;
+                objects.push(PbObject {
+                    object_info: Some(PbObjectInfo::Index(
+                        ObjectModel(index, obj.unwrap(), Some(streaming_job)).into(),
+                    )),
+                });
+            }
+            ObjectType::Source => {
+                let (source, obj) = Source::find_by_id(job_id.as_shared_source_id())
+                    .find_also_related(Object)
+                    .one(txn)
+                    .await?
+                    .ok_or_else(|| MetaError::catalog_id_not_found("source", job_id))?;
+                objects.push(PbObject {
+                    object_info: Some(PbObjectInfo::Source(
+                        ObjectModel(source, obj.unwrap(), None).into(),
+                    )),
+                });
+            }
+            _ => unreachable!("invalid streaming job type: {job_type:?}"),
+        }
+
+        Ok(objects)
+    }
+
+    /// Mark a job as creating after its first barrier is collected and notify frontend to add its
+    /// creating catalogs.
     #[await_tree::instrument]
     pub async fn post_collect_job_fragments(
         &self,
@@ -1220,6 +1273,7 @@ impl CatalogController {
         new_sink_downstream: Option<FragmentDownstreamRelation>,
         split_assignment: Option<&SplitAssignment>,
         replace_sink: Option<&SinkId>,
+        notify_creating: bool,
     ) -> MetaResult<Option<Vec<TableId>>> {
         let mut inner = self.inner.write().await;
         let txn = inner.db.begin().await?;
@@ -1386,7 +1440,24 @@ impl CatalogController {
             ));
         }
 
+        let creating_objects = if notify_creating {
+            Some(Self::build_creating_streaming_job_objects(&txn, job_id).await?)
+        } else {
+            None
+        };
+
         txn.commit().await?;
+
+        if let Some(objects) = creating_objects {
+            self.notify_frontend(
+                NotificationOperation::Add,
+                NotificationInfo::ObjectGroup(PbObjectGroup {
+                    objects,
+                    dependencies: vec![],
+                }),
+            )
+            .await;
+        }
 
         let Some((
             old_state_table_ids,
@@ -1625,14 +1696,6 @@ impl CatalogController {
             .await?
             .ok_or_else(|| MetaError::catalog_id_not_found("streaming job", job_id))?;
 
-        let create_type: CreateType = StreamingJobModel::find_by_id(job_id)
-            .select_only()
-            .column(streaming_job::Column::CreateType)
-            .into_tuple()
-            .one(txn)
-            .await?
-            .ok_or_else(|| MetaError::catalog_id_not_found("streaming job", job_id))?;
-
         // update `created_at` as now() and `created_at_cluster_version` as current cluster version.
         let res = Object::update_many()
             .col_expr(object::Column::CreatedAt, Expr::current_timestamp().into())
@@ -1669,11 +1732,7 @@ impl CatalogController {
                 )),
             })
             .collect_vec();
-        let mut notification_op = if create_type == CreateType::Background {
-            NotificationOperation::Update
-        } else {
-            NotificationOperation::Add
-        };
+        let notification_op = NotificationOperation::Update;
         let mut updated_user_info = vec![];
         let mut need_grant_default_privileges = true;
 
@@ -1684,10 +1743,6 @@ impl CatalogController {
                     .one(txn)
                     .await?
                     .ok_or_else(|| MetaError::catalog_id_not_found("table", job_id))?;
-                if table.table_type == TableType::MaterializedView {
-                    notification_op = NotificationOperation::Update;
-                }
-
                 if let Some(source_id) = table.optional_associated_source_id {
                     let (src, obj) = Source::find_by_id(source_id)
                         .find_also_related(Object)
@@ -1715,9 +1770,6 @@ impl CatalogController {
                 if sink.name.starts_with(ICEBERG_SINK_PREFIX) {
                     need_grant_default_privileges = false;
                 }
-                // If sinks were pre-notified during CREATING, we should use Update at finish
-                // to avoid duplicate Add notifications (align with MV behavior).
-                notification_op = NotificationOperation::Update;
                 objects.push(PbObject {
                     object_info: Some(PbObjectInfo::Sink(
                         ObjectModel(sink, obj.unwrap(), streaming_job).into(),

--- a/src/meta/src/manager/streaming_job.rs
+++ b/src/meta/src/manager/streaming_job.rs
@@ -322,13 +322,6 @@ impl StreamingJob {
         Ok(())
     }
 
-    // Check whether we should notify the FE about the `CREATING` catalog of this job.
-    pub fn should_notify_creating(&self) -> bool {
-        self.is_materialized_view()
-            || self.is_sink()
-            || matches!(self.create_type(), CreateType::Background)
-    }
-
     pub fn is_sink_into_table(&self) -> bool {
         matches!(self, Self::Sink(sink) if sink.target_table.is_some())
     }

--- a/src/meta/src/rpc/ddl_controller.rs
+++ b/src/meta/src/rpc/ddl_controller.rs
@@ -1398,32 +1398,15 @@ impl DdlController {
         }
 
         let backfill_orders = ctx.fragment_backfill_ordering.to_meta_model();
-        // Replacement sinks use a temporary catalog name before cutover, so do not notify
-        // frontend about their creating catalog.
-        let notify_creating = replace_sink.is_none();
-        if notify_creating {
-            self.metadata_manager
-                .catalog_controller
-                .prepare_stream_job_fragments(
-                    &stream_job_fragments,
-                    streaming_job,
-                    false,
-                    Some(backfill_orders),
-                )
-                .await?;
-        } else {
-            self.metadata_manager
-                .catalog_controller
-                .prepare_streaming_job(
-                    stream_job_fragments.stream_job_id(),
-                    || stream_job_fragments.fragments.values(),
-                    &stream_job_fragments.downstreams,
-                    false,
-                    None,
-                    Some(backfill_orders),
-                )
-                .await?;
-        }
+        self.metadata_manager
+            .catalog_controller
+            .prepare_stream_job_fragments(
+                &stream_job_fragments,
+                streaming_job,
+                false,
+                Some(backfill_orders),
+            )
+            .await?;
 
         Ok((stream_job_fragments, ctx))
     }


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

Foreground and background streaming DDL previously exposed creating catalog objects at different phases, with additional differences among tables, indexes, sinks, materialized views, associated sources, and shared sources. These gaps made frontend catalog recovery depend on both creation mode and job type.

This PR unifies the notification lifecycle:

- catalogs remain hidden while a streaming job is in the `Initial` state;
- after the first creation barrier is collected, `post_collect_job_fragments` marks the job `Creating` and sends one `ADD` notification containing all of its relevant catalogs;
- frontend restart snapshots include every non-`Initial` streaming job consistently, without foreground/background or job-type-specific visibility rules;
- finishing creation sends `UPDATE`, while cancellation and recovery cleanup send the corresponding `DELETE` notifications;
- replacement jobs remain excluded from the creating `ADD` path;
- frontend deletion of creating source and index catalogs is idempotent when notification delivery races with recovery or cancellation.

The notification behavior for normal streaming-job creation changes as follows:

| Job/catalog group | Before: foreground creation | Before: foreground finish | Before: background creation | Before: background finish | After: both create types |
|---|---|---|---|---|---|
| Materialized view + internal tables | `ADD` during preparation, before the first barrier | `UPDATE` | `ADD` during preparation | `UPDATE` | `ADD` after the first barrier is collected; `UPDATE` at finish |
| Sink + internal tables | `ADD` during preparation | `UPDATE` | `ADD` during preparation | `UPDATE` | `ADD` after the first barrier is collected; `UPDATE` at finish |
| Table + internal tables | No notification | `ADD` | `ADD` during preparation | `UPDATE` | `ADD` after the first barrier is collected; `UPDATE` at finish |
| Associated source of a table | No notification | Included in `ADD` | Included in preparation `ADD` | Included in `UPDATE` | Included in the post-first-barrier `ADD` and finishing `UPDATE` |
| Index + index/internal tables | No notification | `ADD` | `ADD` during preparation | `UPDATE` | `ADD` after the first barrier is collected; `UPDATE` at finish |
| Shared source | No notification | `ADD` | N/A: shared-source jobs are currently always foreground | N/A | `ADD` after the first barrier is collected; `UPDATE` at finish |

Frontend restart-snapshot visibility is also unified:

| Catalogs in frontend snapshot | Before: foreground | Before: background | After: both create types |
|---|---|---|---|
| Materialized view and sink | Included from `Initial` | Included from `Initial` | Included from `Creating` |
| Table and index | Included only when `Created` | Included from `Initial` | Included from `Creating` |
| Associated source | Included only when its table was `Created` | Included only when its table was `Created` | Included from `Creating` with its table |
| Shared source | Included only when `Created` | N/A: shared-source jobs are currently always foreground | Included from `Creating` |

The resulting lifecycle is `Initial` (hidden) → first barrier collected → `Creating` + `ADD` → creation finished → `Created` + `UPDATE`.

Validation:

- `cargo clippy --all-targets --all-features`
- `cargo test -p risingwave_meta --lib controller::catalog::test::tests::test_foreground_creating_catalog_lifecycle`
- focused associated-source catalog lifecycle test
- `cargo fmt --check`
- `git diff --check`

## Checklist

- [x] I have written necessary rustdoc comments.
- [x] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [x] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->

## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

Catalog objects being created by streaming DDL are now exposed consistently across foreground and background creation modes after creation has started.

</details>
