### PR TITLE
fix(batch): cap masked fragment mapping parallelism

### DIFF
--- a/src/batch/src/worker_manager/worker_node_manager.rs
+++ b/src/batch/src/worker_manager/worker_node_manager.rs
@@ -355,7 +355,11 @@ impl WorkerNodeSelector {
             .sum()
     }
 
-    pub fn fragment_mapping(&self, fragment_id: FragmentId) -> Result<WorkerSlotMapping> {
+    pub fn fragment_mapping(
+        &self,
+        fragment_id: FragmentId,
+        batch_parallelism: usize,
+    ) -> Result<WorkerSlotMapping> {
         if self.enable_barrier_read {
             self.manager.get_streaming_fragment_mapping(&fragment_id)
         } else {
@@ -373,8 +377,8 @@ impl WorkerNodeSelector {
             } else {
                 let workers = self.apply_worker_node_mask(self.manager.list_serving_worker_nodes());
                 // If it's a singleton, set max_parallelism=1 for place_vnode.
-                let max_parallelism = mapping.to_single().map(|_| 1);
-                // TODO: use runtime parameter batch_parallelism
+                // Otherwise, cap re-placement by the query's effective batch parallelism.
+                let max_parallelism = mapping.to_single().map(|_| 1).or(Some(batch_parallelism));
                 let masked_mapping =
                     place_vnode(Some(&mapping), &workers, max_parallelism, mapping.len())
                         .ok_or_else(|| BatchError::EmptyWorkerNodes)?;
@@ -475,6 +479,55 @@ mod tests {
                 .sorted_by_key(|w| w.id)
                 .collect_vec(),
             worker_nodes.as_slice()[1..].to_vec()
+        );
+    }
+
+    #[test]
+    fn test_fragment_mapping_respects_batch_parallelism_with_masked_workers() {
+        use super::*;
+
+        let worker_nodes = vec![
+            WorkerNode {
+                id: 1.into(),
+                r#type: WorkerType::ComputeNode as i32,
+                state: worker_node::State::Running as i32,
+                property: Some(Property {
+                    parallelism: 8,
+                    is_serving: true,
+                    ..Default::default()
+                }),
+                ..Default::default()
+            },
+            WorkerNode {
+                id: 2.into(),
+                r#type: WorkerType::ComputeNode as i32,
+                state: worker_node::State::Running as i32,
+                property: Some(Property {
+                    parallelism: 8,
+                    is_serving: true,
+                    ..Default::default()
+                }),
+                ..Default::default()
+            },
+        ];
+        let manager = Arc::new(WorkerNodeManager::mock(worker_nodes));
+        let selector = WorkerNodeSelector::new(manager.clone(), false);
+        let fragment_id = 1.into();
+        let worker_slot_ids = (0..8)
+            .map(|slot| WorkerSlotId::new(1.into(), slot))
+            .chain((0..8).map(|slot| WorkerSlotId::new(2.into(), slot)))
+            .collect_vec();
+        let mapping = WorkerSlotMapping::build_from_ids(&worker_slot_ids, 32);
+        manager.set_serving_fragment_mapping([(fragment_id, mapping)].into_iter().collect());
+
+        manager.worker_node_mask.write().unwrap().insert(1.into());
+
+        let masked_mapping = selector.fragment_mapping(fragment_id, 3).unwrap();
+        assert_eq!(masked_mapping.iter_unique().count(), 3);
+        assert!(
+            masked_mapping
+                .iter_unique()
+                .all(|worker_slot_id| worker_slot_id.worker_id() == WorkerId::new(2))
         );
     }
 }

--- a/src/frontend/src/optimizer/property/distribution.rs
+++ b/src/frontend/src/optimizer/property/distribution.rs
@@ -122,6 +122,7 @@ impl Distribution {
         output_count: u32,
         catalog_reader: &CatalogReader,
         worker_node_manager: &WorkerNodeSelector,
+        batch_parallelism: usize,
     ) -> Result<ExchangeInfo> {
         let exchange_info = ExchangeInfo {
             mode: match self {
@@ -153,8 +154,10 @@ impl Distribution {
                         "hash key should not be empty, use `Single` instead"
                     );
 
-                    let vnode_mapping = worker_node_manager
-                        .fragment_mapping(Self::get_fragment_id(catalog_reader, *table_id)?)?;
+                    let vnode_mapping = worker_node_manager.fragment_mapping(
+                        Self::get_fragment_id(catalog_reader, *table_id)?,
+                        batch_parallelism,
+                    )?;
 
                     let worker_slot_to_id_map: HashMap<WorkerSlotId, u32> = vnode_mapping
                         .iter_unique()

--- a/src/frontend/src/scheduler/distributed/stage.rs
+++ b/src/frontend/src/scheduler/distributed/stage.rs
@@ -803,7 +803,7 @@ impl StageRunner {
             )?;
             let id_to_worker_slots = self
                 .worker_node_manager
-                .fragment_mapping(fragment_id)?
+                .fragment_mapping(fragment_id, self.query.batch_parallelism())?
                 .iter_unique()
                 .collect_vec();
 

--- a/src/frontend/src/scheduler/local.rs
+++ b/src/frontend/src/scheduler/local.rs
@@ -590,9 +590,10 @@ impl LocalQueryExecution {
                             .inner_side_table_desc
                             .as_ref()
                             .expect("no side table desc");
-                        let mapping = self
-                            .worker_node_manager
-                            .fragment_mapping(self.get_fragment_id(side_table_desc.table_id)?)?;
+                        let mapping = self.worker_node_manager.fragment_mapping(
+                            self.get_fragment_id(side_table_desc.table_id)?,
+                            self.query.batch_parallelism(),
+                        )?;
 
                         // TODO: should we use `pb::WorkerSlotMapping` here?
                         node.inner_side_vnode_mapping =

--- a/src/frontend/src/scheduler/plan_fragmenter.rs
+++ b/src/frontend/src/scheduler/plan_fragmenter.rs
@@ -238,6 +238,7 @@ impl BatchPlanFragmenter {
                 1,
                 &self.catalog_reader,
                 &self.worker_node_manager,
+                self.batch_parallelism,
             )?),
         )?;
         self.stage_graph = Some(
@@ -309,6 +310,10 @@ impl Query {
 
     pub fn stage(&self, stage_id: StageId) -> &QueryStage {
         &self.stage_graph.stages[&stage_id]
+    }
+
+    pub fn batch_parallelism(&self) -> usize {
+        self.stage_graph.batch_parallelism
     }
 }
 
@@ -907,6 +912,7 @@ impl StageGraph {
                     parallelism,
                     catalog_reader,
                     worker_node_manager,
+                    self.batch_parallelism,
                 )?)
             } else {
                 None
@@ -1162,6 +1168,7 @@ impl BatchPlanFragmenter {
                 parallelism,
                 &self.catalog_reader,
                 &self.worker_node_manager,
+                self.batch_parallelism,
             )?)
         } else {
             None
@@ -1264,7 +1271,7 @@ impl BatchPlanFragmenter {
         let build_table_scan_info = |name, table_catalog: &TableCatalog, scan_range| {
             let vnode_mapping = self
                 .worker_node_manager
-                .fragment_mapping(table_catalog.fragment_id)?;
+                .fragment_mapping(table_catalog.fragment_id, self.batch_parallelism)?;
             let partitions = derive_partitions(scan_range, table_catalog, &vnode_mapping)?;
             let info = TableScanInfo::new(name, partitions);
             Ok(Some(info))
@@ -1326,7 +1333,7 @@ impl BatchPlanFragmenter {
             let table_catalog = lookup_join.right_table();
             let vnode_mapping = self
                 .worker_node_manager
-                .fragment_mapping(table_catalog.fragment_id)?;
+                .fragment_mapping(table_catalog.fragment_id, self.batch_parallelism)?;
             let parallelism = vnode_mapping.iter().sorted().dedup().count();
             Ok(Some(parallelism))
         } else {


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

Fixes a corner case in batch query parallelism handling.
- Previous Behavior: When a batch query used a temporary frontend-node-local serving vnode mapping (i.e. worker_node_mask is not empty), it bypassed the normal execution path and ignored the batch_parallelism runtime parameter—always defaulting to 256 parallelism for non-singleton batch scans.
- New Behavior: These queries now correctly respect the batch_parallelism setting.

Details:
This PR threads the query's effective batch parallelism into fragment vnode mapping lookup so worker-mask re-placement does not expand beyond the requested batch parallelism.
It preserves singleton mapping behavior by keeping the singleton cap at 1, while using batch parallelism as the cap for non-singleton masked mappings.
It also updates local and distributed batch scheduling call sites and adds a unit test for masked-worker remapping.

## Checklist

- [ ] I have written necessary rustdoc comments.
- [x] I have added necessary unit tests and integration tests.
- [ ] I have added test labels as necessary.
- [ ] I have added fuzzing tests or opened an issue to track them.
- [ ] My PR contains breaking changes.
- [ ] My PR changes performance-critical code, so I will run (micro) benchmarks and present the results.
- [ ] I have checked the Release Timeline and Currently Supported Versions to determine which release branches I need to cherry-pick this PR into.

## Documentation

- [ ] My PR needs documentation updates.

<details>
<summary><b>Release note</b></summary>

No release note needed.

</details>

## Tests

- `./risedev c`
