### PR TITLE
refactor(storage): decouple table change logs from hummock versions

### DIFF
--- a/ci/scripts/backwards-compat-test.sh
+++ b/ci/scripts/backwards-compat-test.sh
@@ -179,10 +179,9 @@ upgrade_through_intermediate_versions() {
     setup_release_cluster "$version"
     rm -rf .risingwave/config
     ENABLE_UDF=1 ./risedev d full-without-monitoring
-    if version_le "$RECOVERY_STATUS_MIN_VERSION" "$version"; then
+    if version_le "$RECOVER_COMMAND_MIN_VERSION" "$version"; then
       wait_for_recovery "$version"
     fi
-    check_version "$version"
     kill_cluster
   done < <(get_intermediate_versions)
 }

--- a/ci/scripts/backwards-compat-test.sh
+++ b/ci/scripts/backwards-compat-test.sh
@@ -102,7 +102,7 @@ fi
 # Try to download the pre-built Java connector-node tarball for a specific
 # release from GitHub. Returns 0 on success (connector extracted and
 # CONNECTOR_LIBS_PATH exported), non-zero if the release asset is unavailable.
-download_old_connector_artifact() {
+download_release_connector_artifact() {
   local version="$1"
   local tarball="risingwave-connector-v${version}.tar.gz"
   local url="https://github.com/risingwavelabs/risingwave/releases/download/v${version}/${tarball}"
@@ -119,8 +119,10 @@ download_old_connector_artifact() {
   return 0
 }
 
-setup_old_cluster() {
-  echo "--- Build risedev for $OLD_VERSION, it may not be backwards compatible"
+setup_release_cluster() {
+  local version="$1"
+
+  echo "--- Build risedev for $version, it may not be backwards compatible"
   git config --global --add safe.directory /risingwave
   # `common.sh` exports GIT_SHA=$BUILDKITE_COMMIT (the PR tip). After we
   # check out an old tag, vergen's VERGEN_GIT_SHA reflects the old commit,
@@ -128,39 +130,61 @@ setup_old_cluster() {
   # panics because the two SHAs disagree. Drop GIT_SHA so the old build
   # only relies on VERGEN_GIT_SHA.
   unset GIT_SHA
-  git checkout "v${OLD_VERSION}"
+  git checkout "v${version}"
   cargo build -p risedev
-  echo "--- Get RisingWave binary for $OLD_VERSION"
-  OLD_URL=https://github.com/risingwavelabs/risingwave/releases/download/v${OLD_VERSION}/risingwave-v${OLD_VERSION}-x86_64-unknown-linux.tar.gz
+  echo "--- Get RisingWave binary for $version"
+  local archive="risingwave-v${version}-x86_64-unknown-linux.tar.gz"
+  local url="https://github.com/risingwavelabs/risingwave/releases/download/v${version}/${archive}"
   local enable_build_rust="false"
-  set +e
-  wget --no-verbose "$OLD_URL"
-  wget_rc=$?
-  set -e
-  if [[ "$wget_rc" -ne 0 ]]; then
-    echo "Failed to download ${OLD_VERSION} from github releases, build from source later during \`risedev d\`"
+  rm -f "$archive"
+  if ! wget --no-verbose "$url" -O "$archive"; then
+    rm -f "$archive"
+    echo "Failed to download ${version} from github releases, build from source later during \`risedev d\`"
     enable_build_rust="true"
-  elif [[ $OLD_VERSION = '1.10.0' || $OLD_VERSION = '1.10.1' || $OLD_VERSION = '1.10.2' || $OLD_VERSION = '2.0.0' ]]; then
+  elif [[ $version = '1.10.0' || $version = '1.10.1' || $version = '1.10.2' || $version = '2.0.0' ]]; then
     echo "1.10.x, 2.0.0 have dynamically linked openssl, build from source later during \`risedev d\`"
     enable_build_rust="true"
   else
-    tar -xvf risingwave-v"${OLD_VERSION}"-x86_64-unknown-linux.tar.gz
+    rm -f risingwave
+    tar -xvf "$archive"
     mv risingwave target/debug/risingwave
 
-    echo "--- Start cluster on tag $OLD_VERSION"
+    echo "--- Prepared cluster binary from tag $version"
     git config --global --add safe.directory /risingwave
   fi
 
   # Try to reuse the pre-built Java connector from the old release. Falls back
   # to building from source (inside `risedev d`) when the asset is unavailable.
   local build_connector="true"
-  if download_old_connector_artifact "$OLD_VERSION"; then
+  if download_release_connector_artifact "$version"; then
     build_connector="false"
   else
-    echo "Pre-built Java connector for $OLD_VERSION not found, build from source later during \`risedev d\`"
+    echo "Pre-built Java connector for $version not found, build from source later during \`risedev d\`"
   fi
 
-  configure_rw "$OLD_VERSION" "$enable_build_rust" "$build_connector"
+  configure_rw "$version" "$enable_build_rust" "$build_connector"
+}
+
+setup_old_cluster() {
+  setup_release_cluster "$OLD_VERSION"
+}
+
+upgrade_through_intermediate_versions() {
+  local version
+
+  while read -r version; do
+    [[ -z "$version" ]] && continue
+
+    echo "--- Upgrade through intermediate version $version"
+    setup_release_cluster "$version"
+    rm -rf .risingwave/config
+    ENABLE_UDF=1 ./risedev d full-without-monitoring
+    if version_le "$RECOVERY_STATUS_MIN_VERSION" "$version"; then
+      wait_for_recovery "$version"
+    fi
+    check_version "$version"
+    kill_cluster
+  done < <(get_intermediate_versions)
 }
 
 setup_new_cluster() {
@@ -182,6 +206,8 @@ main() {
 
   setup_old_cluster
   seed_old_cluster "$OLD_VERSION"
+
+  upgrade_through_intermediate_versions
 
   setup_new_cluster
   # Assume we use the latest version, so we just set to some large number.

--- a/ci/workflows/main-cron.yml
+++ b/ci/workflows/main-cron.yml
@@ -871,7 +871,8 @@ steps:
       - ./ci/plugins/upload-failure-logs
     matrix:
       setup:
-        # Test the 4 latest versions against the latest main.
+        # Test the 4 latest versions against the latest main. Each matrix entry
+        # upgrades through the latest stable patch of every intermediate release line.
         # e.g.
         # 1: 2.0.0
         # 2: 1.1.1
@@ -884,7 +885,8 @@ steps:
           - "2"
           - "3"
           - "4"
-    timeout_in_minutes: 30
+    # Older releases are upgraded through every intermediate release line.
+    timeout_in_minutes: 60
     retry: *auto-retry
 
   # Sqlsmith differential testing

--- a/ci/workflows/pull-request.yml
+++ b/ci/workflows/pull-request.yml
@@ -880,7 +880,8 @@ steps:
       - ./ci/plugins/upload-failure-logs
     matrix:
       setup:
-        # Test the 4 latest versions against the latest main.
+        # Test the 4 latest versions against the latest main. Each matrix entry
+        # upgrades through the latest stable patch of every intermediate release line.
         # e.g.
         # 1: 2.0.0
         # 2: 1.1.1
@@ -893,7 +894,8 @@ steps:
           - "2"
           - "3"
           - "4"
-    timeout_in_minutes: 25
+    # Older releases are upgraded through every intermediate release line.
+    timeout_in_minutes: 60
 
   # Sqlsmith differential testing
   - label: "Sqlsmith Differential Testing"

--- a/e2e_test/backwards-compat-tests/scripts/run_local.sh
+++ b/e2e_test/backwards-compat-tests/scripts/run_local.sh
@@ -101,10 +101,9 @@ upgrade_through_intermediate_versions() {
     configure_rw "$version"
     rm -rf .risingwave/config
     ENABLE_UDF=1 ./risedev d full-without-monitoring
-    if version_le "$RECOVERY_STATUS_MIN_VERSION" "$version"; then
+    if version_le "$RECOVER_COMMAND_MIN_VERSION" "$version"; then
       wait_for_recovery "$version"
     fi
-    check_version "$version"
     kill_cluster
   done < <(get_intermediate_versions)
 }

--- a/e2e_test/backwards-compat-tests/scripts/run_local.sh
+++ b/e2e_test/backwards-compat-tests/scripts/run_local.sh
@@ -89,12 +89,34 @@ setup_new_cluster() {
   git checkout $LATEST_BRANCH
 }
 
+upgrade_through_intermediate_versions() {
+  local version
+
+  while read -r version; do
+    [[ -z "$version" ]] && continue
+
+    echo "--- Upgrade through intermediate version $version"
+    rm -rf .risingwave/bin/risingwave
+    git checkout "v${version}"
+    configure_rw "$version"
+    rm -rf .risingwave/config
+    ENABLE_UDF=1 ./risedev d full-without-monitoring
+    if version_le "$RECOVERY_STATUS_MIN_VERSION" "$version"; then
+      wait_for_recovery "$version"
+    fi
+    check_version "$version"
+    kill_cluster
+  done < <(get_intermediate_versions)
+}
+
 main() {
   set -euo pipefail
   get_rw_versions
   setup_old_cluster
   configure_rw "$OLD_VERSION"
   seed_old_cluster "$OLD_VERSION"
+
+  upgrade_through_intermediate_versions
 
   setup_new_cluster
   configure_rw "99.99.99"

--- a/e2e_test/backwards-compat-tests/scripts/utils.sh
+++ b/e2e_test/backwards-compat-tests/scripts/utils.sh
@@ -6,16 +6,20 @@
 #
 # 1. Setup old cluster binaries.
 # 2. Seed old cluster.
-# 3. Setup new cluster binaries.
-# 4. Run validation on new cluster.
+# 3. Start the latest stable patch of each intermediate release line and wait
+#    for successful recovery.
+# 4. Setup new cluster binaries and wait for successful recovery.
+# 5. Run validation on new cluster.
 #
-# Steps 1,3 are specific to the execution environment, CI / Local.
-# This script only provides utilities for 2, 4.
+# Steps 1,3,4 are specific to the execution environment, CI / Local.
+# This script provides the shared version, recovery, seeding, and validation utilities.
 
 ################################### ENVIRONMENT CONFIG
 
-# Duration to wait for recovery (seconds)
-RECOVERY_DURATION=20
+# Maximum duration to wait for recovery (seconds)
+RECOVERY_TIMEOUT=300
+# `rw_recovery_status()` was introduced in this version.
+RECOVERY_STATUS_MIN_VERSION=2.0.0
 
 # Setup test directory
 TEST_DIR=.risingwave/e2e_test/backwards-compat-tests/
@@ -90,6 +94,27 @@ run_sql_scalar_db() {
   local db="$1"
   shift
   psql -h localhost -p 4566 -d "$db" -U root -At -c "$@" | tr -d '[:space:]'
+}
+
+wait_for_recovery() {
+  local version="$1"
+  local deadline=$((SECONDS + RECOVERY_TIMEOUT))
+  local recovery_status
+
+  echo "--- Wait for recovery on version ${version}"
+  while (( SECONDS < deadline )); do
+    if recovery_status=$(run_sql_scalar "SELECT rw_recovery_status();" 2>/dev/null); then
+      echo "Recovery status on version ${version}: ${recovery_status}"
+      if [[ "$recovery_status" == "RUNNING" ]]; then
+        echo "--- Recovery succeeded on version ${version}"
+        return
+      fi
+    fi
+    sleep 1
+  done
+
+  echo "Timed out after ${RECOVERY_TIMEOUT}s waiting for recovery on version ${version}"
+  return 1
 }
 
 run_risectl() (
@@ -436,8 +461,7 @@ restart_meta_node() {
 
   echo "--- Restart meta node"
   $tmux_cmd respawn-window -k -t "risedev:${meta_window_index}"
-  echo "--- Wait ${RECOVERY_DURATION}s for recovery after meta restart"
-  sleep "$RECOVERY_DURATION"
+  wait_for_recovery "$NEW_VERSION after meta restart"
 }
 
 validate_cross_db_subscription_after_upgrade() {
@@ -552,6 +576,31 @@ get_rw_versions() {
   fi
 }
 
+get_intermediate_versions() {
+  local version
+  local series
+  local latest_series=""
+  local latest_version=""
+
+  while read -r version; do
+    if version_lt "$OLD_VERSION" "$version" && version_lt "$version" "$NEW_VERSION"; then
+      series="${version%.*}"
+      if [[ -n "$latest_series" && "$series" != "$latest_series" ]]; then
+        echo "$latest_version"
+      fi
+      latest_series="$series"
+      latest_version="$version"
+    fi
+  done < <(git tag --list 'v[0-9]*.[0-9]*.[0-9]*' \
+    | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' \
+    | sed 's/^v//' \
+    | sort -V)
+
+  if [[ -n "$latest_version" ]]; then
+    echo "$latest_version"
+  fi
+}
+
 # Setup table and materialized view.
 # Run updates and deletes on the table.
 # Get the results.
@@ -571,6 +620,9 @@ seed_old_cluster() {
   # `ENABLE_PYTHON_UDF` and `ENABLE_JS_UDF` are set for backwards-compartibility
   ENABLE_PYTHON_UDF=1 ENABLE_JS_UDF=1 ENABLE_UDF=1 ./risedev d full-without-monitoring && rm .risingwave/log/*
 
+  if version_le "$RECOVERY_STATUS_MIN_VERSION" "$OLD_VERSION"; then
+    wait_for_recovery "$OLD_VERSION"
+  fi
   check_version "$OLD_VERSION"
 
   echo "--- BASIC TEST: Seeding old cluster with data"
@@ -692,8 +744,7 @@ validate_new_cluster() {
   echo "--- Start cluster on latest"
   ENABLE_UDF=1 ./risedev d full-without-monitoring
 
-  echo "--- Wait ${RECOVERY_DURATION}s for Recovery on Old Cluster Data"
-  sleep $RECOVERY_DURATION
+  wait_for_recovery "$NEW_VERSION"
 
   check_version "$NEW_VERSION"
 

--- a/e2e_test/backwards-compat-tests/scripts/utils.sh
+++ b/e2e_test/backwards-compat-tests/scripts/utils.sh
@@ -18,8 +18,8 @@
 
 # Maximum duration to wait for recovery (seconds)
 RECOVERY_TIMEOUT=300
-# `rw_recovery_status()` was introduced in this version.
-RECOVERY_STATUS_MIN_VERSION=2.0.0
+# The `RECOVER` command was introduced in this version.
+RECOVER_COMMAND_MIN_VERSION=1.9.0
 
 # Setup test directory
 TEST_DIR=.risingwave/e2e_test/backwards-compat-tests/
@@ -99,21 +99,21 @@ run_sql_scalar_db() {
 wait_for_recovery() {
   local version="$1"
   local deadline=$((SECONDS + RECOVERY_TIMEOUT))
-  local recovery_status
+  local recover_output=""
 
-  echo "--- Wait for recovery on version ${version}"
+  echo "--- Wait for a successful RECOVER command on version ${version}"
   while (( SECONDS < deadline )); do
-    if recovery_status=$(run_sql_scalar "SELECT rw_recovery_status();" 2>/dev/null); then
-      echo "Recovery status on version ${version}: ${recovery_status}"
-      if [[ "$recovery_status" == "RUNNING" ]]; then
-        echo "--- Recovery succeeded on version ${version}"
-        return
-      fi
+    if recover_output=$(run_sql "RECOVER;" 2>&1); then
+      echo "$recover_output"
+      echo "--- RECOVER succeeded on version ${version}"
+      return
     fi
+    echo "RECOVER is not ready on version ${version}; retry in 1 second"
     sleep 1
   done
 
-  echo "Timed out after ${RECOVERY_TIMEOUT}s waiting for recovery on version ${version}"
+  echo "$recover_output"
+  echo "Timed out after ${RECOVERY_TIMEOUT}s waiting for RECOVER on version ${version}"
   return 1
 }
 
@@ -620,7 +620,7 @@ seed_old_cluster() {
   # `ENABLE_PYTHON_UDF` and `ENABLE_JS_UDF` are set for backwards-compartibility
   ENABLE_PYTHON_UDF=1 ENABLE_JS_UDF=1 ENABLE_UDF=1 ./risedev d full-without-monitoring && rm .risingwave/log/*
 
-  if version_le "$RECOVERY_STATUS_MIN_VERSION" "$OLD_VERSION"; then
+  if version_le "$RECOVER_COMMAND_MIN_VERSION" "$OLD_VERSION"; then
     wait_for_recovery "$OLD_VERSION"
   fi
   check_version "$OLD_VERSION"

--- a/proto/hummock.proto
+++ b/proto/hummock.proto
@@ -353,7 +353,7 @@ message HummockVersion {
   reserved 4;
   reserved 'safe_epoch';
   map<uint32, TableWatermarks> table_watermarks = 5;
-  map<uint32, TableChangeLog> table_change_logs = 6;
+  map<uint32, TableChangeLog> table_change_logs = 6 [deprecated = true];
   map<uint32, StateTableInfo> state_table_info = 7;
   map<uint32, VectorIndex> vector_indexes = 8;
 }
@@ -379,7 +379,7 @@ message HummockVersionDelta {
     // only logs in epoch later than truncate_epoch will be preserved
     uint64 truncate_epoch = 2;
   }
-  map<uint32, ChangeLogDelta> change_log_delta = 10;
+  map<uint32, ChangeLogDelta> change_log_delta = 10 [deprecated = true];
   map<uint32, StateTableInfoDelta> state_table_info_delta = 11;
   map<uint32, VectorIndexDelta> vector_index_delta = 12;
 }

--- a/src/meta/src/hummock/manager/checkpoint.rs
+++ b/src/meta/src/hummock/manager/checkpoint.rs
@@ -59,10 +59,10 @@ pub struct HummockVersionCheckpoint {
 
 impl HummockVersionCheckpoint {
     pub fn from_protobuf(checkpoint: &PbHummockVersionCheckpoint) -> Self {
+        let version = checkpoint.version.as_ref().unwrap();
+        warn_if_legacy_table_change_logs_are_present(version);
         Self {
-            version: Arc::new(HummockVersion::from_persisted_protobuf(
-                checkpoint.version.as_ref().unwrap(),
-            )),
+            version: Arc::new(HummockVersion::from_persisted_protobuf(version)),
             stale_objects: checkpoint
                 .stale_objects
                 .iter()
@@ -74,9 +74,10 @@ impl HummockVersionCheckpoint {
     /// Convert an owned `PbHummockVersionCheckpoint` to `HummockVersionCheckpoint`,
     /// moving data instead of cloning for better performance on large checkpoints.
     pub fn from_protobuf_owned(checkpoint: PbHummockVersionCheckpoint) -> Self {
+        let version = checkpoint.version.unwrap();
+        warn_if_legacy_table_change_logs_are_present(&version);
         Self {
-            version: HummockVersion::from_persisted_protobuf_owned(checkpoint.version.unwrap())
-                .into(),
+            version: HummockVersion::from_persisted_protobuf_owned(version).into(),
             stale_objects: checkpoint.stale_objects,
         }
     }
@@ -90,6 +91,16 @@ impl HummockVersionCheckpoint {
                 .map(|(version_id, objects)| (*version_id, objects.clone()))
                 .collect(),
         }
+    }
+}
+
+fn warn_if_legacy_table_change_logs_are_present(version: &PbHummockVersion) {
+    if !version.table_change_logs.is_empty() {
+        warn!(
+            version_id = ?version.id,
+            table_count = version.table_change_logs.len(),
+            "deprecated table change logs found in hummock version checkpoint; ignoring them"
+        );
     }
 }
 
@@ -463,7 +474,7 @@ impl HummockManager {
                 HummockObjectId::HnswGraphFile(_) => {}
             };
             for (object_id, file_size) in version_delta
-                .newly_added_sst_infos(false)
+                .newly_added_sst_infos()
                 .map(|sst| (HummockObjectId::Sstable(sst.object_id), sst.file_size))
                 .chain(
                     version_delta
@@ -616,10 +627,12 @@ mod tests {
     use risingwave_pb::hummock::hummock_version_checkpoint::StaleObjects;
     use risingwave_pb::hummock::{
         PbHummockVersion, PbHummockVersionCheckpoint, PbHummockVersionCheckpointEnvelope,
+        PbTableChangeLog,
     };
 
     use super::{
-        compress_payload, decode_checkpoint_data, read_bytes_in_chunks, xxhash64_checksum,
+        HummockVersionCheckpoint, compress_payload, decode_checkpoint_data, read_bytes_in_chunks,
+        xxhash64_checksum,
     };
 
     #[expect(deprecated)]
@@ -646,6 +659,27 @@ mod tests {
             version: Some(make_version(version_id)),
             stale_objects: [(1u64.into(), stale)].into_iter().collect(),
         }
+    }
+
+    #[test]
+    fn deprecated_table_change_logs_are_ignored() {
+        let mut checkpoint = make_checkpoint(42);
+        checkpoint
+            .version
+            .as_mut()
+            .unwrap()
+            .table_change_logs
+            .insert(1.into(), PbTableChangeLog::default());
+
+        let checkpoint = HummockVersionCheckpoint::from_protobuf(&checkpoint);
+        assert!(
+            checkpoint
+                .to_protobuf()
+                .version
+                .unwrap()
+                .table_change_logs
+                .is_empty()
+        );
     }
 
     fn make_envelope_bytes(

--- a/src/meta/src/hummock/manager/mod.rs
+++ b/src/meta/src/hummock/manager/mod.rs
@@ -400,8 +400,6 @@ impl HummockManager {
         });
         instance.init_time_travel_state().await?;
         instance.load_meta_store_state().await?;
-        // may_fill_backward_table_change_logs MUST execute after load_meta_store_state
-        instance.may_fill_backward_table_change_logs().await?;
         instance.start_worker(rx);
         instance.release_invalid_contexts().await?;
         // Release snapshots pinned by meta on restarting.
@@ -513,8 +511,6 @@ impl HummockManager {
                 version_delta.prev_id, redo_state.id
             );
             redo_state.apply_version_delta(version_delta);
-            // backward compatibility: migrate table change log to meta store.
-            redo_state.apply_table_change_log_delta_backward_compatibility(version_delta);
             applied_delta_count += 1;
             if applied_delta_count % 1000 == 0 {
                 tracing::info!("Redo progress {applied_delta_count}/{total_to_apply}.");

--- a/src/meta/src/hummock/manager/time_travel.rs
+++ b/src/meta/src/hummock/manager/time_travel.rs
@@ -139,8 +139,8 @@ impl HummockManager {
             pinned_snapshot_object_ids.extend(resolved.replay_version.get_object_ids());
             for delta in resolved.deltas {
                 pinned_delta_ids.insert(delta.id);
-                pinned_snapshot_sst_ids.extend(delta.newly_added_sst_ids(true));
-                pinned_snapshot_object_ids.extend(delta.newly_added_object_ids(true));
+                pinned_snapshot_sst_ids.extend(delta.newly_added_sst_ids());
+                pinned_snapshot_object_ids.extend(delta.newly_added_object_ids());
             }
         }
 
@@ -312,7 +312,7 @@ impl HummockManager {
                 let delta_to_delete = IncompleteHummockVersionDelta::from_persisted_protobuf_owned(
                     delta_to_delete.version_delta.to_protobuf(),
                 );
-                let new_sst_ids = delta_to_delete.newly_added_sst_ids(true);
+                let new_sst_ids = delta_to_delete.newly_added_sst_ids();
                 // The SST ids added and then deleted by compaction between the 2 versions.
                 sst_ids_to_delete.extend(&new_sst_ids - &retained_snapshot_sst_ids);
                 if sst_ids_to_delete.len() >= delete_sst_batch_size {
@@ -323,7 +323,7 @@ impl HummockManager {
                     )
                     .await?;
                 }
-                let new_object_ids = delta_to_delete.newly_added_object_ids(true);
+                let new_object_ids = delta_to_delete.newly_added_object_ids();
                 object_ids_to_delete.extend(&new_object_ids - &retained_snapshot_object_ids);
             }
         }
@@ -501,8 +501,7 @@ impl HummockManager {
                     let version_delta = HummockVersionDelta::from_persisted_protobuf_owned(
                         model.version_delta.to_protobuf(),
                     );
-                    // set exclude_table_change_log to true because in time travel delta we ignore the table change log
-                    for object_id in version_delta.newly_added_object_ids(true) {
+                    for object_id in version_delta.newly_added_object_ids() {
                         result.remove(&object_id);
                     }
                     next_prev_version_id = Some(model.version_id);
@@ -759,7 +758,7 @@ impl HummockManager {
             return Ok(version_sst_ids);
         }
         let written = write_sstable_infos(
-            delta.newly_added_sst_infos(true).filter(|s| {
+            delta.newly_added_sst_infos().filter(|s| {
                 !skip_sst_ids.contains(&s.sst_id)
                     && s.table_ids
                         .iter()

--- a/src/meta/src/hummock/manager/transaction.rs
+++ b/src/meta/src/hummock/manager/transaction.rs
@@ -12,12 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::collections::hash_map::Entry;
 use std::collections::{BTreeMap, HashMap, HashSet};
+use std::iter::once;
 use std::ops::{Deref, DerefMut};
-use std::sync::Arc;
+use std::sync::{Arc, LazyLock};
 
 use parking_lot::Mutex;
 use risingwave_common::catalog::TableId;
+use risingwave_common::log::LogSuppressor;
 use risingwave_hummock_sdk::change_log::{ChangeLogDelta, TableChangeLog};
 use risingwave_hummock_sdk::compaction_group::StaticCompactionGroupId;
 use risingwave_hummock_sdk::sstable_info::SstableInfo;
@@ -30,7 +33,7 @@ use risingwave_hummock_sdk::{
 use risingwave_meta_model::Epoch;
 use risingwave_pb::hummock::{
     CompatibilityVersion, GroupConstruct, HummockVersionDeltas, HummockVersionStats,
-    StateTableInfoDelta,
+    StateTableInfo, StateTableInfoDelta,
 };
 use risingwave_pb::meta::subscribe_response::{Info, Operation};
 use sea_orm::{ConnectionTrait, EntityTrait};
@@ -46,6 +49,74 @@ use crate::rpc::metrics::MetaMetrics;
 
 fn trigger_delta_log_stats(metrics: &MetaMetrics, total_number: usize) {
     metrics.delta_log_count.set(total_number as _);
+}
+
+#[derive(Default)]
+struct TableChangeLogTransactionDelta {
+    updates: Vec<HashMap<TableId, ChangeLogDelta>>,
+    delete_all: HashSet<TableId>,
+}
+
+impl TableChangeLogTransactionDelta {
+    fn apply_to_memory(self, table_change_logs: &mut HashMap<TableId, TableChangeLog>) {
+        for updates in self.updates {
+            for (table_id, delta) in updates {
+                let truncate_epoch = delta.truncate_epoch;
+                match table_change_logs.entry(table_id) {
+                    Entry::Occupied(entry) => {
+                        entry.into_mut().add_change_log(delta.new_log);
+                    }
+                    Entry::Vacant(entry) => {
+                        entry.insert(TableChangeLog::new(once(delta.new_log)));
+                    }
+                }
+                if let Some(change_log) = table_change_logs.get_mut(&table_id) {
+                    change_log.truncate(truncate_epoch);
+                }
+            }
+        }
+
+        table_change_logs.retain(|table_id, _| !self.delete_all.contains(table_id));
+    }
+}
+
+fn collect_table_change_logs_to_delete<'a>(
+    current_change_log_table_ids: impl Iterator<Item = &'a TableId>,
+    change_log_updates: &HashMap<TableId, ChangeLogDelta>,
+    removed_table_ids: &HashSet<TableId>,
+    state_table_info_delta: &HashMap<TableId, StateTableInfoDelta>,
+    changed_table_info: &HashMap<TableId, Option<StateTableInfo>>,
+) -> HashSet<TableId> {
+    let mut delete_all = HashSet::new();
+    // If a table has no new change log entry (even an empty one), it means we have stopped
+    // maintaining the change log for the table. The change log is also removed with the table.
+    for table_id in current_change_log_table_ids {
+        if removed_table_ids.contains(table_id) {
+            delete_all.insert(*table_id);
+            continue;
+        }
+        if let Some(table_info_delta) = state_table_info_delta.get(table_id)
+            && let Some(Some(prev_table_info)) = changed_table_info.get(table_id)
+            && table_info_delta.committed_epoch > prev_table_info.committed_epoch
+        {
+            // The table existed previously and its committed epoch has progressed.
+        } else {
+            continue;
+        }
+        if !change_log_updates.contains_key(table_id) {
+            delete_all.insert(*table_id);
+            static LOG_SUPPRESSOR: LazyLock<LogSuppressor> =
+                LazyLock::new(|| LogSuppressor::per_second(1));
+            if let Ok(suppressed_count) = LOG_SUPPRESSOR.check() {
+                tracing::warn!(
+                    suppressed_count,
+                    %table_id,
+                    "table change log dropped due to no further change log at newly committed epoch"
+                );
+            }
+        }
+    }
+    delete_all
 }
 
 pub(super) fn trigger_version_stat(metrics: &MetaMetrics, current_version: &HummockVersion) {
@@ -66,7 +137,11 @@ pub(super) struct HummockVersionTransaction<'a> {
     meta_metrics: &'a MetaMetrics,
     version_stat_tx: &'a tokio::sync::mpsc::UnboundedSender<Arc<HummockVersion>>,
 
-    pre_applied_version: Option<(HummockVersion, Vec<HummockVersionDelta>, HashSet<TableId>)>,
+    pre_applied_version: Option<(
+        HummockVersion,
+        Vec<HummockVersionDelta>,
+        TableChangeLogTransactionDelta,
+    )>,
     disable_apply_to_txn: bool,
     opts: &'a MetaOpts,
 }
@@ -120,28 +195,34 @@ impl<'a> HummockVersionTransaction<'a> {
         }
     }
 
-    fn pre_apply(&mut self, delta: HummockVersionDelta) {
-        let (version, deltas, gc_change_log_deltas) =
+    fn pre_apply(
+        &mut self,
+        delta: HummockVersionDelta,
+        change_log_updates: HashMap<TableId, ChangeLogDelta>,
+    ) {
+        let (version, deltas, table_change_log_delta) =
             self.pre_applied_version.get_or_insert_with(|| {
                 (
                     self.orig_version.as_ref().clone(),
                     Vec::with_capacity(1),
-                    HashSet::new(),
+                    TableChangeLogTransactionDelta::default(),
                 )
             });
         let changed_table_info = version.apply_version_delta(&delta);
-        // Ideally, the first parameter should be the cumulative state (orig_table_change_log + all applied deltas).
-        // However, currently, we use orig_table_change_log directly because deltas are only applied after a successful metastore write in the end of the transaction.
-        // Consequently, some table eligible for GC are not returned by collect_gc_change_log_delta and are deferred to the next transaction.
-        // This delay is acceptable and does not impact system correctness.
-        let gc_change_log_delta = HummockVersion::collect_gc_change_log_delta(
+        // The in-memory change logs are only updated after the metastore transaction succeeds, so
+        // complete deletion is derived from the original state. A deletion that becomes eligible
+        // after multiple deltas in one transaction may be deferred to the next transaction.
+        let delete_all = collect_table_change_logs_to_delete(
             self.orig_table_change_log.keys(),
-            &delta.change_log_delta,
+            &change_log_updates,
             &delta.removed_table_ids,
             &delta.state_table_info_delta,
             &changed_table_info,
         );
-        gc_change_log_deltas.extend(gc_change_log_delta);
+        table_change_log_delta.delete_all.extend(delete_all);
+        if !change_log_updates.is_empty() {
+            table_change_log_delta.updates.push(change_log_updates);
+        }
         deltas.push(delta);
     }
 
@@ -159,7 +240,6 @@ impl<'a> HummockVersionTransaction<'a> {
     ) -> HummockVersionDelta {
         let mut new_version_delta = self.new_delta();
         new_version_delta.new_table_watermarks = new_table_watermarks;
-        new_version_delta.change_log_delta = change_log_delta;
         new_version_delta.vector_index_delta = vector_index_delta;
 
         for compaction_group in &new_compaction_groups {
@@ -245,23 +325,16 @@ impl<'a> HummockVersionTransaction<'a> {
         });
 
         let time_travel_delta = (*new_version_delta).clone();
-        new_version_delta.pre_apply();
+        new_version_delta.pre_apply_with_table_change_log(change_log_delta);
         time_travel_delta
     }
 }
 
 impl InMemValTransaction for HummockVersionTransaction<'_> {
     fn commit(self) {
-        if let Some((version, deltas, gc_change_log_deltas)) = self.pre_applied_version {
+        if let Some((version, deltas, table_change_log_delta)) = self.pre_applied_version {
             *self.orig_version = Arc::new(version);
-            for delta in &deltas {
-                HummockVersion::apply_change_log_delta(
-                    self.orig_table_change_log,
-                    &delta.change_log_delta,
-                );
-            }
-            self.orig_table_change_log
-                .retain(|table_id, _| !gc_change_log_deltas.contains(table_id));
+            table_change_log_delta.apply_to_memory(self.orig_table_change_log);
 
             if !self.disable_apply_to_txn {
                 let pb_deltas = deltas.iter().map(|delta| delta.to_protobuf()).collect();
@@ -310,7 +383,7 @@ where
         if self.disable_apply_to_txn {
             return Ok(());
         }
-        if let Some((_, deltas, gc_change_log_deltas)) = &self.pre_applied_version {
+        if let Some((_, deltas, table_change_log_delta)) = &self.pre_applied_version {
             // These upsert_in_transaction can be batched. However, we know len(deltas) is always 1 currently.
             for delta in deltas {
                 delta.upsert_in_transaction(txn).await?;
@@ -319,9 +392,10 @@ where
             let insert_batch_size = self.opts.table_change_log_insert_batch_size as usize;
             use futures::stream::{self, StreamExt};
             use sea_orm::{ColumnTrait, Condition, QueryFilter};
-            let insert_iter = deltas
+            let insert_iter = table_change_log_delta
+                .updates
                 .iter()
-                .flat_map(|i| i.change_log_delta.iter())
+                .flat_map(|updates| updates.iter())
                 .map(|(table_id, change_log_delta)| (*table_id, &change_log_delta.new_log));
             let mut stream = stream::iter(insert_iter).chunks(insert_batch_size);
             while let Some(change_log_batch) = stream.next().await {
@@ -341,14 +415,16 @@ where
             // `None` means deleting the whole table change log. Do not encode this as
             // `u64::MAX`: the meta store epoch type is signed, so casting the sentinel would
             // overflow and make the SQL predicate match nothing.
-            let delete_iter = deltas
+            let delete_iter = table_change_log_delta
+                .updates
                 .iter()
-                .flat_map(|i| i.change_log_delta.iter())
+                .flat_map(|updates| updates.iter())
                 .map(|(table_id, change_log_delta)| {
                     (*table_id, Some(change_log_delta.truncate_epoch))
                 })
                 .chain(
-                    gc_change_log_deltas
+                    table_change_log_delta
+                        .delete_all
                         .iter()
                         .map(|table_id| (*table_id, None)),
                 );
@@ -390,7 +466,16 @@ impl SingleDeltaTransaction<'_, '_> {
     }
 
     pub(super) fn pre_apply(mut self) {
-        self.version_txn.pre_apply(self.delta.take().unwrap());
+        self.version_txn
+            .pre_apply(self.delta.take().unwrap(), HashMap::new());
+    }
+
+    fn pre_apply_with_table_change_log(
+        mut self,
+        change_log_updates: HashMap<TableId, ChangeLogDelta>,
+    ) {
+        self.version_txn
+            .pre_apply(self.delta.take().unwrap(), change_log_updates);
     }
 
     pub(super) fn with_latest_version(
@@ -421,7 +506,7 @@ impl DerefMut for SingleDeltaTransaction<'_, '_> {
 impl Drop for SingleDeltaTransaction<'_, '_> {
     fn drop(&mut self) {
         if let Some(delta) = self.delta.take() {
-            self.version_txn.pre_apply(delta);
+            self.version_txn.pre_apply(delta, HashMap::new());
         }
     }
 }
@@ -475,5 +560,97 @@ impl Deref for HummockVersionStatsTransaction<'_> {
 impl DerefMut for HummockVersionStatsTransaction<'_> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         self.stats.deref_mut()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use itertools::Itertools;
+    use risingwave_hummock_sdk::change_log::EpochNewChangeLog;
+
+    use super::*;
+
+    fn change_log_delta(checkpoint_epoch: u64, truncate_epoch: u64) -> ChangeLogDelta {
+        ChangeLogDelta {
+            truncate_epoch,
+            new_log: EpochNewChangeLog {
+                new_value: vec![],
+                old_value: vec![],
+                non_checkpoint_epochs: vec![],
+                checkpoint_epoch,
+            },
+        }
+    }
+
+    #[test]
+    fn test_apply_table_change_log_transaction_delta() {
+        let table_id = TableId::new(1);
+        let deleted_table_id = TableId::new(2);
+        let mut table_change_logs = HashMap::from([
+            (
+                table_id,
+                TableChangeLog::new([
+                    change_log_delta(1, 0).new_log,
+                    change_log_delta(2, 0).new_log,
+                ]),
+            ),
+            (
+                deleted_table_id,
+                TableChangeLog::new([change_log_delta(1, 0).new_log]),
+            ),
+        ]);
+        TableChangeLogTransactionDelta {
+            updates: vec![HashMap::from([(table_id, change_log_delta(3, 2))])],
+            delete_all: HashSet::from([deleted_table_id]),
+        }
+        .apply_to_memory(&mut table_change_logs);
+
+        assert_eq!(
+            table_change_logs[&table_id].epochs().collect_vec(),
+            vec![2, 3]
+        );
+        assert!(!table_change_logs.contains_key(&deleted_table_id));
+    }
+
+    #[test]
+    fn test_collect_table_change_logs_to_delete() {
+        let table_id = TableId::new(1);
+        let removed_table_id = TableId::new(2);
+        let current_table_ids = HashSet::from([table_id, removed_table_id]);
+        let state_table_info_delta = HashMap::from([(
+            table_id,
+            StateTableInfoDelta {
+                committed_epoch: 2,
+                compaction_group_id: 1.into(),
+            },
+        )]);
+        let changed_table_info = HashMap::from([(
+            table_id,
+            Some(StateTableInfo {
+                committed_epoch: 1,
+                compaction_group_id: 1.into(),
+            }),
+        )]);
+
+        assert_eq!(
+            collect_table_change_logs_to_delete(
+                current_table_ids.iter(),
+                &HashMap::new(),
+                &HashSet::from([removed_table_id]),
+                &state_table_info_delta,
+                &changed_table_info,
+            ),
+            HashSet::from([table_id, removed_table_id])
+        );
+        assert_eq!(
+            collect_table_change_logs_to_delete(
+                current_table_ids.iter(),
+                &HashMap::from([(table_id, change_log_delta(2, 0))]),
+                &HashSet::new(),
+                &state_table_info_delta,
+                &changed_table_info,
+            ),
+            HashSet::new()
+        );
     }
 }

--- a/src/meta/src/hummock/manager/transaction.rs
+++ b/src/meta/src/hummock/manager/transaction.rs
@@ -12,15 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::collections::hash_map::Entry;
 use std::collections::{BTreeMap, HashMap, HashSet};
-use std::iter::once;
 use std::ops::{Deref, DerefMut};
-use std::sync::{Arc, LazyLock};
+use std::sync::Arc;
 
 use parking_lot::Mutex;
 use risingwave_common::catalog::TableId;
-use risingwave_common::log::LogSuppressor;
 use risingwave_hummock_sdk::change_log::{ChangeLogDelta, TableChangeLog};
 use risingwave_hummock_sdk::compaction_group::StaticCompactionGroupId;
 use risingwave_hummock_sdk::sstable_info::SstableInfo;
@@ -33,7 +30,7 @@ use risingwave_hummock_sdk::{
 use risingwave_meta_model::Epoch;
 use risingwave_pb::hummock::{
     CompatibilityVersion, GroupConstruct, HummockVersionDeltas, HummockVersionStats,
-    StateTableInfo, StateTableInfoDelta,
+    StateTableInfoDelta,
 };
 use risingwave_pb::meta::subscribe_response::{Info, Operation};
 use sea_orm::{ConnectionTrait, EntityTrait};
@@ -55,68 +52,6 @@ fn trigger_delta_log_stats(metrics: &MetaMetrics, total_number: usize) {
 struct TableChangeLogTransactionDelta {
     updates: Vec<HashMap<TableId, ChangeLogDelta>>,
     delete_all: HashSet<TableId>,
-}
-
-impl TableChangeLogTransactionDelta {
-    fn apply_to_memory(self, table_change_logs: &mut HashMap<TableId, TableChangeLog>) {
-        for updates in self.updates {
-            for (table_id, delta) in updates {
-                let truncate_epoch = delta.truncate_epoch;
-                match table_change_logs.entry(table_id) {
-                    Entry::Occupied(entry) => {
-                        entry.into_mut().add_change_log(delta.new_log);
-                    }
-                    Entry::Vacant(entry) => {
-                        entry.insert(TableChangeLog::new(once(delta.new_log)));
-                    }
-                }
-                if let Some(change_log) = table_change_logs.get_mut(&table_id) {
-                    change_log.truncate(truncate_epoch);
-                }
-            }
-        }
-
-        table_change_logs.retain(|table_id, _| !self.delete_all.contains(table_id));
-    }
-}
-
-fn collect_table_change_logs_to_delete<'a>(
-    current_change_log_table_ids: impl Iterator<Item = &'a TableId>,
-    change_log_updates: &HashMap<TableId, ChangeLogDelta>,
-    removed_table_ids: &HashSet<TableId>,
-    state_table_info_delta: &HashMap<TableId, StateTableInfoDelta>,
-    changed_table_info: &HashMap<TableId, Option<StateTableInfo>>,
-) -> HashSet<TableId> {
-    let mut delete_all = HashSet::new();
-    // If a table has no new change log entry (even an empty one), it means we have stopped
-    // maintaining the change log for the table. The change log is also removed with the table.
-    for table_id in current_change_log_table_ids {
-        if removed_table_ids.contains(table_id) {
-            delete_all.insert(*table_id);
-            continue;
-        }
-        if let Some(table_info_delta) = state_table_info_delta.get(table_id)
-            && let Some(Some(prev_table_info)) = changed_table_info.get(table_id)
-            && table_info_delta.committed_epoch > prev_table_info.committed_epoch
-        {
-            // The table existed previously and its committed epoch has progressed.
-        } else {
-            continue;
-        }
-        if !change_log_updates.contains_key(table_id) {
-            delete_all.insert(*table_id);
-            static LOG_SUPPRESSOR: LazyLock<LogSuppressor> =
-                LazyLock::new(|| LogSuppressor::per_second(1));
-            if let Ok(suppressed_count) = LOG_SUPPRESSOR.check() {
-                tracing::warn!(
-                    suppressed_count,
-                    %table_id,
-                    "table change log dropped due to no further change log at newly committed epoch"
-                );
-            }
-        }
-    }
-    delete_all
 }
 
 pub(super) fn trigger_version_stat(metrics: &MetaMetrics, current_version: &HummockVersion) {
@@ -191,7 +126,7 @@ impl<'a> HummockVersionTransaction<'a> {
         let delta = self.latest_version().version_delta_after();
         SingleDeltaTransaction {
             version_txn: self,
-            delta: Some(delta),
+            delta: Some((delta, HashMap::new())),
         }
     }
 
@@ -212,7 +147,7 @@ impl<'a> HummockVersionTransaction<'a> {
         // The in-memory change logs are only updated after the metastore transaction succeeds, so
         // complete deletion is derived from the original state. A deletion that becomes eligible
         // after multiple deltas in one transaction may be deferred to the next transaction.
-        let delete_all = collect_table_change_logs_to_delete(
+        let delete_all = HummockVersion::collect_gc_change_log_delta(
             self.orig_table_change_log.keys(),
             &change_log_updates,
             &delta.removed_table_ids,
@@ -240,6 +175,7 @@ impl<'a> HummockVersionTransaction<'a> {
     ) -> HummockVersionDelta {
         let mut new_version_delta = self.new_delta();
         new_version_delta.new_table_watermarks = new_table_watermarks;
+        new_version_delta.set_change_log_delta(change_log_delta);
         new_version_delta.vector_index_delta = vector_index_delta;
 
         for compaction_group in &new_compaction_groups {
@@ -325,7 +261,7 @@ impl<'a> HummockVersionTransaction<'a> {
         });
 
         let time_travel_delta = (*new_version_delta).clone();
-        new_version_delta.pre_apply_with_table_change_log(change_log_delta);
+        new_version_delta.pre_apply();
         time_travel_delta
     }
 }
@@ -334,7 +270,14 @@ impl InMemValTransaction for HummockVersionTransaction<'_> {
     fn commit(self) {
         if let Some((version, deltas, table_change_log_delta)) = self.pre_applied_version {
             *self.orig_version = Arc::new(version);
-            table_change_log_delta.apply_to_memory(self.orig_table_change_log);
+            for change_log_delta in table_change_log_delta.updates {
+                HummockVersion::apply_change_log_delta(
+                    self.orig_table_change_log,
+                    &change_log_delta,
+                );
+            }
+            self.orig_table_change_log
+                .retain(|table_id, _| !table_change_log_delta.delete_all.contains(table_id));
 
             if !self.disable_apply_to_txn {
                 let pb_deltas = deltas.iter().map(|delta| delta.to_protobuf()).collect();
@@ -457,7 +400,7 @@ where
 
 pub(super) struct SingleDeltaTransaction<'a, 'b> {
     version_txn: &'b mut HummockVersionTransaction<'a>,
-    delta: Option<HummockVersionDelta>,
+    delta: Option<(HummockVersionDelta, HashMap<TableId, ChangeLogDelta>)>,
 }
 
 impl SingleDeltaTransaction<'_, '_> {
@@ -465,17 +408,13 @@ impl SingleDeltaTransaction<'_, '_> {
         self.version_txn.latest_version()
     }
 
-    pub(super) fn pre_apply(mut self) {
-        self.version_txn
-            .pre_apply(self.delta.take().unwrap(), HashMap::new());
+    fn set_change_log_delta(&mut self, change_log_delta: HashMap<TableId, ChangeLogDelta>) {
+        self.delta.as_mut().expect("should exist").1 = change_log_delta;
     }
 
-    fn pre_apply_with_table_change_log(
-        mut self,
-        change_log_updates: HashMap<TableId, ChangeLogDelta>,
-    ) {
-        self.version_txn
-            .pre_apply(self.delta.take().unwrap(), change_log_updates);
+    pub(super) fn pre_apply(mut self) {
+        let (delta, change_log_delta) = self.delta.take().unwrap();
+        self.version_txn.pre_apply(delta, change_log_delta);
     }
 
     pub(super) fn with_latest_version(
@@ -484,7 +423,7 @@ impl SingleDeltaTransaction<'_, '_> {
     ) {
         f(
             self.version_txn.latest_version(),
-            self.delta.as_mut().expect("should exist"),
+            &mut self.delta.as_mut().expect("should exist").0,
         )
     }
 }
@@ -493,20 +432,20 @@ impl Deref for SingleDeltaTransaction<'_, '_> {
     type Target = HummockVersionDelta;
 
     fn deref(&self) -> &Self::Target {
-        self.delta.as_ref().expect("should exist")
+        &self.delta.as_ref().expect("should exist").0
     }
 }
 
 impl DerefMut for SingleDeltaTransaction<'_, '_> {
     fn deref_mut(&mut self) -> &mut Self::Target {
-        self.delta.as_mut().expect("should exist")
+        &mut self.delta.as_mut().expect("should exist").0
     }
 }
 
 impl Drop for SingleDeltaTransaction<'_, '_> {
     fn drop(&mut self) {
-        if let Some(delta) = self.delta.take() {
-            self.version_txn.pre_apply(delta, HashMap::new());
+        if let Some((delta, change_log_delta)) = self.delta.take() {
+            self.version_txn.pre_apply(delta, change_log_delta);
         }
     }
 }
@@ -567,6 +506,7 @@ impl DerefMut for HummockVersionStatsTransaction<'_> {
 mod tests {
     use itertools::Itertools;
     use risingwave_hummock_sdk::change_log::EpochNewChangeLog;
+    use risingwave_pb::hummock::StateTableInfo;
 
     use super::*;
 
@@ -583,37 +523,28 @@ mod tests {
     }
 
     #[test]
-    fn test_apply_table_change_log_transaction_delta() {
+    fn test_apply_change_log_delta() {
         let table_id = TableId::new(1);
-        let deleted_table_id = TableId::new(2);
-        let mut table_change_logs = HashMap::from([
-            (
-                table_id,
-                TableChangeLog::new([
-                    change_log_delta(1, 0).new_log,
-                    change_log_delta(2, 0).new_log,
-                ]),
-            ),
-            (
-                deleted_table_id,
-                TableChangeLog::new([change_log_delta(1, 0).new_log]),
-            ),
-        ]);
-        TableChangeLogTransactionDelta {
-            updates: vec![HashMap::from([(table_id, change_log_delta(3, 2))])],
-            delete_all: HashSet::from([deleted_table_id]),
-        }
-        .apply_to_memory(&mut table_change_logs);
+        let mut table_change_logs = HashMap::from([(
+            table_id,
+            TableChangeLog::new([
+                change_log_delta(1, 0).new_log,
+                change_log_delta(2, 0).new_log,
+            ]),
+        )]);
+        HummockVersion::apply_change_log_delta(
+            &mut table_change_logs,
+            &HashMap::from([(table_id, change_log_delta(3, 2))]),
+        );
 
         assert_eq!(
             table_change_logs[&table_id].epochs().collect_vec(),
             vec![2, 3]
         );
-        assert!(!table_change_logs.contains_key(&deleted_table_id));
     }
 
     #[test]
-    fn test_collect_table_change_logs_to_delete() {
+    fn test_collect_gc_change_log_delta() {
         let table_id = TableId::new(1);
         let removed_table_id = TableId::new(2);
         let current_table_ids = HashSet::from([table_id, removed_table_id]);
@@ -633,9 +564,9 @@ mod tests {
         )]);
 
         assert_eq!(
-            collect_table_change_logs_to_delete(
+            HummockVersion::collect_gc_change_log_delta(
                 current_table_ids.iter(),
-                &HashMap::new(),
+                &HashMap::<TableId, ChangeLogDelta>::new(),
                 &HashSet::from([removed_table_id]),
                 &state_table_info_delta,
                 &changed_table_info,
@@ -643,7 +574,7 @@ mod tests {
             HashSet::from([table_id, removed_table_id])
         );
         assert_eq!(
-            collect_table_change_logs_to_delete(
+            HummockVersion::collect_gc_change_log_delta(
                 current_table_ids.iter(),
                 &HashMap::from([(table_id, change_log_delta(2, 0))]),
                 &HashSet::new(),

--- a/src/meta/src/hummock/manager/versioning.rs
+++ b/src/meta/src/hummock/manager/versioning.rs
@@ -32,13 +32,11 @@ use risingwave_hummock_sdk::{
     CompactionGroupId, HummockContextId, HummockObjectId, HummockSstableId, HummockSstableObjectId,
     HummockVersionId, get_stale_object_ids,
 };
-use risingwave_meta_model::{Epoch, hummock_table_change_log};
 use risingwave_pb::common::WorkerNode;
 use risingwave_pb::hummock::write_limits::WriteLimit;
 use risingwave_pb::hummock::{HummockPinnedVersion, HummockVersionStats};
 use risingwave_pb::id::TableId;
 use risingwave_pb::meta::subscribe_response::{Info, Operation};
-use sea_orm::{EntityTrait, QuerySelect, TransactionTrait};
 
 use super::GroupStateValidator;
 use crate::MetaResult;
@@ -50,7 +48,6 @@ use crate::hummock::manager::context::ContextInfo;
 use crate::hummock::manager::transaction::HummockVersionTransaction;
 use crate::hummock::metrics_utils::{LocalTableMetrics, trigger_write_stop_stats};
 use crate::hummock::model::CompactionGroup;
-use crate::hummock::model::ext::to_table_change_log_meta_store_model;
 use crate::model::VarTransaction;
 
 #[derive(Default)]
@@ -114,7 +111,7 @@ impl Versioning {
             Excluded(self.checkpoint.version.id),
             Included(self.current_version.id),
         )) {
-            tracked_object_ids.extend(delta.newly_added_object_ids(false));
+            tracked_object_ids.extend(delta.newly_added_object_ids());
         }
         // add stale object ids before the checkpoint version
         tracked_object_ids.extend(
@@ -297,85 +294,6 @@ impl HummockManager {
             new_version_delta.pre_apply();
             commit_multi_var!(self.meta_store_ref(), version)?;
         }
-        Ok(())
-    }
-
-    pub async fn may_fill_backward_table_change_logs(&self) -> Result<()> {
-        let is_nonempty_meta_store =
-            risingwave_meta_model::hummock_table_change_log::Entity::find()
-                .select_only()
-                .columns([
-                    hummock_table_change_log::Column::TableId,
-                    hummock_table_change_log::Column::CheckpointEpoch,
-                ])
-                .into_tuple::<(TableId, Epoch)>()
-                .one(&self.env.meta_store_ref().conn)
-                .await?
-                .is_some();
-
-        let table_change_logs = {
-            let mut versioning = self.versioning.write().await;
-            #[expect(deprecated)]
-            if versioning.current_version.table_change_log.is_empty() {
-                tracing::info!("No legacy table change log to migrate.");
-                return Ok(());
-            }
-            let version = Arc::make_mut(&mut versioning.current_version);
-            if is_nonempty_meta_store {
-                tracing::info!("meta store table change log is non-empty.");
-                // Clear legacy in-mem state.
-                #[expect(deprecated)]
-                version.table_change_log = HashMap::default();
-                // Either there are no table change logs to commit to the metastore, or the operation has already been completed.
-                return Ok(());
-            }
-
-            // Clear legacy in-mem state.
-            #[expect(deprecated)]
-            let logs = std::mem::take(&mut version.table_change_log);
-            if logs.values().all(|t| t.is_empty()) {
-                return Ok(());
-            }
-            logs
-        };
-
-        // Store table change log in meta store.
-        let insert_batch_size = self.env.opts.table_change_log_insert_batch_size as usize;
-        let count = {
-            let iter = table_change_logs
-                .iter()
-                .flat_map(|(table_id, change_logs)| {
-                    change_logs
-                        .iter()
-                        .map(move |change_log| (table_id, change_log))
-                });
-
-            use futures::stream::{self, StreamExt};
-            let mut stream = stream::iter(iter).chunks(insert_batch_size);
-            let mut count = 0;
-            let txn = self.env.meta_store_ref().conn.begin().await?;
-            while let Some(change_log_batch) = stream.next().await {
-                if change_log_batch.is_empty() {
-                    break;
-                }
-                count += change_log_batch.len();
-                let insert_many = change_log_batch
-                    .into_iter()
-                    .map(|(table_id, change_log)| {
-                        to_table_change_log_meta_store_model(*table_id, change_log)
-                    })
-                    .collect::<Vec<_>>();
-                risingwave_meta_model::hummock_table_change_log::Entity::insert_many(insert_many)
-                    .exec(&txn)
-                    .await?;
-            }
-            txn.commit().await?;
-            count
-        };
-        tracing::info!("Migrated {count} table change log to meta store.");
-        // Initialize new in-mem state.
-        let mut versioning = self.versioning.write().await;
-        versioning.table_change_log = table_change_logs;
         Ok(())
     }
 

--- a/src/storage/hummock_sdk/src/change_log.rs
+++ b/src/storage/hummock_sdk/src/change_log.rs
@@ -16,7 +16,6 @@ use std::collections::{HashMap, VecDeque};
 use std::ops::RangeBounds;
 
 use risingwave_common::catalog::TableId;
-use risingwave_pb::hummock::hummock_version_delta::PbChangeLogDelta;
 use risingwave_pb::hummock::{PbEpochNewChangeLog, PbSstableInfo, PbTableChangeLog};
 use tracing::warn;
 
@@ -369,54 +368,6 @@ pub struct ChangeLogDeltaCommon<T> {
 }
 
 pub type ChangeLogDelta = ChangeLogDeltaCommon<SstableInfo>;
-
-impl<T> From<&ChangeLogDeltaCommon<T>> for PbChangeLogDelta
-where
-    PbSstableInfo: for<'a> From<&'a T>,
-{
-    fn from(val: &ChangeLogDeltaCommon<T>) -> Self {
-        Self {
-            truncate_epoch: val.truncate_epoch,
-            new_log: Some((&val.new_log).into()),
-        }
-    }
-}
-
-impl<T> From<&PbChangeLogDelta> for ChangeLogDeltaCommon<T>
-where
-    T: for<'a> From<&'a PbSstableInfo>,
-{
-    fn from(val: &PbChangeLogDelta) -> Self {
-        Self {
-            truncate_epoch: val.truncate_epoch,
-            new_log: val.new_log.as_ref().unwrap().into(),
-        }
-    }
-}
-
-impl<T> From<ChangeLogDeltaCommon<T>> for PbChangeLogDelta
-where
-    PbSstableInfo: From<T>,
-{
-    fn from(val: ChangeLogDeltaCommon<T>) -> Self {
-        Self {
-            truncate_epoch: val.truncate_epoch,
-            new_log: Some(val.new_log.into()),
-        }
-    }
-}
-
-impl<T> From<PbChangeLogDelta> for ChangeLogDeltaCommon<T>
-where
-    T: From<PbSstableInfo>,
-{
-    fn from(val: PbChangeLogDelta) -> Self {
-        Self {
-            truncate_epoch: val.truncate_epoch,
-            new_log: val.new_log.unwrap().into(),
-        }
-    }
-}
 
 #[cfg(test)]
 mod tests {

--- a/src/storage/hummock_sdk/src/compaction_group/hummock_version_ext.rs
+++ b/src/storage/hummock_sdk/src/compaction_group/hummock_version_ext.rs
@@ -14,18 +14,24 @@
 
 use std::borrow::Borrow;
 use std::cmp::Ordering;
+use std::collections::hash_map::Entry;
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
-use std::sync::Arc;
+use std::iter::once;
+use std::sync::{Arc, LazyLock};
 
 use bytes::Bytes;
 use itertools::Itertools;
 use risingwave_common::catalog::TableId;
 use risingwave_common::hash::VnodeBitmapExt;
-use risingwave_pb::hummock::{CompactionConfig, CompatibilityVersion, PbLevelType, StateTableInfo};
+use risingwave_common::log::LogSuppressor;
+use risingwave_pb::hummock::{
+    CompactionConfig, CompatibilityVersion, PbLevelType, StateTableInfo, StateTableInfoDelta,
+};
 use tracing::warn;
 
 use super::group_split::split_sst_with_table_ids;
 use super::{StateTableId, group_split};
+use crate::change_log::{ChangeLogDeltaCommon, TableChangeLogCommon};
 use crate::compact_task::is_compaction_task_expired;
 use crate::compaction_group::StaticCompactionGroupId;
 use crate::key_range::KeyRangeCommon;
@@ -735,6 +741,74 @@ impl HummockVersionCommon<SstableInfo> {
         );
 
         changed_table_info
+    }
+
+    pub fn apply_change_log_delta<T: Clone>(
+        table_change_log: &mut HashMap<TableId, TableChangeLogCommon<T>>,
+        change_log_delta: &HashMap<TableId, ChangeLogDeltaCommon<T>>,
+    ) {
+        for (table_id, change_log_delta) in change_log_delta {
+            let new_change_log = &change_log_delta.new_log;
+            match table_change_log.entry(*table_id) {
+                Entry::Occupied(entry) => {
+                    let change_log = entry.into_mut();
+                    change_log.add_change_log(new_change_log.clone());
+                }
+                Entry::Vacant(entry) => {
+                    entry.insert(TableChangeLogCommon::new(once(new_change_log.clone())));
+                }
+            };
+        }
+
+        // truncate the remaining table change log
+        for (table_id, change_log_delta) in change_log_delta {
+            if let Some(change_log) = table_change_log.get_mut(table_id) {
+                change_log.truncate(change_log_delta.truncate_epoch);
+            }
+        }
+    }
+
+    /// Returns the log deltas required to truncate the entire change log for a table.
+    pub fn collect_gc_change_log_delta<'a, T: Clone>(
+        current_change_log_table_ids: impl Iterator<Item = &'a TableId>,
+        change_log_delta: &HashMap<TableId, ChangeLogDeltaCommon<T>>,
+        removed_table_ids: &HashSet<TableId>,
+        state_table_info_delta: &HashMap<TableId, StateTableInfoDelta>,
+        changed_table_info: &HashMap<TableId, Option<StateTableInfo>>,
+    ) -> HashSet<TableId> {
+        let mut gc_change_log_delta = HashSet::new();
+        // If a table has no new change log entry (even an empty one), it means we have stopped maintained
+        // the change log for the table, and then we will remove the table change log.
+        // The table change log will also be removed when the table id is removed.
+        for table_id in current_change_log_table_ids {
+            if removed_table_ids.contains(table_id) {
+                gc_change_log_delta.insert(*table_id);
+                continue;
+            }
+            if let Some(table_info_delta) = state_table_info_delta.get(table_id)
+                && let Some(Some(prev_table_info)) = changed_table_info.get(table_id)
+                && table_info_delta.committed_epoch > prev_table_info.committed_epoch
+            {
+                // the table exists previously, and its committed epoch has progressed.
+            } else {
+                // otherwise, the table change log should be kept anyway
+                continue;
+            }
+            let contains = change_log_delta.contains_key(table_id);
+            if !contains {
+                gc_change_log_delta.insert(*table_id);
+                static LOG_SUPPRESSOR: LazyLock<LogSuppressor> =
+                    LazyLock::new(|| LogSuppressor::per_second(1));
+                if let Ok(suppressed_count) = LOG_SUPPRESSOR.check() {
+                    warn!(
+                        suppressed_count,
+                        %table_id,
+                        "table change log dropped due to no further change log at newly committed epoch"
+                    );
+                }
+            }
+        }
+        gc_change_log_delta
     }
 
     pub fn build_branched_sst_info(&self) -> BTreeMap<HummockSstableObjectId, BranchedSstInfo> {

--- a/src/storage/hummock_sdk/src/compaction_group/hummock_version_ext.rs
+++ b/src/storage/hummock_sdk/src/compaction_group/hummock_version_ext.rs
@@ -14,24 +14,18 @@
 
 use std::borrow::Borrow;
 use std::cmp::Ordering;
-use std::collections::hash_map::Entry;
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
-use std::iter::once;
-use std::sync::{Arc, LazyLock};
+use std::sync::Arc;
 
 use bytes::Bytes;
 use itertools::Itertools;
 use risingwave_common::catalog::TableId;
 use risingwave_common::hash::VnodeBitmapExt;
-use risingwave_common::log::LogSuppressor;
-use risingwave_pb::hummock::{
-    CompactionConfig, CompatibilityVersion, PbLevelType, StateTableInfo, StateTableInfoDelta,
-};
+use risingwave_pb::hummock::{CompactionConfig, CompatibilityVersion, PbLevelType, StateTableInfo};
 use tracing::warn;
 
 use super::group_split::split_sst_with_table_ids;
 use super::{StateTableId, group_split};
-use crate::change_log::{ChangeLogDeltaCommon, TableChangeLogCommon};
 use crate::compact_task::is_compaction_task_expired;
 use crate::compaction_group::StaticCompactionGroupId;
 use crate::key_range::KeyRangeCommon;
@@ -56,7 +50,7 @@ pub struct SstDeltaInfo {
 
 pub type BranchedSstInfo = HashMap<CompactionGroupId, Vec<HummockSstableId>>;
 
-impl<L> HummockVersionCommon<SstableInfo, L> {
+impl HummockVersionCommon<SstableInfo> {
     pub fn get_compaction_group_levels(&self, compaction_group_id: CompactionGroupId) -> &Levels {
         self.levels
             .get(&compaction_group_id)
@@ -72,7 +66,7 @@ impl<L> HummockVersionCommon<SstableInfo, L> {
             .unwrap_or_else(|| panic!("compaction group {} does not exist", compaction_group_id))
     }
 
-    // only scan the sst infos from levels in the specified compaction group (without table change log)
+    // Only scan SST infos from levels in the specified compaction group.
     pub fn get_sst_ids_by_group_id(
         &self,
         compaction_group_id: CompactionGroupId,
@@ -231,7 +225,7 @@ pub fn safe_epoch_read_table_watermarks_impl(
         .collect()
 }
 
-impl<L: Clone> HummockVersionCommon<SstableInfo, L> {
+impl HummockVersionCommon<SstableInfo> {
     pub fn count_new_ssts_in_group_split(
         &self,
         parent_group_id: CompactionGroupId,
@@ -395,7 +389,7 @@ impl<L: Clone> HummockVersionCommon<SstableInfo, L> {
 
     pub fn build_sst_delta_infos(
         &self,
-        version_delta: &HummockVersionDeltaCommon<SstableInfo, L>,
+        version_delta: &HummockVersionDeltaCommon<SstableInfo>,
     ) -> Vec<SstDeltaInfo> {
         let mut infos = vec![];
 
@@ -500,30 +494,9 @@ impl<L: Clone> HummockVersionCommon<SstableInfo, L> {
         infos
     }
 
-    /// Used by migration of table change log to meta store.
-    /// `Self::table_change_log` will be consumed by the migration process later.
-    pub fn apply_table_change_log_delta_backward_compatibility(
-        &mut self,
-        version_delta: &HummockVersionDeltaCommon<SstableInfo, L>,
-    ) {
-        #[expect(deprecated)]
-        for (table_id, change_log_delta) in &version_delta.change_log_delta {
-            let new_change_log = &change_log_delta.new_log;
-            match self.table_change_log.entry(*table_id) {
-                Entry::Occupied(entry) => {
-                    let change_log = entry.into_mut();
-                    change_log.add_change_log(new_change_log.clone());
-                }
-                Entry::Vacant(entry) => {
-                    entry.insert(TableChangeLogCommon::new(once(new_change_log.clone())));
-                }
-            };
-        }
-    }
-
     pub fn apply_version_delta(
         &mut self,
-        version_delta: &HummockVersionDeltaCommon<SstableInfo, L>,
+        version_delta: &HummockVersionDeltaCommon<SstableInfo>,
     ) -> HashMap<TableId, Option<StateTableInfo>> {
         assert_eq!(self.id, version_delta.prev_id);
 
@@ -762,74 +735,6 @@ impl<L: Clone> HummockVersionCommon<SstableInfo, L> {
         );
 
         changed_table_info
-    }
-
-    pub fn apply_change_log_delta<T: Clone>(
-        table_change_log: &mut HashMap<TableId, TableChangeLogCommon<T>>,
-        change_log_delta: &HashMap<TableId, ChangeLogDeltaCommon<T>>,
-    ) {
-        for (table_id, change_log_delta) in change_log_delta {
-            let new_change_log = &change_log_delta.new_log;
-            match table_change_log.entry(*table_id) {
-                Entry::Occupied(entry) => {
-                    let change_log = entry.into_mut();
-                    change_log.add_change_log(new_change_log.clone());
-                }
-                Entry::Vacant(entry) => {
-                    entry.insert(TableChangeLogCommon::new(once(new_change_log.clone())));
-                }
-            };
-        }
-
-        // truncate the remaining table change log
-        for (table_id, change_log_delta) in change_log_delta {
-            if let Some(change_log) = table_change_log.get_mut(table_id) {
-                change_log.truncate(change_log_delta.truncate_epoch);
-            }
-        }
-    }
-
-    /// Returns the log deltas required to truncate the entire change log for a table.
-    pub fn collect_gc_change_log_delta<'a, T: Clone>(
-        current_change_log_table_ids: impl Iterator<Item = &'a TableId>,
-        change_log_delta: &HashMap<TableId, ChangeLogDeltaCommon<T>>,
-        removed_table_ids: &HashSet<TableId>,
-        state_table_info_delta: &HashMap<TableId, StateTableInfoDelta>,
-        changed_table_info: &HashMap<TableId, Option<StateTableInfo>>,
-    ) -> HashSet<TableId> {
-        let mut gc_change_log_delta = HashSet::new();
-        // If a table has no new change log entry (even an empty one), it means we have stopped maintained
-        // the change log for the table, and then we will remove the table change log.
-        // The table change log will also be removed when the table id is removed.
-        for table_id in current_change_log_table_ids {
-            if removed_table_ids.contains(table_id) {
-                gc_change_log_delta.insert(*table_id);
-                continue;
-            }
-            if let Some(table_info_delta) = state_table_info_delta.get(table_id)
-                && let Some(Some(prev_table_info)) = changed_table_info.get(table_id)
-                && table_info_delta.committed_epoch > prev_table_info.committed_epoch
-            {
-                // the table exists previously, and its committed epoch has progressed.
-            } else {
-                // otherwise, the table change log should be kept anyway
-                continue;
-            }
-            let contains = change_log_delta.contains_key(table_id);
-            if !contains {
-                gc_change_log_delta.insert(*table_id);
-                static LOG_SUPPRESSOR: LazyLock<LogSuppressor> =
-                    LazyLock::new(|| LogSuppressor::per_second(1));
-                if let Ok(suppressed_count) = LOG_SUPPRESSOR.check() {
-                    warn!(
-                        suppressed_count,
-                        %table_id,
-                        "table change log dropped due to no further change log at newly committed epoch"
-                    );
-                }
-            }
-        }
-        gc_change_log_delta
     }
 
     pub fn build_branched_sst_info(&self) -> BTreeMap<HummockSstableObjectId, BranchedSstInfo> {
@@ -1157,7 +1062,7 @@ impl Levels {
     }
 }
 
-impl<T, L> HummockVersionCommon<T, L> {
+impl<T> HummockVersionCommon<T> {
     pub fn get_combined_levels(&self) -> impl Iterator<Item = &'_ LevelCommon<T>> + '_ {
         self.levels
             .values()

--- a/src/storage/hummock_sdk/src/frontend_version.rs
+++ b/src/storage/hummock_sdk/src/frontend_version.rs
@@ -16,13 +16,8 @@ use std::collections::{HashMap, HashSet};
 
 use risingwave_common::catalog::TableId;
 use risingwave_common::util::epoch::INVALID_EPOCH;
-use risingwave_pb::hummock::hummock_version_delta::PbChangeLogDelta;
-use risingwave_pb::hummock::{
-    PbEpochNewChangeLog, PbHummockVersion, PbHummockVersionDelta, PbSstableInfo,
-    StateTableInfoDelta,
-};
+use risingwave_pb::hummock::{PbHummockVersion, PbHummockVersionDelta, StateTableInfoDelta};
 
-use crate::change_log::{ChangeLogDeltaCommon, EpochNewChangeLogCommon, resolve_pb_log_epochs};
 use crate::version::{HummockVersion, HummockVersionDelta, HummockVersionStateTableInfo};
 use crate::{HummockVersionId, INVALID_VERSION_ID};
 
@@ -75,7 +70,6 @@ pub struct FrontendHummockVersionDelta {
     pub id: HummockVersionId,
     pub removed_table_id: HashSet<TableId>,
     pub state_table_info_delta: HashMap<TableId, StateTableInfoDelta>,
-    pub change_log_delta: HashMap<TableId, ChangeLogDeltaCommon<()>>,
 }
 
 impl FrontendHummockVersionDelta {
@@ -85,28 +79,6 @@ impl FrontendHummockVersionDelta {
             id: delta.id,
             removed_table_id: delta.removed_table_ids.clone(),
             state_table_info_delta: delta.state_table_info_delta.clone(),
-            change_log_delta: delta
-                .change_log_delta
-                .iter()
-                .map(|(table_id, change_log_delta)| {
-                    (
-                        *table_id,
-                        ChangeLogDeltaCommon {
-                            truncate_epoch: change_log_delta.truncate_epoch,
-                            new_log: EpochNewChangeLogCommon {
-                                // Here we need to determine if value is null but don't care what the value is, so we fill him in using `()`
-                                new_value: vec![(); change_log_delta.new_log.new_value.len()],
-                                old_value: vec![(); change_log_delta.new_log.old_value.len()],
-                                non_checkpoint_epochs: change_log_delta
-                                    .new_log
-                                    .non_checkpoint_epochs
-                                    .clone(),
-                                checkpoint_epoch: change_log_delta.new_log.checkpoint_epoch,
-                            },
-                        },
-                    )
-                })
-                .collect(),
         }
     }
 
@@ -120,30 +92,7 @@ impl FrontendHummockVersionDelta {
             trivial_move: false,
             new_table_watermarks: Default::default(),
             removed_table_ids: self.removed_table_id.iter().copied().collect(),
-            change_log_delta: self
-                .change_log_delta
-                .iter()
-                .map(|(table_id, delta)| {
-                    (
-                        *table_id,
-                        PbChangeLogDelta {
-                            new_log: Some(PbEpochNewChangeLog {
-                                // Here we need to determine if value is null but don't care what the value is, so we fill him in using `PbSstableInfo::default()`
-                                old_value: vec![
-                                    PbSstableInfo::default();
-                                    delta.new_log.old_value.len()
-                                ],
-                                new_value: vec![
-                                    PbSstableInfo::default();
-                                    delta.new_log.new_value.len()
-                                ],
-                                epochs: delta.new_log.epochs().collect(),
-                            }),
-                            truncate_epoch: delta.truncate_epoch,
-                        },
-                    )
-                })
-                .collect(),
+            change_log_delta: Default::default(),
             state_table_info_delta: self.state_table_info_delta.clone(),
             vector_index_delta: Default::default(),
         }
@@ -158,33 +107,6 @@ impl FrontendHummockVersionDelta {
                 .state_table_info_delta
                 .iter()
                 .map(|(table_id, delta)| ((*table_id), *delta))
-                .collect(),
-            change_log_delta: delta
-                .change_log_delta
-                .iter()
-                .map(|(table_id, change_log_delta)| {
-                    (
-                        *table_id,
-                        ChangeLogDeltaCommon {
-                            truncate_epoch: change_log_delta.truncate_epoch,
-                            new_log: change_log_delta
-                                .new_log
-                                .as_ref()
-                                .map(|new_log| {
-                                    let (non_checkpoint_epochs, checkpoint_epoch) =
-                                        resolve_pb_log_epochs(&new_log.epochs);
-                                    EpochNewChangeLogCommon {
-                                        // Here we need to determine if value is null but don't care what the value is, so we fill him in using `()`
-                                        new_value: vec![(); new_log.new_value.len()],
-                                        old_value: vec![(); new_log.old_value.len()],
-                                        non_checkpoint_epochs,
-                                        checkpoint_epoch,
-                                    }
-                                })
-                                .unwrap(),
-                        },
-                    )
-                })
                 .collect(),
         }
     }

--- a/src/storage/hummock_sdk/src/time_travel.rs
+++ b/src/storage/hummock_sdk/src/time_travel.rs
@@ -17,7 +17,7 @@ use std::collections::{HashMap, HashSet};
 use risingwave_common::catalog::TableId;
 use risingwave_pb::hummock::PbSstableInfo;
 use risingwave_pb::hummock::hummock_version::PbLevels;
-use risingwave_pb::hummock::hummock_version_delta::{PbChangeLogDelta, PbGroupDeltas};
+use risingwave_pb::hummock::hummock_version_delta::PbGroupDeltas;
 
 use crate::compaction_group::StateTableId;
 use crate::level::{Level, Levels, LevelsCommon};
@@ -86,8 +86,6 @@ impl From<(&HummockVersion, &HashSet<StateTableId>)> for IncompleteHummockVersio
                 .collect(),
             max_committed_epoch: version.max_committed_epoch,
             table_watermarks: version.table_watermarks.clone(),
-            // time travel metadata doesn't include table change log
-            table_change_log: HashMap::default(),
             state_table_info: version.state_table_info.clone(),
             vector_indexes: version.vector_indexes.clone(),
         }
@@ -121,9 +119,8 @@ fn rewrite_levels(
     PbLevels::from(levels).into()
 }
 
-/// [`IncompleteHummockVersionDelta`] is incomplete because `SSTableInfo` only has the `sst_id` set in the following fields:
-/// - `PbGroupDeltas`
-/// - `ChangeLogDelta`
+/// [`IncompleteHummockVersionDelta`] is incomplete because `SSTableInfo` only has the `sst_id` set
+/// in `PbGroupDeltas`.
 pub type IncompleteHummockVersionDelta = HummockVersionDeltaCommon<SstableIdInVersion>;
 
 /// `SStableInfo` will be stripped.
@@ -146,29 +143,6 @@ impl From<(&HummockVersionDelta, &HashSet<StateTableId>)> for IncompleteHummockV
             trivial_move: delta.trivial_move,
             new_table_watermarks: delta.new_table_watermarks.clone(),
             removed_table_ids: delta.removed_table_ids.clone(),
-            change_log_delta: delta
-                .change_log_delta
-                .iter()
-                .filter_map(|(table_id, log_delta)| {
-                    if !time_travel_table_ids.contains(table_id) {
-                        return None;
-                    }
-                    debug_assert!(
-                        log_delta
-                            .new_log
-                            .new_value
-                            .iter()
-                            .chain(log_delta.new_log.old_value.iter())
-                            .all(|s| {
-                                s.table_ids
-                                    .iter()
-                                    .any(|tid| time_travel_table_ids.contains(tid))
-                            })
-                    );
-
-                    Some((*table_id, PbChangeLogDelta::from(log_delta).into()))
-                })
-                .collect(),
             state_table_info_delta: delta.state_table_info_delta.clone(),
             vector_index_delta: delta.vector_index_delta.clone(),
         }

--- a/src/storage/hummock_sdk/src/version.rs
+++ b/src/storage/hummock_sdk/src/version.rs
@@ -26,7 +26,6 @@ use risingwave_pb::hummock::hummock_version_delta::PbGroupDeltas;
 use risingwave_pb::hummock::*;
 use tracing::warn;
 
-use crate::change_log::{ChangeLogDeltaCommon, EpochNewChangeLogCommon, TableChangeLogCommon};
 use crate::compaction_group::StaticCompactionGroupId;
 use crate::compaction_group::hummock_version_ext::build_initial_compaction_group_levels;
 use crate::level::LevelsCommon;
@@ -223,21 +222,17 @@ impl HummockVersionStateTableInfo {
 }
 
 #[derive(Debug, Clone, PartialEq)]
-pub struct HummockVersionCommon<T, L = T> {
+pub struct HummockVersionCommon<T> {
     pub id: HummockVersionId,
     pub levels: HashMap<CompactionGroupId, LevelsCommon<T>>,
     #[deprecated]
     pub(crate) max_committed_epoch: u64,
     pub table_watermarks: HashMap<TableId, Arc<TableWatermarks>>,
-    #[deprecated]
-    pub table_change_log: HashMap<TableId, TableChangeLogCommon<L>>,
     pub state_table_info: HummockVersionStateTableInfo,
     pub vector_indexes: HashMap<TableId, VectorIndex>,
 }
 
 pub type HummockVersion = HummockVersionCommon<SstableInfo>;
-
-pub type LocalHummockVersion = HummockVersionCommon<SstableInfo, ()>;
 
 impl Default for HummockVersion {
     fn default() -> Self {
@@ -280,7 +275,6 @@ where
 }
 
 impl HummockVersion {
-    #[expect(deprecated)]
     pub fn estimated_encode_len(&self) -> usize {
         self.levels.len() * size_of::<CompactionGroupId>()
             + self
@@ -293,21 +287,6 @@ impl HummockVersion {
                 .table_watermarks
                 .values()
                 .map(|table_watermark| table_watermark.estimated_encode_len())
-                .sum::<usize>()
-            + self
-                .table_change_log
-                .values()
-                .map(|c| {
-                    c.iter()
-                        .map(|l| {
-                            l.old_value
-                                .iter()
-                                .chain(l.new_value.iter())
-                                .map(|s| s.estimated_encode_len())
-                                .sum::<usize>()
-                        })
-                        .sum::<usize>()
-                })
                 .sum::<usize>()
     }
 }
@@ -331,13 +310,6 @@ where
                 .iter()
                 .map(|(table_id, table_watermark)| {
                     (*table_id, Arc::new(TableWatermarks::from(table_watermark)))
-                })
-                .collect(),
-            table_change_log: pb_version
-                .table_change_logs
-                .iter()
-                .map(|(table_id, change_log)| {
-                    (*table_id, TableChangeLogCommon::from_protobuf(change_log))
                 })
                 .collect(),
             state_table_info: HummockVersionStateTableInfo::from_protobuf(
@@ -373,16 +345,6 @@ where
                     (table_id, Arc::new(TableWatermarks::from(table_watermark)))
                 })
                 .collect(),
-            table_change_log: pb_version
-                .table_change_logs
-                .into_iter()
-                .map(|(table_id, change_log)| {
-                    (
-                        table_id,
-                        TableChangeLogCommon::from_protobuf_owned(change_log),
-                    )
-                })
-                .collect(),
             state_table_info: HummockVersionStateTableInfo::from_protobuf_owned(
                 pb_version.state_table_info,
             ),
@@ -414,11 +376,7 @@ where
                 .iter()
                 .map(|(table_id, watermark)| (*table_id, watermark.as_ref().into()))
                 .collect(),
-            table_change_logs: version
-                .table_change_log
-                .iter()
-                .map(|(table_id, change_log)| (*table_id, change_log.to_protobuf()))
-                .collect(),
+            table_change_logs: Default::default(),
             state_table_info: version.state_table_info.state_table_info.clone(),
             vector_indexes: version
                 .vector_indexes
@@ -449,11 +407,7 @@ where
                 .into_iter()
                 .map(|(table_id, watermark)| (table_id, watermark.as_ref().into()))
                 .collect(),
-            table_change_logs: version
-                .table_change_log
-                .into_iter()
-                .map(|(table_id, change_log)| (table_id, change_log.to_protobuf()))
-                .collect(),
+            table_change_logs: Default::default(),
             state_table_info: version.state_table_info.state_table_info.clone(),
             vector_indexes: version
                 .vector_indexes
@@ -513,7 +467,6 @@ impl HummockVersion {
             levels: Default::default(),
             max_committed_epoch: INVALID_EPOCH,
             table_watermarks: HashMap::new(),
-            table_change_log: HashMap::new(),
             state_table_info: HummockVersionStateTableInfo::empty(),
             vector_indexes: Default::default(),
         };
@@ -539,14 +492,13 @@ impl HummockVersion {
             group_deltas: Default::default(),
             new_table_watermarks: HashMap::new(),
             removed_table_ids: HashSet::new(),
-            change_log_delta: HashMap::new(),
             state_table_info_delta: Default::default(),
             vector_index_delta: Default::default(),
         }
     }
 }
 
-impl<T, L> HummockVersionCommon<T, L> {
+impl<T> HummockVersionCommon<T> {
     pub fn table_committed_epoch(&self, table_id: TableId) -> Option<u64> {
         self.state_table_info
             .info()
@@ -556,7 +508,7 @@ impl<T, L> HummockVersionCommon<T, L> {
 }
 
 #[derive(Debug, PartialEq, Clone)]
-pub struct HummockVersionDeltaCommon<T, L = T> {
+pub struct HummockVersionDeltaCommon<T> {
     pub id: HummockVersionId,
     pub prev_id: HummockVersionId,
     pub group_deltas: HashMap<CompactionGroupId, GroupDeltasCommon<T>>,
@@ -565,14 +517,11 @@ pub struct HummockVersionDeltaCommon<T, L = T> {
     pub trivial_move: bool,
     pub new_table_watermarks: HashMap<TableId, TableWatermarks>,
     pub removed_table_ids: HashSet<TableId>,
-    pub change_log_delta: HashMap<TableId, ChangeLogDeltaCommon<L>>,
     pub state_table_info_delta: HashMap<TableId, StateTableInfoDelta>,
     pub vector_index_delta: HashMap<TableId, VectorIndexDelta>,
 }
 
 pub type HummockVersionDelta = HummockVersionDeltaCommon<SstableInfo>;
-
-pub type LocalHummockVersionDelta = HummockVersionDeltaCommon<SstableInfo, ()>;
 
 impl Default for HummockVersionDelta {
     fn default() -> Self {
@@ -588,6 +537,7 @@ where
     /// Convert the `PbHummockVersionDelta` deserialized from persisted state to `HummockVersionDelta`.
     /// We should maintain backward compatibility.
     pub fn from_persisted_protobuf(delta: &PbHummockVersionDelta) -> Self {
+        warn_if_legacy_change_log_delta_is_present(delta);
         delta.into()
     }
 
@@ -610,7 +560,18 @@ where
     /// Convert an owned `PbHummockVersionDelta` deserialized from persisted state to
     /// `HummockVersionDelta`, moving data instead of cloning.
     pub fn from_persisted_protobuf_owned(delta: PbHummockVersionDelta) -> Self {
+        warn_if_legacy_change_log_delta_is_present(&delta);
         delta.into()
+    }
+}
+
+fn warn_if_legacy_change_log_delta_is_present(delta: &PbHummockVersionDelta) {
+    if !delta.change_log_delta.is_empty() {
+        warn!(
+            version_delta_id = ?delta.id,
+            table_count = delta.change_log_delta.len(),
+            "deprecated table change log delta found in persisted hummock version delta; ignoring it"
+        );
     }
 }
 
@@ -630,10 +591,7 @@ where
     ///
     /// Note: the result can be false positive because we only collect the set of sst object ids in the `inserted_table_infos`,
     /// but it is possible that the object is moved or split from other compaction groups or levels.
-    pub fn newly_added_object_ids(
-        &self,
-        exclude_table_change_log: bool,
-    ) -> HashSet<HummockObjectId> {
+    pub fn newly_added_object_ids(&self) -> HashSet<HummockObjectId> {
         // DO NOT REMOVE THIS LINE
         // This is to ensure that when adding new variant to `HummockObjectId`,
         // the compiler will warn us if we forget to handle it here.
@@ -642,7 +600,7 @@ where
             HummockObjectId::VectorFile(_) => {}
             HummockObjectId::HnswGraphFile(_) => {}
         };
-        self.newly_added_sst_infos(exclude_table_change_log)
+        self.newly_added_sst_infos()
             .map(|sst| HummockObjectId::Sstable(sst.object_id()))
             .chain(
                 self.vector_index_delta
@@ -656,52 +614,31 @@ where
             .collect()
     }
 
-    pub fn newly_added_sst_ids(&self, exclude_table_change_log: bool) -> HashSet<HummockSstableId> {
-        self.newly_added_sst_infos(exclude_table_change_log)
+    pub fn newly_added_sst_ids(&self) -> HashSet<HummockSstableId> {
+        self.newly_added_sst_infos()
             .map(|sst| sst.sst_id())
             .collect()
     }
 }
 
 impl<T> HummockVersionDeltaCommon<T> {
-    pub fn newly_added_sst_infos(
-        &self,
-        exclude_table_change_log: bool,
-    ) -> impl Iterator<Item = &'_ T> {
-        let may_table_change_delta = if exclude_table_change_log {
-            None
-        } else {
-            Some(self.change_log_delta.values())
-        };
-        self.group_deltas
-            .values()
-            .flat_map(|group_deltas| {
-                group_deltas.group_deltas.iter().flat_map(|group_delta| {
-                    let sst_slice = match &group_delta {
-                        GroupDeltaCommon::NewL0SubLevel(inserted_table_infos)
-                        | GroupDeltaCommon::IntraLevel(IntraLevelDeltaCommon {
-                            inserted_table_infos,
-                            ..
-                        }) => Some(inserted_table_infos.iter()),
-                        GroupDeltaCommon::GroupConstruct(_)
-                        | GroupDeltaCommon::GroupDestroy(_)
-                        | GroupDeltaCommon::GroupMerge(_)
-                        | GroupDeltaCommon::PruneTableIdsFromSsts(_) => None,
-                    };
-                    sst_slice.into_iter().flatten()
-                })
+    pub fn newly_added_sst_infos(&self) -> impl Iterator<Item = &'_ T> {
+        self.group_deltas.values().flat_map(|group_deltas| {
+            group_deltas.group_deltas.iter().flat_map(|group_delta| {
+                let sst_slice = match &group_delta {
+                    GroupDeltaCommon::NewL0SubLevel(inserted_table_infos)
+                    | GroupDeltaCommon::IntraLevel(IntraLevelDeltaCommon {
+                        inserted_table_infos,
+                        ..
+                    }) => Some(inserted_table_infos.iter()),
+                    GroupDeltaCommon::GroupConstruct(_)
+                    | GroupDeltaCommon::GroupDestroy(_)
+                    | GroupDeltaCommon::GroupMerge(_)
+                    | GroupDeltaCommon::PruneTableIdsFromSsts(_) => None,
+                };
+                sst_slice.into_iter().flatten()
             })
-            .chain(
-                may_table_change_delta
-                    .map(|v| {
-                        v.flat_map(|delta| {
-                            let new_log = &delta.new_log;
-                            new_log.new_value.iter().chain(new_log.old_value.iter())
-                        })
-                    })
-                    .into_iter()
-                    .flatten(),
-            )
+        })
     }
 }
 
@@ -734,20 +671,6 @@ where
                 .map(|(table_id, watermarks)| (*table_id, TableWatermarks::from(watermarks)))
                 .collect(),
             removed_table_ids: pb_version_delta.removed_table_ids.iter().copied().collect(),
-            change_log_delta: pb_version_delta
-                .change_log_delta
-                .iter()
-                .map(|(table_id, log_delta)| {
-                    (
-                        *table_id,
-                        ChangeLogDeltaCommon {
-                            truncate_epoch: log_delta.truncate_epoch,
-                            new_log: log_delta.new_log.as_ref().unwrap().into(),
-                        },
-                    )
-                })
-                .collect(),
-
             state_table_info_delta: pb_version_delta
                 .state_table_info_delta
                 .iter()
@@ -784,11 +707,7 @@ where
                 .map(|(table_id, watermarks)| (*table_id, watermarks.into()))
                 .collect(),
             removed_table_ids: version_delta.removed_table_ids.iter().copied().collect(),
-            change_log_delta: version_delta
-                .change_log_delta
-                .iter()
-                .map(|(table_id, log_delta)| (*table_id, log_delta.into()))
-                .collect(),
+            change_log_delta: Default::default(),
             state_table_info_delta: version_delta.state_table_info_delta.clone(),
             vector_index_delta: version_delta
                 .vector_index_delta
@@ -821,11 +740,7 @@ where
                 .map(|(table_id, watermarks)| (table_id, watermarks.into()))
                 .collect(),
             removed_table_ids: version_delta.removed_table_ids.into_iter().collect(),
-            change_log_delta: version_delta
-                .change_log_delta
-                .into_iter()
-                .map(|(table_id, log_delta)| (table_id, log_delta.into()))
-                .collect(),
+            change_log_delta: Default::default(),
             state_table_info_delta: version_delta.state_table_info_delta,
             vector_index_delta: version_delta
                 .vector_index_delta
@@ -858,11 +773,6 @@ where
                 .map(|(table_id, watermarks)| (table_id, watermarks.into()))
                 .collect(),
             removed_table_ids: pb_version_delta.removed_table_ids.into_iter().collect(),
-            change_log_delta: pb_version_delta
-                .change_log_delta
-                .into_iter()
-                .map(|(table_id, log_delta)| (table_id, log_delta.into()))
-                .collect(),
             state_table_info_delta: pb_version_delta.state_table_info_delta,
             vector_index_delta: pb_version_delta
                 .vector_index_delta
@@ -1244,52 +1154,21 @@ where
     }
 }
 
-impl From<HummockVersionDelta> for LocalHummockVersionDelta {
-    #[expect(deprecated)]
-    fn from(delta: HummockVersionDelta) -> Self {
-        Self {
-            id: delta.id,
-            prev_id: delta.prev_id,
-            group_deltas: delta.group_deltas,
-            max_committed_epoch: delta.max_committed_epoch,
-            trivial_move: delta.trivial_move,
-            new_table_watermarks: delta.new_table_watermarks,
-            removed_table_ids: delta.removed_table_ids,
-            change_log_delta: delta
-                .change_log_delta
-                .into_iter()
-                .map(|(k, v)| {
-                    (
-                        k,
-                        ChangeLogDeltaCommon {
-                            truncate_epoch: v.truncate_epoch,
-                            new_log: EpochNewChangeLogCommon {
-                                new_value: Vec::new(),
-                                old_value: Vec::new(),
-                                non_checkpoint_epochs: v.new_log.non_checkpoint_epochs,
-                                checkpoint_epoch: v.new_log.checkpoint_epoch,
-                            },
-                        },
-                    )
-                })
-                .collect(),
-            state_table_info_delta: delta.state_table_info_delta,
-            vector_index_delta: delta.vector_index_delta,
-        }
-    }
-}
+#[cfg(test)]
+mod tests {
+    use super::*;
 
-impl From<HummockVersion> for LocalHummockVersion {
-    #[expect(deprecated)]
-    fn from(version: HummockVersion) -> Self {
-        Self {
-            id: version.id,
-            levels: version.levels,
-            max_committed_epoch: version.max_committed_epoch,
-            table_watermarks: version.table_watermarks,
-            table_change_log: HashMap::default(),
-            state_table_info: version.state_table_info,
-            vector_indexes: version.vector_indexes,
-        }
+    #[test]
+    fn deprecated_change_log_delta_is_ignored() {
+        let mut pb_delta = PbHummockVersionDelta {
+            id: 1.into(),
+            ..Default::default()
+        };
+        pb_delta
+            .change_log_delta
+            .insert(1.into(), Default::default());
+
+        let delta = HummockVersionDelta::from_persisted_protobuf_owned(pb_delta);
+        assert!(delta.to_protobuf().change_log_delta.is_empty());
     }
 }

--- a/src/storage/src/hummock/event_handler/hummock_event_handler.rs
+++ b/src/storage/src/hummock/event_handler/hummock_event_handler.rs
@@ -32,7 +32,6 @@ use risingwave_common::config::Role;
 use risingwave_common::config::streaming::CacheRefillPolicy;
 use risingwave_common::metrics::UintGauge;
 use risingwave_hummock_sdk::compaction_group::hummock_version_ext::SstDeltaInfo;
-use risingwave_hummock_sdk::version::LocalHummockVersionDelta;
 use risingwave_hummock_sdk::{HummockEpoch, SyncResult};
 use risingwave_pb::meta::table_cache_refill_policies::table_cache_refill_policy::PbCacheRefillPolicy;
 use risingwave_pb::meta::{PbServingTableVnodeMappings, PbTableRefillRuntimeConfig};
@@ -742,16 +741,12 @@ impl HummockEventHandler {
                 {
                     for version_delta in version_deltas {
                         assert_eq!(version_to_apply.id, version_delta.prev_id);
-                        let local_hummock_version_delta =
-                            LocalHummockVersionDelta::from(version_delta);
                         if let Some(sst_delta_infos) = &mut sst_delta_infos {
-                            sst_delta_infos.extend(
-                                version_to_apply
-                                    .build_sst_delta_infos(&local_hummock_version_delta),
-                            );
+                            sst_delta_infos
+                                .extend(version_to_apply.build_sst_delta_infos(&version_delta));
                         }
 
-                        version_to_apply.apply_version_delta(&local_hummock_version_delta);
+                        version_to_apply.apply_version_delta(&version_delta);
                     }
                 }
 

--- a/src/storage/src/hummock/local_version/pinned_version.rs
+++ b/src/storage/src/hummock/local_version/pinned_version.rs
@@ -22,7 +22,7 @@ use auto_enums::auto_enum;
 use risingwave_common::catalog::TableId;
 use risingwave_common::log::LogSuppressor;
 use risingwave_hummock_sdk::level::{Level, Levels};
-use risingwave_hummock_sdk::version::{HummockVersion, LocalHummockVersion};
+use risingwave_hummock_sdk::version::HummockVersion;
 use risingwave_hummock_sdk::{CompactionGroupId, HummockVersionId, INVALID_VERSION_ID};
 use risingwave_rpc_client::HummockMetaClient;
 use thiserror_ext::AsReport;
@@ -83,12 +83,12 @@ impl Drop for PinnedVersionGuard {
 
 #[derive(Clone)]
 pub struct PinnedVersion {
-    version: Arc<LocalHummockVersion>,
+    version: Arc<HummockVersion>,
     guard: Arc<PinnedVersionGuard>,
 }
 
 impl Deref for PinnedVersion {
-    type Target = LocalHummockVersion;
+    type Target = HummockVersion;
 
     fn deref(&self) -> &Self::Target {
         &self.version
@@ -101,13 +101,12 @@ impl PinnedVersion {
         pinned_version_manager_tx: UnboundedSender<PinVersionAction>,
     ) -> Self {
         let version_id = version.id;
-        let local_version = LocalHummockVersion::from(version);
         PinnedVersion {
             guard: Arc::new(PinnedVersionGuard::new(
                 version_id,
                 pinned_version_manager_tx,
             )),
-            version: Arc::new(local_version),
+            version: Arc::new(version),
         }
     }
 
@@ -122,18 +121,18 @@ impl PinnedVersion {
             return None;
         }
         let version_id = version.id;
-        let local_version = LocalHummockVersion::from(version);
         Some(PinnedVersion {
             guard: Arc::new(PinnedVersionGuard::new(
                 version_id,
                 self.guard.pinned_version_manager_tx.clone(),
             )),
-            version: Arc::new(local_version),
+            version: Arc::new(version),
         })
     }
 
-    /// Create a new `PinnedVersion` with the given `LocalHummockVersion`. Referring to the usage in the `hummock_event_handler`.
-    pub fn new_with_local_version(&self, version: LocalHummockVersion) -> Option<Self> {
+    /// Create a new `PinnedVersion` with the given version. Referring to the usage in the
+    /// `hummock_event_handler`.
+    pub fn new_with_local_version(&self, version: HummockVersion) -> Option<Self> {
         assert!(
             version.id >= self.version.id,
             "pinning a older version {}. Current is {}",


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

This PR decouples table change logs from persisted Hummock MVCC version metadata. Table change-log SSTs are already persisted and tracked independently, so storing them in `HummockVersion` and serialized `HummockVersionDelta` duplicated state and incorrectly pulled them into version-based GC accounting.

- Remove table change logs from the runtime Hummock version, frontend projections, time-travel versions, and local pinned versions.
- Keep change-log deltas alongside each Hummock version delta in meta's transient `SingleDeltaTransaction`, while omitting them from Hummock version serialization.
- Persist table change-log updates transactionally through meta's independent table change-log state.
- Stop including table change-log SSTs in Hummock version GC object collection.
- Keep protobuf fields 6 and 10 as deprecated compatibility fields. Persisted legacy values are warned about and ignored, while newly serialized versions and deltas leave the fields empty.
- Remove the completed startup migration and legacy delta replay path.
- Make backward-compatibility tests upgrade through the latest stable patch of each intermediate release line. Intermediate clusters run only the synchronous `RECOVER` command before stopping; the full validation suite runs only on the final version. This preserves one-time migrations when testing skipped release lines, for example `v2.8.5 → v3.0.2 → v3.1.0`.

## Testing

- `cargo test -p risingwave_hummock_sdk deprecated_change_log_delta_is_ignored`
- `cargo test -p risingwave_meta deprecated_table_change_logs_are_ignored`
- `cargo test -p risingwave_meta manager::transaction::tests`
- `cargo test -p risingwave_hummock_test test_iter_log`
- `cargo check -p risingwave_hummock_sdk -p risingwave_meta -p risingwave_storage -p risingwave_hummock_test --all-targets`
- `cargo clippy --all-targets --all-features`
- `bash -n ci/scripts/backwards-compat-test.sh e2e_test/backwards-compat-tests/scripts/utils.sh e2e_test/backwards-compat-tests/scripts/run_local.sh`
- Parsed `ci/workflows/pull-request.yml` and `ci/workflows/main-cron.yml` as YAML.
- Verified backward-compatibility version selection for matrix offsets 1 through 4.
- Verified retry-until-success behavior for the `RECOVER` command.

## Checklist

- [x] I have written necessary rustdoc comments.
- [x] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [x] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->

## Documentation

- [x] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

When upgrading from a release before v3.0, such as v2.8, do not skip the v3.0 release line. First upgrade to the latest supported v3.0 patch and wait for recovery to complete, then upgrade to v3.1 or later.

The v3.0 upgrade migrates retained table change logs from the legacy Hummock checkpoint and version fields into independent metastore tables. Directly upgrading from a pre-v3.0 release to v3.1 or later is unsupported and may make retained historical table change logs unavailable.

</details>
