### PR TITLE
refactor: introduce IcebergCompactionTaskId type

### DIFF
--- a/src/frontend/src/meta_client.rs
+++ b/src/frontend/src/meta_client.rs
@@ -31,7 +31,7 @@ use risingwave_pb::hummock::write_limits::WriteLimit;
 use risingwave_pb::hummock::{
     BranchedObject, CompactTaskAssignment, CompactTaskProgress, CompactionGroupInfo,
 };
-use risingwave_pb::id::ActorId;
+use risingwave_pb::id::{ActorId, IcebergCompactionTaskId};
 use risingwave_pb::meta::cancel_creating_jobs_request::PbJobs;
 use risingwave_pb::meta::list_actor_splits_response::ActorSplit;
 use risingwave_pb::meta::list_actor_states_response::ActorState;
@@ -227,7 +227,7 @@ pub trait FrontendMetaClient: Send + Sync {
 
     async fn set_sync_log_store_aligned(&self, job_id: JobId, aligned: bool) -> Result<()>;
 
-    async fn compact_iceberg_table(&self, sink_id: SinkId) -> Result<u64>;
+    async fn compact_iceberg_table(&self, sink_id: SinkId) -> Result<IcebergCompactionTaskId>;
 
     async fn rewrite_iceberg_table_manifests(&self, sink_id: SinkId) -> Result<()>;
 
@@ -578,7 +578,7 @@ impl FrontendMetaClient for FrontendMetaClientImpl {
         self.0.set_sync_log_store_aligned(job_id, aligned).await
     }
 
-    async fn compact_iceberg_table(&self, sink_id: SinkId) -> Result<u64> {
+    async fn compact_iceberg_table(&self, sink_id: SinkId) -> Result<IcebergCompactionTaskId> {
         self.0.compact_iceberg_table(sink_id).await
     }
 

--- a/src/frontend/src/test_utils.rs
+++ b/src/frontend/src/test_utils.rs
@@ -58,7 +58,7 @@ use risingwave_pb::hummock::write_limits::WriteLimit;
 use risingwave_pb::hummock::{
     BranchedObject, CompactTaskAssignment, CompactTaskProgress, CompactionGroupInfo,
 };
-use risingwave_pb::id::ActorId;
+use risingwave_pb::id::{ActorId, IcebergCompactionTaskId};
 use risingwave_pb::meta::cancel_creating_jobs_request::PbJobs;
 use risingwave_pb::meta::list_actor_splits_response::ActorSplit;
 use risingwave_pb::meta::list_actor_states_response::ActorState;
@@ -1463,8 +1463,8 @@ impl FrontendMetaClient for MockFrontendMetaClient {
         Ok(())
     }
 
-    async fn compact_iceberg_table(&self, _sink_id: SinkId) -> RpcResult<u64> {
-        Ok(1)
+    async fn compact_iceberg_table(&self, _sink_id: SinkId) -> RpcResult<IcebergCompactionTaskId> {
+        Ok(1.into())
     }
 
     async fn rewrite_iceberg_table_manifests(&self, _sink_id: SinkId) -> RpcResult<()> {

--- a/src/meta/src/hummock/compactor_manager.rs
+++ b/src/meta/src/hummock/compactor_manager.rs
@@ -29,6 +29,7 @@ use risingwave_pb::iceberg_compaction::subscribe_iceberg_compaction_event_respon
 use risingwave_pb::iceberg_compaction::{
     CancelCompactTask as IcebergCancelCompactTask, SubscribeIcebergCompactionEventResponse,
 };
+use risingwave_pb::id::IcebergCompactionTaskId;
 use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender};
 
 use crate::MetaResult;
@@ -516,7 +517,7 @@ impl IcebergCompactor {
         Ok(())
     }
 
-    pub fn cancel_task(&self, task_id: u64) -> MetaResult<()> {
+    pub fn cancel_task(&self, task_id: IcebergCompactionTaskId) -> MetaResult<()> {
         self.send_event(IcebergResponseEvent::CancelCompactTask(
             IcebergCancelCompactTask { task_id },
         ))
@@ -701,7 +702,7 @@ mod tests {
             .unwrap();
         assert_eq!(compactor.context_id(), iceberg_context_id);
 
-        compactor.cancel_task(42).unwrap();
+        compactor.cancel_task(42.into()).unwrap();
         let event = receiver.try_recv().unwrap().unwrap().event.unwrap();
         match event {
             IcebergResponseEvent::CancelCompactTask(cancel_task) => {

--- a/src/meta/src/hummock/manager/compaction/compaction_event_loop.rs
+++ b/src/meta/src/hummock/manager/compaction/compaction_event_loop.rs
@@ -696,7 +696,9 @@ impl IcebergCompactionEventHandler {
                     handle
                         .send_compact_task(
                             compactor,
-                            next_compaction_task_id(&self.compaction_manager.env).await?,
+                            next_compaction_task_id(&self.compaction_manager.env)
+                                .await?
+                                .into(),
                         )
                         .await
                 }

--- a/src/meta/src/manager/iceberg_compaction/manual.rs
+++ b/src/meta/src/manager/iceberg_compaction/manual.rs
@@ -16,6 +16,7 @@ use anyhow::anyhow;
 use risingwave_connector::sink::catalog::SinkId;
 use risingwave_pb::iceberg_compaction::subscribe_iceberg_compaction_event_request::ReportTask as IcebergReportTask;
 use risingwave_pb::iceberg_compaction::subscribe_iceberg_compaction_event_request::report_task::Status as IcebergReportTaskStatus;
+use risingwave_pb::id::IcebergCompactionTaskId;
 
 use super::*;
 
@@ -46,7 +47,10 @@ impl IcebergCompactionManager {
         let _ = waiter.send(result);
     }
 
-    pub async fn trigger_manual_compaction(&self, sink_id: SinkId) -> MetaResult<u64> {
+    pub async fn trigger_manual_compaction(
+        &self,
+        sink_id: SinkId,
+    ) -> MetaResult<IcebergCompactionTaskId> {
         // Fast-fail before registering a waiter when no compactor can pull the
         // scheduler task.
         if self.iceberg_compactor_manager.compactor_num() == 0 {

--- a/src/meta/src/manager/iceberg_compaction/mod.rs
+++ b/src/meta/src/manager/iceberg_compaction/mod.rs
@@ -29,6 +29,7 @@ use risingwave_connector::sink::catalog::{SinkCatalog, SinkId};
 use risingwave_connector::sink::iceberg::{ICEBERG_SINK, IcebergConfig};
 use risingwave_connector::source::UPSTREAM_SOURCE_KEY;
 use risingwave_pb::iceberg_compaction::SubscribeIcebergCompactionEventRequest;
+use risingwave_pb::id::IcebergCompactionTaskId;
 use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender};
 use tonic::Streaming;
 
@@ -47,7 +48,7 @@ pub(crate) type CompactorChangeTx =
 pub(crate) type CompactorChangeRx =
     UnboundedReceiver<(WorkerId, Streaming<SubscribeIcebergCompactionEventRequest>)>;
 
-type ManualCompactionWaiter = tokio::sync::oneshot::Sender<MetaResult<u64>>;
+type ManualCompactionWaiter = tokio::sync::oneshot::Sender<MetaResult<IcebergCompactionTaskId>>;
 
 use schedule::CompactionTrack;
 pub use schedule::IcebergCompactionScheduleStatus;

--- a/src/meta/src/manager/iceberg_compaction/schedule.rs
+++ b/src/meta/src/manager/iceberg_compaction/schedule.rs
@@ -31,6 +31,7 @@ use risingwave_pb::iceberg_compaction::IcebergCompactionTask;
 use risingwave_pb::iceberg_compaction::iceberg_compaction_task::TaskType;
 use risingwave_pb::iceberg_compaction::subscribe_iceberg_compaction_event_request::ReportTask as IcebergReportTask;
 use risingwave_pb::iceberg_compaction::subscribe_iceberg_compaction_event_request::report_task::Status as IcebergReportTaskStatus;
+use risingwave_pb::id::IcebergCompactionTaskId;
 use thiserror_ext::AsReport;
 use tokio::sync::oneshot;
 
@@ -58,7 +59,7 @@ enum CompactionTrackState {
     /// Compaction task is in-flight. `report_deadline` acts as a lease; if it
     /// expires before a report arrives, the task becomes retryable.
     InFlight {
-        task_id: u64,
+        task_id: IcebergCompactionTaskId,
         compactor_context_id: HummockContextId,
         task_type: TaskType,
         pending_commit_count_at_dispatch: usize,
@@ -69,7 +70,7 @@ enum CompactionTrackState {
 
 #[derive(Debug, Clone, Copy)]
 struct ScheduledCompactionTask {
-    task_id: u64,
+    task_id: IcebergCompactionTaskId,
     compactor_context_id: HummockContextId,
 }
 
@@ -218,7 +219,7 @@ impl CompactionTrack {
 
     fn mark_dispatched(
         &mut self,
-        task_id: u64,
+        task_id: IcebergCompactionTaskId,
         compactor_context_id: HummockContextId,
         now: Instant,
     ) {
@@ -277,7 +278,7 @@ impl CompactionTrack {
         self.finish_action == CompactionTrackFinishAction::RemoveTrack
     }
 
-    pub(super) fn is_processing_task(&self, task_id: u64) -> bool {
+    pub(super) fn is_processing_task(&self, task_id: IcebergCompactionTaskId) -> bool {
         matches!(
             &self.state,
             CompactionTrackState::InFlight {
@@ -427,7 +428,7 @@ impl IcebergCompactionHandle {
     pub async fn send_compact_task(
         mut self,
         compactor: Arc<crate::hummock::IcebergCompactor>,
-        task_id: u64,
+        task_id: IcebergCompactionTaskId,
     ) -> MetaResult<()> {
         use risingwave_pb::iceberg_compaction::subscribe_iceberg_compaction_event_response::Event as IcebergResponseEvent;
 
@@ -441,7 +442,7 @@ impl IcebergCompactionHandle {
                 iceberg_component = "compaction_scheduler",
                 iceberg_operation = "dispatch_task",
                 sink_id = %self.sink_id,
-                task_id,
+                task_id = %task_id,
                 "iceberg_compaction_dispatch_sink_not_found",
             );
             return Ok(());
@@ -474,7 +475,7 @@ impl IcebergCompactionHandle {
                     iceberg_component = "compaction_scheduler",
                     iceberg_operation = "dispatch_task",
                     sink_id = %self.sink_id,
-                    task_id,
+                    task_id = %task_id,
                     "iceberg_compaction_dispatch_track_not_pending",
                 );
             }
@@ -488,14 +489,18 @@ impl IcebergCompactionHandle {
         result
     }
 
-    fn cancel_sent_task(&self, compactor: &crate::hummock::IcebergCompactor, task_id: u64) {
+    fn cancel_sent_task(
+        &self,
+        compactor: &crate::hummock::IcebergCompactor,
+        task_id: IcebergCompactionTaskId,
+    ) {
         if let Err(e) = compactor.cancel_task(task_id) {
             tracing::warn!(
                 iceberg_component = "compaction_scheduler",
                 iceberg_operation = "cancel_task",
                 error = %e.as_report(),
                 sink_id = %self.sink_id,
-                task_id,
+                task_id = %task_id,
                 "iceberg_compaction_cancel_after_schedule_removal_failed",
             );
         }
@@ -828,7 +833,7 @@ impl IcebergCompactionManager {
     pub(super) async fn start_manual_compaction(
         &self,
         sink_id: SinkId,
-    ) -> MetaResult<oneshot::Receiver<MetaResult<u64>>> {
+    ) -> MetaResult<oneshot::Receiver<MetaResult<IcebergCompactionTaskId>>> {
         let prepared_update = self
             .prepare_sink_update(
                 sink_id,
@@ -1031,7 +1036,7 @@ impl IcebergCompactionManager {
         else {
             tracing::warn!(
                 sink_id = %sink_id,
-                task_id,
+                task_id = %task_id,
                 compactor_context_id = %compactor_context_id,
                 "Unable to cancel iceberg compaction task because compactor is no longer registered",
             );
@@ -1040,7 +1045,7 @@ impl IcebergCompactionManager {
 
         tracing::info!(
             sink_id = %sink_id,
-            task_id,
+            task_id = %task_id,
             compactor_context_id = %compactor_context_id,
             "Cancelling iceberg compaction task for removed schedule",
         );
@@ -1049,7 +1054,7 @@ impl IcebergCompactionManager {
             tracing::warn!(
                 error = %e.as_report(),
                 sink_id = %sink_id,
-                task_id,
+                task_id = %task_id,
                 compactor_context_id = %compactor_context_id,
                 "Failed to cancel iceberg compaction task for removed schedule",
             );
@@ -1125,7 +1130,7 @@ impl IcebergCompactionManager {
                                 iceberg_component = "compaction_scheduler",
                                 iceberg_operation = "handle_report",
                                 sink_id = %sink_id,
-                                task_id,
+                                task_id = %task_id,
                                 status = ?status,
                                 error_message = report.error_message.as_deref().unwrap_or_default(),
                                 "iceberg_compaction_task_reported_failure",
@@ -1142,7 +1147,7 @@ impl IcebergCompactionManager {
                         iceberg_component = "compaction_scheduler",
                         iceberg_operation = "handle_report",
                         sink_id = %sink_id,
-                        task_id,
+                        task_id = %task_id,
                         status = ?status,
                         "iceberg_compaction_report_ignored_stale",
                     );
@@ -1152,7 +1157,7 @@ impl IcebergCompactionManager {
                         iceberg_component = "compaction_scheduler",
                         iceberg_operation = "handle_report",
                         sink_id = %sink_id,
-                        task_id,
+                        task_id = %task_id,
                         status = ?status,
                         "iceberg_compaction_report_unknown_sink",
                     );

--- a/src/meta/src/manager/iceberg_compaction/schedule/tests.rs
+++ b/src/meta/src/manager/iceberg_compaction/schedule/tests.rs
@@ -17,6 +17,7 @@ use std::sync::Arc;
 
 use prometheus::Registry;
 use risingwave_pb::iceberg_compaction::subscribe_iceberg_compaction_event_response::Event as IcebergResponseEvent;
+use risingwave_pb::id::IcebergCompactionTaskId;
 
 use super::*;
 use crate::controller::catalog::CatalogController;
@@ -67,15 +68,19 @@ fn new_track(
 
 fn start_in_flight_on(
     track: &mut CompactionTrack,
-    task_id: u64,
+    task_id: impl Into<IcebergCompactionTaskId>,
     compactor_context_id: HummockContextId,
     now: Instant,
 ) {
     track.start_processing();
-    track.mark_dispatched(task_id, compactor_context_id, now);
+    track.mark_dispatched(task_id.into(), compactor_context_id, now);
 }
 
-fn start_in_flight(track: &mut CompactionTrack, task_id: u64, now: Instant) {
+fn start_in_flight(
+    track: &mut CompactionTrack,
+    task_id: impl Into<IcebergCompactionTaskId>,
+    now: Instant,
+) {
     start_in_flight_on(track, task_id, 1.into(), now);
 }
 
@@ -246,7 +251,7 @@ async fn test_commit_update_freezes_gc_watermark_after_task_start() {
         .sink_schedules
         .get_mut(&sink_id)
         .unwrap()
-        .mark_dispatched(1, 1.into(), now);
+        .mark_dispatched(1.into(), 1.into(), now);
     let applied = manager.apply_sink_update(
         &mut guard,
         PreparedSinkUpdate {
@@ -456,10 +461,10 @@ fn test_mark_dispatched_records_task_id_for_stale_report_filtering() {
     let mut track = new_track(now, 120, 10, 5);
     track.start_processing();
     assert!(track.is_pending_dispatch());
-    track.mark_dispatched(42, 1.into(), now);
+    track.mark_dispatched(42.into(), 1.into(), now);
 
-    assert!(track.is_processing_task(42));
-    assert!(!track.is_processing_task(43));
+    assert!(track.is_processing_task(42.into()));
+    assert!(!track.is_processing_task(43.into()));
 }
 
 #[test]
@@ -831,7 +836,7 @@ async fn test_apply_sink_update_keeps_processing_track_when_compaction_is_disabl
     config.enable_compaction = false;
     let mut track = new_track(now, 300, 3, 0);
     track.start_processing();
-    track.mark_dispatched(task_id, 1.into(), now);
+    track.mark_dispatched(task_id.into(), 1.into(), now);
     let mut guard = empty_inner();
     guard.sink_schedules.insert(sink_id, track);
 
@@ -848,7 +853,7 @@ async fn test_apply_sink_update_keeps_processing_track_when_compaction_is_disabl
 
     assert!(matches!(
         guard.sink_schedules.get(&sink_id).unwrap().state,
-        CompactionTrackState::InFlight { task_id: 8, .. }
+        CompactionTrackState::InFlight { task_id, .. } if task_id.as_raw_id() == 8
     ));
 }
 
@@ -910,7 +915,7 @@ async fn test_apply_sink_update_rejects_temporary_manual_processing_track_withou
     assert_eq!(track.pending_commit_count, 1);
     assert!(matches!(
         track.state,
-        CompactionTrackState::InFlight { task_id: 8, .. }
+        CompactionTrackState::InFlight { task_id, .. } if task_id.as_raw_id() == 8
     ));
 }
 
@@ -946,7 +951,7 @@ async fn test_apply_sink_update_promotes_temporary_manual_track_when_compaction_
     }
 
     manager.handle_report_task(IcebergReportTask {
-        task_id,
+        task_id: task_id.into(),
         sink_id: sink_id.as_raw_id(),
         status: IcebergReportTaskStatus::Success as i32,
         error_message: None,
@@ -1089,7 +1094,7 @@ async fn test_handle_report_task_success_consumes_backlog_and_resets_to_idle() {
     manager.inner.write().sink_schedules.insert(sink_id, track);
 
     manager.handle_report_task(IcebergReportTask {
-        task_id: 9,
+        task_id: 9.into(),
         sink_id: sink_id.as_raw_id(),
         status: IcebergReportTaskStatus::Success as i32,
         error_message: None,
@@ -1109,7 +1114,7 @@ async fn test_handle_report_task_completes_manual_waiter_on_success() {
     let now = Instant::now();
     let mut track = new_track(now, 120, 10, 2);
     track.start_processing();
-    track.mark_dispatched(task_id, 1.into(), now);
+    track.mark_dispatched(task_id.into(), 1.into(), now);
     let (tx, rx) = tokio::sync::oneshot::channel();
     {
         let mut guard = manager.inner.write();
@@ -1118,7 +1123,7 @@ async fn test_handle_report_task_completes_manual_waiter_on_success() {
     }
 
     manager.handle_report_task(IcebergReportTask {
-        task_id,
+        task_id: task_id.into(),
         sink_id: sink_id.as_raw_id(),
         status: IcebergReportTaskStatus::Success as i32,
         error_message: None,
@@ -1140,7 +1145,7 @@ async fn test_handle_report_task_completes_manual_waiter_on_failure() {
     let now = Instant::now();
     let mut track = new_track(now, 120, 10, 2);
     track.start_processing();
-    track.mark_dispatched(task_id, 1.into(), now);
+    track.mark_dispatched(task_id.into(), 1.into(), now);
     let (tx, rx) = tokio::sync::oneshot::channel();
     {
         let mut guard = manager.inner.write();
@@ -1149,7 +1154,7 @@ async fn test_handle_report_task_completes_manual_waiter_on_failure() {
     }
 
     manager.handle_report_task(IcebergReportTask {
-        task_id,
+        task_id: task_id.into(),
         sink_id: sink_id.as_raw_id(),
         status: IcebergReportTaskStatus::Failed as i32,
         error_message: Some("boom".to_owned()),
@@ -1173,7 +1178,7 @@ async fn test_handle_report_task_removes_temporary_manual_track_on_success() {
     let mut track = new_track(now, 120, 10, 0);
     track.finish_action = CompactionTrackFinishAction::RemoveTrack;
     track.start_processing();
-    track.mark_dispatched(task_id, 1.into(), now);
+    track.mark_dispatched(task_id.into(), 1.into(), now);
     let (tx, rx) = tokio::sync::oneshot::channel();
     {
         let mut guard = manager.inner.write();
@@ -1182,7 +1187,7 @@ async fn test_handle_report_task_removes_temporary_manual_track_on_success() {
     }
 
     manager.handle_report_task(IcebergReportTask {
-        task_id,
+        task_id: task_id.into(),
         sink_id: sink_id.as_raw_id(),
         status: IcebergReportTaskStatus::Success as i32,
         error_message: None,
@@ -1203,7 +1208,7 @@ async fn test_handle_report_task_removes_temporary_manual_track_on_failure() {
     let mut track = new_track(now, 120, 10, 0);
     track.finish_action = CompactionTrackFinishAction::RemoveTrack;
     track.start_processing();
-    track.mark_dispatched(task_id, 1.into(), now);
+    track.mark_dispatched(task_id.into(), 1.into(), now);
     let (tx, rx) = tokio::sync::oneshot::channel();
     {
         let mut guard = manager.inner.write();
@@ -1212,7 +1217,7 @@ async fn test_handle_report_task_removes_temporary_manual_track_on_failure() {
     }
 
     manager.handle_report_task(IcebergReportTask {
-        task_id,
+        task_id: task_id.into(),
         sink_id: sink_id.as_raw_id(),
         status: IcebergReportTaskStatus::Failed as i32,
         error_message: Some("boom".to_owned()),
@@ -1313,10 +1318,10 @@ async fn test_manual_compaction_waiter_is_not_stolen_during_config_load() {
         let mut guard = manager.inner.write();
         let track = guard.sink_schedules.get_mut(&sink_id).unwrap();
         track.start_processing();
-        track.mark_dispatched(task_id, 1.into(), now);
+        track.mark_dispatched(task_id.into(), 1.into(), now);
     }
     manager.handle_report_task(IcebergReportTask {
-        task_id,
+        task_id: task_id.into(),
         sink_id: sink_id.as_raw_id(),
         status: IcebergReportTaskStatus::Success as i32,
         error_message: None,
@@ -1441,7 +1446,7 @@ async fn test_trigger_manual_compaction_rejects_existing_task() {
     assert!(!guard.manual_compaction_waiters.contains_key(&sink_id));
     assert!(matches!(
         guard.sink_schedules.get(&sink_id).unwrap().state,
-        CompactionTrackState::InFlight { task_id: 9, .. }
+        CompactionTrackState::InFlight { task_id, .. } if task_id.as_raw_id() == 9
     ));
 }
 
@@ -1494,7 +1499,7 @@ async fn test_handle_report_task_failure_preserves_backlog_and_resets_to_idle() 
     manager.inner.write().sink_schedules.insert(sink_id, track);
 
     manager.handle_report_task(IcebergReportTask {
-        task_id: 9,
+        task_id: 9.into(),
         sink_id: sink_id.as_raw_id(),
         status: IcebergReportTaskStatus::Failed as i32,
         error_message: Some("boom".to_owned()),
@@ -1521,7 +1526,7 @@ async fn test_handle_report_task_ignores_stale_task_id() {
     }
 
     manager.handle_report_task(IcebergReportTask {
-        task_id: 10,
+        task_id: 10.into(),
         sink_id: sink_id.as_raw_id(),
         status: IcebergReportTaskStatus::Success as i32,
         error_message: None,
@@ -1532,7 +1537,7 @@ async fn test_handle_report_task_ignores_stale_task_id() {
     assert_eq!(track.pending_commit_count, 2);
     assert!(matches!(
         track.state,
-        CompactionTrackState::InFlight { task_id: 9, .. }
+        CompactionTrackState::InFlight { task_id, .. } if task_id.as_raw_id() == 9
     ));
     assert!(guard.manual_compaction_waiters.contains_key(&sink_id));
 }

--- a/src/prost/build.rs
+++ b/src/prost/build.rs
@@ -260,6 +260,9 @@ for_all_wrapped_id_fields! (
         CompactIcebergTableRequest {
             sink_id: SinkId,
         }
+        CompactIcebergTableResponse {
+            task_id: IcebergCompactionTaskId,
+        }
         CreateConnectionRequest {
             database_id: DatabaseId,
             schema_id: SchemaId,
@@ -557,8 +560,17 @@ for_all_wrapped_id_fields! (
         }
     }
     iceberg_compaction {
+        CancelCompactTask {
+            task_id: IcebergCompactionTaskId,
+        }
+        IcebergCompactionTask {
+            task_id: IcebergCompactionTaskId,
+        }
         SubscribeIcebergCompactionEventRequest.Register {
             context_id: WorkerId,
+        }
+        SubscribeIcebergCompactionEventRequest.ReportTask {
+            task_id: IcebergCompactionTaskId,
         }
     }
     meta {

--- a/src/prost/src/id.rs
+++ b/src/prost/src/id.rs
@@ -381,7 +381,8 @@ declare_id_types!(
     HummockVectorFileId,
     HummockHnswGraphFileId,
     HummockVersionId,
-    CompactionGroupId
+    CompactionGroupId,
+    IcebergCompactionTaskId
 );
 
 macro_rules! impl_as {

--- a/src/rpc_client/src/meta_client.rs
+++ b/src/rpc_client/src/meta_client.rs
@@ -82,7 +82,7 @@ use risingwave_pb::iceberg_compaction::{
     SubscribeIcebergCompactionEventRequest, SubscribeIcebergCompactionEventResponse,
     subscribe_iceberg_compaction_event_request,
 };
-use risingwave_pb::id::{ActorId, FragmentId, HummockSstableId, SourceId};
+use risingwave_pb::id::{ActorId, FragmentId, HummockSstableId, IcebergCompactionTaskId, SourceId};
 use risingwave_pb::meta::alter_connector_props_request::{
     AlterConnectorPropsObject, AlterIcebergTableIds, ExtraOptions,
 };
@@ -911,7 +911,7 @@ impl MetaClient {
             .ok_or_else(|| anyhow!("wait version not set"))?)
     }
 
-    pub async fn compact_iceberg_table(&self, sink_id: SinkId) -> Result<u64> {
+    pub async fn compact_iceberg_table(&self, sink_id: SinkId) -> Result<IcebergCompactionTaskId> {
         let request = CompactIcebergTableRequest { sink_id };
         let resp = self.inner.compact_iceberg_table(request).await?;
         Ok(resp.task_id)

--- a/src/storage/src/hummock/compactor/iceberg_compaction/iceberg_compactor_runner.rs
+++ b/src/storage/src/hummock/compactor/iceberg_compaction/iceberg_compactor_runner.rs
@@ -41,6 +41,7 @@ use risingwave_connector::sink::iceberg::{
 };
 use risingwave_pb::iceberg_compaction::IcebergCompactionTask;
 use risingwave_pb::iceberg_compaction::iceberg_compaction_task::TaskType;
+use risingwave_pb::id::IcebergCompactionTaskId;
 use thiserror_ext::AsReport;
 use tokio::sync::oneshot::Receiver;
 
@@ -113,7 +114,7 @@ impl Debug for IcebergCompactionTaskStatistics {
 /// Compaction plan runner that executes a single compaction plan.
 #[derive(Debug)]
 pub struct IcebergCompactionPlanRunner {
-    pub task_id: u64,
+    pub task_id: IcebergCompactionTaskId,
     pub sink_id: u32,
     pub plan_index: usize,
 
@@ -206,7 +207,7 @@ impl IcebergCompactionPlanRunner {
                 tracing::info!(
                     iceberg_component = "compaction_worker",
                     iceberg_operation = "execute_plan",
-                    task_id = task_id,
+                    task_id = %task_id,
                     sink_id = sink_id,
                     plan_index = plan_index,
                     task_type = ?task_type,
@@ -223,7 +224,7 @@ impl IcebergCompactionPlanRunner {
                         tracing::info!(
                             iceberg_component = "compaction_worker",
                             iceberg_operation = "execute_plan",
-                            task_id = task_id,
+                            task_id = %task_id,
                             sink_id = sink_id,
                             plan_index = plan_index,
                             task_type = ?task_type,
@@ -240,7 +241,7 @@ impl IcebergCompactionPlanRunner {
                             iceberg_component = "compaction_worker",
                             iceberg_operation = "execute_plan",
                             error = %e.as_report(),
-                            task_id = task_id,
+                            task_id = %task_id,
                             sink_id = sink_id,
                             plan_index = plan_index,
                             task_type = ?task_type,
@@ -257,7 +258,7 @@ impl IcebergCompactionPlanRunner {
     }
 
     async fn compact_impl(
-        task_id: u64,
+        task_id: IcebergCompactionTaskId,
         plan_index: usize,
         catalog: Arc<dyn Catalog>,
         table_ident: TableIdent,
@@ -272,7 +273,7 @@ impl IcebergCompactionPlanRunner {
             tracing::info!(
                 iceberg_component = "compaction_worker",
                 iceberg_operation = "plan_compaction",
-                task_id,
+                task_id = %task_id,
                 plan_index,
                 task_type = ?task_type,
                 table = %table_ident,
@@ -309,7 +310,7 @@ impl IcebergCompactionPlanRunner {
         tracing::info!(
             iceberg_component = "compaction_worker",
             iceberg_operation = "execute_plan",
-            task_id = task_id,
+            task_id = %task_id,
             plan_index = plan_index,
             task_type = ?task_type,
             table = %table_ident,
@@ -608,7 +609,7 @@ pub async fn create_task_execution(
         tracing::info!(
             iceberg_component = "compaction_worker",
             iceberg_operation = "plan_task",
-            task_id = task_id,
+            task_id = %task_id,
             sink_id = sink_id,
             task_type = ?parsed_task_type,
             table = %table_ident,
@@ -642,7 +643,7 @@ pub async fn create_task_execution(
     tracing::info!(
         iceberg_component = "compaction_worker",
         iceberg_operation = "plan_task",
-        task_id = task_id,
+        task_id = %task_id,
         sink_id = sink_id,
         task_type = ?parsed_task_type,
         table = %table_ident,

--- a/src/storage/src/hummock/compactor/iceberg_compaction/mod.rs
+++ b/src/storage/src/hummock/compactor/iceberg_compaction/mod.rs
@@ -26,15 +26,16 @@ pub(crate) mod report;
 use std::collections::{HashMap, VecDeque};
 use std::sync::Arc;
 
+use risingwave_pb::id::IcebergCompactionTaskId;
 use tokio::sync::Notify;
 
 /// Unique key combining `(task_id, plan_index)` since one task can have multiple plans.
-pub(crate) type TaskKey = (u64, usize);
+pub(crate) type TaskKey = (IcebergCompactionTaskId, usize);
 
 /// Task metadata for queue operations.
 #[derive(Debug, Clone)]
 pub struct IcebergTaskMeta {
-    pub task_id: u64,
+    pub task_id: IcebergCompactionTaskId,
     pub plan_index: usize,
     /// Must be in range `1..=max_parallelism`
     pub required_parallelism: u32,
@@ -237,7 +238,7 @@ impl IcebergTaskQueue {
     pub fn finish_running(&mut self, task_key: TaskKey) -> bool {
         let Some(required) = self.inner.id_map.remove(&task_key) else {
             tracing::warn!(
-                task_id = task_key.0,
+                task_id = %task_key.0,
                 plan_index = task_key.1,
                 "finish_running called for unknown task key, possible bug: double-finish or invalid key"
             );
@@ -254,7 +255,7 @@ impl IcebergTaskQueue {
     /// Cancel all waiting plans belonging to the given task.
     ///
     /// Returns the number of waiting plans removed from the queue.
-    pub fn cancel_waiting_task(&mut self, task_id: u64) -> usize {
+    pub fn cancel_waiting_task(&mut self, task_id: IcebergCompactionTaskId) -> usize {
         let mut retained = VecDeque::with_capacity(self.inner.deque.len());
         let mut cancelled_parallelism = 0;
         let mut cancelled_count = 0;
@@ -290,7 +291,7 @@ mod tests {
 
     fn mk_meta(id: u64, plan_index: usize, p: u32) -> IcebergTaskMeta {
         IcebergTaskMeta {
-            task_id: id,
+            task_id: id.into(),
             plan_index,
             required_parallelism: p,
         }
@@ -303,11 +304,11 @@ mod tests {
         assert_eq!(q.waiting_parallelism_sum(), 4);
 
         let popped = q.pop().expect("should pop");
-        assert_eq!(popped.meta.task_id, 1);
+        assert_eq!(popped.meta.task_id.as_raw_id(), 1);
         assert_eq!(q.waiting_parallelism_sum(), 0);
         assert_eq!(q.running_parallelism_sum(), 4);
 
-        assert!(q.finish_running((1, 0)));
+        assert!(q.finish_running((1.into(), 0)));
         assert_eq!(q.running_parallelism_sum(), 0);
     }
 
@@ -318,9 +319,9 @@ mod tests {
         assert_eq!(q.push(mk_meta(2, 0, 2), None), PushResult::Added);
         assert_eq!(q.push(mk_meta(3, 0, 2), None), PushResult::Added);
 
-        assert_eq!(q.pop().unwrap().meta.task_id, 1);
-        assert_eq!(q.pop().unwrap().meta.task_id, 2);
-        assert_eq!(q.pop().unwrap().meta.task_id, 3);
+        assert_eq!(q.pop().unwrap().meta.task_id.as_raw_id(), 1);
+        assert_eq!(q.pop().unwrap().meta.task_id.as_raw_id(), 2);
+        assert_eq!(q.pop().unwrap().meta.task_id.as_raw_id(), 3);
     }
 
     #[test]
@@ -359,9 +360,9 @@ mod tests {
 
         // After pop and finish, the key can be reused
         let p = q.pop().unwrap();
-        assert_eq!(p.meta.task_id, 1);
+        assert_eq!(p.meta.task_id.as_raw_id(), 1);
         assert_eq!(p.meta.plan_index, 0);
-        q.finish_running((1, 0));
+        q.finish_running((1.into(), 0));
 
         // Now the same key can be pushed again
         assert_eq!(q.push(mk_meta(1, 0, 4), None), PushResult::Added);
@@ -374,20 +375,20 @@ mod tests {
         assert_eq!(q.push(mk_meta(2, 0, 4), None), PushResult::Added);
 
         let p1 = q.pop().unwrap();
-        assert_eq!(p1.meta.task_id, 1);
+        assert_eq!(p1.meta.task_id.as_raw_id(), 1);
         // Not enough remaining parallelism (only 2 left)
         assert!(q.pop().is_none());
 
         // Finish first, then second becomes schedulable
-        assert!(q.finish_running((1, 0)));
+        assert!(q.finish_running((1.into(), 0)));
         let p2 = q.pop().unwrap();
-        assert_eq!(p2.meta.task_id, 2);
+        assert_eq!(p2.meta.task_id.as_raw_id(), 2);
     }
 
     #[test]
     fn test_finish_nonexistent_task() {
         let mut q = IcebergTaskQueue::new(4, 16);
-        assert!(!q.finish_running((999, 0)));
+        assert!(!q.finish_running((999.into(), 0)));
         assert_eq!(q.running_parallelism_sum(), 0);
     }
 
@@ -399,11 +400,11 @@ mod tests {
         assert_eq!(q.running_parallelism_sum(), 4);
 
         // First finish succeeds
-        assert!(q.finish_running((1, 0)));
+        assert!(q.finish_running((1.into(), 0)));
         assert_eq!(q.running_parallelism_sum(), 0);
 
         // Second finish on same key returns false (triggers warn log)
-        assert!(!q.finish_running((1, 0)));
+        assert!(!q.finish_running((1.into(), 0)));
         assert_eq!(q.running_parallelism_sum(), 0);
     }
 
@@ -441,16 +442,16 @@ mod tests {
         // Pop all
         for i in 0..3 {
             let p = q.pop().unwrap();
-            assert_eq!(p.meta.task_id, task_id);
+            assert_eq!(p.meta.task_id.as_raw_id(), task_id);
             assert_eq!(p.meta.plan_index, i);
         }
         assert_eq!(q.running_parallelism_sum(), 9);
 
         // Finish out of order
-        assert!(q.finish_running((task_id, 1)));
+        assert!(q.finish_running((task_id.into(), 1)));
         assert_eq!(q.running_parallelism_sum(), 5);
-        assert!(q.finish_running((task_id, 0)));
-        assert!(q.finish_running((task_id, 2)));
+        assert!(q.finish_running((task_id.into(), 0)));
+        assert!(q.finish_running((task_id.into(), 2)));
         assert_eq!(q.running_parallelism_sum(), 0);
     }
 
@@ -464,18 +465,18 @@ mod tests {
         assert_eq!(q.push(mk_meta(2, 0, 2), None), PushResult::Added);
 
         let popped = q.pop().unwrap();
-        assert_eq!(popped.meta.task_id, task_id);
+        assert_eq!(popped.meta.task_id.as_raw_id(), task_id);
         assert_eq!(popped.meta.plan_index, 0);
         assert_eq!(q.running_parallelism_sum(), 3);
         assert_eq!(q.waiting_parallelism_sum(), 6);
 
-        assert_eq!(q.cancel_waiting_task(task_id), 1);
+        assert_eq!(q.cancel_waiting_task(task_id.into()), 1);
         assert_eq!(q.running_parallelism_sum(), 3);
         assert_eq!(q.waiting_parallelism_sum(), 2);
 
-        assert!(q.finish_running((task_id, 0)));
+        assert!(q.finish_running((task_id.into(), 0)));
         let next = q.pop().unwrap();
-        assert_eq!(next.meta.task_id, 2);
+        assert_eq!(next.meta.task_id.as_raw_id(), 2);
         assert_eq!(next.meta.plan_index, 0);
     }
 
@@ -483,7 +484,7 @@ mod tests {
     fn test_empty_queue_behavior() {
         let mut q = IcebergTaskQueue::new(8, 32);
         assert!(q.pop().is_none());
-        assert!(!q.finish_running((1, 0)));
+        assert!(!q.finish_running((1.into(), 0)));
         assert_eq!(q.waiting_parallelism_sum(), 0);
         assert_eq!(q.running_parallelism_sum(), 0);
     }

--- a/src/storage/src/hummock/compactor/iceberg_compaction/report.rs
+++ b/src/storage/src/hummock/compactor/iceberg_compaction/report.rs
@@ -18,6 +18,7 @@ use std::time::SystemTime;
 use risingwave_pb::iceberg_compaction::{
     SubscribeIcebergCompactionEventRequest, subscribe_iceberg_compaction_event_request,
 };
+use risingwave_pb::id::IcebergCompactionTaskId;
 use thiserror_ext::AsReport;
 use tokio::sync::mpsc;
 
@@ -90,7 +91,7 @@ impl IcebergTaskTracker {
         self.failed_plans
     }
 
-    pub(crate) fn into_report(self, task_id: u64) -> IcebergTaskReport {
+    pub(crate) fn into_report(self, task_id: IcebergCompactionTaskId) -> IcebergTaskReport {
         let error_message = if self.successful_plans > 0 {
             None
         } else {
@@ -104,7 +105,7 @@ impl IcebergTaskTracker {
 }
 
 pub(crate) fn build_iceberg_task_report(
-    task_id: u64,
+    task_id: IcebergCompactionTaskId,
     sink_id: u32,
     error_message: Option<String>,
 ) -> IcebergTaskReport {
@@ -137,7 +138,7 @@ pub(crate) fn send_iceberg_task_report(
             iceberg_component = "compaction_worker",
             iceberg_operation = "report_task",
             error = %e.as_report(),
-            task_id = report_event.task_id,
+            task_id = %report_event.task_id,
             sink_id = report_event.sink_id,
             "iceberg_compaction_task_report_send_failed",
         );
@@ -183,7 +184,7 @@ mod tests {
         let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
         drop(rx);
 
-        let report = build_iceberg_task_report(7, 9, Some("send failure".to_owned()));
+        let report = build_iceberg_task_report(7.into(), 9, Some("send failure".to_owned()));
         let failed_report = send_iceberg_task_report(&tx, report.clone()).unwrap_err();
 
         assert_eq!(failed_report.task_id, report.task_id);
@@ -196,7 +197,7 @@ mod tests {
         let mut tracker = IcebergTaskTracker::new(9, 1);
         tracker.record_completion(None);
 
-        let report = tracker.into_report(7);
+        let report = tracker.into_report(7.into());
 
         assert_eq!(
             report.status,
@@ -211,7 +212,7 @@ mod tests {
         tracker.record_completion(Some("first failure".to_owned()));
         tracker.record_completion(Some("second failure".to_owned()));
 
-        let report = tracker.into_report(7);
+        let report = tracker.into_report(7.into());
 
         assert_eq!(
             report.status,

--- a/src/storage/src/hummock/compactor/mod.rs
+++ b/src/storage/src/hummock/compactor/mod.rs
@@ -77,6 +77,7 @@ use risingwave_pb::hummock::{
     CompactTaskProgress, PbSstableFilterLayout, PbSstableFilterType, ReportCompactionTaskRequest,
     SubscribeCompactionEventRequest, SubscribeCompactionEventResponse,
 };
+use risingwave_pb::id::IcebergCompactionTaskId;
 use risingwave_rpc_client::HummockMetaClient;
 pub use shared_buffer_compact::compact;
 use tokio::sync::oneshot::Sender;
@@ -432,7 +433,7 @@ pub fn start_iceberg_compactor(
         // Channel for task completion notifications
         let (task_completion_tx, mut task_completion_rx) =
             tokio::sync::mpsc::unbounded_channel::<IcebergPlanCompletion>();
-        let mut task_trackers = HashMap::<u64, IcebergTaskTracker>::new();
+        let mut task_trackers = HashMap::<IcebergCompactionTaskId, IcebergTaskTracker>::new();
         // Buffers task reports that failed to send on the current stream.
         // The queue is flushed in FIFO order after the stream reconnects.
         let mut pending_task_reports = VecDeque::<IcebergTaskReport>::new();
@@ -507,7 +508,7 @@ pub fn start_iceberg_compactor(
                         let task_key = plan_completion.task_key;
                         let error_message = plan_completion.error_message;
                         tracing::debug!(
-                            task_id = task_key.0,
+                            task_id = %task_key.0,
                             plan_index = task_key.1,
                             success = error_message.is_none(),
                             "Plan completed, updating queue state"
@@ -546,7 +547,7 @@ pub fn start_iceberg_compactor(
                             tracing::info!(
                                 iceberg_component = "compaction_worker",
                                 iceberg_operation = "report_task",
-                                task_id = completed_task_id,
+                                task_id = %completed_task_id,
                                 sink_id = sink_id,
                                 total_plans = total_plans,
                                 successful_plans = successful_plans,
@@ -634,7 +635,7 @@ pub fn start_iceberg_compactor(
                                             iceberg_component = "compaction_worker",
                                             iceberg_operation = "build_runner_config",
                                             error = %e.as_report(),
-                                            task_id = task_id,
+                                            task_id = %task_id,
                                             sink_id = sink_id,
                                             "iceberg_compaction_runner_config_failed",
                                         );
@@ -672,7 +673,7 @@ pub fn start_iceberg_compactor(
                                             iceberg_component = "compaction_worker",
                                             iceberg_operation = "plan_task",
                                             error = %e.as_report(),
-                                            task_id = task_id,
+                                            task_id = %task_id,
                                             sink_id = sink_id,
                                             "iceberg_compaction_task_plan_failed",
                                         );
@@ -705,7 +706,7 @@ pub fn start_iceberg_compactor(
                                     tracing::info!(
                                         iceberg_component = "compaction_worker",
                                         iceberg_operation = "enqueue_plan",
-                                        task_id = task_id,
+                                        task_id = %task_id,
                                         sink_id = sink_id,
                                         "iceberg_compaction_task_skipped_no_plans",
                                     );
@@ -742,7 +743,7 @@ pub fn start_iceberg_compactor(
                                             tracing::debug!(
                                                 iceberg_component = "compaction_worker",
                                                 iceberg_operation = "enqueue_plan",
-                                                task_id = task_id,
+                                                task_id = %task_id,
                                                 sink_id = runner_sink_id,
                                                 plan_index = plan_index,
                                                 task_type = ?runner_task_type,
@@ -755,7 +756,7 @@ pub fn start_iceberg_compactor(
                                             tracing::warn!(
                                                 iceberg_component = "compaction_worker",
                                                 iceberg_operation = "enqueue_plan",
-                                                task_id = task_id,
+                                                task_id = %task_id,
                                                 sink_id = runner_sink_id,
                                                 plan_index = plan_index,
                                                 task_type = ?runner_task_type,
@@ -773,7 +774,7 @@ pub fn start_iceberg_compactor(
                                             tracing::error!(
                                                 iceberg_component = "compaction_worker",
                                                 iceberg_operation = "enqueue_plan",
-                                                task_id = task_id,
+                                                task_id = %task_id,
                                                 sink_id = runner_sink_id,
                                                 plan_index = plan_index,
                                                 task_type = ?runner_task_type,
@@ -787,7 +788,7 @@ pub fn start_iceberg_compactor(
                                             tracing::error!(
                                                 iceberg_component = "compaction_worker",
                                                 iceberg_operation = "enqueue_plan",
-                                                task_id = task_id,
+                                                task_id = %task_id,
                                                 sink_id = runner_sink_id,
                                                 plan_index = plan_index,
                                                 task_type = ?runner_task_type,
@@ -800,7 +801,7 @@ pub fn start_iceberg_compactor(
                                             tracing::error!(
                                                 iceberg_component = "compaction_worker",
                                                 iceberg_operation = "enqueue_plan",
-                                                task_id = task_id,
+                                                task_id = %task_id,
                                                 sink_id = runner_sink_id,
                                                 plan_index = plan_index,
                                                 task_type = ?runner_task_type,
@@ -837,7 +838,7 @@ pub fn start_iceberg_compactor(
                                 tracing::info!(
                                     iceberg_component = "compaction_worker",
                                     iceberg_operation = "enqueue_plan",
-                                    task_id = task_id,
+                                    task_id = %task_id,
                                     sink_id = sink_id,
                                     total_plans = total_plans,
                                     enqueued_count = enqueued_count,
@@ -1448,7 +1449,7 @@ fn schedule_queued_tasks(
             tracing::error!(
                 iceberg_component = "compaction_worker",
                 iceberg_operation = "schedule_plan",
-                task_id = task_id,
+                task_id = %task_id,
                 plan_index = plan_index,
                 "iceberg_compaction_plan_missing_runner",
             );
@@ -1472,7 +1473,7 @@ fn schedule_queued_tasks(
         tracing::info!(
             iceberg_component = "compaction_worker",
             iceberg_operation = "schedule_plan",
-            task_id = task_id,
+            task_id = %task_id,
             sink_id = runner_sink_id,
             plan_index = plan_index,
             task_type = ?runner_task_type,
@@ -1500,7 +1501,7 @@ fn schedule_queued_tasks(
                         tracing::info!(
                             iceberg_component = "compaction_worker",
                             iceberg_operation = "execute_plan",
-                            task_id = task_key.0,
+                            task_id = %task_key.0,
                             sink_id = runner_sink_id,
                             plan_index = task_key.1,
                             task_type = ?runner_task_type,
@@ -1512,7 +1513,7 @@ fn schedule_queued_tasks(
                             iceberg_component = "compaction_worker",
                             iceberg_operation = "execute_plan",
                             error = %e.as_report(),
-                            task_id = task_key.0,
+                            task_id = %task_key.0,
                             sink_id = runner_sink_id,
                             plan_index = task_key.1,
                             task_type = ?runner_task_type,
@@ -1531,7 +1532,7 @@ fn schedule_queued_tasks(
                 tracing::warn!(
                     iceberg_component = "compaction_worker",
                     iceberg_operation = "notify_plan_completion",
-                    task_id = task_key.0,
+                    task_id = %task_key.0,
                     sink_id = runner_sink_id,
                     plan_index = task_key.1,
                     task_type = ?runner_task_type,
@@ -1551,10 +1552,10 @@ fn is_cancelled_iceberg_compaction_error(error: &crate::hummock::HummockError) -
 }
 
 fn cancel_iceberg_task(
-    task_id: u64,
+    task_id: IcebergCompactionTaskId,
     task_queue: &mut IcebergTaskQueue,
     shutdown_map: &Arc<Mutex<HashMap<TaskKey, Sender<()>>>>,
-    task_trackers: &mut HashMap<u64, IcebergTaskTracker>,
+    task_trackers: &mut HashMap<IcebergCompactionTaskId, IcebergTaskTracker>,
 ) {
     // Meta assigns one task id to an Iceberg compact task, but the compactor
     // splits it into multiple plan runners tracked by `(task_id, plan_index)`.
@@ -1576,7 +1577,7 @@ fn cancel_iceberg_task(
                 && tx.send(()).is_err()
             {
                 tracing::debug!(
-                    task_id = task_key.0,
+                    task_id = %task_key.0,
                     plan_index = task_key.1,
                     "Iceberg compaction plan shutdown receiver already closed during cancellation"
                 );
@@ -1588,12 +1589,12 @@ fn cancel_iceberg_task(
 
     if cancelled_waiting == 0 && cancelled_running == 0 && !removed_tracker {
         tracing::warn!(
-            task_id = task_id,
+            task_id = %task_id,
             "Attempting to cancel non-existent iceberg compaction task"
         );
     } else {
         tracing::info!(
-            task_id = task_id,
+            task_id = %task_id,
             cancelled_waiting = cancelled_waiting,
             cancelled_running = cancelled_running,
             removed_tracker = removed_tracker,
@@ -1671,7 +1672,7 @@ mod tests {
 
     #[test]
     fn test_cancel_iceberg_task_removes_waiting_plans_and_tracker() {
-        let task_id = 42;
+        let task_id = IcebergCompactionTaskId::new(42);
         let mut task_queue = IcebergTaskQueue::new(10, 30);
         assert_eq!(
             task_queue.push(
@@ -1708,7 +1709,7 @@ mod tests {
 
     #[test]
     fn test_cancel_iceberg_task_shuts_down_running_plans_and_tracker() {
-        let task_id = 43;
+        let task_id = IcebergCompactionTaskId::new(43);
         let task_key = (task_id, 0);
         let mut task_queue = IcebergTaskQueue::new(10, 30);
         let shutdown_map = Arc::new(Mutex::new(HashMap::new()));


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

**Stack:** PR 1 of 6 for iceberg pk-index compaction (→ #26563)

Introduces `IcebergCompactionTaskId` as a typed ID (replacing raw `u64`) across the entire iceberg compaction lifecycle: dispatch, compactor execution, report, and cancellation.

- Add `IcebergCompactionTaskId` to `declare_id_types!` in `src/prost/src/id.rs`
- Add proto wrapper `CompactIcebergTableResponse { task_id: IcebergCompactionTaskId }` in `src/prost/build.rs`
- Thread the typed ID through all compaction paths: manual trigger, schedule dispatch, compactor queue/tracker, report, cancel
- Update `compact_iceberg_table` return type in frontend meta client and RPC client
- Switch tracing sites to `%task_id` (Display) — `tracing::Value` is not implemented for `TypedId`

Pure mechanical refactor — no behavioral changes.

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] I have added necessary unit tests and integration tests.
- [x] I have added test labels as necessary.
- [ ] I have added fuzzing tests or opened an issue to track them.
- [ ] My PR contains breaking changes.
- [ ] My PR changes performance-critical code, so I will run (micro) benchmarks and present the results.
- [ ] I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into.