### PR TITLE
fix(meta): persist worker resource metadata

### DIFF
--- a/ci/workflows/pull-request.yml
+++ b/ci/workflows/pull-request.yml
@@ -894,6 +894,7 @@ steps:
           - "3"
           - "4"
     timeout_in_minutes: 25
+    retry: *auto-retry
 
   # Sqlsmith differential testing
   - label: "Sqlsmith Differential Testing"

--- a/ci/workflows/pull-request.yml
+++ b/ci/workflows/pull-request.yml
@@ -894,7 +894,6 @@ steps:
           - "3"
           - "4"
     timeout_in_minutes: 25
-    retry: *auto-retry
 
   # Sqlsmith differential testing
   - label: "Sqlsmith Differential Testing"

--- a/proto/common.proto
+++ b/proto/common.proto
@@ -91,12 +91,11 @@ message WorkerNode {
   // Ranges from 0 to 1023, used to generate the machine ID field in the global unique ID.
   optional uint32 transactional_id = 7;
   // Resource spec.
-  // It's populated by meta node with the value reported by worker node, when the worker node is added by meta node.
-  // It's not persistent in meta store.
+  // It's populated by meta node with the value reported by worker node and persisted in meta store.
   optional Resource resource = 8;
   // Timestamp the worker node is added by meta node, in seconds.
   // It's populated by meta node, when the worker node is added by meta node.
-  // It's not persistent in meta store.
+  // It's persisted in meta store.
   optional uint64 started_at = 9;
 
   // Moved to `Property` message.

--- a/proto/meta.proto
+++ b/proto/meta.proto
@@ -27,7 +27,8 @@ service TelemetryInfoService {
 
 message HeartbeatRequest {
   uint32 node_id = 1;
-  common.WorkerNode.Resource resource = 2;
+  reserved 2;
+  reserved "resource";
 }
 
 message HeartbeatResponse {

--- a/src/meta/model/migration/src/lib.rs
+++ b/src/meta/model/migration/src/lib.rs
@@ -73,6 +73,7 @@ mod m20260312_000000_streaming_job_backfill_parallelism_strategy;
 mod m20260518_000000_disable_unused_read_prefix_hints;
 mod m20260519_000000_streaming_job_batch_refresh_seconds;
 mod m20260624_000000_pending_sink_state_object_fk;
+mod m20260804_000000_worker_property_resource;
 mod utils;
 
 pub struct Migrator;
@@ -184,6 +185,7 @@ impl MigratorTrait for Migrator {
             Box::new(m20260518_000000_disable_unused_read_prefix_hints::Migration),
             Box::new(m20260519_000000_streaming_job_batch_refresh_seconds::Migration),
             Box::new(m20260624_000000_pending_sink_state_object_fk::Migration),
+            Box::new(m20260804_000000_worker_property_resource::Migration),
         ]
     }
 }

--- a/src/meta/model/migration/src/m20260804_000000_worker_property_resource.rs
+++ b/src/meta/model/migration/src/m20260804_000000_worker_property_resource.rs
@@ -1,0 +1,56 @@
+use sea_orm_migration::prelude::*;
+
+use crate::utils::ColumnDefExt;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(WorkerProperty::Table)
+                    .add_column(ColumnDef::new(WorkerProperty::Resource).rw_binary(manager))
+                    .to_owned(),
+            )
+            .await?;
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(WorkerProperty::Table)
+                    .add_column(ColumnDef::new(WorkerProperty::StartedAt).big_integer())
+                    .to_owned(),
+            )
+            .await?;
+        Ok(())
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(WorkerProperty::Table)
+                    .drop_column(WorkerProperty::Resource)
+                    .to_owned(),
+            )
+            .await?;
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(WorkerProperty::Table)
+                    .drop_column(WorkerProperty::StartedAt)
+                    .to_owned(),
+            )
+            .await?;
+        Ok(())
+    }
+}
+
+#[derive(DeriveIden)]
+enum WorkerProperty {
+    Table,
+    Resource,
+    StartedAt,
+}

--- a/src/meta/model/migration/src/m20260804_000000_worker_property_resource.rs
+++ b/src/meta/model/migration/src/m20260804_000000_worker_property_resource.rs
@@ -24,6 +24,9 @@ impl MigrationTrait for Migration {
                     .to_owned(),
             )
             .await?;
+        manager
+            .exec_stmt(Query::delete().from_table(Worker::Table).to_owned())
+            .await?;
         Ok(())
     }
 
@@ -46,6 +49,11 @@ impl MigrationTrait for Migration {
             .await?;
         Ok(())
     }
+}
+
+#[derive(DeriveIden)]
+enum Worker {
+    Table,
 }
 
 #[derive(DeriveIden)]

--- a/src/meta/model/src/lib.rs
+++ b/src/meta/model/src/lib.rs
@@ -451,6 +451,10 @@ derive_from_blob!(
 );
 derive_from_blob!(ConnectionParams, risingwave_pb::catalog::ConnectionParams);
 derive_from_blob!(AuthInfo, risingwave_pb::user::PbAuthInfo);
+derive_from_blob!(
+    WorkerResource,
+    risingwave_pb::common::worker_node::PbResource
+);
 
 derive_from_blob!(ConnectorSplits, risingwave_pb::source::ConnectorSplits);
 derive_from_blob!(VnodeBitmap, risingwave_pb::common::Buffer);

--- a/src/meta/model/src/worker_property.rs
+++ b/src/meta/model/src/worker_property.rs
@@ -15,7 +15,7 @@
 use sea_orm::entity::prelude::*;
 use serde::{Deserialize, Serialize};
 
-use crate::WorkerId;
+use crate::{WorkerId, WorkerResource};
 
 #[derive(Clone, Debug, PartialEq, DeriveEntityModel, Eq, Serialize, Deserialize)]
 #[sea_orm(table_name = "worker_property")]
@@ -29,6 +29,8 @@ pub struct Model {
     pub internal_rpc_host_addr: Option<String>,
     pub resource_group: Option<String>,
     pub is_iceberg_compactor: bool,
+    pub resource: Option<WorkerResource>,
+    pub started_at: Option<i64>,
 }
 
 #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]

--- a/src/meta/service/src/heartbeat_service.rs
+++ b/src/meta/service/src/heartbeat_service.rs
@@ -39,7 +39,7 @@ impl HeartbeatService for HeartbeatServiceImpl {
         let result = self
             .metadata_manager
             .cluster_controller
-            .heartbeat(req.node_id, req.resource)
+            .heartbeat(req.node_id)
             .await;
 
         match result {

--- a/src/meta/service/src/notification_service.rs
+++ b/src/meta/service/src/notification_service.rs
@@ -238,7 +238,7 @@ impl NotificationServiceImpl {
     }
 
     /// Get the total resource of the cluster.
-    async fn get_cluster_resource(&self) -> ClusterResource {
+    async fn get_cluster_resource(&self) -> MetaResult<ClusterResource> {
         self.metadata_manager
             .cluster_controller
             .cluster_resource()
@@ -247,7 +247,7 @@ impl NotificationServiceImpl {
 
     async fn compactor_subscribe(&self) -> MetaResult<MetaSnapshot> {
         let (tables, catalog_version) = self.get_tables_snapshot().await?;
-        let cluster_resource = self.get_cluster_resource().await;
+        let cluster_resource = self.get_cluster_resource().await?;
 
         Ok(MetaSnapshot {
             tables,
@@ -320,7 +320,7 @@ impl NotificationServiceImpl {
                 .context("failed to encode session params")?,
         });
 
-        let cluster_resource = self.get_cluster_resource().await;
+        let cluster_resource = self.get_cluster_resource().await?;
 
         Ok(MetaSnapshot {
             databases,
@@ -360,7 +360,7 @@ impl NotificationServiceImpl {
             .await;
         let hummock_write_limits = self.hummock_manager.write_limits().await;
         let meta_backup_manifest_id = self.backup_manager.manifest().await.manifest_id;
-        let cluster_resource = self.get_cluster_resource().await;
+        let cluster_resource = self.get_cluster_resource().await?;
         let table_refill_runtime_config = build_hummock_table_refill_runtime_config(
             &self.serving_vnode_mapping,
             worker_id,
@@ -390,7 +390,7 @@ impl NotificationServiceImpl {
 
     async fn compute_subscribe(&self) -> MetaResult<MetaSnapshot> {
         let (secrets, catalog_version) = self.get_decrypted_secret_snapshot().await?;
-        let cluster_resource = self.get_cluster_resource().await;
+        let cluster_resource = self.get_cluster_resource().await?;
 
         Ok(MetaSnapshot {
             secrets,

--- a/src/meta/src/controller/cluster.rs
+++ b/src/meta/src/controller/cluster.rs
@@ -63,11 +63,7 @@ pub struct ClusterController {
     started_at: u64,
 }
 
-struct WorkerInfo(
-    worker::Model,
-    Option<worker_property::Model>,
-    WorkerExtraInfo,
-);
+struct WorkerInfo(worker::Model, Option<worker_property::Model>);
 
 impl From<WorkerInfo> for PbWorkerNode {
     fn from(info: WorkerInfo) -> Self {
@@ -88,7 +84,11 @@ impl From<WorkerInfo> for PbWorkerNode {
                 is_iceberg_compactor: p.is_iceberg_compactor,
             }),
             transactional_id: info.0.transaction_id.map(|id| id as _),
-            resource: Some(info.2.resource),
+            resource: info
+                .1
+                .as_ref()
+                .and_then(|property| property.resource.as_ref())
+                .map(|resource| resource.to_protobuf()),
             started_at: info
                 .1
                 .as_ref()
@@ -124,13 +124,13 @@ impl ClusterController {
     }
 
     /// Get the total resource of the cluster.
-    pub async fn cluster_resource(&self) -> ClusterResource {
-        self.inner.read().await.cluster_resource()
+    pub async fn cluster_resource(&self) -> MetaResult<ClusterResource> {
+        self.inner.read().await.cluster_resource().await
     }
 
     /// Get the total resource of the cluster, then update license manager and notify all other nodes.
     async fn update_cluster_resource_for_license(&self) -> MetaResult<()> {
-        let resource = self.cluster_resource().await;
+        let resource = self.cluster_resource().await?;
 
         // Update local license manager.
         LicenseManager::get().update_cluster_resource(resource);
@@ -449,21 +449,9 @@ impl StreamingClusterInfo {
 pub struct WorkerExtraInfo {
     // Unix timestamp that the worker will expire at.
     expire_at: Option<u64>,
-    // Cached from worker_property to calculate cluster resources without DB I/O.
-    resource: PbResource,
 }
 
 impl WorkerExtraInfo {
-    fn from_worker_property(property: Option<&worker_property::Model>) -> Self {
-        Self {
-            resource: property
-                .and_then(|property| property.resource.as_ref())
-                .map(|resource| resource.to_protobuf())
-                .unwrap_or_default(),
-            ..Default::default()
-        }
-    }
-
     fn update_ttl(&mut self, ttl: Duration) {
         let expire = cmp::max(
             self.expire_at.unwrap_or_default(),
@@ -522,25 +510,23 @@ impl ClusterControllerInner {
         disable_automatic_parallelism_control: bool,
     ) -> MetaResult<Self> {
         let workers = Worker::find()
-            .find_also_related(WorkerProperty)
+            .select_only()
+            .column(worker::Column::WorkerId)
+            .column(worker::Column::TransactionId)
+            .into_tuple::<(WorkerId, Option<TransactionId>)>()
             .all(&db)
             .await?;
         let inuse_txn_ids: HashSet<_> = workers
             .iter()
-            .filter_map(|(worker, _)| worker.transaction_id)
+            .filter_map(|(_, transaction_id)| *transaction_id)
             .collect();
         let available_transactional_ids = (0..Self::MAX_WORKER_REUSABLE_ID_COUNT as TransactionId)
             .filter(|id| !inuse_txn_ids.contains(id))
             .collect();
 
         let worker_extra_info = workers
-            .iter()
-            .map(|(worker, property)| {
-                (
-                    worker.worker_id,
-                    WorkerExtraInfo::from_worker_property(property.as_ref()),
-                )
-            })
+            .into_iter()
+            .map(|(worker_id, _)| (worker_id, WorkerExtraInfo::default()))
             .collect();
 
         Ok(Self {
@@ -581,22 +567,6 @@ impl ClusterControllerInner {
         }
     }
 
-    fn update_resource(&mut self, worker_id: WorkerId, resource: PbResource) -> MetaResult<()> {
-        if let Some(info) = self.worker_extra_info.get_mut(&worker_id) {
-            info.resource = resource;
-            Ok(())
-        } else {
-            Err(MetaError::invalid_worker(worker_id, "worker not found"))
-        }
-    }
-
-    fn get_extra_info_checked(&self, worker_id: WorkerId) -> MetaResult<WorkerExtraInfo> {
-        self.worker_extra_info
-            .get(&worker_id)
-            .cloned()
-            .ok_or_else(|| MetaError::invalid_worker(worker_id, "worker not found"))
-    }
-
     fn apply_transaction_id(&self, r#type: PbWorkerType) -> MetaResult<Option<TransactionId>> {
         match (self.available_transactional_ids.front(), r#type) {
             (None, _) => Err(MetaError::unavailable("no available reusable machine id")),
@@ -607,7 +577,7 @@ impl ClusterControllerInner {
     }
 
     /// Get the total resource of the cluster.
-    fn cluster_resource(&self) -> ClusterResource {
+    async fn cluster_resource(&self) -> MetaResult<ClusterResource> {
         // For each hostname, we only consider the maximum resource, in case a host has multiple nodes.
         let mut per_host = HashMap::new();
 
@@ -621,23 +591,28 @@ impl ClusterControllerInner {
             },
         );
 
-        for info in self.worker_extra_info.values() {
+        let worker_properties = WorkerProperty::find().all(&self.db).await?;
+        for resource in worker_properties
+            .into_iter()
+            .filter_map(|property| property.resource)
+            .map(|resource| resource.to_protobuf())
+        {
             let r = per_host
-                .entry(info.resource.hostname.clone())
+                .entry(resource.hostname.clone())
                 .or_insert_with(ClusterResource::default);
 
-            r.total_cpu_cores = max(r.total_cpu_cores, info.resource.total_cpu_cores);
-            r.total_memory_bytes = max(r.total_memory_bytes, info.resource.total_memory_bytes);
+            r.total_cpu_cores = max(r.total_cpu_cores, resource.total_cpu_cores);
+            r.total_memory_bytes = max(r.total_memory_bytes, resource.total_memory_bytes);
         }
 
         // For different hostnames, we sum up the resources.
-        per_host
+        Ok(per_host
             .into_values()
             .reduce(|a, b| ClusterResource {
                 total_cpu_cores: a.total_cpu_cores + b.total_cpu_cores,
                 total_memory_bytes: a.total_memory_bytes + b.total_memory_bytes,
             })
-            .unwrap_or_default()
+            .unwrap_or_default())
     }
 
     #[await_tree::instrument]
@@ -720,7 +695,6 @@ impl ClusterControllerInner {
                 WorkerProperty::update(property).exec(&txn).await?;
                 txn.commit().await?;
                 self.update_worker_ttl(worker.worker_id, ttl)?;
-                self.update_resource(worker.worker_id, resource)?;
                 Ok(worker.worker_id)
             } else if worker.worker_type == WorkerType::Frontend && property.is_none() {
                 let worker_property = worker_property::ActiveModel {
@@ -741,7 +715,6 @@ impl ClusterControllerInner {
                 WorkerProperty::insert(worker_property).exec(&txn).await?;
                 txn.commit().await?;
                 self.update_worker_ttl(worker.worker_id, ttl)?;
-                self.update_resource(worker.worker_id, resource)?;
                 Ok(worker.worker_id)
             } else if worker.worker_type == WorkerType::Compactor {
                 if let Some(property) = property {
@@ -774,7 +747,6 @@ impl ClusterControllerInner {
                 }
                 txn.commit().await?;
                 self.update_worker_ttl(worker.worker_id, ttl)?;
-                self.update_resource(worker.worker_id, resource)?;
                 Ok(worker.worker_id)
             } else {
                 if let Some(property) = property {
@@ -785,7 +757,6 @@ impl ClusterControllerInner {
                     txn.commit().await?;
                 }
                 self.update_worker_ttl(worker.worker_id, ttl)?;
-                self.update_resource(worker.worker_id, resource)?;
                 Ok(worker.worker_id)
             };
         }
@@ -846,10 +817,7 @@ impl ClusterControllerInner {
         if let Some(txn_id) = txn_id {
             self.available_transactional_ids.retain(|id| *id != txn_id);
         }
-        let extra_info = WorkerExtraInfo {
-            expire_at: None,
-            resource,
-        };
+        let extra_info = WorkerExtraInfo { expire_at: None };
         self.worker_extra_info.insert(worker_id, extra_info);
 
         Ok(worker_id)
@@ -866,8 +834,7 @@ impl ClusterControllerInner {
         let worker_property = WorkerProperty::find_by_id(worker.worker_id)
             .one(&self.db)
             .await?;
-        let extra_info = self.get_extra_info_checked(worker_id)?;
-        Ok(WorkerInfo(worker, worker_property, extra_info).into())
+        Ok(WorkerInfo(worker, worker_property).into())
     }
 
     pub async fn delete_worker(&mut self, host_addr: HostAddress) -> MetaResult<PbWorkerNode> {
@@ -891,11 +858,11 @@ impl ClusterControllerInner {
             return Err(MetaError::invalid_parameter("worker not found!"));
         }
 
-        let extra_info = self.worker_extra_info.remove(&worker.worker_id).unwrap();
+        self.worker_extra_info.remove(&worker.worker_id).unwrap();
         if let Some(txn_id) = &worker.transaction_id {
             self.available_transactional_ids.push_back(*txn_id);
         }
-        let worker: PbWorkerNode = WorkerInfo(worker, property, extra_info).into();
+        let worker: PbWorkerNode = WorkerInfo(worker, property).into();
 
         Ok(worker)
     }
@@ -906,26 +873,26 @@ impl ClusterControllerInner {
         ttl: Duration,
         resource: Option<PbResource>,
     ) -> MetaResult<()> {
-        let resource_to_update = {
-            let Some(worker_info) = self.worker_extra_info.get_mut(&worker_id) else {
-                return Err(MetaError::invalid_worker(worker_id, "worker not found"));
-            };
-
-            worker_info.update_ttl(ttl);
-            resource.filter(|resource| worker_info.resource != *resource)
+        let Some(worker_info) = self.worker_extra_info.get_mut(&worker_id) else {
+            return Err(MetaError::invalid_worker(worker_id, "worker not found"));
         };
 
-        if let Some(resource) = resource_to_update {
+        worker_info.update_ttl(ttl);
+
+        if let Some(resource) = resource {
             if let Some(property) = WorkerProperty::find_by_id(worker_id).one(&self.db).await? {
+                let needs_update = property
+                    .resource
+                    .as_ref()
+                    .map(|persisted| persisted.to_protobuf() != resource)
+                    .unwrap_or(true);
+                if !needs_update {
+                    return Ok(());
+                }
                 let mut property: worker_property::ActiveModel = property.into();
                 property.resource = Set(Some((&resource).into()));
                 WorkerProperty::update(property).exec(&self.db).await?;
             }
-            let worker_info = self
-                .worker_extra_info
-                .get_mut(&worker_id)
-                .expect("worker must exist after resource update");
-            worker_info.resource = resource;
         }
         Ok(())
     }
@@ -945,10 +912,7 @@ impl ClusterControllerInner {
         let workers = find.find_also_related(WorkerProperty).all(&self.db).await?;
         Ok(workers
             .into_iter()
-            .map(|(worker, property)| {
-                let extra_info = self.get_extra_info_checked(worker.worker_id).unwrap();
-                WorkerInfo(worker, property, extra_info).into()
-            })
+            .map(|(worker, property)| WorkerInfo(worker, property).into())
             .collect_vec())
     }
 
@@ -967,10 +931,7 @@ impl ClusterControllerInner {
 
         Ok(workers
             .into_iter()
-            .map(|(worker, property)| {
-                let extra_info = self.get_extra_info_checked(worker.worker_id).unwrap();
-                WorkerInfo(worker, property, extra_info).into()
-            })
+            .map(|(worker, property)| WorkerInfo(worker, property).into())
             .collect_vec())
     }
 
@@ -1007,10 +968,7 @@ impl ClusterControllerInner {
 
         Ok(workers
             .into_iter()
-            .map(|(worker, property)| {
-                let extra_info = self.get_extra_info_checked(worker.worker_id).unwrap();
-                WorkerInfo(worker, property, extra_info).into()
-            })
+            .map(|(worker, property)| WorkerInfo(worker, property).into())
             .collect_vec())
     }
 
@@ -1033,8 +991,7 @@ impl ClusterControllerInner {
         if worker.is_none() {
             return Ok(None);
         }
-        let extra_info = self.get_extra_info_checked(worker_id)?;
-        Ok(worker.map(|(w, p)| WorkerInfo(w, p, extra_info).into()))
+        Ok(worker.map(|(w, p)| WorkerInfo(w, p).into()))
     }
 
     pub fn get_worker_extra_info_by_id(&self, worker_id: WorkerId) -> Option<WorkerExtraInfo> {

--- a/src/meta/src/controller/cluster.rs
+++ b/src/meta/src/controller/cluster.rs
@@ -218,16 +218,12 @@ impl ClusterController {
     }
 
     /// Invoked when it receives a heartbeat from a worker node.
-    pub async fn heartbeat(
-        &self,
-        worker_id: WorkerId,
-        resource: Option<PbResource>,
-    ) -> MetaResult<()> {
+    pub async fn heartbeat(&self, worker_id: WorkerId) -> MetaResult<()> {
         tracing::trace!(target: "events::meta::server_heartbeat", %worker_id, "receive heartbeat");
-        let mut inner = self.inner.write().await;
-        inner
-            .heartbeat(worker_id, self.max_heartbeat_interval, resource)
+        self.inner
+            .write()
             .await
+            .heartbeat(worker_id, self.max_heartbeat_interval)
     }
 
     pub fn start_heartbeat_checker(
@@ -867,33 +863,12 @@ impl ClusterControllerInner {
         Ok(worker)
     }
 
-    pub async fn heartbeat(
-        &mut self,
-        worker_id: WorkerId,
-        ttl: Duration,
-        resource: Option<PbResource>,
-    ) -> MetaResult<()> {
+    pub fn heartbeat(&mut self, worker_id: WorkerId, ttl: Duration) -> MetaResult<()> {
         let Some(worker_info) = self.worker_extra_info.get_mut(&worker_id) else {
             return Err(MetaError::invalid_worker(worker_id, "worker not found"));
         };
 
         worker_info.update_ttl(ttl);
-
-        if let Some(resource) = resource {
-            if let Some(property) = WorkerProperty::find_by_id(worker_id).one(&self.db).await? {
-                let needs_update = property
-                    .resource
-                    .as_ref()
-                    .map(|persisted| persisted.to_protobuf() != resource)
-                    .unwrap_or(true);
-                if !needs_update {
-                    return Ok(());
-                }
-                let mut property: worker_property::ActiveModel = property.into();
-                property.resource = Set(Some((&resource).into()));
-                WorkerProperty::update(property).exec(&self.db).await?;
-            }
-        }
         Ok(())
     }
 
@@ -1126,7 +1101,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_heartbeat_updates_resource() -> MetaResult<()> {
+    async fn test_heartbeat_does_not_update_resource() -> MetaResult<()> {
         let env = MetaSrvEnv::for_test().await;
         let cluster_ctl = ClusterController::new(env.clone(), Duration::from_secs(1)).await?;
 
@@ -1152,19 +1127,11 @@ mod tests {
                 PbWorkerType::ComputeNode,
                 host.clone(),
                 property,
-                resource_v1,
+                resource_v1.clone(),
             )
             .await?;
 
-        let resource_v2 = PbResource {
-            rw_version: "rw-v2".to_owned(),
-            total_memory_bytes: 2048,
-            total_cpu_cores: 8,
-            hostname: "host-v2".to_owned(),
-        };
-        cluster_ctl
-            .heartbeat(worker_id, Some(resource_v2.clone()))
-            .await?;
+        cluster_ctl.heartbeat(worker_id).await?;
 
         let worker = cluster_ctl
             .get_worker_by_id(worker_id)
@@ -1172,7 +1139,7 @@ mod tests {
             .expect("worker should exist");
         assert_eq!(
             worker.resource.expect("worker resource should exist"),
-            resource_v2
+            resource_v1
         );
 
         let recovered_cluster_ctl = ClusterController::new(env, Duration::from_secs(1)).await?;
@@ -1182,7 +1149,7 @@ mod tests {
             .expect("worker should exist");
         assert_eq!(
             worker.resource.expect("worker resource should be restored"),
-            resource_v2
+            resource_v1
         );
 
         recovered_cluster_ctl.delete_worker(host).await?;

--- a/src/meta/src/controller/cluster.rs
+++ b/src/meta/src/controller/cluster.rs
@@ -89,7 +89,11 @@ impl From<WorkerInfo> for PbWorkerNode {
             }),
             transactional_id: info.0.transaction_id.map(|id| id as _),
             resource: Some(info.2.resource),
-            started_at: info.2.started_at,
+            started_at: info
+                .1
+                .as_ref()
+                .and_then(|property| property.started_at)
+                .map(|started_at| started_at as _),
         }
     }
 }
@@ -220,10 +224,10 @@ impl ClusterController {
         resource: Option<PbResource>,
     ) -> MetaResult<()> {
         tracing::trace!(target: "events::meta::server_heartbeat", %worker_id, "receive heartbeat");
-        self.inner
-            .write()
-            .await
+        let mut inner = self.inner.write().await;
+        inner
             .heartbeat(worker_id, self.max_heartbeat_interval, resource)
+            .await
     }
 
     pub fn start_heartbeat_checker(
@@ -443,15 +447,23 @@ impl StreamingClusterInfo {
 
 #[derive(Default, Clone, Debug)]
 pub struct WorkerExtraInfo {
-    // Volatile values updated by meta node as follows.
-    //
     // Unix timestamp that the worker will expire at.
     expire_at: Option<u64>,
-    started_at: Option<u64>,
+    // Cached from worker_property to calculate cluster resources without DB I/O.
     resource: PbResource,
 }
 
 impl WorkerExtraInfo {
+    fn from_worker_property(property: Option<&worker_property::Model>) -> Self {
+        Self {
+            resource: property
+                .and_then(|property| property.resource.as_ref())
+                .map(|resource| resource.to_protobuf())
+                .unwrap_or_default(),
+            ..Default::default()
+        }
+    }
+
     fn update_ttl(&mut self, ttl: Duration) {
         let expire = cmp::max(
             self.expire_at.unwrap_or_default(),
@@ -462,10 +474,6 @@ impl WorkerExtraInfo {
                 .as_secs(),
         );
         self.expire_at = Some(expire);
-    }
-
-    fn update_started_at(&mut self) {
-        self.started_at = Some(timestamp_now_sec());
     }
 }
 
@@ -513,25 +521,26 @@ impl ClusterControllerInner {
         db: DatabaseConnection,
         disable_automatic_parallelism_control: bool,
     ) -> MetaResult<Self> {
-        let workers: Vec<(WorkerId, Option<TransactionId>)> = Worker::find()
-            .select_only()
-            .column(worker::Column::WorkerId)
-            .column(worker::Column::TransactionId)
-            .into_tuple()
+        let workers = Worker::find()
+            .find_also_related(WorkerProperty)
             .all(&db)
             .await?;
         let inuse_txn_ids: HashSet<_> = workers
             .iter()
-            .cloned()
-            .filter_map(|(_, txn_id)| txn_id)
+            .filter_map(|(worker, _)| worker.transaction_id)
             .collect();
         let available_transactional_ids = (0..Self::MAX_WORKER_REUSABLE_ID_COUNT as TransactionId)
             .filter(|id| !inuse_txn_ids.contains(id))
             .collect();
 
         let worker_extra_info = workers
-            .into_iter()
-            .map(|(w, _)| (w, WorkerExtraInfo::default()))
+            .iter()
+            .map(|(worker, property)| {
+                (
+                    worker.worker_id,
+                    WorkerExtraInfo::from_worker_property(property.as_ref()),
+                )
+            })
             .collect();
 
         Ok(Self {
@@ -572,14 +581,9 @@ impl ClusterControllerInner {
         }
     }
 
-    fn update_resource_and_started_at(
-        &mut self,
-        worker_id: WorkerId,
-        resource: PbResource,
-    ) -> MetaResult<()> {
+    fn update_resource(&mut self, worker_id: WorkerId, resource: PbResource) -> MetaResult<()> {
         if let Some(info) = self.worker_extra_info.get_mut(&worker_id) {
             info.resource = resource;
-            info.update_started_at();
             Ok(())
         } else {
             Err(MetaError::invalid_worker(worker_id, "worker not found"))
@@ -659,6 +663,7 @@ impl ClusterControllerInner {
         // Worker already exist.
         if let Some((worker, property)) = worker {
             assert_eq!(worker.worker_type, r#type.into());
+            let started_at = timestamp_now_sec();
             return if worker.worker_type == WorkerType::ComputeNode {
                 let property = property.unwrap();
                 let mut current_parallelism = property.parallelism as usize;
@@ -701,6 +706,8 @@ impl ClusterControllerInner {
                 property.is_streaming = Set(add_property.is_streaming);
                 property.is_serving = Set(add_property.is_serving);
                 property.parallelism = Set(current_parallelism as _);
+                property.resource = Set(Some((&resource).into()));
+                property.started_at = Set(Some(started_at as _));
                 property.resource_group =
                     Set(Some(add_property.resource_group.unwrap_or_else(|| {
                         tracing::warn!(
@@ -713,7 +720,7 @@ impl ClusterControllerInner {
                 WorkerProperty::update(property).exec(&txn).await?;
                 txn.commit().await?;
                 self.update_worker_ttl(worker.worker_id, ttl)?;
-                self.update_resource_and_started_at(worker.worker_id, resource)?;
+                self.update_resource(worker.worker_id, resource)?;
                 Ok(worker.worker_id)
             } else if worker.worker_type == WorkerType::Frontend && property.is_none() {
                 let worker_property = worker_property::ActiveModel {
@@ -728,11 +735,13 @@ impl ClusterControllerInner {
                     internal_rpc_host_addr: Set(Some(add_property.internal_rpc_host_addr)),
                     resource_group: Set(None),
                     is_iceberg_compactor: Set(false),
+                    resource: Set(Some((&resource).into())),
+                    started_at: Set(Some(started_at as _)),
                 };
                 WorkerProperty::insert(worker_property).exec(&txn).await?;
                 txn.commit().await?;
                 self.update_worker_ttl(worker.worker_id, ttl)?;
-                self.update_resource_and_started_at(worker.worker_id, resource)?;
+                self.update_resource(worker.worker_id, resource)?;
                 Ok(worker.worker_id)
             } else if worker.worker_type == WorkerType::Compactor {
                 if let Some(property) = property {
@@ -740,6 +749,8 @@ impl ClusterControllerInner {
                     property.is_iceberg_compactor = Set(add_property.is_iceberg_compactor);
                     property.internal_rpc_host_addr =
                         Set(Some(add_property.internal_rpc_host_addr));
+                    property.resource = Set(Some((&resource).into()));
+                    property.started_at = Set(Some(started_at as _));
 
                     WorkerProperty::update(property).exec(&txn).await?;
                 } else {
@@ -755,17 +766,26 @@ impl ClusterControllerInner {
                         internal_rpc_host_addr: Set(Some(add_property.internal_rpc_host_addr)),
                         resource_group: Set(None),
                         is_iceberg_compactor: Set(add_property.is_iceberg_compactor),
+                        resource: Set(Some((&resource).into())),
+                        started_at: Set(Some(started_at as _)),
                     };
 
                     WorkerProperty::insert(property).exec(&txn).await?;
                 }
                 txn.commit().await?;
                 self.update_worker_ttl(worker.worker_id, ttl)?;
-                self.update_resource_and_started_at(worker.worker_id, resource)?;
+                self.update_resource(worker.worker_id, resource)?;
                 Ok(worker.worker_id)
             } else {
+                if let Some(property) = property {
+                    let mut property: worker_property::ActiveModel = property.into();
+                    property.resource = Set(Some((&resource).into()));
+                    property.started_at = Set(Some(started_at as _));
+                    WorkerProperty::update(property).exec(&txn).await?;
+                    txn.commit().await?;
+                }
                 self.update_worker_ttl(worker.worker_id, ttl)?;
-                self.update_resource_and_started_at(worker.worker_id, resource)?;
+                self.update_resource(worker.worker_id, resource)?;
                 Ok(worker.worker_id)
             };
         }
@@ -782,6 +802,7 @@ impl ClusterControllerInner {
         };
         let insert_res = Worker::insert(worker).exec(&txn).await?;
         let worker_id = insert_res.last_insert_id as WorkerId;
+        let started_at = timestamp_now_sec();
         if r#type == PbWorkerType::ComputeNode
             || r#type == PbWorkerType::Frontend
             || r#type == PbWorkerType::Compactor
@@ -815,6 +836,8 @@ impl ClusterControllerInner {
                 internal_rpc_host_addr: Set(Some(add_property.internal_rpc_host_addr)),
                 resource_group: Set(resource_group),
                 is_iceberg_compactor: Set(is_iceberg_compactor),
+                resource: Set(Some((&resource).into())),
+                started_at: Set(Some(started_at as _)),
             };
             WorkerProperty::insert(property).exec(&txn).await?;
         }
@@ -824,7 +847,6 @@ impl ClusterControllerInner {
             self.available_transactional_ids.retain(|id| *id != txn_id);
         }
         let extra_info = WorkerExtraInfo {
-            started_at: Some(timestamp_now_sec()),
             expire_at: None,
             resource,
         };
@@ -878,21 +900,34 @@ impl ClusterControllerInner {
         Ok(worker)
     }
 
-    pub fn heartbeat(
+    pub async fn heartbeat(
         &mut self,
         worker_id: WorkerId,
         ttl: Duration,
         resource: Option<PbResource>,
     ) -> MetaResult<()> {
-        if let Some(worker_info) = self.worker_extra_info.get_mut(&worker_id) {
+        let resource_to_update = {
+            let Some(worker_info) = self.worker_extra_info.get_mut(&worker_id) else {
+                return Err(MetaError::invalid_worker(worker_id, "worker not found"));
+            };
+
             worker_info.update_ttl(ttl);
-            if let Some(resource) = resource {
-                worker_info.resource = resource;
+            resource.filter(|resource| worker_info.resource != *resource)
+        };
+
+        if let Some(resource) = resource_to_update {
+            if let Some(property) = WorkerProperty::find_by_id(worker_id).one(&self.db).await? {
+                let mut property: worker_property::ActiveModel = property.into();
+                property.resource = Set(Some((&resource).into()));
+                WorkerProperty::update(property).exec(&self.db).await?;
             }
-            Ok(())
-        } else {
-            Err(MetaError::invalid_worker(worker_id, "worker not found"))
+            let worker_info = self
+                .worker_extra_info
+                .get_mut(&worker_id)
+                .expect("worker must exist after resource update");
+            worker_info.resource = resource;
         }
+        Ok(())
     }
 
     pub async fn list_workers(
@@ -1136,7 +1171,7 @@ mod tests {
     #[tokio::test]
     async fn test_heartbeat_updates_resource() -> MetaResult<()> {
         let env = MetaSrvEnv::for_test().await;
-        let cluster_ctl = ClusterController::new(env, Duration::from_secs(1)).await?;
+        let cluster_ctl = ClusterController::new(env.clone(), Duration::from_secs(1)).await?;
 
         let host = HostAddress {
             host: "localhost".to_owned(),
@@ -1183,7 +1218,69 @@ mod tests {
             resource_v2
         );
 
-        cluster_ctl.delete_worker(host).await?;
+        let recovered_cluster_ctl = ClusterController::new(env, Duration::from_secs(1)).await?;
+        let worker = recovered_cluster_ctl
+            .get_worker_by_id(worker_id)
+            .await?
+            .expect("worker should exist");
+        assert_eq!(
+            worker.resource.expect("worker resource should be restored"),
+            resource_v2
+        );
+
+        recovered_cluster_ctl.delete_worker(host).await?;
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_cluster_controller_restores_worker_extra_info() -> MetaResult<()> {
+        let env = MetaSrvEnv::for_test().await;
+        let cluster_ctl = ClusterController::new(env.clone(), Duration::from_secs(1)).await?;
+
+        let host = HostAddress {
+            host: "localhost".to_owned(),
+            port: 5012,
+        };
+        let property = AddNodeProperty {
+            is_streaming: true,
+            is_serving: true,
+            parallelism: 4,
+            ..Default::default()
+        };
+        let resource = PbResource {
+            rw_version: "rw-v1".to_owned(),
+            total_memory_bytes: 1024,
+            total_cpu_cores: 4,
+            hostname: "host-v1".to_owned(),
+        };
+        let worker_id = cluster_ctl
+            .add_worker(
+                PbWorkerType::ComputeNode,
+                host.clone(),
+                property,
+                resource.clone(),
+            )
+            .await?;
+        let started_at = cluster_ctl
+            .get_worker_by_id(worker_id)
+            .await?
+            .expect("worker should exist")
+            .started_at;
+
+        let recovered_cluster_ctl = ClusterController::new(env, Duration::from_secs(1)).await?;
+        let recovered_worker = recovered_cluster_ctl
+            .get_worker_by_id(worker_id)
+            .await?
+            .expect("worker should exist after recovery");
+        assert_eq!(
+            recovered_worker
+                .resource
+                .expect("worker resource should be restored"),
+            resource
+        );
+        assert_eq!(recovered_worker.started_at, started_at);
+
+        recovered_cluster_ctl.delete_worker(host).await?;
         Ok(())
     }
 

--- a/src/rpc_client/src/meta_client.rs
+++ b/src/rpc_client/src/meta_client.rs
@@ -380,12 +380,6 @@ impl MetaClient {
     pub async fn send_heartbeat(&self) -> Result<()> {
         let request = HeartbeatRequest {
             node_id: self.worker_id,
-            resource: Some(risingwave_pb::common::worker_node::Resource {
-                rw_version: RW_VERSION.to_owned(),
-                total_memory_bytes: system_memory_available_bytes() as _,
-                total_cpu_cores: total_cpu_available() as _,
-                hostname: hostname(),
-            }),
         };
         let resp = self.inner.heartbeat(request).await?;
         if let Some(status) = resp.status

--- a/src/tests/simulation/tests/integration_tests/recovery/batch_refresh.rs
+++ b/src/tests/simulation/tests/integration_tests/recovery/batch_refresh.rs
@@ -177,6 +177,7 @@ async fn test_batch_refresh_periodic_update() -> Result<()> {
     session
         .run("CREATE MATERIALIZED VIEW mv_up AS SELECT * FROM t;")
         .await?;
+    wait_for_mv_count(&mut session, "mv_up", "2", "upstream materialized view").await?;
 
     // Short refresh interval so we don't need to wait long per cycle.
     session
@@ -185,9 +186,9 @@ async fn test_batch_refresh_periodic_update() -> Result<()> {
         )
         .await?;
 
-    // Initial snapshot content.
-    let mv_batch_count = session.run("SELECT COUNT(*) FROM mv_batch;").await?;
-    assert_eq!(mv_batch_count, "2");
+    // Initial snapshot content. The frontend may receive the catalog before the
+    // streaming vnode mapping, so poll the query until both are visible.
+    wait_for_batch_mv_count(&mut session, "2", "initial batch refresh").await?;
 
     // ── First cycle: upstream inserts must appear after a refresh interval. ──
     session
@@ -232,9 +233,19 @@ async fn wait_for_batch_mv_count(
     expected: &str,
     stage: &str,
 ) -> Result<()> {
+    wait_for_mv_count(session, "mv_batch", expected, stage).await
+}
+
+async fn wait_for_mv_count(
+    session: &mut risingwave_simulation::cluster::Session,
+    name: &str,
+    expected: &str,
+    stage: &str,
+) -> Result<()> {
     let mut last = String::new();
+    let query = format!("SELECT COUNT(*) FROM {name};");
     for _ in 0..30 {
-        match session.run("SELECT COUNT(*) FROM mv_batch;").await {
+        match session.run(query.clone()).await {
             Ok(c) => {
                 last = c.clone();
                 if c == expected {

--- a/src/tests/simulation/tests/integration_tests/scale/background_ddl.rs
+++ b/src/tests/simulation/tests/integration_tests/scale/background_ddl.rs
@@ -14,8 +14,9 @@
 
 use std::time::Duration;
 
-use anyhow::Result;
-use risingwave_simulation::cluster::{Cluster, Configuration};
+use anyhow::{Result, anyhow};
+use risingwave_common::error::AsReport;
+use risingwave_simulation::cluster::{Cluster, Configuration, Session};
 use risingwave_simulation::ctl_ext::predicate::{identity_contains, no_identity_contains};
 use risingwave_simulation::utils::AssertResult;
 use tokio::time::sleep;
@@ -129,6 +130,7 @@ async fn test_background_ddl_scale_during_backfill() -> Result<()> {
     session
         .run("create materialized view m as select * from t;")
         .await?;
+    wait_for_materialized_view(&mut session, "m").await?;
 
     for parallelism in [1, 2, 3] {
         session
@@ -171,6 +173,23 @@ async fn test_background_ddl_scale_during_backfill() -> Result<()> {
         .assert_result_eq("60");
 
     Ok(())
+}
+
+async fn wait_for_materialized_view(session: &mut Session, name: &str) -> Result<()> {
+    let sql = format!("show create materialized view {name};");
+    let mut last_error = String::new();
+    for _ in 0..60 {
+        match session.run(sql.clone()).await {
+            Ok(_) => return Ok(()),
+            Err(err) => {
+                last_error = err.as_report().to_string();
+                sleep(Duration::from_millis(200)).await;
+            }
+        }
+    }
+    Err(anyhow!(
+        "timed out waiting for materialized view `{name}` to become visible, last error: {last_error}"
+    ))
 }
 
 #[tokio::test]


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

This PR fixes a bug where, upon restart, a meta node initializes worker node metadata with empty resource fields until workers submit their next heartbeat. Worker resource tracking can now be restored directly from the meta store, avoiding the temporary gap after meta restart. It also narrows heartbeat metadata to liveness only.

- Persist worker `resource` and `started_at` in `worker_property` through a schema migration so meta can restore them directly from the meta store.
- Build `PbWorkerNode.resource` and `PbWorkerNode.started_at` from persisted worker properties instead of `WorkerExtraInfo`.
- Keep `WorkerExtraInfo` scoped to heartbeat expiration state, and make cluster resource snapshots read persisted worker resources from `worker_property`.
- Keep worker registration responsible for refreshing persisted resource metadata, and remove `resource` from `HeartbeatRequest` so heartbeat only extends worker liveness.
- Harden deterministic simulation integration tests that can issue dependent SQL before frontend catalog or vnode-mapping notifications are visible.

## Checklist

- [ ] I have written necessary rustdoc comments.
- [x] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [x] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

No user-facing release note.

</details>
