### PR TITLE
fix(frontend): correct batch hop window order property

### DIFF
--- a/src/frontend/planner_test/tests/testdata/input/time_window.yaml
+++ b/src/frontend/planner_test/tests/testdata/input/time_window.yaml
@@ -82,6 +82,22 @@
   - stream_plan
   - logical_plan
   - batch_plan
+- name: hop window does not preserve input order across window lanes
+  sql: |
+    create table t1 (id int primary key, created_at date);
+    select id, created_at
+    from hop(t1, created_at, interval '1' day, interval '3' day)
+    order by id;
+  expected_outputs:
+  - batch_plan
+- name: single-lane hop window preserves input order
+  sql: |
+    create table t1 (id int primary key, created_at date);
+    select id, created_at
+    from hop(t1, created_at, interval '1' day, interval '1' day)
+    order by id;
+  expected_outputs:
+  - batch_plan
 - sql: |
     create table t1 (id int, created_at date);
     select t_hop.id, t_hop.created_at from hop(t1, created_at, interval '1' day, interval '3' day) as t_hop;

--- a/src/frontend/planner_test/tests/testdata/output/time_window.yaml
+++ b/src/frontend/planner_test/tests/testdata/output/time_window.yaml
@@ -115,6 +115,29 @@
     └─StreamHopWindow { time_col: t1.created_at, slide: 1 day, size: 3 days, output: [t1.id, t1.created_at, window_start, t1._row_id] }
       └─StreamFilter { predicate: IsNotNull(t1.created_at) }
         └─StreamTableScan { table: t1, columns: [t1.id, t1.created_at, t1._row_id], stream_scan_type: SnapshotBackfill, stream_key: [t1._row_id], pk: [_row_id], dist: UpstreamHashShard(t1._row_id) }
+- name: hop window does not preserve input order across window lanes
+  sql: |
+    create table t1 (id int primary key, created_at date);
+    select id, created_at
+    from hop(t1, created_at, interval '1' day, interval '3' day)
+    order by id;
+  batch_plan: |-
+    BatchExchange { order: [t1.id ASC], dist: Single }
+    └─BatchSort { order: [t1.id ASC] }
+      └─BatchHopWindow { time_col: t1.created_at, slide: 1 day, size: 3 days, output: [t1.id, t1.created_at] }
+        └─BatchFilter { predicate: IsNotNull(t1.created_at) }
+          └─BatchScan { table: t1, columns: [t1.id, t1.created_at], distribution: UpstreamHashShard(t1.id) }
+- name: single-lane hop window preserves input order
+  sql: |
+    create table t1 (id int primary key, created_at date);
+    select id, created_at
+    from hop(t1, created_at, interval '1' day, interval '1' day)
+    order by id;
+  batch_plan: |-
+    BatchHopWindow { time_col: t1.created_at, slide: 1 day, size: 1 day, output: [t1.id, t1.created_at] }
+    └─BatchExchange { order: [t1.id ASC], dist: Single }
+      └─BatchFilter { predicate: IsNotNull(t1.created_at) }
+        └─BatchScan { table: t1, columns: [t1.id, t1.created_at], distribution: UpstreamHashShard(t1.id) }
 - sql: |
     create table t1 (id int, created_at date);
     select t_hop.id, t_hop.created_at from hop(t1, created_at, interval '1' day, interval '3' day) as t_hop;

--- a/src/frontend/src/optimizer/plan_node/batch_hop_window.rs
+++ b/src/frontend/src/optimizer/plan_node/batch_hop_window.rs
@@ -47,8 +47,21 @@ impl BatchHopWindow {
         let distribution = core
             .i2o_col_mapping()
             .rewrite_provided_distribution(core.input.distribution());
-        let base =
-            PlanBase::new_batch_with_core(&core, distribution, core.get_out_column_index_order());
+        let orders = if core.window_slide == core.window_size {
+            // A single window is emitted for each input chunk, so orders on pass-through columns
+            // are preserved.
+            core.input
+                .orders()
+                .into_iter()
+                .map(|order| core.i2o_col_mapping().rewrite_provided_order(&order))
+                .collect()
+        } else {
+            // `HopWindowExecutor` emits one whole input chunk for each overlapping window. An input
+            // ordered as `[1, 2]` is therefore emitted as `[1, 2, 1, 2, ...]`, so even orders on
+            // pass-through columns are not preserved.
+            vec![Order::any()]
+        };
+        let base = PlanBase::new_batch_with_core_and_orders(&core, distribution, orders);
         BatchHopWindow {
             base,
             core,
@@ -95,9 +108,19 @@ impl ToDistributedBatch for BatchHopWindow {
             .core
             .o2i_col_mapping()
             .rewrite_required_distribution(required_dist);
+        let input_required_order = if self.core.window_slide == self.core.window_size {
+            self.core
+                .o2i_col_mapping()
+                .rewrite_required_order(required_order)
+                .unwrap_or_else(Order::any)
+        } else {
+            // An overlapping hop window does not preserve input order, so sorting its input cannot
+            // satisfy an output order requirement. Enforce the requirement on the output below.
+            Order::any()
+        };
         let new_input = self
             .input()
-            .to_distributed_with_required(required_order, &input_required)?;
+            .to_distributed_with_required(&input_required_order, &input_required)?;
         let mut new_logical = self.core.clone();
         new_logical.input = new_input;
         let batch_plan = BatchHopWindow::new(

--- a/src/frontend/src/optimizer/plan_node/generic/hop_window.rs
+++ b/src/frontend/src/optimizer/plan_node/generic/hop_window.rs
@@ -26,8 +26,7 @@ use super::{GenericPlanNode, GenericPlanRef, impl_distill_unit_from_fields};
 use crate::error::Result;
 use crate::expr::{ExprImpl, ExprType, FunctionCall, InputRef, InputRefDisplay, Literal};
 use crate::optimizer::optimizer_context::OptimizerContextRef;
-use crate::optimizer::plan_node::batch::BatchPlanNodeMetadata;
-use crate::optimizer::property::{FunctionalDependencySet, Order};
+use crate::optimizer::property::FunctionalDependencySet;
 use crate::utils::ColIndexMappingRewriteExt;
 
 /// [`HopWindow`] implements Hop Table Function.
@@ -113,13 +112,6 @@ impl<PlanRef: GenericPlanRef> GenericPlanNode for HopWindow<PlanRef> {
             fd_set.add_functional_dependency_by_column_indices(&[end_idx], &[start_idx]);
         }
         fd_set
-    }
-}
-
-impl<PlanRef: BatchPlanNodeMetadata> HopWindow<PlanRef> {
-    pub fn get_out_column_index_order(&self) -> Order {
-        self.i2o_col_mapping()
-            .rewrite_provided_order(self.input.order())
     }
 }
 


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

`BatchHopWindow` currently derives its output order from the input and pushes required output orders to the input. This is incorrect for overlapping HOP windows: `HopWindowExecutor` emits one whole input chunk for each window lane, so an input ordered as `[1, 2]` is emitted as `[1, 2, 1, 2, ...]`.

As a result, the optimizer can place a sort below `BatchHopWindow` and omit the required sort above it, causing queries such as `SELECT ... FROM HOP(...) ORDER BY id` to return rows in the wrong order.

This PR:

- reports no provided order for overlapping HOP windows;
- stops pushing required output orders through overlapping HOP windows and enforces them on the output instead;
- preserves all input order alternatives when `window_slide == window_size`, because the executor has only one window lane in that case;
- adds planner regressions for both overlapping and single-lane HOP windows.

## Tests

- `RUSTFLAGS=-Zhigher-ranked-assumptions cargo test -p risingwave_planner_test --test planner_test_runner -- time_window`
- `RUSTFLAGS=-Zhigher-ranked-assumptions cargo test -p risingwave_batch_executors executor::hop_window::tests::test_execute --lib`
- `cargo fmt --all -- --check`
- `git diff origin/main...HEAD --check`

The extra Rust flag works around an unrelated higher-ranked lifetime compiler limitation in the current macOS build of `risingwave_storage`.

## Checklist

- [ ] I have written necessary rustdoc comments.
- [x] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [x] <!-- OPTIONAL --> I have added test labels as necessary.
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them.
- [ ] <!-- OPTIONAL --> My PR contains breaking changes.
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results.
- [ ] <!-- OPTIONAL --> I have checked the Release Timeline and Currently Supported Versions to determine which release branches I need to cherry-pick this PR into.

## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates.

<details>
<summary><b>Release note</b></summary>

Fixed incorrect row ordering for batch queries that use `ORDER BY` above an overlapping HOP window.

</details>
