### PR TITLE
fix(frontend): prevent non-admin rename of admin-owned database

### DIFF
--- a/src/frontend/src/handler/alter_rename.rs
+++ b/src/frontend/src/handler/alter_rename.rs
@@ -19,6 +19,7 @@ use risingwave_sqlparser::ast::ObjectName;
 
 use super::{HandlerArgs, RwPgResponse};
 use crate::Binder;
+use crate::catalog::OwnedByUserCatalog;
 use crate::catalog::root_catalog::SchemaPath;
 use crate::catalog::table_catalog::TableType;
 use crate::error::{ErrorCode, Result};
@@ -292,20 +293,30 @@ pub async fn handle_rename_database(
         let catalog_reader = session.env().catalog_reader().read_guard();
         let user_reader = session.env().user_info_reader().read_guard();
         let database = catalog_reader.get_database_by_name(&database_name)?;
+        let current_user = user_reader
+            .get_user_by_name(&session.user_name())
+            .ok_or_else(|| ErrorCode::PermissionDenied("Session user is invalid".to_owned()))?;
+
+        // If the database owner is an admin, only admin users can rename it.
+        if let Some(database_owner) = user_reader.get_user_by_id(&database.owner())
+            && database_owner.is_admin
+            && !current_user.is_admin
+        {
+            return Err(ErrorCode::PermissionDenied(
+                "only admin users can rename databases owned by admin users".to_owned(),
+            )
+            .into());
+        }
 
         // The user should be super user or owner to alter the database.
         session.check_privilege_for_drop_alter_db_schema(database)?;
 
         // Non-superuser owners must also have the CREATEDB privilege.
-        if let Some(user) = user_reader.get_user_by_name(&session.user_name()) {
-            if !user.is_super && !user.can_create_db {
-                return Err(ErrorCode::PermissionDenied(
-                    "Non-superuser owners must also have the CREATEDB privilege".to_owned(),
-                )
-                .into());
-            }
-        } else {
-            return Err(ErrorCode::PermissionDenied("Session user is invalid".to_owned()).into());
+        if !current_user.is_super && !current_user.can_create_db {
+            return Err(ErrorCode::PermissionDenied(
+                "Non-superuser owners must also have the CREATEDB privilege".to_owned(),
+            )
+            .into());
         }
 
         // The current database cannot be renamed.
@@ -329,7 +340,10 @@ pub async fn handle_rename_database(
 
 #[cfg(test)]
 mod tests {
-    use risingwave_common::catalog::{DEFAULT_DATABASE_NAME, DEFAULT_SCHEMA_NAME};
+    use risingwave_common::catalog::{
+        DEFAULT_DATABASE_NAME, DEFAULT_SCHEMA_NAME, DEFAULT_SUPER_USER_FOR_ADMIN,
+        DEFAULT_SUPER_USER_FOR_ADMIN_ID,
+    };
 
     use crate::catalog::root_catalog::SchemaPath;
     use crate::test_utils::LocalFrontend;
@@ -363,5 +377,68 @@ mod tests {
             .name()
             .to_owned();
         assert_eq!(altered_table_name, "t1");
+    }
+
+    #[tokio::test]
+    async fn test_rename_admin_owned_database() {
+        let frontend = LocalFrontend::new(Default::default()).await;
+        let session = frontend.session_ref();
+        let catalog_reader = session.env().catalog_reader();
+
+        frontend
+            .run_user_sql(
+                "CREATE DATABASE admin_owned_database",
+                DEFAULT_DATABASE_NAME.to_owned(),
+                DEFAULT_SUPER_USER_FOR_ADMIN.to_owned(),
+                DEFAULT_SUPER_USER_FOR_ADMIN_ID,
+            )
+            .await
+            .unwrap();
+
+        let err = frontend
+            .run_sql("ALTER DATABASE admin_owned_database RENAME TO renamed_database")
+            .await
+            .unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("only admin users can rename databases owned by admin users")
+        );
+        assert!(
+            catalog_reader
+                .read_guard()
+                .get_database_by_name("admin_owned_database")
+                .is_ok()
+        );
+
+        frontend
+            .run_user_sql(
+                "ALTER DATABASE admin_owned_database RENAME TO renamed_database",
+                DEFAULT_DATABASE_NAME.to_owned(),
+                DEFAULT_SUPER_USER_FOR_ADMIN.to_owned(),
+                DEFAULT_SUPER_USER_FOR_ADMIN_ID,
+            )
+            .await
+            .unwrap();
+        assert!(
+            catalog_reader
+                .read_guard()
+                .get_database_by_name("renamed_database")
+                .is_ok()
+        );
+
+        frontend
+            .run_sql("CREATE DATABASE regular_database")
+            .await
+            .unwrap();
+        frontend
+            .run_sql("ALTER DATABASE regular_database RENAME TO renamed_regular_database")
+            .await
+            .unwrap();
+        assert!(
+            catalog_reader
+                .read_guard()
+                .get_database_by_name("renamed_regular_database")
+                .is_ok()
+        );
     }
 }

--- a/src/frontend/src/test_utils.rs
+++ b/src/frontend/src/test_utils.rs
@@ -669,7 +669,7 @@ impl CatalogWriter for MockCatalogWriter {
                 let mut database = self
                     .catalog
                     .read()
-                    .get_database_by_id(database_id.into())?
+                    .get_database_by_id(database_id)?
                     .to_prost();
                 database.name = object_name.to_owned();
                 self.catalog.write().update_database(&database);

--- a/src/frontend/src/test_utils.rs
+++ b/src/frontend/src/test_utils.rs
@@ -665,6 +665,16 @@ impl CatalogWriter for MockCatalogWriter {
         object_name: &str,
     ) -> Result<()> {
         match object_id {
+            alter_name_request::Object::DatabaseId(database_id) => {
+                let mut database = self
+                    .catalog
+                    .read()
+                    .get_database_by_id(database_id.into())?
+                    .to_prost();
+                database.name = object_name.to_owned();
+                self.catalog.write().update_database(&database);
+                Ok(())
+            }
             alter_name_request::Object::TableId(table_id) => {
                 self.catalog
                     .write()


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What changed and what is the intention?

- Prevent non-admin users, including superusers, from renaming databases owned by admin users.
- Keep the existing owner/superuser, CREATEDB, and current-database checks unchanged for other databases.
- Add regression coverage for non-admin rejection, admin success, and regular database rename behavior.
- Extend the frontend mock catalog writer to support database rename in unit tests.

Closes #26571

## Verification

- cargo test -p risingwave_frontend handler::alter_rename::tests --lib
- cargo fmt --all -- --check
- cargo check -p risingwave_frontend
- git diff --check

## Checklist

- [ ] I have written necessary rustdoc comments.
- [x] I have added necessary unit tests and integration tests.
- [x] I have added test labels as necessary.
- [ ] I have added fuzzing tests or opened an issue to track them.
- [ ] My PR contains breaking changes.
- [ ] My PR changes performance-critical code, so I will run benchmarks and present the results.
- [ ] I have checked the release timeline and supported versions for cherry-pick needs.

## Documentation

- [ ] My PR needs documentation updates.