### PR TITLE
fix(meta): allow cascade dropping creating streaming jobs

### DIFF
--- a/e2e_test/background_ddl/mv.slt
+++ b/e2e_test/background_ddl/mv.slt
@@ -41,6 +41,9 @@ statement ok
 set backfill_rate_limit=1;
 
 statement ok
+set streaming_use_snapshot_backfill=false;
+
+statement ok
 CREATE MATERIALIZED VIEW m2 as SELECT * FROM t;
 
 query T
@@ -65,3 +68,6 @@ set background_ddl=false;
 
 statement ok
 set backfill_rate_limit=default;
+
+statement ok
+set streaming_use_snapshot_backfill=default;

--- a/e2e_test/background_ddl/mv.slt
+++ b/e2e_test/background_ddl/mv.slt
@@ -38,4 +38,30 @@ statement ok
 DROP MATERIALIZED VIEW m1;
 
 statement ok
-DROP TABLE t;
+set backfill_rate_limit=1;
+
+statement ok
+CREATE MATERIALIZED VIEW m2 as SELECT * FROM t;
+
+query T
+select status from rw_catalog.rw_materialized_views where name='m2';
+----
+Creating
+
+# Dropping an upstream object with CASCADE cancels creating downstream jobs.
+statement ok
+DROP TABLE t CASCADE;
+
+query I
+select count(*) from rw_catalog.rw_materialized_views where name='m2';
+----
+0
+
+statement count 0
+show jobs;
+
+statement ok
+set background_ddl=false;
+
+statement ok
+set backfill_rate_limit=default;

--- a/src/meta/src/controller/catalog/drop_op.rs
+++ b/src/meta/src/controller/catalog/drop_op.rs
@@ -246,27 +246,6 @@ impl CatalogController {
             .all(&txn)
             .await?;
 
-        // Check if there are any streaming jobs that are creating.
-        if !removed_streaming_job_ids.is_empty() {
-            let creating = StreamingJob::find()
-                .filter(
-                    streaming_job::Column::JobStatus
-                        .ne(JobStatus::Created)
-                        .and(streaming_job::Column::JobId.is_in(removed_streaming_job_ids.clone())),
-                )
-                .count(&txn)
-                .await?;
-            if creating != 0 {
-                if creating == 1 && object_type == ObjectType::Sink {
-                    info!("dropping creating sink job, it will be cancelled");
-                } else {
-                    return Err(MetaError::permission_denied(format!(
-                        "can not drop {creating} creating streaming job, please cancel them firstly"
-                    )));
-                }
-            }
-        }
-
         let mut removed_state_table_ids: HashSet<_> = removed_table_ids.clone().collect();
 
         if !drop_database {

--- a/src/meta/src/controller/catalog/test.rs
+++ b/src/meta/src/controller/catalog/test.rs
@@ -977,6 +977,92 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_drop_cascade_allows_creating_streaming_jobs() -> MetaResult<()> {
+        let mgr = CatalogController::new(MetaSrvEnv::for_test().await).await?;
+        let pb_source = PbSource {
+            schema_id: TEST_SCHEMA_ID,
+            database_id: TEST_DATABASE_ID,
+            name: "source_with_creating_jobs".to_owned(),
+            owner: TEST_OWNER_ID as _,
+            info: Some(StreamSourceInfo::default()),
+            ..Default::default()
+        };
+        let (source_id, _) = mgr.create_source(pb_source).await?;
+
+        let inner = mgr.inner.write().await;
+        let txn = inner.db.begin().await?;
+        let (initial_job_id, Some(initial_table_id), initial_internal_table_id) =
+            insert_test_streaming_job(&txn, "initial_mv", true, None).await?
+        else {
+            unreachable!()
+        };
+        let (creating_job_id, Some(creating_table_id), creating_internal_table_id) =
+            insert_test_streaming_job(&txn, "creating_mv", true, None).await?
+        else {
+            unreachable!()
+        };
+        for (job_id, job_status) in [
+            (initial_job_id, JobStatus::Initial),
+            (creating_job_id, JobStatus::Creating),
+        ] {
+            streaming_job::ActiveModel {
+                job_id: Set(job_id),
+                job_status: Set(job_status),
+                ..Default::default()
+            }
+            .update(&txn)
+            .await?;
+        }
+        ObjectDependency::insert_many([initial_job_id, creating_job_id].map(|job_id| {
+            object_dependency::ActiveModel {
+                oid: Set(source_id.as_object_id()),
+                used_by: Set(job_id.as_object_id()),
+                ..Default::default()
+            }
+        }))
+        .exec(&txn)
+        .await?;
+        txn.commit().await?;
+        drop(inner);
+
+        let (release_context, _) = mgr
+            .drop_object(ObjectType::Source, source_id, DropMode::Cascade)
+            .await?;
+        assert_eq!(
+            release_context
+                .removed_streaming_job_ids
+                .into_iter()
+                .collect::<HashSet<_>>(),
+            HashSet::from([initial_job_id, creating_job_id])
+        );
+        assert_eq!(
+            release_context
+                .removed_state_table_ids
+                .into_iter()
+                .collect::<HashSet<_>>(),
+            HashSet::from([
+                initial_table_id,
+                initial_internal_table_id,
+                creating_table_id,
+                creating_internal_table_id,
+            ])
+        );
+
+        let db = &mgr.inner.read().await.db;
+        for object_id in [
+            source_id.as_object_id(),
+            initial_job_id.as_object_id(),
+            initial_internal_table_id.as_object_id(),
+            creating_job_id.as_object_id(),
+            creating_internal_table_id.as_object_id(),
+        ] {
+            assert!(Object::find_by_id(object_id).one(db).await?.is_none());
+        }
+
+        Ok(())
+    }
+
+    #[tokio::test]
     async fn test_cancel_creating_table_deletes_associated_source() -> MetaResult<()> {
         let env = MetaSrvEnv::for_test().await;
         let (tx, mut notification_rx) = mpsc::unbounded_channel();


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

`DROP ... CASCADE` currently fails when its dependency closure contains streaming jobs in the `Initial` or `Creating` state. The catalog drop path rejects those jobs before the existing cancellation and cleanup logic can handle them.

This PR removes that redundant catalog guard so cascade deletion can collect and clean up all dependent streaming jobs, rather than special-casing only one creating sink. `DROP ... RESTRICT` keeps its existing behavior because dependency validation happens before streaming-job cleanup, while directly dropped creating jobs continue to use their status-specific abort or cancellation paths.

The change adds:

- a catalog unit test covering dependent jobs in both `Initial` and `Creating` states, including their internal state tables;
- a background-DDL SQLLogicTest that observes a materialized view in `Creating`, drops its upstream table with `CASCADE`, and verifies that the job is gone.

- Closes #26550

## Checklist

- [ ] I have written necessary rustdoc comments.
- [x] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [x] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove it in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->

## Documentation

- [x] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

`DROP ... CASCADE` now cancels dependent streaming jobs that are still being initialized or created instead of failing with a permission error.

</details>
