### PR TITLE
test(interval): add regression tests for space after negative sign (#22018)

### DIFF
--- a/e2e_test/batch/types/interval.slt.part
+++ b/e2e_test/batch/types/interval.slt.part
@@ -217,3 +217,15 @@ query T
 select interval '- 1 year -1 months -       1 days 4 hours 5 minutes 6 seconds';
 ----
 -1 years -1 mons -1 days +04:05:06
+
+# Regression test for https://github.com/risingwavelabs/risingwave/issues/22018
+# A space is allowed between a negative sign and the following digit.
+query T
+select interval '1 month - 1 day';
+----
+1 mon -1 days
+
+query T
+select interval '1 month -1 day';
+----
+1 mon -1 days

--- a/src/common/src/types/interval.rs
+++ b/src/common/src/types/interval.rs
@@ -1539,6 +1539,25 @@ mod tests {
             interval,
             Interval::from_month(14) + Interval::from_days(3) + Interval::from_minutes(5)
         );
+
+        // Space allowed between negative sign and following digit (issue #22018).
+        let interval = "1 month - 1 day".parse::<Interval>().unwrap();
+        assert_eq!(
+            interval,
+            Interval::from_month(1) + Interval::from_days(-1)
+        );
+
+        let interval = "1 month -1 day".parse::<Interval>().unwrap();
+        assert_eq!(
+            interval,
+            Interval::from_month(1) + Interval::from_days(-1)
+        );
+
+        let interval = "- 1 year + 2 months".parse::<Interval>().unwrap();
+        assert_eq!(
+            interval,
+            Interval::from_month(-12) + Interval::from_month(2)
+        );
     }
 
     #[test]

--- a/src/common/src/types/interval.rs
+++ b/src/common/src/types/interval.rs
@@ -1542,16 +1542,10 @@ mod tests {
 
         // Space allowed between negative sign and following digit (issue #22018).
         let interval = "1 month - 1 day".parse::<Interval>().unwrap();
-        assert_eq!(
-            interval,
-            Interval::from_month(1) + Interval::from_days(-1)
-        );
+        assert_eq!(interval, Interval::from_month(1) + Interval::from_days(-1));
 
         let interval = "1 month -1 day".parse::<Interval>().unwrap();
-        assert_eq!(
-            interval,
-            Interval::from_month(1) + Interval::from_days(-1)
-        );
+        assert_eq!(interval, Interval::from_month(1) + Interval::from_days(-1));
 
         let interval = "- 1 year + 2 months".parse::<Interval>().unwrap();
         assert_eq!(


### PR DESCRIPTION
## Summary
- Closes #22018.
- Investigated the reported parse failure for `INTERVAL '1 month - 1 day'`. The tokenizer's standalone-sign handling in `parse_interval` (src/common/src/types/interval.rs) already correctly parses a `-`/`+` followed by whitespace then a digit — no production code change needed.
- Added unit test cases in `interval.rs::tests::test_parse` and a new e2e SQLLogicTest block in `e2e_test/batch/types/interval.slt.part` covering:
  - `'1 month - 1 day'` (space after sign)
  - `'1 month -1 day'` (no space, control case)
  - `'- 1 year + 2 months'` (leading standalone sign)

## Test plan
- [x] Unit tests: `cargo test -p risingwave_common --lib types::interval::tests` — 10/10 passed
- [x] Smoke test: `./risedev d` + `./risedev psql -c "select interval '1 month - 1 day';"` → `1 mon -1 days`
- [x] Integration/e2e: `./risedev slt './e2e_test/batch/types/interval.slt.part'` — OK