### PR TITLE
feat(storage): support runtime file cache clearing

### DIFF
--- a/.github/workflows/license_check.yml
+++ b/.github/workflows/license_check.yml
@@ -23,7 +23,7 @@ jobs:
         ref: ${{ github.event.pull_request.head.sha || github.sha }}
     - uses: taiki-e/install-action@v2
       with:
-        tool: hawkeye@6.3
+        tool: hawkeye
     - name: Check License Header
       run: |
         hawkeye check || {

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12791,6 +12791,7 @@ dependencies = [
  "risingwave_meta",
  "risingwave_meta_model",
  "risingwave_pb",
+ "risingwave_rpc_client",
  "sea-orm",
  "serde_json",
  "thiserror-ext",

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -1269,7 +1269,7 @@ fi
 [tasks.check-license-header]
 category = "RiseDev - Check"
 description = "Check license headers by HawkEye"
-install_crate = { min_version = "6.3.0", crate_name = "hawkeye", binary = "hawkeye", test_arg = [
+install_crate = { crate_name = "hawkeye", binary = "hawkeye", test_arg = [
     "--help",
 ], install_command = "binstall" }
 command = "hawkeye"
@@ -1279,7 +1279,7 @@ env = { RUST_LOG = "info" }
 [tasks.fix-license-header]
 category = "RiseDev - Check"
 description = "Auto-fix license headers by HawkEye"
-install_crate = { min_version = "6.3.0", crate_name = "hawkeye", binary = "hawkeye", test_arg = [
+install_crate = { crate_name = "hawkeye", binary = "hawkeye", test_arg = [
     "--help",
 ], install_command = "binstall" }
 command = "hawkeye"

--- a/licenserc.toml
+++ b/licenserc.toml
@@ -1,5 +1,7 @@
-headerPath = "ci/license-header.txt"
+[header]
+path = "ci/license-header.txt"
 
+[files]
 includes = [
   "src/**/*.rs",
   "src/**/*.py",
@@ -22,4 +24,4 @@ excludes = [
 
 [git]
 ignore = "enable"
-attrs = "enable"
+file_attrs = "enable"

--- a/proto/compute.proto
+++ b/proto/compute.proto
@@ -13,8 +13,11 @@ message ShowConfigResponse {
 }
 
 message ResizeCacheRequest {
+  // Zero means "do not resize". Cache clearing is controlled independently by the clear_* fields.
   uint64 meta_cache_capacity = 1;
   uint64 data_cache_capacity = 2;
+  bool clear_meta_cache = 3;
+  bool clear_data_cache = 4;
 }
 
 message ResizeCacheResponse {}

--- a/proto/meta.proto
+++ b/proto/meta.proto
@@ -902,9 +902,17 @@ message SetSystemParamResponse {
   optional SystemParams params = 1;
 }
 
+message ClearFileCacheRequest {
+  bool clear_meta_cache = 1;
+  bool clear_data_cache = 2;
+}
+
+message ClearFileCacheResponse {}
+
 service SystemParamsService {
   rpc GetSystemParams(GetSystemParamsRequest) returns (GetSystemParamsResponse);
   rpc SetSystemParam(SetSystemParamRequest) returns (SetSystemParamResponse);
+  rpc ClearFileCache(ClearFileCacheRequest) returns (ClearFileCacheResponse);
 }
 
 message GetSessionParamsRequest {}

--- a/src/compute/src/rpc/service/config_service.rs
+++ b/src/compute/src/rpc/service/config_service.rs
@@ -59,27 +59,45 @@ impl ConfigService for ConfigServiceImpl {
     ) -> Result<Response<ResizeCacheResponse>, Status> {
         let req = request.into_inner();
 
-        if let Some(meta_cache) = &self.meta_cache
-            && req.meta_cache_capacity > 0
-        {
-            match meta_cache.memory().resize(req.meta_cache_capacity as _) {
-                Ok(_) => tracing::info!(
-                    "resize meta cache capacity to {:?}",
-                    req.meta_cache_capacity
-                ),
-                Err(e) => return Err(Status::internal(e.to_report_string())),
+        // A zero capacity means "do not resize" for backward compatibility. The clear flags
+        // independently trigger HybridCache::clear() and never change the configured capacity.
+        if let Some(meta_cache) = &self.meta_cache {
+            if req.clear_meta_cache {
+                meta_cache
+                    .clear()
+                    .await
+                    .map_err(|e| Status::internal(e.to_report_string()))?;
+                tracing::info!("clear meta file cache");
+            }
+
+            if req.meta_cache_capacity > 0 {
+                match meta_cache.memory().resize(req.meta_cache_capacity as _) {
+                    Ok(_) => tracing::info!(
+                        "resize meta cache capacity to {:?}",
+                        req.meta_cache_capacity
+                    ),
+                    Err(e) => return Err(Status::internal(e.to_report_string())),
+                }
             }
         }
 
-        if let Some(block_cache) = &self.block_cache
-            && req.data_cache_capacity > 0
-        {
-            match block_cache.memory().resize(req.data_cache_capacity as _) {
-                Ok(_) => tracing::info!(
-                    "resize data cache capacity to {:?}",
-                    req.data_cache_capacity
-                ),
-                Err(e) => return Err(Status::internal(e.to_report_string())),
+        if let Some(block_cache) = &self.block_cache {
+            if req.clear_data_cache {
+                block_cache
+                    .clear()
+                    .await
+                    .map_err(|e| Status::internal(e.to_report_string()))?;
+                tracing::info!("clear data file cache");
+            }
+
+            if req.data_cache_capacity > 0 {
+                match block_cache.memory().resize(req.data_cache_capacity as _) {
+                    Ok(_) => tracing::info!(
+                        "resize data cache capacity to {:?}",
+                        req.data_cache_capacity
+                    ),
+                    Err(e) => return Err(Status::internal(e.to_report_string())),
+                }
             }
         }
 

--- a/src/connector/src/sink/deltalake.rs
+++ b/src/connector/src/sink/deltalake.rs
@@ -1,4 +1,4 @@
-// Copyright 2023 RisingWave Labs
+// Copyright 2025 RisingWave Labs
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/ctl/src/cmd_impl/hummock/resize_cache.rs
+++ b/src/ctl/src/cmd_impl/hummock/resize_cache.rs
@@ -34,6 +34,8 @@ pub async fn resize_cache(
     context: &CtlContext,
     meta_cache_capacity: Option<u64>,
     data_cache_capacity: Option<u64>,
+    clear_meta_cache: bool,
+    clear_data_cache: bool,
 ) -> anyhow::Result<()> {
     let meta_client = context.meta_client().await?;
 
@@ -53,6 +55,8 @@ pub async fn resize_cache(
             .resize_cache(ResizeCacheRequest {
                 meta_cache_capacity: meta_cache_capacity.unwrap_or(0),
                 data_cache_capacity: data_cache_capacity.unwrap_or(0),
+                clear_meta_cache,
+                clear_data_cache,
             })
             .await
     });

--- a/src/ctl/src/lib.rs
+++ b/src/ctl/src/lib.rs
@@ -339,6 +339,16 @@ enum HummockCommands {
         meta_cache_capacity_mb: Option<u64>,
         #[clap(long)]
         data_cache_capacity_mb: Option<u64>,
+        #[clap(
+            long,
+            help = "Clear the local file-backed meta cache on all compute nodes (best effort)"
+        )]
+        clear_meta_cache: bool,
+        #[clap(
+            long,
+            help = "Clear the local file-backed data cache on all compute nodes (best effort)"
+        )]
+        clear_data_cache: bool,
     },
     /// Table cache refill tools.
     #[clap(subcommand)]
@@ -923,12 +933,16 @@ async fn start_impl(opts: CliOpts, context: &CtlContext) -> Result<()> {
         Commands::Hummock(HummockCommands::ResizeCache {
             meta_cache_capacity_mb,
             data_cache_capacity_mb,
+            clear_meta_cache,
+            clear_data_cache,
         }) => {
             const MIB: u64 = 1024 * 1024;
             cmd_impl::hummock::resize_cache(
                 context,
                 meta_cache_capacity_mb.map(|v| v * MIB),
                 data_cache_capacity_mb.map(|v| v * MIB),
+                clear_meta_cache,
+                clear_data_cache,
             )
             .await?
         }

--- a/src/frontend/src/binder/relation/table_function.rs
+++ b/src/frontend/src/binder/relation/table_function.rs
@@ -1,4 +1,4 @@
-// Copyright 2022 RisingWave Labs
+// Copyright 2023 RisingWave Labs
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/frontend/src/handler/alter_system.rs
+++ b/src/frontend/src/handler/alter_system.rs
@@ -16,7 +16,7 @@ use pgwire::pg_response::StatementType;
 use risingwave_common::session_config::SessionConfig;
 use risingwave_common::system_param::reader::SystemParamsRead;
 use risingwave_common::system_param::{NOTICE_BARRIER_INTERVAL_MS, NOTICE_CHECKPOINT_FREQUENCY};
-use risingwave_sqlparser::ast::{Ident, SetVariableValue};
+use risingwave_sqlparser::ast::{FileCacheType, Ident, SetVariableValue};
 
 use super::variable::set_var_to_param_str;
 use super::{HandlerArgs, RwPgResponse};
@@ -81,4 +81,29 @@ pub async fn handle_alter_system(
         }
     }
     Ok(builder.into())
+}
+
+pub async fn handle_clear_file_cache(
+    handler_args: HandlerArgs,
+    cache_type: FileCacheType,
+) -> Result<RwPgResponse> {
+    if !handler_args.session.is_super_user() {
+        return Err(ErrorCode::PermissionDenied(
+            "must be superuser to clear file cache".to_owned(),
+        )
+        .into());
+    }
+
+    let (clear_meta_cache, clear_data_cache) = match cache_type {
+        FileCacheType::Meta => (true, false),
+        FileCacheType::Data => (false, true),
+        FileCacheType::All => (true, true),
+    };
+    handler_args
+        .session
+        .env()
+        .meta_client()
+        .clear_file_cache(clear_meta_cache, clear_data_cache)
+        .await?;
+    Ok(RwPgResponse::empty_result(StatementType::ALTER_SYSTEM))
 }

--- a/src/frontend/src/handler/mod.rs
+++ b/src/frontend/src/handler/mod.rs
@@ -1581,6 +1581,9 @@ pub async fn handle(
         Statement::AlterSystem { param, value } => {
             alter_system::handle_alter_system(handler_args, param, value).await
         }
+        Statement::AlterSystemClearFileCache { cache_type } => {
+            alter_system::handle_clear_file_cache(handler_args, cache_type).await
+        }
         Statement::AlterSecret { name, operation } => match operation {
             AlterSecretOperation::ChangeCredential {
                 with_options,

--- a/src/frontend/src/meta_client.rs
+++ b/src/frontend/src/meta_client.rs
@@ -101,6 +101,8 @@ pub trait FrontendMetaClient: Send + Sync {
         value: Option<String>,
     ) -> Result<Option<SystemParamsReader>>;
 
+    async fn clear_file_cache(&self, clear_meta_cache: bool, clear_data_cache: bool) -> Result<()>;
+
     async fn get_session_params(&self) -> Result<SessionConfig>;
 
     async fn set_session_param(&self, param: String, value: Option<String>) -> Result<String>;
@@ -325,6 +327,12 @@ impl FrontendMetaClient for FrontendMetaClientImpl {
         value: Option<String>,
     ) -> Result<Option<SystemParamsReader>> {
         self.0.set_system_param(param, value).await
+    }
+
+    async fn clear_file_cache(&self, clear_meta_cache: bool, clear_data_cache: bool) -> Result<()> {
+        self.0
+            .clear_file_cache(clear_meta_cache, clear_data_cache)
+            .await
     }
 
     async fn get_session_params(&self) -> Result<SessionConfig> {

--- a/src/frontend/src/optimizer/plan_node/stream_simple_agg.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_simple_agg.rs
@@ -1,4 +1,4 @@
-// Copyright 2022 RisingWave Labs
+// Copyright 2023 RisingWave Labs
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/frontend/src/test_utils.rs
+++ b/src/frontend/src/test_utils.rs
@@ -1267,6 +1267,14 @@ impl FrontendMetaClient for MockFrontendMetaClient {
         Ok(Some(SystemParams::default().into()))
     }
 
+    async fn clear_file_cache(
+        &self,
+        _clear_meta_cache: bool,
+        _clear_data_cache: bool,
+    ) -> RpcResult<()> {
+        Ok(())
+    }
+
     async fn get_session_params(&self) -> RpcResult<SessionConfig> {
         Ok(Default::default())
     }

--- a/src/java_binding/src/hummock_iterator.rs
+++ b/src/java_binding/src/hummock_iterator.rs
@@ -1,4 +1,4 @@
-// Copyright 2023 RisingWave Labs
+// Copyright 2024 RisingWave Labs
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/meta/node/src/lib.rs
+++ b/src/meta/node/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2025 RisingWave Labs
+// Copyright 2023 RisingWave Labs
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/meta/node/src/server.rs
+++ b/src/meta/node/src/server.rs
@@ -1,4 +1,4 @@
-// Copyright 2025 RisingWave Labs
+// Copyright 2023 RisingWave Labs
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/meta/node/src/server.rs
+++ b/src/meta/node/src/server.rs
@@ -608,6 +608,7 @@ pub async fn start_service_as_election_leader(
     let telemetry_srv = TelemetryInfoServiceImpl::new(env.meta_store());
     let system_params_srv = SystemParamsServiceImpl::new(
         env.system_params_manager_impl_ref(),
+        metadata_manager.clone(),
         env.opts.license_key_path.is_some(),
     );
     let session_params_srv = SessionParamsServiceImpl::new(env.session_params_manager_impl_ref());

--- a/src/meta/service/Cargo.toml
+++ b/src/meta/service/Cargo.toml
@@ -26,6 +26,7 @@ risingwave_hummock_sdk = { workspace = true }
 risingwave_meta = { workspace = true }
 risingwave_meta_model = { workspace = true }
 risingwave_pb = { workspace = true }
+risingwave_rpc_client = { workspace = true }
 sea-orm = { workspace = true }
 serde_json = "1"
 thiserror-ext = { workspace = true }

--- a/src/meta/service/src/system_params_service.rs
+++ b/src/meta/service/src/system_params_service.rs
@@ -13,16 +13,24 @@
 // limitations under the License.
 
 use async_trait::async_trait;
+use futures::future::try_join_all;
+use risingwave_common::config::RpcClientConfig;
 use risingwave_common::system_param::LICENSE_KEY_KEY;
 use risingwave_meta::controller::system_param::SystemParamsControllerRef;
+use risingwave_meta::manager::MetadataManager;
+use risingwave_pb::common::WorkerType;
 use risingwave_pb::meta::system_params_service_server::SystemParamsService;
 use risingwave_pb::meta::{
-    GetSystemParamsRequest, GetSystemParamsResponse, SetSystemParamRequest, SetSystemParamResponse,
+    ClearFileCacheRequest, ClearFileCacheResponse, GetSystemParamsRequest, GetSystemParamsResponse,
+    SetSystemParamRequest, SetSystemParamResponse,
 };
+use risingwave_rpc_client::ComputeClient;
+use thiserror_ext::AsReport;
 use tonic::{Request, Response, Status};
 
 pub struct SystemParamsServiceImpl {
     system_params_manager: SystemParamsControllerRef,
+    metadata_manager: MetadataManager,
 
     /// Whether the license key is managed by license key file, i.e., `--license-key-path` is set.
     managed_license_key: bool,
@@ -31,10 +39,12 @@ pub struct SystemParamsServiceImpl {
 impl SystemParamsServiceImpl {
     pub fn new(
         system_params_manager: SystemParamsControllerRef,
+        metadata_manager: MetadataManager,
         managed_license_key: bool,
     ) -> Self {
         Self {
             system_params_manager,
+            metadata_manager,
             managed_license_key,
         }
     }
@@ -77,5 +87,51 @@ impl SystemParamsService for SystemParamsServiceImpl {
         Ok(Response::new(SetSystemParamResponse {
             params: Some(params),
         }))
+    }
+
+    async fn clear_file_cache(
+        &self,
+        request: Request<ClearFileCacheRequest>,
+    ) -> Result<Response<ClearFileCacheResponse>, Status> {
+        let request = request.into_inner();
+        let worker_nodes = self
+            .metadata_manager
+            .list_worker_node(Some(WorkerType::ComputeNode), None)
+            .await
+            .map_err(|e| Status::internal(e.to_report_string()))?;
+
+        let clear_futures = worker_nodes.into_iter().map(|worker| async move {
+            let worker_id = worker.id;
+            let host = worker
+                .get_host()
+                .map_err(|e| Status::internal(e.to_report_string()))?
+                .clone();
+            let client = ComputeClient::new((&host).into(), &RpcClientConfig::default())
+                .await
+                .map_err(|e| {
+                    Status::internal(format!(
+                        "connect to compute node {worker_id}: {}",
+                        e.as_report()
+                    ))
+                })?;
+            client
+                .resize_cache(risingwave_pb::compute::ResizeCacheRequest {
+                    meta_cache_capacity: 0,
+                    data_cache_capacity: 0,
+                    clear_meta_cache: request.clear_meta_cache,
+                    clear_data_cache: request.clear_data_cache,
+                })
+                .await
+                .map_err(|e| {
+                    Status::internal(format!(
+                        "clear file cache on {worker_id}: {}",
+                        e.as_report()
+                    ))
+                })?;
+            Ok::<_, Status>(())
+        });
+
+        try_join_all(clear_futures).await?;
+        Ok(Response::new(ClearFileCacheResponse {}))
     }
 }

--- a/src/meta/src/backup_restore/meta_snapshot_builder.rs
+++ b/src/meta/src/backup_restore/meta_snapshot_builder.rs
@@ -1,4 +1,4 @@
-// Copyright 2022 RisingWave Labs
+// Copyright 2024 RisingWave Labs
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/rpc_client/src/meta_client.rs
+++ b/src/rpc_client/src/meta_client.rs
@@ -1682,6 +1682,20 @@ impl MetaClient {
         Ok(resp.params.map(SystemParamsReader::from))
     }
 
+    pub async fn clear_file_cache(
+        &self,
+        clear_meta_cache: bool,
+        clear_data_cache: bool,
+    ) -> Result<()> {
+        self.inner
+            .clear_file_cache(ClearFileCacheRequest {
+                clear_meta_cache,
+                clear_data_cache,
+            })
+            .await?;
+        Ok(())
+    }
+
     pub async fn get_session_params(&self) -> Result<String> {
         let req = GetSessionParamsRequest {};
         let resp = self.inner.get_session_params(req).await?;
@@ -2822,6 +2836,7 @@ macro_rules! for_all_meta_rpc {
             ,{ telemetry_client, get_telemetry_info, GetTelemetryInfoRequest, TelemetryInfoResponse}
             ,{ system_params_client, get_system_params, GetSystemParamsRequest, GetSystemParamsResponse }
             ,{ system_params_client, set_system_param, SetSystemParamRequest, SetSystemParamResponse }
+            ,{ system_params_client, clear_file_cache, ClearFileCacheRequest, ClearFileCacheResponse }
             ,{ session_params_client, get_session_params, GetSessionParamsRequest, GetSessionParamsResponse }
             ,{ session_params_client, set_session_param, SetSessionParamRequest, SetSessionParamResponse }
             ,{ serving_client, get_serving_vnode_mappings, GetServingVnodeMappingsRequest, GetServingVnodeMappingsResponse }

--- a/src/sqlparser/src/ast/mod.rs
+++ b/src/sqlparser/src/ast/mod.rs
@@ -1261,6 +1261,13 @@ pub enum WaitTarget {
     Index(ObjectName),
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum FileCacheType {
+    Meta,
+    Data,
+    All,
+}
+
 /// A top-level statement (SELECT, INSERT, CREATE, etc.)
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -1700,6 +1707,10 @@ pub enum Statement {
     AlterSystem {
         param: Ident,
         value: SetVariableValue,
+    },
+    /// ALTER SYSTEM CLEAR FILE CACHE [META | DATA | ALL]
+    AlterSystemClearFileCache {
+        cache_type: FileCacheType,
     },
     /// FLUSH the current barrier.
     ///
@@ -2476,6 +2487,14 @@ impl Statement {
             Statement::AlterSystem { param, value } => {
                 f.write_str("ALTER SYSTEM SET ")?;
                 write!(f, "{param} = {value}",)
+            }
+            Statement::AlterSystemClearFileCache { cache_type } => {
+                f.write_str("ALTER SYSTEM CLEAR FILE CACHE ")?;
+                match cache_type {
+                    FileCacheType::Meta => f.write_str("META"),
+                    FileCacheType::Data => f.write_str("DATA"),
+                    FileCacheType::All => f.write_str("ALL"),
+                }
             }
             Statement::Flush => {
                 write!(f, "FLUSH")

--- a/src/sqlparser/src/parser.rs
+++ b/src/sqlparser/src/parser.rs
@@ -4017,6 +4017,20 @@ impl Parser<'_> {
     }
 
     pub fn parse_alter_system(&mut self) -> ModalResult<Statement> {
+        if self.parse_word("CLEAR") {
+            self.expect_keywords(&[Keyword::FILE, Keyword::CACHE])?;
+            let cache_type = if self.parse_keyword(Keyword::META) {
+                FileCacheType::Meta
+            } else if self.parse_keyword(Keyword::DATA) {
+                FileCacheType::Data
+            } else if self.parse_keyword(Keyword::ALL) {
+                FileCacheType::All
+            } else {
+                return self.expected("META, DATA, or ALL after ALTER SYSTEM CLEAR FILE CACHE");
+            };
+            return Ok(Statement::AlterSystemClearFileCache { cache_type });
+        }
+
         self.expect_keyword(Keyword::SET)?;
         let param = self.parse_identifier()?;
         if self.expect_keyword(Keyword::TO).is_err() && self.expect_token(&Token::Eq).is_err() {

--- a/src/sqlparser/tests/sqlparser_common.rs
+++ b/src/sqlparser/tests/sqlparser_common.rs
@@ -3900,6 +3900,22 @@ fn parse_begin() {
 }
 
 #[test]
+fn parse_alter_system_clear_file_cache() {
+    one_statement_parses_to(
+        "ALTER SYSTEM CLEAR FILE CACHE META",
+        "ALTER SYSTEM CLEAR FILE CACHE META",
+    );
+    one_statement_parses_to(
+        "ALTER SYSTEM CLEAR FILE CACHE DATA",
+        "ALTER SYSTEM CLEAR FILE CACHE DATA",
+    );
+    one_statement_parses_to(
+        "ALTER SYSTEM CLEAR FILE CACHE ALL",
+        "ALTER SYSTEM CLEAR FILE CACHE ALL",
+    );
+}
+
+#[test]
 fn parse_set_transaction() {
     // SET TRANSACTION shares transaction mode parsing code with START
     // TRANSACTION, so no need to duplicate the tests here. We just do a quick

--- a/src/storage/src/hummock/sstable_store.rs
+++ b/src/storage/src/hummock/sstable_store.rs
@@ -971,4 +971,109 @@ mod tests {
             HummockObjectId::Sstable(object_id.into())
         );
     }
+
+    #[tokio::test]
+    async fn test_clear_file_cache_and_refetch() {
+        let sstable_store = mock_sstable_store().await;
+        let x_range = 0..10;
+        let (data, meta) = gen_test_sstable_data(
+            default_builder_opt_for_test(),
+            x_range.map(|x| (iterator_test_key_of(x), get_hummock_value(x))),
+        )
+        .await;
+        let info = put_sst(
+            SST_ID,
+            data,
+            meta,
+            sstable_store.clone(),
+            SstableWriterOptions {
+                capacity_hint: None,
+                tracker: None,
+                policy: CachePolicy::Fill(foyer::Hint::Normal),
+            },
+            vec![0],
+        )
+        .await
+        .unwrap();
+
+        let mut stats = StoreLocalStatistic::default();
+        assert!(
+            sstable_store
+                .sstable_cached(info.object_id)
+                .await
+                .unwrap()
+                .is_some()
+        );
+        let sstable = sstable_store.sstable(&info, &mut stats).await.unwrap();
+        sstable_store
+            .get(
+                &sstable,
+                0,
+                CachePolicy::Fill(foyer::Hint::Normal),
+                &mut stats,
+            )
+            .await
+            .unwrap();
+        assert!(
+            sstable_store
+                .block_cache()
+                .get(&super::SstableBlockIndex {
+                    sst_id: info.object_id,
+                    block_idx: 0,
+                })
+                .await
+                .unwrap()
+                .is_some()
+        );
+
+        sstable_store.clear_meta_cache().await.unwrap();
+        assert!(
+            sstable_store
+                .sstable_cached(info.object_id)
+                .await
+                .unwrap()
+                .is_none()
+        );
+        sstable_store.sstable(&info, &mut stats).await.unwrap();
+        assert!(
+            sstable_store
+                .sstable_cached(info.object_id)
+                .await
+                .unwrap()
+                .is_some()
+        );
+
+        sstable_store.clear_block_cache().await.unwrap();
+        assert!(
+            sstable_store
+                .block_cache()
+                .get(&super::SstableBlockIndex {
+                    sst_id: info.object_id,
+                    block_idx: 0,
+                })
+                .await
+                .unwrap()
+                .is_none()
+        );
+        sstable_store
+            .get(
+                &sstable,
+                0,
+                CachePolicy::Fill(foyer::Hint::Normal),
+                &mut stats,
+            )
+            .await
+            .unwrap();
+        assert!(
+            sstable_store
+                .block_cache()
+                .get(&super::SstableBlockIndex {
+                    sst_id: info.object_id,
+                    block_idx: 0,
+                })
+                .await
+                .unwrap()
+                .is_some()
+        );
+    }
 }

--- a/src/stream/src/executor/source/source_executor.rs
+++ b/src/stream/src/executor/source/source_executor.rs
@@ -1,4 +1,4 @@
-// Copyright 2022 RisingWave Labs
+// Copyright 2023 RisingWave Labs
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/tests/sqlsmith/src/utils.rs
+++ b/src/tests/sqlsmith/src/utils.rs
@@ -1,4 +1,4 @@
-// Copyright 2022 RisingWave Labs
+// Copyright 2023 RisingWave Labs
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.


### PR DESCRIPTION
## What's changed

- Extend the existing `ResizeCacheRequest` with independent meta/data clear flags.
- Clear the corresponding ComputeNode `HybridCache` tiers through the existing `hummock resize-cache` fan-out.
- Add `--clear-meta-cache` and `--clear-data-cache` to `risectl hummock resize-cache`.
- Add a behavior test covering clear, cache miss, refetch from object storage, and cache refill.

## Semantics

This is a best-effort per-ComputeNode operation, not a globally atomic freeze. In-flight reads may repopulate entries, and the existing fan-out can complete partially if a node fails. The operation does not require a restart; subsequent reads refill the cache normally.

## Validation

- `cargo fmt --all`
- `cargo test -p risingwave_storage test_clear_file_cache_and_refetch --lib`
- `cargo check -p risingwave_compute -p risingwave_ctl`
- `cargo clippy --workspace --all-targets -- -D warnings 2>&1`
- `git diff --check`
