### PR TITLE
feat(sql): add ALTER SYSTEM file cache clear

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12791,6 +12791,7 @@ dependencies = [
  "risingwave_meta",
  "risingwave_meta_model",
  "risingwave_pb",
+ "risingwave_rpc_client",
  "sea-orm",
  "serde_json",
  "thiserror-ext",

--- a/proto/meta.proto
+++ b/proto/meta.proto
@@ -902,9 +902,17 @@ message SetSystemParamResponse {
   optional SystemParams params = 1;
 }
 
+message ClearFileCacheRequest {
+  bool clear_meta_cache = 1;
+  bool clear_data_cache = 2;
+}
+
+message ClearFileCacheResponse {}
+
 service SystemParamsService {
   rpc GetSystemParams(GetSystemParamsRequest) returns (GetSystemParamsResponse);
   rpc SetSystemParam(SetSystemParamRequest) returns (SetSystemParamResponse);
+  rpc ClearFileCache(ClearFileCacheRequest) returns (ClearFileCacheResponse);
 }
 
 message GetSessionParamsRequest {}

--- a/src/frontend/src/handler/alter_system.rs
+++ b/src/frontend/src/handler/alter_system.rs
@@ -16,7 +16,7 @@ use pgwire::pg_response::StatementType;
 use risingwave_common::session_config::SessionConfig;
 use risingwave_common::system_param::reader::SystemParamsRead;
 use risingwave_common::system_param::{NOTICE_BARRIER_INTERVAL_MS, NOTICE_CHECKPOINT_FREQUENCY};
-use risingwave_sqlparser::ast::{Ident, SetVariableValue};
+use risingwave_sqlparser::ast::{FileCacheType, Ident, SetVariableValue};
 
 use super::variable::set_var_to_param_str;
 use super::{HandlerArgs, RwPgResponse};
@@ -81,4 +81,29 @@ pub async fn handle_alter_system(
         }
     }
     Ok(builder.into())
+}
+
+pub async fn handle_clear_file_cache(
+    handler_args: HandlerArgs,
+    cache_type: FileCacheType,
+) -> Result<RwPgResponse> {
+    if !handler_args.session.is_super_user() {
+        return Err(ErrorCode::PermissionDenied(
+            "must be superuser to clear file cache".to_owned(),
+        )
+        .into());
+    }
+
+    let (clear_meta_cache, clear_data_cache) = match cache_type {
+        FileCacheType::Meta => (true, false),
+        FileCacheType::Data => (false, true),
+        FileCacheType::All => (true, true),
+    };
+    handler_args
+        .session
+        .env()
+        .meta_client()
+        .clear_file_cache(clear_meta_cache, clear_data_cache)
+        .await?;
+    Ok(RwPgResponse::empty_result(StatementType::ALTER_SYSTEM))
 }

--- a/src/frontend/src/handler/mod.rs
+++ b/src/frontend/src/handler/mod.rs
@@ -1581,6 +1581,9 @@ pub async fn handle(
         Statement::AlterSystem { param, value } => {
             alter_system::handle_alter_system(handler_args, param, value).await
         }
+        Statement::AlterSystemClearFileCache { cache_type } => {
+            alter_system::handle_clear_file_cache(handler_args, cache_type).await
+        }
         Statement::AlterSecret { name, operation } => match operation {
             AlterSecretOperation::ChangeCredential {
                 with_options,

--- a/src/frontend/src/meta_client.rs
+++ b/src/frontend/src/meta_client.rs
@@ -101,6 +101,8 @@ pub trait FrontendMetaClient: Send + Sync {
         value: Option<String>,
     ) -> Result<Option<SystemParamsReader>>;
 
+    async fn clear_file_cache(&self, clear_meta_cache: bool, clear_data_cache: bool) -> Result<()>;
+
     async fn get_session_params(&self) -> Result<SessionConfig>;
 
     async fn set_session_param(&self, param: String, value: Option<String>) -> Result<String>;
@@ -325,6 +327,12 @@ impl FrontendMetaClient for FrontendMetaClientImpl {
         value: Option<String>,
     ) -> Result<Option<SystemParamsReader>> {
         self.0.set_system_param(param, value).await
+    }
+
+    async fn clear_file_cache(&self, clear_meta_cache: bool, clear_data_cache: bool) -> Result<()> {
+        self.0
+            .clear_file_cache(clear_meta_cache, clear_data_cache)
+            .await
     }
 
     async fn get_session_params(&self) -> Result<SessionConfig> {

--- a/src/frontend/src/test_utils.rs
+++ b/src/frontend/src/test_utils.rs
@@ -1267,6 +1267,14 @@ impl FrontendMetaClient for MockFrontendMetaClient {
         Ok(Some(SystemParams::default().into()))
     }
 
+    async fn clear_file_cache(
+        &self,
+        _clear_meta_cache: bool,
+        _clear_data_cache: bool,
+    ) -> RpcResult<()> {
+        Ok(())
+    }
+
     async fn get_session_params(&self) -> RpcResult<SessionConfig> {
         Ok(Default::default())
     }

--- a/src/meta/node/src/server.rs
+++ b/src/meta/node/src/server.rs
@@ -608,6 +608,7 @@ pub async fn start_service_as_election_leader(
     let telemetry_srv = TelemetryInfoServiceImpl::new(env.meta_store());
     let system_params_srv = SystemParamsServiceImpl::new(
         env.system_params_manager_impl_ref(),
+        metadata_manager.clone(),
         env.opts.license_key_path.is_some(),
     );
     let session_params_srv = SessionParamsServiceImpl::new(env.session_params_manager_impl_ref());

--- a/src/meta/service/Cargo.toml
+++ b/src/meta/service/Cargo.toml
@@ -26,6 +26,7 @@ risingwave_hummock_sdk = { workspace = true }
 risingwave_meta = { workspace = true }
 risingwave_meta_model = { workspace = true }
 risingwave_pb = { workspace = true }
+risingwave_rpc_client = { workspace = true }
 sea-orm = { workspace = true }
 serde_json = "1"
 thiserror-ext = { workspace = true }

--- a/src/meta/service/src/system_params_service.rs
+++ b/src/meta/service/src/system_params_service.rs
@@ -13,16 +13,23 @@
 // limitations under the License.
 
 use async_trait::async_trait;
+use futures::future::try_join_all;
+use risingwave_common::config::RpcClientConfig;
 use risingwave_common::system_param::LICENSE_KEY_KEY;
 use risingwave_meta::controller::system_param::SystemParamsControllerRef;
+use risingwave_meta::manager::MetadataManager;
+use risingwave_pb::common::WorkerType;
 use risingwave_pb::meta::system_params_service_server::SystemParamsService;
 use risingwave_pb::meta::{
-    GetSystemParamsRequest, GetSystemParamsResponse, SetSystemParamRequest, SetSystemParamResponse,
+    ClearFileCacheRequest, ClearFileCacheResponse, GetSystemParamsRequest, GetSystemParamsResponse,
+    SetSystemParamRequest, SetSystemParamResponse,
 };
+use risingwave_rpc_client::ComputeClient;
 use tonic::{Request, Response, Status};
 
 pub struct SystemParamsServiceImpl {
     system_params_manager: SystemParamsControllerRef,
+    metadata_manager: MetadataManager,
 
     /// Whether the license key is managed by license key file, i.e., `--license-key-path` is set.
     managed_license_key: bool,
@@ -31,10 +38,12 @@ pub struct SystemParamsServiceImpl {
 impl SystemParamsServiceImpl {
     pub fn new(
         system_params_manager: SystemParamsControllerRef,
+        metadata_manager: MetadataManager,
         managed_license_key: bool,
     ) -> Self {
         Self {
             system_params_manager,
+            metadata_manager,
             managed_license_key,
         }
     }
@@ -77,5 +86,43 @@ impl SystemParamsService for SystemParamsServiceImpl {
         Ok(Response::new(SetSystemParamResponse {
             params: Some(params),
         }))
+    }
+
+    async fn clear_file_cache(
+        &self,
+        request: Request<ClearFileCacheRequest>,
+    ) -> Result<Response<ClearFileCacheResponse>, Status> {
+        let request = request.into_inner();
+        let worker_nodes = self
+            .metadata_manager
+            .list_worker_node(Some(WorkerType::ComputeNode), None)
+            .await
+            .map_err(|e| Status::internal(e.to_string()))?;
+
+        let clear_futures = worker_nodes.into_iter().map(|worker| async move {
+            let worker_id = worker.id;
+            let host = worker
+                .get_host()
+                .map_err(|e| Status::internal(e.to_string()))?
+                .clone();
+            let client = ComputeClient::new((&host).into(), &RpcClientConfig::default())
+                .await
+                .map_err(|e| {
+                    Status::internal(format!("connect to compute node {worker_id}: {e}"))
+                })?;
+            client
+                .resize_cache(risingwave_pb::compute::ResizeCacheRequest {
+                    meta_cache_capacity: 0,
+                    data_cache_capacity: 0,
+                    clear_meta_cache: request.clear_meta_cache,
+                    clear_data_cache: request.clear_data_cache,
+                })
+                .await
+                .map_err(|e| Status::internal(format!("clear file cache on {worker_id}: {e}")))?;
+            Ok::<_, Status>(())
+        });
+
+        try_join_all(clear_futures).await?;
+        Ok(Response::new(ClearFileCacheResponse {}))
     }
 }

--- a/src/meta/service/src/system_params_service.rs
+++ b/src/meta/service/src/system_params_service.rs
@@ -25,6 +25,7 @@ use risingwave_pb::meta::{
     SetSystemParamRequest, SetSystemParamResponse,
 };
 use risingwave_rpc_client::ComputeClient;
+use thiserror_ext::AsReport;
 use tonic::{Request, Response, Status};
 
 pub struct SystemParamsServiceImpl {
@@ -97,18 +98,21 @@ impl SystemParamsService for SystemParamsServiceImpl {
             .metadata_manager
             .list_worker_node(Some(WorkerType::ComputeNode), None)
             .await
-            .map_err(|e| Status::internal(e.to_string()))?;
+            .map_err(|e| Status::internal(e.to_report_string()))?;
 
         let clear_futures = worker_nodes.into_iter().map(|worker| async move {
             let worker_id = worker.id;
             let host = worker
                 .get_host()
-                .map_err(|e| Status::internal(e.to_string()))?
+                .map_err(|e| Status::internal(e.to_report_string()))?
                 .clone();
             let client = ComputeClient::new((&host).into(), &RpcClientConfig::default())
                 .await
                 .map_err(|e| {
-                    Status::internal(format!("connect to compute node {worker_id}: {e}"))
+                    Status::internal(format!(
+                        "connect to compute node {worker_id}: {}",
+                        e.as_report()
+                    ))
                 })?;
             client
                 .resize_cache(risingwave_pb::compute::ResizeCacheRequest {
@@ -118,7 +122,12 @@ impl SystemParamsService for SystemParamsServiceImpl {
                     clear_data_cache: request.clear_data_cache,
                 })
                 .await
-                .map_err(|e| Status::internal(format!("clear file cache on {worker_id}: {e}")))?;
+                .map_err(|e| {
+                    Status::internal(format!(
+                        "clear file cache on {worker_id}: {}",
+                        e.as_report()
+                    ))
+                })?;
             Ok::<_, Status>(())
         });
 

--- a/src/rpc_client/src/meta_client.rs
+++ b/src/rpc_client/src/meta_client.rs
@@ -1682,6 +1682,20 @@ impl MetaClient {
         Ok(resp.params.map(SystemParamsReader::from))
     }
 
+    pub async fn clear_file_cache(
+        &self,
+        clear_meta_cache: bool,
+        clear_data_cache: bool,
+    ) -> Result<()> {
+        self.inner
+            .clear_file_cache(ClearFileCacheRequest {
+                clear_meta_cache,
+                clear_data_cache,
+            })
+            .await?;
+        Ok(())
+    }
+
     pub async fn get_session_params(&self) -> Result<String> {
         let req = GetSessionParamsRequest {};
         let resp = self.inner.get_session_params(req).await?;
@@ -2822,6 +2836,7 @@ macro_rules! for_all_meta_rpc {
             ,{ telemetry_client, get_telemetry_info, GetTelemetryInfoRequest, TelemetryInfoResponse}
             ,{ system_params_client, get_system_params, GetSystemParamsRequest, GetSystemParamsResponse }
             ,{ system_params_client, set_system_param, SetSystemParamRequest, SetSystemParamResponse }
+            ,{ system_params_client, clear_file_cache, ClearFileCacheRequest, ClearFileCacheResponse }
             ,{ session_params_client, get_session_params, GetSessionParamsRequest, GetSessionParamsResponse }
             ,{ session_params_client, set_session_param, SetSessionParamRequest, SetSessionParamResponse }
             ,{ serving_client, get_serving_vnode_mappings, GetServingVnodeMappingsRequest, GetServingVnodeMappingsResponse }

--- a/src/sqlparser/src/ast/mod.rs
+++ b/src/sqlparser/src/ast/mod.rs
@@ -1261,6 +1261,13 @@ pub enum WaitTarget {
     Index(ObjectName),
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum FileCacheType {
+    Meta,
+    Data,
+    All,
+}
+
 /// A top-level statement (SELECT, INSERT, CREATE, etc.)
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -1700,6 +1707,10 @@ pub enum Statement {
     AlterSystem {
         param: Ident,
         value: SetVariableValue,
+    },
+    /// ALTER SYSTEM CLEAR FILE CACHE [META | DATA | ALL]
+    AlterSystemClearFileCache {
+        cache_type: FileCacheType,
     },
     /// FLUSH the current barrier.
     ///
@@ -2476,6 +2487,14 @@ impl Statement {
             Statement::AlterSystem { param, value } => {
                 f.write_str("ALTER SYSTEM SET ")?;
                 write!(f, "{param} = {value}",)
+            }
+            Statement::AlterSystemClearFileCache { cache_type } => {
+                f.write_str("ALTER SYSTEM CLEAR FILE CACHE ")?;
+                match cache_type {
+                    FileCacheType::Meta => f.write_str("META"),
+                    FileCacheType::Data => f.write_str("DATA"),
+                    FileCacheType::All => f.write_str("ALL"),
+                }
             }
             Statement::Flush => {
                 write!(f, "FLUSH")

--- a/src/sqlparser/src/parser.rs
+++ b/src/sqlparser/src/parser.rs
@@ -4017,6 +4017,20 @@ impl Parser<'_> {
     }
 
     pub fn parse_alter_system(&mut self) -> ModalResult<Statement> {
+        if self.parse_word("CLEAR") {
+            self.expect_keywords(&[Keyword::FILE, Keyword::CACHE])?;
+            let cache_type = if self.parse_keyword(Keyword::META) {
+                FileCacheType::Meta
+            } else if self.parse_keyword(Keyword::DATA) {
+                FileCacheType::Data
+            } else if self.parse_keyword(Keyword::ALL) {
+                FileCacheType::All
+            } else {
+                return self.expected("META, DATA, or ALL after ALTER SYSTEM CLEAR FILE CACHE");
+            };
+            return Ok(Statement::AlterSystemClearFileCache { cache_type });
+        }
+
         self.expect_keyword(Keyword::SET)?;
         let param = self.parse_identifier()?;
         if self.expect_keyword(Keyword::TO).is_err() && self.expect_token(&Token::Eq).is_err() {

--- a/src/sqlparser/tests/sqlparser_common.rs
+++ b/src/sqlparser/tests/sqlparser_common.rs
@@ -3900,6 +3900,22 @@ fn parse_begin() {
 }
 
 #[test]
+fn parse_alter_system_clear_file_cache() {
+    one_statement_parses_to(
+        "ALTER SYSTEM CLEAR FILE CACHE META",
+        "ALTER SYSTEM CLEAR FILE CACHE META",
+    );
+    one_statement_parses_to(
+        "ALTER SYSTEM CLEAR FILE CACHE DATA",
+        "ALTER SYSTEM CLEAR FILE CACHE DATA",
+    );
+    one_statement_parses_to(
+        "ALTER SYSTEM CLEAR FILE CACHE ALL",
+        "ALTER SYSTEM CLEAR FILE CACHE ALL",
+    );
+}
+
+#[test]
 fn parse_set_transaction() {
     // SET TRANSACTION shares transaction mode parsing code with START
     // TRANSACTION, so no need to duplicate the tests here. We just do a quick


### PR DESCRIPTION
## Summary

This PR is stacked on #26577 and adds a SQL entry point for the runtime file-cache clear RPC:

```sql
ALTER SYSTEM CLEAR FILE CACHE META;
ALTER SYSTEM CLEAR FILE CACHE DATA;
ALTER SYSTEM CLEAR FILE CACHE ALL;
```

- Require superuser privileges in the Frontend handler.
- Add a Meta RPC that fans out to all ComputeNodes.
- Reuse the existing `ResizeCacheRequest` clear flags and runtime `HybridCache::clear()` implementation.
- Return an error if a ComputeNode cannot be cleared.

The first commit is the base implementation from #26577; the incremental SQL change is commit `3f42fc848a`.

## Validation

- `cargo test -p risingwave_sqlparser parse_alter_system_clear_file_cache`
- `cargo check -p risingwave_meta_service -p risingwave_frontend -p risingwave_rpc_client -p risingwave_sqlparser`
- `cargo fmt --all`
- `git diff --check`
