### PR TITLE
feat(frontend): support PREPARE/EXECUTE/DEALLOCATE in simple query mode

### DIFF
--- a/e2e_test/batch/basic/prepare_execute.slt
+++ b/e2e_test/batch/basic/prepare_execute.slt
@@ -1,0 +1,48 @@
+# Simple-query-mode PREPARE / EXECUTE / DEALLOCATE.
+# https://github.com/risingwavelabs/risingwave/issues/21777
+
+statement ok
+create table t21777 (v1 int, v2 varchar);
+
+statement ok
+insert into t21777 values (1, 'a'), (2, 'b'), (3, 'c');
+
+statement ok
+flush;
+
+statement ok
+prepare p21777 (int) as select v1, v2 from t21777 where v1 = $1;
+
+query IT
+execute p21777(2);
+----
+2 b
+
+statement error does not exist
+execute nonexistent_stmt21777;
+
+statement error already exists
+prepare p21777 (int) as select v1, v2 from t21777 where v1 = $1;
+
+statement ok
+deallocate p21777;
+
+statement error does not exist
+execute p21777(1);
+
+statement ok
+prepare p21777_multi (int, varchar) as select v1, v2 from t21777 where v1 = $1 and v2 = $2;
+
+query IT
+execute p21777_multi(3, 'c');
+----
+3 c
+
+statement ok
+deallocate all;
+
+statement error does not exist
+execute p21777_multi(1, 'a');
+
+statement ok
+drop table t21777;

--- a/src/frontend/src/handler/mod.rs
+++ b/src/frontend/src/handler/mod.rs
@@ -310,6 +310,22 @@ pub async fn handle(
 ) -> Result<RwPgResponse> {
     session.clear_cancel_query_flag();
     let _guard = session.txn_begin_implicit();
+    Box::pin(dispatch_statement(session, stmt, sql, formats)).await
+}
+
+/// Dispatches a single statement to its handler, assuming an (implicit or explicit)
+/// transaction is already in progress on `session`.
+///
+/// This is split out from [`handle`] so that a handler which needs to recursively dispatch
+/// another statement on the same session -- e.g. `EXECUTE` re-dispatching the prepared
+/// statement it names -- can do so without trying to begin a second implicit transaction,
+/// which would panic. Such callers should invoke this function directly rather than [`handle`].
+pub(crate) async fn dispatch_statement(
+    session: Arc<SessionImpl>,
+    stmt: Statement,
+    sql: Arc<str>,
+    formats: Vec<Format>,
+) -> Result<RwPgResponse> {
     let handler_args = HandlerArgs::new(session, &stmt, sql)?;
 
     check_ban_ddl_for_iceberg_engine_table(handler_args.session.clone(), &stmt)?;
@@ -1673,9 +1689,12 @@ pub async fn handle(
             name,
             data_types,
             statement,
-        } => prepared_statement::handle_prepare(name, data_types, statement),
+        } => prepared_statement::handle_prepare(handler_args, name, data_types, statement),
         Statement::Deallocate { name, prepare } => {
-            prepared_statement::handle_deallocate(name, prepare)
+            prepared_statement::handle_deallocate(handler_args, name, prepare)
+        }
+        Statement::Execute { name, parameters } => {
+            prepared_statement::handle_execute(handler_args, name, parameters).await
         }
         Statement::Vacuum { object_name, full } => {
             vacuum::handle_vacuum(handler_args, object_name, full).await

--- a/src/frontend/src/handler/prepared_statement.rs
+++ b/src/frontend/src/handler/prepared_statement.rs
@@ -12,34 +12,184 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::sync::Arc;
+
 use pgwire::pg_response::StatementType;
-use risingwave_sqlparser::ast::{DataType, Ident, Statement};
+use risingwave_sqlparser::ast::{DataType, Expr, Ident, Statement};
+use risingwave_sqlparser::parser::Parser;
+use thiserror_ext::AsReport;
 
+use super::HandlerArgs;
+use crate::error::{ErrorCode, Result};
 use crate::handler::RwPgResponse;
+use crate::session::PreparedStatementEntry;
 
+/// Handles simple-query-mode `PREPARE name [ ( data_type [, ...] ) ] AS statement`.
+///
+/// The statement is stored as its rendered SQL text (rather than the parsed AST), keyed by
+/// name in the current session. `EXECUTE` later substitutes `$n` parameters into this text
+/// and re-parses/re-dispatches it.
 pub fn handle_prepare(
-    _name: Ident,
-    _data_types: Vec<DataType>,
-    _statement: Box<Statement>,
-) -> crate::error::Result<RwPgResponse> {
-    const MESSAGE: &str = "\
-        `PREPARE` is not supported yet.\n\
-        For compatibility, this statement will still succeed but no changes are actually made.";
+    handler_args: HandlerArgs,
+    name: Ident,
+    data_types: Vec<DataType>,
+    statement: Box<Statement>,
+) -> Result<RwPgResponse> {
+    let entry = PreparedStatementEntry {
+        data_types,
+        statement_sql: statement.to_string(),
+    };
+    handler_args
+        .session
+        .create_simple_prepared_statement(name.real_value(), entry)
+        .map_err(ErrorCode::ProtocolError)?;
 
-    Ok(RwPgResponse::builder(StatementType::PREPARE)
-        .notice(MESSAGE)
-        .into())
+    Ok(RwPgResponse::builder(StatementType::PREPARE).into())
 }
 
+/// Handles simple-query-mode `DEALLOCATE [ PREPARE ] { name | ALL }`.
 pub fn handle_deallocate(
-    _name: Option<Ident>,
+    handler_args: HandlerArgs,
+    name: Option<Ident>,
     _prepare: bool,
-) -> crate::error::Result<RwPgResponse> {
-    const MESSAGE: &str = "\
-        `DEALLOCATE` is not supported yet.\n\
-        For compatibility, this statement will still succeed but no changes are actually made.";
+) -> Result<RwPgResponse> {
+    let name = name.map(|n| n.real_value());
+    handler_args
+        .session
+        .deallocate_simple_prepared_statement(name.as_deref());
 
-    Ok(RwPgResponse::builder(StatementType::DEALLOCATE)
-        .notice(MESSAGE)
-        .into())
+    Ok(RwPgResponse::builder(StatementType::DEALLOCATE).into())
+}
+
+/// Handles simple-query-mode `EXECUTE name [ ( parameter [, ...] ) ]`.
+///
+/// Looks up the statement text stored by a previous `PREPARE`, substitutes the `$n`
+/// placeholders with the textual SQL rendering of the given parameter expressions, re-parses
+/// the result, and dispatches it exactly as if the user had typed it directly.
+///
+/// Note: substitution is purely textual and skips the contents of single-quoted string
+/// literals; it does not perform PostgreSQL-style type coercion of parameters against the
+/// declared `data_types`.
+pub async fn handle_execute(
+    handler_args: HandlerArgs,
+    name: Ident,
+    parameters: Vec<Expr>,
+) -> Result<RwPgResponse> {
+    let name = name.real_value();
+    let entry = handler_args
+        .session
+        .get_simple_prepared_statement(&name)
+        .ok_or_else(|| {
+            ErrorCode::ProtocolError(format!("prepared statement \"{name}\" does not exist"))
+        })?;
+
+    let params: Vec<String> = parameters.iter().map(|e| e.to_string()).collect();
+    let substituted_sql = substitute_parameters(&entry.statement_sql, &params)?;
+
+    let mut parsed = Parser::parse_sql(&substituted_sql).map_err(|e| {
+        ErrorCode::InternalError(format!(
+            "failed to re-parse prepared statement \"{name}\" after substituting parameters: {}",
+            e.as_report()
+        ))
+    })?;
+    if parsed.len() != 1 {
+        return Err(ErrorCode::InternalError(format!(
+            "prepared statement \"{name}\" did not resolve to exactly one statement"
+        ))
+        .into());
+    }
+    let stmt = parsed.remove(0);
+
+    // Use `dispatch_statement` rather than `handle` here: an implicit transaction was already
+    // begun for the outer `EXECUTE` statement by `handle`, and beginning a second one on the
+    // same session would panic.
+    Box::pin(super::dispatch_statement(
+        handler_args.session.clone(),
+        stmt,
+        Arc::from(substituted_sql.as_str()),
+        vec![],
+    ))
+    .await
+}
+
+/// Replaces `$n` placeholders in `sql` with `params[n - 1]`, skipping the contents of
+/// single-quoted string literals (with `''` treated as an escaped quote, matching SQL syntax).
+fn substitute_parameters(sql: &str, params: &[String]) -> Result<String> {
+    let mut out = String::with_capacity(sql.len());
+    let mut chars = sql.chars().peekable();
+    let mut in_string = false;
+
+    while let Some(c) = chars.next() {
+        if in_string {
+            out.push(c);
+            if c == '\'' {
+                in_string = false;
+            }
+            continue;
+        }
+        if c == '\'' {
+            in_string = true;
+            out.push(c);
+            continue;
+        }
+        if c == '$' && chars.peek().is_some_and(|c| c.is_ascii_digit()) {
+            let mut digits = String::new();
+            while let Some(d) = chars.peek()
+                && d.is_ascii_digit()
+            {
+                digits.push(*d);
+                chars.next();
+            }
+            let idx: usize = digits.parse().unwrap();
+            let value = params.get(idx.wrapping_sub(1)).ok_or_else(|| {
+                ErrorCode::ProtocolError(format!(
+                    "no parameter was provided for placeholder ${digits}"
+                ))
+            })?;
+            out.push_str(value);
+        } else {
+            out.push(c);
+        }
+    }
+
+    Ok(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_substitute_parameters_basic() {
+        let sql = "SELECT * FROM t WHERE a = $1 AND b = $2";
+        let params = vec!["1".to_owned(), "'foo'".to_owned()];
+        assert_eq!(
+            substitute_parameters(sql, &params).unwrap(),
+            "SELECT * FROM t WHERE a = 1 AND b = 'foo'"
+        );
+    }
+
+    #[test]
+    fn test_substitute_parameters_double_digit_index() {
+        let sql = "SELECT $1, $10";
+        let params: Vec<String> = (1..=10).map(|i| i.to_string()).collect();
+        assert_eq!(substitute_parameters(sql, &params).unwrap(), "SELECT 1, 10");
+    }
+
+    #[test]
+    fn test_substitute_parameters_skips_string_literals() {
+        let sql = "SELECT '$1' , $1";
+        let params = vec!["42".to_owned()];
+        assert_eq!(
+            substitute_parameters(sql, &params).unwrap(),
+            "SELECT '$1' , 42"
+        );
+    }
+
+    #[test]
+    fn test_substitute_parameters_missing_param_errors() {
+        let sql = "SELECT $1, $2";
+        let params = vec!["1".to_owned()];
+        assert!(substitute_parameters(sql, &params).is_err());
+    }
 }

--- a/src/frontend/src/session.rs
+++ b/src/frontend/src/session.rs
@@ -786,6 +786,52 @@ pub struct SessionImpl {
 
     /// staging catalogs for the current session
     staging_catalog_manager: Arc<Mutex<StagingCatalogManager>>,
+
+    /// prepared statements created via simple-query-mode `PREPARE`, keyed by name
+    simple_prepared_statements: Arc<Mutex<SimplePreparedStatementManager>>,
+}
+
+/// Manages prepared statements created via the simple-query-mode `PREPARE` statement, as
+/// opposed to those created through the pgwire extended query protocol (see
+/// `crate::handler::extended_handle::PrepareStatement`). A prepared statement here is stored
+/// as its original SQL text so that `EXECUTE` can substitute `$n` parameters textually and
+/// re-parse/re-dispatch it like a fresh statement.
+#[derive(Default, Clone)]
+pub struct SimplePreparedStatementManager {
+    statements: HashMap<String, PreparedStatementEntry>,
+}
+
+#[derive(Clone)]
+pub struct PreparedStatementEntry {
+    pub data_types: Vec<risingwave_sqlparser::ast::DataType>,
+    pub statement_sql: String,
+}
+
+impl SimplePreparedStatementManager {
+    pub fn create(
+        &mut self,
+        name: String,
+        entry: PreparedStatementEntry,
+    ) -> std::result::Result<(), String> {
+        if self.statements.contains_key(&name) {
+            return Err(format!("prepared statement \"{name}\" already exists"));
+        }
+        self.statements.insert(name, entry);
+        Ok(())
+    }
+
+    pub fn get(&self, name: &str) -> Option<PreparedStatementEntry> {
+        self.statements.get(name).cloned()
+    }
+
+    pub fn deallocate(&mut self, name: Option<&str>) {
+        match name {
+            Some(name) => {
+                self.statements.remove(name);
+            }
+            None => self.statements.clear(),
+        }
+    }
 }
 
 /// If TEMPORARY or TEMP is specified, the source is created as a temporary source.
@@ -897,6 +943,7 @@ impl SessionImpl {
             cursor_manager: Arc::new(CursorManager::new(cursor_metrics)),
             temporary_source_manager: Default::default(),
             staging_catalog_manager: Default::default(),
+            simple_prepared_statements: Default::default(),
         }
     }
 
@@ -930,6 +977,7 @@ impl SessionImpl {
             cursor_manager: Arc::new(CursorManager::new(env.cursor_metrics)),
             temporary_source_manager: Default::default(),
             staging_catalog_manager: Default::default(),
+            simple_prepared_statements: Default::default(),
         }
     }
 
@@ -1475,6 +1523,22 @@ impl SessionImpl {
 
     pub fn temporary_source_manager(&self) -> TemporarySourceManager {
         self.temporary_source_manager.lock().clone()
+    }
+
+    pub fn create_simple_prepared_statement(
+        &self,
+        name: String,
+        entry: PreparedStatementEntry,
+    ) -> std::result::Result<(), String> {
+        self.simple_prepared_statements.lock().create(name, entry)
+    }
+
+    pub fn get_simple_prepared_statement(&self, name: &str) -> Option<PreparedStatementEntry> {
+        self.simple_prepared_statements.lock().get(name)
+    }
+
+    pub fn deallocate_simple_prepared_statement(&self, name: Option<&str>) {
+        self.simple_prepared_statements.lock().deallocate(name);
     }
 
     pub fn create_staging_table(&self, table: TableCatalog) {


### PR DESCRIPTION
## What's changed

Simple-query-mode `PREPARE`, `EXECUTE`, and `DEALLOCATE` statements were unhandled (`bail_not_implemented!`). This adds support:

- `PreparedStatementEntry`/`SimplePreparedStatementManager` on `SessionImpl` store prepared statements per-session, keyed by name, as rendered SQL text.
- `PREPARE name [(types)] AS stmt` stores the statement.
- `EXECUTE name(params)` looks up the stored text, textually substitutes `$n` placeholders (skipping single-quoted string literals) with the rendered SQL of each parameter expression, re-parses the result, and dispatches it.
- `DEALLOCATE [PREPARE] name | ALL` removes one or all prepared statements from the session.
- Split `handle()` in `handler/mod.rs` into a thin wrapper that owns the implicit-transaction guard, plus `pub(crate) dispatch_statement()` which does the actual dispatch. `EXECUTE`'s handler calls `dispatch_statement` directly (via `handle_execute`) to avoid re-entering `txn_begin_implicit()` on the same session, which previously caused an `unreachable!` panic.

Closes #21777.

## Test plan

- [x] Unit tests: `cargo test -p risingwave_frontend --lib prepared_statement` — 4/4 pass (parameter substitution: basic, double-digit index, string-literal skipping, missing-parameter error).
- [x] `cargo check -p risingwave_frontend` — clean.
- [x] `cargo clippy -p risingwave_frontend --lib -- -D warnings` — clean.
- [x] `cargo fmt --all -- --check` — clean.
- [x] Integration/e2e test: new `e2e_test/batch/basic/prepare_execute.slt` covers `PREPARE`/`EXECUTE`/`DEALLOCATE name`/`DEALLOCATE ALL`, multi-parameter statements, re-preparing an existing name (error), and executing after deallocation (error). Run via `./risedev slt './e2e_test/batch/basic/prepare_execute.slt'` — OK.
- [x] Smoke test: started a local cluster (`./risedev d`), manually ran the PREPARE/EXECUTE/DEALLOCATE flow via `./risedev psql`, and confirmed `select 1;` still works afterward (no regression).