### PR TITLE
fix(ci): upgrade through intermediate releases in back-compat tests

### DIFF
--- a/ci/scripts/backwards-compat-test.sh
+++ b/ci/scripts/backwards-compat-test.sh
@@ -102,7 +102,7 @@ fi
 # Try to download the pre-built Java connector-node tarball for a specific
 # release from GitHub. Returns 0 on success (connector extracted and
 # CONNECTOR_LIBS_PATH exported), non-zero if the release asset is unavailable.
-download_old_connector_artifact() {
+download_release_connector_artifact() {
   local version="$1"
   local tarball="risingwave-connector-v${version}.tar.gz"
   local url="https://github.com/risingwavelabs/risingwave/releases/download/v${version}/${tarball}"
@@ -119,8 +119,10 @@ download_old_connector_artifact() {
   return 0
 }
 
-setup_old_cluster() {
-  echo "--- Build risedev for $OLD_VERSION, it may not be backwards compatible"
+setup_release_cluster() {
+  local version="$1"
+
+  echo "--- Build risedev for $version, it may not be backwards compatible"
   git config --global --add safe.directory /risingwave
   # `common.sh` exports GIT_SHA=$BUILDKITE_COMMIT (the PR tip). After we
   # check out an old tag, vergen's VERGEN_GIT_SHA reflects the old commit,
@@ -128,39 +130,60 @@ setup_old_cluster() {
   # panics because the two SHAs disagree. Drop GIT_SHA so the old build
   # only relies on VERGEN_GIT_SHA.
   unset GIT_SHA
-  git checkout "v${OLD_VERSION}"
+  git checkout "v${version}"
   cargo build -p risedev
-  echo "--- Get RisingWave binary for $OLD_VERSION"
-  OLD_URL=https://github.com/risingwavelabs/risingwave/releases/download/v${OLD_VERSION}/risingwave-v${OLD_VERSION}-x86_64-unknown-linux.tar.gz
+  echo "--- Get RisingWave binary for $version"
+  local archive="risingwave-v${version}-x86_64-unknown-linux.tar.gz"
+  local url="https://github.com/risingwavelabs/risingwave/releases/download/v${version}/${archive}"
   local enable_build_rust="false"
-  set +e
-  wget --no-verbose "$OLD_URL"
-  wget_rc=$?
-  set -e
-  if [[ "$wget_rc" -ne 0 ]]; then
-    echo "Failed to download ${OLD_VERSION} from github releases, build from source later during \`risedev d\`"
+  rm -f "$archive"
+  if ! wget --no-verbose "$url" -O "$archive"; then
+    rm -f "$archive"
+    echo "Failed to download ${version} from github releases, build from source later during \`risedev d\`"
     enable_build_rust="true"
-  elif [[ $OLD_VERSION = '1.10.0' || $OLD_VERSION = '1.10.1' || $OLD_VERSION = '1.10.2' || $OLD_VERSION = '2.0.0' ]]; then
+  elif [[ $version = '1.10.0' || $version = '1.10.1' || $version = '1.10.2' || $version = '2.0.0' ]]; then
     echo "1.10.x, 2.0.0 have dynamically linked openssl, build from source later during \`risedev d\`"
     enable_build_rust="true"
   else
-    tar -xvf risingwave-v"${OLD_VERSION}"-x86_64-unknown-linux.tar.gz
+    rm -f risingwave
+    tar -xvf "$archive"
     mv risingwave target/debug/risingwave
 
-    echo "--- Start cluster on tag $OLD_VERSION"
+    echo "--- Prepared cluster binary from tag $version"
     git config --global --add safe.directory /risingwave
   fi
 
   # Try to reuse the pre-built Java connector from the old release. Falls back
   # to building from source (inside `risedev d`) when the asset is unavailable.
   local build_connector="true"
-  if download_old_connector_artifact "$OLD_VERSION"; then
+  if download_release_connector_artifact "$version"; then
     build_connector="false"
   else
-    echo "Pre-built Java connector for $OLD_VERSION not found, build from source later during \`risedev d\`"
+    echo "Pre-built Java connector for $version not found, build from source later during \`risedev d\`"
   fi
 
-  configure_rw "$OLD_VERSION" "$enable_build_rust" "$build_connector"
+  configure_rw "$version" "$enable_build_rust" "$build_connector"
+}
+
+setup_old_cluster() {
+  setup_release_cluster "$OLD_VERSION"
+}
+
+upgrade_through_intermediate_versions() {
+  local version
+
+  while read -r version; do
+    [[ -z "$version" ]] && continue
+
+    echo "--- Upgrade through intermediate version $version"
+    setup_release_cluster "$version"
+    rm -rf .risingwave/config
+    ENABLE_UDF=1 ./risedev d full-without-monitoring
+    if version_le "$RECOVER_COMMAND_MIN_VERSION" "$version"; then
+      wait_for_recovery "$version"
+    fi
+    kill_cluster
+  done < <(get_intermediate_versions)
 }
 
 setup_new_cluster() {
@@ -182,6 +205,8 @@ main() {
 
   setup_old_cluster
   seed_old_cluster "$OLD_VERSION"
+
+  upgrade_through_intermediate_versions
 
   setup_new_cluster
   # Assume we use the latest version, so we just set to some large number.

--- a/ci/workflows/main-cron.yml
+++ b/ci/workflows/main-cron.yml
@@ -871,7 +871,8 @@ steps:
       - ./ci/plugins/upload-failure-logs
     matrix:
       setup:
-        # Test the 4 latest versions against the latest main.
+        # Test the 4 latest versions against the latest main. Each matrix entry
+        # upgrades through the latest stable patch of every intermediate release line.
         # e.g.
         # 1: 2.0.0
         # 2: 1.1.1
@@ -884,7 +885,8 @@ steps:
           - "2"
           - "3"
           - "4"
-    timeout_in_minutes: 30
+    # Older releases are upgraded through every intermediate release line.
+    timeout_in_minutes: 60
     retry: *auto-retry
 
   # Sqlsmith differential testing

--- a/ci/workflows/pull-request.yml
+++ b/ci/workflows/pull-request.yml
@@ -880,7 +880,8 @@ steps:
       - ./ci/plugins/upload-failure-logs
     matrix:
       setup:
-        # Test the 4 latest versions against the latest main.
+        # Test the 4 latest versions against the latest main. Each matrix entry
+        # upgrades through the latest stable patch of every intermediate release line.
         # e.g.
         # 1: 2.0.0
         # 2: 1.1.1
@@ -893,7 +894,8 @@ steps:
           - "2"
           - "3"
           - "4"
-    timeout_in_minutes: 25
+    # Older releases are upgraded through every intermediate release line.
+    timeout_in_minutes: 60
 
   # Sqlsmith differential testing
   - label: "Sqlsmith Differential Testing"

--- a/e2e_test/backwards-compat-tests/scripts/run_local.sh
+++ b/e2e_test/backwards-compat-tests/scripts/run_local.sh
@@ -89,12 +89,33 @@ setup_new_cluster() {
   git checkout $LATEST_BRANCH
 }
 
+upgrade_through_intermediate_versions() {
+  local version
+
+  while read -r version; do
+    [[ -z "$version" ]] && continue
+
+    echo "--- Upgrade through intermediate version $version"
+    rm -rf .risingwave/bin/risingwave
+    git checkout "v${version}"
+    configure_rw "$version"
+    rm -rf .risingwave/config
+    ENABLE_UDF=1 ./risedev d full-without-monitoring
+    if version_le "$RECOVER_COMMAND_MIN_VERSION" "$version"; then
+      wait_for_recovery "$version"
+    fi
+    kill_cluster
+  done < <(get_intermediate_versions)
+}
+
 main() {
   set -euo pipefail
   get_rw_versions
   setup_old_cluster
   configure_rw "$OLD_VERSION"
   seed_old_cluster "$OLD_VERSION"
+
+  upgrade_through_intermediate_versions
 
   setup_new_cluster
   configure_rw "99.99.99"

--- a/e2e_test/backwards-compat-tests/scripts/utils.sh
+++ b/e2e_test/backwards-compat-tests/scripts/utils.sh
@@ -6,16 +6,20 @@
 #
 # 1. Setup old cluster binaries.
 # 2. Seed old cluster.
-# 3. Setup new cluster binaries.
-# 4. Run validation on new cluster.
+# 3. Start the latest stable patch of each intermediate release line and wait
+#    for successful recovery.
+# 4. Setup new cluster binaries and wait for successful recovery.
+# 5. Run validation on new cluster.
 #
-# Steps 1,3 are specific to the execution environment, CI / Local.
-# This script only provides utilities for 2, 4.
+# Steps 1,3,4 are specific to the execution environment, CI / Local.
+# This script provides the shared version, recovery, seeding, and validation utilities.
 
 ################################### ENVIRONMENT CONFIG
 
-# Duration to wait for recovery (seconds)
-RECOVERY_DURATION=20
+# Maximum duration to wait for recovery (seconds)
+RECOVERY_TIMEOUT=300
+# The `RECOVER` command was introduced in this version.
+RECOVER_COMMAND_MIN_VERSION=1.9.0
 
 # Setup test directory
 TEST_DIR=.risingwave/e2e_test/backwards-compat-tests/
@@ -90,6 +94,27 @@ run_sql_scalar_db() {
   local db="$1"
   shift
   psql -h localhost -p 4566 -d "$db" -U root -At -c "$@" | tr -d '[:space:]'
+}
+
+wait_for_recovery() {
+  local version="$1"
+  local deadline=$((SECONDS + RECOVERY_TIMEOUT))
+  local recover_output=""
+
+  echo "--- Wait for a successful RECOVER command on version ${version}"
+  while (( SECONDS < deadline )); do
+    if recover_output=$(run_sql "RECOVER;" 2>&1); then
+      echo "$recover_output"
+      echo "--- RECOVER succeeded on version ${version}"
+      return
+    fi
+    echo "RECOVER is not ready on version ${version}; retry in 1 second"
+    sleep 1
+  done
+
+  echo "$recover_output"
+  echo "Timed out after ${RECOVERY_TIMEOUT}s waiting for RECOVER on version ${version}"
+  return 1
 }
 
 run_risectl() (
@@ -436,8 +461,7 @@ restart_meta_node() {
 
   echo "--- Restart meta node"
   $tmux_cmd respawn-window -k -t "risedev:${meta_window_index}"
-  echo "--- Wait ${RECOVERY_DURATION}s for recovery after meta restart"
-  sleep "$RECOVERY_DURATION"
+  wait_for_recovery "$NEW_VERSION after meta restart"
 }
 
 validate_cross_db_subscription_after_upgrade() {
@@ -552,6 +576,31 @@ get_rw_versions() {
   fi
 }
 
+get_intermediate_versions() {
+  local version
+  local series
+  local latest_series=""
+  local latest_version=""
+
+  while read -r version; do
+    if version_lt "$OLD_VERSION" "$version" && version_lt "$version" "$NEW_VERSION"; then
+      series="${version%.*}"
+      if [[ -n "$latest_series" && "$series" != "$latest_series" ]]; then
+        echo "$latest_version"
+      fi
+      latest_series="$series"
+      latest_version="$version"
+    fi
+  done < <(git tag --list 'v[0-9]*.[0-9]*.[0-9]*' \
+    | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' \
+    | sed 's/^v//' \
+    | sort -V)
+
+  if [[ -n "$latest_version" ]]; then
+    echo "$latest_version"
+  fi
+}
+
 # Setup table and materialized view.
 # Run updates and deletes on the table.
 # Get the results.
@@ -571,6 +620,9 @@ seed_old_cluster() {
   # `ENABLE_PYTHON_UDF` and `ENABLE_JS_UDF` are set for backwards-compartibility
   ENABLE_PYTHON_UDF=1 ENABLE_JS_UDF=1 ENABLE_UDF=1 ./risedev d full-without-monitoring && rm .risingwave/log/*
 
+  if version_le "$RECOVER_COMMAND_MIN_VERSION" "$OLD_VERSION"; then
+    wait_for_recovery "$OLD_VERSION"
+  fi
   check_version "$OLD_VERSION"
 
   echo "--- BASIC TEST: Seeding old cluster with data"
@@ -692,8 +744,7 @@ validate_new_cluster() {
   echo "--- Start cluster on latest"
   ENABLE_UDF=1 ./risedev d full-without-monitoring
 
-  echo "--- Wait ${RECOVERY_DURATION}s for Recovery on Old Cluster Data"
-  sleep $RECOVERY_DURATION
+  wait_for_recovery "$NEW_VERSION"
 
   check_version "$NEW_VERSION"
 


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

Update the backwards compatibility test to upgrade persisted state through the latest stable patch of each intermediate release line before starting the current version.

The CI and local runners now reuse release-cluster setup for every intermediate version and wait for a successful `RECOVER` command where supported. Recovery polling replaces fixed sleeps, and the Buildkite timeouts are extended to account for the additional upgrade steps.

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] I have added necessary unit tests and integration tests.
- [x] I have added test labels as necessary.
- [ ] I have added fuzzing tests or opened an issue to track them.
- [ ] My PR contains breaking changes.
- [ ] My PR changes performance-critical code, so I will run (micro) benchmarks and present the results.
- [ ] I have checked the release timeline and currently supported versions to determine which release branches need this PR.

## Documentation

- [ ] My PR needs documentation updates.

<details>
<summary><b>Release note</b></summary>

Not applicable; this change only affects CI and local backwards compatibility test infrastructure.

</details>
