### PR TITLE
fix(meta): support subscription migration on MySQL

### DIFF
--- a/src/meta/model/migration/src/m20260705_000000_subscription_dependent_object_fk.rs
+++ b/src/meta/model/migration/src/m20260705_000000_subscription_dependent_object_fk.rs
@@ -16,30 +16,32 @@ impl MigrationTrait for Migration {
         // `dependent_table_id` stores the object oid of the upstream table/MV. Add the missing
         // backend FK so deleting that object cascades stale subscription rows in the meta store.
         let backend = manager.get_database_backend();
-        match backend {
-            DatabaseBackend::MySql | DatabaseBackend::Postgres => {
-                manager
-                    .get_connection()
-                    .execute(Statement::from_string(
-                        backend,
-                        "DELETE FROM object WHERE oid IN (\
-                         SELECT subscription_id FROM subscription \
-                         WHERE dependent_table_id NOT IN (SELECT oid FROM object))",
-                    ))
-                    .await?;
-                manager
-                    .alter_table(
-                        Table::alter()
-                            .table(Subscription::Table)
-                            .add_foreign_key(&dependent_object_foreign_key())
-                            .to_owned(),
-                    )
-                    .await?;
+        let cleanup_sql = match backend {
+            DatabaseBackend::MySql => {
+                "DELETE o FROM object AS o \
+                 JOIN subscription AS s ON s.subscription_id = o.oid \
+                 LEFT JOIN object AS dependent ON dependent.oid = s.dependent_table_id \
+                 WHERE dependent.oid IS NULL"
             }
-            DatabaseBackend::Sqlite => {
-                recreate_table(manager, true).await?;
+            DatabaseBackend::Postgres => {
+                "DELETE FROM object WHERE oid IN (\
+                 SELECT subscription_id FROM subscription \
+                 WHERE dependent_table_id NOT IN (SELECT oid FROM object))"
             }
-        }
+            DatabaseBackend::Sqlite => return recreate_table(manager, true).await,
+        };
+        manager
+            .get_connection()
+            .execute(Statement::from_string(backend, cleanup_sql))
+            .await?;
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(Subscription::Table)
+                    .add_foreign_key(&dependent_object_foreign_key())
+                    .to_owned(),
+            )
+            .await?;
         Ok(())
     }
 


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

The subscription dependent-object migration was introduced by [#26171](https://github.com/risingwavelabs/risingwave/pull/26171) to delete orphan subscription objects before adding the new foreign key. Its cleanup statement deleted from `object` while a nested subquery also read `object`, which PostgreSQL accepts but MySQL rejects with error 1093. As a result, a meta node using a MySQL meta store could not start while applying the migration.

This PR uses a MySQL multi-table delete with a `LEFT JOIN` to find missing dependent objects. Deleting the subscription's object row triggers the existing `subscription.subscription_id -> object.oid ON DELETE CASCADE` foreign key, which removes the corresponding subscription row. The existing PostgreSQL cleanup and SQLite table-recreation paths remain unchanged.

Validation:

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features`
- Requested PostgreSQL- and MySQL-backed e2e coverage through `ci/run-e2e-test-other-backends`

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [x] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->

## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

</details>
