### PR TITLE
fix(meta): reject overlapping compaction output before apply

### DIFF
--- a/src/meta/src/hummock/manager/compaction/mod.rs
+++ b/src/meta/src/hummock/manager/compaction/mod.rs
@@ -170,15 +170,26 @@ fn can_concat_after_compact_task(
     let pos =
         target_ssts.partition_point(|sst| sst.key_range.cmp(&first.key_range) == Ordering::Less);
 
-    if pos == target_ssts.len() || last.key_range.cmp(&target_ssts[pos].key_range) == Ordering::Less
-    {
-        let validate_range = target_ssts[..pos]
-            .iter()
+    // The sorted outputs fit in the fast path only if the whole batch precedes its successor.
+    // Absence of a successor means "level end" only when `pos` is exactly the vector length.
+    let fits_before_next = target_ssts
+        .get(pos)
+        .map_or(pos == target_ssts.len(), |next| {
+            last.key_range.cmp(&next.key_range) == Ordering::Less
+        });
+
+    if fits_before_next {
+        // This is the same neighborhood validated after `level_insert_ssts` splices the sorted
+        // outputs at `pos`. Only three kinds of adjacency can be newly introduced: the previous
+        // target SST to the first output, adjacent outputs, and the last output to the next target
+        // SST. Build exactly that view without indexing `target_ssts` or moving its remaining SSTs.
+        let validate_range = pos
+            .checked_sub(1)
+            .and_then(|prev| target_ssts.get(prev))
             .copied()
+            .into_iter()
             .chain(sorted_insert.iter().copied())
-            .chain(target_ssts[pos..].iter().copied())
-            .skip(pos.saturating_sub(1))
-            .take(insert_table_infos.len() + 2)
+            .chain(target_ssts.get(pos).copied())
             .collect_vec();
         can_concat(&validate_range)
     } else {
@@ -1905,6 +1916,53 @@ mod compact_task_apply_tests {
     }
 
     #[test]
+    fn test_can_concat_after_compact_task_at_level_start() {
+        let target = Level {
+            level_type: PbLevelType::Nonoverlapping,
+            table_infos: vec![test_sst(1, "g", "h")],
+            ..Default::default()
+        };
+        let outputs = vec![test_sst(2, "a", "b"), test_sst(3, "d", "e")];
+
+        assert!(can_concat_after_compact_task(
+            &target,
+            &HashSet::new(),
+            &outputs,
+        ));
+    }
+
+    #[test]
+    fn test_can_concat_after_compact_task_with_empty_level() {
+        let target = Level {
+            level_type: PbLevelType::Nonoverlapping,
+            ..Default::default()
+        };
+        let outputs = vec![test_sst(1, "a", "b"), test_sst(2, "d", "e")];
+
+        assert!(can_concat_after_compact_task(
+            &target,
+            &HashSet::new(),
+            &outputs,
+        ));
+    }
+
+    #[test]
+    fn test_can_concat_after_compact_task_between_target_ssts() {
+        let target = Level {
+            level_type: PbLevelType::Nonoverlapping,
+            table_infos: vec![test_sst(1, "a", "b"), test_sst(2, "m", "n")],
+            ..Default::default()
+        };
+        let outputs = vec![test_sst(3, "g", "h"), test_sst(4, "d", "e")];
+
+        assert!(can_concat_after_compact_task(
+            &target,
+            &HashSet::new(),
+            &outputs,
+        ));
+    }
+
+    #[test]
     fn test_can_concat_after_compact_task_rejects_overlap() {
         let target = Level {
             level_type: PbLevelType::Nonoverlapping,
@@ -1916,6 +1974,37 @@ mod compact_task_apply_tests {
             &target,
             &HashSet::new(),
             &[test_sst(2, "c", "d")],
+        ));
+    }
+
+    #[test]
+    fn test_can_concat_after_compact_task_rejects_overlap_with_next_sst() {
+        let target = Level {
+            level_type: PbLevelType::Nonoverlapping,
+            table_infos: vec![test_sst(1, "g", "j")],
+            ..Default::default()
+        };
+
+        assert!(!can_concat_after_compact_task(
+            &target,
+            &HashSet::new(),
+            &[test_sst(2, "a", "h")],
+        ));
+    }
+
+    #[test]
+    fn test_can_concat_after_compact_task_rejects_overlapping_outputs() {
+        let target = Level {
+            level_type: PbLevelType::Nonoverlapping,
+            table_infos: vec![test_sst(1, "a", "b"), test_sst(2, "m", "n")],
+            ..Default::default()
+        };
+        let outputs = vec![test_sst(3, "d", "h"), test_sst(4, "g", "j")];
+
+        assert!(!can_concat_after_compact_task(
+            &target,
+            &HashSet::new(),
+            &outputs,
         ));
     }
 

--- a/src/meta/src/hummock/manager/compaction/mod.rs
+++ b/src/meta/src/hummock/manager/compaction/mod.rs
@@ -156,6 +156,10 @@ fn can_concat_after_compact_task(
         .collect_vec();
 
     if target_level.level_type == PbLevelType::Overlapping {
+        // An overlapping target is normally a whole L0 sub-level selected by tier or manual L0
+        // compaction, so removing task inputs usually leaves it empty. Preserve and validate any
+        // remaining SSTs because the actual apply path retains them before converting the target
+        // level to non-overlapping.
         target_ssts.extend(insert_table_infos);
         target_ssts.sort_by(|left, right| left.key_range.cmp(&right.key_range));
         return can_concat(&target_ssts);

--- a/src/meta/src/hummock/manager/compaction/mod.rs
+++ b/src/meta/src/hummock/manager/compaction/mod.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::cmp::Ordering;
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::ops::DerefMut;
 use std::sync::{Arc, LazyLock};
@@ -34,7 +35,7 @@ use risingwave_common::util::epoch::Epoch;
 use risingwave_hummock_sdk::compact_task::{CompactTask, ReportTask};
 use risingwave_hummock_sdk::compaction_group::StateTableId;
 use risingwave_hummock_sdk::compaction_group::hummock_version_ext::safe_epoch_table_watermarks_impl;
-use risingwave_hummock_sdk::level::Levels;
+use risingwave_hummock_sdk::level::{Level, Levels};
 use risingwave_hummock_sdk::sstable_info::SstableInfo;
 use risingwave_hummock_sdk::table_stats::{
     PbTableStatsMap, add_prost_table_stats_map, purge_prost_table_stats,
@@ -49,7 +50,7 @@ use risingwave_hummock_sdk::{
 use risingwave_pb::hummock::compact_task::{TaskStatus, TaskType};
 use risingwave_pb::hummock::subscribe_compaction_event_response::Event as ResponseEvent;
 use risingwave_pb::hummock::{
-    CompactTaskAssignment, CompactionConfig, PbCompactStatus, PbCompactTaskAssignment,
+    CompactTaskAssignment, CompactionConfig, PbCompactStatus, PbCompactTaskAssignment, PbLevelType,
     SubscribeCompactionEventRequest, TableOption, compact_task,
 };
 use thiserror_ext::AsReport;
@@ -138,6 +139,59 @@ enum BuiltCompactTask {
     PendingAssignment(CompactTask),
 }
 
+// Keep this check in sync with `level_insert_ssts` in `hummock_version_ext.rs`.
+fn can_concat_after_compact_task(
+    target_level: &Level,
+    delete_sst_ids: &HashSet<HummockSstableId>,
+    insert_table_infos: &[SstableInfo],
+) -> bool {
+    if insert_table_infos.is_empty() {
+        return true;
+    }
+
+    let mut target_ssts = target_level
+        .table_infos
+        .iter()
+        .filter(|sst| !delete_sst_ids.contains(&sst.sst_id))
+        .collect_vec();
+
+    if target_level.level_type == PbLevelType::Overlapping {
+        target_ssts.extend(insert_table_infos);
+        target_ssts.sort_by(|left, right| left.key_range.cmp(&right.key_range));
+        return can_concat(&target_ssts);
+    }
+
+    let sorted_insert = insert_table_infos
+        .iter()
+        .sorted_by(|left, right| left.key_range.cmp(&right.key_range))
+        .collect_vec();
+    let first = sorted_insert[0];
+    let last = sorted_insert[sorted_insert.len() - 1];
+    let pos =
+        target_ssts.partition_point(|sst| sst.key_range.cmp(&first.key_range) == Ordering::Less);
+
+    if pos >= target_ssts.len() || last.key_range.cmp(&target_ssts[pos].key_range) == Ordering::Less
+    {
+        let validate_range = target_ssts[..pos]
+            .iter()
+            .copied()
+            .chain(sorted_insert.iter().copied())
+            .chain(target_ssts[pos..].iter().copied())
+            .skip(pos.saturating_sub(1))
+            .take(insert_table_infos.len() + 2)
+            .collect_vec();
+        can_concat(&validate_range)
+    } else {
+        for sst in insert_table_infos {
+            let pos = target_ssts.partition_point(|target_sst| {
+                target_sst.key_range.cmp(&sst.key_range) == Ordering::Less
+            });
+            target_ssts.insert(pos, sst);
+        }
+        can_concat(&target_ssts)
+    }
+}
+
 impl HummockVersionTransaction<'_> {
     fn can_apply_compact_task(&self, compact_task: &CompactTask) -> bool {
         let levels = self
@@ -161,14 +215,11 @@ impl HummockVersionTransaction<'_> {
             .flat_map(|level| &level.table_infos)
             .map(|sst| sst.sst_id)
             .collect::<HashSet<_>>();
-        let mut target_ssts = target_level
-            .table_infos
-            .iter()
-            .filter(|sst| !input_sst_ids.contains(&sst.sst_id))
-            .chain(&compact_task.sorted_output_ssts)
-            .collect_vec();
-        target_ssts.sort_by(|left, right| left.key_range.cmp(&right.key_range));
-        can_concat(&target_ssts)
+        can_concat_after_compact_task(
+            target_level,
+            &input_sst_ids,
+            &compact_task.sorted_output_ssts,
+        )
     }
 
     fn apply_compact_task(&mut self, compact_task: &CompactTask) {
@@ -906,7 +957,7 @@ impl HummockManager {
                     compaction_group_id = %compact_task.compaction_group_id,
                     target_level = compact_task.target_level,
                     target_sub_level_id = compact_task.target_sub_level_id,
-                    "failed to apply compaction task because its output overlaps the target level"
+                    "rejecting stale compaction task because its output conflicts with the current target level"
                 );
                 false
             } else {

--- a/src/meta/src/hummock/manager/compaction/mod.rs
+++ b/src/meta/src/hummock/manager/compaction/mod.rs
@@ -138,8 +138,17 @@ enum BuiltCompactTask {
 }
 
 impl HummockVersionTransaction<'_> {
-    fn apply_compact_task(&mut self, compact_task: &CompactTask) {
+    fn apply_compact_task(&mut self, compact_task: &CompactTask) -> bool {
         let mut version_delta = self.new_delta();
+        let mut candidate_levels = version_delta
+            .latest_version()
+            .get_compaction_group_levels(compact_task.compaction_group_id)
+            .clone();
+        let member_table_ids = version_delta
+            .latest_version()
+            .state_table_info
+            .compaction_group_member_table_ids(compact_task.compaction_group_id)
+            .clone();
         let trivial_move = compact_task.is_trivial_move_task();
         version_delta.trivial_move = trivial_move;
 
@@ -183,7 +192,16 @@ impl HummockVersionTransaction<'_> {
         ));
 
         group_deltas.push(group_delta);
+        if !group_deltas.iter().all(|group_delta| {
+            let GroupDelta::IntraLevel(level_delta) = group_delta else {
+                unreachable!("compaction task should only produce intra-level deltas")
+            };
+            candidate_levels.try_apply_compact_ssts(level_delta, &member_table_ids)
+        }) {
+            return false;
+        }
         version_delta.pre_apply();
+        true
     }
 }
 
@@ -483,7 +501,13 @@ impl HummockManager {
                             ])
                             .inc();
 
-                        version.apply_compact_task(&compact_task);
+                        if !version.apply_compact_task(&compact_task) {
+                            return Err(anyhow::anyhow!(
+                                "meta-finished compaction task {} produced overlapping output",
+                                compact_task.task_id
+                            )
+                            .into());
+                        }
                         trivial_tasks.push(compact_task);
                         if trivial_tasks.len() >= self.env.opts.max_trivial_move_task_count_per_loop
                         {
@@ -866,9 +890,21 @@ impl HummockManager {
             } else {
                 false
             };
+            let is_success = if is_success && !version.apply_compact_task(&compact_task) {
+                compact_task.task_status = TaskStatus::InputOutdatedCanceled;
+                warn!(
+                    task_id = compact_task.task_id,
+                    compaction_group_id = %compact_task.compaction_group_id,
+                    target_level = compact_task.target_level,
+                    target_sub_level_id = compact_task.target_sub_level_id,
+                    "failed to apply compaction task because its output overlaps the target level"
+                );
+                false
+            } else {
+                is_success
+            };
             if is_success {
                 success_count += 1;
-                version.apply_compact_task(&compact_task);
                 if purge_prost_table_stats(
                     &mut version_stats.table_stats,
                     version.latest_version(),

--- a/src/meta/src/hummock/manager/compaction/mod.rs
+++ b/src/meta/src/hummock/manager/compaction/mod.rs
@@ -139,7 +139,8 @@ enum BuiltCompactTask {
     PendingAssignment(CompactTask),
 }
 
-// Keep this check in sync with `level_insert_ssts` in `hummock_version_ext.rs`.
+// Mirror the fast path in `level_insert_ssts`, but reject its unexpected per-SST insertion
+// fallback before applying the version delta.
 fn can_concat_after_compact_task(
     target_level: &Level,
     delete_sst_ids: &HashSet<HummockSstableId>,
@@ -182,31 +183,27 @@ fn can_concat_after_compact_task(
             last.key_range.cmp(&next.key_range) == Ordering::Less
         });
 
-    if fits_before_next {
-        // Match the neighborhood validated after `level_insert_ssts` inserts the outputs: the
-        // previous target SST, all outputs, and the next target SST.
-        let mut validate_range = Vec::with_capacity(sorted_insert.len() + 2);
-        if let Some(previous) = pos
-            .checked_sub(1)
-            .and_then(|index| target_ssts.get(index))
-            .copied()
-        {
-            validate_range.push(previous);
-        }
-        validate_range.extend(sorted_insert.iter().copied());
-        if let Some(next) = target_ssts.get(pos).copied() {
-            validate_range.push(next);
-        }
-        can_concat(&validate_range)
-    } else {
-        for sst in insert_table_infos {
-            let pos = target_ssts.partition_point(|target_sst| {
-                target_sst.key_range.cmp(&sst.key_range) == Ordering::Less
-            });
-            target_ssts.insert(pos, sst);
-        }
-        can_concat(&target_ssts)
+    if !fits_before_next {
+        // A valid task replaces a contiguous target range, so all sorted outputs must fit into a
+        // single gap. Reject interleaved output instead of using `level_insert_ssts`' fallback.
+        return false;
     }
+
+    // Match the neighborhood validated after `level_insert_ssts` inserts the outputs: the
+    // previous target SST, all outputs, and the next target SST.
+    let mut validate_range = Vec::with_capacity(sorted_insert.len() + 2);
+    if let Some(previous) = pos
+        .checked_sub(1)
+        .and_then(|index| target_ssts.get(index))
+        .copied()
+    {
+        validate_range.push(previous);
+    }
+    validate_range.extend(sorted_insert.iter().copied());
+    if let Some(next) = target_ssts.get(pos).copied() {
+        validate_range.push(next);
+    }
+    can_concat(&validate_range)
 }
 
 impl HummockVersionTransaction<'_> {
@@ -1962,6 +1959,22 @@ mod compact_task_apply_tests {
         let outputs = vec![test_sst(3, "g", "h"), test_sst(4, "d", "e")];
 
         assert!(can_concat_after_compact_task(
+            &target,
+            &HashSet::new(),
+            &outputs,
+        ));
+    }
+
+    #[test]
+    fn test_can_concat_after_compact_task_rejects_interleaved_outputs() {
+        let target = Level {
+            level_type: PbLevelType::Nonoverlapping,
+            table_infos: vec![test_sst(1, "f", "g")],
+            ..Default::default()
+        };
+        let outputs = vec![test_sst(2, "h", "i"), test_sst(3, "d", "e")];
+
+        assert!(!can_concat_after_compact_task(
             &target,
             &HashSet::new(),
             &outputs,

--- a/src/meta/src/hummock/manager/compaction/mod.rs
+++ b/src/meta/src/hummock/manager/compaction/mod.rs
@@ -43,7 +43,8 @@ use risingwave_hummock_sdk::table_watermark::TableWatermarks;
 use risingwave_hummock_sdk::version::{GroupDelta, IntraLevelDelta};
 use risingwave_hummock_sdk::{
     CompactionGroupId, HummockCompactionTaskId, HummockContextId, HummockSstableId,
-    HummockSstableObjectId, HummockVersionId, compact_task_to_string, statistics_compact_task,
+    HummockSstableObjectId, HummockVersionId, can_concat, compact_task_to_string,
+    statistics_compact_task,
 };
 use risingwave_pb::hummock::compact_task::{TaskStatus, TaskType};
 use risingwave_pb::hummock::subscribe_compaction_event_response::Event as ResponseEvent;
@@ -138,17 +139,40 @@ enum BuiltCompactTask {
 }
 
 impl HummockVersionTransaction<'_> {
-    fn apply_compact_task(&mut self, compact_task: &CompactTask) -> bool {
+    fn can_apply_compact_task(&self, compact_task: &CompactTask) -> bool {
+        let levels = self
+            .latest_version()
+            .levels
+            .get(&compact_task.compaction_group_id)
+            .unwrap();
+        let target_level = if compact_task.target_level == 0 {
+            levels
+                .l0
+                .sub_levels
+                .iter()
+                .find(|level| level.sub_level_id == compact_task.target_sub_level_id)
+                .unwrap()
+        } else {
+            levels.get_level(compact_task.target_level as usize)
+        };
+        let input_sst_ids = compact_task
+            .input_ssts
+            .iter()
+            .flat_map(|level| &level.table_infos)
+            .map(|sst| sst.sst_id)
+            .collect::<HashSet<_>>();
+        let mut target_ssts = target_level
+            .table_infos
+            .iter()
+            .filter(|sst| !input_sst_ids.contains(&sst.sst_id))
+            .chain(&compact_task.sorted_output_ssts)
+            .collect_vec();
+        target_ssts.sort_by(|left, right| left.key_range.cmp(&right.key_range));
+        can_concat(&target_ssts)
+    }
+
+    fn apply_compact_task(&mut self, compact_task: &CompactTask) {
         let mut version_delta = self.new_delta();
-        let mut candidate_levels = version_delta
-            .latest_version()
-            .get_compaction_group_levels(compact_task.compaction_group_id)
-            .clone();
-        let member_table_ids = version_delta
-            .latest_version()
-            .state_table_info
-            .compaction_group_member_table_ids(compact_task.compaction_group_id)
-            .clone();
         let trivial_move = compact_task.is_trivial_move_task();
         version_delta.trivial_move = trivial_move;
 
@@ -192,16 +216,7 @@ impl HummockVersionTransaction<'_> {
         ));
 
         group_deltas.push(group_delta);
-        if !group_deltas.iter().all(|group_delta| {
-            let GroupDelta::IntraLevel(level_delta) = group_delta else {
-                unreachable!("compaction task should only produce intra-level deltas")
-            };
-            candidate_levels.try_apply_compact_ssts(level_delta, &member_table_ids)
-        }) {
-            return false;
-        }
         version_delta.pre_apply();
-        true
     }
 }
 
@@ -501,13 +516,7 @@ impl HummockManager {
                             ])
                             .inc();
 
-                        if !version.apply_compact_task(&compact_task) {
-                            return Err(anyhow::anyhow!(
-                                "meta-finished compaction task {} produced overlapping output",
-                                compact_task.task_id
-                            )
-                            .into());
-                        }
+                        version.apply_compact_task(&compact_task);
                         trivial_tasks.push(compact_task);
                         if trivial_tasks.len() >= self.env.opts.max_trivial_move_task_count_per_loop
                         {
@@ -890,7 +899,7 @@ impl HummockManager {
             } else {
                 false
             };
-            let is_success = if is_success && !version.apply_compact_task(&compact_task) {
+            let is_success = if is_success && !version.can_apply_compact_task(&compact_task) {
                 compact_task.task_status = TaskStatus::InputOutdatedCanceled;
                 warn!(
                     task_id = compact_task.task_id,
@@ -905,6 +914,7 @@ impl HummockManager {
             };
             if is_success {
                 success_count += 1;
+                version.apply_compact_task(&compact_task);
                 if purge_prost_table_stats(
                     &mut version_stats.table_stats,
                     version.latest_version(),

--- a/src/meta/src/hummock/manager/compaction/mod.rs
+++ b/src/meta/src/hummock/manager/compaction/mod.rs
@@ -186,6 +186,11 @@ fn can_concat_after_compact_task(
     if !fits_before_next {
         // A valid task replaces a contiguous target range, so all sorted outputs must fit into a
         // single gap. Reject interleaved output instead of using `level_insert_ssts`' fallback.
+        warn!(
+            insert = ?insert_table_infos,
+            level = ?target_ssts,
+            "rejecting interleaved compaction output"
+        );
         return false;
     }
 

--- a/src/meta/src/hummock/manager/compaction/mod.rs
+++ b/src/meta/src/hummock/manager/compaction/mod.rs
@@ -183,18 +183,20 @@ fn can_concat_after_compact_task(
         });
 
     if fits_before_next {
-        // This is the same neighborhood validated after `level_insert_ssts` splices the sorted
-        // outputs at `pos`. Only three kinds of adjacency can be newly introduced: the previous
-        // target SST to the first output, adjacent outputs, and the last output to the next target
-        // SST. Build exactly that view without indexing `target_ssts` or moving its remaining SSTs.
-        let validate_range = pos
+        // Match the neighborhood validated after `level_insert_ssts` inserts the outputs: the
+        // previous target SST, all outputs, and the next target SST.
+        let mut validate_range = Vec::with_capacity(sorted_insert.len() + 2);
+        if let Some(previous) = pos
             .checked_sub(1)
-            .and_then(|prev| target_ssts.get(prev))
+            .and_then(|index| target_ssts.get(index))
             .copied()
-            .into_iter()
-            .chain(sorted_insert.iter().copied())
-            .chain(target_ssts.get(pos).copied())
-            .collect_vec();
+        {
+            validate_range.push(previous);
+        }
+        validate_range.extend(sorted_insert.iter().copied());
+        if let Some(next) = target_ssts.get(pos).copied() {
+            validate_range.push(next);
+        }
         can_concat(&validate_range)
     } else {
         for sst in insert_table_infos {

--- a/src/meta/src/hummock/manager/compaction/mod.rs
+++ b/src/meta/src/hummock/manager/compaction/mod.rs
@@ -170,7 +170,7 @@ fn can_concat_after_compact_task(
     let pos =
         target_ssts.partition_point(|sst| sst.key_range.cmp(&first.key_range) == Ordering::Less);
 
-    if pos >= target_ssts.len() || last.key_range.cmp(&target_ssts[pos].key_range) == Ordering::Less
+    if pos == target_ssts.len() || last.key_range.cmp(&target_ssts[pos].key_range) == Ordering::Less
     {
         let validate_range = target_ssts[..pos]
             .iter()
@@ -194,20 +194,28 @@ fn can_concat_after_compact_task(
 
 impl HummockVersionTransaction<'_> {
     fn can_apply_compact_task(&self, compact_task: &CompactTask) -> bool {
-        let levels = self
+        if compact_task.sorted_output_ssts.is_empty() {
+            return true;
+        }
+
+        let Some(levels) = self
             .latest_version()
             .levels
             .get(&compact_task.compaction_group_id)
-            .unwrap();
+        else {
+            return false;
+        };
         let target_level = if compact_task.target_level == 0 {
             levels
                 .l0
                 .sub_levels
                 .iter()
                 .find(|level| level.sub_level_id == compact_task.target_sub_level_id)
-                .unwrap()
         } else {
-            levels.get_level(compact_task.target_level as usize)
+            levels.levels.get(compact_task.target_level as usize - 1)
+        };
+        let Some(target_level) = target_level else {
+            return false;
         };
         let input_sst_ids = compact_task
             .input_ssts
@@ -1850,6 +1858,86 @@ impl GroupStateValidator {
         }
 
         Self::check_single_group_emergency(levels, compaction_config)
+    }
+}
+
+#[cfg(test)]
+mod compact_task_apply_tests {
+    use risingwave_common::catalog::TableId;
+    use risingwave_common::hash::VirtualNode;
+    use risingwave_hummock_sdk::key::{FullKey, gen_key_from_str};
+    use risingwave_pb::hummock::{KeyRange as PbKeyRange, SstableInfo as PbSstableInfo};
+
+    use super::*;
+
+    fn test_key(key: &str) -> Vec<u8> {
+        FullKey::for_test(TableId::new(1), gen_key_from_str(VirtualNode::ZERO, key), 0).encode()
+    }
+
+    fn test_sst(sst_id: u64, left: &str, right: &str) -> SstableInfo {
+        PbSstableInfo {
+            object_id: sst_id.into(),
+            sst_id: sst_id.into(),
+            key_range: Some(PbKeyRange {
+                left: test_key(left),
+                right: test_key(right),
+                right_exclusive: true,
+            }),
+            ..Default::default()
+        }
+        .into()
+    }
+
+    #[test]
+    fn test_can_concat_after_compact_task_at_level_end() {
+        let target = Level {
+            level_type: PbLevelType::Nonoverlapping,
+            table_infos: vec![test_sst(1, "a", "b")],
+            ..Default::default()
+        };
+        let outputs = vec![test_sst(2, "d", "e"), test_sst(3, "g", "h")];
+
+        assert!(can_concat_after_compact_task(
+            &target,
+            &HashSet::new(),
+            &outputs,
+        ));
+    }
+
+    #[test]
+    fn test_can_concat_after_compact_task_rejects_overlap() {
+        let target = Level {
+            level_type: PbLevelType::Nonoverlapping,
+            table_infos: vec![test_sst(1, "a", "e")],
+            ..Default::default()
+        };
+
+        assert!(!can_concat_after_compact_task(
+            &target,
+            &HashSet::new(),
+            &[test_sst(2, "c", "d")],
+        ));
+    }
+
+    #[test]
+    fn test_can_concat_after_compact_task_removes_inputs_first() {
+        let target = Level {
+            level_type: PbLevelType::Overlapping,
+            table_infos: vec![test_sst(1, "a", "z")],
+            ..Default::default()
+        };
+        let outputs = vec![test_sst(2, "a", "b"), test_sst(3, "d", "e")];
+
+        assert!(!can_concat_after_compact_task(
+            &target,
+            &HashSet::new(),
+            &outputs,
+        ));
+        assert!(can_concat_after_compact_task(
+            &target,
+            &HashSet::from([1.into()]),
+            &outputs,
+        ));
     }
 }
 

--- a/src/meta/src/hummock/manager/tests.rs
+++ b/src/meta/src/hummock/manager/tests.rs
@@ -3677,42 +3677,40 @@ async fn test_time_travel_vacuum_with_cross_database_epoch_order() {
 
     let mut version_10 = HummockVersion::default();
     version_10.id = 10.into();
-    version_10.state_table_info =
-        HummockVersionStateTableInfo::from_protobuf(&HashMap::from([
-            (
-                table_a,
-                StateTableInfo {
-                    committed_epoch: 300,
-                    compaction_group_id: 1.into(),
-                },
-            ),
-            (
-                table_b,
-                StateTableInfo {
-                    committed_epoch: 100,
-                    compaction_group_id: 1.into(),
-                },
-            ),
-        ]));
+    version_10.state_table_info = HummockVersionStateTableInfo::from_protobuf(&HashMap::from([
+        (
+            table_a,
+            StateTableInfo {
+                committed_epoch: 300,
+                compaction_group_id: 1.into(),
+            },
+        ),
+        (
+            table_b,
+            StateTableInfo {
+                committed_epoch: 100,
+                compaction_group_id: 1.into(),
+            },
+        ),
+    ]));
     let mut version_11 = version_10.clone();
     version_11.id = 11.into();
-    version_11.state_table_info =
-        HummockVersionStateTableInfo::from_protobuf(&HashMap::from([
-            (
-                table_a,
-                StateTableInfo {
-                    committed_epoch: 300,
-                    compaction_group_id: 1.into(),
-                },
-            ),
-            (
-                table_b,
-                StateTableInfo {
-                    committed_epoch: 200,
-                    compaction_group_id: 1.into(),
-                },
-            ),
-        ]));
+    version_11.state_table_info = HummockVersionStateTableInfo::from_protobuf(&HashMap::from([
+        (
+            table_a,
+            StateTableInfo {
+                committed_epoch: 300,
+                compaction_group_id: 1.into(),
+            },
+        ),
+        (
+            table_b,
+            StateTableInfo {
+                committed_epoch: 200,
+                compaction_group_id: 1.into(),
+            },
+        ),
+    ]));
     for version in [&version_10, &version_11] {
         hummock_time_travel_version::Entity::insert(hummock_time_travel_version::ActiveModel {
             version_id: Set(version.id),

--- a/src/storage/hummock_sdk/src/compaction_group/hummock_version_ext.rs
+++ b/src/storage/hummock_sdk/src/compaction_group/hummock_version_ext.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::borrow::Borrow;
 use std::cmp::Ordering;
 use std::collections::hash_map::Entry;
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
@@ -1072,25 +1073,6 @@ impl Levels {
         level_delta: &IntraLevelDeltaCommon<SstableInfo>,
         member_table_ids: &BTreeSet<TableId>,
     ) {
-        assert!(
-            self.try_apply_compact_ssts(level_delta, member_table_ids),
-            "sstable ids: {:?}",
-            level_delta
-                .inserted_table_infos
-                .iter()
-                .map(|sst| sst.sst_id)
-                .collect_vec()
-        );
-    }
-
-    /// Applies a compaction delta and returns false when it breaks a non-overlapping level.
-    /// The caller must discard this `Levels` value after a false return because it may be partially
-    /// updated.
-    pub fn try_apply_compact_ssts(
-        &mut self,
-        level_delta: &IntraLevelDeltaCommon<SstableInfo>,
-        member_table_ids: &BTreeSet<TableId>,
-    ) -> bool {
         let IntraLevelDeltaCommon {
             level_idx,
             l0_sub_level_id,
@@ -1117,7 +1099,7 @@ impl Levels {
                 ?delete_sst_ids_set,
                 "This VersionDelta may be committed by an expired compact task. Please check it."
             );
-            return true;
+            return;
         }
         if !delete_sst_ids_set.is_empty() {
             if *level_idx == 0 {
@@ -1161,9 +1143,7 @@ impl Levels {
                     // Only change vnode_partition_count for level which update all sst files in this compact task.
                     l0.sub_levels[index].vnode_partition_count = new_vnode_partition_count;
                 }
-                if !level_insert_ssts(&mut l0.sub_levels[index], insert_table_infos) {
-                    return false;
-                }
+                level_insert_ssts(&mut l0.sub_levels[index], insert_table_infos);
             } else {
                 let idx = insert_sst_level_id as usize - 1;
                 if self.levels[idx].table_infos.is_empty()
@@ -1178,12 +1158,9 @@ impl Levels {
                 {
                     self.levels[idx].vnode_partition_count = 0;
                 }
-                if !level_insert_ssts(&mut self.levels[idx], insert_table_infos) {
-                    return false;
-                }
+                level_insert_ssts(&mut self.levels[idx], insert_table_infos);
             }
         }
-        true
     }
 
     /// Prune specified table ids from all SST metadata, remove emptied SSTs and sub-levels,
@@ -1490,7 +1467,13 @@ impl OverlappingLevel {
     }
 }
 
-fn level_insert_ssts(operand: &mut Level, insert_table_infos: &Vec<SstableInfo>) -> bool {
+fn level_insert_ssts(operand: &mut Level, insert_table_infos: &Vec<SstableInfo>) {
+    fn display_sstable_infos(ssts: &[impl Borrow<SstableInfo>]) -> String {
+        format!(
+            "sstable ids: {:?}",
+            ssts.iter().map(|s| s.borrow().sst_id).collect_vec()
+        )
+    }
     operand.total_file_size += insert_table_infos
         .iter()
         .map(|sst| sst.sst_size)
@@ -1507,9 +1490,11 @@ fn level_insert_ssts(operand: &mut Level, insert_table_infos: &Vec<SstableInfo>)
         operand
             .table_infos
             .sort_by(|sst1, sst2| sst1.key_range.cmp(&sst2.key_range));
-        if !can_concat(&operand.table_infos) {
-            return false;
-        }
+        assert!(
+            can_concat(&operand.table_infos),
+            "{}",
+            display_sstable_infos(&operand.table_infos)
+        );
     } else if !insert_table_infos.is_empty() {
         let sorted_insert: Vec<_> = insert_table_infos
             .iter()
@@ -1532,9 +1517,11 @@ fn level_insert_ssts(operand: &mut Level, insert_table_infos: &Vec<SstableInfo>)
                 .skip(pos.saturating_sub(1))
                 .take(insert_table_infos.len() + 2)
                 .collect_vec();
-            if !can_concat(&validate_range) {
-                return false;
-            }
+            assert!(
+                can_concat(&validate_range),
+                "{}",
+                display_sstable_infos(&validate_range),
+            );
         } else {
             // If this branch is reached, it indicates some unexpected behavior in compaction.
             // Here we issue a warning and fall back to insert one by one.
@@ -1545,12 +1532,13 @@ fn level_insert_ssts(operand: &mut Level, insert_table_infos: &Vec<SstableInfo>)
                     .partition_point(|b| b.key_range.cmp(&i.key_range) == Ordering::Less);
                 operand.table_infos.insert(pos, i.clone());
             }
-            if !can_concat(&operand.table_infos) {
-                return false;
-            }
+            assert!(
+                can_concat(&operand.table_infos),
+                "{}",
+                display_sstable_infos(&operand.table_infos)
+            );
         }
     }
-    true
 }
 
 pub fn object_size_map(version: &HummockVersion) -> HashMap<HummockObjectId, u64> {
@@ -1914,56 +1902,6 @@ mod tests {
                 ]),
                 ..Default::default()
             }
-        );
-    }
-
-    #[test]
-    fn test_try_apply_compact_ssts_rejects_overlap_on_candidate() {
-        let old_sst = gen_sstable_info(1, vec![1], test_epoch(1));
-        let mut levels = build_initial_compaction_group_levels(
-            1,
-            &CompactionConfig {
-                max_level: 1,
-                ..Default::default()
-            },
-        );
-        levels.levels[0] = Level {
-            level_idx: 1,
-            level_type: LevelType::Nonoverlapping,
-            table_infos: vec![old_sst.clone()],
-            total_file_size: old_sst.sst_size,
-            ..Default::default()
-        };
-        let version = HummockVersion {
-            id: HummockVersionId::new(0),
-            levels: HashMap::from([(1.into(), levels)]),
-            ..Default::default()
-        };
-        let mut candidate = version.get_compaction_group_levels(1.into()).clone();
-        assert!(candidate.try_apply_compact_ssts(
-            &IntraLevelDelta::new(1, 0, HashSet::from([old_sst.sst_id]), vec![], 0, 0,),
-            &Default::default(),
-        ));
-        assert!(!candidate.try_apply_compact_ssts(
-            &IntraLevelDelta::new(
-                1,
-                0,
-                HashSet::new(),
-                vec![
-                    gen_sstable_info(2, vec![1], test_epoch(1)),
-                    gen_sstable_info(3, vec![1], test_epoch(1)),
-                ],
-                0,
-                0,
-            ),
-            &Default::default(),
-        ));
-        assert_eq!(
-            version
-                .get_compaction_group_levels(1.into())
-                .get_level(1)
-                .table_infos,
-            vec![old_sst]
         );
     }
 

--- a/src/storage/hummock_sdk/src/compaction_group/hummock_version_ext.rs
+++ b/src/storage/hummock_sdk/src/compaction_group/hummock_version_ext.rs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::borrow::Borrow;
 use std::cmp::Ordering;
 use std::collections::hash_map::Entry;
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
@@ -1073,6 +1072,25 @@ impl Levels {
         level_delta: &IntraLevelDeltaCommon<SstableInfo>,
         member_table_ids: &BTreeSet<TableId>,
     ) {
+        assert!(
+            self.try_apply_compact_ssts(level_delta, member_table_ids),
+            "sstable ids: {:?}",
+            level_delta
+                .inserted_table_infos
+                .iter()
+                .map(|sst| sst.sst_id)
+                .collect_vec()
+        );
+    }
+
+    /// Applies a compaction delta and returns false when it breaks a non-overlapping level.
+    /// The caller must discard this `Levels` value after a false return because it may be partially
+    /// updated.
+    pub fn try_apply_compact_ssts(
+        &mut self,
+        level_delta: &IntraLevelDeltaCommon<SstableInfo>,
+        member_table_ids: &BTreeSet<TableId>,
+    ) -> bool {
         let IntraLevelDeltaCommon {
             level_idx,
             l0_sub_level_id,
@@ -1099,7 +1117,7 @@ impl Levels {
                 ?delete_sst_ids_set,
                 "This VersionDelta may be committed by an expired compact task. Please check it."
             );
-            return;
+            return true;
         }
         if !delete_sst_ids_set.is_empty() {
             if *level_idx == 0 {
@@ -1143,7 +1161,9 @@ impl Levels {
                     // Only change vnode_partition_count for level which update all sst files in this compact task.
                     l0.sub_levels[index].vnode_partition_count = new_vnode_partition_count;
                 }
-                level_insert_ssts(&mut l0.sub_levels[index], insert_table_infos);
+                if !level_insert_ssts(&mut l0.sub_levels[index], insert_table_infos) {
+                    return false;
+                }
             } else {
                 let idx = insert_sst_level_id as usize - 1;
                 if self.levels[idx].table_infos.is_empty()
@@ -1158,9 +1178,12 @@ impl Levels {
                 {
                     self.levels[idx].vnode_partition_count = 0;
                 }
-                level_insert_ssts(&mut self.levels[idx], insert_table_infos);
+                if !level_insert_ssts(&mut self.levels[idx], insert_table_infos) {
+                    return false;
+                }
             }
         }
+        true
     }
 
     /// Prune specified table ids from all SST metadata, remove emptied SSTs and sub-levels,
@@ -1467,13 +1490,7 @@ impl OverlappingLevel {
     }
 }
 
-fn level_insert_ssts(operand: &mut Level, insert_table_infos: &Vec<SstableInfo>) {
-    fn display_sstable_infos(ssts: &[impl Borrow<SstableInfo>]) -> String {
-        format!(
-            "sstable ids: {:?}",
-            ssts.iter().map(|s| s.borrow().sst_id).collect_vec()
-        )
-    }
+fn level_insert_ssts(operand: &mut Level, insert_table_infos: &Vec<SstableInfo>) -> bool {
     operand.total_file_size += insert_table_infos
         .iter()
         .map(|sst| sst.sst_size)
@@ -1490,11 +1507,9 @@ fn level_insert_ssts(operand: &mut Level, insert_table_infos: &Vec<SstableInfo>)
         operand
             .table_infos
             .sort_by(|sst1, sst2| sst1.key_range.cmp(&sst2.key_range));
-        assert!(
-            can_concat(&operand.table_infos),
-            "{}",
-            display_sstable_infos(&operand.table_infos)
-        );
+        if !can_concat(&operand.table_infos) {
+            return false;
+        }
     } else if !insert_table_infos.is_empty() {
         let sorted_insert: Vec<_> = insert_table_infos
             .iter()
@@ -1517,11 +1532,9 @@ fn level_insert_ssts(operand: &mut Level, insert_table_infos: &Vec<SstableInfo>)
                 .skip(pos.saturating_sub(1))
                 .take(insert_table_infos.len() + 2)
                 .collect_vec();
-            assert!(
-                can_concat(&validate_range),
-                "{}",
-                display_sstable_infos(&validate_range),
-            );
+            if !can_concat(&validate_range) {
+                return false;
+            }
         } else {
             // If this branch is reached, it indicates some unexpected behavior in compaction.
             // Here we issue a warning and fall back to insert one by one.
@@ -1532,13 +1545,12 @@ fn level_insert_ssts(operand: &mut Level, insert_table_infos: &Vec<SstableInfo>)
                     .partition_point(|b| b.key_range.cmp(&i.key_range) == Ordering::Less);
                 operand.table_infos.insert(pos, i.clone());
             }
-            assert!(
-                can_concat(&operand.table_infos),
-                "{}",
-                display_sstable_infos(&operand.table_infos)
-            );
+            if !can_concat(&operand.table_infos) {
+                return false;
+            }
         }
     }
+    true
 }
 
 pub fn object_size_map(version: &HummockVersion) -> HashMap<HummockObjectId, u64> {
@@ -1902,6 +1914,56 @@ mod tests {
                 ]),
                 ..Default::default()
             }
+        );
+    }
+
+    #[test]
+    fn test_try_apply_compact_ssts_rejects_overlap_on_candidate() {
+        let old_sst = gen_sstable_info(1, vec![1], test_epoch(1));
+        let mut levels = build_initial_compaction_group_levels(
+            1,
+            &CompactionConfig {
+                max_level: 1,
+                ..Default::default()
+            },
+        );
+        levels.levels[0] = Level {
+            level_idx: 1,
+            level_type: LevelType::Nonoverlapping,
+            table_infos: vec![old_sst.clone()],
+            total_file_size: old_sst.sst_size,
+            ..Default::default()
+        };
+        let version = HummockVersion {
+            id: HummockVersionId::new(0),
+            levels: HashMap::from([(1.into(), levels)]),
+            ..Default::default()
+        };
+        let mut candidate = version.get_compaction_group_levels(1.into()).clone();
+        assert!(candidate.try_apply_compact_ssts(
+            &IntraLevelDelta::new(1, 0, HashSet::from([old_sst.sst_id]), vec![], 0, 0,),
+            &Default::default(),
+        ));
+        assert!(!candidate.try_apply_compact_ssts(
+            &IntraLevelDelta::new(
+                1,
+                0,
+                HashSet::new(),
+                vec![
+                    gen_sstable_info(2, vec![1], test_epoch(1)),
+                    gen_sstable_info(3, vec![1], test_epoch(1)),
+                ],
+                0,
+                0,
+            ),
+            &Default::default(),
+        ));
+        assert_eq!(
+            version
+                .get_compaction_group_levels(1.into())
+                .get_level(1)
+                .table_infos,
+            vec![old_sst]
         );
     }
 


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

Add a temporary fail-closed guard for compaction reports on the `v2.8.4-pg-vector-toast-nectar` branch.

Before applying a successful reported task, Meta checks the target level or exact L0 sub-level using the same decision tree as `level_insert_ssts`: remove task inputs first; fully sort an overlapping level; otherwise sort only the outputs, locate their insertion point, and validate the local SST window, with the same insert-one-by-one fallback for interleaved outputs.

If the existing `can_concat` predicate returns `false`, Meta treats the task as a stale plan, marks it as `InputOutdatedCanceled`, and skips the version and table-stat updates instead of reaching the assertion in `level_insert_ssts`. The lower-level assertion and the existing version-delta apply path remain unchanged as invariant guards for other callers.

This is a narrow report-time safety patch. It does not backport the picker-time in-progress target-range tracking from #25946, so rejected work may be retried after replanning.

## Checklist

- [x] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove it in a follow-up PR -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [x] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

</details>
