### PR TITLE
feat(cdc): report non-parallelized backfill progress

### DIFF
--- a/proto/meta.proto
+++ b/proto/meta.proto
@@ -451,6 +451,11 @@ message ListCdcProgressResponse {
     uint64 split_total_count = 1;
     uint64 split_backfilled_count = 2;
     uint64 split_completed_count = 3;
+    // Only set for non-parallelized CDC backfill.
+    optional uint64 backfilled_row_count = 4;
+    // Best-effort estimate from upstream database statistics. Only set for
+    // non-parallelized CDC backfill when the estimate is available.
+    optional uint64 estimated_row_count = 5;
   }
   map<uint32, CdcProgress> cdc_progress = 1;
 }

--- a/proto/stream_service.proto
+++ b/proto/stream_service.proto
@@ -73,6 +73,10 @@ message BarrierCompleteResponse {
     int64 split_id_end_inclusive = 5;
     uint64 generation = 6;
     uint32 fragment_id = 7;
+    // Only set for non-parallelized CDC backfill.
+    optional uint64 backfilled_row_count = 8;
+    // Best-effort estimate from upstream database statistics.
+    optional uint64 estimated_row_count = 9;
   }
   string request_id = 1;
   common.Status status = 2;

--- a/proto/stream_service.proto
+++ b/proto/stream_service.proto
@@ -72,6 +72,10 @@ message BarrierCompleteResponse {
     int64 split_id_end_inclusive = 5;
     uint64 generation = 6;
     uint32 fragment_id = 7;
+    // Only set for non-parallelized CDC backfill.
+    optional uint64 backfilled_row_count = 8;
+    // Best-effort estimate from upstream database statistics.
+    optional uint64 estimated_row_count = 9;
   }
   string request_id = 1;
   common.Status status = 2;

--- a/src/connector/src/source/cdc/external/mod.rs
+++ b/src/connector/src/source/cdc/external/mod.rs
@@ -233,6 +233,17 @@ pub type CdcOffsetParseFunc = Box<dyn Fn(&str) -> ConnectorResult<CdcOffset> + S
 pub trait ExternalTableReader: Sized {
     async fn current_cdc_offset(&self) -> ConnectorResult<CdcOffset>;
 
+    /// Returns a best-effort row count estimate from upstream database statistics.
+    ///
+    /// The estimate must not scan the upstream table. Callers should treat both an
+    /// unavailable estimate and an error as non-fatal for snapshot backfill.
+    async fn estimated_row_count(
+        &self,
+        _table_name: &SchemaTableName,
+    ) -> ConnectorResult<Option<u64>> {
+        Ok(None)
+    }
+
     // Currently, MySQL cdc uses a connection pool to manage connections to MySQL, and other CDC processes do not require the disconnect step for now.
 
     async fn disconnect(self) -> ConnectorResult<()> {
@@ -350,6 +361,22 @@ impl ExternalTableReader for ExternalTableReaderImpl {
             ExternalTableReaderImpl::Postgres(postgres) => postgres.current_cdc_offset().await,
             ExternalTableReaderImpl::SqlServer(sql_server) => sql_server.current_cdc_offset().await,
             ExternalTableReaderImpl::Mock(mock) => mock.current_cdc_offset().await,
+        }
+    }
+
+    async fn estimated_row_count(
+        &self,
+        table_name: &SchemaTableName,
+    ) -> ConnectorResult<Option<u64>> {
+        match self {
+            ExternalTableReaderImpl::MySql(mysql) => mysql.estimated_row_count(table_name).await,
+            ExternalTableReaderImpl::Postgres(postgres) => {
+                postgres.estimated_row_count(table_name).await
+            }
+            ExternalTableReaderImpl::SqlServer(sql_server) => {
+                sql_server.estimated_row_count(table_name).await
+            }
+            ExternalTableReaderImpl::Mock(mock) => mock.estimated_row_count(table_name).await,
         }
     }
 

--- a/src/connector/src/source/cdc/external/mysql.rs
+++ b/src/connector/src/source/cdc/external/mysql.rs
@@ -490,6 +490,22 @@ impl ExternalTableReader for MySqlExternalTableReader {
         }))
     }
 
+    async fn estimated_row_count(
+        &self,
+        table_name: &SchemaTableName,
+    ) -> ConnectorResult<Option<u64>> {
+        let mut conn = self.pool.get_conn().await?;
+        let estimate: Option<(Option<u64>,)> = conn
+            .exec_first(
+                "SELECT TABLE_ROWS \
+                 FROM INFORMATION_SCHEMA.TABLES \
+                 WHERE TABLE_SCHEMA = ? AND TABLE_NAME = ?",
+                (&table_name.schema_name, &table_name.table_name),
+            )
+            .await?;
+        Ok(estimate.and_then(|(row_count,)| row_count))
+    }
+
     fn snapshot_read(
         &self,
         table_name: SchemaTableName,

--- a/src/connector/src/source/cdc/external/mysql.rs
+++ b/src/connector/src/source/cdc/external/mysql.rs
@@ -480,6 +480,22 @@ impl ExternalTableReader for MySqlExternalTableReader {
         }))
     }
 
+    async fn estimated_row_count(
+        &self,
+        table_name: &SchemaTableName,
+    ) -> ConnectorResult<Option<u64>> {
+        let mut conn = self.pool.get_conn().await?;
+        let estimate: Option<(Option<u64>,)> = conn
+            .exec_first(
+                "SELECT TABLE_ROWS \
+                 FROM INFORMATION_SCHEMA.TABLES \
+                 WHERE TABLE_SCHEMA = ? AND TABLE_NAME = ?",
+                (&table_name.schema_name, &table_name.table_name),
+            )
+            .await?;
+        Ok(estimate.and_then(|(row_count,)| row_count))
+    }
+
     fn snapshot_read(
         &self,
         table_name: SchemaTableName,

--- a/src/connector/src/source/cdc/external/postgres.rs
+++ b/src/connector/src/source/cdc/external/postgres.rs
@@ -172,6 +172,29 @@ impl ExternalTableReader for PostgresExternalTableReader {
         Ok(CdcOffset::Postgres(pg_offset))
     }
 
+    async fn estimated_row_count(
+        &self,
+        table_name: &SchemaTableName,
+    ) -> ConnectorResult<Option<u64>> {
+        assert_eq!(table_name, &self.schema_table_name);
+        let client = self.client.lock().await;
+        let row = client
+            .query_opt(
+                "SELECT c.reltuples::double precision \
+                 FROM pg_catalog.pg_class c \
+                 JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace \
+                 WHERE n.nspname = $1 AND c.relname = $2 \
+                   AND c.relkind IN ('r', 'p')",
+                &[&table_name.schema_name, &table_name.table_name],
+            )
+            .await?;
+        let Some(row) = row else {
+            return Ok(None);
+        };
+        let estimate = row.get::<_, f64>(0);
+        Ok((estimate.is_finite() && estimate >= 0.0).then_some(estimate.round() as u64))
+    }
+
     fn snapshot_read(
         &self,
         table_name: SchemaTableName,

--- a/src/connector/src/source/cdc/external/postgres.rs
+++ b/src/connector/src/source/cdc/external/postgres.rs
@@ -171,6 +171,29 @@ impl ExternalTableReader for PostgresExternalTableReader {
         Ok(CdcOffset::Postgres(pg_offset))
     }
 
+    async fn estimated_row_count(
+        &self,
+        table_name: &SchemaTableName,
+    ) -> ConnectorResult<Option<u64>> {
+        assert_eq!(table_name, &self.schema_table_name);
+        let client = self.client.lock().await;
+        let row = client
+            .query_opt(
+                "SELECT c.reltuples::double precision \
+                 FROM pg_catalog.pg_class c \
+                 JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace \
+                 WHERE n.nspname = $1 AND c.relname = $2 \
+                   AND c.relkind IN ('r', 'p')",
+                &[&table_name.schema_name, &table_name.table_name],
+            )
+            .await?;
+        let Some(row) = row else {
+            return Ok(None);
+        };
+        let estimate = row.get::<_, f64>(0);
+        Ok((estimate.is_finite() && estimate >= 0.0).then_some(estimate.round() as u64))
+    }
+
     fn snapshot_read(
         &self,
         table_name: SchemaTableName,

--- a/src/connector/src/source/cdc/external/sql_server.rs
+++ b/src/connector/src/source/cdc/external/sql_server.rs
@@ -38,6 +38,13 @@ use crate::source::cdc::external::{
 // The maximum commit_lsn value in Sql Server
 const MAX_COMMIT_LSN: &str = "ffffffff:ffffffff:ffff";
 
+// Unlike `sys.dm_db_partition_stats`, `sys.partitions` does not require database-wide
+// state/definition permissions. Its rows are filtered by normal metadata visibility, so a CDC
+// user with access to the upstream table can obtain the same approximate row count.
+const ESTIMATED_ROW_COUNT_QUERY: &str = "SELECT SUM(p.rows) \
+    FROM sys.partitions AS p \
+    WHERE p.object_id = OBJECT_ID(@P1) AND p.index_id IN (0, 1)";
+
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
 pub struct SqlServerOffset {
     // https://learn.microsoft.com/en-us/answers/questions/1328359/how-to-accurately-sequence-change-data-capture-dat
@@ -272,11 +279,7 @@ impl ExternalTableReader for SqlServerExternalTableReader {
         &self,
         table_name: &SchemaTableName,
     ) -> ConnectorResult<Option<u64>> {
-        let mut query = Query::new(
-            "SELECT SUM(row_count) \
-             FROM sys.dm_db_partition_stats \
-             WHERE object_id = OBJECT_ID(@P1) AND index_id IN (0, 1)",
-        );
+        let mut query = Query::new(ESTIMATED_ROW_COUNT_QUERY);
         let normalized_table_name = Self::get_normalized_table_name(table_name);
         query.bind(normalized_table_name.as_str());
 
@@ -486,6 +489,15 @@ impl SqlServerExternalTableReader {
 #[cfg(test)]
 mod tests {
     use crate::source::cdc::external::SqlServerExternalTableReader;
+    use crate::source::cdc::external::sql_server::ESTIMATED_ROW_COUNT_QUERY;
+
+    #[test]
+    fn test_estimated_row_count_query_uses_public_catalog_view() {
+        assert_eq!(
+            ESTIMATED_ROW_COUNT_QUERY,
+            "SELECT SUM(p.rows) FROM sys.partitions AS p WHERE p.object_id = OBJECT_ID(@P1) AND p.index_id IN (0, 1)"
+        );
+    }
 
     #[test]
     fn test_sql_server_filter_expr() {

--- a/src/connector/src/source/cdc/external/sql_server.rs
+++ b/src/connector/src/source/cdc/external/sql_server.rs
@@ -268,6 +268,31 @@ impl ExternalTableReader for SqlServerExternalTableReader {
         }))
     }
 
+    async fn estimated_row_count(
+        &self,
+        table_name: &SchemaTableName,
+    ) -> ConnectorResult<Option<u64>> {
+        let mut query = Query::new(
+            "SELECT SUM(row_count) \
+             FROM sys.dm_db_partition_stats \
+             WHERE object_id = OBJECT_ID(@P1) AND index_id IN (0, 1)",
+        );
+        let normalized_table_name = Self::get_normalized_table_name(table_name);
+        query.bind(normalized_table_name.as_str());
+
+        let mut client = self.client.lock().await;
+        let row = query
+            .query(&mut client.inner_client)
+            .await?
+            .into_row()
+            .await?;
+        let Some(row) = row else {
+            return Ok(None);
+        };
+        let estimate = row.try_get::<i64, usize>(0)?;
+        Ok(estimate.and_then(|row_count| u64::try_from(row_count).ok()))
+    }
+
     fn snapshot_read(
         &self,
         table_name: SchemaTableName,

--- a/src/frontend/src/catalog/system_catalog/rw_catalog/rw_cdc_progress.rs
+++ b/src/frontend/src/catalog/system_catalog/rw_catalog/rw_cdc_progress.rs
@@ -26,6 +26,8 @@ struct RwCdcProgress {
     split_total_count: i64,
     split_backfilled_count: i64,
     split_completed_count: i64,
+    backfilled_row_count: Option<i64>,
+    estimated_row_count: Option<i64>,
 }
 
 #[system_catalog(table, "rw_catalog.rw_cdc_progress")]
@@ -39,6 +41,8 @@ async fn read_rw_cdc_progress(reader: &SysCatalogReaderImpl) -> Result<Vec<RwCdc
             split_total_count: p.split_total_count as _,
             split_backfilled_count: p.split_backfilled_count as _,
             split_completed_count: p.split_completed_count as _,
+            backfilled_row_count: p.backfilled_row_count.map(|count| count as _),
+            estimated_row_count: p.estimated_row_count.map(|count| count as _),
         })
         .collect())
 }

--- a/src/frontend/src/catalog/system_catalog/rw_catalog/rw_cdc_progress.rs
+++ b/src/frontend/src/catalog/system_catalog/rw_catalog/rw_cdc_progress.rs
@@ -15,6 +15,7 @@
 use risingwave_common::id::JobId;
 use risingwave_common::types::Fields;
 use risingwave_frontend_macro::system_catalog;
+use risingwave_pb::meta::list_cdc_progress_response::PbCdcProgress;
 
 use crate::catalog::system_catalog::SysCatalogReaderImpl;
 use crate::error::Result;
@@ -36,13 +37,69 @@ async fn read_rw_cdc_progress(reader: &SysCatalogReaderImpl) -> Result<Vec<RwCdc
 
     Ok(progress
         .into_iter()
-        .map(|(job_id, p)| RwCdcProgress {
+        .map(|(job_id, p)| RwCdcProgress::from_progress(job_id, p))
+        .collect())
+}
+
+impl RwCdcProgress {
+    fn from_progress(job_id: JobId, p: PbCdcProgress) -> Self {
+        // Missing or stale upstream statistics must degrade to rows-only progress.
+        let estimated_row_count = p.estimated_row_count.filter(|&estimate| {
+            estimate > 0
+                && p.backfilled_row_count
+                    .is_some_and(|count| count <= estimate)
+        });
+        Self {
             job_id,
             split_total_count: p.split_total_count as _,
             split_backfilled_count: p.split_backfilled_count as _,
             split_completed_count: p.split_completed_count as _,
             backfilled_row_count: p.backfilled_row_count.map(|count| count as _),
-            estimated_row_count: p.estimated_row_count.map(|count| count as _),
-        })
-        .collect())
+            estimated_row_count: estimated_row_count.and_then(|count| i64::try_from(count).ok()),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_cdc_progress_estimate_fallback() {
+        for (backfilled, estimate, expected) in [
+            (Some(10), None, None),
+            (Some(0), Some(0), None),
+            (Some(10), Some(0), None),
+            (Some(10), Some(9), None),
+            (Some(10), Some(10), Some(10)),
+            (Some(10), Some(20), Some(20)),
+            (Some(0), Some(20), Some(20)),
+            (None, None, None),
+            (None, Some(20), None),
+            (Some(10), Some(u64::MAX), None),
+        ] {
+            let row = RwCdcProgress::from_progress(
+                JobId::new(1),
+                PbCdcProgress {
+                    split_total_count: 3,
+                    split_backfilled_count: 2,
+                    split_completed_count: 1,
+                    backfilled_row_count: backfilled,
+                    estimated_row_count: estimate,
+                },
+            );
+            assert_eq!(
+                row.backfilled_row_count,
+                backfilled.map(|count| count as i64)
+            );
+            assert_eq!(
+                row.estimated_row_count, expected,
+                "{backfilled:?}/{estimate:?}"
+            );
+            assert_eq!(row.job_id, JobId::new(1));
+            assert_eq!(row.split_total_count, 3);
+            assert_eq!(row.split_backfilled_count, 2);
+            assert_eq!(row.split_completed_count, 1);
+        }
+    }
 }

--- a/src/meta/service/src/stream_service.rs
+++ b/src/meta/service/src/stream_service.rs
@@ -917,6 +917,8 @@ impl StreamManagerService for StreamServiceImpl {
                         split_total_count: p.split_total_count,
                         split_backfilled_count: p.split_backfilled_count,
                         split_completed_count: p.split_completed_count,
+                        backfilled_row_count: p.backfilled_row_count,
+                        estimated_row_count: p.estimated_row_count,
                     },
                 )
             })

--- a/src/meta/service/src/stream_service.rs
+++ b/src/meta/service/src/stream_service.rs
@@ -922,6 +922,8 @@ impl StreamManagerService for StreamServiceImpl {
                         split_total_count: p.split_total_count,
                         split_backfilled_count: p.split_backfilled_count,
                         split_completed_count: p.split_completed_count,
+                        backfilled_row_count: p.backfilled_row_count,
+                        estimated_row_count: p.estimated_row_count,
                     },
                 )
             })

--- a/src/meta/src/barrier/cdc_progress.rs
+++ b/src/meta/src/barrier/cdc_progress.rs
@@ -52,6 +52,12 @@ struct CdcBackfillProgress {
     split_assignment_generation: u64,
 }
 
+#[derive(Debug, Default)]
+struct CdcBackfillRowProgress {
+    backfilled_row_count: u64,
+    estimated_row_count: Option<u64>,
+}
+
 #[derive(Debug)]
 pub struct CdcProgress {
     /// The total number of splits, immutable.
@@ -60,6 +66,10 @@ pub struct CdcProgress {
     pub split_backfilled_count: u64,
     /// The number of splits that has completed backfill and synchronized CDC offset.
     pub split_completed_count: u64,
+    /// Only set for non-parallelized CDC backfill.
+    pub backfilled_row_count: Option<u64>,
+    /// Best-effort estimate from upstream database statistics.
+    pub estimated_row_count: Option<u64>,
 }
 
 impl CdcTableBackfillTracker {
@@ -93,6 +103,7 @@ impl CdcTableBackfillTracker {
 #[derive(Debug)]
 pub(super) struct CdcTableBackfillTracker {
     status: CdcBackfillStatus,
+    row_progress: Option<CdcBackfillRowProgress>,
     cdc_scan_fragment_id: FragmentId,
     next_generation: u64,
 }
@@ -112,6 +123,7 @@ impl CdcTableBackfillTracker {
         };
         Self {
             status,
+            row_progress: None,
             cdc_scan_fragment_id,
             next_generation: INITIAL_CDC_SPLIT_ASSIGNMENT_GENERATION_ID + 1,
         }
@@ -126,6 +138,24 @@ impl CdcTableBackfillTracker {
             cdc_scan_fragment_id,
             CdcTableSnapshotSplits::Backfilling(splits),
         )
+    }
+
+    pub fn new_non_parallelized(cdc_scan_fragment_id: FragmentId) -> Self {
+        Self {
+            status: CdcBackfillStatus::Backfilling(CdcBackfillProgress {
+                splits: vec![single_merged_split()],
+                split_backfilled_count: 0,
+                split_completed_count: 0,
+                split_assignment_generation: INVALID_CDC_SPLIT_ASSIGNMENT_GENERATION_ID,
+            }),
+            row_progress: Some(CdcBackfillRowProgress::default()),
+            cdc_scan_fragment_id,
+            next_generation: INITIAL_CDC_SPLIT_ASSIGNMENT_GENERATION_ID,
+        }
+    }
+
+    pub fn is_parallelized(&self) -> bool {
+        self.row_progress.is_none()
     }
 
     pub fn cdc_scan_fragment_id(&self) -> FragmentId {
@@ -158,10 +188,28 @@ impl CdcTableBackfillTracker {
         }
     }
 
+    pub fn update_row_progress(&mut self, progress: &PbCdcTableBackfillProgress) {
+        let Some(backfilled_row_count) = progress.backfilled_row_count else {
+            return;
+        };
+        let Some(row_progress) = &mut self.row_progress else {
+            return;
+        };
+        row_progress.backfilled_row_count =
+            row_progress.backfilled_row_count.max(backfilled_row_count);
+        if row_progress.estimated_row_count.is_none() {
+            row_progress.estimated_row_count = progress.estimated_row_count;
+        }
+        if progress.done {
+            self.status = CdcBackfillStatus::Completed;
+        }
+    }
+
     pub fn reassign_splits(
         &mut self,
         actor_ids: HashSet<ActorId>,
     ) -> MetaResult<HashMap<ActorId, PbCdcTableSnapshotSplits>> {
+        assert!(self.is_parallelized());
         let generation = self.next_generation;
         self.next_generation += 1;
         let splits = match &mut self.status {
@@ -181,17 +229,22 @@ impl CdcTableBackfillTracker {
     }
 
     pub fn gen_cdc_progress(&self) -> CdcProgress {
-        match &self.status {
-            CdcBackfillStatus::Backfilling(progress) => CdcProgress {
-                split_total_count: progress.splits.len() as _,
-                split_backfilled_count: progress.split_backfilled_count,
-                split_completed_count: progress.split_completed_count,
-            },
-            CdcBackfillStatus::PreCompleted | CdcBackfillStatus::Completed => CdcProgress {
-                split_total_count: 1,
-                split_backfilled_count: 1,
-                split_completed_count: 1,
-            },
+        let (split_total_count, split_backfilled_count, split_completed_count) = match &self.status
+        {
+            CdcBackfillStatus::Backfilling(progress) => (
+                progress.splits.len() as _,
+                progress.split_backfilled_count,
+                progress.split_completed_count,
+            ),
+            CdcBackfillStatus::PreCompleted | CdcBackfillStatus::Completed => (1, 1, 1),
+        };
+        let row_progress = self.row_progress.as_ref();
+        CdcProgress {
+            split_total_count,
+            split_backfilled_count,
+            split_completed_count,
+            backfilled_row_count: row_progress.map(|progress| progress.backfilled_row_count),
+            estimated_row_count: row_progress.and_then(|progress| progress.estimated_row_count),
         }
     }
 
@@ -318,6 +371,51 @@ mod test {
             tracker.update_split_progress(progress);
         }
         assert!(tracker.take_pre_completed());
+    }
+
+    #[test]
+    fn test_non_parallelized_row_progress() {
+        let mut tracker = CdcTableBackfillTracker::new_non_parallelized(233.into());
+        assert!(!tracker.is_parallelized());
+
+        tracker.update_row_progress(&CdcTableBackfillProgress {
+            fragment_id: 233.into(),
+            backfilled_row_count: Some(40),
+            estimated_row_count: Some(100),
+            ..Default::default()
+        });
+        let progress = tracker.gen_cdc_progress();
+        assert_eq!(progress.split_total_count, 1);
+        assert_eq!(progress.split_backfilled_count, 0);
+        assert_eq!(progress.split_completed_count, 0);
+        assert_eq!(progress.backfilled_row_count, Some(40));
+        assert_eq!(progress.estimated_row_count, Some(100));
+
+        // Retried or stale reports must not move the numerator backwards or
+        // replace the estimate captured by the first successful query.
+        tracker.update_row_progress(&CdcTableBackfillProgress {
+            fragment_id: 233.into(),
+            backfilled_row_count: Some(20),
+            estimated_row_count: Some(200),
+            ..Default::default()
+        });
+        let progress = tracker.gen_cdc_progress();
+        assert_eq!(progress.backfilled_row_count, Some(40));
+        assert_eq!(progress.estimated_row_count, Some(100));
+
+        tracker.update_row_progress(&CdcTableBackfillProgress {
+            fragment_id: 233.into(),
+            done: true,
+            backfilled_row_count: Some(110),
+            estimated_row_count: Some(100),
+            ..Default::default()
+        });
+        let progress = tracker.gen_cdc_progress();
+        assert_eq!(progress.split_backfilled_count, 1);
+        assert_eq!(progress.split_completed_count, 1);
+        assert_eq!(progress.backfilled_row_count, Some(110));
+        assert_eq!(progress.estimated_row_count, Some(100));
+        assert!(!tracker.take_pre_completed());
     }
 
     fn assert_init_state(tracker: &CdcTableBackfillTracker, split_count: u64) {

--- a/src/meta/src/barrier/info.rs
+++ b/src/meta/src/barrier/info.rs
@@ -570,6 +570,9 @@ impl InflightDatabaseInfo {
         let job_id = self.fragment_location[&fragment_id];
         let job = self.jobs.get_mut(&job_id).expect("should exist");
         if let Some(tracker) = &mut job.cdc_table_backfill_tracker {
+            if !tracker.is_parallelized() {
+                return Ok(None);
+            }
             let cdc_scan_fragment_id = tracker.cdc_scan_fragment_id();
             if cdc_scan_fragment_id != fragment_id {
                 return Ok(None);
@@ -591,6 +594,9 @@ impl InflightDatabaseInfo {
     ) -> MetaResult<Option<HashMap<ActorId, PbCdcTableSnapshotSplits>>> {
         let job = self.jobs.get_mut(&job_id).expect("should exist");
         if let Some(tracker) = &mut job.cdc_table_backfill_tracker {
+            if !tracker.is_parallelized() {
+                return Ok(None);
+            }
             let cdc_scan_fragment_id = tracker.cdc_scan_fragment_id();
             let actors = job.fragment_infos[&cdc_scan_fragment_id]
                 .actors
@@ -690,16 +696,29 @@ impl InflightDatabaseInfo {
                 );
                 continue;
             };
-            let Some(tracker) = &mut self
-                .jobs
-                .get_mut(job_id)
-                .expect("should exist")
-                .cdc_table_backfill_tracker
-            else {
+            let job = self.jobs.get_mut(job_id).expect("should exist");
+            if job.cdc_table_backfill_tracker.is_none() && progress.backfilled_row_count.is_some() {
+                job.cdc_table_backfill_tracker = Some(
+                    CdcTableBackfillTracker::new_non_parallelized(progress.fragment_id),
+                );
+            }
+            let Some(tracker) = &mut job.cdc_table_backfill_tracker else {
                 warn!("update the cdc progress of an created streaming job: {progress:?}");
                 continue;
             };
-            tracker.update_split_progress(progress);
+            if progress.backfilled_row_count.is_some() {
+                if tracker.is_parallelized() {
+                    warn!("update row progress on a parallelized CDC backfill: {progress:?}");
+                    continue;
+                }
+                tracker.update_row_progress(progress);
+            } else {
+                if !tracker.is_parallelized() {
+                    warn!("update split progress on a non-parallelized CDC backfill: {progress:?}");
+                    continue;
+                }
+                tracker.update_split_progress(progress);
+            }
         }
         // Handle CDC source offset updated events
         for cdc_offset_updated in resps

--- a/src/meta/src/barrier/info.rs
+++ b/src/meta/src/barrier/info.rs
@@ -568,6 +568,9 @@ impl InflightDatabaseInfo {
         let job_id = self.fragment_location[&fragment_id];
         let job = self.jobs.get_mut(&job_id).expect("should exist");
         if let Some(tracker) = &mut job.cdc_table_backfill_tracker {
+            if !tracker.is_parallelized() {
+                return Ok(None);
+            }
             let cdc_scan_fragment_id = tracker.cdc_scan_fragment_id();
             if cdc_scan_fragment_id != fragment_id {
                 return Ok(None);
@@ -589,6 +592,9 @@ impl InflightDatabaseInfo {
     ) -> MetaResult<Option<HashMap<ActorId, PbCdcTableSnapshotSplits>>> {
         let job = self.jobs.get_mut(&job_id).expect("should exist");
         if let Some(tracker) = &mut job.cdc_table_backfill_tracker {
+            if !tracker.is_parallelized() {
+                return Ok(None);
+            }
             let cdc_scan_fragment_id = tracker.cdc_scan_fragment_id();
             let actors = job.fragment_infos[&cdc_scan_fragment_id]
                 .actors
@@ -688,16 +694,29 @@ impl InflightDatabaseInfo {
                 );
                 continue;
             };
-            let Some(tracker) = &mut self
-                .jobs
-                .get_mut(job_id)
-                .expect("should exist")
-                .cdc_table_backfill_tracker
-            else {
+            let job = self.jobs.get_mut(job_id).expect("should exist");
+            if job.cdc_table_backfill_tracker.is_none() && progress.backfilled_row_count.is_some() {
+                job.cdc_table_backfill_tracker = Some(
+                    CdcTableBackfillTracker::new_non_parallelized(progress.fragment_id),
+                );
+            }
+            let Some(tracker) = &mut job.cdc_table_backfill_tracker else {
                 warn!("update the cdc progress of an created streaming job: {progress:?}");
                 continue;
             };
-            tracker.update_split_progress(progress);
+            if progress.backfilled_row_count.is_some() {
+                if tracker.is_parallelized() {
+                    warn!("update row progress on a parallelized CDC backfill: {progress:?}");
+                    continue;
+                }
+                tracker.update_row_progress(progress);
+            } else {
+                if !tracker.is_parallelized() {
+                    warn!("update split progress on a non-parallelized CDC backfill: {progress:?}");
+                    continue;
+                }
+                tracker.update_split_progress(progress);
+            }
         }
         // Handle CDC source offset updated events
         for cdc_offset_updated in resps

--- a/src/stream/src/executor/backfill/cdc/cdc_backfill.rs
+++ b/src/stream/src/executor/backfill/cdc/cdc_backfill.rs
@@ -375,8 +375,38 @@ impl<S: StateStore> CdcBackfillExecutor<S> {
         //
         // Once the backfill loop ends, we forward the upstream directly to the downstream.
         if need_backfill {
+            // Use a disposable reader for the best-effort estimate. Dropping a timed-out query
+            // does not necessarily cancel it upstream, and PostgreSQL/SQL Server readers use a
+            // single connection. Reusing that connection for the snapshot could therefore block
+            // on the abandoned estimate.
+            estimated_row_count = match tokio::time::timeout(
+                Duration::from_secs(5),
+                estimate_upstream_row_count(self.external_table.clone()),
+            )
+            .await
+            {
+                Ok(Ok(estimate)) => estimate,
+                Ok(Err(error)) => {
+                    tracing::warn!(
+                        error = %error.as_report(),
+                        %table_id,
+                        upstream_table_name,
+                        "failed to estimate upstream table row count"
+                    );
+                    None
+                }
+                Err(_) => {
+                    tracing::warn!(
+                        %table_id,
+                        upstream_table_name,
+                        "timed out estimating upstream table row count"
+                    );
+                    None
+                }
+            };
+
             // After init the state table and forward the initial barrier to downstream,
-            // we now try to create the table reader with retry.
+            // create a fresh table reader for the snapshot with retry.
             // If backfill hasn't finished, we can ignore upstream cdc events before we create the table reader.
             let mut table_reader: Option<ExternalTableReaderImpl> = None;
             let external_table = self.external_table.clone();
@@ -441,32 +471,6 @@ impl<S: StateStore> CdcBackfillExecutor<S> {
                 self.external_table.clone(),
                 table_reader.expect("table reader must created"),
             );
-
-            estimated_row_count = match tokio::time::timeout(
-                Duration::from_secs(5),
-                upstream_table_reader.estimated_row_count(),
-            )
-            .await
-            {
-                Ok(Ok(estimate)) => estimate,
-                Ok(Err(error)) => {
-                    tracing::warn!(
-                        error = %error.as_report(),
-                        %table_id,
-                        upstream_table_name,
-                        "failed to estimate upstream table row count"
-                    );
-                    None
-                }
-                Err(_) => {
-                    tracing::warn!(
-                        %table_id,
-                        upstream_table_name,
-                        "timed out estimating upstream table row count"
-                    );
-                    None
-                }
-            };
 
             if last_binlog_offset.is_none() {
                 // Limit concurrent CDC connections globally to 10 using a semaphore.
@@ -1034,6 +1038,16 @@ impl<S: StateStore> CdcBackfillExecutor<S> {
             }
         }
     }
+}
+
+async fn estimate_upstream_row_count(
+    external_table: ExternalStorageTable,
+) -> StreamExecutorResult<Option<u64>> {
+    let table_reader = external_table.create_table_reader().await?;
+    let upstream_table_reader = UpstreamTableReader::new(external_table, table_reader);
+    let estimate_result = upstream_table_reader.estimated_row_count().await;
+    upstream_table_reader.disconnect().await?;
+    estimate_result
 }
 
 pub(crate) async fn build_reader_and_poll_upstream(

--- a/src/stream/src/executor/backfill/cdc/cdc_backfill.rs
+++ b/src/stream/src/executor/backfill/cdc/cdc_backfill.rs
@@ -15,6 +15,7 @@
 use std::collections::BTreeMap;
 use std::future::Future;
 use std::pin::Pin;
+use std::time::Duration;
 
 use either::Either;
 use futures::stream;
@@ -53,7 +54,7 @@ use crate::executor::backfill::utils::{
 use crate::executor::monitor::CdcBackfillMetrics;
 use crate::executor::prelude::*;
 use crate::executor::source::get_infinite_backoff_strategy;
-use crate::task::CreateMviewProgressReporter;
+use crate::task::cdc_progress::CdcProgressReporter;
 
 /// `split_id`, `is_finished`, `row_count`, `cdc_offset` all occupy 1 column each.
 const METADATA_STATE_LEN: usize = 4;
@@ -127,9 +128,7 @@ pub struct CdcBackfillExecutor<S: StateStore> {
     /// State table of the `CdcBackfill` executor
     state_impl: CdcBackfillState<S>,
 
-    // TODO: introduce a CdcBackfillProgress to report finish to Meta
-    // This object is just a stub right now
-    progress: Option<CreateMviewProgressReporter>,
+    progress: Option<CdcProgressReporter>,
 
     metrics: CdcBackfillMetrics,
 
@@ -149,7 +148,7 @@ impl<S: StateStore> CdcBackfillExecutor<S> {
         upstream: Executor,
         output_indices: Vec<usize>,
         output_columns: Vec<ColumnDesc>,
-        progress: Option<CreateMviewProgressReporter>,
+        progress: Option<CdcProgressReporter>,
         metrics: Arc<StreamingMetrics>,
         state_table: StateTable<S>,
         rate_limit_rps: Option<u32>,
@@ -384,6 +383,15 @@ impl<S: StateStore> CdcBackfillExecutor<S> {
                         Message::Barrier(barrier) => {
                             // commit state to bump the epoch of state table
                             state_impl.commit_state(barrier.epoch).await?;
+                            if let Some(progress) = &self.progress {
+                                progress.update_rows(
+                                    self.actor_ctx.fragment_id,
+                                    self.actor_ctx.id,
+                                    barrier.epoch,
+                                    total_snapshot_row_count,
+                                    None,
+                                );
+                            }
                             yield Message::Barrier(barrier);
                         }
                         Message::Chunk(chunk) => {
@@ -414,6 +422,32 @@ impl<S: StateStore> CdcBackfillExecutor<S> {
             self.external_table.clone(),
             table_reader.expect("table reader must created"),
         );
+
+        let estimated_row_count = match tokio::time::timeout(
+            Duration::from_secs(5),
+            upstream_table_reader.estimated_row_count(),
+        )
+        .await
+        {
+            Ok(Ok(estimate)) => estimate,
+            Ok(Err(error)) => {
+                tracing::warn!(
+                    error = %error.as_report(),
+                    %table_id,
+                    upstream_table_name,
+                    "failed to estimate upstream table row count"
+                );
+                None
+            }
+            Err(_) => {
+                tracing::warn!(
+                    %table_id,
+                    upstream_table_name,
+                    "timed out estimating upstream table row count"
+                );
+                None
+            }
+        };
 
         let mut upstream = upstream.peekable();
 
@@ -513,6 +547,15 @@ impl<S: StateStore> CdcBackfillExecutor<S> {
                         }
                         // commit state just to bump the epoch of state table
                         state_impl.commit_state(barrier.epoch).await?;
+                        if let Some(progress) = &self.progress {
+                            progress.update_rows(
+                                self.actor_ctx.fragment_id,
+                                self.actor_ctx.id,
+                                barrier.epoch,
+                                total_snapshot_row_count,
+                                estimated_row_count,
+                            );
+                        }
                         yield Message::Barrier(barrier);
                         break;
                     }
@@ -671,6 +714,8 @@ impl<S: StateStore> CdcBackfillExecutor<S> {
                                             cur_barrier_snapshot_processed_rows,
                                             cur_barrier_upstream_processed_rows,
                                         );
+                                        cur_barrier_snapshot_processed_rows = 0;
+                                        cur_barrier_upstream_processed_rows = 0;
 
                                         // update and persist current backfill progress
                                         state_impl
@@ -683,6 +728,16 @@ impl<S: StateStore> CdcBackfillExecutor<S> {
                                             .await?;
 
                                         state_impl.commit_state(barrier.epoch).await?;
+
+                                        if let Some(progress) = &self.progress {
+                                            progress.update_rows(
+                                                self.actor_ctx.fragment_id,
+                                                self.actor_ctx.id,
+                                                barrier.epoch,
+                                                total_snapshot_row_count,
+                                                estimated_row_count,
+                                            );
+                                        }
 
                                         // emit barrier and continue consume the backfill stream
                                         yield Message::Barrier(barrier);
@@ -900,6 +955,15 @@ impl<S: StateStore> CdcBackfillExecutor<S> {
                     .await?;
 
                 state_impl.commit_state(pending_barrier.epoch).await?;
+                if let Some(progress) = &self.progress {
+                    progress.update_rows(
+                        self.actor_ctx.fragment_id,
+                        self.actor_ctx.id,
+                        pending_barrier.epoch,
+                        total_snapshot_row_count,
+                        estimated_row_count,
+                    );
+                }
                 yield Message::Barrier(pending_barrier);
             }
         } else if self.options.disable_backfill {
@@ -946,8 +1010,14 @@ impl<S: StateStore> CdcBackfillExecutor<S> {
                     state_impl.commit_state(barrier.epoch).await?;
 
                     // mark progress as finished
-                    if let Some(progress) = self.progress.as_mut() {
-                        progress.finish(barrier.epoch, total_snapshot_row_count);
+                    if let Some(progress) = &self.progress {
+                        progress.finish_rows(
+                            self.actor_ctx.fragment_id,
+                            self.actor_ctx.id,
+                            barrier.epoch,
+                            total_snapshot_row_count,
+                            estimated_row_count,
+                        );
                     }
                     yield msg;
                     // break after the state have been saved

--- a/src/stream/src/executor/backfill/cdc/cdc_backfill.rs
+++ b/src/stream/src/executor/backfill/cdc/cdc_backfill.rs
@@ -15,6 +15,7 @@
 use std::collections::BTreeMap;
 use std::future::Future;
 use std::pin::Pin;
+use std::time::Duration;
 
 use either::Either;
 use futures::stream::select_with_strategy;
@@ -53,7 +54,7 @@ use crate::executor::backfill::utils::{
 use crate::executor::monitor::CdcBackfillMetrics;
 use crate::executor::prelude::*;
 use crate::executor::source::get_infinite_backoff_strategy;
-use crate::task::CreateMviewProgressReporter;
+use crate::task::cdc_progress::CdcProgressReporter;
 
 /// `split_id`, `is_finished`, `row_count`, `cdc_offset` all occupy 1 column each.
 const METADATA_STATE_LEN: usize = 4;
@@ -127,9 +128,7 @@ pub struct CdcBackfillExecutor<S: StateStore> {
     /// State table of the `CdcBackfill` executor
     state_impl: CdcBackfillState<S>,
 
-    // TODO: introduce a CdcBackfillProgress to report finish to Meta
-    // This object is just a stub right now
-    progress: Option<CreateMviewProgressReporter>,
+    progress: Option<CdcProgressReporter>,
 
     metrics: CdcBackfillMetrics,
 
@@ -149,7 +148,7 @@ impl<S: StateStore> CdcBackfillExecutor<S> {
         upstream: Executor,
         output_indices: Vec<usize>,
         output_columns: Vec<ColumnDesc>,
-        progress: Option<CreateMviewProgressReporter>,
+        progress: Option<CdcProgressReporter>,
         metrics: Arc<StreamingMetrics>,
         state_table: StateTable<S>,
         rate_limit_rps: Option<u32>,
@@ -353,6 +352,7 @@ impl<S: StateStore> CdcBackfillExecutor<S> {
         .boxed()
         .peekable();
         let mut last_binlog_offset = state.last_cdc_offset.clone();
+        let mut estimated_row_count = None;
 
         // CDC Backfill Algorithm:
         //
@@ -407,6 +407,15 @@ impl<S: StateStore> CdcBackfillExecutor<S> {
                             Message::Barrier(barrier) => {
                                 // commit state to bump the epoch of state table
                                 state_impl.commit_state(barrier.epoch).await?;
+                                if let Some(progress) = &self.progress {
+                                    progress.update_rows(
+                                        self.actor_ctx.fragment_id,
+                                        self.actor_ctx.id,
+                                        barrier.epoch,
+                                        total_snapshot_row_count,
+                                        None,
+                                    );
+                                }
                                 yield Message::Barrier(barrier);
                             }
                             Message::Chunk(_) => {
@@ -432,6 +441,32 @@ impl<S: StateStore> CdcBackfillExecutor<S> {
                 self.external_table.clone(),
                 table_reader.expect("table reader must created"),
             );
+
+            estimated_row_count = match tokio::time::timeout(
+                Duration::from_secs(5),
+                upstream_table_reader.estimated_row_count(),
+            )
+            .await
+            {
+                Ok(Ok(estimate)) => estimate,
+                Ok(Err(error)) => {
+                    tracing::warn!(
+                        error = %error.as_report(),
+                        %table_id,
+                        upstream_table_name,
+                        "failed to estimate upstream table row count"
+                    );
+                    None
+                }
+                Err(_) => {
+                    tracing::warn!(
+                        %table_id,
+                        upstream_table_name,
+                        "timed out estimating upstream table row count"
+                    );
+                    None
+                }
+            };
 
             if last_binlog_offset.is_none() {
                 // Limit concurrent CDC connections globally to 10 using a semaphore.
@@ -506,6 +541,15 @@ impl<S: StateStore> CdcBackfillExecutor<S> {
                         }
                         // commit state just to bump the epoch of state table
                         state_impl.commit_state(barrier.epoch).await?;
+                        if let Some(progress) = &self.progress {
+                            progress.update_rows(
+                                self.actor_ctx.fragment_id,
+                                self.actor_ctx.id,
+                                barrier.epoch,
+                                total_snapshot_row_count,
+                                estimated_row_count,
+                            );
+                        }
                         yield Message::Barrier(barrier);
                         break;
                     }
@@ -676,6 +720,16 @@ impl<S: StateStore> CdcBackfillExecutor<S> {
                                             .await?;
 
                                         state_impl.commit_state(barrier.epoch).await?;
+
+                                        if let Some(progress) = &self.progress {
+                                            progress.update_rows(
+                                                self.actor_ctx.fragment_id,
+                                                self.actor_ctx.id,
+                                                barrier.epoch,
+                                                total_snapshot_row_count,
+                                                estimated_row_count,
+                                            );
+                                        }
 
                                         // emit barrier and continue consume the backfill stream
                                         yield Message::Barrier(barrier);
@@ -893,6 +947,15 @@ impl<S: StateStore> CdcBackfillExecutor<S> {
                     .await?;
 
                 state_impl.commit_state(pending_barrier.epoch).await?;
+                if let Some(progress) = &self.progress {
+                    progress.update_rows(
+                        self.actor_ctx.fragment_id,
+                        self.actor_ctx.id,
+                        pending_barrier.epoch,
+                        total_snapshot_row_count,
+                        estimated_row_count,
+                    );
+                }
                 yield Message::Barrier(pending_barrier);
             }
             upstream_table_reader.disconnect().await?;
@@ -938,8 +1001,14 @@ impl<S: StateStore> CdcBackfillExecutor<S> {
                     state_impl.commit_state(barrier.epoch).await?;
 
                     // mark progress as finished
-                    if let Some(progress) = self.progress.as_mut() {
-                        progress.finish(barrier.epoch, total_snapshot_row_count);
+                    if let Some(progress) = &self.progress {
+                        progress.finish_rows(
+                            self.actor_ctx.fragment_id,
+                            self.actor_ctx.id,
+                            barrier.epoch,
+                            total_snapshot_row_count,
+                            estimated_row_count,
+                        );
                     }
                     yield msg;
                     // break after the state have been saved
@@ -1105,6 +1174,7 @@ impl<S: StateStore> Execute for CdcBackfillExecutor<S> {
 mod tests {
     use std::collections::BTreeMap;
     use std::str::FromStr;
+    use std::time::Duration;
 
     use futures::{StreamExt, pin_mut};
     use risingwave_common::array::{Array, DataChunk, Op, StreamChunk};
@@ -1371,6 +1441,78 @@ mod tests {
         let state = restored_state.restore_state().await.unwrap();
         assert!(state.is_finished);
         assert_eq!(state.last_cdc_offset, None);
+    }
+
+    #[tokio::test]
+    async fn test_finished_cdc_backfill_forwards_without_table_reader() {
+        let memory_state_store = MemoryStateStore::new();
+        let mut state_writer = CdcBackfillState::new(
+            TableId::new(1234),
+            create_cdc_state_table(memory_state_store.clone()).await,
+            5,
+        );
+        state_writer
+            .init_epoch(Barrier::new_test_barrier(test_epoch(1)).epoch)
+            .await
+            .unwrap();
+        state_writer
+            .mutate_state(None, None, 42, true)
+            .await
+            .unwrap();
+        state_writer
+            .commit_state(Barrier::new_test_barrier(test_epoch(2)).epoch)
+            .await
+            .unwrap();
+
+        let external_storage_table = ExternalStorageTable::new(
+            TableId::new(1234),
+            SchemaTableName {
+                schema_name: "public".to_owned(),
+                table_name: "orders".to_owned(),
+            },
+            "db".to_owned(),
+            ExternalTableConfig::default(),
+            ExternalCdcTableType::Undefined,
+            Schema::new(vec![Field::with_name(DataType::Int64, "id")]),
+            vec![OrderType::ascending()],
+            vec![0],
+        );
+        let schema = Schema::new(vec![
+            Field::unnamed(DataType::Jsonb),
+            Field::unnamed(DataType::Varchar),
+            Field::unnamed(DataType::Varchar),
+        ]);
+        let (tx, source) = MockSource::channel();
+        let source = source.into_executor(schema, vec![1]);
+        let cdc = CdcBackfillExecutor::new(
+            ActorContext::for_test(1),
+            external_storage_table,
+            source,
+            vec![0],
+            vec![ColumnDesc::named("id", ColumnId::new(1), DataType::Int64)],
+            None,
+            StreamingMetrics::unused().into(),
+            create_cdc_state_table(memory_state_store).await,
+            None,
+            CdcScanOptions::default(),
+            BTreeMap::default(),
+        );
+        let executor = cdc.execute_inner();
+        pin_mut!(executor);
+
+        tx.send_barrier(Barrier::new_test_barrier(test_epoch(3)));
+        assert!(matches!(
+            executor.next().await.unwrap().unwrap(),
+            Message::Barrier(_)
+        ));
+
+        tx.send_barrier(Barrier::new_test_barrier(test_epoch(4)));
+        let next = tokio::time::timeout(Duration::from_secs(1), executor.next())
+            .await
+            .expect("finished backfill must not wait for an external table reader")
+            .unwrap()
+            .unwrap();
+        assert!(matches!(next, Message::Barrier(_)));
     }
 
     #[tokio::test]

--- a/src/stream/src/executor/backfill/cdc/upstream_table/snapshot.rs
+++ b/src/stream/src/executor/backfill/cdc/upstream_table/snapshot.rs
@@ -44,6 +44,10 @@ pub trait UpstreamTableRead {
         &self,
     ) -> impl Future<Output = StreamExecutorResult<Option<CdcOffset>>> + Send + '_;
 
+    fn estimated_row_count(
+        &self,
+    ) -> impl Future<Output = StreamExecutorResult<Option<u64>>> + Send + '_;
+
     async fn disconnect(self) -> StreamExecutorResult<()>;
 
     fn snapshot_read_table_split(
@@ -174,6 +178,13 @@ fn with_additional_columns(
 }
 
 impl UpstreamTableRead for UpstreamTableReader<ExternalStorageTable> {
+    async fn estimated_row_count(&self) -> StreamExecutorResult<Option<u64>> {
+        Ok(self
+            .reader
+            .estimated_row_count(&self.table.schema_table_name())
+            .await?)
+    }
+
     #[try_stream(ok = Option<StreamChunk>, error = StreamExecutorError)]
     async fn snapshot_read_full_table(&self, args: SnapshotReadArgs, batch_size: u32) {
         let primary_keys = self

--- a/src/stream/src/from_proto/stream_cdc_scan.rs
+++ b/src/stream/src/from_proto/stream_cdc_scan.rs
@@ -139,13 +139,14 @@ impl ExecutorBuilder for StreamCdcScanExecutorBuilder {
                 .enable_preload_all_rows_by_config(&params.config)
                 .build()
                 .await;
+            let progress = CdcProgressReporter::new(params.local_barrier_manager.clone());
             let exec = CdcBackfillExecutor::new(
                 params.actor_context.clone(),
                 external_table,
                 upstream,
                 output_indices,
                 output_columns,
-                None,
+                Some(progress),
                 params.executor_stats,
                 state_table,
                 node.rate_limit,

--- a/src/stream/src/task/barrier_manager/cdc_progress.rs
+++ b/src/stream/src/task/barrier_manager/cdc_progress.rs
@@ -32,6 +32,12 @@ pub(crate) enum CdcTableBackfillState {
         split_id_end_inclusive: i64,
         generation: u64,
     },
+    Rows {
+        fragment_id: FragmentId,
+        backfilled_row_count: u64,
+        estimated_row_count: Option<u64>,
+        done: bool,
+    },
 }
 
 impl CdcTableBackfillState {
@@ -50,6 +56,8 @@ impl CdcTableBackfillState {
                 split_id_end_inclusive,
                 generation,
                 fragment_id,
+                backfilled_row_count: None,
+                estimated_row_count: None,
             },
             CdcTableBackfillState::Finish {
                 fragment_id,
@@ -64,6 +72,22 @@ impl CdcTableBackfillState {
                 split_id_end_inclusive,
                 generation,
                 fragment_id,
+                backfilled_row_count: None,
+                estimated_row_count: None,
+            },
+            CdcTableBackfillState::Rows {
+                fragment_id,
+                backfilled_row_count,
+                estimated_row_count,
+                done,
+            } => PbCdcTableBackfillProgress {
+                actor_id,
+                epoch,
+                done,
+                fragment_id,
+                backfilled_row_count: Some(backfilled_row_count),
+                estimated_row_count,
+                ..Default::default()
             },
         }
     }
@@ -117,6 +141,46 @@ impl CdcProgressReporter {
             },
         );
     }
+
+    pub fn update_rows(
+        &self,
+        fragment_id: FragmentId,
+        actor_id: ActorId,
+        epoch: EpochPair,
+        backfilled_row_count: u64,
+        estimated_row_count: Option<u64>,
+    ) {
+        self.barrier_manager.update_cdc_backfill_progress(
+            actor_id,
+            epoch,
+            CdcTableBackfillState::Rows {
+                fragment_id,
+                backfilled_row_count,
+                estimated_row_count,
+                done: false,
+            },
+        );
+    }
+
+    pub fn finish_rows(
+        &self,
+        fragment_id: FragmentId,
+        actor_id: ActorId,
+        epoch: EpochPair,
+        backfilled_row_count: u64,
+        estimated_row_count: Option<u64>,
+    ) {
+        self.barrier_manager.update_cdc_backfill_progress(
+            actor_id,
+            epoch,
+            CdcTableBackfillState::Rows {
+                fragment_id,
+                backfilled_row_count,
+                estimated_row_count,
+                done: true,
+            },
+        );
+    }
 }
 
 impl LocalBarrierManager {
@@ -131,5 +195,34 @@ impl LocalBarrierManager {
             epoch,
             state,
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::CdcTableBackfillState;
+
+    #[test]
+    fn test_progress_to_pb_row_fields() {
+        let split_progress = CdcTableBackfillState::Update {
+            fragment_id: 1.into(),
+            split_id_start_inclusive: 2,
+            split_id_end_inclusive: 3,
+            generation: 4,
+        }
+        .to_pb(5.into(), 6);
+        assert_eq!(split_progress.backfilled_row_count, None);
+        assert_eq!(split_progress.estimated_row_count, None);
+
+        let row_progress = CdcTableBackfillState::Rows {
+            fragment_id: 7.into(),
+            backfilled_row_count: 80,
+            estimated_row_count: Some(100),
+            done: true,
+        }
+        .to_pb(8.into(), 9);
+        assert_eq!(row_progress.backfilled_row_count, Some(80));
+        assert_eq!(row_progress.estimated_row_count, Some(100));
+        assert!(row_progress.done);
     }
 }


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

Non-parallelized CDC backfill currently has no supported row-level progress in `rw_catalog.rw_cdc_progress`.

This PR:

- adds nullable `backfilled_row_count` and `estimated_row_count` columns to `rw_catalog.rw_cdc_progress` for non-parallelized CDC backfill;
- reports the persisted V1 snapshot row count through the existing barrier progress path;
- obtains a best-effort upstream estimate once per executor start that actually performs backfill, using a disposable reader and a five-second timeout so an abandoned estimate cannot block the snapshot connection:
  - MySQL and MariaDB: `information_schema.tables.TABLE_ROWS`;
  - PostgreSQL: `pg_catalog.pg_class.reltuples`;
  - SQL Server: `sys.partitions.rows`;
- preserves the reader-free path for disabled or already-completed backfill, where the persisted row count is reported without reopening the upstream snapshot reader;
- keeps the existing split-count semantics unchanged for parallelized CDC backfill, where the new columns remain `NULL`.

The estimated total is intentionally nullable and may be inaccurate when upstream statistics are stale. The catalog always preserves the available `backfilled_row_count` and exposes `estimated_row_count` only when it is positive, fits a SQL bigint, and is at least the backfilled count. Missing, zero, or stale estimates degrade to `NULL`, so consumers should show rows-only progress. Snapshot-reader retries may also report a `NULL` estimate. Once split counts indicate completion, consumers should show Completed rather than a percentage. Estimate failures never block the snapshot reader, and this change never runs `COUNT(*)` or `ANALYZE` upstream.

## Tests

- `cargo test -p risingwave_frontend test_cdc_progress_estimate_fallback --lib`
- `cargo test -p risingwave_connector source::cdc::external --lib`
- `cargo test -p risingwave_stream cdc_backfill --lib`
- `cargo test -p risingwave_stream test_progress_to_pb_row_fields --lib`
- `cargo test -p risingwave_meta test_non_parallelized_row_progress --lib`
- `cargo clippy -p risingwave_connector -p risingwave_stream --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check origin/main...HEAD`

## Checklist

- [x] I have written necessary rustdoc comments.
- [x] I have added necessary unit tests and integration tests.
- [x] I have added test labels as necessary.
- [ ] I have added fuzzing tests or opened an issue to track them.
- [ ] My PR contains breaking changes.
- [ ] My PR changes performance-critical code, so I will run (micro) benchmarks and present the results.
- [ ] I have checked the Release Timeline and Currently Supported Versions to determine which release branches I need to cherry-pick this PR into.

## Documentation

- [x] My PR needs documentation updates.

<details>
<summary><b>Release note</b></summary>

`rw_catalog.rw_cdc_progress` now exposes the number of rows backfilled and a best-effort estimated upstream row count for non-parallelized MySQL, MariaDB, PostgreSQL, and SQL Server CDC backfill. The estimate becomes `NULL` when missing, zero, smaller than the backfilled count, or outside the SQL bigint range; consumers should then show the backfilled row count without a percentage. Completion is determined by the split counts.

</details>
