### PR TITLE
cherry-pick fix(batch): mask serving workers with version mismatch (#26559) to release-3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12943,6 +12943,7 @@ dependencies = [
  "pretty_assertions",
  "rand 0.9.2",
  "rand_chacha 0.9.0",
+ "risingwave_batch",
  "risingwave_batch_executors",
  "risingwave_common",
  "risingwave_compactor",

--- a/src/batch/src/rpc/service/madsim_test_utils.rs
+++ b/src/batch/src/rpc/service/madsim_test_utils.rs
@@ -1,0 +1,40 @@
+// Copyright 2026 RisingWave Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::HashMap;
+use std::sync::{LazyLock, Mutex};
+
+static BATCH_CREATE_TASK_COUNTS: LazyLock<Mutex<HashMap<String, u64>>> =
+    LazyLock::new(Default::default);
+
+pub fn record_create_task() {
+    let hostname = risingwave_common::util::resource_util::hostname();
+    *BATCH_CREATE_TASK_COUNTS
+        .lock()
+        .unwrap()
+        .entry(hostname)
+        .or_default() += 1;
+}
+
+pub fn create_task_count(node: &str) -> u64 {
+    *BATCH_CREATE_TASK_COUNTS
+        .lock()
+        .unwrap()
+        .get(node)
+        .unwrap_or(&0)
+}
+
+pub fn reset_create_task_counts() {
+    BATCH_CREATE_TASK_COUNTS.lock().unwrap().clear();
+}

--- a/src/batch/src/rpc/service/mod.rs
+++ b/src/batch/src/rpc/service/mod.rs
@@ -13,4 +13,6 @@
 // limitations under the License.
 
 pub mod exchange;
+#[cfg(madsim)]
+pub mod madsim_test_utils;
 pub mod task_service;

--- a/src/batch/src/rpc/service/task_service.rs
+++ b/src/batch/src/rpc/service/task_service.rs
@@ -68,6 +68,9 @@ impl TaskService for BatchServiceImpl {
         &self,
         request: Request<CreateTaskRequest>,
     ) -> Result<Response<Self::CreateTaskStream>, Status> {
+        #[cfg(madsim)]
+        crate::rpc::service::madsim_test_utils::record_create_task();
+
         let CreateTaskRequest {
             task_id,
             plan,

--- a/src/batch/src/worker_manager/worker_node_manager.rs
+++ b/src/batch/src/worker_manager/worker_node_manager.rs
@@ -13,13 +13,14 @@
 // limitations under the License.
 
 use std::collections::{HashMap, HashSet};
-use std::sync::{Arc, RwLock, RwLockReadGuard};
+use std::sync::{Arc, RwLock};
 use std::time::Duration;
 
 use rand::seq::IndexedRandom;
 use risingwave_common::bail;
 use risingwave_common::hash::{WorkerSlotId, WorkerSlotMapping};
 use risingwave_common::id::{FragmentId, WorkerId};
+use risingwave_common::util::version::current_rw_version;
 use risingwave_common::vnode_mapping::vnode_placement::place_vnode;
 use risingwave_pb::common::{WorkerNode, WorkerType};
 
@@ -277,8 +278,13 @@ impl WorkerNodeManager {
         }
     }
 
-    fn worker_node_mask(&self) -> RwLockReadGuard<'_, HashSet<WorkerId>> {
+    #[cfg(test)]
+    fn worker_node_mask(&self) -> std::sync::RwLockReadGuard<'_, HashSet<WorkerId>> {
         self.worker_node_mask.read().unwrap()
+    }
+
+    fn worker_node_mask_snapshot(&self) -> HashSet<WorkerId> {
+        self.worker_node_mask.read().unwrap().clone()
     }
 
     pub fn mask_worker_node(&self, worker_node_id: WorkerId, duration: Duration) {
@@ -366,19 +372,29 @@ impl WorkerNodeSelector {
                 );
                 self.manager.get_streaming_fragment_mapping(&fragment_id)
             })?;
+            let workers = self.apply_worker_node_mask(self.manager.list_serving_worker_nodes());
 
             // Filter out unavailable workers.
-            if self.manager.worker_node_mask().is_empty() {
-                Ok(mapping)
+            if workers.is_empty() {
+                Err(BatchError::EmptyWorkerNodes)
             } else {
-                let workers = self.apply_worker_node_mask(self.manager.list_serving_worker_nodes());
-                // If it's a singleton, set max_parallelism=1 for place_vnode.
-                let max_parallelism = mapping.to_single().map(|_| 1);
-                // TODO: use runtime parameter batch_parallelism
-                let masked_mapping =
-                    place_vnode(Some(&mapping), &workers, max_parallelism, mapping.len())
-                        .ok_or_else(|| BatchError::EmptyWorkerNodes)?;
-                Ok(masked_mapping)
+                let worker_ids = workers
+                    .iter()
+                    .map(|worker| worker.id)
+                    .collect::<HashSet<_>>();
+                let mapping_uses_only_available_workers = mapping
+                    .iter_unique()
+                    .all(|slot| worker_ids.contains(&slot.worker_id()));
+                if mapping_uses_only_available_workers {
+                    Ok(mapping)
+                } else {
+                    // If it's a singleton, set max_parallelism=1 for place_vnode.
+                    let max_parallelism = mapping.to_single().map(|_| 1);
+                    let masked_mapping =
+                        place_vnode(Some(&mapping), &workers, max_parallelism, mapping.len())
+                            .ok_or_else(|| BatchError::EmptyWorkerNodes)?;
+                    Ok(masked_mapping)
+                }
             }
         }
     }
@@ -395,29 +411,51 @@ impl WorkerNodeSelector {
             .map(|w| (*w).clone())
     }
 
+    fn is_current_version_worker(worker: &WorkerNode, current_rw_version: &str) -> bool {
+        worker
+            .resource
+            .as_ref()
+            .is_some_and(|resource| resource.rw_version == current_rw_version)
+    }
+
     fn apply_worker_node_mask(&self, origin: Vec<WorkerNode>) -> Vec<WorkerNode> {
-        let mask = self.manager.worker_node_mask();
-        if origin.iter().all(|w| mask.contains(&w.id)) {
+        let current_rw_version = current_rw_version();
+        let workers_with_current_version = origin
+            .into_iter()
+            .filter(|worker| Self::is_current_version_worker(worker, &current_rw_version))
+            .collect::<Vec<_>>();
+        let worker_node_mask = self.manager.worker_node_mask_snapshot();
+        Self::apply_worker_node_mask_inner(workers_with_current_version, &worker_node_mask)
+    }
+
+    fn apply_worker_node_mask_inner(
+        origin: Vec<WorkerNode>,
+        worker_node_mask: &HashSet<WorkerId>,
+    ) -> Vec<WorkerNode> {
+        if origin.iter().all(|w| worker_node_mask.contains(&w.id)) {
             return origin;
         }
         origin
             .into_iter()
-            .filter(|w| !mask.contains(&w.id))
+            .filter(|w| !worker_node_mask.contains(&w.id))
             .collect()
     }
 }
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
     use itertools::Itertools;
+    use risingwave_common::RW_VERSION;
     use risingwave_common::util::addr::HostAddr;
     use risingwave_pb::common::worker_node;
     use risingwave_pb::common::worker_node::Property;
 
+    use super::*;
+
     #[test]
     fn test_worker_node_manager() {
-        use super::*;
-
         let manager = WorkerNodeManager::mock(vec![]);
         assert_eq!(manager.list_serving_worker_nodes().len(), 0);
         assert_eq!(manager.list_streaming_worker_nodes().len(), 0);
@@ -476,5 +514,165 @@ mod tests {
                 .collect_vec(),
             worker_nodes.as_slice()[1..].to_vec()
         );
+    }
+
+    fn serving_worker(id: u32, rw_version: Option<&str>) -> WorkerNode {
+        WorkerNode {
+            id: id.into(),
+            r#type: WorkerType::ComputeNode as i32,
+            host: Some(
+                HostAddr::try_from(format!("127.0.0.1:{}", 1234 + id).as_str())
+                    .unwrap()
+                    .to_protobuf(),
+            ),
+            state: worker_node::State::Running as i32,
+            property: Some(Property {
+                is_serving: true,
+                parallelism: 1,
+                ..Default::default()
+            }),
+            transactional_id: Some(id),
+            resource: rw_version.map(|version| worker_node::Resource {
+                rw_version: version.to_owned(),
+                ..Default::default()
+            }),
+            ..Default::default()
+        }
+    }
+
+    fn fragment_mapping_worker_ids(mapping: &WorkerSlotMapping) -> Vec<WorkerId> {
+        mapping
+            .iter_unique()
+            .map(|worker_slot_id| worker_slot_id.worker_id())
+            .collect_vec()
+    }
+
+    fn worker_slot_mapping(worker_ids: impl IntoIterator<Item = u32>) -> WorkerSlotMapping {
+        WorkerSlotMapping::new_uniform(
+            worker_ids
+                .into_iter()
+                .map(|worker_id| WorkerSlotId::new(worker_id.into(), 0))
+                .collect_vec()
+                .into_iter(),
+            4,
+        )
+    }
+
+    #[test]
+    fn test_fragment_mapping_masks_serving_workers_with_version_mismatch() {
+        let manager = Arc::new(WorkerNodeManager::mock(vec![
+            serving_worker(1, Some(RW_VERSION)),
+            serving_worker(2, Some("different-version")),
+        ]));
+        let selector = WorkerNodeSelector::new(manager.clone(), false);
+        manager
+            .set_serving_fragment_mapping(HashMap::from([(0.into(), worker_slot_mapping([1, 2]))]));
+
+        let mapping = selector.fragment_mapping(0.into()).unwrap();
+
+        assert_eq!(
+            fragment_mapping_worker_ids(&mapping),
+            vec![WorkerId::new(1)]
+        );
+    }
+
+    #[test]
+    fn test_fragment_mapping_keeps_serving_workers_with_current_version() {
+        let manager = Arc::new(WorkerNodeManager::mock(vec![
+            serving_worker(1, Some(RW_VERSION)),
+            serving_worker(2, Some(RW_VERSION)),
+        ]));
+        let selector = WorkerNodeSelector::new(manager.clone(), false);
+        manager
+            .set_serving_fragment_mapping(HashMap::from([(0.into(), worker_slot_mapping([1, 2]))]));
+
+        let mapping = selector.fragment_mapping(0.into()).unwrap();
+
+        assert_eq!(
+            fragment_mapping_worker_ids(&mapping),
+            vec![WorkerId::new(1), WorkerId::new(2)]
+        );
+    }
+
+    #[test]
+    fn test_fragment_mapping_masks_serving_workers_without_current_version() {
+        let manager = Arc::new(WorkerNodeManager::mock(vec![
+            serving_worker(1, Some(RW_VERSION)),
+            serving_worker(2, None),
+            serving_worker(3, Some("")),
+        ]));
+        let selector = WorkerNodeSelector::new(manager.clone(), false);
+        manager.set_serving_fragment_mapping(HashMap::from([(
+            0.into(),
+            worker_slot_mapping([1, 2, 3]),
+        )]));
+
+        let mapping = selector.fragment_mapping(0.into()).unwrap();
+
+        assert_eq!(
+            fragment_mapping_worker_ids(&mapping),
+            vec![WorkerId::new(1)]
+        );
+    }
+
+    #[test]
+    fn test_fragment_mapping_errors_when_all_serving_workers_have_version_mismatch() {
+        let manager = Arc::new(WorkerNodeManager::mock(vec![
+            serving_worker(1, Some("different-version")),
+            serving_worker(2, None),
+            serving_worker(3, Some("")),
+        ]));
+        let selector = WorkerNodeSelector::new(manager.clone(), false);
+        manager.set_serving_fragment_mapping(HashMap::from([(
+            0.into(),
+            worker_slot_mapping([1, 2, 3]),
+        )]));
+
+        assert!(matches!(
+            selector.fragment_mapping(0.into()),
+            Err(BatchError::EmptyWorkerNodes)
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_fragment_mapping_temporary_mask_fallback_keeps_version_filter() {
+        let manager = Arc::new(WorkerNodeManager::mock(vec![
+            serving_worker(1, Some(RW_VERSION)),
+            serving_worker(2, Some("different-version")),
+        ]));
+        let selector = WorkerNodeSelector::new(manager.clone(), false);
+        manager
+            .set_serving_fragment_mapping(HashMap::from([(0.into(), worker_slot_mapping([1, 2]))]));
+        manager.mask_worker_node(1.into(), Duration::from_secs(60));
+
+        let mapping = selector.fragment_mapping(0.into()).unwrap();
+
+        assert_eq!(
+            fragment_mapping_worker_ids(&mapping),
+            vec![WorkerId::new(1)]
+        );
+    }
+
+    #[tokio::test]
+    async fn test_fragment_mapping_version_mask_does_not_clear_temporary_mask() {
+        let manager = Arc::new(WorkerNodeManager::mock(vec![
+            serving_worker(1, Some(RW_VERSION)),
+            serving_worker(2, Some(RW_VERSION)),
+            serving_worker(3, Some("different-version")),
+        ]));
+        let selector = WorkerNodeSelector::new(manager.clone(), false);
+        manager.set_serving_fragment_mapping(HashMap::from([(
+            0.into(),
+            worker_slot_mapping([1, 2, 3]),
+        )]));
+        manager.mask_worker_node(2.into(), Duration::from_secs(60));
+
+        let mapping = selector.fragment_mapping(0.into()).unwrap();
+
+        assert_eq!(
+            fragment_mapping_worker_ids(&mapping),
+            vec![WorkerId::new(1)]
+        );
+        assert!(manager.worker_node_mask().contains(&WorkerId::new(2)));
     }
 }

--- a/src/common/src/util/mod.rs
+++ b/src/common/src/util/mod.rs
@@ -42,6 +42,7 @@ pub mod sort_util;
 pub mod stream_graph_visitor;
 pub mod tracing;
 pub mod value_encoding;
+pub mod version;
 pub mod worker_util;
 pub use tokio_util;
 pub mod cluster_limit;

--- a/src/common/src/util/version.rs
+++ b/src/common/src/util/version.rs
@@ -1,0 +1,40 @@
+// Copyright 2026 RisingWave Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::RW_VERSION;
+
+#[cfg(madsim)]
+const SIMULATED_RW_VERSION_ENV: &str = "RW_SIMULATED_RW_VERSION";
+#[cfg(madsim)]
+const SIMULATED_RW_VERSION_NODES_ENV: &str = "RW_SIMULATED_RW_VERSION_NODES";
+
+pub fn current_rw_version() -> String {
+    #[cfg(madsim)]
+    {
+        if let Ok(version) = std::env::var(SIMULATED_RW_VERSION_ENV)
+            && let Ok(nodes) = std::env::var(SIMULATED_RW_VERSION_NODES_ENV)
+        {
+            let hostname = crate::util::resource_util::hostname();
+            if nodes.split(',').any(|node| node.trim() == hostname) {
+                return version;
+            }
+        }
+    }
+
+    RW_VERSION.to_owned()
+}
+
+pub fn is_compatible_rw_version(rw_version: &str) -> bool {
+    rw_version == current_rw_version()
+}

--- a/src/frontend/src/observer/observer_manager.rs
+++ b/src/frontend/src/observer/observer_manager.rs
@@ -549,6 +549,7 @@ impl FrontendObserverNode {
 
     /// `update_worker_node_manager` is called in `start` method.
     /// It calls `add_worker_node` and `remove_worker_node` of `WorkerNodeManager`.
+    /// Node updates refresh volatile fields such as reported resources.
     fn update_worker_node_manager(&self, operation: Operation, node: WorkerNode) {
         tracing::debug!(
             "Update worker nodes, operation: {:?}, node: {:?}",
@@ -557,7 +558,7 @@ impl FrontendObserverNode {
         );
 
         match operation {
-            Operation::Add => self.worker_node_manager.add_worker_node(node),
+            Operation::Add | Operation::Update => self.worker_node_manager.add_worker_node(node),
             Operation::Delete => self.worker_node_manager.remove_worker_node(node),
             _ => (),
         }

--- a/src/frontend/src/scheduler/distributed/query.rs
+++ b/src/frontend/src/scheduler/distributed/query.rs
@@ -467,13 +467,14 @@ pub(crate) mod tests {
     use risingwave_batch::worker_manager::worker_node_manager::{
         WorkerNodeManager, WorkerNodeSelector,
     };
+    use risingwave_common::RW_VERSION;
     use risingwave_common::catalog::{
         ColumnCatalog, ColumnDesc, ConflictBehavior, CreateType, DEFAULT_SUPER_USER_ID, Engine,
         StreamJobStatus,
     };
     use risingwave_common::hash::{VirtualNode, VnodeCount, WorkerSlotId, WorkerSlotMapping};
     use risingwave_common::types::DataType;
-    use risingwave_pb::common::worker_node::Property;
+    use risingwave_pb::common::worker_node::{Property, Resource};
     use risingwave_pb::common::{HostAddress, WorkerNode, WorkerType};
     use risingwave_pb::plan_common::JoinType;
     use risingwave_rpc_client::ComputeClientPool;
@@ -677,6 +678,10 @@ pub(crate) mod tests {
                 ..Default::default()
             }),
             transactional_id: Some(0),
+            resource: Some(Resource {
+                rw_version: RW_VERSION.to_owned(),
+                ..Default::default()
+            }),
             ..Default::default()
         };
         let worker2 = WorkerNode {
@@ -694,6 +699,10 @@ pub(crate) mod tests {
                 ..Default::default()
             }),
             transactional_id: Some(1),
+            resource: Some(Resource {
+                rw_version: RW_VERSION.to_owned(),
+                ..Default::default()
+            }),
             ..Default::default()
         };
         let worker3 = WorkerNode {
@@ -711,6 +720,10 @@ pub(crate) mod tests {
                 ..Default::default()
             }),
             transactional_id: Some(2),
+            resource: Some(Resource {
+                rw_version: RW_VERSION.to_owned(),
+                ..Default::default()
+            }),
             ..Default::default()
         };
         let workers = vec![worker1, worker2, worker3];

--- a/src/meta/service/src/cluster_service.rs
+++ b/src/meta/service/src/cluster_service.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use risingwave_common::RW_VERSION;
+use risingwave_common::util::version::{current_rw_version, is_compatible_rw_version};
 use risingwave_meta::barrier::BarrierManagerRef;
 use risingwave_meta::manager::MetadataManager;
 use risingwave_pb::common::worker_node::State;
@@ -56,14 +56,15 @@ impl ClusterService for ClusterServiceImpl {
             .property
             .ok_or_else(|| MetaError::invalid_parameter("worker node property is not provided"))?;
         let resource = req.resource.unwrap_or_default();
+        let current_rw_version = current_rw_version();
         if matches!(
             worker_type,
             PbWorkerType::Frontend | PbWorkerType::ComputeNode | PbWorkerType::Compactor
-        ) && resource.rw_version != RW_VERSION
+        ) && !is_compatible_rw_version(&resource.rw_version)
         {
             return Err(MetaError::invalid_parameter(format!(
                 "worker node version {} does not match meta node version {}",
-                resource.rw_version, RW_VERSION,
+                resource.rw_version, current_rw_version,
             ))
             .into());
         }

--- a/src/meta/src/controller/cluster.rs
+++ b/src/meta/src/controller/cluster.rs
@@ -19,12 +19,12 @@ use std::sync::Arc;
 use std::time::{Duration, SystemTime};
 
 use itertools::Itertools;
-use risingwave_common::RW_VERSION;
 use risingwave_common::hash::WorkerSlotId;
 use risingwave_common::util::addr::HostAddr;
 use risingwave_common::util::resource_util::cpu::total_cpu_available;
 use risingwave_common::util::resource_util::hostname;
 use risingwave_common::util::resource_util::memory::system_memory_available_bytes;
+use risingwave_common::util::version::current_rw_version;
 use risingwave_common::util::worker_util::DEFAULT_RESOURCE_GROUP;
 use risingwave_license::LicenseManager;
 use risingwave_meta_model::prelude::{Worker, WorkerProperty};
@@ -220,10 +220,38 @@ impl ClusterController {
         resource: Option<PbResource>,
     ) -> MetaResult<()> {
         tracing::trace!(target: "events::meta::server_heartbeat", %worker_id, "receive heartbeat");
-        self.inner
-            .write()
-            .await
-            .heartbeat(worker_id, self.max_heartbeat_interval, resource)
+        let worker_to_notify = {
+            let mut inner = self.inner.write().await;
+            let should_notify_frontend = resource.as_ref().is_some_and(|resource| {
+                inner
+                    .get_worker_extra_info_by_id(worker_id)
+                    .is_some_and(|info| info.resource != *resource)
+            });
+
+            inner.heartbeat(worker_id, self.max_heartbeat_interval, resource)?;
+
+            if should_notify_frontend {
+                // Resource is volatile and rebuilt as default after meta restart. Notify frontends
+                // once heartbeat restores it, so schedulers see the worker's reported version.
+                inner.get_worker_by_id(worker_id).await?
+            } else {
+                None
+            }
+        };
+
+        if let Some(worker) = worker_to_notify
+            && matches!(
+                worker.r#type(),
+                PbWorkerType::ComputeNode | PbWorkerType::Frontend
+            )
+        {
+            self.env
+                .notification_manager()
+                .notify_frontend(Operation::Update, Info::Node(worker))
+                .await;
+        }
+
+        Ok(())
     }
 
     pub fn start_heartbeat_checker(
@@ -484,7 +512,7 @@ fn meta_node_info(host: &str, started_at: Option<u64>) -> PbWorkerNode {
         property: None,
         transactional_id: None,
         resource: Some(risingwave_pb::common::worker_node::Resource {
-            rw_version: RW_VERSION.to_owned(),
+            rw_version: current_rw_version(),
             total_memory_bytes: system_memory_available_bytes() as _,
             total_cpu_cores: total_cpu_available() as _,
             hostname: hostname(),

--- a/src/rpc_client/src/meta_client.rs
+++ b/src/rpc_client/src/meta_client.rs
@@ -28,7 +28,6 @@ use futures::stream::BoxStream;
 use list_rate_limits_response::RateLimitInfo;
 use lru::LruCache;
 use replace_job_plan::ReplaceJob;
-use risingwave_common::RW_VERSION;
 use risingwave_common::catalog::{
     AlterDatabaseParam, FunctionId, IndexId, ObjectId, SecretId, TableId,
 };
@@ -46,6 +45,7 @@ use risingwave_common::util::meta_addr::MetaAddressStrategy;
 use risingwave_common::util::resource_util::cpu::total_cpu_available;
 use risingwave_common::util::resource_util::hostname;
 use risingwave_common::util::resource_util::memory::system_memory_available_bytes;
+use risingwave_common::util::version::current_rw_version;
 use risingwave_error::bail;
 use risingwave_error::tonic::ErrorIsFromTonicServerImpl;
 use risingwave_hummock_sdk::change_log::{TableChangeLog, TableChangeLogs};
@@ -307,7 +307,7 @@ impl MetaClient {
                         host: Some(addr.to_protobuf()),
                         property: Some(property.clone()),
                         resource: Some(risingwave_pb::common::worker_node::Resource {
-                            rw_version: RW_VERSION.to_owned(),
+                            rw_version: current_rw_version(),
                             total_memory_bytes: system_memory_available_bytes() as _,
                             total_cpu_cores: total_cpu_available() as _,
                             hostname: hostname(),
@@ -381,7 +381,7 @@ impl MetaClient {
         let request = HeartbeatRequest {
             node_id: self.worker_id,
             resource: Some(risingwave_pb::common::worker_node::Resource {
-                rw_version: RW_VERSION.to_owned(),
+                rw_version: current_rw_version(),
                 total_memory_bytes: system_memory_available_bytes() as _,
                 total_cpu_cores: total_cpu_available() as _,
                 hostname: hostname(),

--- a/src/tests/simulation/Cargo.toml
+++ b/src/tests/simulation/Cargo.toml
@@ -26,6 +26,7 @@ pretty_assertions = "1"
 rand = { workspace = true }
 rand_chacha = { version = "0.9" }
 rdkafka = { workspace = true }
+risingwave_batch = { workspace = true }
 risingwave_batch_executors = { workspace = true }
 risingwave_common = { workspace = true }
 risingwave_compactor = { workspace = true }

--- a/src/tests/simulation/tests/integration_tests/recovery/locality_backfill.rs
+++ b/src/tests/simulation/tests/integration_tests/recovery/locality_backfill.rs
@@ -29,6 +29,28 @@ const ALTER_RATE_LIMIT_DEFAULT: &str =
 const WAIT: &str = "WAIT;";
 const WAIT_INTERNAL_STATE_SECS: u64 = 60;
 
+async fn wait_internal_table_name(
+    session: &mut Session,
+    table_name_pattern: &str,
+    context: &str,
+) -> Result<String> {
+    for _ in 0..WAIT_INTERNAL_STATE_SECS * 10 {
+        let table_name = session
+            .run(&format!(
+                "SELECT name FROM rw_internal_tables WHERE name LIKE '{}' LIMIT 1;",
+                table_name_pattern
+            ))
+            .await?;
+        if !table_name.is_empty() {
+            return Ok(table_name);
+        }
+
+        sleep(Duration::from_millis(100)).await;
+    }
+
+    bail!("Internal table should exist {}", context);
+}
+
 async fn wait_internal_state_table_non_empty(
     session: &mut Session,
     state_table_name: &str,
@@ -78,18 +100,18 @@ async fn test_locality_backfill_recovery_internal_tables() -> Result<()> {
     session.run(CREATE_MV).await?;
 
     // Step 5: Find the internal table names for locality provider
-    let state_table_name = session
-        .run("SELECT name FROM rw_internal_tables WHERE name LIKE '%localityproviderstate%';")
-        .await?;
-    let progress_table_name = session
-        .run("SELECT name FROM rw_internal_tables WHERE name LIKE '%localityproviderprogress%';")
-        .await?;
-
-    assert!(!state_table_name.is_empty(), "State table should exist");
-    assert!(
-        !progress_table_name.is_empty(),
-        "Progress table should exist"
-    );
+    let state_table_name = wait_internal_table_name(
+        &mut session,
+        "%localityproviderstate%",
+        "for locality provider state",
+    )
+    .await?;
+    let progress_table_name = wait_internal_table_name(
+        &mut session,
+        "%localityproviderprogress%",
+        "for locality provider progress",
+    )
+    .await?;
 
     // Step 6: Check internal tables before recovery
     // State table should be non-empty (contains vnode positions during backfill)

--- a/src/tests/simulation/tests/integration_tests/recovery/mod.rs
+++ b/src/tests/simulation/tests/integration_tests/recovery/mod.rs
@@ -20,4 +20,5 @@ mod event_log;
 mod locality_backfill;
 mod nexmark_recovery;
 mod serving_mapping;
+mod serving_mapping_start_order;
 mod time_travel;

--- a/src/tests/simulation/tests/integration_tests/recovery/serving_mapping_start_order.rs
+++ b/src/tests/simulation/tests/integration_tests/recovery/serving_mapping_start_order.rs
@@ -1,0 +1,597 @@
+// Copyright 2026 RisingWave Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#![cfg(madsim)]
+
+use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
+use std::time::Duration;
+
+use anyhow::{Context, Result, anyhow};
+use clap::Parser;
+use itertools::Itertools;
+use madsim::net::ipvs::ServiceAddr;
+use risingwave_batch::rpc::service::madsim_test_utils::{
+    create_task_count, reset_create_task_counts,
+};
+use risingwave_common::RW_VERSION;
+use risingwave_common::config::RwConfig;
+use risingwave_common::id::TableId;
+use risingwave_common::util::addr::HostAddr;
+use risingwave_common::util::meta_addr::MetaAddressStrategy;
+use risingwave_common::util::tokio_util::sync::CancellationToken;
+use risingwave_common::util::worker_util::DEFAULT_RESOURCE_GROUP;
+use risingwave_pb::common::worker_node::Property;
+use risingwave_pb::common::{WorkerNode, WorkerType};
+use risingwave_rpc_client::MetaClient;
+use risingwave_simulation::client::RisingWave;
+use risingwave_simulation::cluster::{Cluster, Configuration};
+use sqllogictest::{AsyncDB, DBOutput};
+use tokio::time::sleep;
+
+const WAIT_TIMEOUT: Duration = Duration::from_secs(100);
+const POLL_INTERVAL: Duration = Duration::from_millis(500);
+const FRONTEND_HOSTS: [&str; 2] = ["192.168.2.1", "192.168.2.2"];
+const COMPUTE_HOSTS: [&str; 2] = ["192.168.3.1", "192.168.3.2"];
+const COMPUTE_NODES: [&str; 2] = ["compute-1", "compute-2"];
+const UPGRADED_VERSION: &str = "rw-version-from-newer-binary";
+const SIMULATED_RW_VERSION_ENV: &str = "RW_SIMULATED_RW_VERSION";
+const SIMULATED_RW_VERSION_NODES_ENV: &str = "RW_SIMULATED_RW_VERSION_NODES";
+
+struct SimulatedRwVersionGuard;
+
+impl SimulatedRwVersionGuard {
+    fn enable(version: &str, nodes: &[&str]) -> Self {
+        unsafe {
+            std::env::set_var(SIMULATED_RW_VERSION_ENV, version);
+            std::env::set_var(SIMULATED_RW_VERSION_NODES_ENV, nodes.join(","));
+        }
+        Self
+    }
+}
+
+impl Drop for SimulatedRwVersionGuard {
+    fn drop(&mut self) {
+        unsafe {
+            std::env::remove_var(SIMULATED_RW_VERSION_ENV);
+            std::env::remove_var(SIMULATED_RW_VERSION_NODES_ENV);
+        }
+    }
+}
+
+fn serving_mapping_config() -> Configuration {
+    let mut config = Configuration::default();
+    config.frontend_nodes = 0;
+    config.compute_nodes = 0;
+    config.compactor_nodes = 0;
+    config.compute_node_cores = 1;
+    config
+}
+
+fn start_frontend_node(cluster: &Cluster, index: usize) {
+    let config = cluster.config();
+    madsim::net::NetSim::current().global_ipvs().add_server(
+        ServiceAddr::Tcp("192.168.2.0:4566".into()),
+        &format!("192.168.2.{index}:4566"),
+    );
+
+    let opts = risingwave_frontend::FrontendOpts::parse_from([
+        "frontend-node",
+        "--config-path",
+        config.config_path.as_str(),
+        "--listen-addr",
+        "0.0.0.0:4566",
+        "--health-check-listener-addr",
+        "0.0.0.0:6786",
+        "--advertise-addr",
+        &format!("192.168.2.{index}:4566"),
+        "--temp-secret-file-dir",
+        &format!("./secrets/frontend-{index}"),
+    ]);
+    cluster
+        .handle()
+        .create_node()
+        .name(format!("frontend-{index}"))
+        .ip([192, 168, 2, index as u8].into())
+        .init(move || risingwave_frontend::start(opts.clone(), CancellationToken::new()))
+        .build();
+}
+
+fn start_compute_node(cluster: &Cluster, index: usize) {
+    let config = cluster.config();
+    let opts = risingwave_compute::ComputeNodeOpts::parse_from([
+        "compute-node",
+        "--config-path",
+        config.config_path.as_str(),
+        "--listen-addr",
+        "0.0.0.0:5688",
+        "--advertise-addr",
+        &format!("192.168.3.{index}:5688"),
+        "--total-memory-bytes",
+        "6979321856",
+        "--parallelism",
+        &config.compute_node_cores.to_string(),
+        "--temp-secret-file-dir",
+        &format!("./secrets/compute-{index}"),
+        "--resource-group",
+        DEFAULT_RESOURCE_GROUP,
+        "--role",
+        "both",
+    ]);
+    cluster
+        .handle()
+        .create_node()
+        .name(format!("compute-{index}"))
+        .ip([192, 168, 3, index as u8].into())
+        .cores(config.compute_node_cores)
+        .init(move || risingwave_compute::start(opts.clone(), CancellationToken::new()))
+        .build();
+}
+
+async fn start_frontend_nodes(cluster: &Cluster) {
+    for index in 1..=2 {
+        start_frontend_node(cluster, index);
+    }
+    sleep(Duration::from_secs(5)).await;
+}
+
+async fn start_compute_nodes(cluster: &Cluster) {
+    for index in 1..=2 {
+        start_compute_node(cluster, index);
+    }
+    sleep(Duration::from_secs(5)).await;
+}
+
+async fn run_on_frontend(
+    cluster: &Cluster,
+    host: impl Into<String>,
+    sql: impl Into<String>,
+) -> Result<String> {
+    let host = host.into();
+    let sql = sql.into();
+    cluster
+        .run_on_client(async move {
+            let mut client = RisingWave::connect(host.clone(), "dev".to_owned())
+                .await
+                .with_context(|| format!("failed to connect to frontend {host}"))?;
+            let output = client
+                .run(&sql)
+                .await
+                .with_context(|| format!("failed to run query on frontend {host}: {sql}"))?;
+            Ok(match output {
+                DBOutput::Rows { rows, .. } => rows
+                    .into_iter()
+                    .map(|row| {
+                        row.into_iter()
+                            .map(|value| value.to_string())
+                            .collect_vec()
+                            .join(" ")
+                    })
+                    .collect_vec()
+                    .join("\n"),
+                _ => String::new(),
+            })
+        })
+        .await
+}
+
+async fn wait_frontend_result(
+    cluster: &Cluster,
+    host: &str,
+    sql: &str,
+    expected: &str,
+) -> Result<()> {
+    let host = host.to_owned();
+    let sql = sql.to_owned();
+    let expected = expected.to_owned();
+    let mut last_observation = "no query attempted".to_owned();
+    tokio::time::timeout(WAIT_TIMEOUT, async {
+        loop {
+            match run_on_frontend(cluster, host.clone(), sql.clone()).await {
+                Ok(result) if result.trim() == expected => return Ok(()),
+                Ok(result) => {
+                    last_observation = format!("last result `{}`", result.trim());
+                }
+                Err(error) => {
+                    last_observation = format!("last error: {error:#}");
+                }
+            }
+            sleep(POLL_INTERVAL).await;
+        }
+    })
+    .await
+    .map_err(|_| {
+        anyhow!(
+            "timed out waiting for `{sql}` on {host} to return `{expected}`; {last_observation}"
+        )
+    })?
+}
+
+async fn wait_worker_versions_on_all_frontends(cluster: &Cluster, expected: &str) -> Result<()> {
+    let sql = format!(
+        "SELECT count(*), count(*) FILTER (WHERE rw_version = '{}') \
+         FROM rw_catalog.rw_worker_nodes \
+         WHERE type IN (\
+             'WORKER_TYPE_META', \
+             'WORKER_TYPE_FRONTEND', \
+             'WORKER_TYPE_COMPUTE_NODE'\
+         );",
+        RW_VERSION
+    );
+    for host in FRONTEND_HOSTS {
+        wait_frontend_result(cluster, host, &sql, expected).await?;
+    }
+    Ok(())
+}
+
+async fn wait_batch_query_on_frontend(
+    cluster: &Cluster,
+    frontend_host: &str,
+    table_name: &str,
+) -> Result<()> {
+    let sql = format!("SELECT count(*), sum(v) FROM {table_name};");
+    wait_frontend_result(cluster, frontend_host, &sql, "1000 500500").await
+}
+
+async fn wait_frontend_schedules_batch_query_to_same_version_compute(
+    cluster: &Cluster,
+    frontend_host: &str,
+    table_name: &str,
+    expected_computes: &[&str],
+    mismatched_computes: &[&str],
+) -> Result<()> {
+    tokio::time::timeout(WAIT_TIMEOUT, async {
+        loop {
+            reset_create_task_counts();
+            wait_batch_query_on_frontend(cluster, frontend_host, table_name).await?;
+
+            let expected_counts = expected_computes
+                .iter()
+                .map(|compute| (*compute, create_task_count(compute)))
+                .collect_vec();
+            let mismatched_counts = mismatched_computes
+                .iter()
+                .map(|compute| (*compute, create_task_count(compute)))
+                .collect_vec();
+            if expected_counts.iter().all(|(_, count)| *count > 0)
+                && mismatched_counts.iter().all(|(_, count)| *count == 0)
+            {
+                return Ok(());
+            }
+
+            tracing::info!(
+                frontend_host,
+                ?expected_counts,
+                ?mismatched_counts,
+                "frontend scheduler has not applied rw_version filter yet"
+            );
+            sleep(POLL_INTERVAL).await;
+        }
+    })
+    .await
+    .map_err(|_| {
+        anyhow!(
+            "{frontend_host} did not schedule batch tasks only to same-version computes: \
+             expected {expected_computes:?}, mismatched {mismatched_computes:?}"
+        )
+    })?
+}
+
+async fn wait_frontends_schedule_batch_query_to_same_version_computes(
+    cluster: &Cluster,
+    table_name: &str,
+    frontend_compute_sets: &[(&str, &[&str], &[&str])],
+) -> Result<()> {
+    for (frontend_host, expected_computes, mismatched_computes) in frontend_compute_sets {
+        wait_frontend_schedules_batch_query_to_same_version_compute(
+            cluster,
+            frontend_host,
+            table_name,
+            expected_computes,
+            mismatched_computes,
+        )
+        .await?;
+    }
+    Ok(())
+}
+
+async fn create_test_table(cluster: &mut Cluster, table_name: &str) -> Result<u32> {
+    cluster
+        .run(format!("CREATE TABLE {table_name}(v int);"))
+        .await?;
+    cluster
+        .run(format!(
+            "INSERT INTO {table_name} SELECT * FROM generate_series(1, 1000);"
+        ))
+        .await?;
+    cluster.run("FLUSH;").await?;
+    cluster
+        .run(format!(
+            "SELECT id FROM rw_catalog.rw_tables WHERE name = '{table_name}';"
+        ))
+        .await?
+        .trim()
+        .parse()
+        .with_context(|| format!("failed to parse table id for {table_name}"))
+}
+
+async fn wait_for_cluster_ready(cluster: &Cluster) -> Result<()> {
+    wait_worker_versions_on_all_frontends(cluster, "5 5").await
+}
+
+async fn wait_for_expected_serving_mapping(
+    cluster: &Cluster,
+    table_id: u32,
+    expected_worker_hosts: &[&str],
+) -> Result<()> {
+    let expected_worker_hosts = expected_worker_hosts
+        .iter()
+        .map(|host| (*host).to_owned())
+        .collect::<HashSet<_>>();
+    let expected_worker_count = expected_worker_hosts.len();
+    tokio::time::timeout(WAIT_TIMEOUT, async {
+        loop {
+            match serving_mapping_worker_hosts(cluster, table_id).await {
+                Ok(worker_hosts) if worker_hosts == expected_worker_hosts => return Ok(()),
+                Ok(worker_hosts) => {
+                    tracing::info!(
+                        ?worker_hosts,
+                        ?expected_worker_hosts,
+                        "serving mapping not ready"
+                    );
+                }
+                Err(error) => {
+                    tracing::info!(%error, "serving mapping not ready");
+                }
+            }
+            sleep(POLL_INTERVAL).await;
+        }
+    })
+    .await
+    .map_err(|_| {
+        anyhow!(
+            "timed out waiting for serving mapping of table {table_id} to cover \
+             {expected_worker_count} expected workers"
+        )
+    })?
+}
+
+async fn serving_mapping_worker_hosts(cluster: &Cluster, table_id: u32) -> Result<HashSet<String>> {
+    cluster
+        .run_on_client(async move {
+            let meta_addr = "http://meta-1:5690".parse::<MetaAddressStrategy>()?;
+            let host_addr = "serving-start-order-test-meta-client:0".parse::<HostAddr>()?;
+            let (meta_client, _) = MetaClient::register_new(
+                meta_addr,
+                WorkerType::RiseCtl,
+                &host_addr,
+                Property::default(),
+                Arc::new(RwConfig::default().meta),
+            )
+            .await;
+
+            let result = serving_mapping_worker_hosts_inner(&meta_client, table_id).await;
+            meta_client.try_unregister().await;
+            result
+        })
+        .await
+}
+
+async fn serving_mapping_worker_hosts_inner(
+    meta_client: &MetaClient,
+    table_id: u32,
+) -> Result<HashSet<String>> {
+    let table_id = TableId::new(table_id);
+    let result_fragments = meta_client
+        .list_fragment_distributions(false)
+        .await?
+        .into_iter()
+        .filter(|fragment| fragment.state_table_ids.contains(&table_id))
+        .collect_vec();
+    let [result_fragment] = result_fragments.as_slice() else {
+        return Err(anyhow!(
+            "table {} must have one result fragment, got {}",
+            table_id.as_raw_id(),
+            result_fragments.len()
+        ));
+    };
+
+    let worker_id_to_host = meta_client
+        .list_worker_nodes(None)
+        .await?
+        .into_iter()
+        .filter(|worker| worker.r#type() == WorkerType::ComputeNode)
+        .filter_map(|worker| worker.host.map(|host| (worker.id, host.host)))
+        .collect::<HashMap<_, _>>();
+    let serving_mappings = meta_client.list_serving_vnode_mappings().await?;
+    let (_, serving_mapping) = serving_mappings
+        .get(&result_fragment.fragment_id)
+        .context("serving vnode mapping is missing result fragment")?;
+
+    let worker_ids = serving_mapping
+        .iter_unique()
+        .map(|slot| slot.worker_id())
+        .collect::<HashSet<_>>();
+    worker_ids
+        .into_iter()
+        .map(|worker_id| {
+            worker_id_to_host
+                .get(&worker_id)
+                .cloned()
+                .with_context(|| format!("serving worker {} has no host", worker_id.as_raw_id()))
+        })
+        .collect()
+}
+
+async fn assert_serving_cluster(cluster: &mut Cluster, table_name: &str) -> Result<()> {
+    wait_for_cluster_ready(cluster).await?;
+    let table_id = create_test_table(cluster, table_name).await?;
+    wait_for_expected_serving_mapping(cluster, table_id, &COMPUTE_HOSTS).await?;
+    wait_frontends_schedule_batch_query_to_same_version_computes(
+        cluster,
+        table_name,
+        &[
+            (FRONTEND_HOSTS[0], &COMPUTE_NODES, &[]),
+            (FRONTEND_HOSTS[1], &COMPUTE_NODES, &[]),
+        ],
+    )
+    .await
+}
+
+async fn wait_worker_hosts_registered(
+    cluster: &Cluster,
+    expected_hosts: &[&str],
+) -> Result<Vec<WorkerNode>> {
+    let expected_hosts = expected_hosts
+        .iter()
+        .map(|host| (*host).to_owned())
+        .collect::<HashSet<_>>();
+    tokio::time::timeout(WAIT_TIMEOUT, async {
+        loop {
+            let workers = cluster
+                .run_on_client(async {
+                    let meta_addr = "http://meta-1:5690".parse::<MetaAddressStrategy>()?;
+                    let host_addr = "serving-start-order-worker-wait:0".parse::<HostAddr>()?;
+                    let (meta_client, _) = MetaClient::register_new(
+                        meta_addr,
+                        WorkerType::RiseCtl,
+                        &host_addr,
+                        Property::default(),
+                        Arc::new(RwConfig::default().meta),
+                    )
+                    .await;
+                    let workers = meta_client
+                        .list_worker_nodes(None)
+                        .await
+                        .unwrap_or_default()
+                        .into_iter()
+                        .filter(|worker| worker.r#type() == WorkerType::ComputeNode)
+                        .collect_vec();
+                    let _ = meta_client.try_unregister().await;
+                    Ok::<_, anyhow::Error>(workers)
+                })
+                .await?;
+            let registered_hosts = workers
+                .iter()
+                .filter_map(|worker| worker.host.as_ref().map(|host| host.host.clone()))
+                .collect::<HashSet<_>>();
+            if expected_hosts.is_subset(&registered_hosts) {
+                return Ok(workers);
+            }
+            sleep(POLL_INTERVAL).await;
+        }
+    })
+    .await
+    .map_err(|_| anyhow!("timed out waiting for compute workers {expected_hosts:?}"))?
+}
+
+#[tokio::test]
+async fn test_serving_mapping_frontend_then_serving_join() -> Result<()> {
+    let mut cluster = Cluster::start(serving_mapping_config()).await?;
+
+    start_frontend_nodes(&cluster).await;
+    start_compute_nodes(&cluster).await;
+
+    assert_serving_cluster(&mut cluster, "serve_join_fe_first").await
+}
+
+#[tokio::test]
+async fn test_serving_mapping_serving_then_frontend_join() -> Result<()> {
+    let mut cluster = Cluster::start(serving_mapping_config()).await?;
+
+    start_compute_nodes(&cluster).await;
+    wait_worker_hosts_registered(&cluster, &COMPUTE_HOSTS).await?;
+    start_frontend_nodes(&cluster).await;
+
+    assert_serving_cluster(&mut cluster, "serve_join_compute_first").await
+}
+
+#[tokio::test]
+async fn test_serving_mapping_after_meta_restart() -> Result<()> {
+    let mut cluster = Cluster::start(serving_mapping_config()).await?;
+
+    start_compute_nodes(&cluster).await;
+    start_frontend_nodes(&cluster).await;
+    assert_serving_cluster(&mut cluster, "serve_meta_restart").await?;
+
+    cluster.simple_kill_nodes(["meta-1"]).await;
+    sleep(Duration::from_secs(5)).await;
+    cluster.simple_restart_nodes(["meta-1"]).await;
+
+    wait_worker_versions_on_all_frontends(&cluster, "5 5").await?;
+    let table_id = cluster
+        .run("SELECT id FROM rw_catalog.rw_tables WHERE name = 'serve_meta_restart';")
+        .await?
+        .trim()
+        .parse()
+        .context("failed to parse serve_meta_restart table id")?;
+    wait_for_expected_serving_mapping(&cluster, table_id, &COMPUTE_HOSTS).await?;
+    wait_frontends_schedule_batch_query_to_same_version_computes(
+        &cluster,
+        "serve_meta_restart",
+        &[
+            (FRONTEND_HOSTS[0], &COMPUTE_NODES, &[]),
+            (FRONTEND_HOSTS[1], &COMPUTE_NODES, &[]),
+        ],
+    )
+    .await
+}
+
+#[tokio::test]
+async fn test_serving_mapping_masks_worker_with_mismatched_version() -> Result<()> {
+    let mut cluster = Cluster::start(serving_mapping_config()).await?;
+
+    start_compute_nodes(&cluster).await;
+    start_frontend_nodes(&cluster).await;
+    wait_for_cluster_ready(&cluster).await?;
+    let table_id = create_test_table(&mut cluster, "serve_version_mask").await?;
+    wait_for_expected_serving_mapping(&cluster, table_id, &COMPUTE_HOSTS).await?;
+
+    let _version_guard =
+        SimulatedRwVersionGuard::enable(UPGRADED_VERSION, &["meta-1", "frontend-1", "compute-1"]);
+    cluster
+        .simple_kill_nodes(["meta-1", "frontend-1", "compute-1"])
+        .await;
+    sleep(Duration::from_secs(5)).await;
+    cluster
+        .simple_restart_nodes(["meta-1", "frontend-1", "compute-1"])
+        .await;
+
+    let version_sql = format!(
+        "SELECT count(*), count(*) FILTER (WHERE rw_version = '{}'), \
+         count(*) FILTER (WHERE rw_version = '{}') \
+         FROM rw_catalog.rw_worker_nodes \
+         WHERE type IN (\
+             'WORKER_TYPE_META', \
+             'WORKER_TYPE_FRONTEND', \
+             'WORKER_TYPE_COMPUTE_NODE'\
+         );",
+        RW_VERSION, UPGRADED_VERSION
+    );
+    for host in FRONTEND_HOSTS {
+        wait_frontend_result(&cluster, host, &version_sql, "5 2 3").await?;
+    }
+
+    wait_worker_hosts_registered(&cluster, &COMPUTE_HOSTS).await?;
+    wait_for_expected_serving_mapping(&cluster, table_id, &COMPUTE_HOSTS).await?;
+    wait_frontends_schedule_batch_query_to_same_version_computes(
+        &cluster,
+        "serve_version_mask",
+        &[
+            (FRONTEND_HOSTS[0], &["compute-1"], &["compute-2"]),
+            (FRONTEND_HOSTS[1], &["compute-2"], &["compute-1"]),
+        ],
+    )
+    .await
+}


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

Cherry-picks #26559 (`4afdad1183ddee28a710ffd7fbe9fedc9d6a19d0`) to `release-3.0`.

Release-branch adaptations kept the existing `fragment_mapping(fragment_id)` API while preserving the version-mismatch serving worker mask behavior, and updated the release heartbeat path to report `current_rw_version()`.

- Closes #26595

## Checklist

- [ ] I have written necessary rustdoc comments.
- [x] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [x] <!-- OPTIONAL --> I have added test labels as necessary.
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them.
- [ ] <!-- OPTIONAL --> My PR contains breaking changes.
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results.
- [x] <!-- OPTIONAL --> I have checked the Release Timeline and Currently Supported Versions to determine which release branches I need to cherry-pick this PR into.

## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates.

<details>
<summary><b>Release note</b></summary>

Fixes batch serving worker selection during rolling upgrades by avoiding serving workers whose reported RisingWave version does not match the current binary.

</details>