### PR TITLE
feat(batch): support lookup join on a lookup table with singleton distribution

### DIFF
--- a/e2e_test/batch/basic/lookup_join.slt.part
+++ b/e2e_test/batch/basic/lookup_join.slt.part
@@ -286,3 +286,34 @@ drop materialized view mv;
 
 statement ok
 drop table t;
+
+# Lookup join on a lookup table with singleton distribution (e.g. a topN materialized view).
+statement ok
+create table t (a int, b int);
+
+statement ok
+create materialized view mv_singleton as select a, b from t order by a limit 100;
+
+sleep 1s
+
+statement ok
+insert into t values (1, 10), (2, 20), (3, 30);
+
+query IIII
+select * from t join mv_singleton on t.a = mv_singleton.a order by t.a;
+----
+1 10 1 10
+2 20 2 20
+3 30 3 30
+
+query IIII
+select * from t left join mv_singleton on t.a = mv_singleton.a where t.a > 1 order by t.a;
+----
+2 20 2 20
+3 30 3 30
+
+statement ok
+drop materialized view mv_singleton;
+
+statement ok
+drop table t;

--- a/src/batch/executors/src/executor/join/distributed_lookup_join.rs
+++ b/src/batch/executors/src/executor/join/distributed_lookup_join.rs
@@ -178,7 +178,11 @@ impl BoxedExecutorBuilder for DistributedLookupJoinExecutorBuilder {
             .map(ColumnId::from)
             .collect();
 
-        // Lookup Join always contains distribution key, so we don't need vnode bitmap
+        // Use a full vnode bitmap so that the lookup can be performed on any worker.
+        // For a lookup table with hash distribution, the lookup keys always contain the
+        // distribution key; for a lookup table with singleton distribution, all lookups
+        // are gathered into a single task. In both cases the lookup is correct regardless
+        // of which worker the task is scheduled to.
         let vnodes = Some(Bitmap::ones(table_desc.vnode_count()).into());
 
         dispatch_state_store!(source.context().state_store(), state_store, {

--- a/src/frontend/planner_test/tests/testdata/input/distributed_lookup_join.yaml
+++ b/src/frontend/planner_test/tests/testdata/input/distributed_lookup_join.yaml
@@ -30,3 +30,18 @@
     select * from t1 natural join t2;
   expected_outputs:
     - batch_plan
+- id: lookup join on a lookup table with singleton distribution
+  sql: |
+    create table t1 (a int, b int);
+    create materialized view mv1 as select a, b from t1 order by a limit 100;
+    select * from t1 join mv1 on t1.a = mv1.a;
+  expected_outputs:
+    - batch_plan
+    - batch_local_plan
+- id: no lookup join on a singleton lookup table if the join key is not a prefix of its primary key
+  sql: |
+    create table t1 (a int, b int);
+    create materialized view mv1 as select a, b from t1 order by a limit 100;
+    select * from t1 join mv1 on t1.b = mv1.b;
+  expected_outputs:
+    - batch_plan

--- a/src/frontend/planner_test/tests/testdata/output/distributed_lookup_join.yaml
+++ b/src/frontend/planner_test/tests/testdata/output/distributed_lookup_join.yaml
@@ -43,3 +43,29 @@
     └─BatchLookupJoin { type: Inner, predicate: t1.c = idx.c AND t1.b = idx.b AND t1.a = idx.a, output: [t1.c, t1.b, t1.a], lookup table: idx }
       └─BatchExchange { order: [], dist: UpstreamHashShard(t1.c, t1.b, t1.a) }
         └─BatchScan { table: t1, columns: [t1.a, t1.b, t1.c], distribution: SomeShard }
+- id: lookup join on a lookup table with singleton distribution
+  sql: |
+    create table t1 (a int, b int);
+    create materialized view mv1 as select a, b from t1 order by a limit 100;
+    select * from t1 join mv1 on t1.a = mv1.a;
+  batch_plan: |-
+    BatchExchange { order: [], dist: Single }
+    └─BatchLookupJoin { type: Inner, predicate: t1.a = mv1.a, output: all, lookup table: mv1 }
+      └─BatchExchange { order: [], dist: Single }
+        └─BatchScan { table: t1, columns: [t1.a, t1.b], distribution: SomeShard }
+  batch_local_plan: |-
+    BatchLookupJoin { type: Inner, predicate: t1.a = mv1.a, output: all, lookup table: mv1 }
+    └─BatchExchange { order: [], dist: Single }
+      └─BatchScan { table: t1, columns: [t1.a, t1.b], distribution: SomeShard }
+- id: no lookup join on a singleton lookup table if the join key is not a prefix of its primary key
+  sql: |
+    create table t1 (a int, b int);
+    create materialized view mv1 as select a, b from t1 order by a limit 100;
+    select * from t1 join mv1 on t1.b = mv1.b;
+  batch_plan: |-
+    BatchExchange { order: [], dist: Single }
+    └─BatchHashJoin { type: Inner, predicate: t1.b = mv1.b, output: all }
+      ├─BatchExchange { order: [], dist: HashShard(t1.b) }
+      │ └─BatchScan { table: t1, columns: [t1.a, t1.b], distribution: SomeShard }
+      └─BatchExchange { order: [], dist: HashShard(mv1.b) }
+        └─BatchScan { table: mv1, columns: [mv1.a, mv1.b], distribution: Single }

--- a/src/frontend/planner_test/tests/testdata/output/index_selection.yaml
+++ b/src/frontend/planner_test/tests/testdata/output/index_selection.yaml
@@ -659,13 +659,14 @@
   batch_plan: |-
     BatchExchange { order: [], dist: Single }
     └─BatchProject { exprs: [1:Int32] }
-      └─BatchFilter { predicate: (mc.id = 1:Int32) AND (mc.tag = 'x':Varchar) }
-        └─BatchScan { table: mc, columns: [mc.id, mc.tag], distribution: Single }
+      └─BatchLookupJoin { type: Inner, predicate: mc_idx.mc._row_id IS NOT DISTINCT FROM mc._row_id AND (mc.tag = 'x':Varchar), output: [], lookup table: mc }
+        └─BatchExchange { order: [], dist: Single }
+          └─BatchScan { table: mc_idx, columns: [mc_idx.mc._row_id], scan_ranges: [mc_idx.id = Int32(1)], distribution: SomeShard }
   batch_local_plan: |-
-    BatchExchange { order: [], dist: Single }
-    └─BatchProject { exprs: [1:Int32] }
-      └─BatchFilter { predicate: (mc.id = 1:Int32) AND (mc.tag = 'x':Varchar) }
-        └─BatchScan { table: mc, columns: [mc.id, mc.tag], distribution: SomeShard }
+    BatchProject { exprs: [1:Int32] }
+    └─BatchLookupJoin { type: Inner, predicate: mc_idx.mc._row_id IS NOT DISTINCT FROM mc._row_id AND (mc.tag = 'x':Varchar), output: [], lookup table: mc }
+      └─BatchExchange { order: [], dist: Single }
+        └─BatchScan { table: mc_idx, columns: [mc_idx.mc._row_id], scan_ranges: [mc_idx.id = Int32(1)], distribution: SomeShard }
 - name: create index to include all columns by default
   sql: |
     create table t1 (a int, b numeric, c bigint);

--- a/src/frontend/planner_test/tests/testdata/output/singleton.yaml
+++ b/src/frontend/planner_test/tests/testdata/output/singleton.yaml
@@ -21,15 +21,10 @@
     select mv1.v from mv mv1, mv mv2 where mv1.v = mv2.v;
   batch_plan: |-
     BatchExchange { order: [], dist: Single }
-    └─BatchHashJoin { type: Inner, predicate: mv.v = mv.v, output: [mv.v] }
-      ├─BatchExchange { order: [], dist: HashShard(mv.v) }
-      │ └─BatchScan { table: mv, columns: [mv.v], distribution: Single }
-      └─BatchExchange { order: [], dist: HashShard(mv.v) }
-        └─BatchScan { table: mv, columns: [mv.v], distribution: Single }
+    └─BatchLookupJoin { type: Inner, predicate: mv.v = mv.v, output: [mv.v], lookup table: mv }
+      └─BatchScan { table: mv, columns: [mv.v], distribution: Single }
   batch_local_plan: |-
-    BatchHashJoin { type: Inner, predicate: mv.v = mv.v, output: [mv.v] }
-    ├─BatchExchange { order: [], dist: Single }
-    │ └─BatchScan { table: mv, columns: [mv.v], distribution: SomeShard }
+    BatchLookupJoin { type: Inner, predicate: mv.v = mv.v, output: [mv.v], lookup table: mv }
     └─BatchExchange { order: [], dist: Single }
       └─BatchScan { table: mv, columns: [mv.v], distribution: SomeShard }
 - id: select_from_singleton_mv_join_top_n
@@ -38,18 +33,12 @@
   sql: |
     select mv1.v from mv mv1, mv mv2 where mv1.v = mv2.v order by mv1.v limit 10;
   batch_plan: |-
-    BatchTopN { order: [mv.v ASC], limit: 10, offset: 0 }
-    └─BatchExchange { order: [], dist: Single }
-      └─BatchTopN { order: [mv.v ASC], limit: 10, offset: 0 }
-        └─BatchHashJoin { type: Inner, predicate: mv.v = mv.v, output: [mv.v] }
-          ├─BatchExchange { order: [], dist: HashShard(mv.v) }
-          │ └─BatchScan { table: mv, columns: [mv.v], distribution: Single }
-          └─BatchExchange { order: [], dist: HashShard(mv.v) }
-            └─BatchScan { table: mv, columns: [mv.v], distribution: Single }
+    BatchExchange { order: [mv.v ASC], dist: Single }
+    └─BatchTopN { order: [mv.v ASC], limit: 10, offset: 0 }
+      └─BatchLookupJoin { type: Inner, predicate: mv.v = mv.v, output: [mv.v], lookup table: mv }
+        └─BatchScan { table: mv, columns: [mv.v], distribution: Single }
   batch_local_plan: |-
     BatchTopN { order: [mv.v ASC], limit: 10, offset: 0 }
-    └─BatchHashJoin { type: Inner, predicate: mv.v = mv.v, output: [mv.v] }
-      ├─BatchExchange { order: [], dist: Single }
-      │ └─BatchScan { table: mv, columns: [mv.v], distribution: SomeShard }
+    └─BatchLookupJoin { type: Inner, predicate: mv.v = mv.v, output: [mv.v], lookup table: mv }
       └─BatchExchange { order: [], dist: Single }
         └─BatchScan { table: mv, columns: [mv.v], distribution: SomeShard }

--- a/src/frontend/src/optimizer/mod.rs
+++ b/src/frontend/src/optimizer/mod.rs
@@ -1412,6 +1412,10 @@ impl BatchPlanRef {
             || self.node_type() == BatchPlanNodeType::BatchIcebergScan
     }
 
+    fn is_lookup_join(&self) -> bool {
+        self.node_type() == BatchPlanNodeType::BatchLookupJoin
+    }
+
     fn is_insert(&self) -> bool {
         self.node_type() == BatchPlanNodeType::BatchInsert
     }
@@ -1438,6 +1442,10 @@ fn require_additional_exchange_on_root_in_distributed_mode(plan: BatchPlanRef) -
             || plan.is_insert()
             || plan.is_update()
             || plan.is_delete()
+            // A lookup join on a singleton lookup table may be already in `Single`
+            // distribution and reads from the state store, so it must not be executed
+            // in the root stage on the frontend.
+            || plan.is_lookup_join()
     })
 }
 

--- a/src/frontend/src/optimizer/plan_node/batch_lookup_join.rs
+++ b/src/frontend/src/optimizer/plan_node/batch_lookup_join.rs
@@ -182,10 +182,23 @@ impl_plan_tree_node_for_unary! { Batch, BatchLookupJoin }
 
 impl ToDistributedBatch for BatchLookupJoin {
     fn to_distributed(&self) -> Result<PlanRef> {
+        let right_table = &self.right_table;
+
+        // The lookup table has a singleton distribution, so there's no way to align the
+        // left side with the distribution key of the right table. Instead, gather the left
+        // side into a single task and perform all lookups from there. Note that this is
+        // still correct because the lookup executor scans the table with a full vnode
+        // bitmap, regardless of which worker the task is scheduled to.
+        if right_table.distribution_key.is_empty() {
+            let input = self
+                .input()
+                .to_distributed_with_required(&Order::any(), &RequiredDist::single())?;
+            return Ok(self.clone_with_distributed_lookup(input, true).into());
+        }
+
         // Align left distribution keys with the right table.
         let mut exchange_dist_keys = vec![];
         let left_eq_indexes = self.eq_join_predicate().left_eq_indexes();
-        let right_table = &self.right_table;
         for dist_col_index in &right_table.distribution_key {
             let dist_col_id = right_table.columns[*dist_col_index].column_desc.column_id;
             let output_pos = self

--- a/src/frontend/src/optimizer/plan_node/logical_join.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_join.rs
@@ -381,15 +381,14 @@ impl LogicalJoin {
             dist_key_in_order_key_pos.push(pos);
         }
         // The shortest prefix of order key that contains distribution key.
+        //
+        // If the lookup table has a singleton distribution (i.e. an empty distribution key),
+        // any non-empty prefix of the order key can be used for the lookup, so we require a
+        // prefix of length at least 1.
         let shortest_prefix_len = dist_key_in_order_key_pos
             .iter()
             .max()
-            .map_or(0, |pos| pos + 1);
-
-        // Distributed lookup join can't support lookup table with a singleton distribution.
-        if shortest_prefix_len == 0 {
-            return Ok(None);
-        }
+            .map_or(1, |pos| pos + 1);
 
         // Reorder the join equal predicate to match the order key.
         let mut reorder_idx = Vec::with_capacity(shortest_prefix_len);

--- a/src/frontend/src/scheduler/plan_fragmenter.rs
+++ b/src/frontend/src/scheduler/plan_fragmenter.rs
@@ -1049,6 +1049,13 @@ impl BatchPlanFragmenter {
         let mut has_lookup_join = false;
         let parallelism = match root.distribution() {
             Distribution::Single => {
+                // A lookup join on a lookup table with a singleton distribution is gathered
+                // into a single task. Mark `has_lookup_join` so that epoch unpin is delayed
+                // until the end of the query.
+                has_lookup_join = self
+                    .collect_stage_lookup_join_parallelism(root.clone())?
+                    .is_some();
+
                 if let Some(info) = &mut table_scan_info {
                     if let Some(partitions) = &mut info.partitions {
                         if partitions.len() != 1 {


### PR DESCRIPTION
## What

Support batch lookup join on a lookup table with a **singleton distribution** (empty distribution key).

This addresses the essential problem behind #26286: #26287 only turned the frontend panic into a fallback, so a non-covering index lookup on a singleton MV still fell back to a **full scan of the primary table**, making the index useless. The root cause is that the optimizer could produce a logical index lookup join whose physical conversion was rejected solely because the primary table has a singleton distribution.

## How

- `LogicalJoin::gen_batch_lookup_join`: no longer rejects lookup tables with an empty distribution key. For a singleton lookup table, any **non-empty prefix of the order key** can be used as the lookup prefix (`shortest_prefix_len` becomes 1 instead of bailing out at 0).
- `BatchLookupJoin::to_distributed`: for a singleton lookup table there is no distribution key to align with, so gather the outer side into a single task (`RequiredDist::single()`) and perform all lookups from there. This is correct regardless of which worker the task is scheduled to, because the lookup executor scans the table with a full vnode bitmap; the scheduler still places the task on the worker owning the singleton fragment via the existing `DistributedLookupJoin` worker-assignment logic in `stage.rs`.
- `require_additional_exchange_on_root_in_distributed_mode`: treat `BatchLookupJoin` like a table scan. A lookup join on a singleton table is already in `Single` distribution and reads from the state store, so it must not be merged into the root stage executed on the frontend.
- `plan_fragmenter`: set `has_lookup_join` for stages with `Single` distribution as well, so that epoch unpin is still delayed until the end of the query for such stages.
- The executor side needs no change: `TableDistribution` already computes `SINGLETON_VNODE` for singleton tables in both `LocalLookupJoin` and `DistributedLookupJoin` paths, and stage/task scheduling already derives parallelism (= 1) from the inner table's fragment mapping.

With this change, the #26286 repro (`SELECT` on a singleton MV with a non-covering `INCLUDE` index) plans an index lookup join again instead of falling back to a full scan of the primary table, and general joins whose eq keys cover a non-empty pk prefix of a singleton table (e.g. a top-N MV) can use lookup join as well.

## Notes

For a singleton lookup table, all lookups are performed by a single task. This mirrors the parallelism of the table itself (a singleton table is served by a single fragment anyway), and is strictly better than the previous fallback for the index-selection case. `batch_enable_lookup_join` can still be used to opt out.

## Tests

- Planner tests: the #26286 regression case in `index_selection.yaml` now plans an index lookup join; new cases in `distributed_lookup_join.yaml` cover lookup join on a singleton top-N MV (positive) and non-pk-prefix join keys (negative, stays hash join).
- e2e: new singleton lookup join cases in `e2e_test/batch/basic/lookup_join.slt.part` (inner + left join on a top-N MV); the existing #26286 case in `e2e_test/ddl/index.slt` keeps asserting the user-visible result.

Fixes the follow-up of #26286 / #26287.
