### PR TITLE
chore(deps): bump foyer to 0.22.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5522,7 +5522,6 @@ checksum = "55ac459de2512911e4b674ce33cf20befaba382d05b62b008afc1c8b57cbf181"
 dependencies = [
  "futures-core",
  "futures-sink",
- "nanorand",
  "spin 0.9.8",
 ]
 
@@ -5570,9 +5569,9 @@ dependencies = [
 
 [[package]]
 name = "foyer"
-version = "0.21.2"
+version = "0.22.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a900bed3fe5f2ec8e6b0f95ceeb4c7183972ca5005cd00bf6baeec4a8ff3df71"
+checksum = "3b0abc0b87814989efa711f9becd9f26969820e2d3905db27d10969c4bd45890"
 dependencies = [
  "anyhow",
  "equivalent",
@@ -5580,33 +5579,31 @@ dependencies = [
  "foyer-common",
  "foyer-memory",
  "foyer-storage",
+ "foyer-tokio",
  "futures-util",
- "madsim-tokio",
+ "mea",
  "mixtrics",
  "pin-project",
  "serde",
- "tokio",
  "tracing",
 ]
 
 [[package]]
 name = "foyer-common"
-version = "0.21.2"
+version = "0.22.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff85b66e29d525064696a4f528709f9fc18562353cec494752de3c51e44911c6"
+checksum = "a3db80d5dece93adb7ad709c84578794724a9cba342a7e566c3551c7ec626789"
 dependencies = [
  "anyhow",
  "bincode 1.3.3",
  "bytes",
  "cfg-if",
  "fastrace",
- "itertools 0.14.0",
- "madsim-tokio",
+ "foyer-tokio",
  "mixtrics",
  "parking_lot 0.12.5",
  "pin-project",
  "serde",
- "tokio",
  "twox-hash",
 ]
 
@@ -5621,36 +5618,35 @@ dependencies = [
 
 [[package]]
 name = "foyer-memory"
-version = "0.21.2"
+version = "0.22.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a05125dba2170f5620dfc06f9b49d3a4af479f784cfcc38287a824af7afaf601"
+checksum = "db907f40a527ca2aa2f40a5f68b32ea58aa70f050cd233518e9ffd402cfba6ce"
 dependencies = [
  "anyhow",
- "arc-swap",
  "bitflags 2.13.1",
  "cmsketch",
  "equivalent",
  "fastrace",
  "foyer-common",
  "foyer-intrusive-collections",
+ "foyer-tokio",
  "futures-util",
  "hashbrown 0.16.1",
  "itertools 0.14.0",
- "madsim-tokio",
+ "mea",
  "mixtrics",
  "parking_lot 0.12.5",
  "paste",
  "pin-project",
  "serde",
- "tokio",
  "tracing",
 ]
 
 [[package]]
 name = "foyer-storage"
-version = "0.21.2"
+version = "0.22.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "267c7b3679a2041c9d85e3871a8a84830a2ee4ef3c79efe66e10ffe17aff9eac"
+checksum = "1983f1db3d0710e9c9d5fc116d9202dccd41a2d1e032572224f1aff5520aa958"
 dependencies = [
  "allocator-api2",
  "anyhow",
@@ -5659,9 +5655,9 @@ dependencies = [
  "equivalent",
  "fastant",
  "fastrace",
- "flume",
  "foyer-common",
  "foyer-memory",
+ "foyer-tokio",
  "fs4",
  "futures-core",
  "futures-util",
@@ -5670,15 +5666,24 @@ dependencies = [
  "itertools 0.14.0",
  "libc",
  "lz4",
- "madsim-tokio",
+ "mea",
  "parking_lot 0.12.5",
  "pin-project",
  "rand 0.9.2",
  "serde",
- "tokio",
  "tracing",
  "twox-hash",
  "zstd",
+]
+
+[[package]]
+name = "foyer-tokio"
+version = "0.22.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6577b05a7ffad0db555aedf00bfe52af818220fc4c1c3a7a12520896fc38627"
+dependencies = [
+ "madsim-tokio",
+ "tokio",
 ]
 
 [[package]]
@@ -8171,6 +8176,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "mea"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31fc7d159de0085ab6dd7ff145a9819442cfd3d098f783263120503c3f3e58b0"
+dependencies = [
+ "slab",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8537,15 +8551,6 @@ name = "naive-timer"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "034a0ad7deebf0c2abcf2435950a6666c3c15ea9d8fad0c0f48efa8a7f843fed"
-
-[[package]]
-name = "nanorand"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a51313c5820b0b02bd422f4b44776fbf47961755c74ce64afc73bfad10226c3"
-dependencies = [
- "getrandom 0.2.11",
-]
 
 [[package]]
 name = "native-tls"
@@ -14632,12 +14637,9 @@ checksum = "1b6709c7b6754dca1311b3c73e79fcce40dd414c782c66d88e8823030093b02b"
 
 [[package]]
 name = "slab"
-version = "0.4.9"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67"
-dependencies = [
- "autocfg",
-]
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "sled"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -159,7 +159,11 @@ clap = { version = "4", features = ["cargo", "derive", "env"] }
 criterion = { version = "0.8", features = ["async_futures"] }
 deltalake = { version = "0.32.0", features = ["s3", "gcs"] }
 faiss = { version = "0.12.2-alpha.0", features = ["static"] }
-foyer = { version = "0.21.2", features = ["serde", "tracing"] }
+foyer = { version = "0.22.3", default-features = false, features = [
+    "runtime-madsim-tokio",
+    "serde",
+    "tracing",
+] }
 futures-async-stream = "0.2.13"
 governor = { version = "0.10", default-features = false, features = ["std"] }
 hashbrown = { version = "0.17", features = ["default-hasher", "inline-more"] }

--- a/src/common/src/config/mod.rs
+++ b/src/common/src/config/mod.rs
@@ -754,6 +754,34 @@ pub mod tests {
     }
 
     #[test]
+    fn test_file_cache_separated_runtime_config_backward_compatibility() {
+        let config: RwConfig = toml::from_str(
+            r#"
+            [storage.data_file_cache.runtime_config.Separated.read_runtime_options]
+            worker_threads = 2
+            max_blocking_threads = 4
+
+            [storage.data_file_cache.runtime_config.Separated.write_runtime_options]
+            worker_threads = 6
+            max_blocking_threads = 8
+            "#,
+        )
+        .unwrap();
+
+        let storage::FileCacheRuntimeConfig::Separated {
+            read_runtime_options,
+            write_runtime_options,
+        } = config.storage.data_file_cache.runtime_config
+        else {
+            panic!("expected legacy separated file-cache runtime config");
+        };
+        assert_eq!(read_runtime_options.worker_threads, 2);
+        assert_eq!(read_runtime_options.max_blocking_threads, 4);
+        assert_eq!(write_runtime_options.worker_threads, 6);
+        assert_eq!(write_runtime_options.max_blocking_threads, 8);
+    }
+
+    #[test]
     fn test_meta_configs_backward_compatibility() {
         // Test periodic_space_reclaim_compaction_interval_sec
         {

--- a/src/common/src/config/storage.rs
+++ b/src/common/src/config/storage.rs
@@ -441,9 +441,7 @@ pub enum FileCacheRuntimeConfig {
     Unified(FileCacheTokioRuntimeConfig),
     /// Legacy configuration for separate read and write runtimes.
     ///
-    /// Foyer 0.22 uses one spawner, so RisingWave merges these limits into one dedicated runtime.
-    /// Each merged limit uses the larger explicit value, or the Tokio default if either value is
-    /// `0`.
+    /// Foyer 0.22 uses one spawner, so this configuration is no longer supported.
     Separated {
         read_runtime_options: FileCacheTokioRuntimeConfig,
         write_runtime_options: FileCacheTokioRuntimeConfig,

--- a/src/common/src/config/storage.rs
+++ b/src/common/src/config/storage.rs
@@ -12,9 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use foyer::{
-    Compression, LfuConfig, LruConfig, RecoverMode, RuntimeOptions, S3FifoConfig, Throttle,
-};
+use foyer::{Compression, LfuConfig, LruConfig, RecoverMode, S3FifoConfig, Throttle};
 use serde::de::Error as _;
 
 use super::*;
@@ -426,6 +424,32 @@ pub struct CacheRefillConfig {
     pub unrecognized: Unrecognized<Self>,
 }
 
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+pub struct FileCacheTokioRuntimeConfig {
+    /// Dedicated runtime worker threads. `0` uses the Tokio default.
+    pub worker_threads: usize,
+
+    /// Maximum number of blocking threads. `0` uses the Tokio default.
+    pub max_blocking_threads: usize,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub enum FileCacheRuntimeConfig {
+    /// Use the runtime that creates the file cache.
+    Disabled,
+    /// Use one dedicated runtime for all file cache tasks.
+    Unified(FileCacheTokioRuntimeConfig),
+    /// Legacy configuration for separate read and write runtimes.
+    ///
+    /// Foyer 0.22 uses one spawner, so RisingWave merges these limits into one dedicated runtime.
+    /// Each merged limit uses the larger explicit value, or the Tokio default if either value is
+    /// `0`.
+    Separated {
+        read_runtime_options: FileCacheTokioRuntimeConfig,
+        write_runtime_options: FileCacheTokioRuntimeConfig,
+    },
+}
+
 /// The subsection `[storage.data_file_cache]` and `[storage.meta_file_cache]` in `risingwave.toml`.
 ///
 /// It's put at [`StorageConfig::data_file_cache`] and  [`StorageConfig::meta_file_cache`].
@@ -501,7 +525,7 @@ pub struct FileCacheConfig {
     pub recover_mode: RecoverMode,
 
     #[serde(default = "default::file_cache::runtime_config")]
-    pub runtime_config: RuntimeOptions,
+    pub runtime_config: FileCacheRuntimeConfig,
 
     #[serde(default, flatten)]
     #[config_doc(omitted)]
@@ -1217,7 +1241,9 @@ pub mod default {
     pub mod file_cache {
         use std::num::NonZeroUsize;
 
-        use foyer::{Compression, RecoverMode, RuntimeOptions, Throttle, TokioRuntimeOptions};
+        use foyer::{Compression, RecoverMode, Throttle};
+
+        use super::super::{FileCacheRuntimeConfig, FileCacheTokioRuntimeConfig};
 
         pub fn dir() -> String {
             "".to_owned()
@@ -1275,8 +1301,8 @@ pub mod default {
             RecoverMode::Quiet
         }
 
-        pub fn runtime_config() -> RuntimeOptions {
-            RuntimeOptions::Unified(TokioRuntimeOptions::default())
+        pub fn runtime_config() -> FileCacheRuntimeConfig {
+            FileCacheRuntimeConfig::Unified(FileCacheTokioRuntimeConfig::default())
         }
 
         pub fn throttle() -> Throttle {

--- a/src/storage/src/opts.rs
+++ b/src/storage/src/opts.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use risingwave_common::config::storage::FileCacheRuntimeConfig;
 use risingwave_common::config::streaming::CacheRefillPolicy;
 use risingwave_common::config::{
     EvictionConfig, ObjectStoreConfig, RwConfig, StorageMemoryConfig, extract_storage_memory_config,
@@ -100,7 +101,7 @@ pub struct StorageOpts {
     pub data_file_cache_submit_queue_size_threshold_mb: usize,
     pub data_file_cache_fifo_probation_ratio: f64,
     pub data_file_cache_blob_index_size_kb: usize,
-    pub data_file_cache_runtime_config: foyer::RuntimeOptions,
+    pub data_file_cache_runtime_config: FileCacheRuntimeConfig,
     pub data_file_cache_throttle: foyer::Throttle,
 
     pub cache_refill_data_refill_levels: Vec<u32>,
@@ -129,7 +130,7 @@ pub struct StorageOpts {
     pub meta_file_cache_submit_queue_size_threshold_mb: usize,
     pub meta_file_cache_fifo_probation_ratio: f64,
     pub meta_file_cache_blob_index_size_kb: usize,
-    pub meta_file_cache_runtime_config: foyer::RuntimeOptions,
+    pub meta_file_cache_runtime_config: FileCacheRuntimeConfig,
     pub meta_file_cache_throttle: foyer::Throttle,
     pub sst_skip_bloom_filter_in_serde: bool,
 

--- a/src/storage/src/store_impl.rs
+++ b/src/storage/src/store_impl.rs
@@ -90,6 +90,68 @@ fn build_file_cache_spawner(
     Ok(runtime.into())
 }
 
+#[cfg(test)]
+mod tests {
+    use risingwave_common::config::storage::FileCacheTokioRuntimeConfig;
+
+    use super::*;
+
+    #[test]
+    fn test_build_file_cache_spawner_rejects_separated_runtime() {
+        let runtime_options = FileCacheTokioRuntimeConfig {
+            worker_threads: 1,
+            max_blocking_threads: 1,
+        };
+        let error = build_file_cache_spawner(
+            "foyer.test",
+            &FileCacheRuntimeConfig::Separated {
+                read_runtime_options: runtime_options.clone(),
+                write_runtime_options: runtime_options,
+            },
+        )
+        .unwrap_err()
+        .to_string();
+
+        assert!(error.contains("foyer.test runtime_config.Separated"));
+        assert!(error.contains("use runtime_config.Unified instead"));
+    }
+
+    #[cfg(not(madsim))]
+    #[tokio::test]
+    async fn test_build_file_cache_spawner_runtime_modes() {
+        let current_runtime_id = tokio::runtime::Handle::current().id();
+
+        let disabled =
+            build_file_cache_spawner("foyer.test", &FileCacheRuntimeConfig::Disabled).unwrap();
+        let disabled_runtime_id = disabled
+            .spawn(async { tokio::runtime::Handle::current().id() })
+            .await
+            .unwrap();
+        assert_eq!(disabled_runtime_id, current_runtime_id);
+
+        let unified = build_file_cache_spawner(
+            "foyer.test",
+            &FileCacheRuntimeConfig::Unified(FileCacheTokioRuntimeConfig {
+                worker_threads: 1,
+                max_blocking_threads: 1,
+            }),
+        )
+        .unwrap();
+        let (unified_runtime_id, thread_name) = unified
+            .spawn(async {
+                (
+                    tokio::runtime::Handle::current().id(),
+                    std::thread::current().name().map(str::to_owned),
+                )
+            })
+            .await
+            .unwrap();
+
+        assert_ne!(unified_runtime_id, current_runtime_id);
+        assert_eq!(thread_name.as_deref(), Some("foyer.test-unified"));
+    }
+}
+
 static FOYER_METRICS_REGISTRY: LazyLock<Box<PrometheusMetricsRegistry>> = LazyLock::new(|| {
     Box::new(PrometheusMetricsRegistry::new(
         GLOBAL_METRICS_REGISTRY.clone(),

--- a/src/storage/src/store_impl.rs
+++ b/src/storage/src/store_impl.rs
@@ -19,14 +19,14 @@ use std::time::Duration;
 
 use enum_as_inner::EnumAsInner;
 use foyer::{
-    BlockEngineBuilder, CacheBuilder, DeviceBuilder, FifoPicker, FsDeviceBuilder,
-    HybridCacheBuilder,
+    BlockEngineConfig, CacheBuilder, DeviceBuilder, FifoPicker, FsDeviceBuilder, HybridCacheBuilder,
 };
 use futures::FutureExt;
 use futures::future::BoxFuture;
 use mixtrics::registry::prometheus::PrometheusMetricsRegistry;
 use risingwave_common::catalog::TableId;
 use risingwave_common::config::Role;
+use risingwave_common::config::storage::{FileCacheRuntimeConfig, FileCacheTokioRuntimeConfig};
 use risingwave_common::license::Feature;
 use risingwave_common::monitor::GLOBAL_METRICS_REGISTRY;
 use risingwave_common_service::RpcNotificationClient;
@@ -53,6 +53,72 @@ use crate::monitor::{
     ObjectStoreMetrics,
 };
 use crate::opts::StorageOpts;
+
+fn merge_runtime_limit(read: usize, write: usize) -> usize {
+    if read == 0 || write == 0 {
+        0
+    } else {
+        read.max(write)
+    }
+}
+
+fn build_file_cache_spawner(
+    name: &str,
+    config: &FileCacheRuntimeConfig,
+) -> StorageResult<Option<foyer::Spawner>> {
+    let config = match config {
+        FileCacheRuntimeConfig::Disabled => return Ok(None),
+        FileCacheRuntimeConfig::Unified(config) => config.clone(),
+        FileCacheRuntimeConfig::Separated {
+            read_runtime_options,
+            write_runtime_options,
+        } => {
+            tracing::warn!(
+                cache = name,
+                "Foyer 0.22 uses one spawner; merging the legacy separated runtime configuration"
+            );
+            FileCacheTokioRuntimeConfig {
+                worker_threads: merge_runtime_limit(
+                    read_runtime_options.worker_threads,
+                    write_runtime_options.worker_threads,
+                ),
+                max_blocking_threads: merge_runtime_limit(
+                    read_runtime_options.max_blocking_threads,
+                    write_runtime_options.max_blocking_threads,
+                ),
+            }
+        }
+    };
+
+    let mut builder = tokio::runtime::Builder::new_multi_thread();
+    #[cfg(madsim)]
+    let _ = &config;
+    #[cfg(not(madsim))]
+    if config.worker_threads != 0 {
+        builder.worker_threads(config.worker_threads);
+    }
+    #[cfg(not(madsim))]
+    if config.max_blocking_threads != 0 {
+        builder.max_blocking_threads(config.max_blocking_threads);
+    }
+    builder.thread_name(format!("{name}-unified"));
+    let runtime = builder.enable_all().build().map_err(|error| {
+        HummockError::other(format!("failed to build {name} dedicated runtime: {error}"))
+    })?;
+    Ok(Some(runtime.into()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::merge_runtime_limit;
+
+    #[test]
+    fn test_merge_runtime_limit() {
+        assert_eq!(merge_runtime_limit(4, 8), 8);
+        assert_eq!(merge_runtime_limit(0, 8), 0);
+        assert_eq!(merge_runtime_limit(4, 0), 0);
+    }
+}
 
 static FOYER_METRICS_REGISTRY: LazyLock<Box<PrometheusMetricsRegistry>> = LazyLock::new(|| {
     Box::new(PrometheusMetricsRegistry::new(
@@ -720,7 +786,7 @@ impl StateStoreImpl {
                         .with_throttle(opts.meta_file_cache_throttle.clone())
                         .build()
                         .map_err(HummockError::foyer_error)?;
-                    let engine_builder = BlockEngineBuilder::new(device)
+                    let engine_builder = BlockEngineConfig::new(device)
                         .with_block_size(opts.meta_file_cache_file_capacity_mb * MB)
                         .with_indexer_shards(opts.meta_file_cache_indexer_shards)
                         .with_flushers(opts.meta_file_cache_flushers)
@@ -740,8 +806,13 @@ impl StateStoreImpl {
                     builder = builder
                         .with_engine_config(engine_builder)
                         .with_recover_mode(opts.meta_file_cache_recover_mode)
-                        .with_compression(opts.meta_file_cache_compression)
-                        .with_runtime_options(opts.meta_file_cache_runtime_config.clone());
+                        .with_compression(opts.meta_file_cache_compression);
+                    if let Some(spawner) = build_file_cache_spawner(
+                        "foyer.meta",
+                        &opts.meta_file_cache_runtime_config,
+                    )? {
+                        builder = builder.with_spawner(spawner);
+                    }
                 }
             }
 
@@ -772,7 +843,7 @@ impl StateStoreImpl {
                         .with_throttle(opts.data_file_cache_throttle.clone())
                         .build()
                         .map_err(HummockError::foyer_error)?;
-                    let engine_builder = BlockEngineBuilder::new(device)
+                    let engine_builder = BlockEngineConfig::new(device)
                         .with_block_size(opts.data_file_cache_file_capacity_mb * MB)
                         .with_indexer_shards(opts.data_file_cache_indexer_shards)
                         .with_flushers(opts.data_file_cache_flushers)
@@ -792,8 +863,13 @@ impl StateStoreImpl {
                     builder = builder
                         .with_engine_config(engine_builder)
                         .with_recover_mode(opts.data_file_cache_recover_mode)
-                        .with_compression(opts.data_file_cache_compression)
-                        .with_runtime_options(opts.data_file_cache_runtime_config.clone());
+                        .with_compression(opts.data_file_cache_compression);
+                    if let Some(spawner) = build_file_cache_spawner(
+                        "foyer.data",
+                        &opts.data_file_cache_runtime_config,
+                    )? {
+                        builder = builder.with_spawner(spawner);
+                    }
                 }
             }
 

--- a/src/storage/src/store_impl.rs
+++ b/src/storage/src/store_impl.rs
@@ -26,7 +26,7 @@ use futures::future::BoxFuture;
 use mixtrics::registry::prometheus::PrometheusMetricsRegistry;
 use risingwave_common::catalog::TableId;
 use risingwave_common::config::Role;
-use risingwave_common::config::storage::{FileCacheRuntimeConfig, FileCacheTokioRuntimeConfig};
+use risingwave_common::config::storage::FileCacheRuntimeConfig;
 use risingwave_common::license::Feature;
 use risingwave_common::monitor::GLOBAL_METRICS_REGISTRY;
 use risingwave_common_service::RpcNotificationClient;
@@ -54,39 +54,18 @@ use crate::monitor::{
 };
 use crate::opts::StorageOpts;
 
-fn merge_runtime_limit(read: usize, write: usize) -> usize {
-    if read == 0 || write == 0 {
-        0
-    } else {
-        read.max(write)
-    }
-}
-
 fn build_file_cache_spawner(
     name: &str,
     config: &FileCacheRuntimeConfig,
-) -> StorageResult<Option<foyer::Spawner>> {
+) -> StorageResult<foyer::Spawner> {
     let config = match config {
-        FileCacheRuntimeConfig::Disabled => return Ok(None),
+        FileCacheRuntimeConfig::Disabled => return Ok(foyer::Spawner::current()),
         FileCacheRuntimeConfig::Unified(config) => config.clone(),
-        FileCacheRuntimeConfig::Separated {
-            read_runtime_options,
-            write_runtime_options,
-        } => {
-            tracing::warn!(
-                cache = name,
-                "Foyer 0.22 uses one spawner; merging the legacy separated runtime configuration"
-            );
-            FileCacheTokioRuntimeConfig {
-                worker_threads: merge_runtime_limit(
-                    read_runtime_options.worker_threads,
-                    write_runtime_options.worker_threads,
-                ),
-                max_blocking_threads: merge_runtime_limit(
-                    read_runtime_options.max_blocking_threads,
-                    write_runtime_options.max_blocking_threads,
-                ),
-            }
+        FileCacheRuntimeConfig::Separated { .. } => {
+            return Err(HummockError::other(format!(
+                "{name} runtime_config.Separated is unsupported with Foyer 0.22; use runtime_config.Unified instead"
+            ))
+            .into());
         }
     };
 
@@ -108,19 +87,7 @@ fn build_file_cache_spawner(
             error.as_report()
         ))
     })?;
-    Ok(Some(runtime.into()))
-}
-
-#[cfg(test)]
-mod tests {
-    use super::merge_runtime_limit;
-
-    #[test]
-    fn test_merge_runtime_limit() {
-        assert_eq!(merge_runtime_limit(4, 8), 8);
-        assert_eq!(merge_runtime_limit(0, 8), 0);
-        assert_eq!(merge_runtime_limit(4, 0), 0);
-    }
+    Ok(runtime.into())
 }
 
 static FOYER_METRICS_REGISTRY: LazyLock<Box<PrometheusMetricsRegistry>> = LazyLock::new(|| {
@@ -810,12 +777,10 @@ impl StateStoreImpl {
                         .with_engine_config(engine_builder)
                         .with_recover_mode(opts.meta_file_cache_recover_mode)
                         .with_compression(opts.meta_file_cache_compression);
-                    if let Some(spawner) = build_file_cache_spawner(
+                    builder = builder.with_spawner(build_file_cache_spawner(
                         "foyer.meta",
                         &opts.meta_file_cache_runtime_config,
-                    )? {
-                        builder = builder.with_spawner(spawner);
-                    }
+                    )?);
                 }
             }
 
@@ -867,12 +832,10 @@ impl StateStoreImpl {
                         .with_engine_config(engine_builder)
                         .with_recover_mode(opts.data_file_cache_recover_mode)
                         .with_compression(opts.data_file_cache_compression);
-                    if let Some(spawner) = build_file_cache_spawner(
+                    builder = builder.with_spawner(build_file_cache_spawner(
                         "foyer.data",
                         &opts.data_file_cache_runtime_config,
-                    )? {
-                        builder = builder.with_spawner(spawner);
-                    }
+                    )?);
                 }
             }
 

--- a/src/storage/src/store_impl.rs
+++ b/src/storage/src/store_impl.rs
@@ -103,7 +103,10 @@ fn build_file_cache_spawner(
     }
     builder.thread_name(format!("{name}-unified"));
     let runtime = builder.enable_all().build().map_err(|error| {
-        HummockError::other(format!("failed to build {name} dedicated runtime: {error}"))
+        HummockError::other(format!(
+            "failed to build {name} dedicated runtime: {}",
+            error.as_report()
+        ))
     })?;
     Ok(Some(runtime.into()))
 }


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

- Upgrade Foyer from 0.21.2 to 0.22.3.
- Adapt to the Foyer 0.22 storage and runtime APIs (`BlockEngineConfig` and `Spawner`).
- Select Foyer's `runtime-madsim-tokio` feature explicitly so deterministic simulation keeps using RisingWave's Tokio-compatible runtime.
- Preserve the existing file-cache runtime configuration shape. `Disabled` continues using the current runtime, while `Unified` continues creating one dedicated runtime. Foyer 0.22 accepts only one spawner, so legacy `Separated` configurations now fail with a clear error directing users to migrate to `Unified` instead of silently changing their resource and isolation semantics.

Foyer 0.22 uses the configured spawner for a broader set of cache tasks than Foyer 0.21. This means a `Unified` dedicated runtime can also execute cache-miss fetch work.

This supersedes #25032, which updates the dependency files without adapting the removed Foyer 0.21 APIs.

## Local verification

- `cargo test -p risingwave_common test_file_cache_separated_runtime_config_backward_compatibility --lib --quiet`
- `cargo check -p risingwave_storage --all-targets --quiet`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo fmt --all --check`
- `./risedev generate-example-config`

## Checklist

- [x] I have written necessary rustdoc comments.
- [x] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [x] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [x] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->

## Documentation

- [x] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

Foyer 0.22 no longer supports separate read and write runtimes for the file cache. Deployments using `runtime_config.Separated` must migrate to `runtime_config.Unified`. The default `Unified` configuration is unchanged.

</details>
