### PR TITLE
feat: support initial cache refill policy

### DIFF
--- a/e2e_test/batch/catalog/pg_settings.slt.part
+++ b/e2e_test/batch/catalog/pg_settings.slt.part
@@ -72,6 +72,7 @@ user standard_conforming_strings
 user statement_timeout
 user streaming_allow_jsonb_in_stream_key
 user streaming_asof_join_use_cache
+user streaming_cache_refill_policy
 user streaming_enable_bushy_join
 user streaming_enable_delta_join
 user streaming_enable_unaligned_join

--- a/e2e_test/ddl/alter_streaming_config.slt
+++ b/e2e_test/ddl/alter_streaming_config.slt
@@ -153,3 +153,17 @@ in `developer`
 
 statement ok
 drop table cf;
+
+statement ok
+set streaming_cache_refill_policy = both;
+
+statement ok
+create table cf_initial (v int);
+
+query TTT
+select name, key, value from rw_streaming_job_config where name = 'cf_initial';
+----
+cf_initial	streaming.developer.cache_refill_policy	"both"
+
+statement ok
+drop table cf_initial;

--- a/e2e_test/ddl/alter_streaming_config.slt
+++ b/e2e_test/ddl/alter_streaming_config.slt
@@ -167,3 +167,16 @@ cf_initial	streaming.developer.cache_refill_policy	"both"
 
 statement ok
 drop table cf_initial;
+
+statement ok
+set streaming_cache_refill_policy = default;
+
+statement ok
+create table cf_default (v int);
+
+query TTT
+select name, key, value from rw_streaming_job_config where name = 'cf_default';
+----
+
+statement ok
+drop table cf_default;

--- a/src/common/src/session_config/mod.rs
+++ b/src/common/src/session_config/mod.rs
@@ -36,7 +36,7 @@ use thiserror::Error;
 
 use self::non_zero64::ConfigNonZeroU64;
 use crate::config::mutate::TomlTableMutateExt;
-use crate::config::streaming::{JoinEncodingType, OverWindowCachePolicy};
+use crate::config::streaming::{CacheRefillPolicy, JoinEncodingType, OverWindowCachePolicy};
 use crate::config::{ConfigMergeError, StreamingConfig, merge_streaming_config_section};
 use crate::hash::VirtualNode;
 use crate::session_config::parallelism::{ConfigBackfillParallelism, ConfigParallelism};
@@ -395,6 +395,14 @@ pub struct SessionConfig {
     #[parameter(default = None, alias = "rw_streaming_over_window_cache_policy")]
     streaming_over_window_cache_policy: OptionConfig<OverWindowCachePolicy>,
 
+    /// Cache refill policy for streaming cache refill feature.
+    /// Can be `enabled`, `disabled`, `streaming`, `serving` or `both`.
+    ///
+    /// This overrides the corresponding entry from the `[streaming.developer]` section in the config file,
+    /// taking effect for new streaming jobs created in the current session.
+    #[parameter(default = None)]
+    streaming_cache_refill_policy: OptionConfig<CacheRefillPolicy>,
+
     /// Run DDL statements in background
     #[parameter(default = false)]
     background_ddl: bool,
@@ -660,6 +668,11 @@ impl SessionConfig {
                 .upsert("streaming.developer.over_window_cache_policy", v)
                 .unwrap();
         }
+        if let Some(v) = self.streaming_cache_refill_policy.as_ref() {
+            table
+                .upsert("streaming.developer.cache_refill_policy", v)
+                .unwrap();
+        }
 
         let res = toml::to_string(&table)?;
 
@@ -721,11 +734,15 @@ mod test {
                 &mut (),
             )
             .unwrap();
+        config
+            .set_streaming_cache_refill_policy(Some(CacheRefillPolicy::Both).into(), &mut ())
+            .unwrap();
 
         // Check the converted config override string.
         let override_str = config.to_initial_streaming_config_override().unwrap();
         expect![[r#"
             [streaming.developer]
+            cache_refill_policy = "both"
             join_encoding_type = "cpu_optimized"
             over_window_cache_policy = "recent_first_n"
         "#]]
@@ -739,6 +756,10 @@ mod test {
         assert_eq!(
             merged.developer.over_window_cache_policy,
             OverWindowCachePolicy::RecentFirstN
+        );
+        assert_eq!(
+            merged.developer.cache_refill_policy,
+            CacheRefillPolicy::Both
         );
     }
 

--- a/src/meta/src/controller/catalog/create_op.rs
+++ b/src/meta/src/controller/catalog/create_op.rs
@@ -308,8 +308,6 @@ impl CatalogController {
             if !user_info.is_empty() {
                 version = self.notify_users_update(user_info).await;
             }
-            self.notify_hummock_table_cache_refill_policy_if_explicit(&inner, job_id)
-                .await?;
             inner
                 .creating_table_finish_notifier
                 .values_mut()

--- a/src/meta/src/controller/catalog/create_op.rs
+++ b/src/meta/src/controller/catalog/create_op.rs
@@ -308,6 +308,8 @@ impl CatalogController {
             if !user_info.is_empty() {
                 version = self.notify_users_update(user_info).await;
             }
+            self.notify_hummock_table_cache_refill_policy_if_explicit(&inner, job_id)
+                .await?;
             inner
                 .creating_table_finish_notifier
                 .values_mut()

--- a/src/meta/src/controller/catalog/mod.rs
+++ b/src/meta/src/controller/catalog/mod.rs
@@ -194,6 +194,25 @@ fn explicit_cache_refill_policy(config_override: &str) -> MetaResult<Option<Cach
 }
 
 impl CatalogControllerInner {
+    pub(crate) async fn table_cache_refill_policies_snapshot_if_job_has_explicit_policy(
+        &self,
+        job_id: JobId,
+    ) -> MetaResult<Option<PbTableCacheRefillPolicies>> {
+        let config_override: Option<String> = StreamingJob::find_by_id(job_id)
+            .select_only()
+            .column(streaming_job::Column::ConfigOverride)
+            .into_tuple()
+            .one(&self.db)
+            .await?
+            .ok_or_else(|| MetaError::catalog_id_not_found("streaming job", job_id))?;
+
+        if explicit_cache_refill_policy(&config_override.unwrap_or_default())?.is_none() {
+            return Ok(None);
+        }
+
+        Ok(Some(self.table_cache_refill_policies_snapshot().await?))
+    }
+
     pub async fn table_cache_refill_policies_snapshot(
         &self,
     ) -> MetaResult<PbTableCacheRefillPolicies> {
@@ -270,6 +289,29 @@ impl CatalogControllerInner {
 }
 
 impl CatalogController {
+    pub(crate) async fn notify_hummock_table_cache_refill_policy_if_explicit(
+        &self,
+        inner: &CatalogControllerInner,
+        job_id: JobId,
+    ) -> MetaResult<()> {
+        if let Some(policies) = inner
+            .table_cache_refill_policies_snapshot_if_job_has_explicit_policy(job_id)
+            .await?
+        {
+            self.env
+                .notification_manager()
+                .notify_hummock(
+                    NotificationOperation::Update,
+                    NotificationInfo::TableRefillRuntimeConfig(PbTableRefillRuntimeConfig {
+                        table_cache_refill_policies: Some(policies),
+                        ..Default::default()
+                    }),
+                )
+                .await;
+        }
+        Ok(())
+    }
+
     pub async fn table_cache_refill_policies_snapshot(
         &self,
     ) -> MetaResult<PbTableCacheRefillPolicies> {

--- a/src/meta/src/controller/catalog/mod.rs
+++ b/src/meta/src/controller/catalog/mod.rs
@@ -220,6 +220,15 @@ impl CatalogControllerInner {
             .select_only()
             .column(streaming_job::Column::JobId)
             .column(streaming_job::Column::ConfigOverride)
+            .filter(
+                streaming_job::Column::JobId.in_subquery(
+                    Query::select()
+                        .distinct()
+                        .column(fragment::Column::JobId)
+                        .from(Fragment)
+                        .to_owned(),
+                ),
+            )
             .into_tuple::<(JobId, Option<String>)>()
             .all(&self.db)
             .await?;

--- a/src/meta/src/controller/catalog/test.rs
+++ b/src/meta/src/controller/catalog/test.rs
@@ -14,6 +14,7 @@
 
 #[cfg(test)]
 mod tests {
+    use risingwave_common::catalog::FragmentTypeMask;
     use risingwave_common::hash::VirtualNode;
     use risingwave_meta_model::FragmentId;
     use risingwave_meta_model::fragment::DistributionType;
@@ -22,12 +23,13 @@ mod tests {
     use risingwave_pb::catalog::{PbSinkType, StreamSourceInfo};
     use risingwave_pb::common::{HostAddress, WorkerNode, WorkerType, worker_node};
     use risingwave_pb::meta::SubscribeType;
+    use risingwave_pb::meta::table_fragments::fragment::PbFragmentDistributionType;
     use risingwave_pb::stream_plan::PbStreamNode;
     use tokio::sync::{mpsc, oneshot};
 
     use crate::controller::catalog::*;
     use crate::manager::{LocalNotification, WorkerKey};
-    use crate::model::FragmentDownstreamRelation;
+    use crate::model::{Fragment, FragmentDownstreamRelation};
     use crate::serving::ServingVnodeMapping;
 
     const TEST_DATABASE_ID: DatabaseId = DatabaseId::new(1);
@@ -583,6 +585,13 @@ mod tests {
         else {
             unreachable!()
         };
+        insert_test_fragment(
+            &txn,
+            FragmentId::new(200),
+            result_table_id.as_job_id(),
+            TableIdArray(vec![result_table_id, internal_table_id]),
+        )
+        .await?;
         txn.commit().await?;
         drop(inner);
 
@@ -637,7 +646,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_finish_streaming_job_cache_refill_policy_notifies_hummock() -> MetaResult<()> {
+    async fn test_prepare_streaming_job_cache_refill_policy_notifies_hummock() -> MetaResult<()> {
         let env = MetaSrvEnv::for_test().await;
         let (tx, mut rx) = mpsc::unbounded_channel();
         env.notification_manager().insert_sender(
@@ -662,19 +671,46 @@ mod tests {
         else {
             unreachable!()
         };
-        streaming_job::ActiveModel {
-            job_id: Set(job_id),
-            job_status: Set(JobStatus::Initial),
-            ..Default::default()
-        }
-        .update(&txn)
-        .await?;
-        mgr.finish_streaming_job_inner(&txn, job_id).await?;
-        txn.commit().await?;
-
-        mgr.notify_hummock_table_cache_refill_policy_if_explicit(&inner, job_id)
+        let (unprepared_job_id, Some(unprepared_result_table_id), unprepared_internal_table_id) =
+            insert_test_streaming_job(
+                &txn,
+                "mv_unprepared_cache_refill",
+                true,
+                Some(CacheRefillPolicy::Serving),
+            )
+            .await?
+        else {
+            unreachable!()
+        };
+        for job_id in [job_id, unprepared_job_id] {
+            streaming_job::ActiveModel {
+                job_id: Set(job_id),
+                job_status: Set(JobStatus::Initial),
+                ..Default::default()
+            }
+            .update(&txn)
             .await?;
+        }
+        txn.commit().await?;
         drop(inner);
+
+        let fragments = [Fragment {
+            fragment_id: FragmentId::new(300),
+            fragment_type_mask: FragmentTypeMask::default(),
+            distribution_type: PbFragmentDistributionType::Hash,
+            state_table_ids: vec![],
+            maybe_vnode_count: Some(1),
+            nodes: PbStreamNode::default(),
+        }];
+        mgr.prepare_streaming_job(
+            job_id,
+            || fragments.iter(),
+            &FragmentDownstreamRelation::default(),
+            true,
+            None,
+            None,
+        )
+        .await?;
 
         let response = rx
             .recv()
@@ -690,28 +726,32 @@ mod tests {
         let policies = config
             .table_cache_refill_policies
             .expect("policy snapshot should be present");
+        let table_policies = policies
+            .table_policies
+            .into_iter()
+            .map(|policy| (policy.table_id, policy.policy))
+            .collect::<HashMap<_, _>>();
         assert_eq!(
-            policies
-                .table_policies
-                .into_iter()
-                .map(|policy| (policy.table_id, policy.policy))
-                .collect::<HashMap<_, _>>(),
+            table_policies,
             HashMap::from([(
                 result_table_id.as_raw_id(),
                 CacheRefillPolicy::Both.to_protobuf() as i32,
             )])
         );
+        assert!(!table_policies.contains_key(&unprepared_result_table_id.as_raw_id()));
+        let internal_table_policies = policies
+            .internal_table_policies
+            .into_iter()
+            .map(|policy| (policy.table_id, policy.policy))
+            .collect::<HashMap<_, _>>();
         assert_eq!(
-            policies
-                .internal_table_policies
-                .into_iter()
-                .map(|policy| (policy.table_id, policy.policy))
-                .collect::<HashMap<_, _>>(),
+            internal_table_policies,
             HashMap::from([(
                 internal_table_id.as_raw_id(),
                 CacheRefillPolicy::Both.to_protobuf() as i32,
             )])
         );
+        assert!(!internal_table_policies.contains_key(&unprepared_internal_table_id.as_raw_id()));
 
         Ok(())
     }

--- a/src/meta/src/controller/catalog/test.rs
+++ b/src/meta/src/controller/catalog/test.rs
@@ -657,6 +657,9 @@ mod tests {
             }),
             tx,
         );
+        let (local_notification_tx, mut local_notification_rx) = mpsc::unbounded_channel();
+        env.notification_manager()
+            .insert_local_sender(local_notification_tx);
         let mgr = CatalogController::new(env).await?;
 
         let inner = mgr.inner.write().await;
@@ -711,6 +714,18 @@ mod tests {
             None,
         )
         .await?;
+
+        let local_notification = local_notification_rx
+            .try_recv()
+            .expect("should receive serving fragment mapping notification");
+        let LocalNotification::ServingFragmentMappingsUpsert(fragment_ids) = local_notification
+        else {
+            panic!(
+                "unexpected local notification before hummock notification: {:?}",
+                local_notification
+            );
+        };
+        assert_eq!(fragment_ids, vec![FragmentId::new(300).as_raw_id()]);
 
         let response = rx
             .recv()

--- a/src/meta/src/controller/catalog/test.rs
+++ b/src/meta/src/controller/catalog/test.rs
@@ -636,6 +636,86 @@ mod tests {
         Ok(())
     }
 
+    #[tokio::test]
+    async fn test_finish_streaming_job_cache_refill_policy_notifies_hummock() -> MetaResult<()> {
+        let env = MetaSrvEnv::for_test().await;
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        env.notification_manager().insert_sender(
+            SubscribeType::Hummock,
+            WorkerKey(HostAddress {
+                host: "localhost".to_owned(),
+                port: 1234,
+            }),
+            tx,
+        );
+        let mgr = CatalogController::new(env).await?;
+
+        let inner = mgr.inner.write().await;
+        let txn = inner.db.begin().await?;
+        let (job_id, Some(result_table_id), internal_table_id) = insert_test_streaming_job(
+            &txn,
+            "mv_initial_cache_refill",
+            true,
+            Some(CacheRefillPolicy::Both),
+        )
+        .await?
+        else {
+            unreachable!()
+        };
+        streaming_job::ActiveModel {
+            job_id: Set(job_id),
+            job_status: Set(JobStatus::Initial),
+            ..Default::default()
+        }
+        .update(&txn)
+        .await?;
+        mgr.finish_streaming_job_inner(&txn, job_id).await?;
+        txn.commit().await?;
+
+        mgr.notify_hummock_table_cache_refill_policy_if_explicit(&inner, job_id)
+            .await?;
+        drop(inner);
+
+        let response = rx
+            .recv()
+            .await
+            .expect("should receive hummock notification")
+            .expect("notification should be ok");
+        assert_eq!(response.operation(), NotificationOperation::Update);
+        let info = response.info;
+        let Some(NotificationInfo::TableRefillRuntimeConfig(config)) = info else {
+            panic!("unexpected notification: {:?}", info);
+        };
+        assert!(config.serving_table_vnode_mappings.is_none());
+        let policies = config
+            .table_cache_refill_policies
+            .expect("policy snapshot should be present");
+        assert_eq!(
+            policies
+                .table_policies
+                .into_iter()
+                .map(|policy| (policy.table_id, policy.policy))
+                .collect::<HashMap<_, _>>(),
+            HashMap::from([(
+                result_table_id.as_raw_id(),
+                CacheRefillPolicy::Both.to_protobuf() as i32,
+            )])
+        );
+        assert_eq!(
+            policies
+                .internal_table_policies
+                .into_iter()
+                .map(|policy| (policy.table_id, policy.policy))
+                .collect::<HashMap<_, _>>(),
+            HashMap::from([(
+                internal_table_id.as_raw_id(),
+                CacheRefillPolicy::Both.to_protobuf() as i32,
+            )])
+        );
+
+        Ok(())
+    }
+
     async fn insert_dirty_creating_job_with_fragment(
         mgr: &CatalogController,
         fragment_id: FragmentId,

--- a/src/meta/src/controller/streaming_job.rs
+++ b/src/meta/src/controller/streaming_job.rs
@@ -866,15 +866,15 @@ impl CatalogController {
 
         txn.commit().await?;
 
-        self.notify_hummock_table_cache_refill_policy_if_explicit(&inner, job_id)
-            .await?;
-
         // Notify serving module about newly inserted fragments so it can establish
         // serving vnode mappings. This is driven by the fragment model insertion,
         // decoupled from the barrier-driven streaming mapping notifications.
         self.env
             .notification_manager()
             .notify_serving_fragment_mapping_update(inserted_fragment_ids);
+
+        self.notify_hummock_table_cache_refill_policy_if_explicit(&inner, job_id)
+            .await?;
 
         Ok(())
     }

--- a/src/meta/src/controller/streaming_job.rs
+++ b/src/meta/src/controller/streaming_job.rs
@@ -866,6 +866,9 @@ impl CatalogController {
 
         txn.commit().await?;
 
+        self.notify_hummock_table_cache_refill_policy_if_explicit(&inner, job_id)
+            .await?;
+
         // Notify serving module about newly inserted fragments so it can establish
         // serving vnode mappings. This is driven by the fragment model insertion,
         // decoupled from the barrier-driven streaming mapping notifications.
@@ -1662,9 +1665,6 @@ impl CatalogController {
         if !updated_user_info.is_empty() {
             version = self.notify_users_update(updated_user_info).await;
         }
-
-        self.notify_hummock_table_cache_refill_policy_if_explicit(&inner, job_id)
-            .await?;
 
         inner
             .creating_table_finish_notifier

--- a/src/meta/src/controller/streaming_job.rs
+++ b/src/meta/src/controller/streaming_job.rs
@@ -1663,6 +1663,9 @@ impl CatalogController {
             version = self.notify_users_update(updated_user_info).await;
         }
 
+        self.notify_hummock_table_cache_refill_policy_if_explicit(&inner, job_id)
+            .await?;
+
         inner
             .creating_table_finish_notifier
             .values_mut()


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

Allows setting streaming.developer.cache_refill_policy at job creation rather than via a subsequent ALTER SET CONFIG.

This PR adds a `streaming_cache_refill_policy` session parameter, persists it into new streaming jobs as the initial `streaming.developer.cache_refill_policy` override, and notifies Hummock with an updated refill-policy snapshot after jobs with an explicit creation-time policy finish.

- Closes: N/A

## Checklist

- [ ] I have written necessary rustdoc comments.
- [x] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [x] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [x] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

Users can set `streaming_cache_refill_policy` before creating a streaming job to persist the initial `streaming.developer.cache_refill_policy` for that job.

</details>