### PR TITLE
feat: support initial cache refill policy

### DIFF
--- a/e2e_test/batch/catalog/pg_settings.slt.part
+++ b/e2e_test/batch/catalog/pg_settings.slt.part
@@ -68,6 +68,7 @@ user source_rate_limit
 user standard_conforming_strings
 user statement_timeout
 user streaming_allow_jsonb_in_stream_key
+user streaming_cache_refill_policy
 user streaming_enable_bushy_join
 user streaming_enable_delta_join
 user streaming_enable_unaligned_join

--- a/e2e_test/ddl/alter_streaming_config.slt
+++ b/e2e_test/ddl/alter_streaming_config.slt
@@ -143,3 +143,17 @@ in `developer`
 
 statement ok
 drop table cf;
+
+statement ok
+set streaming_cache_refill_policy = both;
+
+statement ok
+create table cf_initial (v int);
+
+query TTT
+select name, key, value from rw_streaming_job_config where name = 'cf_initial';
+----
+cf_initial	streaming.developer.cache_refill_policy	"both"
+
+statement ok
+drop table cf_initial;

--- a/src/common/src/session_config/mod.rs
+++ b/src/common/src/session_config/mod.rs
@@ -34,7 +34,7 @@ use thiserror::Error;
 
 use self::non_zero64::ConfigNonZeroU64;
 use crate::config::mutate::TomlTableMutateExt;
-use crate::config::streaming::{JoinEncodingType, OverWindowCachePolicy};
+use crate::config::streaming::{CacheRefillPolicy, JoinEncodingType, OverWindowCachePolicy};
 use crate::config::{ConfigMergeError, StreamingConfig, merge_streaming_config_section};
 use crate::hash::VirtualNode;
 use crate::session_config::parallelism::{ConfigAdaptiveParallelismStrategy, ConfigParallelism};
@@ -392,6 +392,14 @@ pub struct SessionConfig {
     #[parameter(default = None, alias = "rw_streaming_over_window_cache_policy")]
     streaming_over_window_cache_policy: OptionConfig<OverWindowCachePolicy>,
 
+    /// Cache refill policy for streaming cache refill feature.
+    /// Can be `enabled`, `disabled`, `streaming`, `serving` or `both`.
+    ///
+    /// This overrides the corresponding entry from the `[streaming.developer]` section in the config file,
+    /// taking effect for new streaming jobs created in the current session.
+    #[parameter(default = None)]
+    streaming_cache_refill_policy: OptionConfig<CacheRefillPolicy>,
+
     /// Run DDL statements in background
     #[parameter(default = false)]
     background_ddl: bool,
@@ -627,6 +635,11 @@ impl SessionConfig {
                 .upsert("streaming.developer.over_window_cache_policy", v)
                 .unwrap();
         }
+        if let Some(v) = self.streaming_cache_refill_policy.as_ref() {
+            table
+                .upsert("streaming.developer.cache_refill_policy", v)
+                .unwrap();
+        }
 
         let res = toml::to_string(&table)?;
 
@@ -681,11 +694,15 @@ mod test {
                 &mut (),
             )
             .unwrap();
+        config
+            .set_streaming_cache_refill_policy(Some(CacheRefillPolicy::Both).into(), &mut ())
+            .unwrap();
 
         // Check the converted config override string.
         let override_str = config.to_initial_streaming_config_override().unwrap();
         expect![[r#"
             [streaming.developer]
+            cache_refill_policy = "both"
             join_encoding_type = "cpu_optimized"
             over_window_cache_policy = "recent_first_n"
         "#]]
@@ -699,6 +716,10 @@ mod test {
         assert_eq!(
             merged.developer.over_window_cache_policy,
             OverWindowCachePolicy::RecentFirstN
+        );
+        assert_eq!(
+            merged.developer.cache_refill_policy,
+            CacheRefillPolicy::Both
         );
     }
 }

--- a/src/meta/src/controller/catalog/create_op.rs
+++ b/src/meta/src/controller/catalog/create_op.rs
@@ -284,6 +284,8 @@ impl CatalogController {
             if !user_info.is_empty() {
                 version = self.notify_users_update(user_info).await;
             }
+            self.notify_hummock_table_cache_refill_policy_if_explicit(&inner, job_id)
+                .await?;
             inner
                 .creating_table_finish_notifier
                 .values_mut()

--- a/src/meta/src/controller/catalog/mod.rs
+++ b/src/meta/src/controller/catalog/mod.rs
@@ -185,6 +185,25 @@ fn explicit_cache_refill_policy(config_override: &str) -> MetaResult<Option<Cach
 }
 
 impl CatalogControllerInner {
+    pub(crate) async fn table_cache_refill_policies_snapshot_if_job_has_explicit_policy(
+        &self,
+        job_id: JobId,
+    ) -> MetaResult<Option<PbTableCacheRefillPolicies>> {
+        let config_override: Option<String> = StreamingJob::find_by_id(job_id)
+            .select_only()
+            .column(streaming_job::Column::ConfigOverride)
+            .into_tuple()
+            .one(&self.db)
+            .await?
+            .ok_or_else(|| MetaError::catalog_id_not_found("streaming job", job_id))?;
+
+        if explicit_cache_refill_policy(&config_override.unwrap_or_default())?.is_none() {
+            return Ok(None);
+        }
+
+        Ok(Some(self.table_cache_refill_policies_snapshot().await?))
+    }
+
     pub async fn table_cache_refill_policies_snapshot(
         &self,
     ) -> MetaResult<PbTableCacheRefillPolicies> {
@@ -261,6 +280,29 @@ impl CatalogControllerInner {
 }
 
 impl CatalogController {
+    pub(crate) async fn notify_hummock_table_cache_refill_policy_if_explicit(
+        &self,
+        inner: &CatalogControllerInner,
+        job_id: JobId,
+    ) -> MetaResult<()> {
+        if let Some(policies) = inner
+            .table_cache_refill_policies_snapshot_if_job_has_explicit_policy(job_id)
+            .await?
+        {
+            self.env
+                .notification_manager()
+                .notify_hummock(
+                    NotificationOperation::Update,
+                    NotificationInfo::TableRefillRuntimeConfig(PbTableRefillRuntimeConfig {
+                        table_cache_refill_policies: Some(policies),
+                        ..Default::default()
+                    }),
+                )
+                .await;
+        }
+        Ok(())
+    }
+
     pub async fn table_cache_refill_policies_snapshot(
         &self,
     ) -> MetaResult<PbTableCacheRefillPolicies> {

--- a/src/meta/src/controller/catalog/test.rs
+++ b/src/meta/src/controller/catalog/test.rs
@@ -333,6 +333,86 @@ mod tests {
         Ok(())
     }
 
+    #[tokio::test]
+    async fn test_finish_streaming_job_cache_refill_policy_notifies_hummock() -> MetaResult<()> {
+        let env = MetaSrvEnv::for_test().await;
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        env.notification_manager().insert_sender(
+            SubscribeType::Hummock,
+            WorkerKey(HostAddress {
+                host: "localhost".to_owned(),
+                port: 1234,
+            }),
+            tx,
+        );
+        let mgr = CatalogController::new(env).await?;
+
+        let inner = mgr.inner.write().await;
+        let txn = inner.db.begin().await?;
+        let (job_id, Some(result_table_id), internal_table_id) = insert_test_streaming_job(
+            &txn,
+            "mv_initial_cache_refill",
+            true,
+            Some(CacheRefillPolicy::Both),
+        )
+        .await?
+        else {
+            unreachable!()
+        };
+        streaming_job::ActiveModel {
+            job_id: Set(job_id),
+            job_status: Set(JobStatus::Initial),
+            ..Default::default()
+        }
+        .update(&txn)
+        .await?;
+        CatalogController::finish_streaming_job_inner(&txn, job_id).await?;
+        txn.commit().await?;
+
+        mgr.notify_hummock_table_cache_refill_policy_if_explicit(&inner, job_id)
+            .await?;
+        drop(inner);
+
+        let response = rx
+            .recv()
+            .await
+            .expect("should receive hummock notification")
+            .expect("notification should be ok");
+        assert_eq!(response.operation(), NotificationOperation::Update);
+        let info = response.info;
+        let Some(NotificationInfo::TableRefillRuntimeConfig(config)) = info else {
+            panic!("unexpected notification: {:?}", info);
+        };
+        assert!(config.serving_table_vnode_mappings.is_none());
+        let policies = config
+            .table_cache_refill_policies
+            .expect("policy snapshot should be present");
+        assert_eq!(
+            policies
+                .table_policies
+                .into_iter()
+                .map(|policy| (policy.table_id, policy.policy))
+                .collect::<HashMap<_, _>>(),
+            HashMap::from([(
+                result_table_id.as_raw_id(),
+                CacheRefillPolicy::Both.to_protobuf() as i32,
+            )])
+        );
+        assert_eq!(
+            policies
+                .internal_table_policies
+                .into_iter()
+                .map(|policy| (policy.table_id, policy.policy))
+                .collect::<HashMap<_, _>>(),
+            HashMap::from([(
+                internal_table_id.as_raw_id(),
+                CacheRefillPolicy::Both.to_protobuf() as i32,
+            )])
+        );
+
+        Ok(())
+    }
+
     async fn insert_dirty_creating_job_with_fragment(
         mgr: &CatalogController,
         fragment_id: FragmentId,

--- a/src/meta/src/controller/streaming_job.rs
+++ b/src/meta/src/controller/streaming_job.rs
@@ -1081,6 +1081,9 @@ impl CatalogController {
             version = self.notify_users_update(updated_user_info).await;
         }
 
+        self.notify_hummock_table_cache_refill_policy_if_explicit(&inner, job_id)
+            .await?;
+
         inner
             .creating_table_finish_notifier
             .values_mut()


### PR DESCRIPTION
Cherry-picks 55f648789a4f5c445baa2512faaa2f47888148ce onto patch/v2.8.5-refill.

Conflict resolved in e2e_test/batch/catalog/pg_settings.slt.part by adding streaming_cache_refill_policy while preserving the branch's existing settings list.