### PR TITLE
chore: use foyer release branch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5351,8 +5351,7 @@ dependencies = [
 [[package]]
 name = "foyer"
 version = "0.21.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a900bed3fe5f2ec8e6b0f95ceeb4c7183972ca5005cd00bf6baeec4a8ff3df71"
+source = "git+https://github.com/zwang28/foyer?branch=release-v0.21#b055078c8ce75d7d2c5dd048af7f79f28fa500ef"
 dependencies = [
  "anyhow",
  "equivalent",
@@ -5372,8 +5371,7 @@ dependencies = [
 [[package]]
 name = "foyer-common"
 version = "0.21.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff85b66e29d525064696a4f528709f9fc18562353cec494752de3c51e44911c6"
+source = "git+https://github.com/zwang28/foyer?branch=release-v0.21#b055078c8ce75d7d2c5dd048af7f79f28fa500ef"
 dependencies = [
  "anyhow",
  "bincode 1.3.3",
@@ -5402,8 +5400,7 @@ dependencies = [
 [[package]]
 name = "foyer-memory"
 version = "0.21.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a05125dba2170f5620dfc06f9b49d3a4af479f784cfcc38287a824af7afaf601"
+source = "git+https://github.com/zwang28/foyer?branch=release-v0.21#b055078c8ce75d7d2c5dd048af7f79f28fa500ef"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -5429,8 +5426,7 @@ dependencies = [
 [[package]]
 name = "foyer-storage"
 version = "0.21.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "267c7b3679a2041c9d85e3871a8a84830a2ee4ef3c79efe66e10ffe17aff9eac"
+source = "git+https://github.com/zwang28/foyer?branch=release-v0.21#b055078c8ce75d7d2c5dd048af7f79f28fa500ef"
 dependencies = [
  "allocator-api2",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -153,7 +153,7 @@ clap = { version = "4", features = ["cargo", "derive", "env"] }
 criterion = { version = "0.8", features = ["async_futures"] }
 deltalake = { version = "0.29", features = ["s3", "gcs", "datafusion"] }
 faiss = { version = "0.12.2-alpha.0", features = ["static"] }
-foyer = { version = "0.21.2", features = ["serde", "tracing", "nightly"] }
+foyer = { git = "https://github.com/zwang28/foyer", branch = "release-v0.21", features = ["serde", "tracing", "nightly"] }
 futures-async-stream = "0.2.13"
 governor = { version = "0.10", default-features = false, features = ["std"] }
 hashbrown = { version = "0.16", features = [


### PR DESCRIPTION
## Summary
- switch the workspace foyer dependency from crates.io 0.21.2 to the release-v0.21 branch
- refresh Cargo.lock for the foyer git source

## Verification
- cargo metadata --no-deps --format-version 1
- git diff --check