### PR TITLE
chore: backport initial cache refill policy

### DIFF
--- a/e2e_test/batch/catalog/pg_settings.slt.part
+++ b/e2e_test/batch/catalog/pg_settings.slt.part
@@ -68,6 +68,7 @@ user source_rate_limit
 user standard_conforming_strings
 user statement_timeout
 user streaming_allow_jsonb_in_stream_key
+user streaming_cache_refill_policy
 user streaming_enable_bushy_join
 user streaming_enable_delta_join
 user streaming_enable_unaligned_join

--- a/e2e_test/ddl/alter_streaming_config.slt
+++ b/e2e_test/ddl/alter_streaming_config.slt
@@ -143,3 +143,17 @@ in `developer`
 
 statement ok
 drop table cf;
+
+statement ok
+set streaming_cache_refill_policy = both;
+
+statement ok
+create table cf_initial (v int);
+
+query TTT
+select name, key, value from rw_streaming_job_config where name = 'cf_initial';
+----
+cf_initial	streaming.developer.cache_refill_policy	"both"
+
+statement ok
+drop table cf_initial;

--- a/src/common/src/session_config/mod.rs
+++ b/src/common/src/session_config/mod.rs
@@ -34,7 +34,7 @@ use thiserror::Error;
 
 use self::non_zero64::ConfigNonZeroU64;
 use crate::config::mutate::TomlTableMutateExt;
-use crate::config::streaming::{JoinEncodingType, OverWindowCachePolicy};
+use crate::config::streaming::{CacheRefillPolicy, JoinEncodingType, OverWindowCachePolicy};
 use crate::config::{ConfigMergeError, StreamingConfig, merge_streaming_config_section};
 use crate::hash::VirtualNode;
 use crate::session_config::parallelism::{ConfigAdaptiveParallelismStrategy, ConfigParallelism};
@@ -392,6 +392,14 @@ pub struct SessionConfig {
     #[parameter(default = None, alias = "rw_streaming_over_window_cache_policy")]
     streaming_over_window_cache_policy: OptionConfig<OverWindowCachePolicy>,
 
+    /// Cache refill policy for streaming cache refill feature.
+    /// Can be `enabled`, `disabled`, `streaming`, `serving` or `both`.
+    ///
+    /// This overrides the corresponding entry from the `[streaming.developer]` section in the config file,
+    /// taking effect for new streaming jobs created in the current session.
+    #[parameter(default = None)]
+    streaming_cache_refill_policy: OptionConfig<CacheRefillPolicy>,
+
     /// Run DDL statements in background
     #[parameter(default = false)]
     background_ddl: bool,
@@ -627,6 +635,11 @@ impl SessionConfig {
                 .upsert("streaming.developer.over_window_cache_policy", v)
                 .unwrap();
         }
+        if let Some(v) = self.streaming_cache_refill_policy.as_ref() {
+            table
+                .upsert("streaming.developer.cache_refill_policy", v)
+                .unwrap();
+        }
 
         let res = toml::to_string(&table)?;
 
@@ -681,11 +694,15 @@ mod test {
                 &mut (),
             )
             .unwrap();
+        config
+            .set_streaming_cache_refill_policy(Some(CacheRefillPolicy::Both).into(), &mut ())
+            .unwrap();
 
         // Check the converted config override string.
         let override_str = config.to_initial_streaming_config_override().unwrap();
         expect![[r#"
             [streaming.developer]
+            cache_refill_policy = "both"
             join_encoding_type = "cpu_optimized"
             over_window_cache_policy = "recent_first_n"
         "#]]
@@ -699,6 +716,10 @@ mod test {
         assert_eq!(
             merged.developer.over_window_cache_policy,
             OverWindowCachePolicy::RecentFirstN
+        );
+        assert_eq!(
+            merged.developer.cache_refill_policy,
+            CacheRefillPolicy::Both
         );
     }
 }

--- a/src/meta/src/controller/catalog/create_op.rs
+++ b/src/meta/src/controller/catalog/create_op.rs
@@ -284,6 +284,8 @@ impl CatalogController {
             if !user_info.is_empty() {
                 version = self.notify_users_update(user_info).await;
             }
+            self.notify_hummock_table_cache_refill_policy_if_explicit(&inner, job_id)
+                .await?;
             inner
                 .creating_table_finish_notifier
                 .values_mut()

--- a/src/meta/src/controller/catalog/create_op.rs
+++ b/src/meta/src/controller/catalog/create_op.rs
@@ -284,8 +284,6 @@ impl CatalogController {
             if !user_info.is_empty() {
                 version = self.notify_users_update(user_info).await;
             }
-            self.notify_hummock_table_cache_refill_policy_if_explicit(&inner, job_id)
-                .await?;
             inner
                 .creating_table_finish_notifier
                 .values_mut()

--- a/src/meta/src/controller/catalog/mod.rs
+++ b/src/meta/src/controller/catalog/mod.rs
@@ -211,6 +211,15 @@ impl CatalogControllerInner {
             .select_only()
             .column(streaming_job::Column::JobId)
             .column(streaming_job::Column::ConfigOverride)
+            .filter(
+                streaming_job::Column::JobId.in_subquery(
+                    Query::select()
+                        .distinct()
+                        .column(fragment::Column::JobId)
+                        .from(Fragment)
+                        .to_owned(),
+                ),
+            )
             .into_tuple::<(JobId, Option<String>)>()
             .all(&self.db)
             .await?;

--- a/src/meta/src/controller/catalog/mod.rs
+++ b/src/meta/src/controller/catalog/mod.rs
@@ -185,6 +185,25 @@ fn explicit_cache_refill_policy(config_override: &str) -> MetaResult<Option<Cach
 }
 
 impl CatalogControllerInner {
+    pub(crate) async fn table_cache_refill_policies_snapshot_if_job_has_explicit_policy(
+        &self,
+        job_id: JobId,
+    ) -> MetaResult<Option<PbTableCacheRefillPolicies>> {
+        let config_override: Option<String> = StreamingJob::find_by_id(job_id)
+            .select_only()
+            .column(streaming_job::Column::ConfigOverride)
+            .into_tuple()
+            .one(&self.db)
+            .await?
+            .ok_or_else(|| MetaError::catalog_id_not_found("streaming job", job_id))?;
+
+        if explicit_cache_refill_policy(&config_override.unwrap_or_default())?.is_none() {
+            return Ok(None);
+        }
+
+        Ok(Some(self.table_cache_refill_policies_snapshot().await?))
+    }
+
     pub async fn table_cache_refill_policies_snapshot(
         &self,
     ) -> MetaResult<PbTableCacheRefillPolicies> {
@@ -261,6 +280,29 @@ impl CatalogControllerInner {
 }
 
 impl CatalogController {
+    pub(crate) async fn notify_hummock_table_cache_refill_policy_if_explicit(
+        &self,
+        inner: &CatalogControllerInner,
+        job_id: JobId,
+    ) -> MetaResult<()> {
+        if let Some(policies) = inner
+            .table_cache_refill_policies_snapshot_if_job_has_explicit_policy(job_id)
+            .await?
+        {
+            self.env
+                .notification_manager()
+                .notify_hummock(
+                    NotificationOperation::Update,
+                    NotificationInfo::TableRefillRuntimeConfig(PbTableRefillRuntimeConfig {
+                        table_cache_refill_policies: Some(policies),
+                        ..Default::default()
+                    }),
+                )
+                .await;
+        }
+        Ok(())
+    }
+
     pub async fn table_cache_refill_policies_snapshot(
         &self,
     ) -> MetaResult<PbTableCacheRefillPolicies> {

--- a/src/meta/src/controller/catalog/test.rs
+++ b/src/meta/src/controller/catalog/test.rs
@@ -14,6 +14,7 @@
 
 #[cfg(test)]
 mod tests {
+    use risingwave_common::catalog::FragmentTypeMask;
     use risingwave_common::hash::VirtualNode;
     use risingwave_common::id::WorkerId;
     use risingwave_meta_model::FragmentId;
@@ -23,11 +24,13 @@ mod tests {
     use risingwave_pb::catalog::subscription::SubscriptionState;
     use risingwave_pb::common::{HostAddress, WorkerNode, WorkerType, worker_node};
     use risingwave_pb::meta::SubscribeType;
+    use risingwave_pb::meta::table_fragments::fragment::PbFragmentDistributionType;
     use risingwave_pb::stream_plan::PbStreamNode;
     use tokio::sync::{mpsc, oneshot};
 
     use crate::controller::catalog::*;
     use crate::manager::{LocalNotification, WorkerKey};
+    use crate::model::{Fragment, FragmentDownstreamRelation};
     use crate::serving::ServingVnodeMapping;
 
     const TEST_DATABASE_ID: DatabaseId = DatabaseId::new(1);
@@ -280,6 +283,13 @@ mod tests {
         else {
             unreachable!()
         };
+        insert_test_fragment(
+            &txn,
+            FragmentId::new(200),
+            result_table_id.as_job_id(),
+            TableIdArray(vec![result_table_id, internal_table_id]),
+        )
+        .await?;
         txn.commit().await?;
         drop(inner);
 
@@ -334,7 +344,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_finish_streaming_job_cache_refill_policy_notifies_hummock() -> MetaResult<()> {
+    async fn test_prepare_streaming_job_cache_refill_policy_notifies_hummock() -> MetaResult<()> {
         let env = MetaSrvEnv::for_test().await;
         let (tx, mut rx) = mpsc::unbounded_channel();
         env.notification_manager().insert_sender(
@@ -359,19 +369,46 @@ mod tests {
         else {
             unreachable!()
         };
-        streaming_job::ActiveModel {
-            job_id: Set(job_id),
-            job_status: Set(JobStatus::Initial),
-            ..Default::default()
-        }
-        .update(&txn)
-        .await?;
-        mgr.finish_streaming_job_inner(&txn, job_id).await?;
-        txn.commit().await?;
-
-        mgr.notify_hummock_table_cache_refill_policy_if_explicit(&inner, job_id)
+        let (unprepared_job_id, Some(unprepared_result_table_id), unprepared_internal_table_id) =
+            insert_test_streaming_job(
+                &txn,
+                "mv_unprepared_cache_refill",
+                true,
+                Some(CacheRefillPolicy::Serving),
+            )
+            .await?
+        else {
+            unreachable!()
+        };
+        for job_id in [job_id, unprepared_job_id] {
+            streaming_job::ActiveModel {
+                job_id: Set(job_id),
+                job_status: Set(JobStatus::Initial),
+                ..Default::default()
+            }
+            .update(&txn)
             .await?;
+        }
+        txn.commit().await?;
         drop(inner);
+
+        let fragments = [Fragment {
+            fragment_id: FragmentId::new(300),
+            fragment_type_mask: FragmentTypeMask::default(),
+            distribution_type: PbFragmentDistributionType::Hash,
+            state_table_ids: vec![],
+            maybe_vnode_count: Some(1),
+            nodes: PbStreamNode::default(),
+        }];
+        mgr.prepare_streaming_job(
+            job_id,
+            || fragments.iter(),
+            &FragmentDownstreamRelation::default(),
+            true,
+            None,
+            None,
+        )
+        .await?;
 
         let response = rx
             .recv()
@@ -387,28 +424,32 @@ mod tests {
         let policies = config
             .table_cache_refill_policies
             .expect("policy snapshot should be present");
+        let table_policies = policies
+            .table_policies
+            .into_iter()
+            .map(|policy| (policy.table_id, policy.policy))
+            .collect::<HashMap<_, _>>();
         assert_eq!(
-            policies
-                .table_policies
-                .into_iter()
-                .map(|policy| (policy.table_id, policy.policy))
-                .collect::<HashMap<_, _>>(),
+            table_policies,
             HashMap::from([(
                 result_table_id.as_raw_id(),
                 CacheRefillPolicy::Both.to_protobuf() as i32,
             )])
         );
+        assert!(!table_policies.contains_key(&unprepared_result_table_id.as_raw_id()));
+        let internal_table_policies = policies
+            .internal_table_policies
+            .into_iter()
+            .map(|policy| (policy.table_id, policy.policy))
+            .collect::<HashMap<_, _>>();
         assert_eq!(
-            policies
-                .internal_table_policies
-                .into_iter()
-                .map(|policy| (policy.table_id, policy.policy))
-                .collect::<HashMap<_, _>>(),
+            internal_table_policies,
             HashMap::from([(
                 internal_table_id.as_raw_id(),
                 CacheRefillPolicy::Both.to_protobuf() as i32,
             )])
         );
+        assert!(!internal_table_policies.contains_key(&unprepared_internal_table_id.as_raw_id()));
 
         Ok(())
     }

--- a/src/meta/src/controller/catalog/test.rs
+++ b/src/meta/src/controller/catalog/test.rs
@@ -30,7 +30,7 @@ mod tests {
 
     use crate::controller::catalog::*;
     use crate::manager::{LocalNotification, WorkerKey};
-    use crate::model::{Fragment, FragmentDownstreamRelation};
+    use crate::model::{Fragment, FragmentDownstreamRelation, StreamActor};
     use crate::serving::ServingVnodeMapping;
 
     const TEST_DATABASE_ID: DatabaseId = DatabaseId::new(1);
@@ -355,6 +355,9 @@ mod tests {
             }),
             tx,
         );
+        let (local_notification_tx, mut local_notification_rx) = mpsc::unbounded_channel();
+        env.notification_manager()
+            .insert_local_sender(local_notification_tx);
         let mgr = CatalogController::new(env).await?;
 
         let inner = mgr.inner.write().await;
@@ -395,7 +398,15 @@ mod tests {
         let fragments = [Fragment {
             fragment_id: FragmentId::new(300),
             fragment_type_mask: FragmentTypeMask::default(),
-            distribution_type: PbFragmentDistributionType::Hash,
+            distribution_type: PbFragmentDistributionType::Single,
+            actors: vec![StreamActor {
+                actor_id: 3000.into(),
+                fragment_id: FragmentId::new(300),
+                vnode_bitmap: None,
+                mview_definition: "".to_owned(),
+                expr_context: None,
+                config_override: "".into(),
+            }],
             state_table_ids: vec![],
             maybe_vnode_count: Some(1),
             nodes: PbStreamNode::default(),
@@ -409,6 +420,17 @@ mod tests {
             None,
         )
         .await?;
+
+        let local_notification = local_notification_rx
+            .try_recv()
+            .expect("should receive serving fragment mapping notification");
+        let LocalNotification::FragmentMappingsUpsert(fragment_ids) = local_notification else {
+            panic!(
+                "unexpected local notification before hummock notification: {:?}",
+                local_notification
+            );
+        };
+        assert_eq!(fragment_ids, vec![FragmentId::new(300).as_raw_id()]);
 
         let response = rx
             .recv()

--- a/src/meta/src/controller/catalog/test.rs
+++ b/src/meta/src/controller/catalog/test.rs
@@ -333,6 +333,86 @@ mod tests {
         Ok(())
     }
 
+    #[tokio::test]
+    async fn test_finish_streaming_job_cache_refill_policy_notifies_hummock() -> MetaResult<()> {
+        let env = MetaSrvEnv::for_test().await;
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        env.notification_manager().insert_sender(
+            SubscribeType::Hummock,
+            WorkerKey(HostAddress {
+                host: "localhost".to_owned(),
+                port: 1234,
+            }),
+            tx,
+        );
+        let mgr = CatalogController::new(env).await?;
+
+        let inner = mgr.inner.write().await;
+        let txn = inner.db.begin().await?;
+        let (job_id, Some(result_table_id), internal_table_id) = insert_test_streaming_job(
+            &txn,
+            "mv_initial_cache_refill",
+            true,
+            Some(CacheRefillPolicy::Both),
+        )
+        .await?
+        else {
+            unreachable!()
+        };
+        streaming_job::ActiveModel {
+            job_id: Set(job_id),
+            job_status: Set(JobStatus::Initial),
+            ..Default::default()
+        }
+        .update(&txn)
+        .await?;
+        mgr.finish_streaming_job_inner(&txn, job_id).await?;
+        txn.commit().await?;
+
+        mgr.notify_hummock_table_cache_refill_policy_if_explicit(&inner, job_id)
+            .await?;
+        drop(inner);
+
+        let response = rx
+            .recv()
+            .await
+            .expect("should receive hummock notification")
+            .expect("notification should be ok");
+        assert_eq!(response.operation(), NotificationOperation::Update);
+        let info = response.info;
+        let Some(NotificationInfo::TableRefillRuntimeConfig(config)) = info else {
+            panic!("unexpected notification: {:?}", info);
+        };
+        assert!(config.serving_table_vnode_mappings.is_none());
+        let policies = config
+            .table_cache_refill_policies
+            .expect("policy snapshot should be present");
+        assert_eq!(
+            policies
+                .table_policies
+                .into_iter()
+                .map(|policy| (policy.table_id, policy.policy))
+                .collect::<HashMap<_, _>>(),
+            HashMap::from([(
+                result_table_id.as_raw_id(),
+                CacheRefillPolicy::Both.to_protobuf() as i32,
+            )])
+        );
+        assert_eq!(
+            policies
+                .internal_table_policies
+                .into_iter()
+                .map(|policy| (policy.table_id, policy.policy))
+                .collect::<HashMap<_, _>>(),
+            HashMap::from([(
+                internal_table_id.as_raw_id(),
+                CacheRefillPolicy::Both.to_protobuf() as i32,
+            )])
+        );
+
+        Ok(())
+    }
+
     async fn insert_dirty_creating_job_with_fragment(
         mgr: &CatalogController,
         fragment_id: FragmentId,

--- a/src/meta/src/controller/streaming_job.rs
+++ b/src/meta/src/controller/streaming_job.rs
@@ -612,6 +612,9 @@ impl CatalogController {
 
         txn.commit().await?;
 
+        self.notify_hummock_table_cache_refill_policy_if_explicit(&inner, job_id)
+            .await?;
+
         // FIXME: there's a gap between the catalog creation and notification, which may lead to
         // frontend receiving duplicate notifications if the frontend restarts right in this gap. We
         // need to either forward the notification or filter catalogs without any fragments in the metastore.
@@ -624,6 +627,13 @@ impl CatalogController {
             )
             .await;
         }
+
+        // Notify serving module about newly inserted fragments so it can establish
+        // serving vnode mappings. This is driven by the fragment model insertion,
+        // decoupled from the barrier-driven streaming mapping notifications.
+        self.env
+            .notification_manager()
+            .notify_serving_fragment_mapping_update(inserted_fragment_ids);
 
         Ok(())
     }
@@ -1080,9 +1090,6 @@ impl CatalogController {
         if !updated_user_info.is_empty() {
             version = self.notify_users_update(updated_user_info).await;
         }
-
-        self.notify_hummock_table_cache_refill_policy_if_explicit(&inner, job_id)
-            .await?;
 
         inner
             .creating_table_finish_notifier

--- a/src/meta/src/controller/streaming_job.rs
+++ b/src/meta/src/controller/streaming_job.rs
@@ -86,7 +86,7 @@ use crate::controller::utils::{
     list_user_info_by_ids, try_get_iceberg_table_by_downstream_sink,
 };
 use crate::error::MetaErrorInner;
-use crate::manager::{NotificationVersion, StreamingJob, StreamingJobType};
+use crate::manager::{LocalNotification, NotificationVersion, StreamingJob, StreamingJobType};
 use crate::model::{
     FragmentDownstreamRelation, FragmentReplaceUpstream, StreamContext, StreamJobFragments,
     StreamJobFragmentsToCreate,
@@ -528,6 +528,10 @@ impl CatalogController {
             .iter()
             .flat_map(|fragment| fragment.state_table_ids.inner_ref().clone())
             .collect_vec();
+        let inserted_fragment_ids = fragments
+            .iter()
+            .map(|fragment| fragment.fragment_id)
+            .collect_vec();
 
         if !fragments.is_empty() {
             let fragment_models = fragments
@@ -612,8 +616,12 @@ impl CatalogController {
 
         txn.commit().await?;
 
-        self.notify_hummock_table_cache_refill_policy_if_explicit(&inner, job_id)
-            .await?;
+        // Notify serving module about newly inserted fragments so it can establish
+        // serving vnode mappings. This is driven by the fragment model insertion,
+        // decoupled from the barrier-driven streaming mapping notifications.
+        self.env.notification_manager().notify_local_subscribers(
+            LocalNotification::FragmentMappingsUpsert(inserted_fragment_ids),
+        );
 
         // FIXME: there's a gap between the catalog creation and notification, which may lead to
         // frontend receiving duplicate notifications if the frontend restarts right in this gap. We
@@ -628,12 +636,8 @@ impl CatalogController {
             .await;
         }
 
-        // Notify serving module about newly inserted fragments so it can establish
-        // serving vnode mappings. This is driven by the fragment model insertion,
-        // decoupled from the barrier-driven streaming mapping notifications.
-        self.env
-            .notification_manager()
-            .notify_serving_fragment_mapping_update(inserted_fragment_ids);
+        self.notify_hummock_table_cache_refill_policy_if_explicit(&inner, job_id)
+            .await?;
 
         Ok(())
     }

--- a/src/meta/src/controller/streaming_job.rs
+++ b/src/meta/src/controller/streaming_job.rs
@@ -1081,6 +1081,9 @@ impl CatalogController {
             version = self.notify_users_update(updated_user_info).await;
         }
 
+        self.notify_hummock_table_cache_refill_policy_if_explicit(&inner, job_id)
+            .await?;
+
         inner
             .creating_table_finish_notifier
             .values_mut()


### PR DESCRIPTION
## Summary

Backports the initial cache refill policy support from #26603 to `patch/v2.8.5-refill`.

Included commits:
- `da8181def9` feat: support initial cache refill policy
- `687dfb0b31` fix: publish cache refill policy before backfill
- `d589c8ae14` fix: notify serving mapping before cache refill policy

## Backport Notes

- Resolved the `pg_settings` SLT expected output against this branch.
- Adapted the serving mapping notification to this branch's `LocalNotification::FragmentMappingsUpsert` API.

## Verification

- `cargo fmt --package risingwave_meta`
- `cargo test -p risingwave_meta test_prepare_streaming_job_cache_refill_policy_notifies_hummock --lib`
- `git diff --check origin/patch/v2.8.5-refill..HEAD`