### PR TITLE
feat(storage): filter disk cache admission by live SSTs

### DIFF
--- a/src/compute/src/rpc/service/config_service.rs
+++ b/src/compute/src/rpc/service/config_service.rs
@@ -22,7 +22,7 @@ use risingwave_pb::compute::config_service_server::ConfigService;
 use risingwave_pb::compute::{
     ResizeCacheRequest, ResizeCacheResponse, ShowConfigRequest, ShowConfigResponse,
 };
-use risingwave_storage::hummock::{Block, Sstable, SstableBlockIndex};
+use risingwave_storage::hummock::{Sstable, SstableBlockCache};
 use risingwave_stream::task::LocalStreamManager;
 use thiserror_ext::AsReport;
 use tonic::{Code, Request, Response, Status};
@@ -31,7 +31,7 @@ pub struct ConfigServiceImpl {
     batch_mgr: Arc<BatchManager>,
     stream_mgr: LocalStreamManager,
     meta_cache: Option<HybridCache<HummockSstableObjectId, Box<Sstable>>>,
-    block_cache: Option<HybridCache<SstableBlockIndex, Box<Block>>>,
+    block_cache: Option<SstableBlockCache>,
 }
 
 #[async_trait::async_trait]
@@ -92,7 +92,7 @@ impl ConfigServiceImpl {
         batch_mgr: Arc<BatchManager>,
         stream_mgr: LocalStreamManager,
         meta_cache: Option<HybridCache<HummockSstableObjectId, Box<Sstable>>>,
-        block_cache: Option<HybridCache<SstableBlockIndex, Box<Block>>>,
+        block_cache: Option<SstableBlockCache>,
     ) -> Self {
         Self {
             batch_mgr,

--- a/src/compute/src/rpc/service/monitor_service.rs
+++ b/src/compute/src/rpc/service/monitor_service.rs
@@ -41,7 +41,7 @@ use risingwave_storage::hummock::event_handler::refiller::{
     TableCacheRefillContext, TableCacheRefillMonitorSnapshot,
 };
 use risingwave_storage::hummock::store::HummockStorage;
-use risingwave_storage::hummock::{Block, Sstable, SstableBlockIndex};
+use risingwave_storage::hummock::{Sstable, SstableBlockCache};
 use risingwave_stream::executor::monitor::global_streaming_metrics;
 use risingwave_stream::task::LocalStreamManager;
 use risingwave_stream::task::await_tree_key::{Actor, BarrierAwait};
@@ -49,7 +49,7 @@ use thiserror_ext::AsReport;
 use tonic::{Request, Response, Status};
 
 type MetaCache = HybridCache<HummockSstableObjectId, Box<Sstable>>;
-type BlockCache = HybridCache<SstableBlockIndex, Box<Block>>;
+type BlockCache = SstableBlockCache;
 
 #[derive(Clone)]
 pub struct MonitorServiceImpl {

--- a/src/ctl/src/common/hummock_service.rs
+++ b/src/ctl/src/common/hummock_service.rs
@@ -23,7 +23,9 @@ use risingwave_object_store::object::build_remote_object_store;
 use risingwave_rpc_client::MetaClient;
 use risingwave_storage::hummock::hummock_meta_client::MonitoredHummockMetaClient;
 use risingwave_storage::hummock::none::NoneRecentFilter;
-use risingwave_storage::hummock::{HummockStorage, SstableStore, SstableStoreConfig};
+use risingwave_storage::hummock::{
+    HummockStorage, LiveSsts, SstableBlockHashBuilder, SstableStore, SstableStoreConfig,
+};
 use risingwave_storage::monitor::{
     CompactorMetrics, HummockMetrics, HummockStateStoreMetrics, MonitoredStateStore,
     MonitoredStorageMetrics, ObjectStoreMetrics, global_hummock_state_store_metrics,
@@ -186,6 +188,7 @@ impl HummockServiceOpts {
             .await?;
         let block_cache = HybridCacheBuilder::new()
             .memory(opts.block_cache_capacity_mb * (1 << 20))
+            .with_hash_builder(SstableBlockHashBuilder::default())
             .with_shards(opts.block_cache_shard_num)
             .storage()
             .build()
@@ -204,6 +207,7 @@ impl HummockServiceOpts {
             skip_bloom_filter_in_serde: opts.sst_skip_bloom_filter_in_serde,
             meta_cache,
             block_cache,
+            live_ssts: LiveSsts::default(),
             vector_meta_cache: CacheBuilder::new(1 << 10).build(),
             vector_block_cache: CacheBuilder::new(1 << 10).build(),
         })))

--- a/src/java_binding/src/hummock_iterator.rs
+++ b/src/java_binding/src/hummock_iterator.rs
@@ -37,7 +37,8 @@ use risingwave_storage::hummock::none::NoneRecentFilter;
 use risingwave_storage::hummock::store::HummockStorageIterator;
 use risingwave_storage::hummock::store::version::HummockVersionReader;
 use risingwave_storage::hummock::{
-    CachePolicy, HummockError, SstableStore, SstableStoreConfig, get_committed_read_version_tuple,
+    CachePolicy, HummockError, LiveSsts, SstableBlockHashBuilder, SstableStore, SstableStoreConfig,
+    get_committed_read_version_tuple,
 };
 use risingwave_storage::monitor::{HummockStateStoreMetrics, global_hummock_state_store_metrics};
 use risingwave_storage::row_serde::value_serde::ValueRowSerdeNew;
@@ -91,6 +92,7 @@ pub(crate) async fn new_hummock_java_binding_iter(
             .await?;
         let block_cache = HybridCacheBuilder::new()
             .memory(1 << 10)
+            .with_hash_builder(SstableBlockHashBuilder::default())
             .with_shards(2)
             .storage()
             .build()
@@ -111,6 +113,7 @@ pub(crate) async fn new_hummock_java_binding_iter(
             skip_bloom_filter_in_serde: false,
             meta_cache,
             block_cache,
+            live_ssts: LiveSsts::default(),
             vector_meta_cache: CacheBuilder::new(1 << 10).build(),
             vector_block_cache: CacheBuilder::new(1 << 10).build(),
         }));

--- a/src/storage/benches/bench_compactor.rs
+++ b/src/storage/benches/bench_compactor.rs
@@ -48,8 +48,8 @@ use risingwave_storage::hummock::sstable::SstableIteratorReadOptions;
 use risingwave_storage::hummock::sstable_store::SstableStoreRef;
 use risingwave_storage::hummock::value::HummockValue;
 use risingwave_storage::hummock::{
-    CachePolicy, SstableBuilder, SstableBuilderOptions, SstableIterator, SstableStore,
-    SstableStoreConfig, SstableWriterOptions, Xor16FilterBuilder,
+    CachePolicy, LiveSsts, SstableBlockHashBuilder, SstableBuilder, SstableBuilderOptions,
+    SstableIterator, SstableStore, SstableStoreConfig, SstableWriterOptions, Xor16FilterBuilder,
 };
 use risingwave_storage::monitor::{
     CompactorMetrics, StoreLocalStatistic, global_hummock_state_store_metrics,
@@ -71,6 +71,7 @@ pub async fn mock_sstable_store() -> SstableStoreRef {
         .unwrap();
     let block_cache = HybridCacheBuilder::new()
         .memory(128 << 20)
+        .with_hash_builder(SstableBlockHashBuilder::default())
         .with_shards(2)
         .storage()
         .build()
@@ -89,6 +90,7 @@ pub async fn mock_sstable_store() -> SstableStoreRef {
 
         meta_cache,
         block_cache,
+        live_ssts: LiveSsts::default(),
         vector_meta_cache: CacheBuilder::new(1 << 10).build(),
         vector_block_cache: CacheBuilder::new(1 << 10).build(),
     }))

--- a/src/storage/benches/bench_multi_builder.rs
+++ b/src/storage/benches/bench_multi_builder.rs
@@ -37,10 +37,10 @@ use risingwave_storage::hummock::multi_builder::{CapacitySplitTableBuilder, Tabl
 use risingwave_storage::hummock::none::NoneRecentFilter;
 use risingwave_storage::hummock::value::HummockValue;
 use risingwave_storage::hummock::{
-    BackwardSstableIterator, BatchSstableWriterFactory, CachePolicy, HummockResult, MemoryLimiter,
-    SstableBuilder, SstableBuilderOptions, SstableIteratorReadOptions, SstableStore,
-    SstableStoreConfig, SstableWriterFactory, SstableWriterOptions, StreamingSstableWriterFactory,
-    Xor16FilterBuilder,
+    BackwardSstableIterator, BatchSstableWriterFactory, CachePolicy, HummockResult, LiveSsts,
+    MemoryLimiter, SstableBlockHashBuilder, SstableBuilder, SstableBuilderOptions,
+    SstableIteratorReadOptions, SstableStore, SstableStoreConfig, SstableWriterFactory,
+    SstableWriterOptions, StreamingSstableWriterFactory, Xor16FilterBuilder,
 };
 use risingwave_storage::monitor::{ObjectStoreMetrics, global_hummock_state_store_metrics};
 
@@ -151,6 +151,7 @@ async fn generate_sstable_store(object_store: Arc<ObjectStoreImpl>) -> Arc<Sstab
         .unwrap();
     let block_cache = HybridCacheBuilder::new()
         .memory(128 << 20)
+        .with_hash_builder(SstableBlockHashBuilder::default())
         .with_shards(2)
         .storage()
         .build()
@@ -167,6 +168,7 @@ async fn generate_sstable_store(object_store: Arc<ObjectStoreImpl>) -> Arc<Sstab
         skip_bloom_filter_in_serde: false,
         meta_cache,
         block_cache,
+        live_ssts: LiveSsts::default(),
         vector_meta_cache: CacheBuilder::new(1 << 10).build(),
         vector_block_cache: CacheBuilder::new(1 << 10).build(),
     }))

--- a/src/storage/hummock_test/src/bin/replay/main.rs
+++ b/src/storage/hummock_test/src/bin/replay/main.rs
@@ -43,7 +43,9 @@ use risingwave_storage::compaction_catalog_manager::{
     CompactionCatalogManager, FakeRemoteTableAccessor,
 };
 use risingwave_storage::hummock::none::NoneRecentFilter;
-use risingwave_storage::hummock::{HummockStorage, SstableStore, SstableStoreConfig};
+use risingwave_storage::hummock::{
+    HummockStorage, LiveSsts, SstableBlockHashBuilder, SstableStore, SstableStoreConfig,
+};
 use risingwave_storage::monitor::{CompactorMetrics, HummockStateStoreMetrics, ObjectStoreMetrics};
 use risingwave_storage::opts::StorageOpts;
 
@@ -121,6 +123,7 @@ async fn create_replay_hummock(r: Record, args: &Args) -> Result<impl GlobalRepl
         .unwrap();
     let block_cache = HybridCacheBuilder::new()
         .memory(storage_opts.block_cache_capacity_mb * (1 << 20))
+        .with_hash_builder(SstableBlockHashBuilder::default())
         .with_shards(storage_opts.block_cache_shard_num)
         .storage()
         .build()
@@ -138,6 +141,7 @@ async fn create_replay_hummock(r: Record, args: &Args) -> Result<impl GlobalRepl
         skip_bloom_filter_in_serde: storage_opts.sst_skip_bloom_filter_in_serde,
         meta_cache,
         block_cache,
+        live_ssts: LiveSsts::default(),
         vector_meta_cache: CacheBuilder::new(1 << 10).build(),
         vector_block_cache: CacheBuilder::new(1 << 10).build(),
     }));

--- a/src/storage/src/hummock/block_cache.rs
+++ b/src/storage/src/hummock/block_cache.rs
@@ -12,17 +12,165 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::collections::HashSet;
+use std::hash::{BuildHasherDefault, Hash, Hasher};
 use std::ops::Deref;
 use std::sync::Arc;
 
+use arc_swap::ArcSwap;
 use await_tree::{InstrumentAwait, SpanExt};
-use foyer::{HybridCacheEntry, HybridGetOrFetch};
+use foyer::{
+    HybridCache, HybridCacheEntry, HybridGetOrFetch, Statistics, StorageFilterCondition,
+    StorageFilterResult,
+};
 use risingwave_common::config::EvictionConfig;
+use risingwave_hummock_sdk::version::HummockVersion;
+use risingwave_hummock_sdk::{HummockObjectId, HummockSstableObjectId};
+use serde::{Deserialize, Serialize};
+use xxhash_rust::xxh64::xxh64;
 
-use super::{Block, HummockResult, SstableBlockIndex};
+use super::{Block, HummockResult};
 use crate::hummock::HummockError;
 
-type HybridCachedBlockEntry = HybridCacheEntry<SstableBlockIndex, Box<Block>>;
+const BLOCK_INDEX_BITS: u32 = 16;
+const BLOCK_INDEX_LIMIT: u64 = 1 << BLOCK_INDEX_BITS;
+// The POC keeps the full SST object ID under the current 32-bit deployment bound. Bit 63 marks
+// keys that cannot use the extractable layout, so the live-SST filter rejects them fail-closed.
+const SST_ID_LIMIT: u64 = 1 << 32;
+const INVALID_HASH_BIT: u64 = 1 << 63;
+
+#[derive(Debug, Clone, Copy, PartialEq, PartialOrd, Eq, Ord, Serialize, Deserialize)]
+pub struct SstableBlockIndex {
+    pub sst_id: HummockSstableObjectId,
+    pub block_idx: u64,
+}
+
+impl SstableBlockIndex {
+    fn encoded_hash(&self) -> u64 {
+        let sst_id = self.sst_id.as_raw_id();
+        if sst_id < SST_ID_LIMIT && self.block_idx < BLOCK_INDEX_LIMIT {
+            return (sst_id << BLOCK_INDEX_BITS) | self.block_idx;
+        }
+
+        let mut bytes = [0; 16];
+        bytes[..8].copy_from_slice(&sst_id.to_le_bytes());
+        bytes[8..].copy_from_slice(&self.block_idx.to_le_bytes());
+        INVALID_HASH_BIT | (xxh64(&bytes, 0) & !INVALID_HASH_BIT)
+    }
+}
+
+impl Hash for SstableBlockIndex {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        state.write_u64(self.encoded_hash());
+    }
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct SstableBlockHasher {
+    hash: u64,
+}
+
+impl Hasher for SstableBlockHasher {
+    fn finish(&self) -> u64 {
+        self.hash
+    }
+
+    fn write(&mut self, bytes: &[u8]) {
+        self.hash = match <&[u8; 8]>::try_from(bytes) {
+            Ok(bytes) => u64::from_ne_bytes(*bytes),
+            Err(_) => INVALID_HASH_BIT | (xxh64(bytes, 0) & !INVALID_HASH_BIT),
+        };
+    }
+
+    fn write_u64(&mut self, value: u64) {
+        self.hash = value;
+    }
+}
+
+pub type SstableBlockHashBuilder = BuildHasherDefault<SstableBlockHasher>;
+pub type SstableBlockCache = HybridCache<SstableBlockIndex, Box<Block>, SstableBlockHashBuilder>;
+type HybridCachedBlockEntry =
+    HybridCacheEntry<SstableBlockIndex, Box<Block>, SstableBlockHashBuilder>;
+type HybridBlockGetOrFetch =
+    HybridGetOrFetch<SstableBlockIndex, Box<Block>, SstableBlockHashBuilder>;
+
+#[derive(Clone)]
+pub struct LiveSsts {
+    inner: Arc<ArcSwap<HashSet<HummockSstableObjectId>>>,
+}
+
+impl Default for LiveSsts {
+    fn default() -> Self {
+        Self {
+            inner: Arc::new(ArcSwap::from_pointee(HashSet::new())),
+        }
+    }
+}
+
+impl std::fmt::Debug for LiveSsts {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("LiveSsts")
+            .field("len", &self.inner.load().len())
+            .finish()
+    }
+}
+
+impl LiveSsts {
+    pub fn replace_from_version(&self, version: &HummockVersion) {
+        self.replace(version.get_object_ids().filter_map(|object_id| {
+            if let HummockObjectId::Sstable(object_id) = object_id {
+                Some(object_id)
+            } else {
+                None
+            }
+        }));
+    }
+
+    fn replace(&self, object_ids: impl IntoIterator<Item = HummockSstableObjectId>) {
+        let next = HashSet::from_iter(object_ids);
+        if self.inner.load().as_ref() != &next {
+            self.inner.store(Arc::new(next));
+        }
+    }
+
+    fn contains(&self, object_id: &HummockSstableObjectId) -> bool {
+        self.inner.load().contains(object_id)
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct LiveSstFilter {
+    live_ssts: LiveSsts,
+}
+
+impl LiveSstFilter {
+    pub fn new(live_ssts: LiveSsts) -> Self {
+        Self { live_ssts }
+    }
+
+    fn is_admitted(&self, hash: u64) -> bool {
+        if hash & INVALID_HASH_BIT != 0 {
+            return false;
+        }
+        self.live_ssts
+            .contains(&HummockSstableObjectId::new(hash >> BLOCK_INDEX_BITS))
+    }
+}
+
+impl StorageFilterCondition for LiveSstFilter {
+    fn filter(
+        &self,
+        _stats: &Arc<Statistics>,
+        hash: u64,
+        _estimated_size: usize,
+    ) -> StorageFilterResult {
+        if self.is_admitted(hash) {
+            StorageFilterResult::Admit
+        } else {
+            StorageFilterResult::Reject
+        }
+    }
+}
 
 pub enum BlockEntry {
     HybridCache(HybridCachedBlockEntry),
@@ -85,7 +233,7 @@ pub struct BlockCacheConfig {
 
 pub enum BlockResponse {
     Block(BlockHolder),
-    Fetch(HybridGetOrFetch<SstableBlockIndex, Box<Block>>),
+    Fetch(HybridBlockGetOrFetch),
 }
 
 impl BlockResponse {
@@ -103,5 +251,126 @@ impl BlockResponse {
             .await
             .map(BlockHolder::from_hybrid_cache_entry)
             .map_err(HummockError::foyer_error)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+    use std::hash::BuildHasher;
+    use std::sync::Arc;
+
+    use risingwave_hummock_sdk::level::{LevelCommon, LevelsCommon};
+    use risingwave_hummock_sdk::sstable_info::{SstableInfo, SstableInfoInner};
+    use risingwave_hummock_sdk::version::HummockVersion;
+    use risingwave_hummock_sdk::{HummockSstableObjectId, HummockVersionId};
+
+    use super::{
+        BLOCK_INDEX_LIMIT, INVALID_HASH_BIT, LiveSstFilter, LiveSsts, SST_ID_LIMIT,
+        SstableBlockHashBuilder, SstableBlockIndex,
+    };
+
+    fn hash(key: SstableBlockIndex) -> u64 {
+        SstableBlockHashBuilder::default().hash_one(key)
+    }
+
+    fn version_with_ssts(sst_ids: &[u64]) -> HummockVersion {
+        let table_infos: Vec<SstableInfo> = sst_ids
+            .iter()
+            .map(|sst_id| {
+                SstableInfoInner {
+                    object_id: (*sst_id).into(),
+                    sst_id: (*sst_id + 1000).into(),
+                    ..Default::default()
+                }
+                .into()
+            })
+            .collect();
+        let level = LevelCommon::<SstableInfo> {
+            level_idx: 0,
+            level_type: Default::default(),
+            table_infos,
+            total_file_size: 0,
+            sub_level_id: 0,
+            uncompressed_file_size: 0,
+            vnode_partition_count: 0,
+        };
+        let mut levels = LevelsCommon::<SstableInfo>::default();
+        levels.l0.sub_levels.push(level);
+        let mut version = HummockVersion::default();
+        version.id = HummockVersionId::new(1);
+        version.levels = HashMap::from([(1.into(), levels)]);
+        version
+    }
+
+    #[test]
+    fn test_live_sst_filter() {
+        let live_ssts = LiveSsts::default();
+        let filter = LiveSstFilter::new(live_ssts.clone());
+        let live = HummockSstableObjectId::new(7);
+        let stale = HummockSstableObjectId::new(8);
+
+        assert!(!filter.is_admitted(hash(SstableBlockIndex {
+            sst_id: live,
+            block_idx: 3,
+        })));
+
+        assert_eq!(
+            hash(SstableBlockIndex {
+                sst_id: live,
+                block_idx: 3,
+            }),
+            (live.as_raw_id() << super::BLOCK_INDEX_BITS) | 3
+        );
+
+        live_ssts.replace([live]);
+        assert!(filter.is_admitted(hash(SstableBlockIndex {
+            sst_id: live,
+            block_idx: 3,
+        })));
+        assert!(!filter.is_admitted(hash(SstableBlockIndex {
+            sst_id: stale,
+            block_idx: 3,
+        })));
+    }
+
+    #[test]
+    fn test_live_ssts_replace_from_version() {
+        let live_ssts = LiveSsts::default();
+        let filter = LiveSstFilter::new(live_ssts.clone());
+        let sst_7 = SstableBlockIndex {
+            sst_id: HummockSstableObjectId::new(7),
+            block_idx: 0,
+        };
+        let sst_8 = SstableBlockIndex {
+            sst_id: HummockSstableObjectId::new(8),
+            block_idx: 0,
+        };
+
+        live_ssts.replace_from_version(&version_with_ssts(&[7, 8]));
+        let first = live_ssts.inner.load_full();
+        live_ssts.replace_from_version(&version_with_ssts(&[7, 8]));
+        assert!(Arc::ptr_eq(&first, &live_ssts.inner.load_full()));
+        assert!(filter.is_admitted(hash(sst_7)));
+        assert!(filter.is_admitted(hash(sst_8)));
+
+        live_ssts.replace_from_version(&version_with_ssts(&[8]));
+        assert!(!filter.is_admitted(hash(sst_7)));
+        assert!(filter.is_admitted(hash(sst_8)));
+    }
+
+    #[test]
+    fn test_sstable_block_hash_bounds_fail_closed() {
+        let block_overflow = hash(SstableBlockIndex {
+            sst_id: HummockSstableObjectId::new(7),
+            block_idx: BLOCK_INDEX_LIMIT,
+        });
+        let sst_overflow = hash(SstableBlockIndex {
+            sst_id: HummockSstableObjectId::new(SST_ID_LIMIT),
+            block_idx: 0,
+        });
+
+        assert_ne!(block_overflow & INVALID_HASH_BIT, 0);
+        assert_ne!(sst_overflow & INVALID_HASH_BIT, 0);
     }
 }

--- a/src/storage/src/hummock/block_cache.rs
+++ b/src/storage/src/hummock/block_cache.rs
@@ -12,17 +12,163 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::collections::HashSet;
+use std::hash::{BuildHasherDefault, Hash, Hasher};
 use std::ops::Deref;
 use std::sync::Arc;
 
+use arc_swap::ArcSwap;
 use await_tree::{InstrumentAwait, SpanExt};
-use foyer::{HybridCacheEntry, HybridGetOrFetch};
+use foyer::{
+    HybridCache, HybridCacheEntry, HybridGetOrFetch, Statistics, StorageFilterCondition,
+    StorageFilterResult,
+};
 use risingwave_common::config::EvictionConfig;
+use risingwave_hummock_sdk::HummockSstableObjectId;
+use risingwave_hummock_sdk::version::LocalHummockVersion;
+use serde::{Deserialize, Serialize};
+use xxhash_rust::xxh64::xxh64;
 
-use super::{Block, HummockResult, SstableBlockIndex};
+use super::{Block, HummockResult};
 use crate::hummock::HummockError;
 
-type HybridCachedBlockEntry = HybridCacheEntry<SstableBlockIndex, Box<Block>>;
+const BLOCK_INDEX_BITS: u32 = 16;
+const BLOCK_INDEX_LIMIT: u64 = 1 << BLOCK_INDEX_BITS;
+// The POC keeps the full SST object ID under the current 32-bit deployment bound. Bit 63 marks
+// keys that cannot use the extractable layout, so the live-SST filter rejects them fail-closed.
+const SST_ID_LIMIT: u64 = 1 << 32;
+const INVALID_HASH_BIT: u64 = 1 << 63;
+
+#[derive(Debug, Clone, Copy, PartialEq, PartialOrd, Eq, Ord, Serialize, Deserialize)]
+pub struct SstableBlockIndex {
+    pub sst_id: HummockSstableObjectId,
+    pub block_idx: u64,
+}
+
+impl SstableBlockIndex {
+    fn encoded_hash(&self) -> u64 {
+        let sst_id = self.sst_id.as_raw_id();
+        if sst_id < SST_ID_LIMIT && self.block_idx < BLOCK_INDEX_LIMIT {
+            return (sst_id << BLOCK_INDEX_BITS) | self.block_idx;
+        }
+
+        let mut bytes = [0; 16];
+        bytes[..8].copy_from_slice(&sst_id.to_le_bytes());
+        bytes[8..].copy_from_slice(&self.block_idx.to_le_bytes());
+        INVALID_HASH_BIT | (xxh64(&bytes, 0) & !INVALID_HASH_BIT)
+    }
+}
+
+impl Hash for SstableBlockIndex {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        state.write_u64(self.encoded_hash());
+    }
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct SstableBlockHasher {
+    hash: u64,
+}
+
+impl Hasher for SstableBlockHasher {
+    fn finish(&self) -> u64 {
+        self.hash
+    }
+
+    fn write(&mut self, bytes: &[u8]) {
+        self.hash = match <&[u8; 8]>::try_from(bytes) {
+            Ok(bytes) => u64::from_ne_bytes(*bytes),
+            Err(_) => INVALID_HASH_BIT | (xxh64(bytes, 0) & !INVALID_HASH_BIT),
+        };
+    }
+
+    fn write_u64(&mut self, value: u64) {
+        self.hash = value;
+    }
+}
+
+pub type SstableBlockHashBuilder = BuildHasherDefault<SstableBlockHasher>;
+pub type SstableBlockCache = HybridCache<SstableBlockIndex, Box<Block>, SstableBlockHashBuilder>;
+type HybridCachedBlockEntry =
+    HybridCacheEntry<SstableBlockIndex, Box<Block>, SstableBlockHashBuilder>;
+type HybridBlockGetOrFetch =
+    HybridGetOrFetch<SstableBlockIndex, Box<Block>, SstableBlockHashBuilder>;
+
+#[derive(Clone)]
+pub struct LiveSsts {
+    inner: Arc<ArcSwap<HashSet<HummockSstableObjectId>>>,
+}
+
+impl Default for LiveSsts {
+    fn default() -> Self {
+        Self {
+            inner: Arc::new(ArcSwap::from_pointee(HashSet::new())),
+        }
+    }
+}
+
+impl std::fmt::Debug for LiveSsts {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("LiveSsts")
+            .field("len", &self.inner.load().len())
+            .finish()
+    }
+}
+
+impl LiveSsts {
+    pub fn replace_from_version(&self, version: &LocalHummockVersion) {
+        self.replace(
+            version
+                .levels
+                .values()
+                .flat_map(|levels| levels.l0.sub_levels.iter().chain(levels.levels.iter()))
+                .flat_map(|level| level.table_infos.iter())
+                .map(|sst| sst.object_id),
+        );
+    }
+
+    fn replace(&self, sst_ids: impl IntoIterator<Item = HummockSstableObjectId>) {
+        self.inner.store(Arc::new(sst_ids.into_iter().collect()));
+    }
+
+    fn contains(&self, sst_id: &HummockSstableObjectId) -> bool {
+        self.inner.load().contains(sst_id)
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct LiveSstFilter {
+    live_ssts: LiveSsts,
+}
+
+impl LiveSstFilter {
+    pub fn new(live_ssts: LiveSsts) -> Self {
+        Self { live_ssts }
+    }
+
+    fn is_admitted(&self, hash: u64) -> bool {
+        if hash & INVALID_HASH_BIT != 0 {
+            return false;
+        }
+        self.live_ssts
+            .contains(&HummockSstableObjectId::new(hash >> BLOCK_INDEX_BITS))
+    }
+}
+
+impl StorageFilterCondition for LiveSstFilter {
+    fn filter(
+        &self,
+        _stats: &Arc<Statistics>,
+        hash: u64,
+        _estimated_size: usize,
+    ) -> StorageFilterResult {
+        if self.is_admitted(hash) {
+            StorageFilterResult::Admit
+        } else {
+            StorageFilterResult::Reject
+        }
+    }
+}
 
 pub enum BlockEntry {
     HybridCache(HybridCachedBlockEntry),
@@ -85,7 +231,7 @@ pub struct BlockCacheConfig {
 
 pub enum BlockResponse {
     Block(BlockHolder),
-    Fetch(HybridGetOrFetch<SstableBlockIndex, Box<Block>>),
+    Fetch(HybridBlockGetOrFetch),
 }
 
 impl BlockResponse {
@@ -103,5 +249,122 @@ impl BlockResponse {
             .await
             .map(BlockHolder::from_hybrid_cache_entry)
             .map_err(HummockError::foyer_error)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+    use std::hash::BuildHasher;
+
+    use risingwave_hummock_sdk::level::{LevelCommon, LevelsCommon};
+    use risingwave_hummock_sdk::sstable_info::{SstableInfo, SstableInfoInner};
+    use risingwave_hummock_sdk::version::{HummockVersion, LocalHummockVersion};
+    use risingwave_hummock_sdk::{HummockSstableObjectId, HummockVersionId};
+
+    use super::{
+        BLOCK_INDEX_LIMIT, INVALID_HASH_BIT, LiveSstFilter, LiveSsts, SST_ID_LIMIT,
+        SstableBlockHashBuilder, SstableBlockIndex,
+    };
+
+    fn hash(key: SstableBlockIndex) -> u64 {
+        SstableBlockHashBuilder::default().hash_one(key)
+    }
+
+    fn version_with_ssts(sst_ids: &[u64]) -> LocalHummockVersion {
+        let table_infos: Vec<SstableInfo> = sst_ids
+            .iter()
+            .map(|sst_id| {
+                SstableInfoInner {
+                    object_id: (*sst_id).into(),
+                    sst_id: (*sst_id).into(),
+                    ..Default::default()
+                }
+                .into()
+            })
+            .collect();
+        let level = LevelCommon::<SstableInfo> {
+            level_idx: 0,
+            level_type: Default::default(),
+            table_infos,
+            total_file_size: 0,
+            sub_level_id: 0,
+            uncompressed_file_size: 0,
+            vnode_partition_count: 0,
+        };
+        let mut levels = LevelsCommon::<SstableInfo>::default();
+        levels.l0.sub_levels.push(level);
+        let mut version = HummockVersion::default();
+        version.id = HummockVersionId::new(1);
+        version.levels = HashMap::from([(1.into(), levels)]);
+        version.into()
+    }
+
+    #[test]
+    fn test_live_sst_filter() {
+        let live_ssts = LiveSsts::default();
+        let filter = LiveSstFilter::new(live_ssts.clone());
+        let live = HummockSstableObjectId::new(7);
+        let stale = HummockSstableObjectId::new(8);
+
+        assert!(!filter.is_admitted(hash(SstableBlockIndex {
+            sst_id: live,
+            block_idx: 3,
+        })));
+
+        assert_eq!(
+            hash(SstableBlockIndex {
+                sst_id: live,
+                block_idx: 3,
+            }),
+            (live.as_raw_id() << super::BLOCK_INDEX_BITS) | 3
+        );
+
+        live_ssts.replace([live]);
+        assert!(filter.is_admitted(hash(SstableBlockIndex {
+            sst_id: live,
+            block_idx: 3,
+        })));
+        assert!(!filter.is_admitted(hash(SstableBlockIndex {
+            sst_id: stale,
+            block_idx: 3,
+        })));
+    }
+
+    #[test]
+    fn test_live_ssts_replace_from_version() {
+        let live_ssts = LiveSsts::default();
+        let filter = LiveSstFilter::new(live_ssts.clone());
+        let sst_7 = SstableBlockIndex {
+            sst_id: HummockSstableObjectId::new(7),
+            block_idx: 0,
+        };
+        let sst_8 = SstableBlockIndex {
+            sst_id: HummockSstableObjectId::new(8),
+            block_idx: 0,
+        };
+
+        live_ssts.replace_from_version(&version_with_ssts(&[7, 8]));
+        assert!(filter.is_admitted(hash(sst_7)));
+        assert!(filter.is_admitted(hash(sst_8)));
+
+        live_ssts.replace_from_version(&version_with_ssts(&[8]));
+        assert!(!filter.is_admitted(hash(sst_7)));
+        assert!(filter.is_admitted(hash(sst_8)));
+    }
+
+    #[test]
+    fn test_sstable_block_hash_bounds_fail_closed() {
+        let block_overflow = hash(SstableBlockIndex {
+            sst_id: HummockSstableObjectId::new(7),
+            block_idx: BLOCK_INDEX_LIMIT,
+        });
+        let sst_overflow = hash(SstableBlockIndex {
+            sst_id: HummockSstableObjectId::new(SST_ID_LIMIT),
+            block_idx: 0,
+        });
+
+        assert_ne!(block_overflow & INVALID_HASH_BIT, 0);
+        assert_ne!(sst_overflow & INVALID_HASH_BIT, 0);
     }
 }

--- a/src/storage/src/hummock/event_handler/hummock_event_handler.rs
+++ b/src/storage/src/hummock/event_handler/hummock_event_handler.rs
@@ -56,7 +56,7 @@ use crate::hummock::event_handler::{
 use crate::hummock::local_version::pinned_version::PinnedVersion;
 use crate::hummock::local_version::recent_versions::RecentVersions;
 use crate::hummock::store::version::{HummockReadVersion, StagingSstableInfo, VersionUpdate};
-use crate::hummock::{HummockResult, MemoryLimiter, ObjectIdManager, SstableStoreRef};
+use crate::hummock::{HummockResult, LiveSsts, MemoryLimiter, ObjectIdManager, SstableStoreRef};
 use crate::mem_table::ImmutableMemtable;
 use crate::monitor::HummockStateStoreMetrics;
 use crate::opts::StorageOpts;
@@ -335,6 +335,7 @@ pub(crate) struct HummockEventHandler {
 
     version_update_notifier_tx: Arc<tokio::sync::watch::Sender<PinnedVersion>>,
     recent_versions: Arc<ArcSwap<RecentVersions>>,
+    live_ssts: LiveSsts,
 
     uploader: HummockUploader,
     refiller: CacheRefiller,
@@ -496,6 +497,8 @@ impl HummockEventHandler {
                 .with_label_values(&["apply_table_refill_runtime_config"]),
         };
 
+        let live_ssts = sstable_store.live_ssts().clone();
+        live_ssts.replace_from_version(recent_versions.latest_version());
         let uploader = HummockUploader::new(
             state_store_metrics,
             recent_versions.latest_version().clone(),
@@ -510,6 +513,7 @@ impl HummockEventHandler {
             observer_event_rx,
             version_update_notifier_tx,
             recent_versions: Arc::new(ArcSwap::from_pointee(recent_versions)),
+            live_ssts,
             read_version_mapping,
             local_read_versions: Default::default(),
             uploader,
@@ -713,6 +717,17 @@ impl HummockEventHandler {
             .metrics
             .event_handler_on_recv_version_update
             .start_timer();
+        let may_change_live_objects = match &version_payload {
+            HummockVersionUpdate::VersionDeltas(version_deltas) => {
+                // The data block filter only queries SST object IDs. SST level membership can only
+                // change through group deltas; table metadata and vector-only deltas do not affect
+                // its decisions.
+                version_deltas
+                    .iter()
+                    .any(|version_delta| !version_delta.group_deltas.is_empty())
+            }
+            HummockVersionUpdate::PinnedVersion(_) => true,
+        };
         let pinned_version = self
             .refiller
             .last_new_pinned_version()
@@ -725,6 +740,11 @@ impl HummockEventHandler {
             version_payload,
             Some(&mut sst_delta_infos),
         ) {
+            if may_change_live_objects {
+                // The refiller uses force insertion after its explicit storage-filter check, so
+                // publish the target version's live objects before starting refill tasks.
+                self.live_ssts.replace_from_version(&new_pinned_version);
+            }
             self.refiller
                 .start_cache_refill(sst_delta_infos, pinned_version, new_pinned_version);
         }

--- a/src/storage/src/hummock/event_handler/hummock_event_handler.rs
+++ b/src/storage/src/hummock/event_handler/hummock_event_handler.rs
@@ -57,7 +57,7 @@ use crate::hummock::event_handler::{
 use crate::hummock::local_version::pinned_version::PinnedVersion;
 use crate::hummock::local_version::recent_versions::RecentVersions;
 use crate::hummock::store::version::{HummockReadVersion, StagingSstableInfo, VersionUpdate};
-use crate::hummock::{HummockResult, MemoryLimiter, ObjectIdManager, SstableStoreRef};
+use crate::hummock::{HummockResult, LiveSsts, MemoryLimiter, ObjectIdManager, SstableStoreRef};
 use crate::mem_table::ImmutableMemtable;
 use crate::monitor::HummockStateStoreMetrics;
 use crate::opts::StorageOpts;
@@ -336,6 +336,7 @@ pub(crate) struct HummockEventHandler {
 
     version_update_notifier_tx: Arc<tokio::sync::watch::Sender<PinnedVersion>>,
     recent_versions: Arc<ArcSwap<RecentVersions>>,
+    live_ssts: LiveSsts,
 
     uploader: HummockUploader,
     refiller: CacheRefiller,
@@ -497,6 +498,8 @@ impl HummockEventHandler {
                 .with_label_values(&["apply_table_refill_runtime_config"]),
         };
 
+        let live_ssts = sstable_store.live_ssts().clone();
+        live_ssts.replace_from_version(recent_versions.latest_version());
         let uploader = HummockUploader::new(
             state_store_metrics,
             recent_versions.latest_version().clone(),
@@ -511,6 +514,7 @@ impl HummockEventHandler {
             observer_event_rx,
             version_update_notifier_tx,
             recent_versions: Arc::new(ArcSwap::from_pointee(recent_versions)),
+            live_ssts,
             read_version_mapping,
             local_read_versions: Default::default(),
             uploader,
@@ -726,6 +730,9 @@ impl HummockEventHandler {
             version_payload,
             Some(&mut sst_delta_infos),
         ) {
+            // The refiller uses force insertion after its explicit storage-filter check, so publish
+            // the target version's live SSTs before starting refill tasks.
+            self.live_ssts.replace_from_version(&new_pinned_version);
             self.refiller
                 .start_cache_refill(sst_delta_infos, pinned_version, new_pinned_version);
         }

--- a/src/storage/src/hummock/iterator/test_utils.rs
+++ b/src/storage/src/hummock/iterator/test_utils.rs
@@ -37,8 +37,8 @@ use crate::hummock::test_utils::{
     gen_test_sstable, gen_test_sstable_info, gen_test_sstable_with_range_tombstone,
 };
 use crate::hummock::{
-    HummockValue, RecentFilter, SstableBuilderOptions, SstableIterator, SstableIteratorType,
-    SstableStoreConfig, SstableStoreRef, TableHolder,
+    HummockValue, LiveSsts, RecentFilter, SstableBlockHashBuilder, SstableBuilderOptions,
+    SstableIterator, SstableIteratorType, SstableStoreConfig, SstableStoreRef, TableHolder,
 };
 use crate::monitor::{ObjectStoreMetrics, global_hummock_state_store_metrics};
 
@@ -97,6 +97,7 @@ pub async fn mock_sstable_store_with_object_store_and_recent_filter(
         .unwrap();
     let block_cache = HybridCacheBuilder::new()
         .memory(64 << 20)
+        .with_hash_builder(SstableBlockHashBuilder::default())
         .with_shards(2)
         .storage()
         .build()
@@ -116,6 +117,7 @@ pub async fn mock_sstable_store_with_object_store_and_recent_filter(
 
         meta_cache,
         block_cache,
+        live_ssts: LiveSsts::default(),
         vector_meta_cache: CacheBuilder::new(64 << 20).build(),
         vector_block_cache: CacheBuilder::new(64 << 20).build(),
     }))

--- a/src/storage/src/hummock/sstable_store.rs
+++ b/src/storage/src/hummock/sstable_store.rs
@@ -39,12 +39,12 @@ use risingwave_object_store::object::{
     ObjectError, ObjectMetadataIter, ObjectResult, ObjectStoreRef, ObjectStreamingUploader,
 };
 use risingwave_pb::hummock::PbHnswGraph;
-use serde::{Deserialize, Serialize};
 use thiserror_ext::AsReport;
 use tokio::time::Instant;
 
 use super::{
-    BatchUploadWriter, Block, BlockMeta, BlockResponse, RecentFilter, Sstable, SstableMeta,
+    BatchUploadWriter, Block, BlockMeta, BlockResponse, LiveSsts, RecentFilter, Sstable,
+    SstableBlockCache, SstableBlockHashBuilder, SstableBlockIndex, SstableMeta,
     SstableWriterOptions,
 };
 use crate::hummock::block_stream::{
@@ -118,12 +118,6 @@ pub type VectorBlockHolder = CacheEntry<(HummockVectorFileId, usize), Box<Vector
 
 pub type VectorFileHolder = VectorMetaFileHolder<VectorFileMeta>;
 pub type HnswGraphFileHolder = VectorMetaFileHolder<PbHnswGraph>;
-
-#[derive(Debug, Clone, Copy, PartialEq, PartialOrd, Eq, Ord, Hash, Serialize, Deserialize)]
-pub struct SstableBlockIndex {
-    pub sst_id: HummockSstableObjectId,
-    pub block_idx: u64,
-}
 
 pub struct BlockCacheEventListener {
     metrics: Arc<HummockStateStoreMetrics>,
@@ -199,7 +193,8 @@ pub struct SstableStoreConfig {
     pub skip_bloom_filter_in_serde: bool,
 
     pub meta_cache: HybridCache<HummockSstableObjectId, Box<Sstable>>,
-    pub block_cache: HybridCache<SstableBlockIndex, Box<Block>>,
+    pub block_cache: SstableBlockCache,
+    pub live_ssts: LiveSsts,
 
     pub vector_meta_cache: Cache<HummockRawObjectId, HummockVectorIndexMetaFile>,
     pub vector_block_cache: Cache<(HummockVectorFileId, usize), Box<VectorBlock>>,
@@ -210,7 +205,8 @@ pub struct SstableStore {
     store: ObjectStoreRef,
 
     meta_cache: HybridCache<HummockSstableObjectId, Box<Sstable>>,
-    block_cache: HybridCache<SstableBlockIndex, Box<Block>>,
+    block_cache: SstableBlockCache,
+    live_ssts: LiveSsts,
     pub vector_meta_cache: Cache<HummockRawObjectId, HummockVectorIndexMetaFile>,
     pub vector_block_cache: Cache<(HummockVectorFileId, usize), Box<VectorBlock>>,
 
@@ -248,6 +244,7 @@ impl SstableStore {
 
             meta_cache: config.meta_cache,
             block_cache: config.block_cache,
+            live_ssts: config.live_ssts,
             vector_meta_cache: config.vector_meta_cache,
             vector_block_cache: config.vector_block_cache,
 
@@ -284,6 +281,7 @@ impl SstableStore {
 
         let block_cache = HybridCacheBuilder::new()
             .memory(block_cache_capacity)
+            .with_hash_builder(SstableBlockHashBuilder::default())
             .with_shards(1)
             .with_weighter(|_: &SstableBlockIndex, value: &Box<Block>| {
                 std::mem::size_of::<SstableBlockIndex>() + value.estimated_memory_weight()
@@ -306,6 +304,7 @@ impl SstableStore {
 
             meta_cache,
             block_cache,
+            live_ssts: LiveSsts::default(),
             vector_meta_cache: CacheBuilder::new(1 << 10).build(),
             vector_block_cache: CacheBuilder::new(1 << 10).build(),
         })
@@ -829,8 +828,12 @@ impl SstableStore {
         &self.meta_cache
     }
 
-    pub fn block_cache(&self) -> &HybridCache<SstableBlockIndex, Box<Block>> {
+    pub fn block_cache(&self) -> &SstableBlockCache {
         &self.block_cache
+    }
+
+    pub fn live_ssts(&self) -> &LiveSsts {
+        &self.live_ssts
     }
 
     pub fn recent_filter(&self) -> &Arc<RecentFilter<(HummockSstableObjectId, usize)>> {

--- a/src/storage/src/store_impl.rs
+++ b/src/storage/src/store_impl.rs
@@ -20,7 +20,7 @@ use std::time::Duration;
 use enum_as_inner::EnumAsInner;
 use foyer::{
     BlockEngineBuilder, CacheBuilder, DeviceBuilder, FifoPicker, FsDeviceBuilder,
-    HybridCacheBuilder,
+    HybridCacheBuilder, StorageFilter,
 };
 use futures::FutureExt;
 use futures::future::BoxFuture;
@@ -43,8 +43,8 @@ use crate::hummock::none::NoneRecentFilter;
 use crate::hummock::sharded::ShardedRecentFilter;
 use crate::hummock::simple::SimpleRecentFilter;
 use crate::hummock::{
-    Block, BlockCacheEventListener, HummockError, HummockStorage, Sstable, SstableBlockIndex,
-    SstableStore, SstableStoreConfig,
+    Block, BlockCacheEventListener, HummockError, HummockStorage, LiveSstFilter, LiveSsts, Sstable,
+    SstableBlockHashBuilder, SstableBlockIndex, SstableStore, SstableStoreConfig,
 };
 use crate::memory::MemoryStateStore;
 use crate::memory::sled::SledStateStore;
@@ -748,6 +748,7 @@ impl StateStoreImpl {
             builder.build().await.map_err(HummockError::foyer_error)?
         };
 
+        let live_ssts = LiveSsts::default();
         let block_cache = {
             let mut builder = HybridCacheBuilder::new()
                 .with_name("foyer.data")
@@ -756,6 +757,7 @@ impl StateStoreImpl {
                     state_store_metrics.clone(),
                 )))
                 .memory(opts.block_cache_capacity_mb * MB)
+                .with_hash_builder(SstableBlockHashBuilder::default())
                 .with_shards(opts.block_cache_shard_num)
                 .with_eviction_config(opts.block_cache_eviction_config.clone())
                 .with_weighter(|_: &SstableBlockIndex, value: &Box<Block>| {
@@ -786,6 +788,14 @@ impl StateStoreImpl {
                         )
                         .with_recover_concurrency(opts.data_file_cache_recover_concurrency)
                         .with_blob_index_size(opts.data_file_cache_blob_index_size_kb * KB)
+                        .with_admission_filter(
+                            StorageFilter::new()
+                                .with_condition(LiveSstFilter::new(live_ssts.clone())),
+                        )
+                        .with_reinsertion_filter(
+                            StorageFilter::new()
+                                .with_condition(LiveSstFilter::new(live_ssts.clone())),
+                        )
                         .with_eviction_pickers(vec![Box::new(FifoPicker::new(
                             opts.data_file_cache_fifo_probation_ratio,
                         ))]);
@@ -859,6 +869,7 @@ impl StateStoreImpl {
 
                     meta_cache,
                     block_cache,
+                    live_ssts,
                     vector_meta_cache,
                     vector_block_cache,
                 }));

--- a/src/storage/src/store_impl.rs
+++ b/src/storage/src/store_impl.rs
@@ -20,7 +20,7 @@ use std::time::Duration;
 use enum_as_inner::EnumAsInner;
 use foyer::{
     BlockEngineBuilder, CacheBuilder, DeviceBuilder, FifoPicker, FsDeviceBuilder,
-    HybridCacheBuilder,
+    HybridCacheBuilder, StorageFilter,
 };
 use futures::FutureExt;
 use futures::future::BoxFuture;
@@ -43,8 +43,8 @@ use crate::hummock::none::NoneRecentFilter;
 use crate::hummock::sharded::ShardedRecentFilter;
 use crate::hummock::simple::SimpleRecentFilter;
 use crate::hummock::{
-    Block, BlockCacheEventListener, HummockError, HummockStorage, Sstable, SstableBlockIndex,
-    SstableStore, SstableStoreConfig,
+    Block, BlockCacheEventListener, HummockError, HummockStorage, LiveSstFilter, LiveSsts, Sstable,
+    SstableBlockHashBuilder, SstableBlockIndex, SstableStore, SstableStoreConfig,
 };
 use crate::memory::MemoryStateStore;
 use crate::memory::sled::SledStateStore;
@@ -748,6 +748,7 @@ impl StateStoreImpl {
             builder.build().await.map_err(HummockError::foyer_error)?
         };
 
+        let live_ssts = LiveSsts::default();
         let block_cache = {
             let mut builder = HybridCacheBuilder::new()
                 .with_name("foyer.data")
@@ -756,6 +757,7 @@ impl StateStoreImpl {
                     state_store_metrics.clone(),
                 )))
                 .memory(opts.block_cache_capacity_mb * MB)
+                .with_hash_builder(SstableBlockHashBuilder::default())
                 .with_shards(opts.block_cache_shard_num)
                 .with_eviction_config(opts.block_cache_eviction_config.clone())
                 .with_weighter(|_: &SstableBlockIndex, value: &Box<Block>| {
@@ -786,6 +788,10 @@ impl StateStoreImpl {
                         )
                         .with_recover_concurrency(opts.data_file_cache_recover_concurrency)
                         .with_blob_index_size(opts.data_file_cache_blob_index_size_kb * KB)
+                        .with_admission_filter(
+                            StorageFilter::new()
+                                .with_condition(LiveSstFilter::new(live_ssts.clone())),
+                        )
                         .with_eviction_pickers(vec![Box::new(FifoPicker::new(
                             opts.data_file_cache_fifo_probation_ratio,
                         ))]);
@@ -859,6 +865,7 @@ impl StateStoreImpl {
 
                     meta_cache,
                     block_cache,
+                    live_ssts,
                     vector_meta_cache,
                     vector_block_cache,
                 }));


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

This draft filters Hummock's Foyer data disk-cache admission using the live SST set from the local Hummock version.

- Encode `(sst_id, block_idx)` into an extractable cache hash under checked POC bounds.
- Keep live SST IDs in an `ArcSwap`-backed immutable snapshot shared with the disk-cache admission filter.
- Initialize the snapshot from the first pinned version and replace it from each fully resolved target version before cache refill starts.

Current POC limitations:

- Admission only; reinsertion policy, table pin policy, and active disk-cache purge are out of scope.
- The exact layout assumes `sst_id < 2^32` and `block_idx < 2^16`; out-of-range keys are rejected from the disk cache.
- The target version replaces the snapshot before version publication so newly added SSTs can be refilled.

## Checklist

- [ ] I have written necessary rustdoc comments.
- [x] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

</details>
