### PR TITLE
refactor(meta): support two-phase barrier command notifiers

### DIFF
--- a/src/meta/service/src/ddl_service.rs
+++ b/src/meta/service/src/ddl_service.rs
@@ -1910,7 +1910,7 @@ impl DdlService for DdlServiceImpl {
         {
             let OptionalAssociatedSourceId::AssociatedSourceId(source_id) =
                 table_catalog.optional_associated_source_id.unwrap();
-            let (jobs, fragment_nodes) = self
+            let fragment_nodes = self
                 .metadata_manager
                 .update_source_rate_limit_by_source_id(source_id, source_rate_limit)
                 .await?;
@@ -1924,7 +1924,7 @@ impl DdlService for DdlServiceImpl {
                 .collect();
             let _ = self
                 .barrier_scheduler
-                .run_command(database_id, Command::Throttle { jobs, config })
+                .run_command(database_id, Command::Throttle { config })
                 .await?;
         }
 

--- a/src/meta/service/src/stream_service.rs
+++ b/src/meta/service/src/stream_service.rs
@@ -194,12 +194,11 @@ impl StreamManagerService for StreamServiceImpl {
         let throttle_type = request.throttle_type();
 
         let raw_object_id: u32;
-        let jobs: HashSet<JobId>;
         let fragments: HashMap<FragmentId, _>;
 
         match (throttle_type, throttle_target) {
             (ThrottleType::Source, ThrottleTarget::Source | ThrottleTarget::Table) => {
-                (jobs, fragments) = self
+                fragments = self
                     .metadata_manager
                     .update_source_rate_limit_by_source_id(request.id.into(), request.rate)
                     .await?;
@@ -212,7 +211,6 @@ impl StreamManagerService for StreamServiceImpl {
                     .metadata_manager
                     .update_backfill_rate_limit_by_job_id(JobId::from(request.id), request.rate)
                     .await?;
-                jobs = [request.id.into()].into_iter().collect();
                 raw_object_id = request.id;
             }
             (ThrottleType::Dml, ThrottleTarget::Table) => {
@@ -220,7 +218,6 @@ impl StreamManagerService for StreamServiceImpl {
                     .metadata_manager
                     .update_dml_rate_limit_by_job_id(JobId::from(request.id), request.rate)
                     .await?;
-                jobs = [request.id.into()].into_iter().collect();
                 raw_object_id = request.id;
             }
             (ThrottleType::Sink, ThrottleTarget::Sink) => {
@@ -228,7 +225,6 @@ impl StreamManagerService for StreamServiceImpl {
                     .metadata_manager
                     .update_sink_rate_limit_by_sink_id(request.id.into(), request.rate)
                     .await?;
-                jobs = [request.id.into()].into_iter().collect();
                 raw_object_id = request.id;
             }
             // FIXME(kwannoel): specialize for throttle type x target
@@ -248,7 +244,6 @@ impl StreamManagerService for StreamServiceImpl {
                     .catalog_controller
                     .get_fragment_streaming_job_id(fragment_id)
                     .await?;
-                jobs = [job_id].into_iter().collect();
                 raw_object_id = job_id.as_raw_id();
             }
             _ => {
@@ -275,7 +270,7 @@ impl StreamManagerService for StreamServiceImpl {
             .collect();
         let _i = self
             .barrier_scheduler
-            .run_command(database_id, Command::Throttle { jobs, config })
+            .run_command(database_id, Command::Throttle { config })
             .await?;
 
         Ok(Response::new(ApplyThrottleResponse { status: None }))

--- a/src/meta/src/barrier/checkpoint/control.rs
+++ b/src/meta/src/barrier/checkpoint/control.rs
@@ -245,7 +245,7 @@ impl CheckpointControl {
             checkpoint,
         } = new_barrier;
 
-        if let Some((mut command, notifiers)) = command {
+        if let Some((mut command, notifier)) = command {
             if let &mut Command::CreateStreamingJob {
                 ref mut cross_db_snapshot_backfill_info,
                 ref info,
@@ -276,9 +276,7 @@ impl CheckpointControl {
                         let err: MetaError =
                             anyhow!("database of cross db upstream table {} not found", table_id)
                                 .into();
-                        for notifier in notifiers {
-                            notifier.notify_start_failed(err.clone());
-                        }
+                        notifier.notify_start_failed(err);
 
                         return Ok(());
                     }
@@ -297,9 +295,7 @@ impl CheckpointControl {
                                     "unexpected first job of type {job_type:?} with info {info:?}"
                                 );
                             } else {
-                                for notifier in notifiers {
-                                    notifier.notify_start_failed(anyhow!("unexpected job_type {job_type:?} for first job {} in database {database_id}", info.streaming_job.id()).into());
-                                }
+                                notifier.notify_start_failed(anyhow!("unexpected job_type {job_type:?} for first job {} in database {database_id}", info.streaming_job.id()).into());
                                 return Ok(());
                             }
                         };
@@ -321,10 +317,7 @@ impl CheckpointControl {
                     | Command::Resume
                     | Command::DropStreamingJobs { .. }
                     | Command::DropSubscription { .. } => {
-                        for mut notifier in notifiers {
-                            notifier.notify_started();
-                            notifier.notify_collected();
-                        }
+                        notifier.start().started();
                         warn!(?command, "skip command for empty database");
                         return Ok(());
                     }
@@ -348,9 +341,7 @@ impl CheckpointControl {
                             )
                         } else {
                             warn!(%database_id, ?command, "database not exist when handling command");
-                            for notifier in notifiers {
-                                notifier.notify_start_failed(anyhow!("database {database_id} not exist when handling command {command:?}").into());
-                            }
+                            notifier.notify_start_failed(anyhow!("database {database_id} not exist when handling command {command:?}").into());
                             return Ok(());
                         }
                     }
@@ -358,7 +349,7 @@ impl CheckpointControl {
             };
 
             database.handle_new_barrier(
-                Some((command, notifiers)),
+                Some((command, notifier)),
                 checkpoint,
                 span,
                 partial_graph_manager,
@@ -1003,7 +994,7 @@ impl DatabaseCheckpointControl {
                         {
                             let resps = resps.into_values().collect_vec();
                             if is_finish_epoch {
-                                assert!(info.notifiers.is_empty());
+                                assert!(info.notifier.is_none());
                                 finished_jobs.push((*job_id, epoch, resps));
                                 continue;
                             };
@@ -1199,7 +1190,7 @@ impl DatabaseCheckpointControl {
     /// Handle the new barrier from the scheduled queue and inject it.
     fn handle_new_barrier(
         &mut self,
-        command: Option<(Command, Vec<Notifier>)>,
+        command: Option<(Command, Notifier)>,
         checkpoint: bool,
         span: tracing::Span,
         partial_graph_manager: &mut PartialGraphManager,
@@ -1208,10 +1199,10 @@ impl DatabaseCheckpointControl {
     ) -> MetaResult<()> {
         let curr_epoch = self.state.in_flight_prev_epoch().next();
 
-        let (command, mut notifiers) = if let Some((command, notifiers)) = command {
-            (Some(command), notifiers)
+        let (mut command, notifier) = if let Some((command, notifier)) = command {
+            (Some(command), Some(notifier))
         } else {
-            (None, vec![])
+            (None, None)
         };
 
         debug_assert!(
@@ -1225,61 +1216,24 @@ impl DatabaseCheckpointControl {
             "reschedule intent should be resolved before injection"
         );
 
+        let mut notifier_start = notifier.map(Notifier::start);
         if let Some(Command::DropStreamingJobs {
             streaming_job_ids, ..
-        }) = &command
+        }) = &mut command
         {
-            if streaming_job_ids.len() > 1 {
-                for job_to_cancel in streaming_job_ids {
-                    if self
-                        .independent_checkpoint_job_controls
-                        .contains_key(job_to_cancel)
-                    {
-                        warn!(
-                            job_id = %job_to_cancel,
-                            "ignore multi-job cancel command on creating snapshot backfill streaming job"
-                        );
-                        for notifier in notifiers {
-                            notifier
-                                .notify_start_failed(anyhow!("cannot cancel creating snapshot backfill streaming job with other jobs, \
-                                the job will continue creating until created or recovery. Please cancel the snapshot backfilling job in a single DDL ").into());
-                        }
-                        return Ok(());
-                    }
+            streaming_job_ids.retain(|job_id| {
+                let Some(job) = self.independent_checkpoint_job_controls.get_mut(job_id) else {
+                    return true;
+                };
+                !job.drop(notifier_start.as_mut(), partial_graph_manager)
+            });
+            if streaming_job_ids.is_empty() {
+                if let Some(notifier) = notifier_start {
+                    notifier.started();
                 }
-            } else if let Some(job_to_drop) = streaming_job_ids.iter().next()
-                && let Some(job) = self
-                    .independent_checkpoint_job_controls
-                    .get_mut(job_to_drop)
-            {
-                let dropped = job.drop(&mut notifiers, partial_graph_manager);
-                if dropped {
-                    return Ok(());
-                }
+                return Ok(());
             }
         }
-
-        if let Some(Command::Throttle { jobs, .. }) = &command
-            && jobs.len() > 1
-            && let Some(independent_job_id) = jobs
-                .iter()
-                .find(|job| self.independent_checkpoint_job_controls.contains_key(*job))
-        {
-            warn!(
-                job_id = %independent_job_id,
-                "ignore multi-job throttle command on independent checkpoint job"
-            );
-            for notifier in notifiers {
-                notifier.notify_start_failed(
-                    anyhow!(
-                        "cannot alter rate limit for independent checkpoint job with other jobs, \
-                                the original rate limit will be kept during recovery."
-                    )
-                    .into(),
-                );
-            }
-            return Ok(());
-        };
 
         if let Some(Command::RescheduleIntent {
             reschedule_plan: Some(reschedule_plan),
@@ -1299,7 +1253,7 @@ impl DatabaseCheckpointControl {
                     blocked_reschedule_job_ids = ?blocked_reschedule_job_ids,
                     "reject reschedule fragments related to creating unreschedulable backfill jobs"
                 );
-                for notifier in notifiers {
+                if let Some(notifier) = notifier_start {
                     notifier.notify_start_failed(
                         anyhow!(
                             "cannot reschedule jobs {:?} when creating jobs with unreschedulable backfill fragments",
@@ -1322,9 +1276,8 @@ impl DatabaseCheckpointControl {
             // Drop the guard to remove the metric series of this database.
             self.last_committed_barrier_time = None;
             // skip the command when there is nothing to do with the barrier
-            for mut notifier in notifiers {
-                notifier.notify_started();
-                notifier.notify_collected();
+            if let Some(notifier) = notifier_start {
+                notifier.started();
             }
             return Ok(());
         };
@@ -1338,7 +1291,7 @@ impl DatabaseCheckpointControl {
             && self.state.is_paused()
         {
             warn!("cannot create streaming job with snapshot backfill when paused");
-            for notifier in notifiers {
+            if let Some(notifier) = notifier_start {
                 notifier.notify_start_failed(
                     anyhow!("cannot create streaming job with snapshot backfill when paused",)
                         .into(),
@@ -1357,18 +1310,18 @@ impl DatabaseCheckpointControl {
         let epoch = barrier_info.epoch();
         let ApplyCommandInfo { jobs_to_wait } = match self.apply_command(
             command,
-            &mut notifiers,
+            &mut notifier_start,
             barrier_info,
             partial_graph_manager,
             hummock_version_stats,
             worker_nodes,
         ) {
             Ok(info) => {
-                assert!(notifiers.is_empty());
+                assert!(notifier_start.is_none());
                 info
             }
             Err(err) => {
-                for notifier in notifiers {
+                if let Some(notifier) = notifier_start {
                     notifier.notify_start_failed(err.clone());
                 }
                 fail_point!("inject_barrier_err_success");

--- a/src/meta/src/barrier/checkpoint/independent_job/batch_refresh_job/mod.rs
+++ b/src/meta/src/barrier/checkpoint/independent_job/batch_refresh_job/mod.rs
@@ -45,11 +45,11 @@ use tracing::{debug, info};
 
 use crate::MetaResult;
 use crate::barrier::backfill_order_control::get_nodes_with_backfill_dependencies;
-use crate::barrier::command::PostCollectCommand;
+use crate::barrier::command::{PostCollectCommand, ThrottleConfigMap, extract_throttle_config};
 use crate::barrier::context::CreateSnapshotBackfillJobCommandInfo;
 use crate::barrier::edge_builder::{EdgeBuilderFragmentInfo, FragmentEdgeBuilder};
 use crate::barrier::info::BarrierInfo;
-use crate::barrier::notifier::Notifier;
+use crate::barrier::notifier::{CollectionNotifier, NotifierStart};
 use crate::barrier::partial_graph::{
     CollectedBarrier, PartialGraphBarrierInfo, PartialGraphManager, PartialGraphStat,
 };
@@ -177,7 +177,7 @@ enum BatchRefreshJobStatus {
         target_upstream_epoch: u64,
     },
     /// The partial graph is being reset (for drop).
-    Resetting { notifiers: Vec<Notifier> },
+    Resetting { notifiers: Vec<CollectionNotifier> },
 }
 
 // ── Complete type ─────────────────────────────────────────────────────────────
@@ -474,7 +474,7 @@ impl BatchRefreshJobCheckpointControl {
         database_id: DatabaseId,
         job_id: JobId,
         create_info: CreateSnapshotBackfillJobCommandInfo,
-        notifiers: Vec<Notifier>,
+        notifier: Option<&mut NotifierStart>,
         snapshot_backfill_upstream_tables: HashSet<TableId>,
         snapshot_epoch: u64,
         version_stat: &HummockVersionStats,
@@ -545,7 +545,7 @@ impl BatchRefreshJobCheckpointControl {
             initial_barrier_info,
             Some(render_result.actors_to_create),
             Some(initial_partial_graph_mutation),
-            notifiers,
+            notifier,
             Some(create_info),
             false,
         ) {
@@ -691,7 +691,7 @@ impl BatchRefreshJobCheckpointControl {
         barrier_info: BarrierInfo,
         new_actors: Option<StreamJobActorsToCreate>,
         mutation: Option<Mutation>,
-        notifiers: Vec<Notifier>,
+        notifier: Option<&mut NotifierStart>,
         first_create_info: Option<CreateSnapshotBackfillJobCommandInfo>,
         is_stop: bool,
     ) -> MetaResult<()> {
@@ -719,7 +719,7 @@ impl BatchRefreshJobCheckpointControl {
                     CreateSnapshotBackfillJobCommandInfo::into_post_collect,
                 ),
                 barrier_info,
-                notifiers,
+                notifier.map(NotifierStart::add_notify),
                 state_table_ids.clone(),
             ),
         )?;
@@ -734,18 +734,17 @@ impl BatchRefreshJobCheckpointControl {
         &mut self,
         partial_graph_manager: &mut PartialGraphManager,
         barrier_info: &BarrierInfo,
-        mutation: Option<(Mutation, Vec<Notifier>)>,
+        mutation: Option<(Mutation, Option<&mut NotifierStart>)>,
     ) -> MetaResult<()> {
         if !matches!(self.status, BatchRefreshJobStatus::ConsumingSnapshot { .. }) {
             // ConsumingLogStore has all barriers pre-injected; no forwarding needed.
             // Idle and Resetting have no partial graph.
             return Ok(());
         }
-        let (mut mutation, mut notifiers) = match mutation {
-            Some((mutation, notifiers)) => (Some(mutation), notifiers),
-            None => (None, vec![]),
+        let (mutation, notifier) = match mutation {
+            Some((mutation, notifier)) => (Some(mutation), notifier),
+            None => (None, None),
         };
-
         // Check if snapshot consumption is finished and we need to inject stop barriers.
         let is_finished = matches!(
             &self.status,
@@ -754,9 +753,6 @@ impl BatchRefreshJobCheckpointControl {
         );
 
         if is_finished {
-            // Discard the upstream mutation — not needed for stop barriers.
-            mutation.take();
-
             // Take the status out to destructure and transition to `FinishingSnapshot`.
             // Use a placeholder; will be overwritten below.
             let old_status = replace(
@@ -810,7 +806,7 @@ impl BatchRefreshJobCheckpointControl {
                 final_checkpoint,
                 None,
                 None,
-                take(&mut notifiers),
+                notifier,
                 None,
                 false,
             )?;
@@ -825,7 +821,7 @@ impl BatchRefreshJobCheckpointControl {
                     actors: stop_actors,
                     dropped_sink_fragments: vec![],
                 })),
-                vec![],
+                None,
                 None,
                 true,
             )?;
@@ -849,7 +845,7 @@ impl BatchRefreshJobCheckpointControl {
             };
 
             // Forward a fake barrier to the partial graph.
-            let mutation = mutation.take().or_else(|| {
+            let mutation = mutation.or_else(|| {
                 let pending_backfill_nodes = create_mview_tracker
                     .take_pending_backfill_nodes()
                     .collect_vec();
@@ -882,13 +878,11 @@ impl BatchRefreshJobCheckpointControl {
                 barrier_to_inject,
                 None,
                 mutation,
-                take(&mut notifiers),
+                notifier,
                 None,
                 false,
             )?;
         }
-        assert!(mutation.is_none(), "must have consumed mutation");
-        assert!(notifiers.is_empty(), "must consumed notifiers");
         Ok(())
     }
 
@@ -1140,6 +1134,32 @@ impl BatchRefreshJobCheckpointControl {
         }
     }
 
+    pub(crate) fn pre_apply_throttle(
+        &mut self,
+        config: &mut ThrottleConfigMap,
+    ) -> Option<Mutation> {
+        let BatchRefreshJobStatus::ConsumingSnapshot {
+            fragment_infos,
+            create_mview_tracker,
+            ..
+        } = &mut self.status
+        else {
+            return None;
+        };
+        if create_mview_tracker.is_finished() {
+            return None;
+        }
+
+        extract_throttle_config(config, |fragment_id, stream_node| {
+            if let Some(fragment_info) = fragment_infos.get_mut(&fragment_id) {
+                fragment_info.nodes = stream_node.clone();
+                true
+            } else {
+                false
+            }
+        })
+    }
+
     /// Whether this idle job should start a refresh run.
     ///
     /// Returns `true` if the job is idle and the upstream committed epoch is
@@ -1361,7 +1381,7 @@ impl BatchRefreshJobCheckpointControl {
                 barrier,
                 None,
                 mutation,
-                vec![],
+                None,
                 None,
                 is_stop_barrier,
             )?;
@@ -1468,7 +1488,7 @@ impl BatchRefreshJobCheckpointControl {
     /// Drop this batch refresh job.
     pub(super) fn drop(
         &mut self,
-        notifiers: &mut Vec<Notifier>,
+        notifier: Option<&mut NotifierStart>,
         partial_graph_manager: &mut PartialGraphManager,
     ) -> bool {
         match &mut self.status {
@@ -1476,34 +1496,31 @@ impl BatchRefreshJobCheckpointControl {
                 notifiers: existing_notifiers,
                 ..
             } => {
-                for notifier in &mut *notifiers {
-                    notifier.notify_started();
-                }
-                existing_notifiers.append(notifiers);
+                existing_notifiers.extend(notifier.map(NotifierStart::add_notify));
                 true
             }
             BatchRefreshJobStatus::ConsumingSnapshot { .. }
             | BatchRefreshJobStatus::FinishingSnapshot { .. }
             | BatchRefreshJobStatus::InitializingBatchRefresh { .. }
             | BatchRefreshJobStatus::ConsumingLogStore { .. } => {
-                for notifier in &mut *notifiers {
-                    notifier.notify_started();
-                }
                 partial_graph_manager.reset_partial_graphs([self.partial_graph_id]);
                 self.status = BatchRefreshJobStatus::Resetting {
-                    notifiers: take(notifiers),
+                    notifiers: notifier
+                        .map(NotifierStart::add_notify)
+                        .into_iter()
+                        .collect(),
                 };
                 true
             }
             BatchRefreshJobStatus::Idle { .. } => {
                 // Idle has no running partial graph, but we still go through
                 // the reset flow so the cleanup path is uniform.
-                for notifier in &mut *notifiers {
-                    notifier.notify_started();
-                }
                 partial_graph_manager.reset_partial_graphs([self.partial_graph_id]);
                 self.status = BatchRefreshJobStatus::Resetting {
-                    notifiers: take(notifiers),
+                    notifiers: notifier
+                        .map(NotifierStart::add_notify)
+                        .into_iter()
+                        .collect(),
                 };
                 true
             }

--- a/src/meta/src/barrier/checkpoint/independent_job/batch_refresh_job/mod.rs
+++ b/src/meta/src/barrier/checkpoint/independent_job/batch_refresh_job/mod.rs
@@ -49,7 +49,7 @@ use crate::barrier::command::{PostCollectCommand, ThrottleConfigMap, extract_thr
 use crate::barrier::context::CreateSnapshotBackfillJobCommandInfo;
 use crate::barrier::edge_builder::{EdgeBuilderFragmentInfo, FragmentEdgeBuilder};
 use crate::barrier::info::BarrierInfo;
-use crate::barrier::notifier::{CollectionNotifier, NotifierStart};
+use crate::barrier::notifier::{CollectionNotifier, NotifierStarter};
 use crate::barrier::partial_graph::{
     CollectedBarrier, PartialGraphBarrierInfo, PartialGraphManager, PartialGraphStat,
 };
@@ -474,7 +474,7 @@ impl BatchRefreshJobCheckpointControl {
         database_id: DatabaseId,
         job_id: JobId,
         create_info: CreateSnapshotBackfillJobCommandInfo,
-        notifier: Option<&mut NotifierStart>,
+        notifier: Option<&mut NotifierStarter>,
         snapshot_backfill_upstream_tables: HashSet<TableId>,
         snapshot_epoch: u64,
         version_stat: &HummockVersionStats,
@@ -691,7 +691,7 @@ impl BatchRefreshJobCheckpointControl {
         barrier_info: BarrierInfo,
         new_actors: Option<StreamJobActorsToCreate>,
         mutation: Option<Mutation>,
-        notifier: Option<&mut NotifierStart>,
+        notifier: Option<&mut NotifierStarter>,
         first_create_info: Option<CreateSnapshotBackfillJobCommandInfo>,
         is_stop: bool,
     ) -> MetaResult<()> {
@@ -719,7 +719,7 @@ impl BatchRefreshJobCheckpointControl {
                     CreateSnapshotBackfillJobCommandInfo::into_post_collect,
                 ),
                 barrier_info,
-                notifier.map(NotifierStart::add_notify),
+                notifier,
                 state_table_ids.clone(),
             ),
         )?;
@@ -734,7 +734,7 @@ impl BatchRefreshJobCheckpointControl {
         &mut self,
         partial_graph_manager: &mut PartialGraphManager,
         barrier_info: &BarrierInfo,
-        mutation: Option<(Mutation, Option<&mut NotifierStart>)>,
+        mutation: Option<(Mutation, Option<&mut NotifierStarter>)>,
     ) -> MetaResult<()> {
         if !matches!(self.status, BatchRefreshJobStatus::ConsumingSnapshot { .. }) {
             // ConsumingLogStore has all barriers pre-injected; no forwarding needed.
@@ -1488,7 +1488,7 @@ impl BatchRefreshJobCheckpointControl {
     /// Drop this batch refresh job.
     pub(super) fn drop(
         &mut self,
-        notifier: Option<&mut NotifierStart>,
+        notifier: Option<&mut NotifierStarter>,
         partial_graph_manager: &mut PartialGraphManager,
     ) -> bool {
         match &mut self.status {
@@ -1496,7 +1496,7 @@ impl BatchRefreshJobCheckpointControl {
                 notifiers: existing_notifiers,
                 ..
             } => {
-                existing_notifiers.extend(notifier.map(NotifierStart::add_notify));
+                existing_notifiers.extend(notifier.map(NotifierStarter::add_notify));
                 true
             }
             BatchRefreshJobStatus::ConsumingSnapshot { .. }
@@ -1506,7 +1506,7 @@ impl BatchRefreshJobCheckpointControl {
                 partial_graph_manager.reset_partial_graphs([self.partial_graph_id]);
                 self.status = BatchRefreshJobStatus::Resetting {
                     notifiers: notifier
-                        .map(NotifierStart::add_notify)
+                        .map(NotifierStarter::add_notify)
                         .into_iter()
                         .collect(),
                 };
@@ -1518,7 +1518,7 @@ impl BatchRefreshJobCheckpointControl {
                 partial_graph_manager.reset_partial_graphs([self.partial_graph_id]);
                 self.status = BatchRefreshJobStatus::Resetting {
                     notifiers: notifier
-                        .map(NotifierStart::add_notify)
+                        .map(NotifierStarter::add_notify)
                         .into_iter()
                         .collect(),
                 };

--- a/src/meta/src/barrier/checkpoint/independent_job/creating_job/mod.rs
+++ b/src/meta/src/barrier/checkpoint/independent_job/creating_job/mod.rs
@@ -913,8 +913,6 @@ impl CreatingStreamingJobControl {
                 None,
             )?;
         }
-        assert!(mutation.is_none(), "must have consumed mutation");
-        assert!(notifier.is_none(), "must consume notifier");
         Ok(())
     }
 

--- a/src/meta/src/barrier/checkpoint/independent_job/creating_job/mod.rs
+++ b/src/meta/src/barrier/checkpoint/independent_job/creating_job/mod.rs
@@ -31,7 +31,7 @@ use risingwave_pb::hummock::HummockVersionStats;
 use risingwave_pb::id::{ActorId, FragmentId, PartialGraphId};
 use risingwave_pb::stream_plan::barrier::PbBarrierKind;
 use risingwave_pb::stream_plan::barrier_mutation::Mutation;
-use risingwave_pb::stream_plan::{AddMutation, PbStreamNode, StopMutation};
+use risingwave_pb::stream_plan::{AddMutation, StopMutation};
 use risingwave_pb::stream_service::BarrierCompleteResponse;
 use status::CreatingStreamingJobStatus;
 use tracing::{debug, info};
@@ -42,11 +42,13 @@ use crate::MetaResult;
 use crate::barrier::backfill_order_control::get_nodes_with_backfill_dependencies;
 use crate::barrier::checkpoint::independent_job::creating_job::barrier_control::CreatingStreamingJobBarrierStats;
 use crate::barrier::checkpoint::independent_job::creating_job::status::CreateMviewLogStoreProgressTracker;
-use crate::barrier::command::{PostCollectCommand, TableLogEpochs, UpstreamTableLogEpochs};
+use crate::barrier::command::{
+    PostCollectCommand, TableLogEpochs, ThrottleConfigMap, UpstreamTableLogEpochs,
+};
 use crate::barrier::context::CreateSnapshotBackfillJobCommandInfo;
 use crate::barrier::edge_builder::FragmentEdgeBuildResult;
 use crate::barrier::info::{BarrierInfo, InflightStreamingJobInfo};
-use crate::barrier::notifier::Notifier;
+use crate::barrier::notifier::NotifierStart;
 use crate::barrier::partial_graph::{
     CollectedBarrier, PartialGraphBarrierInfo, PartialGraphManager, PartialGraphRecoverer,
 };
@@ -100,7 +102,7 @@ impl CreatingStreamingJobControl {
     pub(crate) fn new<'a>(
         entry: hash_map::VacantEntry<'a, JobId, IndependentCheckpointJobControl>,
         create_info: CreateSnapshotBackfillJobCommandInfo,
-        notifiers: Vec<Notifier>,
+        notifier: Option<&mut NotifierStart>,
         snapshot_backfill_upstream_tables: HashSet<TableId>,
         snapshot_epoch: u64,
         since_timestamp_upstream_log_epochs: Option<(&TableLogEpochs, PartialGraphId, u64)>,
@@ -258,7 +260,7 @@ impl CreatingStreamingJobControl {
             initial_barrier_info,
             Some(actors_to_create),
             Some(initial_mutation),
-            notifiers,
+            notifier,
             Some(create_info),
         ) {
             graph_adder.failed();
@@ -807,7 +809,7 @@ impl CreatingStreamingJobControl {
         barrier_info: BarrierInfo,
         new_actors: Option<StreamJobActorsToCreate>,
         mutation: Option<Mutation>,
-        notifiers: Vec<Notifier>,
+        notifier: Option<&mut NotifierStart>,
         first_create_info: Option<CreateSnapshotBackfillJobCommandInfo>,
     ) -> MetaResult<()> {
         let (table_ids_to_sync, nodes_to_sync_table) = if !is_finishing {
@@ -828,7 +830,7 @@ impl CreatingStreamingJobControl {
                     CreateSnapshotBackfillJobCommandInfo::into_post_collect,
                 ),
                 barrier_info,
-                notifiers,
+                notifier.map(NotifierStart::add_notify),
                 state_table_ids.clone(),
             ),
         )?;
@@ -863,7 +865,7 @@ impl CreatingStreamingJobControl {
                     .collect(),
                 dropped_sink_fragments: vec![], // not related to sink-into-table
             })),
-            vec![], // no notifiers when start consuming upstream
+            None, // no notifier when start consuming upstream
             None,
         )?;
         Ok(info)
@@ -873,7 +875,7 @@ impl CreatingStreamingJobControl {
         &mut self,
         partial_graph_manager: &mut PartialGraphManager,
         barrier_info: &BarrierInfo,
-        mutation: Option<(Mutation, Vec<Notifier>)>,
+        mutation: Option<(Mutation, Option<&mut NotifierStart>)>,
     ) -> MetaResult<()> {
         let progress_epoch = if let Some(max_committed_epoch) = self.max_committed_epoch {
             max(max_committed_epoch, self.snapshot_epoch)
@@ -887,42 +889,40 @@ impl CreatingStreamingJobControl {
                 .0
                 .saturating_sub(progress_epoch) as _,
         );
-        let (mut mutation, mut notifiers) = match mutation {
-            Some((mutation, notifiers)) => (Some(mutation), notifiers),
-            None => (None, vec![]),
+        let (mut mutation, mut notifier) = match mutation {
+            Some((mutation, notifier)) => (Some(mutation), notifier),
+            None => (None, None),
         };
-        {
-            for (barrier_to_inject, mutation) in self.status.on_new_upstream_epoch(
-                partial_graph_manager,
+        for (barrier_to_inject, mutation) in self.status.on_new_upstream_epoch(
+            partial_graph_manager,
+            self.partial_graph_id,
+            self.max_pending_barrier_num,
+            barrier_info,
+            mutation.take(),
+        ) {
+            Self::inject_barrier(
                 self.partial_graph_id,
-                self.max_pending_barrier_num,
-                barrier_info,
-                mutation.take(),
-            ) {
-                Self::inject_barrier(
-                    self.partial_graph_id,
-                    partial_graph_manager,
-                    &self.node_actors,
-                    &self.state_table_ids,
-                    false,
-                    barrier_to_inject,
-                    None,
-                    mutation,
-                    take(&mut notifiers),
-                    None,
-                )?;
-            }
-            assert!(mutation.is_none(), "must have consumed mutation");
-            assert!(notifiers.is_empty(), "must consumed notifiers");
+                partial_graph_manager,
+                &self.node_actors,
+                &self.state_table_ids,
+                false,
+                barrier_to_inject,
+                None,
+                mutation,
+                notifier.take(),
+                None,
+            )?;
         }
+        assert!(mutation.is_none(), "must have consumed mutation");
+        assert!(notifier.is_none(), "must consume notifier");
         Ok(())
     }
 
-    pub(crate) fn pre_apply_throttle<'a>(
+    pub(crate) fn pre_apply_throttle(
         &mut self,
-        fragment_nodes: impl IntoIterator<Item = (FragmentId, &'a PbStreamNode)>,
-    ) {
-        self.status.pre_apply_throttle(fragment_nodes);
+        config: &mut ThrottleConfigMap,
+    ) -> Option<Mutation> {
+        self.status.pre_apply_throttle(config)
     }
 
     /// Returns whether the next barrier should be forced to a checkpoint.
@@ -1105,24 +1105,23 @@ impl CreatingStreamingJobControl {
     /// to mean that the job has been dropped.
     pub(super) fn drop(
         &mut self,
-        notifiers: &mut Vec<Notifier>,
+        notifier: Option<&mut NotifierStart>,
         partial_graph_manager: &mut PartialGraphManager,
     ) -> bool {
         match &mut self.status {
             CreatingStreamingJobStatus::Resetting(existing_notifiers) => {
-                for notifier in &mut *notifiers {
-                    notifier.notify_started();
-                }
-                existing_notifiers.append(notifiers);
+                existing_notifiers.extend(notifier.map(NotifierStart::add_notify));
                 true
             }
             CreatingStreamingJobStatus::ConsumingSnapshot { .. }
             | CreatingStreamingJobStatus::ConsumingLogStore { .. } => {
-                for notifier in &mut *notifiers {
-                    notifier.notify_started();
-                }
                 partial_graph_manager.reset_partial_graphs([self.partial_graph_id]);
-                self.status = CreatingStreamingJobStatus::Resetting(take(notifiers));
+                self.status = CreatingStreamingJobStatus::Resetting(
+                    notifier
+                        .map(NotifierStart::add_notify)
+                        .into_iter()
+                        .collect(),
+                );
                 true
             }
             CreatingStreamingJobStatus::Finishing(_, _) => false,

--- a/src/meta/src/barrier/checkpoint/independent_job/creating_job/mod.rs
+++ b/src/meta/src/barrier/checkpoint/independent_job/creating_job/mod.rs
@@ -48,7 +48,7 @@ use crate::barrier::command::{
 use crate::barrier::context::CreateSnapshotBackfillJobCommandInfo;
 use crate::barrier::edge_builder::FragmentEdgeBuildResult;
 use crate::barrier::info::{BarrierInfo, InflightStreamingJobInfo};
-use crate::barrier::notifier::NotifierStart;
+use crate::barrier::notifier::NotifierStarter;
 use crate::barrier::partial_graph::{
     CollectedBarrier, PartialGraphBarrierInfo, PartialGraphManager, PartialGraphRecoverer,
 };
@@ -102,7 +102,7 @@ impl CreatingStreamingJobControl {
     pub(crate) fn new<'a>(
         entry: hash_map::VacantEntry<'a, JobId, IndependentCheckpointJobControl>,
         create_info: CreateSnapshotBackfillJobCommandInfo,
-        notifier: Option<&mut NotifierStart>,
+        notifier: Option<&mut NotifierStarter>,
         snapshot_backfill_upstream_tables: HashSet<TableId>,
         snapshot_epoch: u64,
         since_timestamp_upstream_log_epochs: Option<(&TableLogEpochs, PartialGraphId, u64)>,
@@ -809,7 +809,7 @@ impl CreatingStreamingJobControl {
         barrier_info: BarrierInfo,
         new_actors: Option<StreamJobActorsToCreate>,
         mutation: Option<Mutation>,
-        notifier: Option<&mut NotifierStart>,
+        notifier: Option<&mut NotifierStarter>,
         first_create_info: Option<CreateSnapshotBackfillJobCommandInfo>,
     ) -> MetaResult<()> {
         let (table_ids_to_sync, nodes_to_sync_table) = if !is_finishing {
@@ -830,7 +830,7 @@ impl CreatingStreamingJobControl {
                     CreateSnapshotBackfillJobCommandInfo::into_post_collect,
                 ),
                 barrier_info,
-                notifier.map(NotifierStart::add_notify),
+                notifier,
                 state_table_ids.clone(),
             ),
         )?;
@@ -875,7 +875,7 @@ impl CreatingStreamingJobControl {
         &mut self,
         partial_graph_manager: &mut PartialGraphManager,
         barrier_info: &BarrierInfo,
-        mutation: Option<(Mutation, Option<&mut NotifierStart>)>,
+        mutation: Option<(Mutation, Option<&mut NotifierStarter>)>,
     ) -> MetaResult<()> {
         let progress_epoch = if let Some(max_committed_epoch) = self.max_committed_epoch {
             max(max_committed_epoch, self.snapshot_epoch)
@@ -1105,12 +1105,12 @@ impl CreatingStreamingJobControl {
     /// to mean that the job has been dropped.
     pub(super) fn drop(
         &mut self,
-        notifier: Option<&mut NotifierStart>,
+        notifier: Option<&mut NotifierStarter>,
         partial_graph_manager: &mut PartialGraphManager,
     ) -> bool {
         match &mut self.status {
             CreatingStreamingJobStatus::Resetting(existing_notifiers) => {
-                existing_notifiers.extend(notifier.map(NotifierStart::add_notify));
+                existing_notifiers.extend(notifier.map(NotifierStarter::add_notify));
                 true
             }
             CreatingStreamingJobStatus::ConsumingSnapshot { .. }
@@ -1118,7 +1118,7 @@ impl CreatingStreamingJobControl {
                 partial_graph_manager.reset_partial_graphs([self.partial_graph_id]);
                 self.status = CreatingStreamingJobStatus::Resetting(
                     notifier
-                        .map(NotifierStart::add_notify)
+                        .map(NotifierStarter::add_notify)
                         .into_iter()
                         .collect(),
                 );

--- a/src/meta/src/barrier/checkpoint/independent_job/creating_job/status.rs
+++ b/src/meta/src/barrier/checkpoint/independent_job/creating_job/status.rs
@@ -347,12 +347,10 @@ impl CreatingStreamingJobStatus {
         &mut self,
         config: &mut ThrottleConfigMap,
     ) -> Option<Mutation> {
-        let (fragment_infos, inject_mutation) = match self {
-            CreatingStreamingJobStatus::ConsumingSnapshot { info, .. } => {
-                (&mut info.fragment_infos, true)
-            }
-            CreatingStreamingJobStatus::ConsumingLogStore { info, .. } => {
-                (&mut info.fragment_infos, false)
+        let fragment_infos = match self {
+            CreatingStreamingJobStatus::ConsumingSnapshot { info, .. }
+            | CreatingStreamingJobStatus::ConsumingLogStore { info, .. } => {
+                &mut info.fragment_infos
             }
             CreatingStreamingJobStatus::Finishing(..)
             | CreatingStreamingJobStatus::Resetting(..) => return None,
@@ -361,15 +359,14 @@ impl CreatingStreamingJobStatus {
             }
         };
 
-        let mutation = extract_throttle_config(config, |fragment_id, stream_node| {
+        extract_throttle_config(config, |fragment_id, stream_node| {
             if let Some(fragment_info) = fragment_infos.get_mut(&fragment_id) {
                 fragment_info.nodes = stream_node.clone();
                 true
             } else {
                 false
             }
-        });
-        if inject_mutation { mutation } else { None }
+        })
     }
 }
 

--- a/src/meta/src/barrier/checkpoint/independent_job/creating_job/status.rs
+++ b/src/meta/src/barrier/checkpoint/independent_job/creating_job/status.rs
@@ -22,16 +22,17 @@ use risingwave_common::hash::ActorId;
 use risingwave_common::util::epoch::Epoch;
 use risingwave_pb::hummock::HummockVersionStats;
 use risingwave_pb::id::{FragmentId, PartialGraphId};
+use risingwave_pb::stream_plan::StartFragmentBackfillMutation;
 use risingwave_pb::stream_plan::barrier::PbBarrierKind;
 use risingwave_pb::stream_plan::barrier_mutation::Mutation;
-use risingwave_pb::stream_plan::{PbStreamNode, StartFragmentBackfillMutation};
 use risingwave_pb::stream_service::barrier_complete_response::{
     CreateMviewProgress, PbCreateMviewProgress,
 };
 use tracing::warn;
 
 use crate::barrier::checkpoint::independent_job::creating_job::CreatingJobInfo;
-use crate::barrier::notifier::Notifier;
+use crate::barrier::command::{ThrottleConfigMap, extract_throttle_config};
+use crate::barrier::notifier::CollectionNotifier;
 use crate::barrier::partial_graph::PartialGraphManager;
 use crate::barrier::progress::{CreateMviewProgressTracker, TrackingJob};
 use crate::barrier::{BarrierInfo, BarrierKind, TracedEpoch};
@@ -131,7 +132,7 @@ pub(super) enum CreatingStreamingJobStatus {
     /// will be finished when all previously injected barriers have been collected
     /// Store the `prev_epoch` that will finish at.
     Finishing(u64, TrackingJob),
-    Resetting(Vec<Notifier>),
+    Resetting(Vec<CollectionNotifier>),
     PlaceHolder,
 }
 
@@ -342,27 +343,33 @@ impl CreatingStreamingJobStatus {
         }
     }
 
-    pub(super) fn pre_apply_throttle<'a>(
+    pub(super) fn pre_apply_throttle(
         &mut self,
-        fragment_nodes: impl IntoIterator<Item = (FragmentId, &'a PbStreamNode)>,
-    ) {
-        let fragment_infos = match self {
-            CreatingStreamingJobStatus::ConsumingSnapshot { info, .. }
-            | CreatingStreamingJobStatus::ConsumingLogStore { info, .. } => {
-                &mut info.fragment_infos
+        config: &mut ThrottleConfigMap,
+    ) -> Option<Mutation> {
+        let (fragment_infos, inject_mutation) = match self {
+            CreatingStreamingJobStatus::ConsumingSnapshot { info, .. } => {
+                (&mut info.fragment_infos, true)
+            }
+            CreatingStreamingJobStatus::ConsumingLogStore { info, .. } => {
+                (&mut info.fragment_infos, false)
             }
             CreatingStreamingJobStatus::Finishing(..)
-            | CreatingStreamingJobStatus::Resetting(..) => return,
+            | CreatingStreamingJobStatus::Resetting(..) => return None,
             CreatingStreamingJobStatus::PlaceHolder => {
                 unreachable!()
             }
         };
 
-        for (fragment_id, stream_node) in fragment_nodes {
+        let mutation = extract_throttle_config(config, |fragment_id, stream_node| {
             if let Some(fragment_info) = fragment_infos.get_mut(&fragment_id) {
                 fragment_info.nodes = stream_node.clone();
+                true
+            } else {
+                false
             }
-        }
+        });
+        if inject_mutation { mutation } else { None }
     }
 }
 

--- a/src/meta/src/barrier/checkpoint/independent_job/creating_job/status.rs
+++ b/src/meta/src/barrier/checkpoint/independent_job/creating_job/status.rs
@@ -301,14 +301,19 @@ impl CreatingStreamingJobStatus {
             }
             CreatingStreamingJobStatus::ConsumingLogStore {
                 pending_barriers, ..
-            } => drain_pending_barriers(
-                pending_barriers,
-                barrier_info.clone(),
-                resolve_initial_barrier_num_to_inject(),
-            )
-            .into_iter()
-            .map(|barrier_info| (barrier_info, None))
-            .collect(),
+            } => {
+                // Throttle has no effect on the snapshot executor after it starts consuming the
+                // log store. The updated fragment plan is kept for the actors created on merge,
+                // so the mutation does not need to be forwarded in this phase.
+                drain_pending_barriers(
+                    pending_barriers,
+                    barrier_info.clone(),
+                    resolve_initial_barrier_num_to_inject(),
+                )
+                .into_iter()
+                .map(|barrier_info| (barrier_info, None))
+                .collect()
+            }
             CreatingStreamingJobStatus::Finishing { .. }
             | CreatingStreamingJobStatus::Resetting(..) => vec![],
             CreatingStreamingJobStatus::PlaceHolder => {
@@ -382,6 +387,8 @@ fn drain_pending_barriers(
 
 #[cfg(test)]
 mod tests {
+    use risingwave_pb::stream_plan::PbStreamNode;
+
     use super::*;
 
     fn barrier(prev_epoch: u64, curr_epoch: u64) -> BarrierInfo {
@@ -454,5 +461,66 @@ mod tests {
         );
 
         assert!(injected.is_empty());
+    }
+
+    #[test]
+    fn test_pre_apply_throttle_before_merge() {
+        let job_id = risingwave_common::id::JobId::new(1);
+        let fragment_id = FragmentId::new(1);
+        let old_node = PbStreamNode {
+            identity: "old".to_owned(),
+            ..Default::default()
+        };
+        let new_node = PbStreamNode {
+            identity: "new".to_owned(),
+            ..Default::default()
+        };
+        let fragment_infos = HashMap::from([(
+            fragment_id,
+            InflightFragmentInfo {
+                fragment_id,
+                distribution_type: risingwave_meta_model::fragment::DistributionType::Single,
+                fragment_type_mask: Default::default(),
+                vnode_count: 1,
+                nodes: old_node,
+                actors: Default::default(),
+                state_table_ids: Default::default(),
+            },
+        )]);
+        let mut status = CreatingStreamingJobStatus::ConsumingLogStore {
+            tracking_job: TrackingJob::recovered(job_id, &fragment_infos),
+            info: CreatingJobInfo {
+                fragment_infos,
+                upstream_fragment_downstreams: Default::default(),
+                downstreams: Default::default(),
+                snapshot_backfill_upstream_tables: Default::default(),
+                stream_actors: Default::default(),
+            },
+            log_store_progress_tracker: CreateMviewLogStoreProgressTracker::new(
+                std::iter::empty(),
+                0,
+            ),
+            pending_barriers: Default::default(),
+        };
+        let mut config = HashMap::from([(
+            fragment_id,
+            (
+                risingwave_pb::stream_plan::throttle_mutation::ThrottleConfig {
+                    rate_limit: Some(1_000),
+                    throttle_type: Default::default(),
+                },
+                new_node.clone(),
+            ),
+        )]);
+
+        assert!(status.pre_apply_throttle(&mut config).is_some());
+        assert!(config.is_empty());
+
+        let info = status.start_consume_upstream(&BarrierInfo {
+            prev_epoch: TracedEpoch::new(Epoch(1)),
+            curr_epoch: TracedEpoch::new(Epoch(2)),
+            kind: BarrierKind::Checkpoint(vec![1]),
+        });
+        assert_eq!(info.fragment_infos[&fragment_id].nodes, new_node);
     }
 }

--- a/src/meta/src/barrier/checkpoint/independent_job/mod.rs
+++ b/src/meta/src/barrier/checkpoint/independent_job/mod.rs
@@ -30,7 +30,7 @@ pub(crate) use batch_refresh_job::{
 pub(crate) use creating_job::CreatingStreamingJobControl;
 
 use crate::barrier::info::BarrierInfo;
-use crate::barrier::notifier::Notifier;
+use crate::barrier::notifier::NotifierStart;
 use crate::barrier::partial_graph::{CollectedBarrier, PartialGraphManager};
 use crate::barrier::{BackfillProgress, BarrierKind, FragmentBackfillProgress, TracedEpoch};
 use crate::controller::fragment::InflightFragmentInfo;
@@ -134,12 +134,12 @@ impl IndependentCheckpointJobControl {
 
     pub(crate) fn drop(
         &mut self,
-        notifiers: &mut Vec<Notifier>,
+        notifier: Option<&mut NotifierStart>,
         partial_graph_manager: &mut PartialGraphManager,
     ) -> bool {
         match self {
-            Self::CreatingStreamingJob(j) => j.drop(notifiers, partial_graph_manager),
-            Self::BatchRefresh(j) => j.drop(notifiers, partial_graph_manager),
+            Self::CreatingStreamingJob(j) => j.drop(notifier, partial_graph_manager),
+            Self::BatchRefresh(j) => j.drop(notifier, partial_graph_manager),
         }
     }
 

--- a/src/meta/src/barrier/checkpoint/independent_job/mod.rs
+++ b/src/meta/src/barrier/checkpoint/independent_job/mod.rs
@@ -30,7 +30,7 @@ pub(crate) use batch_refresh_job::{
 pub(crate) use creating_job::CreatingStreamingJobControl;
 
 use crate::barrier::info::BarrierInfo;
-use crate::barrier::notifier::NotifierStart;
+use crate::barrier::notifier::NotifierStarter;
 use crate::barrier::partial_graph::{CollectedBarrier, PartialGraphManager};
 use crate::barrier::{BackfillProgress, BarrierKind, FragmentBackfillProgress, TracedEpoch};
 use crate::controller::fragment::InflightFragmentInfo;
@@ -134,7 +134,7 @@ impl IndependentCheckpointJobControl {
 
     pub(crate) fn drop(
         &mut self,
-        notifier: Option<&mut NotifierStart>,
+        notifier: Option<&mut NotifierStarter>,
         partial_graph_manager: &mut PartialGraphManager,
     ) -> bool {
         match self {

--- a/src/meta/src/barrier/checkpoint/state.rs
+++ b/src/meta/src/barrier/checkpoint/state.rs
@@ -30,11 +30,10 @@ use risingwave_pb::common::WorkerNode;
 use risingwave_pb::hummock::HummockVersionStats;
 use risingwave_pb::source::{ConnectorSplit, ConnectorSplits};
 use risingwave_pb::stream_plan::barrier_mutation::{Mutation, PbMutation};
-use risingwave_pb::stream_plan::throttle_mutation::ThrottleConfig;
 use risingwave_pb::stream_plan::update_mutation::PbDispatcherUpdate;
 use risingwave_pb::stream_plan::{
-    AddMutation, PbStartFragmentBackfillMutation, PbStreamNode, PbSubscriptionUpstreamInfo,
-    PbUpdateMutation, PbUpstreamSinkInfo, ThrottleMutation,
+    AddMutation, PbStartFragmentBackfillMutation, PbSubscriptionUpstreamInfo, PbUpdateMutation,
+    PbUpstreamSinkInfo,
 };
 use tracing::warn;
 
@@ -43,14 +42,16 @@ use crate::barrier::checkpoint::{
     BatchRefreshJobCheckpointControl, BatchRefreshLogicalFragments, CreatingStreamingJobControl,
     DatabaseCheckpointControl, IndependentCheckpointJobControl,
 };
-use crate::barrier::command::{CreateStreamingJobCommandInfo, PostCollectCommand, ReschedulePlan};
+use crate::barrier::command::{
+    CreateStreamingJobCommandInfo, PostCollectCommand, ReschedulePlan, ThrottleConfigMap,
+};
 use crate::barrier::context::CreateSnapshotBackfillJobCommandInfo;
 use crate::barrier::edge_builder::{EdgeBuilderFragmentInfo, FragmentEdgeBuilder};
 use crate::barrier::info::{
     BarrierInfo, CreateStreamingJobStatus, InflightDatabaseInfo, InflightStreamingJobInfo,
     SubscriberType,
 };
-use crate::barrier::notifier::Notifier;
+use crate::barrier::notifier::NotifierStart;
 use crate::barrier::partial_graph::{PartialGraphBarrierInfo, PartialGraphManager};
 use crate::barrier::rpc::to_partial_graph_id;
 use crate::barrier::{BarrierKind, Command, CreateStreamingJobType, TracedEpoch};
@@ -69,11 +70,6 @@ use crate::stream::{
     fill_snapshot_backfill_epoch,
 };
 use crate::{MetaError, MetaResult};
-
-type ThrottleForCreatingJobs = (
-    HashSet<JobId>,
-    HashMap<FragmentId, (ThrottleConfig, PbStreamNode)>,
-);
 
 /// The latest state of `GlobalBarrierWorker` after injecting the latest barrier.
 pub(in crate::barrier) struct BarrierWorkerState {
@@ -412,7 +408,7 @@ impl DatabaseCheckpointControl {
     pub(super) fn apply_command(
         &mut self,
         command: Option<Command>,
-        notifiers: &mut Vec<Notifier>,
+        notifier: &mut Option<NotifierStart>,
         barrier_info: BarrierInfo,
         partial_graph_manager: &mut PartialGraphManager,
         hummock_version_stats: &HummockVersionStats,
@@ -477,10 +473,8 @@ impl DatabaseCheckpointControl {
             Ok(resolved)
         }
 
-        // Throttle data for creating jobs (set only in the Throttle arm). Creating jobs live
-        // outside `database_info`, so they need both the compute mutation and the stream-node
-        // pre-apply.
-        let mut throttle_for_creating_jobs: Option<ThrottleForCreatingJobs> = None;
+        let mut notify_database_graph = command.is_some();
+        let mut throttle_config: Option<ThrottleConfigMap> = None;
 
         // Each variant handles its own pre-apply, edge building, mutation generation,
         // collect base info, and post-apply. The match produces values consumed by the
@@ -502,6 +496,7 @@ impl DatabaseCheckpointControl {
                     },
                 cross_db_snapshot_backfill_info,
             }) => {
+                notify_database_graph = false;
                 let ensembles = resolve_no_shuffle_ensembles(
                     &info.stream_job_fragments,
                     &info.upstream_fragment_downstreams,
@@ -597,7 +592,7 @@ impl DatabaseCheckpointControl {
                             resolved_split_assignment: resolved_split_assignment.clone(),
                             refresh_interval_sec: None,
                         },
-                        take(notifiers),
+                        notifier.as_mut(),
                         snapshot_backfill_upstream_tables,
                         snapshot_epoch,
                         since_timestamp_upstream_log_epochs,
@@ -657,6 +652,7 @@ impl DatabaseCheckpointControl {
                 job_type: CreateStreamingJobType::BatchRefresh(mut batch_refresh_info),
                 cross_db_snapshot_backfill_info,
             }) => {
+                notify_database_graph = false;
                 {
                     if self.state.is_paused() {
                         bail!("cannot create batch refresh job while database barrier is paused");
@@ -770,7 +766,7 @@ impl DatabaseCheckpointControl {
                             resolved_split_assignment: Default::default(),
                             refresh_interval_sec: Some(refresh_interval_sec),
                         },
-                        take(notifiers),
+                        notifier.as_mut(),
                         snapshot_backfill_upstream_tables,
                         snapshot_epoch,
                         hummock_version_stats,
@@ -1007,13 +1003,10 @@ impl DatabaseCheckpointControl {
                 )
             }
 
-            Some(Command::Throttle { jobs, config }) => {
-                let mutation = Some(Command::throttle_to_mutation(&config));
-                for (fragment_id, (_, stream_node)) in &config {
-                    self.database_info
-                        .pre_apply_throttle(*fragment_id, stream_node);
-                }
-                throttle_for_creating_jobs = Some((jobs, config));
+            Some(Command::Throttle { mut config }) => {
+                let mutation = self.database_info.pre_apply_throttle(&mut config);
+                notify_database_graph = mutation.is_some();
+                throttle_config = Some(config);
                 self.apply_simple_command(mutation, "Throttle")
             }
 
@@ -1727,50 +1720,40 @@ impl DatabaseCheckpointControl {
         for (job_id, job) in &mut self.independent_checkpoint_job_controls {
             match job {
                 IndependentCheckpointJobControl::CreatingStreamingJob(creating_job) => {
-                    if !finished_snapshot_backfill_jobs.contains(job_id) {
-                        let throttle_mutation = if let Some((ref jobs, ref config)) =
-                            throttle_for_creating_jobs
-                            && jobs.contains(job_id)
-                        {
-                            assert_eq!(
-                                jobs.len(),
-                                1,
-                                "should not alter rate limit of snapshot backfill job with other jobs"
-                            );
-                            creating_job.pre_apply_throttle(config.iter().map(
-                                |(fragment_id, (_, stream_node))| (*fragment_id, stream_node),
-                            ));
-                            Some((
-                                Mutation::Throttle(ThrottleMutation {
-                                    fragment_throttle: config
-                                        .iter()
-                                        .map(|(fragment_id, (throttle_config, _))| {
-                                            (*fragment_id, *throttle_config)
-                                        })
-                                        .collect(),
-                                }),
-                                take(notifiers),
-                            ))
-                        } else {
-                            None
-                        };
-                        creating_job.on_new_upstream_barrier(
-                            partial_graph_manager,
-                            &barrier_info,
-                            throttle_mutation,
-                        )?;
+                    if finished_snapshot_backfill_jobs.contains(job_id) {
+                        continue;
                     }
+                    let throttle_mutation = throttle_config.as_mut().and_then(|config| {
+                        creating_job
+                            .pre_apply_throttle(config)
+                            .map(|mutation| (mutation, notifier.as_mut()))
+                    });
+                    creating_job.on_new_upstream_barrier(
+                        partial_graph_manager,
+                        &barrier_info,
+                        throttle_mutation,
+                    )?;
                 }
                 IndependentCheckpointJobControl::BatchRefresh(batch_refresh_job) => {
+                    let throttle_mutation = throttle_config.as_mut().and_then(|config| {
+                        batch_refresh_job
+                            .pre_apply_throttle(config)
+                            .map(|mutation| (mutation, notifier.as_mut()))
+                    });
                     batch_refresh_job.on_new_upstream_barrier(
                         partial_graph_manager,
                         &barrier_info,
-                        None, // no throttle mutation for batch refresh jobs
+                        throttle_mutation,
                     )?;
                 }
             }
         }
 
+        let database_notifier = if notify_database_graph {
+            notifier.as_mut().map(NotifierStart::add_notify)
+        } else {
+            None
+        };
         partial_graph_manager.inject_barrier(
             to_partial_graph_id(self.database_id, None),
             mutation,
@@ -1781,10 +1764,16 @@ impl DatabaseCheckpointControl {
             PartialGraphBarrierInfo::new(
                 post_collect_command,
                 barrier_info,
-                take(notifiers),
+                database_notifier,
                 table_ids_to_commit,
             ),
         )?;
+
+        // Publish the collection receivers only after all parts of a scheduled command have been
+        // dispatched successfully. Periodic barriers do not have a notifier.
+        if let Some(notifier) = notifier.take() {
+            notifier.started();
+        }
 
         Ok(ApplyCommandInfo {
             jobs_to_wait: finished_snapshot_backfill_jobs,

--- a/src/meta/src/barrier/checkpoint/state.rs
+++ b/src/meta/src/barrier/checkpoint/state.rs
@@ -1490,6 +1490,16 @@ impl DatabaseCheckpointControl {
                             job
                             && creating_job.should_merge_to_upstream(partial_graph_manager)
                         {
+                            // The independent actors will stop on this barrier. Apply throttle to
+                            // the in-memory plan used to create the database-graph actors, and let
+                            // the database barrier own the collection notification.
+                            if throttle_config
+                                .as_mut()
+                                .and_then(|config| creating_job.pre_apply_throttle(config))
+                                .is_some()
+                            {
+                                notify_database_graph = true;
+                            }
                             let info = creating_job
                                 .start_consume_upstream(partial_graph_manager, &barrier_info)?;
                             finished_snapshot_backfill_job_info

--- a/src/meta/src/barrier/checkpoint/state.rs
+++ b/src/meta/src/barrier/checkpoint/state.rs
@@ -51,7 +51,7 @@ use crate::barrier::info::{
     BarrierInfo, CreateStreamingJobStatus, InflightDatabaseInfo, InflightStreamingJobInfo,
     SubscriberType,
 };
-use crate::barrier::notifier::NotifierStart;
+use crate::barrier::notifier::NotifierStarter;
 use crate::barrier::partial_graph::{PartialGraphBarrierInfo, PartialGraphManager};
 use crate::barrier::rpc::to_partial_graph_id;
 use crate::barrier::{BarrierKind, Command, CreateStreamingJobType, TracedEpoch};
@@ -408,7 +408,7 @@ impl DatabaseCheckpointControl {
     pub(super) fn apply_command(
         &mut self,
         command: Option<Command>,
-        notifier: &mut Option<NotifierStart>,
+        notifier: &mut Option<NotifierStarter>,
         barrier_info: BarrierInfo,
         partial_graph_manager: &mut PartialGraphManager,
         hummock_version_stats: &HummockVersionStats,
@@ -1750,7 +1750,7 @@ impl DatabaseCheckpointControl {
         }
 
         let database_notifier = if notify_database_graph {
-            notifier.as_mut().map(NotifierStart::add_notify)
+            notifier.as_mut()
         } else {
             None
         };

--- a/src/meta/src/barrier/command.rs
+++ b/src/meta/src/barrier/command.rs
@@ -78,6 +78,20 @@ use crate::stream::{
 };
 use crate::{MetaError, MetaResult};
 
+pub(crate) type ThrottleConfigMap = HashMap<FragmentId, (ThrottleConfig, PbStreamNode)>;
+
+pub(crate) fn extract_throttle_config(
+    config: &mut ThrottleConfigMap,
+    mut apply: impl FnMut(FragmentId, &PbStreamNode) -> bool,
+) -> Option<Mutation> {
+    let fragment_throttle = config
+        .extract_if(|fragment_id, (_, stream_node)| apply(*fragment_id, stream_node))
+        .map(|(fragment_id, (throttle_config, _))| (fragment_id, throttle_config))
+        .collect::<HashMap<_, _>>();
+    (!fragment_throttle.is_empty())
+        .then_some(Mutation::Throttle(ThrottleMutation { fragment_throttle }))
+}
+
 /// [`Reschedule`] describes per-fragment changes in a resolved reschedule plan,
 /// used for actor scaling or migration.
 #[derive(Debug, Clone)]
@@ -519,8 +533,7 @@ pub enum Command {
     /// `Throttle` command generates a `Throttle` barrier with the given throttle config to change
     /// the `rate_limit` of executors. `throttle_type` specifies which executor kinds should apply it.
     Throttle {
-        jobs: HashSet<JobId>,
-        config: HashMap<FragmentId, (ThrottleConfig, PbStreamNode)>,
+        config: ThrottleConfigMap,
     },
 
     /// `CreateSubscription` command generates a `CreateSubscriptionMutation` to notify
@@ -989,22 +1002,6 @@ impl Command {
 
                 Mutation::Splits(SourceChangeSplitMutation {
                     actor_splits: build_actor_connector_splits(&diff),
-                })
-            }
-        }
-    }
-
-    /// Build the `Throttle` mutation.
-    pub(super) fn throttle_to_mutation(
-        config: &HashMap<FragmentId, (ThrottleConfig, PbStreamNode)>,
-    ) -> Mutation {
-        {
-            {
-                Mutation::Throttle(ThrottleMutation {
-                    fragment_throttle: config
-                        .iter()
-                        .map(|(fragment_id, (throttle_config, _))| (*fragment_id, *throttle_config))
-                        .collect(),
                 })
             }
         }

--- a/src/meta/src/barrier/complete_task.rs
+++ b/src/meta/src/barrier/complete_task.rs
@@ -163,7 +163,7 @@ impl CompleteBarrierTask {
                 let (database_id, job_id) = from_partial_graph_id(partial_graph_id);
                 let command_name = info.post_collect_command.command_name().to_owned();
                 let elapsed_secs = info.elapsed_secs();
-                notifiers.extend(info.notifiers);
+                notifiers.extend(info.notifier);
                 context
                     .post_collect_command(info.post_collect_command)
                     .await?;

--- a/src/meta/src/barrier/info.rs
+++ b/src/meta/src/barrier/info.rs
@@ -34,14 +34,16 @@ use risingwave_pb::id::SubscriberId;
 use risingwave_pb::meta::PbFragmentWorkerSlotMapping;
 use risingwave_pb::meta::subscribe_response::Operation;
 use risingwave_pb::source::PbCdcTableSnapshotSplits;
+use risingwave_pb::stream_plan::PbUpstreamSinkInfo;
+use risingwave_pb::stream_plan::barrier_mutation::Mutation;
 use risingwave_pb::stream_plan::stream_node::NodeBody;
-use risingwave_pb::stream_plan::{PbStreamNode, PbUpstreamSinkInfo};
 use risingwave_pb::stream_service::BarrierCompleteResponse;
 use tracing::{info, warn};
 
 use crate::barrier::cdc_progress::{CdcProgress, CdcTableBackfillTracker};
 use crate::barrier::command::{
-    CreateStreamingJobCommandInfo, PostCollectCommand, ReplaceStreamJobPlan,
+    CreateStreamingJobCommandInfo, PostCollectCommand, ReplaceStreamJobPlan, ThrottleConfigMap,
+    extract_throttle_config,
 };
 use crate::barrier::edge_builder::{
     EdgeBuilderFragmentInfo, FragmentEdgeBuildResult, FragmentEdgeBuilder,
@@ -1153,15 +1155,15 @@ impl InflightDatabaseInfo {
     /// Sync inflight `nodes` so a later reschedule won't materialize new actors from stale data.
     pub(crate) fn pre_apply_throttle(
         &mut self,
-        fragment_id: FragmentId,
-        stream_node: &PbStreamNode,
-    ) {
-        // Snapshot-backfill creating jobs live outside main inflight; their throttles
-        // flow through `on_new_upstream_barrier`.
-        if !self.fragment_location.contains_key(&fragment_id) {
-            return;
-        }
-        self.fragment_mut(fragment_id).0.nodes = stream_node.clone();
+        config: &mut ThrottleConfigMap,
+    ) -> Option<Mutation> {
+        extract_throttle_config(config, |fragment_id, stream_node| {
+            if !self.fragment_location.contains_key(&fragment_id) {
+                return false;
+            }
+            self.fragment_mut(fragment_id).0.nodes = stream_node.clone();
+            true
+        })
     }
 
     /// Update split assignments for actors in fragments.

--- a/src/meta/src/barrier/mod.rs
+++ b/src/meta/src/barrier/mod.rs
@@ -87,11 +87,11 @@ enum BarrierManagerStatus {
     Running,
 }
 
-/// Scheduled command with its notifiers.
+/// Scheduled command with its notifier.
 struct Scheduled {
     database_id: DatabaseId,
     command: Command,
-    notifiers: Vec<Notifier>,
+    notifier: Notifier,
     span: tracing::Span,
 }
 

--- a/src/meta/src/barrier/notifier.rs
+++ b/src/meta/src/barrier/notifier.rs
@@ -12,45 +12,193 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use anyhow::anyhow;
+use futures::future::join_all;
 use tokio::sync::oneshot;
 
 use crate::{MetaError, MetaResult};
 
-/// Used for notifying the status of a scheduled command/barrier.
-#[derive(Debug, Default)]
-pub(crate) struct Notifier {
-    /// Get notified when scheduled barrier has started to be handled.
-    pub started: Option<oneshot::Sender<MetaResult<()>>>,
+pub(crate) type CollectionReceiver = oneshot::Receiver<MetaResult<()>>;
+pub(crate) type StartReceiver = oneshot::Receiver<MetaResult<Vec<CollectionReceiver>>>;
 
-    /// Get notified when scheduled barrier is collected or failed.
-    pub collected: Option<oneshot::Sender<MetaResult<()>>>,
+pub(crate) async fn wait_collection(receivers: Vec<CollectionReceiver>) -> MetaResult<()> {
+    let mut first_error = None;
+    for result in join_all(receivers).await {
+        let result = match result {
+            Ok(result) => result,
+            Err(_) => Err(anyhow!("failed to collect barrier: notifier dropped").into()),
+        };
+        if let Err(err) = result
+            && first_error.is_none()
+        {
+            first_error = Some(err);
+        }
+    }
+    match first_error {
+        Some(err) => Err(err),
+        None => Ok(()),
+    }
+}
+
+/// Used for notifying the status of a scheduled command/barrier.
+#[derive(Debug)]
+pub(crate) struct Notifier {
+    started: oneshot::Sender<MetaResult<Vec<CollectionReceiver>>>,
 }
 
 impl Notifier {
-    /// Notify when we have injected a barrier to compute nodes.
-    pub fn notify_started(&mut self) {
-        if let Some(tx) = self.started.take() {
-            tx.send(Ok(())).ok();
+    pub fn new() -> (Self, StartReceiver) {
+        let (started, receiver) = oneshot::channel();
+        (Self { started }, receiver)
+    }
+
+    pub fn start(self) -> NotifierStart {
+        NotifierStart {
+            started: self.started,
+            pending_collection: vec![],
         }
     }
 
     pub fn notify_start_failed(self, err: MetaError) {
-        if let Some(tx) = self.started {
-            tx.send(Err(err)).ok();
-        }
+        self.started.send(Err(err)).ok();
+    }
+}
+
+/// Builds the set of collection notifications before publishing that the command has started.
+#[derive(Debug)]
+pub(crate) struct NotifierStart {
+    started: oneshot::Sender<MetaResult<Vec<CollectionReceiver>>>,
+    pending_collection: Vec<CollectionReceiver>,
+}
+
+impl NotifierStart {
+    pub fn add_notify(&mut self) -> CollectionNotifier {
+        let (collected, receiver) = oneshot::channel();
+        self.pending_collection.push(receiver);
+        CollectionNotifier { collected }
     }
 
-    /// Notify when we have collected a barrier from all actors.
+    pub fn started(self) {
+        self.started.send(Ok(self.pending_collection)).ok();
+    }
+
+    pub fn notify_start_failed(self, err: MetaError) {
+        self.started.send(Err(err)).ok();
+    }
+}
+
+/// Notifies the completion of one part of a started command.
+#[derive(Debug)]
+pub(crate) struct CollectionNotifier {
+    collected: oneshot::Sender<MetaResult<()>>,
+}
+
+impl CollectionNotifier {
     pub fn notify_collected(self) {
-        if let Some(tx) = self.collected {
-            tx.send(Ok(())).ok();
-        }
+        self.collected.send(Ok(())).ok();
     }
 
     /// Notify when we failed to collect a barrier. This function consumes `self`.
     pub fn notify_collection_failed(self, err: MetaError) {
-        if let Some(tx) = self.collected {
-            tx.send(Err(err)).ok();
-        }
+        self.collected.send(Err(err)).ok();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use tokio::time::{Duration, timeout};
+
+    use super::*;
+
+    #[tokio::test]
+    async fn test_zero_collection_notifier() {
+        let (notifier, started_rx) = Notifier::new();
+        notifier.start().started();
+
+        let receivers = started_rx.await.unwrap().unwrap();
+        assert!(receivers.is_empty());
+        wait_collection(receivers).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_one_collection_notifier() {
+        let (notifier, started_rx) = Notifier::new();
+        let mut start = notifier.start();
+        let collection = start.add_notify();
+        start.started();
+
+        collection.notify_collected();
+        let receivers = started_rx.await.unwrap().unwrap();
+        wait_collection(receivers).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_wait_all_collection_notifiers() {
+        let (notifier, started_rx) = Notifier::new();
+        let mut start = notifier.start();
+        let first = start.add_notify();
+        let second = start.add_notify();
+        start.started();
+
+        let receivers = started_rx.await.unwrap().unwrap();
+        let mut wait = Box::pin(wait_collection(receivers));
+        first.notify_collected();
+        assert!(timeout(Duration::from_millis(10), &mut wait).await.is_err());
+        second.notify_collected();
+        wait.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_waits_for_all_collection_notifiers_after_failure() {
+        let (notifier, started_rx) = Notifier::new();
+        let mut start = notifier.start();
+        let first = start.add_notify();
+        let second = start.add_notify();
+        start.started();
+
+        let receivers = started_rx.await.unwrap().unwrap();
+        let mut wait = Box::pin(wait_collection(receivers));
+        first.notify_collection_failed(anyhow!("first part failed").into());
+        assert!(timeout(Duration::from_millis(10), &mut wait).await.is_err());
+        second.notify_collection_failed(anyhow!("second part failed").into());
+        let err = wait.await.unwrap_err();
+        assert!(err.to_string().contains("first part failed"));
+    }
+
+    #[tokio::test]
+    async fn test_dropped_collection_notifier_fails() {
+        let (notifier, started_rx) = Notifier::new();
+        let mut start = notifier.start();
+        let dropped = start.add_notify();
+        start.started();
+        drop(dropped);
+
+        let receivers = started_rx.await.unwrap().unwrap();
+        assert!(wait_collection(receivers).await.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_start_failure() {
+        let (notifier, started_rx) = Notifier::new();
+        notifier.notify_start_failed(anyhow!("start failed").into());
+        assert!(started_rx.await.unwrap().is_err());
+    }
+
+    #[tokio::test]
+    async fn test_start_failure_after_entering_start_phase() {
+        let (notifier, started_rx) = Notifier::new();
+        let mut start = notifier.start();
+        let collection = start.add_notify();
+        start.notify_start_failed(anyhow!("start failed").into());
+
+        assert!(started_rx.await.unwrap().is_err());
+        collection.notify_collected();
+    }
+
+    #[tokio::test]
+    async fn test_dropped_notifier_cancels_start() {
+        let (notifier, started_rx) = Notifier::new();
+        drop(notifier);
+        assert!(started_rx.await.is_err());
     }
 }

--- a/src/meta/src/barrier/notifier.rs
+++ b/src/meta/src/barrier/notifier.rs
@@ -52,8 +52,8 @@ impl Notifier {
         (Self { started }, receiver)
     }
 
-    pub fn start(self) -> NotifierStart {
-        NotifierStart {
+    pub fn start(self) -> NotifierStarter {
+        NotifierStarter {
             started: self.started,
             pending_collection: vec![],
         }
@@ -66,12 +66,12 @@ impl Notifier {
 
 /// Builds the set of collection notifications before publishing that the command has started.
 #[derive(Debug)]
-pub(crate) struct NotifierStart {
+pub(crate) struct NotifierStarter {
     started: oneshot::Sender<MetaResult<Vec<CollectionReceiver>>>,
     pending_collection: Vec<CollectionReceiver>,
 }
 
-impl NotifierStart {
+impl NotifierStarter {
     pub fn add_notify(&mut self) -> CollectionNotifier {
         let (collected, receiver) = oneshot::channel();
         self.pending_collection.push(receiver);

--- a/src/meta/src/barrier/partial_graph.rs
+++ b/src/meta/src/barrier/partial_graph.rs
@@ -37,7 +37,7 @@ use crate::barrier::BarrierKind;
 use crate::barrier::command::PostCollectCommand;
 use crate::barrier::context::GlobalBarrierWorkerContext;
 use crate::barrier::info::BarrierInfo;
-use crate::barrier::notifier::Notifier;
+use crate::barrier::notifier::CollectionNotifier;
 use crate::barrier::rpc::{ControlStreamManager, WorkerNodeEvent};
 use crate::barrier::utils::{BarrierItemCollector, NodeToCollect, is_valid_after_worker_err};
 use crate::manager::MetaSrvEnv;
@@ -49,7 +49,7 @@ pub(super) struct PartialGraphBarrierInfo {
     enqueue_time: Instant,
     pub(super) post_collect_command: PostCollectCommand,
     pub(super) barrier_info: BarrierInfo,
-    pub(super) notifiers: Vec<Notifier>,
+    pub(super) notifier: Option<CollectionNotifier>,
     pub(super) table_ids_to_commit: HashSet<TableId>,
 }
 
@@ -57,14 +57,14 @@ impl PartialGraphBarrierInfo {
     pub(super) fn new(
         post_collect_command: PostCollectCommand,
         barrier_info: BarrierInfo,
-        notifiers: Vec<Notifier>,
+        notifier: Option<CollectionNotifier>,
         table_ids_to_commit: HashSet<TableId>,
     ) -> Self {
         Self {
             enqueue_time: Instant::now(),
             post_collect_command,
             barrier_info,
-            notifiers,
+            notifier,
             table_ids_to_commit,
         }
     }
@@ -108,13 +108,12 @@ impl PartialGraphRunningState {
             + usize::from(self.completing_epoch.is_some())
     }
 
-    fn enqueue(&mut self, node_to_collect: NodeToCollect, mut info: PartialGraphBarrierInfo) {
+    fn enqueue(&mut self, node_to_collect: NodeToCollect, info: PartialGraphBarrierInfo) {
         let epoch = info.barrier_info.epoch();
         assert_ne!(info.barrier_info.kind, BarrierKind::Initial);
         if info.post_collect_command.should_checkpoint() {
             assert!(info.barrier_info.kind.is_checkpoint());
         }
-        info.notifiers.iter_mut().for_each(|n| n.notify_started());
         self.barrier_item_collector
             .enqueue(epoch, node_to_collect, info);
         self.stat.observe_barrier_num(
@@ -371,7 +370,7 @@ impl PartialGraphManager {
         for (_, graph) in self.graphs.drain() {
             if let PartialGraphStatus::Running(graph) = graph {
                 for info in graph.barrier_item_collector.into_infos() {
-                    for notifier in info.notifiers {
+                    if let Some(notifier) = info.notifier {
                         notifier.notify_collection_failed(err.clone());
                     }
                 }
@@ -582,9 +581,9 @@ impl PartialGraphManager {
             if info.post_collect_command.should_checkpoint() {
                 assert!(info.barrier_info.kind.is_checkpoint());
             } else if !info.barrier_info.kind.is_checkpoint() {
-                info.notifiers
-                    .into_iter()
-                    .for_each(Notifier::notify_collected);
+                if let Some(notifier) = info.notifier {
+                    notifier.notify_collected();
+                }
                 on_non_checkpoint_epoch(epoch, resps, info.post_collect_command);
                 continue;
             }
@@ -897,7 +896,7 @@ mod tests {
                 curr_epoch: TracedEpoch::new(Epoch(curr_epoch)),
                 kind: BarrierKind::Barrier,
             },
-            vec![],
+            None,
             HashSet::new(),
         )
     }

--- a/src/meta/src/barrier/partial_graph.rs
+++ b/src/meta/src/barrier/partial_graph.rs
@@ -37,7 +37,7 @@ use crate::barrier::BarrierKind;
 use crate::barrier::command::PostCollectCommand;
 use crate::barrier::context::GlobalBarrierWorkerContext;
 use crate::barrier::info::BarrierInfo;
-use crate::barrier::notifier::CollectionNotifier;
+use crate::barrier::notifier::{CollectionNotifier, NotifierStarter};
 use crate::barrier::rpc::{ControlStreamManager, WorkerNodeEvent};
 use crate::barrier::utils::{BarrierItemCollector, NodeToCollect, is_valid_after_worker_err};
 use crate::manager::MetaSrvEnv;
@@ -57,14 +57,14 @@ impl PartialGraphBarrierInfo {
     pub(super) fn new(
         post_collect_command: PostCollectCommand,
         barrier_info: BarrierInfo,
-        notifier: Option<CollectionNotifier>,
+        notifier: Option<&mut NotifierStarter>,
         table_ids_to_commit: HashSet<TableId>,
     ) -> Self {
         Self {
             enqueue_time: Instant::now(),
             post_collect_command,
             barrier_info,
-            notifier,
+            notifier: notifier.map(NotifierStarter::add_notify),
             table_ids_to_commit,
         }
     }

--- a/src/meta/src/barrier/schedule.rs
+++ b/src/meta/src/barrier/schedule.rs
@@ -27,13 +27,13 @@ use risingwave_hummock_sdk::HummockVersionId;
 use risingwave_pb::catalog::Database;
 use rw_futures_util::pending_on_none;
 use tokio::select;
-use tokio::sync::{oneshot, watch};
+use tokio::sync::watch;
 use tokio::time::{Duration, Instant};
 use tokio_stream::wrappers::IntervalStream;
 use tokio_stream::{StreamExt, StreamMap};
 use tracing::{info, warn};
 
-use super::notifier::Notifier;
+use super::notifier::{Notifier, wait_collection};
 use super::{Command, Scheduled};
 use crate::barrier::context::GlobalBarrierWorkerContext;
 use crate::hummock::HummockManagerRef;
@@ -42,15 +42,12 @@ use crate::{MetaError, MetaResult};
 
 pub(super) struct NewBarrier {
     pub database_id: DatabaseId,
-    pub command: Option<(Command, Vec<Notifier>)>,
+    pub command: Option<(Command, Notifier)>,
     pub span: tracing::Span,
     pub checkpoint: bool,
 }
 
 /// A queue for scheduling barriers.
-///
-/// We manually implement one here instead of using channels since we may need to update the front
-/// of the queue to add some notifiers for instant flushes.
 struct Inner {
     queue: Mutex<ScheduledQueue>,
 
@@ -74,7 +71,7 @@ impl QueueStatus {
 
 struct ScheduledQueueItem {
     command: Command,
-    notifiers: Vec<Notifier>,
+    notifier: Notifier,
     span: tracing::Span,
 }
 
@@ -188,7 +185,7 @@ impl BarrierScheduler {
         for (command, notifier) in scheduleds {
             queue.queue.push_back(ScheduledQueueItem {
                 command,
-                notifiers: vec![notifier],
+                notifier,
                 span: tracing_span(),
             });
             if queue.queue.len() == 1 {
@@ -237,37 +234,30 @@ impl BarrierScheduler {
         let mut scheduleds = Vec::with_capacity(commands.len());
 
         for command in commands {
-            let (started_tx, started_rx) = oneshot::channel();
-            let (collect_tx, collect_rx) = oneshot::channel();
-
-            contexts.push((started_rx, collect_rx));
-            scheduleds.push((
-                command,
-                Notifier {
-                    started: Some(started_tx),
-                    collected: Some(collect_tx),
-                },
-            ));
+            let (notifier, started_rx) = Notifier::new();
+            contexts.push(started_rx);
+            scheduleds.push((command, notifier));
         }
 
         self.push(database_id, scheduleds)?;
 
-        for (injected_rx, collect_rx) in contexts {
+        for injected_rx in contexts {
             // Wait for this command to be injected, and record the result.
             tracing::trace!("waiting for injected_rx");
-            injected_rx
+            let collect_rxs = injected_rx
                 .instrument_await("wait_injected")
                 .await
                 .ok()
                 .context("failed to inject barrier")??;
 
-            tracing::trace!("waiting for collect_rx");
-            // Throw the error if it occurs when collecting this barrier.
-            collect_rx
+            tracing::trace!(
+                collection_count = collect_rxs.len(),
+                "waiting for collect_rx"
+            );
+            // Wait for every part before returning the first collection error.
+            wait_collection(collect_rxs)
                 .instrument_await("wait_collected")
-                .await
-                .ok()
-                .context("failed to collect barrier")??;
+                .await?;
         }
 
         Ok(())
@@ -286,7 +276,8 @@ impl BarrierScheduler {
     /// Schedule a command without waiting for it to be executed.
     pub fn run_command_no_wait(&self, database_id: DatabaseId, command: Command) -> MetaResult<()> {
         tracing::trace!("run_command_no_wait: {:?}", command);
-        self.push(database_id, vec![(command, Notifier::default())])
+        let (notifier, _started_rx) = Notifier::new();
+        self.push(database_id, vec![(command, notifier)])
     }
 
     /// Flush means waiting for the next barrier to collect.
@@ -507,7 +498,7 @@ impl PeriodicBarriers {
                     let checkpoint = scheduled.command.need_checkpoint() || self.try_get_checkpoint(database_id);
                     NewBarrier {
                         database_id: scheduled.database_id,
-                        command: Some((scheduled.command, scheduled.notifiers)),
+                        command: Some((scheduled.command, scheduled.notifier)),
                         span: scheduled.span,
                         checkpoint,
                     }
@@ -567,7 +558,7 @@ impl ScheduledBarriers {
                         break 'outer Scheduled {
                             database_id: *database_id,
                             command: item.command,
-                            notifiers: item.notifiers,
+                            notifier: item.notifier,
                             span: item.span,
                         };
                     }
@@ -618,10 +609,8 @@ impl ScheduledBarriers {
             let reason = database_blocked_reason(database_id, reason);
             let err: MetaError = anyhow!("{}", reason).into();
             queue.mark_blocked(reason);
-            while let Some(ScheduledQueueItem { notifiers, .. }) = queue.queue.pop_front() {
-                notifiers
-                    .into_iter()
-                    .for_each(|notify| notify.notify_collection_failed(err.clone()))
+            while let Some(ScheduledQueueItem { notifier, .. }) = queue.queue.pop_front() {
+                notifier.notify_start_failed(err.clone());
             }
         }
         if let Some(database_id) = database_id {
@@ -736,7 +725,7 @@ impl ScheduledBarriers {
 
         let mut pre_apply_drop_cancel = |queue: &mut DatabaseScheduledQueue| {
             while let Some(ScheduledQueueItem {
-                notifiers, command, ..
+                notifier, command, ..
             }) = queue.queue.pop_front()
             {
                 match command {
@@ -755,13 +744,8 @@ impl ScheduledBarriers {
                         unreachable!("only drop and cancel streaming jobs should be buffered");
                     }
                 }
-                // `run_command` waits for both the started and collected notifications. These
-                // buffered commands are pre-applied during recovery without injecting a real
-                // barrier, so complete both waiters here.
-                notifiers.into_iter().for_each(|mut notify| {
-                    notify.notify_started();
-                    notify.notify_collected();
-                });
+                // These buffered commands are pre-applied without injecting a real barrier.
+                notifier.start().started();
             }
         };
 
@@ -1032,10 +1016,11 @@ mod tests {
         periodic.next_barrier(&context).await;
 
         // Schedule a command
+        let (notifier, _started_rx) = Notifier::new();
         let scheduled_command = Scheduled {
             database_id: DatabaseId::from(1),
             command: Command::Flush,
-            notifiers: vec![],
+            notifier,
             span: tracing::Span::none(),
         };
 

--- a/src/meta/src/barrier/worker.rs
+++ b/src/meta/src/barrier/worker.rs
@@ -14,7 +14,7 @@
 
 use std::collections::hash_map::Entry;
 use std::collections::{HashMap, HashSet};
-use std::mem::{replace, take};
+use std::mem::replace;
 use std::pin::pin;
 use std::sync::Arc;
 use std::time::Duration;
@@ -112,8 +112,6 @@ pub(super) struct GlobalBarrierWorker<C> {
 mod tests {
     use std::collections::HashMap;
 
-    use tokio::sync::oneshot;
-
     use super::*;
     use crate::barrier::RescheduleContext;
     use crate::barrier::notifier::Notifier;
@@ -124,13 +122,7 @@ mod tests {
         let database_id = DatabaseId::new(1);
         let database_info =
             InflightDatabaseInfo::empty(database_id, env.shared_actor_infos().clone());
-        let (started_tx, started_rx) = oneshot::channel();
-        let (_collected_tx, _collected_rx) = oneshot::channel();
-
-        let notifier = Notifier {
-            started: Some(started_tx),
-            collected: Some(_collected_tx),
-        };
+        let (notifier, started_rx) = Notifier::new();
 
         let new_barrier = schedule::NewBarrier {
             database_id,
@@ -139,7 +131,7 @@ mod tests {
                     context: RescheduleContext::empty(),
                     reschedule_plan: None,
                 },
-                vec![notifier],
+                notifier,
             )),
             span: tracing::Span::none(),
             checkpoint: false,
@@ -193,7 +185,7 @@ fn resolve_reschedule_intent(
     database_info: Option<&InflightDatabaseInfo>,
     mut new_barrier: schedule::NewBarrier,
 ) -> MetaResult<Option<schedule::NewBarrier>> {
-    let Some((command, notifiers)) = new_barrier.command.take() else {
+    let Some((command, notifier)) = new_barrier.command.take() else {
         return Ok(Some(new_barrier));
     };
 
@@ -208,7 +200,7 @@ fn resolve_reschedule_intent(
                         context,
                         reschedule_plan: Some(reschedule_plan),
                     },
-                    notifiers,
+                    notifier,
                 ));
                 return Ok(Some(new_barrier));
             }
@@ -238,28 +230,23 @@ fn resolve_reschedule_intent(
                             context: RescheduleContext::empty(),
                             reschedule_plan: Some(reschedule_plan),
                         },
-                        notifiers,
+                        notifier,
                     ));
                     Ok(Some(new_barrier))
                 }
                 Ok(None) => {
                     // No-op intent: notify to unblock callers even though no barrier is injected.
-                    for mut notifier in notifiers {
-                        notifier.notify_started();
-                        notifier.notify_collected();
-                    }
+                    notifier.start().started();
                     Ok(None)
                 }
                 Err(err) => {
-                    for notifier in notifiers {
-                        notifier.notify_start_failed(err.clone());
-                    }
+                    notifier.notify_start_failed(err);
                     Ok(None)
                 }
             }
         }
         _ => {
-            new_barrier.command = Some((command, notifiers));
+            new_barrier.command = Some((command, notifier));
             Ok(Some(new_barrier))
         }
     }
@@ -455,7 +442,7 @@ impl<C: GlobalBarrierWorkerContext> GlobalBarrierWorker<C> {
                     },
                 ..
             },
-            notifiers,
+            _,
         )) = &mut new_barrier.command
         else {
             return Ok(true);
@@ -498,9 +485,11 @@ impl<C: GlobalBarrierWorkerContext> GlobalBarrierWorker<C> {
                     err = %err.as_report(),
                     "failed to resolve log store epoch for since_timestamp"
                 );
-                for notifier in take(notifiers) {
-                    notifier.notify_start_failed(err.clone());
-                }
+                let (_, notifier) = new_barrier
+                    .command
+                    .take()
+                    .expect("matched command should still exist");
+                notifier.notify_start_failed(err);
                 Ok(false)
             }
         }

--- a/src/meta/src/controller/streaming_job.rs
+++ b/src/meta/src/controller/streaming_job.rs
@@ -2430,7 +2430,7 @@ impl CatalogController {
         &self,
         source_id: SourceId,
         rate_limit: Option<u32>,
-    ) -> MetaResult<(HashSet<JobId>, HashMap<FragmentId, PbStreamNode>)> {
+    ) -> MetaResult<HashMap<FragmentId, PbStreamNode>> {
         let inner = self.inner.read().await;
         let txn = inner.db.begin().await?;
 
@@ -2535,13 +2535,10 @@ impl CatalogController {
             "source id should be used by at least one fragment"
         );
 
-        let (fragment_nodes, job_ids): (HashMap<FragmentId, PbStreamNode>, HashSet<JobId>) =
-            fragments
-                .iter()
-                .map(|(fragment_id, job_id, _, stream_node)| {
-                    ((*fragment_id, stream_node.clone()), *job_id)
-                })
-                .unzip();
+        let fragment_nodes = fragments
+            .iter()
+            .map(|(fragment_id, _, _, stream_node)| (*fragment_id, stream_node.clone()))
+            .collect();
 
         for (fragment_id, _, fragment_type_mask, stream_node) in fragments {
             Fragment::update(fragment::ActiveModel {
@@ -2569,7 +2566,7 @@ impl CatalogController {
             )
             .await;
 
-        Ok((job_ids, fragment_nodes))
+        Ok(fragment_nodes)
     }
 
     // edit the content of fragments in given `table_id`

--- a/src/meta/src/manager/metadata.rs
+++ b/src/meta/src/manager/metadata.rs
@@ -534,7 +534,7 @@ impl MetadataManager {
         &self,
         source_id: SourceId,
         rate_limit: Option<u32>,
-    ) -> MetaResult<(HashSet<JobId>, HashMap<FragmentId, PbStreamNode>)> {
+    ) -> MetaResult<HashMap<FragmentId, PbStreamNode>> {
         self.catalog_controller
             .update_source_rate_limit_by_source_id(source_id as _, rate_limit)
             .await


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

Previously, each barrier-command notifier represented only one collection subtask. When one command needed to fan out to multiple independently handled parts, callers had to maintain multiple command-level notifiers or manually aggregate their completion before notifying the original request.

The main motivation of this PR is to let a single command dynamically register multiple collection subtasks. This directly improves drop-streaming-job and throttle commands: one command can now wait for all affected database, snapshot-backfill, and batch-refresh graphs instead of restricting the operation to one independently handled part.

This PR introduces a two-phase notifier flow:

- A first-phase `NotifierStarter` dynamically registers collection parts and publishes their receivers only after dispatch succeeds.
- Each database or independent partial graph receives its own `CollectionNotifier` and reports collection success or failure independently.
- The scheduler waits for every registered collection part and returns the first error in insertion order.
- Multi-job drop and throttle commands are partitioned across the database graph, snapshot-backfill graphs, and active batch-refresh graphs without command-level completion bookkeeping.
- Start failures remain first-phase failures, while recovery and post-collection failures are delivered through the corresponding collection notifier.

Zero-part commands publish an empty receiver list and complete immediately. This is an internal meta barrier-handling refactor with no protobuf or external API changes.

## Checklist

- [x] I have written necessary rustdoc comments.
- [x] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [x] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

No user-facing changes.

</details>
