### PR TITLE
chore: upgrade Snowflake ADBC driver to 1.12.0

### DIFF
--- a/src/connector/Cargo.toml
+++ b/src/connector/Cargo.toml
@@ -36,7 +36,7 @@ sink-doris = []
 sink-starrocks = []
 
 [dependencies]
-# Rust ADBC crates (e.g., adbc_core 0.21) are built against the ADBC C/C++ core driver library version 0.19
+# Rust ADBC crates (e.g., adbc_core 0.23) are built against the ADBC C/C++ core driver library version 0.19
 adbc_core = { workspace = true, optional = true }
 adbc_snowflake = { workspace = true, optional = true, default-features = false }
 anyhow = "1"

--- a/src/risedevtool/adbc.toml
+++ b/src/risedevtool/adbc.toml
@@ -1,11 +1,11 @@
 extend = "common.toml"
 
 [env]
-ADBC_VERSION = { value = "21", condition = { env_not_set = [
+ADBC_VERSION = { value = "23", condition = { env_not_set = [
     "ADBC_VERSION",
 ] } }
-# Driver version in wheel filename (e.g., 1.9.0 for ADBC release 21)
-ADBC_DRIVER_VERSION = { value = "1.9.0", condition = { env_not_set = [
+# Driver version in wheel filename (e.g., 1.11.0 for ADBC release 23)
+ADBC_DRIVER_VERSION = { value = "1.11.0", condition = { env_not_set = [
     "ADBC_DRIVER_VERSION",
 ] } }
 ADBC_LIB_SUFFIX = { source = "${OS}", mapping = { linux = "so", darwin = "dylib" } }

--- a/src/risedevtool/adbc.toml
+++ b/src/risedevtool/adbc.toml
@@ -1,11 +1,8 @@
 extend = "common.toml"
 
 [env]
-ADBC_VERSION = { value = "23", condition = { env_not_set = [
-    "ADBC_VERSION",
-] } }
-# Driver version in wheel filename (e.g., 1.11.0 for ADBC release 23)
-ADBC_DRIVER_VERSION = { value = "1.11.0", condition = { env_not_set = [
+# ADBC Driver Foundry Snowflake driver release version.
+ADBC_DRIVER_VERSION = { value = "1.12.0", condition = { env_not_set = [
     "ADBC_DRIVER_VERSION",
 ] } }
 ADBC_LIB_SUFFIX = { source = "${OS}", mapping = { linux = "so", darwin = "dylib" } }
@@ -33,7 +30,6 @@ fi
 # Note: cargo-make runs task scripts from a temp dir (e.g. /tmp/scripts),
 # so we must not rely on `${BASH_SOURCE[0]}` to locate repo files.
 SCRIPT_PATH="${CARGO_MAKE_WORKING_DIRECTORY:-$(pwd)}/src/risedevtool/scripts/download_adbc_snowflake_driver.sh"
-ADBC_VERSION="${ADBC_VERSION}" \
 ADBC_DRIVER_VERSION="${ADBC_DRIVER_VERSION}" \
 DEST_DIR="${PREFIX_BIN}/adbc" \
 TMP_DIR="${PREFIX_TMP}" \

--- a/src/risedevtool/scripts/download_adbc_snowflake_driver.sh
+++ b/src/risedevtool/scripts/download_adbc_snowflake_driver.sh
@@ -1,43 +1,45 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Download and extract the ADBC Snowflake driver shared library from the official wheel release.
+# Download and extract the official ADBC Snowflake driver shared library.
 #
 # This script is intentionally shared by:
 # - RiseDev task `download-adbc-snowflake` (src/risedevtool/adbc.toml)
 # - Docker image build (docker/Dockerfile)
 #
 # Inputs (env vars):
-# - ADBC_VERSION: ADBC release version (default: 23)
-# - ADBC_DRIVER_VERSION: driver version in wheel filename (default: 1.11.0)
+# - ADBC_DRIVER_VERSION: ADBC Driver Foundry release version (default: 1.12.0)
 # - DEST_DIR: where to place the extracted shared library (default: "${PWD}/.risingwave/bin/adbc")
-# - TMP_DIR: temp directory for the downloaded wheel (default: "${PWD}/.risingwave/tmp")
+# - TMP_DIR: temp directory for the downloaded archive (default: "${PWD}/.risingwave/tmp")
 #
 # Outputs:
 # - ${DEST_DIR}/libadbc_driver_snowflake.so (Linux) or .dylib (macOS)
 
-ADBC_VERSION="${ADBC_VERSION:-23}"
-ADBC_DRIVER_VERSION="${ADBC_DRIVER_VERSION:-1.11.0}"
+ADBC_DRIVER_VERSION="${ADBC_DRIVER_VERSION:-1.12.0}"
 DEST_DIR="${DEST_DIR:-"${PWD}/.risingwave/bin/adbc"}"
 TMP_DIR="${TMP_DIR:-"${PWD}/.risingwave/tmp"}"
+
+# ADBC Driver Foundry does not publish Intel macOS artifacts. Keep using the
+# last Apache Arrow ADBC release that supports this development platform.
+LEGACY_ADBC_RELEASE_VERSION="23"
+LEGACY_ADBC_DRIVER_VERSION="1.11.0"
 
 OS_TYPE="$(uname -s)"
 ARCH_TYPE="$(uname -m)"
 
 LIB_SUFFIX=""
-WHEEL_LIB_SUFFIX=""
-WHEEL_SUFFIX=""
+ARCHIVE_PLATFORM=""
+USE_LEGACY_WHEEL="false"
 
 case "${OS_TYPE}" in
   Linux)
     LIB_SUFFIX="so"
-    WHEEL_LIB_SUFFIX="so"
     case "${ARCH_TYPE}" in
       x86_64)
-        WHEEL_SUFFIX="manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64"
+        ARCHIVE_PLATFORM="linux_amd64"
         ;;
       aarch64)
-        WHEEL_SUFFIX="manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64"
+        ARCHIVE_PLATFORM="linux_arm64"
         ;;
       *)
         echo "Error: Unsupported Linux architecture: ${ARCH_TYPE}" >&2
@@ -47,14 +49,12 @@ case "${OS_TYPE}" in
     ;;
   Darwin)
     LIB_SUFFIX="dylib"
-    # The macOS wheel packages the Mach-O shared library with a .so suffix.
-    WHEEL_LIB_SUFFIX="so"
     case "${ARCH_TYPE}" in
       x86_64)
-        WHEEL_SUFFIX="macosx_10_15_x86_64"
+        USE_LEGACY_WHEEL="true"
         ;;
       arm64)
-        WHEEL_SUFFIX="macosx_11_0_arm64"
+        ARCHIVE_PLATFORM="macos_arm64"
         ;;
       *)
         echo "Error: Unsupported macOS architecture: ${ARCH_TYPE}" >&2
@@ -69,27 +69,40 @@ case "${OS_TYPE}" in
 esac
 
 DRIVER_NAME="libadbc_driver_snowflake.${LIB_SUFFIX}"
-WHEEL_DRIVER_NAME="libadbc_driver_snowflake.${WHEEL_LIB_SUFFIX}"
-WHEEL_FILENAME="adbc_driver_snowflake-${ADBC_DRIVER_VERSION}-py3-none-${WHEEL_SUFFIX}.whl"
-DOWNLOAD_URL="https://github.com/apache/arrow-adbc/releases/download/apache-arrow-adbc-${ADBC_VERSION}/${WHEEL_FILENAME}"
+
+if [ "${USE_LEGACY_WHEEL}" = "true" ]; then
+  ARTIFACT_FILENAME="adbc_driver_snowflake-${LEGACY_ADBC_DRIVER_VERSION}-py3-none-macosx_10_15_x86_64.whl"
+  DOWNLOAD_URL="https://github.com/apache/arrow-adbc/releases/download/apache-arrow-adbc-${LEGACY_ADBC_RELEASE_VERSION}/${ARTIFACT_FILENAME}"
+  SOURCE_DRIVER_NAME="libadbc_driver_snowflake.so"
+  DOWNLOAD_DESCRIPTION="Apache Arrow ADBC ${LEGACY_ADBC_RELEASE_VERSION} (driver ${LEGACY_ADBC_DRIVER_VERSION}, Intel macOS fallback)"
+else
+  ARTIFACT_FILENAME="snowflake_${ARCHIVE_PLATFORM}_v${ADBC_DRIVER_VERSION}.tar.gz"
+  DOWNLOAD_URL="https://github.com/adbc-drivers/snowflake/releases/download/go/v${ADBC_DRIVER_VERSION}/${ARTIFACT_FILENAME}"
+  SOURCE_DRIVER_NAME="${DRIVER_NAME}"
+  DOWNLOAD_DESCRIPTION="ADBC Driver Foundry Snowflake driver ${ADBC_DRIVER_VERSION}"
+fi
 
 if [ -f "${DEST_DIR}/${DRIVER_NAME}" ]; then
   exit 0
 fi
 
-echo "ADBC Snowflake driver not found, downloading ADBC ${ADBC_VERSION} (driver ${ADBC_DRIVER_VERSION})"
+echo "ADBC Snowflake driver not found, downloading ${DOWNLOAD_DESCRIPTION}"
 echo "Platform: ${OS_TYPE} ${ARCH_TYPE}"
 echo "Download URL: ${DOWNLOAD_URL}"
 
 mkdir -p "${DEST_DIR}" "${TMP_DIR}"
-curl -fL -o "${TMP_DIR}/${WHEEL_FILENAME}" "${DOWNLOAD_URL}"
+curl -fL -o "${TMP_DIR}/${ARTIFACT_FILENAME}" "${DOWNLOAD_URL}"
 
-# Extract shared library from wheel (wheel is a zip file).
-unzip -j -o "${TMP_DIR}/${WHEEL_FILENAME}" "adbc_driver_snowflake/${WHEEL_DRIVER_NAME}" -d "${DEST_DIR}"
-if [ "${WHEEL_DRIVER_NAME}" != "${DRIVER_NAME}" ]; then
-  mv "${DEST_DIR}/${WHEEL_DRIVER_NAME}" "${DEST_DIR}/${DRIVER_NAME}"
+# Intel macOS still uses the legacy wheel. Current releases use tar archives.
+if [ "${USE_LEGACY_WHEEL}" = "true" ]; then
+  unzip -j -o "${TMP_DIR}/${ARTIFACT_FILENAME}" "adbc_driver_snowflake/${SOURCE_DRIVER_NAME}" -d "${DEST_DIR}"
+else
+  tar -xzf "${TMP_DIR}/${ARTIFACT_FILENAME}" -C "${DEST_DIR}" "${SOURCE_DRIVER_NAME}"
 fi
-rm -f "${TMP_DIR}/${WHEEL_FILENAME}"
+if [ "${SOURCE_DRIVER_NAME}" != "${DRIVER_NAME}" ]; then
+  mv "${DEST_DIR}/${SOURCE_DRIVER_NAME}" "${DEST_DIR}/${DRIVER_NAME}"
+fi
+rm -f "${TMP_DIR}/${ARTIFACT_FILENAME}"
 
 if [ ! -f "${DEST_DIR}/${DRIVER_NAME}" ]; then
   echo "Error: ADBC Snowflake driver file not found after extraction" >&2

--- a/src/risedevtool/scripts/download_adbc_snowflake_driver.sh
+++ b/src/risedevtool/scripts/download_adbc_snowflake_driver.sh
@@ -8,16 +8,16 @@ set -euo pipefail
 # - Docker image build (docker/Dockerfile)
 #
 # Inputs (env vars):
-# - ADBC_VERSION: ADBC release version (default: 21)
-# - ADBC_DRIVER_VERSION: driver version in wheel filename (default: 1.9.0)
+# - ADBC_VERSION: ADBC release version (default: 23)
+# - ADBC_DRIVER_VERSION: driver version in wheel filename (default: 1.11.0)
 # - DEST_DIR: where to place the extracted shared library (default: "${PWD}/.risingwave/bin/adbc")
 # - TMP_DIR: temp directory for the downloaded wheel (default: "${PWD}/.risingwave/tmp")
 #
 # Outputs:
 # - ${DEST_DIR}/libadbc_driver_snowflake.so (Linux) or .dylib (macOS)
 
-ADBC_VERSION="${ADBC_VERSION:-21}"
-ADBC_DRIVER_VERSION="${ADBC_DRIVER_VERSION:-1.9.0}"
+ADBC_VERSION="${ADBC_VERSION:-23}"
+ADBC_DRIVER_VERSION="${ADBC_DRIVER_VERSION:-1.11.0}"
 DEST_DIR="${DEST_DIR:-"${PWD}/.risingwave/bin/adbc"}"
 TMP_DIR="${TMP_DIR:-"${PWD}/.risingwave/tmp"}"
 
@@ -25,17 +25,19 @@ OS_TYPE="$(uname -s)"
 ARCH_TYPE="$(uname -m)"
 
 LIB_SUFFIX=""
+WHEEL_LIB_SUFFIX=""
 WHEEL_SUFFIX=""
 
 case "${OS_TYPE}" in
   Linux)
     LIB_SUFFIX="so"
+    WHEEL_LIB_SUFFIX="so"
     case "${ARCH_TYPE}" in
       x86_64)
-        WHEEL_SUFFIX="manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64"
+        WHEEL_SUFFIX="manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64"
         ;;
       aarch64)
-        WHEEL_SUFFIX="manylinux2014_aarch64.manylinux_2_17_aarch64"
+        WHEEL_SUFFIX="manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64"
         ;;
       *)
         echo "Error: Unsupported Linux architecture: ${ARCH_TYPE}" >&2
@@ -45,6 +47,8 @@ case "${OS_TYPE}" in
     ;;
   Darwin)
     LIB_SUFFIX="dylib"
+    # The macOS wheel packages the Mach-O shared library with a .so suffix.
+    WHEEL_LIB_SUFFIX="so"
     case "${ARCH_TYPE}" in
       x86_64)
         WHEEL_SUFFIX="macosx_10_15_x86_64"
@@ -65,6 +69,7 @@ case "${OS_TYPE}" in
 esac
 
 DRIVER_NAME="libadbc_driver_snowflake.${LIB_SUFFIX}"
+WHEEL_DRIVER_NAME="libadbc_driver_snowflake.${WHEEL_LIB_SUFFIX}"
 WHEEL_FILENAME="adbc_driver_snowflake-${ADBC_DRIVER_VERSION}-py3-none-${WHEEL_SUFFIX}.whl"
 DOWNLOAD_URL="https://github.com/apache/arrow-adbc/releases/download/apache-arrow-adbc-${ADBC_VERSION}/${WHEEL_FILENAME}"
 
@@ -80,7 +85,10 @@ mkdir -p "${DEST_DIR}" "${TMP_DIR}"
 curl -fL -o "${TMP_DIR}/${WHEEL_FILENAME}" "${DOWNLOAD_URL}"
 
 # Extract shared library from wheel (wheel is a zip file).
-unzip -j -o "${TMP_DIR}/${WHEEL_FILENAME}" "adbc_driver_snowflake/${DRIVER_NAME}" -d "${DEST_DIR}"
+unzip -j -o "${TMP_DIR}/${WHEEL_FILENAME}" "adbc_driver_snowflake/${WHEEL_DRIVER_NAME}" -d "${DEST_DIR}"
+if [ "${WHEEL_DRIVER_NAME}" != "${DRIVER_NAME}" ]; then
+  mv "${DEST_DIR}/${WHEEL_DRIVER_NAME}" "${DEST_DIR}/${DRIVER_NAME}"
+fi
 rm -f "${TMP_DIR}/${WHEEL_FILENAME}"
 
 if [ ! -f "${DEST_DIR}/${DRIVER_NAME}" ]; then


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

Upgrade the bundled Snowflake ADBC driver from Apache Arrow ADBC release 21 / driver 1.9.0 to ADBC Driver Foundry Snowflake driver 1.12.0.

Active Snowflake driver development moved from `apache/arrow-adbc` to `adbc-drivers/snowflake`. The new upstream release uses Go 1.26.5, `golang.org/x/crypto` 0.54.0, `golang.org/x/net` 0.57.0, and gRPC 1.83.0, removing all Critical findings from the driver.

The new upstream publishes platform tarballs instead of Python wheels. This PR updates the shared RiseDev/Docker download script for Linux amd64, Linux arm64, and macOS arm64. ADBC Driver Foundry does not publish a macOS x86_64 artifact, so Intel Macs retain an explicit fallback to the last Apache Arrow ADBC artifact, release 23 / driver 1.11.0.

Compatibility checks:

- The 1.9.0, 1.11.0, and 1.12.0 Linux drivers expose the same 57 `Adbc*` symbols.
- The 1.12.0 manifest declares ADBC 1.1 ABI compatibility.
- The macOS arm64 1.12.0 library downloads and loads successfully.
- The Linux amd64 1.12.0 download path produces the same binary used for the Scout scan.
- The Linux arm64 release asset exists.
- The Intel macOS fallback downloads and extracts a valid x86_64 Mach-O library.
- The RisingWave connector compiles with `adbc_core` and `adbc_snowflake` 0.23.

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] I have added necessary unit tests and integration tests.
- [x] I have added test labels as necessary.
- [ ] I have added fuzzing tests or opened an issue to track them.
- [ ] My PR contains breaking changes.
- [ ] My PR changes performance-critical code, so I will run (micro) benchmarks and present the results.
- [ ] I have checked the Release Timeline and Currently Supported Versions to determine which release branches I need to cherry-pick this PR into.

## Test plan

- `bash -n src/risedevtool/scripts/download_adbc_snowflake_driver.sh`
- Download and dynamically load the macOS arm64 1.12.0 artifact.
- Download and inspect the Linux amd64 1.12.0 artifact.
- Verify the Linux arm64 asset URL.
- Download and inspect the Intel macOS 1.11.0 fallback artifact.
- Compare exported ADBC symbols between 1.9.0, 1.11.0, and 1.12.0.
- `cargo check -p risingwave_connector --features source-adbc_snowflake`
- `git diff --check`

## Docker Scout verification

Scanned the final root filesystem of the same image used by Docker build 18599, replacing only the Snowflake ADBC library:

| Severity | Baseline | Patched | Change |
| --- | ---: | ---: | ---: |
| Critical | 12 | 1 | -11 |
| High | 130 | 106 | -24 |
| Medium | 1074 | 1040 | -34 |
| Low | 128 | 125 | -3 |
| Unspecified | 6 | 1 | -5 |
| Total | 1350 | 1273 | -77 |

The new 1.12.0 driver itself has no Critical, High, Medium, or Low findings. Its only finding is the Unspecified `GO-2026-5932` notice for the unmaintained `golang.org/x/crypto/openpgp` package. The one Critical remaining in the patched full image is the separately bundled Avro 1.9.2 finding addressed by #26614.

Applying this PR together with #26614 produces 0 Critical, 104 High, 1038 Medium, 124 Low, and 1 Unspecified finding (1267 total) in the same local Scout scan.

## Documentation

- [ ] My PR needs documentation updates.

<details>
<summary><b>Release note</b></summary>

</details>
