### PR TITLE
fix: upgrade shaded Hadoop client runtime

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -125,6 +125,12 @@
                 <artifactId>commons-lang3</artifactId>
                 <version>3.18.0</version>
             </dependency>
+            <!-- ORC otherwise pulls Hadoop 3.4.1's runtime, which embeds vulnerable Avro 1.9.2. -->
+            <dependency>
+                <groupId>org.apache.hadoop</groupId>
+                <artifactId>hadoop-client-runtime</artifactId>
+                <version>3.5.0</version>
+            </dependency>
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-databind</artifactId>


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

Manage ORC's transitive `hadoop-client-runtime` dependency at version 3.5.0 while keeping RisingWave's direct Hadoop dependencies at 3.4.1.

`hadoop-client-runtime` 3.4.1 embeds a relocated copy of Avro 1.9.2, which Docker Scout reports as critical. Updating the ordinary Avro dependency does not replace these shaded classes. Hadoop client runtime 3.5.0 embeds Avro 1.11.5, while the separate Avro dependency in the final assembly remains 1.12.0.

The override is deliberately narrow: it avoids moving all Hadoop components to 3.5.0 and therefore reduces compatibility risk for connectors and workflows that depend on Hadoop 3.4.1.

Verified final assembly contents:

- `libs/hadoop-client-runtime-3.5.0.jar`
- embedded/shaded Avro 1.11.5
- `libs/avro-1.12.0.jar`
- no `hadoop-client-runtime-3.4.1.jar`

## Checklist

- [ ] I have written necessary rustdoc comments.
- [x] I have added necessary unit tests and integration tests.
- [x] I have added test labels as necessary.
- [ ] I have added fuzzing tests or opened an issue to track them.
- [ ] My PR contains breaking changes.
- [ ] My PR changes performance-critical code, so I will run (micro) benchmarks and present the results.
- [ ] I have checked the Release Timeline and Currently Supported Versions to determine which release branches I need to cherry-pick this PR into.

## Test plan

- `mvn -B -f java/pom.xml -pl connector-node/s3-common,connector-node/risingwave-sink-iceberg -am test -Dno-build-rust`
- `mvn -B -f java/pom.xml package -Dmaven.test.skip=true -Dno-build-rust`
- Inspect the generated connector assembly and the embedded Avro metadata.
- `git diff --check`

## Docker Scout verification

Scanned the final root filesystem of the same image used by Docker build 18599, replacing only `hadoop-client-runtime`:

| Severity | Baseline | Patched | Change |
| --- | ---: | ---: | ---: |
| Critical | 12 | 11 | -1 |
| High | 130 | 128 | -2 |
| Medium | 1074 | 1072 | -2 |
| Low | 128 | 127 | -1 |
| Unspecified | 6 | 6 | 0 |
| Total | 1350 | 1344 | -6 |

The removed advisories are the Avro 1.9.2 Critical and High findings, a Jackson Core High, two Medium findings, and one Low finding. No new advisory ID is introduced. Some existing Jetty/Jackson advisories remain associated with their newer shaded versions.

## Documentation

- [ ] My PR needs documentation updates.

<details>
<summary><b>Release note</b></summary>

</details>
