### PR TITLE
feat(iceberg): support writing variant columns

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7592,7 +7592,7 @@ dependencies = [
 [[package]]
 name = "iceberg"
 version = "0.10.0"
-source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=2768ccf8b1847a14162337d7ef7a76935881fbc8#2768ccf8b1847a14162337d7ef7a76935881fbc8"
+source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=631180827ceb8d6296644edb9c5c8c29f770da5e#631180827ceb8d6296644edb9c5c8c29f770da5e"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -7651,7 +7651,7 @@ dependencies = [
 [[package]]
 name = "iceberg-catalog-glue"
 version = "0.10.0"
-source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=2768ccf8b1847a14162337d7ef7a76935881fbc8#2768ccf8b1847a14162337d7ef7a76935881fbc8"
+source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=631180827ceb8d6296644edb9c5c8c29f770da5e#631180827ceb8d6296644edb9c5c8c29f770da5e"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7666,7 +7666,7 @@ dependencies = [
 [[package]]
 name = "iceberg-catalog-rest"
 version = "0.10.0"
-source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=2768ccf8b1847a14162337d7ef7a76935881fbc8#2768ccf8b1847a14162337d7ef7a76935881fbc8"
+source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=631180827ceb8d6296644edb9c5c8c29f770da5e#631180827ceb8d6296644edb9c5c8c29f770da5e"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -7687,7 +7687,7 @@ dependencies = [
 [[package]]
 name = "iceberg-compaction-core"
 version = "0.1.0"
-source = "git+https://github.com/nimtable/iceberg-compaction.git?rev=53410bea82ff2319196df43e7447ab2bb13da1d6#53410bea82ff2319196df43e7447ab2bb13da1d6"
+source = "git+https://github.com/nimtable/iceberg-compaction.git?rev=072233a040b02eeed1a1afd882c51214e286f0ae#072233a040b02eeed1a1afd882c51214e286f0ae"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -7716,7 +7716,7 @@ dependencies = [
 [[package]]
 name = "iceberg-datafusion"
 version = "0.10.0"
-source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=2768ccf8b1847a14162337d7ef7a76935881fbc8#2768ccf8b1847a14162337d7ef7a76935881fbc8"
+source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=631180827ceb8d6296644edb9c5c8c29f770da5e#631180827ceb8d6296644edb9c5c8c29f770da5e"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7732,7 +7732,7 @@ dependencies = [
 [[package]]
 name = "iceberg-storage-opendal"
 version = "0.10.0"
-source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=2768ccf8b1847a14162337d7ef7a76935881fbc8#2768ccf8b1847a14162337d7ef7a76935881fbc8"
+source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=631180827ceb8d6296644edb9c5c8c29f770da5e#631180827ceb8d6296644edb9c5c8c29f770da5e"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -176,10 +176,10 @@ hashbrown0_16 = { package = "hashbrown", version = "0.16.1", features = [
 ] }
 hytra = "0.1"
 # branch dev_rebase_main_20260807
-iceberg = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "2768ccf8b1847a14162337d7ef7a76935881fbc8" }
-iceberg-catalog-glue = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "2768ccf8b1847a14162337d7ef7a76935881fbc8" }
-iceberg-catalog-rest = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "2768ccf8b1847a14162337d7ef7a76935881fbc8" }
-iceberg-storage-opendal = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "2768ccf8b1847a14162337d7ef7a76935881fbc8", features = [
+iceberg = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "631180827ceb8d6296644edb9c5c8c29f770da5e" }
+iceberg-catalog-glue = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "631180827ceb8d6296644edb9c5c8c29f770da5e" }
+iceberg-catalog-rest = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "631180827ceb8d6296644edb9c5c8c29f770da5e" }
+iceberg-storage-opendal = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "631180827ceb8d6296644edb9c5c8c29f770da5e", features = [
     "opendal-azblob",
     "opendal-azdls",
     "opendal-fs",

--- a/e2e_test/ddl/variant.slt
+++ b/e2e_test/ddl/variant.slt
@@ -433,8 +433,9 @@ create function variant_arg_udf(variant) returns int as 'variant_arg_udf' using 
 statement error VARIANT is not supported in UDFs yet
 create function variant_ret_udf(int) returns variant as 'variant_ret_udf' using link 'http://localhost:8815';
 
-# Sinks cannot serialize VARIANT values with an external encoder yet: creation is
-# rejected unless the sink does not encode (blackhole, sink-into-table).
+# Most external encoders cannot serialize VARIANT values yet: creation is rejected
+# unless the sink does not encode (blackhole, sink-into-table). Iceberg is supported
+# separately through its native Parquet Variant layout.
 
 statement ok
 create table variant_sink_t (id int primary key, v variant, s struct<sv variant>);

--- a/e2e_test/iceberg/test_case/iceberg_sink_variant.slt
+++ b/e2e_test/iceberg/test_case/iceberg_sink_variant.slt
@@ -1,0 +1,170 @@
+statement ok
+set sink_decouple = false;
+
+statement ok
+create table variant_sink_input (
+    id int primary key,
+    payload variant,
+    nested struct<
+        top_variant variant,
+        variant_list variant[],
+        variant_map map(varchar, variant)
+    >
+);
+
+# Write to an existing Iceberg v3 table through the upsert writer. VARIANT is not a key.
+statement ok
+create sink variant_sink_existing as
+select id, payload, nested from variant_sink_input
+with (
+    connector = 'iceberg',
+    type = 'upsert',
+    primary_key = 'id',
+    catalog.name = 'demo',
+    catalog.type = 'storage',
+    warehouse.path = 's3a://icebergdata/demo',
+    database.name = 'demo_db',
+    table.name = 'test_variant_sink',
+    s3.endpoint = 'http://127.0.0.1:9301',
+    s3.region = 'us-east-1',
+    s3.access.key = 'hummockadmin',
+    s3.secret.key = 'hummockadmin',
+    commit_checkpoint_interval = 1
+);
+
+# Auto-created tables with VARIANT columns must be v3. This sink exercises nested
+# VARIANT fields under struct, list, and map value as well as the top-level column.
+statement ok
+create sink variant_sink_auto as
+select id, payload, nested from variant_sink_input
+with (
+    connector = 'iceberg',
+    type = 'append-only',
+    force_append_only = 'true',
+    catalog.name = 'demo',
+    catalog.type = 'storage',
+    warehouse.path = 's3a://icebergdata/demo',
+    database.name = 'demo_db',
+    table.name = 'test_variant_sink_auto',
+    s3.endpoint = 'http://127.0.0.1:9301',
+    s3.region = 'us-east-1',
+    s3.access.key = 'hummockadmin',
+    s3.secret.key = 'hummockadmin',
+    create_table_if_not_exists = 'true',
+    format_version = '3',
+    commit_checkpoint_interval = 1
+);
+
+# A v1/v2 table cannot legally contain the Iceberg VARIANT type. Reject the
+# request before creating a partially configured external table.
+statement error creating an Iceberg table with VARIANT column `payload` requires `format_version = '3'`
+create sink variant_sink_v2_rejected as
+select id, payload, nested from variant_sink_input
+with (
+    connector = 'iceberg',
+    type = 'append-only',
+    force_append_only = 'true',
+    catalog.name = 'demo',
+    catalog.type = 'storage',
+    warehouse.path = 's3a://icebergdata/demo',
+    database.name = 'demo_db',
+    table.name = 'test_variant_sink_v2_rejected',
+    s3.endpoint = 'http://127.0.0.1:9301',
+    s3.region = 'us-east-1',
+    s3.access.key = 'hummockadmin',
+    s3.secret.key = 'hummockadmin',
+    create_table_if_not_exists = 'true',
+    format_version = '2'
+);
+
+statement ok
+insert into variant_sink_input values
+    (
+        1,
+        '{"a":[1,true,null],"s":"x"}'::variant,
+        row(
+            '"inner"'::variant,
+            array['7'::variant, '{"nested":2}'::variant],
+            map {'k': '{"n":2}'::variant}
+        )
+    ),
+    (
+        2,
+        'null'::variant,
+        row(
+            '"plain"'::variant,
+            array['true'::variant],
+            map {'k': '"map-string"'::variant}
+        )
+    ),
+    (3, null, null);
+
+statement ok
+flush;
+
+sleep 5s
+
+statement ok retry 6 backoff 1s
+create source variant_sink_existing_source with (
+    connector = 'iceberg',
+    catalog.name = 'demo',
+    catalog.type = 'storage',
+    warehouse.path = 's3a://icebergdata/demo',
+    database.name = 'demo_db',
+    table.name = 'test_variant_sink',
+    s3.endpoint = 'http://127.0.0.1:9301',
+    s3.region = 'us-east-1',
+    s3.access.key = 'hummockadmin',
+    s3.secret.key = 'hummockadmin'
+);
+
+statement ok retry 6 backoff 1s
+create source variant_sink_auto_source with (
+    connector = 'iceberg',
+    catalog.name = 'demo',
+    catalog.type = 'storage',
+    warehouse.path = 's3a://icebergdata/demo',
+    database.name = 'demo_db',
+    table.name = 'test_variant_sink_auto',
+    s3.endpoint = 'http://127.0.0.1:9301',
+    s3.region = 'us-east-1',
+    s3.access.key = 'hummockadmin',
+    s3.secret.key = 'hummockadmin'
+);
+
+query TITTTT retry 6 backoff 1s
+select
+    origin,
+    id,
+    coalesce(payload::varchar, '<sql-null>'),
+    coalesce((nested).top_variant::varchar, '<sql-null>'),
+    coalesce((nested).variant_list[1]::varchar, '<sql-null>'),
+    coalesce((nested).variant_map['k']::varchar, '<sql-null>')
+from (
+    select 'existing' as origin, id, payload, nested from variant_sink_existing_source
+    union all
+    select 'auto' as origin, id, payload, nested from variant_sink_auto_source
+)
+order by origin, id;
+----
+auto 1 {"a":[1,true,null],"s":"x"} "inner" 7 {"n":2}
+auto 2 null "plain" true "map-string"
+auto 3 <sql-null> <sql-null> <sql-null> <sql-null>
+existing 1 {"a":[1,true,null],"s":"x"} "inner" 7 {"n":2}
+existing 2 null "plain" true "map-string"
+existing 3 <sql-null> <sql-null> <sql-null> <sql-null>
+
+statement ok
+drop source variant_sink_existing_source;
+
+statement ok
+drop source variant_sink_auto_source;
+
+statement ok
+drop sink variant_sink_existing;
+
+statement ok
+drop sink variant_sink_auto;
+
+statement ok
+drop table variant_sink_input;

--- a/e2e_test/iceberg/test_case/iceberg_sink_variant.toml
+++ b/e2e_test/iceberg/test_case/iceberg_sink_variant.toml
@@ -1,0 +1,54 @@
+init_sqls = [
+    'CREATE SCHEMA IF NOT EXISTS demo_db',
+    'DROP TABLE IF EXISTS demo_db.test_variant_sink PURGE',
+    'DROP TABLE IF EXISTS demo_db.test_variant_sink_auto PURGE',
+    'DROP TABLE IF EXISTS demo_db.test_variant_sink_v2_rejected PURGE',
+    """CREATE TABLE demo_db.test_variant_sink (
+        id INT,
+        payload VARIANT,
+        nested STRUCT<
+            top_variant: VARIANT,
+            variant_list: ARRAY<VARIANT>,
+            variant_map: MAP<STRING, VARIANT>
+        >
+    ) USING iceberg
+    TBLPROPERTIES ('format-version'='3')""",
+]
+
+slt = 'test_case/iceberg_sink_variant.slt'
+
+# Iceberg 1.10.1's Spark reader cannot yet materialize VARIANT values inside
+# ARRAY/MAP containers (`ReusableArrayData.getVariant` is unimplemented). The
+# SLT above verifies those values through RisingWave; Spark independently
+# verifies the top-level and nested-struct encodings here.
+verify_schema = ['string', 'int', 'string', 'string']
+
+verify_sql = """
+SELECT
+    origin,
+    id,
+    COALESCE(to_json(payload), '<sql-null>'),
+    COALESCE(to_json(nested.top_variant), '<sql-null>')
+FROM (
+    SELECT 'existing' AS origin, * FROM demo_db.test_variant_sink
+    UNION ALL
+    SELECT 'auto' AS origin, * FROM demo_db.test_variant_sink_auto
+)
+ORDER BY origin, id
+"""
+
+verify_data = """
+auto,1,{"a":[1,true,null],"s":"x"},"inner"
+auto,2,null,"plain"
+auto,3,<sql-null>,<sql-null>
+existing,1,{"a":[1,true,null],"s":"x"},"inner"
+existing,2,null,"plain"
+existing,3,<sql-null>,<sql-null>
+"""
+
+drop_sqls = [
+    'DROP TABLE IF EXISTS demo_db.test_variant_sink PURGE',
+    'DROP TABLE IF EXISTS demo_db.test_variant_sink_auto PURGE',
+    'DROP TABLE IF EXISTS demo_db.test_variant_sink_v2_rejected PURGE',
+    'DROP SCHEMA IF EXISTS demo_db',
+]

--- a/src/common/src/array/arrow/arrow_iceberg.rs
+++ b/src/common/src/array/arrow/arrow_iceberg.rs
@@ -291,12 +291,10 @@ fn variant_arrow_fields() -> arrow_schema::Fields {
             arrow_schema::DataType::Binary,
             false,
         )),
-        // Nullable to match iceberg-rust's layout, which reserves an absent `value`
-        // for shredded variants; we always write it.
         Arc::new(arrow_schema::Field::new(
             "value",
             arrow_schema::DataType::Binary,
-            true,
+            false,
         )),
     ]
     .into()

--- a/src/common/src/array/arrow/arrow_iceberg.rs
+++ b/src/common/src/array/arrow/arrow_iceberg.rs
@@ -227,9 +227,9 @@ impl ToArrow for IcebergArrowConvert {
         &self,
         array: &RwVariantArray,
     ) -> Result<arrow_array::ArrayRef, ArrayError> {
-        // Variant's physical Arrow layout has required children. For a SQL NULL row their
-        // bytes are ignored by the parent null bitmap, so `raw_iter`'s valid variant-null
-        // placeholder keeps both child arrays non-null without a special branch per row.
+        // For a SQL NULL row the children's bytes are ignored by the parent null bitmap,
+        // so `raw_iter`'s valid variant-null placeholder keeps both child arrays non-null
+        // without a special branch per row.
         let metadata = Arc::new(arrow_array::BinaryArray::from_iter_values(
             array.raw_iter().map(|variant| variant.metadata()),
         )) as ArrayRef;
@@ -291,10 +291,12 @@ fn variant_arrow_fields() -> arrow_schema::Fields {
             arrow_schema::DataType::Binary,
             false,
         )),
+        // Nullable to match iceberg-rust's layout, which reserves an absent `value`
+        // for shredded variants; we always write it.
         Arc::new(arrow_schema::Field::new(
             "value",
             arrow_schema::DataType::Binary,
-            false,
+            true,
         )),
     ]
     .into()

--- a/src/common/src/array/arrow/arrow_iceberg.rs
+++ b/src/common/src/array/arrow/arrow_iceberg.rs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 use std::cell::RefCell;
-use std::collections::HashMap;
 use std::ops::Div;
 use std::sync::{Arc, LazyLock};
 
@@ -21,7 +20,7 @@ use arrow_array::ArrayRef;
 use arrow_array::cast::AsArray;
 use arrow_schema::extension::ExtensionType;
 use num_traits::abs;
-use parquet_variant_compute::{VariantArray, VariantType};
+use parquet_variant_compute::{VariantArray as ParquetVariantArray, VariantType};
 use risingwave_common_log::LogSuppressor;
 use thiserror_ext::AsReport;
 
@@ -31,7 +30,7 @@ pub use super::arrow_58::{
 };
 use crate::array::{
     Array, ArrayBuilder, ArrayError, ArrayImpl, DataChunk, DataType, DecimalArray, IntervalArray,
-    VariantArrayBuilder,
+    VariantArray as RwVariantArray, VariantArrayBuilder,
 };
 use crate::types::{Scalar, StructType, VariantVal};
 
@@ -141,8 +140,6 @@ impl ToArrow for IcebergArrowConvert {
             DataType::Serial => self.serial_type_to_arrow(),
             DataType::Decimal => return Ok(self.decimal_type_to_arrow(name)),
             DataType::Jsonb => self.varchar_type_to_arrow(),
-            // Schema-only mapping: converting variant arrays to Arrow (the write path)
-            // is still unsupported.
             DataType::Variant => return Ok(variant_arrow_field(name)),
             DataType::Struct(fields) => self.struct_type_to_arrow(fields)?,
             DataType::List(list) => self.list_type_to_arrow(list)?,
@@ -225,6 +222,28 @@ impl ToArrow for IcebergArrowConvert {
     ) -> Result<arrow_array::ArrayRef, ArrayError> {
         Ok(Arc::new(arrow_array::StringArray::from(array)))
     }
+
+    fn variant_to_arrow(
+        &self,
+        array: &RwVariantArray,
+    ) -> Result<arrow_array::ArrayRef, ArrayError> {
+        // Variant's physical Arrow layout has required children. For a SQL NULL row their
+        // bytes are ignored by the parent null bitmap, so `raw_iter`'s valid variant-null
+        // placeholder keeps both child arrays non-null without a special branch per row.
+        let metadata = Arc::new(arrow_array::BinaryArray::from_iter_values(
+            array.raw_iter().map(|variant| variant.metadata()),
+        )) as ArrayRef;
+        let value = Arc::new(arrow_array::BinaryArray::from_iter_values(
+            array.raw_iter().map(|variant| variant.value()),
+        )) as ArrayRef;
+        let nulls = (!array.null_bitmap().all()).then(|| array.null_bitmap().into());
+
+        Ok(Arc::new(arrow_array::StructArray::new(
+            variant_arrow_fields(),
+            vec![metadata, value],
+            nulls,
+        )))
+    }
 }
 
 impl FromArrow for IcebergArrowConvert {
@@ -257,7 +276,16 @@ impl FromArrow for IcebergArrowConvert {
 /// The Arrow field layout of an unshredded variant column, tagged with the
 /// `arrow.parquet.variant` extension.
 fn variant_arrow_field(name: &str) -> arrow_schema::Field {
-    let fields = [
+    arrow_schema::Field::new(
+        name,
+        arrow_schema::DataType::Struct(variant_arrow_fields()),
+        true,
+    )
+    .with_extension_type(VariantType)
+}
+
+fn variant_arrow_fields() -> arrow_schema::Fields {
+    [
         Arc::new(arrow_schema::Field::new(
             "metadata",
             arrow_schema::DataType::Binary,
@@ -269,13 +297,12 @@ fn variant_arrow_field(name: &str) -> arrow_schema::Field {
             false,
         )),
     ]
-    .into();
-    arrow_schema::Field::new(name, arrow_schema::DataType::Struct(fields), true)
-        .with_extension_type(VariantType)
+    .into()
 }
 
 fn variant_array_to_variant(array: &arrow_array::ArrayRef) -> Result<ArrayImpl, ArrayError> {
-    let variant_array = VariantArray::try_new(array.as_ref()).map_err(ArrayError::from_arrow)?;
+    let variant_array =
+        ParquetVariantArray::try_new(array.as_ref()).map_err(ArrayError::from_arrow)?;
     // The shredded encoding cannot be reconstructed yet, and decoding only metadata/value
     // would yield silently partial objects, so the whole column reads as NULL.
     if variant_array.typed_value_field().is_some() {
@@ -417,7 +444,9 @@ impl IcebergCreateTableArrowConvert {
         *self.next_field_id.borrow_mut() += 1;
         let field_id = *self.next_field_id.borrow();
 
-        let mut metadata = HashMap::new();
+        // Preserve extension metadata such as `arrow.parquet.variant` while adding the
+        // Iceberg field id required by `arrow_schema_to_schema`.
+        let mut metadata = arrow_field.metadata().clone();
         // for iceberg-rust
         metadata.insert("PARQUET:field_id".to_owned(), field_id.to_string());
         arrow_field.set_metadata(metadata);
@@ -481,11 +510,10 @@ impl ToArrow for IcebergCreateTableArrowConvert {
             DataType::Serial => self.serial_type_to_arrow(),
             DataType::Decimal => return Ok(self.decimal_type_to_arrow(name)),
             DataType::Jsonb => self.varchar_type_to_arrow(),
-            // TODO: support creating Iceberg tables with VARIANT columns.
             DataType::Variant => {
-                return Err(ArrayError::to_arrow(
-                    "VARIANT is not supported for Iceberg table creation yet",
-                ));
+                let mut arrow_field = variant_arrow_field(name);
+                self.add_field_id(&mut arrow_field);
+                return Ok(arrow_field);
             }
             DataType::Struct(fields) => self.struct_type_to_arrow(fields)?,
             DataType::List(list) => self.list_type_to_arrow(list)?,

--- a/src/connector/src/sink/iceberg/create_table.rs
+++ b/src/connector/src/sink/iceberg/create_table.rs
@@ -308,12 +308,14 @@ fn field_is_compatible(
     use risingwave_common::types::DataType as RwDataType;
 
     // A Variant is physically an Arrow struct, but its extension metadata makes it a leaf
-    // Iceberg type. Check that metadata before the generic struct recursion below.
-    if matches!(rw_type, RwDataType::Variant) {
-        return Ok(matches!(
-            IcebergArrowConvert.type_from_field(arrow_field),
-            Ok(RwDataType::Variant)
-        ));
+    // Iceberg type. The binding is exclusive in both directions: a plain struct mimicking
+    // the physical layout must not be written into a VARIANT column.
+    let arrow_is_variant = matches!(
+        IcebergArrowConvert.type_from_field(arrow_field),
+        Ok(RwDataType::Variant)
+    );
+    if matches!(rw_type, RwDataType::Variant) || arrow_is_variant {
+        return Ok(matches!(rw_type, RwDataType::Variant) && arrow_is_variant);
     }
 
     let converted_arrow_data_type = IcebergArrowConvert
@@ -349,13 +351,12 @@ fn field_is_compatible(
             if rw_fields.len() != arrow_fields.len() {
                 return Ok(false);
             }
-            for arrow_field in arrow_fields {
-                let Some((_, rw_type)) = rw_fields
-                    .iter()
-                    .find(|(name, _)| name == arrow_field.name())
-                else {
+            // `struct_to_arrow` writes struct children by position, so nested fields
+            // must match by position as well, like the top-level column-order check.
+            for ((rw_name, rw_type), arrow_field) in rw_fields.iter().zip_eq_fast(arrow_fields) {
+                if rw_name != arrow_field.name().as_str() {
                     return Ok(false);
-                };
+                }
                 if !field_is_compatible(rw_type, arrow_field)? {
                     return Ok(false);
                 }

--- a/src/connector/src/sink/iceberg/create_table.rs
+++ b/src/connector/src/sink/iceberg/create_table.rs
@@ -114,6 +114,18 @@ pub(super) async fn create_table_if_not_exists_impl(
         return Ok(false);
     }
 
+    if config.table_format_version() < FormatVersion::V3
+        && let Some(column) = param
+            .columns
+            .iter()
+            .find(|column| column.data_type.contains_variant())
+    {
+        return Err(SinkError::Config(anyhow!(
+            "creating an Iceberg table with VARIANT column `{}` requires `format_version = '3'`",
+            column.name
+        )));
+    }
+
     let iceberg_create_table_arrow_convert = IcebergCreateTableArrowConvert::default();
     // convert risingwave schema -> arrow schema -> iceberg schema
     let arrow_fields = param
@@ -289,43 +301,68 @@ async fn create_namespace_if_not_exists(
 const MAP_KEY: &str = "key";
 const MAP_VALUE: &str = "value";
 
-fn get_fields<'a>(
-    our_field_type: &'a risingwave_common::types::DataType,
-    data_type: &ArrowDataType,
-    schema_fields: &mut HashMap<&'a str, &'a risingwave_common::types::DataType>,
-) -> Option<ArrowFields> {
-    match data_type {
-        ArrowDataType::Struct(fields) => {
-            match our_field_type {
-                risingwave_common::types::DataType::Struct(struct_fields) => {
-                    struct_fields.iter().for_each(|(name, data_type)| {
-                        let res = schema_fields.insert(name, data_type);
-                        // This assert is to make sure there is no duplicate field name in the schema.
-                        assert!(res.is_none())
-                    });
-                }
-                risingwave_common::types::DataType::Map(map_fields) => {
-                    schema_fields.insert(MAP_KEY, map_fields.key());
-                    schema_fields.insert(MAP_VALUE, map_fields.value());
-                }
-                risingwave_common::types::DataType::List(list) => {
-                    list.elem()
-                        .as_struct()
-                        .iter()
-                        .for_each(|(name, data_type)| {
-                            let res = schema_fields.insert(name, data_type);
-                            // This assert is to make sure there is no duplicate field name in the schema.
-                            assert!(res.is_none())
-                        });
-                }
-                _ => {}
+fn field_is_compatible(
+    rw_type: &risingwave_common::types::DataType,
+    arrow_field: &ArrowField,
+) -> anyhow::Result<bool> {
+    use risingwave_common::types::DataType as RwDataType;
+
+    // A Variant is physically an Arrow struct, but its extension metadata makes it a leaf
+    // Iceberg type. Check that metadata before the generic struct recursion below.
+    if matches!(rw_type, RwDataType::Variant) {
+        return Ok(matches!(
+            IcebergArrowConvert.type_from_field(arrow_field),
+            Ok(RwDataType::Variant)
+        ));
+    }
+
+    let converted_arrow_data_type = IcebergArrowConvert
+        .to_arrow_field("", rw_type)
+        .map_err(|e| anyhow!(e))?
+        .data_type()
+        .clone();
+
+    match (rw_type, &converted_arrow_data_type, arrow_field.data_type()) {
+        (_, ArrowDataType::Decimal128(_, _), ArrowDataType::Decimal128(_, _)) => Ok(true),
+        (_, ArrowDataType::Binary, ArrowDataType::LargeBinary)
+        | (_, ArrowDataType::LargeBinary, ArrowDataType::Binary) => Ok(true),
+        (RwDataType::List(list), ArrowDataType::List(_), ArrowDataType::List(element)) => {
+            field_is_compatible(list.elem(), element)
+        }
+        (RwDataType::Map(map), ArrowDataType::Map(_, _), ArrowDataType::Map(entries, _)) => {
+            let ArrowDataType::Struct(fields) = entries.data_type() else {
+                return Ok(false);
             };
-            Some(fields.clone())
+            let key = fields.iter().find(|field| field.name() == MAP_KEY);
+            let value = fields.iter().find(|field| field.name() == MAP_VALUE);
+            match (key, value) {
+                (Some(key), Some(value)) => Ok(field_is_compatible(map.key(), key)?
+                    && field_is_compatible(map.value(), value)?),
+                _ => Ok(false),
+            }
         }
-        ArrowDataType::List(field) | ArrowDataType::Map(field, _) => {
-            get_fields(our_field_type, field.data_type(), schema_fields)
+        (
+            RwDataType::Struct(rw_fields),
+            ArrowDataType::Struct(_),
+            ArrowDataType::Struct(arrow_fields),
+        ) => {
+            if rw_fields.len() != arrow_fields.len() {
+                return Ok(false);
+            }
+            for arrow_field in arrow_fields {
+                let Some((_, rw_type)) = rw_fields
+                    .iter()
+                    .find(|(name, _)| name == arrow_field.name())
+                else {
+                    return Ok(false);
+                };
+                if !field_is_compatible(rw_type, arrow_field)? {
+                    return Ok(false);
+                }
+            }
+            Ok(true)
         }
-        _ => None, // not a supported complex type and unlikely to show up
+        (_, left, right) => Ok(left.equals_datatype(right)),
     }
 }
 
@@ -338,46 +375,12 @@ fn check_compatibility(
             .get(arrow_field.name().as_str())
             .ok_or_else(|| anyhow!("Field {} not found in our schema", arrow_field.name()))?;
 
-        // Iceberg source should be able to read iceberg decimal type.
-        let converted_arrow_data_type = IcebergArrowConvert
-            .to_arrow_field("", our_field_type)
-            .map_err(|e| anyhow!(e))?
-            .data_type()
-            .clone();
-
-        let compatible = match (&converted_arrow_data_type, arrow_field.data_type()) {
-            (ArrowDataType::Decimal128(_, _), ArrowDataType::Decimal128(_, _)) => true,
-            (ArrowDataType::Binary, ArrowDataType::LargeBinary) => true,
-            (ArrowDataType::LargeBinary, ArrowDataType::Binary) => true,
-            (ArrowDataType::List(_), ArrowDataType::List(field))
-            | (ArrowDataType::Map(_, _), ArrowDataType::Map(field, _)) => {
-                let mut schema_fields = HashMap::new();
-                get_fields(our_field_type, field.data_type(), &mut schema_fields)
-                    .is_none_or(|fields| check_compatibility(schema_fields, &fields).unwrap())
-            }
-            // validate nested structs
-            (ArrowDataType::Struct(_), ArrowDataType::Struct(fields)) => {
-                let mut schema_fields = HashMap::new();
-                our_field_type
-                    .as_struct()
-                    .iter()
-                    .for_each(|(name, data_type)| {
-                        let res = schema_fields.insert(name, data_type);
-                        // This assert is to make sure there is no duplicate field name in the schema.
-                        assert!(res.is_none())
-                    });
-                check_compatibility(schema_fields, fields)?
-            }
-            // cases where left != right (metadata, field name mismatch)
-            //
-            // all nested types: in iceberg `field_id` will always be present, but RW doesn't have it:
-            // {"PARQUET:field_id": ".."}
-            //
-            // map: The standard name in arrow is "entries", "key", "value".
-            // in iceberg-rs, it's called "key_value"
-            (left, right) => left.equals_datatype(right),
-        };
-        if !compatible {
+        if !field_is_compatible(our_field_type, arrow_field)? {
+            let converted_arrow_data_type = IcebergArrowConvert
+                .to_arrow_field("", our_field_type)
+                .map_err(|e| anyhow!(e))?
+                .data_type()
+                .clone();
             bail!(
                 "field {}'s type is incompatible\nRisingWave converted data type: {}\niceberg's data type: {}",
                 arrow_field.name(),

--- a/src/connector/src/sink/iceberg/mod.rs
+++ b/src/connector/src/sink/iceberg/mod.rs
@@ -233,6 +233,27 @@ impl Sink for IcebergSink {
         validate_explicit_compaction_type(&self.config)?;
         validate_compaction_option_compatibility(&self.config)?;
 
+        // VARIANT is not comparable, so it can never be an equality-delete key.
+        if self.config.r#type == SINK_TYPE_UPSERT
+            && !self.config.force_append_only
+            && let Some(pk_indices) = self
+                .param
+                .downstream_pk
+                .as_ref()
+                .filter(|pk| !pk.is_empty())
+        {
+            for &idx in pk_indices {
+                if let Some(column) = self.param.columns.get(idx)
+                    && column.data_type.contains_variant()
+                {
+                    bail!(
+                        "VARIANT column `{}` cannot be used as the primary key of an upsert iceberg sink",
+                        column.name
+                    );
+                }
+            }
+        }
+
         let table = self.create_and_validate_table().await?;
         self.config
             .validate_manifest_rewrite_format(table.metadata().format_version())?;

--- a/src/meta/src/stream/sink.rs
+++ b/src/meta/src/stream/sink.rs
@@ -16,6 +16,7 @@ use anyhow::Context;
 use risingwave_common::catalog::ColumnCatalog;
 use risingwave_connector::dispatch_sink;
 use risingwave_connector::sink::catalog::SinkCatalog;
+use risingwave_connector::sink::iceberg::ICEBERG_SINK;
 use risingwave_connector::sink::trivial::BLACKHOLE_SINK;
 use risingwave_connector::sink::{CONNECTOR_TYPE_KEY, Sink, SinkParam, build_sink};
 use risingwave_pb::catalog::PbSink;
@@ -38,22 +39,24 @@ pub async fn validate_sink(prost_sink_catalog: &PbSink) -> MetaResult<()> {
     )
 }
 
-/// Returns the first column whose type contains VARIANT (nested included). No sink connector can
-/// encode variant values yet, so callers reject such columns at creation time.
+/// Returns the first column whose type contains VARIANT (nested included). Callers use this to
+/// reject connectors that cannot encode variant values.
 pub fn first_variant_column(columns: &[ColumnCatalog]) -> Option<&ColumnCatalog> {
     columns
         .iter()
         .find(|column| column.data_type().contains_variant())
 }
 
-/// Reject sinks that carry VARIANT columns at creation time.
+/// Reject sinks that carry VARIANT columns at creation time unless their connector supports it.
 fn reject_variant_sink(sink_catalog: &SinkCatalog) -> MetaResult<()> {
-    // Sinks into tables and blackhole sinks do not serialize values with an external encoder.
+    // Sinks into tables and blackhole sinks do not serialize values with an external encoder;
+    // Iceberg uses the standard Parquet Variant physical layout.
     if sink_catalog.target_table.is_some() {
         return Ok(());
     }
     if let Some(connector) = sink_catalog.properties.get(CONNECTOR_TYPE_KEY)
-        && connector.eq_ignore_ascii_case(BLACKHOLE_SINK)
+        && (connector.eq_ignore_ascii_case(BLACKHOLE_SINK)
+            || connector.eq_ignore_ascii_case(ICEBERG_SINK))
     {
         return Ok(());
     }

--- a/src/storage/Cargo.toml
+++ b/src/storage/Cargo.toml
@@ -34,7 +34,7 @@ futures = { version = "0.3", default-features = false, features = ["alloc"] }
 futures-async-stream = { workspace = true }
 hex = "0.4"
 iceberg = { workspace = true }
-iceberg-compaction-core = { git = "https://github.com/nimtable/iceberg-compaction.git", rev = "53410bea82ff2319196df43e7447ab2bb13da1d6" }
+iceberg-compaction-core = { git = "https://github.com/nimtable/iceberg-compaction.git", rev = "072233a040b02eeed1a1afd882c51214e286f0ae" }
 itertools = { workspace = true }
 libc = "0.2"
 lz4 = "1.28.0"


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What is changed and what is your intention?

This PR adds native `VARIANT` writes to Iceberg sinks, complementing the Iceberg source support from #25165.

- Encode RisingWave `VARIANT` arrays with the standard unshredded Parquet Variant physical layout while preserving the distinction between SQL `NULL` and Variant `null`.
- Support `VARIANT` recursively in structs, lists, and map values for both existing Iceberg v3 tables and tables created by the sink.
- Require `format_version = 3` when auto-creating an Iceberg table that contains `VARIANT`; v1/v2 requests fail before table creation with a clear error.
- Preserve Parquet Variant extension metadata while assigning Iceberg field IDs during table creation.
- Recognize Variant physical structs as logical leaf types during existing-table schema compatibility checks.
- Exempt only the Iceberg connector from the general `VARIANT` sink rejection; unsupported sink encoders remain rejected.
- Add an Iceberg MinIO/RisingWave/Spark E2E covering existing upsert tables, auto-created append-only tables, nested values, and SQL/Variant null semantics.

One current ecosystem limitation is that Spark/Iceberg 1.10.1 cannot materialize Variant values inside ARRAY/MAP containers. The E2E verifies those values through a RisingWave source and independently verifies top-level and struct-contained Variant values through Spark.

## Test

- `cargo check -p risingwave_common -p risingwave_connector -p risingwave_meta`
- `cargo fmt --all -- --check`
- Iceberg `iceberg_sink_variant` E2E with MinIO, RisingWave, and Spark

## Checklist

- [x] I have written necessary rustdoc comments.
- [x] I have added the necessary integration test.
- [ ] I have added test labels as necessary.
- [ ] I have added fuzzing tests or opened an issue to track them.
- [ ] My PR contains breaking changes.
- [ ] My PR changes performance-critical code, so I will run (micro) benchmarks and present the results.
- [ ] I have checked the Release Timeline and Currently Supported Versions to determine which release branches I need to cherry-pick this PR into.

## Documentation

- [ ] My PR needs documentation updates.

<details>
<summary><b>Release note</b></summary>

Iceberg sinks can now write `VARIANT` columns, including Variant values nested in structs, lists, and map values. The target Iceberg table must use format version 3; set `format_version = 3` when using `create_table_if_not_exists`.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added Iceberg sink support for top-level and nested `VARIANT` values in Iceberg v3 tables.
  - Preserved `VARIANT` metadata during Iceberg schema creation and updates.
  - Added end-to-end validation for writing, reading, and comparing `VARIANT` data across supported sink configurations.

- **Bug Fixes**
  - Improved compatibility checks for nested Iceberg schemas.
  - Prevented unsupported `VARIANT` configurations, including non-v3 tables and primary-key usage in applicable upsert sinks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->