### PR TITLE
fix(test): avoid logging Vault AppRole secret IDs

### DIFF
--- a/e2e_test/source_inline/vault/vault_approle_setup.py
+++ b/e2e_test/source_inline/vault/vault_approle_setup.py
@@ -92,7 +92,7 @@ def create_vault_approle(vault_addr, vault_token, role_name="test-role"):
         )
         secret_id_resp.raise_for_status()
         secret_id = secret_id_resp.json()["data"]["secret_id"]
-        print(f"Generated secret ID: {secret_id}")
+        print("Generated secret ID successfully")
     except requests.exceptions.RequestException as e:
         print(f"Failed to generate secret ID: {e}")
         sys.exit(1)
@@ -187,7 +187,6 @@ def main():
 
     print("✅ Setup completed successfully!")
     print(f"Role ID: {role_id}")
-    print(f"Secret ID: {secret_id}")
 
     # Export environment variables for potential use by other tests
     os.environ["VAULT_TEST_ROLE_ID"] = role_id


### PR DESCRIPTION
## What changed

- Stop printing the generated Vault AppRole `secret_id` in the setup helper.
- Keep a non-sensitive success message so CI logs still show setup progress.
- Remove the repeated secret value from the final setup summary.

This addresses code-scanning alerts [#25](https://github.com/risingwavelabs/risingwave/security/code-scanning/25) and [#26](https://github.com/risingwavelabs/risingwave/security/code-scanning/26).

## Why

The generated AppRole secret ID is a credential. Even though this helper is used by e2e tests, writing it to CI logs unnecessarily exposes the credential to log readers and retention systems.

## Verification

- `python3 -m py_compile e2e_test/source_inline/vault/vault_approle_setup.py`
- `git diff --check`