### PR TITLE
feat(source): support PostgreSQL polygon in CDC

### DIFF
--- a/e2e_test/source_inline/cdc/postgres/postgres_polygon.slt
+++ b/e2e_test/source_inline/cdc/postgres/postgres_polygon.slt
@@ -1,0 +1,377 @@
+control substitution on
+
+# Test that Postgres CDC correctly handles PostgreSQL's built-in `polygon` type.
+#
+# Covers:
+#   1. explicit_rw : a polygon column explicitly mapped to VARCHAR, with a backfill
+#      check followed by separate INSERT and UPDATE exact-text comparisons.
+#   2. auto_rw      : `polygon` and `polygon[]` columns derived via `(*)`, with a NULL
+#      row backfill kept intact, then an INSERT and an UPDATE each carrying two array
+#      elements, all compared against upstream by exact scalar/element text.
+#   3. schema_rw    : ALTER TABLE ADD COLUMN polygon after source creation, then an
+#      UPDATE of the old row plus an INSERT of a new row, verified via describe and
+#      exact ordered checks.
+#
+# A single postgres-cdc source with auto.schema.change is shared by all three tables;
+# polygon values are compared to their upstream text rather than hardcoded.
+
+# --- Conditional cleanup of a leftover slot and upstream tables (idempotent) ---
+system ok
+psql -c "
+    SELECT pg_terminate_backend(active_pid)
+    FROM pg_replication_slots
+    WHERE slot_name = 'polygon_issue_25517_slot' AND active_pid IS NOT NULL;
+    SELECT pg_sleep(1);
+    SELECT pg_drop_replication_slot(slot_name)
+    FROM pg_replication_slots
+    WHERE slot_name = 'polygon_issue_25517_slot';
+    DROP TABLE IF EXISTS public.upstream_polygon_explicit CASCADE;
+    DROP TABLE IF EXISTS public.upstream_polygon_auto CASCADE;
+    DROP TABLE IF EXISTS public.upstream_polygon_schema CASCADE;
+"
+
+statement ok
+drop table if exists explicit_rw;
+
+statement ok
+drop table if exists auto_rw;
+
+statement ok
+drop table if exists schema_rw;
+
+statement ok
+drop source if exists polygon_source;
+
+# One source shared by all three reading tables.
+statement ok
+create source polygon_source with (
+  connector = 'postgres-cdc',
+  hostname = '${PGHOST:localhost}',
+  port = '${PGPORT:5432}',
+  username = '${PGUSER:$USER}',
+  password = '${PGPASSWORD:}',
+  database.name = '${PGDATABASE:postgres}',
+  schema.name = 'public',
+  slot.name = 'polygon_issue_25517_slot',
+  auto.schema.change = 'true',
+  debezium.include.unknown.datatypes = 'true'
+);
+
+# ===========================================================================
+# 1. explicit_rw : explicit VARCHAR mapping of a polygon column
+# ===========================================================================
+system ok
+psql -c "
+    CREATE TABLE public.upstream_polygon_explicit (
+        id int PRIMARY KEY,
+        name varchar,
+        location polygon
+    );
+    INSERT INTO public.upstream_polygon_explicit (id, name, location) VALUES
+        (1, 'seed', polygon '((0,0),(10,0),(10,10),(0,10),(0,0))'),
+        (3, 'sci-backfill', polygon '((1e15,1e-5),(1e20,1e-10))');
+"
+
+statement ok
+create table explicit_rw (
+    id int primary key,
+    name varchar,
+    location varchar
+) from polygon_source table 'public.upstream_polygon_explicit';
+
+# Backfill check: compare our exact text against upstream text (no hardcoded polygon).
+query ITT retry 10 backoff 1s
+select ours.id, ours.name, ours.location = upstream.location_text as location_ok
+from explicit_rw ours
+join (
+    select * from postgres_query(
+        '${PGHOST:localhost}',
+        '${PGPORT:5432}',
+        '${PGUSER:$USER}',
+        '${PGPASSWORD:}',
+        '${PGDATABASE:postgres}',
+        'select id, name, location::text as location_text from public.upstream_polygon_explicit order by id'
+    )
+) as upstream(id, name, location_text)
+on ours.id = upstream.id and ours.name = upstream.name
+where ours.id in (1, 3)
+order by ours.id;
+----
+1 seed t
+3 sci-backfill t
+
+# Separate INSERT exact-text check.
+system ok
+psql -c "
+    INSERT INTO public.upstream_polygon_explicit (id, name, location) VALUES
+        (2, 'inserted', polygon '((1,1),(11,1),(11,11),(1,11),(1,1))');
+"
+
+query ITT retry 10 backoff 1s
+select ours.id, ours.name, ours.location = upstream.location_text as location_ok
+from explicit_rw ours
+join (
+    select * from postgres_query(
+        '${PGHOST:localhost}',
+        '${PGPORT:5432}',
+        '${PGUSER:$USER}',
+        '${PGPASSWORD:}',
+        '${PGDATABASE:postgres}',
+        'select id, name, location::text as location_text from public.upstream_polygon_explicit order by id'
+    )
+) as upstream(id, name, location_text)
+on ours.id = upstream.id and ours.name = upstream.name
+where ours.id = 2
+order by ours.id;
+----
+2 inserted t
+
+# Separate UPDATE exact-text check.
+system ok
+psql -c "
+    UPDATE public.upstream_polygon_explicit SET
+        name = 'updated',
+        location = polygon '((20,20),(30,20),(30,30),(20,30),(20,20))'
+    WHERE id = 1;
+    INSERT INTO public.upstream_polygon_explicit (id, name, location) VALUES
+        (4, 'sci-incremental', polygon '((1e20,1e-10),(1e15,1e-5))');
+"
+
+query ITT retry 10 backoff 1s
+select ours.id, ours.name, ours.location = upstream.location_text as location_ok
+from explicit_rw ours
+join (
+    select * from postgres_query(
+        '${PGHOST:localhost}',
+        '${PGPORT:5432}',
+        '${PGUSER:$USER}',
+        '${PGPASSWORD:}',
+        '${PGDATABASE:postgres}',
+        'select id, name, location::text as location_text from public.upstream_polygon_explicit order by id'
+    )
+) as upstream(id, name, location_text)
+on ours.id = upstream.id and ours.name = upstream.name
+where ours.id = 1
+order by ours.id;
+----
+1 updated t
+
+query ITT retry 10 backoff 1s
+select ours.id, ours.name, ours.location = upstream.location_text as location_ok
+from explicit_rw ours
+join (
+    select * from postgres_query(
+        '${PGHOST:localhost}',
+        '${PGPORT:5432}',
+        '${PGUSER:$USER}',
+        '${PGPASSWORD:}',
+        '${PGDATABASE:postgres}',
+        'select id, name, location::text as location_text from public.upstream_polygon_explicit order by id'
+    )
+) as upstream(id, name, location_text)
+on ours.id = upstream.id and ours.name = upstream.name
+where ours.id = 4
+order by ours.id;
+----
+4 sci-incremental t
+
+# ===========================================================================
+# 2. auto_rw : auto-derive `polygon` and `polygon[]` via (*), NULL preserved
+# ===========================================================================
+system ok
+psql -c "
+    CREATE TABLE public.upstream_polygon_auto (
+        id int PRIMARY KEY,
+        scalar polygon,
+        locations polygon[]
+    );
+    INSERT INTO public.upstream_polygon_auto (id, scalar, locations) VALUES
+        (1, polygon '((0,0),(10,0),(10,10),(0,10),(0,0))',
+            ARRAY[polygon '((1,1),(11,1),(11,11),(1,11),(1,1))',
+                  polygon '((2,2),(12,2),(12,12),(2,12),(2,2))']),
+        (2, NULL, NULL);
+"
+
+statement ok
+create table auto_rw (*)
+from polygon_source table 'public.upstream_polygon_auto';
+
+# Type assertions: polygon -> varchar, polygon[] -> varchar[].
+query TTTT retry 10 backoff 1s
+describe auto_rw;
+----
+id integer false NULL
+"scalar" character varying false NULL
+locations character varying[] false NULL
+_rw_timestamp timestamp with time zone true NULL
+primary key id NULL NULL
+distribution key id NULL NULL
+table description auto_rw NULL NULL
+
+# Backfill check: scalar plus both array elements match upstream exactly.
+query ITTT retry 10 backoff 1s
+select ours.id,
+    ours.scalar = upstream.scalar_text as scalar_ok,
+    ours.locations[1] = upstream.loc1_text as loc1_ok,
+    ours.locations[2] = upstream.loc2_text as loc2_ok
+from auto_rw ours
+join (
+    select * from postgres_query(
+        '${PGHOST:localhost}',
+        '${PGPORT:5432}',
+        '${PGUSER:$USER}',
+        '${PGPASSWORD:}',
+        '${PGDATABASE:postgres}',
+        'select id, scalar::text as scalar_text, locations[1]::text as loc1_text, locations[2]::text as loc2_text from public.upstream_polygon_auto order by id'
+    )
+) as upstream(id, scalar_text, loc1_text, loc2_text)
+on ours.id = upstream.id
+where ours.id = 1
+order by ours.id;
+----
+1 t t t
+
+# NULL backfill row stays NULL.
+query ITTT retry 10 backoff 1s
+select id,
+    scalar is null as scalar_null,
+    locations[1] is null as loc1_null,
+    locations[2] is null as loc2_null
+from auto_rw
+where id = 2
+order by id;
+----
+2 t t t
+
+# INSERT and UPDATE, each carrying two array elements.
+system ok
+psql -c "
+    INSERT INTO public.upstream_polygon_auto (id, scalar, locations) VALUES
+        (3, polygon '((3,3),(13,3),(13,13),(3,13),(3,3))',
+            ARRAY[polygon '((4,4),(14,4),(14,14),(4,14),(4,4))',
+                  polygon '((5,5),(15,5),(15,15),(5,15),(5,5))']);
+    UPDATE public.upstream_polygon_auto SET
+        scalar = polygon '((6,6),(16,6),(16,16),(6,16),(6,6))',
+        locations = ARRAY[polygon '((7,7),(17,7),(17,17),(7,17),(7,7))',
+                          polygon '((8,8),(18,8),(18,18),(8,18),(8,8))']
+    WHERE id = 1;
+"
+
+query ITTT retry 10 backoff 1s
+select ours.id,
+    ours.scalar = upstream.scalar_text as scalar_ok,
+    ours.locations[1] = upstream.loc1_text as loc1_ok,
+    ours.locations[2] = upstream.loc2_text as loc2_ok
+from auto_rw ours
+join (
+    select * from postgres_query(
+        '${PGHOST:localhost}',
+        '${PGPORT:5432}',
+        '${PGUSER:$USER}',
+        '${PGPASSWORD:}',
+        '${PGDATABASE:postgres}',
+        'select id, scalar::text as scalar_text, locations[1]::text as loc1_text, locations[2]::text as loc2_text from public.upstream_polygon_auto order by id'
+    )
+) as upstream(id, scalar_text, loc1_text, loc2_text)
+on ours.id = upstream.id
+order by ours.id;
+----
+1 t t t
+2 NULL NULL NULL
+3 t t t
+
+# ===========================================================================
+# 3. schema_rw : ALTER TABLE ADD COLUMN polygon after source creation
+# ===========================================================================
+system ok
+psql -c "
+    CREATE TABLE public.upstream_polygon_schema (
+        id int PRIMARY KEY,
+        note varchar
+    );
+    INSERT INTO public.upstream_polygon_schema (id, note) VALUES
+        (1, 'baseline');
+"
+
+statement ok
+create table schema_rw (*)
+from polygon_source table 'public.upstream_polygon_schema';
+
+# Baseline row backfill (no polygon column yet).
+query IT retry 10 backoff 1s
+select id, note from schema_rw where id = 1 order by id;
+----
+1 baseline
+
+# Add the polygon column upstream; update the old row and insert a new row.
+system ok
+psql -c "
+    ALTER TABLE public.upstream_polygon_schema ADD COLUMN location polygon;
+    UPDATE public.upstream_polygon_schema SET
+        location = polygon '((9,9),(19,9),(19,19),(9,19),(9,9))'
+    WHERE id = 1;
+    INSERT INTO public.upstream_polygon_schema (id, note, location) VALUES
+        (2, 'added', polygon '((10,10),(20,10),(20,20),(10,20),(10,10))');
+"
+
+# The added column is derived as VARCHAR via schema change.
+query TTTT retry 10 backoff 1s
+describe schema_rw;
+----
+id integer false NULL
+note character varying false NULL
+"location" character varying false NULL
+_rw_timestamp timestamp with time zone true NULL
+primary key id NULL NULL
+distribution key id NULL NULL
+table description schema_rw NULL NULL
+
+# Exact ordered checks against upstream text.
+query ITT retry 10 backoff 1s
+select ours.id, ours.note, ours.location = upstream.location_text as location_ok
+from schema_rw ours
+join (
+    select * from postgres_query(
+        '${PGHOST:localhost}',
+        '${PGPORT:5432}',
+        '${PGUSER:$USER}',
+        '${PGPASSWORD:}',
+        '${PGDATABASE:postgres}',
+        'select id, note, location::text as location_text from public.upstream_polygon_schema order by id'
+    )
+) as upstream(id, note, location_text)
+on ours.id = upstream.id and ours.note = upstream.note
+order by ours.id;
+----
+1 baseline t
+2 added t
+
+# ===========================================================================
+# Cleanup: drop RW tables, drop source with cascade, drop upstream tables and
+# conditionally drop the replication slot.
+# ===========================================================================
+statement ok
+drop table explicit_rw;
+
+statement ok
+drop table auto_rw;
+
+statement ok
+drop table schema_rw;
+
+statement ok
+drop source polygon_source cascade;
+
+system ok
+psql -c "
+    SELECT pg_terminate_backend(active_pid)
+    FROM pg_replication_slots
+    WHERE slot_name = 'polygon_issue_25517_slot' AND active_pid IS NOT NULL;
+    SELECT pg_sleep(1);
+    SELECT pg_drop_replication_slot(slot_name)
+    FROM pg_replication_slots
+    WHERE slot_name = 'polygon_issue_25517_slot';
+    DROP TABLE IF EXISTS public.upstream_polygon_explicit CASCADE;
+    DROP TABLE IF EXISTS public.upstream_polygon_auto CASCADE;
+    DROP TABLE IF EXISTS public.upstream_polygon_schema CASCADE;
+"

--- a/java/connector-node/risingwave-connector-service/src/main/java/com/risingwave/connector/source/common/PostgresValidator.java
+++ b/java/connector-node/risingwave-connector-service/src/main/java/com/risingwave/connector/source/common/PostgresValidator.java
@@ -795,8 +795,9 @@ public class PostgresValidator extends DatabaseValidator implements AutoCloseabl
             case "tsrange":
             case "tstzrange":
             case "daterange":
+            case "polygon":
                 // TEXT, XML, UUID, INET, CIDR, MACADDR, MACADDR8, INT4RANGE, INT8RANGE,
-                // NUMRANGE, TSRANGE, TSTZRANGE, DATERANGE -> CHARACTER VARYING
+                // NUMRANGE, TSRANGE, TSTZRANGE, DATERANGE, POLYGON -> CHARACTER VARYING
                 return val == Data.DataType.TypeName.VARCHAR_VALUE;
             case "timestamp with time zone":
             case "timestamptz":

--- a/java/connector-node/risingwave-source-cdc/src/main/java/com/risingwave/connector/cdc/debezium/converters/PgCompositeToStringConverter.java
+++ b/java/connector-node/risingwave-source-cdc/src/main/java/com/risingwave/connector/cdc/debezium/converters/PgCompositeToStringConverter.java
@@ -18,6 +18,9 @@ package com.risingwave.connector.cdc.debezium.converters;
 
 import io.debezium.spi.converter.CustomConverter;
 import io.debezium.spi.converter.RelationalColumn;
+import java.math.BigDecimal;
+import java.math.MathContext;
+import java.math.RoundingMode;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.sql.Types;
@@ -25,8 +28,13 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Properties;
 import org.apache.kafka.connect.data.SchemaBuilder;
+import org.postgresql.geometric.PGpoint;
+import org.postgresql.geometric.PGpolygon;
 
-/** Converts PostgreSQL composite values (and arrays of composites) into plain strings. */
+/**
+ * Converts PostgreSQL composite values (and arrays of composites) into plain strings, and narrowly
+ * handles the built-in polygon scalar/array case.
+ */
 public class PgCompositeToStringConverter
         implements CustomConverter<SchemaBuilder, RelationalColumn> {
 
@@ -68,6 +76,23 @@ public class PgCompositeToStringConverter
             registration.register(SchemaBuilder.string().optional(), this::convertScalar);
             return;
         }
+        if (isPostgresPolygonScalar(column)) {
+            // Built-in geometric polygon arrives as JDBC Types.OTHER. Render
+            // it as text (e.g. `(0,0),(1,1)`) matching the RW VARCHAR column.
+            // This must stay narrow: geometry/geography and other geometric
+            // types (point/box/circle/...) are left to Debezium's handlers.
+            registration.register(SchemaBuilder.string().optional(), this::convertPolygonScalar);
+            return;
+        }
+        if (isPostgresPolygonArray(column)) {
+            // Built-in polygon[] reports an element OID below the user type
+            // threshold, so it is not caught by isUserDefinedArray. Render it
+            // as an array of text to match the RW `List(VARCHAR)` column.
+            var elementSchema = SchemaBuilder.string().optional().build();
+            registration.register(
+                    SchemaBuilder.array(elementSchema).optional(), this::convertPolygonArray);
+            return;
+        }
         if (isUserDefinedArray(column)) {
             var elementSchema = SchemaBuilder.string().optional().build();
             registration.register(
@@ -94,6 +119,35 @@ public class PgCompositeToStringConverter
 
     private static boolean isDebeziumNativeExtensionArray(RelationalColumn column) {
         return isPostgresArrayOf(column, "geometry") || isPostgresArrayOf(column, "geography");
+    }
+
+    private static boolean isPostgresPolygonScalar(RelationalColumn column) {
+        // Scalar polygon arrives as JDBC Types.OTHER with a built-in OID below
+        // PG_FIRST_USER_OID, so it is not a user-defined type. Match only the
+        // `polygon` type name / expression; never geometry/geography or other
+        // geometric types.
+        return column.jdbcType() == Types.OTHER
+                && (isPostgresTypeRef(column.typeName(), "polygon")
+                        || isPostgresTypeRef(column.typeExpression(), "polygon"));
+    }
+
+    private static boolean isPostgresPolygonArray(RelationalColumn column) {
+        // polygon[] is a built-in array (`_polygon` / `polygon[]`) and would
+        // otherwise be skipped by isUserDefinedArray because its element OID is
+        // below the user threshold. Require JDBC ARRAY first so a non-array
+        // RelationalColumn with misleading type metadata is never registered
+        // with an array schema.
+        return column.jdbcType() == Types.ARRAY
+                && (isPostgresArrayTypeName(column.typeName(), "polygon")
+                        || isPostgresArrayTypeExpression(column.typeExpression(), "polygon"));
+    }
+
+    private static boolean isPostgresTypeRef(String typeRef, String typeName) {
+        if (typeRef == null) {
+            return false;
+        }
+        var normalized = unquoteAndUnqualify(typeRef.toLowerCase().trim());
+        return normalized.equals(typeName);
     }
 
     private static boolean isPostgresArrayOf(RelationalColumn column, String elementTypeName) {
@@ -160,6 +214,124 @@ public class PgCompositeToStringConverter
         // PG textual array form `{"(a,b)","(c,d)"}` as bytes / string.
         // Split it into individual element strings.
         return parsePgTextArray(elementToString(value));
+    }
+
+    /**
+     * Renders a polygon scalar as text in the form {@code ((x0,y0),...,(xn,yn))}, matching how
+     * RisingWave's VARCHAR column stores the value. Null passes through unchanged; non-PGpolygon
+     * values (byte / ByteBuffer / already-text) fall back to the generic scalar conversion.
+     */
+    private String convertPolygonScalar(Object value) {
+        if (value == null) {
+            return null;
+        }
+        if (value instanceof PGpolygon polygon) {
+            StringBuilder sb = new StringBuilder();
+            sb.append('(');
+            for (int i = 0; i < polygon.points.length; i++) {
+                if (i > 0) {
+                    sb.append(',');
+                }
+                PGpoint p = polygon.points[i];
+                sb.append('(')
+                        .append(formatDouble(p.x))
+                        .append(',')
+                        .append(formatDouble(p.y))
+                        .append(')');
+            }
+            sb.append(')');
+            return sb.toString();
+        }
+        return convertScalar(value);
+    }
+
+    /**
+     * Renders a polygon[] array as a {@code List<String>} of polygon scalars. A pre-decoded {@code
+     * List} maps each element through polygon conversion while preserving nulls; the Debezium
+     * unavailable sentinel keeps the current placeholder behavior; raw textual arrays are parsed
+     * through the existing {@link #parsePgTextArray} parser without normalizing strings.
+     */
+    private List<String> convertPolygonArray(Object value) {
+        if (value == null) {
+            return null;
+        }
+        if (value instanceof List<?> list) {
+            var out = new ArrayList<String>(list.size());
+            for (Object el : list) {
+                out.add(convertPolygonScalar(el));
+            }
+            return out;
+        }
+        if (isDebeziumUnavailableValueObject(value)) {
+            return List.of(UNAVAILABLE_VALUE_PLACEHOLDER);
+        }
+        return parsePgTextArray(elementToString(value));
+    }
+
+    /**
+     * Formats a double the way PostgreSQL renders coordinates with {@code extra_float_digits > 0}
+     * (shortest representation that round-trips). {@code NaN}, the infinities and {@code 0.0} /
+     * {@code -0.0} are preserved explicitly. Finite non-zero values are rendered by progressively
+     * reducing the {@link BigDecimal} precision (1..17 significant digits, {@link
+     * RoundingMode#HALF_EVEN}) until {@code doubleValue()} bitwise round-trips back to the original
+     * {@code double}, then emitting either plain notation (decimal exponent in [-4, 14]) or
+     * PostgreSQL-style scientific notation for everything else. This mirrors upstream {@code
+     * float8out} rather than {@link Double#toString} (which emits {@code 1.0E7} / {@code 1.0E-4} /
+     * {@code 4.9E-324}).
+     */
+    static String formatDouble(double value) {
+        if (Double.isNaN(value)) {
+            return "NaN";
+        }
+        if (value == Double.POSITIVE_INFINITY) {
+            return "Infinity";
+        }
+        if (value == Double.NEGATIVE_INFINITY) {
+            return "-Infinity";
+        }
+        if (value == 0.0) {
+            // +0.0 and -0.0 compare equal; detect the sign via the reciprocal.
+            return 1.0 / value < 0 ? "-0" : "0";
+        }
+        BigDecimal original = BigDecimal.valueOf(value);
+        for (int precision = 1; precision <= 17; precision++) {
+            BigDecimal candidate =
+                    original.round(new MathContext(precision, RoundingMode.HALF_EVEN));
+            if (candidate.doubleValue() == value) {
+                return formatBigDecimal(candidate.stripTrailingZeros());
+            }
+        }
+        return formatBigDecimal(original.stripTrailingZeros());
+    }
+
+    /**
+     * Renders a finite, non-zero {@link BigDecimal} with PostgreSQL {@code float8out} semantics.
+     * Decimal exponent = precision - scale - 1; plain notation when it is in [-4, 14], otherwise
+     * shortest scientific notation ({@code d.ddde±XX}, lowercase {@code e}, mandatory {@code +}
+     * sign on non-negative exponents, and a two-digit minimum for the exponent magnitude).
+     */
+    private static String formatBigDecimal(BigDecimal value) {
+        int exponent = value.precision() - value.scale() - 1;
+        if (exponent >= -4 && exponent <= 14) {
+            // e.g. 1e-4 -> "0.0001", 1e7 -> "10000000".
+            return value.toPlainString();
+        }
+        // e.g. 1e-5 -> "1e-05", 1e20 -> "1e+20", 5e-324 -> "5e-324".
+        String digits = value.unscaledValue().abs().toString();
+        StringBuilder sb = new StringBuilder();
+        if (value.signum() < 0) {
+            sb.append('-');
+        }
+        sb.append(digits.charAt(0));
+        if (digits.length() > 1) {
+            sb.append('.').append(digits.substring(1));
+        }
+        sb.append('e');
+        int absExponent = Math.abs(exponent);
+        sb.append(exponent >= 0 ? '+' : '-')
+                .append(absExponent < 10 ? "0" : "")
+                .append(absExponent);
+        return sb.toString();
     }
 
     /**

--- a/java/connector-node/risingwave-source-cdc/src/test/java/com/risingwave/connector/cdc/debezium/converters/PgCompositeToStringConverterTest.java
+++ b/java/connector-node/risingwave-source-cdc/src/test/java/com/risingwave/connector/cdc/debezium/converters/PgCompositeToStringConverterTest.java
@@ -1,0 +1,455 @@
+/*
+ * Copyright 2026 RisingWave Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.risingwave.connector.cdc.debezium.converters;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
+import io.debezium.spi.converter.CustomConverter;
+import io.debezium.spi.converter.RelationalColumn;
+import java.nio.ByteBuffer;
+import java.sql.Types;
+import java.util.Arrays;
+import java.util.List;
+import java.util.OptionalInt;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.junit.Test;
+import org.postgresql.geometric.PGpoint;
+import org.postgresql.geometric.PGpolygon;
+
+public class PgCompositeToStringConverterTest {
+
+    private static class TestColumn implements RelationalColumn {
+        private final String name;
+        private final String dataCollection;
+        private final int jdbcType;
+        private final int nativeType;
+        private final String typeName;
+        private final String typeExpression;
+        private final boolean optional;
+        private final Object defaultValue;
+        private final boolean hasDefaultValue;
+
+        TestColumn(
+                String name,
+                String dataCollection,
+                int jdbcType,
+                int nativeType,
+                String typeName,
+                String typeExpression,
+                boolean optional,
+                Object defaultValue,
+                boolean hasDefaultValue) {
+            this.name = name;
+            this.dataCollection = dataCollection;
+            this.jdbcType = jdbcType;
+            this.nativeType = nativeType;
+            this.typeName = typeName;
+            this.typeExpression = typeExpression;
+            this.optional = optional;
+            this.defaultValue = defaultValue;
+            this.hasDefaultValue = hasDefaultValue;
+        }
+
+        @Override
+        public String name() {
+            return name;
+        }
+
+        @Override
+        public String dataCollection() {
+            return dataCollection;
+        }
+
+        @Override
+        public int jdbcType() {
+            return jdbcType;
+        }
+
+        @Override
+        public int nativeType() {
+            return nativeType;
+        }
+
+        @Override
+        public String typeName() {
+            return typeName;
+        }
+
+        @Override
+        public String typeExpression() {
+            return typeExpression;
+        }
+
+        @Override
+        public OptionalInt length() {
+            return OptionalInt.empty();
+        }
+
+        @Override
+        public OptionalInt scale() {
+            return OptionalInt.empty();
+        }
+
+        @Override
+        public boolean isOptional() {
+            return optional;
+        }
+
+        @Override
+        public Object defaultValue() {
+            return defaultValue;
+        }
+
+        @Override
+        public boolean hasDefaultValue() {
+            return hasDefaultValue;
+        }
+    }
+
+    private static class Capture implements CustomConverter.ConverterRegistration<SchemaBuilder> {
+        SchemaBuilder schema;
+        CustomConverter.Converter converter;
+
+        @Override
+        public void register(SchemaBuilder schema, CustomConverter.Converter converter) {
+            this.schema = schema;
+            this.converter = converter;
+        }
+    }
+
+    private CustomConverter.Converter capturingConverter(TestColumn column) {
+        PgCompositeToStringConverter subject = new PgCompositeToStringConverter();
+        Capture capture = new Capture();
+        subject.converterFor(column, capture);
+        assertNotNull("converter should be registered", capture.converter);
+        return capture.converter;
+    }
+
+    private CustomConverter.Converter capturedOrNull(TestColumn column) {
+        PgCompositeToStringConverter subject = new PgCompositeToStringConverter();
+        Capture capture = new Capture();
+        subject.converterFor(column, capture);
+        return capture.converter;
+    }
+
+    private TestColumn polygonScalarColumn() {
+        return new TestColumn(
+                "poly",
+                "public.polygon",
+                Types.OTHER,
+                604,
+                "public.\"polygon\"",
+                "public.\"polygon\"",
+                true,
+                null,
+                false);
+    }
+
+    private TestColumn polygonArrayColumn() {
+        return new TestColumn(
+                "poly_arr",
+                "public.polygon[]",
+                Types.ARRAY,
+                1027,
+                "public.\"_polygon\"",
+                "public.\"polygon\"[]",
+                true,
+                null,
+                false);
+    }
+
+    private TestColumn geometryColumn() {
+        return new TestColumn(
+                "geom",
+                "public.geometry",
+                Types.OTHER,
+                20000,
+                "geometry",
+                "geometry",
+                true,
+                null,
+                false);
+    }
+
+    private TestColumn geographyColumn() {
+        return new TestColumn(
+                "geog",
+                "public.geography",
+                Types.OTHER,
+                20000,
+                "geography",
+                "geography",
+                true,
+                null,
+                false);
+    }
+
+    private TestColumn pointColumn() {
+        return new TestColumn(
+                "pt", "public.point", Types.OTHER, 600, "point", "point", true, null, false);
+    }
+
+    private TestColumn geometryArrayColumn() {
+        return new TestColumn(
+                "geom_arr",
+                "public.geometry[]",
+                Types.ARRAY,
+                20000,
+                "_geometry",
+                "geometry[]",
+                true,
+                null,
+                false);
+    }
+
+    private TestColumn geographyArrayColumn() {
+        return new TestColumn(
+                "geog_arr",
+                "public.geography[]",
+                Types.ARRAY,
+                20000,
+                "_geography",
+                "geography[]",
+                true,
+                null,
+                false);
+    }
+
+    private TestColumn structColumn() {
+        return new TestColumn(
+                "comp",
+                "public.composite",
+                Types.STRUCT,
+                0,
+                "composite",
+                "composite",
+                true,
+                null,
+                false);
+    }
+
+    private TestColumn typeExpressionOnlyScalarColumn() {
+        return new TestColumn(
+                "poly",
+                "public.polygon",
+                Types.OTHER,
+                604,
+                null,
+                "public.\"polygon\"",
+                true,
+                null,
+                false);
+    }
+
+    private TestColumn typeExpressionOnlyArrayColumn() {
+        return new TestColumn(
+                "poly_arr",
+                "public.polygon[]",
+                Types.ARRAY,
+                1027,
+                null,
+                "public.\"polygon\"[]",
+                true,
+                null,
+                false);
+    }
+
+    @Test
+    public void testScalarPolygonConversion() {
+        CustomConverter.Converter converter = capturingConverter(polygonScalarColumn());
+        PGpoint[] points = new PGpoint[] {new PGpoint(1, 1), new PGpoint(11, -2)};
+        PGpolygon polygon = new PGpolygon(points);
+        Object result = converter.convert(polygon);
+        assertEquals("((1,1),(11,-2))", result);
+    }
+
+    @Test
+    public void testScalarPolygonNonIntegral() {
+        CustomConverter.Converter converter = capturingConverter(polygonScalarColumn());
+        PGpoint[] points = new PGpoint[] {new PGpoint(-1.5, -2), new PGpoint(0.0, -0.0)};
+        PGpolygon polygon = new PGpolygon(points);
+        Object result = converter.convert(polygon);
+        assertEquals("((-1.5,-2),(0,-0))", result);
+    }
+
+    @Test
+    public void testScalarPolygonScientificRange() {
+        // The formatter must produce PostgreSQL float8out text (extra_float_digits > 0)
+        // rather than Double.toString for extreme magnitudes, and shortest scientific
+        // notation out of the plain exponent window.
+        CustomConverter.Converter converter = capturingConverter(polygonScalarColumn());
+        PGpoint[] points =
+                new PGpoint[] {
+                    new PGpoint(1e7, 1e-4), // -> (10000000,0.0001)
+                    new PGpoint(1e15, 1e-5), // -> (1e+15,1e-05)
+                    new PGpoint(1e20, 1e-10), // -> (1e+20,1e-10)
+                    new PGpoint(Double.MIN_VALUE, -Double.MIN_VALUE), // -> (5e-324,-5e-324)
+                };
+        PGpolygon polygon = new PGpolygon(points);
+        Object result = converter.convert(polygon);
+        assertEquals("((10000000,0.0001),(1e+15,1e-05),(1e+20,1e-10),(5e-324,-5e-324))", result);
+    }
+
+    @Test
+    public void testScalarPolygonSpecialValues() {
+        // NaN and the infinities are preserved verbatim; existing integer / decimal /
+        // +/-0 handling must not regress.
+        CustomConverter.Converter converter = capturingConverter(polygonScalarColumn());
+        PGpoint[] points =
+                new PGpoint[] {
+                    new PGpoint(Double.NaN, Double.POSITIVE_INFINITY),
+                    new PGpoint(Double.NEGATIVE_INFINITY, 0.25),
+                    new PGpoint(-0.0, 0.0),
+                };
+        PGpolygon polygon = new PGpolygon(points);
+        Object result = converter.convert(polygon);
+        assertEquals("((NaN,Infinity),(-Infinity,0.25),(-0,0))", result);
+    }
+
+    @Test
+    public void testScalarNull() {
+        CustomConverter.Converter converter = capturingConverter(polygonScalarColumn());
+        assertNull(converter.convert(null));
+    }
+
+    @Test
+    public void testScalarStringFallback() {
+        CustomConverter.Converter converter = capturingConverter(polygonScalarColumn());
+        String input = "some string";
+        assertSame(input, converter.convert(input));
+    }
+
+    @Test
+    public void testArrayPolygonList() {
+        CustomConverter.Converter converter = capturingConverter(polygonArrayColumn());
+        PGpoint[] points1 = new PGpoint[] {new PGpoint(1, 1), new PGpoint(2, 2)};
+        PGpoint[] points2 = new PGpoint[] {new PGpoint(3, 3), new PGpoint(4, 4)};
+        List<Object> input = Arrays.asList(new PGpolygon(points1), null, new PGpolygon(points2));
+        Object result = converter.convert(input);
+        assertTrue(result instanceof List);
+        List<?> list = (List<?>) result;
+        assertEquals(3, list.size());
+        assertEquals("((1,1),(2,2))", list.get(0));
+        assertNull(list.get(1));
+        assertEquals("((3,3),(4,4))", list.get(2));
+    }
+
+    @Test
+    public void testArrayRawString() {
+        CustomConverter.Converter converter = capturingConverter(polygonArrayColumn());
+        String raw = "{\"((1.0,2.5),(3,4))\",NULL}";
+        Object result = converter.convert(raw);
+        assertTrue(result instanceof List);
+        List<?> list = (List<?>) result;
+        assertEquals(2, list.size());
+        assertEquals("((1.0,2.5),(3,4))", list.get(0));
+        assertNull(list.get(1));
+    }
+
+    @Test
+    public void testScalarRegistrationTypeRefs() {
+        PgCompositeToStringConverter subject = new PgCompositeToStringConverter();
+        Capture capture = new Capture();
+        subject.converterFor(polygonScalarColumn(), capture);
+        assertNotNull(capture.converter);
+        assertNotNull(capture.schema);
+    }
+
+    @Test
+    public void testArrayRegistrationTypeRefs() {
+        PgCompositeToStringConverter subject = new PgCompositeToStringConverter();
+        Capture capture = new Capture();
+        subject.converterFor(polygonArrayColumn(), capture);
+        assertNotNull(capture.converter);
+        assertNotNull(capture.schema);
+    }
+
+    @Test
+    public void testScalarRegistrationByTypeExpressionOnly() {
+        assertNotNull(capturingConverter(typeExpressionOnlyScalarColumn()));
+    }
+
+    @Test
+    public void testArrayRegistrationByTypeExpressionOnly() {
+        assertNotNull(capturingConverter(typeExpressionOnlyArrayColumn()));
+    }
+
+    @Test
+    public void testOtherGeometryDoesNotRegister() {
+        assertNull(capturedOrNull(geometryColumn()));
+    }
+
+    @Test
+    public void testOtherGeographyDoesNotRegister() {
+        assertNull(capturedOrNull(geographyColumn()));
+    }
+
+    @Test
+    public void testOtherPointDoesNotRegister() {
+        assertNull(capturedOrNull(pointColumn()));
+    }
+
+    @Test
+    public void testArrayGeometryDoesNotRegister() {
+        assertNull(capturedOrNull(geometryArrayColumn()));
+    }
+
+    @Test
+    public void testArrayGeographyDoesNotRegister() {
+        assertNull(capturedOrNull(geographyArrayColumn()));
+    }
+
+    @Test
+    public void testStructCompositeRegisters() {
+        CustomConverter.Converter converter = capturingConverter(structColumn());
+        assertNotNull(converter);
+    }
+
+    @Test
+    public void testStructString() {
+        CustomConverter.Converter converter = capturingConverter(structColumn());
+        String input = "hello";
+        assertSame(input, converter.convert(input));
+    }
+
+    @Test
+    public void testStructByteArray() {
+        CustomConverter.Converter converter = capturingConverter(structColumn());
+        byte[] input = "bytes".getBytes(java.nio.charset.StandardCharsets.UTF_8);
+        Object result = converter.convert(input);
+        assertEquals("bytes", result);
+    }
+
+    @Test
+    public void testStructByteBuffer() {
+        CustomConverter.Converter converter = capturingConverter(structColumn());
+        ByteBuffer input =
+                ByteBuffer.wrap("buffer".getBytes(java.nio.charset.StandardCharsets.UTF_8));
+        Object result = converter.convert(input);
+        assertEquals("buffer", result);
+    }
+
+    @Test
+    public void testStructNull() {
+        CustomConverter.Converter converter = capturingConverter(structColumn());
+        assertNull(converter.convert(null));
+    }
+}

--- a/src/connector/src/connector_common/postgres.rs
+++ b/src/connector/src/connector_common/postgres.rs
@@ -726,12 +726,12 @@ pub fn sea_type_to_rw_type(col_type: &SeaType) -> ConnectorResult<DataType> {
         | SeaType::TsRange
         | SeaType::TsTzRange
         | SeaType::DateRange
-        | SeaType::Enum(_) => DataType::Varchar,
+        | SeaType::Enum(_)
+        | SeaType::Polygon => DataType::Varchar,
         SeaType::Line
         | SeaType::Lseg
         | SeaType::Box
         | SeaType::Path
-        | SeaType::Polygon
         | SeaType::Circle
         | SeaType::Bit(_)
         | SeaType::VarBit(_)
@@ -871,10 +871,21 @@ fn sea_type_to_pg_type(sea_type: &SeaType) -> ConnectorResult<tokio_postgres::ty
 
 #[cfg(test)]
 mod tests {
+    use risingwave_common::types::DataType;
+    use sea_schema::postgres::def::ColumnType as SeaType;
+
     use super::{
         format_grant_table_privilege, format_grant_usage, format_pg_table_name,
-        format_required_table_grants, parse_pgvector_dimension,
+        format_required_table_grants, parse_pgvector_dimension, sea_type_to_rw_type,
     };
+
+    #[test]
+    fn test_sea_type_polygon_maps_to_varchar() {
+        assert_eq!(
+            sea_type_to_rw_type(&SeaType::Polygon).unwrap(),
+            DataType::Varchar
+        );
+    }
 
     #[test]
     fn test_parse_pgvector_dimension() {

--- a/src/connector/src/source/cdc/external/postgres.rs
+++ b/src/connector/src/source/cdc/external/postgres.rs
@@ -244,14 +244,15 @@ impl PostgresExternalTableReader {
         // No TCP keepalive for CDC source
         let client = create_pg_client(&config.pg_connection_config()?, None).await?;
 
-        // Discover user-defined composite columns and arrays of composites.
-        // tokio-postgres cannot decode composite values natively, so for these
-        // columns we cast to text in the snapshot SELECT. Scalar composites
-        // become `(a,b,c)`; arrays become `text[]` so tokio-postgres can
-        // decode them directly as `Vec<Option<String>>` matching the RW
-        // `List(Varchar)` column. Other varchar columns stay as-is to
-        // preserve RW's own text rendering (e.g. numeric -> "NaN").
-        let composite_columns = client
+        // Discover columns that must be text-cast in the snapshot SELECT
+        // because tokio-postgres cannot decode them natively: user-defined
+        // composite columns, arrays of composites, and the geometric polygon
+        // type (scalar and array). Scalar values become `(a,b,c)` / polygon
+        // text; arrays become `text[]` so tokio-postgres can decode them
+        // directly as `Vec<Option<String>>` matching the RW `List(Varchar)`
+        // column. Other varchar columns stay as-is to preserve RW's own text
+        // rendering (e.g. numeric -> "NaN").
+        let text_cast_columns = client
             .query(
                 "SELECT a.attname, (t.typcategory = 'A') AS is_array \
                  FROM pg_attribute a \
@@ -264,7 +265,9 @@ impl PostgresExternalTableReader {
                    AND a.attnum > 0 \
                    AND NOT a.attisdropped \
                    AND (t.typtype = 'c' \
-                        OR (t.typcategory = 'A' AND t_elem.typtype = 'c'))",
+                         OR t.typname = 'polygon' \
+                         OR (t.typcategory = 'A' \
+                             AND (t_elem.typtype = 'c' OR t_elem.typname = 'polygon')))",
                 &[
                     &schema_table_name.schema_name,
                     &schema_table_name.table_name,
@@ -281,7 +284,7 @@ impl PostgresExternalTableReader {
                     error = %err.as_report(),
                     schema = %schema_table_name.schema_name,
                     table = %schema_table_name.table_name,
-                    "failed to discover postgres composite columns; falling back to no text cast"
+                    "failed to discover postgres text-cast columns; falling back to no text cast"
                 );
                 std::collections::HashMap::new()
             });
@@ -291,7 +294,7 @@ impl PostgresExternalTableReader {
             .iter()
             .map(|f| {
                 let quoted = Self::quote_column(&f.name);
-                match composite_columns.get(&f.name) {
+                match text_cast_columns.get(&f.name) {
                     Some(false) if matches!(f.data_type, DataType::Varchar) => {
                         format!("{quoted}::text AS {quoted}")
                     }
@@ -856,7 +859,7 @@ pub fn type_name_to_pg_type(ty_name: &str) -> Option<PgType> {
             "numeric" => Some(PgType::NUMERIC_ARRAY),
             "bool" => Some(PgType::BOOL_ARRAY),
             "xml" | "macaddr" | "macaddr8" | "cidr" | "inet" | "int4range" | "int8range"
-            | "numrange" | "tsrange" | "tstzrange" | "daterange" | "citext" => {
+            | "numrange" | "tsrange" | "tstzrange" | "daterange" | "citext" | "polygon" => {
                 Some(PgType::VARCHAR_ARRAY)
             }
             "varchar" => Some(PgType::VARCHAR_ARRAY),
@@ -891,7 +894,7 @@ pub fn type_name_to_pg_type(ty_name: &str) -> Option<PgType> {
             "boolean" | "bool" => Some(PgType::BOOL),
             "inet" | "xml" | "varchar" | "character varying" | "int4range" | "int8range"
             | "numrange" | "tsrange" | "tstzrange" | "daterange" | "macaddr" | "macaddr8"
-            | "cidr" => Some(PgType::VARCHAR),
+            | "cidr" | "polygon" => Some(PgType::VARCHAR),
             "char" | "character" | "bpchar" => Some(PgType::BPCHAR),
             "citext" | "text" => Some(PgType::TEXT),
             "bytea" => Some(PgType::BYTEA),
@@ -1172,6 +1175,26 @@ mod tests {
         assert!(result.is_err());
         let error_msg = result.unwrap_err().to_string();
         assert!(error_msg.contains("invalid postgres lsn_proc"));
+    }
+
+    #[test]
+    fn test_type_name_to_pg_type_polygon() {
+        use tokio_postgres::types::Type as PgType;
+
+        let polygon = super::type_name_to_pg_type("polygon").unwrap();
+        let polygon_array = super::type_name_to_pg_type("_polygon").unwrap();
+        assert_eq!(polygon, PgType::VARCHAR);
+        assert_eq!(polygon_array, PgType::VARCHAR_ARRAY);
+
+        // Polygon (scalar and array) renders as RW Varchar / List(Varchar).
+        assert_eq!(
+            super::pg_type_to_rw_type(&polygon).unwrap(),
+            DataType::Varchar
+        );
+        assert_eq!(
+            super::pg_type_to_rw_type(&polygon_array).unwrap(),
+            DataType::Varchar.list()
+        );
     }
 
     #[test]


### PR DESCRIPTION
## What's changed

- map PostgreSQL built-in `polygon` values to `VARCHAR` consistently in validation, schema discovery, snapshots, Debezium streaming conversion, and automatic schema evolution
- preserve polygon arrays as element-wise textual values
- add a narrowly scoped Debezium composite-to-string converter
- match PostgreSQL `float8out` formatting so snapshot and incremental values do not diverge at scientific-notation boundaries
- add CDC and Java converter coverage for explicit, inferred, backfill, incremental, array, and schema-change paths

## Why

PostgreSQL's JDBC snapshot path and Debezium streaming path represent polygon values differently. Without a dedicated conversion, the same polygon can change textual representation when CDC switches from backfill to incremental processing.

This is PR 2/3 for #25517. It is independent of PR #26622 and is based directly on `main`.

## Validation

- Java converter tests: 22/22
- Maven Spotless and Checkstyle
- full 18-module connector build
- Rust polygon tests: 2/2
- full `postgres_polygon.slt`
- SLT coverage check
- `cargo fmt`
- `git diff --check`

Not covered: exhaustive property comparison of every IEEE-754 value against PostgreSQL `float8out`.

Part of #25517