### PR TITLE
feat(source): preserve PostgreSQL point precision in CDC

### DIFF
--- a/e2e_test/source_inline/cdc/postgres/postgres_point.slt
+++ b/e2e_test/source_inline/cdc/postgres/postgres_point.slt
@@ -1,0 +1,340 @@
+control substitution on
+
+# Test that Postgres CDC correctly handles PostgreSQL's built-in `point` type with full
+# double-precision (float64) fidelity.
+#
+# Covers:
+#   1. explicit_rw : a point column explicitly mapped to struct<x DOUBLE PRECISION, y DOUBLE PRECISION>,
+#      with a backfill check followed by separate INSERT and UPDATE checks that compare
+#      (location).x / (location).y against exact float64 literals.
+#   2. auto_rw      : `point` columns derived via (*), including a NULL scalar row, then INSERT
+#      and UPDATE checks.
+#   3. schema_rw    : ALTER TABLE ADD COLUMN location point after source creation, updating the old
+#      row and inserting a new row, verified via describe and exact coordinate checks.
+#
+# A single postgres-cdc source with auto.schema.change is shared by all three tables. Coordinates
+# are chosen to be unrepresentable in f32 (e.g. 1.23456789012345), so any precision loss to real
+# would make the exact double-precision comparisons fail.
+
+# --- Conditional cleanup of a leftover slot and upstream tables (idempotent) ---
+system ok
+psql -c "
+    SELECT pg_terminate_backend(active_pid)
+    FROM pg_replication_slots
+    WHERE slot_name = 'point_issue_25517_slot' AND active_pid IS NOT NULL;
+    SELECT pg_sleep(1);
+    SELECT pg_drop_replication_slot(slot_name)
+    FROM pg_replication_slots
+    WHERE slot_name = 'point_issue_25517_slot';
+    DROP TABLE IF EXISTS public.upstream_point_explicit CASCADE;
+    DROP TABLE IF EXISTS public.upstream_point_auto CASCADE;
+    DROP TABLE IF EXISTS public.upstream_point_schema CASCADE;
+"
+
+statement ok
+drop table if exists explicit_rw;
+
+statement ok
+drop table if exists auto_rw;
+
+statement ok
+drop table if exists schema_rw;
+
+statement ok
+drop source if exists point_source;
+
+# One source shared by all three reading tables.
+statement ok
+create source point_source with (
+  connector = 'postgres-cdc',
+  hostname = '${PGHOST:localhost}',
+  port = '${PGPORT:5432}',
+  username = '${PGUSER:$USER}',
+  password = '${PGPASSWORD:}',
+  database.name = '${PGDATABASE:postgres}',
+  schema.name = 'public',
+  slot.name = 'point_issue_25517_slot',
+  auto.schema.change = 'true',
+  debezium.include.unknown.datatypes = 'true'
+);
+
+# ===========================================================================
+# 1. explicit_rw : explicit struct mapping with full double precision
+# ===========================================================================
+system ok
+psql -c "
+    CREATE TABLE public.upstream_point_explicit (
+        id int PRIMARY KEY,
+        name varchar,
+        location point
+    );
+    INSERT INTO public.upstream_point_explicit (id, name, location) VALUES
+        (1, 'seed', point(1.23456789012345, -9.87654321098765)),
+        (3, 'sci-backfill', point(-1.23456789012345, 9.87654321098765));
+"
+
+statement ok
+create table explicit_rw (
+    id int primary key,
+    name varchar,
+    location struct<x DOUBLE PRECISION, y DOUBLE PRECISION>
+) from point_source table 'public.upstream_point_explicit';
+
+# Backfill check: compare against exact float64 literals via a literal table so output is stable.
+query ITT retry 10 backoff 1s
+select ours.id, ours.name,
+    (ours.location).x = exp.x and (ours.location).y = exp.y as loc_ok
+from explicit_rw ours
+join (
+    values (1, 'seed', 1.23456789012345::double precision, -9.87654321098765::double precision),
+           (3, 'sci-backfill', -1.23456789012345::double precision, 9.87654321098765::double precision)
+) as exp(id, name, x, y)
+on ours.id = exp.id and ours.name = exp.name
+where ours.id in (1, 3)
+order by ours.id;
+----
+1 seed t
+3 sci-backfill t
+
+# Separate INSERT exact-coordinate check.
+system ok
+psql -c "
+    INSERT INTO public.upstream_point_explicit (id, name, location) VALUES
+        (2, 'inserted', point(3.333333333333333, 4.444444444444444));
+"
+
+query ITT retry 10 backoff 1s
+select e.id, e.name,
+    (e.location).x = 3.333333333333333::double precision and
+    (e.location).y = 4.444444444444444::double precision as loc_ok
+from explicit_rw e
+where e.id = 2
+order by id;
+----
+2 inserted t
+
+# Separate UPDATE, plus an extra inserted row.
+system ok
+psql -c "
+    UPDATE public.upstream_point_explicit SET
+        name = 'updated',
+        location = point(9.999999999999999, -8.888888888888888)
+    WHERE id = 1;
+    INSERT INTO public.upstream_point_explicit (id, name, location) VALUES
+        (4, 'sci-incremental', point(6.666666666666666, -5.555555555555555));
+"
+
+query ITT retry 10 backoff 1s
+select e.id, e.name,
+    (e.location).x = 9.999999999999999::double precision and
+    (e.location).y = -8.888888888888888::double precision as loc_ok
+from explicit_rw e
+where e.id = 1
+order by id;
+----
+1 updated t
+
+query ITT retry 10 backoff 1s
+select e.id, e.name,
+    (e.location).x = 6.666666666666666::double precision and
+    (e.location).y = -5.555555555555555::double precision as loc_ok
+from explicit_rw e
+where e.id = 4
+order by id;
+----
+4 sci-incremental t
+
+# ===========================================================================
+# 2. auto_rw : auto-derive `point` via (*), NULL preserved
+# ===========================================================================
+system ok
+psql -c "
+    CREATE TABLE public.upstream_point_auto (
+        id int PRIMARY KEY,
+        scalar point
+    );
+    INSERT INTO public.upstream_point_auto (id, scalar) VALUES
+        (1, point(1.23456789012345, -9.87654321098765)),
+        (2, NULL),
+        (3, point(7.777777777777777, -8.888888888888888));
+"
+
+statement ok
+create table auto_rw (*)
+from point_source table 'public.upstream_point_auto';
+
+# Type assertion: point -> struct<x,y> of double precision.
+query TTTT retry 10 backoff 1s
+describe auto_rw;
+----
+id integer false NULL
+"scalar" struct false NULL
+"scalar".x double precision false NULL
+"scalar".y double precision false NULL
+_rw_timestamp timestamp with time zone true NULL
+primary key id NULL NULL
+distribution key id NULL NULL
+table description auto_rw NULL NULL
+
+# Backfill check: scalar matches exact float64 coordinates.
+query IT retry 10 backoff 1s
+select id,
+    (scalar).x = 1.23456789012345::double precision and (scalar).y = -9.87654321098765::double precision as scalar_ok
+from auto_rw
+where id = 1
+order by id;
+----
+1 t
+
+# NULL backfill row: scalar stays NULL.
+query IT retry 10 backoff 1s
+select id, scalar is null as scalar_null
+from auto_rw
+where id = 2
+order by id;
+----
+2 t
+
+# Backfill row 3 scalar coordinates intact.
+query IT retry 10 backoff 1s
+select id,
+    (scalar).x = 7.777777777777777::double precision and (scalar).y = -8.888888888888888::double precision as scalar_ok
+from auto_rw
+where id = 3
+order by id;
+----
+3 t
+
+# INSERT and UPDATE exact float64 scalar.
+system ok
+psql -c "
+    INSERT INTO public.upstream_point_auto (id, scalar) VALUES
+        (4, point(6.666666666666666, -5.555555555555555));
+    UPDATE public.upstream_point_auto SET
+        scalar = point(8.888888888888888, -7.777777777777777)
+    WHERE id = 1;
+"
+
+query IT retry 10 backoff 1s
+select id,
+    (scalar).x = 8.888888888888888::double precision and (scalar).y = -7.777777777777777::double precision as scalar_ok
+from auto_rw
+where id = 1
+order by id;
+----
+1 t
+
+query IT retry 10 backoff 1s
+select id,
+    (scalar).x = 6.666666666666666::double precision and (scalar).y = -5.555555555555555::double precision as scalar_ok
+from auto_rw
+where id = 4
+order by id;
+----
+4 t
+
+# NULL row still untouched after incremental events.
+query IT retry 10 backoff 1s
+select id, scalar is null as scalar_null
+from auto_rw
+where id = 2
+order by id;
+----
+2 t
+
+# ===========================================================================
+# 3. schema_rw : ALTER TABLE ADD COLUMN point after source creation
+# ===========================================================================
+system ok
+psql -c "
+    CREATE TABLE public.upstream_point_schema (
+        id int PRIMARY KEY,
+        note varchar
+    );
+    INSERT INTO public.upstream_point_schema (id, note) VALUES
+        (1, 'baseline');
+"
+
+statement ok
+create table schema_rw (*)
+from point_source table 'public.upstream_point_schema';
+
+# Baseline row backfill (no point column yet).
+query IT retry 10 backoff 1s
+select id, note from schema_rw where id = 1 order by id;
+----
+1 baseline
+
+# Add the point column upstream; update the old row and insert a new row.
+system ok
+psql -c "
+    ALTER TABLE public.upstream_point_schema ADD COLUMN location point;
+    UPDATE public.upstream_point_schema SET
+        location = point(1.23456789012345, -9.87654321098765)
+    WHERE id = 1;
+    INSERT INTO public.upstream_point_schema (id, note, location) VALUES
+        (2, 'added', point(-4.444444444444444, 5.555555555555555));
+"
+
+# The added column is derived as struct with double-precision x/y via schema change.
+query TTTT retry 10 backoff 1s
+describe schema_rw;
+----
+id integer false NULL
+note character varying false NULL
+"location" struct false NULL
+"location".x double precision false NULL
+"location".y double precision false NULL
+_rw_timestamp timestamp with time zone true NULL
+primary key id NULL NULL
+distribution key id NULL NULL
+table description schema_rw NULL NULL
+
+# Exact coordinate checks for both rows.
+query ITT retry 10 backoff 1s
+select s.id, s.note,
+    (s.location).x = 1.23456789012345::double precision and (s.location).y = -9.87654321098765::double precision as loc_ok
+from schema_rw s
+where s.id = 1
+order by s.id;
+----
+1 baseline t
+
+query ITT retry 10 backoff 1s
+select s.id, s.note,
+    (s.location).x = -4.444444444444444::double precision and (s.location).y = 5.555555555555555::double precision as loc_ok
+from schema_rw s
+where s.id = 2
+order by s.id;
+----
+2 added t
+
+# ===========================================================================
+# Cleanup: drop RW tables, drop source with cascade, drop upstream tables and
+# conditionally drop the replication slot.
+# ===========================================================================
+statement ok
+drop table explicit_rw;
+
+statement ok
+drop table auto_rw;
+
+statement ok
+drop table schema_rw;
+
+statement ok
+drop source point_source cascade;
+
+system ok
+psql -c "
+    SELECT pg_terminate_backend(active_pid)
+    FROM pg_replication_slots
+    WHERE slot_name = 'point_issue_25517_slot' AND active_pid IS NOT NULL;
+    SELECT pg_sleep(1);
+    SELECT pg_drop_replication_slot(slot_name)
+    FROM pg_replication_slots
+    WHERE slot_name = 'point_issue_25517_slot';
+    DROP TABLE IF EXISTS public.upstream_point_explicit CASCADE;
+    DROP TABLE IF EXISTS public.upstream_point_auto CASCADE;
+    DROP TABLE IF EXISTS public.upstream_point_schema CASCADE;
+"

--- a/e2e_test/source_inline/cdc/postgres/postgres_schema_check_and_schema_change.slt
+++ b/e2e_test/source_inline/cdc/postgres/postgres_schema_check_and_schema_change.slt
@@ -138,7 +138,7 @@ create table t (
   v18 bytea,
   v19 jsonb,
   v20 character varying,
-  v21 struct<x REAL, y REAL>,
+  v21 struct<x DOUBLE PRECISION, y DOUBLE PRECISION>,
   v22 character varying,
   v23 character varying,
   v24 character varying,
@@ -303,8 +303,8 @@ v18 bytea false NULL
 v19 jsonb false NULL
 v20 character varying false NULL
 v21 struct false NULL
-v21.x real false NULL
-v21.y real false NULL
+v21.x double precision false NULL
+v21.y double precision false NULL
 v22 character varying false NULL
 v23 character varying false NULL
 v24 character varying false NULL

--- a/java/connector-node/risingwave-connector-service/src/main/java/com/risingwave/connector/source/common/PostgresValidator.java
+++ b/java/connector-node/risingwave-connector-service/src/main/java/com/risingwave/connector/source/common/PostgresValidator.java
@@ -839,7 +839,7 @@ public class PostgresValidator extends DatabaseValidator implements AutoCloseabl
                 // MONEY -> NUMERIC
                 return val == Data.DataType.TypeName.DECIMAL_VALUE;
             case "point":
-                // POINT -> STRUCT<x REAL, y REAL>
+                // POINT -> STRUCT<x DOUBLE, y DOUBLE>
                 return val == Data.DataType.TypeName.STRUCT_VALUE;
             case "ARRAY":
                 // ARRAY -> LIST

--- a/src/connector/src/connector_common/postgres.rs
+++ b/src/connector/src/connector_common/postgres.rs
@@ -698,8 +698,8 @@ pub fn sea_type_to_rw_type(col_type: &SeaType) -> ConnectorResult<DataType> {
         SeaType::Interval(_) => DataType::Interval,
         SeaType::Boolean => DataType::Boolean,
         SeaType::Point => DataType::Struct(StructType::new(vec![
-            ("x", DataType::Float32),
-            ("y", DataType::Float32),
+            ("x", DataType::Float64),
+            ("y", DataType::Float64),
         ])),
         SeaType::Uuid => DataType::Varchar,
         SeaType::Xml => DataType::Varchar,

--- a/src/connector/src/parser/debezium/simd_json_parser.rs
+++ b/src/connector/src/parser/debezium/simd_json_parser.rs
@@ -637,8 +637,8 @@ mod tests {
                 SourceColumnDesc {
                     name: "o_point".to_owned(),
                     data_type: DataType::Struct(StructType::new(vec![
-                        ("x", DataType::Float32),
-                        ("y", DataType::Float32),
+                        ("x", DataType::Float64),
+                        ("y", DataType::Float64),
                     ])),
                     column_id: 7.into(),
                     column_type: SourceColumnType::Normal,
@@ -797,8 +797,8 @@ mod tests {
                 "60f14fe2-f857-404a-b586-3b5375b3259f".into()
             ))));
             assert!(row[7].eq(&Some(ScalarImpl::Struct(StructValue::new(vec![
-                Some(ScalarImpl::Float32(1.into())),
-                Some(ScalarImpl::Float32(2.into()))
+                Some(ScalarImpl::Float64(1.into())),
+                Some(ScalarImpl::Float64(2.into()))
             ])))));
             assert!(row[8].eq(&Some(ScalarImpl::Utf8("polar".into()))));
             assert!(row[9].eq(&Some(ScalarImpl::Utf8("h".into()))));

--- a/src/connector/src/parser/postgres.rs
+++ b/src/connector/src/parser/postgres.rs
@@ -20,7 +20,7 @@ use risingwave_common::array::Finite32;
 use risingwave_common::catalog::Schema;
 use risingwave_common::log::LogSuppressor;
 use risingwave_common::row::OwnedRow;
-use risingwave_common::types::{DataType, Datum, Decimal, ScalarImpl, VectorVal};
+use risingwave_common::types::{DataType, Datum, Decimal, ScalarImpl, StructValue, VectorVal};
 use thiserror_ext::AsReport;
 use tokio_postgres::types::{FromSql, Type};
 
@@ -67,6 +67,47 @@ impl PgVectorAdapter {
     }
 }
 
+/// Adapter for the PostgreSQL built-in `point` type in CDC snapshot reads.
+/// It parses the 16-byte binary format: two `float8` values in network
+/// (big-endian) byte order, `x` followed by `y`.
+struct PgPointAdapter {
+    x: f64,
+    y: f64,
+}
+
+impl<'a> FromSql<'a> for PgPointAdapter {
+    fn accepts(ty: &Type) -> bool {
+        ty == &Type::POINT
+    }
+
+    fn from_sql(
+        _ty: &Type,
+        raw: &'a [u8],
+    ) -> Result<Self, Box<dyn std::error::Error + Sync + Send>> {
+        Self::parse_binary(raw)
+    }
+}
+
+impl PgPointAdapter {
+    fn parse_binary(raw: &[u8]) -> Result<Self, Box<dyn std::error::Error + Sync + Send>> {
+        if raw.len() != 2 * std::mem::size_of::<f64>() {
+            return Err("invalid point binary payload length".into());
+        }
+        let mut buf = raw;
+        let x = buf.get_f64();
+        let y = buf.get_f64();
+        Ok(Self { x, y })
+    }
+
+    /// Convert the adapter into a `ScalarImpl::Struct` with `x` and `y` `Float64` fields.
+    fn into_scalar_impl(self) -> ScalarImpl {
+        ScalarImpl::Struct(StructValue::new(vec![
+            Some(ScalarImpl::Float64(self.x.into())),
+            Some(ScalarImpl::Float64(self.y.into())),
+        ]))
+    }
+}
+
 macro_rules! try_handle_data_type {
     ($row:expr, $i:expr, $name:expr, $type:ty) => {{
         $row.try_get::<_, Option<$type>>($i)
@@ -107,6 +148,25 @@ pub fn postgres_row_to_owned_row_with_strict_pk(
             postgres_cell_to_scalar_impl_strict(&row, &field.data_type, index, &field.name)
         },
         |name, err| log_error!(name, err, "parse column failed"),
+    )
+}
+
+/// Returns true if `data_type` is the struct used to represent a PostgreSQL built-in
+/// `point`: exactly two fields named `x` and `y`, both `Float64`.
+fn is_point_struct_type(data_type: &DataType) -> bool {
+    let DataType::Struct(t) = data_type else {
+        return false;
+    };
+    if t.len() != 2 {
+        return false;
+    }
+    let mut fields = t.iter();
+    matches!(
+        (fields.next(), fields.next()),
+        (
+            Some(("x", &DataType::Float64)),
+            Some(("y", &DataType::Float64))
+        )
     )
 }
 
@@ -217,7 +277,24 @@ pub fn postgres_cell_to_scalar_impl_strict(
                 }
             }
         },
-        DataType::Struct(_) | DataType::Serial | DataType::Map(_) | DataType::Variant => {
+        DataType::Struct(_) => {
+            // PostgreSQL built-in `point` maps to `STRUCT<x FLOAT64, y FLOAT64>`.
+            // Decode it only when the requested struct fields are exactly `x`/`y` `Float64`
+            // and the actual row column type is `POINT`.
+            if is_point_struct_type(data_type) && matches!(row.columns()[i].type_(), &Type::POINT) {
+                match row
+                    .try_get::<_, Option<PgPointAdapter>>(i)
+                    .with_context(|| {
+                        format!("failed to decode PostgreSQL snapshot point column `{name}`")
+                    })? {
+                    Some(point) => Ok(Some(point.into_scalar_impl())),
+                    None => Ok(None),
+                }
+            } else {
+                bail!("unsupported PostgreSQL snapshot data type {data_type} for column `{name}`")
+            }
+        }
+        DataType::Serial | DataType::Map(_) | DataType::Variant => {
             bail!("unsupported PostgreSQL snapshot data type {data_type} for column `{name}`")
         }
     }
@@ -225,9 +302,10 @@ pub fn postgres_cell_to_scalar_impl_strict(
 
 #[cfg(test)]
 mod tests {
+    use risingwave_common::types::{ScalarImpl, StructValue};
     use tokio_postgres::NoTls;
 
-    use crate::parser::postgres::PgVectorAdapter;
+    use crate::parser::postgres::{PgPointAdapter, PgVectorAdapter};
     use crate::parser::scalar_adapter::EnumString;
     const DB: &str = "postgres";
     const USER: &str = "kexiang";
@@ -245,6 +323,34 @@ mod tests {
 
         let v = PgVectorAdapter::parse_binary(&raw).unwrap();
         assert_eq!(v.0, vec![1.5, -2.25, 3.0]);
+    }
+
+    #[test]
+    fn test_pg_point_adapter_parse_binary() {
+        // Two float64 values, x then y, in network (big-endian) byte order.
+        let mut raw = vec![];
+        raw.extend_from_slice(&1.5f64.to_be_bytes());
+        raw.extend_from_slice(&(-2.25f64).to_be_bytes());
+        assert_eq!(raw.len(), 16);
+
+        let p = PgPointAdapter::parse_binary(&raw).unwrap();
+        assert_eq!(p.x, 1.5);
+        assert_eq!(p.y, -2.25);
+
+        let scalar = p.into_scalar_impl();
+        assert_eq!(
+            scalar,
+            ScalarImpl::Struct(StructValue::new(vec![
+                Some(ScalarImpl::Float64(1.5.into())),
+                Some(ScalarImpl::Float64((-2.25).into())),
+            ]))
+        );
+    }
+
+    #[test]
+    fn test_pg_point_adapter_invalid_length() {
+        let raw = vec![0u8; 15];
+        assert!(PgPointAdapter::parse_binary(&raw).is_err());
     }
 
     #[ignore]

--- a/src/connector/src/source/cdc/external/postgres.rs
+++ b/src/connector/src/source/cdc/external/postgres.rs
@@ -926,8 +926,8 @@ pub fn pg_type_to_rw_type(pg_type: &PgType) -> ConnectorResult<DataType> {
         PgType::TIME => DataType::Time,
         PgType::TIMETZ => DataType::Time,
         PgType::POINT => DataType::Struct(risingwave_common::types::StructType::new(vec![
-            ("x", DataType::Float32),
-            ("y", DataType::Float32),
+            ("x", DataType::Float64),
+            ("y", DataType::Float64),
         ])),
         PgType::TIMESTAMP => DataType::Timestamp,
         PgType::TIMESTAMPTZ => DataType::Timestamptz,


### PR DESCRIPTION
## What's changed

- map scalar PostgreSQL `point` values to `STRUCT<x DOUBLE PRECISION, y DOUBLE PRECISION>`
- replace the previous lossy `Float32` mappings with `Float64` in schema discovery and Debezium parsing
- decode PostgreSQL's native 16-byte point binary representation during snapshot/backfill reads
- restrict snapshot struct decoding to an actual PostgreSQL `POINT` column and an exact `x/y Float64` struct
- add precision-sensitive CDC coverage for explicit and inferred schemas, backfill, NULL values, INSERT, UPDATE, and automatic schema changes

## Why

Debezium emits point coordinates as `FLOAT64`, while the previous RisingWave type mapping used `Float32`. That could lose coordinate precision and also left snapshot decoding unable to handle the inferred struct representation.

This is PR 3/3 for #25517. It is independent of PRs #26622 and #26623 and is based directly on `main`.

## Validation

- complete `risingwave_cmd_all` playground build
- full 18-module Java connector build
- PostgreSQL CDC `postgres_point.slt`: passed
- connector point unit tests
- `cargo fmt --all -- --check`
- SLT coverage check
- `git diff --check`

## Scope

PostgreSQL `point[]` retains its pre-existing behavior. Debezium 3.2.4 does not implement `POINT_ARRAY` incremental schema/value conversion, so adding snapshot-only array decoding would create inconsistent backfill and streaming semantics.

Part of #25517