### PR TITLE
ci: restrict GitHub Actions token permissions

### DIFF
--- a/.github/workflows/assign-issue-milestone.yml
+++ b/.github/workflows/assign-issue-milestone.yml
@@ -1,5 +1,8 @@
 name: Assign milestone
 
+permissions:
+  issues: write
+
 on:
   issues:
     types: [opened]

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -1,4 +1,10 @@
 name: Security audit
+
+permissions:
+  checks: write
+  contents: read
+  issues: write
+
 on:
   schedule:
     - cron: '0 0 * * *'

--- a/.github/workflows/auto-create-doc-issue-by-issue.yml
+++ b/.github/workflows/auto-create-doc-issue-by-issue.yml
@@ -1,5 +1,8 @@
 name: Issue Documentation Checker
 
+permissions:
+  contents: read
+
 on:
   issues:
     types:

--- a/.github/workflows/auto-update-helm-and-operator-version-by-release.yml
+++ b/.github/workflows/auto-update-helm-and-operator-version-by-release.yml
@@ -1,5 +1,7 @@
 name: Update Helm Charts and Risingwave Operator on New Release
 
+permissions: {}
+
 on:
   release:
     types: [published]

--- a/.github/workflows/build-docker-image-on-demand-ec2.yml
+++ b/.github/workflows/build-docker-image-on-demand-ec2.yml
@@ -1,5 +1,9 @@
 # To test: gh workflow run 'Build Docker Image on On-Demand EC2' --ref kwannoel/workflow-update-branch
 name: Build Docker Image on On-Demand EC2
+
+permissions:
+  contents: read
+
 on:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -1,5 +1,9 @@
 # To test: gh workflow run 'Build Docker Image' --ref kwannoel/workflow-update-branch
 name: Build Docker Image
+
+permissions:
+  contents: read
+
 on:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/connector-node-integration.yml
+++ b/.github/workflows/connector-node-integration.yml
@@ -1,5 +1,9 @@
 name: Connector Node Integration Tests
 
+permissions:
+  contents: read
+  pull-requests: read
+
 on:
   push:
     branches: [ main ]

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -1,5 +1,8 @@
 name: "Copilot Setup Steps"
 
+permissions:
+  contents: read
+
 # Automatically run the setup steps when they are changed to allow for easy validation, and
 # allow manual testing through the repository's "Actions" tab
 on:

--- a/.github/workflows/dashboard.yml
+++ b/.github/workflows/dashboard.yml
@@ -1,4 +1,8 @@
 name: Dashboard
+
+permissions:
+  contents: write
+
 on:
   push:
     branches: [main]

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -1,5 +1,8 @@
 name: Deploy Developer Docs
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:

--- a/.github/workflows/grafana-generate-check.yml
+++ b/.github/workflows/grafana-generate-check.yml
@@ -1,5 +1,8 @@
 name: Grafana Generate Check
 
+permissions:
+  contents: read
+
 on:
   pull_request:
     branches: [main]

--- a/.github/workflows/grafana-generate-prod.yml
+++ b/.github/workflows/grafana-generate-prod.yml
@@ -1,5 +1,8 @@
 name: Grafana Generate Production Dashboard
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [main]

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,5 +1,9 @@
 name: Label PRs
 
+permissions:
+  contents: read
+  pull-requests: write
+
 on:
   pull_request:
     types: [opened, edited, synchronize]

--- a/.github/workflows/license_check.yml
+++ b/.github/workflows/license_check.yml
@@ -1,5 +1,8 @@
 name: License checker
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:

--- a/.github/workflows/nightly-rust.yml
+++ b/.github/workflows/nightly-rust.yml
@@ -1,5 +1,8 @@
 name: Build with Latest Nightly Rust
 
+permissions:
+  contents: read
+
 # Helpful to know when it does not compile.
 
 on:

--- a/.github/workflows/package_version_check.yml
+++ b/.github/workflows/package_version_check.yml
@@ -1,5 +1,8 @@
 name: Package Version Checker
 
+permissions:
+  contents: read
+
 on:
   pull_request:
     branches:

--- a/.github/workflows/pr-auto-update-with-rebase.yml
+++ b/.github/workflows/pr-auto-update-with-rebase.yml
@@ -1,5 +1,7 @@
 name: auto update branch with rebase
 
+permissions: {}
+
 on:
   push:
     branches:

--- a/.github/workflows/pr-title-checker.yml
+++ b/.github/workflows/pr-title-checker.yml
@@ -1,5 +1,9 @@
 name: PR Title Checker
 
+permissions:
+  contents: read
+  pull-requests: write
+
 on:
   pull_request:
     types: [opened, edited, labeled]

--- a/.github/workflows/protobuf-breaking.yml
+++ b/.github/workflows/protobuf-breaking.yml
@@ -1,5 +1,8 @@
 name: Protobuf Breaking Check
 
+permissions:
+  contents: read
+
 on:
   pull_request:
     branches: [main]

--- a/.github/workflows/run-perf-test.yml
+++ b/.github/workflows/run-perf-test.yml
@@ -1,4 +1,8 @@
 name: Run Perf Test
+
+permissions:
+  contents: read
+
 on:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/slt-coverage-check.yml
+++ b/.github/workflows/slt-coverage-check.yml
@@ -1,5 +1,8 @@
 name: SLT Coverage Check
 
+permissions:
+  contents: read
+
 on:
   pull_request:
     paths:

--- a/.github/workflows/trigger-homebrew-bump.yml
+++ b/.github/workflows/trigger-homebrew-bump.yml
@@ -1,5 +1,7 @@
 name: Trigger Homebrew bump
 
+permissions: {}
+
 on:
   release:
     types: [published]

--- a/.github/workflows/typo.yml
+++ b/.github/workflows/typo.yml
@@ -1,4 +1,8 @@
 name: Typo checker
+
+permissions:
+  contents: read
+
 on: [pull_request]
 
 jobs:


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

This PR resolves the open CodeQL `actions/missing-workflow-permissions` alerts by adding explicit, least-privilege `GITHUB_TOKEN` permissions to the 23 affected GitHub Actions workflows.

- Default read-only workflows now request only `contents: read`.
- Workflows that update issues, checks, pull requests, or repository contents receive only the write scopes their actions require.
- Workflows that authenticate exclusively with separate cross-repository PATs disable the default token with `permissions: {}`.
- Existing GitHub Pages deployment permissions remain scoped to the deployment job.

Previously, these workflows inherited the repository or organization defaults because they omitted a `permissions` block. Explicit scopes document their requirements and prevent a future default-permission change from granting broader access.

This is an internal CI security-hardening change and does not affect RisingWave runtime behavior.

## Validation

- Parsed all 23 changed workflows as YAML.
- Ran `actionlint` on all 23 workflows, excluding only diagnostics for the repository's known custom runner labels.
- Ran `git diff --check`.
- Verified the changed-file set exactly matches the 23 unique workflow files referenced by all 24 open alerts.

## Checklist

- [x] I have written necessary rustdoc comments.
- [x] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [x] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->

## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

Not applicable: this PR only restricts GitHub Actions token permissions.

</details>
