### PR TITLE
fix(iceberg): bump dependencies on release-3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6859,7 +6859,7 @@ dependencies = [
 [[package]]
 name = "iceberg"
 version = "0.8.0"
-source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=8f7c952f66de9b2d65c1d168eccf32a3fe291a55#8f7c952f66de9b2d65c1d168eccf32a3fe291a55"
+source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=6bd8e98fe920def857f80024f5a666c9631e80f4#6bd8e98fe920def857f80024f5a666c9631e80f4"
 dependencies = [
  "anyhow",
  "apache-avro 0.21.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -6918,7 +6918,7 @@ dependencies = [
 [[package]]
 name = "iceberg-catalog-glue"
 version = "0.8.0"
-source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=8f7c952f66de9b2d65c1d168eccf32a3fe291a55#8f7c952f66de9b2d65c1d168eccf32a3fe291a55"
+source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=6bd8e98fe920def857f80024f5a666c9631e80f4#6bd8e98fe920def857f80024f5a666c9631e80f4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6933,7 +6933,7 @@ dependencies = [
 [[package]]
 name = "iceberg-catalog-rest"
 version = "0.8.0"
-source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=8f7c952f66de9b2d65c1d168eccf32a3fe291a55#8f7c952f66de9b2d65c1d168eccf32a3fe291a55"
+source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=6bd8e98fe920def857f80024f5a666c9631e80f4#6bd8e98fe920def857f80024f5a666c9631e80f4"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -6955,7 +6955,7 @@ dependencies = [
 [[package]]
 name = "iceberg-compaction-core"
 version = "0.1.0"
-source = "git+https://github.com/nimtable/iceberg-compaction.git?rev=001be834b30f8e7d9a6c16df7aa369ab21e31505#001be834b30f8e7d9a6c16df7aa369ab21e31505"
+source = "git+https://github.com/nimtable/iceberg-compaction.git?rev=f06bdcd0a54efb73115d0a37cfcba636f0438567#f06bdcd0a54efb73115d0a37cfcba636f0438567"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -6984,7 +6984,7 @@ dependencies = [
 [[package]]
 name = "iceberg-datafusion"
 version = "0.8.0"
-source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=8f7c952f66de9b2d65c1d168eccf32a3fe291a55#8f7c952f66de9b2d65c1d168eccf32a3fe291a55"
+source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=6bd8e98fe920def857f80024f5a666c9631e80f4#6bd8e98fe920def857f80024f5a666c9631e80f4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9461,6 +9461,9 @@ dependencies = [
  "num-integer",
  "num-traits",
  "object_store",
+ "parquet-variant",
+ "parquet-variant-compute",
+ "parquet-variant-json",
  "paste",
  "seq-macro",
  "simdutf8",
@@ -9469,6 +9472,51 @@ dependencies = [
  "tokio",
  "twox-hash",
  "zstd",
+]
+
+[[package]]
+name = "parquet-variant"
+version = "58.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bf493f3c9ddd984d0efb019f67343e4aa4bab893931f6a14b82083065dc3d28"
+dependencies = [
+ "arrow-schema 58.1.0",
+ "chrono",
+ "half 2.7.1",
+ "indexmap 2.13.0",
+ "simdutf8",
+ "uuid",
+]
+
+[[package]]
+name = "parquet-variant-compute"
+version = "58.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ac038d46a503a7d563b4f5df5802c4315d5343d009feab195d15ac512b4cb27"
+dependencies = [
+ "arrow 58.1.0",
+ "arrow-schema 58.1.0",
+ "chrono",
+ "half 2.7.1",
+ "indexmap 2.13.0",
+ "parquet-variant",
+ "parquet-variant-json",
+ "serde_json",
+ "uuid",
+]
+
+[[package]]
+name = "parquet-variant-json"
+version = "58.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "015a09c2ffe5108766c7c1235c307b8a3c2ea64eca38455ba1a7f3a7f32f16e2"
+dependencies = [
+ "arrow-schema 58.1.0",
+ "base64 0.22.1",
+ "chrono",
+ "parquet-variant",
+ "serde_json",
+ "uuid",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -160,15 +160,15 @@ hashbrown0_15 = { package = "hashbrown", version = "0.15", features = [
     "nightly",
 ] }
 hytra = "0.1"
-# branch dev_rebase_main_20251111
-iceberg = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "8f7c952f66de9b2d65c1d168eccf32a3fe291a55", features = [
+# branch dev_rebase_main_20260303
+iceberg = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "6bd8e98fe920def857f80024f5a666c9631e80f4", features = [
     "storage-s3",
     "storage-gcs",
     "storage-azblob",
     "storage-azdls",
 ] }
-iceberg-catalog-glue = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "8f7c952f66de9b2d65c1d168eccf32a3fe291a55" }
-iceberg-catalog-rest = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "8f7c952f66de9b2d65c1d168eccf32a3fe291a55" }
+iceberg-catalog-glue = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "6bd8e98fe920def857f80024f5a666c9631e80f4" }
+iceberg-catalog-rest = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "6bd8e98fe920def857f80024f5a666c9631e80f4" }
 
 adbc_core = { version = "0.23" }
 adbc_snowflake = { version = "0.23", default-features = false }

--- a/src/connector/src/source/iceberg/mod.rs
+++ b/src/connector/src/source/iceberg/mod.rs
@@ -663,6 +663,7 @@ mod tests {
             start: 0,
             record_count: Some(0),
             data_file_path: format!("test_{}.parquet", id),
+            referenced_data_file: None,
             data_file_content: DataContentType::Data,
             data_file_format: iceberg::spec::DataFileFormat::Parquet,
             schema: Arc::new(Schema::builder().build().unwrap()),

--- a/src/storage/Cargo.toml
+++ b/src/storage/Cargo.toml
@@ -33,7 +33,7 @@ futures = { version = "0.3", default-features = false, features = ["alloc"] }
 futures-async-stream = { workspace = true }
 hex = "0.4"
 iceberg = { workspace = true }
-iceberg-compaction-core = { git = "https://github.com/nimtable/iceberg-compaction.git", rev = "001be834b30f8e7d9a6c16df7aa369ab21e31505" }
+iceberg-compaction-core = { git = "https://github.com/nimtable/iceberg-compaction.git", rev = "f06bdcd0a54efb73115d0a37cfcba636f0438567" }
 itertools = { workspace = true }
 libc = "0.2"
 lz4 = "1.28.0"

--- a/src/stream/src/executor/source/iceberg_fetch_executor.rs
+++ b/src/stream/src/executor/source/iceberg_fetch_executor.rs
@@ -117,6 +117,10 @@ mod state {
         /// The data file path corresponding to the task.
         pub data_file_path: String,
 
+        /// The data file referenced by a deletion vector.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        pub referenced_data_file: Option<String>,
+
         /// The content type of the file to scan.
         pub data_file_content: DataContentType,
 
@@ -166,6 +170,7 @@ mod state {
                 length,
                 record_count,
                 data_file_path,
+                referenced_data_file,
                 data_file_content,
                 data_file_format,
                 schema,
@@ -183,6 +188,7 @@ mod state {
                 length,
                 record_count,
                 data_file_path,
+                referenced_data_file,
                 data_file_content,
                 data_file_format,
                 schema,
@@ -209,6 +215,7 @@ mod state {
                 length,
                 record_count,
                 data_file_path,
+                referenced_data_file,
                 data_file_content,
                 data_file_format,
                 schema,
@@ -227,6 +234,7 @@ mod state {
                 length,
                 record_count,
                 data_file_path,
+                referenced_data_file,
                 data_file_content,
                 data_file_format,
                 schema,
@@ -249,6 +257,7 @@ mod state {
                 length: task.length,
                 record_count: task.record_count,
                 data_file_path: task.data_file_path.clone(),
+                referenced_data_file: task.referenced_data_file.clone(),
                 data_file_content: task.data_file_content,
                 data_file_format: task.data_file_format,
                 schema: task.schema.clone(),


### PR DESCRIPTION
## What changed

- Bump `iceberg`, `iceberg-catalog-glue`, and `iceberg-catalog-rest` from `8f7c952f` to `6bd8e98f`, the latest commit on `dev_rebase_main_20260303`. This includes the malformed snapshot summary panic fix from risingwavelabs/iceberg-rust#161.
- Pin `iceberg-compaction-core` to nimtable/iceberg-compaction@f06bdcd, a release-3.0-specific branch based on the existing `001be834` dependency. It only updates iceberg-rust and the affected test fixtures, avoiding unrelated compaction changes from main.
- Preserve the new `FileScanTask::referenced_data_file` field in stream state, with a serde default for backward compatibility.
- Refresh the lockfile, including the parquet Variant dependencies required by the new iceberg-rust revision.

## Verification

- `cargo +nightly-2025-10-10 check -p risingwave_connector -p risingwave_stream -p risingwave_storage --all-targets --locked`
- `cargo +nightly-2025-10-10 clippy -p risingwave_connector -p risingwave_stream -p risingwave_storage --all-targets --locked -- -D warnings`
- `cargo +nightly-2025-10-10 fmt --all -- --check`
- `git diff --check`