### PR TITLE
fix(frontend): derive scan ranges for SOME array predicates

### DIFF
--- a/src/frontend/planner_test/tests/testdata/input/index_selection.yaml
+++ b/src/frontend/planner_test/tests/testdata/input/index_selection.yaml
@@ -65,6 +65,11 @@
   expected_outputs:
   - batch_plan
 - sql: |
+    create table t1 (a int primary key, b numeric, c bigint);
+    select * from t1 where a = some(array[1::bigint])
+  expected_outputs:
+  - batch_plan
+- sql: |
     create table t1 (a int, b numeric, c bigint);
     create index idx1 on t1(a, b) include(c);
     select * from t1 where a = some('{1,2,3}')

--- a/src/frontend/planner_test/tests/testdata/input/index_selection.yaml
+++ b/src/frontend/planner_test/tests/testdata/input/index_selection.yaml
@@ -60,6 +60,17 @@
   expected_outputs:
   - batch_plan
 - sql: |
+    create table t1 (a int primary key, b numeric, c bigint);
+    select * from t1 where a = some('{1}')
+  expected_outputs:
+  - batch_plan
+- sql: |
+    create table t1 (a int, b numeric, c bigint);
+    create index idx1 on t1(a, b) include(c);
+    select * from t1 where a = some('{1,2,3}')
+  expected_outputs:
+  - batch_plan
+- sql: |
     create table t1 (a int, b numeric, c bigint);
     create index idx1 on t1(a, b) include(c);
     select * from t1 where a between 1 and 8

--- a/src/frontend/planner_test/tests/testdata/output/index_selection.yaml
+++ b/src/frontend/planner_test/tests/testdata/output/index_selection.yaml
@@ -104,6 +104,19 @@
     BatchExchange { order: [], dist: Single }
     └─BatchScan { table: idx1, columns: [idx1.a, idx1.b, idx1.c], scan_ranges: [idx1.a = Int32(1), idx1.a = Int32(2), idx1.a = Int32(3)], distribution: UpstreamHashShard(idx1.a) }
 - sql: |
+    create table t1 (a int primary key, b numeric, c bigint);
+    select * from t1 where a = some('{1}')
+  batch_plan: |-
+    BatchExchange { order: [], dist: Single }
+    └─BatchScan { table: t1, columns: [t1.a, t1.b, t1.c], scan_ranges: [t1.a = Int32(1)], distribution: UpstreamHashShard(t1.a) }
+- sql: |
+    create table t1 (a int, b numeric, c bigint);
+    create index idx1 on t1(a, b) include(c);
+    select * from t1 where a = some('{1,2,3}')
+  batch_plan: |-
+    BatchExchange { order: [], dist: Single }
+    └─BatchScan { table: idx1, columns: [idx1.a, idx1.b, idx1.c], scan_ranges: [idx1.a = Int32(1), idx1.a = Int32(2), idx1.a = Int32(3)], distribution: UpstreamHashShard(idx1.a) }
+- sql: |
     create table t1 (a int, b numeric, c bigint);
     create index idx1 on t1(a, b) include(c);
     select * from t1 where a between 1 and 8

--- a/src/frontend/planner_test/tests/testdata/output/index_selection.yaml
+++ b/src/frontend/planner_test/tests/testdata/output/index_selection.yaml
@@ -110,6 +110,12 @@
     BatchExchange { order: [], dist: Single }
     └─BatchScan { table: t1, columns: [t1.a, t1.b, t1.c], scan_ranges: [t1.a = Int32(1)], distribution: UpstreamHashShard(t1.a) }
 - sql: |
+    create table t1 (a int primary key, b numeric, c bigint);
+    select * from t1 where a = some(array[1::bigint])
+  batch_plan: |-
+    BatchExchange { order: [], dist: Single }
+    └─BatchScan { table: t1, columns: [t1.a, t1.b, t1.c], scan_ranges: [t1.a = Int32(1)], distribution: UpstreamHashShard(t1.a) }
+- sql: |
     create table t1 (a int, b numeric, c bigint);
     create index idx1 on t1(a, b) include(c);
     select * from t1 where a = some('{1,2,3}')

--- a/src/frontend/src/expr/mod.rs
+++ b/src/frontend/src/expr/mod.rs
@@ -17,7 +17,9 @@ use fixedbitset::FixedBitSet;
 use futures::FutureExt;
 use paste::paste;
 use risingwave_common::array::ListValue;
-use risingwave_common::types::{DataType, Datum, JsonbVal, MapType, Scalar, ScalarImpl};
+use risingwave_common::types::{
+    DataType, Datum, JsonbVal, MapType, Scalar, ScalarImpl, ToOwnedDatum,
+};
 use risingwave_expr::aggregate::PbAggKind;
 use risingwave_expr::expr::build_from_prost;
 use risingwave_pb::expr::expr_node::RexNode;
@@ -937,6 +939,52 @@ impl ExprImpl {
             }
 
             Some((input_ref, list.to_vec()))
+        } else {
+            None
+        }
+    }
+
+    pub fn as_some_eq_const_list(&self) -> Option<(InputRef, Vec<ExprImpl>)> {
+        if let ExprImpl::FunctionCall(function_call) = self
+            && function_call.func_type() == ExprType::Some
+        {
+            let (_, inner) = function_call.clone().decompose_as_unary();
+            let ExprImpl::FunctionCall(inner_call) = inner else {
+                return None;
+            };
+            if inner_call.func_type() != ExprType::Equal {
+                return None;
+            }
+
+            let (_, left, right) = inner_call.decompose_as_binary();
+            let (input_ref, list_expr) = match (left, right) {
+                (ExprImpl::InputRef(input_ref), list_expr) if list_expr.is_const() => {
+                    (input_ref.as_ref().clone(), list_expr)
+                }
+                (list_expr, ExprImpl::InputRef(input_ref)) if list_expr.is_const() => {
+                    (input_ref.as_ref().clone(), list_expr)
+                }
+                _ => return None,
+            };
+
+            let literal = list_expr.as_literal()?;
+            let DataType::List(list_type) = literal.return_type() else {
+                return None;
+            };
+            let list = literal
+                .get_data()
+                .as_ref()?
+                .as_list()
+                .iter()
+                .map(|datum| {
+                    ExprImpl::Literal(Box::new(Literal::new(
+                        datum.to_owned_datum(),
+                        list_type.elem().clone(),
+                    )))
+                })
+                .collect();
+
+            Some((input_ref, list))
         } else {
             None
         }

--- a/src/frontend/src/optimizer/rule/index_selection_rule.rs
+++ b/src/frontend/src/optimizer/rule/index_selection_rule.rs
@@ -400,7 +400,10 @@ impl IndexSelectionRule {
             .into_iter()
             .filter(|expr| {
                 expr.as_eq_const().is_some()
-                    || expr.as_in_const_list().is_some()
+                    || expr
+                        .as_in_const_list()
+                        .or_else(|| expr.as_some_eq_const_list())
+                        .is_some()
                     || expr.as_comparison_const().is_some()
             })
             .collect();
@@ -486,7 +489,10 @@ impl IndexSelectionRule {
             let idx = {
                 if let Some((input_ref, _const_expr)) = expr.as_eq_const() {
                     Some(input_ref.index)
-                } else if let Some((input_ref, _in_const_list)) = expr.as_in_const_list() {
+                } else if let Some((input_ref, _in_const_list)) = expr
+                    .as_in_const_list()
+                    .or_else(|| expr.as_some_eq_const_list())
+                {
                     Some(input_ref.index)
                 } else if let Some((input_ref, _op, _const_expr)) = expr.as_comparison_const() {
                     Some(input_ref.index)
@@ -867,7 +873,9 @@ impl<'a> TableScanIoEstimator<'a> {
 
         // In
         for (i, expr) in conjunctions.iter().enumerate() {
-            if let Some((input_ref, in_const_list)) = expr.as_in_const_list()
+            if let Some((input_ref, in_const_list)) = expr
+                .as_in_const_list()
+                .or_else(|| expr.as_some_eq_const_list())
                 && input_ref.index == column_idx
             {
                 conjunctions.remove(i);

--- a/src/frontend/src/utils/condition.rs
+++ b/src/frontend/src/utils/condition.rs
@@ -889,7 +889,10 @@ impl Condition {
                     return Ok(None);
                 }
                 eq_conds = vec![None];
-            } else if let Some((input_ref, in_const_list)) = expr.as_in_const_list() {
+            } else if let Some((input_ref, in_const_list)) = expr
+                .as_in_const_list()
+                .or_else(|| expr.as_some_eq_const_list())
+            {
                 let mut scalars = HashSet::new();
                 for const_expr in in_const_list {
                     // The cast should succeed, because otherwise the input_ref is casted

--- a/src/frontend/src/utils/condition.rs
+++ b/src/frontend/src/utils/condition.rs
@@ -857,7 +857,7 @@ impl Condition {
         let mut other_conds = vec![];
 
         // analyze exprs in the group. scan_range is not updated
-        for expr in group {
+        'group_loop: for expr in group {
             if let Some((input_ref, const_expr)) = expr.as_eq_const() {
                 let new_expr = if let Ok(expr) =
                     const_expr.clone().cast_implicit(&input_ref.data_type)
@@ -895,10 +895,26 @@ impl Condition {
             {
                 let mut scalars = HashSet::new();
                 for const_expr in in_const_list {
-                    // The cast should succeed, because otherwise the input_ref is casted
-                    // and thus `as_in_const_list` returns None.
-                    let const_expr = const_expr.cast_implicit(&input_ref.data_type).unwrap();
-                    let value = const_expr.fold_const()?;
+                    let new_expr =
+                        if let Ok(expr) = const_expr.clone().cast_implicit(&input_ref.data_type) {
+                            expr
+                        } else {
+                            match self::cast_compare::cast_compare_for_eq(
+                                const_expr,
+                                input_ref.data_type.clone(),
+                            ) {
+                                Ok(ResultForEq::Success(expr)) => expr,
+                                Ok(ResultForEq::NeverEqual) => {
+                                    continue;
+                                }
+                                Err(_) => {
+                                    other_conds.push(expr);
+                                    continue 'group_loop;
+                                }
+                            }
+                        };
+
+                    let value = new_expr.fold_const()?;
                     let Some(value) = value else {
                         continue;
                     };


### PR DESCRIPTION
## Summary
Fix the issue where point select degrades to full table scan:
```
explain SELECT
    the_pk,
    ...
FROM
    some_table
WHERE
    the_pk = SOME('{315945938209194116}');
                                                                                                                                                QUERY PLAN
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 BatchExchange { order: [], dist: Single }
 └─BatchProject { exprs: [some_table.the_pk, ...] }
   └─BatchFilter { predicate: Some((some_table.the_pk = ARRAY[315945938209194116]:List(Int64))) }
     └─BatchScan { table: some_table, columns: [the_pk, ...] }
(4 rows)
```


- recognize `input_ref = SOME(const_array)` as an equality-list predicate
- reuse existing scan-range extraction for table scans and index selection
- add planner regressions for primary-key and index-backed `SOME` queries

## Tests
- `cargo check -p risingwave_frontend`
- `./risedev run-planner-test index_selection`
- `git diff --check`