### PR TITLE
fix(risedev): skip unnecessary pgpass lookup

### DIFF
--- a/src/risedevtool/src/bin/risedev-dev.rs
+++ b/src/risedevtool/src/bin/risedev-dev.rs
@@ -326,7 +326,7 @@ fn task_main(
                 ServiceConfig::Postgres(c) => {
                     PostgresService::new(c.clone()).execute(&mut ctx)?;
                     let mut task = risedev::DbReadyCheckTask::new(
-                        PgConnectOptions::new()
+                        PgConnectOptions::new_without_pgpass()
                             .host(&c.address)
                             .port(c.port)
                             .database("template1")

--- a/src/risedevtool/src/task/lakekeeper_service.rs
+++ b/src/risedevtool/src/task/lakekeeper_service.rs
@@ -102,7 +102,7 @@ impl LakekeeperService {
             rt.block_on(async move {
                 use sqlx::postgres::*;
                 use tokio::time::{sleep, Duration};
-                let options = PgConnectOptions::new()
+                let options = PgConnectOptions::new_without_pgpass()
                     .host(&host)
                     .port(port)
                     .username(&username)


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What changed and what is the intention?

- Use `PgConnectOptions::new_without_pgpass()` for the managed PostgreSQL readiness check and Lakekeeper database initialization.
- Both paths always provide an explicit password, so probing `~/.pgpass` is unnecessary and emits misleading warnings when the file does not exist.
- Keep the existing host, port, database, username, password, and TLS configuration unchanged.

## Tests

- `cargo +nightly-2026-06-11 check --locked -p risedev --all-targets`
- `cargo +nightly-2026-06-11 test --locked -p risedev --lib`
- `cargo +nightly-2026-06-11 fmt --all -- --check`
- `cargo sort --check --workspace --grouped`
- `git diff --check`

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] I have added necessary unit tests and integration tests.
- [x] I have evaluated test labels; default PR check and unit-test coverage are sufficient for this narrow risedev-only change.
- [ ] My PR contains breaking changes.

## Documentation

- [ ] My PR needs documentation updates.