### PR TITLE
fix(meta): tolerate exactly-once metadata cleanup during sink drop

### DIFF
--- a/ci/workflows/main-cron.yml
+++ b/ci/workflows/main-cron.yml
@@ -981,7 +981,7 @@ steps:
           <<: *docker-compose
           run: sink-test-env
       - ./ci/plugins/upload-failure-logs
-    timeout_in_minutes: 10
+    timeout_in_minutes: 20
     retry: *auto-retry
 
   - label: "end-to-end redis sink test"

--- a/ci/workflows/pull-request.yml
+++ b/ci/workflows/pull-request.yml
@@ -566,7 +566,7 @@ steps:
           <<: *docker-compose
           run: sink-test-env
       - ./ci/plugins/upload-failure-logs
-    timeout_in_minutes: 10
+    timeout_in_minutes: 20
     retry: *auto-retry
 
   - label: "end-to-end redis sink test"

--- a/src/meta/src/manager/exactly_once_util.rs
+++ b/src/meta/src/manager/exactly_once_util.rs
@@ -12,17 +12,31 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use risingwave_meta_model::pending_sink_state::{self};
-use risingwave_meta_model::{Epoch, SinkId, SinkSchemachange};
+use risingwave_meta_model::{
+    Epoch, ObjectId, SinkId, SinkSchemachange, object, pending_sink_state,
+};
 use risingwave_pb::stream_plan::PbSinkSchemaChange;
 use sea_orm::{
-    ColumnTrait, DatabaseConnection, EntityTrait, Order, QueryFilter, QueryOrder, QuerySelect, Set,
-    TransactionTrait,
+    ColumnTrait, ConnectionTrait, DatabaseConnection, EntityTrait, Order, QueryFilter, QueryOrder,
+    QuerySelect, Set, TransactionTrait,
 };
 use thiserror_ext::AsReport;
 
 // Helpers for accessing the `pending_sink_state` system table used by exactly-once sink coordinators
 // (both the generic sink coordinator and the Iceberg pk-index sink coordinator).
+
+async fn sink_object_exists<C: ConnectionTrait>(
+    db: &C,
+    sink_id: SinkId,
+) -> Result<bool, sea_orm::DbErr> {
+    let object_id: Option<ObjectId> = object::Entity::find_by_id(sink_id.as_object_id())
+        .select_only()
+        .column(object::Column::Oid)
+        .into_tuple()
+        .one(db)
+        .await?;
+    Ok(object_id.is_some())
+}
 
 pub async fn persist_pre_commit_metadata(
     db: &DatabaseConnection,
@@ -45,6 +59,19 @@ pub async fn persist_pre_commit_metadata(
     match pending_sink_state::Entity::insert(m).exec(db).await {
         Ok(_) => Ok(()),
         Err(e) => {
+            // `DROP SINK` currently removes the catalog object before the stop barrier reaches
+            // the sink actor. A commit request already in flight can therefore race with the
+            // cascading deletion of `pending_sink_state`. Once the object is gone there is no
+            // state to recover, so let the request finish instead of failing the actor and the
+            // whole database. Other insert errors must still be surfaced.
+            if !sink_object_exists(db, sink_id).await? {
+                tracing::debug!(
+                    %sink_id,
+                    epoch,
+                    "skip persisting exactly-once metadata for a dropped sink"
+                );
+                return Ok(());
+            }
             tracing::error!(
                 "Error inserting into exactly once system table: {:?}",
                 e.as_report()
@@ -64,14 +91,30 @@ pub async fn commit_and_prune_epoch(
         "injected: iceberg_v3_commit_prune_fail"
     )));
     let txn = db.begin().await?;
-    pending_sink_state::Entity::update(pending_sink_state::ActiveModel {
+    let update_result = pending_sink_state::Entity::update(pending_sink_state::ActiveModel {
         sink_id: Set(sink_id),
         epoch: Set(epoch as Epoch),
         sink_state: Set(pending_sink_state::SinkState::Committed),
         ..Default::default()
     })
     .exec(&txn)
-    .await?;
+    .await;
+
+    if let Err(e) = update_result {
+        // The row may have been cascade-deleted while an external two-phase commit was in
+        // progress. Roll back before checking through `db`: PostgreSQL leaves a transaction in
+        // an aborted state after a statement error.
+        txn.rollback().await?;
+        if !sink_object_exists(db, sink_id).await? {
+            tracing::debug!(
+                %sink_id,
+                epoch,
+                "skip marking exactly-once metadata committed for a dropped sink"
+            );
+            return Ok(());
+        }
+        return Err(e.into());
+    }
 
     if let Some(prev_epoch) = prev_epoch {
         pending_sink_state::Entity::delete_many()
@@ -171,4 +214,102 @@ pub async fn list_sink_states_ordered_by_epoch(
             )
         })
         .collect())
+}
+
+#[cfg(test)]
+mod tests {
+    use sea_orm::{ConnectionTrait, Database, DatabaseConnection, DbBackend, Statement};
+
+    use super::{commit_and_prune_epoch, persist_pre_commit_metadata};
+
+    async fn prepare_db() -> DatabaseConnection {
+        let db = Database::connect("sqlite::memory:").await.unwrap();
+        for ddl in [
+            "PRAGMA foreign_keys = ON",
+            "CREATE TABLE object (oid INTEGER PRIMARY KEY)",
+            "CREATE TABLE pending_sink_state (\
+                sink_id INTEGER NOT NULL, \
+                epoch BIGINT NOT NULL, \
+                sink_state STRING NOT NULL, \
+                metadata BLOB, \
+                schema_change BLOB, \
+                PRIMARY KEY (sink_id, epoch), \
+                FOREIGN KEY (sink_id) REFERENCES object(oid) ON DELETE CASCADE\
+            )",
+        ] {
+            db.execute(Statement::from_string(DbBackend::Sqlite, ddl))
+                .await
+                .unwrap();
+        }
+        db
+    }
+
+    async fn insert_object(db: &DatabaseConnection, sink_id: i32) {
+        db.execute(Statement::from_sql_and_values(
+            DbBackend::Sqlite,
+            "INSERT INTO object (oid) VALUES (?)",
+            [sink_id.into()],
+        ))
+        .await
+        .unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_exactly_once_metadata_writes_ignore_dropped_sink() {
+        let db = prepare_db().await;
+        insert_object(&db, 1).await;
+
+        persist_pre_commit_metadata(&db, 1.into(), 100, Some(vec![1, 2, 3]), None)
+            .await
+            .unwrap();
+        db.execute(Statement::from_string(
+            DbBackend::Sqlite,
+            "DELETE FROM object WHERE oid = 1",
+        ))
+        .await
+        .unwrap();
+
+        // The first row was cascade-deleted while the coordinator was committing it, and a new
+        // pre-commit request arrived after the parent object was removed. Both are expected
+        // during `DROP SINK` and must not fail the sink actor.
+        commit_and_prune_epoch(&db, 1.into(), 100, None)
+            .await
+            .unwrap();
+        persist_pre_commit_metadata(&db, 1.into(), 101, Some(vec![4, 5, 6]), None)
+            .await
+            .unwrap();
+
+        let row_count = db
+            .query_one(Statement::from_string(
+                DbBackend::Sqlite,
+                "SELECT COUNT(*) AS count FROM pending_sink_state",
+            ))
+            .await
+            .unwrap()
+            .unwrap()
+            .try_get::<i64>("", "count")
+            .unwrap();
+        assert_eq!(row_count, 0);
+    }
+
+    #[tokio::test]
+    async fn test_missing_state_is_error_for_existing_sink() {
+        let db = prepare_db().await;
+        insert_object(&db, 1).await;
+
+        assert!(
+            commit_and_prune_epoch(&db, 1.into(), 100, None)
+                .await
+                .is_err()
+        );
+
+        persist_pre_commit_metadata(&db, 1.into(), 101, None, None)
+            .await
+            .unwrap();
+        assert!(
+            persist_pre_commit_metadata(&db, 1.into(), 101, None, None)
+                .await
+                .is_err()
+        );
+    }
 }


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What changed and what is the intention?

Delta Lake exactly-once sinks can race with `DROP SINK`: catalog deletion removes the parent object and cascade-deletes `pending_sink_state` before the stop barrier reaches the sink actor. An in-flight coordinator request then fails its metadata insert or committed-state update with a foreign-key or record-not-found error. That RPC failure terminates the sink actor and, when recovery is disabled, causes the barrier worker to fail fast.

This change treats those two metadata errors as successful cleanup only after verifying that the sink object no longer exists. Errors remain unchanged while the object exists, including duplicate epochs and unexpectedly missing state. The commit path rolls back its transaction before checking the object so this also works with PostgreSQL aborted-transaction semantics.

The barrier recovery-disabled panic is intentionally unchanged: it should still report real actor failures.

Reproduced from main-cron builds 9777, 9775, and 9772, in `e2e_test/sink/deltalake_rust_sink.slt` while dropping the exactly-once sink.

## Checklist

- [x] I have added unit tests for both post-drop race windows.
- [x] Existing sink coordinator tests pass.
- [x] `cargo clippy -p risingwave_meta --lib --tests -- -D warnings` passes.
- [x] I will run the Delta Lake sink E2E test through the dedicated CI label.

## Documentation

- [ ] My PR needs documentation updates.