### PR TITLE
fix(source): nack uncommitted Pub/Sub messages on recovery

### DIFF
--- a/src/connector/Cargo.toml
+++ b/src/connector/Cargo.toml
@@ -26,11 +26,11 @@ source-adbc_snowflake = ["dep:adbc_core", "dep:adbc_snowflake"]
 sink-bigquery = [
     "dep:gcp-bigquery-client",
     "dep:google-cloud-bigquery",
-    "dep:google-cloud-googleapis",
+    "google-cloud-googleapis/bigquery",
 ]
 sink-deltalake = ["dep:deltalake"]
 # TODO: pubsub source is not feature-gated, thus `google-cloud-pubsub` cannot be optional.
-sink-google_pubsub = ["dep:google-cloud-googleapis"]
+sink-google_pubsub = []
 sink-clickhouse = ["dep:clickhouse"]
 sink-doris = []
 sink-starrocks = []
@@ -86,8 +86,7 @@ google-cloud-bigquery = { package = "gcloud-bigquery", version = "1.6", features
 google-cloud-gax = { package = "gcloud-gax", version = "1" }
 google-cloud-googleapis = { package = "gcloud-googleapis", version = "1", features = [
     "pubsub",
-    "bigquery",
-], optional = true }
+] }
 google-cloud-pubsub = { package = "gcloud-pubsub", version = "1.5" }
 iceberg = { workspace = true }
 iceberg-catalog-glue = { workspace = true }

--- a/src/connector/src/source/mod.rs
+++ b/src/connector/src/source/mod.rs
@@ -66,6 +66,8 @@ use std::time::Duration;
 pub use base::{UPSTREAM_SOURCE_KEY, WEBHOOK_CONNECTOR, *};
 pub use batch::BatchSourceSplitImpl;
 pub(crate) use common::*;
+#[cfg(not(madsim))]
+use google_cloud_googleapis::pubsub::v1::ModifyAckDeadlineRequest;
 use google_cloud_pubsub::subscription::Subscription;
 pub use google_pubsub::GOOGLE_PUBSUB_CONNECTOR;
 pub use kafka::KAFKA_CONNECTOR;
@@ -131,6 +133,73 @@ pub enum WaitCheckpointTask {
     AckPulsarMessage(Vec<(String, ArrayRef)>),
 }
 
+#[cfg(not(madsim))]
+const PUBSUB_RPC_TIMEOUT: Duration = Duration::from_secs(30);
+#[cfg(not(madsim))]
+const MAX_PUBSUB_NACK_BATCH_SIZE: usize = 100;
+
+#[cfg(any(not(madsim), test))]
+fn collect_pubsub_ack_ids(ack_id_arrs: &[ArrayRef]) -> Vec<String> {
+    ack_id_arrs
+        .iter()
+        .flat_map(|arr| arr.as_utf8().iter().flatten().map(str::to_owned))
+        .collect()
+}
+
+#[cfg(not(madsim))]
+async fn nack_pubsub_messages(
+    subscription: &Subscription,
+    ack_ids: Vec<String>,
+    source_id_label: &str,
+    source_name: &str,
+) {
+    if ack_ids.is_empty() {
+        return;
+    }
+
+    let ack_id_count = ack_ids.len();
+    for ack_ids in ack_ids.chunks(MAX_PUBSUB_NACK_BATCH_SIZE) {
+        let request = ModifyAckDeadlineRequest {
+            subscription: subscription.fully_qualified_name().to_owned(),
+            ack_deadline_seconds: 0,
+            ack_ids: ack_ids.to_vec(),
+        };
+
+        match tokio::time::timeout(
+            PUBSUB_RPC_TIMEOUT,
+            subscription.get_client().modify_ack_deadline(request, None),
+        )
+        .await
+        {
+            Ok(Ok(_)) => {}
+            Ok(Err(e)) => {
+                tracing::error!(
+                    source_id = source_id_label,
+                    source_name,
+                    error = %e.as_report(),
+                    "failed to nack uncommitted pubsub messages",
+                );
+                return;
+            }
+            Err(_) => {
+                tracing::error!(
+                    source_id = source_id_label,
+                    source_name,
+                    "pubsub nack timed out after {PUBSUB_RPC_TIMEOUT:?}",
+                );
+                return;
+            }
+        }
+    }
+
+    tracing::info!(
+        source_id = source_id_label,
+        source_name,
+        ack_id_count,
+        "nacked uncommitted pubsub messages",
+    );
+}
+
 impl WaitCheckpointTask {
     /// Create a fresh task for the next epoch, reusing expensive-to-create clients
     /// (e.g. `PubSub` `Subscription`, NATS `JetStreamContext`) from the current task.
@@ -146,6 +215,19 @@ impl WaitCheckpointTask {
             }
             WaitCheckpointTask::AckPulsarMessage(_) => WaitCheckpointTask::AckPulsarMessage(vec![]),
         }
+    }
+
+    #[cfg(not(madsim))]
+    pub async fn nack_uncommitted_pubsub_messages(&self, source_id: SourceId, source_name: &str) {
+        let WaitCheckpointTask::AckPubsubMessage(subscription, ack_id_arrs) = self else {
+            return;
+        };
+        let ack_ids = collect_pubsub_ack_ids(ack_id_arrs);
+        nack_pubsub_messages(subscription, ack_ids, &source_id.to_string(), source_name).await;
+    }
+
+    #[cfg(madsim)]
+    pub async fn nack_uncommitted_pubsub_messages(&self, _source_id: SourceId, _source_name: &str) {
     }
 
     pub async fn run(self, source_id: SourceId, source_name: &str) {
@@ -411,4 +493,24 @@ pub type CdcTableSnapshotSplitRaw = CdcTableSnapshotSplitCommon<Vec<u8>>;
 #[inline]
 pub fn build_pulsar_ack_channel_id(source_id: SourceId, split_id: &SplitId) -> String {
     format!("{}-{}", source_id, split_id)
+}
+
+#[cfg(test)]
+mod tests {
+    use risingwave_common::array::Utf8Array;
+
+    use super::*;
+
+    #[test]
+    fn test_collect_pubsub_ack_ids() {
+        let ack_id_arrs = vec![
+            Utf8Array::from_iter([Some("ack-1"), None, Some("ack-2")]).into_ref(),
+            Utf8Array::from_iter([Some("ack-3")]).into_ref(),
+        ];
+
+        assert_eq!(
+            collect_pubsub_ack_ids(&ack_id_arrs),
+            ["ack-1", "ack-2", "ack-3"],
+        );
+    }
 }

--- a/src/stream/src/executor/source/source_executor.rs
+++ b/src/stream/src/executor/source/source_executor.rs
@@ -1108,8 +1108,13 @@ impl<S: StateStore> Debug for SourceExecutor<S> {
     }
 }
 
+enum WaitCheckpointWorkerEvent {
+    Checkpoint(Epoch, WaitCheckpointTask),
+    Abort(WaitCheckpointTask),
+}
+
 struct WaitCheckpointTaskBuilder {
-    wait_checkpoint_tx: UnboundedSender<(Epoch, WaitCheckpointTask)>,
+    wait_checkpoint_tx: UnboundedSender<WaitCheckpointWorkerEvent>,
     building_task: WaitCheckpointTask,
 }
 
@@ -1159,8 +1164,21 @@ impl WaitCheckpointTaskBuilder {
     fn send(&mut self, epoch: Epoch) {
         let new_task = self.building_task.reset_for_next_epoch();
         self.wait_checkpoint_tx
-            .send((epoch, std::mem::replace(&mut self.building_task, new_task)))
+            .send(WaitCheckpointWorkerEvent::Checkpoint(
+                epoch,
+                std::mem::replace(&mut self.building_task, new_task),
+            ))
             .expect("wait_checkpoint_tx send should succeed");
+    }
+}
+
+impl Drop for WaitCheckpointTaskBuilder {
+    fn drop(&mut self) {
+        let new_task = self.building_task.reset_for_next_epoch();
+        let task = std::mem::replace(&mut self.building_task, new_task);
+        let _ = self
+            .wait_checkpoint_tx
+            .send(WaitCheckpointWorkerEvent::Abort(task));
     }
 }
 
@@ -1190,7 +1208,7 @@ impl WaitCheckpointTaskBuilder {
 ///
 /// See also <https://cloud.google.com/pubsub/docs/subscribe-best-practices#process-messages>
 struct WaitCheckpointWorker<S: StateStore> {
-    wait_checkpoint_rx: UnboundedReceiver<(Epoch, WaitCheckpointTask)>,
+    wait_checkpoint_rx: UnboundedReceiver<WaitCheckpointWorkerEvent>,
     state_store: S,
     table_id: TableId,
     source_id: SourceId,
@@ -1204,7 +1222,11 @@ impl<S: StateStore> WaitCheckpointWorker<S> {
         loop {
             // poll the rx and wait for the epoch commit
             match self.wait_checkpoint_rx.recv().await {
-                Some((epoch, task)) => {
+                Some(WaitCheckpointWorkerEvent::Abort(task)) => {
+                    task.nack_uncommitted_pubsub_messages(self.source_id, &self.source_name)
+                        .await;
+                }
+                Some(WaitCheckpointWorkerEvent::Checkpoint(epoch, task)) => {
                     tracing::debug!("start to wait epoch {}", epoch.0);
                     let ret = self
                         .state_store
@@ -1220,6 +1242,17 @@ impl<S: StateStore> WaitCheckpointWorker<S> {
                         // The wait_checkpoint_rx lifetime is tied to the lifecycle of the source executor actor.
                         // The old actor must be dropped before any subsequent recovery can succeed; see PartialGraphState::abort_and_wait_actors
                         tracing::debug!(epoch = epoch.0, "Drop stale wait checkpoint task.");
+                        task.nack_uncommitted_pubsub_messages(self.source_id, &self.source_name)
+                            .await;
+                        while let Ok(stale_event) = self.wait_checkpoint_rx.try_recv() {
+                            let stale_task = match stale_event {
+                                WaitCheckpointWorkerEvent::Checkpoint(_, task)
+                                | WaitCheckpointWorkerEvent::Abort(task) => task,
+                            };
+                            stale_task
+                                .nack_uncommitted_pubsub_messages(self.source_id, &self.source_name)
+                                .await;
+                        }
                         break;
                     }
                     match ret {
@@ -1256,6 +1289,11 @@ impl<S: StateStore> WaitCheckpointWorker<S> {
                             error = %e.as_report(),
                             "wait epoch {} failed", epoch.0
                             );
+                            task.nack_uncommitted_pubsub_messages(
+                                self.source_id,
+                                &self.source_name,
+                            )
+                            .await;
                         }
                     }
                 }
@@ -1290,6 +1328,22 @@ mod tests {
     use crate::task::LocalBarrierManager;
 
     const MOCK_SOURCE_NAME: &str = "mock_source";
+
+    #[test]
+    fn test_wait_checkpoint_builder_sends_abort_task_on_drop() {
+        let (wait_checkpoint_tx, mut wait_checkpoint_rx) = unbounded_channel();
+        let task_builder = WaitCheckpointTaskBuilder {
+            wait_checkpoint_tx,
+            building_task: WaitCheckpointTask::CommitCdcOffset(None),
+        };
+
+        drop(task_builder);
+
+        assert!(matches!(
+            wait_checkpoint_rx.try_recv().unwrap(),
+            WaitCheckpointWorkerEvent::Abort(WaitCheckpointTask::CommitCdcOffset(None)),
+        ));
+    }
 
     #[tokio::test]
     async fn test_source_executor() {


### PR DESCRIPTION
## What changed

- Send the unfinished Pub/Sub checkpoint task to the existing checkpoint worker when a source actor exits.
- Set the ack deadline of all delivered but uncommitted messages to zero, in batches, so Pub/Sub immediately redelivers them after recovery.
- Apply the same cleanup to stale checkpoint tasks and epoch-wait failures.

## Root cause

In main-cron #9777, all 10 messages were delivered before RECOVER. The gcloud stream disposal then reported zero buffered messages because the ack IDs had already moved into RisingWave WaitCheckpointTaskBuilder. Since the test intentionally had no checkpoint, actor recovery dropped that builder and lost all 10 ack IDs without acking or nacking them. Four replacement readers started normally, but the emulator redelivered only one message and kept the other nine outstanding.

Split discovery, actor restart, and barrier progress were healthy. Explicitly nacking the uncommitted ack IDs removes the dependency on ack-deadline expiry and emulator redelivery timing.

Failure: https://buildkite.com/risingwavelabs/main-cron/builds/9777#019fe8f8-facc-4597-9bec-b803bcba3f17

## Tests

- cargo test -p risingwave_connector source::tests::test_collect_pubsub_ack_ids --lib
- CARGO_INCREMENTAL=0 cargo test -p risingwave_stream test_wait_checkpoint_builder_sends_abort_task_on_drop --lib
- CARGO_INCREMENTAL=0 cargo check -p risingwave_connector -p risingwave_stream
- CARGO_INCREMENTAL=0 cargo clippy -p risingwave_connector -p risingwave_stream --lib --all-features -- -D warnings
- cargo fmt --all -- --check
- git diff --check