### PR TITLE
fix(iceberg): bump dependencies for operator caching on release-3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6859,7 +6859,7 @@ dependencies = [
 [[package]]
 name = "iceberg"
 version = "0.8.0"
-source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=6bd8e98fe920def857f80024f5a666c9631e80f4#6bd8e98fe920def857f80024f5a666c9631e80f4"
+source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=deb4a3c8d5277b76d60f43ecaf6d598b0de50873#deb4a3c8d5277b76d60f43ecaf6d598b0de50873"
 dependencies = [
  "anyhow",
  "apache-avro 0.21.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -6918,7 +6918,7 @@ dependencies = [
 [[package]]
 name = "iceberg-catalog-glue"
 version = "0.8.0"
-source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=6bd8e98fe920def857f80024f5a666c9631e80f4#6bd8e98fe920def857f80024f5a666c9631e80f4"
+source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=deb4a3c8d5277b76d60f43ecaf6d598b0de50873#deb4a3c8d5277b76d60f43ecaf6d598b0de50873"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6933,7 +6933,7 @@ dependencies = [
 [[package]]
 name = "iceberg-catalog-rest"
 version = "0.8.0"
-source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=6bd8e98fe920def857f80024f5a666c9631e80f4#6bd8e98fe920def857f80024f5a666c9631e80f4"
+source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=deb4a3c8d5277b76d60f43ecaf6d598b0de50873#deb4a3c8d5277b76d60f43ecaf6d598b0de50873"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -6955,7 +6955,7 @@ dependencies = [
 [[package]]
 name = "iceberg-compaction-core"
 version = "0.1.0"
-source = "git+https://github.com/nimtable/iceberg-compaction.git?rev=f06bdcd0a54efb73115d0a37cfcba636f0438567#f06bdcd0a54efb73115d0a37cfcba636f0438567"
+source = "git+https://github.com/nimtable/iceberg-compaction.git?rev=22078f205d3c841f1e02118adfe5fc869d90d38c#22078f205d3c841f1e02118adfe5fc869d90d38c"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -6984,7 +6984,7 @@ dependencies = [
 [[package]]
 name = "iceberg-datafusion"
 version = "0.8.0"
-source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=6bd8e98fe920def857f80024f5a666c9631e80f4#6bd8e98fe920def857f80024f5a666c9631e80f4"
+source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=deb4a3c8d5277b76d60f43ecaf6d598b0de50873#deb4a3c8d5277b76d60f43ecaf6d598b0de50873"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -161,14 +161,14 @@ hashbrown0_15 = { package = "hashbrown", version = "0.15", features = [
 ] }
 hytra = "0.1"
 # branch dev_rebase_main_20260303
-iceberg = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "6bd8e98fe920def857f80024f5a666c9631e80f4", features = [
+iceberg = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "deb4a3c8d5277b76d60f43ecaf6d598b0de50873", features = [
     "storage-s3",
     "storage-gcs",
     "storage-azblob",
     "storage-azdls",
 ] }
-iceberg-catalog-glue = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "6bd8e98fe920def857f80024f5a666c9631e80f4" }
-iceberg-catalog-rest = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "6bd8e98fe920def857f80024f5a666c9631e80f4" }
+iceberg-catalog-glue = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "deb4a3c8d5277b76d60f43ecaf6d598b0de50873" }
+iceberg-catalog-rest = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "deb4a3c8d5277b76d60f43ecaf6d598b0de50873" }
 
 adbc_core = { version = "0.23" }
 adbc_snowflake = { version = "0.23", default-features = false }

--- a/src/storage/Cargo.toml
+++ b/src/storage/Cargo.toml
@@ -33,7 +33,7 @@ futures = { version = "0.3", default-features = false, features = ["alloc"] }
 futures-async-stream = { workspace = true }
 hex = "0.4"
 iceberg = { workspace = true }
-iceberg-compaction-core = { git = "https://github.com/nimtable/iceberg-compaction.git", rev = "f06bdcd0a54efb73115d0a37cfcba636f0438567" }
+iceberg-compaction-core = { git = "https://github.com/nimtable/iceberg-compaction.git", rev = "22078f205d3c841f1e02118adfe5fc869d90d38c" }
 itertools = { workspace = true }
 libc = "0.2"
 lz4 = "1.28.0"


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

- Pin `iceberg`, `iceberg-catalog-glue`, and `iceberg-catalog-rest` to `deb4a3c8`, the merge commit of risingwavelabs/iceberg-rust#208 on `dev_rebase_main_20260303`.
- The upstream fix caches S3 and GCS OpenDAL operators by bucket so credential and token loaders are reused instead of rebuilt for each file operation.
- Pin `iceberg-compaction-core` to nimtable/iceberg-compaction@`22078f2`. It is a one-commit child of the release-3.0 baseline `f06bdcd` from #26628 and only bumps iceberg-rust.
- Refresh only the corresponding git source anchors in `Cargo.lock`.

Related to #25921.

## Verification

- `cargo +nightly-2025-10-10 check --locked -p risingwave_storage`
- `cargo +nightly-2025-10-10 clippy --locked -p risingwave_connector -p risingwave_storage -- -D warnings`
- `cargo +nightly-2025-10-10 fmt --all -- --check`
- `git diff --check`
- iceberg-compaction: `cargo check --locked --workspace --all-targets --all-features`
- iceberg-compaction: `make check`
- iceberg-compaction: `make unit-test` (119 passed)

## Checklist

- [x] I have added test labels as necessary.
- [x] I have checked the release branch target for this fix.
- [ ] My PR contains breaking changes.

## Documentation

- [x] My PR needs release-note coverage for this operational fix.

<details>
<summary><b>Release note</b></summary>

Iceberg S3 and GCS access now reuses OpenDAL operators per bucket. This avoids rebuilding credential and token loaders for every file operation and substantially reduces repeated STS calls for IRSA-backed S3 deployments.

</details>
