### PR TITLE
perf(meta): summarize time travel version epochs

### DIFF
--- a/src/meta/model/migration/src/lib.rs
+++ b/src/meta/model/migration/src/lib.rs
@@ -75,6 +75,7 @@ mod m20260519_000000_streaming_job_batch_refresh_seconds;
 mod m20260624_000000_pending_sink_state_object_fk;
 mod m20260705_000000_subscription_dependent_object_fk;
 mod m20260804_000000_worker_property_resource;
+mod m20260811_000000_hummock_time_travel_version_epoch_summary;
 mod utils;
 
 pub struct Migrator;
@@ -188,6 +189,7 @@ impl MigratorTrait for Migrator {
             Box::new(m20260624_000000_pending_sink_state_object_fk::Migration),
             Box::new(m20260705_000000_subscription_dependent_object_fk::Migration),
             Box::new(m20260804_000000_worker_property_resource::Migration),
+            Box::new(m20260811_000000_hummock_time_travel_version_epoch_summary::Migration),
         ]
     }
 }

--- a/src/meta/model/migration/src/m20260811_000000_hummock_time_travel_version_epoch_summary.rs
+++ b/src/meta/model/migration/src/m20260811_000000_hummock_time_travel_version_epoch_summary.rs
@@ -1,0 +1,64 @@
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+const TABLE_NAME: &str = "hummock_time_travel_version_epoch_summary";
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .create_table(
+                Table::create()
+                    .table(HummockTimeTravelVersionEpochSummary::Table)
+                    .if_not_exists()
+                    .col(
+                        ColumnDef::new(HummockTimeTravelVersionEpochSummary::VersionId)
+                            .big_integer()
+                            .not_null()
+                            .primary_key(),
+                    )
+                    .col(
+                        ColumnDef::new(HummockTimeTravelVersionEpochSummary::MaxEpoch)
+                            .big_integer()
+                            .not_null(),
+                    )
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
+            .get_connection()
+            .execute(sea_orm::Statement::from_string(
+                manager.get_database_backend(),
+                format!(
+                    "INSERT INTO {TABLE_NAME} (version_id, max_epoch) \
+                     SELECT version_id, MAX(epoch) FROM hummock_epoch_to_version GROUP BY version_id"
+                ),
+            ))
+            .await?;
+
+        Ok(())
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .drop_table(
+                Table::drop()
+                    .table(HummockTimeTravelVersionEpochSummary::Table)
+                    .if_exists()
+                    .cascade()
+                    .to_owned(),
+            )
+            .await?;
+        Ok(())
+    }
+}
+
+#[derive(DeriveIden)]
+enum HummockTimeTravelVersionEpochSummary {
+    Table,
+    VersionId,
+    MaxEpoch,
+}

--- a/src/meta/model/src/hummock_time_travel_version_epoch_summary.rs
+++ b/src/meta/model/src/hummock_time_travel_version_epoch_summary.rs
@@ -1,0 +1,31 @@
+// Copyright 2026 RisingWave Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use sea_orm::entity::prelude::*;
+use sea_orm::{DeriveEntityModel, DeriveRelation, EnumIter};
+
+use crate::{Epoch, HummockVersionId};
+
+#[derive(Clone, Debug, PartialEq, DeriveEntityModel, Eq, Default)]
+#[sea_orm(table_name = "hummock_time_travel_version_epoch_summary")]
+pub struct Model {
+    #[sea_orm(primary_key, auto_increment = false)]
+    pub version_id: HummockVersionId,
+    pub max_epoch: Epoch,
+}
+
+impl ActiveModelBehavior for ActiveModel {}
+
+#[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+pub enum Relation {}

--- a/src/meta/model/src/lib.rs
+++ b/src/meta/model/src/lib.rs
@@ -47,6 +47,7 @@ pub mod hummock_sstable_info;
 pub mod hummock_table_change_log;
 pub mod hummock_time_travel_delta;
 pub mod hummock_time_travel_version;
+pub mod hummock_time_travel_version_epoch_summary;
 pub mod hummock_version_delta;
 pub mod hummock_version_stats;
 pub mod iceberg_namespace_properties;
@@ -99,6 +100,7 @@ macro_rules! for_all_meta_model_entities {
             hummock_table_change_log,
             hummock_time_travel_delta,
             hummock_time_travel_version,
+            hummock_time_travel_version_epoch_summary,
             hummock_version_delta,
             hummock_version_stats,
             iceberg_namespace_properties,

--- a/src/meta/src/hummock/manager/tests.rs
+++ b/src/meta/src/hummock/manager/tests.rs
@@ -3749,7 +3749,10 @@ async fn test_schedule_group_split_with_normalize_disabled() {
 
 #[tokio::test]
 async fn test_time_travel_vacuum_with_cross_database_epoch_order() {
-    use risingwave_meta_model::{hummock_epoch_to_version, hummock_time_travel_version};
+    use risingwave_meta_model::{
+        hummock_epoch_to_version, hummock_time_travel_version,
+        hummock_time_travel_version_epoch_summary,
+    };
     use sea_orm::ActiveValue::Set;
     use sea_orm::{EntityTrait, PaginatorTrait};
 
@@ -3818,6 +3821,17 @@ async fn test_time_travel_vacuum_with_cross_database_epoch_order() {
         .await
         .unwrap();
     }
+    for (version_id, max_epoch) in [(10_u64, 300_u64), (11, 200)] {
+        hummock_time_travel_version_epoch_summary::Entity::insert(
+            hummock_time_travel_version_epoch_summary::ActiveModel {
+                version_id: Set(version_id.into()),
+                max_epoch: Set(max_epoch.try_into().unwrap()),
+            },
+        )
+        .exec(&env.meta_store_ref().conn)
+        .await
+        .unwrap();
+    }
 
     hummock_manager
         .truncate_time_travel_metadata(50, HashMap::new())
@@ -3882,7 +3896,9 @@ async fn test_time_travel_vacuum_with_cross_database_epoch_order() {
 #[tokio::test]
 async fn test_time_travel_epoch_mapping_excludes_internal_tables() {
     use risingwave_hummock_sdk::version::HummockVersionDelta;
-    use risingwave_meta_model::hummock_epoch_to_version;
+    use risingwave_meta_model::{
+        hummock_epoch_to_version, hummock_time_travel_version_epoch_summary,
+    };
     use sea_orm::{EntityTrait, TransactionTrait};
 
     let (env, hummock_manager, _, _) = setup_compute_env(80).await;
@@ -3931,6 +3947,13 @@ async fn test_time_travel_epoch_mapping_excludes_internal_tables() {
         epoch_mappings[0].table_id,
         i64::from(user_table_id.as_raw_id())
     );
+    let version_epoch_summaries = hummock_time_travel_version_epoch_summary::Entity::find()
+        .all(&env.meta_store_ref().conn)
+        .await
+        .unwrap();
+    assert_eq!(version_epoch_summaries.len(), 1);
+    assert_eq!(version_epoch_summaries[0].version_id.as_raw_id(), 2);
+    assert_eq!(version_epoch_summaries[0].max_epoch, 100);
 }
 
 #[tokio::test]
@@ -3939,7 +3962,7 @@ async fn test_time_travel_vacuum_pins_snapshot_epoch() {
     use risingwave_meta_model::hummock_sstable_info::SstableInfoV2Backend;
     use risingwave_meta_model::{
         hummock_epoch_to_version, hummock_sstable_info, hummock_time_travel_delta,
-        hummock_time_travel_version,
+        hummock_time_travel_version, hummock_time_travel_version_epoch_summary,
     };
     use sea_orm::ActiveValue::Set;
     use sea_orm::{EntityTrait, PaginatorTrait, QueryOrder, QuerySelect};
@@ -4003,6 +4026,18 @@ async fn test_time_travel_vacuum_pins_snapshot_epoch() {
         .unwrap();
     }
 
+    async fn insert_epoch_summary(env: &MetaSrvEnv, version: u64, max_epoch: u64) {
+        hummock_time_travel_version_epoch_summary::Entity::insert(
+            hummock_time_travel_version_epoch_summary::ActiveModel {
+                version_id: Set(version.into()),
+                max_epoch: Set(max_epoch.try_into().unwrap()),
+            },
+        )
+        .exec(&env.meta_store_ref().conn)
+        .await
+        .unwrap();
+    }
+
     let mut opts = MetaOpts::test(false);
     opts.time_travel_vacuum_max_version_count = Some(1);
     let (env, hummock_manager, _, _) = setup_compute_env_with_meta_opts(80, opts).await;
@@ -4020,6 +4055,11 @@ async fn test_time_travel_vacuum_pins_snapshot_epoch() {
     insert_epoch_mapping(&env, table_id, 200, 4).await;
     insert_epoch_mapping(&env, table_id, 300, 5).await;
     insert_epoch_mapping(&env, TableId::new(2), 50, 6).await;
+    insert_epoch_summary(&env, 2, 100).await;
+    insert_epoch_summary(&env, 3, 175).await;
+    insert_epoch_summary(&env, 4, 200).await;
+    insert_epoch_summary(&env, 5, 300).await;
+    insert_epoch_summary(&env, 6, 50).await;
 
     hummock_manager
         .truncate_time_travel_metadata(

--- a/src/meta/src/hummock/manager/time_travel.rs
+++ b/src/meta/src/hummock/manager/time_travel.rs
@@ -29,7 +29,7 @@ use risingwave_hummock_sdk::{CompactionGroupId, HummockEpoch, HummockObjectId, H
 use risingwave_meta_model::hummock_sstable_info::SstableInfoV2Backend;
 use risingwave_meta_model::{
     HummockVersionId, hummock_epoch_to_version, hummock_sstable_info, hummock_time_travel_delta,
-    hummock_time_travel_version,
+    hummock_time_travel_version, hummock_time_travel_version_epoch_summary,
 };
 use risingwave_pb::hummock::{PbHummockVersion, PbHummockVersionDelta};
 use sea_orm::ActiveValue::Set;
@@ -144,15 +144,17 @@ impl HummockManager {
             }
         }
 
-        // Version ids follow global commit order, while epochs are only monotonic per table.
-        // Use the earliest version needed by any retained mapping as the watermark so its replay
-        // metadata cannot be truncated. If no mapping is retained, only version pins and vacuum
-        // throttling need to constrain the watermark.
-        let version_watermark = hummock_epoch_to_version::Entity::find()
-            .filter(hummock_epoch_to_version::Column::Epoch.gte(epoch_watermark_model))
+        // Version ids follow global commit order, while epochs are only monotonic per table. Use
+        // the per-version max epoch summary to find the earliest version with any retained mapping
+        // without scanning/sorting the larger per-table mapping table.
+        let version_watermark = hummock_time_travel_version_epoch_summary::Entity::find()
+            .filter(
+                hummock_time_travel_version_epoch_summary::Column::MaxEpoch
+                    .gte(epoch_watermark_model),
+            )
             .select_only()
-            .column(hummock_epoch_to_version::Column::VersionId)
-            .order_by_asc(hummock_epoch_to_version::Column::VersionId)
+            .column(hummock_time_travel_version_epoch_summary::Column::VersionId)
+            .order_by_asc(hummock_time_travel_version_epoch_summary::Column::VersionId)
             .into_tuple::<HummockVersionId>()
             .one(&txn)
             .await?;
@@ -385,6 +387,31 @@ impl HummockManager {
             %watermark_version_id,
             %latest_valid_version_id,
             "Deleted {} rows from hummock_time_travel_delta.",
+            res.rows_affected
+        );
+
+        let mut version_epoch_summary_delete_condition = Condition::all().add(
+            hummock_time_travel_version_epoch_summary::Column::VersionId
+                .lt(latest_valid_version_id),
+        );
+        let pinned_time_travel_version_ids = pinned_replay_version_ids
+            .into_iter()
+            .chain(pinned_delta_ids)
+            .collect::<Vec<_>>();
+        if !pinned_time_travel_version_ids.is_empty() {
+            version_epoch_summary_delete_condition = version_epoch_summary_delete_condition.add(
+                hummock_time_travel_version_epoch_summary::Column::VersionId
+                    .is_not_in(pinned_time_travel_version_ids),
+            );
+        }
+        let res = hummock_time_travel_version_epoch_summary::Entity::delete_many()
+            .filter(version_epoch_summary_delete_condition)
+            .exec(&txn)
+            .await?;
+        tracing::info!(
+            %watermark_version_id,
+            %latest_valid_version_id,
+            "Deleted {} rows from hummock_time_travel_version_epoch_summary.",
             res.rows_affected
         );
 
@@ -683,10 +710,15 @@ impl HummockManager {
         }
 
         let mut batch = vec![];
+        let mut max_committed_epoch: Option<u64> = None;
         for (table_id, _cg_id, committed_epoch) in tables_to_commit {
             if !time_travel_table_ids.contains(table_id) {
                 continue;
             }
+            max_committed_epoch = Some(
+                max_committed_epoch
+                    .map_or(committed_epoch, |max_epoch| max_epoch.max(committed_epoch)),
+            );
             let m = hummock_epoch_to_version::ActiveModel {
                 epoch: Set(committed_epoch.try_into().unwrap()),
                 table_id: Set(i64::from(table_id.as_raw_id())),
@@ -712,6 +744,17 @@ impl HummockManager {
                 .do_nothing()
                 .exec(txn)
                 .await?;
+        }
+        if let Some(max_committed_epoch) = max_committed_epoch {
+            hummock_time_travel_version_epoch_summary::Entity::insert(
+                hummock_time_travel_version_epoch_summary::ActiveModel {
+                    version_id: Set(delta.id),
+                    max_epoch: Set(max_committed_epoch.try_into().unwrap()),
+                },
+            )
+            .on_conflict_do_nothing()
+            .exec(txn)
+            .await?;
         }
 
         let mut version_sst_ids = None;

--- a/src/storage/backup/tests/metadata_models_v2.rs
+++ b/src/storage/backup/tests/metadata_models_v2.rs
@@ -92,6 +92,7 @@ fn for_all_metadata_models_v2_should_cover_all_required_meta_model_tables() {
         "hummock_sstable_info",
         "hummock_time_travel_delta",
         "hummock_time_travel_version",
+        "hummock_time_travel_version_epoch_summary",
         // Version deltas are replayed from meta store during snapshot build, not persisted in snapshot.
         "hummock_version_delta",
     ]


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

This PR adds `hummock_time_travel_version_epoch_summary`, a compact metadata table keyed by Hummock version id with the max committed epoch for that version, and backfills it from existing `hummock_epoch_to_version` rows during migration.
Time-travel commit metadata now writes the summary for versions with user table epoch mappings, and vacuum uses the summary to find the earliest retained version without scanning and sorting the larger per-table mapping table.
The vacuum cleanup path also deletes stale summary rows while preserving pinned replay versions and deltas.
Tests cover cross-database epoch ordering, internal-table exclusion, pinned snapshot epochs, and metadata snapshot model coverage.

- https://github.com/risingwavelabs/risingwave/issues/26608

## Checklist

- [ ] I have written necessary rustdoc comments.
- [x] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [x] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

No user-facing behavior changes.

</details>
