### PR TITLE
refactor(stream): load global watermark asynchronously

### DIFF
--- a/src/stream/src/executor/watermark_filter.rs
+++ b/src/stream/src/executor/watermark_filter.rs
@@ -14,7 +14,7 @@
 
 use std::cmp;
 
-use futures::future::{try_join, try_join_all};
+use futures::future::{BoxFuture, Either, select, try_join, try_join_all};
 use risingwave_common::hash::VnodeBitmapExt;
 use risingwave_common::types::DefaultOrd;
 use risingwave_common::{bail, row};
@@ -30,6 +30,13 @@ use risingwave_storage::table::batch_table::BatchTable;
 use super::filter::FilterExecutorInner;
 use crate::executor::prelude::*;
 use crate::task::ActorEvalErrorReport;
+
+type WatermarkRefreshFuture = BoxFuture<'static, StreamExecutorResult<Option<ScalarImpl>>>;
+
+enum WatermarkFilterEvent {
+    GlobalRefresh(StreamExecutorResult<Option<ScalarImpl>>),
+    Input(Option<MessageStreamItem>),
+}
 
 /// The executor will generate a `Watermark` after each chunk.
 /// This will also guarantee all later rows with event time **less than** the watermark will be
@@ -131,193 +138,220 @@ impl<S: StateStore, const UPSERT: bool> WatermarkFilterExecutorInner<S, UPSERT> 
         // If the input is idle
         let mut idle_input = true;
         let mut barrier_num_during_idle = 0;
-        #[for_await]
-        for msg in input {
-            let msg = msg?;
-            match msg {
-                Message::Chunk(chunk) => {
-                    let chunk = chunk.compact_vis();
+        let mut pending_global_refresh: Option<WatermarkRefreshFuture> = None;
 
-                    // Empty chunk should not be processed.
-                    if chunk.cardinality() == 0 {
-                        continue;
+        loop {
+            let event = if let Some(refresh) = pending_global_refresh.as_mut() {
+                let next_msg = input.next();
+                pin_mut!(next_msg);
+                match select(refresh, next_msg).await {
+                    Either::Left((refresh_result, _)) => {
+                        pending_global_refresh = None;
+                        WatermarkFilterEvent::GlobalRefresh(refresh_result)
                     }
+                    Either::Right((msg, _)) => WatermarkFilterEvent::Input(msg),
+                }
+            } else {
+                WatermarkFilterEvent::Input(input.next().await)
+            };
 
-                    let watermark_array = watermark_expr.eval_infallible(chunk.data_chunk()).await;
-
-                    // Build the expression to calculate watermark filter.
-                    let watermark_filter_expr = current_watermark
-                        .clone()
-                        .map(|watermark| {
-                            Self::build_watermark_filter_expr(
-                                watermark_type.clone(),
-                                event_time_col_idx,
-                                watermark,
-                                eval_error_report.clone(),
-                            )
-                        })
-                        .transpose()?;
-
-                    // NULL watermark should not be considered.
-                    let max_watermark = watermark_array
-                        .iter()
-                        .flatten() // skip NULL values
-                        .max_by(DefaultOrd::default_cmp);
-
-                    if let Some(max_watermark) = max_watermark {
-                        // Assign a new watermark.
-                        current_watermark = Some(current_watermark.map_or(
-                            max_watermark.into_scalar_impl(),
-                            |watermark| {
-                                cmp::max_by(
-                                    watermark,
-                                    max_watermark.into_scalar_impl(),
-                                    DefaultOrd::default_cmp,
-                                )
-                            },
-                        ));
-                    }
-
-                    if let Some(expr) = watermark_filter_expr {
-                        let pred_output = expr.eval_infallible(chunk.data_chunk()).await;
-
-                        if let Some(output_chunk) =
-                            FilterExecutorInner::<UPSERT>::filter(chunk, pred_output)?
-                        {
-                            yield Message::Chunk(output_chunk);
-                        };
-                    } else {
-                        // No watermark
-                        yield Message::Chunk(chunk);
-                    }
-
-                    if let Some(watermark) = current_watermark.clone() {
-                        idle_input = false;
+            match event {
+                WatermarkFilterEvent::GlobalRefresh(refresh_result) => {
+                    pending_global_refresh = None;
+                    let global_max_watermark = refresh_result?;
+                    let previous_watermark = current_watermark.clone();
+                    current_watermark =
+                        Self::merge_global_watermark(current_watermark, global_max_watermark);
+                    if current_watermark != previous_watermark
+                        && let Some(watermark) = current_watermark.clone()
+                        && !is_paused
+                    {
                         yield Message::Watermark(Watermark::new(
                             event_time_col_idx,
                             watermark_type.clone(),
                             watermark,
                         ));
                     }
-                    table.try_flush().await?;
                 }
-                Message::Watermark(watermark) => {
-                    if watermark.col_idx == event_time_col_idx {
-                        tracing::warn!(
-                            "WatermarkFilterExecutor received a watermark on the event it is filtering."
-                        );
-                        let watermark = watermark.val;
-                        if let Some(cur_watermark) = current_watermark.clone()
-                            && cur_watermark.default_cmp(&watermark).is_lt()
-                        {
-                            current_watermark = Some(watermark.clone());
-                            idle_input = false;
-                            yield Message::Watermark(Watermark::new(
-                                event_time_col_idx,
-                                watermark_type.clone(),
-                                watermark,
-                            ));
-                        }
-                    } else {
-                        yield Message::Watermark(watermark)
-                    }
-                }
-                Message::Barrier(barrier) => {
-                    let prev_epoch = barrier.epoch.prev;
-                    let is_checkpoint = barrier.kind.is_checkpoint();
+                WatermarkFilterEvent::Input(msg) => {
+                    let Some(msg) = msg else {
+                        break;
+                    };
+                    let msg = msg?;
 
-                    if is_checkpoint && last_checkpoint_watermark != current_watermark {
-                        last_checkpoint_watermark.clone_from(&current_watermark);
-                        // Persist the watermark when checkpoint arrives.
-                        if let Some(watermark) = current_watermark.clone() {
-                            for vnode in table.vnodes().clone().iter_vnodes() {
-                                let pk = vnode.to_datum();
-                                let row = [pk, Some(watermark.clone())];
-                                // This is an upsert.
-                                table.insert(row);
+                    match msg {
+                        Message::Chunk(chunk) => {
+                            let chunk = chunk.compact_vis();
+
+                            // Empty chunk should not be processed.
+                            if chunk.cardinality() == 0 {
+                                continue;
                             }
-                        }
-                    }
-                    let post_commit = table.commit(barrier.epoch).await?;
 
-                    if let Some(mutation) = barrier.mutation.as_deref() {
-                        match mutation {
-                            Mutation::Pause => {
-                                is_paused = true;
-                            }
-                            Mutation::Resume => {
-                                is_paused = false;
-                            }
-                            _ => (),
-                        }
-                    }
+                            let watermark_array =
+                                watermark_expr.eval_infallible(chunk.data_chunk()).await;
 
-                    let update_vnode_bitmap = barrier.as_update_vnode_bitmap(ctx.id);
-                    yield Message::Barrier(barrier);
-
-                    let mut need_update_global_max_watermark = false;
-                    // Update the vnode bitmap for state tables of all agg calls if asked.
-                    if let Some(((vnode_bitmap, previous_vnode_bitmap, _), _cache_may_stale)) =
-                        post_commit.post_yield_barrier(update_vnode_bitmap).await?
-                    {
-                        let other_vnodes_bitmap = Arc::new(!(*vnode_bitmap).clone());
-                        let _ = global_watermark_table.update_vnode_bitmap(other_vnodes_bitmap);
-
-                        // Take the global max watermark when scaling happens.
-                        if previous_vnode_bitmap != vnode_bitmap {
-                            need_update_global_max_watermark = true;
-                        }
-                    }
-
-                    if need_update_global_max_watermark {
-                        current_watermark = Self::get_global_max_watermark(
-                            &table,
-                            &global_watermark_table,
-                            HummockReadEpoch::Committed(prev_epoch),
-                        )
-                        .await?;
-                    }
-
-                    if is_checkpoint && !is_paused {
-                        if idle_input {
-                            barrier_num_during_idle += 1;
-
-                            if barrier_num_during_idle
-                                == UPDATE_GLOBAL_WATERMARK_FREQUENCY_WHEN_IDLE
-                            {
-                                barrier_num_during_idle = 0;
-                                // Align watermark
-                                // NOTE(st1page): Should be `NoWait` because it could lead to a degradation of concurrent checkpoint situations, as it would require waiting for the previous epoch
-                                let global_max_watermark = Self::get_global_max_watermark(
-                                    &table,
-                                    &global_watermark_table,
-                                    HummockReadEpoch::NoWait(prev_epoch),
-                                )
-                                .await?;
-
-                                current_watermark = if let Some(global_max_watermark) =
-                                    global_max_watermark.clone()
-                                    && let Some(watermark) = current_watermark.clone()
-                                {
-                                    Some(cmp::max_by(
+                            // Build the expression to calculate watermark filter.
+                            let watermark_filter_expr = current_watermark
+                                .clone()
+                                .map(|watermark| {
+                                    Self::build_watermark_filter_expr(
+                                        watermark_type.clone(),
+                                        event_time_col_idx,
                                         watermark,
-                                        global_max_watermark,
-                                        DefaultOrd::default_cmp,
-                                    ))
-                                } else {
-                                    current_watermark.or(global_max_watermark)
+                                        eval_error_report.clone(),
+                                    )
+                                })
+                                .transpose()?;
+
+                            // NULL watermark should not be considered.
+                            let max_watermark = watermark_array
+                                .iter()
+                                .flatten() // skip NULL values
+                                .max_by(DefaultOrd::default_cmp);
+
+                            if let Some(max_watermark) = max_watermark {
+                                // Assign a new watermark.
+                                current_watermark = Some(current_watermark.map_or(
+                                    max_watermark.into_scalar_impl(),
+                                    |watermark| {
+                                        cmp::max_by(
+                                            watermark,
+                                            max_watermark.into_scalar_impl(),
+                                            DefaultOrd::default_cmp,
+                                        )
+                                    },
+                                ));
+                            }
+
+                            if let Some(expr) = watermark_filter_expr {
+                                let pred_output = expr.eval_infallible(chunk.data_chunk()).await;
+
+                                if let Some(output_chunk) =
+                                    FilterExecutorInner::<UPSERT>::filter(chunk, pred_output)?
+                                {
+                                    yield Message::Chunk(output_chunk);
                                 };
-                                if let Some(watermark) = current_watermark.clone() {
+                            } else {
+                                // No watermark
+                                yield Message::Chunk(chunk);
+                            }
+
+                            if let Some(watermark) = current_watermark.clone() {
+                                idle_input = false;
+                                yield Message::Watermark(Watermark::new(
+                                    event_time_col_idx,
+                                    watermark_type.clone(),
+                                    watermark,
+                                ));
+                            }
+                            table.try_flush().await?;
+                        }
+                        Message::Watermark(watermark) => {
+                            if watermark.col_idx == event_time_col_idx {
+                                tracing::warn!(
+                                    "WatermarkFilterExecutor received a watermark on the event it is filtering."
+                                );
+                                let watermark = watermark.val;
+                                if let Some(cur_watermark) = current_watermark.clone()
+                                    && cur_watermark.default_cmp(&watermark).is_lt()
+                                {
+                                    current_watermark = Some(watermark.clone());
+                                    idle_input = false;
                                     yield Message::Watermark(Watermark::new(
                                         event_time_col_idx,
                                         watermark_type.clone(),
                                         watermark,
                                     ));
                                 }
+                            } else {
+                                yield Message::Watermark(watermark)
                             }
-                        } else {
-                            idle_input = true;
-                            barrier_num_during_idle = 0;
+                        }
+                        Message::Barrier(barrier) => {
+                            let prev_epoch = barrier.epoch.prev;
+                            let is_checkpoint = barrier.kind.is_checkpoint();
+
+                            if is_checkpoint && last_checkpoint_watermark != current_watermark {
+                                last_checkpoint_watermark.clone_from(&current_watermark);
+                                // Persist the watermark when checkpoint arrives.
+                                if let Some(watermark) = current_watermark.clone() {
+                                    for vnode in table.vnodes().clone().iter_vnodes() {
+                                        let pk = vnode.to_datum();
+                                        let row = [pk, Some(watermark.clone())];
+                                        // This is an upsert.
+                                        table.insert(row);
+                                    }
+                                }
+                            }
+                            let post_commit = table.commit(barrier.epoch).await?;
+
+                            if let Some(mutation) = barrier.mutation.as_deref() {
+                                match mutation {
+                                    Mutation::Pause => {
+                                        is_paused = true;
+                                    }
+                                    Mutation::Resume => {
+                                        is_paused = false;
+                                    }
+                                    _ => (),
+                                }
+                            }
+
+                            let update_vnode_bitmap = barrier.as_update_vnode_bitmap(ctx.id);
+                            yield Message::Barrier(barrier);
+
+                            let mut need_update_global_max_watermark = false;
+                            // Update the vnode bitmap for state tables of all agg calls if asked.
+                            if let Some((
+                                (vnode_bitmap, previous_vnode_bitmap, _),
+                                _cache_may_stale,
+                            )) = post_commit.post_yield_barrier(update_vnode_bitmap).await?
+                            {
+                                let other_vnodes_bitmap = Arc::new(!(*vnode_bitmap).clone());
+                                let _ =
+                                    global_watermark_table.update_vnode_bitmap(other_vnodes_bitmap);
+
+                                // Take the global max watermark when scaling happens.
+                                if previous_vnode_bitmap != vnode_bitmap {
+                                    need_update_global_max_watermark = true;
+                                }
+                            }
+
+                            if need_update_global_max_watermark {
+                                current_watermark = Self::get_global_max_watermark(
+                                    &table,
+                                    &global_watermark_table,
+                                    HummockReadEpoch::Committed(prev_epoch),
+                                )
+                                .await?;
+                            }
+
+                            if is_checkpoint && !is_paused {
+                                if idle_input {
+                                    barrier_num_during_idle += 1;
+
+                                    if barrier_num_during_idle
+                                        == UPDATE_GLOBAL_WATERMARK_FREQUENCY_WHEN_IDLE
+                                    {
+                                        barrier_num_during_idle = 0;
+                                        if pending_global_refresh.is_none() {
+                                            let global_watermark_table =
+                                                global_watermark_table.clone();
+                                            pending_global_refresh = Some(Box::pin(async move {
+                                                Self::read_global_max_watermark(
+                                                    global_watermark_table,
+                                                    HummockReadEpoch::Committed(prev_epoch),
+                                                )
+                                                .await
+                                            }));
+                                        }
+                                    }
+                                } else {
+                                    idle_input = true;
+                                    barrier_num_during_idle = 0;
+                                }
+                            }
                         }
                     }
                 }
@@ -342,39 +376,74 @@ impl<S: StateStore, const UPSERT: bool> WatermarkFilterExecutorInner<S, UPSERT> 
         )
     }
 
+    fn decode_watermark_row(
+        watermark_row: Option<OwnedRow>,
+    ) -> StreamExecutorResult<Option<ScalarImpl>> {
+        match watermark_row {
+            Some(row) => {
+                if row.len() == 1 {
+                    Ok(row[0].clone())
+                } else {
+                    bail!("The watermark row should only contain 1 datum");
+                }
+            }
+            _ => Ok(None),
+        }
+    }
+
+    fn merge_global_watermark(
+        current_watermark: Option<ScalarImpl>,
+        global_max_watermark: Option<ScalarImpl>,
+    ) -> Option<ScalarImpl> {
+        match (current_watermark, global_max_watermark) {
+            (Some(watermark), Some(global_max_watermark)) => Some(cmp::max_by(
+                watermark,
+                global_max_watermark,
+                DefaultOrd::default_cmp,
+            )),
+            (Some(watermark), None) => Some(watermark),
+            (None, global_max_watermark) => global_max_watermark,
+        }
+    }
+
+    async fn read_global_max_watermark(
+        global_watermark_table: BatchTable<S>,
+        wait_epoch: HummockReadEpoch,
+    ) -> StreamExecutorResult<Option<ScalarImpl>> {
+        let vnodes = global_watermark_table
+            .vnodes()
+            .iter_vnodes()
+            .collect::<Vec<_>>();
+        let global_watermark_iter_futures = vnodes.into_iter().map(|vnode| {
+            let global_watermark_table = global_watermark_table.clone();
+            async move {
+                let pk = row::once(vnode.to_datum());
+                let watermark_row: Option<OwnedRow> =
+                    global_watermark_table.get_row(pk, wait_epoch).await?;
+                Self::decode_watermark_row(watermark_row)
+            }
+        });
+        let global_watermarks = try_join_all(global_watermark_iter_futures).await?;
+
+        Ok(global_watermarks
+            .into_iter()
+            .flatten()
+            .max_by(DefaultOrd::default_cmp))
+    }
+
     /// If the returned if `Ok(None)`, it means there is no global max watermark.
     async fn get_global_max_watermark(
         table: &StateTable<S>,
         global_watermark_table: &BatchTable<S>,
         wait_epoch: HummockReadEpoch,
     ) -> StreamExecutorResult<Option<ScalarImpl>> {
-        let handle_watermark_row = |watermark_row: Option<OwnedRow>| match watermark_row {
-            Some(row) => {
-                if row.len() == 1 {
-                    Ok::<_, StreamExecutorError>(row[0].clone())
-                } else {
-                    bail!("The watermark row should only contain 1 datum");
-                }
-            }
-            _ => Ok(None),
-        };
-        let global_watermark_iter_futures =
-            global_watermark_table
-                .vnodes()
-                .iter_vnodes()
-                .map(|vnode| async move {
-                    let pk = row::once(vnode.to_datum());
-                    let watermark_row: Option<OwnedRow> =
-                        global_watermark_table.get_row(pk, wait_epoch).await?;
-                    handle_watermark_row(watermark_row)
-                });
         let local_watermark_iter_futures = table.vnodes().iter_vnodes().map(|vnode| async move {
             let pk = row::once(vnode.to_datum());
             let watermark_row: Option<OwnedRow> = table.get_row(pk).await?;
-            handle_watermark_row(watermark_row)
+            Self::decode_watermark_row(watermark_row)
         });
         let (global_watermarks, local_watermarks) = try_join(
-            try_join_all(global_watermark_iter_futures),
+            Self::read_global_max_watermark(global_watermark_table.clone(), wait_epoch),
             try_join_all(local_watermark_iter_futures),
         )
         .await?;
@@ -382,8 +451,7 @@ impl<S: StateStore, const UPSERT: bool> WatermarkFilterExecutorInner<S, UPSERT> 
         // Return the minimal value if the remote max watermark is Null.
         let watermark = global_watermarks
             .into_iter()
-            .chain(local_watermarks)
-            .flatten()
+            .chain(local_watermarks.into_iter().flatten())
             .max_by(DefaultOrd::default_cmp);
 
         Ok(watermark)

--- a/src/stream/src/executor/watermark_filter.rs
+++ b/src/stream/src/executor/watermark_filter.rs
@@ -153,9 +153,7 @@ impl<S: StateStore, const UPSERT: bool> WatermarkFilterExecutorInner<S, UPSERT> 
 
             let msg = match event {
                 WatermarkFilterEvent::GlobalRefresh(refresh_result) => {
-                    pending_global_refresh = None;
                     let global_max_watermark = refresh_result?;
-                    let previous_watermark = current_watermark.clone();
                     current_watermark = match (current_watermark, global_max_watermark) {
                         (Some(watermark), Some(global_max_watermark)) => Some(cmp::max_by(
                             watermark,
@@ -165,8 +163,7 @@ impl<S: StateStore, const UPSERT: bool> WatermarkFilterExecutorInner<S, UPSERT> 
                         (Some(watermark), None) => Some(watermark),
                         (None, global_max_watermark) => global_max_watermark,
                     };
-                    if current_watermark != previous_watermark
-                        && let Some(watermark) = current_watermark.clone()
+                    if let Some(watermark) = current_watermark.clone()
                         && !is_paused
                     {
                         yield Message::Watermark(Watermark::new(
@@ -329,12 +326,13 @@ impl<S: StateStore, const UPSERT: bool> WatermarkFilterExecutorInner<S, UPSERT> 
                         .await?;
                     }
 
-                    if is_checkpoint && !is_paused && pending_global_refresh.is_none() {
+                    if is_checkpoint && !is_paused {
                         if idle_input {
                             barrier_num_during_idle += 1;
 
                             if barrier_num_during_idle
                                 >= UPDATE_GLOBAL_WATERMARK_FREQUENCY_WHEN_IDLE
+                                && pending_global_refresh.is_none()
                             {
                                 barrier_num_during_idle = 0;
                                 let global_watermark_table = global_watermark_table.clone();

--- a/src/stream/src/executor/watermark_filter.rs
+++ b/src/stream/src/executor/watermark_filter.rs
@@ -15,7 +15,6 @@
 use std::cmp;
 
 use futures::future::{BoxFuture, Either, select, try_join, try_join_all};
-use futures::stream::FuturesOrdered;
 use risingwave_common::hash::VnodeBitmapExt;
 use risingwave_common::types::DefaultOrd;
 use risingwave_common::{bail, row};
@@ -86,7 +85,7 @@ impl<S: StateStore, const UPSERT: bool> Execute for WatermarkFilterExecutorInner
         self.execute_inner().boxed()
     }
 }
-const UPDATE_GLOBAL_WATERMARK_FREQUENCY: usize = 5;
+const UPDATE_GLOBAL_WATERMARK_FREQUENCY_WHEN_IDLE: usize = 5;
 
 impl<S: StateStore, const UPSERT: bool> WatermarkFilterExecutorInner<S, UPSERT> {
     #[try_stream(ok = Message, error = StreamExecutorError)]
@@ -132,28 +131,29 @@ impl<S: StateStore, const UPSERT: bool> WatermarkFilterExecutorInner<S, UPSERT> 
             ));
         }
 
-        let mut barrier_num_since_last_global_refresh = 0;
-        let mut pending_global_refreshes = FuturesOrdered::<WatermarkRefreshFuture>::new();
+        // If the input is idle
+        let mut idle_input = true;
+        let mut barrier_num_during_idle = 0;
+        let mut pending_global_refresh: Option<WatermarkRefreshFuture> = None;
 
         loop {
-            let event = if pending_global_refreshes.is_empty() {
-                WatermarkFilterEvent::Input(input.next().await)
-            } else {
+            let event = if let Some(refresh) = pending_global_refresh.as_mut() {
                 let next_msg = input.next();
-                let next_global_refresh = pending_global_refreshes.next();
                 pin_mut!(next_msg);
-                pin_mut!(next_global_refresh);
-                match select(next_global_refresh, next_msg).await {
-                    Either::Left((Some(refresh_result), _)) => {
+                match select(refresh, next_msg).await {
+                    Either::Left((refresh_result, _)) => {
+                        pending_global_refresh = None;
                         WatermarkFilterEvent::GlobalRefresh(refresh_result)
                     }
-                    Either::Left((None, _)) => continue,
                     Either::Right((msg, _)) => WatermarkFilterEvent::Input(msg),
                 }
+            } else {
+                WatermarkFilterEvent::Input(input.next().await)
             };
 
             let msg = match event {
                 WatermarkFilterEvent::GlobalRefresh(refresh_result) => {
+                    pending_global_refresh = None;
                     let global_max_watermark = refresh_result?;
                     let previous_watermark = current_watermark.clone();
                     current_watermark = match (current_watermark, global_max_watermark) {
@@ -243,6 +243,7 @@ impl<S: StateStore, const UPSERT: bool> WatermarkFilterExecutorInner<S, UPSERT> 
                     }
 
                     if let Some(watermark) = current_watermark.clone() {
+                        idle_input = false;
                         yield Message::Watermark(Watermark::new(
                             event_time_col_idx,
                             watermark_type.clone(),
@@ -261,6 +262,7 @@ impl<S: StateStore, const UPSERT: bool> WatermarkFilterExecutorInner<S, UPSERT> 
                             && cur_watermark.default_cmp(&watermark).is_lt()
                         {
                             current_watermark = Some(watermark.clone());
+                            idle_input = false;
                             yield Message::Watermark(Watermark::new(
                                 event_time_col_idx,
                                 watermark_type.clone(),
@@ -327,17 +329,26 @@ impl<S: StateStore, const UPSERT: bool> WatermarkFilterExecutorInner<S, UPSERT> 
                         .await?;
                     }
 
-                    if is_checkpoint {
-                        barrier_num_since_last_global_refresh += 1;
-                        if barrier_num_since_last_global_refresh
-                            >= UPDATE_GLOBAL_WATERMARK_FREQUENCY
-                        {
-                            barrier_num_since_last_global_refresh = 0;
-                            let global_watermark_table = global_watermark_table.clone();
-                            pending_global_refreshes.push_back(Box::pin(async move {
-                                Self::read_global_max_watermark(&global_watermark_table, prev_epoch)
+                    if is_checkpoint && !is_paused && pending_global_refresh.is_none() {
+                        if idle_input {
+                            barrier_num_during_idle += 1;
+
+                            if barrier_num_during_idle
+                                >= UPDATE_GLOBAL_WATERMARK_FREQUENCY_WHEN_IDLE
+                            {
+                                barrier_num_during_idle = 0;
+                                let global_watermark_table = global_watermark_table.clone();
+                                pending_global_refresh = Some(Box::pin(async move {
+                                    Self::read_global_max_watermark(
+                                        &global_watermark_table,
+                                        prev_epoch,
+                                    )
                                     .await
-                            }));
+                                }));
+                            }
+                        } else {
+                            idle_input = true;
+                            barrier_num_during_idle = 0;
                         }
                     }
                 }

--- a/src/stream/src/executor/watermark_filter.rs
+++ b/src/stream/src/executor/watermark_filter.rs
@@ -15,6 +15,7 @@
 use std::cmp;
 
 use futures::future::{BoxFuture, Either, select, try_join, try_join_all};
+use futures::stream::FuturesOrdered;
 use risingwave_common::hash::VnodeBitmapExt;
 use risingwave_common::types::DefaultOrd;
 use risingwave_common::{bail, row};
@@ -85,7 +86,7 @@ impl<S: StateStore, const UPSERT: bool> Execute for WatermarkFilterExecutorInner
         self.execute_inner().boxed()
     }
 }
-const UPDATE_GLOBAL_WATERMARK_FREQUENCY_WHEN_IDLE: usize = 5;
+const UPDATE_GLOBAL_WATERMARK_FREQUENCY: usize = 5;
 
 impl<S: StateStore, const UPSERT: bool> WatermarkFilterExecutorInner<S, UPSERT> {
     #[try_stream(ok = Message, error = StreamExecutorError)]
@@ -116,12 +117,8 @@ impl<S: StateStore, const UPSERT: bool> WatermarkFilterExecutorInner<S, UPSERT> 
         table.init_epoch(first_epoch).await?;
 
         // Initiate and yield the first watermark.
-        let mut current_watermark = Self::get_global_max_watermark(
-            &table,
-            &global_watermark_table,
-            HummockReadEpoch::Committed(prev_epoch),
-        )
-        .await?;
+        let mut current_watermark =
+            Self::get_global_max_watermark(&table, &global_watermark_table, prev_epoch).await?;
 
         let mut last_checkpoint_watermark = None;
 
@@ -135,33 +132,39 @@ impl<S: StateStore, const UPSERT: bool> WatermarkFilterExecutorInner<S, UPSERT> 
             ));
         }
 
-        // If the input is idle
-        let mut idle_input = true;
-        let mut barrier_num_during_idle = 0;
-        let mut pending_global_refresh: Option<WatermarkRefreshFuture> = None;
+        let mut barrier_num_since_last_global_refresh = 0;
+        let mut pending_global_refreshes = FuturesOrdered::<WatermarkRefreshFuture>::new();
 
         loop {
-            let event = if let Some(refresh) = pending_global_refresh.as_mut() {
+            let event = if pending_global_refreshes.is_empty() {
+                WatermarkFilterEvent::Input(input.next().await)
+            } else {
                 let next_msg = input.next();
+                let next_global_refresh = pending_global_refreshes.next();
                 pin_mut!(next_msg);
-                match select(refresh, next_msg).await {
-                    Either::Left((refresh_result, _)) => {
-                        pending_global_refresh = None;
+                pin_mut!(next_global_refresh);
+                match select(next_global_refresh, next_msg).await {
+                    Either::Left((Some(refresh_result), _)) => {
                         WatermarkFilterEvent::GlobalRefresh(refresh_result)
                     }
+                    Either::Left((None, _)) => continue,
                     Either::Right((msg, _)) => WatermarkFilterEvent::Input(msg),
                 }
-            } else {
-                WatermarkFilterEvent::Input(input.next().await)
             };
 
-            match event {
+            let msg = match event {
                 WatermarkFilterEvent::GlobalRefresh(refresh_result) => {
-                    pending_global_refresh = None;
                     let global_max_watermark = refresh_result?;
                     let previous_watermark = current_watermark.clone();
-                    current_watermark =
-                        Self::merge_global_watermark(current_watermark, global_max_watermark);
+                    current_watermark = match (current_watermark, global_max_watermark) {
+                        (Some(watermark), Some(global_max_watermark)) => Some(cmp::max_by(
+                            watermark,
+                            global_max_watermark,
+                            DefaultOrd::default_cmp,
+                        )),
+                        (Some(watermark), None) => Some(watermark),
+                        (None, global_max_watermark) => global_max_watermark,
+                    };
                     if current_watermark != previous_watermark
                         && let Some(watermark) = current_watermark.clone()
                         && !is_paused
@@ -172,186 +175,169 @@ impl<S: StateStore, const UPSERT: bool> WatermarkFilterExecutorInner<S, UPSERT> 
                             watermark,
                         ));
                     }
+                    continue;
                 }
                 WatermarkFilterEvent::Input(msg) => {
                     let Some(msg) = msg else {
                         break;
                     };
-                    let msg = msg?;
+                    msg?
+                }
+            };
 
-                    match msg {
-                        Message::Chunk(chunk) => {
-                            let chunk = chunk.compact_vis();
+            match msg {
+                Message::Chunk(chunk) => {
+                    let chunk = chunk.compact_vis();
 
-                            // Empty chunk should not be processed.
-                            if chunk.cardinality() == 0 {
-                                continue;
-                            }
+                    // Empty chunk should not be processed.
+                    if chunk.cardinality() == 0 {
+                        continue;
+                    }
 
-                            let watermark_array =
-                                watermark_expr.eval_infallible(chunk.data_chunk()).await;
+                    let watermark_array = watermark_expr.eval_infallible(chunk.data_chunk()).await;
 
-                            // Build the expression to calculate watermark filter.
-                            let watermark_filter_expr = current_watermark
-                                .clone()
-                                .map(|watermark| {
-                                    Self::build_watermark_filter_expr(
-                                        watermark_type.clone(),
-                                        event_time_col_idx,
-                                        watermark,
-                                        eval_error_report.clone(),
-                                    )
-                                })
-                                .transpose()?;
+                    // Build the expression to calculate watermark filter.
+                    let watermark_filter_expr = current_watermark
+                        .clone()
+                        .map(|watermark| {
+                            Self::build_watermark_filter_expr(
+                                watermark_type.clone(),
+                                event_time_col_idx,
+                                watermark,
+                                eval_error_report.clone(),
+                            )
+                        })
+                        .transpose()?;
 
-                            // NULL watermark should not be considered.
-                            let max_watermark = watermark_array
-                                .iter()
-                                .flatten() // skip NULL values
-                                .max_by(DefaultOrd::default_cmp);
+                    // NULL watermark should not be considered.
+                    let max_watermark = watermark_array
+                        .iter()
+                        .flatten() // skip NULL values
+                        .max_by(DefaultOrd::default_cmp);
 
-                            if let Some(max_watermark) = max_watermark {
-                                // Assign a new watermark.
-                                current_watermark = Some(current_watermark.map_or(
-                                    max_watermark.into_scalar_impl(),
-                                    |watermark| {
-                                        cmp::max_by(
-                                            watermark,
-                                            max_watermark.into_scalar_impl(),
-                                            DefaultOrd::default_cmp,
-                                        )
-                                    },
-                                ));
-                            }
-
-                            if let Some(expr) = watermark_filter_expr {
-                                let pred_output = expr.eval_infallible(chunk.data_chunk()).await;
-
-                                if let Some(output_chunk) =
-                                    FilterExecutorInner::<UPSERT>::filter(chunk, pred_output)?
-                                {
-                                    yield Message::Chunk(output_chunk);
-                                };
-                            } else {
-                                // No watermark
-                                yield Message::Chunk(chunk);
-                            }
-
-                            if let Some(watermark) = current_watermark.clone() {
-                                idle_input = false;
-                                yield Message::Watermark(Watermark::new(
-                                    event_time_col_idx,
-                                    watermark_type.clone(),
+                    if let Some(max_watermark) = max_watermark {
+                        // Assign a new watermark.
+                        current_watermark = Some(current_watermark.map_or(
+                            max_watermark.into_scalar_impl(),
+                            |watermark| {
+                                cmp::max_by(
                                     watermark,
-                                ));
-                            }
-                            table.try_flush().await?;
-                        }
-                        Message::Watermark(watermark) => {
-                            if watermark.col_idx == event_time_col_idx {
-                                tracing::warn!(
-                                    "WatermarkFilterExecutor received a watermark on the event it is filtering."
-                                );
-                                let watermark = watermark.val;
-                                if let Some(cur_watermark) = current_watermark.clone()
-                                    && cur_watermark.default_cmp(&watermark).is_lt()
-                                {
-                                    current_watermark = Some(watermark.clone());
-                                    idle_input = false;
-                                    yield Message::Watermark(Watermark::new(
-                                        event_time_col_idx,
-                                        watermark_type.clone(),
-                                        watermark,
-                                    ));
-                                }
-                            } else {
-                                yield Message::Watermark(watermark)
-                            }
-                        }
-                        Message::Barrier(barrier) => {
-                            let prev_epoch = barrier.epoch.prev;
-                            let is_checkpoint = barrier.kind.is_checkpoint();
-
-                            if is_checkpoint && last_checkpoint_watermark != current_watermark {
-                                last_checkpoint_watermark.clone_from(&current_watermark);
-                                // Persist the watermark when checkpoint arrives.
-                                if let Some(watermark) = current_watermark.clone() {
-                                    for vnode in table.vnodes().clone().iter_vnodes() {
-                                        let pk = vnode.to_datum();
-                                        let row = [pk, Some(watermark.clone())];
-                                        // This is an upsert.
-                                        table.insert(row);
-                                    }
-                                }
-                            }
-                            let post_commit = table.commit(barrier.epoch).await?;
-
-                            if let Some(mutation) = barrier.mutation.as_deref() {
-                                match mutation {
-                                    Mutation::Pause => {
-                                        is_paused = true;
-                                    }
-                                    Mutation::Resume => {
-                                        is_paused = false;
-                                    }
-                                    _ => (),
-                                }
-                            }
-
-                            let update_vnode_bitmap = barrier.as_update_vnode_bitmap(ctx.id);
-                            yield Message::Barrier(barrier);
-
-                            let mut need_update_global_max_watermark = false;
-                            // Update the vnode bitmap for state tables of all agg calls if asked.
-                            if let Some((
-                                (vnode_bitmap, previous_vnode_bitmap, _),
-                                _cache_may_stale,
-                            )) = post_commit.post_yield_barrier(update_vnode_bitmap).await?
-                            {
-                                let other_vnodes_bitmap = Arc::new(!(*vnode_bitmap).clone());
-                                let _ =
-                                    global_watermark_table.update_vnode_bitmap(other_vnodes_bitmap);
-
-                                // Take the global max watermark when scaling happens.
-                                if previous_vnode_bitmap != vnode_bitmap {
-                                    need_update_global_max_watermark = true;
-                                }
-                            }
-
-                            if need_update_global_max_watermark {
-                                current_watermark = Self::get_global_max_watermark(
-                                    &table,
-                                    &global_watermark_table,
-                                    HummockReadEpoch::Committed(prev_epoch),
+                                    max_watermark.into_scalar_impl(),
+                                    DefaultOrd::default_cmp,
                                 )
-                                .await?;
-                            }
+                            },
+                        ));
+                    }
 
-                            if is_checkpoint && !is_paused {
-                                if idle_input {
-                                    barrier_num_during_idle += 1;
+                    if let Some(expr) = watermark_filter_expr {
+                        let pred_output = expr.eval_infallible(chunk.data_chunk()).await;
 
-                                    if barrier_num_during_idle
-                                        == UPDATE_GLOBAL_WATERMARK_FREQUENCY_WHEN_IDLE
-                                    {
-                                        barrier_num_during_idle = 0;
-                                        if pending_global_refresh.is_none() {
-                                            let global_watermark_table =
-                                                global_watermark_table.clone();
-                                            pending_global_refresh = Some(Box::pin(async move {
-                                                Self::read_global_max_watermark(
-                                                    global_watermark_table,
-                                                    HummockReadEpoch::Committed(prev_epoch),
-                                                )
-                                                .await
-                                            }));
-                                        }
-                                    }
-                                } else {
-                                    idle_input = true;
-                                    barrier_num_during_idle = 0;
-                                }
+                        if let Some(output_chunk) =
+                            FilterExecutorInner::<UPSERT>::filter(chunk, pred_output)?
+                        {
+                            yield Message::Chunk(output_chunk);
+                        };
+                    } else {
+                        // No watermark
+                        yield Message::Chunk(chunk);
+                    }
+
+                    if let Some(watermark) = current_watermark.clone() {
+                        yield Message::Watermark(Watermark::new(
+                            event_time_col_idx,
+                            watermark_type.clone(),
+                            watermark,
+                        ));
+                    }
+                    table.try_flush().await?;
+                }
+                Message::Watermark(watermark) => {
+                    if watermark.col_idx == event_time_col_idx {
+                        tracing::warn!(
+                            "WatermarkFilterExecutor received a watermark on the event it is filtering."
+                        );
+                        let watermark = watermark.val;
+                        if let Some(cur_watermark) = current_watermark.clone()
+                            && cur_watermark.default_cmp(&watermark).is_lt()
+                        {
+                            current_watermark = Some(watermark.clone());
+                            yield Message::Watermark(Watermark::new(
+                                event_time_col_idx,
+                                watermark_type.clone(),
+                                watermark,
+                            ));
+                        }
+                    } else {
+                        yield Message::Watermark(watermark)
+                    }
+                }
+                Message::Barrier(barrier) => {
+                    let prev_epoch = barrier.epoch.prev;
+                    let is_checkpoint = barrier.kind.is_checkpoint();
+
+                    if is_checkpoint && last_checkpoint_watermark != current_watermark {
+                        last_checkpoint_watermark.clone_from(&current_watermark);
+                        // Persist the watermark when checkpoint arrives.
+                        if let Some(watermark) = current_watermark.clone() {
+                            for vnode in table.vnodes().clone().iter_vnodes() {
+                                let pk = vnode.to_datum();
+                                let row = [pk, Some(watermark.clone())];
+                                // This is an upsert.
+                                table.insert(row);
                             }
+                        }
+                    }
+                    let post_commit = table.commit(barrier.epoch).await?;
+
+                    if let Some(mutation) = barrier.mutation.as_deref() {
+                        match mutation {
+                            Mutation::Pause => {
+                                is_paused = true;
+                            }
+                            Mutation::Resume => {
+                                is_paused = false;
+                            }
+                            _ => (),
+                        }
+                    }
+
+                    let update_vnode_bitmap = barrier.as_update_vnode_bitmap(ctx.id);
+                    yield Message::Barrier(barrier);
+
+                    let mut need_update_global_max_watermark = false;
+                    // Update the vnode bitmap for state tables of all agg calls if asked.
+                    if let Some(((vnode_bitmap, previous_vnode_bitmap, _), _cache_may_stale)) =
+                        post_commit.post_yield_barrier(update_vnode_bitmap).await?
+                    {
+                        let other_vnodes_bitmap = Arc::new(!(*vnode_bitmap).clone());
+                        let _ = global_watermark_table.update_vnode_bitmap(other_vnodes_bitmap);
+
+                        // Take the global max watermark when scaling happens.
+                        if previous_vnode_bitmap != vnode_bitmap {
+                            need_update_global_max_watermark = true;
+                        }
+                    }
+
+                    if need_update_global_max_watermark {
+                        current_watermark = Self::get_global_max_watermark(
+                            &table,
+                            &global_watermark_table,
+                            prev_epoch,
+                        )
+                        .await?;
+                    }
+
+                    if is_checkpoint {
+                        barrier_num_since_last_global_refresh += 1;
+                        if barrier_num_since_last_global_refresh
+                            >= UPDATE_GLOBAL_WATERMARK_FREQUENCY
+                        {
+                            barrier_num_since_last_global_refresh = 0;
+                            let global_watermark_table = global_watermark_table.clone();
+                            pending_global_refreshes.push_back(Box::pin(async move {
+                                Self::read_global_max_watermark(&global_watermark_table, prev_epoch)
+                                    .await
+                            }));
                         }
                     }
                 }
@@ -391,38 +377,21 @@ impl<S: StateStore, const UPSERT: bool> WatermarkFilterExecutorInner<S, UPSERT> 
         }
     }
 
-    fn merge_global_watermark(
-        current_watermark: Option<ScalarImpl>,
-        global_max_watermark: Option<ScalarImpl>,
-    ) -> Option<ScalarImpl> {
-        match (current_watermark, global_max_watermark) {
-            (Some(watermark), Some(global_max_watermark)) => Some(cmp::max_by(
-                watermark,
-                global_max_watermark,
-                DefaultOrd::default_cmp,
-            )),
-            (Some(watermark), None) => Some(watermark),
-            (None, global_max_watermark) => global_max_watermark,
-        }
-    }
-
     async fn read_global_max_watermark(
-        global_watermark_table: BatchTable<S>,
-        wait_epoch: HummockReadEpoch,
+        global_watermark_table: &BatchTable<S>,
+        read_epoch: u64,
     ) -> StreamExecutorResult<Option<ScalarImpl>> {
-        let vnodes = global_watermark_table
-            .vnodes()
-            .iter_vnodes()
-            .collect::<Vec<_>>();
-        let global_watermark_iter_futures = vnodes.into_iter().map(|vnode| {
-            let global_watermark_table = global_watermark_table.clone();
-            async move {
-                let pk = row::once(vnode.to_datum());
-                let watermark_row: Option<OwnedRow> =
-                    global_watermark_table.get_row(pk, wait_epoch).await?;
-                Self::decode_watermark_row(watermark_row)
-            }
-        });
+        let global_watermark_iter_futures =
+            global_watermark_table
+                .vnodes()
+                .iter_vnodes()
+                .map(|vnode| async move {
+                    let pk = row::once(vnode.to_datum());
+                    let watermark_row: Option<OwnedRow> = global_watermark_table
+                        .get_row(pk, HummockReadEpoch::Committed(read_epoch))
+                        .await?;
+                    Self::decode_watermark_row(watermark_row)
+                });
         let global_watermarks = try_join_all(global_watermark_iter_futures).await?;
 
         Ok(global_watermarks
@@ -435,7 +404,7 @@ impl<S: StateStore, const UPSERT: bool> WatermarkFilterExecutorInner<S, UPSERT> 
     async fn get_global_max_watermark(
         table: &StateTable<S>,
         global_watermark_table: &BatchTable<S>,
-        wait_epoch: HummockReadEpoch,
+        read_epoch: u64,
     ) -> StreamExecutorResult<Option<ScalarImpl>> {
         let local_watermark_iter_futures = table.vnodes().iter_vnodes().map(|vnode| async move {
             let pk = row::once(vnode.to_datum());
@@ -443,7 +412,7 @@ impl<S: StateStore, const UPSERT: bool> WatermarkFilterExecutorInner<S, UPSERT> 
             Self::decode_watermark_row(watermark_row)
         });
         let (global_watermarks, local_watermarks) = try_join(
-            Self::read_global_max_watermark(global_watermark_table.clone(), wait_epoch),
+            Self::read_global_max_watermark(global_watermark_table, read_epoch),
             try_join_all(local_watermark_iter_futures),
         )
         .await?;


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

This PR changes watermark filter's global watermark refresh path to avoid using `HummockReadEpoch::NoWait` when querying the global watermark batch table.

Previously, when the input stayed idle for several checkpoint barriers, watermark filter synchronously called `get_global_max_watermark` with `HummockReadEpoch::NoWait(prev_epoch)`. That avoided waiting on committed epochs, but it also made the batch-table read depend on `NoWait` semantics.

Now the executor:

- reads startup and vnode-update global watermarks with committed epochs,
- keeps global refresh conditional on idle input and unpaused execution,
- schedules at most one async committed global watermark read after 5 idle checkpoint barriers,
- merges an async-loaded global watermark into `current_watermark` by max, and yields it only when it advances and the executor is not paused.

- Closes: none

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

Internal streaming executor change. No user-facing documentation update is needed.

</details>
