### PR TITLE
fix(sink): throttle coordinator recovery retries

### DIFF
--- a/src/meta/src/manager/exactly_once_util.rs
+++ b/src/meta/src/manager/exactly_once_util.rs
@@ -101,6 +101,10 @@ pub async fn clean_aborted_records(
     sink_id: SinkId,
     aborted_epochs: Vec<u64>,
 ) -> anyhow::Result<()> {
+    if aborted_epochs.is_empty() {
+        return Ok(());
+    }
+
     match pending_sink_state::Entity::delete_many()
         .filter(
             pending_sink_state::Column::SinkId

--- a/src/meta/src/manager/sink_coordination/coordinator_worker.rs
+++ b/src/meta/src/manager/sink_coordination/coordinator_worker.rs
@@ -39,8 +39,8 @@ use risingwave_pb::stream_plan::PbSinkSchemaChange;
 use sea_orm::DatabaseConnection;
 use thiserror_ext::AsReport;
 use tokio::select;
+use tokio::sync::Semaphore;
 use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender};
-use tokio::sync::{Semaphore, SemaphorePermit};
 use tokio::time::sleep;
 use tokio_retry::strategy::{ExponentialBackoff, jitter};
 use tonic::Status;
@@ -534,21 +534,6 @@ impl CoordinatorWorker {
         subscriber: SinkCommittedEpochSubscriber,
         iceberg_compact_stat_sender: UnboundedSender<IcebergSinkCompactionUpdate>,
     ) {
-        let coordinator_init_permit = match COORDINATOR_INIT_SEMAPHORE
-            .acquire()
-            .instrument_await("acquire_sink_coordinator_init_permit")
-            .await
-        {
-            Ok(permit) => permit,
-            Err(e) => {
-                error!(
-                    error = %e.as_report(),
-                    "sink coordinator initialization limiter closed unexpectedly"
-                );
-                return;
-            }
-        };
-
         let sink = match build_sink(param.clone()) {
             Ok(sink) => sink,
             Err(e) => {
@@ -574,36 +559,16 @@ impl CoordinatorWorker {
                         return;
                     }
                 };
-            Self::execute_coordinator_inner(
-                db,
-                param,
-                request_rx,
-                coordinator,
-                subscriber,
-                Some(coordinator_init_permit),
-            )
-            .await
+            Self::execute_coordinator(db, param, request_rx, coordinator, subscriber).await
         });
     }
 
-    #[cfg(test)]
     pub async fn execute_coordinator(
         db: DatabaseConnection,
         param: SinkParam,
         request_rx: UnboundedReceiver<SinkWriterCoordinationHandle>,
         coordinator: SinkCommitCoordinator,
         subscriber: SinkCommittedEpochSubscriber,
-    ) {
-        Self::execute_coordinator_inner(db, param, request_rx, coordinator, subscriber, None).await;
-    }
-
-    async fn execute_coordinator_inner(
-        db: DatabaseConnection,
-        param: SinkParam,
-        request_rx: UnboundedReceiver<SinkWriterCoordinationHandle>,
-        coordinator: SinkCommitCoordinator,
-        subscriber: SinkCommittedEpochSubscriber,
-        coordinator_init_permit: Option<SemaphorePermit<'static>>,
     ) {
         let mut worker = CoordinatorWorker {
             handle_manager: CoordinationHandleManager {
@@ -616,10 +581,7 @@ impl CoordinatorWorker {
             curr_state: CoordinatorWorkerState::Running,
         };
 
-        if let Err(e) = worker
-            .run_coordination(db, coordinator, subscriber, coordinator_init_permit)
-            .await
-        {
+        if let Err(e) = worker.run_coordination(db, coordinator, subscriber).await {
             for handle in worker.handle_manager.writer_handles.into_values() {
                 handle.abort(Status::internal(format!(
                     "failed to run coordination: {:?}",
@@ -710,10 +672,13 @@ impl CoordinatorWorker {
         db: DatabaseConnection,
         mut coordinator: SinkCommitCoordinator,
         subscriber: SinkCommittedEpochSubscriber,
-        coordinator_init_permit: Option<SemaphorePermit<'static>>,
     ) -> anyhow::Result<()> {
         let sink_id = self.handle_manager.param.sink_id;
 
+        let coordinator_init_permit = COORDINATOR_INIT_SEMAPHORE
+            .acquire()
+            .instrument_await("acquire_sink_coordinator_init_permit")
+            .await?;
         let mut two_phase_handler = self
             .init_state_from_store(&db, sink_id, subscriber, &mut coordinator)
             .await?;

--- a/src/meta/src/manager/sink_coordination/coordinator_worker.rs
+++ b/src/meta/src/manager/sink_coordination/coordinator_worker.rs
@@ -16,7 +16,7 @@ use std::collections::{BTreeMap, HashMap, HashSet, VecDeque};
 use std::fmt::Debug;
 use std::future::{Future, poll_fn};
 use std::pin::pin;
-use std::sync::Arc;
+use std::sync::LazyLock;
 use std::task::Poll;
 use std::time::{Duration, Instant};
 
@@ -40,7 +40,7 @@ use sea_orm::DatabaseConnection;
 use thiserror_ext::AsReport;
 use tokio::select;
 use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender};
-use tokio::sync::{OwnedSemaphorePermit, Semaphore};
+use tokio::sync::{Semaphore, SemaphorePermit};
 use tokio::time::sleep;
 use tokio_retry::strategy::{ExponentialBackoff, jitter};
 use tonic::Status;
@@ -51,6 +51,12 @@ use crate::manager::exactly_once_util::{
     persist_pre_commit_metadata,
 };
 use crate::manager::sink_coordination::handle::SinkWriterCoordinationHandle;
+
+// Keep coordinator initialization below the default MetaStore pool size (10), leaving
+// connections available for recovery and other Meta services.
+const MAX_CONCURRENT_COORDINATOR_INITIALIZATIONS: usize = 8;
+static COORDINATOR_INIT_SEMAPHORE: LazyLock<Semaphore> =
+    LazyLock::new(|| Semaphore::new(MAX_CONCURRENT_COORDINATOR_INITIALIZATIONS));
 
 async fn run_future_with_periodic_fn<F: Future>(
     future: F,
@@ -527,10 +533,9 @@ impl CoordinatorWorker {
         db: DatabaseConnection,
         subscriber: SinkCommittedEpochSubscriber,
         iceberg_compact_stat_sender: UnboundedSender<IcebergSinkCompactionUpdate>,
-        coordinator_init_semaphore: Arc<Semaphore>,
     ) {
-        let coordinator_init_permit = match coordinator_init_semaphore
-            .acquire_owned()
+        let coordinator_init_permit = match COORDINATOR_INIT_SEMAPHORE
+            .acquire()
             .instrument_await("acquire_sink_coordinator_init_permit")
             .await
         {
@@ -598,7 +603,7 @@ impl CoordinatorWorker {
         request_rx: UnboundedReceiver<SinkWriterCoordinationHandle>,
         coordinator: SinkCommitCoordinator,
         subscriber: SinkCommittedEpochSubscriber,
-        coordinator_init_permit: Option<OwnedSemaphorePermit>,
+        coordinator_init_permit: Option<SemaphorePermit<'static>>,
     ) {
         let mut worker = CoordinatorWorker {
             handle_manager: CoordinationHandleManager {
@@ -705,7 +710,7 @@ impl CoordinatorWorker {
         db: DatabaseConnection,
         mut coordinator: SinkCommitCoordinator,
         subscriber: SinkCommittedEpochSubscriber,
-        coordinator_init_permit: Option<OwnedSemaphorePermit>,
+        coordinator_init_permit: Option<SemaphorePermit<'static>>,
     ) -> anyhow::Result<()> {
         let sink_id = self.handle_manager.param.sink_id;
 

--- a/src/meta/src/manager/sink_coordination/coordinator_worker.rs
+++ b/src/meta/src/manager/sink_coordination/coordinator_worker.rs
@@ -16,6 +16,7 @@ use std::collections::{BTreeMap, HashMap, HashSet, VecDeque};
 use std::fmt::Debug;
 use std::future::{Future, poll_fn};
 use std::pin::pin;
+use std::sync::Arc;
 use std::task::Poll;
 use std::time::{Duration, Instant};
 
@@ -39,6 +40,7 @@ use sea_orm::DatabaseConnection;
 use thiserror_ext::AsReport;
 use tokio::select;
 use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender};
+use tokio::sync::{OwnedSemaphorePermit, Semaphore};
 use tokio::time::sleep;
 use tokio_retry::strategy::{ExponentialBackoff, jitter};
 use tonic::Status;
@@ -525,7 +527,23 @@ impl CoordinatorWorker {
         db: DatabaseConnection,
         subscriber: SinkCommittedEpochSubscriber,
         iceberg_compact_stat_sender: UnboundedSender<IcebergSinkCompactionUpdate>,
+        coordinator_init_semaphore: Arc<Semaphore>,
     ) {
+        let coordinator_init_permit = match coordinator_init_semaphore
+            .acquire_owned()
+            .instrument_await("acquire_sink_coordinator_init_permit")
+            .await
+        {
+            Ok(permit) => permit,
+            Err(e) => {
+                error!(
+                    error = %e.as_report(),
+                    "sink coordinator initialization limiter closed unexpectedly"
+                );
+                return;
+            }
+        };
+
         let sink = match build_sink(param.clone()) {
             Ok(sink) => sink,
             Err(e) => {
@@ -551,16 +569,36 @@ impl CoordinatorWorker {
                         return;
                     }
                 };
-            Self::execute_coordinator(db, param, request_rx, coordinator, subscriber).await
+            Self::execute_coordinator_inner(
+                db,
+                param,
+                request_rx,
+                coordinator,
+                subscriber,
+                Some(coordinator_init_permit),
+            )
+            .await
         });
     }
 
+    #[cfg(test)]
     pub async fn execute_coordinator(
         db: DatabaseConnection,
         param: SinkParam,
         request_rx: UnboundedReceiver<SinkWriterCoordinationHandle>,
         coordinator: SinkCommitCoordinator,
         subscriber: SinkCommittedEpochSubscriber,
+    ) {
+        Self::execute_coordinator_inner(db, param, request_rx, coordinator, subscriber, None).await;
+    }
+
+    async fn execute_coordinator_inner(
+        db: DatabaseConnection,
+        param: SinkParam,
+        request_rx: UnboundedReceiver<SinkWriterCoordinationHandle>,
+        coordinator: SinkCommitCoordinator,
+        subscriber: SinkCommittedEpochSubscriber,
+        coordinator_init_permit: Option<OwnedSemaphorePermit>,
     ) {
         let mut worker = CoordinatorWorker {
             handle_manager: CoordinationHandleManager {
@@ -573,7 +611,10 @@ impl CoordinatorWorker {
             curr_state: CoordinatorWorkerState::Running,
         };
 
-        if let Err(e) = worker.run_coordination(db, coordinator, subscriber).await {
+        if let Err(e) = worker
+            .run_coordination(db, coordinator, subscriber, coordinator_init_permit)
+            .await
+        {
             for handle in worker.handle_manager.writer_handles.into_values() {
                 handle.abort(Status::internal(format!(
                     "failed to run coordination: {:?}",
@@ -664,6 +705,7 @@ impl CoordinatorWorker {
         db: DatabaseConnection,
         mut coordinator: SinkCommitCoordinator,
         subscriber: SinkCommittedEpochSubscriber,
+        coordinator_init_permit: Option<OwnedSemaphorePermit>,
     ) -> anyhow::Result<()> {
         let sink_id = self.handle_manager.param.sink_id;
 
@@ -674,6 +716,7 @@ impl CoordinatorWorker {
             SinkCommitCoordinator::SinglePhase(coordinator) => coordinator.init().await?,
             SinkCommitCoordinator::TwoPhase(coordinator) => coordinator.init().await?,
         }
+        drop(coordinator_init_permit);
 
         let mut running_handles = self.handle_manager.wait_init_handles().await?;
         self.try_handle_init_requests(&running_handles, &mut two_phase_handler)

--- a/src/meta/src/manager/sink_coordination/manager.rs
+++ b/src/meta/src/manager/sink_coordination/manager.rs
@@ -31,7 +31,7 @@ use sea_orm::DatabaseConnection;
 use thiserror_ext::AsReport;
 use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender, unbounded_channel};
 use tokio::sync::oneshot::{Receiver, Sender, channel};
-use tokio::sync::{Semaphore, mpsc, oneshot};
+use tokio::sync::{mpsc, oneshot};
 use tokio::task::{JoinError, JoinHandle};
 use tokio_stream::wrappers::UnboundedReceiverStream;
 use tonic::Status;
@@ -60,9 +60,6 @@ macro_rules! send_await_with_err_check {
 }
 
 const BOUNDED_CHANNEL_SIZE: usize = 16;
-// Keep coordinator initialization below the default MetaStore pool size (10), leaving
-// connections available for recovery and other Meta services.
-const MAX_CONCURRENT_COORDINATOR_INITIALIZATIONS: usize = 8;
 
 enum ManagerRequest {
     NewSinkWriter(SinkWriterCoordinationHandle),
@@ -110,8 +107,6 @@ impl SinkCoordinatorManager {
         await_tree_reg: await_tree::Registry,
     ) -> (Self, (JoinHandle<()>, Sender<()>)) {
         let subscriber = new_committed_epoch_subscriber(hummock_manager, metadata_manager);
-        let coordinator_init_semaphore =
-            Arc::new(Semaphore::new(MAX_CONCURRENT_COORDINATOR_INITIALIZATIONS));
         Self::start_worker_with_spawn_worker({
             move |param, manager_request_stream| {
                 let sink_id = param.sink_id;
@@ -121,7 +116,6 @@ impl SinkCoordinatorManager {
                     db.clone(),
                     subscriber.clone(),
                     iceberg_compact_stat_sender.clone(),
-                    coordinator_init_semaphore.clone(),
                 );
                 tokio::spawn(
                     await_tree_reg

--- a/src/meta/src/manager/sink_coordination/manager.rs
+++ b/src/meta/src/manager/sink_coordination/manager.rs
@@ -31,7 +31,7 @@ use sea_orm::DatabaseConnection;
 use thiserror_ext::AsReport;
 use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender, unbounded_channel};
 use tokio::sync::oneshot::{Receiver, Sender, channel};
-use tokio::sync::{mpsc, oneshot};
+use tokio::sync::{Semaphore, mpsc, oneshot};
 use tokio::task::{JoinError, JoinHandle};
 use tokio_stream::wrappers::UnboundedReceiverStream;
 use tonic::Status;
@@ -60,6 +60,9 @@ macro_rules! send_await_with_err_check {
 }
 
 const BOUNDED_CHANNEL_SIZE: usize = 16;
+// Keep coordinator initialization below the default MetaStore pool size (10), leaving
+// connections available for recovery and other Meta services.
+const MAX_CONCURRENT_COORDINATOR_INITIALIZATIONS: usize = 8;
 
 enum ManagerRequest {
     NewSinkWriter(SinkWriterCoordinationHandle),
@@ -107,6 +110,8 @@ impl SinkCoordinatorManager {
         await_tree_reg: await_tree::Registry,
     ) -> (Self, (JoinHandle<()>, Sender<()>)) {
         let subscriber = new_committed_epoch_subscriber(hummock_manager, metadata_manager);
+        let coordinator_init_semaphore =
+            Arc::new(Semaphore::new(MAX_CONCURRENT_COORDINATOR_INITIALIZATIONS));
         Self::start_worker_with_spawn_worker({
             move |param, manager_request_stream| {
                 let sink_id = param.sink_id;
@@ -116,6 +121,7 @@ impl SinkCoordinatorManager {
                     db.clone(),
                     subscriber.clone(),
                     iceberg_compact_stat_sender.clone(),
+                    coordinator_init_semaphore.clone(),
                 );
                 tokio::spawn(
                     await_tree_reg

--- a/src/stream/src/executor/sink.rs
+++ b/src/stream/src/executor/sink.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use std::collections::{BTreeMap, HashMap};
+use std::time::{Duration, Instant};
 use std::{assert_matches, mem};
 
 use anyhow::anyhow;
@@ -44,6 +45,7 @@ use thiserror_ext::AsReport;
 use tokio::select;
 use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender, unbounded_channel};
 use tokio::sync::oneshot;
+use tokio_retry::strategy::{ExponentialBackoff, jitter};
 
 use crate::common::change_buffer::{OutputKind, output_kind};
 use crate::common::compact_chunk::{
@@ -63,6 +65,19 @@ pub struct SinkExecutor<F: LogStoreFactory> {
     input_data_types: Vec<DataType>,
     non_append_only_behavior: Option<NonAppendOnlyBehavior>,
     rate_limit: Option<u32>,
+}
+
+const SINK_RETRY_BACKOFF_RESET_INTERVAL: Duration = Duration::from_secs(60);
+
+fn sink_retry_backoff() -> ExponentialBackoff {
+    ExponentialBackoff::from_millis(2)
+        .factor(500)
+        .max_delay(Duration::from_secs(30))
+}
+
+fn jitter_sink_retry_delay(delay: Duration) -> Duration {
+    let half = delay / 2;
+    half + jitter(half)
 }
 
 // Drop all the DELETE messages in this chunk and convert UPDATE INSERT into INSERT.
@@ -780,14 +795,17 @@ impl<F: LogStoreFactory> SinkExecutor<F> {
             .rate_limited(rate_limit_rx);
 
         log_reader.init().await?;
+        let mut retry_backoff = sink_retry_backoff();
         loop {
             // Boxed so that `drop` below releases its borrows on `log_reader` and `sink`.
             let mut future = Box::pin(async {
                 loop {
+                    let attempt_started_at = Instant::now();
                     let Err(e) = sink
                         .new_log_sinker(sink_writer_param.clone())
                         .and_then(|log_sinker| log_sinker.consume_log_and_sink(&mut log_reader))
                         .await;
+                    let attempt_duration = attempt_started_at.elapsed();
                     GLOBAL_ERROR_METRICS.user_sink_error.report([
                         "sink_executor_error".to_owned(),
                         sink_param.sink_id.to_string(),
@@ -809,12 +827,20 @@ impl<F: LogStoreFactory> SinkExecutor<F> {
                     if F::ALLOW_REWIND {
                         match log_reader.rewind().await {
                             Ok(()) => {
+                                if attempt_duration >= SINK_RETRY_BACKOFF_RESET_INTERVAL {
+                                    retry_backoff = sink_retry_backoff();
+                                }
+                                let retry_delay = jitter_sink_retry_delay(
+                                    retry_backoff.next().expect("retry strategy is infinite"),
+                                );
                                 error!(
                                     error = %e.as_report(),
                                     executor_id = %sink_writer_param.executor_id,
                                     sink_id = %sink_param.sink_id,
-                                    "reset log reader stream successfully after sink error"
+                                    ?retry_delay,
+                                    "reset log reader stream successfully after sink error; retrying after backoff"
                                 );
+                                tokio::time::sleep(retry_delay).await;
                                 Ok(())
                             }
                             Err(rewind_err) => {
@@ -1203,6 +1229,25 @@ mod test {
         assert_eq!(state.start_count.load(Ordering::SeqCst), 1);
         assert_eq!(state.rewind_count.load(Ordering::SeqCst), 0);
         drop(rate_limit_tx);
+    }
+
+    #[test]
+    fn test_sink_retry_backoff_is_bounded() {
+        let mut retry_backoff = sink_retry_backoff();
+        for expected in [1, 2, 4, 8, 16, 30, 30].map(Duration::from_secs) {
+            assert_eq!(retry_backoff.next(), Some(expected));
+        }
+    }
+
+    #[test]
+    fn test_sink_retry_jitter_stays_in_upper_half() {
+        for delay in [Duration::from_secs(1), Duration::from_secs(30)] {
+            for _ in 0..100 {
+                let jittered = jitter_sink_retry_delay(delay);
+                assert!(jittered >= delay / 2);
+                assert!(jittered <= delay);
+            }
+        }
     }
 
     #[tokio::test]

--- a/src/stream/src/executor/sink.rs
+++ b/src/stream/src/executor/sink.rs
@@ -69,15 +69,11 @@ pub struct SinkExecutor<F: LogStoreFactory> {
 
 const SINK_RETRY_BACKOFF_RESET_INTERVAL: Duration = Duration::from_secs(60);
 
-fn sink_retry_backoff() -> ExponentialBackoff {
+fn sink_retry_backoff() -> impl Iterator<Item = Duration> {
     ExponentialBackoff::from_millis(2)
         .factor(500)
         .max_delay(Duration::from_secs(30))
-}
-
-fn jitter_sink_retry_delay(delay: Duration) -> Duration {
-    let half = delay / 2;
-    half + jitter(half)
+        .map(jitter)
 }
 
 // Drop all the DELETE messages in this chunk and convert UPDATE INSERT into INSERT.
@@ -830,9 +826,8 @@ impl<F: LogStoreFactory> SinkExecutor<F> {
                                 if attempt_duration >= SINK_RETRY_BACKOFF_RESET_INTERVAL {
                                     retry_backoff = sink_retry_backoff();
                                 }
-                                let retry_delay = jitter_sink_retry_delay(
-                                    retry_backoff.next().expect("retry strategy is infinite"),
-                                );
+                                let retry_delay =
+                                    retry_backoff.next().expect("retry strategy is infinite");
                                 error!(
                                     error = %e.as_report(),
                                     executor_id = %sink_writer_param.executor_id,
@@ -1234,19 +1229,8 @@ mod test {
     #[test]
     fn test_sink_retry_backoff_is_bounded() {
         let mut retry_backoff = sink_retry_backoff();
-        for expected in [1, 2, 4, 8, 16, 30, 30].map(Duration::from_secs) {
-            assert_eq!(retry_backoff.next(), Some(expected));
-        }
-    }
-
-    #[test]
-    fn test_sink_retry_jitter_stays_in_upper_half() {
-        for delay in [Duration::from_secs(1), Duration::from_secs(30)] {
-            for _ in 0..100 {
-                let jittered = jitter_sink_retry_delay(delay);
-                assert!(jittered >= delay / 2);
-                assert!(jittered <= delay);
-            }
+        for max_delay in [1, 2, 4, 8, 16, 30, 30].map(Duration::from_secs) {
+            assert!(retry_backoff.next().expect("retry strategy is infinite") <= max_delay);
         }
     }
 


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

During cluster recovery, all sink coordinators currently initialize at once. A transient MetaStore pool timeout terminates the coordinator worker, while KV log-store sinks immediately rewind and reconnect. With many Iceberg sinks, this creates repeated synchronized request bursts against both the external catalog and the MetaStore.

This change:

- limits concurrent sink coordinator initialization to 8 per Meta process, leaving capacity in the default 10-connection MetaStore pool for recovery and other Meta services;
- holds the permit through coordinator construction, persisted-state recovery, and coordinator initialization, then releases it before the long-running commit loop;
- adds exponential retry backoff with equal jitter for rewindable sink writers (1s to 30s strategy, reset after a 60s healthy attempt) to prevent synchronized reconnect loops;
- skips the MetaStore cleanup query when there are no aborted sink epochs.

The patch does not change exactly-once state transitions or persisted sink metadata semantics. This is the `main` counterpart of release-3.0 hotfix #26639.

## Verification

- `cargo +nightly-2026-06-11 test -p risingwave_stream executor::sink::test --lib` (14 passed)
- `cargo +nightly-2026-06-11 test -p risingwave_meta manager::sink_coordination --lib` (11 passed)
- `cargo +nightly-2026-06-11 fmt --all -- --check`
- `cargo +nightly-2026-06-11 clippy -p risingwave_meta -p risingwave_stream --all-targets -- -D warnings`
- `git diff --check`

## Checklist

- [x] I have written necessary rustdoc comments.
- [x] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [x] <!-- OPTIONAL --> I have added test labels as necessary.
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them.
- [ ] <!-- OPTIONAL --> My PR contains breaking changes.
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results.
- [x] <!-- OPTIONAL --> I have checked the Release Timeline and Currently Supported Versions to determine which release branches I need to cherry-pick this PR into.

## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates.

<details>
<summary><b>Release note</b></summary>

Improves cluster recovery stability when many sinks reconnect simultaneously by throttling coordinator initialization and adding retry backoff.

</details>
