### PR TITLE
fix(iceberg): bump dependencies for operator caching

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6840,7 +6840,7 @@ dependencies = [
 [[package]]
 name = "iceberg"
 version = "0.8.0"
-source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=6bd8e98fe920def857f80024f5a666c9631e80f4#6bd8e98fe920def857f80024f5a666c9631e80f4"
+source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=deb4a3c8d5277b76d60f43ecaf6d598b0de50873#deb4a3c8d5277b76d60f43ecaf6d598b0de50873"
 dependencies = [
  "anyhow",
  "apache-avro 0.21.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -6899,7 +6899,7 @@ dependencies = [
 [[package]]
 name = "iceberg-catalog-glue"
 version = "0.8.0"
-source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=6bd8e98fe920def857f80024f5a666c9631e80f4#6bd8e98fe920def857f80024f5a666c9631e80f4"
+source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=deb4a3c8d5277b76d60f43ecaf6d598b0de50873#deb4a3c8d5277b76d60f43ecaf6d598b0de50873"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6914,7 +6914,7 @@ dependencies = [
 [[package]]
 name = "iceberg-catalog-rest"
 version = "0.8.0"
-source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=6bd8e98fe920def857f80024f5a666c9631e80f4#6bd8e98fe920def857f80024f5a666c9631e80f4"
+source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=deb4a3c8d5277b76d60f43ecaf6d598b0de50873#deb4a3c8d5277b76d60f43ecaf6d598b0de50873"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -6936,7 +6936,7 @@ dependencies = [
 [[package]]
 name = "iceberg-compaction-core"
 version = "0.1.0"
-source = "git+https://github.com/nimtable/iceberg-compaction.git?rev=200543af4e56bc9c476e9782e3664ab5b47a568b#200543af4e56bc9c476e9782e3664ab5b47a568b"
+source = "git+https://github.com/nimtable/iceberg-compaction.git?rev=74bdc45cb17feaf0ec4eb351d4be271c99d3624c#74bdc45cb17feaf0ec4eb351d4be271c99d3624c"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -6965,7 +6965,7 @@ dependencies = [
 [[package]]
 name = "iceberg-datafusion"
 version = "0.8.0"
-source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=6bd8e98fe920def857f80024f5a666c9631e80f4#6bd8e98fe920def857f80024f5a666c9631e80f4"
+source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=deb4a3c8d5277b76d60f43ecaf6d598b0de50873#deb4a3c8d5277b76d60f43ecaf6d598b0de50873"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -172,14 +172,14 @@ hashbrown0_16 = { package = "hashbrown", version = "0.16.1", features = [
 ] }
 hytra = "0.1"
 # branch dev_rebase_main_20260303
-iceberg = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "6bd8e98fe920def857f80024f5a666c9631e80f4", features = [
+iceberg = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "deb4a3c8d5277b76d60f43ecaf6d598b0de50873", features = [
     "storage-s3",
     "storage-gcs",
     "storage-azblob",
     "storage-azdls",
 ] }
-iceberg-catalog-glue = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "6bd8e98fe920def857f80024f5a666c9631e80f4" }
-iceberg-catalog-rest = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "6bd8e98fe920def857f80024f5a666c9631e80f4" }
+iceberg-catalog-glue = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "deb4a3c8d5277b76d60f43ecaf6d598b0de50873" }
+iceberg-catalog-rest = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "deb4a3c8d5277b76d60f43ecaf6d598b0de50873" }
 indexmap = { version = "2.12.0", features = ["serde"] }
 itertools = "0.14.0"
 jni = { version = "0.21.1", features = ["invocation"] }

--- a/src/storage/Cargo.toml
+++ b/src/storage/Cargo.toml
@@ -34,7 +34,7 @@ futures = { version = "0.3", default-features = false, features = ["alloc"] }
 futures-async-stream = { workspace = true }
 hex = "0.4"
 iceberg = { workspace = true }
-iceberg-compaction-core = { git = "https://github.com/nimtable/iceberg-compaction.git", rev = "200543af4e56bc9c476e9782e3664ab5b47a568b" }
+iceberg-compaction-core = { git = "https://github.com/nimtable/iceberg-compaction.git", rev = "74bdc45cb17feaf0ec4eb351d4be271c99d3624c" }
 itertools = { workspace = true }
 libc = "0.2"
 lz4 = "1.28.0"


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

- Bump `iceberg-rust` from `6bd8e98f` to `deb4a3c8`, which includes [risingwavelabs/iceberg-rust#208](https://github.com/risingwavelabs/iceberg-rust/pull/208) to cache S3 and GCS OpenDAL operators by bucket.
- Bump `iceberg-compaction` from `200543af` to `74bdc45c`, the merge commit of [nimtable/iceberg-compaction#167](https://github.com/nimtable/iceberg-compaction/pull/167), which uses the same `iceberg-rust` revision.
- Keep RisingWave's direct Iceberg dependencies and the compaction library on one exact `iceberg-rust` revision.

This lets Iceberg file operations reuse configured OpenDAL operators and their credential/token state instead of rebuilding them repeatedly, reducing client and authentication churn during sink recovery and compaction.

## Verification

- `cargo metadata --locked --format-version 1 --no-deps`
- `cargo tree --locked -p risingwave_storage -i iceberg`
- `cargo check --locked -p risingwave_storage --all-targets`
- `cargo check --locked -p risingwave_connector --all-targets`
- `cargo test --locked -p risingwave_storage --lib iceberg_compaction` (15 passed)
- `cargo fmt --all -- --check`
- `cargo sort --check . src/storage`
- `git diff --check`

## Checklist

- [x] I have run the existing relevant tests. (The cache behavior is covered by the upstream fix; RisingWave's Iceberg compaction tests pass.)
- [x] I have added test labels as necessary.

This dependency-only change adds no Rust API, breaking behavior, or fuzzing surface.

## Documentation

No documentation update is required; this is an internal dependency and operator-cache fix with no user-facing interface change.
