### PR TITLE
feat(iceberg): support auto compaction type

### DIFF
--- a/proto/iceberg_compaction.proto
+++ b/proto/iceberg_compaction.proto
@@ -45,7 +45,6 @@ message SubscribeIcebergCompactionEventRequest {
 
 message IcebergCompactionTask {
   uint64 task_id = 1;
-  // Now we only support iceberg table full compaction.
   // compactor will get the information of the iceberg table from the properties
   map<string, string> props = 2;
 
@@ -58,6 +57,9 @@ message IcebergCompactionTask {
     SMALL_FILES = 2;
 
     FILES_WITH_DELETE = 3;
+
+    // Select a localized compaction strategy from the current snapshot.
+    AUTO = 4;
   }
 
   TaskType task_type = 3;

--- a/src/connector/src/sink/iceberg/config.rs
+++ b/src/connector/src/sink/iceberg/config.rs
@@ -41,6 +41,7 @@ pub const ICEBERG_COW_BRANCH: &str = "ingestion";
 
 pub const ICEBERG_WRITE_MODE_MERGE_ON_READ: &str = "merge-on-read";
 pub const ICEBERG_WRITE_MODE_COPY_ON_WRITE: &str = "copy-on-write";
+pub const ICEBERG_COMPACTION_TYPE_AUTO: &str = "auto";
 pub const ICEBERG_COMPACTION_TYPE_FULL: &str = "full";
 pub const ICEBERG_COMPACTION_TYPE_SMALL_FILES: &str = "small-files";
 pub const ICEBERG_COMPACTION_TYPE_FILES_WITH_DELETE: &str = "files-with-delete";
@@ -227,6 +228,8 @@ where
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
 #[serde(rename_all = "kebab-case")]
 pub enum CompactionType {
+    /// Auto compaction - selects a localized strategy from the current snapshot
+    Auto,
     /// Full compaction - rewrites all data files
     #[default]
     Full,
@@ -239,6 +242,7 @@ pub enum CompactionType {
 impl CompactionType {
     pub fn as_str(&self) -> &'static str {
         match self {
+            CompactionType::Auto => ICEBERG_COMPACTION_TYPE_AUTO,
             CompactionType::Full => ICEBERG_COMPACTION_TYPE_FULL,
             CompactionType::SmallFiles => ICEBERG_COMPACTION_TYPE_SMALL_FILES,
             CompactionType::FilesWithDelete => ICEBERG_COMPACTION_TYPE_FILES_WITH_DELETE,
@@ -251,12 +255,14 @@ impl std::str::FromStr for CompactionType {
 
     fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
         match s {
+            ICEBERG_COMPACTION_TYPE_AUTO => Ok(CompactionType::Auto),
             ICEBERG_COMPACTION_TYPE_FULL => Ok(CompactionType::Full),
             ICEBERG_COMPACTION_TYPE_SMALL_FILES => Ok(CompactionType::SmallFiles),
             ICEBERG_COMPACTION_TYPE_FILES_WITH_DELETE => Ok(CompactionType::FilesWithDelete),
             _ => Err(SinkError::Config(anyhow!(format!(
-                "invalid compaction_type: {}, must be one of: {}, {}, {}",
+                "invalid compaction_type: {}, must be one of: {}, {}, {}, {}",
                 s,
+                ICEBERG_COMPACTION_TYPE_AUTO,
                 ICEBERG_COMPACTION_TYPE_FULL,
                 ICEBERG_COMPACTION_TYPE_SMALL_FILES,
                 ICEBERG_COMPACTION_TYPE_FILES_WITH_DELETE
@@ -456,7 +462,7 @@ pub struct IcebergConfig {
     #[with_option(allow_alter_on_fly, iceberg_engine)]
     pub target_file_size_mb: Option<u64>,
 
-    /// Compaction type: `full`, `small-files`, or `files-with-delete`
+    /// Compaction type: `auto`, `full`, `small-files`, or `files-with-delete`
     /// If not set, will default to `full`
     #[serde(rename = "compaction.type", default)]
     #[with_option(allow_alter_on_fly, iceberg_engine)]

--- a/src/connector/src/sink/iceberg/mod.rs
+++ b/src/connector/src/sink/iceberg/mod.rs
@@ -188,6 +188,18 @@ impl Sink for IcebergSink {
         }
 
         match compaction_type {
+            CompactionType::Auto => {
+                risingwave_common::license::Feature::IcebergCompaction
+                    .check_available()
+                    .map_err(|e| anyhow::anyhow!(e))?;
+
+                if self.config.write_mode != IcebergWriteMode::MergeOnRead {
+                    bail!(
+                        "'auto' compaction type only supports 'merge-on-read' write mode, got: '{}'",
+                        self.config.write_mode
+                    );
+                }
+            }
             CompactionType::SmallFiles => {
                 // 1. check license
                 risingwave_common::license::Feature::IcebergCompaction

--- a/src/connector/src/sink/iceberg/test.rs
+++ b/src/connector/src/sink/iceberg/test.rs
@@ -599,7 +599,7 @@ fn test_parse_compaction_config() {
         ("compaction.delete_files_count_threshold", "50"),
         ("compaction.trigger_snapshot_count", "10"),
         ("compaction.target_file_size_mb", "256"),
-        ("compaction.type", "full"),
+        ("compaction.type", "auto"),
         ("compaction.write_parquet_compression", "zstd"),
         ("compaction.write_parquet_max_row_group_rows", "50000"),
         ("compaction.write_parquet_max_row_group_bytes", "67108864"),
@@ -618,7 +618,7 @@ fn test_parse_compaction_config() {
     assert_eq!(config.delete_files_count_threshold, Some(50));
     assert_eq!(config.trigger_snapshot_count, Some(10));
     assert_eq!(config.target_file_size_mb, Some(256));
-    assert_eq!(config.compaction_type, Some(CompactionType::Full));
+    assert_eq!(config.compaction_type, Some(CompactionType::Auto));
     assert_eq!(config.target_file_size_mb(), 256);
     assert_eq!(config.write_parquet_compression(), "zstd");
     assert_eq!(config.write_parquet_max_row_group_rows(), Some(50000));

--- a/src/connector/with_options_sink.yaml
+++ b/src/connector/with_options_sink.yaml
@@ -824,7 +824,7 @@ IcebergConfig:
   - name: compaction.type
     field_type: CompactionType
     comments: |-
-      Compaction type: `full`, `small-files`, or `files-with-delete`
+      Compaction type: `auto`, `full`, `small-files`, or `files-with-delete`
       If not set, will default to `full`
     required: false
     default: Default::default

--- a/src/meta/src/manager/iceberg_compaction/schedule.rs
+++ b/src/meta/src/manager/iceberg_compaction/schedule.rs
@@ -820,6 +820,7 @@ impl IcebergCompactionManager {
                 TaskType::Full
             } else {
                 match iceberg_config.compaction_type() {
+                    CompactionType::Auto => TaskType::Auto,
                     CompactionType::Full => TaskType::Full,
                     CompactionType::SmallFiles => TaskType::SmallFiles,
                     CompactionType::FilesWithDelete => TaskType::FilesWithDelete,

--- a/src/meta/src/manager/iceberg_compaction/schedule/tests.rs
+++ b/src/meta/src/manager/iceberg_compaction/schedule/tests.rs
@@ -145,6 +145,7 @@ fn new_test_iceberg_config(
     values.insert(
         "compaction.type".to_owned(),
         match compaction_type {
+            CompactionType::Auto => "auto",
             CompactionType::Full => "full",
             CompactionType::SmallFiles => "small-files",
             CompactionType::FilesWithDelete => "files-with-delete",
@@ -617,7 +618,7 @@ async fn test_apply_sink_update_refreshes_existing_idle_track() {
     manager.inner.write().sink_schedules.insert(sink_id, track);
 
     let refresh_at = now + Duration::from_secs(30);
-    let config = new_test_iceberg_config(300, 3, CompactionType::SmallFiles);
+    let config = new_test_iceberg_config(300, 3, CompactionType::Auto);
     let mut guard = manager.inner.write();
 
     manager.apply_sink_update(
@@ -632,7 +633,7 @@ async fn test_apply_sink_update_refreshes_existing_idle_track() {
     );
 
     let track = guard.sink_schedules.get(&sink_id).unwrap();
-    assert_eq!(track.task_type, TaskType::SmallFiles);
+    assert_eq!(track.task_type, TaskType::Auto);
     assert_eq!(track.trigger_interval_sec, 300);
     assert_eq!(track.trigger_snapshot_count, 3);
     assert_eq!(track.last_config_refresh_at, refresh_at);

--- a/src/storage/src/hummock/compactor/iceberg_compaction/iceberg_compactor_runner.rs
+++ b/src/storage/src/hummock/compactor/iceberg_compaction/iceberg_compactor_runner.rs
@@ -20,13 +20,13 @@ use derive_builder::Builder;
 use iceberg::spec::MAIN_BRANCH;
 use iceberg::{Catalog, TableIdent};
 use iceberg_compaction_core::compaction::{
-    CommitConsistencyParams, CommitManagerRetryConfig, CompactionBuilder, CompactionPlan,
-    CompactionPlanner, CompactionResult,
+    AutoCompactionPlanner, CommitConsistencyParams, CommitManagerRetryConfig, CompactionBuilder,
+    CompactionPlan, CompactionPlanner, CompactionResult,
 };
 use iceberg_compaction_core::config::{
-    CompactionExecutionConfigBuilder, CompactionPlanningConfig, FileGroupScope,
-    FilesWithDeletesConfigBuilder, FullCompactionConfigBuilder, GroupFilters,
-    SmallFilesConfigBuilder,
+    AutoCompactionConfig, AutoCompactionConfigBuilder, CompactionExecutionConfigBuilder,
+    CompactionPlanningConfig, FileGroupScope, FilesWithDeletesConfigBuilder,
+    FullCompactionConfigBuilder, GroupFilters, SmallFilesConfigBuilder,
 };
 use iceberg_compaction_core::executor::RewriteFilesStat;
 use mixtrics::registry::prometheus::PrometheusMetricsRegistry;
@@ -98,6 +98,11 @@ pub struct IcebergCompactionTaskStatistics {
     pub total_eq_del_file_count: u32,
 }
 
+enum IcebergTaskPlanningConfig {
+    Auto(AutoCompactionConfig),
+    Explicit(CompactionPlanningConfig),
+}
+
 impl Debug for IcebergCompactionTaskStatistics {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("IcebergCompactionTaskStatistics")
@@ -157,6 +162,7 @@ impl IcebergCompactionPlanRunner {
     /// ```
     pub fn unique_ident(&self) -> String {
         let task_type_str = match self.task_type {
+            TaskType::Auto => "auto",
             TaskType::SmallFiles => "small-files",
             TaskType::Full => "full",
             TaskType::FilesWithDelete => "files-with-delete",
@@ -468,6 +474,121 @@ fn analyze_task_statistics(plan: &CompactionPlan) -> IcebergCompactionTaskStatis
     }
 }
 
+fn build_task_planning_config(
+    task_type: TaskType,
+    iceberg_config: &IcebergConfig,
+    config: &IcebergCompactorRunnerConfig,
+) -> HummockResult<IcebergTaskPlanningConfig> {
+    let grouping_strategy = match iceberg_config.write_mode {
+        IcebergWriteMode::CopyOnWrite => iceberg_compaction_core::config::GroupingStrategy::Single,
+        IcebergWriteMode::MergeOnRead => match config.target_binpack_group_size_mb {
+            Some(target_binpack_group_size_mb) => {
+                iceberg_compaction_core::config::GroupingStrategy::BinPack(
+                    iceberg_compaction_core::config::BinPackConfig::new(
+                        target_binpack_group_size_mb * 1024 * 1024,
+                    ),
+                )
+            }
+            None => iceberg_compaction_core::config::GroupingStrategy::Single,
+        },
+    };
+
+    let group_filters =
+        if config.min_group_size_mb.is_some() || config.min_group_file_count.is_some() {
+            Some(GroupFilters {
+                min_group_size_bytes: config.min_group_size_mb.map(|mb| mb * 1024 * 1024),
+                min_group_file_count: config.min_group_file_count,
+            })
+        } else {
+            None
+        };
+
+    let planning_config = match task_type {
+        TaskType::Auto => {
+            let mut builder = AutoCompactionConfigBuilder::default();
+            builder
+                .max_input_parallelism(config.max_parallelism as usize)
+                .max_output_parallelism(config.max_parallelism as usize)
+                .min_size_per_partition(config.min_size_per_partition)
+                .max_file_count_per_partition(config.max_file_count_per_partition as usize)
+                .target_file_size_bytes(iceberg_config.target_file_size_mb() * 1024 * 1024)
+                .enable_heuristic_output_parallelism(config.enable_heuristic_output_parallelism)
+                .small_file_threshold_bytes(iceberg_config.small_files_threshold_mb() * 1024 * 1024)
+                .min_delete_file_count_threshold(iceberg_config.delete_files_count_threshold())
+                .grouping_strategy(grouping_strategy);
+
+            if let Some(group_filters) = group_filters {
+                builder.group_filters(group_filters);
+            }
+
+            let config = builder
+                .build()
+                .map_err(|e| HummockError::compaction_executor(e.as_report()))?;
+            IcebergTaskPlanningConfig::Auto(config)
+        }
+        TaskType::SmallFiles => {
+            let mut builder = SmallFilesConfigBuilder::default();
+            builder
+                .max_input_parallelism(config.max_parallelism as usize)
+                .max_output_parallelism(config.max_parallelism as usize)
+                .min_size_per_partition(config.min_size_per_partition)
+                .max_file_count_per_partition(config.max_file_count_per_partition as usize)
+                .target_file_size_bytes(iceberg_config.target_file_size_mb() * 1024 * 1024)
+                .enable_heuristic_output_parallelism(config.enable_heuristic_output_parallelism)
+                .small_file_threshold_bytes(iceberg_config.small_files_threshold_mb() * 1024 * 1024)
+                .grouping_strategy(grouping_strategy);
+
+            if let Some(group_filters) = group_filters {
+                builder.group_filters(group_filters);
+            }
+
+            let config = builder
+                .build()
+                .map_err(|e| HummockError::compaction_executor(e.as_report()))?;
+            IcebergTaskPlanningConfig::Explicit(CompactionPlanningConfig::SmallFiles(config))
+        }
+        TaskType::Full => {
+            let file_group_scope = if should_enable_iceberg_cow(
+                iceberg_config.r#type.as_str(),
+                iceberg_config.write_mode,
+            ) {
+                FileGroupScope::Table
+            } else {
+                FileGroupScope::Partition
+            };
+            let config = FullCompactionConfigBuilder::default()
+                .max_input_parallelism(config.max_parallelism as usize)
+                .max_output_parallelism(config.max_parallelism as usize)
+                .min_size_per_partition(config.min_size_per_partition)
+                .max_file_count_per_partition(config.max_file_count_per_partition as usize)
+                .target_file_size_bytes(iceberg_config.target_file_size_mb() * 1024 * 1024)
+                .enable_heuristic_output_parallelism(config.enable_heuristic_output_parallelism)
+                .grouping_strategy(grouping_strategy)
+                .file_group_scope(file_group_scope)
+                .build()
+                .map_err(|e| HummockError::compaction_executor(e.as_report()))?;
+            IcebergTaskPlanningConfig::Explicit(CompactionPlanningConfig::Full(config))
+        }
+        TaskType::FilesWithDelete => {
+            let config = FilesWithDeletesConfigBuilder::default()
+                .max_input_parallelism(config.max_parallelism as usize)
+                .max_output_parallelism(config.max_parallelism as usize)
+                .min_size_per_partition(config.min_size_per_partition)
+                .max_file_count_per_partition(config.max_file_count_per_partition as usize)
+                .target_file_size_bytes(iceberg_config.target_file_size_mb() * 1024 * 1024)
+                .enable_heuristic_output_parallelism(config.enable_heuristic_output_parallelism)
+                .grouping_strategy(grouping_strategy)
+                .min_delete_file_count_threshold(iceberg_config.delete_files_count_threshold())
+                .build()
+                .map_err(|e| HummockError::compaction_executor(e.as_report()))?;
+            IcebergTaskPlanningConfig::Explicit(CompactionPlanningConfig::FilesWithDeletes(config))
+        }
+        _ => unreachable!("Unsupported task type in iceberg compaction task: {task_type:?}"),
+    };
+
+    Ok(planning_config)
+}
+
 /// Creates a task execution context from an iceberg compaction task.
 pub async fn create_task_execution(
     iceberg_compaction_task: IcebergCompactionTask,
@@ -493,117 +614,44 @@ pub async fn create_task_execution(
         .full_table_name()
         .map_err(|e| HummockError::compaction_executor(e.as_report()))?;
 
-    let grouping_strategy = match iceberg_config.write_mode {
-        IcebergWriteMode::CopyOnWrite => iceberg_compaction_core::config::GroupingStrategy::Single,
-        IcebergWriteMode::MergeOnRead => match config.target_binpack_group_size_mb {
-            Some(target_binpack_group_size_mb) => {
-                iceberg_compaction_core::config::GroupingStrategy::BinPack(
-                    iceberg_compaction_core::config::BinPackConfig::new(
-                        target_binpack_group_size_mb * 1024 * 1024,
-                    ),
-                )
-            }
-            None => iceberg_compaction_core::config::GroupingStrategy::Single,
-        },
-    };
-
-    let group_filters = {
-        if config.min_group_size_mb.is_some() || config.min_group_file_count.is_some() {
-            Some(GroupFilters {
-                min_group_size_bytes: config.min_group_size_mb.map(|mb| mb * 1024 * 1024),
-                min_group_file_count: config.min_group_file_count,
-            })
-        } else {
-            None
-        }
-    };
-
     let parsed_task_type = TaskType::try_from(task_type)
         .map_err(|e| HummockError::compaction_executor(e.as_report()))?;
-    let should_use_cow =
-        should_enable_iceberg_cow(iceberg_config.r#type.as_str(), iceberg_config.write_mode);
-
-    let planning_config = match parsed_task_type {
-        TaskType::SmallFiles => {
-            let mut builder = SmallFilesConfigBuilder::default();
-            builder
-                .max_input_parallelism(config.max_parallelism as usize)
-                .max_output_parallelism(config.max_parallelism as usize)
-                .min_size_per_partition(config.min_size_per_partition)
-                .max_file_count_per_partition(config.max_file_count_per_partition as usize)
-                .target_file_size_bytes(iceberg_config.target_file_size_mb() * 1024 * 1024)
-                .enable_heuristic_output_parallelism(config.enable_heuristic_output_parallelism)
-                .small_file_threshold_bytes(iceberg_config.small_files_threshold_mb() * 1024 * 1024)
-                .grouping_strategy(grouping_strategy);
-
-            if let Some(group_filters) = group_filters.clone() {
-                builder.group_filters(group_filters);
-            }
-
-            let config = builder
-                .build()
-                .map_err(|e| HummockError::compaction_executor(e.as_report()))?;
-
-            CompactionPlanningConfig::SmallFiles(config)
-        }
-        TaskType::Full => {
-            let file_group_scope = if should_use_cow {
-                FileGroupScope::Table
-            } else {
-                FileGroupScope::Partition
-            };
-            let config = FullCompactionConfigBuilder::default()
-                .max_input_parallelism(config.max_parallelism as usize)
-                .max_output_parallelism(config.max_parallelism as usize)
-                .min_size_per_partition(config.min_size_per_partition)
-                .max_file_count_per_partition(config.max_file_count_per_partition as usize)
-                .target_file_size_bytes(iceberg_config.target_file_size_mb() * 1024 * 1024)
-                .enable_heuristic_output_parallelism(config.enable_heuristic_output_parallelism)
-                .grouping_strategy(grouping_strategy)
-                .file_group_scope(file_group_scope)
-                .build()
-                .map_err(|e| HummockError::compaction_executor(e.as_report()))?;
-
-            CompactionPlanningConfig::Full(config)
-        }
-
-        TaskType::FilesWithDelete => {
-            let config = FilesWithDeletesConfigBuilder::default()
-                .max_input_parallelism(config.max_parallelism as usize)
-                .max_output_parallelism(config.max_parallelism as usize)
-                .min_size_per_partition(config.min_size_per_partition)
-                .max_file_count_per_partition(config.max_file_count_per_partition as usize)
-                .target_file_size_bytes(iceberg_config.target_file_size_mb() * 1024 * 1024)
-                .enable_heuristic_output_parallelism(config.enable_heuristic_output_parallelism)
-                .grouping_strategy(grouping_strategy)
-                .min_delete_file_count_threshold(iceberg_config.delete_files_count_threshold())
-                .build()
-                .map_err(|e| HummockError::compaction_executor(e.as_report()))?;
-
-            CompactionPlanningConfig::FilesWithDeletes(config)
-        }
-
-        _ => {
-            unreachable!(
-                "Unsupported task type in iceberg compaction task {}: {:?}",
-                task_id, parsed_task_type
-            )
-        }
-    };
+    let planning_config = build_task_planning_config(parsed_task_type, &iceberg_config, &config)?;
 
     let branch = commit_branch(iceberg_config.r#type.as_str(), iceberg_config.write_mode);
-
-    let planner = CompactionPlanner::new(planning_config.clone());
 
     let table = catalog
         .load_table(&table_ident)
         .await
         .map_err(|e| HummockError::compaction_executor(e.as_report()))?;
 
-    let compaction_plans = planner
-        .plan_compaction_with_branch(&table, &branch)
-        .await
-        .map_err(|e| HummockError::compaction_executor(e.as_report()))?;
+    let compaction_plans = match planning_config {
+        IcebergTaskPlanningConfig::Auto(config) => {
+            let report = AutoCompactionPlanner::new(config)
+                .plan_compaction_report_with_branch(&table, &branch)
+                .await
+                .map_err(|e| HummockError::compaction_executor(e.as_report()))?;
+            tracing::info!(
+                iceberg_component = "compaction_worker",
+                iceberg_operation = "plan_auto_task",
+                task_id = %task_id,
+                sink_id,
+                table = %table_ident,
+                branch = %branch,
+                selected_strategy = ?report.selected_strategy,
+                reason = ?report.reason,
+                planned_input_bytes = report.planned_input_bytes,
+                planned_input_files = report.planned_input_files,
+                rewrite_ratio = report.rewrite_ratio,
+                "iceberg_auto_compaction_strategy_selected",
+            );
+            report.plans
+        }
+        IcebergTaskPlanningConfig::Explicit(config) => CompactionPlanner::new(config)
+            .plan_compaction_with_branch(&table, &branch)
+            .await
+            .map_err(|e| HummockError::compaction_executor(e.as_report()))?,
+    };
 
     if compaction_plans.is_empty() {
         tracing::info!(
@@ -656,4 +704,77 @@ pub async fn create_task_execution(
         sink_id,
         plan_runners: runners,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_build_auto_compaction_planning_config() {
+        let iceberg_config = IcebergConfig::from_btreemap(BTreeMap::from([
+            ("connector".to_owned(), "iceberg".to_owned()),
+            ("type".to_owned(), "append-only".to_owned()),
+            ("force_append_only".to_owned(), "true".to_owned()),
+            ("catalog.name".to_owned(), "test-catalog".to_owned()),
+            ("catalog.type".to_owned(), "storage".to_owned()),
+            ("warehouse.path".to_owned(), "s3://iceberg".to_owned()),
+            ("database.name".to_owned(), "test_db".to_owned()),
+            ("table.name".to_owned(), "test_table".to_owned()),
+            ("compaction.type".to_owned(), "auto".to_owned()),
+            (
+                "compaction.small_files_threshold_mb".to_owned(),
+                "96".to_owned(),
+            ),
+            (
+                "compaction.delete_files_count_threshold".to_owned(),
+                "7".to_owned(),
+            ),
+            (
+                "compaction.target_file_size_mb".to_owned(),
+                "256".to_owned(),
+            ),
+        ]))
+        .unwrap();
+        let runner_config = IcebergCompactorRunnerConfig {
+            max_parallelism: 8,
+            min_size_per_partition: 512 * 1024 * 1024,
+            max_file_count_per_partition: 16,
+            enable_validate_compaction: false,
+            max_record_batch_rows: 1024,
+            enable_heuristic_output_parallelism: true,
+            max_concurrent_closes: 4,
+            enable_prefetch: false,
+            target_binpack_group_size_mb: Some(64),
+            min_group_size_mb: Some(32),
+            min_group_file_count: Some(3),
+        };
+
+        let IcebergTaskPlanningConfig::Auto(config) =
+            build_task_planning_config(TaskType::Auto, &iceberg_config, &runner_config).unwrap()
+        else {
+            panic!("expected auto planning config");
+        };
+
+        assert_eq!(config.max_input_parallelism, 8);
+        assert_eq!(config.max_output_parallelism, 8);
+        assert_eq!(config.min_size_per_partition, 512 * 1024 * 1024);
+        assert_eq!(config.max_file_count_per_partition, 16);
+        assert_eq!(config.target_file_size_bytes, 256 * 1024 * 1024);
+        assert_eq!(config.small_file_threshold_bytes, 96 * 1024 * 1024);
+        assert_eq!(config.min_delete_file_count_threshold, 7);
+        assert_eq!(config.thresholds.min_small_files_count, 5);
+        assert_eq!(config.thresholds.min_delete_heavy_files_count, 1);
+
+        let iceberg_compaction_core::config::GroupingStrategy::BinPack(bin_pack) =
+            config.grouping_strategy
+        else {
+            panic!("expected bin-pack grouping strategy");
+        };
+        assert_eq!(bin_pack.target_group_size_bytes, 64 * 1024 * 1024);
+
+        let group_filters = config.group_filters.unwrap();
+        assert_eq!(group_filters.min_group_size_bytes, Some(32 * 1024 * 1024));
+        assert_eq!(group_filters.min_group_file_count, Some(3));
+    }
 }


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

Add `compaction.type = 'auto'` for Iceberg sinks so RisingWave can delegate snapshot-local strategy selection to `iceberg-compaction`.

The new mode:

- prefers files-with-deletes compaction when delete-heavy candidates are present, then falls back to small-files compaction;
- reuses RisingWave's existing interval/snapshot scheduler and task de-duplication;
- maps the existing target size, small-file threshold, delete-file threshold, parallelism, grouping, and group-filter settings into the upstream auto planner;
- is restricted to merge-on-read sinks and remains gated by the Iceberg compaction license;
- intentionally does not fall back to full compaction, matching the [upstream strategy contract](https://github.com/nimtable/iceberg-compaction/blob/74bdc45cb17feaf0ec4eb351d4be271c99d3624c/docs/compaction-strategy-contract.md).

Copy-on-write sinks continue to use full compaction.

## Testing

- `cargo +nightly-2026-06-11 test -q -p risingwave_connector test_parse_compaction_config --lib`
- `cargo +nightly-2026-06-11 test -q -p risingwave_meta test_apply_sink_update_refreshes_existing_idle_track --lib`
- `cargo +nightly-2026-06-11 test -q -p risingwave_storage test_build_auto_compaction_planning_config --lib`
- `RUSTUP_TOOLCHAIN=nightly-2026-06-11 ./risedev generate-with-options`
- `RUSTUP_TOOLCHAIN=nightly-2026-06-11 ./risedev b`
- `env -u CARGO_PKG_NAME RUSTUP_TOOLCHAIN=nightly-2026-06-11 ./risedev c`
- `cargo +nightly-2026-06-11 fmt --all -- --check`
- `git diff --check`

## Checklist

- [x] I have written necessary rustdoc comments.
- [x] I have added necessary unit tests and integration tests.
- [x] I have added test labels as necessary.
- [ ] I have added fuzzing tests or opened an issue to track them.
- [ ] My PR contains breaking changes.
- [ ] My PR changes performance-critical code, so I will run (micro) benchmarks and present the results.
- [ ] I have checked the release timeline to determine which release branches need a cherry-pick.

## Documentation

- [x] My PR needs documentation updates.

The generated Iceberg sink option metadata now lists `auto` as a supported `compaction.type` value.

<details>
<summary><b>Release note</b></summary>

Iceberg merge-on-read sinks can now use `compaction.type = 'auto'` to automatically prioritize delete-file cleanup and otherwise compact small files. Copy-on-write sinks continue to require full compaction.

</details>
