### PR TITLE
fix(catalog): reject altering internal table schema

### DIFF
--- a/e2e_test/ddl/alter_set_schema.slt
+++ b/e2e_test/ddl/alter_set_schema.slt
@@ -1,5 +1,7 @@
 # ALTER CONNECTION SET SCHEMA is covered in `e2e_test/source_inline/connection/ddl.slt`
 
+control substitution on
+
 statement ok
 SET RW_IMPLICIT_FLUSH TO true;
 
@@ -27,6 +29,42 @@ CREATE INDEX test_index2 ON test_table(v);
 
 statement ok
 CREATE MATERIALIZED VIEW test_mv AS SELECT u FROM test_table;
+
+statement error cannot alter schema
+ALTER MATERIALIZED VIEW test_table SET SCHEMA test_schema;
+
+statement error cannot alter schema
+ALTER TABLE test_mv SET SCHEMA test_schema;
+
+statement ok
+CREATE MATERIALIZED VIEW alter_internal_mv AS SELECT v FROM test_table;
+
+let internal_table_name
+SELECT name
+FROM rw_catalog.rw_internal_table_info
+WHERE job_name = 'alter_internal_mv'
+ORDER BY id
+LIMIT 1
+
+let internal_table_id
+SELECT id
+FROM rw_catalog.rw_internal_table_info
+WHERE name = '${internal_table_name}'
+
+# The internal table starts in public, so this also verifies rejection before the no-op return.
+statement error table not found
+ALTER TABLE ${internal_table_name} SET SCHEMA public;
+
+statement error table not found
+ALTER TABLE ${internal_table_name} SET SCHEMA test_schema;
+
+statement ok
+DROP MATERIALIZED VIEW alter_internal_mv;
+
+query I
+SELECT count(*) FROM rw_catalog.rw_internal_table_info WHERE id = ${internal_table_id};
+----
+0
 
 statement ok
 CREATE INDEX test_mv_index ON test_mv(u);

--- a/src/frontend/src/handler/alter_set_schema.rs
+++ b/src/frontend/src/handler/alter_set_schema.rs
@@ -15,6 +15,7 @@
 use pgwire::pg_response::StatementType;
 use risingwave_sqlparser::ast::{ObjectName, OperateFunctionArg};
 
+use super::alter_utils::validate_table_type_for_alter;
 use super::{HandlerArgs, RwPgResponse};
 use crate::catalog::root_catalog::SchemaPath;
 use crate::error::{ErrorCode, Result};
@@ -51,6 +52,7 @@ pub async fn handle_alter_set_schema(
                     schema_path,
                     &real_obj_name,
                 )?;
+                validate_table_type_for_alter(table, stmt_type, "schema")?;
                 if old_schema_name == new_schema_name {
                     return Ok(RwPgResponse::empty_result(stmt_type));
                 }

--- a/src/frontend/src/handler/alter_utils.rs
+++ b/src/frontend/src/handler/alter_utils.rs
@@ -20,9 +20,33 @@ use risingwave_sqlparser::ast::ObjectName;
 use crate::Binder;
 use crate::catalog::CatalogError;
 use crate::catalog::root_catalog::SchemaPath;
-use crate::catalog::table_catalog::TableType;
+use crate::catalog::table_catalog::{TableCatalog, TableType};
 use crate::error::{Result, bail_invalid_input_syntax};
 use crate::session::SessionImpl;
+
+pub(super) fn validate_table_type_for_alter(
+    table: &TableCatalog,
+    alter_stmt_type: StatementType,
+    alter_target: &str,
+) -> Result<()> {
+    match (table.table_type(), alter_stmt_type) {
+        (TableType::Internal, _) => {
+            // We treat internal tables as not found because they are not user-addressable objects.
+            Err(CatalogError::not_found("table", table.name()).into())
+        }
+        (TableType::Table, StatementType::ALTER_TABLE)
+        | (TableType::MaterializedView, StatementType::ALTER_MATERIALIZED_VIEW)
+        | (TableType::Index, StatementType::ALTER_INDEX) => Ok(()),
+        _ => {
+            bail_invalid_input_syntax!(
+                "cannot alter {alter_target} of {} {} by {}",
+                table.table_type().to_prost().as_str_name(),
+                table.name(),
+                alter_stmt_type,
+            );
+        }
+    }
+}
 
 /// Resolve the **streaming** job id for alter operations.
 ///
@@ -70,23 +94,7 @@ fn resolve_streaming_job_id_for_alter_impl(
                 reader.get_created_table_by_name(db_name, schema_path, &real_table_name)?
             };
 
-            match (table.table_type(), alter_stmt_type) {
-                (TableType::Internal, _) => {
-                    // we treat internal table as NOT FOUND
-                    return Err(CatalogError::not_found("table", table.name()).into());
-                }
-                (TableType::Table, StatementType::ALTER_TABLE)
-                | (TableType::MaterializedView, StatementType::ALTER_MATERIALIZED_VIEW)
-                | (TableType::Index, StatementType::ALTER_INDEX) => {}
-                _ => {
-                    bail_invalid_input_syntax!(
-                        "cannot alter {alter_target} of {} {} by {}",
-                        table.table_type().to_prost().as_str_name(),
-                        table.name(),
-                        alter_stmt_type,
-                    );
-                }
-            }
+            validate_table_type_for_alter(table, alter_stmt_type, alter_target)?;
 
             session.check_privilege_for_drop_alter(schema_name, &**table)?;
             table.id.as_job_id()

--- a/src/meta/src/controller/catalog/alter_op.rs
+++ b/src/meta/src/controller/catalog/alter_op.rs
@@ -644,6 +644,18 @@ impl CatalogController {
                 object_id,
             ));
         }
+        if object_type == ObjectType::Table {
+            let table_type = Table::find_by_id(object_id.as_table_id())
+                .select_only()
+                .column(table::Column::TableType)
+                .into_tuple::<TableType>()
+                .one(&txn)
+                .await?
+                .ok_or_else(|| MetaError::catalog_id_not_found("table", object_id))?;
+            if table_type == TableType::Internal {
+                return Err(MetaError::catalog_id_not_found("table", object_id));
+            }
+        }
         if obj.schema_id == Some(new_schema) {
             return Ok(IGNORED_NOTIFICATION_VERSION);
         }

--- a/src/meta/src/controller/catalog/test.rs
+++ b/src/meta/src/controller/catalog/test.rs
@@ -1165,6 +1165,87 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_alter_internal_table_schema_rejected() -> MetaResult<()> {
+        let mgr = CatalogController::new(MetaSrvEnv::for_test().await).await?;
+        mgr.create_schema(PbSchema {
+            database_id: TEST_DATABASE_ID,
+            name: "internal_table_alter_target".to_owned(),
+            owner: TEST_OWNER_ID as _,
+            ..Default::default()
+        })
+        .await?;
+        let target_schema_id: SchemaId = Schema::find()
+            .select_only()
+            .column(schema::Column::SchemaId)
+            .filter(schema::Column::Name.eq("internal_table_alter_target"))
+            .into_tuple()
+            .one(&mgr.inner.read().await.db)
+            .await?
+            .unwrap();
+
+        let txn = mgr.inner.read().await.db.begin().await?;
+        let parent_obj = CatalogController::create_object(
+            &txn,
+            ObjectType::Table,
+            TEST_OWNER_ID,
+            Some(TEST_SCHEMA_ID.as_object_id()),
+        )
+        .await?;
+        let parent_job_id = parent_obj.oid.as_job_id();
+        insert_test_table(
+            &txn,
+            parent_job_id.as_mv_table_id(),
+            "internal_table_parent",
+            TableType::MaterializedView,
+            None,
+            "",
+        )
+        .await?;
+        let internal_obj = CatalogController::create_object(
+            &txn,
+            ObjectType::Table,
+            TEST_OWNER_ID,
+            Some(parent_job_id.as_object_id()),
+        )
+        .await?;
+        let internal_table_id = internal_obj.oid.as_table_id();
+        insert_test_table(
+            &txn,
+            internal_table_id,
+            "__internal_table_alter_target",
+            TableType::Internal,
+            Some(parent_job_id),
+            "",
+        )
+        .await?;
+        txn.commit().await?;
+
+        for new_schema in [TEST_SCHEMA_ID, target_schema_id] {
+            assert!(
+                mgr.alter_schema(
+                    ObjectType::Table,
+                    internal_table_id.as_object_id(),
+                    new_schema,
+                )
+                .await
+                .is_err()
+            );
+        }
+
+        let internal_obj = Object::find_by_id(internal_table_id)
+            .one(&mgr.inner.read().await.db)
+            .await?
+            .unwrap();
+        assert_eq!(internal_obj.schema_id, Some(TEST_SCHEMA_ID));
+        assert_eq!(
+            internal_obj.belong_to_oid,
+            Some(parent_job_id.as_object_id())
+        );
+
+        Ok(())
+    }
+
+    #[tokio::test]
     async fn test_alter_table_schema_moves_indexes_but_not_subscriptions() -> MetaResult<()> {
         let mgr = CatalogController::new(MetaSrvEnv::for_test().await).await?;
         mgr.create_schema(PbSchema {


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

Internal state tables share the regular table catalog and their generated names are discoverable through system catalogs. Consequently, `ALTER TABLE ... SET SCHEMA` could address an internal table directly. Besides moving an object that is not independently managed, this could overwrite its `belong_to_oid` relation and prevent the parent streaming job from cleaning it up.

This PR:

- extracts the existing frontend table-type validation into a shared helper and applies it to `ALTER ... SET SCHEMA` before the same-schema no-op return;
- rejects internal tables as table-not-found and also distinguishes `ALTER TABLE` from `ALTER MATERIALIZED VIEW`;
- adds a defense-in-depth guard in the meta catalog controller before the no-op return and belonging-object updates;
- adds meta and SQLLogicTest regressions for same-schema and cross-schema attempts, unchanged catalog relations, and parent cleanup.

This is a follow-up to #26491.

## Checklist

- [ ] I have written necessary rustdoc comments.
- [x] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [x] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->

## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

</details>

## Tests

- `cargo test -p risingwave_meta test_alter_internal_table_schema_rejected --lib`
- `cargo clippy --all-targets --all-features`
- `./risedev slt './e2e_test/ddl/alter_set_schema.slt'`
- `git diff --check`
