### PR TITLE
doc: explain Buildkite approval for fork PRs

### DIFF
--- a/docs/dev/src/ci.md
+++ b/docs/dev/src/ci.md
@@ -2,6 +2,38 @@
 
 <!-- TODO: How to debug CI -->
 
+## Buildkite approval for fork pull requests
+
+Buildkite runs automatically for eligible pull requests whose branches are in
+the RisingWave repository. Pull requests opened from forks require approval
+before Buildkite executes their code.
+
+After reviewing the changes, a RisingWave maintainer can approve the current
+commit by posting this exact comment on the GitHub pull request:
+
+```text
+/approve-run-bk
+```
+
+Buildkite accepts this command only from a trusted GitHub owner, member, or
+collaborator, or from a GitHub account linked to a Buildkite user with permission
+to run the pipeline. The command from an outside contributor does not start a
+build.
+
+The comment creates a new build for the pull request's current head commit. A
+new commit does not inherit an earlier approval, so a maintainer must post the
+command again after the contributor pushes.
+
+The `pull-request` pipeline runs after approval when the pull request is ready
+for review. To run `main-cron` for a fork pull request, first add either:
+
+- `ci/main-cron/run-all`; or
+- `ci/main-cron/run-selected` together with one or more applicable
+  `ci/run-*` labels.
+
+Then post `/approve-run-bk`. A single approved comment can trigger both
+pipelines when their respective conditions are satisfied.
+
 ## CI Labels Guide
 
 - `[ci/run-xxx ...]`: Run additional steps in the PR workflow indicated by `ci/run-xxx` in your PR.

--- a/docs/dev/src/contributing.md
+++ b/docs/dev/src/contributing.md
@@ -26,6 +26,25 @@ Before submitting your code changes, ensure you fully test them and perform nece
 
 To get your PR reviewed and merged sooner, you can find and `@` mention developers who recently worked on the same files. If you're not sure who to ask, feel free to reach out to any active developers to help find relevant reviewers. Don't hesitate to follow up politely if you haven't received a response, or ask for help in the RisingWave Community Slack channel. We welcome you to be proactive in finding reviewers for your PR!
 
+### CI approval for fork pull requests
+
+For security, Buildkite does not automatically run code from pull requests
+opened from forks. When your pull request is ready for CI, ask a maintainer to
+review the changes and comment the following command on the pull request:
+
+```text
+/approve-run-bk
+```
+
+Only a trusted maintainer can trigger the build. Comments from the pull request
+author or other outside contributors do not start Buildkite. After you push a
+new commit, ask a maintainer to approve Buildkite again so that CI runs against
+the new commit.
+
+Other checks may still run automatically. See the
+[Continuous Integration](./ci.md) guide for details about the Buildkite
+`pull-request` and `main-cron` pipelines.
+
 ### Pull Request title
 
 As described in [here](https://github.com/commitizen/conventional-commit-types/blob/master/index.json), a valid PR title should begin with one of the following prefixes:


### PR DESCRIPTION
## Summary

- explain why Buildkite does not automatically run for fork pull requests
- document the trusted maintainer `/approve-run-bk` comment flow
- document reapproval after new commits and the `main-cron` label requirements

## Why

Outside contributors need a clear indication that a missing Buildkite run is an
intentional security gate rather than a CI failure. Maintainers also need the
exact approval command and pipeline-specific conditions in the CI guide.

## Verification

- `mdbook build`
- `git diff --check`
- validated the approval flow with temporary fork PR #26651
