### PR TITLE
feat: support expression in FETCH clause

### DIFF
--- a/e2e_test/batch/order/test_limit.slt.part
+++ b/e2e_test/batch/order/test_limit.slt.part
@@ -304,6 +304,49 @@ Caused by these errors (recent errors listed first):
   2: expects an integer or expression that can be evaluated to an integer after LIMIT, but found non-const expression
 
 
+# expression in the FETCH clause
+query I
+SELECT * FROM generate_series(0,10,1) as t(v) order by v FETCH FIRST 1+2 ROWS ONLY;
+----
+0
+1
+2
+
+query I
+SELECT * FROM generate_series(0,10,1) as t(v) order by v OFFSET 2 FETCH FIRST 1.5*2 ROWS ONLY;
+----
+2
+3
+4
+
+# quantity omitted (bare ROW/ROWS): must not be misparsed as a `ROW(...)` expression, see
+# https://github.com/risingwavelabs/risingwave/issues/19952
+query I
+SELECT * FROM generate_series(0,3,1) as t(v) order by v FETCH FIRST ROW ONLY;
+----
+0
+
+statement error
+SELECT * FROM generate_series(0,3,1) as t(v) order by v FETCH FIRST '2.2' ROWS ONLY;
+----
+db error: ERROR: Failed to run the query
+
+Caused by these errors (recent errors listed first):
+  1: Expr error
+  2: expects an integer or expression that can be evaluated to an integer after LIMIT,
+but the evaluation of the expression returns error:Expr error: error while evaluating expression `str_parse('2.2')`: Parse error: bigint invalid digit found in string
+
+
+statement error
+select 1 fetch first generate_series(1, 2) rows only;
+----
+db error: ERROR: Failed to run the query
+
+Caused by these errors (recent errors listed first):
+  1: Expr error
+  2: expects an integer or expression that can be evaluated to an integer after LIMIT, but found non-const expression
+
+
 # Subqueries that return negative values
 statement error
 SELECT * FROM integers as int LIMIT (SELECT -1);

--- a/src/frontend/src/binder/query.rs
+++ b/src/frontend/src/binder/query.rs
@@ -190,7 +190,7 @@ impl Binder {
             ) => {
                 with_ties = *fetch_with_ties;
                 match quantity {
-                    Some(v) => Some(Expr::Value(Value::Number(v.clone()))),
+                    Some(v) => Some(v.clone()),
                     None => Some(Expr::Value(Value::Number("1".to_owned()))),
                 }
             }

--- a/src/sqlparser/src/ast/query.rs
+++ b/src/sqlparser/src/ast/query.rs
@@ -673,7 +673,7 @@ impl fmt::Display for OrderByExpr {
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Fetch {
     pub with_ties: bool,
-    pub quantity: Option<String>,
+    pub quantity: Option<Expr>,
 }
 
 impl fmt::Display for Fetch {

--- a/src/sqlparser/src/parser.rs
+++ b/src/sqlparser/src/parser.rs
@@ -6165,13 +6165,22 @@ impl Parser<'_> {
     /// Parse a FETCH clause
     pub fn parse_fetch(&mut self) -> ModalResult<Fetch> {
         self.expect_one_of_keywords(&[Keyword::FIRST, Keyword::NEXT])?;
+        // Peek for a bare ROW/ROWS keyword *before* attempting to parse an expression.
+        //
+        // This resolves the grammar conflict called out in
+        // <https://github.com/risingwavelabs/risingwave/issues/19952>: PostgreSQL's `c_expr`
+        // (and our `parse_expr`) is happy to start parsing `ROW(...)` as a row-constructor
+        // expression, which would otherwise swallow the `ROW`/`ROWS` noise word that marks an
+        // *omitted* quantity, e.g. in `FETCH FIRST ROW ONLY`. By checking for the bare keyword
+        // first, we make sure `FETCH FIRST ROW ONLY` is always parsed as "no quantity" rather
+        // than misinterpreting `ROW` as the start of an expression.
         let quantity = if self
             .parse_one_of_keywords(&[Keyword::ROW, Keyword::ROWS])
             .is_some()
         {
             None
         } else {
-            let quantity = self.parse_number_value()?;
+            let quantity = self.parse_expr()?;
             self.expect_one_of_keywords(&[Keyword::ROW, Keyword::ROWS])?;
             Some(quantity)
         };

--- a/src/sqlparser/tests/sqlparser_common.rs
+++ b/src/sqlparser/tests/sqlparser_common.rs
@@ -3695,7 +3695,7 @@ fn parse_fetch() {
     let fetch_first_two_rows_only = Some(Fetch {
         with_ties: false,
 
-        quantity: Some("2".to_owned()),
+        quantity: Some(Expr::Value(Value::Number("2".to_owned()))),
     });
     let ast = verified_query("SELECT foo FROM bar FETCH FIRST 2 ROWS ONLY");
     assert_eq!(ast.fetch, fetch_first_two_rows_only);
@@ -3720,7 +3720,7 @@ fn parse_fetch() {
         ast.fetch,
         Some(Fetch {
             with_ties: true,
-            quantity: Some("2".to_owned()),
+            quantity: Some(Expr::Value(Value::Number("2".to_owned()))),
         })
     );
     let ast = verified_query(
@@ -3779,6 +3779,41 @@ fn parse_fetch_variations() {
     one_statement_parses_to(
         "SELECT foo FROM bar FETCH FIRST ROWS ONLY",
         "SELECT foo FROM bar FETCH FIRST ROWS ONLY",
+    );
+}
+
+#[test]
+fn parse_fetch_expression() {
+    // The quantity of a FETCH clause can be an arbitrary expression, not just a literal
+    // number, e.g. `FETCH FIRST 1 + 1 ROWS ONLY`.
+    let ast = verified_query("SELECT foo FROM bar FETCH FIRST 1 + 1 ROWS ONLY");
+    assert_eq!(
+        ast.fetch,
+        Some(Fetch {
+            with_ties: false,
+            quantity: Some(Expr::BinaryOp {
+                left: Box::new(Expr::Value(Value::Number("1".to_owned()))),
+                op: BinaryOperator::Plus,
+                right: Box::new(Expr::Value(Value::Number("1".to_owned()))),
+            }),
+        })
+    );
+
+    // Regression test for the grammar conflict described in
+    // <https://github.com/risingwavelabs/risingwave/issues/19952>: when the quantity is
+    // omitted, the `ROW`/`ROWS` noise word must not be misparsed as the start of a `ROW(...)`
+    // expression.
+    let ast = query(
+        "SELECT 1 OFFSET 1 ROW FETCH FIRST ROW ONLY",
+        "SELECT 1 OFFSET 1 FETCH FIRST ROWS ONLY",
+    );
+    assert_eq!(ast.offset, Some("1".to_owned()));
+    assert_eq!(
+        ast.fetch,
+        Some(Fetch {
+            with_ties: false,
+            quantity: None,
+        })
     );
 }
 


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

The `FETCH FIRST <n> ROWS ONLY` clause only accepted a plain numeric literal for `<n>`, unlike `LIMIT`, which was already extended to accept an arbitrary expression in #19834. This PR brings the `FETCH` clause's quantity up to parity with `LIMIT`, e.g. `SELECT * FROM t ORDER BY a FETCH FIRST 1 + 1 ROWS ONLY` now works.

**Grammar conflict.** The linked issue points out the exact PostgreSQL parsing conflict that makes this "not as simple as it looks": `parse_expr` is happy to start parsing `ROW(...)` as a row-constructor expression, which would swallow the `ROW`/`ROWS` noise word that marks an *omitted* quantity, e.g. in `FETCH FIRST ROW ONLY` or `SELECT 1 OFFSET 1 ROW FETCH FIRST ROW ONLY`. The existing `parse_fetch` already avoided this by peeking for a bare `ROW`/`ROWS` keyword *before* attempting to parse the quantity, so I kept that check and only replaced the numeric-literal branch with `parse_expr()`. I added a regression test (`parse_fetch_expression` in `src/sqlparser/tests/sqlparser_common.rs`) covering exactly the `OFFSET 1 ROW ... FETCH FIRST ROW ONLY` case from the issue to make sure this doesn't regress.

**Implementation.**
- `src/sqlparser/src/ast/query.rs`: `Fetch::quantity` changed from `Option<String>` to `Option<Expr>` (mirrors `Query::limit`, which #19834 already changed the same way).
- `src/sqlparser/src/parser.rs`: `parse_fetch` now calls `parse_expr()` instead of `parse_number_value()` for the quantity, guarded by the pre-existing `ROW`/`ROWS` peek described above.
- `src/frontend/src/binder/query.rs`: since `Fetch::quantity` is already funneled into the same `limit` expression-binding path used for `LIMIT` (cast to bigint, constant-fold, reject negative/non-const), the binder now just forwards the parsed `Expr` directly instead of re-wrapping a `String` in `Expr::Value(Value::Number(..))`. No new binder logic was needed — `FETCH` and `LIMIT` share the exact same error messages as a result.

I verified this stays scoped to the `FETCH` clause; `OFFSET`'s quantity is untouched (still a plain literal), matching the issue's title/scope.

- Closes #19952

## Checklist

- [x] I have written necessary rustdoc comments.
- [x] I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

The `FETCH FIRST <n> ROWS ONLY` clause now accepts an arbitrary expression for `<n>` (e.g. `FETCH FIRST 1 + 1 ROWS ONLY`), in addition to plain numeric literals, matching the existing behavior of `LIMIT`.

</details>

## Verification

This environment's sandbox couldn't link a full `risingwave_frontend`/full-workspace build (an unrelated native `faiss-sys` C++ build dependency fails to configure via CMake/mingw in this Windows sandbox), so verification was scoped to what changed:

- `cargo test -p risingwave_sqlparser`: all 185 tests + doctest pass, including new `parse_fetch_expression` (proves both the expression parsing and the grammar-conflict regression case from the issue) and updated `parse_fetch`/`parse_fetch_variations`.
- `cargo fmt -p risingwave_sqlparser -- --check` and `cargo fmt -p risingwave_frontend -- --check`: clean.
- `cargo clippy -p risingwave_sqlparser`: clean.
- `src/frontend/src/binder/query.rs` compiles type-correctly against the new `Option<Expr>` (the diff is a one-line change to code identical to the already-merged, CI-verified `LIMIT` handling in the same function), but I could not run `cargo check -p risingwave_frontend` end-to-end here due to the `faiss-sys` build issue above — flagging this explicitly rather than claiming a full build passed.
- Added e2e tests to `e2e_test/batch/order/test_limit.slt.part` (included via `e2e_test/batch/{distribution_mode,local_mode}.slt`) mirroring the existing `LIMIT`-expression e2e tests, including the exact error messages, since `FETCH` now shares the same binder code path/error strings as `LIMIT`. These weren't run against a live server in this sandbox for the same build-environment reason.
