### PR TITLE
cherry-pick fix(stream): keep consuming on a no-op sink config update (#26484) to release-3.0

### DIFF
--- a/src/stream/src/executor/sink.rs
+++ b/src/stream/src/executor/sink.rs
@@ -851,23 +851,26 @@ impl<F: LogStoreFactory> SinkExecutor<F> {
                             log_reader.init().await?;
                         },
                         RebuildSinkMessage::UpdateConfig(config) => {
-                            if !sink_config_has_changes(&sink_param.properties, &config) {
-                                info!(
-                                    executor_id = %sink_writer_param.executor_id,
-                                    sink_id = %sink_param.sink_id,
-                                    "skip alter sink config because properties are unchanged"
-                                );
-                                Ok(())
-                            } else if F::ALLOW_REWIND {
+                            let config_has_changes =
+                                sink_config_has_changes(&sink_param.properties, &config);
+                            if F::ALLOW_REWIND {
                                 match log_reader.rewind().await {
                                     Ok(()) => {
-                                        sink_param.properties.extend(config.into_iter());
-                                        sink = TryFrom::try_from(sink_param.clone()).map_err(|e| StreamExecutorError::from((e, sink_param.sink_id)))?;
-                                        info!(
-                                            executor_id = %sink_writer_param.executor_id,
-                                            sink_id = %sink_param.sink_id,
-                                            "alter sink config successfully with rewind"
-                                        );
+                                        if config_has_changes {
+                                            sink_param.properties.extend(config.into_iter());
+                                            sink = TryFrom::try_from(sink_param.clone()).map_err(|e| StreamExecutorError::from((e, sink_param.sink_id)))?;
+                                            info!(
+                                                executor_id = %sink_writer_param.executor_id,
+                                                sink_id = %sink_param.sink_id,
+                                                "alter sink config successfully with rewind"
+                                            );
+                                        } else {
+                                            info!(
+                                                executor_id = %sink_writer_param.executor_id,
+                                                sink_id = %sink_param.sink_id,
+                                                "skip alter sink config because properties are unchanged"
+                                            );
+                                        }
                                         Ok(())
                                     }
                                     Err(rewind_err) => {
@@ -875,12 +878,20 @@ impl<F: LogStoreFactory> SinkExecutor<F> {
                                             error = %rewind_err.as_report(),
                                             "fail to rewind log reader for alter sink config "
                                         );
-                                        Err(anyhow!("fail to rewind log after alter table").into())
+                                        Err(anyhow!("fail to rewind log reader after alter sink config notification").into())
                                     }
                                 }
                             } else {
-                                sink_param.properties.extend(config.into_iter());
-                                sink = TryFrom::try_from(sink_param.clone()).map_err(|e| StreamExecutorError::from((e, sink_param.sink_id)))?;
+                                if config_has_changes {
+                                    sink_param.properties.extend(config.into_iter());
+                                    sink = TryFrom::try_from(sink_param.clone()).map_err(|e| StreamExecutorError::from((e, sink_param.sink_id)))?;
+                                } else {
+                                    info!(
+                                        executor_id = %sink_writer_param.executor_id,
+                                        sink_id = %sink_param.sink_id,
+                                        "skip rebuilding sink because properties are unchanged"
+                                    );
+                                }
                                 Err(anyhow!("This is not an actual error condition. The system is intentionally triggering recovery procedures to ensure ALTER SINK CONFIG are fully applied.").into())
                             }
                             .map_err(|e| StreamExecutorError::from((e, sink_param.sink_id)))?;
@@ -914,13 +925,115 @@ impl<F: LogStoreFactory> Execute for SinkExecutor<F> {
 
 #[cfg(test)]
 mod test {
+    use std::future::pending;
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::time::Duration;
+
     use risingwave_common::catalog::{ColumnDesc, ColumnId};
     use risingwave_common::util::epoch::test_epoch;
     use risingwave_connector::sink::build_sink;
+    use risingwave_connector::sink::log_store::{LogStoreReadItem, LogStoreResult, TruncateOffset};
+    use risingwave_connector::sink::trivial::BlackHoleSink;
+    use tokio::sync::Notify;
 
     use super::*;
-    use crate::common::log_store_impl::in_mem::BoundedInMemLogStoreFactory;
+    use crate::common::log_store_impl::in_mem::{
+        BoundedInMemLogStoreFactory, BoundedInMemLogStoreWriter,
+    };
     use crate::executor::test_utils::*;
+
+    #[derive(Default)]
+    struct RewindRequiredLogReaderState {
+        start_count: AtomicUsize,
+        rewind_count: AtomicUsize,
+        started: Notify,
+    }
+
+    impl RewindRequiredLogReaderState {
+        async fn wait_for_start_count(&self, expected: usize) {
+            tokio::time::timeout(Duration::from_secs(5), async {
+                loop {
+                    let started = self.started.notified();
+                    if self.start_count.load(Ordering::SeqCst) >= expected {
+                        break;
+                    }
+                    started.await;
+                }
+            })
+            .await
+            .unwrap_or_else(|_| panic!("log reader was not started {expected} times"));
+        }
+    }
+
+    struct RewindRequiredLogReader {
+        is_reset: bool,
+        state: Arc<RewindRequiredLogReaderState>,
+    }
+
+    impl LogReader for RewindRequiredLogReader {
+        async fn init(&mut self) -> LogStoreResult<()> {
+            self.is_reset = true;
+            Ok(())
+        }
+
+        async fn start_from(&mut self, _start_offset: Option<u64>) -> LogStoreResult<()> {
+            assert!(
+                self.is_reset,
+                "log reader must be rewound before restarting"
+            );
+            self.is_reset = false;
+            self.state.start_count.fetch_add(1, Ordering::SeqCst);
+            self.state.started.notify_waiters();
+            Ok(())
+        }
+
+        async fn next_item(&mut self) -> LogStoreResult<(u64, LogStoreReadItem)> {
+            pending().await
+        }
+
+        fn truncate(&mut self, _offset: TruncateOffset) -> LogStoreResult<()> {
+            Ok(())
+        }
+
+        async fn rewind(&mut self) -> LogStoreResult<()> {
+            self.is_reset = true;
+            self.state.rewind_count.fetch_add(1, Ordering::SeqCst);
+            Ok(())
+        }
+    }
+
+    struct TestLogStoreFactory<const CAN_REWIND: bool>;
+
+    impl<const CAN_REWIND: bool> LogStoreFactory for TestLogStoreFactory<CAN_REWIND> {
+        type Reader = RewindRequiredLogReader;
+        type Writer = BoundedInMemLogStoreWriter;
+
+        const ALLOW_REWIND: bool = CAN_REWIND;
+        const REBUILD_SINK_ON_UPDATE_VNODE_BITMAP: bool = false;
+
+        async fn build(self) -> (Self::Reader, Self::Writer) {
+            unreachable!()
+        }
+    }
+
+    fn sink_param_for_config_update_test() -> SinkParam {
+        SinkParam {
+            sink_id: 0.into(),
+            sink_name: "test".into(),
+            properties: BTreeMap::from([
+                ("connector".to_owned(), "blackhole".to_owned()),
+                ("commit_checkpoint_interval".to_owned(), "1".to_owned()),
+            ]),
+            columns: vec![],
+            downstream_pk: None,
+            sink_type: SinkType::AppendOnly,
+            ignore_delete: false,
+            format_desc: None,
+            db_name: "test".into(),
+            sink_from_name: "test".into(),
+        }
+    }
 
     #[test]
     fn test_sink_config_has_changes() {
@@ -949,6 +1062,98 @@ mod test {
         for max_delay in [1, 2, 4, 8, 16, 30, 30].map(Duration::from_secs) {
             assert!(retry_backoff.next().expect("retry strategy is infinite") <= max_delay);
         }
+    }
+
+    #[tokio::test]
+    async fn test_no_op_sink_config_update_rewinds_log_reader() {
+        let sink_param = sink_param_for_config_update_test();
+        let sink = BlackHoleSink::try_from(sink_param.clone()).unwrap();
+        let state = Arc::new(RewindRequiredLogReaderState::default());
+        let log_reader = RewindRequiredLogReader {
+            is_reset: false,
+            state: state.clone(),
+        };
+        let (rate_limit_tx, rate_limit_rx) = unbounded_channel();
+        let (rebuild_sink_tx, rebuild_sink_rx) = unbounded_channel();
+
+        let consume_log = SinkExecutor::<TestLogStoreFactory<true>>::execute_consume_log(
+            sink,
+            log_reader,
+            vec![],
+            sink_param,
+            SinkWriterParam::for_test(),
+            None,
+            ActorContext::for_test(0),
+            rate_limit_rx,
+            rebuild_sink_rx,
+        );
+        tokio::pin!(consume_log);
+
+        tokio::select! {
+            result = &mut consume_log => panic!("log consumer exited unexpectedly: {result:?}"),
+            () = state.wait_for_start_count(1) => {},
+        }
+
+        rebuild_sink_tx
+            .send(RebuildSinkMessage::UpdateConfig(HashMap::from([(
+                "commit_checkpoint_interval".to_owned(),
+                "1".to_owned(),
+            )])))
+            .unwrap();
+
+        tokio::select! {
+            result = &mut consume_log => panic!("log consumer exited unexpectedly: {result:?}"),
+            () = state.wait_for_start_count(2) => {},
+        }
+
+        assert_eq!(state.rewind_count.load(Ordering::SeqCst), 1);
+        drop(rate_limit_tx);
+    }
+
+    #[tokio::test]
+    async fn test_no_op_sink_config_update_triggers_recovery_without_rewind() {
+        let sink_param = sink_param_for_config_update_test();
+        let sink = BlackHoleSink::try_from(sink_param.clone()).unwrap();
+        let state = Arc::new(RewindRequiredLogReaderState::default());
+        let log_reader = RewindRequiredLogReader {
+            is_reset: false,
+            state: state.clone(),
+        };
+        let (rate_limit_tx, rate_limit_rx) = unbounded_channel();
+        let (rebuild_sink_tx, rebuild_sink_rx) = unbounded_channel();
+
+        let consume_log = SinkExecutor::<TestLogStoreFactory<false>>::execute_consume_log(
+            sink,
+            log_reader,
+            vec![],
+            sink_param,
+            SinkWriterParam::for_test(),
+            None,
+            ActorContext::for_test(0),
+            rate_limit_rx,
+            rebuild_sink_rx,
+        );
+        tokio::pin!(consume_log);
+
+        tokio::select! {
+            result = &mut consume_log => panic!("log consumer exited unexpectedly: {result:?}"),
+            () = state.wait_for_start_count(1) => {},
+        }
+
+        rebuild_sink_tx
+            .send(RebuildSinkMessage::UpdateConfig(HashMap::from([(
+                "commit_checkpoint_interval".to_owned(),
+                "1".to_owned(),
+            )])))
+            .unwrap();
+
+        tokio::time::timeout(Duration::from_secs(5), consume_log)
+            .await
+            .expect("log consumer should trigger recovery")
+            .expect_err("log consumer should return an error");
+        assert_eq!(state.start_count.load(Ordering::SeqCst), 1);
+        assert_eq!(state.rewind_count.load(Ordering::SeqCst), 0);
+        drop(rate_limit_tx);
     }
 
     #[tokio::test]

--- a/src/stream/src/executor/sink.rs
+++ b/src/stream/src/executor/sink.rs
@@ -778,7 +778,8 @@ impl<F: LogStoreFactory> SinkExecutor<F> {
         log_reader.init().await?;
         let mut retry_backoff = sink_retry_backoff();
         loop {
-            let future = async {
+            // Boxed so that `drop` below releases its borrows on `log_reader` and `sink`.
+            let mut future = Box::pin(async {
                 loop {
                     let attempt_started_at = Instant::now();
                     let Err(e) = sink
@@ -835,68 +836,67 @@ impl<F: LogStoreFactory> SinkExecutor<F> {
                     }
                     .map_err(|e| StreamExecutorError::from((e, sink_param.sink_id)))?;
                 }
-            };
-            select! {
-                result = future => {
-                    let Err(e): StreamExecutorResult<!> = result;
-                    return Err(e);
-                }
-                result = rebuild_sink_rx.recv() => {
-                    match result.ok_or_else(|| anyhow!("failed to receive rebuild sink notify"))? {
-                        RebuildSinkMessage::RebuildSink(new_vnode, notify) => {
-                            sink_writer_param.vnode_bitmap = Some((*new_vnode).clone());
-                            if notify.send(()).is_err() {
-                                warn!("failed to notify rebuild sink");
-                            }
-                            log_reader.init().await?;
-                        },
-                        RebuildSinkMessage::UpdateConfig(config) => {
-                            let config_has_changes =
-                                sink_config_has_changes(&sink_param.properties, &config);
-                            if F::ALLOW_REWIND {
-                                match log_reader.rewind().await {
-                                    Ok(()) => {
-                                        if config_has_changes {
-                                            sink_param.properties.extend(config.into_iter());
-                                            sink = TryFrom::try_from(sink_param.clone()).map_err(|e| StreamExecutorError::from((e, sink_param.sink_id)))?;
-                                            info!(
-                                                executor_id = %sink_writer_param.executor_id,
-                                                sink_id = %sink_param.sink_id,
-                                                "alter sink config successfully with rewind"
-                                            );
-                                        } else {
-                                            info!(
-                                                executor_id = %sink_writer_param.executor_id,
-                                                sink_id = %sink_param.sink_id,
-                                                "skip alter sink config because properties are unchanged"
-                                            );
-                                        }
-                                        Ok(())
-                                    }
-                                    Err(rewind_err) => {
-                                        error!(
-                                            error = %rewind_err.as_report(),
-                                            "fail to rewind log reader for alter sink config "
-                                        );
-                                        Err(anyhow!("fail to rewind log reader after alter sink config notification").into())
-                                    }
-                                }
-                            } else {
-                                if config_has_changes {
-                                    sink_param.properties.extend(config.into_iter());
-                                    sink = TryFrom::try_from(sink_param.clone()).map_err(|e| StreamExecutorError::from((e, sink_param.sink_id)))?;
-                                } else {
-                                    info!(
-                                        executor_id = %sink_writer_param.executor_id,
-                                        sink_id = %sink_param.sink_id,
-                                        "skip rebuilding sink because properties are unchanged"
-                                    );
-                                }
-                                Err(anyhow!("This is not an actual error condition. The system is intentionally triggering recovery procedures to ensure ALTER SINK CONFIG are fully applied.").into())
-                            }
-                            .map_err(|e| StreamExecutorError::from((e, sink_param.sink_id)))?;
-                        },
+            });
+            let message = loop {
+                select! {
+                    result = &mut future => {
+                        let Err(e): StreamExecutorResult<!> = result;
+                        return Err(e);
                     }
+                    result = rebuild_sink_rx.recv() => {
+                        let message = result.ok_or_else(|| anyhow!("failed to receive rebuild sink notify"))?;
+                        // Dropping the consumer costs a rewind, or a recovery when the log
+                        // reader cannot rewind. Not worth it for an update that changes nothing.
+                        if let RebuildSinkMessage::UpdateConfig(config) = &message
+                            && !sink_config_has_changes(&sink_param.properties, config)
+                        {
+                            info!(
+                                executor_id = %sink_writer_param.executor_id,
+                                sink_id = %sink_param.sink_id,
+                                "skip alter sink config because properties are unchanged"
+                            );
+                            continue;
+                        }
+                        break message;
+                    }
+                }
+            };
+            drop(future);
+            match message {
+                RebuildSinkMessage::RebuildSink(new_vnode, notify) => {
+                    sink_writer_param.vnode_bitmap = Some((*new_vnode).clone());
+                    if notify.send(()).is_err() {
+                        warn!("failed to notify rebuild sink");
+                    }
+                    log_reader.init().await?;
+                }
+                RebuildSinkMessage::UpdateConfig(config) => {
+                    if F::ALLOW_REWIND {
+                        match log_reader.rewind().await {
+                            Ok(()) => {
+                                sink_param.properties.extend(config);
+                                sink = TryFrom::try_from(sink_param.clone()).map_err(|e| StreamExecutorError::from((e, sink_param.sink_id)))?;
+                                info!(
+                                    executor_id = %sink_writer_param.executor_id,
+                                    sink_id = %sink_param.sink_id,
+                                    "alter sink config successfully with rewind"
+                                );
+                                Ok(())
+                            }
+                            Err(rewind_err) => {
+                                error!(
+                                    error = %rewind_err.as_report(),
+                                    "fail to rewind log reader for alter sink config "
+                                );
+                                Err(anyhow!("fail to rewind log reader after alter sink config notification").into())
+                            }
+                        }
+                    } else {
+                        sink_param.properties.extend(config);
+                        sink = TryFrom::try_from(sink_param.clone()).map_err(|e| StreamExecutorError::from((e, sink_param.sink_id)))?;
+                        Err(anyhow!("This is not an actual error condition. The system is intentionally triggering recovery procedures to ensure ALTER SINK CONFIG are fully applied.").into())
+                    }
+                    .map_err(|e| StreamExecutorError::from((e, sink_param.sink_id)))?;
                 }
             }
         }
@@ -1064,8 +1064,81 @@ mod test {
         }
     }
 
+    fn no_op_config_update() -> RebuildSinkMessage {
+        RebuildSinkMessage::UpdateConfig(HashMap::from([(
+            "commit_checkpoint_interval".to_owned(),
+            "1".to_owned(),
+        )]))
+    }
+
+    fn changed_config_update() -> RebuildSinkMessage {
+        RebuildSinkMessage::UpdateConfig(HashMap::from([(
+            "commit_checkpoint_interval".to_owned(),
+            "2".to_owned(),
+        )]))
+    }
+
+    async fn assert_no_op_config_update_keeps_consuming<const CAN_REWIND: bool>() {
+        let sink_param = sink_param_for_config_update_test();
+        let sink = BlackHoleSink::try_from(sink_param.clone()).unwrap();
+        let state = Arc::new(RewindRequiredLogReaderState::default());
+        let log_reader = RewindRequiredLogReader {
+            is_reset: false,
+            state: state.clone(),
+        };
+        let (rate_limit_tx, rate_limit_rx) = unbounded_channel();
+        let (rebuild_sink_tx, rebuild_sink_rx) = unbounded_channel();
+
+        let consume_log = SinkExecutor::<TestLogStoreFactory<CAN_REWIND>>::execute_consume_log(
+            sink,
+            log_reader,
+            vec![],
+            sink_param,
+            SinkWriterParam::for_test(),
+            None,
+            ActorContext::for_test(0),
+            rate_limit_rx,
+            rebuild_sink_rx,
+        );
+        tokio::pin!(consume_log);
+
+        tokio::select! {
+            result = &mut consume_log => panic!("log consumer exited unexpectedly: {result:?}"),
+            () = state.wait_for_start_count(1) => {},
+        }
+
+        rebuild_sink_tx.send(no_op_config_update()).unwrap();
+
+        // Messages are handled in order, so an acknowledged rebuild proves the consumer survived
+        // the no-op update.
+        let (notify_tx, notify_rx) = oneshot::channel();
+        rebuild_sink_tx
+            .send(RebuildSinkMessage::RebuildSink(
+                Arc::new(Bitmap::ones(1)),
+                notify_tx,
+            ))
+            .unwrap();
+        tokio::select! {
+            result = &mut consume_log => panic!("log consumer exited unexpectedly: {result:?}"),
+            result = notify_rx => result.expect("rebuild sink should be acknowledged"),
+        }
+
+        assert_eq!(state.rewind_count.load(Ordering::SeqCst), 0);
+        drop(rate_limit_tx);
+    }
+
     #[tokio::test]
-    async fn test_no_op_sink_config_update_rewinds_log_reader() {
+    async fn test_no_op_sink_config_update_keeps_consuming_with_rewind() {
+        assert_no_op_config_update_keeps_consuming::<true>().await;
+    }
+
+    #[tokio::test]
+    async fn test_no_op_sink_config_update_keeps_consuming_without_rewind() {
+        assert_no_op_config_update_keeps_consuming::<false>().await;
+    }
+
+    #[tokio::test]
+    async fn test_sink_config_update_rewinds_log_reader() {
         let sink_param = sink_param_for_config_update_test();
         let sink = BlackHoleSink::try_from(sink_param.clone()).unwrap();
         let state = Arc::new(RewindRequiredLogReaderState::default());
@@ -1094,12 +1167,7 @@ mod test {
             () = state.wait_for_start_count(1) => {},
         }
 
-        rebuild_sink_tx
-            .send(RebuildSinkMessage::UpdateConfig(HashMap::from([(
-                "commit_checkpoint_interval".to_owned(),
-                "1".to_owned(),
-            )])))
-            .unwrap();
+        rebuild_sink_tx.send(changed_config_update()).unwrap();
 
         tokio::select! {
             result = &mut consume_log => panic!("log consumer exited unexpectedly: {result:?}"),
@@ -1111,7 +1179,7 @@ mod test {
     }
 
     #[tokio::test]
-    async fn test_no_op_sink_config_update_triggers_recovery_without_rewind() {
+    async fn test_sink_config_update_triggers_recovery_without_rewind() {
         let sink_param = sink_param_for_config_update_test();
         let sink = BlackHoleSink::try_from(sink_param.clone()).unwrap();
         let state = Arc::new(RewindRequiredLogReaderState::default());
@@ -1140,12 +1208,7 @@ mod test {
             () = state.wait_for_start_count(1) => {},
         }
 
-        rebuild_sink_tx
-            .send(RebuildSinkMessage::UpdateConfig(HashMap::from([(
-                "commit_checkpoint_interval".to_owned(),
-                "1".to_owned(),
-            )])))
-            .unwrap();
+        rebuild_sink_tx.send(changed_config_update()).unwrap();
 
         tokio::time::timeout(Duration::from_secs(5), consume_log)
             .await


### PR DESCRIPTION
Cherry-picks the fix for [#26409](https://github.com/risingwavelabs/risingwave/issues/26409) to `release-3.0`.

## Why

On `release-3.0`, an `ALTER SINK ... CONNECTOR WITH (...)` whose properties are **unchanged** aborts the compute node:

```
thread 'rw-streaming' panicked at src/stream/src/common/log_store_impl/kv_log_store/reader.rs:252:13:
future state is not Reset
```

```
KvLogStoreReader::start_from            reader.rs:252
TruncateBarrierLogReader::start_from    connector/src/sink/log_store.rs:317
CoordinatedLogSinker::consume_log_and_sink  connector/src/sink/coordinate.rs:93
```

The `UpdateConfig` branch on `release-3.0` logs `skip alter sink config because properties are unchanged` and returns `Ok(())` without rewinding, but selecting that branch has already cancelled the active `consume_log_and_sink` future. The outer loop then builds a new log sinker, which calls `start_from` on a reader that is no longer in `Reset` — hitting the assertion.

This is reachable from plain user SQL and it aborts the process rather than returning an error, so a deployment pipeline that idempotently re-issues sink `ALTER`s will restart-loop compute nodes.

Observed on a v3.0.2 cluster: two compute nodes aborted simultaneously (exit 133), the barrier could not be collected, the `AlterConnectorProps` call failed with `failed to collect barrier`, and the affected database stalled until recovery completed. It repeated on the next `ALTER`.

## What is included

Two commits, in order:

| Commit | PR | Role |
| --- | --- | --- |
| `e459ee3` | [#26412](https://github.com/risingwavelabs/risingwave/pull/26412) | rewind the log reader on a no-op sink config update |
| `645cd2f` | [#26484](https://github.com/risingwavelabs/risingwave/pull/26484) | keep consuming instead — do not drop the consumer at all |

[#26484](https://github.com/risingwavelabs/risingwave/pull/26484) supersedes [#26412](https://github.com/risingwavelabs/risingwave/pull/26412), but its pre-image assumes [#26412](https://github.com/risingwavelabs/risingwave/pull/26412) is applied. Cherry-picking [#26484](https://github.com/risingwavelabs/risingwave/pull/26484) alone conflicts throughout `src/stream/src/executor/sink.rs`; with [#26412](https://github.com/risingwavelabs/risingwave/pull/26412) first, the only remaining conflict is the one-hunk test-ordering collision described below.

## Verification

Rebased onto `release-3.0` after [#26639](https://github.com/risingwavelabs/risingwave/pull/26639) landed, which modifies the same `execute_consume_log` retry loop that [#26484](https://github.com/risingwavelabs/risingwave/pull/26484) restructures.

- [#26412](https://github.com/risingwavelabs/risingwave/pull/26412) applied cleanly. [#26484](https://github.com/risingwavelabs/risingwave/pull/26484) produced a single conflict, entirely within `mod test`: both sides append a new function at the same position. Resolved by keeping both.
- The production code merged automatically, so it was verified separately. Every line introduced by [#26639](https://github.com/risingwavelabs/risingwave/pull/26639) — `retry_backoff`, `attempt_started_at`, `attempt_duration`, `retry_delay`, `SINK_RETRY_BACKOFF_RESET_INTERVAL` — appears only as context in `origin/release-3.0..HEAD`, never as an added or removed line.
- `src/stream/src/executor/sink.rs` now differs from `main` by 12 insertions / 27 deletions across four hunks, none of them in the fixed path. Three are pre-existing gaps that appear verbatim in the `origin/release-3.0` vs `main` baseline, so they are not rebase artifacts: the `use std::{assert_matches, mem}` grouping, `wait_log_store_flush`, and `needs_projection` / `extra_partition_col_idx` ([#26356](https://github.com/risingwavelabs/risingwave/pull/26356) partition-column pruning). The fourth is the position of `test_sink_retry_backoff_is_bounded`, whose body is byte-identical. `execute_consume_log` and the `RebuildSinkMessage::UpdateConfig` handling are identical to `main`.
- `cargo check -p risingwave_stream --tests` passes with 0 errors and 0 warnings.
- `cargo test -p risingwave_stream --lib executor::sink::` passes 13/13, covering all three changes that now share this file: `test_sink_config_update_rewinds_log_reader` ([#26412](https://github.com/risingwavelabs/risingwave/pull/26412)), `test_no_op_sink_config_update_keeps_consuming_with_rewind` / `_without_rewind` ([#26484](https://github.com/risingwavelabs/risingwave/pull/26484)), and `test_sink_retry_backoff_is_bounded` ([#26639](https://github.com/risingwavelabs/risingwave/pull/26639)).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

