### PR TITLE
fix(grafana): set pod all value regex

### DIFF
--- a/grafana/dashboard/common.py
+++ b/grafana/dashboard/common.py
@@ -36,6 +36,7 @@ COMPONENT_VARIABLE = "job"
 NODE_LABEL = "instance"
 NODE_VARIABLE_LABEL = "Node"
 NODE_VARIABLE = "node"
+NODE_VARIABLE_CUSTOM_ALL_VALUE = None
 
 # Use different labels for role and instance when namespace filter enabled. (Kubernetes)
 if namespace_filter_enabled:
@@ -45,6 +46,7 @@ if namespace_filter_enabled:
     NODE_LABEL = "pod"
     NODE_VARIABLE_LABEL = "Pod"
     NODE_VARIABLE = "pod"
+    NODE_VARIABLE_CUSTOM_ALL_VALUE = ".+"
 
 templating = Templating()
 if namespace_filter_enabled:

--- a/grafana/risingwave-dev-dashboard.dashboard.py
+++ b/grafana/risingwave-dev-dashboard.dashboard.py
@@ -130,6 +130,8 @@ node_json = {
     "sort": 6,
     "type": "query",
 }
+if NODE_VARIABLE_CUSTOM_ALL_VALUE is not None:
+    node_json["allValue"] = NODE_VARIABLE_CUSTOM_ALL_VALUE
 
 job_json = {
     "current": {"selected": False, "text": "All", "value": "__all"},

--- a/grafana/risingwave-user-dashboard.dashboard.py
+++ b/grafana/risingwave-user-dashboard.dashboard.py
@@ -140,6 +140,8 @@ node_json = {
     "sort": 6,
     "type": "query",
 }
+if NODE_VARIABLE_CUSTOM_ALL_VALUE is not None:
+    node_json["allValue"] = NODE_VARIABLE_CUSTOM_ALL_VALUE
 
 job_json = {
     "current": {"selected": False, "text": "All", "value": "__all"},


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

This PR sets the Grafana `pod` variable's custom all value to `.+` when namespace filtering is enabled and applies the shared setting to both the development and user dashboard models.

Previously, Grafana expanded **All** from the enumerated pod options because the variable had no custom all value. Using a stable `.+` PromQL regex explicitly matches every non-empty pod label, including pods that appear after the variable options were refreshed. The default non-Kubernetes `node` variable remains unchanged.

Validation:

- Generated both dashboards with namespace, RisingWave name, and dynamic datasource filters enabled; verified `pod.allValue` is `.+`.
- Generated both dashboards in default mode; verified `node` has no custom all value and the committed dashboard JSON remains current.
- Ran Python compilation and `git diff --check`.

## Checklist

- [x] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [x] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

Not applicable. This changes development dashboard variable behavior only.

</details>
