### PR TITLE
feat(config): enable background DDL by default for new clusters

### DIFF
--- a/src/common/src/session_config/mod.rs
+++ b/src/common/src/session_config/mod.rs
@@ -404,7 +404,7 @@ pub struct SessionConfig {
     streaming_cache_refill_policy: OptionConfig<CacheRefillPolicy>,
 
     /// Run DDL statements in background
-    #[parameter(default = false)]
+    #[parameter(default = true)]
     background_ddl: bool,
 
     /// Enable shared source. Currently only for Kafka.

--- a/src/meta/src/controller/session_params.rs
+++ b/src/meta/src/controller/session_params.rs
@@ -261,6 +261,51 @@ mod tests {
         assert_eq!(models.value, params.get("rw_implicit_flush").unwrap());
     }
 
+    #[tokio::test]
+    async fn test_background_ddl_default_for_new_and_existing_clusters() {
+        let env = MetaSrvEnv::for_test().await;
+        let meta_store = env.meta_store_ref().clone();
+
+        // A new cluster uses and persists the current built-in default.
+        SessionParameter::delete_many()
+            .exec(&meta_store.conn)
+            .await
+            .unwrap();
+        let ctl = SessionParamsController::new(
+            meta_store.clone(),
+            env.notification_manager_ref(),
+            SessionInitConfig::default(),
+        )
+        .await
+        .unwrap();
+        assert!(ctl.get_params().await.background_ddl());
+
+        let persisted = SessionParameter::find_by_id("background_ddl".to_owned())
+            .one(&meta_store.conn)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(persisted.value, "true");
+        drop(ctl);
+
+        // Simulate an existing cluster whose previous built-in default was persisted as false.
+        let mut persisted: session_parameter::ActiveModel = persisted.into();
+        persisted.value = Set("false".to_owned());
+        SessionParameter::update(persisted)
+            .exec(&meta_store.conn)
+            .await
+            .unwrap();
+
+        let ctl = SessionParamsController::new(
+            meta_store.clone(),
+            env.notification_manager_ref(),
+            SessionInitConfig::default(),
+        )
+        .await
+        .unwrap();
+        assert!(!ctl.get_params().await.background_ddl());
+    }
+
     /// Scenario 1: on a new cluster, `[session_init]` seeds values into the meta store, including
     /// the `default` placeholder which must be persisted verbatim.
     #[tokio::test]


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What changed and what is the intention?

This changes the built-in `background_ddl` session default from `false` to `true`.

- Fresh clusters now run eligible streaming DDL jobs in background mode by default.
- Existing clusters retain their previous behavior after upgrade because all effective session parameter values are persisted in `session_parameter`, and persisted values take precedence over the new built-in default.
- Plans rejected by `plan_can_use_background_ddl` continue to use foreground creation.
- Users can still opt into synchronous creation with `ALTER SYSTEM SET background_ddl = false` or a session-level `SET`.

This gives recoverable long-running DDL explicit background semantics instead of turning an interrupted foreground request into a job that reports an error to the client but silently continues in the background. It is an alternative direction discussed while reviewing #26472.

The regression test covers both rollout paths:

- an empty Meta store uses and persists `background_ddl=true`;
- an existing cluster with a persisted historical value of `background_ddl=false` keeps `false` after restart with the new binary.

## Validation

- `cargo test -p risingwave_meta controller::session_params::tests --lib`
- `cargo clippy -p risingwave_meta -p risingwave_common --lib --all-features -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`

## Checklist

- [ ] I have written necessary rustdoc comments.
- [x] I have added necessary unit tests and integration tests.
- [x] I have added test labels as necessary.
- [ ] I have added fuzzing tests or opened an issue to track them.
- [ ] My PR contains breaking changes.
- [ ] My PR changes performance-critical code, so I will run (micro) benchmarks and present the results.
- [x] I have checked the release timeline and currently supported versions; this changes the default only for fresh clusters and is not intended for release-branch cherry-picks.

## Documentation

- [x] My PR needs documentation updates.

<details>
<summary><b>Release note</b></summary>

New RisingWave clusters now enable background DDL by default for recoverable streaming jobs. Eligible `CREATE MATERIALIZED VIEW`, `CREATE INDEX`, and `CREATE SINK` statements can return before backfill finishes, and their progress can continue across recovery. Existing clusters retain their persisted `background_ddl` setting after upgrade. Set `background_ddl = false` to keep synchronous foreground creation.

</details>