### PR TITLE
perf(sink): restore multi-row batched writes in native postgres sink

### DIFF
--- a/e2e_test/sink/postgres_sink.slt
+++ b/e2e_test/sink/postgres_sink.slt
@@ -704,6 +704,116 @@ DROP TABLE rw_fk_parent;
 system ok
 PGDATABASE=sink_test psql -c "DROP TABLE pg_fk_child; DROP TABLE pg_fk_parent"
 
+################### Test batched writes: rows are buffered across chunks and flushed once max_batch_rows is reached
+
+statement ok
+DROP TABLE IF EXISTS rw_batch_table CASCADE;
+
+system ok
+PGDATABASE=sink_test psql -c "DROP TABLE IF EXISTS pg_batch_table"
+
+system ok
+PGDATABASE=sink_test psql -c "CREATE TABLE pg_batch_table (
+    id BIGINT PRIMARY KEY,
+    grp INTEGER,
+    ver INTEGER,
+    val BIGINT,
+    payload VARCHAR
+)"
+
+statement ok
+CREATE TABLE rw_batch_table (
+    id BIGINT PRIMARY KEY,
+    grp INTEGER,
+    ver INTEGER,
+    val BIGINT,
+    payload VARCHAR
+);
+
+statement ok
+CREATE SINK rw_batch_sink FROM rw_batch_table WITH (
+    connector='postgres',
+    host='$PGHOST',
+    port='$PGPORT',
+    user='$PGUSER',
+    password='$PGPASSWORD',
+    database='sink_test',
+    table='pg_batch_table',
+    type='upsert',
+    primary_key='id',
+    max_batch_rows='64',
+);
+
+# Every statement below feeds far more than 64 rows per epoch, so the batch-full flush runs repeatedly.
+
+statement ok
+INSERT INTO rw_batch_table SELECT x, x % 7, 1, x, 'v1-' || x FROM generate_series(1, 500) t(x);
+
+statement ok
+flush;
+
+# Updates emit U-/U+ pairs on the same key, so the in-batch dedup collapses them to one upsert per key.
+
+statement ok
+UPDATE rw_batch_table SET ver = 2, val = val + 1000, payload = 'v2-' || id WHERE id % 3 = 0;
+
+statement ok
+flush;
+
+statement ok
+UPDATE rw_batch_table SET ver = 3, val = val + 2000, payload = 'v3-' || id WHERE id <= 120;
+
+statement ok
+flush;
+
+statement ok
+DELETE FROM rw_batch_table WHERE id % 10 = 0;
+
+statement ok
+flush;
+
+# Bring part of the deleted key range back.
+
+statement ok
+INSERT INTO rw_batch_table SELECT x * 10, (x * 10) % 7, 4, x * 10, 'v4-' || (x * 10) FROM generate_series(1, 20) t(x);
+
+statement ok
+flush;
+
+query I retry 4 backoff 1s
+select * from postgres_query('$PGHOST', '$PGPORT', '$PGUSER', '${PGPASSWORD:postgres}', 'sink_test', 'select count(*), sum(val), sum(grp), sum(ver) from pg_batch_table;');
+----
+470 480600 1410 860
+
+query I
+select count(*), sum(val), sum(grp), sum(ver) from rw_batch_table;
+----
+470 480600 1410 860
+
+# Symmetric difference between RisingWave and the sink target must be empty.
+
+query I retry 4 backoff 1s
+select count(*) from (
+    (select id, grp, ver, val, payload from rw_batch_table
+     except
+     select id, grp, ver, val, payload from postgres_query('$PGHOST', '$PGPORT', '$PGUSER', '${PGPASSWORD:postgres}', 'sink_test', 'select id, grp, ver, val, payload from pg_batch_table;'))
+    union all
+    (select id, grp, ver, val, payload from postgres_query('$PGHOST', '$PGPORT', '$PGUSER', '${PGPASSWORD:postgres}', 'sink_test', 'select id, grp, ver, val, payload from pg_batch_table;')
+     except
+     select id, grp, ver, val, payload from rw_batch_table)
+) as diff;
+----
+0
+
+statement ok
+DROP SINK rw_batch_sink;
+
+statement ok
+DROP TABLE rw_batch_table;
+
+system ok
+PGDATABASE=sink_test psql -c "DROP TABLE pg_batch_table"
+
 ################### Drop DB
 
 system ok

--- a/src/connector/src/connector_common/common.rs
+++ b/src/connector/src/connector_common/common.rs
@@ -1256,3 +1256,36 @@ impl MongodbCommon {
         Ok(client)
     }
 }
+
+/// TCP keepalive knobs for long-lived Postgres clients, see `create_pg_client`.
+#[serde_as]
+#[derive(Debug, Clone, Deserialize, WithOptions)]
+pub struct TcpKeepaliveConfig {
+    #[serde(rename = "tcp.keepalive.idle", default = "default_tcp_keepalive_idle")]
+    #[serde_as(as = "DisplayFromStr")]
+    pub tcp_keepalive_idle: u32,
+    #[serde(
+        rename = "tcp.keepalive.interval",
+        default = "default_tcp_keepalive_interval"
+    )]
+    #[serde_as(as = "DisplayFromStr")]
+    pub tcp_keepalive_interval: u32,
+    #[serde(
+        rename = "tcp.keepalive.count",
+        default = "default_tcp_keepalive_count"
+    )]
+    #[serde_as(as = "DisplayFromStr")]
+    pub tcp_keepalive_count: u32,
+}
+
+const fn default_tcp_keepalive_idle() -> u32 {
+    10 * 60
+}
+
+const fn default_tcp_keepalive_interval() -> u32 {
+    10
+}
+
+const fn default_tcp_keepalive_count() -> u32 {
+    3
+}

--- a/src/connector/src/connector_common/mod.rs
+++ b/src/connector/src/connector_common/mod.rs
@@ -23,6 +23,7 @@ pub use common::{
     KafkaConnectionProps, KafkaPrivateLinkCommon, KinesisCommon, MongodbCommon, NatsCommon,
     NatsConnectionProps, PRIVATE_LINK_BROKER_REWRITE_MAP_KEY, PRIVATE_LINK_TARGETS_KEY,
     PulsarCommon, PulsarOauthCommon, RdKafkaPropertiesCommon, SHARED_NATS_CLIENT,
+    TcpKeepaliveConfig,
 };
 mod connection;
 pub use connection::{
@@ -41,7 +42,7 @@ pub use iceberg::{
     ResolvedIcebergCatalogConfig, iceberg_java_catalog_props_from_options,
 };
 pub use postgres::{
-    PgConnectionConfig, PostgresExternalTable, SslMode, TcpKeepaliveConfig, create_pg_client,
+    PgConnectionConfig, PostgresExternalTable, SslMode, create_pg_client,
     create_pg_client_from_properties, discover_pgvector_dimensions,
     pg_connection_config_from_properties,
 };

--- a/src/connector/src/connector_common/postgres.rs
+++ b/src/connector/src/connector_common/postgres.rs
@@ -31,6 +31,7 @@ use sqlx::{PgPool, Row};
 use thiserror_ext::AsReport;
 use tokio_postgres::types::Kind as PgKind;
 use tokio_postgres::{Client as PgClient, NoTls};
+use with_options::WithOptions;
 
 #[cfg(not(madsim))]
 use super::maybe_tls_connector::MaybeMakeTlsConnector;
@@ -134,7 +135,7 @@ impl PgConnectionConfig {
 /// Lives in `connector_common` so both the sink config and the shared
 /// `create_pg_client` helper reference the same definition.
 #[serde_as]
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, WithOptions)]
 pub struct TcpKeepaliveConfig {
     #[serde(rename = "tcp.keepalive.idle")]
     #[serde_as(as = "DisplayFromStr")]

--- a/src/connector/src/connector_common/postgres.rs
+++ b/src/connector/src/connector_common/postgres.rs
@@ -25,14 +25,13 @@ use sea_schema::postgres::def::{ColumnType as SeaType, TableDef, TableInfo};
 use sea_schema::postgres::discovery::SchemaDiscovery;
 use sea_schema::sea_query::{Alias, IntoIden};
 use serde::Deserialize;
-use serde_with::{DisplayFromStr, serde_as};
 use sqlx::postgres::{PgConnectOptions, PgSslMode};
 use sqlx::{PgPool, Row};
 use thiserror_ext::AsReport;
 use tokio_postgres::types::Kind as PgKind;
 use tokio_postgres::{Client as PgClient, NoTls};
-use with_options::WithOptions;
 
+use super::TcpKeepaliveConfig;
 #[cfg(not(madsim))]
 use super::maybe_tls_connector::MaybeMakeTlsConnector;
 use crate::error::ConnectorResult;
@@ -128,33 +127,6 @@ impl PgConnectionConfig {
         }
 
         options
-    }
-}
-
-/// TCP keepalive knobs for the long-lived Postgres client used by the sink.
-/// Lives in `connector_common` so both the sink config and the shared
-/// `create_pg_client` helper reference the same definition.
-#[serde_as]
-#[derive(Debug, Clone, Deserialize, WithOptions)]
-pub struct TcpKeepaliveConfig {
-    #[serde(rename = "tcp.keepalive.idle")]
-    #[serde_as(as = "DisplayFromStr")]
-    pub tcp_keepalive_idle: u32,
-    #[serde(rename = "tcp.keepalive.interval")]
-    #[serde_as(as = "DisplayFromStr")]
-    pub tcp_keepalive_interval: u32,
-    #[serde(rename = "tcp.keepalive.count")]
-    #[serde_as(as = "DisplayFromStr")]
-    pub tcp_keepalive_count: u32,
-}
-
-impl Default for TcpKeepaliveConfig {
-    fn default() -> Self {
-        Self {
-            tcp_keepalive_idle: 10 * 60,
-            tcp_keepalive_interval: 10,
-            tcp_keepalive_count: 3,
-        }
     }
 }
 

--- a/src/connector/src/sink/postgres.rs
+++ b/src/connector/src/sink/postgres.rs
@@ -635,13 +635,20 @@ impl PostgresSinkWriter {
 
         // Statements are prepared before the transaction; after warm-up every size hits the cache.
         let write_kind = self.write_kind();
-        let mut batches = self
+        let delete_batches = self
             .prepare_batches(StatementKind::Delete, &deletes)
             .await?;
-        batches.extend(self.prepare_batches(write_kind, &upserts).await?);
+        let upsert_batches = self.prepare_batches(write_kind, &upserts).await?;
 
         let transaction = self.client.transaction().await?;
-        if let Err(e) = execute_batches(&transaction, &batches).await {
+        // Deletes are awaited before upserts are sent, so that no delete can land after a
+        // PG-equal upsert and erase a live row; costs one extra round trip on mixed flushes.
+        let result = async {
+            execute_batches(&transaction, &delete_batches).await?;
+            execute_batches(&transaction, &upsert_batches).await
+        }
+        .await;
+        if let Err(e) = result {
             // Retry any failed batch row by row: keys distinct to RisingWave but equal to
             // PostgreSQL fail a multi-row upsert with SQLSTATE 21000 yet apply cleanly one row at
             // a time; other errors recover on retry or resurface localized to a single row.
@@ -736,8 +743,10 @@ async fn execute_batches(
     transaction: &tokio_postgres::Transaction<'_>,
     batches: &[(tokio_postgres::Statement, &[PgRow])],
 ) -> std::result::Result<(), tokio_postgres::Error> {
-    // Polling all statements concurrently pipelines them into a single round trip; they still
-    // execute in wire order, i.e. in the order of `batches`.
+    // Polling all statements concurrently pipelines them into a single round trip; they execute
+    // in first-poll order, i.e. the order of `batches` — an unstated implementation detail of
+    // `futures` and `tokio-postgres`. If it ever breaks, only the winner among PG-equal upsert
+    // keys can change, which is best-effort anyway.
     let executions = batches.iter().map(|(statement, tuples)| {
         let mut params = Vec::with_capacity(tuples.len() * tuples.first().map_or(0, |t| t.len()));
         params.extend(tuples.iter().flatten());

--- a/src/connector/src/sink/postgres.rs
+++ b/src/connector/src/sink/postgres.rs
@@ -88,7 +88,7 @@ pub struct PostgresConfig {
     pub tcp_keepalive_enable: bool,
 
     #[serde(flatten)]
-    pub tcp_keepalive: Option<TcpKeepaliveConfig>,
+    pub tcp_keepalive: TcpKeepaliveConfig,
 
     #[serde(flatten)]
     pub unknown_fields: std::collections::HashMap<String, String>,
@@ -111,14 +111,9 @@ fn default_schema() -> String {
 }
 
 fn tcp_keepalive_from_config(config: &PostgresConfig) -> Option<TcpKeepaliveConfig> {
-    if config.tcp_keepalive_enable {
-        config
-            .tcp_keepalive
-            .clone()
-            .or_else(|| Some(TcpKeepaliveConfig::default()))
-    } else {
-        None
-    }
+    config
+        .tcp_keepalive_enable
+        .then(|| config.tcp_keepalive.clone())
 }
 
 async fn ensure_no_foreign_key(config: &PostgresConfig) -> Result<()> {

--- a/src/connector/src/sink/postgres.rs
+++ b/src/connector/src/sink/postgres.rs
@@ -21,7 +21,6 @@ use phf::phf_set;
 use risingwave_common::array::{Op, StreamChunk};
 use risingwave_common::catalog::Schema;
 use risingwave_common::row::{OwnedRow, Row, RowExt};
-use risingwave_common::util::iter_util::ZipEqFast;
 use serde::Deserialize;
 use serde_with::{DisplayFromStr, serde_as};
 use simd_json::prelude::ArrayTrait;
@@ -333,16 +332,18 @@ impl Sink for PostgresSink {
     }
 }
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy)]
 enum StatementKind {
-    /// Plain `INSERT` for append-only sinks, `INSERT .. ON CONFLICT` otherwise.
+    /// Plain `INSERT`, used by append-only sinks.
+    Insert,
     Upsert,
     Delete,
 }
 
 impl StatementKind {
-    fn as_str(&self) -> &'static str {
+    fn as_str(self) -> &'static str {
         match self {
+            StatementKind::Insert => "insert",
             StatementKind::Upsert => "upsert",
             StatementKind::Delete => "delete",
         }
@@ -351,7 +352,7 @@ impl StatementKind {
 
 enum PendingOp {
     Upsert(PgRow),
-    Delete(PgRow),
+    Delete,
 }
 
 /// Rows accumulated across chunks, written out on flush.
@@ -376,15 +377,10 @@ impl PendingRows {
         }
     }
 
-    fn absorb(
-        &mut self,
-        chunk: &StreamChunk,
-        key_indices: &[usize],
-        key_types: &[PgType],
-        schema_types: &[PgType],
-    ) {
+    fn absorb(&mut self, chunk: &StreamChunk, key_indices: &[usize], schema_types: &[PgType]) {
         match self {
             PendingRows::Insert(rows) => {
+                rows.reserve(chunk.cardinality());
                 for (op, row) in chunk.rows() {
                     if op == Op::Insert {
                         rows.push(convert_row_to_pg_row(row, schema_types));
@@ -396,16 +392,14 @@ impl PendingRows {
                 }
             }
             PendingRows::Upsert(rows) => {
+                rows.reserve(chunk.cardinality());
                 for (op, row) in chunk.rows() {
                     let key = row.project(key_indices).into_owned_row();
                     let pending_op = match op {
                         Op::Insert | Op::UpdateInsert => {
                             PendingOp::Upsert(convert_row_to_pg_row(row, schema_types))
                         }
-                        Op::Delete | Op::UpdateDelete => PendingOp::Delete(convert_row_to_pg_row(
-                            row.project(key_indices),
-                            key_types,
-                        )),
+                        Op::Delete | Op::UpdateDelete => PendingOp::Delete,
                     };
                     rows.insert(key, pending_op);
                 }
@@ -413,17 +407,17 @@ impl PendingRows {
         }
     }
 
-    /// Takes all pending rows out, split into deletes and upserts.
-    fn take(&mut self) -> (Vec<PgRow>, Vec<PgRow>) {
+    /// Takes all pending rows out, split into deletes (rebuilt from the keys) and upserts.
+    fn take(&mut self, key_types: &[PgType]) -> (Vec<PgRow>, Vec<PgRow>) {
         match self {
             PendingRows::Insert(rows) => (vec![], std::mem::take(rows)),
             PendingRows::Upsert(rows) => {
-                let mut deletes = Vec::new();
-                let mut upserts = Vec::new();
-                for op in rows.drain().map(|(_, op)| op) {
+                let mut deletes = Vec::with_capacity(rows.len());
+                let mut upserts = Vec::with_capacity(rows.len());
+                for (key, op) in rows.drain() {
                     match op {
                         PendingOp::Upsert(row) => upserts.push(row),
-                        PendingOp::Delete(row) => deletes.push(row),
+                        PendingOp::Delete => deletes.push(convert_row_to_pg_row(&key, key_types)),
                     }
                 }
                 (deletes, upserts)
@@ -433,21 +427,17 @@ impl PendingRows {
 }
 
 pub struct PostgresSinkWriter {
-    is_append_only: bool,
+    write_kind: StatementKind,
     client: tokio_postgres::Client,
     schema: Schema,
     schema_name: String,
     table_name: String,
-    pk_indices: Vec<usize>,
-    pk_indices_lookup: HashSet<usize>,
     /// Columns identifying a downstream row: the sink pk, or all columns when there is no pk.
     key_indices: Vec<usize>,
     key_types: Vec<PgType>,
     schema_types: Vec<PgType>,
     max_batch_rows: usize,
-    upsert_tuples_per_statement: usize,
-    delete_tuples_per_statement: usize,
-    upsert_statement: Option<tokio_postgres::Statement>,
+    write_statement: Option<tokio_postgres::Statement>,
     delete_statement: Option<tokio_postgres::Statement>,
     pending: PendingRows,
 }
@@ -465,8 +455,6 @@ impl PostgresSinkWriter {
         let client = create_pg_client(&pg_conn, tcp_keepalive).await?;
 
         ensure_no_foreign_key_with_client(&client, &config.schema, &config.table).await?;
-
-        let pk_indices_lookup = pk_indices.iter().copied().collect::<HashSet<_>>();
 
         // Rewrite schema types for serialization
         let schema_types = {
@@ -494,41 +482,37 @@ impl PostgresSinkWriter {
             schema_types
         };
 
-        // Fall back to all columns when no pk is defined, consistent with `create_delete_sql`.
+        // Normalize the key here: pk, or all columns when there is no pk. SQL builders require it non-empty.
         let key_indices = if pk_indices.is_empty() {
             (0..schema.len()).collect_vec()
         } else {
-            pk_indices.clone()
+            pk_indices
         };
         let key_types = key_indices
             .iter()
             .map(|i| schema_types[*i].clone())
             .collect_vec();
 
-        let upsert_tuples_per_statement = tuples_per_statement(config.max_batch_rows, schema.len());
-        let delete_tuples_per_statement =
-            tuples_per_statement(config.max_batch_rows, key_indices.len());
-        let pending = if is_append_only {
-            PendingRows::Insert(Vec::new())
+        let (write_kind, pending) = if is_append_only {
+            (StatementKind::Insert, PendingRows::Insert(Vec::new()))
         } else {
-            PendingRows::Upsert(HashMap::new())
+            (
+                StatementKind::Upsert,
+                PendingRows::Upsert(HashMap::with_capacity(config.max_batch_rows)),
+            )
         };
 
         let writer = Self {
-            is_append_only,
+            write_kind,
             client,
             schema,
             schema_name: config.schema,
             table_name: config.table,
-            pk_indices,
-            pk_indices_lookup,
             key_indices,
             key_types,
             schema_types,
             max_batch_rows: config.max_batch_rows,
-            upsert_tuples_per_statement,
-            delete_tuples_per_statement,
-            upsert_statement: None,
+            write_statement: None,
             delete_statement: None,
             pending,
         };
@@ -537,15 +521,14 @@ impl PostgresSinkWriter {
 
     fn create_sql(&self, kind: StatementKind, n_tuples: usize) -> String {
         match kind {
-            StatementKind::Upsert if self.is_append_only => {
+            StatementKind::Insert => {
                 create_insert_sql(&self.schema, &self.schema_name, &self.table_name, n_tuples)
             }
             StatementKind::Upsert => create_upsert_sql(
                 &self.schema,
                 &self.schema_name,
                 &self.table_name,
-                &self.pk_indices,
-                &self.pk_indices_lookup,
+                &self.key_indices,
                 n_tuples,
             ),
             StatementKind::Delete => create_delete_sql(
@@ -558,95 +541,86 @@ impl PostgresSinkWriter {
         }
     }
 
-    fn tuples_per_statement(&self, kind: StatementKind) -> usize {
+    fn statement_cache(&mut self, kind: StatementKind) -> &mut Option<tokio_postgres::Statement> {
         match kind {
-            StatementKind::Upsert => self.upsert_tuples_per_statement,
-            StatementKind::Delete => self.delete_tuples_per_statement,
+            StatementKind::Insert | StatementKind::Upsert => &mut self.write_statement,
+            StatementKind::Delete => &mut self.delete_statement,
         }
     }
 
-    /// Prepares one statement per sub-batch. Only the full-sized statement is cached, the
-    /// remainder differs from flush to flush and is prepared ad hoc.
-    async fn prepare_statements(
+    /// Pairs each sub-batch with a statement of matching tuple count. Only the full-size
+    /// statement is cached; remainder sizes (barrier flushes) are prepared ad hoc.
+    async fn prepare_batches<'a>(
         &mut self,
         kind: StatementKind,
-        n_rows: usize,
-    ) -> Result<Vec<tokio_postgres::Statement>> {
-        let full = self.tuples_per_statement(kind);
-        let mut statements = Vec::with_capacity(n_rows.div_ceil(full));
-        let mut remaining = n_rows;
-        while remaining > 0 {
-            let n_tuples = remaining.min(full);
-            let cached = match kind {
-                StatementKind::Upsert => &self.upsert_statement,
-                StatementKind::Delete => &self.delete_statement,
-            };
-            let statement = match cached {
-                Some(statement) if n_tuples == full => statement.clone(),
+        rows: &'a [PgRow],
+    ) -> Result<Vec<(tokio_postgres::Statement, &'a [PgRow])>> {
+        if rows.is_empty() {
+            return Ok(vec![]);
+        }
+        let params_per_tuple = match kind {
+            StatementKind::Insert | StatementKind::Upsert => self.schema.len(),
+            StatementKind::Delete => self.key_indices.len(),
+        };
+        let full = tuples_per_statement(self.max_batch_rows, params_per_tuple);
+        let mut batches = Vec::with_capacity(rows.len().div_ceil(full));
+        for tuples in rows.chunks(full) {
+            let is_full = tuples.len() == full;
+            let statement = match self.statement_cache(kind).clone() {
+                Some(statement) if is_full => statement,
                 _ => {
-                    let sql = self.create_sql(kind, n_tuples);
+                    let sql = self.create_sql(kind, tuples.len());
                     let statement = self.client.prepare(&sql).await.with_context(|| {
                         format!(
                             "failed to prepare {} statement for {} rows",
                             kind.as_str(),
-                            n_tuples
+                            tuples.len()
                         )
                     })?;
-                    if n_tuples == full {
-                        match kind {
-                            StatementKind::Upsert => {
-                                self.upsert_statement = Some(statement.clone())
-                            }
-                            StatementKind::Delete => {
-                                self.delete_statement = Some(statement.clone())
-                            }
-                        }
+                    if is_full {
+                        *self.statement_cache(kind) = Some(statement.clone());
                     }
                     statement
                 }
             };
-            statements.push(statement);
-            remaining -= n_tuples;
+            batches.push((statement, tuples));
         }
-        Ok(statements)
+        Ok(batches)
     }
 
     /// Writes out all pending rows in a single transaction.
     async fn flush(&mut self) -> Result<()> {
-        let (deletes, upserts) = self.pending.take();
+        let (deletes, upserts) = self.pending.take(&self.key_types);
         if deletes.is_empty() && upserts.is_empty() {
             return Ok(());
         }
 
-        // Statements are prepared before the transaction begins, as it borrows the client mutably.
-        let delete_statements = self
-            .prepare_statements(StatementKind::Delete, deletes.len())
+        // Statements are prepared before the transaction so cache hits skip the prepare round trip
+        // entirely.
+        let delete_batches = self
+            .prepare_batches(StatementKind::Delete, &deletes)
             .await?;
-        let upsert_statements = self
-            .prepare_statements(StatementKind::Upsert, upserts.len())
-            .await?;
+        let write_batches = self.prepare_batches(self.write_kind, &upserts).await?;
 
         let transaction = self.client.transaction().await?;
         // Deletes go first, which is safe because dedup leaves deleted and upserted keys disjoint.
-        execute_batches(
-            &transaction,
-            StatementKind::Delete,
-            &delete_statements,
-            &deletes,
-            self.delete_tuples_per_statement,
-        )
-        .await?;
-        execute_batches(
-            &transaction,
-            StatementKind::Upsert,
-            &upsert_statements,
-            &upserts,
-            self.upsert_tuples_per_statement,
-        )
-        .await?;
+        execute_batches(&transaction, StatementKind::Delete, &delete_batches).await?;
+        execute_batches(&transaction, self.write_kind, &write_batches).await?;
         transaction.commit().await?;
 
         Ok(())
+    }
+
+    /// Buffers the chunk, flushing when the batch is full. Returns whether a flush happened.
+    async fn write_chunk(&mut self, chunk: &StreamChunk) -> Result<bool> {
+        self.pending
+            .absorb(chunk, &self.key_indices, &self.schema_types);
+        if self.pending.len() >= self.max_batch_rows {
+            self.flush().await?;
+            Ok(true)
+        } else {
+            Ok(false)
+        }
     }
 }
 
@@ -660,15 +634,11 @@ fn tuples_per_statement(max_batch_rows: usize, params_per_tuple: usize) -> usize
 async fn execute_batches(
     transaction: &tokio_postgres::Transaction<'_>,
     kind: StatementKind,
-    statements: &[tokio_postgres::Statement],
-    rows: &[PgRow],
-    tuples_per_statement: usize,
+    batches: &[(tokio_postgres::Statement, &[PgRow])],
 ) -> Result<()> {
-    for (statement, tuples) in statements
-        .iter()
-        .zip_eq_fast(rows.chunks(tuples_per_statement))
-    {
-        let params = tuples.iter().flatten().collect_vec();
+    for (statement, tuples) in batches {
+        let mut params = Vec::with_capacity(tuples.len() * tuples.first().map_or(0, |t| t.len()));
+        params.extend(tuples.iter().flatten());
         transaction
             .execute_raw(statement, params)
             .await
@@ -691,17 +661,10 @@ impl LogSinker for PostgresSinkWriter {
             let (epoch, item) = log_reader.next_item().await?;
             match item {
                 LogStoreReadItem::StreamChunk { chunk, chunk_id } => {
-                    self.pending.absorb(
-                        &chunk,
-                        &self.key_indices,
-                        &self.key_types,
-                        &self.schema_types,
-                    );
-                    // Rows are buffered across chunks, so an offset may only be truncated once
-                    // the flush that commits its rows has succeeded. Offsets of chunks that are
-                    // still buffered are covered by a later truncation.
-                    if self.pending.len() >= self.max_batch_rows {
-                        self.flush().await?;
+                    // Rows are buffered across chunks, so an offset may only be truncated once the
+                    // flush that commits its rows has succeeded. Offsets of chunks that are still
+                    // buffered are covered by a later truncation.
+                    if self.write_chunk(&chunk).await? {
                         log_reader.truncate(TruncateOffset::Chunk { epoch, chunk_id })?;
                     }
                 }
@@ -750,7 +713,7 @@ fn create_delete_sql(
     schema: &Schema,
     schema_name: &str,
     table_name: &str,
-    pk_indices: &[usize],
+    key_indices: &[usize],
     n_tuples: usize,
 ) -> String {
     let normalized_table_name = format!(
@@ -758,19 +721,14 @@ fn create_delete_sql(
         quote_identifier(schema_name),
         quote_identifier(table_name)
     );
-    let pk_indices = if pk_indices.is_empty() {
-        (0..schema.len()).collect_vec()
-    } else {
-        pk_indices.to_vec()
-    };
     let pk = {
-        let pk_symbols = pk_indices
+        let pk_symbols = key_indices
             .iter()
-            .map(|pk_index| quote_identifier(&schema.fields()[*pk_index].name))
+            .map(|key_index| quote_identifier(&schema.fields()[*key_index].name))
             .join(", ");
         format!("({})", pk_symbols)
     };
-    let parameters = create_parameter_tuples(pk_indices.len(), n_tuples);
+    let parameters = create_parameter_tuples(key_indices.len(), n_tuples);
     format!("DELETE FROM {normalized_table_name} WHERE {pk} in ({parameters})")
 }
 
@@ -779,7 +737,6 @@ fn create_upsert_sql(
     schema_name: &str,
     table_name: &str,
     pk_indices: &[usize],
-    pk_indices_lookup: &HashSet<usize>,
     n_tuples: usize,
 ) -> String {
     let insert_sql = create_insert_sql(schema, schema_name, table_name, n_tuples);
@@ -792,7 +749,7 @@ fn create_upsert_sql(
         .collect_vec()
         .join(", ");
     let update_parameters: String = (0..schema.len())
-        .filter(|i| !pk_indices_lookup.contains(i))
+        .filter(|i| !pk_indices.contains(i))
         .map(|i| {
             let column = quote_identifier(&schema.fields()[i].name);
             format!("{column} = EXCLUDED.{column}")
@@ -915,29 +872,14 @@ mod tests {
         let schema = test_schema();
         let schema_name = "test_schema";
         let table_name = "test_table";
-        let pk_indices_lookup = HashSet::from_iter([1]);
-        let sql = create_upsert_sql(
-            &schema,
-            schema_name,
-            table_name,
-            &[1],
-            &pk_indices_lookup,
-            1,
-        );
+        let sql = create_upsert_sql(&schema, schema_name, table_name, &[1], 1);
         check(
             sql,
             expect![[
                 r#"INSERT INTO "test_schema"."test_table" ("a", "b") VALUES ($1, $2) on conflict ("b") do update set "a" = EXCLUDED."a""#
             ]],
         );
-        let sql = create_upsert_sql(
-            &schema,
-            schema_name,
-            table_name,
-            &[1],
-            &pk_indices_lookup,
-            3,
-        );
+        let sql = create_upsert_sql(&schema, schema_name, table_name, &[1], 3);
         check(
             sql,
             expect![[
@@ -964,15 +906,7 @@ mod tests {
         ]);
         let schema_name = "test_schema";
         let table_name = "test_table";
-        let pk_indices_lookup = HashSet::from_iter([0, 1]);
-        let sql = create_upsert_sql(
-            &schema,
-            schema_name,
-            table_name,
-            &[0, 1],
-            &pk_indices_lookup,
-            2,
-        );
+        let sql = create_upsert_sql(&schema, schema_name, table_name, &[0, 1], 2);
         check(
             sql,
             expect![[
@@ -995,15 +929,7 @@ mod tests {
         ]);
         let schema_name = "test_schema";
         let table_name = "test_table";
-        let pk_indices_lookup = HashSet::from_iter([0, 1]);
-        let sql = create_upsert_sql(
-            &schema,
-            schema_name,
-            table_name,
-            &[0, 1],
-            &pk_indices_lookup,
-            2,
-        );
+        let sql = create_upsert_sql(&schema, schema_name, table_name, &[0, 1], 2);
         check(
             sql,
             expect![[
@@ -1040,7 +966,7 @@ mod tests {
                 .iter()
                 .map(|(key, op)| match op {
                     PendingOp::Upsert(row) => format!("{:?} => upsert {:?}", key, row),
-                    PendingOp::Delete(row) => format!("{:?} => delete {:?}", key, row),
+                    PendingOp::Delete => format!("{:?} => delete", key),
                 })
                 .sorted()
                 .join("\n"),
@@ -1066,7 +992,6 @@ mod tests {
                  + 3 30",
             ),
             &key_indices,
-            &key_types,
             &types,
         );
         pending.absorb(
@@ -1076,7 +1001,6 @@ mod tests {
                  U+ 3 31",
             ),
             &key_indices,
-            &key_types,
             &types,
         );
         assert_eq!(pending.len(), 3);
@@ -1084,11 +1008,11 @@ mod tests {
             render_pending(&pending),
             expect![[r#"
                 OwnedRow([Some(Int32(1))]) => upsert [Some(Builtin(Int32(1))), Some(Builtin(Int32(11)))]
-                OwnedRow([Some(Int32(2))]) => delete [Some(Builtin(Int32(2)))]
+                OwnedRow([Some(Int32(2))]) => delete
                 OwnedRow([Some(Int32(3))]) => upsert [Some(Builtin(Int32(3))), Some(Builtin(Int32(31)))]"#]],
         );
 
-        let (deletes, upserts) = pending.take();
+        let (deletes, upserts) = pending.take(&key_types);
         assert_eq!(deletes.len(), 1);
         assert_eq!(upserts.len(), 2);
         assert_eq!(pending.len(), 0);
@@ -1107,7 +1031,6 @@ mod tests {
                  - 1 10",
             ),
             &[0],
-            &[PgType::INT4],
             &types,
         );
         check(
@@ -1116,7 +1039,7 @@ mod tests {
                 insert [Some(Builtin(Int32(1))), Some(Builtin(Int32(10)))]
                 insert [Some(Builtin(Int32(1))), Some(Builtin(Int32(10)))]"#]],
         );
-        let (deletes, upserts) = pending.take();
+        let (deletes, upserts) = pending.take(&[PgType::INT4]);
         assert!(deletes.is_empty());
         assert_eq!(upserts.len(), 2);
     }

--- a/src/connector/src/sink/postgres.rs
+++ b/src/connector/src/sink/postgres.rs
@@ -25,7 +25,6 @@ use serde::Deserialize;
 use serde_with::{DisplayFromStr, serde_as};
 use simd_json::prelude::ArrayTrait;
 use thiserror_ext::AsReport;
-use tokio_postgres::error::SqlState;
 use tokio_postgres::types::Type as PgType;
 use with_options::WithOptions;
 
@@ -643,34 +642,33 @@ impl PostgresSinkWriter {
 
         let transaction = self.client.transaction().await?;
         if let Err(e) = execute_batches(&transaction, &batches).await {
-            // Keys the dedup kept apart may still be equal to PostgreSQL (e.g. `char(n)` padding
-            // or a case-insensitive collation), which a multi-row upsert rejects with SQLSTATE
-            // 21000. Retry such batches row by row.
-            if e.code() == Some(&SqlState::CARDINALITY_VIOLATION) {
-                transaction.rollback().await?;
-                tracing::warn!(
-                    error = %e.as_report(),
-                    rows = upserts.len(),
-                    "batch contains keys equal to PostgreSQL but distinct to RisingWave, retrying row by row"
-                );
-                return self.flush_row_by_row(&deletes, &upserts).await;
-            }
-            return Err(anyhow::Error::new(e)
-                .context(format!(
+            // Retry any failed batch row by row: keys distinct to RisingWave but equal to
+            // PostgreSQL fail a multi-row upsert with SQLSTATE 21000 yet apply cleanly one row at
+            // a time; other errors recover on retry or resurface localized to a single row.
+            let context = || {
+                format!(
                     "failed to execute batched {} statements ({} delete rows, {} write rows)",
                     write_kind.as_str(),
                     deletes.len(),
                     upserts.len()
-                ))
-                .into());
+                )
+            };
+            if let Err(rollback_err) = transaction.rollback().await {
+                tracing::warn!(
+                    error = %rollback_err.as_report(),
+                    "failed to roll back failed batch"
+                );
+                return Err(anyhow::Error::new(e).context(context()).into());
+            }
+            tracing::warn!(error = %e.as_report(), "{}, retrying row by row", context());
+            return self.flush_row_by_row(&deletes, &upserts).await;
         }
         transaction.commit().await?;
 
         Ok(())
     }
 
-    /// Applies a batch whose upsert keys collide under PostgreSQL's equality: batched deletes
-    /// first, then one upsert per statement.
+    /// Fallback for a failed batched flush: batched deletes first, then one upsert per statement.
     async fn flush_row_by_row(&mut self, deletes: &[PgRow], upserts: &[PgRow]) -> Result<()> {
         let delete_batches = self.prepare_batches(StatementKind::Delete, deletes).await?;
         let statement = self.cached_statement(self.write_kind(), 1).await?;

--- a/src/connector/src/sink/postgres.rs
+++ b/src/connector/src/sink/postgres.rs
@@ -25,6 +25,7 @@ use serde::Deserialize;
 use serde_with::{DisplayFromStr, serde_as};
 use simd_json::prelude::ArrayTrait;
 use thiserror_ext::AsReport;
+use tokio_postgres::error::SqlState;
 use tokio_postgres::types::Type as PgType;
 
 use super::{
@@ -44,6 +45,10 @@ pub const POSTGRES_SINK: &str = "postgres";
 /// the client encodes the parameter count of a `Bind` message as `i16`, so a larger batch fails
 /// before ever reaching the server.
 const MAX_STATEMENT_PARAMS: usize = i16::MAX as usize;
+
+/// Upper bound of `max_batch_rows`: bigger batches only add buffer memory, since statements are
+/// split at [`MAX_STATEMENT_PARAMS`] anyway.
+const MAX_BATCH_ROWS_LIMIT: usize = 65536;
 
 const CHECK_FOREIGN_KEY_SQL: &str = r#"
     SELECT EXISTS (
@@ -227,6 +232,14 @@ impl Sink for PostgresSink {
     crate::impl_validate_sink_unknown_fields!();
 
     async fn validate(&self) -> Result<()> {
+        if !(1..=MAX_BATCH_ROWS_LIMIT).contains(&self.config.max_batch_rows) {
+            return Err(SinkError::Config(anyhow!(
+                "`max_batch_rows` must be between 1 and {}, got {}",
+                MAX_BATCH_ROWS_LIMIT,
+                self.config.max_batch_rows
+            )));
+        }
+
         if !self.is_append_only && self.pk_indices.is_empty() {
             return Err(SinkError::Config(anyhow!(
                 "Primary key not defined for upsert Postgres sink (please define in `primary_key` field)"
@@ -493,12 +506,23 @@ impl PostgresSinkWriter {
             .map(|i| schema_types[*i].clone())
             .collect_vec();
 
+        // `validate()` rejects out-of-range values at DDL time; only clamp here so pre-existing
+        // sinks (the option was inert before batching) keep running after an upgrade.
+        let max_batch_rows = config.max_batch_rows.clamp(1, MAX_BATCH_ROWS_LIMIT);
+        if max_batch_rows != config.max_batch_rows {
+            tracing::warn!(
+                configured = config.max_batch_rows,
+                effective = max_batch_rows,
+                "max_batch_rows out of range, clamped"
+            );
+        }
+
         let (write_kind, pending) = if is_append_only {
             (StatementKind::Insert, PendingRows::Insert(Vec::new()))
         } else {
             (
                 StatementKind::Upsert,
-                PendingRows::Upsert(HashMap::with_capacity(config.max_batch_rows)),
+                PendingRows::Upsert(HashMap::with_capacity(max_batch_rows.min(1024))),
             )
         };
 
@@ -511,7 +535,7 @@ impl PostgresSinkWriter {
             key_indices,
             key_types,
             schema_types,
-            max_batch_rows: config.max_batch_rows,
+            max_batch_rows,
             write_statement: None,
             delete_statement: None,
             pending,
@@ -604,10 +628,67 @@ impl PostgresSinkWriter {
 
         let transaction = self.client.transaction().await?;
         // Deletes go first, which is safe because dedup leaves deleted and upserted keys disjoint.
-        execute_batches(&transaction, StatementKind::Delete, &delete_batches).await?;
-        execute_batches(&transaction, self.write_kind, &write_batches).await?;
+        execute_batches(&transaction, &delete_batches)
+            .await
+            .with_context(|| {
+                format!(
+                    "failed to execute delete statements on {} rows",
+                    deletes.len()
+                )
+            })?;
+        if let Err(e) = execute_batches(&transaction, &write_batches).await {
+            // Keys the dedup kept apart may still be equal to PostgreSQL (e.g. `char(n)` padding
+            // or a case-insensitive collation), which a multi-row upsert rejects with SQLSTATE
+            // 21000. Retry such batches row by row.
+            if e.code() == Some(&SqlState::CARDINALITY_VIOLATION) {
+                transaction.rollback().await?;
+                tracing::warn!(
+                    error = %e.as_report(),
+                    rows = upserts.len(),
+                    "batch contains keys equal to PostgreSQL but distinct to RisingWave, retrying row by row"
+                );
+                return self.flush_row_by_row(&deletes, &upserts).await;
+            }
+            return Err(anyhow::Error::new(e)
+                .context(format!(
+                    "failed to execute {} statements on {} rows",
+                    self.write_kind.as_str(),
+                    upserts.len()
+                ))
+                .into());
+        }
         transaction.commit().await?;
 
+        Ok(())
+    }
+
+    /// Applies a batch whose upsert keys collide under PostgreSQL's equality: batched deletes
+    /// first, then one upsert per statement.
+    async fn flush_row_by_row(&mut self, deletes: &[PgRow], upserts: &[PgRow]) -> Result<()> {
+        let delete_batches = self.prepare_batches(StatementKind::Delete, deletes).await?;
+        let sql = self.create_sql(self.write_kind, 1);
+        let statement = self
+            .client
+            .prepare(&sql)
+            .await
+            .context("failed to prepare single-row write statement")?;
+
+        let transaction = self.client.transaction().await?;
+        execute_batches(&transaction, &delete_batches)
+            .await
+            .with_context(|| {
+                format!(
+                    "failed to execute delete statements on {} rows",
+                    deletes.len()
+                )
+            })?;
+        for row in upserts {
+            transaction
+                .execute_raw(&statement, row)
+                .await
+                .context("failed to execute single-row write statement")?;
+        }
+        transaction.commit().await?;
         Ok(())
     }
 
@@ -633,22 +714,12 @@ fn tuples_per_statement(max_batch_rows: usize, params_per_tuple: usize) -> usize
 
 async fn execute_batches(
     transaction: &tokio_postgres::Transaction<'_>,
-    kind: StatementKind,
     batches: &[(tokio_postgres::Statement, &[PgRow])],
-) -> Result<()> {
+) -> std::result::Result<(), tokio_postgres::Error> {
     for (statement, tuples) in batches {
         let mut params = Vec::with_capacity(tuples.len() * tuples.first().map_or(0, |t| t.len()));
         params.extend(tuples.iter().flatten());
-        transaction
-            .execute_raw(statement, params)
-            .await
-            .with_context(|| {
-                format!(
-                    "failed to execute {} statement on {} rows",
-                    kind.as_str(),
-                    tuples.len()
-                )
-            })?;
+        transaction.execute_raw(statement, params).await?;
     }
     Ok(())
 }
@@ -936,6 +1007,31 @@ mod tests {
                 r#"INSERT INTO "test_schema"."test_table" ("user_id", "client_id") VALUES ($1, $2), ($3, $4) on conflict ("user_id", "client_id") do nothing"#
             ]],
         );
+    }
+
+    #[tokio::test]
+    async fn test_validate_max_batch_rows_range() {
+        let properties = BTreeMap::from(
+            [
+                ("host", "localhost"),
+                ("port", "5432"),
+                ("user", "u"),
+                ("password", "p"),
+                ("database", "d"),
+                ("table", "t"),
+                ("type", "upsert"),
+            ]
+            .map(|(k, v)| (k.to_owned(), v.to_owned())),
+        );
+        // The range check fails before any connection is attempted.
+        for bad in ["0", "65537"] {
+            let mut properties = properties.clone();
+            properties.insert("max_batch_rows".to_owned(), bad.to_owned());
+            let config = PostgresConfig::from_btreemap(properties).unwrap();
+            let sink = PostgresSink::new(config, test_schema(), vec![0], false).unwrap();
+            let err = sink.validate().await.unwrap_err();
+            assert!(err.to_string().contains("max_batch_rows"), "{}", err);
+        }
     }
 
     #[test]

--- a/src/connector/src/sink/postgres.rs
+++ b/src/connector/src/sink/postgres.rs
@@ -12,18 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::collections::{BTreeMap, HashSet};
-use std::sync::Arc;
+use std::collections::{BTreeMap, HashMap, HashSet};
 
 use anyhow::{Context, anyhow};
 use async_trait::async_trait;
-use futures::StreamExt;
-use futures::stream::FuturesUnordered;
 use itertools::Itertools;
 use phf::phf_set;
 use risingwave_common::array::{Op, StreamChunk};
 use risingwave_common::catalog::Schema;
-use risingwave_common::row::{Row, RowExt};
+use risingwave_common::row::{OwnedRow, Row, RowExt};
+use risingwave_common::util::iter_util::ZipEqFast;
 use serde::Deserialize;
 use serde_with::{DisplayFromStr, serde_as};
 use simd_json::prelude::ArrayTrait;
@@ -42,6 +40,11 @@ use crate::sink::log_store::{LogStoreReadItem, TruncateOffset};
 use crate::sink::{Result, Sink, SinkParam, SinkWriterParam};
 
 pub const POSTGRES_SINK: &str = "postgres";
+
+/// Maximum number of bind parameters of a single statement. PostgreSQL itself allows 65535, but
+/// the client encodes the parameter count of a `Bind` message as `i16`, so a larger batch fails
+/// before ever reaching the server.
+const MAX_STATEMENT_PARAMS: usize = i16::MAX as usize;
 
 const CHECK_FOREIGN_KEY_SQL: &str = r#"
     SELECT EXISTS (
@@ -330,18 +333,123 @@ impl Sink for PostgresSink {
     }
 }
 
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum StatementKind {
+    /// Plain `INSERT` for append-only sinks, `INSERT .. ON CONFLICT` otherwise.
+    Upsert,
+    Delete,
+}
+
+impl StatementKind {
+    fn as_str(&self) -> &'static str {
+        match self {
+            StatementKind::Upsert => "upsert",
+            StatementKind::Delete => "delete",
+        }
+    }
+}
+
+enum PendingOp {
+    Upsert(PgRow),
+    Delete(PgRow),
+}
+
+/// Rows accumulated across chunks, written out on flush.
+enum PendingRows {
+    Insert(Vec<PgRow>),
+    /// Only the last operation per key is kept: PostgreSQL rejects an
+    /// `INSERT .. ON CONFLICT DO UPDATE` that affects the same row twice.
+    ///
+    /// Deliberately not `ChangeBuffer` semantics, which assume the downstream state matches
+    /// the buffer start. At-least-once replay breaks that: a committed-but-untruncated batch
+    /// may be re-delivered and regrouped with new chunks, so insert-then-delete must still
+    /// emit the delete rather than annihilate. Same-key duplicates (e.g. replay, or a subset
+    /// downstream pk with `preserve_row_level_changes`) are legal input, not inconsistencies.
+    Upsert(HashMap<OwnedRow, PendingOp>),
+}
+
+impl PendingRows {
+    fn len(&self) -> usize {
+        match self {
+            PendingRows::Insert(rows) => rows.len(),
+            PendingRows::Upsert(rows) => rows.len(),
+        }
+    }
+
+    fn absorb(
+        &mut self,
+        chunk: &StreamChunk,
+        key_indices: &[usize],
+        key_types: &[PgType],
+        schema_types: &[PgType],
+    ) {
+        match self {
+            PendingRows::Insert(rows) => {
+                for (op, row) in chunk.rows() {
+                    if op == Op::Insert {
+                        rows.push(convert_row_to_pg_row(row, schema_types));
+                    } else {
+                        tracing::error!(
+                            "row ignored, append-only sink should not receive update insert, update delete and delete operations"
+                        );
+                    }
+                }
+            }
+            PendingRows::Upsert(rows) => {
+                for (op, row) in chunk.rows() {
+                    let key = row.project(key_indices).into_owned_row();
+                    let pending_op = match op {
+                        Op::Insert | Op::UpdateInsert => {
+                            PendingOp::Upsert(convert_row_to_pg_row(row, schema_types))
+                        }
+                        Op::Delete | Op::UpdateDelete => PendingOp::Delete(convert_row_to_pg_row(
+                            row.project(key_indices),
+                            key_types,
+                        )),
+                    };
+                    rows.insert(key, pending_op);
+                }
+            }
+        }
+    }
+
+    /// Takes all pending rows out, split into deletes and upserts.
+    fn take(&mut self) -> (Vec<PgRow>, Vec<PgRow>) {
+        match self {
+            PendingRows::Insert(rows) => (vec![], std::mem::take(rows)),
+            PendingRows::Upsert(rows) => {
+                let mut deletes = Vec::new();
+                let mut upserts = Vec::new();
+                for op in rows.drain().map(|(_, op)| op) {
+                    match op {
+                        PendingOp::Upsert(row) => upserts.push(row),
+                        PendingOp::Delete(row) => deletes.push(row),
+                    }
+                }
+                (deletes, upserts)
+            }
+        }
+    }
+}
+
 pub struct PostgresSinkWriter {
     is_append_only: bool,
     client: tokio_postgres::Client,
+    schema: Schema,
+    schema_name: String,
+    table_name: String,
     pk_indices: Vec<usize>,
-    pk_types: Vec<PgType>,
+    pk_indices_lookup: HashSet<usize>,
+    /// Columns identifying a downstream row: the sink pk, or all columns when there is no pk.
+    key_indices: Vec<usize>,
+    key_types: Vec<PgType>,
     schema_types: Vec<PgType>,
-    raw_insert_sql: Arc<String>,
-    raw_upsert_sql: Arc<String>,
-    raw_delete_sql: Arc<String>,
-    insert_sql: Arc<tokio_postgres::Statement>,
-    delete_sql: Arc<tokio_postgres::Statement>,
-    upsert_sql: Arc<tokio_postgres::Statement>,
+    max_batch_rows: usize,
+    upsert_tuples_per_statement: usize,
+    delete_tuples_per_statement: usize,
+    upsert_statement: Option<tokio_postgres::Statement>,
+    delete_statement: Option<tokio_postgres::Statement>,
+    pending: PendingRows,
 }
 
 impl PostgresSinkWriter {
@@ -361,7 +469,7 @@ impl PostgresSinkWriter {
         let pk_indices_lookup = pk_indices.iter().copied().collect::<HashSet<_>>();
 
         // Rewrite schema types for serialization
-        let (pk_types, schema_types) = {
+        let schema_types = {
             let name_to_type = PostgresExternalTable::type_mapping(
                 &pg_conn,
                 &config.schema,
@@ -370,8 +478,7 @@ impl PostgresSinkWriter {
             )
             .await?;
             let mut schema_types = Vec::with_capacity(schema.fields.len());
-            let mut pk_types = Vec::with_capacity(pk_indices.len());
-            for (i, field) in schema.fields.iter().enumerate() {
+            for field in &schema.fields {
                 let field_name = &field.name;
                 let actual_data_type = name_to_type.get(field_name).map(|t| (*t).clone());
                 let actual_data_type = actual_data_type
@@ -382,164 +489,198 @@ impl PostgresSinkWriter {
                         ))
                     })?
                     .clone();
-                if pk_indices_lookup.contains(&i) {
-                    pk_types.push(actual_data_type.clone())
-                }
                 schema_types.push(actual_data_type);
             }
-            (pk_types, schema_types)
+            schema_types
         };
 
-        let raw_insert_sql = create_insert_sql(&schema, &config.schema, &config.table);
-        let raw_upsert_sql = create_upsert_sql(
-            &schema,
-            &config.schema,
-            &config.table,
-            &pk_indices,
-            &pk_indices_lookup,
-        );
-        let raw_delete_sql = create_delete_sql(&schema, &config.schema, &config.table, &pk_indices);
+        // Fall back to all columns when no pk is defined, consistent with `create_delete_sql`.
+        let key_indices = if pk_indices.is_empty() {
+            (0..schema.len()).collect_vec()
+        } else {
+            pk_indices.clone()
+        };
+        let key_types = key_indices
+            .iter()
+            .map(|i| schema_types[*i].clone())
+            .collect_vec();
 
-        let insert_sql = client
-            .prepare(&raw_insert_sql)
-            .await
-            .with_context(|| format!("failed to prepare insert statement: {}", raw_insert_sql))?;
-        let upsert_sql = client
-            .prepare(&raw_upsert_sql)
-            .await
-            .with_context(|| format!("failed to prepare upsert statement: {}", raw_upsert_sql))?;
-        let delete_sql = client
-            .prepare(&raw_delete_sql)
-            .await
-            .with_context(|| format!("failed to prepare delete statement: {}", raw_delete_sql))?;
+        let upsert_tuples_per_statement = tuples_per_statement(config.max_batch_rows, schema.len());
+        let delete_tuples_per_statement =
+            tuples_per_statement(config.max_batch_rows, key_indices.len());
+        let pending = if is_append_only {
+            PendingRows::Insert(Vec::new())
+        } else {
+            PendingRows::Upsert(HashMap::new())
+        };
 
         let writer = Self {
             is_append_only,
             client,
+            schema,
+            schema_name: config.schema,
+            table_name: config.table,
             pk_indices,
-            pk_types,
+            pk_indices_lookup,
+            key_indices,
+            key_types,
             schema_types,
-            raw_insert_sql: Arc::new(raw_insert_sql),
-            raw_upsert_sql: Arc::new(raw_upsert_sql),
-            raw_delete_sql: Arc::new(raw_delete_sql),
-            insert_sql: Arc::new(insert_sql),
-            delete_sql: Arc::new(delete_sql),
-            upsert_sql: Arc::new(upsert_sql),
+            max_batch_rows: config.max_batch_rows,
+            upsert_tuples_per_statement,
+            delete_tuples_per_statement,
+            upsert_statement: None,
+            delete_statement: None,
+            pending,
         };
         Ok(writer)
     }
 
-    async fn write_batch(&mut self, chunk: StreamChunk) -> Result<()> {
-        // https://www.postgresql.org/docs/current/limits.html
-        // We have a limit of 65,535 parameters in a single query, as restricted by the PostgreSQL protocol.
-        if self.is_append_only {
-            self.write_batch_append_only(chunk).await
-        } else {
-            self.write_batch_non_append_only(chunk).await
+    fn create_sql(&self, kind: StatementKind, n_tuples: usize) -> String {
+        match kind {
+            StatementKind::Upsert if self.is_append_only => {
+                create_insert_sql(&self.schema, &self.schema_name, &self.table_name, n_tuples)
+            }
+            StatementKind::Upsert => create_upsert_sql(
+                &self.schema,
+                &self.schema_name,
+                &self.table_name,
+                &self.pk_indices,
+                &self.pk_indices_lookup,
+                n_tuples,
+            ),
+            StatementKind::Delete => create_delete_sql(
+                &self.schema,
+                &self.schema_name,
+                &self.table_name,
+                &self.key_indices,
+                n_tuples,
+            ),
         }
     }
 
-    async fn write_batch_append_only(&mut self, chunk: StreamChunk) -> Result<()> {
-        let transaction = Arc::new(self.client.transaction().await?);
-        let mut insert_futures = FuturesUnordered::new();
-        for (op, row) in chunk.rows() {
-            match op {
-                Op::Insert => {
-                    let pg_row = convert_row_to_pg_row(row, &self.schema_types);
-                    let insert_sql = self.insert_sql.clone();
-                    let raw_insert_sql = self.raw_insert_sql.clone();
-                    let transaction = transaction.clone();
-                    let future = async move {
-                        transaction
-                            .execute_raw(insert_sql.as_ref(), &pg_row)
-                            .await
-                            .with_context(|| {
-                                format!(
-                                    "failed to execute insert statement: {}, parameters: {:?}",
-                                    raw_insert_sql, pg_row
-                                )
-                            })
-                    };
-                    insert_futures.push(future);
-                }
+    fn tuples_per_statement(&self, kind: StatementKind) -> usize {
+        match kind {
+            StatementKind::Upsert => self.upsert_tuples_per_statement,
+            StatementKind::Delete => self.delete_tuples_per_statement,
+        }
+    }
+
+    /// Prepares one statement per sub-batch. Only the full-sized statement is cached, the
+    /// remainder differs from flush to flush and is prepared ad hoc.
+    async fn prepare_statements(
+        &mut self,
+        kind: StatementKind,
+        n_rows: usize,
+    ) -> Result<Vec<tokio_postgres::Statement>> {
+        let full = self.tuples_per_statement(kind);
+        let mut statements = Vec::with_capacity(n_rows.div_ceil(full));
+        let mut remaining = n_rows;
+        while remaining > 0 {
+            let n_tuples = remaining.min(full);
+            let cached = match kind {
+                StatementKind::Upsert => &self.upsert_statement,
+                StatementKind::Delete => &self.delete_statement,
+            };
+            let statement = match cached {
+                Some(statement) if n_tuples == full => statement.clone(),
                 _ => {
-                    tracing::error!(
-                        "row ignored: an append-only sink should not receive update-insert, update-delete, or delete operations"
-                    );
+                    let sql = self.create_sql(kind, n_tuples);
+                    let statement = self.client.prepare(&sql).await.with_context(|| {
+                        format!(
+                            "failed to prepare {} statement for {} rows",
+                            kind.as_str(),
+                            n_tuples
+                        )
+                    })?;
+                    if n_tuples == full {
+                        match kind {
+                            StatementKind::Upsert => {
+                                self.upsert_statement = Some(statement.clone())
+                            }
+                            StatementKind::Delete => {
+                                self.delete_statement = Some(statement.clone())
+                            }
+                        }
+                    }
+                    statement
                 }
-            }
+            };
+            statements.push(statement);
+            remaining -= n_tuples;
+        }
+        Ok(statements)
+    }
+
+    /// Writes out all pending rows in a single transaction.
+    async fn flush(&mut self) -> Result<()> {
+        let (deletes, upserts) = self.pending.take();
+        if deletes.is_empty() && upserts.is_empty() {
+            return Ok(());
         }
 
-        while let Some(result) = insert_futures.next().await {
-            result?;
-        }
-        if let Some(transaction) = Arc::into_inner(transaction) {
-            transaction.commit().await?;
-        } else {
-            tracing::error!("transaction handle was lost");
-        }
+        // Statements are prepared before the transaction begins, as it borrows the client mutably.
+        let delete_statements = self
+            .prepare_statements(StatementKind::Delete, deletes.len())
+            .await?;
+        let upsert_statements = self
+            .prepare_statements(StatementKind::Upsert, upserts.len())
+            .await?;
+
+        let transaction = self.client.transaction().await?;
+        // Deletes go first, which is safe because dedup leaves deleted and upserted keys disjoint.
+        execute_batches(
+            &transaction,
+            StatementKind::Delete,
+            &delete_statements,
+            &deletes,
+            self.delete_tuples_per_statement,
+        )
+        .await?;
+        execute_batches(
+            &transaction,
+            StatementKind::Upsert,
+            &upsert_statements,
+            &upserts,
+            self.upsert_tuples_per_statement,
+        )
+        .await?;
+        transaction.commit().await?;
 
         Ok(())
     }
+}
 
-    async fn write_batch_non_append_only(&mut self, chunk: StreamChunk) -> Result<()> {
-        let transaction = Arc::new(self.client.transaction().await?);
-        let mut delete_futures = FuturesUnordered::new();
-        let mut upsert_futures = FuturesUnordered::new();
-        for (op, row) in chunk.rows() {
-            match op {
-                Op::Delete | Op::UpdateDelete => {
-                    let pg_row =
-                        convert_row_to_pg_row(row.project(&self.pk_indices), &self.pk_types);
-                    let delete_sql = self.delete_sql.clone();
-                    let raw_delete_sql = self.raw_delete_sql.clone();
-                    let transaction = transaction.clone();
-                    let future = async move {
-                        transaction
-                            .execute_raw(delete_sql.as_ref(), &pg_row)
-                            .await
-                            .with_context(|| {
-                                format!(
-                                    "failed to execute delete statement: {}, parameters: {:?}",
-                                    raw_delete_sql, pg_row
-                                )
-                            })
-                    };
-                    delete_futures.push(future);
-                }
-                Op::Insert | Op::UpdateInsert => {
-                    let pg_row = convert_row_to_pg_row(row, &self.schema_types);
-                    let upsert_sql = self.upsert_sql.clone();
-                    let raw_upsert_sql = self.raw_upsert_sql.clone();
-                    let transaction = transaction.clone();
-                    let future = async move {
-                        transaction
-                            .execute_raw(upsert_sql.as_ref(), &pg_row)
-                            .await
-                            .with_context(|| {
-                                format!(
-                                    "failed to execute upsert statement: {}, parameters: {:?}",
-                                    raw_upsert_sql, pg_row
-                                )
-                            })
-                    };
-                    upsert_futures.push(future);
-                }
-            }
-        }
-        while let Some(result) = delete_futures.next().await {
-            result?;
-        }
-        while let Some(result) = upsert_futures.next().await {
-            result?;
-        }
-        if let Some(transaction) = Arc::into_inner(transaction) {
-            transaction.commit().await?;
-        } else {
-            tracing::error!("transaction handle was lost");
-        }
-        Ok(())
+/// Number of tuples a single statement may carry, bounded by the parameter limit of the protocol.
+fn tuples_per_statement(max_batch_rows: usize, params_per_tuple: usize) -> usize {
+    max_batch_rows
+        .min(MAX_STATEMENT_PARAMS / params_per_tuple.max(1))
+        .max(1)
+}
+
+async fn execute_batches(
+    transaction: &tokio_postgres::Transaction<'_>,
+    kind: StatementKind,
+    statements: &[tokio_postgres::Statement],
+    rows: &[PgRow],
+    tuples_per_statement: usize,
+) -> Result<()> {
+    for (statement, tuples) in statements
+        .iter()
+        .zip_eq_fast(rows.chunks(tuples_per_statement))
+    {
+        let params = tuples.iter().flatten().collect_vec();
+        transaction
+            .execute_raw(statement, params)
+            .await
+            .with_context(|| {
+                format!(
+                    "failed to execute {} statement on {} rows",
+                    kind.as_str(),
+                    tuples.len()
+                )
+            })?;
     }
+    Ok(())
 }
 
 #[async_trait]
@@ -550,10 +691,22 @@ impl LogSinker for PostgresSinkWriter {
             let (epoch, item) = log_reader.next_item().await?;
             match item {
                 LogStoreReadItem::StreamChunk { chunk, chunk_id } => {
-                    self.write_batch(chunk).await?;
-                    log_reader.truncate(TruncateOffset::Chunk { epoch, chunk_id })?;
+                    self.pending.absorb(
+                        &chunk,
+                        &self.key_indices,
+                        &self.key_types,
+                        &self.schema_types,
+                    );
+                    // Rows are buffered across chunks, so an offset may only be truncated once
+                    // the flush that commits its rows has succeeded. Offsets of chunks that are
+                    // still buffered are covered by a later truncation.
+                    if self.pending.len() >= self.max_batch_rows {
+                        self.flush().await?;
+                        log_reader.truncate(TruncateOffset::Chunk { epoch, chunk_id })?;
+                    }
                 }
                 LogStoreReadItem::Barrier { .. } => {
+                    self.flush().await?;
                     log_reader.truncate(TruncateOffset::Barrier { epoch })?;
                 }
             }
@@ -561,22 +714,36 @@ impl LogSinker for PostgresSinkWriter {
     }
 }
 
-fn create_insert_sql(schema: &Schema, schema_name: &str, table_name: &str) -> String {
+/// `($1, $2), ($3, $4), ...`
+fn create_parameter_tuples(params_per_tuple: usize, n_tuples: usize) -> String {
+    (0..n_tuples)
+        .map(|tuple| {
+            let parameters = (0..params_per_tuple)
+                .map(|i| format!("${}", tuple * params_per_tuple + i + 1))
+                .join(", ");
+            format!("({parameters})")
+        })
+        .join(", ")
+}
+
+fn create_insert_sql(
+    schema: &Schema,
+    schema_name: &str,
+    table_name: &str,
+    n_tuples: usize,
+) -> String {
     let normalized_table_name = format!(
         "{}.{}",
         quote_identifier(schema_name),
         quote_identifier(table_name)
     );
-    let number_of_columns = schema.len();
     let columns: String = schema
         .fields()
         .iter()
         .map(|field| quote_identifier(&field.name))
         .join(", ");
-    let column_parameters: String = (0..number_of_columns)
-        .map(|i| format!("${}", i + 1))
-        .join(", ");
-    format!("INSERT INTO {normalized_table_name} ({columns}) VALUES ({column_parameters})")
+    let values = create_parameter_tuples(schema.len(), n_tuples);
+    format!("INSERT INTO {normalized_table_name} ({columns}) VALUES {values}")
 }
 
 fn create_delete_sql(
@@ -584,6 +751,7 @@ fn create_delete_sql(
     schema_name: &str,
     table_name: &str,
     pk_indices: &[usize],
+    n_tuples: usize,
 ) -> String {
     let normalized_table_name = format!(
         "{}.{}",
@@ -602,10 +770,8 @@ fn create_delete_sql(
             .join(", ");
         format!("({})", pk_symbols)
     };
-    let parameters: String = (0..pk_indices.len())
-        .map(|i| format!("${}", i + 1))
-        .join(", ");
-    format!("DELETE FROM {normalized_table_name} WHERE {pk} in (({parameters}))")
+    let parameters = create_parameter_tuples(pk_indices.len(), n_tuples);
+    format!("DELETE FROM {normalized_table_name} WHERE {pk} in ({parameters})")
 }
 
 fn create_upsert_sql(
@@ -614,8 +780,9 @@ fn create_upsert_sql(
     table_name: &str,
     pk_indices: &[usize],
     pk_indices_lookup: &HashSet<usize>,
+    n_tuples: usize,
 ) -> String {
-    let insert_sql = create_insert_sql(schema, schema_name, table_name);
+    let insert_sql = create_insert_sql(schema, schema_name, table_name, n_tuples);
     if pk_indices.is_empty() {
         return insert_sql;
     }
@@ -670,6 +837,7 @@ mod tests {
 
     use expect_test::{Expect, expect};
     use risingwave_common::catalog::Field;
+    use risingwave_common::test_prelude::StreamChunkTestExt;
     use risingwave_common::types::DataType;
 
     use super::*;
@@ -679,9 +847,8 @@ mod tests {
         expect.assert_eq(&actual);
     }
 
-    #[test]
-    fn test_create_insert_sql() {
-        let schema = Schema::new(vec![
+    fn test_schema() -> Schema {
+        Schema::new(vec![
             Field {
                 data_type: DataType::Int32,
                 name: "a".to_owned(),
@@ -690,63 +857,126 @@ mod tests {
                 data_type: DataType::Int32,
                 name: "b".to_owned(),
             },
-        ]);
+        ])
+    }
+
+    #[test]
+    fn test_create_insert_sql() {
+        let schema = test_schema();
         let schema_name = "test_schema";
         let table_name = "test_table";
-        let sql = create_insert_sql(&schema, schema_name, table_name);
+        let sql = create_insert_sql(&schema, schema_name, table_name, 1);
         check(
             sql,
             expect![[r#"INSERT INTO "test_schema"."test_table" ("a", "b") VALUES ($1, $2)"#]],
+        );
+        let sql = create_insert_sql(&schema, schema_name, table_name, 3);
+        check(
+            sql,
+            expect![[
+                r#"INSERT INTO "test_schema"."test_table" ("a", "b") VALUES ($1, $2), ($3, $4), ($5, $6)"#
+            ]],
         );
     }
 
     #[test]
     fn test_create_delete_sql() {
-        let schema = Schema::new(vec![
-            Field {
-                data_type: DataType::Int32,
-                name: "a".to_owned(),
-            },
-            Field {
-                data_type: DataType::Int32,
-                name: "b".to_owned(),
-            },
-        ]);
+        let schema = test_schema();
         let schema_name = "test_schema";
         let table_name = "test_table";
-        let sql = create_delete_sql(&schema, schema_name, table_name, &[1]);
+        let sql = create_delete_sql(&schema, schema_name, table_name, &[1], 1);
         check(
             sql,
             expect![[r#"DELETE FROM "test_schema"."test_table" WHERE ("b") in (($1))"#]],
         );
-        let table_name = "test_table";
-        let sql = create_delete_sql(&schema, schema_name, table_name, &[0, 1]);
+        let sql = create_delete_sql(&schema, schema_name, table_name, &[0, 1], 1);
         check(
             sql,
             expect![[r#"DELETE FROM "test_schema"."test_table" WHERE ("a", "b") in (($1, $2))"#]],
+        );
+        let sql = create_delete_sql(&schema, schema_name, table_name, &[1], 3);
+        check(
+            sql,
+            expect![[
+                r#"DELETE FROM "test_schema"."test_table" WHERE ("b") in (($1), ($2), ($3))"#
+            ]],
+        );
+        let sql = create_delete_sql(&schema, schema_name, table_name, &[0, 1], 3);
+        check(
+            sql,
+            expect![[
+                r#"DELETE FROM "test_schema"."test_table" WHERE ("a", "b") in (($1, $2), ($3, $4), ($5, $6))"#
+            ]],
         );
     }
 
     #[test]
     fn test_create_upsert_sql() {
-        let schema = Schema::new(vec![
-            Field {
-                data_type: DataType::Int32,
-                name: "a".to_owned(),
-            },
-            Field {
-                data_type: DataType::Int32,
-                name: "b".to_owned(),
-            },
-        ]);
+        let schema = test_schema();
         let schema_name = "test_schema";
         let table_name = "test_table";
         let pk_indices_lookup = HashSet::from_iter([1]);
-        let sql = create_upsert_sql(&schema, schema_name, table_name, &[1], &pk_indices_lookup);
+        let sql = create_upsert_sql(
+            &schema,
+            schema_name,
+            table_name,
+            &[1],
+            &pk_indices_lookup,
+            1,
+        );
         check(
             sql,
             expect![[
                 r#"INSERT INTO "test_schema"."test_table" ("a", "b") VALUES ($1, $2) on conflict ("b") do update set "a" = EXCLUDED."a""#
+            ]],
+        );
+        let sql = create_upsert_sql(
+            &schema,
+            schema_name,
+            table_name,
+            &[1],
+            &pk_indices_lookup,
+            3,
+        );
+        check(
+            sql,
+            expect![[
+                r#"INSERT INTO "test_schema"."test_table" ("a", "b") VALUES ($1, $2), ($3, $4), ($5, $6) on conflict ("b") do update set "a" = EXCLUDED."a""#
+            ]],
+        );
+    }
+
+    #[test]
+    fn test_create_upsert_sql_composite_primary_key() {
+        let schema = Schema::new(vec![
+            Field {
+                data_type: DataType::Int32,
+                name: "user_id".to_owned(),
+            },
+            Field {
+                data_type: DataType::Int32,
+                name: "client_id".to_owned(),
+            },
+            Field {
+                data_type: DataType::Int32,
+                name: "value".to_owned(),
+            },
+        ]);
+        let schema_name = "test_schema";
+        let table_name = "test_table";
+        let pk_indices_lookup = HashSet::from_iter([0, 1]);
+        let sql = create_upsert_sql(
+            &schema,
+            schema_name,
+            table_name,
+            &[0, 1],
+            &pk_indices_lookup,
+            2,
+        );
+        check(
+            sql,
+            expect![[
+                r#"INSERT INTO "test_schema"."test_table" ("user_id", "client_id", "value") VALUES ($1, $2, $3), ($4, $5, $6) on conflict ("user_id", "client_id") do update set "value" = EXCLUDED."value""#
             ]],
         );
     }
@@ -772,12 +1002,122 @@ mod tests {
             table_name,
             &[0, 1],
             &pk_indices_lookup,
+            2,
         );
         check(
             sql,
             expect![[
-                r#"INSERT INTO "test_schema"."test_table" ("user_id", "client_id") VALUES ($1, $2) on conflict ("user_id", "client_id") do nothing"#
+                r#"INSERT INTO "test_schema"."test_table" ("user_id", "client_id") VALUES ($1, $2), ($3, $4) on conflict ("user_id", "client_id") do nothing"#
             ]],
         );
+    }
+
+    #[test]
+    fn test_tuples_per_statement() {
+        assert_eq!(tuples_per_statement(1024, 2), 1024);
+        // Absurd `max_batch_rows` values are capped by the parameter limit.
+        assert_eq!(tuples_per_statement(usize::MAX, 1), 32767);
+        assert_eq!(tuples_per_statement(usize::MAX, 2), 16383);
+        assert_eq!(tuples_per_statement(1_000_000, 3), 10922);
+        assert_eq!(tuples_per_statement(0, 2), 1);
+
+        // The largest allowed statement stays within the parameter limit.
+        let schema = test_schema();
+        let n_tuples = tuples_per_statement(usize::MAX, schema.len());
+        assert_eq!(n_tuples * schema.len(), 32766);
+        assert!(n_tuples * schema.len() <= MAX_STATEMENT_PARAMS);
+        let sql = create_insert_sql(&schema, "test_schema", "test_table", n_tuples);
+        assert!(sql.ends_with("($32765, $32766)"));
+    }
+
+    fn render_pending(pending: &PendingRows) -> String {
+        match pending {
+            PendingRows::Insert(rows) => rows
+                .iter()
+                .map(|row| format!("insert {:?}", row))
+                .join("\n"),
+            PendingRows::Upsert(rows) => rows
+                .iter()
+                .map(|(key, op)| match op {
+                    PendingOp::Upsert(row) => format!("{:?} => upsert {:?}", key, row),
+                    PendingOp::Delete(row) => format!("{:?} => delete {:?}", key, row),
+                })
+                .sorted()
+                .join("\n"),
+        }
+    }
+
+    #[test]
+    fn test_pending_upsert_keep_last() {
+        let types = vec![PgType::INT4, PgType::INT4];
+        let key_indices = [0];
+        let key_types = vec![PgType::INT4];
+        let mut pending = PendingRows::Upsert(HashMap::new());
+
+        // Delete then insert on the same key collapses into an upsert, insert then delete into a
+        // delete, and the last of several upserts wins.
+        pending.absorb(
+            &StreamChunk::from_pretty(
+                " i i
+                 - 1 10
+                 + 1 11
+                 + 2 20
+                 - 2 20
+                 + 3 30",
+            ),
+            &key_indices,
+            &key_types,
+            &types,
+        );
+        pending.absorb(
+            &StreamChunk::from_pretty(
+                "  i i
+                 U- 3 30
+                 U+ 3 31",
+            ),
+            &key_indices,
+            &key_types,
+            &types,
+        );
+        assert_eq!(pending.len(), 3);
+        check(
+            render_pending(&pending),
+            expect![[r#"
+                OwnedRow([Some(Int32(1))]) => upsert [Some(Builtin(Int32(1))), Some(Builtin(Int32(11)))]
+                OwnedRow([Some(Int32(2))]) => delete [Some(Builtin(Int32(2)))]
+                OwnedRow([Some(Int32(3))]) => upsert [Some(Builtin(Int32(3))), Some(Builtin(Int32(31)))]"#]],
+        );
+
+        let (deletes, upserts) = pending.take();
+        assert_eq!(deletes.len(), 1);
+        assert_eq!(upserts.len(), 2);
+        assert_eq!(pending.len(), 0);
+    }
+
+    #[test]
+    fn test_pending_insert_no_dedup() {
+        let types = vec![PgType::INT4, PgType::INT4];
+        let mut pending = PendingRows::Insert(Vec::new());
+        // Non-insert ops are dropped by append-only sinks.
+        pending.absorb(
+            &StreamChunk::from_pretty(
+                " i i
+                 + 1 10
+                 + 1 10
+                 - 1 10",
+            ),
+            &[0],
+            &[PgType::INT4],
+            &types,
+        );
+        check(
+            render_pending(&pending),
+            expect![[r#"
+                insert [Some(Builtin(Int32(1))), Some(Builtin(Int32(10)))]
+                insert [Some(Builtin(Int32(1))), Some(Builtin(Int32(10)))]"#]],
+        );
+        let (deletes, upserts) = pending.take();
+        assert!(deletes.is_empty());
+        assert_eq!(upserts.len(), 2);
     }
 }

--- a/src/connector/src/sink/postgres.rs
+++ b/src/connector/src/sink/postgres.rs
@@ -519,7 +519,7 @@ impl PostgresSinkWriter {
         } else {
             PendingRows::Upsert {
                 absorbed: 0,
-                rows: HashMap::with_capacity(max_batch_rows.min(1024)),
+                rows: HashMap::new(),
             }
         };
 

--- a/src/connector/src/sink/postgres.rs
+++ b/src/connector/src/sink/postgres.rs
@@ -379,7 +379,9 @@ enum PendingRows {
         /// Rows absorbed since the last flush; drives the flush threshold so log-store
         /// truncation keeps pace even when dedup keeps the map small.
         absorbed: usize,
-        rows: HashMap<OwnedRow, PendingOp>,
+        /// Last op per key, tagged with its arrival sequence: keys distinct to RisingWave may
+        /// be equal to PostgreSQL (e.g. `char(n)` padding), so execution order is observable.
+        rows: HashMap<OwnedRow, (usize, PendingOp)>,
     },
 }
 
@@ -406,7 +408,6 @@ impl PendingRows {
                 }
             }
             PendingRows::Upsert { absorbed, rows } => {
-                *absorbed += chunk.cardinality();
                 rows.reserve(chunk.cardinality());
                 for (op, row) in chunk.rows() {
                     let key = row.project(key_indices).into_owned_row();
@@ -416,13 +417,15 @@ impl PendingRows {
                         }
                         Op::Delete | Op::UpdateDelete => PendingOp::Delete,
                     };
-                    rows.insert(key, pending_op);
+                    rows.insert(key, (*absorbed, pending_op));
+                    *absorbed += 1;
                 }
             }
         }
     }
 
-    /// Takes all pending rows out, split into deletes (rebuilt from the keys) and upserts.
+    /// Takes all pending rows out, split into deletes (rebuilt from the keys) and upserts, each
+    /// in chronological order.
     fn take(&mut self, key_types: &[PgType]) -> (Vec<PgRow>, Vec<PgRow>) {
         match self {
             PendingRows::Insert(rows) => (vec![], std::mem::take(rows)),
@@ -430,13 +433,20 @@ impl PendingRows {
                 *absorbed = 0;
                 let mut deletes = Vec::with_capacity(rows.len());
                 let mut upserts = Vec::with_capacity(rows.len());
-                for (key, op) in rows.drain() {
+                for (key, (seq, op)) in rows.drain() {
                     match op {
-                        PendingOp::Upsert(row) => upserts.push(row),
-                        PendingOp::Delete => deletes.push(convert_row_to_pg_row(&key, key_types)),
+                        PendingOp::Upsert(row) => upserts.push((seq, row)),
+                        PendingOp::Delete => {
+                            deletes.push((seq, convert_row_to_pg_row(&key, key_types)))
+                        }
                     }
                 }
-                (deletes, upserts)
+                deletes.sort_unstable_by_key(|(seq, _)| *seq);
+                upserts.sort_unstable_by_key(|(seq, _)| *seq);
+                (
+                    deletes.into_iter().map(|(_, row)| row).collect(),
+                    upserts.into_iter().map(|(_, row)| row).collect(),
+                )
             }
         }
     }
@@ -619,7 +629,10 @@ impl PostgresSinkWriter {
         Ok(batches)
     }
 
-    /// Writes out all pending rows in a single transaction.
+    /// Writes out all pending rows in a single transaction: all deletes first, then upserts in
+    /// chronological order. Deletes are not interleaved by time because every upsert surviving
+    /// dedup is live in RisingWave and must reach the target even if a PG-equal key was deleted
+    /// after it.
     async fn flush(&mut self) -> Result<()> {
         let (deletes, upserts) = self.pending.take(&self.key_types);
         if deletes.is_empty() && upserts.is_empty() {
@@ -676,8 +689,8 @@ impl PostgresSinkWriter {
                     deletes.len()
                 )
             })?;
-        // Polled concurrently to pipeline; statements still execute in wire order, so which of
-        // several PG-equal keys wins is unchanged.
+        // Polled concurrently to pipeline; statements still execute in wire order, so the
+        // chronologically last of several PG-equal keys wins.
         let executions = upserts
             .iter()
             .map(|row| transaction.execute_raw(&statement, row));
@@ -730,9 +743,8 @@ async fn execute_batches(
     transaction: &tokio_postgres::Transaction<'_>,
     batches: &[(tokio_postgres::Statement, &[PgRow])],
 ) -> std::result::Result<(), tokio_postgres::Error> {
-    // Polling all statements concurrently pipelines them into a single round trip. Execution
-    // order does not matter: dedup keeps deleted and upserted keys disjoint, and sub-batches
-    // never share a row.
+    // Polling all statements concurrently pipelines them into a single round trip; they still
+    // execute in wire order, i.e. in the order of `batches`.
     let executions = batches.iter().map(|(statement, tuples)| {
         let mut params = Vec::with_capacity(tuples.len() * tuples.first().map_or(0, |t| t.len()));
         params.extend(tuples.iter().flatten());
@@ -1066,13 +1078,17 @@ mod tests {
                 .join("\n"),
             PendingRows::Upsert { rows, .. } => rows
                 .iter()
-                .map(|(key, op)| match op {
-                    PendingOp::Upsert(row) => format!("{:?} => upsert {:?}", key, row),
-                    PendingOp::Delete => format!("{:?} => delete", key),
+                .map(|(key, (seq, op))| match op {
+                    PendingOp::Upsert(row) => format!("{:?} => #{} upsert {:?}", key, seq, row),
+                    PendingOp::Delete => format!("{:?} => #{} delete", key, seq),
                 })
                 .sorted()
                 .join("\n"),
         }
+    }
+
+    fn first_columns(rows: &[PgRow]) -> Vec<String> {
+        rows.iter().map(|row| format!("{:?}", row[0])).collect()
     }
 
     #[test]
@@ -1113,15 +1129,53 @@ mod tests {
         check(
             render_pending(&pending),
             expect![[r#"
-                OwnedRow([Some(Int32(1))]) => upsert [Some(Builtin(Int32(1))), Some(Builtin(Int32(11)))]
-                OwnedRow([Some(Int32(2))]) => delete
-                OwnedRow([Some(Int32(3))]) => upsert [Some(Builtin(Int32(3))), Some(Builtin(Int32(31)))]"#]],
+                OwnedRow([Some(Int32(1))]) => #1 upsert [Some(Builtin(Int32(1))), Some(Builtin(Int32(11)))]
+                OwnedRow([Some(Int32(2))]) => #3 delete
+                OwnedRow([Some(Int32(3))]) => #6 upsert [Some(Builtin(Int32(3))), Some(Builtin(Int32(31)))]"#]],
         );
 
         let (deletes, upserts) = pending.take(&key_types);
         assert_eq!(deletes.len(), 1);
         assert_eq!(upserts.len(), 2);
         assert_eq!(pending.absorbed(), 0);
+    }
+
+    #[test]
+    fn test_pending_take_chronological() {
+        let types = vec![PgType::INT4, PgType::INT4];
+        let mut pending = PendingRows::Upsert {
+            absorbed: 0,
+            rows: HashMap::new(),
+        };
+
+        let inserts = (1..=64).map(|k| format!("+ {k} {k}")).join("\n");
+        pending.absorb(
+            &StreamChunk::from_pretty(&format!(" i i\n{inserts}")),
+            &[0],
+            &types,
+        );
+        // Re-upserting a key moves it to the end.
+        pending.absorb(
+            &StreamChunk::from_pretty(
+                " i i
+                 - 3 3
+                 + 1 100
+                 - 2 2",
+            ),
+            &[0],
+            &types,
+        );
+
+        let (deletes, upserts) = pending.take(&[PgType::INT4]);
+        let expected_upserts = (4..=64)
+            .chain([1])
+            .map(|k| format!("Some(Builtin(Int32({k})))"))
+            .collect_vec();
+        assert_eq!(first_columns(&upserts), expected_upserts);
+        assert_eq!(
+            first_columns(&deletes),
+            ["Some(Builtin(Int32(3)))", "Some(Builtin(Int32(2)))"]
+        );
     }
 
     #[test]

--- a/src/connector/src/sink/postgres.rs
+++ b/src/connector/src/sink/postgres.rs
@@ -450,8 +450,10 @@ pub struct PostgresSinkWriter {
     key_types: Vec<PgType>,
     schema_types: Vec<PgType>,
     max_batch_rows: usize,
-    write_statement: Option<tokio_postgres::Statement>,
-    delete_statement: Option<tokio_postgres::Statement>,
+    /// Prepared statements keyed by tuple count. Only power-of-two sizes are inserted, so each
+    /// cache stays logarithmic in `max_batch_rows`.
+    write_statements: HashMap<usize, tokio_postgres::Statement>,
+    delete_statements: HashMap<usize, tokio_postgres::Statement>,
     pending: PendingRows,
 }
 
@@ -536,8 +538,8 @@ impl PostgresSinkWriter {
             key_types,
             schema_types,
             max_batch_rows,
-            write_statement: None,
-            delete_statement: None,
+            write_statements: HashMap::new(),
+            delete_statements: HashMap::new(),
             pending,
         };
         Ok(writer)
@@ -565,48 +567,52 @@ impl PostgresSinkWriter {
         }
     }
 
-    fn statement_cache(&mut self, kind: StatementKind) -> &mut Option<tokio_postgres::Statement> {
+    fn statement_cache(
+        &mut self,
+        kind: StatementKind,
+    ) -> &mut HashMap<usize, tokio_postgres::Statement> {
         match kind {
-            StatementKind::Insert | StatementKind::Upsert => &mut self.write_statement,
-            StatementKind::Delete => &mut self.delete_statement,
+            StatementKind::Insert | StatementKind::Upsert => &mut self.write_statements,
+            StatementKind::Delete => &mut self.delete_statements,
         }
     }
 
-    /// Pairs each sub-batch with a statement of matching tuple count. Only the full-size
-    /// statement is cached; remainder sizes (barrier flushes) are prepared ad hoc.
+    async fn cached_statement(
+        &mut self,
+        kind: StatementKind,
+        n_tuples: usize,
+    ) -> Result<tokio_postgres::Statement> {
+        if let Some(statement) = self.statement_cache(kind).get(&n_tuples) {
+            return Ok(statement.clone());
+        }
+        let sql = self.create_sql(kind, n_tuples);
+        let statement = self.client.prepare(&sql).await.with_context(|| {
+            format!(
+                "failed to prepare {} statement for {} rows",
+                kind.as_str(),
+                n_tuples
+            )
+        })?;
+        self.statement_cache(kind)
+            .insert(n_tuples, statement.clone());
+        Ok(statement)
+    }
+
+    /// Pairs each sub-batch with a prepared statement of matching tuple count. Batches are split
+    /// into power-of-two sizes so that once warm, every size hits the statement cache.
     async fn prepare_batches<'a>(
         &mut self,
         kind: StatementKind,
         rows: &'a [PgRow],
     ) -> Result<Vec<(tokio_postgres::Statement, &'a [PgRow])>> {
-        if rows.is_empty() {
-            return Ok(vec![]);
-        }
         let params_per_tuple = match kind {
             StatementKind::Insert | StatementKind::Upsert => self.schema.len(),
             StatementKind::Delete => self.key_indices.len(),
         };
-        let full = tuples_per_statement(self.max_batch_rows, params_per_tuple);
-        let mut batches = Vec::with_capacity(rows.len().div_ceil(full));
-        for tuples in rows.chunks(full) {
-            let is_full = tuples.len() == full;
-            let statement = match self.statement_cache(kind).clone() {
-                Some(statement) if is_full => statement,
-                _ => {
-                    let sql = self.create_sql(kind, tuples.len());
-                    let statement = self.client.prepare(&sql).await.with_context(|| {
-                        format!(
-                            "failed to prepare {} statement for {} rows",
-                            kind.as_str(),
-                            tuples.len()
-                        )
-                    })?;
-                    if is_full {
-                        *self.statement_cache(kind) = Some(statement.clone());
-                    }
-                    statement
-                }
-            };
+        let cap = tuples_per_statement(self.max_batch_rows, params_per_tuple);
+        let mut batches = Vec::new();
+        for tuples in split_power_of_two(rows, cap) {
+            let statement = self.cached_statement(kind, tuples.len()).await?;
             batches.push((statement, tuples));
         }
         Ok(batches)
@@ -619,24 +625,14 @@ impl PostgresSinkWriter {
             return Ok(());
         }
 
-        // Statements are prepared before the transaction so cache hits skip the prepare round trip
-        // entirely.
-        let delete_batches = self
+        // Statements are prepared before the transaction; after warm-up every size hits the cache.
+        let mut batches = self
             .prepare_batches(StatementKind::Delete, &deletes)
             .await?;
-        let write_batches = self.prepare_batches(self.write_kind, &upserts).await?;
+        batches.extend(self.prepare_batches(self.write_kind, &upserts).await?);
 
         let transaction = self.client.transaction().await?;
-        // Deletes go first, which is safe because dedup leaves deleted and upserted keys disjoint.
-        execute_batches(&transaction, &delete_batches)
-            .await
-            .with_context(|| {
-                format!(
-                    "failed to execute delete statements on {} rows",
-                    deletes.len()
-                )
-            })?;
-        if let Err(e) = execute_batches(&transaction, &write_batches).await {
+        if let Err(e) = execute_batches(&transaction, &batches).await {
             // Keys the dedup kept apart may still be equal to PostgreSQL (e.g. `char(n)` padding
             // or a case-insensitive collation), which a multi-row upsert rejects with SQLSTATE
             // 21000. Retry such batches row by row.
@@ -651,8 +647,8 @@ impl PostgresSinkWriter {
             }
             return Err(anyhow::Error::new(e)
                 .context(format!(
-                    "failed to execute {} statements on {} rows",
-                    self.write_kind.as_str(),
+                    "failed to execute batched statements ({} delete rows, {} write rows)",
+                    deletes.len(),
                     upserts.len()
                 ))
                 .into());
@@ -666,12 +662,7 @@ impl PostgresSinkWriter {
     /// first, then one upsert per statement.
     async fn flush_row_by_row(&mut self, deletes: &[PgRow], upserts: &[PgRow]) -> Result<()> {
         let delete_batches = self.prepare_batches(StatementKind::Delete, deletes).await?;
-        let sql = self.create_sql(self.write_kind, 1);
-        let statement = self
-            .client
-            .prepare(&sql)
-            .await
-            .context("failed to prepare single-row write statement")?;
+        let statement = self.cached_statement(self.write_kind, 1).await?;
 
         let transaction = self.client.transaction().await?;
         execute_batches(&transaction, &delete_batches)
@@ -712,15 +703,37 @@ fn tuples_per_statement(max_batch_rows: usize, params_per_tuple: usize) -> usize
         .max(1)
 }
 
+/// Splits `rows` into power-of-two-sized chunks no larger than `cap`, largest first, so any
+/// length is covered by a logarithmic set of statement sizes.
+fn split_power_of_two<T>(rows: &[T], cap: usize) -> Vec<&[T]> {
+    let mut chunks = Vec::new();
+    let mut rest = rows;
+    while !rest.is_empty() {
+        let (chunk, tail) = rest.split_at(prev_power_of_two(rest.len().min(cap)));
+        chunks.push(chunk);
+        rest = tail;
+    }
+    chunks
+}
+
+/// Largest power of two not exceeding `n`. `n` must be positive.
+fn prev_power_of_two(n: usize) -> usize {
+    1 << (usize::BITS - 1 - n.leading_zeros())
+}
+
 async fn execute_batches(
     transaction: &tokio_postgres::Transaction<'_>,
     batches: &[(tokio_postgres::Statement, &[PgRow])],
 ) -> std::result::Result<(), tokio_postgres::Error> {
-    for (statement, tuples) in batches {
+    // Polling all statements concurrently pipelines them into a single round trip. Execution
+    // order does not matter: dedup keeps deleted and upserted keys disjoint, and sub-batches
+    // never share a row.
+    let executions = batches.iter().map(|(statement, tuples)| {
         let mut params = Vec::with_capacity(tuples.len() * tuples.first().map_or(0, |t| t.len()));
         params.extend(tuples.iter().flatten());
-        transaction.execute_raw(statement, params).await?;
-    }
+        transaction.execute_raw(statement, params)
+    });
+    futures::future::try_join_all(executions).await?;
     Ok(())
 }
 
@@ -1007,6 +1020,29 @@ mod tests {
                 r#"INSERT INTO "test_schema"."test_table" ("user_id", "client_id") VALUES ($1, $2), ($3, $4) on conflict ("user_id", "client_id") do nothing"#
             ]],
         );
+    }
+
+    #[test]
+    fn test_split_power_of_two() {
+        let check_split = |len: usize, cap: usize, expect: &[usize]| {
+            let rows = vec![(); len];
+            let sizes = split_power_of_two(&rows, cap)
+                .iter()
+                .map(|c| c.len())
+                .collect_vec();
+            assert_eq!(sizes, expect, "len={len} cap={cap}");
+        };
+        check_split(1024, 1024, &[1024]);
+        check_split(922, 1024, &[512, 256, 128, 16, 8, 2]);
+        check_split(37, 1024, &[32, 4, 1]);
+        check_split(1, 1, &[1]);
+        // A non-power-of-two cap yields chunks of at most the previous power of two.
+        check_split(1000, 327, &[256, 256, 256, 128, 64, 32, 8]);
+
+        assert_eq!(prev_power_of_two(1), 1);
+        assert_eq!(prev_power_of_two(3), 2);
+        assert_eq!(prev_power_of_two(1023), 512);
+        assert_eq!(prev_power_of_two(1024), 1024);
     }
 
     #[tokio::test]

--- a/src/connector/src/sink/postgres.rs
+++ b/src/connector/src/sink/postgres.rs
@@ -27,6 +27,7 @@ use simd_json::prelude::ArrayTrait;
 use thiserror_ext::AsReport;
 use tokio_postgres::error::SqlState;
 use tokio_postgres::types::Type as PgType;
+use with_options::WithOptions;
 
 use super::{
     LogSinker, SINK_TYPE_APPEND_ONLY, SINK_TYPE_OPTION, SINK_TYPE_UPSERT, SinkError, SinkLogReader,
@@ -63,7 +64,7 @@ const CHECK_FOREIGN_KEY_SQL: &str = r#"
 "#;
 
 #[serde_as]
-#[derive(Clone, Debug, Deserialize)]
+#[derive(Clone, Debug, Deserialize, WithOptions)]
 pub struct PostgresConfig {
     pub host: String,
     #[serde_as(as = "DisplayFromStr")]
@@ -347,7 +348,6 @@ impl Sink for PostgresSink {
 
 #[derive(Clone, Copy)]
 enum StatementKind {
-    /// Plain `INSERT`, used by append-only sinks.
     Insert,
     Upsert,
     Delete,
@@ -371,22 +371,23 @@ enum PendingOp {
 /// Rows accumulated across chunks, written out on flush.
 enum PendingRows {
     Insert(Vec<PgRow>),
-    /// Only the last operation per key is kept: PostgreSQL rejects an
-    /// `INSERT .. ON CONFLICT DO UPDATE` that affects the same row twice.
-    ///
-    /// Deliberately not `ChangeBuffer` semantics, which assume the downstream state matches
-    /// the buffer start. At-least-once replay breaks that: a committed-but-untruncated batch
-    /// may be re-delivered and regrouped with new chunks, so insert-then-delete must still
-    /// emit the delete rather than annihilate. Same-key duplicates (e.g. replay, or a subset
-    /// downstream pk with `preserve_row_level_changes`) are legal input, not inconsistencies.
-    Upsert(HashMap<OwnedRow, PendingOp>),
+    /// Keeps only the last operation per key: PostgreSQL rejects an `INSERT .. ON CONFLICT
+    /// DO UPDATE` affecting the same row twice. Unlike `ChangeBuffer`, insert-then-delete
+    /// still emits the delete: at-least-once replay may regroup a committed batch with new
+    /// chunks, so same-key duplicates are legal and the downstream state is unknown.
+    Upsert {
+        /// Rows absorbed since the last flush; drives the flush threshold so log-store
+        /// truncation keeps pace even when dedup keeps the map small.
+        absorbed: usize,
+        rows: HashMap<OwnedRow, PendingOp>,
+    },
 }
 
 impl PendingRows {
-    fn len(&self) -> usize {
+    fn absorbed(&self) -> usize {
         match self {
             PendingRows::Insert(rows) => rows.len(),
-            PendingRows::Upsert(rows) => rows.len(),
+            PendingRows::Upsert { absorbed, .. } => *absorbed,
         }
     }
 
@@ -404,7 +405,8 @@ impl PendingRows {
                     }
                 }
             }
-            PendingRows::Upsert(rows) => {
+            PendingRows::Upsert { absorbed, rows } => {
+                *absorbed += chunk.cardinality();
                 rows.reserve(chunk.cardinality());
                 for (op, row) in chunk.rows() {
                     let key = row.project(key_indices).into_owned_row();
@@ -424,7 +426,8 @@ impl PendingRows {
     fn take(&mut self, key_types: &[PgType]) -> (Vec<PgRow>, Vec<PgRow>) {
         match self {
             PendingRows::Insert(rows) => (vec![], std::mem::take(rows)),
-            PendingRows::Upsert(rows) => {
+            PendingRows::Upsert { absorbed, rows } => {
+                *absorbed = 0;
                 let mut deletes = Vec::with_capacity(rows.len());
                 let mut upserts = Vec::with_capacity(rows.len());
                 for (key, op) in rows.drain() {
@@ -440,18 +443,18 @@ impl PendingRows {
 }
 
 pub struct PostgresSinkWriter {
-    write_kind: StatementKind,
     client: tokio_postgres::Client,
     schema: Schema,
     schema_name: String,
     table_name: String,
     /// Columns identifying a downstream row: the sink pk, or all columns when there is no pk.
+    /// Never empty.
     key_indices: Vec<usize>,
     key_types: Vec<PgType>,
     schema_types: Vec<PgType>,
     max_batch_rows: usize,
-    /// Prepared statements keyed by tuple count. Only power-of-two sizes are inserted, so each
-    /// cache stays logarithmic in `max_batch_rows`.
+    /// Prepared statements keyed by tuple count; only power-of-two sizes, so the caches stay
+    /// small.
     write_statements: HashMap<usize, tokio_postgres::Statement>,
     delete_statements: HashMap<usize, tokio_postgres::Statement>,
     pending: PendingRows,
@@ -482,22 +485,14 @@ impl PostgresSinkWriter {
             .await?;
             let mut schema_types = Vec::with_capacity(schema.fields.len());
             for field in &schema.fields {
-                let field_name = &field.name;
-                let actual_data_type = name_to_type.get(field_name).map(|t| (*t).clone());
-                let actual_data_type = actual_data_type
-                    .ok_or_else(|| {
-                        SinkError::Config(anyhow!(
-                            "Column `{}` not found in sink schema",
-                            field_name
-                        ))
-                    })?
-                    .clone();
+                let actual_data_type = name_to_type.get(&field.name).cloned().ok_or_else(|| {
+                    SinkError::Config(anyhow!("Column `{}` not found in sink schema", field.name))
+                })?;
                 schema_types.push(actual_data_type);
             }
             schema_types
         };
 
-        // Normalize the key here: pk, or all columns when there is no pk. SQL builders require it non-empty.
         let key_indices = if pk_indices.is_empty() {
             (0..schema.len()).collect_vec()
         } else {
@@ -508,8 +503,8 @@ impl PostgresSinkWriter {
             .map(|i| schema_types[*i].clone())
             .collect_vec();
 
-        // `validate()` rejects out-of-range values at DDL time; only clamp here so pre-existing
-        // sinks (the option was inert before batching) keep running after an upgrade.
+        // validate() rejects out-of-range values at DDL time; clamp here so pre-existing sinks
+        // keep running after an upgrade.
         let max_batch_rows = config.max_batch_rows.clamp(1, MAX_BATCH_ROWS_LIMIT);
         if max_batch_rows != config.max_batch_rows {
             tracing::warn!(
@@ -519,17 +514,16 @@ impl PostgresSinkWriter {
             );
         }
 
-        let (write_kind, pending) = if is_append_only {
-            (StatementKind::Insert, PendingRows::Insert(Vec::new()))
+        let pending = if is_append_only {
+            PendingRows::Insert(Vec::new())
         } else {
-            (
-                StatementKind::Upsert,
-                PendingRows::Upsert(HashMap::with_capacity(max_batch_rows.min(1024))),
-            )
+            PendingRows::Upsert {
+                absorbed: 0,
+                rows: HashMap::with_capacity(max_batch_rows.min(1024)),
+            }
         };
 
         let writer = Self {
-            write_kind,
             client,
             schema,
             schema_name: config.schema,
@@ -543,6 +537,13 @@ impl PostgresSinkWriter {
             pending,
         };
         Ok(writer)
+    }
+
+    fn write_kind(&self) -> StatementKind {
+        match &self.pending {
+            PendingRows::Insert(_) => StatementKind::Insert,
+            PendingRows::Upsert { .. } => StatementKind::Upsert,
+        }
     }
 
     fn create_sql(&self, kind: StatementKind, n_tuples: usize) -> String {
@@ -626,10 +627,11 @@ impl PostgresSinkWriter {
         }
 
         // Statements are prepared before the transaction; after warm-up every size hits the cache.
+        let write_kind = self.write_kind();
         let mut batches = self
             .prepare_batches(StatementKind::Delete, &deletes)
             .await?;
-        batches.extend(self.prepare_batches(self.write_kind, &upserts).await?);
+        batches.extend(self.prepare_batches(write_kind, &upserts).await?);
 
         let transaction = self.client.transaction().await?;
         if let Err(e) = execute_batches(&transaction, &batches).await {
@@ -647,7 +649,8 @@ impl PostgresSinkWriter {
             }
             return Err(anyhow::Error::new(e)
                 .context(format!(
-                    "failed to execute batched statements ({} delete rows, {} write rows)",
+                    "failed to execute batched {} statements ({} delete rows, {} write rows)",
+                    write_kind.as_str(),
                     deletes.len(),
                     upserts.len()
                 ))
@@ -662,7 +665,7 @@ impl PostgresSinkWriter {
     /// first, then one upsert per statement.
     async fn flush_row_by_row(&mut self, deletes: &[PgRow], upserts: &[PgRow]) -> Result<()> {
         let delete_batches = self.prepare_batches(StatementKind::Delete, deletes).await?;
-        let statement = self.cached_statement(self.write_kind, 1).await?;
+        let statement = self.cached_statement(self.write_kind(), 1).await?;
 
         let transaction = self.client.transaction().await?;
         execute_batches(&transaction, &delete_batches)
@@ -673,21 +676,24 @@ impl PostgresSinkWriter {
                     deletes.len()
                 )
             })?;
-        for row in upserts {
-            transaction
-                .execute_raw(&statement, row)
-                .await
-                .context("failed to execute single-row write statement")?;
-        }
+        // Polled concurrently to pipeline; statements still execute in wire order, so which of
+        // several PG-equal keys wins is unchanged.
+        let executions = upserts
+            .iter()
+            .map(|row| transaction.execute_raw(&statement, row));
+        futures::future::try_join_all(executions)
+            .await
+            .context("failed to execute single-row write statements")?;
         transaction.commit().await?;
         Ok(())
     }
 
-    /// Buffers the chunk, flushing when the batch is full. Returns whether a flush happened.
+    /// Buffers the chunk, flushing once enough rows have been absorbed. Returns whether a flush
+    /// happened.
     async fn write_chunk(&mut self, chunk: &StreamChunk) -> Result<bool> {
         self.pending
             .absorb(chunk, &self.key_indices, &self.schema_types);
-        if self.pending.len() >= self.max_batch_rows {
+        if self.pending.absorbed() >= self.max_batch_rows {
             self.flush().await?;
             Ok(true)
         } else {
@@ -703,8 +709,7 @@ fn tuples_per_statement(max_batch_rows: usize, params_per_tuple: usize) -> usize
         .max(1)
 }
 
-/// Splits `rows` into power-of-two-sized chunks no larger than `cap`, largest first, so any
-/// length is covered by a logarithmic set of statement sizes.
+/// Splits `rows` into power-of-two-sized chunks no larger than `cap`, largest first.
 fn split_power_of_two<T>(rows: &[T], cap: usize) -> Vec<&[T]> {
     let mut chunks = Vec::new();
     let mut rest = rows;
@@ -820,20 +825,17 @@ fn create_upsert_sql(
     schema: &Schema,
     schema_name: &str,
     table_name: &str,
-    pk_indices: &[usize],
+    key_indices: &[usize],
     n_tuples: usize,
 ) -> String {
     let insert_sql = create_insert_sql(schema, schema_name, table_name, n_tuples);
-    if pk_indices.is_empty() {
-        return insert_sql;
-    }
-    let pk_columns = pk_indices
+    let pk_columns = key_indices
         .iter()
-        .map(|pk_index| quote_identifier(&schema.fields()[*pk_index].name))
+        .map(|key_index| quote_identifier(&schema.fields()[*key_index].name))
         .collect_vec()
         .join(", ");
     let update_parameters: String = (0..schema.len())
-        .filter(|i| !pk_indices.contains(i))
+        .filter(|i| !key_indices.contains(i))
         .map(|i| {
             let column = quote_identifier(&schema.fields()[i].name);
             format!("{column} = EXCLUDED.{column}")
@@ -906,11 +908,6 @@ mod tests {
         let schema = test_schema();
         let schema_name = "test_schema";
         let table_name = "test_table";
-        let sql = create_insert_sql(&schema, schema_name, table_name, 1);
-        check(
-            sql,
-            expect![[r#"INSERT INTO "test_schema"."test_table" ("a", "b") VALUES ($1, $2)"#]],
-        );
         let sql = create_insert_sql(&schema, schema_name, table_name, 3);
         check(
             sql,
@@ -925,16 +922,6 @@ mod tests {
         let schema = test_schema();
         let schema_name = "test_schema";
         let table_name = "test_table";
-        let sql = create_delete_sql(&schema, schema_name, table_name, &[1], 1);
-        check(
-            sql,
-            expect![[r#"DELETE FROM "test_schema"."test_table" WHERE ("b") in (($1))"#]],
-        );
-        let sql = create_delete_sql(&schema, schema_name, table_name, &[0, 1], 1);
-        check(
-            sql,
-            expect![[r#"DELETE FROM "test_schema"."test_table" WHERE ("a", "b") in (($1, $2))"#]],
-        );
         let sql = create_delete_sql(&schema, schema_name, table_name, &[1], 3);
         check(
             sql,
@@ -956,13 +943,6 @@ mod tests {
         let schema = test_schema();
         let schema_name = "test_schema";
         let table_name = "test_table";
-        let sql = create_upsert_sql(&schema, schema_name, table_name, &[1], 1);
-        check(
-            sql,
-            expect![[
-                r#"INSERT INTO "test_schema"."test_table" ("a", "b") VALUES ($1, $2) on conflict ("b") do update set "a" = EXCLUDED."a""#
-            ]],
-        );
         let sql = create_upsert_sql(&schema, schema_name, table_name, &[1], 3);
         check(
             sql,
@@ -970,11 +950,8 @@ mod tests {
                 r#"INSERT INTO "test_schema"."test_table" ("a", "b") VALUES ($1, $2), ($3, $4), ($5, $6) on conflict ("b") do update set "a" = EXCLUDED."a""#
             ]],
         );
-    }
 
-    #[test]
-    fn test_create_upsert_sql_composite_primary_key() {
-        let schema = Schema::new(vec![
+        let composite = Schema::new(vec![
             Field {
                 data_type: DataType::Int32,
                 name: "user_id".to_owned(),
@@ -988,20 +965,16 @@ mod tests {
                 name: "value".to_owned(),
             },
         ]);
-        let schema_name = "test_schema";
-        let table_name = "test_table";
-        let sql = create_upsert_sql(&schema, schema_name, table_name, &[0, 1], 2);
+        let sql = create_upsert_sql(&composite, schema_name, table_name, &[0, 1], 2);
         check(
             sql,
             expect![[
                 r#"INSERT INTO "test_schema"."test_table" ("user_id", "client_id", "value") VALUES ($1, $2, $3), ($4, $5, $6) on conflict ("user_id", "client_id") do update set "value" = EXCLUDED."value""#
             ]],
         );
-    }
 
-    #[test]
-    fn test_create_upsert_sql_all_columns_are_primary_keys() {
-        let schema = Schema::new(vec![
+        // All columns in the pk: nothing to update on conflict.
+        let all_pk = Schema::new(vec![
             Field {
                 data_type: DataType::Int32,
                 name: "user_id".to_owned(),
@@ -1011,9 +984,7 @@ mod tests {
                 name: "client_id".to_owned(),
             },
         ]);
-        let schema_name = "test_schema";
-        let table_name = "test_table";
-        let sql = create_upsert_sql(&schema, schema_name, table_name, &[0, 1], 2);
+        let sql = create_upsert_sql(&all_pk, schema_name, table_name, &[0, 1], 2);
         check(
             sql,
             expect![[
@@ -1036,7 +1007,6 @@ mod tests {
         check_split(922, 1024, &[512, 256, 128, 16, 8, 2]);
         check_split(37, 1024, &[32, 4, 1]);
         check_split(1, 1, &[1]);
-        // A non-power-of-two cap yields chunks of at most the previous power of two.
         check_split(1000, 327, &[256, 256, 256, 128, 64, 32, 8]);
 
         assert_eq!(prev_power_of_two(1), 1);
@@ -1094,7 +1064,7 @@ mod tests {
                 .iter()
                 .map(|row| format!("insert {:?}", row))
                 .join("\n"),
-            PendingRows::Upsert(rows) => rows
+            PendingRows::Upsert { rows, .. } => rows
                 .iter()
                 .map(|(key, op)| match op {
                     PendingOp::Upsert(row) => format!("{:?} => upsert {:?}", key, row),
@@ -1110,7 +1080,10 @@ mod tests {
         let types = vec![PgType::INT4, PgType::INT4];
         let key_indices = [0];
         let key_types = vec![PgType::INT4];
-        let mut pending = PendingRows::Upsert(HashMap::new());
+        let mut pending = PendingRows::Upsert {
+            absorbed: 0,
+            rows: HashMap::new(),
+        };
 
         // Delete then insert on the same key collapses into an upsert, insert then delete into a
         // delete, and the last of several upserts wins.
@@ -1135,7 +1108,8 @@ mod tests {
             &key_indices,
             &types,
         );
-        assert_eq!(pending.len(), 3);
+        // Seven rows absorbed, three distinct keys left after dedup.
+        assert_eq!(pending.absorbed(), 7);
         check(
             render_pending(&pending),
             expect![[r#"
@@ -1147,7 +1121,50 @@ mod tests {
         let (deletes, upserts) = pending.take(&key_types);
         assert_eq!(deletes.len(), 1);
         assert_eq!(upserts.len(), 2);
-        assert_eq!(pending.len(), 0);
+        assert_eq!(pending.absorbed(), 0);
+    }
+
+    #[test]
+    fn test_permuted_key_indices() {
+        // Regression guard: key types and values must follow the declared key order, not schema
+        // order.
+        let schema = Schema::new(vec![
+            Field {
+                data_type: DataType::Int32,
+                name: "a".to_owned(),
+            },
+            Field {
+                data_type: DataType::Varchar,
+                name: "b".to_owned(),
+            },
+        ]);
+        let sql = create_delete_sql(&schema, "test_schema", "test_table", &[1, 0], 2);
+        check(
+            sql,
+            expect![[
+                r#"DELETE FROM "test_schema"."test_table" WHERE ("b", "a") in (($1, $2), ($3, $4))"#
+            ]],
+        );
+
+        let schema_types = vec![PgType::INT4, PgType::TEXT];
+        let mut pending = PendingRows::Upsert {
+            absorbed: 0,
+            rows: HashMap::new(),
+        };
+        pending.absorb(
+            &StreamChunk::from_pretty(
+                " i T
+                 - 1 x",
+            ),
+            &[1, 0],
+            &schema_types,
+        );
+        let (deletes, upserts) = pending.take(&[PgType::TEXT, PgType::INT4]);
+        assert!(upserts.is_empty());
+        check(
+            format!("{:?}", deletes),
+            expect![[r#"[[Some(Builtin(Utf8("x"))), Some(Builtin(Int32(1)))]]"#]],
+        );
     }
 
     #[test]

--- a/src/connector/src/with_options.rs
+++ b/src/connector/src/with_options.rs
@@ -73,6 +73,7 @@ impl WithOptions for i64 {}
 impl WithOptions for f64 {}
 impl WithOptions for std::time::Duration {}
 impl WithOptions for crate::connector_common::MqttQualityOfService {}
+impl WithOptions for crate::connector_common::SslMode {}
 impl WithOptions for crate::sink::file_sink::opendal_sink::PathPartitionPrefix {}
 impl WithOptions for crate::sink::kafka::CompressionCodec {}
 impl WithOptions for crate::sink::pulsar::PulsarRoutingMode {}

--- a/src/connector/with_options_sink.yaml
+++ b/src/connector/with_options_sink.yaml
@@ -1463,6 +1463,51 @@ OpenSearchConfig:
     field_type: String
     required: false
     default: '"upsert" . to_owned ()'
+PostgresConfig:
+  fields:
+  - name: host
+    field_type: String
+    required: true
+  - name: port
+    field_type: u16
+    required: true
+  - name: user
+    field_type: String
+    required: true
+  - name: password
+    field_type: String
+    required: true
+  - name: database
+    field_type: String
+    required: true
+  - name: table
+    field_type: String
+    required: true
+  - name: schema
+    field_type: String
+    required: false
+    default: '"public" . to_owned ()'
+  - name: ssl_mode
+    field_type: SslMode
+    required: false
+    default: Default::default
+  - name: ssl.root.cert
+    field_type: String
+    required: false
+  - name: max_batch_rows
+    field_type: usize
+    required: false
+    default: '1024'
+  - name: r#type
+    field_type: String
+    required: true
+  - name: tcp.keepalive.enable
+    field_type: bool
+    required: false
+    default: Default::default
+  - name: tcp_keepalive
+    field_type: TcpKeepaliveConfig
+    required: false
 PulsarConfig:
   fields:
   - name: properties.retry.max

--- a/src/connector/with_options_sink.yaml
+++ b/src/connector/with_options_sink.yaml
@@ -1505,9 +1505,18 @@ PostgresConfig:
     field_type: bool
     required: false
     default: Default::default
-  - name: tcp_keepalive
-    field_type: TcpKeepaliveConfig
+  - name: tcp.keepalive.idle
+    field_type: u32
     required: false
+    default: 10 * 60
+  - name: tcp.keepalive.interval
+    field_type: u32
+    required: false
+    default: '10'
+  - name: tcp.keepalive.count
+    field_type: u32
+    required: false
+    default: '3'
 PulsarConfig:
   fields:
   - name: properties.retry.max

--- a/src/connector/with_options_source.yaml
+++ b/src/connector/with_options_source.yaml
@@ -1455,6 +1455,20 @@ PulsarProperties:
     field_type: bool
     required: false
     default: Default::default
+TcpKeepaliveConfig:
+  fields:
+  - name: tcp.keepalive.idle
+    field_type: u32
+    required: false
+    default: 10 * 60
+  - name: tcp.keepalive.interval
+    field_type: u32
+    required: false
+    default: '10'
+  - name: tcp.keepalive.count
+    field_type: u32
+    required: false
+    default: '3'
 TestSourceProperties:
   fields:
   - name: properties


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

Restore multi-row batched writes in the native Postgres sink, replacing the per-row pipelined writer.

### Background

A user reported that for bulk upsert the (deprecated) JDBC sink is still ~66% faster than the native Postgres sink. We reproduced and profiled this: with the current per-row `execute_raw` + `FuturesUnordered` pipelining, **~76% of wall time is spent on client-side async overhead** (one future/waker per row, ~2 voluntary context switches per row — `perf` shows ~28% in atomics alone), not on PostgreSQL work.

Some history: the sink used multi-row `VALUES` batching from #19688 until #22310 removed it in favor of pipelining. That change was benchmarked on the **network-latency axis** (#22309), where it was a genuine win over the old implementation — the old batching re-prepared statements on every flush and only batched within a single chunk. This PR keeps the latency win and recovers the throughput: multi-row `VALUES` with cached statements and cross-chunk accumulation beats pipelining on **both** axes (see numbers below).

### Implementation

- Rows are accumulated across chunks into a pending buffer and flushed in one transaction when `max_batch_rows` (default 1024, **previously parsed but never used**) is reached, or on every barrier.
- Upsert mode dedups the buffer by pk, keeping the last op per key. This is required because `INSERT .. ON CONFLICT DO UPDATE` rejects a statement affecting the same row twice — and it also fixes a latent hazard acknowledged in #22310's review: chunks replayed from the log store are not compacted, so per-row pipelined execution of duplicate keys had nondeterministic order.
- Flush = one transaction: multi-tuple `DELETE .. WHERE (pk) IN ((..), (..))` first, then multi-row `INSERT .. VALUES (..), (..) ON CONFLICT DO UPDATE` (plain multi-row `INSERT` for append-only). Under RisingWave's equality the delete/upsert key sets are disjoint after dedup; upserts (and deletes) are emitted in arrival order, so when keys are distinct to RisingWave but equal to PostgreSQL (see below) the chronologically last upsert wins deterministically, both across sub-batches and in the row-by-row fallback. Deletes are deliberately not interleaved by time: every upsert surviving dedup is live in RisingWave and must reach the target even if a PG-equal key was deleted after it.
- Batches are split into power-of-two-sized sub-batches (further capped by the **32767** bind-parameter client limit — the client encodes the `Bind` parameter count as `i16`; PostgreSQL's own 65535 is unreachable), so once warm, every statement size hits a small bounded prepared-statement cache regardless of batch shape. Delete statements are awaited before upserts are sent, so their relative execution order is enforced by control flow rather than by polling order (a delete landing after a PG-equal upsert would erase a live row); the statements within each phase are polled concurrently and pipeline into a single round trip. A flush is 3 round trips (`BEGIN` + statements + `COMMIT`) for a pure-upsert or pure-delete batch and 4 for a mixed one — measured −23% throughput on a 922-upsert/102-delete mix at ~12 ms RTT, no cost otherwise.
- Log-store truncation is deferred: a chunk offset is truncated only after the flush that committed its rows, preserving at-least-once delivery.
- A failed batch is rolled back and re-applied with batched deletes plus row-by-row upserts in arrival order. This covers keys that are distinct to RisingWave but equal under the target column's semantics (e.g. `char(n)` padding, case-insensitive collations, `numeric` scale): they cannot be deduped client-side and fail a multi-row upsert with SQLSTATE 21000, while single-tuple statements apply cleanly, last-write-wins (verified against PG 18). The fallback applies to any error, not just 21000: transient failures (e.g. deadlocks) can recover in place, and a data error (e.g. a constraint violation) resurfaces on the single offending statement instead of an opaque whole-batch failure. PG-equal-key handling is best-effort by nature: such keys may also hash to different sink parallelisms, or be flushed in different batches, where no ordering is possible.
- `max_batch_rows` is validated to `1..=65536` at `CREATE SINK`. Out-of-range values on pre-existing sinks are clamped with a warning instead of failing the writer, since the option was inert before this PR and an upgrade must not break running sinks.

### Benchmarks

Motivating microbenchmark (standalone harness, PostgreSQL 18, 5-column table, upsert workload, `synchronous_commit=on`, latency via `tc netem` on loopback). Rows/s:

| writer | 0 ms RTT (500k rows) | ~1 ms RTT (500k) | ~10 ms RTT (100k) |
|---|---|---|---|
| per-row pipelining (current) | 40,192 | 27,890 | 16,786 |
| JDBC sink `addBatch`/`executeBatch` | 70,952 | 47,865 | 13,222 |
| **multi-row VALUES, batch 1024 (this PR)** | **147,630** | **93,390** | **26,703** |

Cross-chunk accumulation matters: at ~10 ms RTT a 256-row batch (chunk-sized, what #19688 did) achieves only 7.7k rows/s — worse than pipelining — while 1024 wins. In-batch dedup costs ~3.4%.

End-to-end (2M rows through a real cluster into local PG):

| workload | unpatched | patched | speedup |
|---|---|---|---|
| isolated sink drain, steady slope | 4,510 rows/s | 16,235 rows/s | **3.6x** |
| isolated sink drain, 2M total wall | 446.6 s | 126.4 s | 3.5x |
| concurrent ingest + sink, 2M total wall | 750.3 s | 538.8 s | 1.4x |

(The concurrent workload is backpressured by the sink and shares CPU with ingestion, so it understates the sink-side change; the isolated drain matches the microbenchmarks.)

JDBC comparison, re-measured on the final shape (delete phase awaited before upserts). One session: PostgreSQL 14, latency injected by a userspace TCP proxy (rows labeled by measured effective RTT), medians of 3 interleaved runs. The JDBC side is real pgjdbc (42.7.7) driving the JDBC sink's exact statement shapes: per-row `DELETE .. WHERE pk = ?` and `INSERT .. ON CONFLICT DO UPDATE` via `addBatch`/`executeBatch` (no `reWriteBatchedInserts`), deletes first, one transaction per 1024-row flush. Rows/s:

| workload | eff. RTT | this PR | JDBC sink pattern | speedup |
|---|---|---|---|---|
| upsert-only (1024) | ~0.1 ms | 451,067 | 240,737 | 1.9x |
| upsert-only | ~2.5 ms | 104,349 | 51,746 | 2.0x |
| upsert-only | ~12.3 ms | 25,255 | 12,576 | 2.0x |
| mixed (922 upserts + 102 deletes) | ~0.1 ms | 482,020 | 255,701 | 1.9x |
| mixed | ~2.5 ms | 81,061 | 53,176 | 1.5x |
| mixed | ~12.3 ms | 19,384 | 12,498 | 1.6x |

Per-flush times fit `N x RTT + local work`: this PR runs 3 blocking turns for a pure batch and 4 for a mixed one (the delete-ordering round trip), while pgjdbc measures ~6.5 turns (per-row `Bind`/`Execute` flushed in sub-batches, plus a separate delete `executeBatch`). The pre-phased revision that pipelined deletes with the upserts was ~23% faster on the mixed rows at ≥1 ms RTT — the price of pinning delete-before-upsert by control flow, paid only by flushes containing both.

Cross-checked through a real cluster against the actual JDBC sink (500k-row drain into the same PostgreSQL, parallelism 1): at ~13 ms injected RTT the native sink sustains ~19.3k rows/s vs ~6.6k for the JDBC sink (**2.9x**), with both targets converging to identical contents. The 0 ms arm of that run is not comparable: the cluster was a dev-profile build, so the CPU-bound axis is covered by the release-profile harness numbers above instead.

Correctness verified on the patched build: mixed-op convergence (RW == PG exact sums), a single row far below the batch threshold becomes visible in ~1.3 s (barrier flush), five same-key ops within one chunk converge last-write-wins (directly exercising the dedup that prevents `ON CONFLICT DO UPDATE command cannot affect row a second time`), force-append-only semantics unchanged, `max_batch_rows='64'` accepted and effective, and `e2e_test/sink/postgres_sink.slt` passes. No sink errors in cluster logs.

### Behavior changes

- Commit granularity is per-batch/per-barrier instead of per-chunk; sink visibility latency is bounded by the barrier interval.
- `max_batch_rows` is now effective (documented already; previously a silent no-op).
- `tcp.keepalive.idle` / `.interval` / `.count` are now listed in `with_options_sink.yaml` (the struct was invisible to the generator and rendered as a fake `tcp_keepalive` key). Each has a serde default, so a subset can be set; previously a partial set silently fell back to all defaults.
- Within one batch, a delete followed by an insert of the same key issues only the upsert. Target-table columns outside the sink schema keep their values instead of being reset to defaults; PG triggers fire once per final row version.
- Statement-failure error context no longer embeds the full SQL and parameters (a 32k-parameter statement would produce MB-sized error strings).
- Known trade-off: batched multi-tuple `DELETE`s on a composite pk plan as an N-branch `BitmapOr` in PostgreSQL (row-value `IN` lists have no `= ANY` form), measured ~15% slower than the previous pipelined per-row deletes at batch 1024 in a delete-heavy workload — while single-column-pk deletes are ~8.5x faster batched. Accepted for now; a per-row fallback for composite pks can be added if this shows up in practice.

Note for maintainers: `max_batch_rows` becoming effective and the visibility-latency change are arguably user-facing; I have not added `user-facing-changes` — please advise whether docs follow-up is warranted.

### Known follow-ups (intentionally not in this PR)

- **Fail-fast and richer error detail.** Statements are prepared lazily, so an incompatible target table (e.g. its unique constraint dropped after `CREATE SINK`) surfaces only at the first flush instead of at writer construction. The row-by-row fallback localizes a data error to its single offending statement, but the surfaced error still omits `DbError::detail()` (often `Failing row contains (...)`), and a persistent data error still replays the batch on every recovery. Planned: an eager single-row prepare as a startup probe and surfacing `detail()`; deferred because how much row data belongs in logs needs its own discussion.
- **Deferred-truncation protocol is a third hand-rolled copy.** `BatchingLogSinker` (file sink) and `TurbopufferLogSinker` implement the same buffer-until-commit-then-truncate contract; lifting a small trait and reusing one implementation would leave a single copy of the subtlest sink-layer invariant.
- **Commit path is invisible to sink observability** (pre-existing): `SinkWriterParam` is discarded, so the flush transaction reports no `sink_commit_duration` and no await-tree spans. Worth wiring up now that all blocking time is concentrated in one transaction.

## Checklist

- [x] I have written necessary rustdoc comments.
- [x] I have added necessary unit tests and integration tests.
- [x] I have added test labels as necessary.
- [x] My PR changes performance-critical code, so I will run (micro) benchmarks and present the results.

## Documentation

- [ ] My PR needs documentation updates.

<details>
<summary><b>Release note</b></summary>

The native Postgres sink now batches writes into multi-row statements. `max_batch_rows` (default 1024) controls the flush threshold and now takes effect; bulk upsert throughput improves ~3-4x on low-latency links and ~1.6x at 10 ms RTT compared to the previous per-row writer.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

