### PR TITLE
fix(frontend): avoid panic when webhook cannot select worker

### DIFF
--- a/src/frontend/src/webhook/mod.rs
+++ b/src/frontend/src/webhook/mod.rs
@@ -276,7 +276,12 @@ pub(super) mod handlers {
 
         let compute_client = choose_fast_insert_client(table_id, frontend_env, request_id)
             .await
-            .unwrap();
+            .map_err(|e| {
+                err(
+                    anyhow!(e).context("Failed to choose a compute node for fast insert"),
+                    StatusCode::SERVICE_UNAVAILABLE,
+                )
+            })?;
 
         Ok(WebhookTableInsertContext {
             webhook_source_info,


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What’s changed and what’s your intention?

Webhook table lookup selects a compute client for fast insert. When the streaming vnode mapping temporarily references an unavailable worker, `choose_fast_insert_client` returns a scheduler error, but the webhook path previously unwrapped that result and panicked the frontend request task.

This PR propagates the scheduler error through the existing webhook error response instead. The request now returns `503 Service Unavailable`, preserves the underlying error in the response/log, and can be retried after worker mappings recover. The shared table-info path also prevents the same scheduler failure from panicking WebSocket ingest.

## Test plan

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo check -p risingwave_frontend`
- `cargo test -p risingwave_frontend webhook --lib` (32 passed)

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] I have added necessary unit tests and integration tests.
- [ ] I have added test labels as necessary.
- [ ] My PR contains breaking changes.
- [ ] My PR changes performance-critical code.

## Documentation

- [ ] My PR needs documentation updates.