### PR TITLE
feat(storage): reinsert live SST blocks during reclaim

### DIFF
--- a/src/storage/src/store_impl.rs
+++ b/src/storage/src/store_impl.rs
@@ -792,6 +792,10 @@ impl StateStoreImpl {
                             StorageFilter::new()
                                 .with_condition(LiveSstFilter::new(live_ssts.clone())),
                         )
+                        .with_reinsertion_filter(
+                            StorageFilter::new()
+                                .with_condition(LiveSstFilter::new(live_ssts.clone())),
+                        )
                         .with_eviction_pickers(vec![Box::new(FifoPicker::new(
                             opts.data_file_cache_fifo_probation_ratio,
                         ))]);


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

This draft is the Graphite child of #26610. It adds only the Foyer reinsertion policy on top of the live-SST admission policy:

- Reuse the live SST snapshot from #26610.
- Reinsert cache entries whose decoded SST object ID is still live when FIFO reclaim selects their block.

This PR is intentionally kept as a design/WIP draft:

- A full disk followed by stopped writes reproduced unbounded circular FIFO rewrite with `live => reinsert`; upgrading Foyer to 0.22.3 did not remove that behavior.
- At fixed capacity, preserving every arbitrary `Keep` entry, continuously accepting new writes, and guaranteeing reclaim progress cannot all be guaranteed simultaneously.
- Do not merge or production-enable this policy until the reinsertion contract explicitly chooses which guarantee to weaken and the resulting behavior has deterministic coverage.

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

</details>
