### PR TITLE
refactor(sink): share BatchingLogSinker between file and postgres sinks

### DIFF
--- a/src/connector/src/sink/batching_log_sink.rs
+++ b/src/connector/src/sink/batching_log_sink.rs
@@ -1,4 +1,4 @@
-// Copyright 2024 RisingWave Labs
+// Copyright 2026 RisingWave Labs
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -13,45 +13,55 @@
 // limitations under the License.
 
 use async_trait::async_trait;
+use risingwave_common::array::StreamChunk;
 
-use crate::sink::file_sink::opendal_sink::OpenDalSinkWriter;
 use crate::sink::log_store::{LogStoreReadItem, TruncateOffset};
 use crate::sink::{LogSinker, Result, SinkLogReader};
 
-/// `BatchingLogSinker` is used for a commit-decoupled sink that supports cross-barrier batching.
-/// Currently, it is only used for file sinks, so it contains an `OpenDalSinkWriter`.
-pub struct BatchingLogSinker {
-    writer: OpenDalSinkWriter,
+/// A sink writer that buffers rows across chunks and commits them in batches, driven by
+/// [`BatchingLogSinker`].
+#[async_trait]
+pub trait BatchingSinkWriter: Send + 'static {
+    async fn write_batch(&mut self, chunk: StreamChunk) -> Result<()>;
+
+    /// Commits buffered data if a batch is ready. Returning `true` means everything received so
+    /// far is visible downstream, allowing the log store to truncate up to this point.
+    async fn try_commit(&mut self) -> Result<bool>;
+
+    /// Called at a barrier. Returns whether the barrier may be truncated, i.e. everything received
+    /// so far is committed or was never buffered. Batching across barriers by returning `false`
+    /// while data is pending is only safe for sinks guaranteed to run decoupled: on the in-memory
+    /// log store, an untruncated checkpoint barrier blocks the checkpoint from completing. Sinks
+    /// that may run non-decoupled must flush here and return `true`.
+    async fn commit_on_barrier(&mut self) -> Result<bool>;
 }
 
-impl BatchingLogSinker {
-    /// Create a log sinker with a file sink writer.
-    pub fn new(writer: OpenDalSinkWriter) -> Self {
+/// Log sinker for sinks that batch rows across chunks: an offset is truncated only once a commit
+/// has made its rows visible downstream, preserving at-least-once delivery on restart.
+pub struct BatchingLogSinker<W> {
+    writer: W,
+}
+
+impl<W> BatchingLogSinker<W> {
+    pub fn new(writer: W) -> Self {
         BatchingLogSinker { writer }
     }
 }
 
 #[async_trait]
-impl LogSinker for BatchingLogSinker {
+impl<W: BatchingSinkWriter> LogSinker for BatchingLogSinker<W> {
     async fn consume_log_and_sink(self, mut log_reader: impl SinkLogReader) -> Result<!> {
         log_reader.start_from(None).await?;
         let mut sink_writer = self.writer;
-        #[derive(Debug)]
         enum LogConsumerState {
-            /// Mark that the log consumer is not initialized yet
             Uninitialized,
-
-            /// Mark that a new epoch has begun.
             EpochBegun { curr_epoch: u64 },
-
-            /// Mark that the consumer has just received a barrier
             BarrierReceived { prev_epoch: u64 },
         }
 
         let mut state = LogConsumerState::Uninitialized;
         loop {
             let (epoch, item): (u64, LogStoreReadItem) = log_reader.next_item().await?;
-            // begin_epoch when not previously began
             state = match state {
                 LogConsumerState::Uninitialized => {
                     LogConsumerState::EpochBegun { curr_epoch: epoch }
@@ -79,8 +89,7 @@ impl LogSinker for BatchingLogSinker {
                 LogStoreReadItem::StreamChunk { chunk, chunk_id } => {
                     sink_writer.write_batch(chunk).await?;
                     if sink_writer.try_commit().await? {
-                        // The file has been successfully written and is now visible to downstream consumers.
-                        // Truncate up to this chunk, which also covers any preceding barriers.
+                        // A chunk truncation also covers all preceding barriers.
                         log_reader.truncate(TruncateOffset::Chunk { epoch, chunk_id })?;
                     }
                 }
@@ -90,11 +99,8 @@ impl LogSinker for BatchingLogSinker {
                         _ => unreachable!("epoch must have begun before handling barrier"),
                     };
 
-                    // Truncate the barrier if either:
-                    // 1. try_commit succeeded (file was written and is now visible), or
-                    // 2. there is no pending data (no active writer), so the barrier can be safely discarded.
-                    // This avoids accumulating barriers in the log store during idle periods with no data.
-                    if sink_writer.try_commit().await? || !sink_writer.has_pending_data() {
+                    // Truncating in idle periods keeps barriers from accumulating in the log store.
+                    if sink_writer.commit_on_barrier().await? {
                         log_reader.truncate(TruncateOffset::Barrier { epoch: prev_epoch })?;
                     }
 

--- a/src/connector/src/sink/file_sink/mod.rs
+++ b/src/connector/src/sink/file_sink/mod.rs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 pub mod azblob;
-pub mod batching_log_sink;
 pub mod fs;
 pub mod gcs;
 pub mod opendal_sink;

--- a/src/connector/src/sink/file_sink/opendal_sink.rs
+++ b/src/connector/src/sink/file_sink/opendal_sink.rs
@@ -19,6 +19,7 @@ use std::sync::Arc;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use anyhow::anyhow;
+use async_trait::async_trait;
 use bytes::BytesMut;
 use chrono::{TimeZone, Utc};
 use opendal::{FuturesAsyncWriter, Operator, Writer as OpendalWriter};
@@ -39,12 +40,12 @@ use uuid::Uuid;
 use with_options::WithOptions;
 
 use crate::enforce_secret::EnforceSecret;
+use crate::sink::batching_log_sink::{BatchingLogSinker, BatchingSinkWriter};
 use crate::sink::catalog::SinkEncode;
 use crate::sink::encoder::{
     JsonEncoder, JsonbHandlingMode, RowEncoder, TimeHandlingMode, TimestampHandlingMode,
     TimestamptzHandlingMode,
 };
-use crate::sink::file_sink::batching_log_sink::BatchingLogSinker;
 use crate::sink::{
     Result, Sink, SinkDecouple, SinkError, SinkFormatDesc, SinkParam, UnknownFields,
 };
@@ -123,7 +124,7 @@ pub enum EngineType {
 }
 
 impl<S: OpendalSinkBackend> Sink for FileSink<S> {
-    type LogSinker = BatchingLogSinker;
+    type LogSinker = BatchingLogSinker<OpenDalSinkWriter>;
 
     const SINK_NAME: &'static str = S::SINK_NAME;
 
@@ -255,10 +256,9 @@ enum FileWriterEnum {
     FileWriter(OpendalWriter),
 }
 
-/// Public interface exposed to `BatchingLogSinker`, used to write chunk and commit files.
-impl OpenDalSinkWriter {
-    /// This method writes a chunk.
-    pub async fn write_batch(&mut self, chunk: StreamChunk) -> Result<()> {
+#[async_trait]
+impl BatchingSinkWriter for OpenDalSinkWriter {
+    async fn write_batch(&mut self, chunk: StreamChunk) -> Result<()> {
         if self.sink_writer.is_none() {
             assert_eq!(self.current_bached_row_num, 0);
             self.create_sink_writer().await?;
@@ -267,8 +267,28 @@ impl OpenDalSinkWriter {
         Ok(())
     }
 
-    /// This method close current writer, finish writing a file and returns whether the commit is successful.
-    pub async fn commit(&mut self) -> Result<bool> {
+    async fn try_commit(&mut self) -> Result<bool> {
+        if self.can_commit() {
+            return self.commit().await;
+        }
+        Ok(false)
+    }
+
+    /// A barrier may also be truncated without a commit when no writer is active.
+    async fn commit_on_barrier(&mut self) -> Result<bool> {
+        Ok(self.try_commit().await? || self.sink_writer.is_none())
+    }
+}
+
+/// Private methods related to batching.
+impl OpenDalSinkWriter {
+    fn can_commit(&self) -> bool {
+        self.duration_seconds_since_writer_created() >= self.batching_strategy.rollover_seconds
+            || self.current_bached_row_num >= self.batching_strategy.max_row_count
+    }
+
+    /// Closes the current writer, finishing the file. Returns `false` when no writer is active.
+    async fn commit(&mut self) -> Result<bool> {
         if let Some(sink_writer) = self.sink_writer.take() {
             match sink_writer {
                 FileWriterEnum::ParquetFileWriter(w) => {
@@ -295,28 +315,6 @@ impl OpenDalSinkWriter {
             return Ok(true);
         }
         Ok(false)
-    }
-
-    /// Returns whether there is pending data (i.e., an active writer that has not been committed yet).
-    pub fn has_pending_data(&self) -> bool {
-        self.sink_writer.is_some()
-    }
-
-    // Try commit if the batching condition is met.
-    pub async fn try_commit(&mut self) -> Result<bool> {
-        if self.can_commit() {
-            return self.commit().await;
-        }
-        Ok(false)
-    }
-}
-
-/// Private methods related to batching.
-impl OpenDalSinkWriter {
-    /// Method for judging whether batch condition is met.
-    fn can_commit(&self) -> bool {
-        self.duration_seconds_since_writer_created() >= self.batching_strategy.rollover_seconds
-            || self.current_bached_row_num >= self.batching_strategy.max_row_count
     }
 
     fn path_partition_prefix(&self, duration: &Duration) -> String {

--- a/src/connector/src/sink/mod.rs
+++ b/src/connector/src/sink/mod.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 feature_gated_sink_mod!(big_query, "bigquery");
+pub mod batching_log_sink;
 pub mod boxed;
 pub mod catalog;
 feature_gated_sink_mod!(clickhouse, ClickHouse, "clickhouse");

--- a/src/connector/src/sink/postgres.rs
+++ b/src/connector/src/sink/postgres.rs
@@ -28,15 +28,13 @@ use thiserror_ext::AsReport;
 use tokio_postgres::types::Type as PgType;
 use with_options::WithOptions;
 
-use super::{
-    LogSinker, SINK_TYPE_APPEND_ONLY, SINK_TYPE_OPTION, SINK_TYPE_UPSERT, SinkError, SinkLogReader,
-};
+use super::{SINK_TYPE_APPEND_ONLY, SINK_TYPE_OPTION, SINK_TYPE_UPSERT, SinkError};
 use crate::connector_common::{
     PgConnectionConfig, PostgresExternalTable, SslMode, TcpKeepaliveConfig, create_pg_client,
 };
 use crate::enforce_secret::EnforceSecret;
 use crate::parser::scalar_adapter::{ScalarAdapter, validate_pg_type_to_rw_type};
-use crate::sink::log_store::{LogStoreReadItem, TruncateOffset};
+use crate::sink::batching_log_sink::{BatchingLogSinker, BatchingSinkWriter};
 use crate::sink::{Result, Sink, SinkParam, SinkWriterParam};
 
 pub const POSTGRES_SINK: &str = "postgres";
@@ -225,7 +223,7 @@ impl TryFrom<SinkParam> for PostgresSink {
 }
 
 impl Sink for PostgresSink {
-    type LogSinker = PostgresSinkWriter;
+    type LogSinker = BatchingLogSinker<PostgresSinkWriter>;
 
     const SINK_NAME: &'static str = POSTGRES_SINK;
 
@@ -335,14 +333,15 @@ impl Sink for PostgresSink {
     }
 
     async fn new_log_sinker(&self, writer_param: SinkWriterParam) -> Result<Self::LogSinker> {
-        PostgresSinkWriter::new(
+        let writer = PostgresSinkWriter::new(
             self.config.clone(),
             self.schema.clone(),
             self.pk_indices.clone(),
             self.is_append_only,
             &writer_param,
         )
-        .await
+        .await?;
+        Ok(BatchingLogSinker::new(writer))
     }
 }
 
@@ -711,18 +710,29 @@ impl PostgresSinkWriter {
         transaction.commit().await?;
         Ok(())
     }
+}
 
-    /// Buffers the chunk, flushing once enough rows have been absorbed. Returns whether a flush
-    /// happened.
-    async fn write_chunk(&mut self, chunk: &StreamChunk) -> Result<bool> {
+#[async_trait]
+impl BatchingSinkWriter for PostgresSinkWriter {
+    async fn write_batch(&mut self, chunk: StreamChunk) -> Result<()> {
         self.pending
-            .absorb(chunk, &self.key_indices, &self.schema_types);
+            .absorb(&chunk, &self.key_indices, &self.schema_types);
+        Ok(())
+    }
+
+    async fn try_commit(&mut self) -> Result<bool> {
         if self.pending.absorbed() >= self.max_batch_rows {
             self.flush().await?;
             Ok(true)
         } else {
             Ok(false)
         }
+    }
+
+    /// Barriers bound the sink's visibility latency, so they always flush.
+    async fn commit_on_barrier(&mut self) -> Result<bool> {
+        self.flush().await?;
+        Ok(true)
     }
 }
 
@@ -765,30 +775,6 @@ async fn execute_batches(
     });
     futures::future::try_join_all(executions).await?;
     Ok(())
-}
-
-#[async_trait]
-impl LogSinker for PostgresSinkWriter {
-    async fn consume_log_and_sink(mut self, mut log_reader: impl SinkLogReader) -> Result<!> {
-        log_reader.start_from(None).await?;
-        loop {
-            let (epoch, item) = log_reader.next_item().await?;
-            match item {
-                LogStoreReadItem::StreamChunk { chunk, chunk_id } => {
-                    // Rows are buffered across chunks, so an offset may only be truncated once the
-                    // flush that commits its rows has succeeded. Offsets of chunks that are still
-                    // buffered are covered by a later truncation.
-                    if self.write_chunk(&chunk).await? {
-                        log_reader.truncate(TruncateOffset::Chunk { epoch, chunk_id })?;
-                    }
-                }
-                LogStoreReadItem::Barrier { .. } => {
-                    self.flush().await?;
-                    log_reader.truncate(TruncateOffset::Barrier { epoch })?;
-                }
-            }
-        }
-    }
 }
 
 /// `($1, $2), ($3, $4), ...`


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

Follow-up to #26671, now merged; this targets `main` directly. Pure refactor — no behavior change.

`BatchingLogSinker` — the buffer-until-commit-then-truncate log sinker whose invariant is "an offset may be truncated only once a commit has made its rows visible downstream" — was hardcoded to `OpenDalSinkWriter`, and #26671 added a second hand-rolled copy of the same loop to the postgres sink. This PR generalizes it over a small `BatchingSinkWriter` trait (`write_batch` / `try_commit` / `commit_on_barrier`), moves it from `file_sink/` up to `sink/`, and makes the postgres sink use it, deleting the hand-rolled loop.

Per-sink barrier semantics live in a single required method: `commit_on_barrier()` returns whether the barrier may be truncated, i.e. everything received so far is committed or was never buffered. File sinks keep batching across barriers — their impl is the previous inherent methods verbatim — which is only safe under sink decoupling and is now documented as such on the trait; the postgres sink flushes on every barrier, bounding visibility latency by the barrier interval as before.

### Verification

- Unit tests and clippy clean.
- The file-sink barrier decision is the previous expression verbatim (same short-circuit, same evaluation order), and the postgres arm reproduces the deleted loop exactly (barrier epoch, truncation conditions, flush timing checked case by case in review).
- `e2e_test/sink/postgres_sink.slt` (including the `max_batch_rows='64'` batching section) and the file-sink suite pass on a local cluster built from the final tree.
- Cross-barrier batching checked by hand earlier on this branch: with `rollover_seconds=10`, files stay open across several barriers and commit after the rollover window with exact row counts.

## Known follow-ups (separate PRs)

- Fail fast on incompatible postgres target tables: an `EXPLAIN`-based probe at writer construction (prepared in review; needs to also cover the DELETE statement's privileges and document its limits — DEFERRABLE arbiters and read-only targets are not detectable by `EXPLAIN`), plus possibly the same check at `validate()` time for a DDL-time error.
- Barrier metadata (`is_checkpoint` / `is_stop`) and an abort/cleanup hook on `BatchingSinkWriter` — both needed to unify `TurbopufferLogSinker`'s linger-timer variant onto this trait.
- e2e coverage for the postgres sink on the default (kv log store) path: `e2e_test/sink/postgres_sink.slt` currently pins `sink_decouple = false` for the whole file.

## Checklist

- [x] I have written necessary rustdoc comments.
- [x] I have added necessary unit tests and integration tests.
- [x] I have added test labels as necessary.
- [ ] My PR changes performance-critical code, so I will run (micro) benchmarks and present the results.

## Documentation

- [ ] My PR needs documentation updates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Standardized batching and commit handling across file and PostgreSQL sinks.
  * Improved barrier-time processing with more reliable flushing, including when no writer is active.
  * Expanded batching support for consistent behavior across supported storage backends.
  * Improved coordination between buffered writes, commit thresholds, and barrier-triggered flushes.
  * Improved PostgreSQL sink connection identification for easier operational monitoring.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->