### PR TITLE
feat(sink): fail fast on incompatible postgres target tables

### DIFF
--- a/src/connector/src/sink/batching_log_sink.rs
+++ b/src/connector/src/sink/batching_log_sink.rs
@@ -1,4 +1,4 @@
-// Copyright 2024 RisingWave Labs
+// Copyright 2026 RisingWave Labs
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -13,45 +13,55 @@
 // limitations under the License.
 
 use async_trait::async_trait;
+use risingwave_common::array::StreamChunk;
 
-use crate::sink::file_sink::opendal_sink::OpenDalSinkWriter;
 use crate::sink::log_store::{LogStoreReadItem, TruncateOffset};
 use crate::sink::{LogSinker, Result, SinkLogReader};
 
-/// `BatchingLogSinker` is used for a commit-decoupled sink that supports cross-barrier batching.
-/// Currently, it is only used for file sinks, so it contains an `OpenDalSinkWriter`.
-pub struct BatchingLogSinker {
-    writer: OpenDalSinkWriter,
+/// A sink writer that buffers rows across chunks and commits them in batches, driven by
+/// [`BatchingLogSinker`].
+#[async_trait]
+pub trait BatchingSinkWriter: Send + 'static {
+    async fn write_batch(&mut self, chunk: StreamChunk) -> Result<()>;
+
+    /// Commits buffered data if a batch is ready. Returning `true` means everything received so
+    /// far is visible downstream, allowing the log store to truncate up to this point.
+    async fn try_commit(&mut self) -> Result<bool>;
+
+    /// Called at a barrier. Returns whether the barrier may be truncated, i.e. everything received
+    /// so far is committed or was never buffered. Batching across barriers by returning `false`
+    /// while data is pending is only safe for sinks guaranteed to run decoupled: on the in-memory
+    /// log store, an untruncated checkpoint barrier blocks the checkpoint from completing. Sinks
+    /// that may run non-decoupled must flush here and return `true`.
+    async fn commit_on_barrier(&mut self) -> Result<bool>;
 }
 
-impl BatchingLogSinker {
-    /// Create a log sinker with a file sink writer.
-    pub fn new(writer: OpenDalSinkWriter) -> Self {
+/// Log sinker for sinks that batch rows across chunks: an offset is truncated only once a commit
+/// has made its rows visible downstream, preserving at-least-once delivery on restart.
+pub struct BatchingLogSinker<W> {
+    writer: W,
+}
+
+impl<W> BatchingLogSinker<W> {
+    pub fn new(writer: W) -> Self {
         BatchingLogSinker { writer }
     }
 }
 
 #[async_trait]
-impl LogSinker for BatchingLogSinker {
+impl<W: BatchingSinkWriter> LogSinker for BatchingLogSinker<W> {
     async fn consume_log_and_sink(self, mut log_reader: impl SinkLogReader) -> Result<!> {
         log_reader.start_from(None).await?;
         let mut sink_writer = self.writer;
-        #[derive(Debug)]
         enum LogConsumerState {
-            /// Mark that the log consumer is not initialized yet
             Uninitialized,
-
-            /// Mark that a new epoch has begun.
             EpochBegun { curr_epoch: u64 },
-
-            /// Mark that the consumer has just received a barrier
             BarrierReceived { prev_epoch: u64 },
         }
 
         let mut state = LogConsumerState::Uninitialized;
         loop {
             let (epoch, item): (u64, LogStoreReadItem) = log_reader.next_item().await?;
-            // begin_epoch when not previously began
             state = match state {
                 LogConsumerState::Uninitialized => {
                     LogConsumerState::EpochBegun { curr_epoch: epoch }
@@ -79,8 +89,7 @@ impl LogSinker for BatchingLogSinker {
                 LogStoreReadItem::StreamChunk { chunk, chunk_id } => {
                     sink_writer.write_batch(chunk).await?;
                     if sink_writer.try_commit().await? {
-                        // The file has been successfully written and is now visible to downstream consumers.
-                        // Truncate up to this chunk, which also covers any preceding barriers.
+                        // A chunk truncation also covers all preceding barriers.
                         log_reader.truncate(TruncateOffset::Chunk { epoch, chunk_id })?;
                     }
                 }
@@ -90,11 +99,8 @@ impl LogSinker for BatchingLogSinker {
                         _ => unreachable!("epoch must have begun before handling barrier"),
                     };
 
-                    // Truncate the barrier if either:
-                    // 1. try_commit succeeded (file was written and is now visible), or
-                    // 2. there is no pending data (no active writer), so the barrier can be safely discarded.
-                    // This avoids accumulating barriers in the log store during idle periods with no data.
-                    if sink_writer.try_commit().await? || !sink_writer.has_pending_data() {
+                    // Truncating in idle periods keeps barriers from accumulating in the log store.
+                    if sink_writer.commit_on_barrier().await? {
                         log_reader.truncate(TruncateOffset::Barrier { epoch: prev_epoch })?;
                     }
 

--- a/src/connector/src/sink/file_sink/mod.rs
+++ b/src/connector/src/sink/file_sink/mod.rs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 pub mod azblob;
-pub mod batching_log_sink;
 pub mod fs;
 pub mod gcs;
 pub mod opendal_sink;

--- a/src/connector/src/sink/file_sink/opendal_sink.rs
+++ b/src/connector/src/sink/file_sink/opendal_sink.rs
@@ -19,6 +19,7 @@ use std::sync::Arc;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use anyhow::anyhow;
+use async_trait::async_trait;
 use bytes::BytesMut;
 use chrono::{TimeZone, Utc};
 use opendal::{FuturesAsyncWriter, Operator, Writer as OpendalWriter};
@@ -39,12 +40,12 @@ use uuid::Uuid;
 use with_options::WithOptions;
 
 use crate::enforce_secret::EnforceSecret;
+use crate::sink::batching_log_sink::{BatchingLogSinker, BatchingSinkWriter};
 use crate::sink::catalog::SinkEncode;
 use crate::sink::encoder::{
     JsonEncoder, JsonbHandlingMode, RowEncoder, TimeHandlingMode, TimestampHandlingMode,
     TimestamptzHandlingMode,
 };
-use crate::sink::file_sink::batching_log_sink::BatchingLogSinker;
 use crate::sink::{
     Result, Sink, SinkDecouple, SinkError, SinkFormatDesc, SinkParam, UnknownFields,
 };
@@ -123,7 +124,7 @@ pub enum EngineType {
 }
 
 impl<S: OpendalSinkBackend> Sink for FileSink<S> {
-    type LogSinker = BatchingLogSinker;
+    type LogSinker = BatchingLogSinker<OpenDalSinkWriter>;
 
     const SINK_NAME: &'static str = S::SINK_NAME;
 
@@ -255,10 +256,9 @@ enum FileWriterEnum {
     FileWriter(OpendalWriter),
 }
 
-/// Public interface exposed to `BatchingLogSinker`, used to write chunk and commit files.
-impl OpenDalSinkWriter {
-    /// This method writes a chunk.
-    pub async fn write_batch(&mut self, chunk: StreamChunk) -> Result<()> {
+#[async_trait]
+impl BatchingSinkWriter for OpenDalSinkWriter {
+    async fn write_batch(&mut self, chunk: StreamChunk) -> Result<()> {
         if self.sink_writer.is_none() {
             assert_eq!(self.current_bached_row_num, 0);
             self.create_sink_writer().await?;
@@ -267,8 +267,28 @@ impl OpenDalSinkWriter {
         Ok(())
     }
 
-    /// This method close current writer, finish writing a file and returns whether the commit is successful.
-    pub async fn commit(&mut self) -> Result<bool> {
+    async fn try_commit(&mut self) -> Result<bool> {
+        if self.can_commit() {
+            return self.commit().await;
+        }
+        Ok(false)
+    }
+
+    /// A barrier may also be truncated without a commit when no writer is active.
+    async fn commit_on_barrier(&mut self) -> Result<bool> {
+        Ok(self.try_commit().await? || self.sink_writer.is_none())
+    }
+}
+
+/// Private methods related to batching.
+impl OpenDalSinkWriter {
+    fn can_commit(&self) -> bool {
+        self.duration_seconds_since_writer_created() >= self.batching_strategy.rollover_seconds
+            || self.current_bached_row_num >= self.batching_strategy.max_row_count
+    }
+
+    /// Closes the current writer, finishing the file. Returns `false` when no writer is active.
+    async fn commit(&mut self) -> Result<bool> {
         if let Some(sink_writer) = self.sink_writer.take() {
             match sink_writer {
                 FileWriterEnum::ParquetFileWriter(w) => {
@@ -295,28 +315,6 @@ impl OpenDalSinkWriter {
             return Ok(true);
         }
         Ok(false)
-    }
-
-    /// Returns whether there is pending data (i.e., an active writer that has not been committed yet).
-    pub fn has_pending_data(&self) -> bool {
-        self.sink_writer.is_some()
-    }
-
-    // Try commit if the batching condition is met.
-    pub async fn try_commit(&mut self) -> Result<bool> {
-        if self.can_commit() {
-            return self.commit().await;
-        }
-        Ok(false)
-    }
-}
-
-/// Private methods related to batching.
-impl OpenDalSinkWriter {
-    /// Method for judging whether batch condition is met.
-    fn can_commit(&self) -> bool {
-        self.duration_seconds_since_writer_created() >= self.batching_strategy.rollover_seconds
-            || self.current_bached_row_num >= self.batching_strategy.max_row_count
     }
 
     fn path_partition_prefix(&self, duration: &Duration) -> String {

--- a/src/connector/src/sink/mod.rs
+++ b/src/connector/src/sink/mod.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 feature_gated_sink_mod!(big_query, "bigquery");
+pub mod batching_log_sink;
 pub mod boxed;
 pub mod catalog;
 feature_gated_sink_mod!(clickhouse, ClickHouse, "clickhouse");

--- a/src/connector/src/sink/postgres.rs
+++ b/src/connector/src/sink/postgres.rs
@@ -28,15 +28,13 @@ use thiserror_ext::AsReport;
 use tokio_postgres::types::Type as PgType;
 use with_options::WithOptions;
 
-use super::{
-    LogSinker, SINK_TYPE_APPEND_ONLY, SINK_TYPE_OPTION, SINK_TYPE_UPSERT, SinkError, SinkLogReader,
-};
+use super::{SINK_TYPE_APPEND_ONLY, SINK_TYPE_OPTION, SINK_TYPE_UPSERT, SinkError};
 use crate::connector_common::{
     PgConnectionConfig, PostgresExternalTable, SslMode, TcpKeepaliveConfig, create_pg_client,
 };
 use crate::enforce_secret::EnforceSecret;
 use crate::parser::scalar_adapter::{ScalarAdapter, validate_pg_type_to_rw_type};
-use crate::sink::log_store::{LogStoreReadItem, TruncateOffset};
+use crate::sink::batching_log_sink::{BatchingLogSinker, BatchingSinkWriter};
 use crate::sink::{Result, Sink, SinkParam, SinkWriterParam};
 
 pub const POSTGRES_SINK: &str = "postgres";
@@ -225,7 +223,7 @@ impl TryFrom<SinkParam> for PostgresSink {
 }
 
 impl Sink for PostgresSink {
-    type LogSinker = PostgresSinkWriter;
+    type LogSinker = BatchingLogSinker<PostgresSinkWriter>;
 
     const SINK_NAME: &'static str = POSTGRES_SINK;
 
@@ -335,14 +333,15 @@ impl Sink for PostgresSink {
     }
 
     async fn new_log_sinker(&self, writer_param: SinkWriterParam) -> Result<Self::LogSinker> {
-        PostgresSinkWriter::new(
+        let writer = PostgresSinkWriter::new(
             self.config.clone(),
             self.schema.clone(),
             self.pk_indices.clone(),
             self.is_append_only,
             &writer_param,
         )
-        .await
+        .await?;
+        Ok(BatchingLogSinker::new(writer))
     }
 }
 
@@ -711,18 +710,29 @@ impl PostgresSinkWriter {
         transaction.commit().await?;
         Ok(())
     }
+}
 
-    /// Buffers the chunk, flushing once enough rows have been absorbed. Returns whether a flush
-    /// happened.
-    async fn write_chunk(&mut self, chunk: &StreamChunk) -> Result<bool> {
+#[async_trait]
+impl BatchingSinkWriter for PostgresSinkWriter {
+    async fn write_batch(&mut self, chunk: StreamChunk) -> Result<()> {
         self.pending
-            .absorb(chunk, &self.key_indices, &self.schema_types);
+            .absorb(&chunk, &self.key_indices, &self.schema_types);
+        Ok(())
+    }
+
+    async fn try_commit(&mut self) -> Result<bool> {
         if self.pending.absorbed() >= self.max_batch_rows {
             self.flush().await?;
             Ok(true)
         } else {
             Ok(false)
         }
+    }
+
+    /// Barriers bound the sink's visibility latency, so they always flush.
+    async fn commit_on_barrier(&mut self) -> Result<bool> {
+        self.flush().await?;
+        Ok(true)
     }
 }
 
@@ -765,30 +775,6 @@ async fn execute_batches(
     });
     futures::future::try_join_all(executions).await?;
     Ok(())
-}
-
-#[async_trait]
-impl LogSinker for PostgresSinkWriter {
-    async fn consume_log_and_sink(mut self, mut log_reader: impl SinkLogReader) -> Result<!> {
-        log_reader.start_from(None).await?;
-        loop {
-            let (epoch, item) = log_reader.next_item().await?;
-            match item {
-                LogStoreReadItem::StreamChunk { chunk, chunk_id } => {
-                    // Rows are buffered across chunks, so an offset may only be truncated once the
-                    // flush that commits its rows has succeeded. Offsets of chunks that are still
-                    // buffered are covered by a later truncation.
-                    if self.write_chunk(&chunk).await? {
-                        log_reader.truncate(TruncateOffset::Chunk { epoch, chunk_id })?;
-                    }
-                }
-                LogStoreReadItem::Barrier { .. } => {
-                    self.flush().await?;
-                    log_reader.truncate(TruncateOffset::Barrier { epoch })?;
-                }
-            }
-        }
-    }
 }
 
 /// `($1, $2), ($3, $4), ...`

--- a/src/connector/src/sink/postgres.rs
+++ b/src/connector/src/sink/postgres.rs
@@ -60,6 +60,9 @@ const CHECK_FOREIGN_KEY_SQL: &str = r#"
     )
 "#;
 
+const CHECK_READ_ONLY_SQL: &str =
+    "SELECT pg_is_in_recovery() OR current_setting('transaction_read_only') = 'on'";
+
 #[serde_as]
 #[derive(Clone, Debug, Deserialize, WithOptions)]
 pub struct PostgresConfig {
@@ -139,6 +142,29 @@ async fn ensure_no_foreign_key_with_client(
     if has_foreign_key {
         return Err(SinkError::Config(anyhow!(
             "Postgres sink does not support target table \"{}\".\"{}\" with foreign key constraints. Please remove foreign key constraints from the target table or choose a different sink table.",
+            schema,
+            table,
+        )));
+    }
+
+    Ok(())
+}
+
+/// `EXPLAIN` is exempt from PostgreSQL's read-only check, so the probe cannot catch a reader.
+async fn ensure_target_writable(
+    client: &tokio_postgres::Client,
+    schema: &str,
+    table: &str,
+) -> Result<()> {
+    let read_only = client
+        .query_one(CHECK_READ_ONLY_SQL, &[])
+        .await
+        .context("failed to check whether the target database accepts writes")?
+        .get::<_, bool>(0);
+
+    if read_only {
+        return Err(SinkError::Config(anyhow!(
+            "Postgres sink cannot write to target table \"{}\".\"{}\": the connection is read-only (hot standby, or `transaction_read_only` set to `on`). Please point the sink at an endpoint that accepts writes.",
             schema,
             table,
         )));
@@ -487,6 +513,7 @@ impl PostgresSinkWriter {
         let client = create_pg_client(&pg_conn, tcp_keepalive, Some(&application_name)).await?;
 
         ensure_no_foreign_key_with_client(&client, &config.schema, &config.table).await?;
+        ensure_target_writable(&client, &config.schema, &config.table).await?;
 
         // Rewrite schema types for serialization
         let schema_types = {
@@ -537,7 +564,7 @@ impl PostgresSinkWriter {
             }
         };
 
-        let writer = Self {
+        let mut writer = Self {
             client,
             schema,
             schema_name: config.schema,
@@ -550,7 +577,38 @@ impl PostgresSinkWriter {
             delete_statements: HashMap::new(),
             pending,
         };
+        // Fails fast on unparsable SQL, and pre-warms a size the batch path really uses:
+        // power-of-two splitting ends a batch at a single row.
+        writer.cached_statement(writer.write_kind(), 1).await?;
+        writer.probe_target_table(writer.write_kind()).await?;
+        if !is_append_only {
+            writer.cached_statement(StatementKind::Delete, 1).await?;
+            writer.probe_target_table(StatementKind::Delete).await?;
+        }
         Ok(writer)
+    }
+
+    /// Plans a single-row statement of `kind` via `EXPLAIN`. Planning resolves the `ON CONFLICT`
+    /// arbiter and runs executor-start privilege checks, both invisible to `prepare`, so an
+    /// incompatible or under-privileged target fails at construction, not at the first flush.
+    /// Executor-init-only checks (e.g. a `DEFERRABLE` arbiter) still surface at the first flush.
+    async fn probe_target_table(&self, kind: StatementKind) -> Result<()> {
+        let sql = format!("EXPLAIN {}", self.create_sql(kind, 1));
+        let nulls = (0..self.params_per_tuple(kind)).map(|_| PgDatum::None);
+        self.client
+            .execute_raw(&sql, nulls)
+            .await
+            .with_context(|| {
+                format!(
+                    "failed to plan the {} statement against the target table",
+                    kind.as_str()
+                )
+            })?;
+        Ok(())
+    }
+
+    fn params_per_tuple(&self, kind: StatementKind) -> usize {
+        params_per_tuple(kind, self.schema.len(), self.key_indices.len())
     }
 
     fn write_kind(&self) -> StatementKind {
@@ -620,11 +678,7 @@ impl PostgresSinkWriter {
         kind: StatementKind,
         rows: &'a [PgRow],
     ) -> Result<Vec<(tokio_postgres::Statement, &'a [PgRow])>> {
-        let params_per_tuple = match kind {
-            StatementKind::Insert | StatementKind::Upsert => self.schema.len(),
-            StatementKind::Delete => self.key_indices.len(),
-        };
-        let cap = tuples_per_statement(self.max_batch_rows, params_per_tuple);
+        let cap = tuples_per_statement(self.max_batch_rows, self.params_per_tuple(kind));
         let mut batches = Vec::new();
         for tuples in split_power_of_two(rows, cap) {
             let statement = self.cached_statement(kind, tuples.len()).await?;
@@ -733,6 +787,13 @@ impl BatchingSinkWriter for PostgresSinkWriter {
     async fn commit_on_barrier(&mut self) -> Result<bool> {
         self.flush().await?;
         Ok(true)
+    }
+}
+
+fn params_per_tuple(kind: StatementKind, schema_len: usize, n_key_columns: usize) -> usize {
+    match kind {
+        StatementKind::Insert | StatementKind::Upsert => schema_len,
+        StatementKind::Delete => n_key_columns,
     }
 }
 
@@ -1002,6 +1063,35 @@ mod tests {
                 r#"INSERT INTO "test_schema"."test_table" ("user_id", "client_id") VALUES ($1, $2), ($3, $4) on conflict ("user_id", "client_id") do nothing"#
             ]],
         );
+    }
+
+    /// The probe binds `params_per_tuple` NULLs against the single-row SQL, so the two must agree.
+    #[test]
+    fn test_params_per_tuple_matches_placeholders() {
+        let schema = test_schema();
+        let key_indices = [1];
+        let statements = [
+            (
+                StatementKind::Insert,
+                create_insert_sql(&schema, "test_schema", "test_table", 1),
+            ),
+            (
+                StatementKind::Upsert,
+                create_upsert_sql(&schema, "test_schema", "test_table", &key_indices, 1),
+            ),
+            (
+                StatementKind::Delete,
+                create_delete_sql(&schema, "test_schema", "test_table", &key_indices, 1),
+            ),
+        ];
+        for (kind, sql) in statements {
+            assert_eq!(
+                sql.matches('$').count(),
+                params_per_tuple(kind, schema.len(), key_indices.len()),
+                "{} statement: {sql}",
+                kind.as_str()
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

Stacked on #26677 (which is stacked on #26671).

Statements are prepared lazily since #26671, so an incompatible target table — a unique constraint dropped after `CREATE SINK`, a role missing a DML privilege, a read-only endpoint — only surfaced at the first flush, with data already flowing through the sink. The postgres writer constructor now fails fast:

- **Read-only targets are rejected** (`pg_is_in_recovery()` / `transaction_read_only = on`, e.g. an RDS/Aurora reader endpoint). This needs its own check because `EXPLAIN` is exempt from PostgreSQL's read-only enforcement.
- **A single-row write — and, for upsert sinks, a single-row delete — is planned via `EXPLAIN` with NULL binds.** Planning resolves the `ON CONFLICT` arbiter index and runs executor-start privilege checks; both are invisible to `prepare`, which performs parse analysis only (verified at the protocol level: `PREPARE` of a delete succeeds without the DELETE privilege, `EXPLAIN` of it fails; `PREPARE` of an upsert succeeds on a table without a matching unique index, `EXPLAIN` fails with SQLSTATE 42P10). Nothing is executed: `EXPLAIN` without `ANALYZE` writes no rows.
- The single-row statements are prepared and cached: parse-level fail-fast, and size 1 is a genuine tail size of the power-of-two batch path.

The probe's bind arity now comes from a shared `params_per_tuple(kind)` (also used by `prepare_batches`), with a unit test pinning it to the `$n` placeholder count of each statement kind.

Documented limit: executor-init-only checks (e.g. a `DEFERRABLE` arbiter) are not exercised by `EXPLAIN` and still surface at the first flush.

### Verification

- Unit tests (10, including the new placeholder-arity test) and clippy clean.
- Probe mechanics verified against PostgreSQL 18.4 at the protocol level (extended-protocol `EXPLAIN` with NULL binds plans and executes nothing; arbiter shown in the plan; privilege and read-only behaviors as described above).
- `e2e_test/sink/postgres_sink.slt` (append-only + upsert + batching sections) passes on a local cluster with the probes active at every writer startup.
- Read-only fail-fast end to end: a sink created against a database with `default_transaction_read_only = on` fails writer construction with the new error and retries with backoff; after `ALTER DATABASE ... SET default_transaction_read_only = off`, the sink recovers on its own and drains the backlog (row verified present in the target table).
- Fail-fast end to end (manual, earlier on this stack): swapping the target table's pk to a different column and triggering `RECOVER` makes writer construction fail with `failed to plan the upsert statement against the target table: ... there is no unique or exclusion constraint matching the ON CONFLICT specification` before any row is written; restoring the pk and recovering resumes the sink and drains the backlog.

## Known follow-ups (separate PRs)

- Run the same `EXPLAIN` probe in `validate()` as well, so mismatches knowable at DDL time fail `CREATE SINK` instead of sink startup.
- A `condeferrable` check in `validate()` to close the `DEFERRABLE`-arbiter gap at DDL time.

## Checklist

- [x] I have written necessary rustdoc comments.
- [x] I have added necessary unit tests and integration tests.
- [x] I have added test labels as necessary.
- [ ] My PR changes performance-critical code, so I will run (micro) benchmarks and present the results.

## Documentation

- [ ] My PR needs documentation updates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
