### PR TITLE
fix(sink): require sink decoupling in the file sink impl itself

### DIFF
--- a/e2e_test/sink/append_only_sink.slt
+++ b/e2e_test/sink/append_only_sink.slt
@@ -121,7 +121,7 @@ set database to dev;
 statement ok
 set sink_decouple=false;
 
-statement error
+statement error File sink can only be created with sink_decouple enabled
 CREATE SINK file_sink
 FROM
   t
@@ -134,13 +134,34 @@ WITH
   type = 'append-only',
   force_append_only='true'
 ) FORMAT PLAIN ENCODE PARQUET(force_append_only='true');
-----
-db error: ERROR: Failed to run the query
 
-Caused by:
-  Not supported: File sink can only be created with sink_decouple enabled.
-HINT: Please run `set sink_decouple = true` first.
+statement error File sink can only be created with sink_decouple enabled
+CREATE SINK file_sink
+FROM
+  t
+WITH
+(
+  connector = 'gcs',
+  gcs.bucket_name = 'test',
+  gcs.credential = 'test',
+  gcs.path = '',
+  type = 'append-only',
+  force_append_only='true'
+) FORMAT PLAIN ENCODE PARQUET(force_append_only='true');
 
+statement error File sink can only be created with sink_decouple enabled
+CREATE SINK file_sink
+FROM
+  t
+WITH
+(
+  connector = 'snowflake',
+  s3.region_name = 'test',
+  s3.bucket_name = 'test',
+  s3.path = '',
+  type = 'append-only',
+  force_append_only='true'
+) FORMAT PLAIN ENCODE PARQUET(force_append_only='true');
 
 statement ok
 drop sink s1

--- a/src/connector/src/sink/catalog/desc.rs
+++ b/src/connector/src/sink/catalog/desc.rs
@@ -23,11 +23,6 @@ use risingwave_pb::secret::PbSecretRef;
 use risingwave_pb::stream_plan::PbSinkDesc;
 
 use super::{SinkCatalog, SinkFormatDesc, SinkId, SinkType};
-use crate::sink::CONNECTOR_TYPE_KEY;
-use crate::sink::file_sink::azblob::AZBLOB_SINK;
-use crate::sink::file_sink::fs::FS_SINK;
-use crate::sink::file_sink::s3::S3_SINK;
-use crate::sink::file_sink::webhdfs::WEBHDFS_SINK;
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct SinkDesc {
@@ -154,17 +149,5 @@ impl SinkDesc {
             extra_partition_col_idx: self.extra_partition_col_idx.map(|idx| idx as u64),
             secret_refs: self.secret_refs.clone(),
         }
-    }
-
-    pub fn is_file_sink(&self) -> bool {
-        self.properties
-            .get(CONNECTOR_TYPE_KEY)
-            .map(|s| {
-                s.eq_ignore_ascii_case(FS_SINK)
-                    || s.eq_ignore_ascii_case(AZBLOB_SINK)
-                    || s.eq_ignore_ascii_case(S3_SINK)
-                    || s.eq_ignore_ascii_case(WEBHDFS_SINK)
-            })
-            .unwrap_or(false)
     }
 }

--- a/src/connector/src/sink/file_sink/opendal_sink.rs
+++ b/src/connector/src/sink/file_sink/opendal_sink.rs
@@ -45,7 +45,9 @@ use crate::sink::encoder::{
     TimestamptzHandlingMode,
 };
 use crate::sink::file_sink::batching_log_sink::BatchingLogSinker;
-use crate::sink::{Result, Sink, SinkError, SinkFormatDesc, SinkParam, UnknownFields};
+use crate::sink::{
+    Result, Sink, SinkDecouple, SinkError, SinkFormatDesc, SinkParam, UnknownFields,
+};
 use crate::source::TryFromBTreeMap;
 use crate::with_options::WithOptions;
 
@@ -127,6 +129,17 @@ impl<S: OpendalSinkBackend> Sink for FileSink<S> {
 
     fn validate_unknown_fields(&self) -> Result<()> {
         crate::sink::validate_sink_unknown_fields(&self.unknown_fields)
+    }
+
+    /// A file is committed only once the batching strategy is met, so an untruncated barrier
+    /// would block the checkpoint forever on the non-decoupled in-memory log store.
+    fn is_sink_decouple(user_specified: &SinkDecouple) -> Result<bool> {
+        match user_specified {
+            SinkDecouple::Default | SinkDecouple::Enable => Ok(true),
+            SinkDecouple::Disable => Err(SinkError::Config(anyhow!(
+                "File sink can only be created with sink_decouple enabled. Please run `set sink_decouple = true` first."
+            ))),
+        }
     }
 
     async fn validate(&self) -> Result<()> {
@@ -545,4 +558,30 @@ pub enum PathPartitionPrefix {
     Month = 2,
     #[serde(alias = "hour")]
     Hour = 3,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::sink::file_sink::fs::FsSink;
+    use crate::sink::file_sink::gcs::GcsSink;
+    use crate::sink::file_sink::s3::{S3Sink, SnowflakeSink};
+
+    #[test]
+    fn test_requires_sink_decouple() {
+        fn assert_requires_decouple<S: OpendalSinkBackend>() {
+            assert!(FileSink::<S>::is_sink_decouple(&SinkDecouple::Default).unwrap());
+            assert!(FileSink::<S>::is_sink_decouple(&SinkDecouple::Enable).unwrap());
+            let err = FileSink::<S>::is_sink_decouple(&SinkDecouple::Disable).unwrap_err();
+            assert!(
+                err.to_string()
+                    .contains("File sink can only be created with sink_decouple enabled")
+            );
+        }
+
+        assert_requires_decouple::<FsSink>();
+        assert_requires_decouple::<GcsSink>();
+        assert_requires_decouple::<S3Sink>();
+        assert_requires_decouple::<SnowflakeSink>();
+    }
 }

--- a/src/frontend/src/optimizer/plan_node/stream_sink.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_sink.rs
@@ -634,29 +634,17 @@ impl StreamSink {
                 .into());
             }
         };
-        let hint_string =
-            |expected: bool| format!("Please run `set sink_decouple = {}` first.", expected);
-        if !sink_decouple {
-            // For file sink, it must have sink_decouple turned on.
-            if sink_desc.is_file_sink() {
-                return Err(ErrorCode::NotSupported(
-                    "File sink can only be created with sink_decouple enabled.".to_owned(),
-                    hint_string(true),
-                )
-                .into());
-            }
-
-            if sink_desc.is_exactly_once.is_none()
-                && let Some(connector) = sink_desc.properties.get(CONNECTOR_TYPE_KEY)
-            {
-                let connector_type = connector.to_lowercase();
-                if connector_type == ICEBERG_SINK {
-                    // iceberg sink defaults to exactly once
-                    // However, when sink_decouple is disabled, we enforce it to false.
-                    sink_desc
-                        .properties
-                        .insert("is_exactly_once".to_owned(), "false".to_owned());
-                }
+        if !sink_decouple
+            && sink_desc.is_exactly_once.is_none()
+            && let Some(connector) = sink_desc.properties.get(CONNECTOR_TYPE_KEY)
+        {
+            let connector_type = connector.to_lowercase();
+            if connector_type == ICEBERG_SINK {
+                // iceberg sink defaults to exactly once
+                // However, when sink_decouple is disabled, we enforce it to false.
+                sink_desc
+                    .properties
+                    .insert("is_exactly_once".to_owned(), "false".to_owned());
             }
         }
         let log_store_type = if sink_decouple {


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

The rule "a file sink must run decoupled" was expressed as a connector-name whitelist in the frontend catalog — `SinkDesc::is_file_sink()` listing `fs` / `azblob` / `s3` / `webhdfs` — and checked in `StreamSink::create`. `for_all_sinks!` registers six `FileSink<_>` backends over the same OpenDAL writer, so `gcs` and `snowflake` were missing from that list.

The rule is load-bearing. `OpenDalSinkWriter` commits a file only once its batching strategy is met (10s rollover / 10240 rows) and truncates the log store only after a commit. On the non-decoupled in-memory log store, an untruncated checkpoint barrier parks `BoundedInMemLogStoreReader` in `AwaitingTruncate` (`next_item()` returns `pending()` forever), so the sink never gets another chance to commit and the checkpoint never completes. Verified locally against a `FileSink<_>` sink created with `set sink_decouple = false`: `FLUSH` hangs indefinitely, unrelated DDL on the same cluster stops making progress, and nothing is ever written to the target; with decoupling enabled the same sink flushes in 0.1s and lands its files after the rollover.

Rather than adding the two names to the list, this moves the rule to where the property lives: `is_sink_decouple` on `impl<S: OpendalSinkBackend> Sink for FileSink<S>`. One generic impl covers all six backends and any backend added later, so the list can't drift out of sync again. The whitelist and its frontend special case are deleted. This mirrors the turbopuffer sink, which has the same requirement and already handles it this way.

The frontend already dispatches `SinkType::is_sink_decouple(...)` through `match_sink_name_str!` a few lines above the special case, so no new machinery is needed.

### Behavior change

The error is now a sink config error rather than `ErrorCode::NotSupported` with a `HINT`, so the remedy moves into the message text:

```
ERROR:  Failed to run the query

Caused by these errors (recent errors listed first):
  1: Sink error
  2: config error
  3: File sink can only be created with sink_decouple enabled. Please run `set sink_decouple = true` first.
```

### Verification

- New unit test `test_requires_sink_decouple` in `opendal_sink.rs` (`Default`/`Enable` accepted, `Disable` rejected) over `fs`, `gcs`, `s3` and `snowflake`.
- `e2e_test/sink/append_only_sink.slt` extended from the `s3` case to `s3` + `gcs` + `snowflake`; passes locally. The check happens at planning time, before the connector's `validate()`, so no cloud credentials are involved.
- Checked that a decoupled `fs` sink is unaffected: `FLUSH` returns immediately and a non-empty parquet file lands after the rollover.
- `./risedev c` clean.

## Checklist

- [x] I have written necessary rustdoc comments.
- [x] I have added necessary unit tests and integration tests.
- [x] I have added test labels as necessary.
- [ ] My PR changes performance-critical code, so I will run (micro) benchmarks and present the results.

## Documentation

- [x] My PR needs documentation updates.

`gcs` and `snowflake` file sinks can no longer be created with `sink_decouple = false` (they previously appeared to succeed and then stalled the streaming job). The error message for all file sinks changes as shown above.

The check runs at plan time only, and the resulting log store type is persisted in the sink's plan, so this does not affect sinks that already exist: they keep the log store they were created with and are not re-validated on upgrade or recovery. A `gcs` or `snowflake` sink created earlier with `sink_decouple = false` therefore keeps its in-memory log store and its stalling behavior — it has to be dropped and recreated with decoupling enabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
