### PR TITLE
fix(frontend): decouple CREATE VIEW from batch execution engine

### DIFF
--- a/e2e_test/ddl/dependency_check.slt
+++ b/e2e_test/ddl/dependency_check.slt
@@ -8,6 +8,15 @@ statement ok
 create index i_a1 on a(a1);
 
 statement ok
+create view v_index as select * from a where a1 = 1;
+
+statement error Permission denied
+drop index i_a1;
+
+statement ok
+drop view v_index;
+
+statement ok
 create table b (b1 int, b2 int);
 
 statement ok

--- a/e2e_test/iceberg/test_case/iceberg_select_empty_table.slt
+++ b/e2e_test/iceberg/test_case/iceberg_select_empty_table.slt
@@ -53,6 +53,26 @@ select count(*) from iceberg_t1_source;
 0
 
 statement ok
+set enable_datafusion_engine = true;
+
+statement ok
+INSERT INTO s1 VALUES (1, 'hello', 'world');
+
+statement ok
+flush;
+
+statement ok
+create view iceberg_t1_view as select * from iceberg_t1_source;
+
+query I
+select count(*) from iceberg_t1_view;
+----
+1
+
+statement ok
+drop view iceberg_t1_view;
+
+statement ok
 DROP SINK sink1;
 
 statement ok

--- a/e2e_test/iceberg/test_case/iceberg_select_empty_table.slt
+++ b/e2e_test/iceberg/test_case/iceberg_select_empty_table.slt
@@ -52,9 +52,12 @@ select count(*) from iceberg_t1_source;
 ----
 0
 
+# Regression test for issue #25968: creating a logical view over an Iceberg source must not depend on
+# DataFusion being selected as the batch execution engine.
 statement ok
 set enable_datafusion_engine = true;
 
+# Insert a row through the sink and verify that the view can read it after the checkpoint commits.
 statement ok
 INSERT INTO s1 VALUES (1, 'hello', 'world');
 

--- a/src/frontend/src/handler/create_view.rs
+++ b/src/frontend/src/handler/create_view.rs
@@ -21,10 +21,12 @@ use risingwave_pb::catalog::PbView;
 use risingwave_sqlparser::ast::{Ident, ObjectName, Query};
 
 use super::RwPgResponse;
-use crate::binder::Binder;
+use crate::binder::{Binder, BoundStatement};
 use crate::error::Result;
 use crate::handler::HandlerArgs;
 use crate::handler::util::reject_internal_table_dependencies;
+use crate::optimizer::{OptimizerContext, RelationCollectorVisitor};
+use crate::planner::Planner;
 
 pub async fn handle_create_view(
     handler_args: HandlerArgs,
@@ -49,13 +51,22 @@ pub async fn handle_create_view(
         return Ok(resp);
     }
 
-    // Bind the query to validate it and resolve its schema and dependencies.
+    // Bind and plan the query to validate it and resolve its schema and dependencies. The batch
+    // plan is only used for validation and dependency collection. It is neither stored nor
+    // executed, so creating a logical view does not depend on the selected batch execution engine.
     let (dependent_relations, dependent_secrets, schema) = {
         let mut binder = Binder::new_for_batch(&session);
         let bound_query = binder.bind_query(&query)?;
-        let schema = bound_query.schema().into_owned();
         let dependent_relations = binder.included_relations().clone();
         let dependent_secrets = binder.included_secrets().clone();
+
+        let context = OptimizerContext::from_handler_args(handler_args);
+        let logical = Planner::new_for_batch_dql(context.into())
+            .plan(BoundStatement::Query(bound_query.into()))?;
+        let schema = logical.schema();
+        let batch_plan = logical.gen_batch_plan()?;
+        let dependent_relations =
+            RelationCollectorVisitor::collect_with(dependent_relations, batch_plan.plan);
 
         reject_internal_table_dependencies(&session, &dependent_relations, "CREATE VIEW")?;
 

--- a/src/frontend/src/handler/create_view.rs
+++ b/src/frontend/src/handler/create_view.rs
@@ -18,14 +18,13 @@ use either::Either;
 use pgwire::pg_response::{PgResponse, StatementType};
 use risingwave_common::util::iter_util::ZipEqFast;
 use risingwave_pb::catalog::PbView;
-use risingwave_sqlparser::ast::{Ident, ObjectName, Query, Statement};
+use risingwave_sqlparser::ast::{Ident, ObjectName, Query};
 
 use super::RwPgResponse;
 use crate::binder::Binder;
 use crate::error::Result;
 use crate::handler::HandlerArgs;
 use crate::handler::util::reject_internal_table_dependencies;
-use crate::optimizer::OptimizerContext;
 
 pub async fn handle_create_view(
     handler_args: HandlerArgs,
@@ -50,20 +49,13 @@ pub async fn handle_create_view(
         return Ok(resp);
     }
 
-    // plan the query to validate it and resolve dependencies
+    // Bind the query to validate it and resolve its schema and dependencies.
     let (dependent_relations, dependent_secrets, schema) = {
-        let context = OptimizerContext::from_handler_args(handler_args);
-        let super::query::RwBatchQueryPlanResult {
-            schema,
-            dependent_relations,
-            dependent_secrets,
-            ..
-        } = super::query::gen_batch_plan_by_statement(
-            &session,
-            context.into(),
-            Statement::Query(Box::new(query.clone())),
-        )?
-        .unwrap_rw()?;
+        let mut binder = Binder::new_for_batch(&session);
+        let bound_query = binder.bind_query(&query)?;
+        let schema = bound_query.schema().into_owned();
+        let dependent_relations = binder.included_relations().clone();
+        let dependent_secrets = binder.included_secrets().clone();
 
         reject_internal_table_dependencies(&session, &dependent_relations, "CREATE VIEW")?;
 

--- a/src/frontend/src/handler/query.rs
+++ b/src/frontend/src/handler/query.rs
@@ -39,8 +39,7 @@ use crate::handler::flush::do_flush;
 use crate::handler::util::{DataChunkToRowSetAdapter, to_pg_field};
 use crate::optimizer::plan_node::{BatchPlanRef, Explain};
 use crate::optimizer::{
-    BatchPlanRoot, ExecutionModeDecider, OptimizerContext, OptimizerContextRef,
-    RelationCollectorVisitor, SysTableVisitor,
+    BatchPlanRoot, ExecutionModeDecider, OptimizerContext, OptimizerContextRef, SysTableVisitor,
 };
 use crate::planner::Planner;
 use crate::scheduler::plan_fragmenter::Query;
@@ -302,11 +301,6 @@ pub struct RwBatchQueryPlanResult {
     pub(crate) query_mode: QueryMode,
     pub(crate) schema: Schema,
     pub(crate) stmt_type: StatementType,
-    // Note that these relations are only resolved in the binding phase, and it may only be a
-    // subset of the final one. i.e. the final one may contain more implicit dependencies on
-    // indices.
-    pub(crate) dependent_relations: Vec<ObjectId>,
-    pub(crate) dependent_secrets: Vec<SecretId>,
 }
 
 fn gen_batch_query_plan(
@@ -318,8 +312,6 @@ fn gen_batch_query_plan(
         stmt_type,
         must_dist,
         bound,
-        dependent_relations,
-        dependent_secrets,
         ..
     } = bind_result;
 
@@ -361,9 +353,6 @@ fn gen_batch_query_plan(
 
     let batch_plan = optimized_logical.gen_batch_plan()?;
 
-    let dependent_relations =
-        RelationCollectorVisitor::collect_with(dependent_relations, batch_plan.plan.clone());
-
     let must_local = must_run_in_local_mode(&batch_plan);
 
     let query_mode = match (must_dist, must_local) {
@@ -393,8 +382,6 @@ fn gen_batch_query_plan(
         query_mode,
         schema,
         stmt_type,
-        dependent_relations: dependent_relations.into_iter().collect_vec(),
-        dependent_secrets: dependent_secrets.into_iter().collect_vec(),
     };
     Ok(BatchPlanChoice::Rw(result))
 }

--- a/src/frontend/src/session/cursor_manager.rs
+++ b/src/frontend/src/session/cursor_manager.rs
@@ -1067,8 +1067,6 @@ impl SubscriptionCursor {
             query_mode,
             schema,
             stmt_type: StatementType::SELECT,
-            dependent_relations: vec![],
-            dependent_secrets: vec![],
         })
     }
 


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

<!--

**Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

- Closes #25968.

`CREATE VIEW ... AS SELECT ... FROM <iceberg_source>` fails when
`enable_datafusion_engine` is enabled:

Expected RisingWave plan in BatchPlanChoice, but got DataFusion plan
CREATE VIEW previously called `gen_batch_plan_by_statement()` and then
unconditionally unwrapped the result as a RisingWave plan. Iceberg queries may
produce a DataFusion plan, so view creation failed even though the query itself
was valid.

This PR decouples logical view creation from batch execution engine selection:
- Bind and plan the view query directly with the RisingWave batch planner for
validation and dependency collection.
- Do not store or execute the generated batch plan.
- Preserve planner validation so unsupported queries are still rejected during
`CREATE VIEW`.
- Preserve implicit index dependencies by running `RelationCollectorVisitor` on
the generated batch plan.
- Remove relation and secret dependency fields from
`RwBatchQueryPlanResult`, as they are no longer consumed by query execution.
- Add regression coverage for creating and querying a view over an Iceberg
source while DataFusion is enabled.
- Add dependency coverage verifying that an index selected by a view cannot be
dropped while the view exists.

## Checklist

- [x] I have written necessary rustdoc comments.
- [x] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->
Fixed an issue where creating a logical view over an Iceberg source failed when
the DataFusion batch engine was enabled.

</details>
