### PR TITLE
ci: label external contributor PRs as community

### DIFF
--- a/.github/workflows/label-community-contributor.yml
+++ b/.github/workflows/label-community-contributor.yml
@@ -1,0 +1,56 @@
+name: Label community pull requests
+
+on:
+  pull_request_target:
+    types: [opened, reopened, synchronize, ready_for_review]
+
+permissions:
+  issues: write
+
+jobs:
+  label-community-contributor:
+    # External collaborators are included; only organization members and owners are excluded.
+    if: >-
+      github.event.pull_request.user.type == 'User' &&
+      github.event.pull_request.author_association != 'MEMBER' &&
+      github.event.pull_request.author_association != 'OWNER'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Add community label
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const label = {
+              name: "community",
+              color: "0e8a16",
+              description: "Pull request from an external community contributor",
+            };
+
+            try {
+              await github.rest.issues.getLabel({
+                ...context.repo,
+                name: label.name,
+              });
+            } catch (error) {
+              if (error.status !== 404) {
+                throw error;
+              }
+
+              try {
+                await github.rest.issues.createLabel({
+                  ...context.repo,
+                  ...label,
+                });
+              } catch (createError) {
+                // Another workflow run may have created the label concurrently.
+                if (createError.status !== 422) {
+                  throw createError;
+                }
+              }
+            }
+
+            await github.rest.issues.addLabels({
+              ...context.repo,
+              issue_number: context.issue.number,
+              labels: [label.name],
+            });

--- a/.github/workflows/label-community-contributor.yml
+++ b/.github/workflows/label-community-contributor.yml
@@ -2,7 +2,7 @@ name: Label community pull requests
 
 on:
   pull_request_target:
-    types: [opened, reopened, synchronize, ready_for_review]
+    types: [opened]
 
 permissions:
   issues: write

--- a/.github/workflows/label-community-contributor.yml
+++ b/.github/workflows/label-community-contributor.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Add community label
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const label = {


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

Add a `pull_request_target` workflow that applies the `community` label to pull requests opened by users outside the RisingWave Labs organization.

The workflow:

- excludes organization members and owners using GitHub's `author_association`
- includes external repository collaborators because they are outside the organization
- excludes bot accounts
- creates the `community` label on demand if it does not exist
- runs when a pull request is opened

The workflow does not check out or execute pull request code. This keeps the write-enabled `pull_request_target` workflow isolated from untrusted changes while allowing it to label pull requests from forks.

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] I have added necessary unit tests and integration tests.
- [ ] I have added test labels as necessary.
- [ ] I have added fuzzing tests or opened an issue to track them.
- [ ] My PR contains breaking changes.
- [ ] My PR changes performance-critical code, so I will run (micro) benchmarks and present the results.
- [ ] I have checked the release timeline and supported versions for cherry-pick needs.

## Validation

- `actionlint .github/workflows/label-community-contributor.yml`
- Evaluated the selection condition against current open pull requests to confirm members and bots are skipped while external contributors are selected.

## Documentation

- [ ] My PR needs documentation updates.
