### PR TITLE
fix(ci): authenticate cherry-pick checkout with PAT

### DIFF
--- a/.github/workflows/cherry-pick-since-release-branch.yml
+++ b/.github/workflows/cherry-pick-since-release-branch.yml
@@ -108,6 +108,10 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5
+        with:
+          # Persist the PAT used by the cherry-pick action. Otherwise checkout stores the
+          # built-in GITHUB_TOKEN, and git push ignores the PAT supplied through .netrc.
+          token: ${{ secrets.RISINGWAVE_CI_GITHUB_TOKEN }}
 
       - name: Create PR to branch
         uses: risingwavelabs/github-action-cherry-pick@master


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What changed and what is the intention?

The cherry-pick workflow passes `RISINGWAVE_CI_GITHUB_TOKEN` to the cherry-pick action, but its preceding `actions/checkout` step persists the built-in `github.token` in the local Git configuration. As a result, `git push` can authenticate as `github-actions[bot]` instead of using the intended PAT. This breaks backports that modify workflow files and can also turn workflow-validation timeouts into rejected pushes.

Configure the publishing job checkout with `RISINGWAVE_CI_GITHUB_TOKEN` so all later authenticated Git commands consistently use the PAT. This matches the intent of #22137.

Observed failures:

- https://github.com/risingwavelabs/risingwave/actions/runs/32000837376
- https://github.com/risingwavelabs/risingwave/actions/runs/32001294738
- https://github.com/risingwavelabs/risingwave/actions/runs/32001284298

The shared `github-action-cherry-pick` action still continues to PR creation after a failed push; hardening that behavior belongs in its own repository and is outside this focused change.

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] I have added necessary unit tests and integration tests.
- [x] I have added necessary test labels as applicable.
- [ ] I have added fuzzing tests or opened an issue to track them.
- [ ] My PR contains breaking changes.
- [ ] My PR changes performance-critical code, so I will run benchmarks.
- [ ] I have checked the release timeline and currently supported versions.

## Validation

- `yq eval . .github/workflows/cherry-pick-since-release-branch.yml`
- Verified `jobs.release_pull_request.steps[0].with.token` resolves to `${{ secrets.RISINGWAVE_CI_GITHUB_TOKEN }}`
- `git diff --check`

## Documentation

No user-facing documentation changes.