### PR TITLE
feat(pg-cdc): support postgis geography

### DIFF
--- a/e2e_test/source_inline/cdc/postgres/postgres_postgis_geography.slt
+++ b/e2e_test/source_inline/cdc/postgres/postgres_postgis_geography.slt
@@ -2,47 +2,12 @@ control substitution on
 
 # PostGIS geography type CDC test
 
+# Shared setup
 system ok
-psql -c "
-    CREATE EXTENSION IF NOT EXISTS postgis;
-    DROP TABLE IF EXISTS test_geography CASCADE;
-    DROP TABLE IF EXISTS test_geography_array CASCADE;
-    DROP TABLE IF EXISTS test_geography_auto_discovery CASCADE;
-    DROP TABLE IF EXISTS test_geography_schema_change CASCADE;
-    CREATE TABLE test_geography (
-        id int PRIMARY KEY,
-        name varchar,
-        location geography(Point, 4326)
-    );
-    INSERT INTO test_geography VALUES
-        (1, 'Chicago', ST_SetSRID(ST_MakePoint(-87.6298, 41.8781), 4326)),
-        (2, 'NewYork', ST_SetSRID(ST_MakePoint(-74.0060, 40.7128), 4326));
-    CREATE TABLE test_geography_array (
-        id int PRIMARY KEY,
-        name varchar,
-        locations geography(Point, 4326)[]
-    );
-    INSERT INTO test_geography_array VALUES
-        (
-            1,
-            'InitialRoute',
-            ARRAY[
-                ST_SetSRID(ST_MakePoint(-87.6298, 41.8781), 4326),
-                ST_SetSRID(ST_MakePoint(-74.0060, 40.7128), 4326)
-            ]::geography(Point, 4326)[]
-        );
-    CREATE TABLE test_geography_auto_discovery (
-        id int PRIMARY KEY,
-        location geography(Point, 4326)
-    );
-    INSERT INTO test_geography_auto_discovery VALUES
-        (1, ST_SetSRID(ST_MakePoint(-122.4194, 37.7749), 4326));
-    CREATE TABLE test_geography_schema_change (
-        id int PRIMARY KEY,
-        name varchar
-    );
-    INSERT INTO test_geography_schema_change VALUES (1, 'Before');
-"
+psql -c "CREATE EXTENSION IF NOT EXISTS postgis;"
+
+statement ok
+drop source if exists geography_source cascade;
 
 statement ok
 create source geography_source with (
@@ -57,6 +22,25 @@ create source geography_source with (
   auto.schema.change = 'true'
 );
 
+# Test: accept correct explicit schemas
+
+# Scalar geography maps to bytea and backfill preserves the complete EWKB bytes.
+system ok
+psql -c "
+    DROP TABLE IF EXISTS test_geography CASCADE;
+    CREATE TABLE test_geography (
+        id int PRIMARY KEY,
+        name varchar,
+        location geography(Point, 4326)
+    );
+    INSERT INTO test_geography VALUES
+        (1, 'Chicago', ST_SetSRID(ST_MakePoint(-87.6298, 41.8781), 4326)),
+        (2, 'NewYork', ST_SetSRID(ST_MakePoint(-74.0060, 40.7128), 4326));
+"
+
+statement ok
+drop table if exists test_geography;
+
 statement ok
 create table test_geography (
     id int primary key,
@@ -64,19 +48,67 @@ create table test_geography (
     location bytea
 ) from geography_source table 'public.test_geography';
 
-# A geography column cannot be mapped to a non-bytea RisingWave type.
-statement error Incompatible data type of column location
-create table test_geography_invalid_mapping (
-    id int primary key,
-    name varchar,
-    location varchar
-) from geography_source table 'public.test_geography';
+query T
+select c.data_type
+from rw_catalog.rw_columns c
+join rw_catalog.rw_tables t on c.relation_id = t.id
+where t.name = 'test_geography' and c.name = 'location';
+----
+bytea
+
+query ITTT retry 10 backoff 1s
+select
+    ours.id,
+    encode(ours.location, 'hex'),
+    upstream.upstream_hex,
+    encode(ours.location, 'hex') = upstream.upstream_hex
+from test_geography as ours
+join (
+    select * from postgres_query(
+        '${PGHOST:localhost}',
+        '${PGPORT:5432}',
+        '${PGUSER:$USER}',
+        '${PGPASSWORD:}',
+        '${PGDATABASE:postgres}',
+        'select id, encode(location, ''hex'') as upstream_hex from test_geography'
+    )
+) as upstream(id, upstream_hex) on ours.id = upstream.id
+order by ours.id;
+----
+1 0101000020e610000055c1a8a44ee855c00e4faf9465f04440 0101000020e610000055c1a8a44ee855c00e4faf9465f04440 t
+2 0101000020e6100000aaf1d24d628052c05e4bc8073d5b4440 0101000020e6100000aaf1d24d628052c05e4bc8073d5b4440 t
+
+# Geography arrays map to bytea[] and backfill preserves each EWKB value.
+system ok
+psql -c "
+    DROP TABLE IF EXISTS test_geography_array CASCADE;
+    CREATE TABLE test_geography_array (
+        id int PRIMARY KEY,
+        name varchar,
+        locations geography(Point, 4326)[]
+    );
+    INSERT INTO test_geography_array VALUES
+        (
+            1,
+            'InitialRoute',
+            ARRAY[
+                ST_SetSRID(ST_MakePoint(-87.6298, 41.8781), 4326),
+                ST_SetSRID(ST_MakePoint(-74.0060, 40.7128), 4326)
+            ]::geography(Point, 4326)[]
+        );
+"
 
 statement ok
-create table test_geography_array (*)
-from geography_source table 'public.test_geography_array';
+drop table if exists test_geography_array;
 
-query T retry 10 backoff 1s
+statement ok
+create table test_geography_array (
+    id int primary key,
+    name varchar,
+    locations bytea[]
+) from geography_source table 'public.test_geography_array';
+
+query T
 select c.data_type
 from rw_catalog.rw_columns c
 join rw_catalog.rw_tables t on c.relation_id = t.id
@@ -84,57 +116,244 @@ where t.name = 'test_geography_array' and c.name = 'locations';
 ----
 bytea[]
 
-# Backfill preserves the complete EWKB bytes.
-query IT retry 10 backoff 1s
-select id, encode(location, 'hex') from test_geography order by id;
+query ITTTTTTT retry 10 backoff 1s
+select
+    ours.id,
+    ours.name,
+    encode(ours.locations[1], 'hex'),
+    upstream.upstream_hex_1,
+    encode(ours.locations[1], 'hex') = upstream.upstream_hex_1,
+    encode(ours.locations[2], 'hex'),
+    upstream.upstream_hex_2,
+    encode(ours.locations[2], 'hex') = upstream.upstream_hex_2
+from test_geography_array as ours
+join (
+    select * from postgres_query(
+        '${PGHOST:localhost}',
+        '${PGPORT:5432}',
+        '${PGUSER:$USER}',
+        '${PGPASSWORD:}',
+        '${PGDATABASE:postgres}',
+        'select id, encode(locations[1], ''hex'') as upstream_hex_1, encode(locations[2], ''hex'') as upstream_hex_2 from test_geography_array where id = 1'
+    )
+) as upstream(id, upstream_hex_1, upstream_hex_2) on ours.id = upstream.id
+where ours.id = 1;
 ----
-1 0101000020e610000055c1a8a44ee855c00e4faf9465f04440
-2 0101000020e6100000aaf1d24d628052c05e4bc8073d5b4440
+1 InitialRoute 0101000020e610000055c1a8a44ee855c00e4faf9465f04440 0101000020e610000055c1a8a44ee855c00e4faf9465f04440 t 0101000020e6100000aaf1d24d628052c05e4bc8073d5b4440 0101000020e6100000aaf1d24d628052c05e4bc8073d5b4440 t
 
-# Test incremental INSERT.
+# Other geography subtypes also map to bytea.
 system ok
-psql -c "INSERT INTO test_geography VALUES (3, 'London', ST_SetSRID(ST_MakePoint(-0.1278, 51.5074), 4326));"
+psql -c "
+    DROP TABLE IF EXISTS test_geography_line CASCADE;
+    CREATE TABLE test_geography_line (
+        id int PRIMARY KEY,
+        name varchar,
+        path geography(LineString, 4326)
+    );
+    INSERT INTO test_geography_line VALUES
+        (1, 'Route1', ST_SetSRID(ST_MakeLine(ST_MakePoint(-87.6298, 41.8781), ST_MakePoint(-74.0060, 40.7128)), 4326));
+"
 
-query IT retry 10 backoff 1s
-select id, encode(location, 'hex') from test_geography where id = 3;
+statement ok
+drop table if exists test_geography_line;
+
+statement ok
+create table test_geography_line (
+    id int primary key,
+    name varchar,
+    path bytea
+) from geography_source table 'public.test_geography_line';
+
+query T
+select c.data_type
+from rw_catalog.rw_columns c
+join rw_catalog.rw_tables t on c.relation_id = t.id
+where t.name = 'test_geography_line' and c.name = 'path';
 ----
-3 0101000020e6100000ebe2361ac05bc0bfc5feb27bf2c04940
+bytea
 
-# Test incremental UPDATE.
-system ok
-psql -c "UPDATE test_geography SET location = ST_SetSRID(ST_MakePoint(0, 0), 4326) WHERE id = 1;"
-
-query IT retry 10 backoff 1s
-select id, encode(location, 'hex') from test_geography where id = 1;
-----
-1 0101000020e610000000000000000000000000000000000000
-
-# Test incremental DELETE.
-system ok
-psql -c "DELETE FROM test_geography WHERE id = 2;"
-
-query I retry 10 backoff 1s
-select count(*) from test_geography where id = 2;
-----
-0
-
-# Test NULL geography.
-system ok
-psql -c "INSERT INTO test_geography VALUES (4, 'NullLocation', NULL);"
-
-query ITI retry 10 backoff 1s
-select id, name, location from test_geography where id = 4;
-----
-4 NullLocation NULL
-
-# Test geography[] backfill.
 query ITTT retry 10 backoff 1s
-select id, name, encode(locations[1], 'hex'), encode(locations[2], 'hex')
-from test_geography_array where id = 1;
+select
+    ours.id,
+    encode(ours.path, 'hex'),
+    upstream.upstream_hex,
+    encode(ours.path, 'hex') = upstream.upstream_hex
+from test_geography_line as ours
+join (
+    select * from postgres_query(
+        '${PGHOST:localhost}',
+        '${PGPORT:5432}',
+        '${PGUSER:$USER}',
+        '${PGPASSWORD:}',
+        '${PGDATABASE:postgres}',
+        'select id, encode(path, ''hex'') as upstream_hex from test_geography_line where id = 1'
+    )
+) as upstream(id, upstream_hex) on ours.id = upstream.id
+where ours.id = 1;
 ----
-1 InitialRoute 0101000020e610000055c1a8a44ee855c00e4faf9465f04440 0101000020e6100000aaf1d24d628052c05e4bc8073d5b4440
+1 0102000020e61000000200000055c1a8a44ee855c00e4faf9465f04440aaf1d24d628052c05e4bc8073d5b4440 0102000020e61000000200000055c1a8a44ee855c00e4faf9465f04440aaf1d24d628052c05e4bc8073d5b4440 t
 
-# Test incremental INSERT into geography[].
+# Test: reject an incorrect explicit scalar schema
+system ok
+psql -c "
+    DROP TABLE IF EXISTS test_geography_invalid_mapping_upstream CASCADE;
+    CREATE TABLE test_geography_invalid_mapping_upstream (
+        id int PRIMARY KEY,
+        name varchar,
+        location geography(Point, 4326)
+    );
+"
+
+statement ok
+drop table if exists test_geography_invalid_mapping;
+
+statement error Incompatible data type of column location
+create table test_geography_invalid_mapping (
+    id int primary key,
+    name varchar,
+    location varchar
+) from geography_source table 'public.test_geography_invalid_mapping_upstream';
+
+# TODO: Enable this after explicit array type validation is implemented correctly.
+# statement ok
+# drop table if exists test_geography_array_invalid_mapping;
+#
+# statement error Incompatible data type of column locations
+# create table test_geography_array_invalid_mapping (
+#     id int primary key,
+#     name varchar,
+#     locations varchar[]
+# ) from geography_source table 'public.test_geography_array';
+
+# Test: automatic schema discovery maps geography correctly
+
+# Scalar geography is discovered as bytea.
+system ok
+psql -c "
+    DROP TABLE IF EXISTS test_geography_auto_discovery CASCADE;
+    CREATE TABLE test_geography_auto_discovery (
+        id int PRIMARY KEY,
+        location geography(Point, 4326)
+    );
+    INSERT INTO test_geography_auto_discovery VALUES
+        (1, ST_SetSRID(ST_MakePoint(-122.4194, 37.7749), 4326));
+"
+
+statement ok
+drop table if exists test_geography_auto_discovery_rw;
+
+statement ok
+create table test_geography_auto_discovery_rw (*)
+from geography_source table 'public.test_geography_auto_discovery';
+
+query T retry 10 backoff 1s
+select c.data_type
+from rw_catalog.rw_columns c
+join rw_catalog.rw_tables t on c.relation_id = t.id
+where t.name = 'test_geography_auto_discovery_rw' and c.name = 'location';
+----
+bytea
+
+query ITTT retry 10 backoff 1s
+select
+    ours.id,
+    encode(ours.location, 'hex'),
+    upstream.upstream_hex,
+    encode(ours.location, 'hex') = upstream.upstream_hex
+from test_geography_auto_discovery_rw as ours
+join (
+    select * from postgres_query(
+        '${PGHOST:localhost}',
+        '${PGPORT:5432}',
+        '${PGUSER:$USER}',
+        '${PGPASSWORD:}',
+        '${PGDATABASE:postgres}',
+        'select id, encode(location, ''hex'') as upstream_hex from test_geography_auto_discovery where id = 1'
+    )
+) as upstream(id, upstream_hex) on ours.id = upstream.id
+where ours.id = 1;
+----
+1 0101000020e610000050fc1873d79a5ec0d0d556ec2fe34240 0101000020e610000050fc1873d79a5ec0d0d556ec2fe34240 t
+
+# Geography arrays are discovered as bytea[].
+system ok
+psql -c "
+    DROP TABLE IF EXISTS test_geography_array_auto_discovery CASCADE;
+    CREATE TABLE test_geography_array_auto_discovery (
+        id int PRIMARY KEY,
+        locations geography(Point, 4326)[]
+    );
+"
+
+statement ok
+drop table if exists test_geography_array_auto_discovery_rw;
+
+statement ok
+create table test_geography_array_auto_discovery_rw (*)
+from geography_source table 'public.test_geography_array_auto_discovery';
+
+query T retry 10 backoff 1s
+select c.data_type
+from rw_catalog.rw_columns c
+join rw_catalog.rw_tables t on c.relation_id = t.id
+where t.name = 'test_geography_array_auto_discovery_rw' and c.name = 'locations';
+----
+bytea[]
+
+# Test: incremental INSERT
+
+# Insert non-NULL and NULL scalar geography values.
+system ok
+psql -c "
+    INSERT INTO test_geography VALUES
+        (3, 'London', ST_SetSRID(ST_MakePoint(-0.1278, 51.5074), 4326)),
+        (4, 'NullLocation', NULL);
+"
+
+query ITTT retry 10 backoff 1s
+select
+    ours.id,
+    encode(ours.location, 'hex'),
+    upstream.upstream_hex,
+    encode(ours.location, 'hex') = upstream.upstream_hex
+from test_geography as ours
+join (
+    select * from postgres_query(
+        '${PGHOST:localhost}',
+        '${PGPORT:5432}',
+        '${PGUSER:$USER}',
+        '${PGPASSWORD:}',
+        '${PGDATABASE:postgres}',
+        'select id, encode(location, ''hex'') as upstream_hex from test_geography where id = 3'
+    )
+) as upstream(id, upstream_hex) on ours.id = upstream.id
+where ours.id = 3;
+----
+3 0101000020e6100000ebe2361ac05bc0bfc5feb27bf2c04940 0101000020e6100000ebe2361ac05bc0bfc5feb27bf2c04940 t
+
+query ITTTT retry 10 backoff 1s
+select
+    ours.id,
+    ours.name,
+    ours.location is null,
+    upstream.upstream_is_null,
+    (ours.location is null) = upstream.upstream_is_null
+from test_geography as ours
+join (
+    select * from postgres_query(
+        '${PGHOST:localhost}',
+        '${PGPORT:5432}',
+        '${PGUSER:$USER}',
+        '${PGPASSWORD:}',
+        '${PGDATABASE:postgres}',
+        'select id, location is null as upstream_is_null from test_geography where id = 4'
+    )
+) as upstream(id, upstream_is_null) on ours.id = upstream.id
+where ours.id = 4;
+----
+4 NullLocation t t t
+
+# Insert a geography array.
 system ok
 psql -c "
     INSERT INTO test_geography_array VALUES
@@ -148,13 +367,59 @@ psql -c "
         );
 "
 
-query ITTT retry 10 backoff 1s
-select id, name, encode(locations[1], 'hex'), encode(locations[2], 'hex')
-from test_geography_array where id = 2;
+query ITTTTTTT retry 10 backoff 1s
+select
+    ours.id,
+    ours.name,
+    encode(ours.locations[1], 'hex'),
+    upstream.upstream_hex_1,
+    encode(ours.locations[1], 'hex') = upstream.upstream_hex_1,
+    encode(ours.locations[2], 'hex'),
+    upstream.upstream_hex_2,
+    encode(ours.locations[2], 'hex') = upstream.upstream_hex_2
+from test_geography_array as ours
+join (
+    select * from postgres_query(
+        '${PGHOST:localhost}',
+        '${PGPORT:5432}',
+        '${PGUSER:$USER}',
+        '${PGPASSWORD:}',
+        '${PGDATABASE:postgres}',
+        'select id, encode(locations[1], ''hex'') as upstream_hex_1, encode(locations[2], ''hex'') as upstream_hex_2 from test_geography_array where id = 2'
+    )
+) as upstream(id, upstream_hex_1, upstream_hex_2) on ours.id = upstream.id
+where ours.id = 2;
 ----
-2 InsertedRoute 0101000020e6100000ebe2361ac05bc0bfc5feb27bf2c04940 0101000020e610000050fc1873d79a5ec0d0d556ec2fe34240
+2 InsertedRoute 0101000020e6100000ebe2361ac05bc0bfc5feb27bf2c04940 0101000020e6100000ebe2361ac05bc0bfc5feb27bf2c04940 t 0101000020e610000050fc1873d79a5ec0d0d556ec2fe34240 0101000020e610000050fc1873d79a5ec0d0d556ec2fe34240 t
 
-# Test incremental UPDATE of geography[].
+# Test: incremental UPDATE
+
+# Update a scalar geography value.
+system ok
+psql -c "UPDATE test_geography SET location = ST_SetSRID(ST_MakePoint(0, 0), 4326) WHERE id = 1;"
+
+query ITTT retry 10 backoff 1s
+select
+    ours.id,
+    encode(ours.location, 'hex'),
+    upstream.upstream_hex,
+    encode(ours.location, 'hex') = upstream.upstream_hex
+from test_geography as ours
+join (
+    select * from postgres_query(
+        '${PGHOST:localhost}',
+        '${PGPORT:5432}',
+        '${PGUSER:$USER}',
+        '${PGPASSWORD:}',
+        '${PGDATABASE:postgres}',
+        'select id, encode(location, ''hex'') as upstream_hex from test_geography where id = 1'
+    )
+) as upstream(id, upstream_hex) on ours.id = upstream.id
+where ours.id = 1;
+----
+1 0101000020e610000000000000000000000000000000000000 0101000020e610000000000000000000000000000000000000 t
+
+# Update a geography array.
 system ok
 psql -c "
     UPDATE test_geography_array
@@ -165,48 +430,114 @@ psql -c "
     WHERE id = 1;
 "
 
-query ITT retry 10 backoff 1s
-select id, encode(locations[1], 'hex'), encode(locations[2], 'hex')
-from test_geography_array where id = 1;
+query ITTTTTT retry 10 backoff 1s
+select
+    ours.id,
+    encode(ours.locations[1], 'hex'),
+    upstream.upstream_hex_1,
+    encode(ours.locations[1], 'hex') = upstream.upstream_hex_1,
+    encode(ours.locations[2], 'hex'),
+    upstream.upstream_hex_2,
+    encode(ours.locations[2], 'hex') = upstream.upstream_hex_2
+from test_geography_array as ours
+join (
+    select * from postgres_query(
+        '${PGHOST:localhost}',
+        '${PGPORT:5432}',
+        '${PGUSER:$USER}',
+        '${PGPASSWORD:}',
+        '${PGDATABASE:postgres}',
+        'select id, encode(locations[1], ''hex'') as upstream_hex_1, encode(locations[2], ''hex'') as upstream_hex_2 from test_geography_array where id = 1'
+    )
+) as upstream(id, upstream_hex_1, upstream_hex_2) on ours.id = upstream.id
+where ours.id = 1;
 ----
-1 0101000020e610000000000000000000000000000000000000 0101000020e6100000a54e4013613f5ac0029a081b9ede4340
+1 0101000020e610000000000000000000000000000000000000 0101000020e610000000000000000000000000000000000000 t 0101000020e6100000a54e4013613f5ac0029a081b9ede4340 0101000020e6100000a54e4013613f5ac0029a081b9ede4340 t
 
-# Test incremental DELETE from geography[].
+# Test: incremental DELETE
+
+# Delete a scalar geography row.
+system ok
+psql -c "DELETE FROM test_geography WHERE id = 2;"
+
+query IIT retry 10 backoff 1s
+select
+    (select count(*) from test_geography where id = 2),
+    upstream.upstream_count,
+    (select count(*) from test_geography where id = 2) = upstream.upstream_count
+from (
+    select * from postgres_query(
+        '${PGHOST:localhost}',
+        '${PGPORT:5432}',
+        '${PGUSER:$USER}',
+        '${PGPASSWORD:}',
+        '${PGDATABASE:postgres}',
+        'select count(*)::int as upstream_count from test_geography where id = 2'
+    )
+) as upstream(upstream_count);
+----
+0 0 t
+
+# Delete a geography array row.
 system ok
 psql -c "DELETE FROM test_geography_array WHERE id = 2;"
 
-query I retry 10 backoff 1s
-select count(*) from test_geography_array where id = 2;
+query IIT retry 10 backoff 1s
+select
+    (select count(*) from test_geography_array where id = 2),
+    upstream.upstream_count,
+    (select count(*) from test_geography_array where id = 2) = upstream.upstream_count
+from (
+    select * from postgres_query(
+        '${PGHOST:localhost}',
+        '${PGPORT:5432}',
+        '${PGUSER:$USER}',
+        '${PGPASSWORD:}',
+        '${PGDATABASE:postgres}',
+        'select count(*)::int as upstream_count from test_geography_array where id = 2'
+    )
+) as upstream(upstream_count);
 ----
-0
+0 0 t
 
-# Test automatic schema discovery.
+# Test: automatic schema change
+system ok
+psql -c "
+    DROP TABLE IF EXISTS test_geography_schema_change CASCADE;
+    CREATE TABLE test_geography_schema_change (
+        id int PRIMARY KEY,
+        name varchar
+    );
+    INSERT INTO test_geography_schema_change VALUES (1, 'Before');
+"
+
 statement ok
-create table test_geography_auto_discovery_rw (*)
-from geography_source table 'public.test_geography_auto_discovery';
+drop table if exists test_geography_schema_change_rw;
 
-query T retry 10 backoff 1s
-select c.data_type
-from rw_catalog.rw_columns c
-join rw_catalog.rw_tables t on c.relation_id = t.id
-where t.name = 'test_geography_auto_discovery_rw' and c.name = 'location';
-----
-bytea
-
-query IT retry 10 backoff 1s
-select id, encode(location, 'hex') from test_geography_auto_discovery_rw where id = 1;
-----
-1 0101000020e610000050fc1873d79a5ec0d0d556ec2fe34240
-
-# Test automatic schema changes.
 statement ok
 create table test_geography_schema_change_rw (*)
 from geography_source table 'public.test_geography_schema_change';
 
-query IT retry 10 backoff 1s
-select id, name from test_geography_schema_change_rw where id = 1;
+query ITTT retry 10 backoff 1s
+select
+    ours.id,
+    ours.name,
+    upstream.upstream_name,
+    ours.name = upstream.upstream_name
+from test_geography_schema_change_rw as ours
+join (
+    select * from postgres_query(
+        '${PGHOST:localhost}',
+        '${PGPORT:5432}',
+        '${PGUSER:$USER}',
+        '${PGPASSWORD:}',
+        '${PGDATABASE:postgres}',
+        'select id, name as upstream_name from test_geography_schema_change where id = 1'
+    )
+) as upstream(id, upstream_name) on ours.id = upstream.id
+where ours.id = 1;
 ----
-1 Before
+1 Before Before t
 
 system ok
 psql -c "
@@ -236,71 +567,88 @@ order by c.name;
 location bytea
 locations bytea[]
 
-query ITT retry 10 backoff 1s
-select id, location is null, locations is null
-from test_geography_schema_change_rw where id = 1;
-----
-1 t t
-
-query ITTT retry 10 backoff 1s
+query ITTTTTT retry 10 backoff 1s
 select
-    id,
-    encode(location, 'hex'),
-    encode(locations[1], 'hex'),
-    encode(locations[2], 'hex')
-from test_geography_schema_change_rw where id = 2;
+    ours.id,
+    ours.location is null,
+    upstream.upstream_location_is_null,
+    (ours.location is null) = upstream.upstream_location_is_null,
+    ours.locations is null,
+    upstream.upstream_locations_is_null,
+    (ours.locations is null) = upstream.upstream_locations_is_null
+from test_geography_schema_change_rw as ours
+join (
+    select * from postgres_query(
+        '${PGHOST:localhost}',
+        '${PGPORT:5432}',
+        '${PGUSER:$USER}',
+        '${PGPASSWORD:}',
+        '${PGDATABASE:postgres}',
+        'select id, location is null as upstream_location_is_null, locations is null as upstream_locations_is_null from test_geography_schema_change where id = 1'
+    )
+) as upstream(id, upstream_location_is_null, upstream_locations_is_null)
+on ours.id = upstream.id
+where ours.id = 1;
 ----
-2 0101000020e6100000a54e4013613f5ac0029a081b9ede4340 0101000020e610000055c1a8a44ee855c00e4faf9465f04440 0101000020e6100000aaf1d24d628052c05e4bc8073d5b4440
+1 t t t t t t
 
-# Test a different geography type.
+query ITTTTTTTTT retry 10 backoff 1s
+select
+    ours.id,
+    encode(ours.location, 'hex'),
+    upstream.upstream_location_hex,
+    encode(ours.location, 'hex') = upstream.upstream_location_hex,
+    encode(ours.locations[1], 'hex'),
+    upstream.upstream_location_1_hex,
+    encode(ours.locations[1], 'hex') = upstream.upstream_location_1_hex,
+    encode(ours.locations[2], 'hex'),
+    upstream.upstream_location_2_hex,
+    encode(ours.locations[2], 'hex') = upstream.upstream_location_2_hex
+from test_geography_schema_change_rw as ours
+join (
+    select * from postgres_query(
+        '${PGHOST:localhost}',
+        '${PGPORT:5432}',
+        '${PGUSER:$USER}',
+        '${PGPASSWORD:}',
+        '${PGDATABASE:postgres}',
+        'select id, encode(location, ''hex'') as upstream_location_hex, encode(locations[1], ''hex'') as upstream_location_1_hex, encode(locations[2], ''hex'') as upstream_location_2_hex from test_geography_schema_change where id = 2'
+    )
+) as upstream(id, upstream_location_hex, upstream_location_1_hex, upstream_location_2_hex)
+on ours.id = upstream.id
+where ours.id = 2;
+----
+2 0101000020e6100000a54e4013613f5ac0029a081b9ede4340 0101000020e6100000a54e4013613f5ac0029a081b9ede4340 t 0101000020e610000055c1a8a44ee855c00e4faf9465f04440 0101000020e610000055c1a8a44ee855c00e4faf9465f04440 t 0101000020e6100000aaf1d24d628052c05e4bc8073d5b4440 0101000020e6100000aaf1d24d628052c05e4bc8073d5b4440 t
+
+# Teardown
+statement ok
+drop table if exists test_geography_line;
+
+statement ok
+drop table if exists test_geography;
+
+statement ok
+drop table if exists test_geography_array;
+
+statement ok
+drop table if exists test_geography_auto_discovery_rw;
+
+statement ok
+drop table if exists test_geography_array_auto_discovery_rw;
+
+statement ok
+drop table if exists test_geography_schema_change_rw;
+
+statement ok
+drop source if exists geography_source;
+
 system ok
 psql -c "
-    DROP TABLE IF EXISTS test_geography_line CASCADE;
-    CREATE TABLE test_geography_line (
-        id int PRIMARY KEY,
-        name varchar,
-        path geography(LineString, 4326)
-    );
-    INSERT INTO test_geography_line VALUES
-        (1, 'Route1', ST_SetSRID(ST_MakeLine(ST_MakePoint(-87.6298, 41.8781), ST_MakePoint(-74.0060, 40.7128)), 4326));
-"
-
-statement ok
-create table test_geography_line (
-    id int primary key,
-    name varchar,
-    path bytea
-) from geography_source table 'public.test_geography_line';
-
-query IT retry 10 backoff 1s
-select id, encode(path, 'hex') from test_geography_line where id = 1;
-----
-1 0102000020e61000000200000055c1a8a44ee855c00e4faf9465f04440aaf1d24d628052c05e4bc8073d5b4440
-
-# Clean up.
-statement ok
-drop table test_geography_line;
-
-statement ok
-drop table test_geography;
-
-statement ok
-drop table test_geography_array;
-
-statement ok
-drop table test_geography_auto_discovery_rw;
-
-statement ok
-drop table test_geography_schema_change_rw;
-
-statement ok
-drop source geography_source;
-
-system ok
-psql -c "
-    DROP TABLE IF EXISTS test_geography CASCADE;
-    DROP TABLE IF EXISTS test_geography_array CASCADE;
-    DROP TABLE IF EXISTS test_geography_auto_discovery CASCADE;
-    DROP TABLE IF EXISTS test_geography_schema_change CASCADE;
-    DROP TABLE IF EXISTS test_geography_line CASCADE;
+    DROP TABLE IF EXISTS test_geography;
+    DROP TABLE IF EXISTS test_geography_array;
+    DROP TABLE IF EXISTS test_geography_line;
+    DROP TABLE IF EXISTS test_geography_invalid_mapping_upstream;
+    DROP TABLE IF EXISTS test_geography_auto_discovery;
+    DROP TABLE IF EXISTS test_geography_array_auto_discovery;
+    DROP TABLE IF EXISTS test_geography_schema_change;
 "

--- a/e2e_test/source_inline/cdc/postgres/postgres_postgis_geography.slt
+++ b/e2e_test/source_inline/cdc/postgres/postgres_postgis_geography.slt
@@ -5,11 +5,10 @@ control substitution on
 system ok
 psql -c "
     CREATE EXTENSION IF NOT EXISTS postgis;
-
     DROP TABLE IF EXISTS test_geography CASCADE;
+    DROP TABLE IF EXISTS test_geography_array CASCADE;
     DROP TABLE IF EXISTS test_geography_auto_discovery CASCADE;
     DROP TABLE IF EXISTS test_geography_schema_change CASCADE;
-
     CREATE TABLE test_geography (
         id int PRIMARY KEY,
         name varchar,
@@ -18,14 +17,26 @@ psql -c "
     INSERT INTO test_geography VALUES
         (1, 'Chicago', ST_SetSRID(ST_MakePoint(-87.6298, 41.8781), 4326)),
         (2, 'NewYork', ST_SetSRID(ST_MakePoint(-74.0060, 40.7128), 4326));
-
+    CREATE TABLE test_geography_array (
+        id int PRIMARY KEY,
+        name varchar,
+        locations geography(Point, 4326)[]
+    );
+    INSERT INTO test_geography_array VALUES
+        (
+            1,
+            'InitialRoute',
+            ARRAY[
+                ST_SetSRID(ST_MakePoint(-87.6298, 41.8781), 4326),
+                ST_SetSRID(ST_MakePoint(-74.0060, 40.7128), 4326)
+            ]::geography(Point, 4326)[]
+        );
     CREATE TABLE test_geography_auto_discovery (
         id int PRIMARY KEY,
         location geography(Point, 4326)
     );
     INSERT INTO test_geography_auto_discovery VALUES
         (1, ST_SetSRID(ST_MakePoint(-122.4194, 37.7749), 4326));
-
     CREATE TABLE test_geography_schema_change (
         id int PRIMARY KEY,
         name varchar
@@ -52,6 +63,18 @@ create table test_geography (
     name varchar,
     location bytea
 ) from geography_source table 'public.test_geography';
+
+statement ok
+create table test_geography_array (*)
+from geography_source table 'public.test_geography_array';
+
+query T retry 10 backoff 1s
+select c.data_type
+from rw_catalog.rw_columns c
+join rw_catalog.rw_tables t on c.relation_id = t.id
+where t.name = 'test_geography_array' and c.name = 'locations';
+----
+bytea[]
 
 # Backfill preserves the complete EWKB bytes.
 query IT retry 10 backoff 1s
@@ -96,6 +119,59 @@ select id, name, location from test_geography where id = 4;
 ----
 4 NullLocation NULL
 
+# Test geography[] backfill.
+query ITTT retry 10 backoff 1s
+select id, name, encode(locations[1], 'hex'), encode(locations[2], 'hex')
+from test_geography_array where id = 1;
+----
+1 InitialRoute 0101000020e610000055c1a8a44ee855c00e4faf9465f04440 0101000020e6100000aaf1d24d628052c05e4bc8073d5b4440
+
+# Test incremental INSERT into geography[].
+system ok
+psql -c "
+    INSERT INTO test_geography_array VALUES
+        (
+            2,
+            'InsertedRoute',
+            ARRAY[
+                ST_SetSRID(ST_MakePoint(-0.1278, 51.5074), 4326),
+                ST_SetSRID(ST_MakePoint(-122.4194, 37.7749), 4326)
+            ]::geography(Point, 4326)[]
+        );
+"
+
+query ITTT retry 10 backoff 1s
+select id, name, encode(locations[1], 'hex'), encode(locations[2], 'hex')
+from test_geography_array where id = 2;
+----
+2 InsertedRoute 0101000020e6100000ebe2361ac05bc0bfc5feb27bf2c04940 0101000020e610000050fc1873d79a5ec0d0d556ec2fe34240
+
+# Test incremental UPDATE of geography[].
+system ok
+psql -c "
+    UPDATE test_geography_array
+    SET locations = ARRAY[
+        ST_SetSRID(ST_MakePoint(0, 0), 4326),
+        ST_SetSRID(ST_MakePoint(-104.9903, 39.7392), 4326)
+    ]::geography(Point, 4326)[]
+    WHERE id = 1;
+"
+
+query ITT retry 10 backoff 1s
+select id, encode(locations[1], 'hex'), encode(locations[2], 'hex')
+from test_geography_array where id = 1;
+----
+1 0101000020e610000000000000000000000000000000000000 0101000020e6100000a54e4013613f5ac0029a081b9ede4340
+
+# Test incremental DELETE from geography[].
+system ok
+psql -c "DELETE FROM test_geography_array WHERE id = 2;"
+
+query I retry 10 backoff 1s
+select count(*) from test_geography_array where id = 2;
+----
+0
+
 # Test automatic schema discovery.
 statement ok
 create table test_geography_auto_discovery_rw (*)
@@ -127,28 +203,46 @@ select id, name from test_geography_schema_change_rw where id = 1;
 system ok
 psql -c "
     ALTER TABLE test_geography_schema_change
-        ADD COLUMN location geography(Point, 4326);
+        ADD COLUMN location geography(Point, 4326),
+        ADD COLUMN locations geography(Point, 4326)[];
     INSERT INTO test_geography_schema_change VALUES
-        (2, 'After', ST_SetSRID(ST_MakePoint(-104.9903, 39.7392), 4326));
+        (
+            2,
+            'After',
+            ST_SetSRID(ST_MakePoint(-104.9903, 39.7392), 4326),
+            ARRAY[
+                ST_SetSRID(ST_MakePoint(-87.6298, 41.8781), 4326),
+                ST_SetSRID(ST_MakePoint(-74.0060, 40.7128), 4326)
+            ]::geography(Point, 4326)[]
+        );
 "
 
-query T retry 10 backoff 1s
-select c.data_type
+query TT retry 10 backoff 1s
+select c.name, c.data_type
 from rw_catalog.rw_columns c
 join rw_catalog.rw_tables t on c.relation_id = t.id
-where t.name = 'test_geography_schema_change_rw' and c.name = 'location';
+where t.name = 'test_geography_schema_change_rw'
+  and c.name in ('location', 'locations')
+order by c.name;
 ----
-bytea
+location bytea
+locations bytea[]
 
-query IT retry 10 backoff 1s
-select id, location is null from test_geography_schema_change_rw where id = 1;
+query ITT retry 10 backoff 1s
+select id, location is null, locations is null
+from test_geography_schema_change_rw where id = 1;
 ----
-1 t
+1 t t
 
-query IT retry 10 backoff 1s
-select id, encode(location, 'hex') from test_geography_schema_change_rw where id = 2;
+query ITTT retry 10 backoff 1s
+select
+    id,
+    encode(location, 'hex'),
+    encode(locations[1], 'hex'),
+    encode(locations[2], 'hex')
+from test_geography_schema_change_rw where id = 2;
 ----
-2 0101000020e6100000a54e4013613f5ac0029a081b9ede4340
+2 0101000020e6100000a54e4013613f5ac0029a081b9ede4340 0101000020e610000055c1a8a44ee855c00e4faf9465f04440 0101000020e6100000aaf1d24d628052c05e4bc8073d5b4440
 
 # Test a different geography type.
 system ok
@@ -183,6 +277,9 @@ statement ok
 drop table test_geography;
 
 statement ok
+drop table test_geography_array;
+
+statement ok
 drop table test_geography_auto_discovery_rw;
 
 statement ok
@@ -194,6 +291,7 @@ drop source geography_source;
 system ok
 psql -c "
     DROP TABLE IF EXISTS test_geography CASCADE;
+    DROP TABLE IF EXISTS test_geography_array CASCADE;
     DROP TABLE IF EXISTS test_geography_auto_discovery CASCADE;
     DROP TABLE IF EXISTS test_geography_schema_change CASCADE;
     DROP TABLE IF EXISTS test_geography_line CASCADE;

--- a/e2e_test/source_inline/cdc/postgres/postgres_postgis_geography.slt
+++ b/e2e_test/source_inline/cdc/postgres/postgres_postgis_geography.slt
@@ -1,0 +1,200 @@
+control substitution on
+
+# PostGIS geography type CDC test
+
+system ok
+psql -c "
+    CREATE EXTENSION IF NOT EXISTS postgis;
+
+    DROP TABLE IF EXISTS test_geography CASCADE;
+    DROP TABLE IF EXISTS test_geography_auto_discovery CASCADE;
+    DROP TABLE IF EXISTS test_geography_schema_change CASCADE;
+
+    CREATE TABLE test_geography (
+        id int PRIMARY KEY,
+        name varchar,
+        location geography(Point, 4326)
+    );
+    INSERT INTO test_geography VALUES
+        (1, 'Chicago', ST_SetSRID(ST_MakePoint(-87.6298, 41.8781), 4326)),
+        (2, 'NewYork', ST_SetSRID(ST_MakePoint(-74.0060, 40.7128), 4326));
+
+    CREATE TABLE test_geography_auto_discovery (
+        id int PRIMARY KEY,
+        location geography(Point, 4326)
+    );
+    INSERT INTO test_geography_auto_discovery VALUES
+        (1, ST_SetSRID(ST_MakePoint(-122.4194, 37.7749), 4326));
+
+    CREATE TABLE test_geography_schema_change (
+        id int PRIMARY KEY,
+        name varchar
+    );
+    INSERT INTO test_geography_schema_change VALUES (1, 'Before');
+"
+
+statement ok
+create source geography_source with (
+  connector = 'postgres-cdc',
+  hostname = '${PGHOST:localhost}',
+  port = '${PGPORT:5432}',
+  username = '${PGUSER:$USER}',
+  password = '${PGPASSWORD:}',
+  database.name = '${PGDATABASE:postgres}',
+  schema.name = 'public',
+  slot.name = 'geography_slot',
+  auto.schema.change = 'true'
+);
+
+statement ok
+create table test_geography (
+    id int primary key,
+    name varchar,
+    location bytea
+) from geography_source table 'public.test_geography';
+
+# Backfill preserves the complete EWKB bytes.
+query IT retry 10 backoff 1s
+select id, encode(location, 'hex') from test_geography order by id;
+----
+1 0101000020e610000055c1a8a44ee855c00e4faf9465f04440
+2 0101000020e6100000aaf1d24d628052c05e4bc8073d5b4440
+
+# Test incremental INSERT.
+system ok
+psql -c "INSERT INTO test_geography VALUES (3, 'London', ST_SetSRID(ST_MakePoint(-0.1278, 51.5074), 4326));"
+
+query IT retry 10 backoff 1s
+select id, encode(location, 'hex') from test_geography where id = 3;
+----
+3 0101000020e6100000ebe2361ac05bc0bfc5feb27bf2c04940
+
+# Test incremental UPDATE.
+system ok
+psql -c "UPDATE test_geography SET location = ST_SetSRID(ST_MakePoint(0, 0), 4326) WHERE id = 1;"
+
+query IT retry 10 backoff 1s
+select id, encode(location, 'hex') from test_geography where id = 1;
+----
+1 0101000020e610000000000000000000000000000000000000
+
+# Test incremental DELETE.
+system ok
+psql -c "DELETE FROM test_geography WHERE id = 2;"
+
+query I retry 10 backoff 1s
+select count(*) from test_geography where id = 2;
+----
+0
+
+# Test NULL geography.
+system ok
+psql -c "INSERT INTO test_geography VALUES (4, 'NullLocation', NULL);"
+
+query ITI retry 10 backoff 1s
+select id, name, location from test_geography where id = 4;
+----
+4 NullLocation NULL
+
+# Test automatic schema discovery.
+statement ok
+create table test_geography_auto_discovery_rw (*)
+from geography_source table 'public.test_geography_auto_discovery';
+
+query T retry 10 backoff 1s
+select c.data_type
+from rw_catalog.rw_columns c
+join rw_catalog.rw_tables t on c.relation_id = t.id
+where t.name = 'test_geography_auto_discovery_rw' and c.name = 'location';
+----
+bytea
+
+query IT retry 10 backoff 1s
+select id, encode(location, 'hex') from test_geography_auto_discovery_rw where id = 1;
+----
+1 0101000020e610000050fc1873d79a5ec0d0d556ec2fe34240
+
+# Test automatic schema changes.
+statement ok
+create table test_geography_schema_change_rw (*)
+from geography_source table 'public.test_geography_schema_change';
+
+query IT retry 10 backoff 1s
+select id, name from test_geography_schema_change_rw where id = 1;
+----
+1 Before
+
+system ok
+psql -c "
+    ALTER TABLE test_geography_schema_change
+        ADD COLUMN location geography(Point, 4326);
+    INSERT INTO test_geography_schema_change VALUES
+        (2, 'After', ST_SetSRID(ST_MakePoint(-104.9903, 39.7392), 4326));
+"
+
+query T retry 10 backoff 1s
+select c.data_type
+from rw_catalog.rw_columns c
+join rw_catalog.rw_tables t on c.relation_id = t.id
+where t.name = 'test_geography_schema_change_rw' and c.name = 'location';
+----
+bytea
+
+query IT retry 10 backoff 1s
+select id, location is null from test_geography_schema_change_rw where id = 1;
+----
+1 t
+
+query IT retry 10 backoff 1s
+select id, encode(location, 'hex') from test_geography_schema_change_rw where id = 2;
+----
+2 0101000020e6100000a54e4013613f5ac0029a081b9ede4340
+
+# Test a different geography type.
+system ok
+psql -c "
+    DROP TABLE IF EXISTS test_geography_line CASCADE;
+    CREATE TABLE test_geography_line (
+        id int PRIMARY KEY,
+        name varchar,
+        path geography(LineString, 4326)
+    );
+    INSERT INTO test_geography_line VALUES
+        (1, 'Route1', ST_SetSRID(ST_MakeLine(ST_MakePoint(-87.6298, 41.8781), ST_MakePoint(-74.0060, 40.7128)), 4326));
+"
+
+statement ok
+create table test_geography_line (
+    id int primary key,
+    name varchar,
+    path bytea
+) from geography_source table 'public.test_geography_line';
+
+query IT retry 10 backoff 1s
+select id, encode(path, 'hex') from test_geography_line where id = 1;
+----
+1 0102000020e61000000200000055c1a8a44ee855c00e4faf9465f04440aaf1d24d628052c05e4bc8073d5b4440
+
+# Clean up.
+statement ok
+drop table test_geography_line;
+
+statement ok
+drop table test_geography;
+
+statement ok
+drop table test_geography_auto_discovery_rw;
+
+statement ok
+drop table test_geography_schema_change_rw;
+
+statement ok
+drop source geography_source;
+
+system ok
+psql -c "
+    DROP TABLE IF EXISTS test_geography CASCADE;
+    DROP TABLE IF EXISTS test_geography_auto_discovery CASCADE;
+    DROP TABLE IF EXISTS test_geography_schema_change CASCADE;
+    DROP TABLE IF EXISTS test_geography_line CASCADE;
+"

--- a/e2e_test/source_inline/cdc/postgres/postgres_postgis_geography.slt
+++ b/e2e_test/source_inline/cdc/postgres/postgres_postgis_geography.slt
@@ -64,6 +64,14 @@ create table test_geography (
     location bytea
 ) from geography_source table 'public.test_geography';
 
+# A geography column cannot be mapped to a non-bytea RisingWave type.
+statement error Incompatible data type of column location
+create table test_geography_invalid_mapping (
+    id int primary key,
+    name varchar,
+    location varchar
+) from geography_source table 'public.test_geography';
+
 statement ok
 create table test_geography_array (*)
 from geography_source table 'public.test_geography_array';

--- a/e2e_test/source_inline/cdc/postgres/postgres_postgis_geometry.slt
+++ b/e2e_test/source_inline/cdc/postgres/postgres_postgis_geometry.slt
@@ -296,6 +296,28 @@ select id, name, location from test_geo where id = 4;
 ----
 4 NullLocation NULL
 
+# Test automatic schema discovery maps geometry to bytea.
+system ok
+psql -c "
+    DROP TABLE IF EXISTS test_geo_auto_discovery CASCADE;
+    CREATE TABLE test_geo_auto_discovery (
+        id int PRIMARY KEY,
+        location geometry(Point, 4326)
+    );
+"
+
+statement ok
+create table test_geo_auto_discovery_rw (*)
+from geo_source table 'public.test_geo_auto_discovery';
+
+query T
+select c.data_type
+from rw_catalog.rw_columns c
+join rw_catalog.rw_tables t on c.relation_id = t.id
+where t.name = 'test_geo_auto_discovery_rw' and c.name = 'location';
+----
+bytea
+
 # Test with different geometry types (LineString)
 system ok
 psql -c "
@@ -336,6 +358,9 @@ statement ok
 drop table test_geo_line;
 
 statement ok
+drop table test_geo_auto_discovery_rw;
+
+statement ok
 drop table test_geo_array;
 
 statement ok
@@ -348,5 +373,6 @@ system ok
 psql -c "
     DROP TABLE IF EXISTS test_geo CASCADE;
     DROP TABLE IF EXISTS test_geo_array CASCADE;
+    DROP TABLE IF EXISTS test_geo_auto_discovery CASCADE;
     DROP TABLE IF EXISTS test_geo_line CASCADE;
 "

--- a/src/common/src/catalog/cdc_type_compatibility.rs
+++ b/src/common/src/catalog/cdc_type_compatibility.rs
@@ -169,7 +169,7 @@ fn postgres_source_column_type_compatible(
             rw_type == PbTypeName::Time
         }
         "interval" => rw_type == PbTypeName::Interval,
-        "bytea" | "geometry" => rw_type == PbTypeName::Bytea,
+        "bytea" | "geometry" | "geography" => rw_type == PbTypeName::Bytea,
         "json" | "jsonb" => rw_type == PbTypeName::Jsonb,
         "date" => rw_type == PbTypeName::Date,
         "numeric" => matches!(
@@ -181,7 +181,7 @@ fn postgres_source_column_type_compatible(
         "array" => rw_type == PbTypeName::List,
         "user-defined" => match udt_name.map(str::to_ascii_lowercase).as_deref() {
             Some("citext") => rw_type == PbTypeName::Varchar,
-            Some("geometry") => rw_type == PbTypeName::Bytea,
+            Some("geometry" | "geography") => rw_type == PbTypeName::Bytea,
             Some("vector") => rw_type == PbTypeName::Vector,
             Some("ltree" | "hstore") | None => false,
             Some(_) => rw_type == PbTypeName::Varchar,

--- a/src/common/src/types/from_sql.rs
+++ b/src/common/src/types/from_sql.rs
@@ -47,8 +47,8 @@ impl<'a> FromSql<'a> for ScalarImpl {
             {
                 ScalarImpl::from(String::from_sql(ty, raw)?)
             }
-            // PostGIS geometry type: read as EWKB bytes
-            ref ty if ty.name() == "geometry" => {
+            // PostGIS spatial types: read as EWKB bytes.
+            ref ty if matches!(ty.name(), "geometry" | "geography") => {
                 ScalarImpl::from(Vec::<u8>::from_sql(ty, raw)?.into_boxed_slice())
             }
             // Serial, Int256, Struct, List and Decimal are not supported here
@@ -83,6 +83,7 @@ impl<'a> FromSql<'a> for ScalarImpl {
             || ty.name() == "ltree"
             || ty.name() == "lquery"
             || ty.name() == "ltxtquery"
+            || ty.name() == "geography"
             || ty.name() == "geometry")
     }
 }

--- a/src/connector/src/connector_common/postgres.rs
+++ b/src/connector/src/connector_common/postgres.rs
@@ -742,6 +742,8 @@ pub fn sea_type_to_rw_type(col_type: &SeaType) -> ConnectorResult<DataType> {
         SeaType::Unknown(name) => {
             if let Some(dim) = parse_pgvector_dimension(name)? {
                 DataType::Vector(dim)
+            } else if matches!(name.to_ascii_lowercase().as_str(), "geometry" | "geography") {
+                DataType::Bytea
             } else {
                 // NOTES: user-defined enum type is classified as `Unknown`
                 tracing::warn!("Unknown Postgres data type: {name}, map to varchar");

--- a/src/connector/src/parser/unified/json.rs
+++ b/src/connector/src/parser/unified/json.rs
@@ -37,9 +37,9 @@ use super::{Access, AccessError, AccessResult};
 use crate::parser::DatumCow;
 use crate::schema::{InvalidOptionError, bail_invalid_option_error};
 
-/// Try to parse a Debezium PostGIS spatial object.
+/// Try to parse a Debezium `PostGIS` spatial object.
 ///
-/// Debezium represents PostGIS `geometry` and `geography` values as an object:
+/// Debezium represents `PostGIS` `geometry` and `geography` values as an object:
 /// `{"srid": <int>, "wkb": <base64_string>}`.
 /// For our current Postgres CDC ingestion, the `wkb` field is expected to be EWKB bytes (base64-encoded),
 /// and `srid` is redundant. We decode `wkb` into raw bytes and store it as `bytea`.

--- a/src/connector/src/parser/unified/json.rs
+++ b/src/connector/src/parser/unified/json.rs
@@ -37,9 +37,10 @@ use super::{Access, AccessError, AccessResult};
 use crate::parser::DatumCow;
 use crate::schema::{InvalidOptionError, bail_invalid_option_error};
 
-/// Try to parse Debezium `PostGIS` `geometry` object.
+/// Try to parse a Debezium PostGIS spatial object.
 ///
-/// Debezium represents `PostGIS` `geometry` as an object: `{"srid": <int>, "wkb": <base64_string>}`.
+/// Debezium represents PostGIS `geometry` and `geography` values as an object:
+/// `{"srid": <int>, "wkb": <base64_string>}`.
 /// For our current Postgres CDC ingestion, the `wkb` field is expected to be EWKB bytes (base64-encoded),
 /// and `srid` is redundant. We decode `wkb` into raw bytes and store it as `bytea`.
 ///
@@ -47,14 +48,14 @@ use crate::schema::{InvalidOptionError, bail_invalid_option_error};
 /// unification across connectors (e.g., MySQL): see `GeometryFormatTransformer`.
 ///
 /// Return semantics:
-/// - `Ok(Some(bytes))`: The input matches the Debezium geometry shape (`srid` is numeric AND `wkb` is string),
+/// - `Ok(Some(bytes))`: The input matches the Debezium spatial shape (`srid` is numeric AND `wkb` is string),
 ///   and we successfully decoded `wkb` into bytes.
-/// - `Ok(None)`: The input does NOT look like a Debezium geometry object. This allows the caller to keep the
+/// - `Ok(None)`: The input does NOT look like a Debezium spatial object. This allows the caller to keep the
 ///   match arm focused on dispatching, and avoids misclassifying other JSON objects that might map to `bytea`
 ///   in the future.
-/// - `Err(...)`: The input looks like a Debezium geometry object, but decoding/parsing failed (e.g. invalid
+/// - `Err(...)`: The input looks like a Debezium spatial object, but decoding/parsing failed (e.g. invalid
 ///   base64). This indicates a real data/format error and should not be silently ignored.
-fn try_parse_debezium_geometry_as_bytea(
+fn try_parse_debezium_postgis_spatial_as_bytea(
     value: &BorrowedValue<'_>,
     create_error: impl Fn() -> AccessError,
 ) -> AccessResult<Option<Box<[u8]>>> {
@@ -63,7 +64,7 @@ fn try_parse_debezium_geometry_as_bytea(
         None => return Ok(None),
     };
 
-    // Strictly identify the geometry object by checking both fields and their types.
+    // Strictly identify the spatial object by checking both fields and their types.
     // There may be other objects that map to bytea in the future.
     let srid = obj.get("srid").and_then(|v| v.as_i64());
     let wkb = obj.get("wkb").and_then(|v| v.as_str());
@@ -763,10 +764,11 @@ impl JsonParseOptions {
                         .into(),
                 }
             }
-            // Handle Debezium PostGIS geometry type: {"srid": <int>, "wkb": <base64_string>}
-            // We extract the wkb field and decode it as EWKB bytes
+            // Handle Debezium PostGIS geometry and geography types:
+            // {"srid": <int>, "wkb": <base64_string>}. We extract the wkb field and
+            // decode it as EWKB bytes.
             (DataType::Bytea, ValueType::Object) => {
-                match try_parse_debezium_geometry_as_bytea(value, create_error)? {
+                match try_parse_debezium_postgis_spatial_as_bytea(value, create_error)? {
                     Some(bytes) => bytes.into(),
                     None => Err(create_error())?,
                 }

--- a/src/connector/src/source/cdc/external/postgres.rs
+++ b/src/connector/src/source/cdc/external/postgres.rs
@@ -862,7 +862,7 @@ pub fn type_name_to_pg_type(ty_name: &str) -> Option<PgType> {
             "varchar" => Some(PgType::VARCHAR_ARRAY),
             "text" => Some(PgType::TEXT_ARRAY),
             "bytea" => Some(PgType::BYTEA_ARRAY),
-            "geometry" => Some(PgType::BYTEA_ARRAY), // PostGIS geometry array
+            "geometry" | "geography" => Some(PgType::BYTEA_ARRAY), // PostGIS spatial arrays
             "date" => Some(PgType::DATE_ARRAY),
             "time" => Some(PgType::TIME_ARRAY),
             "timetz" => Some(PgType::TIMETZ_ARRAY),

--- a/src/connector/src/source/cdc/external/postgres.rs
+++ b/src/connector/src/source/cdc/external/postgres.rs
@@ -895,7 +895,7 @@ pub fn type_name_to_pg_type(ty_name: &str) -> Option<PgType> {
             "char" | "character" | "bpchar" => Some(PgType::BPCHAR),
             "citext" | "text" => Some(PgType::TEXT),
             "bytea" => Some(PgType::BYTEA),
-            "geometry" => Some(PgType::BYTEA), // PostGIS geometry type
+            "geometry" | "geography" => Some(PgType::BYTEA), // PostGIS spatial types
             "date" => Some(PgType::DATE),
             "time" => Some(PgType::TIME),
             "timetz" => Some(PgType::TIMETZ),


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

<!--

**Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->
Closes part of #25517

Support for PostGIS `geography` type is added based on [this](https://github.com/risingwavelabs/risingwave/pull/24491) PR. 

Changes:
- Add PostgreSQL CDC support for PostGIS `geography` and `geography[]`.
- Map `geography` to RisingWave `bytea` and `geography[]` to `bytea[]`, preserving their EWKB representation.
- Support these types during:
    - snapshot backfill,
    - incremental CDC events,
    - automatic schema discovery,
    - explicit schema validation, and
    - automatic schema changes.
- Fix automatic schema discovery for PostGIS `geometry`, which was missed by the reference implementation in #24491.
- Add a regression test confirming that automatically discovered `geometry` columns use `bytea` rather than `varchar`.

Current limitation:
- Rejection of an incompatible explicitly specified type for `geography[]`
     is not enabled in the test because explicit array schema validation does
     not currently validate the element type correctly.

Tests:
- **Correct explicit schemas**
    - Verify `geography` → `bytea`.
    - Verify `geography[]` → `bytea[]`.
    - Verify another geography subtype, `LineString`, maps to `bytea`.
    - Assert catalog metadata before validating backfilled values.

- **Incorrect explicit schemas**
    - Verify mapping scalar `geography` to `varchar` is rejected.
    - Document the currently disabled `geography[]` rejection case.

- **Automatic schema discovery**
    - Verify scalar `geography` is inferred as `bytea`.
    - Verify `geography[]` is inferred as `bytea[]`.
    - Verify `geometry` is inferred as `bytea` rather than `varchar`.

- **Incremental CDC**
    - Verify scalar and array INSERT events.
    - Verify insertion of a NULL scalar geography value.
    - Verify scalar and array UPDATE events.
    - Verify scalar and array DELETE events.

- **Automatic schema changes**
    - Add `geography` and `geography[]` columns upstream.
    - Verify RisingWave discovers them as `bytea` and `bytea[]`.
    - Verify existing rows receive NULL values and new rows contain the
       expected EWKB values.

- **Data validation**
    - Preserve fixed golden EWKB values to detect representation changes.
    - Query PostgreSQL at runtime and assert that RisingWave contains the
       exact same bytes.


## Checklist

- [x] I have written necessary rustdoc comments.
- [x] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [x] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

PostgreSQL CDC sources now support PostGIS `geography` and `geography[]`
columns. RisingWave maps these types to `bytea` and `bytea[]`, preserving
their EWKB representation during backfill, incremental changes, automatic
schema discovery, and automatic schema changes.

</details>
