### PR TITLE
fix(sink): scope clickhouse decimal precision check and make it consistent

### DIFF
--- a/ci/scripts/e2e-clickhouse-sink-test.sh
+++ b/ci/scripts/e2e-clickhouse-sink-test.sh
@@ -25,9 +25,10 @@ sink_test_env_setup "$profile"
 
 
 echo "--- create clickhouse table"
+# v9 is left out of the sink on purpose: a Decimal256 column the sink does not write must not break it.
 curl https://clickhouse.com/ | sh
 sleep 2
-./clickhouse client --host=clickhouse-server --port=9000 --password='default' --query="SET enable_json_type = 1;CREATE table demo_test(v1 Int32,v2 Int64,v3 String,v4 Enum16('A'=1,'B'=2), v5 decimal64(3), v6 Nullable(String), v7 DateTime64(6), v8 json)ENGINE = ReplacingMergeTree PRIMARY KEY (v1);"
+./clickhouse client --host=clickhouse-server --port=9000 --password='default' --query="SET enable_json_type = 1;CREATE table demo_test(v1 Int32,v2 Int64,v3 String,v4 Enum16('A'=1,'B'=2), v5 decimal64(3), v6 Nullable(String), v7 DateTime64(6), v8 json, v9 Decimal(76, 4))ENGINE = ReplacingMergeTree PRIMARY KEY (v1);"
 
 echo "--- testing sinks"
 sqllogictest -p 4566 -d dev './e2e_test/sink/clickhouse_sink.slt'

--- a/src/connector/src/sink/clickhouse.rs
+++ b/src/connector/src/sink/clickhouse.rs
@@ -55,6 +55,10 @@ const ALLOW_EXPERIMENTAL_JSON_TYPE: &str = "allow_experimental_json_type";
 const INPUT_FORMAT_BINARY_READ_JSON_AS_STRING: &str = "input_format_binary_read_json_as_string";
 const OUTPUT_FORMAT_BINARY_WRITE_JSON_AS_STRING: &str = "output_format_binary_write_json_as_string";
 
+/// `ClickHouse` backs `Decimal(P, S)` with `Decimal256` once `P > 38`, which takes 32 bytes on the
+/// wire, while [`ClickHouseDecimal`] never writes more than 16.
+const MAX_ENCODABLE_DECIMAL_PRECISION: u8 = 38;
+
 #[serde_as]
 #[derive(Deserialize, Debug, Clone, WithOptions)]
 pub struct ClickHouseCommon {
@@ -482,7 +486,23 @@ impl ClickHouseSink {
             }
             risingwave_common::types::DataType::Float32 => Ok(ck_column.r#type.contains("Float32")),
             risingwave_common::types::DataType::Float64 => Ok(ck_column.r#type.contains("Float64")),
-            risingwave_common::types::DataType::Decimal => Ok(ck_column.r#type.contains("Decimal")),
+            risingwave_common::types::DataType::Decimal => {
+                match parse_decimal_accuracy(&ck_column.r#type)? {
+                    Some((precision, _)) if precision > MAX_ENCODABLE_DECIMAL_PRECISION => {
+                        Err(SinkError::ClickHouse(format!(
+                            "column {:?} has ClickHouse type `{}`: precision {} is backed by Decimal256, \
+                             but this sink can only encode decimals up to precision {}. Lower the column \
+                             precision (recreating the table if it is a key column), or leave the column \
+                             out of the sink.",
+                            ck_column.name,
+                            ck_column.r#type,
+                            precision,
+                            MAX_ENCODABLE_DECIMAL_PRECISION,
+                        )))
+                    }
+                    accuracy => Ok(accuracy.is_some()),
+                }
+            }
             risingwave_common::types::DataType::Date => Ok(ck_column.r#type.contains("Date32")),
             risingwave_common::types::DataType::Varchar => Ok(ck_column.r#type.contains("String")),
             risingwave_common::types::DataType::Time => Err(SinkError::ClickHouse(
@@ -651,10 +671,23 @@ impl ClickHouseSinkWriter {
                 .iter()
                 .map(Self::build_column_correct_map)
                 .collect();
-        let mut rw_fields_name_after_calibration = build_fields_name_type_from_schema(&schema)?
+        let sink_fields = build_fields_name_type_from_schema(&schema)?;
+
+        // The table may have been altered since `CREATE SINK` validated it, and an under-sized
+        // decimal encoding would desync every following column of the same RowBinary row. Only
+        // columns the writer encodes as decimals are held to the decimal rule.
+        let ck_columns: HashMap<&str, &SystemColumn> = clickhouse_column
             .iter()
-            .map(|(a, _)| a.clone())
-            .collect_vec();
+            .map(|c| (c.name.as_str(), c))
+            .collect();
+        for (name, data_type) in sink_fields.iter().filter(|(_, t)| contains_decimal(t)) {
+            if let Some(ck_column) = ck_columns.get(name.as_str()) {
+                ClickHouseSink::check_and_correct_column_type(data_type, ck_column)?;
+            }
+        }
+
+        let mut rw_fields_name_after_calibration =
+            sink_fields.iter().map(|(a, _)| a.clone()).collect_vec();
 
         if let Some(sign) = clickhouse_engine.get_sign_name() {
             rw_fields_name_after_calibration.push(sign);
@@ -699,38 +732,7 @@ impl ClickHouseSinkWriter {
         } else {
             0_u8
         };
-        let accuracy_decimal = if ck_column.r#type.contains("Decimal(") {
-            let decimal_all = ck_column
-                .r#type
-                .split("Decimal(")
-                .last()
-                .ok_or_else(|| SinkError::ClickHouse("must have last".to_owned()))?
-                .split(')')
-                .next()
-                .ok_or_else(|| SinkError::ClickHouse("must have next".to_owned()))?
-                .split(", ")
-                .collect_vec();
-            let length = decimal_all
-                .first()
-                .ok_or_else(|| SinkError::ClickHouse("must have next".to_owned()))?
-                .parse::<u8>()
-                .map_err(|e| SinkError::ClickHouse(e.to_report_string()))?;
-
-            if length > 38 {
-                return Err(SinkError::ClickHouse(
-                    "RW don't support Decimal256".to_owned(),
-                ));
-            }
-
-            let scale = decimal_all
-                .last()
-                .ok_or_else(|| SinkError::ClickHouse("must have next".to_owned()))?
-                .parse::<u8>()
-                .map_err(|e| SinkError::ClickHouse(e.to_report_string()))?;
-            (length, scale)
-        } else {
-            (0_u8, 0_u8)
-        };
+        let accuracy_decimal = parse_decimal_accuracy(&ck_column.r#type)?.unwrap_or((0, 0));
         Ok((
             ck_column.name.clone(),
             ClickHouseSchemaFeature {
@@ -831,6 +833,38 @@ struct SystemColumn {
     name: String,
     r#type: String,
     is_in_primary_key: u8,
+}
+
+/// Parse `(precision, scale)` out of a decimal type, or `None` if it is not a decimal.
+/// `system.columns` renders decimals canonically, so `Decimal128(10)` arrives as `Decimal(38, 10)`.
+fn parse_decimal_accuracy(ck_type: &str) -> Result<Option<(u8, u8)>> {
+    let Some((_, rest)) = ck_type.split_once("Decimal(") else {
+        return Ok(None);
+    };
+    let (args, _) = rest
+        .split_once(')')
+        .ok_or_else(|| SinkError::ClickHouse(format!("unterminated decimal type {ck_type:?}")))?;
+    let (precision, scale) = args
+        .split_once(',')
+        .ok_or_else(|| SinkError::ClickHouse(format!("decimal type {ck_type:?} has no scale")))?;
+    let parse = |field: &str| {
+        field.trim().parse::<u8>().map_err(|e| {
+            SinkError::ClickHouse(format!(
+                "cannot parse decimal type {:?}: {}",
+                ck_type,
+                e.to_report_string()
+            ))
+        })
+    };
+    Ok(Some((parse(precision)?, parse(scale)?)))
+}
+
+fn contains_decimal(data_type: &DataType) -> bool {
+    match data_type {
+        DataType::Decimal => true,
+        DataType::List(list) => contains_decimal(list.elem()),
+        _ => false,
+    }
 }
 
 #[derive(ClickHouseRow, Deserialize)]
@@ -1182,5 +1216,51 @@ pub fn build_fields_name_type_from_schema(schema: &Schema) -> Result<Vec<(String
 impl From<::clickhouse::error::Error> for SinkError {
     fn from(value: ::clickhouse::error::Error) -> Self {
         SinkError::ClickHouse(value.to_report_string())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn system_column(ck_type: &str) -> SystemColumn {
+        SystemColumn {
+            name: "amount".to_owned(),
+            r#type: ck_type.to_owned(),
+            is_in_primary_key: 0,
+        }
+    }
+
+    #[test]
+    fn test_parse_decimal_accuracy() {
+        let parse = |ck_type: &str| parse_decimal_accuracy(ck_type).unwrap();
+
+        assert_eq!(parse("Decimal(38, 10)"), Some((38, 10)));
+        assert_eq!(parse("Decimal(38,10)"), Some((38, 10)));
+        assert_eq!(parse("Nullable(Decimal(76, 4))"), Some((76, 4)));
+        assert_eq!(parse("DateTime64(3)"), None);
+
+        assert!(parse_decimal_accuracy("Decimal(38)").is_err());
+    }
+
+    #[test]
+    fn test_decimal_column_check() {
+        let check = |rw_type: &DataType, ck_type: &str| {
+            ClickHouseSink::check_and_correct_column_type(rw_type, &system_column(ck_type))
+        };
+        let decimal_list = DataType::list(DataType::Decimal);
+
+        check(&DataType::Decimal, "Nullable(Decimal(38, 10))").unwrap();
+        check(&decimal_list, "Array(Decimal(9, 2))").unwrap();
+        // Only columns encoded as decimals are held to the precision rule.
+        check(&DataType::Jsonb, "JSON(a Decimal(76, 4), b Decimal(9, 2))").unwrap();
+
+        check(&DataType::Decimal, "String").unwrap_err();
+        let err = check(&DataType::Decimal, "Decimal(76, 4)")
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("amount"), "{err}");
+        assert!(err.contains("Decimal(76, 4)"), "{err}");
+        assert!(err.contains("precision 76"), "{err}");
     }
 }


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

A ClickHouse sink can fail at runtime with `ClickHouse error: RW don't support Decimal256` even when every column it writes is `Decimal128`. Three defects combine to produce that:

- **Scope.** The precision check ran over *every* column returned by `system.columns`, including columns the sink never writes — while `validate()` explicitly allows the ClickHouse table's columns to be a superset of the sink's. A `MATERIALIZED` or `ALIAS` column is enough to trip it: multiplying two `Decimal(38, S)` columns yields `Decimal(76, S1+S2)`.
- **Two standards.** `validate()` matched decimals with `contains("Decimal")`, which accepts `Decimal(76, 4)`; the writer rejected that same column with `precision > 38`. So `CREATE SINK` reported success and the sink then failed forever in the writer retry loop.
- **Message.** `RW don't support Decimal256` named neither the column, nor its actual ClickHouse type, nor the threshold. "Decimal256" may never appear in the user's DDL at all, since `system.columns` renders decimals canonically and any precision in 39..=76 is Decimal256 underneath.

### How it works now

- The decimal rule lives in one place, the `Decimal` arm of `check_and_correct_column_type`: the ClickHouse side must be `Decimal(P, S)` with `P <= 38`. It is keyed on the **RisingWave** column type, so a `jsonb` column pointed at `JSON(a Decimal(76, 4))`, or a `varchar` at `Map(String, Decimal(76, 4))`, is not held to it — those columns are not encoded as decimals.
- `validate()` reaches it through the existing per-column loop, which only sees columns the sink writes, so the scope narrows for free.
- `ClickHouseSinkWriter::new` re-runs the same function for the sink's decimal-typed columns. This stays on purpose: it is the only thing that catches an `ALTER TABLE ... MODIFY COLUMN` landing after validation, and RowBinary has no field delimiters, so an under-sized encoding desyncs every following column of the row.
- The error now carries the column, the type and the precision:

```
column "amount" has ClickHouse type `Decimal(76, 4)`: precision 76 is backed by
Decimal256, but this sink can only encode decimals up to precision 38. Lower the
column precision, or leave the column out of the sink.
```

Rejecting a real Decimal256 remains correct: `ClickHouseDecimal` encodes at most an `i128` (16 bytes) while Decimal256 occupies 32.

### Behavior changes

- A sink whose target table merely *contains* a `Decimal(P > 38)` column now works, instead of failing at runtime.
- A sink that actually *writes* such a column now fails at `CREATE SINK` instead of after creation.
- Recognizing a decimal column now requires the canonical `Decimal(P, S)` form rather than a `contains("Decimal")` substring match. This closes a silent hole: a decimal type that failed to parse used to be accepted and then encoded with scale `0`, turning `1.23` into `1`. `system.columns` always renders decimals in that form, so existing sinks are unaffected.

## Follow-ups

Found while working on this, tracked separately:

- #26690 — the sink caches the target schema at writer construction and never revalidates it, so an `ALTER` during a writer's lifetime silently corrupts data. Scale and `DateTime64` precision changes produce no error at all.
- #26691 — decimal rescaling uses unchecked `i128` arithmetic and `as` narrowing, so an out-of-range value wraps instead of erroring.
- #26694 — `clickhouse.delete.column` is never checked for existence or type.
- #26695 — substring type matching accepts a scalar RisingWave column against a container ClickHouse type.

## Checklist

- [x] I have written necessary rustdoc comments.
- [x] I have added necessary unit tests and integration tests.
- [x] I have added test labels as necessary.
- [ ] I have added fuzzing tests or opened an issue to track them.
- [ ] My PR contains breaking changes.
- [ ] My PR changes performance-critical code, so I will run (micro) benchmarks and present the results.
- [ ] I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into.

## Documentation

- [ ] My PR needs documentation updates.

<details>
<summary><b>Release note</b></summary>

Fixed a ClickHouse sink failure where a sink would be created successfully and then never start, reporting `RW don't support Decimal256`, because the target table contained a column with decimal precision above 38 that the sink did not even write. Sinks that do write such a column are now rejected at `CREATE SINK`, with an error naming the column and its ClickHouse type.

</details>
