### PR TITLE
refactor(meta): label Hummock lock write operations

### DIFF
--- a/src/meta/src/hummock/manager/commit_epoch.rs
+++ b/src/meta/src/hummock/manager/commit_epoch.rs
@@ -146,8 +146,10 @@ impl HummockManager {
                         .clone(),
                     )
                 } else {
-                    let compaction_group_manager_guard =
-                        self.compaction_group_manager.write().await;
+                    let compaction_group_manager_guard = self
+                        .compaction_group_manager
+                        .write_with_process_name("commit_epoch")
+                        .await;
                     let new_compaction_group_config =
                         compaction_group_manager_guard.default_compaction_config();
                     compaction_group_config = Some(new_compaction_group_config.clone());

--- a/src/meta/src/hummock/manager/compaction/compaction_group_manager.rs
+++ b/src/meta/src/hummock/manager/compaction/compaction_group_manager.rs
@@ -176,9 +176,15 @@ impl HummockManager {
         if pairs.is_empty() {
             return Ok(());
         }
-        let mut versioning_guard = self.versioning.write().await;
+        let mut versioning_guard = self
+            .versioning
+            .write_with_process_name("register_table_ids_for_test")
+            .await;
         let versioning = versioning_guard.deref_mut();
-        let mut compaction_group_manager = self.compaction_group_manager.write().await;
+        let mut compaction_group_manager = self
+            .compaction_group_manager
+            .write_with_process_name("register_table_ids_for_test")
+            .await;
         let current_version = &versioning.current_version;
         let default_config = compaction_group_manager.default_compaction_config();
         let mut compaction_groups_txn = compaction_group_manager.start_compaction_groups_txn();
@@ -292,7 +298,10 @@ impl HummockManager {
             }
         }
 
-        let mut versioning_guard = self.versioning.write().await;
+        let mut versioning_guard = self
+            .versioning
+            .write_with_process_name("unregister_table_ids")
+            .await;
         let versioning = versioning_guard.deref_mut();
         let mut version = HummockVersionTransaction::new(
             &mut versioning.current_version,
@@ -368,7 +377,10 @@ impl HummockManager {
 
         // Purge may cause write to meta store. If it hurts performance while holding versioning
         // lock, consider to make it in batch.
-        let mut compaction_group_manager = self.compaction_group_manager.write().await;
+        let mut compaction_group_manager = self
+            .compaction_group_manager
+            .write_with_process_name("unregister_table_ids")
+            .await;
         let mut compaction_groups_txn = compaction_group_manager.start_compaction_groups_txn();
 
         compaction_groups_txn.purge(HashSet::from_iter(get_compaction_group_ids(
@@ -387,7 +399,10 @@ impl HummockManager {
     ) -> Result<()> {
         {
             // Avoid lock conflicts with `try_update_write_limits``
-            let mut compaction_group_manager = self.compaction_group_manager.write().await;
+            let mut compaction_group_manager = self
+                .compaction_group_manager
+                .write_with_process_name("update_compaction_config")
+                .await;
             let mut compaction_groups_txn = compaction_group_manager.start_compaction_groups_txn();
             compaction_groups_txn
                 .update_compaction_config(compaction_group_ids, config_to_update)?;
@@ -408,7 +423,10 @@ impl HummockManager {
     /// Gets complete compaction group info.
     /// It is the aggregate of `HummockVersion` and `CompactionGroupConfig`
     pub async fn list_compaction_group(&self) -> Vec<CompactionGroupInfo> {
-        let mut versioning_guard = self.versioning.write().await;
+        let mut versioning_guard = self
+            .versioning
+            .write_with_process_name("list_compaction_group")
+            .await;
         let versioning = versioning_guard.deref_mut();
         let current_version = &versioning.current_version;
         let mut results = vec![];

--- a/src/meta/src/hummock/manager/compaction/compaction_group_schedule.rs
+++ b/src/meta/src/hummock/manager/compaction/compaction_group_schedule.rs
@@ -193,8 +193,14 @@ impl HummockManager {
         group_2: CompactionGroupId,
         created_tables: Option<HashSet<TableId>>,
     ) -> Result<()> {
-        let compaction_guard = self.compaction.write().await;
-        let mut versioning_guard = self.versioning.write().await;
+        let compaction_guard = self
+            .compaction
+            .write_with_process_name("merge_compaction_group_impl")
+            .await;
+        let mut versioning_guard = self
+            .versioning
+            .write_with_process_name("merge_compaction_group_impl")
+            .await;
         let versioning = versioning_guard.deref_mut();
         // Validate parameters.
         if !versioning.current_version.levels.contains_key(&group_1) {
@@ -415,7 +421,10 @@ impl HummockManager {
         });
 
         {
-            let mut compaction_group_manager = self.compaction_group_manager.write().await;
+            let mut compaction_group_manager = self
+                .compaction_group_manager
+                .write_with_process_name("merge_compaction_group_impl")
+                .await;
             let mut compaction_groups_txn = compaction_group_manager.start_compaction_groups_txn();
 
             // for metrics reclaim
@@ -615,8 +624,14 @@ impl HummockManager {
         partition_vnode_count: Option<u32>,
     ) -> Result<Vec<(CompactionGroupId, Vec<StateTableId>)>> {
         let mut result = vec![];
-        let compaction_guard = self.compaction.write().await;
-        let mut versioning_guard = self.versioning.write().await;
+        let compaction_guard = self
+            .compaction
+            .write_with_process_name("split_compaction_group_impl")
+            .await;
+        let mut versioning_guard = self
+            .versioning
+            .write_with_process_name("split_compaction_group_impl")
+            .await;
         let versioning = versioning_guard.deref_mut();
         // Validate parameters.
         if !versioning
@@ -758,7 +773,10 @@ impl HummockManager {
         result.push((new_compaction_group_id, table_ids_right));
 
         {
-            let mut compaction_group_manager = self.compaction_group_manager.write().await;
+            let mut compaction_group_manager = self
+                .compaction_group_manager
+                .write_with_process_name("split_compaction_group_impl")
+                .await;
             let mut compaction_groups_txn = compaction_group_manager.start_compaction_groups_txn();
             compaction_groups_txn
                 .create_compaction_groups(new_compaction_group_id, Arc::new(config));
@@ -977,9 +995,15 @@ impl HummockManager {
 
     async fn apply_normalize_plan(&self, plan: &NormalizePlan) -> Result<bool> {
         let (table_ids_right, boundary_table_id, new_compaction_group_id) = {
-            let mut versioning_guard = self.versioning.write().await;
+            let mut versioning_guard = self
+                .versioning
+                .write_with_process_name("apply_normalize_plan")
+                .await;
             let versioning = versioning_guard.deref_mut();
-            let mut compaction_group_manager = self.compaction_group_manager.write().await;
+            let mut compaction_group_manager = self
+                .compaction_group_manager
+                .write_with_process_name("apply_normalize_plan")
+                .await;
 
             let groups = collect_normalize_group_statistics(
                 &versioning.current_version,
@@ -1101,8 +1125,14 @@ impl HummockManager {
         parent_group_id: CompactionGroupId,
     ) -> Result<()> {
         let mut canceled_tasks = vec![];
-        let compaction_guard = self.compaction.write().await;
-        let mut versioning_guard = self.versioning.write().await;
+        let compaction_guard = self
+            .compaction
+            .write_with_process_name("cancel_expired_normalize_split_tasks")
+            .await;
+        let mut versioning_guard = self
+            .versioning
+            .write_with_process_name("cancel_expired_normalize_split_tasks")
+            .await;
         let versioning = versioning_guard.deref_mut();
         let compact_task_assignments =
             compaction_guard.get_compact_task_assignments_by_group_id(parent_group_id);

--- a/src/meta/src/hummock/manager/compaction/mod.rs
+++ b/src/meta/src/hummock/manager/compaction/mod.rs
@@ -1378,7 +1378,10 @@ impl HummockManager {
         table_stats_change: Option<PbTableStatsMap>,
     ) -> Result<()> {
         if let Some(task) = compact_task {
-            let mut guard = self.compaction.write().await;
+            let mut guard = self
+                .compaction
+                .write_with_process_name("report_compact_task_for_test")
+                .await;
             guard.compact_task_assignment.insert(
                 task_id,
                 CompactTaskAssignment {

--- a/src/meta/src/hummock/manager/context.rs
+++ b/src/meta/src/hummock/manager/context.rs
@@ -95,7 +95,10 @@ impl HummockManager {
         &self,
         context_ids: impl AsRef<[HummockContextId]>,
     ) -> Result<()> {
-        let mut context_info = self.context_info.write().await;
+        let mut context_info = self
+            .context_info
+            .write_with_process_name("release_contexts")
+            .await;
         context_info
             .release_contexts(context_ids, self.env.meta_store())
             .await?;
@@ -161,7 +164,10 @@ impl HummockManager {
     pub(super) async fn release_invalid_contexts(&self) -> Result<Vec<HummockContextId>> {
         let (active_context_ids, mut context_info) = {
             let compaction_guard = self.compaction.read().await;
-            let context_info = self.context_info.write().await;
+            let context_info = self
+                .context_info
+                .write_with_process_name("release_invalid_contexts")
+                .await;
             let mut active_context_ids = HashSet::new();
             active_context_ids.extend(
                 compaction_guard
@@ -358,7 +364,10 @@ impl HummockManager {
     /// and will be unpinned when `context_id` is invalidated.
     pub async fn pin_version(&self, context_id: HummockContextId) -> Result<Arc<HummockVersion>> {
         let versioning = self.versioning.read().await;
-        let mut context_info = self.context_info.write().await;
+        let mut context_info = self
+            .context_info
+            .write_with_process_name("pin_version")
+            .await;
         self.check_context_with_meta_node(context_id, &context_info)
             .await?;
         let mut pinned_versions = BTreeMapTransaction::new(&mut context_info.pinned_versions);
@@ -397,7 +406,10 @@ impl HummockManager {
         context_id: HummockContextId,
         unpin_before: HummockVersionId,
     ) -> Result<()> {
-        let mut context_info = self.context_info.write().await;
+        let mut context_info = self
+            .context_info
+            .write_with_process_name("unpin_version_before")
+            .await;
         self.check_context_with_meta_node(context_id, &context_info)
             .await?;
         let mut pinned_versions = BTreeMapTransaction::new(&mut context_info.pinned_versions);
@@ -432,7 +444,10 @@ impl HummockManager {
 impl HummockManager {
     pub async fn register_safe_point(&self) -> HummockVersionSafePoint {
         let versioning = self.versioning.read().await;
-        let mut wl = self.context_info.write().await;
+        let mut wl = self
+            .context_info
+            .write_with_process_name("register_safe_point")
+            .await;
         let safe_point = HummockVersionSafePoint {
             id: versioning.current_version.id,
             event_sender: self.event_sender.clone(),
@@ -443,7 +458,10 @@ impl HummockManager {
     }
 
     pub async fn unregister_safe_point(&self, safe_point: HummockVersionId) {
-        let mut wl = self.context_info.write().await;
+        let mut wl = self
+            .context_info
+            .write_with_process_name("unregister_safe_point")
+            .await;
         let version_safe_points = &mut wl.version_safe_points;
         if let Some(pos) = version_safe_points.iter().position(|sp| *sp == safe_point) {
             version_safe_points.remove(pos);

--- a/src/meta/src/hummock/manager/gc.rs
+++ b/src/meta/src/hummock/manager/gc.rs
@@ -185,7 +185,10 @@ impl HummockManager {
     ///
     /// Returns number of deleted deltas
     pub async fn delete_version_deltas(&self) -> Result<usize> {
-        let mut versioning_guard = self.versioning.write().await;
+        let mut versioning_guard = self
+            .versioning
+            .write_with_process_name("delete_version_deltas")
+            .await;
         let versioning = versioning_guard.deref_mut();
         let context_info = self.context_info.read().await;
         // If there is any safe point, skip this to ensure meta backup has required delta logs to

--- a/src/meta/src/hummock/manager/mod.rs
+++ b/src/meta/src/hummock/manager/mod.rs
@@ -416,9 +416,18 @@ impl HummockManager {
         let now = self.load_now().await?;
         *self.now.lock().await = now.unwrap_or(0);
 
-        let mut compaction_guard = self.compaction.write().await;
-        let mut versioning_guard = self.versioning.write().await;
-        let mut context_info_guard = self.context_info.write().await;
+        let mut compaction_guard = self
+            .compaction
+            .write_with_process_name("load_meta_store_state")
+            .await;
+        let mut versioning_guard = self
+            .versioning
+            .write_with_process_name("load_meta_store_state")
+            .await;
+        let mut context_info_guard = self
+            .context_info
+            .write_with_process_name("load_meta_store_state")
+            .await;
         self.load_meta_store_state_impl(
             &mut compaction_guard,
             &mut versioning_guard,
@@ -569,7 +578,10 @@ impl HummockManager {
 
         self.initial_compaction_group_config_after_load(
             versioning_guard,
-            self.compaction_group_manager.write().await.deref_mut(),
+            self.compaction_group_manager
+                .write_with_process_name("load_meta_store_state")
+                .await
+                .deref_mut(),
         )
         .await?;
 
@@ -592,7 +604,10 @@ impl HummockManager {
         &self,
         mut version_delta: HummockVersionDelta,
     ) -> Result<(HummockVersion, Vec<CompactionGroupId>)> {
-        let mut versioning_guard = self.versioning.write().await;
+        let mut versioning_guard = self
+            .versioning
+            .write_with_process_name("replay_version_delta")
+            .await;
         // ensure the version id is ascending after replay
         version_delta.id = versioning_guard.current_version.next_version_id();
         version_delta.prev_id = versioning_guard.current_version.id;
@@ -605,7 +620,10 @@ impl HummockManager {
     }
 
     pub async fn disable_commit_epoch(&self) -> Arc<HummockVersion> {
-        let mut versioning_guard = self.versioning.write().await;
+        let mut versioning_guard = self
+            .versioning
+            .write_with_process_name("disable_commit_epoch")
+            .await;
         versioning_guard.disable_commit_epochs = true;
         versioning_guard.current_version.clone()
     }

--- a/src/meta/src/hummock/manager/tests.rs
+++ b/src/meta/src/hummock/manager/tests.rs
@@ -149,7 +149,7 @@ async fn test_get_table_change_logs_with_inverted_epoch_range() {
     let table_id = TableId::new(1);
     hummock_manager
         .versioning
-        .write()
+        .write_with_process_name("test_get_table_change_logs_with_inverted_epoch_range")
         .await
         .table_change_log
         .insert(

--- a/src/meta/src/hummock/manager/time_travel.rs
+++ b/src/meta/src/hummock/manager/time_travel.rs
@@ -46,7 +46,10 @@ use crate::hummock::error::{Error, Result};
 impl HummockManager {
     pub(crate) async fn init_time_travel_state(&self) -> Result<()> {
         let sql_store = self.env.meta_store_ref();
-        let mut guard = self.versioning.write().await;
+        let mut guard = self
+            .versioning
+            .write_with_process_name("init_time_travel_state")
+            .await;
         guard.mark_next_time_travel_version_snapshot();
 
         guard.last_time_travel_snapshot_sst_ids = HashSet::new();

--- a/src/meta/src/hummock/manager/utils.rs
+++ b/src/meta/src/hummock/manager/utils.rs
@@ -68,9 +68,18 @@ impl HummockManager {
         use crate::hummock::manager::compaction::Compaction;
         use crate::hummock::manager::context::ContextInfo;
         use crate::hummock::manager::versioning::Versioning;
-        let mut compaction_guard = self.compaction.write().await;
-        let mut versioning_guard = self.versioning.write().await;
-        let mut context_info_guard = self.context_info.write().await;
+        let mut compaction_guard = self
+            .compaction
+            .write_with_process_name("check_state_consistency")
+            .await;
+        let mut versioning_guard = self
+            .versioning
+            .write_with_process_name("check_state_consistency")
+            .await;
+        let mut context_info_guard = self
+            .context_info
+            .write_with_process_name("check_state_consistency")
+            .await;
         // We don't check `checkpoint` because it's allowed to update its in memory state without
         // persisting to object store.
         let get_state = |compaction_guard: &mut Compaction,

--- a/src/meta/src/hummock/manager/versioning.rs
+++ b/src/meta/src/hummock/manager/versioning.rs
@@ -214,7 +214,10 @@ impl HummockManager {
         target_group_ids: &[CompactionGroupId],
     ) -> bool {
         let versioning = self.versioning.read().await;
-        let mut cg_manager = self.compaction_group_manager.write().await;
+        let mut cg_manager = self
+            .compaction_group_manager
+            .write_with_process_name("try_update_write_limits")
+            .await;
         let target_group_configs = target_group_ids
             .iter()
             .filter_map(|id| {
@@ -261,7 +264,10 @@ impl HummockManager {
     }
 
     pub async fn rebuild_table_stats(&self) -> Result<()> {
-        let mut versioning = self.versioning.write().await;
+        let mut versioning = self
+            .versioning
+            .write_with_process_name("rebuild_table_stats")
+            .await;
         let new_stats = rebuild_table_stats(&versioning.current_version);
         let mut version_stats = VarTransaction::new(&mut versioning.version_stats);
         // version_stats.hummock_version_id is always 0 in meta store.
@@ -271,7 +277,10 @@ impl HummockManager {
     }
 
     pub async fn may_fill_backward_state_table_info(&self) -> Result<()> {
-        let mut versioning = self.versioning.write().await;
+        let mut versioning = self
+            .versioning
+            .write_with_process_name("may_fill_backward_state_table_info")
+            .await;
         if versioning
             .current_version
             .need_fill_backward_compatible_state_table_info_delta()


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

- Label every Hummock manager write acquisition for `versioning`, `compaction`, `compaction_group_manager`, and `context_info` with its enclosing operation name so lock-processing metrics no longer aggregate these paths under `unnamed`.
- Apply the labels consistently to multi-lock operations and test-only helpers without changing lock ordering or behavior.

## Checklist

- [x] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [x] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

None; this only improves internal lock observability.

</details>
