### PR TITLE
refactor(meta): name hummock lock write processes

### DIFF
--- a/src/meta/src/hummock/manager/commit_epoch.rs
+++ b/src/meta/src/hummock/manager/commit_epoch.rs
@@ -138,8 +138,10 @@ impl HummockManager {
                         .clone(),
                     )
                 } else {
-                    let compaction_group_manager_guard =
-                        self.compaction_group_manager.write().await;
+                    let compaction_group_manager_guard = self
+                        .compaction_group_manager
+                        .write_with_process_name("commit_epoch")
+                        .await;
                     let new_compaction_group_config =
                         compaction_group_manager_guard.default_compaction_config();
                     compaction_group_config = Some(new_compaction_group_config.clone());

--- a/src/meta/src/hummock/manager/compaction/compaction_group_manager.rs
+++ b/src/meta/src/hummock/manager/compaction/compaction_group_manager.rs
@@ -171,9 +171,15 @@ impl HummockManager {
         if pairs.is_empty() {
             return Ok(());
         }
-        let mut versioning_guard = self.versioning.write().await;
+        let mut versioning_guard = self
+            .versioning
+            .write_with_process_name("register_table_ids_for_test")
+            .await;
         let versioning = versioning_guard.deref_mut();
-        let mut compaction_group_manager = self.compaction_group_manager.write().await;
+        let mut compaction_group_manager = self
+            .compaction_group_manager
+            .write_with_process_name("register_table_ids_for_test")
+            .await;
         let current_version = &versioning.current_version;
         let default_config = compaction_group_manager.default_compaction_config();
         let mut compaction_groups_txn = compaction_group_manager.start_compaction_groups_txn();
@@ -285,7 +291,10 @@ impl HummockManager {
             }
         }
 
-        let mut versioning_guard = self.versioning.write().await;
+        let mut versioning_guard = self
+            .versioning
+            .write_with_process_name("unregister_table_ids")
+            .await;
         let versioning = versioning_guard.deref_mut();
         let mut version = HummockVersionTransaction::new(
             &mut versioning.current_version,
@@ -359,7 +368,10 @@ impl HummockManager {
 
         // Purge may cause write to meta store. If it hurts performance while holding versioning
         // lock, consider to make it in batch.
-        let mut compaction_group_manager = self.compaction_group_manager.write().await;
+        let mut compaction_group_manager = self
+            .compaction_group_manager
+            .write_with_process_name("unregister_table_ids")
+            .await;
         let mut compaction_groups_txn = compaction_group_manager.start_compaction_groups_txn();
 
         compaction_groups_txn.purge(HashSet::from_iter(get_compaction_group_ids(
@@ -378,7 +390,10 @@ impl HummockManager {
     ) -> Result<()> {
         {
             // Avoid lock conflicts with `try_update_write_limits``
-            let mut compaction_group_manager = self.compaction_group_manager.write().await;
+            let mut compaction_group_manager = self
+                .compaction_group_manager
+                .write_with_process_name("update_compaction_config")
+                .await;
             let mut compaction_groups_txn = compaction_group_manager.start_compaction_groups_txn();
             compaction_groups_txn
                 .update_compaction_config(compaction_group_ids, config_to_update)?;
@@ -399,7 +414,10 @@ impl HummockManager {
     /// Gets complete compaction group info.
     /// It is the aggregate of `HummockVersion` and `CompactionGroupConfig`
     pub async fn list_compaction_group(&self) -> Vec<CompactionGroupInfo> {
-        let mut versioning_guard = self.versioning.write().await;
+        let mut versioning_guard = self
+            .versioning
+            .write_with_process_name("list_compaction_group")
+            .await;
         let versioning = versioning_guard.deref_mut();
         let current_version = &versioning.current_version;
         let mut results = vec![];

--- a/src/meta/src/hummock/manager/compaction/compaction_group_schedule.rs
+++ b/src/meta/src/hummock/manager/compaction/compaction_group_schedule.rs
@@ -193,8 +193,14 @@ impl HummockManager {
         group_2: CompactionGroupId,
         created_tables: Option<HashSet<TableId>>,
     ) -> Result<()> {
-        let compaction_guard = self.compaction.write().await;
-        let mut versioning_guard = self.versioning.write().await;
+        let compaction_guard = self
+            .compaction
+            .write_with_process_name("merge_compaction_group_impl")
+            .await;
+        let mut versioning_guard = self
+            .versioning
+            .write_with_process_name("merge_compaction_group_impl")
+            .await;
         let versioning = versioning_guard.deref_mut();
         // Validate parameters.
         if !versioning.current_version.levels.contains_key(&group_1) {
@@ -413,7 +419,10 @@ impl HummockManager {
         });
 
         {
-            let mut compaction_group_manager = self.compaction_group_manager.write().await;
+            let mut compaction_group_manager = self
+                .compaction_group_manager
+                .write_with_process_name("merge_compaction_group_impl")
+                .await;
             let mut compaction_groups_txn = compaction_group_manager.start_compaction_groups_txn();
 
             // for metrics reclaim
@@ -615,8 +624,14 @@ impl HummockManager {
         partition_vnode_count: Option<u32>,
     ) -> Result<Vec<(CompactionGroupId, Vec<StateTableId>)>> {
         let mut result = vec![];
-        let compaction_guard = self.compaction.write().await;
-        let mut versioning_guard = self.versioning.write().await;
+        let compaction_guard = self
+            .compaction
+            .write_with_process_name("split_compaction_group_impl")
+            .await;
+        let mut versioning_guard = self
+            .versioning
+            .write_with_process_name("split_compaction_group_impl")
+            .await;
         let versioning = versioning_guard.deref_mut();
         // Validate parameters.
         if !versioning
@@ -756,7 +771,10 @@ impl HummockManager {
         result.push((new_compaction_group_id, table_ids_right));
 
         {
-            let mut compaction_group_manager = self.compaction_group_manager.write().await;
+            let mut compaction_group_manager = self
+                .compaction_group_manager
+                .write_with_process_name("split_compaction_group_impl")
+                .await;
             let mut compaction_groups_txn = compaction_group_manager.start_compaction_groups_txn();
             compaction_groups_txn
                 .create_compaction_groups(new_compaction_group_id, Arc::new(config));
@@ -976,9 +994,15 @@ impl HummockManager {
 
     async fn apply_normalize_plan(&self, plan: &NormalizePlan) -> Result<bool> {
         let (table_ids_right, boundary_table_id, new_compaction_group_id) = {
-            let mut versioning_guard = self.versioning.write().await;
+            let mut versioning_guard = self
+                .versioning
+                .write_with_process_name("apply_normalize_plan")
+                .await;
             let versioning = versioning_guard.deref_mut();
-            let mut compaction_group_manager = self.compaction_group_manager.write().await;
+            let mut compaction_group_manager = self
+                .compaction_group_manager
+                .write_with_process_name("apply_normalize_plan")
+                .await;
 
             let groups = collect_normalize_group_statistics(
                 &versioning.current_version,
@@ -1098,8 +1122,14 @@ impl HummockManager {
         parent_group_id: CompactionGroupId,
     ) -> Result<()> {
         let mut canceled_tasks = vec![];
-        let compaction_guard = self.compaction.write().await;
-        let mut versioning_guard = self.versioning.write().await;
+        let compaction_guard = self
+            .compaction
+            .write_with_process_name("cancel_expired_normalize_split_tasks")
+            .await;
+        let mut versioning_guard = self
+            .versioning
+            .write_with_process_name("cancel_expired_normalize_split_tasks")
+            .await;
         let versioning = versioning_guard.deref_mut();
         let compact_task_assignments =
             compaction_guard.get_compact_task_assignments_by_group_id(parent_group_id);

--- a/src/meta/src/hummock/manager/compaction/mod.rs
+++ b/src/meta/src/hummock/manager/compaction/mod.rs
@@ -1435,7 +1435,10 @@ impl HummockManager {
         table_stats_change: Option<PbTableStatsMap>,
     ) -> Result<()> {
         if let Some(task) = compact_task {
-            let mut guard = self.compaction.write().await;
+            let mut guard = self
+                .compaction
+                .write_with_process_name("report_compact_task_for_test")
+                .await;
             guard.compact_task_assignment.insert(
                 task_id,
                 CompactTaskAssignment {

--- a/src/meta/src/hummock/manager/context.rs
+++ b/src/meta/src/hummock/manager/context.rs
@@ -95,7 +95,10 @@ impl HummockManager {
         &self,
         context_ids: impl AsRef<[HummockContextId]>,
     ) -> Result<()> {
-        let mut context_info = self.context_info.write().await;
+        let mut context_info = self
+            .context_info
+            .write_with_process_name("release_contexts")
+            .await;
         context_info
             .release_contexts(context_ids, self.env.meta_store())
             .await?;
@@ -161,7 +164,10 @@ impl HummockManager {
     pub(super) async fn release_invalid_contexts(&self) -> Result<Vec<HummockContextId>> {
         let (active_context_ids, mut context_info) = {
             let compaction_guard = self.compaction.read().await;
-            let context_info = self.context_info.write().await;
+            let context_info = self
+                .context_info
+                .write_with_process_name("release_invalid_contexts")
+                .await;
             let mut active_context_ids = HashSet::new();
             active_context_ids.extend(
                 compaction_guard
@@ -355,7 +361,10 @@ impl HummockManager {
     /// and will be unpinned when `context_id` is invalidated.
     pub async fn pin_version(&self, context_id: HummockContextId) -> Result<Arc<HummockVersion>> {
         let versioning = self.versioning.read().await;
-        let mut context_info = self.context_info.write().await;
+        let mut context_info = self
+            .context_info
+            .write_with_process_name("pin_version")
+            .await;
         self.check_context_with_meta_node(context_id, &context_info)
             .await?;
         let mut pinned_versions = BTreeMapTransaction::new(&mut context_info.pinned_versions);
@@ -394,7 +403,10 @@ impl HummockManager {
         context_id: HummockContextId,
         unpin_before: HummockVersionId,
     ) -> Result<()> {
-        let mut context_info = self.context_info.write().await;
+        let mut context_info = self
+            .context_info
+            .write_with_process_name("unpin_version_before")
+            .await;
         self.check_context_with_meta_node(context_id, &context_info)
             .await?;
         let mut pinned_versions = BTreeMapTransaction::new(&mut context_info.pinned_versions);
@@ -429,7 +441,10 @@ impl HummockManager {
 impl HummockManager {
     pub async fn register_safe_point(&self) -> HummockVersionSafePoint {
         let versioning = self.versioning.read().await;
-        let mut wl = self.context_info.write().await;
+        let mut wl = self
+            .context_info
+            .write_with_process_name("register_safe_point")
+            .await;
         let safe_point = HummockVersionSafePoint {
             id: versioning.current_version.id,
             event_sender: self.event_sender.clone(),
@@ -440,7 +455,10 @@ impl HummockManager {
     }
 
     pub async fn unregister_safe_point(&self, safe_point: HummockVersionId) {
-        let mut wl = self.context_info.write().await;
+        let mut wl = self
+            .context_info
+            .write_with_process_name("unregister_safe_point")
+            .await;
         let version_safe_points = &mut wl.version_safe_points;
         if let Some(pos) = version_safe_points.iter().position(|sp| *sp == safe_point) {
             version_safe_points.remove(pos);

--- a/src/meta/src/hummock/manager/gc.rs
+++ b/src/meta/src/hummock/manager/gc.rs
@@ -185,7 +185,10 @@ impl HummockManager {
     ///
     /// Returns number of deleted deltas
     pub async fn delete_version_deltas(&self) -> Result<usize> {
-        let mut versioning_guard = self.versioning.write().await;
+        let mut versioning_guard = self
+            .versioning
+            .write_with_process_name("delete_version_deltas")
+            .await;
         let versioning = versioning_guard.deref_mut();
         let context_info = self.context_info.read().await;
         // If there is any safe point, skip this to ensure meta backup has required delta logs to

--- a/src/meta/src/hummock/manager/mod.rs
+++ b/src/meta/src/hummock/manager/mod.rs
@@ -368,9 +368,18 @@ impl HummockManager {
         let now = self.load_now().await?;
         *self.now.lock().await = now.unwrap_or(0);
 
-        let mut compaction_guard = self.compaction.write().await;
-        let mut versioning_guard = self.versioning.write().await;
-        let mut context_info_guard = self.context_info.write().await;
+        let mut compaction_guard = self
+            .compaction
+            .write_with_process_name("load_meta_store_state")
+            .await;
+        let mut versioning_guard = self
+            .versioning
+            .write_with_process_name("load_meta_store_state")
+            .await;
+        let mut context_info_guard = self
+            .context_info
+            .write_with_process_name("load_meta_store_state")
+            .await;
         self.load_meta_store_state_impl(
             &mut compaction_guard,
             &mut versioning_guard,
@@ -501,7 +510,10 @@ impl HummockManager {
 
         self.initial_compaction_group_config_after_load(
             versioning_guard,
-            self.compaction_group_manager.write().await.deref_mut(),
+            self.compaction_group_manager
+                .write_with_process_name("load_meta_store_state")
+                .await
+                .deref_mut(),
         )
         .await?;
 
@@ -524,7 +536,10 @@ impl HummockManager {
         &self,
         mut version_delta: HummockVersionDelta,
     ) -> Result<(HummockVersion, Vec<CompactionGroupId>)> {
-        let mut versioning_guard = self.versioning.write().await;
+        let mut versioning_guard = self
+            .versioning
+            .write_with_process_name("replay_version_delta")
+            .await;
         // ensure the version id is ascending after replay
         version_delta.id = versioning_guard.current_version.next_version_id();
         version_delta.prev_id = versioning_guard.current_version.id;
@@ -537,7 +552,10 @@ impl HummockManager {
     }
 
     pub async fn disable_commit_epoch(&self) -> Arc<HummockVersion> {
-        let mut versioning_guard = self.versioning.write().await;
+        let mut versioning_guard = self
+            .versioning
+            .write_with_process_name("disable_commit_epoch")
+            .await;
         versioning_guard.disable_commit_epochs = true;
         versioning_guard.current_version.clone()
     }

--- a/src/meta/src/hummock/manager/time_travel.rs
+++ b/src/meta/src/hummock/manager/time_travel.rs
@@ -46,7 +46,10 @@ use crate::hummock::error::{Error, Result};
 impl HummockManager {
     pub(crate) async fn init_time_travel_state(&self) -> Result<()> {
         let sql_store = self.env.meta_store_ref();
-        let mut guard = self.versioning.write().await;
+        let mut guard = self
+            .versioning
+            .write_with_process_name("init_time_travel_state")
+            .await;
         guard.mark_next_time_travel_version_snapshot();
 
         guard.last_time_travel_snapshot_sst_ids = HashSet::new();

--- a/src/meta/src/hummock/manager/utils.rs
+++ b/src/meta/src/hummock/manager/utils.rs
@@ -67,9 +67,18 @@ impl HummockManager {
         use crate::hummock::manager::compaction::Compaction;
         use crate::hummock::manager::context::ContextInfo;
         use crate::hummock::manager::versioning::Versioning;
-        let mut compaction_guard = self.compaction.write().await;
-        let mut versioning_guard = self.versioning.write().await;
-        let mut context_info_guard = self.context_info.write().await;
+        let mut compaction_guard = self
+            .compaction
+            .write_with_process_name("check_state_consistency")
+            .await;
+        let mut versioning_guard = self
+            .versioning
+            .write_with_process_name("check_state_consistency")
+            .await;
+        let mut context_info_guard = self
+            .context_info
+            .write_with_process_name("check_state_consistency")
+            .await;
         // We don't check `checkpoint` because it's allowed to update its in memory state without
         // persisting to object store.
         let get_state = |compaction_guard: &mut Compaction,

--- a/src/meta/src/hummock/manager/versioning.rs
+++ b/src/meta/src/hummock/manager/versioning.rs
@@ -200,7 +200,10 @@ impl HummockManager {
         target_group_ids: &[CompactionGroupId],
     ) -> bool {
         let versioning = self.versioning.read().await;
-        let mut cg_manager = self.compaction_group_manager.write().await;
+        let mut cg_manager = self
+            .compaction_group_manager
+            .write_with_process_name("try_update_write_limits")
+            .await;
         let target_group_configs = target_group_ids
             .iter()
             .filter_map(|id| {
@@ -247,7 +250,10 @@ impl HummockManager {
     }
 
     pub async fn rebuild_table_stats(&self) -> Result<()> {
-        let mut versioning = self.versioning.write().await;
+        let mut versioning = self
+            .versioning
+            .write_with_process_name("rebuild_table_stats")
+            .await;
         let new_stats = rebuild_table_stats(&versioning.current_version);
         let mut version_stats = VarTransaction::new(&mut versioning.version_stats);
         // version_stats.hummock_version_id is always 0 in meta store.
@@ -257,7 +263,10 @@ impl HummockManager {
     }
 
     pub async fn may_fill_backward_state_table_info(&self) -> Result<()> {
-        let mut versioning = self.versioning.write().await;
+        let mut versioning = self
+            .versioning
+            .write_with_process_name("may_fill_backward_state_table_info")
+            .await;
         if versioning
             .current_version
             .need_fill_backward_compatible_state_table_info_delta()


### PR DESCRIPTION
## Summary

- specify process names for all meta-node writes to the Hummock `versioning`, `compaction`, `compaction_group_manager`, and `context_info` monitored locks
- attribute lock processing time to the enclosing Hummock manager operation instead of the unnamed process label

## Tests

- `cargo fmt --all -- --check`
- `cargo check -p risingwave_meta`