### PR TITLE
refactor(meta): label Hummock lock read operations

### DIFF
--- a/src/meta/src/hummock/manager/checkpoint.rs
+++ b/src/meta/src/hummock/manager/checkpoint.rs
@@ -427,8 +427,14 @@ impl HummockManager {
             }
             if cfg!(test) && new_checkpoint_id == old_checkpoint_id {
                 drop(versioning_guard);
-                let versioning = self.versioning.read().await;
-                let context_info = self.context_info.read().await;
+                let versioning = self
+                    .versioning
+                    .read_with_process_name("version_checkpoint_build")
+                    .await;
+                let context_info = self
+                    .context_info
+                    .read_with_process_name("version_checkpoint_build")
+                    .await;
                 let min_pinned_version_id = context_info.min_pinned_version_id();
                 let stale_object_stats = gc_stale_object_stats(
                     &versioning.checkpoint.stale_objects,
@@ -542,7 +548,11 @@ impl HummockManager {
                     .collect(),
             });
         }
-        let min_pinned_version_id = self.context_info.read().await.min_pinned_version_id();
+        let min_pinned_version_id = self
+            .context_info
+            .read_with_process_name("version_checkpoint_build")
+            .await
+            .min_pinned_version_id();
         let may_delete_object = stale_objects
             .iter()
             .filter_map(|(version_id, object_ids)| {
@@ -569,7 +579,11 @@ impl HummockManager {
                 archive.version.as_ref().unwrap().id
             );
         }
-        let min_pinned_version_id = self.context_info.read().await.min_pinned_version_id();
+        let min_pinned_version_id = self
+            .context_info
+            .read_with_process_name("version_checkpoint_build")
+            .await
+            .min_pinned_version_id();
         let stale_object_stats =
             gc_stale_object_stats(&new_checkpoint.stale_objects, min_pinned_version_id);
         // 3. hold write lock briefly and update in memory state
@@ -614,7 +628,10 @@ impl HummockManager {
     }
 
     pub async fn get_checkpoint_version(&self) -> Arc<HummockVersion> {
-        let versioning_guard = self.versioning.read().await;
+        let versioning_guard = self
+            .versioning
+            .read_with_process_name("get_checkpoint_version")
+            .await;
         versioning_guard.checkpoint.version.clone()
     }
 }

--- a/src/meta/src/hummock/manager/commit_epoch.rs
+++ b/src/meta/src/hummock/manager/commit_epoch.rs
@@ -196,7 +196,10 @@ impl HummockManager {
                 group_id_to_config.insert(*cg_id, compaction_group);
             }
         } else {
-            let compaction_group_manager = self.compaction_group_manager.read().await;
+            let compaction_group_manager = self
+                .compaction_group_manager
+                .read_with_process_name("commit_epoch")
+                .await;
             for cg_id in &modified_compaction_groups {
                 let compaction_group = compaction_group_manager
                     .try_get_compaction_group_config(*cg_id)

--- a/src/meta/src/hummock/manager/compaction/compaction_group_manager.rs
+++ b/src/meta/src/hummock/manager/compaction/compaction_group_manager.rs
@@ -98,13 +98,20 @@ impl HummockManager {
     /// Should not be called inside [`HummockManager`], because it requests locks internally.
     /// The implementation acquires `versioning` lock.
     pub async fn compaction_group_ids(&self) -> Vec<CompactionGroupId> {
-        get_compaction_group_ids(&self.versioning.read().await.current_version).collect_vec()
+        get_compaction_group_ids(
+            &self
+                .versioning
+                .read_with_process_name("compaction_group_ids")
+                .await
+                .current_version,
+        )
+        .collect_vec()
     }
 
     /// The implementation acquires `compaction_group_manager` lock.
     pub async fn get_compaction_group_map(&self) -> BTreeMap<CompactionGroupId, CompactionGroup> {
         self.compaction_group_manager
-            .read()
+            .read_with_process_name("get_compaction_group_map")
             .await
             .compaction_groups
             .clone()
@@ -150,7 +157,7 @@ impl HummockManager {
     pub async fn purge(&self, valid_ids: &HashSet<TableId>) -> Result<()> {
         let to_unregister = self
             .versioning
-            .read()
+            .read_with_process_name("purge")
             .await
             .current_version
             .state_table_info
@@ -430,7 +437,10 @@ impl HummockManager {
         let versioning = versioning_guard.deref_mut();
         let current_version = &versioning.current_version;
         let mut results = vec![];
-        let compaction_group_manager = self.compaction_group_manager.read().await;
+        let compaction_group_manager = self
+            .compaction_group_manager
+            .read_with_process_name("list_compaction_group")
+            .await;
 
         for levels in current_version.levels.values() {
             let compaction_config = compaction_group_manager
@@ -492,8 +502,14 @@ impl HummockManager {
     }
 
     pub async fn calculate_compaction_group_statistic(&self) -> Vec<CompactionGroupStatistic> {
-        let versioning_guard = self.versioning.read().await;
-        let manager = self.compaction_group_manager.read().await;
+        let versioning_guard = self
+            .versioning
+            .read_with_process_name("calculate_compaction_group_statistic")
+            .await;
+        let manager = self
+            .compaction_group_manager
+            .read_with_process_name("calculate_compaction_group_statistic")
+            .await;
         Self::calculate_compaction_group_statistic_from_snapshot(
             &versioning_guard.current_version,
             &versioning_guard.version_stats,

--- a/src/meta/src/hummock/manager/compaction/compaction_group_schedule.rs
+++ b/src/meta/src/hummock/manager/compaction/compaction_group_schedule.rs
@@ -716,7 +716,7 @@ impl HummockManager {
             // Inherit config from parent group
             let config = self
                 .compaction_group_manager
-                .read()
+                .read_with_process_name("split_compaction_group_impl")
                 .await
                 .try_get_compaction_group_config(parent_group_id)
                 .ok_or_else(|| {
@@ -878,7 +878,10 @@ impl HummockManager {
         }
 
         let parent_table_ids = {
-            let versioning_guard = self.versioning.read().await;
+            let versioning_guard = self
+                .versioning
+                .read_with_process_name("move_state_tables_to_dedicated_compaction_group")
+                .await;
             versioning_guard
                 .current_version
                 .state_table_info
@@ -1642,7 +1645,9 @@ impl GroupMergeValidator {
 
         {
             // Avoid merge when the group is in emergency state
-            let versioning_guard = versioning.read().await;
+            let versioning_guard = versioning
+                .read_with_process_name("validate_group_merge")
+                .await;
             let levels = &versioning_guard.current_version.levels;
             if !levels.contains_key(&group.group_id) {
                 return Err(Error::CompactionGroup(format!(

--- a/src/meta/src/hummock/manager/compaction/mod.rs
+++ b/src/meta/src/hummock/manager/compaction/mod.rs
@@ -206,14 +206,21 @@ pub struct Compaction {
 
 impl HummockManager {
     pub async fn get_assigned_compact_task_num(&self) -> u64 {
-        self.compaction.read().await.compact_task_assignment.len() as u64
+        self.compaction
+            .read_with_process_name("get_assigned_compact_task_num")
+            .await
+            .compact_task_assignment
+            .len() as u64
     }
 
     pub async fn list_compaction_status(
         &self,
     ) -> (Vec<PbCompactStatus>, Vec<PbCompactTaskAssignment>) {
         let (compaction_statuses, compact_task_assignments) = {
-            let compaction = self.compaction.read().await;
+            let compaction = self
+                .compaction
+                .read_with_process_name("list_compaction_status")
+                .await;
             (
                 compaction
                     .compaction_statuses
@@ -242,9 +249,18 @@ impl HummockManager {
         compaction_group_id: CompactionGroupId,
     ) -> Vec<PickerInfo> {
         let (status, levels, group) = {
-            let compaction = self.compaction.read().await;
-            let versioning = self.versioning.read().await;
-            let config_manager = self.compaction_group_manager.read().await;
+            let compaction = self
+                .compaction
+                .read_with_process_name("get_compaction_scores")
+                .await;
+            let versioning = self
+                .versioning
+                .read_with_process_name("get_compaction_scores")
+                .await;
+            let config_manager = self
+                .compaction_group_manager
+                .read_with_process_name("get_compaction_scores")
+                .await;
             match (
                 compaction.compaction_statuses.get(&compaction_group_id),
                 versioning.current_version.levels.get(&compaction_group_id),
@@ -409,7 +425,10 @@ impl HummockManager {
             // config) is destroyed as well. Then a compaction task for this group may come later and
             // cannot find its config.
             let group_config = {
-                let config_manager = self.compaction_group_manager.read().await;
+                let config_manager = self
+                    .compaction_group_manager
+                    .read_with_process_name("get_compact_tasks_impl")
+                    .await;
 
                 match config_manager.try_get_compaction_group_config(compaction_group_id) {
                     Some(config) => config,
@@ -1364,7 +1383,10 @@ impl HummockManager {
         &self,
         task_id: u64,
     ) -> Option<CompactTaskAssignment> {
-        let compaction_guard = self.compaction.read().await;
+        let compaction_guard = self
+            .compaction
+            .read_with_process_name("compaction_task_from_assignment_for_test")
+            .await;
         let assignment_ref = &compaction_guard.compact_task_assignment;
         assignment_ref.get(&task_id).cloned()
     }

--- a/src/meta/src/hummock/manager/context.rs
+++ b/src/meta/src/hummock/manager/context.rs
@@ -113,7 +113,7 @@ impl HummockManager {
     /// Checks whether `context_id` is valid.
     pub async fn check_context(&self, context_id: HummockContextId) -> Result<bool> {
         self.context_info
-            .read()
+            .read_with_process_name("check_context")
             .await
             .check_context(context_id, &self.metadata_manager)
             .await
@@ -138,7 +138,10 @@ impl HummockManager {
 
     #[cfg(any(test, feature = "test"))]
     pub async fn get_min_pinned_version_id(&self) -> HummockVersionId {
-        self.context_info.read().await.min_pinned_version_id()
+        self.context_info
+            .read_with_process_name("get_min_pinned_version_id")
+            .await
+            .min_pinned_version_id()
     }
 }
 
@@ -163,7 +166,10 @@ impl HummockManager {
     /// Release invalid contexts, aka worker node ids which are no longer valid in `ClusterManager`.
     pub(super) async fn release_invalid_contexts(&self) -> Result<Vec<HummockContextId>> {
         let (active_context_ids, mut context_info) = {
-            let compaction_guard = self.compaction.read().await;
+            let compaction_guard = self
+                .compaction
+                .read_with_process_name("release_invalid_contexts")
+                .await;
             let context_info = self
                 .context_info
                 .write_with_process_name("release_invalid_contexts")
@@ -214,7 +220,7 @@ impl HummockManager {
             }
             if !self
                 .context_info
-                .read()
+                .read_with_process_name("commit_epoch_sanity_check")
                 .await
                 .check_context(*context_id, &self.metadata_manager)
                 .await?
@@ -363,7 +369,7 @@ impl HummockManager {
     /// Pin the current greatest hummock version. The pin belongs to `context_id`
     /// and will be unpinned when `context_id` is invalidated.
     pub async fn pin_version(&self, context_id: HummockContextId) -> Result<Arc<HummockVersion>> {
-        let versioning = self.versioning.read().await;
+        let versioning = self.versioning.read_with_process_name("pin_version").await;
         let mut context_info = self
             .context_info
             .write_with_process_name("pin_version")
@@ -443,7 +449,10 @@ impl HummockManager {
 // safe point
 impl HummockManager {
     pub async fn register_safe_point(&self) -> HummockVersionSafePoint {
-        let versioning = self.versioning.read().await;
+        let versioning = self
+            .versioning
+            .read_with_process_name("register_safe_point")
+            .await;
         let mut wl = self
             .context_info
             .write_with_process_name("register_safe_point")

--- a/src/meta/src/hummock/manager/gc.rs
+++ b/src/meta/src/hummock/manager/gc.rs
@@ -190,7 +190,10 @@ impl HummockManager {
             .write_with_process_name("delete_version_deltas")
             .await;
         let versioning = versioning_guard.deref_mut();
-        let context_info = self.context_info.read().await;
+        let context_info = self
+            .context_info
+            .read_with_process_name("delete_version_deltas")
+            .await;
         // If there is any safe point, skip this to ensure meta backup has required delta logs to
         // replay version.
         if !context_info.version_safe_points.is_empty() {
@@ -222,9 +225,16 @@ impl HummockManager {
         object_ids: impl Iterator<Item = HummockObjectId>,
     ) -> Result<Vec<HummockObjectId>> {
         // This lock ensures `commit_epoch` and `report_compat_task` can see the latest GC history during sanity check.
-        let versioning = self.versioning.read().await;
-        let tracked_object_ids: HashSet<HummockObjectId> = versioning
-            .get_tracked_object_ids(self.context_info.read().await.min_pinned_version_id());
+        let versioning = self
+            .versioning
+            .read_with_process_name("finalize_objects_to_delete")
+            .await;
+        let tracked_object_ids: HashSet<HummockObjectId> = versioning.get_tracked_object_ids(
+            self.context_info
+                .read_with_process_name("finalize_objects_to_delete")
+                .await
+                .min_pinned_version_id(),
+        );
         let to_delete = object_ids
             .filter(|object_id| !tracked_object_ids.contains(object_id))
             .collect_vec();
@@ -526,9 +536,16 @@ impl HummockManager {
         let backup_pinned: HashSet<_> = backup_manager.list_pinned_object_ids().await;
         // The version_pinned is obtained after the candidate object_ids for deletion, which is new enough for filtering purpose.
         let version_pinned = {
-            let versioning = self.versioning.read().await;
-            versioning
-                .get_tracked_object_ids(self.context_info.read().await.min_pinned_version_id())
+            let versioning = self
+                .versioning
+                .read_with_process_name("try_start_minor_gc")
+                .await;
+            versioning.get_tracked_object_ids(
+                self.context_info
+                    .read_with_process_name("try_start_minor_gc")
+                    .await
+                    .min_pinned_version_id(),
+            )
         };
         let object_ids = object_ids
             .into_iter()

--- a/src/meta/src/hummock/manager/mod.rs
+++ b/src/meta/src/hummock/manager/mod.rs
@@ -491,7 +491,7 @@ impl HummockManager {
         } else {
             let default_compaction_config = self
                 .compaction_group_manager
-                .read()
+                .read_with_process_name("load_meta_store_state")
                 .await
                 .default_compaction_config();
             let checkpoint_version = HummockVersion::create_init_version(default_compaction_config);
@@ -651,7 +651,10 @@ impl HummockManager {
         &self,
         table_id: TableId,
     ) -> MetaResult<(u64, UnboundedReceiver<u64>)> {
-        let version = self.versioning.read().await;
+        let version = self
+            .versioning
+            .read_with_process_name("subscribe_table_committed_epoch")
+            .await;
         if let Some(epoch) = version.current_version.table_committed_epoch(table_id) {
             let (tx, rx) = unbounded_channel();
             self.table_committed_epoch_notifiers

--- a/src/meta/src/hummock/manager/tests.rs
+++ b/src/meta/src/hummock/manager/tests.rs
@@ -3539,7 +3539,9 @@ async fn test_normalize_overlapping_compaction_groups_cancels_expired_compact_ta
     assert!(
         !hummock_manager
             .compaction
-            .read()
+            .read_with_process_name(
+                "test_normalize_overlapping_compaction_groups_cancels_expired_compact_tasks",
+            )
             .await
             .get_compact_task_assignments_by_group_id(cg_64)
             .is_empty()
@@ -3553,7 +3555,9 @@ async fn test_normalize_overlapping_compaction_groups_cancels_expired_compact_ta
     assert!(
         hummock_manager
             .compaction
-            .read()
+            .read_with_process_name(
+                "test_normalize_overlapping_compaction_groups_cancels_expired_compact_tasks",
+            )
             .await
             .get_compact_task_assignments_by_group_id(cg_64)
             .is_empty(),

--- a/src/meta/src/hummock/manager/time_travel.rs
+++ b/src/meta/src/hummock/manager/time_travel.rs
@@ -76,7 +76,11 @@ impl HummockManager {
             .metrics
             .time_travel_vacuum_metadata_latency
             .start_timer();
-        let min_pinned_version_id = self.context_info.read().await.min_pinned_version_id();
+        let min_pinned_version_id = self
+            .context_info
+            .read_with_process_name("truncate_time_travel_metadata")
+            .await
+            .min_pinned_version_id();
         let sql_store = self.env.meta_store_ref();
         let txn = sql_store.conn.begin().await?;
 

--- a/src/meta/src/hummock/manager/timer_task.rs
+++ b/src/meta/src/hummock/manager/timer_task.rs
@@ -437,7 +437,10 @@ impl HummockManager {
         // This keeps the report lane from blocking writers on `versioning` or
         // `compaction_group_manager` while doing potentially heavy metric iteration.
         let (current_version, version_stats) = {
-            let versioning_guard = self.versioning.read().await;
+            let versioning_guard = self
+                .versioning
+                .read_with_process_name("handle_timer_report")
+                .await;
             (
                 versioning_guard.current_version.clone(),
                 versioning_guard.version_stats.clone(),
@@ -583,8 +586,14 @@ impl HummockManager {
         const MAX_COMPACTION_L0_MULTIPLIER: u64 = 32;
         const MAX_COMPACTION_DURATION_SEC: u64 = 20 * 60;
         let slowdown_groups = {
-            let versioning_guard = self.versioning.read().await;
-            let compaction_group_manager = self.compaction_group_manager.read().await;
+            let versioning_guard = self
+                .versioning
+                .read_with_process_name("check_dead_task")
+                .await;
+            let compaction_group_manager = self
+                .compaction_group_manager
+                .read_with_process_name("check_dead_task")
+                .await;
             let mut slowdown_groups: HashMap<CompactionGroupId, u64> = HashMap::default();
 
             for (group_id, group_levels) in &versioning_guard.current_version.levels {
@@ -617,7 +626,10 @@ impl HummockManager {
         let mut pending_tasks: HashMap<u64, (CompactionGroupId, usize, RunningCompactTask)> =
             HashMap::default();
         {
-            let compaction_guard = self.compaction.read().await;
+            let compaction_guard = self
+                .compaction
+                .read_with_process_name("check_dead_task")
+                .await;
             for group_id in slowdown_groups.keys() {
                 if let Some(status) = compaction_guard.compaction_statuses.get(group_id) {
                     for (idx, level_handler) in status.level_handlers.iter().enumerate() {

--- a/src/meta/src/hummock/manager/versioning.rs
+++ b/src/meta/src/hummock/manager/versioning.rs
@@ -128,7 +128,7 @@ impl Versioning {
 impl HummockManager {
     pub async fn list_pinned_version(&self) -> Vec<HummockPinnedVersion> {
         self.context_info
-            .read()
+            .read_with_process_name("list_pinned_version")
             .await
             .pinned_versions
             .values()
@@ -163,14 +163,22 @@ impl HummockManager {
     }
 
     pub async fn on_current_version<T>(&self, mut f: impl FnMut(&HummockVersion) -> T) -> T {
-        f(self.versioning.read().await.current_version.as_ref())
+        f(self
+            .versioning
+            .read_with_process_name("on_current_version")
+            .await
+            .current_version
+            .as_ref())
     }
 
     pub async fn on_current_version_and_table_change_log<T>(
         &self,
         mut f: impl FnMut(&HummockVersion, &TableChangeLogs) -> T,
     ) -> T {
-        let guard = self.versioning.read().await;
+        let guard = self
+            .versioning
+            .read_with_process_name("on_current_version_and_table_change_log")
+            .await;
         f(&guard.current_version, &guard.table_change_log)
     }
 
@@ -182,7 +190,13 @@ impl HummockManager {
     pub async fn get_table_compaction_group_id_mapping(
         &self,
     ) -> HashMap<StateTableId, CompactionGroupId> {
-        get_table_compaction_group_id_mapping(&self.versioning.read().await.current_version)
+        get_table_compaction_group_id_mapping(
+            &self
+                .versioning
+                .read_with_process_name("get_table_compaction_group_id_mapping")
+                .await
+                .current_version,
+        )
     }
 
     /// Get version deltas from meta store
@@ -191,7 +205,10 @@ impl HummockManager {
         start_id: HummockVersionId,
         num_limit: u32,
     ) -> Result<Vec<HummockVersionDelta>> {
-        let versioning = self.versioning.read().await;
+        let versioning = self
+            .versioning
+            .read_with_process_name("list_version_deltas")
+            .await;
         let version_deltas = versioning
             .hummock_version_deltas
             .range(start_id..)
@@ -203,7 +220,11 @@ impl HummockManager {
     }
 
     pub async fn get_version_stats(&self) -> HummockVersionStats {
-        self.versioning.read().await.version_stats.clone()
+        self.versioning
+            .read_with_process_name("get_version_stats")
+            .await
+            .version_stats
+            .clone()
     }
 
     /// Updates write limits for `target_groups` and sends notification.
@@ -213,7 +234,10 @@ impl HummockManager {
         &self,
         target_group_ids: &[CompactionGroupId],
     ) -> bool {
-        let versioning = self.versioning.read().await;
+        let versioning = self
+            .versioning
+            .read_with_process_name("try_update_write_limits")
+            .await;
         let mut cg_manager = self
             .compaction_group_manager
             .write_with_process_name("try_update_write_limits")
@@ -254,12 +278,18 @@ impl HummockManager {
     /// Gets write limits.
     /// The implementation acquires `versioning` lock.
     pub async fn write_limits(&self) -> HashMap<CompactionGroupId, WriteLimit> {
-        let guard = self.compaction_group_manager.read().await;
+        let guard = self
+            .compaction_group_manager
+            .read_with_process_name("write_limits")
+            .await;
         guard.write_limit.clone()
     }
 
     pub async fn list_branched_objects(&self) -> BTreeMap<HummockSstableObjectId, BranchedSstInfo> {
-        let guard = self.versioning.read().await;
+        let guard = self
+            .versioning
+            .read_with_process_name("list_branched_objects")
+            .await;
         guard.current_version.build_branched_sst_info()
     }
 


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

- Label every Hummock manager read acquisition for `versioning`, `compaction`, `compaction_group_manager`, and `context_info` with its enclosing operation name so lock-processing metrics no longer aggregate these paths under `unnamed`.
- Apply the labels consistently to multi-lock operations and test-only helpers without changing lock ordering or behavior.
- Follow up on #26698, which added the corresponding write-lock labels.

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

None; this only improves internal lock observability.

</details>
