### PR TITLE
feat: add table change log latency metrics (#26292)

### DIFF
--- a/src/meta/src/hummock/manager/versioning.rs
+++ b/src/meta/src/hummock/manager/versioning.rs
@@ -326,6 +326,7 @@ impl HummockManager {
         exclude_empty: bool,
         limit: Option<u32>,
     ) -> TableChangeLogs {
+        let _timer = self.metrics.table_change_log_get_latency.start_timer();
         self.on_current_version(|version| {
             version
                 .table_change_log

--- a/src/meta/src/rpc/metrics.rs
+++ b/src/meta/src/rpc/metrics.rs
@@ -172,6 +172,8 @@ pub struct MetaMetrics {
     pub table_change_log_object_size: IntGaugeVec,
     /// Min epoch currently retained in table change log.
     pub table_change_log_min_epoch: IntGaugeVec,
+    /// Latency of serving table change log requests.
+    pub table_change_log_get_latency: Histogram,
     /// The number of hummock version delta log.
     pub delta_log_count: IntGauge,
     /// latency of version checkpoint
@@ -568,6 +570,14 @@ impl MetaMetrics {
             registry
         )
         .unwrap();
+
+        let opts = histogram_opts!(
+            "storage_table_change_log_get_latency",
+            "latency of serving table change log requests",
+            exponential_buckets(0.001, 5.0, 7).unwrap()
+        );
+        let table_change_log_get_latency =
+            register_histogram_with_registry!(opts, registry).unwrap();
 
         let time_travel_object_count = register_int_gauge_with_registry!(
             "storage_time_travel_object_count",
@@ -998,6 +1008,7 @@ impl MetaMetrics {
             table_change_log_object_count,
             table_change_log_object_size,
             table_change_log_min_epoch,
+            table_change_log_get_latency,
             delta_log_count,
             version_checkpoint_latency,
             current_version_id,

--- a/src/storage/src/hummock/store/hummock_storage.rs
+++ b/src/storage/src/hummock/store/hummock_storage.rs
@@ -226,6 +226,7 @@ impl HummockStorage {
         let table_change_log_manager = Arc::new(TableChangeLogManager::new(
             options.table_change_log_cache_capacity,
             hummock_meta_client.clone(),
+            state_store_metrics.clone(),
         ));
         let instance = Self {
             context: compactor_context,

--- a/src/storage/src/hummock/store/table_change_log_manager.rs
+++ b/src/storage/src/hummock/store/table_change_log_manager.rs
@@ -25,6 +25,7 @@ use risingwave_hummock_sdk::change_log::TableChangeLogs;
 use risingwave_rpc_client::HummockMetaClient;
 
 use crate::hummock::{HummockError, HummockResult};
+use crate::monitor::HummockStateStoreMetrics;
 
 type InflightResult = Shared<Pin<Box<dyn Future<Output = HummockResult<TableChangeLogs>> + Send>>>;
 
@@ -40,14 +41,20 @@ struct CacheKey {
 pub struct TableChangeLogManager {
     cache: Cache<CacheKey, InflightResult>,
     hummock_meta_client: Arc<dyn HummockMetaClient>,
+    metrics: Arc<HummockStateStoreMetrics>,
 }
 
 impl TableChangeLogManager {
-    pub fn new(capacity: u64, hummock_meta_client: Arc<dyn HummockMetaClient>) -> Self {
+    pub fn new(
+        capacity: u64,
+        hummock_meta_client: Arc<dyn HummockMetaClient>,
+        metrics: Arc<HummockStateStoreMetrics>,
+    ) -> Self {
         let cache = Cache::builder().max_capacity(capacity).build();
         Self {
             cache,
             hummock_meta_client,
+            metrics,
         }
     }
 
@@ -59,7 +66,8 @@ impl TableChangeLogManager {
         limit: Option<u32>,
         fetch: impl Future<Output = HummockResult<TableChangeLogs>> + Send + 'static,
     ) -> HummockResult<TableChangeLogs> {
-        self.cache
+        let entry = self
+            .cache
             .entry(CacheKey {
                 table_id,
                 epoch_range,
@@ -74,10 +82,13 @@ impl TableChangeLogManager {
                     }
                     false
                 },
-            )
-            .value()
-            .clone()
-            .await
+            );
+        if entry.is_fresh() {
+            self.metrics.table_change_log_cache_miss.inc();
+        } else {
+            self.metrics.table_change_log_cache_hit.inc();
+        }
+        entry.value().clone().await
     }
 
     /// Fetches table change logs for the given `table_id` and `epoch_range`.
@@ -99,6 +110,7 @@ impl TableChangeLogManager {
         include_epoch_only: bool,
         limit: Option<u32>,
     ) -> HummockResult<TableChangeLogs> {
+        let _timer = self.metrics.table_change_log_fetch_latency.start_timer();
         let hummock_meta_client = self.hummock_meta_client.clone();
         let fetch = async move {
             hummock_meta_client

--- a/src/storage/src/monitor/hummock_state_store_metrics.rs
+++ b/src/storage/src/monitor/hummock_state_store_metrics.rs
@@ -95,6 +95,9 @@ pub struct HummockStateStoreMetrics {
 
     pub safe_version_hit: GenericCounter<AtomicU64>,
     pub safe_version_miss: GenericCounter<AtomicU64>,
+    pub table_change_log_fetch_latency: Histogram,
+    pub table_change_log_cache_hit: GenericCounter<AtomicU64>,
+    pub table_change_log_cache_miss: GenericCounter<AtomicU64>,
 }
 
 pub static GLOBAL_HUMMOCK_STATE_STORE_METRICS: OnceLock<HummockStateStoreMetrics> = OnceLock::new();
@@ -209,7 +212,7 @@ impl HummockStateStoreMetrics {
         let opts = histogram_opts!(
             "state_store_iter_fetch_meta_duration",
             "Histogram of iterator fetch SST meta time that have been issued to state store",
-            state_store_read_time_buckets,
+            state_store_read_time_buckets.clone(),
         );
         let iter_fetch_meta_duration =
             register_guarded_histogram_vec_with_registry!(opts, &["table_id"], registry).unwrap();
@@ -232,6 +235,25 @@ impl HummockStateStoreMetrics {
             registry
         )
         .unwrap();
+
+        let opts = histogram_opts!(
+            "state_store_table_change_log_fetch_latency",
+            "Latency of fetching table change logs",
+            state_store_read_time_buckets,
+        );
+        let table_change_log_fetch_latency =
+            register_histogram_with_registry!(opts, registry).unwrap();
+
+        let table_change_log_cache_counts = register_int_counter_vec_with_registry!(
+            "state_store_table_change_log_cache_counts",
+            "Total number of table change log cache lookups",
+            &["result"],
+            registry
+        )
+        .unwrap();
+        let table_change_log_cache_hit = table_change_log_cache_counts.with_label_values(&["hit"]);
+        let table_change_log_cache_miss =
+            table_change_log_cache_counts.with_label_values(&["miss"]);
 
         // ----- vector -----
         let vector_object_request_counts = register_guarded_int_counter_vec_with_registry!(
@@ -620,6 +642,9 @@ impl HummockStateStoreMetrics {
             event_handler_latency,
             safe_version_hit,
             safe_version_miss,
+            table_change_log_fetch_latency,
+            table_change_log_cache_hit,
+            table_change_log_cache_miss,
         }
     }
 


### PR DESCRIPTION
Backport/cherry-pick of 40d2a482ca033a7699cd424c76a4474e7e7e0255.

Adds table change log latency metrics to the v2.8.4 pg-vector-toast-nectar branch.