### PR TITLE
fix(cdc): avoid recovery loops for missing upstream tables

### DIFF
--- a/src/connector/src/source/cdc/external/mock_external_table.rs
+++ b/src/connector/src/source/cdc/external/mock_external_table.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::sync::atomic::AtomicUsize;
+use std::sync::atomic::{AtomicUsize, Ordering};
 
 use futures::stream::BoxStream;
 use futures_async_stream::try_stream;
@@ -31,6 +31,7 @@ use crate::source::cdc::external::{
 pub struct MockExternalTableReader {
     binlog_watermarks: Vec<MySqlOffset>,
     snapshot_cnt: AtomicUsize,
+    snapshot_errors_remaining: AtomicUsize,
     cdc_offset_idx: AtomicUsize,
     parallel_backfill_snapshots: Vec<OwnedRow>,
 }
@@ -86,9 +87,30 @@ impl MockExternalTableReader {
         Self {
             binlog_watermarks,
             snapshot_cnt: AtomicUsize::new(0),
+            snapshot_errors_remaining: AtomicUsize::new(0),
             parallel_backfill_snapshots,
             cdc_offset_idx: AtomicUsize::new(0),
         }
+    }
+
+    pub fn new_with_snapshot_errors(snapshot_errors: usize) -> Self {
+        Self {
+            snapshot_errors_remaining: AtomicUsize::new(snapshot_errors),
+            ..Self::new()
+        }
+    }
+
+    fn take_snapshot_error(&self) -> ConnectorResult<()> {
+        if self
+            .snapshot_errors_remaining
+            .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |remaining| {
+                remaining.checked_sub(1)
+            })
+            .is_ok()
+        {
+            return Err(anyhow::anyhow!("mock snapshot read error").into());
+        }
+        Ok(())
     }
 
     pub fn get_normalized_table_name(_table_name: &SchemaTableName) -> String {
@@ -107,9 +129,9 @@ impl MockExternalTableReader {
     /// After that we will emit the buffered upstream chunks all in one.
     #[try_stream(boxed, ok = OwnedRow, error = ConnectorError)]
     async fn snapshot_read_inner(&self) {
-        let snap_idx = self
-            .snapshot_cnt
-            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        self.take_snapshot_error()?;
+
+        let snap_idx = self.snapshot_cnt.fetch_add(1, Ordering::Relaxed);
         println!("snapshot read: idx {}", snap_idx);
 
         let snap0 = vec![
@@ -151,6 +173,7 @@ impl MockExternalTableReader {
 
     #[try_stream(boxed, ok = OwnedRow, error = ConnectorError)]
     async fn split_snapshot_read_inner(&self, left: OwnedRow, right: OwnedRow) {
+        self.take_snapshot_error()?;
         for row in &self.parallel_backfill_snapshots {
             if (left[0].is_none()
                 || cmp_datum(&row[0], &left[0], OrderType::ascending_nulls_first()).is_ge())
@@ -165,9 +188,7 @@ impl MockExternalTableReader {
 
 impl ExternalTableReader for MockExternalTableReader {
     async fn current_cdc_offset(&self) -> ConnectorResult<CdcOffset> {
-        let idx = self
-            .cdc_offset_idx
-            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        let idx = self.cdc_offset_idx.fetch_add(1, Ordering::Relaxed);
         if idx < self.binlog_watermarks.len() {
             Ok(CdcOffset::MySql(self.binlog_watermarks[idx].clone()))
         } else {

--- a/src/connector/src/source/cdc/external/mod.rs
+++ b/src/connector/src/source/cdc/external/mod.rs
@@ -81,6 +81,16 @@ impl ExternalCdcTableType {
         matches!(self, Self::MySql | Self::Postgres)
     }
 
+    pub fn get_cdc_offset_parser(&self) -> ConnectorResult<CdcOffsetParseFunc> {
+        match self {
+            Self::MySql => Ok(MySqlExternalTableReader::get_cdc_offset_parser()),
+            Self::Postgres => Ok(PostgresExternalTableReader::get_cdc_offset_parser()),
+            Self::SqlServer => Ok(SqlServerExternalTableReader::get_cdc_offset_parser()),
+            Self::Mock => Ok(MockExternalTableReader::get_cdc_offset_parser()),
+            _ => bail!("invalid external table type: {:?}", *self),
+        }
+    }
+
     pub async fn create_table_reader(
         &self,
         config: ExternalTableConfig,

--- a/src/connector/src/source/cdc/external/mysql.rs
+++ b/src/connector/src/source/cdc/external/mysql.rs
@@ -577,6 +577,7 @@ impl MySqlExternalTableReader {
         // Query MySQL primary key infos for type casting.
         let upstream_mysql_pk_infos =
             Self::query_upstream_pk_infos(&pool, &database, &table).await?;
+        Self::validate_upstream_pk_columns(&upstream_mysql_pk_infos, &rw_schema, &pk_indices)?;
         // Get MySQL version
         let (major_version, minor_version, is_mariadb) = Self::get_mysql_version(&pool).await?;
         let mysql_version = (major_version, minor_version);
@@ -644,6 +645,43 @@ impl MySqlExternalTableReader {
         drop(conn);
 
         Ok(column_infos)
+    }
+
+    fn validate_upstream_pk_columns(
+        upstream_pk_infos: &[(String, ColumnType)],
+        rw_schema: &Schema,
+        pk_indices: &[usize],
+    ) -> ConnectorResult<()> {
+        let expected_pk_names = pk_indices
+            .iter()
+            .map(|&index| rw_schema.fields[index].name.as_str())
+            .collect_vec();
+        let upstream_pk_names = upstream_pk_infos
+            .iter()
+            .map(|(name, _)| name.as_str())
+            .collect_vec();
+
+        if upstream_pk_names.is_empty() {
+            return Err(anyhow!(
+                "upstream MySQL primary key metadata is empty; expected columns {:?}",
+                expected_pk_names
+            )
+            .into());
+        }
+        if upstream_pk_names.len() != expected_pk_names.len()
+            || upstream_pk_names
+                .iter()
+                .zip_eq_fast(&expected_pk_names)
+                .any(|(upstream, expected)| !upstream.eq_ignore_ascii_case(expected))
+        {
+            return Err(anyhow!(
+                "upstream MySQL primary key columns {:?} do not match expected columns {:?}",
+                upstream_pk_names,
+                expected_pk_names
+            )
+            .into());
+        }
+        Ok(())
     }
 
     /// Check whether a column is `BIGINT UNSIGNED`.
@@ -988,6 +1026,49 @@ mod tests {
             mysql_type_to_rw_type(&parse_mysql_type_name("BIGINT UNSIGNED")).unwrap();
         assert_eq!(serial_type, DataType::Decimal);
         assert_eq!(serial_type, unsigned_bigint_type);
+    }
+
+    #[test]
+    fn test_validate_upstream_pk_columns() {
+        let rw_schema = Schema::new(vec![
+            Field::with_name(DataType::Int64, "id"),
+            Field::with_name(DataType::Varchar, "tenant"),
+        ]);
+        let int_type = || ColumnType::BigInt(Default::default());
+
+        MySqlExternalTableReader::validate_upstream_pk_columns(
+            &[
+                ("ID".to_owned(), int_type()),
+                ("tenant".to_owned(), int_type()),
+            ],
+            &rw_schema,
+            &[0, 1],
+        )
+        .unwrap();
+
+        for invalid_pk_infos in [
+            vec![],
+            vec![
+                ("tenant".to_owned(), int_type()),
+                ("id".to_owned(), int_type()),
+            ],
+            vec![("id".to_owned(), int_type())],
+            vec![
+                ("id".to_owned(), int_type()),
+                ("tenant".to_owned(), int_type()),
+                ("extra".to_owned(), int_type()),
+            ],
+        ] {
+            assert!(
+                MySqlExternalTableReader::validate_upstream_pk_columns(
+                    &invalid_pk_infos,
+                    &rw_schema,
+                    &[0, 1],
+                )
+                .is_err(),
+                "unexpectedly accepted {invalid_pk_infos:?}"
+            );
+        }
     }
 
     #[ignore]

--- a/src/connector/src/source/cdc/external/mysql.rs
+++ b/src/connector/src/source/cdc/external/mysql.rs
@@ -622,12 +622,16 @@ impl MySqlExternalTableReader {
 
         // Query primary key columns and their data types
         let sql = format!(
-            "SELECT COLUMN_NAME, COLUMN_TYPE
-            FROM INFORMATION_SCHEMA.COLUMNS
-            WHERE TABLE_SCHEMA = '{}'
-            AND TABLE_NAME = '{}'
-            AND COLUMN_KEY = 'PRI'
-            ORDER BY ORDINAL_POSITION",
+            "SELECT s.COLUMN_NAME, c.COLUMN_TYPE
+            FROM INFORMATION_SCHEMA.STATISTICS AS s
+            JOIN INFORMATION_SCHEMA.COLUMNS AS c
+              ON c.TABLE_SCHEMA = s.TABLE_SCHEMA
+             AND c.TABLE_NAME = s.TABLE_NAME
+             AND c.COLUMN_NAME = s.COLUMN_NAME
+            WHERE s.TABLE_SCHEMA = '{}'
+              AND s.TABLE_NAME = '{}'
+              AND s.INDEX_NAME = 'PRIMARY'
+            ORDER BY s.SEQ_IN_INDEX",
             database, table
         );
 

--- a/src/stream/src/executor/backfill/cdc/cdc_backfill.rs
+++ b/src/stream/src/executor/backfill/cdc/cdc_backfill.rs
@@ -53,7 +53,7 @@ use crate::executor::backfill::utils::{
 use crate::executor::monitor::CdcBackfillMetrics;
 use crate::executor::prelude::*;
 use crate::executor::source::get_infinite_backoff_strategy;
-use crate::task::CreateMviewProgressReporter;
+use crate::task::{ActorId, CreateMviewProgressReporter, FragmentId};
 
 /// `split_id`, `is_finished`, `row_count`, `cdc_offset` all occupy 1 column each.
 const METADATA_STATE_LEN: usize = 4;
@@ -382,21 +382,11 @@ impl<S: StateStore> CdcBackfillExecutor<S> {
             let external_table = self.external_table.clone();
             let actor_id = self.actor_ctx.id;
             let fragment_id = self.actor_ctx.fragment_id;
-            let mut future = Box::pin(async move {
-                let backoff = get_infinite_backoff_strategy();
-                tokio_retry::Retry::spawn(backoff, || async {
-                    match external_table.create_table_reader().await {
-                        Ok(reader) => Ok(reader),
-                        Err(e) => {
-                            tracing::warn!(error = %e.as_report(), actor_id = %actor_id, fragment_id = %fragment_id, "failed to create cdc table reader, retrying...");
-                            Err(e)
-                        }
-                    }
-                })
-                .instrument(tracing::info_span!("create_cdc_table_reader_with_retry"))
-                .await
-                .expect("Retry create cdc table reader until success.")
-            });
+            let mut future = Box::pin(create_table_reader_with_retry(
+                external_table,
+                actor_id,
+                fragment_id,
+            ));
             loop {
                 if let Some(msg) =
                     build_reader_and_poll_upstream(&mut upstream, &mut table_reader, &mut future)
@@ -428,7 +418,7 @@ impl<S: StateStore> CdcBackfillExecutor<S> {
                 }
             }
 
-            let upstream_table_reader = UpstreamTableReader::new(
+            let mut upstream_table_reader = UpstreamTableReader::new(
                 self.external_table.clone(),
                 table_reader.expect("table reader must created"),
             );
@@ -448,16 +438,14 @@ impl<S: StateStore> CdcBackfillExecutor<S> {
             // Whether each pk column needs unsigned `i64` comparison. Frontend up-casts narrower
             // unsigned integers, while unsigned float/double/decimal keep their native comparison
             // semantics; only `BIGINT UNSIGNED` can overflow into a negative `i64` in RisingWave.
-            let pk_needs_unsigned_i64_compare = {
-                let schema = self.external_table.schema();
-                let pk_names: Vec<String> = pk_indices
-                    .iter()
-                    .map(|&i| schema.fields[i].name.clone())
-                    .collect();
-                upstream_table_reader
-                    .reader
-                    .pk_column_unsigned_i64_compare_flags(&pk_names)?
-            };
+            let schema = self.external_table.schema();
+            let pk_names: Vec<String> = pk_indices
+                .iter()
+                .map(|&i| schema.fields[i].name.clone())
+                .collect();
+            let mut pk_needs_unsigned_i64_compare = upstream_table_reader
+                .reader
+                .pk_column_unsigned_i64_compare_flags(&pk_names)?;
 
             tracing::info!(
                 %table_id,
@@ -527,8 +515,138 @@ impl<S: StateStore> CdcBackfillExecutor<S> {
 
             // the buffer will be drained when a barrier comes
             let mut upstream_chunk_buffer: Vec<StreamChunk> = vec![];
+            let mut needs_reader_rebuild = false;
 
             'backfill_loop: loop {
+                if needs_reader_rebuild {
+                    tracing::info!(
+                        %table_id,
+                        upstream_table_name,
+                        "rebuilding CDC table reader after snapshot read failure"
+                    );
+                    let mut table_reader = None;
+                    let mut future = Box::pin(create_table_reader_with_retry(
+                        self.external_table.clone(),
+                        self.actor_ctx.id,
+                        self.actor_ctx.fragment_id,
+                    ));
+
+                    loop {
+                        let Some(msg) = build_reader_and_poll_upstream(
+                            &mut upstream,
+                            &mut table_reader,
+                            &mut future,
+                        )
+                        .await?
+                        else {
+                            break;
+                        };
+
+                        match msg {
+                            Message::Barrier(barrier) => {
+                                if let Some(mutation) = barrier.mutation.as_deref() {
+                                    use crate::executor::Mutation;
+                                    match mutation {
+                                        Mutation::Pause => {
+                                            is_snapshot_paused = true;
+                                        }
+                                        Mutation::Resume => {
+                                            is_snapshot_paused = false;
+                                        }
+                                        Mutation::Throttle(some) => {
+                                            if let Some(entry) =
+                                                some.get(&self.actor_ctx.fragment_id)
+                                                && entry.throttle_type() == ThrottleType::Backfill
+                                            {
+                                                self.rate_limit_rps = entry.rate_limit;
+                                            }
+                                        }
+                                        mutation if mutation.is_stop(self.actor_ctx.id) => {
+                                            tracing::info!(
+                                                %table_id,
+                                                upstream_table_name,
+                                                "CdcBackfill has been dropped due to config change"
+                                            );
+                                            yield Message::Barrier(barrier);
+                                            break 'backfill_loop;
+                                        }
+                                        _ => (),
+                                    }
+                                }
+
+                                let (
+                                    emitted_upstream_chunks,
+                                    upstream_processed_row_count,
+                                    consumed_binlog_offset,
+                                ) = Self::consume_upstream_chunk_buffer(
+                                    &offset_parse_func,
+                                    &mut upstream_chunk_buffer,
+                                    current_pk_pos.as_ref(),
+                                    PkCompareInfo {
+                                        indices: &pk_indices,
+                                        order: &pk_order,
+                                        needs_unsigned_i64_compare: &pk_needs_unsigned_i64_compare,
+                                    },
+                                    &last_binlog_offset,
+                                    &self.output_indices,
+                                )?;
+                                if let Some(consumed_binlog_offset) = consumed_binlog_offset {
+                                    last_binlog_offset = Some(consumed_binlog_offset);
+                                }
+                                for chunk in emitted_upstream_chunks {
+                                    yield Message::Chunk(chunk);
+                                }
+
+                                Self::report_metrics(
+                                    &self.metrics,
+                                    0,
+                                    upstream_processed_row_count,
+                                );
+                                state_impl
+                                    .mutate_state(
+                                        current_pk_pos.clone(),
+                                        last_binlog_offset.clone(),
+                                        total_snapshot_row_count,
+                                        false,
+                                    )
+                                    .await?;
+                                state_impl.commit_state(barrier.epoch).await?;
+                                yield Message::Barrier(barrier);
+                            }
+                            Message::Chunk(chunk) => {
+                                if chunk.cardinality() == 0 {
+                                    continue;
+                                }
+                                let chunk_binlog_offset =
+                                    get_cdc_chunk_last_offset(&offset_parse_func, &chunk)?;
+                                if let Some(last_binlog_offset) = last_binlog_offset.as_ref()
+                                    && let Some(chunk_offset) = chunk_binlog_offset
+                                    && chunk_offset < *last_binlog_offset
+                                {
+                                    continue;
+                                }
+                                upstream_chunk_buffer.push(chunk.compact_vis());
+                            }
+                            Message::Watermark(_) => {
+                                // Ignore watermark while the snapshot reader is unavailable.
+                            }
+                        }
+                    }
+
+                    upstream_table_reader = UpstreamTableReader::new(
+                        self.external_table.clone(),
+                        table_reader.expect("table reader must be created"),
+                    );
+                    pk_needs_unsigned_i64_compare = upstream_table_reader
+                        .reader
+                        .pk_column_unsigned_i64_compare_flags(&pk_names)?;
+                    tracing::info!(
+                        %table_id,
+                        upstream_table_name,
+                        "CDC table reader rebuilt successfully"
+                    );
+                }
+
                 let mut should_bypass_snapshot_stream_patch =
                     self.rate_limit_rps.is_some_and(|val| val == 0);
                 let left_upstream = upstream.by_ref().map(Either::Left);
@@ -562,6 +680,7 @@ impl<S: StateStore> CdcBackfillExecutor<S> {
                 let mut cur_barrier_upstream_processed_rows: u64 = 0;
                 let mut barrier_count: u32 = 0;
                 let mut pending_barrier = None;
+                let mut snapshot_read_failed = false;
 
                 #[for_await]
                 for either in &mut backfill_stream {
@@ -619,7 +738,10 @@ impl<S: StateStore> CdcBackfillExecutor<S> {
 
                                     // when processing a barrier, check whether can start a new snapshot
                                     // if the number of barriers reaches the snapshot interval
-                                    if can_start_new_snapshot || needs_rebuild_snapshot {
+                                    if can_start_new_snapshot
+                                        || needs_rebuild_snapshot
+                                        || snapshot_read_failed
+                                    {
                                         // staging the barrier
                                         pending_barrier = Some(barrier);
                                         tracing::debug!(
@@ -762,11 +884,12 @@ impl<S: StateStore> CdcBackfillExecutor<S> {
                                     ));
                                 }
                                 Err(error) => {
+                                    snapshot_read_failed = true;
                                     tracing::warn!(
                                         error = %error.as_report(),
                                         %table_id,
                                         upstream_table_name,
-                                        "failed to read CDC snapshot; retrying after a barrier"
+                                        "failed to read CDC snapshot; rebuilding reader after a barrier"
                                     );
                                 }
                             }
@@ -847,11 +970,12 @@ impl<S: StateStore> CdcBackfillExecutor<S> {
                             yield Message::Chunk(mapping_chunk(chunk, &self.output_indices));
                         }
                         Err(error) => {
+                            snapshot_read_failed = true;
                             tracing::warn!(
                                 error = %error.as_report(),
                                 %table_id,
                                 upstream_table_name,
-                                "failed to read CDC snapshot; retrying after a barrier"
+                                "failed to read CDC snapshot; rebuilding reader after a barrier"
                             );
                         }
                     }
@@ -910,6 +1034,7 @@ impl<S: StateStore> CdcBackfillExecutor<S> {
 
                 state_impl.commit_state(pending_barrier.epoch).await?;
                 yield Message::Barrier(pending_barrier);
+                needs_reader_rebuild = snapshot_read_failed;
             }
             upstream_table_reader.disconnect().await?;
         } else if self.options.disable_backfill {
@@ -1001,6 +1126,31 @@ pub(crate) async fn build_reader_and_poll_upstream(
             msg.transpose()
         }
     }
+}
+
+pub(crate) async fn create_table_reader_with_retry(
+    external_table: ExternalStorageTable,
+    actor_id: ActorId,
+    fragment_id: FragmentId,
+) -> ExternalTableReaderImpl {
+    let backoff = get_infinite_backoff_strategy();
+    tokio_retry::Retry::spawn(backoff, || async {
+        match external_table.create_table_reader().await {
+            Ok(reader) => Ok(reader),
+            Err(error) => {
+                tracing::warn!(
+                    error = %error.as_report(),
+                    actor_id = %actor_id,
+                    fragment_id = %fragment_id,
+                    "failed to create CDC table reader; retrying"
+                );
+                Err(error)
+            }
+        }
+    })
+    .instrument(tracing::info_span!("create_cdc_table_reader_with_retry"))
+    .await
+    .expect("retry creating CDC table reader until success")
 }
 
 #[try_stream(ok = Message, error = StreamExecutorError)]
@@ -1348,7 +1498,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_snapshot_read_error_retries_without_failing_executor() {
+    async fn test_snapshot_read_error_rebuilds_reader() {
         let (tx, source) = MockSource::channel();
         let source = source.into_executor(
             Schema::new(vec![
@@ -1373,7 +1523,8 @@ mod tests {
             vec![OrderType::ascending()],
             vec![0],
         )
-        .with_mock_snapshot_errors(usize::MAX);
+        .with_mock_snapshot_errors([1, 0]);
+        let reader_create_probe = external_table.clone();
         let executor = CdcBackfillExecutor::new(
             ActorContext::for_test(0x1a),
             external_table,
@@ -1402,8 +1553,7 @@ mod tests {
             Message::Barrier(_)
         ));
 
-        // The second barrier starts the snapshot. Its permanent reader error must leave the
-        // executor pending rather than escape and trigger recovery.
+        // The second barrier starts the snapshot. The first reader fails when it is polled.
         tx.send_barrier(Barrier::new_test_barrier(test_epoch(2)));
         assert!(matches!(
             executor.next().await.unwrap().unwrap(),
@@ -1414,15 +1564,27 @@ mod tests {
                 .await
                 .is_err()
         );
+        assert_eq!(reader_create_probe.mock_reader_create_count(), 1);
 
-        // Barriers continue to pass while each new snapshot attempt remains retryable.
-        for epoch in [3, 4] {
-            tx.send_barrier(Barrier::new_test_barrier(test_epoch(epoch)));
-            assert!(matches!(
-                executor.next().await.unwrap().unwrap(),
-                Message::Barrier(_)
-            ));
-        }
+        // The next barrier checkpoints the resume position before the failed reader is replaced.
+        tx.send_barrier(Barrier::new_test_barrier(test_epoch(3)));
+        assert!(matches!(
+            executor.next().await.unwrap().unwrap(),
+            Message::Barrier(_)
+        ));
+
+        // The replacement reader succeeds, proving that retries do not reuse the failed reader.
+        let Message::Chunk(chunk) = executor.next().await.unwrap().unwrap() else {
+            panic!("replacement reader should produce the snapshot chunk");
+        };
+        assert_eq!(chunk.cardinality(), 6);
+        assert_eq!(reader_create_probe.mock_reader_create_count(), 2);
+
+        tx.send_barrier(Barrier::new_test_barrier(test_epoch(4)));
+        assert!(matches!(
+            executor.next().await.unwrap().unwrap(),
+            Message::Barrier(_)
+        ));
     }
 
     #[tokio::test]

--- a/src/stream/src/executor/backfill/cdc/cdc_backfill.rs
+++ b/src/stream/src/executor/backfill/cdc/cdc_backfill.rs
@@ -720,8 +720,8 @@ impl<S: StateStore> CdcBackfillExecutor<S> {
                         }
                         // Snapshot read
                         Either::Right(msg) => {
-                            match msg? {
-                                None => {
+                            match msg {
+                                Ok(None) => {
                                     tracing::info!(
                                         %table_id,
                                         ?last_binlog_offset,
@@ -742,7 +742,7 @@ impl<S: StateStore> CdcBackfillExecutor<S> {
                                     // backfill has finished, exit the backfill loop and persist the state when we recv a barrier
                                     break 'backfill_loop;
                                 }
-                                Some(chunk) => {
+                                Ok(Some(chunk)) => {
                                     // Raise the current position.
                                     // As snapshot read streams are ordered by pk, so we can
                                     // just use the last row to update `current_pos`.
@@ -760,6 +760,14 @@ impl<S: StateStore> CdcBackfillExecutor<S> {
                                         chunk,
                                         &self.output_indices,
                                     ));
+                                }
+                                Err(error) => {
+                                    tracing::warn!(
+                                        error = %error.as_report(),
+                                        %table_id,
+                                        upstream_table_name,
+                                        "failed to read CDC snapshot; retrying after a barrier"
+                                    );
                                 }
                             }
                         }
@@ -788,8 +796,8 @@ impl<S: StateStore> CdcBackfillExecutor<S> {
                     let Either::Right(msg) = msg else {
                         bail!("BUG: snapshot_read contains upstream messages");
                     };
-                    match msg? {
-                        None => {
+                    match msg {
+                        Ok(None) => {
                             tracing::info!(
                                 %table_id,
                                 ?last_binlog_offset,
@@ -818,10 +826,10 @@ impl<S: StateStore> CdcBackfillExecutor<S> {
                             // end of backfill loop, since backfill has finished
                             break 'backfill_loop;
                         }
-                        Some(_) if is_snapshot_paused => {
+                        Ok(Some(_)) if is_snapshot_paused => {
                             // Since the snapshot stream is paused, drop the chunk.
                         }
-                        Some(chunk) => {
+                        Ok(Some(chunk)) => {
                             // Raise the current pk position.
                             current_pk_pos = Some(get_new_pos(&chunk, &pk_indices));
 
@@ -837,6 +845,14 @@ impl<S: StateStore> CdcBackfillExecutor<S> {
                                 "force emit a snapshot chunk"
                             );
                             yield Message::Chunk(mapping_chunk(chunk, &self.output_indices));
+                        }
+                        Err(error) => {
+                            tracing::warn!(
+                                error = %error.as_report(),
+                                %table_id,
+                                upstream_table_name,
+                                "failed to read CDC snapshot; retrying after a barrier"
+                            );
                         }
                     }
                 }
@@ -1105,6 +1121,7 @@ impl<S: StateStore> Execute for CdcBackfillExecutor<S> {
 mod tests {
     use std::collections::BTreeMap;
     use std::str::FromStr;
+    use std::time::Duration;
 
     use futures::{StreamExt, pin_mut};
     use risingwave_common::array::{Array, DataChunk, Op, StreamChunk};
@@ -1128,7 +1145,6 @@ mod tests {
     use crate::executor::backfill::cdc::state::CdcBackfillState;
     use crate::executor::monitor::StreamingMetrics;
     use crate::executor::prelude::StateTable;
-    use crate::executor::source::default_source_internal_table;
     use crate::executor::test_utils::MockSource;
     use crate::executor::{
         ActorContext, Barrier, CdcBackfillExecutor, ExternalStorageTable, Message,
@@ -1209,9 +1225,22 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_build_reader_and_poll_upstream() {
+    async fn test_finished_backfill_forwards_without_reader() {
         let actor_context = ActorContext::for_test(1);
-        let external_storage_table = ExternalStorageTable::for_test_undefined();
+        let table_id = TableId::new(1234);
+        let external_storage_table = ExternalStorageTable::new(
+            table_id,
+            SchemaTableName {
+                schema_name: "public".to_owned(),
+                table_name: "missing_table".to_owned(),
+            },
+            "mydb".to_owned(),
+            ExternalTableConfig::default(),
+            ExternalCdcTableType::Undefined,
+            Schema::new(vec![Field::with_name(DataType::Int64, "O_ORDERKEY")]),
+            vec![OrderType::ascending()],
+            vec![0],
+        );
         let schema = Schema::new(vec![
             Field::unnamed(DataType::Jsonb),   // debezium json payload
             Field::unnamed(DataType::Varchar), // _rw_offset
@@ -1219,7 +1248,9 @@ mod tests {
         ]);
         let stream_key = vec![1];
         let (mut tx, source) = MockSource::channel();
-        let source = source.into_executor(schema.clone(), stream_key.clone());
+        let source = source
+            .stop_on_finish(false)
+            .into_executor(schema.clone(), stream_key.clone());
         let output_indices = vec![1, 0, 4]; //reorder
         let output_columns = vec![
             ColumnDesc::named("O_ORDERKEY", ColumnId::new(1), DataType::Int64),
@@ -1230,9 +1261,29 @@ mod tests {
             ColumnDesc::named("commit_ts", ColumnId::new(6), DataType::Timestamptz),
         ];
         let store = MemoryStateStore::new();
-        let state_table =
-            StateTable::from_table_catalog(&default_source_internal_table(0x2333), store, None)
-                .await;
+        let mut persisted_state =
+            CdcBackfillState::new(table_id, create_cdc_state_table(store.clone()).await, 5);
+        persisted_state
+            .init_epoch(Barrier::new_test_barrier(test_epoch(6)).epoch)
+            .await
+            .unwrap();
+        persisted_state
+            .mutate_state(
+                Some(OwnedRow::new(vec![Some(ScalarImpl::Int64(5))])),
+                Some(CdcOffset::MySql(MySqlOffset::new(
+                    "1.binlog".to_owned(),
+                    100,
+                ))),
+                1,
+                true,
+            )
+            .await
+            .unwrap();
+        persisted_state
+            .commit_state(Barrier::new_test_barrier(test_epoch(7)).epoch)
+            .await
+            .unwrap();
+        let state_table = create_cdc_state_table(store).await;
         let cdc = CdcBackfillExecutor::new(
             actor_context,
             external_storage_table,
@@ -1243,17 +1294,9 @@ mod tests {
             StreamingMetrics::unused().into(),
             state_table,
             None,
-            CdcScanOptions {
-                // We want to mark backfill as finished. However it's not straightforward to do so.
-                // Here we disable_backfill instead.
-                disable_backfill: true,
-                ..CdcScanOptions::default()
-            },
+            CdcScanOptions::default(),
             BTreeMap::default(),
         );
-        // cdc.state_impl.init_epoch(EpochPair::new(test_epoch(4), test_epoch(3))).await.unwrap();
-        // cdc.state_impl.mutate_state(None, None, 0, true).await.unwrap();
-        // cdc.state_impl.commit_state(EpochPair::new(test_epoch(5), test_epoch(4))).await.unwrap();
         let s = cdc.execute_inner();
         pin_mut!(s);
 
@@ -1299,6 +1342,87 @@ mod tests {
             chunk.columns()[2].as_int64().iter().collect::<Vec<_>>(),
             vec![Some(100)]
         );
+
+        drop(tx);
+        assert!(s.next().await.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_snapshot_read_error_retries_without_failing_executor() {
+        let (tx, source) = MockSource::channel();
+        let source = source.into_executor(
+            Schema::new(vec![
+                Field::unnamed(DataType::Jsonb),
+                Field::unnamed(DataType::Varchar),
+            ]),
+            vec![0],
+        );
+        let external_table = ExternalStorageTable::new(
+            TableId::new(1234),
+            SchemaTableName {
+                schema_name: "public".to_owned(),
+                table_name: "mock_table".to_owned(),
+            },
+            "mydb".to_owned(),
+            ExternalTableConfig::default(),
+            ExternalCdcTableType::Mock,
+            Schema::new(vec![
+                Field::with_name(DataType::Int64, "id"),
+                Field::with_name(DataType::Float64, "price"),
+            ]),
+            vec![OrderType::ascending()],
+            vec![0],
+        )
+        .with_mock_snapshot_errors(usize::MAX);
+        let executor = CdcBackfillExecutor::new(
+            ActorContext::for_test(0x1a),
+            external_table,
+            source,
+            vec![0, 1],
+            vec![
+                ColumnDesc::named("id", ColumnId::new(1), DataType::Int64),
+                ColumnDesc::named("price", ColumnId::new(2), DataType::Float64),
+            ],
+            None,
+            StreamingMetrics::unused().into(),
+            create_cdc_state_table(MemoryStateStore::new()).await,
+            None,
+            CdcScanOptions {
+                snapshot_barrier_interval: 1,
+                ..Default::default()
+            },
+            BTreeMap::default(),
+        )
+        .execute_inner();
+        pin_mut!(executor);
+
+        tx.send_barrier(Barrier::new_test_barrier(test_epoch(1)));
+        assert!(matches!(
+            executor.next().await.unwrap().unwrap(),
+            Message::Barrier(_)
+        ));
+
+        // The second barrier starts the snapshot. Its permanent reader error must leave the
+        // executor pending rather than escape and trigger recovery.
+        tx.send_barrier(Barrier::new_test_barrier(test_epoch(2)));
+        assert!(matches!(
+            executor.next().await.unwrap().unwrap(),
+            Message::Barrier(_)
+        ));
+        assert!(
+            tokio::time::timeout(Duration::from_millis(20), executor.next())
+                .await
+                .is_err()
+        );
+
+        // Barriers continue to pass while each new snapshot attempt remains retryable.
+        for epoch in [3, 4] {
+            tx.send_barrier(Barrier::new_test_barrier(test_epoch(epoch)));
+            assert!(matches!(
+                executor.next().await.unwrap().unwrap(),
+                Message::Barrier(_)
+            ));
+        }
     }
 
     #[tokio::test]

--- a/src/stream/src/executor/backfill/cdc/cdc_backill_v2.rs
+++ b/src/stream/src/executor/backfill/cdc/cdc_backill_v2.rs
@@ -254,79 +254,90 @@ impl<S: StateStore> ParallelizedCdcBackfillExecutor<S> {
                 None
             };
 
-            // After init the state table and forward the initial barrier to downstream,
-            // we now try to create the table reader with retry.
-            let mut table_reader: Option<ExternalTableReaderImpl> = None;
-            let external_table = self.external_table.clone();
-            let actor_id = self.actor_ctx.id;
-            let fragment_id = self.actor_ctx.fragment_id;
-            let mut future = Box::pin(async move {
-                let backoff = get_infinite_backoff_strategy();
-                tokio_retry::Retry::spawn(backoff, || async {
-                    match external_table.create_table_reader().await {
-                        Ok(reader) => Ok(reader),
-                        Err(e) => {
-                            tracing::warn!(error = %e.as_report(), actor_id = %actor_id, fragment_id = %fragment_id, "failed to create cdc table reader, retrying...");
-                            Err(e)
+            let offset_parse_func = self.external_table.table_type().get_cdc_offset_parser()?;
+
+            // A reader is only needed while at least one assigned snapshot split is unfinished.
+            // Once all splits are complete, the executor only forwards the table-filtered CDC
+            // stream and must not depend on the upstream snapshot table still existing.
+            let upstream_table_reader = if next_split_idx < actor_snapshot_splits.len() {
+                let mut table_reader: Option<ExternalTableReaderImpl> = None;
+                let external_table = self.external_table.clone();
+                let actor_id = self.actor_ctx.id;
+                let fragment_id = self.actor_ctx.fragment_id;
+                let mut future = Box::pin(async move {
+                    let backoff = get_infinite_backoff_strategy();
+                    tokio_retry::Retry::spawn(backoff, || async {
+                        match external_table.create_table_reader().await {
+                            Ok(reader) => Ok(reader),
+                            Err(e) => {
+                                tracing::warn!(error = %e.as_report(), actor_id = %actor_id, fragment_id = %fragment_id, "failed to create cdc table reader, retrying...");
+                                Err(e)
+                            }
                         }
-                    }
-                })
+                    })
                     .instrument(tracing::info_span!("create_cdc_table_reader_with_retry"))
                     .await
                     .expect("Retry create cdc table reader until success.")
-            });
-            loop {
-                if let Some(msg) =
-                    build_reader_and_poll_upstream(&mut upstream, &mut table_reader, &mut future)
-                        .await?
-                {
-                    if let Some(msg) = mapping_message(msg, &self.output_indices) {
-                        match msg {
-                            Message::Barrier(barrier) => {
-                                state_impl.commit_state(barrier.epoch).await?;
-                                if is_reset_barrier(&barrier, self.actor_ctx.id) {
-                                    next_reset_barrier = Some(barrier);
-                                    continue 'with_cdc_table_snapshot_splits;
+                });
+                loop {
+                    if let Some(msg) = build_reader_and_poll_upstream(
+                        &mut upstream,
+                        &mut table_reader,
+                        &mut future,
+                    )
+                    .await?
+                    {
+                        if let Some(msg) = mapping_message(msg, &self.output_indices) {
+                            match msg {
+                                Message::Barrier(barrier) => {
+                                    state_impl.commit_state(barrier.epoch).await?;
+                                    if is_reset_barrier(&barrier, self.actor_ctx.id) {
+                                        next_reset_barrier = Some(barrier);
+                                        continue 'with_cdc_table_snapshot_splits;
+                                    }
+                                    yield Message::Barrier(barrier);
                                 }
-                                yield Message::Barrier(barrier);
-                            }
-                            Message::Chunk(chunk) => {
-                                if chunk.cardinality() == 0 {
-                                    continue;
+                                Message::Chunk(chunk) => {
+                                    if chunk.cardinality() == 0 {
+                                        continue;
+                                    }
+                                    if let Some(filtered_chunk) = filter_stream_chunk(
+                                        chunk,
+                                        &current_actor_bounds,
+                                        snapshot_split_column_index,
+                                    ) && filtered_chunk.cardinality() > 0
+                                    {
+                                        yield Message::Chunk(filtered_chunk);
+                                    }
                                 }
-                                if let Some(filtered_chunk) = filter_stream_chunk(
-                                    chunk,
-                                    &current_actor_bounds,
-                                    snapshot_split_column_index,
-                                ) && filtered_chunk.cardinality() > 0
-                                {
-                                    yield Message::Chunk(filtered_chunk);
+                                Message::Watermark(_) => {
+                                    // Ignore watermark, like the `CdcBackfillExecutor`.
                                 }
-                            }
-                            Message::Watermark(_) => {
-                                // Ignore watermark, like the `CdcBackfillExecutor`.
                             }
                         }
+                    } else {
+                        assert!(table_reader.is_some(), "table reader must be created");
+                        tracing::info!(
+                            %table_id,
+                            upstream_table_name,
+                            "table reader created successfully"
+                        );
+                        break;
                     }
-                } else {
-                    assert!(table_reader.is_some(), "table reader must created");
-                    tracing::info!(
-                        %table_id,
-                        upstream_table_name,
-                        "table reader created successfully"
-                    );
-                    break;
                 }
-            }
-            let upstream_table_reader = UpstreamTableReader::new(
-                self.external_table.clone(),
-                table_reader.expect("table reader must created"),
-            );
-            // let mut upstream = upstream.peekable();
-            let offset_parse_func = upstream_table_reader.reader.get_cdc_offset_parser();
+                Some(UpstreamTableReader::new(
+                    self.external_table.clone(),
+                    table_reader.expect("table reader must be created"),
+                ))
+            } else {
+                None
+            };
 
             // Backfill snapshot splits sequentially.
             for split in actor_snapshot_splits.iter().skip(next_split_idx) {
+                let upstream_table_reader = upstream_table_reader
+                    .as_ref()
+                    .expect("unfinished snapshot split must have a table reader");
                 tracing::info!(
                     %table_id,
                     upstream_table_name,
@@ -567,7 +578,9 @@ impl<S: StateStore> ParallelizedCdcBackfillExecutor<S> {
                 }
             }
 
-            upstream_table_reader.disconnect().await?;
+            if let Some(upstream_table_reader) = upstream_table_reader {
+                upstream_table_reader.disconnect().await?;
+            }
             tracing::info!(
                 %table_id,
                 upstream_table_name,

--- a/src/stream/src/executor/backfill/cdc/cdc_backill_v2.rs
+++ b/src/stream/src/executor/backfill/cdc/cdc_backill_v2.rs
@@ -30,11 +30,10 @@ use risingwave_connector::source::cdc::external::{
 use risingwave_connector::source::{CdcTableSnapshotSplit, CdcTableSnapshotSplitRaw};
 use risingwave_pb::common::ThrottleType;
 use rw_futures_util::pausable;
-use thiserror_ext::AsReport;
-use tracing::Instrument;
 
 use crate::executor::backfill::cdc::cdc_backfill::{
-    build_reader_and_poll_upstream, get_cdc_json_parse_handling_from_properties, transform_upstream,
+    build_reader_and_poll_upstream, create_table_reader_with_retry,
+    get_cdc_json_parse_handling_from_properties, transform_upstream,
 };
 use crate::executor::backfill::cdc::state_v2::ParallelizedCdcBackfillState;
 use crate::executor::backfill::cdc::upstream_table::external::ExternalStorageTable;
@@ -43,7 +42,6 @@ use crate::executor::backfill::cdc::upstream_table::snapshot::{
 };
 use crate::executor::backfill::utils::{get_cdc_chunk_last_offset, mapping_chunk, mapping_message};
 use crate::executor::prelude::*;
-use crate::executor::source::get_infinite_backoff_strategy;
 use crate::task::cdc_progress::CdcProgressReporter;
 pub struct ParallelizedCdcBackfillExecutor<S: StateStore> {
     actor_ctx: ActorContextRef,
@@ -264,21 +262,11 @@ impl<S: StateStore> ParallelizedCdcBackfillExecutor<S> {
                 let external_table = self.external_table.clone();
                 let actor_id = self.actor_ctx.id;
                 let fragment_id = self.actor_ctx.fragment_id;
-                let mut future = Box::pin(async move {
-                    let backoff = get_infinite_backoff_strategy();
-                    tokio_retry::Retry::spawn(backoff, || async {
-                        match external_table.create_table_reader().await {
-                            Ok(reader) => Ok(reader),
-                            Err(e) => {
-                                tracing::warn!(error = %e.as_report(), actor_id = %actor_id, fragment_id = %fragment_id, "failed to create cdc table reader, retrying...");
-                                Err(e)
-                            }
-                        }
-                    })
-                    .instrument(tracing::info_span!("create_cdc_table_reader_with_retry"))
-                    .await
-                    .expect("Retry create cdc table reader until success.")
-                });
+                let mut future = Box::pin(create_table_reader_with_retry(
+                    external_table,
+                    actor_id,
+                    fragment_id,
+                ));
                 loop {
                     if let Some(msg) = build_reader_and_poll_upstream(
                         &mut upstream,

--- a/src/stream/src/executor/backfill/cdc/upstream_table/external.rs
+++ b/src/stream/src/executor/backfill/cdc/upstream_table/external.rs
@@ -47,6 +47,9 @@ pub struct ExternalStorageTable {
     /// Indices of primary key.
     /// Note that the index is based on the all columns of the table.
     pk_indices: Vec<usize>,
+
+    #[cfg(test)]
+    mock_snapshot_errors: Option<usize>,
 }
 
 impl ExternalStorageTable {
@@ -74,6 +77,8 @@ impl ExternalStorageTable {
             schema,
             pk_order_types,
             pk_indices,
+            #[cfg(test)]
+            mock_snapshot_errors: None,
         }
     }
 
@@ -89,7 +94,14 @@ impl ExternalStorageTable {
             schema: Schema::empty().to_owned(),
             pk_order_types: vec![],
             pk_indices: vec![],
+            mock_snapshot_errors: None,
         }
+    }
+
+    #[cfg(test)]
+    pub fn with_mock_snapshot_errors(mut self, snapshot_errors: usize) -> Self {
+        self.mock_snapshot_errors = Some(snapshot_errors);
+        self
     }
 
     pub fn table_id(&self) -> TableId {
@@ -116,6 +128,13 @@ impl ExternalStorageTable {
     }
 
     pub async fn create_table_reader(&self) -> ConnectorResult<ExternalTableReaderImpl> {
+        #[cfg(test)]
+        if let Some(snapshot_errors) = self.mock_snapshot_errors {
+            return Ok(ExternalTableReaderImpl::Mock(
+                risingwave_connector::source::cdc::external::mock_external_table::MockExternalTableReader::new_with_snapshot_errors(snapshot_errors),
+            ));
+        }
+
         self.table_type
             .create_table_reader(
                 self.config.clone(),

--- a/src/stream/src/executor/backfill/cdc/upstream_table/external.rs
+++ b/src/stream/src/executor/backfill/cdc/upstream_table/external.rs
@@ -12,6 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#[cfg(test)]
+use std::collections::VecDeque;
+#[cfg(test)]
+use std::sync::atomic::{AtomicUsize, Ordering};
+#[cfg(test)]
+use std::sync::{Arc, Mutex};
+
 use risingwave_common::catalog::{Schema, TableId};
 use risingwave_common::util::sort_util::OrderType;
 use risingwave_connector::error::ConnectorResult;
@@ -49,7 +56,10 @@ pub struct ExternalStorageTable {
     pk_indices: Vec<usize>,
 
     #[cfg(test)]
-    mock_snapshot_errors: Option<usize>,
+    mock_snapshot_errors: Option<Arc<Mutex<VecDeque<usize>>>>,
+
+    #[cfg(test)]
+    mock_reader_create_count: Arc<AtomicUsize>,
 }
 
 impl ExternalStorageTable {
@@ -79,6 +89,8 @@ impl ExternalStorageTable {
             pk_indices,
             #[cfg(test)]
             mock_snapshot_errors: None,
+            #[cfg(test)]
+            mock_reader_create_count: Arc::new(AtomicUsize::new(0)),
         }
     }
 
@@ -95,13 +107,23 @@ impl ExternalStorageTable {
             pk_order_types: vec![],
             pk_indices: vec![],
             mock_snapshot_errors: None,
+            mock_reader_create_count: Arc::new(AtomicUsize::new(0)),
         }
     }
 
     #[cfg(test)]
-    pub fn with_mock_snapshot_errors(mut self, snapshot_errors: usize) -> Self {
-        self.mock_snapshot_errors = Some(snapshot_errors);
+    pub fn with_mock_snapshot_errors(
+        mut self,
+        snapshot_errors: impl IntoIterator<Item = usize>,
+    ) -> Self {
+        self.mock_snapshot_errors =
+            Some(Arc::new(Mutex::new(snapshot_errors.into_iter().collect())));
         self
+    }
+
+    #[cfg(test)]
+    pub fn mock_reader_create_count(&self) -> usize {
+        self.mock_reader_create_count.load(Ordering::Relaxed)
     }
 
     pub fn table_id(&self) -> TableId {
@@ -129,7 +151,14 @@ impl ExternalStorageTable {
 
     pub async fn create_table_reader(&self) -> ConnectorResult<ExternalTableReaderImpl> {
         #[cfg(test)]
-        if let Some(snapshot_errors) = self.mock_snapshot_errors {
+        if let Some(snapshot_errors) = &self.mock_snapshot_errors {
+            self.mock_reader_create_count
+                .fetch_add(1, Ordering::Relaxed);
+            let snapshot_errors = snapshot_errors
+                .lock()
+                .expect("mock snapshot error queue must not be poisoned")
+                .pop_front()
+                .unwrap_or_default();
             return Ok(ExternalTableReaderImpl::Mock(
                 risingwave_connector::source::cdc::external::mock_external_table::MockExternalTableReader::new_with_snapshot_errors(snapshot_errors),
             ));

--- a/src/stream/src/executor/backfill/cdc/upstream_table/snapshot.rs
+++ b/src/stream/src/executor/backfill/cdc/upstream_table/snapshot.rs
@@ -27,12 +27,10 @@ use risingwave_connector::source::cdc::external::{
     CdcOffset, ExternalTableReader, ExternalTableReaderImpl, SchemaTableName,
 };
 use risingwave_pb::plan_common::additional_column::ColumnType;
-use thiserror_ext::AsReport;
 
 use super::external::ExternalStorageTable;
 use crate::common::rate_limit::limited_chunk_size;
 use crate::executor::backfill::utils::{get_new_pos, iter_chunks};
-use crate::executor::source::get_infinite_backoff_strategy;
 use crate::executor::{StreamExecutorError, StreamExecutorResult};
 
 pub trait UpstreamTableRead {
@@ -302,79 +300,53 @@ impl UpstreamTableRead for UpstreamTableReader<ExternalStorageTable> {
         let database_name = read_args.database_name.clone();
         // tracing::debug!(?args, "snapshot_read",);
 
-        let mut backoff = get_infinite_backoff_strategy();
-        let mut emitted_rows = false;
-        'retry: loop {
-            let row_stream = self.reader.split_snapshot_read(
-                self.table.schema_table_name(),
-                read_args.left_bound_inclusive.clone(),
-                read_args.right_bound_exclusive.clone(),
-                read_args.split_columns.clone(),
-            );
+        let row_stream = self.reader.split_snapshot_read(
+            self.table.schema_table_name(),
+            read_args.left_bound_inclusive.clone(),
+            read_args.right_bound_exclusive.clone(),
+            read_args.split_columns.clone(),
+        );
 
-            pin_mut!(row_stream);
-            let mut builder = DataChunkBuilder::new(
-                self.table.schema().data_types(),
-                limited_chunk_size(read_args.rate_limit_rps),
-            );
-            let chunk_stream = iter_chunks(row_stream, &mut builder);
+        pin_mut!(row_stream);
+        let mut builder = DataChunkBuilder::new(
+            self.table.schema().data_types(),
+            limited_chunk_size(read_args.rate_limit_rps),
+        );
+        let chunk_stream = iter_chunks(row_stream, &mut builder);
 
-            #[for_await]
-            for chunk in chunk_stream {
-                let chunk = match chunk {
-                    Ok(chunk) => chunk,
-                    Err(error) => {
-                        tracing::warn!(
-                            error = %error.as_report(),
-                            table = %self.table.qualified_table_name(),
-                            "failed to read CDC snapshot split"
-                        );
-                        if emitted_rows {
-                            // Restarting a partially emitted split can duplicate rows. Leave it
-                            // unfinished until a split reset or actor reschedule rebuilds it.
-                            let () = futures::future::pending().await;
-                            unreachable!();
-                        }
-                        tokio::time::sleep(
-                            backoff.next().expect("CDC snapshot retry must be infinite"),
-                        )
-                        .await;
-                        continue 'retry;
-                    }
-                };
-                let chunk_size = chunk.capacity();
-                emitted_rows |= chunk.cardinality() > 0;
+        #[for_await]
+        for chunk in chunk_stream {
+            let chunk = chunk?;
+            let chunk_size = chunk.capacity();
 
-                if let Some(rate_limit_rps) = read_args.rate_limit_rps
-                    && chunk_size != 0
-                {
-                    // Apply rate limit, see `risingwave_stream::executor::source::apply_rate_limit` for more.
-                    // May be should be refactored to a common function later.
-                    let limit = rate_limit_rps as usize;
+            if let Some(rate_limit_rps) = read_args.rate_limit_rps
+                && chunk_size != 0
+            {
+                // Apply rate limit, see `risingwave_stream::executor::source::apply_rate_limit` for more.
+                // May be should be refactored to a common function later.
+                let limit = rate_limit_rps as usize;
 
-                    // Because we produce chunks with limited-sized data chunk builder and all rows
-                    // are `Insert`s, the chunk size should never exceed the limit.
-                    assert!(chunk_size <= limit);
+                // Because we produce chunks with limited-sized data chunk builder and all rows
+                // are `Insert`s, the chunk size should never exceed the limit.
+                assert!(chunk_size <= limit);
 
-                    // `InsufficientCapacity` should never happen because we have check the cardinality
-                    rate_limiter.wait(chunk_size as _).await;
-                    yield Some(with_additional_columns(
-                        chunk,
-                        &read_args.additional_columns,
-                        schema_table_name.clone(),
-                        database_name.clone(),
-                    ));
-                } else {
-                    // no limit, or empty chunk
-                    yield Some(with_additional_columns(
-                        chunk,
-                        &read_args.additional_columns,
-                        schema_table_name.clone(),
-                        database_name.clone(),
-                    ));
-                }
+                // `InsufficientCapacity` should never happen because we have check the cardinality
+                rate_limiter.wait(chunk_size as _).await;
+                yield Some(with_additional_columns(
+                    chunk,
+                    &read_args.additional_columns,
+                    schema_table_name.clone(),
+                    database_name.clone(),
+                ));
+            } else {
+                // no limit, or empty chunk
+                yield Some(with_additional_columns(
+                    chunk,
+                    &read_args.additional_columns,
+                    schema_table_name.clone(),
+                    database_name.clone(),
+                ));
             }
-            break;
         }
         yield None;
     }
@@ -398,67 +370,16 @@ mod tests {
     use futures::pin_mut;
     use futures_async_stream::for_await;
     use maplit::{convert_args, hashmap};
-    use risingwave_common::catalog::{ColumnDesc, ColumnId, Field, Schema, TableId};
+    use risingwave_common::catalog::{ColumnDesc, ColumnId, Field, Schema};
     use risingwave_common::row::OwnedRow;
     use risingwave_common::types::{DataType, ScalarImpl};
     use risingwave_common::util::chunk_coalesce::DataChunkBuilder;
-    use risingwave_common::util::sort_util::OrderType;
     use risingwave_connector::source::cdc::external::mysql::MySqlExternalTableReader;
     use risingwave_connector::source::cdc::external::{
-        ExternalCdcTableType, ExternalTableConfig, ExternalTableReader, SchemaTableName,
+        ExternalTableConfig, ExternalTableReader, SchemaTableName,
     };
 
-    use super::{SplitSnapshotReadArgs, UpstreamTableRead, UpstreamTableReader};
-    use crate::executor::backfill::cdc::upstream_table::external::ExternalStorageTable;
     use crate::executor::backfill::utils::{get_new_pos, iter_chunks};
-
-    #[tokio::test]
-    async fn test_split_snapshot_retries_before_emitting_rows() {
-        let external_table = ExternalStorageTable::new(
-            TableId::new(1),
-            SchemaTableName {
-                schema_name: "public".to_owned(),
-                table_name: "mock_table".to_owned(),
-            },
-            "mock_database".to_owned(),
-            ExternalTableConfig::default(),
-            ExternalCdcTableType::Mock,
-            Schema::new(vec![
-                Field::with_name(DataType::Int64, "id"),
-                Field::with_name(DataType::Float64, "price"),
-            ]),
-            vec![OrderType::ascending()],
-            vec![0],
-        )
-        .with_mock_snapshot_errors(1);
-        let reader = external_table.create_table_reader().await.unwrap();
-        let upstream_table_reader = UpstreamTableReader::new(external_table, reader);
-        let stream = upstream_table_reader.snapshot_read_table_split(SplitSnapshotReadArgs::new(
-            OwnedRow::new(vec![None]),
-            OwnedRow::new(vec![None]),
-            vec![Field::with_name(DataType::Int64, "id")],
-            None,
-            vec![],
-            SchemaTableName {
-                schema_name: "public".to_owned(),
-                table_name: "mock_table".to_owned(),
-            },
-            "mock_database".to_owned(),
-        ));
-        pin_mut!(stream);
-
-        let mut row_count = 0;
-        let mut finished = false;
-        #[for_await]
-        for result in stream {
-            match result.unwrap() {
-                Some(chunk) => row_count += chunk.cardinality(),
-                None => finished = true,
-            }
-        }
-        assert!(finished);
-        assert_eq!(row_count, 8);
-    }
 
     #[ignore]
     #[tokio::test]

--- a/src/stream/src/executor/backfill/cdc/upstream_table/snapshot.rs
+++ b/src/stream/src/executor/backfill/cdc/upstream_table/snapshot.rs
@@ -27,10 +27,12 @@ use risingwave_connector::source::cdc::external::{
     CdcOffset, ExternalTableReader, ExternalTableReaderImpl, SchemaTableName,
 };
 use risingwave_pb::plan_common::additional_column::ColumnType;
+use thiserror_ext::AsReport;
 
 use super::external::ExternalStorageTable;
 use crate::common::rate_limit::limited_chunk_size;
 use crate::executor::backfill::utils::{get_new_pos, iter_chunks};
+use crate::executor::source::get_infinite_backoff_strategy;
 use crate::executor::{StreamExecutorError, StreamExecutorResult};
 
 pub trait UpstreamTableRead {
@@ -300,53 +302,79 @@ impl UpstreamTableRead for UpstreamTableReader<ExternalStorageTable> {
         let database_name = read_args.database_name.clone();
         // tracing::debug!(?args, "snapshot_read",);
 
-        let row_stream = self.reader.split_snapshot_read(
-            self.table.schema_table_name(),
-            read_args.left_bound_inclusive.clone(),
-            read_args.right_bound_exclusive.clone(),
-            read_args.split_columns.clone(),
-        );
+        let mut backoff = get_infinite_backoff_strategy();
+        let mut emitted_rows = false;
+        'retry: loop {
+            let row_stream = self.reader.split_snapshot_read(
+                self.table.schema_table_name(),
+                read_args.left_bound_inclusive.clone(),
+                read_args.right_bound_exclusive.clone(),
+                read_args.split_columns.clone(),
+            );
 
-        pin_mut!(row_stream);
-        let mut builder = DataChunkBuilder::new(
-            self.table.schema().data_types(),
-            limited_chunk_size(read_args.rate_limit_rps),
-        );
-        let chunk_stream = iter_chunks(row_stream, &mut builder);
+            pin_mut!(row_stream);
+            let mut builder = DataChunkBuilder::new(
+                self.table.schema().data_types(),
+                limited_chunk_size(read_args.rate_limit_rps),
+            );
+            let chunk_stream = iter_chunks(row_stream, &mut builder);
 
-        #[for_await]
-        for chunk in chunk_stream {
-            let chunk = chunk?;
-            let chunk_size = chunk.capacity();
+            #[for_await]
+            for chunk in chunk_stream {
+                let chunk = match chunk {
+                    Ok(chunk) => chunk,
+                    Err(error) => {
+                        tracing::warn!(
+                            error = %error.as_report(),
+                            table = %self.table.qualified_table_name(),
+                            "failed to read CDC snapshot split"
+                        );
+                        if emitted_rows {
+                            // Restarting a partially emitted split can duplicate rows. Leave it
+                            // unfinished until a split reset or actor reschedule rebuilds it.
+                            let () = futures::future::pending().await;
+                            unreachable!();
+                        }
+                        tokio::time::sleep(
+                            backoff.next().expect("CDC snapshot retry must be infinite"),
+                        )
+                        .await;
+                        continue 'retry;
+                    }
+                };
+                let chunk_size = chunk.capacity();
+                emitted_rows |= chunk.cardinality() > 0;
 
-            if let Some(rate_limit_rps) = read_args.rate_limit_rps
-                && chunk_size != 0
-            {
-                // Apply rate limit, see `risingwave_stream::executor::source::apply_rate_limit` for more.
-                // May be should be refactored to a common function later.
-                let limit = rate_limit_rps as usize;
+                if let Some(rate_limit_rps) = read_args.rate_limit_rps
+                    && chunk_size != 0
+                {
+                    // Apply rate limit, see `risingwave_stream::executor::source::apply_rate_limit` for more.
+                    // May be should be refactored to a common function later.
+                    let limit = rate_limit_rps as usize;
 
-                // Because we produce chunks with limited-sized data chunk builder and all rows
-                // are `Insert`s, the chunk size should never exceed the limit.
-                assert!(chunk_size <= limit);
+                    // Because we produce chunks with limited-sized data chunk builder and all rows
+                    // are `Insert`s, the chunk size should never exceed the limit.
+                    assert!(chunk_size <= limit);
 
-                // `InsufficientCapacity` should never happen because we have check the cardinality
-                rate_limiter.wait(chunk_size as _).await;
-                yield Some(with_additional_columns(
-                    chunk,
-                    &read_args.additional_columns,
-                    schema_table_name.clone(),
-                    database_name.clone(),
-                ));
-            } else {
-                // no limit, or empty chunk
-                yield Some(with_additional_columns(
-                    chunk,
-                    &read_args.additional_columns,
-                    schema_table_name.clone(),
-                    database_name.clone(),
-                ));
+                    // `InsufficientCapacity` should never happen because we have check the cardinality
+                    rate_limiter.wait(chunk_size as _).await;
+                    yield Some(with_additional_columns(
+                        chunk,
+                        &read_args.additional_columns,
+                        schema_table_name.clone(),
+                        database_name.clone(),
+                    ));
+                } else {
+                    // no limit, or empty chunk
+                    yield Some(with_additional_columns(
+                        chunk,
+                        &read_args.additional_columns,
+                        schema_table_name.clone(),
+                        database_name.clone(),
+                    ));
+                }
             }
+            break;
         }
         yield None;
     }
@@ -370,16 +398,67 @@ mod tests {
     use futures::pin_mut;
     use futures_async_stream::for_await;
     use maplit::{convert_args, hashmap};
-    use risingwave_common::catalog::{ColumnDesc, ColumnId, Field, Schema};
+    use risingwave_common::catalog::{ColumnDesc, ColumnId, Field, Schema, TableId};
     use risingwave_common::row::OwnedRow;
     use risingwave_common::types::{DataType, ScalarImpl};
     use risingwave_common::util::chunk_coalesce::DataChunkBuilder;
+    use risingwave_common::util::sort_util::OrderType;
     use risingwave_connector::source::cdc::external::mysql::MySqlExternalTableReader;
     use risingwave_connector::source::cdc::external::{
-        ExternalTableConfig, ExternalTableReader, SchemaTableName,
+        ExternalCdcTableType, ExternalTableConfig, ExternalTableReader, SchemaTableName,
     };
 
+    use super::{SplitSnapshotReadArgs, UpstreamTableRead, UpstreamTableReader};
+    use crate::executor::backfill::cdc::upstream_table::external::ExternalStorageTable;
     use crate::executor::backfill::utils::{get_new_pos, iter_chunks};
+
+    #[tokio::test]
+    async fn test_split_snapshot_retries_before_emitting_rows() {
+        let external_table = ExternalStorageTable::new(
+            TableId::new(1),
+            SchemaTableName {
+                schema_name: "public".to_owned(),
+                table_name: "mock_table".to_owned(),
+            },
+            "mock_database".to_owned(),
+            ExternalTableConfig::default(),
+            ExternalCdcTableType::Mock,
+            Schema::new(vec![
+                Field::with_name(DataType::Int64, "id"),
+                Field::with_name(DataType::Float64, "price"),
+            ]),
+            vec![OrderType::ascending()],
+            vec![0],
+        )
+        .with_mock_snapshot_errors(1);
+        let reader = external_table.create_table_reader().await.unwrap();
+        let upstream_table_reader = UpstreamTableReader::new(external_table, reader);
+        let stream = upstream_table_reader.snapshot_read_table_split(SplitSnapshotReadArgs::new(
+            OwnedRow::new(vec![None]),
+            OwnedRow::new(vec![None]),
+            vec![Field::with_name(DataType::Int64, "id")],
+            None,
+            vec![],
+            SchemaTableName {
+                schema_name: "public".to_owned(),
+                table_name: "mock_table".to_owned(),
+            },
+            "mock_database".to_owned(),
+        ));
+        pin_mut!(stream);
+
+        let mut row_count = 0;
+        let mut finished = false;
+        #[for_await]
+        for result in stream {
+            match result.unwrap() {
+                Some(chunk) => row_count += chunk.cardinality(),
+                None => finished = true,
+            }
+        }
+        assert!(finished);
+        assert_eq!(row_count, 8);
+    }
 
     #[ignore]
     #[tokio::test]


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

An upstream table can disappear after a RisingWave CDC table has been created, for example because it was renamed. CDC routing already continues to filter changelog events by the stored upstream table name, so events under the new name do not belong to the old CDC table. The recovery path must therefore keep barriers flowing instead of turning snapshot-reader failures into actor failures and cluster recovery loops.

This PR is stacked on #26650, which makes the legacy executor construct an external snapshot reader only when snapshot backfill is actually needed. On top of that lifecycle split, this PR:

- validates MySQL upstream primary-key metadata while constructing the reader, so a missing table or incompatible primary key stays in the existing barrier-aware reader preparation retry;
- keeps legacy snapshot read failures inside the unfinished backfill lifecycle, checkpoints progress at the next barrier, and creates a fresh external reader before resuming;
- keeps barriers flowing and preserves buffered CDC events while reader construction retries, so a missing table or broken connection does not force actor recovery;
- leaves parallel split read failures on the existing actor-recovery path instead of swallowing them: the current split state has no checkpointed in-split cursor, so replaying or indefinitely parking a partially emitted split would be unsafe;
- skips external reader construction in the parallel executor after all assigned splits are complete and obtains the CDC offset parser from the connector type instead;
- adds regression coverage for completed backfill without a reader, failure followed by successful reader reconstruction, and MySQL primary-key metadata validation.

There is no rename-specific error matching, empty-snapshot fallback, forced completion, or automatic rebinding to the new upstream table name. For completed backfills and the resumable legacy backfill executor, the old CDC table keeps its existing rows and receives no new matching events after a rename, while checkpoints for the rest of the database continue. An unfinished parallel split retains its existing actor-recovery behavior until checkpointed in-split resume progress is implemented separately.

### Dependency

- Base: #26650 (`tbilisi`). It is approved and its Buildkite checks have passed.
- After #26650 merges, this PR should be retargeted to `main`.

### Verification

- `cargo test -p risingwave_connector source::cdc::external --lib` — 12 passed, 4 ignored
- `cargo test -p risingwave_stream executor::backfill::cdc --lib` — 13 passed, 1 ignored
- `cargo clippy -p risingwave_connector --lib -- -D warnings`
- `cargo clippy -p risingwave_stream --lib --tests -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`

## Checklist

- [ ] I have written necessary rustdoc comments.
- [x] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [x] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/dev/src/ci.md#ci-labels-guide -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->

## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

No SQL, connector-option, or user workflow changes.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * CDC backfills now recover from temporary snapshot-read failures and resume processing after rebuilding the required readers.
  * Completed backfill tasks can continue forwarding CDC changes without requiring an active snapshot table.
  * MySQL CDC connections now detect mismatches between upstream and configured primary-key columns earlier, improving setup reliability.
* **Tests**
  * Added coverage for snapshot-read recovery, reader recreation, and primary-key validation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->