### PR TITLE
fix(stream): keep sink into table upsert semantics with preserve_row_level_changes

### DIFF
--- a/e2e_test/sink/sink_into_table/stream_key_mismatch_partial_update.slt
+++ b/e2e_test/sink/sink_into_table/stream_key_mismatch_partial_update.slt
@@ -1,0 +1,58 @@
+statement ok
+SET RW_IMPLICIT_FLUSH TO true;
+
+statement ok
+create table wide_t (id int primary key, col_a int, col_b int) on conflict do update if not null;
+
+statement ok
+create table l (id int primary key, col_a int);
+
+statement ok
+create table r (rid int primary key, id int);
+
+statement ok
+create sink sink_a into wide_t (id, col_a) as
+select l.id, l.col_a from l join r on l.id = r.id;
+
+statement ok
+insert into l values (1, 10);
+
+statement ok
+insert into r values (1, 1), (2, 99);
+
+statement ok
+insert into wide_t (id, col_b) values (1, 100);
+
+query III
+select id, col_a, col_b from wide_t order by id;
+----
+1 10 100
+
+# The join row of `id = 1` moves to another stream key within one barrier. It must be applied
+# as an update to `wide_t`, keeping `col_b`.
+statement ok
+update r set id = case rid when 1 then 99 else 1 end;
+
+query III
+select id, col_a, col_b from wide_t order by id;
+----
+1 10 100
+
+statement ok
+delete from l where id = 1;
+
+query III
+select id, col_a, col_b from wide_t order by id;
+----
+
+statement ok
+drop sink sink_a;
+
+statement ok
+drop table wide_t;
+
+statement ok
+drop table l;
+
+statement ok
+drop table r;

--- a/src/stream/src/executor/sink.rs
+++ b/src/stream/src/executor/sink.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::collections::{BTreeMap, HashMap};
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::time::{Duration, Instant};
 use std::{assert_matches, mem};
 
@@ -25,6 +25,7 @@ use risingwave_common::array::stream_chunk::StreamChunkMut;
 use risingwave_common::bitmap::Bitmap;
 use risingwave_common::catalog::{ColumnCatalog, Field};
 use risingwave_common::metrics::{GLOBAL_ERROR_METRICS, LabelGuardedIntGauge};
+use risingwave_common::row::RowExt;
 use risingwave_common_estimate_size::EstimateSize;
 use risingwave_common_estimate_size::collections::EstimatedVec;
 use risingwave_common_rate_limit::RateLimit;
@@ -100,6 +101,32 @@ fn force_delete_only(c: StreamChunk) -> StreamChunk {
         }
     }
     c.into()
+}
+
+// Drop the DELETE messages whose downstream key is inserted again in the same barrier, since such
+// a key is updated rather than deleted from the downstream's perspective.
+fn drop_deletes_of_reinserted_keys(
+    delete_chunks: Vec<StreamChunk>,
+    insert_chunks: &[StreamChunk],
+    downstream_pk: &[usize],
+) -> Vec<StreamChunk> {
+    let inserted_keys: HashSet<_> = insert_chunks
+        .iter()
+        .flat_map(|c| c.rows())
+        .map(|(_, row)| row.project(downstream_pk))
+        .collect();
+    delete_chunks
+        .into_iter()
+        .map(|c| {
+            let mut c: StreamChunkMut = c.into();
+            for (row, mut r) in c.to_rows_mut() {
+                if inserted_keys.contains(&row.project(downstream_pk)) {
+                    r.set_vis(false);
+                }
+            }
+            c.into()
+        })
+        .collect()
 }
 
 /// When the sink is non-append-only, i.e. upsert or retract, we need to do some extra work for
@@ -610,11 +637,6 @@ impl<F: LogStoreFactory> SinkExecutor<F> {
                                 insert_chunks.push(chunk);
                             }
                         }
-                        let chunks = delete_chunks
-                            .into_iter()
-                            .chain(insert_chunks.into_iter())
-                            .collect();
-
                         // 2. If user specifies a primary key, compact the chunk based on the **downstream pk**
                         //    to eliminate any unnecessary updates to external systems. This also rewrites the
                         //    `DELETE` and `INSERT` operations on the same key into `UPDATE` operations, which
@@ -624,6 +646,10 @@ impl<F: LogStoreFactory> SinkExecutor<F> {
                         if let Some(downstream_pk) = &downstream_pk
                             && !preserve_row_level_changes
                         {
+                            let chunks = delete_chunks
+                                .into_iter()
+                                .chain(insert_chunks.into_iter())
+                                .collect();
                             let chunks = dispatch_output_kind!(sink_type, KIND, {
                                 StreamChunkCompactor::new(downstream_pk.clone(), chunks)
                                     .into_compacted_chunks_reconstructed::<KIND>(
@@ -638,9 +664,18 @@ impl<F: LogStoreFactory> SinkExecutor<F> {
                                 yield Message::Chunk(c);
                             }
                         } else {
+                            if let Some(downstream_pk) = &downstream_pk
+                                && compact_output_kind(sink_type) == output_kind::UPSERT
+                            {
+                                delete_chunks = drop_deletes_of_reinserted_keys(
+                                    delete_chunks,
+                                    &insert_chunks,
+                                    downstream_pk,
+                                );
+                            }
                             let mut chunk_builder =
                                 StreamChunkBuilder::new(chunk_size, input_data_types.clone());
-                            for chunk in chunks {
+                            for chunk in delete_chunks.into_iter().chain(insert_chunks) {
                                 for (op, row) in chunk.rows() {
                                     if let Some(c) = chunk_builder.append_row(op, row) {
                                         yield Message::Chunk(c);
@@ -1544,6 +1579,15 @@ mod test {
                   + 1 20  2",
             )),
             Message::Barrier(Barrier::new_test_barrier(test_epoch(2))),
+            // Downstream key 1 moves to a new stream key, while downstream key 2 is really deleted.
+            Message::Chunk(StreamChunk::from_pretty(
+                " I  I  I
+                  - 1 10  1
+                  - 1 20  2
+                  + 1 30  3
+                  - 2 50  5",
+            )),
+            Message::Barrier(Barrier::new_test_barrier(test_epoch(3))),
         ])
         .into_executor(schema.clone(), vec![0, 2]);
 
@@ -1589,6 +1633,18 @@ mod test {
                 " I  I  I
                   + 1 10  1
                   + 1 20  2",
+            )
+        );
+
+        executor.next().await.unwrap().unwrap();
+
+        let chunk_msg = executor.next().await.unwrap().unwrap();
+        assert_eq!(
+            chunk_msg.into_chunk().unwrap().compact_vis(),
+            StreamChunk::from_pretty(
+                " I  I  I
+                  - 2 50  5
+                  + 1 30  3",
             )
         );
 


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

Regression of #26015 (in v2.8.5 via #26042) for sink-into-table when the input stream key differs from the target table pk.

- In that case the sink executor buffers a barrier, compacts by stream key and emits all deletes before all inserts. The downstream-pk compaction that followed used to turn a same-key `Delete + Insert` back into an upsert.
- `preserve_row_level_changes` (auto-enabled for `DO UPDATE IF NOT NULL` / `IGNORE CONFLICT` / version-column targets) skips that compaction, so a row moving between stream keys (e.g. a join whose key column changes) now reaches the target as a raw `Delete` followed by an `Insert`. Under `DO UPDATE IF NOT NULL` the `Delete` wipes the whole row, and the `Insert` no longer merges, nulling out the columns written by other sinks (customer report CF-2771).
- Fix: in the preserve path, drop the deletes whose downstream key is inserted again in the same barrier (upsert output only). The target still observes every insert, so the row-level semantics #26015 wanted are kept.

Note: for `IGNORE CONFLICT` targets, an update from a pk-mismatched sink still arrives as `Insert` (ignored, same as before #26015), while the pk-matched path applies it since #26015. Not changed here.

Needs cherry-pick to release-2.8.

## Checklist

- [x] I have written necessary rustdoc comments.
- [x] I have added necessary unit tests and integration tests.
- [ ] I have added test labels as necessary.
- [ ] I have added fuzzing tests or opened an issue to track them.
- [ ] My PR contains breaking changes.
- [ ] My PR changes performance-critical code, so I will run (micro) benchmarks and present the results.
- [x] I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into.

## Documentation

- [ ] My PR needs documentation updates.

<details>
<summary><b>Release note</b></summary>

Fix a regression in v2.8.5 where a non-append-only sink into a table with `ON CONFLICT DO UPDATE IF NOT NULL` could null out columns written by other sinks when the sink's stream key differs from the table's primary key.

</details>
