### PR TITLE
ci: fix community PR labeling workflow

### DIFF
--- a/.github/workflows/label-community-contributor.yml
+++ b/.github/workflows/label-community-contributor.yml
@@ -10,11 +10,13 @@ permissions:
 
 jobs:
   label-community-contributor:
-    # External collaborators are included; only organization members and owners are excluded.
+    # Only label unaffiliated users and contributors, not owners, members, or collaborators.
     if: >-
       github.event.pull_request.user.type == 'User' &&
-      github.event.pull_request.author_association != 'MEMBER' &&
-      github.event.pull_request.author_association != 'OWNER'
+      contains(
+        fromJSON('["NONE", "CONTRIBUTOR", "FIRST_TIMER", "FIRST_TIME_CONTRIBUTOR"]'),
+        github.event.pull_request.author_association
+      )
     runs-on: ubuntu-latest
     steps:
       - name: Add community label

--- a/.github/workflows/label-community-contributor.yml
+++ b/.github/workflows/label-community-contributor.yml
@@ -6,6 +6,7 @@ on:
 
 permissions:
   issues: write
+  pull-requests: write
 
 jobs:
   label-community-contributor:


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

Fix two issues in the community-label workflow:

- grant `pull-requests: write` in addition to the existing `issues: write` permission
- use an explicit allowlist of external contributor associations instead of treating every non-owner/non-member association as eligible

The permission issue caused the workflow to fail when adding `community` to a pull request:

```
POST /repos/risingwavelabs/risingwave/issues/<pr>/labels
403 Resource not accessible by integration
```

The association issue allowed `COLLABORATOR` pull requests to run the workflow. The workflow now labels only `NONE`, `CONTRIBUTOR`, `FIRST_TIMER`, and `FIRST_TIME_CONTRIBUTOR`. It skips `OWNER`, `MEMBER`, `COLLABORATOR`, bots, and unknown association values.

The existing `issues: write` permission remains necessary for creating the label when it does not exist. The new `pull-requests: write` permission allows the workflow token to apply the label to pull requests.

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] I have added necessary unit tests and integration tests.
- [ ] I have added test labels as necessary.
- [ ] I have added fuzzing tests or opened an issue to track them.
- [ ] My PR contains breaking changes.
- [ ] My PR changes performance-critical code, so I will run (micro) benchmarks and present the results.
- [ ] I have checked the release timeline and supported versions for cherry-pick needs.

## Validation

- `actionlint .github/workflows/label-community-contributor.yml`
- Checked the association matrix: `OWNER`, `MEMBER`, and `COLLABORATOR` skip; external contributor associations label.
- Confirmed the failed run requested only `Issues: write` and received HTTP 403 while adding the label.
- This PR's own `pull_request_target` run is expected to fail because it loaded the old workflow from the default branch when the PR was opened.
- Runtime verification requires the next eligible external pull request `opened` event after this change is merged.

## Documentation

- [ ] My PR needs documentation updates.
