### PR TITLE
cherry-pick: ci: fix community PR labeling workflow (#26717)

### DIFF
--- a/.github/workflows/label-community-contributor.yml
+++ b/.github/workflows/label-community-contributor.yml
@@ -6,14 +6,17 @@ on:
 
 permissions:
   issues: write
+  pull-requests: write
 
 jobs:
   label-community-contributor:
-    # External collaborators are included; only organization members and owners are excluded.
+    # Only label unaffiliated users and contributors, not owners, members, or collaborators.
     if: >-
       github.event.pull_request.user.type == 'User' &&
-      github.event.pull_request.author_association != 'MEMBER' &&
-      github.event.pull_request.author_association != 'OWNER'
+      contains(
+        fromJSON('["NONE", "CONTRIBUTOR", "FIRST_TIMER", "FIRST_TIME_CONTRIBUTOR"]'),
+        github.event.pull_request.author_association
+      )
     runs-on: ubuntu-latest
     steps:
       - name: Add community label


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

Cherry-pick #26717 to `release-3.1`.

This keeps the community-label workflow on the release branch aligned with `main`:

- grant `pull-requests: write` in addition to `issues: write`
- label only explicit external contributor associations
- skip owners, organization members, repository collaborators, bots, and unknown associations

This prevents automated and member-authored cherry-pick PRs targeting `release-3.1` from being labeled `community`.

Cherry-picked commit: `3dd27beb37f991bd068fbcdf0666a776376cb2f9`.

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] I have added necessary unit tests and integration tests.
- [ ] I have added test labels as necessary.
- [ ] I have added fuzzing tests or opened an issue to track them.
- [ ] My PR contains breaking changes.
- [ ] My PR changes performance-critical code, so I will run (micro) benchmarks and present the results.
- [x] I have checked the release timeline and supported versions for cherry-pick needs.

## Validation

- `actionlint .github/workflows/label-community-contributor.yml`
- `git diff --check origin/release-3.1...HEAD`
- Confirmed the backported workflow is identical to the current `main` version.

## Documentation

- [ ] My PR needs documentation updates.
