### PR TITLE
perf(meta): reuse checkpoint object IDs during GC

### DIFF
--- a/src/meta/src/hummock/manager/checkpoint.rs
+++ b/src/meta/src/hummock/manager/checkpoint.rs
@@ -38,6 +38,12 @@ use crate::hummock::metrics_utils::{gc_stale_object_stats, trigger_gc_stat, trig
 pub struct HummockVersionCheckpoint {
     pub version: Arc<HummockVersion>,
 
+    /// Object ids referenced by `version`.
+    ///
+    /// This index is only kept in memory. Checkpoint creation already materializes the same set to
+    /// find removed objects, so retaining it avoids rebuilding a large hash set during every GC.
+    pub(super) object_ids: HashSet<HummockObjectId>,
+
     /// stale objects of versions before the current checkpoint.
     ///
     /// Previously we stored the stale object of each single version.
@@ -47,17 +53,42 @@ pub struct HummockVersionCheckpoint {
 }
 
 impl HummockVersionCheckpoint {
-    pub fn from_protobuf(checkpoint: &PbHummockVersionCheckpoint) -> Self {
+    /// Creates a checkpoint and builds its in-memory object-id index.
+    pub fn new(
+        version: Arc<HummockVersion>,
+        stale_objects: HashMap<HummockVersionId, PbStaleObjects>,
+    ) -> Self {
+        let object_ids = version.get_object_ids(false).collect();
         Self {
-            version: Arc::new(HummockVersion::from_persisted_protobuf(
+            version,
+            object_ids,
+            stale_objects,
+        }
+    }
+
+    fn with_object_ids(
+        version: Arc<HummockVersion>,
+        object_ids: HashSet<HummockObjectId>,
+        stale_objects: HashMap<HummockVersionId, PbStaleObjects>,
+    ) -> Self {
+        Self {
+            version,
+            object_ids,
+            stale_objects,
+        }
+    }
+
+    pub fn from_protobuf(checkpoint: &PbHummockVersionCheckpoint) -> Self {
+        Self::new(
+            Arc::new(HummockVersion::from_persisted_protobuf(
                 checkpoint.version.as_ref().unwrap(),
             )),
-            stale_objects: checkpoint
+            checkpoint
                 .stale_objects
                 .iter()
                 .map(|(version_id, objects)| (*version_id, objects.clone()))
                 .collect(),
-        }
+        )
     }
 
     pub fn to_protobuf(&self) -> PbHummockVersionCheckpoint {
@@ -218,8 +249,8 @@ impl HummockManager {
         }
 
         // Object ids that once exist in any hummock version but not exist in the latest hummock version
-        let removed_object_ids =
-            &versions_object_ids - &current_version.get_object_ids(false).collect();
+        let current_version_object_ids = current_version.get_object_ids(false).collect();
+        let removed_object_ids = &versions_object_ids - &current_version_object_ids;
         let total_file_size = removed_object_ids
             .iter()
             .map(|t| {
@@ -280,10 +311,11 @@ impl HummockManager {
             .flatten();
         self.gc_manager.add_may_delete_object_ids(may_delete_object);
         stale_objects.retain(|version_id, _| *version_id >= min_pinned_version_id);
-        let new_checkpoint = HummockVersionCheckpoint {
-            version: current_version.clone(),
+        let new_checkpoint = HummockVersionCheckpoint::with_object_ids(
+            current_version.clone(),
+            current_version_object_ids,
             stale_objects,
-        };
+        );
         // 2. persist the new checkpoint without holding lock
         self.write_checkpoint(&new_checkpoint).await?;
         if let Some(archive) = archive

--- a/src/meta/src/hummock/manager/gc.rs
+++ b/src/meta/src/hummock/manager/gc.rs
@@ -224,6 +224,7 @@ impl HummockManager {
         &self,
         object_ids: impl Iterator<Item = HummockObjectId>,
     ) -> Result<Vec<HummockObjectId>> {
+        let mut object_ids = object_ids.collect::<HashSet<_>>();
         // This lock ensures `commit_epoch` and `report_compat_task` can see the latest GC history during sanity check.
         let versioning = self
             .versioning
@@ -234,11 +235,8 @@ impl HummockManager {
             .read_with_process_name("finalize_objects_to_delete")
             .await
             .min_pinned_version_id();
-        let tracked_object_ids: HashSet<HummockObjectId> =
-            versioning.get_tracked_object_ids(min_pinned_version_id);
-        let to_delete = object_ids
-            .filter(|object_id| !tracked_object_ids.contains(object_id))
-            .collect_vec();
+        versioning.remove_tracked_object_ids(&mut object_ids, min_pinned_version_id);
+        let to_delete = object_ids.into_iter().collect_vec();
         self.write_gc_history(to_delete.iter().copied()).await?;
         Ok(to_delete)
     }
@@ -527,7 +525,7 @@ impl HummockManager {
     /// Minor GC attempts to delete objects that were part of Hummock version but are no longer in use.
     pub async fn try_start_minor_gc(&self, backup_manager: BackupManagerRef) -> Result<()> {
         const MIN_MINOR_GC_OBJECT_COUNT: usize = 1000;
-        let Some(object_ids) = self
+        let Some(mut object_ids) = self
             .gc_manager
             .try_take_may_delete_object_ids(MIN_MINOR_GC_OBJECT_COUNT)
         else {
@@ -535,8 +533,9 @@ impl HummockManager {
         };
         // Objects pinned by either meta backup or time travel should be filtered out.
         let backup_pinned: HashSet<_> = backup_manager.list_pinned_object_ids().await;
-        // The version_pinned is obtained after the candidate object_ids for deletion, which is new enough for filtering purpose.
-        let version_pinned = {
+        // Read version state after taking the deletion candidates so the snapshot is new enough for
+        // filtering purposes.
+        {
             let versioning = self
                 .versioning
                 .read_with_process_name("try_start_minor_gc")
@@ -546,11 +545,11 @@ impl HummockManager {
                 .read_with_process_name("try_start_minor_gc")
                 .await
                 .min_pinned_version_id();
-            versioning.get_tracked_object_ids(min_pinned_version_id)
-        };
+            versioning.remove_tracked_object_ids(&mut object_ids, min_pinned_version_id);
+        }
         let object_ids = object_ids
             .into_iter()
-            .filter(|s| !version_pinned.contains(s) && !backup_pinned.contains(&s.as_raw()));
+            .filter(|s| !backup_pinned.contains(&s.as_raw()));
         let filter_by_time_travel_start_time = Instant::now();
         let object_ids = self.filter_out_objects_by_time_travel(object_ids).await?;
         tracing::info!(elapsed = ?filter_by_time_travel_start_time.elapsed(), "filter out objects by time travel in minor GC");

--- a/src/meta/src/hummock/manager/mod.rs
+++ b/src/meta/src/hummock/manager/mod.rs
@@ -448,10 +448,10 @@ impl HummockManager {
                 .default_compaction_config();
             let checkpoint_version = HummockVersion::create_init_version(default_compaction_config);
             tracing::info!("init hummock version checkpoint");
-            versioning_guard.checkpoint = HummockVersionCheckpoint {
-                version: Arc::new(checkpoint_version.clone()),
-                stale_objects: Default::default(),
-            };
+            versioning_guard.checkpoint = HummockVersionCheckpoint::new(
+                Arc::new(checkpoint_version.clone()),
+                Default::default(),
+            );
             self.write_checkpoint(&versioning_guard.checkpoint).await?;
             checkpoint_version
         };

--- a/src/meta/src/hummock/manager/tests.rs
+++ b/src/meta/src/hummock/manager/tests.rs
@@ -1364,6 +1364,19 @@ async fn test_extend_objects_to_delete() {
         hummock_manager.create_version_checkpoint(1).await.unwrap(),
         6
     );
+    {
+        let versioning = hummock_manager
+            .versioning
+            .read_with_process_name("test_extend_objects_to_delete")
+            .await;
+        let checkpoint = &versioning.checkpoint;
+        let expected_object_ids = checkpoint.version.get_object_ids(false).collect();
+        assert_eq!(checkpoint.object_ids, expected_object_ids);
+
+        let restored_checkpoint =
+            HummockVersionCheckpoint::from_protobuf(&checkpoint.to_protobuf());
+        assert_eq!(restored_checkpoint.object_ids, expected_object_ids);
+    }
     // since version1 is still pinned, the sst removed in compaction can not be reclaimed.
     assert_eq!(
         hummock_manager
@@ -3028,10 +3041,10 @@ async fn test_old_version_dropped_table_sst_does_not_make_new_compaction_fail() 
     // in SST metadata and remove SSTs whose `table_ids` become empty. Otherwise the new compactor
     // will pass the stale read set to catalog acquire and fail before compaction can run.
     initial_manager
-        .write_checkpoint(&HummockVersionCheckpoint {
-            version: Arc::new(dirty_version),
-            stale_objects: Default::default(),
-        })
+        .write_checkpoint(&HummockVersionCheckpoint::new(
+            Arc::new(dirty_version),
+            Default::default(),
+        ))
         .await
         .unwrap();
 

--- a/src/meta/src/hummock/manager/versioning.rs
+++ b/src/meta/src/hummock/manager/versioning.rs
@@ -90,32 +90,46 @@ impl Versioning {
         self.time_travel_snapshot_interval_counter = u64::MAX;
     }
 
-    pub fn get_tracked_object_ids(
+    pub fn remove_tracked_object_ids(
         &self,
+        object_ids: &mut HashSet<HummockObjectId>,
         min_pinned_version_id: HummockVersionId,
-    ) -> HashSet<HummockObjectId> {
-        // object ids in checkpoint version
-        let mut tracked_object_ids = self
-            .checkpoint
-            .version
-            .get_object_ids(false)
-            .collect::<HashSet<_>>();
-        // add object ids added between checkpoint version and current version
+    ) {
+        // Filter object ids in the checkpoint version using the index built during checkpoint
+        // creation. The candidate set is typically much smaller than the checkpoint version.
+        object_ids.retain(|object_id| !self.checkpoint.object_ids.contains(object_id));
+        if object_ids.is_empty() {
+            return;
+        }
+
+        // Filter object ids added between checkpoint version and current version. Iterate directly
+        // to avoid allocating and re-hashing a temporary set for each delta.
         for (_, delta) in self.hummock_version_deltas.range((
             Excluded(self.checkpoint.version.id),
             Included(self.current_version.id),
         )) {
-            tracked_object_ids.extend(delta.newly_added_object_ids(false));
+            for object_id in delta.newly_added_object_ids_iter(false) {
+                object_ids.remove(&object_id);
+            }
+            if object_ids.is_empty() {
+                return;
+            }
         }
-        // add stale object ids before the checkpoint version
-        tracked_object_ids.extend(
-            self.checkpoint
-                .stale_objects
-                .iter()
-                .filter(|(version_id, _)| **version_id >= min_pinned_version_id)
-                .flat_map(|(_, objects)| get_stale_object_ids(objects)),
-        );
-        tracked_object_ids
+
+        // Filter stale object ids before the checkpoint version that are still pinned.
+        for (_, objects) in self
+            .checkpoint
+            .stale_objects
+            .iter()
+            .filter(|(version_id, _)| **version_id >= min_pinned_version_id)
+        {
+            for object_id in get_stale_object_ids(objects) {
+                object_ids.remove(&object_id);
+            }
+            if object_ids.is_empty() {
+                return;
+            }
+        }
     }
 }
 

--- a/src/storage/hummock_sdk/src/version.rs
+++ b/src/storage/hummock_sdk/src/version.rs
@@ -630,14 +630,15 @@ impl<T> HummockVersionDeltaCommon<T>
 where
     T: SstableIdReader + ObjectIdReader,
 {
-    /// Get the newly added object ids from the version delta.
+    /// Iterate over the newly added object ids in the version delta.
     ///
-    /// Note: the result can be false positive because we only collect the set of sst object ids in the `inserted_table_infos`,
-    /// but it is possible that the object is moved or split from other compaction groups or levels.
-    pub fn newly_added_object_ids(
+    /// Note: the result can be false positive because we only collect the set of sst object ids in
+    /// the `inserted_table_infos`, but it is possible that the object is moved or split from other
+    /// compaction groups or levels.
+    pub fn newly_added_object_ids_iter(
         &self,
         exclude_table_change_log: bool,
-    ) -> HashSet<HummockObjectId> {
+    ) -> impl Iterator<Item = HummockObjectId> + '_ {
         // DO NOT REMOVE THIS LINE
         // This is to ensure that when adding new variant to `HummockObjectId`,
         // the compiler will warn us if we forget to handle it here.
@@ -657,6 +658,14 @@ where
                             .map(|(object_id, _)| object_id)
                     }),
             )
+    }
+
+    /// Collect the object ids from [`Self::newly_added_object_ids_iter`] into a set.
+    pub fn newly_added_object_ids(
+        &self,
+        exclude_table_change_log: bool,
+    ) -> HashSet<HummockObjectId> {
+        self.newly_added_object_ids_iter(exclude_table_change_log)
             .collect()
     }
 


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What changed and what is the intention?

Minor and full GC previously rebuilt a hash set containing every object tracked by the checkpoint version on every filtering pass. For clusters with large vector indexes, this means repeatedly hashing hundreds of thousands of object IDs while holding the Hummock versioning read lock.

This PR:

- retains the current-version object-ID set that checkpoint creation already materializes;
- rebuilds the in-memory index once when loading a persisted checkpoint;
- filters the comparatively small GC candidate set against that index;
- streams post-checkpoint delta object IDs instead of allocating a temporary set per delta;
- preserves the existing conservative handling of checkpoint objects, delta additions, and pinned stale objects.

The recurring filtering work changes from building a set of every tracked object to checking candidates plus scanning post-checkpoint additions and retained stale objects.

## Tests

- `cargo fmt --all -- --check`
- `cargo check -p risingwave_hummock_sdk -p risingwave_meta`
- `cargo test -p risingwave_meta test_extend_objects_to_delete -- --nocapture`
- `cargo test -p risingwave_meta test_old_version_dropped_table_sst_does_not_make_new_compaction_fail -- --nocapture`
- `cargo test -p risingwave_hummock_sdk newly_added_object_ids -- --nocapture`

## Checklist

- [x] I have written necessary rustdoc comments.
- [x] I have added necessary unit tests and integration tests.
- [ ] My PR contains breaking changes.
- [ ] My PR needs documentation updates.