### PR TITLE
perf(meta): reuse checkpoint object IDs during GC

### DIFF
--- a/src/meta/src/hummock/manager/checkpoint.rs
+++ b/src/meta/src/hummock/manager/checkpoint.rs
@@ -19,7 +19,6 @@ use std::sync::Arc;
 use std::sync::atomic::Ordering;
 
 use bytes::BytesMut;
-use risingwave_hummock_sdk::change_log::TableChangeLogs;
 use risingwave_hummock_sdk::compaction_group::hummock_version_ext::version_object_size_map;
 use risingwave_hummock_sdk::version::HummockVersion;
 use risingwave_hummock_sdk::{HummockObjectId, HummockVersionId, get_stale_object_ids};
@@ -50,11 +49,11 @@ pub(crate) fn xxhash64_checksum(data: &[u8]) -> u64 {
 pub struct HummockVersionCheckpoint {
     pub version: Arc<HummockVersion>,
 
-    /// Object ids known to be referenced when this checkpoint was built.
+    /// Object ids referenced by `version`.
     ///
-    /// This in-memory index includes separately managed table change logs for newly created
-    /// checkpoints. Restored checkpoints rebuild the version object ids, while live table change
-    /// logs are filtered separately during GC.
+    /// This index deliberately excludes separately managed table change logs because their
+    /// membership can change without replacing the checkpoint. GC filters live table change logs
+    /// separately.
     pub(super) object_ids: HashSet<HummockObjectId>,
 
     /// stale objects of versions before the current checkpoint.
@@ -66,20 +65,12 @@ pub struct HummockVersionCheckpoint {
 }
 
 impl HummockVersionCheckpoint {
-    /// Creates a checkpoint and indexes object ids from both the version and table change logs.
+    /// Creates a checkpoint and builds its in-memory version object-id index.
     pub fn new(
         version: Arc<HummockVersion>,
         stale_objects: HashMap<HummockVersionId, PbStaleObjects>,
-        table_change_log: &TableChangeLogs,
     ) -> Self {
-        let object_ids = version
-            .get_object_ids()
-            .chain(
-                table_change_log
-                    .values()
-                    .flat_map(|change_log| change_log.get_object_ids()),
-            )
-            .collect();
+        let object_ids = version.get_object_ids().collect();
         Self {
             version,
             object_ids,
@@ -109,7 +100,6 @@ impl HummockVersionCheckpoint {
                 .iter()
                 .map(|(version_id, objects)| (*version_id, objects.clone()))
                 .collect(),
-            &Default::default(),
         )
     }
 
@@ -121,7 +111,6 @@ impl HummockVersionCheckpoint {
         Self::new(
             HummockVersion::from_persisted_protobuf_owned(version).into(),
             checkpoint.stale_objects,
-            &Default::default(),
         )
     }
 
@@ -539,15 +528,14 @@ impl HummockManager {
 
         // Object ids that once exist in any hummock version but not exist in the latest hummock
         // version or its separately managed table change logs.
-        let current_version_object_ids = current_version
-            .get_object_ids()
-            .chain(
-                current_table_change_log
-                    .values()
-                    .flat_map(|change_log| change_log.get_object_ids()),
-            )
-            .collect();
-        let removed_object_ids = &versions_object_ids - &current_version_object_ids;
+        let checkpoint_version_object_ids = current_version.get_object_ids().collect();
+        let mut removed_object_ids = &versions_object_ids - &checkpoint_version_object_ids;
+        for object_id in current_table_change_log
+            .values()
+            .flat_map(|change_log| change_log.get_object_ids())
+        {
+            removed_object_ids.remove(&object_id);
+        }
         let total_file_size = removed_object_ids
             .iter()
             .map(|t| {
@@ -610,7 +598,7 @@ impl HummockManager {
         stale_objects.retain(|version_id, _| *version_id >= min_pinned_version_id);
         let new_checkpoint = HummockVersionCheckpoint::with_object_ids(
             current_version.clone(),
-            current_version_object_ids,
+            checkpoint_version_object_ids,
             stale_objects,
         );
         // 2. persist the new checkpoint without holding lock

--- a/src/meta/src/hummock/manager/checkpoint.rs
+++ b/src/meta/src/hummock/manager/checkpoint.rs
@@ -49,6 +49,12 @@ pub(crate) fn xxhash64_checksum(data: &[u8]) -> u64 {
 pub struct HummockVersionCheckpoint {
     pub version: Arc<HummockVersion>,
 
+    /// Object ids referenced by `version`.
+    ///
+    /// This index is only kept in memory. Checkpoint creation already materializes the same set to
+    /// find removed objects, so retaining it avoids rebuilding a large hash set during every GC.
+    pub(super) object_ids: HashSet<HummockObjectId>,
+
     /// stale objects of versions before the current checkpoint.
     ///
     /// Previously we stored the stale object of each single version.
@@ -58,17 +64,42 @@ pub struct HummockVersionCheckpoint {
 }
 
 impl HummockVersionCheckpoint {
+    /// Creates a checkpoint and builds its in-memory object-id index.
+    pub fn new(
+        version: Arc<HummockVersion>,
+        stale_objects: HashMap<HummockVersionId, PbStaleObjects>,
+    ) -> Self {
+        let object_ids = version.get_object_ids().collect();
+        Self {
+            version,
+            object_ids,
+            stale_objects,
+        }
+    }
+
+    fn with_object_ids(
+        version: Arc<HummockVersion>,
+        object_ids: HashSet<HummockObjectId>,
+        stale_objects: HashMap<HummockVersionId, PbStaleObjects>,
+    ) -> Self {
+        Self {
+            version,
+            object_ids,
+            stale_objects,
+        }
+    }
+
     pub fn from_protobuf(checkpoint: &PbHummockVersionCheckpoint) -> Self {
         let version = checkpoint.version.as_ref().unwrap();
         warn_if_legacy_table_change_logs_are_present(version);
-        Self {
-            version: Arc::new(HummockVersion::from_persisted_protobuf(version)),
-            stale_objects: checkpoint
+        Self::new(
+            Arc::new(HummockVersion::from_persisted_protobuf(version)),
+            checkpoint
                 .stale_objects
                 .iter()
                 .map(|(version_id, objects)| (*version_id, objects.clone()))
                 .collect(),
-        }
+        )
     }
 
     /// Convert an owned `PbHummockVersionCheckpoint` to `HummockVersionCheckpoint`,
@@ -76,10 +107,10 @@ impl HummockVersionCheckpoint {
     pub fn from_protobuf_owned(checkpoint: PbHummockVersionCheckpoint) -> Self {
         let version = checkpoint.version.unwrap();
         warn_if_legacy_table_change_logs_are_present(&version);
-        Self {
-            version: HummockVersion::from_persisted_protobuf_owned(version).into(),
-            stale_objects: checkpoint.stale_objects,
-        }
+        Self::new(
+            HummockVersion::from_persisted_protobuf_owned(version).into(),
+            checkpoint.stale_objects,
+        )
     }
 
     pub fn to_protobuf(&self) -> PbHummockVersionCheckpoint {
@@ -494,16 +525,16 @@ impl HummockManager {
             }
         }
 
-        // Object ids that once exist in any hummock version but not exist in the latest hummock version
-        let current_version_object_ids = current_version
-            .get_object_ids()
-            .chain(
-                current_table_change_log
-                    .values()
-                    .flat_map(|l| l.get_object_ids()),
-            )
-            .collect();
-        let removed_object_ids = &versions_object_ids - &current_version_object_ids;
+        // Object ids that once exist in any hummock version but not exist in the latest hummock
+        // version or its separately managed table change logs.
+        let current_version_object_ids = current_version.get_object_ids().collect();
+        let mut removed_object_ids = &versions_object_ids - &current_version_object_ids;
+        for object_id in current_table_change_log
+            .values()
+            .flat_map(|change_log| change_log.get_object_ids())
+        {
+            removed_object_ids.remove(&object_id);
+        }
         let total_file_size = removed_object_ids
             .iter()
             .map(|t| {
@@ -564,10 +595,11 @@ impl HummockManager {
             .flatten();
         self.gc_manager.add_may_delete_object_ids(may_delete_object);
         stale_objects.retain(|version_id, _| *version_id >= min_pinned_version_id);
-        let new_checkpoint = HummockVersionCheckpoint {
-            version: current_version.clone(),
+        let new_checkpoint = HummockVersionCheckpoint::with_object_ids(
+            current_version.clone(),
+            current_version_object_ids,
             stale_objects,
-        };
+        );
         // 2. persist the new checkpoint without holding lock
         self.write_checkpoint(&new_checkpoint).await?;
         if let Some(archive) = archive

--- a/src/meta/src/hummock/manager/checkpoint.rs
+++ b/src/meta/src/hummock/manager/checkpoint.rs
@@ -49,10 +49,11 @@ pub(crate) fn xxhash64_checksum(data: &[u8]) -> u64 {
 pub struct HummockVersionCheckpoint {
     pub version: Arc<HummockVersion>,
 
-    /// Object ids referenced by `version`.
+    /// Object ids known to be referenced when this checkpoint was built.
     ///
-    /// This index is only kept in memory. Checkpoint creation already materializes the same set to
-    /// find removed objects, so retaining it avoids rebuilding a large hash set during every GC.
+    /// This in-memory index includes separately managed table change logs for newly created
+    /// checkpoints. Restored checkpoints rebuild the version object ids, while live table change
+    /// logs are filtered separately during GC.
     pub(super) object_ids: HashSet<HummockObjectId>,
 
     /// stale objects of versions before the current checkpoint.
@@ -527,14 +528,15 @@ impl HummockManager {
 
         // Object ids that once exist in any hummock version but not exist in the latest hummock
         // version or its separately managed table change logs.
-        let current_version_object_ids = current_version.get_object_ids().collect();
-        let mut removed_object_ids = &versions_object_ids - &current_version_object_ids;
-        for object_id in current_table_change_log
-            .values()
-            .flat_map(|change_log| change_log.get_object_ids())
-        {
-            removed_object_ids.remove(&object_id);
-        }
+        let current_version_object_ids = current_version
+            .get_object_ids()
+            .chain(
+                current_table_change_log
+                    .values()
+                    .flat_map(|change_log| change_log.get_object_ids()),
+            )
+            .collect();
+        let removed_object_ids = &versions_object_ids - &current_version_object_ids;
         let total_file_size = removed_object_ids
             .iter()
             .map(|t| {

--- a/src/meta/src/hummock/manager/checkpoint.rs
+++ b/src/meta/src/hummock/manager/checkpoint.rs
@@ -19,6 +19,7 @@ use std::sync::Arc;
 use std::sync::atomic::Ordering;
 
 use bytes::BytesMut;
+use risingwave_hummock_sdk::change_log::TableChangeLogs;
 use risingwave_hummock_sdk::compaction_group::hummock_version_ext::version_object_size_map;
 use risingwave_hummock_sdk::version::HummockVersion;
 use risingwave_hummock_sdk::{HummockObjectId, HummockVersionId, get_stale_object_ids};
@@ -65,12 +66,20 @@ pub struct HummockVersionCheckpoint {
 }
 
 impl HummockVersionCheckpoint {
-    /// Creates a checkpoint and builds its in-memory object-id index.
+    /// Creates a checkpoint and indexes object ids from both the version and table change logs.
     pub fn new(
         version: Arc<HummockVersion>,
         stale_objects: HashMap<HummockVersionId, PbStaleObjects>,
+        table_change_log: &TableChangeLogs,
     ) -> Self {
-        let object_ids = version.get_object_ids().collect();
+        let object_ids = version
+            .get_object_ids()
+            .chain(
+                table_change_log
+                    .values()
+                    .flat_map(|change_log| change_log.get_object_ids()),
+            )
+            .collect();
         Self {
             version,
             object_ids,
@@ -100,6 +109,7 @@ impl HummockVersionCheckpoint {
                 .iter()
                 .map(|(version_id, objects)| (*version_id, objects.clone()))
                 .collect(),
+            &Default::default(),
         )
     }
 
@@ -111,6 +121,7 @@ impl HummockVersionCheckpoint {
         Self::new(
             HummockVersion::from_persisted_protobuf_owned(version).into(),
             checkpoint.stale_objects,
+            &Default::default(),
         )
     }
 

--- a/src/meta/src/hummock/manager/gc.rs
+++ b/src/meta/src/hummock/manager/gc.rs
@@ -224,20 +224,19 @@ impl HummockManager {
         &self,
         object_ids: impl Iterator<Item = HummockObjectId>,
     ) -> Result<Vec<HummockObjectId>> {
+        let mut object_ids = object_ids.collect::<HashSet<_>>();
         // This lock ensures `commit_epoch` and `report_compat_task` can see the latest GC history during sanity check.
         let versioning = self
             .versioning
             .read_with_process_name("finalize_objects_to_delete")
             .await;
-        let tracked_object_ids: HashSet<HummockObjectId> = versioning.get_tracked_object_ids(
-            self.context_info
-                .read_with_process_name("finalize_objects_to_delete")
-                .await
-                .min_pinned_version_id(),
-        );
-        let to_delete = object_ids
-            .filter(|object_id| !tracked_object_ids.contains(object_id))
-            .collect_vec();
+        let min_pinned_version_id = self
+            .context_info
+            .read_with_process_name("finalize_objects_to_delete")
+            .await
+            .min_pinned_version_id();
+        versioning.remove_tracked_object_ids(&mut object_ids, min_pinned_version_id);
+        let to_delete = object_ids.into_iter().collect_vec();
         self.write_gc_history(to_delete.iter().copied()).await?;
         Ok(to_delete)
     }
@@ -526,7 +525,7 @@ impl HummockManager {
     /// Minor GC attempts to delete objects that were part of Hummock version but are no longer in use.
     pub async fn try_start_minor_gc(&self, backup_manager: BackupManagerRef) -> Result<()> {
         const MIN_MINOR_GC_OBJECT_COUNT: usize = 1000;
-        let Some(object_ids) = self
+        let Some(mut object_ids) = self
             .gc_manager
             .try_take_may_delete_object_ids(MIN_MINOR_GC_OBJECT_COUNT)
         else {
@@ -534,22 +533,23 @@ impl HummockManager {
         };
         // Objects pinned by either meta backup or time travel should be filtered out.
         let backup_pinned: HashSet<_> = backup_manager.list_pinned_object_ids().await;
-        // The version_pinned is obtained after the candidate object_ids for deletion, which is new enough for filtering purpose.
-        let version_pinned = {
+        // Read version state after taking the deletion candidates so the snapshot is new enough for
+        // filtering purposes.
+        {
             let versioning = self
                 .versioning
                 .read_with_process_name("try_start_minor_gc")
                 .await;
-            versioning.get_tracked_object_ids(
-                self.context_info
-                    .read_with_process_name("try_start_minor_gc")
-                    .await
-                    .min_pinned_version_id(),
-            )
-        };
+            let min_pinned_version_id = self
+                .context_info
+                .read_with_process_name("try_start_minor_gc")
+                .await
+                .min_pinned_version_id();
+            versioning.remove_tracked_object_ids(&mut object_ids, min_pinned_version_id);
+        }
         let object_ids = object_ids
             .into_iter()
-            .filter(|s| !version_pinned.contains(s) && !backup_pinned.contains(&s.as_raw()));
+            .filter(|s| !backup_pinned.contains(&s.as_raw()));
         let filter_by_time_travel_start_time = Instant::now();
         let object_ids = self.filter_out_objects_by_time_travel(object_ids).await?;
         tracing::info!(elapsed = ?filter_by_time_travel_start_time.elapsed(), "filter out objects by time travel in minor GC");

--- a/src/meta/src/hummock/manager/mod.rs
+++ b/src/meta/src/hummock/manager/mod.rs
@@ -496,10 +496,10 @@ impl HummockManager {
                 .default_compaction_config();
             let checkpoint_version = HummockVersion::create_init_version(default_compaction_config);
             tracing::info!("init hummock version checkpoint");
-            versioning_guard.checkpoint = HummockVersionCheckpoint {
-                version: Arc::new(checkpoint_version.clone()),
-                stale_objects: Default::default(),
-            };
+            versioning_guard.checkpoint = HummockVersionCheckpoint::new(
+                Arc::new(checkpoint_version.clone()),
+                Default::default(),
+            );
             self.write_checkpoint(&versioning_guard.checkpoint).await?;
             checkpoint_version
         };

--- a/src/meta/src/hummock/manager/mod.rs
+++ b/src/meta/src/hummock/manager/mod.rs
@@ -499,6 +499,7 @@ impl HummockManager {
             versioning_guard.checkpoint = HummockVersionCheckpoint::new(
                 Arc::new(checkpoint_version.clone()),
                 Default::default(),
+                &Default::default(),
             );
             self.write_checkpoint(&versioning_guard.checkpoint).await?;
             checkpoint_version
@@ -567,6 +568,12 @@ impl HummockManager {
                     )
                 })
                 .collect();
+        versioning_guard.checkpoint.object_ids.extend(
+            versioning_guard
+                .table_change_log
+                .values()
+                .flat_map(|change_log| change_log.get_object_ids()),
+        );
 
         context_info.pinned_versions = hummock_pinned_version::Entity::find()
             .all(&meta_store.conn)

--- a/src/meta/src/hummock/manager/mod.rs
+++ b/src/meta/src/hummock/manager/mod.rs
@@ -499,7 +499,6 @@ impl HummockManager {
             versioning_guard.checkpoint = HummockVersionCheckpoint::new(
                 Arc::new(checkpoint_version.clone()),
                 Default::default(),
-                &Default::default(),
             );
             self.write_checkpoint(&versioning_guard.checkpoint).await?;
             checkpoint_version
@@ -568,12 +567,6 @@ impl HummockManager {
                     )
                 })
                 .collect();
-        versioning_guard.checkpoint.object_ids.extend(
-            versioning_guard
-                .table_change_log
-                .values()
-                .flat_map(|change_log| change_log.get_object_ids()),
-        );
 
         context_info.pinned_versions = hummock_pinned_version::Entity::find()
             .all(&meta_store.conn)

--- a/src/meta/src/hummock/manager/tests.rs
+++ b/src/meta/src/hummock/manager/tests.rs
@@ -1451,6 +1451,19 @@ async fn test_extend_objects_to_delete() {
         hummock_manager.create_version_checkpoint(1).await.unwrap(),
         6
     );
+    {
+        let versioning = hummock_manager
+            .versioning
+            .read_with_process_name("test_extend_objects_to_delete")
+            .await;
+        let checkpoint = &versioning.checkpoint;
+        let expected_object_ids = checkpoint.version.get_object_ids().collect();
+        assert_eq!(checkpoint.object_ids, expected_object_ids);
+
+        let restored_checkpoint =
+            HummockVersionCheckpoint::from_protobuf(&checkpoint.to_protobuf());
+        assert_eq!(restored_checkpoint.object_ids, expected_object_ids);
+    }
     // since version1 is still pinned, the sst removed in compaction can not be reclaimed.
     assert_eq!(
         hummock_manager
@@ -3118,10 +3131,10 @@ async fn test_old_version_dropped_table_sst_does_not_make_new_compaction_fail() 
     // in SST metadata and remove SSTs whose `table_ids` become empty. Otherwise the new compactor
     // will pass the stale read set to catalog acquire and fail before compaction can run.
     initial_manager
-        .write_checkpoint(&HummockVersionCheckpoint {
-            version: Arc::new(dirty_version),
-            stale_objects: Default::default(),
-        })
+        .write_checkpoint(&HummockVersionCheckpoint::new(
+            Arc::new(dirty_version),
+            Default::default(),
+        ))
         .await
         .unwrap();
 

--- a/src/meta/src/hummock/manager/tests.rs
+++ b/src/meta/src/hummock/manager/tests.rs
@@ -1457,12 +1457,19 @@ async fn test_extend_objects_to_delete() {
             .read_with_process_name("test_extend_objects_to_delete")
             .await;
         let checkpoint = &versioning.checkpoint;
-        let expected_object_ids = checkpoint.version.get_object_ids().collect();
-        assert_eq!(checkpoint.object_ids, expected_object_ids);
+        let expected_version_object_ids: HashSet<_> = checkpoint.version.get_object_ids().collect();
+        let mut expected_checkpoint_object_ids = expected_version_object_ids.clone();
+        expected_checkpoint_object_ids.extend(
+            versioning
+                .table_change_log
+                .values()
+                .flat_map(|change_log| change_log.get_object_ids()),
+        );
+        assert_eq!(checkpoint.object_ids, expected_checkpoint_object_ids);
 
         let restored_checkpoint =
             HummockVersionCheckpoint::from_protobuf(&checkpoint.to_protobuf());
-        assert_eq!(restored_checkpoint.object_ids, expected_object_ids);
+        assert_eq!(restored_checkpoint.object_ids, expected_version_object_ids);
     }
     // since version1 is still pinned, the sst removed in compaction can not be reclaimed.
     assert_eq!(

--- a/src/meta/src/hummock/manager/tests.rs
+++ b/src/meta/src/hummock/manager/tests.rs
@@ -1458,44 +1458,66 @@ async fn test_extend_objects_to_delete() {
             .await;
         let checkpoint = &versioning.checkpoint;
         let expected_version_object_ids: HashSet<_> = checkpoint.version.get_object_ids().collect();
-        let mut expected_checkpoint_object_ids = expected_version_object_ids.clone();
-        expected_checkpoint_object_ids.extend(
-            versioning
-                .table_change_log
-                .values()
-                .flat_map(|change_log| change_log.get_object_ids()),
-        );
-        assert_eq!(checkpoint.object_ids, expected_checkpoint_object_ids);
+        assert_eq!(checkpoint.object_ids, expected_version_object_ids);
 
-        let change_log_object_id = 10_000;
-        let table_change_log = HashMap::from([(
-            TableId::new(1),
+        let restored_checkpoint =
+            HummockVersionCheckpoint::from_protobuf(&checkpoint.to_protobuf());
+        assert_eq!(restored_checkpoint.object_ids, expected_version_object_ids);
+    }
+
+    // A table-change-log-only object is protected while the log is live, but must not be retained
+    // by the immutable checkpoint index after the log is removed.
+    let change_log_object_id = 10_000;
+    let change_log_object = HummockObjectId::Sstable(change_log_object_id.into());
+    let change_log_table_id = TableId::new(u32::MAX);
+    {
+        let mut versioning = hummock_manager
+            .versioning
+            .write_with_process_name("test_extend_objects_to_delete")
+            .await;
+        let checkpoint_version = versioning.checkpoint.version.clone();
+        let stale_objects = versioning.checkpoint.stale_objects.clone();
+        versioning.table_change_log.insert(
+            change_log_table_id,
             TableChangeLog::new([EpochNewChangeLog {
                 new_value: vec![gen_sstable_info(
                     change_log_object_id,
-                    vec![1],
+                    vec![change_log_table_id.as_raw_id()],
                     test_epoch(1),
                 )],
                 old_value: vec![],
                 non_checkpoint_epochs: vec![],
                 checkpoint_epoch: test_epoch(1),
             }]),
-        )]);
-        let checkpoint_with_change_log = HummockVersionCheckpoint::new(
-            checkpoint.version.clone(),
-            Default::default(),
-            &table_change_log,
         );
+        versioning.checkpoint = HummockVersionCheckpoint::new(checkpoint_version, stale_objects);
         assert!(
-            checkpoint_with_change_log
+            !versioning
+                .checkpoint
                 .object_ids
-                .contains(&HummockObjectId::Sstable(change_log_object_id.into()))
+                .contains(&change_log_object)
         );
-
-        let restored_checkpoint =
-            HummockVersionCheckpoint::from_protobuf(&checkpoint.to_protobuf());
-        assert_eq!(restored_checkpoint.object_ids, expected_version_object_ids);
     }
+    assert!(
+        hummock_manager
+            .finalize_objects_to_delete([change_log_object].into_iter())
+            .await
+            .unwrap()
+            .is_empty()
+    );
+    hummock_manager
+        .versioning
+        .write_with_process_name("test_extend_objects_to_delete")
+        .await
+        .table_change_log
+        .remove(&change_log_table_id);
+    assert_eq!(
+        hummock_manager
+            .finalize_objects_to_delete([change_log_object].into_iter())
+            .await
+            .unwrap(),
+        vec![change_log_object]
+    );
     // since version1 is still pinned, the sst removed in compaction can not be reclaimed.
     assert_eq!(
         hummock_manager
@@ -3166,7 +3188,6 @@ async fn test_old_version_dropped_table_sst_does_not_make_new_compaction_fail() 
         .write_checkpoint(&HummockVersionCheckpoint::new(
             Arc::new(dirty_version),
             Default::default(),
-            &Default::default(),
         ))
         .await
         .unwrap();

--- a/src/meta/src/hummock/manager/tests.rs
+++ b/src/meta/src/hummock/manager/tests.rs
@@ -1467,6 +1467,31 @@ async fn test_extend_objects_to_delete() {
         );
         assert_eq!(checkpoint.object_ids, expected_checkpoint_object_ids);
 
+        let change_log_object_id = 10_000;
+        let table_change_log = HashMap::from([(
+            TableId::new(1),
+            TableChangeLog::new([EpochNewChangeLog {
+                new_value: vec![gen_sstable_info(
+                    change_log_object_id,
+                    vec![1],
+                    test_epoch(1),
+                )],
+                old_value: vec![],
+                non_checkpoint_epochs: vec![],
+                checkpoint_epoch: test_epoch(1),
+            }]),
+        )]);
+        let checkpoint_with_change_log = HummockVersionCheckpoint::new(
+            checkpoint.version.clone(),
+            Default::default(),
+            &table_change_log,
+        );
+        assert!(
+            checkpoint_with_change_log
+                .object_ids
+                .contains(&HummockObjectId::Sstable(change_log_object_id.into()))
+        );
+
         let restored_checkpoint =
             HummockVersionCheckpoint::from_protobuf(&checkpoint.to_protobuf());
         assert_eq!(restored_checkpoint.object_ids, expected_version_object_ids);
@@ -3141,6 +3166,7 @@ async fn test_old_version_dropped_table_sst_does_not_make_new_compaction_fail() 
         .write_checkpoint(&HummockVersionCheckpoint::new(
             Arc::new(dirty_version),
             Default::default(),
+            &Default::default(),
         ))
         .await
         .unwrap();

--- a/src/meta/src/hummock/manager/versioning.rs
+++ b/src/meta/src/hummock/manager/versioning.rs
@@ -91,37 +91,59 @@ impl Versioning {
         self.time_travel_snapshot_interval_counter = u64::MAX;
     }
 
-    pub fn get_tracked_object_ids(
+    pub fn remove_tracked_object_ids(
         &self,
+        object_ids: &mut HashSet<HummockObjectId>,
         min_pinned_version_id: HummockVersionId,
-    ) -> HashSet<HummockObjectId> {
-        // object ids in checkpoint version
-        let mut tracked_object_ids = self
-            .checkpoint
-            .version
-            .get_object_ids()
-            .chain(
-                self.table_change_log
-                    .values()
-                    .flat_map(|c| c.get_object_ids()),
-            )
-            .collect::<HashSet<_>>();
-        // add object ids added between checkpoint version and current version
+    ) {
+        // Filter object ids in the checkpoint version using the index built during checkpoint
+        // creation. The candidate set is typically much smaller than the checkpoint version.
+        object_ids.retain(|object_id| !self.checkpoint.object_ids.contains(object_id));
+        if object_ids.is_empty() {
+            return;
+        }
+
+        // Table change logs are managed separately from the checkpoint version on main. Iterate
+        // over them directly so GC does not have to allocate a second large set.
+        for object_id in self
+            .table_change_log
+            .values()
+            .flat_map(|change_log| change_log.get_object_ids())
+        {
+            object_ids.remove(&object_id);
+            if object_ids.is_empty() {
+                return;
+            }
+        }
+
+        // Filter object ids added between checkpoint version and current version. Iterate directly
+        // to avoid allocating and re-hashing a temporary set for each delta.
         for (_, delta) in self.hummock_version_deltas.range((
             Excluded(self.checkpoint.version.id),
             Included(self.current_version.id),
         )) {
-            tracked_object_ids.extend(delta.newly_added_object_ids());
+            for object_id in delta.newly_added_object_ids_iter() {
+                object_ids.remove(&object_id);
+            }
+            if object_ids.is_empty() {
+                return;
+            }
         }
-        // add stale object ids before the checkpoint version
-        tracked_object_ids.extend(
-            self.checkpoint
-                .stale_objects
-                .iter()
-                .filter(|(version_id, _)| **version_id >= min_pinned_version_id)
-                .flat_map(|(_, objects)| get_stale_object_ids(objects)),
-        );
-        tracked_object_ids
+
+        // Filter stale object ids before the checkpoint version that are still pinned.
+        for (_, objects) in self
+            .checkpoint
+            .stale_objects
+            .iter()
+            .filter(|(version_id, _)| **version_id >= min_pinned_version_id)
+        {
+            for object_id in get_stale_object_ids(objects) {
+                object_ids.remove(&object_id);
+            }
+            if object_ids.is_empty() {
+                return;
+            }
+        }
     }
 }
 

--- a/src/storage/hummock_sdk/src/version.rs
+++ b/src/storage/hummock_sdk/src/version.rs
@@ -587,11 +587,12 @@ impl<T> HummockVersionDeltaCommon<T>
 where
     T: SstableIdReader + ObjectIdReader,
 {
-    /// Get the newly added object ids from the version delta.
+    /// Iterate over the newly added object ids in the version delta.
     ///
-    /// Note: the result can be false positive because we only collect the set of sst object ids in the `inserted_table_infos`,
-    /// but it is possible that the object is moved or split from other compaction groups or levels.
-    pub fn newly_added_object_ids(&self) -> HashSet<HummockObjectId> {
+    /// Note: the result can be false positive because we only collect the set of sst object ids in
+    /// the `inserted_table_infos`, but it is possible that the object is moved or split from other
+    /// compaction groups or levels.
+    pub fn newly_added_object_ids_iter(&self) -> impl Iterator<Item = HummockObjectId> + '_ {
         // DO NOT REMOVE THIS LINE
         // This is to ensure that when adding new variant to `HummockObjectId`,
         // the compiler will warn us if we forget to handle it here.
@@ -611,7 +612,11 @@ where
                             .map(|(object_id, _)| object_id)
                     }),
             )
-            .collect()
+    }
+
+    /// Collect the object ids from [`Self::newly_added_object_ids_iter`] into a set.
+    pub fn newly_added_object_ids(&self) -> HashSet<HummockObjectId> {
+        self.newly_added_object_ids_iter().collect()
     }
 
     pub fn newly_added_sst_ids(&self) -> HashSet<HummockSstableId> {


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

- Cache checkpoint object IDs in memory so full and minor GC can filter candidate IDs without rebuilding the complete tracked-object set on every run.
- Filter candidates in place across checkpoint IDs, separately managed table change logs, version deltas, and pinned stale objects while preserving checkpoint serialization compatibility.
- Ports #26722 to main.

## Checklist

- [x] I have written necessary rustdoc comments.
- [x] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [x] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/dev/src/ci.md#ci-labels-guide -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwavelabs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved storage cleanup accuracy by preserving objects still referenced by checkpoints, table change logs, backups, or active versions.
  - Corrected lifecycle handling for table-change-log-only objects, ensuring they remain protected while needed and become eligible for reclamation after removal.
  - Improved checkpoint consistency across creation and restoration, including more reliable tracking of associated objects.

- **Performance**
  - Reduced unnecessary intermediate processing during garbage-collection checks for more efficient cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->