### PR TITLE
cherry-pick fix(cdc): parse MySQL binlog file seq independent of binlog basename (#25919) to release-3.0

### DIFF
--- a/src/connector/src/source/cdc/enumerator/mod.rs
+++ b/src/connector/src/source/cdc/enumerator/mod.rs
@@ -39,7 +39,7 @@ use crate::connector_common::{SslMode, create_pg_client};
 use crate::error::ConnectorResult;
 use crate::sink::sqlserver::SqlServerClient;
 use crate::source::cdc::external::mysql::build_mysql_connection_pool;
-use crate::source::cdc::split::parse_sql_server_lsn_str;
+use crate::source::cdc::split::{extract_binlog_file_seq, parse_sql_server_lsn_str};
 use crate::source::cdc::{
     CdcProperties, CdcSourceTypeTrait, Citus, DebeziumCdcSplit, Mongodb, Mysql, Postgres,
     SqlServer, table_schema_exclude_additional_columns,
@@ -474,7 +474,7 @@ impl DebeziumSplitEnumerator<Mysql> {
             Ok(binlog_files) => {
                 if let Some((oldest_file, oldest_size)) = binlog_files.first() {
                     // Extract sequence number from filename (e.g., "binlog.000001" -> 1)
-                    if let Some(seq) = Self::extract_binlog_seq(oldest_file) {
+                    if let Some(seq) = extract_binlog_file_seq(oldest_file) {
                         let labels = vec![hostname.to_owned(), port.to_owned()];
                         get_or_create_guarded_int_gauge(
                             &mut self.mysql_cdc_binlog_file_seq_min,
@@ -495,7 +495,7 @@ impl DebeziumSplitEnumerator<Mysql> {
                 }
                 if let Some((newest_file, newest_size)) = binlog_files.last() {
                     // Extract sequence number from filename
-                    if let Some(seq) = Self::extract_binlog_seq(newest_file) {
+                    if let Some(seq) = extract_binlog_file_seq(newest_file) {
                         let labels = vec![hostname.to_owned(), port.to_owned()];
                         get_or_create_guarded_int_gauge(
                             &mut self.mysql_cdc_binlog_file_seq_max,
@@ -533,12 +533,6 @@ impl DebeziumSplitEnumerator<Mysql> {
             }
         }
         Ok(())
-    }
-
-    /// Extract sequence number from binlog filename
-    /// e.g., "binlog.000001" -> Some(1), "mysql-bin.000123" -> Some(123)
-    fn extract_binlog_seq(filename: &str) -> Option<u64> {
-        filename.rsplit('.').next()?.parse::<u64>().ok()
     }
 
     /// Query binlog files from MySQL, returns Vec<(filename, size)>

--- a/src/connector/src/source/cdc/split.rs
+++ b/src/connector/src/source/cdc/split.rs
@@ -133,8 +133,7 @@ impl MySqlCdcSplit {
         let file = source_offset.get("file")?.as_str()?;
         let pos = source_offset.get("pos")?.as_u64()?;
 
-        // Extract numeric sequence from "binlog.NNNNNN"
-        let file_seq = file.strip_prefix("binlog.")?.parse::<u64>().ok()?;
+        let file_seq = extract_binlog_file_seq(file)?;
 
         Some((file_seq, pos))
     }
@@ -527,6 +526,14 @@ impl DebeziumCdcSplit<SqlServer> {
     }
 }
 
+/// Extract the numeric sequence from a MySQL binlog file name `<basename>.<sequence>`.
+///
+/// The basename is configurable (`binlog`, `mysql-bin`, `mysql-bin-changelog` on RDS/Aurora, ...),
+/// so we take the number after the last `.` rather than assuming a fixed prefix.
+pub fn extract_binlog_file_seq(file_name: &str) -> Option<u64> {
+    file_name.rsplit('.').next()?.parse::<u64>().ok()
+}
+
 /// Extract PostgreSQL LSN value from a CDC offset JSON string.
 ///
 /// This is a standalone helper function that can be used when you only have the offset string
@@ -743,6 +750,38 @@ mod tests {
 
         assert_eq!(split.pg_lsn_commit(), Some(33_969_832));
         assert_eq!(split.pg_lsn_proc(), Some(33_918_336));
+    }
+
+    #[test]
+    fn test_extract_binlog_file_seq() {
+        // default MySQL 8.0 basename
+        assert_eq!(extract_binlog_file_seq("binlog.000123"), Some(123));
+        // `--log-bin=mysql-bin`
+        assert_eq!(extract_binlog_file_seq("mysql-bin.000123"), Some(123));
+        // `<hostname>-bin` on older versions
+        assert_eq!(extract_binlog_file_seq("my-host-bin.000001"), Some(1));
+        // RDS / Aurora MySQL
+        assert_eq!(
+            extract_binlog_file_seq("mysql-bin-changelog.037568"),
+            Some(37568)
+        );
+        // invalid suffix
+        assert_eq!(extract_binlog_file_seq("binlog.index"), None);
+        assert_eq!(extract_binlog_file_seq("no-extension"), None);
+    }
+
+    #[test]
+    fn test_mysql_binlog_offset() {
+        let offset = r#"{
+            "sourcePartition": {"server": "test"},
+            "sourceOffset": {
+                "file": "mysql-bin-changelog.037568",
+                "pos": 12345
+            },
+            "isHeartbeat": false
+        }"#;
+        let split = MySqlCdcSplit::new(1, Some(offset.to_owned()));
+        assert_eq!(split.mysql_binlog_offset(), Some((37568, 12345)));
     }
 
     #[test]


### PR DESCRIPTION
Backport #25919 to `release-3.0`.

This fixes MySQL CDC binlog state metrics for deployments whose binlog basename is not the MySQL 8.0 default `binlog`, including `mysql-bin`, `<hostname>-bin`, and `mysql-bin-changelog` on RDS/Aurora. The parser now takes the numeric sequence after the last `.` and shares the same helper between state-table and enumerator metrics.

The original commit `5ebc3f24e4fdc82f905fc67906bbf0f28e96ef2f` was cherry-picked with `-x` as `787ca15da5cf45469cfc3eab538accc8a74a17e5`.

## Conflict resolution

`src/connector/src/source/cdc/enumerator/mod.rs` conflicted because `release-3.0` retains guarded gauge handles in the enumerator. The resolution preserves the release branch's `get_or_create_guarded_int_gauge` lifecycle logic and only replaces its duplicated parser with the shared `extract_binlog_file_seq` helper from the original PR.

## Verification

- `cargo fmt --all -- --check`
- `cargo test -p risingwave_connector test_extract_binlog_file_seq` (1 passed)
- `cargo test -p risingwave_connector test_mysql_binlog_offset` (2 passed)
- `git diff --check origin/release-3.0...HEAD`

