### PR TITLE
fix(sqlsmith): permit the VARIANT-as-key rejection

### DIFF
--- a/src/tests/sqlsmith/src/validation.rs
+++ b/src/tests/sqlsmith/src/validation.rs
@@ -14,6 +14,7 @@
 
 //! Provides validation logic for expected errors.
 use risingwave_expr::ExprError;
+use risingwave_frontend::optimizer::variant_key::VARIANT_KEY_HINT;
 
 /// Ignore errors related to `0`.
 fn is_zero_err(db_error: &str) -> bool {
@@ -55,6 +56,10 @@ fn is_window_error(db_error: &str) -> bool {
 // Streaming nested-loop join is not supported, as it is expensive.
 fn is_nested_loop_join_error(db_error: &str) -> bool {
     db_error.contains("Not supported: streaming nested-loop join")
+}
+
+fn is_variant_key_error(db_error: &str) -> bool {
+    db_error.contains(VARIANT_KEY_HINT)
 }
 
 fn is_subquery_unnesting_error(db_error: &str) -> bool {
@@ -119,6 +124,7 @@ pub fn is_permissible_error(db_error: &str) -> bool {
         || not_unique_error(db_error)
         || is_window_error(db_error)
         || is_nested_loop_join_error(db_error)
+        || is_variant_key_error(db_error)
         || is_subquery_unnesting_error(db_error)
         || is_numeric_overflow_error(db_error)
         || is_neg_substr_error(db_error)


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

`is_permissible_error` does not recognize the VARIANT-as-key rejection introduced in #26080, so sqlsmith treats a legitimate planner error as an unexpected one and panics at whichever harness `unwrap` sees it first — observed at `test_runners/fuzzing.rs:173`, `:223`, `:227` and `test_runners/utils.rs:97`:

```
Encountered unexpected error: db error: ERROR: Failed to run the query

Caused by:
  Not supported: VARIANT column "null:Variant" should not be in the aggregation group key.
HINT: VARIANT values only have byte-wise equality and ordering, so they cannot be used as a key: ...
```

sqlsmith readily generates expressions like `count(DISTINCT (CAST(NULL AS VARIANT)))`, so this is not rare: on plain main `3e6c791b61`, **6 of the 32 deterministic-fuzz seeds fail this way**. That is why `deterministic fuzz test` is red on PRs that have nothing to do with it.

The rejection is raised from several sites with different wording — `StreamKeyChecker` for grouping keys, distinct-agg arguments and join keys, and `reject_variant_keys` for `ORDER BY` — all of which attach the same `VARIANT_KEY_HINT`, documented as the stable string to assert on regardless of which layer fired. Matching that constant covers every variant without duplicating message text or drifting when wording changes.

## Verification

Applied to `3e6c791b61` and re-ran the failing seeds with `--sqlsmith 100`:

| Seed | Before | After |
|---|---|---|
| 5, 18, 20, 21, 26 | fail — VARIANT-as-key | **pass** |
| 8 | fail — `eq_join_predicate.rs:271` | **still fails**, same panic |
| 1, 2, 3, 14 (controls) | pass | pass |

Seed 8 is a genuine frontend panic unrelated to this change (tracked in #26730); it is listed to show the new predicate does not mask real failures.

The rejection is still raised and logged — it is only reclassified. On seed 5 the hint appears 3 times before the fix (server log, harness-logged error, panic payload) and 2 times after, with zero `panicked at` sites; the query and error text are otherwise identical.

`ci/run-deterministic-sqlsmith-fuzzing-tests` and `ci/run-sqlsmith-fuzzing-tests` are set on this PR so both harnesses exercise the change.

## Checklist

- [x] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [x] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/dev/src/ci.md#ci-labels-guide -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->

## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates.

<details>
<summary><b>Release note</b></summary>

Test-only change; no user-facing impact.

</details>
