### PR TITLE
fix(ci): stop deterministic fuzz test from wiping its own failure logs

### DIFF
--- a/ci/scripts/run-deterministic-fuzz-test.sh
+++ b/ci/scripts/run-deterministic-fuzz-test.sh
@@ -3,7 +3,8 @@
 # Exits as soon as any line fails.
 set -euo pipefail
 
-export LOGDIR=.risingwave/log
+# Outside `.risingwave/log`, which `risedev ci-start` wipes before and during reducing.
+export LOGDIR=fuzz-logs
 export RUST_LOG=info
 mkdir -p $LOGDIR
 
@@ -52,6 +53,7 @@ failed_logs=$(ls $LOGDIR/fuzzing-*.log 2>/dev/null || true)
 
 if [[ -n "$failed_logs" ]]; then
     echo "Simulation fuzzing failed, see logs in $LOGDIR"
+    buildkite-agent artifact upload "$LOGDIR/fuzzing-*.log"
     echo "--- e2e, ci-3cn-1fe, build for reducer to start"
     risedev ci-start ci-3cn-1fe
     for log_file in $failed_logs; do
@@ -61,13 +63,16 @@ if [[ -n "$failed_logs" ]]; then
 
         echo "Processing seed $seed (log: $log_file)"
         extract_error_sql "$log_file" > "$error_sql"
+        buildkite-agent artifact upload "$error_sql"
 
         echo "--- Running reducer on failing queries for seed $seed"
         ./target/debug/sqlsmith-reducer \
             --input-file "$error_sql" \
             --output-file "$shrunk_sql" \
             --run-rw-cmd './risedev k && ./risedev ci-start ci-3cn-1fe' \
-            > "$LOGDIR/reducer-$seed.log" 2>&1
+            > "$LOGDIR/reducer-$seed.log" 2>&1 || echo "Reducer failed for seed $seed"
+        # Per seed, so that hitting the job timeout mid-reduction loses at most the seed in flight.
+        buildkite-agent artifact upload "$LOGDIR/reducer-$seed.log;$shrunk_sql"
         echo "--- Reducer finished for seed $seed (log: $LOGDIR/reducer-$seed.log)"
         echo "Reduced queries saved at $shrunk_sql"
     done


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

`ci/scripts/run-deterministic-fuzz-test.sh` wrote `fuzzing-<seed>.log` into `.risingwave/log`, then ran `risedev ci-start` for the reducer. `ci-start` depends on `clean-data`, which `rm -rf`s that directory, so every failure log was gone before `extract_error_sql` read it; under `set -e` the script died on the missing file and the job uploaded nothing actionable (see build [#99585](https://buildkite.com/risingwavelabs/pull-request/builds/99585)). The reducer's `--run-rw-cmd` wipes the directory again on every iteration, so its own log was lost too.

- Keep all fuzz output in `fuzz-logs/`, which `risedev` never touches — no ordering or copy-around needed.
- Upload `fuzzing-*.log` before starting the cluster, and `error-*.log` / `reducer-*.log` after the reducer, with `buildkite-agent artifact upload` (the `upload-failure-logs` plugin only covers `.risingwave/log`).
- A reducer failure for one seed no longer skips the remaining seeds or the final upload.

Verified on this PR's own CI run ([build 99609](https://buildkite.com/risingwavelabs/pull-request/builds/99609), 3 seeds failed): the raw `fuzz-logs/fuzzing-{1,15,30}.log` were uploaded before the cluster started and survived the job hitting its 45-min timeout mid-reduction. Uploads are per seed because the reducer restarts the cluster on every iteration and can exceed the job timeout when several seeds fail — a timeout now loses at most the seed in flight. Also verified locally with stub `risedev`/reducer, including the reducer-exits-non-zero path.

- Closes #26729

## Checklist

- [x] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [x] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/dev/src/ci.md#ci-labels-guide -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->

## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

</details>
