### PR TITLE
cherry-pick fix(iceberg): use table-scoped COW compaction (#25855) to release-3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6955,7 +6955,7 @@ dependencies = [
 [[package]]
 name = "iceberg-compaction-core"
 version = "0.1.0"
-source = "git+https://github.com/nimtable/iceberg-compaction.git?rev=22078f205d3c841f1e02118adfe5fc869d90d38c#22078f205d3c841f1e02118adfe5fc869d90d38c"
+source = "git+https://github.com/nimtable/iceberg-compaction.git?rev=ad2190ac74870dbf4acbe3d6682920e403daffd7#ad2190ac74870dbf4acbe3d6682920e403daffd7"
 dependencies = [
  "async-stream",
  "async-trait",

--- a/e2e_test/iceberg/test_case/pure_slt/iceberg_copy_on_write.slt
+++ b/e2e_test/iceberg/test_case/pure_slt/iceberg_copy_on_write.slt
@@ -83,6 +83,43 @@ select count(*) from rw_iceberg_snapshots where schema_name = 'public' and sourc
 ----
 2
 
+# COW compaction for partitioned tables must publish all partitions atomically.
+statement ok
+create table t_cow_partitioned(p int, id int, v int, primary key(p, id))
+with(
+    commit_checkpoint_interval = 1,
+    partition_by = 'p',
+    write_mode = 'copy-on-write',
+    enable_snapshot_expiration = 'false'
+) engine = iceberg;
+
+statement ok
+insert into t_cow_partitioned values
+    (1, 1, 10), (1, 2, 20),
+    (2, 3, 30), (2, 4, 40),
+    (3, 5, 50), (3, 6, 60);
+
+statement ok
+flush;
+
+sleep 5s
+
+statement ok
+VACUUM FULL t_cow_partitioned;
+
+query ??? rowsort retry 6 backoff 1s
+select p, id, v from t_cow_partitioned order by p, id;
+----
+1 1 10
+1 2 20
+2 3 30
+2 4 40
+3 5 50
+3 6 60
+
+statement ok
+DROP TABLE t_cow_partitioned;
+
 statement ok
 DROP TABLE t_cow;
 

--- a/src/storage/Cargo.toml
+++ b/src/storage/Cargo.toml
@@ -33,7 +33,7 @@ futures = { version = "0.3", default-features = false, features = ["alloc"] }
 futures-async-stream = { workspace = true }
 hex = "0.4"
 iceberg = { workspace = true }
-iceberg-compaction-core = { git = "https://github.com/nimtable/iceberg-compaction.git", rev = "22078f205d3c841f1e02118adfe5fc869d90d38c" }
+iceberg-compaction-core = { git = "https://github.com/nimtable/iceberg-compaction.git", rev = "ad2190ac74870dbf4acbe3d6682920e403daffd7" }
 itertools = { workspace = true }
 libc = "0.2"
 lz4 = "1.28.0"

--- a/src/storage/src/hummock/compactor/iceberg_compaction/iceberg_compactor_runner.rs
+++ b/src/storage/src/hummock/compactor/iceberg_compaction/iceberg_compactor_runner.rs
@@ -24,8 +24,9 @@ use iceberg_compaction_core::compaction::{
     CompactionPlanner, CompactionResult,
 };
 use iceberg_compaction_core::config::{
-    CompactionExecutionConfigBuilder, CompactionPlanningConfig, FilesWithDeletesConfigBuilder,
-    FullCompactionConfigBuilder, GroupFilters, SmallFilesConfigBuilder,
+    CompactionExecutionConfigBuilder, CompactionPlanningConfig, FileGroupScope,
+    FilesWithDeletesConfigBuilder, FullCompactionConfigBuilder, GroupFilters,
+    SmallFilesConfigBuilder,
 };
 use iceberg_compaction_core::executor::RewriteFilesStat;
 use mixtrics::registry::prometheus::PrometheusMetricsRegistry;
@@ -479,6 +480,8 @@ pub async fn create_task_execution(
 
     let parsed_task_type = TaskType::try_from(task_type)
         .map_err(|e| HummockError::compaction_executor(e.as_report()))?;
+    let should_use_cow =
+        should_enable_iceberg_cow(iceberg_config.r#type.as_str(), iceberg_config.write_mode);
 
     let planning_config = match parsed_task_type {
         TaskType::SmallFiles => {
@@ -504,6 +507,11 @@ pub async fn create_task_execution(
             CompactionPlanningConfig::SmallFiles(config)
         }
         TaskType::Full => {
+            let file_group_scope = if should_use_cow {
+                FileGroupScope::Table
+            } else {
+                FileGroupScope::Partition
+            };
             let config = FullCompactionConfigBuilder::default()
                 .max_input_parallelism(config.max_parallelism as usize)
                 .max_output_parallelism(config.max_parallelism as usize)
@@ -512,6 +520,7 @@ pub async fn create_task_execution(
                 .target_file_size_bytes(iceberg_config.target_file_size_mb() * 1024 * 1024)
                 .enable_heuristic_output_parallelism(config.enable_heuristic_output_parallelism)
                 .grouping_strategy(grouping_strategy)
+                .file_group_scope(file_group_scope)
                 .build()
                 .map_err(|e| HummockError::compaction_executor(e.as_report()))?;
 


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

Backport #25855 to `release-3.0` to fix a correctness issue in full compaction of partitioned Iceberg Copy-on-Write tables.

Previously, full compaction planned one rewrite per partition. Each Copy-on-Write commit replaced the table's current files while writing back only that plan's partition, so successive commits could leave only the last partition visible.

This PR:

- uses table-scoped file groups for full Copy-on-Write compaction, so all partitions are rewritten and published atomically;
- keeps partition-scoped planning for non-Copy-on-Write compaction;
- pins `iceberg-compaction-core` to [`ad2190a`](https://github.com/nimtable/iceberg-compaction/commit/ad2190ac74870dbf4acbe3d6682920e403daffd7), a minimal backport of [nimtable/iceberg-compaction#147](https://github.com/nimtable/iceberg-compaction/pull/147) onto the release-compatible dependency revision; and
- adds an Iceberg SLT covering `VACUUM FULL` on a three-partition Copy-on-Write table and verifying that every partition remains visible.

Related upstream fix: #25855.

## Checklist

- [x] I have written necessary rustdoc comments.
- [x] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [x] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [x] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->

## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

Fix a RisingWave 3.0 correctness issue where `VACUUM FULL` on a partitioned Iceberg Copy-on-Write table could publish a snapshot containing only one partition. Full compaction now publishes all partitions atomically. This prevents future incorrect compaction snapshots; it does not restore data omitted by snapshots created before the fix.

</details>
