### PR TITLE
fix(sink): rate limit kafka producer backpressure warnings

### DIFF
--- a/src/connector/src/sink/kafka.rs
+++ b/src/connector/src/sink/kafka.rs
@@ -14,7 +14,7 @@
 
 use std::collections::BTreeMap;
 use std::fmt::Debug;
-use std::sync::Arc;
+use std::sync::{Arc, LazyLock};
 use std::time::Duration;
 
 use anyhow::anyhow;
@@ -26,6 +26,7 @@ use rdkafka::producer::{DeliveryFuture, FutureProducer, FutureRecord};
 use rdkafka::types::RDKafkaErrorCode;
 use risingwave_common::array::StreamChunk;
 use risingwave_common::catalog::Schema;
+use risingwave_common::log::LogSuppressor;
 use serde::Deserialize;
 use serde_with::{DisplayFromStr, serde_as};
 use strum_macros::{Display, EnumString};
@@ -524,44 +525,54 @@ impl KafkaPayloadWriter<'_> {
         for i in 0..self.config.max_retry_num {
             match self.inner.send_result(record) {
                 Ok(delivery_future) => {
-                    if self
+                    // The buffer holds delivery futures that we have not polled yet, including
+                    // those of records already acked by the broker, so reaching the cap is
+                    // ordinary backpressure rather than an anomaly.
+                    let awaited = self
                         .add_future
                         .add_future_may_await(map_delivery_future(delivery_future))
-                        .await?
-                    {
-                        tracing::warn!(
-                            "Number of records being delivered ({}) >= expected kafka producer queue size ({}).
-                            This indicates the default value of queue.buffering.max.messages has changed.",
-                            self.add_future.future_count(),
-                            self.add_future.max_future_count()
-                        );
+                        .await?;
+                    if awaited {
+                        static LOG_SUPPRESSOR: LazyLock<LogSuppressor> =
+                            LazyLock::new(LogSuppressor::default);
+                        if let Ok(suppressed_count) = LOG_SUPPRESSOR.check() {
+                            tracing::warn!(
+                                suppressed_count,
+                                future_count = self.add_future.future_count(),
+                                max_future_count = self.add_future.max_future_count(),
+                                "delivery future buffer is full, awaited an outstanding delivery before enqueuing"
+                            );
+                        }
                     }
                     success_flag = true;
                     break;
                 }
-                // The enqueue buffer is full, `send_result` will immediately return
-                // We can retry for another round after sleeping for sometime
-                Err((e, rec)) => {
-                    tracing::warn!(
-                        error = %e.as_report(),
-                        "producing message (key {:?}) to topic {} failed",
-                        rec.key.map(|k| k.to_bytes()),
-                        rec.topic,
-                    );
-                    record = rec;
-                    match e {
-                        KafkaError::MessageProduction(RDKafkaErrorCode::QueueFull) => {
+                Err((e, rec)) => match e {
+                    KafkaError::MessageProduction(RDKafkaErrorCode::QueueFull) => {
+                        record = rec;
+                        static LOG_SUPPRESSOR: LazyLock<LogSuppressor> =
+                            LazyLock::new(LogSuppressor::default);
+                        if let Ok(suppressed_count) = LOG_SUPPRESSOR.check() {
                             tracing::warn!(
-                                "Producer queue full. Delivery future buffer size={}. Await and retry #{}",
-                                self.add_future.future_count(),
-                                i
+                                suppressed_count,
+                                future_count = self.add_future.future_count(),
+                                retry = i,
+                                "producer queue is full, awaiting an outstanding delivery before retry"
                             );
-                            self.add_future.await_one_delivery().await?;
-                            continue;
                         }
-                        _ => return Err(e.into()),
+                        self.add_future.await_one_delivery().await?;
+                        continue;
                     }
-                }
+                    _ => {
+                        tracing::warn!(
+                            error = %e.as_report(),
+                            "producing message (key {:?}) to topic {} failed",
+                            rec.key.map(|k| k.to_bytes()),
+                            rec.topic,
+                        );
+                        return Err(e.into());
+                    }
+                },
             }
         }
 


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

`KafkaPayloadWriter::send_result` runs once per record, and two warnings on that path are unbounded:

- **Delivery-future buffer full** — fires whenever `add_future_may_await` had to await. Once the buffer is saturated it returns to the cap after every enqueue, so this fires *once per record* for as long as backpressure lasts. A production backfill emitted ~843k identical lines in 7 seconds.
- **`QueueFull`** — logged twice per attempt (the generic `producing message ... failed` log sits above the `match`, and the `QueueFull` arm logs again), repeated for each of `properties.retry.max` attempts.

Changes:

- Rate-limit both warnings with `LogSuppressor` (1/s each, carrying `suppressed_count`).
- Move the generic failure log into the non-`QueueFull` arm so each send failure logs once.
- Reword the buffer-full message. It claimed `This indicates the default value of queue.buffering.max.messages has changed`, assuming our 1.2x buffer cap is unreachable because librdkafka refuses new messages at 1.0x. It isn't: the buffer holds delivery futures we have not polled yet, including those of records already acked by the broker, so it reaches the cap under ordinary backpressure.

Logging only — no behavior change.

## Checklist

- [x] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary.
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them.
- [ ] <!-- OPTIONAL --> My PR contains breaking changes.
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results.
- [ ] <!-- OPTIONAL --> I have checked the Release Timeline and Currently Supported Versions to determine which release branches I need to cherry-pick this PR into.

## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates.

<details>
<summary><b>Release note</b></summary>

</details>
