### PR TITLE
fix(optimizer): stop the lookup prefix at a duplicated order-key column

### DIFF
--- a/e2e_test/batch/join/issue_26730.slt
+++ b/e2e_test/batch/join/issue_26730.slt
@@ -1,0 +1,29 @@
+# Batch lookup join on an MV whose ORDER BY repeats a column used to panic the
+# frontend (https://github.com/risingwavelabs/risingwave/issues/26730). The join
+# below returns empty if the lookup prefix binds b against the repeated `a`.
+
+statement ok
+SET RW_IMPLICIT_FLUSH TO true;
+
+statement ok
+set rw_batch_enable_lookup_join = true;
+
+statement ok
+create table t (a int, b int);
+
+statement ok
+insert into t values (1, 10), (1, 20), (2, 30);
+
+statement ok
+create materialized view mv as select a, b from t order by a, a, b limit 1;
+
+query II
+select t.a, t.b from t join mv on t.a = mv.a and t.b = mv.b;
+----
+1 10
+
+statement ok
+drop materialized view mv;
+
+statement ok
+drop table t;

--- a/src/frontend/planner_test/tests/testdata/input/distributed_lookup_join.yaml
+++ b/src/frontend/planner_test/tests/testdata/input/distributed_lookup_join.yaml
@@ -45,3 +45,11 @@
     select * from t1 join mv1 on t1.b = mv1.b;
   expected_outputs:
     - batch_plan
+- id: fix https://github.com/risingwavelabs/risingwave/issues/26730
+  sql: |
+    create table t1 (a int);
+    create materialized view mv1 as select a from t1 order by a, a limit 1;
+    select t1.a from t1 join mv1 on t1.a = mv1.a;
+  expected_outputs:
+    - batch_plan
+    - batch_local_plan

--- a/src/frontend/planner_test/tests/testdata/input/temporal_join.yaml
+++ b/src/frontend/planner_test/tests/testdata/input/temporal_join.yaml
@@ -183,3 +183,11 @@
     select id1, a1, id2, v1 from stream left join version FOR SYSTEM_TIME AS OF PROCTIME() on id1 = id2;
   expected_outputs:
     - stream_plan
+- name: temporal join on an MV with a duplicated order key
+  sql: |
+    create table stream (a int, b int) APPEND ONLY;
+    create table version (a int, b int);
+    create materialized view v_mv as select a, b from version order by a, a limit 1;
+    select stream.a, stream.b from stream join v_mv FOR SYSTEM_TIME AS OF PROCTIME() on stream.a = v_mv.a;
+  expected_outputs:
+    - stream_plan

--- a/src/frontend/planner_test/tests/testdata/output/distributed_lookup_join.yaml
+++ b/src/frontend/planner_test/tests/testdata/output/distributed_lookup_join.yaml
@@ -69,3 +69,17 @@
       │ └─BatchScan { table: t1, columns: [t1.a, t1.b], distribution: SomeShard }
       └─BatchExchange { order: [], dist: HashShard(mv1.b) }
         └─BatchScan { table: mv1, columns: [mv1.a, mv1.b], distribution: Single }
+- id: fix https://github.com/risingwavelabs/risingwave/issues/26730
+  sql: |
+    create table t1 (a int);
+    create materialized view mv1 as select a from t1 order by a, a limit 1;
+    select t1.a from t1 join mv1 on t1.a = mv1.a;
+  batch_plan: |-
+    BatchExchange { order: [], dist: Single }
+    └─BatchLookupJoin { type: Inner, predicate: t1.a = mv1.a, output: [t1.a], lookup table: mv1 }
+      └─BatchExchange { order: [], dist: Single }
+        └─BatchScan { table: t1, columns: [t1.a], distribution: SomeShard }
+  batch_local_plan: |-
+    BatchLookupJoin { type: Inner, predicate: t1.a = mv1.a, output: [t1.a], lookup table: mv1 }
+    └─BatchExchange { order: [], dist: Single }
+      └─BatchScan { table: t1, columns: [t1.a], distribution: SomeShard }

--- a/src/frontend/planner_test/tests/testdata/output/temporal_join.yaml
+++ b/src/frontend/planner_test/tests/testdata/output/temporal_join.yaml
@@ -325,3 +325,16 @@
         │ └─StreamTableScan { table: stream, columns: [stream.id1, stream.a1, stream.v1, stream._row_id], stream_scan_type: ArrangementBackfill, stream_key: [stream._row_id], pk: [_row_id], dist: UpstreamHashShard(stream._row_id) }
         └─StreamExchange [no_shuffle] { dist: UpstreamHashShard(version.id2) }
           └─StreamTableScan { table: version, columns: [version.id2], stream_scan_type: UpstreamOnly, stream_key: [version.id2], pk: [id2], dist: UpstreamHashShard(version.id2) }
+- name: temporal join on an MV with a duplicated order key
+  sql: |
+    create table stream (a int, b int) APPEND ONLY;
+    create table version (a int, b int);
+    create materialized view v_mv as select a, b from version order by a, a limit 1;
+    select stream.a, stream.b from stream join v_mv FOR SYSTEM_TIME AS OF PROCTIME() on stream.a = v_mv.a;
+  stream_plan: |-
+    StreamMaterialize { columns: [a, b, stream._row_id(hidden)], stream_key: [stream._row_id, a], pk_columns: [stream._row_id, a], pk_conflict: NoCheck }
+    └─StreamTemporalJoin { type: Inner, append_only: true, predicate: stream.a = v_mv.a, nested_loop: false, output: [stream.a, stream.b, stream._row_id] }
+      ├─StreamExchange { dist: Single }
+      │ └─StreamTableScan { table: stream, columns: [stream.a, stream.b, stream._row_id], stream_scan_type: ArrangementBackfill, stream_key: [stream._row_id], pk: [_row_id], dist: UpstreamHashShard(stream._row_id) }
+      └─StreamExchange [no_shuffle] { dist: Single }
+        └─StreamTableScan { table: v_mv, columns: [v_mv.a], stream_scan_type: UpstreamOnly, stream_key: [], pk: [a, a], dist: Single }

--- a/src/frontend/src/optimizer/plan_node/logical_join.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_join.rs
@@ -18,6 +18,7 @@ use std::ops::Deref;
 use fixedbitset::FixedBitSet;
 use itertools::{EitherOrBoth, Itertools};
 use pretty_xmlish::{Pretty, XmlNode};
+use risingwave_common::catalog::ColumnId;
 use risingwave_expr::bail;
 use risingwave_pb::expr::expr_node::PbType;
 use risingwave_pb::plan_common::{AsOfJoinDesc, JoinType, PbAsOfJoinInequalityType};
@@ -348,6 +349,33 @@ impl LogicalJoin {
         Self::gen_batch_lookup_join(logical_scan, predicate, logical_join, self.is_asof_join())
     }
 
+    /// Decides the lookup prefix, as a reordering of the eq keys, by matching the lookup
+    /// table's order-key columns. The executor binds eq keys to the order key positionally,
+    /// so a repeated order-key column (e.g. an MV with `ORDER BY a, a`) ends the prefix.
+    fn lookup_prefix_reorder_idx(
+        predicate: &EqJoinPredicate,
+        output_column_ids: &[ColumnId],
+        order_col_ids: &[ColumnId],
+    ) -> Vec<usize> {
+        let mut reorder_idx = Vec::with_capacity(order_col_ids.len());
+        for order_col_id in order_col_ids {
+            let mut found = false;
+            for (i, eq_idx) in predicate.right_eq_indexes().into_iter().enumerate() {
+                if *order_col_id == output_column_ids[eq_idx] {
+                    if !reorder_idx.contains(&i) {
+                        reorder_idx.push(i);
+                        found = true;
+                    }
+                    break;
+                }
+            }
+            if !found {
+                break;
+            }
+        }
+        reorder_idx
+    }
+
     pub fn gen_batch_lookup_join(
         logical_scan: &LogicalScan,
         predicate: EqJoinPredicate,
@@ -391,20 +419,8 @@ impl LogicalJoin {
             .map_or(1, |pos| pos + 1);
 
         // Reorder the join equal predicate to match the order key.
-        let mut reorder_idx = Vec::with_capacity(shortest_prefix_len);
-        for order_col_id in order_col_ids {
-            let mut found = false;
-            for (i, eq_idx) in predicate.right_eq_indexes().into_iter().enumerate() {
-                if order_col_id == output_column_ids[eq_idx] {
-                    reorder_idx.push(i);
-                    found = true;
-                    break;
-                }
-            }
-            if !found {
-                break;
-            }
-        }
+        let reorder_idx =
+            Self::lookup_prefix_reorder_idx(&predicate, &output_column_ids, &order_col_ids);
         if reorder_idx.len() < shortest_prefix_len {
             return Ok(None);
         }
@@ -1269,20 +1285,8 @@ impl LogicalJoin {
             .map_or(0, |pos| pos + 1);
 
         // Reorder the join equal predicate to match the order key.
-        let mut reorder_idx = Vec::with_capacity(shortest_prefix_len);
-        for order_col_id in order_col_ids {
-            let mut found = false;
-            for (i, eq_idx) in predicate.right_eq_indexes().into_iter().enumerate() {
-                if order_col_id == output_column_ids[eq_idx] {
-                    reorder_idx.push(i);
-                    found = true;
-                    break;
-                }
-            }
-            if !found {
-                break;
-            }
-        }
+        let reorder_idx =
+            Self::lookup_prefix_reorder_idx(&predicate, &output_column_ids, &order_col_ids);
         if reorder_idx.len() < shortest_prefix_len {
             return Err(RwError::from(ErrorCode::NotSupported(
                 "Temporal join requires the equivalence join condition includes the key columns that form the distribution key of the lookup table".into(),


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

A batch lookup join (and, it turns out, a stream temporal join) against a materialized view whose `ORDER BY` repeats a column panicked the frontend on `assert!(reorder_idx.len() <= self.eq_keys.len())` in `EqJoinPredicate::reorder`. Three statements reproduce it (see the issue).

- A TopN MV stores `order by a, a` verbatim, so `order_column_ids()` returns `[a, a]`; the eq-key reorder loops matched both entries to the same eq key and pushed its index twice.
- Fix: extract the loop into `lookup_prefix_reorder_idx`, shared by `gen_batch_lookup_join` and `to_stream_temporal_join`. A repeated order-key column maps to an eq key already bound to an earlier position; the executor binds eq keys to the order key positionally, so the prefix must stop there (skipping and continuing would bind the wrong value against the repeated pk column). Remaining eq keys are evaluated after the lookup, as for any non-prefix eq key.
- The batch path regressed in #26597 (singleton lookup tables became eligible); the temporal path was reachable all along (its shortest-prefix requirement can be 0) and also affects earlier releases.
- Tests: planner cases for both paths (the temporal one previously panicked in-process) plus an e2e slt that returns a wrong (empty) result under the skip-and-continue misfix, so it pins positional correctness, not just absence of panic.
- Originally surfaced by the `deterministic fuzz test` job; the fuzz label is added to exercise it on this PR.

- Closes #26730

## Follow-ups

- #26747: TopN MVs should not store duplicated `ORDER BY` columns in their primary key in the first place; plan-side tolerance must stay regardless for existing catalogs.

## Checklist

- [x] I have written necessary rustdoc comments.
- [x] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [x] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/dev/src/ci.md#ci-labels-guide -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [x] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) --> (batch path: post-2.8 only, #26597 is not in release-2.8; temporal path: pre-existing in older releases — cherry-pick judgment left to maintainers)

## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

</details>
