### PR TITLE
refactor(meta): limit commit epoch latency scope

### DIFF
--- a/src/meta/src/hummock/manager/commit_epoch.rs
+++ b/src/meta/src/hummock/manager/commit_epoch.rs
@@ -405,14 +405,10 @@ impl HummockManager {
         }
         trigger_epoch_stat(&self.metrics, &versioning.current_version);
         timer.observe_duration();
+        total_timer.observe_duration();
 
         drop(versioning_guard);
 
-        let timer = self
-            .metrics
-            .commit_epoch_latency
-            .with_label_values(&["trigger_compaction"])
-            .start_timer();
         // Don't trigger compactions if we enable deterministic compaction
         if !self.env.opts.compaction_deterministic_test {
             // commit_epoch may contains SSTs from any compaction group
@@ -424,23 +420,15 @@ impl HummockManager {
                     .await;
             }
         }
-        timer.observe_duration();
 
-        let timer = self
-            .metrics
-            .commit_epoch_latency
-            .with_label_values(&["update_write_limits"])
-            .start_timer();
         if !modified_compaction_groups.is_empty() {
             self.try_update_write_limits(&modified_compaction_groups)
                 .await;
         }
-        timer.observe_duration();
         #[cfg(test)]
         {
             self.check_state_consistency().await;
         }
-        total_timer.observe_duration();
         Ok(())
     }
 

--- a/src/meta/src/rpc/metrics.rs
+++ b/src/meta/src/rpc/metrics.rs
@@ -597,7 +597,7 @@ impl MetaMetrics {
 
         let opts = histogram_opts!(
             "storage_commit_epoch_latency",
-            "latency of each hummock commit epoch section after acquiring the versioning lock",
+            "latency of each hummock commit epoch section while holding the versioning lock",
             exponential_buckets(0.001, 5.0, 8).unwrap()
         );
         let commit_epoch_latency =


### PR DESCRIPTION
## Summary

- stop the total commit epoch latency timer before releasing the versioning guard
- stop emitting commit epoch sections for post-unlock compaction triggering and write-limit updates
- clarify that the metric covers work while holding the versioning lock

## Testing

- cargo fmt --check -- src/meta/src/hummock/manager/commit_epoch.rs src/meta/src/rpc/metrics.rs
- git diff --check
- cargo check -p risingwave_meta --lib