### PR TITLE
perf(meta): skip SST retention checks without GC history

### DIFF
--- a/src/meta/src/hummock/manager/context.rs
+++ b/src/meta/src/hummock/manager/context.rs
@@ -254,20 +254,17 @@ impl HummockManager {
         }
 
         // HummockManager::now requires a write to the meta store. Thus, it should be avoided whenever feasible.
-        if !sstables.is_empty() {
+        if self.env.opts.gc_history_retention_time_sec != 0 && !sstables.is_empty() {
             // Sanity check to ensure SSTs to commit have not been full GCed yet.
-            let now = self.now().await?;
             check_sst_retention(
-                now,
+                self.now().await?,
                 self.env.opts.min_sst_retention_time_sec,
                 sstables
                     .iter()
                     .map(|s| (s.sst_info.object_id, s.created_at)),
             )?;
-            if self.env.opts.gc_history_retention_time_sec != 0 {
-                let ids = sstables.iter().map(|s| s.sst_info.object_id).collect_vec();
-                check_gc_history(&self.meta_store_ref().conn, ids).await?;
-            }
+            let ids = sstables.iter().map(|s| s.sst_info.object_id).collect_vec();
+            check_gc_history(&self.meta_store_ref().conn, ids).await?;
         }
 
         async {
@@ -314,19 +311,16 @@ impl HummockManager {
         object_timestamps: &HashMap<HummockSstableObjectId, u64>,
     ) -> Result<()> {
         // HummockManager::now requires a write to the meta store. Thus, it should be avoided whenever feasible.
-        if object_timestamps.is_empty() {
+        if self.env.opts.gc_history_retention_time_sec == 0 || object_timestamps.is_empty() {
             return Ok(());
         }
-        let now = self.now().await?;
         check_sst_retention(
-            now,
+            self.now().await?,
             self.env.opts.min_sst_retention_time_sec,
             object_timestamps.iter().map(|(k, v)| (*k, *v)),
         )?;
-        if self.env.opts.gc_history_retention_time_sec != 0 {
-            let ids = object_timestamps.keys().copied().collect_vec();
-            check_gc_history(&self.meta_store_ref().conn, ids).await?;
-        }
+        let ids = object_timestamps.keys().copied().collect_vec();
+        check_gc_history(&self.meta_store_ref().conn, ids).await?;
         Ok(())
     }
 }

--- a/src/meta/src/hummock/manager/tests.rs
+++ b/src/meta/src/hummock/manager/tests.rs
@@ -1007,6 +1007,42 @@ async fn test_invalid_sst_id() {
 }
 
 #[tokio::test]
+async fn test_sst_retention_check_is_disabled_without_gc_history() {
+    let mut opts = MetaOpts::test(false);
+    opts.gc_history_retention_time_sec = 0;
+    let (_env, hummock_manager, _cluster_manager, _worker_id) =
+        setup_compute_env_with_meta_opts(80, opts).await;
+    let current_version = hummock_manager.get_current_version().await;
+
+    assert!(hummock_manager.load_now().await.unwrap().is_none());
+    hummock_manager
+        .commit_epoch_sanity_check(
+            &HashMap::new(),
+            &[gen_local_sstable_info(1, vec![1], test_epoch(1))],
+            &HashMap::new(),
+            &current_version,
+        )
+        .await
+        .unwrap();
+    assert!(hummock_manager.load_now().await.unwrap().is_none());
+
+    hummock_manager
+        .commit_epoch_sanity_check(
+            &HashMap::new(),
+            &[LocalSstableInfo {
+                sst_info: gen_sstable_info(2, vec![1], test_epoch(1)),
+                table_stats: Default::default(),
+                created_at: 0,
+            }],
+            &HashMap::new(),
+            &current_version,
+        )
+        .await
+        .unwrap();
+    assert!(hummock_manager.load_now().await.unwrap().is_none());
+}
+
+#[tokio::test]
 async fn test_trigger_manual_compaction() {
     let (_, hummock_manager, _, worker_id) = setup_compute_env(80).await;
     let hummock_meta_client: Arc<dyn HummockMetaClient> = Arc::new(MockHummockMetaClient::new(


### PR DESCRIPTION
## Summary

- skip commit-epoch SST retention and GC-history checks when `gc_history_retention_time_sec` is zero
- skip the corresponding compaction-result sanity check in the same configuration
- avoid the `HUMMOCK_NOW` meta-store write in `storage_commit_epoch_latency{section="sanity_check"}`
- add regression coverage confirming the retention check is disabled and `HUMMOCK_NOW` is not persisted

## Testing

- `cargo test -p risingwave_meta test_sst_retention_check_is_disabled_without_gc_history --lib`
- `cargo test -p risingwave_meta test_invalid_sst_id --lib`
- `cargo fmt --all -- --check`
- `git diff --check`