### PR TITLE
perf(meta): isolate version checkpoint runtime

### DIFF
--- a/src/meta/src/hummock/mod.rs
+++ b/src/meta/src/hummock/mod.rs
@@ -186,7 +186,7 @@ pub fn start_checkpoint_loop(
                     tracing::warn!(error = %err.as_report(), "Hummock version checkpoint error.");
                 }
                 Err(err) => {
-                    tracing::warn!(error = %err, "Hummock version checkpoint task failed.");
+                    tracing::warn!(error = %err.as_report(), "Hummock version checkpoint task failed.");
                 }
                 Ok(Ok(_)) => {
                     let backup_manager_2 = backup_manager.clone();

--- a/src/meta/src/hummock/mod.rs
+++ b/src/meta/src/hummock/mod.rs
@@ -27,6 +27,7 @@ pub mod mock_hummock_meta_client;
 pub mod model;
 pub mod test_utils;
 use std::collections::{HashMap, HashSet};
+use std::sync::LazyLock;
 use std::time::Duration;
 
 pub use compactor_manager::*;
@@ -34,6 +35,7 @@ use futures::future::BoxFuture;
 #[cfg(any(test, feature = "test"))]
 pub use mock_hummock_meta_client::MockHummockMetaClient;
 use risingwave_common::catalog::TableId;
+use tokio::runtime::Runtime;
 use tokio::sync::oneshot::Sender;
 use tokio::task::JoinHandle;
 
@@ -42,6 +44,17 @@ use crate::backup_restore::BackupManagerRef;
 
 type PinnedSnapshotEpochsFetcher =
     Box<dyn Fn() -> BoxFuture<'static, Option<HashMap<TableId, HashSet<u64>>>> + Send>;
+
+// Building and compressing a large checkpoint can spend a long time without yielding. Keep that
+// work off the main meta runtime so it cannot monopolize one of its worker threads.
+static VERSION_CHECKPOINT_RUNTIME: LazyLock<Runtime> = LazyLock::new(|| {
+    tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(1)
+        .thread_name("rw-version-checkpoint")
+        .enable_all()
+        .build()
+        .expect("failed to build hummock version checkpoint runtime")
+});
 
 /// Start hummock's asynchronous tasks.
 pub fn start_hummock_workers(
@@ -160,14 +173,22 @@ pub fn start_checkpoint_loop(
             {
                 continue;
             }
-            match hummock_manager
-                .create_version_checkpoint(min_delta_log_num)
+            let checkpoint_manager = hummock_manager.clone();
+            match VERSION_CHECKPOINT_RUNTIME
+                .spawn(async move {
+                    checkpoint_manager
+                        .create_version_checkpoint(min_delta_log_num)
+                        .await
+                })
                 .await
             {
-                Err(err) => {
+                Ok(Err(err)) => {
                     tracing::warn!(error = %err.as_report(), "Hummock version checkpoint error.");
                 }
-                _ => {
+                Err(err) => {
+                    tracing::warn!(error = %err, "Hummock version checkpoint task failed.");
+                }
+                Ok(Ok(_)) => {
                     let backup_manager_2 = backup_manager.clone();
                     let hummock_manager_2 = hummock_manager.clone();
                     tokio::task::spawn(async move {


### PR DESCRIPTION
## Summary

- forward-port #26754 from the release branch to `main`
- run Hummock version checkpoint creation on a dedicated single-worker Tokio runtime
- keep the checkpoint timer loop and minor GC on the main meta runtime
- report failures from the dedicated runtime task

## Testing

- `cargo fmt --all -- --check`
- `cargo check -p risingwave_meta --lib`
- `git diff --check origin/main...HEAD`

The original PR also passed `cargo test -p risingwave_meta decode_checkpoint_data_roundtrips_envelope_with_checksum --lib`.