### PR TITLE
cherry-pick fix(stream): keep sink into table upsert semantics with preserve_row_level_changes (#26713) to release-3.0

### DIFF
--- a/e2e_test/sink/sink_into_table/stream_key_mismatch_partial_update.slt
+++ b/e2e_test/sink/sink_into_table/stream_key_mismatch_partial_update.slt
@@ -1,0 +1,58 @@
+statement ok
+SET RW_IMPLICIT_FLUSH TO true;
+
+statement ok
+create table wide_t (id int primary key, col_a int, col_b int) on conflict do update if not null;
+
+statement ok
+create table l (id int primary key, col_a int);
+
+statement ok
+create table r (rid int primary key, id int);
+
+statement ok
+create sink sink_a into wide_t (id, col_a) as
+select l.id, l.col_a from l join r on l.id = r.id;
+
+statement ok
+insert into l values (1, 10);
+
+statement ok
+insert into r values (1, 1), (2, 99);
+
+statement ok
+insert into wide_t (id, col_b) values (1, 100);
+
+query III
+select id, col_a, col_b from wide_t order by id;
+----
+1 10 100
+
+# The join row of `id = 1` moves to another stream key within one barrier. It must be applied
+# as an update to `wide_t`, keeping `col_b`.
+statement ok
+update r set id = case rid when 1 then 99 else 1 end;
+
+query III
+select id, col_a, col_b from wide_t order by id;
+----
+1 10 100
+
+statement ok
+delete from l where id = 1;
+
+query III
+select id, col_a, col_b from wide_t order by id;
+----
+
+statement ok
+drop sink sink_a;
+
+statement ok
+drop table wide_t;
+
+statement ok
+drop table l;
+
+statement ok
+drop table r;

--- a/src/stream/src/executor/sink.rs
+++ b/src/stream/src/executor/sink.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use std::assert_matches::assert_matches;
-use std::collections::{BTreeMap, HashMap};
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::mem;
 use std::time::{Duration, Instant};
 
@@ -26,6 +26,7 @@ use risingwave_common::array::stream_chunk::StreamChunkMut;
 use risingwave_common::bitmap::Bitmap;
 use risingwave_common::catalog::{ColumnCatalog, Field};
 use risingwave_common::metrics::{GLOBAL_ERROR_METRICS, LabelGuardedIntGauge};
+use risingwave_common::row::RowExt;
 use risingwave_common_estimate_size::EstimateSize;
 use risingwave_common_estimate_size::collections::EstimatedVec;
 use risingwave_common_rate_limit::RateLimit;
@@ -101,6 +102,32 @@ fn force_delete_only(c: StreamChunk) -> StreamChunk {
         }
     }
     c.into()
+}
+
+// Drop the DELETE messages whose downstream key is inserted again in the same barrier, since such
+// a key is updated rather than deleted from the downstream's perspective.
+fn drop_deletes_of_reinserted_keys(
+    delete_chunks: Vec<StreamChunk>,
+    insert_chunks: &[StreamChunk],
+    downstream_pk: &[usize],
+) -> Vec<StreamChunk> {
+    let inserted_keys: HashSet<_> = insert_chunks
+        .iter()
+        .flat_map(|c| c.rows())
+        .map(|(_, row)| row.project(downstream_pk))
+        .collect();
+    delete_chunks
+        .into_iter()
+        .map(|c| {
+            let mut c: StreamChunkMut = c.into();
+            for (row, mut r) in c.to_rows_mut() {
+                if inserted_keys.contains(&row.project(downstream_pk)) {
+                    r.set_vis(false);
+                }
+            }
+            c.into()
+        })
+        .collect()
 }
 
 /// When the sink is non-append-only, i.e. upsert or retract, we need to do some extra work for
@@ -606,11 +633,6 @@ impl<F: LogStoreFactory> SinkExecutor<F> {
                                 insert_chunks.push(chunk);
                             }
                         }
-                        let chunks = delete_chunks
-                            .into_iter()
-                            .chain(insert_chunks.into_iter())
-                            .collect();
-
                         // 2. If user specifies a primary key, compact the chunk based on the **downstream pk**
                         //    to eliminate any unnecessary updates to external systems. This also rewrites the
                         //    `DELETE` and `INSERT` operations on the same key into `UPDATE` operations, which
@@ -620,6 +642,10 @@ impl<F: LogStoreFactory> SinkExecutor<F> {
                         if let Some(downstream_pk) = &downstream_pk
                             && !preserve_row_level_changes
                         {
+                            let chunks = delete_chunks
+                                .into_iter()
+                                .chain(insert_chunks.into_iter())
+                                .collect();
                             let chunks = dispatch_output_kind!(sink_type, KIND, {
                                 StreamChunkCompactor::new(downstream_pk.clone(), chunks)
                                     .into_compacted_chunks_reconstructed::<KIND>(
@@ -634,9 +660,18 @@ impl<F: LogStoreFactory> SinkExecutor<F> {
                                 yield Message::Chunk(c);
                             }
                         } else {
+                            if let Some(downstream_pk) = &downstream_pk
+                                && compact_output_kind(sink_type) == output_kind::UPSERT
+                            {
+                                delete_chunks = drop_deletes_of_reinserted_keys(
+                                    delete_chunks,
+                                    &insert_chunks,
+                                    downstream_pk,
+                                );
+                            }
                             let mut chunk_builder =
                                 StreamChunkBuilder::new(chunk_size, input_data_types.clone());
-                            for chunk in chunks {
+                            for chunk in delete_chunks.into_iter().chain(insert_chunks) {
                                 for (op, row) in chunk.rows() {
                                     if let Some(c) = chunk_builder.append_row(op, row) {
                                         yield Message::Chunk(c);
@@ -1529,6 +1564,15 @@ mod test {
                   + 1 20  2",
             )),
             Message::Barrier(Barrier::new_test_barrier(test_epoch(2))),
+            // Downstream key 1 moves to a new stream key, while downstream key 2 is really deleted.
+            Message::Chunk(StreamChunk::from_pretty(
+                " I  I  I
+                  - 1 10  1
+                  - 1 20  2
+                  + 1 30  3
+                  - 2 50  5",
+            )),
+            Message::Barrier(Barrier::new_test_barrier(test_epoch(3))),
         ])
         .into_executor(schema.clone(), vec![0, 2]);
 
@@ -1574,6 +1618,18 @@ mod test {
                 " I  I  I
                   + 1 10  1
                   + 1 20  2",
+            )
+        );
+
+        executor.next().await.unwrap().unwrap();
+
+        let chunk_msg = executor.next().await.unwrap().unwrap();
+        assert_eq!(
+            chunk_msg.into_chunk().unwrap().compact_vis(),
+            StreamChunk::from_pretty(
+                " I  I  I
+                  - 2 50  5
+                  + 1 30  3",
             )
         );
 


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

Backport #26713 to `release-3.0` to fix a sink-into-table correctness regression when the input stream key differs from the target table primary key.

With `preserve_row_level_changes`, a row moving between stream keys could reach a partial-update target as a raw `Delete` followed by an `Insert`. The delete removed the complete target row before the partial insert was applied, losing columns maintained by other sinks.

This backport drops deletes whose downstream key is inserted again in the same barrier for upsert output, while preserving all inserts and the intended row-level semantics. It also includes the upstream unit and SQLLogicTest regressions.

## Backport conflict resolution

The cherry-pick had one conflict, limited to the `std` imports in `src/stream/src/executor/sink.rs`. The upstream branch grouped `assert_matches` and `mem` in a combined `std` import, while `release-3.0` uses separate imports compatible with its toolchain. The resolution keeps the existing `release-3.0` import style and adds only the new `HashSet` import required by this fix. All functional code and regression-test hunks from #26713 applied unchanged.

Closes #26718.

## Checklist

- [x] I have written necessary rustdoc comments.
- [x] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [x] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [x] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->

## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

Fix a RisingWave 3.0 correctness issue where a non-append-only sink into a table with `ON CONFLICT DO UPDATE IF NOT NULL` could lose columns written by other sinks when the sink stream key differed from the table primary key.

</details>
