### PR TITLE
fix(streaming): remove undefined behavior in chunk compaction

### DIFF
--- a/src/common/src/array/stream_chunk.rs
+++ b/src/common/src/array/stream_chunk.rs
@@ -13,9 +13,10 @@
 // limitations under the License.
 
 use std::fmt::Display;
+use std::marker::PhantomData;
 use std::mem::size_of;
 use std::ops::{Deref, DerefMut};
-use std::sync::{Arc, LazyLock};
+use std::sync::Arc;
 use std::{fmt, mem};
 
 use either::Either;
@@ -535,23 +536,13 @@ impl From<StreamChunkMut> for StreamChunk {
     }
 }
 
+/// A handle to one row of a [`StreamChunkMut`] that can update the row's op and
+/// visibility in place. It holds a raw pointer instead of `&mut` since multiple
+/// handles to the same chunk coexist (see [`StreamChunkMut::to_rows_mut`]).
 pub struct OpRowMutRef<'a> {
-    c: &'a mut StreamChunkMut,
+    c: *mut StreamChunkMut,
     i: usize,
-}
-
-// Act as a placeholder value when using in `ChangeBuffer`.
-impl Default for OpRowMutRef<'_> {
-    fn default() -> Self {
-        static mut DUMMY_CHUNK_MUT: LazyLock<StreamChunkMut> =
-            LazyLock::new(|| StreamChunk::default().into());
-
-        #[expect(clippy::deref_addrof)] // false positive
-        OpRowMutRef {
-            c: unsafe { &mut *(&raw mut DUMMY_CHUNK_MUT) },
-            i: 0,
-        }
-    }
+    _phantom: PhantomData<&'a mut StreamChunkMut>,
 }
 
 impl PartialEq for OpRowMutRef<'_> {
@@ -566,24 +557,31 @@ impl<'a> OpRowMutRef<'a> {
         self.i
     }
 
+    // SAFETY of derefs below: `self.c` is valid for `'a`, and each access reborrows
+    // a single disjoint field only.
+
     pub fn vis(&self) -> bool {
-        self.c.vis.is_set(self.i)
+        let vis = unsafe { &(*self.c).vis };
+        vis.is_set(self.i)
     }
 
     pub fn op(&self) -> Op {
-        self.c.ops.get(self.i)
+        let ops = unsafe { &(*self.c).ops };
+        ops.get(self.i)
     }
 
     pub fn set_vis(&mut self, val: bool) {
-        self.c.set_vis(self.i, val);
+        let vis = unsafe { &mut (*self.c).vis };
+        vis.set(self.i, val);
     }
 
     pub fn set_op(&mut self, val: Op) {
-        self.c.set_op(self.i, val);
+        let ops = unsafe { &mut (*self.c).ops };
+        ops.set(self.i, val);
     }
 
     pub fn row_ref(&self) -> RowRef<'_> {
-        RowRef::with_columns(self.c.columns(), self.i)
+        RowRef::with_columns(unsafe { &(*self.c).columns }, self.i)
     }
 
     /// return if the two row ref is in the same chunk
@@ -623,20 +621,37 @@ impl StreamChunkMut {
 
     /// get the mut reference of the stream chunk.
     pub fn to_rows_mut(&mut self) -> impl Iterator<Item = (RowRef<'_>, OpRowMutRef<'_>)> {
-        // SAFETY: `OpRowMutRef` can only mutate the visibility and ops, which is safe even
-        // when the columns are borrowed by `RowRef` at the same time.
-        unsafe {
-            (0..self.vis.len())
-                .filter(|i| self.vis.is_set(*i))
-                .map(|i| {
-                    let p = self as *const StreamChunkMut;
-                    let p = p as *mut StreamChunkMut;
-                    (
-                        RowRef::with_columns(self.columns(), i),
-                        OpRowMutRef { c: &mut *p, i },
-                    )
-                })
-        }
+        // SAFETY: the pointer is derived from `&mut self`, which stays exclusively
+        // borrowed by the returned iterator.
+        unsafe { Self::rows_mut_ptr(self) }
+    }
+
+    /// # Safety
+    ///
+    /// `p` must be derived from an exclusive reference valid for `'a`, and the chunk must
+    /// not be accessed in other ways while the iterator or any yielded item is alive.
+    unsafe fn rows_mut_ptr<'a>(
+        p: *mut Self,
+    ) -> impl Iterator<Item = (RowRef<'a>, OpRowMutRef<'a>)> {
+        let len = {
+            let vis = unsafe { &(*p).vis };
+            vis.len()
+        };
+        (0..len)
+            .filter(move |i| {
+                let vis = unsafe { &(*p).vis };
+                vis.is_set(*i)
+            })
+            .map(move |i| {
+                (
+                    RowRef::with_columns(unsafe { &(*p).columns }, i),
+                    OpRowMutRef {
+                        c: p,
+                        i,
+                        _phantom: PhantomData,
+                    },
+                )
+            })
     }
 }
 

--- a/src/stream/src/common/change_buffer.rs
+++ b/src/stream/src/common/change_buffer.rs
@@ -55,15 +55,23 @@ mod private {
     pub trait Key: Eq + std::hash::Hash {}
     impl<K> Key for K where K: Eq + std::hash::Hash {}
 
-    pub trait Row: Eq + Default {}
-    impl<R> Row for R where R: Eq + Default {}
+    pub trait Row: Eq {}
+    impl<R> Row for R where R: Eq {}
+}
+
+/// The accumulated change of a key, with each side in an [`Option`] so that state
+/// transitions can take one side out in place. `(None, None)` entries are removed eagerly.
+#[derive(Debug)]
+struct Slot<R> {
+    old: Option<R>,
+    new: Option<R>,
 }
 
 /// A buffer that accumulates changes and produce compacted changes.
 #[derive(Debug)]
 pub struct ChangeBuffer<K, R> {
     // We use an `IndexMap` to preserve the original order of the changes as much as possible.
-    buffer: IndexMap<K, Record<R>>,
+    buffer: IndexMap<K, Slot<R>>,
     ib: InconsistencyBehavior,
 }
 
@@ -77,22 +85,18 @@ where
         let entry = self.buffer.entry(key);
         match entry {
             Entry::Vacant(e) => {
-                e.insert(Record::Insert { new_row });
+                e.insert(Slot {
+                    old: None,
+                    new: Some(new_row),
+                });
             }
-            Entry::Occupied(mut e) => match e.get_mut() {
-                Record::Delete { old_row } => {
-                    let old_row = std::mem::take(old_row);
-                    e.insert(Record::Update { old_row, new_row });
-                }
-                Record::Insert { new_row: dst } => {
+            Entry::Occupied(mut e) => {
+                let slot = e.get_mut();
+                if slot.new.is_some() {
                     self.ib.report("inconsistent changes: double-inserting");
-                    *dst = new_row;
                 }
-                Record::Update { new_row: dst, .. } => {
-                    self.ib.report("inconsistent changes: double-inserting");
-                    *dst = new_row;
-                }
-            },
+                slot.new = Some(new_row);
+            }
         }
     }
 
@@ -101,23 +105,25 @@ where
         let entry = self.buffer.entry(key);
         match entry {
             Entry::Vacant(e) => {
-                e.insert(Record::Delete { old_row });
+                e.insert(Slot {
+                    old: Some(old_row),
+                    new: None,
+                });
             }
-            Entry::Occupied(mut e) => match e.get_mut() {
-                Record::Insert { .. } => {
-                    // FIXME: though preserving the order well,
-                    // this is not performant compared to `swap_remove`
-                    e.shift_remove();
-                }
-                Record::Update { old_row, .. } => {
-                    let old_row = std::mem::take(old_row);
-                    e.insert(Record::Delete { old_row });
-                }
-                Record::Delete { old_row: dst } => {
+            Entry::Occupied(mut e) => {
+                let slot = e.get_mut();
+                if slot.new.take().is_some() {
+                    if slot.old.is_none() {
+                        // The previous `Insert` is fully cancelled by this deletion.
+                        // FIXME: though preserving the order well,
+                        // this is not performant compared to `swap_remove`
+                        e.shift_remove();
+                    }
+                } else {
                     self.ib.report("inconsistent changes: double-deleting");
-                    *dst = old_row;
+                    slot.old = Some(old_row);
                 }
-            },
+            }
         }
     }
 
@@ -126,20 +132,21 @@ where
         let entry = self.buffer.entry(key);
         match entry {
             Entry::Vacant(e) => {
-                e.insert(Record::Update { old_row, new_row });
+                e.insert(Slot {
+                    old: Some(old_row),
+                    new: Some(new_row),
+                });
             }
-            Entry::Occupied(mut e) => match e.get_mut() {
-                Record::Insert { .. } => {
-                    e.insert(Record::Insert { new_row });
-                }
-                Record::Update { new_row: dst, .. } => {
-                    *dst = new_row;
-                }
-                Record::Delete { .. } => {
+            Entry::Occupied(mut e) => {
+                let slot = e.get_mut();
+                if slot.new.is_some() {
+                    slot.new = Some(new_row);
+                } else {
                     self.ib.report("inconsistent changes: update after delete");
-                    e.insert(Record::Update { old_row, new_row });
+                    slot.old = Some(old_row);
+                    slot.new = Some(new_row);
                 }
-            },
+            }
         }
     }
 
@@ -180,11 +187,16 @@ where
     ///
     /// No-op updates are filtered out.
     pub fn into_records(self) -> impl Iterator<Item = Record<R>> {
-        self.buffer.into_values().filter(|record| match record {
-            Record::Insert { .. } => true,
-            Record::Delete { .. } => true,
-            Record::Update { old_row, new_row } => old_row != new_row,
-        })
+        self.buffer
+            .into_values()
+            .filter_map(|slot| match (slot.old, slot.new) {
+                (None, Some(new_row)) => Some(Record::Insert { new_row }),
+                (Some(old_row), None) => Some(Record::Delete { old_row }),
+                (Some(old_row), Some(new_row)) => {
+                    (old_row != new_row).then(|| Record::Update { old_row, new_row })
+                }
+                (None, None) => unreachable!("empty slot should have been removed"),
+            })
     }
 }
 


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

Remove two pieces of undefined behavior in the chunk compaction path (`StreamChunkCompactor` / `ChangeBuffer`), introduced by #23507:

- `ChangeBuffer` stored records as `Record<R>` and required `R: Default` only to `mem::take` rows during state transitions. For `R = OpRowMutRef`, the `Default` impl handed out aliased `&mut` to a function-local `static mut LazyLock<StreamChunkMut>`, whose `DerefMut` goes through `LazyLock::force_mut` — an **unsynchronized, non-atomic initialization** path. When multiple sink actors compact `U-`/`U+` pairs concurrently at the same barrier and this is the process's first touch, the initialization is a data race. Miri confirms the race (non-atomic write in `force_mut::really_init_mut` vs. concurrent retag), and a native stress test on the extracted pattern reproduces **silent SIGSEGV in 70 / 24108 cold-start runs** (0 / 18215 once initialized single-threaded). This is the suspected root cause of #23702: the crashing statement is the only one in that suite producing a concurrent first touch.
- `StreamChunkMut::to_rows_mut` fabricated one `&mut StreamChunkMut` per row via `self as *const _ as *mut _`, keeping many live aliasing exclusive references in the buffer at once (Stacked Borrows violation; `noalias` risk).

Fix:

- `ChangeBuffer` now stores `Slot { old: Option<R>, new: Option<R> }` and transitions take sides out with `Option::take`. The `R: Default` bound and the `static mut` dummy are removed entirely. All transitions (including inconsistency reporting, the `shift_remove` on insert-then-delete, and `IndexMap` ordering) are behavior-preserving.
- `OpRowMutRef` holds `*mut StreamChunkMut` + `PhantomData<&'a mut _>`; every access reborrows a single disjoint field (`ops`/`vis` for writes, `columns` for reads). The pointer is derived directly from `&mut self` in a helper that takes only the raw pointer, so no `self` misuse is possible.

Verification:

- The extracted pattern (verbatim pointer structure) passes Miri under strict Stacked Borrows including a 4-thread concurrent compaction test with 16 scheduler seeds; the old pattern fails immediately.
- Differential tests on the extracted model show bit-identical outputs between old and new transition logic; existing `compact_chunk` unit tests pass unchanged.
- Microbenchmark of the compaction hot paths shows no measurable difference (±1%, within noise).
- `./risedev check --all-targets` clean.

Related: #23702, #23507.

## Checklist

- [x] I have written necessary rustdoc comments.
- [x] My PR changes performance-critical code, so I will run (micro) benchmarks and present the results.

## Documentation

- [ ] My PR needs documentation updates.

<details>
<summary><b>Release note</b></summary>

</details>
