### PR TITLE
chore: migrate HawkEye to v7

### DIFF
--- a/.github/workflows/license_check.yml
+++ b/.github/workflows/license_check.yml
@@ -26,7 +26,7 @@ jobs:
         ref: ${{ github.event.pull_request.head.sha || github.sha }}
     - uses: taiki-e/install-action@v2
       with:
-        tool: hawkeye@6.3
+        tool: hawkeye
     - name: Check License Header
       run: |
         hawkeye check || {

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -1269,7 +1269,7 @@ fi
 [tasks.check-license-header]
 category = "RiseDev - Check"
 description = "Check license headers by HawkEye"
-install_crate = { min_version = "6.3.0", crate_name = "hawkeye", binary = "hawkeye", test_arg = [
+install_crate = { crate_name = "hawkeye", binary = "hawkeye", test_arg = [
     "--help",
 ], install_command = "binstall" }
 command = "hawkeye"
@@ -1279,7 +1279,7 @@ env = { RUST_LOG = "info" }
 [tasks.fix-license-header]
 category = "RiseDev - Check"
 description = "Auto-fix license headers by HawkEye"
-install_crate = { min_version = "6.3.0", crate_name = "hawkeye", binary = "hawkeye", test_arg = [
+install_crate = { crate_name = "hawkeye", binary = "hawkeye", test_arg = [
     "--help",
 ], install_command = "binstall" }
 command = "hawkeye"

--- a/licenserc.toml
+++ b/licenserc.toml
@@ -1,5 +1,7 @@
-headerPath = "ci/license-header.txt"
+[header]
+path = "ci/license-header.txt"
 
+[files]
 includes = [
   "src/**/*.rs",
   "src/**/*.py",
@@ -22,4 +24,4 @@ excludes = [
 
 [git]
 ignore = "enable"
-attrs = "enable"
+file_attrs = "enable"

--- a/src/connector/src/sink/deltalake.rs
+++ b/src/connector/src/sink/deltalake.rs
@@ -1,4 +1,4 @@
-// Copyright 2023 RisingWave Labs
+// Copyright 2025 RisingWave Labs
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/frontend/src/binder/relation/table_function.rs
+++ b/src/frontend/src/binder/relation/table_function.rs
@@ -1,4 +1,4 @@
-// Copyright 2022 RisingWave Labs
+// Copyright 2023 RisingWave Labs
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/frontend/src/optimizer/plan_node/stream_simple_agg.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_simple_agg.rs
@@ -1,4 +1,4 @@
-// Copyright 2022 RisingWave Labs
+// Copyright 2023 RisingWave Labs
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/java_binding/src/hummock_iterator.rs
+++ b/src/java_binding/src/hummock_iterator.rs
@@ -1,4 +1,4 @@
-// Copyright 2023 RisingWave Labs
+// Copyright 2024 RisingWave Labs
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/meta/node/src/lib.rs
+++ b/src/meta/node/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2025 RisingWave Labs
+// Copyright 2023 RisingWave Labs
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/meta/node/src/server.rs
+++ b/src/meta/node/src/server.rs
@@ -1,4 +1,4 @@
-// Copyright 2025 RisingWave Labs
+// Copyright 2023 RisingWave Labs
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/meta/src/backup_restore/meta_snapshot_builder.rs
+++ b/src/meta/src/backup_restore/meta_snapshot_builder.rs
@@ -1,4 +1,4 @@
-// Copyright 2022 RisingWave Labs
+// Copyright 2024 RisingWave Labs
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/stream/src/executor/source/source_executor.rs
+++ b/src/stream/src/executor/source/source_executor.rs
@@ -1,4 +1,4 @@
-// Copyright 2022 RisingWave Labs
+// Copyright 2023 RisingWave Labs
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/tests/sqlsmith/src/utils.rs
+++ b/src/tests/sqlsmith/src/utils.rs
@@ -1,4 +1,4 @@
-// Copyright 2022 RisingWave Labs
+// Copyright 2023 RisingWave Labs
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

- migrate the HawkEye configuration to the v7 schema
- install the latest HawkEye release in CI and local cargo-make tasks without pinning the tool version
- refresh the few copyright years whose exact-path Git history is interpreted differently by v7
- validate 2742 selected files with 0 changes, 0 conflicts, and 0 unsupported files

## Documentation

No user-facing documentation changes are needed.