### PR TITLE
fix(catalog): make streaming object drops race-safe

### DIFF
--- a/proto/ddl_service.proto
+++ b/proto/ddl_service.proto
@@ -67,6 +67,7 @@ message CreateSourceResponse {
 message DropSourceRequest {
   uint32 source_id = 1;
   bool cascade = 2;
+  bool if_exists = 3;
 }
 
 message DropSourceResponse {
@@ -117,6 +118,7 @@ message DropSinkRequest {
   bool cascade = 2;
   reserved 3;
   reserved "affected_table_change";
+  bool if_exists = 4;
 }
 
 message DropSinkResponse {
@@ -177,6 +179,7 @@ message CreateMaterializedViewResponse {
 message DropMaterializedViewRequest {
   uint32 table_id = 1;
   bool cascade = 2;
+  bool if_exists = 3;
 }
 
 message DropMaterializedViewResponse {
@@ -437,6 +440,7 @@ message DropTableRequest {
   }
   uint32 table_id = 2;
   bool cascade = 3;
+  bool if_exists = 4;
 }
 
 message DropTableResponse {
@@ -479,6 +483,7 @@ message CreateIndexResponse {
 message DropIndexRequest {
   uint32 index_id = 1;
   bool cascade = 2;
+  bool if_exists = 3;
 }
 
 message DropIndexResponse {

--- a/proto/ddl_service.proto
+++ b/proto/ddl_service.proto
@@ -136,6 +136,7 @@ message CreateSubscriptionResponse {
 message DropSubscriptionRequest {
   uint32 subscription_id = 1;
   bool cascade = 2;
+  bool if_exists = 3;
 }
 
 message DropSubscriptionResponse {

--- a/src/frontend/src/catalog/catalog_service.rs
+++ b/src/frontend/src/catalog/catalog_service.rs
@@ -189,17 +189,23 @@ pub trait CatalogWriter: Send + Sync {
         source_id: Option<SourceId>,
         table_id: TableId,
         cascade: bool,
+        if_exists: bool,
     ) -> Result<()>;
 
-    async fn drop_materialized_view(&self, table_id: TableId, cascade: bool) -> Result<()>;
+    async fn drop_materialized_view(
+        &self,
+        table_id: TableId,
+        cascade: bool,
+        if_exists: bool,
+    ) -> Result<()>;
 
     async fn drop_view(&self, view_id: ViewId, cascade: bool) -> Result<()>;
 
-    async fn drop_source(&self, source_id: SourceId, cascade: bool) -> Result<()>;
+    async fn drop_source(&self, source_id: SourceId, cascade: bool, if_exists: bool) -> Result<()>;
 
     async fn reset_source(&self, source_id: SourceId) -> Result<()>;
 
-    async fn drop_sink(&self, sink_id: SinkId, cascade: bool) -> Result<()>;
+    async fn drop_sink(&self, sink_id: SinkId, cascade: bool, if_exists: bool) -> Result<()>;
 
     async fn drop_subscription(
         &self,
@@ -212,7 +218,7 @@ pub trait CatalogWriter: Send + Sync {
 
     async fn drop_schema(&self, schema_id: SchemaId, cascade: bool) -> Result<()>;
 
-    async fn drop_index(&self, index_id: IndexId, cascade: bool) -> Result<()>;
+    async fn drop_index(&self, index_id: IndexId, cascade: bool, if_exists: bool) -> Result<()>;
 
     async fn drop_function(&self, function_id: FunctionId, cascade: bool) -> Result<()>;
 
@@ -598,18 +604,24 @@ impl CatalogWriter for CatalogWriterImpl {
         source_id: Option<SourceId>,
         table_id: TableId,
         cascade: bool,
+        if_exists: bool,
     ) -> Result<()> {
         let version = self
             .meta_client
-            .drop_table(source_id, table_id, cascade)
+            .drop_table(source_id, table_id, cascade, if_exists)
             .await?;
         self.wait_version(version).await
     }
 
-    async fn drop_materialized_view(&self, table_id: TableId, cascade: bool) -> Result<()> {
+    async fn drop_materialized_view(
+        &self,
+        table_id: TableId,
+        cascade: bool,
+        if_exists: bool,
+    ) -> Result<()> {
         let version = self
             .meta_client
-            .drop_materialized_view(table_id, cascade)
+            .drop_materialized_view(table_id, cascade, if_exists)
             .await?;
         self.wait_version(version).await
     }
@@ -619,8 +631,11 @@ impl CatalogWriter for CatalogWriterImpl {
         self.wait_version(version).await
     }
 
-    async fn drop_source(&self, source_id: SourceId, cascade: bool) -> Result<()> {
-        let version = self.meta_client.drop_source(source_id, cascade).await?;
+    async fn drop_source(&self, source_id: SourceId, cascade: bool, if_exists: bool) -> Result<()> {
+        let version = self
+            .meta_client
+            .drop_source(source_id, cascade, if_exists)
+            .await?;
         self.wait_version(version).await
     }
 
@@ -629,8 +644,11 @@ impl CatalogWriter for CatalogWriterImpl {
         self.wait_version(version).await
     }
 
-    async fn drop_sink(&self, sink_id: SinkId, cascade: bool) -> Result<()> {
-        let version = self.meta_client.drop_sink(sink_id, cascade).await?;
+    async fn drop_sink(&self, sink_id: SinkId, cascade: bool, if_exists: bool) -> Result<()> {
+        let version = self
+            .meta_client
+            .drop_sink(sink_id, cascade, if_exists)
+            .await?;
         self.wait_version(version).await
     }
 
@@ -647,8 +665,11 @@ impl CatalogWriter for CatalogWriterImpl {
         self.wait_version(version).await
     }
 
-    async fn drop_index(&self, index_id: IndexId, cascade: bool) -> Result<()> {
-        let version = self.meta_client.drop_index(index_id, cascade).await?;
+    async fn drop_index(&self, index_id: IndexId, cascade: bool, if_exists: bool) -> Result<()> {
+        let version = self
+            .meta_client
+            .drop_index(index_id, cascade, if_exists)
+            .await?;
         self.wait_version(version).await
     }
 

--- a/src/frontend/src/catalog/catalog_service.rs
+++ b/src/frontend/src/catalog/catalog_service.rs
@@ -201,8 +201,12 @@ pub trait CatalogWriter: Send + Sync {
 
     async fn drop_sink(&self, sink_id: SinkId, cascade: bool) -> Result<()>;
 
-    async fn drop_subscription(&self, subscription_id: SubscriptionId, cascade: bool)
-    -> Result<()>;
+    async fn drop_subscription(
+        &self,
+        subscription_id: SubscriptionId,
+        cascade: bool,
+        if_exists: bool,
+    ) -> Result<()>;
 
     async fn drop_database(&self, database_id: DatabaseId) -> Result<()>;
 
@@ -634,10 +638,11 @@ impl CatalogWriter for CatalogWriterImpl {
         &self,
         subscription_id: SubscriptionId,
         cascade: bool,
+        if_exists: bool,
     ) -> Result<()> {
         let version = self
             .meta_client
-            .drop_subscription(subscription_id, cascade)
+            .drop_subscription(subscription_id, cascade, if_exists)
             .await?;
         self.wait_version(version).await
     }

--- a/src/frontend/src/handler/drop_index.rs
+++ b/src/frontend/src/handler/drop_index.rs
@@ -99,7 +99,7 @@ pub async fn handle_drop_index(
     } else {
         let catalog_writer = session.catalog_writer()?;
         execute_with_long_running_notification(
-            catalog_writer.drop_index(index_id, cascade),
+            catalog_writer.drop_index(index_id, cascade, if_exists),
             &session,
             "DROP INDEX",
             LongRunningNotificationAction::SuggestRecover,

--- a/src/frontend/src/handler/drop_mv.rs
+++ b/src/frontend/src/handler/drop_mv.rs
@@ -76,7 +76,7 @@ pub async fn handle_drop_mv(
     let catalog_writer = session.catalog_writer()?;
 
     execute_with_long_running_notification(
-        catalog_writer.drop_materialized_view(table_id, cascade),
+        catalog_writer.drop_materialized_view(table_id, cascade, if_exists),
         &session,
         "DROP MATERIALIZED VIEW",
         LongRunningNotificationAction::SuggestRecover,

--- a/src/frontend/src/handler/drop_sink.rs
+++ b/src/frontend/src/handler/drop_sink.rs
@@ -69,7 +69,7 @@ pub async fn handle_drop_sink(
 
     let catalog_writer = session.catalog_writer()?;
     execute_with_long_running_notification(
-        catalog_writer.drop_sink(sink_id, cascade),
+        catalog_writer.drop_sink(sink_id, cascade, if_exists),
         &session,
         "DROP SINK",
         LongRunningNotificationAction::SuggestRecover,

--- a/src/frontend/src/handler/drop_source.rs
+++ b/src/frontend/src/handler/drop_source.rs
@@ -81,7 +81,7 @@ pub async fn handle_drop_source(
 
     let catalog_writer = session.catalog_writer()?;
     execute_with_long_running_notification(
-        catalog_writer.drop_source(source.id, cascade),
+        catalog_writer.drop_source(source.id, cascade, if_exists),
         &session,
         "DROP SOURCE",
         LongRunningNotificationAction::SuggestRecover,

--- a/src/frontend/src/handler/drop_subscription.rs
+++ b/src/frontend/src/handler/drop_subscription.rs
@@ -64,7 +64,7 @@ pub async fn handle_drop_subscription(
 
     let catalog_writer = session.catalog_writer()?;
     execute_with_long_running_notification(
-        catalog_writer.drop_subscription(subscription_id, cascade),
+        catalog_writer.drop_subscription(subscription_id, cascade, if_exists),
         &session,
         "DROP SUBSCRIPTION",
         LongRunningNotificationAction::SuggestRecover,

--- a/src/frontend/src/handler/drop_table.rs
+++ b/src/frontend/src/handler/drop_table.rs
@@ -63,7 +63,7 @@ pub async fn handle_drop_table(
 
     let catalog_writer = session.catalog_writer()?;
     execute_with_long_running_notification(
-        catalog_writer.drop_table(source_id, table_id, cascade),
+        catalog_writer.drop_table(source_id, table_id, cascade, if_exists),
         &session,
         "DROP TABLE",
         LongRunningNotificationAction::SuggestRecover,

--- a/src/frontend/src/handler/util.rs
+++ b/src/frontend/src/handler/util.rs
@@ -404,7 +404,7 @@ where
 /// # Example
 /// ```ignore
 /// execute_with_long_running_notification(
-///     catalog_writer.drop_table(source_id, table_id, cascade),
+///     catalog_writer.drop_table(source_id, table_id, cascade, if_exists),
 ///     &session,
 ///     "DROP TABLE",
 /// ).await?;

--- a/src/frontend/src/test_utils.rs
+++ b/src/frontend/src/test_utils.rs
@@ -586,6 +586,7 @@ impl CatalogWriter for MockCatalogWriter {
         &self,
         subscription_id: SubscriptionId,
         cascade: bool,
+        _if_exists: bool,
     ) -> Result<()> {
         if cascade {
             return Err(ErrorCode::NotSupported(

--- a/src/frontend/src/test_utils.rs
+++ b/src/frontend/src/test_utils.rs
@@ -492,6 +492,7 @@ impl CatalogWriter for MockCatalogWriter {
         source_id: Option<SourceId>,
         table_id: TableId,
         cascade: bool,
+        _if_exists: bool,
     ) -> Result<()> {
         if cascade {
             return Err(ErrorCode::NotSupported(
@@ -509,7 +510,7 @@ impl CatalogWriter for MockCatalogWriter {
                 .read()
                 .get_all_indexes_related_to_object(database_id, schema_id, table_id);
         for index in indexes {
-            self.drop_index(index.id, cascade).await?;
+            self.drop_index(index.id, cascade, false).await?;
         }
         self.catalog
             .write()
@@ -526,7 +527,12 @@ impl CatalogWriter for MockCatalogWriter {
         unreachable!()
     }
 
-    async fn drop_materialized_view(&self, table_id: TableId, cascade: bool) -> Result<()> {
+    async fn drop_materialized_view(
+        &self,
+        table_id: TableId,
+        cascade: bool,
+        _if_exists: bool,
+    ) -> Result<()> {
         if cascade {
             return Err(ErrorCode::NotSupported(
                 "drop cascade in MockCatalogWriter is unsupported".to_owned(),
@@ -540,7 +546,7 @@ impl CatalogWriter for MockCatalogWriter {
                 .read()
                 .get_all_indexes_related_to_object(database_id, schema_id, table_id);
         for index in indexes {
-            self.drop_index(index.id, cascade).await?;
+            self.drop_index(index.id, cascade, false).await?;
         }
         self.catalog
             .write()
@@ -548,7 +554,12 @@ impl CatalogWriter for MockCatalogWriter {
         Ok(())
     }
 
-    async fn drop_source(&self, source_id: SourceId, cascade: bool) -> Result<()> {
+    async fn drop_source(
+        &self,
+        source_id: SourceId,
+        cascade: bool,
+        _if_exists: bool,
+    ) -> Result<()> {
         if cascade {
             return Err(ErrorCode::NotSupported(
                 "drop cascade in MockCatalogWriter is unsupported".to_owned(),
@@ -567,7 +578,7 @@ impl CatalogWriter for MockCatalogWriter {
         Ok(())
     }
 
-    async fn drop_sink(&self, sink_id: SinkId, cascade: bool) -> Result<()> {
+    async fn drop_sink(&self, sink_id: SinkId, cascade: bool, _if_exists: bool) -> Result<()> {
         if cascade {
             return Err(ErrorCode::NotSupported(
                 "drop cascade in MockCatalogWriter is unsupported".to_owned(),
@@ -603,7 +614,7 @@ impl CatalogWriter for MockCatalogWriter {
         Ok(())
     }
 
-    async fn drop_index(&self, index_id: IndexId, cascade: bool) -> Result<()> {
+    async fn drop_index(&self, index_id: IndexId, cascade: bool, _if_exists: bool) -> Result<()> {
         if cascade {
             return Err(ErrorCode::NotSupported(
                 "drop cascade in MockCatalogWriter is unsupported".to_owned(),

--- a/src/meta/service/src/ddl_service.rs
+++ b/src/meta/service/src/ddl_service.rs
@@ -540,7 +540,7 @@ impl DdlService for DdlServiceImpl {
         let subscription_id = request.subscription_id;
         let drop_mode = DropMode::from_request_setting(request.cascade);
 
-        let command = DdlCommand::DropSubscription(subscription_id, drop_mode);
+        let command = DdlCommand::DropSubscription(subscription_id, drop_mode, request.if_exists);
 
         let version = self.ddl_controller.run_command(command).await?;
 

--- a/src/meta/service/src/ddl_service.rs
+++ b/src/meta/service/src/ddl_service.rs
@@ -415,7 +415,11 @@ impl DdlService for DdlServiceImpl {
         let drop_mode = DropMode::from_request_setting(request.cascade);
         let version = self
             .ddl_controller
-            .run_command(DdlCommand::DropSource(source_id, drop_mode))
+            .run_command(DdlCommand::DropSource(
+                source_id,
+                drop_mode,
+                request.if_exists,
+            ))
             .await?;
 
         Ok(Response::new(DropSourceResponse {
@@ -497,6 +501,7 @@ impl DdlService for DdlServiceImpl {
         let command = DdlCommand::DropStreamingJob {
             job_id: StreamingJobId::Sink(sink_id),
             drop_mode,
+            if_exists: request.if_exists,
         };
 
         let version = self.ddl_controller.run_command(command).await?;
@@ -598,6 +603,7 @@ impl DdlService for DdlServiceImpl {
             .run_command(DdlCommand::DropStreamingJob {
                 job_id: StreamingJobId::MaterializedView(table_id),
                 drop_mode,
+                if_exists: request.if_exists,
             })
             .await?;
 
@@ -657,6 +663,7 @@ impl DdlService for DdlServiceImpl {
             .run_command(DdlCommand::DropStreamingJob {
                 job_id: StreamingJobId::Index(index_id),
                 drop_mode,
+                if_exists: request.if_exists,
             })
             .await?;
 
@@ -750,6 +757,7 @@ impl DdlService for DdlServiceImpl {
             .run_command(DdlCommand::DropStreamingJob {
                 job_id: StreamingJobId::Table(source_id.map(|PbSourceId::Id(id)| id), table_id),
                 drop_mode,
+                if_exists: request.if_exists,
             })
             .await?;
 
@@ -1936,6 +1944,7 @@ impl DdlService for DdlServiceImpl {
                 .run_command(DdlCommand::DropStreamingJob {
                     job_id: StreamingJobId::Table(None, table_id),
                     drop_mode: DropMode::Cascade,
+                    if_exists: false,
                 })
                 .await
                 .inspect_err(|err| {
@@ -1985,6 +1994,7 @@ impl DdlService for DdlServiceImpl {
                 .run_command(DdlCommand::DropStreamingJob {
                     job_id: StreamingJobId::Table(None, table_id),
                     drop_mode: DropMode::Cascade,
+                    if_exists: false,
                 })
                 .await
                 .inspect_err(|err| {

--- a/src/meta/src/controller/catalog/get_op.rs
+++ b/src/meta/src/controller/catalog/get_op.rs
@@ -339,7 +339,7 @@ impl CatalogController {
             .into_iter()
             .map(|(subscription, obj)| ObjectModel(subscription, obj.unwrap(), None).into())
             .find_or_first(|_| true)
-            .ok_or_else(|| anyhow!("cannot find subscription with id {}", subscription_id))?;
+            .ok_or_else(|| MetaError::catalog_id_not_found("subscription", subscription_id))?;
 
         Ok(subscription)
     }

--- a/src/meta/src/rpc/ddl_controller.rs
+++ b/src/meta/src/rpc/ddl_controller.rs
@@ -117,10 +117,25 @@ impl DropMode {
     }
 }
 
-fn ignore_missing_subscription<T>(result: MetaResult<T>, if_exists: bool) -> MetaResult<Option<T>> {
+fn ignore_missing_object<T>(
+    result: MetaResult<T>,
+    if_exists: bool,
+    object_type: &'static str,
+    object_id: impl ToString,
+) -> MetaResult<Option<T>> {
+    let object_id = object_id.to_string();
     match result {
         Ok(value) => Ok(Some(value)),
-        Err(err) if if_exists && err.is_catalog_id_not_found("subscription") => Ok(None),
+        Err(err)
+            if if_exists
+                && matches!(
+                    err.inner(),
+                    MetaErrorInner::CatalogIdNotFound(found_type, found_id)
+                        if *found_type == object_type && found_id == &object_id
+                ) =>
+        {
+            Ok(None)
+        }
         Err(err) => Err(err),
     }
 }
@@ -164,7 +179,7 @@ pub enum DdlCommand {
     CreateSchema(Schema),
     DropSchema(SchemaId, DropMode),
     CreateNonSharedSource(Source, Option<TableId>),
-    DropSource(SourceId, DropMode),
+    DropSource(SourceId, DropMode, bool),
     ResetSource(SourceId),
     CreateFunction(Function),
     DropFunction(FunctionId, DropMode),
@@ -183,6 +198,7 @@ pub enum DdlCommand {
     DropStreamingJob {
         job_id: StreamingJobId,
         drop_mode: DropMode,
+        if_exists: bool,
     },
     AlterName(alter_name_request::Object, String),
     AlterSwapRename(alter_swap_rename_request::Object),
@@ -218,7 +234,7 @@ impl DdlCommand {
             DdlCommand::CreateSchema(schema) => Left(schema.name.clone()),
             DdlCommand::DropSchema(id, _) => Right(id.as_object_id()),
             DdlCommand::CreateNonSharedSource(source, _) => Left(source.name.clone()),
-            DdlCommand::DropSource(id, _) => Right(id.as_object_id()),
+            DdlCommand::DropSource(id, _, _) => Right(id.as_object_id()),
             DdlCommand::ResetSource(id) => Right(id.as_object_id()),
             DdlCommand::CreateFunction(function) => Left(function.name.clone()),
             DdlCommand::DropFunction(id, _) => Right(id.as_object_id()),
@@ -253,7 +269,7 @@ impl DdlCommand {
         match self {
             DdlCommand::DropDatabase(_)
             | DdlCommand::DropSchema(_, _)
-            | DdlCommand::DropSource(_, _)
+            | DdlCommand::DropSource(_, _, _)
             | DdlCommand::DropFunction(_, _)
             | DdlCommand::DropView(_, _)
             | DdlCommand::DropStreamingJob { .. }
@@ -469,8 +485,8 @@ impl DdlController {
                     ctrl.create_non_shared_source(source, iceberg_table_id)
                         .await
                 }
-                DdlCommand::DropSource(source_id, drop_mode) => {
-                    ctrl.drop_source(source_id, drop_mode).await
+                DdlCommand::DropSource(source_id, drop_mode, if_exists) => {
+                    ctrl.drop_source(source_id, drop_mode, if_exists).await
                 }
                 DdlCommand::ResetSource(source_id) => ctrl.reset_source(source_id).await,
                 DdlCommand::CreateFunction(function) => ctrl.create_function(function).await,
@@ -505,9 +521,11 @@ impl DdlController {
                     )
                     .await
                 }
-                DdlCommand::DropStreamingJob { job_id, drop_mode } => {
-                    ctrl.drop_streaming_job(job_id, drop_mode).await
-                }
+                DdlCommand::DropStreamingJob {
+                    job_id,
+                    drop_mode,
+                    if_exists,
+                } => ctrl.drop_streaming_job(job_id, drop_mode, if_exists).await,
                 DdlCommand::ReplaceStreamJob(ReplaceStreamJobInfo {
                     streaming_job,
                     fragment_graph,
@@ -720,9 +738,23 @@ impl DdlController {
         &self,
         source_id: SourceId,
         drop_mode: DropMode,
+        if_exists: bool,
     ) -> MetaResult<NotificationVersion> {
-        self.drop_object(ObjectType::Source, source_id, drop_mode)
-            .await
+        let Some(version) = ignore_missing_object(
+            self.drop_object(ObjectType::Source, source_id, drop_mode)
+                .await,
+            if_exists,
+            ObjectType::Source.as_str(),
+            source_id,
+        )?
+        else {
+            return Ok(self
+                .metadata_manager
+                .catalog_controller
+                .notify_frontend_trivial()
+                .await);
+        };
+        Ok(version)
     }
 
     async fn reset_source(&self, source_id: SourceId) -> MetaResult<NotificationVersion> {
@@ -947,12 +979,14 @@ impl DdlController {
     ) -> MetaResult<NotificationVersion> {
         tracing::debug!("preparing drop subscription");
         let _reschedule_job_lock = self.stream_manager.reschedule_lock_read_guard().await;
-        let Some(subscription) = ignore_missing_subscription(
+        let Some(subscription) = ignore_missing_object(
             self.metadata_manager
                 .catalog_controller
                 .get_subscription_by_id(subscription_id)
                 .await,
             if_exists,
+            ObjectType::Subscription.as_str(),
+            subscription_id,
         )?
         else {
             return Ok(self
@@ -963,12 +997,14 @@ impl DdlController {
         };
         let table_id = subscription.dependent_table_id;
         let database_id = subscription.database_id;
-        let Some((_, version)) = ignore_missing_subscription(
+        let Some((_, version)) = ignore_missing_object(
             self.metadata_manager
                 .catalog_controller
                 .drop_object(ObjectType::Subscription, subscription_id, drop_mode)
                 .await,
             if_exists,
+            ObjectType::Subscription.as_str(),
+            subscription_id,
         )?
         else {
             return Ok(self
@@ -1900,6 +1936,7 @@ impl DdlController {
         &self,
         job_id: StreamingJobId,
         drop_mode: DropMode,
+        if_exists: bool,
     ) -> MetaResult<NotificationVersion> {
         let (object_id, object_type) = match job_id {
             StreamingJobId::MaterializedView(id) => (id.as_object_id(), ObjectType::Table),
@@ -1908,11 +1945,22 @@ impl DdlController {
             StreamingJobId::Index(idx) => (idx.as_object_id(), ObjectType::Index),
         };
 
-        let job_status = self
-            .metadata_manager
-            .catalog_controller
-            .get_streaming_job_status(job_id.id())
-            .await?;
+        let Some(job_status) = ignore_missing_object(
+            self.metadata_manager
+                .catalog_controller
+                .get_streaming_job_status(job_id.id())
+                .await,
+            if_exists,
+            "streaming job",
+            job_id.id(),
+        )?
+        else {
+            return Ok(self
+                .metadata_manager
+                .catalog_controller
+                .notify_frontend_trivial()
+                .await);
+        };
         let version = match job_status {
             JobStatus::Initial => {
                 let abort_result = self
@@ -1930,7 +1978,22 @@ impl DdlController {
                     .await?;
                 IGNORED_NOTIFICATION_VERSION
             }
-            JobStatus::Created => self.drop_object(object_type, object_id, drop_mode).await?,
+            JobStatus::Created => {
+                let Some(version) = ignore_missing_object(
+                    self.drop_object(object_type, object_id, drop_mode).await,
+                    if_exists,
+                    object_type.as_str(),
+                    object_id,
+                )?
+                else {
+                    return Ok(self
+                        .metadata_manager
+                        .catalog_controller
+                        .notify_frontend_trivial()
+                        .await);
+                };
+                version
+            }
         };
 
         Ok(version)
@@ -2622,26 +2685,33 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_ignore_missing_subscription() {
+    fn test_ignore_missing_object() {
         let missing_subscription = MetaError::catalog_id_not_found("subscription", 1);
         assert!(
-            ignore_missing_subscription::<()>(Err(missing_subscription), true)
+            ignore_missing_object::<()>(Err(missing_subscription), true, "subscription", 1)
                 .unwrap()
                 .is_none()
         );
 
         let missing_subscription = MetaError::catalog_id_not_found("subscription", 1);
         assert!(
-            ignore_missing_subscription::<()>(Err(missing_subscription), false)
+            ignore_missing_object::<()>(Err(missing_subscription), false, "subscription", 1)
                 .unwrap_err()
                 .is_catalog_id_not_found("subscription")
         );
 
         let missing_table = MetaError::catalog_id_not_found("table", 1);
         assert!(
-            ignore_missing_subscription::<()>(Err(missing_table), true)
+            ignore_missing_object::<()>(Err(missing_table), true, "subscription", 1)
                 .unwrap_err()
                 .is_catalog_id_not_found("table")
+        );
+
+        let other_subscription = MetaError::catalog_id_not_found("subscription", 2);
+        assert!(
+            ignore_missing_object::<()>(Err(other_subscription), true, "subscription", 1)
+                .unwrap_err()
+                .is_catalog_id_not_found("subscription")
         );
     }
 

--- a/src/meta/src/rpc/ddl_controller.rs
+++ b/src/meta/src/rpc/ddl_controller.rs
@@ -117,6 +117,14 @@ impl DropMode {
     }
 }
 
+fn ignore_missing_subscription<T>(result: MetaResult<T>, if_exists: bool) -> MetaResult<Option<T>> {
+    match result {
+        Ok(value) => Ok(Some(value)),
+        Err(err) if if_exists && err.is_catalog_id_not_found("subscription") => Ok(None),
+        Err(err) => Err(err),
+    }
+}
+
 #[derive(strum::AsRefStr)]
 pub enum StreamingJobId {
     MaterializedView(TableId),
@@ -189,7 +197,7 @@ pub enum DdlCommand {
     DropSecret(SecretId, DropMode),
     CommentOn(Comment),
     CreateSubscription(Subscription),
-    DropSubscription(SubscriptionId, DropMode),
+    DropSubscription(SubscriptionId, DropMode, bool),
     AlterSubscriptionRetention {
         subscription_id: SubscriptionId,
         retention_seconds: u64,
@@ -231,7 +239,7 @@ impl DdlCommand {
             DdlCommand::DropSecret(id, _) => Right(id.as_object_id()),
             DdlCommand::CommentOn(comment) => Right(comment.table_id.into()),
             DdlCommand::CreateSubscription(subscription) => Left(subscription.name.clone()),
-            DdlCommand::DropSubscription(id, _) => Right(id.as_object_id()),
+            DdlCommand::DropSubscription(id, _, _) => Right(id.as_object_id()),
             DdlCommand::AlterSubscriptionRetention {
                 subscription_id, ..
             } => Right(subscription_id.as_object_id()),
@@ -251,7 +259,7 @@ impl DdlCommand {
             | DdlCommand::DropStreamingJob { .. }
             | DdlCommand::DropConnection(_, _)
             | DdlCommand::DropSecret(_, _)
-            | DdlCommand::DropSubscription(_, _)
+            | DdlCommand::DropSubscription(_, _, _)
             | DdlCommand::AlterName(_, _)
             | DdlCommand::AlterObjectOwner(_, _)
             | DdlCommand::AlterSetSchema(_, _)
@@ -529,8 +537,9 @@ impl DdlController {
                 DdlCommand::CreateSubscription(subscription) => {
                     ctrl.create_subscription(subscription).await
                 }
-                DdlCommand::DropSubscription(subscription_id, drop_mode) => {
-                    ctrl.drop_subscription(subscription_id, drop_mode).await
+                DdlCommand::DropSubscription(subscription_id, drop_mode, if_exists) => {
+                    ctrl.drop_subscription(subscription_id, drop_mode, if_exists)
+                        .await
                 }
                 DdlCommand::AlterSubscriptionRetention {
                     subscription_id,
@@ -934,21 +943,40 @@ impl DdlController {
         &self,
         subscription_id: SubscriptionId,
         drop_mode: DropMode,
+        if_exists: bool,
     ) -> MetaResult<NotificationVersion> {
         tracing::debug!("preparing drop subscription");
         let _reschedule_job_lock = self.stream_manager.reschedule_lock_read_guard().await;
-        let subscription = self
-            .metadata_manager
-            .catalog_controller
-            .get_subscription_by_id(subscription_id)
-            .await?;
+        let Some(subscription) = ignore_missing_subscription(
+            self.metadata_manager
+                .catalog_controller
+                .get_subscription_by_id(subscription_id)
+                .await,
+            if_exists,
+        )?
+        else {
+            return Ok(self
+                .metadata_manager
+                .catalog_controller
+                .notify_frontend_trivial()
+                .await);
+        };
         let table_id = subscription.dependent_table_id;
         let database_id = subscription.database_id;
-        let (_, version) = self
-            .metadata_manager
-            .catalog_controller
-            .drop_object(ObjectType::Subscription, subscription_id, drop_mode)
-            .await?;
+        let Some((_, version)) = ignore_missing_subscription(
+            self.metadata_manager
+                .catalog_controller
+                .drop_object(ObjectType::Subscription, subscription_id, drop_mode)
+                .await,
+            if_exists,
+        )?
+        else {
+            return Ok(self
+                .metadata_manager
+                .catalog_controller
+                .notify_frontend_trivial()
+                .await);
+        };
         self.stream_manager
             .drop_subscription(database_id, subscription_id, table_id)
             .await;
@@ -2592,6 +2620,30 @@ mod tests {
     use std::num::NonZeroUsize;
 
     use super::*;
+
+    #[test]
+    fn test_ignore_missing_subscription() {
+        let missing_subscription = MetaError::catalog_id_not_found("subscription", 1);
+        assert!(
+            ignore_missing_subscription::<()>(Err(missing_subscription), true)
+                .unwrap()
+                .is_none()
+        );
+
+        let missing_subscription = MetaError::catalog_id_not_found("subscription", 1);
+        assert!(
+            ignore_missing_subscription::<()>(Err(missing_subscription), false)
+                .unwrap_err()
+                .is_catalog_id_not_found("subscription")
+        );
+
+        let missing_table = MetaError::catalog_id_not_found("table", 1);
+        assert!(
+            ignore_missing_subscription::<()>(Err(missing_table), true)
+                .unwrap_err()
+                .is_catalog_id_not_found("table")
+        );
+    }
 
     #[test]
     fn test_validate_specified_parallelism_accepts_within_max() {

--- a/src/rpc_client/src/meta_client.rs
+++ b/src/rpc_client/src/meta_client.rs
@@ -445,8 +445,13 @@ impl MetaClient {
         &self,
         table_id: TableId,
         cascade: bool,
+        if_exists: bool,
     ) -> Result<WaitVersion> {
-        let request = DropMaterializedViewRequest { table_id, cascade };
+        let request = DropMaterializedViewRequest {
+            table_id,
+            cascade,
+            if_exists,
+        };
 
         let resp = self.inner.drop_materialized_view(request).await?;
         Ok(resp
@@ -892,11 +897,13 @@ impl MetaClient {
         source_id: Option<SourceId>,
         table_id: TableId,
         cascade: bool,
+        if_exists: bool,
     ) -> Result<WaitVersion> {
         let request = DropTableRequest {
             source_id: source_id.map(risingwave_pb::ddl_service::drop_table_request::SourceId::Id),
             table_id,
             cascade,
+            if_exists,
         };
 
         let resp = self.inner.drop_table(request).await?;
@@ -931,8 +938,17 @@ impl MetaClient {
             .ok_or_else(|| anyhow!("wait version not set"))?)
     }
 
-    pub async fn drop_source(&self, source_id: SourceId, cascade: bool) -> Result<WaitVersion> {
-        let request = DropSourceRequest { source_id, cascade };
+    pub async fn drop_source(
+        &self,
+        source_id: SourceId,
+        cascade: bool,
+        if_exists: bool,
+    ) -> Result<WaitVersion> {
+        let request = DropSourceRequest {
+            source_id,
+            cascade,
+            if_exists,
+        };
         let resp = self.inner.drop_source(request).await?;
         Ok(resp
             .version
@@ -947,8 +963,17 @@ impl MetaClient {
             .ok_or_else(|| anyhow!("wait version not set"))?)
     }
 
-    pub async fn drop_sink(&self, sink_id: SinkId, cascade: bool) -> Result<WaitVersion> {
-        let request = DropSinkRequest { sink_id, cascade };
+    pub async fn drop_sink(
+        &self,
+        sink_id: SinkId,
+        cascade: bool,
+        if_exists: bool,
+    ) -> Result<WaitVersion> {
+        let request = DropSinkRequest {
+            sink_id,
+            cascade,
+            if_exists,
+        };
         let resp = self.inner.drop_sink(request).await?;
         Ok(resp
             .version
@@ -972,8 +997,17 @@ impl MetaClient {
             .ok_or_else(|| anyhow!("wait version not set"))?)
     }
 
-    pub async fn drop_index(&self, index_id: IndexId, cascade: bool) -> Result<WaitVersion> {
-        let request = DropIndexRequest { index_id, cascade };
+    pub async fn drop_index(
+        &self,
+        index_id: IndexId,
+        cascade: bool,
+        if_exists: bool,
+    ) -> Result<WaitVersion> {
+        let request = DropIndexRequest {
+            index_id,
+            cascade,
+            if_exists,
+        };
         let resp = self.inner.drop_index(request).await?;
         Ok(resp
             .version

--- a/src/rpc_client/src/meta_client.rs
+++ b/src/rpc_client/src/meta_client.rs
@@ -959,10 +959,12 @@ impl MetaClient {
         &self,
         subscription_id: SubscriptionId,
         cascade: bool,
+        if_exists: bool,
     ) -> Result<WaitVersion> {
         let request = DropSubscriptionRequest {
             subscription_id,
             cascade,
+            if_exists,
         };
         let resp = self.inner.drop_subscription(request).await?;
         Ok(resp


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

`DROP ... IF EXISTS` for streaming objects currently handles `IF EXISTS` only during the frontend catalog lookup. If another request or a cascade removes the object before meta performs the authoritative deletion, meta returns `CatalogIdNotFound` and the valid statement fails.

This affects subscriptions and all `StreamingJob` variants: tables, materialized views, sinks, indexes, and sources.

This PR makes these operations race-safe by:

- forwarding `if_exists` through the catalog writer and the corresponding drop RPCs;
- treating only a missing target with the exact expected object type and ID as a no-op in meta;
- handling both the streaming-job status lookup and the authoritative catalog deletion race windows;
- returning a trivial frontend notification version for no-op drops so the normal DDL version wait completes;
- preserving errors for ordinary `DROP` statements, unrelated objects, dependency checks, and all other failures.

Creating-job cancellation already has idempotent cleanup and remains unchanged.

## Checklist

- [x] I have written necessary rustdoc comments.
- [x] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [x] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/dev/src/ci.md#ci-labels-guide -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into.

## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates.

<details>
<summary><b>Release note</b></summary>

`DROP ... IF EXISTS` no longer fails when a concurrent operation removes a subscription, table, materialized view, sink, index, or source after the frontend catalog lookup.

</details>
