### PR TITLE
chore(deps): unify OpenDAL on 0.58.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,7 +27,7 @@ dependencies = [
  "regex",
  "toml 1.1.2+spec-1.1.0",
  "windows-registry",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2100,7 +2100,7 @@ dependencies = [
  "bitflags 2.13.1",
  "cexpr",
  "clang-sys",
- "itertools 0.13.0",
+ "itertools 0.10.5",
  "log",
  "prettyplease",
  "proc-macro2",
@@ -5495,7 +5495,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6660,7 +6660,7 @@ dependencies = [
  "base64 0.22.1",
  "gcloud-metadata",
  "home",
- "jsonwebtoken 10.3.0",
+ "jsonwebtoken",
  "reqwest 0.13.4",
  "serde",
  "serde_json",
@@ -7544,7 +7544,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.5",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -7741,7 +7741,7 @@ dependencies = [
  "futures",
  "iceberg",
  "once_cell",
- "opendal 0.58.1",
+ "opendal",
  "reqsign-aws-v4",
  "reqsign-core",
  "serde",
@@ -8216,21 +8216,6 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
-]
-
-[[package]]
-name = "jsonwebtoken"
-version = "9.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a87cc7a48537badeae96744432de36f4be2b4a34a05a5ef32e9dd8a1c169dde"
-dependencies = [
- "base64 0.22.1",
- "js-sys",
- "pem 3.0.6",
- "ring",
- "serde",
- "serde_json",
- "simple_asn1",
 ]
 
 [[package]]
@@ -9647,7 +9632,7 @@ version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51e219e79014df21a225b1860a479e2dcd7cbd9130f4defd4bd0e191ea31d67d"
 dependencies = [
- "base64 0.22.1",
+ "base64 0.21.7",
  "chrono",
  "getrandom 0.2.11",
  "http 1.4.0",
@@ -9787,36 +9772,6 @@ dependencies = [
 
 [[package]]
 name = "opendal"
-version = "0.55.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d075ab8a203a6ab4bc1bce0a4b9fe486a72bf8b939037f4b78d95386384bc80a"
-dependencies = [
- "anyhow",
- "backon",
- "base64 0.22.1",
- "bytes",
- "crc32c",
- "futures",
- "getrandom 0.2.11",
- "http 1.4.0",
- "http-body 1.0.1",
- "jiff 0.2.35",
- "log",
- "md-5 0.10.6",
- "percent-encoding",
- "quick-xml 0.38.4",
- "reqsign",
- "reqwest 0.12.25",
- "serde",
- "serde_json",
- "sha2 0.10.9",
- "tokio",
- "url",
- "uuid",
-]
-
-[[package]]
-name = "opendal"
 version = "0.58.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f20562cc7447fcc915fc5c23df305a412ea80a733c9f2fd9e2d267e2815be6d"
@@ -9830,9 +9785,13 @@ dependencies = [
  "opendal-layer-timeout",
  "opendal-service-azblob",
  "opendal-service-azdls",
+ "opendal-service-azfile",
  "opendal-service-fs",
  "opendal-service-gcs",
+ "opendal-service-obs",
+ "opendal-service-oss",
  "opendal-service-s3",
+ "opendal-service-webhdfs",
 ]
 
 [[package]]
@@ -9961,6 +9920,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "opendal-service-azfile"
+version = "0.58.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6cd228c87087e4486c5a4d7b978b1db3ebed7f98351e6ed02e9f9bde24f3ce30"
+dependencies = [
+ "bytes",
+ "http 1.4.0",
+ "log",
+ "opendal-core",
+ "opendal-service-azure-common",
+ "quick-xml 0.41.0",
+ "reqsign-azure-storage",
+ "reqsign-core",
+ "reqsign-file-read-tokio",
+ "serde",
+]
+
+[[package]]
 name = "opendal-service-azure-common"
 version = "0.58.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10006,6 +9983,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "opendal-service-obs"
+version = "0.58.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a39f4a4e705d9fb375d53a0dbbdb6fc435a04b94e7697b86a365a6b4ea4b5639"
+dependencies = [
+ "bytes",
+ "http 1.4.0",
+ "log",
+ "opendal-core",
+ "quick-xml 0.41.0",
+ "reqsign-core",
+ "reqsign-file-read-tokio",
+ "reqsign-huaweicloud-obs",
+ "serde",
+]
+
+[[package]]
+name = "opendal-service-oss"
+version = "0.58.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd528ec2d49c5ca69e674ffed7b3e0686fb9cfcfea0596870de381467fda4f1b"
+dependencies = [
+ "bytes",
+ "http 1.4.0",
+ "log",
+ "opendal-core",
+ "quick-xml 0.41.0",
+ "reqsign-aliyun-oss",
+ "reqsign-core",
+ "reqsign-file-read-tokio",
+ "serde",
+]
+
+[[package]]
 name = "opendal-service-s3"
 version = "0.58.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10024,6 +10035,23 @@ dependencies = [
  "reqsign-file-read-tokio",
  "serde",
  "url",
+]
+
+[[package]]
+name = "opendal-service-webhdfs"
+version = "0.58.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8703b22fe6e6b8aef40a8fc884aba39c78405c657ec545134552f785c2f193a"
+dependencies = [
+ "anyhow",
+ "bytes",
+ "http 1.4.0",
+ "log",
+ "mea",
+ "opendal-core",
+ "serde",
+ "serde_json",
+ "uuid",
 ]
 
 [[package]]
@@ -10726,7 +10754,7 @@ dependencies = [
  "bytes",
  "futures",
  "itertools 0.14.0",
- "jsonwebtoken 10.3.0",
+ "jsonwebtoken",
  "ldap3",
  "madsim-tokio",
  "openssl",
@@ -11422,7 +11450,7 @@ version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
- "heck 0.5.0",
+ "heck 0.4.1",
  "itertools 0.14.0",
  "log",
  "multimap",
@@ -11441,7 +11469,7 @@ name = "prost-build"
 version = "0.14.3"
 source = "git+https://github.com/risingwavelabs/prost.git?rev=040a192409e45069158300baec4f402ad1fe101a#040a192409e45069158300baec4f402ad1fe101a"
 dependencies = [
- "heck 0.5.0",
+ "heck 0.4.1",
  "itertools 0.14.0",
  "log",
  "multimap",
@@ -11771,26 +11799,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f50b1c63b38611e7d4d7f68b82d3ad0cc71a2ad2e7f61fc10f1328d917c93cd"
 dependencies = [
  "memchr",
-]
-
-[[package]]
-name = "quick-xml"
-version = "0.37.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f22f29bdff3987b4d8632ef95fd6424ec7e4e0a57e2f4fc63e489e75357f6a03"
-dependencies = [
- "memchr",
- "serde",
-]
-
-[[package]]
-name = "quick-xml"
-version = "0.38.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b66c2058c55a409d601666cffe35f04333cf1013010882cec174a7467cd4e21c"
-dependencies = [
- "memchr",
- "serde",
 ]
 
 [[package]]
@@ -12262,35 +12270,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51743d3e274e2b18df81c4dc6caf8a5b8e15dbe799e0dca05c7617380094e884"
 
 [[package]]
-name = "reqsign"
-version = "0.16.5"
+name = "reqsign-aliyun-oss"
+version = "3.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43451dbf3590a7590684c25fb8d12ecdcc90ed3ac123433e500447c7d77ed701"
+checksum = "68d24d281f734a463093b7b93aae8b16f5f8496a54fbeec4d2d10b0488295296"
 dependencies = [
  "anyhow",
- "async-trait",
- "base64 0.22.1",
- "chrono",
  "form_urlencoded",
- "getrandom 0.2.11",
- "hex",
- "hmac 0.12.1",
- "home",
  "http 1.4.0",
- "jsonwebtoken 9.3.1",
  "log",
- "once_cell",
  "percent-encoding",
- "quick-xml 0.37.1",
- "rand 0.8.5",
- "reqwest 0.12.25",
- "rsa",
+ "reqsign-core",
  "rust-ini",
  "serde",
  "serde_json",
- "sha1 0.10.6",
- "sha2 0.10.9",
- "tokio",
 ]
 
 [[package]]
@@ -12402,6 +12395,19 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
+]
+
+[[package]]
+name = "reqsign-huaweicloud-obs"
+version = "3.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "745a05797db6a44c21b66e303dff97d8072ff18982977cf13b976f7af2fc0d61"
+dependencies = [
+ "anyhow",
+ "http 1.4.0",
+ "log",
+ "percent-encoding",
+ "reqsign-core",
 ]
 
 [[package]]
@@ -12669,7 +12675,7 @@ dependencies = [
  "madsim-tonic",
  "memcomparable",
  "mysql_async",
- "opendal 0.55.0",
+ "opendal",
  "panic-message",
  "parking_lot 0.12.5",
  "parquet",
@@ -12715,7 +12721,7 @@ dependencies = [
  "linkme",
  "madsim-tokio",
  "mysql_async",
- "opendal 0.55.0",
+ "opendal",
  "prometheus",
  "rand 0.9.5",
  "risingwave_batch",
@@ -13245,7 +13251,7 @@ dependencies = [
  "mysql_common",
  "nexmark",
  "num-bigint",
- "opendal 0.55.0",
+ "opendal",
  "opensearch",
  "openssl",
  "parking_lot 0.12.5",
@@ -13785,7 +13791,7 @@ dependencies = [
  "expect-test",
  "humansize",
  "jsonbb",
- "jsonwebtoken 10.3.0",
+ "jsonwebtoken",
  "risingwave_pb",
  "risingwave_telemetry_event",
  "serde",
@@ -14022,10 +14028,11 @@ dependencies = [
  "madsim",
  "madsim-aws-sdk-s3",
  "madsim-tokio",
- "opendal 0.55.0",
+ "opendal",
+ "opendal-http-transport-reqwest",
  "pin-project-lite",
  "prometheus",
- "reqwest 0.12.25",
+ "reqwest 0.13.4",
  "risingwave_common",
  "spin 0.10.0",
  "thiserror 2.0.17",
@@ -14749,7 +14756,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.11.0",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -14860,7 +14867,7 @@ dependencies = [
  "security-framework 3.5.1",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -15915,7 +15922,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -16627,10 +16634,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0136791f7c95b1f6dd99f9cc786b91bb81c3800b639b3478e561ddb7be95e5f1"
 dependencies = [
  "fastrand",
- "getrandom 0.4.2",
+ "getrandom 0.3.1",
  "once_cell",
  "rustix 1.1.3",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -200,7 +200,8 @@ mysql_async = { version = "0.36", features = [
     "native-tls-tls",
     "rust_decimal",
 ] }
-opendal = "0.55"
+opendal = "0.58.1"
+opendal-http-transport-reqwest = "0.58.1"
 openssl = "0.10.80"
 opentelemetry = "0.31"
 opentelemetry-otlp = { version = "0.31", features = ["grpc-tonic"] }

--- a/src/batch/src/spill/spill_op.rs
+++ b/src/batch/src/spill/spill_op.rs
@@ -67,15 +67,11 @@ impl SpillOp {
         let op = match spill_backend {
             SpillBackend::Disk => {
                 let builder = Fs::default().root(&root.to_string_lossy());
-                Operator::new(builder)?
-                    .layer(RetryLayer::default())
-                    .finish()
+                Operator::new(builder)?.layer(RetryLayer::default())
             }
             SpillBackend::Memory => {
                 let builder = Memory::default().root(&root.to_string_lossy());
-                Operator::new(builder)?
-                    .layer(RetryLayer::default())
-                    .finish()
+                Operator::new(builder)?.layer(RetryLayer::default())
             }
         };
         Ok(SpillOp { op })
@@ -89,11 +85,9 @@ impl SpillOp {
 
         let builder = Fs::default().root(&root.to_string_lossy());
 
-        let op: Operator = Operator::new(builder)?
-            .layer(RetryLayer::default())
-            .finish();
+        let op: Operator = Operator::new(builder)?.layer(RetryLayer::default());
 
-        op.remove_all("/").await
+        op.delete_with("/").recursive(true).await
     }
 
     pub async fn writer_with(&self, name: &str) -> Result<opendal::Writer> {
@@ -149,7 +143,7 @@ impl Drop for SpillOp {
     fn drop(&mut self) {
         let op = self.op.clone();
         tokio::task::spawn(async move {
-            let result = op.remove_all("/").await;
+            let result = op.delete_with("/").recursive(true).await;
             if let Err(error) = result {
                 error!(
                     error = %error.as_report(),

--- a/src/connector/src/connector_common/connection.rs
+++ b/src/connector/src/connector_common/connection.rs
@@ -229,7 +229,7 @@ impl Connection for IcebergConnection {
                         builder = builder.secret_access_key(secret_key);
                     }
                     builder = builder.root(root.as_str()).bucket(bucket.as_str());
-                    let op = Operator::new(builder)?.finish();
+                    let op = Operator::new(builder)?;
                     op.check().await?;
                 }
                 "gs" | "gcs" => {
@@ -238,7 +238,7 @@ impl Connection for IcebergConnection {
                         builder = builder.credential(credential);
                     }
                     builder = builder.root(root.as_str()).bucket(bucket.as_str());
-                    let op = Operator::new(builder)?.finish();
+                    let op = Operator::new(builder)?;
                     op.check().await?;
                 }
                 "azblob" => {
@@ -253,7 +253,7 @@ impl Connection for IcebergConnection {
                         builder = builder.endpoint(azblob_endpoint_url);
                     }
                     builder = builder.root(root.as_str()).container(bucket.as_str());
-                    let op = Operator::new(builder)?.finish();
+                    let op = Operator::new(builder)?;
                     op.check().await?;
                 }
                 _ => {

--- a/src/connector/src/sink/file_sink/azblob.rs
+++ b/src/connector/src/sink/file_sink/azblob.rs
@@ -85,8 +85,7 @@ impl<S: OpendalSinkBackend> FileSink<S> {
         }
         let operator: Operator = Operator::new(builder)?
             .layer(LoggingLayer::default())
-            .layer(RetryLayer::default())
-            .finish();
+            .layer(RetryLayer::default());
 
         Ok(operator)
     }

--- a/src/connector/src/sink/file_sink/fs.rs
+++ b/src/connector/src/sink/file_sink/fs.rs
@@ -64,8 +64,7 @@ impl<S: OpendalSinkBackend> FileSink<S> {
         let builder = Fs::default().root(&config.common.path);
         let operator: Operator = Operator::new(builder)?
             .layer(LoggingLayer::default())
-            .layer(RetryLayer::default())
-            .finish();
+            .layer(RetryLayer::default());
         Ok(operator)
     }
 }

--- a/src/connector/src/sink/file_sink/gcs.rs
+++ b/src/connector/src/sink/file_sink/gcs.rs
@@ -80,8 +80,7 @@ impl<S: OpendalSinkBackend> FileSink<S> {
 
         let operator: Operator = Operator::new(builder)?
             .layer(LoggingLayer::default())
-            .layer(RetryLayer::default())
-            .finish();
+            .layer(RetryLayer::default());
         Ok(operator)
     }
 }

--- a/src/connector/src/sink/file_sink/s3.rs
+++ b/src/connector/src/sink/file_sink/s3.rs
@@ -115,8 +115,7 @@ impl<S: OpendalSinkBackend> FileSink<S> {
 
         let operator: Operator = Operator::new(builder)?
             .layer(LoggingLayer::default())
-            .layer(RetryLayer::default())
-            .finish();
+            .layer(RetryLayer::default());
 
         Ok(operator)
     }

--- a/src/connector/src/sink/file_sink/webhdfs.rs
+++ b/src/connector/src/sink/file_sink/webhdfs.rs
@@ -59,9 +59,7 @@ impl<S: OpendalSinkBackend> FileSink<S> {
             .endpoint(&config.common.endpoint)
             .root(&config.common.path);
 
-        let operator: Operator = Operator::new(builder)?
-            .layer(LoggingLayer::default())
-            .finish();
+        let operator: Operator = Operator::new(builder)?.layer(LoggingLayer::default());
 
         Ok(operator)
     }

--- a/src/connector/src/source/filesystem/opendal_source/azblob_source.rs
+++ b/src/connector/src/source/filesystem/opendal_source/azblob_source.rs
@@ -51,8 +51,7 @@ impl<Src: OpendalSource> OpendalEnumerator<Src> {
         }
         let op: Operator = Operator::new(builder)?
             .layer(LoggingLayer::default())
-            .layer(RetryLayer::default())
-            .finish();
+            .layer(RetryLayer::default());
 
         let (prefix, matcher) = if let Some(pattern) = azblob_properties.match_pattern.as_ref() {
             let prefix = get_prefix(pattern);

--- a/src/connector/src/source/filesystem/opendal_source/gcs_source.rs
+++ b/src/connector/src/source/filesystem/opendal_source/gcs_source.rs
@@ -44,8 +44,7 @@ impl<Src: OpendalSource> OpendalEnumerator<Src> {
         }
         let op: Operator = Operator::new(builder)?
             .layer(LoggingLayer::default())
-            .layer(RetryLayer::default())
-            .finish();
+            .layer(RetryLayer::default());
 
         let (prefix, matcher) = if let Some(pattern) = gcs_properties.match_pattern.as_ref() {
             let prefix = get_prefix(pattern);

--- a/src/connector/src/source/filesystem/opendal_source/posix_fs_source.rs
+++ b/src/connector/src/source/filesystem/opendal_source/posix_fs_source.rs
@@ -34,8 +34,7 @@ impl<Src: OpendalSource> OpendalEnumerator<Src> {
         let builder = Fs::default().root(&posix_fs_properties.root);
         let op: Operator = Operator::new(builder)?
             .layer(LoggingLayer::default())
-            .layer(RetryLayer::default())
-            .finish();
+            .layer(RetryLayer::default());
 
         let (prefix, matcher) = if let Some(pattern) = posix_fs_properties.match_pattern.as_ref() {
             // TODO(Kexiang): Currently, FsListnenr in opendal does not support a prefix. (Seems a bug in opendal)

--- a/src/connector/src/source/filesystem/opendal_source/s3_source.rs
+++ b/src/connector/src/source/filesystem/opendal_source/s3_source.rs
@@ -69,8 +69,7 @@ impl<Src: OpendalSource> OpendalEnumerator<Src> {
         }
         let op: Operator = Operator::new(builder)?
             .layer(LoggingLayer::default())
-            .layer(RetryLayer::default())
-            .finish();
+            .layer(RetryLayer::default());
 
         Ok(Self {
             op,

--- a/src/connector/src/source/iceberg/parquet_file_handler.rs
+++ b/src/connector/src/source/iceberg/parquet_file_handler.rs
@@ -122,8 +122,7 @@ pub fn new_s3_operator(
         .disable_config_load();
     let op: Operator = Operator::new(builder)?
         .layer(LoggingLayer::default())
-        .layer(RetryLayer::default())
-        .finish();
+        .layer(RetryLayer::default());
 
     Ok(op)
 }
@@ -134,8 +133,7 @@ pub fn new_gcs_operator(credential: String, bucket: String) -> ConnectorResult<O
 
     let operator: Operator = Operator::new(builder)?
         .layer(LoggingLayer::default())
-        .layer(RetryLayer::default())
-        .finish();
+        .layer(RetryLayer::default());
     Ok(operator)
 }
 
@@ -155,8 +153,7 @@ pub fn new_azblob_operator(
 
     let operator: Operator = Operator::new(builder)?
         .layer(LoggingLayer::default())
-        .layer(RetryLayer::default())
-        .finish();
+        .layer(RetryLayer::default());
     Ok(operator)
 }
 

--- a/src/object_store/Cargo.toml
+++ b/src/object_store/Cargo.toml
@@ -40,9 +40,10 @@ opendal = { workspace = true, features = [
     "services-webhdfs",
     "services-azfile",
 ] }
+opendal-http-transport-reqwest = { workspace = true }
 pin-project-lite = { workspace = true }
 prometheus = { version = "0.14", features = ["process"] }
-reqwest = "0.12.2" # required by opendal
+reqwest = "0.13.4" # required by opendal-http-transport-reqwest
 risingwave_common = { workspace = true }
 spin = "0.10"
 thiserror = { workspace = true }

--- a/src/object_store/src/object/opendal_engine/mod.rs
+++ b/src/object_store/src/object/opendal_engine/mod.rs
@@ -14,9 +14,8 @@
 
 pub mod opendal_object_store;
 
+use opendal::Operator;
 use opendal::layers::{ConcurrentLimitLayer, LoggingLayer};
-use opendal::raw::Access;
-use opendal::{Operator, OperatorBuilder};
 pub use opendal_object_store::*;
 use risingwave_common::config::ObjectStoreConfig;
 
@@ -37,7 +36,7 @@ pub mod fs;
 // To make sure the the operation is consistent, we should specially set `atomic_write_dir` for fs, hdfs and webhdfs services.
 const ATOMIC_WRITE_DIR: &str = "atomic_write_dir/";
 
-fn new_operator(config: &ObjectStoreConfig, builder: OperatorBuilder<impl Access>) -> Operator {
+fn new_operator(config: &ObjectStoreConfig, op: Operator) -> Operator {
     // Tokio semaphore rejects values above `usize::MAX >> 3`.
     const UNLIMITED_OPERATION_CONCURRENCY: usize = usize::MAX >> 3;
 
@@ -52,8 +51,8 @@ fn new_operator(config: &ObjectStoreConfig, builder: OperatorBuilder<impl Access
             concurrent_limit_layer =
                 concurrent_limit_layer.with_http_concurrent_limit(config.http_concurrent_limit);
         }
-        builder.layer(concurrent_limit_layer).finish()
+        op.layer(concurrent_limit_layer)
     } else {
-        builder.layer(LoggingLayer::default()).finish()
+        op.layer(LoggingLayer::default())
     }
 }

--- a/src/object_store/src/object/opendal_engine/opendal_object_store.rs
+++ b/src/object_store/src/object/opendal_engine/opendal_object_store.rs
@@ -77,7 +77,7 @@ impl OpendalObjectStore {
     pub fn test_new_memory_engine() -> ObjectResult<Self> {
         // Create memory backend builder.
         let builder = Memory::default();
-        let op: Operator = Operator::new(builder)?.finish();
+        let op: Operator = Operator::new(builder)?;
 
         Ok(Self {
             op,
@@ -124,7 +124,7 @@ impl ObjectStore for OpendalObjectStore {
     }
 
     async fn streaming_upload(&self, path: &str) -> ObjectResult<Self::StreamingUploader> {
-        if self.op.info().native_capability().write_can_multi {
+        if self.op.info().capability().write_can_multi {
             Ok(OpendalStreamingUploader::Native(Box::new(
                 OpendalNativeStreamingUploader::new(
                     self.op.clone(),
@@ -374,7 +374,11 @@ impl OpendalNativeStreamingUploader {
     ) -> ObjectResult<Self> {
         let monitored_execute = OpendalStreamingUploaderExecute::new(metrics, media_type);
         let executor = Executor::with(monitored_execute);
-        op.update_executor(|_| executor);
+        // Start from the base context so existing layers are replayed exactly once by
+        // `with_context`. Using the composed context here would double-wrap resources such as
+        // the HTTP concurrency semaphore.
+        let ctx = op.base_context().with_executor(executor);
+        let op = op.with_context(ctx);
 
         let writer = op
             .clone()
@@ -549,13 +553,12 @@ mod tests {
     }
 
     #[tokio::test]
-    #[should_panic]
-    async fn test_memory_read_overflow() {
+    async fn test_memory_read_out_of_range_returns_error() {
         let block = Bytes::from("123456");
         let store = OpendalObjectStore::test_new_memory_engine().unwrap();
         store.upload("/abc", block).await.unwrap();
 
-        // Overflow.
+        // OpenDAL 0.58 reports an out-of-range read instead of panicking.
         store.read("/abc", 4..44).await.unwrap_err();
     }
 

--- a/src/object_store/src/object/opendal_engine/s3.rs
+++ b/src/object_store/src/object/opendal_engine/s3.rs
@@ -15,15 +15,15 @@
 use std::sync::Arc;
 use std::time::Duration;
 
-use opendal::Operator;
-use opendal::layers::{HttpClientLayer, LoggingLayer};
-use opendal::raw::HttpClient;
+use opendal::layers::LoggingLayer;
 use opendal::services::S3;
+use opendal::{HttpTransporter, OperationContext, Operator};
+use opendal_http_transport_reqwest::ReqwestTransport;
 use risingwave_common::config::ObjectStoreConfig;
 
 use super::{MediaType, OpendalObjectStore, new_operator};
-use crate::object::ObjectResult;
 use crate::object::object_metrics::ObjectStoreMetrics;
+use crate::object::{ObjectError, ObjectResult};
 
 impl OpendalObjectStore {
     /// create opendal s3 engine.
@@ -44,11 +44,12 @@ impl OpendalObjectStore {
         }
 
         let http_client = Self::new_http_client(&config)?;
+        let transport = HttpTransporter::new(ReqwestTransport::new(http_client));
 
         let op = new_operator(
             &config,
             Operator::new(builder)?
-                .layer(HttpClientLayer::new(http_client))
+                .with_context(OperationContext::new().with_http_transport(transport))
                 .layer(LoggingLayer::default()),
         );
 
@@ -89,11 +90,11 @@ impl OpendalObjectStore {
             .disable_config_load();
 
         let http_client = Self::new_http_client(&config)?;
+        let transport = HttpTransporter::new(ReqwestTransport::new(http_client));
 
-        let op: Operator = Operator::new(builder)?
-            .layer(HttpClientLayer::new(http_client))
-            .layer(LoggingLayer::default())
-            .finish();
+        let op = Operator::new(builder)?
+            .with_context(OperationContext::new().with_http_transport(transport))
+            .layer(LoggingLayer::default());
 
         Ok(Self {
             op,
@@ -103,7 +104,7 @@ impl OpendalObjectStore {
         })
     }
 
-    pub fn new_http_client(config: &ObjectStoreConfig) -> ObjectResult<HttpClient> {
+    pub fn new_http_client(config: &ObjectStoreConfig) -> ObjectResult<reqwest::Client> {
         let mut client_builder = reqwest::ClientBuilder::new();
 
         if let Some(keepalive_ms) = config.s3.keepalive_ms.as_ref() {
@@ -113,7 +114,8 @@ impl OpendalObjectStore {
         if let Some(nodelay) = config.s3.nodelay.as_ref() {
             client_builder = client_builder.tcp_nodelay(*nodelay);
         }
-        #[expect(deprecated)]
-        Ok(HttpClient::build(client_builder)?)
+        client_builder
+            .build()
+            .map_err(|e| ObjectError::internal(format!("failed to build HTTP client: {e}")))
     }
 }

--- a/src/object_store/src/object/opendal_engine/s3.rs
+++ b/src/object_store/src/object/opendal_engine/s3.rs
@@ -20,6 +20,7 @@ use opendal::services::S3;
 use opendal::{HttpTransporter, OperationContext, Operator};
 use opendal_http_transport_reqwest::ReqwestTransport;
 use risingwave_common::config::ObjectStoreConfig;
+use thiserror_ext::AsReport as _;
 
 use super::{MediaType, OpendalObjectStore, new_operator};
 use crate::object::object_metrics::ObjectStoreMetrics;
@@ -114,8 +115,8 @@ impl OpendalObjectStore {
         if let Some(nodelay) = config.s3.nodelay.as_ref() {
             client_builder = client_builder.tcp_nodelay(*nodelay);
         }
-        client_builder
-            .build()
-            .map_err(|e| ObjectError::internal(format!("failed to build HTTP client: {e}")))
+        client_builder.build().map_err(|e| {
+            ObjectError::internal(format!("failed to build HTTP client: {}", e.as_report()))
+        })
     }
 }


### PR DESCRIPTION
## What's changed

- Unify RisingWave's direct OpenDAL dependency with Iceberg on `0.58.1`, removing the duplicate `0.55.0` dependency tree.
- Migrate the affected object-store, connector, and batch spill code to the OpenDAL 0.58 APIs.
- Preserve the custom S3 reqwest transport settings and install the streaming-upload executor from `base_context()`, so existing layers (including the HTTP concurrency limiter) are replayed exactly once.
- Keep the current Iceberg revision and existing Tokio/AWS SDK versions unchanged.
- Update the memory range regression to assert OpenDAL 0.58's `RangeNotSatisfied` error instead of the old backend panic.

## Verification

- `cargo check -p risingwave_object_store -p risingwave_connector -p risingwave_batch -p risingwave_batch_executors`
- `cargo clippy -p risingwave_object_store -p risingwave_connector -p risingwave_batch -p risingwave_batch_executors --all-targets -- -D warnings`
- `cargo test -p risingwave_object_store --lib` (14 passed)
- `cargo test -p risingwave_batch --lib` (16 passed, 2 ignored)
- `cargo tree --workspace -i opendal@0.58.1 --depth 2 --prefix none`
- `git diff --check`

Supersedes #26574. Thanks @Xuanwo for the original migration.
