### PR TITLE
test(sim): wait for per-database recovery in kill-and-recover helpers

### DIFF
--- a/src/tests/simulation/tests/integration_tests/main.rs
+++ b/src/tests/simulation/tests/integration_tests/main.rs
@@ -17,7 +17,7 @@
 //! See [this post](https://matklad.github.io/2021/02/27/delete-cargo-integration-tests.html)
 //! for the rationale behind this approach.
 
-#![feature(stmt_expr_attributes)]
+#![cfg_attr(madsim, feature(stmt_expr_attributes))]
 #![cfg_attr(madsim, feature(impl_trait_in_assoc_type))]
 
 mod backfill_tests;

--- a/src/tests/simulation/tests/integration_tests/recovery/mod.rs
+++ b/src/tests/simulation/tests/integration_tests/recovery/mod.rs
@@ -20,6 +20,7 @@ mod drop_streaming_job;
 mod event_log;
 mod locality_backfill;
 mod nexmark_recovery;
+mod recovery_info;
 mod serving_mapping;
 mod serving_mapping_start_order;
 mod time_travel;

--- a/src/tests/simulation/tests/integration_tests/recovery/recovery_info.rs
+++ b/src/tests/simulation/tests/integration_tests/recovery/recovery_info.rs
@@ -1,0 +1,353 @@
+// Copyright 2026 RisingWave Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Tests `rw_catalog.rw_recovery_info` after known recovery scenarios by
+//! re-deriving every column of the view from the raw `rw_event_logs` rows, so
+//! a divergence points at the view or at meta's recovery event emission.
+
+use std::time::Duration;
+
+use anyhow::{Result, anyhow};
+use risingwave_simulation::cluster::{Cluster, Configuration, Session};
+use serde::Deserialize;
+use tokio::time::sleep;
+
+use crate::utils::{kill_cn_and_meta_and_wait_recover, kill_cn_and_wait_recover};
+
+const VIEW_SQL: &str = r#"
+SELECT jsonb_build_object(
+    'database_id', database_id,
+    'database_name', database_name,
+    'recovery_state', recovery_state,
+    'last_database_event', last_database_event,
+    'last_global_event', last_global_event,
+    'in_global_running', in_global_running,
+    'in_global_recovering', in_global_recovering
+) AS json_line
+FROM rw_catalog.rw_recovery_info
+ORDER BY database_id;
+"#;
+
+const EVENTS_SQL: &str = r#"
+SELECT jsonb_build_object(
+    'event_type', event_type,
+    'ts', extract(epoch FROM timestamp)::double precision,
+    'info', info
+) AS json_line
+FROM rw_catalog.rw_event_logs
+WHERE event_type LIKE 'DATABASE_RECOVERY%' OR event_type LIKE 'GLOBAL_RECOVERY%'
+ORDER BY timestamp, event_type;
+"#;
+
+#[derive(Debug, Deserialize)]
+struct RecoveryInfoRow {
+    database_id: u32,
+    database_name: String,
+    recovery_state: String,
+    last_database_event: String,
+    last_global_event: String,
+    // NULL when no global recovery event has been logged yet.
+    in_global_running: Option<bool>,
+    in_global_recovering: Option<bool>,
+}
+
+#[derive(Debug, Deserialize)]
+struct RecoveryEventRow {
+    event_type: String,
+    ts: f64,
+    info: serde_json::Value,
+}
+
+fn parse_lines<T: for<'a> Deserialize<'a>>(output: &str) -> Result<Vec<T>> {
+    output
+        .lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty())
+        .map(|line| Ok(serde_json::from_str(line)?))
+        .collect()
+}
+
+/// Fetches the view and the recovery events, retrying until no event is
+/// flushed between the two reads.
+async fn stable_snapshot(
+    session: &mut Session,
+) -> Result<(Vec<RecoveryInfoRow>, Vec<RecoveryEventRow>)> {
+    for _ in 0..20 {
+        let events_before = session.run(EVENTS_SQL).await?;
+        let rows = session.run(VIEW_SQL).await?;
+        let events_after = session.run(EVENTS_SQL).await?;
+        if events_before == events_after {
+            return Ok((parse_lines(&rows)?, parse_lines(&events_before)?));
+        }
+        sleep(Duration::from_millis(200)).await;
+    }
+    Err(anyhow!("event log kept changing while snapshotting"))
+}
+
+fn json_u32(value: &serde_json::Value) -> Option<u32> {
+    value
+        .as_u64()
+        .or_else(|| value.as_str().and_then(|s| s.parse().ok()))
+        .map(|id| id as u32)
+}
+
+/// The database a `DATABASE_RECOVERY_*` event refers to. `None` mirrors the
+/// view dropping events whose id it cannot extract.
+fn event_database_id(info: &serde_json::Value) -> Option<u32> {
+    let recovery = info.get("recovery")?;
+    ["databaseStart", "databaseSuccess", "databaseFailure"]
+        .iter()
+        .find_map(|key| recovery.get(key))
+        .and_then(|event| event.get("databaseId"))
+        .and_then(json_u32)
+}
+
+fn global_id_list(info: &serde_json::Value, key: &str) -> Vec<u32> {
+    info.get("recovery")
+        .and_then(|r| r.get("globalSuccess"))
+        .and_then(|s| s.get(key))
+        .and_then(|v| v.as_array())
+        .map(|ids| ids.iter().filter_map(json_u32).collect())
+        .unwrap_or_default()
+}
+
+#[derive(Debug, PartialEq)]
+struct Expected {
+    last_database_event: String,
+    last_global_event: String,
+    in_global_running: bool,
+    in_global_recovering: bool,
+    recovery_state: String,
+}
+
+/// Re-derives one view row from the latest global recovery event and the
+/// database's latest own event, following the view's SQL exactly.
+fn derive_expected(
+    database_id: u32,
+    global: Option<&RecoveryEventRow>,
+    database: Option<&RecoveryEventRow>,
+) -> Expected {
+    let last_database_event = database
+        .map(|d| {
+            d.event_type
+                .trim_start_matches("DATABASE_RECOVERY_")
+                .to_owned()
+        })
+        .unwrap_or_else(|| "UNKNOWN".to_owned());
+
+    let mut in_global_running = false;
+    let mut in_global_recovering = false;
+    let mut last_global_event = "UNKNOWN";
+    if let Some(g) = global {
+        if g.event_type == "GLOBAL_RECOVERY_SUCCESS" {
+            // The view only trusts a global event that is at least as new as the
+            // database's own latest event.
+            if g.ts >= database.map_or(g.ts, |d| d.ts) {
+                in_global_running =
+                    global_id_list(&g.info, "runningDatabaseIds").contains(&database_id);
+                in_global_recovering =
+                    global_id_list(&g.info, "recoveringDatabaseIds").contains(&database_id);
+                last_global_event = if in_global_running {
+                    "RUNNING"
+                } else if in_global_recovering {
+                    "RECOVERING"
+                } else {
+                    "UNKNOWN"
+                };
+            }
+        } else if g.event_type == "GLOBAL_RECOVERY_FAILURE" {
+            last_global_event = "RECOVERING";
+        }
+    }
+
+    let recovery_state = if last_database_event == "SUCCESS"
+        || (last_global_event == "RUNNING" && in_global_running)
+    {
+        "RUNNING"
+    } else if (last_global_event == "RUNNING" && in_global_recovering)
+        || (last_global_event == "RECOVERING" && in_global_recovering)
+        || last_database_event == "START"
+        || last_global_event == "RECOVERING"
+    {
+        "RECOVERING"
+    } else {
+        "UNKNOWN"
+    };
+
+    Expected {
+        last_database_event,
+        last_global_event: last_global_event.to_owned(),
+        in_global_running,
+        in_global_recovering,
+        recovery_state: recovery_state.to_owned(),
+    }
+}
+
+/// Checks every view row against the raw event log. Events sharing the maximal
+/// timestamp are all tried, since the view breaks such ties arbitrarily.
+fn check_view_against_events(rows: &[RecoveryInfoRow], events: &[RecoveryEventRow]) {
+    let globals: Vec<_> = events
+        .iter()
+        .filter(|e| {
+            matches!(
+                e.event_type.as_str(),
+                "GLOBAL_RECOVERY_SUCCESS" | "GLOBAL_RECOVERY_FAILURE"
+            )
+        })
+        .collect();
+    let global_max_ts = globals
+        .iter()
+        .map(|e| e.ts)
+        .fold(f64::NEG_INFINITY, f64::max);
+    let global_candidates: Vec<&RecoveryEventRow> = globals
+        .iter()
+        .copied()
+        .filter(|e| e.ts == global_max_ts)
+        .collect();
+
+    for row in rows {
+        let db_events: Vec<_> = events
+            .iter()
+            .filter(|e| e.event_type.starts_with("DATABASE_RECOVERY_"))
+            .filter(|e| event_database_id(&e.info) == Some(row.database_id))
+            .collect();
+        let db_max_ts = db_events
+            .iter()
+            .map(|e| e.ts)
+            .fold(f64::NEG_INFINITY, f64::max);
+        let db_candidates: Vec<&RecoveryEventRow> = db_events
+            .iter()
+            .copied()
+            .filter(|e| e.ts == db_max_ts)
+            .collect();
+
+        let global_options: Vec<Option<&RecoveryEventRow>> = if global_candidates.is_empty() {
+            vec![None]
+        } else {
+            global_candidates.iter().map(|e| Some(*e)).collect()
+        };
+        let db_options: Vec<Option<&RecoveryEventRow>> = if db_candidates.is_empty() {
+            vec![None]
+        } else {
+            db_candidates.iter().map(|e| Some(*e)).collect()
+        };
+
+        let mut mismatches = Vec::new();
+        let matched = global_options.iter().any(|global| {
+            db_options.iter().any(|database| {
+                let expected = derive_expected(row.database_id, *global, *database);
+                let ok = expected.last_database_event == row.last_database_event
+                    && expected.last_global_event == row.last_global_event
+                    && expected.in_global_running == row.in_global_running.unwrap_or(false)
+                    && expected.in_global_recovering == row.in_global_recovering.unwrap_or(false)
+                    && expected.recovery_state == row.recovery_state;
+                if !ok {
+                    mismatches.push(expected);
+                }
+                ok
+            })
+        });
+        assert!(
+            matched,
+            "rw_recovery_info row diverges from the event log:\nrow: {row:?}\nexpected one of ({} global x {} database candidates): {mismatches:?}",
+            global_options.len(),
+            db_options.len(),
+        );
+    }
+}
+
+fn row<'a>(rows: &'a [RecoveryInfoRow], name: &str) -> &'a RecoveryInfoRow {
+    rows.iter()
+        .find(|r| r.database_name == name)
+        .unwrap_or_else(|| panic!("database {name} missing from rw_recovery_info: {rows:?}"))
+}
+
+/// Both databases need streaming state so that recovery tracks them.
+async fn create_streaming_jobs(session: &mut Session) -> Result<()> {
+    session.run("create table t (v int);").await?;
+    session
+        .run("create materialized view mv as select count(*) as c from t;")
+        .await?;
+    Ok(())
+}
+
+async fn setup_two_databases(cluster: &mut Cluster) -> Result<Session> {
+    let mut session = cluster.start_session();
+    create_streaming_jobs(&mut session).await?;
+    session.run("create database db2;").await?;
+    session.run("use db2;").await?;
+    create_streaming_jobs(&mut session).await?;
+    Ok(session)
+}
+
+#[tokio::test]
+async fn test_recovery_info_view_after_cn_kill() -> Result<()> {
+    let mut cluster = Cluster::start(Configuration::for_background_ddl()).await?;
+    let mut session = setup_two_databases(&mut cluster).await?;
+
+    let (rows, events) = stable_snapshot(&mut session).await?;
+    check_view_against_events(&rows, &events);
+    // A database created after the last recovery has no event referencing it.
+    assert_eq!(row(&rows, "db2").recovery_state, "UNKNOWN");
+    let events_before = events.len();
+    drop(session);
+
+    kill_cn_and_wait_recover(&mut cluster).await;
+
+    let mut session = cluster.start_session();
+    let (rows, events) = stable_snapshot(&mut session).await?;
+    check_view_against_events(&rows, &events);
+    assert!(
+        events.len() > events_before,
+        "killing compute nodes must append recovery events: before={events_before}, after={}",
+        events.len()
+    );
+    for name in ["dev", "db2"] {
+        assert_eq!(row(&rows, name).recovery_state, "RUNNING");
+    }
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_recovery_info_view_after_meta_kill() -> Result<()> {
+    let mut cluster = Cluster::start(Configuration::for_background_ddl()).await?;
+    let session = setup_two_databases(&mut cluster).await?;
+    drop(session);
+
+    kill_cn_and_meta_and_wait_recover(&mut cluster).await;
+
+    let mut session = cluster.start_session();
+    let (rows, events) = stable_snapshot(&mut session).await?;
+    check_view_against_events(&rows, &events);
+    // The event log is in-memory on meta, so everything present was emitted by
+    // the restarted meta, whose bootstrap is a global recovery.
+    assert!(
+        events
+            .iter()
+            .any(|e| e.event_type == "GLOBAL_RECOVERY_SUCCESS"),
+        "restarted meta must log a global recovery success: {events:?}"
+    );
+    for name in ["dev", "db2"] {
+        let r = row(&rows, name);
+        assert_eq!(r.recovery_state, "RUNNING", "database {name}: {r:?}");
+        // RUNNING must be explained by one of the two mechanisms: the last
+        // global recovery brought the database up, or the database logged its
+        // own success afterwards.
+        assert!(
+            r.in_global_running.unwrap_or(false) || r.last_database_event == "SUCCESS",
+            "database {name} is RUNNING without a mechanism explaining it: {r:?}"
+        );
+    }
+    Ok(())
+}

--- a/src/tests/simulation/tests/integration_tests/utils.rs
+++ b/src/tests/simulation/tests/integration_tests/utils.rs
@@ -17,7 +17,6 @@ use std::time::Duration;
 
 use anyhow::{Result, anyhow};
 use risingwave_simulation::cluster::{Cluster, KillOpts, Session};
-use serde::Deserialize;
 use tokio::time::{Instant, sleep};
 
 pub(crate) async fn kill_cn_and_wait_recover(cluster: &mut Cluster) {
@@ -103,205 +102,21 @@ pub(crate) async fn wait_member_table_ids(
     ))
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub enum DatabaseRecoveryState {
-    Running,
-    Recovering,
-    Unknown,
-}
-
-impl DatabaseRecoveryState {
-    fn from_str(state: &str) -> Self {
-        match state.trim() {
-            "RUNNING" => Self::Running,
-            "RECOVERING" => Self::Recovering,
-            "UNKNOWN" => Self::Unknown,
-            other => panic!("Unexpected recovery state: {other}"),
-        }
-    }
-
-    fn is_running(self) -> bool {
-        matches!(self, Self::Running)
-    }
-}
-
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-enum DatabaseRecoveryEvent {
-    Success,
-    Start,
-    Failure,
-    Unknown,
-}
-
-impl DatabaseRecoveryEvent {
-    fn from_str(event: &str) -> Self {
-        match event.trim() {
-            "SUCCESS" => Self::Success,
-            "START" => Self::Start,
-            "FAILURE" => Self::Failure,
-            "UNKNOWN" => Self::Unknown,
-            other => panic!("Unexpected last database event: {other}"),
-        }
-    }
-
-    fn is_success(self) -> bool {
-        matches!(self, Self::Success)
-    }
-}
-
-#[derive(Debug)]
-pub(crate) struct DatabaseRecoveryInfo {
-    id: u32,
-    name: String,
-    last_database_event: DatabaseRecoveryEvent,
-    last_global_event: GlobalRecoveryEvent,
-    in_global_running: bool,
-    in_global_recovering: bool,
-    state: DatabaseRecoveryState,
-}
-
-#[derive(Deserialize)]
-struct DatabaseRecoveryRow {
-    #[serde(rename = "database_id")]
-    database_id: u32,
-    #[serde(rename = "database_name")]
-    database_name: String,
-    #[serde(rename = "last_database_event")]
-    last_database_event: String,
-    #[serde(rename = "last_global_event")]
-    last_global_event: String,
-    #[serde(rename = "recovery_state")]
-    recovery_state: String,
-    #[serde(rename = "in_global_running")]
-    in_global_running: bool,
-    #[serde(rename = "in_global_recovering")]
-    in_global_recovering: bool,
-}
-
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-enum GlobalRecoveryEvent {
-    Running,
-    Recovering,
-    Unknown,
-}
-
-impl GlobalRecoveryEvent {
-    fn from_str(event: &str) -> Self {
-        match event.trim() {
-            "RUNNING" => Self::Running,
-            "RECOVERING" => Self::Recovering,
-            "UNKNOWN" => Self::Unknown,
-            other => panic!("Unexpected global recovery event: {other}"),
-        }
-    }
-}
-
-const ALL_DATABASE_RECOVERY_STATUS_SQL: &str = r#"
-SELECT jsonb_build_object(
-    'database_id', database_id,
-    'database_name', database_name,
-    'recovery_state', recovery_state,
-    'last_database_event', last_database_event,
-    'last_global_event', last_global_event,
-    'in_global_running', in_global_running,
-    'in_global_recovering', in_global_recovering
-) AS json_line
-FROM rw_catalog.rw_recovery_info;
-"#;
-
-pub(crate) async fn query_all_database_recovery_state(
-    cluster: &mut Cluster,
-) -> Result<Vec<DatabaseRecoveryInfo>> {
+/// Whether every database in the cluster reports `RUNNING` in
+/// `rw_catalog.rw_recovery_info`. Errors (e.g. meta still down) map to `false`.
+async fn cluster_fully_running(cluster: &mut Cluster) -> bool {
     let mut session = cluster.start_session();
-    let output = session.run(ALL_DATABASE_RECOVERY_STATUS_SQL).await?;
-    drop(session);
-
-    let mut result = Vec::new();
-    for line in output.lines().filter(|line| !line.trim().is_empty()) {
-        let row: DatabaseRecoveryRow = serde_json::from_str(line)?;
-        result.push(DatabaseRecoveryInfo {
-            id: row.database_id,
-            name: row.database_name,
-            last_database_event: DatabaseRecoveryEvent::from_str(&row.last_database_event),
-            last_global_event: GlobalRecoveryEvent::from_str(&row.last_global_event),
-            in_global_running: row.in_global_running,
-            in_global_recovering: row.in_global_recovering,
-            state: DatabaseRecoveryState::from_str(&row.recovery_state),
-        });
-    }
-    Ok(result)
-}
-
-fn validate_global_consistency(databases: &[DatabaseRecoveryInfo]) {
-    for info in databases {
-        let expected = derive_state(
-            info.last_database_event,
-            info.last_global_event,
-            info.in_global_running,
-            info.in_global_recovering,
-        );
-        if info.state != expected {
-            panic!(
-                "Derived recovery state mismatch for database {}({}): expected {:?}, got {:?}",
-                info.name, info.id, expected, info.state
-            );
-        }
-
-        if info.in_global_running && info.in_global_recovering {
-            panic!(
-                "Database {}({}) marked as both running and recovering in global event",
-                info.name, info.id
-            );
-        }
-
-        if info.last_global_event == GlobalRecoveryEvent::Running
-            && !info.in_global_running
-            && !info.in_global_recovering
-        {
-            panic!(
-                "Global recovery event indicates RUNNING but database {}({}) absent from both running and recovering ids",
-                info.name, info.id
-            );
-        }
-    }
-}
-
-fn derive_state(
-    database_event: DatabaseRecoveryEvent,
-    global_event: GlobalRecoveryEvent,
-    in_global_running: bool,
-    in_global_recovering: bool,
-) -> DatabaseRecoveryState {
-    let global_running = matches!(global_event, GlobalRecoveryEvent::Running);
-    let global_recovering = matches!(global_event, GlobalRecoveryEvent::Recovering);
-
-    if database_event.is_success() || (global_running && in_global_running) {
-        DatabaseRecoveryState::Running
-    } else if (global_running && in_global_recovering)
-        || global_recovering
-        || matches!(database_event, DatabaseRecoveryEvent::Start)
-    {
-        DatabaseRecoveryState::Recovering
-    } else {
-        DatabaseRecoveryState::Unknown
-    }
-}
-
-pub(crate) async fn cluster_fully_running(cluster: &mut Cluster) -> Result<bool> {
-    let db_statuses = match query_all_database_recovery_state(cluster).await {
-        Ok(statuses) => statuses,
-        Err(_) => return Ok(false),
+    let Ok(output) = session
+        .run("SELECT recovery_state FROM rw_catalog.rw_recovery_info;")
+        .await
+    else {
+        return false;
     };
-
-    if db_statuses.is_empty() {
-        return Ok(false);
-    }
-
-    validate_global_consistency(&db_statuses);
-
-    let fully_running = db_statuses.iter().all(|info| info.state.is_running());
-
-    Ok(fully_running)
+    let states: Vec<_> = (output.lines())
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .collect();
+    !states.is_empty() && states.iter().all(|s| *s == "RUNNING")
 }
 
 const WAIT_ALL_DB_TIMEOUT: Duration = Duration::from_secs(100);
@@ -310,7 +125,7 @@ const WAIT_ALL_DB_INTERVAL: Duration = Duration::from_millis(500);
 pub(crate) async fn wait_all_database_recovered(cluster: &mut Cluster) {
     let start = Instant::now();
     while start.elapsed() < WAIT_ALL_DB_TIMEOUT {
-        if matches!(cluster_fully_running(cluster).await, Ok(true)) {
+        if cluster_fully_running(cluster).await {
             return;
         }
         sleep(WAIT_ALL_DB_INTERVAL).await;

--- a/src/tests/simulation/tests/integration_tests/utils.rs
+++ b/src/tests/simulation/tests/integration_tests/utils.rs
@@ -26,7 +26,7 @@ pub(crate) async fn kill_cn_and_wait_recover(cluster: &mut Cluster) {
         .await;
     // Keep the sleep: probing too early can read a stale RUNNING before the kill lands.
     sleep(Duration::from_secs(10)).await;
-    cluster.wait_for_recovery().await.unwrap();
+    wait_all_database_recovered(cluster).await;
 }
 
 pub(crate) async fn kill_cn_and_meta_and_wait_recover(cluster: &mut Cluster) {
@@ -34,7 +34,7 @@ pub(crate) async fn kill_cn_and_meta_and_wait_recover(cluster: &mut Cluster) {
         .kill_nodes(["compute-1", "compute-2", "compute-3", "meta-1"], 0)
         .await;
     sleep(Duration::from_secs(10)).await;
-    cluster.wait_for_recovery().await.unwrap();
+    wait_all_database_recovered(cluster).await;
 }
 
 pub(crate) async fn kill_random_and_wait_recover(cluster: &mut Cluster) {
@@ -197,8 +197,16 @@ impl GlobalRecoveryEvent {
 }
 
 const ALL_DATABASE_RECOVERY_STATUS_SQL: &str = r#"
-SELECT row_to_json(row) AS json_line
-FROM rw_catalog.rw_recovery_info AS row;
+SELECT jsonb_build_object(
+    'database_id', database_id,
+    'database_name', database_name,
+    'recovery_state', recovery_state,
+    'last_database_event', last_database_event,
+    'last_global_event', last_global_event,
+    'in_global_running', in_global_running,
+    'in_global_recovering', in_global_recovering
+) AS json_line
+FROM rw_catalog.rw_recovery_info;
 "#;
 
 pub(crate) async fn query_all_database_recovery_state(
@@ -246,20 +254,6 @@ fn validate_global_consistency(databases: &[DatabaseRecoveryInfo]) {
             );
         }
 
-        if info.in_global_running && !info.last_database_event.is_success() {
-            panic!(
-                "Global recovery marks database {}({}) running but latest database event is {:?}",
-                info.name, info.id, info.last_database_event
-            );
-        }
-
-        if info.in_global_recovering && info.last_database_event.is_success() {
-            panic!(
-                "Global recovery marks database {}({}) recovering but latest database event is SUCCESS",
-                info.name, info.id
-            );
-        }
-
         if info.last_global_event == GlobalRecoveryEvent::Running
             && !info.in_global_running
             && !info.in_global_recovering
@@ -279,10 +273,12 @@ fn derive_state(
     in_global_recovering: bool,
 ) -> DatabaseRecoveryState {
     let global_running = matches!(global_event, GlobalRecoveryEvent::Running);
+    let global_recovering = matches!(global_event, GlobalRecoveryEvent::Recovering);
 
     if database_event.is_success() || (global_running && in_global_running) {
         DatabaseRecoveryState::Running
     } else if (global_running && in_global_recovering)
+        || global_recovering
         || matches!(database_event, DatabaseRecoveryEvent::Start)
     {
         DatabaseRecoveryState::Recovering
@@ -309,7 +305,7 @@ pub(crate) async fn cluster_fully_running(cluster: &mut Cluster) -> Result<bool>
 }
 
 const WAIT_ALL_DB_TIMEOUT: Duration = Duration::from_secs(100);
-const WAIT_ALL_DB_INTERVAL: Duration = Duration::from_secs(10);
+const WAIT_ALL_DB_INTERVAL: Duration = Duration::from_millis(500);
 
 pub(crate) async fn wait_all_database_recovered(cluster: &mut Cluster) {
     let start = Instant::now();


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

`kill_cn_and_wait_recover` / `kill_cn_and_meta_and_wait_recover` waited on `Cluster::wait_for_recovery`, which polls `rw_recovery_status()` — the **global** barrier manager status. A per-database recovery never flips that status back, so the helpers can return while a database is still blocked:

```
14:55:57.413  bootstrap_recovery: recovery success
14:55:57.413  cluster marked as ready blocked_databases={1}
14:55:57.431  failed to inject initial barrier database_id=1 e=unconnected worker node 2
14:55:57.943  meta WARN: frontend subscribe returns empty streaming_worker_slot_mappings
14:55:57.947  frontend: Refresh streaming vnode mapping for fragments [].
14:56:04.683  failed to inject initial barrier database_id=1 e=unconnected worker node 6
14:56:08.143  SELECT rw_recovery_status() -> RUNNING
14:56:08.195  DELETE FROM t WHERE v1 <= 50 -> Streaming vnode mapping not found for fragment 2
```

- A frontend that re-subscribes inside that window gets an empty streaming vnode mapping snapshot — it is built from the in-memory `shared_actor_info`, which is only populated once the database finishes recovering. Serving mappings come from the catalog, so reads keep working and only DML fails.
- Both helpers now use `wait_all_database_recovered`, which `kill_cn_meta_and_wait_full_recovery` already uses and which checks every database through `rw_catalog.rw_recovery_info`.

That helper had never actually run. Its query was

```sql
SELECT row_to_json(row) AS json_line FROM rw_catalog.rw_recovery_info AS row;
```

`row_to_json` is not implemented in RisingWave (this line was its only occurrence in the tree) and `row` is a keyword, so every call failed with `sql parser error: expected (, found: )`. `query_all_database_recovery_state` therefore always returned `Err`, `cluster_fully_running` always reported `false`, and `wait_all_database_recovered` silently burned its full 100s timeout — which is why routing the kill helpers through it first broke `backfill_tests::test_arrangement_backfill_progress` (`progress not within bounds 11.6`) and `recovery::background_ddl::test_ddl_cancel` (`cancel jobs ;` with no jobs left).

So this PR reworks the helper: `cluster_fully_running` now polls `SELECT recovery_state FROM rw_catalog.rw_recovery_info` every 500ms (was 10s) and reports true when the result is non-empty and all rows are `RUNNING`.

The Rust-side validation layer (`validate_global_consistency` / `derive_state` / the event enums) is removed rather than fixed. Once the query parsed, it panicked on states the view produces on purpose (`main-cron` 9877 seed 20, `test_background_join_mv_recovery`: `Global recovery marks database dev(1) running but latest database event is Unknown`) — a global recovery lists the databases it brought up in `GLOBAL_RECOVERY_SUCCESS` without emitting per-database events, so `in_global_running` / `in_global_recovering` imply nothing about the latest database event. Of the remaining checks, `derive_state` was a Rust transcription of the view's own `CASE` (it can only fire when the view SQL changes, and then inside whichever recovery test happens to be polling), and the "`RUNNING` but absent from both id lists" check is unsatisfiable by construction of the view SQL. None of it is needed to wait for recovery.

The removed validator's job is taken over by a new `recovery::recovery_info` test, in the shape that actually works: instead of asserting relations between the view's own output columns from inside a shared polling helper, it re-derives every `rw_recovery_info` column from the raw `rw_event_logs` rows after a known recovery scenario (CN-only kill, meta+CN kill) and compares. It also pins the scenario-anchored facts: recovery appends events, a restarted meta logs a `GLOBAL_RECOVERY_SUCCESS` (the event log is in-memory on meta), a `RUNNING` database is always explained by `in_global_running` or a `SUCCESS` database event, and a freshly created database reports `UNKNOWN`.

The 100s timeout stays silent on purpose: `cross_db_retention::test_cross_db_retention_miss_after_restart_does_not_recover` and `background_ddl::test_foreground_snapshot_backfill_recovery_keeps_hummock_table_catalog_fetchable` both leave a database short of `RUNNING` by design.

Verification (final revision):

- Full `recovery::` filter suite (48 tests; the substring filter also pulls in `sink::recovery::*` and `log_store::recovery::*`): 48/48 pass on both seed 1 and seed 20.
- Targeted: `test_background_join_mv_recovery` seed 20 (the 9877 panic), `test_background_agg_mv_recovery` seed 27, `test_batch_refresh_periodic_update` seed 1, `test_cross_db_retention_miss_after_restart_does_not_recover` seed 1, `test_arrangement_backfill_progress` / `test_ddl_cancel` seed 1 — all pass. The first canary's `±1.5%` progress assertion (at 1 record/s, 1% ≈ 10 virtual seconds) bounds the helper's return to within ~15 virtual seconds of recovery completing, ruling out another silent timeout.
- New `recovery_info` tests: pass on seeds 1/20/27.
- On `main`, `test_batch_refresh_periodic_update` fails for seeds 27/49/58 (the seeds red in `main-cron` build 9858, job `integration test (madsim) - recovery`).

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [x] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/dev/src/ci.md#ci-labels-guide -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->

## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

</details>
