### PR TITLE
fix(meta): gate batch refresh job completion on upstream snapshot epoch commit

### DIFF
--- a/src/meta/src/barrier/checkpoint/control.rs
+++ b/src/meta/src/barrier/checkpoint/control.rs
@@ -1002,8 +1002,8 @@ impl DatabaseCheckpointControl {
                         }
                     }
                     IndependentCheckpointJobControl::BatchRefresh(batch_refresh_job) => {
-                        if let Some((epoch, resps, info, tracking_job)) =
-                            batch_refresh_job.start_completing(partial_graph_manager)
+                        if let Some((epoch, resps, info, tracking_job)) = batch_refresh_job
+                            .start_completing(partial_graph_manager, committed_epoch)
                         {
                             let resps = resps.into_values().collect_vec();
                             if let Some(tracking_job) = tracking_job {

--- a/src/meta/src/barrier/checkpoint/independent_job/batch_refresh_job/mod.rs
+++ b/src/meta/src/barrier/checkpoint/independent_job/batch_refresh_job/mod.rs
@@ -920,12 +920,18 @@ impl BatchRefreshJobCheckpointControl {
     pub(crate) fn start_completing(
         &mut self,
         partial_graph_manager: &mut PartialGraphManager,
+        upstream_committed_epoch: u64,
     ) -> Option<(
         u64,
         HashMap<WorkerId, BarrierCompleteResponse>,
         PartialGraphBarrierInfo,
         Option<TrackingJob>,
     )> {
+        // Do not complete any barrier until upstream has committed the snapshot epoch,
+        // since completing the first barrier persists the snapshot epoch to catalog.
+        if upstream_committed_epoch < self.snapshot_epoch {
+            return None;
+        }
         match &self.status {
             BatchRefreshJobStatus::ConsumingSnapshot { .. }
             | BatchRefreshJobStatus::FinishingSnapshot { .. }


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

Fix the permanent per-database recovery loop that turns the main-cron `background_ddl, arrangement_backfill recovery test (madsim)` lane red daily on `e2e_test/streaming/batch_refresh_periodic.slt` (e.g. [build 9858](https://buildkite.com/risingwavelabs/main-cron/builds/9858#01a03112-0c55-4b5f-b377-32421fc7b394), [build 9814](https://buildkite.com/risingwavelabs/main-cron/builds/9814#01a0122b-e90e-40d0-8c6c-a0dafaeb73c5)): after compute nodes are killed right after a batch-refresh `CREATE MATERIALIZED VIEW`, meta loops forever with `downstream epoch ... later than upstream epoch ... of table ...` and the database never recovers.

- A batch refresh job's first partial-graph barrier completes independently of the database graph. Its post-collect persists the snapshot epoch (the command barrier's `prev_epoch`, not committed yet at that point) into the catalog fragments and marks the job `Creating`.
- If compute nodes crash before the database graph commits that epoch, every recovery attempt bails in `resolve_hummock_version_epochs`, and the upstream committed epoch can never advance while the database is down.
- Fix: mirror the existing guard in `CreatingStreamingJobControl::start_completing` — complete no barrier of the batch refresh job until the database graph has committed the snapshot epoch. A crash before that leaves the job in `Initial`, so recovery cleans it as a dirty background job.

Verified with a targeted madsim repro (background `CREATE`, then kill all compute nodes 50ms later): seed 7 reproduces the recovery loop on `main` (94 bails) and passes with this fix; the `recovery::batch_refresh::` madsim suite passes.

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [x] <!-- OPTIONAL --> I have added test labels as necessary.
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them.
- [ ] <!-- OPTIONAL --> My PR contains breaking changes.
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results.
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into.

## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates.

<details>
<summary><b>Release note</b></summary>

</details>
