### PR TITLE
fix(udf): support standard http/https endpoints in USING LINK

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13534,6 +13534,7 @@ dependencies = [
  "thiserror 2.0.17",
  "thiserror-ext",
  "tracing",
+ "url",
  "uuid",
  "workspace-hack",
  "zstd",

--- a/e2e_test/error_ui/simple/main.slt
+++ b/e2e_test/error_ui/simple/main.slt
@@ -15,7 +15,7 @@ create function int_42() returns int as int_42 using link '555.0.0.1:8815';
 db error: ERROR: Failed to run the query
 
 Caused by these errors (recent errors listed first):
-  1: failed to parse address: http://555.0.0.1:8815
+  1: failed to parse UDF link: 555.0.0.1:8815
   2: invalid IPv4 address
 
 

--- a/src/expr/impl/Cargo.toml
+++ b/src/expr/impl/Cargo.toml
@@ -12,7 +12,7 @@ repository = { workspace = true }
 ignored = ["chrono-tz", "futures-async-stream"]
 
 [features]
-udf = ["arrow-udf-runtime", "tonic", "ginepro", "zstd"]
+udf = ["arrow-udf-runtime", "tonic", "ginepro", "zstd", "url"]
 
 [dependencies]
 aho-corasick = "1"
@@ -67,8 +67,9 @@ thiserror = { workspace = true }
 thiserror-ext = { workspace = true }
 tokio = { workspace = true }
 # For arrow-udf-runtime/remote
-tonic = { workspace = true, optional = true }
+tonic = { workspace = true, optional = true, features = ["tls-native-roots"] }
 tracing = "0.1"
+url = { version = "2", optional = true }
 uuid = { version = "1", features = ["v4"] }
 zstd = { version = "0.13", default-features = false, optional = true }
 

--- a/src/expr/impl/src/udf/external.rs
+++ b/src/expr/impl/src/udf/external.rs
@@ -227,25 +227,23 @@ async fn connect_tonic(addr: &str) -> Result<tonic::transport::Channel> {
 
 /// Parse a UDF link into `(tls, host, port)`.
 ///
-/// The link may be a plain `host:port`, or an `http://` / `https://` URL, where `https` enables
-/// TLS and an omitted port defaults to 80 / 443.
+/// The link is an `http://` / `https://` URL, with `http://` as the default scheme when omitted.
+/// `https` enables TLS; an omitted port defaults to 80 / 443.
 fn parse_udf_link(link: &str) -> Result<(bool, String, u16)> {
-    let (tls, rest) = match link.split_once("://") {
-        Some((scheme, rest)) if scheme.eq_ignore_ascii_case("https") => (true, rest),
-        Some((scheme, rest)) if scheme.eq_ignore_ascii_case("http") => (false, rest),
-        Some((scheme, _)) => bail!("unsupported scheme in UDF link: {scheme}"),
-        None => (false, link),
+    let url = match url::Url::parse(link) {
+        Ok(url) if matches!(url.scheme(), "http" | "https") => url,
+        Ok(url) if link.contains("://") => {
+            bail!("unsupported scheme in UDF link: {}", url.scheme())
+        }
+        // no scheme (a plain `host:port` parses as scheme `host`): default to `http://`
+        _ => url::Url::parse(&format!("http://{link}"))
+            .with_context(|| format!("failed to parse UDF link: {link}"))?,
     };
-    let scheme = if tls { "https" } else { "http" };
-    let url = url::Url::parse(&format!("{scheme}://{rest}"))
-        .with_context(|| format!("failed to parse UDF link: {link}"))?;
-    let host = url
-        .host_str()
-        .with_context(|| format!("no host in UDF link: {link}"))?;
+    let host = url.host_str().expect("http(s) URL always has a host");
     let port = url
         .port_or_known_default()
         .expect("http(s) scheme always has a default port");
-    Ok((tls, host.to_owned(), port))
+    Ok((url.scheme() == "https", host.to_owned(), port))
 }
 
 impl ExternalFunction {
@@ -355,7 +353,26 @@ mod tests {
             (true, "example.com".into(), 8443)
         );
         assert_eq!(parse("[::1]:8815"), (false, "[::1]".into(), 8815));
+        assert_eq!(parse("example.com:80"), (false, "example.com".into(), 80));
+        assert_eq!(parse("example.com:443"), (false, "example.com".into(), 443));
+        // WHATWG parsing tolerates missing slashes after `http(s):`
+        assert_eq!(
+            parse("http:/example.com"),
+            (false, "example.com".into(), 80)
+        );
+        assert_eq!(
+            parse("https:/example.com"),
+            (true, "example.com".into(), 443)
+        );
+        assert_eq!(parse("http:example.com"), (false, "example.com".into(), 80));
+        // a scheme-less link defaults to `http://`
+        assert_eq!(parse("localhost"), (false, "localhost".into(), 80));
+        assert_eq!(
+            parse("udf.example.com"),
+            (false, "udf.example.com".into(), 80)
+        );
 
+        assert!(parse_udf_link("ftp://localhost:8815").is_err());
         assert!(parse_udf_link("localhost:12345:12345").is_err());
         assert!(parse_udf_link("localhost:65536").is_err());
         assert!(parse_udf_link("").is_err());

--- a/src/expr/impl/src/udf/external.rs
+++ b/src/expr/impl/src/udf/external.rs
@@ -24,9 +24,9 @@ use futures_util::{StreamExt, TryStreamExt};
 use ginepro::{LoadBalancedChannel, ResolutionStrategy};
 use risingwave_common::array::arrow::arrow_schema_udf::{self, Fields};
 use risingwave_common::array::arrow::{UdfArrowConvert, UdfToArrow};
-use risingwave_common::util::addr::HostAddr;
 use thiserror_ext::AsReport;
 use tokio::runtime::Runtime;
+use tonic::transport::ClientTlsConfig;
 
 use super::*;
 
@@ -198,7 +198,7 @@ fn get_or_create_flight_client(link: &str) -> Result<Arc<Client>> {
 }
 
 /// Connect to a UDF service and return a tonic `Channel`.
-async fn connect_tonic(mut addr: &str) -> Result<tonic::transport::Channel> {
+async fn connect_tonic(addr: &str) -> Result<tonic::transport::Channel> {
     // Interval between two successive probes of the UDF DNS.
     const DNS_PROBE_INTERVAL_SECS: u64 = 5;
     // Timeout duration for performing an eager DNS resolution.
@@ -206,24 +206,46 @@ async fn connect_tonic(mut addr: &str) -> Result<tonic::transport::Channel> {
     const REQUEST_TIMEOUT_SECS: u64 = 5;
     const CONNECT_TIMEOUT_SECS: u64 = 5;
 
-    if let Some(s) = addr.strip_prefix("http://") {
-        addr = s;
-    }
-    if let Some(s) = addr.strip_prefix("https://") {
-        addr = s;
-    }
-    let host_addr = addr.parse::<HostAddr>()?;
-    let channel = LoadBalancedChannel::builder((host_addr.host.clone(), host_addr.port))
+    let (tls, host, port) = parse_udf_link(addr)?;
+    let mut builder = LoadBalancedChannel::builder((host.clone(), port))
         .dns_probe_interval(std::time::Duration::from_secs(DNS_PROBE_INTERVAL_SECS))
         .timeout(Duration::from_secs(REQUEST_TIMEOUT_SECS))
         .connect_timeout(Duration::from_secs(CONNECT_TIMEOUT_SECS))
         .resolution_strategy(ResolutionStrategy::Eager {
             timeout: tokio::time::Duration::from_secs(EAGER_DNS_RESOLVE_TIMEOUT_SECS),
-        })
+        });
+    if tls {
+        // ginepro sets the TLS domain name (SNI) to `host` rather than the resolved IPs.
+        builder = builder.with_tls(ClientTlsConfig::new().with_native_roots());
+    }
+    let channel = builder
         .channel()
         .await
-        .with_context(|| format!("failed to create LoadBalancedChannel, address: {host_addr}"))?;
+        .with_context(|| format!("failed to create LoadBalancedChannel, address: {host}:{port}"))?;
     Ok(channel.into())
+}
+
+/// Parse a UDF link into `(tls, host, port)`.
+///
+/// The link may be a plain `host:port`, or an `http://` / `https://` URL, where `https` enables
+/// TLS and an omitted port defaults to 80 / 443.
+fn parse_udf_link(link: &str) -> Result<(bool, String, u16)> {
+    let (tls, rest) = match link.split_once("://") {
+        Some((scheme, rest)) if scheme.eq_ignore_ascii_case("https") => (true, rest),
+        Some((scheme, rest)) if scheme.eq_ignore_ascii_case("http") => (false, rest),
+        Some((scheme, _)) => bail!("unsupported scheme in UDF link: {scheme}"),
+        None => (false, link),
+    };
+    let scheme = if tls { "https" } else { "http" };
+    let url = url::Url::parse(&format!("{scheme}://{rest}"))
+        .with_context(|| format!("failed to parse UDF link: {link}"))?;
+    let host = url
+        .host_str()
+        .with_context(|| format!("no host in UDF link: {link}"))?;
+    let port = url
+        .port_or_known_default()
+        .expect("http(s) scheme always has a default port");
+    Ok((tls, host.to_owned(), port))
 }
 
 impl ExternalFunction {
@@ -301,4 +323,41 @@ fn data_types_match(a: &arrow_schema_udf::Schema, b: &arrow_schema_udf::Schema) 
         .iter()
         .zip(b.fields())
         .all(|(a, b)| a.data_type().equals_datatype(b.data_type()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse_udf_link;
+
+    #[test]
+    fn test_parse_udf_link() {
+        let parse = |link: &str| parse_udf_link(link).unwrap();
+        assert_eq!(parse("localhost:8815"), (false, "localhost".into(), 8815));
+        assert_eq!(parse("http://localhost"), (false, "localhost".into(), 80));
+        assert_eq!(
+            parse("http://localhost:80"),
+            (false, "localhost".into(), 80)
+        );
+        assert_eq!(
+            parse("http://localhost:8815"),
+            (false, "localhost".into(), 8815)
+        );
+        assert_eq!(
+            parse("https://example.com"),
+            (true, "example.com".into(), 443)
+        );
+        assert_eq!(
+            parse("https://example.com:443"),
+            (true, "example.com".into(), 443)
+        );
+        assert_eq!(
+            parse("https://example.com:8443"),
+            (true, "example.com".into(), 8443)
+        );
+        assert_eq!(parse("[::1]:8815"), (false, "[::1]".into(), 8815));
+
+        assert!(parse_udf_link("localhost:12345:12345").is_err());
+        assert!(parse_udf_link("localhost:65536").is_err());
+        assert!(parse_udf_link("").is_err());
+    }
 }


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

External UDF `USING LINK` could not address a standard HTTP(S) endpoint: the scheme was stripped and the rest parsed as `host:port` with a mandatory port, so `http://host`, `http://host:80` and `https://host` failed with `invalid port`, while `https://host:443` connected in plaintext because TLS was never enabled.

- Parse links per the WHATWG URL standard, with `http://` as the default scheme when none is given: `https` enables TLS on the ginepro channel (system native roots; SNI is set to the link hostname by our ginepro fork), `http` or scheme-less stays plaintext h2c, and an omitted port defaults from the scheme (80/443). This is one uniform rule — `host:port`, `host:80`, and a bare `host` are all just scheme-completed URLs.
- Reject unknown schemes with a clear error instead of a confusing `invalid port`.

Upgrade safety: all newly accepted forms were rejected before, and `CREATE FUNCTION` validates the link by connecting, so no persisted function can change target. The one intended behavior change for persisted links is `https://` now actually using TLS.

- Closes #26791

## Local e2e verification

Against a local cluster with an arrow-udf python server on ports 8815 and 80 (h2c) and a TLS-terminating proxy (ALPN h2, cert for `localhost` signed by a test CA injected via `SSL_CERT_FILE`) on 443 and 8443:

- `CREATE FUNCTION ... USING LINK` + `SELECT` succeed for all of: `localhost:8815`, `http://localhost:8815`, `http://localhost:80`, `http://localhost`, `https://localhost`, `https://localhost:8443`.
- `ftp://localhost:8815` fails with `unsupported scheme in UDF link: ftp`.
- `https://localhost:9443` serving a cert not signed by the trusted CA fails with `invalid peer certificate: UnknownIssuer` — certificate validation is active.

L7 load balancing (the motivating scenario) verified with nginx `grpc_pass` round-robin over two UDF backends, on both `http://localhost` (h2c :80) and `https://localhost` (TLS :443): nginx's per-request log shows strict backend alternation for gRPC requests arriving on a single client connection, and a query calling the UDF twice returns two different backend identities — i.e. individual HTTP/2 streams are demultiplexed across backends, which an L4 balancer cannot do.

## Follow-ups

- #26795: hardcoded 5s request/connect/DNS-probe timeouts of the external UDF channel are not configurable.
- #26796: custom CA / mTLS for private PKI.
- #26794: the same default-port normalization bug in `HostAddr` itself, fixed separately in the stacked PR.

## Checklist

- [x] I have written necessary rustdoc comments.
- [x] I have added necessary unit tests and integration tests.

## Documentation

- [x] My PR needs documentation updates. Docs PR: risingwavelabs/risingwave-docs#1534 (draft until this merges).

<details>
<summary><b>Release note</b></summary>

External UDF links (`CREATE FUNCTION ... USING LINK`) now accept standard HTTP(S) endpoints: `http://host` (port defaults to 80), `https://host` (port defaults to 443), and explicit default ports like `:80`. A scheme-less link defaults to `http://`. `https` links enable TLS with certificates validated against the system trust store.

</details>
