### PR TITLE
test(ci): run inline CDC source tests serially

### DIFF
--- a/ci/scripts/e2e-source-cdc-test.sh
+++ b/ci/scripts/e2e-source-cdc-test.sh
@@ -30,7 +30,7 @@ wget --no-verbose https://repo.mongodb.org/apt/ubuntu/dists/noble/mongodb-org/8.
 dpkg -i mongodb-mongosh_2.5.8_amd64.deb
 
 echo "--- Run inline CDC source tests"
-risedev slt './e2e_test/source_inline/cdc/**/*.slt' --skip 'cron_only' -j8
+risedev slt './e2e_test/source_inline/cdc/**/*.slt' --skip 'cron_only' -j1
 risedev slt './e2e_test/source_inline/cdc/**/*.slt.serial' --skip 'cron_only'
 
 echo "--- Run TVF source tests"


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

Run the inline CDC SLT suite with `-j1` instead of `-j8`.

- The files share one upstream MySQL / PG instance. A shared CDC source captures every table in the database, so one test's cleanup `DROP TABLE` can land inside another test's Debezium schema snapshot and kill the connector — see #26797 for the mechanism.
- 10 of the last 25 `end-to-end cdc source test` failures are this race (builds 99439 → 99760). The upstream table that vanishes differs each run; only the victim is stable.
- `-j1` rather than dropping the flag: without `-j`, sqllogictest runs everything in `dev`, and several files reuse object names (`s`, `t`, `tt1`). `-j1` keeps the per-file database and just removes the concurrency.

Cost: the inline CDC step goes from ~55s to ~5min (sum of the per-file times in a green run). The job as a whole goes from ~15min to ~19min, against a 30min timeout.

This is a CI mitigation only. The product bug is tracked in #26797.

## Checklist

- [x] I have written necessary rustdoc comments.
- [x] I have added necessary unit tests and integration tests.
- [x] I have added test labels as necessary.

## Documentation

- [ ] My PR needs documentation updates.
