### PR TITLE
fix(catalog): expose DML rate limits in rw_rate_limit

### DIFF
--- a/e2e_test/dml/rate_limit_pause_resume.slt
+++ b/e2e_test/dml/rate_limit_pause_resume.slt
@@ -8,6 +8,11 @@ alter table t set parallelism to 1;
 statement ok
 alter table t set dml_rate_limit to 0;
 
+query TI
+select node_name, rate_limit from rw_catalog.rw_rate_limit join rw_catalog.rw_relations on table_id = id where name = 't';
+----
+DML 0
+
 include ./inserts.slt.part
 
 
@@ -20,6 +25,10 @@ select count(*) from t;
 statement ok
 alter table t set dml_rate_limit to 1;
 
+query TI
+select node_name, rate_limit from rw_catalog.rw_rate_limit join rw_catalog.rw_relations on table_id = id where name = 't';
+----
+DML 1
 
 query II retry 6 backoff 1s
 select case when count(*) between 1 and 5 then 3 else 0 end from t;

--- a/src/common/src/catalog/mod.rs
+++ b/src/common/src/catalog/mod.rs
@@ -438,6 +438,7 @@ impl FragmentTypeFlag {
         Self::backfill_rate_limit_fragments()
             .chain(Self::source_rate_limit_fragments())
             .chain(Self::sink_rate_limit_fragments())
+            .chain(Self::dml_rate_limit_fragments())
     }
 
     pub fn dml_rate_limit_fragments() -> impl Iterator<Item = FragmentTypeFlag> {

--- a/src/meta/src/controller/streaming_job.rs
+++ b/src/meta/src/controller/streaming_job.rs
@@ -3789,6 +3789,10 @@ impl CatalogController {
                         rate_limit = node.rate_limit;
                         node_name = Some("SINK");
                     }
+                    PbNodeBody::Dml(node) => {
+                        rate_limit = node.rate_limit;
+                        node_name = Some("DML");
+                    }
                     _ => {}
                 }
 


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

- Include DML fragments when listing rate limits and expose configured DML nodes as `DML` rows in `rw_catalog.rw_rate_limit`.
- Add regression coverage for paused and resumed DML rate limits.

## Checklist

- [ ] I have written necessary rustdoc comments.
- [x] I have added necessary unit tests and integration tests.
- [x] I have added test labels as necessary.
- [ ] I have added fuzzing tests or opened an issue to track them.
- [ ] My PR contains breaking changes.
- [ ] My PR changes performance-critical code, so I will run (micro) benchmarks and present the results.
- [ ] I have checked the release timeline and supported versions to determine which release branches need cherry-picks.

## Documentation

- [x] My PR needs documentation updates.

<details>
<summary><b>Release note</b></summary>

`rw_catalog.rw_rate_limit` now reports configured DML rate limits.

</details>
