### PR TITLE
ci: require fork for community PR label

### DIFF
--- a/.github/workflows/label-community-contributor.yml
+++ b/.github/workflows/label-community-contributor.yml
@@ -10,9 +10,11 @@ permissions:
 
 jobs:
   label-community-contributor:
-    # Only label unaffiliated users and contributors, not owners, members, or collaborators.
+    # External community contributors submit pull requests from forks. Requiring a fork also
+    # avoids misclassifying private organization members whose association appears as CONTRIBUTOR.
     if: >-
       github.event.pull_request.user.type == 'User' &&
+      github.event.pull_request.head.repo.full_name != github.repository &&
       contains(
         fromJSON('["NONE", "CONTRIBUTOR", "FIRST_TIMER", "FIRST_TIME_CONTRIBUTOR"]'),
         github.event.pull_request.author_association


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What changed and what is your intention?

Require community pull requests to come from a fork in addition to matching the existing external contributor association allowlist.

Private organization memberships are not reliably represented by `pull_request.author_association`: an authenticated API request with `read:org` reports `MEMBER`, while the public representation can report `CONTRIBUTOR`. This caused repository-internal PRs #26801 and #26802 to be incorrectly labeled `community`. Both incorrect labels have been removed.

The new head-repository check prevents repository-internal branches from being classified as external community contributions while preserving normal fork-based external contributions.

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] I have added necessary unit tests and integration tests.
- [ ] I have added test labels as necessary.
- [ ] I have added fuzzing tests or opened an issue to track them.
- [ ] My PR contains breaking changes.
- [ ] My PR changes performance-critical code, so I will run (micro) benchmarks and present the results.
- [ ] I have checked the release timeline and supported versions for cherry-pick needs.

## Validation

- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.7 .github/workflows/label-community-contributor.yml`
- `git diff --check`
- Confirmed #26801 and #26802 originate from `risingwavelabs/risingwave` and no longer have the `community` label.

## Documentation

- [ ] My PR needs documentation updates.
