### PR TITLE
refactor(meta): unify independent job reset handling

### DIFF
--- a/src/meta/src/barrier/checkpoint/control.rs
+++ b/src/meta/src/barrier/checkpoint/control.rs
@@ -31,8 +31,8 @@ use risingwave_meta_model::WorkerId;
 use risingwave_pb::common::WorkerNode;
 use risingwave_pb::hummock::HummockVersionStats;
 use risingwave_pb::id::{FragmentId, PartialGraphId};
-use risingwave_pb::stream_plan::DispatcherType as PbDispatcherType;
 use risingwave_pb::stream_plan::stream_node::NodeBody;
+use risingwave_pb::stream_plan::{DispatcherType as PbDispatcherType, PbSubscriptionUpstreamInfo};
 use risingwave_pb::stream_service::BarrierCompleteResponse;
 use risingwave_pb::stream_service::streaming_control_stream_response::ResetPartialGraphResponse;
 use tracing::{debug, warn};
@@ -40,7 +40,7 @@ use uuid::Uuid;
 
 use crate::barrier::cdc_progress::CdcProgress;
 use crate::barrier::checkpoint::independent_job::{
-    BatchRefreshJobTriggerContext, IndependentCheckpointJobControl,
+    BatchRefreshJobTriggerContext, IndependentCheckpointJob, IndependentCheckpointJobControl,
 };
 use crate::barrier::checkpoint::recovery::{
     DatabaseRecoveringState, DatabaseStatusAction, EnterInitializing, EnterRunning,
@@ -521,8 +521,10 @@ impl CheckpointControl {
             .independent_checkpoint_job_controls
             .get(&job_id)
             .expect("job should exist")
+            .running()
+            .expect("job should be running")
         {
-            IndependentCheckpointJobControl::BatchRefresh(job) => job,
+            IndependentCheckpointJob::BatchRefresh(job) => job,
             _ => panic!("expected batch refresh job"),
         };
         if let Some(fragment_infos) = br_job.fragment_infos() {
@@ -560,7 +562,9 @@ impl CheckpointControl {
                         .remove(&independent_job_id)
                     {
                         Some(independent_job) => {
-                            independent_job.on_partial_graph_reset();
+                            database
+                                .pending_independent_job_subscriptions_to_drop
+                                .extend(independent_job.on_partial_graph_reset());
                         }
                         None => {
                             if cfg!(debug_assertions) {
@@ -600,11 +604,11 @@ impl CheckpointControl {
                     .independent_checkpoint_job_controls
                     .get_mut(&independent_job_id)
                     .expect("independent job should exist");
-                match job {
-                    IndependentCheckpointJobControl::BatchRefresh(job) => {
+                match job.running_mut().expect("job should be running") {
+                    IndependentCheckpointJob::BatchRefresh(job) => {
                         job.on_log_store_initialized(partial_graph_manager)
                     }
-                    IndependentCheckpointJobControl::CreatingStreamingJob(_) => {
+                    IndependentCheckpointJob::CreatingStreamingJob(_) => {
                         unreachable!("creating streaming job should not initialize when running")
                     }
                 }
@@ -630,7 +634,8 @@ impl CheckpointControl {
                         // Check if any idle batch refresh job should start a refresh run.
                         if let Some(committed_epoch) = database.committed_epoch {
                             for (job_id, job) in &database.independent_checkpoint_job_controls {
-                                if let IndependentCheckpointJobControl::BatchRefresh(br_job) = job
+                                if let Some(IndependentCheckpointJob::BatchRefresh(br_job)) =
+                                    job.running()
                                     && br_job.should_start_refresh(committed_epoch)
                                 {
                                     let job_id = *job_id;
@@ -762,6 +767,7 @@ pub(in crate::barrier) struct DatabaseCheckpointControl {
 
     pub(super) database_info: InflightDatabaseInfo,
     pub independent_checkpoint_job_controls: HashMap<JobId, IndependentCheckpointJobControl>,
+    pub(super) pending_independent_job_subscriptions_to_drop: Vec<PbSubscriptionUpstreamInfo>,
 }
 
 impl DatabaseCheckpointControl {
@@ -777,6 +783,7 @@ impl DatabaseCheckpointControl {
             last_committed_barrier_time: None,
             database_info: InflightDatabaseInfo::empty(database_id, shared_actor_infos),
             independent_checkpoint_job_controls: Default::default(),
+            pending_independent_job_subscriptions_to_drop: Default::default(),
         }
     }
 
@@ -799,6 +806,7 @@ impl DatabaseCheckpointControl {
             last_committed_barrier_time: None,
             database_info,
             independent_checkpoint_job_controls,
+            pending_independent_job_subscriptions_to_drop: Default::default(),
         }
     }
 
@@ -991,8 +999,11 @@ impl DatabaseCheckpointControl {
                 .first_inflight_barrier(self.partial_graph_id)
                 .map(|epoch| epoch.prev);
             for (job_id, job) in &mut self.independent_checkpoint_job_controls {
+                let Some(job) = job.running_mut() else {
+                    continue;
+                };
                 match job {
-                    IndependentCheckpointJobControl::CreatingStreamingJob(creating_job) => {
+                    IndependentCheckpointJob::CreatingStreamingJob(creating_job) => {
                         if let Some((epoch, resps, info, is_finish_epoch)) = creating_job
                             .start_completing(
                                 partial_graph_manager,
@@ -1009,7 +1020,7 @@ impl DatabaseCheckpointControl {
                             independent_jobs_task.push((*job_id, epoch, resps, info));
                         }
                     }
-                    IndependentCheckpointJobControl::BatchRefresh(batch_refresh_job) => {
+                    IndependentCheckpointJob::BatchRefresh(batch_refresh_job) => {
                         if let Some((epoch, resps, info, tracking_job)) = batch_refresh_job
                             .start_completing(partial_graph_manager, committed_epoch)
                         {
@@ -1035,9 +1046,10 @@ impl DatabaseCheckpointControl {
                 debug!(epoch, %job_id, "finish creating job");
                 // It's safe to remove the creating job, because on CompleteJobType::Finished,
                 // all previous barriers have been collected and completed.
-                let Some(IndependentCheckpointJobControl::CreatingStreamingJob(
-                    creating_streaming_job,
-                )) = self.independent_checkpoint_job_controls.remove(&job_id)
+                let Some(IndependentCheckpointJob::CreatingStreamingJob(creating_streaming_job)) =
+                    self.independent_checkpoint_job_controls
+                        .remove(&job_id)
+                        .and_then(IndependentCheckpointJobControl::into_running)
                 else {
                     panic!("finished job {job_id} should be a creating streaming job");
                 };
@@ -1233,7 +1245,7 @@ impl DatabaseCheckpointControl {
                 let Some(job) = self.independent_checkpoint_job_controls.get_mut(job_id) else {
                     return true;
                 };
-                !job.drop(notifier_start.as_mut(), partial_graph_manager)
+                !job.drop(*job_id, notifier_start.as_mut(), partial_graph_manager)
             });
             if streaming_job_ids.is_empty() {
                 if let Some(notifier) = notifier_start {
@@ -1350,9 +1362,11 @@ impl DatabaseCheckpointControl {
         let job = self
             .independent_checkpoint_job_controls
             .get(&job_id)
-            .expect("batch refresh job should exist");
+            .expect("batch refresh job should exist")
+            .running()
+            .expect("batch refresh job should be running");
         match job {
-            IndependentCheckpointJobControl::BatchRefresh(br_job) => br_job
+            IndependentCheckpointJob::BatchRefresh(br_job) => br_job
                 .last_committed_epoch()
                 .expect("idle job must have a last_committed_epoch"),
             _ => panic!("job {} should be a batch refresh job", job_id),
@@ -1374,9 +1388,11 @@ impl DatabaseCheckpointControl {
         let job = self
             .independent_checkpoint_job_controls
             .get_mut(&job_id)
-            .expect("batch refresh job should exist");
+            .expect("batch refresh job should exist")
+            .running_mut()
+            .expect("batch refresh job should be running");
         match job {
-            IndependentCheckpointJobControl::BatchRefresh(br_job) => br_job.start_refresh_run(
+            IndependentCheckpointJob::BatchRefresh(br_job) => br_job.start_refresh_run(
                 context,
                 worker_nodes,
                 actor_id_counter,

--- a/src/meta/src/barrier/checkpoint/control.rs
+++ b/src/meta/src/barrier/checkpoint/control.rs
@@ -512,6 +512,8 @@ impl CheckpointControl {
         database_id: DatabaseId,
         job_id: JobId,
     ) {
+        // This is called synchronously after `start_batch_refresh_run` returns `true`, with no
+        // barrier-worker event in between that could transition the job to Resetting.
         let database = self
             .databases
             .get_mut(&database_id)
@@ -875,7 +877,7 @@ impl DatabaseCheckpointControl {
     fn collect_backfill_pinned_upstream_tables(&self) -> HashSet<TableId> {
         self.independent_checkpoint_job_controls
             .values()
-            .flat_map(|job| job.pinned_upstream_tables())
+            .flat_map(|job| job.pinned_upstream_tables().iter().copied())
             .collect()
     }
 
@@ -1046,10 +1048,12 @@ impl DatabaseCheckpointControl {
                 debug!(epoch, %job_id, "finish creating job");
                 // It's safe to remove the creating job, because on CompleteJobType::Finished,
                 // all previous barriers have been collected and completed.
-                let Some(IndependentCheckpointJob::CreatingStreamingJob(creating_streaming_job)) =
-                    self.independent_checkpoint_job_controls
-                        .remove(&job_id)
-                        .and_then(IndependentCheckpointJobControl::into_running)
+                // `finished_jobs` was populated above only from a Running creating job, and the
+                // map cannot change between that scan and this removal.
+                let Some(IndependentCheckpointJobControl::Running {
+                    job: IndependentCheckpointJob::CreatingStreamingJob(creating_streaming_job),
+                    ..
+                }) = self.independent_checkpoint_job_controls.remove(&job_id)
                 else {
                     panic!("finished job {job_id} should be a creating streaming job");
                 };
@@ -1245,7 +1249,7 @@ impl DatabaseCheckpointControl {
                 let Some(job) = self.independent_checkpoint_job_controls.get_mut(job_id) else {
                     return true;
                 };
-                !job.drop(*job_id, notifier_start.as_mut(), partial_graph_manager)
+                !job.drop(notifier_start.as_mut(), partial_graph_manager)
             });
             if streaming_job_ids.is_empty() {
                 if let Some(notifier) = notifier_start {
@@ -1359,6 +1363,8 @@ impl DatabaseCheckpointControl {
 
     /// Get the last committed epoch for a batch refresh job.
     pub(crate) fn get_batch_refresh_trigger_info(&self, job_id: JobId) -> u64 {
+        // `CheckpointControl::next_event` emits a trigger only after matching this job as a
+        // Running batch-refresh job. The worker reads this value before awaiting any other work.
         let job = self
             .independent_checkpoint_job_controls
             .get(&job_id)
@@ -1384,6 +1390,8 @@ impl DatabaseCheckpointControl {
         actor_id_counter: &AtomicU32,
         partial_graph_manager: &mut PartialGraphManager,
     ) -> MetaResult<bool> {
+        // The global barrier worker handles the trigger serially. Although metadata loading is
+        // asynchronous, it does not process a drop/reset event before reaching this call.
         let term_id = self.term_id.as_str();
         let job = self
             .independent_checkpoint_job_controls

--- a/src/meta/src/barrier/checkpoint/independent_job/batch_refresh_job/mod.rs
+++ b/src/meta/src/barrier/checkpoint/independent_job/batch_refresh_job/mod.rs
@@ -1073,13 +1073,13 @@ impl BatchRefreshJobCheckpointControl {
         }
     }
 
-    pub(super) fn pinned_upstream_tables(&self) -> HashSet<TableId> {
+    pub(super) fn pinned_upstream_tables(&self) -> &HashSet<TableId> {
         match &self.status {
             BatchRefreshJobStatus::ConsumingSnapshot { .. }
             | BatchRefreshJobStatus::FinishingSnapshot { .. }
             | BatchRefreshJobStatus::ConsumingLogStore { .. }
             | BatchRefreshJobStatus::InitializingBatchRefresh { .. }
-            | BatchRefreshJobStatus::Idle { .. } => self.snapshot_backfill_upstream_tables.clone(),
+            | BatchRefreshJobStatus::Idle { .. } => &self.snapshot_backfill_upstream_tables,
         }
     }
 
@@ -1437,12 +1437,6 @@ impl BatchRefreshLogicalFragments {
             fragments: ctx.fragments.clone(),
             downstreams: ctx.downstreams.clone(),
         }
-    }
-}
-
-impl BatchRefreshJobCheckpointControl {
-    pub(super) fn partial_graph_id(&self) -> PartialGraphId {
-        self.partial_graph_id
     }
 }
 

--- a/src/meta/src/barrier/checkpoint/independent_job/batch_refresh_job/mod.rs
+++ b/src/meta/src/barrier/checkpoint/independent_job/batch_refresh_job/mod.rs
@@ -15,7 +15,7 @@
 //! Batch refresh job checkpoint control for periodically-refreshed materialized views.
 //!
 //! It lives permanently in `DatabaseCheckpointControl.independent_checkpoint_job_controls`
-//! as an `IndependentCheckpointJobControl::BatchRefresh` variant for its entire lifetime.
+//! as a running batch-refresh independent job for its entire lifetime.
 //!
 //! Lifecycle:
 //!   DDL → `ConsumingSnapshot` → `FinishingSnapshot` → `Idle`
@@ -49,7 +49,7 @@ use crate::barrier::command::{PostCollectCommand, ThrottleConfigMap, extract_thr
 use crate::barrier::context::CreateSnapshotBackfillJobCommandInfo;
 use crate::barrier::edge_builder::{EdgeBuilderFragmentInfo, FragmentEdgeBuilder};
 use crate::barrier::info::BarrierInfo;
-use crate::barrier::notifier::{CollectionNotifier, NotifierStarter};
+use crate::barrier::notifier::NotifierStarter;
 use crate::barrier::partial_graph::{
     CollectedBarrier, PartialGraphBarrierInfo, PartialGraphManager, PartialGraphStat,
 };
@@ -121,9 +121,6 @@ pub(crate) struct BatchRefreshJobTriggerContext {
 
 // ── Status ────────────────────────────────────────────────────────────────────
 
-/// The partial graph is being reset (always for drop).
-/// Once the reset is confirmed, the job is removed from the map.
-
 #[derive(Debug)]
 enum BatchRefreshJobStatus {
     /// The job is consuming upstream snapshot.
@@ -173,8 +170,6 @@ enum BatchRefreshJobStatus {
         /// `prev_epoch` of the stop barrier; becomes `last_committed_epoch` when transitioning to Idle.
         target_upstream_epoch: u64,
     },
-    /// The partial graph is being reset (for drop).
-    Resetting { notifiers: Vec<CollectionNotifier> },
 }
 
 // ── Complete type ─────────────────────────────────────────────────────────────
@@ -740,7 +735,7 @@ impl BatchRefreshJobCheckpointControl {
     ) -> MetaResult<()> {
         if !matches!(self.status, BatchRefreshJobStatus::ConsumingSnapshot { .. }) {
             // ConsumingLogStore has all barriers pre-injected; no forwarding needed.
-            // Idle and Resetting have no partial graph.
+            // Idle has no partial graph.
             return Ok(());
         }
         let (mutation, notifier) = match mutation {
@@ -938,8 +933,7 @@ impl BatchRefreshJobCheckpointControl {
             | BatchRefreshJobStatus::FinishingSnapshot { .. }
             | BatchRefreshJobStatus::ConsumingLogStore { .. } => {}
             BatchRefreshJobStatus::Idle { .. }
-            | BatchRefreshJobStatus::InitializingBatchRefresh { .. }
-            | BatchRefreshJobStatus::Resetting { .. } => {
+            | BatchRefreshJobStatus::InitializingBatchRefresh { .. } => {
                 return None;
             }
         };
@@ -1024,30 +1018,9 @@ impl BatchRefreshJobCheckpointControl {
             BatchRefreshJobStatus::ConsumingLogStore { .. } => {
                 partial_graph_manager.ack_completed(self.partial_graph_id, completed_epoch);
             }
-            BatchRefreshJobStatus::Resetting { .. } => {
-                // The job was dropped while the completing task was running in the background.
-                // The partial graph has already been reset, so skip the ack.
-            }
             BatchRefreshJobStatus::Idle { .. }
             | BatchRefreshJobStatus::InitializingBatchRefresh { .. } => {
                 unreachable!("batch refresh job should not be completing in this state")
-            }
-        }
-    }
-
-    /// Called when the partial graph reset is confirmed (drop only).
-    pub(super) fn on_partial_graph_reset(mut self) {
-        match &mut self.status {
-            BatchRefreshJobStatus::Resetting { notifiers } => {
-                for notifier in notifiers.drain(..) {
-                    notifier.notify_collected();
-                }
-            }
-            _ => {
-                panic!(
-                    "batch refresh job {}: on_partial_graph_reset in unexpected state {:?}",
-                    self.job_id, self.status
-                );
             }
         }
     }
@@ -1082,7 +1055,7 @@ impl BatchRefreshJobCheckpointControl {
                 progress: "BatchRefresh LogStore".to_owned(),
                 backfill_type: PbBackfillType::SnapshotBackfill,
             }),
-            BatchRefreshJobStatus::Idle { .. } | BatchRefreshJobStatus::Resetting { .. } => None,
+            BatchRefreshJobStatus::Idle { .. } => None,
         }
     }
 
@@ -1107,7 +1080,6 @@ impl BatchRefreshJobCheckpointControl {
             | BatchRefreshJobStatus::ConsumingLogStore { .. }
             | BatchRefreshJobStatus::InitializingBatchRefresh { .. }
             | BatchRefreshJobStatus::Idle { .. } => self.snapshot_backfill_upstream_tables.clone(),
-            BatchRefreshJobStatus::Resetting { .. } => HashSet::new(),
         }
     }
 
@@ -1119,8 +1091,7 @@ impl BatchRefreshJobCheckpointControl {
             }
             BatchRefreshJobStatus::ConsumingLogStore { fragment_infos, .. } => Some(fragment_infos),
             BatchRefreshJobStatus::FinishingSnapshot { .. }
-            | BatchRefreshJobStatus::Idle { .. }
-            | BatchRefreshJobStatus::Resetting { .. } => None,
+            | BatchRefreshJobStatus::Idle { .. } => None,
         }
     }
 
@@ -1469,69 +1440,9 @@ impl BatchRefreshLogicalFragments {
     }
 }
 
-// ── Drop handling ─────────────────────────────────────────────────────────────
-
 impl BatchRefreshJobCheckpointControl {
-    /// Drop this batch refresh job.
-    pub(super) fn drop(
-        &mut self,
-        notifier: Option<&mut NotifierStarter>,
-        partial_graph_manager: &mut PartialGraphManager,
-    ) -> bool {
-        match &mut self.status {
-            BatchRefreshJobStatus::Resetting {
-                notifiers: existing_notifiers,
-                ..
-            } => {
-                existing_notifiers.extend(notifier.map(NotifierStarter::add_notify));
-                true
-            }
-            BatchRefreshJobStatus::ConsumingSnapshot { .. }
-            | BatchRefreshJobStatus::FinishingSnapshot { .. }
-            | BatchRefreshJobStatus::InitializingBatchRefresh { .. }
-            | BatchRefreshJobStatus::ConsumingLogStore { .. } => {
-                partial_graph_manager.reset_partial_graphs([self.partial_graph_id]);
-                self.status = BatchRefreshJobStatus::Resetting {
-                    notifiers: notifier
-                        .map(NotifierStarter::add_notify)
-                        .into_iter()
-                        .collect(),
-                };
-                true
-            }
-            BatchRefreshJobStatus::Idle { .. } => {
-                // Idle has no running partial graph, but we still go through
-                // the reset flow so the cleanup path is uniform.
-                partial_graph_manager.reset_partial_graphs([self.partial_graph_id]);
-                self.status = BatchRefreshJobStatus::Resetting {
-                    notifiers: notifier
-                        .map(NotifierStarter::add_notify)
-                        .into_iter()
-                        .collect(),
-                };
-                true
-            }
-        }
-    }
-
-    /// Reset during database recovery.
-    ///
-    /// Returns `true` if the partial graph was already resetting (from a prior drop),
-    /// meaning we should not issue a new reset request.
-    pub(crate) fn reset(self) -> bool {
-        match self.status {
-            BatchRefreshJobStatus::ConsumingSnapshot { .. }
-            | BatchRefreshJobStatus::FinishingSnapshot { .. }
-            | BatchRefreshJobStatus::InitializingBatchRefresh { .. }
-            | BatchRefreshJobStatus::ConsumingLogStore { .. }
-            | BatchRefreshJobStatus::Idle { .. } => false,
-            BatchRefreshJobStatus::Resetting { notifiers, .. } => {
-                for notifier in notifiers {
-                    notifier.notify_collected();
-                }
-                true
-            }
-        }
+    pub(super) fn partial_graph_id(&self) -> PartialGraphId {
+        self.partial_graph_id
     }
 }
 

--- a/src/meta/src/barrier/checkpoint/independent_job/creating_job/mod.rs
+++ b/src/meta/src/barrier/checkpoint/independent_job/creating_job/mod.rs
@@ -37,7 +37,7 @@ use status::CreatingStreamingJobStatus;
 use tracing::{debug, info};
 
 use super::super::state::RenderResult;
-use super::IndependentCheckpointJobControl;
+use super::{IndependentCheckpointJob, IndependentCheckpointJobControl};
 use crate::MetaResult;
 use crate::barrier::backfill_order_control::get_nodes_with_backfill_dependencies;
 use crate::barrier::checkpoint::independent_job::creating_job::barrier_control::CreatingStreamingJobBarrierStats;
@@ -227,8 +227,8 @@ impl CreatingStreamingJobControl {
         let opts = &partial_graph_manager.control_stream_manager().env.opts;
         let max_pending_barrier_num = snapshot_backfill_max_pending_barrier_num(opts);
 
-        let IndependentCheckpointJobControl::CreatingStreamingJob(job) = entry.insert(
-            IndependentCheckpointJobControl::CreatingStreamingJob(Self {
+        let job_control = entry.insert(IndependentCheckpointJobControl::creating_streaming_job(
+            Self {
                 partial_graph_id,
                 job_id,
                 snapshot_backfill_upstream_tables,
@@ -242,10 +242,8 @@ impl CreatingStreamingJobControl {
                     .with_guarded_label_values(&[&format!("{}", job_id)]),
                 node_actors,
                 state_table_ids,
-            }),
-        ) else {
-            unreachable!()
-        };
+            },
+        ));
 
         let mut graph_adder = partial_graph_manager.add_partial_graph(
             partial_graph_id,
@@ -253,64 +251,80 @@ impl CreatingStreamingJobControl {
             CreatingStreamingJobBarrierStats::new(job_id, snapshot_epoch),
         );
 
-        if let Err(e) = Self::inject_barrier(
-            partial_graph_id,
-            graph_adder.manager(),
-            &job.node_actors,
-            &job.state_table_ids,
-            false,
-            initial_barrier_info,
-            Some(actors_to_create),
-            Some(initial_mutation),
-            notifier,
-            Some(create_info),
-        ) {
+        let inject_result = {
+            let Some(IndependentCheckpointJob::CreatingStreamingJob(job)) =
+                job_control.running_mut()
+            else {
+                unreachable!()
+            };
+            Self::inject_barrier(
+                partial_graph_id,
+                graph_adder.manager(),
+                &job.node_actors,
+                &job.state_table_ids,
+                false,
+                initial_barrier_info,
+                Some(actors_to_create),
+                Some(initial_mutation),
+                notifier,
+                Some(create_info),
+            )
+        };
+        if let Err(e) = inject_result {
             graph_adder.failed();
-            job.status = CreatingStreamingJobStatus::Resetting(vec![]);
-            Err(e)
-        } else {
-            graph_adder.added();
-            let job_info = CreatingJobInfo {
-                fragment_infos,
-                upstream_fragment_downstreams: info.upstream_fragment_downstreams.clone(),
-                downstreams: info.stream_job_fragments.downstreams,
-                snapshot_backfill_upstream_tables: job.snapshot_backfill_upstream_tables.clone(),
-                stream_actors: actors
-                    .stream_actors
-                    .values()
-                    .flatten()
-                    .map(|actor| (actor.actor_id, actor.clone()))
-                    .collect(),
+            *job_control = IndependentCheckpointJobControl::Resetting {
+                pinned_upstream_tables: job_control.pinned_upstream_tables(),
+                subscriptions_to_drop: vec![],
+                notifiers: vec![],
             };
-            if let Some(log_store_barriers_to_inject) = log_store_barriers_to_inject {
-                let upstream_lag = log_store_barriers_to_inject
-                    .last()
-                    .map(|info| info.prev_epoch().saturating_sub(snapshot_epoch))
-                    .unwrap_or(0);
-                job.status = CreatingStreamingJobStatus::ConsumingLogStore {
-                    tracking_job: TrackingJob::recovered(job_id, &job_info.fragment_infos),
-                    info: job_info,
-                    log_store_progress_tracker: CreateMviewLogStoreProgressTracker::new(
-                        snapshot_backfill_actors.iter().cloned(),
-                        upstream_lag,
-                    ),
-                    pending_barriers: log_store_barriers_to_inject.into(),
-                };
-            } else {
-                assert!(pending_non_checkpoint_barriers.is_empty());
-                job.status = CreatingStreamingJobStatus::ConsumingSnapshot {
-                    prev_epoch_fake_physical_time,
-                    pending_upstream_barriers: vec![],
-                    version_stats: version_stat.clone(),
-                    create_mview_tracker,
-                    snapshot_backfill_actors,
-                    snapshot_epoch,
-                    info: job_info,
-                    pending_non_checkpoint_barriers,
-                };
-            };
-            Ok(job)
+            return Err(e);
         }
+
+        graph_adder.added();
+        let Some(IndependentCheckpointJob::CreatingStreamingJob(job)) = job_control.running_mut()
+        else {
+            unreachable!()
+        };
+        let job_info = CreatingJobInfo {
+            fragment_infos,
+            upstream_fragment_downstreams: info.upstream_fragment_downstreams.clone(),
+            downstreams: info.stream_job_fragments.downstreams,
+            snapshot_backfill_upstream_tables: job.snapshot_backfill_upstream_tables.clone(),
+            stream_actors: actors
+                .stream_actors
+                .values()
+                .flatten()
+                .map(|actor| (actor.actor_id, actor.clone()))
+                .collect(),
+        };
+        if let Some(log_store_barriers_to_inject) = log_store_barriers_to_inject {
+            let upstream_lag = log_store_barriers_to_inject
+                .last()
+                .map(|info| info.prev_epoch().saturating_sub(snapshot_epoch))
+                .unwrap_or(0);
+            job.status = CreatingStreamingJobStatus::ConsumingLogStore {
+                tracking_job: TrackingJob::recovered(job_id, &job_info.fragment_infos),
+                info: job_info,
+                log_store_progress_tracker: CreateMviewLogStoreProgressTracker::new(
+                    snapshot_backfill_actors.iter().cloned(),
+                    upstream_lag,
+                ),
+                pending_barriers: log_store_barriers_to_inject.into(),
+            };
+        } else {
+            assert!(pending_non_checkpoint_barriers.is_empty());
+            job.status = CreatingStreamingJobStatus::ConsumingSnapshot {
+                prev_epoch_fake_physical_time,
+                pending_upstream_barriers: vec![],
+                version_stats: version_stat.clone(),
+                create_mview_tracker,
+                snapshot_backfill_actors,
+                snapshot_epoch,
+                info: job_info,
+                pending_non_checkpoint_barriers,
+            };
+        }
+        Ok(job)
     }
 
     pub(super) fn gen_fragment_backfill_progress(&self) -> Vec<FragmentBackfillProgress> {
@@ -324,7 +338,6 @@ impl CreatingStreamingJobControl {
                 collect_done_fragments(self.job_id, &info.fragment_infos)
             }
             CreatingStreamingJobStatus::Finishing(_, _)
-            | CreatingStreamingJobStatus::Resetting(_)
             | CreatingStreamingJobStatus::PlaceHolder => vec![],
         }
     }
@@ -786,7 +799,6 @@ impl CreatingStreamingJobControl {
                 );
                 format!("Finishing [epoch lag: {lag:?}]",)
             }
-            CreatingStreamingJobStatus::Resetting(_) => "Resetting".to_owned(),
             CreatingStreamingJobStatus::PlaceHolder => {
                 unreachable!()
             }
@@ -1003,9 +1015,6 @@ impl CreatingStreamingJobControl {
                     .map(Excluded)
                     .unwrap_or(Unbounded),
             ),
-            CreatingStreamingJobStatus::Resetting(..) => {
-                return None;
-            }
             CreatingStreamingJobStatus::PlaceHolder => {
                 unreachable!()
             }
@@ -1053,10 +1062,6 @@ impl CreatingStreamingJobControl {
                     assert!(completed_epoch > prev_max_committed_epoch);
                 }
             }
-            CreatingStreamingJobStatus::Resetting(_) => {
-                // The job was dropped while the completing task was running in the background.
-                // The partial graph has already been reset, so skip the ack.
-            }
             CreatingStreamingJobStatus::PlaceHolder => {
                 unreachable!()
             }
@@ -1071,7 +1076,6 @@ impl CreatingStreamingJobControl {
         match self.status {
             CreatingStreamingJobStatus::ConsumingSnapshot { .. }
             | CreatingStreamingJobStatus::ConsumingLogStore { .. }
-            | CreatingStreamingJobStatus::Resetting(..)
             | CreatingStreamingJobStatus::PlaceHolder => {
                 unreachable!("expect finish")
             }
@@ -1079,69 +1083,19 @@ impl CreatingStreamingJobControl {
         }
     }
 
-    pub(super) fn on_partial_graph_reset(mut self) {
-        match &mut self.status {
-            CreatingStreamingJobStatus::Resetting(notifiers) => {
-                for notifier in notifiers.drain(..) {
-                    notifier.notify_collected();
-                }
-            }
-            CreatingStreamingJobStatus::ConsumingSnapshot { .. }
-            | CreatingStreamingJobStatus::ConsumingLogStore { .. }
-            | CreatingStreamingJobStatus::Finishing(_, _) => {
-                panic!(
-                    "should be resetting when receiving reset partial graph resp, but at {:?}",
-                    self.status
-                )
-            }
-            CreatingStreamingJobStatus::PlaceHolder => {
-                unreachable!()
-            }
-        }
+    pub(super) fn partial_graph_id(&self) -> PartialGraphId {
+        self.partial_graph_id
     }
 
-    /// Drop a creating snapshot backfill job by directly resetting the partial graph
-    /// Return `false` if the partial graph has been merged to upstream database, and `true` otherwise
-    /// to mean that the job has been dropped.
-    pub(super) fn drop(
-        &mut self,
-        notifier: Option<&mut NotifierStarter>,
-        partial_graph_manager: &mut PartialGraphManager,
-    ) -> bool {
-        match &mut self.status {
-            CreatingStreamingJobStatus::Resetting(existing_notifiers) => {
-                existing_notifiers.extend(notifier.map(NotifierStarter::add_notify));
-                true
-            }
+    /// Whether the job can be dropped by resetting its independent partial graph.
+    ///
+    /// A finishing job has already been merged into the database graph, so it must be handled by
+    /// the database-graph drop command instead.
+    pub(super) fn can_drop_independently(&self) -> bool {
+        match &self.status {
             CreatingStreamingJobStatus::ConsumingSnapshot { .. }
-            | CreatingStreamingJobStatus::ConsumingLogStore { .. } => {
-                partial_graph_manager.reset_partial_graphs([self.partial_graph_id]);
-                self.status = CreatingStreamingJobStatus::Resetting(
-                    notifier
-                        .map(NotifierStarter::add_notify)
-                        .into_iter()
-                        .collect(),
-                );
-                true
-            }
+            | CreatingStreamingJobStatus::ConsumingLogStore { .. } => true,
             CreatingStreamingJobStatus::Finishing(_, _) => false,
-            CreatingStreamingJobStatus::PlaceHolder => {
-                unreachable!()
-            }
-        }
-    }
-
-    pub(crate) fn reset(self) -> bool {
-        match self.status {
-            CreatingStreamingJobStatus::ConsumingSnapshot { .. }
-            | CreatingStreamingJobStatus::ConsumingLogStore { .. }
-            | CreatingStreamingJobStatus::Finishing(_, _) => false,
-            CreatingStreamingJobStatus::Resetting(notifiers) => {
-                for notifier in notifiers {
-                    notifier.notify_collected();
-                }
-                true
-            }
             CreatingStreamingJobStatus::PlaceHolder => {
                 unreachable!()
             }

--- a/src/meta/src/barrier/checkpoint/independent_job/creating_job/mod.rs
+++ b/src/meta/src/barrier/checkpoint/independent_job/creating_job/mod.rs
@@ -227,23 +227,21 @@ impl CreatingStreamingJobControl {
         let opts = &partial_graph_manager.control_stream_manager().env.opts;
         let max_pending_barrier_num = snapshot_backfill_max_pending_barrier_num(opts);
 
-        let job_control = entry.insert(IndependentCheckpointJobControl::creating_streaming_job(
-            Self {
-                partial_graph_id,
-                job_id,
-                snapshot_backfill_upstream_tables,
-                max_committed_epoch: None,
-                snapshot_epoch,
-                status: CreatingStreamingJobStatus::PlaceHolder, // filled in later code
-                max_lagged_barrier_num,
-                max_pending_barrier_num,
-                upstream_lag: GLOBAL_META_METRICS
-                    .snapshot_backfill_lag
-                    .with_guarded_label_values(&[&format!("{}", job_id)]),
-                node_actors,
-                state_table_ids,
-            },
-        ));
+        let mut job = Self {
+            partial_graph_id,
+            job_id,
+            snapshot_backfill_upstream_tables,
+            max_committed_epoch: None,
+            snapshot_epoch,
+            status: CreatingStreamingJobStatus::PlaceHolder, // filled in later code
+            max_lagged_barrier_num,
+            max_pending_barrier_num,
+            upstream_lag: GLOBAL_META_METRICS
+                .snapshot_backfill_lag
+                .with_guarded_label_values(&[&format!("{}", job_id)]),
+            node_actors,
+            state_table_ids,
+        };
 
         let mut graph_adder = partial_graph_manager.add_partial_graph(
             partial_graph_id,
@@ -251,40 +249,28 @@ impl CreatingStreamingJobControl {
             CreatingStreamingJobBarrierStats::new(job_id, snapshot_epoch),
         );
 
-        let inject_result = {
-            let Some(IndependentCheckpointJob::CreatingStreamingJob(job)) =
-                job_control.running_mut()
-            else {
-                unreachable!()
-            };
-            Self::inject_barrier(
-                partial_graph_id,
-                graph_adder.manager(),
-                &job.node_actors,
-                &job.state_table_ids,
-                false,
-                initial_barrier_info,
-                Some(actors_to_create),
-                Some(initial_mutation),
-                notifier,
-                Some(create_info),
-            )
-        };
-        if let Err(e) = inject_result {
+        if let Err(e) = Self::inject_barrier(
+            partial_graph_id,
+            graph_adder.manager(),
+            &job.node_actors,
+            &job.state_table_ids,
+            false,
+            initial_barrier_info,
+            Some(actors_to_create),
+            Some(initial_mutation),
+            notifier,
+            Some(create_info),
+        ) {
             graph_adder.failed();
-            *job_control = IndependentCheckpointJobControl::Resetting {
-                pinned_upstream_tables: job_control.pinned_upstream_tables(),
+            entry.insert(IndependentCheckpointJobControl::Resetting {
+                pinned_upstream_tables: job.snapshot_backfill_upstream_tables,
                 subscriptions_to_drop: vec![],
                 notifiers: vec![],
-            };
+            });
             return Err(e);
         }
 
         graph_adder.added();
-        let Some(IndependentCheckpointJob::CreatingStreamingJob(job)) = job_control.running_mut()
-        else {
-            unreachable!()
-        };
         let job_info = CreatingJobInfo {
             fragment_infos,
             upstream_fragment_downstreams: info.upstream_fragment_downstreams.clone(),
@@ -324,6 +310,15 @@ impl CreatingStreamingJobControl {
                 pending_non_checkpoint_barriers,
             };
         }
+        let job_control = entry.insert(IndependentCheckpointJobControl::creating_streaming_job(
+            job_id,
+            partial_graph_id,
+            job,
+        ));
+        let Some(IndependentCheckpointJob::CreatingStreamingJob(job)) = job_control.running_mut()
+        else {
+            unreachable!()
+        };
         Ok(job)
     }
 
@@ -809,8 +804,8 @@ impl CreatingStreamingJobControl {
         }
     }
 
-    pub(super) fn pinned_upstream_tables(&self) -> HashSet<TableId> {
-        self.snapshot_backfill_upstream_tables.clone()
+    pub(super) fn pinned_upstream_tables(&self) -> &HashSet<TableId> {
+        &self.snapshot_backfill_upstream_tables
     }
 
     fn inject_barrier(
@@ -1081,10 +1076,6 @@ impl CreatingStreamingJobControl {
             }
             CreatingStreamingJobStatus::Finishing(_, tracking_job) => tracking_job,
         }
-    }
-
-    pub(super) fn partial_graph_id(&self) -> PartialGraphId {
-        self.partial_graph_id
     }
 
     /// Whether the job can be dropped by resetting its independent partial graph.

--- a/src/meta/src/barrier/checkpoint/independent_job/creating_job/status.rs
+++ b/src/meta/src/barrier/checkpoint/independent_job/creating_job/status.rs
@@ -32,7 +32,6 @@ use tracing::warn;
 
 use crate::barrier::checkpoint::independent_job::creating_job::CreatingJobInfo;
 use crate::barrier::command::{ThrottleConfigMap, extract_throttle_config};
-use crate::barrier::notifier::CollectionNotifier;
 use crate::barrier::partial_graph::PartialGraphManager;
 use crate::barrier::progress::{CreateMviewProgressTracker, TrackingJob};
 use crate::barrier::{BarrierInfo, BarrierKind, TracedEpoch};
@@ -132,7 +131,6 @@ pub(super) enum CreatingStreamingJobStatus {
     /// will be finished when all previously injected barriers have been collected
     /// Store the `prev_epoch` that will finish at.
     Finishing(u64, TrackingJob),
-    Resetting(Vec<CollectionNotifier>),
     PlaceHolder,
 }
 
@@ -202,8 +200,7 @@ impl CreatingStreamingJobStatus {
             } => {
                 log_store_progress_tracker.update(create_mview_progress);
             }
-            CreatingStreamingJobStatus::Finishing(..)
-            | CreatingStreamingJobStatus::Resetting(..) => {}
+            CreatingStreamingJobStatus::Finishing(..) => {}
             CreatingStreamingJobStatus::PlaceHolder => {
                 unreachable!()
             }
@@ -233,9 +230,6 @@ impl CreatingStreamingJobStatus {
             }
             CreatingStreamingJobStatus::Finishing { .. } => {
                 unreachable!("should not start consuming upstream for a job again")
-            }
-            CreatingStreamingJobStatus::Resetting(..) => {
-                unreachable!("unlikely to start consume upstream when resetting")
             }
             CreatingStreamingJobStatus::PlaceHolder => {
                 unreachable!()
@@ -314,8 +308,7 @@ impl CreatingStreamingJobStatus {
                 .map(|barrier_info| (barrier_info, None))
                 .collect()
             }
-            CreatingStreamingJobStatus::Finishing { .. }
-            | CreatingStreamingJobStatus::Resetting(..) => vec![],
+            CreatingStreamingJobStatus::Finishing { .. } => vec![],
             CreatingStreamingJobStatus::PlaceHolder => {
                 unreachable!()
             }
@@ -340,8 +333,7 @@ impl CreatingStreamingJobStatus {
             | CreatingStreamingJobStatus::ConsumingLogStore { info, .. } => {
                 Some(&info.fragment_infos)
             }
-            CreatingStreamingJobStatus::Finishing(..)
-            | CreatingStreamingJobStatus::Resetting(..) => None,
+            CreatingStreamingJobStatus::Finishing(..) => None,
             CreatingStreamingJobStatus::PlaceHolder => {
                 unreachable!()
             }
@@ -357,8 +349,7 @@ impl CreatingStreamingJobStatus {
             | CreatingStreamingJobStatus::ConsumingLogStore { info, .. } => {
                 &mut info.fragment_infos
             }
-            CreatingStreamingJobStatus::Finishing(..)
-            | CreatingStreamingJobStatus::Resetting(..) => return None,
+            CreatingStreamingJobStatus::Finishing(..) => return None,
             CreatingStreamingJobStatus::PlaceHolder => {
                 unreachable!()
             }
@@ -444,23 +435,6 @@ mod tests {
 
         assert_eq!(epochs(&injected), vec![(1, 2)]);
         assert!(pending_barriers.is_empty());
-    }
-
-    #[tokio::test]
-    async fn test_resetting_skips_barrier_capacity_lookup() {
-        let mut status = CreatingStreamingJobStatus::Resetting(vec![]);
-        let partial_graph_manager =
-            PartialGraphManager::uninitialized(crate::manager::MetaSrvEnv::for_test().await);
-
-        let injected = status.on_new_upstream_epoch(
-            &partial_graph_manager,
-            PartialGraphId::new(1),
-            10,
-            &barrier(1, 2),
-            None,
-        );
-
-        assert!(injected.is_empty());
     }
 
     #[test]

--- a/src/meta/src/barrier/checkpoint/independent_job/mod.rs
+++ b/src/meta/src/barrier/checkpoint/independent_job/mod.rs
@@ -81,8 +81,14 @@ pub(crate) enum IndependentCheckpointJob {
 
 /// The lifecycle shared by all independent checkpoint jobs.
 pub(crate) enum IndependentCheckpointJobControl {
-    Running(IndependentCheckpointJob),
+    Running {
+        job_id: JobId,
+        partial_graph_id: PartialGraphId,
+        job: IndependentCheckpointJob,
+    },
     Resetting {
+        /// Keep changelog pins until compute acknowledges the partial-graph reset. Before that
+        /// acknowledgment, snapshot-backfill executors may still be stopping and reading logs.
         pinned_upstream_tables: HashSet<TableId>,
         subscriptions_to_drop: Vec<PbSubscriptionUpstreamInfo>,
         notifiers: Vec<CollectionNotifier>,
@@ -90,13 +96,6 @@ pub(crate) enum IndependentCheckpointJobControl {
 }
 
 impl IndependentCheckpointJob {
-    fn partial_graph_id(&self) -> PartialGraphId {
-        match self {
-            Self::CreatingStreamingJob(j) => j.partial_graph_id(),
-            Self::BatchRefresh(j) => j.partial_graph_id(),
-        }
-    }
-
     fn can_drop_independently(&self) -> bool {
         match self {
             Self::CreatingStreamingJob(j) => j.can_drop_independently(),
@@ -104,7 +103,7 @@ impl IndependentCheckpointJob {
         }
     }
 
-    fn pinned_upstream_tables(&self) -> HashSet<TableId> {
+    fn pinned_upstream_tables(&self) -> &HashSet<TableId> {
         match self {
             Self::CreatingStreamingJob(j) => j.pinned_upstream_tables(),
             Self::BatchRefresh(j) => j.pinned_upstream_tables(),
@@ -113,31 +112,40 @@ impl IndependentCheckpointJob {
 }
 
 impl IndependentCheckpointJobControl {
-    pub(crate) fn creating_streaming_job(job: CreatingStreamingJobControl) -> Self {
-        Self::Running(IndependentCheckpointJob::CreatingStreamingJob(job))
+    pub(crate) fn creating_streaming_job(
+        job_id: JobId,
+        partial_graph_id: PartialGraphId,
+        job: CreatingStreamingJobControl,
+    ) -> Self {
+        Self::Running {
+            job_id,
+            partial_graph_id,
+            job: IndependentCheckpointJob::CreatingStreamingJob(job),
+        }
     }
 
-    pub(crate) fn batch_refresh(job: BatchRefreshJobCheckpointControl) -> Self {
-        Self::Running(IndependentCheckpointJob::BatchRefresh(job))
+    pub(crate) fn batch_refresh(
+        job_id: JobId,
+        partial_graph_id: PartialGraphId,
+        job: BatchRefreshJobCheckpointControl,
+    ) -> Self {
+        Self::Running {
+            job_id,
+            partial_graph_id,
+            job: IndependentCheckpointJob::BatchRefresh(job),
+        }
     }
 
     pub(crate) fn running(&self) -> Option<&IndependentCheckpointJob> {
         match self {
-            Self::Running(job) => Some(job),
+            Self::Running { job, .. } => Some(job),
             Self::Resetting { .. } => None,
         }
     }
 
     pub(crate) fn running_mut(&mut self) -> Option<&mut IndependentCheckpointJob> {
         match self {
-            Self::Running(job) => Some(job),
-            Self::Resetting { .. } => None,
-        }
-    }
-
-    pub(crate) fn into_running(self) -> Option<IndependentCheckpointJob> {
-        match self {
-            Self::Running(job) => Some(job),
+            Self::Running { job, .. } => Some(job),
             Self::Resetting { .. } => None,
         }
     }
@@ -151,10 +159,12 @@ impl IndependentCheckpointJobControl {
 
     /// Collect a barrier and return whether a checkpoint should be forced in the next barrier.
     pub(crate) fn collect(&mut self, collected_barrier: CollectedBarrier<'_>) -> bool {
-        match self.running_mut() {
-            Some(IndependentCheckpointJob::CreatingStreamingJob(j)) => j.collect(collected_barrier),
-            Some(IndependentCheckpointJob::BatchRefresh(j)) => j.collect(collected_barrier),
-            None => false,
+        let job = self
+            .running_mut()
+            .expect("barriers should only be collected from a running partial graph");
+        match job {
+            IndependentCheckpointJob::CreatingStreamingJob(j) => j.collect(collected_barrier),
+            IndependentCheckpointJob::BatchRefresh(j) => j.collect(collected_barrier),
         }
     }
 
@@ -168,13 +178,13 @@ impl IndependentCheckpointJobControl {
         }
     }
 
-    pub(crate) fn pinned_upstream_tables(&self) -> HashSet<TableId> {
+    pub(crate) fn pinned_upstream_tables(&self) -> &HashSet<TableId> {
         match self {
-            Self::Running(job) => job.pinned_upstream_tables(),
+            Self::Running { job, .. } => job.pinned_upstream_tables(),
             Self::Resetting {
                 pinned_upstream_tables,
                 ..
-            } => pinned_upstream_tables.clone(),
+            } => pinned_upstream_tables,
         }
     }
 
@@ -216,7 +226,7 @@ impl IndependentCheckpointJobControl {
                 }
                 subscriptions_to_drop
             }
-            Self::Running(_) => {
+            Self::Running { .. } => {
                 panic!("should be resetting when receiving reset partial graph resp")
             }
         }
@@ -224,7 +234,6 @@ impl IndependentCheckpointJobControl {
 
     pub(crate) fn drop(
         &mut self,
-        job_id: JobId,
         notifier: Option<&mut NotifierStarter>,
         partial_graph_manager: &mut PartialGraphManager,
     ) -> bool {
@@ -233,17 +242,23 @@ impl IndependentCheckpointJobControl {
                 notifiers.extend(notifier.map(NotifierStarter::add_notify));
                 true
             }
-            Self::Running(job) if !job.can_drop_independently() => false,
-            Self::Running(job) => {
-                let pinned_upstream_tables = job.pinned_upstream_tables();
-                let subscriptions_to_drop = pinned_upstream_tables
+            Self::Running { job, .. } if !job.can_drop_independently() => false,
+            Self::Running {
+                job_id,
+                partial_graph_id,
+                job,
+            } => {
+                let subscriptions_to_drop = job
+                    .pinned_upstream_tables()
                     .iter()
                     .map(|upstream_mv_table_id| PbSubscriptionUpstreamInfo {
                         subscriber_id: job_id.as_subscriber_id(),
                         upstream_mv_table_id: *upstream_mv_table_id,
                     })
                     .collect();
-                partial_graph_manager.reset_partial_graphs([job.partial_graph_id()]);
+                // Resetting must keep owning the pins after the concrete job is replaced.
+                let pinned_upstream_tables = job.pinned_upstream_tables().clone();
+                partial_graph_manager.reset_partial_graphs([*partial_graph_id]);
                 *self = Self::Resetting {
                     pinned_upstream_tables,
                     subscriptions_to_drop,
@@ -263,7 +278,9 @@ impl IndependentCheckpointJobControl {
     /// meaning caller should not issue a new reset request.
     pub(crate) fn reset(self) -> bool {
         match self {
-            Self::Running(_) => false,
+            // Running jobs have no reset state to drain. Recovery will issue the partial-graph
+            // reset after rebuilding its reset plan.
+            Self::Running { .. } => false,
             Self::Resetting { notifiers, .. } => {
                 for notifier in notifiers {
                     notifier.notify_collected();
@@ -290,7 +307,7 @@ mod tests {
         assert!(job.running().is_none());
         assert!(job.gen_backfill_progress().is_none());
         assert!(job.gen_fragment_backfill_progress().is_empty());
-        assert_eq!(job.pinned_upstream_tables(), pinned_upstream_tables);
+        assert_eq!(job.pinned_upstream_tables(), &pinned_upstream_tables);
         assert!(job.fragment_infos().is_none());
         assert!(job.reset());
     }

--- a/src/meta/src/barrier/checkpoint/independent_job/mod.rs
+++ b/src/meta/src/barrier/checkpoint/independent_job/mod.rs
@@ -16,8 +16,10 @@ use std::collections::{HashMap, HashSet};
 use std::mem::take;
 
 use risingwave_common::catalog::TableId;
+use risingwave_common::id::JobId;
 use risingwave_common::util::epoch::Epoch;
-use risingwave_pb::id::FragmentId;
+use risingwave_pb::id::{FragmentId, PartialGraphId};
+use risingwave_pb::stream_plan::PbSubscriptionUpstreamInfo;
 use risingwave_pb::stream_plan::barrier::PbBarrierKind;
 
 pub(crate) mod batch_refresh_job;
@@ -30,7 +32,7 @@ pub(crate) use batch_refresh_job::{
 pub(crate) use creating_job::CreatingStreamingJobControl;
 
 use crate::barrier::info::BarrierInfo;
-use crate::barrier::notifier::NotifierStarter;
+use crate::barrier::notifier::{CollectionNotifier, NotifierStarter};
 use crate::barrier::partial_graph::{CollectedBarrier, PartialGraphManager};
 use crate::barrier::{BackfillProgress, BarrierKind, FragmentBackfillProgress, TracedEpoch};
 use crate::controller::fragment::InflightFragmentInfo;
@@ -70,47 +72,116 @@ fn new_fake_barrier(
 
 // ── Enum unifying independent checkpoint job types ──────────────────────────
 
-/// A streaming job that checkpoints independently from the database's main graph,
-/// using its own partial graph.
-pub(crate) enum IndependentCheckpointJobControl {
+/// The type-specific running state of a streaming job that checkpoints independently from the
+/// database's main graph.
+pub(crate) enum IndependentCheckpointJob {
     CreatingStreamingJob(CreatingStreamingJobControl),
     BatchRefresh(BatchRefreshJobCheckpointControl),
 }
 
-impl IndependentCheckpointJobControl {
-    pub(crate) fn gen_backfill_progress(&self) -> Option<BackfillProgress> {
+/// The lifecycle shared by all independent checkpoint jobs.
+pub(crate) enum IndependentCheckpointJobControl {
+    Running(IndependentCheckpointJob),
+    Resetting {
+        pinned_upstream_tables: HashSet<TableId>,
+        subscriptions_to_drop: Vec<PbSubscriptionUpstreamInfo>,
+        notifiers: Vec<CollectionNotifier>,
+    },
+}
+
+impl IndependentCheckpointJob {
+    fn partial_graph_id(&self) -> PartialGraphId {
         match self {
-            Self::CreatingStreamingJob(j) => Some(j.gen_backfill_progress()),
-            Self::BatchRefresh(j) => j.gen_backfill_progress(),
+            Self::CreatingStreamingJob(j) => j.partial_graph_id(),
+            Self::BatchRefresh(j) => j.partial_graph_id(),
         }
     }
 
-    /// Collect a barrier and return whether a checkpoint should be forced in the next barrier.
-    pub(crate) fn collect(&mut self, collected_barrier: CollectedBarrier<'_>) -> bool {
+    fn can_drop_independently(&self) -> bool {
         match self {
-            Self::CreatingStreamingJob(j) => j.collect(collected_barrier),
-            Self::BatchRefresh(j) => j.collect(collected_barrier),
+            Self::CreatingStreamingJob(j) => j.can_drop_independently(),
+            Self::BatchRefresh(_) => true,
         }
     }
 
-    pub(crate) fn gen_fragment_backfill_progress(&self) -> Vec<FragmentBackfillProgress> {
-        match self {
-            Self::CreatingStreamingJob(j) => j.gen_fragment_backfill_progress(),
-            Self::BatchRefresh(j) => j.gen_fragment_backfill_progress(),
-        }
-    }
-
-    pub(crate) fn pinned_upstream_tables(&self) -> HashSet<TableId> {
+    fn pinned_upstream_tables(&self) -> HashSet<TableId> {
         match self {
             Self::CreatingStreamingJob(j) => j.pinned_upstream_tables(),
             Self::BatchRefresh(j) => j.pinned_upstream_tables(),
         }
     }
+}
+
+impl IndependentCheckpointJobControl {
+    pub(crate) fn creating_streaming_job(job: CreatingStreamingJobControl) -> Self {
+        Self::Running(IndependentCheckpointJob::CreatingStreamingJob(job))
+    }
+
+    pub(crate) fn batch_refresh(job: BatchRefreshJobCheckpointControl) -> Self {
+        Self::Running(IndependentCheckpointJob::BatchRefresh(job))
+    }
+
+    pub(crate) fn running(&self) -> Option<&IndependentCheckpointJob> {
+        match self {
+            Self::Running(job) => Some(job),
+            Self::Resetting { .. } => None,
+        }
+    }
+
+    pub(crate) fn running_mut(&mut self) -> Option<&mut IndependentCheckpointJob> {
+        match self {
+            Self::Running(job) => Some(job),
+            Self::Resetting { .. } => None,
+        }
+    }
+
+    pub(crate) fn into_running(self) -> Option<IndependentCheckpointJob> {
+        match self {
+            Self::Running(job) => Some(job),
+            Self::Resetting { .. } => None,
+        }
+    }
+
+    pub(crate) fn gen_backfill_progress(&self) -> Option<BackfillProgress> {
+        match self.running()? {
+            IndependentCheckpointJob::CreatingStreamingJob(j) => Some(j.gen_backfill_progress()),
+            IndependentCheckpointJob::BatchRefresh(j) => j.gen_backfill_progress(),
+        }
+    }
+
+    /// Collect a barrier and return whether a checkpoint should be forced in the next barrier.
+    pub(crate) fn collect(&mut self, collected_barrier: CollectedBarrier<'_>) -> bool {
+        match self.running_mut() {
+            Some(IndependentCheckpointJob::CreatingStreamingJob(j)) => j.collect(collected_barrier),
+            Some(IndependentCheckpointJob::BatchRefresh(j)) => j.collect(collected_barrier),
+            None => false,
+        }
+    }
+
+    pub(crate) fn gen_fragment_backfill_progress(&self) -> Vec<FragmentBackfillProgress> {
+        match self.running() {
+            Some(IndependentCheckpointJob::CreatingStreamingJob(j)) => {
+                j.gen_fragment_backfill_progress()
+            }
+            Some(IndependentCheckpointJob::BatchRefresh(j)) => j.gen_fragment_backfill_progress(),
+            None => vec![],
+        }
+    }
+
+    pub(crate) fn pinned_upstream_tables(&self) -> HashSet<TableId> {
+        match self {
+            Self::Running(job) => job.pinned_upstream_tables(),
+            Self::Resetting {
+                pinned_upstream_tables,
+                ..
+            } => pinned_upstream_tables.clone(),
+        }
+    }
 
     pub(crate) fn fragment_infos(&self) -> Option<&HashMap<FragmentId, InflightFragmentInfo>> {
-        match self {
-            Self::CreatingStreamingJob(j) => j.fragment_infos(),
-            Self::BatchRefresh(j) => j.fragment_infos(),
+        match self.running()? {
+            IndependentCheckpointJob::CreatingStreamingJob(j) => j.fragment_infos(),
+            IndependentCheckpointJob::BatchRefresh(j) => j.fragment_infos(),
         }
     }
 
@@ -119,27 +190,70 @@ impl IndependentCheckpointJobControl {
         partial_graph_manager: &mut PartialGraphManager,
         epoch: u64,
     ) {
-        match self {
-            Self::CreatingStreamingJob(j) => j.ack_completed(partial_graph_manager, epoch),
-            Self::BatchRefresh(j) => j.ack_completed(partial_graph_manager, epoch),
+        match self.running_mut() {
+            Some(IndependentCheckpointJob::CreatingStreamingJob(j)) => {
+                j.ack_completed(partial_graph_manager, epoch)
+            }
+            Some(IndependentCheckpointJob::BatchRefresh(j)) => {
+                j.ack_completed(partial_graph_manager, epoch)
+            }
+            None => {
+                // The job was dropped while the completing task was running in the background.
+                // The partial graph has already been reset, so skip the ack.
+            }
         }
     }
 
-    pub(crate) fn on_partial_graph_reset(self) {
+    pub(crate) fn on_partial_graph_reset(self) -> Vec<PbSubscriptionUpstreamInfo> {
         match self {
-            Self::CreatingStreamingJob(j) => j.on_partial_graph_reset(),
-            Self::BatchRefresh(j) => j.on_partial_graph_reset(),
+            Self::Resetting {
+                subscriptions_to_drop,
+                notifiers,
+                ..
+            } => {
+                for notifier in notifiers {
+                    notifier.notify_collected();
+                }
+                subscriptions_to_drop
+            }
+            Self::Running(_) => {
+                panic!("should be resetting when receiving reset partial graph resp")
+            }
         }
     }
 
     pub(crate) fn drop(
         &mut self,
+        job_id: JobId,
         notifier: Option<&mut NotifierStarter>,
         partial_graph_manager: &mut PartialGraphManager,
     ) -> bool {
         match self {
-            Self::CreatingStreamingJob(j) => j.drop(notifier, partial_graph_manager),
-            Self::BatchRefresh(j) => j.drop(notifier, partial_graph_manager),
+            Self::Resetting { notifiers, .. } => {
+                notifiers.extend(notifier.map(NotifierStarter::add_notify));
+                true
+            }
+            Self::Running(job) if !job.can_drop_independently() => false,
+            Self::Running(job) => {
+                let pinned_upstream_tables = job.pinned_upstream_tables();
+                let subscriptions_to_drop = pinned_upstream_tables
+                    .iter()
+                    .map(|upstream_mv_table_id| PbSubscriptionUpstreamInfo {
+                        subscriber_id: job_id.as_subscriber_id(),
+                        upstream_mv_table_id: *upstream_mv_table_id,
+                    })
+                    .collect();
+                partial_graph_manager.reset_partial_graphs([job.partial_graph_id()]);
+                *self = Self::Resetting {
+                    pinned_upstream_tables,
+                    subscriptions_to_drop,
+                    notifiers: notifier
+                        .map(NotifierStarter::add_notify)
+                        .into_iter()
+                        .collect(),
+                };
+                true
+            }
         }
     }
 
@@ -149,8 +263,50 @@ impl IndependentCheckpointJobControl {
     /// meaning caller should not issue a new reset request.
     pub(crate) fn reset(self) -> bool {
         match self {
-            Self::CreatingStreamingJob(j) => j.reset(),
-            Self::BatchRefresh(j) => j.reset(),
+            Self::Running(_) => false,
+            Self::Resetting { notifiers, .. } => {
+                for notifier in notifiers {
+                    notifier.notify_collected();
+                }
+                true
+            }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_resetting_has_shared_inactive_behavior_and_keeps_pin() {
+        let pinned_upstream_tables = HashSet::from([TableId::new(7)]);
+        let job = IndependentCheckpointJobControl::Resetting {
+            pinned_upstream_tables: pinned_upstream_tables.clone(),
+            subscriptions_to_drop: vec![],
+            notifiers: vec![],
+        };
+
+        assert!(job.running().is_none());
+        assert!(job.gen_backfill_progress().is_none());
+        assert!(job.gen_fragment_backfill_progress().is_empty());
+        assert_eq!(job.pinned_upstream_tables(), pinned_upstream_tables);
+        assert!(job.fragment_infos().is_none());
+        assert!(job.reset());
+    }
+
+    #[test]
+    fn test_reset_completion_returns_subscriptions_to_drop() {
+        let subscriptions_to_drop = vec![PbSubscriptionUpstreamInfo {
+            subscriber_id: JobId::new(8).as_subscriber_id(),
+            upstream_mv_table_id: TableId::new(7),
+        }];
+        let job = IndependentCheckpointJobControl::Resetting {
+            pinned_upstream_tables: HashSet::from([TableId::new(7)]),
+            subscriptions_to_drop: subscriptions_to_drop.clone(),
+            notifiers: vec![],
+        };
+
+        assert_eq!(job.on_partial_graph_reset(), subscriptions_to_drop);
     }
 }

--- a/src/meta/src/barrier/checkpoint/mod.rs
+++ b/src/meta/src/barrier/checkpoint/mod.rs
@@ -23,6 +23,6 @@ pub(super) use control::{
 };
 pub(crate) use independent_job::{
     BatchRefreshJobCheckpointControl, BatchRefreshLogicalFragments, BatchRefreshRenderResult,
-    CreatingStreamingJobControl, IndependentCheckpointJobControl,
+    CreatingStreamingJobControl, IndependentCheckpointJob, IndependentCheckpointJobControl,
 };
 pub(super) use state::BarrierWorkerState;

--- a/src/meta/src/barrier/checkpoint/state.rs
+++ b/src/meta/src/barrier/checkpoint/state.rs
@@ -32,15 +32,15 @@ use risingwave_pb::source::{ConnectorSplit, ConnectorSplits};
 use risingwave_pb::stream_plan::barrier_mutation::{Mutation, PbMutation};
 use risingwave_pb::stream_plan::update_mutation::PbDispatcherUpdate;
 use risingwave_pb::stream_plan::{
-    AddMutation, PbStartFragmentBackfillMutation, PbSubscriptionUpstreamInfo, PbUpdateMutation,
-    PbUpstreamSinkInfo,
+    AddMutation, PbDropSubscriptionsMutation, PbStartFragmentBackfillMutation,
+    PbSubscriptionUpstreamInfo, PbUpdateMutation, PbUpstreamSinkInfo,
 };
 use tracing::warn;
 
 use crate::barrier::cdc_progress::CdcTableBackfillTracker;
 use crate::barrier::checkpoint::{
     BatchRefreshJobCheckpointControl, BatchRefreshLogicalFragments, CreatingStreamingJobControl,
-    DatabaseCheckpointControl, IndependentCheckpointJobControl,
+    DatabaseCheckpointControl, IndependentCheckpointJob, IndependentCheckpointJobControl,
 };
 use crate::barrier::command::{
     CreateStreamingJobCommandInfo, PostCollectCommand, ReschedulePlan, ThrottleConfigMap,
@@ -377,6 +377,28 @@ pub(super) fn render_actors(
     })
 }
 impl DatabaseCheckpointControl {
+    fn take_pending_independent_job_subscriptions_to_drop(
+        &mut self,
+    ) -> Vec<PbSubscriptionUpstreamInfo> {
+        take(&mut self.pending_independent_job_subscriptions_to_drop)
+            .into_iter()
+            .filter(|info| {
+                let upstream_job_id = info.upstream_mv_table_id.as_job_id();
+                if !self.database_info.contains_job(upstream_job_id) {
+                    // The upstream job and its materialize executors have already been removed, so
+                    // there is no subscriber left to unregister or notify.
+                    return false;
+                }
+                assert_matches!(
+                    self.database_info
+                        .unregister_subscriber(upstream_job_id, info.subscriber_id),
+                    Some(SubscriberType::SnapshotBackfill)
+                );
+                true
+            })
+            .collect()
+    }
+
     /// Collect table IDs to commit and actor IDs to collect from current fragment infos.
     fn collect_base_info(&self) -> (HashSet<TableId>, HashMap<WorkerId, HashSet<ActorId>>) {
         let table_ids_to_commit = self.database_info.existing_table_ids().collect();
@@ -787,7 +809,7 @@ impl DatabaseCheckpointControl {
                     }
 
                     self.independent_checkpoint_job_controls
-                        .insert(job_id, IndependentCheckpointJobControl::BatchRefresh(job));
+                        .insert(job_id, IndependentCheckpointJobControl::batch_refresh(job));
 
                     // Register permanent subscriber (never unregistered until MV is dropped)
                     for upstream_mv_table_id in snapshot_backfill_info_clone
@@ -1483,14 +1505,14 @@ impl DatabaseCheckpointControl {
         };
 
         let mut finished_snapshot_backfill_jobs = HashSet::new();
-        let mutation = match mutation {
+        let mut mutation = match mutation {
             Some(mutation) => Some(mutation),
             None => {
                 let mut finished_snapshot_backfill_job_info = HashMap::new();
                 if barrier_info.kind.is_checkpoint() {
                     for (&job_id, job) in &mut self.independent_checkpoint_job_controls {
-                        if let IndependentCheckpointJobControl::CreatingStreamingJob(creating_job) =
-                            job
+                        if let Some(IndependentCheckpointJob::CreatingStreamingJob(creating_job)) =
+                            job.running_mut()
                             && creating_job.should_merge_to_upstream(partial_graph_manager)
                         {
                             // The independent actors will stop on this barrier. Apply throttle to
@@ -1729,10 +1751,42 @@ impl DatabaseCheckpointControl {
             }
         };
 
+        let can_drop_pending_subscriptions = matches!(
+            mutation,
+            None | Some(PbMutation::Update(_)) | Some(PbMutation::DropSubscriptions(_))
+        );
+        if can_drop_pending_subscriptions
+            && !self
+                .pending_independent_job_subscriptions_to_drop
+                .is_empty()
+        {
+            let subscriptions_to_drop = self.take_pending_independent_job_subscriptions_to_drop();
+            if !subscriptions_to_drop.is_empty() {
+                match &mut mutation {
+                    None => {
+                        mutation =
+                            Some(PbMutation::DropSubscriptions(PbDropSubscriptionsMutation {
+                                info: subscriptions_to_drop,
+                            }));
+                    }
+                    Some(PbMutation::Update(update)) => {
+                        update.subscriptions_to_drop.extend(subscriptions_to_drop);
+                    }
+                    Some(PbMutation::DropSubscriptions(drop_subscriptions)) => {
+                        drop_subscriptions.info.extend(subscriptions_to_drop);
+                    }
+                    Some(_) => unreachable!("checked compatible mutation above"),
+                }
+            }
+        }
+
         // Forward barrier to independent job controls
         for (job_id, job) in &mut self.independent_checkpoint_job_controls {
+            let Some(job) = job.running_mut() else {
+                continue;
+            };
             match job {
-                IndependentCheckpointJobControl::CreatingStreamingJob(creating_job) => {
+                IndependentCheckpointJob::CreatingStreamingJob(creating_job) => {
                     if finished_snapshot_backfill_jobs.contains(job_id) {
                         continue;
                     }
@@ -1747,7 +1801,7 @@ impl DatabaseCheckpointControl {
                         throttle_mutation,
                     )?;
                 }
-                IndependentCheckpointJobControl::BatchRefresh(batch_refresh_job) => {
+                IndependentCheckpointJob::BatchRefresh(batch_refresh_job) => {
                     let throttle_mutation = throttle_config.as_mut().and_then(|config| {
                         batch_refresh_job
                             .pre_apply_throttle(config)

--- a/src/meta/src/barrier/checkpoint/state.rs
+++ b/src/meta/src/barrier/checkpoint/state.rs
@@ -808,8 +808,14 @@ impl DatabaseCheckpointControl {
                         );
                     }
 
-                    self.independent_checkpoint_job_controls
-                        .insert(job_id, IndependentCheckpointJobControl::batch_refresh(job));
+                    self.independent_checkpoint_job_controls.insert(
+                        job_id,
+                        IndependentCheckpointJobControl::batch_refresh(
+                            job_id,
+                            to_partial_graph_id(self.database_id, Some(job_id)),
+                            job,
+                        ),
+                    );
 
                     // Register permanent subscriber (never unregistered until MV is dropped)
                     for upstream_mv_table_id in snapshot_backfill_info_clone
@@ -1751,14 +1757,12 @@ impl DatabaseCheckpointControl {
             }
         };
 
-        let can_drop_pending_subscriptions = matches!(
+        if matches!(
             mutation,
             None | Some(PbMutation::Update(_)) | Some(PbMutation::DropSubscriptions(_))
-        );
-        if can_drop_pending_subscriptions
-            && !self
-                .pending_independent_job_subscriptions_to_drop
-                .is_empty()
+        ) && !self
+            .pending_independent_job_subscriptions_to_drop
+            .is_empty()
         {
             let subscriptions_to_drop = self.take_pending_independent_job_subscriptions_to_drop();
             if !subscriptions_to_drop.is_empty() {

--- a/src/meta/src/barrier/rpc.rs
+++ b/src/meta/src/barrier/rpc.rs
@@ -1112,7 +1112,11 @@ impl PartialGraphRecoverer<'_> {
             )?;
             independent_checkpoint_job_controls.insert(
                 job_id,
-                IndependentCheckpointJobControl::creating_streaming_job(job),
+                IndependentCheckpointJobControl::creating_streaming_job(
+                    job_id,
+                    to_partial_graph_id(database_id, Some(job_id)),
+                    job,
+                ),
             );
         }
 
@@ -1186,8 +1190,14 @@ impl PartialGraphRecoverer<'_> {
                 self,
                 refresh_interval_sec,
             )?;
-            independent_checkpoint_job_controls
-                .insert(job_id, IndependentCheckpointJobControl::batch_refresh(job));
+            independent_checkpoint_job_controls.insert(
+                job_id,
+                IndependentCheckpointJobControl::batch_refresh(
+                    job_id,
+                    to_partial_graph_id(database_id, Some(job_id)),
+                    job,
+                ),
+            );
         }
 
         self.control_stream_manager()

--- a/src/meta/src/barrier/rpc.rs
+++ b/src/meta/src/barrier/rpc.rs
@@ -1112,7 +1112,7 @@ impl PartialGraphRecoverer<'_> {
             )?;
             independent_checkpoint_job_controls.insert(
                 job_id,
-                IndependentCheckpointJobControl::CreatingStreamingJob(job),
+                IndependentCheckpointJobControl::creating_streaming_job(job),
             );
         }
 
@@ -1187,7 +1187,7 @@ impl PartialGraphRecoverer<'_> {
                 refresh_interval_sec,
             )?;
             independent_checkpoint_job_controls
-                .insert(job_id, IndependentCheckpointJobControl::BatchRefresh(job));
+                .insert(job_id, IndependentCheckpointJobControl::batch_refresh(job));
         }
 
         self.control_stream_manager()


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

This PR unifies the lifecycle of independently checkpointed streaming jobs under an outer `Running` / `Resetting` state shared by creating snapshot-backfill jobs and batch-refresh jobs.

The shared reset path now:

- preserves the upstream changelog pin while the partial graph is still resetting;
- releases the pin after compute acknowledges the reset;
- queues the snapshot-backfill subscriber cleanup; and
- folds queued cleanup into the next compatible database-graph mutation (`Update`, `DropSubscriptions`, or an otherwise mutation-free barrier).

This removes the duplicated type-specific reset handling and prevents Materialize executors from retaining stale snapshot-backfill subscribers until recovery. If an intervening mutation cannot carry subscription removals, the cleanup remains pending for a later compatible barrier.

## Checklist

- [x] I have written necessary rustdoc comments.
- [x] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [x] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/dev/src/ci.md#ci-labels-guide -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->

## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

Not applicable: this is an internal barrier lifecycle refactor and cleanup fix.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recovery and lifecycle handling for background checkpoint operations.
  * Fixed cleanup of subscriptions and resources when processing graphs are reset.
  * Improved coordination of batch refresh and streaming-job creation workflows.
  * Prevented stale subscription information from being retained after related jobs are removed.

* **Reliability**
  * Improved state tracking during checkpoint resets and recovery.
  * Ensured recovery operations remain associated with the correct checkpoint instance.
  * Reduced unnecessary copying while tracking upstream tables.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->