### PR TITLE
feat(connector): support ADC for Google Pub/Sub

### DIFF
--- a/e2e_test/source_inline/pubsub/pubsub.slt.serial
+++ b/e2e_test/source_inline/pubsub/pubsub.slt.serial
@@ -8,12 +8,6 @@ CREATE SOURCE s (v1 int, v2 varchar) WITH (
     connector = 'google_pubsub'
 ) FORMAT PLAIN ENCODE JSON;
 
-statement error credentials must be set if not using the pubsub emulator
-CREATE SOURCE s (v1 int, v2 varchar) WITH (
-    connector = 'google_pubsub',
-    pubsub.subscription = 'test-subscription-1'
-) FORMAT PLAIN ENCODE JSON;
-
 statement error failed to lookup address information
 CREATE TABLE s (v1 int, v2 varchar) WITH (
     connector = 'google_pubsub',

--- a/src/connector/src/connector_common/mod.rs
+++ b/src/connector/src/connector_common/mod.rs
@@ -17,6 +17,9 @@
 mod mqtt_common;
 pub use mqtt_common::{MqttCommon, QualityOfService as MqttQualityOfService};
 
+mod pubsub_common;
+pub(crate) use pubsub_common::resolve_pubsub_project_id;
+
 mod common;
 pub use common::{
     AwsAuthProps, AwsPrivateLinkItem, DISABLE_DEFAULT_CREDENTIAL, KafkaCommon,

--- a/src/connector/src/connector_common/pubsub_common.rs
+++ b/src/connector/src/connector_common/pubsub_common.rs
@@ -1,0 +1,48 @@
+// Copyright 2026 RisingWave Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+const DEFAULT_EMULATOR_PROJECT_ID: &str = "local-project";
+
+pub(crate) fn resolve_pubsub_project_id(
+    configured: Option<&str>,
+    detected: Option<&str>,
+    is_emulator: bool,
+) -> Option<String> {
+    configured
+        .or(detected)
+        .or(is_emulator.then_some(DEFAULT_EMULATOR_PROJECT_ID))
+        .map(ToOwned::to_owned)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_resolve_pubsub_project_id() {
+        assert_eq!(
+            resolve_pubsub_project_id(Some("configured"), Some("detected"), true).as_deref(),
+            Some("configured")
+        );
+        assert_eq!(
+            resolve_pubsub_project_id(None, Some("detected"), true).as_deref(),
+            Some("detected")
+        );
+        assert_eq!(
+            resolve_pubsub_project_id(None, None, true).as_deref(),
+            Some(DEFAULT_EMULATOR_PROJECT_ID)
+        );
+        assert_eq!(resolve_pubsub_project_id(None, None, false), None);
+    }
+}

--- a/src/connector/src/sink/google_pubsub.rs
+++ b/src/connector/src/sink/google_pubsub.rs
@@ -38,7 +38,7 @@ use super::writer::{
     AsyncTruncateLogSinkerOf, AsyncTruncateSinkWriter, AsyncTruncateSinkWriterExt, FormattedSink,
 };
 use super::{Result, Sink, SinkError, SinkParam, SinkWriterParam};
-use crate::connector_common::DISABLE_DEFAULT_CREDENTIAL;
+use crate::connector_common::{DISABLE_DEFAULT_CREDENTIAL, resolve_pubsub_project_id};
 use crate::dispatch_sink_formatter_str_key_impl;
 use crate::enforce_secret::EnforceSecret;
 
@@ -76,9 +76,10 @@ use delivery_future::*;
 #[serde_as]
 #[derive(Clone, Debug, Deserialize, WithOptions)]
 pub struct GooglePubSubConfig {
-    /// The Google Pub/Sub Project ID
+    /// The Google Pub/Sub project ID. If omitted, the connector uses the project ID from
+    /// the credentials or Application Default Credentials.
     #[serde(rename = "pubsub.project_id")]
-    pub project_id: String,
+    pub project_id: Option<String>,
 
     /// Specifies the Pub/Sub topic to publish messages
     #[serde(rename = "pubsub.topic")]
@@ -220,7 +221,7 @@ impl GooglePubSubSinkWriter {
         db_name: String,
         sink_from_name: String,
     ) -> Result<Self> {
-        let environment = if let Some(ref cred) = config.credentials {
+        let (environment, detected_project_id) = if let Some(ref cred) = config.credentials {
             let mut auth_config = project::Config::default();
             auth_config = auth_config.with_audience(apiv1::conn_pool::AUDIENCE);
             auth_config = auth_config.with_scopes(&apiv1::conn_pool::SCOPES);
@@ -239,9 +240,10 @@ impl GooglePubSubSinkWriter {
                             ),
                         )
                     })?;
-            Environment::GoogleCloud(Box::new(provider))
+            let project_id = provider.project_id.clone();
+            (Environment::GoogleCloud(Box::new(provider)), project_id)
         } else if let Some(emu_host) = config.emulator_host {
-            Environment::Emulator(emu_host)
+            (Environment::Emulator(emu_host), None)
         } else {
             if env_var_is_true(DISABLE_DEFAULT_CREDENTIAL) {
                 return Err(SinkError::GooglePubSub(anyhow!(
@@ -259,12 +261,23 @@ impl GooglePubSubSinkWriter {
                         "failed to initialize Google Cloud Pub/Sub ADC; provide `pubsub.credentials`, configure ADC, or use `pubsub.emulator_host`",
                     ))
                 })?;
-            Environment::GoogleCloud(Box::new(provider))
+            let project_id = provider.project_id.clone();
+            (Environment::GoogleCloud(Box::new(provider)), project_id)
         };
 
+        let project_id = resolve_pubsub_project_id(
+            config.project_id.as_deref(),
+            detected_project_id.as_deref(),
+            matches!(&environment, Environment::Emulator(_)),
+        )
+        .ok_or_else(|| {
+            SinkError::Config(anyhow!(
+                "Google Cloud Pub/Sub project ID is unavailable; configure `pubsub.project_id` or provide credentials/ADC with a project ID"
+            ))
+        })?;
         let client_config = ClientConfig {
             endpoint: config.endpoint,
-            project_id: Some(config.project_id),
+            project_id: Some(project_id),
             environment,
             ..Default::default()
         };

--- a/src/connector/src/sink/google_pubsub.rs
+++ b/src/connector/src/sink/google_pubsub.rs
@@ -26,6 +26,7 @@ use google_cloud_pubsub::client::{Client, ClientConfig};
 use google_cloud_pubsub::publisher::Publisher;
 use risingwave_common::array::StreamChunk;
 use risingwave_common::catalog::Schema;
+use risingwave_common::util::env_var::env_var_is_true;
 use serde::Deserialize;
 use serde_with::serde_as;
 use with_options::WithOptions;
@@ -37,6 +38,7 @@ use super::writer::{
     AsyncTruncateLogSinkerOf, AsyncTruncateSinkWriter, AsyncTruncateSinkWriterExt, FormattedSink,
 };
 use super::{Result, Sink, SinkError, SinkParam, SinkWriterParam};
+use crate::connector_common::DISABLE_DEFAULT_CREDENTIAL;
 use crate::dispatch_sink_formatter_str_key_impl;
 use crate::enforce_secret::EnforceSecret;
 
@@ -91,7 +93,9 @@ pub struct GooglePubSubConfig {
     #[serde(rename = "pubsub.emulator_host")]
     pub emulator_host: Option<String>,
 
-    /// A JSON string containing the service account credentials for authorization,
+    /// A JSON string containing the service account credentials for authorization. If omitted,
+    /// the connector uses Google Application Default Credentials (ADC) when allowed by the
+    /// deployment environment.
     /// see the [service-account](https://developers.google.com/workspace/guides/create-credentials#create_credentials_for_a_service_account) credentials guide.
     /// The provided account credential must have the
     /// `pubsub.publisher` [role](https://cloud.google.com/pubsub/docs/access-control#roles)
@@ -154,9 +158,11 @@ impl Sink for GooglePubSubSink {
         }
 
         let conf = &self.config;
-        if matches!((&conf.emulator_host, &conf.credentials), (None, None)) {
+        if matches!((&conf.emulator_host, &conf.credentials), (None, None))
+            && env_var_is_true(DISABLE_DEFAULT_CREDENTIAL)
+        {
             return Err(SinkError::GooglePubSub(anyhow!(
-                "Configure at least one of `pubsub.emulator_host` and `pubsub.credentials` in the Google Pub/Sub sink"
+                "Google Application Default Credentials are disabled; configure `pubsub.credentials` or `pubsub.emulator_host`"
             )));
         }
 
@@ -237,9 +243,23 @@ impl GooglePubSubSinkWriter {
         } else if let Some(emu_host) = config.emulator_host {
             Environment::Emulator(emu_host)
         } else {
-            return Err(SinkError::GooglePubSub(anyhow!(
-                "Missing emulator_host or credentials in Google Pub/Sub sink"
-            )));
+            if env_var_is_true(DISABLE_DEFAULT_CREDENTIAL) {
+                return Err(SinkError::GooglePubSub(anyhow!(
+                    "Google Application Default Credentials are disabled; configure `pubsub.credentials` or `pubsub.emulator_host`"
+                )));
+            }
+
+            let auth_config = project::Config::default()
+                .with_audience(apiv1::conn_pool::AUDIENCE)
+                .with_scopes(&apiv1::conn_pool::SCOPES);
+            let provider = DefaultTokenSourceProvider::new(auth_config)
+                .await
+                .map_err(|e| {
+                    SinkError::GooglePubSub(anyhow!(e).context(
+                        "failed to initialize Google Cloud Pub/Sub ADC; provide `pubsub.credentials`, configure ADC, or use `pubsub.emulator_host`",
+                    ))
+                })?;
+            Environment::GoogleCloud(Box::new(provider))
         };
 
         let client_config = ClientConfig {

--- a/src/connector/src/source/google_pubsub/enumerator/client.rs
+++ b/src/connector/src/source/google_pubsub/enumerator/client.rs
@@ -50,10 +50,6 @@ impl SplitEnumerator for PubsubSplitEnumerator {
             bail!("pubsub.ack_deadline_seconds must be between 10 and 600");
         }
 
-        if properties.credentials.is_none() && properties.emulator_host.is_none() {
-            bail!("credentials must be set if not using the pubsub emulator")
-        }
-
         let sub = properties.subscription_client().await?;
         if !sub
             .exists(None)

--- a/src/connector/src/source/google_pubsub/mod.rs
+++ b/src/connector/src/source/google_pubsub/mod.rs
@@ -15,6 +15,11 @@
 use std::collections::HashMap;
 
 use anyhow::Context;
+use google_cloud_gax::conn::Environment;
+use google_cloud_pubsub::apiv1;
+use google_cloud_pubsub::client::google_cloud_auth::credentials::CredentialsFile;
+use google_cloud_pubsub::client::google_cloud_auth::project;
+use google_cloud_pubsub::client::google_cloud_auth::token::DefaultTokenSourceProvider;
 use google_cloud_pubsub::client::{Client, ClientConfig};
 use google_cloud_pubsub::subscription::Subscription;
 use risingwave_common::bail;
@@ -130,33 +135,47 @@ impl crate::source::UnknownFields for PubsubProperties {
 
 impl PubsubProperties {
     pub(crate) async fn subscription_client(&self) -> ConnectorResult<Subscription> {
-        if self.credentials.is_none()
-            && self.emulator_host.is_none()
-            && env_var_is_true(DISABLE_DEFAULT_CREDENTIAL)
-        {
-            bail!(
-                "Google Application Default Credentials are disabled; configure `pubsub.credentials` or `pubsub.emulator_host`"
-            );
-        }
+        let auth_config = project::Config::default()
+            .with_audience(apiv1::conn_pool::AUDIENCE)
+            .with_scopes(&apiv1::conn_pool::SCOPES);
+        let (environment, project_id) = if let Some(credentials) = &self.credentials {
+            let credentials = CredentialsFile::new_from_str(credentials)
+                .await
+                .context("failed to parse Google Cloud Pub/Sub credentials")?;
+            let provider = DefaultTokenSourceProvider::new_with_credentials(
+                auth_config,
+                Box::new(credentials),
+            )
+            .await
+            .context("failed to initialize Google Cloud Pub/Sub token source")?;
+            let project_id = provider.project_id.clone();
+            (Environment::GoogleCloud(Box::new(provider)), project_id)
+        } else if let Some(emulator_host) = &self.emulator_host {
+            (
+                Environment::Emulator(emulator_host.clone()),
+                Some("local-project".to_owned()),
+            )
+        } else {
+            if env_var_is_true(DISABLE_DEFAULT_CREDENTIAL) {
+                bail!(
+                    "Google Application Default Credentials are disabled; configure `pubsub.credentials` or `pubsub.emulator_host`"
+                );
+            }
 
-        // initialize env
-        {
-            tracing::debug!("setting pubsub environment variables");
-            if let Some(emulator_host) = &self.emulator_host {
-                // safety: only read in the same thread below in with_auth
-                unsafe { std::env::set_var("PUBSUB_EMULATOR_HOST", emulator_host) };
-            }
-            if let Some(credentials) = &self.credentials {
-                // safety: only read in the same thread below in with_auth
-                unsafe { std::env::set_var("GOOGLE_APPLICATION_CREDENTIALS_JSON", credentials) };
-            }
+            let provider = DefaultTokenSourceProvider::new(auth_config)
+                .await
+                .context(
+                    "failed to initialize Google Cloud Pub/Sub ADC; provide `pubsub.credentials`, configure ADC, or use `pubsub.emulator_host`",
+                )?;
+            let project_id = provider.project_id.clone();
+            (Environment::GoogleCloud(Box::new(provider)), project_id)
         };
 
-        // Validate config
-        let config = ClientConfig::default()
-            .with_auth()
-            .await
-            .context("failed to initialize Google Cloud Pub/Sub authentication")?;
+        let config = ClientConfig {
+            environment,
+            project_id,
+            ..Default::default()
+        };
         let client = Client::new(config)
             .await
             .context("error initializing pubsub client")?;

--- a/src/connector/src/source/google_pubsub/mod.rs
+++ b/src/connector/src/source/google_pubsub/mod.rs
@@ -17,6 +17,8 @@ use std::collections::HashMap;
 use anyhow::Context;
 use google_cloud_pubsub::client::{Client, ClientConfig};
 use google_cloud_pubsub::subscription::Subscription;
+use risingwave_common::bail;
+use risingwave_common::util::env_var::env_var_is_true;
 use serde::Deserialize;
 
 pub mod enumerator;
@@ -30,6 +32,7 @@ pub use source::*;
 pub use split::*;
 use with_options::WithOptions;
 
+use crate::connector_common::DISABLE_DEFAULT_CREDENTIAL;
 use crate::enforce_secret::EnforceSecret;
 use crate::error::ConnectorResult;
 use crate::source::SourceProperties;
@@ -58,7 +61,9 @@ pub struct PubsubProperties {
     #[serde(rename = "pubsub.emulator_host")]
     pub emulator_host: Option<String>,
 
-    /// `credentials` is a JSON string containing the service account credentials.
+    /// `credentials` is a JSON string containing the service account credentials. If omitted,
+    /// the connector uses Google Application Default Credentials (ADC) when allowed by the
+    /// deployment environment.
     /// See the [service-account credentials guide](https://developers.google.com/workspace/guides/create-credentials#create_credentials_for_a_service_account).
     /// The service account must have the `pubsub.subscriber` [role](https://cloud.google.com/pubsub/docs/access-control#roles).
     #[serde(rename = "pubsub.credentials")]
@@ -125,6 +130,15 @@ impl crate::source::UnknownFields for PubsubProperties {
 
 impl PubsubProperties {
     pub(crate) async fn subscription_client(&self) -> ConnectorResult<Subscription> {
+        if self.credentials.is_none()
+            && self.emulator_host.is_none()
+            && env_var_is_true(DISABLE_DEFAULT_CREDENTIAL)
+        {
+            bail!(
+                "Google Application Default Credentials are disabled; configure `pubsub.credentials` or `pubsub.emulator_host`"
+            );
+        }
+
         // initialize env
         {
             tracing::debug!("setting pubsub environment variables");
@@ -139,7 +153,10 @@ impl PubsubProperties {
         };
 
         // Validate config
-        let config = ClientConfig::default().with_auth().await?;
+        let config = ClientConfig::default()
+            .with_auth()
+            .await
+            .context("failed to initialize Google Cloud Pub/Sub authentication")?;
         let client = Client::new(config)
             .await
             .context("error initializing pubsub client")?;

--- a/src/connector/src/source/google_pubsub/mod.rs
+++ b/src/connector/src/source/google_pubsub/mod.rs
@@ -37,7 +37,7 @@ pub use source::*;
 pub use split::*;
 use with_options::WithOptions;
 
-use crate::connector_common::DISABLE_DEFAULT_CREDENTIAL;
+use crate::connector_common::{DISABLE_DEFAULT_CREDENTIAL, resolve_pubsub_project_id};
 use crate::enforce_secret::EnforceSecret;
 use crate::error::ConnectorResult;
 use crate::source::SourceProperties;
@@ -51,6 +51,11 @@ pub const GOOGLE_PUBSUB_CONNECTOR: &str = "google_pubsub";
 #[serde_as]
 #[derive(Clone, Debug, Deserialize, WithOptions)]
 pub struct PubsubProperties {
+    /// The Google Pub/Sub project ID. If omitted, the connector uses the project ID from
+    /// the credentials or Application Default Credentials.
+    #[serde(rename = "pubsub.project_id")]
+    pub project_id: Option<String>,
+
     /// Pub/Sub subscription to consume messages from.
     ///
     /// Note that we rely on Pub/Sub to load-balance messages between all Readers pulling from
@@ -138,7 +143,7 @@ impl PubsubProperties {
         let auth_config = project::Config::default()
             .with_audience(apiv1::conn_pool::AUDIENCE)
             .with_scopes(&apiv1::conn_pool::SCOPES);
-        let (environment, project_id) = if let Some(credentials) = &self.credentials {
+        let (environment, detected_project_id) = if let Some(credentials) = &self.credentials {
             let credentials = CredentialsFile::new_from_str(credentials)
                 .await
                 .context("failed to parse Google Cloud Pub/Sub credentials")?;
@@ -151,10 +156,7 @@ impl PubsubProperties {
             let project_id = provider.project_id.clone();
             (Environment::GoogleCloud(Box::new(provider)), project_id)
         } else if let Some(emulator_host) = &self.emulator_host {
-            (
-                Environment::Emulator(emulator_host.clone()),
-                Some("local-project".to_owned()),
-            )
+            (Environment::Emulator(emulator_host.clone()), None)
         } else {
             if env_var_is_true(DISABLE_DEFAULT_CREDENTIAL) {
                 bail!(
@@ -171,9 +173,17 @@ impl PubsubProperties {
             (Environment::GoogleCloud(Box::new(provider)), project_id)
         };
 
+        let project_id = resolve_pubsub_project_id(
+            self.project_id.as_deref(),
+            detected_project_id.as_deref(),
+            matches!(&environment, Environment::Emulator(_)),
+        )
+        .context(
+            "Google Cloud Pub/Sub project ID is unavailable; configure `pubsub.project_id` or provide credentials/ADC with a project ID",
+        )?;
         let config = ClientConfig {
             environment,
-            project_id,
+            project_id: Some(project_id),
             ..Default::default()
         };
         let client = Client::new(config)

--- a/src/connector/with_options_sink.yaml
+++ b/src/connector/with_options_sink.yaml
@@ -446,7 +446,9 @@ GooglePubSubConfig:
   - name: pubsub.credentials
     field_type: String
     comments: |-
-      A JSON string containing the service account credentials for authorization,
+      A JSON string containing the service account credentials for authorization. If omitted,
+      the connector uses Google Application Default Credentials (ADC) when allowed by the
+      deployment environment.
       see the [service-account](https://developers.google.com/workspace/guides/create-credentials#create_credentials_for_a_service_account) credentials guide.
       The provided account credential must have the
       `pubsub.publisher` [role](https://cloud.google.com/pubsub/docs/access-control#roles)

--- a/src/connector/with_options_sink.yaml
+++ b/src/connector/with_options_sink.yaml
@@ -427,8 +427,10 @@ GooglePubSubConfig:
   fields:
   - name: pubsub.project_id
     field_type: String
-    comments: The Google Pub/Sub Project ID
-    required: true
+    comments: |-
+      The Google Pub/Sub project ID. If omitted, the connector uses the project ID from
+      the credentials or Application Default Credentials.
+    required: false
   - name: pubsub.topic
     field_type: String
     comments: Specifies the Pub/Sub topic to publish messages

--- a/src/connector/with_options_source.yaml
+++ b/src/connector/with_options_source.yaml
@@ -1286,7 +1286,9 @@ PubsubProperties:
   - name: pubsub.credentials
     field_type: String
     comments: |-
-      `credentials` is a JSON string containing the service account credentials.
+      `credentials` is a JSON string containing the service account credentials. If omitted,
+      the connector uses Google Application Default Credentials (ADC) when allowed by the
+      deployment environment.
       See the [service-account credentials guide](https://developers.google.com/workspace/guides/create-credentials#create_credentials_for_a_service_account).
       The service account must have the `pubsub.subscriber` [role](https://cloud.google.com/pubsub/docs/access-control#roles).
     required: false

--- a/src/connector/with_options_source.yaml
+++ b/src/connector/with_options_source.yaml
@@ -1266,6 +1266,12 @@ PosixFsProperties:
     default: Default::default
 PubsubProperties:
   fields:
+  - name: pubsub.project_id
+    field_type: String
+    comments: |-
+      The Google Pub/Sub project ID. If omitted, the connector uses the project ID from
+      the credentials or Application Default Credentials.
+    required: false
   - name: pubsub.subscription
     field_type: String
     comments: |-

--- a/src/risedevtool/run_command.sh
+++ b/src/risedevtool/run_command.sh
@@ -15,7 +15,11 @@ strip_ansi() {
 # Run the command and log the output to both the terminal and the log file.
 # - CLICOLOR_FORCE=1: force color output, see https://bixense.com/clicolors/
 # -           tee -i: ignore interrupts in tee
-CLICOLOR_FORCE=1 "${@:3}" 2>&1 | tee -i >(strip_ansi > "$1")
+if [[ -n "${RISEDEV_PROXYCHAINS_BIN:-}" ]]; then
+  CLICOLOR_FORCE=1 "${RISEDEV_PROXYCHAINS_BIN}" -q -f "${RISEDEV_PROXYCHAINS_CONFIG}" "${@:3}" 2>&1 | tee -i >(strip_ansi > "$1")
+else
+  CLICOLOR_FORCE=1 "${@:3}" 2>&1 | tee -i >(strip_ansi > "$1")
+fi
 
 # Retrieve the return status.
 RET_STATUS="${PIPESTATUS[0]}"


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

Add Google Application Default Credentials (ADC) support to the Google Cloud Pub/Sub source and sink connectors when neither `pubsub.credentials` nor `pubsub.emulator_host` is configured.

- Use the Google auth library's standard ADC lookup for Pub/Sub sources and sinks.
- Keep explicit service-account credentials and emulator configuration behavior unchanged.
- Respect `DISABLE_DEFAULT_CREDENTIAL`, so ADC remains disabled in RisingWave Cloud Hosted while working in BYOC and self-hosted deployments.
- Add stable, connector-owned authentication error context.
- Document the ADC fallback in the generated connector option descriptions.
- Remove the SLT assertion that required credentials, since the result now depends on the deployment's ADC environment.

This supersedes #24647 and addresses its maintainer feedback about Cloud Hosted credential isolation and error clarity. Thanks to @tuantran0910 for the original implementation.

- Closes #24646

## Checklist

- [x] I have written necessary rustdoc comments.
- [ ] I have added necessary unit tests and integration tests.
- [x] I have added test labels as necessary.
- [ ] I have added fuzzing tests or opened an issue to track them.
- [ ] My PR contains breaking changes.
- [ ] My PR changes performance-critical code, so I will run (micro) benchmarks and present the results.
- [ ] I have checked the Release Timeline and Currently Supported Versions to determine which release branches I need to cherry-pick this PR into.

## Testing

- `cargo check -p risingwave_connector --features sink-google_pubsub`
- `cargo clippy -p risingwave_connector --features sink-google_pubsub --no-deps -- -D warnings`
- `cargo test -p risingwave_connector tests::test_with_options_yaml_up_to_date --features sink-google_pubsub`

## Documentation

- [x] My PR needs documentation updates.

<details>
<summary><b>Release note</b></summary>

The Google Cloud Pub/Sub source and sink connectors can now authenticate with Google Application Default Credentials when explicit `pubsub.credentials` are omitted. ADC is available in BYOC and self-hosted deployments; RisingWave Cloud Hosted continues to require explicit connector credentials.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Google Pub/Sub source and sink connectors now support Google Application Default Credentials (ADC) when explicit credentials are not provided.
  * Pub/Sub project ID configuration is now optional; the connector can detect it from credentials or use the emulator’s default project.
  * Pub/Sub connectors provide clearer credential and project ID configuration guidance.
* **Bug Fixes**
  * Improved Pub/Sub authentication and project ID resolution across emulator, explicit credential, and ADC configurations.
* **Chores**
  * Added optional proxy-chain support for development command execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->