### PR TITLE
chore: add Cloud code owner for license features

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,2 @@
 Cargo.lock @risingwavelabs/cargo-lock
+/src/license/src/feature.json @risingwavelabs/cloud


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What changed and what is the intention?

Add the RisingWave Cloud team as the code owner for src/license/src/feature.json.

Changes to this file introduce or modify licensed feature definitions. Automatically requesting Cloud team review helps keep Cloud entitlement configuration and validation aligned with kernel license features.

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] I have added necessary unit tests and integration tests.
- [x] I have added test labels as necessary.
- [ ] I have added fuzzing tests or opened an issue to track them.
- [ ] My PR contains breaking changes.
- [ ] My PR changes performance-critical code.
- [x] I have checked the release timeline and supported versions; no backport is needed.

## Validation

- git diff --check
- Verified that @risingwavelabs/cloud is an existing organization team.

## Documentation

- [ ] My PR needs documentation updates.