### PR TITLE
fix(connector): avoid Snowflake CDC cleanup race

### DIFF
--- a/src/connector/src/sink/snowflake_redshift/mod.rs
+++ b/src/connector/src/sink/snowflake_redshift/mod.rs
@@ -42,15 +42,21 @@ pub mod snowflake;
 pub const __ROW_ID: &str = "__row_id";
 pub const __OP: &str = "__op";
 
+fn build_row_id(epoch: u64, row_count: usize, actor_id: u32) -> String {
+    // Keep the ID deterministic across retries while making it unique across parallel writers.
+    format!("{epoch}_{row_count}_{actor_id}")
+}
+
 pub struct AugmentedRow {
     row_encoder: JsonEncoder,
     current_epoch: u64,
     current_row_count: usize,
+    actor_id: u32,
     is_append_only: bool,
 }
 
 impl AugmentedRow {
-    pub fn new(current_epoch: u64, is_append_only: bool, schema: Schema) -> Self {
+    pub fn new(current_epoch: u64, actor_id: u32, is_append_only: bool, schema: Schema) -> Self {
         let row_encoder = JsonEncoder::new(
             schema,
             None,
@@ -64,6 +70,7 @@ impl AugmentedRow {
             row_encoder,
             current_epoch,
             current_row_count: 0,
+            actor_id,
             is_append_only,
         }
     }
@@ -84,7 +91,11 @@ impl AugmentedRow {
         self.current_row_count += 1;
         row.insert(
             __ROW_ID.to_owned(),
-            Value::String(format!("{}_{}", self.current_epoch, self.current_row_count)),
+            Value::String(build_row_id(
+                self.current_epoch,
+                self.current_row_count,
+                self.actor_id,
+            )),
         );
         row.insert(
             __OP.to_owned(),
@@ -97,14 +108,16 @@ impl AugmentedRow {
 pub struct AugmentedChunk {
     current_epoch: u64,
     current_row_count: usize,
+    actor_id: u32,
     is_append_only: bool,
 }
 
 impl AugmentedChunk {
-    pub fn new(current_epoch: u64, is_append_only: bool) -> Self {
+    pub fn new(current_epoch: u64, actor_id: u32, is_append_only: bool) -> Self {
         Self {
             current_epoch,
             current_row_count: 0,
+            actor_id,
             is_append_only,
         }
     }
@@ -127,7 +140,13 @@ impl AugmentedChunk {
 
         let op_column = ops.iter().map(|op| op.to_i16() as i32).collect::<Vec<_>>();
         let row_column_strings: Vec<String> = (0..chunk_row_count)
-            .map(|i| format!("{}_{}", self.current_epoch, self.current_row_count + i))
+            .map(|i| {
+                build_row_id(
+                    self.current_epoch,
+                    self.current_row_count + i,
+                    self.actor_id,
+                )
+            })
             .collect();
 
         let row_column_refs: Vec<&str> = row_column_strings.iter().map(|s| s.as_str()).collect();
@@ -160,6 +179,7 @@ impl SnowflakeRedshiftSinkS3Writer {
     pub fn new(
         s3_config: S3Common,
         schema: Schema,
+        actor_id: u32,
         is_append_only: bool,
         target_table_name: String,
     ) -> Result<Self> {
@@ -168,7 +188,7 @@ impl SnowflakeRedshiftSinkS3Writer {
             s3_config,
             s3_operator,
             opendal_writer_path: None,
-            augmented_row: AugmentedRow::new(0, is_append_only, schema),
+            augmented_row: AugmentedRow::new(0, actor_id, is_append_only, schema),
             target_table_name,
         })
     }
@@ -261,6 +281,7 @@ impl SnowflakeRedshiftSinkJdbcWriter {
         full_table_name: String,
     ) -> Result<Self> {
         let metrics = SinkWriterMetrics::new(&writer_param);
+        let actor_id = writer_param.actor_id.as_raw_id();
         let column_descs = &mut param.columns;
 
         // Build full table name based on connector type
@@ -305,7 +326,7 @@ impl SnowflakeRedshiftSinkJdbcWriter {
             CoordinatedRemoteSinkWriter::new(param.clone(), metrics.clone()).await?;
 
         Ok(Self {
-            augmented_row: AugmentedChunk::new(0, is_append_only),
+            augmented_row: AugmentedChunk::new(0, actor_id, is_append_only),
             jdbc_sink_writer,
         })
     }
@@ -331,5 +352,16 @@ impl SnowflakeRedshiftSinkJdbcWriter {
         // TODO: abort should clean up all the data written in this epoch
         self.jdbc_sink_writer.abort().await?;
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::build_row_id;
+
+    #[test]
+    fn test_build_row_id() {
+        assert_eq!(build_row_id(42, 10, 7), "42_10_7");
+        assert_ne!(build_row_id(42, 10, 7), build_row_id(42, 10, 8));
     }
 }

--- a/src/connector/src/sink/snowflake_redshift/redshift.rs
+++ b/src/connector/src/sink/snowflake_redshift/redshift.rs
@@ -316,6 +316,7 @@ impl RedShiftSinkWriter {
                     SinkError::Config(anyhow!("S3 configuration is required for S3 sink"))
                 })?,
                 schema,
+                writer_param.actor_id.as_raw_id(),
                 is_append_only,
                 config.table,
             )?;

--- a/src/connector/src/sink/snowflake_redshift/snowflake.rs
+++ b/src/connector/src/sink/snowflake_redshift/snowflake.rs
@@ -597,6 +597,7 @@ impl SnowflakeSinkWriter {
                     ))
                 })?,
                 schema,
+                writer_param.actor_id.as_raw_id(),
                 is_append_only,
                 table_name,
             )?;
@@ -1153,6 +1154,20 @@ fn build_create_merge_into_task_sql(snowflake_task_context: &SnowflakeTaskContex
         .map(|name| format!(r#"source."{}""#, name))
         .collect::<Vec<String>>()
         .join(", ");
+    // Legacy row IDs did not contain the actor ID and can collide across writers. Match the
+    // complete row so that a late legacy row with the same ID is not deleted accidentally.
+    let consumed_row_eq_str = std::iter::once(__ROW_ID)
+        .chain(std::iter::once(__OP))
+        .chain(
+            all_column_names
+                .as_ref()
+                .unwrap()
+                .iter()
+                .map(String::as_str),
+        )
+        .map(|name| format!(r#"EQUAL_NULL({full_cdc_table_name}."{name}", consumed."{name}")"#))
+        .collect::<Vec<_>>()
+        .join(" AND ");
 
     let compute_clause = if *task_serverless {
         task_target_completion_interval
@@ -1168,18 +1183,24 @@ fn build_create_merge_into_task_sql(snowflake_task_context: &SnowflakeTaskContex
 SCHEDULE = '{writer_target_interval_seconds} SECONDS'
 AS
 BEGIN
-    LET max_row_id STRING;
+    LET cdc_batch_query_id STRING;
 
-    SELECT COALESCE(MAX("{snowflake_sink_row_id}"), '0') INTO :max_row_id
+    SELECT *
     FROM {cdc_table_name};
+    cdc_batch_query_id := SQLID;
 
     MERGE INTO {target_table_name} AS target
     USING (
         SELECT *
         FROM (
-            SELECT *, ROW_NUMBER() OVER (PARTITION BY {pk_names_str} ORDER BY "{snowflake_sink_row_id}" DESC) AS dedupe_id
-            FROM {cdc_table_name}
-            WHERE "{snowflake_sink_row_id}" <= :max_row_id
+            SELECT *, ROW_NUMBER() OVER (
+                PARTITION BY {pk_names_str}
+                ORDER BY
+                    TRY_TO_NUMBER(SPLIT_PART("{snowflake_sink_row_id}", '_', 1)) DESC,
+                    TRY_TO_NUMBER(SPLIT_PART("{snowflake_sink_row_id}", '_', 2)) DESC,
+                    COALESCE(TRY_TO_NUMBER(SPLIT_PART("{snowflake_sink_row_id}", '_', 3)), -1) DESC
+            ) AS dedupe_id
+            FROM TABLE(RESULT_SCAN(:cdc_batch_query_id))
         ) AS subquery
         WHERE dedupe_id = 1
     ) AS source
@@ -1189,7 +1210,8 @@ BEGIN
     WHEN NOT MATCHED AND source."{snowflake_sink_op}" IN (1, 3) THEN INSERT ({all_column_names_str}) VALUES ({all_column_names_insert_str});
 
     DELETE FROM {cdc_table_name}
-    WHERE "{snowflake_sink_row_id}" <= :max_row_id;
+    USING (SELECT * FROM TABLE(RESULT_SCAN(:cdc_batch_query_id))) AS consumed
+    WHERE {consumed_row_eq_str};
 END;"#,
         task_name = full_task_name,
         compute_clause = compute_clause
@@ -1203,6 +1225,7 @@ END;"#,
         all_column_names_set_str = all_column_names_set_str,
         all_column_names_str = all_column_names_str,
         all_column_names_insert_str = all_column_names_insert_str,
+        consumed_row_eq_str = consumed_row_eq_str,
         snowflake_sink_row_id = __ROW_ID,
         snowflake_sink_op = __OP,
     )
@@ -1369,18 +1392,24 @@ WAREHOUSE = test_warehouse
 SCHEDULE = '3600 SECONDS'
 AS
 BEGIN
-    LET max_row_id STRING;
+    LET cdc_batch_query_id STRING;
 
-    SELECT COALESCE(MAX("__row_id"), '0') INTO :max_row_id
+    SELECT *
     FROM "test_db"."test_schema"."test_cdc_table";
+    cdc_batch_query_id := SQLID;
 
     MERGE INTO "test_db"."test_schema"."test_target_table" AS target
     USING (
         SELECT *
         FROM (
-            SELECT *, ROW_NUMBER() OVER (PARTITION BY "v1" ORDER BY "__row_id" DESC) AS dedupe_id
-            FROM "test_db"."test_schema"."test_cdc_table"
-            WHERE "__row_id" <= :max_row_id
+            SELECT *, ROW_NUMBER() OVER (
+                PARTITION BY "v1"
+                ORDER BY
+                    TRY_TO_NUMBER(SPLIT_PART("__row_id", '_', 1)) DESC,
+                    TRY_TO_NUMBER(SPLIT_PART("__row_id", '_', 2)) DESC,
+                    COALESCE(TRY_TO_NUMBER(SPLIT_PART("__row_id", '_', 3)), -1) DESC
+            ) AS dedupe_id
+            FROM TABLE(RESULT_SCAN(:cdc_batch_query_id))
         ) AS subquery
         WHERE dedupe_id = 1
     ) AS source
@@ -1390,7 +1419,8 @@ BEGIN
     WHEN NOT MATCHED AND source."__op" IN (1, 3) THEN INSERT ("v1", "v2") VALUES (source."v1", source."v2");
 
     DELETE FROM "test_db"."test_schema"."test_cdc_table"
-    WHERE "__row_id" <= :max_row_id;
+    USING (SELECT * FROM TABLE(RESULT_SCAN(:cdc_batch_query_id))) AS consumed
+    WHERE EQUAL_NULL("test_db"."test_schema"."test_cdc_table"."__row_id", consumed."__row_id") AND EQUAL_NULL("test_db"."test_schema"."test_cdc_table"."__op", consumed."__op") AND EQUAL_NULL("test_db"."test_schema"."test_cdc_table"."v1", consumed."v1") AND EQUAL_NULL("test_db"."test_schema"."test_cdc_table"."v2", consumed."v2");
 END;"#;
         assert_eq!(normalize_sql(&task_sql), normalize_sql(expected));
     }
@@ -1419,18 +1449,24 @@ WAREHOUSE = multi_pk_warehouse
 SCHEDULE = '300 SECONDS'
 AS
 BEGIN
-    LET max_row_id STRING;
+    LET cdc_batch_query_id STRING;
 
-    SELECT COALESCE(MAX("__row_id"), '0') INTO :max_row_id
+    SELECT *
     FROM "test_db"."test_schema"."cdc_multi_pk";
+    cdc_batch_query_id := SQLID;
 
     MERGE INTO "test_db"."test_schema"."target_multi_pk" AS target
     USING (
         SELECT *
         FROM (
-            SELECT *, ROW_NUMBER() OVER (PARTITION BY "id1", "id2" ORDER BY "__row_id" DESC) AS dedupe_id
-            FROM "test_db"."test_schema"."cdc_multi_pk"
-            WHERE "__row_id" <= :max_row_id
+            SELECT *, ROW_NUMBER() OVER (
+                PARTITION BY "id1", "id2"
+                ORDER BY
+                    TRY_TO_NUMBER(SPLIT_PART("__row_id", '_', 1)) DESC,
+                    TRY_TO_NUMBER(SPLIT_PART("__row_id", '_', 2)) DESC,
+                    COALESCE(TRY_TO_NUMBER(SPLIT_PART("__row_id", '_', 3)), -1) DESC
+            ) AS dedupe_id
+            FROM TABLE(RESULT_SCAN(:cdc_batch_query_id))
         ) AS subquery
         WHERE dedupe_id = 1
     ) AS source
@@ -1440,7 +1476,8 @@ BEGIN
     WHEN NOT MATCHED AND source."__op" IN (1, 3) THEN INSERT ("id1", "id2", "val") VALUES (source."id1", source."id2", source."val");
 
     DELETE FROM "test_db"."test_schema"."cdc_multi_pk"
-    WHERE "__row_id" <= :max_row_id;
+    USING (SELECT * FROM TABLE(RESULT_SCAN(:cdc_batch_query_id))) AS consumed
+    WHERE EQUAL_NULL("test_db"."test_schema"."cdc_multi_pk"."__row_id", consumed."__row_id") AND EQUAL_NULL("test_db"."test_schema"."cdc_multi_pk"."__op", consumed."__op") AND EQUAL_NULL("test_db"."test_schema"."cdc_multi_pk"."id1", consumed."id1") AND EQUAL_NULL("test_db"."test_schema"."cdc_multi_pk"."id2", consumed."id2") AND EQUAL_NULL("test_db"."test_schema"."cdc_multi_pk"."val", consumed."val");
 END;"#;
         assert_eq!(normalize_sql(&task_sql), normalize_sql(expected));
     }
@@ -1469,18 +1506,24 @@ TARGET_COMPLETION_INTERVAL = '5 MINUTES'
 SCHEDULE = '120 SECONDS'
 AS
 BEGIN
-    LET max_row_id STRING;
+    LET cdc_batch_query_id STRING;
 
-    SELECT COALESCE(MAX("__row_id"), '0') INTO :max_row_id
+    SELECT *
     FROM "test_db"."test_schema"."serverless_cdc_table";
+    cdc_batch_query_id := SQLID;
 
     MERGE INTO "test_db"."test_schema"."serverless_target_table" AS target
     USING (
         SELECT *
         FROM (
-            SELECT *, ROW_NUMBER() OVER (PARTITION BY "id" ORDER BY "__row_id" DESC) AS dedupe_id
-            FROM "test_db"."test_schema"."serverless_cdc_table"
-            WHERE "__row_id" <= :max_row_id
+            SELECT *, ROW_NUMBER() OVER (
+                PARTITION BY "id"
+                ORDER BY
+                    TRY_TO_NUMBER(SPLIT_PART("__row_id", '_', 1)) DESC,
+                    TRY_TO_NUMBER(SPLIT_PART("__row_id", '_', 2)) DESC,
+                    COALESCE(TRY_TO_NUMBER(SPLIT_PART("__row_id", '_', 3)), -1) DESC
+            ) AS dedupe_id
+            FROM TABLE(RESULT_SCAN(:cdc_batch_query_id))
         ) AS subquery
         WHERE dedupe_id = 1
     ) AS source
@@ -1490,7 +1533,8 @@ BEGIN
     WHEN NOT MATCHED AND source."__op" IN (1, 3) THEN INSERT ("id", "val") VALUES (source."id", source."val");
 
     DELETE FROM "test_db"."test_schema"."serverless_cdc_table"
-    WHERE "__row_id" <= :max_row_id;
+    USING (SELECT * FROM TABLE(RESULT_SCAN(:cdc_batch_query_id))) AS consumed
+    WHERE EQUAL_NULL("test_db"."test_schema"."serverless_cdc_table"."__row_id", consumed."__row_id") AND EQUAL_NULL("test_db"."test_schema"."serverless_cdc_table"."__op", consumed."__op") AND EQUAL_NULL("test_db"."test_schema"."serverless_cdc_table"."id", consumed."id") AND EQUAL_NULL("test_db"."test_schema"."serverless_cdc_table"."val", consumed."val");
 END;"#;
         assert_eq!(normalize_sql(&task_sql), normalize_sql(expected));
     }


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

- Capture each Snowflake CDC task batch once with `SQLID`/`RESULT_SCAN`, use that immutable batch for both `MERGE` and cleanup, and add actor-aware numeric row IDs so concurrent arrivals and legacy collisions cannot be deleted prematurely. Generated-SQL tests cover warehouse and serverless tasks, including multi-column primary keys.
- Closes #26811

## Checklist

- [x] I have written necessary rustdoc comments.
- [x] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [x] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/dev/src/ci.md#ci-labels-guide -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [x] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

Fixes a Snowflake V2 upsert sink race that could silently drop CDC changes arriving while the scheduled merge task was running.

</details>
