### PR TITLE
fix: make exponential backoff schedules explicit

### DIFF
--- a/clippy.toml
+++ b/clippy.toml
@@ -2,6 +2,7 @@ disallowed-methods = [
     { path = "std::iter::Iterator::zip", reason = "Please use `zip_eq_fast` if it's available. Otherwise use `zip_eq_debug`" },
     { path = "itertools::Itertools::zip_eq", reason = "Please use `zip_eq_fast` if it's available. Otherwise use `zip_eq_debug`" },
     { path = "futures::stream::select_all", reason = "Please use `risingwave_common::util::select_all` instead." },
+    { path = "tokio_retry::strategy::ExponentialBackoff::from_millis", reason = "Please use `risingwave_common::util::retry::exponential_backoff` instead; `from_millis` sets the exponent base, not the initial delay." },
     { path = "std::panic::catch_unwind", reason = "Please use `risingwave_common::util::panic::rw_catch_unwind` instead." },
     { path = "futures::FutureExt::catch_unwind", reason = "Please use `risingwave_common::util::panic::FutureCatchUnwindExt::rw_catch_unwind` instead." },
     { path = "num_traits::sign::Signed::is_positive", reason = "This returns true for 0.0 but false for 0." },

--- a/src/batch/clippy.toml
+++ b/src/batch/clippy.toml
@@ -1,4 +1,6 @@
-disallowed-methods = []
+disallowed-methods = [
+    { path = "tokio_retry::strategy::ExponentialBackoff::from_millis", reason = "Please use `risingwave_common::util::retry::exponential_backoff` instead; `from_millis` sets the exponent base, not the initial delay." },
+]
 
 disallowed-types = [
     { path = "iceberg::Error", reason = "Please use `risingwave_common::error::IcebergError` instead." },

--- a/src/common/src/util/addr.rs
+++ b/src/common/src/util/addr.rs
@@ -20,8 +20,9 @@ use anyhow::Context;
 use risingwave_pb::common::PbHostAddress;
 use thiserror_ext::AsReport;
 use tokio::time::sleep;
-use tokio_retry::strategy::ExponentialBackoff;
 use tracing::error;
+
+use crate::util::retry::exponential_backoff;
 
 /// General host address and port.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -97,9 +98,7 @@ pub fn is_local_address(server_addr: &HostAddr, peer_addr: &HostAddr) -> bool {
 
 pub async fn try_resolve_dns(host: &str, port: i32) -> Result<SocketAddr, String> {
     let addr = format!("{}:{}", host, port);
-    let mut backoff = ExponentialBackoff::from_millis(100)
-        .max_delay(Duration::from_secs(3))
-        .factor(5);
+    let mut backoff = exponential_backoff(Duration::from_millis(100), 5, Duration::from_secs(3));
     const MAX_RETRY: usize = 20;
     for i in 1..=MAX_RETRY {
         let err = match addr.to_socket_addrs() {

--- a/src/common/src/util/mod.rs
+++ b/src/common/src/util/mod.rs
@@ -30,6 +30,7 @@ pub mod panic;
 pub mod pretty_bytes;
 pub mod prost;
 pub mod query_log;
+pub mod retry;
 pub use rw_resource_util as resource_util;
 pub mod functional;
 pub mod recursive;

--- a/src/common/src/util/retry.rs
+++ b/src/common/src/util/retry.rs
@@ -1,0 +1,83 @@
+// Copyright 2026 RisingWave Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::time::Duration;
+
+use tokio_retry::strategy::ExponentialBackoff;
+
+/// Creates a backoff starting at `initial_delay`, multiplying subsequent delays by
+/// `multiplier`, and capping every delay at `max_delay`.
+///
+/// This wraps [`ExponentialBackoff`], whose `from_millis` argument is the mathematical
+/// base rather than the initial delay.
+pub fn exponential_backoff(
+    initial_delay: Duration,
+    multiplier: u64,
+    max_delay: Duration,
+) -> impl Iterator<Item = Duration> + Clone {
+    let initial_delay = initial_delay.min(max_delay);
+    let initial_delay_ms = initial_delay.as_millis().try_into().unwrap_or(u64::MAX);
+
+    // Keep the confusing low-level API contained in this wrapper.
+    #[expect(
+        clippy::disallowed_methods,
+        reason = "this wrapper is the only permitted caller of the low-level API"
+    )]
+    let remaining_delays = ExponentialBackoff::from_millis(multiplier)
+        .factor(initial_delay_ms)
+        .max_delay(max_delay);
+
+    std::iter::once(initial_delay).chain(remaining_delays)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn starts_at_initial_delay_and_uses_multiplier() {
+        let delays = exponential_backoff(Duration::from_millis(101), 3, Duration::from_secs(10))
+            .take(4)
+            .collect::<Vec<_>>();
+
+        assert_eq!(
+            delays,
+            [
+                Duration::from_millis(101),
+                Duration::from_millis(303),
+                Duration::from_millis(909),
+                Duration::from_millis(2727),
+            ]
+        );
+    }
+
+    #[test]
+    fn caps_all_delays_at_max_delay() {
+        let delays = exponential_backoff(Duration::from_secs(1), 2, Duration::from_secs(10))
+            .take(6)
+            .collect::<Vec<_>>();
+
+        assert_eq!(
+            delays,
+            [
+                Duration::from_secs(1),
+                Duration::from_secs(2),
+                Duration::from_secs(4),
+                Duration::from_secs(8),
+                Duration::from_secs(10),
+                Duration::from_secs(10),
+            ]
+        );
+    }
+}

--- a/src/connector/src/schema/schema_registry/client.rs
+++ b/src/connector/src/schema/schema_registry/client.rs
@@ -20,11 +20,12 @@ use std::time::Duration;
 use futures::future::select_all;
 use itertools::Itertools;
 use reqwest::{Method, Url};
+use risingwave_common::util::retry::exponential_backoff;
 use serde::Deserialize;
 use serde::de::DeserializeOwned;
 use thiserror_ext::AsReport as _;
 use tokio_retry::Retry;
-use tokio_retry::strategy::{ExponentialBackoff, jitter};
+use tokio_retry::strategy::jitter;
 
 use super::util::*;
 use crate::connector_common::ConfluentSchemaRegistryConnection;
@@ -227,11 +228,13 @@ impl Client {
         });
         tracing::debug!("retry config: {:?}", self.retry_config);
 
-        let retry_strategy = ExponentialBackoff::from_millis(self.retry_config.backoff_duration_ms)
-            .factor(self.retry_config.backoff_factor)
-            .max_delay(Duration::from_secs(self.retry_config.max_delay_sec as u64))
-            .take(self.retry_config.retries_max)
-            .map(jitter);
+        let retry_strategy = exponential_backoff(
+            Duration::from_millis(self.retry_config.backoff_duration_ms),
+            self.retry_config.backoff_factor,
+            Duration::from_secs(self.retry_config.max_delay_sec as u64),
+        )
+        .take(self.retry_config.retries_max)
+        .map(jitter);
 
         for url in &self.url {
             let url_clone = url.clone();

--- a/src/connector/src/sink/dynamodb.rs
+++ b/src/connector/src/sink/dynamodb.rs
@@ -463,8 +463,9 @@ mod write_chunk_future {
     use futures::{FutureExt, StreamExt, TryFuture, TryStreamExt, stream};
     use itertools::Itertools;
     use maplit::hashmap;
+    use risingwave_common::util::retry::exponential_backoff;
     use tokio::time::sleep;
-    use tokio_retry::strategy::{ExponentialBackoff, jitter};
+    use tokio_retry::strategy::jitter;
 
     use super::{DynamoDbRequest, SinkError};
 
@@ -547,11 +548,11 @@ mod write_chunk_future {
                     async move {
                         let mut req_items = req_items;
                         let mut retry_count = 0;
-                        let mut retry_backoff = ExponentialBackoff::from_millis(
-                            batch_write_retry_backoff_ms,
+                        let mut retry_backoff = exponential_backoff(
+                            Duration::from_millis(batch_write_retry_backoff_ms),
+                            2,
+                            Duration::from_millis(MAX_BATCH_WRITE_RETRY_DELAY_MS),
                         )
-                        .factor(2)
-                        .max_delay(Duration::from_millis(MAX_BATCH_WRITE_RETRY_DELAY_MS))
                         .map(jitter)
                         .take(batch_write_retry_times);
 

--- a/src/connector/src/sink/iceberg/commit_retry.rs
+++ b/src/connector/src/sink/iceberg/commit_retry.rs
@@ -24,9 +24,10 @@ use std::time::Duration;
 use anyhow::{Result, anyhow, bail};
 use iceberg::table::Table;
 use iceberg::{Catalog, TableIdent};
+use risingwave_common::util::retry::exponential_backoff;
 use thiserror_ext::AsReport;
 use tokio_retry::RetryIf;
-use tokio_retry::strategy::{ExponentialBackoff, jitter};
+use tokio_retry::strategy::jitter;
 
 #[derive(Clone, Debug)]
 pub struct CommitRetryLogContext {
@@ -133,10 +134,10 @@ where
     F: Fn(Table) -> Fut + Send + Sync,
     Fut: Future<Output = Result<Out, CommitError>> + Send,
 {
-    let retry_strategy = ExponentialBackoff::from_millis(10)
-        .max_delay(Duration::from_secs(60))
-        .map(jitter)
-        .take(retry_num);
+    let retry_strategy =
+        exponential_backoff(Duration::from_millis(10), 10, Duration::from_secs(60))
+            .map(jitter)
+            .take(retry_num);
 
     RetryIf::spawn(
         retry_strategy,

--- a/src/connector/src/sink/kinesis.rs
+++ b/src/connector/src/sink/kinesis.rs
@@ -218,9 +218,10 @@ mod opaque_type {
     use std::cmp::min;
     use std::time::Duration;
 
+    use risingwave_common::util::retry::exponential_backoff;
     use thiserror_ext::AsReport;
     use tokio::time::sleep;
-    use tokio_retry::strategy::{ExponentialBackoff, jitter};
+    use tokio_retry::strategy::jitter;
     use tracing::warn;
 
     use super::*;
@@ -321,7 +322,7 @@ mod opaque_type {
                                     // ProvisionedThroughputExceededException or InternalFailure. ErrorMessage provides more detailed
                                     // information about the ProvisionedThroughputExceededException exception including the account ID,
                                     // stream name, and shard ID of the record that was throttled.
-                                    let throttle_delay = throttle_delay.get_or_insert_with(|| ExponentialBackoff::from_millis(100).factor(2).max_delay(Duration::from_secs(2)).map(jitter)).next().expect("should not be none");
+                                    let throttle_delay = throttle_delay.get_or_insert_with(|| exponential_backoff(Duration::from_millis(100), 2, Duration::from_secs(2)).map(jitter)).next().expect("should not be none");
                                     warn!(err_string = ?result_entry.error_message, ?throttle_delay, "throttle");
                                     sleep(throttle_delay).await;
                                 } else  {

--- a/src/connector/src/sink/nats.rs
+++ b/src/connector/src/sink/nats.rs
@@ -16,6 +16,7 @@ use core::fmt::Debug;
 use core::future::IntoFuture;
 use std::collections::BTreeMap;
 use std::sync::Arc;
+use std::time::Duration;
 
 use anyhow::{Context as _, anyhow};
 use async_nats::jetstream::context::Context;
@@ -23,10 +24,11 @@ use futures::FutureExt;
 use futures::prelude::TryFuture;
 use risingwave_common::array::StreamChunk;
 use risingwave_common::catalog::Schema;
+use risingwave_common::util::retry::exponential_backoff;
 use serde::Deserialize;
 use serde_with::serde_as;
 use tokio_retry::Retry;
-use tokio_retry::strategy::{ExponentialBackoff, jitter};
+use tokio_retry::strategy::jitter;
 use with_options::WithOptions;
 
 use super::SinkWriterParam;
@@ -188,7 +190,9 @@ impl AsyncTruncateSinkWriter for NatsSinkWriter {
         let mut data = chunk_to_json(chunk, &self.json_encoder)?;
         for item in &mut data {
             let publish_ack_future = Retry::spawn(
-                ExponentialBackoff::from_millis(100).map(jitter).take(3),
+                exponential_backoff(Duration::from_millis(100), 2, Duration::MAX)
+                    .map(jitter)
+                    .take(3),
                 || async {
                     self.context
                         .publish(self.config.common.subject.clone(), item.clone().into())

--- a/src/connector/src/source/kinesis/source/reader.rs
+++ b/src/connector/src/source/kinesis/source/reader.rs
@@ -24,6 +24,7 @@ use aws_sdk_kinesis::types::ShardIteratorType;
 use futures_async_stream::try_stream;
 use risingwave_common::bail;
 use risingwave_common::metrics::{LabelGuardedHistogram, LabelGuardedIntCounter};
+use risingwave_common::util::retry::exponential_backoff;
 use thiserror_ext::AsReport;
 
 use crate::error::ConnectorResult as Result;
@@ -378,7 +379,7 @@ impl KinesisSplitReader {
 
         self.shard_iter = Some(
             tokio_retry::Retry::spawn(
-                tokio_retry::strategy::ExponentialBackoff::from_millis(100).take(3),
+                exponential_backoff(Duration::from_millis(100), 2, Duration::MAX).take(3),
                 || {
                     get_shard_iter_inner(
                         &self.client,

--- a/src/meta/model/migration/clippy.toml
+++ b/src/meta/model/migration/clippy.toml
@@ -1,4 +1,5 @@
 disallowed-methods = [
+    { path = "tokio_retry::strategy::ExponentialBackoff::from_millis", reason = "Please use `risingwave_common::util::retry::exponential_backoff` instead; `from_millis` sets the exponent base, not the initial delay." },
     { path = "sea_query::table::column::ColumnDef::binary", reason = "Please use `.rw_binary(..)` instead." },
     { path = "sea_query::table::column::ColumnDef::blob", reason = "Please use `.rw_binary(..)` instead." },
 ]

--- a/src/meta/src/barrier/rpc.rs
+++ b/src/meta/src/barrier/rpc.rs
@@ -30,6 +30,7 @@ use risingwave_common::bail;
 use risingwave_common::catalog::{DatabaseId, FragmentTypeFlag, TableId};
 use risingwave_common::id::JobId;
 use risingwave_common::util::epoch::Epoch;
+use risingwave_common::util::retry::exponential_backoff;
 use risingwave_common::util::stream_graph_visitor::visit_stream_node_cont;
 use risingwave_common::util::tracing::TracingContext;
 use risingwave_connector::source::SplitImpl;
@@ -58,7 +59,6 @@ use risingwave_pb::stream_service::{
 use risingwave_rpc_client::StreamingControlHandle;
 use thiserror_ext::AsReport;
 use tokio::time::{Instant, sleep};
-use tokio_retry::strategy::ExponentialBackoff;
 use tracing::{debug, error, info, warn};
 use uuid::Uuid;
 
@@ -218,9 +218,8 @@ impl ControlStreamManager {
             }
         }
         let node_host = node.host.clone().unwrap();
-        let mut backoff = ExponentialBackoff::from_millis(100)
-            .max_delay(Duration::from_secs(3))
-            .factor(5);
+        let mut backoff =
+            exponential_backoff(Duration::from_millis(100), 5, Duration::from_secs(3));
         const MAX_RETRY: usize = 5;
         for i in 1..=MAX_RETRY {
             match context
@@ -315,9 +314,11 @@ impl ControlStreamManager {
     ) -> BoxFuture<'static, StreamingControlHandle> {
         async move {
             let mut attempt = 0;
-            let backoff = ExponentialBackoff::from_millis(100)
-                .max_delay(Duration::from_mins(1))
-                .factor(5);
+            let backoff = exponential_backoff(
+                Duration::from_millis(100),
+                5,
+                Duration::from_mins(1),
+            );
             let init_request = PbInitRequest { term_id };
             for delay in backoff {
                 attempt += 1;

--- a/src/meta/src/barrier/worker.rs
+++ b/src/meta/src/barrier/worker.rs
@@ -1007,7 +1007,8 @@ impl<C> GlobalBarrierWorker<C> {
 mod retry_strategy {
     use std::time::Duration;
 
-    use tokio_retry::strategy::{ExponentialBackoff, jitter};
+    use risingwave_common::util::retry::exponential_backoff;
+    use tokio_retry::strategy::jitter;
 
     // Retry base interval in milliseconds.
     const RECOVERY_RETRY_BASE_INTERVAL: u64 = 20;
@@ -1044,9 +1045,12 @@ mod retry_strategy {
     /// Initialize a retry strategy for operation in recovery.
     #[inline(always)]
     pub(crate) fn get_retry_strategy() -> impl Iterator<Item = Duration> + Send + 'static {
-        ExponentialBackoff::from_millis(RECOVERY_RETRY_BASE_INTERVAL)
-            .max_delay(RECOVERY_RETRY_MAX_INTERVAL)
-            .map(jitter)
+        exponential_backoff(
+            Duration::from_millis(RECOVERY_RETRY_BASE_INTERVAL),
+            RECOVERY_RETRY_BASE_INTERVAL,
+            RECOVERY_RETRY_MAX_INTERVAL,
+        )
+        .map(jitter)
     }
 
     #[define_opaque(RetryBackoffStrategy)]

--- a/src/meta/src/manager/sink_coordination/coordinator_worker.rs
+++ b/src/meta/src/manager/sink_coordination/coordinator_worker.rs
@@ -27,6 +27,7 @@ use futures::pin_mut;
 use itertools::Itertools;
 use risingwave_common::bail;
 use risingwave_common::bitmap::Bitmap;
+use risingwave_common::util::retry::exponential_backoff;
 use risingwave_connector::connector_common::IcebergSinkCompactionUpdate;
 use risingwave_connector::dispatch_sink;
 use risingwave_connector::sink::catalog::SinkId;
@@ -42,7 +43,7 @@ use tokio::select;
 use tokio::sync::Semaphore;
 use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender};
 use tokio::time::sleep;
-use tokio_retry::strategy::{ExponentialBackoff, jitter};
+use tokio_retry::strategy::jitter;
 use tonic::Status;
 use tracing::{error, warn};
 
@@ -156,8 +157,7 @@ impl TwoPhaseCommitHandler {
 
     #[define_opaque(RetryBackoffStrategy)]
     fn get_retry_backoff_strategy() -> RetryBackoffStrategy {
-        ExponentialBackoff::from_millis(10)
-            .max_delay(Duration::from_secs(60))
+        exponential_backoff(Duration::from_millis(10), 10, Duration::from_secs(60))
             .map(jitter)
             .map(|delay| Box::pin(tokio::time::sleep(delay)))
     }

--- a/src/object_store/src/object/mod.rs
+++ b/src/object_store/src/object/mod.rs
@@ -49,9 +49,10 @@ pub mod prefix;
 
 pub use error::*;
 use object_metrics::ObjectStoreMetrics;
+use risingwave_common::util::retry::exponential_backoff;
 use thiserror_ext::AsReport;
 use tokio::io::{AsyncRead, ReadBuf};
-use tokio_retry::strategy::{ExponentialBackoff, jitter};
+use tokio_retry::strategy::jitter;
 
 #[cfg(madsim)]
 use self::sim::SimObjectStore;
@@ -1064,11 +1065,13 @@ fn get_retry_strategy(
     operation_type: OperationType,
 ) -> impl Iterator<Item = Duration> + use<> {
     let attempts = get_retry_attempts_by_type(config, operation_type);
-    ExponentialBackoff::from_millis(config.retry.req_backoff_interval_ms)
-        .max_delay(Duration::from_millis(config.retry.req_backoff_max_delay_ms))
-        .factor(config.retry.req_backoff_factor)
-        .take(attempts)
-        .map(jitter)
+    exponential_backoff(
+        Duration::from_millis(config.retry.req_backoff_interval_ms),
+        config.retry.req_backoff_factor,
+        Duration::from_millis(config.retry.req_backoff_max_delay_ms),
+    )
+    .take(attempts)
+    .map(jitter)
 }
 
 pub type ObjectMetadataIter = BoxStream<'static, ObjectResult<ObjectMetadata>>;

--- a/src/rpc_client/src/compactor_client.rs
+++ b/src/rpc_client/src/compactor_client.rs
@@ -17,6 +17,7 @@ use std::time::Duration;
 
 use risingwave_common::monitor::EndpointExt;
 use risingwave_common::util::addr::HostAddr;
+use risingwave_common::util::retry::exponential_backoff;
 use risingwave_pb::configured_monitor_service_client;
 use risingwave_pb::hummock::hummock_manager_service_client::HummockManagerServiceClient;
 use risingwave_pb::hummock::{
@@ -28,7 +29,7 @@ use risingwave_pb::meta::{GetSystemParamsRequest, GetSystemParamsResponse};
 use risingwave_pb::monitor_service::monitor_service_client::MonitorServiceClient;
 use risingwave_pb::monitor_service::{StackTraceRequest, StackTraceResponse};
 use tokio::sync::RwLock;
-use tokio_retry::strategy::{ExponentialBackoff, jitter};
+use tokio_retry::strategy::jitter;
 use tonic::transport::{Channel, Endpoint};
 
 use crate::error::{Result, RpcError};
@@ -160,10 +161,13 @@ impl GrpcCompactorProxyClient {
 
     #[inline(always)]
     fn get_retry_strategy() -> impl Iterator<Item = Duration> {
-        ExponentialBackoff::from_millis(DEFAULT_RETRY_INTERVAL)
-            .max_delay(DEFAULT_RETRY_MAX_DELAY)
-            .take(DEFAULT_RETRY_MAX_ATTEMPTS)
-            .map(jitter)
+        exponential_backoff(
+            Duration::from_millis(DEFAULT_RETRY_INTERVAL),
+            DEFAULT_RETRY_INTERVAL,
+            DEFAULT_RETRY_MAX_DELAY,
+        )
+        .take(DEFAULT_RETRY_MAX_ATTEMPTS)
+        .map(jitter)
     }
 
     #[inline(always)]

--- a/src/rpc_client/src/frontend_client.rs
+++ b/src/rpc_client/src/frontend_client.rs
@@ -19,13 +19,14 @@ use async_trait::async_trait;
 use risingwave_common::config::{MAX_CONNECTION_WINDOW_SIZE, RpcClientConfig};
 use risingwave_common::monitor::{EndpointExt, TcpConfig};
 use risingwave_common::util::addr::HostAddr;
+use risingwave_common::util::retry::exponential_backoff;
 use risingwave_pb::frontend_service::frontend_service_client::FrontendServiceClient;
 use risingwave_pb::frontend_service::{
     CancelRunningSqlRequest, CancelRunningSqlResponse, GetAllCursorsRequest, GetAllCursorsResponse,
     GetAllSubCursorsRequest, GetAllSubCursorsResponse, GetRunningSqlsRequest,
     GetRunningSqlsResponse, GetTableReplacePlanRequest, GetTableReplacePlanResponse,
 };
-use tokio_retry::strategy::{ExponentialBackoff, jitter};
+use tokio_retry::strategy::jitter;
 use tonic::Response;
 use tonic::transport::Endpoint;
 
@@ -85,10 +86,13 @@ impl FrontendRetryClient {
 
     #[inline(always)]
     fn get_retry_strategy() -> impl Iterator<Item = Duration> {
-        ExponentialBackoff::from_millis(DEFAULT_RETRY_INTERVAL)
-            .max_delay(DEFAULT_RETRY_MAX_DELAY)
-            .take(DEFAULT_RETRY_MAX_ATTEMPTS)
-            .map(jitter)
+        exponential_backoff(
+            Duration::from_millis(DEFAULT_RETRY_INTERVAL),
+            DEFAULT_RETRY_INTERVAL,
+            DEFAULT_RETRY_MAX_DELAY,
+        )
+        .take(DEFAULT_RETRY_MAX_ATTEMPTS)
+        .map(jitter)
     }
 
     fn should_retry(status: &tonic::Status) -> bool {

--- a/src/rpc_client/src/meta_client.rs
+++ b/src/rpc_client/src/meta_client.rs
@@ -45,6 +45,7 @@ use risingwave_common::util::meta_addr::MetaAddressStrategy;
 use risingwave_common::util::resource_util::cpu::total_cpu_available;
 use risingwave_common::util::resource_util::hostname;
 use risingwave_common::util::resource_util::memory::system_memory_available_bytes;
+use risingwave_common::util::retry::exponential_backoff;
 use risingwave_common::util::version::current_rw_version;
 use risingwave_error::bail;
 use risingwave_error::tonic::ErrorIsFromTonicServerImpl;
@@ -122,7 +123,7 @@ use tokio::sync::oneshot::Sender;
 use tokio::sync::{RwLock, mpsc, oneshot};
 use tokio::task::JoinHandle;
 use tokio::time::{self};
-use tokio_retry::strategy::{ExponentialBackoff, jitter};
+use tokio_retry::strategy::jitter;
 use tokio_stream::wrappers::UnboundedReceiverStream;
 use tonic::transport::Endpoint;
 use tonic::{Code, Request, Streaming};
@@ -2659,9 +2660,12 @@ impl GrpcMetaClient {
         high_bound: Duration,
         exceed: bool,
     ) -> impl Iterator<Item = Duration> {
-        let iter = ExponentialBackoff::from_millis(Self::INIT_RETRY_BASE_INTERVAL_MS)
-            .max_delay(Duration::from_millis(Self::INIT_RETRY_MAX_INTERVAL_MS))
-            .map(jitter);
+        let iter = exponential_backoff(
+            Duration::from_millis(Self::INIT_RETRY_BASE_INTERVAL_MS),
+            Self::INIT_RETRY_BASE_INTERVAL_MS,
+            Duration::from_millis(Self::INIT_RETRY_MAX_INTERVAL_MS),
+        )
+        .map(jitter);
 
         let mut sum = Duration::default();
 

--- a/src/storage/clippy.toml
+++ b/src/storage/clippy.toml
@@ -2,6 +2,7 @@ disallowed-methods = [
     { path = "std::iter::Iterator::zip", reason = "Please use `zip_eq_fast` if it's available. Otherwise use `zip_eq_debug`" },
     { path = "itertools::Itertools::zip_eq", reason = "Please use `zip_eq_fast` if it's available. Otherwise use `zip_eq_debug`" },
     { path = "futures::stream::select_all", reason = "Please use `risingwave_common::util::select_all` instead." },
+    { path = "tokio_retry::strategy::ExponentialBackoff::from_millis", reason = "Please use `risingwave_common::util::retry::exponential_backoff` instead; `from_millis` sets the exponent base, not the initial delay." },
     { path = "std::panic::catch_unwind", reason = "Please use `risingwave_common::util::panic::rw_catch_unwind` instead." },
     { path = "futures::FutureExt::catch_unwind", reason = "Please use `risingwave_common::util::panic::FutureCatchUnwindExt::rw_catch_unwind` instead." },
 ]

--- a/src/storage/src/hummock/local_version/pinned_version.rs
+++ b/src/storage/src/hummock/local_version/pinned_version.rs
@@ -21,6 +21,7 @@ use std::time::{Duration, Instant};
 use auto_enums::auto_enum;
 use risingwave_common::catalog::TableId;
 use risingwave_common::log::LogSuppressor;
+use risingwave_common::util::retry::exponential_backoff;
 use risingwave_hummock_sdk::level::{Level, Levels};
 use risingwave_hummock_sdk::version::HummockVersion;
 use risingwave_hummock_sdk::{CompactionGroupId, HummockVersionId, INVALID_VERSION_ID};
@@ -200,11 +201,8 @@ pub(crate) async fn start_pinned_version_worker(
 ) {
     let min_execute_interval = Duration::from_millis(1000);
     let max_retry_interval = Duration::from_secs(10);
-    let get_backoff_strategy = || {
-        tokio_retry::strategy::ExponentialBackoff::from_millis(10)
-            .max_delay(max_retry_interval)
-            .map(jitter)
-    };
+    let get_backoff_strategy =
+        || exponential_backoff(Duration::from_millis(10), 10, max_retry_interval).map(jitter);
     let mut retry_backoff = get_backoff_strategy();
     let mut min_execute_interval_tick = tokio::time::interval(min_execute_interval);
     min_execute_interval_tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);

--- a/src/stream/clippy.toml
+++ b/src/stream/clippy.toml
@@ -1,5 +1,6 @@
 disallowed-methods = [
     { path = "std::iter::Iterator::zip", reason = "Please use Itertools::zip_eq instead." },
+    { path = "tokio_retry::strategy::ExponentialBackoff::from_millis", reason = "Please use `risingwave_common::util::retry::exponential_backoff` instead; `from_millis` sets the exponent base, not the initial delay." },
 
     { path = "risingwave_expr::expr::build_from_prost", reason = "Expressions in streaming must be in non-strict mode. Please use `build_non_strict_from_prost` instead." },
     { path = "risingwave_expr::expr::build_func", reason = "Expressions in streaming must be in non-strict mode. Please use `build_func_non_strict` instead." },

--- a/src/stream/src/common/log_store_impl/kv_log_store/mod.rs
+++ b/src/stream/src/common/log_store_impl/kv_log_store/mod.rs
@@ -44,7 +44,7 @@ pub(crate) mod state;
 pub mod test_utils;
 mod writer;
 
-pub(crate) use reader::{REWIND_BACKOFF_BASE, REWIND_BACKOFF_FACTOR_MS, REWIND_MAX_DELAY};
+pub(crate) use reader::{REWIND_BACKOFF_MULTIPLIER, REWIND_INITIAL_DELAY, REWIND_MAX_DELAY};
 use risingwave_common::hash::{VirtualNode, VnodeBitmapExt};
 use risingwave_common::row::ArrayVec;
 use risingwave_common::types::{DataType, Datum};

--- a/src/stream/src/common/log_store_impl/kv_log_store/reader.rs
+++ b/src/stream/src/common/log_store_impl/kv_log_store/reader.rs
@@ -54,25 +54,29 @@ use crate::common::log_store_impl::kv_log_store::{
     Epoch, KvLogStoreMetrics, KvLogStoreReadMetrics, SeqId,
 };
 
-pub(crate) const REWIND_BACKOFF_BASE: u64 = 2;
-pub(crate) const REWIND_BACKOFF_FACTOR_MS: u64 = 500;
+pub(crate) const REWIND_INITIAL_DELAY: Duration = Duration::from_secs(1);
+pub(crate) const REWIND_BACKOFF_MULTIPLIER: u64 = 2;
 pub(crate) const REWIND_MAX_DELAY: Duration = Duration::from_secs(180);
 
 mod rewind_backoff_policy {
     use std::time::Duration;
 
+    use risingwave_common::util::retry::exponential_backoff;
+
     use crate::common::log_store_impl::kv_log_store::{
-        REWIND_BACKOFF_BASE, REWIND_BACKOFF_FACTOR_MS, REWIND_MAX_DELAY,
+        REWIND_BACKOFF_MULTIPLIER, REWIND_INITIAL_DELAY, REWIND_MAX_DELAY,
     };
 
     pub(super) type RewindBackoffPolicy = impl Iterator<Item = Duration>;
 
     #[define_opaque(RewindBackoffPolicy)]
     pub(super) fn initial_rewind_backoff_policy() -> RewindBackoffPolicy {
-        tokio_retry::strategy::ExponentialBackoff::from_millis(REWIND_BACKOFF_BASE)
-            .factor(REWIND_BACKOFF_FACTOR_MS)
-            .max_delay(REWIND_MAX_DELAY)
-            .map(tokio_retry::strategy::jitter)
+        exponential_backoff(
+            REWIND_INITIAL_DELAY,
+            REWIND_BACKOFF_MULTIPLIER,
+            REWIND_MAX_DELAY,
+        )
+        .map(tokio_retry::strategy::jitter)
     }
 }
 

--- a/src/stream/src/executor/monitor/streaming_stats.rs
+++ b/src/stream/src/executor/monitor/streaming_stats.rs
@@ -36,7 +36,7 @@ use risingwave_connector::sink::catalog::SinkId;
 use risingwave_pb::id::ExecutorId;
 
 use crate::common::log_store_impl::kv_log_store::{
-    REWIND_BACKOFF_BASE, REWIND_BACKOFF_FACTOR_MS, REWIND_MAX_DELAY,
+    REWIND_BACKOFF_MULTIPLIER, REWIND_INITIAL_DELAY, REWIND_MAX_DELAY,
 };
 use crate::executor::prelude::ActorId;
 use crate::task::FragmentId;
@@ -1102,8 +1102,8 @@ impl StreamingMetrics {
         .unwrap();
 
         let kv_log_store_rewind_delay_opts = {
-            let first_delay_secs = (REWIND_BACKOFF_FACTOR_MS * REWIND_BACKOFF_BASE) as f64 / 1000.0;
-            let base = REWIND_BACKOFF_BASE as f64;
+            let first_delay_secs = REWIND_INITIAL_DELAY.as_secs_f64();
+            let base = REWIND_BACKOFF_MULTIPLIER as f64;
             let bucket_count = (REWIND_MAX_DELAY.as_secs_f64() / first_delay_secs)
                 .log(base)
                 .ceil() as usize;

--- a/src/stream/src/executor/sink.rs
+++ b/src/stream/src/executor/sink.rs
@@ -26,6 +26,7 @@ use risingwave_common::bitmap::Bitmap;
 use risingwave_common::catalog::{ColumnCatalog, Field};
 use risingwave_common::metrics::{GLOBAL_ERROR_METRICS, LabelGuardedIntGauge};
 use risingwave_common::row::RowExt;
+use risingwave_common::util::retry::exponential_backoff;
 use risingwave_common_estimate_size::EstimateSize;
 use risingwave_common_estimate_size::collections::EstimatedVec;
 use risingwave_common_rate_limit::RateLimit;
@@ -46,7 +47,7 @@ use thiserror_ext::AsReport;
 use tokio::select;
 use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender, unbounded_channel};
 use tokio::sync::oneshot;
-use tokio_retry::strategy::{ExponentialBackoff, jitter};
+use tokio_retry::strategy::jitter;
 
 use crate::common::change_buffer::{OutputKind, output_kind};
 use crate::common::compact_chunk::{
@@ -71,10 +72,7 @@ pub struct SinkExecutor<F: LogStoreFactory> {
 const SINK_RETRY_BACKOFF_RESET_INTERVAL: Duration = Duration::from_secs(60);
 
 fn sink_retry_backoff() -> impl Iterator<Item = Duration> {
-    ExponentialBackoff::from_millis(2)
-        .factor(500)
-        .max_delay(Duration::from_secs(30))
-        .map(jitter)
+    exponential_backoff(Duration::from_secs(1), 2, Duration::from_secs(30)).map(jitter)
 }
 
 // Drop all the DELETE messages in this chunk and convert UPDATE INSERT into INSERT.

--- a/src/stream/src/executor/source/mod.rs
+++ b/src/stream/src/executor/source/mod.rs
@@ -56,8 +56,9 @@ pub(crate) use source_backfill_state_table::BackfillStateTableHandler;
 
 pub mod state_table_handler;
 use futures_async_stream::try_stream;
+use risingwave_common::util::retry::exponential_backoff;
 use tokio::sync::mpsc::UnboundedReceiver;
-use tokio_retry::strategy::{ExponentialBackoff, jitter};
+use tokio_retry::strategy::jitter;
 
 use crate::executor::error::StreamExecutorError;
 use crate::executor::{Barrier, Message};
@@ -258,8 +259,5 @@ pub fn get_infinite_backoff_strategy() -> impl Iterator<Item = Duration> {
     const BASE_DELAY: Duration = Duration::from_secs(1);
     const BACKOFF_FACTOR: u64 = 2;
     const MAX_DELAY: Duration = Duration::from_secs(10);
-    ExponentialBackoff::from_millis(BASE_DELAY.as_millis() as u64)
-        .factor(BACKOFF_FACTOR)
-        .max_delay(MAX_DELAY)
-        .map(jitter)
+    exponential_backoff(BASE_DELAY, BACKOFF_FACTOR, MAX_DELAY).map(jitter)
 }

--- a/src/tests/sqlsmith/clippy.toml
+++ b/src/tests/sqlsmith/clippy.toml
@@ -1,3 +1,4 @@
 disallowed-methods = [
+    { path = "tokio_retry::strategy::ExponentialBackoff::from_millis", reason = "Please use `risingwave_common::util::retry::exponential_backoff` instead; `from_millis` sets the exponent base, not the initial delay." },
     { path = "tokio_postgres::Client::query", reason = "Please use `simple_query` instead, extended `query` uses binary format, which has some outstanding issues." },
 ]


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

`tokio_retry::strategy::ExponentialBackoff::from_millis` is easy to misuse because its argument is the exponential base, not the initial delay. Several call sites treated it as an initial delay and then used `factor` as the multiplier, producing unintended retry sequences.

This is a repository-wide follow-up to Yuhao Su's [#26753](https://github.com/risingwavelabs/risingwave/pull/26753), which corrected the KV log-store rewind schedule and exposed the same API pitfall.

This PR:

- adds `risingwave_common::util::retry::exponential_backoff`, whose arguments explicitly represent the initial delay, multiplier, and maximum delay;
- migrates all direct usages, correcting schedules that misinterpreted the low-level API while preserving the effective timing of intentional schedules;
- gives the KV log-store rewind schedule semantic constant names and keeps its metrics calculation aligned with the actual sequence;
- adds a repository-wide Clippy prohibition, including each subtree-specific Clippy configuration, with guidance to use the RisingWave utility instead.

The utility has focused tests for its initial-delay/multiplier progression and maximum-delay cap.

## Checklist

- [x] I have written necessary rustdoc comments.
- [x] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [x] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/dev/src/ci.md#ci-labels-guide -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->

## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

Not applicable. This changes internal retry scheduling and developer linting without changing a supported external interface.

</details>

## Tests

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features`
- `cargo test -p risingwave_common util::retry`
- `git diff --check`
