### PR TITLE
fix(connector): avoid Pub/Sub streaming pull flow-control stalls

### DIFF
--- a/src/connector/src/allow_alter_on_fly_fields.rs
+++ b/src/connector/src/allow_alter_on_fly_fields.rs
@@ -192,6 +192,8 @@ pub static SOURCE_ALLOW_ALTER_ON_FLY_FIELDS: LazyLock<HashMap<String, HashSet<St
         std::any::type_name::<PubsubProperties>().to_owned(),
         [
             "pubsub.ack_deadline_seconds".to_owned(),
+            "pubsub.max_outstanding_messages".to_owned(),
+            "pubsub.max_outstanding_bytes".to_owned(),
         ].into_iter().collect(),
     ).unwrap();
     // PulsarProperties

--- a/src/connector/src/source/google_pubsub/enumerator/client.rs
+++ b/src/connector/src/source/google_pubsub/enumerator/client.rs
@@ -44,11 +44,7 @@ impl SplitEnumerator for PubsubSplitEnumerator {
             );
         }
 
-        if let Some(ack_deadline) = properties.ack_deadline_seconds
-            && !(10..=600).contains(&ack_deadline)
-        {
-            bail!("pubsub.ack_deadline_seconds must be between 10 and 600");
-        }
+        properties.subscriber_config()?;
 
         if properties.credentials.is_none() && properties.emulator_host.is_none() {
             bail!("credentials must be set if not using the pubsub emulator")

--- a/src/connector/src/source/google_pubsub/mod.rs
+++ b/src/connector/src/source/google_pubsub/mod.rs
@@ -16,7 +16,9 @@ use std::collections::HashMap;
 
 use anyhow::Context;
 use google_cloud_pubsub::client::{Client, ClientConfig};
+use google_cloud_pubsub::subscriber::SubscriberConfig;
 use google_cloud_pubsub::subscription::Subscription;
+use risingwave_common::bail;
 use serde::Deserialize;
 
 pub mod enumerator;
@@ -35,6 +37,12 @@ use crate::error::ConnectorResult;
 use crate::source::SourceProperties;
 
 pub const GOOGLE_PUBSUB_CONNECTOR: &str = "google_pubsub";
+
+const DEFAULT_ACK_DEADLINE_SECONDS: i32 = 60;
+// Pub/Sub messages are acknowledged only after a checkpoint. The upstream client default of 50
+// can therefore stall each reader between checkpoints and severely limit throughput.
+const DEFAULT_MAX_OUTSTANDING_MESSAGES: i64 = 1024;
+const DEFAULT_MAX_OUTSTANDING_BYTES: i64 = 1_000_000_000;
 
 /// # Implementation Notes
 /// Pub/Sub does not rely on persisted state (`SplitImpl`) to start from a position.
@@ -99,6 +107,22 @@ pub struct PubsubProperties {
     #[with_option(allow_alter_on_fly)]
     pub ack_deadline_seconds: Option<i32>,
 
+    /// The maximum number of unacknowledged messages delivered to each streaming pull reader.
+    /// Pub/Sub pauses delivery to a reader when this limit is reached. Must be greater than 0.
+    /// Defaults to 1024.
+    #[serde_as(as = "Option<DisplayFromStr>")]
+    #[serde(rename = "pubsub.max_outstanding_messages")]
+    #[with_option(allow_alter_on_fly)]
+    pub max_outstanding_messages: Option<i64>,
+
+    /// The maximum total size of unacknowledged messages delivered to each streaming pull reader.
+    /// Pub/Sub pauses delivery to a reader when this limit is reached. Must be greater than 0.
+    /// Defaults to 1 GB.
+    #[serde_as(as = "Option<DisplayFromStr>")]
+    #[serde(rename = "pubsub.max_outstanding_bytes")]
+    #[with_option(allow_alter_on_fly)]
+    pub max_outstanding_bytes: Option<i64>,
+
     #[serde(flatten)]
     pub unknown_fields: HashMap<String, String>,
 }
@@ -124,6 +148,36 @@ impl crate::source::UnknownFields for PubsubProperties {
 }
 
 impl PubsubProperties {
+    pub(crate) fn subscriber_config(&self) -> ConnectorResult<SubscriberConfig> {
+        let stream_ack_deadline_seconds = self
+            .ack_deadline_seconds
+            .unwrap_or(DEFAULT_ACK_DEADLINE_SECONDS);
+        if !(10..=600).contains(&stream_ack_deadline_seconds) {
+            bail!("pubsub.ack_deadline_seconds must be between 10 and 600");
+        }
+
+        let max_outstanding_messages = self
+            .max_outstanding_messages
+            .unwrap_or(DEFAULT_MAX_OUTSTANDING_MESSAGES);
+        if max_outstanding_messages <= 0 {
+            bail!("pubsub.max_outstanding_messages must be greater than 0");
+        }
+
+        let max_outstanding_bytes = self
+            .max_outstanding_bytes
+            .unwrap_or(DEFAULT_MAX_OUTSTANDING_BYTES);
+        if max_outstanding_bytes <= 0 {
+            bail!("pubsub.max_outstanding_bytes must be greater than 0");
+        }
+
+        Ok(SubscriberConfig {
+            stream_ack_deadline_seconds,
+            max_outstanding_messages,
+            max_outstanding_bytes,
+            ..Default::default()
+        })
+    }
+
     pub(crate) async fn subscription_client(&self) -> ConnectorResult<Subscription> {
         // initialize env
         {
@@ -145,5 +199,75 @@ impl PubsubProperties {
             .context("error initializing pubsub client")?;
 
         Ok(client.subscription(&self.subscription))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::*;
+
+    fn parse_pubsub_properties(extra: serde_json::Value) -> PubsubProperties {
+        let mut value = json!({
+            "pubsub.subscription": "projects/test/subscriptions/test",
+            "pubsub.emulator_host": "localhost:8900",
+        });
+        value
+            .as_object_mut()
+            .unwrap()
+            .extend(extra.as_object().unwrap().clone());
+        serde_json::from_value(value).unwrap()
+    }
+
+    #[test]
+    fn test_subscriber_config_defaults() {
+        let config = parse_pubsub_properties(json!({}))
+            .subscriber_config()
+            .unwrap();
+
+        assert_eq!(config.stream_ack_deadline_seconds, 60);
+        assert_eq!(config.max_outstanding_messages, 1024);
+        assert_eq!(config.max_outstanding_bytes, 1_000_000_000);
+    }
+
+    #[test]
+    fn test_subscriber_config_overrides() {
+        let config = parse_pubsub_properties(json!({
+            "pubsub.ack_deadline_seconds": "120",
+            "pubsub.max_outstanding_messages": "2048",
+            "pubsub.max_outstanding_bytes": "1048576",
+        }))
+        .subscriber_config()
+        .unwrap();
+
+        assert_eq!(config.stream_ack_deadline_seconds, 120);
+        assert_eq!(config.max_outstanding_messages, 2048);
+        assert_eq!(config.max_outstanding_bytes, 1_048_576);
+    }
+
+    #[test]
+    fn test_subscriber_config_validation() {
+        let invalid_values = [
+            (
+                json!({"pubsub.ack_deadline_seconds": "9"}),
+                "pubsub.ack_deadline_seconds must be between 10 and 600",
+            ),
+            (
+                json!({"pubsub.max_outstanding_messages": "0"}),
+                "pubsub.max_outstanding_messages must be greater than 0",
+            ),
+            (
+                json!({"pubsub.max_outstanding_bytes": "0"}),
+                "pubsub.max_outstanding_bytes must be greater than 0",
+            ),
+        ];
+
+        for (value, expected_error) in invalid_values {
+            let error = parse_pubsub_properties(value)
+                .subscriber_config()
+                .unwrap_err();
+            assert!(error.to_string().contains(expected_error));
+        }
     }
 }

--- a/src/connector/src/source/google_pubsub/source/reader.rs
+++ b/src/connector/src/source/google_pubsub/source/reader.rs
@@ -21,7 +21,7 @@ use futures::{FutureExt, Stream, StreamExt};
 use futures_async_stream::try_stream;
 use google_cloud_pubsub::subscriber::SubscriberConfig;
 use google_cloud_pubsub::subscription::{MessageStream, SubscribeConfig, Subscription};
-use risingwave_common::{bail, ensure};
+use risingwave_common::ensure;
 
 use super::TaggedReceivedMessage;
 use crate::error::{ConnectorError, ConnectorResult as Result};
@@ -32,7 +32,6 @@ use crate::source::{
     SplitReader, into_chunk_stream,
 };
 
-const DEFAULT_ACK_DEADLINE_SECONDS: i32 = 60;
 const MAX_BATCH_SIZE: usize = 1024;
 
 /// Wrapper around [`MessageStream`] that calls [`MessageStream::dispose()`] on drop
@@ -72,7 +71,7 @@ impl Stream for DisposableMessageStream {
 
 pub struct PubsubSplitReader {
     subscription: Subscription,
-    ack_deadline_seconds: i32,
+    subscriber_config: SubscriberConfig,
 
     split_id: SplitId,
     parser_config: ParserConfig,
@@ -81,11 +80,7 @@ pub struct PubsubSplitReader {
 
 impl PubsubSplitReader {
     fn build_subscribe_config(&self) -> SubscribeConfig {
-        let subscriber_config = SubscriberConfig {
-            stream_ack_deadline_seconds: self.ack_deadline_seconds,
-            ..Default::default()
-        };
-        SubscribeConfig::default().with_subscriber_config(subscriber_config)
+        SubscribeConfig::default().with_subscriber_config(self.subscriber_config.clone())
     }
 
     #[try_stream(ok = Vec<SourceMessage>, error = ConnectorError)]
@@ -146,19 +141,12 @@ impl SplitReader for PubsubSplitReader {
         );
         let split = splits.into_iter().next().unwrap();
 
-        let ack_deadline_seconds = properties
-            .ack_deadline_seconds
-            .unwrap_or(DEFAULT_ACK_DEADLINE_SECONDS);
-
-        if !(10..=600).contains(&ack_deadline_seconds) {
-            bail!("pubsub.ack_deadline_seconds must be between 10 and 600");
-        }
-
+        let subscriber_config = properties.subscriber_config()?;
         let subscription = properties.subscription_client().await?;
 
         Ok(Self {
             subscription,
-            ack_deadline_seconds,
+            subscriber_config,
             split_id: split.id(),
             parser_config,
             source_ctx,

--- a/src/connector/with_options_source.yaml
+++ b/src/connector/with_options_source.yaml
@@ -1327,6 +1327,22 @@ PubsubProperties:
       Must be between 10 and 600 seconds. Defaults to 60.
     required: false
     allow_alter_on_fly: true
+  - name: pubsub.max_outstanding_messages
+    field_type: i64
+    comments: |-
+      The maximum number of unacknowledged messages delivered to each streaming pull reader.
+      Pub/Sub pauses delivery to a reader when this limit is reached. Must be greater than 0.
+      Defaults to 1024.
+    required: false
+    allow_alter_on_fly: true
+  - name: pubsub.max_outstanding_bytes
+    field_type: i64
+    comments: |-
+      The maximum total size of unacknowledged messages delivered to each streaming pull reader.
+      Pub/Sub pauses delivery to a reader when this limit is reached. Must be greater than 0.
+      Defaults to 1 GB.
+    required: false
+    allow_alter_on_fly: true
 PulsarProperties:
   fields:
   - name: scan.startup.mode


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

RisingWave acknowledges Pub/Sub messages only after checkpoints, so the client default of 50 outstanding messages can stall each streaming reader between checkpoints. This PR raises the per-reader default to 1024 and adds alter-on-fly `pubsub.max_outstanding_messages` and `pubsub.max_outstanding_bytes` options with validation. It also centralizes subscriber configuration and adds unit coverage for defaults, overrides, and invalid values.

## Checklist

- [x] I have written necessary rustdoc comments.
- [x] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [x] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/dev/src/ci.md#ci-labels-guide -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [x] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

Google Pub/Sub sources now use a larger streaming-pull flow-control window by default and expose per-reader outstanding message and byte limits for online tuning.

</details>
