### PR TITLE
feat(cdc): support append-only PostgreSQL event tables

### DIFF
--- a/e2e_test/source_legacy/cdc/cdc.share_stream.slt
+++ b/e2e_test/source_legacy/cdc/cdc.share_stream.slt
@@ -353,6 +353,21 @@ SELECT c_boolean, c_bit, c_tinyint, c_smallint, c_mediumint, c_integer, c_bigint
 t t -128 -32767 -8388608 -2147483647 -9223372036854775807 -10 -10000 -10000 a b 1001-01-01 00:00:00 1998-01-01 00:00:00 1970-01-01 00:00:01+00:00
 f f NULL NULL -8388608 -2147483647 9223372036854775806 -10 -10000 -10000 c d 1001-01-01 NULL 2000-01-01 00:00:00 NULL
 
+# Prepare a row before the shared source and event table are activated. The raw
+# event table must not backfill it.
+system ok
+psql -v ON_ERROR_STOP=1 -c "
+DROP TABLE IF EXISTS public.rw_cdc_event_history_fixture;
+DROP TABLE IF EXISTS public.rw_cdc_event_history_flush;
+CREATE TABLE public.rw_cdc_event_history_fixture (
+    id INT PRIMARY KEY,
+    value INT NOT NULL
+);
+CREATE TABLE public.rw_cdc_event_history_flush (id INT PRIMARY KEY);
+ALTER TABLE public.rw_cdc_event_history_fixture REPLICA IDENTITY FULL;
+INSERT INTO public.rw_cdc_event_history_fixture VALUES (1, 0);
+"
+
 statement ok
 create secret pg_pwd with (
   backend = 'meta'
@@ -376,6 +391,119 @@ create source pg_source with (
 
 statement ok
 show create source pg_source;
+
+# A raw CDC event table starts at its activation barrier and preserves each
+# routed data envelope without typed parsing or same-key compaction.
+statement ok
+CREATE TABLE pg_cdc_event_history
+APPEND ONLY
+WITH (snapshot = 'false')
+FROM pg_source TABLE 'public.rw_cdc_event_history_fixture';
+
+# The seed row predates activation and snapshot/backfill is disabled.
+sleep 2s
+
+query I
+SELECT count(*) FROM pg_cdc_event_history;
+----
+0
+
+# This succeeds only when the source relation is planned as append-only.
+statement ok
+CREATE SINK pg_cdc_event_history_sink
+FROM pg_cdc_event_history
+WITH (
+    connector = 'blackhole',
+    type = 'append-only',
+    snapshot = 'false'
+);
+
+statement ok
+CREATE MATERIALIZED VIEW pg_cdc_update_history AS
+SELECT
+    (payload->'before'->>'value')::INT AS before_value,
+    (payload->'after'->>'value')::INT AS after_value,
+    source_offset
+FROM pg_cdc_event_history
+WHERE payload->>'op' = 'u';
+
+# Ten updates to the same key are deliberately committed together. The insert
+# and delete additionally verify both envelope shapes and control-record filtering.
+system ok
+psql -v ON_ERROR_STOP=1 -c "
+BEGIN;
+UPDATE public.rw_cdc_event_history_fixture SET value = 1 WHERE id = 1;
+UPDATE public.rw_cdc_event_history_fixture SET value = 2 WHERE id = 1;
+UPDATE public.rw_cdc_event_history_fixture SET value = 3 WHERE id = 1;
+UPDATE public.rw_cdc_event_history_fixture SET value = 4 WHERE id = 1;
+UPDATE public.rw_cdc_event_history_fixture SET value = 5 WHERE id = 1;
+UPDATE public.rw_cdc_event_history_fixture SET value = 6 WHERE id = 1;
+UPDATE public.rw_cdc_event_history_fixture SET value = 7 WHERE id = 1;
+UPDATE public.rw_cdc_event_history_fixture SET value = 8 WHERE id = 1;
+UPDATE public.rw_cdc_event_history_fixture SET value = 9 WHERE id = 1;
+UPDATE public.rw_cdc_event_history_fixture SET value = 10 WHERE id = 1;
+INSERT INTO public.rw_cdc_event_history_fixture VALUES (2, 20);
+DELETE FROM public.rw_cdc_event_history_fixture WHERE id = 2;
+COMMIT;
+"
+
+# PostgreSQL transaction metadata can be delivered when the following
+# transaction starts. This event is routed to another upstream table.
+system ok
+psql -v ON_ERROR_STOP=1 -c "INSERT INTO public.rw_cdc_event_history_flush VALUES (1);"
+
+# BEGIN/END transaction records are not rows, and the pre-activation seed is absent.
+query I retry 15 backoff 1s
+SELECT count(*) FROM pg_cdc_event_history;
+----
+12
+
+query II retry 15 backoff 1s
+SELECT
+    (payload->'before'->>'value')::INT,
+    (payload->'after'->>'value')::INT
+FROM pg_cdc_event_history
+WHERE payload->>'op' = 'u'
+ORDER BY (payload->'transaction'->>'total_order')::BIGINT;
+----
+0 1
+1 2
+2 3
+3 4
+4 5
+5 6
+6 7
+7 8
+8 9
+9 10
+
+query TTT retry 15 backoff 1s
+SELECT
+    payload->>'op',
+    payload->'before'->>'id',
+    payload->'after'->>'id'
+FROM pg_cdc_event_history
+WHERE coalesce(payload->'before'->>'id', payload->'after'->>'id') = '2'
+ORDER BY (payload->'transaction'->>'total_order')::BIGINT;
+----
+c NULL 2
+d 2 NULL
+
+query I retry 15 backoff 1s
+SELECT count(*)
+FROM pg_cdc_event_history
+WHERE source_table_name = 'public.rw_cdc_event_history_fixture'
+  AND source_offset IS NOT NULL
+  AND length(source_offset) > 0
+  AND payload->'source' IS NOT NULL
+  AND payload->'transaction' IS NOT NULL;
+----
+12
+
+query I retry 15 backoff 1s
+SELECT count(*) FROM pg_cdc_update_history;
+----
+10
 
 # postgres streaming test
 system ok
@@ -984,3 +1112,24 @@ onlyif can-use-recover
 statement ok
 recover;
 ### END
+
+# The same assertion also runs after recovery in recovery-enabled profiles.
+query I
+SELECT count(*) FROM pg_cdc_event_history;
+----
+12
+
+statement ok
+DROP SINK pg_cdc_event_history_sink;
+
+statement ok
+DROP MATERIALIZED VIEW pg_cdc_update_history;
+
+statement ok
+DROP TABLE pg_cdc_event_history;
+
+system ok
+psql -c "
+DROP TABLE IF EXISTS public.rw_cdc_event_history_fixture;
+DROP TABLE IF EXISTS public.rw_cdc_event_history_flush;
+"

--- a/src/common/src/catalog/column.rs
+++ b/src/common/src/catalog/column.rs
@@ -27,6 +27,7 @@ use risingwave_pb::plan_common::{
 
 use super::schema::FieldLike;
 use super::{
+    CDC_EVENT_SOURCE_OFFSET_COLUMN_NAME, CDC_EVENT_SOURCE_TABLE_NAME_COLUMN_NAME,
     CDC_OFFSET_COLUMN_NAME, CDC_TABLE_NAME_COLUMN_NAME, ICEBERG_FILE_PATH_COLUMN_NAME,
     ICEBERG_FILE_POS_COLUMN_NAME, ICEBERG_SEQUENCE_NUM_COLUMN_NAME, ROW_ID_COLUMN_NAME,
     RW_TIMESTAMP_COLUMN_ID, RW_TIMESTAMP_COLUMN_NAME, USER_COLUMN_ID_OFFSET,
@@ -457,6 +458,27 @@ impl ColumnCatalog {
             // upstream table name of the cdc table
             Self::hidden(ColumnDesc::named(
                 CDC_TABLE_NAME_COLUMN_NAME,
+                ColumnId::placeholder(),
+                DataType::Varchar,
+            )),
+        ]
+    }
+
+    /// Visible columns exposed by an append-only CDC event table.
+    pub fn debezium_cdc_event_table_cols() -> [Self; 3] {
+        [
+            Self::visible(ColumnDesc::named(
+                "payload",
+                ColumnId::placeholder(),
+                DataType::Jsonb,
+            )),
+            Self::visible(ColumnDesc::named(
+                CDC_EVENT_SOURCE_OFFSET_COLUMN_NAME,
+                ColumnId::placeholder(),
+                DataType::Varchar,
+            )),
+            Self::visible(ColumnDesc::named(
+                CDC_EVENT_SOURCE_TABLE_NAME_COLUMN_NAME,
                 ColumnId::placeholder(),
                 DataType::Varchar,
             )),

--- a/src/common/src/catalog/mod.rs
+++ b/src/common/src/catalog/mod.rs
@@ -141,6 +141,8 @@ pub const CDC_OFFSET_COLUMN_NAME: &str = "_rw_offset";
 /// see [`ColumnCatalog::debezium_cdc_source_cols()`] for details
 pub const CDC_SOURCE_COLUMN_NUM: u32 = 3;
 pub const CDC_TABLE_NAME_COLUMN_NAME: &str = "_rw_table_name";
+pub const CDC_EVENT_SOURCE_OFFSET_COLUMN_NAME: &str = "source_offset";
+pub const CDC_EVENT_SOURCE_TABLE_NAME_COLUMN_NAME: &str = "source_table_name";
 
 pub const ICEBERG_SOURCE_PREFIX: &str = "__iceberg_source_";
 pub const ICEBERG_SINK_PREFIX: &str = "__iceberg_sink_";

--- a/src/connector/src/connector_common/mod.rs
+++ b/src/connector/src/connector_common/mod.rs
@@ -42,7 +42,7 @@ pub use iceberg::{
     ResolvedIcebergCatalogConfig, iceberg_java_catalog_props_from_options,
 };
 pub use postgres::{
-    PgConnectionConfig, PostgresExternalTable, SslMode, create_pg_client,
+    PgConnectionConfig, PostgresCdcTableMetadata, PostgresExternalTable, SslMode, create_pg_client,
     create_pg_client_from_properties, discover_pgvector_dimensions,
     pg_connection_config_from_properties,
 };

--- a/src/connector/src/connector_common/postgres.rs
+++ b/src/connector/src/connector_common/postgres.rs
@@ -89,6 +89,18 @@ const CHECK_TABLE_PRIVILEGE_QUERY: &str = r#"
     LIMIT 1
 "#;
 
+const INSPECT_CDC_TABLE_QUERY: &str = r#"
+    SELECT
+      n.oid IS NOT NULL AS schema_exists,
+      c.relreplident::text AS replica_identity
+    FROM (SELECT 1) AS one
+    LEFT JOIN pg_namespace n ON n.nspname = $1
+    LEFT JOIN pg_class c ON c.relnamespace = n.oid
+      AND c.relname = $2
+      AND c.relkind IN ('r', 'p')
+    LIMIT 1
+"#;
+
 /// Canonical Postgres connection parameters shared across sink, source CDC, batch
 /// executor, and frontend `postgres_query` table function. Each caller constructs
 /// this from its own user-facing config struct before invoking the shared helpers
@@ -219,6 +231,17 @@ pub struct PostgresExternalTable {
     pk_names: Vec<String>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PostgresCdcTableMetadata {
+    pub replica_identity: String,
+}
+
+impl PostgresCdcTableMetadata {
+    pub fn has_full_replica_identity(&self) -> bool {
+        self.replica_identity == "f"
+    }
+}
+
 struct PostgresTablePrivilege {
     user_name: String,
     schema_exists: bool,
@@ -229,6 +252,31 @@ struct PostgresTablePrivilege {
 }
 
 impl PostgresExternalTable {
+    /// Validate that a CDC target exists without discovering or binding its column types.
+    pub async fn inspect_cdc_table(
+        config: &PgConnectionConfig,
+        schema: &str,
+        table: &str,
+    ) -> ConnectorResult<PostgresCdcTableMetadata> {
+        let connection = PgPool::connect_with(config.to_sqlx_connect_options()).await?;
+        let row = sqlx::query(INSPECT_CDC_TABLE_QUERY)
+            .bind(schema)
+            .bind(table)
+            .fetch_one(&connection)
+            .await
+            .context("Failed to inspect PostgreSQL CDC table")?;
+
+        if !row.get::<bool, _>("schema_exists") {
+            return Err(anyhow!("PostgreSQL schema `{schema}` does not exist").into());
+        }
+
+        let replica_identity = row
+            .try_get::<Option<String>, _>("replica_identity")?
+            .ok_or_else(|| anyhow!("PostgreSQL table `{schema}`.`{table}` does not exist"))?;
+
+        Ok(PostgresCdcTableMetadata { replica_identity })
+    }
+
     /// Discover primary key columns directly from PostgreSQL system tables.
     /// This bypasses querying `information_schema.table_constraints` to avoid requiring table owner permissions.
     async fn discover_primary_key(

--- a/src/connector/src/parser/plain_parser.rs
+++ b/src/connector/src/parser/plain_parser.rs
@@ -265,7 +265,10 @@ mod tests {
     use futures::{StreamExt, TryStreamExt};
     use futures_async_stream::try_stream;
     use itertools::Itertools;
+    use risingwave_common::array::Op;
     use risingwave_common::catalog::ColumnCatalog;
+    use risingwave_common::row::Row;
+    use risingwave_common::types::ScalarRefImpl;
     use risingwave_pb::connector_service::{SourceType, cdc_message};
 
     use super::*;
@@ -322,8 +325,8 @@ mod tests {
                     assert_eq!(4, c.cardinality());
                 }
                 if i == 1 {
-                    // 2 data messages + 1 end
-                    assert_eq!(3, c.cardinality());
+                    // 3 data messages + 1 end
+                    assert_eq!(4, c.cardinality());
                 }
                 c
             })
@@ -358,13 +361,55 @@ mod tests {
                 SourceReaderEvent::DataChunk(_) | SourceReaderEvent::SplitProgress(_) => None,
             })
             .inspect(|c| {
-                // 5 data messages in a single chunk
-                assert_eq!(5, c.cardinality());
+                // 6 data messages in a single chunk
+                assert_eq!(6, c.cardinality());
             })
             .collect_vec();
 
         // a single transactional chunk
         assert_eq!(1, output.len());
+        let rows = output[0].rows().collect_vec();
+        assert!(rows.iter().all(|(op, _)| *op == Op::Insert));
+
+        let payloads = rows
+            .iter()
+            .map(|(_, row)| {
+                let Some(ScalarRefImpl::Jsonb(payload)) = row.datum_at(0) else {
+                    panic!("expected JSONB payload")
+                };
+                let payload: serde_json::Value =
+                    serde_json::from_str(&payload.to_string()).unwrap();
+                assert!(payload.get("source").is_some());
+                assert!(payload.get("transaction").is_some());
+
+                let Some(ScalarRefImpl::Utf8(offset)) = row.datum_at(1) else {
+                    panic!("expected source offset")
+                };
+                assert_eq!(offset, "0");
+                let Some(ScalarRefImpl::Utf8(table_name)) = row.datum_at(2) else {
+                    panic!("expected source table name")
+                };
+                assert_eq!(table_name, "orders");
+
+                payload
+            })
+            .collect_vec();
+        assert_eq!(
+            payloads
+                .iter()
+                .map(|payload| payload["op"].as_str().unwrap())
+                .collect_vec(),
+            ["c", "c", "c", "c", "c", "t"]
+        );
+        let customer_names = payloads
+            .iter()
+            .filter_map(|payload| {
+                payload["after"]["customer_name"]
+                    .as_str()
+                    .map(str::to_owned)
+            })
+            .collect_vec();
+        assert_eq!(customer_names, ["a1", "a2", "a3", "a4", "a5"]);
     }
 
     #[try_stream(ok = Vec<SourceMessage>, error = crate::error::ConnectorError)]
@@ -380,11 +425,25 @@ mod tests {
             vec![
                 r#"{ "schema": null, "payload": {"after": {"customer_name": "a4", "order_date": "2020-04-30", "order_id": 10024, "order_status": false, "price": "50.50", "product_id": 102}, "before": null, "op": "c", "source": {"connector": "postgresql", "db": "mydb", "lsn": 3963199336, "name": "RW_CDC_1001", "schema": "public", "sequence": "[\"3963198512\",\"3963199336\"]", "snapshot": "false", "table": "orders_tx", "ts_ms": 1704355505506, "txId": 35352, "version": "2.4.2.Final", "xmin": null}, "transaction": {"data_collection_order": 1, "id": "35392:3963199336", "total_order": 1}, "ts_ms": 1704355839905} }"#,
                 r#"{ "schema": null, "payload": {"after": {"customer_name": "a5", "order_date": "2020-05-30", "order_id": 10025, "order_status": false, "price": "50.50", "product_id": 102}, "before": null, "op": "c", "source": {"connector": "postgresql", "db": "mydb", "lsn": 3963199336, "name": "RW_CDC_1001", "schema": "public", "sequence": "[\"3963198512\",\"3963199336\"]", "snapshot": "false", "table": "orders_tx", "ts_ms": 1704355505506, "txId": 35352, "version": "2.4.2.Final", "xmin": null}, "transaction": {"data_collection_order": 1, "id": "35392:3963199336", "total_order": 1}, "ts_ms": 1704355839905} }"#,
+                r#"{ "schema": null, "payload": {"after": null, "before": null, "op": "t", "source": {"connector": "postgresql", "db": "mydb", "lsn": 3963199336, "name": "RW_CDC_1001", "schema": "public", "sequence": "[\"3963198512\",\"3963199336\"]", "snapshot": "false", "table": "orders_tx", "ts_ms": 1704355505506, "txId": 35352, "version": "2.4.2.Final", "xmin": null}, "transaction": {"data_collection_order": 6, "id": "35392:3963199336", "total_order": 6}, "ts_ms": 1704355839905} }"#,
             ],
         ];
         for (i, batch) in data_batches.iter().enumerate() {
             let mut source_msg_batch = vec![];
             if i == 0 {
+                // A heartbeat updates the source offset but must not become an event row.
+                source_msg_batch.push(SourceMessage {
+                    meta: SourceMeta::DebeziumCdc(DebeziumCdcMeta::new(
+                        "orders".to_owned(),
+                        0,
+                        cdc_message::CdcMessageType::Heartbeat,
+                        SourceType::Unspecified,
+                    )),
+                    split_id: SplitId::from("1001"),
+                    offset: "0".into(),
+                    key: None,
+                    payload: None,
+                });
                 // put begin message at first
                 source_msg_batch.push(SourceMessage {
                     meta: SourceMeta::DebeziumCdc(DebeziumCdcMeta::new(

--- a/src/frontend/src/handler/create_table.rs
+++ b/src/frontend/src/handler/create_table.rs
@@ -37,12 +37,16 @@ use risingwave_common::session_config::sink_decouple::SinkDecouple;
 use risingwave_common::util::sort_util::{ColumnOrder, OrderType};
 use risingwave_common::util::value_encoding::DatumToProtoExt;
 use risingwave_common::{bail, bail_not_implemented};
+use risingwave_connector::connector_common::PostgresExternalTable;
 use risingwave_connector::source::cdc::external::{
     DATABASE_NAME_KEY, ExternalCdcTableType, ExternalTableConfig, ExternalTableImpl,
     SCHEMA_NAME_KEY, SchemaTableName, TABLE_NAME_KEY,
 };
 use risingwave_connector::source::cdc::{
-    build_cdc_table_id, normalize_simple_postgres_quoted_table_name,
+    CDC_BACKFILL_AS_EVEN_SPLITS, CDC_BACKFILL_ENABLE_KEY, CDC_BACKFILL_NUM_ROWS_PER_SPLIT,
+    CDC_BACKFILL_PARALLELISM, CDC_BACKFILL_SNAPSHOT_BATCH_SIZE_KEY,
+    CDC_BACKFILL_SNAPSHOT_INTERVAL_KEY, CDC_BACKFILL_SPLIT_PK_COLUMN_INDEX, build_cdc_table_id,
+    normalize_simple_postgres_quoted_table_name,
 };
 use risingwave_connector::{
     AUTO_SCHEMA_CHANGE_KEY, WithOptionsSecResolved, WithPropertiesExt, source,
@@ -59,10 +63,11 @@ use risingwave_pb::secret::PbSecretRef;
 use risingwave_pb::secret::secret_ref::PbRefAsType;
 use risingwave_pb::stream_plan::StreamFragmentGraph;
 use risingwave_sqlparser::ast::{
-    CdcTableInfo, ColumnDef, ColumnOption, CompatibleFormatEncode, ConnectionRefValue, CreateSink,
-    CreateSinkStatement, CreateSourceStatement, DataType as AstDataType, ExplainOptions, Format,
-    FormatEncodeOptions, Ident, ObjectName, OnConflict, SecretRefAsType, SourceWatermark,
-    Statement, TableConstraint, WebhookSourceInfo, WithProperties,
+    BackfillOrderStrategy, CdcTableInfo, ColumnDef, ColumnOption, CompatibleFormatEncode,
+    ConnectionRefValue, CreateSink, CreateSinkStatement, CreateSourceStatement,
+    DataType as AstDataType, ExplainOptions, Format, FormatEncodeOptions, Ident, ObjectName,
+    OnConflict, SecretRefAsType, SourceWatermark, Statement, TableConstraint, WebhookSourceInfo,
+    WithProperties,
 };
 use risingwave_sqlparser::parser::IncludeOption;
 use thiserror_ext::AsReport;
@@ -980,6 +985,99 @@ pub(crate) fn gen_create_table_plan_for_cdc_table(
     ))
 }
 
+/// Generate the append-only raw event plan for a table based on a shared PostgreSQL CDC source.
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn gen_create_table_plan_for_raw_cdc_table(
+    context: OptimizerContextRef,
+    source: Arc<SourceCatalog>,
+    external_table_name: String,
+    cdc_with_options: WithOptionsSecResolved,
+    mut col_id_gen: ColumnIdGenerator,
+    resolved_table_name: String,
+    database_id: DatabaseId,
+    schema_id: SchemaId,
+    table_id: TableId,
+    engine: Engine,
+) -> Result<(PlanRef, TableCatalog)> {
+    let session = context.session_ctx().clone();
+    let mut columns = ColumnCatalog::debezium_cdc_event_table_cols().to_vec();
+    for column in &mut columns {
+        col_id_gen.generate(column)?;
+    }
+
+    let (columns, pk_column_ids, row_id_index) =
+        bind_pk_and_row_id_on_relation(columns, vec![], true)?;
+    let row_id_index = row_id_index.expect("raw CDC event tables always have a row ID");
+    let table_pk = vec![ColumnOrder::new(row_id_index, OrderType::ascending())];
+
+    let (options, secret_refs) = cdc_with_options.into_parts();
+    let cdc_table_type = ExternalCdcTableType::from_properties(&options);
+    debug_assert_eq!(cdc_table_type, ExternalCdcTableType::Postgres);
+    let cdc_table_desc = CdcTableDesc {
+        table_id,
+        source_id: source.id,
+        external_table_name: external_table_name.clone(),
+        pk: table_pk,
+        columns: columns
+            .iter()
+            .map(|column| column.column_desc.clone())
+            .collect(),
+        stream_key: vec![row_id_index],
+        connect_properties: options,
+        secret_refs,
+    };
+
+    let logical_scan = LogicalCdcScan::create_raw_append_only(
+        external_table_name.clone(),
+        Rc::new(cdc_table_desc),
+        context.clone(),
+    );
+    let required_cols = FixedBitSet::with_capacity(columns.len());
+    let plan_root = PlanRoot::new_with_logical_plan(
+        logical_scan.into(),
+        RequiredDist::Any,
+        Order::any(),
+        required_cols,
+        vec![],
+    );
+
+    let cdc_table_id_external_table_name =
+        normalize_simple_postgres_quoted_table_name(&external_table_name)
+            .unwrap_or(external_table_name);
+    let cdc_table_id = build_cdc_table_id(source.id, &cdc_table_id_external_table_name);
+    let materialize = plan_root.gen_table_plan(
+        context.clone(),
+        resolved_table_name,
+        database_id,
+        schema_id,
+        CreateTableInfo {
+            columns,
+            pk_column_ids,
+            row_id_index: Some(row_id_index),
+            watermark_descs: vec![],
+            source_catalog: Some((*source).clone()),
+            version: col_id_gen.into_version(),
+        },
+        CreateTableProps {
+            definition: context.normalized_sql().to_owned(),
+            append_only: true,
+            on_conflict: ConflictBehavior::NoCheck.into(),
+            with_version_columns: vec![],
+            webhook_info: None,
+            engine,
+        },
+    )?;
+
+    let mut table = materialize.table().clone();
+    table.owner = session.user_id();
+    table.cdc_table_id = Some(cdc_table_id);
+    table.cdc_table_type = Some(cdc_table_type);
+    Ok((
+        ensure_sync_log_store_fragment_root(materialize.into()),
+        table,
+    ))
+}
+
 /// Derive connector properties and normalize `external_table_name` for CDC tables.
 ///
 /// Returns (`connector_properties`, `normalized_external_table_name`) where:
@@ -1177,6 +1275,14 @@ fn parse_postgres_cdc_external_table_name(external_table_name: &str) -> Result<(
     parts.push(current);
 
     if let [schema_name, table_name] = parts.as_slice() {
+        if external_table_name.contains('"')
+            && normalize_simple_postgres_quoted_table_name(external_table_name).is_none()
+        {
+            return Err(anyhow!(
+                "Postgres CDC supports quoted table names only in the form schema.\"table\" without embedded dots, quotes, or backslashes"
+            )
+            .into());
+        }
         Ok((schema_name.clone(), table_name.clone()))
     } else {
         Err(
@@ -1325,6 +1431,14 @@ pub(super) async fn handle_create_table_plan(
     TableJobType,
     Option<SourceId>,
 )> {
+    if append_only && cdc_table_info.is_none() && handler_args.with_options.is_cdc_connector() {
+        return Err(ErrorCode::NotSupported(
+            "a direct CDC connector on an append-only table".to_owned(),
+            "Create a shared `postgres-cdc` source and reference it with FROM ... TABLE".to_owned(),
+        )
+        .into());
+    }
+
     let col_id_gen = ColumnIdGenerator::new_initial();
     let format_encode = check_create_table_with_source(
         &handler_args.with_options,
@@ -1391,6 +1505,11 @@ pub(super) async fn handle_create_table_plan(
                 &wildcard_idx,
                 &constraints,
                 &source_watermarks,
+                on_conflict.is_some(),
+                !with_version_columns.is_empty(),
+                !include_column_options.is_empty(),
+                engine,
+                &handler_args.with_options,
             )?;
 
             generated_columns_check_for_cdc_table(&column_defs)?;
@@ -1405,7 +1524,6 @@ pub(super) async fn handle_create_table_plan(
             let (database_id, schema_id) =
                 session.get_database_and_schema_id_for_create(schema_name.clone())?;
 
-            // cdc table cannot be append-only
             let (source_schema, source_name) =
                 Binder::resolve_schema_qualified_name(db_name, &cdc_table.source_name)?;
 
@@ -1427,63 +1545,86 @@ pub(super) async fn handle_create_table_plan(
                     cdc_table.external_table_name.clone(),
                 )?;
 
-            let (columns, pk_names) = match wildcard_idx {
-                Some(_) => bind_cdc_table_schema_externally(cdc_with_options.clone()).await?,
-                None => {
-                    for column_def in &column_defs {
-                        for option_def in &column_def.options {
-                            if let ColumnOption::DefaultValue(_)
-                            | ColumnOption::DefaultValueInternal { .. } = option_def.option
-                            {
-                                return Err(ErrorCode::NotSupported(
-                                            "Default value for columns defined on the table created from a CDC source".into(),
-                                            "Remove the default value expression in the column definitions".into(),
-                                        )
-                                            .into());
+            let shared_source_id = source.id;
+            let (plan, table) = if append_only {
+                if !source.with_properties.is_shareable_cdc_connector() {
+                    return Err(ErrorCode::NotSupported(
+                        "append-only CDC event tables require a shared CDC source".to_owned(),
+                        "Create and reference a shared `postgres-cdc` source".to_owned(),
+                    )
+                    .into());
+                }
+                validate_raw_postgres_cdc_table(session, cdc_with_options.clone()).await?;
+                let context: OptimizerContextRef =
+                    OptimizerContext::new(handler_args, explain_options).into();
+                gen_create_table_plan_for_raw_cdc_table(
+                    context,
+                    source,
+                    normalized_external_table_name,
+                    cdc_with_options,
+                    col_id_gen,
+                    resolved_table_name,
+                    database_id,
+                    schema_id,
+                    TableId::placeholder(),
+                    engine,
+                )?
+            } else {
+                let (columns, pk_names) = match wildcard_idx {
+                    Some(_) => bind_cdc_table_schema_externally(cdc_with_options.clone()).await?,
+                    None => {
+                        for column_def in &column_defs {
+                            for option_def in &column_def.options {
+                                if let ColumnOption::DefaultValue(_)
+                                | ColumnOption::DefaultValueInternal { .. } = option_def.option
+                                {
+                                    return Err(ErrorCode::NotSupported(
+                                                "Default value for columns defined on the table created from a CDC source".into(),
+                                                "Remove the default value expression in the column definitions".into(),
+                                            )
+                                                .into());
+                                }
                             }
                         }
+
+                        let (columns, pk_names) =
+                            bind_cdc_table_schema(&column_defs, &constraints, false)?;
+                        // Read default value definitions from the external database.
+                        let (options, secret_refs) = cdc_with_options.clone().into_parts();
+                        let _config = ExternalTableConfig::try_from_btreemap(options, secret_refs)
+                            .context("failed to extract external table config")?;
+
+                        (columns, pk_names)
                     }
+                };
 
-                    let (columns, pk_names) =
-                        bind_cdc_table_schema(&column_defs, &constraints, false)?;
-                    // read default value definition from external db
-                    let (options, secret_refs) = cdc_with_options.clone().into_parts();
-                    let _config = ExternalTableConfig::try_from_btreemap(options, secret_refs)
-                        .context("failed to extract external table config")?;
+                // If Debezium column filters remove a PK column from the change-event value,
+                // RisingWave reads NULL for that PK and silently corrupts current-state updates.
+                reject_pk_filtered_by_debezium_column_filter(&pk_names, &cdc_with_options)?;
 
-                    (columns, pk_names)
-                }
+                let context: OptimizerContextRef =
+                    OptimizerContext::new(handler_args, explain_options).into();
+                gen_create_table_plan_for_cdc_table(
+                    context,
+                    source,
+                    normalized_external_table_name,
+                    column_defs,
+                    source_watermarks,
+                    columns,
+                    pk_names,
+                    cdc_with_options,
+                    col_id_gen,
+                    on_conflict,
+                    with_version_columns,
+                    include_column_options,
+                    table_name.clone(),
+                    resolved_table_name,
+                    database_id,
+                    schema_id,
+                    TableId::placeholder(),
+                    engine,
+                )?
             };
-
-            // CDC-table branch only: if Debezium column filters remove a PK column from the
-            // change-event value, RisingWave reads NULL for that PK from the payload and silently
-            // corrupts downstream (UPDATE turns into a fresh INSERT, DELETE no-ops). Plain
-            // (non-CDC) tables don't hit this check.
-            reject_pk_filtered_by_debezium_column_filter(&pk_names, &cdc_with_options)?;
-
-            let context: OptimizerContextRef =
-                OptimizerContext::new(handler_args, explain_options).into();
-            let shared_source_id = source.id;
-            let (plan, table) = gen_create_table_plan_for_cdc_table(
-                context,
-                source,
-                normalized_external_table_name,
-                column_defs,
-                source_watermarks,
-                columns,
-                pk_names,
-                cdc_with_options,
-                col_id_gen,
-                on_conflict,
-                with_version_columns,
-                include_column_options,
-                table_name.clone(),
-                resolved_table_name,
-                database_id,
-                schema_id,
-                TableId::placeholder(),
-                engine,
-            )?;
 
             (
                 (plan, None, table),
@@ -1552,12 +1693,18 @@ fn not_null_check_for_cdc_table(
 }
 
 // Only for table from cdc source
+#[allow(clippy::too_many_arguments)]
 fn sanity_check_for_table_on_cdc_source(
     append_only: bool,
     column_defs: &Vec<ColumnDef>,
     wildcard_idx: &Option<usize>,
     constraints: &Vec<TableConstraint>,
     source_watermarks: &Vec<SourceWatermark>,
+    has_on_conflict: bool,
+    has_version_columns: bool,
+    has_include_columns: bool,
+    engine: Engine,
+    with_options: &WithOptions,
 ) -> Result<()> {
     // wildcard cannot be used with column definitions
     if wildcard_idx.is_some() && !column_defs.is_empty() {
@@ -1566,6 +1713,120 @@ fn sanity_check_for_table_on_cdc_source(
             "Remove the wildcard or column definitions".to_owned(),
         )
         .into());
+    }
+
+    if append_only {
+        if !column_defs.is_empty() {
+            return Err(ErrorCode::NotSupported(
+                "explicit columns on an append-only CDC event table".to_owned(),
+                "Remove the column definitions; the event schema is inferred automatically"
+                    .to_owned(),
+            )
+            .into());
+        }
+        if wildcard_idx.is_some() {
+            return Err(ErrorCode::NotSupported(
+                "wildcard schema inference on an append-only CDC event table".to_owned(),
+                "Remove the wildcard".to_owned(),
+            )
+            .into());
+        }
+        if !constraints.is_empty() {
+            return Err(ErrorCode::NotSupported(
+                "constraints on an append-only CDC event table".to_owned(),
+                "Remove the constraints".to_owned(),
+            )
+            .into());
+        }
+        if !source_watermarks.is_empty() {
+            return Err(ErrorCode::NotSupported(
+                "watermarks on an append-only CDC event table".to_owned(),
+                "Remove the watermark definitions".to_owned(),
+            )
+            .into());
+        }
+        if has_on_conflict {
+            return Err(ErrorCode::NotSupported(
+                "ON CONFLICT on an append-only CDC event table".to_owned(),
+                "Remove the ON CONFLICT clause".to_owned(),
+            )
+            .into());
+        }
+        if has_version_columns {
+            return Err(ErrorCode::NotSupported(
+                "version columns on an append-only CDC event table".to_owned(),
+                "Remove the WITH VERSION COLUMN clause".to_owned(),
+            )
+            .into());
+        }
+        if has_include_columns {
+            return Err(ErrorCode::NotSupported(
+                "INCLUDE columns on an append-only CDC event table".to_owned(),
+                "Remove the INCLUDE clause".to_owned(),
+            )
+            .into());
+        }
+        if engine != Engine::Hummock {
+            return Err(ErrorCode::NotSupported(
+                "Iceberg engine for an append-only CDC event table".to_owned(),
+                "Use the default Hummock engine".to_owned(),
+            )
+            .into());
+        }
+        if with_options.contains_key(UPSTREAM_SOURCE_KEY) {
+            return Err(ErrorCode::NotSupported(
+                "a direct connector on an append-only CDC event table".to_owned(),
+                "Reference a shared PostgreSQL CDC source with FROM ... TABLE instead".to_owned(),
+            )
+            .into());
+        }
+
+        match with_options.get(CDC_BACKFILL_ENABLE_KEY) {
+            Some(value) if value.parse::<bool>() == Ok(false) => {}
+            Some(_) => {
+                return Err(ErrorCode::InvalidParameterValue(
+                    "append-only CDC event tables require `snapshot = 'false'`".to_owned(),
+                )
+                .into());
+            }
+            None => {
+                return Err(ErrorCode::InvalidParameterValue(
+                    "append-only CDC event tables require an explicit `snapshot = 'false'`"
+                        .to_owned(),
+                )
+                .into());
+            }
+        }
+
+        for key in [
+            CDC_BACKFILL_SNAPSHOT_INTERVAL_KEY,
+            CDC_BACKFILL_SNAPSHOT_BATCH_SIZE_KEY,
+            CDC_BACKFILL_PARALLELISM,
+            CDC_BACKFILL_NUM_ROWS_PER_SPLIT,
+            CDC_BACKFILL_AS_EVEN_SPLITS,
+            CDC_BACKFILL_SPLIT_PK_COLUMN_INDEX,
+            OverwriteOptions::BACKFILL_RATE_LIMIT_KEY,
+        ] {
+            if with_options.contains_key(key) {
+                return Err(ErrorCode::NotSupported(
+                    format!("backfill option `{key}` on an append-only CDC event table"),
+                    "Remove the backfill option".to_owned(),
+                )
+                .into());
+            }
+        }
+        if !matches!(
+            with_options.backfill_order_strategy(),
+            BackfillOrderStrategy::Default
+        ) {
+            return Err(ErrorCode::NotSupported(
+                "backfill order on an append-only CDC event table".to_owned(),
+                "Remove the `backfill_order` option".to_owned(),
+            )
+            .into());
+        }
+
+        return Ok(());
     }
 
     // cdc table must have primary key constraint or primary key column
@@ -1588,14 +1849,6 @@ fn sanity_check_for_table_on_cdc_source(
         return Err(ErrorCode::NotSupported(
             "CDC table without primary key constraint is not supported".to_owned(),
             "Please define a primary key".to_owned(),
-        )
-        .into());
-    }
-
-    if append_only {
-        return Err(ErrorCode::NotSupported(
-            "append only modifier on the table created from a CDC source".into(),
-            "Remove the APPEND ONLY clause".into(),
         )
         .into());
     }
@@ -1640,6 +1893,40 @@ async fn bind_cdc_table_schema_externally(
             .collect(),
         table.pk_names().clone(),
     ))
+}
+
+async fn validate_raw_postgres_cdc_table(
+    session: &SessionImpl,
+    cdc_with_options: WithOptionsSecResolved,
+) -> Result<()> {
+    let (options, secret_refs) = cdc_with_options.into_parts();
+    if ExternalCdcTableType::from_properties(&options) != ExternalCdcTableType::Postgres {
+        return Err(ErrorCode::NotSupported(
+            "append-only CDC event tables are only supported for PostgreSQL and AlloyDB sources"
+                .to_owned(),
+            "Use a shared `postgres-cdc` source".to_owned(),
+        )
+        .into());
+    }
+
+    let config = ExternalTableConfig::try_from_btreemap(options, secret_refs)
+        .context("failed to extract PostgreSQL CDC table config")?;
+    let metadata = PostgresExternalTable::inspect_cdc_table(
+        &config.pg_connection_config()?,
+        &config.schema,
+        &config.table,
+    )
+    .await
+    .context("failed to validate PostgreSQL CDC event table")?;
+
+    if !metadata.has_full_replica_identity() {
+        session.notice_to_user(format!(
+            "Upstream table {}.{} does not use REPLICA IDENTITY FULL. CDC event rows will still be recorded, but UPDATE and DELETE envelopes may contain only key or partial before-images.",
+            config.schema, config.table
+        ));
+    }
+
+    Ok(())
 }
 
 /// Derive schema for cdc table when create a new Table or alter an existing Table
@@ -1696,7 +1983,7 @@ pub async fn handle_create_table(
     }
 
     let (graph, source, hummock_table, job_type, shared_source_id) = {
-        let (plan, source, table, job_type, shared_source_id) = handle_create_table_plan(
+        let (plan, source, table, job_type, shared_source_id) = Box::pin(handle_create_table_plan(
             handler_args.clone(),
             ExplainOptions::default(),
             format_encode,
@@ -1712,7 +1999,7 @@ pub async fn handle_create_table(
             include_column_options,
             webhook_info,
             engine,
-        )
+        ))
         .await?;
         tracing::trace!("table_plan: {:?}", plan.explain_to_string());
 
@@ -1736,7 +2023,9 @@ pub async fn handle_create_table(
         Engine::Hummock => {
             let catalog_writer = session.catalog_writer()?;
             let action = match job_type {
-                TableJobType::SharedCdcSource => LongRunningNotificationAction::MonitorBackfillJob,
+                TableJobType::SharedCdcSource if !hummock_table.append_only => {
+                    LongRunningNotificationAction::MonitorBackfillJob
+                }
                 _ => LongRunningNotificationAction::DiagnoseBarrierLatency,
             };
             execute_with_long_running_notification(
@@ -2297,6 +2586,14 @@ pub async fn generate_stream_graph_for_replace_table(
         panic!("unexpected statement type: {:?}", statement);
     };
 
+    if append_only && cdc_table_info.is_none() && handler_args.with_options.is_cdc_connector() {
+        return Err(ErrorCode::NotSupported(
+            "a direct CDC connector on an append-only table".to_owned(),
+            "Create a shared `postgres-cdc` source and reference it with FROM ... TABLE".to_owned(),
+        )
+        .into());
+    }
+
     let format_encode = format_encode
         .clone()
         .map(|format_encode| format_encode.into_v2_with_warning());
@@ -2370,6 +2667,11 @@ pub async fn generate_stream_graph_for_replace_table(
                 &wildcard_idx,
                 &constraints,
                 &source_watermarks,
+                on_conflict.is_some(),
+                !with_version_columns.is_empty(),
+                !include_column_options.is_empty(),
+                engine,
+                &handler_args.with_options,
             )?;
 
             let session = &handler_args.session;
@@ -2382,37 +2684,62 @@ pub async fn generate_stream_graph_for_replace_table(
                     cdc_table.external_table_name.clone(),
                 )?;
 
-            let (column_catalogs, pk_names) = bind_cdc_table_schema(&columns, &constraints, true)?;
+            let (plan, table) = if append_only {
+                if !source.with_properties.is_shareable_cdc_connector() {
+                    return Err(ErrorCode::NotSupported(
+                        "append-only CDC event tables require a shared CDC source".to_owned(),
+                        "Create and reference a shared `postgres-cdc` source".to_owned(),
+                    )
+                    .into());
+                }
+                validate_raw_postgres_cdc_table(session, cdc_with_options.clone()).await?;
+                let context: OptimizerContextRef =
+                    OptimizerContext::new(handler_args, ExplainOptions::default()).into();
+                gen_create_table_plan_for_raw_cdc_table(
+                    context,
+                    source,
+                    normalized_external_table_name,
+                    cdc_with_options,
+                    col_id_gen,
+                    resolved_table_name,
+                    original_catalog.database_id,
+                    original_catalog.schema_id,
+                    original_catalog.id(),
+                    engine,
+                )?
+            } else {
+                let (column_catalogs, pk_names) =
+                    bind_cdc_table_schema(&columns, &constraints, true)?;
 
-            // CDC-table branch only: see the comment at the symmetric call site in
-            // `handle_create_table_plan`. Plain (non-CDC) tables don't hit this check.
-            reject_pk_filtered_by_debezium_column_filter(&pk_names, &cdc_with_options)?;
+                // See the comment at the symmetric call site in `handle_create_table_plan`.
+                reject_pk_filtered_by_debezium_column_filter(&pk_names, &cdc_with_options)?;
 
-            let context: OptimizerContextRef =
-                OptimizerContext::new(handler_args, ExplainOptions::default()).into();
-            let (plan, table) = gen_create_table_plan_for_cdc_table(
-                context,
-                source,
-                normalized_external_table_name,
-                columns,
-                source_watermarks,
-                column_catalogs,
-                pk_names,
-                cdc_with_options,
-                col_id_gen,
-                on_conflict,
-                with_version_columns
-                    .iter()
-                    .map(|col| col.real_value())
-                    .collect(),
-                include_column_options,
-                table_name,
-                resolved_table_name,
-                original_catalog.database_id,
-                original_catalog.schema_id,
-                original_catalog.id(),
-                engine,
-            )?;
+                let context: OptimizerContextRef =
+                    OptimizerContext::new(handler_args, ExplainOptions::default()).into();
+                gen_create_table_plan_for_cdc_table(
+                    context,
+                    source,
+                    normalized_external_table_name,
+                    columns,
+                    source_watermarks,
+                    column_catalogs,
+                    pk_names,
+                    cdc_with_options,
+                    col_id_gen,
+                    on_conflict,
+                    with_version_columns
+                        .iter()
+                        .map(|col| col.real_value())
+                        .collect(),
+                    include_column_options,
+                    table_name,
+                    resolved_table_name,
+                    original_catalog.database_id,
+                    original_catalog.schema_id,
+                    original_catalog.id(),
+                    engine,
+                )?
+            };
 
             ((plan, None, table), TableJobType::SharedCdcSource)
         }
@@ -2583,9 +2910,12 @@ fn bind_webhook_info(
 #[cfg(test)]
 mod tests {
     use risingwave_common::catalog::{
+        CDC_EVENT_SOURCE_OFFSET_COLUMN_NAME, CDC_EVENT_SOURCE_TABLE_NAME_COLUMN_NAME,
         DEFAULT_DATABASE_NAME, ROW_ID_COLUMN_NAME, RW_TIMESTAMP_COLUMN_NAME,
     };
     use risingwave_common::types::{DataType, StructType};
+    use risingwave_pb::catalog::StreamSourceInfo;
+    use risingwave_pb::stream_plan::stream_node::{NodeBody, StreamKind as PbStreamKind};
 
     use super::*;
     use crate::test_utils::{LocalFrontend, PROTO_FILE_DATA, create_proto_file};
@@ -2870,11 +3200,6 @@ mod tests {
         for (input, expected) in [
             ("public.Note", ("public", "Note")),
             ("public.\"Note\"", ("public", "Note")),
-            (
-                "\"Mixed.Schema\".\"Note.Table\"",
-                ("Mixed.Schema", "Note.Table"),
-            ),
-            ("public.\"Note\"\"Archive\"", ("public", "Note\"Archive")),
         ] {
             assert_eq!(
                 parse_postgres_cdc_external_table_name(input).unwrap(),
@@ -2889,6 +3214,9 @@ mod tests {
             ".Note",
             "public.\"Note",
             "public.\"Note\"Archive",
+            "\"MixedSchema\".\"Note\"",
+            "\"Mixed.Schema\".\"Note.Table\"",
+            "public.\"Note\"\"Archive\"",
             "public.Note.Archive",
         ] {
             assert!(
@@ -2896,6 +3224,294 @@ mod tests {
                 "input should be rejected: {input}"
             );
         }
+    }
+
+    fn check_raw_cdc_table_syntax(sql: &str) -> Result<CdcTableInfo> {
+        let statement = risingwave_sqlparser::parser::Parser::parse_exactly_one(sql)?;
+        let with_options = WithOptions::try_from(&statement)?;
+        let Statement::CreateTable {
+            columns,
+            wildcard_idx,
+            constraints,
+            source_watermarks,
+            append_only,
+            on_conflict,
+            with_version_columns,
+            cdc_table_info,
+            include_column_options,
+            engine,
+            ..
+        } = statement
+        else {
+            unreachable!()
+        };
+        let engine = match engine {
+            risingwave_sqlparser::ast::Engine::Hummock => Engine::Hummock,
+            risingwave_sqlparser::ast::Engine::Iceberg => Engine::Iceberg,
+        };
+
+        sanity_check_for_table_on_cdc_source(
+            append_only,
+            &columns,
+            &wildcard_idx,
+            &constraints,
+            &source_watermarks,
+            on_conflict.is_some(),
+            !with_version_columns.is_empty(),
+            !include_column_options.is_empty(),
+            engine,
+            &with_options,
+        )?;
+        cdc_table_info.ok_or_else(|| anyhow!("test statement must use FROM ... TABLE").into())
+    }
+
+    #[test]
+    fn test_raw_cdc_table_syntax_contract() {
+        let cdc_table = check_raw_cdc_table_syntax(
+            r#"CREATE TABLE fuelaudit_events
+               APPEND ONLY
+               WITH (snapshot = 'false')
+               FROM alloydb_source TABLE 'public."FuelAudit"'"#,
+        )
+        .unwrap();
+        assert_eq!(cdc_table.source_name.real_value(), "alloydb_source");
+        assert_eq!(cdc_table.external_table_name, r#"public."FuelAudit""#);
+
+        for (sql, expected_error) in [
+            (
+                "CREATE TABLE e APPEND ONLY FROM s TABLE 'public.t'",
+                "explicit `snapshot = 'false'`",
+            ),
+            (
+                "CREATE TABLE e APPEND ONLY WITH (snapshot = 'true') FROM s TABLE 'public.t'",
+                "require `snapshot = 'false'`",
+            ),
+            (
+                "CREATE TABLE e (id int) APPEND ONLY WITH (snapshot = 'false') FROM s TABLE 'public.t'",
+                "explicit columns",
+            ),
+            (
+                "CREATE TABLE e (*) APPEND ONLY WITH (snapshot = 'false') FROM s TABLE 'public.t'",
+                "wildcard schema inference",
+            ),
+            (
+                "CREATE TABLE e (PRIMARY KEY (id)) APPEND ONLY WITH (snapshot = 'false') FROM s TABLE 'public.t'",
+                "constraints",
+            ),
+            (
+                "CREATE TABLE e (WATERMARK FOR payload AS payload) APPEND ONLY WITH (snapshot = 'false') FROM s TABLE 'public.t'",
+                "watermarks",
+            ),
+            (
+                "CREATE TABLE e APPEND ONLY ON CONFLICT DO NOTHING WITH (snapshot = 'false') FROM s TABLE 'public.t'",
+                "ON CONFLICT",
+            ),
+            (
+                "CREATE TABLE e APPEND ONLY WITH VERSION COLUMN(payload) WITH (snapshot = 'false') FROM s TABLE 'public.t'",
+                "version columns",
+            ),
+            (
+                "CREATE TABLE e APPEND ONLY INCLUDE KEY WITH (snapshot = 'false') FROM s TABLE 'public.t'",
+                "INCLUDE columns",
+            ),
+            (
+                "CREATE TABLE e APPEND ONLY WITH (snapshot = 'false', backfill_order = NONE) FROM s TABLE 'public.t'",
+                "backfill order",
+            ),
+            (
+                "CREATE TABLE e APPEND ONLY WITH (snapshot = 'false') FROM s TABLE 'public.t' ENGINE = ICEBERG",
+                "Iceberg engine",
+            ),
+            (
+                "CREATE TABLE e APPEND ONLY WITH (connector = 'postgres-cdc', snapshot = 'false') FORMAT DEBEZIUM ENCODE JSON FROM s TABLE 'public.t'",
+                "direct connector",
+            ),
+        ] {
+            let err = check_raw_cdc_table_syntax(sql).unwrap_err();
+            assert!(
+                err.to_report_string().contains(expected_error),
+                "unexpected error for `{sql}`: {}",
+                err.to_report_string()
+            );
+        }
+
+        for option in [
+            "snapshot.interval",
+            "snapshot.batch_size",
+            "backfill.parallelism",
+            "backfill.num_rows_per_split",
+            "backfill.as_even_splits",
+            "backfill.split_pk_column_index",
+            "backfill_rate_limit",
+        ] {
+            let sql = format!(
+                "CREATE TABLE e APPEND ONLY WITH \
+                 (snapshot = 'false', {option} = '1') FROM s TABLE 'public.t'"
+            );
+            let err = check_raw_cdc_table_syntax(&sql).unwrap_err();
+            assert!(
+                err.to_report_string()
+                    .contains(&format!("backfill option `{option}`")),
+                "unexpected error for `{sql}`: {}",
+                err.to_report_string()
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn test_raw_cdc_table_rejects_direct_connector() {
+        let frontend = LocalFrontend::new(Default::default()).await;
+        let err = frontend
+            .run_sql(
+                "CREATE TABLE direct_cdc_events APPEND ONLY \
+                 WITH (connector = 'postgres-cdc') FORMAT DEBEZIUM ENCODE JSON",
+            )
+            .await
+            .unwrap_err();
+        assert!(
+            err.to_report_string()
+                .contains("direct CDC connector on an append-only table")
+        );
+    }
+
+    #[tokio::test]
+    async fn test_raw_cdc_table_rejects_non_postgres_source() {
+        let options = WithOptionsSecResolved::new(
+            BTreeMap::from([("connector".to_owned(), "mysql-cdc".to_owned())]),
+            BTreeMap::new(),
+        );
+        let err = validate_raw_postgres_cdc_table(&SessionImpl::mock(), options)
+            .await
+            .unwrap_err();
+        assert!(
+            err.to_report_string()
+                .contains("only supported for PostgreSQL and AlloyDB")
+        );
+    }
+
+    fn raw_cdc_graph_contains(
+        graph: &StreamFragmentGraph,
+        predicate: fn(&NodeBody) -> bool,
+    ) -> bool {
+        fn node_contains(
+            node: &risingwave_pb::stream_plan::StreamNode,
+            predicate: fn(&NodeBody) -> bool,
+        ) -> bool {
+            node.node_body.as_ref().is_some_and(predicate)
+                || node
+                    .input
+                    .iter()
+                    .any(|input| node_contains(input, predicate))
+        }
+
+        graph.fragments.values().any(|fragment| {
+            fragment
+                .node
+                .as_ref()
+                .is_some_and(|node| node_contains(node, predicate))
+        })
+    }
+
+    #[test]
+    fn test_raw_cdc_table_catalog_and_graph() {
+        let context = OptimizerContext::mock();
+        let source = Arc::new(SourceCatalog {
+            id: SourceId::new(42),
+            name: "postgres_source".to_owned(),
+            schema_id: SchemaId::new(1),
+            database_id: DatabaseId::new(1),
+            columns: ColumnCatalog::debezium_cdc_source_cols().to_vec(),
+            pk_col_ids: vec![],
+            append_only: true,
+            owner: context.session_ctx().user_id(),
+            info: StreamSourceInfo {
+                cdc_source_job: true,
+                ..Default::default()
+            },
+            row_id_index: None,
+            with_properties: WithOptionsSecResolved::new(
+                BTreeMap::from([("connector".to_owned(), "postgres-cdc".to_owned())]),
+                BTreeMap::new(),
+            ),
+            watermark_descs: vec![],
+            associated_table_id: None,
+            definition: String::new(),
+            connection_id: None,
+            created_at_epoch: None,
+            initialized_at_epoch: None,
+            version: 0,
+            created_at_cluster_version: None,
+            initialized_at_cluster_version: None,
+            rate_limit: None,
+            refresh_mode: None,
+        });
+        let cdc_options = source.with_properties.clone();
+
+        let (plan, table) = gen_create_table_plan_for_raw_cdc_table(
+            context,
+            source,
+            "public.fuelaudit".to_owned(),
+            cdc_options,
+            ColumnIdGenerator::new_initial(),
+            "fuelaudit_events".to_owned(),
+            DatabaseId::new(1),
+            SchemaId::new(1),
+            TableId::placeholder(),
+            Engine::Hummock,
+        )
+        .unwrap();
+
+        assert!(table.append_only);
+        assert_eq!(table.conflict_behavior(), ConflictBehavior::NoCheck);
+        assert_eq!(table.row_id_index, Some(3));
+        assert_eq!(table.stream_key(), &[3]);
+        assert_eq!(
+            table
+                .columns
+                .iter()
+                .filter(|column| !column.is_hidden)
+                .map(ColumnCatalog::name)
+                .collect_vec(),
+            [
+                "payload",
+                CDC_EVENT_SOURCE_OFFSET_COLUMN_NAME,
+                CDC_EVENT_SOURCE_TABLE_NAME_COLUMN_NAME,
+            ]
+        );
+        assert_eq!(table.columns[3].name(), ROW_ID_COLUMN_NAME);
+        assert!(table.columns[3].is_hidden);
+
+        let graph = build_graph(plan, Some(GraphJobType::Table)).unwrap();
+        assert!(raw_cdc_graph_contains(&graph, |body| matches!(
+            body,
+            NodeBody::CdcFilter(_)
+        )));
+        assert!(raw_cdc_graph_contains(&graph, |body| matches!(
+            body,
+            NodeBody::RowIdGen(_)
+        )));
+        assert!(!raw_cdc_graph_contains(&graph, |body| matches!(
+            body,
+            NodeBody::StreamCdcScan(_)
+        )));
+        assert!(
+            graph.fragments.values().any(|fragment| {
+                fragment.node.as_ref().is_some_and(|node| {
+                    node.identity == "RawCdcEventProject"
+                        && node.stream_kind == PbStreamKind::AppendOnly as i32
+                })
+            }) || graph.fragments.values().any(|fragment| {
+                fragment.node.as_ref().is_some_and(|node| {
+                    fn find_raw_project(node: &risingwave_pb::stream_plan::StreamNode) -> bool {
+                        (node.identity == "RawCdcEventProject"
+                            && node.stream_kind == PbStreamKind::AppendOnly as i32)
+                            || node.input.iter().any(find_raw_project)
+                    }
+                    find_raw_project(node)
+                })
+            })
+        );
+        assert!(graph.backfill_parallelism.is_none());
     }
 
     #[test]

--- a/src/frontend/src/handler/explain.rs
+++ b/src/frontend/src/handler/explain.rs
@@ -96,7 +96,7 @@ pub async fn do_handle_explain(
             } => {
                 let format_encode = format_encode.map(|s| s.into_v2_with_warning());
 
-                let (plan, _source, table, _job_type, _) = handle_create_table_plan(
+                let (plan, _source, table, _job_type, _) = Box::pin(handle_create_table_plan(
                     handler_args,
                     explain_options,
                     format_encode,
@@ -115,7 +115,7 @@ pub async fn do_handle_explain(
                     include_column_options,
                     webhook_info,
                     risingwave_common::catalog::Engine::Hummock,
-                )
+                ))
                 .await?;
                 let context = plan.ctx();
                 (

--- a/src/frontend/src/optimizer/plan_node/generic/cdc_scan.rs
+++ b/src/frontend/src/optimizer/plan_node/generic/cdc_scan.rs
@@ -37,6 +37,12 @@ use crate::expr::{ExprRewriter, ExprVisitor};
 use crate::optimizer::optimizer_context::OptimizerContextRef;
 use crate::optimizer::property::{FunctionalDependencySet, MonotonicityMap, WatermarkColumns};
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum CdcScanMode {
+    CurrentState,
+    RawAppendOnly,
+}
+
 /// [`CdcScan`] reads rows of a table from an external upstream database
 #[derive(Debug, Clone, Educe)]
 #[educe(PartialEq, Eq, Hash)]
@@ -51,6 +57,8 @@ pub struct CdcScan {
     pub ctx: OptimizerContextRef,
 
     pub options: CdcScanOptions,
+
+    pub mode: CdcScanMode,
 }
 
 pub fn build_cdc_scan_options_with_options(
@@ -188,6 +196,7 @@ impl CdcScan {
         cdc_table_desc: Rc<CdcTableDesc>,
         ctx: OptimizerContextRef,
         options: CdcScanOptions,
+        mode: CdcScanMode,
     ) -> Self {
         Self {
             table_name,
@@ -195,6 +204,7 @@ impl CdcScan {
             cdc_table_desc,
             ctx,
             options,
+            mode,
         }
     }
 

--- a/src/frontend/src/optimizer/plan_node/logical_cdc_scan.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_cdc_scan.rs
@@ -69,6 +69,23 @@ impl LogicalCdcScan {
             cdc_table_desc,
             ctx,
             options,
+            generic::CdcScanMode::CurrentState,
+        )
+        .into()
+    }
+
+    pub fn create_raw_append_only(
+        table_name: String,
+        cdc_table_desc: Rc<CdcTableDesc>,
+        ctx: OptimizerContextRef,
+    ) -> Self {
+        generic::CdcScan::new(
+            table_name,
+            (0..cdc_table_desc.columns.len()).collect(),
+            cdc_table_desc,
+            ctx,
+            CdcScanOptions::default(),
+            generic::CdcScanMode::RawAppendOnly,
         )
         .into()
     }
@@ -98,6 +115,7 @@ impl LogicalCdcScan {
             self.core.cdc_table_desc.clone(),
             self.base.ctx(),
             self.core.options.clone(),
+            self.core.mode,
         )
         .into()
     }

--- a/src/frontend/src/optimizer/plan_node/stream_cdc_table_scan.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_cdc_table_scan.rs
@@ -14,7 +14,7 @@
 
 use itertools::Itertools;
 use pretty_xmlish::{Pretty, XmlNode};
-use risingwave_common::catalog::{ColumnCatalog, Field};
+use risingwave_common::catalog::{ColumnCatalog, Field, ROW_ID_COLUMN_ID};
 use risingwave_common::types::DataType;
 use risingwave_common::util::sort_util::OrderType;
 use risingwave_connector::source::cdc::normalize_simple_postgres_quoted_table_name;
@@ -25,7 +25,9 @@ use super::stream::prelude::*;
 use super::utils::{Distill, childless_record};
 use super::{ExprRewritable, PlanBase, StreamNode, StreamPlanRef as PlanRef, generic};
 use crate::catalog::ColumnId;
-use crate::expr::{Expr, ExprImpl, ExprRewriter, ExprType, ExprVisitor, FunctionCall, InputRef};
+use crate::expr::{
+    Expr, ExprImpl, ExprRewriter, ExprType, ExprVisitor, FunctionCall, InputRef, Literal,
+};
 use crate::optimizer::plan_node::expr_visitable::ExprVisitable;
 use crate::optimizer::plan_node::utils::{IndicesDisplay, TableCatalogBuilder};
 use crate::optimizer::property::{Distribution, DistributionDisplay};
@@ -44,10 +46,14 @@ pub struct StreamCdcTableScan {
 impl StreamCdcTableScan {
     pub fn new(core: generic::CdcScan) -> Self {
         let distribution = Distribution::SomeShard;
+        let stream_kind = match core.mode {
+            generic::CdcScanMode::CurrentState => StreamKind::Retract,
+            generic::CdcScanMode::RawAppendOnly => StreamKind::AppendOnly,
+        };
         let base = PlanBase::new_stream_with_core(
             &core,
             distribution,
-            StreamKind::Retract,
+            stream_kind,
             false,
             core.watermark_columns(),
             core.columns_monotonicity(),
@@ -180,32 +186,25 @@ impl StreamCdcTableScan {
             .map(|c| Field::from(c.column_desc).to_prost())
             .collect_vec();
 
-        let catalog = self
-            .build_backfill_state_catalog(state, self.core.options.is_parallelized_backfill())
-            .to_internal_table_prost();
-
-        // We need to pass the id of upstream source job here
+        // We need to pass the id of upstream source job here.
         let upstream_source_id = self.core.cdc_table_desc.source_id;
 
-        // filter upstream source chunk by the value of `_rw_table_name` column
+        // Filter upstream source chunks by the value of `_rw_table_name`.
         let filter_expr =
             Self::build_cdc_filter_expr(self.core.cdc_table_desc.external_table_name.as_str());
 
         let filter_operator_id = self.core.ctx.next_plan_node_id();
-        // The filter node receive chunks in `(payload, _rw_offset, _rw_table_name)` schema
+        // The merge node body will be filled by the actor builder on the meta service.
         let filter_stream_node = StreamNode {
             operator_id: filter_operator_id.to_stream_node_operator_id(),
-            input: vec![
-                // The merge node body will be filled by the `ActorBuilder` on the meta service.
-                PbStreamNode {
-                    node_body: Some(PbNodeBody::Merge(Default::default())),
-                    identity: "Upstream".into(),
-                    fields: cdc_source_schema.clone(),
-                    stream_key: vec![], // not used
-                    ..Default::default()
-                },
-            ],
-            stream_key: vec![], // not used
+            input: vec![PbStreamNode {
+                node_body: Some(PbNodeBody::Merge(Default::default())),
+                identity: "Upstream".into(),
+                fields: cdc_source_schema.clone(),
+                stream_key: vec![],
+                ..Default::default()
+            }],
+            stream_key: vec![],
             stream_kind: PbStreamKind::AppendOnly as _,
             identity: "StreamCdcFilter".to_owned(),
             fields: cdc_source_schema.clone(),
@@ -214,6 +213,40 @@ impl StreamCdcTableScan {
                 upstream_source_id,
             }))),
         };
+
+        if self.core.mode == generic::CdcScanMode::RawAppendOnly {
+            let select_list = self
+                .core
+                .output_col_idx
+                .iter()
+                .map(|&index| match index {
+                    0 => ExprImpl::from(InputRef::new(0, DataType::Jsonb)),
+                    1 | 2 => ExprImpl::from(InputRef::new(index, DataType::Varchar)),
+                    _ if self.core.get_table_columns()[index].column_id == ROW_ID_COLUMN_ID => {
+                        ExprImpl::from(Literal::new(None, DataType::Serial))
+                    }
+                    _ => unreachable!("unexpected raw CDC event table column index: {index}"),
+                })
+                .map(|expr| expr.to_expr_proto())
+                .collect();
+
+            return Ok(PbStreamNode {
+                fields: self.schema().to_prost(),
+                input: vec![filter_stream_node],
+                node_body: Some(PbNodeBody::Project(Box::new(ProjectNode {
+                    select_list,
+                    ..Default::default()
+                }))),
+                stream_key,
+                operator_id: self.base.id().to_stream_node_operator_id(),
+                identity: "RawCdcEventProject".to_owned(),
+                stream_kind: PbStreamKind::AppendOnly as _,
+            });
+        }
+
+        let catalog = self
+            .build_backfill_state_catalog(state, self.core.options.is_parallelized_backfill())
+            .to_internal_table_prost();
 
         let exchange_operator_id = self.core.ctx.next_plan_node_id();
         let strategy = if self.core.options.is_parallelized_backfill() {

--- a/src/meta/service/src/ddl_service.rs
+++ b/src/meta/service/src/ddl_service.rs
@@ -1398,6 +1398,19 @@ impl DdlService for DdlServiceImpl {
                 .await?;
 
             for table in tables {
+                // Raw append-only CDC event tables have a fixed envelope schema. Upstream schema
+                // changes remain visible inside future JSON payloads and must not replace the
+                // RisingWave table definition.
+                if table.append_only {
+                    tracing::debug!(
+                        target: "auto_schema_change",
+                        table_id = %table.id,
+                        cdc_table_id = table.cdc_table_id,
+                        "Skipping auto schema change for append-only CDC event table"
+                    );
+                    continue;
+                }
+
                 // Since we only support `ADD` and `DROP` column, we check whether the new columns and the original columns
                 // is a subset of the other.
                 let original_columns_by_name: HashMap<String, ColumnCatalog> = table

--- a/src/meta/src/model/stream.rs
+++ b/src/meta/src/model/stream.rs
@@ -491,8 +491,9 @@ impl StreamJobFragments {
         let mut actor_ids = vec![];
         for (fragment_type_mask, actors) in fragments {
             if fragment_type_mask.contains(FragmentTypeFlag::CdcFilter) {
-                // Note: CDC table job contains a StreamScan fragment (StreamCdcScan node) and a CdcFilter fragment.
-                // We don't track any fragments' progress.
+                // Current-state CDC tables also contain a StreamCdcScan backfill fragment, while
+                // raw append-only CDC event tables do not. Creation progress for either kind is
+                // driven by the CDC job lifecycle rather than generic actor progress tracking.
                 return vec![];
             }
             if fragment_type_mask.contains_any([

--- a/src/meta/src/rpc/ddl_controller.rs
+++ b/src/meta/src/rpc/ddl_controller.rs
@@ -981,13 +981,21 @@ impl DdlController {
         Ok(version)
     }
 
-    /// Validates the connect properties in the `cdc_table_desc` stored in the `StreamCdcScan` node
+    /// Validates the connect properties in the `cdc_table_desc` stored in a current-state
+    /// `StreamCdcScan` node. Raw append-only CDC event tables are validated in the frontend and do
+    /// not contain this node.
     #[await_tree::instrument]
     pub(crate) async fn validate_cdc_table(
         &self,
         table: &Table,
         table_fragments: &StreamJobFragments,
     ) -> MetaResult<()> {
+        // Append-only CDC event tables consume the already validated raw shared-source stream.
+        // They intentionally contain a CdcFilter but no StreamCdcScan or backfill executor.
+        if table.append_only {
+            return Ok(());
+        }
+
         let stream_scan_fragment =
             Itertools::exactly_one(table_fragments.fragments.values().filter(|f| {
                 f.fragment_type_mask.contains(FragmentTypeFlag::StreamScan)

--- a/src/meta/src/stream/stream_graph/fragment.rs
+++ b/src/meta/src/stream/stream_graph/fragment.rs
@@ -1783,7 +1783,7 @@ impl CompleteStreamFragmentGraph {
                                     downstream_fragment_id: id,
                                 },
                                 // We always use `NoShuffle` for the exchange between the upstream
-                                // `Source` and the downstream `StreamScan` of the new cdc table.
+                                // `Source` and the downstream `CdcFilter` of the new CDC table.
                                 dispatch_strategy: DispatchStrategy {
                                     r#type: DispatcherType::NoShuffle as _,
                                     dist_key_indices: vec![], // not used for `NoShuffle`

--- a/src/stream/src/executor/mview/materialize.rs
+++ b/src/stream/src/executor/mview/materialize.rs
@@ -242,10 +242,12 @@ impl<S: StateStore, SD: ValueRowSerde> MaterializeExecutor<S, SD> {
             .map(|col| col.column_desc.as_ref().unwrap().into())
             .collect();
 
-        // Extract TOAST-able column indices from table columns.
-        // Only for PostgreSQL CDC tables.
-        let toastable_column_indices = if table_catalog.cdc_table_type()
-            == risingwave_pb::catalog::table::CdcTableType::Postgres
+        // Extract TOAST-able column indices from typed PostgreSQL CDC tables. Append-only CDC
+        // event tables carry opaque envelopes and must not interpret or replace values inside
+        // them; keeping this `None` also selects the cache-free `NoCheck` materialize path.
+        let toastable_column_indices = if !table_catalog.append_only
+            && table_catalog.cdc_table_type()
+                == risingwave_pb::catalog::table::CdcTableType::Postgres
         {
             let toastable_indices: Vec<usize> = table_columns
                 .iter()
@@ -1257,21 +1259,238 @@ impl<S: StateStore, SD: ValueRowSerde> std::fmt::Debug for MaterializeExecutor<S
 #[cfg(test)]
 mod tests {
 
+    use std::collections::HashSet;
     use std::iter;
     use std::sync::atomic::AtomicU64;
 
+    use futures::TryStreamExt;
     use rand::rngs::SmallRng;
     use rand::{Rng, RngCore, SeedableRng};
+    use risingwave_common::array::Array;
     use risingwave_common::array::stream_chunk::{StreamChunkMut, StreamChunkTestExt};
     use risingwave_common::catalog::Field;
+    use risingwave_common::types::JsonbVal;
     use risingwave_common::util::epoch::test_epoch;
     use risingwave_common::util::sort_util::OrderType;
     use risingwave_hummock_sdk::HummockReadEpoch;
+    use risingwave_pb::catalog::table::CdcTableType as PbCdcTableType;
+    use risingwave_pb::stream_plan::stream_node::StreamKind as PbStreamKind;
     use risingwave_storage::memory::MemoryStateStore;
     use risingwave_storage::table::batch_table::BatchTable;
 
     use super::*;
+    use crate::executor::row_id_gen::RowIdGenExecutor;
     use crate::executor::test_utils::*;
+
+    #[tokio::test]
+    async fn test_append_only_cdc_events_preserve_same_key_rows_across_recovery() {
+        const EVENT_COUNT: usize = 3_000;
+
+        let memory_state_store = MemoryStateStore::new();
+        let table_id = TableId::new(1);
+        let schema = Schema::new(vec![
+            Field::unnamed(DataType::Jsonb),
+            Field::unnamed(DataType::Varchar),
+            Field::unnamed(DataType::Varchar),
+            Field::unnamed(DataType::Serial),
+        ]);
+        let column_ids = vec![1.into(), 2.into(), 3.into(), 0.into()];
+        let data_types = schema.data_types();
+        let rows = (0..EVENT_COUNT)
+            .map(|transition| {
+                (
+                    Op::Insert,
+                    OwnedRow::new(vec![
+                        Some(
+                            JsonbVal::from(serde_json::json!({
+                                "before": { "id": 42, "value": transition },
+                                "after": { "id": 42, "value": transition + 1 },
+                                "op": "u",
+                                "source": { "lsn": 100 },
+                                "transaction": { "total_order": transition + 1 },
+                            }))
+                            .into(),
+                        ),
+                        Some("same-native-offset".into()),
+                        Some("public.same_key_updates".into()),
+                        None,
+                    ]),
+                )
+            })
+            .collect_vec();
+        let event_chunk = StreamChunk::from_rows(&rows, &data_types);
+
+        let column_descs = vec![
+            ColumnDesc::unnamed(column_ids[0], DataType::Jsonb),
+            ColumnDesc::unnamed(column_ids[1], DataType::Varchar),
+            ColumnDesc::unnamed(column_ids[2], DataType::Varchar),
+            ColumnDesc::unnamed(column_ids[3], DataType::Serial),
+        ];
+        let mut materialize_table = crate::common::table::test_utils::gen_pbtable(
+            table_id,
+            column_descs.clone(),
+            vec![OrderType::ascending()],
+            vec![3],
+            0,
+        );
+        materialize_table.stream_key = vec![3];
+        materialize_table.append_only = true;
+        materialize_table.cdc_table_type = Some(PbCdcTableType::Postgres as i32);
+        let table = BatchTable::for_test(
+            memory_state_store.clone(),
+            table_id,
+            column_descs,
+            vec![OrderType::ascending()],
+            vec![3],
+            vec![0, 1, 2, 3],
+        );
+
+        let source = MockSource::with_messages(vec![
+            Message::Barrier(Barrier::new_test_barrier(test_epoch(1))),
+            Message::Chunk(event_chunk),
+            Message::Barrier(Barrier::new_test_barrier(test_epoch(2))),
+        ])
+        .into_executor(schema.clone(), StreamKey::new());
+        let row_id_gen = (
+            ExecutorInfo {
+                schema: schema.clone(),
+                stream_key: vec![3],
+                stream_kind: PbStreamKind::AppendOnly,
+                identity: "RawCdcEventRowIdGen".to_owned(),
+                ..Default::default()
+            },
+            RowIdGenExecutor::new(
+                ActorContext::for_test(1),
+                source,
+                3,
+                Bitmap::ones(VirtualNode::COUNT_FOR_TEST),
+            ),
+        )
+            .into();
+        let mut materialize = MaterializeExecutor::<_, BasicSerde>::new(
+            row_id_gen,
+            schema.clone(),
+            memory_state_store.clone(),
+            vec![ColumnOrder::new(3, OrderType::ascending())],
+            ActorContext::for_test(1),
+            None,
+            &materialize_table,
+            Arc::new(AtomicU64::new(0)),
+            ConflictBehavior::NoCheck,
+            vec![],
+            StreamingMetrics::unused().into(),
+            None,
+            false,
+            LocalBarrierManager::for_test(),
+        )
+        .await
+        .boxed()
+        .execute();
+
+        assert!(matches!(
+            materialize.next().await.transpose().unwrap(),
+            Some(Message::Barrier(_))
+        ));
+        let output = materialize
+            .next()
+            .await
+            .transpose()
+            .unwrap()
+            .unwrap()
+            .into_chunk()
+            .unwrap();
+        assert_eq!(output.cardinality(), EVENT_COUNT);
+        let row_ids = output
+            .column_at(3)
+            .as_serial()
+            .iter()
+            .map(|value| value.unwrap())
+            .collect::<HashSet<_>>();
+        assert_eq!(row_ids.len(), EVENT_COUNT);
+        assert!(matches!(
+            materialize.next().await.transpose().unwrap(),
+            Some(Message::Barrier(_))
+        ));
+        drop(materialize);
+
+        let stored_rows = table
+            .batch_iter(
+                HummockReadEpoch::NoWait(u64::MAX),
+                false,
+                Default::default(),
+            )
+            .await
+            .unwrap()
+            .try_collect::<Vec<_>>()
+            .await
+            .unwrap();
+        assert_eq!(stored_rows.len(), EVENT_COUNT);
+
+        // Recover the row-id and materialize executors after the committed barrier. Replaying no
+        // source data must neither duplicate nor lose any event row already in storage.
+        let recovered_source = MockSource::with_messages(vec![
+            Message::Barrier(Barrier::new_test_barrier(test_epoch(2))),
+            Message::Barrier(Barrier::new_test_barrier(test_epoch(3))),
+        ])
+        .into_executor(schema.clone(), StreamKey::new());
+        let recovered_row_id_gen = (
+            ExecutorInfo {
+                schema: schema.clone(),
+                stream_key: vec![3],
+                stream_kind: PbStreamKind::AppendOnly,
+                identity: "RecoveredRawCdcEventRowIdGen".to_owned(),
+                ..Default::default()
+            },
+            RowIdGenExecutor::new(
+                ActorContext::for_test(1),
+                recovered_source,
+                3,
+                Bitmap::ones(VirtualNode::COUNT_FOR_TEST),
+            ),
+        )
+            .into();
+        let mut recovered_materialize = MaterializeExecutor::<_, BasicSerde>::new(
+            recovered_row_id_gen,
+            schema.clone(),
+            memory_state_store,
+            vec![ColumnOrder::new(3, OrderType::ascending())],
+            ActorContext::for_test(1),
+            None,
+            &materialize_table,
+            Arc::new(AtomicU64::new(0)),
+            ConflictBehavior::NoCheck,
+            vec![],
+            StreamingMetrics::unused().into(),
+            None,
+            false,
+            LocalBarrierManager::for_test(),
+        )
+        .await
+        .boxed()
+        .execute();
+        assert!(matches!(
+            recovered_materialize.next().await.transpose().unwrap(),
+            Some(Message::Barrier(_))
+        ));
+        assert!(matches!(
+            recovered_materialize.next().await.transpose().unwrap(),
+            Some(Message::Barrier(_))
+        ));
+        drop(recovered_materialize);
+
+        let stored_rows_after_recovery = table
+            .batch_iter(
+                HummockReadEpoch::NoWait(u64::MAX),
+                false,
+                Default::default(),
+            )
+            .await
+            .unwrap()
+            .try_collect::<Vec<_>>()
+            .await
+            .unwrap();
+        assert_eq!(stored_rows_after_recovery.len(), EVENT_COUNT);
+    }
 
     #[tokio::test]
     async fn test_materialize_executor() {


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

This PR adds a native append-only event-history mode for PostgreSQL and AlloyDB shared CDC sources through `CREATE TABLE ... APPEND ONLY WITH (snapshot = 'false') FROM ... TABLE ...`.
It exposes each raw Debezium data envelope with source offset and routing metadata, generates an internal row ID, and lowers directly to the shared-source `Merge -> CdcFilter -> Project` path without typed parsing, backfill, or same-key materialization compaction.
Metadata-only upstream validation, replica-identity notices, replace/recovery support, and fixed-schema auto-evolution handling preserve existing CDC dependency semantics, while connector, frontend, stream recovery, sink-planning, and PostgreSQL CDC integration tests cover the new behavior.

## Checklist

- [x] I have written necessary rustdoc comments.
- [x] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [x] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/dev/src/ci.md#ci-labels-guide -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [x] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

RisingWave can now capture every future PostgreSQL or AlloyDB CDC data-change envelope in a native append-only event table for lossless changelog processing; snapshot/backfill is intentionally unsupported, and complete old-row images require upstream `REPLICA IDENTITY FULL`.

</details>
