### PR TITLE
feat(sink): support PUT method in HTTP sink

### DIFF
--- a/ci/scripts/e2e-sink-test.sh
+++ b/ci/scripts/e2e-sink-test.sh
@@ -55,7 +55,8 @@ risedev slt './e2e_test/sink/force_compaction_sink.slt'
 echo "--- e2e, http sink"
 HTTP_SINK_OUTPUT=$(mktemp)
 HTTP_SINK_HEADERS=$(mktemp)
-python3 e2e_test/sink/http_sink_mock_server.py "$HTTP_SINK_OUTPUT" 18081 "$HTTP_SINK_HEADERS" &
+HTTP_SINK_METHODS=$(mktemp)
+python3 e2e_test/sink/http_sink_mock_server.py "$HTTP_SINK_OUTPUT" 18081 "$HTTP_SINK_HEADERS" "" "$HTTP_SINK_METHODS" &
 HTTP_SINK_SERVER_PID=$!
 # Wait for the server to be ready
 for i in $(seq 1 20); do curl -sf http://localhost:18081/ && break; sleep 0.5; done
@@ -68,11 +69,15 @@ sleep 1
 grep -Fx 'before update' "$HTTP_SINK_OUTPUT"
 grep -Fx 'hello world' "$HTTP_SINK_OUTPUT"
 grep -Fx '{"key":"value"}' "$HTTP_SINK_OUTPUT"
+grep -Fx 'put payload' "$HTTP_SINK_OUTPUT"
 grep -q '"event"' "$HTTP_SINK_OUTPUT"
 grep -Fx 'dynamic url payload' "$HTTP_SINK_OUTPUT"
 grep -Fx 'dynamic url as select payload' "$HTTP_SINK_OUTPUT"
-# Exactly 1 line from ignore_delete test + 2 from varchar test (NULL was skipped) + 1 from jsonb + 2 from dynamic URL tests
-test "$(wc -l < "$HTTP_SINK_OUTPUT")" -eq 6
+# Exactly 1 line from ignore_delete test + 2 from varchar test (NULL was skipped) + 1 from PUT + 1 from jsonb + 2 from dynamic URL tests
+test "$(wc -l < "$HTTP_SINK_OUTPUT")" -eq 7
+# Verify the default method remains POST and an explicitly configured PUT is honored
+test "$(grep -c '^POST$' "$HTTP_SINK_METHODS")" -eq 6
+test "$(grep -c '^PUT$' "$HTTP_SINK_METHODS")" -eq 1
 # Verify the custom header set via header.x_test = 'rw-http-sink' was sent
 grep -q '"x_test": "rw-http-sink"' "$HTTP_SINK_HEADERS"
 # Verify inferred default content types for varchar and jsonb payloads
@@ -80,7 +85,7 @@ grep -q '"content-type": "text/plain"' "$HTTP_SINK_HEADERS"
 grep -q '"content-type": "application/json"' "$HTTP_SINK_HEADERS"
 
 kill "$HTTP_SINK_SERVER_PID" || true
-rm -f "$HTTP_SINK_OUTPUT" "$HTTP_SINK_HEADERS"
+rm -f "$HTTP_SINK_OUTPUT" "$HTTP_SINK_HEADERS" "$HTTP_SINK_METHODS"
 
 echo "--- e2e, turbopuffer sink"
 TURBOPUFFER_SINK_OUTPUT=$(mktemp)

--- a/e2e_test/sink/http_sink.slt
+++ b/e2e_test/sink/http_sink.slt
@@ -119,6 +119,22 @@ CREATE SINK s_bad_url FROM t_url WITH (
 statement ok
 DROP TABLE t_url;
 
+# ---- Validation: unsupported HTTP method should be rejected ----
+statement ok
+CREATE TABLE t_unsupported_method (payload varchar);
+
+statement error HTTP sink method must be POST or PUT, got 'DELETE'
+CREATE SINK s_unsupported_method FROM t_unsupported_method WITH (
+    connector = 'http',
+    url = 'http://localhost:18081',
+    method = 'DELETE',
+    type = 'append-only',
+    force_append_only = 'true'
+);
+
+statement ok
+DROP TABLE t_unsupported_method;
+
 # ---- Validation: auto schema change should be rejected ----
 statement ok
 CREATE TABLE t_auto_schema_change (payload varchar primary key);
@@ -200,6 +216,31 @@ DROP SINK s_varchar;
 
 statement ok
 DROP TABLE t_varchar;
+
+# ---- Success: PUT method ----
+statement ok
+CREATE TABLE t_put (payload varchar);
+
+statement ok
+CREATE SINK s_put FROM t_put WITH (
+    connector = 'http',
+    url = 'http://localhost:18081',
+    method = 'PUT',
+    type = 'append-only',
+    force_append_only = 'true'
+);
+
+statement ok
+INSERT INTO t_put VALUES ('put payload');
+
+statement ok
+FLUSH;
+
+statement ok
+DROP SINK s_put;
+
+statement ok
+DROP TABLE t_put;
 
 # ---- Success: jsonb payload ----
 statement ok

--- a/e2e_test/sink/http_sink_mock_server.py
+++ b/e2e_test/sink/http_sink_mock_server.py
@@ -17,12 +17,13 @@
 Mock HTTP server for testing the RisingWave HTTP sink.
 
 Usage:
-    python3 http_sink_mock_server.py <body_output_file> <port> [<header_output_file>] [<path_output_file>]
+    python3 http_sink_mock_server.py <body_output_file> <port> [<header_output_file>] [<path_output_file>] [<method_output_file>]
 
-Each POST request body is appended as a line to the body output file.
+Each POST or PUT request body is appended as a line to the body output file.
 If a header output file is given, received headers are appended as a JSON line per request.
 If a path output file is given, each request path is appended as a line per request.
-Responds 200 OK to every POST, 400 to anything else.
+If a method output file is given, each request method is appended as a line per request.
+Responds 200 OK to every POST and PUT request.
 """
 
 import json
@@ -35,10 +36,11 @@ def main():
     body_output_file = sys.argv[1] if len(sys.argv) > 1 else "/tmp/http_sink_test_body.txt"
     port = int(sys.argv[2]) if len(sys.argv) > 2 else 18081
     header_output_file = sys.argv[3] if len(sys.argv) > 3 else None
-    path_output_file = sys.argv[4] if len(sys.argv) > 4 else None
+    path_output_file = sys.argv[4] if len(sys.argv) > 4 and sys.argv[4] else None
+    method_output_file = sys.argv[5] if len(sys.argv) > 5 and sys.argv[5] else None
 
     class Handler(BaseHTTPRequestHandler):
-        def do_POST(self):
+        def _handle_request(self):
             length = int(self.headers.get("Content-Length", 0))
             body = self.rfile.read(length).decode("utf-8")
             with open(body_output_file, "a") as f:
@@ -46,12 +48,21 @@ def main():
             if path_output_file is not None:
                 with open(path_output_file, "a") as f:
                     f.write(self.path + "\n")
+            if method_output_file is not None:
+                with open(method_output_file, "a") as f:
+                    f.write(self.command + "\n")
             if header_output_file is not None:
                 headers = {k.lower(): v for k, v in self.headers.items()}
                 with open(header_output_file, "a") as f:
                     f.write(json.dumps(headers) + "\n")
             self.send_response(200)
             self.end_headers()
+
+        def do_POST(self):
+            self._handle_request()
+
+        def do_PUT(self):
+            self._handle_request()
 
         def do_GET(self):
             # Health check endpoint
@@ -64,7 +75,7 @@ def main():
     server = HTTPServer(("", port), Handler)
 
     def handle_sigterm(signum, frame):
-        server.shutdown()
+        server.server_close()
         sys.exit(0)
 
     signal.signal(signal.SIGTERM, handle_sigterm)

--- a/src/connector/src/sink/http.rs
+++ b/src/connector/src/sink/http.rs
@@ -37,8 +37,11 @@ const HTTP_SINK_URL_COLUMN: &str = "url";
 
 #[derive(Clone, Debug, Deserialize, WithOptions)]
 pub struct HttpConfig {
-    /// The endpoint URL to POST data to.
+    /// The endpoint URL to send data to.
     pub url: Option<String>,
+
+    /// HTTP request method. Supported values are `POST` and `PUT`. Defaults to `POST`.
+    pub method: Option<String>,
 
     /// Content-Type header value. Defaults to `text/plain` for `varchar` and `application/json`
     /// for `jsonb`.
@@ -96,6 +99,7 @@ fn validate_http_sink(
     ignore_delete: bool,
     schema: &Schema,
     url: Option<&str>,
+    method: Option<&str>,
     content_type: Option<&str>,
     headers: &BTreeMap<String, String>,
     unknown_fields: std::collections::HashMap<String, String>,
@@ -105,6 +109,17 @@ fn validate_http_sink(
             "HTTP sink only supports append-only mode"
         )));
     }
+
+    let method = match method {
+        None => reqwest::Method::POST,
+        Some(method) if method.eq_ignore_ascii_case("POST") => reqwest::Method::POST,
+        Some(method) if method.eq_ignore_ascii_case("PUT") => reqwest::Method::PUT,
+        Some(method) => {
+            return Err(SinkError::Config(anyhow!(
+                "HTTP sink method must be POST or PUT, got '{method}'"
+            )));
+        }
+    };
 
     let fields = schema.fields();
     let (payload_index, url, payload_type) = if fields.len() == 1 {
@@ -208,6 +223,7 @@ fn validate_http_sink(
 
     Ok(HttpSink {
         url,
+        method,
         payload_index,
         header_map,
         unknown_fields,
@@ -217,6 +233,7 @@ fn validate_http_sink(
 #[derive(Clone, Debug)]
 pub struct HttpSink {
     url: HttpUrl,
+    method: reqwest::Method,
     payload_index: usize,
     header_map: HeaderMap,
     unknown_fields: std::collections::HashMap<String, String>,
@@ -244,6 +261,7 @@ impl TryFrom<SinkParam> for HttpSink {
             param.ignore_delete,
             &schema,
             config.url.as_deref(),
+            config.method.as_deref(),
             config.content_type.as_deref(),
             &headers,
             config.unknown_fields,
@@ -267,6 +285,7 @@ impl Sink for HttpSink {
     async fn new_log_sinker(&self, _writer_param: SinkWriterParam) -> Result<Self::LogSinker> {
         Ok(HttpSinkWriter::new(
             self.url.clone(),
+            self.method.clone(),
             self.payload_index,
             self.header_map.clone(),
         )?
@@ -277,11 +296,17 @@ impl Sink for HttpSink {
 pub struct HttpSinkWriter {
     client: reqwest::Client,
     url: HttpUrl,
+    method: reqwest::Method,
     payload_index: usize,
 }
 
 impl HttpSinkWriter {
-    fn new(url: HttpUrl, payload_index: usize, header_map: HeaderMap) -> Result<Self> {
+    fn new(
+        url: HttpUrl,
+        method: reqwest::Method,
+        payload_index: usize,
+        header_map: HeaderMap,
+    ) -> Result<Self> {
         let client = reqwest::Client::builder()
             .default_headers(header_map)
             .build()
@@ -291,6 +316,7 @@ impl HttpSinkWriter {
         Ok(Self {
             client,
             url,
+            method,
             payload_index,
         })
     }
@@ -430,7 +456,7 @@ impl AsyncTruncateSinkWriter for HttpSinkWriter {
 
             let resp = self
                 .client
-                .post(url)
+                .request(self.method.clone(), url)
                 .body(payload)
                 .send()
                 .await

--- a/src/connector/with_options_sink.yaml
+++ b/src/connector/with_options_sink.yaml
@@ -455,7 +455,11 @@ HttpConfig:
   fields:
   - name: url
     field_type: String
-    comments: The endpoint URL to POST data to.
+    comments: The endpoint URL to send data to.
+    required: false
+  - name: method
+    field_type: String
+    comments: HTTP request method. Supported values are `POST` and `PUT`. Defaults to `POST`.
     required: false
   - name: content_type
     field_type: String


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

- Add an optional `method` property to the native HTTP sink. It accepts `POST` and `PUT` case-insensitively and defaults to `POST` for backward compatibility.
- Validate unsupported methods during `CREATE SINK` and return a clear configuration error instead of silently ignoring the property.
- Send requests with the validated method rather than always using `POST`.
- Extend HTTP sink SLT and CI coverage to verify the default `POST`, an explicit `PUT`, and rejection of unsupported methods.
- Regenerate the connector option reference with the new property and default.
- Closes #26821

## Checklist

- [x] I have written necessary rustdoc comments.
- [x] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [x] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/dev/src/ci.md#ci-labels-guide -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [x] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

The native HTTP sink now supports `method = 'PUT'` for APIs that require idempotent updates. Existing sinks and sinks that omit `method` continue to send `POST` requests.

</details>
