### PR TITLE
fix(connector): serialize Snowflake upsert CDC processing

### DIFF
--- a/src/connector/src/sink/snowflake_redshift/mod.rs
+++ b/src/connector/src/sink/snowflake_redshift/mod.rs
@@ -42,15 +42,28 @@ pub mod snowflake;
 pub const __ROW_ID: &str = "__row_id";
 pub const __OP: &str = "__op";
 
+fn build_ordered_cdc_row_id(epoch: u64, row_count: u64, actor_id: u32) -> String {
+    // Keep the components fixed-width so the string representation has the same ordering as the
+    // numeric (epoch, row count, actor) tuple. The actor id makes ids from parallel sink writers
+    // distinct while remaining a deterministic tie-breaker.
+    format!("{epoch:020}_{row_count:020}_{actor_id:010}")
+}
+
 pub struct AugmentedRow {
     row_encoder: JsonEncoder,
     current_epoch: u64,
-    current_row_count: usize,
+    current_row_count: u64,
+    actor_id: Option<u32>,
     is_append_only: bool,
 }
 
 impl AugmentedRow {
-    pub fn new(current_epoch: u64, is_append_only: bool, schema: Schema) -> Self {
+    pub fn new(
+        current_epoch: u64,
+        actor_id: Option<u32>,
+        is_append_only: bool,
+        schema: Schema,
+    ) -> Self {
         let row_encoder = JsonEncoder::new(
             schema,
             None,
@@ -64,6 +77,7 @@ impl AugmentedRow {
             row_encoder,
             current_epoch,
             current_row_count: 0,
+            actor_id,
             is_append_only,
         }
     }
@@ -82,10 +96,14 @@ impl AugmentedRow {
             return Ok(row);
         }
         self.current_row_count += 1;
-        row.insert(
-            __ROW_ID.to_owned(),
-            Value::String(format!("{}_{}", self.current_epoch, self.current_row_count)),
-        );
+        let row_id = if let Some(actor_id) = self.actor_id {
+            build_ordered_cdc_row_id(self.current_epoch, self.current_row_count, actor_id)
+        } else {
+            // Preserve the existing Redshift row-id format. Snowflake upsert sinks always provide
+            // an actor id and use the order-safe format above.
+            format!("{}_{}", self.current_epoch, self.current_row_count)
+        };
+        row.insert(__ROW_ID.to_owned(), Value::String(row_id));
         row.insert(
             __OP.to_owned(),
             Value::Number(serde_json::Number::from(op.to_i16())),
@@ -160,6 +178,7 @@ impl SnowflakeRedshiftSinkS3Writer {
     pub fn new(
         s3_config: S3Common,
         schema: Schema,
+        actor_id: Option<u32>,
         is_append_only: bool,
         target_table_name: String,
     ) -> Result<Self> {
@@ -168,7 +187,7 @@ impl SnowflakeRedshiftSinkS3Writer {
             s3_config,
             s3_operator,
             opendal_writer_path: None,
-            augmented_row: AugmentedRow::new(0, is_append_only, schema),
+            augmented_row: AugmentedRow::new(0, actor_id, is_append_only, schema),
             target_table_name,
         })
     }
@@ -331,5 +350,20 @@ impl SnowflakeRedshiftSinkJdbcWriter {
         // TODO: abort should clean up all the data written in this epoch
         self.jdbc_sink_writer.abort().await?;
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::build_ordered_cdc_row_id;
+
+    #[test]
+    fn cdc_row_ids_are_unique_and_numerically_ordered() {
+        assert!(build_ordered_cdc_row_id(100, 10, 1) > build_ordered_cdc_row_id(100, 9, 1));
+        assert!(build_ordered_cdc_row_id(101, 0, 1) > build_ordered_cdc_row_id(100, u64::MAX, 1));
+        assert_ne!(
+            build_ordered_cdc_row_id(100, 10, 1),
+            build_ordered_cdc_row_id(100, 10, 2)
+        );
     }
 }

--- a/src/connector/src/sink/snowflake_redshift/mod.rs
+++ b/src/connector/src/sink/snowflake_redshift/mod.rs
@@ -42,28 +42,15 @@ pub mod snowflake;
 pub const __ROW_ID: &str = "__row_id";
 pub const __OP: &str = "__op";
 
-fn build_ordered_cdc_row_id(epoch: u64, row_count: u64, actor_id: u32) -> String {
-    // Keep the components fixed-width so the string representation has the same ordering as the
-    // numeric (epoch, row count, actor) tuple. The actor id makes ids from parallel sink writers
-    // distinct while remaining a deterministic tie-breaker.
-    format!("{epoch:020}_{row_count:020}_{actor_id:010}")
-}
-
 pub struct AugmentedRow {
     row_encoder: JsonEncoder,
     current_epoch: u64,
-    current_row_count: u64,
-    actor_id: Option<u32>,
+    current_row_count: usize,
     is_append_only: bool,
 }
 
 impl AugmentedRow {
-    pub fn new(
-        current_epoch: u64,
-        actor_id: Option<u32>,
-        is_append_only: bool,
-        schema: Schema,
-    ) -> Self {
+    pub fn new(current_epoch: u64, is_append_only: bool, schema: Schema) -> Self {
         let row_encoder = JsonEncoder::new(
             schema,
             None,
@@ -77,7 +64,6 @@ impl AugmentedRow {
             row_encoder,
             current_epoch,
             current_row_count: 0,
-            actor_id,
             is_append_only,
         }
     }
@@ -96,13 +82,7 @@ impl AugmentedRow {
             return Ok(row);
         }
         self.current_row_count += 1;
-        let row_id = if let Some(actor_id) = self.actor_id {
-            build_ordered_cdc_row_id(self.current_epoch, self.current_row_count, actor_id)
-        } else {
-            // Preserve the existing Redshift row-id format. Snowflake upsert sinks always provide
-            // an actor id and use the order-safe format above.
-            format!("{}_{}", self.current_epoch, self.current_row_count)
-        };
+        let row_id = format!("{}_{}", self.current_epoch, self.current_row_count);
         row.insert(__ROW_ID.to_owned(), Value::String(row_id));
         row.insert(
             __OP.to_owned(),
@@ -178,7 +158,6 @@ impl SnowflakeRedshiftSinkS3Writer {
     pub fn new(
         s3_config: S3Common,
         schema: Schema,
-        actor_id: Option<u32>,
         is_append_only: bool,
         target_table_name: String,
     ) -> Result<Self> {
@@ -187,7 +166,7 @@ impl SnowflakeRedshiftSinkS3Writer {
             s3_config,
             s3_operator,
             opendal_writer_path: None,
-            augmented_row: AugmentedRow::new(0, actor_id, is_append_only, schema),
+            augmented_row: AugmentedRow::new(0, is_append_only, schema),
             target_table_name,
         })
     }
@@ -350,20 +329,5 @@ impl SnowflakeRedshiftSinkJdbcWriter {
         // TODO: abort should clean up all the data written in this epoch
         self.jdbc_sink_writer.abort().await?;
         Ok(())
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::build_ordered_cdc_row_id;
-
-    #[test]
-    fn cdc_row_ids_are_unique_and_numerically_ordered() {
-        assert!(build_ordered_cdc_row_id(100, 10, 1) > build_ordered_cdc_row_id(100, 9, 1));
-        assert!(build_ordered_cdc_row_id(101, 0, 1) > build_ordered_cdc_row_id(100, u64::MAX, 1));
-        assert_ne!(
-            build_ordered_cdc_row_id(100, 10, 1),
-            build_ordered_cdc_row_id(100, 10, 2)
-        );
     }
 }

--- a/src/connector/src/sink/snowflake_redshift/redshift.rs
+++ b/src/connector/src/sink/snowflake_redshift/redshift.rs
@@ -316,6 +316,7 @@ impl RedShiftSinkWriter {
                     SinkError::Config(anyhow!("S3 configuration is required for S3 sink"))
                 })?,
                 schema,
+                None,
                 is_append_only,
                 config.table,
             )?;

--- a/src/connector/src/sink/snowflake_redshift/redshift.rs
+++ b/src/connector/src/sink/snowflake_redshift/redshift.rs
@@ -316,7 +316,6 @@ impl RedShiftSinkWriter {
                     SinkError::Config(anyhow!("S3 configuration is required for S3 sink"))
                 })?,
                 schema,
-                None,
                 is_append_only,
                 config.table,
             )?;

--- a/src/connector/src/sink/snowflake_redshift/snowflake.rs
+++ b/src/connector/src/sink/snowflake_redshift/snowflake.rs
@@ -239,6 +239,11 @@ impl SnowflakeV2Config {
                 SINK_TYPE_UPSERT
             )));
         }
+        if config.r#type == SINK_TYPE_UPSERT && !config.with_s3 {
+            return Err(SinkError::Config(anyhow!(
+                "Snowflake upsert sinks require `with_s3 = true` so all CDC rows are loaded by the serialized COPY INTO task"
+            )));
+        }
         let has_upsert_task_config = config.snowflake_cdc_table_name.is_some()
             || properties.contains_key("write.target.interval.seconds")
             || config.snowflake_warehouse.is_some()
@@ -389,7 +394,9 @@ impl SnowflakeV2Config {
                 .clone()
                 .ok_or(SinkError::Config(anyhow!("stage is required")))?;
             snowflake_task_ctx.stage = Some(stage);
-            snowflake_task_ctx.pipe_name = Some(format!("{}_pipe", target_table_name));
+            if is_append_only {
+                snowflake_task_ctx.pipe_name = Some(format!("{}_pipe", target_table_name));
+            }
         }
         if !is_append_only {
             let cdc_table_name = self
@@ -597,6 +604,7 @@ impl SnowflakeSinkWriter {
                     ))
                 })?,
                 schema,
+                Some(writer_param.actor_id.as_raw_id()),
                 is_append_only,
                 table_name,
             )?;
@@ -699,22 +707,28 @@ impl SnowflakeSinkCommitter {
             if let Some((snowflake_task_ctx, client)) =
                 config.build_snowflake_task_ctx_jdbc_client(is_append_only, schema, pk_indices)?
             {
-                let (shutdown_sender, shutdown_receiver) = unbounded_channel();
-                let snowflake_client =
-                    SnowflakeJniClient::new(client.clone(), snowflake_task_ctx.clone());
-                let periodic_task_handle = tokio::spawn(async move {
-                    Self::run_periodic_query_task(
-                        snowflake_client,
-                        config.write_intermediate_interval_seconds,
-                        sink_id,
-                        shutdown_receiver,
-                    )
-                    .await;
-                });
+                let (periodic_task_handle, shutdown_sender) =
+                    if snowflake_task_ctx.pipe_name.is_some() {
+                        let (shutdown_sender, shutdown_receiver) = unbounded_channel();
+                        let snowflake_client =
+                            SnowflakeJniClient::new(client.clone(), snowflake_task_ctx.clone());
+                        let periodic_task_handle = tokio::spawn(async move {
+                            Self::run_periodic_query_task(
+                                snowflake_client,
+                                config.write_intermediate_interval_seconds,
+                                sink_id,
+                                shutdown_receiver,
+                            )
+                            .await;
+                        });
+                        (Some(periodic_task_handle), Some(shutdown_sender))
+                    } else {
+                        (None, None)
+                    };
                 (
                     Some(SnowflakeJniClient::new(client, snowflake_task_ctx)),
-                    Some(periodic_task_handle),
-                    Some(shutdown_sender),
+                    periodic_task_handle,
+                    shutdown_sender,
                 )
             } else {
                 (None, None, None)
@@ -757,6 +771,7 @@ impl SinglePhaseCommitCoordinator for SnowflakeSinkCommitter {
     async fn init(&mut self) -> Result<()> {
         if let Some(client) = &self.client {
             // Todo: move this to validate
+            client.execute_drop_legacy_pipe().await?;
             client.execute_create_pipe().await?;
             client.execute_create_merge_into_task().await?;
         }
@@ -944,6 +959,25 @@ impl SnowflakeJniClient {
         Ok(())
     }
 
+    pub async fn execute_drop_legacy_pipe(&self) -> Result<()> {
+        // Older upsert sinks created this pipe and refreshed it from a local timer. Remove it
+        // before starting the task so no asynchronous Snowpipe load can race with MERGE/DELETE.
+        if self.snowflake_task_context.task_name.is_some()
+            && self.snowflake_task_context.stage.is_some()
+        {
+            let pipe_name = format!("{}_pipe", self.snowflake_task_context.target_table_name);
+            let drop_pipe_sql = build_drop_pipe_sql(
+                &self.snowflake_task_context.database,
+                &self.snowflake_task_context.schema_name,
+                &pipe_name,
+            );
+            self.jdbc_client
+                .execute_sql_sync(vec![drop_pipe_sql])
+                .await?;
+        }
+        Ok(())
+    }
+
     pub async fn execute_flush_pipe(&self) -> Result<()> {
         if let Some(pipe_name) = &self.snowflake_task_context.pipe_name {
             let flush_pipe_sql = build_flush_pipe_sql(
@@ -1025,8 +1059,22 @@ fn build_create_pipe_sql(
     target_table_name: &str,
 ) -> String {
     let pipe_name = format!(r#""{}"."{}"."{}""#, database, schema, pipe_name);
+    let copy_into_sql = build_copy_into_sql(table_name, database, schema, stage, target_table_name);
+    format!(
+        "CREATE OR REPLACE PIPE {} AUTO_INGEST = FALSE AS {}",
+        pipe_name, copy_into_sql
+    )
+}
+
+fn build_copy_into_sql(
+    table_name: &str,
+    database: &str,
+    schema: &str,
+    stage: &str,
+    target_table_name: &str,
+) -> String {
     // Trailing `/` is required to enforce exact directory matching.
-    // Without it, a PIPE for table "dim_project" would also match files under
+    // Without it, a COPY for table "dim_project" would also match files under
     // "dim_project_contract/" since Snowflake uses prefix matching.
     let stage = format!(
         r#""{}"."{}"."{}"/{}/"#,
@@ -1034,14 +1082,19 @@ fn build_create_pipe_sql(
     );
     let table_name = format!(r#""{}"."{}"."{}""#, database, schema, table_name);
     format!(
-        "CREATE OR REPLACE PIPE {} AUTO_INGEST = FALSE AS COPY INTO {} FROM @{} MATCH_BY_COLUMN_NAME = CASE_INSENSITIVE FILE_FORMAT = (type = 'JSON');",
-        pipe_name, table_name, stage
+        "COPY INTO {} FROM @{} MATCH_BY_COLUMN_NAME = CASE_INSENSITIVE FILE_FORMAT = (TYPE = 'JSON');",
+        table_name, stage
     )
 }
 
 fn build_flush_pipe_sql(database: &str, schema: &str, pipe_name: &str) -> String {
     let pipe_name = format!(r#""{}"."{}"."{}""#, database, schema, pipe_name);
     format!("ALTER PIPE {} REFRESH;", pipe_name,)
+}
+
+fn build_drop_pipe_sql(database: &str, schema: &str, pipe_name: &str) -> String {
+    let pipe_name = format!(r#""{}"."{}"."{}""#, database, schema, pipe_name);
+    format!("DROP PIPE IF EXISTS {}", pipe_name)
 }
 
 fn build_alter_add_column_sql(
@@ -1099,6 +1152,7 @@ fn build_create_merge_into_task_sql(snowflake_task_context: &SnowflakeTaskContex
         all_column_names,
         database,
         schema_name,
+        stage,
         ..
     } = snowflake_task_context;
     let full_task_name = format!(
@@ -1116,6 +1170,15 @@ fn build_create_merge_into_task_sql(snowflake_task_context: &SnowflakeTaskContex
     let full_target_table_name = format!(
         r#""{}"."{}"."{}""#,
         database, schema_name, target_table_name
+    );
+    let copy_into_sql = build_copy_into_sql(
+        cdc_table_name.as_ref().unwrap(),
+        database,
+        schema_name,
+        stage
+            .as_ref()
+            .expect("stage is required for Snowflake upsert tasks"),
+        target_table_name,
     );
 
     let pk_names_str = pk_column_names
@@ -1153,6 +1216,10 @@ fn build_create_merge_into_task_sql(snowflake_task_context: &SnowflakeTaskContex
         .map(|name| format!(r#"source."{}""#, name))
         .collect::<Vec<String>>()
         .join(", ");
+    let row_id_ordering = format!(
+        r#"TRY_TO_NUMBER(SPLIT_PART("{row_id}", '_', 1)) DESC NULLS LAST, TRY_TO_NUMBER(SPLIT_PART("{row_id}", '_', 2)) DESC NULLS LAST, TRY_TO_NUMBER(SPLIT_PART("{row_id}", '_', 3)) DESC NULLS LAST, "{row_id}" DESC"#,
+        row_id = __ROW_ID,
+    );
 
     let compute_clause = if *task_serverless {
         task_target_completion_interval
@@ -1162,24 +1229,24 @@ fn build_create_merge_into_task_sql(snowflake_task_context: &SnowflakeTaskContex
         Some(format!("WAREHOUSE = {}", warehouse.as_ref().unwrap()))
     };
 
+    // Snowflake Scripting autocommits each statement. This sequence is safe because upsert writers
+    // can only stage files in S3, COPY INTO is the only CDC-table writer, and NO_OVERLAP prevents a
+    // second task run from inserting rows between MERGE and DELETE.
     format!(
         r#"CREATE OR REPLACE TASK {task_name}
 {compute_clause}
 SCHEDULE = '{writer_target_interval_seconds} SECONDS'
+OVERLAP_POLICY = NO_OVERLAP
 AS
 BEGIN
-    LET max_row_id STRING;
-
-    SELECT COALESCE(MAX("{snowflake_sink_row_id}"), '0') INTO :max_row_id
-    FROM {cdc_table_name};
+    {copy_into_sql}
 
     MERGE INTO {target_table_name} AS target
     USING (
         SELECT *
         FROM (
-            SELECT *, ROW_NUMBER() OVER (PARTITION BY {pk_names_str} ORDER BY "{snowflake_sink_row_id}" DESC) AS dedupe_id
+            SELECT *, ROW_NUMBER() OVER (PARTITION BY {pk_names_str} ORDER BY {row_id_ordering}) AS dedupe_id
             FROM {cdc_table_name}
-            WHERE "{snowflake_sink_row_id}" <= :max_row_id
         ) AS subquery
         WHERE dedupe_id = 1
     ) AS source
@@ -1188,22 +1255,22 @@ BEGIN
     WHEN MATCHED AND source."{snowflake_sink_op}" IN (1, 3) THEN UPDATE SET {all_column_names_set_str}
     WHEN NOT MATCHED AND source."{snowflake_sink_op}" IN (1, 3) THEN INSERT ({all_column_names_str}) VALUES ({all_column_names_insert_str});
 
-    DELETE FROM {cdc_table_name}
-    WHERE "{snowflake_sink_row_id}" <= :max_row_id;
+    DELETE FROM {cdc_table_name};
 END;"#,
         task_name = full_task_name,
         compute_clause = compute_clause
             .map(|clause| format!("{clause}\n"))
             .unwrap_or_default(),
         writer_target_interval_seconds = writer_target_interval_seconds,
+        copy_into_sql = copy_into_sql,
         cdc_table_name = full_cdc_table_name,
         target_table_name = full_target_table_name,
         pk_names_str = pk_names_str,
+        row_id_ordering = row_id_ordering,
         pk_names_eq_str = pk_names_eq_str,
         all_column_names_set_str = all_column_names_set_str,
         all_column_names_str = all_column_names_str,
         all_column_names_insert_str = all_column_names_insert_str,
-        snowflake_sink_row_id = __ROW_ID,
         snowflake_sink_op = __OP,
     )
 }
@@ -1346,6 +1413,21 @@ mod tests {
     }
 
     #[test]
+    fn test_snowflake_upsert_requires_s3() {
+        let mut props = base_properties();
+        props.insert("password".to_owned(), "secret".to_owned());
+        props.insert("type".to_owned(), "upsert".to_owned());
+        props.insert("with_s3".to_owned(), "false".to_owned());
+
+        let err = SnowflakeV2Config::from_btreemap(&props).unwrap_err();
+        assert!(
+            err.as_report()
+                .to_string()
+                .contains("Snowflake upsert sinks require `with_s3 = true`")
+        );
+    }
+
+    #[test]
     fn test_snowflake_sink_commit_coordinator() {
         let snowflake_task_context = SnowflakeTaskContext {
             task_name: Some("test_task".to_owned()),
@@ -1360,27 +1442,24 @@ mod tests {
             database: "test_db".to_owned(),
             schema_name: "test_schema".to_owned(),
             schema: Schema { fields: vec![] },
-            stage: None,
+            stage: Some("RW_S3_STAGE".to_owned()),
             pipe_name: None,
         };
         let task_sql = build_create_merge_into_task_sql(&snowflake_task_context);
         let expected = r#"CREATE OR REPLACE TASK "test_db"."test_schema"."test_task"
 WAREHOUSE = test_warehouse
 SCHEDULE = '3600 SECONDS'
+OVERLAP_POLICY = NO_OVERLAP
 AS
 BEGIN
-    LET max_row_id STRING;
-
-    SELECT COALESCE(MAX("__row_id"), '0') INTO :max_row_id
-    FROM "test_db"."test_schema"."test_cdc_table";
+    COPY INTO "test_db"."test_schema"."test_cdc_table" FROM @"test_db"."test_schema"."RW_S3_STAGE"/test_target_table/ MATCH_BY_COLUMN_NAME = CASE_INSENSITIVE FILE_FORMAT = (TYPE = 'JSON');
 
     MERGE INTO "test_db"."test_schema"."test_target_table" AS target
     USING (
         SELECT *
         FROM (
-            SELECT *, ROW_NUMBER() OVER (PARTITION BY "v1" ORDER BY "__row_id" DESC) AS dedupe_id
+            SELECT *, ROW_NUMBER() OVER (PARTITION BY "v1" ORDER BY TRY_TO_NUMBER(SPLIT_PART("__row_id", '_', 1)) DESC NULLS LAST, TRY_TO_NUMBER(SPLIT_PART("__row_id", '_', 2)) DESC NULLS LAST, TRY_TO_NUMBER(SPLIT_PART("__row_id", '_', 3)) DESC NULLS LAST, "__row_id" DESC) AS dedupe_id
             FROM "test_db"."test_schema"."test_cdc_table"
-            WHERE "__row_id" <= :max_row_id
         ) AS subquery
         WHERE dedupe_id = 1
     ) AS source
@@ -1389,8 +1468,7 @@ BEGIN
     WHEN MATCHED AND source."__op" IN (1, 3) THEN UPDATE SET target."v1" = source."v1", target."v2" = source."v2"
     WHEN NOT MATCHED AND source."__op" IN (1, 3) THEN INSERT ("v1", "v2") VALUES (source."v1", source."v2");
 
-    DELETE FROM "test_db"."test_schema"."test_cdc_table"
-    WHERE "__row_id" <= :max_row_id;
+    DELETE FROM "test_db"."test_schema"."test_cdc_table";
 END;"#;
         assert_eq!(normalize_sql(&task_sql), normalize_sql(expected));
     }
@@ -1410,27 +1488,24 @@ END;"#;
             database: "test_db".to_owned(),
             schema_name: "test_schema".to_owned(),
             schema: Schema { fields: vec![] },
-            stage: None,
+            stage: Some("RW_S3_STAGE".to_owned()),
             pipe_name: None,
         };
         let task_sql = build_create_merge_into_task_sql(&snowflake_task_context);
         let expected = r#"CREATE OR REPLACE TASK "test_db"."test_schema"."test_task_multi_pk"
 WAREHOUSE = multi_pk_warehouse
 SCHEDULE = '300 SECONDS'
+OVERLAP_POLICY = NO_OVERLAP
 AS
 BEGIN
-    LET max_row_id STRING;
-
-    SELECT COALESCE(MAX("__row_id"), '0') INTO :max_row_id
-    FROM "test_db"."test_schema"."cdc_multi_pk";
+    COPY INTO "test_db"."test_schema"."cdc_multi_pk" FROM @"test_db"."test_schema"."RW_S3_STAGE"/target_multi_pk/ MATCH_BY_COLUMN_NAME = CASE_INSENSITIVE FILE_FORMAT = (TYPE = 'JSON');
 
     MERGE INTO "test_db"."test_schema"."target_multi_pk" AS target
     USING (
         SELECT *
         FROM (
-            SELECT *, ROW_NUMBER() OVER (PARTITION BY "id1", "id2" ORDER BY "__row_id" DESC) AS dedupe_id
+            SELECT *, ROW_NUMBER() OVER (PARTITION BY "id1", "id2" ORDER BY TRY_TO_NUMBER(SPLIT_PART("__row_id", '_', 1)) DESC NULLS LAST, TRY_TO_NUMBER(SPLIT_PART("__row_id", '_', 2)) DESC NULLS LAST, TRY_TO_NUMBER(SPLIT_PART("__row_id", '_', 3)) DESC NULLS LAST, "__row_id" DESC) AS dedupe_id
             FROM "test_db"."test_schema"."cdc_multi_pk"
-            WHERE "__row_id" <= :max_row_id
         ) AS subquery
         WHERE dedupe_id = 1
     ) AS source
@@ -1439,8 +1514,7 @@ BEGIN
     WHEN MATCHED AND source."__op" IN (1, 3) THEN UPDATE SET target."id1" = source."id1", target."id2" = source."id2", target."val" = source."val"
     WHEN NOT MATCHED AND source."__op" IN (1, 3) THEN INSERT ("id1", "id2", "val") VALUES (source."id1", source."id2", source."val");
 
-    DELETE FROM "test_db"."test_schema"."cdc_multi_pk"
-    WHERE "__row_id" <= :max_row_id;
+    DELETE FROM "test_db"."test_schema"."cdc_multi_pk";
 END;"#;
         assert_eq!(normalize_sql(&task_sql), normalize_sql(expected));
     }
@@ -1460,27 +1534,24 @@ END;"#;
             database: "test_db".to_owned(),
             schema_name: "test_schema".to_owned(),
             schema: Schema { fields: vec![] },
-            stage: None,
+            stage: Some("RW_S3_STAGE".to_owned()),
             pipe_name: None,
         };
         let task_sql = build_create_merge_into_task_sql(&snowflake_task_context);
         let expected = r#"CREATE OR REPLACE TASK "test_db"."test_schema"."test_serverless_task"
 TARGET_COMPLETION_INTERVAL = '5 MINUTES'
 SCHEDULE = '120 SECONDS'
+OVERLAP_POLICY = NO_OVERLAP
 AS
 BEGIN
-    LET max_row_id STRING;
-
-    SELECT COALESCE(MAX("__row_id"), '0') INTO :max_row_id
-    FROM "test_db"."test_schema"."serverless_cdc_table";
+    COPY INTO "test_db"."test_schema"."serverless_cdc_table" FROM @"test_db"."test_schema"."RW_S3_STAGE"/serverless_target_table/ MATCH_BY_COLUMN_NAME = CASE_INSENSITIVE FILE_FORMAT = (TYPE = 'JSON');
 
     MERGE INTO "test_db"."test_schema"."serverless_target_table" AS target
     USING (
         SELECT *
         FROM (
-            SELECT *, ROW_NUMBER() OVER (PARTITION BY "id" ORDER BY "__row_id" DESC) AS dedupe_id
+            SELECT *, ROW_NUMBER() OVER (PARTITION BY "id" ORDER BY TRY_TO_NUMBER(SPLIT_PART("__row_id", '_', 1)) DESC NULLS LAST, TRY_TO_NUMBER(SPLIT_PART("__row_id", '_', 2)) DESC NULLS LAST, TRY_TO_NUMBER(SPLIT_PART("__row_id", '_', 3)) DESC NULLS LAST, "__row_id" DESC) AS dedupe_id
             FROM "test_db"."test_schema"."serverless_cdc_table"
-            WHERE "__row_id" <= :max_row_id
         ) AS subquery
         WHERE dedupe_id = 1
     ) AS source
@@ -1489,8 +1560,7 @@ BEGIN
     WHEN MATCHED AND source."__op" IN (1, 3) THEN UPDATE SET target."id" = source."id", target."val" = source."val"
     WHEN NOT MATCHED AND source."__op" IN (1, 3) THEN INSERT ("id", "val") VALUES (source."id", source."val");
 
-    DELETE FROM "test_db"."test_schema"."serverless_cdc_table"
-    WHERE "__row_id" <= :max_row_id;
+    DELETE FROM "test_db"."test_schema"."serverless_cdc_table";
 END;"#;
         assert_eq!(normalize_sql(&task_sql), normalize_sql(expected));
     }

--- a/src/connector/src/sink/snowflake_redshift/snowflake.rs
+++ b/src/connector/src/sink/snowflake_redshift/snowflake.rs
@@ -604,7 +604,6 @@ impl SnowflakeSinkWriter {
                     ))
                 })?,
                 schema,
-                Some(writer_param.actor_id.as_raw_id()),
                 is_append_only,
                 table_name,
             )?;
@@ -1217,7 +1216,7 @@ fn build_create_merge_into_task_sql(snowflake_task_context: &SnowflakeTaskContex
         .collect::<Vec<String>>()
         .join(", ");
     let row_id_ordering = format!(
-        r#"TRY_TO_NUMBER(SPLIT_PART("{row_id}", '_', 1)) DESC NULLS LAST, TRY_TO_NUMBER(SPLIT_PART("{row_id}", '_', 2)) DESC NULLS LAST, TRY_TO_NUMBER(SPLIT_PART("{row_id}", '_', 3)) DESC NULLS LAST, "{row_id}" DESC"#,
+        r#"TRY_TO_NUMBER(SPLIT_PART("{row_id}", '_', 1)) DESC NULLS LAST, TRY_TO_NUMBER(SPLIT_PART("{row_id}", '_', 2)) DESC NULLS LAST, "{row_id}" DESC"#,
         row_id = __ROW_ID,
     );
 
@@ -1458,7 +1457,7 @@ BEGIN
     USING (
         SELECT *
         FROM (
-            SELECT *, ROW_NUMBER() OVER (PARTITION BY "v1" ORDER BY TRY_TO_NUMBER(SPLIT_PART("__row_id", '_', 1)) DESC NULLS LAST, TRY_TO_NUMBER(SPLIT_PART("__row_id", '_', 2)) DESC NULLS LAST, TRY_TO_NUMBER(SPLIT_PART("__row_id", '_', 3)) DESC NULLS LAST, "__row_id" DESC) AS dedupe_id
+            SELECT *, ROW_NUMBER() OVER (PARTITION BY "v1" ORDER BY TRY_TO_NUMBER(SPLIT_PART("__row_id", '_', 1)) DESC NULLS LAST, TRY_TO_NUMBER(SPLIT_PART("__row_id", '_', 2)) DESC NULLS LAST, "__row_id" DESC) AS dedupe_id
             FROM "test_db"."test_schema"."test_cdc_table"
         ) AS subquery
         WHERE dedupe_id = 1
@@ -1504,7 +1503,7 @@ BEGIN
     USING (
         SELECT *
         FROM (
-            SELECT *, ROW_NUMBER() OVER (PARTITION BY "id1", "id2" ORDER BY TRY_TO_NUMBER(SPLIT_PART("__row_id", '_', 1)) DESC NULLS LAST, TRY_TO_NUMBER(SPLIT_PART("__row_id", '_', 2)) DESC NULLS LAST, TRY_TO_NUMBER(SPLIT_PART("__row_id", '_', 3)) DESC NULLS LAST, "__row_id" DESC) AS dedupe_id
+            SELECT *, ROW_NUMBER() OVER (PARTITION BY "id1", "id2" ORDER BY TRY_TO_NUMBER(SPLIT_PART("__row_id", '_', 1)) DESC NULLS LAST, TRY_TO_NUMBER(SPLIT_PART("__row_id", '_', 2)) DESC NULLS LAST, "__row_id" DESC) AS dedupe_id
             FROM "test_db"."test_schema"."cdc_multi_pk"
         ) AS subquery
         WHERE dedupe_id = 1
@@ -1550,7 +1549,7 @@ BEGIN
     USING (
         SELECT *
         FROM (
-            SELECT *, ROW_NUMBER() OVER (PARTITION BY "id" ORDER BY TRY_TO_NUMBER(SPLIT_PART("__row_id", '_', 1)) DESC NULLS LAST, TRY_TO_NUMBER(SPLIT_PART("__row_id", '_', 2)) DESC NULLS LAST, TRY_TO_NUMBER(SPLIT_PART("__row_id", '_', 3)) DESC NULLS LAST, "__row_id" DESC) AS dedupe_id
+            SELECT *, ROW_NUMBER() OVER (PARTITION BY "id" ORDER BY TRY_TO_NUMBER(SPLIT_PART("__row_id", '_', 1)) DESC NULLS LAST, TRY_TO_NUMBER(SPLIT_PART("__row_id", '_', 2)) DESC NULLS LAST, "__row_id" DESC) AS dedupe_id
             FROM "test_db"."test_schema"."serverless_cdc_table"
         ) AS subquery
         WHERE dedupe_id = 1

--- a/src/frontend/src/handler/create_sink.rs
+++ b/src/frontend/src/handler/create_sink.rs
@@ -41,8 +41,8 @@ use risingwave_connector::sink::kafka::KAFKA_SINK;
 use risingwave_connector::sink::snowflake_redshift::redshift::RedshiftSink;
 use risingwave_connector::sink::snowflake_redshift::snowflake::SnowflakeV2Sink;
 use risingwave_connector::sink::{
-    CONNECTOR_TYPE_KEY, SINK_SNAPSHOT_OPTION, SINK_TYPE_OPTION, SINK_USER_FORCE_APPEND_ONLY_OPTION,
-    SINK_USER_IGNORE_DELETE_OPTION, Sink, enforce_secret_sink,
+    CONNECTOR_TYPE_KEY, SINK_SNAPSHOT_OPTION, SINK_TYPE_OPTION, SINK_TYPE_UPSERT,
+    SINK_USER_FORCE_APPEND_ONLY_OPTION, SINK_USER_IGNORE_DELETE_OPTION, Sink, enforce_secret_sink,
 };
 use risingwave_connector::{
     AUTO_SCHEMA_CHANGE_KEY, SINK_CREATE_TABLE_IF_NOT_EXISTS_KEY, SINK_INTERMEDIATE_TABLE_NAME,
@@ -117,6 +117,34 @@ pub struct SinkPlanContext {
     pub target_table_catalog: Option<Arc<TableCatalog>>,
     pub dependencies: HashSet<ObjectId>,
     pub since_timestamp_epoch: Option<u64>,
+}
+
+fn maybe_fill_intermediate_table_name(
+    with_options: &mut WithOptionsSecResolved,
+    connector: &str,
+    sink_name: &str,
+) -> Result<()> {
+    let should_fill = with_options
+        .value_eq_ignore_case(SINK_CREATE_TABLE_IF_NOT_EXISTS_KEY, "true")
+        && with_options.value_eq_ignore_case(SINK_TYPE_OPTION, SINK_TYPE_UPSERT)
+        && matches!(
+            connector,
+            RedshiftSink::SINK_NAME | SnowflakeV2Sink::SINK_NAME
+        );
+    if !should_fill || with_options.contains_key(SINK_INTERMEDIATE_TABLE_NAME) {
+        return Ok(());
+    }
+
+    let table_name = with_options
+        .get(SINK_TARGET_TABLE_NAME)
+        .ok_or_else(|| ErrorCode::BindError("'table.name' option must be specified.".to_owned()))?;
+    let intermediate_table_name =
+        format!("rw_{}_{}_{}", sink_name, table_name, uuid::Uuid::new_v4());
+    with_options.insert(
+        SINK_INTERMEDIATE_TABLE_NAME.to_owned(),
+        intermediate_table_name,
+    );
+    Ok(())
 }
 
 pub async fn gen_sink_plan(
@@ -241,35 +269,11 @@ pub async fn gen_sink_plan(
                     "auto schema change not supported for sink-into-table".to_owned(),
                 )));
             }
-            if resolved_with_options
-                .value_eq_ignore_case(SINK_CREATE_TABLE_IF_NOT_EXISTS_KEY, "true")
-                && connector == RedshiftSink::SINK_NAME
-                || connector == SnowflakeV2Sink::SINK_NAME
-            {
-                if let Some(table_name) = resolved_with_options.get(SINK_TARGET_TABLE_NAME) {
-                    // auto fill intermediate table name if target table name is specified
-                    if resolved_with_options
-                        .get(SINK_INTERMEDIATE_TABLE_NAME)
-                        .is_none()
-                    {
-                        // generate the intermediate table name with random value appended to the target table name
-                        let intermediate_table_name = format!(
-                            "rw_{}_{}_{}",
-                            sink_table_name,
-                            table_name,
-                            uuid::Uuid::new_v4()
-                        );
-                        resolved_with_options.insert(
-                            SINK_INTERMEDIATE_TABLE_NAME.to_owned(),
-                            intermediate_table_name,
-                        );
-                    }
-                } else {
-                    return Err(RwError::from(ErrorCode::BindError(
-                        "'table.name' option must be specified.".to_owned(),
-                    )));
-                }
-            }
+            maybe_fill_intermediate_table_name(
+                &mut resolved_with_options,
+                &connector,
+                &sink_table_name,
+            )?;
             Box::new(gen_query_from_table_name(from_name))
         }
         CreateSink::AsQuery(query) => {
@@ -1208,11 +1212,74 @@ pub fn validate_compatibility(connector: &str, format_desc: &FormatEncodeOptions
 
 #[cfg(test)]
 pub mod tests {
+    use std::collections::BTreeMap;
+
     use risingwave_common::catalog::{CreateType, DEFAULT_DATABASE_NAME, DEFAULT_SCHEMA_NAME};
     use risingwave_common::config::FrontendConfig;
+    use risingwave_connector::sink::Sink;
+    use risingwave_connector::sink::snowflake_redshift::redshift::RedshiftSink;
+    use risingwave_connector::sink::snowflake_redshift::snowflake::SnowflakeV2Sink;
+    use risingwave_connector::{
+        SINK_CREATE_TABLE_IF_NOT_EXISTS_KEY, SINK_INTERMEDIATE_TABLE_NAME, SINK_TARGET_TABLE_NAME,
+    };
 
+    use crate::WithOptionsSecResolved;
     use crate::catalog::root_catalog::SchemaPath;
+    use crate::handler::create_sink::maybe_fill_intermediate_table_name;
     use crate::test_utils::{LocalFrontend, PROTO_FILE_DATA, create_proto_file};
+
+    #[test]
+    fn test_fill_intermediate_table_name_for_upsert_auto_create_only() {
+        for (connector, sink_type, create_table, should_fill) in [
+            (SnowflakeV2Sink::SINK_NAME, "append-only", false, false),
+            (SnowflakeV2Sink::SINK_NAME, "append-only", true, false),
+            (SnowflakeV2Sink::SINK_NAME, "upsert", false, false),
+            (SnowflakeV2Sink::SINK_NAME, "upsert", true, true),
+            (RedshiftSink::SINK_NAME, "upsert", true, true),
+            ("jdbc", "upsert", true, false),
+        ] {
+            let mut options = WithOptionsSecResolved::without_secrets(BTreeMap::from([
+                ("type".to_owned(), sink_type.to_owned()),
+                (
+                    SINK_CREATE_TABLE_IF_NOT_EXISTS_KEY.to_owned(),
+                    create_table.to_string(),
+                ),
+                (SINK_TARGET_TABLE_NAME.to_owned(), "target".to_owned()),
+            ]));
+
+            maybe_fill_intermediate_table_name(&mut options, connector, "sink").unwrap();
+
+            assert_eq!(
+                options.contains_key(SINK_INTERMEDIATE_TABLE_NAME),
+                should_fill,
+                "connector={connector}, type={sink_type}, create_table={create_table}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_fill_intermediate_table_name_preserves_user_value() {
+        let mut options = WithOptionsSecResolved::without_secrets(BTreeMap::from([
+            ("type".to_owned(), "upsert".to_owned()),
+            (
+                SINK_CREATE_TABLE_IF_NOT_EXISTS_KEY.to_owned(),
+                "true".to_owned(),
+            ),
+            (SINK_TARGET_TABLE_NAME.to_owned(), "target".to_owned()),
+            (
+                SINK_INTERMEDIATE_TABLE_NAME.to_owned(),
+                "custom_cdc".to_owned(),
+            ),
+        ]));
+
+        maybe_fill_intermediate_table_name(&mut options, SnowflakeV2Sink::SINK_NAME, "sink")
+            .unwrap();
+
+        assert_eq!(
+            options.get(SINK_INTERMEDIATE_TABLE_NAME).unwrap(),
+            "custom_cdc"
+        );
+    }
 
     #[tokio::test]
     async fn test_create_sink_handler() {


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

Fix the Snowflake V2 upsert race where the asynchronous Snowpipe load and the task's `MERGE`/`DELETE` statements could observe different versions of the intermediate CDC table, allowing a row to be deleted before it was applied to the target table.

- For Snowflake upsert sinks, move `COPY INTO` into the scheduled Snowflake task before `MERGE` and `DELETE`, and set `OVERLAP_POLICY = NO_OVERLAP`. The task is therefore the only writer to the intermediate table, and task executions cannot overlap.
- Stop creating and periodically refreshing a Snowpipe for upsert sinks. During initialization, drop the existing `<target_table>_pipe` so it cannot continue loading rows concurrently with the task.
- Keep the existing two-component CDC row-ID format, `(epoch, writer-local row count)`, and deduplicate rows by ordering both components numerically. The raw row ID remains the final deterministic fallback.
- Require `with_s3 = true` for Snowflake upsert sinks because the serialized task flow loads CDC files from the stage. Snowflake append-only sinks remain pipe-based, and Redshift retains its existing behavior and row-ID format.
- Add unit coverage for upsert configuration validation and generated task SQL for warehouse-backed, multi-column-PK, and serverless tasks.

Closes #26811.
Closes https://github.com/risingwavelabs/risingwave/issues/26966
Closes https://github.com/risingwavelabs/risingwave/issues/26820

### Test coverage

- `cargo test -p risingwave_connector snowflake --lib`
- `cargo check -p risingwave_connector --tests`
- `cargo fmt --all -- --check`
- `git diff --check origin/main...HEAD`

## Checklist

- [ ] I have written necessary rustdoc comments.
- [x] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [x] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/dev/src/ci.md#ci-labels-guide -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [x] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->

## Documentation

- [x] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

Snowflake V2 upsert sinks now require S3 staging (`with_s3 = true`). RisingWave loads staged CDC files and applies them through one non-overlapping Snowflake task, preventing concurrent ingestion from causing silent update loss. JDBC-only Snowflake upsert configurations (`with_s3 = false`) are no longer accepted. Snowflake append-only sinks and Redshift sinks are unchanged.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Snowflake upsert processing in S3 mode, including safer task recreation and more reliable change-data deduplication.
  * Ensured processed change records are cleared after successful task execution.
  * Append-only S3 sinks no longer run periodic pipe-refresh tasks.
  * Improved automatic intermediate table naming for eligible Snowflake and Redshift upsert sinks while preserving custom names.

* **Compatibility**
  * Snowflake upsert sinks now require S3 mode.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->