### PR TITLE
fix(pgwire): enforce password authentication flow

### DIFF
--- a/src/utils/pgwire/src/error.rs
+++ b/src/utils/pgwire/src/error.rs
@@ -32,6 +32,9 @@ pub enum PsqlError {
     #[error("Invalid password")]
     PasswordError,
 
+    #[error("Protocol violation: {0}")]
+    ProtocolError(String),
+
     #[error("Failed to run the query: {0}")]
     SimpleQueryError(
         #[source]

--- a/src/utils/pgwire/src/error.rs
+++ b/src/utils/pgwire/src/error.rs
@@ -12,8 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::fmt;
 use std::io::Error as IoError;
 
+use risingwave_common::error::code::PostgresErrorCode;
 use thiserror::Error;
 
 use crate::pg_server::BoxedError;
@@ -33,7 +35,11 @@ pub enum PsqlError {
     PasswordError,
 
     #[error("Protocol violation: {0}")]
-    ProtocolError(String),
+    ProtocolError(
+        #[source]
+        #[backtrace]
+        ProtocolViolationError,
+    ),
 
     #[error("Failed to run the query: {0}")]
     SimpleQueryError(
@@ -82,7 +88,26 @@ This is a bug. We would appreciate a bug report at:
     ServerThrottle(String),
 }
 
+#[derive(Debug)]
+pub struct ProtocolViolationError(String);
+
+impl fmt::Display for ProtocolViolationError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+impl std::error::Error for ProtocolViolationError {
+    fn provide<'a>(&'a self, request: &mut std::error::Request<'a>) {
+        request.provide_value(PostgresErrorCode::ProtocolViolation);
+    }
+}
+
 impl PsqlError {
+    pub fn protocol_error(message: impl Into<String>) -> Self {
+        Self::ProtocolError(ProtocolViolationError(message.into()))
+    }
+
     pub fn no_statement() -> Self {
         PsqlError::Uncategorized("No statement found".into())
     }

--- a/src/utils/pgwire/src/pg_protocol.rs
+++ b/src/utils/pgwire/src/pg_protocol.rs
@@ -172,8 +172,10 @@ where
 }
 
 /// States flow happened from top to down.
+#[derive(PartialEq, Eq)]
 enum PgProtocolState {
     Startup,
+    Authentication,
     Regular,
 }
 
@@ -513,7 +515,9 @@ where
                         return None;
                     }
 
-                    PsqlError::StartupError(_) | PsqlError::PasswordError => {
+                    PsqlError::StartupError(_)
+                    | PsqlError::PasswordError
+                    | PsqlError::ProtocolError(_) => {
                         self.stream
                             .write_no_flush(BeMessage::ErrorResponse {
                                 error: &e,
@@ -574,6 +578,13 @@ where
     }
 
     async fn do_process_inner(&mut self, msg: FeMessage) -> PsqlResult<()> {
+        if self.state == PgProtocolState::Authentication && !matches!(&msg, FeMessage::Password(_))
+        {
+            return Err(PsqlError::ProtocolError(
+                "expected PasswordMessage during authentication".to_owned(),
+            ));
+        }
+
         // Ignore util sync message.
         if self.ignore_util_sync {
             if let FeMessage::Sync = msg {
@@ -663,7 +674,7 @@ where
                 .read_startup()
                 .await
                 .map(|message: FeMessage| (message, None)),
-            PgProtocolState::Regular => {
+            PgProtocolState::Authentication | PgProtocolState::Regular => {
                 self.stream.read_header().await?;
                 let guard = if let Some(ref header) = self.stream.read_header {
                     let payload_len = std::cmp::max(header.payload_len, 0) as u64;
@@ -756,7 +767,7 @@ where
                 .map_err(|e| PsqlError::StartupError(e.into()))?;
         }
 
-        match session.user_authenticator() {
+        self.state = match session.user_authenticator() {
             UserAuthenticator::None => {
                 self.stream.write_no_flush(BeMessage::AuthenticationOk)?;
 
@@ -777,21 +788,23 @@ where
                         application_name: application_name.cloned(),
                     })?;
                 self.ready_for_query()?;
+                PgProtocolState::Regular
             }
             UserAuthenticator::ClearText(_)
             | UserAuthenticator::OAuth { .. }
             | UserAuthenticator::Ldap(..) => {
                 self.stream
                     .write_no_flush(BeMessage::AuthenticationCleartextPassword)?;
+                PgProtocolState::Authentication
             }
             UserAuthenticator::Md5WithSalt { salt, .. } => {
                 self.stream
                     .write_no_flush(BeMessage::AuthenticationMd5Password(salt))?;
+                PgProtocolState::Authentication
             }
-        }
+        };
 
         self.session = Some(session);
-        self.state = PgProtocolState::Regular;
         Ok(())
     }
 

--- a/src/utils/pgwire/src/pg_protocol.rs
+++ b/src/utils/pgwire/src/pg_protocol.rs
@@ -580,8 +580,8 @@ where
     async fn do_process_inner(&mut self, msg: FeMessage) -> PsqlResult<()> {
         if self.state == PgProtocolState::Authentication && !matches!(&msg, FeMessage::Password(_))
         {
-            return Err(PsqlError::ProtocolError(
-                "expected PasswordMessage during authentication".to_owned(),
+            return Err(PsqlError::protocol_error(
+                "expected PasswordMessage during authentication",
             ));
         }
 


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).


## What's changed and what's your intention?

<!--

**Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->
Previously, the protocol unconditionally transitioned to a regular state after sending a password challenge [ref](https://github.com/risingwavelabs/risingwave/blob/main/src/utils/pgwire/src/pg_protocol.rs#L794). Meaning an attacker could handcraft a wire message with a `Query` tag instead of a `Password` tag to execute a query, bypassing an authenticated user.

The fix is to reject non `Password` frontend messages when the program is in an authenticating state

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/dev/src/ci.md#ci-labels-guide -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
