### PR TITLE
fix(connector): isolate Pulsar ACK channels by actor

### DIFF
--- a/src/connector/src/source/mod.rs
+++ b/src/connector/src/source/mod.rs
@@ -209,7 +209,8 @@ impl WaitCheckpointTask {
                         return;
                     };
 
-                    let Some(ack_tx) = PULSAR_ACK_CHANNEL.get(ack_channel_id).await else {
+                    let Some(ack_tx) = PULSAR_ACK_CHANNEL.lock().get(ack_channel_id).cloned()
+                    else {
                         GLOBAL_SOURCE_METRICS.inc_connector_ack_failure_count(
                             source_name,
                             "pulsar",

--- a/src/connector/src/source/mod.rs
+++ b/src/connector/src/source/mod.rs
@@ -88,7 +88,7 @@ use async_nats::jetstream::context::Context as JetStreamContext;
 pub use manager::{SourceColumnDesc, SourceColumnType};
 use risingwave_common::array::{Array, ArrayRef};
 use risingwave_common::row::OwnedRow;
-use risingwave_pb::id::SourceId;
+use risingwave_pb::id::{ActorId, SourceId};
 use thiserror_ext::AsReport;
 pub use util::fill_adaptive_split;
 
@@ -408,7 +408,33 @@ pub struct CdcTableSnapshotSplitCommon<T: Clone> {
 pub type CdcTableSnapshotSplit = CdcTableSnapshotSplitCommon<OwnedRow>;
 pub type CdcTableSnapshotSplitRaw = CdcTableSnapshotSplitCommon<Vec<u8>>;
 
+/// Build the identifier of the ACK channel for a Pulsar reader.
+///
+/// Multiple actors can consume the same source split in one process, so the actor ID is required
+/// to prevent one reader from replacing another reader's channel.
 #[inline]
-pub fn build_pulsar_ack_channel_id(source_id: SourceId, split_id: &SplitId) -> String {
-    format!("{}-{}", source_id, split_id)
+pub fn build_pulsar_ack_channel_id(
+    source_id: SourceId,
+    split_id: &SplitId,
+    actor_id: ActorId,
+) -> String {
+    format!("{}-{}-{}", source_id, split_id, actor_id)
+}
+
+#[cfg(test)]
+mod tests {
+    use risingwave_pb::id::{ActorId, SourceId};
+
+    use super::{SplitId, build_pulsar_ack_channel_id};
+
+    #[test]
+    fn test_pulsar_ack_channel_id_is_actor_scoped() {
+        let source_id = SourceId::new(7);
+        let split_id: SplitId = "persistent://public/default/topic".into();
+
+        let first = build_pulsar_ack_channel_id(source_id, &split_id, ActorId::new(11));
+        let second = build_pulsar_ack_channel_id(source_id, &split_id, ActorId::new(12));
+
+        assert_ne!(first, second);
+    }
 }

--- a/src/connector/src/source/pulsar/source/reader.rs
+++ b/src/connector/src/source/pulsar/source/reader.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::collections::HashMap;
 use std::sync::LazyLock;
 use std::task::Poll;
 
@@ -20,7 +21,7 @@ use async_trait::async_trait;
 use futures::StreamExt;
 use futures_async_stream::try_stream;
 use itertools::Itertools;
-use moka::future::Cache as MokaCache;
+use parking_lot::Mutex;
 use prost_013::Message as _;
 use pulsar::consumer::{InitialPosition, Message};
 use pulsar::message::proto::MessageIdData;
@@ -38,9 +39,40 @@ use crate::source::{
     BoxSourceChunkStream, Column, SourceContextRef, SourceMessage, SplitId, SplitMetaData,
     SplitReader, build_pulsar_ack_channel_id, into_chunk_stream,
 };
-pub static PULSAR_ACK_CHANNEL: LazyLock<
-    MokaCache<String, tokio::sync::mpsc::UnboundedSender<Vec<u8>>>,
-> = LazyLock::new(|| moka::future::Cache::builder().build()); // mapping:
+type PulsarAckSender = tokio::sync::mpsc::UnboundedSender<Vec<u8>>;
+
+pub(crate) static PULSAR_ACK_CHANNEL: LazyLock<Mutex<HashMap<String, PulsarAckSender>>> =
+    LazyLock::new(|| Mutex::new(HashMap::new()));
+
+/// Owns one ACK channel registry entry and removes it when its reader is dropped.
+///
+/// The sender identity check prevents an old reader from removing the replacement channel when a
+/// stream is rebuilt with the same channel ID.
+struct PulsarAckChannelRegistration {
+    channel_id: String,
+    sender: PulsarAckSender,
+}
+
+impl PulsarAckChannelRegistration {
+    fn new(channel_id: String, sender: PulsarAckSender) -> Self {
+        PULSAR_ACK_CHANNEL
+            .lock()
+            .insert(channel_id.clone(), sender.clone());
+        Self { channel_id, sender }
+    }
+}
+
+impl Drop for PulsarAckChannelRegistration {
+    fn drop(&mut self) {
+        let mut channels = PULSAR_ACK_CHANNEL.lock();
+        if channels
+            .get(&self.channel_id)
+            .is_some_and(|sender| sender.same_channel(&self.sender))
+        {
+            channels.remove(&self.channel_id);
+        }
+    }
+}
 
 const PULSAR_DEFAULT_SUBSCRIPTION_PREFIX: &str = "rw-consumer";
 
@@ -329,16 +361,14 @@ impl PulsarBrokerReader {
             &self.split_id,
             self.source_ctx.actor_id,
         );
-        PULSAR_ACK_CHANNEL
-            .entry(channel_entry)
-            .and_upsert_with(|_| std::future::ready(ack_tx))
-            .await;
+        let ack_channel_registration = PulsarAckChannelRegistration::new(channel_entry, ack_tx);
 
         PulsarConsumeStream {
             source_ctx: self.source_ctx,
             split_id: self.split_id,
             pulsar_reader: self.consumer,
             ack_rx,
+            _ack_channel_registration: ack_channel_registration,
             topic: self.split.topic.to_string(),
         }
     }
@@ -349,6 +379,7 @@ struct PulsarConsumeStream {
     split_id: SplitId,
     pulsar_reader: Consumer<Vec<u8>, TokioExecutor>,
     ack_rx: tokio::sync::mpsc::UnboundedReceiver<Vec<u8>>,
+    _ack_channel_registration: PulsarAckChannelRegistration,
     topic: String,
 }
 
@@ -469,5 +500,31 @@ impl futures::Stream for PulsarConsumeStream {
         }
 
         Poll::Pending
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{PULSAR_ACK_CHANNEL, PulsarAckChannelRegistration};
+
+    #[test]
+    fn test_ack_channel_registration_cleanup_does_not_remove_replacement() {
+        let channel_id = "pulsar-ack-channel-registration-test".to_owned();
+        let (first_tx, _first_rx) = tokio::sync::mpsc::unbounded_channel();
+        let first = PulsarAckChannelRegistration::new(channel_id.clone(), first_tx);
+
+        let (second_tx, _second_rx) = tokio::sync::mpsc::unbounded_channel();
+        let second = PulsarAckChannelRegistration::new(channel_id.clone(), second_tx.clone());
+
+        drop(first);
+        assert!(
+            PULSAR_ACK_CHANNEL
+                .lock()
+                .get(&channel_id)
+                .is_some_and(|sender| sender.same_channel(&second_tx))
+        );
+
+        drop(second);
+        assert!(!PULSAR_ACK_CHANNEL.lock().contains_key(&channel_id));
     }
 }

--- a/src/connector/src/source/pulsar/source/reader.rs
+++ b/src/connector/src/source/pulsar/source/reader.rs
@@ -324,7 +324,11 @@ impl PulsarBrokerReader {
 
     async fn into_stream(self) -> PulsarConsumeStream {
         let (ack_tx, ack_rx) = tokio::sync::mpsc::unbounded_channel();
-        let channel_entry = build_pulsar_ack_channel_id(self.source_ctx.source_id, &self.split_id);
+        let channel_entry = build_pulsar_ack_channel_id(
+            self.source_ctx.source_id,
+            &self.split_id,
+            self.source_ctx.actor_id,
+        );
         PULSAR_ACK_CHANNEL
             .entry(channel_entry)
             .and_upsert_with(|_| std::future::ready(ack_tx))
@@ -383,7 +387,11 @@ impl PulsarConsumeStream {
         tracing::debug!(
             "ack message id: {:?} from channel {}",
             message_id,
-            build_pulsar_ack_channel_id(self.source_ctx.source_id, &self.split_id)
+            build_pulsar_ack_channel_id(
+                self.source_ctx.source_id,
+                &self.split_id,
+                self.source_ctx.actor_id,
+            )
         );
         #[cfg(not(madsim))]
         {

--- a/src/connector/src/source/pulsar/source/reader.rs
+++ b/src/connector/src/source/pulsar/source/reader.rs
@@ -312,7 +312,7 @@ impl PulsarBrokerReader {
             )
         });
         #[for_await]
-        for msgs in self.into_stream().await.ready_chunks(max_chunk_size) {
+        for msgs in self.into_stream().ready_chunks(max_chunk_size) {
             let msgs = msgs
                 .into_iter()
                 .collect::<Result<Vec<Message<Vec<u8>>>, _>>()?;
@@ -354,7 +354,7 @@ impl PulsarBrokerReader {
         }
     }
 
-    async fn into_stream(self) -> PulsarConsumeStream {
+    fn into_stream(self) -> PulsarConsumeStream {
         let (ack_tx, ack_rx) = tokio::sync::mpsc::unbounded_channel();
         let channel_entry = build_pulsar_ack_channel_id(
             self.source_ctx.source_id,

--- a/src/stream/src/executor/source/source_executor.rs
+++ b/src/stream/src/executor/source/source_executor.rs
@@ -1020,6 +1020,7 @@ impl<S: StateStore> SourceExecutor<S> {
                         if let Some(pulsar_message_id_idx) = pulsar_message_id_idx {
                             let pulsar_message_id_col = chunk.column_at(pulsar_message_id_idx);
                             task_builder.update_task_on_chunk(
+                                self.actor_ctx.id,
                                 source_id,
                                 &latest_state,
                                 pulsar_message_id_col.clone(),
@@ -1027,6 +1028,7 @@ impl<S: StateStore> SourceExecutor<S> {
                         } else {
                             let offset_col = chunk.column_at(offset_idx);
                             task_builder.update_task_on_chunk(
+                                self.actor_ctx.id,
                                 source_id,
                                 &latest_state,
                                 offset_col.clone(),
@@ -1116,6 +1118,7 @@ struct WaitCheckpointTaskBuilder {
 impl WaitCheckpointTaskBuilder {
     fn update_task_on_chunk(
         &mut self,
+        actor_id: ActorId,
         source_id: SourceId,
         latest_state: &HashMap<SplitId, SplitImpl>,
         offset_col: ArrayRef,
@@ -1130,7 +1133,8 @@ impl WaitCheckpointTaskBuilder {
             WaitCheckpointTask::AckPulsarMessage(arrays) => {
                 // each pulsar chunk will only contain one split
                 let split_id = latest_state.keys().next().unwrap();
-                let pulsar_ack_channel_id = build_pulsar_ack_channel_id(source_id, split_id);
+                let pulsar_ack_channel_id =
+                    build_pulsar_ack_channel_id(source_id, split_id, actor_id);
                 arrays.push((pulsar_ack_channel_id, offset_col));
             }
             WaitCheckpointTask::CommitCdcOffset(_) => {}


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

- Scope internal Pulsar ACK channels by actor so colocated jobs consuming the same source split cannot overwrite each other's ACK route.
- Remove each in-memory channel registration when its reader is dropped, while preserving a newer replacement registered under the same ID.
- Keep reader registration and checkpoint ACK lookup aligned, with regression tests for actor isolation and cleanup safety.

## Checklist

- [x] I have written necessary rustdoc comments.
- [x] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [x] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/dev/src/ci.md#ci-labels-guide -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove it in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results.
- [ ] <!-- OPTIONAL --> I have checked the Release Timeline for significant changes. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/dev/src/release/release_cycle_and_model.md -->

## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

No user-facing documentation changes.

</details>
