### PR TITLE
chore(iceberg): bump iceberg dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7592,7 +7592,7 @@ dependencies = [
 [[package]]
 name = "iceberg"
 version = "0.10.0"
-source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=c39309944d2b7f1c81ae2d24c3aa32fd1da66590#c39309944d2b7f1c81ae2d24c3aa32fd1da66590"
+source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=2768ccf8b1847a14162337d7ef7a76935881fbc8#2768ccf8b1847a14162337d7ef7a76935881fbc8"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -7651,7 +7651,7 @@ dependencies = [
 [[package]]
 name = "iceberg-catalog-glue"
 version = "0.10.0"
-source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=c39309944d2b7f1c81ae2d24c3aa32fd1da66590#c39309944d2b7f1c81ae2d24c3aa32fd1da66590"
+source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=2768ccf8b1847a14162337d7ef7a76935881fbc8#2768ccf8b1847a14162337d7ef7a76935881fbc8"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7666,7 +7666,7 @@ dependencies = [
 [[package]]
 name = "iceberg-catalog-rest"
 version = "0.10.0"
-source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=c39309944d2b7f1c81ae2d24c3aa32fd1da66590#c39309944d2b7f1c81ae2d24c3aa32fd1da66590"
+source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=2768ccf8b1847a14162337d7ef7a76935881fbc8#2768ccf8b1847a14162337d7ef7a76935881fbc8"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -7687,7 +7687,7 @@ dependencies = [
 [[package]]
 name = "iceberg-compaction-core"
 version = "0.1.0"
-source = "git+https://github.com/nimtable/iceberg-compaction.git?rev=7bae3fab234e54891af64f0b1ac2d27be0c25236#7bae3fab234e54891af64f0b1ac2d27be0c25236"
+source = "git+https://github.com/nimtable/iceberg-compaction.git?rev=53410bea82ff2319196df43e7447ab2bb13da1d6#53410bea82ff2319196df43e7447ab2bb13da1d6"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -7716,7 +7716,7 @@ dependencies = [
 [[package]]
 name = "iceberg-datafusion"
 version = "0.10.0"
-source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=c39309944d2b7f1c81ae2d24c3aa32fd1da66590#c39309944d2b7f1c81ae2d24c3aa32fd1da66590"
+source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=2768ccf8b1847a14162337d7ef7a76935881fbc8#2768ccf8b1847a14162337d7ef7a76935881fbc8"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7732,7 +7732,7 @@ dependencies = [
 [[package]]
 name = "iceberg-storage-opendal"
 version = "0.10.0"
-source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=c39309944d2b7f1c81ae2d24c3aa32fd1da66590#c39309944d2b7f1c81ae2d24c3aa32fd1da66590"
+source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=2768ccf8b1847a14162337d7ef7a76935881fbc8#2768ccf8b1847a14162337d7ef7a76935881fbc8"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -176,10 +176,10 @@ hashbrown0_16 = { package = "hashbrown", version = "0.16.1", features = [
 ] }
 hytra = "0.1"
 # branch dev_rebase_main_20260807
-iceberg = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "c39309944d2b7f1c81ae2d24c3aa32fd1da66590" }
-iceberg-catalog-glue = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "c39309944d2b7f1c81ae2d24c3aa32fd1da66590" }
-iceberg-catalog-rest = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "c39309944d2b7f1c81ae2d24c3aa32fd1da66590" }
-iceberg-storage-opendal = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "c39309944d2b7f1c81ae2d24c3aa32fd1da66590", features = [
+iceberg = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "2768ccf8b1847a14162337d7ef7a76935881fbc8" }
+iceberg-catalog-glue = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "2768ccf8b1847a14162337d7ef7a76935881fbc8" }
+iceberg-catalog-rest = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "2768ccf8b1847a14162337d7ef7a76935881fbc8" }
+iceberg-storage-opendal = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "2768ccf8b1847a14162337d7ef7a76935881fbc8", features = [
     "opendal-azblob",
     "opendal-azdls",
     "opendal-fs",

--- a/src/storage/Cargo.toml
+++ b/src/storage/Cargo.toml
@@ -34,7 +34,7 @@ futures = { version = "0.3", default-features = false, features = ["alloc"] }
 futures-async-stream = { workspace = true }
 hex = "0.4"
 iceberg = { workspace = true }
-iceberg-compaction-core = { git = "https://github.com/nimtable/iceberg-compaction.git", rev = "7bae3fab234e54891af64f0b1ac2d27be0c25236" }
+iceberg-compaction-core = { git = "https://github.com/nimtable/iceberg-compaction.git", rev = "53410bea82ff2319196df43e7447ab2bb13da1d6" }
 itertools = { workspace = true }
 libc = "0.2"
 lz4 = "1.28.0"

--- a/src/storage/src/hummock/compactor/iceberg_compaction/iceberg_compactor_runner.rs
+++ b/src/storage/src/hummock/compactor/iceberg_compaction/iceberg_compactor_runner.rs
@@ -20,13 +20,13 @@ use derive_builder::Builder;
 use iceberg::spec::MAIN_BRANCH;
 use iceberg::{Catalog, TableIdent};
 use iceberg_compaction_core::compaction::{
-    AutoCompactionPlanner, CommitConsistencyParams, CommitManagerRetryConfig, CompactionBuilder,
-    CompactionPlan, CompactionPlanner, CompactionResult, RewriteResult,
+    CommitConsistencyParams, CommitManagerRetryConfig, CompactionBuilder, CompactionPlan,
+    CompactionPlanner, CompactionResult, RewriteResult,
 };
 use iceberg_compaction_core::config::{
-    AutoCompactionConfig, AutoCompactionConfigBuilder, CompactionExecutionConfigBuilder,
-    CompactionPlanningConfig, FileGroupScope, FilesWithDeletesConfigBuilder,
-    FullCompactionConfigBuilder, GroupFilters, SmallFilesConfigBuilder,
+    AutoCompactionConfigBuilder, CompactionExecutionConfigBuilder, CompactionPlanningConfig,
+    FileGroupScope, FilesWithDeletesConfigBuilder, FullCompactionConfigBuilder, GroupFilters,
+    SmallFilesConfigBuilder,
 };
 use iceberg_compaction_core::executor::RewriteFilesStat;
 use mixtrics::registry::prometheus::PrometheusMetricsRegistry;
@@ -96,11 +96,6 @@ pub struct IcebergCompactionTaskStatistics {
     pub total_pos_del_file_count: u32,
     pub total_eq_del_file_size: u64,
     pub total_eq_del_file_count: u32,
-}
-
-enum IcebergTaskPlanningConfig {
-    Auto(AutoCompactionConfig),
-    Explicit(CompactionPlanningConfig),
 }
 
 impl Debug for IcebergCompactionTaskStatistics {
@@ -532,7 +527,7 @@ fn build_task_planning_config(
     task_type: TaskType,
     iceberg_config: &IcebergConfig,
     config: &IcebergCompactorRunnerConfig,
-) -> HummockResult<IcebergTaskPlanningConfig> {
+) -> HummockResult<CompactionPlanningConfig> {
     let grouping_strategy = match iceberg_config.write_mode {
         IcebergWriteMode::CopyOnWrite => iceberg_compaction_core::config::GroupingStrategy::Single,
         IcebergWriteMode::MergeOnRead => match config.target_binpack_group_size_mb {
@@ -578,7 +573,7 @@ fn build_task_planning_config(
             let config = builder
                 .build()
                 .map_err(|e| HummockError::compaction_executor(e.as_report()))?;
-            IcebergTaskPlanningConfig::Auto(config)
+            CompactionPlanningConfig::Auto(config)
         }
         TaskType::SmallFiles => {
             let mut builder = SmallFilesConfigBuilder::default();
@@ -599,7 +594,7 @@ fn build_task_planning_config(
             let config = builder
                 .build()
                 .map_err(|e| HummockError::compaction_executor(e.as_report()))?;
-            IcebergTaskPlanningConfig::Explicit(CompactionPlanningConfig::SmallFiles(config))
+            CompactionPlanningConfig::SmallFiles(config)
         }
         TaskType::Full => {
             let file_group_scope = if should_enable_iceberg_cow(
@@ -621,7 +616,7 @@ fn build_task_planning_config(
                 .file_group_scope(file_group_scope)
                 .build()
                 .map_err(|e| HummockError::compaction_executor(e.as_report()))?;
-            IcebergTaskPlanningConfig::Explicit(CompactionPlanningConfig::Full(config))
+            CompactionPlanningConfig::Full(config)
         }
         TaskType::FilesWithDelete => {
             let config = FilesWithDeletesConfigBuilder::default()
@@ -635,7 +630,7 @@ fn build_task_planning_config(
                 .min_delete_file_count_threshold(iceberg_config.delete_files_count_threshold())
                 .build()
                 .map_err(|e| HummockError::compaction_executor(e.as_report()))?;
-            IcebergTaskPlanningConfig::Explicit(CompactionPlanningConfig::FilesWithDeletes(config))
+            CompactionPlanningConfig::FilesWithDeletes(config)
         }
         _ => unreachable!("Unsupported task type in iceberg compaction task: {task_type:?}"),
     };
@@ -680,33 +675,10 @@ pub async fn create_task_execution(
         .await
         .map_err(|e| HummockError::compaction_executor(e.as_report()))?;
 
-    let compaction_plans = match planning_config {
-        IcebergTaskPlanningConfig::Auto(config) => {
-            let report = AutoCompactionPlanner::new(config)
-                .plan_compaction_report_with_branch(&table, &branch)
-                .await
-                .map_err(|e| HummockError::compaction_executor(e.as_report()))?;
-            tracing::info!(
-                iceberg_component = "compaction_worker",
-                iceberg_operation = "plan_auto_task",
-                task_id = %task_id,
-                sink_id,
-                table = %table_ident,
-                branch = %branch,
-                selected_strategy = ?report.selected_strategy,
-                reason = ?report.reason,
-                planned_input_bytes = report.planned_input_bytes,
-                planned_input_files = report.planned_input_files,
-                rewrite_ratio = report.rewrite_ratio,
-                "iceberg_auto_compaction_strategy_selected",
-            );
-            report.plans
-        }
-        IcebergTaskPlanningConfig::Explicit(config) => CompactionPlanner::new(config)
-            .plan_compaction_with_branch(&table, &branch)
-            .await
-            .map_err(|e| HummockError::compaction_executor(e.as_report()))?,
-    };
+    let compaction_plans = CompactionPlanner::new(planning_config)
+        .plan_compaction_with_branch(&table, &branch)
+        .await
+        .map_err(|e| HummockError::compaction_executor(e.as_report()))?;
 
     if compaction_plans.is_empty() {
         tracing::info!(
@@ -806,7 +778,7 @@ mod tests {
             min_group_file_count: Some(3),
         };
 
-        let IcebergTaskPlanningConfig::Auto(config) =
+        let CompactionPlanningConfig::Auto(config) =
             build_task_planning_config(TaskType::Auto, &iceberg_config, &runner_config).unwrap()
         else {
             panic!("expected auto planning config");
@@ -819,9 +791,6 @@ mod tests {
         assert_eq!(config.target_file_size_bytes, 256 * 1024 * 1024);
         assert_eq!(config.small_file_threshold_bytes, 96 * 1024 * 1024);
         assert_eq!(config.min_delete_file_count_threshold, 7);
-        assert_eq!(config.thresholds.min_small_files_count, 5);
-        assert_eq!(config.thresholds.min_delete_heavy_files_count, 1);
-
         let iceberg_compaction_core::config::GroupingStrategy::BinPack(bin_pack) =
             config.grouping_strategy
         else {


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

- Bump the `iceberg`, `iceberg-catalog-glue`, `iceberg-catalog-rest`, `iceberg-datafusion`, and `iceberg-storage-opendal` crates from `c39309944d2b7f1c81ae2d24c3aa32fd1da66590` to the latest `dev_rebase_main_20260807` commit, `2768ccf8b1847a14162337d7ef7a76935881fbc8`.
- Bump `iceberg-compaction-core` from `7bae3fab234e54891af64f0b1ac2d27be0c25236` to `53410bea82ff2319196df43e7447ab2bb13da1d6`, including [nimtable/iceberg-compaction#179](https://github.com/nimtable/iceberg-compaction/pull/179).
- Migrate RisingWave's Iceberg compaction runner from the removed `AutoCompactionPlanner` API to the unified `CompactionPlanner`. Auto compaction now passes `CompactionPlanningConfig::Auto` through the same planning path as the explicit strategies.
- Remove the obsolete auto-strategy selection report logging and assertions for the removed strategy thresholds. The latest upstream planner builds one candidate set from small and delete-heavy files instead of selecting one strategy.
- Pull in the latest upstream Iceberg fixes for delete-file pruning and cleanup, Variant handling, partial-overwrite summaries, partition validation, and pre-epoch/default timestamps.

This is an internal dependency/API migration and does not change RisingWave's supported user-facing Iceberg interfaces.

### Local verification

- `cargo fmt --all -- --check`
- `cargo metadata --locked --offline --no-deps`
- `git diff --check`
- `cargo check -p risingwave_storage --all-targets --locked` compiled the new Iceberg dependency stack and reached `risingwave_storage`, then stopped on `lifetime bound not satisfied` diagnostics in untouched files at `src/storage/src/hummock/store/local_hummock_storage.rs:431` and `src/storage/src/memory.rs:1115`.
- `cargo clippy -p risingwave_storage --all-targets --locked -- -D warnings` reached the same two unrelated lifetime diagnostics; no diagnostic referenced the changed Iceberg compaction runner.

## Checklist

- [x] I have written necessary rustdoc comments, or no public API documentation is needed.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [x] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/dev/src/ci.md#ci-labels-guide -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->

## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

Not applicable: internal dependency and API migration only.

</details>
