### PR TITLE
fix(frontend): do not pushdown volatile predicate into aggregate

### DIFF
--- a/src/frontend/planner_test/tests/testdata/input/predicate_pushdown.yaml
+++ b/src/frontend/planner_test/tests/testdata/input/predicate_pushdown.yaml
@@ -60,6 +60,19 @@
   expected_outputs:
   - logical_plan
   - optimized_logical_plan_for_batch
+- name: impure filter should not transpose grouped agg
+  sql: |
+    create table t(g int);
+    select *
+    from (
+      select g, count(*) as n
+      from t
+      group by g
+    ) grouped
+    where g = 1 and random() < 0.5;
+  expected_outputs:
+  - logical_plan
+  - optimized_logical_plan_for_batch
 - name: filter project set transpose
   sql: |
     create table t(v1 int, v2 int, v3 int, arr int[]);

--- a/src/frontend/planner_test/tests/testdata/output/predicate_pushdown.yaml
+++ b/src/frontend/planner_test/tests/testdata/output/predicate_pushdown.yaml
@@ -126,6 +126,27 @@
     └─LogicalAgg { group_key: [t.v1, t.v2, t.v3], aggs: [count, count(1:Int32)] }
       └─LogicalProject { exprs: [t.v1, t.v2, t.v3, 1:Int32] }
         └─LogicalScan { table: t, columns: [t.v1, t.v2, t.v3], predicate: (t.v1 = 10:Int32) AND (t.v2 = 20:Int32) AND (t.v3 = 30:Int32) AND (t.v2 > t.v3) }
+- name: impure filter should not transpose grouped agg
+  sql: |
+    create table t(g int);
+    select *
+    from (
+      select g, count(*) as n
+      from t
+      group by g
+    ) grouped
+    where g = 1 and random() < 0.5;
+  logical_plan: |-
+    LogicalProject { exprs: [t.g, count] }
+    └─LogicalFilter { predicate: (t.g = 1:Int32) AND (Random < 0.5:Decimal::Float64) }
+      └─LogicalProject { exprs: [t.g, count] }
+        └─LogicalAgg { group_key: [t.g], aggs: [count] }
+          └─LogicalProject { exprs: [t.g] }
+            └─LogicalScan { table: t, columns: [t.g, t._row_id, t._rw_timestamp] }
+  optimized_logical_plan_for_batch: |-
+    LogicalFilter { predicate: (Random < 0.5:Decimal::Float64) }
+    └─LogicalAgg { group_key: [t.g], aggs: [count] }
+      └─LogicalScan { table: t, columns: [t.g], predicate: (t.g = 1:Int32) }
 - name: filter project set transpose
   sql: |
     create table t(v1 int, v2 int, v3 int, arr int[]);

--- a/src/frontend/src/optimizer/plan_node/logical_agg.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_agg.rs
@@ -1342,10 +1342,17 @@ impl PredicatePushdown for LogicalAgg {
             return gen_filter_and_pushdown(self, predicate, Condition::true_cond(), ctx);
         }
 
-        // If the filter references agg_calls, we can not push it.
+        // If the filter references agg_calls, we can not push it. An impure predicate must also
+        // remain above the aggregation because pushing it down changes its evaluation cardinality
+        // from once per group to once per input row.
         let mut agg_call_columns = FixedBitSet::with_capacity(num_group_key + num_agg_calls);
         agg_call_columns.insert_range(num_group_key..num_group_key + num_agg_calls);
-        let (agg_call_pred, pushed_predicate) = predicate.split_disjoint(&agg_call_columns);
+        let [agg_call_pred, pushed_predicate] = predicate.group_by::<_, 2>(|expr| {
+            (expr.is_pure()
+                && expr
+                    .collect_input_refs(self.schema().len())
+                    .is_disjoint(&agg_call_columns)) as usize
+        });
 
         // convert the predicate to one that references the child of the agg
         let mut subst = Substitute {


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

<!--

**Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

When running a query with an impure predicate, say:

```
WITH t(g) AS (VALUES (1),(1),(1),(1), (2),(2),(2),(2))
SELECT g, n
FROM (
    SELECT g, count(*) AS n 
    FROM t 
    GROUP BY g) AS grouped
WHERE random() < 0.5;
```

evaluating the predicate once per group, versus once per row will provide different results:
- pushdown: predicate is evaluated once per row, meaning the following states are possible:
    - (1, 3), (2, 2)
    - (1, 4), (2, 3)
    - (1, x), (2, y)
- do not pushdown: predicate is only evaluated once per group, meaning there's only 4 possible states
    - (1, 4), (2, 4)
    - (1, 4)
    - (2, 4)
    - NULL
    
The fix is to also also check whether the predicate expression is pure before pushdown

## Checklist

- [ ] I have written necessary rustdoc comments.
- [x] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/dev/src/ci.md#ci-labels-guide -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
