### PR TITLE
cherry-pick: feat(cdc): allow altering snapshot options for CDC tables

### DIFF
--- a/e2e_test/source_inline/cdc/mysql/mysql_alter_snapshot_options.slt.serial
+++ b/e2e_test/source_inline/cdc/mysql/mysql_alter_snapshot_options.slt.serial
@@ -39,6 +39,10 @@ select id, payload from rw_mysql_alter_snapshot_options order by id;
 ----
 1 before
 
+# Metadata-only snapshot option changes must not advance the live DML schema version.
+statement ok
+insert into rw_mysql_alter_snapshot_options values (10, 'rw_before_alter');
+
 statement error snapshot.batch_size must be greater than 0
 alter table rw_mysql_alter_snapshot_options connector with (
   snapshot.batch_size = '0'
@@ -67,9 +71,18 @@ where name = 'rw_mysql_alter_snapshot_options'
 ----
 1
 
+statement ok
+insert into rw_mysql_alter_snapshot_options values (11, 'rw_after_alter');
+
+statement ok
+flush;
+
 # Recovery rebuilds the actor from the updated persisted fragment plan.
 statement ok
 recover;
+
+statement ok
+insert into rw_mysql_alter_snapshot_options values (12, 'rw_after_recover');
 
 system ok
 mysql -e "
@@ -82,6 +95,9 @@ select id, payload from rw_mysql_alter_snapshot_options order by id;
 ----
 1 before
 2 after_recover
+10 rw_before_alter
+11 rw_after_alter
+12 rw_after_recover
 
 # A later automatic schema replacement must accept the advanced table version and preserve the
 # altered snapshot options.
@@ -98,6 +114,9 @@ select id, payload, added from rw_mysql_alter_snapshot_options order by id;
 1 before 7
 2 after_recover 7
 3 after_schema_change 9
+10 rw_before_alter 7
+11 rw_after_alter 7
+12 rw_after_recover 7
 
 query I
 select count(*)

--- a/e2e_test/source_inline/cdc/mysql/mysql_alter_snapshot_options.slt.serial
+++ b/e2e_test/source_inline/cdc/mysql/mysql_alter_snapshot_options.slt.serial
@@ -44,6 +44,11 @@ alter table rw_mysql_alter_snapshot_options connector with (
   snapshot.batch_size = '0'
 );
 
+statement error snapshot.interval must be greater than 0
+alter table rw_mysql_alter_snapshot_options connector with (
+  snapshot.interval = '0'
+);
+
 statement ok
 alter table rw_mysql_alter_snapshot_options connector with (
   snapshot.batch_size = '16',

--- a/e2e_test/source_inline/cdc/mysql/mysql_alter_snapshot_options.slt.serial
+++ b/e2e_test/source_inline/cdc/mysql/mysql_alter_snapshot_options.slt.serial
@@ -1,0 +1,118 @@
+control substitution on
+
+system ok
+mysql -e "
+    CREATE DATABASE IF NOT EXISTS risedev;
+    USE risedev;
+    DROP TABLE IF EXISTS mysql_alter_snapshot_options;
+    CREATE TABLE mysql_alter_snapshot_options (
+        id INT NOT NULL PRIMARY KEY,
+        payload VARCHAR(64) NOT NULL
+    );
+    INSERT INTO mysql_alter_snapshot_options VALUES (1, 'before');
+"
+
+statement ok
+create source s_mysql_alter_snapshot_options with (
+  ${RISEDEV_MYSQL_WITH_OPTIONS_COMMON},
+  username = '${RISEDEV_MYSQL_USER}',
+  password = '${MYSQL_PWD}',
+  database.name = 'risedev',
+  auto.schema.change = 'true'
+);
+
+sleep 2s
+
+# Quoted option names are valid and must be replaced by their canonical forms.
+statement ok
+create table rw_mysql_alter_snapshot_options (
+  id INT,
+  payload VARCHAR,
+  primary key (id)
+) with (
+  "snapshot.batch_size" = '1',
+  "snapshot"."interval" = '1'
+) from s_mysql_alter_snapshot_options table 'risedev.mysql_alter_snapshot_options';
+
+query IT retry 10 backoff 1s
+select id, payload from rw_mysql_alter_snapshot_options order by id;
+----
+1 before
+
+statement error snapshot.batch_size must be greater than 0
+alter table rw_mysql_alter_snapshot_options connector with (
+  snapshot.batch_size = '0'
+);
+
+statement ok
+alter table rw_mysql_alter_snapshot_options connector with (
+  snapshot.batch_size = '16',
+  snapshot.interval = '3'
+);
+
+# The metadata definition contains one canonical copy of each altered option.
+query I
+select count(*)
+from rw_catalog.rw_tables
+where name = 'rw_mysql_alter_snapshot_options'
+  and regexp_count(replace(definition, '"', ''), 'snapshot[.]batch_size') = 1
+  and regexp_count(replace(definition, '"', ''), 'snapshot[.]interval') = 1
+  and replace(definition, '"', '') like '%snapshot.batch_size = ''16''%'
+  and replace(definition, '"', '') like '%snapshot.interval = ''3''%';
+----
+1
+
+# Recovery rebuilds the actor from the updated persisted fragment plan.
+statement ok
+recover;
+
+system ok
+mysql -e "
+    USE risedev;
+    INSERT INTO mysql_alter_snapshot_options VALUES (2, 'after_recover');
+"
+
+query IT retry 10 backoff 1s
+select id, payload from rw_mysql_alter_snapshot_options order by id;
+----
+1 before
+2 after_recover
+
+# A later automatic schema replacement must accept the advanced table version and preserve the
+# altered snapshot options.
+system ok
+mysql -e "
+    USE risedev;
+    ALTER TABLE mysql_alter_snapshot_options ADD COLUMN added INT NOT NULL DEFAULT 7;
+    INSERT INTO mysql_alter_snapshot_options VALUES (3, 'after_schema_change', 9);
+"
+
+query ITI retry 20 backoff 1s
+select id, payload, added from rw_mysql_alter_snapshot_options order by id;
+----
+1 before 7
+2 after_recover 7
+3 after_schema_change 9
+
+query I
+select count(*)
+from rw_catalog.rw_tables
+where name = 'rw_mysql_alter_snapshot_options'
+  and regexp_count(replace(definition, '"', ''), 'snapshot[.]batch_size') = 1
+  and regexp_count(replace(definition, '"', ''), 'snapshot[.]interval') = 1
+  and replace(definition, '"', '') like '%snapshot.batch_size = ''16''%'
+  and replace(definition, '"', '') like '%snapshot.interval = ''3''%';
+----
+1
+
+statement ok
+drop table rw_mysql_alter_snapshot_options;
+
+statement ok
+drop source s_mysql_alter_snapshot_options cascade;
+
+system ok
+mysql -e "
+    USE risedev;
+    DROP TABLE IF EXISTS mysql_alter_snapshot_options;
+"

--- a/proto/meta.proto
+++ b/proto/meta.proto
@@ -394,6 +394,7 @@ message AlterConnectorPropsRequest {
     SINK = 2;
     CONNECTION = 3;
     ICEBERG_TABLE = 4;
+    CDC_TABLE = 5;
   }
 
   uint32 object_id = 1;

--- a/src/frontend/src/handler/alter_table_props.rs
+++ b/src/frontend/src/handler/alter_table_props.rs
@@ -13,6 +13,9 @@
 // limitations under the License.
 
 use pgwire::pg_response::{PgResponse, StatementType};
+use risingwave_connector::source::cdc::{
+    CDC_BACKFILL_SNAPSHOT_BATCH_SIZE_KEY, CDC_BACKFILL_SNAPSHOT_INTERVAL_KEY,
+};
 use risingwave_expr::bail;
 use risingwave_sqlparser::ast::{Ident, ObjectName, SqlOption};
 
@@ -24,6 +27,9 @@ use crate::handler::alter_source_props::handle_alter_table_connector_props;
 use crate::utils::resolve_connection_ref_and_secret_ref;
 use crate::{Binder, WithOptions};
 
+const ALTER_CDC_SNAPSHOT_OPTIONS_RECOVER_NOTICE: &str =
+    "The new CDC snapshot options will take effect after a RECOVER.";
+
 pub async fn handle_alter_table_props(
     handler_args: HandlerArgs,
     table_name: ObjectName,
@@ -31,6 +37,36 @@ pub async fn handle_alter_table_props(
 ) -> Result<RwPgResponse> {
     let session = handler_args.session.clone();
     let (original_table, _) = fetch_table_catalog_for_alter(session.as_ref(), &table_name)?;
+    if original_table.cdc_table_id.is_some()
+        && !changed_props.is_empty()
+        && changed_props.iter().all(|prop| {
+            matches!(
+                prop.name.real_value().as_str(),
+                CDC_BACKFILL_SNAPSHOT_BATCH_SIZE_KEY | CDC_BACKFILL_SNAPSHOT_INTERVAL_KEY
+            )
+        })
+    {
+        let (resolved_with_options, _, connector_conn_ref) = resolve_connection_ref_and_secret_ref(
+            WithOptions::try_from(changed_props.as_ref() as &[SqlOption])?,
+            &session,
+            None,
+        )?;
+        let (changed_props, changed_secret_refs) = resolved_with_options.into_parts();
+        if !changed_secret_refs.is_empty() || connector_conn_ref.is_some() {
+            bail!("CDC snapshot options do not support SECRET or CONNECTION")
+        }
+
+        session
+            .env()
+            .meta_client()
+            .alter_cdc_table_snapshot_options(original_table.id, changed_props)
+            .await?;
+
+        return Ok(RwPgResponse::builder(StatementType::ALTER_TABLE)
+            .notice(ALTER_CDC_SNAPSHOT_OPTIONS_RECOVER_NOTICE)
+            .into());
+    }
+
     match original_table.engine() {
         risingwave_common::catalog::Engine::Hummock => {
             handle_alter_table_connector_props(handler_args, table_name, changed_props).await

--- a/src/frontend/src/meta_client.rs
+++ b/src/frontend/src/meta_client.rs
@@ -193,6 +193,12 @@ pub trait FrontendMetaClient: Send + Sync {
         connector_conn_ref: Option<ConnectionId>,
     ) -> Result<()>;
 
+    async fn alter_cdc_table_snapshot_options(
+        &self,
+        table_id: TableId,
+        changed_props: BTreeMap<String, String>,
+    ) -> Result<()>;
+
     async fn alter_source_connector_props(
         &self,
         source_id: SourceId,
@@ -508,6 +514,16 @@ impl FrontendMetaClient for FrontendMetaClientImpl {
                 changed_secret_refs,
                 connector_conn_ref,
             )
+            .await
+    }
+
+    async fn alter_cdc_table_snapshot_options(
+        &self,
+        table_id: TableId,
+        changed_props: BTreeMap<String, String>,
+    ) -> Result<()> {
+        self.0
+            .alter_cdc_table_snapshot_options(table_id, changed_props)
             .await
     }
 

--- a/src/frontend/src/test_utils.rs
+++ b/src/frontend/src/test_utils.rs
@@ -1382,6 +1382,14 @@ impl FrontendMetaClient for MockFrontendMetaClient {
         unimplemented!()
     }
 
+    async fn alter_cdc_table_snapshot_options(
+        &self,
+        _table_id: TableId,
+        _changed_props: BTreeMap<String, String>,
+    ) -> RpcResult<()> {
+        unimplemented!()
+    }
+
     async fn alter_source_connector_props(
         &self,
         _source_id: SourceId,

--- a/src/meta/service/src/stream_service.rs
+++ b/src/meta/service/src/stream_service.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet};
 
 use chrono::DateTime;
 use itertools::Itertools;
@@ -755,6 +755,30 @@ impl StreamManagerService for StreamServiceImpl {
                 (prop, sink_id.as_object_id())
             }
 
+            Ok(AlterConnectorPropsObject::CdcTable) => {
+                if !request.changed_secret_refs.is_empty()
+                    || request.connector_conn_ref.is_some()
+                    || request.extra_options.is_some()
+                {
+                    return Err(Status::invalid_argument(
+                        "CDC table snapshot options do not support secrets, connections, or extra options",
+                    ));
+                }
+                let props = request
+                    .changed_props
+                    .clone()
+                    .into_iter()
+                    .collect::<BTreeMap<_, _>>();
+                self.metadata_manager
+                    .catalog_controller
+                    .update_cdc_table_snapshot_options_by_table_id(
+                        request.object_id.into(),
+                        props.clone(),
+                    )
+                    .await?;
+                (props.into_iter().collect(), request.object_id.into())
+            }
+
             Ok(AlterConnectorPropsObject::Source) => {
                 // alter source and table's associated source
                 if request.connector_conn_ref.is_some() {
@@ -861,11 +885,15 @@ impl StreamManagerService for StreamServiceImpl {
             .catalog_controller
             .get_object_database_id(object_id)
             .await?;
-        // Connection updates are broadcast to dependent sources/sinks inside the `Connection` branch above.
+        // Connection updates are broadcast to dependent sources/sinks inside the `Connection`
+        // branch above. CDC table snapshot options intentionally stay metadata-only until recovery.
         // For sources/sinks/iceberg-table updates, broadcast the change to the object itself.
-        if AlterConnectorPropsObject::try_from(request.object_type)
-            .is_ok_and(|t| t != AlterConnectorPropsObject::Connection)
-        {
+        if AlterConnectorPropsObject::try_from(request.object_type).is_ok_and(|t| {
+            !matches!(
+                t,
+                AlterConnectorPropsObject::Connection | AlterConnectorPropsObject::CdcTable
+            )
+        }) {
             let mut mutation = HashMap::default();
             mutation.insert(object_id, new_props_plaintext);
             let _version = self

--- a/src/meta/src/controller/streaming_job.rs
+++ b/src/meta/src/controller/streaming_job.rs
@@ -3647,12 +3647,15 @@ impl TryFrom<&BTreeMap<String, String>> for CdcSnapshotOptionsUpdate {
         for (key, value) in props {
             match key.as_str() {
                 CDC_BACKFILL_SNAPSHOT_INTERVAL_KEY => {
-                    update.snapshot_barrier_interval =
-                        Some(value.parse::<u32>().map_err(|_| {
-                            MetaError::invalid_parameter(format!(
-                                "Invalid value for {key}: {value}"
-                            ))
-                        })?);
+                    let parsed = value.parse::<u32>().map_err(|_| {
+                        MetaError::invalid_parameter(format!("Invalid value for {key}: {value}"))
+                    })?;
+                    if parsed == 0 {
+                        return Err(MetaError::invalid_parameter(format!(
+                            "{CDC_BACKFILL_SNAPSHOT_INTERVAL_KEY} must be greater than 0"
+                        )));
+                    }
+                    update.snapshot_barrier_interval = Some(parsed);
                 }
                 CDC_BACKFILL_SNAPSHOT_BATCH_SIZE_KEY => {
                     let parsed = value.parse::<u32>().map_err(|_| {
@@ -3887,6 +3890,11 @@ mod tests {
             CDC_BACKFILL_SNAPSHOT_BATCH_SIZE_KEY.to_owned() => "0".to_owned(),
         };
         assert!(CdcSnapshotOptionsUpdate::try_from(&zero_batch_size).is_err());
+
+        let zero_interval = btreemap! {
+            CDC_BACKFILL_SNAPSHOT_INTERVAL_KEY.to_owned() => "0".to_owned(),
+        };
+        assert!(CdcSnapshotOptionsUpdate::try_from(&zero_interval).is_err());
 
         let unsupported_option = btreemap! {
             "snapshot.unsupported".to_owned() => "1".to_owned(),

--- a/src/meta/src/controller/streaming_job.rs
+++ b/src/meta/src/controller/streaming_job.rs
@@ -71,7 +71,7 @@ use risingwave_pb::stream_plan::stream_fragment_graph::Parallelism;
 use risingwave_pb::stream_plan::stream_node::PbNodeBody;
 use risingwave_pb::stream_plan::{PbSinkLogStoreType, PbStreamNode, StreamScanType};
 use risingwave_pb::user::PbUserInfo;
-use risingwave_sqlparser::ast::{Engine, SqlOption, Statement};
+use risingwave_sqlparser::ast::{Engine, SqlOption, SqlOptionValue, Statement, Value};
 use risingwave_sqlparser::parser::{Parser, ParserError};
 use sea_orm::ActiveValue::Set;
 use sea_orm::sea_query::{Expr, Query, SimpleExpr};
@@ -1158,6 +1158,37 @@ impl CatalogController {
         Ok(())
     }
 
+    async fn ensure_cdc_snapshot_options_not_stale(
+        txn: &DatabaseTransaction,
+        streaming_job: &StreamingJob,
+    ) -> MetaResult<()> {
+        let StreamingJob::Table(_, replacement_table, _) = streaming_job else {
+            return Ok(());
+        };
+        if replacement_table.cdc_table_id.is_none() {
+            return Ok(());
+        }
+
+        let current_definition: String = Table::find_by_id(replacement_table.id)
+            .select_only()
+            .column(table::Column::Definition)
+            .into_tuple()
+            .one(txn)
+            .await?
+            .ok_or_else(|| {
+                MetaError::catalog_id_not_found(ObjectType::Table.as_str(), replacement_table.id)
+            })?;
+        if cdc_snapshot_options_from_definition(&current_definition)?
+            != cdc_snapshot_options_from_definition(&replacement_table.definition)?
+        {
+            return Err(MetaError::permission_denied(
+                "CDC snapshot options in the replacement plan are stale",
+            ));
+        }
+
+        Ok(())
+    }
+
     pub async fn create_job_catalog_for_replace(
         &self,
         streaming_job: &StreamingJob,
@@ -1171,6 +1202,7 @@ impl CatalogController {
 
         // 1. check version.
         streaming_job.verify_version_for_replace(&txn).await?;
+        Self::ensure_cdc_snapshot_options_not_stale(&txn, streaming_job).await?;
         // 2. check concurrent replace.
         Self::ensure_job_not_being_altered_or_referenced(&txn, id).await?;
 
@@ -2780,20 +2812,6 @@ impl CatalogController {
         // temporary job depends on this table and must finish before the options can be changed.
         Self::ensure_job_not_being_altered_or_referenced(&txn, table.job_id()).await?;
 
-        // Advancing the version makes a replacement plan generated before this transaction stale.
-        // It prevents that replacement from silently restoring the previous snapshot options.
-        let mut version = table
-            .version
-            .as_ref()
-            .ok_or_else(|| {
-                MetaError::invalid_parameter(format!("table {table_id} has no version"))
-            })?
-            .to_protobuf();
-        version.version = version
-            .version
-            .checked_add(1)
-            .ok_or_else(|| MetaError::invalid_parameter("table version overflow"))?;
-
         let [mut stmt]: [_; 1] = Parser::parse_sql(&table.definition)
             .map_err(|e| MetaError::invalid_parameter(e.to_report_string()))?
             .try_into()
@@ -2830,7 +2848,6 @@ impl CatalogController {
         Table::update(table::ActiveModel {
             table_id: Set(table_id),
             definition: Set(stmt.to_string()),
-            version: Set(Some((&version).into())),
             ..Default::default()
         })
         .exec(&txn)
@@ -3630,6 +3647,44 @@ fn update_stmt_with_props(
     Ok(())
 }
 
+fn cdc_snapshot_options_from_definition(definition: &str) -> MetaResult<BTreeMap<String, String>> {
+    let [stmt]: [_; 1] = Parser::parse_sql(definition)
+        .map_err(|e| MetaError::invalid_parameter(e.to_report_string()))?
+        .try_into()
+        .map_err(|_| MetaError::invalid_parameter("expected exactly one table definition"))?;
+    let Statement::CreateTable { with_options, .. } = stmt else {
+        return Err(MetaError::invalid_parameter(
+            "expected a CREATE TABLE definition",
+        ));
+    };
+
+    with_options
+        .into_iter()
+        .filter_map(|option| {
+            let key = option.name.real_value();
+            matches!(
+                key.as_str(),
+                CDC_BACKFILL_SNAPSHOT_BATCH_SIZE_KEY | CDC_BACKFILL_SNAPSHOT_INTERVAL_KEY
+            )
+            .then_some((key, option.value))
+        })
+        .map(|(key, value)| {
+            let value = match value {
+                SqlOptionValue::Value(Value::CstyleEscapedString(value)) => value.value,
+                SqlOptionValue::Value(Value::SingleQuotedString(value))
+                | SqlOptionValue::Value(Value::Number(value)) => value,
+                SqlOptionValue::Value(Value::Boolean(value)) => value.to_string(),
+                _ => {
+                    return Err(MetaError::invalid_parameter(format!(
+                        "invalid value for CDC snapshot option '{key}'"
+                    )));
+                }
+            };
+            Ok((key, value))
+        })
+        .collect()
+}
+
 #[derive(Debug, PartialEq)]
 struct CdcSnapshotOptionsUpdate {
     snapshot_barrier_interval: Option<u32>,
@@ -3941,5 +3996,28 @@ mod tests {
                 ("snapshot.interval".to_owned(), "'7'".to_owned())
             ]
         );
+    }
+
+    #[test]
+    fn test_extract_cdc_snapshot_options_from_definition() {
+        let numeric = cdc_snapshot_options_from_definition(
+            r#"CREATE TABLE t (v INT) WITH (
+                "snapshot.batch_size" = 2048,
+                "snapshot"."interval" = 7,
+                unrelated = 'value'
+            )"#,
+        )
+        .unwrap();
+        let quoted = cdc_snapshot_options_from_definition(
+            "CREATE TABLE t (v INT) WITH (snapshot.batch_size = '2048', snapshot.interval = '7')",
+        )
+        .unwrap();
+        let stale = cdc_snapshot_options_from_definition(
+            "CREATE TABLE t (v INT) WITH (snapshot.batch_size = '1024', snapshot.interval = '7')",
+        )
+        .unwrap();
+
+        assert_eq!(numeric, quoted);
+        assert_ne!(numeric, stale);
     }
 }

--- a/src/meta/src/controller/streaming_job.rs
+++ b/src/meta/src/controller/streaming_job.rs
@@ -38,6 +38,9 @@ use risingwave_connector::connector_common::validate_connection;
 use risingwave_connector::error::ConnectorError;
 use risingwave_connector::sink::file_sink::fs::FsSink;
 use risingwave_connector::sink::{CONNECTOR_TYPE_KEY, SinkError};
+use risingwave_connector::source::cdc::{
+    CDC_BACKFILL_SNAPSHOT_BATCH_SIZE_KEY, CDC_BACKFILL_SNAPSHOT_INTERVAL_KEY, CdcScanOptions,
+};
 use risingwave_connector::source::{
     ConnectorProperties, UPSTREAM_SOURCE_KEY, pb_connection_type_to_connection_type,
 };
@@ -2744,6 +2747,104 @@ impl CatalogController {
         Ok(props.into_iter().collect())
     }
 
+    /// Persists CDC snapshot options in the table definition and stream plan.
+    /// Running actors pick up the updated plan after recovery.
+    pub async fn update_cdc_table_snapshot_options_by_table_id(
+        &self,
+        table_id: TableId,
+        props: BTreeMap<String, String>,
+    ) -> MetaResult<()> {
+        let snapshot_options_update = CdcSnapshotOptionsUpdate::try_from(&props)?;
+        let inner = self.inner.read().await;
+        let txn = inner.db.begin().await?;
+
+        let table = Table::find_by_id(table_id)
+            .one(&txn)
+            .await?
+            .ok_or_else(|| MetaError::catalog_id_not_found(ObjectType::Table.as_str(), table_id))?;
+        if table.cdc_table_id.is_none() {
+            return Err(MetaError::invalid_parameter(format!(
+                "table {table_id} is not a CDC table"
+            )));
+        }
+
+        let [mut stmt]: [_; 1] = Parser::parse_sql(&table.definition)
+            .map_err(|e| MetaError::invalid_parameter(e.to_report_string()))?
+            .try_into()
+            .unwrap();
+        if let Statement::CreateTable { with_options, .. } = &mut stmt {
+            update_stmt_with_props(with_options, &props)?;
+        } else {
+            return Err(MetaError::invalid_parameter(format!(
+                "table {table_id} has an invalid CDC table definition"
+            )));
+        }
+
+        let fragments: Vec<(FragmentId, StreamNode)> = Fragment::find()
+            .select_only()
+            .columns([fragment::Column::FragmentId, fragment::Column::StreamNode])
+            .filter(fragment::Column::JobId.eq(table.job_id()))
+            .into_tuple()
+            .all(&txn)
+            .await?;
+        let mut updated_fragments = Vec::new();
+        for (fragment_id, stream_node) in fragments {
+            let mut stream_node = stream_node.to_protobuf();
+            if apply_cdc_snapshot_options_to_stream_node(&mut stream_node, &snapshot_options_update)
+            {
+                updated_fragments.push((fragment_id, stream_node));
+            }
+        }
+        if updated_fragments.is_empty() {
+            return Err(MetaError::invalid_parameter(format!(
+                "table {table_id} has no CDC scan node"
+            )));
+        }
+
+        Table::update(table::ActiveModel {
+            table_id: Set(table_id),
+            definition: Set(stmt.to_string()),
+            ..Default::default()
+        })
+        .exec(&txn)
+        .await?;
+        for (fragment_id, stream_node) in updated_fragments {
+            Fragment::update(fragment::ActiveModel {
+                fragment_id: Set(fragment_id),
+                stream_node: Set(StreamNode::from(&stream_node)),
+                ..Default::default()
+            })
+            .exec(&txn)
+            .await?;
+        }
+
+        let (table, obj) = Table::find_by_id(table_id)
+            .find_also_related(Object)
+            .one(&txn)
+            .await?
+            .ok_or_else(|| MetaError::catalog_id_not_found(ObjectType::Table.as_str(), table_id))?;
+        let streaming_job = StreamingJobModel::find_by_id(table.job_id())
+            .one(&txn)
+            .await?;
+        txn.commit().await?;
+        drop(inner);
+
+        self.notify_frontend(
+            NotificationOperation::Update,
+            NotificationInfo::ObjectGroup(PbObjectGroup {
+                objects: vec![PbObject {
+                    object_info: Some(PbObjectInfo::Table(
+                        ObjectModel(table, obj.unwrap(), streaming_job).into(),
+                    )),
+                }],
+                dependencies: vec![],
+            }),
+        )
+        .await;
+
+        Ok(())
+    }
+
     pub async fn update_iceberg_table_props_by_table_id(
         &self,
         table_id: TableId,
@@ -3502,6 +3603,81 @@ fn update_stmt_with_props(
     Ok(())
 }
 
+#[derive(Debug, PartialEq)]
+struct CdcSnapshotOptionsUpdate {
+    snapshot_barrier_interval: Option<u32>,
+    snapshot_batch_size: Option<u32>,
+}
+
+impl TryFrom<&BTreeMap<String, String>> for CdcSnapshotOptionsUpdate {
+    type Error = MetaError;
+
+    fn try_from(props: &BTreeMap<String, String>) -> Result<Self, Self::Error> {
+        let mut update = Self {
+            snapshot_barrier_interval: None,
+            snapshot_batch_size: None,
+        };
+        for (key, value) in props {
+            let parsed = value.parse::<u32>().map_err(|_| {
+                MetaError::invalid_parameter(format!("Invalid value for {key}: {value}"))
+            })?;
+            match key.as_str() {
+                CDC_BACKFILL_SNAPSHOT_INTERVAL_KEY => {
+                    update.snapshot_barrier_interval = Some(parsed);
+                }
+                CDC_BACKFILL_SNAPSHOT_BATCH_SIZE_KEY => {
+                    update.snapshot_batch_size = Some(parsed);
+                }
+                _ => {
+                    return Err(MetaError::invalid_parameter(format!(
+                        "CDC table snapshot option '{key}' cannot be altered"
+                    )));
+                }
+            }
+        }
+        if props.is_empty() {
+            return Err(MetaError::invalid_parameter(
+                "no CDC table snapshot option was specified",
+            ));
+        }
+        Ok(update)
+    }
+}
+
+impl CdcSnapshotOptionsUpdate {
+    fn apply(&self, options: &mut CdcScanOptions) {
+        if let Some(snapshot_barrier_interval) = self.snapshot_barrier_interval {
+            options.snapshot_barrier_interval = snapshot_barrier_interval;
+        }
+        if let Some(snapshot_batch_size) = self.snapshot_batch_size {
+            options.snapshot_batch_size = snapshot_batch_size;
+        }
+    }
+}
+
+fn apply_cdc_snapshot_options_to_stream_node(
+    stream_node: &mut PbStreamNode,
+    update: &CdcSnapshotOptionsUpdate,
+) -> bool {
+    let mut found = false;
+    visit_stream_node_mut(stream_node, |node| {
+        if let PbNodeBody::StreamCdcScan(node) = node {
+            let mut options = node
+                .options
+                .as_ref()
+                .map(CdcScanOptions::from_proto)
+                .unwrap_or(CdcScanOptions {
+                    disable_backfill: node.disable_backfill,
+                    ..Default::default()
+                });
+            update.apply(&mut options);
+            node.options = Some(options.to_proto());
+            found = true;
+        }
+    });
+    found
+}
+
 async fn update_sink_fragment_props(
     txn: &DatabaseTransaction,
     sink_id: SinkId,
@@ -3622,4 +3798,57 @@ where
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use maplit::btreemap;
+    use risingwave_pb::stream_plan::StreamCdcScanNode;
+
+    use super::*;
+
+    #[test]
+    fn test_apply_cdc_snapshot_options_to_stream_node() {
+        let update = CdcSnapshotOptionsUpdate::try_from(&btreemap! {
+            CDC_BACKFILL_SNAPSHOT_INTERVAL_KEY.to_owned() => "7".to_owned(),
+            CDC_BACKFILL_SNAPSHOT_BATCH_SIZE_KEY.to_owned() => "2048".to_owned(),
+        })
+        .unwrap();
+        let original_options = CdcScanOptions {
+            backfill_parallelism: 4,
+            ..Default::default()
+        };
+        let mut stream_node = PbStreamNode {
+            node_body: Some(PbNodeBody::StreamCdcScan(Box::new(StreamCdcScanNode {
+                options: Some(original_options.to_proto()),
+                ..Default::default()
+            }))),
+            ..Default::default()
+        };
+
+        assert!(apply_cdc_snapshot_options_to_stream_node(
+            &mut stream_node,
+            &update
+        ));
+        let PbNodeBody::StreamCdcScan(cdc_scan) = stream_node.node_body.unwrap() else {
+            unreachable!()
+        };
+        let options = CdcScanOptions::from_proto(cdc_scan.options.as_ref().unwrap());
+        assert_eq!(options.snapshot_barrier_interval, 7);
+        assert_eq!(options.snapshot_batch_size, 2048);
+        assert_eq!(options.backfill_parallelism, 4);
+    }
+
+    #[test]
+    fn test_reject_invalid_cdc_snapshot_options_update() {
+        let invalid_value = btreemap! {
+            CDC_BACKFILL_SNAPSHOT_BATCH_SIZE_KEY.to_owned() => "invalid".to_owned(),
+        };
+        assert!(CdcSnapshotOptionsUpdate::try_from(&invalid_value).is_err());
+
+        let unsupported_option = btreemap! {
+            "snapshot.unsupported".to_owned() => "1".to_owned(),
+        };
+        assert!(CdcSnapshotOptionsUpdate::try_from(&unsupported_option).is_err());
+    }
 }

--- a/src/meta/src/controller/streaming_job.rs
+++ b/src/meta/src/controller/streaming_job.rs
@@ -1132,6 +1132,32 @@ impl CatalogController {
         Ok(())
     }
 
+    async fn ensure_job_not_being_altered_or_referenced(
+        txn: &DatabaseTransaction,
+        job_id: JobId,
+    ) -> MetaResult<()> {
+        let referring_cnt = ObjectDependency::find()
+            .join(
+                JoinType::InnerJoin,
+                object_dependency::Relation::Object1.def(),
+            )
+            .join(JoinType::InnerJoin, object::Relation::StreamingJob.def())
+            .filter(
+                object_dependency::Column::Oid
+                    .eq(job_id)
+                    .and(object::Column::ObjType.eq(ObjectType::Table))
+                    .and(streaming_job::Column::JobStatus.ne(JobStatus::Created)),
+            )
+            .count(txn)
+            .await?;
+        if referring_cnt != 0 {
+            return Err(MetaError::permission_denied(
+                "job is being altered or referenced by some creating jobs",
+            ));
+        }
+        Ok(())
+    }
+
     pub async fn create_job_catalog_for_replace(
         &self,
         streaming_job: &StreamingJob,
@@ -1146,25 +1172,7 @@ impl CatalogController {
         // 1. check version.
         streaming_job.verify_version_for_replace(&txn).await?;
         // 2. check concurrent replace.
-        let referring_cnt = ObjectDependency::find()
-            .join(
-                JoinType::InnerJoin,
-                object_dependency::Relation::Object1.def(),
-            )
-            .join(JoinType::InnerJoin, object::Relation::StreamingJob.def())
-            .filter(
-                object_dependency::Column::Oid
-                    .eq(id)
-                    .and(object::Column::ObjType.eq(ObjectType::Table))
-                    .and(streaming_job::Column::JobStatus.ne(JobStatus::Created)),
-            )
-            .count(&txn)
-            .await?;
-        if referring_cnt != 0 {
-            return Err(MetaError::permission_denied(
-                "job is being altered or referenced by some creating jobs",
-            ));
-        }
+        Self::ensure_job_not_being_altered_or_referenced(&txn, id).await?;
 
         // 3. check parallelism.
         let original_job = StreamingJobModel::find_by_id(id)
@@ -2755,7 +2763,7 @@ impl CatalogController {
         props: BTreeMap<String, String>,
     ) -> MetaResult<()> {
         let snapshot_options_update = CdcSnapshotOptionsUpdate::try_from(&props)?;
-        let inner = self.inner.read().await;
+        let inner = self.inner.write().await;
         let txn = inner.db.begin().await?;
 
         let table = Table::find_by_id(table_id)
@@ -2767,6 +2775,24 @@ impl CatalogController {
                 "table {table_id} is not a CDC table"
             )));
         }
+
+        // Serialize with streaming job replacement. If a replacement has already started, its
+        // temporary job depends on this table and must finish before the options can be changed.
+        Self::ensure_job_not_being_altered_or_referenced(&txn, table.job_id()).await?;
+
+        // Advancing the version makes a replacement plan generated before this transaction stale.
+        // It prevents that replacement from silently restoring the previous snapshot options.
+        let mut version = table
+            .version
+            .as_ref()
+            .ok_or_else(|| {
+                MetaError::invalid_parameter(format!("table {table_id} has no version"))
+            })?
+            .to_protobuf();
+        version.version = version
+            .version
+            .checked_add(1)
+            .ok_or_else(|| MetaError::invalid_parameter("table version overflow"))?;
 
         let [mut stmt]: [_; 1] = Parser::parse_sql(&table.definition)
             .map_err(|e| MetaError::invalid_parameter(e.to_report_string()))?
@@ -2804,6 +2830,7 @@ impl CatalogController {
         Table::update(table::ActiveModel {
             table_id: Set(table_id),
             definition: Set(stmt.to_string()),
+            version: Set(Some((&version).into())),
             ..Default::default()
         })
         .exec(&txn)
@@ -3587,7 +3614,7 @@ fn update_stmt_with_props(
 ) -> MetaResult<()> {
     let mut new_sql_options = with_properties
         .iter()
-        .map(|sql_option| (&sql_option.name, sql_option))
+        .map(|sql_option| (sql_option.name.real_value(), sql_option))
         .collect::<IndexMap<_, _>>();
     let add_sql_options = props
         .iter()
@@ -3597,7 +3624,7 @@ fn update_stmt_with_props(
     new_sql_options.extend(
         add_sql_options
             .iter()
-            .map(|sql_option| (&sql_option.name, sql_option)),
+            .map(|sql_option| (sql_option.name.real_value(), sql_option)),
     );
     *with_properties = new_sql_options.into_values().cloned().collect();
     Ok(())
@@ -3618,14 +3645,24 @@ impl TryFrom<&BTreeMap<String, String>> for CdcSnapshotOptionsUpdate {
             snapshot_batch_size: None,
         };
         for (key, value) in props {
-            let parsed = value.parse::<u32>().map_err(|_| {
-                MetaError::invalid_parameter(format!("Invalid value for {key}: {value}"))
-            })?;
             match key.as_str() {
                 CDC_BACKFILL_SNAPSHOT_INTERVAL_KEY => {
-                    update.snapshot_barrier_interval = Some(parsed);
+                    update.snapshot_barrier_interval =
+                        Some(value.parse::<u32>().map_err(|_| {
+                            MetaError::invalid_parameter(format!(
+                                "Invalid value for {key}: {value}"
+                            ))
+                        })?);
                 }
                 CDC_BACKFILL_SNAPSHOT_BATCH_SIZE_KEY => {
+                    let parsed = value.parse::<u32>().map_err(|_| {
+                        MetaError::invalid_parameter(format!("Invalid value for {key}: {value}"))
+                    })?;
+                    if parsed == 0 {
+                        return Err(MetaError::invalid_parameter(format!(
+                            "{CDC_BACKFILL_SNAPSHOT_BATCH_SIZE_KEY} must be greater than 0"
+                        )));
+                    }
                     update.snapshot_batch_size = Some(parsed);
                 }
                 _ => {
@@ -3846,9 +3883,55 @@ mod tests {
         };
         assert!(CdcSnapshotOptionsUpdate::try_from(&invalid_value).is_err());
 
+        let zero_batch_size = btreemap! {
+            CDC_BACKFILL_SNAPSHOT_BATCH_SIZE_KEY.to_owned() => "0".to_owned(),
+        };
+        assert!(CdcSnapshotOptionsUpdate::try_from(&zero_batch_size).is_err());
+
         let unsupported_option = btreemap! {
             "snapshot.unsupported".to_owned() => "1".to_owned(),
         };
         assert!(CdcSnapshotOptionsUpdate::try_from(&unsupported_option).is_err());
+    }
+
+    #[test]
+    fn test_update_stmt_with_quoted_cdc_snapshot_options() {
+        let [
+            Statement::CreateTable {
+                mut with_options, ..
+            },
+        ]: [_; 1] = Parser::parse_sql(
+            r#"CREATE TABLE t (v INT) WITH (
+                "snapshot.batch_size" = '1',
+                "snapshot"."interval" = '1'
+            )"#,
+        )
+        .unwrap()
+        .try_into()
+        .unwrap()
+        else {
+            unreachable!()
+        };
+
+        update_stmt_with_props(
+            &mut with_options,
+            &btreemap! {
+                CDC_BACKFILL_SNAPSHOT_BATCH_SIZE_KEY.to_owned() => "2048".to_owned(),
+                CDC_BACKFILL_SNAPSHOT_INTERVAL_KEY.to_owned() => "7".to_owned(),
+            },
+        )
+        .unwrap();
+
+        assert_eq!(with_options.len(), 2);
+        assert_eq!(
+            with_options
+                .iter()
+                .map(|option| (option.name.real_value(), option.value.to_string()))
+                .collect_vec(),
+            vec![
+                ("snapshot.batch_size".to_owned(), "'2048'".to_owned()),
+                ("snapshot.interval".to_owned(), "'7'".to_owned())
+            ]
+        );
     }
 }

--- a/src/rpc_client/src/meta_client.rs
+++ b/src/rpc_client/src/meta_client.rs
@@ -1569,6 +1569,23 @@ impl MetaClient {
         Ok(())
     }
 
+    pub async fn alter_cdc_table_snapshot_options(
+        &self,
+        table_id: TableId,
+        changed_props: BTreeMap<String, String>,
+    ) -> Result<()> {
+        let req = AlterConnectorPropsRequest {
+            object_id: table_id.as_raw_id(),
+            changed_props: changed_props.into_iter().collect(),
+            changed_secret_refs: Default::default(),
+            connector_conn_ref: None,
+            object_type: AlterConnectorPropsObject::CdcTable as i32,
+            extra_options: None,
+        };
+        let _resp = self.inner.alter_connector_props(req).await?;
+        Ok(())
+    }
+
     pub async fn alter_source_connector_props(
         &self,
         source_id: SourceId,


### PR DESCRIPTION
Backports #26833 onto silver/cherry-pick-26708-3.0.

## What is changed

- Allow CDC tables to alter snapshot.batch_size and snapshot.interval through ALTER TABLE CONNECTOR WITH.
- Persist and validate positive snapshot option values while preserving unrelated scan options.
- Preserve the live DML schema version during metadata-only snapshot option changes and reject stale replacement plans.
- Add unit coverage and a MySQL CDC serial SQLLogicTest.

## Verification

- Source commits were backported without pulling unrelated main-branch changes from the latest merge commit.
- cargo fmt --all -- --check
- cargo test -p risingwave_meta test_extract_cdc_snapshot_options_from_definition