### PR TITLE
feat(iceberg): include pending rows in batch reads

### DIFF
--- a/e2e_test/iceberg/test_case/pure_slt/iceberg_engine_append_only.slt
+++ b/e2e_test/iceberg/test_case/pure_slt/iceberg_engine_append_only.slt
@@ -20,6 +20,23 @@ with (
 statement ok
 set iceberg_engine_connection = 'public.my_conn';
 
+# Batch reads include rows that are durable in the sink log store but have not reached an Iceberg
+# snapshot yet.
+statement ok
+create table t_realtime(id int primary key, name varchar) APPEND ONLY
+with(commit_checkpoint_interval = 1000) engine = iceberg;
+
+statement ok
+insert into t_realtime values(1, 'pending');
+
+query ?? retry 6 backoff 1s
+select * from t_realtime;
+----
+1 pending
+
+statement ok
+DROP TABLE t_realtime;
+
 statement ok
 create table t(id int primary key, name varchar) APPEND ONLY
 with(commit_checkpoint_interval = 1) engine = iceberg;
@@ -34,6 +51,16 @@ query ?? retry 6 backoff 1s
 select * from t;
 ----
 1 xxx
+
+query T retry 6 backoff 1s
+select summary->>'risingwave.commit.epoch' is not null
+from rw_iceberg_snapshots
+where schema_name = 'public'
+and source_name = '__iceberg_source_t'
+order by sequence_number desc
+limit 1;
+----
+t
 
 query ??
 select * from t for system_time as of '2222-12-10 11:48:06';

--- a/src/common/src/catalog/mod.rs
+++ b/src/common/src/catalog/mod.rs
@@ -145,6 +145,11 @@ pub const CDC_TABLE_NAME_COLUMN_NAME: &str = "_rw_table_name";
 pub const ICEBERG_SOURCE_PREFIX: &str = "__iceberg_source_";
 pub const ICEBERG_SINK_PREFIX: &str = "__iceberg_sink_";
 
+/// Iceberg snapshot summary property containing the highest RisingWave epoch committed by the
+/// sink. Append-only Iceberg engine batch reads use it to exclude committed rows from the sink
+/// log store.
+pub const RISINGWAVE_ICEBERG_COMMIT_EPOCH: &str = "risingwave.commit.epoch";
+
 /// The local system catalog reader in the frontend node.
 pub trait SysCatalogReader: Sync + Send + 'static {
     /// Reads the data of the system catalog table.

--- a/src/common/src/constants.rs
+++ b/src/common/src/constants.rs
@@ -45,6 +45,18 @@ pub mod log_store {
     pub const SEQ_ID_COLUMN_TYPE: DataType = DataType::Int32;
     pub const ROW_OP_COLUMN_TYPE: DataType = DataType::Int16;
     pub const VNODE_COLUMN_TYPE: DataType = DataType::Int16;
+    pub const INSERT_OP_CODE: i16 = 1;
+
+    /// Encode an unsigned RisingWave epoch so that its signed integer ordering is preserved in
+    /// the log-store primary key.
+    pub const fn encode_epoch(epoch: u64) -> i64 {
+        epoch as i64 ^ (1i64 << 63)
+    }
+
+    /// Decode an epoch stored by [`encode_epoch`].
+    pub const fn decode_epoch(encoded_epoch: i64) -> u64 {
+        encoded_epoch as u64 ^ (1u64 << 63)
+    }
 
     pub mod v1 {
         use std::sync::LazyLock;

--- a/src/connector/src/sink/iceberg/commit.rs
+++ b/src/connector/src/sink/iceberg/commit.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -28,7 +29,7 @@ use risingwave_common::array::arrow::arrow_schema_iceberg::{
 };
 use risingwave_common::array::arrow::{IcebergArrowConvert, IcebergCreateTableArrowConvert};
 use risingwave_common::bail;
-use risingwave_common::catalog::Field;
+use risingwave_common::catalog::{Field, RISINGWAVE_ICEBERG_COMMIT_EPOCH};
 use risingwave_common::error::IcebergError;
 use risingwave_pb::connector_service::SinkMetadata;
 use risingwave_pb::connector_service::sink_metadata::Metadata::Serialized;
@@ -739,6 +740,10 @@ impl IcebergSinkCommitter {
                         .fast_append()
                         .set_snapshot_id(snapshot_id)
                         .set_target_branch(target_branch.clone())
+                        .set_snapshot_properties(HashMap::from([(
+                            RISINGWAVE_ICEBERG_COMMIT_EPOCH.to_owned(),
+                            epoch.to_string(),
+                        )]))
                         .add_data_files(data_files);
 
                     let tx = append_action.apply(txn).map_err(|err| {

--- a/src/frontend/src/optimizer/optimizer_context.rs
+++ b/src/frontend/src/optimizer/optimizer_context.rs
@@ -19,6 +19,7 @@ use std::marker::PhantomData;
 use std::rc::{Rc, Weak};
 use std::sync::Arc;
 
+use risingwave_common::id::SourceId;
 use risingwave_sqlparser::ast::{ExplainFormat, ExplainOptions, ExplainType};
 
 use super::property::WatermarkGroupId;
@@ -100,9 +101,9 @@ pub struct OptimizerContext {
     /// Store the configs can be overwritten in with clause
     /// if not specified, use the value from session variable.
     overwrite_options: OverwriteOptions,
-    /// Mapping from iceberg table identifier to current snapshot id.
-    /// Used to keep same snapshot id when multiple scans from the same iceberg table exist in a query.
-    iceberg_snapshot_id_map: RefCell<HashMap<String, Option<i64>>>,
+    /// Mapping from Iceberg table identifier to the current snapshot and its RisingWave commit
+    /// boundary. Used to keep multiple scans of the same table consistent within one query.
+    iceberg_snapshot_info_map: RefCell<HashMap<SourceId, Option<IcebergSnapshotInfo>>>,
     /// Batch materialized view candidates for exact-match rewriting.
     batch_mview_candidates: RefCell<Vec<MaterializedViewCandidate>>,
 
@@ -128,6 +129,12 @@ pub struct OptimizerContext {
 pub struct MaterializedViewCandidate {
     pub plan: LogicalPlanRef,
     pub table: Arc<TableCatalog>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct IcebergSnapshotInfo {
+    pub(crate) snapshot_id: i64,
+    pub(crate) commit_epoch: Option<u64>,
 }
 
 pub(in crate::optimizer) struct LastAssignedIds {
@@ -163,7 +170,7 @@ impl OptimizerContext {
             session_timezone,
             total_rule_applied: RefCell::new(0),
             overwrite_options,
-            iceberg_snapshot_id_map: RefCell::new(HashMap::new()),
+            iceberg_snapshot_info_map: RefCell::new(HashMap::new()),
             batch_mview_candidates: RefCell::new(Vec::new()),
 
             last_plan_node_id: Cell::new(RESERVED_ID_NUM.into()),
@@ -192,7 +199,7 @@ impl OptimizerContext {
             session_timezone: RefCell::new(SessionTimezone::new("UTC".into())),
             total_rule_applied: RefCell::new(0),
             overwrite_options: OverwriteOptions::default(),
-            iceberg_snapshot_id_map: RefCell::new(HashMap::new()),
+            iceberg_snapshot_info_map: RefCell::new(HashMap::new()),
             batch_mview_candidates: RefCell::new(Vec::new()),
 
             last_plan_node_id: Cell::new(0),
@@ -448,8 +455,10 @@ impl OptimizerContext {
         self.session_timezone.borrow().timezone()
     }
 
-    pub fn iceberg_snapshot_id_map(&self) -> RefMut<'_, HashMap<String, Option<i64>>> {
-        self.iceberg_snapshot_id_map.borrow_mut()
+    pub(crate) fn iceberg_snapshot_info_map(
+        &self,
+    ) -> RefMut<'_, HashMap<SourceId, Option<IcebergSnapshotInfo>>> {
+        self.iceberg_snapshot_info_map.borrow_mut()
     }
 }
 

--- a/src/frontend/src/optimizer/rule/iceberg_engine_storage_selection_rule.rs
+++ b/src/frontend/src/optimizer/rule/iceberg_engine_storage_selection_rule.rs
@@ -44,6 +44,13 @@ impl InfallibleRule<Logical> for IcebergEngineStorageSelectionRule {
         let source_catalog = scan.source_catalog()?;
         let table = get_table_from_iceberg_source(session, source_catalog)?;
 
+        // Append-only Iceberg engine tables do not materialize rows in their Hummock table. Their
+        // batch plan combines Iceberg with the sink log store, so rewriting the Iceberg side to
+        // the dummy Hummock table would silently drop committed rows.
+        if table.append_only {
+            return None;
+        }
+
         let prefer_rowstore = check_point_lookup(scan, &table);
         if !prefer_rowstore {
             return None;

--- a/src/frontend/src/planner/relation.rs
+++ b/src/frontend/src/planner/relation.rs
@@ -16,13 +16,19 @@ use std::collections::HashMap;
 use std::ops::Deref;
 use std::rc::Rc;
 
+use iceberg::spec::{Operation, TableMetadata};
 use itertools::Itertools;
 use risingwave_common::bail_not_implemented;
 use risingwave_common::catalog::{
-    ColumnCatalog, Engine, Field, RISINGWAVE_ICEBERG_ROW_ID, ROW_ID_COLUMN_NAME, Schema,
+    ColumnCatalog, Engine, Field, RISINGWAVE_ICEBERG_COMMIT_EPOCH, RISINGWAVE_ICEBERG_ROW_ID,
+    ROW_ID_COLUMN_NAME, Schema,
+};
+use risingwave_common::constants::log_store::{
+    EPOCH_COLUMN_NAME, INSERT_OP_CODE, ROW_OP_COLUMN_NAME, encode_epoch,
 };
 use risingwave_common::session_config::IcebergQueryStorageMode;
 use risingwave_common::types::{DataType, Interval, ScalarImpl};
+use risingwave_common::util::iter_util::ZipEqFast;
 use risingwave_connector::source::ConnectorProperties;
 use risingwave_connector::source::iceberg::IcebergTimeTravelInfo;
 use risingwave_sqlparser::ast::AsOf;
@@ -36,12 +42,14 @@ use crate::binder::{
 use crate::catalog::source_catalog::SourceCatalog;
 use crate::error::{ErrorCode, Result};
 use crate::expr::{CastContext, Expr, ExprImpl, ExprType, FunctionCall, InputRef, Literal};
-use crate::optimizer::plan_node::generic::{GenericPlanRef, SourceNodeKind};
+use crate::optimizer::IcebergSnapshotInfo;
+use crate::optimizer::plan_node::generic::{self, GenericPlanRef, SourceNodeKind};
 use crate::optimizer::plan_node::utils::to_iceberg_time_travel_as_of;
 use crate::optimizer::plan_node::{
     LogicalApply, LogicalGapFill, LogicalHopWindow, LogicalIcebergIntermediateScan,
     LogicalIcebergMetadataScan, LogicalJoin, LogicalPlanRef as PlanRef, LogicalProject,
-    LogicalScan, LogicalShare, LogicalSource, LogicalSysScan, LogicalTableFunction, LogicalValues,
+    LogicalScan, LogicalShare, LogicalSource, LogicalSysScan, LogicalTableFunction, LogicalUnion,
+    LogicalValues,
 };
 use crate::optimizer::property::Cardinality;
 use crate::planner::{PlanFor, Planner};
@@ -137,7 +145,9 @@ impl Planner {
         let plan_target = match self.plan_for() {
             PlanFor::StreamIcebergEngineInternal => PlanTarget::TableScan,
             PlanFor::BatchDql => match iceberg_query_storage_mode {
-                IcebergQueryStorageMode::Hummock => PlanTarget::TableScan,
+                // Append-only Iceberg engine tables use a dummy Hummock materialization and keep
+                // their rows in Iceberg plus the sink log store.
+                IcebergQueryStorageMode::Hummock if !is_append_only => PlanTarget::TableScan,
                 _ => PlanTarget::IntermediateScan,
             },
             PlanFor::Stream => {
@@ -277,17 +287,54 @@ impl Planner {
             Rc::new(source_catalog),
             SourceNodeKind::CreateMViewOrBatch,
             self.ctx(),
-            as_of,
+            as_of.clone(),
         )?;
         if matches!(plan_target, PlanTarget::Source) {
             return Ok(LogicalProject::new(logical_source.into(), exprs).into());
         }
 
-        let logical_iceberg_intermediate_scan = self.plan_iceberg_intermediate_scan(
+        // Pin Hummock before loading the latest Iceberg snapshot. If a sink commit races with
+        // planning, this ordering guarantees that the Iceberg snapshot plus the filtered log
+        // store still represents a coherent prefix of the table.
+        let read_pending_log_store =
+            matches!(self.plan_for(), PlanFor::BatchDql) && is_append_only && as_of.is_none();
+        if read_pending_log_store {
+            drop(self.ctx().session_ctx().pinned_snapshot());
+        }
+
+        let mut logical_iceberg_intermediate_scan = self.plan_iceberg_intermediate_scan(
             &logical_source,
             table_column_type_mapping,
             source_to_table_mapping,
         )?;
+
+        if read_pending_log_store {
+            let snapshot_info = self.fetch_current_snapshot_info(&logical_source)?;
+            // A table without a snapshot has no committed rows, so all log-store rows are
+            // pending. For an existing snapshot without a RisingWave epoch marker, fall back to
+            // Iceberg-only reads to avoid returning duplicates from legacy/external snapshots.
+            let committed_epoch = match snapshot_info {
+                None => Some(None),
+                Some(IcebergSnapshotInfo {
+                    commit_epoch: Some(epoch),
+                    ..
+                }) => Some(Some(epoch)),
+                Some(_) => None,
+            };
+            if let Some(committed_epoch) = committed_epoch
+                && let Some(log_store_scan) = self.plan_iceberg_log_store_scan(
+                    &base_table.table_catalog,
+                    logical_iceberg_intermediate_scan.schema(),
+                    committed_epoch,
+                )?
+            {
+                logical_iceberg_intermediate_scan = LogicalUnion::create(
+                    true,
+                    vec![logical_iceberg_intermediate_scan, log_store_scan],
+                );
+            }
+        }
+
         Ok(LogicalProject::new(logical_iceberg_intermediate_scan, exprs).into())
     }
 
@@ -655,8 +702,8 @@ source: {:?}",
         let mut time_travel_info = to_iceberg_time_travel_as_of(&source.core.as_of, &timezone)?;
         if time_travel_info.is_none() {
             time_travel_info = self
-                .fetch_current_snapshot_id(source)?
-                .map(IcebergTimeTravelInfo::Version);
+                .fetch_current_snapshot_info(source)?
+                .map(|info| IcebergTimeTravelInfo::Version(info.snapshot_id));
         }
         let Some(time_travel_info) = time_travel_info else {
             let mut schema = source.schema().clone();
@@ -676,16 +723,18 @@ source: {:?}",
         Ok(intermediate_scan.into())
     }
 
-    fn fetch_current_snapshot_id(&self, source: &LogicalSource) -> Result<Option<i64>> {
-        let mut map = self.ctx.iceberg_snapshot_id_map();
+    fn fetch_current_snapshot_info(
+        &self,
+        source: &LogicalSource,
+    ) -> Result<Option<IcebergSnapshotInfo>> {
+        let mut map = self.ctx.iceberg_snapshot_info_map();
         let catalog = source.source_catalog().ok_or_else(|| {
             crate::error::ErrorCode::InternalError(
                 "Iceberg source must have a valid source catalog".to_owned(),
             )
         })?;
-        let name = catalog.name.as_str();
-        if let Some(&snapshot_id) = map.get(name) {
-            return Ok(snapshot_id);
+        if let Some(&snapshot_info) = map.get(&catalog.id) {
+            return Ok(snapshot_info);
         }
 
         #[cfg(madsim)]
@@ -705,16 +754,145 @@ source: {:?}",
                 .into());
             };
 
-            let snapshot_id = tokio::task::block_in_place(|| {
+            let snapshot_info = tokio::task::block_in_place(|| {
                 crate::utils::FRONTEND_RUNTIME.block_on(async {
-                    prop.load_table()
-                        .await
-                        .map(|table| table.metadata().current_snapshot_id())
+                    prop.load_table().await.map(|table| {
+                        let metadata = table.metadata();
+                        metadata
+                            .current_snapshot()
+                            .map(|snapshot| IcebergSnapshotInfo {
+                                snapshot_id: snapshot.snapshot_id(),
+                                commit_epoch: risingwave_iceberg_commit_epoch(
+                                    metadata,
+                                    snapshot.snapshot_id(),
+                                ),
+                            })
+                    })
                 })
             })?;
-            map.insert(name.to_owned(), snapshot_id);
-            Ok(snapshot_id)
+            map.insert(catalog.id, snapshot_info);
+            Ok(snapshot_info)
         }
+    }
+
+    /// Build a scan of insert rows that have not yet reached the current Iceberg snapshot.
+    /// Returns `None` for legacy/in-memory sinks whose persisted KV log store cannot be found.
+    fn plan_iceberg_log_store_scan(
+        &self,
+        table_catalog: &TableCatalog,
+        target_schema: &Schema,
+        committed_epoch: Option<u64>,
+    ) -> Result<Option<PlanRef>> {
+        let Some(sink_name) = table_catalog.iceberg_sink_name() else {
+            return Ok(None);
+        };
+        let log_store_table = {
+            let catalog_reader = self.ctx.session_ctx().env().catalog_reader().read_guard();
+            let Ok(schema) =
+                catalog_reader.get_schema_by_id(table_catalog.database_id, table_catalog.schema_id)
+            else {
+                return Ok(None);
+            };
+            let Some(sink) = schema.get_created_sink_by_name(&sink_name) else {
+                return Ok(None);
+            };
+            schema
+                .iter_internal_table()
+                .find(|table| {
+                    table.job_id == Some(sink.id.as_job_id())
+                        && table
+                            .columns()
+                            .iter()
+                            .any(|column| column.name() == EPOCH_COLUMN_NAME)
+                        && table
+                            .columns()
+                            .iter()
+                            .any(|column| column.name() == ROW_OP_COLUMN_NAME)
+                })
+                .cloned()
+        };
+        let Some(log_store_table) = log_store_table else {
+            return Ok(None);
+        };
+
+        let Some(epoch_idx) = log_store_table
+            .columns()
+            .iter()
+            .position(|column| column.name() == EPOCH_COLUMN_NAME)
+        else {
+            return Ok(None);
+        };
+        let Some(row_op_idx) = log_store_table
+            .columns()
+            .iter()
+            .position(|column| column.name() == ROW_OP_COLUMN_NAME)
+        else {
+            return Ok(None);
+        };
+        let payload_col_idx = (row_op_idx + 1..log_store_table.columns().len()).collect_vec();
+        if payload_col_idx.len() != target_schema.len() {
+            return Ok(None);
+        }
+
+        let row_op_predicate: ExprImpl = FunctionCall::new(
+            ExprType::Equal,
+            vec![
+                InputRef::new(row_op_idx, DataType::Int16).into(),
+                Literal::new(Some(ScalarImpl::Int16(INSERT_OP_CODE)), DataType::Int16).into(),
+            ],
+        )?
+        .into();
+        let mut predicate = Condition::with_expr(row_op_predicate);
+        if let Some(epoch) = committed_epoch {
+            let epoch_predicate: ExprImpl = FunctionCall::new(
+                ExprType::GreaterThan,
+                vec![
+                    InputRef::new(epoch_idx, DataType::Int64).into(),
+                    Literal::new(
+                        Some(ScalarImpl::Int64(encode_epoch(epoch))),
+                        DataType::Int64,
+                    )
+                    .into(),
+                ],
+            )?
+            .into();
+            predicate = predicate.and(Condition::with_expr(epoch_predicate));
+        }
+
+        let log_store_scan: PlanRef = LogicalScan::from(generic::TableScan::new(
+            payload_col_idx,
+            log_store_table,
+            vec![],
+            vec![],
+            self.ctx(),
+            predicate,
+            None,
+        ))
+        .into();
+
+        let source_types = log_store_scan.schema().data_types();
+        let target_types = target_schema.data_types();
+        if source_types == target_types {
+            return Ok(Some(log_store_scan));
+        }
+
+        let cast_exprs = source_types
+            .into_iter()
+            .zip_eq_fast(target_types)
+            .enumerate()
+            .map(|(idx, (source_type, target_type))| {
+                let mut expr: ExprImpl = InputRef::new(idx, source_type).into();
+                FunctionCall::cast_mut(&mut expr, &target_type, CastContext::Explicit).map_err(
+                    |error| {
+                        ErrorCode::InternalError(format!(
+                            "failed to align Iceberg log-store payload type: {error}"
+                        ))
+                    },
+                )?;
+                Ok(expr)
+            })
+            .collect::<Result<Vec<_>>>()?;
+        Ok(Some(LogicalProject::create(log_store_scan, cast_exprs)))
     }
 
     fn get_iceberg_source_by_table_catalog(
@@ -729,5 +907,109 @@ source: {:?}",
             .ok()?;
         let source_catalog = schema.get_source_by_name(&iceberg_source_name)?;
         Some(source_catalog.deref().clone())
+    }
+}
+
+/// Find the latest known RisingWave commit boundary. Iceberg compaction produces `replace`
+/// snapshots without changing table contents, so the marker is inherited across a chain of those
+/// snapshots. We deliberately stop at any other unmarked operation: an external or legacy append
+/// cannot be assigned a safe log-store boundary.
+fn risingwave_iceberg_commit_epoch(metadata: &TableMetadata, snapshot_id: i64) -> Option<u64> {
+    let mut snapshot = metadata.snapshot_by_id(snapshot_id)?;
+    loop {
+        if let Some(epoch) = snapshot
+            .summary()
+            .additional_properties
+            .get(RISINGWAVE_ICEBERG_COMMIT_EPOCH)
+        {
+            return epoch.parse().ok();
+        }
+        if snapshot.summary().operation != Operation::Replace {
+            return None;
+        }
+        snapshot = metadata.snapshot_by_id(snapshot.parent_snapshot_id()?)?;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use iceberg::spec::{
+        FormatVersion, MAIN_BRANCH, NestedField, PrimitiveType, Schema as IcebergSchema, Snapshot,
+        SortOrder, Summary, TableMetadataBuilder, Type, UnboundPartitionSpec,
+    };
+
+    use super::*;
+
+    #[test]
+    fn test_risingwave_commit_epoch_inherits_only_across_replace_snapshots() {
+        let append = snapshot(
+            1,
+            None,
+            Operation::Append,
+            HashMap::from([(RISINGWAVE_ICEBERG_COMMIT_EPOCH.to_owned(), "42".to_owned())]),
+        );
+        let replace = snapshot(2, Some(1), Operation::Replace, HashMap::new());
+        let metadata = metadata_with_current(vec![append, replace]);
+        assert_eq!(risingwave_iceberg_commit_epoch(&metadata, 2), Some(42));
+
+        let external_append = snapshot(3, Some(2), Operation::Append, HashMap::new());
+        let metadata = metadata_with_current(vec![
+            snapshot(
+                1,
+                None,
+                Operation::Append,
+                HashMap::from([(RISINGWAVE_ICEBERG_COMMIT_EPOCH.to_owned(), "42".to_owned())]),
+            ),
+            snapshot(2, Some(1), Operation::Replace, HashMap::new()),
+            external_append,
+        ]);
+        assert_eq!(risingwave_iceberg_commit_epoch(&metadata, 3), None);
+    }
+
+    fn metadata_with_current(mut snapshots: Vec<Snapshot>) -> TableMetadata {
+        let current = snapshots.pop().unwrap();
+        let mut builder = TableMetadataBuilder::new(
+            IcebergSchema::builder()
+                .with_fields(vec![
+                    NestedField::new(1, "id", Type::Primitive(PrimitiveType::Long), false).into(),
+                ])
+                .build()
+                .unwrap(),
+            UnboundPartitionSpec::builder().build(),
+            SortOrder::unsorted_order(),
+            "s3://warehouse/db/table".to_owned(),
+            FormatVersion::V2,
+            HashMap::new(),
+        )
+        .unwrap();
+        for snapshot in snapshots {
+            builder = builder.add_snapshot(snapshot).unwrap();
+        }
+        builder
+            .set_branch_snapshot(current, MAIN_BRANCH)
+            .unwrap()
+            .build()
+            .unwrap()
+            .metadata
+    }
+
+    fn snapshot(
+        snapshot_id: i64,
+        parent_snapshot_id: Option<i64>,
+        operation: Operation,
+        additional_properties: HashMap<String, String>,
+    ) -> Snapshot {
+        Snapshot::builder()
+            .with_snapshot_id(snapshot_id)
+            .with_parent_snapshot_id(parent_snapshot_id)
+            .with_sequence_number(snapshot_id)
+            .with_timestamp_ms(snapshot_id)
+            .with_manifest_list(format!("/snap-{snapshot_id}.avro"))
+            .with_summary(Summary {
+                operation,
+                additional_properties,
+            })
+            .with_schema_id(0)
+            .build()
     }
 }

--- a/src/frontend/src/planner/relation.rs
+++ b/src/frontend/src/planner/relation.rs
@@ -326,6 +326,7 @@ impl Planner {
                 && let Some(log_store_scan) = self.plan_iceberg_log_store_scan(
                     &base_table.table_catalog,
                     logical_iceberg_intermediate_scan.schema(),
+                    &logical_source.core.column_catalog,
                     committed_epoch,
                 )?
             {
@@ -782,6 +783,7 @@ source: {:?}",
         &self,
         table_catalog: &TableCatalog,
         target_schema: &Schema,
+        source_columns: &[ColumnCatalog],
         committed_epoch: Option<u64>,
     ) -> Result<Option<PlanRef>> {
         let Some(sink_name) = table_catalog.iceberg_sink_name() else {
@@ -830,8 +832,23 @@ source: {:?}",
         else {
             return Ok(None);
         };
-        let payload_col_idx = (row_op_idx + 1..log_store_table.columns().len()).collect_vec();
-        if payload_col_idx.len() != target_schema.len() {
+        // The log-store payload can contain hidden upstream columns such as `_rw_timestamp`
+        // that are not part of the Iceberg table schema. Do not let those implementation-only
+        // columns prevent the pending rows from being planned.
+        let payload_col_idx = log_store_table
+            .columns()
+            .iter()
+            .enumerate()
+            .skip(row_op_idx + 1)
+            .filter_map(|(idx, column)| (!column.is_hidden).then_some(idx))
+            .collect_vec();
+        if source_columns.len() != target_schema.len()
+            || payload_col_idx.len()
+                != source_columns
+                    .iter()
+                    .filter(|column| !column.is_hidden)
+                    .count()
+        {
             return Ok(None);
         }
 
@@ -873,16 +890,18 @@ source: {:?}",
 
         let source_types = log_store_scan.schema().data_types();
         let target_types = target_schema.data_types();
-        if source_types == target_types {
-            return Ok(Some(log_store_scan));
-        }
-
-        let cast_exprs = source_types
-            .into_iter()
+        let mut payload_idx = 0;
+        let project_exprs = source_columns
+            .iter()
             .zip_eq_fast(target_types)
-            .enumerate()
-            .map(|(idx, (source_type, target_type))| {
-                let mut expr: ExprImpl = InputRef::new(idx, source_type).into();
+            .map(|(source_column, target_type)| {
+                if source_column.is_hidden {
+                    return Ok(Literal::new(None, target_type).into());
+                }
+
+                let source_type = source_types[payload_idx].clone();
+                let mut expr: ExprImpl = InputRef::new(payload_idx, source_type).into();
+                payload_idx += 1;
                 FunctionCall::cast_mut(&mut expr, &target_type, CastContext::Explicit).map_err(
                     |error| {
                         ErrorCode::InternalError(format!(
@@ -894,7 +913,7 @@ source: {:?}",
                 Ok(expr)
             })
             .collect::<Result<Vec<_>>>()?;
-        Ok(Some(LogicalProject::create(log_store_scan, cast_exprs)))
+        Ok(Some(LogicalProject::create(log_store_scan, project_exprs)))
     }
 
     fn get_iceberg_source_by_table_catalog(

--- a/src/frontend/src/planner/relation.rs
+++ b/src/frontend/src/planner/relation.rs
@@ -32,6 +32,7 @@ use risingwave_common::util::iter_util::ZipEqFast;
 use risingwave_connector::source::ConnectorProperties;
 use risingwave_connector::source::iceberg::IcebergTimeTravelInfo;
 use risingwave_sqlparser::ast::AsOf;
+use thiserror_ext::AsReport;
 
 use crate::TableCatalog;
 use crate::binder::{
@@ -885,7 +886,8 @@ source: {:?}",
                 FunctionCall::cast_mut(&mut expr, &target_type, CastContext::Explicit).map_err(
                     |error| {
                         ErrorCode::InternalError(format!(
-                            "failed to align Iceberg log-store payload type: {error}"
+                            "failed to align Iceberg log-store payload type: {}",
+                            error.as_report()
                         ))
                     },
                 )?;

--- a/src/stream/src/common/log_store_impl/kv_log_store/serde.rs
+++ b/src/stream/src/common/log_store_impl/kv_log_store/serde.rs
@@ -51,7 +51,7 @@ use crate::common::log_store_impl::kv_log_store::{
     SeqId,
 };
 
-const INSERT_OP_CODE: RowOpCodeType = 1;
+const INSERT_OP_CODE: RowOpCodeType = risingwave_common::constants::log_store::INSERT_OP_CODE;
 const DELETE_OP_CODE: RowOpCodeType = 2;
 const UPDATE_INSERT_OP_CODE: RowOpCodeType = 3;
 const UPDATE_DELETE_OP_CODE: RowOpCodeType = 4;
@@ -276,11 +276,11 @@ impl LogStoreRowSerde {
     }
 
     pub(crate) fn encode_epoch(epoch: u64) -> i64 {
-        epoch as i64 ^ (1i64 << 63)
+        risingwave_common::constants::log_store::encode_epoch(epoch)
     }
 
     pub(crate) fn decode_epoch(encoded_epoch: i64) -> u64 {
-        encoded_epoch as u64 ^ (1u64 << 63)
+        risingwave_common::constants::log_store::decode_epoch(encoded_epoch)
     }
 }
 


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

Append-only Iceberg engine tables keep recent rows in the sink KV log store until the next Iceberg commit. Batch queries previously read only the current Iceberg snapshot, so those durable rows were invisible during the commit interval.

This change combines the pinned Iceberg snapshot with pending insert rows from the sink log store for normal batch queries. Each RisingWave Iceberg append records its committed epoch in the snapshot summary; the planner uses that boundary to exclude rows already present in Iceberg. It pins the Hummock read snapshot before resolving the Iceberg snapshot so a concurrent sink commit cannot create gaps or duplicates.

Explicit time-travel queries remain Iceberg-only. Existing snapshots without a RisingWave epoch marker also fall back to Iceberg-only reads until a marker-bearing commit is available.

## Checklist

- [x] I have written necessary rustdoc comments.
- [x] I have added necessary unit tests and integration tests.
- [ ] I have added test labels as necessary.
- [ ] I have added fuzzing tests or opened an issue to track them.
- [ ] My PR contains breaking changes.
- [ ] My PR changes performance-critical code, so I will run (micro) benchmarks and present the results.
- [ ] I have checked the release timeline and currently supported versions to determine which release branches need a cherry-pick.

## Documentation

- [ ] My PR needs documentation updates.
