### PR TITLE
feat(optimizer): implement try_better_locality for LogicalDedup

### DIFF
--- a/src/frontend/planner_test/tests/testdata/input/locality_backfill.yaml
+++ b/src/frontend/planner_test/tests/testdata/input/locality_backfill.yaml
@@ -59,6 +59,14 @@
     select distinct on(a) * from t ;
   expected_outputs:
     - stream_plan
+- name: dedup provides locality on its dedup columns, so no extra locality provider is needed for the downstream agg.
+  sql: |
+    set enable_locality_backfill = true;
+    set locality_backfill_mode = always;
+    create table t(a int, b int, c int) append only;
+    select count(*) from (select distinct on(a, b) * from t) group by a;
+  expected_outputs:
+    - stream_plan
 - sql: |
     set enable_locality_backfill = true;
     set locality_backfill_mode = always;

--- a/src/frontend/planner_test/tests/testdata/output/locality_backfill.yaml
+++ b/src/frontend/planner_test/tests/testdata/output/locality_backfill.yaml
@@ -123,6 +123,22 @@
         └─StreamLocalityProvider { locality_columns: [t.a] }
           └─StreamExchange { dist: HashShard(t.a) }
             └─StreamTableScan { table: t, columns: [t.a, t.b, t.c, t._row_id], stream_scan_type: SnapshotBackfill, stream_key: [t._row_id], pk: [_row_id], dist: UpstreamHashShard(t._row_id) }
+- name: dedup provides locality on its dedup columns, so no extra locality provider is needed for the downstream agg.
+  sql: |
+    set enable_locality_backfill = true;
+    set locality_backfill_mode = always;
+    create table t(a int, b int, c int) append only;
+    select count(*) from (select distinct on(a, b) * from t) group by a;
+  stream_plan: |-
+    StreamMaterialize { columns: [count, t.a(hidden)], stream_key: [t.a], pk_columns: [t.a], pk_conflict: NoCheck }
+    └─StreamProject { exprs: [count, t.a] }
+      └─StreamHashAgg [append_only] { group_key: [t.a], aggs: [count] }
+        └─StreamExchange { dist: HashShard(t.a) }
+          └─StreamAppendOnlyDedup { dedup_cols: [t.a, t.b] }
+            └─StreamExchange { dist: HashShard(t.a, t.b) }
+              └─StreamLocalityProvider { locality_columns: [t.a, t.b] }
+                └─StreamExchange { dist: HashShard(t.a, t.b) }
+                  └─StreamTableScan { table: t, columns: [t.a, t.b, t._row_id], stream_scan_type: SnapshotBackfill, stream_key: [t._row_id], pk: [_row_id], dist: UpstreamHashShard(t._row_id) }
 - sql: |
     set enable_locality_backfill = true;
     set locality_backfill_mode = always;

--- a/src/frontend/src/optimizer/plan_node/logical_dedup.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_dedup.rs
@@ -89,6 +89,24 @@ impl PredicatePushdown for LogicalDedup {
 }
 
 impl ToStream for LogicalDedup {
+    fn try_better_locality(&self, columns: &[usize]) -> Option<PlanRef> {
+        if columns.is_empty() {
+            return None;
+        }
+
+        // Dedup stores rows with dedup columns as the primary key in its internal state
+        // table, so it can directly satisfy locality requests on a prefix of its dedup columns.
+        let dedup_cols = self.dedup_cols();
+        if columns.len() > dedup_cols.len() || columns != &dedup_cols[..columns.len()] {
+            return None;
+        }
+
+        // Similar to agg/topn, return the current plan directly instead of asking input for
+        // better locality first. The locality can be provided by the current Dedup itself
+        // after `to_stream`, while its input does not have it yet during logical rewrite.
+        Some(self.clone_with_input(self.input()).into())
+    }
+
     fn logical_rewrite_for_stream(
         &self,
         ctx: &mut RewriteStreamContext,


### PR DESCRIPTION
## What's changed and what's your intention?

When locality backfill is enabled, `LogicalDedup` already enforces a locality requirement on its dedup columns for its input (in `logical_rewrite_for_stream`), so its output naturally carries locality on the dedup columns during backfill. However, it did not implement `try_better_locality`, so a downstream operator requesting locality on a prefix of the dedup columns (e.g. an agg or join keyed on them) would wrap the dedup in a redundant `StreamLocalityProvider`, buffering the deduplicated stream a second time.

This PR implements `ToStream::try_better_locality` for `LogicalDedup` following the same pattern as agg / group top-n: if the requested columns are a prefix of the dedup columns, return the current plan directly so no extra locality provider is inserted above it.

## Checklist

- [x] I have written necessary rustdoc comments.
- [ ] I have added necessary unit tests and integration tests.
- [ ] I have added test labels as necessary.
- [ ] My PR contains breaking changes.
- [ ] My PR changes performance-critical code, so I will run (micro) benchmarks and present the results.
- [ ] My PR contains critical fixes that are necessary to be merged into the latest release.