### PR TITLE
fix(connector): preserve MySQL composite primary key order

### DIFF
--- a/e2e_test/source_inline/cdc/mysql/mysql_composite_pk_order.slt
+++ b/e2e_test/source_inline/cdc/mysql/mysql_composite_pk_order.slt
@@ -1,0 +1,72 @@
+# Verify that auto schema discovery preserves the upstream composite primary-key order.
+
+control substitution on
+
+statement ok
+drop source if exists s_mysql_composite_pk_order cascade;
+
+system ok
+mysql -e "
+    DROP USER IF EXISTS 'composite_pk_cdc'@'%';
+    DROP DATABASE IF EXISTS mysql_composite_pk_order;
+    CREATE DATABASE mysql_composite_pk_order;
+    CREATE USER 'composite_pk_cdc'@'%' IDENTIFIED BY 'composite_pk_cdc_pwd';
+    GRANT SELECT, RELOAD, SHOW DATABASES, REPLICATION SLAVE, REPLICATION CLIENT ON *.* TO 'composite_pk_cdc'@'%';
+    USE mysql_composite_pk_order;
+    CREATE TABLE upstream_table (
+        TypeID INT NOT NULL,
+        RelatedID INT NOT NULL,
+        ClientID INT NOT NULL,
+        payload VARCHAR(50),
+        PRIMARY KEY (RelatedID, TypeID, ClientID)
+    );
+    INSERT INTO upstream_table VALUES
+        (2, 1, 3, 'first'),
+        (1, 2, 3, 'second');
+"
+
+statement ok
+create source s_mysql_composite_pk_order with (
+  ${RISEDEV_MYSQL_WITH_OPTIONS_COMMON},
+  username = 'composite_pk_cdc',
+  password = 'composite_pk_cdc_pwd',
+  database.name = 'mysql_composite_pk_order'
+);
+
+statement ok
+create table rw_mysql_composite_pk_order (*)
+from s_mysql_composite_pk_order table 'mysql_composite_pk_order.upstream_table';
+
+# Physical column order is (TypeID, RelatedID, ClientID), while the upstream
+# primary-key index order is (RelatedID, TypeID, ClientID).
+query TTTT
+describe rw_mysql_composite_pk_order;
+----
+typeid integer false NULL
+relatedid integer false NULL
+clientid integer false NULL
+payload character varying false NULL
+_rw_timestamp timestamp with time zone true NULL
+primary key relatedid, typeid, clientid NULL NULL
+distribution key relatedid, typeid, clientid NULL NULL
+table description rw_mysql_composite_pk_order NULL NULL
+
+query IIIT retry 10 backoff 1s
+select typeid, relatedid, clientid, payload
+from rw_mysql_composite_pk_order
+order by relatedid, typeid, clientid;
+----
+2 1 3 first
+1 2 3 second
+
+statement ok
+drop table rw_mysql_composite_pk_order;
+
+statement ok
+drop source s_mysql_composite_pk_order cascade;
+
+system ok
+mysql -e "
+    DROP DATABASE IF EXISTS mysql_composite_pk_order;
+    DROP USER IF EXISTS 'composite_pk_cdc'@'%';
+"

--- a/src/connector/src/source/cdc/external/mysql.rs
+++ b/src/connector/src/source/cdc/external/mysql.rs
@@ -28,7 +28,7 @@ use risingwave_common::catalog::{CDC_OFFSET_COLUMN_NAME, ColumnDesc, ColumnId, F
 use risingwave_common::row::OwnedRow;
 use risingwave_common::types::{DataType, Datum, Decimal, F32, ScalarImpl};
 use risingwave_common::util::iter_util::ZipEqFast;
-use sea_schema::mysql::def::{ColumnDefault, ColumnKey, ColumnType, NumericAttr};
+use sea_schema::mysql::def::{ColumnDefault, ColumnType, IndexInfo, NumericAttr};
 use sea_schema::mysql::discovery::SchemaDiscovery;
 use sea_schema::mysql::query::SchemaQueryBuilder;
 use sea_schema::sea_query::{Alias, IntoIden};
@@ -155,10 +155,10 @@ impl MySqlExternalTable {
         let schema = Alias::new(config.database.as_str()).into_iden();
         let table = Alias::new(config.table.as_str()).into_iden();
         let columns = schema_discovery
-            .discover_columns(schema, table, &system_info)
+            .discover_columns(schema.clone(), table.clone(), &system_info)
             .await?;
+        let indexes = schema_discovery.discover_indexes(schema, table).await?;
         let mut column_descs = vec![];
-        let mut pk_names = vec![];
         for col in columns {
             let data_type = mysql_type_to_rw_type(&col.col_type)?;
             // column name in mysql is case-insensitive, convert to lowercase
@@ -187,14 +187,10 @@ impl MySqlExternalTable {
             };
 
             column_descs.push(column_desc);
-            if matches!(col.key, ColumnKey::Primary) {
-                pk_names.push(col_name);
-            }
         }
 
-        if pk_names.is_empty() {
-            return Err(anyhow!("MySQL table doesn't define the primary key").into());
-        }
+        let pk_names = primary_key_names(&indexes)
+            .ok_or_else(|| anyhow!("MySQL table doesn't define the primary key"))?;
         Ok(Self {
             column_descs,
             pk_names,
@@ -208,6 +204,20 @@ impl MySqlExternalTable {
     pub fn pk_names(&self) -> &Vec<String> {
         &self.pk_names
     }
+}
+
+fn primary_key_names(indexes: &[IndexInfo]) -> Option<Vec<String>> {
+    indexes
+        .iter()
+        .find(|index| index.name.eq_ignore_ascii_case("PRIMARY"))
+        .map(|index| {
+            index
+                .parts
+                .iter()
+                .map(|part| part.column.to_lowercase())
+                .collect()
+        })
+        .filter(|names: &Vec<_>| !names.is_empty())
 }
 
 fn derive_default_value(default: ColumnDefault, data_type: &DataType) -> ConnectorResult<Datum> {
@@ -849,9 +859,12 @@ mod tests {
     use maplit::{convert_args, hashmap};
     use risingwave_common::catalog::{ColumnDesc, ColumnId, Field, Schema};
     use risingwave_common::types::DataType;
-    use sea_schema::mysql::def::ColumnType;
+    use sea_schema::mysql::def::{ColumnType, IndexInfo, IndexOrder, IndexPart, IndexType};
 
-    use super::{mysql_type_is_unsigned_bigint, mysql_type_to_rw_type, type_name_to_mysql_type};
+    use super::{
+        mysql_type_is_unsigned_bigint, mysql_type_to_rw_type, primary_key_names,
+        type_name_to_mysql_type,
+    };
     use crate::source::cdc::external::mysql::MySqlExternalTable;
     use crate::source::cdc::external::{
         CdcOffset, ExternalTableConfig, ExternalTableReader, MySqlExternalTableReader, MySqlOffset,
@@ -860,6 +873,35 @@ mod tests {
 
     fn parse_mysql_type_name(ty_name: &str) -> ColumnType {
         type_name_to_mysql_type(ty_name).unwrap()
+    }
+
+    #[test]
+    fn test_primary_key_names_preserve_index_order() {
+        let indexes = vec![IndexInfo {
+            unique: true,
+            name: "PRIMARY".to_owned(),
+            parts: ["RelatedID", "TypeID", "ClientID"]
+                .into_iter()
+                .map(|column| IndexPart {
+                    column: column.to_owned(),
+                    order: IndexOrder::Ascending,
+                    sub_part: None,
+                })
+                .collect(),
+            nullable: false,
+            idx_type: IndexType::BTree,
+            comment: String::new(),
+            functional: false,
+        }];
+
+        assert_eq!(
+            primary_key_names(&indexes),
+            Some(vec![
+                "relatedid".to_owned(),
+                "typeid".to_owned(),
+                "clientid".to_owned(),
+            ])
+        );
     }
 
     #[test]


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

Discover MySQL CDC primary keys from index metadata ordered by `SEQ_IN_INDEX` instead of deriving them from physical column order. This preserves the upstream composite-key order for RisingWave's storage distribution and snapshot pagination.

- Closes #26846

## Checklist

- [ ] I have written necessary rustdoc comments.
- [x] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [x] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/dev/src/ci.md#ci-labels-guide -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->

## Documentation

- [x] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

MySQL CDC schema discovery now preserves the upstream order of composite primary-key columns for newly created tables.

</details>
