### PR TITLE
fix(connector): handle early MySQL date cursors

### DIFF
--- a/e2e_test/source_inline/cdc/mysql/mysql_early_date_pk.slt
+++ b/e2e_test/source_inline/cdc/mysql/mysql_early_date_pk.slt
@@ -1,0 +1,61 @@
+# Regression test for MySQL CDC snapshot pagination with pre-1000 DATE primary keys.
+
+control substitution on
+
+system ok
+mysql -e "
+    CREATE DATABASE IF NOT EXISTS risedev;
+    USE risedev;
+    DROP TABLE IF EXISTS mysql_early_date_pk_test;
+    CREATE TABLE mysql_early_date_pk_test (
+        d DATE NOT NULL PRIMARY KEY,
+        id INT NOT NULL
+    ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+    INSERT INTO mysql_early_date_pk_test (d, id) VALUES
+        ('0023-04-05', 23),
+        ('0024-01-01', 24),
+        ('0999-12-31', 999),
+        ('1000-01-01', 1000);
+"
+
+statement ok
+create source s_mysql_early_date_pk with (
+  ${RISEDEV_MYSQL_WITH_OPTIONS_COMMON},
+  username = '${RISEDEV_MYSQL_USER}',
+  password = '${MYSQL_PWD}',
+  database.name = 'risedev'
+);
+
+sleep 2s
+
+# A batch size of one makes 0023-04-05 the cursor for the second snapshot page.
+statement ok
+create table rw_mysql_early_date_pk (
+  d DATE,
+  id INT,
+  PRIMARY KEY (d)
+) with (
+  snapshot = 'true',
+  snapshot.batch_size = 1,
+  backfill.parallelism = 1
+) from s_mysql_early_date_pk table 'risedev.mysql_early_date_pk_test';
+
+query TI retry 10 backoff 1s
+select d, id from rw_mysql_early_date_pk order by d;
+----
+0023-04-05 23
+0024-01-01 24
+0999-12-31 999
+1000-01-01 1000
+
+statement ok
+drop table rw_mysql_early_date_pk;
+
+statement ok
+drop source s_mysql_early_date_pk cascade;
+
+system ok
+mysql -e "
+    USE risedev;
+    DROP TABLE IF EXISTS mysql_early_date_pk_test;
+"

--- a/src/connector/src/source/cdc/external/mysql.rs
+++ b/src/connector/src/source/cdc/external/mysql.rs
@@ -15,7 +15,7 @@
 use std::collections::HashMap;
 
 use anyhow::{Context, anyhow};
-use chrono::{DateTime, NaiveDateTime};
+use chrono::{DateTime, Datelike, NaiveDateTime, Timelike};
 use futures::stream::BoxStream;
 use futures::{StreamExt, pin_mut, stream};
 use futures_async_stream::try_stream;
@@ -257,6 +257,25 @@ pub fn timestamp_val_to_timestamptz(value_text: &str) -> ConnectorResult<String>
     Ok(postgres_timestamptz
         .format("%Y-%m-%d %H:%M:%S%:z")
         .to_string())
+}
+
+fn naive_datetime_to_mysql_value(datetime: NaiveDateTime) -> ConnectorResult<Value> {
+    let year = datetime.year();
+    if !(0..=9999).contains(&year) {
+        bail!("year `{year}` is outside the range supported by MySQL [0, 9999]");
+    }
+
+    // `mysql_common` rejects years before 1000 when converting from chrono, even though
+    // MySQL can return such values and its binary protocol can represent them.
+    Ok(Value::Date(
+        year as u16,
+        datetime.month() as u8,
+        datetime.day() as u8,
+        datetime.hour() as u8,
+        datetime.minute() as u8,
+        datetime.second() as u8,
+        datetime.nanosecond() / 1000,
+    ))
 }
 
 pub fn type_name_to_mysql_type(ty_name: &str) -> Option<ColumnType> {
@@ -734,9 +753,13 @@ impl MySqlExternalTableReader {
                             DataType::Float32 => Value::from(value.into_float32().into_inner()),
                             DataType::Float64 => Value::from(value.into_float64().into_inner()),
                             DataType::Varchar => Value::from(String::from(value.into_utf8())),
-                            DataType::Date => Value::from(value.into_date().0),
+                            DataType::Date => naive_datetime_to_mysql_value(
+                                value.into_date().0.and_time(Default::default()),
+                            )?,
                             DataType::Time => Value::from(value.into_time().0),
-                            DataType::Timestamp => Value::from(value.into_timestamp().0),
+                            DataType::Timestamp => {
+                                naive_datetime_to_mysql_value(value.into_timestamp().0)?
+                            }
                             DataType::Decimal => Value::from(value.into_decimal().to_string()),
                             DataType::Timestamptz => {
                                 // Convert timestamptz to NaiveDateTime for MySQL TIMESTAMP comparison
@@ -744,7 +767,7 @@ impl MySqlExternalTableReader {
                                 let ts = value.into_timestamptz();
                                 let datetime_utc = ts.to_datetime_utc();
                                 let naive_datetime = datetime_utc.naive_utc();
-                                Value::from(naive_datetime)
+                                naive_datetime_to_mysql_value(naive_datetime)?
                             }
                             _ => bail!("unsupported primary key data type: {}", ty),
                         };
@@ -844,14 +867,19 @@ impl MySqlExternalTableReader {
 mod tests {
     use std::collections::HashMap;
 
+    use chrono::NaiveDate;
     use futures::pin_mut;
     use futures_async_stream::for_await;
     use maplit::{convert_args, hashmap};
+    use mysql_common::value::Value;
     use risingwave_common::catalog::{ColumnDesc, ColumnId, Field, Schema};
     use risingwave_common::types::DataType;
     use sea_schema::mysql::def::ColumnType;
 
-    use super::{mysql_type_is_unsigned_bigint, mysql_type_to_rw_type, type_name_to_mysql_type};
+    use super::{
+        mysql_type_is_unsigned_bigint, mysql_type_to_rw_type, naive_datetime_to_mysql_value,
+        type_name_to_mysql_type,
+    };
     use crate::source::cdc::external::mysql::MySqlExternalTable;
     use crate::source::cdc::external::{
         CdcOffset, ExternalTableConfig, ExternalTableReader, MySqlExternalTableReader, MySqlOffset,
@@ -946,6 +974,29 @@ mod tests {
             mysql_type_to_rw_type(&parse_mysql_type_name("BIGINT UNSIGNED")).unwrap();
         assert_eq!(serial_type, DataType::Decimal);
         assert_eq!(serial_type, unsigned_bigint_type);
+    }
+
+    #[test]
+    fn test_mysql_value_from_early_date() {
+        let datetime = NaiveDate::from_ymd_opt(23, 4, 5)
+            .unwrap()
+            .and_hms_micro_opt(6, 7, 8, 9)
+            .unwrap();
+
+        assert_eq!(
+            naive_datetime_to_mysql_value(datetime).unwrap(),
+            Value::Date(23, 4, 5, 6, 7, 8, 9)
+        );
+    }
+
+    #[test]
+    fn test_mysql_value_rejects_year_outside_protocol_range() {
+        let datetime = NaiveDate::from_ymd_opt(-1, 1, 1)
+            .unwrap()
+            .and_hms_opt(0, 0, 0)
+            .unwrap();
+
+        assert!(naive_datetime_to_mysql_value(datetime).is_err());
     }
 
     #[ignore]


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

MySQL CDC snapshot pagination converted date-like primary-key cursors through `mysql_common`'s chrono conversion. That conversion panics for years before 1000, even though MySQL can return such dates and its binary protocol can encode them.

This PR constructs the corresponding MySQL wire value directly for date and timestamp cursors. It preserves the existing encoding for normal dates, supports early years such as 0023, and returns a connector error for years outside MySQL's representable range instead of panicking.

Unit tests cover both the early-year encoding and the out-of-range error. A MySQL CDC end-to-end test uses a `DATE` primary key with year 0023 and a snapshot batch size of one, forcing that value to be sent back to MySQL as the cursor for the next snapshot page.

## Checklist

- [x] I have written necessary rustdoc comments.
- [x] I have added necessary unit tests and integration tests.
- [x] I have added test labels as necessary.
- [ ] I have added fuzzing tests or opened an issue to track them.
- [ ] My PR contains breaking changes.
- [ ] My PR changes performance-critical code, so I will run (micro) benchmarks and present the results.
- [ ] I have checked the Release Timeline and Currently Supported Versions to determine which release branches I need to cherry-pick this PR into.

## Documentation

- [ ] My PR needs documentation updates.
