### PR TITLE
fix(connector): return errors for invalid JSON schemas

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13337,6 +13337,7 @@ dependencies = [
  "jsonschema-transpiler",
  "madsim-tokio",
  "num-bigint",
+ "panic-message",
  "prost 0.14.3",
  "prost-build 0.14.3",
  "prost-reflect",

--- a/src/connector/codec/Cargo.toml
+++ b/src/connector/codec/Cargo.toml
@@ -21,6 +21,7 @@ itertools = { workspace = true }
 jsonbb = { workspace = true }
 jst = { package = 'jsonschema-transpiler', git = "https://github.com/mozilla/jsonschema-transpiler", rev = "c1a89d720d118843d8bcca51084deb0ed223e4b4" }
 num-bigint = "0.4"
+panic-message = "0.3"
 prost = { workspace = true, features = ["no-recursion-limit"] }
 prost-reflect = { workspace = true }
 prost-types = { workspace = true }

--- a/src/connector/codec/src/decoder/json/mod.rs
+++ b/src/connector/codec/src/decoder/json/mod.rs
@@ -37,8 +37,9 @@
 use std::collections::HashMap;
 use std::fs;
 
-use anyhow::Context;
+use anyhow::{Context, anyhow};
 use risingwave_common::catalog::Field;
+use risingwave_common::util::panic::rw_catch_unwind;
 use serde_json::Value;
 use thiserror::Error;
 use url::Url;
@@ -190,8 +191,6 @@ impl JsonRef {
 }
 
 impl crate::JsonSchema {
-    /// FIXME: when the JSON schema is invalid, it will panic.
-    ///
     /// ## Notes on type conversion
     /// Map will be used when an object doesn't have `properties` but has `additionalProperties`.
     /// When an object has `properties` and `additionalProperties`, the latter will be ignored.
@@ -205,7 +204,9 @@ impl crate::JsonSchema {
         JsonRef::new()
             .deref_value(&mut self.0, &retrieval_url)
             .await?;
-        let avro_schema = jst::convert_avro(&self.0, jst::Context::default()).to_string();
+        let avro_schema =
+            rw_catch_unwind(|| jst::convert_avro(&self.0, jst::Context::default()).to_string())
+                .map_err(|_| anyhow!("failed to convert JSON schema to Avro schema"))?;
         let schema =
             apache_avro::Schema::parse_str(&avro_schema).context("failed to parse avro schema")?;
         avro_schema_to_fields(&schema, Some(MapHandling::Jsonb))

--- a/src/connector/codec/src/decoder/json/mod.rs
+++ b/src/connector/codec/src/decoder/json/mod.rs
@@ -206,7 +206,12 @@ impl crate::JsonSchema {
             .await?;
         let avro_schema =
             rw_catch_unwind(|| jst::convert_avro(&self.0, jst::Context::default()).to_string())
-                .map_err(|_| anyhow!("failed to convert JSON schema to Avro schema"))?;
+                .map_err(|payload| {
+                    anyhow!(
+                        "failed to convert JSON schema to Avro schema: {}",
+                        panic_message::panic_message(&payload)
+                    )
+                })?;
         let schema =
             apache_avro::Schema::parse_str(&avro_schema).context("failed to parse avro schema")?;
         avro_schema_to_fields(&schema, Some(MapHandling::Jsonb))

--- a/src/connector/codec/tests/integration_tests/json.rs
+++ b/src/connector/codec/tests/integration_tests/json.rs
@@ -228,3 +228,43 @@ async fn test_json_schema_parse() {
     "#]]
     .assert_debug_eq(&column_display);
 }
+
+#[tokio::test]
+async fn test_invalid_json_schema_returns_error() {
+    for schema in [
+        r#"{"type":"nonsense"}"#,
+        r#"{"type":[]}"#,
+        r#"{"type":"array"}"#,
+    ] {
+        let mut json_schema = JsonSchema::parse_str(schema).unwrap();
+
+        let result = json_schema
+            .json_schema_to_columns(Url::parse("http://test_schema_uri.test").unwrap())
+            .await;
+
+        assert_eq!(
+            result.unwrap_err().to_string(),
+            "failed to convert JSON schema to Avro schema",
+            "{schema}"
+        );
+    }
+}
+
+#[tokio::test]
+async fn test_json_schema_valid_object() {
+    let mut json_schema =
+        JsonSchema::parse_str(r#"{"type":"object","properties":{"id":{"type":"integer"}}}"#)
+            .unwrap();
+
+    let columns = json_schema
+        .json_schema_to_columns(Url::parse("http://test_schema_uri.test").unwrap())
+        .await
+        .unwrap();
+
+    expect![[r#"
+        [
+            id: Int64,
+        ]
+    "#]]
+    .assert_debug_eq(&columns.iter().map(FieldTestDisplay).collect_vec());
+}

--- a/src/connector/codec/tests/integration_tests/json.rs
+++ b/src/connector/codec/tests/integration_tests/json.rs
@@ -231,22 +231,24 @@ async fn test_json_schema_parse() {
 
 #[tokio::test]
 async fn test_invalid_json_schema_returns_error() {
-    for schema in [
-        r#"{"type":"nonsense"}"#,
-        r#"{"type":[]}"#,
-        r#"{"type":"array"}"#,
+    for (schema, cause) in [
+        (r#"{"type":"nonsense"}"#, "unknown variant `nonsense`"),
+        (r#"{"type":[]}"#, "empty union is not allowed"),
+        (r#"{"type":"array"}"#, "array missing item"),
     ] {
         let mut json_schema = JsonSchema::parse_str(schema).unwrap();
 
-        let result = json_schema
+        let error = json_schema
             .json_schema_to_columns(Url::parse("http://test_schema_uri.test").unwrap())
-            .await;
+            .await
+            .unwrap_err()
+            .to_string();
 
-        assert_eq!(
-            result.unwrap_err().to_string(),
-            "failed to convert JSON schema to Avro schema",
-            "{schema}"
+        assert!(
+            error.starts_with("failed to convert JSON schema to Avro schema: "),
+            "{schema}: {error}"
         );
+        assert!(error.contains(cause), "{schema}: {error}");
     }
 }
 


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

An invalid JSON Schema used for connector column inference can panic inside `jsonschema-transpiler`. RisingWave's panic hook then aborts the frontend process instead of returning a DDL error.

This change contains the converter call with `rw_catch_unwind` and returns the original panic detail as an error. It covers three separate failure paths: unknown types, empty unions, and arrays without `items`.

- Closes #26351

## Checklist

- [x] No new public API needs rustdoc changes.
- [x] I added regression coverage for the invalid schemas and the valid conversion path.
- Test labels are not needed for this focused connector codec change.
- Fuzzing, breaking-change, performance, and release-branch follow-ups do not apply.

<details>
<summary>Regression evidence</summary>

Current `main` at `b71e8d8607354010685a152ea4147dd7c7edae55`, with the regression test applied:

```text
$ cargo test --locked -p risingwave_connector_codec --test repro_26351 -- --test-threads=1 --nocapture
test control_valid_object_schema_returns_columns ... ok
test invalid_json_schema_returns_error_array_without_items ... FAILED
test invalid_json_schema_returns_error_empty_type_array ... FAILED
test invalid_json_schema_returns_error_unknown_type ... FAILED
test result: FAILED. 1 passed; 3 failed
```

After the fix:

```text
$ cargo test --locked -p risingwave_connector_codec
test result: ok. 6 passed; 0 failed
test result: ok. 14 passed; 0 failed

$ cargo clippy --locked -p risingwave_connector_codec --all-targets -- -D warnings
Finished `dev` profile
```

</details>

## Documentation

No documentation update is needed. Invalid schemas now return a diagnostic error instead of aborting the frontend.

<details>
<summary><b>Release note</b></summary>

Invalid JSON Schemas used during connector column inference now return an error with the conversion failure instead of aborting the frontend process.

</details>
