### PR TITLE
fix(frontend): reject ALTER SOURCE refresh for tables

### DIFF
--- a/e2e_test/source_inline/kafka/avro/alter_table.slt
+++ b/e2e_test/source_inline/kafka/avro/alter_table.slt
@@ -44,6 +44,11 @@ select * from t
 system ok
 sr_register avro_alter_table_test-value AVRO <<< '{"type":"record","name":"Root","fields":[{"name":"bar","type":"int","default":0},{"name":"foo","type":"string"},{"name":"nested","type":["null",{"type":"record","name":"Nested","fields":[{"name":"baz","type":"int"}]}],"default":null}]}'
 
+# A connector-backed table owns an internal source with a CREATE TABLE definition. ALTER SOURCE
+# must reject it before parsing that definition as CREATE SOURCE. See #25862.
+statement error try to use ALTER TABLE instead
+ALTER SOURCE t REFRESH SCHEMA;
+
 # Before refreshing schema, we create a `SINK INTO TABLE` which involves table replacement,
 # showing that this will NOT accidentally refresh the schema.
 statement ok

--- a/src/frontend/src/handler/alter_source_with_sr.rs
+++ b/src/frontend/src/handler/alter_source_with_sr.rs
@@ -198,9 +198,25 @@ fn get_format_encode_from_source(source: &SourceCatalog) -> Result<FormatEncodeO
         stmt: CreateSourceStatement { format_encode, .. },
     } = stmt
     else {
-        unreachable!()
+        return Err(ErrorCode::InternalError(format!(
+            "source \"{}\" has a non-CREATE SOURCE definition",
+            source.name
+        ))
+        .into());
     };
     Ok(format_encode.into_v2_with_warning())
+}
+
+fn reject_associated_table(source: &SourceCatalog) -> Result<()> {
+    if source.associated_table_id.is_some() {
+        return Err(ErrorCode::NotSupported(
+            "alter table with connector using ALTER SOURCE statement".to_owned(),
+            "try to use ALTER TABLE instead".to_owned(),
+        )
+        .into());
+    }
+
+    Ok(())
 }
 
 pub async fn handler_refresh_schema(
@@ -208,6 +224,7 @@ pub async fn handler_refresh_schema(
     name: ObjectName,
 ) -> Result<RwPgResponse> {
     let source = fetch_source_catalog_with_db_schema_id(&handler_args.session, &name)?;
+    reject_associated_table(&source)?;
     let format_encode = get_format_encode_from_source(&source)?;
     handle_alter_source_with_sr(handler_args, name, format_encode).await
 }
@@ -221,13 +238,7 @@ pub async fn handle_alter_source_with_sr(
     let source = fetch_source_catalog_with_db_schema_id(&session, &name)?;
     let mut source = source.as_ref().clone();
 
-    if source.associated_table_id.is_some() {
-        return Err(ErrorCode::NotSupported(
-            "alter table with connector using ALTER SOURCE statement".to_owned(),
-            "try to use ALTER TABLE instead".to_owned(),
-        )
-        .into());
-    };
+    reject_associated_table(&source)?;
 
     check_format_encode(&source, &format_encode)?;
 
@@ -323,6 +334,32 @@ pub mod tests {
 
     use crate::catalog::root_catalog::SchemaPath;
     use crate::test_utils::{LocalFrontend, PROTO_FILE_DATA, create_proto_file};
+
+    #[tokio::test]
+    async fn test_refresh_schema_rejects_associated_table() {
+        let proto_file = create_proto_file(PROTO_FILE_DATA);
+        let sql = format!(
+            r#"CREATE TABLE t
+            WITH (
+                connector = 'kafka',
+                topic = 'test-topic',
+                properties.bootstrap.server = 'localhost:29092'
+            )
+            FORMAT PLAIN ENCODE PROTOBUF (
+                message = '.test.TestRecord',
+                schema.location = 'file://{}'
+            )"#,
+            proto_file.path().to_str().unwrap()
+        );
+        let frontend = LocalFrontend::new(Default::default()).await;
+        frontend.run_sql(sql).await.unwrap();
+
+        let error = frontend
+            .run_sql("ALTER SOURCE t REFRESH SCHEMA")
+            .await
+            .unwrap_err();
+        assert!(error.to_string().contains("try to use ALTER TABLE instead"));
+    }
 
     #[tokio::test]
     async fn test_alter_source_with_sr_handler() {


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

<!--

**Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

- Closes #25862.

Connector-backed tables own an internal source with the same name. The source stores the original `CREATE TABLE` definition and has `associated_table_id` set.

When running:

```sql
ALTER SOURCE <table_name> REFRESH SCHEMA;
```

the frontend previously parsed the stored definition as CREATE SOURCE before checking associated_table_id. Because the definition was actually a CREATE TABLE statement, the pattern match reached unreachable!() and panicked the frontend.

This PR:
- Rejects ALTER SOURCE ... REFRESH SCHEMA for table-associated sources before parsing their stored definitions.
- Returns the existing user-facing hint to use ALTER TABLE instead.
- Reuses the associated-table validation for other schema-registry alter-source paths.
- Replaces the remaining unreachable!() with an internal error for unexpected source definitions.
- Adds a frontend unit test covering the table-associated source case.
- Adds an Avro schema-evolution regression assertion after registering a new nullable field.
After this change, users receive an actionable error instead of a frontend panic:
```
try to use ALTER TABLE instead
```
The correct statement is:
```
ALTER TABLE <table_name> REFRESH SCHEMA;
```


### Tests
- cargo fmt --all -- --check
- git diff --check
- cargo test -p risingwave_frontend 'handler::alter_source_with_sr::tests' --lib
  - 2 passed
- Added coverage to `e2e_test/source_inline/kafka/avro/alter_table.slt`
  - Local connector E2E verification is pending [#26697](https://github.com/risingwavelabs/risingwave/pull/26697), which fixes startup of the `local-inline-source-test` profile.
  - Covered by the Kafka source CI lane.

#### Kafka/Avro end-to-end test
Start a local RisingWave cluster with Kafka and Schema Registry:
```
./risedev d local-inline-source-test
```
Run the Avro schema-evolution test:
```
./risedev slt './e2e_test/source_inline/kafka/avro/alter_table.slt'
```


## Checklist

- [x] I have written necessary rustdoc comments.
- [x] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/dev/src/ci.md#ci-labels-guide -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
