### PR TITLE
ci: verify community contributors by collaborator status

### DIFF
--- a/.github/workflows/label-community-contributor.yml
+++ b/.github/workflows/label-community-contributor.yml
@@ -5,16 +5,16 @@ on:
     types: [opened]
 
 permissions:
+  contents: write
   issues: write
   pull-requests: write
 
 jobs:
   label-community-contributor:
-    # External community contributors submit pull requests from forks. Requiring a fork also
-    # avoids misclassifying private organization members whose association appears as CONTRIBUTOR.
+    # The public event payload can hide private organization membership, so the step below also
+    # checks whether the author is a repository collaborator with the authenticated workflow token.
     if: >-
       github.event.pull_request.user.type == 'User' &&
-      github.event.pull_request.head.repo.full_name != github.repository &&
       contains(
         fromJSON('["NONE", "CONTRIBUTOR", "FIRST_TIMER", "FIRST_TIME_CONTRIBUTOR"]'),
         github.event.pull_request.author_association
@@ -25,6 +25,20 @@ jobs:
         uses: actions/github-script@v9
         with:
           script: |
+            const author = context.payload.pull_request.user.login;
+            try {
+              await github.rest.repos.checkCollaborator({
+                ...context.repo,
+                username: author,
+              });
+              core.info(`Skipping ${author}, who is a repository collaborator.`);
+              return;
+            } catch (error) {
+              if (error.status !== 404) {
+                throw error;
+              }
+            }
+
             const label = {
               name: "community",
               color: "0e8a16",


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What changed and what is your intention?

Fix the remaining false-positive case in the community PR labeler. In #26838, a private organization member opened a PR from a personal fork. The public pull-request payload reported `author_association: CONTRIBUTOR`, so both the association allowlist and fork check passed.

The workflow now calls the authenticated repository collaborator endpoint before applying the label:

- collaborator check returns 204: skip the author
- collaborator check returns 404: treat the author as external and continue
- any other API error: fail closed without applying the label

This covers organization members with access through RisingWave Labs default organization permissions, team members, direct collaborators, outside collaborators, and owners, including authors using personal forks. The current organization default repository permission is `write`, so every organization member is included in the collaborator check.

The endpoint requires the caller to have push access, so the workflow grants the ephemeral `GITHUB_TOKEN` `contents: write`. The `pull_request_target` workflow does not check out or execute pull-request code, and the author login is passed only as an API parameter and log value.

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] I have added necessary unit tests and integration tests.
- [ ] I have added test labels as necessary.
- [ ] I have added fuzzing tests or opened an issue to track them.
- [ ] My PR contains breaking changes.
- [ ] My PR changes performance-critical code, so I will run (micro) benchmarks and present the results.
- [ ] I have checked the release timeline and supported versions for cherry-pick needs.

## Validation

- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.7 .github/workflows/label-community-contributor.yml`
- `git diff --check`
- Real collaborator endpoint matrix:
  - `chenzl25`, `risingwave-ci`, `howenyap`: 204, skip
  - `Standing-Man`, `jeacott1`: 404, label
- Local Kimi review: no actionable findings after addressing its initial permission and API-design findings.

Because `pull_request_target` loads the workflow from the default branch, live end-to-end verification of this exact revision requires merge followed by a new `opened` event.

## Documentation

- [ ] My PR needs documentation updates.
