### PR TITLE
fix(source): don't gzip-decode file source payloads that are already decompressed

### DIFF
--- a/src/connector/src/source/filesystem/opendal_source/opendal_reader.rs
+++ b/src/connector/src/source/filesystem/opendal_source/opendal_reader.rs
@@ -23,7 +23,7 @@ use opendal::Operator;
 use prometheus::core::GenericCounter;
 use risingwave_common::array::StreamChunk;
 use risingwave_common::metrics::LabelGuardedMetric;
-use tokio::io::{AsyncBufRead, AsyncBufReadExt, BufReader};
+use tokio::io::{AsyncBufRead, AsyncBufReadExt, AsyncReadExt, BufReader};
 use tokio_util::io::StreamReader;
 
 use super::OpendalSource;
@@ -40,6 +40,9 @@ use crate::source::{
     BoxSourceChunkStream, Column, SourceContextRef, SourceMessage, SourceMessageEvent, SourceMeta,
     SplitMetaData, SplitReader,
 };
+
+/// The magic number at the beginning of a gzip member (RFC 1952).
+const GZIP_MAGIC: [u8; 2] = [0x1f, 0x8b];
 
 #[derive(Debug, Clone)]
 pub struct OpendalReader<Src: OpendalSource> {
@@ -172,9 +175,10 @@ impl<Src: OpendalSource> OpendalReader<Src> {
         let split_id = split.id();
         let object_name = split.name.clone();
         let start_offset = split.offset;
+        let has_gzip_extension = object_name.ends_with(".gz") || object_name.ends_with(".gzip");
         // After a recovery occurs, for gzip-compressed files, it is necessary to read from the beginning each time,
         // other files can continue reading from the last read `start_offset`.
-        let reader = match object_name.ends_with(".gz") || object_name.ends_with(".gzip") {
+        let reader = match has_gzip_extension {
             true => op.read_with(&object_name).into_future().await?,
 
             false => {
@@ -185,25 +189,57 @@ impl<Src: OpendalSource> OpendalReader<Src> {
             }
         };
 
-        let stream_reader = StreamReader::new(reader.map_err(std::io::Error::other));
+        let mut stream_reader = StreamReader::new(reader.map_err(std::io::Error::other));
 
-        let mut buf_reader: Pin<Box<dyn AsyncBufRead + Send>> = match compression_format {
-            CompressionFormat::Gzip => {
-                let gzip_decoder = GzipDecoder::new(stream_reader);
-                Box::pin(BufReader::new(gzip_decoder)) as Pin<Box<dyn AsyncBufRead + Send>>
-            }
-            CompressionFormat::None => {
-                // todo: support automatic decompression of more compression types.
-                if object_name.ends_with(".gz") || object_name.ends_with(".gzip") {
-                    let gzip_decoder = GzipDecoder::new(stream_reader);
-                    Box::pin(BufReader::new(gzip_decoder)) as Pin<Box<dyn AsyncBufRead + Send>>
-                } else {
-                    Box::pin(BufReader::new(stream_reader)) as Pin<Box<dyn AsyncBufRead + Send>>
+        // Whether the object is supposed to be gzip-compressed, either by the
+        // explicit `compression_format` property or by its file extension.
+        let expect_gzip =
+            matches!(compression_format, CompressionFormat::Gzip) || has_gzip_extension;
+
+        // Objects stored with `Content-Encoding: gzip` metadata (e.g. files delivered
+        // by AWS Kinesis Data Firehose with GZIP compression enabled) may be
+        // transparently decompressed by the HTTP client before reaching us, when the
+        // client is built with auto-decompression support (reqwest's `gzip` feature,
+        // which other dependencies enable transitively). Gzip-decoding such a payload
+        // again fails with "Invalid gzip header". To be robust, peek the first two
+        // bytes and only decompress when the payload actually starts with the gzip
+        // magic number. Skip the sniffing when resuming a file without a gzip
+        // extension from a non-zero offset, as the peeked bytes would come from the
+        // middle of the file.
+        let sniff_gzip_magic = expect_gzip && (has_gzip_extension || start_offset == 0);
+        let mut magic = [0u8; GZIP_MAGIC.len()];
+        let mut magic_len = 0;
+        if sniff_gzip_magic {
+            while magic_len < magic.len() {
+                let n = stream_reader.read(&mut magic[magic_len..]).await?;
+                if n == 0 {
+                    break;
                 }
+                magic_len += n;
             }
+        }
+        let payload_is_gzip = magic[..magic_len] == GZIP_MAGIC;
+        // Put the peeked bytes back in front of the remaining stream.
+        let reader = std::io::Cursor::new(magic[..magic_len].to_vec()).chain(stream_reader);
+
+        let mut buf_reader: Pin<Box<dyn AsyncBufRead + Send>> = if expect_gzip {
+            if !sniff_gzip_magic || payload_is_gzip {
+                Box::pin(BufReader::new(GzipDecoder::new(reader)))
+                    as Pin<Box<dyn AsyncBufRead + Send>>
+            } else {
+                tracing::warn!(
+                    source_name,
+                    object_name,
+                    "object is expected to be gzip-compressed but does not start with the gzip magic number, reading it as plain data; this typically happens when the object carries `Content-Encoding: gzip` metadata and has already been decompressed transparently by the HTTP client",
+                );
+                Box::pin(BufReader::new(reader)) as Pin<Box<dyn AsyncBufRead + Send>>
+            }
+        } else {
+            // todo: support automatic decompression of more compression types.
+            Box::pin(BufReader::new(reader)) as Pin<Box<dyn AsyncBufRead + Send>>
         };
 
-        let mut offset = match object_name.ends_with(".gz") || object_name.ends_with(".gzip") {
+        let mut offset = match has_gzip_extension {
             true => 0,
             false => start_offset,
         };
@@ -231,9 +267,7 @@ impl<Src: OpendalSource> OpendalReader<Src> {
             let msg_offset = (offset + n_read).to_string();
             // note that the buffer contains the newline character
             debug_assert_eq!(n_read, line_buf.len());
-            if (object_name.ends_with(".gz") || object_name.ends_with(".gzip"))
-                && offset + n_read <= start_offset
-            {
+            if has_gzip_extension && offset + n_read <= start_offset {
                 // For gzip compressed files, the reader needs to read from the beginning each time,
                 // but it needs to skip the previously read part and start yielding chunks from a position greater than or equal to start_offset.
             } else {
@@ -260,5 +294,129 @@ impl<Src: OpendalSource> OpendalReader<Src> {
             file_source_input_row_count_metrics.inc_by(batch.len() as _);
             yield batch;
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use async_compression::tokio::write::GzipEncoder;
+    use futures::TryStreamExt;
+    use opendal::Operator;
+    use opendal::services::Memory;
+    use tokio::io::AsyncWriteExt;
+
+    use super::*;
+    use crate::source::SourceContext;
+    use crate::source::filesystem::opendal_source::OpendalS3;
+
+    const CONTENT: &str = "line1\nline2\nline3\n";
+
+    async fn gzipped(data: &[u8]) -> Vec<u8> {
+        let mut encoder = GzipEncoder::new(Vec::new());
+        encoder.write_all(data).await.unwrap();
+        encoder.shutdown().await.unwrap();
+        encoder.into_inner()
+    }
+
+    async fn read_lines(
+        op: &Operator,
+        object_name: &str,
+        compression_format: CompressionFormat,
+    ) -> Vec<String> {
+        let split = OpendalFsSplit::<OpendalS3>::new(object_name.to_owned(), 0, 0);
+        let source_ctx = Arc::new(SourceContext::dummy());
+        let metrics = source_ctx
+            .metrics
+            .file_source_input_row_count
+            .with_guarded_label_values(&["0", "dummy", "0", "0"]);
+        OpendalReader::<OpendalS3>::stream_read_lines(
+            op.clone(),
+            split,
+            source_ctx,
+            compression_format,
+            metrics,
+        )
+        .try_collect::<Vec<_>>()
+        .await
+        .unwrap()
+        .into_iter()
+        .flatten()
+        .map(|m| String::from_utf8(m.payload.unwrap()).unwrap())
+        .collect()
+    }
+
+    fn expected_lines() -> Vec<String> {
+        vec![
+            "line1\n".to_owned(),
+            "line2\n".to_owned(),
+            "line3\n".to_owned(),
+        ]
+    }
+
+    #[tokio::test]
+    async fn test_gzip_payload_with_gzip_extension() {
+        let op = Operator::new(Memory::default()).unwrap();
+        op.write("data.gz", gzipped(CONTENT.as_bytes()).await)
+            .await
+            .unwrap();
+        let lines = read_lines(&op, "data.gz", CompressionFormat::None).await;
+        assert_eq!(lines, expected_lines());
+    }
+
+    #[tokio::test]
+    async fn test_gzip_payload_with_compression_format() {
+        let op = Operator::new(Memory::default()).unwrap();
+        op.write("data.log", gzipped(CONTENT.as_bytes()).await)
+            .await
+            .unwrap();
+        let lines = read_lines(&op, "data.log", CompressionFormat::Gzip).await;
+        assert_eq!(lines, expected_lines());
+    }
+
+    /// A `.gz`-named object whose payload is actually plain data, which happens
+    /// when the object carries `Content-Encoding: gzip` metadata and the HTTP
+    /// client has already decompressed it transparently. This used to fail with
+    /// "Invalid gzip header".
+    #[tokio::test]
+    async fn test_plain_payload_with_gzip_extension() {
+        let op = Operator::new(Memory::default()).unwrap();
+        op.write("data.gz", CONTENT.as_bytes()).await.unwrap();
+        let lines = read_lines(&op, "data.gz", CompressionFormat::None).await;
+        assert_eq!(lines, expected_lines());
+    }
+
+    #[tokio::test]
+    async fn test_plain_payload_with_compression_format() {
+        let op = Operator::new(Memory::default()).unwrap();
+        op.write("data.log", CONTENT.as_bytes()).await.unwrap();
+        let lines = read_lines(&op, "data.log", CompressionFormat::Gzip).await;
+        assert_eq!(lines, expected_lines());
+    }
+
+    #[tokio::test]
+    async fn test_plain_payload_plain_extension() {
+        let op = Operator::new(Memory::default()).unwrap();
+        op.write("data.log", CONTENT.as_bytes()).await.unwrap();
+        let lines = read_lines(&op, "data.log", CompressionFormat::None).await;
+        assert_eq!(lines, expected_lines());
+    }
+
+    /// An object shorter than the gzip magic number must not break the sniffing.
+    #[tokio::test]
+    async fn test_tiny_payload_with_gzip_extension() {
+        let op = Operator::new(Memory::default()).unwrap();
+        op.write("data.gz", "x".as_bytes()).await.unwrap();
+        let lines = read_lines(&op, "data.gz", CompressionFormat::None).await;
+        assert_eq!(lines, vec!["x".to_owned()]);
+    }
+
+    #[tokio::test]
+    async fn test_empty_payload_with_gzip_extension() {
+        let op = Operator::new(Memory::default()).unwrap();
+        op.write("data.gz", Vec::<u8>::new()).await.unwrap();
+        let lines = read_lines(&op, "data.gz", CompressionFormat::None).await;
+        assert!(lines.is_empty());
     }
 }


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

The opendal file source fails with `Connector error: Invalid gzip header` on S3 objects that carry `Content-Encoding: gzip` metadata — which includes everything written by AWS Kinesis Data Firehose with GZIP compression. reqwest's `gzip` feature (enabled transitively by the `opensearch`/`elasticsearch` sink dependencies through cargo feature unification) makes the HTTP client transparently decompress such responses, and `stream_read_lines` then feeds the already-decompressed payload to `GzipDecoder` a second time. See the linked issue for the full root-cause analysis and an A/B reproduction (identical bytes, with/without the metadata).

This PR peeks the first two bytes of the payload and only applies `GzipDecoder` when the payload actually starts with the gzip magic number (RFC 1952), falling back to reading it as plain data with a warning otherwise. The peeked bytes are chained back in front of the remaining stream. Sniffing is skipped when resuming a file without a gzip extension from a non-zero offset, since the peeked bytes would come from the middle of the file — that path keeps today's behavior.

This also makes the source robust against plain files that merely have a `.gz` name.

An alternative/complementary fix would be to build the file source's HTTP transport with `reqwest::Client::builder().no_gzip().no_brotli().no_deflate().no_zstd()` so the connector always sees the raw object bytes; happy to follow up with that if preferred.

- Closes #26855

This affects released versions as well (verified on v2.8.1, where `elasticsearch` enables `reqwest/gzip`), so a cherry-pick to the supported release branches would be appreciated.

## Checklist

- [x] I have written necessary rustdoc comments.
- [x] I have added necessary unit tests and integration tests. <!-- 7 unit tests: gzip/plain payloads × `.gz` extension / `compression_format` combinations, plus sub-magic-length and empty objects -->

## Documentation

- [ ] My PR needs documentation updates.

<details>
<summary><b>Release note</b></summary>

The S3/GCS/Azure Blob file source no longer fails with "Invalid gzip header" on gzip objects stored with `Content-Encoding: gzip` metadata (e.g. objects delivered by AWS Kinesis Data Firehose with GZIP compression). Such objects are now ingested correctly.

</details>
