### PR TITLE
fix(compactor): align iceberg task multiplier default

### DIFF
--- a/src/common/src/config/storage.rs
+++ b/src/common/src/config/storage.rs
@@ -1028,13 +1028,7 @@ pub mod default {
         }
 
         pub fn compactor_max_task_multiplier() -> f32 {
-            match std::env::var("RW_COMPACTOR_MODE")
-                .unwrap_or_default()
-                .as_str()
-            {
-                mode if mode.contains("iceberg") => 12.0000,
-                _ => 3.0000,
-            }
+            3.0
         }
 
         pub fn compactor_memory_available_proportion() -> f64 {


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

The dedicated Iceberg compactor implicitly changed `compactor_max_task_multiplier` from the documented default of `3.0` to `12.0` based on `RW_COMPACTOR_MODE`, while Hummock used `3.0`.

Remove the mode-dependent override so both compactors default to `3.0`. Explicit values in the storage configuration continue to take precedence.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized storage compaction behavior by consistently using the default task multiplier of 3.0.
  * Removed a mode-specific variation that could increase the multiplier unexpectedly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->