### PR TITLE
fix(frontend): enforce source SELECT privilege for postgres_query

### DIFF
--- a/e2e_test/source_inline/tvf/postgres_query.slt
+++ b/e2e_test/source_inline/tvf/postgres_query.slt
@@ -73,5 +73,25 @@ select * from postgres_query('postgres_cdc_source', 'select * from test where id
 99 t 1 1 1 1 1 1.0 2021-01-01 00:00:00 2021-01-01 00:00:00 2021-01-01 08:00:00+00:00 text varchar 1 day {} \x01
 100 t 1 1 1 1 1 1.0 2021-01-01 00:00:00 2021-01-01 00:00:00 2021-01-01 08:00:00+00:00 text varchar 1 day {} \x01
 
+# postgres_query(source_name, query) requires SELECT privilege on that source.
+statement ok
+create user new_user;
+
+system ok
+! psql \
+  -X \
+  -h "$SLT_HOST" \
+  -p "$SLT_PORT" \
+  -U new_user \
+  -d "$SLT_DB" \
+  -v ON_ERROR_STOP=1 \
+  <<'SQL'
+SELECT *
+FROM postgres_query('postgres_cdc_source', 'select id from test limit 1');
+SQL
+
+statement ok
+drop user new_user;
+
 statement ok
 drop source postgres_cdc_source;

--- a/e2e_test/source_inline/tvf/postgres_query.slt
+++ b/e2e_test/source_inline/tvf/postgres_query.slt
@@ -78,17 +78,19 @@ statement ok
 create user new_user;
 
 system ok
-! psql \
+psql \
   -X \
   -h "$SLT_HOST" \
   -p "$SLT_PORT" \
   -U new_user \
   -d "$SLT_DB" \
   -v ON_ERROR_STOP=1 \
-  <<'SQL'
+  2>&1 \
+  <<'SQL' |
 SELECT *
 FROM postgres_query('postgres_cdc_source', 'select id from test limit 1');
 SQL
+grep -Fq 'permission denied for source "postgres_cdc_source": "SELECT"'
 
 statement ok
 drop user new_user;

--- a/src/frontend/src/binder/expr/function/mod.rs
+++ b/src/frontend/src/binder/expr/function/mod.rs
@@ -21,6 +21,7 @@ use itertools::Itertools;
 use risingwave_common::acl::AclMode;
 use risingwave_common::bail_not_implemented;
 use risingwave_common::catalog::INFORMATION_SCHEMA_SCHEMA_NAME;
+use risingwave_common::secret::LocalSecretManager;
 use risingwave_common::types::{DataType, MapType, StructType};
 use risingwave_common::util::iter_util::ZipEqFast;
 use risingwave_expr::aggregate::AggType;
@@ -38,7 +39,7 @@ use crate::catalog::function_catalog::FunctionCatalog;
 use crate::error::{ErrorCode, Result, RwError};
 use crate::expr::{
     Expr, ExprImpl, ExprType, FunctionCall, FunctionCallWithLambda, InputRef, TableFunction,
-    TableFunctionType, UserDefinedFunction,
+    TableFunctionType, UserDefinedFunction, expr_impl_to_string_fn,
 };
 use crate::handler::privilege::ObjectCheckItem;
 
@@ -56,6 +57,9 @@ const SYS_FUNCTION_WITHOUT_ARGS: &[&str] = &[
     "current_schema",
     "current_timestamp",
 ];
+
+const INLINE_QUERY_ARG_LEN: usize = 6;
+const CDC_SOURCE_QUERY_ARG_LEN: usize = 2;
 
 pub(super) fn is_sys_function_without_args(ident: &Ident) -> bool {
     SYS_FUNCTION_WITHOUT_ARGS
@@ -80,6 +84,84 @@ macro_rules! reject_syntax {
 }
 
 impl Binder {
+    fn bind_postgres_or_mysql_query_args(
+        &self,
+        schema_name: Option<&str>,
+        args: Vec<ExprImpl>,
+        expected_connector_name: &str,
+    ) -> Result<Vec<ExprImpl>> {
+        match args.len() {
+            INLINE_QUERY_ARG_LEN => {
+                let mut cast_args = Vec::with_capacity(INLINE_QUERY_ARG_LEN);
+                for arg in args {
+                    cast_args.push(arg.cast_implicit(&DataType::Varchar)?);
+                }
+                Ok(cast_args)
+            }
+            CDC_SOURCE_QUERY_ARG_LEN => {
+                let source_name = expr_impl_to_string_fn(&args[0])?;
+                let source_catalog = self
+                    .catalog
+                    .get_source_by_name(
+                        &self.db_name,
+                        self.bind_schema_path(schema_name),
+                        &source_name,
+                    )?
+                    .0;
+
+                self.check_privilege(
+                    ObjectCheckItem::new(
+                        source_catalog.owner,
+                        AclMode::Select,
+                        source_catalog.name.clone(),
+                        source_catalog.id,
+                    ),
+                    source_catalog.database_id,
+                )?;
+
+                if !source_catalog
+                    .connector_name()
+                    .eq_ignore_ascii_case(expected_connector_name)
+                {
+                    return Err(ErrorCode::BindError(format!(
+                        "TVF function only accepts `mysql-cdc` and `postgres-cdc` source. Expected: {}, but got: {}",
+                        expected_connector_name,
+                        source_catalog.connector_name()
+                    ))
+                    .into());
+                }
+
+                let (props, secret_refs) = source_catalog.with_properties.clone().into_parts();
+                let secret_resolved =
+                    LocalSecretManager::global().fill_secrets(props, secret_refs)?;
+
+                let mut args_vec = vec![
+                    ExprImpl::literal_varchar(secret_resolved["hostname"].clone()),
+                    ExprImpl::literal_varchar(secret_resolved["port"].clone()),
+                    ExprImpl::literal_varchar(secret_resolved["username"].clone()),
+                    ExprImpl::literal_varchar(secret_resolved["password"].clone()),
+                    ExprImpl::literal_varchar(secret_resolved["database.name"].clone()),
+                    args[1].clone().cast_implicit(&DataType::Varchar)?,
+                ];
+
+                if expected_connector_name.eq_ignore_ascii_case("postgres-cdc") {
+                    args_vec.push(ExprImpl::literal_varchar(
+                        secret_resolved.get("ssl.mode").cloned().unwrap_or_default(),
+                    ));
+                    args_vec.push(ExprImpl::literal_varchar(
+                        secret_resolved
+                            .get("ssl.root.cert")
+                            .cloned()
+                            .unwrap_or_default(),
+                    ));
+                }
+
+                Ok(args_vec)
+            }
+            _ => Err(ErrorCode::BindError("postgres_query function and mysql_query function accept either 2 arguments: (cdc_source_name varchar, query varchar) or 6 arguments: (hostname varchar, port varchar, username varchar, password varchar, database_name varchar, query varchar)".to_owned()).into()),
+        }
+    }
+
     pub(in crate::binder) fn bind_function(
         &mut self,
         Function {
@@ -392,14 +474,12 @@ impl Binder {
                     "`VARIADIC` is not allowed in table function call"
                 );
                 self.ensure_table_function_allowed()?;
-                return Ok(TableFunction::new_postgres_query(
-                    &self.catalog,
-                    &self.db_name,
-                    self.bind_schema_path(schema_name.as_deref()),
-                    args,
-                )
-                .context("postgres_query error")?
-                .into());
+                let args = self
+                    .bind_postgres_or_mysql_query_args(schema_name.as_deref(), args, "postgres-cdc")
+                    .context("postgres_query error")?;
+                return Ok(TableFunction::new_postgres_query(args)
+                    .context("postgres_query error")?
+                    .into());
             }
             // `mysql_query` table function
             if func_name.eq("mysql_query") {
@@ -408,14 +488,12 @@ impl Binder {
                     "`VARIADIC` is not allowed in table function call"
                 );
                 self.ensure_table_function_allowed()?;
-                return Ok(TableFunction::new_mysql_query(
-                    &self.catalog,
-                    &self.db_name,
-                    self.bind_schema_path(schema_name.as_deref()),
-                    args,
-                )
-                .context("mysql_query error")?
-                .into());
+                let args = self
+                    .bind_postgres_or_mysql_query_args(schema_name.as_deref(), args, "mysql-cdc")
+                    .context("mysql_query error")?;
+                return Ok(TableFunction::new_mysql_query(args)
+                    .context("mysql_query error")?
+                    .into());
             }
             // `internal_backfill_progress` table function
             if func_name.eq("internal_backfill_progress") {

--- a/src/frontend/src/expr/mod.rs
+++ b/src/frontend/src/expr/mod.rs
@@ -71,6 +71,7 @@ pub use risingwave_pb::expr::expr_node::Type as ExprType;
 pub use secret_ref::SecretRef;
 pub use session_timezone::{SessionTimezone, TimestamptzExprFinder};
 pub use subquery::{Subquery, SubqueryKind};
+pub(crate) use table_function::expr_impl_to_string_fn;
 pub use table_function::{TableFunction, TableFunctionType};
 pub use type_inference::*;
 pub use user_defined_function::UserDefinedFunction;

--- a/src/frontend/src/expr/table_function.rs
+++ b/src/frontend/src/expr/table_function.rs
@@ -19,7 +19,6 @@ use itertools::Itertools;
 use mysql_async::consts::ColumnType as MySqlColumnType;
 use mysql_async::prelude::*;
 use risingwave_common::array::arrow::IcebergArrowConvert;
-use risingwave_common::secret::LocalSecretManager;
 use risingwave_common::types::{DataType, ScalarImpl, StructType};
 use risingwave_connector::connector_common::{PgConnectionConfig, create_pg_client};
 use risingwave_connector::source::iceberg::{
@@ -31,15 +30,10 @@ pub use risingwave_pb::expr::table_function::PbType as TableFunctionType;
 use tokio_postgres::types::Type as TokioPgType;
 
 use super::{Expr, ExprImpl, ExprRewriter, Literal, RwResult, infer_type};
-use crate::catalog::catalog_service::CatalogReadGuard;
 use crate::catalog::function_catalog::{FunctionCatalog, FunctionKind};
-use crate::catalog::root_catalog::SchemaPath;
 use crate::error::ErrorCode::BindError;
 use crate::expr::reject_impure;
 use crate::utils::FRONTEND_RUNTIME;
-
-const INLINE_ARG_LEN: usize = 6;
-const CDC_SOURCE_ARG_LEN: usize = 2;
 
 /// A table function takes a row as input and returns a table. It is also known as Set-Returning
 /// Function.
@@ -298,85 +292,7 @@ impl TableFunction {
         })
     }
 
-    fn handle_postgres_or_mysql_query_args(
-        catalog_reader: &CatalogReadGuard,
-        db_name: &str,
-        schema_path: SchemaPath<'_>,
-        args: Vec<ExprImpl>,
-        expect_connector_name: &str,
-    ) -> RwResult<Vec<ExprImpl>> {
-        let cast_args = match args.len() {
-            INLINE_ARG_LEN => {
-                let mut cast_args = Vec::with_capacity(INLINE_ARG_LEN);
-                for arg in args {
-                    let arg = arg.cast_implicit(&DataType::Varchar)?;
-                    cast_args.push(arg);
-                }
-                cast_args
-            }
-            CDC_SOURCE_ARG_LEN => {
-                let source_name = expr_impl_to_string_fn(&args[0])?;
-                let source_catalog = catalog_reader
-                    .get_source_by_name(db_name, schema_path, &source_name)?
-                    .0;
-                if !source_catalog
-                    .connector_name()
-                    .eq_ignore_ascii_case(expect_connector_name)
-                {
-                    return Err(BindError(format!("TVF function only accepts `mysql-cdc` and `postgres-cdc` source. Expected: {}, but got: {}", expect_connector_name, source_catalog.connector_name())).into());
-                }
-
-                let (props, secret_refs) = source_catalog.with_properties.clone().into_parts();
-                let secret_resolved =
-                    LocalSecretManager::global().fill_secrets(props, secret_refs)?;
-
-                let mut args_vec = vec![
-                    ExprImpl::literal_varchar(secret_resolved["hostname"].clone()),
-                    ExprImpl::literal_varchar(secret_resolved["port"].clone()),
-                    ExprImpl::literal_varchar(secret_resolved["username"].clone()),
-                    ExprImpl::literal_varchar(secret_resolved["password"].clone()),
-                    ExprImpl::literal_varchar(secret_resolved["database.name"].clone()),
-                    args.get(1)
-                        .unwrap()
-                        .clone()
-                        .cast_implicit(&DataType::Varchar)?,
-                ];
-
-                if expect_connector_name.eq_ignore_ascii_case("postgres-cdc") {
-                    args_vec.push(ExprImpl::literal_varchar(
-                        secret_resolved.get("ssl.mode").cloned().unwrap_or_default(),
-                    ));
-                    args_vec.push(ExprImpl::literal_varchar(
-                        secret_resolved
-                            .get("ssl.root.cert")
-                            .cloned()
-                            .unwrap_or_default(),
-                    ));
-                }
-
-                args_vec
-            }
-            _ => {
-                return Err(BindError("postgres_query function and mysql_query function accept either 2 arguments: (cdc_source_name varchar, query varchar) or 6 arguments: (hostname varchar, port varchar, username varchar, password varchar, database_name varchar, query varchar)".to_owned()).into());
-            }
-        };
-
-        Ok(cast_args)
-    }
-
-    pub fn new_postgres_query(
-        catalog_reader: &CatalogReadGuard,
-        db_name: &str,
-        schema_path: SchemaPath<'_>,
-        args: Vec<ExprImpl>,
-    ) -> RwResult<Self> {
-        let args = Self::handle_postgres_or_mysql_query_args(
-            catalog_reader,
-            db_name,
-            schema_path,
-            args,
-            "postgres-cdc",
-        )?;
+    pub fn new_postgres_query(args: Vec<ExprImpl>) -> RwResult<Self> {
         let evaled_args = args
             .iter()
             .map(expr_impl_to_string_fn)
@@ -463,19 +379,7 @@ impl TableFunction {
         }
     }
 
-    pub fn new_mysql_query(
-        catalog_reader: &CatalogReadGuard,
-        db_name: &str,
-        schema_path: SchemaPath<'_>,
-        args: Vec<ExprImpl>,
-    ) -> RwResult<Self> {
-        let args = Self::handle_postgres_or_mysql_query_args(
-            catalog_reader,
-            db_name,
-            schema_path,
-            args,
-            "mysql-cdc",
-        )?;
+    pub fn new_mysql_query(args: Vec<ExprImpl>) -> RwResult<Self> {
         let evaled_args = args
             .iter()
             .map(expr_impl_to_string_fn)
@@ -735,7 +639,7 @@ impl Expr for TableFunction {
     }
 }
 
-fn expr_impl_to_string_fn(arg: &ExprImpl) -> RwResult<String> {
+pub(crate) fn expr_impl_to_string_fn(arg: &ExprImpl) -> RwResult<String> {
     match arg.try_fold_const() {
         Some(Ok(value)) => {
             let Some(scalar) = value else {


### PR DESCRIPTION
## What changed

- Require `SELECT` privilege on the referenced CDC source when using the source-backed `postgres_query(source_name, query)` overload.
- Perform the privilege check before resolving source secrets or connecting to upstream PostgreSQL.
- Apply the same check to the shared source-backed `mysql_query` path.
- Leave the six-argument overload, where callers provide credentials directly, unchanged.
- Add an SLT regression covering an unprivileged RisingWave user.

code change is mostly just adding [this](https://github.com/risingwavelabs/risingwave/pull/26862/changes#diff-abe0fae35cac6452c8d3165bb592d95cfd631c500a67ca82b110a8590f90282bR112-R120) check, but some functions had to be moved around for accessibility.

## Why

The two-argument `postgres_query` overload resolved a CDC source directly and used its stored connection credentials without checking whether the current RisingWave user had `SELECT` privilege on that source.

This allowed a user without access to the source to query upstream PostgreSQL through the source owner credentials.

## Testing

- `cargo check -p risingwave_frontend --lib`
- `./risedev slt ./e2e_test/source_inline/tvf/postgres_query.slt`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for running PostgreSQL and MySQL CDC queries by specifying a source name and query.
  * Added validation of source type and required `SELECT` privileges before execution.
  * Added automatic handling of connector settings, secrets, and PostgreSQL SSL configuration.

* **Bug Fixes**
  * Improved permission handling so unauthorized source queries return a clear access-denied error.

* **Tests**
  * Added end-to-end coverage for PostgreSQL query privilege enforcement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->