### PR TITLE
perf(iceberg): use partition-affinity compaction backport

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6955,7 +6955,7 @@ dependencies = [
 [[package]]
 name = "iceberg-compaction-core"
 version = "0.1.0"
-source = "git+https://github.com/nimtable/iceberg-compaction.git?rev=b29220e1656f56b49a8630a04f2fb26cc3aec2bb#b29220e1656f56b49a8630a04f2fb26cc3aec2bb"
+source = "git+https://github.com/nimtable/iceberg-compaction.git?rev=77f6cc305d872a43a8c33c67416846fc12b8971b#77f6cc305d872a43a8c33c67416846fc12b8971b"
 dependencies = [
  "async-stream",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6955,7 +6955,7 @@ dependencies = [
 [[package]]
 name = "iceberg-compaction-core"
 version = "0.1.0"
-source = "git+https://github.com/nimtable/iceberg-compaction.git?rev=683de44b7b9b25183f6405f377d690f90f79788a#683de44b7b9b25183f6405f377d690f90f79788a"
+source = "git+https://github.com/nimtable/iceberg-compaction.git?rev=b29220e1656f56b49a8630a04f2fb26cc3aec2bb#b29220e1656f56b49a8630a04f2fb26cc3aec2bb"
 dependencies = [
  "async-stream",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6955,7 +6955,7 @@ dependencies = [
 [[package]]
 name = "iceberg-compaction-core"
 version = "0.1.0"
-source = "git+https://github.com/nimtable/iceberg-compaction.git?rev=77f6cc305d872a43a8c33c67416846fc12b8971b#77f6cc305d872a43a8c33c67416846fc12b8971b"
+source = "git+https://github.com/nimtable/iceberg-compaction.git?rev=68199414368e094af21cd54191c69f2560409288#68199414368e094af21cd54191c69f2560409288"
 dependencies = [
  "async-stream",
  "async-trait",

--- a/src/storage/Cargo.toml
+++ b/src/storage/Cargo.toml
@@ -33,7 +33,7 @@ futures = { version = "0.3", default-features = false, features = ["alloc"] }
 futures-async-stream = { workspace = true }
 hex = "0.4"
 iceberg = { workspace = true }
-iceberg-compaction-core = { git = "https://github.com/nimtable/iceberg-compaction.git", rev = "683de44b7b9b25183f6405f377d690f90f79788a" }
+iceberg-compaction-core = { git = "https://github.com/nimtable/iceberg-compaction.git", rev = "b29220e1656f56b49a8630a04f2fb26cc3aec2bb" }
 itertools = { workspace = true }
 libc = "0.2"
 lz4 = "1.28.0"

--- a/src/storage/Cargo.toml
+++ b/src/storage/Cargo.toml
@@ -33,7 +33,7 @@ futures = { version = "0.3", default-features = false, features = ["alloc"] }
 futures-async-stream = { workspace = true }
 hex = "0.4"
 iceberg = { workspace = true }
-iceberg-compaction-core = { git = "https://github.com/nimtable/iceberg-compaction.git", rev = "77f6cc305d872a43a8c33c67416846fc12b8971b" }
+iceberg-compaction-core = { git = "https://github.com/nimtable/iceberg-compaction.git", rev = "68199414368e094af21cd54191c69f2560409288" }
 itertools = { workspace = true }
 libc = "0.2"
 lz4 = "1.28.0"

--- a/src/storage/Cargo.toml
+++ b/src/storage/Cargo.toml
@@ -33,7 +33,7 @@ futures = { version = "0.3", default-features = false, features = ["alloc"] }
 futures-async-stream = { workspace = true }
 hex = "0.4"
 iceberg = { workspace = true }
-iceberg-compaction-core = { git = "https://github.com/nimtable/iceberg-compaction.git", rev = "b29220e1656f56b49a8630a04f2fb26cc3aec2bb" }
+iceberg-compaction-core = { git = "https://github.com/nimtable/iceberg-compaction.git", rev = "77f6cc305d872a43a8c33c67416846fc12b8971b" }
 itertools = { workspace = true }
 libc = "0.2"
 lz4 = "1.28.0"


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What’s changed and what’s your intention?

Updates the `iceberg-compaction-core` revision used by #26757 to the release-line backport in [nimtable/iceberg-compaction#183](https://github.com/nimtable/iceberg-compaction/pull/183).

The backport hash-repartitions partitioned compaction output by the complete transformed Iceberg partition value before sorting and writing. Each Iceberg partition is assigned to one output stream, avoiding output-stream × partition writer fan-out while retaining size-based parallelism. Groups proven to contain one partition under the current spec keep round-robin distribution for throughput; files from old or missing specs stay on the hash path so partition-spec evolution cannot underestimate fan-out.

The dependency remains on the release-3.0 DataFusion 53 and iceberg-rust 515177 stack. This PR changes only the dependency revision and lockfile source hash.

Part of #26757.

## Checklist

- [x] I have written necessary rustdoc comments.
- [x] I have added necessary unit tests and integration tests.
- [x] I have added test labels as necessary.
- [ ] I have added fuzzing tests or opened an issue to track them.
- [ ] My PR contains breaking changes.
- [ ] My PR changes performance-critical code, so I will run benchmarks and present the results.
- [x] I have checked the Release Timeline and Currently Supported Versions to determine which release branches need this change.

## Documentation

- [ ] My PR needs documentation updates.