### PR TITLE
fix(postgres-query): make source-backed queries read-only

### DIFF
--- a/e2e_test/source_inline/tvf/postgres_query.slt
+++ b/e2e_test/source_inline/tvf/postgres_query.slt
@@ -74,4 +74,30 @@ select * from postgres_query('postgres_cdc_source', 'select * from test where id
 100 t 1 1 1 1 1 1.0 2021-01-01 00:00:00 2021-01-01 00:00:00 2021-01-01 08:00:00+00:00 text varchar 1 day {} \x01
 
 statement ok
+create user postgres_query_read_only_user;
+
+statement ok
+grant select on source postgres_cdc_source to postgres_query_read_only_user;
+
+# SELECT privilege on a source must not authorize upstream writes.
+system ok
+! psql \
+  -X \
+  -h "$SLT_HOST" \
+  -p "$SLT_PORT" \
+  -U postgres_query_read_only_user \
+  -d "$SLT_DB" \
+  -v ON_ERROR_STOP=1 \
+  <<'SQL'
+SELECT *
+FROM postgres_query(
+  'postgres_cdc_source',
+  'update test set v12 = ''mutated'' where id = 1'
+);
+SQL
+
+statement ok
+drop user postgres_query_read_only_user;
+
+statement ok
 drop source postgres_cdc_source;

--- a/proto/batch_plan.proto
+++ b/proto/batch_plan.proto
@@ -160,6 +160,7 @@ message PostgresQueryNode {
   string query = 7;
   string ssl_mode = 8;
   string ssl_root_cert = 9;
+  bool read_only = 10;
 }
 
 // NOTE(kwannoel): This will only be used in batch mode. We can change the definition as needed.

--- a/src/batch/executors/src/executor/postgres_query.rs
+++ b/src/batch/executors/src/executor/postgres_query.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use anyhow::Context;
+use either::Either;
 use futures_async_stream::try_stream;
 use futures_util::stream::StreamExt;
 use risingwave_common::array::DataChunk;
@@ -32,6 +33,7 @@ pub struct PostgresQueryExecutor {
     schema: Schema,
     config: PgConnectionConfig,
     query: String,
+    read_only: bool,
     identity: String,
     chunk_size: usize,
 }
@@ -107,6 +109,7 @@ impl PostgresQueryExecutor {
         schema: Schema,
         config: PgConnectionConfig,
         query: String,
+        read_only: bool,
         identity: String,
         chunk_size: usize,
     ) -> Self {
@@ -114,6 +117,7 @@ impl PostgresQueryExecutor {
             schema,
             config,
             query,
+            read_only,
             identity,
             chunk_size,
         }
@@ -123,16 +127,33 @@ impl PostgresQueryExecutor {
     async fn do_execute(self: Box<Self>) {
         tracing::debug!("postgres_query_executor: started");
 
-        let client = create_pg_client(&self.config, None).await?;
-
+        let mut client = create_pg_client(&self.config, None).await?;
         let params: &[&str] = &[];
-        let row_stream = client
+
+        let execution = if self.read_only {
+            Either::Left(
+                client
+                    .build_transaction()
+                    .read_only(true)
+                    .start()
+                    .await
+                    .context("failed to start read-only transaction for postgres_query")?,
+            )
+        } else {
+            Either::Right(&client)
+        };
+
+        let query_client = match &execution {
+            Either::Left(transaction) => transaction.client(),
+            Either::Right(client) => client,
+        };
+        let row_stream = query_client
             .query_raw(&self.query, params)
             .await
             .context("postgres_query received error from remote server")?;
+
         let mut builder = DataChunkBuilder::new(self.schema.data_types(), self.chunk_size);
         tracing::debug!("postgres_query_executor: query executed, start deserializing rows");
-        // deserialize the rows
         #[for_await]
         for row in row_stream {
             let row = row?;
@@ -144,6 +165,14 @@ impl PostgresQueryExecutor {
         if let Some(chunk) = builder.consume_all() {
             yield chunk;
         }
+
+        if let Either::Left(transaction) = execution {
+            transaction
+                .commit()
+                .await
+                .context("failed to commit read-only transaction for postgres_query")?;
+        }
+
         return Ok(());
     }
 }
@@ -180,6 +209,7 @@ impl BoxedExecutorBuilder for PostgresQueryExecutorBuilder {
                 },
             },
             postgres_query_node.query.clone(),
+            postgres_query_node.read_only,
             source.plan_node().get_identity().clone(),
             source.context().get_config().developer.chunk_size,
         )))

--- a/src/frontend/src/optimizer/plan_node/batch_postgres_query.rs
+++ b/src/frontend/src/optimizer/plan_node/batch_postgres_query.rs
@@ -90,6 +90,7 @@ impl ToBatchPb for BatchPostgresQuery {
             query: self.core.query.clone(),
             ssl_mode: self.core.ssl_mode.clone().unwrap_or_default(),
             ssl_root_cert: self.core.ssl_root_cert.clone().unwrap_or_default(),
+            read_only: self.core.read_only,
         })
     }
 }

--- a/src/frontend/src/optimizer/plan_node/generic/postgres_query.rs
+++ b/src/frontend/src/optimizer/plan_node/generic/postgres_query.rs
@@ -31,6 +31,7 @@ pub struct PostgresQuery {
     pub query: String,
     pub ssl_mode: Option<String>,
     pub ssl_root_cert: Option<String>,
+    pub read_only: bool,
 
     #[educe(PartialEq(ignore))]
     #[educe(Hash(ignore))]

--- a/src/frontend/src/optimizer/plan_node/logical_postgres_query.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_postgres_query.rs
@@ -50,6 +50,7 @@ impl LogicalPostgresQuery {
         query: String,
         ssl_mode: Option<String>,
         ssl_root_cert: Option<String>,
+        read_only: bool,
     ) -> Self {
         let core = generic::PostgresQuery {
             schema,
@@ -61,6 +62,7 @@ impl LogicalPostgresQuery {
             query,
             ssl_mode,
             ssl_root_cert,
+            read_only,
             ctx,
         };
 

--- a/src/frontend/src/optimizer/plan_node/logical_postgres_query.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_postgres_query.rs
@@ -14,7 +14,6 @@
 
 use pretty_xmlish::XmlNode;
 use risingwave_common::bail;
-use risingwave_common::catalog::Schema;
 
 use super::generic::GenericPlanRef;
 use super::utils::{Distill, childless_record};
@@ -22,7 +21,6 @@ use super::{
     BatchPostgresQuery, ColPrunable, ExprRewritable, Logical, LogicalPlanRef as PlanRef,
     LogicalProject, PlanBase, PredicatePushdown, ToBatch, ToStream, generic,
 };
-use crate::OptimizerContextRef;
 use crate::error::Result;
 use crate::optimizer::plan_node::expr_visitable::ExprVisitable;
 use crate::optimizer::plan_node::utils::column_names_pretty;
@@ -39,36 +37,10 @@ pub struct LogicalPostgresQuery {
 }
 
 impl LogicalPostgresQuery {
-    pub fn new(
-        ctx: OptimizerContextRef,
-        schema: Schema,
-        hostname: String,
-        port: String,
-        username: String,
-        password: String,
-        database: String,
-        query: String,
-        ssl_mode: Option<String>,
-        ssl_root_cert: Option<String>,
-        read_only: bool,
-    ) -> Self {
-        let core = generic::PostgresQuery {
-            schema,
-            hostname,
-            port,
-            username,
-            password,
-            database,
-            query,
-            ssl_mode,
-            ssl_root_cert,
-            read_only,
-            ctx,
-        };
-
+    pub fn new(core: generic::PostgresQuery) -> Self {
         let base = PlanBase::new_logical_with_core(&core);
 
-        LogicalPostgresQuery { base, core }
+        Self { base, core }
     }
 }
 

--- a/src/frontend/src/optimizer/rule/table_function_to_postgres_query_rule.rs
+++ b/src/frontend/src/optimizer/rule/table_function_to_postgres_query_rule.rs
@@ -21,6 +21,9 @@ use crate::expr::{Expr, TableFunctionType};
 use crate::optimizer::plan_node::generic::GenericPlanRef;
 use crate::optimizer::plan_node::{LogicalPostgresQuery, LogicalTableFunction};
 
+const EXPLICIT_CREDENTIAL_QUERY_ARG_LEN: usize = 6;
+const SOURCE_BACKED_QUERY_ARG_LEN: usize = 8;
+
 /// Transform a special `TableFunction` (with `POSTGRES_QUERY` table function type) into a `LogicalPostgresQuery`
 pub struct TableFunctionToPostgresQueryRule {}
 impl Rule<Logical> for TableFunctionToPostgresQueryRule {
@@ -41,7 +44,6 @@ impl Rule<Logical> for TableFunctionToPostgresQueryRule {
 
             let schema = Schema::new(fields);
 
-            assert!(logical_table_function.table_function().args.len() >= 6);
             let mut eval_args = vec![];
             for arg in &logical_table_function.table_function().args {
                 assert_eq!(arg.return_type(), DataType::Varchar);
@@ -55,6 +57,11 @@ impl Rule<Logical> for TableFunctionToPostgresQueryRule {
                     }
                 }
             }
+            let read_only = match eval_args.len() {
+                EXPLICIT_CREDENTIAL_QUERY_ARG_LEN => false,
+                SOURCE_BACKED_QUERY_ARG_LEN => true,
+                len => unreachable!("postgres_query must have 6 or 8 arguments, got {len}"),
+            };
             let hostname = eval_args[0].clone();
             let port = eval_args[1].clone();
             let username = eval_args[2].clone();
@@ -76,6 +83,7 @@ impl Rule<Logical> for TableFunctionToPostgresQueryRule {
                     query,
                     ssl_mode,
                     ssl_root_cert,
+                    read_only,
                 )
                 .into(),
             )

--- a/src/frontend/src/optimizer/rule/table_function_to_postgres_query_rule.rs
+++ b/src/frontend/src/optimizer/rule/table_function_to_postgres_query_rule.rs
@@ -18,7 +18,7 @@ use risingwave_common::types::{DataType, ScalarImpl};
 
 use super::prelude::{PlanRef, *};
 use crate::expr::{Expr, TableFunctionType};
-use crate::optimizer::plan_node::generic::GenericPlanRef;
+use crate::optimizer::plan_node::generic::{self, GenericPlanRef};
 use crate::optimizer::plan_node::{LogicalPostgresQuery, LogicalTableFunction};
 
 const EXPLICIT_CREDENTIAL_QUERY_ARG_LEN: usize = 6;
@@ -72,8 +72,7 @@ impl Rule<Logical> for TableFunctionToPostgresQueryRule {
             let ssl_root_cert = eval_args.get(7).cloned();
 
             Some(
-                LogicalPostgresQuery::new(
-                    logical_table_function.ctx(),
+                LogicalPostgresQuery::new(generic::PostgresQuery {
                     schema,
                     hostname,
                     port,
@@ -84,7 +83,8 @@ impl Rule<Logical> for TableFunctionToPostgresQueryRule {
                     ssl_mode,
                     ssl_root_cert,
                     read_only,
-                )
+                    ctx: logical_table_function.ctx(),
+                })
                 .into(),
             )
         } else {


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

`postgres_query` supports an explicit-credential overload and a source-backed overload. The source-backed overload reuses the PostgreSQL credentials stored in a RisingWave source. Previously, its query ran with the full upstream privileges of those credentials, allowing a caller with access to the source to execute statements such as `UPDATE` against the upstream database.

This PR makes source-backed `postgres_query(source_name, query)` calls read-only:

- Distinguish the normalized source-backed arguments from the explicit-credential arguments and propagate a `read_only` flag through the logical plan, batch plan, and protobuf.
- Execute source-backed queries in a tokio-postgres read-only transaction, consume the streamed rows, and commit the transaction afterward.
- Preserve the existing autocommit behavior for the explicit-credential overload.
- Add an end-to-end regression test that verifies a plain upstream `UPDATE` is rejected.

## Testing

- `cargo fmt --all --check`
- `git diff --check`
- `cargo check --offline -p risingwave_frontend -p risingwave_batch_executors`
- `cargo clippy --offline -p risingwave_frontend --all-targets -- -D warnings`
- `./risedev slt './e2e_test/source_inline/tvf/postgres_query.slt'`

## Checklist

- [ ] I have written necessary rustdoc comments.
- [x] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [x] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/dev/src/ci.md#ci-labels-guide -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->

## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added read-only execution support for PostgreSQL queries.
  * Read-only queries now run in protected transactions that prevent data modifications.
  * PostgreSQL query configuration supports both credential-based and source-backed queries.
* **Bug Fixes**
  * Improved authorization enforcement so data-changing operations are rejected during read-only execution.
  * Added end-to-end coverage verifying that unauthorized updates cannot run through read-only queries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
