### PR TITLE
fix(sink): support coordinated sinks with singleton input

### DIFF
--- a/e2e_test/iceberg/test_case/pure_slt/iceberg_sink_singleton.slt
+++ b/e2e_test/iceberg/test_case/pure_slt/iceberg_sink_singleton.slt
@@ -1,0 +1,85 @@
+# A streaming LIMIT makes the sink fragment singleton. Coordinated sinks must still
+# commit the sole writer's metadata instead of rejecting its omitted vnode bitmap.
+
+system ok
+sparksql --e "
+DROP TABLE IF EXISTS demo.demo_db.e2e_singleton_sink_table PURGE;
+"
+
+statement ok
+SET sink_decouple = true;
+
+statement ok
+CREATE TABLE iceberg_singleton_sink_input (id INT, name VARCHAR) APPEND ONLY;
+
+statement ok
+CREATE SINK iceberg_singleton_sink AS
+SELECT id, name
+FROM iceberg_singleton_sink_input
+LIMIT 3
+WITH (
+    connector = 'iceberg',
+    type = 'append-only',
+    force_append_only = 'true',
+    warehouse.path = 's3a://icebergdata',
+    s3.endpoint = 'http://127.0.0.1:9301',
+    s3.access.key = 'hummockadmin',
+    s3.secret.key = 'hummockadmin',
+    s3.region = 'us-east-1',
+    catalog.name = 'demo',
+    catalog.type = 'storage',
+    database.name = 'demo_db',
+    table.name = 'e2e_singleton_sink_table',
+    commit_checkpoint_interval = 1,
+    create_table_if_not_exists = 'true'
+);
+
+query I
+SELECT watermark_vnode_count
+FROM rw_catalog.rw_sink_decouple
+JOIN rw_catalog.rw_sinks ON rw_sinks.id = rw_sink_decouple.sink_id
+WHERE rw_sinks.name = 'iceberg_singleton_sink';
+----
+1
+
+statement ok
+CREATE SOURCE iceberg_singleton_sink_source WITH (
+    connector = 'iceberg',
+    warehouse.path = 's3a://icebergdata',
+    s3.endpoint = 'http://127.0.0.1:9301',
+    s3.access.key = 'hummockadmin',
+    s3.secret.key = 'hummockadmin',
+    s3.region = 'us-east-1',
+    catalog.name = 'demo',
+    catalog.type = 'storage',
+    database.name = 'demo_db',
+    table.name = 'e2e_singleton_sink_table'
+);
+
+statement ok
+INSERT INTO iceberg_singleton_sink_input VALUES
+    (1, 'alice'),
+    (2, 'bob'),
+    (3, 'carol');
+
+statement ok
+FLUSH;
+
+query IT retry 10 backoff 1s
+SELECT id, name FROM iceberg_singleton_sink_source ORDER BY id;
+----
+1 alice
+2 bob
+3 carol
+
+statement ok
+DROP SOURCE iceberg_singleton_sink_source;
+
+statement ok
+DROP SINK iceberg_singleton_sink;
+
+statement ok
+DROP TABLE iceberg_singleton_sink_input;
+
+system ok
+sparksql --e "DROP TABLE IF EXISTS demo.demo_db.e2e_singleton_sink_table PURGE;"

--- a/src/connector/src/sink/coordinate.rs
+++ b/src/connector/src/sink/coordinate.rs
@@ -21,6 +21,7 @@ use anyhow::anyhow;
 use async_trait::async_trait;
 use risingwave_common::bail;
 use risingwave_common::bitmap::Bitmap;
+use risingwave_common::hash::VnodeBitmapExt;
 use risingwave_pb::connector_service::SinkMetadata;
 use tracing::{info, warn};
 
@@ -57,13 +58,12 @@ impl<W: SinkWriter<CommitMetadata = Option<SinkMetadata>>> CoordinatedLogSinker<
                 .sink_coordinate_client()
                 .await,
             param,
+            // Singleton actors do not carry a vnode bitmap. For sink coordination, the only
+            // writer owns the singleton fragment's sole vnode.
             vnode_bitmap: writer_param
                 .vnode_bitmap
-                .as_ref()
-                .ok_or_else(|| {
-                    anyhow!("sink needs coordination and should not have singleton input")
-                })?
-                .clone(),
+                .clone()
+                .unwrap_or_else(|| Bitmap::singleton().clone()),
             commit_checkpoint_interval,
             sink_writer_metrics: SinkWriterMetrics::new(writer_param),
         })

--- a/src/tests/simulation/tests/integration_tests/sink/basic.rs
+++ b/src/tests/simulation/tests/integration_tests/sink/basic.rs
@@ -17,7 +17,7 @@ use std::time::{Duration, Instant};
 
 use anyhow::Result;
 use itertools::Itertools;
-use tokio::time::sleep;
+use tokio::time::{sleep, timeout};
 
 use crate::sink::utils::*;
 use crate::{assert_eq_with_err_returned as assert_eq, assert_with_err_returned as assert};
@@ -100,6 +100,52 @@ async fn basic_test_inner(is_decouple: bool, test_type: TestSinkType) -> Result<
 
     assert_eq!(0, test_sink.parallelism_counter.load(Relaxed));
     test_sink.store.check_simple_result(&test_source.id_list)?;
+    assert!(test_sink.store.checkpoint_count() > 0);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_coordinated_sink_with_singleton_input() -> Result<()> {
+    let mut cluster = start_sink_test_cluster().await?;
+
+    let source_parallelism = 2;
+    let test_sink = SimulationTestSink::register_new(TestSinkType::SinglePhaseCoordinatedSink);
+    let test_source = SimulationTestSource::register_new(source_parallelism, 0..10, 1.0, 20);
+
+    let mut session = cluster.start_session();
+    session.run("set streaming_parallelism = 2").await?;
+    session.run("set sink_decouple = true").await?;
+    session.run(CREATE_SOURCE).await?;
+    session
+        .run(
+            "create sink test_sink as \
+             select id, name from test_source limit 10 \
+             with (connector = 'test', type = 'append-only', force_append_only = 'true')",
+        )
+        .await?;
+
+    timeout(
+        Duration::from_secs(30),
+        test_sink.wait_initial_parallelism(1),
+    )
+    .await??;
+    timeout(Duration::from_secs(30), test_sink.store.wait_for_count(10)).await??;
+
+    let result = session.run("select * from rw_sink_decouple").await?;
+    let [_, is_sink_decouple, vnode_count] =
+        TryInto::<[&str; 3]>::try_into(result.split_whitespace().collect_vec()).unwrap();
+    assert_eq!(is_sink_decouple, "t");
+    assert_eq!(vnode_count, "1");
+
+    session.run(DROP_SINK).await?;
+    session.run(DROP_SOURCE).await?;
+
+    assert_eq!(
+        source_parallelism,
+        test_source.create_stream_count.load(Relaxed)
+    );
+    assert_eq!(0, test_sink.parallelism_counter.load(Relaxed));
     assert!(test_sink.store.checkpoint_count() > 0);
 
     Ok(())


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

Coordinated sink writers currently reject singleton input because singleton actors intentionally omit their vnode bitmap. This failure happens after DDL creation, so the sink executor continuously rewinds and retries without producing output.

Treat an omitted writer bitmap as the canonical singleton vnode bitmap. The sole coordinated writer then owns the only vnode in the singleton fragment, matching the existing fragment and table representation. Add simulation and Iceberg end-to-end regressions that build coordinated sinks over singleton input and verify that data reaches the sink through Meta coordination and an external Iceberg commit.

- Closes #26854

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Coordinated sinks now support singleton inputs without vnode bitmap configuration.
  * Single-phase coordinated sinks can initialize and process decoupled inputs.

* **Bug Fixes**
  * Prevented initialization failures for singleton inputs missing vnode bitmap data.

* **Tests**
  * Added integration coverage for singleton sink processing, decoupling, cleanup, and timeouts.
  * Added end-to-end coverage for singleton Iceberg sinks created by streaming limits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
