### PR TITLE
fix(frontend): avoid missing existing table change log epochs

### DIFF
--- a/src/frontend/src/scheduler/snapshot.rs
+++ b/src/frontend/src/scheduler/snapshot.rs
@@ -325,10 +325,6 @@ impl HummockSnapshotManager {
     ) -> Result<(), RwError> {
         let mut rx = self.version_update_notification_sender.subscribe();
         loop {
-            rx.changed()
-                .await
-                .map_err(|_| ErrorCode::InternalError("cursor notify channel is closed.".into()))?;
-            let _ = rx.borrow_and_update();
             if let Some(info) = self
                 .acquire()
                 .version()
@@ -346,7 +342,52 @@ impl HummockSnapshotManager {
                 ))
                 .into());
             }
+            rx.changed()
+                .await
+                .map_err(|_| ErrorCode::InternalError("cursor notify channel is closed.".into()))?;
+            let _ = rx.borrow_and_update();
         }
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use super::*;
+    use crate::test_utils::MockFrontendMetaClient;
+
+    /// Verifies that an already-available seek epoch is observed immediately without waiting for
+    /// another version-update notification.
+    #[tokio::test]
+    async fn test_wait_table_change_log_notification_observes_existing_version() {
+        let manager = HummockSnapshotManager::new(Arc::new(MockFrontendMetaClient {}));
+        let table_id = TableId::new(1);
+        let committed_epoch = 42;
+        manager.add_table_for_test(table_id);
+        manager.update_inner(|version| {
+            let mut version = version.clone();
+            version.id += 1;
+            version.state_table_info.apply_delta(
+                &HashMap::from_iter([(
+                    table_id,
+                    StateTableInfoDelta {
+                        committed_epoch,
+                        compaction_group_id: 0.into(),
+                    },
+                )]),
+                &HashSet::new(),
+            );
+            Some(version)
+        });
+
+        tokio::time::timeout(
+            Duration::from_secs(1),
+            manager.wait_table_change_log_notification(table_id, committed_epoch),
+        )
+        .await
+        .expect("an existing committed epoch must not wait for another notification")
+        .unwrap();
     }
 }


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

`wait_table_change_log_notification` previously waited for the next Hummock version notification before inspecting the current snapshot. If the requested table-change-log epoch was already committed before the waiter subscribed, and no later update arrived, the waiter remained blocked even though the requested epoch was available.

This PR checks the current snapshot first and waits for a notification only when the requested epoch is not available yet. It also adds a deterministic regression test that publishes epoch 42 before starting the waiter and verifies that the waiter returns immediately without requiring another version update.

Tested with:

```bash
cargo +nightly-2026-06-21 test -p risingwave_frontend \
  test_wait_table_change_log_notification_observes_existing_version \
  -- --nocapture
```

## Checklist

- [x] I have written necessary rustdoc comments.
- [x] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/dev/src/ci.md#ci-labels-guide -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->

## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

None.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved snapshot update handling so already-available committed changes are returned immediately instead of waiting unnecessarily.
  * Added coverage to prevent regressions in snapshot notification behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->