### PR TITLE
fix(cdc): normalize MySQL schema-change column names

### DIFF
--- a/e2e_test/source_inline/cdc/mysql/mysql_auto_schema_change_column_case.slt
+++ b/e2e_test/source_inline/cdc/mysql/mysql_auto_schema_change_column_case.slt
@@ -1,0 +1,89 @@
+control substitution on
+
+# Regression test for MySQL schema changes when upstream column names are not lowercase.
+# Snapshot discovery and Debezium DDL parsing must produce the same lowercase names.
+
+system ok
+mysql -e "
+    CREATE DATABASE IF NOT EXISTS risedev;
+    USE risedev;
+    DROP TABLE IF EXISTS mysql_auto_schema_change_column_case;
+    CREATE TABLE mysql_auto_schema_change_column_case (
+        Id INT NOT NULL PRIMARY KEY,
+        Details VARCHAR(50),
+        TOPS_CreatedOn INT
+    ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+    INSERT INTO mysql_auto_schema_change_column_case VALUES
+        (1, 'before', 100);
+"
+
+statement ok
+create source s_mysql_auto_schema_change_column_case with (
+  ${RISEDEV_MYSQL_WITH_OPTIONS_COMMON},
+  username = '${RISEDEV_MYSQL_USER}',
+  password = '${MYSQL_PWD}',
+  database.name = 'risedev',
+  auto.schema.change = 'true'
+);
+
+sleep 2s
+
+statement ok
+create table rw_mysql_auto_schema_change_column_case (
+  id INT,
+  details VARCHAR,
+  tops_createdon INT,
+  primary key (id)
+) with (
+  snapshot = 'true',
+  snapshot.batch_size = 1
+) from s_mysql_auto_schema_change_column_case table 'risedev.mysql_auto_schema_change_column_case';
+
+query ITI retry 10 backoff 1s
+select id, details, tops_createdon
+from rw_mysql_auto_schema_change_column_case
+order by id;
+----
+1 before 100
+
+system ok
+mysql -e "
+    USE risedev;
+    ALTER TABLE mysql_auto_schema_change_column_case ADD COLUMN NewCol VARCHAR(50);
+    INSERT INTO mysql_auto_schema_change_column_case
+        (Id, Details, TOPS_CreatedOn, NewCol)
+    VALUES
+        (2, 'after', 200, 'added');
+"
+
+query ITIT retry 10 backoff 1s
+select id, details, tops_createdon, coalesce(newcol, 'NULL')
+from rw_mysql_auto_schema_change_column_case
+order by id;
+----
+1 before 100 NULL
+2 after 200 added
+
+query TTTT retry 10 backoff 1s
+describe rw_mysql_auto_schema_change_column_case;
+----
+id integer false NULL
+details character varying false NULL
+tops_createdon integer false NULL
+newcol character varying false NULL
+_rw_timestamp timestamp with time zone true NULL
+primary key id NULL NULL
+distribution key id NULL NULL
+table description rw_mysql_auto_schema_change_column_case NULL NULL
+
+statement ok
+drop table rw_mysql_auto_schema_change_column_case;
+
+statement ok
+drop source s_mysql_auto_schema_change_column_case cascade;
+
+system ok
+mysql -e "
+    USE risedev;
+    DROP TABLE IF EXISTS mysql_auto_schema_change_column_case;
+"

--- a/src/connector/src/parser/plain_parser.rs
+++ b/src/connector/src/parser/plain_parser.rs
@@ -535,7 +535,7 @@ mod tests {
         .unwrap();
         let mut dummy_builder = SourceStreamChunkBuilder::new(columns, SourceCtrlOpts::for_test());
 
-        let msg = r#"{"schema":null,"payload": { "databaseName": "mydb", "ddl": "ALTER TABLE test add column v2 varchar(32)", "schemaName": null, "source": { "connector": "mysql", "db": "mydb", "file": "binlog.000065", "gtid": null, "name": "RW_CDC_0", "pos": 234, "query": null, "row": 0, "sequence": null, "server_id": 1, "snapshot": "false", "table": "test", "thread": null, "ts_ms": 1718354727000, "version": "2.4.2.Final" }, "tableChanges": [ { "id": "\"mydb\".\"test\"", "table": { "columns": [ { "autoIncremented": false, "charsetName": null, "comment": null, "defaultValueExpression": null, "enumValues": null, "generated": false, "jdbcType": 4, "length": null, "name": "id", "nativeType": null, "optional": false, "position": 1, "scale": null, "typeExpression": "INT", "typeName": "INT" }, { "autoIncremented": false, "charsetName": null, "comment": null, "defaultValueExpression": null, "enumValues": null, "generated": false, "jdbcType": 2014, "length": null, "name": "v1", "nativeType": null, "optional": true, "position": 2, "scale": null, "typeExpression": "TIMESTAMP", "typeName": "TIMESTAMP" }, { "autoIncremented": false, "charsetName": "utf8mb4", "comment": null, "defaultValueExpression": null, "enumValues": null, "generated": false, "jdbcType": 12, "length": 32, "name": "v2", "nativeType": null, "optional": true, "position": 3, "scale": null, "typeExpression": "VARCHAR", "typeName": "VARCHAR" } ], "comment": null, "defaultCharsetName": "utf8mb4", "primaryKeyColumnNames": [ "id" ] }, "type": "ALTER" } ], "ts_ms": 1718354727594 }}"#;
+        let msg = r#"{"schema":null,"payload": { "databaseName": "mydb", "ddl": "ALTER TABLE test add column NewCol varchar(32)", "schemaName": null, "source": { "connector": "mysql", "db": "mydb", "file": "binlog.000065", "gtid": null, "name": "RW_CDC_0", "pos": 234, "query": null, "row": 0, "sequence": null, "server_id": 1, "snapshot": "false", "table": "test", "thread": null, "ts_ms": 1718354727000, "version": "2.4.2.Final" }, "tableChanges": [ { "id": "\"mydb\".\"test\"", "table": { "columns": [ { "autoIncremented": false, "charsetName": null, "comment": null, "defaultValueExpression": null, "enumValues": null, "generated": false, "jdbcType": 4, "length": null, "name": "Id", "nativeType": null, "optional": false, "position": 1, "scale": null, "typeExpression": "INT", "typeName": "INT" }, { "autoIncremented": false, "charsetName": null, "comment": null, "defaultValueExpression": null, "enumValues": null, "generated": false, "jdbcType": 2014, "length": null, "name": "SCREAMING_SNAKE", "nativeType": null, "optional": true, "position": 2, "scale": null, "typeExpression": "TIMESTAMP", "typeName": "TIMESTAMP" }, { "autoIncremented": false, "charsetName": "utf8mb4", "comment": null, "defaultValueExpression": null, "enumValues": null, "generated": false, "jdbcType": 12, "length": 32, "name": "NewCol", "nativeType": null, "optional": true, "position": 3, "scale": null, "typeExpression": "VARCHAR", "typeName": "VARCHAR" } ], "comment": null, "defaultCharsetName": "utf8mb4", "primaryKeyColumnNames": [ "Id" ] }, "type": "ALTER" } ], "ts_ms": 1718354727594 }}"#;
         let cdc_meta = SourceMeta::DebeziumCdc(DebeziumCdcMeta::new(
             "mydb.test".to_owned(),
             0,
@@ -584,7 +584,7 @@ mod tests {
                                     column_desc: ColumnDesc {
                                         data_type: Timestamptz,
                                         column_id: #2147483646,
-                                        name: "v1",
+                                        name: "screaming_snake",
                                         generated_or_default_column: None,
                                         description: None,
                                         additional_column: AdditionalColumn {
@@ -600,7 +600,7 @@ mod tests {
                                     column_desc: ColumnDesc {
                                         data_type: Varchar,
                                         column_id: #2147483646,
-                                        name: "v2",
+                                        name: "newcol",
                                         generated_or_default_column: None,
                                         description: None,
                                         additional_column: AdditionalColumn {
@@ -614,7 +614,7 @@ mod tests {
                                 },
                             ],
                             change_type: Alter,
-                            upstream_ddl: "ALTER TABLE test add column v2 varchar(32)",
+                            upstream_ddl: "ALTER TABLE test add column NewCol varchar(32)",
                         },
                     ],
                 },

--- a/src/connector/src/parser/unified/debezium.rs
+++ b/src/connector/src/parser/unified/debezium.rs
@@ -335,6 +335,13 @@ pub async fn parse_schema_change(
             {
                 for col in columns.array_elements().unwrap() {
                     let name = jsonb_access_field!(col, "name", string);
+                    // MySQL column names are normalized when the initial schema is
+                    // discovered. Apply the same normalization to schema changes so
+                    // auto schema change can compare the two schemas consistently.
+                    let name = match connector_props {
+                        ConnectorProperties::MysqlCdc(_) => name.to_lowercase(),
+                        _ => name,
+                    };
                     let type_name = jsonb_access_field!(col, "typeName", string);
                     // User-defined types (enum, composite) are not in the
                     // `type_name_to_pg_type` whitelist because their type names are


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What changed and what is the intention?

MySQL CDC snapshot discovery lowercases upstream column names, but Debezium schema-change parsing previously preserved their original case. Auto schema change then compared the two schemas case-sensitively and rejected valid DDL for mixed-case upstream columns.

This PR:

- normalizes MySQL Debezium schema-change column names using the same lowercase mapping as snapshot discovery;
- keeps PostgreSQL CDC identifier behavior unchanged;
- extends the parser unit test with PascalCase and SCREAMING_SNAKE identifiers; and
- adds an end-to-end MySQL CDC test that backfills mixed-case columns, adds NewCol upstream, verifies old and new rows, and checks that RisingWave exposes newcol.

Closes #26867

## Checklist

- [x] I have written necessary rustdoc comments.
- [x] I have added necessary unit tests and integration tests.
- [x] I have added test labels as necessary.
- [ ] I have added fuzzing tests or opened an issue to track them.
- [ ] My PR contains breaking changes.
- [ ] My PR changes performance-critical code, so I will run benchmarks and present the results.
- [ ] I have checked the release timeline and currently supported versions to determine required cherry-picks.

## Documentation

- [x] My PR needs release-note follow-up.

<details>
<summary><b>Release note</b></summary>

MySQL CDC auto schema change now handles upstream columns with mixed-case names. Previously, an upstream DDL such as adding NewCol could be rejected because snapshot and schema-change column names used different casing, leaving the RisingWave table schema out of sync.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed MySQL CDC schema changes so mixed-case column names are consistently normalized to lowercase.
  * Ensured newly added columns and their data are correctly propagated during schema updates.

* **Tests**
  * Added end-to-end coverage for MySQL CDC tables with mixed-case column names and dynamically added columns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->