### PR TITLE
fix(cdc): match MySQL schema-change columns case-insensitively

### DIFF
--- a/e2e_test/source_inline/cdc/mysql/mysql_auto_schema_change_column_case.slt
+++ b/e2e_test/source_inline/cdc/mysql/mysql_auto_schema_change_column_case.slt
@@ -1,0 +1,112 @@
+control substitution on
+
+system ok
+mysql -e "
+    CREATE DATABASE IF NOT EXISTS risedev;
+    USE risedev;
+    DROP TABLE IF EXISTS mysql_auto_schema_change_column_case;
+    CREATE TABLE mysql_auto_schema_change_column_case (
+        Id INT NOT NULL PRIMARY KEY,
+        Details VARCHAR(50),
+        SCREAMING_SNAKE INT
+    ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+    INSERT INTO mysql_auto_schema_change_column_case VALUES (1, 'before', 10);
+"
+
+statement ok
+create source s_mysql_auto_schema_change_column_case with (
+  ${RISEDEV_MYSQL_WITH_OPTIONS_COMMON},
+  username = '${RISEDEV_MYSQL_USER}',
+  password = '${MYSQL_PWD}',
+  database.name = 'risedev',
+  auto.schema.change = 'true'
+);
+
+sleep 2s
+
+statement ok
+create table rw_mysql_column_case_lowercase (
+  id INT,
+  details VARCHAR,
+  screaming_snake INT,
+  primary key (id)
+) with (
+  snapshot = 'true',
+  snapshot.batch_size = 1
+) from s_mysql_auto_schema_change_column_case table 'risedev.mysql_auto_schema_change_column_case';
+
+statement ok
+create table rw_mysql_column_case_quoted (
+  "Id" INT,
+  "Details" VARCHAR,
+  "SCREAMING_SNAKE" INT,
+  primary key ("Id")
+) with (
+  snapshot = 'true',
+  snapshot.batch_size = 1
+) from s_mysql_auto_schema_change_column_case table 'risedev.mysql_auto_schema_change_column_case';
+
+query ITI retry 10 backoff 1s
+select id, details, screaming_snake
+from rw_mysql_column_case_lowercase;
+----
+1 before 10
+
+query ITI retry 10 backoff 1s
+select "Id", "Details", "SCREAMING_SNAKE"
+from rw_mysql_column_case_quoted;
+----
+1 before 10
+
+system ok
+mysql -e "
+    USE risedev;
+    ALTER TABLE mysql_auto_schema_change_column_case ADD COLUMN NewCol VARCHAR(50);
+    INSERT INTO mysql_auto_schema_change_column_case
+        (Id, Details, SCREAMING_SNAKE, NewCol)
+    VALUES
+        (2, 'after', 20, 'added');
+"
+
+query ITIT retry 10 backoff 1s
+select id, details, screaming_snake, newcol
+from rw_mysql_column_case_lowercase
+where id = 2;
+----
+2 after 20 added
+
+query ITIT retry 10 backoff 1s
+select "Id", "Details", "SCREAMING_SNAKE", newcol
+from rw_mysql_column_case_quoted
+where "Id" = 2;
+----
+2 after 20 added
+
+query TT rowsort retry 10 backoff 1s
+select table_name, column_name
+from information_schema.columns
+where table_name in ('rw_mysql_column_case_lowercase', 'rw_mysql_column_case_quoted');
+----
+rw_mysql_column_case_lowercase details
+rw_mysql_column_case_lowercase id
+rw_mysql_column_case_lowercase newcol
+rw_mysql_column_case_lowercase screaming_snake
+rw_mysql_column_case_quoted Details
+rw_mysql_column_case_quoted Id
+rw_mysql_column_case_quoted SCREAMING_SNAKE
+rw_mysql_column_case_quoted newcol
+
+statement ok
+drop table rw_mysql_column_case_lowercase;
+
+statement ok
+drop table rw_mysql_column_case_quoted;
+
+statement ok
+drop source s_mysql_auto_schema_change_column_case cascade;
+
+system ok
+mysql -e "
+    USE risedev;
+    DROP TABLE IF EXISTS mysql_auto_schema_change_column_case;
+"

--- a/src/meta/service/src/ddl_service.rs
+++ b/src/meta/service/src/ddl_service.rs
@@ -1417,6 +1417,15 @@ impl DdlService for DdlServiceImpl {
                 let original_column_names: HashSet<String> =
                     HashSet::from_iter(original_column_types.keys().cloned());
 
+                let cdc_table_type =
+                    PbCdcTableType::try_from(table.cdc_table_type.unwrap_or_default())
+                        .unwrap_or(PbCdcTableType::Unspecified);
+                let table_change = normalize_cdc_auto_schema_change_column_names(
+                    table_change.clone(),
+                    cdc_table_type,
+                    &original_columns_by_name,
+                );
+
                 let collect_new_columns = |table_change: &TableSchemaChange| {
                     let mut new_columns: HashSet<(String, DataType)> =
                         HashSet::from_iter(table_change.columns.iter().filter_map(|col| {
@@ -1452,17 +1461,15 @@ impl DdlService for DdlServiceImpl {
                 let table_change =
                     if original_column_names != new_column_names && is_add_or_drop_by_name {
                         normalize_cdc_auto_schema_change_existing_column_types(
-                            table_change.clone(),
-                            PbCdcTableType::try_from(table.cdc_table_type.unwrap_or_default())
-                                .unwrap_or(PbCdcTableType::Unspecified),
+                            table_change,
+                            cdc_table_type,
                             &original_columns_by_name,
                         )
                     } else {
-                        // Keep the raw schema change for non-add/drop-only cases, such as a
-                        // mixed add-and-drop change. Existing validation below should see the
-                        // original change and reject unsupported schema changes without masking
-                        // them through type normalization.
-                        table_change.clone()
+                        // Keep the schema change without type normalization for non-add/drop-only
+                        // cases, such as a mixed add-and-drop change. Existing validation below
+                        // should reject unsupported schema changes without masking them.
+                        table_change
                     };
 
                 let original_columns: HashSet<(String, DataType)> = HashSet::from_iter(
@@ -2033,6 +2040,50 @@ fn cdc_auto_schema_change_comparable_column(column: &ColumnCatalog) -> Option<(S
     }
 }
 
+fn normalize_cdc_auto_schema_change_column_names(
+    mut table_change: TableSchemaChange,
+    cdc_table_type: PbCdcTableType,
+    original_columns_by_name: &HashMap<String, ColumnCatalog>,
+) -> TableSchemaChange {
+    if cdc_table_type != PbCdcTableType::Mysql {
+        return table_change;
+    }
+
+    // MySQL column names are case-insensitive, while RisingWave catalog names may preserve
+    // explicitly quoted spelling. Reuse that spelling for existing columns and apply the same
+    // lowercase convention as MySQL snapshot discovery only to genuinely new columns.
+    let mut original_names_by_lowercase = HashMap::<String, Option<String>>::new();
+    for original_name in original_columns_by_name.keys() {
+        original_names_by_lowercase
+            .entry(original_name.to_lowercase())
+            .and_modify(|name| *name = None)
+            .or_insert_with(|| Some(original_name.clone()));
+    }
+
+    for column in &mut table_change.columns {
+        let mut column_catalog = ColumnCatalog::from(column.clone());
+        if column_catalog.is_generated() || column_catalog.is_hidden() {
+            continue;
+        }
+
+        let incoming_name = &column_catalog.column_desc.name;
+        let lowercase_name = incoming_name.to_lowercase();
+        let normalized_name = if original_columns_by_name.contains_key(incoming_name) {
+            incoming_name.clone()
+        } else {
+            original_names_by_lowercase
+                .get(&lowercase_name)
+                .and_then(|name| name.clone())
+                .unwrap_or(lowercase_name)
+        };
+
+        column_catalog.column_desc.name = normalized_name;
+        *column = column_catalog.to_protobuf();
+    }
+
+    table_change
+}
+
 fn normalize_cdc_auto_schema_change_existing_column_types(
     mut table_change: TableSchemaChange,
     cdc_table_type: PbCdcTableType,
@@ -2144,6 +2195,89 @@ mod tests {
         assert_eq!(columns["id"], DataType::Int64);
         assert_eq!(columns["v"], DataType::Varchar);
         assert_eq!(columns["note"], DataType::Varchar);
+    }
+
+    #[test]
+    fn test_mysql_cdc_auto_schema_change_normalizes_column_names() {
+        let original_columns_by_name = HashMap::from([
+            (
+                "Id".to_owned(),
+                ColumnCatalog::visible(ColumnDesc::named(
+                    "Id",
+                    ColumnId::placeholder(),
+                    DataType::Int64,
+                )),
+            ),
+            (
+                "Details".to_owned(),
+                ColumnCatalog::visible(ColumnDesc::named(
+                    "Details",
+                    ColumnId::placeholder(),
+                    DataType::Varchar,
+                )),
+            ),
+        ]);
+        let table_change = pb_table_change(vec![
+            pb_column("ID", DataType::Int32),
+            pb_column("details", DataType::Varchar),
+            pb_column("NewCol", DataType::Varchar),
+        ]);
+
+        let normalized = normalize_cdc_auto_schema_change_column_names(
+            table_change,
+            PbCdcTableType::Mysql,
+            &original_columns_by_name,
+        );
+        let normalized = normalize_cdc_auto_schema_change_existing_column_types(
+            normalized,
+            PbCdcTableType::Mysql,
+            &original_columns_by_name,
+        );
+        let columns = normalized
+            .columns
+            .into_iter()
+            .map(ColumnCatalog::from)
+            .map(|column| (column.column_desc.name, column.column_desc.data_type))
+            .collect::<Vec<_>>();
+
+        assert_eq!(
+            columns,
+            vec![
+                ("Id".to_owned(), DataType::Int64),
+                ("Details".to_owned(), DataType::Varchar),
+                ("newcol".to_owned(), DataType::Varchar),
+            ]
+        );
+    }
+
+    #[test]
+    fn test_non_mysql_cdc_auto_schema_change_preserves_column_names() {
+        let original_columns_by_name = HashMap::from([(
+            "Id".to_owned(),
+            ColumnCatalog::visible(ColumnDesc::named(
+                "Id",
+                ColumnId::placeholder(),
+                DataType::Int64,
+            )),
+        )]);
+        let table_change = pb_table_change(vec![
+            pb_column("ID", DataType::Int64),
+            pb_column("NewCol", DataType::Varchar),
+        ]);
+
+        let normalized = normalize_cdc_auto_schema_change_column_names(
+            table_change,
+            PbCdcTableType::Postgres,
+            &original_columns_by_name,
+        );
+        let column_names = normalized
+            .columns
+            .into_iter()
+            .map(ColumnCatalog::from)
+            .map(|column| column.column_desc.name)
+            .collect::<Vec<_>>();
+
+        assert_eq!(column_names, vec!["ID".to_owned(), "NewCol".to_owned()]);
     }
 
     #[test]


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

MySQL CDC auto schema change now matches incoming column names case-insensitively while preserving each existing RisingWave catalog column's spelling, and genuinely new columns retain the lowercase convention established during snapshot discovery.
This prevents mixed-case upstream schemas from failing add/drop validation while continuing to support explicitly quoted mixed-case RisingWave schemas.
Unit coverage and a Docker-validated MySQL CDC SQLLogicTest exercise both lowercase and quoted catalogs.

- Closes #26867

## Checklist

- [ ] I have written necessary rustdoc comments.
- [x] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [x] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/dev/src/ci.md#ci-labels-guide -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved automatic MySQL CDC schema changes to handle column-name casing consistently.
  - Existing columns retain their catalog casing, while newly added columns use lowercase names.
  - Schema and data updates now propagate correctly to both lowercase and quoted target tables.
- **Bug Fixes**
  - Fixed column-name and type handling during automatic schema updates.
  - Preserved existing behavior for non-MySQL sources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->