### PR TITLE
cherry-pick fix(cdc): match MySQL schema-change columns case-insensitively (#26878) to release-3.0

### DIFF
--- a/e2e_test/source_inline/cdc/mysql/mysql_auto_schema_change_column_case.slt
+++ b/e2e_test/source_inline/cdc/mysql/mysql_auto_schema_change_column_case.slt
@@ -1,0 +1,112 @@
+control substitution on
+
+system ok
+mysql -e "
+    CREATE DATABASE IF NOT EXISTS risedev;
+    USE risedev;
+    DROP TABLE IF EXISTS mysql_auto_schema_change_column_case;
+    CREATE TABLE mysql_auto_schema_change_column_case (
+        Id INT NOT NULL PRIMARY KEY,
+        Details VARCHAR(50),
+        SCREAMING_SNAKE INT
+    ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+    INSERT INTO mysql_auto_schema_change_column_case VALUES (1, 'before', 10);
+"
+
+statement ok
+create source s_mysql_auto_schema_change_column_case with (
+  ${RISEDEV_MYSQL_WITH_OPTIONS_COMMON},
+  username = '${RISEDEV_MYSQL_USER}',
+  password = '${MYSQL_PWD}',
+  database.name = 'risedev',
+  auto.schema.change = 'true'
+);
+
+sleep 2s
+
+statement ok
+create table rw_mysql_column_case_lowercase (
+  id INT,
+  details VARCHAR,
+  screaming_snake INT,
+  primary key (id)
+) with (
+  snapshot = 'true',
+  snapshot.batch_size = 1
+) from s_mysql_auto_schema_change_column_case table 'risedev.mysql_auto_schema_change_column_case';
+
+statement ok
+create table rw_mysql_column_case_quoted (
+  "Id" INT,
+  "Details" VARCHAR,
+  "SCREAMING_SNAKE" INT,
+  primary key ("Id")
+) with (
+  snapshot = 'true',
+  snapshot.batch_size = 1
+) from s_mysql_auto_schema_change_column_case table 'risedev.mysql_auto_schema_change_column_case';
+
+query ITI retry 10 backoff 1s
+select id, details, screaming_snake
+from rw_mysql_column_case_lowercase;
+----
+1 before 10
+
+query ITI retry 10 backoff 1s
+select "Id", "Details", "SCREAMING_SNAKE"
+from rw_mysql_column_case_quoted;
+----
+1 before 10
+
+system ok
+mysql -e "
+    USE risedev;
+    ALTER TABLE mysql_auto_schema_change_column_case ADD COLUMN NewCol VARCHAR(50);
+    INSERT INTO mysql_auto_schema_change_column_case
+        (Id, Details, SCREAMING_SNAKE, NewCol)
+    VALUES
+        (2, 'after', 20, 'added');
+"
+
+query ITIT retry 10 backoff 1s
+select id, details, screaming_snake, newcol
+from rw_mysql_column_case_lowercase
+where id = 2;
+----
+2 after 20 added
+
+query ITIT retry 10 backoff 1s
+select "Id", "Details", "SCREAMING_SNAKE", newcol
+from rw_mysql_column_case_quoted
+where "Id" = 2;
+----
+2 after 20 added
+
+query TT rowsort retry 10 backoff 1s
+select table_name, column_name
+from information_schema.columns
+where table_name in ('rw_mysql_column_case_lowercase', 'rw_mysql_column_case_quoted');
+----
+rw_mysql_column_case_lowercase details
+rw_mysql_column_case_lowercase id
+rw_mysql_column_case_lowercase newcol
+rw_mysql_column_case_lowercase screaming_snake
+rw_mysql_column_case_quoted Details
+rw_mysql_column_case_quoted Id
+rw_mysql_column_case_quoted SCREAMING_SNAKE
+rw_mysql_column_case_quoted newcol
+
+statement ok
+drop table rw_mysql_column_case_lowercase;
+
+statement ok
+drop table rw_mysql_column_case_quoted;
+
+statement ok
+drop source s_mysql_auto_schema_change_column_case cascade;
+
+system ok
+mysql -e "
+    USE risedev;
+    DROP TABLE IF EXISTS mysql_auto_schema_change_column_case;
+"

--- a/src/meta/service/src/ddl_service.rs
+++ b/src/meta/service/src/ddl_service.rs
@@ -36,7 +36,7 @@ use risingwave_meta::stream::{ParallelismPolicy, ReschedulePolicy, ResourceGroup
 use risingwave_meta::{MetaResult, bail_invalid_parameter, bail_unavailable};
 use risingwave_meta_model::StreamingParallelism;
 use risingwave_pb::catalog::connection::Info as ConnectionInfo;
-use risingwave_pb::catalog::table::OptionalAssociatedSourceId;
+use risingwave_pb::catalog::table::{CdcTableType as PbCdcTableType, OptionalAssociatedSourceId};
 use risingwave_pb::catalog::{Comment, Connection, PbCreateType, Secret, Table};
 use risingwave_pb::common::WorkerType;
 use risingwave_pb::common::worker_node::State;
@@ -1350,15 +1350,30 @@ impl DdlService for DdlServiceImpl {
             for table in tables {
                 // Since we only support `ADD` and `DROP` column, we check whether the new columns and the original columns
                 // is a subset of the other.
-                let original_columns: HashSet<(String, DataType)> =
-                    HashSet::from_iter(table.columns.iter().filter_map(|col| {
+                let original_columns_by_name: HashMap<String, ColumnCatalog> =
+                    HashMap::from_iter(table.columns.iter().filter_map(|col| {
                         let col = ColumnCatalog::from(col.clone());
                         if col.is_generated() || col.is_hidden() {
                             None
                         } else {
-                            Some((col.column_desc.name.clone(), col.data_type().clone()))
+                            Some((col.column_desc.name.clone(), col))
                         }
                     }));
+
+                let original_columns: HashSet<(String, DataType)> = HashSet::from_iter(
+                    original_columns_by_name
+                        .iter()
+                        .map(|(name, col)| (name.clone(), col.data_type().clone())),
+                );
+
+                let cdc_table_type =
+                    PbCdcTableType::try_from(table.cdc_table_type.unwrap_or_default())
+                        .unwrap_or(PbCdcTableType::Unspecified);
+                let table_change = normalize_cdc_auto_schema_change_column_names(
+                    table_change.clone(),
+                    cdc_table_type,
+                    &original_columns_by_name,
+                );
 
                 let mut new_columns: HashSet<(String, DataType)> =
                     HashSet::from_iter(table_change.columns.iter().filter_map(|col| {
@@ -1882,4 +1897,150 @@ fn add_auto_schema_change_fail_event_log(
         fail_info,
     };
     event_log_manager.add_event_logs(vec![event_log::Event::AutoSchemaChangeFail(event)]);
+}
+
+fn normalize_cdc_auto_schema_change_column_names(
+    mut table_change: TableSchemaChange,
+    cdc_table_type: PbCdcTableType,
+    original_columns_by_name: &HashMap<String, ColumnCatalog>,
+) -> TableSchemaChange {
+    if cdc_table_type != PbCdcTableType::Mysql {
+        return table_change;
+    }
+
+    // MySQL column names are case-insensitive, while RisingWave catalog names may preserve
+    // explicitly quoted spelling. Reuse that spelling for existing columns and apply the same
+    // lowercase convention as MySQL snapshot discovery only to genuinely new columns.
+    let mut original_names_by_lowercase = HashMap::<String, Option<String>>::new();
+    for original_name in original_columns_by_name.keys() {
+        original_names_by_lowercase
+            .entry(original_name.to_lowercase())
+            .and_modify(|name| *name = None)
+            .or_insert_with(|| Some(original_name.clone()));
+    }
+
+    for column in &mut table_change.columns {
+        let mut column_catalog = ColumnCatalog::from(column.clone());
+        if column_catalog.is_generated() || column_catalog.is_hidden() {
+            continue;
+        }
+
+        let incoming_name = &column_catalog.column_desc.name;
+        let lowercase_name = incoming_name.to_lowercase();
+        let normalized_name = if original_columns_by_name.contains_key(incoming_name) {
+            incoming_name.clone()
+        } else {
+            original_names_by_lowercase
+                .get(&lowercase_name)
+                .and_then(|name| name.clone())
+                .unwrap_or(lowercase_name)
+        };
+
+        column_catalog.column_desc.name = normalized_name;
+        *column = column_catalog.to_protobuf();
+    }
+
+    table_change
+}
+
+#[cfg(test)]
+mod tests {
+    use risingwave_common::catalog::{ColumnDesc, ColumnId};
+    use risingwave_pb::ddl_service::table_schema_change::TableChangeType;
+
+    use super::*;
+
+    fn pb_column(name: &str, data_type: DataType) -> risingwave_pb::plan_common::ColumnCatalog {
+        ColumnCatalog::visible(ColumnDesc::named(name, ColumnId::placeholder(), data_type))
+            .to_protobuf()
+    }
+
+    fn pb_table_change(
+        columns: Vec<risingwave_pb::plan_common::ColumnCatalog>,
+    ) -> TableSchemaChange {
+        TableSchemaChange {
+            change_type: TableChangeType::Alter as _,
+            cdc_table_id: "1.db.t".to_owned(),
+            columns,
+            upstream_ddl: "ALTER TABLE t ADD COLUMN note VARCHAR(255)".to_owned(),
+        }
+    }
+
+    #[test]
+    fn test_mysql_cdc_auto_schema_change_normalizes_column_names() {
+        let original_columns_by_name = HashMap::from([
+            (
+                "Id".to_owned(),
+                ColumnCatalog::visible(ColumnDesc::named(
+                    "Id",
+                    ColumnId::placeholder(),
+                    DataType::Int64,
+                )),
+            ),
+            (
+                "Details".to_owned(),
+                ColumnCatalog::visible(ColumnDesc::named(
+                    "Details",
+                    ColumnId::placeholder(),
+                    DataType::Varchar,
+                )),
+            ),
+        ]);
+        let table_change = pb_table_change(vec![
+            pb_column("ID", DataType::Int32),
+            pb_column("details", DataType::Varchar),
+            pb_column("NewCol", DataType::Varchar),
+        ]);
+
+        let normalized = normalize_cdc_auto_schema_change_column_names(
+            table_change,
+            PbCdcTableType::Mysql,
+            &original_columns_by_name,
+        );
+        let columns = normalized
+            .columns
+            .into_iter()
+            .map(ColumnCatalog::from)
+            .map(|column| (column.column_desc.name, column.column_desc.data_type))
+            .collect::<Vec<_>>();
+
+        assert_eq!(
+            columns,
+            vec![
+                ("Id".to_owned(), DataType::Int32),
+                ("Details".to_owned(), DataType::Varchar),
+                ("newcol".to_owned(), DataType::Varchar),
+            ]
+        );
+    }
+
+    #[test]
+    fn test_non_mysql_cdc_auto_schema_change_preserves_column_names() {
+        let original_columns_by_name = HashMap::from([(
+            "Id".to_owned(),
+            ColumnCatalog::visible(ColumnDesc::named(
+                "Id",
+                ColumnId::placeholder(),
+                DataType::Int64,
+            )),
+        )]);
+        let table_change = pb_table_change(vec![
+            pb_column("ID", DataType::Int64),
+            pb_column("NewCol", DataType::Varchar),
+        ]);
+
+        let normalized = normalize_cdc_auto_schema_change_column_names(
+            table_change,
+            PbCdcTableType::Postgres,
+            &original_columns_by_name,
+        );
+        let column_names = normalized
+            .columns
+            .into_iter()
+            .map(ColumnCatalog::from)
+            .map(|column| column.column_desc.name)
+            .collect::<Vec<_>>();
+
+        assert_eq!(column_names, vec!["ID".to_owned(), "NewCol".to_owned()]);
+    }
 }


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

Backport #26878 to `release-3.0` to make MySQL CDC auto schema change match existing columns case-insensitively.

MySQL schema-change events can use different letter casing than the RisingWave catalog, especially when a CDC table was declared with quoted column names. The mismatch made a valid `ADD COLUMN` look like a mixed add-and-drop change. This backport reuses the catalog spelling for existing MySQL columns, lowercases genuinely new columns consistently with MySQL snapshot discovery, and leaves non-MySQL CDC behavior unchanged.

The included SQLLogicTest covers both unquoted lowercase and quoted case-preserving CDC tables through an upstream `ADD COLUMN`.

- Closes #26881

## Backport conflict resolution

The cherry-pick conflicted in `src/meta/service/src/ddl_service.rs` because `release-3.0` does not contain the newer existing-column type-normalization refactor from `main`. The resolution keeps the release branch's existing subset/superset validation and adds only the case-insensitive MySQL name normalization needed by #26878.

## Testing

- `cargo fmt --all -- --check`
- `git diff --check origin/release-3.0...HEAD`
- `python3 e2e_test/check_slt_coverage.py -d`
- `cargo test -p risingwave_meta_service ddl_service::tests --lib` *(blocked by an unrelated existing `origin/release-3.0` compile error: `HummockManager::replay_version_delta` is missing in `src/meta/service/src/hummock_service.rs`)*

## Checklist

- [ ] I have written necessary rustdoc comments.
- [x] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [x] <!-- OPTIONAL --> I have added test labels as necessary.
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them.
- [ ] <!-- OPTIONAL --> My PR contains breaking changes.
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results.
- [x] <!-- OPTIONAL --> I have checked the Release Timeline and Currently Supported Versions to determine which release branches I need to cherry-pick this PR into.

## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates.

<details>
<summary><b>Release note</b></summary>

Fix MySQL CDC automatic schema changes for tables whose schema-change event uses different column-name casing than the RisingWave catalog, including tables declared with quoted case-preserving column names.

</details>
