### PR TITLE
fix(frontend): redact source passwords in catalog output

### DIFF
--- a/e2e_test/source_inline/cdc/postgres/postgres_select_privilege.slt
+++ b/e2e_test/source_inline/cdc/postgres/postgres_select_privilege.slt
@@ -59,3 +59,98 @@ PGDATABASE=${PGDATABASE:-postgres} psql -v ON_ERROR_STOP=1 -c "
     DROP TABLE IF EXISTS public.pg_cdc_select_privilege_test CASCADE;
     DROP ROLE IF EXISTS rw_cdc_slt_limited;
     "
+
+# A RisingWave source SELECT grant must not expose the inline upstream password.
+system ok
+PGDATABASE=${PGDATABASE:-postgres} psql -v ON_ERROR_STOP=1 -c "
+    SELECT pg_terminate_backend(active_pid)
+    FROM pg_replication_slots
+    WHERE slot_name = 'pg_cdc_password_redaction_slot' AND active_pid IS NOT NULL;
+    SELECT pg_sleep(1);
+    SELECT pg_drop_replication_slot(slot_name)
+    FROM pg_replication_slots
+    WHERE slot_name = 'pg_cdc_password_redaction_slot';
+    DROP PUBLICATION IF EXISTS pg_cdc_password_redaction_pub;
+    CREATE PUBLICATION pg_cdc_password_redaction_pub FOR ALL TABLES;
+    DROP USER IF EXISTS rw_cdc_slt_redaction;
+    CREATE USER rw_cdc_slt_redaction
+        WITH REPLICATION PASSWORD 'rw_cdc_slt_password_marker';
+    "
+
+statement ok
+drop source if exists pg_cdc_password_redaction_source;
+
+statement ok
+create source pg_cdc_password_redaction_source with (
+    connector = 'postgres-cdc',
+    hostname = '${PGHOST:localhost}',
+    port = '${PGPORT:5432}',
+    username = 'rw_cdc_slt_redaction',
+    password = 'rw_cdc_slt_password_marker',
+    database.name = '${PGDATABASE:postgres}',
+    schema.name = 'public',
+    publication.name = 'pg_cdc_password_redaction_pub',
+    slot.name = 'pg_cdc_password_redaction_slot',
+);
+
+statement ok
+drop user if exists pg_cdc_source_reader;
+
+statement ok
+create user pg_cdc_source_reader;
+
+statement ok
+grant select on source pg_cdc_password_redaction_source to pg_cdc_source_reader;
+
+system ok
+bash -c '
+set -euo pipefail
+readonly marker="rw_cdc_slt_password_marker"
+readonly source_name="pg_cdc_password_redaction_source"
+psql_args=(
+  -h "$SLT_HOST"
+  -p "$SLT_PORT"
+  -U pg_cdc_source_reader
+  -d "$SLT_DB"
+  -At
+)
+assert_redacted() {
+  local surface="$1"
+  local sql="$2"
+  local output
+  output=$(psql "${psql_args[@]}" -c "$sql")
+  test -n "$output"
+  if grep -Fq "$marker" <<<"$output"; then
+    echo "$surface exposed the upstream password" >&2
+    exit 1
+  fi
+}
+assert_redacted \
+  "SHOW CREATE SOURCE" \
+  "SHOW CREATE SOURCE $source_name;"
+assert_redacted \
+  "rw_sources.definition" \
+  "SELECT definition FROM rw_catalog.rw_sources WHERE name = \$\$$source_name\$\$;"
+assert_redacted \
+  "rw_sources.connector_props" \
+  "SELECT connector_props FROM rw_catalog.rw_sources WHERE name = \$\$$source_name\$\$;"
+'
+
+statement ok
+drop source pg_cdc_password_redaction_source;
+
+statement ok
+drop user pg_cdc_source_reader;
+
+system ok
+PGDATABASE=${PGDATABASE:-postgres} psql -v ON_ERROR_STOP=1 -c "
+    SELECT pg_terminate_backend(active_pid)
+    FROM pg_replication_slots
+    WHERE slot_name = 'pg_cdc_password_redaction_slot' AND active_pid IS NOT NULL;
+    SELECT pg_sleep(1);
+    SELECT pg_drop_replication_slot(slot_name)
+    FROM pg_replication_slots
+    WHERE slot_name = 'pg_cdc_password_redaction_slot';
+    DROP PUBLICATION IF EXISTS pg_cdc_password_redaction_pub;
+    DROP USER IF EXISTS rw_cdc_slt_redaction;
+    "

--- a/e2e_test/source_inline/cdc/postgres/postgres_select_privilege.slt
+++ b/e2e_test/source_inline/cdc/postgres/postgres_select_privilege.slt
@@ -134,6 +134,9 @@ assert_redacted \
 assert_redacted \
   "rw_sources.connector_props" \
   "SELECT connector_props FROM rw_catalog.rw_sources WHERE name = \$\$$source_name\$\$;"
+assert_redacted \
+  "rw_relation_info.definition" \
+  "SELECT definition FROM rw_catalog.rw_relation_info WHERE relationname = \$\$$source_name\$\$ AND relationtype = \$\$SOURCE\$\$;"
 '
 
 statement ok

--- a/src/frontend/src/catalog/source_catalog.rs
+++ b/src/frontend/src/catalog/source_catalog.rs
@@ -28,6 +28,8 @@ use crate::error::Result;
 use crate::session::current::notice_to_user;
 use crate::user::UserId;
 
+pub(crate) const SENSITIVE_PROPERTY_KEYWORDS: &[&str] = &["password"];
+
 /// This struct `SourceCatalog` is used in frontend.
 /// Compared with `PbSource`, it only maintains information used during optimization.
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
@@ -124,6 +126,26 @@ impl SourceCatalog {
     /// Returns the SQL definition when the source was created, purified with best effort.
     pub fn create_sql_purified(&self) -> String {
         self.create_sql_ast_purified()
+            .and_then(|stmt| stmt.try_to_string().map_err(Into::into))
+            .unwrap_or_else(|_| self.create_sql())
+    }
+
+    /// Returns the purified SQL definition with inline password properties redacted.
+    pub fn create_sql_redacted(&self) -> String {
+        self.create_sql_ast_purified()
+            .map(|mut statement| {
+                let ast::Statement::CreateSource { stmt: source_stmt } = &mut statement else {
+                    return statement;
+                };
+
+                for option in &mut source_stmt.with_properties.0 {
+                    if option.is_sensitive(SENSITIVE_PROPERTY_KEYWORDS) {
+                        option.redact();
+                    }
+                }
+
+                statement
+            })
             .and_then(|stmt| stmt.try_to_string().map_err(Into::into))
             .unwrap_or_else(|_| self.create_sql())
     }

--- a/src/frontend/src/catalog/system_catalog/rw_catalog/rw_relation_info.rs
+++ b/src/frontend/src/catalog/system_catalog/rw_catalog/rw_relation_info.rs
@@ -203,7 +203,7 @@ async fn read_relation_info(reader: &SysCatalogReaderImpl) -> Result<Vec<RwRelat
                     schemaname: schema.clone(),
                     relationname: t.name.clone(),
                     relationowner: t.owner,
-                    definition: t.create_sql_purified(),
+                    definition: t.create_sql_redacted(),
                     relationtype: "SOURCE".into(),
                     relationid: t.id.as_relation_id(),
                     relationtimezone: timezone,

--- a/src/frontend/src/catalog/system_catalog/rw_catalog/rw_sources.rs
+++ b/src/frontend/src/catalog/system_catalog/rw_catalog/rw_sources.rs
@@ -15,10 +15,12 @@
 use risingwave_common::id::{ConnectionId, SchemaId, SourceId, TableId, UserId};
 use risingwave_common::types::{Fields, JsonbVal, Timestamptz};
 use risingwave_frontend_macro::system_catalog;
+use risingwave_sqlparser::ast::{REDACTED_SQL_OPTION_VALUE, is_sensitive_sql_option_name};
 use serde_json::{Map as JsonMap, json};
 
 use crate::WithOptionsSecResolved;
 use crate::catalog::catalog_service::CatalogReadGuard;
+use crate::catalog::source_catalog::SENSITIVE_PROPERTY_KEYWORDS;
 use crate::catalog::system_catalog::{SysCatalogReaderImpl, get_acl_items};
 use crate::error::Result;
 use crate::handler::create_source::UPSTREAM_SOURCE_KEY;
@@ -93,7 +95,7 @@ fn read_rw_sources_info(reader: &SysCatalogReaderImpl) -> Result<Vec<RwSource>> 
                     append_only: source.append_only,
                     associated_table_id: source.associated_table_id,
                     connection_id: source.connection_id,
-                    definition: source.create_sql_purified(),
+                    definition: source.create_sql_redacted(),
                     acl: get_acl_items(source.id, false, &users, username_map),
                     initialized_at: source.initialized_at_epoch.map(|e| e.as_timestamptz()),
                     created_at: source.created_at_epoch.map(|e| e.as_timestamptz()),
@@ -130,7 +132,12 @@ pub fn serialize_props_with_secret(
     let mut result: JsonMap<String, serde_json::Value> = JsonMap::new();
 
     for (k, v) in inner {
-        result.insert(k, json!({"type": "plaintext", "value": v}));
+        let value = if is_sensitive_sql_option_name(&k, SENSITIVE_PROPERTY_KEYWORDS) {
+            REDACTED_SQL_OPTION_VALUE
+        } else {
+            &v
+        };
+        result.insert(k, json!({"type": "plaintext", "value": value}));
     }
     for (k, v) in secret_ref {
         let secret = catalog_reader

--- a/src/frontend/src/handler/show.rs
+++ b/src/frontend/src/handler/show.rs
@@ -928,7 +928,7 @@ pub fn handle_show_create_object(
                     )
                 })?
                 .ok_or_else(|| CatalogError::not_found("source", name.to_string()))?;
-            (source.create_sql_purified(), schema)
+            (source.create_sql_redacted(), schema)
         }
         ShowCreateType::Index => {
             let (index, schema) = schema_path

--- a/src/sqlparser/src/ast/mod.rs
+++ b/src/sqlparser/src/ast/mod.rs
@@ -59,6 +59,13 @@ use crate::tokenizer::Tokenizer;
 
 pub type RedactSqlOptionKeywordsRef = Arc<HashSet<String>>;
 
+pub const REDACTED_SQL_OPTION_VALUE: &str = "<redacted>";
+
+pub fn is_sensitive_sql_option_name(name: &str, keywords: &[&str]) -> bool {
+    let name = name.to_ascii_lowercase();
+    keywords.iter().any(|keyword| name.contains(keyword))
+}
+
 task_local::task_local! {
     pub static REDACT_SQL_OPTION_KEYWORDS: RedactSqlOptionKeywordsRef;
 }
@@ -3295,6 +3302,17 @@ pub struct SqlOption {
     pub value: SqlOptionValue,
 }
 
+impl SqlOption {
+    pub fn is_sensitive(&self, keywords: &[&str]) -> bool {
+        matches!(&self.value, SqlOptionValue::Value(_))
+            && is_sensitive_sql_option_name(&self.name.real_value(), keywords)
+    }
+
+    pub fn redact(&mut self) {
+        self.value.redact();
+    }
+}
+
 impl fmt::Display for SqlOption {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let should_redact = REDACT_SQL_OPTION_KEYWORDS
@@ -3347,6 +3365,14 @@ impl SqlOptionValue {
     /// Returns a `NULL` value.
     pub const fn null() -> Self {
         Self::Value(Value::Null)
+    }
+
+    pub fn redact(&mut self) {
+        if matches!(self, Self::Value(_)) {
+            *self = Self::Value(Value::SingleQuotedString(
+                REDACTED_SQL_OPTION_VALUE.to_owned(),
+            ));
+        }
     }
 }
 


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

Redact inline source passwords from catalog display surfaces for all users. The regression test uses a user granted `SELECT` because that privilege makes the source metadata visible, but the redaction itself is unconditional.

- Redact plaintext source properties whose names contain `password`, case-insensitively, when rendering `SHOW CREATE SOURCE`, `rw_catalog.rw_sources.definition`, and source definitions in `rw_catalog.rw_relation_info`.
- Redact the corresponding plaintext value in `rw_catalog.rw_sources.connector_props` while preserving its JSON shape.
- Preserve explicit `SECRET` references and keep redaction display-only so source creation and connector runtime behavior continue using the original credential.
- Add a PostgreSQL CDC regression test that grants a separate RisingWave user access to the source and checks all four surfaces.

## Checklist

- [ ] I have written necessary rustdoc comments.
- [x] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [x] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/dev/src/ci.md#ci-labels-guide -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

Inline source passwords are now redacted for all users from `SHOW CREATE SOURCE`, `rw_catalog.rw_sources.definition`, `rw_catalog.rw_sources.connector_props`, and source definitions in `rw_catalog.rw_relation_info`.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Sensitive PostgreSQL CDC connection details, including passwords, are now redacted from `SHOW CREATE SOURCE` output and source catalog metadata.
  * Accessing source definitions no longer exposes inline credentials through system views or catalog fields.

* **Tests**
  * Added end-to-end coverage confirming credential redaction across multiple metadata surfaces.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
