### PR TITLE
refactor(meta): unify independent job initial barrier handling

### DIFF
--- a/src/meta/src/barrier/checkpoint/control.rs
+++ b/src/meta/src/barrier/checkpoint/control.rs
@@ -994,73 +994,66 @@ impl DatabaseCheckpointControl {
     ) {
         // `Vec::new` is a const fn, and do not have memory allocation, and therefore is lightweight enough
         let mut independent_jobs_task = vec![];
-        if let Some(committed_epoch) = self.committed_epoch {
-            // `Vec::new` is a const fn, and do not have memory allocation, and therefore is lightweight enough
-            let mut finished_jobs = Vec::new();
-            let min_upstream_inflight_barrier = partial_graph_manager
-                .first_inflight_barrier(self.partial_graph_id)
-                .map(|epoch| epoch.prev);
-            for (job_id, job) in &mut self.independent_checkpoint_job_controls {
-                let Some(job) = job.running_mut() else {
-                    continue;
-                };
-                match job {
-                    IndependentCheckpointJob::CreatingStreamingJob(creating_job) => {
-                        if let Some((epoch, resps, info, is_finish_epoch)) = creating_job
-                            .start_completing(
-                                partial_graph_manager,
-                                min_upstream_inflight_barrier,
-                                committed_epoch,
-                            )
-                        {
-                            let resps = resps.into_values().collect_vec();
-                            if is_finish_epoch {
-                                assert!(info.notifier.is_none());
-                                finished_jobs.push((*job_id, epoch, resps));
-                                continue;
-                            };
-                            independent_jobs_task.push((*job_id, epoch, resps, info));
-                        }
+        let mut finished_jobs = Vec::new();
+        let min_upstream_inflight_barrier = partial_graph_manager
+            .first_inflight_barrier(self.partial_graph_id)
+            .map(|epoch| epoch.prev);
+        for (job_id, job) in &mut self.independent_checkpoint_job_controls {
+            let Some(job) = job.ready_mut() else {
+                continue;
+            };
+            match job {
+                IndependentCheckpointJob::CreatingStreamingJob(creating_job) => {
+                    if let Some((epoch, resps, info, is_finish_epoch)) = creating_job
+                        .start_completing(partial_graph_manager, min_upstream_inflight_barrier)
+                    {
+                        let resps = resps.into_values().collect_vec();
+                        if is_finish_epoch {
+                            assert!(info.notifier.is_none());
+                            finished_jobs.push((*job_id, epoch, resps));
+                            continue;
+                        };
+                        independent_jobs_task.push((*job_id, epoch, resps, info));
                     }
-                    IndependentCheckpointJob::BatchRefresh(batch_refresh_job) => {
-                        if let Some((epoch, resps, info, tracking_job)) = batch_refresh_job
-                            .start_completing(partial_graph_manager, committed_epoch)
-                        {
-                            let resps = resps.into_values().collect_vec();
-                            if let Some(tracking_job) = tracking_job {
-                                let task = task.get_or_insert_default();
-                                task.finished_jobs.push(tracking_job);
-                            }
-                            independent_jobs_task.push((*job_id, epoch, resps, info));
+                }
+                IndependentCheckpointJob::BatchRefresh(batch_refresh_job) => {
+                    if let Some((epoch, resps, info, tracking_job)) =
+                        batch_refresh_job.start_completing(partial_graph_manager)
+                    {
+                        let resps = resps.into_values().collect_vec();
+                        if let Some(tracking_job) = tracking_job {
+                            let task = task.get_or_insert_default();
+                            task.finished_jobs.push(tracking_job);
                         }
+                        independent_jobs_task.push((*job_id, epoch, resps, info));
                     }
                 }
             }
-            if !finished_jobs.is_empty() {
-                partial_graph_manager.remove_partial_graphs(
-                    finished_jobs
-                        .iter()
-                        .map(|(job_id, ..)| to_partial_graph_id(self.database_id, Some(*job_id)))
-                        .collect(),
-                );
-            }
-            for (job_id, epoch, resps) in finished_jobs {
-                debug!(epoch, %job_id, "finish creating job");
-                // It's safe to remove the creating job, because on CompleteJobType::Finished,
-                // all previous barriers have been collected and completed.
-                // `finished_jobs` was populated above only from a Running creating job, and the
-                // map cannot change between that scan and this removal.
-                let Some(IndependentCheckpointJobControl::Running {
-                    job: IndependentCheckpointJob::CreatingStreamingJob(creating_streaming_job),
-                    ..
-                }) = self.independent_checkpoint_job_controls.remove(&job_id)
-                else {
-                    panic!("finished job {job_id} should be a creating streaming job");
-                };
-                let tracking_job = creating_streaming_job.into_tracking_job();
-                self.finishing_jobs_collector
-                    .collect(epoch, job_id, (resps, tracking_job));
-            }
+        }
+        if !finished_jobs.is_empty() {
+            partial_graph_manager.remove_partial_graphs(
+                finished_jobs
+                    .iter()
+                    .map(|(job_id, ..)| to_partial_graph_id(self.database_id, Some(*job_id)))
+                    .collect(),
+            );
+        }
+        for (job_id, epoch, resps) in finished_jobs {
+            debug!(epoch, %job_id, "finish creating job");
+            // It's safe to remove the creating job, because on CompleteJobType::Finished,
+            // all previous barriers have been collected and completed.
+            // `finished_jobs` was populated above only from a Running creating job, and the
+            // map cannot change between that scan and this removal.
+            let Some(IndependentCheckpointJobControl::Running {
+                job: IndependentCheckpointJob::CreatingStreamingJob(creating_streaming_job),
+                ..
+            }) = self.independent_checkpoint_job_controls.remove(&job_id)
+            else {
+                panic!("finished job {job_id} should be a creating streaming job");
+            };
+            let tracking_job = creating_streaming_job.into_tracking_job();
+            self.finishing_jobs_collector
+                .collect(epoch, job_id, (resps, tracking_job));
         }
         let mut observed_non_checkpoint = false;
         self.finishing_jobs_collector.advance_collected();
@@ -1151,6 +1144,9 @@ impl DatabaseCheckpointControl {
                 assert_eq!(command_prev_epoch, Some(epoch.prev));
                 self.committed_epoch = Some(epoch.prev);
                 partial_graph_manager.ack_completed(self.partial_graph_id, epoch.prev);
+                for job in self.independent_checkpoint_job_controls.values_mut() {
+                    job.on_upstream_database_ack_completed(epoch.prev);
+                }
                 self.last_committed_barrier_time
                     .get_or_insert_with(|| {
                         GLOBAL_META_METRICS

--- a/src/meta/src/barrier/checkpoint/independent_job/batch_refresh_job/mod.rs
+++ b/src/meta/src/barrier/checkpoint/independent_job/batch_refresh_job/mod.rs
@@ -916,18 +916,12 @@ impl BatchRefreshJobCheckpointControl {
     pub(crate) fn start_completing(
         &mut self,
         partial_graph_manager: &mut PartialGraphManager,
-        upstream_committed_epoch: u64,
     ) -> Option<(
         u64,
         HashMap<WorkerId, BarrierCompleteResponse>,
         PartialGraphBarrierInfo,
         Option<TrackingJob>,
     )> {
-        // Do not complete any barrier until upstream has committed the snapshot epoch,
-        // since completing the first barrier persists the snapshot epoch to catalog.
-        if upstream_committed_epoch < self.snapshot_epoch {
-            return None;
-        }
         match &self.status {
             BatchRefreshJobStatus::ConsumingSnapshot { .. }
             | BatchRefreshJobStatus::FinishingSnapshot { .. }

--- a/src/meta/src/barrier/checkpoint/independent_job/creating_job/mod.rs
+++ b/src/meta/src/barrier/checkpoint/independent_job/creating_job/mod.rs
@@ -37,7 +37,9 @@ use status::CreatingStreamingJobStatus;
 use tracing::{debug, info};
 
 use super::super::state::RenderResult;
-use super::{IndependentCheckpointJob, IndependentCheckpointJobControl};
+use super::{
+    IndependentCheckpointJob, IndependentCheckpointJobControl, IndependentCheckpointJobStatus,
+};
 use crate::MetaResult;
 use crate::barrier::backfill_order_control::get_nodes_with_backfill_dependencies;
 use crate::barrier::checkpoint::independent_job::creating_job::barrier_control::CreatingStreamingJobBarrierStats;
@@ -116,6 +118,7 @@ impl CreatingStreamingJobControl {
         let info = create_info.info.clone();
         let job_id = info.stream_job_fragments.stream_job_id();
         let database_id = info.streaming_job.database_id();
+        let is_since_timestamp = since_timestamp_upstream_log_epochs.is_some();
         debug!(
             %job_id,
             definition = info.definition,
@@ -310,11 +313,23 @@ impl CreatingStreamingJobControl {
                 pending_non_checkpoint_barriers,
             };
         }
-        let job_control = entry.insert(IndependentCheckpointJobControl::creating_streaming_job(
-            job_id,
-            partial_graph_id,
-            job,
-        ));
+        let job_control = entry.insert(if is_since_timestamp {
+            // Since-timestamp resolution waits for current completion work and requires the
+            // resolved snapshot epoch to be older than the upstream committed epoch.
+            IndependentCheckpointJobControl::creating_streaming_job(
+                job_id,
+                partial_graph_id,
+                IndependentCheckpointJobStatus::Ready,
+                job,
+            )
+        } else {
+            IndependentCheckpointJobControl::creating_streaming_job(
+                job_id,
+                partial_graph_id,
+                IndependentCheckpointJobStatus::Initial { snapshot_epoch },
+                job,
+            )
+        });
         let Some(IndependentCheckpointJob::CreatingStreamingJob(job)) = job_control.running_mut()
         else {
             unreachable!()
@@ -979,17 +994,12 @@ impl CreatingStreamingJobControl {
         &mut self,
         partial_graph_manager: &mut PartialGraphManager,
         min_upstream_inflight_epoch: Option<u64>,
-        upstream_committed_epoch: u64,
     ) -> Option<(
         u64,
         HashMap<WorkerId, BarrierCompleteResponse>,
         PartialGraphBarrierInfo,
         bool,
     )> {
-        // do not commit snapshot backfill job until upstream has committed the snapshot epoch
-        if upstream_committed_epoch < self.snapshot_epoch {
-            return None;
-        }
         let (finished_at_epoch, epoch_end_bound) = match &self.status {
             CreatingStreamingJobStatus::Finishing(finish_at_epoch, _) => {
                 let epoch_end_bound = min_upstream_inflight_epoch

--- a/src/meta/src/barrier/checkpoint/independent_job/mod.rs
+++ b/src/meta/src/barrier/checkpoint/independent_job/mod.rs
@@ -79,9 +79,19 @@ pub(crate) enum IndependentCheckpointJob {
     BatchRefresh(BatchRefreshJobCheckpointControl),
 }
 
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) enum IndependentCheckpointJobStatus {
+    /// The initial barrier cannot be completed until the database has committed the snapshot
+    /// epoch.
+    Initial { snapshot_epoch: u64 },
+    /// The upstream database has committed the snapshot epoch, so barriers may complete.
+    Ready,
+}
+
 /// The lifecycle shared by all independent checkpoint jobs.
 pub(crate) enum IndependentCheckpointJobControl {
     Running {
+        status: IndependentCheckpointJobStatus,
         job_id: JobId,
         partial_graph_id: PartialGraphId,
         job: IndependentCheckpointJob,
@@ -111,13 +121,25 @@ impl IndependentCheckpointJob {
     }
 }
 
+impl IndependentCheckpointJobStatus {
+    fn on_upstream_database_ack_completed(&mut self, committed_epoch: u64) {
+        if let Self::Initial { snapshot_epoch } = self
+            && committed_epoch >= *snapshot_epoch
+        {
+            *self = Self::Ready;
+        }
+    }
+}
+
 impl IndependentCheckpointJobControl {
     pub(crate) fn creating_streaming_job(
         job_id: JobId,
         partial_graph_id: PartialGraphId,
+        status: IndependentCheckpointJobStatus,
         job: CreatingStreamingJobControl,
     ) -> Self {
         Self::Running {
+            status,
             job_id,
             partial_graph_id,
             job: IndependentCheckpointJob::CreatingStreamingJob(job),
@@ -127,9 +149,11 @@ impl IndependentCheckpointJobControl {
     pub(crate) fn batch_refresh(
         job_id: JobId,
         partial_graph_id: PartialGraphId,
+        status: IndependentCheckpointJobStatus,
         job: BatchRefreshJobCheckpointControl,
     ) -> Self {
         Self::Running {
+            status,
             job_id,
             partial_graph_id,
             job: IndependentCheckpointJob::BatchRefresh(job),
@@ -147,6 +171,27 @@ impl IndependentCheckpointJobControl {
         match self {
             Self::Running { job, .. } => Some(job),
             Self::Resetting { .. } => None,
+        }
+    }
+
+    pub(crate) fn ready_mut(&mut self) -> Option<&mut IndependentCheckpointJob> {
+        match self {
+            Self::Running {
+                status: IndependentCheckpointJobStatus::Ready,
+                job,
+                ..
+            } => Some(job),
+            Self::Running {
+                status: IndependentCheckpointJobStatus::Initial { .. },
+                ..
+            }
+            | Self::Resetting { .. } => None,
+        }
+    }
+
+    pub(crate) fn on_upstream_database_ack_completed(&mut self, committed_epoch: u64) {
+        if let Self::Running { status, .. } = self {
+            status.on_upstream_database_ack_completed(committed_epoch);
         }
     }
 
@@ -200,14 +245,24 @@ impl IndependentCheckpointJobControl {
         partial_graph_manager: &mut PartialGraphManager,
         epoch: u64,
     ) {
-        match self.running_mut() {
-            Some(IndependentCheckpointJob::CreatingStreamingJob(j)) => {
-                j.ack_completed(partial_graph_manager, epoch)
+        match self {
+            Self::Running {
+                status: IndependentCheckpointJobStatus::Ready,
+                job: IndependentCheckpointJob::CreatingStreamingJob(j),
+                ..
+            } => j.ack_completed(partial_graph_manager, epoch),
+            Self::Running {
+                status: IndependentCheckpointJobStatus::Ready,
+                job: IndependentCheckpointJob::BatchRefresh(j),
+                ..
+            } => j.ack_completed(partial_graph_manager, epoch),
+            Self::Running {
+                status: IndependentCheckpointJobStatus::Initial { .. },
+                ..
+            } => {
+                panic!("an initial job should transition to ready before completing a barrier")
             }
-            Some(IndependentCheckpointJob::BatchRefresh(j)) => {
-                j.ack_completed(partial_graph_manager, epoch)
-            }
-            None => {
+            Self::Resetting { .. } => {
                 // The job was dropped while the completing task was running in the background.
                 // The partial graph has already been reset, so skip the ack.
             }
@@ -247,6 +302,7 @@ impl IndependentCheckpointJobControl {
                 job_id,
                 partial_graph_id,
                 job,
+                ..
             } => {
                 let subscriptions_to_drop = job
                     .pinned_upstream_tables()
@@ -325,5 +381,20 @@ mod tests {
         };
 
         assert_eq!(job.on_partial_graph_reset(), subscriptions_to_drop);
+    }
+
+    #[test]
+    fn test_initial_status_transitions_on_upstream_database_ack() {
+        let mut status = IndependentCheckpointJobStatus::Initial { snapshot_epoch: 10 };
+
+        status.on_upstream_database_ack_completed(9);
+        assert_eq!(
+            status,
+            IndependentCheckpointJobStatus::Initial { snapshot_epoch: 10 }
+        );
+        status.on_upstream_database_ack_completed(10);
+        assert_eq!(status, IndependentCheckpointJobStatus::Ready);
+        status.on_upstream_database_ack_completed(11);
+        assert_eq!(status, IndependentCheckpointJobStatus::Ready);
     }
 }

--- a/src/meta/src/barrier/checkpoint/mod.rs
+++ b/src/meta/src/barrier/checkpoint/mod.rs
@@ -24,5 +24,6 @@ pub(super) use control::{
 pub(crate) use independent_job::{
     BatchRefreshJobCheckpointControl, BatchRefreshLogicalFragments, BatchRefreshRenderResult,
     CreatingStreamingJobControl, IndependentCheckpointJob, IndependentCheckpointJobControl,
+    IndependentCheckpointJobStatus,
 };
 pub(super) use state::BarrierWorkerState;

--- a/src/meta/src/barrier/checkpoint/state.rs
+++ b/src/meta/src/barrier/checkpoint/state.rs
@@ -41,6 +41,7 @@ use crate::barrier::cdc_progress::CdcTableBackfillTracker;
 use crate::barrier::checkpoint::{
     BatchRefreshJobCheckpointControl, BatchRefreshLogicalFragments, CreatingStreamingJobControl,
     DatabaseCheckpointControl, IndependentCheckpointJob, IndependentCheckpointJobControl,
+    IndependentCheckpointJobStatus,
 };
 use crate::barrier::command::{
     CreateStreamingJobCommandInfo, PostCollectCommand, ReschedulePlan, ThrottleConfigMap,
@@ -813,6 +814,7 @@ impl DatabaseCheckpointControl {
                         IndependentCheckpointJobControl::batch_refresh(
                             job_id,
                             to_partial_graph_id(self.database_id, Some(job_id)),
+                            IndependentCheckpointJobStatus::Initial { snapshot_epoch },
                             job,
                         ),
                     );

--- a/src/meta/src/barrier/rpc.rs
+++ b/src/meta/src/barrier/rpc.rs
@@ -69,7 +69,7 @@ use crate::barrier::cdc_progress::CdcTableBackfillTracker;
 use crate::barrier::checkpoint::{
     BarrierWorkerState, BatchRefreshJobCheckpointControl, BatchRefreshRenderResult,
     CreatingStreamingJobControl, DatabaseCheckpointControl, DatabaseCheckpointControlMetrics,
-    IndependentCheckpointJobControl,
+    IndependentCheckpointJobControl, IndependentCheckpointJobStatus,
 };
 use crate::barrier::context::{GlobalBarrierWorkerContext, GlobalBarrierWorkerContextImpl};
 use crate::barrier::edge_builder::{EdgeBuilderFragmentInfo, FragmentEdgeBuilder};
@@ -1115,6 +1115,7 @@ impl PartialGraphRecoverer<'_> {
                 IndependentCheckpointJobControl::creating_streaming_job(
                     job_id,
                     to_partial_graph_id(database_id, Some(job_id)),
+                    IndependentCheckpointJobStatus::Ready,
                     job,
                 ),
             );
@@ -1195,6 +1196,7 @@ impl PartialGraphRecoverer<'_> {
                 IndependentCheckpointJobControl::batch_refresh(
                     job_id,
                     to_partial_graph_id(database_id, Some(job_id)),
+                    IndependentCheckpointJobStatus::Ready,
                     job,
                 ),
             );


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

This PR is stacked on #26806.

Independent checkpoint jobs currently duplicate the rule that their initial barrier cannot complete until the upstream database has committed the job's snapshot epoch. This PR moves that rule into the shared independent-job lifecycle:

- Add an `Initial`/`Ready` status to the shared `Running` job control.
- Promote `Initial` to `Ready` when the upstream database acknowledgment reaches the snapshot epoch.
- Gate completion through the shared `ready_mut` accessor and remove the duplicated epoch checks from snapshot-backfill and batch-refresh jobs.
- Start ordinary snapshot-backfill and batch-refresh jobs as `Initial`.
- Start since-timestamp sinks as `Ready`, because timestamp resolution already waits for pending completion work and proves the resolved snapshot epoch is older than the upstream committed epoch.
- Start recovered jobs as `Ready`, because recovery only reconstructs jobs whose first barrier has already committed.

The existing since-timestamp log-store initialization and historical checkpoint barriers remain unchanged.

Local verification:

- `cargo test -p risingwave_meta barrier::checkpoint::independent_job`
- `cargo clippy --all-targets --all-features`
- `cargo fmt --all -- --check`
- `git diff --check`

## Checklist

- [x] I have written necessary rustdoc comments.
- [x] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [x] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/dev/src/ci.md#ci-labels-guide -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->

## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

Not applicable. This is an internal meta lifecycle refactor with no user-facing interface changes.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved independent checkpoint job handling so eligible jobs can progress without waiting for a database commit.
  * Added lifecycle tracking for checkpoint jobs, including transitions from initial to ready.
  * Automatically propagates database acknowledgment progress to independent checkpoint jobs.

* **Bug Fixes**
  * Prevented checkpoint completion from being blocked solely by an uncommitted upstream snapshot epoch.
  * Ensured recovered checkpoint jobs resume in a ready state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->