### PR TITLE
refactor(frontend): add cursor query lifecycle infrastructure

### DIFF
--- a/src/frontend/src/scheduler/distributed/query.rs
+++ b/src/frontend/src/scheduler/distributed/query.rs
@@ -464,6 +464,7 @@ pub(crate) mod tests {
     use std::sync::{Arc, RwLock};
 
     use fixedbitset::FixedBitSet;
+    use pgwire::pg_server::SessionId;
     use risingwave_batch::worker_manager::worker_node_manager::{
         WorkerNodeManager, WorkerNodeSelector,
     };
@@ -478,7 +479,9 @@ pub(crate) mod tests {
     use risingwave_pb::common::{HostAddress, WorkerNode, WorkerType};
     use risingwave_pb::plan_common::JoinType;
     use risingwave_rpc_client::ComputeClientPool;
+    use tokio::sync::mpsc::{Receiver, channel};
 
+    use super::{QueryMessage, QueryState};
     use crate::TableCatalog;
     use crate::catalog::catalog_service::CatalogReader;
     use crate::catalog::root_catalog::Catalog;
@@ -495,6 +498,21 @@ pub(crate) mod tests {
     use crate::scheduler::{DistributedQueryMetrics, ExecutionContext, QueryExecutionInfo};
     use crate::session::SessionImpl;
     use crate::utils::Condition;
+
+    pub(crate) fn running_query_execution_with_control_receiver(
+        query: Query,
+        session_id: SessionId,
+    ) -> (Arc<QueryExecution>, Receiver<QueryMessage>) {
+        let (shutdown_tx, shutdown_rx) = channel(100);
+        let query_execution = Arc::new(QueryExecution {
+            query: Arc::new(query),
+            state: tokio::sync::RwLock::new(QueryState::Running),
+            shutdown_tx,
+            session_id,
+            permit: None,
+        });
+        (query_execution, shutdown_rx)
+    }
 
     #[tokio::test]
     async fn test_query_should_not_hang_with_empty_worker() {

--- a/src/frontend/src/scheduler/distributed/query_manager.rs
+++ b/src/frontend/src/scheduler/distributed/query_manager.rs
@@ -106,6 +106,64 @@ impl QueryExecutionInfo {
 
 pub type QueryExecutionInfoRef = Arc<RwLock<QueryExecutionInfo>>;
 
+/// Owns cleanup of a registered distributed query until its result stream takes ownership.
+///
+/// Dropping an armed guard removes the registration and requests execution cancellation, including
+/// when the scheduling future is dropped at an await point. Dropping it requires a Tokio runtime.
+#[cfg_attr(
+    not(test),
+    expect(dead_code, reason = "wired into query scheduling in the follow-up PR")
+)]
+struct DistributedQueryRegistrationGuard {
+    query_id: QueryId,
+    query_execution: Arc<QueryExecution>,
+    query_execution_info: QueryExecutionInfoRef,
+    armed: bool,
+}
+
+#[cfg_attr(
+    not(test),
+    expect(dead_code, reason = "wired into query scheduling in the follow-up PR")
+)]
+impl DistributedQueryRegistrationGuard {
+    /// Arms cleanup for a query already inserted into the execution registry.
+    fn new(
+        query_id: QueryId,
+        query_execution: Arc<QueryExecution>,
+        query_execution_info: QueryExecutionInfoRef,
+    ) -> Self {
+        Self {
+            query_id,
+            query_execution,
+            query_execution_info,
+            armed: true,
+        }
+    }
+
+    /// Relinquishes cleanup after the result stream has assumed ownership.
+    fn disarm(&mut self) {
+        self.armed = false;
+    }
+}
+
+impl Drop for DistributedQueryRegistrationGuard {
+    fn drop(&mut self) {
+        if !self.armed {
+            return;
+        }
+        self.query_execution_info
+            .write()
+            .unwrap()
+            .delete_query(&self.query_id);
+        let query_execution = self.query_execution.clone();
+        tokio::spawn(async move {
+            query_execution
+                .abort("query scheduling was cancelled".to_owned())
+                .await;
+        });
+    }
+}
+
 impl QueryExecutionInfo {
     pub fn add_query(&mut self, query_id: QueryId, query_execution: Arc<QueryExecution>) {
         self.query_execution_map.insert(query_id, query_execution);
@@ -242,6 +300,30 @@ impl QueryManager {
         Ok(query_result_fetcher.stream_from_channel())
     }
 
+    /// Requests cancellation of the query IDs selected by their owners, without applying session
+    /// or cursor classification. Queries no longer present in the registry are ignored.
+    #[cfg_attr(
+        not(test),
+        expect(
+            dead_code,
+            reason = "used by cursor-owned execution in the follow-up PR"
+        )
+    )]
+    pub(crate) fn cancel_queries_by_ids(&self, query_ids: &[QueryId], reason: impl Into<String>) {
+        let query_executions = {
+            let registry = self.query_execution_info.read().unwrap();
+            query_ids
+                .iter()
+                .filter_map(|query_id| registry.query_execution_map.get(query_id).cloned())
+                .collect::<Vec<_>>()
+        };
+        let reason = reason.into();
+        for query_execution in query_executions {
+            let reason = reason.clone();
+            tokio::spawn(async move { query_execution.abort(reason).await });
+        }
+    }
+
     pub fn cancel_queries_in_session(&self, session_id: SessionId) {
         let query_execution_info = self.query_execution_info.read().unwrap();
         query_execution_info.abort_queries(session_id);
@@ -290,5 +372,139 @@ impl Debug for QueryResultFetcher {
             .field("task_output_id", &self.task_output_id)
             .field("task_host", &self.task_host)
             .finish()
+    }
+}
+
+#[cfg(test)]
+mod cursor_lifecycle_tests {
+    use std::time::Duration;
+
+    use tokio::sync::mpsc;
+
+    use super::*;
+    use crate::scheduler::distributed::query::QueryMessage;
+    use crate::scheduler::distributed::query::tests::{
+        create_query, running_query_execution_with_control_receiver,
+    };
+
+    impl QueryManager {
+        /// Creates a result stream backed by a test-controlled channel and this query registry.
+        pub(crate) fn query_stream_for_test(
+            &self,
+            query_id: QueryId,
+            chunk_rx: mpsc::Receiver<SchedulerResult<DataChunk>>,
+        ) -> DistributedQueryStream {
+            DistributedQueryStream {
+                chunk_rx,
+                query_id,
+                query_execution_info: self.query_execution_info.clone(),
+            }
+        }
+
+        /// Returns whether the query is still present in the execution registry.
+        pub(crate) fn contains_query_for_test(&self, query_id: &QueryId) -> bool {
+            self.query_execution_info
+                .read()
+                .unwrap()
+                .query_execution_map
+                .contains_key(query_id)
+        }
+    }
+
+    /// Verifies that dropping an in-flight scheduling future removes its guarded registration
+    /// and requests cancellation of the unfinished query.
+    #[tokio::test]
+    async fn test_registration_guard_cleans_up_dropped_scheduling_future() {
+        let query = create_query().await;
+        let query_id = query.query_id().clone();
+        let (query_execution, mut control_rx) =
+            running_query_execution_with_control_receiver(query, (0, 0));
+        let registry = Arc::new(RwLock::new(QueryExecutionInfo::new_from_map(
+            HashMap::from([(query_id.clone(), query_execution.clone())]),
+        )));
+        let registration = DistributedQueryRegistrationGuard::new(
+            query_id.clone(),
+            query_execution,
+            registry.clone(),
+        );
+        let mut scheduling = Box::pin(async move {
+            let _registration = registration;
+            std::future::pending::<()>().await;
+        });
+        assert!(futures::poll!(scheduling.as_mut()).is_pending());
+        assert!(
+            registry
+                .read()
+                .unwrap()
+                .query_execution_map
+                .contains_key(&query_id)
+        );
+
+        drop(scheduling);
+
+        assert!(
+            !registry
+                .read()
+                .unwrap()
+                .query_execution_map
+                .contains_key(&query_id)
+        );
+        let message = tokio::time::timeout(Duration::from_secs(1), control_rx.recv())
+            .await
+            .expect("dropping scheduling must request query cancellation")
+            .expect("query cancellation message must arrive");
+        assert!(matches!(
+            message,
+            QueryMessage::CancelQuery(reason) if reason == "query scheduling was cancelled"
+        ));
+    }
+
+    /// Verifies that disarming the guard preserves the query without cancellation and leaves
+    /// registration cleanup to the result stream's drop.
+    #[tokio::test]
+    async fn test_registration_guard_hands_cleanup_to_result_stream() {
+        let query = create_query().await;
+        let query_id = query.query_id().clone();
+        let (query_execution, mut control_rx) =
+            running_query_execution_with_control_receiver(query, (0, 0));
+        let registry = Arc::new(RwLock::new(QueryExecutionInfo::new_from_map(
+            HashMap::from([(query_id.clone(), query_execution.clone())]),
+        )));
+        let mut registration = DistributedQueryRegistrationGuard::new(
+            query_id.clone(),
+            query_execution,
+            registry.clone(),
+        );
+        let (_chunk_tx, chunk_rx) = mpsc::channel(1);
+        let stream = DistributedQueryStream {
+            chunk_rx,
+            query_id: query_id.clone(),
+            query_execution_info: registry.clone(),
+        };
+        registration.disarm();
+        drop(registration);
+
+        assert!(
+            registry
+                .read()
+                .unwrap()
+                .query_execution_map
+                .contains_key(&query_id)
+        );
+        assert!(
+            tokio::time::timeout(Duration::from_secs(1), control_rx.recv())
+                .await
+                .is_err(),
+            "disarming the guard must leave the query control channel open without cancellation"
+        );
+
+        drop(stream);
+        assert!(
+            !registry
+                .read()
+                .unwrap()
+                .query_execution_map
+                .contains_key(&query_id)
+        );
     }
 }

--- a/src/frontend/src/session.rs
+++ b/src/frontend/src/session.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::fmt::{Display, Formatter};
 use std::io::{Error, ErrorKind};
 use std::iter;
@@ -124,6 +124,7 @@ use crate::meta_client::{FrontendMetaClient, FrontendMetaClientImpl};
 use crate::monitor::{CursorMetrics, FrontendMetrics, GLOBAL_FRONTEND_METRICS};
 use crate::observer::FrontendObserverNode;
 use crate::rpc::{FrontendServiceImpl, MonitorServiceImpl};
+use crate::scheduler::plan_fragmenter::QueryId;
 use crate::scheduler::streaming_manager::{StreamingJobTracker, StreamingJobTrackerRef};
 use crate::scheduler::{
     DistributedQueryMetrics, GLOBAL_DISTRIBUTED_QUERY_METRICS, HummockSnapshotManager,
@@ -744,6 +745,19 @@ impl AuthContext {
         }
     }
 }
+
+/// Distributed query IDs grouped by their owner's cancellation domain.
+#[derive(Default)]
+#[expect(dead_code, reason = "wired into session ownership in the follow-up PR")]
+struct SessionDistributedQueryIds {
+    /// Single-statement queries that can be terminated by `CancelRequest` and cannot resume
+    /// after cancellation. Queries retained by extended-protocol portals are currently also
+    /// classified as ordinary, pending the cancellation-targeting changes in TODO(#26999).
+    ordinary_query_ids: HashSet<QueryId>,
+    /// Queries whose execution is owned by a cursor rather than an individual FETCH.
+    cursor_query_ids: HashSet<QueryId>,
+}
+
 pub struct SessionImpl {
     env: FrontendEnv,
     auth_context: Arc<RwLock<AuthContext>>,

--- a/src/frontend/src/session/cursor_manager.rs
+++ b/src/frontend/src/session/cursor_manager.rs
@@ -16,17 +16,21 @@ use core::mem;
 use core::time::Duration;
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::fmt::{Display, Formatter};
+use std::pin::Pin;
 use std::sync::Arc;
+use std::task::{Context, Poll};
 use std::time::Instant;
 
 use anyhow::anyhow;
 use bytes::Bytes;
-use futures::StreamExt;
+use futures::{Stream, StreamExt};
 use itertools::Itertools;
+use parking_lot::Mutex;
 use pgwire::pg_field_descriptor::PgFieldDescriptor;
 use pgwire::pg_response::StatementType;
 use pgwire::types::{Format, Row};
 use risingwave_batch::task::{ShutdownSender, ShutdownToken};
+use risingwave_common::array::DataChunk;
 use risingwave_common::catalog::{ColumnCatalog, Field};
 use risingwave_common::error::BoxedError;
 use risingwave_common::session_config::QueryMode;
@@ -50,9 +54,154 @@ use crate::monitor::{CursorMetrics, PeriodicCursorMetrics};
 use crate::optimizer::PlanRoot;
 use crate::optimizer::plan_node::{BatchFilter, BatchLogSeqScan, BatchSeqScan, generic};
 use crate::optimizer::property::{Order, RequiredDist};
-use crate::scheduler::{DistributedQueryStream, LocalQueryStream, ReadSnapshot, SchedulerError};
+use crate::scheduler::{
+    DistributedQueryStream, LocalQueryStream, QueryManager, ReadSnapshot, SchedulerError,
+};
 use crate::utils::Condition;
 use crate::{OptimizerContext, OptimizerContextRef, PgResponseStream, TableCatalog};
+
+/// Cursor-scoped shutdown resources, separate from individual FETCH cancellation.
+#[cfg_attr(
+    not(test),
+    expect(dead_code, reason = "wired into cursor execution in the follow-up PR")
+)]
+struct CursorShutdownHandle {
+    /// Signals termination of this cursor's execution.
+    shutdown_tx: ShutdownSender,
+    /// Observes termination of this cursor's execution.
+    shutdown_rx: ShutdownToken,
+}
+
+#[cfg_attr(
+    not(test),
+    expect(dead_code, reason = "wired into cursor execution in the follow-up PR")
+)]
+impl CursorShutdownHandle {
+    fn new() -> Self {
+        let (shutdown_tx, shutdown_rx) = ShutdownToken::new();
+        Self {
+            shutdown_tx,
+            shutdown_rx,
+        }
+    }
+
+    /// Returns a token for observing cursor shutdown in FETCH or local query execution.
+    fn shutdown_token(&self) -> ShutdownToken {
+        self.shutdown_rx.clone()
+    }
+
+    /// Returns a sender that the cursor manager can retain to request cursor shutdown.
+    fn shutdown_sender(&self) -> ShutdownSender {
+        self.shutdown_tx.clone()
+    }
+
+    fn shutdown(&self) {
+        self.shutdown_tx.cancel();
+    }
+}
+
+impl Drop for CursorShutdownHandle {
+    fn drop(&mut self) {
+        self.shutdown();
+    }
+}
+
+/// A cursor-owned query stream and the resources needed to stop its execution and clean up.
+#[cfg_attr(
+    not(test),
+    expect(dead_code, reason = "wired into cursor execution in the follow-up PR")
+)]
+enum CursorQueryStreamInner {
+    Local {
+        stream: LocalQueryStream,
+        shutdown_tx: ShutdownSender,
+    },
+    Distributed {
+        stream: DistributedQueryStream,
+        query_manager: QueryManager,
+    },
+}
+
+/// Owns one cursor query's raw output and cancels unfinished execution when dropped.
+///
+/// Ownership begins after query scheduling returns a stream. The distributed registration guard
+/// covers cancellation during scheduling, before this wrapper can take ownership.
+#[cfg_attr(
+    not(test),
+    expect(dead_code, reason = "wired into cursor execution in the follow-up PR")
+)]
+pub(crate) struct CursorQueryStream {
+    inner: CursorQueryStreamInner,
+    /// Whether the underlying stream has reached EOF and no longer needs cancellation.
+    finished: bool,
+}
+
+#[cfg_attr(
+    not(test),
+    expect(dead_code, reason = "wired into cursor execution in the follow-up PR")
+)]
+impl CursorQueryStream {
+    /// Takes ownership of a local query stream and its executor's shutdown sender.
+    pub(crate) fn local(stream: LocalQueryStream, shutdown_tx: ShutdownSender) -> Self {
+        Self {
+            inner: CursorQueryStreamInner::Local {
+                stream,
+                shutdown_tx,
+            },
+            finished: false,
+        }
+    }
+
+    /// Takes ownership of a distributed query stream and cancels it by ID if dropped before EOF.
+    pub(crate) fn distributed(stream: DistributedQueryStream, query_manager: QueryManager) -> Self {
+        Self {
+            inner: CursorQueryStreamInner::Distributed {
+                stream,
+                query_manager,
+            },
+            finished: false,
+        }
+    }
+}
+
+impl Stream for CursorQueryStream {
+    type Item = std::result::Result<DataChunk, BoxedError>;
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        let this = self.get_mut();
+        let result = match &mut this.inner {
+            CursorQueryStreamInner::Local { stream, .. } => stream.poll_next_unpin(cx),
+            CursorQueryStreamInner::Distributed { stream, .. } => stream.poll_next_unpin(cx),
+        };
+        if matches!(&result, Poll::Ready(None)) {
+            this.finished = true;
+        }
+        result
+    }
+}
+
+impl Drop for CursorQueryStream {
+    fn drop(&mut self) {
+        if self.finished {
+            return;
+        }
+        match &self.inner {
+            CursorQueryStreamInner::Local { shutdown_tx, .. } => {
+                shutdown_tx.cancel();
+            }
+            CursorQueryStreamInner::Distributed {
+                stream,
+                query_manager,
+            } => {
+                // Request cancellation before dropping the inner stream removes its registration.
+                query_manager.cancel_queries_by_ids(
+                    std::slice::from_ref(stream.query_id()),
+                    "cursor closed",
+                );
+            }
+        }
+    }
+}
 
 pub enum CursorDataChunkStream {
     LocalDataChunk(Option<LocalQueryStream>),
@@ -1085,6 +1234,9 @@ impl SubscriptionCursor {
 
 pub struct CursorManager {
     cursor_map: tokio::sync::Mutex<HashMap<String, Cursor>>,
+    /// Sender clones accessible without the cursor map lock held by FETCH.
+    #[expect(dead_code, reason = "wired into cursor management in the follow-up PR")]
+    cursor_shutdown_sender_map: Mutex<HashMap<String, ShutdownSender>>,
     cursor_metrics: Arc<CursorMetrics>,
 }
 
@@ -1092,6 +1244,7 @@ impl CursorManager {
     pub fn new(cursor_metrics: Arc<CursorMetrics>) -> Self {
         Self {
             cursor_map: tokio::sync::Mutex::new(HashMap::new()),
+            cursor_shutdown_sender_map: Mutex::new(HashMap::new()),
             cursor_metrics,
         }
     }
@@ -1272,5 +1425,160 @@ impl CursorManager {
             },
             Cursor::Query(_) => Err(ErrorCode::InternalError("The plan of the cursor is the same as the query statement of the as when it was created.".to_owned()).into()),
         }
+    }
+}
+
+#[cfg(test)]
+mod cursor_lifecycle_tests {
+    use std::time::Duration;
+
+    use futures::StreamExt;
+    use risingwave_batch::task::ShutdownToken;
+    use risingwave_common::array::{DataChunk, DataChunkTestExt};
+    use tokio::sync::mpsc;
+    use tokio_stream::wrappers::ReceiverStream;
+
+    use super::{CursorQueryStream, CursorShutdownHandle};
+    use crate::scheduler::QueryMessage;
+    use crate::scheduler::tests::{create_query, running_query_execution_with_control_receiver};
+    use crate::session::SessionImpl;
+
+    /// Verifies that dropping a local cursor query stream before EOF signals its shutdown token.
+    #[tokio::test]
+    async fn test_dropping_unfinished_local_cursor_query_signals_shutdown() {
+        let (shutdown_tx, shutdown_rx) = ShutdownToken::new();
+        let (_chunk_tx, chunk_rx) = mpsc::channel(1);
+        let mut stream = CursorQueryStream::local(ReceiverStream::new(chunk_rx), shutdown_tx);
+        assert!(futures::poll!(stream.next()).is_pending());
+        assert!(!shutdown_rx.is_cancelled());
+
+        drop(stream);
+
+        assert!(shutdown_rx.is_cancelled());
+    }
+
+    /// Verifies that a local cursor query stream forwards chunks and does not request
+    /// cancellation when dropped after EOF.
+    #[tokio::test]
+    async fn test_completed_local_cursor_query_does_not_signals_shutdown() {
+        let (shutdown_tx, shutdown_rx) = ShutdownToken::new();
+        let (chunk_tx, chunk_rx) = mpsc::channel(1);
+        let chunk = DataChunk::from_pretty("i\n1\n2");
+        chunk_tx.try_send(Ok(chunk.clone())).unwrap();
+        drop(chunk_tx);
+        let mut stream = CursorQueryStream::local(ReceiverStream::new(chunk_rx), shutdown_tx);
+
+        assert_eq!(stream.next().await.unwrap().unwrap(), chunk);
+        assert!(stream.next().await.is_none());
+        drop(stream);
+
+        assert!(!shutdown_rx.is_cancelled());
+    }
+
+    /// Verifies that dropping an unfinished distributed cursor query cancels only its query ID,
+    /// even when another query belongs to the same session, and removes its stream registration.
+    #[tokio::test]
+    async fn test_dropping_unfinished_distributed_cursor_query_cancels_only_owned_query() {
+        let manager = SessionImpl::mock().env().query_manager().clone();
+        let query = create_query().await;
+        let query_id = query.query_id().clone();
+        let (execution, mut control_rx) =
+            running_query_execution_with_control_receiver(query, (0, 0));
+        manager.add_query(query_id.clone(), execution);
+        let other_query = create_query().await;
+        let other_id = other_query.query_id().clone();
+        let (other_execution, mut other_control_rx) =
+            running_query_execution_with_control_receiver(other_query, (0, 0));
+        manager.add_query(other_id.clone(), other_execution);
+        let (_chunk_tx, chunk_rx) = mpsc::channel(1);
+        let mut stream = CursorQueryStream::distributed(
+            manager.query_stream_for_test(query_id.clone(), chunk_rx),
+            manager.clone(),
+        );
+        assert!(futures::poll!(stream.next()).is_pending());
+
+        drop(stream);
+
+        let message = tokio::time::timeout(Duration::from_secs(1), control_rx.recv())
+            .await
+            .expect("dropping the stream must request query cancellation")
+            .expect("query cancellation message must arrive");
+        assert!(matches!(message, QueryMessage::CancelQuery(reason) if reason == "cursor closed"));
+        assert!(!manager.contains_query_for_test(&query_id));
+        assert!(manager.contains_query_for_test(&other_id));
+        assert!(
+            tokio::time::timeout(Duration::from_secs(1), other_control_rx.recv())
+                .await
+                .is_err(),
+            "dropping one cursor stream must not cancel another query in the same session"
+        );
+    }
+
+    /// Verifies that a distributed cursor query stream forwards chunks and releases its
+    /// registration without cancellation when dropped after EOF.
+    #[tokio::test]
+    async fn test_completed_distributed_cursor_query_does_not_cancel_execution() {
+        let manager = SessionImpl::mock().env().query_manager().clone();
+        let query = create_query().await;
+        let query_id = query.query_id().clone();
+        let (execution, mut control_rx) =
+            running_query_execution_with_control_receiver(query, (0, 0));
+        manager.add_query(query_id.clone(), execution.clone());
+        let (chunk_tx, chunk_rx) = mpsc::channel(1);
+        let chunk = DataChunk::from_pretty("i\n1\n2");
+        chunk_tx.try_send(Ok(chunk.clone())).unwrap();
+        drop(chunk_tx);
+        let mut stream = CursorQueryStream::distributed(
+            manager.query_stream_for_test(query_id.clone(), chunk_rx),
+            manager.clone(),
+        );
+
+        assert_eq!(stream.next().await.unwrap().unwrap(), chunk);
+        assert!(stream.next().await.is_none());
+        drop(stream);
+
+        assert!(!manager.contains_query_for_test(&query_id));
+        assert!(
+            tokio::time::timeout(Duration::from_secs(1), control_rx.recv())
+                .await
+                .is_err(),
+            "dropping a completed stream must not request query cancellation"
+        );
+        drop(execution);
+    }
+
+    /// Verifies that each sender targets only its own cursor and that retained sender clones
+    /// can shut down all cursors independently of their handles.
+    #[test]
+    fn test_cursor_shutdown_handles_are_independent() {
+        let first = CursorShutdownHandle::new();
+        let second = CursorShutdownHandle::new();
+        let first_rx = first.shutdown_token();
+        let second_rx = second.shutdown_token();
+        let senders = [first.shutdown_sender(), second.shutdown_sender()];
+
+        senders[0].cancel();
+        assert!(first_rx.is_cancelled());
+        assert!(first.shutdown_token().is_cancelled());
+        assert!(!second_rx.is_cancelled());
+
+        // A manager can shut down all cursors through retained sender clones.
+        for sender in senders {
+            sender.cancel();
+        }
+        assert!(first_rx.is_cancelled());
+        assert!(second_rx.is_cancelled());
+    }
+
+    /// Verifies that the receiver observes cancellation when the shutdown handle is dropped.
+    #[test]
+    fn test_cursor_shutdown_handle_drop_signals_shutdown() {
+        let handle = CursorShutdownHandle::new();
+        let shutdown_rx = handle.shutdown_token();
+        assert!(!shutdown_rx.is_cancelled());
+
+        drop(handle);
+
+        assert!(shutdown_rx.is_cancelled());
     }
 }


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

This is the first additive infrastructure PR extracted from #26675 for #26611. It introduces cursor-query lifetime and cancellation-ownership primitives without changing production cancellation or FETCH behavior.

### Infrastructure introduced

- `CursorShutdownHandle` owns a per-cursor shutdown sender/token pair and signals shutdown on drop. Individual FETCH cancellation is a separate scope.
- `CursorQueryStream` owns a local or distributed query's raw output. Dropping it before observed EOF signals local shutdown or requests cancellation of that distributed query by ID. After EOF, dropping it does not request cancellation; the inner distributed stream still removes its execution registration.
- `DistributedQueryRegistrationGuard` owns global registration cleanup while scheduling is in progress. Dropping an armed guard removes the registration and asynchronously requests cancellation; disarming it leaves cleanup to the returned result stream.
- `QueryManager::cancel_queries_by_ids` accepts owner-selected IDs rather than applying session/cursor classification. It captures execution references before spawning cancellation, so dropping a stream cannot remove the registry entry before its cancellation target is captured.
- `SessionDistributedQueryIds` defines ordinary and cursor-owned distributed query ID sets. This is a container definition only; session registration/removal and cancellation routing are deferred.
- `CursorManager::cursor_shutdown_sender_map` is a separately locked map keyed by cursor name, intended to retain sender clones accessible without the cursor-map lock held by FETCH. This PR only adds and initializes the field; population, removal, and shutdown coordination are deferred.

### Cancellation ownership and scope

This revision replaces the earlier `can_session_cancel`-based proposal with preparatory owner-driven abstractions. `QueryManager` remains an execution registry; lifecycle owners will select the IDs to cancel. No `can_session_cancel` flag is introduced.

The new guard, stream wrapper, and cancellation API are not yet wired into production execution. The existing session-wide cancellation API and its callers remain unchanged. Follow-up wiring will connect query ownership bookkeeping, cursor teardown, and session shutdown, including registration-versus-shutdown coordination. Current-query targeting for retained extended-protocol portals remains a separate concern tracked in #26999; the ordinary-query set must not be mistaken for an implementation of that targeting.

Interruptible FETCH and transactional FETCH buffering are also deferred to later PRs in the breakdown. This PR does not by itself fix #26611.

Part of #26611. Extracted from #26675.

## Unit tests

Eight focused lifecycle tests cover:

- Independent cursor shutdown signals and handle-drop signalling.
- Local/distributed stream chunk forwarding and drop behavior before and after EOF.
- Query-specific cancellation isolation when another live execution belongs to the same session.
- Registration cleanup and cancellation requests when a guarded scheduling future is dropped, plus disarmed handoff to a result stream.

The tests assert shutdown tokens, cancellation messages, and registry membership; they do not claim to prove executor termination. Asynchronous negative message assertions require a receive timeout to expire.

## E2E tests

No E2E tests added or run locally: production execution paths are unchanged. Behavioral integration tests belong with the follow-up wiring.

## Other verification

- `cargo test --locked -p risingwave_frontend --lib`: **254 passed**.
- `cargo clippy --locked -p risingwave_frontend --lib --tests -- -D warnings`: passed.
- `rustfmt --check --edition 2024 --config skip_children=true` on all four changed Rust files: passed.
- `git diff --check`: passed.

Existing macOS linker unwind-section and dependency future-incompatibility warnings remain.

Default PR CI coverage, including ordinary and deterministic-simulation unit tests, is retained. No additional CI selector or expansion labels are requested for this additive scope.

## Checklist

- [x] I have written necessary rustdoc comments.
- [x] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [x] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/dev/src/ci.md#ci-labels-guide -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->

## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

## Release note

None. Internal lifecycle infrastructure only; no user-visible behavior change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved cursor lifecycle handling so abandoned or closed query streams are cancelled reliably.
  - Distributed queries now stop executing when their associated cursor stream is dropped.
  - Added cleanup safeguards when query scheduling is interrupted or handed off to result streaming.

- **Reliability**
  - Improved cancellation behavior for both local and distributed cursor queries.
  - Added coverage for cursor shutdown and query cancellation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->