### PR TITLE
refactor(frontend): isolate cursor-owned queries from statement cancellation

### DIFF
--- a/src/frontend/src/handler/declare_cursor.rs
+++ b/src/frontend/src/handler/declare_cursor.rs
@@ -15,6 +15,7 @@
 use std::sync::Arc;
 
 use pgwire::pg_response::{PgResponse, StatementType};
+use risingwave_batch::task::ShutdownToken;
 use risingwave_common::catalog::Field;
 use risingwave_common::session_config::QueryMode;
 use risingwave_common::util::epoch::Epoch;
@@ -31,7 +32,7 @@ use crate::error::{ErrorCode, Result};
 use crate::handler::HandlerArgs;
 use crate::handler::query::{distribute_execute, local_execute};
 use crate::session::SessionImpl;
-use crate::session::cursor_manager::CursorDataChunkStream;
+use crate::session::cursor_manager::{CursorDataChunkStream, CursorQueryStream};
 use crate::{Binder, OptimizerContext};
 
 pub async fn handle_declare_cursor(
@@ -179,7 +180,8 @@ pub async fn create_chunk_stream_for_cursor(
         ..
     } = plan_fragmenter_result;
 
-    let can_timeout_cancel = true;
+    // Cursor-owned queries outlive individual statements and must not inherit statement_timeout.
+    let can_timeout_cancel = false;
 
     let query = plan_fragmenter.generate_complete_query().await?;
     tracing::trace!("Generated query after plan fragmenter: {:?}", &query);
@@ -187,13 +189,83 @@ pub async fn create_chunk_stream_for_cursor(
     Ok((
         match query_mode {
             QueryMode::Auto => unreachable!(),
-            QueryMode::Local => CursorDataChunkStream::LocalDataChunk(Some(
-                local_execute(session.clone(), query, can_timeout_cancel).await?,
-            )),
-            QueryMode::Distributed => CursorDataChunkStream::DistributedDataChunk(Some(
-                distribute_execute(session.clone(), query, can_timeout_cancel).await?,
-            )),
+            QueryMode::Local => {
+                let (shutdown_tx, shutdown_rx) = ShutdownToken::new();
+                CursorDataChunkStream::LocalDataChunk(Some(CursorQueryStream::local(
+                    local_execute(
+                        session.clone(),
+                        query,
+                        can_timeout_cancel,
+                        Some(shutdown_rx),
+                    )
+                    .await?,
+                    shutdown_tx,
+                )))
+            }
+            QueryMode::Distributed => {
+                CursorDataChunkStream::DistributedDataChunk(Some(CursorQueryStream::distributed(
+                    distribute_execute(session.clone(), query, can_timeout_cancel, true).await?,
+                    session.env().query_manager().clone(),
+                )))
+            }
         },
         schema.fields.clone(),
     ))
+}
+
+// Statement timeouts are disabled unconditionally under madsim.
+#[cfg(all(test, not(madsim)))]
+mod tests {
+    use std::time::Duration;
+
+    use futures::StreamExt;
+    use risingwave_sqlparser::parser::Parser;
+
+    use super::*;
+
+    /// Verifies that a local cursor query survives being left unread beyond `statement_timeout`
+    /// and subsequently returns every row without a timeout error.
+    #[tokio::test]
+    async fn test_local_cursor_query_does_not_inherit_statement_timeout() {
+        let session = Arc::new(SessionImpl::mock());
+        session
+            .set_config("visibility_mode", "all".to_owned())
+            .unwrap();
+        session
+            .set_config("query_mode", "local".to_owned())
+            .unwrap();
+        session
+            .set_config("statement_timeout", "50ms".to_owned())
+            .unwrap();
+        let _txn = session.txn_begin_implicit();
+        // The result exceeds the output channel's capacity, keeping execution active while unread.
+        let sql = "SELECT * FROM generate_series(1, 1000000)";
+        let stmt = Parser::parse_sql(sql).unwrap().pop().unwrap();
+        let args = HandlerArgs::new(session, &stmt, sql.into()).unwrap();
+        let (stream, _) = create_stream_for_cursor_stmt(args, stmt).await.unwrap();
+        let CursorDataChunkStream::LocalDataChunk(Some(mut stream)) = stream else {
+            panic!("the query must execute in local mode");
+        };
+        let first_chunk = tokio::time::timeout(Duration::from_secs(5), stream.next())
+            .await
+            .expect("the local cursor query must produce its first chunk")
+            .unwrap()
+            .unwrap();
+        let mut rows = first_chunk.cardinality();
+
+        // Keep the cursor unread beyond the 50 ms statement timeout while backpressure keeps it
+        // active. Otherwise, a fast query could finish before the deadline and hide a regression.
+        tokio::time::sleep(Duration::from_millis(100)).await;
+
+        tokio::time::timeout(Duration::from_secs(5), async {
+            while let Some(chunk) = stream.next().await {
+                rows += chunk
+                    .expect("cursor execution must not time out")
+                    .cardinality();
+            }
+        })
+        .await
+        .expect("the cursor query must finish after consumption resumes");
+        assert_eq!(rows, 1000000);
+    }
 }

--- a/src/frontend/src/handler/query.rs
+++ b/src/frontend/src/handler/query.rs
@@ -20,6 +20,7 @@ use itertools::Itertools;
 use pgwire::pg_field_descriptor::PgFieldDescriptor;
 use pgwire::pg_response::{PgResponse, StatementType};
 use pgwire::types::Format;
+use risingwave_batch::task::ShutdownToken;
 use risingwave_batch::worker_manager::worker_node_manager::WorkerNodeSelector;
 use risingwave_common::bail_not_implemented;
 use risingwave_common::catalog::{FunctionId, Schema, SecretId};
@@ -513,7 +514,7 @@ pub async fn create_stream(
     let row_stream = match query_mode {
         QueryMode::Auto => unreachable!(),
         QueryMode::Local => PgResponseStream::LocalQuery(DataChunkToRowSetAdapter::new(
-            local_execute(session.clone(), query, can_timeout_cancel).await?,
+            local_execute(session.clone(), query, can_timeout_cancel, None).await?,
             column_types,
             formats,
             session.clone(),
@@ -521,7 +522,7 @@ pub async fn create_stream(
         // Local mode do not support cancel tasks.
         QueryMode::Distributed => {
             PgResponseStream::DistributedQuery(DataChunkToRowSetAdapter::new(
-                distribute_execute(session.clone(), query, can_timeout_cancel).await?,
+                distribute_execute(session.clone(), query, can_timeout_cancel, false).await?,
                 column_types,
                 formats,
                 session.clone(),
@@ -601,6 +602,7 @@ pub async fn distribute_execute(
     session: Arc<SessionImpl>,
     query: Query,
     can_timeout_cancel: bool,
+    is_cursor_query: bool,
 ) -> Result<DistributedQueryStream> {
     let timeout = if cfg!(madsim) {
         None
@@ -614,7 +616,7 @@ pub async fn distribute_execute(
     let query_manager = session.env().query_manager().clone();
 
     query_manager
-        .schedule(execution_context, query)
+        .schedule(execution_context, query, is_cursor_query)
         .await
         .map_err(|err| err.into())
 }
@@ -623,6 +625,7 @@ pub async fn local_execute(
     session: Arc<SessionImpl>,
     mut query: Query,
     can_timeout_cancel: bool,
+    shutdown_rx: Option<ShutdownToken>,
 ) -> Result<LocalQueryStream> {
     let timeout = if cfg!(madsim) {
         None
@@ -643,6 +646,7 @@ pub async fn local_execute(
         snapshot.support_barrier_read(),
         session,
         timeout,
+        shutdown_rx,
     );
 
     Ok(execution.stream_rows())

--- a/src/frontend/src/scheduler/distributed/query.rs
+++ b/src/frontend/src/scheduler/distributed/query.rs
@@ -21,7 +21,6 @@ use anyhow::Context;
 use futures::executor::block_on;
 use petgraph::Graph;
 use petgraph::dot::{Config, Dot};
-use pgwire::pg_server::SessionId;
 use risingwave_batch::worker_manager::worker_node_manager::WorkerNodeSelector;
 use risingwave_common::array::DataChunk;
 use risingwave_pb::batch_plan::{TaskId as PbTaskId, TaskOutputId as PbTaskOutputId};
@@ -70,8 +69,6 @@ pub struct QueryExecution {
     query: Arc<Query>,
     state: RwLock<QueryState>,
     shutdown_tx: Sender<QueryMessage>,
-    /// Identified by `process_id`, `secret_key`. Query in the same session should have same key.
-    pub session_id: SessionId,
     /// Permit to execute the query. Once query finishes execution, this is dropped.
     #[expect(dead_code)]
     pub permit: Option<tokio::sync::OwnedSemaphorePermit>,
@@ -95,12 +92,7 @@ struct QueryRunner {
 }
 
 impl QueryExecution {
-    #[allow(clippy::too_many_arguments)]
-    pub fn new(
-        query: Query,
-        session_id: SessionId,
-        permit: Option<tokio::sync::OwnedSemaphorePermit>,
-    ) -> Self {
+    pub fn new(query: Query, permit: Option<tokio::sync::OwnedSemaphorePermit>) -> Self {
         let query = Arc::new(query);
         let (sender, receiver) = channel(100);
         let state = QueryState::Pending {
@@ -111,7 +103,6 @@ impl QueryExecution {
             query,
             state: RwLock::new(state),
             shutdown_tx: sender,
-            session_id,
             permit,
         }
     }
@@ -464,7 +455,6 @@ pub(crate) mod tests {
     use std::sync::{Arc, RwLock};
 
     use fixedbitset::FixedBitSet;
-    use pgwire::pg_server::SessionId;
     use risingwave_batch::worker_manager::worker_node_manager::{
         WorkerNodeManager, WorkerNodeSelector,
     };
@@ -499,16 +489,14 @@ pub(crate) mod tests {
     use crate::session::SessionImpl;
     use crate::utils::Condition;
 
-    pub(crate) fn running_query_execution_with_control_receiver(
+    pub(crate) fn running_query_execution_with_query_message_receiver(
         query: Query,
-        session_id: SessionId,
     ) -> (Arc<QueryExecution>, Receiver<QueryMessage>) {
         let (shutdown_tx, shutdown_rx) = channel(100);
         let query_execution = Arc::new(QueryExecution {
             query: Arc::new(query),
             state: tokio::sync::RwLock::new(QueryState::Running),
             shutdown_tx,
-            session_id,
             permit: None,
         });
         (query_execution, shutdown_rx)
@@ -523,7 +511,7 @@ pub(crate) mod tests {
             CatalogReader::new(Arc::new(parking_lot::RwLock::new(Catalog::default())));
         let query = create_query().await;
         let query_id = query.query_id().clone();
-        let query_execution = Arc::new(QueryExecution::new(query, (0, 0), None));
+        let query_execution = Arc::new(QueryExecution::new(query, None));
         let query_execution_info = Arc::new(RwLock::new(QueryExecutionInfo::new_from_map(
             HashMap::from([(query_id, query_execution.clone())]),
         )));

--- a/src/frontend/src/scheduler/distributed/query_manager.rs
+++ b/src/frontend/src/scheduler/distributed/query_manager.rs
@@ -15,11 +15,11 @@
 use std::collections::HashMap;
 use std::fmt::{Debug, Formatter};
 use std::pin::Pin;
-use std::sync::{Arc, RwLock};
+use std::sync::{Arc, RwLock, Weak};
 use std::task::{Context, Poll};
 
 use futures::Stream;
-use pgwire::pg_server::{BoxedError, Session, SessionId};
+use pgwire::pg_server::BoxedError;
 use risingwave_batch::worker_manager::worker_node_manager::{
     WorkerNodeManagerRef, WorkerNodeSelector,
 };
@@ -35,12 +35,15 @@ use super::stats::DistributedQueryMetrics;
 use crate::catalog::catalog_service::CatalogReader;
 use crate::scheduler::plan_fragmenter::{Query, QueryId};
 use crate::scheduler::{ExecutionContextRef, SchedulerResult};
+use crate::session::SessionImpl;
 
 pub struct DistributedQueryStream {
     chunk_rx: tokio::sync::mpsc::Receiver<SchedulerResult<DataChunk>>,
     // Used for cleaning up `QueryExecution` after all data are polled.
     query_id: QueryId,
     query_execution_info: QueryExecutionInfoRef,
+    // Avoid a Session -> cursor -> stream -> Session reference cycle.
+    session: Weak<SessionImpl>,
 }
 
 impl DistributedQueryStream {
@@ -70,8 +73,13 @@ impl Stream for DistributedQueryStream {
 impl Drop for DistributedQueryStream {
     fn drop(&mut self) {
         // Clear `QueryExecution`. Avoid holding it after execution ends.
-        let mut query_execution_info = self.query_execution_info.write().unwrap();
-        query_execution_info.delete_query(&self.query_id);
+        self.query_execution_info
+            .write()
+            .unwrap()
+            .delete_query(&self.query_id);
+        if let Some(session) = self.session.upgrade() {
+            session.unregister_distributed_query(&self.query_id);
+        }
     }
 }
 
@@ -108,34 +116,30 @@ pub type QueryExecutionInfoRef = Arc<RwLock<QueryExecutionInfo>>;
 
 /// Owns cleanup of a registered distributed query until its result stream takes ownership.
 ///
-/// Dropping an armed guard removes the registration and requests execution cancellation, including
-/// when the scheduling future is dropped at an await point. Dropping it requires a Tokio runtime.
-#[cfg_attr(
-    not(test),
-    expect(dead_code, reason = "wired into query scheduling in the follow-up PR")
-)]
+/// Dropping an armed guard removes the execution registration and session ownership record and
+/// requests execution cancellation, including when the scheduling future is dropped at an await
+/// point. Dropping it requires a Tokio runtime.
 struct DistributedQueryRegistrationGuard {
     query_id: QueryId,
     query_execution: Arc<QueryExecution>,
     query_execution_info: QueryExecutionInfoRef,
+    session: Weak<SessionImpl>,
     armed: bool,
 }
 
-#[cfg_attr(
-    not(test),
-    expect(dead_code, reason = "wired into query scheduling in the follow-up PR")
-)]
 impl DistributedQueryRegistrationGuard {
     /// Arms cleanup for a query already inserted into the execution registry.
     fn new(
         query_id: QueryId,
         query_execution: Arc<QueryExecution>,
         query_execution_info: QueryExecutionInfoRef,
+        session: Weak<SessionImpl>,
     ) -> Self {
         Self {
             query_id,
             query_execution,
             query_execution_info,
+            session,
             armed: true,
         }
     }
@@ -155,6 +159,9 @@ impl Drop for DistributedQueryRegistrationGuard {
             .write()
             .unwrap()
             .delete_query(&self.query_id);
+        if let Some(session) = self.session.upgrade() {
+            session.unregister_distributed_query(&self.query_id);
+        }
         let query_execution = self.query_execution.clone();
         tokio::spawn(async move {
             query_execution
@@ -171,17 +178,6 @@ impl QueryExecutionInfo {
 
     pub fn delete_query(&mut self, query_id: &QueryId) {
         self.query_execution_map.remove(query_id);
-    }
-
-    pub fn abort_queries(&self, session_id: SessionId) {
-        for query in self.query_execution_map.values() {
-            // `QueryExecutionInfo` might have queries from different sessions.
-            if query.session_id == session_id {
-                let query = query.clone();
-                // Spawn a task to abort. Avoid await point in this function.
-                tokio::spawn(async move { query.abort("cancelled by user".to_owned()).await });
-            }
-        }
     }
 }
 
@@ -248,6 +244,7 @@ impl QueryManager {
         &self,
         context: ExecutionContextRef,
         mut query: Query,
+        is_cursor_query: bool,
     ) -> SchedulerResult<DistributedQueryStream> {
         // TODO: if there's no table scan, we don't need to acquire snapshot.
         let pinned_snapshot = context.session().pinned_snapshot();
@@ -264,14 +261,19 @@ impl QueryManager {
         }
         let query_id = query.query_id.clone();
         let permit = self.get_permit().await?;
-        let query_execution = Arc::new(QueryExecution::new(query, context.session().id(), permit));
+        let query_execution = Arc::new(QueryExecution::new(query, permit));
 
-        // Add queries status when begin.
+        self.add_query(query_id.clone(), query_execution.clone());
         context
             .session()
-            .env()
-            .query_manager()
-            .add_query(query_id.clone(), query_execution.clone());
+            .register_distributed_query(query_id.clone(), is_cursor_query);
+        let session = Arc::downgrade(context.session());
+        let mut registration = DistributedQueryRegistrationGuard::new(
+            query_id,
+            query_execution.clone(),
+            self.query_execution_info.clone(),
+            session.clone(),
+        );
 
         let worker_node_manager_reader = WorkerNodeSelector::new(
             self.worker_node_manager.clone(),
@@ -288,27 +290,14 @@ impl QueryManager {
                 self.query_execution_info.clone(),
                 self.query_metrics.clone(),
             )
-            .await
-            .inspect_err(|_| {
-                // Clean up query execution on error.
-                context
-                    .session()
-                    .env()
-                    .query_manager()
-                    .delete_query(&query_id);
-            })?;
-        Ok(query_result_fetcher.stream_from_channel())
+            .await?;
+        let stream = query_result_fetcher.stream_from_channel(session);
+        registration.disarm();
+        Ok(stream)
     }
 
     /// Requests cancellation of the query IDs selected by their owners, without applying session
     /// or cursor classification. Queries no longer present in the registry are ignored.
-    #[cfg_attr(
-        not(test),
-        expect(
-            dead_code,
-            reason = "used by cursor-owned execution in the follow-up PR"
-        )
-    )]
     pub(crate) fn cancel_queries_by_ids(&self, query_ids: &[QueryId], reason: impl Into<String>) {
         let query_executions = {
             let registry = self.query_execution_info.read().unwrap();
@@ -324,19 +313,9 @@ impl QueryManager {
         }
     }
 
-    pub fn cancel_queries_in_session(&self, session_id: SessionId) {
-        let query_execution_info = self.query_execution_info.read().unwrap();
-        query_execution_info.abort_queries(session_id);
-    }
-
     pub fn add_query(&self, query_id: QueryId, query_execution: Arc<QueryExecution>) {
         let mut query_execution_info = self.query_execution_info.write().unwrap();
         query_execution_info.add_query(query_id, query_execution);
-    }
-
-    pub fn delete_query(&self, query_id: &QueryId) {
-        let mut query_execution_info = self.query_execution_info.write().unwrap();
-        query_execution_info.delete_query(query_id);
     }
 }
 
@@ -357,11 +336,12 @@ impl QueryResultFetcher {
         }
     }
 
-    fn stream_from_channel(self) -> DistributedQueryStream {
+    fn stream_from_channel(self, session: Weak<SessionImpl>) -> DistributedQueryStream {
         DistributedQueryStream {
             chunk_rx: self.chunk_rx,
             query_id: self.query_id,
             query_execution_info: self.query_execution_info,
+            session,
         }
     }
 }
@@ -382,9 +362,10 @@ mod cursor_lifecycle_tests {
     use tokio::sync::mpsc;
 
     use super::*;
+    use crate::scheduler::ExecutionContext;
     use crate::scheduler::distributed::query::QueryMessage;
     use crate::scheduler::distributed::query::tests::{
-        create_query, running_query_execution_with_control_receiver,
+        create_query, running_query_execution_with_query_message_receiver,
     };
 
     impl QueryManager {
@@ -393,11 +374,13 @@ mod cursor_lifecycle_tests {
             &self,
             query_id: QueryId,
             chunk_rx: mpsc::Receiver<SchedulerResult<DataChunk>>,
+            session: Weak<SessionImpl>,
         ) -> DistributedQueryStream {
             DistributedQueryStream {
                 chunk_rx,
                 query_id,
                 query_execution_info: self.query_execution_info.clone(),
+                session,
             }
         }
 
@@ -411,47 +394,91 @@ mod cursor_lifecycle_tests {
         }
     }
 
-    /// Verifies that dropping an in-flight scheduling future removes its guarded registration
-    /// and requests cancellation of the unfinished query.
-    #[tokio::test]
-    async fn test_registration_guard_cleans_up_dropped_scheduling_future() {
+    async fn assert_schedule_drops_armed_registration_guard(drop_schedule: bool) {
+        for is_cursor_query in [false, true] {
+            let session = Arc::new(SessionImpl::mock());
+            session
+                .set_config("visibility_mode", "all".to_owned())
+                .unwrap();
+            let _txn = session.txn_begin_implicit();
+            let manager = session.env().query_manager().clone();
+            let query = create_query().await;
+            let query_id = query.query_id().clone();
+            let context = Arc::new(ExecutionContext::new(session.clone(), None));
+            let mut scheduling = Box::pin(manager.schedule(context, query, is_cursor_query));
+
+            // With no semaphore configured, get_permit().await completes immediately.
+            // The registration checks below confirm this poll has passed that await;
+            // the next await, query_execution.start(...).await, is where it suspends.
+            assert!(futures::poll!(scheduling.as_mut()).is_pending());
+            assert!(manager.contains_query_for_test(&query_id));
+            assert_eq!(session.all_distributed_query_ids(), vec![query_id.clone()]);
+            assert_eq!(
+                session.ordinary_distributed_query_ids(),
+                if is_cursor_query {
+                    vec![]
+                } else {
+                    vec![query_id.clone()]
+                }
+            );
+
+            if drop_schedule {
+                drop(scheduling);
+            } else {
+                // The mock query manager has no workers to execute the query.
+                assert!(scheduling.await.is_err());
+            }
+
+            assert!(!manager.contains_query_for_test(&query_id));
+            assert!(session.all_distributed_query_ids().is_empty());
+        }
+    }
+
+    async fn registration_guard_with_control_receiver() -> (
+        DistributedQueryRegistrationGuard,
+        mpsc::Receiver<QueryMessage>,
+    ) {
         let query = create_query().await;
         let query_id = query.query_id().clone();
-        let (query_execution, mut control_rx) =
-            running_query_execution_with_control_receiver(query, (0, 0));
+        let (query_execution, control_rx) =
+            running_query_execution_with_query_message_receiver(query);
         let registry = Arc::new(RwLock::new(QueryExecutionInfo::new_from_map(
             HashMap::from([(query_id.clone(), query_execution.clone())]),
         )));
         let registration = DistributedQueryRegistrationGuard::new(
-            query_id.clone(),
+            query_id,
             query_execution,
-            registry.clone(),
+            registry,
+            Weak::new(),
         );
-        let mut scheduling = Box::pin(async move {
-            let _registration = registration;
-            std::future::pending::<()>().await;
-        });
-        assert!(futures::poll!(scheduling.as_mut()).is_pending());
-        assert!(
-            registry
-                .read()
-                .unwrap()
-                .query_execution_map
-                .contains_key(&query_id)
-        );
+        (registration, control_rx)
+    }
 
-        drop(scheduling);
+    /// Verifies that dropping a schedule drops its armed registration guard, removing both
+    /// global and session registrations for ordinary and cursor-owned queries.
+    #[tokio::test]
+    async fn test_dropped_schedule_drops_armed_registration_guard() {
+        assert_schedule_drops_armed_registration_guard(true).await;
+    }
 
-        assert!(
-            !registry
-                .read()
-                .unwrap()
-                .query_execution_map
-                .contains_key(&query_id)
-        );
+    /// Verifies that a failed schedule drops its armed registration guard, removing both
+    /// global and session registrations for ordinary and cursor-owned queries.
+    #[tokio::test]
+    async fn test_failed_schedule_drops_armed_registration_guard() {
+        assert_schedule_drops_armed_registration_guard(false).await;
+    }
+
+    /// Verifies that dropping an armed registration guard requests cancellation of the unfinished
+    /// query by sending a cancellation message.
+    #[tokio::test]
+    async fn test_dropping_armed_registration_guard_requests_cancellation() {
+        let (registration, mut control_rx) = registration_guard_with_control_receiver().await;
+
+        drop(registration);
+
         let message = tokio::time::timeout(Duration::from_secs(1), control_rx.recv())
             .await
-            .expect("dropping scheduling must request query cancellation")
+            .expect("dropping an armed guard must request query cancellation")
             .expect("query cancellation message must arrive");
         assert!(matches!(
             message,
@@ -459,52 +486,22 @@ mod cursor_lifecycle_tests {
         ));
     }
 
-    /// Verifies that disarming the guard preserves the query without cancellation and leaves
-    /// registration cleanup to the result stream's drop.
+    /// Verifies that dropping a disarmed registration guard does not send a cancellation message.
     #[tokio::test]
-    async fn test_registration_guard_hands_cleanup_to_result_stream() {
-        let query = create_query().await;
-        let query_id = query.query_id().clone();
-        let (query_execution, mut control_rx) =
-            running_query_execution_with_control_receiver(query, (0, 0));
-        let registry = Arc::new(RwLock::new(QueryExecutionInfo::new_from_map(
-            HashMap::from([(query_id.clone(), query_execution.clone())]),
-        )));
-        let mut registration = DistributedQueryRegistrationGuard::new(
-            query_id.clone(),
-            query_execution,
-            registry.clone(),
-        );
-        let (_chunk_tx, chunk_rx) = mpsc::channel(1);
-        let stream = DistributedQueryStream {
-            chunk_rx,
-            query_id: query_id.clone(),
-            query_execution_info: registry.clone(),
-        };
+    async fn test_dropping_disarmed_registration_guard_does_not_request_cancellation() {
+        let (mut registration, mut control_rx) = registration_guard_with_control_receiver().await;
+        let query_execution = registration.query_execution.clone();
+
         registration.disarm();
         drop(registration);
 
         assert!(
-            registry
-                .read()
-                .unwrap()
-                .query_execution_map
-                .contains_key(&query_id)
-        );
-        assert!(
             tokio::time::timeout(Duration::from_secs(1), control_rx.recv())
                 .await
                 .is_err(),
-            "disarming the guard must leave the query control channel open without cancellation"
+            "dropping a disarmed guard must not request query cancellation"
         );
-
-        drop(stream);
-        assert!(
-            !registry
-                .read()
-                .unwrap()
-                .query_execution_map
-                .contains_key(&query_id)
-        );
+        // Keep the execution alive through the assertion so channel closure cannot end the wait.
+        drop(query_execution);
     }
 }

--- a/src/frontend/src/scheduler/local.rs
+++ b/src/frontend/src/scheduler/local.rs
@@ -63,6 +63,7 @@ pub struct LocalQueryExecution {
     session: Arc<SessionImpl>,
     worker_node_manager: WorkerNodeSelector,
     timeout: Option<Duration>,
+    shutdown_rx: Option<ShutdownToken>,
 }
 
 impl LocalQueryExecution {
@@ -72,6 +73,7 @@ impl LocalQueryExecution {
         support_barrier_read: bool,
         session: Arc<SessionImpl>,
         timeout: Option<Duration>,
+        shutdown_rx: Option<ShutdownToken>,
     ) -> Self {
         let worker_node_manager =
             WorkerNodeSelector::new(front_env.worker_node_manager_ref(), support_barrier_read);
@@ -82,11 +84,14 @@ impl LocalQueryExecution {
             session,
             worker_node_manager,
             timeout,
+            shutdown_rx,
         }
     }
 
     fn shutdown_rx(&self) -> ShutdownToken {
-        self.session.reset_cancel_query_flag()
+        self.shutdown_rx
+            .clone()
+            .unwrap_or_else(|| self.session.reset_cancel_query_flag())
     }
 
     #[try_stream(ok = DataChunk, error = RwError)]
@@ -691,5 +696,105 @@ impl LocalQueryExecution {
             }
             Ok(workers)
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use risingwave_sqlparser::parser::Parser;
+
+    use super::*;
+    use crate::OptimizerContext;
+    use crate::handler::HandlerArgs;
+    use crate::handler::query::{
+        gen_batch_plan_by_statement, gen_batch_plan_fragmenter, local_execute,
+    };
+
+    async fn start_local_query(
+        session: Arc<SessionImpl>,
+        shutdown_rx: Option<ShutdownToken>,
+    ) -> LocalQueryStream {
+        session
+            .set_config("visibility_mode", "all".to_owned())
+            .unwrap();
+        session
+            .set_config("query_mode", "local".to_owned())
+            .unwrap();
+        // More rows than the output channel can buffer keeps execution active until cancellation.
+        let sql = "SELECT * FROM generate_series(1, 1000000)";
+        let stmt = Parser::parse_sql(sql).unwrap().pop().unwrap();
+        let args = HandlerArgs::new(session.clone(), &stmt, sql.into()).unwrap();
+        let context = OptimizerContext::from_handler_args(args);
+        let plan = gen_batch_plan_by_statement(&session, context.into(), stmt)
+            .unwrap()
+            .unwrap_rw()
+            .unwrap();
+        let query = gen_batch_plan_fragmenter(&session, plan)
+            .unwrap()
+            .plan_fragmenter
+            .generate_complete_query()
+            .await
+            .unwrap();
+        let mut stream = local_execute(session, query, false, shutdown_rx)
+            .await
+            .unwrap();
+        let first_chunk = tokio::time::timeout(Duration::from_secs(5), stream.next())
+            .await
+            .expect("the local executor must produce its first chunk")
+            .unwrap()
+            .unwrap();
+        assert!(first_chunk.cardinality() > 0);
+        stream
+    }
+
+    async fn expect_error_then_eof(mut stream: LocalQueryStream) -> BoxedError {
+        tokio::time::timeout(Duration::from_secs(5), async {
+            // Drain chunks already buffered before cancellation until the executor reports it.
+            while let Some(result) = stream.next().await {
+                if let Err(error) = result {
+                    assert!(stream.next().await.is_none());
+                    return error;
+                }
+            }
+            panic!("the executor must report cancellation, not successful completion");
+        })
+        .await
+        .expect("the local executor must report cancellation")
+    }
+
+    /// Verifies that local cursor execution observes its explicitly supplied shutdown token,
+    /// reporting a cancellation error followed by EOF when that token is cancelled.
+    #[tokio::test]
+    async fn test_local_execution_uses_supplied_shutdown_token() {
+        let session = Arc::new(SessionImpl::mock());
+        let _txn = session.txn_begin_implicit();
+        let ordinary_shutdown = session.reset_cancel_query_flag();
+        let (shutdown_tx, shutdown_rx) = ShutdownToken::new();
+        let stream = start_local_query(session.clone(), Some(shutdown_rx.clone())).await;
+
+        session.cancel_current_query();
+
+        assert!(ordinary_shutdown.is_cancelled());
+        assert!(!shutdown_rx.is_cancelled());
+        shutdown_tx.cancel();
+        let error = expect_error_then_eof(stream).await;
+        assert!(matches!(
+            error.downcast_ref::<SchedulerError>(),
+            Some(SchedulerError::QueryCancelled(_))
+        ));
+    }
+
+    /// Verifies that ordinary local execution uses the session's shutdown token when none is
+    /// supplied. Calling `cancel_current_query` produces a cancellation error followed by EOF.
+    #[tokio::test]
+    async fn test_local_execution_uses_session_shutdown_token() {
+        let session = Arc::new(SessionImpl::mock());
+        let _txn = session.txn_begin_implicit();
+        let stream = start_local_query(session.clone(), None).await;
+
+        session.cancel_current_query();
+
+        let error = expect_error_then_eof(stream).await;
+        assert!(error.to_string().contains("cancelled"), "{error}");
     }
 }

--- a/src/frontend/src/scheduler/mod.rs
+++ b/src/frontend/src/scheduler/mod.rs
@@ -59,7 +59,7 @@ impl ExecutionContext {
         Self { session, timeout }
     }
 
-    pub fn session(&self) -> &SessionImpl {
+    pub fn session(&self) -> &Arc<SessionImpl> {
         &self.session
     }
 

--- a/src/frontend/src/session.rs
+++ b/src/frontend/src/session.rs
@@ -748,7 +748,6 @@ impl AuthContext {
 
 /// Distributed query IDs grouped by their owner's cancellation domain.
 #[derive(Default)]
-#[expect(dead_code, reason = "wired into session ownership in the follow-up PR")]
 struct SessionDistributedQueryIds {
     /// Single-statement queries that can be terminated by `CancelRequest` and cannot resume
     /// after cancellation. Queries retained by extended-protocol portals are currently also
@@ -786,6 +785,9 @@ pub struct SessionImpl {
     /// This flag is set only when current query is executed in local mode, and used to cancel
     /// local query.
     current_query_cancel_flag: Mutex<Option<ShutdownSender>>,
+
+    /// Distributed queries owned by this session, grouped by cancellation domain.
+    distributed_query_ids: Mutex<SessionDistributedQueryIds>,
 
     /// execution context represents the lifetime of a running SQL in the current session
     exec_context: Mutex<Option<Weak<ExecContext>>>,
@@ -884,6 +886,42 @@ impl From<CheckRelationError> for RwError {
 }
 
 impl SessionImpl {
+    pub(crate) fn register_distributed_query(&self, query_id: QueryId, is_cursor_query: bool) {
+        let mut ids = self.distributed_query_ids.lock();
+        let query_ids = if is_cursor_query {
+            &mut ids.cursor_query_ids
+        } else {
+            &mut ids.ordinary_query_ids
+        };
+        query_ids.insert(query_id);
+    }
+
+    pub(crate) fn unregister_distributed_query(&self, query_id: &QueryId) {
+        let mut ids = self.distributed_query_ids.lock();
+        ids.ordinary_query_ids.remove(query_id);
+        ids.cursor_query_ids.remove(query_id);
+    }
+
+    pub(crate) fn ordinary_distributed_query_ids(&self) -> Vec<QueryId> {
+        self.distributed_query_ids
+            .lock()
+            .ordinary_query_ids
+            .iter()
+            .cloned()
+            .collect()
+    }
+
+    pub(crate) fn all_distributed_query_ids(&self) -> Vec<QueryId> {
+        let ids = self.distributed_query_ids.lock();
+        ids.ordinary_query_ids
+            .iter()
+            .chain(&ids.cursor_query_ids)
+            .cloned()
+            .collect()
+    }
+}
+
+impl SessionImpl {
     pub(crate) fn new(
         env: FrontendEnv,
         auth_context: AuthContext,
@@ -904,6 +942,7 @@ impl SessionImpl {
             peer_addr,
             txn: Default::default(),
             current_query_cancel_flag: Mutex::new(None),
+            distributed_query_ids: Default::default(),
             notice_tx,
             notice_rx: Mutex::new(notice_rx),
             exec_context: Mutex::new(None),
@@ -932,6 +971,7 @@ impl SessionImpl {
             id: (0, 0),
             txn: Default::default(),
             current_query_cancel_flag: Mutex::new(None),
+            distributed_query_ids: Default::default(),
             notice_tx,
             notice_rx: Mutex::new(notice_rx),
             exec_context: Mutex::new(None),
@@ -1404,16 +1444,29 @@ impl SessionImpl {
         *flag = Some(shutdown_tx);
     }
 
-    pub fn cancel_current_query(&self) {
-        let mut flag_guard = self.current_query_cancel_flag.lock();
-        if let Some(sender) = flag_guard.take() {
+    fn cancel_current_local_query(&self) {
+        let cancel_sender = self.current_query_cancel_flag.lock().take();
+        if let Some(sender) = cancel_sender {
             info!("Trying to cancel query in local mode.");
             // Current running query is in local mode
             sender.cancel();
             info!("Cancel query request sent.");
         }
+    }
+
+    pub fn cancel_current_query(&self) {
+        self.cancel_current_local_query();
         info!("Trying to cancel query in distributed mode.");
-        self.env.query_manager().cancel_queries_in_session(self.id)
+        self.env
+            .query_manager()
+            .cancel_queries_by_ids(&self.ordinary_distributed_query_ids(), "cancelled by user");
+    }
+
+    fn cancel_all_queries(&self) {
+        self.cancel_current_local_query();
+        self.env
+            .query_manager()
+            .cancel_queries_by_ids(&self.all_distributed_query_ids(), "session ended");
     }
 
     pub fn cancel_current_creating_job(&self) {
@@ -1603,7 +1656,12 @@ impl SessionManager for SessionManagerImpl {
         self.connect_inner(database_id, user_name, peer_addr)
     }
 
-    /// Used when cancel request happened.
+    /// Handles cancellation requests for ordinary queries in this session; cursor-owned queries
+    /// are excluded. Portal queries are currently also treated as ordinary queries due to #26999,
+    /// so the distributed path cancels all ordinary queries in the session, not just the current one.
+    ///
+    /// TODO(#26999): Split portal queries out of the ordinary-query group and rename this API to
+    /// reflect cancellation of only the current ordinary query.
     fn cancel_queries_in_session(&self, session_id: SessionId) {
         self.env.cancel_queries_in_session(session_id);
     }
@@ -1617,8 +1675,16 @@ impl SessionManager for SessionManagerImpl {
     }
 
     async fn shutdown(&self) {
-        // Clean up the session map.
-        self.env.sessions_map().write().clear();
+        // Release the session map lock before requesting query cancellation.
+        let sessions = std::mem::take(&mut *self.env.sessions_map().write());
+        self.env.frontend_metrics.active_sessions.set(0);
+        for session in sessions.values() {
+            session.cancel_all_queries();
+            session.get_cursor_manager().initiate_shutdown();
+        }
+        for session in sessions.into_values() {
+            session.get_cursor_manager().shutdown_and_wait().await;
+        }
         // Unregister from the meta service.
         self.env.meta_client().try_unregister().await;
     }
@@ -1653,15 +1719,19 @@ impl SessionManagerImpl {
     }
 
     fn delete_session(&self, session_id: &SessionId) {
-        let active_sessions = {
+        let (session, active_sessions) = {
             let mut write_guard = self.env.sessions_map.write();
-            write_guard.remove(session_id);
-            write_guard.len()
+            let session = write_guard.remove(session_id);
+            (session, write_guard.len())
         };
         self.env
             .frontend_metrics
             .active_sessions
             .set(active_sessions as i64);
+        if let Some(session) = session {
+            session.cancel_all_queries();
+            session.get_cursor_manager().initiate_shutdown();
+        }
     }
 
     fn connect_inner(
@@ -2050,5 +2120,242 @@ pub fn cancel_creating_jobs_in_session(session_id: SessionId, sessions_map: Sess
     } else {
         info!("Current session finished, ignoring cancel creating request");
         false
+    }
+}
+
+#[cfg(test)]
+mod cancellation_tests {
+    use std::time::Duration;
+
+    use futures::StreamExt;
+    use risingwave_common::array::DataChunk;
+    use risingwave_common::error::BoxedError;
+    use tokio::sync::mpsc;
+
+    use super::*;
+    use crate::scheduler::tests::{
+        create_query, running_query_execution_with_query_message_receiver,
+    };
+    use crate::scheduler::{DistributedQueryStream, QueryMessage, SchedulerError};
+    use crate::session::cursor_manager::CursorDataChunkStream;
+
+    fn session_manager_for_test() -> SessionManagerImpl {
+        SessionManagerImpl {
+            env: FrontendEnv::mock(),
+            _join_handles: vec![],
+            _shutdown_senders: vec![],
+            number: AtomicI32::new(0),
+        }
+    }
+
+    fn add_session_for_test(manager: &SessionManagerImpl, id: SessionId) -> Arc<SessionImpl> {
+        let mut session = SessionImpl::mock();
+        session.env = manager.env.clone();
+        session.id = id;
+        let session = Arc::new(session);
+        manager.insert_session(session.clone());
+        session
+    }
+
+    async fn add_pending_query_cursor(
+        session: &SessionImpl,
+    ) -> mpsc::Sender<std::result::Result<DataChunk, BoxedError>> {
+        let (chunk_tx, chunk_rx) = mpsc::channel(1);
+        session
+            .get_cursor_manager()
+            .add_query_cursor(
+                "cursor".to_owned(),
+                CursorDataChunkStream::local_stream_without_executor_for_test(chunk_rx),
+                vec![],
+            )
+            .await
+            .unwrap();
+        chunk_tx
+    }
+
+    async fn register_running_distributed_query_stream(
+        session: &Arc<SessionImpl>,
+        is_cursor_query: bool,
+    ) -> (QueryId, DistributedQueryStream) {
+        let query = create_query().await;
+        let query_id = query.query_id().clone();
+        let (execution, mut control_rx) =
+            running_query_execution_with_query_message_receiver(query);
+        let manager = session.env().query_manager();
+        manager.add_query(query_id.clone(), execution);
+        session.register_distributed_query(query_id.clone(), is_cursor_query);
+        let (chunk_tx, chunk_rx) = mpsc::channel(1);
+        // Simulate the executor reporting cancellation through its result stream.
+        tokio::spawn(async move {
+            if let Some(QueryMessage::CancelQuery(reason)) = control_rx.recv().await {
+                let _ = chunk_tx
+                    .send(Err(SchedulerError::QueryCancelled(reason)))
+                    .await;
+            }
+        });
+        let stream =
+            manager.query_stream_for_test(query_id.clone(), chunk_rx, Arc::downgrade(session));
+        (query_id, stream)
+    }
+
+    async fn assert_cancelled_and_drop(mut stream: DistributedQueryStream, expected_reason: &str) {
+        let error = tokio::time::timeout(Duration::from_secs(1), stream.next())
+            .await
+            .expect("cancellation must reach the result stream")
+            .expect("the stream must report a cancellation error")
+            .expect_err("the cancelled query must not return a data chunk");
+        assert!(matches!(
+            error.downcast_ref::<SchedulerError>(),
+            Some(SchedulerError::QueryCancelled(reason)) if reason == expected_reason
+        ));
+        drop(stream);
+    }
+
+    /// Verifies that `CancelRequest` targets all ordinary distributed queries, while cursor-owned
+    /// and other-session streams remain pending and registered. The fixture simulates executor
+    /// cancellation errors; dropping affected streams removes global and session registrations.
+    /// Also checks the local-query cancellation token, without starting a local executor.
+    #[tokio::test]
+    async fn test_cancel_request_respects_distributed_query_ownership() {
+        let manager = session_manager_for_test();
+        let session = add_session_for_test(&manager, (0, 0));
+        let other_session = add_session_for_test(&manager, (1, 1));
+        let local_shutdown = session.reset_cancel_query_flag();
+        let (ordinary_id, ordinary_stream) =
+            register_running_distributed_query_stream(&session, false).await;
+        // Preserve cancellation of all ordinary queries, including retained portals, for now.
+        let (other_ordinary_id, other_ordinary_stream) =
+            register_running_distributed_query_stream(&session, false).await;
+        let (cursor_id, mut cursor_stream) =
+            register_running_distributed_query_stream(&session, true).await;
+        let (other_session_query_id, mut other_session_stream) =
+            register_running_distributed_query_stream(&other_session, false).await;
+
+        manager.cancel_queries_in_session(session.id());
+
+        assert!(local_shutdown.is_cancelled());
+        for stream in [ordinary_stream, other_ordinary_stream] {
+            assert_cancelled_and_drop(stream, "cancelled by user").await;
+        }
+        for stream in [&mut cursor_stream, &mut other_session_stream] {
+            assert!(
+                tokio::time::timeout(Duration::from_secs(1), stream.next())
+                    .await
+                    .is_err(),
+                "cursor-owned and other-session streams must remain pending"
+            );
+        }
+        assert_eq!(session.all_distributed_query_ids(), vec![cursor_id.clone()]);
+        assert_eq!(
+            other_session.all_distributed_query_ids(),
+            vec![other_session_query_id.clone()]
+        );
+        let queries = manager.env.query_manager();
+        for query_id in [ordinary_id, other_ordinary_id] {
+            assert!(!queries.contains_query_for_test(&query_id));
+        }
+        for query_id in [cursor_id, other_session_query_id] {
+            assert!(queries.contains_query_for_test(&query_id));
+        }
+        manager.shutdown().await;
+    }
+
+    /// Verifies that ending one session targets its ordinary and cursor-owned distributed queries.
+    /// The fixture simulates executor cancellation errors; dropping affected streams removes their
+    /// global and session registrations without affecting another session's distributed query.
+    /// Also checks local-query tokens and executor-free cursor-stream fixtures: only the ended
+    /// session's token is signaled and its registered cursor stream dropped.
+    #[tokio::test]
+    async fn test_end_session_cancels_all_owned_distributed_queries() {
+        let manager = session_manager_for_test();
+        let session = add_session_for_test(&manager, (0, 0));
+        let other_session = add_session_for_test(&manager, (1, 1));
+        let local_shutdown = session.reset_cancel_query_flag();
+        let other_local_shutdown = other_session.reset_cancel_query_flag();
+        let cursor_tx = add_pending_query_cursor(&session).await;
+        let other_cursor_tx = add_pending_query_cursor(&other_session).await;
+        let (ordinary_id, ordinary_stream) =
+            register_running_distributed_query_stream(&session, false).await;
+        let (cursor_id, cursor_stream) =
+            register_running_distributed_query_stream(&session, true).await;
+        let (other_query_id, mut other_stream) =
+            register_running_distributed_query_stream(&other_session, false).await;
+
+        manager.end_session(&session);
+
+        assert!(!manager.env.sessions_map.read().contains_key(&session.id()));
+        assert!(
+            manager
+                .env
+                .sessions_map
+                .read()
+                .contains_key(&other_session.id())
+        );
+        assert!(local_shutdown.is_cancelled());
+        assert!(!other_local_shutdown.is_cancelled());
+        assert!(cursor_tx.is_closed());
+        assert!(!other_cursor_tx.is_closed());
+        for stream in [ordinary_stream, cursor_stream] {
+            assert_cancelled_and_drop(stream, "session ended").await;
+        }
+        assert!(session.all_distributed_query_ids().is_empty());
+        assert!(
+            tokio::time::timeout(Duration::from_secs(1), other_stream.next())
+                .await
+                .is_err(),
+            "ending one session must leave the other session's stream pending"
+        );
+        assert_eq!(
+            other_session.all_distributed_query_ids(),
+            vec![other_query_id.clone()]
+        );
+        let queries = manager.env.query_manager();
+        for query_id in [ordinary_id, cursor_id] {
+            assert!(!queries.contains_query_for_test(&query_id));
+        }
+        assert!(queries.contains_query_for_test(&other_query_id));
+        manager.shutdown().await;
+        assert!(other_cursor_tx.is_closed());
+    }
+
+    /// Verifies that frontend shutdown targets ordinary and cursor-owned distributed queries in
+    /// every session. The fixture simulates executor cancellation errors; dropping their result
+    /// streams removes all global and session registrations. Also checks each session's local-query
+    /// cancellation token and cleanup of executor-free cursor-stream fixtures, without starting
+    /// local executors.
+    #[tokio::test]
+    async fn test_frontend_shutdown_cancels_distributed_queries_in_all_sessions() {
+        let manager = session_manager_for_test();
+        let first = add_session_for_test(&manager, (0, 0));
+        let second = add_session_for_test(&manager, (1, 1));
+        let first_local_shutdown = first.reset_cancel_query_flag();
+        let second_local_shutdown = second.reset_cancel_query_flag();
+        let first_cursor_tx = add_pending_query_cursor(&first).await;
+        let second_cursor_tx = add_pending_query_cursor(&second).await;
+        let queries = [
+            register_running_distributed_query_stream(&first, false).await,
+            register_running_distributed_query_stream(&first, true).await,
+            register_running_distributed_query_stream(&second, false).await,
+            register_running_distributed_query_stream(&second, true).await,
+        ];
+
+        manager.shutdown().await;
+
+        assert!(manager.env.sessions_map.read().is_empty());
+        assert!(first_local_shutdown.is_cancelled());
+        assert!(second_local_shutdown.is_cancelled());
+        assert!(first_cursor_tx.is_closed());
+        assert!(second_cursor_tx.is_closed());
+        for (query_id, stream) in queries {
+            assert_cancelled_and_drop(stream, "session ended").await;
+            assert!(
+                !manager
+                    .env
+                    .query_manager()
+                    .contains_query_for_test(&query_id)
+            );
+        }
+        assert!(first.all_distributed_query_ids().is_empty());
+        assert!(second.all_distributed_query_ids().is_empty());
     }
 }

--- a/src/frontend/src/session/cursor_manager.rs
+++ b/src/frontend/src/session/cursor_manager.rs
@@ -14,10 +14,12 @@
 
 use core::mem;
 use core::time::Duration;
+use std::collections::hash_map::Entry;
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::fmt::{Display, Formatter};
 use std::pin::Pin;
 use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::task::{Context, Poll};
 use std::time::Instant;
 
@@ -61,10 +63,6 @@ use crate::utils::Condition;
 use crate::{OptimizerContext, OptimizerContextRef, PgResponseStream, TableCatalog};
 
 /// Cursor-scoped shutdown resources, separate from individual FETCH cancellation.
-#[cfg_attr(
-    not(test),
-    expect(dead_code, reason = "wired into cursor execution in the follow-up PR")
-)]
 struct CursorShutdownHandle {
     /// Signals termination of this cursor's execution.
     shutdown_tx: ShutdownSender,
@@ -72,10 +70,6 @@ struct CursorShutdownHandle {
     shutdown_rx: ShutdownToken,
 }
 
-#[cfg_attr(
-    not(test),
-    expect(dead_code, reason = "wired into cursor execution in the follow-up PR")
-)]
 impl CursorShutdownHandle {
     fn new() -> Self {
         let (shutdown_tx, shutdown_rx) = ShutdownToken::new();
@@ -107,10 +101,6 @@ impl Drop for CursorShutdownHandle {
 }
 
 /// A cursor-owned query stream and the resources needed to stop its execution and clean up.
-#[cfg_attr(
-    not(test),
-    expect(dead_code, reason = "wired into cursor execution in the follow-up PR")
-)]
 enum CursorQueryStreamInner {
     Local {
         stream: LocalQueryStream,
@@ -126,20 +116,12 @@ enum CursorQueryStreamInner {
 ///
 /// Ownership begins after query scheduling returns a stream. The distributed registration guard
 /// covers cancellation during scheduling, before this wrapper can take ownership.
-#[cfg_attr(
-    not(test),
-    expect(dead_code, reason = "wired into cursor execution in the follow-up PR")
-)]
-pub(crate) struct CursorQueryStream {
+pub struct CursorQueryStream {
     inner: CursorQueryStreamInner,
     /// Whether the underlying stream has reached EOF and no longer needs cancellation.
     finished: bool,
 }
 
-#[cfg_attr(
-    not(test),
-    expect(dead_code, reason = "wired into cursor execution in the follow-up PR")
-)]
 impl CursorQueryStream {
     /// Takes ownership of a local query stream and its executor's shutdown sender.
     pub(crate) fn local(stream: LocalQueryStream, shutdown_tx: ShutdownSender) -> Self {
@@ -204,8 +186,8 @@ impl Drop for CursorQueryStream {
 }
 
 pub enum CursorDataChunkStream {
-    LocalDataChunk(Option<LocalQueryStream>),
-    DistributedDataChunk(Option<DistributedQueryStream>),
+    LocalDataChunk(Option<CursorQueryStream>),
+    DistributedDataChunk(Option<CursorQueryStream>),
     PgResponse(PgResponseStream),
 }
 
@@ -245,24 +227,18 @@ impl CursorDataChunkStream {
     ) {
         let columns_type = fields.iter().map(|f| f.data_type()).collect();
         match self {
-            CursorDataChunkStream::LocalDataChunk(data_chunk) => {
+            CursorDataChunkStream::LocalDataChunk(data_chunk)
+            | CursorDataChunkStream::DistributedDataChunk(data_chunk) => {
                 let data_chunk = mem::take(data_chunk).unwrap();
-                let row_stream = PgResponseStream::LocalQuery(DataChunkToRowSetAdapter::new(
-                    data_chunk,
-                    columns_type,
-                    formats.clone(),
-                    session,
-                ));
-                *self = CursorDataChunkStream::PgResponse(row_stream);
-            }
-            CursorDataChunkStream::DistributedDataChunk(data_chunk) => {
-                let data_chunk = mem::take(data_chunk).unwrap();
-                let row_stream = PgResponseStream::DistributedQuery(DataChunkToRowSetAdapter::new(
-                    data_chunk,
-                    columns_type,
-                    formats.clone(),
-                    session,
-                ));
+                let row_stream = PgResponseStream::Rows(
+                    DataChunkToRowSetAdapter::new(
+                        data_chunk,
+                        columns_type,
+                        formats.clone(),
+                        session,
+                    )
+                    .boxed(),
+                );
                 *self = CursorDataChunkStream::PgResponse(row_stream);
             }
             _ => {}
@@ -284,6 +260,13 @@ pub enum Cursor {
     Query(QueryCursor),
 }
 impl Cursor {
+    fn shutdown_handle(&self) -> &CursorShutdownHandle {
+        match self {
+            Cursor::Subscription(cursor) => &cursor.shutdown_handle,
+            Cursor::Query(cursor) => &cursor.shutdown_handle,
+        }
+    }
+
     pub async fn next(
         &mut self,
         count: u32,
@@ -314,6 +297,7 @@ impl Cursor {
 }
 
 pub struct QueryCursor {
+    shutdown_handle: CursorShutdownHandle,
     chunk_stream: CursorDataChunkStream,
     fields: Vec<Field>,
     remaining_rows: VecDeque<Row>,
@@ -322,6 +306,7 @@ pub struct QueryCursor {
 impl QueryCursor {
     pub fn new(chunk_stream: CursorDataChunkStream, fields: Vec<Field>) -> Result<Self> {
         Ok(Self {
+            shutdown_handle: CursorShutdownHandle::new(),
             chunk_stream,
             fields,
             remaining_rows: VecDeque::<Row>::new(),
@@ -554,6 +539,7 @@ impl FieldsManager {
 }
 
 pub struct SubscriptionCursor {
+    shutdown_handle: CursorShutdownHandle,
     cursor_name: String,
     subscription: Arc<SubscriptionCatalog>,
     dependent_table_id: TableId,
@@ -634,6 +620,7 @@ impl SubscriptionCursor {
         let cursor_need_drop_time =
             Instant::now() + Duration::from_secs(subscription.retention_seconds);
         Ok(Self {
+            shutdown_handle: CursorShutdownHandle::new(),
             cursor_name,
             subscription,
             dependent_table_id,
@@ -1235,9 +1222,81 @@ impl SubscriptionCursor {
 pub struct CursorManager {
     cursor_map: tokio::sync::Mutex<HashMap<String, Cursor>>,
     /// Sender clones accessible without the cursor map lock held by FETCH.
-    #[expect(dead_code, reason = "wired into cursor management in the follow-up PR")]
     cursor_shutdown_sender_map: Mutex<HashMap<String, ShutdownSender>>,
+    shutting_down: AtomicBool,
     cursor_metrics: Arc<CursorMetrics>,
+}
+
+impl CursorManager {
+    fn register_cursor_shutdown_sender(
+        &self,
+        cursor_name: String,
+        sender: ShutdownSender,
+    ) -> Result<()> {
+        let mut senders = self.cursor_shutdown_sender_map.lock();
+        if self.shutting_down.load(Ordering::Acquire) {
+            drop(senders);
+            sender.cancel();
+            return Err(SchedulerError::QueryCancelled("session ended".to_owned()).into());
+        }
+        senders.try_insert(cursor_name, sender).map_err(|error| {
+            ErrorCode::CatalogError(format!("cursor `{}` already exists", error.entry.key()).into())
+        })?;
+        Ok(())
+    }
+
+    fn insert_cursor(
+        &self,
+        cursor_map: &mut HashMap<String, Cursor>,
+        cursor_name: String,
+        cursor: Cursor,
+    ) -> Result<()> {
+        match cursor_map.entry(cursor_name) {
+            Entry::Occupied(entry) => Err(ErrorCode::CatalogError(
+                format!("cursor `{}` already exists", entry.key()).into(),
+            )
+            .into()),
+            Entry::Vacant(entry) => {
+                self.register_cursor_shutdown_sender(
+                    entry.key().clone(),
+                    cursor.shutdown_handle().shutdown_sender(),
+                )?;
+                entry.insert(cursor);
+                Ok(())
+            }
+        }
+    }
+
+    fn signal_shutdown(&self) {
+        let senders = {
+            // Serialize registration with terminal shutdown so no sender misses the signal.
+            let mut senders = self.cursor_shutdown_sender_map.lock();
+            self.shutting_down.store(true, Ordering::Release);
+            mem::take(&mut *senders)
+        };
+        for sender in senders.into_values() {
+            sender.cancel();
+        }
+    }
+
+    /// Signals shutdown immediately and schedules cleanup if the cursor map is busy.
+    pub(crate) fn initiate_shutdown(self: &Arc<Self>) {
+        self.signal_shutdown();
+        if let Ok(mut cursor_map) = self.cursor_map.try_lock() {
+            cursor_map.clear();
+            return;
+        }
+        let manager = self.clone();
+        tokio::spawn(async move {
+            manager.cursor_map.lock().await.clear();
+        });
+    }
+
+    /// Signals shutdown and waits until every cursor in the map has been dropped.
+    pub(crate) async fn shutdown_and_wait(&self) {
+        self.signal_shutdown();
+        self.cursor_map.lock().await.clear();
+    }
 }
 
 impl CursorManager {
@@ -1245,6 +1304,7 @@ impl CursorManager {
         Self {
             cursor_map: tokio::sync::Mutex::new(HashMap::new()),
             cursor_shutdown_sender_map: Mutex::new(HashMap::new()),
+            shutting_down: AtomicBool::new(false),
             cursor_metrics,
         }
     }
@@ -1274,24 +1334,22 @@ impl CursorManager {
             .with_label_values(&[&subscription_name])
             .observe(create_cursor_timer.elapsed().as_millis() as _);
 
-        cursor_map.retain(|_, v| {
+        cursor_map.retain(|name, v| {
             if let Cursor::Subscription(cursor) = v
                 && matches!(cursor.state, State::Invalid)
             {
+                self.cursor_shutdown_sender_map.lock().remove(name);
                 false
             } else {
                 true
             }
         });
 
-        cursor_map
-            .try_insert(cursor.cursor_name.clone(), Cursor::Subscription(cursor))
-            .map_err(|error| {
-                ErrorCode::CatalogError(
-                    format!("cursor `{}` already exists", error.entry.key()).into(),
-                )
-            })?;
-        Ok(())
+        self.insert_cursor(
+            &mut cursor_map,
+            cursor.cursor_name.clone(),
+            Cursor::Subscription(cursor),
+        )
     }
 
     pub async fn add_query_cursor(
@@ -1301,39 +1359,34 @@ impl CursorManager {
         fields: Vec<Field>,
     ) -> Result<()> {
         let cursor = QueryCursor::new(chunk_stream, fields)?;
-        self.cursor_map
-            .lock()
-            .await
-            .try_insert(cursor_name, Cursor::Query(cursor))
-            .map_err(|error| {
-                ErrorCode::CatalogError(
-                    format!("cursor `{}` already exists", error.entry.key()).into(),
-                )
-            })?;
-
-        Ok(())
+        let mut cursor_map = self.cursor_map.lock().await;
+        self.insert_cursor(&mut cursor_map, cursor_name, Cursor::Query(cursor))
     }
 
     pub async fn remove_cursor(&self, cursor_name: &str) -> Result<()> {
-        self.cursor_map
-            .lock()
-            .await
-            .remove(cursor_name)
-            .ok_or_else(|| {
-                ErrorCode::CatalogError(format!("cursor `{}` don't exists", cursor_name).into())
-            })?;
+        let mut cursor_map = self.cursor_map.lock().await;
+        cursor_map.remove(cursor_name).ok_or_else(|| {
+            ErrorCode::CatalogError(format!("cursor `{}` don't exists", cursor_name).into())
+        })?;
+        self.cursor_shutdown_sender_map.lock().remove(cursor_name);
         Ok(())
     }
 
     pub async fn remove_all_cursor(&self) {
-        self.cursor_map.lock().await.clear();
+        let mut cursor_map = self.cursor_map.lock().await;
+        cursor_map.clear();
+        self.cursor_shutdown_sender_map.lock().clear();
     }
 
     pub async fn remove_all_query_cursor(&self) {
-        self.cursor_map
-            .lock()
-            .await
-            .retain(|_, v| matches!(v, Cursor::Subscription(_)));
+        self.cursor_map.lock().await.retain(|name, cursor| {
+            if matches!(cursor, Cursor::Subscription(_)) {
+                true
+            } else {
+                self.cursor_shutdown_sender_map.lock().remove(name);
+                false
+            }
+        });
     }
 
     pub async fn get_rows_with_cursor(
@@ -1346,9 +1399,15 @@ impl CursorManager {
         cancel_handle: &mut FetchCursorCancelHandle,
     ) -> Result<(Vec<Row>, Vec<PgFieldDescriptor>)> {
         if let Some(cursor) = self.cursor_map.lock().await.get_mut(cursor_name) {
-            cursor
-                .next(count, handler_args, formats, timeout_seconds, cancel_handle)
-                .await
+            let mut shutdown_rx = cursor.shutdown_handle().shutdown_token();
+            // Dropping FETCH's future is safe for terminal shutdown because the cursor is discarded.
+            tokio::select! {
+                biased;
+                _ = shutdown_rx.cancelled() => {
+                    Err(SchedulerError::QueryCancelled("cursor closed".to_owned()).into())
+                }
+                result = cursor.next(count, handler_args, formats, timeout_seconds, cancel_handle) => result,
+            }
         } else {
             Err(ErrorCode::InternalError(format!("Cannot find cursor `{}`", cursor_name)).into())
         }
@@ -1430,31 +1489,385 @@ impl CursorManager {
 
 #[cfg(test)]
 mod cursor_lifecycle_tests {
-    use std::time::Duration;
+    use std::collections::VecDeque;
+    use std::sync::Arc;
+    use std::time::{Duration, Instant};
 
     use futures::StreamExt;
     use risingwave_batch::task::ShutdownToken;
     use risingwave_common::array::{DataChunk, DataChunkTestExt};
+    use risingwave_common::catalog::TableId;
+    use risingwave_common::error::BoxedError;
+    use risingwave_sqlparser::parser::Parser;
     use tokio::sync::mpsc;
     use tokio_stream::wrappers::ReceiverStream;
 
-    use super::{CursorQueryStream, CursorShutdownHandle};
+    use super::{
+        Cursor, CursorDataChunkStream, CursorManager, CursorQueryStream, CursorShutdownHandle,
+        FetchCursorCancelHandle, FieldsManager, State, SubscriptionCursor,
+    };
+    use crate::TableCatalog;
+    use crate::catalog::subscription_catalog::SubscriptionCatalog;
+    use crate::handler::HandlerArgs;
+    use crate::monitor::CursorMetrics;
     use crate::scheduler::QueryMessage;
-    use crate::scheduler::tests::{create_query, running_query_execution_with_control_receiver};
+    use crate::scheduler::tests::{
+        create_query, running_query_execution_with_query_message_receiver,
+    };
     use crate::session::SessionImpl;
 
-    /// Verifies that dropping a local cursor query stream before EOF signals its shutdown token.
+    impl CursorDataChunkStream {
+        /// Creates a local cursor stream backed by `chunk_rx`, without a real executor.
+        /// The shutdown pair only satisfies the wrapper's constructor: the receiver is unused,
+        /// and the sender has no executor to cancel.
+        pub(crate) fn local_stream_without_executor_for_test(
+            chunk_rx: mpsc::Receiver<Result<DataChunk, BoxedError>>,
+        ) -> Self {
+            let (shutdown_tx, _shutdown_rx) = ShutdownToken::new();
+            Self::LocalDataChunk(Some(CursorQueryStream::local(
+                ReceiverStream::new(chunk_rx),
+                shutdown_tx,
+            )))
+        }
+    }
+
+    async fn add_pending_query_cursor(
+        manager: &CursorManager,
+        name: &str,
+    ) -> (ShutdownToken, mpsc::Sender<Result<DataChunk, BoxedError>>) {
+        let (chunk_tx, chunk_rx) = mpsc::channel(1);
+        manager
+            .add_query_cursor(
+                name.to_owned(),
+                CursorDataChunkStream::local_stream_without_executor_for_test(chunk_rx),
+                vec![],
+            )
+            .await
+            .unwrap();
+        let token = manager
+            .cursor_map
+            .lock()
+            .await
+            .get(name)
+            .unwrap()
+            .shutdown_handle()
+            .shutdown_token();
+        (token, chunk_tx)
+    }
+
+    /// Creates a subscription cursor with a test-controlled pending stream for lifecycle tests.
+    /// `add_subscription_cursor` does not accept an injected stream: it looks up the catalog and
+    /// may start a snapshot query. Constructing `State::Fetch` directly avoids that setup while
+    /// `insert_cursor` still exercises normal cursor and shutdown-sender registration.
+    async fn add_pending_subscription_cursor(
+        manager: &CursorManager,
+        name: &str,
+    ) -> (ShutdownToken, mpsc::Sender<Result<DataChunk, BoxedError>>) {
+        let (chunk_tx, chunk_rx) = mpsc::channel(1);
+        let cursor = SubscriptionCursor {
+            shutdown_handle: CursorShutdownHandle::new(),
+            cursor_name: name.to_owned(),
+            subscription: Arc::new(SubscriptionCatalog {
+                name: name.to_owned(),
+                retention_seconds: 60,
+                ..Default::default()
+            }),
+            dependent_table_id: TableId::new(1),
+            cursor_need_drop_time: Instant::now() + Duration::from_secs(60),
+            state: State::Fetch {
+                from_snapshot: true,
+                rw_timestamp: 0,
+                chunk_stream: CursorDataChunkStream::local_stream_without_executor_for_test(
+                    chunk_rx,
+                ),
+                remaining_rows: VecDeque::new(),
+                expected_timestamp: None,
+                init_query_timer: Instant::now(),
+            },
+            fields_manager: FieldsManager::new(&TableCatalog::default()),
+            cursor_metrics: manager.cursor_metrics.clone(),
+            last_fetch: Instant::now(),
+            seek_pk_row: None,
+        };
+        let token = cursor.shutdown_handle.shutdown_token();
+        let mut cursor_map = manager.cursor_map.lock().await;
+        manager
+            .insert_cursor(
+                &mut cursor_map,
+                name.to_owned(),
+                Cursor::Subscription(cursor),
+            )
+            .unwrap();
+        (token, chunk_tx)
+    }
+
+    /// Verifies that initiating shutdown signals all registered cursors and drops their streams
+    /// before returning when the cursor map is unlocked.
     #[tokio::test]
-    async fn test_dropping_unfinished_local_cursor_query_signals_shutdown() {
-        let (shutdown_tx, shutdown_rx) = ShutdownToken::new();
-        let (_chunk_tx, chunk_rx) = mpsc::channel(1);
-        let mut stream = CursorQueryStream::local(ReceiverStream::new(chunk_rx), shutdown_tx);
-        assert!(futures::poll!(stream.next()).is_pending());
-        assert!(!shutdown_rx.is_cancelled());
+    async fn test_cursor_shutdown_with_unlocked_map() {
+        let manager = Arc::new(CursorManager::new(Arc::new(CursorMetrics::for_test())));
+        let (first, first_tx) = add_pending_query_cursor(&manager, "first").await;
+        let (second, second_tx) = add_pending_query_cursor(&manager, "second").await;
 
-        drop(stream);
+        manager.initiate_shutdown();
 
-        assert!(shutdown_rx.is_cancelled());
+        assert!(first.is_cancelled());
+        assert!(second.is_cancelled());
+        assert!(first_tx.is_closed());
+        assert!(second_tx.is_closed());
+    }
+
+    /// Verifies that initiating shutdown signals all registered cursors without waiting for the
+    /// locked cursor map, then drops their streams in the background after the lock is released.
+    #[tokio::test]
+    async fn test_cursor_shutdown_with_locked_map() {
+        let manager = Arc::new(CursorManager::new(Arc::new(CursorMetrics::for_test())));
+        let (first, first_tx) = add_pending_query_cursor(&manager, "first").await;
+        let (second, second_tx) = add_pending_query_cursor(&manager, "second").await;
+        let cursor_map = manager.cursor_map.lock().await;
+
+        manager.initiate_shutdown();
+
+        assert!(first.is_cancelled());
+        assert!(second.is_cancelled());
+        assert!(!first_tx.is_closed());
+        assert!(!second_tx.is_closed());
+        drop(cursor_map);
+        tokio::time::timeout(Duration::from_secs(1), async {
+            first_tx.closed().await;
+            second_tx.closed().await;
+        })
+        .await
+        .expect("background cleanup must drop both cursor streams after the lock is released");
+    }
+
+    /// Verifies that awaited shutdown signals the cursor before waiting for its map lock, rejects
+    /// and signals late registrations while cleanup is blocked, and returns after stream drop.
+    #[tokio::test]
+    async fn test_cursor_shutdown_and_wait_blocks_until_streams_are_dropped() {
+        let manager = Arc::new(CursorManager::new(Arc::new(CursorMetrics::for_test())));
+        let (handle, chunk_tx) = add_pending_query_cursor(&manager, "cursor").await;
+        let cursor_map = manager.cursor_map.lock().await;
+        let mut shutdown = Box::pin(manager.shutdown_and_wait());
+
+        assert!(futures::poll!(shutdown.as_mut()).is_pending());
+        assert!(handle.is_cancelled());
+        assert!(!chunk_tx.is_closed());
+        let late = CursorShutdownHandle::new();
+        assert!(
+            manager
+                .register_cursor_shutdown_sender("late".to_owned(), late.shutdown_sender())
+                .is_err()
+        );
+        assert!(late.shutdown_token().is_cancelled());
+
+        drop(cursor_map);
+        shutdown.await;
+
+        assert!(chunk_tx.is_closed());
+    }
+
+    /// Verifies that shutdown interrupts pending query and subscription cursors' FETCH futures,
+    /// allowing both shutdown methods to acquire the cursor-map lock and drop their result streams.
+    #[tokio::test]
+    async fn test_cursor_shutdown_interrupts_pending_fetch() {
+        for is_subscription in [false, true] {
+            for wait_for_cleanup in [false, true] {
+                let session = Arc::new(SessionImpl::mock());
+                let manager = session.get_cursor_manager();
+                let (token, chunk_tx) = if is_subscription {
+                    add_pending_subscription_cursor(&manager, "c").await
+                } else {
+                    add_pending_query_cursor(&manager, "c").await
+                };
+                let sql = "FETCH 1 FROM c";
+                let stmt = Parser::parse_sql(sql).unwrap().pop().unwrap();
+                let args = HandlerArgs::new(session, &stmt, sql.into()).unwrap();
+                let formats = vec![];
+                let mut cancel_handle = FetchCursorCancelHandle::new();
+                let mut fetch = Box::pin(manager.get_rows_with_cursor(
+                    "c",
+                    1,
+                    args,
+                    &formats,
+                    None,
+                    &mut cancel_handle,
+                ));
+                assert!(futures::poll!(fetch.as_mut()).is_pending());
+                assert!(manager.cursor_map.try_lock().is_err());
+
+                let result = if wait_for_cleanup {
+                    let mut shutdown = Box::pin(manager.shutdown_and_wait());
+                    assert!(futures::poll!(shutdown.as_mut()).is_pending());
+                    tokio::time::timeout(Duration::from_secs(1), async {
+                        let (result, ()) = tokio::join!(fetch, shutdown);
+                        result
+                    })
+                    .await
+                    .expect("FETCH must release the lock so awaited shutdown can finish")
+                } else {
+                    manager.initiate_shutdown();
+                    tokio::time::timeout(Duration::from_secs(1), fetch)
+                        .await
+                        .expect("initiated shutdown must interrupt FETCH")
+                };
+
+                assert!(result.unwrap_err().to_string().contains("cursor closed"));
+                assert!(token.is_cancelled());
+                tokio::time::timeout(Duration::from_secs(1), chunk_tx.closed())
+                    .await
+                    .expect("shutdown must drop the cursor stream after FETCH releases the lock");
+            }
+        }
+    }
+
+    /// Verifies that a cursor creation already waiting for the map lock is rejected after terminal
+    /// shutdown begins, and its unregistered result stream is dropped.
+    #[tokio::test]
+    async fn test_cursor_shutdown_rejects_creation_waiting_for_map() {
+        let manager = Arc::new(CursorManager::new(Arc::new(CursorMetrics::for_test())));
+        let cursor_map = manager.cursor_map.lock().await;
+        let (chunk_tx, chunk_rx) = mpsc::channel(1);
+        let mut adding = Box::pin(manager.add_query_cursor(
+            "late".to_owned(),
+            CursorDataChunkStream::local_stream_without_executor_for_test(chunk_rx),
+            vec![],
+        ));
+        assert!(futures::poll!(adding.as_mut()).is_pending());
+
+        manager.initiate_shutdown();
+        drop(cursor_map);
+
+        let error = tokio::time::timeout(Duration::from_secs(1), adding)
+            .await
+            .expect("cursor creation must finish after the lock is released")
+            .unwrap_err();
+        assert!(error.to_string().contains("session ended"));
+        assert!(chunk_tx.is_closed());
+        manager.shutdown_and_wait().await;
+        assert!(manager.cursor_map.lock().await.is_empty());
+        assert!(manager.cursor_shutdown_sender_map.lock().is_empty());
+    }
+
+    /// Verifies that declaring a duplicate name fails and drops the new cursor's stream without
+    /// signaling the existing cursor or dropping its stream.
+    #[tokio::test]
+    async fn test_duplicate_cursor_name_rejects_new_cursor_and_preserves_existing_cursor() {
+        let manager = Arc::new(CursorManager::new(Arc::new(CursorMetrics::for_test())));
+        let (query, query_tx) = add_pending_query_cursor(&manager, "query").await;
+        let (duplicate_tx, duplicate_rx) = mpsc::channel(1);
+
+        assert!(
+            manager
+                .add_query_cursor(
+                    "query".to_owned(),
+                    CursorDataChunkStream::local_stream_without_executor_for_test(duplicate_rx),
+                    vec![],
+                )
+                .await
+                .is_err()
+        );
+
+        assert!(duplicate_tx.is_closed());
+        assert!(!query.is_cancelled());
+        assert!(!query_tx.is_closed());
+    }
+
+    /// Verifies that shutting down one cursor via CLOSE signals it and drops its stream, leaves
+    /// another cursor untouched, and permits a new live cursor to reuse the closed cursor's name.
+    #[tokio::test]
+    async fn test_cursor_shutdown_preserves_other_cursor_and_allows_name_reuse() {
+        let manager = Arc::new(CursorManager::new(Arc::new(CursorMetrics::for_test())));
+        let (query, query_tx) = add_pending_query_cursor(&manager, "query").await;
+        let (subscription, subscription_tx) =
+            add_pending_subscription_cursor(&manager, "subscription").await;
+
+        manager.remove_cursor("query").await.unwrap();
+
+        assert!(query.is_cancelled());
+        assert!(query_tx.is_closed());
+        assert!(!subscription.is_cancelled());
+        assert!(!subscription_tx.is_closed());
+        let (replacement, replacement_tx) = add_pending_query_cursor(&manager, "query").await;
+        assert!(!replacement.is_cancelled());
+        assert!(!replacement_tx.is_closed());
+    }
+
+    /// Verifies that query-only cleanup signals query cursors and drops their streams while
+    /// leaving subscription cursors unsignalled with their streams still open.
+    #[tokio::test]
+    async fn test_all_query_cursors_shutdown_preserves_subscription_cursors() {
+        let manager = Arc::new(CursorManager::new(Arc::new(CursorMetrics::for_test())));
+        let (query, query_tx) = add_pending_query_cursor(&manager, "query").await;
+        let (subscription, subscription_tx) =
+            add_pending_subscription_cursor(&manager, "subscription").await;
+
+        manager.remove_all_query_cursor().await;
+
+        assert!(query.is_cancelled());
+        assert!(query_tx.is_closed());
+        assert!(!subscription.is_cancelled());
+        assert!(!subscription_tx.is_closed());
+    }
+
+    /// Verifies that CLOSE ALL signals both cursor types and drops their streams without ending
+    /// the manager's lifetime: new live cursors can be declared using both removed names.
+    #[tokio::test]
+    async fn test_all_cursors_shutdown_allows_new_declarations() {
+        let manager = Arc::new(CursorManager::new(Arc::new(CursorMetrics::for_test())));
+        let (query, query_tx) = add_pending_query_cursor(&manager, "query").await;
+        let (subscription, subscription_tx) =
+            add_pending_subscription_cursor(&manager, "subscription").await;
+
+        manager.remove_all_cursor().await;
+
+        assert!(query.is_cancelled());
+        assert!(query_tx.is_closed());
+        assert!(subscription.is_cancelled());
+        assert!(subscription_tx.is_closed());
+        let (new_query, new_query_tx) = add_pending_query_cursor(&manager, "query").await;
+        let (new_subscription, new_subscription_tx) =
+            add_pending_subscription_cursor(&manager, "subscription").await;
+        assert!(!new_query.is_cancelled());
+        assert!(!new_query_tx.is_closed());
+        assert!(!new_subscription.is_cancelled());
+        assert!(!new_subscription_tx.is_closed());
+    }
+
+    /// Verifies that unfinished local cursor shutdown via CLOSE signals its executor token and drops
+    /// its output stream without signaling the ordinary local query. A query cursor converts its
+    /// chunk stream to a row stream only when the first FETCH is invoked, so shutdown must work
+    /// with either representation.
+    #[tokio::test]
+    async fn test_local_cursor_shutdown_preserves_ordinary_query() {
+        // Simulate shutdown before the first FETCH (false) or after it initializes the row stream
+        // (true), without executing FETCH itself.
+        for initialize_rows in [false, true] {
+            let session = Arc::new(SessionImpl::mock());
+            let ordinary_shutdown = session.reset_cancel_query_flag();
+            let (shutdown_tx, shutdown_rx) = ShutdownToken::new();
+            let (chunk_tx, chunk_rx) = mpsc::channel(1);
+            let mut stream = CursorQueryStream::local(ReceiverStream::new(chunk_rx), shutdown_tx);
+            assert!(futures::poll!(stream.next()).is_pending());
+            let mut stream = CursorDataChunkStream::LocalDataChunk(Some(stream));
+            if initialize_rows {
+                stream.init_row_stream(&vec![], &vec![], session.clone());
+            }
+            let manager = session.get_cursor_manager();
+            manager
+                .add_query_cursor("cursor".to_owned(), stream, vec![])
+                .await
+                .unwrap();
+
+            assert!(!shutdown_rx.is_cancelled());
+            manager.remove_cursor("cursor").await.unwrap();
+
+            assert!(shutdown_rx.is_cancelled());
+            assert!(chunk_tx.is_closed());
+            assert!(!ordinary_shutdown.is_cancelled());
+            session.cancel_current_query();
+            assert!(ordinary_shutdown.is_cancelled());
+        }
     }
 
     /// Verifies that a local cursor query stream forwards chunks and does not request
@@ -1475,61 +1888,89 @@ mod cursor_lifecycle_tests {
         assert!(!shutdown_rx.is_cancelled());
     }
 
-    /// Verifies that dropping an unfinished distributed cursor query cancels only its query ID,
-    /// even when another query belongs to the same session, and removes its stream registration.
+    /// Verifies that unfinished distributed cursor shutdown via CLOSE requests cancellation and
+    /// removes its global and session registrations. Another registered query remains owned and
+    /// receives no cancellation request. A query cursor converts its chunk stream to a row stream
+    /// only when the first FETCH is invoked, so shutdown must work with either representation.
     #[tokio::test]
-    async fn test_dropping_unfinished_distributed_cursor_query_cancels_only_owned_query() {
-        let manager = SessionImpl::mock().env().query_manager().clone();
-        let query = create_query().await;
-        let query_id = query.query_id().clone();
-        let (execution, mut control_rx) =
-            running_query_execution_with_control_receiver(query, (0, 0));
-        manager.add_query(query_id.clone(), execution);
-        let other_query = create_query().await;
-        let other_id = other_query.query_id().clone();
-        let (other_execution, mut other_control_rx) =
-            running_query_execution_with_control_receiver(other_query, (0, 0));
-        manager.add_query(other_id.clone(), other_execution);
-        let (_chunk_tx, chunk_rx) = mpsc::channel(1);
-        let mut stream = CursorQueryStream::distributed(
-            manager.query_stream_for_test(query_id.clone(), chunk_rx),
-            manager.clone(),
-        );
-        assert!(futures::poll!(stream.next()).is_pending());
-
-        drop(stream);
-
-        let message = tokio::time::timeout(Duration::from_secs(1), control_rx.recv())
-            .await
-            .expect("dropping the stream must request query cancellation")
-            .expect("query cancellation message must arrive");
-        assert!(matches!(message, QueryMessage::CancelQuery(reason) if reason == "cursor closed"));
-        assert!(!manager.contains_query_for_test(&query_id));
-        assert!(manager.contains_query_for_test(&other_id));
-        assert!(
-            tokio::time::timeout(Duration::from_secs(1), other_control_rx.recv())
+    async fn test_distributed_cursor_shutdown_cancels_only_owned_query() {
+        // Simulate shutdown before the first FETCH (false) or after it initializes the row stream
+        // (true), without executing FETCH itself.
+        for initialize_rows in [false, true] {
+            let session = Arc::new(SessionImpl::mock());
+            let manager = session.env().query_manager().clone();
+            let query = create_query().await;
+            let query_id = query.query_id().clone();
+            let (execution, mut control_rx) =
+                running_query_execution_with_query_message_receiver(query);
+            manager.add_query(query_id.clone(), execution);
+            session.register_distributed_query(query_id.clone(), true);
+            let other_query = create_query().await;
+            let other_id = other_query.query_id().clone();
+            let (other_execution, mut other_control_rx) =
+                running_query_execution_with_query_message_receiver(other_query);
+            manager.add_query(other_id.clone(), other_execution);
+            session.register_distributed_query(other_id.clone(), false);
+            let (_chunk_tx, chunk_rx) = mpsc::channel(1);
+            let mut stream = CursorQueryStream::distributed(
+                manager.query_stream_for_test(query_id.clone(), chunk_rx, Arc::downgrade(&session)),
+                manager.clone(),
+            );
+            assert!(futures::poll!(stream.next()).is_pending());
+            let mut chunk_stream = CursorDataChunkStream::DistributedDataChunk(Some(stream));
+            if initialize_rows {
+                chunk_stream.init_row_stream(&vec![], &vec![], session.clone());
+                assert!(futures::poll!(std::pin::pin!(chunk_stream.next())).is_pending());
+            }
+            let cursors = session.get_cursor_manager();
+            cursors
+                .add_query_cursor("cursor".to_owned(), chunk_stream, vec![])
                 .await
-                .is_err(),
-            "dropping one cursor stream must not cancel another query in the same session"
-        );
+                .unwrap();
+
+            cursors.remove_cursor("cursor").await.unwrap();
+
+            let message = tokio::time::timeout(Duration::from_secs(1), control_rx.recv())
+                .await
+                .expect("closing the cursor must request query cancellation")
+                .expect("query cancellation message must arrive");
+            assert!(
+                matches!(message, QueryMessage::CancelQuery(reason) if reason == "cursor closed")
+            );
+            assert!(!manager.contains_query_for_test(&query_id));
+            assert_eq!(session.all_distributed_query_ids(), vec![other_id.clone()]);
+            assert_eq!(
+                session.ordinary_distributed_query_ids(),
+                vec![other_id.clone()]
+            );
+            assert!(manager.contains_query_for_test(&other_id));
+            assert!(
+                tokio::time::timeout(Duration::from_secs(1), other_control_rx.recv())
+                    .await
+                    .is_err(),
+                "closing one cursor must not cancel another registered query"
+            );
+        }
     }
 
-    /// Verifies that a distributed cursor query stream forwards chunks and releases its
-    /// registration without cancellation when dropped after EOF.
+    /// Verifies that a distributed cursor query stream forwards chunks and releases its global
+    /// and session registrations without cancellation when dropped after EOF.
     #[tokio::test]
-    async fn test_completed_distributed_cursor_query_does_not_cancel_execution() {
-        let manager = SessionImpl::mock().env().query_manager().clone();
+    async fn test_completed_distributed_cursor_query_does_not_request_query_cancellation() {
+        let session = Arc::new(SessionImpl::mock());
+        let manager = session.env().query_manager().clone();
         let query = create_query().await;
         let query_id = query.query_id().clone();
         let (execution, mut control_rx) =
-            running_query_execution_with_control_receiver(query, (0, 0));
+            running_query_execution_with_query_message_receiver(query);
         manager.add_query(query_id.clone(), execution.clone());
+        session.register_distributed_query(query_id.clone(), true);
         let (chunk_tx, chunk_rx) = mpsc::channel(1);
         let chunk = DataChunk::from_pretty("i\n1\n2");
         chunk_tx.try_send(Ok(chunk.clone())).unwrap();
         drop(chunk_tx);
         let mut stream = CursorQueryStream::distributed(
-            manager.query_stream_for_test(query_id.clone(), chunk_rx),
+            manager.query_stream_for_test(query_id.clone(), chunk_rx, Arc::downgrade(&session)),
             manager.clone(),
         );
 
@@ -1538,6 +1979,7 @@ mod cursor_lifecycle_tests {
         drop(stream);
 
         assert!(!manager.contains_query_for_test(&query_id));
+        assert!(session.all_distributed_query_ids().is_empty());
         assert!(
             tokio::time::timeout(Duration::from_secs(1), control_rx.recv())
                 .await


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## Expectations

This is **PR2 of the #26675 breakdown for #26611**, based on #26902. PR1 added lifecycle infrastructure; this PR wires execution ownership, cancellation policy, and cleanup into production paths.

- **Cursor-owned execution is independent of individual statements.** `CancelRequest` must not terminate local or distributed cursor-owned background queries, including subscription inner queries. Those executions do not inherit `statement_timeout`; ordinary-query timeouts and explicit FETCH timeout handling remain separate.
- **Cursor lifetime owns cleanup.** Dropping an unfinished cursor stream requests execution cancellation before releasing its distributed registrations. Observed EOF avoids unnecessary cancellation on stream drop. Session disconnect and frontend shutdown also cancel owned queries and clean up registered cursors.
- **Terminal shutdown can unblock FETCH.** Shutdown signals pending query and subscription FETCH operations independently of the cursor-map lock, allowing cursor-stream cleanup to proceed.

## Limitations

- This is not the complete interruptible/resumable FETCH implementation. Prompt general FETCH interruption, persistent-stream refactoring, and transactional buffering are later steps. Existing subscription FETCH cancellation can still discard rows already accumulated by that FETCH; lossless retry/resumption is not promised here.
- Terminal shutdown rejects late cursor insertion and drops the rejected stream, but does not promise prompt interruption while cursor construction is waiting on planning RPCs or scheduling permits.
- Awaited shutdown ensures registered cursor streams are dropped before meta unregistration; it does not join remote executors or guarantee instantaneous executor termination.
- Portal queries are still included among ordinary queries due to #26999, so distributed cancellation targets all ordinary queries in the session rather than only the current one. Portal queries should be split out when that issue is addressed.

## What's changed and what's your intention?

- Track ordinary and cursor-owned distributed query IDs on `SessionImpl`. The session selects cancellation targets; `QueryManager` accepts explicit IDs rather than scanning executions by session ID. Ordinary `CancelRequest` selects ordinary queries, while session teardown selects all owned queries.
- Wire the registration guard from #26902 into distributed scheduling. Ownership is recorded before startup; failed or dropped scheduling removes global/session registrations and requests cancellation. Successful scheduling transfers cleanup to the result stream, which holds a weak session reference.
- Wrap local and distributed cursor results with the existing `CursorQueryStream`, retaining it through row conversion. Local cursor execution receives an independent executor token; unfinished distributed cursor streams request cancellation before unregistering.
- Disable statement-timeout cancellation in the shared cursor-query creation path for query and subscription cursors, leaving ordinary-query timeout policy unchanged.
- Maintain per-cursor shutdown handles and a separately locked, cursor-name-keyed sender map. Shutdown signals pending FETCH independently of its cursor-map lock, rejects late insertion, and clears registered cursors. Individual close, query-only cleanup, CLOSE ALL, and invalid-subscription cleanup keep both maps consistent.
- Wire session disconnect and frontend shutdown to cancellation and cursor cleanup outside the session-map lock. Frontend shutdown signals all captured sessions before awaiting their cursor cleanup.

## Unit tests

Added or extended unit/in-process coverage includes:

- **Distributed scheduling and registration guards:** failed and dropped scheduling must remove global and session registrations for both ordinary and cursor-owned queries. Separate armed/disarmed guard tests check whether dropping the guard requests cancellation.
- **Distributed cancellation routing and session teardown:** registered-query fixtures exercise `CancelRequest`, session disconnect, and frontend shutdown, checking cancellation targets, deregistration after stream drop, and isolation of unrelated queries/sessions. The fixtures simulate executor cancellation errors; local checks here use tokens and executor-free cursor streams, not running local executors.
- **Terminal cursor shutdown:** controlled pending query/subscription FETCH futures and locked/unlocked cursor maps exercise initiated and awaited cleanup. Assertions cover interrupting FETCH to release the map lock, dropping cursor streams, and rejecting late cursor insertion.
- **Cursor removal and name handling:** duplicate declarations preserve the original cursor; individual shutdown preserves other cursors and permits name reuse; query-only cleanup preserves subscriptions; CLOSE ALL permits new declarations.
- **Cursor stream ownership:** local and distributed cursor shutdown is checked before and after row conversion, simulating the states before and after the first FETCH initializes it. Unfinished streams signal only their owned execution; completed-stream coverage checks data forwarding and cleanup without a cancellation request.
- **Real local execution token selection:** separate executions cover a supplied cursor token and the ordinary session-token fallback, requiring a cancellation error followed by EOF when the selected token is cancelled. The supplied-token case also checks independence from the ordinary session token.
- **Cursor statement-timeout isolation:** a real local cursor is left unread beyond its configured statement timeout while backpressure keeps execution active, then drained to verify successful completion with the expected row count.

## E2E tests

No new E2E tests are added in this lifecycle step. Existing cursor, subscription FETCH, and ordinary-query timeout suites provide baseline SQL/protocol regression coverage; the new ownership and teardown cases above are exercised in-process. New cancelled-FETCH resumption scenarios are deferred to the later persistent-stream and transactional-buffering changes.

## Checklist

- [x] I have written necessary rustdoc comments.
- [x] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [x] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/dev/src/ci.md#ci-labels-guide -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->

## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

None. This PR is an internal prerequisite in the CancelRequest implementation stack.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Cursor queries can now remain unread beyond the statement timeout without being interrupted.
  - Abandoning an unfinished cursor query now reliably stops its execution and releases resources.
  - FETCH operations can be interrupted when the associated cursor is shut down.
  - Canceling the current query no longer unintentionally cancels active cursor queries.

- **Reliability**
  - Improved cleanup and shutdown handling for local and distributed cursor execution.
  - Cursor lifecycle handling is more consistent during session closure and failed operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->