### PR TITLE
fix(meta): reject unspecified worker type in dashboard `/clusters/{ty}`

### DIFF
--- a/src/meta/src/dashboard/mod.rs
+++ b/src/meta/src/dashboard/mod.rs
@@ -149,9 +149,12 @@ pub(super) mod handlers {
         Path(ty): Path<i32>,
         Extension(srv): Extension<Service>,
     ) -> Result<Json<Vec<WorkerNode>>> {
-        let worker_type = WorkerType::try_from(ty)
-            .map_err(|_| anyhow!("invalid worker type"))
-            .map_err(err)?;
+        let worker_type = match WorkerType::try_from(ty) {
+            Ok(WorkerType::Unspecified) | Err(_) => {
+                return Err(err(anyhow!("invalid worker type: {ty}")));
+            }
+            Ok(worker_type) => worker_type,
+        };
         let mut result = srv
             .metadata_manager
             .list_worker_node(Some(worker_type), None)


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

`GET /api/clusters/0` on the meta dashboard port (5691) panics the meta node.

The handler validates the path parameter with `WorkerType::try_from(ty)`, but that accepts every *declared* variant of the proto enum — including `WORKER_TYPE_UNSPECIFIED = 0`. Only out-of-range values (`6`, `-1`) are rejected. `Unspecified` then flows through `MetadataManager::list_worker_node` → `worker_type.map(Into::into)` → `From<PbWorkerType> for risingwave_meta_model::WorkerType`, which is

```rust
PbWorkerType::Unspecified => unreachable!("unspecified worker type"),
```

so the meta process exits with SIGTRAP (133) and the pod goes into CrashLoopBackOff until it restarts. Reproduced on a 3.0.x deployment with a single `curl localhost:5691/api/clusters/0`; the code path is unchanged on `main`.

This PR rejects `Unspecified` at the HTTP boundary, so the request gets the same `{"error": "invalid worker type: 0"}` response that other bad values already get. The model conversion is left as-is: `Unspecified` is not a storable worker type, so the invariant there is correct — the bug was that the dashboard did not enforce it at the ingress. For comparison, the gRPC ingress (`AddWorkerNodeRequest::get_worker_type()`) already returns `PbFieldNotFound` for `0`, so this was the only external path into the `unreachable!`.

No behavior change for valid types; the dashboard UI only calls `/clusters/1`, `/2` and `/4`.

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] I have added necessary unit tests and integration tests.
- [ ] I have added test labels as necessary.
- [ ] I have added fuzzing tests or opened an issue to track them.
- [ ] My PR contains breaking changes.
- [ ] My PR changes performance-critical code, so I will run (micro) benchmarks and present the results.
- [x] I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. — all supported branches carry this code path; a single GET restarting meta is worth backporting.

## Documentation

- [ ] My PR needs documentation updates.

<details>
<summary><b>Release note</b></summary>

Fixed a meta node panic when the dashboard API `/api/clusters/{ty}` was called with worker type `0` (`UNSPECIFIED`). The request now returns an error response instead of restarting the meta node.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation when listing clusters by rejecting unspecified worker types.
  * Error messages now report the invalid worker-type value provided.
  * Unknown worker types continue to be rejected before worker-node lookup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->