### PR TITLE
fix(udf): avoid panic on zero-row UDAF finish output

### DIFF
--- a/src/expr/core/src/aggregate/user_defined.rs
+++ b/src/expr/core/src/aggregate/user_defined.rs
@@ -16,7 +16,7 @@ use std::sync::Arc;
 
 use anyhow::Context;
 use risingwave_common::array::Op;
-use risingwave_common::array::arrow::arrow_array_udf::ArrayRef;
+use risingwave_common::array::arrow::arrow_array_udf::{Array as _, ArrayRef};
 use risingwave_common::array::arrow::arrow_schema_udf::{Field, Fields, Schema, SchemaRef};
 use risingwave_common::array::arrow::{UdfArrowConvert, UdfFromArrow, UdfToArrow};
 use risingwave_common::bitmap::Bitmap;
@@ -85,6 +85,7 @@ impl AggregateFunction for UserDefinedAggregateFunction {
     async fn get_result(&self, state: &AggregateState) -> Result<Datum> {
         let state = &state.downcast_ref::<State>().0;
         let arrow_output = self.runtime.call_agg_finish(state).await?;
+        ensure_single_row(&arrow_output, "output")?;
         let output = UdfArrowConvert::default().from_array(&self.return_field, &arrow_output)?;
         // The UDF runtime is external input: a server may drift from the signature it was
         // checked against at creation time. Surface a mistyped result instead of letting it
@@ -97,20 +98,13 @@ impl AggregateFunction for UserDefinedAggregateFunction {
             )
             .into());
         }
-        // The runtime is external input and may return the wrong number of rows. Guard the
-        // cardinality the way the scalar UDF path does (`expr_udf.rs`), so a zero-row
-        // finish surfaces as an error instead of panicking inside `datum_at`.
-        if output.len() != 1 {
-            return Err(
-                anyhow::anyhow!("UDF returned {} rows, but expected 1", output.len()).into(),
-            );
-        }
         Ok(output.datum_at(0))
     }
 
     /// Encode the state into a datum that can be stored in state table.
     fn encode_state(&self, state: &AggregateState) -> Result<Datum> {
         let state = &state.downcast_ref::<State>().0;
+        ensure_single_row(state, "state")?;
         let state = UdfArrowConvert::default().from_array(&self.state_field, state)?;
         Ok(state.datum_at(0))
     }
@@ -125,6 +119,19 @@ impl AggregateFunction for UserDefinedAggregateFunction {
         let state = UdfArrowConvert::default().to_array(self.state_field.data_type(), &array)?;
         Ok(AggregateState::Any(Box::new(State(state))))
     }
+}
+
+/// The runtime is external input: reject an array of the wrong length so that `datum_at(0)` at
+/// the call sites is in bounds.
+fn ensure_single_row(array: &ArrayRef, what: &str) -> Result<()> {
+    if array.len() != 1 {
+        return Err(anyhow::anyhow!(
+            "UDF aggregate {what} has {} rows, but expected exactly 1",
+            array.len()
+        )
+        .into());
+    }
+    Ok(())
 }
 
 // In arrow-udf, aggregate state is represented as an `ArrayRef`.
@@ -200,7 +207,8 @@ mod tests {
     use anyhow::Result;
     use futures::stream::BoxStream;
     use risingwave_common::array::arrow::arrow_array_udf::{
-        Float64Array, Int32Array, Int64Array, MapArray, RecordBatch, StringArray, StructArray,
+        BinaryArray, Float64Array, Int32Array, Int64Array, MapArray, RecordBatch, StringArray,
+        StructArray,
     };
     use risingwave_common::array::arrow::arrow_buffer_udf::OffsetBuffer;
     use risingwave_common::array::arrow::arrow_schema_udf::DataType as ArrowDataType;
@@ -209,12 +217,12 @@ mod tests {
     use super::*;
     use crate::sig::UdfImpl;
 
-    /// Returns the given array from `finish`, regardless of the declared return type.
+    /// Returns the given array from `finish`, regardless of the declared signature.
     #[derive(Debug)]
-    struct MistypedRuntime(ArrayRef);
+    struct StubRuntime(ArrayRef);
 
     #[async_trait::async_trait]
-    impl UdfImpl for MistypedRuntime {
+    impl UdfImpl for StubRuntime {
         async fn call(&self, _input: &RecordBatch) -> Result<RecordBatch> {
             unimplemented!()
         }
@@ -231,20 +239,36 @@ mod tests {
         }
     }
 
-    /// Drives `get_result` with a runtime that returns `output` and yields the error message.
-    async fn get_result_err(return_type: DataType, output: ArrayRef) -> String {
+    fn build_agg(return_type: DataType, finish_output: ArrayRef) -> UserDefinedAggregateFunction {
         let convert = UdfArrowConvert::default();
-        let agg = UserDefinedAggregateFunction {
+        UserDefinedAggregateFunction {
             return_field: convert.to_arrow_field("", &return_type).unwrap(),
             state_field: Field::new("state", ArrowDataType::Binary, true),
             return_type,
             arg_schema: Arc::new(Schema::new(Vec::<Field>::new())),
-            runtime: Box::new(MistypedRuntime(output)),
-        };
+            runtime: Box::new(StubRuntime(finish_output)),
+        }
+    }
+
+    /// Drives `get_result` with a runtime that returns `output` and yields the error message.
+    async fn get_result_err(return_type: DataType, output: ArrayRef) -> String {
+        let agg = build_agg(return_type, output);
         let state = AggregateState::Any(Box::new(State(
             Arc::new(Int64Array::from(vec![0i64])) as ArrayRef
         )));
         let err = agg.get_result(&state).await.unwrap_err();
+        format!("{:?}", anyhow::anyhow!(err))
+    }
+
+    /// Drives `encode_state` with `state` and yields the error message.
+    fn encode_state_err(state: ArrayRef) -> String {
+        let agg = build_agg(
+            DataType::Int64,
+            Arc::new(Int64Array::from(vec![Some(1i64)])),
+        );
+        let err = agg
+            .encode_state(&AggregateState::Any(Box::new(State(state))))
+            .unwrap_err();
         format!("{:?}", anyhow::anyhow!(err))
     }
 
@@ -313,8 +337,6 @@ mod tests {
 
     #[tokio::test]
     async fn misbehaving_runtime_miscounted_finish() {
-        // A zero-row `call_agg_finish` must be a graceful error, not a panic from
-        // `datum_at(0)` (`bitmap.rs` asserts `idx < self.len()`).
         let msg = get_result_err(
             DataType::Int64,
             Arc::new(Int64Array::from(Vec::<Option<i64>>::new())),
@@ -322,13 +344,24 @@ mod tests {
         .await;
         assert!(msg.contains("0 rows"), "unexpected error: {msg}");
 
-        // More than one row is equally invalid: `datum_at(0)` would silently return
-        // the first row and discard the rest.
+        // More than one row does not panic, but `datum_at(0)` would silently drop the rest.
         let msg = get_result_err(
             DataType::Int64,
             Arc::new(Int64Array::from(vec![Some(1i64), Some(2i64)])),
         )
         .await;
+        assert!(msg.contains("2 rows"), "unexpected error: {msg}");
+    }
+
+    #[test]
+    fn misbehaving_runtime_miscounted_state() {
+        let msg = encode_state_err(Arc::new(BinaryArray::from(Vec::<Option<&[u8]>>::new())));
+        assert!(msg.contains("0 rows"), "unexpected error: {msg}");
+
+        let msg = encode_state_err(Arc::new(BinaryArray::from(vec![
+            Some(b"a".as_slice()),
+            Some(b"b".as_slice()),
+        ])));
         assert!(msg.contains("2 rows"), "unexpected error: {msg}");
     }
 }

--- a/src/expr/core/src/aggregate/user_defined.rs
+++ b/src/expr/core/src/aggregate/user_defined.rs
@@ -97,6 +97,14 @@ impl AggregateFunction for UserDefinedAggregateFunction {
             )
             .into());
         }
+        // The runtime is external input and may return the wrong number of rows. Guard the
+        // cardinality the way the scalar UDF path does (`expr_udf.rs`), so a zero-row
+        // finish surfaces as an error instead of panicking inside `datum_at`.
+        if output.len() != 1 {
+            return Err(
+                anyhow::anyhow!("UDF returned {} rows, but expected 1", output.len()).into(),
+            );
+        }
         Ok(output.datum_at(0))
     }
 
@@ -301,5 +309,26 @@ mod tests {
             msg.contains("invalid map key type"),
             "unexpected error: {msg}"
         );
+    }
+
+    #[tokio::test]
+    async fn misbehaving_runtime_miscounted_finish() {
+        // A zero-row `call_agg_finish` must be a graceful error, not a panic from
+        // `datum_at(0)` (`bitmap.rs` asserts `idx < self.len()`).
+        let msg = get_result_err(
+            DataType::Int64,
+            Arc::new(Int64Array::from(Vec::<Option<i64>>::new())),
+        )
+        .await;
+        assert!(msg.contains("0 rows"), "unexpected error: {msg}");
+
+        // More than one row is equally invalid: `datum_at(0)` would silently return
+        // the first row and discard the rest.
+        let msg = get_result_err(
+            DataType::Int64,
+            Arc::new(Int64Array::from(vec![Some(1i64), Some(2i64)])),
+        )
+        .await;
+        assert!(msg.contains("2 rows"), "unexpected error: {msg}");
     }
 }


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

`UserDefinedAggregateFunction::get_result` validates the type of the value returned by `call_agg_finish` but never its row count, then indexes the result unconditionally with `output.datum_at(0)`. For an output whose length is not one, that index is out of bounds and `ArrayImpl::datum_at` panics inside `Bitmap::is_set` instead of returning an error:

```
src/common/src/bitmap.rs:382:9: assertion failed: idx < self.len()
```

Since `get_result` runs in the aggregation operator, the failure mode is an actor panic rather than a query error.

The scalar UDF path already treats a wrong-row-count runtime result as an error, bailing in `expr_udf.rs` when `arrow_output.num_rows() != input.cardinality()`. Only the aggregate path is unguarded.

Fix: reject an output whose length is not one before indexing. This aligns the aggregate path with the scalar path and leaves the following `datum_at(0)` provably in bounds. Checking `!= 1` rather than `== 0` also covers a multi-row output, which does not panic today but silently returns the first row and discards the rest.

### Reachability

I could not construct a SQL-level reproduction, and I believe this is currently unreachable through the supported runtimes. Recording the analysis so a reviewer does not have to redo it:

- Only the embedded Python and QuickJS runtimes implement `call_agg_finish`. `external.rs` does not, so remote UDAFs fall through to the trait default and bail with "aggregate function is not supported".
- In both embedded runtimes, `create_state` and `accumulate_or_retract` build the state with `build_array(..., &[state])`, so the state array is always exactly one element.
- Both `finish` implementations produce one output per state row, and return `states.clone()` when the aggregate declares no `finish`. Output length therefore tracks state length, which is always one.

So this is defensive hardening rather than a fix for an observed failure. It seemed worth guarding anyway: `get_result` is the only place that can enforce the "exactly one row" contract it already depends on, the output length is entirely determined by state length that it never checks, and the cost is one comparison on a path that runs once per aggregate result.

Because no supported runtime can produce the offending input, the regression test drives `get_result` through a stub runtime. `misbehaving_runtime_miscounted_finish` covers both halves of the contract: the zero-row case reproduces the exact panic (`bitmap.rs:382:9`) without the fix, and the two-row case asserts the error reports `2 rows`. It reuses the `get_result_err` helper and stub runtime already used by `misbehaving_runtime_mistyped_finish`.

### Folded in: `encode_state` (`d39a33e5e`, maintainer edit)

`encode_state` has the same unguarded `state.datum_at(0)` on a runtime-produced array, with the same failure mode and the same reachability argument. It was originally left out of this PR; folded in instead of deferred, since it is the same invariant:

- The check is now a shared `ensure_single_row` helper used by both call sites.
- It runs on the raw arrow array before `from_array`, matching the ordering of the scalar UDF path.
- Test stub renamed to `StubRuntime` (it no longer serves only the mistyped case); added `misbehaving_runtime_miscounted_state`.

Closes #26376

## Tests

On `d39a33e5e`:

- `./risedev check` — pass
- `./risedev test misbehaving_runtime` — 3 passed (mistyped finish, miscounted finish, miscounted state)

`./risedev check` runs clippy without `--all-targets`, so the test module is linted only by CI.

## Checklist

- [x] I have written necessary rustdoc comments. <!-- no public items added or changed, so no rustdoc was needed -->
- [x] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/dev/src/ci.md#ci-labels-guide -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->

## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

No user-facing changes. Hardening only: the supported UDAF runtimes cannot currently produce the offending output.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * UDF aggregate operations now report an error when finish output or encoded aggregate state contains anything other than exactly one row.
  * Added validation for zero-row and multi-row results to prevent invalid aggregate conversions.
  * Added regression coverage for invalid finish and state row counts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
