### PR TITLE
fix(frontend): check source privilege for CDC tables

### DIFF
--- a/src/frontend/src/handler/create_table.rs
+++ b/src/frontend/src/handler/create_table.rs
@@ -26,6 +26,7 @@ use itertools::Itertools;
 use percent_encoding::percent_decode_str;
 use pgwire::pg_response::{PgResponse, StatementType};
 use prost::Message as _;
+use risingwave_common::acl::AclMode;
 use risingwave_common::catalog::{
     CdcTableDesc, ColumnCatalog, ColumnDesc, ConflictBehavior, DEFAULT_SCHEMA_NAME, Engine,
     ICEBERG_SINK_PREFIX, ICEBERG_SOURCE_PREFIX, RISINGWAVE_ICEBERG_ROW_ID, ROW_ID_COLUMN_NAME,
@@ -81,6 +82,7 @@ use crate::handler::create_source::{
     UPSTREAM_SOURCE_KEY, bind_connector_props, bind_create_source_or_table_with_connector,
     bind_source_watermark, handle_addition_columns, reject_variant_columns,
 };
+use crate::handler::privilege::ObjectCheckItem;
 use crate::handler::util::{
     LongRunningNotificationAction, SourceSchemaCompatExt, execute_with_long_running_notification,
 };
@@ -1421,6 +1423,7 @@ pub(super) async fn handle_create_table_plan(
                 )?;
                 source.clone()
             };
+            check_cdc_source_select_privilege(session, &source)?;
             let (cdc_with_options, normalized_external_table_name) =
                 derive_with_options_for_cdc_table(
                     &source.with_properties,
@@ -2468,8 +2471,18 @@ fn get_source_and_resolved_table_name(
         )?;
         source.clone()
     };
+    check_cdc_source_select_privilege(session, &source)?;
 
     Ok((source, resolved_table_name))
+}
+
+fn check_cdc_source_select_privilege(session: &SessionImpl, source: &SourceCatalog) -> Result<()> {
+    session.check_privileges(&[ObjectCheckItem::new(
+        source.owner,
+        AclMode::Select,
+        source.name.clone(),
+        source.id,
+    )])
 }
 
 // validate the webhook_info and also bind the webhook_info to protobuf
@@ -2599,6 +2612,80 @@ mod tests {
 
     fn pk_names() -> Vec<String> {
         vec!["plan_id".to_owned(), "site_id".to_owned()]
+    }
+
+    #[tokio::test]
+    async fn test_cdc_table_requires_select_privilege_on_source() {
+        let frontend = LocalFrontend::new(Default::default()).await;
+        frontend
+            .run_sql(
+                r#"
+                CREATE SOURCE cdc_source WITH (
+                    connector = 'mysql-cdc',
+                    hostname = 'localhost',
+                    port = '3306',
+                    username = 'root',
+                    password = '',
+                    database.name = 'db'
+                ) FORMAT PLAIN ENCODE JSON
+                "#,
+            )
+            .await
+            .unwrap();
+        frontend.run_sql("CREATE USER cdc_user").await.unwrap();
+        frontend
+            .run_sql("GRANT CREATE ON SCHEMA public TO cdc_user")
+            .await
+            .unwrap();
+
+        let user_id = frontend
+            .session_ref()
+            .env()
+            .user_info_reader()
+            .read_guard()
+            .get_user_by_name("cdc_user")
+            .unwrap()
+            .id;
+        let user_session = frontend.session_user_ref(
+            DEFAULT_DATABASE_NAME.to_owned(),
+            "cdc_user".to_owned(),
+            user_id,
+        );
+        let create_table =
+            "CREATE TABLE cdc_table (id INT PRIMARY KEY) FROM cdc_source TABLE 'db.t'";
+
+        let err = frontend
+            .run_sql_with_session(user_session.clone(), create_table)
+            .await
+            .unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("permission denied for source \"cdc_source\": \"SELECT\""),
+            "{err:?}"
+        );
+
+        frontend
+            .run_sql("GRANT SELECT ON SOURCE cdc_source TO cdc_user")
+            .await
+            .unwrap();
+        frontend
+            .run_sql_with_session(user_session.clone(), create_table)
+            .await
+            .unwrap();
+
+        frontend
+            .run_sql("REVOKE SELECT ON SOURCE cdc_source FROM cdc_user")
+            .await
+            .unwrap();
+        let err = frontend
+            .run_sql_with_session(user_session, "ALTER TABLE cdc_table ADD COLUMN value INT")
+            .await
+            .unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("permission denied for source \"cdc_source\": \"SELECT\""),
+            "{err:?}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

`CREATE TABLE ... FROM <cdc_source>` resolved the source catalog without checking whether the current user had `SELECT` privilege on that source. As a result, a user with `CREATE` privilege on the target schema could create and consume a CDC table from a source they were not allowed to read. Table replacement paths used by `ALTER TABLE` had the same gap.

This PR:

- checks `AclMode::Select` on the referenced CDC source before building a new CDC table plan;
- applies the same check when rebuilding an existing CDC table for `ALTER TABLE`;
- adds a regression test covering rejection without permission, success after `GRANT SELECT`, and rejection of `ALTER TABLE` after `REVOKE SELECT`.

## Checklist

- [x] I have written necessary rustdoc comments (no new public API).
- [x] I have added necessary unit tests and integration tests.
- [x] I have added test labels as necessary.
- [ ] I have added fuzzing tests or opened an issue to track them.
- [ ] My PR contains breaking changes.
- [ ] My PR changes performance-critical code, so I will run (micro) benchmarks and present the results.
- [ ] I have checked the Release Timeline and Currently Supported Versions to determine which release branches I need to cherry-pick this PR into.

## Documentation

- [x] My PR needs documentation updates.

<details>
<summary><b>Release note</b></summary>

Creating or altering a table from a shared CDC source now requires `SELECT` privilege on that source. Source owners and superusers are unaffected.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * CDC table creation and replacement now require `SELECT` permission on the referenced source.
  * CDC table alterations are rejected when the required `SELECT` permission has been revoked.
  * Permission checks now consistently apply when CDC sources are resolved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->