### PR TITLE
chore(iceberg): bump iceberg dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7687,7 +7687,7 @@ dependencies = [
 [[package]]
 name = "iceberg-compaction-core"
 version = "0.1.0"
-source = "git+https://github.com/nimtable/iceberg-compaction.git?rev=7baafbebe4de555533a4720cd3ffc0d30b2742dd#7baafbebe4de555533a4720cd3ffc0d30b2742dd"
+source = "git+https://github.com/nimtable/iceberg-compaction.git?rev=072233a040b02eeed1a1afd882c51214e286f0ae#072233a040b02eeed1a1afd882c51214e286f0ae"
 dependencies = [
  "async-stream",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7592,7 +7592,7 @@ dependencies = [
 [[package]]
 name = "iceberg"
 version = "0.10.0"
-source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=2768ccf8b1847a14162337d7ef7a76935881fbc8#2768ccf8b1847a14162337d7ef7a76935881fbc8"
+source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=631180827ceb8d6296644edb9c5c8c29f770da5e#631180827ceb8d6296644edb9c5c8c29f770da5e"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -7651,7 +7651,7 @@ dependencies = [
 [[package]]
 name = "iceberg-catalog-glue"
 version = "0.10.0"
-source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=2768ccf8b1847a14162337d7ef7a76935881fbc8#2768ccf8b1847a14162337d7ef7a76935881fbc8"
+source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=631180827ceb8d6296644edb9c5c8c29f770da5e#631180827ceb8d6296644edb9c5c8c29f770da5e"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7666,7 +7666,7 @@ dependencies = [
 [[package]]
 name = "iceberg-catalog-rest"
 version = "0.10.0"
-source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=2768ccf8b1847a14162337d7ef7a76935881fbc8#2768ccf8b1847a14162337d7ef7a76935881fbc8"
+source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=631180827ceb8d6296644edb9c5c8c29f770da5e#631180827ceb8d6296644edb9c5c8c29f770da5e"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -7687,7 +7687,7 @@ dependencies = [
 [[package]]
 name = "iceberg-compaction-core"
 version = "0.1.0"
-source = "git+https://github.com/nimtable/iceberg-compaction.git?rev=53410bea82ff2319196df43e7447ab2bb13da1d6#53410bea82ff2319196df43e7447ab2bb13da1d6"
+source = "git+https://github.com/nimtable/iceberg-compaction.git?rev=7baafbebe4de555533a4720cd3ffc0d30b2742dd#7baafbebe4de555533a4720cd3ffc0d30b2742dd"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -7716,7 +7716,7 @@ dependencies = [
 [[package]]
 name = "iceberg-datafusion"
 version = "0.10.0"
-source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=2768ccf8b1847a14162337d7ef7a76935881fbc8#2768ccf8b1847a14162337d7ef7a76935881fbc8"
+source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=631180827ceb8d6296644edb9c5c8c29f770da5e#631180827ceb8d6296644edb9c5c8c29f770da5e"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7732,7 +7732,7 @@ dependencies = [
 [[package]]
 name = "iceberg-storage-opendal"
 version = "0.10.0"
-source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=2768ccf8b1847a14162337d7ef7a76935881fbc8#2768ccf8b1847a14162337d7ef7a76935881fbc8"
+source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=631180827ceb8d6296644edb9c5c8c29f770da5e#631180827ceb8d6296644edb9c5c8c29f770da5e"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -176,10 +176,10 @@ hashbrown0_16 = { package = "hashbrown", version = "0.16.1", features = [
 ] }
 hytra = "0.1"
 # branch dev_rebase_main_20260807
-iceberg = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "2768ccf8b1847a14162337d7ef7a76935881fbc8" }
-iceberg-catalog-glue = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "2768ccf8b1847a14162337d7ef7a76935881fbc8" }
-iceberg-catalog-rest = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "2768ccf8b1847a14162337d7ef7a76935881fbc8" }
-iceberg-storage-opendal = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "2768ccf8b1847a14162337d7ef7a76935881fbc8", features = [
+iceberg = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "631180827ceb8d6296644edb9c5c8c29f770da5e" }
+iceberg-catalog-glue = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "631180827ceb8d6296644edb9c5c8c29f770da5e" }
+iceberg-catalog-rest = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "631180827ceb8d6296644edb9c5c8c29f770da5e" }
+iceberg-storage-opendal = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "631180827ceb8d6296644edb9c5c8c29f770da5e", features = [
     "opendal-azblob",
     "opendal-azdls",
     "opendal-fs",

--- a/src/storage/Cargo.toml
+++ b/src/storage/Cargo.toml
@@ -34,7 +34,7 @@ futures = { version = "0.3", default-features = false, features = ["alloc"] }
 futures-async-stream = { workspace = true }
 hex = "0.4"
 iceberg = { workspace = true }
-iceberg-compaction-core = { git = "https://github.com/nimtable/iceberg-compaction.git", rev = "53410bea82ff2319196df43e7447ab2bb13da1d6" }
+iceberg-compaction-core = { git = "https://github.com/nimtable/iceberg-compaction.git", rev = "7baafbebe4de555533a4720cd3ffc0d30b2742dd" }
 itertools = { workspace = true }
 libc = "0.2"
 lz4 = "1.28.0"

--- a/src/storage/Cargo.toml
+++ b/src/storage/Cargo.toml
@@ -34,7 +34,7 @@ futures = { version = "0.3", default-features = false, features = ["alloc"] }
 futures-async-stream = { workspace = true }
 hex = "0.4"
 iceberg = { workspace = true }
-iceberg-compaction-core = { git = "https://github.com/nimtable/iceberg-compaction.git", rev = "7baafbebe4de555533a4720cd3ffc0d30b2742dd" }
+iceberg-compaction-core = { git = "https://github.com/nimtable/iceberg-compaction.git", rev = "072233a040b02eeed1a1afd882c51214e286f0ae" }
 itertools = { workspace = true }
 libc = "0.2"
 lz4 = "1.28.0"


### PR DESCRIPTION
Update the Iceberg dependency stack together:

- Bump `iceberg-rust` from `2768ccf8` to `631180827`, including variant statistics/pruning fixes and stricter equality-delete validation.
- Bump `iceberg-compaction` from `53410bea` to `072233a0`, including [partition-affinity repartitioning](https://github.com/nimtable/iceberg-compaction/pull/182) and the matching iceberg-rust revision from merged [nimtable/iceberg-compaction#186](https://github.com/nimtable/iceberg-compaction/pull/186).

The revisions must stay aligned because iceberg-compaction exposes Iceberg types at its public boundary; mixing revisions creates incompatible `Table`, `DataFile`, and `FileScanTask` types. The aligned pins keep the dependency graph on a single Iceberg revision.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated pinned component revisions to incorporate the latest upstream changes.
  - Updated the storage compaction component revision for improved alignment with its upstream release.
  - No user-facing interface or capability changes are included.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->