### PR TITLE
fix(risedev): propagate check-clippy and check-typos failures

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -1226,9 +1226,11 @@ script = """
 echo "Running $(tput setaf 4)cargo clippy$(tput sgr0) checks"
 set -x
 cargo clippy $@ ${RISINGWAVE_FEATURE_FLAGS}
+STATUS=$?
 set +x
 echo "If cargo clippy check failed or generates warning, you may run $(tput setaf 4)cargo clippy --workspace --all-targets --fix$(tput sgr0) to fix it. Note that clippy fix requires manual review, as not all auto fixes are guaranteed to be reasonable."
 echo "Alternately, you may run $(tput setaf 4)./risedev cf {package_names}$(tput sgr0) to fix those packages (e.g. frontend, meta)."
+exit $STATUS
 """
 
 [tasks.check-clippy-fix]
@@ -1263,6 +1265,7 @@ script = """
 
 if ! typos ; then
   echo "Hint: use 'typos -w' to fix."
+  exit 1
 fi
 """
 


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

`./risedev check` exits 0 even when `cargo clippy` or `typos` fails, so its exit code is useless as a pass/fail signal — you have to grep the output. This bites agents and scripts hardest, since they trust `$?`. (CI is unaffected: it runs `ci/scripts/check.sh` directly, which has `set -euo pipefail`.)

Cause: cargo-make does not run scripts under `set -e`, so a task's exit code is that of its last command — and in both tasks the last command is a hint `echo`.

- `check-clippy`: two hint echoes after `cargo clippy`. Fixed by capturing `$?` and exiting with it.
- `check-typos`: `if ! typos ; then echo hint ; fi` — the `echo` inside the failure branch is what `fi` returns. Fixed by adding `exit 1`.

The clippy hints keep printing unconditionally. They are worded "failed **or generates warning**", and a warnings-only run exits 0 locally (no `-D warnings`), so they can't move into a failure-only branch. Plain `set -e` is wrong for the same reason — it would skip the hints exactly when clippy fails.

Verified on the real `./risedev` path with a bogus clippy flag:

| | exit code | hints |
| --- | --- | --- |
| before | 0 (`Build Done`) | printed |
| after | 1 (`Build Failed`) | printed |

Sibling check tasks (`check-fmt`, `check-dep-sort`, `check-machete`, `check-trailing-spaces`, `check-java`, `check-clippy-fix`) already propagate. cargo-make aborts the flow when a dependency task fails, so fixing these two leaves is enough for `./risedev check`.

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/dev/src/ci.md#ci-labels-guide -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->

## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation task results so linting and typo checks now correctly report failures through their exit statuses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->