### PR TITLE
feat(sink): support dynamic methods in HTTP sink

### DIFF
--- a/ci/scripts/e2e-sink-test.sh
+++ b/ci/scripts/e2e-sink-test.sh
@@ -70,14 +70,26 @@ grep -Fx 'before update' "$HTTP_SINK_OUTPUT"
 grep -Fx 'hello world' "$HTTP_SINK_OUTPUT"
 grep -Fx '{"key":"value"}' "$HTTP_SINK_OUTPUT"
 grep -Fx 'put payload' "$HTTP_SINK_OUTPUT"
+grep -Fx 'patch payload' "$HTTP_SINK_OUTPUT"
 grep -q '"event"' "$HTTP_SINK_OUTPUT"
 grep -Fx 'dynamic url payload' "$HTTP_SINK_OUTPUT"
 grep -Fx 'dynamic url as select payload' "$HTTP_SINK_OUTPUT"
-# Exactly 1 line from ignore_delete test + 2 from varchar test (NULL was skipped) + 1 from PUT + 1 from jsonb + 2 from dynamic URL tests
-test "$(wc -l < "$HTTP_SINK_OUTPUT")" -eq 7
-# Verify the default method remains POST and an explicitly configured PUT is honored
+grep -Fx 'dynamic patch payload' "$HTTP_SINK_OUTPUT"
+grep -Fx 'dynamic custom method payload' "$HTTP_SINK_OUTPUT"
+grep -Fx 'dynamic url and method payload' "$HTTP_SINK_OUTPUT"
+! grep -F 'skipped invalid method payload' "$HTTP_SINK_OUTPUT"
+! grep -F 'skipped empty method payload' "$HTTP_SINK_OUTPUT"
+! grep -F 'skipped null method payload' "$HTTP_SINK_OUTPUT"
+# Exactly 7 existing requests + static PATCH and DELETE + 3 valid dynamic-method requests + 1 combined dynamic URL/method request.
+test "$(wc -l < "$HTTP_SINK_OUTPUT")" -eq 13
+# Verify static, dynamic, case-insensitive standard, and extension methods.
 test "$(grep -c '^POST$' "$HTTP_SINK_METHODS")" -eq 6
-test "$(grep -c '^PUT$' "$HTTP_SINK_METHODS")" -eq 1
+test "$(grep -c '^PUT$' "$HTTP_SINK_METHODS")" -eq 2
+test "$(grep -c '^PATCH$' "$HTTP_SINK_METHODS")" -eq 2
+test "$(grep -c '^DELETE$' "$HTTP_SINK_METHODS")" -eq 2
+test "$(grep -c '^PROPFIND$' "$HTTP_SINK_METHODS")" -eq 1
+# The static and dynamic DELETE requests have no body.
+test "$(paste "$HTTP_SINK_METHODS" "$HTTP_SINK_OUTPUT" | grep -c $'^DELETE\t$')" -eq 2
 # Verify the custom header set via header.x_test = 'rw-http-sink' was sent
 grep -q '"x_test": "rw-http-sink"' "$HTTP_SINK_HEADERS"
 # Verify inferred default content types for varchar and jsonb payloads

--- a/e2e_test/sink/http_sink.slt
+++ b/e2e_test/sink/http_sink.slt
@@ -1,13 +1,13 @@
 statement ok
 set sink_decouple = false;
 
-# ---- Validation: multiple columns must use payload/url shape ----
+# ---- Validation: multiple columns must use payload/url/method shape ----
 # force_append_only bypasses the planner-level retract-stream check so our
 # connector validate() is actually reached.
 statement ok
 CREATE TABLE t_multi_col (a varchar, b varchar);
 
-statement error HTTP sink with multiple columns only supports payload and url columns, got a
+statement error HTTP sink with multiple columns only supports payload, url, and method columns, got a
 CREATE SINK s_multi_col FROM t_multi_col WITH (
     connector = 'http',
     url = 'http://localhost:18081',
@@ -51,7 +51,7 @@ DROP TABLE t_dynamic_url_with_static_option;
 statement ok
 CREATE TABLE t_dynamic_url_missing_url (payload varchar, extra varchar);
 
-statement error HTTP sink with multiple columns only supports payload and url columns, got extra
+statement error HTTP sink with multiple columns only supports payload, url, and method columns, got extra
 CREATE SINK s_dynamic_url_missing_url FROM t_dynamic_url_missing_url WITH (
     connector = 'http',
     type = 'append-only',
@@ -75,11 +75,42 @@ CREATE SINK s_dynamic_url_bad_type FROM t_dynamic_url_bad_type WITH (
 statement ok
 DROP TABLE t_dynamic_url_bad_type;
 
+# ---- Validation: dynamic method column cannot coexist with method option ----
+statement ok
+CREATE TABLE t_dynamic_method_with_static_option (payload varchar, method varchar);
+
+statement error HTTP sink method option cannot coexist with method column
+CREATE SINK s_dynamic_method_with_static_option FROM t_dynamic_method_with_static_option WITH (
+    connector = 'http',
+    url = 'http://localhost:18081',
+    method = 'PATCH',
+    type = 'append-only',
+    force_append_only = 'true'
+);
+
+statement ok
+DROP TABLE t_dynamic_method_with_static_option;
+
+# ---- Validation: dynamic method column must be varchar ----
+statement ok
+CREATE TABLE t_dynamic_method_bad_type (payload varchar, method int);
+
+statement error HTTP sink method column must be varchar
+CREATE SINK s_dynamic_method_bad_type FROM t_dynamic_method_bad_type WITH (
+    connector = 'http',
+    url = 'http://localhost:18081',
+    type = 'append-only',
+    force_append_only = 'true'
+);
+
+statement ok
+DROP TABLE t_dynamic_method_bad_type;
+
 # ---- Validation: extra columns are rejected ----
 statement ok
 CREATE TABLE t_dynamic_url_extra_column (payload varchar, url varchar, extra varchar);
 
-statement error HTTP sink with multiple columns only supports payload and url columns, got extra
+statement error HTTP sink with multiple columns only supports payload, url, and method columns, got extra
 CREATE SINK s_dynamic_url_extra_column FROM t_dynamic_url_extra_column WITH (
     connector = 'http',
     type = 'append-only',
@@ -119,21 +150,21 @@ CREATE SINK s_bad_url FROM t_url WITH (
 statement ok
 DROP TABLE t_url;
 
-# ---- Validation: unsupported HTTP method should be rejected ----
+# ---- Validation: syntactically invalid static HTTP method should be rejected ----
 statement ok
-CREATE TABLE t_unsupported_method (payload varchar);
+CREATE TABLE t_invalid_method (payload varchar);
 
-statement error HTTP sink method must be POST or PUT, got 'DELETE'
-CREATE SINK s_unsupported_method FROM t_unsupported_method WITH (
+statement error invalid HTTP sink method 'invalid method'
+CREATE SINK s_invalid_method FROM t_invalid_method WITH (
     connector = 'http',
     url = 'http://localhost:18081',
-    method = 'DELETE',
+    method = 'invalid method',
     type = 'append-only',
     force_append_only = 'true'
 );
 
 statement ok
-DROP TABLE t_unsupported_method;
+DROP TABLE t_invalid_method;
 
 # ---- Validation: auto schema change should be rejected ----
 statement ok
@@ -242,6 +273,56 @@ DROP SINK s_put;
 statement ok
 DROP TABLE t_put;
 
+# ---- Success: static PATCH method ----
+statement ok
+CREATE TABLE t_patch (payload varchar);
+
+statement ok
+CREATE SINK s_patch FROM t_patch WITH (
+    connector = 'http',
+    url = 'http://localhost:18081',
+    method = 'PATCH',
+    type = 'append-only',
+    force_append_only = 'true'
+);
+
+statement ok
+INSERT INTO t_patch VALUES ('patch payload');
+
+statement ok
+FLUSH;
+
+statement ok
+DROP SINK s_patch;
+
+statement ok
+DROP TABLE t_patch;
+
+# ---- Success: static DELETE with a NULL payload sends a bodyless request ----
+statement ok
+CREATE TABLE t_delete (payload varchar);
+
+statement ok
+CREATE SINK s_delete FROM t_delete WITH (
+    connector = 'http',
+    url = 'http://localhost:18081',
+    method = 'DELETE',
+    type = 'append-only',
+    force_append_only = 'true'
+);
+
+statement ok
+INSERT INTO t_delete VALUES (NULL);
+
+statement ok
+FLUSH;
+
+statement ok
+DROP SINK s_delete;
+
+statement ok
+DROP TABLE t_delete;
+
 # ---- Success: jsonb payload ----
 statement ok
 CREATE TABLE t_jsonb (payload jsonb);
@@ -314,3 +395,69 @@ DROP SINK s_dynamic_url_as_select;
 
 statement ok
 DROP TABLE t_dynamic_url_as_select_src;
+
+# ---- Success: dynamic method column ----
+statement ok
+CREATE TABLE t_dynamic_method (payload varchar, method varchar);
+
+statement ok
+CREATE SINK s_dynamic_method FROM t_dynamic_method WITH (
+    connector = 'http',
+    url = 'http://localhost:18081',
+    type = 'append-only',
+    force_append_only = 'true'
+);
+
+statement ok
+INSERT INTO t_dynamic_method VALUES ('dynamic patch payload', 'patch');
+
+statement ok
+INSERT INTO t_dynamic_method VALUES ('dynamic custom method payload', 'PROPFIND');
+
+statement ok
+INSERT INTO t_dynamic_method VALUES (NULL, 'delete');
+
+statement ok
+INSERT INTO t_dynamic_method VALUES ('skipped invalid method payload', 'invalid method');
+
+statement ok
+INSERT INTO t_dynamic_method VALUES ('skipped empty method payload', '');
+
+statement ok
+INSERT INTO t_dynamic_method VALUES ('skipped null method payload', NULL);
+
+statement ok
+FLUSH;
+
+statement ok
+DROP SINK s_dynamic_method;
+
+statement ok
+DROP TABLE t_dynamic_method;
+
+# ---- Success: dynamic url and method columns ----
+statement ok
+CREATE TABLE t_dynamic_url_method (payload varchar, url varchar, method varchar);
+
+statement ok
+CREATE SINK s_dynamic_url_method FROM t_dynamic_url_method WITH (
+    connector = 'http',
+    type = 'append-only',
+    force_append_only = 'true'
+);
+
+statement ok
+INSERT INTO t_dynamic_url_method VALUES (
+    'dynamic url and method payload',
+    'http://localhost:18081',
+    'PUT'
+);
+
+statement ok
+FLUSH;
+
+statement ok
+DROP SINK s_dynamic_url_method;
+
+statement ok
+DROP TABLE t_dynamic_url_method;

--- a/e2e_test/sink/http_sink_mock_server.py
+++ b/e2e_test/sink/http_sink_mock_server.py
@@ -19,11 +19,11 @@ Mock HTTP server for testing the RisingWave HTTP sink.
 Usage:
     python3 http_sink_mock_server.py <body_output_file> <port> [<header_output_file>] [<path_output_file>] [<method_output_file>]
 
-Each POST or PUT request body is appended as a line to the body output file.
+Each handled request body is appended as a line to the body output file.
 If a header output file is given, received headers are appended as a JSON line per request.
 If a path output file is given, each request path is appended as a line per request.
 If a method output file is given, each request method is appended as a line per request.
-Responds 200 OK to every POST and PUT request.
+Responds 200 OK to every handled request.
 """
 
 import json
@@ -62,6 +62,15 @@ def main():
             self._handle_request()
 
         def do_PUT(self):
+            self._handle_request()
+
+        def do_PATCH(self):
+            self._handle_request()
+
+        def do_DELETE(self):
+            self._handle_request()
+
+        def do_PROPFIND(self):
             self._handle_request()
 
         def do_GET(self):

--- a/src/connector/src/sink/http.rs
+++ b/src/connector/src/sink/http.rs
@@ -34,13 +34,15 @@ use crate::sink::{Result, SINK_TYPE_APPEND_ONLY, Sink, SinkError, SinkParam, Sin
 pub const HTTP_SINK: &str = "http";
 const HTTP_SINK_PAYLOAD_COLUMN: &str = "payload";
 const HTTP_SINK_URL_COLUMN: &str = "url";
+const HTTP_SINK_METHOD_COLUMN: &str = "method";
 
 #[derive(Clone, Debug, Deserialize, WithOptions)]
 pub struct HttpConfig {
     /// The endpoint URL to send data to.
     pub url: Option<String>,
 
-    /// HTTP request method. Supported values are `POST` and `PUT`. Defaults to `POST`.
+    /// Static HTTP request method. Any syntactically valid method is accepted. Defaults to `POST`.
+    /// Cannot be used together with a dynamic `method` column.
     pub method: Option<String>,
 
     /// Content-Type header value. Defaults to `text/plain` for `varchar` and `application/json`
@@ -92,6 +94,44 @@ enum HttpUrl {
     Dynamic { url_index: usize },
 }
 
+#[derive(Clone, Debug)]
+enum HttpMethod {
+    Static(reqwest::Method),
+    Dynamic { method_index: usize },
+}
+
+fn parse_http_method(method: &str) -> anyhow::Result<reqwest::Method> {
+    // Preserve the existing case-insensitive behavior for standard methods. Extension methods are
+    // case-sensitive and should be sent exactly as supplied.
+    for standard_method in [
+        reqwest::Method::GET,
+        reqwest::Method::HEAD,
+        reqwest::Method::POST,
+        reqwest::Method::PUT,
+        reqwest::Method::DELETE,
+        reqwest::Method::CONNECT,
+        reqwest::Method::OPTIONS,
+        reqwest::Method::TRACE,
+        reqwest::Method::PATCH,
+    ] {
+        if method.eq_ignore_ascii_case(standard_method.as_str()) {
+            return Ok(standard_method);
+        }
+    }
+
+    method.parse().context("invalid HTTP method")
+}
+
+fn parse_static_http_method(method: Option<&str>) -> Result<HttpMethod> {
+    let method = match method {
+        Some(method) => parse_http_method(method)
+            .with_context(|| format!("invalid HTTP sink method '{method}'"))
+            .map_err(SinkError::Config)?,
+        None => reqwest::Method::POST,
+    };
+    Ok(HttpMethod::Static(method))
+}
+
 /// Validates the HTTP sink parameters and returns the sink so callers can use it directly without
 /// re-parsing.
 fn validate_http_sink(
@@ -110,19 +150,8 @@ fn validate_http_sink(
         )));
     }
 
-    let method = match method {
-        None => reqwest::Method::POST,
-        Some(method) if method.eq_ignore_ascii_case("POST") => reqwest::Method::POST,
-        Some(method) if method.eq_ignore_ascii_case("PUT") => reqwest::Method::PUT,
-        Some(method) => {
-            return Err(SinkError::Config(anyhow!(
-                "HTTP sink method must be POST or PUT, got '{method}'"
-            )));
-        }
-    };
-
     let fields = schema.fields();
-    let (payload_index, url, payload_type) = if fields.len() == 1 {
+    let (payload_index, url, method, payload_type) = if fields.len() == 1 {
         let Some(url) = url else {
             return Err(SinkError::Config(anyhow!(
                 "HTTP sink requires url option when schema has exactly 1 column"
@@ -132,14 +161,15 @@ fn validate_http_sink(
             .parse()
             .context("invalid URL")
             .map_err(SinkError::Config)?;
-        (0, HttpUrl::Static(url), fields[0].data_type.clone())
+        let method = parse_static_http_method(method)?;
+        (0, HttpUrl::Static(url), method, fields[0].data_type.clone())
     } else {
         for field in fields {
             match field.name.as_str() {
-                HTTP_SINK_PAYLOAD_COLUMN | HTTP_SINK_URL_COLUMN => {}
+                HTTP_SINK_PAYLOAD_COLUMN | HTTP_SINK_URL_COLUMN | HTTP_SINK_METHOD_COLUMN => {}
                 _ => {
                     return Err(SinkError::Config(anyhow!(
-                        "HTTP sink with multiple columns only supports payload and url columns, got {}",
+                        "HTTP sink with multiple columns only supports payload, url, and method columns, got {}",
                         field.name
                     )));
                 }
@@ -186,7 +216,34 @@ fn validate_http_sink(
             }
         };
 
-        (payload_index, url, fields[payload_index].data_type.clone())
+        let method_index = fields
+            .iter()
+            .position(|field| field.name == HTTP_SINK_METHOD_COLUMN);
+        let method = match (method, method_index) {
+            (Some(_), Some(_)) => {
+                return Err(SinkError::Config(anyhow!(
+                    "HTTP sink method option cannot coexist with method column"
+                )));
+            }
+            (Some(method), None) => parse_static_http_method(Some(method))?,
+            (None, Some(method_index)) => {
+                if fields[method_index].data_type != DataType::Varchar {
+                    return Err(SinkError::Config(anyhow!(
+                        "HTTP sink method column must be varchar, got {:?}",
+                        fields[method_index].data_type
+                    )));
+                }
+                HttpMethod::Dynamic { method_index }
+            }
+            (None, None) => parse_static_http_method(None)?,
+        };
+
+        (
+            payload_index,
+            url,
+            method,
+            fields[payload_index].data_type.clone(),
+        )
     };
 
     if payload_type != DataType::Varchar && payload_type != DataType::Jsonb {
@@ -233,7 +290,7 @@ fn validate_http_sink(
 #[derive(Clone, Debug)]
 pub struct HttpSink {
     url: HttpUrl,
-    method: reqwest::Method,
+    method: HttpMethod,
     payload_index: usize,
     header_map: HeaderMap,
     unknown_fields: std::collections::HashMap<String, String>,
@@ -296,14 +353,14 @@ impl Sink for HttpSink {
 pub struct HttpSinkWriter {
     client: reqwest::Client,
     url: HttpUrl,
-    method: reqwest::Method,
+    method: HttpMethod,
     payload_index: usize,
 }
 
 impl HttpSinkWriter {
     fn new(
         url: HttpUrl,
-        method: reqwest::Method,
+        method: HttpMethod,
         payload_index: usize,
         header_map: HeaderMap,
     ) -> Result<Self> {
@@ -352,6 +409,35 @@ impl HttpSinkWriter {
         }
     }
 
+    fn extract_method(&self, row: &impl Row) -> Result<Option<reqwest::Method>> {
+        match &self.method {
+            HttpMethod::Static(method) => Ok(Some(method.clone())),
+            HttpMethod::Dynamic { method_index } => match row.datum_at(*method_index) {
+                Some(ScalarRefImpl::Utf8(method)) => match parse_http_method(method) {
+                    Ok(method) => Ok(Some(method)),
+                    Err(err) => {
+                        tracing::warn!(
+                            error = %err.as_report(),
+                            payload = %self.strip_payload_for_log(row),
+                            "skip HTTP sink row due to invalid HTTP method in method column"
+                        );
+                        Ok(None)
+                    }
+                },
+                None => {
+                    tracing::warn!(
+                        payload = %self.strip_payload_for_log(row),
+                        "skip HTTP sink row due to null method column"
+                    );
+                    Ok(None)
+                }
+                Some(_) => Err(SinkError::Http(anyhow!(
+                    "unexpected method column type, expected varchar"
+                ))),
+            },
+        }
+    }
+
     fn strip_payload_for_log(&self, row: &impl Row) -> String {
         match row.datum_at(self.payload_index) {
             Some(ScalarRefImpl::Utf8(s)) => strip_text_payload(s),
@@ -370,7 +456,7 @@ impl HttpSinkWriter {
                     "unexpected payload column type, expected varchar or jsonb"
                 )));
             }
-            None => None, // skip NULL rows
+            None => None,
         })
     }
 }
@@ -447,17 +533,23 @@ impl AsyncTruncateSinkWriter for HttpSinkWriter {
                 continue;
             }
 
-            let Some(payload) = self.extract_payload(&row)? else {
+            let Some(method) = self.extract_method(&row)? else {
                 continue;
             };
+            let payload = self.extract_payload(&row)?;
+            if payload.is_none() && method != reqwest::Method::DELETE {
+                continue;
+            }
             let Some(url) = self.extract_url(&row)? else {
                 continue;
             };
 
-            let resp = self
-                .client
-                .request(self.method.clone(), url)
-                .body(payload)
+            let mut request = self.client.request(method, url);
+            if let Some(payload) = payload {
+                request = request.body(payload);
+            }
+
+            let resp = request
                 .send()
                 .await
                 .context("HTTP request failed")
@@ -483,6 +575,17 @@ mod tests {
     use risingwave_common::types::{JsonbVal, Scalar};
 
     use super::*;
+
+    #[test]
+    fn test_parse_http_method() {
+        assert_eq!(parse_http_method("patch").unwrap(), reqwest::Method::PATCH);
+        assert_eq!(
+            parse_http_method("DeLeTe").unwrap(),
+            reqwest::Method::DELETE
+        );
+        assert_eq!(parse_http_method("PROPFIND").unwrap().as_str(), "PROPFIND");
+        assert!(parse_http_method("invalid method").is_err());
+    }
 
     #[test]
     fn test_strip_text_payload() {

--- a/src/connector/with_options_sink.yaml
+++ b/src/connector/with_options_sink.yaml
@@ -459,7 +459,9 @@ HttpConfig:
     required: false
   - name: method
     field_type: String
-    comments: HTTP request method. Supported values are `POST` and `PUT`. Defaults to `POST`.
+    comments: |-
+      Static HTTP request method. Any syntactically valid method is accepted. Defaults to `POST`.
+      Cannot be used together with a dynamic `method` column.
     required: false
   - name: content_type
     field_type: String


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

- Allow the native HTTP sink to select the request method from a dynamic `method varchar` column, similar to the existing dynamic `url` column.
- Accept any syntactically valid static or dynamic HTTP method. Standard methods are case-insensitive, while extension methods preserve their supplied spelling.
- Reject static/dynamic method conflicts and non-varchar dynamic method columns during `CREATE SINK` validation.
- Warn and skip rows whose dynamic method is NULL or invalid, including empty strings parsed through the invalid-method path.
- Send bodyless DELETE requests for NULL payloads while preserving NULL-row skipping for other methods.
- Extend HTTP sink SLT, mock-server, and CI assertions for PATCH, DELETE, PROPFIND, combined dynamic URL/method routing, skipped invalid values, and absent DELETE bodies.
- Follow-up to #26822.

Local verification:

- `cargo test -p risingwave_connector sink::http`
- `cargo clippy --all-targets --all-features`
- `./risedev generate-with-options`
- `python3 -m py_compile e2e_test/sink/http_sink_mock_server.py`
- `bash -n ci/scripts/e2e-sink-test.sh`
- `./risedev slt './e2e_test/sink/http_sink.slt'` with the HTTP mock server and CI assertions
- `git diff --check`

## Checklist

- [x] I have written necessary rustdoc comments.
- [x] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [x] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/dev/src/ci.md#ci-labels-guide -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->

## Documentation

- [x] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

The native HTTP sink now accepts any valid HTTP request method and can read the method from a per-row `method varchar` column. This enables endpoints requiring methods such as PATCH, DELETE, or extension methods. A DELETE row with a NULL payload sends a request without a body; invalid dynamic methods are skipped with a warning. Existing sinks that omit `method` continue to use POST.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - HTTP sinks now support configurable static or per-row dynamic HTTP methods.
  - Standard methods are accepted case-insensitively, while valid extension methods retain their casing.
  - Supported request flows now include PATCH, DELETE, and other custom methods.
  - DELETE requests can be sent without a body when the payload is null.
  - Dynamic method columns can be used alongside dynamic URL columns.

- **Documentation**
  - Updated HTTP sink configuration guidance to document valid methods, the default POST method, and method-column restrictions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->