### PR TITLE
feat(dashboard): support CPU profile dumps

### DIFF
--- a/dashboard/components/Layout.tsx
+++ b/dashboard/components/Layout.tsx
@@ -124,6 +124,11 @@ const navSections: NavSectionData[] = [
     items: [
       { href: "/await_tree/", title: "Await tree dump", icon: IconHourglass },
       {
+        href: "/cpu_profiling/",
+        title: "CPU profiling",
+        icon: IconActivity,
+      },
+      {
         href: "/heap_profiling/",
         title: "Heap profiling",
         icon: IconMemoryStick,

--- a/dashboard/pages/cpu_profiling.tsx
+++ b/dashboard/pages/cpu_profiling.tsx
@@ -1,0 +1,250 @@
+/*
+ * Copyright 2026 RisingWave Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  Box,
+  Button,
+  Flex,
+  FormControl,
+  FormLabel,
+  NumberInput,
+  NumberInputField,
+  Select,
+  VStack,
+} from "@chakra-ui/react"
+import Editor from "@monaco-editor/react"
+import { saveAs } from "file-saver"
+import Head from "next/head"
+import { Fragment, useEffect, useState } from "react"
+import Title from "../components/Title"
+import api from "../lib/api/api"
+import { getClusterInfoProfileWorkers } from "../lib/api/cluster"
+import useFetch from "../lib/api/fetch"
+import { WorkerNode, WorkerType } from "../proto/gen/common"
+
+const SIDEBAR_WIDTH = 200
+const DEFAULT_DURATION_SECS = 10
+
+const workerTypeLabel = (workerType: WorkerType) => {
+  switch (workerType) {
+    case WorkerType.WORKER_TYPE_FRONTEND:
+      return "Frontend"
+    case WorkerType.WORKER_TYPE_COMPUTE_NODE:
+      return "Compute"
+    case WorkerType.WORKER_TYPE_COMPACTOR:
+      return "Compactor"
+    default:
+      return "Other"
+  }
+}
+
+const getWorkerLabel = (
+  nodeId: number | undefined,
+  workerNodes: WorkerNode[] | undefined
+) => {
+  if (nodeId === undefined) {
+    return "Worker Node"
+  }
+  const node = (workerNodes ?? []).find((n) => n.id === nodeId)
+  if (!node) {
+    return `Worker Node ${nodeId}`
+  }
+  return `Worker Node ${nodeId} (${workerTypeLabel(node.type)})`
+}
+
+export default function CpuProfiling() {
+  const { response: workerNodes } = useFetch(getClusterInfoProfileWorkers)
+
+  const [workerNodeId, setWorkerNodeId] = useState<number>()
+  const [durationSecs, setDurationSecs] = useState(DEFAULT_DURATION_SECS)
+  const [isProfiling, setIsProfiling] = useState(false)
+  const [displayInfo, setDisplayInfo] = useState(
+    'Select a worker node and click "Dump" to collect and download a CPU flame graph.'
+  )
+
+  useEffect(() => {
+    if (workerNodes && !workerNodeId && workerNodes.length > 0) {
+      setWorkerNodeId(workerNodes[0].id)
+    }
+  }, [workerNodes, workerNodeId])
+
+  async function dumpProfile() {
+    if (
+      workerNodeId === undefined ||
+      !Number.isInteger(durationSecs) ||
+      durationSecs < 1 ||
+      durationSecs > 300
+    ) {
+      return
+    }
+
+    const workerLabel = getWorkerLabel(workerNodeId, workerNodes)
+    setIsProfiling(true)
+    setDisplayInfo(
+      `Collecting a ${durationSecs}-second CPU profile from ${workerLabel}...`
+    )
+
+    try {
+      const url = api.urlFor(
+        `/monitor/dump_cpu_profile/${workerNodeId}/${durationSecs}`
+      )
+      const response = await fetch(url)
+      if (!response.ok) {
+        const errorBody = await response.text()
+        const errorDetail = (() => {
+          try {
+            return JSON.parse(errorBody).error ?? errorBody
+          } catch (_) {
+            return errorBody
+          }
+        })()
+        throw Error(
+          `${response.status} ${response.statusText}${
+            errorDetail ? `: ${errorDetail}` : ""
+          }`
+        )
+      }
+
+      const flamegraph = await response.blob()
+      const timestamp = new Date().toISOString().replace(/[:.]/g, "-")
+      const fileName = `cpu-profile-worker-${workerNodeId}-${timestamp}.svg`
+      saveAs(flamegraph, fileName)
+      setDisplayInfo(
+        `CPU profile from ${workerLabel} downloaded as ${fileName}.`
+      )
+    } catch (e: any) {
+      setDisplayInfo(
+        `Failed to collect CPU profile from ${workerLabel}.\n\nError: ${
+          e.message
+        }${e.cause ? `\nCause: ${e.cause}` : ""}`
+      )
+    } finally {
+      setIsProfiling(false)
+    }
+  }
+
+  const workerTypeOrder = [
+    WorkerType.WORKER_TYPE_COMPUTE_NODE,
+    WorkerType.WORKER_TYPE_FRONTEND,
+    WorkerType.WORKER_TYPE_COMPACTOR,
+  ]
+  const groupedWorkerNodes = (workerNodes ?? []).reduce((groups, node) => {
+    const list = groups.get(node.type) ?? []
+    list.push(node)
+    groups.set(node.type, list)
+    return groups
+  }, new Map<WorkerType, WorkerNode[]>())
+  for (const nodes of groupedWorkerNodes.values()) {
+    nodes.sort((a, b) => a.id - b.id)
+  }
+
+  return (
+    <Fragment>
+      <Head>
+        <title>CPU Profiling</title>
+      </Head>
+      <Flex p={3} height="calc(50vh - 20px)" flexDirection="column">
+        <Title>CPU Profiling</Title>
+        <Flex flexDirection="row" height="full" width="full">
+          <VStack
+            mr={3}
+            spacing={3}
+            alignItems="flex-start"
+            width={SIDEBAR_WIDTH}
+            height="full"
+          >
+            <FormControl>
+              <FormLabel textColor="blue.500">Dump CPU Profile</FormLabel>
+              <VStack>
+                <FormLabel>Worker Nodes</FormLabel>
+                <Select
+                  value={workerNodeId ?? ""}
+                  onChange={(event) =>
+                    setWorkerNodeId(parseInt(event.target.value))
+                  }
+                >
+                  {workerTypeOrder.flatMap((workerType) => {
+                    const nodes = groupedWorkerNodes.get(workerType)
+                    if (!nodes || nodes.length === 0) {
+                      return []
+                    }
+                    return (
+                      <optgroup
+                        key={workerType}
+                        label={workerTypeLabel(workerType)}
+                      >
+                        {nodes.map((node) => (
+                          <option value={node.id} key={node.id}>
+                            ({node.id}) {node.host?.host}:{node.host?.port}
+                          </option>
+                        ))}
+                      </optgroup>
+                    )
+                  })}
+                </Select>
+                <FormLabel>Duration (seconds)</FormLabel>
+                <NumberInput
+                  min={1}
+                  max={300}
+                  step={1}
+                  value={durationSecs}
+                  onChange={(_, value) =>
+                    setDurationSecs(Number.isNaN(value) ? 0 : value)
+                  }
+                  width="full"
+                >
+                  <NumberInputField />
+                </NumberInput>
+                <Button
+                  isDisabled={
+                    workerNodeId === undefined ||
+                    !Number.isInteger(durationSecs) ||
+                    durationSecs < 1 ||
+                    durationSecs > 300
+                  }
+                  isLoading={isProfiling}
+                  loadingText="Profiling"
+                  onClick={dumpProfile}
+                  width="full"
+                >
+                  Dump
+                </Button>
+              </VStack>
+            </FormControl>
+          </VStack>
+          <Box
+            flex={1}
+            height="full"
+            ml={3}
+            overflowX="scroll"
+            overflowY="scroll"
+          >
+            <Editor
+              language="plaintext"
+              options={{
+                fontSize: 13,
+                readOnly: true,
+                renderWhitespace: "boundary",
+                wordWrap: "on",
+              }}
+              value={displayInfo}
+            />
+          </Box>
+        </Flex>
+      </Flex>
+    </Fragment>
+  )
+}

--- a/src/meta/src/dashboard/mod.rs
+++ b/src/meta/src/dashboard/mod.rs
@@ -75,7 +75,7 @@ pub(super) mod handlers {
     use risingwave_pb::monitor_service::{
         AnalyzeHeapRequest, ChannelDeltaStats, GetStreamingPrometheusStatsResponse,
         GetStreamingStatsResponse, HeapProfilingRequest, HeapProfilingResponse,
-        ListHeapProfilingRequest, ListHeapProfilingResponse, StackTraceResponse,
+        ListHeapProfilingRequest, ListHeapProfilingResponse, ProfilingRequest, StackTraceResponse,
     };
     use risingwave_pb::user::PbUserInfo;
     use serde::{Deserialize, Serialize};
@@ -562,6 +562,44 @@ pub(super) mod handlers {
         Ok(result.into())
     }
 
+    pub async fn cpu_profile(
+        Path((worker_id, duration_secs)): Path<(WorkerId, u64)>,
+        Extension(srv): Extension<Service>,
+    ) -> Result<Response> {
+        if duration_secs == 0 {
+            return Err(err(anyhow!(
+                "CPU profiling duration must be greater than zero"
+            )));
+        }
+
+        let flamegraph = if worker_id == crate::manager::META_NODE_ID {
+            srv.profile_service
+                .profiling(Request::new(ProfilingRequest {
+                    sleep_s: duration_secs,
+                }))
+                .await
+                .map_err(err)?
+                .into_inner()
+                .result
+        } else {
+            let worker_node = srv
+                .metadata_manager
+                .get_worker_by_id(worker_id)
+                .await
+                .map_err(err)?
+                .context("worker node not found")
+                .map_err(err)?;
+
+            let client = srv.monitor_clients.get(&worker_node).await.map_err(err)?;
+            client.profile(duration_secs).await.map_err(err)?.result
+        };
+
+        Response::builder()
+            .header("Content-Type", "image/svg+xml")
+            .body(flamegraph.into())
+            .map_err(err)
+    }
+
     pub async fn list_heap_profile(
         Path(worker_id): Path<WorkerId>,
         Extension(srv): Extension<Service>,
@@ -981,6 +1019,10 @@ impl DashboardService {
             .route("/monitor/await_tree/{worker_id}", get(dump_await_tree))
             // /monitor/await_tree/?format={text or json}
             .route("/monitor/await_tree/", get(dump_await_tree_all))
+            .route(
+                "/monitor/dump_cpu_profile/{worker_id}/{duration_secs}",
+                get(cpu_profile),
+            )
             .route("/monitor/dump_heap_profile/{worker_id}", get(heap_profile))
             .route(
                 "/monitor/list_heap_profile/{worker_id}",


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

- Add a meta dashboard endpoint that invokes the existing monitor-service CPU profiler for a selected worker and returns its flamegraph as SVG.
- Add a CPU Profiling dashboard page with worker and duration selection, progress and error feedback, automatic SVG download, and a Debug navigation entry.
- Local validation: `cargo check -p risingwave_meta`, `cargo fmt --check -p risingwave_meta`, `pnpm run lint`, and `pnpm run build`.

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [x] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/dev/src/ci.md#ci-labels-guide -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwavelabs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a CPU profiling page accessible from the Debug section.
  * Select a worker and profiling duration from 1–300 seconds.
  * Generate and download CPU profile flamegraphs in SVG format.
  * Added loading states and clear success or error status messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->