### PR TITLE
fix(meta): preserve connection and secret refs during connector alters

### DIFF
--- a/e2e_test/source_inline/kafka/alter/alter_connector_props.slt
+++ b/e2e_test/source_inline/kafka/alter/alter_connector_props.slt
@@ -75,7 +75,7 @@ ALTER TABLE plain_students CONNECTOR WITH (properties.receive.message.max.bytes 
 # the table definition is changed accordingly
 query I
 select count(*) from rw_tables
-where definition ILIKE '%secret s2%'
+where definition ILIKE '%properties.receive.message.max.bytes = secret public.s2%'
   and definition ILIKE '%topic = ''kafka_alter_connector_props''%'
   and name = 'plain_students';
 ----
@@ -85,12 +85,12 @@ query I
 select definition from rw_tables
 where name = 'plain_students';
 ----
-CREATE TABLE plain_students ("ID" INT, "firstName" CHARACTER VARYING, "lastName" CHARACTER VARYING, age INT, height REAL, weight REAL) WITH (connector = 'kafka', properties.bootstrap.server = '127.0.0.1:29092', topic = 'kafka_alter_connector_props', properties.receive.message.max.bytes = 'SECRET s2') FORMAT PLAIN ENCODE JSON
+CREATE TABLE plain_students ("ID" INT, "firstName" CHARACTER VARYING, "lastName" CHARACTER VARYING, age INT, height REAL, weight REAL) WITH (connector = 'kafka', properties.bootstrap.server = '127.0.0.1:29092', topic = 'kafka_alter_connector_props', properties.receive.message.max.bytes = secret public.s2) FORMAT PLAIN ENCODE JSON
 
 # the associated source definition is changed accordingly
 query I
 select count(*) from rw_sources
-where definition ILIKE '%secret s2%'
+where definition ILIKE '%properties.receive.message.max.bytes = secret public.s2%'
   and definition ILIKE '%topic = ''kafka_alter_connector_props''%'
   and name = 'plain_students';
 ----

--- a/e2e_test/source_inline/kafka/alter/alter_connector_props.slt
+++ b/e2e_test/source_inline/kafka/alter/alter_connector_props.slt
@@ -42,6 +42,23 @@ FORMAT PLAIN ENCODE JSON;
 statement error Invalid input syntax: Cannot alter connector properties that are set by CONNECTION.
 alter table plain_students_1 connector with ( properties.security.protocol = 'sasl_ssl' ) ;
 
+statement ok
+alter table plain_students_1 connector with (
+    properties.receive.message.max.bytes = secret s2
+);
+
+query I
+select definition from rw_tables
+where name = 'plain_students_1';
+----
+CREATE TABLE plain_students_1 ("ID" INT, "firstName" CHARACTER VARYING, "lastName" CHARACTER VARYING, age INT, height REAL, weight REAL) WITH (connector = 'kafka', connection = conn, topic = 'kafka_alter_connector_props', properties.receive."message"."max".bytes = secret public.s2) FORMAT PLAIN ENCODE JSON
+
+query I
+select definition from rw_sources
+where name = 'plain_students_1';
+----
+CREATE TABLE plain_students_1 ("ID" INT, "firstName" CHARACTER VARYING, "lastName" CHARACTER VARYING, age INT, height REAL, weight REAL) WITH (connector = 'kafka', connection = conn, topic = 'kafka_alter_connector_props', properties.receive."message"."max".bytes = secret public.s2) FORMAT PLAIN ENCODE JSON
+
 
 statement ok
 CREATE TABLE plain_students (
@@ -75,7 +92,7 @@ ALTER TABLE plain_students CONNECTOR WITH (properties.receive.message.max.bytes 
 # the table definition is changed accordingly
 query I
 select count(*) from rw_tables
-where definition ILIKE '%properties.receive.message.max.bytes = secret public.s2%'
+where definition ILIKE '%properties.receive."message"."max".bytes = secret public.s2%'
   and definition ILIKE '%topic = ''kafka_alter_connector_props''%'
   and name = 'plain_students';
 ----
@@ -85,12 +102,12 @@ query I
 select definition from rw_tables
 where name = 'plain_students';
 ----
-CREATE TABLE plain_students ("ID" INT, "firstName" CHARACTER VARYING, "lastName" CHARACTER VARYING, age INT, height REAL, weight REAL) WITH (connector = 'kafka', properties.bootstrap.server = '127.0.0.1:29092', topic = 'kafka_alter_connector_props', properties.receive.message.max.bytes = secret public.s2) FORMAT PLAIN ENCODE JSON
+CREATE TABLE plain_students ("ID" INT, "firstName" CHARACTER VARYING, "lastName" CHARACTER VARYING, age INT, height REAL, weight REAL) WITH (connector = 'kafka', properties.bootstrap.server = '127.0.0.1:29092', topic = 'kafka_alter_connector_props', properties.receive."message"."max".bytes = secret public.s2) FORMAT PLAIN ENCODE JSON
 
 # the associated source definition is changed accordingly
 query I
 select count(*) from rw_sources
-where definition ILIKE '%properties.receive.message.max.bytes = secret public.s2%'
+where definition ILIKE '%properties.receive."message"."max".bytes = secret public.s2%'
   and definition ILIKE '%topic = ''kafka_alter_connector_props''%'
   and name = 'plain_students';
 ----

--- a/e2e_test/source_inline/kafka/alter/alter_connector_props.slt
+++ b/e2e_test/source_inline/kafka/alter/alter_connector_props.slt
@@ -81,6 +81,12 @@ where definition ILIKE '%secret s2%'
 ----
 1
 
+query I
+select definition from rw_tables
+where name = 'plain_students';
+----
+CREATE TABLE plain_students ("ID" INT, "firstName" CHARACTER VARYING, "lastName" CHARACTER VARYING, age INT, height REAL, weight REAL) WITH (connector = 'kafka', properties.bootstrap.server = '127.0.0.1:29092', topic = 'kafka_alter_connector_props', properties.receive.message.max.bytes = 'SECRET s2') FORMAT PLAIN ENCODE JSON
+
 # the associated source definition is changed accordingly
 query I
 select count(*) from rw_sources

--- a/e2e_test/source_inline/kafka/alter/alter_connector_props.slt
+++ b/e2e_test/source_inline/kafka/alter/alter_connector_props.slt
@@ -74,13 +74,19 @@ ALTER TABLE plain_students CONNECTOR WITH (properties.receive.message.max.bytes 
 
 # the table definition is changed accordingly
 query I
-select count(*)  from rw_tables where definition ILIKE '%secret s2%' and name = 'plain_students';
+select count(*) from rw_tables
+where definition ILIKE '%secret s2%'
+  and definition ILIKE '%topic = ''kafka_alter_connector_props''%'
+  and name = 'plain_students';
 ----
 1
 
 # the associated source definition is changed accordingly
 query I
-select count(*)  from rw_sources where definition ILIKE '%secret s2%' and name = 'plain_students';
+select count(*) from rw_sources
+where definition ILIKE '%secret s2%'
+  and definition ILIKE '%topic = ''kafka_alter_connector_props''%'
+  and name = 'plain_students';
 ----
 1
 

--- a/e2e_test/source_inline/kafka/alter/alter_connector_props_non_shared_source.slt
+++ b/e2e_test/source_inline/kafka/alter/alter_connector_props_non_shared_source.slt
@@ -173,11 +173,25 @@ statement ok
 create source non_shared_conn_source (x int) with (
     connector = 'kafka',
     connection = kafka_conn_non_shared,
+    properties.receive.message.max.bytes = secret s1,
     topic = 'test_alter_non_shared_source_conn'
 ) format plain encode json;
 
 statement ok
 create materialized view non_shared_conn_source_mv as select * from non_shared_conn_source;
+
+statement ok
+alter source non_shared_conn_source connector with (
+    properties.receive.message.max.bytes = secret s2
+);
+
+query I
+select count(*) from rw_sources
+where name = 'non_shared_conn_source'
+  and definition ILIKE '%connection = kafka_conn_non_shared%'
+  and definition ILIKE '%properties.receive.message.max.bytes%secret s2%';
+----
+1
 
 query I retry 3 backoff 1s
 select * from non_shared_conn_source_mv order by x;

--- a/e2e_test/source_inline/kafka/alter/alter_connector_props_non_shared_source.slt
+++ b/e2e_test/source_inline/kafka/alter/alter_connector_props_non_shared_source.slt
@@ -90,13 +90,19 @@ statement ok
 alter source non_shared_source_2 connector WITH (properties.receive.message.max.bytes = secret s2);
 
 query I retry 5 backoff 1s
-select count(*)  from rw_sources where definition ILIKE '%secret s2%' and name = 'non_shared_source_1';
+select count(*) from rw_sources
+where definition ILIKE '%secret s2%'
+  and definition ILIKE '%topic = ''test_alter_non_shared_source''%'
+  and name = 'non_shared_source_1';
 ----
 1
 
 
 query I retry 5 backoff 1s
-select count(*)  from rw_sources where definition ILIKE '%secret s2%' and name = 'non_shared_source_2';
+select count(*) from rw_sources
+where definition ILIKE '%secret s2%'
+  and definition ILIKE '%topic = ''test_alter_non_shared_source''%'
+  and name = 'non_shared_source_2';
 ----
 1
 

--- a/e2e_test/source_inline/kafka/alter/alter_connector_props_non_shared_source.slt
+++ b/e2e_test/source_inline/kafka/alter/alter_connector_props_non_shared_source.slt
@@ -13,6 +13,9 @@ statement ok
 set streaming_use_shared_source to false;
 
 system ok
+rpk topic delete test_alter_non_shared_source -X brokers=message_queue_sasl_1:19092 -X sasl.mechanism=PLAIN -X user=dev -X pass=rw || true
+
+system ok
 rpk topic create test_alter_non_shared_source -X brokers=message_queue_sasl_1:19092 -X sasl.mechanism=PLAIN -X user=dev -X pass=rw
 
 system ok
@@ -21,6 +24,9 @@ cat << EOF | rpk topic produce test_alter_non_shared_source -X brokers=message_q
 {"x": 2}
 {"x": 3}
 EOF
+
+system ok
+rpk topic delete test_alter_non_shared_source -X brokers=message_queue_sasl_2:19093 -X sasl.mechanism=PLAIN -X user=dev1 -X pass=rw || true
 
 system ok
 rpk topic create test_alter_non_shared_source -X brokers=message_queue_sasl_2:19093 -X sasl.mechanism=PLAIN -X user=dev1 -X pass=rw
@@ -91,7 +97,7 @@ alter source non_shared_source_2 connector WITH (properties.receive.message.max.
 
 query I retry 5 backoff 1s
 select count(*) from rw_sources
-where definition ILIKE '%secret s2%'
+where definition ILIKE '%properties.receive.message.max.bytes = secret public.s2%'
   and definition ILIKE '%topic = ''test_alter_non_shared_source''%'
   and name = 'non_shared_source_1';
 ----
@@ -100,7 +106,7 @@ where definition ILIKE '%secret s2%'
 
 query I retry 5 backoff 1s
 select count(*) from rw_sources
-where definition ILIKE '%secret s2%'
+where definition ILIKE '%properties.receive.message.max.bytes = secret public.s2%'
   and definition ILIKE '%topic = ''test_alter_non_shared_source''%'
   and name = 'non_shared_source_2';
 ----
@@ -131,6 +137,9 @@ select * from non_shared_source_1_mv order by x;
 # ==== test non shared source with connection ====
 
 system ok
+rpk topic delete test_alter_non_shared_source_conn -X brokers=message_queue_sasl_1:19092 -X sasl.mechanism=PLAIN -X user=dev -X pass=rw || true
+
+system ok
 rpk topic create test_alter_non_shared_source_conn -X brokers=message_queue_sasl_1:19092 -X sasl.mechanism=PLAIN -X user=dev -X pass=rw
 
 system ok
@@ -139,6 +148,9 @@ cat << EOF | rpk topic produce test_alter_non_shared_source_conn -X brokers=mess
 {"x": 2}
 {"x": 3}
 EOF
+
+system ok
+rpk topic delete test_alter_non_shared_source_conn -X brokers=message_queue_sasl_2:19093 -X sasl.mechanism=PLAIN -X user=dev1 -X pass=rw || true
 
 system ok
 rpk topic create test_alter_non_shared_source_conn -X brokers=message_queue_sasl_2:19093 -X sasl.mechanism=PLAIN -X user=dev1 -X pass=rw
@@ -189,7 +201,7 @@ query I
 select count(*) from rw_sources
 where name = 'non_shared_conn_source'
   and definition ILIKE '%connection = kafka_conn_non_shared%'
-  and definition ILIKE '%properties.receive.message.max.bytes%secret s2%';
+  and definition ILIKE '%properties.receive.message.max.bytes = secret public.s2%';
 ----
 1
 
@@ -268,16 +280,16 @@ statement ok
 drop secret s_password_conn_new;
 
 system ok
-rpk topic delete test_alter_non_shared_source -X brokers=message_queue_sasl_1:19092 -X sasl.mechanism=PLAIN -X user=dev -X pass=rw
+rpk topic delete test_alter_non_shared_source -X brokers=message_queue_sasl_1:19092 -X sasl.mechanism=PLAIN -X user=dev -X pass=rw || true
 
 system ok
-rpk topic delete test_alter_non_shared_source -X brokers=message_queue_sasl_2:19093 -X sasl.mechanism=PLAIN -X user=dev1 -X pass=rw
+rpk topic delete test_alter_non_shared_source -X brokers=message_queue_sasl_2:19093 -X sasl.mechanism=PLAIN -X user=dev1 -X pass=rw || true
 
 system ok
-rpk topic delete test_alter_non_shared_source_conn -X brokers=message_queue_sasl_1:19092 -X sasl.mechanism=PLAIN -X user=dev -X pass=rw
+rpk topic delete test_alter_non_shared_source_conn -X brokers=message_queue_sasl_1:19092 -X sasl.mechanism=PLAIN -X user=dev -X pass=rw || true
 
 system ok
-rpk topic delete test_alter_non_shared_source_conn -X brokers=message_queue_sasl_2:19093 -X sasl.mechanism=PLAIN -X user=dev1 -X pass=rw
+rpk topic delete test_alter_non_shared_source_conn -X brokers=message_queue_sasl_2:19093 -X sasl.mechanism=PLAIN -X user=dev1 -X pass=rw || true
 
 statement ok
 set streaming_use_shared_source to true;

--- a/e2e_test/source_inline/kafka/alter/alter_connector_props_non_shared_source.slt
+++ b/e2e_test/source_inline/kafka/alter/alter_connector_props_non_shared_source.slt
@@ -97,7 +97,7 @@ alter source non_shared_source_2 connector WITH (properties.receive.message.max.
 
 query I retry 5 backoff 1s
 select count(*) from rw_sources
-where definition ILIKE '%properties.receive.message.max.bytes = secret public.s2%'
+where definition ILIKE '%properties.receive."message"."max".bytes = secret public.s2%'
   and definition ILIKE '%topic = ''test_alter_non_shared_source''%'
   and name = 'non_shared_source_1';
 ----
@@ -106,7 +106,7 @@ where definition ILIKE '%properties.receive.message.max.bytes = secret public.s2
 
 query I retry 5 backoff 1s
 select count(*) from rw_sources
-where definition ILIKE '%properties.receive.message.max.bytes = secret public.s2%'
+where definition ILIKE '%properties.receive."message"."max".bytes = secret public.s2%'
   and definition ILIKE '%topic = ''test_alter_non_shared_source''%'
   and name = 'non_shared_source_2';
 ----
@@ -201,7 +201,7 @@ query I
 select count(*) from rw_sources
 where name = 'non_shared_conn_source'
   and definition ILIKE '%connection = kafka_conn_non_shared%'
-  and definition ILIKE '%properties.receive.message.max.bytes = secret public.s2%';
+  and definition ILIKE '%properties.receive."message"."max".bytes = secret public.s2%';
 ----
 1
 

--- a/e2e_test/source_inline/kafka/alter/cron_only/alter_source_properties_safe.slt.serial
+++ b/e2e_test/source_inline/kafka/alter/cron_only/alter_source_properties_safe.slt.serial
@@ -76,6 +76,70 @@ WHERE name = 'kafka_test_source'
 ----
 1
 
+# A source-level admin update must not override a property owned by its CONNECTION.
+statement ok
+CREATE CONNECTION safe_update_conn WITH (
+    type = 'kafka',
+    properties.bootstrap.server = '${RISEDEV_KAFKA_BOOTSTRAP_SERVERS}',
+    properties.security.protocol = 'plaintext'
+);
+
+statement ok
+CREATE SOURCE kafka_connection_test_source (id INT, data VARCHAR)
+WITH (
+    connector = 'kafka',
+    connection = safe_update_conn,
+    topic = 'test_safe_update'
+) FORMAT PLAIN ENCODE JSON;
+
+system ok
+SOURCE_ID=$(psql -h ${RISEDEV_RW_FRONTEND_LISTEN_ADDRESS} \
+    -p ${RISEDEV_RW_FRONTEND_PORT} \
+    -d $__DATABASE__ \
+    -U root \
+    -t -A \
+    -c "SELECT id FROM rw_sources WHERE name = 'kafka_connection_test_source'") && \
+if OUTPUT=$(./risedev ctl meta alter-source-properties-safe \
+    --source-id $SOURCE_ID \
+    --props '{"properties.bootstrap.server": "other-broker:9092"}' 2>&1); then \
+    echo "Expected connection-owned property update to fail" >&2; \
+    exit 1; \
+fi && \
+echo "$OUTPUT" | grep -Fq 'Use ALTER CONNECTION instead.'
+
+query I
+SELECT COUNT(*) FROM rw_sources
+WHERE name = 'kafka_connection_test_source'
+  AND definition LIKE '%connection = safe_update_conn%'
+  AND definition NOT LIKE '%properties.bootstrap.server%';
+----
+1
+
+# Replay the saved definition to detect conflicts between direct options and CONNECTION options.
+system ok
+SOURCE_DDL=$(psql -X -v ON_ERROR_STOP=1 \
+    -h "$SLT_HOST" -p "$SLT_PORT" -d "$__DATABASE__" -U root -t -A \
+    -c "SELECT definition FROM rw_sources WHERE name = 'kafka_connection_test_source'") && \
+test -n "$SOURCE_DDL" && \
+psql -X -v ON_ERROR_STOP=1 \
+    -h "$SLT_HOST" -p "$SLT_PORT" -d "$__DATABASE__" -U root \
+    -c "DROP SOURCE kafka_connection_test_source" \
+    -c "$SOURCE_DDL"
+
+query I
+SELECT COUNT(*) FROM rw_sources
+WHERE name = 'kafka_connection_test_source'
+  AND definition LIKE '%connection = safe_update_conn%'
+  AND definition NOT LIKE '%properties.bootstrap.server%';
+----
+1
+
+statement ok
+DROP SOURCE kafka_connection_test_source;
+
+statement ok
+DROP CONNECTION safe_update_conn;
+
 # Test 2: Reset splits (without property update)
 system ok
 SOURCE_ID=$(psql -h ${RISEDEV_RW_FRONTEND_LISTEN_ADDRESS} \

--- a/src/meta/src/controller/streaming_job.rs
+++ b/src/meta/src/controller/streaming_job.rs
@@ -3967,7 +3967,7 @@ fn merge_with_options(with_properties: &mut Vec<SqlOption>, altered_options: Vec
             .iter_mut()
             .find(|option| option.name.real_value() == altered_option.name.real_value())
         {
-            existing_option.value = altered_option.value;
+            *existing_option = altered_option;
         } else {
             with_properties.push(altered_option);
         }
@@ -4103,7 +4103,7 @@ mod tests {
     use super::{Parser, merge_with_options};
 
     #[test]
-    fn test_merge_with_options_preserves_original_option_name() {
+    fn test_merge_with_options_normalizes_altered_option_name() {
         let mut statements = Parser::parse_sql(
             "CREATE SOURCE s WITH (properties.receive.message.max.bytes = 'old', \
              connection = kafka_conn) FORMAT PLAIN ENCODE JSON",
@@ -4124,7 +4124,7 @@ mod tests {
         assert_eq!(with_properties.len(), 2);
         assert_eq!(
             with_properties[0].to_string(),
-            "properties.receive.message.max.bytes = 'new'"
+            "properties.receive.\"message\".\"max\".bytes = 'new'"
         );
         assert_eq!(with_properties[1].to_string(), "connection = kafka_conn");
     }

--- a/src/meta/src/controller/streaming_job.rs
+++ b/src/meta/src/controller/streaming_job.rs
@@ -88,8 +88,8 @@ use crate::controller::fragment::FragmentTypeMaskExt;
 use crate::controller::utils::{
     PartialObject, build_object_group_for_delete, check_if_belongs_to_iceberg_table,
     check_relation_name_duplicate, check_sink_into_table_cycle, ensure_job_not_canceled,
-    ensure_object_id, ensure_user_id, fetch_target_fragments, get_belong_objects,
-    get_belong_objects_by_ids, get_referring_objects, get_table_columns,
+    ensure_object_id, ensure_user_id, fetch_target_fragments, format_with_option_secret_resolved,
+    get_belong_objects, get_belong_objects_by_ids, get_referring_objects, get_table_columns,
     grant_default_privileges_automatically, insert_fragment_relations,
     list_object_dependencies_by_object_id, list_user_info_by_ids, upsert_user_privileges,
 };
@@ -2943,42 +2943,6 @@ impl CatalogController {
                 })?
                 .try_into()
                 .unwrap();
-
-            /// Formats SQL options with secret values properly resolved
-            ///
-            /// This function processes configuration options that may contain sensitive data:
-            /// - Plaintext options are directly converted to `SqlOption`
-            /// - Secret options are retrieved from the database and formatted as "SECRET {name}"
-            ///   without exposing the actual secret value
-            ///
-            /// # Arguments
-            /// * `txn` - Database transaction for retrieving secrets
-            /// * `options_with_secret` - Container of options with both plaintext and secret values
-            ///
-            /// # Returns
-            /// * `MetaResult<Vec<SqlOption>>` - List of formatted SQL options or error
-            async fn format_with_option_secret_resolved(
-                txn: &DatabaseTransaction,
-                options_with_secret: &WithOptionsSecResolved,
-            ) -> MetaResult<Vec<SqlOption>> {
-                let mut options = Vec::new();
-                for (k, v) in options_with_secret.as_plaintext() {
-                    let sql_option = SqlOption::try_from((k, &format!("'{}'", v)))
-                        .map_err(|e| MetaError::invalid_parameter(e.to_report_string()))?;
-                    options.push(sql_option);
-                }
-                for (k, v) in options_with_secret.as_secret() {
-                    if let Some(secret_model) = Secret::find_by_id(v.secret_id).one(txn).await? {
-                        let sql_option =
-                            SqlOption::try_from((k, &format!("SECRET {}", secret_model.name)))
-                                .map_err(|e| MetaError::invalid_parameter(e.to_report_string()))?;
-                        options.push(sql_option);
-                    } else {
-                        return Err(MetaError::catalog_id_not_found("secret", v.secret_id));
-                    }
-                }
-                Ok(options)
-            }
 
             match &mut stmt {
                 Statement::CreateSource { stmt } => {

--- a/src/meta/src/controller/streaming_job.rs
+++ b/src/meta/src/controller/streaming_job.rs
@@ -2914,6 +2914,8 @@ impl CatalogController {
                 .map(|secret_ref| secret_ref.to_protobuf())
                 .unwrap_or_default(),
         );
+        let altered_options_with_secret =
+            WithOptionsSecResolved::new(alter_props.clone(), alter_secret_refs.clone());
         let (to_add_secret_dep, to_remove_secret_dep) =
             options_with_secret.handle_update(alter_props, alter_secret_refs)?;
 
@@ -2946,12 +2948,16 @@ impl CatalogController {
 
             match &mut stmt {
                 Statement::CreateSource { stmt } => {
-                    stmt.with_properties.0 =
-                        format_with_option_secret_resolved(&txn, &options_with_secret).await?;
+                    let altered_sql_options =
+                        format_with_option_secret_resolved(&txn, &altered_options_with_secret)
+                            .await?;
+                    merge_with_options(&mut stmt.with_properties.0, altered_sql_options);
                 }
                 Statement::CreateTable { with_options, .. } => {
-                    *with_options =
-                        format_with_option_secret_resolved(&txn, &options_with_secret).await?;
+                    let altered_sql_options =
+                        format_with_option_secret_resolved(&txn, &altered_options_with_secret)
+                            .await?;
+                    merge_with_options(with_options, altered_sql_options);
                     associate_table_id = source.optional_associated_table_id;
                     preferred_id = associate_table_id.unwrap().as_object_id();
                 }
@@ -3955,6 +3961,19 @@ fn update_stmt_with_props(
     Ok(())
 }
 
+fn merge_with_options(with_properties: &mut Vec<SqlOption>, altered_options: Vec<SqlOption>) {
+    for altered_option in altered_options {
+        if let Some(existing_option) = with_properties
+            .iter_mut()
+            .find(|option| option.name.real_value() == altered_option.name.real_value())
+        {
+            existing_option.value = altered_option.value;
+        } else {
+            with_properties.push(altered_option);
+        }
+    }
+}
+
 async fn update_sink_fragment_props(
     txn: &DatabaseTransaction,
     sink_id: SinkId,
@@ -4075,4 +4094,38 @@ where
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use risingwave_sqlparser::ast::{SqlOption, Statement};
+
+    use super::{Parser, merge_with_options};
+
+    #[test]
+    fn test_merge_with_options_preserves_original_option_name() {
+        let mut statements = Parser::parse_sql(
+            "CREATE SOURCE s WITH (properties.receive.message.max.bytes = 'old', \
+             connection = kafka_conn) FORMAT PLAIN ENCODE JSON",
+        )
+        .unwrap();
+        let Statement::CreateSource { stmt } = statements.remove(0) else {
+            unreachable!()
+        };
+        let mut with_properties = stmt.with_properties.0;
+        let altered_name = "properties.receive.message.max.bytes".to_owned();
+        let altered_value = "new".to_owned();
+
+        merge_with_options(
+            &mut with_properties,
+            vec![SqlOption::try_from((&altered_name, &altered_value)).unwrap()],
+        );
+
+        assert_eq!(with_properties.len(), 2);
+        assert_eq!(
+            with_properties[0].to_string(),
+            "properties.receive.message.max.bytes = 'new'"
+        );
+        assert_eq!(with_properties[1].to_string(), "connection = kafka_conn");
+    }
 }

--- a/src/meta/src/controller/streaming_job.rs
+++ b/src/meta/src/controller/streaming_job.rs
@@ -2870,6 +2870,8 @@ impl CatalogController {
             .ok_or_else(|| {
                 MetaError::catalog_id_not_found(ObjectType::Source.as_str(), source_id)
             })?;
+        ensure_source_props_not_set_by_connection(&txn, &source, &alter_props, &alter_secret_refs)
+            .await?;
         let connector = source.with_properties.0.get_connector().unwrap();
         let is_shared_source = source.is_shared();
 
@@ -3972,6 +3974,41 @@ fn merge_with_options(with_properties: &mut Vec<SqlOption>, altered_options: Vec
             with_properties.push(altered_option);
         }
     }
+}
+
+async fn ensure_source_props_not_set_by_connection(
+    txn: &DatabaseTransaction,
+    source: &source::Model,
+    alter_props: &BTreeMap<String, String>,
+    alter_secret_refs: &BTreeMap<String, PbSecretRef>,
+) -> MetaResult<()> {
+    let Some(connection_id) = source.connection_id else {
+        return Ok(());
+    };
+
+    let connection = Connection::find_by_id(connection_id)
+        .one(txn)
+        .await?
+        .ok_or_else(|| {
+            MetaError::catalog_id_not_found(ObjectType::Connection.as_str(), connection_id)
+        })?;
+    let connection_params = connection.params.to_protobuf();
+
+    if let Some(key) = alter_props
+        .keys()
+        .chain(alter_secret_refs.keys())
+        .find(|key| {
+            connection_params.properties.contains_key(*key)
+                || connection_params.secret_refs.contains_key(*key)
+        })
+    {
+        return Err(MetaError::invalid_parameter(format!(
+            "Cannot alter source connector property `{key}` because it is set by CONNECTION `{}`. Use ALTER CONNECTION instead.",
+            connection.name
+        )));
+    }
+
+    Ok(())
 }
 
 async fn update_sink_fragment_props(

--- a/src/meta/src/controller/utils.rs
+++ b/src/meta/src/controller/utils.rs
@@ -27,6 +27,7 @@ use risingwave_common::types::{DataType, Datum};
 use risingwave_common::util::value_encoding::DatumToProtoExt;
 use risingwave_common::util::worker_util::DEFAULT_RESOURCE_GROUP;
 use risingwave_common::{bail, hash};
+use risingwave_connector::WithOptionsSecResolved;
 use risingwave_meta_model::fragment::DistributionType;
 use risingwave_meta_model::object::ObjectType;
 use risingwave_meta_model::prelude::*;
@@ -57,7 +58,7 @@ use risingwave_pb::plan_common::{ColumnCatalog, DefaultColumnDesc};
 use risingwave_pb::stream_plan::{PbDispatchOutputMapping, PbDispatcher, PbDispatcherType};
 use risingwave_pb::user::grant_privilege::{PbActionWithGrantOption, PbObject as PbGrantObject};
 use risingwave_pb::user::{PbAction, PbGrantPrivilege, PbUserInfo};
-use risingwave_sqlparser::ast::Statement as SqlStatement;
+use risingwave_sqlparser::ast::{SqlOption, Statement as SqlStatement};
 use risingwave_sqlparser::parser::Parser;
 use sea_orm::sea_query::{
     Alias, CommonTableExpression, Expr, OnConflict, Query, QueryStatementBuilder, SelectStatement,
@@ -544,6 +545,34 @@ where
     let cnt: i64 = res.try_get_by(0)?;
 
     Ok(cnt != 0)
+}
+
+/// Formats SQL options with secret values properly resolved.
+///
+/// This function processes configuration options that may contain sensitive data:
+/// - Plaintext options are directly converted to `SqlOption`.
+/// - Secret options are retrieved from the database and formatted as `SECRET {name}` without
+///   exposing the actual secret value.
+pub async fn format_with_option_secret_resolved(
+    txn: &DatabaseTransaction,
+    options_with_secret: &WithOptionsSecResolved,
+) -> MetaResult<Vec<SqlOption>> {
+    let mut options = Vec::new();
+    for (k, v) in options_with_secret.as_plaintext() {
+        let sql_option = SqlOption::try_from((k, &format!("'{}'", v)))
+            .map_err(|e| MetaError::invalid_parameter(e.to_report_string()))?;
+        options.push(sql_option);
+    }
+    for (k, v) in options_with_secret.as_secret() {
+        if let Some(secret_model) = Secret::find_by_id(v.secret_id).one(txn).await? {
+            let sql_option = SqlOption::try_from((k, &format!("SECRET {}", secret_model.name)))
+                .map_err(|e| MetaError::invalid_parameter(e.to_report_string()))?;
+            options.push(sql_option);
+        } else {
+            return Err(MetaError::catalog_id_not_found("secret", v.secret_id));
+        }
+    }
+    Ok(options)
 }
 
 /// `ensure_object_id` ensures the existence of target object in the cluster.

--- a/src/meta/src/controller/utils.rs
+++ b/src/meta/src/controller/utils.rs
@@ -559,7 +559,7 @@ pub async fn format_with_option_secret_resolved(
 ) -> MetaResult<Vec<SqlOption>> {
     let mut options = Vec::new();
     for (k, v) in options_with_secret.as_plaintext() {
-        let sql_option = SqlOption::try_from((k, &format!("'{}'", v)))
+        let sql_option = SqlOption::try_from((k, v))
             .map_err(|e| MetaError::invalid_parameter(e.to_report_string()))?;
         options.push(sql_option);
     }

--- a/src/meta/src/controller/utils.rs
+++ b/src/meta/src/controller/utils.rs
@@ -55,10 +55,14 @@ use risingwave_pb::meta::{
 };
 use risingwave_pb::plan_common::column_desc::GeneratedOrDefaultColumn;
 use risingwave_pb::plan_common::{ColumnCatalog, DefaultColumnDesc};
+use risingwave_pb::secret::PbSecretRef;
+use risingwave_pb::secret::secret_ref::PbRefAsType;
 use risingwave_pb::stream_plan::{PbDispatchOutputMapping, PbDispatcher, PbDispatcherType};
 use risingwave_pb::user::grant_privilege::{PbActionWithGrantOption, PbObject as PbGrantObject};
 use risingwave_pb::user::{PbAction, PbGrantPrivilege, PbUserInfo};
-use risingwave_sqlparser::ast::{SqlOption, Statement as SqlStatement};
+use risingwave_sqlparser::ast::{
+    Ident, ObjectName, SecretRefAsType, SecretRefValue, SqlOption, Statement as SqlStatement,
+};
 use risingwave_sqlparser::parser::Parser;
 use sea_orm::sea_query::{
     Alias, CommonTableExpression, Expr, OnConflict, Query, QueryStatementBuilder, SelectStatement,
@@ -563,16 +567,53 @@ pub async fn format_with_option_secret_resolved(
             .map_err(|e| MetaError::invalid_parameter(e.to_report_string()))?;
         options.push(sql_option);
     }
-    for (k, v) in options_with_secret.as_secret() {
-        if let Some(secret_model) = Secret::find_by_id(v.secret_id).one(txn).await? {
-            let sql_option = SqlOption::try_from((k, &format!("SECRET {}", secret_model.name)))
-                .map_err(|e| MetaError::invalid_parameter(e.to_report_string()))?;
-            options.push(sql_option);
-        } else {
-            return Err(MetaError::catalog_id_not_found("secret", v.secret_id));
-        }
+    for (name, secret_ref) in options_with_secret.as_secret() {
+        let secret_ref_value = resolve_secret_ref_value(txn, secret_ref).await?;
+        options.push(SqlOption::from_secret_ref(name, secret_ref_value));
     }
     Ok(options)
+}
+
+async fn resolve_secret_ref_value(
+    txn: &DatabaseTransaction,
+    secret_ref: &PbSecretRef,
+) -> MetaResult<SecretRefValue> {
+    let (secret, object) = Secret::find_by_id(secret_ref.secret_id)
+        .find_also_related(Object)
+        .one(txn)
+        .await?
+        .ok_or_else(|| MetaError::catalog_id_not_found("secret", secret_ref.secret_id))?;
+    let object =
+        object.ok_or_else(|| MetaError::catalog_id_not_found("object", secret_ref.secret_id))?;
+    let schema_id = object.schema_id.ok_or_else(|| {
+        MetaError::invalid_parameter(format!(
+            "secret {} does not belong to a schema",
+            secret_ref.secret_id
+        ))
+    })?;
+    let schema = Schema::find_by_id(schema_id)
+        .one(txn)
+        .await?
+        .ok_or_else(|| MetaError::catalog_id_not_found("schema", schema_id))?;
+
+    let ref_as = match PbRefAsType::try_from(secret_ref.ref_as) {
+        Ok(PbRefAsType::File) => SecretRefAsType::File,
+        Ok(PbRefAsType::Text | PbRefAsType::Unspecified) => SecretRefAsType::Text,
+        Err(_) => {
+            return Err(MetaError::invalid_parameter(format!(
+                "invalid reference type {} for secret {}",
+                secret_ref.ref_as, secret_ref.secret_id
+            )));
+        }
+    };
+
+    Ok(SecretRefValue {
+        secret_name: ObjectName(vec![
+            Ident::from_real_value(&schema.name),
+            Ident::from_real_value(&secret.name),
+        ]),
+        ref_as,
+    })
 }
 
 /// `ensure_object_id` ensures the existence of target object in the cluster.

--- a/src/sqlparser/src/ast/mod.rs
+++ b/src/sqlparser/src/ast/mod.rs
@@ -3316,6 +3316,16 @@ pub struct SqlOption {
     pub value: SqlOptionValue,
 }
 
+impl SqlOption {
+    /// Creates an option whose value is a typed secret reference.
+    pub fn from_secret_ref(name: &str, secret_ref: SecretRefValue) -> Self {
+        Self {
+            name: ObjectName(name.split('.').map(Ident::from_real_value).collect()),
+            value: SqlOptionValue::SecretRef(secret_ref),
+        }
+    }
+}
+
 impl fmt::Display for SqlOption {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let should_redact = REDACT_SQL_OPTION_KEYWORDS
@@ -4199,5 +4209,32 @@ mod tests {
             "CREATE FUNCTION foo(INT) RETURNS INT LANGUAGE python IMMUTABLE AS 'SELECT 1' WITH ( always_retry_on_network_error = true )",
             format!("{}", create_function)
         );
+    }
+
+    #[test]
+    fn test_sql_option_from_secret_ref() {
+        let text_option = SqlOption::from_secret_ref(
+            "password",
+            SecretRefValue {
+                secret_name: ObjectName(vec![
+                    Ident::from_real_value("public"),
+                    Ident::from_real_value("s2"),
+                ]),
+                ref_as: SecretRefAsType::Text,
+            },
+        );
+
+        assert!(matches!(text_option.value, SqlOptionValue::SecretRef(_)));
+        assert_eq!(text_option.to_string(), "password = secret public.s2");
+
+        let file_option = SqlOption::from_secret_ref(
+            "certificate",
+            SecretRefValue {
+                secret_name: ObjectName(vec![Ident::from_real_value("cert")]),
+                ref_as: SecretRefAsType::File,
+            },
+        );
+
+        assert_eq!(file_option.to_string(), "certificate = secret cert AS FILE");
     }
 }


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

<!--

**Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->


- Closes #26904
- Related to #25148

`ALTER SOURCE/TABLE ... CONNECTOR WITH (...)` previously rebuilt the stored SQL definition from fully resolved connector properties.

For sources or tables created with a `CONNECTION`, this removed the original `connection = <name>` option and expanded connection-owned properties into the stored definition. Secret references could also be rewritten as ordinary strings or lose their schema and reference type.

This PR fixes connector definition rewriting by:

- formatting only the properties supplied by the current `ALTER` statement;
- merging altered options into the original parsed SQL definition, preserving unchanged options such as `connection` and `topic`;
- avoiding double quoting of plaintext connector property values;
- reconstructing secret options as typed, schema-qualified `SecretRef` AST nodes;
- preserving both `TEXT` and `FILE` secret reference semantics;
- normalizing altered option names using their canonical SQL representation;
- extracting `format_with_option_secret_resolved` as a reusable helper for the secret-aware connector alteration work in #25148;
- adding SLT coverage for shared and non-shared Kafka sources/tables, including definitions created with a connection.

## Tests

- `cargo fmt --all --check`
- `cargo check -p risingwave_meta --lib`
- `cargo test -p risingwave_sqlparser test_sql_option_from_secret_ref`
- `cargo test -p risingwave_meta test_merge_with_options_normalizes_altered_option_name --lib`
- `./risedev slt './e2e_test/source_inline/kafka/alter/alter_connector_props_non_shared_source.slt'`
- `./risedev slt './e2e_test/source_inline/kafka/alter/alter_connector_props.slt'`

## Checklist

- [x] I have written necessary rustdoc comments.
- [x] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/dev/src/ci.md#ci-labels-guide -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes

- Altering source and table properties now updates only specified options while preserving existing settings.
- Connection-backed property changes stay synchronized across related tables and sources.
- Direct source updates can no longer override connection-managed properties.
- Secret-backed options support schema-qualified, text-based, and file-based references without exposing values.
- Secret references now use consistent SQL quoting and escaping.
- Invalid secret references and missing catalog objects return clearer errors.
- Rate-limit updates and listings now include `LocalityProvider` nodes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->