### PR TITLE
refactor(frontend): add persistent cursor stream infrastructure

### DIFF
--- a/src/frontend/src/handler/util.rs
+++ b/src/frontend/src/handler/util.rs
@@ -185,7 +185,7 @@ fn timestamptz_to_string_with_session_data(
     result_string.into()
 }
 
-fn to_pg_rows(
+pub(crate) fn to_pg_rows(
     column_types: &[DataType],
     chunk: DataChunk,
     formats: &[Format],

--- a/src/frontend/src/session/cursor_manager.rs
+++ b/src/frontend/src/session/cursor_manager.rs
@@ -62,6 +62,10 @@ use crate::scheduler::{
 use crate::utils::Condition;
 use crate::{OptimizerContext, OptimizerContextRef, PgResponseStream, TableCatalog};
 
+#[expect(dead_code, reason = "The persistent-stream layer is not wired yet")]
+#[path = "cursor_stream.rs"]
+mod cursor_stream;
+
 /// Cursor-scoped shutdown resources, separate from individual FETCH cancellation.
 struct CursorShutdownHandle {
     /// Signals termination of this cursor's execution.

--- a/src/frontend/src/session/cursor_stream.rs
+++ b/src/frontend/src/session/cursor_stream.rs
@@ -1,4 +1,4 @@
-// Copyright 2024 RisingWave Labs
+// Copyright 2026 RisingWave Labs
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/frontend/src/session/cursor_stream.rs
+++ b/src/frontend/src/session/cursor_stream.rs
@@ -1,0 +1,1185 @@
+// Copyright 2024 RisingWave Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Persistent cursor-stream infrastructure, separate from the active cursor execution path.
+
+use std::collections::VecDeque;
+use std::pin::Pin;
+use std::sync::{Arc, Weak};
+use std::task::{Context, Poll};
+use std::time::Instant;
+
+use futures::stream::BoxStream;
+use futures::{Stream, StreamExt};
+use futures_async_stream::try_stream;
+use pgwire::types::{Format, Row};
+use risingwave_common::array::DataChunk;
+use risingwave_common::catalog::Field;
+use risingwave_common::error::BoxedError;
+
+use super::{CursorQueryStream, FieldsManager, SubscriptionCursor};
+use crate::error::{ErrorCode, Result};
+use crate::handler::HandlerArgs;
+use crate::handler::util::{StaticSessionData, to_pg_rows};
+use crate::session::SessionImpl;
+use crate::utils::WithOptions;
+
+/// Schema and provenance of a raw cursor data chunk.
+enum CursorDataChunkMetadata {
+    /// A chunk from a regular query cursor.
+    Query {
+        /// Fields describing every column in the chunk.
+        fields: Arc<Vec<Field>>,
+    },
+    /// A chunk from the initial snapshot or a log-store epoch of a subscription cursor.
+    Subscription {
+        /// Field mapping in effect when this chunk was produced.
+        fields: Arc<FieldsManager>,
+        /// Whether the chunk comes from the initial upstream-table snapshot.
+        from_snapshot: bool,
+        /// Snapshot or log-store epoch represented by the chunk.
+        rw_timestamp: u64,
+    },
+}
+
+/// Unformatted executor output and the metadata needed to interpret its rows.
+struct CursorDataChunk {
+    chunk: DataChunk,
+    metadata: CursorDataChunkMetadata,
+}
+
+impl CursorDataChunk {
+    fn into_pg_rows(
+        self,
+        format: &CursorRowFormat,
+    ) -> Result<(VecDeque<Row>, CursorDataChunkMetadata)> {
+        let (column_types, formats) = match &self.metadata {
+            CursorDataChunkMetadata::Query { fields } => (
+                fields.iter().map(Field::data_type).collect::<Vec<_>>(),
+                format.formats.clone(),
+            ),
+            CursorDataChunkMetadata::Subscription {
+                fields,
+                from_snapshot,
+                ..
+            } => {
+                let (row_fields, formats) =
+                    fields.get_row_stream_fields_and_formats(&format.formats, *from_snapshot);
+                (row_fields.iter().map(Field::data_type).collect(), formats)
+            }
+        };
+        let rows = to_pg_rows(&column_types, self.chunk, &formats, &format.session_data)?;
+        Ok((rows.into(), self.metadata))
+    }
+}
+
+/// An ordered, non-row event exposing a cursor's execution or data-availability transition.
+///
+/// Unlike [`std::task::Poll::Pending`], each barrier identifies a specific transition rather
+/// than an arbitrary unfinished asynchronous operation. These events are not FETCH checkpoints.
+enum CursorDataChunkBarrier {
+    /// The single query owned by a regular query cursor has completed.
+    QueryEnd,
+    /// A query for the subscription snapshot or a log-store epoch has started.
+    /// Emitted before rows from that query.
+    SubscriptionQueryStarted {
+        /// Whether the query reads the initial upstream-table snapshot.
+        from_snapshot: bool,
+        /// Snapshot or log-store epoch read by the query.
+        rw_timestamp: u64,
+        /// Exact next log-store epoch, when known, used to detect a retention gap.
+        expected_timestamp: Option<u64>,
+        /// When query initialization began, for duration metrics and diagnostics.
+        init_query_timer: Instant,
+        /// Output schema for rows from this query.
+        output_fields: Vec<Field>,
+        /// Retention deadline associated with this query.
+        expires_at: Instant,
+    },
+    /// A subscription query has completed; the stream will look for the next log-store epoch.
+    SubscriptionNewEpoch {
+        /// Lower bound for the next log-store epoch search.
+        seek_timestamp: u64,
+        /// Exact log-store epoch required at that position, when known, to detect a retention gap.
+        expected_timestamp: Option<u64>,
+    },
+    /// No log-store epoch is currently available.
+    /// Emitted before waiting for the next log-store epoch.
+    /// This distinguishes an intentional idle wait from pending query startup or row reads.
+    SubscriptionIdle,
+    /// The wait for the next log-store epoch has finished.
+    /// The stream will check for available log-store epochs again.
+    SubscriptionIdleEnded,
+    /// The output schema changed. End a nonwaiting FETCH or one that already yielded rows;
+    /// otherwise, continue with the new schema in the current FETCH.
+    SchemaChanged,
+}
+
+/// A raw data chunk or a control barrier, ordered by the cursor's persistent producer.
+enum CursorDataChunkEvent {
+    Chunk(CursorDataChunk),
+    Barrier(CursorDataChunkBarrier),
+}
+
+/// A persistent producer of raw query chunks followed by a query-completion barrier.
+struct QueryCursorDataChunkStream {
+    /// Owns the query stream and its pending read across individual FETCH calls.
+    inner: BoxStream<'static, std::result::Result<CursorDataChunkEvent, BoxedError>>,
+}
+
+impl QueryCursorDataChunkStream {
+    fn new(query_stream: CursorQueryStream, fields: Vec<Field>) -> Self {
+        Self {
+            inner: Self::event_stream(query_stream, fields).boxed(),
+        }
+    }
+
+    #[try_stream(ok = CursorDataChunkEvent, error = BoxedError)]
+    async fn event_stream(mut query_stream: CursorQueryStream, fields: Vec<Field>) {
+        let fields = Arc::new(fields);
+        while let Some(chunk) = query_stream.next().await {
+            yield CursorDataChunkEvent::Chunk(CursorDataChunk {
+                chunk: chunk?,
+                metadata: CursorDataChunkMetadata::Query {
+                    fields: fields.clone(),
+                },
+            });
+        }
+        yield CursorDataChunkEvent::Barrier(CursorDataChunkBarrier::QueryEnd);
+    }
+}
+
+impl Stream for QueryCursorDataChunkStream {
+    type Item = std::result::Result<CursorDataChunkEvent, BoxedError>;
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        self.get_mut().inner.poll_next_unpin(cx)
+    }
+}
+
+/// A persistent subscription event stream, independent of any single FETCH future.
+///
+/// TODO: Implement `event_stream` in the subsequent PR once the prerequisite snapshot-aware query
+/// startup and execution refactors are in place.
+struct SubscriptionCursorDataChunkStream {
+    /// Owns the event producer, including its suspended asynchronous operations.
+    inner: BoxStream<'static, std::result::Result<CursorDataChunkEvent, BoxedError>>,
+}
+
+impl Stream for SubscriptionCursorDataChunkStream {
+    type Item = std::result::Result<CursorDataChunkEvent, BoxedError>;
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        self.get_mut().inner.poll_next_unpin(cx)
+    }
+}
+
+/// Subscription position exposed to the response adapter by ordered control barriers.
+/// This is not a checkpoint for rolling back a cancelled FETCH.
+enum SubscriptionCursorState {
+    /// Looking for the next available log-store epoch.
+    InitLogStoreQuery {
+        /// Lower bound for the next log-store epoch search.
+        seek_timestamp: u64,
+        /// Exact next log-store epoch, when known, used to detect a retention gap.
+        expected_timestamp: Option<u64>,
+    },
+    /// Reading the initial snapshot or a log-store epoch.
+    Fetch {
+        /// Whether the query reads the initial upstream-table snapshot.
+        from_snapshot: bool,
+        /// Snapshot or log-store epoch read by the query.
+        rw_timestamp: u64,
+        /// Exact next log-store epoch, when known, used to detect a retention gap.
+        expected_timestamp: Option<u64>,
+        /// When query initialization began, for duration metrics and diagnostics.
+        init_query_timer: Instant,
+    },
+    /// The producer reported an unrecoverable error.
+    Invalid,
+}
+
+/// Stored planning context for later subscription queries, without a strong session reference.
+/// Reconstructed handler arguments may still retain the session during an asynchronous operation.
+struct SubscriptionCursorHandlerContext {
+    session: Weak<SessionImpl>,
+    sql: Arc<str>,
+    normalized_sql: String,
+    with_options: WithOptions,
+}
+
+impl SubscriptionCursorHandlerContext {
+    fn new(handler_args: &HandlerArgs) -> Self {
+        Self {
+            session: Arc::downgrade(&handler_args.session),
+            sql: handler_args.sql.clone(),
+            normalized_sql: handler_args.normalized_sql.clone(),
+            with_options: handler_args.with_options.clone(),
+        }
+    }
+
+    fn handler_args(&self) -> Result<HandlerArgs> {
+        let session = self.session.upgrade().ok_or_else(|| {
+            ErrorCode::InternalError("session ended while polling subscription cursor".to_owned())
+        })?;
+        Ok(HandlerArgs {
+            session,
+            sql: self.sql.clone(),
+            normalized_sql: self.normalized_sql.clone(),
+            with_options: self.with_options.clone(),
+        })
+    }
+}
+
+/// PostgreSQL formats and session settings used for row conversion, without retaining a session.
+struct CursorRowFormat {
+    formats: Vec<Format>,
+    session_data: StaticSessionData,
+}
+
+impl CursorRowFormat {
+    fn new(formats: &[Format], session: &SessionImpl) -> Self {
+        Self {
+            formats: formats.to_vec(),
+            session_data: StaticSessionData {
+                timezone: session.config().timezone(),
+            },
+        }
+    }
+}
+
+/// Shared row conversion and buffering for query and subscription response streams.
+/// Only unread formatted rows are retained; rows returned to FETCH cannot be replayed.
+///
+/// TODO: Add transactional buffering in a subsequent PR (Goal 3) so rows consumed by a cancelled
+///     FETCH can be replayed.
+struct CursorPgResponseStreamInner<S> {
+    /// Released on terminal EOF or error, but retained across individual FETCH boundaries.
+    data_stream: Option<S>,
+    /// Currently inspected only by subscription cursors; their integration will use it for
+    /// invalid-cursor cleanup and statistics. Query cursors also record this state for possible
+    /// future query-cursor failure statistics.
+    failed: bool,
+    current_rows: VecDeque<Row>,
+    current_metadata: Option<Arc<CursorDataChunkMetadata>>,
+    /// Fixed for each underlying query, matching the existing row-stream initialization.
+    row_format: Option<Arc<CursorRowFormat>>,
+    output_fields: Vec<Field>,
+    /// A command boundary, not necessarily the end of the persistent data stream.
+    fetch_stream_terminated: bool,
+}
+
+enum CursorPgResponsePollItem {
+    Row {
+        row: Row,
+        metadata: Arc<CursorDataChunkMetadata>,
+    },
+    Barrier(CursorDataChunkBarrier),
+    DataChunkStreamEnd,
+}
+
+impl<S> CursorPgResponseStreamInner<S> {
+    fn new(data_stream: S, output_fields: Vec<Field>) -> Self {
+        Self {
+            data_stream: Some(data_stream),
+            failed: false,
+            current_rows: VecDeque::new(),
+            current_metadata: None,
+            row_format: None,
+            output_fields,
+            fetch_stream_terminated: false,
+        }
+    }
+
+    fn begin_fetch(&mut self, format: Arc<CursorRowFormat>) {
+        self.row_format.get_or_insert(format);
+        self.fetch_stream_terminated = false;
+    }
+
+    /// Releases the data stream at the end of its lifecycle. To end only the current FETCH,
+    /// set `fetch_stream_terminated` to true; `begin_fetch` resets it to false to resume.
+    fn mark_completed(&mut self, is_failed: bool) {
+        self.failed = is_failed;
+        self.fetch_stream_terminated = true;
+        self.data_stream = None;
+        self.current_rows.clear();
+        self.current_metadata = None;
+    }
+}
+
+impl<S> CursorPgResponseStreamInner<S>
+where
+    S: Stream<Item = std::result::Result<CursorDataChunkEvent, BoxedError>> + Unpin,
+{
+    fn poll_next_item(&mut self, cx: &mut Context<'_>) -> Poll<Result<CursorPgResponsePollItem>> {
+        if self.data_stream.is_none() {
+            return Poll::Ready(Ok(CursorPgResponsePollItem::DataChunkStreamEnd));
+        }
+        loop {
+            if let Some(row) = self.current_rows.pop_front() {
+                return Poll::Ready(Ok(CursorPgResponsePollItem::Row {
+                    row,
+                    metadata: self.current_metadata.as_ref().unwrap().clone(),
+                }));
+            }
+            match self.data_stream.as_mut().unwrap().poll_next_unpin(cx) {
+                Poll::Pending => return Poll::Pending,
+                Poll::Ready(Some(Ok(CursorDataChunkEvent::Chunk(chunk)))) => {
+                    let format = self
+                        .row_format
+                        .as_ref()
+                        .expect("row formatting must be initialized before reading cursor chunks");
+                    match chunk.into_pg_rows(format) {
+                        Ok((rows, metadata)) => {
+                            self.current_rows = rows;
+                            self.current_metadata = Some(Arc::new(metadata));
+                        }
+                        Err(error) => {
+                            self.mark_completed(true);
+                            return Poll::Ready(Err(error));
+                        }
+                    }
+                }
+                Poll::Ready(Some(Ok(CursorDataChunkEvent::Barrier(barrier)))) => {
+                    return Poll::Ready(Ok(CursorPgResponsePollItem::Barrier(barrier)));
+                }
+                Poll::Ready(Some(Err(error))) => {
+                    self.mark_completed(true);
+                    return Poll::Ready(Err(error.into()));
+                }
+                Poll::Ready(None) => {
+                    self.mark_completed(false);
+                    return Poll::Ready(Ok(CursorPgResponsePollItem::DataChunkStreamEnd));
+                }
+            }
+        }
+    }
+}
+
+/// A query response stream that retains unread rows across FETCH boundaries.
+struct QueryCursorPgResponseStream {
+    inner: CursorPgResponseStreamInner<QueryCursorDataChunkStream>,
+}
+
+impl QueryCursorPgResponseStream {
+    fn new(data_stream: QueryCursorDataChunkStream, output_fields: Vec<Field>) -> Self {
+        Self {
+            inner: CursorPgResponseStreamInner::new(data_stream, output_fields),
+        }
+    }
+
+    fn fields(&self) -> Vec<Field> {
+        self.inner.output_fields.clone()
+    }
+
+    fn begin_fetch(&mut self, formats: &[Format], session: &SessionImpl) {
+        self.inner
+            .begin_fetch(Arc::new(CursorRowFormat::new(formats, session)));
+    }
+}
+
+impl Stream for QueryCursorPgResponseStream {
+    type Item = Result<Row>;
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        let this = self.get_mut();
+        if this.inner.fetch_stream_terminated {
+            return Poll::Ready(None);
+        }
+        match this.inner.poll_next_item(cx) {
+            Poll::Pending => Poll::Pending,
+            Poll::Ready(Err(error)) => Poll::Ready(Some(Err(error))),
+            Poll::Ready(Ok(CursorPgResponsePollItem::Row { row, .. })) => {
+                Poll::Ready(Some(Ok(row)))
+            }
+            Poll::Ready(Ok(CursorPgResponsePollItem::Barrier(
+                CursorDataChunkBarrier::QueryEnd,
+            ))) => {
+                this.inner.mark_completed(false);
+                Poll::Ready(None)
+            }
+            Poll::Ready(Ok(CursorPgResponsePollItem::DataChunkStreamEnd)) => Poll::Ready(None),
+            Poll::Ready(Ok(CursorPgResponsePollItem::Barrier(_))) => {
+                this.inner.mark_completed(true);
+                Poll::Ready(Some(Err(ErrorCode::InternalError(
+                    "query cursor received a subscription cursor barrier".to_owned(),
+                )
+                .into())))
+            }
+        }
+    }
+}
+
+/// A subscription response stream that applies log-store epoch and schema barriers in order.
+/// Position and seek metadata advance as rows/events are consumed, without FETCH rollback.
+struct SubscriptionCursorPgResponseStream {
+    inner: CursorPgResponseStreamInner<SubscriptionCursorDataChunkStream>,
+    subscription_state: SubscriptionCursorState,
+    seek_pk_row: Option<Row>,
+    expires_at: Instant,
+    is_idle: bool,
+    /// Whether an idle FETCH should wait when it has yielded no rows. Once rows have been
+    /// yielded, idle always ends the FETCH, regardless of this flag.
+    /// Also allows an empty FETCH to continue past a schema boundary.
+    should_wait_when_idle_and_empty: bool,
+    yielded_rows: usize,
+    /// Used for synthetic subscription columns; raw columns keep the query's row format.
+    fetch_format: Option<Arc<CursorRowFormat>>,
+}
+
+impl SubscriptionCursorPgResponseStream {
+    fn new(
+        data_stream: SubscriptionCursorDataChunkStream,
+        output_fields: Vec<Field>,
+        subscription_state: SubscriptionCursorState,
+        expires_at: Instant,
+    ) -> Self {
+        Self {
+            inner: CursorPgResponseStreamInner::new(data_stream, output_fields),
+            subscription_state,
+            seek_pk_row: None,
+            expires_at,
+            is_idle: false,
+            should_wait_when_idle_and_empty: false,
+            yielded_rows: 0,
+            fetch_format: None,
+        }
+    }
+
+    fn fields(&self) -> Vec<Field> {
+        self.inner.output_fields.clone()
+    }
+
+    fn subscription_state(&self) -> &SubscriptionCursorState {
+        &self.subscription_state
+    }
+
+    fn seek_pk_row(&self) -> Option<Row> {
+        self.seek_pk_row.clone()
+    }
+
+    fn is_expired(&self, now: Instant) -> bool {
+        now > self.expires_at
+    }
+
+    fn is_failed(&self) -> bool {
+        self.inner.failed
+    }
+
+    fn begin_fetch(
+        &mut self,
+        formats: &[Format],
+        session: &SessionImpl,
+        should_wait_when_idle_and_empty: bool,
+    ) {
+        let format = Arc::new(CursorRowFormat::new(formats, session));
+        self.inner.begin_fetch(format.clone());
+        self.fetch_format = Some(format);
+        self.should_wait_when_idle_and_empty = should_wait_when_idle_and_empty;
+        self.yielded_rows = 0;
+    }
+
+    fn project_row(&mut self, row: Row, metadata: &CursorDataChunkMetadata) -> Result<Row> {
+        let CursorDataChunkMetadata::Subscription {
+            fields,
+            from_snapshot,
+            rw_timestamp,
+        } = metadata
+        else {
+            return Err(ErrorCode::InternalError(
+                "subscription cursor received query metadata".to_owned(),
+            )
+            .into());
+        };
+        let format = self.fetch_format.as_ref().unwrap();
+        let row = SubscriptionCursor::build_row(
+            row.take(),
+            (!from_snapshot).then_some(*rw_timestamp),
+            &format.formats,
+            &format.session_data,
+        )?;
+        let (mut rows, seek_pk_row) = fields.process_output_desc_row(vec![row]);
+        self.seek_pk_row = seek_pk_row;
+        Ok(rows.pop().unwrap())
+    }
+}
+
+impl Stream for SubscriptionCursorPgResponseStream {
+    type Item = Result<Row>;
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        const INVALID_CURSOR_ERROR_MESSAGE: &str =
+            "Subscription cursor data stream ended unexpectedly; close and recreate the cursor";
+        let this = self.get_mut();
+        if let SubscriptionCursorState::Invalid = this.subscription_state {
+            return Poll::Ready(Some(Err(ErrorCode::InternalError(
+                INVALID_CURSOR_ERROR_MESSAGE.to_owned(),
+            )
+            .into())));
+        }
+        loop {
+            if this.inner.fetch_stream_terminated {
+                return Poll::Ready(None);
+            }
+            match this.inner.poll_next_item(cx) {
+                Poll::Pending => {
+                    if this.is_idle
+                        && (this.yielded_rows > 0 || !this.should_wait_when_idle_and_empty)
+                    {
+                        this.inner.fetch_stream_terminated = true;
+                        return Poll::Ready(None);
+                    }
+                    return Poll::Pending;
+                }
+                Poll::Ready(Err(error)) => {
+                    this.subscription_state = SubscriptionCursorState::Invalid;
+                    return Poll::Ready(Some(Err(error)));
+                }
+                Poll::Ready(Ok(CursorPgResponsePollItem::Row { row, metadata })) => {
+                    let row = this.project_row(row, &metadata);
+                    if row.is_err() {
+                        this.inner.mark_completed(true);
+                        this.subscription_state = SubscriptionCursorState::Invalid;
+                    } else {
+                        this.is_idle = false;
+                        this.yielded_rows += 1;
+                    }
+                    return Poll::Ready(Some(row));
+                }
+                Poll::Ready(Ok(CursorPgResponsePollItem::Barrier(barrier))) => {
+                    this.is_idle = false;
+                    match barrier {
+                        CursorDataChunkBarrier::SubscriptionQueryStarted {
+                            from_snapshot,
+                            rw_timestamp,
+                            expected_timestamp,
+                            init_query_timer,
+                            output_fields,
+                            expires_at,
+                        } => {
+                            this.subscription_state = SubscriptionCursorState::Fetch {
+                                from_snapshot,
+                                rw_timestamp,
+                                expected_timestamp,
+                                init_query_timer,
+                            };
+                            this.inner.output_fields = output_fields;
+                            this.expires_at = expires_at;
+                            this.inner.row_format = this.fetch_format.clone();
+                        }
+                        CursorDataChunkBarrier::SubscriptionNewEpoch {
+                            seek_timestamp,
+                            expected_timestamp,
+                        } => {
+                            this.subscription_state = SubscriptionCursorState::InitLogStoreQuery {
+                                seek_timestamp,
+                                expected_timestamp,
+                            };
+                        }
+                        CursorDataChunkBarrier::SubscriptionIdle => {
+                            this.is_idle = true;
+                            if this.yielded_rows > 0 || !this.should_wait_when_idle_and_empty {
+                                this.inner.fetch_stream_terminated = true;
+                                return Poll::Ready(None);
+                            }
+                        }
+                        CursorDataChunkBarrier::SubscriptionIdleEnded => {}
+                        CursorDataChunkBarrier::SchemaChanged => {
+                            // Rows preceding this barrier have been drained. Release their metadata
+                            // before continuing with the new schema or ending this FETCH.
+                            debug_assert!(this.inner.current_rows.is_empty());
+                            this.inner.current_metadata = None;
+                            if this.yielded_rows > 0 || !this.should_wait_when_idle_and_empty {
+                                this.inner.fetch_stream_terminated = true;
+                                return Poll::Ready(None);
+                            }
+                        }
+                        CursorDataChunkBarrier::QueryEnd => {
+                            this.inner.mark_completed(true);
+                            this.subscription_state = SubscriptionCursorState::Invalid;
+                            return Poll::Ready(Some(Err(ErrorCode::InternalError(
+                                "subscription cursor received a query cursor barrier".to_owned(),
+                            )
+                            .into())));
+                        }
+                    }
+                }
+                // Subscription cursor query stream expects never terminated, it will periodically
+                // launch new query to query new log-store epoch when consumed one.
+                Poll::Ready(Ok(CursorPgResponsePollItem::DataChunkStreamEnd)) => {
+                    this.inner.mark_completed(true);
+                    this.subscription_state = SubscriptionCursorState::Invalid;
+                    return Poll::Ready(Some(Err(ErrorCode::InternalError(
+                        INVALID_CURSOR_ERROR_MESSAGE.to_owned(),
+                    )
+                    .into())));
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::time::Duration;
+
+    use risingwave_batch::task::ShutdownToken;
+    use risingwave_common::array::DataChunkTestExt;
+    use risingwave_common::types::DataType;
+    use tokio::sync::{mpsc, oneshot};
+    use tokio_stream::wrappers::ReceiverStream;
+
+    use super::*;
+
+    /// Verifies that the cursor data chunk stream preserves chunks and schema, then emits
+    /// `QueryEnd` and EOF; this does not exercise a real executor.
+    #[tokio::test]
+    async fn test_local_cursor_query_data_chunk_stream_preserves_chunks() {
+        let (shutdown_tx, shutdown_rx) = ShutdownToken::new();
+        let (chunk_tx, chunk_rx) = mpsc::channel(2);
+        let chunks = [
+            DataChunk::from_pretty("i\n1\n2"),
+            DataChunk::from_pretty("i\n3"),
+        ];
+        for chunk in &chunks {
+            chunk_tx.try_send(Ok(chunk.clone())).unwrap();
+        }
+        drop(chunk_tx);
+        let fields = vec![Field::with_name(DataType::Int32, "v")];
+        let mut stream = QueryCursorDataChunkStream::new(
+            CursorQueryStream::local(ReceiverStream::new(chunk_rx), shutdown_tx),
+            fields.clone(),
+        );
+
+        for expected in chunks {
+            let CursorDataChunkEvent::Chunk(chunk) = stream.next().await.unwrap().unwrap() else {
+                panic!("expected a query data chunk, but received a barrier");
+            };
+            assert_eq!(chunk.chunk, expected);
+            let CursorDataChunkMetadata::Query { fields: actual } = chunk.metadata else {
+                panic!("query chunks must carry query metadata");
+            };
+            assert_eq!(*actual, fields);
+        }
+        assert!(matches!(
+            stream.next().await.unwrap().unwrap(),
+            CursorDataChunkEvent::Barrier(CursorDataChunkBarrier::QueryEnd)
+        ));
+        assert!(stream.next().await.is_none());
+        drop(stream);
+        assert!(!shutdown_rx.is_cancelled());
+    }
+
+    /// Verifies that dropping a pending poll leaves the channel-backed cursor query owned by the
+    /// cursor data chunk stream, which can still receive a chunk; this does not exercise a real
+    /// executor.
+    #[tokio::test]
+    async fn test_pending_cursor_data_chunk_event_poll_preserves_local_cursor_query_ownership() {
+        let (shutdown_tx, shutdown_rx) = ShutdownToken::new();
+        let (chunk_tx, chunk_rx) = mpsc::channel(1);
+        let mut stream = QueryCursorDataChunkStream::new(
+            CursorQueryStream::local(ReceiverStream::new(chunk_rx), shutdown_tx),
+            vec![Field::with_name(DataType::Int32, "v")],
+        );
+
+        let mut next = Box::pin(stream.next());
+        assert!(futures::poll!(next.as_mut()).is_pending());
+        drop(next);
+        assert!(!shutdown_rx.is_cancelled());
+        assert!(!chunk_tx.is_closed());
+
+        let expected = DataChunk::from_pretty("i\n1");
+        chunk_tx.try_send(Ok(expected.clone())).unwrap();
+        let event = tokio::time::timeout(Duration::from_secs(1), stream.next())
+            .await
+            .expect("the same producer must still receive query output")
+            .unwrap()
+            .unwrap();
+        let CursorDataChunkEvent::Chunk(chunk) = event else {
+            panic!("the pending query must resume with its chunk");
+        };
+        assert_eq!(chunk.chunk, expected);
+        assert!(!shutdown_rx.is_cancelled());
+    }
+
+    /// A test-controlled producer: the gate simulates a log-store epoch wait, not a real
+    /// snapshot-manager notification. The counter detects re-entry before the suspended wait.
+    #[try_stream(ok = CursorDataChunkEvent, error = BoxedError)]
+    async fn gated_log_store_epoch_events(
+        wait_starts: Arc<AtomicUsize>,
+        resume_rx: oneshot::Receiver<()>,
+    ) {
+        yield CursorDataChunkEvent::Barrier(CursorDataChunkBarrier::SubscriptionIdle);
+        wait_starts.fetch_add(1, Ordering::Relaxed);
+        resume_rx.await.unwrap();
+        yield CursorDataChunkEvent::Barrier(CursorDataChunkBarrier::SubscriptionIdleEnded);
+    }
+
+    /// Verifies that dropping temporary polls preserves a subscription cursor data chunk stream
+    /// coroutine's pending operation and resumes it once the gate opens, without restarting the
+    /// simulated log-store epoch wait; this does not exercise a real executor.
+    #[tokio::test]
+    async fn test_subscription_cursor_data_chunk_stream_preserves_pending_operation() {
+        let wait_starts = Arc::new(AtomicUsize::new(0));
+        let (resume_tx, resume_rx) = oneshot::channel();
+        let mut stream = SubscriptionCursorDataChunkStream {
+            inner: gated_log_store_epoch_events(wait_starts.clone(), resume_rx).boxed(),
+        };
+        assert!(matches!(
+            stream.next().await.unwrap().unwrap(),
+            CursorDataChunkEvent::Barrier(CursorDataChunkBarrier::SubscriptionIdle)
+        ));
+
+        for _ in 0..2 {
+            let mut next = Box::pin(stream.next());
+            assert!(futures::poll!(next.as_mut()).is_pending());
+            drop(next);
+            assert_eq!(wait_starts.load(Ordering::Relaxed), 1);
+        }
+        resume_tx.send(()).unwrap();
+        let event = tokio::time::timeout(Duration::from_secs(1), stream.next())
+            .await
+            .expect("the suspended operation must resume when its gate opens")
+            .unwrap()
+            .unwrap();
+        assert!(matches!(
+            event,
+            CursorDataChunkEvent::Barrier(CursorDataChunkBarrier::SubscriptionIdleEnded)
+        ));
+        assert_eq!(wait_starts.load(Ordering::Relaxed), 1);
+        assert!(stream.next().await.is_none());
+    }
+
+    fn assert_text_row(row: &Row, expected: &[Option<&str>]) {
+        let actual = row
+            .values()
+            .iter()
+            .map(|value| value.as_deref())
+            .collect::<Vec<_>>();
+        let expected = expected
+            .iter()
+            .map(|value| value.map(str::as_bytes))
+            .collect::<Vec<_>>();
+        assert_eq!(actual, expected);
+    }
+
+    /// A query cursor's local query output channel without an executor.
+    fn pending_query_response_stream_for_test() -> (
+        QueryCursorPgResponseStream,
+        mpsc::Sender<std::result::Result<DataChunk, BoxedError>>,
+    ) {
+        let (shutdown_tx, _shutdown_rx) = ShutdownToken::new();
+        let (chunk_tx, chunk_rx) = mpsc::channel(4);
+        let fields = vec![Field::with_name(DataType::Int32, "v")];
+        let data_stream = QueryCursorDataChunkStream::new(
+            CursorQueryStream::local(ReceiverStream::new(chunk_rx), shutdown_tx),
+            fields.clone(),
+        );
+        (
+            QueryCursorPgResponseStream::new(data_stream, fields),
+            chunk_tx,
+        )
+    }
+
+    /// Places a hidden key before the visible value; snapshot chunks omit the synthetic columns.
+    fn subscription_fields_for_test(value_name: &str) -> Arc<FieldsManager> {
+        Arc::new(FieldsManager {
+            columns_catalog: vec![],
+            row_fields: vec![
+                Field::with_name(DataType::Int32, "hidden_pk"),
+                Field::with_name(DataType::Int32, value_name),
+                Field::with_name(DataType::Varchar, "op"),
+                Field::with_name(DataType::Int64, "rw_timestamp"),
+            ],
+            row_output_col_indices: vec![1, 2, 3],
+            row_pk_indices: vec![0],
+            stream_chunk_row_indices: vec![0, 1],
+            op_index: 2,
+        })
+    }
+
+    /// Injects events directly without subscription planning, execution, or notifications.
+    fn pending_subscription_response_stream_for_test(
+        fields: &FieldsManager,
+        expires_at: Instant,
+    ) -> (
+        SubscriptionCursorPgResponseStream,
+        mpsc::Sender<std::result::Result<CursorDataChunkEvent, BoxedError>>,
+    ) {
+        let (event_tx, event_rx) = mpsc::channel(8);
+        let stream = SubscriptionCursorPgResponseStream::new(
+            SubscriptionCursorDataChunkStream {
+                inner: ReceiverStream::new(event_rx).boxed(),
+            },
+            fields.get_output_fields(),
+            SubscriptionCursorState::InitLogStoreQuery {
+                seek_timestamp: 0,
+                expected_timestamp: None,
+            },
+            expires_at,
+        );
+        (stream, event_tx)
+    }
+
+    fn subscription_chunk_for_test(
+        fields: Arc<FieldsManager>,
+        from_snapshot: bool,
+        rw_timestamp: u64,
+        chunk: &str,
+    ) -> CursorDataChunkEvent {
+        CursorDataChunkEvent::Chunk(CursorDataChunk {
+            chunk: DataChunk::from_pretty(chunk),
+            metadata: CursorDataChunkMetadata::Subscription {
+                fields,
+                from_snapshot,
+                rw_timestamp,
+            },
+        })
+    }
+
+    /// Verifies that the query response stream retains unread rows across `begin_fetch` calls
+    /// and ends after consuming its chunks; this does not execute SQL FETCH or a real executor.
+    #[tokio::test]
+    async fn test_query_cursor_pg_response_stream_preserves_remaining_rows() {
+        let session = SessionImpl::mock();
+        let (mut stream, chunk_tx) = pending_query_response_stream_for_test();
+        for chunk in ["i\n1\n2", "i\n3"] {
+            chunk_tx
+                .try_send(Ok(DataChunk::from_pretty(chunk)))
+                .unwrap();
+        }
+        drop(chunk_tx);
+
+        stream.begin_fetch(&[], &session);
+        assert_text_row(&stream.next().await.unwrap().unwrap(), &[Some("1")]);
+        stream.begin_fetch(&[], &session);
+        for expected in ["2", "3"] {
+            assert_text_row(&stream.next().await.unwrap().unwrap(), &[Some(expected)]);
+        }
+        assert!(stream.next().await.is_none());
+        stream.begin_fetch(&[], &session);
+        assert!(stream.next().await.is_none());
+    }
+
+    /// Verifies that the subscription response stream projects snapshot and log-store epoch rows
+    /// and keeps the hidden key as seek metadata; this does not exercise a real executor.
+    #[tokio::test]
+    async fn test_subscription_cursor_pg_response_stream_projects_rows_and_seek_key() {
+        let session = SessionImpl::mock();
+        let fields = subscription_fields_for_test("v");
+        let rw_timestamp = crate::handler::util::convert_unix_millis_to_logstore_u64(1700000000000);
+        for from_snapshot in [true, false] {
+            let (mut stream, event_tx) =
+                pending_subscription_response_stream_for_test(&fields, Instant::now());
+            event_tx
+                .try_send(Ok(CursorDataChunkEvent::Barrier(
+                    CursorDataChunkBarrier::SubscriptionQueryStarted {
+                        from_snapshot,
+                        rw_timestamp,
+                        expected_timestamp: None,
+                        init_query_timer: Instant::now(),
+                        output_fields: fields.get_output_fields(),
+                        expires_at: Instant::now() + Duration::from_secs(60),
+                    },
+                )))
+                .unwrap();
+            let chunk = if from_snapshot {
+                "i i\n7 42"
+            } else {
+                "i i T\n7 42 Delete"
+            };
+            event_tx
+                .try_send(Ok(subscription_chunk_for_test(
+                    fields.clone(),
+                    from_snapshot,
+                    rw_timestamp,
+                    chunk,
+                )))
+                .unwrap();
+
+            stream.begin_fetch(&[], &session, false);
+            let row = stream.next().await.unwrap().unwrap();
+            let expected = if from_snapshot {
+                [Some("42"), Some("Insert"), None]
+            } else {
+                [Some("42"), Some("Delete"), Some("1700000000000")]
+            };
+            assert_text_row(&row, &expected);
+            assert_text_row(&stream.seek_pk_row().unwrap(), &[Some("7")]);
+        }
+    }
+
+    /// Verifies that the subscription response stream continues through a schema change when a
+    /// waiting FETCH has no rows, but stops when nonwaiting or after yielding rows. Ordered barriers
+    /// also update position and expiry; this uses injected events, not SQL FETCH or a real executor.
+    #[tokio::test]
+    async fn test_subscription_cursor_pg_response_stream_handles_log_store_epoch_and_schema_boundaries()
+     {
+        let session = SessionImpl::mock();
+        let old_fields = subscription_fields_for_test("old_value");
+        let new_fields = subscription_fields_for_test("new_value");
+        let mut latest_fields = subscription_fields_for_test("latest_value");
+        // The second schema change changes the visible column's type as well as its name.
+        Arc::get_mut(&mut latest_fields).unwrap().row_fields[1] =
+            Field::with_name(DataType::Varchar, "latest_value");
+        let initial_expiry = Instant::now();
+        let renewed_expiry = initial_expiry + Duration::from_secs(60);
+        let latest_expiry = renewed_expiry + Duration::from_secs(60);
+        for should_wait_when_idle_and_empty in [false, true] {
+            let (mut stream, event_tx) =
+                pending_subscription_response_stream_for_test(&old_fields, initial_expiry);
+            stream.begin_fetch(&[], &session, should_wait_when_idle_and_empty);
+            event_tx
+                .try_send(Ok(CursorDataChunkEvent::Barrier(
+                    CursorDataChunkBarrier::SubscriptionNewEpoch {
+                        seek_timestamp: 12,
+                        expected_timestamp: Some(12),
+                    },
+                )))
+                .unwrap();
+            // The response stream consumes the position barrier, but has no row to yield yet.
+            assert!(futures::poll!(stream.next()).is_pending());
+            assert!(matches!(
+                stream.subscription_state(),
+                SubscriptionCursorState::InitLogStoreQuery {
+                    seek_timestamp: 12,
+                    expected_timestamp: Some(12),
+                }
+            ));
+            assert!(stream.is_expired(initial_expiry + Duration::from_secs(1)));
+
+            for event in [
+                CursorDataChunkEvent::Barrier(CursorDataChunkBarrier::SchemaChanged),
+                CursorDataChunkEvent::Barrier(CursorDataChunkBarrier::SubscriptionQueryStarted {
+                    from_snapshot: false,
+                    rw_timestamp: 12,
+                    expected_timestamp: Some(20),
+                    init_query_timer: initial_expiry,
+                    output_fields: new_fields.get_output_fields(),
+                    expires_at: renewed_expiry,
+                }),
+                subscription_chunk_for_test(
+                    new_fields.clone(),
+                    false,
+                    12,
+                    "i i T\n8 99 Insert\n9 100 Insert",
+                ),
+                CursorDataChunkEvent::Barrier(CursorDataChunkBarrier::SubscriptionNewEpoch {
+                    seek_timestamp: 20,
+                    expected_timestamp: Some(20),
+                }),
+                CursorDataChunkEvent::Barrier(CursorDataChunkBarrier::SchemaChanged),
+                CursorDataChunkEvent::Barrier(CursorDataChunkBarrier::SubscriptionQueryStarted {
+                    from_snapshot: false,
+                    rw_timestamp: 20,
+                    expected_timestamp: None,
+                    init_query_timer: initial_expiry,
+                    output_fields: latest_fields.get_output_fields(),
+                    expires_at: latest_expiry,
+                }),
+                subscription_chunk_for_test(
+                    latest_fields.clone(),
+                    false,
+                    20,
+                    "i T T\n10 changed Insert",
+                ),
+            ] {
+                event_tx.try_send(Ok(event)).unwrap();
+            }
+
+            // With no accumulated rows, only a nonwaiting FETCH stops at the first schema change.
+            if !should_wait_when_idle_and_empty {
+                assert!(stream.next().await.is_none());
+                assert!(stream.inner.current_metadata.is_none());
+                assert_eq!(stream.fields(), old_fields.get_output_fields());
+                assert!(stream.is_expired(initial_expiry + Duration::from_secs(1)));
+                assert!(matches!(
+                    stream.subscription_state(),
+                    SubscriptionCursorState::InitLogStoreQuery {
+                        seek_timestamp: 12,
+                        expected_timestamp: Some(12),
+                    }
+                ));
+                stream.begin_fetch(&[], &session, should_wait_when_idle_and_empty);
+            }
+            let row = stream.next().await.unwrap().unwrap();
+            assert_eq!(row.values()[0].as_deref(), Some(b"99".as_slice()));
+            assert_eq!(stream.fields(), new_fields.get_output_fields());
+            assert_eq!(stream.inner.current_rows.len(), 1);
+            assert!(stream.inner.current_metadata.is_some());
+            assert!(matches!(
+                stream.subscription_state(),
+                SubscriptionCursorState::Fetch {
+                    from_snapshot: false,
+                    rw_timestamp: 12,
+                    expected_timestamp: Some(20),
+                    ..
+                }
+            ));
+            assert!(!stream.is_expired(initial_expiry + Duration::from_secs(1)));
+            assert!(stream.is_expired(renewed_expiry + Duration::from_secs(1)));
+
+            // Drain the buffered row before reading the second schema barrier; do not discard it.
+            let row = stream.next().await.unwrap().unwrap();
+            assert_eq!(row.values()[0].as_deref(), Some(b"100".as_slice()));
+            // This FETCH has yielded two rows, so the second schema change must end it even in
+            // waiting mode, before consuming the next query's metadata or rows.
+            assert!(stream.next().await.is_none());
+            assert!(stream.inner.current_rows.is_empty());
+            assert!(stream.inner.current_metadata.is_none());
+            assert!(!event_tx.is_closed());
+            assert_eq!(stream.fields(), new_fields.get_output_fields());
+            assert!(matches!(
+                stream.subscription_state(),
+                SubscriptionCursorState::InitLogStoreQuery {
+                    seek_timestamp: 20,
+                    expected_timestamp: Some(20),
+                }
+            ));
+            assert!(!stream.is_expired(initial_expiry + Duration::from_secs(1)));
+            assert!(stream.is_expired(renewed_expiry + Duration::from_secs(1)));
+
+            // The next query's metadata and chunk remain unread until the next FETCH begins.
+            stream.begin_fetch(&[], &session, should_wait_when_idle_and_empty);
+            let row = stream.next().await.unwrap().unwrap();
+            assert_eq!(row.values()[0].as_deref(), Some(b"changed".as_slice()));
+            assert_eq!(stream.fields(), latest_fields.get_output_fields());
+            assert!(matches!(
+                stream.subscription_state(),
+                SubscriptionCursorState::Fetch {
+                    from_snapshot: false,
+                    rw_timestamp: 20,
+                    expected_timestamp: None,
+                    ..
+                }
+            ));
+            assert!(!stream.is_expired(renewed_expiry + Duration::from_secs(1)));
+            assert!(stream.is_expired(latest_expiry + Duration::from_secs(1)));
+        }
+    }
+
+    /// Verifies that subscription idle boundaries end non-waiting reads or reads that already
+    /// yielded rows, while other pending operations remain pending; this uses injected events.
+    #[tokio::test]
+    async fn test_subscription_cursor_pg_response_stream_distinguishes_idle_from_pending() {
+        let session = SessionImpl::mock();
+        let fields = subscription_fields_for_test("v");
+        let (mut stream, event_tx) =
+            pending_subscription_response_stream_for_test(&fields, Instant::now());
+        stream.begin_fetch(&[], &session, false);
+        assert!(futures::poll!(stream.next()).is_pending());
+        event_tx
+            .try_send(Ok(CursorDataChunkEvent::Barrier(
+                CursorDataChunkBarrier::SubscriptionIdle,
+            )))
+            .unwrap();
+        assert!(stream.next().await.is_none());
+
+        stream.begin_fetch(&[], &session, true);
+        assert!(futures::poll!(stream.next()).is_pending());
+        event_tx
+            .try_send(Ok(CursorDataChunkEvent::Barrier(
+                CursorDataChunkBarrier::SubscriptionIdleEnded,
+            )))
+            .unwrap();
+        stream.begin_fetch(&[], &session, false);
+        assert!(futures::poll!(stream.next()).is_pending());
+
+        for event in [
+            CursorDataChunkEvent::Barrier(CursorDataChunkBarrier::SubscriptionQueryStarted {
+                from_snapshot: true,
+                rw_timestamp: 0,
+                expected_timestamp: None,
+                init_query_timer: Instant::now(),
+                output_fields: fields.get_output_fields(),
+                expires_at: Instant::now() + Duration::from_secs(60),
+            }),
+            subscription_chunk_for_test(fields, true, 0, "i i\n7 42"),
+            CursorDataChunkEvent::Barrier(CursorDataChunkBarrier::SubscriptionNewEpoch {
+                seek_timestamp: 1,
+                expected_timestamp: None,
+            }),
+            CursorDataChunkEvent::Barrier(CursorDataChunkBarrier::SubscriptionIdle),
+        ] {
+            event_tx.try_send(Ok(event)).unwrap();
+        }
+        stream.begin_fetch(&[], &session, true);
+        assert_text_row(
+            &stream.next().await.unwrap().unwrap(),
+            &[Some("42"), Some("Insert"), None],
+        );
+        assert!(stream.next().await.is_none());
+    }
+
+    /// Verifies that a row-conversion error terminates the query response stream and releases its
+    /// channel-backed input, without returning subsequent chunks; this does not exercise a real executor.
+    #[tokio::test]
+    async fn test_query_cursor_pg_response_stream_rejects_invalid_formats() {
+        let session = SessionImpl::mock();
+        let (mut stream, chunk_tx) = pending_query_response_stream_for_test();
+        chunk_tx
+            .try_send(Ok(DataChunk::from_pretty("i\n1")))
+            .unwrap();
+        chunk_tx
+            .try_send(Ok(DataChunk::from_pretty("i\n2")))
+            .unwrap();
+        stream.begin_fetch(&[Format::Text, Format::Text], &session);
+        let error = stream.next().await.unwrap().unwrap_err();
+        assert!(error.to_string().contains("format codes length"));
+        assert!(chunk_tx.is_closed());
+        assert!(stream.next().await.is_none());
+        stream.begin_fetch(&[], &session);
+        assert!(stream.next().await.is_none());
+    }
+
+    /// Verifies that a source error or unexpected EOF invalidates the subscription response
+    /// stream and every subsequent poll returns an error; this uses injected events, not a real executor.
+    #[tokio::test]
+    async fn test_subscription_cursor_pg_response_stream_invalidates_on_stream_failure() {
+        let session = SessionImpl::mock();
+        let fields = subscription_fields_for_test("v");
+        for source_error in [false, true] {
+            let (mut stream, event_tx) =
+                pending_subscription_response_stream_for_test(&fields, Instant::now());
+            if source_error {
+                event_tx
+                    .try_send(Err(anyhow::anyhow!("injected source error").into()))
+                    .unwrap();
+            }
+            drop(event_tx);
+            stream.begin_fetch(&[], &session, true);
+            let error = stream.next().await.unwrap().unwrap_err();
+            let expected = if source_error {
+                "injected source error"
+            } else {
+                "ended unexpectedly"
+            };
+            assert!(error.to_string().contains(expected));
+            assert!(stream.is_failed());
+            assert!(matches!(
+                stream.subscription_state(),
+                SubscriptionCursorState::Invalid
+            ));
+            // Once invalid, every poll returns an error, even before another FETCH begins.
+            let error = stream.next().await.unwrap().unwrap_err();
+            assert!(error.to_string().contains("ended unexpectedly"));
+            stream.begin_fetch(&[], &session, true);
+            let error = stream.next().await.unwrap().unwrap_err();
+            assert!(error.to_string().contains("ended unexpectedly"));
+            let error = stream.next().await.unwrap().unwrap_err();
+            assert!(error.to_string().contains("ended unexpectedly"));
+        }
+    }
+}


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## Expectations

Provide an independently reviewable persistent-stream layer for the CancelRequest implementation, building on the cursor-query ownership and teardown infrastructure in #26906. The new layer separates the lifetime of a raw event producer from temporary polling and PostgreSQL response boundaries, without changing the active cursor implementation.

## Limitations

- This is additive, currently unwired infrastructure—not a completed production CancelRequest fix. Existing DECLARE/FETCH behavior is unchanged.
- `SubscriptionCursorDataChunkStream` is a container only. Its real `event_stream` producer is explicitly deferred until the subsequent PR supplies the prerequisite snapshot-aware query startup and execution refactors.
- Production integration and FETCH cancellation/deadline arbitration remain in PR4. The tests here do not exercise SQL FETCH, real query executors, or snapshot-manager/catalog notifications.
- The adapters retain only unread formatted rows. They do not replay rows consumed by a cancelled FETCH. Transactional buffering/replay, per-FETCH raw-column reformatting, and typed seek-key correctness remain in PR5; underlying query formatting retains its existing lifetime.

## What's changed and what's your intention?

This is the third dependency-ordered extraction from #26675 for #26611, based on #26906.

- Add raw cursor chunks with schema/provenance metadata and ordered events for query completion, subscription query startup, log-store epoch transitions, idle boundaries, and schema changes.
- Add a persistent query producer that owns the existing `CursorQueryStream` wrapper, preserving its EOF and unfinished-execution cleanup semantics. Add the subscription stream container, metadata-only state, and weak session planning context without a replacement startup path.
- Add query and subscription PostgreSQL response adapters that reuse existing row formatting and subscription projection helpers. FETCH boundaries retain the producer and unread rows; terminal completion or failure releases the source and metadata.
- Model subscription idle separately from arbitrary pending operations. At a schema boundary, drain old-schema rows and clear stale metadata; an empty waiting read can continue, while a nonwaiting read or one that already yielded rows stops before consuming the next query's metadata. `SchemaChanged` precedes `SubscriptionQueryStarted`.
- Treat subscription source errors and unexpected EOF as invalidation, with every subsequent poll returning an error. Query completion instead ends the response stream.
- Register the private module with an explicit unwired-code allowance and expose `to_pg_rows` within the crate. Existing function bodies, execution/scheduling APIs, and cursor ownership routing remain unchanged.

Part of #26611. Extracted from draft PR #26675. Depends on #26906.

## Unit tests

- Channel-backed query wrappers verify raw chunk/schema preservation and normal completion, and that dropping a pending next-item future retains the same query input so polling can resume. These are not real executor tests.
- A gated subscription event coroutine verifies that temporary polls preserve and resume a suspended operation without restarting it; the gate simulates a log-store epoch wait rather than a real notification.
- Query response tests verify unread rows survive successive `begin_fetch` calls, completed streams stay exhausted, and invalid formatting releases the input without returning later chunks.
- Injected subscription events verify snapshot/log-store row projection and hidden seek-key metadata; ordered schema, position, and expiry updates; and preservation of buffered rows across schema boundaries, including a visible-column type change.
- Subscription response tests distinguish idle from arbitrary pending work and verify that source errors or unexpected EOF invalidate the stream and produce errors on repeated polls, including after another `begin_fetch`.

## E2E tests

No new E2E tests are added because this module is not connected to production cursor commands. Real subscription startup, snapshot handling, and interruptible FETCH require the subsequent integration work and its coverage.

## Checklist

- [x] I have written necessary rustdoc comments.
- [x] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/dev/src/ci.md#ci-labels-guide -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->

## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

None. This PR adds unwired persistent cursor-stream infrastructure and does not change user-visible behavior.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added persistent cursor-stream support for query and subscription results across multiple FETCH operations.
  - Preserves unread rows and result ordering between FETCH requests, including query completion, subscription updates, idle periods, and schema changes.
  - Supports subscription snapshots and ongoing results with cursor position and expiry tracking.

- **Bug Fixes**
  - Prevents new cursors from being registered after session shutdown.
  - Reports persistent errors after stream failures or unexpected end-of-stream conditions.
  - Improves handling of executor cancellation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->