### PR TITLE
fix(iceberg): prevent and detect duplicate COW data files on release-3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6859,7 +6859,7 @@ dependencies = [
 [[package]]
 name = "iceberg"
 version = "0.8.0"
-source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=638c02e4f56354f8ce17667a27ef2f794a453653#638c02e4f56354f8ce17667a27ef2f794a453653"
+source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=515177b5317886f01cbbe54f235519430e72e219#515177b5317886f01cbbe54f235519430e72e219"
 dependencies = [
  "anyhow",
  "apache-avro 0.21.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -6918,7 +6918,7 @@ dependencies = [
 [[package]]
 name = "iceberg-catalog-glue"
 version = "0.8.0"
-source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=638c02e4f56354f8ce17667a27ef2f794a453653#638c02e4f56354f8ce17667a27ef2f794a453653"
+source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=515177b5317886f01cbbe54f235519430e72e219#515177b5317886f01cbbe54f235519430e72e219"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6933,7 +6933,7 @@ dependencies = [
 [[package]]
 name = "iceberg-catalog-rest"
 version = "0.8.0"
-source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=638c02e4f56354f8ce17667a27ef2f794a453653#638c02e4f56354f8ce17667a27ef2f794a453653"
+source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=515177b5317886f01cbbe54f235519430e72e219#515177b5317886f01cbbe54f235519430e72e219"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -6955,7 +6955,7 @@ dependencies = [
 [[package]]
 name = "iceberg-compaction-core"
 version = "0.1.0"
-source = "git+https://github.com/nimtable/iceberg-compaction.git?rev=e1696bae2193fe2b4ebb6835f97764a761ede22b#e1696bae2193fe2b4ebb6835f97764a761ede22b"
+source = "git+https://github.com/nimtable/iceberg-compaction.git?rev=68199414368e094af21cd54191c69f2560409288#68199414368e094af21cd54191c69f2560409288"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -6984,7 +6984,7 @@ dependencies = [
 [[package]]
 name = "iceberg-datafusion"
 version = "0.8.0"
-source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=638c02e4f56354f8ce17667a27ef2f794a453653#638c02e4f56354f8ce17667a27ef2f794a453653"
+source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=515177b5317886f01cbbe54f235519430e72e219#515177b5317886f01cbbe54f235519430e72e219"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6955,7 +6955,7 @@ dependencies = [
 [[package]]
 name = "iceberg-compaction-core"
 version = "0.1.0"
-source = "git+https://github.com/nimtable/iceberg-compaction.git?rev=39af10777aac735a7b2ca6e495073c1b42ab85a6#39af10777aac735a7b2ca6e495073c1b42ab85a6"
+source = "git+https://github.com/nimtable/iceberg-compaction.git?rev=52539ebf3f3b75c58eb97174fef3926e3e9fb6d4#52539ebf3f3b75c58eb97174fef3926e3e9fb6d4"
 dependencies = [
  "async-stream",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6955,7 +6955,7 @@ dependencies = [
 [[package]]
 name = "iceberg-compaction-core"
 version = "0.1.0"
-source = "git+https://github.com/nimtable/iceberg-compaction.git?rev=2391256b121b9850c0c4786b00a412b018047582#2391256b121b9850c0c4786b00a412b018047582"
+source = "git+https://github.com/nimtable/iceberg-compaction.git?rev=e1696bae2193fe2b4ebb6835f97764a761ede22b#e1696bae2193fe2b4ebb6835f97764a761ede22b"
 dependencies = [
  "async-stream",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6859,7 +6859,7 @@ dependencies = [
 [[package]]
 name = "iceberg"
 version = "0.8.0"
-source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=515177b5317886f01cbbe54f235519430e72e219#515177b5317886f01cbbe54f235519430e72e219"
+source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=638c02e4f56354f8ce17667a27ef2f794a453653#638c02e4f56354f8ce17667a27ef2f794a453653"
 dependencies = [
  "anyhow",
  "apache-avro 0.21.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -6918,7 +6918,7 @@ dependencies = [
 [[package]]
 name = "iceberg-catalog-glue"
 version = "0.8.0"
-source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=515177b5317886f01cbbe54f235519430e72e219#515177b5317886f01cbbe54f235519430e72e219"
+source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=638c02e4f56354f8ce17667a27ef2f794a453653#638c02e4f56354f8ce17667a27ef2f794a453653"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6933,7 +6933,7 @@ dependencies = [
 [[package]]
 name = "iceberg-catalog-rest"
 version = "0.8.0"
-source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=515177b5317886f01cbbe54f235519430e72e219#515177b5317886f01cbbe54f235519430e72e219"
+source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=638c02e4f56354f8ce17667a27ef2f794a453653#638c02e4f56354f8ce17667a27ef2f794a453653"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -6955,7 +6955,7 @@ dependencies = [
 [[package]]
 name = "iceberg-compaction-core"
 version = "0.1.0"
-source = "git+https://github.com/nimtable/iceberg-compaction.git?rev=68199414368e094af21cd54191c69f2560409288#68199414368e094af21cd54191c69f2560409288"
+source = "git+https://github.com/nimtable/iceberg-compaction.git?rev=39af10777aac735a7b2ca6e495073c1b42ab85a6#39af10777aac735a7b2ca6e495073c1b42ab85a6"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -6984,7 +6984,7 @@ dependencies = [
 [[package]]
 name = "iceberg-datafusion"
 version = "0.8.0"
-source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=515177b5317886f01cbbe54f235519430e72e219#515177b5317886f01cbbe54f235519430e72e219"
+source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=638c02e4f56354f8ce17667a27ef2f794a453653#638c02e4f56354f8ce17667a27ef2f794a453653"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6955,7 +6955,7 @@ dependencies = [
 [[package]]
 name = "iceberg-compaction-core"
 version = "0.1.0"
-source = "git+https://github.com/nimtable/iceberg-compaction.git?rev=52539ebf3f3b75c58eb97174fef3926e3e9fb6d4#52539ebf3f3b75c58eb97174fef3926e3e9fb6d4"
+source = "git+https://github.com/nimtable/iceberg-compaction.git?rev=2391256b121b9850c0c4786b00a412b018047582#2391256b121b9850c0c4786b00a412b018047582"
 dependencies = [
  "async-stream",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -161,14 +161,14 @@ hashbrown0_15 = { package = "hashbrown", version = "0.15", features = [
 ] }
 hytra = "0.1"
 # branch dev_rebase_main_20260303
-iceberg = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "638c02e4f56354f8ce17667a27ef2f794a453653", features = [
+iceberg = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "515177b5317886f01cbbe54f235519430e72e219", features = [
     "storage-s3",
     "storage-gcs",
     "storage-azblob",
     "storage-azdls",
 ] }
-iceberg-catalog-glue = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "638c02e4f56354f8ce17667a27ef2f794a453653" }
-iceberg-catalog-rest = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "638c02e4f56354f8ce17667a27ef2f794a453653" }
+iceberg-catalog-glue = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "515177b5317886f01cbbe54f235519430e72e219" }
+iceberg-catalog-rest = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "515177b5317886f01cbbe54f235519430e72e219" }
 
 adbc_core = { version = "0.23" }
 adbc_snowflake = { version = "0.23", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -161,14 +161,14 @@ hashbrown0_15 = { package = "hashbrown", version = "0.15", features = [
 ] }
 hytra = "0.1"
 # branch dev_rebase_main_20260303
-iceberg = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "515177b5317886f01cbbe54f235519430e72e219", features = [
+iceberg = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "638c02e4f56354f8ce17667a27ef2f794a453653", features = [
     "storage-s3",
     "storage-gcs",
     "storage-azblob",
     "storage-azdls",
 ] }
-iceberg-catalog-glue = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "515177b5317886f01cbbe54f235519430e72e219" }
-iceberg-catalog-rest = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "515177b5317886f01cbbe54f235519430e72e219" }
+iceberg-catalog-glue = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "638c02e4f56354f8ce17667a27ef2f794a453653" }
+iceberg-catalog-rest = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "638c02e4f56354f8ce17667a27ef2f794a453653" }
 
 adbc_core = { version = "0.23" }
 adbc_snowflake = { version = "0.23", default-features = false }

--- a/src/storage/Cargo.toml
+++ b/src/storage/Cargo.toml
@@ -33,7 +33,7 @@ futures = { version = "0.3", default-features = false, features = ["alloc"] }
 futures-async-stream = { workspace = true }
 hex = "0.4"
 iceberg = { workspace = true }
-iceberg-compaction-core = { git = "https://github.com/nimtable/iceberg-compaction.git", rev = "39af10777aac735a7b2ca6e495073c1b42ab85a6" }
+iceberg-compaction-core = { git = "https://github.com/nimtable/iceberg-compaction.git", rev = "52539ebf3f3b75c58eb97174fef3926e3e9fb6d4" }
 itertools = { workspace = true }
 libc = "0.2"
 lz4 = "1.28.0"

--- a/src/storage/Cargo.toml
+++ b/src/storage/Cargo.toml
@@ -33,7 +33,7 @@ futures = { version = "0.3", default-features = false, features = ["alloc"] }
 futures-async-stream = { workspace = true }
 hex = "0.4"
 iceberg = { workspace = true }
-iceberg-compaction-core = { git = "https://github.com/nimtable/iceberg-compaction.git", rev = "52539ebf3f3b75c58eb97174fef3926e3e9fb6d4" }
+iceberg-compaction-core = { git = "https://github.com/nimtable/iceberg-compaction.git", rev = "2391256b121b9850c0c4786b00a412b018047582" }
 itertools = { workspace = true }
 libc = "0.2"
 lz4 = "1.28.0"

--- a/src/storage/Cargo.toml
+++ b/src/storage/Cargo.toml
@@ -33,7 +33,7 @@ futures = { version = "0.3", default-features = false, features = ["alloc"] }
 futures-async-stream = { workspace = true }
 hex = "0.4"
 iceberg = { workspace = true }
-iceberg-compaction-core = { git = "https://github.com/nimtable/iceberg-compaction.git", rev = "68199414368e094af21cd54191c69f2560409288" }
+iceberg-compaction-core = { git = "https://github.com/nimtable/iceberg-compaction.git", rev = "39af10777aac735a7b2ca6e495073c1b42ab85a6" }
 itertools = { workspace = true }
 libc = "0.2"
 lz4 = "1.28.0"

--- a/src/storage/Cargo.toml
+++ b/src/storage/Cargo.toml
@@ -33,7 +33,7 @@ futures = { version = "0.3", default-features = false, features = ["alloc"] }
 futures-async-stream = { workspace = true }
 hex = "0.4"
 iceberg = { workspace = true }
-iceberg-compaction-core = { git = "https://github.com/nimtable/iceberg-compaction.git", rev = "2391256b121b9850c0c4786b00a412b018047582" }
+iceberg-compaction-core = { git = "https://github.com/nimtable/iceberg-compaction.git", rev = "e1696bae2193fe2b4ebb6835f97764a761ede22b" }
 itertools = { workspace = true }
 libc = "0.2"
 lz4 = "1.28.0"

--- a/src/storage/Cargo.toml
+++ b/src/storage/Cargo.toml
@@ -33,7 +33,7 @@ futures = { version = "0.3", default-features = false, features = ["alloc"] }
 futures-async-stream = { workspace = true }
 hex = "0.4"
 iceberg = { workspace = true }
-iceberg-compaction-core = { git = "https://github.com/nimtable/iceberg-compaction.git", rev = "e1696bae2193fe2b4ebb6835f97764a761ede22b" }
+iceberg-compaction-core = { git = "https://github.com/nimtable/iceberg-compaction.git", rev = "68199414368e094af21cd54191c69f2560409288" }
 itertools = { workspace = true }
 libc = "0.2"
 lz4 = "1.28.0"

--- a/src/storage/src/hummock/compactor/iceberg_compaction/iceberg_compactor_runner.rs
+++ b/src/storage/src/hummock/compactor/iceberg_compaction/iceberg_compactor_runner.rs
@@ -17,12 +17,12 @@ use std::fmt::Debug;
 use std::sync::{Arc, LazyLock};
 
 use derive_builder::Builder;
-use iceberg::spec::{DataContentType, DataFile, MAIN_BRANCH};
+use iceberg::spec::{DataContentType, DataFile, MAIN_BRANCH, Snapshot};
 use iceberg::table::Table;
 use iceberg::{Catalog, TableIdent};
 use iceberg_compaction_core::compaction::{
     CommitConsistencyParams, CommitManagerRetryConfig, Compaction, CompactionBuilder,
-    CompactionPlan, CompactionPlanner, CompactionResult, TargetBranchSequenceGuard,
+    CompactionPlan, CompactionPlanner, CompactionResult, TargetBranchSnapshotGuard,
 };
 use iceberg_compaction_core::config::{
     AutoCompactionConfigBuilder, CompactionExecutionConfigBuilder, CompactionPlanningConfig,
@@ -63,8 +63,6 @@ static ICEBERG_COMPACTION_METRICS_REGISTRY: LazyLock<Box<PrometheusMetricsRegist
         ))
     });
 
-const COW_SOURCE_SNAPSHOT_SEQUENCE_NUMBER_PROPERTY: &str =
-    "risingwave.cow.source-snapshot-sequence-number";
 const MAX_DUPLICATE_DATA_FILE_PATH_SAMPLES: usize = 10;
 
 #[derive(Builder, Debug, Clone)]
@@ -152,6 +150,7 @@ impl IcebergCompactionKind {
 #[derive(Debug)]
 struct CowPublishPlan {
     snapshot_id: i64,
+    expected_target_snapshot_id: Option<i64>,
     rewritten_data_file_paths: HashSet<String>,
 }
 
@@ -169,9 +168,13 @@ struct CowPruningStatistics {
 }
 
 impl CowPublishPlan {
-    fn from_compaction_plan(plan: &CompactionPlan) -> Self {
+    fn from_compaction_plan(
+        plan: &CompactionPlan,
+        expected_target_snapshot_id: Option<i64>,
+    ) -> Self {
         Self {
             snapshot_id: plan.snapshot_id,
+            expected_target_snapshot_id,
             rewritten_data_file_paths: plan
                 .file_group
                 .data_files
@@ -211,6 +214,8 @@ pub struct IcebergCompactionPlanRunner {
     compaction_kind: IcebergCompactionKind,
     branch: String,
     compaction_plan: CompactionPlan,
+    /// `main` snapshot observed in the same table metadata used to build `compaction_plan`.
+    planned_main_snapshot_id: Option<i64>,
     pub memory_reservation_bytes: usize,
 }
 
@@ -311,6 +316,7 @@ impl IcebergCompactionPlanRunner {
             compaction_kind,
             branch,
             compaction_plan,
+            planned_main_snapshot_id,
             memory_reservation_bytes,
         } = self;
 
@@ -326,9 +332,9 @@ impl IcebergCompactionPlanRunner {
         // COW publishing must stay bound to the snapshot used for planning. The ingestion branch
         // may advance while the rewrite is running, and publishing that newer branch state without
         // its delete files would make stale or duplicate rows visible on `main`.
-        let cow_publish_plan = compaction_kind
-            .is_copy_on_write()
-            .then(|| CowPublishPlan::from_compaction_plan(&compaction_plan));
+        let cow_publish_plan = compaction_kind.is_copy_on_write().then(|| {
+            CowPublishPlan::from_compaction_plan(&compaction_plan, planned_main_snapshot_id)
+        });
 
         if !compaction_plan.has_files() {
             if let Some(cow_publish_plan) = cow_publish_plan {
@@ -340,7 +346,6 @@ impl IcebergCompactionPlanRunner {
                     task_id,
                     &compaction,
                     &table,
-                    metrics.as_ref(),
                     &branch,
                     &cow_publish_plan,
                     vec![],
@@ -429,7 +434,6 @@ impl IcebergCompactionPlanRunner {
                 task_id,
                 &compaction,
                 &committed_table,
-                metrics.as_ref(),
                 &branch,
                 &cow_publish_plan,
                 data_files,
@@ -531,15 +535,20 @@ fn deduplicate_data_files_by_path(data_files: &mut Vec<DataFile>) -> (usize, Vec
     (duplicate_count, duplicate_path_samples)
 }
 
-fn cow_publish_watermark_covers(
+/// Returns whether the planned target snapshot itself already fences this source snapshot.
+///
+/// Iceberg sequence numbers are table-global. A matching target snapshot whose sequence is at
+/// least the source sequence either is the source snapshot or was committed after it. When their
+/// file sets are also equal, no older task can cross that target snapshot's commit-time CAS.
+fn cow_publish_is_already_fenced(
     source_sequence_number: i64,
-    target_sequence_number_property: Option<&str>,
+    expected_target_snapshot_id: Option<i64>,
+    target_snapshot: Option<&Snapshot>,
 ) -> bool {
-    target_sequence_number_property
-        .and_then(|value| value.parse::<i64>().ok())
-        .is_some_and(|published_sequence_number| {
-            published_sequence_number >= source_sequence_number
-        })
+    target_snapshot.is_some_and(|snapshot| {
+        Some(snapshot.snapshot_id()) == expected_target_snapshot_id
+            && snapshot.sequence_number() >= source_sequence_number
+    })
 }
 
 fn retain_unrewritten_data_files(
@@ -605,7 +614,6 @@ async fn publish_cow_snapshot_to_main(
     task_id: u64,
     compaction: &Compaction,
     table: &Table,
-    metrics: &CompactorMetrics,
     ingestion_branch: &str,
     publish_plan: &CowPublishPlan,
     output_data_files: Vec<DataFile>,
@@ -643,10 +651,6 @@ async fn publish_cow_snapshot_to_main(
         );
     }
     if pruning_statistics.duplicate_data_file_count > 0 {
-        metrics
-            .iceberg_cow_duplicate_data_file_paths
-            .with_label_values(&["source"])
-            .inc_by(pruning_statistics.duplicate_data_file_count as u64);
         tracing::error!(
             iceberg_component = "compaction_worker",
             iceberg_operation = "deduplicate_cow_publish",
@@ -664,10 +668,6 @@ async fn publish_cow_snapshot_to_main(
     let (main_duplicate_data_file_count, main_duplicate_data_file_path_samples) =
         deduplicate_data_files_by_path(&mut main_files);
     if main_duplicate_data_file_count > 0 {
-        metrics
-            .iceberg_cow_duplicate_data_file_paths
-            .with_label_values(&["target"])
-            .inc_by(main_duplicate_data_file_count as u64);
         tracing::error!(
             iceberg_component = "compaction_worker",
             iceberg_operation = "deduplicate_cow_publish_target",
@@ -681,7 +681,7 @@ async fn publish_cow_snapshot_to_main(
     }
     let (added_files, deleted_files) = diff_data_files(published_files, main_files);
 
-    let planned_snapshot_sequence_number = table
+    let planned_snapshot = table
         .metadata()
         .snapshot_by_id(publish_plan.snapshot_id)
         .ok_or_else(|| {
@@ -689,23 +689,21 @@ async fn publish_cow_snapshot_to_main(
                 "No snapshot found with ID {} while publishing COW compaction",
                 publish_plan.snapshot_id
             ))
-        })?
-        .sequence_number();
-    let target_sequence_number_property = table
+        })?;
+    let target_snapshot = table
         .metadata()
         .snapshot_for_ref(MAIN_BRANCH)
-        .and_then(|snapshot| {
-            snapshot
-                .summary()
-                .additional_properties
-                .get(COW_SOURCE_SNAPSHOT_SEQUENCE_NUMBER_PROPERTY)
-        })
-        .map(String::as_str);
+        .map(AsRef::as_ref);
+    // A source snapshot that made no file-level change still needs a durable ordering point. If
+    // the planned target predates the source, fall through and create a metadata-only overwrite;
+    // future tasks can recognize that snapshot by its native sequence number without a custom
+    // snapshot-summary property.
     if added_files.is_empty()
         && deleted_files.is_empty()
-        && cow_publish_watermark_covers(
-            planned_snapshot_sequence_number,
-            target_sequence_number_property,
+        && cow_publish_is_already_fenced(
+            planned_snapshot.sequence_number(),
+            publish_plan.expected_target_snapshot_id,
+            target_snapshot,
         )
     {
         return Ok(());
@@ -715,12 +713,8 @@ async fn publish_cow_snapshot_to_main(
         starting_snapshot_id: publish_plan.snapshot_id,
         use_starting_sequence_number: true,
         basic_schema_id: table.metadata().current_schema().schema_id(),
-        target_branch_sequence_guard: Some(TargetBranchSequenceGuard {
-            snapshot_property: COW_SOURCE_SNAPSHOT_SEQUENCE_NUMBER_PROPERTY.to_owned(),
-            expected_target_snapshot_id: table
-                .metadata()
-                .snapshot_for_ref(MAIN_BRANCH)
-                .map(|snapshot| snapshot.snapshot_id()),
+        target_branch_snapshot_guard: Some(TargetBranchSnapshotGuard {
+            expected_target_snapshot_id: publish_plan.expected_target_snapshot_id,
         }),
     };
     let commit_manager = compaction.build_commit_manager(consistency_params);
@@ -736,7 +730,7 @@ async fn publish_cow_snapshot_to_main(
         iceberg_operation = "publish_cow_snapshot",
         ingestion_branch,
         planned_snapshot_id = publish_plan.snapshot_id,
-        planned_snapshot_sequence_number,
+        planned_snapshot_sequence_number = planned_snapshot.sequence_number(),
         added_file_count,
         deleted_file_count,
         "iceberg_cow_snapshot_published",
@@ -999,6 +993,10 @@ pub async fn create_task_execution(
     let table_schema = table.metadata().current_schema();
     let format_version = table.metadata().format_version();
     let requires_sort = !table.metadata().default_sort_order().fields.is_empty();
+    let planned_main_snapshot_id = table
+        .metadata()
+        .snapshot_for_ref(MAIN_BRANCH)
+        .map(|snapshot| snapshot.snapshot_id());
     let mut runners = Vec::with_capacity(compaction_plans.len());
     for (plan_index, compaction_plan) in compaction_plans.into_iter().enumerate() {
         let memory_estimate = estimate_plan_memory(
@@ -1027,6 +1025,7 @@ pub async fn create_task_execution(
             compaction_kind,
             branch: branch.clone(),
             compaction_plan,
+            planned_main_snapshot_id,
             memory_reservation_bytes,
         });
     }
@@ -1293,6 +1292,7 @@ mod tests {
 
         let publish_plan = CowPublishPlan {
             snapshot_id: 1,
+            expected_target_snapshot_id: None,
             rewritten_data_file_paths: HashSet::from(["data/old.parquet".to_owned()]),
         };
         let compacted_file = test_data_file("data/compacted.parquet");
@@ -1315,12 +1315,30 @@ mod tests {
     }
 
     #[test]
-    fn test_cow_publish_watermark_covers_source_sequence() {
-        assert!(!cow_publish_watermark_covers(10, None));
-        assert!(!cow_publish_watermark_covers(10, Some("invalid")));
-        assert!(!cow_publish_watermark_covers(10, Some("9")));
-        assert!(cow_publish_watermark_covers(10, Some("10")));
-        assert!(cow_publish_watermark_covers(10, Some("11")));
+    fn test_cow_publish_fence_uses_target_snapshot_and_native_sequence() {
+        let target_snapshot = test_snapshot(10, None, "unused.avro".to_owned(), 10);
+
+        assert!(!cow_publish_is_already_fenced(10, None, None));
+        assert!(!cow_publish_is_already_fenced(
+            10,
+            Some(9),
+            Some(&target_snapshot)
+        ));
+        assert!(!cow_publish_is_already_fenced(
+            11,
+            Some(10),
+            Some(&target_snapshot)
+        ));
+        assert!(cow_publish_is_already_fenced(
+            10,
+            Some(10),
+            Some(&target_snapshot)
+        ));
+        assert!(cow_publish_is_already_fenced(
+            9,
+            Some(10),
+            Some(&target_snapshot)
+        ));
     }
 
     #[test]

--- a/src/storage/src/hummock/compactor/iceberg_compaction/iceberg_compactor_runner.rs
+++ b/src/storage/src/hummock/compactor/iceberg_compaction/iceberg_compactor_runner.rs
@@ -324,6 +324,11 @@ impl IcebergCompactionPlanRunner {
             .is_copy_on_write()
             .then(|| CowPublishPlan::from_compaction_plan(&compaction_plan));
 
+        // A data file that appears twice in the plan would be read twice by the rewrite and its
+        // rows doubled in the output, after which the duplicate can no longer be detected by path.
+        // Fail before touching the table so the snapshot stays intact for manual repair.
+        ensure_unique_compaction_plan_data_files(&compaction_plan, &table_ident)?;
+
         if !compaction_plan.has_files() {
             if let Some(cow_publish_plan) = cow_publish_plan {
                 let table = catalog
@@ -474,16 +479,55 @@ async fn live_data_files_for_snapshot(
     Ok(data_files)
 }
 
-async fn live_data_files_for_branch(table: &Table, branch: &str) -> HummockResult<Vec<DataFile>> {
-    let Some(snapshot_id) = table
+fn branch_snapshot_id(table: &Table, branch: &str) -> Option<i64> {
+    table
         .metadata()
         .snapshot_for_ref(branch)
         .map(|snapshot| snapshot.snapshot_id())
-    else {
+}
+
+/// Loads the live data files of `main` before a COW publish.
+///
+/// Duplicate paths on `main` are reported but do not fail the task: the publish set has already
+/// been verified unique, so the following overwrite can only repair `main` (when the duplicated
+/// file was rewritten) or leave it unchanged. Failing here would pin `main` to the corrupted
+/// snapshot forever, because meta reschedules a failed task immediately and nothing else rewrites
+/// the branch.
+async fn load_cow_target_data_files(
+    task_id: u64,
+    table: &Table,
+    ingestion_branch: &str,
+    publish_plan: &CowPublishPlan,
+) -> HummockResult<Vec<DataFile>> {
+    let Some(main_snapshot_id) = branch_snapshot_id(table, MAIN_BRANCH) else {
         return Ok(vec![]);
     };
+    let main_files = live_data_files_for_snapshot(table, main_snapshot_id).await?;
 
-    live_data_files_for_snapshot(table, snapshot_id).await
+    let duplicates = duplicate_data_file_paths(main_files.iter().map(|file| file.file_path()));
+    if !duplicates.is_empty() {
+        let report = DuplicateDataFilePathReport::new(
+            &duplicates,
+            "COW target snapshot",
+            table.identifier(),
+            main_snapshot_id,
+        );
+        tracing::error!(
+            iceberg_component = "compaction_worker",
+            iceberg_operation = "publish_cow_snapshot",
+            task_id,
+            table = %table.identifier(),
+            ingestion_branch,
+            planned_snapshot_id = publish_plan.snapshot_id,
+            main_snapshot_id,
+            duplicated_path_count = report.duplicated_path_count,
+            duplicate_entry_count = report.duplicate_entry_count,
+            duplicate_paths = ?report.sample_paths,
+            "{report}; publishing anyway so the overwrite can repair main",
+        );
+    }
+
+    Ok(main_files)
 }
 
 async fn build_cow_publish_data_files(
@@ -493,30 +537,133 @@ async fn build_cow_publish_data_files(
 ) -> HummockResult<(Vec<DataFile>, CowPruningStatistics)> {
     let mut planned_snapshot_files =
         live_data_files_for_snapshot(table, publish_plan.snapshot_id).await?;
-    ensure_unique_cow_data_file_paths(&planned_snapshot_files, "source")?;
+    ensure_unique_data_file_paths(
+        &planned_snapshot_files,
+        "COW source snapshot",
+        table.identifier(),
+        publish_plan.snapshot_id,
+    )?;
     let pruning_statistics = retain_unrewritten_data_files(
         &mut planned_snapshot_files,
         &publish_plan.rewritten_data_file_paths,
     );
     planned_snapshot_files.extend(output_data_files);
-    ensure_unique_cow_data_file_paths(&planned_snapshot_files, "publish")?;
+    ensure_unique_data_file_paths(
+        &planned_snapshot_files,
+        "COW publish set",
+        table.identifier(),
+        publish_plan.snapshot_id,
+    )?;
     Ok((planned_snapshot_files, pruning_statistics))
 }
 
-fn ensure_unique_cow_data_file_paths(
-    data_files: &[DataFile],
-    snapshot_role: &str,
-) -> HummockResult<()> {
-    let mut seen_paths = HashSet::with_capacity(data_files.len());
-    for file in data_files {
-        if !seen_paths.insert(file.file_path()) {
-            return Err(HummockError::compaction_executor(anyhow::anyhow!(
-                "Duplicate data file path '{}' found in COW {snapshot_role} snapshot",
-                file.file_path()
-            )));
+/// Maximum number of duplicated paths spelled out in one error/log line.
+const MAX_REPORTED_DUPLICATE_DATA_FILE_PATHS: usize = 8;
+
+/// Returns every data file path that occurs more than once, with its occurrence count, sorted by
+/// path so reports are deterministic.
+fn duplicate_data_file_paths<'a>(
+    paths: impl IntoIterator<Item = &'a str>,
+) -> Vec<(&'a str, usize)> {
+    let mut occurrences: BTreeMap<&str, usize> = BTreeMap::new();
+    for path in paths {
+        *occurrences.entry(path).or_default() += 1;
+    }
+    occurrences
+        .into_iter()
+        .filter(|(_, count)| *count > 1)
+        .collect()
+}
+
+/// Summary of duplicated data file paths carrying enough context (table, snapshot, counts) for
+/// oncall to locate the corrupted snapshot from a single log line.
+struct DuplicateDataFilePathReport {
+    role: String,
+    table: TableIdent,
+    snapshot_id: i64,
+    /// Number of distinct paths that appear more than once.
+    duplicated_path_count: usize,
+    /// Number of surplus manifest entries across all duplicated paths.
+    duplicate_entry_count: usize,
+    /// Up to [`MAX_REPORTED_DUPLICATE_DATA_FILE_PATHS`] entries formatted as `path (xN)`.
+    sample_paths: Vec<String>,
+}
+
+impl DuplicateDataFilePathReport {
+    fn new(duplicates: &[(&str, usize)], role: &str, table: &TableIdent, snapshot_id: i64) -> Self {
+        Self {
+            role: role.to_owned(),
+            table: table.clone(),
+            snapshot_id,
+            duplicated_path_count: duplicates.len(),
+            duplicate_entry_count: duplicates
+                .iter()
+                .map(|(_, count)| count.saturating_sub(1))
+                .sum(),
+            sample_paths: duplicates
+                .iter()
+                .take(MAX_REPORTED_DUPLICATE_DATA_FILE_PATHS)
+                .map(|(path, count)| format!("{path} (x{count})"))
+                .collect(),
         }
     }
-    Ok(())
+}
+
+impl std::fmt::Display for DuplicateDataFilePathReport {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "Duplicate data file paths found in {}: table={}, snapshot_id={}, duplicated_path_count={}, duplicate_entry_count={}, paths=[{}",
+            self.role,
+            self.table,
+            self.snapshot_id,
+            self.duplicated_path_count,
+            self.duplicate_entry_count,
+            self.sample_paths.join(", "),
+        )?;
+        let omitted = self
+            .duplicated_path_count
+            .saturating_sub(self.sample_paths.len());
+        if omitted > 0 {
+            write!(f, ", ... {omitted} more")?;
+        }
+        write!(f, "]")
+    }
+}
+
+fn ensure_unique_data_file_paths(
+    data_files: &[DataFile],
+    role: &str,
+    table: &TableIdent,
+    snapshot_id: i64,
+) -> HummockResult<()> {
+    let duplicates = duplicate_data_file_paths(data_files.iter().map(|file| file.file_path()));
+    if duplicates.is_empty() {
+        return Ok(());
+    }
+    Err(HummockError::compaction_executor(anyhow::anyhow!(
+        "{}",
+        DuplicateDataFilePathReport::new(&duplicates, role, table, snapshot_id)
+    )))
+}
+
+fn ensure_unique_compaction_plan_data_files(
+    plan: &CompactionPlan,
+    table: &TableIdent,
+) -> HummockResult<()> {
+    let duplicates = duplicate_data_file_paths(
+        plan.file_group
+            .data_files
+            .iter()
+            .map(|task| task.data_file_path.as_str()),
+    );
+    if duplicates.is_empty() {
+        return Ok(());
+    }
+    Err(HummockError::compaction_executor(anyhow::anyhow!(
+        "{}",
+        DuplicateDataFilePathReport::new(&duplicates, "compaction plan", table, plan.snapshot_id)
+    )))
 }
 
 fn retain_unrewritten_data_files(
@@ -619,8 +766,8 @@ async fn publish_cow_snapshot_to_main(
         );
     }
 
-    let main_files = live_data_files_for_branch(table, MAIN_BRANCH).await?;
-    ensure_unique_cow_data_file_paths(&main_files, "target")?;
+    let main_files =
+        load_cow_target_data_files(task_id, table, ingestion_branch, publish_plan).await?;
     let (added_files, deleted_files) = diff_data_files(published_files, main_files);
 
     if added_files.is_empty() && deleted_files.is_empty() {
@@ -958,6 +1105,7 @@ mod tests {
 
     use iceberg::NamespaceIdent;
     use iceberg::io::FileIOBuilder;
+    use iceberg::scan::FileScanTask;
     use iceberg::spec::{
         DataFileBuilder, DataFileFormat, FormatVersion, ManifestListWriter, ManifestWriterBuilder,
         NestedField, Operation, PrimitiveType, Schema, Snapshot, SnapshotReference,
@@ -993,6 +1141,29 @@ mod tests {
             .file_size_in_bytes(1)
             .build()
             .unwrap()
+    }
+
+    fn test_data_scan_task(schema: Arc<Schema>, path: &str) -> FileScanTask {
+        FileScanTask {
+            file_size_in_bytes: 1,
+            start: 0,
+            length: 1,
+            record_count: Some(1),
+            data_file_path: path.to_owned(),
+            referenced_data_file: None,
+            data_file_content: DataContentType::Data,
+            data_file_format: DataFileFormat::Parquet,
+            schema,
+            project_field_ids: vec![],
+            predicate: None,
+            deletes: vec![],
+            sequence_number: 0,
+            equality_ids: None,
+            partition: None,
+            partition_spec: None,
+            name_mapping: None,
+            case_sensitive: true,
+        }
     }
 
     fn test_equality_delete_file(path: &str) -> DataFile {
@@ -1188,9 +1359,12 @@ mod tests {
 
         assert_eq!(
             sorted_file_paths(
-                &live_data_files_for_branch(&table, "ingestion")
-                    .await
-                    .unwrap()
+                &live_data_files_for_snapshot(
+                    &table,
+                    branch_snapshot_id(&table, "ingestion").unwrap()
+                )
+                .await
+                .unwrap()
             ),
             vec![
                 "data/clean.parquet",
@@ -1218,13 +1392,146 @@ mod tests {
 
     #[test]
     fn test_cow_publish_rejects_duplicate_data_file_paths() {
+        let table_ident = test_table().identifier().clone();
         let duplicate_file = test_data_file("data/duplicate.parquet");
-        let error =
-            ensure_unique_cow_data_file_paths(&[duplicate_file.clone(), duplicate_file], "source")
-                .unwrap_err();
+        let files = vec![
+            duplicate_file.clone(),
+            test_data_file("data/clean.parquet"),
+            duplicate_file.clone(),
+            duplicate_file,
+        ];
+        let error = ensure_unique_data_file_paths(&files, "COW source snapshot", &table_ident, 42)
+            .unwrap_err();
 
-        assert!(error.to_string().contains("data/duplicate.parquet"));
-        assert!(error.to_string().contains("COW source snapshot"));
+        let message = error.to_report_string();
+        assert!(message.contains("COW source snapshot"), "{message}");
+        assert!(
+            message.contains(&format!("table={table_ident}")),
+            "{message}"
+        );
+        assert!(message.contains("snapshot_id=42"), "{message}");
+        assert!(message.contains("duplicated_path_count=1"), "{message}");
+        assert!(message.contains("duplicate_entry_count=2"), "{message}");
+        assert!(message.contains("data/duplicate.parquet (x3)"), "{message}");
+        assert!(!message.contains("data/clean.parquet"), "{message}");
+
+        assert!(
+            ensure_unique_data_file_paths(&files[..2], "COW source snapshot", &table_ident, 42)
+                .is_ok()
+        );
+    }
+
+    #[test]
+    fn test_duplicate_data_file_path_report_truncates_paths() {
+        let paths = (0..MAX_REPORTED_DUPLICATE_DATA_FILE_PATHS + 2)
+            .map(|index| format!("data/dup-{index:02}.parquet"))
+            .collect::<Vec<_>>();
+        let files = paths
+            .iter()
+            .flat_map(|path| [test_data_file(path), test_data_file(path)])
+            .collect::<Vec<_>>();
+        let duplicates = duplicate_data_file_paths(files.iter().map(|file| file.file_path()));
+        assert_eq!(duplicates.len(), paths.len());
+        assert!(duplicates.iter().all(|(_, count)| *count == 2));
+
+        let report = DuplicateDataFilePathReport::new(
+            &duplicates,
+            "COW target snapshot",
+            test_table().identifier(),
+            7,
+        )
+        .to_string();
+        assert!(report.contains("duplicated_path_count=10"), "{report}");
+        assert!(report.contains("duplicate_entry_count=10"), "{report}");
+        assert!(report.contains("data/dup-07.parquet (x2)"), "{report}");
+        assert!(!report.contains("data/dup-08.parquet"), "{report}");
+        assert!(report.contains("... 2 more]"), "{report}");
+    }
+
+    #[test]
+    fn test_compaction_plan_rejects_duplicate_data_file_paths() {
+        let table = test_table();
+        let schema = table.metadata().current_schema().clone();
+        let duplicate_task = test_data_scan_task(schema.clone(), "data/duplicate.parquet");
+        let clean_task = test_data_scan_task(schema, "data/clean.parquet");
+
+        let clean_plan = CompactionPlan::new(
+            FileGroup::new(vec![clean_task.clone(), duplicate_task.clone()]),
+            "ingestion",
+            11,
+        );
+        assert!(ensure_unique_compaction_plan_data_files(&clean_plan, table.identifier()).is_ok());
+
+        let duplicate_plan = CompactionPlan::new(
+            FileGroup::new(vec![duplicate_task.clone(), clean_task, duplicate_task]),
+            "ingestion",
+            11,
+        );
+        let message = ensure_unique_compaction_plan_data_files(&duplicate_plan, table.identifier())
+            .unwrap_err()
+            .to_report_string();
+        assert!(message.contains("compaction plan"), "{message}");
+        assert!(message.contains("snapshot_id=11"), "{message}");
+        assert!(message.contains("data/duplicate.parquet (x2)"), "{message}");
+    }
+
+    #[cfg_attr(madsim, ignore = "requires Iceberg's native Tokio runtime")]
+    #[tokio::test]
+    async fn test_cow_target_duplicates_are_reported_but_not_fatal() {
+        let table = test_table();
+        let duplicate_file = test_data_file("data/duplicate.parquet");
+        let clean_file = test_data_file("data/clean.parquet");
+        let main_manifest_list = write_snapshot_manifests(
+            &table,
+            1,
+            None,
+            vec![duplicate_file.clone(), clean_file, duplicate_file],
+            vec![],
+        )
+        .await;
+        let base_timestamp_ms = table.metadata().last_updated_ms();
+        let metadata = table
+            .metadata()
+            .clone()
+            .into_builder(None)
+            .add_snapshot(test_snapshot(
+                1,
+                None,
+                main_manifest_list,
+                base_timestamp_ms + 1,
+            ))
+            .unwrap()
+            .set_ref(MAIN_BRANCH, test_snapshot_ref(1))
+            .unwrap()
+            .build()
+            .unwrap()
+            .metadata;
+        let table = Table::builder()
+            .identifier(table.identifier().clone())
+            .file_io(table.file_io().clone())
+            .metadata(metadata)
+            .build()
+            .unwrap();
+        let publish_plan = CowPublishPlan {
+            snapshot_id: 1,
+            rewritten_data_file_paths: HashSet::new(),
+        };
+
+        let main_files = load_cow_target_data_files(1, &table, "ingestion", &publish_plan)
+            .await
+            .unwrap();
+        assert_eq!(
+            sorted_file_paths(&main_files),
+            vec![
+                "data/clean.parquet",
+                "data/duplicate.parquet",
+                "data/duplicate.parquet",
+            ]
+        );
+        assert_eq!(
+            duplicate_data_file_paths(main_files.iter().map(|file| file.file_path())),
+            vec![("data/duplicate.parquet", 2)]
+        );
     }
 
     #[test]

--- a/src/storage/src/hummock/compactor/iceberg_compaction/iceberg_compactor_runner.rs
+++ b/src/storage/src/hummock/compactor/iceberg_compaction/iceberg_compactor_runner.rs
@@ -17,12 +17,12 @@ use std::fmt::Debug;
 use std::sync::{Arc, LazyLock};
 
 use derive_builder::Builder;
-use iceberg::spec::{DataContentType, DataFile, MAIN_BRANCH, Snapshot};
+use iceberg::spec::{DataContentType, DataFile, MAIN_BRANCH};
 use iceberg::table::Table;
 use iceberg::{Catalog, TableIdent};
 use iceberg_compaction_core::compaction::{
     CommitConsistencyParams, CommitManagerRetryConfig, Compaction, CompactionBuilder,
-    CompactionPlan, CompactionPlanner, CompactionResult, TargetBranchSnapshotGuard,
+    CompactionPlan, CompactionPlanner, CompactionResult,
 };
 use iceberg_compaction_core::config::{
     AutoCompactionConfigBuilder, CompactionExecutionConfigBuilder, CompactionPlanningConfig,
@@ -62,8 +62,6 @@ static ICEBERG_COMPACTION_METRICS_REGISTRY: LazyLock<Box<PrometheusMetricsRegist
             GLOBAL_METRICS_REGISTRY.clone(),
         ))
     });
-
-const MAX_DUPLICATE_DATA_FILE_PATH_SAMPLES: usize = 10;
 
 #[derive(Builder, Debug, Clone)]
 pub struct IcebergCompactorRunnerConfig {
@@ -150,7 +148,6 @@ impl IcebergCompactionKind {
 #[derive(Debug)]
 struct CowPublishPlan {
     snapshot_id: i64,
-    expected_target_snapshot_id: Option<i64>,
     rewritten_data_file_paths: HashSet<String>,
 }
 
@@ -163,18 +160,12 @@ struct CowPruningStatistics {
     pruned_data_file_count: usize,
     pruned_data_file_size_bytes: u64,
     missing_rewrite_data_file_count: usize,
-    duplicate_data_file_count: usize,
-    duplicate_data_file_path_samples: Vec<String>,
 }
 
 impl CowPublishPlan {
-    fn from_compaction_plan(
-        plan: &CompactionPlan,
-        expected_target_snapshot_id: Option<i64>,
-    ) -> Self {
+    fn from_compaction_plan(plan: &CompactionPlan) -> Self {
         Self {
             snapshot_id: plan.snapshot_id,
-            expected_target_snapshot_id,
             rewritten_data_file_paths: plan
                 .file_group
                 .data_files
@@ -214,8 +205,6 @@ pub struct IcebergCompactionPlanRunner {
     compaction_kind: IcebergCompactionKind,
     branch: String,
     compaction_plan: CompactionPlan,
-    /// `main` snapshot observed in the same table metadata used to build `compaction_plan`.
-    planned_main_snapshot_id: Option<i64>,
     pub memory_reservation_bytes: usize,
 }
 
@@ -316,7 +305,6 @@ impl IcebergCompactionPlanRunner {
             compaction_kind,
             branch,
             compaction_plan,
-            planned_main_snapshot_id,
             memory_reservation_bytes,
         } = self;
 
@@ -332,9 +320,9 @@ impl IcebergCompactionPlanRunner {
         // COW publishing must stay bound to the snapshot used for planning. The ingestion branch
         // may advance while the rewrite is running, and publishing that newer branch state without
         // its delete files would make stale or duplicate rows visible on `main`.
-        let cow_publish_plan = compaction_kind.is_copy_on_write().then(|| {
-            CowPublishPlan::from_compaction_plan(&compaction_plan, planned_main_snapshot_id)
-        });
+        let cow_publish_plan = compaction_kind
+            .is_copy_on_write()
+            .then(|| CowPublishPlan::from_compaction_plan(&compaction_plan));
 
         if !compaction_plan.has_files() {
             if let Some(cow_publish_plan) = cow_publish_plan {
@@ -505,50 +493,30 @@ async fn build_cow_publish_data_files(
 ) -> HummockResult<(Vec<DataFile>, CowPruningStatistics)> {
     let mut planned_snapshot_files =
         live_data_files_for_snapshot(table, publish_plan.snapshot_id).await?;
-    let mut pruning_statistics = retain_unrewritten_data_files(
+    ensure_unique_cow_data_file_paths(&planned_snapshot_files, "source")?;
+    let pruning_statistics = retain_unrewritten_data_files(
         &mut planned_snapshot_files,
         &publish_plan.rewritten_data_file_paths,
     );
     planned_snapshot_files.extend(output_data_files);
-    (
-        pruning_statistics.duplicate_data_file_count,
-        pruning_statistics.duplicate_data_file_path_samples,
-    ) = deduplicate_data_files_by_path(&mut planned_snapshot_files);
+    ensure_unique_cow_data_file_paths(&planned_snapshot_files, "publish")?;
     Ok((planned_snapshot_files, pruning_statistics))
 }
 
-fn deduplicate_data_files_by_path(data_files: &mut Vec<DataFile>) -> (usize, Vec<String>) {
+fn ensure_unique_cow_data_file_paths(
+    data_files: &[DataFile],
+    snapshot_role: &str,
+) -> HummockResult<()> {
     let mut seen_paths = HashSet::with_capacity(data_files.len());
-    let mut duplicate_count = 0;
-    let mut duplicate_path_samples = Vec::new();
-    data_files.retain(|file| {
-        if seen_paths.insert(file.file_path().to_owned()) {
-            true
-        } else {
-            duplicate_count += 1;
-            if duplicate_path_samples.len() < MAX_DUPLICATE_DATA_FILE_PATH_SAMPLES {
-                duplicate_path_samples.push(file.file_path().to_owned());
-            }
-            false
+    for file in data_files {
+        if !seen_paths.insert(file.file_path()) {
+            return Err(HummockError::compaction_executor(anyhow::anyhow!(
+                "Duplicate data file path '{}' found in COW {snapshot_role} snapshot",
+                file.file_path()
+            )));
         }
-    });
-    (duplicate_count, duplicate_path_samples)
-}
-
-/// Returns whether the planned target snapshot itself already fences this source snapshot.
-///
-/// Iceberg sequence numbers are table-global. A matching target snapshot whose sequence is at
-/// least the source sequence either is the source snapshot or was committed after it. When their
-/// file sets are also equal, no older task can cross that target snapshot's commit-time CAS.
-fn cow_publish_is_already_fenced(
-    source_sequence_number: i64,
-    expected_target_snapshot_id: Option<i64>,
-    target_snapshot: Option<&Snapshot>,
-) -> bool {
-    target_snapshot.is_some_and(|snapshot| {
-        Some(snapshot.snapshot_id()) == expected_target_snapshot_id
-            && snapshot.sequence_number() >= source_sequence_number
-    })
+    }
+    Ok(())
 }
 
 fn retain_unrewritten_data_files(
@@ -650,62 +618,12 @@ async fn publish_cow_snapshot_to_main(
             "COW rewrite paths were missing from the planned snapshot",
         );
     }
-    if pruning_statistics.duplicate_data_file_count > 0 {
-        tracing::error!(
-            iceberg_component = "compaction_worker",
-            iceberg_operation = "deduplicate_cow_publish",
-            task_id,
-            table = %table.identifier(),
-            ingestion_branch,
-            planned_snapshot_id = publish_plan.snapshot_id,
-            duplicate_data_file_count = pruning_statistics.duplicate_data_file_count,
-            duplicate_data_file_path_samples = ?pruning_statistics.duplicate_data_file_path_samples,
-            "Duplicate data file paths found while building COW publish snapshot",
-        );
-    }
 
-    let mut main_files = live_data_files_for_branch(table, MAIN_BRANCH).await?;
-    let (main_duplicate_data_file_count, main_duplicate_data_file_path_samples) =
-        deduplicate_data_files_by_path(&mut main_files);
-    if main_duplicate_data_file_count > 0 {
-        tracing::error!(
-            iceberg_component = "compaction_worker",
-            iceberg_operation = "deduplicate_cow_publish_target",
-            task_id,
-            table = %table.identifier(),
-            target_branch = MAIN_BRANCH,
-            main_duplicate_data_file_count,
-            main_duplicate_data_file_path_samples = ?main_duplicate_data_file_path_samples,
-            "Duplicate data file paths found in COW publish target snapshot",
-        );
-    }
+    let main_files = live_data_files_for_branch(table, MAIN_BRANCH).await?;
+    ensure_unique_cow_data_file_paths(&main_files, "target")?;
     let (added_files, deleted_files) = diff_data_files(published_files, main_files);
 
-    let planned_snapshot = table
-        .metadata()
-        .snapshot_by_id(publish_plan.snapshot_id)
-        .ok_or_else(|| {
-            HummockError::compaction_executor(anyhow::anyhow!(
-                "No snapshot found with ID {} while publishing COW compaction",
-                publish_plan.snapshot_id
-            ))
-        })?;
-    let target_snapshot = table
-        .metadata()
-        .snapshot_for_ref(MAIN_BRANCH)
-        .map(AsRef::as_ref);
-    // A source snapshot that made no file-level change still needs a durable ordering point. If
-    // the planned target predates the source, fall through and create a metadata-only overwrite;
-    // future tasks can recognize that snapshot by its native sequence number without a custom
-    // snapshot-summary property.
-    if added_files.is_empty()
-        && deleted_files.is_empty()
-        && cow_publish_is_already_fenced(
-            planned_snapshot.sequence_number(),
-            publish_plan.expected_target_snapshot_id,
-            target_snapshot,
-        )
-    {
+    if added_files.is_empty() && deleted_files.is_empty() {
         return Ok(());
     }
 
@@ -713,9 +631,6 @@ async fn publish_cow_snapshot_to_main(
         starting_snapshot_id: publish_plan.snapshot_id,
         use_starting_sequence_number: true,
         basic_schema_id: table.metadata().current_schema().schema_id(),
-        target_branch_snapshot_guard: Some(TargetBranchSnapshotGuard {
-            expected_target_snapshot_id: publish_plan.expected_target_snapshot_id,
-        }),
     };
     let commit_manager = compaction.build_commit_manager(consistency_params);
     let added_file_count = added_files.len();
@@ -730,7 +645,6 @@ async fn publish_cow_snapshot_to_main(
         iceberg_operation = "publish_cow_snapshot",
         ingestion_branch,
         planned_snapshot_id = publish_plan.snapshot_id,
-        planned_snapshot_sequence_number = planned_snapshot.sequence_number(),
         added_file_count,
         deleted_file_count,
         "iceberg_cow_snapshot_published",
@@ -993,10 +907,6 @@ pub async fn create_task_execution(
     let table_schema = table.metadata().current_schema();
     let format_version = table.metadata().format_version();
     let requires_sort = !table.metadata().default_sort_order().fields.is_empty();
-    let planned_main_snapshot_id = table
-        .metadata()
-        .snapshot_for_ref(MAIN_BRANCH)
-        .map(|snapshot| snapshot.snapshot_id());
     let mut runners = Vec::with_capacity(compaction_plans.len());
     for (plan_index, compaction_plan) in compaction_plans.into_iter().enumerate() {
         let memory_estimate = estimate_plan_memory(
@@ -1025,7 +935,6 @@ pub async fn create_task_execution(
             compaction_kind,
             branch: branch.clone(),
             compaction_plan,
-            planned_main_snapshot_id,
             memory_reservation_bytes,
         });
     }
@@ -1234,7 +1143,7 @@ mod tests {
             &table,
             1,
             None,
-            vec![old_file.clone(), clean_file.clone(), clean_file.clone()],
+            vec![old_file.clone(), clean_file.clone()],
             vec![],
         )
         .await;
@@ -1292,14 +1201,12 @@ mod tests {
 
         let publish_plan = CowPublishPlan {
             snapshot_id: 1,
-            expected_target_snapshot_id: None,
             rewritten_data_file_paths: HashSet::from(["data/old.parquet".to_owned()]),
         };
-        let compacted_file = test_data_file("data/compacted.parquet");
-        let (published_files, statistics) = build_cow_publish_data_files(
+        let (published_files, _) = build_cow_publish_data_files(
             &table,
             &publish_plan,
-            vec![compacted_file.clone(), compacted_file],
+            vec![test_data_file("data/compacted.parquet")],
         )
         .await
         .unwrap();
@@ -1307,38 +1214,17 @@ mod tests {
             sorted_file_paths(&published_files),
             vec!["data/clean.parquet", "data/compacted.parquet"]
         );
-        assert_eq!(statistics.duplicate_data_file_count, 2);
-        assert_eq!(
-            statistics.duplicate_data_file_path_samples,
-            vec!["data/clean.parquet", "data/compacted.parquet"]
-        );
     }
 
     #[test]
-    fn test_cow_publish_fence_uses_target_snapshot_and_native_sequence() {
-        let target_snapshot = test_snapshot(10, None, "unused.avro".to_owned(), 10);
+    fn test_cow_publish_rejects_duplicate_data_file_paths() {
+        let duplicate_file = test_data_file("data/duplicate.parquet");
+        let error =
+            ensure_unique_cow_data_file_paths(&[duplicate_file.clone(), duplicate_file], "source")
+                .unwrap_err();
 
-        assert!(!cow_publish_is_already_fenced(10, None, None));
-        assert!(!cow_publish_is_already_fenced(
-            10,
-            Some(9),
-            Some(&target_snapshot)
-        ));
-        assert!(!cow_publish_is_already_fenced(
-            11,
-            Some(10),
-            Some(&target_snapshot)
-        ));
-        assert!(cow_publish_is_already_fenced(
-            10,
-            Some(10),
-            Some(&target_snapshot)
-        ));
-        assert!(cow_publish_is_already_fenced(
-            9,
-            Some(10),
-            Some(&target_snapshot)
-        ));
+        assert!(error.to_string().contains("data/duplicate.parquet"));
+        assert!(error.to_string().contains("COW source snapshot"));
     }
 
     #[test]

--- a/src/storage/src/hummock/compactor/iceberg_compaction/iceberg_compactor_runner.rs
+++ b/src/storage/src/hummock/compactor/iceberg_compaction/iceberg_compactor_runner.rs
@@ -22,7 +22,7 @@ use iceberg::table::Table;
 use iceberg::{Catalog, TableIdent};
 use iceberg_compaction_core::compaction::{
     CommitConsistencyParams, CommitManagerRetryConfig, Compaction, CompactionBuilder,
-    CompactionPlan, CompactionPlanner, CompactionResult,
+    CompactionPlan, CompactionPlanner, CompactionResult, TargetBranchSequenceGuard,
 };
 use iceberg_compaction_core::config::{
     AutoCompactionConfigBuilder, CompactionExecutionConfigBuilder, CompactionPlanningConfig,
@@ -62,6 +62,10 @@ static ICEBERG_COMPACTION_METRICS_REGISTRY: LazyLock<Box<PrometheusMetricsRegist
             GLOBAL_METRICS_REGISTRY.clone(),
         ))
     });
+
+const COW_SOURCE_SNAPSHOT_SEQUENCE_NUMBER_PROPERTY: &str =
+    "risingwave.cow.source-snapshot-sequence-number";
+const MAX_DUPLICATE_DATA_FILE_PATH_SAMPLES: usize = 10;
 
 #[derive(Builder, Debug, Clone)]
 pub struct IcebergCompactorRunnerConfig {
@@ -160,6 +164,8 @@ struct CowPruningStatistics {
     pruned_data_file_count: usize,
     pruned_data_file_size_bytes: u64,
     missing_rewrite_data_file_count: usize,
+    duplicate_data_file_count: usize,
+    duplicate_data_file_path_samples: Vec<String>,
 }
 
 impl CowPublishPlan {
@@ -334,6 +340,7 @@ impl IcebergCompactionPlanRunner {
                     task_id,
                     &compaction,
                     &table,
+                    metrics.as_ref(),
                     &branch,
                     &cow_publish_plan,
                     vec![],
@@ -422,6 +429,7 @@ impl IcebergCompactionPlanRunner {
                 task_id,
                 &compaction,
                 &committed_table,
+                metrics.as_ref(),
                 &branch,
                 &cow_publish_plan,
                 data_files,
@@ -493,12 +501,34 @@ async fn build_cow_publish_data_files(
 ) -> HummockResult<(Vec<DataFile>, CowPruningStatistics)> {
     let mut planned_snapshot_files =
         live_data_files_for_snapshot(table, publish_plan.snapshot_id).await?;
-    let pruning_statistics = retain_unrewritten_data_files(
+    let mut pruning_statistics = retain_unrewritten_data_files(
         &mut planned_snapshot_files,
         &publish_plan.rewritten_data_file_paths,
     );
     planned_snapshot_files.extend(output_data_files);
+    (
+        pruning_statistics.duplicate_data_file_count,
+        pruning_statistics.duplicate_data_file_path_samples,
+    ) = deduplicate_data_files_by_path(&mut planned_snapshot_files);
     Ok((planned_snapshot_files, pruning_statistics))
+}
+
+fn deduplicate_data_files_by_path(data_files: &mut Vec<DataFile>) -> (usize, Vec<String>) {
+    let mut seen_paths = HashSet::with_capacity(data_files.len());
+    let mut duplicate_count = 0;
+    let mut duplicate_path_samples = Vec::new();
+    data_files.retain(|file| {
+        if seen_paths.insert(file.file_path().to_owned()) {
+            true
+        } else {
+            duplicate_count += 1;
+            if duplicate_path_samples.len() < MAX_DUPLICATE_DATA_FILE_PATH_SAMPLES {
+                duplicate_path_samples.push(file.file_path().to_owned());
+            }
+            false
+        }
+    });
+    (duplicate_count, duplicate_path_samples)
 }
 
 fn retain_unrewritten_data_files(
@@ -564,6 +594,7 @@ async fn publish_cow_snapshot_to_main(
     task_id: u64,
     compaction: &Compaction,
     table: &Table,
+    metrics: &CompactorMetrics,
     ingestion_branch: &str,
     publish_plan: &CowPublishPlan,
     output_data_files: Vec<DataFile>,
@@ -600,8 +631,43 @@ async fn publish_cow_snapshot_to_main(
             "COW rewrite paths were missing from the planned snapshot",
         );
     }
+    if pruning_statistics.duplicate_data_file_count > 0 {
+        metrics
+            .iceberg_cow_duplicate_data_file_paths
+            .with_label_values(&["source"])
+            .inc_by(pruning_statistics.duplicate_data_file_count as u64);
+        tracing::error!(
+            iceberg_component = "compaction_worker",
+            iceberg_operation = "deduplicate_cow_publish",
+            task_id,
+            table = %table.identifier(),
+            ingestion_branch,
+            planned_snapshot_id = publish_plan.snapshot_id,
+            duplicate_data_file_count = pruning_statistics.duplicate_data_file_count,
+            duplicate_data_file_path_samples = ?pruning_statistics.duplicate_data_file_path_samples,
+            "Duplicate data file paths found while building COW publish snapshot",
+        );
+    }
 
-    let main_files = live_data_files_for_branch(table, MAIN_BRANCH).await?;
+    let mut main_files = live_data_files_for_branch(table, MAIN_BRANCH).await?;
+    let (main_duplicate_data_file_count, main_duplicate_data_file_path_samples) =
+        deduplicate_data_files_by_path(&mut main_files);
+    if main_duplicate_data_file_count > 0 {
+        metrics
+            .iceberg_cow_duplicate_data_file_paths
+            .with_label_values(&["target"])
+            .inc_by(main_duplicate_data_file_count as u64);
+        tracing::error!(
+            iceberg_component = "compaction_worker",
+            iceberg_operation = "deduplicate_cow_publish_target",
+            task_id,
+            table = %table.identifier(),
+            target_branch = MAIN_BRANCH,
+            main_duplicate_data_file_count,
+            main_duplicate_data_file_path_samples = ?main_duplicate_data_file_path_samples,
+            "Duplicate data file paths found in COW publish target snapshot",
+        );
+    }
     let (added_files, deleted_files) = diff_data_files(published_files, main_files);
 
     if added_files.is_empty() && deleted_files.is_empty() {
@@ -612,6 +678,13 @@ async fn publish_cow_snapshot_to_main(
         starting_snapshot_id: publish_plan.snapshot_id,
         use_starting_sequence_number: true,
         basic_schema_id: table.metadata().current_schema().schema_id(),
+        target_branch_sequence_guard: Some(TargetBranchSequenceGuard {
+            snapshot_property: COW_SOURCE_SNAPSHOT_SEQUENCE_NUMBER_PROPERTY.to_owned(),
+            expected_target_snapshot_id: table
+                .metadata()
+                .snapshot_for_ref(MAIN_BRANCH)
+                .map(|snapshot| snapshot.snapshot_id()),
+        }),
     };
     let commit_manager = compaction.build_commit_manager(consistency_params);
     let added_file_count = added_files.len();
@@ -626,6 +699,10 @@ async fn publish_cow_snapshot_to_main(
         iceberg_operation = "publish_cow_snapshot",
         ingestion_branch,
         planned_snapshot_id = publish_plan.snapshot_id,
+        planned_snapshot_sequence_number = ?table
+            .metadata()
+            .snapshot_by_id(publish_plan.snapshot_id)
+            .map(|snapshot| snapshot.sequence_number()),
         added_file_count,
         deleted_file_count,
         "iceberg_cow_snapshot_published",
@@ -1124,7 +1201,7 @@ mod tests {
             &table,
             1,
             None,
-            vec![old_file.clone(), clean_file.clone()],
+            vec![old_file.clone(), clean_file.clone(), clean_file.clone()],
             vec![],
         )
         .await;
@@ -1184,15 +1261,21 @@ mod tests {
             snapshot_id: 1,
             rewritten_data_file_paths: HashSet::from(["data/old.parquet".to_owned()]),
         };
-        let (published_files, _) = build_cow_publish_data_files(
+        let compacted_file = test_data_file("data/compacted.parquet");
+        let (published_files, statistics) = build_cow_publish_data_files(
             &table,
             &publish_plan,
-            vec![test_data_file("data/compacted.parquet")],
+            vec![compacted_file.clone(), compacted_file],
         )
         .await
         .unwrap();
         assert_eq!(
             sorted_file_paths(&published_files),
+            vec!["data/clean.parquet", "data/compacted.parquet"]
+        );
+        assert_eq!(statistics.duplicate_data_file_count, 2);
+        assert_eq!(
+            statistics.duplicate_data_file_path_samples,
             vec!["data/clean.parquet", "data/compacted.parquet"]
         );
     }

--- a/src/storage/src/hummock/compactor/iceberg_compaction/iceberg_compactor_runner.rs
+++ b/src/storage/src/hummock/compactor/iceberg_compaction/iceberg_compactor_runner.rs
@@ -531,6 +531,17 @@ fn deduplicate_data_files_by_path(data_files: &mut Vec<DataFile>) -> (usize, Vec
     (duplicate_count, duplicate_path_samples)
 }
 
+fn cow_publish_watermark_covers(
+    source_sequence_number: i64,
+    target_sequence_number_property: Option<&str>,
+) -> bool {
+    target_sequence_number_property
+        .and_then(|value| value.parse::<i64>().ok())
+        .is_some_and(|published_sequence_number| {
+            published_sequence_number >= source_sequence_number
+        })
+}
+
 fn retain_unrewritten_data_files(
     planned_snapshot_files: &mut Vec<DataFile>,
     rewritten_data_file_paths: &HashSet<String>,
@@ -670,7 +681,33 @@ async fn publish_cow_snapshot_to_main(
     }
     let (added_files, deleted_files) = diff_data_files(published_files, main_files);
 
-    if added_files.is_empty() && deleted_files.is_empty() {
+    let planned_snapshot_sequence_number = table
+        .metadata()
+        .snapshot_by_id(publish_plan.snapshot_id)
+        .ok_or_else(|| {
+            HummockError::compaction_executor(anyhow::anyhow!(
+                "No snapshot found with ID {} while publishing COW compaction",
+                publish_plan.snapshot_id
+            ))
+        })?
+        .sequence_number();
+    let target_sequence_number_property = table
+        .metadata()
+        .snapshot_for_ref(MAIN_BRANCH)
+        .and_then(|snapshot| {
+            snapshot
+                .summary()
+                .additional_properties
+                .get(COW_SOURCE_SNAPSHOT_SEQUENCE_NUMBER_PROPERTY)
+        })
+        .map(String::as_str);
+    if added_files.is_empty()
+        && deleted_files.is_empty()
+        && cow_publish_watermark_covers(
+            planned_snapshot_sequence_number,
+            target_sequence_number_property,
+        )
+    {
         return Ok(());
     }
 
@@ -699,10 +736,7 @@ async fn publish_cow_snapshot_to_main(
         iceberg_operation = "publish_cow_snapshot",
         ingestion_branch,
         planned_snapshot_id = publish_plan.snapshot_id,
-        planned_snapshot_sequence_number = ?table
-            .metadata()
-            .snapshot_by_id(publish_plan.snapshot_id)
-            .map(|snapshot| snapshot.sequence_number()),
+        planned_snapshot_sequence_number,
         added_file_count,
         deleted_file_count,
         "iceberg_cow_snapshot_published",
@@ -1278,6 +1312,15 @@ mod tests {
             statistics.duplicate_data_file_path_samples,
             vec!["data/clean.parquet", "data/compacted.parquet"]
         );
+    }
+
+    #[test]
+    fn test_cow_publish_watermark_covers_source_sequence() {
+        assert!(!cow_publish_watermark_covers(10, None));
+        assert!(!cow_publish_watermark_covers(10, Some("invalid")));
+        assert!(!cow_publish_watermark_covers(10, Some("9")));
+        assert!(cow_publish_watermark_covers(10, Some("10")));
+        assert!(cow_publish_watermark_covers(10, Some("11")));
     }
 
     #[test]

--- a/src/storage/src/monitor/compactor_metrics.rs
+++ b/src/storage/src/monitor/compactor_metrics.rs
@@ -54,6 +54,7 @@ pub struct CompactorMetrics {
     pub iceberg_compaction_memory_budget_bytes: IntGauge,
     pub iceberg_compaction_waiting_memory_reservation_bytes: IntGauge,
     pub iceberg_compaction_running_memory_reservation_bytes: IntGauge,
+    pub iceberg_cow_duplicate_data_file_paths: GenericCounterVec<AtomicU64>,
 }
 
 pub static GLOBAL_COMPACTOR_METRICS: LazyLock<CompactorMetrics> =
@@ -283,6 +284,13 @@ impl CompactorMetrics {
                 registry
             )
             .unwrap();
+        let iceberg_cow_duplicate_data_file_paths = register_int_counter_vec_with_registry!(
+            "storage_iceberg_cow_duplicate_data_file_paths",
+            "Number of duplicate data file paths detected while publishing Iceberg COW snapshots",
+            &["snapshot_role"],
+            registry
+        )
+        .unwrap();
         Self {
             compaction_upload_sst_counts,
             compact_fast_runner_bytes,
@@ -313,6 +321,7 @@ impl CompactorMetrics {
             iceberg_compaction_memory_budget_bytes,
             iceberg_compaction_waiting_memory_reservation_bytes,
             iceberg_compaction_running_memory_reservation_bytes,
+            iceberg_cow_duplicate_data_file_paths,
         }
     }
 

--- a/src/storage/src/monitor/compactor_metrics.rs
+++ b/src/storage/src/monitor/compactor_metrics.rs
@@ -54,7 +54,6 @@ pub struct CompactorMetrics {
     pub iceberg_compaction_memory_budget_bytes: IntGauge,
     pub iceberg_compaction_waiting_memory_reservation_bytes: IntGauge,
     pub iceberg_compaction_running_memory_reservation_bytes: IntGauge,
-    pub iceberg_cow_duplicate_data_file_paths: GenericCounterVec<AtomicU64>,
 }
 
 pub static GLOBAL_COMPACTOR_METRICS: LazyLock<CompactorMetrics> =
@@ -284,13 +283,6 @@ impl CompactorMetrics {
                 registry
             )
             .unwrap();
-        let iceberg_cow_duplicate_data_file_paths = register_int_counter_vec_with_registry!(
-            "storage_iceberg_cow_duplicate_data_file_paths",
-            "Number of duplicate data file paths detected while publishing Iceberg COW snapshots",
-            &["snapshot_role"],
-            registry
-        )
-        .unwrap();
         Self {
             compaction_upload_sst_counts,
             compact_fast_runner_bytes,
@@ -321,7 +313,6 @@ impl CompactorMetrics {
             iceberg_compaction_memory_budget_bytes,
             iceberg_compaction_waiting_memory_reservation_bytes,
             iceberg_compaction_running_memory_reservation_bytes,
-            iceberg_cow_duplicate_data_file_paths,
         }
     }
 


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

Prevent duplicate Iceberg FastAppend inputs at the producer boundary, detect duplicate live data-file paths around COW compaction and publication, and make the failure mode safe:

- **Producer-side prevention:** bump the `iceberg-rust` pin from `515177b` to `638c02e4`, a focused backport of apache/iceberg-rust#2509 that deduplicates same-path data and delete files before FastAppend writes a manifest. The matching `iceberg-compaction` pin is updated to `39af1077`.
- **Compaction plan (before the rewrite):** reject a plan whose `data_files` contain the same path twice. Without this, a duplicated file is read twice by the rewrite, its rows are doubled in the output, and the duplicate can no longer be detected by path once the rewrite lands on the ingestion branch.
- **COW source snapshot:** reject duplicates in the planned snapshot before pruning rewritten files.
- **COW publish set:** reject duplicates in the final file set after adding compaction outputs.
- **COW target (`main`):** report duplicates with `tracing::error!` but **do not fail**. The publish set has already been verified unique, so the overwrite can only repair `main` (when the duplicated file was rewritten) or leave it unchanged; failing here would pin `main` to the corrupted snapshot forever because meta reschedules a failed task immediately.
- Every error/log line carries `table`, `snapshot_id`, `duplicated_path_count`, `duplicate_entry_count` and up to 8 `path (xN)` samples so oncall can grep it directly.

The RisingWave checks do not repair source/ingestion corruption, register metrics, write snapshot properties, or add a new publication protocol. The pinned Iceberg SDK separately deduplicates FastAppend inputs before manifest creation.

Validation:

- `cargo check -p risingwave_storage --locked`: passed.
- `cargo test -p risingwave_storage iceberg_compactor_runner::tests --locked`: passed (`7/7`).

## Checklist

- [x] I have written necessary rustdoc comments.
- [x] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [x] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwavelabs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [x] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->

## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

Iceberg FastAppend now deduplicates same-path files before manifest creation. Iceberg COW compaction also fails before rewriting or publishing when duplicate live data-file paths are detected in its plan, source snapshot, or publish set. Duplicates already present on `main` are logged with table/snapshot context and repaired by the next successful COW publish instead of blocking compaction.

</details>
