### PR TITLE
refactor(frontend): persist cursor execution across FETCH interruptions

### DIFF
--- a/src/frontend/src/handler/declare_cursor.rs
+++ b/src/frontend/src/handler/declare_cursor.rs
@@ -13,11 +13,9 @@
 // limitations under the License.
 
 use std::sync::Arc;
+use std::time::Instant;
 
 use pgwire::pg_response::{PgResponse, StatementType};
-use risingwave_batch::task::ShutdownToken;
-use risingwave_common::catalog::Field;
-use risingwave_common::session_config::QueryMode;
 use risingwave_common::util::epoch::Epoch;
 use risingwave_sqlparser::ast::{
     DeclareCursorStatement, Ident, ObjectName, Query, Since, Statement,
@@ -30,9 +28,8 @@ use super::query::{
 use super::util::convert_unix_millis_to_logstore_u64;
 use crate::error::{ErrorCode, Result};
 use crate::handler::HandlerArgs;
-use crate::handler::query::{distribute_execute, local_execute};
 use crate::session::SessionImpl;
-use crate::session::cursor_manager::{CursorDataChunkStream, CursorQueryStream};
+use crate::session::cursor_manager::{QueryCursor, SubscriptionCursor};
 use crate::{Binder, OptimizerContext};
 
 pub async fn handle_declare_cursor(
@@ -84,16 +81,30 @@ pub async fn handle_declare_subscription_cursor(
         risingwave_sqlparser::ast::Since::Full => None,
     };
     // Create cursor based on the response
-    if let Err(e) = session
-        .get_cursor_manager()
-        .add_subscription_cursor(
+    if let Err(e) = async {
+        let create_cursor_timer = Instant::now();
+        let cursor = SubscriptionCursor::new(
             cursor_name.real_value(),
             start_rw_timestamp,
+            subscription.clone(),
             subscription.dependent_table_id,
-            subscription,
             &handler_args,
+            session.env().cursor_metrics.clone(),
         )
-        .await
+        .await?;
+        let result = session
+            .get_cursor_manager()
+            .add_subscription_cursor(cursor)
+            .await;
+        session
+            .env()
+            .cursor_metrics
+            .subscription_cursor_declare_duration
+            .with_label_values(&[&subscription.name])
+            .observe(create_cursor_timer.elapsed().as_millis() as _);
+        result
+    }
+    .await
     {
         session
             .env()
@@ -128,12 +139,12 @@ async fn handle_declare_query_cursor(
     cursor_name: Ident,
     query: Box<Query>,
 ) -> Result<RwPgResponse> {
-    let (chunk_stream, fields) =
-        create_stream_for_cursor_stmt(handler_args.clone(), Statement::Query(query)).await?;
+    let cursor =
+        create_query_cursor_from_stmt(handler_args.clone(), Statement::Query(query)).await?;
     handler_args
         .session
         .get_cursor_manager()
-        .add_query_cursor(cursor_name.real_value(), chunk_stream, fields)
+        .add_query_cursor(cursor_name.real_value(), cursor)
         .await?;
     Ok(PgResponse::empty_result(StatementType::DECLARE_CURSOR))
 }
@@ -144,21 +155,21 @@ pub async fn handle_bound_declare_query_cursor(
     plan_fragmenter_result: BatchPlanFragmenterResult,
 ) -> Result<RwPgResponse> {
     let session = handler_args.session.clone();
-    let (chunk_stream, fields) =
-        create_chunk_stream_for_cursor(session, plan_fragmenter_result).await?;
+    let cursor = create_query_cursor_from_fragment(session, plan_fragmenter_result).await?;
 
     handler_args
         .session
         .get_cursor_manager()
-        .add_query_cursor(cursor_name.real_value(), chunk_stream, fields)
+        .add_query_cursor(cursor_name.real_value(), cursor)
         .await?;
     Ok(PgResponse::empty_result(StatementType::DECLARE_CURSOR))
 }
 
-pub async fn create_stream_for_cursor_stmt(
+/// Plans a statement and constructs the cursor that owns its execution.
+pub async fn create_query_cursor_from_stmt(
     handler_args: HandlerArgs,
     stmt: Statement,
-) -> Result<(CursorDataChunkStream, Vec<Field>)> {
+) -> Result<QueryCursor> {
     let session = handler_args.session.clone();
     let plan_fragmenter_result = {
         let context = OptimizerContext::from_handler_args(handler_args);
@@ -166,106 +177,13 @@ pub async fn create_stream_for_cursor_stmt(
             gen_batch_plan_by_statement(&session, context.into(), stmt)?.unwrap_rw()?;
         gen_batch_plan_fragmenter(&session, plan_result)?
     };
-    create_chunk_stream_for_cursor(session, plan_fragmenter_result).await
+    create_query_cursor_from_fragment(session, plan_fragmenter_result).await
 }
 
-pub async fn create_chunk_stream_for_cursor(
+/// Constructs a query cursor from a prepared plan, including its shutdown resources and execution.
+pub async fn create_query_cursor_from_fragment(
     session: Arc<SessionImpl>,
     plan_fragmenter_result: BatchPlanFragmenterResult,
-) -> Result<(CursorDataChunkStream, Vec<Field>)> {
-    let BatchPlanFragmenterResult {
-        plan_fragmenter,
-        query_mode,
-        schema,
-        ..
-    } = plan_fragmenter_result;
-
-    // Cursor-owned queries outlive individual statements and must not inherit statement_timeout.
-    let can_timeout_cancel = false;
-
-    let query = plan_fragmenter.generate_complete_query().await?;
-    tracing::trace!("Generated query after plan fragmenter: {:?}", &query);
-
-    Ok((
-        match query_mode {
-            QueryMode::Auto => unreachable!(),
-            QueryMode::Local => {
-                let (shutdown_tx, shutdown_rx) = ShutdownToken::new();
-                CursorDataChunkStream::LocalDataChunk(Some(CursorQueryStream::local(
-                    local_execute(
-                        session.clone(),
-                        query,
-                        can_timeout_cancel,
-                        Some(shutdown_rx),
-                    )
-                    .await?,
-                    shutdown_tx,
-                )))
-            }
-            QueryMode::Distributed => {
-                CursorDataChunkStream::DistributedDataChunk(Some(CursorQueryStream::distributed(
-                    distribute_execute(session.clone(), query, can_timeout_cancel, true).await?,
-                    session.env().query_manager().clone(),
-                )))
-            }
-        },
-        schema.fields.clone(),
-    ))
-}
-
-// Statement timeouts are disabled unconditionally under madsim.
-#[cfg(all(test, not(madsim)))]
-mod tests {
-    use std::time::Duration;
-
-    use futures::StreamExt;
-    use risingwave_sqlparser::parser::Parser;
-
-    use super::*;
-
-    /// Verifies that a local cursor query survives being left unread beyond `statement_timeout`
-    /// and subsequently returns every row without a timeout error.
-    #[tokio::test]
-    async fn test_local_cursor_query_does_not_inherit_statement_timeout() {
-        let session = Arc::new(SessionImpl::mock());
-        session
-            .set_config("visibility_mode", "all".to_owned())
-            .unwrap();
-        session
-            .set_config("query_mode", "local".to_owned())
-            .unwrap();
-        session
-            .set_config("statement_timeout", "50ms".to_owned())
-            .unwrap();
-        let _txn = session.txn_begin_implicit();
-        // The result exceeds the output channel's capacity, keeping execution active while unread.
-        let sql = "SELECT * FROM generate_series(1, 1000000)";
-        let stmt = Parser::parse_sql(sql).unwrap().pop().unwrap();
-        let args = HandlerArgs::new(session, &stmt, sql.into()).unwrap();
-        let (stream, _) = create_stream_for_cursor_stmt(args, stmt).await.unwrap();
-        let CursorDataChunkStream::LocalDataChunk(Some(mut stream)) = stream else {
-            panic!("the query must execute in local mode");
-        };
-        let first_chunk = tokio::time::timeout(Duration::from_secs(5), stream.next())
-            .await
-            .expect("the local cursor query must produce its first chunk")
-            .unwrap()
-            .unwrap();
-        let mut rows = first_chunk.cardinality();
-
-        // Keep the cursor unread beyond the 50 ms statement timeout while backpressure keeps it
-        // active. Otherwise, a fast query could finish before the deadline and hide a regression.
-        tokio::time::sleep(Duration::from_millis(100)).await;
-
-        tokio::time::timeout(Duration::from_secs(5), async {
-            while let Some(chunk) = stream.next().await {
-                rows += chunk
-                    .expect("cursor execution must not time out")
-                    .cardinality();
-            }
-        })
-        .await
-        .expect("the cursor query must finish after consumption resumes");
-        assert_eq!(rows, 1000000);
-    }
+) -> Result<QueryCursor> {
+    QueryCursor::new(session, plan_fragmenter_result).await
 }

--- a/src/frontend/src/handler/query.rs
+++ b/src/frontend/src/handler/query.rs
@@ -14,7 +14,7 @@
 
 use std::collections::HashSet;
 use std::sync::Arc;
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 use itertools::Itertools;
 use pgwire::pg_field_descriptor::PgFieldDescriptor;
@@ -46,7 +46,7 @@ use crate::planner::Planner;
 use crate::scheduler::plan_fragmenter::Query;
 use crate::scheduler::{
     BatchPlanFragmenter, DistributedQueryStream, ExecutionContext, ExecutionContextRef,
-    LocalQueryExecution, LocalQueryStream,
+    LocalQueryExecution, LocalQueryStream, ReadSnapshot,
 };
 use crate::session::SessionImpl;
 
@@ -514,7 +514,7 @@ pub async fn create_stream(
     let row_stream = match query_mode {
         QueryMode::Auto => unreachable!(),
         QueryMode::Local => PgResponseStream::LocalQuery(DataChunkToRowSetAdapter::new(
-            local_execute(session.clone(), query, can_timeout_cancel, None).await?,
+            local_execute(session.clone(), query, can_timeout_cancel, None)?,
             column_types,
             formats,
             session.clone(),
@@ -616,14 +616,29 @@ pub async fn distribute_execute(
     let query_manager = session.env().query_manager().clone();
 
     query_manager
-        .schedule(execution_context, query, is_cursor_query)
+        .schedule(execution_context, query, is_cursor_query, None)
         .await
         .map_err(|err| err.into())
 }
 
-pub async fn local_execute(
+/// Schedules cursor-owned execution with a caller-selected snapshot and no statement timeout.
+pub(crate) async fn distribute_execute_for_cursor(
     session: Arc<SessionImpl>,
-    mut query: Query,
+    query: Query,
+    snapshot: ReadSnapshot,
+) -> Result<DistributedQueryStream> {
+    let execution_context = ExecutionContext::new(session.clone(), None).into();
+    session
+        .env()
+        .query_manager()
+        .schedule(execution_context, query, true, Some(snapshot))
+        .await
+        .map_err(Into::into)
+}
+
+pub fn local_execute(
+    session: Arc<SessionImpl>,
+    query: Query,
     can_timeout_cancel: bool,
     shutdown_rx: Option<ShutdownToken>,
 ) -> Result<LocalQueryStream> {
@@ -634,10 +649,28 @@ pub async fn local_execute(
     } else {
         None
     };
-    let front_env = session.env();
-
     let snapshot = session.pinned_snapshot();
+    local_execute_inner(session, query, timeout, shutdown_rx, snapshot)
+}
 
+/// Starts cursor-owned execution with an independent token, explicit snapshot, and no timeout.
+pub(crate) fn local_execute_for_cursor(
+    session: Arc<SessionImpl>,
+    query: Query,
+    shutdown_rx: ShutdownToken,
+    snapshot: ReadSnapshot,
+) -> Result<LocalQueryStream> {
+    local_execute_inner(session, query, None, Some(shutdown_rx), snapshot)
+}
+
+fn local_execute_inner(
+    session: Arc<SessionImpl>,
+    mut query: Query,
+    timeout: Option<Duration>,
+    shutdown_rx: Option<ShutdownToken>,
+    snapshot: ReadSnapshot,
+) -> Result<LocalQueryStream> {
+    let front_env = session.env();
     snapshot.fill_batch_query_epoch(&mut query)?;
 
     let execution = LocalQueryExecution::new(

--- a/src/frontend/src/scheduler/distributed/query.rs
+++ b/src/frontend/src/scheduler/distributed/query.rs
@@ -107,6 +107,11 @@ impl QueryExecution {
         }
     }
 
+    /// Returns the query associated with this execution.
+    pub fn query(&self) -> &Query {
+        &self.query
+    }
+
     /// Start execution of this query.
     /// Note the two shutdown channel sender and receivers are not dual.
     /// One is used for propagate error to `QueryResultFetcher`, one is used for listening on
@@ -206,7 +211,7 @@ impl QueryExecution {
         {
             warn!("Send cancel query request failed: the query has ended");
         } else {
-            info!("Send cancel request to query-{:?}", self.query.query_id);
+            info!("Send cancel request to query-{:?}", self.query().query_id);
         };
     }
 

--- a/src/frontend/src/scheduler/distributed/query_manager.rs
+++ b/src/frontend/src/scheduler/distributed/query_manager.rs
@@ -34,7 +34,7 @@ use super::QueryExecution;
 use super::stats::DistributedQueryMetrics;
 use crate::catalog::catalog_service::CatalogReader;
 use crate::scheduler::plan_fragmenter::{Query, QueryId};
-use crate::scheduler::{ExecutionContextRef, SchedulerResult};
+use crate::scheduler::{ExecutionContextRef, ReadSnapshot, SchedulerResult};
 use crate::session::SessionImpl;
 
 pub struct DistributedQueryStream {
@@ -240,14 +240,17 @@ impl QueryManager {
         }
     }
 
+    /// Uses the supplied snapshot, or pins the current transaction's snapshot when none is
+    /// supplied.
     pub async fn schedule(
         &self,
         context: ExecutionContextRef,
         mut query: Query,
         is_cursor_query: bool,
+        snapshot: Option<ReadSnapshot>,
     ) -> SchedulerResult<DistributedQueryStream> {
         // TODO: if there's no table scan, we don't need to acquire snapshot.
-        let pinned_snapshot = context.session().pinned_snapshot();
+        let pinned_snapshot = snapshot.unwrap_or_else(|| context.session().pinned_snapshot());
         pinned_snapshot.fill_batch_query_epoch(&mut query)?;
 
         if let Some(query_limit) = self.distributed_query_limit
@@ -405,7 +408,7 @@ mod cursor_lifecycle_tests {
             let query = create_query().await;
             let query_id = query.query_id().clone();
             let context = Arc::new(ExecutionContext::new(session.clone(), None));
-            let mut scheduling = Box::pin(manager.schedule(context, query, is_cursor_query));
+            let mut scheduling = Box::pin(manager.schedule(context, query, is_cursor_query, None));
 
             // With no semaphore configured, get_permit().await completes immediately.
             // The registration checks below confirm this poll has passed that await;
@@ -432,6 +435,70 @@ mod cursor_lifecycle_tests {
             assert!(!manager.contains_query_for_test(&query_id));
             assert!(session.all_distributed_query_ids().is_empty());
         }
+    }
+
+    /// Verifies scheduling uses the supplied snapshot without calling `session.pinned_snapshot()`.
+    /// The mock session has no transaction, so that fallback would panic. Checking each table
+    /// scan's epoch additionally verifies that the supplied snapshot is actually applied.
+    #[tokio::test]
+    async fn test_schedule_uses_supplied_snapshot_when_provided() {
+        use risingwave_common::util::epoch::Epoch;
+        use risingwave_pb::batch_plan::plan_node::NodeBody;
+        use risingwave_pb::common::batch_query_epoch;
+
+        use crate::scheduler::plan_fragmenter::ExecutionPlanNode;
+
+        fn check_scan_epochs(node: &ExecutionPlanNode, epoch: u64) -> usize {
+            let own_scan = if let NodeBody::RowSeqScan(scan) = &node.node {
+                assert_eq!(
+                    scan.query_epoch.as_ref().unwrap().epoch,
+                    Some(batch_query_epoch::Epoch::Backup(epoch))
+                );
+                1
+            } else {
+                0
+            };
+            own_scan
+                + node
+                    .children
+                    .iter()
+                    .map(|child| check_scan_epochs(child, epoch))
+                    .sum::<usize>()
+        }
+
+        let session = Arc::new(SessionImpl::mock());
+        // Deliberately do not begin a transaction. Calling session.pinned_snapshot() would panic,
+        // so reaching suspended startup also verifies that the fallback was not evaluated.
+        let manager = session.env().query_manager().clone();
+        let query = create_query().await;
+        let query_id = query.query_id().clone();
+        let epoch = Epoch(123 << 16);
+        let context = Arc::new(ExecutionContext::new(session.clone(), None));
+        let mut scheduling =
+            Box::pin(manager.schedule(context, query, true, Some(ReadSnapshot::Other(epoch))));
+        assert!(futures::poll!(scheduling.as_mut()).is_pending());
+        let execution = manager
+            .query_execution_info
+            .read()
+            .unwrap()
+            .query_execution_map
+            .get(&query_id)
+            .unwrap()
+            .clone();
+        let scan_count: usize = execution
+            .query()
+            .stage_graph
+            .stages
+            .values()
+            .map(|stage| check_scan_epochs(&stage.root, epoch.0))
+            .sum();
+        assert!(scan_count > 0);
+        assert_eq!(session.all_distributed_query_ids(), vec![query_id.clone()]);
+        assert!(session.ordinary_distributed_query_ids().is_empty());
+
+        drop(scheduling);
+        assert!(!manager.contains_query_for_test(&query_id));
+        assert!(session.all_distributed_query_ids().is_empty());
     }
 
     async fn registration_guard_with_control_receiver() -> (

--- a/src/frontend/src/scheduler/local.rs
+++ b/src/frontend/src/scheduler/local.rs
@@ -735,9 +735,7 @@ mod tests {
             .generate_complete_query()
             .await
             .unwrap();
-        let mut stream = local_execute(session, query, false, shutdown_rx)
-            .await
-            .unwrap();
+        let mut stream = local_execute(session, query, false, shutdown_rx).unwrap();
         let first_chunk = tokio::time::timeout(Duration::from_secs(5), stream.next())
             .await
             .expect("the local executor must produce its first chunk")

--- a/src/frontend/src/session.rs
+++ b/src/frontend/src/session.rs
@@ -930,7 +930,6 @@ impl SessionImpl {
         peer_addr: AddressRef,
         session_config: SessionConfig,
     ) -> Self {
-        let cursor_metrics = env.cursor_metrics.clone();
         let (notice_tx, notice_rx) = mpsc::unbounded_channel();
 
         Self {
@@ -947,7 +946,7 @@ impl SessionImpl {
             notice_rx: Mutex::new(notice_rx),
             exec_context: Mutex::new(None),
             last_idle_instant: Default::default(),
-            cursor_manager: Arc::new(CursorManager::new(cursor_metrics)),
+            cursor_manager: Arc::new(CursorManager::default()),
             temporary_source_manager: Default::default(),
             staging_catalog_manager: Default::default(),
         }
@@ -955,7 +954,6 @@ impl SessionImpl {
 
     #[cfg(test)]
     pub fn mock() -> Self {
-        let env = FrontendEnv::mock();
         let (notice_tx, notice_rx) = mpsc::unbounded_channel();
 
         Self {
@@ -981,7 +979,7 @@ impl SessionImpl {
             ))
             .into(),
             last_idle_instant: Default::default(),
-            cursor_manager: Arc::new(CursorManager::new(env.cursor_metrics)),
+            cursor_manager: Arc::new(CursorManager::default()),
             temporary_source_manager: Default::default(),
             staging_catalog_manager: Default::default(),
         }
@@ -2137,7 +2135,7 @@ mod cancellation_tests {
         create_query, running_query_execution_with_query_message_receiver,
     };
     use crate::scheduler::{DistributedQueryStream, QueryMessage, SchedulerError};
-    use crate::session::cursor_manager::CursorDataChunkStream;
+    use crate::session::cursor_manager::{CursorQueryStream, QueryCursor};
 
     fn session_manager_for_test() -> SessionManagerImpl {
         SessionManagerImpl {
@@ -2165,8 +2163,10 @@ mod cancellation_tests {
             .get_cursor_manager()
             .add_query_cursor(
                 "cursor".to_owned(),
-                CursorDataChunkStream::local_stream_without_executor_for_test(chunk_rx),
-                vec![],
+                QueryCursor::from_query_stream_for_test(
+                    CursorQueryStream::local_stream_without_executor_for_test(chunk_rx),
+                    vec![],
+                ),
             )
             .await
             .unwrap();

--- a/src/frontend/src/session/cursor_manager.rs
+++ b/src/frontend/src/session/cursor_manager.rs
@@ -14,9 +14,8 @@
 
 use core::mem;
 use core::time::Duration;
+use std::collections::HashMap;
 use std::collections::hash_map::Entry;
-use std::collections::{HashMap, HashSet, VecDeque};
-use std::fmt::{Display, Formatter};
 use std::pin::Pin;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -30,11 +29,12 @@ use itertools::Itertools;
 use parking_lot::Mutex;
 use pgwire::pg_field_descriptor::PgFieldDescriptor;
 use pgwire::pg_response::StatementType;
-use pgwire::types::{Format, Row};
+use pgwire::types::{Format, FormatIterator, Row};
 use risingwave_batch::task::{ShutdownSender, ShutdownToken};
 use risingwave_common::array::DataChunk;
 use risingwave_common::catalog::{ColumnCatalog, Field};
 use risingwave_common::error::BoxedError;
+use risingwave_common::row::OwnedRow;
 use risingwave_common::session_config::QueryMode;
 use risingwave_common::types::{DataType, ScalarImpl, StructType, StructValue};
 use risingwave_common::util::iter_util::ZipEqFast;
@@ -46,11 +46,12 @@ use crate::catalog::subscription_catalog::SubscriptionCatalog;
 use crate::error::{ErrorCode, Result};
 use crate::expr::{ExprType, FunctionCall, InputRef, Literal};
 use crate::handler::HandlerArgs;
-use crate::handler::declare_cursor::create_chunk_stream_for_cursor;
-use crate::handler::query::{RwBatchQueryPlanResult, gen_batch_plan_fragmenter};
+use crate::handler::query::{
+    BatchPlanFragmenterResult, RwBatchQueryPlanResult, distribute_execute_for_cursor,
+    local_execute_for_cursor,
+};
 use crate::handler::util::{
-    DataChunkToRowSetAdapter, StaticSessionData, convert_logstore_u64_to_unix_millis,
-    pg_value_format, to_pg_field,
+    StaticSessionData, convert_logstore_u64_to_unix_millis, pg_value_format, to_pg_field,
 };
 use crate::monitor::{CursorMetrics, PeriodicCursorMetrics};
 use crate::optimizer::PlanRoot;
@@ -60,11 +61,50 @@ use crate::scheduler::{
     DistributedQueryStream, LocalQueryStream, QueryManager, ReadSnapshot, SchedulerError,
 };
 use crate::utils::Condition;
-use crate::{OptimizerContext, OptimizerContextRef, PgResponseStream, TableCatalog};
+use crate::{OptimizerContext, OptimizerContextRef, TableCatalog};
 
-#[expect(dead_code, reason = "The persistent-stream layer is not wired yet")]
 #[path = "cursor_stream.rs"]
 mod cursor_stream;
+use cursor_stream::{
+    QueryCursorDataChunkStream, QueryCursorPgResponseStream, SubscriptionCursorDataChunkStream,
+    SubscriptionCursorHandlerContext, SubscriptionCursorPgResponseStream, SubscriptionCursorState,
+};
+
+/// Creates raw cursor-owned output using a snapshot selected by the caller before startup.
+/// The snapshot is retained across asynchronous fragmentation and scheduling, without consulting
+/// the current transaction's snapshot again when a suspended startup resumes.
+async fn create_cursor_query_stream(
+    session: Arc<SessionImpl>,
+    plan_fragmenter_result: BatchPlanFragmenterResult,
+    snapshot: ReadSnapshot,
+) -> Result<(CursorQueryStream, Vec<Field>)> {
+    let BatchPlanFragmenterResult {
+        plan_fragmenter,
+        query_mode,
+        schema,
+        ..
+    } = plan_fragmenter_result;
+
+    let query = plan_fragmenter.generate_complete_query().await?;
+    tracing::trace!("Generated query after plan fragmenter: {:?}", &query);
+
+    // Cursor-owned queries outlive individual statements and must not inherit statement_timeout.
+    let stream = match query_mode {
+        QueryMode::Auto => unreachable!(),
+        QueryMode::Local => {
+            let (shutdown_tx, shutdown_rx) = ShutdownToken::new();
+            CursorQueryStream::local(
+                local_execute_for_cursor(session, query, shutdown_rx, snapshot)?,
+                shutdown_tx,
+            )
+        }
+        QueryMode::Distributed => CursorQueryStream::distributed(
+            distribute_execute_for_cursor(session.clone(), query, snapshot).await?,
+            session.env().query_manager().clone(),
+        ),
+    };
+    Ok((stream, schema.fields))
+}
 
 /// Cursor-scoped shutdown resources, separate from individual FETCH cancellation.
 struct CursorShutdownHandle {
@@ -189,12 +229,6 @@ impl Drop for CursorQueryStream {
     }
 }
 
-pub enum CursorDataChunkStream {
-    LocalDataChunk(Option<CursorQueryStream>),
-    DistributedDataChunk(Option<CursorQueryStream>),
-    PgResponse(PgResponseStream),
-}
-
 pub struct FetchCursorCancelHandle {
     cancel_tx: ShutdownSender,
     cancel_rx: ShutdownToken,
@@ -216,49 +250,8 @@ impl FetchCursorCancelHandle {
     async fn cancelled(&mut self) {
         self.cancel_rx.cancelled().await;
     }
-
-    fn is_cancelled(&self) -> bool {
-        self.cancel_rx.is_cancelled()
-    }
 }
 
-impl CursorDataChunkStream {
-    pub fn init_row_stream(
-        &mut self,
-        fields: &Vec<Field>,
-        formats: &Vec<Format>,
-        session: Arc<SessionImpl>,
-    ) {
-        let columns_type = fields.iter().map(|f| f.data_type()).collect();
-        match self {
-            CursorDataChunkStream::LocalDataChunk(data_chunk)
-            | CursorDataChunkStream::DistributedDataChunk(data_chunk) => {
-                let data_chunk = mem::take(data_chunk).unwrap();
-                let row_stream = PgResponseStream::Rows(
-                    DataChunkToRowSetAdapter::new(
-                        data_chunk,
-                        columns_type,
-                        formats.clone(),
-                        session,
-                    )
-                    .boxed(),
-                );
-                *self = CursorDataChunkStream::PgResponse(row_stream);
-            }
-            _ => {}
-        }
-    }
-
-    pub async fn next(&mut self) -> Result<Option<std::result::Result<Vec<Row>, BoxedError>>> {
-        match self {
-            CursorDataChunkStream::PgResponse(row_stream) => Ok(row_stream.next().await),
-            _ => Err(ErrorCode::InternalError(
-                "Only 'CursorDataChunkStream' can call next and return rows".to_owned(),
-            )
-            .into()),
-        }
-    }
-}
 pub enum Cursor {
     Subscription(SubscriptionCursor),
     Query(QueryCursor),
@@ -271,7 +264,7 @@ impl Cursor {
         }
     }
 
-    pub async fn next(
+    pub async fn fetch(
         &mut self,
         count: u32,
         handler_args: HandlerArgs,
@@ -279,151 +272,144 @@ impl Cursor {
         timeout_seconds: Option<u64>,
         cancel_handle: &mut FetchCursorCancelHandle,
     ) -> Result<(Vec<Row>, Vec<PgFieldDescriptor>)> {
-        match self {
-            Cursor::Subscription(cursor) => cursor
-                .next(count, handler_args, formats, timeout_seconds, cancel_handle)
-                .await
-                .inspect_err(|_| cursor.cursor_metrics.subscription_cursor_error_count.inc()),
-            Cursor::Query(cursor) => {
-                cursor
-                    .next(count, formats, handler_args, timeout_seconds)
-                    .await
+        let mut shutdown_rx = self.shutdown_handle().shutdown_token();
+        // Dropping FETCH's future is safe for terminal shutdown because the cursor is discarded.
+        tokio::select! {
+            biased;
+            _ = shutdown_rx.cancelled() => {
+                Err(SchedulerError::QueryCancelled("cursor closed".to_owned()).into())
             }
+            result = async {
+                match self {
+                    Cursor::Subscription(cursor) => cursor
+                        .fetch(count, handler_args, formats, timeout_seconds, cancel_handle)
+                        .await
+                        .inspect_err(|_| cursor.cursor_metrics.subscription_cursor_error_count.inc()),
+                    Cursor::Query(cursor) => {
+                        cursor
+                            .fetch(count, formats, handler_args, timeout_seconds, cancel_handle)
+                            .await
+                    }
+                }
+            } => result,
         }
     }
 
     pub fn get_fields(&mut self) -> Vec<Field> {
         match self {
-            Cursor::Subscription(cursor) => cursor.fields_manager.get_output_fields(),
-            Cursor::Query(cursor) => cursor.fields.clone(),
+            Cursor::Subscription(cursor) => cursor.pg_response_stream.fields(),
+            Cursor::Query(cursor) => cursor.pg_response_stream.fields(),
         }
     }
+}
+
+/// Polls a temporary borrow of the persistent response stream for one FETCH.
+/// Cancellation can discard accumulated rows; transactional replay belongs to Goal 3.
+async fn fetch_rows<S: Stream<Item = Result<Row>> + Unpin>(
+    stream: &mut S,
+    count: u32,
+    timeout_seconds: Option<u64>,
+    cancel_handle: &mut FetchCursorCancelHandle,
+    mut record_poll: impl FnMut(Duration),
+) -> Result<Vec<Row>> {
+    let deadline =
+        timeout_seconds.map(|seconds| tokio::time::Instant::now() + Duration::from_secs(seconds));
+    let timeout = async {
+        match deadline {
+            Some(deadline) => tokio::time::sleep_until(deadline).await,
+            None => std::future::pending::<()>().await,
+        }
+    };
+    tokio::pin!(timeout);
+    let mut rows = Vec::with_capacity(count.min(100) as usize);
+    while rows.len() < count as usize {
+        let started = Instant::now();
+        let row = if timeout_seconds == Some(0) {
+            // Keep the legacy zero-timeout behavior: allow an immediately-ready row, but do
+            // not wait for pending work. Cancellation always takes priority over consuming data.
+            tokio::select! {
+                biased;
+                _ = cancel_handle.cancelled() => {
+                    return Err(SchedulerError::QueryCancelled("Cancelled by user".to_owned()).into());
+                }
+                row = stream.next() => row,
+                _ = &mut timeout => break,
+            }
+        } else {
+            tokio::select! {
+                biased;
+                _ = cancel_handle.cancelled() => {
+                    return Err(SchedulerError::QueryCancelled("Cancelled by user".to_owned()).into());
+                }
+                _ = &mut timeout => break,
+                row = stream.next() => row,
+            }
+        };
+        let Some(row) = row.transpose()? else {
+            break;
+        };
+        record_poll(started.elapsed());
+        rows.push(row);
+        // Ready rows may keep this task running without letting the timer driver advance.
+        // Check elapsed time directly as well; zero timeout still returns at most one ready row.
+        if deadline.is_some_and(|deadline| tokio::time::Instant::now() >= deadline) {
+            break;
+        }
+    }
+    Ok(rows)
 }
 
 pub struct QueryCursor {
     shutdown_handle: CursorShutdownHandle,
-    chunk_stream: CursorDataChunkStream,
-    fields: Vec<Field>,
-    remaining_rows: VecDeque<Row>,
+    pg_response_stream: QueryCursorPgResponseStream,
 }
 
 impl QueryCursor {
-    pub fn new(chunk_stream: CursorDataChunkStream, fields: Vec<Field>) -> Result<Self> {
+    /// Creates shutdown resources, selects the snapshot, and starts the cursor-owned query.
+    pub(crate) async fn new(
+        session: Arc<SessionImpl>,
+        plan_fragmenter_result: BatchPlanFragmenterResult,
+    ) -> Result<Self> {
+        let shutdown_handle = CursorShutdownHandle::new();
+        let snapshot = session.pinned_snapshot();
+        let (query_stream, fields) =
+            create_cursor_query_stream(session, plan_fragmenter_result, snapshot).await?;
+        let data_stream = QueryCursorDataChunkStream::new(query_stream, fields.clone());
         Ok(Self {
-            shutdown_handle: CursorShutdownHandle::new(),
-            chunk_stream,
-            fields,
-            remaining_rows: VecDeque::<Row>::new(),
+            shutdown_handle,
+            pg_response_stream: QueryCursorPgResponseStream::new(data_stream, fields),
         })
     }
 
-    pub async fn next_once(&mut self) -> Result<Option<Row>> {
-        while self.remaining_rows.is_empty() {
-            let rows = self.chunk_stream.next().await?;
-            let rows = match rows {
-                None => return Ok(None),
-                Some(row) => row?,
-            };
-            self.remaining_rows = rows.into_iter().collect();
-        }
-        let row = self.remaining_rows.pop_front().unwrap();
-        Ok(Some(row))
-    }
-
-    pub async fn next(
+    pub async fn fetch(
         &mut self,
         count: u32,
         formats: &Vec<Format>,
         handler_args: HandlerArgs,
         timeout_seconds: Option<u64>,
+        cancel_handle: &mut FetchCursorCancelHandle,
     ) -> Result<(Vec<Row>, Vec<PgFieldDescriptor>)> {
-        // `FETCH NEXT` is equivalent to `FETCH 1`.
-        // min with 100 to avoid allocating too many memory at once.
-        let timeout_instant = timeout_seconds.map(|s| Instant::now() + Duration::from_secs(s));
-        let session = handler_args.session;
-        let mut ans = Vec::with_capacity(std::cmp::min(100, count) as usize);
-        let mut cur = 0;
-        let desc = self.fields.iter().map(to_pg_field).collect();
-        self.chunk_stream
-            .init_row_stream(&self.fields, formats, session);
-        while cur < count
-            && let Some(row) = self.next_once().await?
-        {
-            cur += 1;
-            ans.push(row);
-            if let Some(timeout_instant) = timeout_instant
-                && Instant::now() > timeout_instant
-            {
-                break;
-            }
-        }
-        Ok((ans, desc))
+        self.pg_response_stream
+            .begin_fetch(formats, &handler_args.session);
+        let rows = fetch_rows(
+            &mut self.pg_response_stream,
+            count,
+            timeout_seconds,
+            cancel_handle,
+            |_| {},
+        )
+        .await?;
+        let desc = self
+            .pg_response_stream
+            .fields()
+            .iter()
+            .map(to_pg_field)
+            .collect();
+        Ok((rows, desc))
     }
 }
 
-enum State {
-    InitLogStoreQuery {
-        // The rw_timestamp used to initiate the query to read from subscription logstore.
-        seek_timestamp: u64,
-
-        // If specified, the expected_timestamp must be an exact match for the next rw_timestamp.
-        expected_timestamp: Option<u64>,
-    },
-    Fetch {
-        // Whether the query is reading from snapshot
-        // true: read from the upstream table snapshot
-        // false: read from subscription logstore
-        from_snapshot: bool,
-
-        // The rw_timestamp used to initiate the query to read from subscription logstore.
-        rw_timestamp: u64,
-
-        // The row stream to from the batch query read.
-        // It is returned from the batch execution.
-        chunk_stream: CursorDataChunkStream,
-
-        // A cache to store the remaining rows from the row stream.
-        remaining_rows: VecDeque<Row>,
-
-        expected_timestamp: Option<u64>,
-
-        init_query_timer: Instant,
-    },
-    Invalid,
-}
-
-impl Display for State {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        match self {
-            State::InitLogStoreQuery {
-                seek_timestamp,
-                expected_timestamp,
-            } => write!(
-                f,
-                "InitLogStoreQuery {{ seek_timestamp: {}, expected_timestamp: {:?} }}",
-                seek_timestamp, expected_timestamp
-            ),
-            State::Fetch {
-                from_snapshot,
-                rw_timestamp,
-                expected_timestamp,
-                remaining_rows,
-                init_query_timer,
-                ..
-            } => write!(
-                f,
-                "Fetch {{ from_snapshot: {}, rw_timestamp: {}, expected_timestamp: {:?}, cached rows: {}, query init at {}ms before }}",
-                from_snapshot,
-                rw_timestamp,
-                expected_timestamp,
-                remaining_rows.len(),
-                init_query_timer.elapsed().as_millis()
-            ),
-            State::Invalid => write!(f, "Invalid"),
-        }
-    }
-}
-
+#[derive(Clone)]
 struct FieldsManager {
     columns_catalog: Vec<ColumnCatalog>,
     // All row fields, including hidden pk, op, rw_timestamp and all non-hidden columns in the upstream table.
@@ -445,18 +431,20 @@ impl FieldsManager {
     pub fn new(catalog: &TableCatalog) -> Self {
         let mut row_fields = Vec::new();
         let mut row_output_col_indices = Vec::new();
-        let mut row_pk_indices = Vec::new();
+        let mut row_pk_indices = vec![0; catalog.pk.len()];
         let mut stream_chunk_row_indices = Vec::new();
         let mut output_idx = 0_usize;
-        let pk_set: HashSet<usize> = catalog
+        let pk_positions: HashMap<usize, usize> = catalog
             .pk
             .iter()
-            .map(|col_order| col_order.column_index)
+            .enumerate()
+            .map(|(position, col_order)| (col_order.column_index, position))
             .collect();
 
         for (index, v) in catalog.columns.iter().enumerate() {
-            if pk_set.contains(&index) {
-                row_pk_indices.push(output_idx);
+            if let Some(&pk_position) = pk_positions.get(&index) {
+                // Seek predicates pair values with catalog.pk, not table-column order.
+                row_pk_indices[pk_position] = output_idx;
                 stream_chunk_row_indices.push(output_idx);
                 row_fields.push(Field::with_name(v.data_type().clone(), v.name()));
                 if !v.is_hidden {
@@ -496,18 +484,6 @@ impl FieldsManager {
         }
     }
 
-    pub fn process_output_desc_row(&self, mut rows: Vec<Row>) -> (Vec<Row>, Option<Row>) {
-        let last_row = rows.last_mut().map(|row| {
-            let mut row = row.clone();
-            row.project(&self.row_pk_indices)
-        });
-        let rows = rows
-            .iter_mut()
-            .map(|row| row.project(&self.row_output_col_indices))
-            .collect();
-        (rows, last_row)
-    }
-
     pub fn get_output_fields(&self) -> Vec<Field> {
         self.row_output_col_indices
             .iter()
@@ -515,30 +491,36 @@ impl FieldsManager {
             .collect()
     }
 
-    // In the beginning (declare cur), we will give it an empty formats,
-    // this formats is not a real, when we fetch, We fill it with the formats returned from the pg client.
+    /// Maps FETCH result formats to the full row layout, including hidden and synthetic columns.
+    /// An empty list selects default text; a single code is expanded to all visible columns.
     pub fn get_row_stream_fields_and_formats(
         &self,
-        formats: &Vec<Format>,
+        formats: &[Format],
         from_snapshot: bool,
-    ) -> (Vec<Field>, Vec<Format>) {
-        let mut fields = Vec::new();
-        let need_format = !(formats.is_empty() || formats.len() == 1);
-        let mut new_formats = formats.clone();
-        let stream_chunk_row_indices_iter = if from_snapshot {
-            self.stream_chunk_row_indices.iter().chain(None)
-        } else {
-            self.stream_chunk_row_indices
-                .iter()
-                .chain(Some(&self.op_index))
-        };
-        for index in stream_chunk_row_indices_iter {
-            fields.push(self.row_fields[*index].clone());
-            if need_format && !self.row_output_col_indices.contains(index) {
-                new_formats.insert(*index, Format::Text);
-            }
+    ) -> Result<(Vec<Field>, Vec<Format>)> {
+        let raw_indices = self
+            .stream_chunk_row_indices
+            .iter()
+            .copied()
+            .chain((!from_snapshot).then_some(self.op_index));
+        let fields = raw_indices
+            .map(|index| self.row_fields[index].clone())
+            .collect();
+        if formats.is_empty() {
+            return Ok((fields, vec![]));
         }
-        (fields, new_formats)
+        let output_formats = FormatIterator::new(formats, self.row_output_col_indices.len())
+            .map_err(ErrorCode::InternalError)?;
+        let mut row_formats = vec![Format::Text; self.row_fields.len()];
+        for (row_index, format) in self
+            .row_output_col_indices
+            .iter()
+            .copied()
+            .zip_eq_fast(output_formats)
+        {
+            row_formats[row_index] = format;
+        }
+        Ok((fields, row_formats))
     }
 }
 
@@ -547,14 +529,9 @@ pub struct SubscriptionCursor {
     cursor_name: String,
     subscription: Arc<SubscriptionCatalog>,
     dependent_table_id: TableId,
-    cursor_need_drop_time: Instant,
-    state: State,
-    // fields will be set in the table's catalog when the cursor is created,
-    // and will be reset each time it is created chunk_stream, this is to avoid changes in the catalog due to alter.
-    fields_manager: FieldsManager,
+    pg_response_stream: SubscriptionCursorPgResponseStream,
     cursor_metrics: Arc<CursorMetrics>,
     last_fetch: Instant,
-    seek_pk_row: Option<Row>,
 }
 
 impl SubscriptionCursor {
@@ -566,26 +543,21 @@ impl SubscriptionCursor {
         handler_args: &HandlerArgs,
         cursor_metrics: Arc<CursorMetrics>,
     ) -> Result<Self> {
+        let shutdown_handle = CursorShutdownHandle::new();
         let (state, fields_manager) = if let Some(start_timestamp) = start_timestamp {
             let table_catalog = handler_args.session.get_table_by_id(dependent_table_id)?;
             (
-                State::InitLogStoreQuery {
+                SubscriptionCursorState::InitLogStoreQuery {
                     seek_timestamp: start_timestamp,
                     expected_timestamp: None,
                 },
                 FieldsManager::new(&table_catalog),
             )
         } else {
-            // The query stream needs to initiated on cursor creation to make sure
-            // future fetch on the cursor starts from the snapshot when the cursor is declared.
-            //
-            // TODO: is this the right behavior? Should we delay the query stream initiation till the first fetch?
-            let (chunk_stream, init_query_timer, table_catalog) =
-                Self::initiate_query(None, dependent_table_id, handler_args.clone(), None).await?;
-            let pinned_epoch = match handler_args.session.get_pinned_snapshot().ok_or_else(
-                || ErrorCode::InternalError("Fetch Cursor can't find snapshot epoch".to_owned()),
-            )? {
-                ReadSnapshot::FrontendPinned { snapshot, .. } => {
+            // FULL selects its snapshot and epoch during DECLARE, before startup can suspend.
+            let snapshot = handler_args.session.pinned_snapshot();
+            let pinned_epoch = match &snapshot {
+                ReadSnapshot::FrontendPinned { snapshot } => {
                     snapshot
                         .version()
                         .state_table_info
@@ -606,171 +578,53 @@ impl SubscriptionCursor {
                     .into());
                 }
             };
-            let start_timestamp = pinned_epoch;
-
+            let (query_stream, init_query_timer, table_catalog) =
+                SubscriptionCursorDataChunkStream::initiate_query(
+                    None,
+                    dependent_table_id,
+                    handler_args.clone(),
+                    snapshot,
+                )
+                .await?;
             (
-                State::Fetch {
+                SubscriptionCursorState::Fetch {
                     from_snapshot: true,
-                    rw_timestamp: start_timestamp,
-                    chunk_stream,
-                    remaining_rows: VecDeque::new(),
+                    rw_timestamp: pinned_epoch,
+                    query_stream,
                     expected_timestamp: None,
                     init_query_timer,
                 },
                 FieldsManager::new(&table_catalog),
             )
         };
-
-        let cursor_need_drop_time =
-            Instant::now() + Duration::from_secs(subscription.retention_seconds);
+        let expires_at = Instant::now() + Duration::from_secs(subscription.retention_seconds);
+        let output_fields = fields_manager.get_output_fields();
+        let response_state = state.strip_query_stream();
+        let data_stream = SubscriptionCursorDataChunkStream::new(
+            subscription.clone(),
+            dependent_table_id,
+            SubscriptionCursorHandlerContext::new(handler_args),
+            fields_manager,
+            state,
+            cursor_metrics.clone(),
+        );
         Ok(Self {
-            shutdown_handle: CursorShutdownHandle::new(),
+            shutdown_handle,
             cursor_name,
             subscription,
             dependent_table_id,
-            cursor_need_drop_time,
-            state,
-            fields_manager,
+            pg_response_stream: SubscriptionCursorPgResponseStream::new(
+                data_stream,
+                output_fields,
+                response_state,
+                expires_at,
+            ),
             cursor_metrics,
             last_fetch: Instant::now(),
-            seek_pk_row: None,
         })
     }
 
-    async fn next_row(
-        &mut self,
-        handler_args: &HandlerArgs,
-        formats: &Vec<Format>,
-    ) -> Result<Option<Row>> {
-        loop {
-            match &mut self.state {
-                State::InitLogStoreQuery {
-                    seek_timestamp,
-                    expected_timestamp,
-                } => {
-                    let from_snapshot = false;
-
-                    // Initiate a new batch query to continue fetching
-                    match Self::get_next_rw_timestamp(
-                        *seek_timestamp,
-                        self.dependent_table_id,
-                        *expected_timestamp,
-                        handler_args.clone(),
-                        &self.subscription,
-                    )
-                    .await
-                    {
-                        Ok((Some(rw_timestamp), expected_timestamp)) => {
-                            let (mut chunk_stream, init_query_timer, catalog) =
-                                Self::initiate_query(
-                                    Some(rw_timestamp),
-                                    self.dependent_table_id,
-                                    handler_args.clone(),
-                                    None,
-                                )
-                                .await?;
-                            let table_schema_changed =
-                                self.fields_manager.try_refill_fields(&catalog);
-                            let (fields, formats) = self
-                                .fields_manager
-                                .get_row_stream_fields_and_formats(formats, from_snapshot);
-                            chunk_stream.init_row_stream(
-                                &fields,
-                                &formats,
-                                handler_args.session.clone(),
-                            );
-
-                            self.cursor_need_drop_time = Instant::now()
-                                + Duration::from_secs(self.subscription.retention_seconds);
-                            let mut remaining_rows = VecDeque::new();
-                            Self::try_refill_remaining_rows(&mut chunk_stream, &mut remaining_rows)
-                                .await?;
-                            // Transition to the Fetch state
-                            self.state = State::Fetch {
-                                from_snapshot,
-                                rw_timestamp,
-                                chunk_stream,
-                                remaining_rows,
-                                expected_timestamp,
-                                init_query_timer,
-                            };
-                            if table_schema_changed {
-                                return Ok(None);
-                            }
-                        }
-                        Ok((None, _)) => return Ok(None),
-                        Err(e) => {
-                            self.state = State::Invalid;
-                            return Err(e);
-                        }
-                    }
-                }
-                State::Fetch {
-                    from_snapshot,
-                    rw_timestamp,
-                    chunk_stream,
-                    remaining_rows,
-                    expected_timestamp,
-                    init_query_timer,
-                } => {
-                    let session_data = StaticSessionData {
-                        timezone: handler_args.session.config().timezone(),
-                    };
-                    let from_snapshot = *from_snapshot;
-                    let rw_timestamp = *rw_timestamp;
-
-                    // Try refill remaining rows
-                    Self::try_refill_remaining_rows(chunk_stream, remaining_rows).await?;
-
-                    if let Some(row) = remaining_rows.pop_front() {
-                        // 1. Fetch the next row
-                        if from_snapshot {
-                            return Ok(Some(Self::build_row(
-                                row.take(),
-                                None,
-                                formats,
-                                &session_data,
-                            )?));
-                        } else {
-                            return Ok(Some(Self::build_row(
-                                row.take(),
-                                Some(rw_timestamp),
-                                formats,
-                                &session_data,
-                            )?));
-                        }
-                    } else {
-                        self.cursor_metrics
-                            .subscription_cursor_query_duration
-                            .with_label_values(&[&self.subscription.name])
-                            .observe(init_query_timer.elapsed().as_millis() as _);
-                        // 2. Reach EOF for the current query.
-                        if let Some(expected_timestamp) = expected_timestamp {
-                            self.state = State::InitLogStoreQuery {
-                                seek_timestamp: *expected_timestamp,
-                                expected_timestamp: Some(*expected_timestamp),
-                            };
-                        } else {
-                            self.state = State::InitLogStoreQuery {
-                                seek_timestamp: rw_timestamp + 1,
-                                expected_timestamp: None,
-                            };
-                        }
-                    }
-                }
-                State::Invalid => {
-                    // TODO: auto close invalid cursor?
-                    return Err(ErrorCode::InternalError(
-                        "Cursor is in invalid state. Please close and re-create the cursor."
-                            .to_owned(),
-                    )
-                    .into());
-                }
-            }
-        }
-    }
-
-    pub async fn next(
+    pub async fn fetch(
         &mut self,
         count: u32,
         handler_args: HandlerArgs,
@@ -778,107 +632,40 @@ impl SubscriptionCursor {
         timeout_seconds: Option<u64>,
         cancel_handle: &mut FetchCursorCancelHandle,
     ) -> Result<(Vec<Row>, Vec<PgFieldDescriptor>)> {
-        let timeout_instant = timeout_seconds.map(|s| Instant::now() + Duration::from_secs(s));
-        if Instant::now() > self.cursor_need_drop_time {
+        if self.pg_response_stream.is_expired(Instant::now()) {
             return Err(ErrorCode::InternalError(
                 "The cursor has exceeded its maximum lifetime, please recreate it (close then declare cursor).".to_owned(),
-            )
-            .into());
+            ).into());
         }
-
-        let session = &handler_args.session;
-        let mut ans = Vec::with_capacity(std::cmp::min(100, count) as usize);
-        let mut cur = 0;
-        if let State::Fetch {
-            from_snapshot,
-            chunk_stream,
-            ..
-        } = &mut self.state
-        {
-            let (fields, fotmats) = self
-                .fields_manager
-                .get_row_stream_fields_and_formats(formats, *from_snapshot);
-            chunk_stream.init_row_stream(&fields, &fotmats, session.clone());
-        }
-        while cur < count {
-            if cancel_handle.is_cancelled() {
-                return Err(SchedulerError::QueryCancelled("Cancelled by user".to_owned()).into());
-            }
-            let fetch_cursor_timer = Instant::now();
-            let row = self.next_row(&handler_args, formats).await?;
-            self.cursor_metrics
-                .subscription_cursor_fetch_duration
-                .with_label_values(&[&self.subscription.name])
-                .observe(fetch_cursor_timer.elapsed().as_millis() as _);
-            match row {
-                Some(row) => {
-                    cur += 1;
-                    ans.push(row);
-                }
-                None => {
-                    let timeout_seconds = timeout_seconds.unwrap_or(0);
-                    if cur > 0 || timeout_seconds == 0 {
-                        break;
-                    }
-                    let State::InitLogStoreQuery { seek_timestamp, .. } = &self.state else {
-                        // Triggered when previous next_row returns None while self.state is State::Fetch.
-                        continue;
-                    };
-                    // This is the only point where subscription cursor fetch waits without an
-                    // inner query. Register the FETCH-level cancel token so CancelRequest can
-                    // interrupt this wait. The token also marks the whole FETCH as cancelled, so
-                    // we won't start another inner query after a cancellation.
-                    cancel_handle.register(session);
-                    let timeout = tokio::time::sleep(Duration::from_secs(timeout_seconds));
-                    tokio::pin!(timeout);
-                    tokio::select! {
-                        biased;
-                        _ = cancel_handle.cancelled() => {
-                            return Err(SchedulerError::QueryCancelled(
-                                "Cancelled by user".to_owned(),
-                            )
-                            .into());
-                        }
-                        result = session
-                            .env
-                            .hummock_snapshot_manager()
-                            .wait_table_change_log_notification(
-                                self.dependent_table_id,
-                                *seek_timestamp,
-                            ) => {
-                            result?;
-                        }
-                        _ = &mut timeout => {
-                            tracing::debug!("Cursor wait next epoch timeout");
-                            break;
-                        }
-                    }
-                    if cancel_handle.is_cancelled() {
-                        return Err(
-                            SchedulerError::QueryCancelled("Cancelled by user".to_owned()).into(),
-                        );
-                    }
-                }
-            }
-            // Timeout, return with current value
-            if let Some(timeout_instant) = timeout_instant
-                && Instant::now() > timeout_instant
-            {
-                break;
-            }
-        }
-        self.last_fetch = Instant::now();
-        let (rows, seek_pk_row) = self.fields_manager.process_output_desc_row(ans);
-        if let Some(seek_pk_row) = seek_pk_row {
-            self.seek_pk_row = Some(seek_pk_row);
-        }
+        // A schema boundary publishes fields for the next FETCH before ending this one.
+        // Keep this response's descriptors consistent with its rows and any earlier Describe.
         let desc = self
-            .fields_manager
-            .get_output_fields()
+            .pg_response_stream
+            .fields()
             .iter()
             .map(to_pg_field)
             .collect();
-
+        self.pg_response_stream.begin_fetch(
+            formats,
+            &handler_args.session,
+            timeout_seconds.is_some_and(|seconds| seconds > 0),
+        );
+        let metrics = &self.cursor_metrics;
+        let subscription_name = &self.subscription.name;
+        let rows = fetch_rows(
+            &mut self.pg_response_stream,
+            count,
+            timeout_seconds,
+            cancel_handle,
+            |elapsed| {
+                metrics
+                    .subscription_cursor_fetch_duration
+                    .with_label_values(&[subscription_name])
+                    .observe(elapsed.as_millis() as _);
+            },
+        )
+        .await?;
+        self.last_fetch = Instant::now();
         Ok((rows, desc))
     }
 
@@ -922,36 +709,38 @@ impl SubscriptionCursor {
         &self,
         handler_args: HandlerArgs,
     ) -> Result<RwBatchQueryPlanResult> {
-        match self.state {
+        match self.pg_response_stream.subscription_state() {
             // Only used to return generated plans, so rw_timestamp are meaningless
-            State::InitLogStoreQuery { .. } => Self::init_batch_plan_for_subscription_cursor(
-                Some(0),
-                self.dependent_table_id,
-                handler_args,
-                self.seek_pk_row.clone(),
-            ),
-            State::Fetch {
+            SubscriptionCursorState::InitLogStoreQuery { .. } => {
+                Self::init_batch_plan_for_subscription_cursor(
+                    Some(0),
+                    self.dependent_table_id,
+                    handler_args,
+                    self.pg_response_stream.seek_pk_row(),
+                )
+            }
+            SubscriptionCursorState::Fetch {
                 from_snapshot,
                 rw_timestamp,
                 ..
             } => {
-                if from_snapshot {
+                if *from_snapshot {
                     Self::init_batch_plan_for_subscription_cursor(
                         None,
                         self.dependent_table_id,
                         handler_args,
-                        self.seek_pk_row.clone(),
+                        self.pg_response_stream.seek_pk_row(),
                     )
                 } else {
                     Self::init_batch_plan_for_subscription_cursor(
-                        Some(rw_timestamp),
+                        Some(*rw_timestamp),
                         self.dependent_table_id,
                         handler_args,
-                        self.seek_pk_row.clone(),
+                        self.pg_response_stream.seek_pk_row(),
                     )
                 }
             }
-            State::Invalid => Err(ErrorCode::InternalError(
+            SubscriptionCursorState::Invalid => Err(ErrorCode::InternalError(
                 "Cursor is in invalid state. Please close and re-create the cursor.".to_owned(),
             )
             .into()),
@@ -962,7 +751,7 @@ impl SubscriptionCursor {
         rw_timestamp: Option<u64>,
         dependent_table_id: TableId,
         handler_args: HandlerArgs,
-        seek_pk_row: Option<Row>,
+        seek_pk_row: Option<OwnedRow>,
     ) -> Result<RwBatchQueryPlanResult> {
         let session = handler_args.clone().session;
         let table_catalog = session.get_table_by_id(dependent_table_id)?;
@@ -987,39 +776,6 @@ impl SubscriptionCursor {
             version_id,
             seek_pk_row,
         )
-    }
-
-    async fn initiate_query(
-        rw_timestamp: Option<u64>,
-        dependent_table_id: TableId,
-        handler_args: HandlerArgs,
-        seek_pk_row: Option<Row>,
-    ) -> Result<(CursorDataChunkStream, Instant, Arc<TableCatalog>)> {
-        let init_query_timer = Instant::now();
-        let session = handler_args.clone().session;
-        let table_catalog = session.get_table_by_id(dependent_table_id)?;
-        let plan_result = Self::init_batch_plan_for_subscription_cursor(
-            rw_timestamp,
-            dependent_table_id,
-            handler_args.clone(),
-            seek_pk_row,
-        )?;
-        let plan_fragmenter_result = gen_batch_plan_fragmenter(&handler_args.session, plan_result)?;
-        let (chunk_stream, _) =
-            create_chunk_stream_for_cursor(handler_args.session, plan_fragmenter_result).await?;
-        Ok((chunk_stream, init_query_timer, table_catalog))
-    }
-
-    async fn try_refill_remaining_rows(
-        chunk_stream: &mut CursorDataChunkStream,
-        remaining_rows: &mut VecDeque<Row>,
-    ) -> Result<()> {
-        if remaining_rows.is_empty()
-            && let Some(row_set) = chunk_stream.next().await?
-        {
-            remaining_rows.extend(row_set?);
-        }
-        Ok(())
     }
 
     pub fn build_row(
@@ -1067,7 +823,7 @@ impl SubscriptionCursor {
         context: OptimizerContextRef,
         epoch_range: Option<(u64, u64)>,
         version_id: HummockVersionId,
-        seek_pk_rows: Option<Row>,
+        seek_pk_rows: Option<OwnedRow>,
     ) -> Result<RwBatchQueryPlanResult> {
         // pk + all column without hidden
         let output_col_idx = table_catalog
@@ -1094,17 +850,18 @@ impl SubscriptionCursor {
         let (scan, predicate) = if let Some(seek_pk_rows) = seek_pk_rows {
             let mut pk_rows = vec![];
             let mut values = vec![];
-            for (seek_pk, (data_type, column_index)) in
-                seek_pk_rows.take().into_iter().zip_eq_fast(pks.into_iter())
+            for (seek_pk, (data_type, column_index)) in seek_pk_rows
+                .into_inner()
+                .into_vec()
+                .into_iter()
+                .zip_eq_fast(pks.into_iter())
             {
                 if let Some(seek_pk) = seek_pk {
                     pk_rows.push(InputRef {
                         index: column_index,
                         data_type: data_type.clone(),
                     });
-                    let value_string = String::from_utf8(seek_pk.clone().into()).unwrap();
-                    let value_data = ScalarImpl::from_text(&value_string, data_type).unwrap();
-                    values.push((Some(value_data), data_type.clone()));
+                    values.push((Some(seek_pk), data_type.clone()));
                 }
             }
             if pk_rows.is_empty() {
@@ -1219,16 +976,16 @@ impl SubscriptionCursor {
     }
 
     pub fn state_info_string(&self) -> String {
-        format!("{}", self.state)
+        self.pg_response_stream.state_info_string()
     }
 }
 
+#[derive(Default)]
 pub struct CursorManager {
     cursor_map: tokio::sync::Mutex<HashMap<String, Cursor>>,
     /// Sender clones accessible without the cursor map lock held by FETCH.
     cursor_shutdown_sender_map: Mutex<HashMap<String, ShutdownSender>>,
     shutting_down: AtomicBool,
-    cursor_metrics: Arc<CursorMetrics>,
 }
 
 impl CursorManager {
@@ -1304,43 +1061,16 @@ impl CursorManager {
 }
 
 impl CursorManager {
-    pub fn new(cursor_metrics: Arc<CursorMetrics>) -> Self {
-        Self {
-            cursor_map: tokio::sync::Mutex::new(HashMap::new()),
-            cursor_shutdown_sender_map: Mutex::new(HashMap::new()),
-            shutting_down: AtomicBool::new(false),
-            cursor_metrics,
-        }
-    }
-
-    pub async fn add_subscription_cursor(
-        &self,
-        cursor_name: String,
-        start_timestamp: Option<u64>,
-        dependent_table_id: TableId,
-        subscription: Arc<SubscriptionCatalog>,
-        handler_args: &HandlerArgs,
-    ) -> Result<()> {
-        let create_cursor_timer = Instant::now();
-        let subscription_name = subscription.name.clone();
-        let cursor = SubscriptionCursor::new(
-            cursor_name,
-            start_timestamp,
-            subscription,
-            dependent_table_id,
-            handler_args,
-            self.cursor_metrics.clone(),
-        )
-        .await?;
+    /// Registers a constructed subscription cursor, rejecting insertion after shutdown.
+    pub async fn add_subscription_cursor(&self, cursor: SubscriptionCursor) -> Result<()> {
         let mut cursor_map = self.cursor_map.lock().await;
-        self.cursor_metrics
-            .subscription_cursor_declare_duration
-            .with_label_values(&[&subscription_name])
-            .observe(create_cursor_timer.elapsed().as_millis() as _);
 
         cursor_map.retain(|name, v| {
             if let Cursor::Subscription(cursor) = v
-                && matches!(cursor.state, State::Invalid)
+                && matches!(
+                    cursor.pg_response_stream.subscription_state(),
+                    SubscriptionCursorState::Invalid
+                )
             {
                 self.cursor_shutdown_sender_map.lock().remove(name);
                 false
@@ -1356,13 +1086,8 @@ impl CursorManager {
         )
     }
 
-    pub async fn add_query_cursor(
-        &self,
-        cursor_name: String,
-        chunk_stream: CursorDataChunkStream,
-        fields: Vec<Field>,
-    ) -> Result<()> {
-        let cursor = QueryCursor::new(chunk_stream, fields)?;
+    /// Registers a constructed query cursor, rejecting insertion after shutdown.
+    pub async fn add_query_cursor(&self, cursor_name: String, cursor: QueryCursor) -> Result<()> {
         let mut cursor_map = self.cursor_map.lock().await;
         self.insert_cursor(&mut cursor_map, cursor_name, Cursor::Query(cursor))
     }
@@ -1402,16 +1127,11 @@ impl CursorManager {
         timeout_seconds: Option<u64>,
         cancel_handle: &mut FetchCursorCancelHandle,
     ) -> Result<(Vec<Row>, Vec<PgFieldDescriptor>)> {
+        cancel_handle.register(&handler_args.session);
         if let Some(cursor) = self.cursor_map.lock().await.get_mut(cursor_name) {
-            let mut shutdown_rx = cursor.shutdown_handle().shutdown_token();
-            // Dropping FETCH's future is safe for terminal shutdown because the cursor is discarded.
-            tokio::select! {
-                biased;
-                _ = shutdown_rx.cancelled() => {
-                    Err(SchedulerError::QueryCancelled("cursor closed".to_owned()).into())
-                }
-                result = cursor.next(count, handler_args, formats, timeout_seconds, cancel_handle) => result,
-            }
+            cursor
+                .fetch(count, handler_args, formats, timeout_seconds, cancel_handle)
+                .await
         } else {
             Err(ErrorCode::InternalError(format!("Cannot find cursor `{}`", cursor_name)).into())
         }
@@ -1432,7 +1152,10 @@ impl CursorManager {
         for cursor in self.cursor_map.lock().await.values() {
             if let Cursor::Subscription(subscription_cursor) = cursor {
                 subscription_cursor_nums += 1;
-                if matches!(subscription_cursor.state, State::Invalid) {
+                if matches!(
+                    subscription_cursor.pg_response_stream.subscription_state(),
+                    SubscriptionCursorState::Invalid
+                ) {
                     invalid_subscription_cursor_nums += 1;
                 } else {
                     let fetch_duration =
@@ -1491,24 +1214,90 @@ impl CursorManager {
     }
 }
 
+// Statement timeouts are disabled unconditionally under madsim.
+#[cfg(all(test, not(madsim)))]
+mod cursor_query_startup_tests {
+    use std::time::Duration;
+
+    use futures::StreamExt;
+    use risingwave_sqlparser::parser::Parser;
+
+    use super::*;
+    use crate::handler::query::{gen_batch_plan_by_statement, gen_batch_plan_fragmenter};
+
+    /// Verifies that a local cursor query survives being left unread beyond `statement_timeout`
+    /// and subsequently returns every row without a timeout error.
+    #[tokio::test]
+    async fn test_local_cursor_query_does_not_inherit_statement_timeout() {
+        let session = Arc::new(SessionImpl::mock());
+        session
+            .set_config("visibility_mode", "all".to_owned())
+            .unwrap();
+        session
+            .set_config("query_mode", "local".to_owned())
+            .unwrap();
+        session
+            .set_config("statement_timeout", "50ms".to_owned())
+            .unwrap();
+        let _txn = session.txn_begin_implicit();
+        // The result exceeds the output channel's capacity, keeping execution active while unread.
+        let sql = "SELECT * FROM generate_series(1, 1000000)";
+        let stmt = Parser::parse_sql(sql).unwrap().pop().unwrap();
+        let args = HandlerArgs::new(session.clone(), &stmt, sql.into()).unwrap();
+        let context = OptimizerContext::from_handler_args(args);
+        let plan = gen_batch_plan_by_statement(&session, context.into(), stmt)
+            .unwrap()
+            .unwrap_rw()
+            .unwrap();
+        let fragment = gen_batch_plan_fragmenter(&session, plan).unwrap();
+        assert_eq!(fragment.query_mode, QueryMode::Local);
+        let snapshot = session.pinned_snapshot();
+        let (mut stream, _) = create_cursor_query_stream(session, fragment, snapshot)
+            .await
+            .unwrap();
+        let first_chunk = tokio::time::timeout(Duration::from_secs(5), stream.next())
+            .await
+            .expect("the local cursor query must produce its first chunk")
+            .unwrap()
+            .unwrap();
+        let mut rows = first_chunk.cardinality();
+
+        // Keep the cursor unread beyond the 50 ms statement timeout while backpressure keeps it
+        // active. Otherwise, a fast query could finish before the deadline and hide a regression.
+        tokio::time::sleep(Duration::from_millis(100)).await;
+
+        tokio::time::timeout(Duration::from_secs(5), async {
+            while let Some(chunk) = stream.next().await {
+                rows += chunk
+                    .expect("cursor execution must not time out")
+                    .cardinality();
+            }
+        })
+        .await
+        .expect("the cursor query must finish after consumption resumes");
+        assert_eq!(rows, 1000000);
+    }
+}
+
 #[cfg(test)]
 mod cursor_lifecycle_tests {
-    use std::collections::VecDeque;
     use std::sync::Arc;
     use std::time::{Duration, Instant};
 
     use futures::StreamExt;
     use risingwave_batch::task::ShutdownToken;
     use risingwave_common::array::{DataChunk, DataChunkTestExt};
-    use risingwave_common::catalog::TableId;
+    use risingwave_common::catalog::{Field, TableId};
     use risingwave_common::error::BoxedError;
     use risingwave_sqlparser::parser::Parser;
     use tokio::sync::mpsc;
     use tokio_stream::wrappers::ReceiverStream;
 
     use super::{
-        Cursor, CursorDataChunkStream, CursorManager, CursorQueryStream, CursorShutdownHandle,
-        FetchCursorCancelHandle, FieldsManager, State, SubscriptionCursor,
+        CursorManager, CursorQueryStream, CursorShutdownHandle, FetchCursorCancelHandle,
+        FieldsManager, QueryCursor, QueryCursorDataChunkStream, QueryCursorPgResponseStream,
+        SubscriptionCursor, SubscriptionCursorDataChunkStream, SubscriptionCursorHandlerContext,
+        SubscriptionCursorPgResponseStream, SubscriptionCursorState,
     };
     use crate::TableCatalog;
     use crate::catalog::subscription_catalog::SubscriptionCatalog;
@@ -1520,7 +1309,21 @@ mod cursor_lifecycle_tests {
     };
     use crate::session::SessionImpl;
 
-    impl CursorDataChunkStream {
+    impl QueryCursor {
+        /// Constructs a cursor around injected output without planning or starting an executor.
+        pub(crate) fn from_query_stream_for_test(
+            query_stream: CursorQueryStream,
+            fields: Vec<Field>,
+        ) -> Self {
+            let data_stream = QueryCursorDataChunkStream::new(query_stream, fields.clone());
+            Self {
+                shutdown_handle: CursorShutdownHandle::new(),
+                pg_response_stream: QueryCursorPgResponseStream::new(data_stream, fields),
+            }
+        }
+    }
+
+    impl CursorQueryStream {
         /// Creates a local cursor stream backed by `chunk_rx`, without a real executor.
         /// The shutdown pair only satisfies the wrapper's constructor: the receiver is unused,
         /// and the sender has no executor to cancel.
@@ -1528,23 +1331,30 @@ mod cursor_lifecycle_tests {
             chunk_rx: mpsc::Receiver<Result<DataChunk, BoxedError>>,
         ) -> Self {
             let (shutdown_tx, _shutdown_rx) = ShutdownToken::new();
-            Self::LocalDataChunk(Some(CursorQueryStream::local(
-                ReceiverStream::new(chunk_rx),
-                shutdown_tx,
-            )))
+            Self::local(ReceiverStream::new(chunk_rx), shutdown_tx)
         }
     }
 
+    /// Returns the cursor shutdown token, query shutdown token, and injected chunk sender.
+    /// The query token observes cancellation signalling; there is no real executor in this fixture.
     async fn add_pending_query_cursor(
         manager: &CursorManager,
         name: &str,
-    ) -> (ShutdownToken, mpsc::Sender<Result<DataChunk, BoxedError>>) {
+        fields: Vec<Field>,
+    ) -> (
+        ShutdownToken,
+        ShutdownToken,
+        mpsc::Sender<Result<DataChunk, BoxedError>>,
+    ) {
         let (chunk_tx, chunk_rx) = mpsc::channel(1);
+        let (shutdown_tx, shutdown_rx) = ShutdownToken::new();
         manager
             .add_query_cursor(
                 name.to_owned(),
-                CursorDataChunkStream::local_stream_without_executor_for_test(chunk_rx),
-                vec![],
+                QueryCursor::from_query_stream_for_test(
+                    CursorQueryStream::local(ReceiverStream::new(chunk_rx), shutdown_tx),
+                    fields,
+                ),
             )
             .await
             .unwrap();
@@ -1556,62 +1366,295 @@ mod cursor_lifecycle_tests {
             .unwrap()
             .shutdown_handle()
             .shutdown_token();
-        (token, chunk_tx)
+        (token, shutdown_rx, chunk_tx)
     }
 
     /// Creates a subscription cursor with a test-controlled pending stream for lifecycle tests.
-    /// `add_subscription_cursor` does not accept an injected stream: it looks up the catalog and
-    /// may start a snapshot query. Constructing `State::Fetch` directly avoids that setup while
-    /// `insert_cursor` still exercises normal cursor and shutdown-sender registration.
+    /// Constructing `SubscriptionCursorState::Fetch` directly avoids the catalog lookup and snapshot query
+    /// in `SubscriptionCursor::new`; `add_subscription_cursor` still exercises normal cursor and
+    /// shutdown-sender registration. Returns the cursor shutdown token, query shutdown token,
+    /// and injected chunk sender, like `add_pending_query_cursor`.
     async fn add_pending_subscription_cursor(
         manager: &CursorManager,
         name: &str,
-    ) -> (ShutdownToken, mpsc::Sender<Result<DataChunk, BoxedError>>) {
+        fields: FieldsManager,
+    ) -> (
+        ShutdownToken,
+        ShutdownToken,
+        mpsc::Sender<Result<DataChunk, BoxedError>>,
+    ) {
         let (chunk_tx, chunk_rx) = mpsc::channel(1);
+        let (shutdown_tx, shutdown_rx) = ShutdownToken::new();
+        let subscription = Arc::new(SubscriptionCatalog {
+            name: name.to_owned(),
+            retention_seconds: 60,
+            ..Default::default()
+        });
+        let cursor_metrics = Arc::new(CursorMetrics::for_test());
+        let state = SubscriptionCursorState::Fetch {
+            from_snapshot: true,
+            rw_timestamp: 0,
+            query_stream: CursorQueryStream::local(ReceiverStream::new(chunk_rx), shutdown_tx),
+            expected_timestamp: None,
+            init_query_timer: Instant::now(),
+        };
+        let response_state = state.strip_query_stream();
+        let output_fields = fields.get_output_fields();
+        let session = Arc::new(SessionImpl::mock());
+        let sql = "select 1";
+        let stmt = Parser::parse_sql(sql).unwrap().pop().unwrap();
+        let args = HandlerArgs::new(session, &stmt, sql.into()).unwrap();
+        let data_stream = SubscriptionCursorDataChunkStream::new(
+            subscription.clone(),
+            TableId::new(1),
+            SubscriptionCursorHandlerContext::new(&args),
+            fields,
+            state,
+            cursor_metrics.clone(),
+        );
         let cursor = SubscriptionCursor {
             shutdown_handle: CursorShutdownHandle::new(),
             cursor_name: name.to_owned(),
-            subscription: Arc::new(SubscriptionCatalog {
-                name: name.to_owned(),
-                retention_seconds: 60,
-                ..Default::default()
-            }),
+            subscription,
             dependent_table_id: TableId::new(1),
-            cursor_need_drop_time: Instant::now() + Duration::from_secs(60),
-            state: State::Fetch {
-                from_snapshot: true,
-                rw_timestamp: 0,
-                chunk_stream: CursorDataChunkStream::local_stream_without_executor_for_test(
-                    chunk_rx,
-                ),
-                remaining_rows: VecDeque::new(),
-                expected_timestamp: None,
-                init_query_timer: Instant::now(),
-            },
-            fields_manager: FieldsManager::new(&TableCatalog::default()),
-            cursor_metrics: manager.cursor_metrics.clone(),
+            pg_response_stream: SubscriptionCursorPgResponseStream::new(
+                data_stream,
+                output_fields,
+                response_state,
+                Instant::now() + Duration::from_secs(60),
+            ),
+            cursor_metrics,
             last_fetch: Instant::now(),
-            seek_pk_row: None,
         };
         let token = cursor.shutdown_handle.shutdown_token();
-        let mut cursor_map = manager.cursor_map.lock().await;
-        manager
-            .insert_cursor(
-                &mut cursor_map,
-                name.to_owned(),
-                Cursor::Subscription(cursor),
-            )
+        manager.add_subscription_cursor(cursor).await.unwrap();
+        (token, shutdown_rx, chunk_tx)
+    }
+
+    fn query_cursor_fetch_handler_args_for_test(session: Arc<SessionImpl>) -> HandlerArgs {
+        let sql = "fetch 10 from cursor";
+        let stmt = Parser::parse_sql(sql).unwrap().pop().unwrap();
+        HandlerArgs::new(session, &stmt, sql.into()).unwrap()
+    }
+
+    /// Verifies `CancelRequest` interrupts a pending FETCH without cancelling its channel-backed
+    /// cursor query, and another FETCH receives later output. No rows were consumed before cancel;
+    /// this is not a real executor or a transactional replay test.
+    #[tokio::test]
+    async fn test_query_cursor_fetch_cancellation_preserves_cursor_query() {
+        let session = Arc::new(SessionImpl::mock());
+        let manager = session.get_cursor_manager();
+        let (_, shutdown_rx, chunk_tx) = add_pending_query_cursor(
+            &manager,
+            "cursor",
+            vec![Field::with_name(
+                risingwave_common::types::DataType::Int32,
+                "v",
+            )],
+        )
+        .await;
+        let formats = vec![];
+        let mut cancel = FetchCursorCancelHandle::new();
+        let mut fetch = Box::pin(manager.get_rows_with_cursor(
+            "cursor",
+            1,
+            query_cursor_fetch_handler_args_for_test(session.clone()),
+            &formats,
+            None,
+            &mut cancel,
+        ));
+        assert!(futures::poll!(fetch.as_mut()).is_pending());
+        session.cancel_current_query();
+        let error = tokio::time::timeout(Duration::from_secs(1), fetch)
+            .await
+            .unwrap()
+            .unwrap_err();
+        assert!(error.to_string().contains("Cancelled by user"));
+        assert!(!shutdown_rx.is_cancelled());
+        assert!(!chunk_tx.is_closed());
+        chunk_tx
+            .try_send(Ok(DataChunk::from_pretty("i\n7")))
             .unwrap();
-        (token, chunk_tx)
+        let (rows, _) = manager
+            .get_rows_with_cursor(
+                "cursor",
+                1,
+                query_cursor_fetch_handler_args_for_test(session),
+                &formats,
+                None,
+                &mut FetchCursorCancelHandle::new(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(rows[0].values()[0].as_deref(), Some(b"7".as_slice()));
+        assert!(!shutdown_rx.is_cancelled());
+        manager.remove_cursor("cursor").await.unwrap();
+        assert!(shutdown_rx.is_cancelled());
+    }
+
+    /// Verifies a zero-timeout FETCH returns an immediately-ready row, and cancellation between
+    /// FETCH commands makes a reused cancel handle reject the next FETCH without consuming buffered rows.
+    /// No FETCH is active when cancellation is requested. This channel-backed fixture retains and
+    /// reuses the registered handle rather than exercising normal per-command handle lifetimes.
+    #[tokio::test]
+    async fn test_query_cursor_fetch_zero_timeout_and_cancellation_between_fetches() {
+        let session = Arc::new(SessionImpl::mock());
+        let manager = session.get_cursor_manager();
+        let (_, _shutdown_rx, chunk_tx) = add_pending_query_cursor(
+            &manager,
+            "cursor",
+            vec![Field::with_name(
+                risingwave_common::types::DataType::Int32,
+                "v",
+            )],
+        )
+        .await;
+        let mut cancel = FetchCursorCancelHandle::new();
+        chunk_tx
+            .try_send(Ok(DataChunk::from_pretty("i\n1\n2")))
+            .unwrap();
+        drop(chunk_tx);
+        let (rows, _) = manager
+            .get_rows_with_cursor(
+                "cursor",
+                10,
+                query_cursor_fetch_handler_args_for_test(session.clone()),
+                &vec![],
+                Some(0),
+                &mut cancel,
+            )
+            .await
+            .unwrap();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].values()[0].as_deref(), Some(b"1".as_slice()));
+        session.cancel_current_query();
+        assert!(
+            manager
+                .get_rows_with_cursor(
+                    "cursor",
+                    1,
+                    query_cursor_fetch_handler_args_for_test(session.clone()),
+                    &vec![],
+                    None,
+                    &mut cancel,
+                )
+                .await
+                .is_err()
+        );
+        let (rows, _) = manager
+            .get_rows_with_cursor(
+                "cursor",
+                10,
+                query_cursor_fetch_handler_args_for_test(session),
+                &vec![],
+                None,
+                &mut FetchCursorCancelHandle::new(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].values()[0].as_deref(), Some(b"2".as_slice()));
+    }
+
+    /// Verifies that a positive FETCH timeout returns accumulated rows while retaining a pending
+    /// channel-backed query, and a later FETCH can continue. This does not exercise SQL or an executor.
+    #[tokio::test]
+    async fn test_query_cursor_fetch_timeout_returns_rows_and_preserves_cursor_query() {
+        let session = Arc::new(SessionImpl::mock());
+        let manager = session.get_cursor_manager();
+        let (_, shutdown_rx, chunk_tx) = add_pending_query_cursor(
+            &manager,
+            "cursor",
+            vec![Field::with_name(
+                risingwave_common::types::DataType::Int32,
+                "v",
+            )],
+        )
+        .await;
+        chunk_tx
+            .try_send(Ok(DataChunk::from_pretty("i\n1\n2")))
+            .unwrap();
+        let formats = vec![];
+        let mut cancel = FetchCursorCancelHandle::new();
+        let started = tokio::time::Instant::now();
+        let mut fetch = Box::pin(manager.get_rows_with_cursor(
+            "cursor",
+            3,
+            query_cursor_fetch_handler_args_for_test(session.clone()),
+            &formats,
+            Some(1),
+            &mut cancel,
+        ));
+        assert!(futures::poll!(fetch.as_mut()).is_pending());
+        let (rows, _) = tokio::time::timeout(Duration::from_secs(5), fetch)
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(started.elapsed() >= Duration::from_secs(1));
+        assert_eq!(rows.len(), 2);
+        assert_eq!(rows[0].values()[0].as_deref(), Some(b"1".as_slice()));
+        assert_eq!(rows[1].values()[0].as_deref(), Some(b"2".as_slice()));
+        assert!(!shutdown_rx.is_cancelled());
+        assert!(!chunk_tx.is_closed());
+        chunk_tx
+            .try_send(Ok(DataChunk::from_pretty("i\n3")))
+            .unwrap();
+        let (rows, _) = manager
+            .get_rows_with_cursor(
+                "cursor",
+                1,
+                query_cursor_fetch_handler_args_for_test(session),
+                &vec![],
+                None,
+                &mut FetchCursorCancelHandle::new(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(rows[0].values()[0].as_deref(), Some(b"3".as_slice()));
+        assert!(!shutdown_rx.is_cancelled());
+    }
+
+    /// Verifies FETCH stops draining ready input after its deadline without relying on the timer
+    /// driver. Blocking a current-thread runtime simulates synchronous row work, not an executor.
+    // This regression needs real elapsed time without advancing the simulated timer driver.
+    #[cfg(not(madsim))]
+    #[tokio::test(flavor = "current_thread")]
+    async fn test_fetch_rows_stops_at_deadline_with_ready_input() {
+        let mut stream = futures::stream::iter((1..=3).map(|value| {
+            if value == 1 {
+                // Cross the deadline without yielding to the timer driver. Every input poll
+                // still returns Ready, including those for the remaining rows.
+                std::thread::sleep(Duration::from_millis(1100));
+            }
+            Ok(pgwire::types::Row::new(vec![Some(
+                value.to_string().into(),
+            )]))
+        }));
+        let rows = super::fetch_rows(
+            &mut stream,
+            3,
+            Some(1),
+            &mut FetchCursorCancelHandle::new(),
+            |_| {},
+        )
+        .await
+        .unwrap();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].values()[0].as_deref(), Some(b"1".as_slice()));
+        for expected in ["2", "3"] {
+            let row = stream.next().await.unwrap().unwrap();
+            assert_eq!(row.values()[0].as_deref(), Some(expected.as_bytes()));
+        }
+        assert!(stream.next().await.is_none());
     }
 
     /// Verifies that initiating shutdown signals all registered cursors and drops their streams
     /// before returning when the cursor map is unlocked.
     #[tokio::test]
     async fn test_cursor_shutdown_with_unlocked_map() {
-        let manager = Arc::new(CursorManager::new(Arc::new(CursorMetrics::for_test())));
-        let (first, first_tx) = add_pending_query_cursor(&manager, "first").await;
-        let (second, second_tx) = add_pending_query_cursor(&manager, "second").await;
+        let manager = Arc::new(CursorManager::default());
+        let (first, _, first_tx) = add_pending_query_cursor(&manager, "first", vec![]).await;
+        let (second, _, second_tx) = add_pending_query_cursor(&manager, "second", vec![]).await;
 
         manager.initiate_shutdown();
 
@@ -1625,9 +1668,9 @@ mod cursor_lifecycle_tests {
     /// locked cursor map, then drops their streams in the background after the lock is released.
     #[tokio::test]
     async fn test_cursor_shutdown_with_locked_map() {
-        let manager = Arc::new(CursorManager::new(Arc::new(CursorMetrics::for_test())));
-        let (first, first_tx) = add_pending_query_cursor(&manager, "first").await;
-        let (second, second_tx) = add_pending_query_cursor(&manager, "second").await;
+        let manager = Arc::new(CursorManager::default());
+        let (first, _, first_tx) = add_pending_query_cursor(&manager, "first", vec![]).await;
+        let (second, _, second_tx) = add_pending_query_cursor(&manager, "second", vec![]).await;
         let cursor_map = manager.cursor_map.lock().await;
 
         manager.initiate_shutdown();
@@ -1649,8 +1692,8 @@ mod cursor_lifecycle_tests {
     /// and signals late registrations while cleanup is blocked, and returns after stream drop.
     #[tokio::test]
     async fn test_cursor_shutdown_and_wait_blocks_until_streams_are_dropped() {
-        let manager = Arc::new(CursorManager::new(Arc::new(CursorMetrics::for_test())));
-        let (handle, chunk_tx) = add_pending_query_cursor(&manager, "cursor").await;
+        let manager = Arc::new(CursorManager::default());
+        let (handle, _, chunk_tx) = add_pending_query_cursor(&manager, "cursor", vec![]).await;
         let cursor_map = manager.cursor_map.lock().await;
         let mut shutdown = Box::pin(manager.shutdown_and_wait());
 
@@ -1679,10 +1722,15 @@ mod cursor_lifecycle_tests {
             for wait_for_cleanup in [false, true] {
                 let session = Arc::new(SessionImpl::mock());
                 let manager = session.get_cursor_manager();
-                let (token, chunk_tx) = if is_subscription {
-                    add_pending_subscription_cursor(&manager, "c").await
+                let (token, _, chunk_tx) = if is_subscription {
+                    add_pending_subscription_cursor(
+                        &manager,
+                        "c",
+                        FieldsManager::new(&TableCatalog::default()),
+                    )
+                    .await
                 } else {
-                    add_pending_query_cursor(&manager, "c").await
+                    add_pending_query_cursor(&manager, "c", vec![]).await
                 };
                 let sql = "FETCH 1 FROM c";
                 let stmt = Parser::parse_sql(sql).unwrap().pop().unwrap();
@@ -1729,13 +1777,15 @@ mod cursor_lifecycle_tests {
     /// shutdown begins, and its unregistered result stream is dropped.
     #[tokio::test]
     async fn test_cursor_shutdown_rejects_creation_waiting_for_map() {
-        let manager = Arc::new(CursorManager::new(Arc::new(CursorMetrics::for_test())));
+        let manager = Arc::new(CursorManager::default());
         let cursor_map = manager.cursor_map.lock().await;
         let (chunk_tx, chunk_rx) = mpsc::channel(1);
         let mut adding = Box::pin(manager.add_query_cursor(
             "late".to_owned(),
-            CursorDataChunkStream::local_stream_without_executor_for_test(chunk_rx),
-            vec![],
+            QueryCursor::from_query_stream_for_test(
+                CursorQueryStream::local_stream_without_executor_for_test(chunk_rx),
+                vec![],
+            ),
         ));
         assert!(futures::poll!(adding.as_mut()).is_pending());
 
@@ -1757,16 +1807,18 @@ mod cursor_lifecycle_tests {
     /// signaling the existing cursor or dropping its stream.
     #[tokio::test]
     async fn test_duplicate_cursor_name_rejects_new_cursor_and_preserves_existing_cursor() {
-        let manager = Arc::new(CursorManager::new(Arc::new(CursorMetrics::for_test())));
-        let (query, query_tx) = add_pending_query_cursor(&manager, "query").await;
+        let manager = Arc::new(CursorManager::default());
+        let (query, _, query_tx) = add_pending_query_cursor(&manager, "query", vec![]).await;
         let (duplicate_tx, duplicate_rx) = mpsc::channel(1);
 
         assert!(
             manager
                 .add_query_cursor(
                     "query".to_owned(),
-                    CursorDataChunkStream::local_stream_without_executor_for_test(duplicate_rx),
-                    vec![],
+                    QueryCursor::from_query_stream_for_test(
+                        CursorQueryStream::local_stream_without_executor_for_test(duplicate_rx),
+                        vec![],
+                    ),
                 )
                 .await
                 .is_err()
@@ -1781,10 +1833,14 @@ mod cursor_lifecycle_tests {
     /// another cursor untouched, and permits a new live cursor to reuse the closed cursor's name.
     #[tokio::test]
     async fn test_cursor_shutdown_preserves_other_cursor_and_allows_name_reuse() {
-        let manager = Arc::new(CursorManager::new(Arc::new(CursorMetrics::for_test())));
-        let (query, query_tx) = add_pending_query_cursor(&manager, "query").await;
-        let (subscription, subscription_tx) =
-            add_pending_subscription_cursor(&manager, "subscription").await;
+        let manager = Arc::new(CursorManager::default());
+        let (query, _, query_tx) = add_pending_query_cursor(&manager, "query", vec![]).await;
+        let (subscription, _, subscription_tx) = add_pending_subscription_cursor(
+            &manager,
+            "subscription",
+            FieldsManager::new(&TableCatalog::default()),
+        )
+        .await;
 
         manager.remove_cursor("query").await.unwrap();
 
@@ -1792,7 +1848,8 @@ mod cursor_lifecycle_tests {
         assert!(query_tx.is_closed());
         assert!(!subscription.is_cancelled());
         assert!(!subscription_tx.is_closed());
-        let (replacement, replacement_tx) = add_pending_query_cursor(&manager, "query").await;
+        let (replacement, _, replacement_tx) =
+            add_pending_query_cursor(&manager, "query", vec![]).await;
         assert!(!replacement.is_cancelled());
         assert!(!replacement_tx.is_closed());
     }
@@ -1801,10 +1858,14 @@ mod cursor_lifecycle_tests {
     /// leaving subscription cursors unsignalled with their streams still open.
     #[tokio::test]
     async fn test_all_query_cursors_shutdown_preserves_subscription_cursors() {
-        let manager = Arc::new(CursorManager::new(Arc::new(CursorMetrics::for_test())));
-        let (query, query_tx) = add_pending_query_cursor(&manager, "query").await;
-        let (subscription, subscription_tx) =
-            add_pending_subscription_cursor(&manager, "subscription").await;
+        let manager = Arc::new(CursorManager::default());
+        let (query, _, query_tx) = add_pending_query_cursor(&manager, "query", vec![]).await;
+        let (subscription, _, subscription_tx) = add_pending_subscription_cursor(
+            &manager,
+            "subscription",
+            FieldsManager::new(&TableCatalog::default()),
+        )
+        .await;
 
         manager.remove_all_query_cursor().await;
 
@@ -1818,10 +1879,14 @@ mod cursor_lifecycle_tests {
     /// the manager's lifetime: new live cursors can be declared using both removed names.
     #[tokio::test]
     async fn test_all_cursors_shutdown_allows_new_declarations() {
-        let manager = Arc::new(CursorManager::new(Arc::new(CursorMetrics::for_test())));
-        let (query, query_tx) = add_pending_query_cursor(&manager, "query").await;
-        let (subscription, subscription_tx) =
-            add_pending_subscription_cursor(&manager, "subscription").await;
+        let manager = Arc::new(CursorManager::default());
+        let (query, _, query_tx) = add_pending_query_cursor(&manager, "query", vec![]).await;
+        let (subscription, _, subscription_tx) = add_pending_subscription_cursor(
+            &manager,
+            "subscription",
+            FieldsManager::new(&TableCatalog::default()),
+        )
+        .await;
 
         manager.remove_all_cursor().await;
 
@@ -1829,9 +1894,14 @@ mod cursor_lifecycle_tests {
         assert!(query_tx.is_closed());
         assert!(subscription.is_cancelled());
         assert!(subscription_tx.is_closed());
-        let (new_query, new_query_tx) = add_pending_query_cursor(&manager, "query").await;
-        let (new_subscription, new_subscription_tx) =
-            add_pending_subscription_cursor(&manager, "subscription").await;
+        let (new_query, _, new_query_tx) =
+            add_pending_query_cursor(&manager, "query", vec![]).await;
+        let (new_subscription, _, new_subscription_tx) = add_pending_subscription_cursor(
+            &manager,
+            "subscription",
+            FieldsManager::new(&TableCatalog::default()),
+        )
+        .await;
         assert!(!new_query.is_cancelled());
         assert!(!new_query_tx.is_closed());
         assert!(!new_subscription.is_cancelled());
@@ -1839,9 +1909,8 @@ mod cursor_lifecycle_tests {
     }
 
     /// Verifies that unfinished local cursor shutdown via CLOSE signals its executor token and drops
-    /// its output stream without signaling the ordinary local query. A query cursor converts its
-    /// chunk stream to a row stream only when the first FETCH is invoked, so shutdown must work
-    /// with either representation.
+    /// its output stream without signaling the ordinary local query. Shutdown must work both
+    /// before and after the first FETCH initializes row formatting in the persistent adapter.
     #[tokio::test]
     async fn test_local_cursor_shutdown_preserves_ordinary_query() {
         // Simulate shutdown before the first FETCH (false) or after it initializes the row stream
@@ -1853,13 +1922,13 @@ mod cursor_lifecycle_tests {
             let (chunk_tx, chunk_rx) = mpsc::channel(1);
             let mut stream = CursorQueryStream::local(ReceiverStream::new(chunk_rx), shutdown_tx);
             assert!(futures::poll!(stream.next()).is_pending());
-            let mut stream = CursorDataChunkStream::LocalDataChunk(Some(stream));
+            let mut cursor = QueryCursor::from_query_stream_for_test(stream, vec![]);
             if initialize_rows {
-                stream.init_row_stream(&vec![], &vec![], session.clone());
+                cursor.pg_response_stream.begin_fetch(&[], &session);
             }
             let manager = session.get_cursor_manager();
             manager
-                .add_query_cursor("cursor".to_owned(), stream, vec![])
+                .add_query_cursor("cursor".to_owned(), cursor)
                 .await
                 .unwrap();
 
@@ -1894,8 +1963,8 @@ mod cursor_lifecycle_tests {
 
     /// Verifies that unfinished distributed cursor shutdown via CLOSE requests cancellation and
     /// removes its global and session registrations. Another registered query remains owned and
-    /// receives no cancellation request. A query cursor converts its chunk stream to a row stream
-    /// only when the first FETCH is invoked, so shutdown must work with either representation.
+    /// receives no cancellation request. Shutdown must work both before and after the first FETCH
+    /// initializes row formatting in the persistent adapter.
     #[tokio::test]
     async fn test_distributed_cursor_shutdown_cancels_only_owned_query() {
         // Simulate shutdown before the first FETCH (false) or after it initializes the row stream
@@ -1921,14 +1990,14 @@ mod cursor_lifecycle_tests {
                 manager.clone(),
             );
             assert!(futures::poll!(stream.next()).is_pending());
-            let mut chunk_stream = CursorDataChunkStream::DistributedDataChunk(Some(stream));
+            let mut cursor = QueryCursor::from_query_stream_for_test(stream, vec![]);
             if initialize_rows {
-                chunk_stream.init_row_stream(&vec![], &vec![], session.clone());
-                assert!(futures::poll!(std::pin::pin!(chunk_stream.next())).is_pending());
+                cursor.pg_response_stream.begin_fetch(&[], &session);
+                assert!(futures::poll!(cursor.pg_response_stream.next()).is_pending());
             }
             let cursors = session.get_cursor_manager();
             cursors
-                .add_query_cursor("cursor".to_owned(), chunk_stream, vec![])
+                .add_query_cursor("cursor".to_owned(), cursor)
                 .await
                 .unwrap();
 

--- a/src/frontend/src/session/cursor_stream.rs
+++ b/src/frontend/src/session/cursor_stream.rs
@@ -12,26 +12,33 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! Persistent cursor-stream infrastructure, separate from the active cursor execution path.
+//! Persistent raw cursor streams and PostgreSQL response adapters.
 
 use std::collections::VecDeque;
+use std::mem;
 use std::pin::Pin;
 use std::sync::{Arc, Weak};
 use std::task::{Context, Poll};
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 use futures::stream::BoxStream;
 use futures::{Stream, StreamExt};
 use futures_async_stream::try_stream;
 use pgwire::types::{Format, Row};
 use risingwave_common::array::DataChunk;
-use risingwave_common::catalog::Field;
+use risingwave_common::catalog::{Field, TableId};
 use risingwave_common::error::BoxedError;
+use risingwave_common::row::{OwnedRow, Row as _, RowExt as _};
 
-use super::{CursorQueryStream, FieldsManager, SubscriptionCursor};
+use super::{CursorQueryStream, FieldsManager, SubscriptionCursor, create_cursor_query_stream};
+use crate::TableCatalog;
+use crate::catalog::subscription_catalog::SubscriptionCatalog;
 use crate::error::{ErrorCode, Result};
 use crate::handler::HandlerArgs;
+use crate::handler::query::gen_batch_plan_fragmenter;
 use crate::handler::util::{StaticSessionData, to_pg_rows};
+use crate::monitor::CursorMetrics;
+use crate::scheduler::ReadSnapshot;
 use crate::session::SessionImpl;
 use crate::utils::WithOptions;
 
@@ -54,7 +61,7 @@ enum CursorDataChunkMetadata {
 }
 
 /// Unformatted executor output and the metadata needed to interpret its rows.
-struct CursorDataChunk {
+pub(super) struct CursorDataChunk {
     chunk: DataChunk,
     metadata: CursorDataChunkMetadata,
 }
@@ -63,7 +70,17 @@ impl CursorDataChunk {
     fn into_pg_rows(
         self,
         format: &CursorRowFormat,
-    ) -> Result<(VecDeque<Row>, CursorDataChunkMetadata)> {
+    ) -> Result<(VecDeque<CursorPgRow>, CursorDataChunkMetadata)> {
+        // Keep seek values typed and independent of the PostgreSQL result encoding.
+        let mut seek_keys = match &self.metadata {
+            CursorDataChunkMetadata::Query { .. } => None,
+            CursorDataChunkMetadata::Subscription { fields, .. } => Some(
+                self.chunk
+                    .rows()
+                    .map(|row| row.project(&fields.row_pk_indices).into_owned_row())
+                    .collect::<VecDeque<_>>(),
+            ),
+        };
         let (column_types, formats) = match &self.metadata {
             CursorDataChunkMetadata::Query { fields } => (
                 fields.iter().map(Field::data_type).collect::<Vec<_>>(),
@@ -74,13 +91,35 @@ impl CursorDataChunk {
                 from_snapshot,
                 ..
             } => {
-                let (row_fields, formats) =
-                    fields.get_row_stream_fields_and_formats(&format.formats, *from_snapshot);
-                (row_fields.iter().map(Field::data_type).collect(), formats)
+                let (row_fields, mut row_formats) =
+                    fields.get_row_stream_fields_and_formats(&format.formats, *from_snapshot)?;
+                // Raw chunks omit the synthetic columns appended by build_row.
+                row_formats.truncate(row_fields.len());
+                (
+                    row_fields.iter().map(Field::data_type).collect(),
+                    row_formats,
+                )
             }
         };
         let rows = to_pg_rows(&column_types, self.chunk, &formats, &format.session_data)?;
-        Ok((rows.into(), self.metadata))
+        // Each formatted subscription row must have one typed seek key from the same raw row.
+        // Query cursor rows have no seek keys.
+        debug_assert!(
+            seek_keys
+                .as_ref()
+                .is_none_or(|keys| keys.len() == rows.len())
+        );
+        let rows = rows
+            .into_iter()
+            .map(|row| CursorPgRow {
+                row,
+                seek_pk_row: seek_keys.as_mut().map(|keys| {
+                    keys.pop_front()
+                        .expect("one seek key per formatted subscription row")
+                }),
+            })
+            .collect();
+        Ok((rows, self.metadata))
     }
 }
 
@@ -88,7 +127,7 @@ impl CursorDataChunk {
 ///
 /// Unlike [`std::task::Poll::Pending`], each barrier identifies a specific transition rather
 /// than an arbitrary unfinished asynchronous operation. These events are not FETCH checkpoints.
-enum CursorDataChunkBarrier {
+pub(super) enum CursorDataChunkBarrier {
     /// The single query owned by a regular query cursor has completed.
     QueryEnd,
     /// A query for the subscription snapshot or a log-store epoch has started.
@@ -121,25 +160,25 @@ enum CursorDataChunkBarrier {
     /// The wait for the next log-store epoch has finished.
     /// The stream will check for available log-store epochs again.
     SubscriptionIdleEnded,
-    /// The output schema changed. End a nonwaiting FETCH or one that already yielded rows;
-    /// otherwise, continue with the new schema in the current FETCH.
+    /// The output schema changed. Always end the current FETCH before consuming new-schema
+    /// rows, even if it is empty and waiting. The new fields have already been published.
     SchemaChanged,
 }
 
 /// A raw data chunk or a control barrier, ordered by the cursor's persistent producer.
-enum CursorDataChunkEvent {
+pub(super) enum CursorDataChunkEvent {
     Chunk(CursorDataChunk),
     Barrier(CursorDataChunkBarrier),
 }
 
 /// A persistent producer of raw query chunks followed by a query-completion barrier.
-struct QueryCursorDataChunkStream {
+pub(super) struct QueryCursorDataChunkStream {
     /// Owns the query stream and its pending read across individual FETCH calls.
     inner: BoxStream<'static, std::result::Result<CursorDataChunkEvent, BoxedError>>,
 }
 
 impl QueryCursorDataChunkStream {
-    fn new(query_stream: CursorQueryStream, fields: Vec<Field>) -> Self {
+    pub(super) fn new(query_stream: CursorQueryStream, fields: Vec<Field>) -> Self {
         Self {
             inner: Self::event_stream(query_stream, fields).boxed(),
         }
@@ -169,12 +208,202 @@ impl Stream for QueryCursorDataChunkStream {
 }
 
 /// A persistent subscription event stream, independent of any single FETCH future.
-///
-/// TODO: Implement `event_stream` in the subsequent PR once the prerequisite snapshot-aware query
-/// startup and execution refactors are in place.
-struct SubscriptionCursorDataChunkStream {
+pub(super) struct SubscriptionCursorDataChunkStream {
     /// Owns the event producer, including its suspended asynchronous operations.
     inner: BoxStream<'static, std::result::Result<CursorDataChunkEvent, BoxedError>>,
+}
+
+impl SubscriptionCursorDataChunkStream {
+    /// Starts a snapshot or log-store query with the snapshot selected before asynchronous startup.
+    pub(super) async fn initiate_query(
+        rw_timestamp: Option<u64>,
+        dependent_table_id: TableId,
+        handler_args: HandlerArgs,
+        snapshot: ReadSnapshot,
+    ) -> Result<(CursorQueryStream, Instant, Arc<TableCatalog>)> {
+        let init_query_timer = Instant::now();
+        let session = handler_args.session.clone();
+        let table_catalog = session.get_table_by_id(dependent_table_id)?;
+        let plan_result = SubscriptionCursor::init_batch_plan_for_subscription_cursor(
+            rw_timestamp,
+            dependent_table_id,
+            handler_args,
+            None,
+        )?;
+        let plan_fragmenter_result = gen_batch_plan_fragmenter(&session, plan_result)?;
+        let (query_stream, _) =
+            create_cursor_query_stream(session, plan_fragmenter_result, snapshot).await?;
+        Ok((query_stream, init_query_timer, table_catalog))
+    }
+
+    /// FULL supplies `Fetch` with its query already started during DECLARE; SINCE supplies
+    /// `InitLogStoreQuery`. Constructing this container does not poll either state.
+    pub(super) fn new(
+        subscription: Arc<SubscriptionCatalog>,
+        dependent_table_id: TableId,
+        handler_context: SubscriptionCursorHandlerContext,
+        fields_manager: FieldsManager,
+        state: SubscriptionCursorState<CursorQueryStream>,
+        cursor_metrics: Arc<CursorMetrics>,
+    ) -> Self {
+        Self {
+            inner: Self::event_stream(
+                subscription,
+                dependent_table_id,
+                handler_context,
+                fields_manager,
+                state,
+                cursor_metrics,
+            )
+            .boxed(),
+        }
+    }
+
+    #[try_stream(ok = CursorDataChunkEvent, error = BoxedError)]
+    async fn event_stream(
+        subscription: Arc<SubscriptionCatalog>,
+        dependent_table_id: TableId,
+        handler_context: SubscriptionCursorHandlerContext,
+        fields_manager: FieldsManager,
+        mut state: SubscriptionCursorState<CursorQueryStream>,
+        cursor_metrics: Arc<CursorMetrics>,
+    ) {
+        let mut fields_manager = Arc::new(fields_manager);
+        loop {
+            match mem::replace(&mut state, SubscriptionCursorState::Invalid) {
+                SubscriptionCursorState::InitLogStoreQuery {
+                    seek_timestamp,
+                    expected_timestamp,
+                } => {
+                    let (rw_timestamp, next_expected_timestamp) =
+                        match SubscriptionCursor::get_next_rw_timestamp(
+                            seek_timestamp,
+                            dependent_table_id,
+                            expected_timestamp,
+                            handler_context.handler_args()?,
+                            &subscription,
+                        )
+                        .await?
+                        {
+                            (Some(rw_timestamp), next_expected_timestamp) => {
+                                (rw_timestamp, next_expected_timestamp)
+                            }
+                            (None, _) => {
+                                state = SubscriptionCursorState::InitLogStoreQuery {
+                                    seek_timestamp,
+                                    expected_timestamp,
+                                };
+                                yield CursorDataChunkEvent::Barrier(
+                                    CursorDataChunkBarrier::SubscriptionIdle,
+                                );
+                                let session = handler_context.handler_args()?.session;
+                                session
+                                    .env()
+                                    .hummock_snapshot_manager()
+                                    .wait_table_change_log_notification(
+                                        dependent_table_id,
+                                        seek_timestamp,
+                                    )
+                                    .await?;
+                                yield CursorDataChunkEvent::Barrier(
+                                    CursorDataChunkBarrier::SubscriptionIdleEnded,
+                                );
+                                continue;
+                            }
+                        };
+                    let handler_args = handler_context.handler_args()?;
+                    let snapshot = ReadSnapshot::FrontendPinned {
+                        snapshot: handler_args
+                            .session
+                            .env()
+                            .hummock_snapshot_manager()
+                            .acquire(),
+                    };
+                    let (query_stream, init_query_timer, catalog) = Self::initiate_query(
+                        Some(rw_timestamp),
+                        dependent_table_id,
+                        handler_args,
+                        snapshot,
+                    )
+                    .await?;
+                    let schema_changed =
+                        Arc::make_mut(&mut fields_manager).try_refill_fields(&catalog);
+                    let expires_at =
+                        Instant::now() + Duration::from_secs(subscription.retention_seconds);
+                    state = SubscriptionCursorState::Fetch {
+                        from_snapshot: false,
+                        rw_timestamp,
+                        query_stream,
+                        expected_timestamp: next_expected_timestamp,
+                        init_query_timer,
+                    };
+                    // Publish the new fields before ending FETCH so the next Parse/Describe
+                    // sees them. The current FETCH keeps its original response descriptors.
+                    yield CursorDataChunkEvent::Barrier(
+                        CursorDataChunkBarrier::SubscriptionQueryStarted {
+                            from_snapshot: false,
+                            rw_timestamp,
+                            expected_timestamp: next_expected_timestamp,
+                            init_query_timer,
+                            output_fields: fields_manager.get_output_fields(),
+                            expires_at,
+                        },
+                    );
+                    // Always stop before new-schema rows: even an empty waiting FETCH may
+                    // already have sent an extended-protocol Describe for the old schema.
+                    if schema_changed {
+                        yield CursorDataChunkEvent::Barrier(CursorDataChunkBarrier::SchemaChanged);
+                    }
+                }
+                SubscriptionCursorState::Fetch {
+                    from_snapshot,
+                    rw_timestamp,
+                    mut query_stream,
+                    expected_timestamp,
+                    init_query_timer,
+                } => match query_stream.next().await {
+                    Some(Ok(chunk)) => {
+                        state = SubscriptionCursorState::Fetch {
+                            from_snapshot,
+                            rw_timestamp,
+                            query_stream,
+                            expected_timestamp,
+                            init_query_timer,
+                        };
+                        yield CursorDataChunkEvent::Chunk(CursorDataChunk {
+                            chunk,
+                            metadata: CursorDataChunkMetadata::Subscription {
+                                fields: fields_manager.clone(),
+                                from_snapshot,
+                                rw_timestamp,
+                            },
+                        });
+                    }
+                    Some(Err(error)) => Err(error)?,
+                    None => {
+                        // EOF disarms the wrapper's unfinished-execution cancellation.
+                        drop(query_stream);
+                        cursor_metrics
+                            .subscription_cursor_query_duration
+                            .with_label_values(&[&subscription.name])
+                            .observe(init_query_timer.elapsed().as_millis() as _);
+                        let seek_timestamp = expected_timestamp.unwrap_or_else(|| rw_timestamp + 1);
+                        state = SubscriptionCursorState::InitLogStoreQuery {
+                            seek_timestamp,
+                            expected_timestamp,
+                        };
+                        yield CursorDataChunkEvent::Barrier(
+                            CursorDataChunkBarrier::SubscriptionNewEpoch {
+                                seek_timestamp,
+                                expected_timestamp,
+                            },
+                        );
+                    }
+                },
+                SubscriptionCursorState::Invalid => return Ok(()),
+            }
+        }
+    }
 }
 
 impl Stream for SubscriptionCursorDataChunkStream {
@@ -185,9 +414,10 @@ impl Stream for SubscriptionCursorDataChunkStream {
     }
 }
 
-/// Subscription position exposed to the response adapter by ordered control barriers.
-/// This is not a checkpoint for rolling back a cancelled FETCH.
-enum SubscriptionCursorState {
+/// Shared subscription state definition for the producer and its response adapter.
+/// The producer owns a `CursorQueryStream` in Fetch; the adapter uses `()` and tracks position
+/// through ordered barriers without duplicating query ownership. This is not a rollback checkpoint.
+pub(super) enum SubscriptionCursorState<QueryStream = ()> {
     /// Looking for the next available log-store epoch.
     InitLogStoreQuery {
         /// Lower bound for the next log-store epoch search.
@@ -205,14 +435,46 @@ enum SubscriptionCursorState {
         expected_timestamp: Option<u64>,
         /// When query initialization began, for duration metrics and diagnostics.
         init_query_timer: Instant,
+        /// Holds the actual query stream in the producer. The response adapter does not use this
+        /// field, so it uses the unit type `()` and assigns `()` instead.
+        query_stream: QueryStream,
     },
     /// The producer reported an unrecoverable error.
     Invalid,
 }
 
+impl<QueryStream> SubscriptionCursorState<QueryStream> {
+    /// Returns a copy of the cursor state with `query_stream` replaced by `()`.
+    pub(super) fn strip_query_stream(&self) -> SubscriptionCursorState {
+        match self {
+            Self::InitLogStoreQuery {
+                seek_timestamp,
+                expected_timestamp,
+            } => SubscriptionCursorState::InitLogStoreQuery {
+                seek_timestamp: *seek_timestamp,
+                expected_timestamp: *expected_timestamp,
+            },
+            Self::Fetch {
+                from_snapshot,
+                rw_timestamp,
+                expected_timestamp,
+                init_query_timer,
+                ..
+            } => SubscriptionCursorState::Fetch {
+                from_snapshot: *from_snapshot,
+                rw_timestamp: *rw_timestamp,
+                expected_timestamp: *expected_timestamp,
+                init_query_timer: *init_query_timer,
+                query_stream: (),
+            },
+            Self::Invalid => SubscriptionCursorState::Invalid,
+        }
+    }
+}
+
 /// Stored planning context for later subscription queries, without a strong session reference.
 /// Reconstructed handler arguments may still retain the session during an asynchronous operation.
-struct SubscriptionCursorHandlerContext {
+pub(super) struct SubscriptionCursorHandlerContext {
     session: Weak<SessionImpl>,
     sql: Arc<str>,
     normalized_sql: String,
@@ -220,7 +482,7 @@ struct SubscriptionCursorHandlerContext {
 }
 
 impl SubscriptionCursorHandlerContext {
-    fn new(handler_args: &HandlerArgs) -> Self {
+    pub(super) fn new(handler_args: &HandlerArgs) -> Self {
         Self {
             session: Arc::downgrade(&handler_args.session),
             sql: handler_args.sql.clone(),
@@ -259,6 +521,12 @@ impl CursorRowFormat {
     }
 }
 
+/// A formatted output row paired with its original typed subscription seek key, if any.
+struct CursorPgRow {
+    row: Row,
+    seek_pk_row: Option<OwnedRow>,
+}
+
 /// Shared row conversion and buffering for query and subscription response streams.
 /// Only unread formatted rows are retained; rows returned to FETCH cannot be replayed.
 ///
@@ -267,11 +535,10 @@ impl CursorRowFormat {
 struct CursorPgResponseStreamInner<S> {
     /// Released on terminal EOF or error, but retained across individual FETCH boundaries.
     data_stream: Option<S>,
-    /// Currently inspected only by subscription cursors; their integration will use it for
-    /// invalid-cursor cleanup and statistics. Query cursors also record this state for possible
-    /// future query-cursor failure statistics.
+    /// Records terminal failure without clearing it on subsequent EOF polls.
+    /// Subscription invalidity checks use `SubscriptionCursorState::Invalid` instead.
     failed: bool,
-    current_rows: VecDeque<Row>,
+    current_rows: VecDeque<CursorPgRow>,
     current_metadata: Option<Arc<CursorDataChunkMetadata>>,
     /// Fixed for each underlying query, matching the existing row-stream initialization.
     row_format: Option<Arc<CursorRowFormat>>,
@@ -282,7 +549,7 @@ struct CursorPgResponseStreamInner<S> {
 
 enum CursorPgResponsePollItem {
     Row {
-        row: Row,
+        row: CursorPgRow,
         metadata: Arc<CursorDataChunkMetadata>,
     },
     Barrier(CursorDataChunkBarrier),
@@ -368,22 +635,22 @@ where
 }
 
 /// A query response stream that retains unread rows across FETCH boundaries.
-struct QueryCursorPgResponseStream {
+pub(super) struct QueryCursorPgResponseStream {
     inner: CursorPgResponseStreamInner<QueryCursorDataChunkStream>,
 }
 
 impl QueryCursorPgResponseStream {
-    fn new(data_stream: QueryCursorDataChunkStream, output_fields: Vec<Field>) -> Self {
+    pub(super) fn new(data_stream: QueryCursorDataChunkStream, output_fields: Vec<Field>) -> Self {
         Self {
             inner: CursorPgResponseStreamInner::new(data_stream, output_fields),
         }
     }
 
-    fn fields(&self) -> Vec<Field> {
+    pub(super) fn fields(&self) -> Vec<Field> {
         self.inner.output_fields.clone()
     }
 
-    fn begin_fetch(&mut self, formats: &[Format], session: &SessionImpl) {
+    pub(super) fn begin_fetch(&mut self, formats: &[Format], session: &SessionImpl) {
         self.inner
             .begin_fetch(Arc::new(CursorRowFormat::new(formats, session)));
     }
@@ -401,7 +668,7 @@ impl Stream for QueryCursorPgResponseStream {
             Poll::Pending => Poll::Pending,
             Poll::Ready(Err(error)) => Poll::Ready(Some(Err(error))),
             Poll::Ready(Ok(CursorPgResponsePollItem::Row { row, .. })) => {
-                Poll::Ready(Some(Ok(row)))
+                Poll::Ready(Some(Ok(row.row)))
             }
             Poll::Ready(Ok(CursorPgResponsePollItem::Barrier(
                 CursorDataChunkBarrier::QueryEnd,
@@ -423,15 +690,14 @@ impl Stream for QueryCursorPgResponseStream {
 
 /// A subscription response stream that applies log-store epoch and schema barriers in order.
 /// Position and seek metadata advance as rows/events are consumed, without FETCH rollback.
-struct SubscriptionCursorPgResponseStream {
+pub(super) struct SubscriptionCursorPgResponseStream {
     inner: CursorPgResponseStreamInner<SubscriptionCursorDataChunkStream>,
     subscription_state: SubscriptionCursorState,
-    seek_pk_row: Option<Row>,
+    seek_pk_row: Option<OwnedRow>,
     expires_at: Instant,
     is_idle: bool,
     /// Whether an idle FETCH should wait when it has yielded no rows. Once rows have been
     /// yielded, idle always ends the FETCH, regardless of this flag.
-    /// Also allows an empty FETCH to continue past a schema boundary.
     should_wait_when_idle_and_empty: bool,
     yielded_rows: usize,
     /// Used for synthetic subscription columns; raw columns keep the query's row format.
@@ -439,7 +705,7 @@ struct SubscriptionCursorPgResponseStream {
 }
 
 impl SubscriptionCursorPgResponseStream {
-    fn new(
+    pub(super) fn new(
         data_stream: SubscriptionCursorDataChunkStream,
         output_fields: Vec<Field>,
         subscription_state: SubscriptionCursorState,
@@ -457,27 +723,50 @@ impl SubscriptionCursorPgResponseStream {
         }
     }
 
-    fn fields(&self) -> Vec<Field> {
+    pub(super) fn fields(&self) -> Vec<Field> {
         self.inner.output_fields.clone()
     }
 
-    fn subscription_state(&self) -> &SubscriptionCursorState {
+    pub(super) fn state_info_string(&self) -> String {
+        match self.subscription_state() {
+            SubscriptionCursorState::InitLogStoreQuery {
+                seek_timestamp,
+                expected_timestamp,
+            } => format!(
+                "InitLogStoreQuery {{ seek_timestamp: {}, expected_timestamp: {:?} }}",
+                seek_timestamp, expected_timestamp
+            ),
+            SubscriptionCursorState::Fetch {
+                from_snapshot,
+                rw_timestamp,
+                expected_timestamp,
+                init_query_timer,
+                ..
+            } => format!(
+                "Fetch {{ from_snapshot: {}, rw_timestamp: {}, expected_timestamp: {:?}, cached rows: {}, query init at {}ms before }}",
+                from_snapshot,
+                rw_timestamp,
+                expected_timestamp,
+                self.inner.current_rows.len(),
+                init_query_timer.elapsed().as_millis()
+            ),
+            SubscriptionCursorState::Invalid => "Invalid".to_owned(),
+        }
+    }
+
+    pub(super) fn subscription_state(&self) -> &SubscriptionCursorState {
         &self.subscription_state
     }
 
-    fn seek_pk_row(&self) -> Option<Row> {
+    pub(super) fn seek_pk_row(&self) -> Option<OwnedRow> {
         self.seek_pk_row.clone()
     }
 
-    fn is_expired(&self, now: Instant) -> bool {
+    pub(super) fn is_expired(&self, now: Instant) -> bool {
         now > self.expires_at
     }
 
-    fn is_failed(&self) -> bool {
-        self.inner.failed
-    }
-
-    fn begin_fetch(
+    pub(super) fn begin_fetch(
         &mut self,
         formats: &[Format],
         session: &SessionImpl,
@@ -490,7 +779,12 @@ impl SubscriptionCursorPgResponseStream {
         self.yielded_rows = 0;
     }
 
-    fn project_row(&mut self, row: Row, metadata: &CursorDataChunkMetadata) -> Result<Row> {
+    fn project_row(
+        &mut self,
+        row: Row,
+        seek_pk_row: Option<OwnedRow>,
+        metadata: &CursorDataChunkMetadata,
+    ) -> Result<Row> {
         let CursorDataChunkMetadata::Subscription {
             fields,
             from_snapshot,
@@ -503,15 +797,17 @@ impl SubscriptionCursorPgResponseStream {
             .into());
         };
         let format = self.fetch_format.as_ref().unwrap();
-        let row = SubscriptionCursor::build_row(
+        let (_, row_formats) =
+            fields.get_row_stream_fields_and_formats(&format.formats, *from_snapshot)?;
+        let mut row = SubscriptionCursor::build_row(
             row.take(),
             (!from_snapshot).then_some(*rw_timestamp),
-            &format.formats,
+            &row_formats,
             &format.session_data,
         )?;
-        let (mut rows, seek_pk_row) = fields.process_output_desc_row(vec![row]);
+        let row = row.project(&fields.row_output_col_indices);
         self.seek_pk_row = seek_pk_row;
-        Ok(rows.pop().unwrap())
+        Ok(row)
     }
 }
 
@@ -547,7 +843,7 @@ impl Stream for SubscriptionCursorPgResponseStream {
                     return Poll::Ready(Some(Err(error)));
                 }
                 Poll::Ready(Ok(CursorPgResponsePollItem::Row { row, metadata })) => {
-                    let row = this.project_row(row, &metadata);
+                    let row = this.project_row(row.row, row.seek_pk_row, &metadata);
                     if row.is_err() {
                         this.inner.mark_completed(true);
                         this.subscription_state = SubscriptionCursorState::Invalid;
@@ -569,6 +865,7 @@ impl Stream for SubscriptionCursorPgResponseStream {
                             expires_at,
                         } => {
                             this.subscription_state = SubscriptionCursorState::Fetch {
+                                query_stream: (),
                                 from_snapshot,
                                 rw_timestamp,
                                 expected_timestamp,
@@ -596,14 +893,17 @@ impl Stream for SubscriptionCursorPgResponseStream {
                         }
                         CursorDataChunkBarrier::SubscriptionIdleEnded => {}
                         CursorDataChunkBarrier::SchemaChanged => {
-                            // Rows preceding this barrier have been drained. Release their metadata
-                            // before continuing with the new schema or ending this FETCH.
+                            // Old-schema rows have been drained. Retain the producer and end the
+                            // current FETCH regardless of waiting mode, so that any new-schema rows
+                            // will be left for the next FETCH with latest description.
                             debug_assert!(this.inner.current_rows.is_empty());
                             this.inner.current_metadata = None;
-                            if this.yielded_rows > 0 || !this.should_wait_when_idle_and_empty {
-                                this.inner.fetch_stream_terminated = true;
-                                return Poll::Ready(None);
-                            }
+                            // No new-query rows have been formatted yet. The next FETCH supplies
+                            // formats for its new schema, which may have a different column count,
+                            // so the current format should not be used any more.
+                            this.inner.row_format = None;
+                            this.inner.fetch_stream_terminated = true;
+                            return Poll::Ready(None);
                         }
                         CursorDataChunkBarrier::QueryEnd => {
                             this.inner.mark_completed(true);
@@ -635,13 +935,18 @@ mod tests {
     use std::sync::atomic::{AtomicUsize, Ordering};
     use std::time::Duration;
 
+    use pgwire::pg_server::Session as _;
     use risingwave_batch::task::ShutdownToken;
     use risingwave_common::array::DataChunkTestExt;
     use risingwave_common::types::DataType;
+    use risingwave_sqlparser::parser::Parser;
     use tokio::sync::{mpsc, oneshot};
     use tokio_stream::wrappers::ReceiverStream;
 
+    use super::super::{CursorShutdownHandle, FetchCursorCancelHandle};
     use super::*;
+    use crate::handler::fetch_cursor::handle_parse;
+    use crate::handler::util::to_pg_field;
 
     /// Verifies that the cursor data chunk stream preserves chunks and schema, then emits
     /// `QueryEnd` and EOF; this does not exercise a real executor.
@@ -760,6 +1065,118 @@ mod tests {
         ));
         assert_eq!(wait_starts.load(Ordering::Relaxed), 1);
         assert!(stream.next().await.is_none());
+    }
+
+    /// Creates a subscription cursor data chunk stream for a FULL subscription cursor, starting in
+    /// `SubscriptionCursorState::Fetch` with the supplied query stream. This bypasses real snapshot
+    /// selection and query startup. The handler context contains an empty weak session reference,
+    /// so attempting to look up the next log-store epoch returns an error.
+    fn full_subscription_cursor_data_chunk_stream_with_empty_weak_session_ref_for_test(
+        query_stream: CursorQueryStream,
+    ) -> SubscriptionCursorDataChunkStream {
+        SubscriptionCursorDataChunkStream::new(
+            Arc::new(SubscriptionCatalog {
+                name: "subscription".to_owned(),
+                retention_seconds: 60,
+                ..Default::default()
+            }),
+            TableId::new(1),
+            SubscriptionCursorHandlerContext {
+                session: Weak::new(),
+                sql: "".into(),
+                normalized_sql: String::new(),
+                with_options: WithOptions::default(),
+            },
+            subscription_fields_for_test("v").as_ref().clone(),
+            SubscriptionCursorState::Fetch {
+                from_snapshot: true,
+                rw_timestamp: 12,
+                expected_timestamp: Some(20),
+                init_query_timer: Instant::now(),
+                query_stream,
+            },
+            Arc::new(CursorMetrics::for_test()),
+        )
+    }
+
+    /// Verifies that a subscription cursor data chunk stream retains its pending channel-backed
+    /// query, yields snapshot chunks, then advances to the expected log-store epoch without
+    /// cancellation. This does not exercise query startup, real snapshot selection, or log-store
+    /// notifications.
+    #[tokio::test]
+    async fn test_subscription_cursor_data_chunk_stream_preserves_pending_query_and_advances_epoch()
+    {
+        let (shutdown_tx, shutdown_rx) = ShutdownToken::new();
+        let (chunk_tx, chunk_rx) = mpsc::channel(2);
+        let mut stream =
+            full_subscription_cursor_data_chunk_stream_with_empty_weak_session_ref_for_test(
+                CursorQueryStream::local(ReceiverStream::new(chunk_rx), shutdown_tx),
+            );
+        for _ in 0..2 {
+            let mut next = Box::pin(stream.next());
+            assert!(futures::poll!(next.as_mut()).is_pending());
+            drop(next);
+            assert!(!chunk_tx.is_closed());
+            assert!(!shutdown_rx.is_cancelled());
+        }
+        let expected = DataChunk::from_pretty("i i\n7 42");
+        chunk_tx.try_send(Ok(expected.clone())).unwrap();
+        chunk_tx.try_send(Ok(expected.clone())).unwrap();
+        drop(chunk_tx);
+        let mut previous_fields = None;
+        for _ in 0..2 {
+            let CursorDataChunkEvent::Chunk(chunk) = stream.next().await.unwrap().unwrap() else {
+                panic!("expected the existing snapshot query's chunk");
+            };
+            assert_eq!(chunk.chunk, expected);
+            let CursorDataChunkMetadata::Subscription {
+                fields,
+                from_snapshot,
+                rw_timestamp,
+            } = chunk.metadata
+            else {
+                panic!("expected subscription metadata");
+            };
+            assert!(from_snapshot);
+            assert_eq!(rw_timestamp, 12);
+            if let Some(previous) = previous_fields {
+                assert!(Arc::ptr_eq(&previous, &fields));
+            }
+            previous_fields = Some(fields);
+        }
+        assert!(matches!(
+            stream.next().await.unwrap().unwrap(),
+            CursorDataChunkEvent::Barrier(CursorDataChunkBarrier::SubscriptionNewEpoch {
+                seek_timestamp: 20,
+                expected_timestamp: Some(20),
+            })
+        ));
+        assert!(!shutdown_rx.is_cancelled());
+        // Only the next poll attempts a lookup; this fixture deliberately has no live session.
+        let error = stream.next().await.unwrap().err().unwrap();
+        assert!(error.to_string().contains("session ended"));
+        assert!(!shutdown_rx.is_cancelled());
+    }
+
+    /// Verifies that an injected query error terminates the subscription cursor data chunk stream
+    /// and requests cancellation of its failed query. The channel-backed input is also dropped;
+    /// token signaling is not proof of real executor termination.
+    #[tokio::test]
+    async fn test_subscription_cursor_data_chunk_stream_cancels_failed_query() {
+        let (shutdown_tx, shutdown_rx) = ShutdownToken::new();
+        let (chunk_tx, chunk_rx) = mpsc::channel(1);
+        let mut stream =
+            full_subscription_cursor_data_chunk_stream_with_empty_weak_session_ref_for_test(
+                CursorQueryStream::local(ReceiverStream::new(chunk_rx), shutdown_tx),
+            );
+        chunk_tx
+            .try_send(Err(anyhow::anyhow!("injected query failure").into()))
+            .unwrap();
+        let error = stream.next().await.unwrap().err().unwrap();
+        assert!(error.to_string().contains("injected query failure"));
+        assert!(stream.next().await.is_none());
+        assert!(chunk_tx.is_closed());
+        assert!(shutdown_rx.is_cancelled());
     }
 
     fn assert_text_row(row: &Row, expected: &[Option<&str>]) {
@@ -917,13 +1334,145 @@ mod tests {
                 [Some("42"), Some("Delete"), Some("1700000000000")]
             };
             assert_text_row(&row, &expected);
-            assert_text_row(&stream.seek_pk_row().unwrap(), &[Some("7")]);
+            assert_eq!(
+                stream.seek_pk_row().unwrap(),
+                OwnedRow::new(vec![Some(7i32.into())])
+            );
         }
     }
 
-    /// Verifies that the subscription response stream continues through a schema change when a
-    /// waiting FETCH has no rows, but stops when nonwaiting or after yielding rows. Ordered barriers
-    /// also update position and expiry; this uses injected events, not SQL FETCH or a real executor.
+    /// Verifies zero, single, and per-column format codes for snapshot and log-store output.
+    /// The fixture has a hidden key, so output-format positions differ from raw-column positions.
+    /// Events are injected directly; protocol coverage lives in the extended-mode E2E suite.
+    #[tokio::test]
+    async fn test_subscription_cursor_pg_response_stream_honors_result_format_codes() {
+        let session = SessionImpl::mock();
+        let fields = subscription_fields_for_test("v");
+        let timestamp = 1700000000000i64;
+        let rw_timestamp =
+            crate::handler::util::convert_unix_millis_to_logstore_u64(timestamp as u64);
+        for from_snapshot in [true, false] {
+            for (formats, binary_value, binary_timestamp) in [
+                (vec![], false, false),
+                (vec![Format::Binary], true, true),
+                (
+                    vec![Format::Binary, Format::Text, Format::Text],
+                    true,
+                    false,
+                ),
+                (
+                    vec![Format::Text, Format::Binary, Format::Binary],
+                    false,
+                    true,
+                ),
+            ] {
+                let (mut stream, event_tx) =
+                    pending_subscription_response_stream_for_test(&fields, Instant::now());
+                let chunk = if from_snapshot {
+                    "i i\n7 42"
+                } else {
+                    "i i T\n7 42 Delete"
+                };
+                event_tx
+                    .try_send(Ok(subscription_chunk_for_test(
+                        fields.clone(),
+                        from_snapshot,
+                        rw_timestamp,
+                        chunk,
+                    )))
+                    .unwrap();
+                stream.begin_fetch(&formats, &session, false);
+                let row = stream.next().await.unwrap().unwrap();
+                let value = if binary_value {
+                    42i32.to_be_bytes().to_vec()
+                } else {
+                    b"42".to_vec()
+                };
+                let timestamp = if from_snapshot {
+                    None
+                } else if binary_timestamp {
+                    Some(timestamp.to_be_bytes().to_vec())
+                } else {
+                    Some(timestamp.to_string().into_bytes())
+                };
+                assert_eq!(row.values().len(), 3);
+                assert_eq!(row.values()[0].as_deref(), Some(value.as_slice()));
+                assert_eq!(
+                    row.values()[1].as_deref(),
+                    Some(if from_snapshot {
+                        b"Insert".as_slice()
+                    } else {
+                        b"Delete".as_slice()
+                    })
+                );
+                assert_eq!(row.values()[2].as_deref(), timestamp.as_deref());
+                assert_eq!(
+                    stream.seek_pk_row(),
+                    Some(OwnedRow::new(vec![Some(7i32.into())]))
+                );
+            }
+        }
+    }
+
+    /// Verifies that binary-formatted subscription rows retain typed seek keys in declared primary
+    /// key order, advancing per yielded row rather than per chunk. This uses injected snapshot
+    /// events.
+    #[tokio::test]
+    async fn test_subscription_cursor_pg_response_stream_preserves_typed_seek_keys_with_binary_rows()
+     {
+        use risingwave_common::catalog::{ColumnCatalog, ColumnDesc, ColumnId};
+        use risingwave_common::util::sort_util::{ColumnOrder, OrderType};
+
+        let session = SessionImpl::mock();
+        let catalog = TableCatalog {
+            columns: vec![
+                ColumnCatalog::visible(ColumnDesc::named("a", ColumnId::new(1), DataType::Int32)),
+                ColumnCatalog::visible(ColumnDesc::named("b", ColumnId::new(2), DataType::Int32)),
+            ],
+            pk: vec![
+                ColumnOrder::new(1, OrderType::ascending()),
+                ColumnOrder::new(0, OrderType::ascending()),
+            ],
+            ..Default::default()
+        };
+        let fields = Arc::new(FieldsManager::new(&catalog));
+        let (mut stream, event_tx) =
+            pending_subscription_response_stream_for_test(&fields, Instant::now());
+        event_tx
+            .try_send(Ok(subscription_chunk_for_test(
+                fields,
+                true,
+                12,
+                "i i\n7 42\n8 43",
+            )))
+            .unwrap();
+        stream.begin_fetch(&[Format::Binary], &session, false);
+        assert!(stream.seek_pk_row().is_none());
+        let row = stream.next().await.unwrap().unwrap();
+        assert_eq!(
+            row.values()[0].as_deref(),
+            Some(7i32.to_be_bytes().as_slice())
+        );
+        assert_eq!(
+            stream.seek_pk_row(),
+            Some(OwnedRow::new(vec![Some(42i32.into()), Some(7i32.into())]))
+        );
+        assert_eq!(stream.inner.current_rows.len(), 1);
+        stream.begin_fetch(&[Format::Binary], &session, false);
+        let row = stream.next().await.unwrap().unwrap();
+        assert_eq!(
+            row.values()[0].as_deref(),
+            Some(8i32.to_be_bytes().as_slice())
+        );
+        assert_eq!(
+            stream.seek_pk_row(),
+            Some(OwnedRow::new(vec![Some(43i32.into()), Some(8i32.into())]))
+        );
+    }
+
+    /// Verifies that every schema boundary ends the subscription response stream's current FETCH,
+    /// with new fields, position, and expiry already visible but new-schema rows left unread.
+    /// This uses injected events, not SQL FETCH or a real executor.
     #[tokio::test]
     async fn test_subscription_cursor_pg_response_stream_handles_log_store_epoch_and_schema_boundaries()
      {
@@ -961,7 +1510,6 @@ mod tests {
             assert!(stream.is_expired(initial_expiry + Duration::from_secs(1)));
 
             for event in [
-                CursorDataChunkEvent::Barrier(CursorDataChunkBarrier::SchemaChanged),
                 CursorDataChunkEvent::Barrier(CursorDataChunkBarrier::SubscriptionQueryStarted {
                     from_snapshot: false,
                     rw_timestamp: 12,
@@ -970,6 +1518,7 @@ mod tests {
                     output_fields: new_fields.get_output_fields(),
                     expires_at: renewed_expiry,
                 }),
+                CursorDataChunkEvent::Barrier(CursorDataChunkBarrier::SchemaChanged),
                 subscription_chunk_for_test(
                     new_fields.clone(),
                     false,
@@ -980,7 +1529,6 @@ mod tests {
                     seek_timestamp: 20,
                     expected_timestamp: Some(20),
                 }),
-                CursorDataChunkEvent::Barrier(CursorDataChunkBarrier::SchemaChanged),
                 CursorDataChunkEvent::Barrier(CursorDataChunkBarrier::SubscriptionQueryStarted {
                     from_snapshot: false,
                     rw_timestamp: 20,
@@ -989,6 +1537,7 @@ mod tests {
                     output_fields: latest_fields.get_output_fields(),
                     expires_at: latest_expiry,
                 }),
+                CursorDataChunkEvent::Barrier(CursorDataChunkBarrier::SchemaChanged),
                 subscription_chunk_for_test(
                     latest_fields.clone(),
                     false,
@@ -999,21 +1548,23 @@ mod tests {
                 event_tx.try_send(Ok(event)).unwrap();
             }
 
-            // With no accumulated rows, only a nonwaiting FETCH stops at the first schema change.
-            if !should_wait_when_idle_and_empty {
-                assert!(stream.next().await.is_none());
-                assert!(stream.inner.current_metadata.is_none());
-                assert_eq!(stream.fields(), old_fields.get_output_fields());
-                assert!(stream.is_expired(initial_expiry + Duration::from_secs(1)));
-                assert!(matches!(
-                    stream.subscription_state(),
-                    SubscriptionCursorState::InitLogStoreQuery {
-                        seek_timestamp: 12,
-                        expected_timestamp: Some(12),
-                    }
-                ));
-                stream.begin_fetch(&[], &session, should_wait_when_idle_and_empty);
-            }
+            // Even an empty waiting FETCH stops. Publish the next query's metadata before
+            // the boundary so the next Parse/Describe sees the schema of its unread rows.
+            assert!(stream.next().await.is_none());
+            assert!(stream.inner.current_rows.is_empty());
+            assert!(stream.inner.current_metadata.is_none());
+            assert_eq!(stream.fields(), new_fields.get_output_fields());
+            assert!(!stream.is_expired(initial_expiry + Duration::from_secs(1)));
+            assert!(stream.is_expired(renewed_expiry + Duration::from_secs(1)));
+            assert!(matches!(
+                stream.subscription_state(),
+                SubscriptionCursorState::Fetch {
+                    rw_timestamp: 12,
+                    expected_timestamp: Some(20),
+                    ..
+                }
+            ));
+            stream.begin_fetch(&[], &session, should_wait_when_idle_and_empty);
             let row = stream.next().await.unwrap().unwrap();
             assert_eq!(row.values()[0].as_deref(), Some(b"99".as_slice()));
             assert_eq!(stream.fields(), new_fields.get_output_fields());
@@ -1034,24 +1585,25 @@ mod tests {
             // Drain the buffered row before reading the second schema barrier; do not discard it.
             let row = stream.next().await.unwrap().unwrap();
             assert_eq!(row.values()[0].as_deref(), Some(b"100".as_slice()));
-            // This FETCH has yielded two rows, so the second schema change must end it even in
-            // waiting mode, before consuming the next query's metadata or rows.
+            // The second boundary also ends FETCH after its two old-schema rows, with the
+            // latest metadata published but no rows from that query consumed.
             assert!(stream.next().await.is_none());
             assert!(stream.inner.current_rows.is_empty());
             assert!(stream.inner.current_metadata.is_none());
             assert!(!event_tx.is_closed());
-            assert_eq!(stream.fields(), new_fields.get_output_fields());
+            assert_eq!(stream.fields(), latest_fields.get_output_fields());
             assert!(matches!(
                 stream.subscription_state(),
-                SubscriptionCursorState::InitLogStoreQuery {
-                    seek_timestamp: 20,
-                    expected_timestamp: Some(20),
+                SubscriptionCursorState::Fetch {
+                    rw_timestamp: 20,
+                    expected_timestamp: None,
+                    ..
                 }
             ));
-            assert!(!stream.is_expired(initial_expiry + Duration::from_secs(1)));
-            assert!(stream.is_expired(renewed_expiry + Duration::from_secs(1)));
+            assert!(!stream.is_expired(renewed_expiry + Duration::from_secs(1)));
+            assert!(stream.is_expired(latest_expiry + Duration::from_secs(1)));
 
-            // The next query's metadata and chunk remain unread until the next FETCH begins.
+            // The next query's first chunk remains unread until the next FETCH begins.
             stream.begin_fetch(&[], &session, should_wait_when_idle_and_empty);
             let row = stream.next().await.unwrap().unwrap();
             assert_eq!(row.values()[0].as_deref(), Some(b"changed".as_slice()));
@@ -1067,6 +1619,143 @@ mod tests {
             ));
             assert!(!stream.is_expired(renewed_expiry + Duration::from_secs(1)));
             assert!(stream.is_expired(latest_expiry + Duration::from_secs(1)));
+        }
+    }
+
+    /// Verifies a subscription FETCH retains its response fields while the next Parse/Describe
+    /// sees the new schema, for empty and nonempty FETCH commands with or without waiting.
+    /// This uses injected events, not SQL FETCH or a real executor.
+    #[tokio::test]
+    async fn test_subscription_cursor_fetch_preserves_response_fields_across_schema_change() {
+        let old_fields = subscription_fields_for_test("v");
+        let mut new_fields = old_fields.as_ref().clone();
+        // Simulate adding a visible column between the old value and the synthetic columns.
+        new_fields
+            .row_fields
+            .insert(2, Field::with_name(DataType::Varchar, "added_value"));
+        new_fields.row_output_col_indices = vec![1, 2, 3, 4];
+        new_fields.stream_chunk_row_indices = vec![0, 1, 2];
+        new_fields.op_index = 3;
+        let new_fields = Arc::new(new_fields);
+        let expected_old_desc = old_fields
+            .get_output_fields()
+            .iter()
+            .map(to_pg_field)
+            .collect::<Vec<_>>();
+        let expected_new_desc = new_fields
+            .get_output_fields()
+            .iter()
+            .map(to_pg_field)
+            .collect::<Vec<_>>();
+
+        // SubscriptionCursor::fetch enables idle waiting only for a positive timeout:
+        // None is nonwaiting; Some(5) allows an empty FETCH to wait. SchemaChanged must
+        // end both immediately, without waiting for the timeout or consuming new-schema rows.
+        for timeout_seconds in [None, Some(5)] {
+            // false reaches the boundary with no rows; true queues an old-schema row first,
+            // so FETCH must return that accumulated row with its original descriptors.
+            for has_old_row in [false, true] {
+                let session = Arc::new(SessionImpl::mock());
+                let manager = session.get_cursor_manager();
+                let expires_at = Instant::now() + Duration::from_secs(60);
+                let (pg_response_stream, event_tx) =
+                    pending_subscription_response_stream_for_test(&old_fields, expires_at);
+                manager
+                    .add_subscription_cursor(SubscriptionCursor {
+                        shutdown_handle: CursorShutdownHandle::new(),
+                        cursor_name: "cursor".to_owned(),
+                        subscription: Arc::new(SubscriptionCatalog {
+                            name: "subscription".to_owned(),
+                            retention_seconds: 60,
+                            ..Default::default()
+                        }),
+                        dependent_table_id: TableId::new(1),
+                        pg_response_stream,
+                        cursor_metrics: session.env().cursor_metrics.clone(),
+                        last_fetch: Instant::now(),
+                    })
+                    .await
+                    .unwrap();
+                if has_old_row {
+                    event_tx
+                        .try_send(Ok(subscription_chunk_for_test(
+                            old_fields.clone(),
+                            true,
+                            0,
+                            "i i\n7 42",
+                        )))
+                        .unwrap();
+                }
+                for event in [
+                    CursorDataChunkEvent::Barrier(
+                        CursorDataChunkBarrier::SubscriptionQueryStarted {
+                            from_snapshot: false,
+                            rw_timestamp: 12,
+                            expected_timestamp: None,
+                            init_query_timer: Instant::now(),
+                            output_fields: new_fields.get_output_fields(),
+                            expires_at,
+                        },
+                    ),
+                    CursorDataChunkEvent::Barrier(CursorDataChunkBarrier::SchemaChanged),
+                    subscription_chunk_for_test(
+                        new_fields.clone(),
+                        false,
+                        12,
+                        "i i T T\n8 99 added Insert",
+                    ),
+                ] {
+                    event_tx.try_send(Ok(event)).unwrap();
+                }
+
+                let sql = "fetch 10 from cursor";
+                let stmt = Parser::parse_sql(sql).unwrap().pop().unwrap();
+                let args = HandlerArgs::new(session.clone(), &stmt, sql.into()).unwrap();
+                let prepared = handle_parse(args.clone(), stmt.clone(), vec![])
+                    .await
+                    .unwrap();
+                let (_, described_fields) = session.clone().describe_statement(prepared).unwrap();
+                assert_eq!(described_fields, expected_old_desc);
+
+                // Explicit per-column codes must be selected again for the new column count.
+                let (rows, response_fields) = manager
+                    .get_rows_with_cursor(
+                        "cursor",
+                        10,
+                        args.clone(),
+                        &vec![Format::Text; described_fields.len()],
+                        timeout_seconds,
+                        &mut FetchCursorCancelHandle::new(),
+                    )
+                    .await
+                    .unwrap();
+                assert_eq!(rows.len(), usize::from(has_old_row));
+                if has_old_row {
+                    assert_text_row(&rows[0], &[Some("42"), Some("Insert"), None]);
+                }
+                // Simple mode uses these response fields; extended mode already described them.
+                assert_eq!(response_fields, described_fields);
+                assert!(!event_tx.is_closed());
+
+                let prepared = handle_parse(args.clone(), stmt, vec![]).await.unwrap();
+                let (_, described_fields) = session.clone().describe_statement(prepared).unwrap();
+                assert_eq!(described_fields, expected_new_desc);
+                let (rows, response_fields) = manager
+                    .get_rows_with_cursor(
+                        "cursor",
+                        1,
+                        args,
+                        &vec![Format::Text; described_fields.len()],
+                        timeout_seconds,
+                        &mut FetchCursorCancelHandle::new(),
+                    )
+                    .await
+                    .unwrap();
+                assert_eq!(rows.len(), 1);
+                assert_eq!(response_fields, described_fields);
+                assert_eq!(rows[0].values().len(), response_fields.len());
+                assert_eq!(rows[0].values()[1].as_deref(), Some(b"added".as_slice()));
+            }
         }
     }
 
@@ -1167,7 +1856,7 @@ mod tests {
                 "ended unexpectedly"
             };
             assert!(error.to_string().contains(expected));
-            assert!(stream.is_failed());
+            assert!(stream.inner.failed);
             assert!(matches!(
                 stream.subscription_state(),
                 SubscriptionCursorState::Invalid

--- a/src/tests/e2e_extended_mode/src/test.rs
+++ b/src/tests/e2e_extended_mode/src/test.rs
@@ -81,12 +81,22 @@ impl TestSuite {
         self.max_row().await?;
         self.multiple_on_going_portal().await?;
         self.create_with_parameter().await?;
-        self.simple_cancel(false).await?;
-        self.simple_cancel(true).await?;
-        self.complex_cancel(false).await?;
-        self.complex_cancel(true).await?;
-        self.subscription_fetch_cancel(false).await?;
-        self.subscription_fetch_cancel(true).await?;
+        for is_distributed in [false, true] {
+            self.simple_cancel(is_distributed).await?;
+            self.complex_cancel(is_distributed).await?;
+            for is_binary_format in [false, true] {
+                self.query_cursor_interruptions(is_distributed, is_binary_format)
+                    .await?;
+                for is_full in [false, true] {
+                    self.subscription_cursor_interruptions(
+                        is_distributed,
+                        is_binary_format,
+                        is_full,
+                    )
+                    .await?;
+                }
+            }
+        }
         self.subquery_with_param().await?;
         self.create_mview_with_parameter().await?;
         Ok(())
@@ -587,53 +597,275 @@ impl TestSuite {
         Ok(())
     }
 
-    async fn subscription_fetch_cancel(&self, is_distributed: bool) -> anyhow::Result<()> {
-        let client = self.create_client(is_distributed).await?;
-        let suffix = if is_distributed { "dist" } else { "local" };
-        let table_name = format!("sub_cancel_t_{suffix}");
-        let subscription_name = format!("sub_cancel_{suffix}");
-
-        client
-            .execute(&format!("create table {table_name}(v int)"), &[])
-            .await?;
-        client
-            .execute(
-                &format!("create subscription {subscription_name} from {table_name} with(retention = '1D')"),
-                &[],
-            )
-            .await?;
-        client
-            .execute(
-                &format!("declare cur subscription cursor for {subscription_name} since now()"),
-                &[],
-            )
-            .await?;
-
-        let cancel_token = client.cancel_token();
-        let fetch_handle = tokio::spawn(async move {
-            client
-                .query("fetch 1 from cur with (timeout = '60s')", &[])
-                .await
-        });
-
-        tokio::time::sleep(Duration::from_secs(1)).await;
-        cancel_token.cancel_query(NoTls).await?;
-
-        let result = tokio::time::timeout(Duration::from_secs(10), fetch_handle).await??;
-        if result.is_ok() {
-            return Err(anyhow!(
-                "subscription cursor fetch should be cancelled by CancelRequest"
-            ));
+    /// Runs the same assertions through simple/text and extended/binary query protocols.
+    /// Only the scalar types used by these cursor fixtures are supported.
+    async fn cursor_rows(
+        client: &Client,
+        sql: &str,
+        is_binary_format: bool,
+    ) -> anyhow::Result<Vec<Vec<Option<String>>>> {
+        if !is_binary_format {
+            return Ok(client
+                .simple_query(sql)
+                .await?
+                .into_iter()
+                .filter_map(|message| match message {
+                    tokio_postgres::SimpleQueryMessage::Row(row) => Some(
+                        (0..row.len())
+                            .map(|index| row.get(index).map(str::to_owned))
+                            .collect(),
+                    ),
+                    _ => None,
+                })
+                .collect());
         }
+        client
+            .query(sql, &[])
+            .await?
+            .into_iter()
+            .map(|row| {
+                row.columns()
+                    .iter()
+                    .enumerate()
+                    .map(|(index, column)| {
+                        Ok(match *column.type_() {
+                            Type::INT4 => {
+                                row.try_get::<_, Option<i32>>(index)?.map(|v| v.to_string())
+                            }
+                            Type::INT8 => {
+                                row.try_get::<_, Option<i64>>(index)?.map(|v| v.to_string())
+                            }
+                            Type::VARCHAR | Type::TEXT => {
+                                row.try_get::<_, Option<String>>(index)?
+                            }
+                            Type::VOID => None,
+                            ref other => anyhow::bail!("unexpected cursor fixture type: {other}"),
+                        })
+                    })
+                    .collect()
+            })
+            .collect()
+    }
 
-        let cleanup_client = self.create_client(is_distributed).await?;
-        cleanup_client
-            .execute(&format!("drop subscription {subscription_name}"), &[])
-            .await?;
-        cleanup_client
-            .execute(&format!("drop table {table_name}"), &[])
-            .await?;
+    /// Sends real `CancelRequest` packets while a request is pending, requiring a cancellation
+    /// error rather than treating any error or a successful completion as cancellation.
+    async fn cancel_pending_request(
+        client: &Client,
+        sql: &str,
+        is_binary_format: bool,
+    ) -> anyhow::Result<()> {
+        let request = Self::cursor_rows(client, sql, is_binary_format);
+        tokio::pin!(request);
+        anyhow::ensure!(
+            tokio::time::timeout(Duration::from_millis(250), request.as_mut())
+                .await
+                .is_err(),
+            "request completed before cancellation: {sql}"
+        );
+        let token = client.cancel_token();
+        // Repeat to tolerate dispatch latency: CancelRequest itself has no acknowledgement.
+        // Stop before submitting another SQL command on this connection.
+        let result = tokio::time::timeout(Duration::from_secs(5), async {
+            loop {
+                token.cancel_query(NoTls).await?;
+                tokio::select! {
+                    biased;
+                    result = request.as_mut() => return result,
+                    _ = tokio::time::sleep(Duration::from_millis(100)) => {}
+                }
+            }
+        })
+        .await?;
+        let error = result.expect_err("pending request must be cancelled");
+        let database_error = error
+            .downcast_ref::<tokio_postgres::Error>()
+            .and_then(tokio_postgres::Error::as_db_error);
+        anyhow::ensure!(
+            database_error
+                .is_some_and(|error| error.message().to_ascii_lowercase().contains("cancelled")),
+            "expected a server cancellation error, got: {error:#}"
+        );
         Ok(())
+    }
+
+    /// Checks actual executor output survives a FETCH timeout, FETCH cancellation, and ordinary
+    /// query cancellation. No row is consumed by the interrupted FETCH: this does not test replay.
+    async fn query_cursor_interruptions(
+        &self,
+        is_distributed: bool,
+        is_binary_format: bool,
+    ) -> anyhow::Result<()> {
+        tokio::time::timeout(Duration::from_secs(30), async {
+            tracing::info!(
+                is_distributed,
+                is_binary_format,
+                "query cursor interruption acceptance"
+            );
+            let client = self.create_client(is_distributed).await?;
+            client
+                .simple_query("declare cur cursor for select 7::int as v, pg_sleep(4)")
+                .await?;
+            let started = tokio::time::Instant::now();
+            let rows = Self::cursor_rows(
+                &client,
+                "fetch 1 from cur with (timeout = '1s')",
+                is_binary_format,
+            )
+            .await?;
+            anyhow::ensure!(rows.is_empty(), "slow cursor returned before FETCH timeout");
+            anyhow::ensure!(started.elapsed() >= Duration::from_secs(1));
+            Self::cancel_pending_request(&client, "fetch 1 from cur", is_binary_format).await?;
+            Self::cancel_pending_request(&client, "select pg_sleep(60)", is_binary_format).await?;
+            let rows = Self::cursor_rows(&client, "fetch 1 from cur", is_binary_format).await?;
+            test_eq!(rows.len(), 1);
+            test_eq!(rows[0][0].as_deref(), Some("7"));
+            anyhow::ensure!(
+                Self::cursor_rows(&client, "fetch 1 from cur", is_binary_format)
+                    .await?
+                    .is_empty()
+            );
+            client.simple_query("close cur").await?;
+            // CLOSE must not wait for the sleeping executor to finish.
+            client
+                .simple_query("declare closing cursor for select pg_sleep(60)")
+                .await?;
+            tokio::time::timeout(Duration::from_secs(5), client.simple_query("close closing"))
+                .await??;
+            let rows = Self::cursor_rows(&client, "select 1::int", is_binary_format).await?;
+            test_eq!(rows[0][0].as_deref(), Some("1"));
+            Ok(())
+        })
+        .await?
+    }
+
+    /// Checks FULL snapshot selection, SINCE exclusion of old rows, idle timeout/cancellation,
+    /// continuation, another cursor's isolation, and binary FETCH followed by EXPLAIN FETCH.
+    async fn subscription_cursor_interruptions(
+        &self,
+        is_distributed: bool,
+        is_binary_format: bool,
+        is_full: bool,
+    ) -> anyhow::Result<()> {
+        tokio::time::timeout(Duration::from_secs(30), async {
+            tracing::info!(
+                is_distributed,
+                is_binary_format,
+                is_full,
+                "subscription cursor interruption acceptance"
+            );
+            let client = self.create_client(is_distributed).await?;
+            let suffix = format!(
+                "{}_{}_{}",
+                if is_distributed { "dist" } else { "local" },
+                if is_binary_format { "binary" } else { "text" },
+                if is_full { "full" } else { "since" }
+            );
+            let table = format!("cursor_interrupt_t_{suffix}");
+            let subscription = format!("cursor_interrupt_s_{suffix}");
+            client
+                .simple_query(&format!("drop table if exists {table} cascade"))
+                .await?;
+            client
+                .simple_query(&format!(
+                    "create table {table}(a int, b int, primary key(b, a))"
+                ))
+                .await?;
+            client
+                .simple_query(&format!(
+                    "create subscription {subscription} from {table} with(retention = '1D')"
+                ))
+                .await?;
+            client
+                .simple_query(&format!("insert into {table} values(7, 42); flush"))
+                .await?;
+            let start = if is_full { "full" } else { "since now()" };
+            client
+                .simple_query(&format!(
+                    "declare cur subscription cursor for {subscription} {start}"
+                ))
+                .await?;
+            client
+                .simple_query("declare other_cursor cursor for select 99::int")
+                .await?;
+            // Close the epoch that began before SINCE NOW, so the next insert's epoch is newer
+            // than the declaration timestamp. No wall-clock sleep is needed.
+            client.simple_query("flush").await?;
+            // This commit occurs after DECLARE but before the first FETCH.
+            client
+                .simple_query(&format!("insert into {table} values(8, 43); flush"))
+                .await?;
+            if is_full {
+                let rows = Self::cursor_rows(&client, "fetch 1 from cur", is_binary_format).await?;
+                test_eq!(
+                    rows,
+                    vec![vec![
+                        Some("7".to_owned()),
+                        Some("42".to_owned()),
+                        Some("Insert".to_owned()),
+                        None
+                    ]]
+                );
+                // The last PK is typed even when the prior FETCH requested binary output.
+                client.simple_query("explain fetch 1 from cur").await?;
+            }
+            let rows = Self::cursor_rows(
+                &client,
+                "fetch 1 from cur with (timeout = '5s')",
+                is_binary_format,
+            )
+            .await?;
+            test_eq!(rows.len(), 1);
+            test_eq!(rows[0][0].as_deref(), Some("8"));
+            test_eq!(rows[0][1].as_deref(), Some("43"));
+            test_eq!(rows[0][2].as_deref(), Some("Insert"));
+            anyhow::ensure!(
+                rows[0][3].is_some(),
+                "post-DECLARE row must come from the log store, not FULL snapshot"
+            );
+            client.simple_query("explain fetch 1 from cur").await?;
+            let started = tokio::time::Instant::now();
+            anyhow::ensure!(
+                Self::cursor_rows(
+                    &client,
+                    "fetch 1 from cur with (timeout = '1s')",
+                    is_binary_format
+                )
+                .await?
+                .is_empty()
+            );
+            anyhow::ensure!(started.elapsed() >= Duration::from_secs(1));
+            Self::cancel_pending_request(
+                &client,
+                "fetch 1 from cur with (timeout = '60s')",
+                is_binary_format,
+            )
+            .await?;
+            let rows =
+                Self::cursor_rows(&client, "fetch 1 from other_cursor", is_binary_format).await?;
+            test_eq!(rows[0][0].as_deref(), Some("99"));
+            client
+                .simple_query(&format!("insert into {table} values(9, 44); flush"))
+                .await?;
+            let rows = Self::cursor_rows(
+                &client,
+                "fetch 1 from cur with (timeout = '5s')",
+                is_binary_format,
+            )
+            .await?;
+            test_eq!(rows.len(), 1);
+            test_eq!(rows[0][0].as_deref(), Some("9"));
+            client.simple_query("close all").await?;
+            anyhow::ensure!(
+                Self::cursor_rows(&client, "fetch 1 from cur", is_binary_format)
+                    .await
+                    .is_err()
+            );
+            client
+                .simple_query(&format!("drop table {table} cascade"))
+                .await?;
+            Ok(())
+        })
+        .await?
     }
 
     async fn subquery_with_param(&self) -> anyhow::Result<()> {


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## Expectations

- Query and subscription cursors retain their underlying execution and pending producer work across FETCH timeouts and CancelRequest interruptions. Cancelling an ordinary query does not cancel cursor-owned execution.
- FULL subscriptions use the snapshot selected at DECLARE; later log-store queries retain their explicitly selected snapshots across asynchronous startup.
- FETCH uses one deadline across pending work and ready rows. A timeout returns accumulated rows; a schema boundary ends the current FETCH with its original response fields, while the next freshly parsed FETCH sees the new schema.

## Limitations

- This implements persistent execution, not transactional FETCH progress. Cancellation can still discard rows already consumed by that FETCH. Transactional replay/rollback and per-FETCH raw-column reformatting remain Goal 3 / PR5; raw-column formats currently remain fixed for each underlying query.
- Portal cancellation separation (#26999) and prompt interruption of every cursor-construction await remain outside this PR. Existing cursor ownership and teardown rules are preserved; cancellation signalling and stream cleanup do not guarantee that every executor has already terminated.

## What's changed and what's your intention?

This is the fourth dependency-ordered extraction from #26675 for #26611, building on #26924. It **integrates the persistent-stream infrastructure into production cursor execution**, replacing the legacy cursor path rather than adding another dormant layer.

- Centralize cursor-owned local/distributed startup around a caller-selected snapshot, preserving independent cancellation ownership and disabling execution-level statement timeouts for cursors. Ordinary execution retains its existing snapshot and timeout behavior.
- Implement the demand-driven subscription producer for FULL snapshots and subsequent log-store queries, including epoch lookup, notifications, schema transitions, expiry updates, and terminal errors. Pending work stays in the retained stream rather than being recreated for each FETCH.
- Wire query and subscription cursors to persistent response adapters, remove the legacy refill/state machinery, and poll a temporary stream borrow for each interruptible FETCH.
- Preserve current response descriptors at schema boundaries, publish the next query's fields before stopping, and leave new-schema rows and format selection for the next FETCH—even when the current FETCH is empty and waiting.
- Extract typed subscription seek keys before PostgreSQL formatting, preserve declared compound-primary-key order, and use typed literals for EXPLAIN FETCH. Normalize empty, singleton, and per-column result formats across visible, hidden, and synthetic columns.

## Unit tests

- Verify supplied snapshots reach every table scan without falling back to the session snapshot, with registration cleanup while startup is suspended. This uses a mock session without workers or storage reads.
- Exercise the subscription producer's pending-query retention, snapshot-to-log-store epoch transition, and failure cleanup using channel-backed queries. Cancellation tokens establish signalling, not executor termination.
- Cover pending FETCH cancellation and continuation, zero-timeout ready input, partial results on timeout, and deadline enforcement while input remains continuously ready.
- Check typed compound seek keys and text/binary format normalization, including hidden columns and synthetic subscription fields.
- Verify empty/nonempty and waiting/nonwaiting FETCH commands stop at schema changes with their original descriptors; subsequent Parse/Describe and FETCH use the new fields and per-column format count. These tests inject events rather than exercising schema changes over the wire.
- Adapt existing cursor lifecycle regressions to the persistent adapters while retaining their ownership and shutdown assertions.

## E2E tests

- Extend the existing extended-mode harness with real SQL and CancelRequest scenarios in local/distributed execution over simple/text and extended/binary protocols.
- Query cursor scenarios cover FETCH timeout, FETCH cancellation, ordinary-query cancellation, continuation to EOF, bounded CLOSE of unfinished execution, and connection reuse.
- FULL/SINCE subscription scenarios cover rows committed before/after DECLARE, snapshot versus log-store provenance, idle timeout/cancellation, continuation, another cursor's isolation, CLOSE ALL, and FETCH followed by EXPLAIN with compound-primary-key ordering.
- Existing cursor SLT, statement-timeout, and subscription SQL/Python suites remain baseline coverage, not newly added scenarios.
- Interrupted FETCH scenarios consume no rows before cancellation and therefore do not establish replay. Deterministic interruption of real subscription startup and network-disconnect/session-teardown scenarios are not added here.

## Checklist

- [x] I have written necessary rustdoc comments.
- [x] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/dev/src/ci.md#ci-labels-guide -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->

## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

Cursor FETCH timeouts and CancelRequest interruptions preserve the underlying cursor query so a later FETCH can continue. Subscription cursors preserve their selected snapshots, use typed compound seek keys, and normalize text/binary result formats. Schema changes end the current FETCH before new-schema rows are returned. Replay of rows already consumed by a cancelled FETCH is not yet guaranteed.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added cursor fetching with cancellation, timeouts, and deadline-based stopping.
  - Improved subscription cursors to wait for new changes and advance through updates.
  - Added consistent behavior across local and distributed execution, text and binary formats, and standard and extended protocols.

- **Bug Fixes**
  - Improved subscription seeking and continuation for snapshot and log-based results.
  - Preserved response fields across schema changes.
  - Cursor cancellation now returns expected errors without affecting other cursors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->