### PR TITLE
build(udf): bump arrow-udf-runtime to 0.10.0 for CPython 3.14 support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -787,9 +787,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-udf-runtime"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65b70cb374bc7f5d7f55b7db7ccdd37759d3c7a5471688069cd922ea45a5e062"
+checksum = "a5373955f41636c6bc8e7a508e31fb3f5c369a14496a000e6dc51708a31c271a"
 dependencies = [
  "anyhow",
  "arrow-array 58.4.0",
@@ -11719,37 +11719,32 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.24.2"
+version = "0.29.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5203598f366b11a02b13aa20cab591229ff0a89fd121a308a5df751d5fc9219"
+checksum = "4688ddedf473e32662b9b067670129a8afb8c18e351482c70d62ba4a88171e8b"
 dependencies = [
- "cfg-if",
- "indoc",
  "libc",
- "memoffset",
  "once_cell",
  "portable-atomic",
  "pyo3-build-config",
  "pyo3-ffi",
  "pyo3-macros",
- "unindent",
 ]
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.24.2"
+version = "0.29.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99636d423fa2ca130fa5acde3059308006d46f98caac629418e53f7ebb1e9999"
+checksum = "f41027e41b4bd03f6e60f9f417fe24a6341a6bb744edd62b6f709f2a52ea30e9"
 dependencies = [
- "once_cell",
  "target-lexicon",
 ]
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.24.2"
+version = "0.29.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78f9cf92ba9c409279bc3305b5409d90db2d2c22392d443a87df3a1adad59e33"
+checksum = "e591a95526fead067432c3b3a33fc74770b87b1e04e73671090d9c2055a2b327"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -11757,9 +11752,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.24.2"
+version = "0.29.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b999cb1a6ce21f9a6b147dcf1be9ffedf02e0043aec74dc390f3007047cecd9"
+checksum = "73225868fc1cd84eef2c3c230ddb91273bf1de46aeb8a4248da76d32a0924a1c"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -11769,13 +11764,12 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.24.2"
+version = "0.29.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "822ece1c7e1012745607d5cf0bcb2874769f0f7cb34c4cde03b9358eb9ef911a"
+checksum = "571575aa3749fa6216757dd47d2a3e7ef360f329a40f0666a9fbd14889024952"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
- "pyo3-build-config",
  "quote",
  "syn 2.0.117",
 ]
@@ -16617,9 +16611,9 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "target-lexicon"
-version = "0.13.2"
+version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e502f78cdbb8ba4718f566c418c52bc729126ffd16baee5baa718cf25dd5a69a"
+checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
 
 [[package]]
 name = "task-local"
@@ -17728,12 +17722,6 @@ name = "unicode_categories"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39ec24b3121d976906ece63c9daad25b85969647682eee313cb5779fdd69e14e"
-
-[[package]]
-name = "unindent"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7de7d73e1754487cb58364ee906a499937a0dfabd86bcb980fa99ec8c8fa2ce"
 
 [[package]]
 name = "unit-prefix"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -111,7 +111,7 @@ adbc_core = { version = "0.23" }
 adbc_snowflake = { version = "0.23", default-features = false }
 apache-avro = { git = "https://github.com/risingwavelabs/avro-rs", rev = "1f2723802d4fb77b97fa084f7bb81e3b60b9e03f" }
 arc-swap = "1"
-arrow-udf-runtime = "0.9.0"
+arrow-udf-runtime = "0.10.0"
 async-openai = { version = "0.41.0", features = ["embedding"] }
 auto_enums = { version = "0.8", features = ["futures03", "tokio1"] }
 await-tree = { version = "0.3.2-alpha.2", features = ["serde", "attributes"] }

--- a/e2e_test/udf/remote_python/requirements.txt
+++ b/e2e_test/udf/remote_python/requirements.txt
@@ -1,1 +1,1 @@
-arrow_udf==0.3.1
+arrow_udf==0.3.2


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

Lets RisingWave build against CPython 3.14. The blocker is one transitive dependency:

```
risingwave_expr_impl (feature udf) -> arrow-udf-runtime 0.9.0 -> pyo3 0.24.2
```

`pyo3-ffi`'s build script rejects any interpreter newer than the version it supports, and 0.24 stops
at 3.13, so `PYO3_PYTHON=python3.14 ./risedev b` fails with:

```
the configured Python interpreter version (3.14) is newer than PyO3's maximum supported version (3.13)
```

The `abi3` forward-compatibility escape hatch does not apply — the embedded runtime uses
`auto-initialize`, not the stable ABI.

pyo3 0.29 supports CPython 3.8–3.15 and also closes [RUSTSEC-2026-0177](https://rustsec.org/advisories/RUSTSEC-2026-0177)
(#25957), so this bumps straight to it rather than to 0.25, the first release that merely accepts 3.14.

`target-lexicon` moves 0.13.2 → 0.13.5 because `pyo3-build-config` 0.29 requires `>=0.13.3`.

RisingWave's own code needs no change — `src/expr/impl/src/udf/python.rs` only touches
`arrow_udf_runtime::python::Runtime`, no pyo3 type crosses the boundary.

### Upstream

`arrow-udf-runtime` 0.10.0 carries the pyo3 bump (https://github.com/arrow-udf/arrow-udf/pull/160).
The lockfile diff is that crate, the five pyo3 crates, `target-lexicon`, and the dropped `unindent`.

The remote Python UDF test moves to `arrow_udf` 0.3.2 (https://github.com/arrow-udf/arrow-udf/pull/161):
0.3.1 pins `pyarrow<20`, which has no CPython 3.14 wheels.

### Verification

Built with `PYO3_PYTHON=python3.14` (Homebrew CPython 3.14.6) and run on the `ci-1cn-1fe` profile:

- `otool -L target/debug/risingwave` links `Python.framework/Versions/3.14`
- an embedded UDF returning `sys.version` reports `3.14.6`
- `./risedev slt './e2e_test/udf/tests/**/*.slt'` — all 22 files pass, including the remote Python
  (`arrow_udf` 0.3.2 on CPython 3.14) and remote Java UDF servers

Upstream, `cargo test -p arrow-udf-runtime --features python` passes 24/24 on both 3.14.6 and 3.13.12.

### Not in this PR

This only *allows* 3.14. RisingWave's own build and runtime images stay on 3.12, so the shipped binary
still embeds CPython 3.12 and user UDFs keep running on it. Moving those is a separate decision with a
much wider blast radius (CPython 3.14 changes user-visible behaviour — for instance every
`ZeroDivisionError` message is now `division by zero`), and would touch `ci/Dockerfile` +
`ci/.env`, `docker/Dockerfile`, `docker/Dockerfile.hdfs`, `ci/scripts/release.sh`,
`.github/workflows/copilot-setup-steps.yml` and `docs/dev/src/build-and-run/intro.md`.

## Checklist

- [ ] I have written necessary rustdoc comments.
- [x] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/dev/src/ci.md#ci-labels-guide -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [x] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->

## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

No user-visible change: the shipped binary still embeds CPython 3.12. Documentation follows if and when
the build and runtime images move to 3.14.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the runtime components used by the application to newer compatible versions.
  * Updated the remote Python integration dependency to version 0.3.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->