### PR TITLE
fix(meta): fence stale exchange requests across database recovery

### DIFF
--- a/proto/stream_service.proto
+++ b/proto/stream_service.proto
@@ -147,13 +147,16 @@ message BarrierCompleteResponse {
 
 message StreamingControlStreamRequest {
   message InitRequest {
-    string term_id = 1;
+    reserved 1;
+    reserved "term_id";
   }
 
   message CreatePartialGraphRequest {
     uint64 partial_graph_id = 1;
     reserved 2;
     reserved "database_id";
+    // Identifies the database recovery incarnation of this partial graph.
+    string term_id = 3;
   }
 
   message RemovePartialGraphRequest {

--- a/src/meta/src/barrier/checkpoint/control.rs
+++ b/src/meta/src/barrier/checkpoint/control.rs
@@ -36,6 +36,7 @@ use risingwave_pb::stream_plan::stream_node::NodeBody;
 use risingwave_pb::stream_service::BarrierCompleteResponse;
 use risingwave_pb::stream_service::streaming_control_stream_response::ResetPartialGraphResponse;
 use tracing::{debug, warn};
+use uuid::Uuid;
 
 use crate::barrier::cdc_progress::CdcProgress;
 use crate::barrier::checkpoint::independent_job::{
@@ -305,6 +306,7 @@ impl CheckpointControl {
                         );
                         let adder = partial_graph_manager.add_partial_graph(
                             to_partial_graph_id(database_id, None),
+                            new_database.term_id(),
                             DatabaseCheckpointControlMetrics::new(database_id),
                         );
                         adder.added();
@@ -742,6 +744,8 @@ impl PartialGraphStat for DatabaseCheckpointControlMetrics {
 /// Controls the concurrent execution of commands.
 pub(in crate::barrier) struct DatabaseCheckpointControl {
     pub(super) database_id: DatabaseId,
+    /// Identifies the current recovery incarnation of this database.
+    pub(super) term_id: String,
     partial_graph_id: PartialGraphId,
     pub(super) state: BarrierWorkerState,
 
@@ -764,6 +768,7 @@ impl DatabaseCheckpointControl {
     fn new(database_id: DatabaseId, shared_actor_infos: SharedActorInfos) -> Self {
         Self {
             database_id,
+            term_id: Uuid::new_v4().to_string(),
             partial_graph_id: to_partial_graph_id(database_id, None),
             state: BarrierWorkerState::new(),
             finishing_jobs_collector: BarrierItemCollector::new(false),
@@ -777,6 +782,7 @@ impl DatabaseCheckpointControl {
 
     pub(crate) fn recovery(
         database_id: DatabaseId,
+        term_id: String,
         state: BarrierWorkerState,
         committed_epoch: u64,
         database_info: InflightDatabaseInfo,
@@ -784,6 +790,7 @@ impl DatabaseCheckpointControl {
     ) -> Self {
         Self {
             database_id,
+            term_id,
             partial_graph_id: to_partial_graph_id(database_id, None),
             state,
             finishing_jobs_collector: BarrierItemCollector::new(false),
@@ -793,6 +800,10 @@ impl DatabaseCheckpointControl {
             database_info,
             independent_checkpoint_job_controls,
         }
+    }
+
+    pub(super) fn term_id(&self) -> &str {
+        &self.term_id
     }
 
     pub(crate) fn is_valid_after_worker_err(&self, worker_id: WorkerId) -> bool {
@@ -1359,6 +1370,7 @@ impl DatabaseCheckpointControl {
         actor_id_counter: &AtomicU32,
         partial_graph_manager: &mut PartialGraphManager,
     ) -> MetaResult<bool> {
+        let term_id = self.term_id.as_str();
         let job = self
             .independent_checkpoint_job_controls
             .get_mut(&job_id)
@@ -1368,6 +1380,7 @@ impl DatabaseCheckpointControl {
                 context,
                 worker_nodes,
                 actor_id_counter,
+                term_id,
                 partial_graph_manager,
             ),
             _ => panic!("job {} should be a batch refresh job", job_id),

--- a/src/meta/src/barrier/checkpoint/independent_job/batch_refresh_job/mod.rs
+++ b/src/meta/src/barrier/checkpoint/independent_job/batch_refresh_job/mod.rs
@@ -475,6 +475,7 @@ impl BatchRefreshJobCheckpointControl {
         snapshot_backfill_upstream_tables: HashSet<TableId>,
         snapshot_epoch: u64,
         version_stat: &HummockVersionStats,
+        term_id: &str,
         partial_graph_manager: &mut PartialGraphManager,
         logical: &BatchRefreshLogicalFragments,
         worker_nodes: &HashMap<WorkerId, WorkerNode>,
@@ -531,6 +532,7 @@ impl BatchRefreshJobCheckpointControl {
 
         let mut graph_adder = partial_graph_manager.add_partial_graph(
             partial_graph_id,
+            term_id,
             BatchRefreshBarrierStats::new(job_id, snapshot_epoch),
         );
 
@@ -588,6 +590,7 @@ impl BatchRefreshJobCheckpointControl {
         version_stat: &HummockVersionStats,
         initial_mutation: Mutation,
         render_result: BatchRefreshRenderResult,
+        term_id: &str,
         partial_graph_recoverer: &mut crate::barrier::partial_graph::PartialGraphRecoverer<'_>,
         batch_refresh_seconds: u64,
     ) -> MetaResult<Self> {
@@ -649,6 +652,7 @@ impl BatchRefreshJobCheckpointControl {
 
         partial_graph_recoverer.recover_graph(
             partial_graph_id,
+            term_id,
             initial_mutation,
             &first_barrier_info,
             &render_result.node_actors,
@@ -1196,6 +1200,7 @@ impl BatchRefreshJobCheckpointControl {
         context: &BatchRefreshJobTriggerContext,
         worker_nodes: &HashMap<WorkerId, WorkerNode>,
         actor_id_counter: &AtomicU32,
+        term_id: &str,
         partial_graph_manager: &mut PartialGraphManager,
     ) -> MetaResult<bool> {
         let last_committed_epoch = match &self.status {
@@ -1282,6 +1287,7 @@ impl BatchRefreshJobCheckpointControl {
         let mut partial_graph_recoverer = partial_graph_manager.start_recover();
         let recover_result = partial_graph_recoverer.recover_graph(
             self.partial_graph_id,
+            term_id,
             initial_mutation,
             &initial_barrier,
             node_actors,

--- a/src/meta/src/barrier/checkpoint/independent_job/creating_job/mod.rs
+++ b/src/meta/src/barrier/checkpoint/independent_job/creating_job/mod.rs
@@ -107,6 +107,7 @@ impl CreatingStreamingJobControl {
         snapshot_epoch: u64,
         since_timestamp_upstream_log_epochs: Option<(&TableLogEpochs, PartialGraphId, u64)>,
         version_stat: &HummockVersionStats,
+        term_id: &str,
         partial_graph_manager: &mut PartialGraphManager,
         edges: &mut FragmentEdgeBuildResult,
         split_assignment: &SplitAssignment,
@@ -248,6 +249,7 @@ impl CreatingStreamingJobControl {
 
         let mut graph_adder = partial_graph_manager.add_partial_graph(
             partial_graph_id,
+            term_id,
             CreatingStreamingJobBarrierStats::new(job_id, snapshot_epoch),
         );
 
@@ -638,6 +640,7 @@ impl CreatingStreamingJobControl {
         version_stat: &HummockVersionStats,
         new_actors: StreamJobActorsToCreate,
         initial_mutation: Mutation,
+        term_id: &str,
         partial_graph_recoverer: &mut PartialGraphRecoverer<'_>,
     ) -> MetaResult<Self> {
         info!(
@@ -728,6 +731,7 @@ impl CreatingStreamingJobControl {
 
         partial_graph_recoverer.recover_graph(
             partial_graph_id,
+            term_id,
             initial_mutation,
             &first_barrier_info,
             &node_actors,

--- a/src/meta/src/barrier/checkpoint/state.rs
+++ b/src/meta/src/barrier/checkpoint/state.rs
@@ -583,6 +583,7 @@ impl DatabaseCheckpointControl {
                         panic!("duplicated creating snapshot backfill job {job_id}");
                     };
 
+                    let term_id = self.term_id.as_str();
                     let job = CreatingStreamingJobControl::new(
                         entry,
                         CreateSnapshotBackfillJobCommandInfo {
@@ -597,6 +598,7 @@ impl DatabaseCheckpointControl {
                         snapshot_epoch,
                         since_timestamp_upstream_log_epochs,
                         hummock_version_stats,
+                        term_id,
                         partial_graph_manager,
                         &mut edges,
                         &resolved_split_assignment,
@@ -770,6 +772,7 @@ impl DatabaseCheckpointControl {
                         snapshot_backfill_upstream_tables,
                         snapshot_epoch,
                         hummock_version_stats,
+                        self.term_id(),
                         partial_graph_manager,
                         &logical,
                         worker_nodes,

--- a/src/meta/src/barrier/context/context_impl.rs
+++ b/src/meta/src/barrier/context/context_impl.rs
@@ -31,7 +31,6 @@ use risingwave_pb::meta::subscribe_response::{Info, Operation};
 use risingwave_pb::stream_service::barrier_complete_response::{
     PbIcebergPkIndexSinkMetadata, PbListFinishedSource, PbLoadFinishedSource,
 };
-use risingwave_pb::stream_service::streaming_control_stream_request::PbInitRequest;
 use risingwave_rpc_client::StreamingControlHandle;
 use thiserror_ext::AsReport;
 
@@ -297,12 +296,8 @@ impl GlobalBarrierWorkerContext for GlobalBarrierWorkerContextImpl {
     }
 
     #[await_tree::instrument("new_control_stream({})", node.id)]
-    async fn new_control_stream(
-        &self,
-        node: &WorkerNode,
-        init_request: &PbInitRequest,
-    ) -> MetaResult<StreamingControlHandle> {
-        self.new_control_stream_impl(node, init_request).await
+    async fn new_control_stream(&self, node: &WorkerNode) -> MetaResult<StreamingControlHandle> {
+        self.new_control_stream_impl(node).await
     }
 
     async fn reload_runtime_info(&self) -> MetaResult<BarrierWorkerRuntimeInfoSnapshot> {

--- a/src/meta/src/barrier/context/mod.rs
+++ b/src/meta/src/barrier/context/mod.rs
@@ -28,7 +28,6 @@ use risingwave_pb::stream_service::barrier_complete_response::{
     IcebergPkIndexSinkMetadata as PbIcebergPkIndexSinkMetadata, PbListFinishedSource,
     PbLoadFinishedSource,
 };
-use risingwave_pb::stream_service::streaming_control_stream_request::PbInitRequest;
 use risingwave_rpc_client::StreamingControlHandle;
 
 use crate::MetaResult;
@@ -131,7 +130,6 @@ pub(super) trait GlobalBarrierWorkerContext: Send + Sync + 'static {
     fn new_control_stream<'a>(
         &'a self,
         node: &'a WorkerNode,
-        init_request: &'a PbInitRequest,
     ) -> impl Future<Output = MetaResult<StreamingControlHandle>> + Send + 'a;
 
     fn reload_runtime_info(

--- a/src/meta/src/barrier/partial_graph.rs
+++ b/src/meta/src/barrier/partial_graph.rs
@@ -32,7 +32,6 @@ use risingwave_pb::stream_service::streaming_control_stream_response::{
     ResetPartialGraphResponse, Response,
 };
 use tracing::{debug, warn};
-use uuid::Uuid;
 
 use crate::barrier::BarrierKind;
 use crate::barrier::command::PostCollectCommand;
@@ -171,9 +170,13 @@ impl ResetPartialGraphCollector {
 #[derive(Educe)]
 #[educe(Debug)]
 enum PartialGraphStatus {
-    Running(PartialGraphRunningState),
+    Running {
+        term_id: String,
+        state: PartialGraphRunningState,
+    },
     Resetting(ResetPartialGraphCollector),
     Initializing {
+        term_id: String,
         epoch: EpochPair,
         node_to_collect: NodeToCollect,
         #[educe(Debug(ignore))]
@@ -190,7 +193,7 @@ impl PartialGraphStatus {
     ) -> Option<PartialGraphEvent<'a>> {
         assert_eq!(worker_id, resp.worker_id);
         match self {
-            PartialGraphStatus::Running(state) => {
+            PartialGraphStatus::Running { state, .. } => {
                 state.collect(resp);
                 state
                     .barrier_collected(temp_ref)
@@ -198,6 +201,7 @@ impl PartialGraphStatus {
             }
             PartialGraphStatus::Resetting(_) => None,
             PartialGraphStatus::Initializing {
+                term_id,
                 epoch,
                 node_to_collect,
                 stat,
@@ -205,9 +209,12 @@ impl PartialGraphStatus {
                 assert_eq!(epoch.prev, resp.epoch);
                 assert!(node_to_collect.remove(&worker_id));
                 if node_to_collect.is_empty() {
-                    *self = PartialGraphStatus::Running(PartialGraphRunningState::new(
-                        stat.take().expect("should be taken for once"),
-                    ));
+                    *self = PartialGraphStatus::Running {
+                        term_id: take(term_id),
+                        state: PartialGraphRunningState::new(
+                            stat.take().expect("should be taken for once"),
+                        ),
+                    };
                     Some(PartialGraphEvent::Initialized)
                 } else {
                     None
@@ -304,12 +311,13 @@ pub(super) enum WorkerEvent {
 
 fn existing_graphs(
     graphs: &HashMap<PartialGraphId, PartialGraphStatus>,
-) -> impl Iterator<Item = PartialGraphId> + '_ {
+) -> impl Iterator<Item = (PartialGraphId, &str)> + '_ {
     graphs
         .iter()
         .filter_map(|(partial_graph_id, status)| match status {
-            PartialGraphStatus::Running(_) | PartialGraphStatus::Initializing { .. } => {
-                Some(*partial_graph_id)
+            PartialGraphStatus::Running { term_id, .. }
+            | PartialGraphStatus::Initializing { term_id, .. } => {
+                Some((*partial_graph_id, term_id.as_str()))
             }
             PartialGraphStatus::Resetting(_) => None,
         })
@@ -317,7 +325,6 @@ fn existing_graphs(
 
 pub(super) struct PartialGraphManager {
     control_stream_manager: ControlStreamManager,
-    term_id: String,
     graphs: HashMap<PartialGraphId, PartialGraphStatus>,
 }
 
@@ -325,7 +332,6 @@ impl PartialGraphManager {
     pub(super) fn uninitialized(env: MetaSrvEnv) -> Self {
         Self {
             control_stream_manager: ControlStreamManager::new(env),
-            term_id: "uninitialized".to_owned(),
             graphs: HashMap::new(),
         }
     }
@@ -335,12 +341,9 @@ impl PartialGraphManager {
         nodes: &HashMap<WorkerId, WorkerNode>,
         context: Arc<impl GlobalBarrierWorkerContext>,
     ) -> Self {
-        let term_id = Uuid::new_v4().to_string();
-        let control_stream_manager =
-            ControlStreamManager::recover(env, nodes, &term_id, context).await;
+        let control_stream_manager = ControlStreamManager::recover(env, nodes, context).await;
         Self {
             control_stream_manager,
-            term_id,
             graphs: Default::default(),
         }
     }
@@ -355,7 +358,7 @@ impl PartialGraphManager {
         context: Arc<impl GlobalBarrierWorkerContext>,
     ) {
         self.control_stream_manager
-            .add_worker(node, existing_graphs(&self.graphs), &self.term_id, context)
+            .add_worker(node, existing_graphs(&self.graphs), context)
             .await
     }
 
@@ -369,8 +372,8 @@ impl PartialGraphManager {
 
     pub(crate) fn notify_all_err(&mut self, err: &MetaError) {
         for (_, graph) in self.graphs.drain() {
-            if let PartialGraphStatus::Running(graph) = graph {
-                for info in graph.barrier_item_collector.into_infos() {
+            if let PartialGraphStatus::Running { state, .. } = graph {
+                for info in state.barrier_item_collector.into_infos() {
                     if let Some(notifier) = info.notifier {
                         notifier.notify_collection_failed(err.clone());
                     }
@@ -415,16 +418,20 @@ impl PartialGraphManager {
     pub(super) fn add_partial_graph(
         &mut self,
         partial_graph_id: PartialGraphId,
+        term_id: &str,
         stat: impl PartialGraphStat,
     ) -> PartialGraphAdder<'_> {
         self.graphs
             .try_insert(
                 partial_graph_id,
-                PartialGraphStatus::Running(PartialGraphRunningState::new(Box::new(stat))),
+                PartialGraphStatus::Running {
+                    term_id: term_id.to_owned(),
+                    state: PartialGraphRunningState::new(Box::new(stat)),
+                },
             )
             .expect("non-duplicated");
         self.control_stream_manager
-            .add_partial_graph(partial_graph_id);
+            .add_partial_graph(partial_graph_id, term_id);
         PartialGraphAdder {
             partial_graph_id,
             manager: self,
@@ -435,7 +442,7 @@ impl PartialGraphManager {
     pub(super) fn remove_partial_graphs(&mut self, partial_graphs: Vec<PartialGraphId>) {
         for partial_graph_id in &partial_graphs {
             let graph = self.graphs.remove(partial_graph_id).expect("should exist");
-            let PartialGraphStatus::Running(state) = graph else {
+            let PartialGraphStatus::Running { state, .. } = graph else {
                 panic!("graph to be explicitly removed should be running");
             };
             assert!(state.is_empty());
@@ -467,7 +474,7 @@ impl PartialGraphManager {
                         PartialGraphStatus::Resetting(_) => {
                             unreachable!("should not reset again")
                         }
-                        PartialGraphStatus::Running(_)
+                        PartialGraphStatus::Running { .. }
                         | PartialGraphStatus::Initializing { .. } => {
                             *graph = PartialGraphStatus::Resetting(new_collector());
                         }
@@ -509,7 +516,7 @@ impl PartialGraphManager {
             nodes_to_sync_table,
             new_actors,
         )?;
-        let PartialGraphStatus::Running(state) = graph else {
+        let PartialGraphStatus::Running { state, .. } = graph else {
             panic!("should not inject barrier on non-running status: {graph:?}")
         };
         state.enqueue(node_to_collect, info);
@@ -517,7 +524,8 @@ impl PartialGraphManager {
     }
 
     fn running_graph(&self, partial_graph_id: PartialGraphId) -> &PartialGraphRunningState {
-        let PartialGraphStatus::Running(graph) = &self.graphs[&partial_graph_id] else {
+        let PartialGraphStatus::Running { state: graph, .. } = &self.graphs[&partial_graph_id]
+        else {
             unreachable!("should be running")
         };
         graph
@@ -527,7 +535,7 @@ impl PartialGraphManager {
         &mut self,
         partial_graph_id: PartialGraphId,
     ) -> &mut PartialGraphRunningState {
-        let PartialGraphStatus::Running(graph) = self
+        let PartialGraphStatus::Running { state: graph, .. } = self
             .graphs
             .get_mut(&partial_graph_id)
             .expect("should exist")
@@ -633,6 +641,7 @@ impl PartialGraphRecoverer<'_> {
     pub(super) fn recover_graph(
         &mut self,
         partial_graph_id: PartialGraphId,
+        term_id: &str,
         mutation: Mutation,
         barrier_info: &BarrierInfo,
         node_actors: &HashMap<WorkerId, HashSet<ActorId>>,
@@ -646,7 +655,7 @@ impl PartialGraphRecoverer<'_> {
         );
         self.manager
             .control_stream_manager
-            .add_partial_graph(partial_graph_id);
+            .add_partial_graph(partial_graph_id, term_id);
         assert!(barrier_info.kind.is_initial());
         let node_to_collect = self.manager.control_stream_manager.inject_barrier(
             partial_graph_id,
@@ -663,6 +672,7 @@ impl PartialGraphRecoverer<'_> {
             .try_insert(
                 partial_graph_id,
                 PartialGraphStatus::Initializing {
+                    term_id: term_id.to_owned(),
                     epoch: barrier_info.epoch(),
                     node_to_collect,
                     stat: Some(Box::new(stat)),
@@ -721,7 +731,7 @@ impl PartialGraphManager {
     ) -> PartialGraphManagerEvent<'a> {
         for (&partial_graph_id, graph) in &mut self.graphs {
             match graph {
-                PartialGraphStatus::Running(state) => {
+                PartialGraphStatus::Running { state, .. } => {
                     if let Some(collected) = state.barrier_collected(temp_ref) {
                         return PartialGraphManagerEvent::PartialGraph(
                             partial_graph_id,
@@ -740,14 +750,18 @@ impl PartialGraphManager {
                     }
                 }
                 PartialGraphStatus::Initializing {
+                    term_id,
                     node_to_collect,
                     stat,
                     ..
                 } => {
                     if node_to_collect.is_empty() {
-                        *graph = PartialGraphStatus::Running(PartialGraphRunningState::new(
-                            stat.take().expect("should be taken once"),
-                        ));
+                        *graph = PartialGraphStatus::Running {
+                            term_id: take(term_id),
+                            state: PartialGraphRunningState::new(
+                                stat.take().expect("should be taken once"),
+                            ),
+                        };
                         return PartialGraphManagerEvent::PartialGraph(
                             partial_graph_id,
                             PartialGraphEvent::Initialized,
@@ -757,10 +771,7 @@ impl PartialGraphManager {
             }
         }
         loop {
-            let (worker_id, event) = self
-                .control_stream_manager
-                .next_event(&self.term_id, context)
-                .await;
+            let (worker_id, event) = self.control_stream_manager.next_event(context).await;
             match event {
                 WorkerNodeEvent::Response(result) => match result {
                     Ok(resp) => match resp {
@@ -788,7 +799,7 @@ impl PartialGraphManager {
                                 PartialGraphStatus::Resetting(_) => {
                                     // ignore reported error when resetting
                                 }
-                                PartialGraphStatus::Running(_)
+                                PartialGraphStatus::Running { .. }
                                 | PartialGraphStatus::Initializing { .. } => {
                                     return PartialGraphManagerEvent::PartialGraph(
                                         partial_graph_id,
@@ -804,7 +815,7 @@ impl PartialGraphManager {
                                 .get_mut(&partial_graph_id)
                                 .expect("should exist");
                             match graph {
-                                PartialGraphStatus::Running(_)
+                                PartialGraphStatus::Running { .. }
                                 | PartialGraphStatus::Initializing { .. } => {
                                     if cfg!(debug_assertions) {
                                         unreachable!(
@@ -838,7 +849,7 @@ impl PartialGraphManager {
                             .graphs
                             .iter_mut()
                             .filter_map(|(partial_graph_id, graph)| match graph {
-                                PartialGraphStatus::Running(state) => state
+                                PartialGraphStatus::Running { state, .. } => state
                                     .barrier_item_collector
                                     .iter_to_collect()
                                     .any(|to_collect| {

--- a/src/meta/src/barrier/rpc.rs
+++ b/src/meta/src/barrier/rpc.rs
@@ -194,11 +194,10 @@ impl ControlStreamManager {
         self.workers[&worker_id].0.host.clone().unwrap()
     }
 
-    pub(super) async fn add_worker(
+    pub(super) async fn add_worker<'a>(
         &mut self,
         node: WorkerNode,
-        partial_graphs: impl Iterator<Item = PartialGraphId>,
-        term_id: &String,
+        partial_graphs: impl Iterator<Item = (PartialGraphId, &'a str)>,
         context: Arc<impl GlobalBarrierWorkerContext>,
     ) {
         let node_id = node.id;
@@ -222,15 +221,7 @@ impl ControlStreamManager {
             exponential_backoff(Duration::from_millis(100), 5, Duration::from_secs(3));
         const MAX_RETRY: usize = 5;
         for i in 1..=MAX_RETRY {
-            match context
-                .new_control_stream(
-                    &node,
-                    &PbInitRequest {
-                        term_id: term_id.clone(),
-                    },
-                )
-                .await
-            {
+            match context.new_control_stream(&node).await {
                 Ok(mut handle) => {
                     WorkerNodeConnected {
                         handle: &mut handle,
@@ -281,9 +272,7 @@ impl ControlStreamManager {
                     (
                         node.clone(),
                         WorkerNodeState::Reconnecting(ControlStreamManager::retry_connect(
-                            node,
-                            term_id.to_owned(),
-                            context,
+                            node, context,
                         ))
                     )
                 )
@@ -309,7 +298,6 @@ impl ControlStreamManager {
 
     fn retry_connect(
         node: WorkerNode,
-        term_id: String,
         context: Arc<impl GlobalBarrierWorkerContext>,
     ) -> BoxFuture<'static, StreamingControlHandle> {
         async move {
@@ -319,11 +307,10 @@ impl ControlStreamManager {
                 5,
                 Duration::from_mins(1),
             );
-            let init_request = PbInitRequest { term_id };
             for delay in backoff {
                 attempt += 1;
                 sleep(delay).await;
-                match context.new_control_stream(&node, &init_request).await {
+                match context.new_control_stream(&node).await {
                     Ok(handle) => {
                         return handle;
                     }
@@ -339,16 +326,11 @@ impl ControlStreamManager {
     pub(super) async fn recover(
         env: MetaSrvEnv,
         nodes: &HashMap<WorkerId, WorkerNode>,
-        term_id: &str,
         context: Arc<impl GlobalBarrierWorkerContext>,
     ) -> Self {
         let reset_start_time = Instant::now();
-        let init_request = PbInitRequest {
-            term_id: term_id.to_owned(),
-        };
-        let init_request = &init_request;
         let nodes = join_all(nodes.iter().map(|(worker_id, node)| async {
-            let result = context.new_control_stream(node, init_request).await;
+            let result = context.new_control_stream(node).await;
             (*worker_id, node.clone(), result)
         }))
         .await;
@@ -393,7 +375,6 @@ impl ControlStreamManager {
                                     node.clone(),
                                     WorkerNodeState::Reconnecting(Self::retry_connect(
                                         node,
-                                        term_id.to_owned(),
                                         context.clone()
                                     ))
                                 )
@@ -421,12 +402,18 @@ pub(super) struct WorkerNodeConnected<'a> {
 }
 
 impl<'a> WorkerNodeConnected<'a> {
-    pub(super) fn initialize(self, partial_graphs: impl Iterator<Item = PartialGraphId>) {
-        for partial_graph_id in partial_graphs {
+    pub(super) fn initialize<'b>(
+        self,
+        partial_graphs: impl Iterator<Item = (PartialGraphId, &'b str)>,
+    ) {
+        for (partial_graph_id, term_id) in partial_graphs {
             if let Err(e) = self.handle.send_request(StreamingControlStreamRequest {
                 request: Some(
                     streaming_control_stream_request::Request::CreatePartialGraph(
-                        PbCreatePartialGraphRequest { partial_graph_id },
+                        PbCreatePartialGraphRequest {
+                            partial_graph_id,
+                            term_id: term_id.to_owned(),
+                        },
                     ),
                 ),
             }) {
@@ -445,7 +432,6 @@ impl ControlStreamManager {
     fn poll_next_event<'a>(
         this_opt: &mut Option<&'a mut Self>,
         cx: &mut Context<'_>,
-        term_id: &str,
         context: &Arc<impl GlobalBarrierWorkerContext>,
         poll_reconnect: bool,
     ) -> Poll<(WorkerId, WorkerNodeEvent<'a>)> {
@@ -536,7 +522,6 @@ impl ControlStreamManager {
                                         *worker_state = WorkerNodeState::Reconnecting(
                                             ControlStreamManager::retry_connect(
                                                 node.clone(),
-                                                term_id.to_owned(),
                                                 context.clone(),
                                             ),
                                         );
@@ -560,17 +545,15 @@ impl ControlStreamManager {
     #[await_tree::instrument("control_stream_next_event")]
     pub(super) async fn next_event<'a>(
         &'a mut self,
-        term_id: &str,
         context: &Arc<impl GlobalBarrierWorkerContext>,
     ) -> (WorkerId, WorkerNodeEvent<'a>) {
         let mut this = Some(self);
-        poll_fn(|cx| Self::poll_next_event(&mut this, cx, term_id, context, true)).await
+        poll_fn(|cx| Self::poll_next_event(&mut this, cx, context, true)).await
     }
 
     #[await_tree::instrument("control_stream_next_response")]
     pub(super) async fn next_response(
         &mut self,
-        term_id: &str,
         context: &Arc<impl GlobalBarrierWorkerContext>,
     ) -> (
         WorkerId,
@@ -578,7 +561,7 @@ impl ControlStreamManager {
     ) {
         let mut this = Some(self);
         let (worker_id, event) =
-            poll_fn(|cx| Self::poll_next_event(&mut this, cx, term_id, context, false)).await;
+            poll_fn(|cx| Self::poll_next_event(&mut this, cx, context, false)).await;
         match event {
             WorkerNodeEvent::Response(result) => (worker_id, result),
             WorkerNodeEvent::Connected(_) => {
@@ -652,6 +635,8 @@ impl PartialGraphRecoverer<'_> {
         cdc_table_snapshot_splits: &mut HashMap<JobId, CdcTableSnapshotSplits>,
         batch_refresh: HashMap<JobId, BatchRefreshRenderResult>,
     ) -> MetaResult<DatabaseCheckpointControl> {
+        let term_id = Uuid::new_v4().to_string();
+
         fn collect_source_splits(
             fragment_infos: impl Iterator<Item = &InflightFragmentInfo>,
             source_splits: &mut HashMap<ActorId, Vec<SplitImpl>>,
@@ -1046,6 +1031,7 @@ impl PartialGraphRecoverer<'_> {
             let partial_graph_id = to_partial_graph_id(database_id, None);
             self.recover_graph(
                 partial_graph_id,
+                &term_id,
                 mutation,
                 &barrier_info,
                 &nodes_actors,
@@ -1121,6 +1107,7 @@ impl PartialGraphRecoverer<'_> {
                 hummock_version_stats,
                 node_actors,
                 mutation.clone(),
+                &term_id,
                 self,
             )?;
             independent_checkpoint_job_controls.insert(
@@ -1195,6 +1182,7 @@ impl PartialGraphRecoverer<'_> {
                 hummock_version_stats,
                 mutation,
                 render_result,
+                &term_id,
                 self,
                 refresh_interval_sec,
             )?;
@@ -1238,6 +1226,7 @@ impl PartialGraphRecoverer<'_> {
         let database_state = BarrierWorkerState::recovery(new_epoch, is_paused);
         Ok(DatabaseCheckpointControl::recovery(
             database_id,
+            term_id,
             database_state,
             committed_epoch,
             database_info,
@@ -1396,7 +1385,7 @@ impl ControlStreamManager {
         Ok(node_need_collect)
     }
 
-    pub(super) fn add_partial_graph(&mut self, partial_graph_id: PartialGraphId) {
+    pub(super) fn add_partial_graph(&mut self, partial_graph_id: PartialGraphId, term_id: &str) {
         self.connected_workers().for_each(|(_, node)| {
             if node
                 .handle
@@ -1406,6 +1395,7 @@ impl ControlStreamManager {
                         streaming_control_stream_request::Request::CreatePartialGraph(
                             CreatePartialGraphRequest {
                                 partial_graph_id,
+                                term_id: term_id.to_owned(),
                             },
                         ),
                     ),
@@ -1470,14 +1460,13 @@ impl GlobalBarrierWorkerContextImpl {
     pub(super) async fn new_control_stream_impl(
         &self,
         node: &WorkerNode,
-        init_request: &PbInitRequest,
     ) -> MetaResult<StreamingControlHandle> {
         let handle = self
             .env
             .stream_client_pool()
             .get(node)
             .await?
-            .start_streaming_control(init_request.clone())
+            .start_streaming_control(PbInitRequest::default())
             .await?;
         Ok(handle)
     }

--- a/src/meta/src/barrier/schedule.rs
+++ b/src/meta/src/barrier/schedule.rs
@@ -857,7 +857,6 @@ mod tests {
         async fn new_control_stream(
             &self,
             _node: &risingwave_pb::common::WorkerNode,
-            _init_request: &risingwave_pb::stream_service::streaming_control_stream_request::PbInitRequest,
         ) -> MetaResult<risingwave_rpc_client::StreamingControlHandle> {
             unimplemented!()
         }

--- a/src/meta/src/barrier/tests/worker_crash_no_early_commit.rs
+++ b/src/meta/src/barrier/tests/worker_crash_no_early_commit.rs
@@ -31,7 +31,7 @@ use risingwave_pb::catalog::Database;
 use risingwave_pb::common::{HostAddress, PbWorkerType, WorkerNode, worker_node};
 use risingwave_pb::hummock::HummockVersionStats;
 use risingwave_pb::stream_plan::PbStreamNode;
-use risingwave_pb::stream_service::streaming_control_stream_request::{PbInitRequest, Request};
+use risingwave_pb::stream_service::streaming_control_stream_request::Request;
 use risingwave_pb::stream_service::streaming_control_stream_response::Response;
 use risingwave_pb::stream_service::{
     BarrierCompleteResponse, StreamingControlStreamRequest, StreamingControlStreamResponse,
@@ -115,11 +115,7 @@ impl GlobalBarrierWorkerContext for MockBarrierWorkerContext {
         unreachable!()
     }
 
-    async fn new_control_stream(
-        &self,
-        node: &WorkerNode,
-        _init_request: &PbInitRequest,
-    ) -> MetaResult<StreamingControlHandle> {
+    async fn new_control_stream(&self, node: &WorkerNode) -> MetaResult<StreamingControlHandle> {
         let (tx, rx) = oneshot::channel();
         self.0
             .send(ContextRequest::NewControlStream(node.clone(), tx))

--- a/src/stream/src/task/barrier_manager/mod.rs
+++ b/src/stream/src/task/barrier_manager/mod.rs
@@ -74,6 +74,7 @@ pub(super) enum LocalBarrierEvent {
         actor_id: ActorId,
         upstream_actor_id: ActorId,
         upstream_partial_graph_id: PartialGraphId,
+        term_id: String,
         tx: permit::Sender,
     },
     ReportCdcTableBackfillProgress {
@@ -188,6 +189,7 @@ impl LocalBarrierManager {
             actor_id,
             upstream_actor_id,
             upstream_partial_graph_id,
+            term_id: self.term_id.clone(),
             tx,
         });
         rx

--- a/src/stream/src/task/barrier_worker/managed_state.rs
+++ b/src/stream/src/task/barrier_worker/managed_state.rs
@@ -442,7 +442,7 @@ pub(crate) struct ResetPartialGraphOutput {
 }
 
 pub(in crate::task) enum PartialGraphStatus {
-    ReceivedExchangeRequest(Vec<(UpDownActorIds, TakeReceiverRequest)>),
+    ReceivedExchangeRequest(Vec<(String, UpDownActorIds, TakeReceiverRequest)>),
     Running(PartialGraphState),
     Suspended(SuspendedPartialGraphState),
     Resetting,
@@ -454,7 +454,7 @@ impl PartialGraphStatus {
     pub(crate) async fn abort(&mut self) {
         match self {
             PartialGraphStatus::ReceivedExchangeRequest(pending_requests) => {
-                for (_, request) in pending_requests.drain(..) {
+                for (_, _, request) in pending_requests.drain(..) {
                     if let TakeReceiverRequest::Remote { result_sender, .. } = request {
                         let _ = result_sender.send(Err(anyhow!("partial graph aborted").into()));
                     }
@@ -525,7 +525,7 @@ impl PartialGraphStatus {
     ) -> BoxFuture<'static, ResetPartialGraphOutput> {
         match replace(self, PartialGraphStatus::Resetting) {
             PartialGraphStatus::ReceivedExchangeRequest(pending_requests) => {
-                for (_, request) in pending_requests {
+                for (_, _, request) in pending_requests {
                     if let TakeReceiverRequest::Remote { result_sender, .. } = request {
                         let _ = result_sender.send(Err(anyhow!("partial graph reset").into()));
                     }
@@ -589,6 +589,7 @@ pub(super) enum ManagedBarrierStateEvent {
         actor_id: ActorId,
         upstream_actor_id: ActorId,
         upstream_partial_graph_id: PartialGraphId,
+        term_id: String,
         tx: permit::Sender,
     },
 }
@@ -971,12 +972,14 @@ impl PartialGraphState {
                     actor_id,
                     upstream_actor_id,
                     upstream_partial_graph_id,
+                    term_id,
                     tx,
                 } => {
                     return Poll::Ready(ManagedBarrierStateEvent::RegisterLocalUpstreamOutput {
                         actor_id,
                         upstream_actor_id,
                         upstream_partial_graph_id,
+                        term_id,
                         tx,
                     });
                 }

--- a/src/stream/src/task/barrier_worker/mod.rs
+++ b/src/stream/src/task/barrier_worker/mod.rs
@@ -312,18 +312,15 @@ pub(super) struct LocalBarrierWorker {
     control_stream_handle: ControlStreamHandle,
 
     pub(super) actor_manager: Arc<StreamActorManager>,
-
-    pub(super) term_id: String,
 }
 
 impl LocalBarrierWorker {
-    pub(super) fn new(actor_manager: Arc<StreamActorManager>, term_id: String) -> Self {
+    pub(super) fn new(actor_manager: Arc<StreamActorManager>) -> Self {
         Self {
             state: Default::default(),
             await_epoch_completed_futures: Default::default(),
             control_stream_handle: ControlStreamHandle::empty(),
             actor_manager,
-            term_id,
         }
     }
 
@@ -401,11 +398,12 @@ impl LocalBarrierWorker {
                             actor_id,
                             upstream_actor_id,
                             upstream_partial_graph_id,
+                            term_id,
                             tx
                         } => {
                             self.handle_actor_op(LocalActorOperation::TakeReceiver {
                                 partial_graph_id: upstream_partial_graph_id,
-                                term_id: self.term_id.clone(),
+                                term_id,
                                 ids: (upstream_actor_id, actor_id),
                                 request: TakeReceiverRequest::Local(tx),
                             });
@@ -495,7 +493,7 @@ impl LocalBarrierWorker {
                 Ok(())
             }
             Request::CreatePartialGraph(req) => {
-                self.add_partial_graph(req.partial_graph_id);
+                self.add_partial_graph(req.partial_graph_id, req.term_id);
                 Ok(())
             }
             Request::ResetPartialGraphs(req) => {
@@ -519,29 +517,28 @@ impl LocalBarrierWorker {
                 ids,
                 request,
             } => {
-                let err = if self.term_id != term_id {
-                    {
-                        warn!(
-                            ?ids,
-                            term_id,
-                            current_term_id = self.term_id,
-                            "take receiver on unmatched term_id"
-                        );
-                        anyhow!(
-                            "take receiver {:?} on unmatched term_id {} to current term_id {}",
-                            ids,
-                            term_id,
-                            self.term_id
-                        )
-                    }
-                } else {
-                    match self.state.partial_graphs.entry(partial_graph_id) {
-                        Entry::Occupied(mut entry) => match entry.get_mut() {
-                            PartialGraphStatus::ReceivedExchangeRequest(pending_requests) => {
-                                pending_requests.push((ids, request));
-                                return;
-                            }
-                            PartialGraphStatus::Running(graph) => {
+                let err = match self.state.partial_graphs.entry(partial_graph_id) {
+                    Entry::Occupied(mut entry) => match entry.get_mut() {
+                        PartialGraphStatus::ReceivedExchangeRequest(pending_requests) => {
+                            pending_requests.push((term_id, ids, request));
+                            return;
+                        }
+                        PartialGraphStatus::Running(graph) => {
+                            if graph.local_barrier_manager.term_id != term_id {
+                                warn!(
+                                    %partial_graph_id,
+                                    ?ids,
+                                    request_term_id = term_id,
+                                    current_term_id = graph.local_barrier_manager.term_id,
+                                    "take receiver on unmatched partial graph term"
+                                );
+                                anyhow!(
+                                    "take receiver {:?} on unmatched partial graph term {} to current term {}",
+                                    ids,
+                                    term_id,
+                                    graph.local_barrier_manager.term_id
+                                )
+                            } else {
                                 let (upstream_actor_id, actor_id) = ids;
                                 graph.new_actor_output_request(
                                     actor_id,
@@ -550,22 +547,16 @@ impl LocalBarrierWorker {
                                 );
                                 return;
                             }
-                            PartialGraphStatus::Suspended(_) => {
-                                anyhow!("partial graph suspended")
-                            }
-                            PartialGraphStatus::Resetting => {
-                                anyhow!("partial graph resetting")
-                            }
-                            PartialGraphStatus::Unspecified => {
-                                unreachable!()
-                            }
-                        },
-                        Entry::Vacant(entry) => {
-                            entry.insert(PartialGraphStatus::ReceivedExchangeRequest(vec![(
-                                ids, request,
-                            )]));
-                            return;
                         }
+                        PartialGraphStatus::Suspended(_) => anyhow!("partial graph suspended"),
+                        PartialGraphStatus::Resetting => anyhow!("partial graph resetting"),
+                        PartialGraphStatus::Unspecified => unreachable!(),
+                    },
+                    Entry::Vacant(entry) => {
+                        entry.insert(PartialGraphStatus::ReceivedExchangeRequest(vec![(
+                            term_id, ids, request,
+                        )]));
+                        return;
                     }
                 };
                 if let TakeReceiverRequest::Remote { result_sender, .. } = request {
@@ -946,18 +937,37 @@ impl LocalBarrierWorker {
         }
     }
 
-    fn add_partial_graph(&mut self, partial_graph_id: PartialGraphId) {
+    fn add_partial_graph(&mut self, partial_graph_id: PartialGraphId, term_id: String) {
         match self.state.partial_graphs.entry(partial_graph_id) {
             Entry::Occupied(entry) => {
                 let status = entry.into_mut();
                 if let PartialGraphStatus::ReceivedExchangeRequest(pending_requests) = status {
                     let mut graph = PartialGraphState::new(
                         partial_graph_id,
-                        self.term_id.clone(),
+                        term_id.clone(),
                         self.actor_manager.clone(),
                     );
-                    for ((upstream_actor_id, actor_id), request) in pending_requests.drain(..) {
-                        graph.new_actor_output_request(actor_id, upstream_actor_id, request);
+                    for (request_term_id, (upstream_actor_id, actor_id), request) in
+                        pending_requests.drain(..)
+                    {
+                        if request_term_id == term_id {
+                            graph.new_actor_output_request(actor_id, upstream_actor_id, request);
+                        } else {
+                            warn!(
+                                %partial_graph_id,
+                                %upstream_actor_id,
+                                %actor_id,
+                                request_term_id,
+                                current_term_id = term_id,
+                                "reject buffered exchange request with stale partial graph term"
+                            );
+                            if let TakeReceiverRequest::Remote { result_sender, .. } = request {
+                                let _ = result_sender.send(Err(anyhow!(
+                                    "take receiver ({upstream_actor_id}, {actor_id}) on stale partial graph term {request_term_id}; current term is {term_id}"
+                                )
+                                .into()));
+                            }
+                        }
                     }
                     *status = PartialGraphStatus::Running(graph);
                 } else {
@@ -966,13 +976,9 @@ impl LocalBarrierWorker {
 
                 status
             }
-            Entry::Vacant(entry) => {
-                entry.insert(PartialGraphStatus::Running(PartialGraphState::new(
-                    partial_graph_id,
-                    self.term_id.clone(),
-                    self.actor_manager.clone(),
-                )))
-            }
+            Entry::Vacant(entry) => entry.insert(PartialGraphStatus::Running(
+                PartialGraphState::new(partial_graph_id, term_id, self.actor_manager.clone()),
+            )),
         };
     }
 
@@ -1057,7 +1063,7 @@ impl LocalBarrierWorker {
     }
 
     /// Force stop all actors on this worker, and then drop their resources.
-    async fn reset(&mut self, init_request: InitRequest) {
+    async fn reset(&mut self, _init_request: InitRequest) {
         join(
             join_all(
                 self.state
@@ -1083,7 +1089,7 @@ impl LocalBarrierWorker {
                 .await
         }
         self.actor_manager.env.dml_manager_ref().clear();
-        *self = Self::new(self.actor_manager.clone(), init_request.term_id);
+        *self = Self::new(self.actor_manager.clone());
         self.actor_manager.env.client_pool().invalidate_all();
     }
 
@@ -1115,7 +1121,7 @@ impl LocalBarrierWorker {
             runtime: runtime.into(),
             config_override_cache: ConfigOverrideCache::new(CONFIG_OVERRIDE_CACHE_DEFAULT_CAPACITY),
         });
-        let worker = LocalBarrierWorker::new(actor_manager, "uninitialized".into());
+        let worker = LocalBarrierWorker::new(actor_manager);
         tokio::spawn(worker.run(actor_op_rx))
     }
 }
@@ -1191,6 +1197,7 @@ pub(crate) mod barrier_test_utils {
                         streaming_control_stream_request::Request::CreatePartialGraph(
                             PbCreatePartialGraphRequest {
                                 partial_graph_id: TEST_PARTIAL_GRAPH_ID,
+                                term_id: "for_test".into(),
                             },
                         ),
                     ),
@@ -1202,9 +1209,7 @@ pub(crate) mod barrier_test_utils {
                     response_tx,
                     UnboundedReceiverStream::new(request_rx).boxed(),
                 ),
-                init_request: InitRequest {
-                    term_id: "for_test".into(),
-                },
+                init_request: InitRequest {},
             });
 
             assert_matches!(

--- a/src/stream/src/task/barrier_worker/tests.rs
+++ b/src/stream/src/task/barrier_worker/tests.rs
@@ -20,9 +20,114 @@ use std::task::Poll;
 use futures::FutureExt;
 use futures::future::join_all;
 use risingwave_common::util::epoch::{EpochExt, test_epoch};
+use risingwave_pb::stream_service::streaming_control_stream_request::{
+    CreatePartialGraphRequest, ResetPartialGraphsRequest,
+};
+use risingwave_pb::stream_service::{
+    StreamingControlStreamRequest, streaming_control_stream_request,
+};
 
 use super::*;
+use crate::task::TEST_PARTIAL_GRAPH_ID;
 use crate::task::barrier_test_utils::LocalBarrierTestEnv;
+
+#[tokio::test]
+async fn test_reject_exchange_request_with_stale_partial_graph_term() -> StreamResult<()> {
+    let test_env = LocalBarrierTestEnv::for_test().await;
+    let result = test_env
+        .actor_op_tx
+        .send_and_await(|result_sender| LocalActorOperation::TakeReceiver {
+            partial_graph_id: TEST_PARTIAL_GRAPH_ID,
+            term_id: "stale".to_owned(),
+            ids: (1.into(), 2.into()),
+            request: TakeReceiverRequest::Remote {
+                result_sender,
+                upstream_fragment_id: 1.into(),
+            },
+        })
+        .await?;
+
+    assert!(
+        result
+            .err()
+            .unwrap()
+            .to_string()
+            .contains("unmatched partial graph term")
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_filter_buffered_exchange_requests_by_partial_graph_term() -> StreamResult<()> {
+    let mut test_env = LocalBarrierTestEnv::for_test().await;
+    test_env
+        .request_tx
+        .send(Ok(StreamingControlStreamRequest {
+            request: Some(
+                streaming_control_stream_request::Request::ResetPartialGraphs(
+                    ResetPartialGraphsRequest {
+                        partial_graph_ids: vec![TEST_PARTIAL_GRAPH_ID],
+                    },
+                ),
+            ),
+        }))
+        .unwrap();
+    assert!(matches!(
+        test_env
+            .response_rx
+            .recv()
+            .await
+            .unwrap()
+            .unwrap()
+            .response
+            .unwrap(),
+        streaming_control_stream_response::Response::ResetPartialGraph(_)
+    ));
+
+    let actor_op_tx = test_env.actor_op_tx.clone();
+    let take_receiver = move |term_id: &str, upstream_actor_id: ActorId| {
+        let actor_op_tx = actor_op_tx.clone();
+        let term_id = term_id.to_owned();
+        tokio::spawn(async move {
+            actor_op_tx
+                .send_and_await(|result_sender| LocalActorOperation::TakeReceiver {
+                    partial_graph_id: TEST_PARTIAL_GRAPH_ID,
+                    term_id,
+                    ids: (upstream_actor_id, 3.into()),
+                    request: TakeReceiverRequest::Remote {
+                        result_sender,
+                        upstream_fragment_id: 1.into(),
+                    },
+                })
+                .await
+                .unwrap()
+        })
+    };
+    let stale_request = take_receiver("for_test", 1.into());
+    let matching_request = take_receiver("next_term", 2.into());
+    LocalBarrierTestEnv::flush_all_events_impl(&test_env.actor_op_tx).await;
+
+    test_env
+        .request_tx
+        .send(Ok(StreamingControlStreamRequest {
+            request: Some(
+                streaming_control_stream_request::Request::CreatePartialGraph(
+                    CreatePartialGraphRequest {
+                        partial_graph_id: TEST_PARTIAL_GRAPH_ID,
+                        term_id: "next_term".to_owned(),
+                    },
+                ),
+            ),
+        }))
+        .unwrap();
+
+    assert!(stale_request.await.unwrap().is_err());
+    assert!(matching_request.await.unwrap().is_ok());
+    let pending = test_env.take_pending_new_output_requests(2.into()).await;
+    assert_eq!(pending.len(), 1);
+    assert_eq!(pending[0].0, ActorId::from(3));
+    Ok(())
+}
 
 #[tokio::test]
 async fn test_managed_barrier_collection() -> StreamResult<()> {


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

Per-database recovery reuses partial graph IDs across attempts. A delayed `GetStreamRequest` from the previous attempt could therefore reach a recreated graph and be treated as part of the current recovery, causing repeated initialization failures.

This PR fences those stale exchange requests with one UUID term per database recovery incarnation:

- `DatabaseCheckpointControl` owns the term shared by all partial graphs in the database.
- `CreatePartialGraphRequest` installs that term in each compute-side partial graph.
- Remote exchange requests reuse the existing `GetStreamRequest.term_id` field.
- Compute validates live requests against the graph-local term and filters buffered pre-creation requests when the graph is created.
- The former control-stream-global term is removed; `InitRequest` remains only as the empty wire handshake required by the streaming RPC.

Tests cover both a stale request received by an existing graph and stale/matching requests buffered before graph creation.

- Closes #26883

## Checklist

- [x] I have written necessary rustdoc comments.
- [x] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [x] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/dev/src/ci.md#ci-labels-guide -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Partial graphs now track their own recovery incarnation, improving recovery across database restarts and refresh operations.
  * Recovery information is propagated consistently when creating, restoring, and registering partial graphs and upstream outputs.

* **Bug Fixes**
  * Stale requests from previous recovery incarnations are rejected, preventing outdated graph activity from affecting current processing.
  * Buffered exchange requests are filtered against the active recovery incarnation.

* **Tests**
  * Added coverage for stale partial-graph requests and recovery-aware buffered request handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->