### PR TITLE
feat(stream): support broadcast temporal join

### DIFF
--- a/e2e_test/streaming/temporal_join/append_only/broadcast.slt
+++ b/e2e_test/streaming/temporal_join/append_only/broadcast.slt
@@ -1,0 +1,52 @@
+statement ok
+SET RW_IMPLICIT_FLUSH TO true;
+
+statement ok
+CREATE TABLE events(id INT, payload INT) APPEND ONLY;
+
+statement ok
+CREATE TABLE dimensions(id INT PRIMARY KEY, dim_value INT);
+
+statement ok
+CREATE MATERIALIZED VIEW joined AS
+SELECT events.id, payload, dim_value
+FROM events
+BROADCAST LEFT JOIN dimensions FOR SYSTEM_TIME AS OF PROCTIME()
+ON events.id = dimensions.id;
+
+statement ok
+INSERT INTO dimensions VALUES (1, 10), (2, 20);
+
+statement ok
+INSERT INTO events VALUES (1, 101), (1, 102), (3, 103);
+
+query III rowsort
+SELECT * FROM joined;
+----
+1 101 10
+1 102 10
+3 103 NULL
+
+statement ok
+UPDATE dimensions SET dim_value = 11 WHERE id = 1;
+
+statement ok
+INSERT INTO events VALUES (1, 104), (2, 105);
+
+query III rowsort
+SELECT * FROM joined;
+----
+1 101 10
+1 102 10
+1 104 11
+2 105 20
+3 103 NULL
+
+statement ok
+DROP MATERIALIZED VIEW joined;
+
+statement ok
+DROP TABLE events;
+
+statement ok
+DROP TABLE dimensions;

--- a/e2e_test/streaming/temporal_join/non_append_only/broadcast.slt
+++ b/e2e_test/streaming/temporal_join/non_append_only/broadcast.slt
@@ -148,6 +148,57 @@ DROP TABLE raw_events;
 statement ok
 DROP TABLE dimensions;
 
+# A singleton retractable left input has no actor vnode bitmap. Its memo table must use singleton
+# distribution while the lookup side remains fully replicated.
+statement ok
+CREATE TABLE singleton_events(id INT PRIMARY KEY, v INT);
+
+statement ok
+CREATE TABLE singleton_dimensions(id INT PRIMARY KEY, name VARCHAR);
+
+statement ok
+INSERT INTO singleton_dimensions VALUES (1, 'one'), (2, 'two');
+
+statement ok
+CREATE MATERIALIZED VIEW singleton_joined AS
+SELECT s.k, s.c, singleton_dimensions.name
+FROM (SELECT max(id) AS k, count(*) AS c FROM singleton_events) AS s
+BROADCAST LEFT JOIN singleton_dimensions FOR SYSTEM_TIME AS OF PROCTIME()
+ON s.k = singleton_dimensions.id;
+
+statement ok
+INSERT INTO singleton_events VALUES (1, 10);
+
+query IIT
+SELECT * FROM singleton_joined;
+----
+1 1 one
+
+statement ok
+INSERT INTO singleton_events VALUES (2, 20);
+
+query IIT
+SELECT * FROM singleton_joined;
+----
+2 2 two
+
+statement ok
+DELETE FROM singleton_events WHERE id = 2;
+
+query IIT
+SELECT * FROM singleton_joined;
+----
+1 1 one
+
+statement ok
+DROP MATERIALIZED VIEW singleton_joined;
+
+statement ok
+DROP TABLE singleton_events;
+
+statement ok
+DROP TABLE singleton_dimensions;
+
 statement ok
 SET streaming_parallelism = default;
 

--- a/e2e_test/streaming/temporal_join/non_append_only/broadcast.slt
+++ b/e2e_test/streaming/temporal_join/non_append_only/broadcast.slt
@@ -1,0 +1,155 @@
+statement ok
+SET RW_IMPLICIT_FLUSH TO true;
+
+# Give the left index and lookup table different vnode counts. The temporal join fragment follows
+# the left side; every actor independently keeps a full replica of the lookup side.
+statement ok
+SET streaming_parallelism = 2;
+
+statement ok
+SET streaming_max_parallelism = 8;
+
+statement ok
+CREATE TABLE raw_events(
+    event_id INT PRIMARY KEY,
+    lookup_id INT,
+    shard_id INT,
+    payload INT
+);
+
+statement ok
+CREATE INDEX events_by_shard
+ON raw_events(shard_id, event_id, lookup_id, payload)
+DISTRIBUTED BY (shard_id);
+
+statement ok
+SET streaming_max_parallelism = 16;
+
+statement ok
+CREATE TABLE dimensions(id INT PRIMARY KEY, dim_value INT);
+
+statement ok
+SET streaming_max_parallelism = 8;
+
+statement ok
+CREATE MATERIALIZED VIEW joined AS
+SELECT event_id, lookup_id, shard_id, payload, dim_value
+FROM events_by_shard AS events
+BROADCAST LEFT JOIN dimensions FOR SYSTEM_TIME AS OF PROCTIME()
+ON events.lookup_id = dimensions.id;
+
+statement ok
+INSERT INTO raw_events VALUES (99, 1, 0, 999);
+
+query IIIII
+SELECT * FROM joined;
+----
+99 1 0 999 NULL
+
+# A later dimension insert must not rewrite the existing unmatched temporal result. Deleting the
+# left row must retract the memoized NULL result rather than the now-current matching dimension.
+statement ok
+INSERT INTO dimensions VALUES (1, 10);
+
+query IIIII
+SELECT * FROM joined;
+----
+99 1 0 999 NULL
+
+statement ok
+DELETE FROM raw_events WHERE event_id = 99;
+
+query IIIII
+SELECT * FROM joined;
+----
+
+
+statement ok
+INSERT INTO raw_events VALUES (100, 1, 0, 1000);
+
+query IIIII
+SELECT * FROM joined;
+----
+100 1 0 1000 10
+
+# Updating the lookup table does not rewrite an existing temporal-join result.
+statement ok
+UPDATE dimensions SET dim_value = 20 WHERE id = 1;
+
+query IIIII
+SELECT * FROM joined;
+----
+100 1 0 1000 10
+
+# Deleting the left row must retract the memoized v1 row, not the current v2 lookup row.
+statement ok
+DELETE FROM raw_events WHERE event_id = 100;
+
+query IIIII
+SELECT * FROM joined;
+----
+
+
+statement ok
+INSERT INTO raw_events VALUES (101, 1, 0, 1001);
+
+query IIIII
+SELECT * FROM joined;
+----
+101 1 0 1001 20
+
+# Updating the index distribution key sends U- and U+ to actors selected by the old and new
+# shard_id respectively. Each side must access the corresponding left-owned memo vnode.
+statement ok
+UPDATE raw_events SET shard_id = 1, payload = 1002 WHERE event_id = 101;
+
+query IIIII
+SELECT * FROM joined;
+----
+101 1 1 1002 20
+
+statement ok
+UPDATE dimensions SET dim_value = 30 WHERE id = 1;
+
+# Exercise memo migration in both directions while the lookup replica keeps its full vnode set.
+statement ok
+ALTER MATERIALIZED VIEW joined SET PARALLELISM = 1;
+
+query IIIII
+SELECT * FROM joined;
+----
+101 1 1 1002 20
+
+statement ok
+ALTER MATERIALIZED VIEW joined SET PARALLELISM = 2;
+
+query IIIII
+SELECT * FROM joined;
+----
+101 1 1 1002 20
+
+statement ok
+DELETE FROM raw_events WHERE event_id = 101;
+
+query IIIII
+SELECT * FROM joined;
+----
+
+
+statement ok
+DROP MATERIALIZED VIEW joined;
+
+statement ok
+DROP INDEX events_by_shard;
+
+statement ok
+DROP TABLE raw_events;
+
+statement ok
+DROP TABLE dimensions;
+
+statement ok
+SET streaming_parallelism = default;
+
+statement ok
+SET streaming_max_parallelism = default;

--- a/proto/stream_plan.proto
+++ b/proto/stream_plan.proto
@@ -726,6 +726,8 @@ message TemporalJoinNode {
   optional catalog.Table memo_table = 9;
   // If it is a nested lool temporal join
   bool is_nested_loop = 10;
+  // Whether lookup-side changes are broadcast to every temporal join actor.
+  bool is_broadcast = 11;
 }
 
 message DynamicFilterNode {

--- a/src/frontend/planner_test/tests/testdata/input/temporal_join.yaml
+++ b/src/frontend/planner_test/tests/testdata/input/temporal_join.yaml
@@ -22,6 +22,16 @@
   expected_outputs:
   - stream_plan
   - stream_dist_plan
+- name: Broadcast temporal join supports a singleton retractable left input
+  sql: |
+    create table stream(id int primary key, v int);
+    create table version(id int primary key, name varchar);
+    select s.k, s.c, version.name
+    from (select max(id) as k, count(*) as c from stream) as s
+    broadcast left join version FOR SYSTEM_TIME AS OF PROCTIME() on s.k = version.id;
+  expected_outputs:
+  - stream_plan
+  - stream_dist_plan
 - name: Inner join type for temporal join
   sql: |
     create table stream(id1 int, a1 int, b1 int) APPEND ONLY;

--- a/src/frontend/planner_test/tests/testdata/input/temporal_join.yaml
+++ b/src/frontend/planner_test/tests/testdata/input/temporal_join.yaml
@@ -14,13 +14,14 @@
   expected_outputs:
   - stream_plan
   - stream_dist_plan
-- name: Broadcast temporal join requires an append-only left input
+- name: Broadcast temporal join memo table follows the non-append-only left distribution
   sql: |
     create table stream(id1 int primary key, a1 int, b1 int);
     create table version(id2 int, a2 int, b2 int, primary key (id2));
-    select id1, a1, id2, a2 from stream broadcast join version FOR SYSTEM_TIME AS OF PROCTIME() on id1 = id2;
+    select id1, a1, id2, a2 from stream broadcast join version FOR SYSTEM_TIME AS OF PROCTIME() on a1 = id2;
   expected_outputs:
-  - stream_error
+  - stream_plan
+  - stream_dist_plan
 - name: Inner join type for temporal join
   sql: |
     create table stream(id1 int, a1 int, b1 int) APPEND ONLY;

--- a/src/frontend/planner_test/tests/testdata/input/temporal_join.yaml
+++ b/src/frontend/planner_test/tests/testdata/input/temporal_join.yaml
@@ -6,6 +6,21 @@
   expected_outputs:
   - batch_error
   - stream_plan
+- name: Broadcast temporal join keeps the left distribution
+  sql: |
+    create table stream(id1 int, a1 int, b1 int) APPEND ONLY;
+    create table version(id2 int, a2 int, b2 int, primary key (id2));
+    select id1, a1, id2, a2 from stream broadcast left join version FOR SYSTEM_TIME AS OF PROCTIME() on id1 = id2;
+  expected_outputs:
+  - stream_plan
+  - stream_dist_plan
+- name: Broadcast temporal join requires an append-only left input
+  sql: |
+    create table stream(id1 int primary key, a1 int, b1 int);
+    create table version(id2 int, a2 int, b2 int, primary key (id2));
+    select id1, a1, id2, a2 from stream broadcast join version FOR SYSTEM_TIME AS OF PROCTIME() on id1 = id2;
+  expected_outputs:
+  - stream_error
 - name: Inner join type for temporal join
   sql: |
     create table stream(id1 int, a1 int, b1 int) APPEND ONLY;

--- a/src/frontend/planner_test/tests/testdata/output/temporal_join.yaml
+++ b/src/frontend/planner_test/tests/testdata/output/temporal_join.yaml
@@ -112,6 +112,62 @@
     ├── distribution key: [ 0, 1 ]
     └── read pk prefix len hint: 2
 
+- name: Broadcast temporal join supports a singleton retractable left input
+  sql: |
+    create table stream(id int primary key, v int);
+    create table version(id int primary key, name varchar);
+    select s.k, s.c, version.name
+    from (select max(id) as k, count(*) as c from stream) as s
+    broadcast left join version FOR SYSTEM_TIME AS OF PROCTIME() on s.k = version.id;
+  stream_plan: |-
+    StreamMaterialize { columns: [k, c, name, version.id(hidden)], stream_key: [k], pk_columns: [k], pk_conflict: NoCheck }
+    └─StreamTemporalJoin { type: LeftOuter, append_only: false, predicate: max(max(stream.id)) = version.id, nested_loop: false, broadcast: true, output: [max(max(stream.id)), sum0(count), version.name, version.id] }
+      ├─StreamProject { exprs: [max(max(stream.id)), sum0(count)] }
+      │ └─StreamSimpleAgg { aggs: [max(max(stream.id)), sum0(count), count] }
+      │   └─StreamExchange { dist: Single }
+      │     └─StreamHashAgg { group_key: [_vnode], aggs: [max(stream.id), count] }
+      │       └─StreamProject { exprs: [stream.id, Vnode(stream.id) as _vnode] }
+      │         └─StreamTableScan { table: stream, columns: [stream.id], stream_scan_type: ArrangementBackfill, stream_key: [stream.id], pk: [id], dist: UpstreamHashShard(stream.id) }
+      └─StreamExchange { dist: Broadcast }
+        └─StreamTableScan { table: version, columns: [version.id, version.name], stream_scan_type: UpstreamOnly, stream_key: [version.id], pk: [id], dist: UpstreamHashShard(version.id) }
+  stream_dist_plan: |+
+    Fragment 0
+    StreamMaterialize { columns: [k, c, name, version.id(hidden)], stream_key: [k], pk_columns: [k], pk_conflict: NoCheck }
+    └── StreamTemporalJoin { type: LeftOuter, append_only: false, predicate: max(max(stream.id)) = version.id, nested_loop: false, broadcast: true, output: [max(max(stream.id)), sum0(count), version.name, version.id] }
+        ├── tables: [ TemporalJoinMemo: 0 ]
+        ├── StreamProject { exprs: [max(max(stream.id)), sum0(count)] }
+        │   └── StreamSimpleAgg { aggs: [max(max(stream.id)), sum0(count), count] } { tables: [ SimpleAggState: 2, SimpleAggCall0: 1 ] }
+        │       └── StreamExchange Single from 1
+        └── StreamExchange Broadcast from 2
+
+    Fragment 1
+    StreamHashAgg { group_key: [_vnode], aggs: [max(stream.id), count] } { tables: [ HashAggState: 4, HashAggCall0: 3 ] }
+    └── StreamProject { exprs: [stream.id, Vnode(stream.id) as _vnode] }
+        └── StreamTableScan { table: stream, columns: [stream.id], stream_scan_type: ArrangementBackfill, stream_key: [stream.id], pk: [id], dist: UpstreamHashShard(stream.id) } { tables: [ StreamScan: 5 ] }
+            ├── Upstream
+            └── BatchPlanNode
+
+    Fragment 2
+    StreamTableScan { table: version, columns: [version.id, version.name], stream_scan_type: UpstreamOnly, stream_key: [version.id], pk: [id], dist: UpstreamHashShard(version.id) } { tables: [ StreamScan: 6 ] }
+    ├── Upstream
+    └── BatchPlanNode
+
+    Table 0 { columns: [ version_id, version_name, max(max(stream_id)), _rw_timestamp ], primary key: [ $2 ASC, $0 ASC ], value indices: [ 0, 1, 2 ], distribution key: [], read pk prefix len hint: 1 }
+
+    Table 1 { columns: [ max(stream_id), _vnode, _rw_timestamp ], primary key: [ $0 DESC, $1 ASC ], value indices: [ 0, 1 ], distribution key: [], read pk prefix len hint: 0 }
+
+    Table 2 { columns: [ max(max(stream_id)), sum0(count), count, _rw_timestamp ], primary key: [], value indices: [ 0, 1, 2 ], distribution key: [], read pk prefix len hint: 0 }
+
+    Table 3 { columns: [ _vnode, stream_id, _rw_timestamp ], primary key: [ $0 ASC, $1 DESC ], value indices: [ 1 ], distribution key: [ 1 ], read pk prefix len hint: 1, vnode column idx: 0 }
+
+    Table 4 { columns: [ _vnode, max(stream_id), count, _rw_timestamp ], primary key: [ $0 ASC ], value indices: [ 1, 2 ], distribution key: [], read pk prefix len hint: 1, vnode column idx: 0 }
+
+    Table 5 { columns: [ vnode, id, backfill_finished, row_count, _rw_timestamp ], primary key: [ $0 ASC ], value indices: [ 1, 2, 3 ], distribution key: [ 0 ], read pk prefix len hint: 1, vnode column idx: 0 }
+
+    Table 6 { columns: [ vnode, id, backfill_finished, row_count, _rw_timestamp ], primary key: [ $0 ASC ], value indices: [ 1, 2, 3 ], distribution key: [ 0 ], read pk prefix len hint: 1, vnode column idx: 0 }
+
+    Table 4294967294 { columns: [ k, c, name, version.id, _rw_timestamp ], primary key: [ $0 ASC ], value indices: [ 0, 1, 2, 3 ], distribution key: [], read pk prefix len hint: 1 }
+
 - name: Inner join type for temporal join
   sql: |
     create table stream(id1 int, a1 int, b1 int) APPEND ONLY;

--- a/src/frontend/planner_test/tests/testdata/output/temporal_join.yaml
+++ b/src/frontend/planner_test/tests/testdata/output/temporal_join.yaml
@@ -83,11 +83,11 @@
     └── BatchPlanNode
 
     Table 0
-    ├── columns: [ version_id2, version_a2, stream_id1, _rw_timestamp ]
-    ├── primary key: [ $2 ASC, $0 ASC ]
-    ├── value indices: [ 0, 1, 2 ]
-    ├── distribution key: [ 2 ]
-    └── read pk prefix len hint: 1
+    ├── columns: [ version_id2, version_a2, stream_a1, stream_id1, _rw_timestamp ]
+    ├── primary key: [ $2 ASC, $3 ASC, $0 ASC ]
+    ├── value indices: [ 0, 1, 2, 3 ]
+    ├── distribution key: [ 3 ]
+    └── read pk prefix len hint: 2
 
     Table 1
     ├── columns: [ vnode, id1, backfill_finished, row_count, _rw_timestamp ]

--- a/src/frontend/planner_test/tests/testdata/output/temporal_join.yaml
+++ b/src/frontend/planner_test/tests/testdata/output/temporal_join.yaml
@@ -51,14 +51,67 @@
 
     Table 4294967294 { columns: [ id1, a1, id2, a2, stream._row_id, _rw_timestamp ], primary key: [ $4 ASC, $0 ASC ], value indices: [ 0, 1, 2, 3, 4 ], distribution key: [ 0, 4 ], read pk prefix len hint: 2 }
 
-- name: Broadcast temporal join requires an append-only left input
+- name: Broadcast temporal join memo table follows the non-append-only left distribution
   sql: |
     create table stream(id1 int primary key, a1 int, b1 int);
     create table version(id2 int, a2 int, b2 int, primary key (id2));
-    select id1, a1, id2, a2 from stream broadcast join version FOR SYSTEM_TIME AS OF PROCTIME() on id1 = id2;
-  stream_error: |-
-    Not supported: Broadcast temporal join requires the left input to be append-only
-    HINT: Please use a regular temporal join for a non-append-only input
+    select id1, a1, id2, a2 from stream broadcast join version FOR SYSTEM_TIME AS OF PROCTIME() on a1 = id2;
+  stream_plan: |-
+    StreamMaterialize { columns: [id1, a1, id2, a2], stream_key: [id1, a1], pk_columns: [id1, a1], pk_conflict: NoCheck }
+    └─StreamExchange { dist: HashShard(stream.id1, stream.a1) }
+      └─StreamTemporalJoin { type: Inner, append_only: false, predicate: stream.a1 = version.id2, nested_loop: false, broadcast: true, output: all }
+        ├─StreamTableScan { table: stream, columns: [stream.id1, stream.a1], stream_scan_type: ArrangementBackfill, stream_key: [stream.id1], pk: [id1], dist: UpstreamHashShard(stream.id1) }
+        └─StreamExchange { dist: Broadcast }
+          └─StreamTableScan { table: version, columns: [version.id2, version.a2], stream_scan_type: UpstreamOnly, stream_key: [version.id2], pk: [id2], dist: UpstreamHashShard(version.id2) }
+  stream_dist_plan: |+
+    Fragment 0
+    StreamMaterialize { columns: [id1, a1, id2, a2], stream_key: [id1, a1], pk_columns: [id1, a1], pk_conflict: NoCheck }
+    └── StreamExchange Hash([0, 1]) from 1
+
+    Fragment 1
+    StreamTemporalJoin { type: Inner, append_only: false, predicate: stream.a1 = version.id2, nested_loop: false, broadcast: true, output: all } { tables: [ TemporalJoinMemo: 0 ] }
+    ├── StreamTableScan { table: stream, columns: [stream.id1, stream.a1], stream_scan_type: ArrangementBackfill, stream_key: [stream.id1], pk: [id1], dist: UpstreamHashShard(stream.id1) }
+    │   ├── tables: [ StreamScan: 1 ]
+    │   ├── Upstream
+    │   └── BatchPlanNode
+    └── StreamExchange Broadcast from 2
+
+    Fragment 2
+    StreamTableScan { table: version, columns: [version.id2, version.a2], stream_scan_type: UpstreamOnly, stream_key: [version.id2], pk: [id2], dist: UpstreamHashShard(version.id2) }
+    ├── tables: [ StreamScan: 2 ]
+    ├── Upstream
+    └── BatchPlanNode
+
+    Table 0
+    ├── columns: [ version_id2, version_a2, stream_id1, _rw_timestamp ]
+    ├── primary key: [ $2 ASC, $0 ASC ]
+    ├── value indices: [ 0, 1, 2 ]
+    ├── distribution key: [ 2 ]
+    └── read pk prefix len hint: 1
+
+    Table 1
+    ├── columns: [ vnode, id1, backfill_finished, row_count, _rw_timestamp ]
+    ├── primary key: [ $0 ASC ]
+    ├── value indices: [ 1, 2, 3 ]
+    ├── distribution key: [ 0 ]
+    ├── read pk prefix len hint: 1
+    └── vnode column idx: 0
+
+    Table 2
+    ├── columns: [ vnode, id2, backfill_finished, row_count, _rw_timestamp ]
+    ├── primary key: [ $0 ASC ]
+    ├── value indices: [ 1, 2, 3 ]
+    ├── distribution key: [ 0 ]
+    ├── read pk prefix len hint: 1
+    └── vnode column idx: 0
+
+    Table 4294967294
+    ├── columns: [ id1, a1, id2, a2, _rw_timestamp ]
+    ├── primary key: [ $0 ASC, $1 ASC ]
+    ├── value indices: [ 0, 1, 2, 3 ]
+    ├── distribution key: [ 0, 1 ]
+    └── read pk prefix len hint: 2
+
 - name: Inner join type for temporal join
   sql: |
     create table stream(id1 int, a1 int, b1 int) APPEND ONLY;

--- a/src/frontend/planner_test/tests/testdata/output/temporal_join.yaml
+++ b/src/frontend/planner_test/tests/testdata/output/temporal_join.yaml
@@ -15,6 +15,50 @@
   batch_error: |-
     Not supported: do not support temporal join for batch queries
     HINT: please use temporal join in streaming queries
+- name: Broadcast temporal join keeps the left distribution
+  sql: |
+    create table stream(id1 int, a1 int, b1 int) APPEND ONLY;
+    create table version(id2 int, a2 int, b2 int, primary key (id2));
+    select id1, a1, id2, a2 from stream broadcast left join version FOR SYSTEM_TIME AS OF PROCTIME() on id1 = id2;
+  stream_plan: |-
+    StreamMaterialize { columns: [id1, a1, id2, a2, stream._row_id(hidden)], stream_key: [stream._row_id, id1], pk_columns: [stream._row_id, id1], pk_conflict: NoCheck }
+    └─StreamExchange { dist: HashShard(stream.id1, stream._row_id) }
+      └─StreamTemporalJoin { type: LeftOuter, append_only: true, predicate: stream.id1 = version.id2, nested_loop: false, broadcast: true, output: [stream.id1, stream.a1, version.id2, version.a2, stream._row_id] }
+        ├─StreamTableScan { table: stream, columns: [stream.id1, stream.a1, stream._row_id], stream_scan_type: ArrangementBackfill, stream_key: [stream._row_id], pk: [_row_id], dist: UpstreamHashShard(stream._row_id) }
+        └─StreamExchange { dist: Broadcast }
+          └─StreamTableScan { table: version, columns: [version.id2, version.a2], stream_scan_type: UpstreamOnly, stream_key: [version.id2], pk: [id2], dist: UpstreamHashShard(version.id2) }
+  stream_dist_plan: |+
+    Fragment 0
+    StreamMaterialize { columns: [id1, a1, id2, a2, stream._row_id(hidden)], stream_key: [stream._row_id, id1], pk_columns: [stream._row_id, id1], pk_conflict: NoCheck }
+    └── StreamExchange Hash([0, 4]) from 1
+
+    Fragment 1
+    StreamTemporalJoin { type: LeftOuter, append_only: true, predicate: stream.id1 = version.id2, nested_loop: false, broadcast: true, output: [stream.id1, stream.a1, version.id2, version.a2, stream._row_id] }
+    ├── StreamTableScan { table: stream, columns: [stream.id1, stream.a1, stream._row_id], stream_scan_type: ArrangementBackfill, stream_key: [stream._row_id], pk: [_row_id], dist: UpstreamHashShard(stream._row_id) }
+    │   ├── tables: [ StreamScan: 0 ]
+    │   ├── Upstream
+    │   └── BatchPlanNode
+    └── StreamExchange Broadcast from 2
+
+    Fragment 2
+    StreamTableScan { table: version, columns: [version.id2, version.a2], stream_scan_type: UpstreamOnly, stream_key: [version.id2], pk: [id2], dist: UpstreamHashShard(version.id2) } { tables: [ StreamScan: 1 ] }
+    ├── Upstream
+    └── BatchPlanNode
+
+    Table 0 { columns: [ vnode, _row_id, backfill_finished, row_count, _rw_timestamp ], primary key: [ $0 ASC ], value indices: [ 1, 2, 3 ], distribution key: [ 0 ], read pk prefix len hint: 1, vnode column idx: 0 }
+
+    Table 1 { columns: [ vnode, id2, backfill_finished, row_count, _rw_timestamp ], primary key: [ $0 ASC ], value indices: [ 1, 2, 3 ], distribution key: [ 0 ], read pk prefix len hint: 1, vnode column idx: 0 }
+
+    Table 4294967294 { columns: [ id1, a1, id2, a2, stream._row_id, _rw_timestamp ], primary key: [ $4 ASC, $0 ASC ], value indices: [ 0, 1, 2, 3, 4 ], distribution key: [ 0, 4 ], read pk prefix len hint: 2 }
+
+- name: Broadcast temporal join requires an append-only left input
+  sql: |
+    create table stream(id1 int primary key, a1 int, b1 int);
+    create table version(id2 int, a2 int, b2 int, primary key (id2));
+    select id1, a1, id2, a2 from stream broadcast join version FOR SYSTEM_TIME AS OF PROCTIME() on id1 = id2;
+  stream_error: |-
+    Not supported: Broadcast temporal join requires the left input to be append-only
+    HINT: Please use a regular temporal join for a non-append-only input
 - name: Inner join type for temporal join
   sql: |
     create table stream(id1 int, a1 int, b1 int) APPEND ONLY;

--- a/src/frontend/src/binder/relation/table_or_source.rs
+++ b/src/frontend/src/binder/relation/table_or_source.rs
@@ -326,7 +326,7 @@ impl Binder {
         }
         if matches!(
             as_of,
-            Some(AsOf::ProcessTime | AsOf::ProcessTimeWithInterval(_))
+            Some(AsOf::ProcessTime | AsOf::ProcessTimeBroadcast | AsOf::ProcessTimeWithInterval(_))
         ) {
             bail_not_implemented!(
                 "As Of ProcessTime() is not supported for Iceberg metadata relations."

--- a/src/frontend/src/optimizer/plan_node/logical_join.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_join.rs
@@ -1318,14 +1318,7 @@ impl LogicalJoin {
 
         let left = self.left().to_stream(ctx)?;
         let left = if is_broadcast {
-            let left = left.enforce_concrete_distribution();
-            if !left.append_only() {
-                return Err(RwError::from(ErrorCode::NotSupported(
-                    "Broadcast temporal join requires the left input to be append-only".into(),
-                    "Please use a regular temporal join for a non-append-only input".into(),
-                )));
-            }
-            left
+            left.enforce_concrete_distribution()
         } else {
             // Enforce a shuffle for the temporal join LHS to let the scheduler be able to schedule
             // the join fragment together with the RHS with a `no_shuffle` exchange.

--- a/src/frontend/src/optimizer/plan_node/logical_join.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_join.rs
@@ -1100,8 +1100,11 @@ impl LogicalJoin {
 
     fn temporal_join_on(&self) -> Option<TemporalJoinScan<'_>> {
         if let Some(logical_scan) = self.core.right.as_logical_scan() {
-            matches!(logical_scan.as_of(), Some(AsOf::ProcessTime))
-                .then_some(TemporalJoinScan(logical_scan))
+            matches!(
+                logical_scan.as_of(),
+                Some(AsOf::ProcessTime | AsOf::ProcessTimeBroadcast)
+            )
+            .then_some(TemporalJoinScan(logical_scan))
         } else {
             None
         }
@@ -1262,6 +1265,8 @@ impl LogicalJoin {
 
         assert!(predicate.has_eq());
 
+        let is_broadcast = matches!(logical_scan.as_of(), Some(AsOf::ProcessTimeBroadcast));
+
         let table = logical_scan.table();
         let output_column_ids = logical_scan.output_column_ids();
 
@@ -1312,8 +1317,20 @@ impl LogicalJoin {
         };
 
         let left = self.left().to_stream(ctx)?;
-        // Enforce a shuffle for the temporal join LHS to let the scheduler be able to schedule the join fragment together with the RHS with a `no_shuffle` exchange.
-        let left = required_dist.stream_enforce(left);
+        let left = if is_broadcast {
+            let left = left.enforce_concrete_distribution();
+            if !left.append_only() {
+                return Err(RwError::from(ErrorCode::NotSupported(
+                    "Broadcast temporal join requires the left input to be append-only".into(),
+                    "Please use a regular temporal join for a non-append-only input".into(),
+                )));
+            }
+            left
+        } else {
+            // Enforce a shuffle for the temporal join LHS to let the scheduler be able to schedule
+            // the join fragment together with the RHS with a `no_shuffle` exchange.
+            required_dist.stream_enforce(left)
+        };
 
         let (new_stream_table_scan, new_predicate, new_join_on, new_join_output_indices) =
             Self::temporal_join_scan_predicate_pull_up(
@@ -1323,7 +1340,12 @@ impl LogicalJoin {
                 self.left().schema().len(),
             )?;
 
-        let right = RequiredDist::no_shuffle(new_stream_table_scan.into());
+        let right = if is_broadcast {
+            RequiredDist::PhysicalDist(Distribution::Broadcast)
+                .streaming_enforce_if_not_satisfies(new_stream_table_scan.into())?
+        } else {
+            RequiredDist::no_shuffle(new_stream_table_scan.into())
+        };
         if !new_predicate.has_eq() {
             return Err(RwError::from(ErrorCode::NotSupported(
                 "Temporal join requires a non trivial join condition".into(),
@@ -1355,6 +1377,13 @@ impl LogicalJoin {
     ) -> Result<StreamPlanRef> {
         use super::stream::prelude::*;
         assert!(!predicate.has_eq());
+
+        if matches!(logical_scan.as_of(), Some(AsOf::ProcessTimeBroadcast)) {
+            return Err(RwError::from(ErrorCode::NotSupported(
+                "Broadcast temporal join requires an equality condition".into(),
+                "Please add an equality condition over a lookup-table key".into(),
+            )));
+        }
 
         let left = self.left().to_stream_with_dist_required(
             &RequiredDist::PhysicalDist(Distribution::Broadcast),

--- a/src/frontend/src/optimizer/plan_node/logical_vector_search_lookup_join.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_vector_search_lookup_join.rs
@@ -300,6 +300,8 @@ impl ToStream for LogicalVectorSearchLookupJoin {
 
     fn to_stream(&self, ctx: &mut ToStreamContext) -> Result<StreamPlanRef> {
         if let Some(core) = self.to_vector_index_lookup_join(|plan| plan.to_stream(ctx))? {
+            // `ProcessTimeBroadcast` is intentionally excluded: the vector-index lookup executor
+            // does not consume a broadcast change stream or maintain replicated lookup state.
             if !matches!(&core.as_of, Some(AsOf::ProcessTime)) {
                 bail!("streaming vector index lookup join must be proctime temporal join");
             }

--- a/src/frontend/src/optimizer/plan_node/stream_temporal_join.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_temporal_join.rs
@@ -32,6 +32,7 @@ use crate::optimizer::plan_node::utils::{IndicesDisplay, TableCatalogBuilder};
 use crate::optimizer::plan_node::{
     EqJoinPredicate, EqJoinPredicateDisplay, StreamExchange, StreamTableScan, TryToStreamPb,
 };
+use crate::optimizer::property::Distribution;
 use crate::scheduler::SchedulerResult;
 use crate::stream_fragmenter::BuildFragmentGraphState;
 use crate::utils::ColIndexMappingRewriteExt;
@@ -42,6 +43,7 @@ pub struct StreamTemporalJoin {
     core: generic::Join<PlanRef>,
     append_only: bool,
     is_nested_loop: bool,
+    is_broadcast: bool,
 }
 
 impl StreamTemporalJoin {
@@ -58,13 +60,24 @@ impl StreamTemporalJoin {
         let right = core.right.clone();
         let exchange: &StreamExchange = right
             .as_stream_exchange()
-            .expect("should be a no shuffle stream exchange");
-        assert!(exchange.no_shuffle());
+            .expect("temporal join lookup side should have an exchange");
         let exchange_input = exchange.input();
         let scan: &StreamTableScan = exchange_input
             .as_stream_table_scan()
             .expect("should be a stream table scan");
-        assert!(matches!(scan.core().as_of, Some(AsOf::ProcessTime)));
+        let is_broadcast = matches!(scan.core().as_of, Some(AsOf::ProcessTimeBroadcast));
+        assert!(matches!(
+            scan.core().as_of,
+            Some(AsOf::ProcessTime | AsOf::ProcessTimeBroadcast)
+        ));
+        if is_broadcast {
+            assert!(!exchange.no_shuffle());
+            assert_eq!(exchange.distribution(), &Distribution::Broadcast);
+            assert!(append_only);
+            assert!(!is_nested_loop);
+        } else {
+            assert!(exchange.no_shuffle());
+        }
 
         let dist = if is_nested_loop {
             // Use right side distribution directly if it's nested loop temporal join.
@@ -104,6 +117,7 @@ impl StreamTemporalJoin {
             core,
             append_only,
             is_nested_loop,
+            is_broadcast,
         })
     }
 
@@ -125,6 +139,10 @@ impl StreamTemporalJoin {
 
     pub fn is_nested_loop(&self) -> bool {
         self.is_nested_loop
+    }
+
+    pub fn is_broadcast(&self) -> bool {
+        self.is_broadcast
     }
 
     /// Return memo-table catalog and its `pk_indices`.
@@ -193,6 +211,9 @@ impl Distill for StreamTemporalJoin {
         ));
 
         vec.push(("nested_loop", Pretty::debug(&self.is_nested_loop)));
+        if self.is_broadcast {
+            vec.push(("broadcast", Pretty::debug(&self.is_broadcast)));
+        }
 
         if let Some(ow) = watermark_pretty(self.base.watermark_columns(), self.schema()) {
             vec.push(("output_watermarks", ow));
@@ -241,8 +262,13 @@ impl TryToStreamPb for StreamTemporalJoin {
         let right = self.right();
         let exchange: &StreamExchange = right
             .as_stream_exchange()
-            .expect("should be a no shuffle stream exchange");
-        assert!(exchange.no_shuffle());
+            .expect("temporal join lookup side should have an exchange");
+        if self.is_broadcast {
+            assert!(!exchange.no_shuffle());
+            assert_eq!(exchange.distribution(), &Distribution::Broadcast);
+        } else {
+            assert!(exchange.no_shuffle());
+        }
         let exchange_input = exchange.input();
         let scan: &StreamTableScan = exchange_input
             .as_stream_table_scan()
@@ -276,6 +302,7 @@ impl TryToStreamPb for StreamTemporalJoin {
                 Some(memo_table.to_internal_table_prost())
             },
             is_nested_loop: self.is_nested_loop,
+            is_broadcast: self.is_broadcast,
         })))
     }
 }

--- a/src/frontend/src/optimizer/plan_node/stream_temporal_join.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_temporal_join.rs
@@ -146,10 +146,9 @@ impl StreamTemporalJoin {
 
     /// Return the memo-table catalog.
     ///
-    /// A regular temporal join is distributed by the lookup key, so its memo prefix remains
-    /// `join_key + left_stream_key` for compatibility. A broadcast temporal join preserves the
-    /// left input distribution, so its memo prefix is the left stream key itself. The latter
-    /// uniquely identifies the left row and already contains the left distribution key.
+    /// The memo prefix is `join_key + left_stream_key`. A regular temporal join is distributed by
+    /// the lookup key, while a broadcast temporal join preserves the left input distribution and
+    /// maps that distribution key to its copy in the `left_stream_key` part of the prefix.
     ///
     /// Write pattern:
     ///   for each left input row (with insert op), persist the matched right row followed by the
@@ -161,15 +160,11 @@ impl StreamTemporalJoin {
     pub fn infer_memo_table_catalog(&self, right_scan: &StreamTableScan) -> TableCatalog {
         let left_eq_indexes = self.eq_join_predicate().left_eq_indexes();
         let left_stream_key = self.core.left.expect_stream_key();
-        let memo_prefix_indices = if self.is_broadcast {
-            left_stream_key.to_vec()
-        } else {
-            left_eq_indexes
-                .iter()
-                .chain(left_stream_key)
-                .copied()
-                .collect_vec()
-        };
+        let memo_prefix_indices = left_eq_indexes
+            .iter()
+            .chain(left_stream_key)
+            .copied()
+            .collect_vec();
         let read_prefix_len_hint = memo_prefix_indices.len();
 
         // Build internal table
@@ -206,11 +201,11 @@ impl StreamTemporalJoin {
             left_dist_key
                 .iter()
                 .map(|dist_idx| {
-                    let position = memo_prefix_indices
+                    let position = left_stream_key
                         .iter()
                         .position(|idx| idx == dist_idx)
                         .expect("left distribution key must be part of the left stream key");
-                    right_scan_schema.len() + position
+                    right_scan_schema.len() + left_eq_indexes.len() + position
                 })
                 .collect()
         } else {

--- a/src/frontend/src/optimizer/plan_node/stream_temporal_join.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_temporal_join.rs
@@ -73,7 +73,6 @@ impl StreamTemporalJoin {
         if is_broadcast {
             assert!(!exchange.no_shuffle());
             assert_eq!(exchange.distribution(), &Distribution::Broadcast);
-            assert!(append_only);
             assert!(!is_nested_loop);
         } else {
             assert!(exchange.no_shuffle());
@@ -145,17 +144,33 @@ impl StreamTemporalJoin {
         self.is_broadcast
     }
 
-    /// Return memo-table catalog and its `pk_indices`.
-    /// (`join_key` + `left_pk` + `right_pk`) -> (`right_scan_schema` + `join_key` + `left_pk`)
+    /// Return the memo-table catalog.
+    ///
+    /// A regular temporal join is distributed by the lookup key, so its memo prefix remains
+    /// `join_key + left_stream_key` for compatibility. A broadcast temporal join preserves the
+    /// left input distribution, so its memo prefix is the left stream key itself. The latter
+    /// uniquely identifies the left row and already contains the left distribution key.
     ///
     /// Write pattern:
-    ///   for each left input row (with insert op), construct the memo table pk and insert the row into the memo table.
+    ///   for each left input row (with insert op), persist the matched right row followed by the
+    ///   memo prefix.
     ///
     /// Read pattern:
-    ///   for each left input row (with delete op), construct pk prefix (`join_key` + `left_pk`) to fetch rows and delete them from the memo table.
+    ///   for each left input row (with delete op), use the memo prefix to fetch and delete all
+    ///   right rows that matched when the left row was inserted.
     pub fn infer_memo_table_catalog(&self, right_scan: &StreamTableScan) -> TableCatalog {
         let left_eq_indexes = self.eq_join_predicate().left_eq_indexes();
-        let read_prefix_len_hint = left_eq_indexes.len() + self.left().stream_key().unwrap().len();
+        let left_stream_key = self.core.left.expect_stream_key();
+        let memo_prefix_indices = if self.is_broadcast {
+            left_stream_key.to_vec()
+        } else {
+            left_eq_indexes
+                .iter()
+                .chain(left_stream_key)
+                .copied()
+                .collect_vec()
+        };
+        let read_prefix_len_hint = memo_prefix_indices.len();
 
         // Build internal table
         let mut internal_table_catalog_builder = TableCatalogBuilder::default();
@@ -164,10 +179,9 @@ impl StreamTemporalJoin {
         for field in right_scan_schema.fields() {
             internal_table_catalog_builder.add_column(field);
         }
-        // Add join_key + left_pk
-        for field in left_eq_indexes
+        // Add the columns that identify and route a left row.
+        for field in memo_prefix_indices
             .iter()
-            .chain(self.core.left.stream_key().unwrap())
             .map(|idx| &self.core.left.schema().fields()[*idx])
         {
             internal_table_catalog_builder.add_column(field);
@@ -182,14 +196,31 @@ impl StreamTemporalJoin {
             internal_table_catalog_builder.add_order_column(*idx, OrderType::ascending())
         });
 
-        let dist_key_len = right_scan
-            .core()
-            .distribution_key()
-            .map(|keys| keys.len())
-            .unwrap_or(0);
-
-        let internal_table_dist_keys =
-            (right_scan_schema.len()..(right_scan_schema.len() + dist_key_len)).collect();
+        let internal_table_dist_keys = if self.is_broadcast {
+            let left_dist_key = self
+                .core
+                .left
+                .distribution()
+                .dist_column_indices_opt()
+                .expect("broadcast temporal join left input must have a concrete distribution");
+            left_dist_key
+                .iter()
+                .map(|dist_idx| {
+                    let position = memo_prefix_indices
+                        .iter()
+                        .position(|idx| idx == dist_idx)
+                        .expect("left distribution key must be part of the left stream key");
+                    right_scan_schema.len() + position
+                })
+                .collect()
+        } else {
+            let dist_key_len = right_scan
+                .core()
+                .distribution_key()
+                .map(|keys| keys.len())
+                .unwrap_or(0);
+            (right_scan_schema.len()..(right_scan_schema.len() + dist_key_len)).collect()
+        };
         internal_table_catalog_builder.build(internal_table_dist_keys, read_prefix_len_hint)
     }
 }

--- a/src/frontend/src/optimizer/plan_node/utils.rs
+++ b/src/frontend/src/optimizer/plan_node/utils.rs
@@ -511,7 +511,7 @@ pub fn to_batch_query_epoch(a: &Option<AsOf>) -> Result<Option<PbBatchQueryEpoch
     };
     Feature::TimeTravel.check_available()?;
     let timestamp = match a {
-        AsOf::ProcessTime => {
+        AsOf::ProcessTime | AsOf::ProcessTimeBroadcast => {
             return Err(ErrorCode::NotSupported(
                 "AS OF PROCTIME is not supported".to_owned(),
                 "please use AS OF TIMESTAMP".to_owned(),
@@ -613,7 +613,9 @@ pub fn to_iceberg_time_travel_as_of(
                 timestamp * 1000 + date_time.time.microsecond as i64 / 1000,
             ))
         }
-        Some(AsOf::ProcessTime) | Some(AsOf::ProcessTimeWithInterval(_)) => {
+        Some(AsOf::ProcessTime)
+        | Some(AsOf::ProcessTimeBroadcast)
+        | Some(AsOf::ProcessTimeWithInterval(_)) => {
             unreachable!()
         }
         None => None,

--- a/src/frontend/src/optimizer/plan_visitor/temporal_join_validator.rs
+++ b/src/frontend/src/optimizer/plan_visitor/temporal_join_validator.rs
@@ -55,7 +55,10 @@ impl LogicalPlanVisitor for TemporalJoinValidator {
     }
 
     fn visit_logical_scan(&mut self, logical_scan: &LogicalScan) -> bool {
-        matches!(logical_scan.as_of(), Some(AsOf::ProcessTime))
+        matches!(
+            logical_scan.as_of(),
+            Some(AsOf::ProcessTime | AsOf::ProcessTimeBroadcast)
+        )
     }
 }
 
@@ -69,7 +72,10 @@ impl BatchPlanVisitor for TemporalJoinValidator {
     }
 
     fn visit_batch_seq_scan(&mut self, batch_seq_scan: &BatchSeqScan) -> bool {
-        matches!(batch_seq_scan.core().as_of, Some(AsOf::ProcessTime))
+        matches!(
+            batch_seq_scan.core().as_of,
+            Some(AsOf::ProcessTime | AsOf::ProcessTimeBroadcast)
+        )
     }
 }
 
@@ -83,7 +89,10 @@ impl StreamPlanVisitor for TemporalJoinValidator {
     }
 
     fn visit_stream_table_scan(&mut self, stream_table_scan: &StreamTableScan) -> bool {
-        matches!(stream_table_scan.core().as_of, Some(AsOf::ProcessTime))
+        matches!(
+            stream_table_scan.core().as_of,
+            Some(AsOf::ProcessTime | AsOf::ProcessTimeBroadcast)
+        )
     }
 
     fn visit_stream_temporal_join(&mut self, stream_temporal_join: &StreamTemporalJoin) -> bool {

--- a/src/frontend/src/planner/relation.rs
+++ b/src/frontend/src/planner/relation.rs
@@ -112,6 +112,7 @@ impl Planner {
                 match as_of {
                     None
                     | Some(AsOf::ProcessTime)
+                    | Some(AsOf::ProcessTimeBroadcast)
                     | Some(AsOf::TimestampNum(_))
                     | Some(AsOf::TimestampString(_))
                     | Some(AsOf::ProcessTimeWithInterval(_)) => {}
@@ -171,7 +172,9 @@ impl Planner {
             | Some(AsOf::VersionNum(_))
             | Some(AsOf::TimestampString(_))
             | Some(AsOf::TimestampNum(_)) => {}
-            Some(AsOf::ProcessTime) | Some(AsOf::ProcessTimeWithInterval(_)) => {
+            Some(AsOf::ProcessTime)
+            | Some(AsOf::ProcessTimeBroadcast)
+            | Some(AsOf::ProcessTimeWithInterval(_)) => {
                 bail_not_implemented!("As Of ProcessTime() is not supported yet.")
             }
             Some(AsOf::VersionString(_)) => {
@@ -353,7 +356,9 @@ impl Planner {
                 | Some(AsOf::VersionNum(_))
                 | Some(AsOf::TimestampString(_))
                 | Some(AsOf::TimestampNum(_)) => {}
-                Some(AsOf::ProcessTime) | Some(AsOf::ProcessTimeWithInterval(_)) => {
+                Some(AsOf::ProcessTime)
+                | Some(AsOf::ProcessTimeBroadcast)
+                | Some(AsOf::ProcessTimeWithInterval(_)) => {
                     bail_not_implemented!("As Of ProcessTime() is not supported yet.")
                 }
                 Some(AsOf::VersionString(_)) => {

--- a/src/meta/src/stream/stream_graph/schedule.rs
+++ b/src/meta/src/stream/stream_graph/schedule.rs
@@ -207,7 +207,15 @@ impl Scheduler {
                             return;
                         }
                     }
-                    NodeBody::TemporalJoin(node) => node.get_table_desc().unwrap().vnode_count(),
+                    NodeBody::TemporalJoin(node) => {
+                        if node.is_broadcast {
+                            // Every actor owns a full replicated view of the lookup table, so the
+                            // join fragment follows the left input rather than the lookup table's
+                            // vnode count.
+                            return;
+                        }
+                        node.get_table_desc().unwrap().vnode_count()
+                    }
                     NodeBody::BatchPlan(node) => node.get_table_desc().unwrap().vnode_count(),
                     NodeBody::Lookup(node) => node
                         .get_arrangement_table_info()

--- a/src/sqlparser/src/ast/mod.rs
+++ b/src/sqlparser/src/ast/mod.rs
@@ -3910,7 +3910,9 @@ impl fmt::Display for SetVariableValueSingle {
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum AsOf {
     ProcessTime,
-    /// Process-time temporal join with the lookup side broadcast to all join actors.
+    /// Internal marker for a process-time temporal join whose lookup side is broadcast to all join
+    /// actors. It stays on the lookup relation so optimizer rewrites cannot detach the strategy
+    /// from that relation; [`crate::ast::Join`]'s `Display` renders the modifier in join position.
     ProcessTimeBroadcast,
     // used by time travel
     ProcessTimeWithInterval((String, DateTimeField)),

--- a/src/sqlparser/src/ast/mod.rs
+++ b/src/sqlparser/src/ast/mod.rs
@@ -3910,6 +3910,8 @@ impl fmt::Display for SetVariableValueSingle {
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum AsOf {
     ProcessTime,
+    /// Process-time temporal join with the lookup side broadcast to all join actors.
+    ProcessTimeBroadcast,
     // used by time travel
     ProcessTimeWithInterval((String, DateTimeField)),
     // the number of seconds that have elapsed since the Unix epoch, which is January 1, 1970 at 00:00:00 Coordinated Universal Time (UTC).
@@ -3923,7 +3925,9 @@ impl fmt::Display for AsOf {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         use AsOf::*;
         match self {
-            ProcessTime => write!(f, " FOR SYSTEM_TIME AS OF PROCTIME()"),
+            ProcessTime | ProcessTimeBroadcast => {
+                write!(f, " FOR SYSTEM_TIME AS OF PROCTIME()")
+            }
             ProcessTimeWithInterval((value, leading_field)) => write!(
                 f,
                 " FOR SYSTEM_TIME AS OF NOW() - '{}' {}",

--- a/src/sqlparser/src/ast/query.rs
+++ b/src/sqlparser/src/ast/query.rs
@@ -576,18 +576,31 @@ impl fmt::Display for Join {
             }
             Suffix(constraint)
         }
+        let broadcast = if matches!(
+            self.relation,
+            TableFactor::Table {
+                as_of: Some(AsOf::ProcessTimeBroadcast),
+                ..
+            }
+        ) {
+            "BROADCAST "
+        } else {
+            ""
+        };
         match &self.join_operator {
             JoinOperator::Inner(constraint) => write!(
                 f,
-                " {}JOIN {}{}",
+                " {}{}JOIN {}{}",
                 prefix(constraint),
+                broadcast,
                 self.relation,
                 suffix(constraint)
             ),
             JoinOperator::LeftOuter(constraint) => write!(
                 f,
-                " {}LEFT JOIN {}{}",
+                " {}{}LEFT JOIN {}{}",
                 prefix(constraint),
+                broadcast,
                 self.relation,
                 suffix(constraint)
             ),

--- a/src/sqlparser/src/keywords.rs
+++ b/src/sqlparser/src/keywords.rs
@@ -106,7 +106,6 @@ define_keywords!(
     BOOL,
     BOOLEAN,
     BOTH,
-    BROADCAST,
     BY,
     BYTEA,
     CACHE,
@@ -622,7 +621,6 @@ pub const RESERVED_FOR_TABLE_ALIAS: &[Keyword] = &[
     Keyword::RIGHT,
     Keyword::NATURAL,
     Keyword::ASOF,
-    Keyword::BROADCAST,
     Keyword::USING,
     Keyword::CLUSTER,
     // for MSSQL-specific OUTER APPLY (seems reserved in most dialects)

--- a/src/sqlparser/src/keywords.rs
+++ b/src/sqlparser/src/keywords.rs
@@ -106,6 +106,7 @@ define_keywords!(
     BOOL,
     BOOLEAN,
     BOTH,
+    BROADCAST,
     BY,
     BYTEA,
     CACHE,
@@ -621,6 +622,7 @@ pub const RESERVED_FOR_TABLE_ALIAS: &[Keyword] = &[
     Keyword::RIGHT,
     Keyword::NATURAL,
     Keyword::ASOF,
+    Keyword::BROADCAST,
     Keyword::USING,
     Keyword::CLUSTER,
     // for MSSQL-specific OUTER APPLY (seems reserved in most dialects)

--- a/src/sqlparser/src/parser.rs
+++ b/src/sqlparser/src/parser.rs
@@ -4409,6 +4409,9 @@ impl Parser<'_> {
         &mut self,
         reserved_kwds: &[Keyword],
     ) -> ModalResult<Option<TableAlias>> {
+        if self.peek_broadcast_join() {
+            return Ok(None);
+        }
         match self.parse_optional_alias(reserved_kwds)? {
             Some(name) => {
                 let columns = self.parse_parenthesized_column_list(Optional)?;
@@ -5449,17 +5452,17 @@ impl Parser<'_> {
                     join_operator,
                 }
             } else {
-                let (natural, asof, broadcast) = match self.parse_one_of_keywords(&[
-                    Keyword::NATURAL,
-                    Keyword::ASOF,
-                    Keyword::BROADCAST,
-                ]) {
-                    Some(Keyword::NATURAL) => (true, false, false),
-                    Some(Keyword::ASOF) => (false, true, false),
-                    Some(Keyword::BROADCAST) => (false, false, true),
-                    Some(_) => unreachable!(),
-                    None => (false, false, false),
-                };
+                let broadcast = self.peek_broadcast_join();
+                if broadcast {
+                    let _ = self.next_token();
+                }
+                let (natural, asof) =
+                    match self.parse_one_of_keywords(&[Keyword::NATURAL, Keyword::ASOF]) {
+                        Some(Keyword::NATURAL) => (true, false),
+                        Some(Keyword::ASOF) => (false, true),
+                        Some(_) => unreachable!(),
+                        None => (false, false),
+                    };
                 let peek_keyword = if let Token::Word(w) = self.peek_token().token {
                     w.keyword
                 } else {
@@ -5508,6 +5511,9 @@ impl Parser<'_> {
                     _ if asof => {
                         return self.expected("a join type after ASOF");
                     }
+                    _ if broadcast => {
+                        return self.expected_at(join_checkpoint, "a join type after BROADCAST");
+                    }
                     _ => break,
                 };
                 let mut relation = self.parse_table_factor()?;
@@ -5555,6 +5561,22 @@ impl Parser<'_> {
             joins.push(join);
         }
         Ok(TableWithJoins { relation, joins })
+    }
+
+    /// Whether the next tokens start a supported broadcast join.
+    ///
+    /// `BROADCAST` remains a regular identifier outside this exact position so that existing
+    /// table aliases and identifier formatting remain compatible.
+    fn peek_broadcast_join(&self) -> bool {
+        matches!(
+            self.peek_nth_token(0).token,
+            Token::Word(word)
+                if word.quote_style.is_none() && word.value.eq_ignore_ascii_case("BROADCAST")
+        ) && matches!(
+            self.peek_nth_token(1).token,
+            Token::Word(word)
+                if matches!(word.keyword, Keyword::INNER | Keyword::JOIN | Keyword::LEFT)
+        )
     }
 
     /// A table name or a parenthesized subquery, followed by optional `[AS] alias`

--- a/src/sqlparser/src/parser.rs
+++ b/src/sqlparser/src/parser.rs
@@ -5437,6 +5437,7 @@ impl Parser<'_> {
         // a table alias.
         let mut joins = vec![];
         loop {
+            let join_checkpoint = *self;
             let join = if self.parse_keyword(Keyword::CROSS) {
                 let join_operator = if self.parse_keyword(Keyword::JOIN) {
                     JoinOperator::CrossJoin
@@ -5448,13 +5449,17 @@ impl Parser<'_> {
                     join_operator,
                 }
             } else {
-                let (natural, asof) =
-                    match self.parse_one_of_keywords(&[Keyword::NATURAL, Keyword::ASOF]) {
-                        Some(Keyword::NATURAL) => (true, false),
-                        Some(Keyword::ASOF) => (false, true),
-                        Some(_) => unreachable!(),
-                        None => (false, false),
-                    };
+                let (natural, asof, broadcast) = match self.parse_one_of_keywords(&[
+                    Keyword::NATURAL,
+                    Keyword::ASOF,
+                    Keyword::BROADCAST,
+                ]) {
+                    Some(Keyword::NATURAL) => (true, false, false),
+                    Some(Keyword::ASOF) => (false, true, false),
+                    Some(Keyword::BROADCAST) => (false, false, true),
+                    Some(_) => unreachable!(),
+                    None => (false, false, false),
+                };
                 let peek_keyword = if let Token::Word(w) = self.peek_token().token {
                     w.keyword
                 } else {
@@ -5505,9 +5510,33 @@ impl Parser<'_> {
                     }
                     _ => break,
                 };
-                let relation = self.parse_table_factor()?;
+                let mut relation = self.parse_table_factor()?;
                 let join_constraint = self.parse_join_constraint(natural)?;
                 let join_operator = join_operator_type(join_constraint);
+                if broadcast {
+                    if !matches!(
+                        join_operator,
+                        JoinOperator::Inner(_) | JoinOperator::LeftOuter(_)
+                    ) {
+                        return self.expected_at(
+                            join_checkpoint,
+                            "INNER or LEFT temporal join after BROADCAST",
+                        );
+                    }
+                    match &mut relation {
+                        TableFactor::Table {
+                            as_of: Some(as_of), ..
+                        } if matches!(as_of, AsOf::ProcessTime) => {
+                            *as_of = AsOf::ProcessTimeBroadcast;
+                        }
+                        _ => {
+                            return self.expected_at(
+                                join_checkpoint,
+                                "a table with FOR SYSTEM_TIME AS OF PROCTIME() after BROADCAST JOIN",
+                            );
+                        }
+                    }
+                }
                 let need_constraint = match join_operator {
                     JoinOperator::Inner(JoinConstraint::None) => Some("INNER JOIN"),
                     JoinOperator::AsOfInner(JoinConstraint::None) => Some("ASOF INNER JOIN"),

--- a/src/sqlparser/tests/sqlparser_common.rs
+++ b/src/sqlparser/tests/sqlparser_common.rs
@@ -2757,6 +2757,35 @@ fn parse_broadcast_temporal_join() {
         err.to_string()
             .contains("FOR SYSTEM_TIME AS OF PROCTIME() after BROADCAST JOIN")
     );
+
+    // BROADCAST is contextual rather than globally reserved, so existing aliases retain their
+    // original meaning whenever they are not immediately followed by a supported join type.
+    for (sql, canonical) in [
+        (
+            "SELECT broadcast.a FROM t broadcast WHERE broadcast.a = 1",
+            "SELECT broadcast.a FROM t AS broadcast WHERE broadcast.a = 1",
+        ),
+        (
+            "SELECT * FROM t broadcast, u",
+            "SELECT * FROM t AS broadcast, u",
+        ),
+        (
+            "SELECT * FROM t broadcast CROSS JOIN u",
+            "SELECT * FROM t AS broadcast CROSS JOIN u",
+        ),
+        (
+            "SELECT * FROM t broadcast RIGHT JOIN u ON true",
+            "SELECT * FROM t AS broadcast RIGHT JOIN u ON true",
+        ),
+        (
+            "SELECT * FROM t \"broadcast\" LEFT JOIN u ON true",
+            "SELECT * FROM t AS \"broadcast\" LEFT JOIN u ON true",
+        ),
+    ] {
+        query(sql, canonical);
+    }
+
+    assert_eq!(Ident::from_real_value("broadcast").to_string(), "broadcast");
 }
 
 #[test]

--- a/src/sqlparser/tests/sqlparser_common.rs
+++ b/src/sqlparser/tests/sqlparser_common.rs
@@ -2728,6 +2728,38 @@ fn parse_temporal_join() {
 }
 
 #[test]
+fn parse_broadcast_temporal_join() {
+    let sql = "SELECT * FROM t1 BROADCAST LEFT JOIN t2 FOR SYSTEM_TIME AS OF PROCTIME() ON c1 = c2";
+    let select = verified_only_select(sql);
+    assert_eq!(
+        Join {
+            relation: TableFactor::Table {
+                name: ObjectName(vec![Ident::new_unchecked("t2")]),
+                alias: None,
+                as_of: Some(AsOf::ProcessTimeBroadcast),
+            },
+            join_operator: JoinOperator::LeftOuter(JoinConstraint::On(Expr::BinaryOp {
+                left: Box::new(Expr::Identifier("c1".into())),
+                op: BinaryOperator::Eq,
+                right: Box::new(Expr::Identifier("c2".into())),
+            })),
+        },
+        only(only(select.from).joins),
+    );
+
+    assert_eq!(
+        verified_only_select(sql).to_string(),
+        "SELECT * FROM t1 BROADCAST LEFT JOIN t2 FOR SYSTEM_TIME AS OF PROCTIME() ON c1 = c2"
+    );
+
+    let err = parse_sql_statements("SELECT * FROM t1 BROADCAST JOIN t2 ON c1 = c2").unwrap_err();
+    assert!(
+        err.to_string()
+            .contains("FOR SYSTEM_TIME AS OF PROCTIME() after BROADCAST JOIN")
+    );
+}
+
+#[test]
 fn parse_joins_on() {
     fn join_with_constraint(
         relation: impl Into<String>,

--- a/src/sqlparser/tests/sqlparser_common.rs
+++ b/src/sqlparser/tests/sqlparser_common.rs
@@ -2728,67 +2728,6 @@ fn parse_temporal_join() {
 }
 
 #[test]
-fn parse_broadcast_temporal_join() {
-    let sql = "SELECT * FROM t1 BROADCAST LEFT JOIN t2 FOR SYSTEM_TIME AS OF PROCTIME() ON c1 = c2";
-    let select = verified_only_select(sql);
-    assert_eq!(
-        Join {
-            relation: TableFactor::Table {
-                name: ObjectName(vec![Ident::new_unchecked("t2")]),
-                alias: None,
-                as_of: Some(AsOf::ProcessTimeBroadcast),
-            },
-            join_operator: JoinOperator::LeftOuter(JoinConstraint::On(Expr::BinaryOp {
-                left: Box::new(Expr::Identifier("c1".into())),
-                op: BinaryOperator::Eq,
-                right: Box::new(Expr::Identifier("c2".into())),
-            })),
-        },
-        only(only(select.from).joins),
-    );
-
-    assert_eq!(
-        verified_only_select(sql).to_string(),
-        "SELECT * FROM t1 BROADCAST LEFT JOIN t2 FOR SYSTEM_TIME AS OF PROCTIME() ON c1 = c2"
-    );
-
-    let err = parse_sql_statements("SELECT * FROM t1 BROADCAST JOIN t2 ON c1 = c2").unwrap_err();
-    assert!(
-        err.to_string()
-            .contains("FOR SYSTEM_TIME AS OF PROCTIME() after BROADCAST JOIN")
-    );
-
-    // BROADCAST is contextual rather than globally reserved, so existing aliases retain their
-    // original meaning whenever they are not immediately followed by a supported join type.
-    for (sql, canonical) in [
-        (
-            "SELECT broadcast.a FROM t broadcast WHERE broadcast.a = 1",
-            "SELECT broadcast.a FROM t AS broadcast WHERE broadcast.a = 1",
-        ),
-        (
-            "SELECT * FROM t broadcast, u",
-            "SELECT * FROM t AS broadcast, u",
-        ),
-        (
-            "SELECT * FROM t broadcast CROSS JOIN u",
-            "SELECT * FROM t AS broadcast CROSS JOIN u",
-        ),
-        (
-            "SELECT * FROM t broadcast RIGHT JOIN u ON true",
-            "SELECT * FROM t AS broadcast RIGHT JOIN u ON true",
-        ),
-        (
-            "SELECT * FROM t \"broadcast\" LEFT JOIN u ON true",
-            "SELECT * FROM t AS \"broadcast\" LEFT JOIN u ON true",
-        ),
-    ] {
-        query(sql, canonical);
-    }
-
-    assert_eq!(Ident::from_real_value("broadcast").to_string(), "broadcast");
-}
-
-#[test]
 fn parse_joins_on() {
     fn join_with_constraint(
         relation: impl Into<String>,

--- a/src/storage/src/hummock/shared_buffer/mod.rs
+++ b/src/storage/src/hummock/shared_buffer/mod.rs
@@ -19,7 +19,7 @@ use std::sync::Arc;
 
 use risingwave_common::metrics::{
     LabelGuardedHistogram, LabelGuardedIntCounter, LabelGuardedIntGauge,
-    LazyLabelGuardedIntCounter, LazyLabelGuardedIntGauge,
+    LazyLabelGuardedIntCounter, LazyLabelGuardedIntGauge, UintGauge,
 };
 use risingwave_pb::id::{FragmentId, TableId};
 
@@ -30,6 +30,7 @@ pub mod shared_buffer_batch;
 pub(crate) struct TableMemoryMetrics {
     imm_total_size: LabelGuardedIntGauge,
     imm_count: LabelGuardedIntGauge,
+    replicated_imm_size: Option<UintGauge>,
     pub write_batch_tuple_counts: LabelGuardedIntCounter,
     pub write_batch_duration: LabelGuardedHistogram,
     pub write_batch_size: LabelGuardedHistogram,
@@ -60,6 +61,7 @@ impl TableMemoryMetrics {
             imm_count: metrics
                 .per_table_imm_count
                 .with_guarded_label_values(table_labels),
+            replicated_imm_size: is_replicated.then(|| metrics.replicated_imm_size.clone()),
             write_batch_tuple_counts: metrics
                 .write_batch_tuple_counts
                 .with_guarded_label_values(table_labels),
@@ -91,16 +93,46 @@ impl TableMemoryMetrics {
     pub(super) fn inc_imm(&self, imm_size: usize) {
         self.imm_total_size.add(imm_size as _);
         self.imm_count.inc();
+        if let Some(replicated_imm_size) = &self.replicated_imm_size {
+            replicated_imm_size.add(imm_size as _);
+        }
     }
 
     pub(super) fn dec_imm(&self, imm_size: usize) {
         self.imm_total_size.sub(imm_size as _);
         self.imm_count.dec();
+        if let Some(replicated_imm_size) = &self.replicated_imm_size {
+            replicated_imm_size.sub(imm_size as _);
+        }
     }
 }
 
 impl Debug for TableMemoryMetrics {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("TableMemoryMetrics").finish()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use prometheus::Registry;
+    use risingwave_common::config::MetricLevel;
+
+    use super::*;
+
+    #[test]
+    fn test_replicated_imm_size_metric() {
+        let metrics = HummockStateStoreMetrics::new(&Registry::new(), MetricLevel::Info);
+        let replicated =
+            TableMemoryMetrics::new(&metrics, TableId::new(1), FragmentId::new(1), true);
+        let regular = TableMemoryMetrics::new(&metrics, TableId::new(2), FragmentId::new(2), false);
+
+        replicated.inc_imm(42);
+        regular.inc_imm(100);
+        assert_eq!(metrics.replicated_imm_size.get(), 42);
+
+        regular.dec_imm(100);
+        replicated.dec_imm(42);
+        assert_eq!(metrics.replicated_imm_size.get(), 0);
     }
 }

--- a/src/storage/src/hummock/shared_buffer/mod.rs
+++ b/src/storage/src/hummock/shared_buffer/mod.rs
@@ -112,27 +112,3 @@ impl Debug for TableMemoryMetrics {
         f.debug_struct("TableMemoryMetrics").finish()
     }
 }
-
-#[cfg(test)]
-mod tests {
-    use prometheus::Registry;
-    use risingwave_common::config::MetricLevel;
-
-    use super::*;
-
-    #[test]
-    fn test_replicated_imm_size_metric() {
-        let metrics = HummockStateStoreMetrics::new(&Registry::new(), MetricLevel::Info);
-        let replicated =
-            TableMemoryMetrics::new(&metrics, TableId::new(1), FragmentId::new(1), true);
-        let regular = TableMemoryMetrics::new(&metrics, TableId::new(2), FragmentId::new(2), false);
-
-        replicated.inc_imm(42);
-        regular.inc_imm(100);
-        assert_eq!(metrics.replicated_imm_size.get(), 42);
-
-        regular.dec_imm(100);
-        replicated.dec_imm(42);
-        assert_eq!(metrics.replicated_imm_size.get(), 0);
-    }
-}

--- a/src/storage/src/hummock/store/local_hummock_storage.rs
+++ b/src/storage/src/hummock/store/local_hummock_storage.rs
@@ -679,6 +679,11 @@ impl LocalHummockStorage {
             self.spill_offset += 1;
 
             if self.is_replicated {
+                // A replicated imm cannot be uploaded independently: it is discarded when the
+                // source table's committed epoch catches up. It therefore bypasses the regular
+                // write and memory limiters. Keep this memory visible through
+                // `state_store_replicated_imm_size`, especially for operators that maintain one
+                // full replica per actor.
                 self.read_version.write().add_replicated_imm(imm);
             } else {
                 self.write_limiter.wait_permission(self.table_id).await;

--- a/src/storage/src/monitor/hummock_state_store_metrics.rs
+++ b/src/storage/src/monitor/hummock_state_store_metrics.rs
@@ -83,6 +83,7 @@ pub struct HummockStateStoreMetrics {
     pub uploader_per_table_imm_count: RelabeledGuardedIntGaugeVec,
 
     // memory
+    pub replicated_imm_size: UintGauge,
     pub per_table_imm_size: RelabeledGuardedIntGaugeVec,
     pub per_table_imm_count: RelabeledGuardedIntGaugeVec,
     pub mem_table_spill_counts: RelabeledGuardedIntCounterVec,
@@ -474,6 +475,15 @@ impl HummockStateStoreMetrics {
             metric_level,
         );
 
+        let replicated_imm_size = UintGauge::new(
+            "state_store_replicated_imm_size",
+            "Total retained replicated immutable memtable size",
+        )
+        .unwrap();
+        registry
+            .register(Box::new(replicated_imm_size.clone()))
+            .unwrap();
+
         let per_table_imm_size = register_guarded_int_gauge_vec_with_registry!(
             "state_store_per_table_imm_size",
             "Total imm size per table",
@@ -650,6 +660,7 @@ impl HummockStateStoreMetrics {
             uploader_wait_poll_latency,
             uploader_per_table_imm_size,
             uploader_per_table_imm_count,
+            replicated_imm_size,
             per_table_imm_size,
             per_table_imm_count,
             mem_table_spill_counts,

--- a/src/stream/src/executor/temporal_join.rs
+++ b/src/stream/src/executor/temporal_join.rs
@@ -892,12 +892,12 @@ impl<
 
 #[cfg(test)]
 mod tests {
-    use std::collections::HashSet;
+    use std::collections::{HashMap, HashSet};
     use std::sync::Arc;
     use std::sync::atomic::AtomicU64;
 
     use risingwave_common::array::*;
-    use risingwave_common::bitmap::Bitmap;
+    use risingwave_common::bitmap::{Bitmap, BitmapBuilder};
     use risingwave_common::catalog::{ColumnDesc, ColumnId, Field, Schema, TableId};
     use risingwave_common::hash::Key32;
     use risingwave_common::types::{DataType, ScalarRefImpl};
@@ -905,8 +905,8 @@ mod tests {
     use risingwave_common::util::sort_util::OrderType;
     use risingwave_common::util::value_encoding::BasicSerde;
     use risingwave_hummock_test::test_utils::prepare_hummock_test_env;
+    use risingwave_pb::id::ActorId;
     use risingwave_storage::hummock::HummockStorage;
-    use risingwave_storage::memory::MemoryStateStore;
 
     use super::*;
     use crate::common::table::state_table::{
@@ -915,13 +915,14 @@ mod tests {
     use crate::common::table::test_utils::{gen_pbtable, gen_pbtable_with_dist_key};
     use crate::executor::monitor::StreamingMetrics;
     use crate::executor::test_utils::{MockSource, StreamExecutorTestExt};
-    use crate::executor::{ActorContext, ExecutorInfo, JoinType};
+    use crate::executor::{ActorContext, ExecutorInfo, JoinType, Mutation, UpdateMutation};
 
     /// Tests that a temporal join on a pk-prefix (join key is a strict prefix of the right table's
     /// pk) correctly merges rows committed in epoch1 with rows staged/committed during epoch2, and
     /// produces the right results when the left side arrives in epoch3.
     ///
-    /// Right table: (key INT, seq INT, val INT), pk = (key, seq), SINGLETON distribution.
+    /// Right table: (key INT, seq INT, val INT), pk = (key, seq). The regular variant uses a
+    /// singleton table; the broadcast variant uses a distributed table with all vnodes replicated.
     /// Join condition: `left.left_key` = right.key  (pk prefix: join uses only the first pk column).
     ///
     /// Pre-commit at epoch1: (1,1,100), (1,2,200), (2,1,300)
@@ -948,11 +949,13 @@ mod tests {
     /// deliberately different vnode counts here.
     #[tokio::test]
     async fn test_broadcast_temporal_join_retracts_memoized_row() {
-        let store = MemoryStateStore::new();
+        let test_env = prepare_hummock_test_env().await;
+        let right_table_id = TableId::new(1);
+        let memo_table_id = TableId::new(2);
 
         // Lookup table: (lookup_id, dim_value), distributed across 16 vnodes.
         let mut right_catalog = gen_pbtable_with_dist_key(
-            TableId::new(1),
+            right_table_id,
             vec![
                 ColumnDesc::unnamed(ColumnId::new(0), DataType::Int32),
                 ColumnDesc::unnamed(ColumnId::new(1), DataType::Int32),
@@ -963,9 +966,10 @@ mod tests {
             vec![0],
         );
         right_catalog.maybe_vnode_count = Some(16);
+        test_env.register_table(right_catalog.clone()).await;
         let right_table = StateTableBuilder::<_, BasicSerde, true, _>::new(
             &right_catalog,
-            store.clone(),
+            test_env.storage.clone(),
             Some(Arc::new(Bitmap::ones(16))),
         )
         .with_op_consistency_level(StateTableOpConsistencyLevel::Inconsistent)
@@ -977,7 +981,7 @@ mod tests {
         // Memo row: (right_lookup_id, dim_value, left_lookup_id, left_id). Its prefix remains
         // `left_lookup_id + left_id`, while its distribution key refers to the `left_id` copy.
         let mut memo_catalog = gen_pbtable_with_dist_key(
-            TableId::new(2),
+            memo_table_id,
             vec![
                 ColumnDesc::unnamed(ColumnId::new(0), DataType::Int32),
                 ColumnDesc::unnamed(ColumnId::new(1), DataType::Int32),
@@ -994,11 +998,28 @@ mod tests {
             vec![3],
         );
         memo_catalog.maybe_vnode_count = Some(8);
-        let memo_table =
-            StateTableBuilder::new(&memo_catalog, store, Some(Arc::new(Bitmap::ones(8))))
-                .forbid_preload_all_rows()
-                .build()
-                .await;
+        test_env.register_table(memo_catalog.clone()).await;
+        let memo_table = StateTableBuilder::new(
+            &memo_catalog,
+            test_env.storage.clone(),
+            Some(Arc::new(Bitmap::ones(8))),
+        )
+        .forbid_preload_all_rows()
+        .build()
+        .await;
+
+        // Keep ownership of the memo rows used after the update. The lookup table has a different
+        // vnode count, so incorrectly applying this bitmap to the replica would fail immediately.
+        let mut updated_memo_vnodes = BitmapBuilder::zeroed(8);
+        for left_id in [100, 101] {
+            let vnode = memo_table.compute_vnode_by_pk(OwnedRow::new(vec![
+                Some(1i32.into()),
+                Some(left_id.into()),
+                Some(1i32.into()),
+            ]));
+            updated_memo_vnodes.set(vnode.to_index(), true);
+        }
+        let updated_memo_vnodes = Arc::new(updated_memo_vnodes.finish());
 
         // Left: (left_id, lookup_id, payload), distributed and keyed by `left_id`.
         let left_schema = Schema::new(vec![
@@ -1032,7 +1053,7 @@ mod tests {
 
         let executor = TemporalJoinExecutor::<
             Key32,
-            MemoryStateStore,
+            HummockStorage,
             BasicSerde,
             { JoinType::Inner },
             false,
@@ -1057,6 +1078,10 @@ mod tests {
         );
         let mut stream = Box::new(executor).execute();
 
+        test_env.storage.start_epoch(
+            test_epoch(1),
+            HashSet::from_iter([right_table_id, memo_table_id]),
+        );
         left_tx.push_barrier(test_epoch(1), false);
         right_tx.push_barrier(test_epoch(1), false);
         stream.expect_barrier().await;
@@ -1066,6 +1091,10 @@ mod tests {
             " i  i
              + 1 10",
         ));
+        test_env.storage.start_epoch(
+            test_epoch(2),
+            HashSet::from_iter([right_table_id, memo_table_id]),
+        );
         left_tx.push_barrier(test_epoch(2), false);
         right_tx.push_barrier(test_epoch(2), false);
         stream.expect_barrier().await;
@@ -1082,6 +1111,10 @@ mod tests {
                  + 100 1 7 1 10",
             )
         );
+        test_env.storage.start_epoch(
+            test_epoch(3),
+            HashSet::from_iter([right_table_id, memo_table_id]),
+        );
         left_tx.push_barrier(test_epoch(3), false);
         right_tx.push_barrier(test_epoch(3), false);
         stream.expect_barrier().await;
@@ -1092,9 +1125,21 @@ mod tests {
              U- 1 10
              U+ 1 20",
         ));
-        left_tx.push_barrier(test_epoch(4), false);
-        right_tx.push_barrier(test_epoch(4), false);
+        test_env.storage.start_epoch(
+            test_epoch(4),
+            HashSet::from_iter([right_table_id, memo_table_id]),
+        );
+        let barrier = Barrier::new_test_barrier(test_epoch(4)).with_mutation(Mutation::Update(
+            UpdateMutation {
+                vnode_bitmaps: HashMap::from([(ActorId::new(0), updated_memo_vnodes)]),
+                ..Default::default()
+            },
+        ));
+        left_tx.send_barrier(barrier.clone());
+        right_tx.send_barrier(barrier);
         stream.expect_barrier().await;
+        // Applying the memo vnode update waits for this committed epoch after the barrier yield.
+        test_env.commit_epoch(test_epoch(3)).await;
 
         // Deleting the old left row must retract v1, while a new row sees v2.
         left_tx.push_chunk(StreamChunk::from_pretty(
@@ -1111,6 +1156,10 @@ mod tests {
             )
         );
 
+        test_env.storage.start_epoch(
+            test_epoch(5),
+            HashSet::from_iter([right_table_id, memo_table_id]),
+        );
         left_tx.push_barrier(test_epoch(5), true);
         right_tx.push_barrier(test_epoch(5), true);
         stream.expect_barrier().await;
@@ -1121,8 +1170,9 @@ mod tests {
         let table_id = TableId::new(1);
 
         // Right table schema: (key INT col_id=1, seq INT col_id=2, val INT col_id=3)
-        // pk = (key idx=0, seq idx=1), SINGLETON distribution (empty distribution_key),
-        // read_prefix_len_hint = 2 (= full pk length).
+        // pk = (key idx=0, seq idx=1), read_prefix_len_hint = 2 (= full pk length).
+        // The broadcast variant uses a distributed catalog and owns every lookup vnode; the
+        // regular variant preserves the original singleton coverage.
         let right_col_descs = vec![
             ColumnDesc::unnamed(ColumnId::new(1), DataType::Int32),
             ColumnDesc::unnamed(ColumnId::new(2), DataType::Int32),
@@ -1130,7 +1180,24 @@ mod tests {
         ];
         let order_types = vec![OrderType::ascending(), OrderType::ascending()];
         let pk_indices = vec![0usize, 1];
-        let pbtable = gen_pbtable(table_id, right_col_descs, order_types, pk_indices, 2);
+        let vnode_count = 16;
+        let (pbtable, lookup_vnodes) = if is_broadcast {
+            let mut table = gen_pbtable_with_dist_key(
+                table_id,
+                right_col_descs,
+                order_types,
+                pk_indices,
+                2,
+                vec![0],
+            );
+            table.maybe_vnode_count = Some(vnode_count as _);
+            (table, Some(Arc::new(Bitmap::ones(vnode_count))))
+        } else {
+            (
+                gen_pbtable(table_id, right_col_descs, order_types, pk_indices, 2),
+                None,
+            )
+        };
 
         test_env.register_table(pbtable.clone()).await;
 
@@ -1139,7 +1206,7 @@ mod tests {
             let mut setup_table = StateTable::<HummockStorage>::from_table_catalog_inconsistent_op(
                 &pbtable,
                 test_env.storage.clone(),
-                None,
+                lookup_vnodes.clone(),
             )
             .await;
             test_env
@@ -1180,13 +1247,17 @@ mod tests {
         let right_table = StateTableBuilder::<_, BasicSerde, true, _>::new(
             &pbtable,
             test_env.storage.clone(),
-            None,
+            lookup_vnodes,
         )
         .with_op_consistency_level(StateTableOpConsistencyLevel::Inconsistent)
         .with_output_column_ids(output_column_ids)
         .forbid_preload_all_rows()
         .build()
         .await;
+        let key3_vnode = is_broadcast.then(|| {
+            right_table
+                .compute_vnode_by_pk(OwnedRow::new(vec![Some(3i32.into()), Some(1i32.into())]))
+        });
 
         // Left source: (left_key INT, left_val INT), stream_key = [0].
         let left_schema = Schema::new(vec![
@@ -1270,8 +1341,22 @@ mod tests {
         test_env
             .storage
             .start_epoch(test_epoch(3), HashSet::from_iter([table_id]));
-        left_tx.push_barrier_with_prev_epoch_for_test(test_epoch(3), test_epoch(2), false);
-        right_tx.push_barrier_with_prev_epoch_for_test(test_epoch(3), test_epoch(2), false);
+        let mut barrier = Barrier::with_prev_epoch_for_test(test_epoch(3), test_epoch(2));
+        if let Some(key3_vnode) = key3_vnode {
+            let mut updated_vnodes = BitmapBuilder::zeroed(vnode_count);
+            for vnode in 0..vnode_count {
+                updated_vnodes.set(vnode, vnode != key3_vnode.to_index());
+            }
+            barrier = barrier.with_mutation(Mutation::Update(UpdateMutation {
+                vnode_bitmaps: HashMap::from([(
+                    ActorId::new(0),
+                    Arc::new(updated_vnodes.finish()),
+                )]),
+                ..Default::default()
+            }));
+        }
+        left_tx.send_barrier(barrier.clone());
+        right_tx.send_barrier(barrier);
         stream.expect_barrier().await;
 
         // Start epoch4 before the stop barrier that commits epoch3 data.

--- a/src/stream/src/executor/temporal_join.rs
+++ b/src/stream/src/executor/temporal_join.rs
@@ -598,13 +598,15 @@ pub(super) mod phase1 {
                 }
             } else {
                 // Non-append-only temporal join
-                // The memo-table pk and columns:
-                // (`join_key` + `left_pk` + `right_pk`) -> (`right_scan_schema` + `join_key` + `left_pk`)
+                // The memo table persists each matched right row followed by a prefix identifying
+                // the left row. Regular temporal joins use `join_key + left_stream_key`; broadcast
+                // temporal joins use `left_stream_key`, which also owns the memo state.
                 //
                 // Write pattern:
-                //   for each left input row (with insert op), construct the memo table pk and insert the row into the memo table.
+                //   for each left input row (with insert op), persist every matched right row.
                 // Read pattern:
-                //   for each left input row (with delete op), construct pk prefix (`join_key` + `left_pk`) to fetch rows and delete them from the memo table.
+                //   for each left input row (with delete op), fetch the historical right rows by
+                //   memo prefix and delete them from the memo table.
                 //
                 // Temporal join supports inner join and left outer join, additionally, it could contain other conditions.
                 // Surprisingly, we could handle them in a unified way with memo table.
@@ -766,12 +768,19 @@ impl<
 
         let left_stream_key_indices = self.left.stream_key().to_vec();
         let right_stream_key_indices = self.right.stream_key().to_vec();
-        let memo_table_lookup_prefix = self
-            .left_join_keys
-            .iter()
-            .cloned()
-            .chain(left_stream_key_indices)
-            .collect_vec();
+        let memo_table_lookup_prefix = if self.is_broadcast {
+            // Broadcast preserves the left input distribution. Its stream key uniquely identifies
+            // the left row and contains the distribution key, so the memo state follows the left
+            // actor's vnode ownership.
+            left_stream_key_indices
+        } else {
+            // Keep the legacy layout for regular temporal joins and restored plans.
+            self.left_join_keys
+                .iter()
+                .cloned()
+                .chain(left_stream_key_indices)
+                .collect_vec()
+        };
 
         let null_matched = K::Bitmap::from_bool_vec(self.null_safe);
 
@@ -992,6 +1001,7 @@ mod tests {
     use std::sync::atomic::AtomicU64;
 
     use risingwave_common::array::*;
+    use risingwave_common::bitmap::Bitmap;
     use risingwave_common::catalog::{ColumnDesc, ColumnId, Field, Schema, TableId};
     use risingwave_common::hash::Key32;
     use risingwave_common::types::{DataType, ScalarRefImpl};
@@ -1000,12 +1010,13 @@ mod tests {
     use risingwave_common::util::value_encoding::BasicSerde;
     use risingwave_hummock_test::test_utils::prepare_hummock_test_env;
     use risingwave_storage::hummock::HummockStorage;
+    use risingwave_storage::memory::MemoryStateStore;
 
     use super::*;
     use crate::common::table::state_table::{
         StateTable, StateTableBuilder, StateTableOpConsistencyLevel,
     };
-    use crate::common::table::test_utils::gen_pbtable;
+    use crate::common::table::test_utils::{gen_pbtable, gen_pbtable_with_dist_key};
     use crate::executor::monitor::StreamingMetrics;
     use crate::executor::test_utils::{MockSource, StreamExecutorTestExt};
     use crate::executor::{ActorContext, ExecutorInfo, JoinType};
@@ -1028,12 +1039,180 @@ mod tests {
     ///   (3, 333, 3, 1, 400)  — key=3 row matched from epoch2 data
     #[tokio::test]
     async fn test_temporal_join_pk_prefix_staging_merge_cached() {
-        run_temporal_join_pk_prefix_staging_merge(false).await;
+        Box::pin(run_temporal_join_pk_prefix_staging_merge(false)).await;
     }
 
     #[tokio::test]
     async fn test_broadcast_temporal_join_pk_prefix_staging_merge_uncached() {
-        run_temporal_join_pk_prefix_staging_merge(true).await;
+        Box::pin(run_temporal_join_pk_prefix_staging_merge(true)).await;
+    }
+
+    /// A broadcast temporal join must retract the right row that matched at insert time, even if
+    /// the lookup table has since changed. The lookup replica and left-owned memo table also use
+    /// deliberately different vnode counts here.
+    #[tokio::test]
+    async fn test_broadcast_temporal_join_retracts_memoized_row() {
+        let store = MemoryStateStore::new();
+
+        // Lookup table: (lookup_id, dim_value), distributed across 16 vnodes.
+        let mut right_catalog = gen_pbtable_with_dist_key(
+            TableId::new(1),
+            vec![
+                ColumnDesc::unnamed(ColumnId::new(0), DataType::Int32),
+                ColumnDesc::unnamed(ColumnId::new(1), DataType::Int32),
+            ],
+            vec![OrderType::ascending()],
+            vec![0],
+            1,
+            vec![0],
+        );
+        right_catalog.maybe_vnode_count = Some(16);
+        let right_table = StateTableBuilder::<_, BasicSerde, true, _>::new(
+            &right_catalog,
+            store.clone(),
+            Some(Arc::new(Bitmap::ones(16))),
+        )
+        .with_op_consistency_level(StateTableOpConsistencyLevel::Inconsistent)
+        .with_output_column_ids(vec![ColumnId::new(0), ColumnId::new(1)])
+        .forbid_preload_all_rows()
+        .build()
+        .await;
+
+        // Memo row: (lookup_id, dim_value, left_id). Its prefix and distribution key are the
+        // broadcast join's left stream key (`left_id`), across 8 vnodes.
+        let mut memo_catalog = gen_pbtable_with_dist_key(
+            TableId::new(2),
+            vec![
+                ColumnDesc::unnamed(ColumnId::new(0), DataType::Int32),
+                ColumnDesc::unnamed(ColumnId::new(1), DataType::Int32),
+                ColumnDesc::unnamed(ColumnId::new(2), DataType::Int32),
+            ],
+            vec![OrderType::ascending(), OrderType::ascending()],
+            vec![2, 0],
+            1,
+            vec![2],
+        );
+        memo_catalog.maybe_vnode_count = Some(8);
+        let memo_table =
+            StateTableBuilder::new(&memo_catalog, store, Some(Arc::new(Bitmap::ones(8))))
+                .forbid_preload_all_rows()
+                .build()
+                .await;
+
+        // Left: (left_id, lookup_id, payload), distributed and keyed by `left_id`.
+        let left_schema = Schema::new(vec![
+            Field::unnamed(DataType::Int32),
+            Field::unnamed(DataType::Int32),
+            Field::unnamed(DataType::Int32),
+        ]);
+        let (mut left_tx, left_source) = MockSource::channel();
+        let left_executor = left_source.into_executor(left_schema, vec![0]);
+
+        let right_schema = Schema::new(vec![
+            Field::unnamed(DataType::Int32),
+            Field::unnamed(DataType::Int32),
+        ]);
+        let (mut right_tx, right_source) = MockSource::channel();
+        let right_executor = right_source.into_executor(right_schema, vec![0]);
+
+        let output_schema = Schema::new(vec![
+            Field::unnamed(DataType::Int32),
+            Field::unnamed(DataType::Int32),
+            Field::unnamed(DataType::Int32),
+            Field::unnamed(DataType::Int32),
+            Field::unnamed(DataType::Int32),
+        ]);
+        let info = ExecutorInfo::for_test(
+            output_schema,
+            vec![0],
+            "BroadcastTemporalJoinRetractTest".to_owned(),
+            0,
+        );
+
+        let executor = TemporalJoinExecutor::<
+            Key32,
+            MemoryStateStore,
+            BasicSerde,
+            { JoinType::Inner },
+            false,
+        >::new(
+            ActorContext::for_test(0),
+            info,
+            left_executor,
+            right_executor,
+            right_table,
+            vec![1], // left lookup key
+            vec![0], // right lookup key
+            vec![false],
+            None,
+            vec![0, 1, 2, 3, 4],
+            vec![0], // right stream key
+            Arc::new(AtomicU64::new(0)),
+            Arc::new(StreamingMetrics::unused()),
+            1024,
+            vec![DataType::Int32],
+            Some(memo_table),
+            true,
+        );
+        let mut stream = Box::new(executor).execute();
+
+        left_tx.push_barrier(test_epoch(1), false);
+        right_tx.push_barrier(test_epoch(1), false);
+        stream.expect_barrier().await;
+
+        // Publish dimension v1.
+        right_tx.push_chunk(StreamChunk::from_pretty(
+            " i  i
+             + 1 10",
+        ));
+        left_tx.push_barrier(test_epoch(2), false);
+        right_tx.push_barrier(test_epoch(2), false);
+        stream.expect_barrier().await;
+
+        // The left row joins v1, which is persisted in memo state under `left_id = 100`.
+        left_tx.push_chunk(StreamChunk::from_pretty(
+            " i   i i
+             + 100 1 7",
+        ));
+        assert_eq!(
+            stream.expect_chunk().await,
+            StreamChunk::from_pretty(
+                " i   i i i  i
+                 + 100 1 7 1 10",
+            )
+        );
+        left_tx.push_barrier(test_epoch(3), false);
+        right_tx.push_barrier(test_epoch(3), false);
+        stream.expect_barrier().await;
+
+        // Replace dimension v1 with v2 after the left row was joined.
+        right_tx.push_chunk(StreamChunk::from_pretty(
+            "  i  i
+             U- 1 10
+             U+ 1 20",
+        ));
+        left_tx.push_barrier(test_epoch(4), false);
+        right_tx.push_barrier(test_epoch(4), false);
+        stream.expect_barrier().await;
+
+        // Deleting the old left row must retract v1, while a new row sees v2.
+        left_tx.push_chunk(StreamChunk::from_pretty(
+            " i   i i
+             - 100 1 7
+             + 101 1 8",
+        ));
+        assert_eq!(
+            stream.expect_chunk().await,
+            StreamChunk::from_pretty(
+                " i   i i i  i
+                 - 100 1 7 1 10
+                 + 101 1 8 1 20",
+            )
+        );
+
+        left_tx.push_barrier(test_epoch(5), true);
+        right_tx.push_barrier(test_epoch(5), true);
+        stream.expect_barrier().await;
     }
 
     async fn run_temporal_join_pk_prefix_staging_merge(is_broadcast: bool) {

--- a/src/stream/src/executor/temporal_join.rs
+++ b/src/stream/src/executor/temporal_join.rs
@@ -60,6 +60,7 @@ pub struct TemporalJoinExecutor<
     chunk_size: usize,
     memo_table: Option<StateTable<S>>,
     metrics: TemporalJoinMetrics,
+    is_broadcast: bool,
 }
 
 #[derive(Default)]
@@ -107,7 +108,7 @@ impl JoinEntry {
 struct TemporalSide<K: HashKey, S: StateStore, SD: ValueRowSerde> {
     source: ReplicatedStateTable<S, SD>,
     table_stream_key_indices: Vec<usize>,
-    cache: ManagedLruCache<K, JoinEntry>,
+    cache: Option<ManagedLruCache<K, JoinEntry>>,
     join_key_data_types: Vec<DataType>,
 }
 
@@ -123,7 +124,13 @@ impl<K: HashKey, S: StateStore, SD: ValueRowSerde> TemporalSide<K, S, SD> {
         for key in keys {
             metrics.temporal_join_total_query_cache_count.inc();
 
-            if self.cache.get(key).is_none() {
+            if self
+                .cache
+                .as_mut()
+                .expect("lookup cache should be enabled")
+                .get(key)
+                .is_none()
+            {
                 metrics.temporal_join_cache_miss_count.inc();
 
                 futs.push(async {
@@ -159,14 +166,73 @@ impl<K: HashKey, S: StateStore, SD: ValueRowSerde> TemporalSide<K, S, SD> {
         #[for_await]
         for res in stream::iter(futs).buffered(16) {
             let (key, entry) = res?;
-            self.cache.put(key, entry);
+            self.cache
+                .as_mut()
+                .expect("lookup cache should be enabled")
+                .put(key, entry);
         }
 
         Ok(())
     }
 
+    /// Fetch records directly from storage without retaining them in an operator cache.
+    async fn fetch_keys_uncached(
+        &self,
+        keys: impl Iterator<Item = &K>,
+        metrics: &TemporalJoinMetrics,
+    ) -> StreamExecutorResult<HashMap<K, JoinEntry>> {
+        let mut unique_keys = HashMap::new();
+        for key in keys {
+            metrics.temporal_join_total_query_cache_count.inc();
+            if let Entry::Vacant(entry) = unique_keys.entry(key.clone()) {
+                metrics.temporal_join_cache_miss_count.inc();
+                entry.insert(());
+            }
+        }
+
+        let mut futs = Vec::with_capacity(unique_keys.len());
+        for key in unique_keys.into_keys() {
+            futs.push(async {
+                let pk_prefix = key.deserialize(&self.join_key_data_types)?;
+                let iter = self
+                    .source
+                    .iter_with_prefix(
+                        &pk_prefix,
+                        &(Bound::<OwnedRow>::Unbounded, Bound::<OwnedRow>::Unbounded),
+                        PrefetchOptions::default(),
+                    )
+                    .await?;
+
+                let mut entry = JoinEntry::default();
+                pin_mut!(iter);
+                while let Some(row) = iter.next().await {
+                    let row: OwnedRow = row?;
+                    entry.insert(
+                        row.as_ref()
+                            .project(&self.table_stream_key_indices)
+                            .into_owned_row(),
+                        row,
+                    );
+                }
+                Ok((key, entry)) as StreamExecutorResult<_>
+            });
+        }
+
+        let mut entries = HashMap::with_capacity(futs.len());
+        #[for_await]
+        for res in stream::iter(futs).buffered(16) {
+            let (key, entry) = res?;
+            entries.insert(key, entry);
+        }
+        Ok(entries)
+    }
+
     fn force_peek(&self, key: &K) -> &JoinEntry {
-        self.cache.peek(key).expect("key should exists")
+        self.cache
+            .as_ref()
+            .expect("lookup cache should be enabled")
+            .peek(key)
+            .expect("key should exist")
     }
 
     fn update(
@@ -181,9 +247,13 @@ impl<K: HashKey, S: StateStore, SD: ValueRowSerde> TemporalSide<K, S, SD> {
                 let Some((op, row)) = r else {
                     continue;
                 };
-                if self.cache.contains(&key) {
+                if self
+                    .cache
+                    .as_ref()
+                    .is_some_and(|cache| cache.contains(&key))
+                {
                     // Update cache
-                    let mut entry = self.cache.get_mut(&key).unwrap();
+                    let mut entry = self.cache.as_mut().unwrap().get_mut(&key).unwrap();
                     let stream_key = row.project(right_stream_key_indices).into_owned_row();
                     match op {
                         Op::Insert | Op::UpdateInsert => {
@@ -485,9 +555,18 @@ pub(super) mod phase1 {
                     None
                 }
             });
-        right_table
-            .fetch_or_promote_keys(to_fetch_keys, metrics)
-            .await?;
+        let uncached_entries = if right_table.cache.is_some() {
+            right_table
+                .fetch_or_promote_keys(to_fetch_keys, metrics)
+                .await?;
+            None
+        } else {
+            Some(
+                right_table
+                    .fetch_keys_uncached(to_fetch_keys, metrics)
+                    .await?,
+            )
+        };
 
         for (r, key) in chunk.rows_with_holes().zip_eq_debug(keys.into_iter()) {
             let Some((op, left_row)) = r else {
@@ -499,7 +578,13 @@ pub(super) mod phase1 {
             if APPEND_ONLY {
                 // Append-only temporal join
                 if key.null_bitmap().is_subset(null_matched)
-                    && let join_entry = right_table.force_peek(&key)
+                    && let join_entry = if let Some(entries) = &uncached_entries {
+                        entries
+                            .get(&key)
+                            .expect("join key should have been fetched")
+                    } else {
+                        right_table.force_peek(&key)
+                    }
                     && !join_entry.is_empty()
                 {
                     matched = true;
@@ -529,7 +614,13 @@ pub(super) mod phase1 {
                 match op {
                     Op::Insert | Op::UpdateInsert => {
                         if key.null_bitmap().is_subset(null_matched)
-                            && let join_entry = right_table.force_peek(&key)
+                            && let join_entry = if let Some(entries) = &uncached_entries {
+                                entries
+                                    .get(&key)
+                                    .expect("join key should have been fetched")
+                            } else {
+                                right_table.force_peek(&key)
+                            }
                             && !join_entry.is_empty()
                         {
                             matched = true;
@@ -628,11 +719,13 @@ impl<
         chunk_size: usize,
         join_key_data_types: Vec<DataType>,
         memo_table: Option<StateTable<S>>,
+        is_broadcast: bool,
     ) -> Self {
-        let metrics_info =
-            MetricsInfo::new(metrics.clone(), table.table_id(), ctx.id, "temporal join");
-
-        let cache = ManagedLruCache::unbounded(watermark_sequence, metrics_info);
+        let cache = (!is_broadcast).then(|| {
+            let metrics_info =
+                MetricsInfo::new(metrics.clone(), table.table_id(), ctx.id, "temporal join");
+            ManagedLruCache::unbounded(watermark_sequence, metrics_info)
+        });
 
         let metrics = metrics.new_temporal_join_metrics(table.table_id(), ctx.id, ctx.fragment_id);
 
@@ -655,6 +748,7 @@ impl<
             chunk_size,
             memo_table,
             metrics,
+            is_broadcast,
         }
     }
 
@@ -705,10 +799,14 @@ impl<
 
         #[for_await]
         for msg in input {
-            self.right_table.cache.evict();
-            self.metrics
-                .temporal_join_cached_entry_count
-                .set(self.right_table.cache.len() as i64);
+            if let Some(cache) = self.right_table.cache.as_mut() {
+                cache.evict();
+                self.metrics
+                    .temporal_join_cached_entry_count
+                    .set(cache.len() as i64);
+            } else {
+                self.metrics.temporal_join_cached_entry_count.set(0);
+            }
             match msg? {
                 InternalMessage::WaterMark(watermark) => {
                     let output_watermark_col_idx = *left_to_output.get(&watermark.col_idx).unwrap();
@@ -828,6 +926,11 @@ impl<
                 }
                 InternalMessage::Barrier(updates, barrier) => {
                     let update_vnode_bitmap = barrier.as_update_vnode_bitmap(self.ctx.id);
+                    let right_update_vnode_bitmap = if self.is_broadcast {
+                        None
+                    } else {
+                        update_vnode_bitmap.clone()
+                    };
 
                     // Write right-side chunks to the replicated state table and update LRU cache.
                     // Must happen before commit.
@@ -852,10 +955,11 @@ impl<
                     yield Message::Barrier(barrier);
 
                     if let Some((_, true)) = right_post_commit
-                        .post_yield_barrier(update_vnode_bitmap.clone())
+                        .post_yield_barrier(right_update_vnode_bitmap)
                         .await?
+                        && let Some(cache) = self.right_table.cache.as_mut()
                     {
-                        self.right_table.cache.clear();
+                        cache.clear();
                     }
                     if let Some(memo_post_commit) = memo_post_commit {
                         memo_post_commit
@@ -919,11 +1023,20 @@ mod tests {
     /// Epoch3:  left side sends (`left_key=1`, `left_val=111`) and (`left_key=3`, `left_val=333`).
     ///
     /// Expected join output in epoch3:
-    ///   (1, 111, 1, 1, 100)  — key=1 row matched from epoch1 data (cache miss → state store read)
-    ///   (1, 111, 1, 2, 200)  — key=1 row matched from epoch1 data (same cache entry)
-    ///   (3, 333, 3, 1, 400)  — key=3 row matched from epoch2 data (cache miss → state store read)
+    ///   (1, 111, 1, 1, 100)  — key=1 row matched from epoch1 data
+    ///   (1, 111, 1, 2, 200)  — key=1 row matched from the same lookup entry
+    ///   (3, 333, 3, 1, 400)  — key=3 row matched from epoch2 data
     #[tokio::test]
-    async fn test_temporal_join_pk_prefix_staging_merge() {
+    async fn test_temporal_join_pk_prefix_staging_merge_cached() {
+        run_temporal_join_pk_prefix_staging_merge(false).await;
+    }
+
+    #[tokio::test]
+    async fn test_broadcast_temporal_join_pk_prefix_staging_merge_uncached() {
+        run_temporal_join_pk_prefix_staging_merge(true).await;
+    }
+
+    async fn run_temporal_join_pk_prefix_staging_merge(is_broadcast: bool) {
         let test_env = prepare_hummock_test_env().await;
         let table_id = TableId::new(1);
 
@@ -1056,6 +1169,7 @@ mod tests {
             1024,
             join_key_data_types,
             None, // no memo table (append-only inner join)
+            is_broadcast,
         );
 
         let mut stream = Box::new(executor).execute();
@@ -1067,7 +1181,7 @@ mod tests {
 
         // Epoch2: right side inserts (3, 1, 400); left side is quiet.
         // The epoch2→epoch3 barrier will trigger write_chunk + commit for the right table,
-        // making (3,1,400) visible as committed epoch2 data.
+        // making (3,1,400) visible in the replicated state table at epoch3.
         right_tx.push_chunk(StreamChunk::from_pretty(
             " i i   i
             + 3 1 400",
@@ -1086,8 +1200,8 @@ mod tests {
             .start_epoch(test_epoch(4), HashSet::from_iter([table_id]));
 
         // Epoch3: left side sends two rows.
-        //   key=1 → cache miss → state store read → finds (1,1,100) and (1,2,200) from epoch1.
-        //   key=3 → cache miss → state store read → finds (3,1,400) from epoch2.
+        //   key=1 → state store read → finds (1,1,100) and (1,2,200) from epoch1.
+        //   key=3 → state store read → finds (3,1,400) from epoch2.
         left_tx.push_chunk(StreamChunk::from_pretty(
             " i   i
             + 1 111

--- a/src/stream/src/executor/temporal_join.rs
+++ b/src/stream/src/executor/temporal_join.rs
@@ -892,12 +892,11 @@ impl<
 
 #[cfg(test)]
 mod tests {
-    use std::collections::{HashMap, HashSet};
+    use std::collections::HashSet;
     use std::sync::Arc;
     use std::sync::atomic::AtomicU64;
 
     use risingwave_common::array::*;
-    use risingwave_common::bitmap::{Bitmap, BitmapBuilder};
     use risingwave_common::catalog::{ColumnDesc, ColumnId, Field, Schema, TableId};
     use risingwave_common::hash::Key32;
     use risingwave_common::types::{DataType, ScalarRefImpl};
@@ -905,24 +904,22 @@ mod tests {
     use risingwave_common::util::sort_util::OrderType;
     use risingwave_common::util::value_encoding::BasicSerde;
     use risingwave_hummock_test::test_utils::prepare_hummock_test_env;
-    use risingwave_pb::id::ActorId;
     use risingwave_storage::hummock::HummockStorage;
 
     use super::*;
     use crate::common::table::state_table::{
         StateTable, StateTableBuilder, StateTableOpConsistencyLevel,
     };
-    use crate::common::table::test_utils::{gen_pbtable, gen_pbtable_with_dist_key};
+    use crate::common::table::test_utils::gen_pbtable;
     use crate::executor::monitor::StreamingMetrics;
     use crate::executor::test_utils::{MockSource, StreamExecutorTestExt};
-    use crate::executor::{ActorContext, ExecutorInfo, JoinType, Mutation, UpdateMutation};
+    use crate::executor::{ActorContext, ExecutorInfo, JoinType};
 
     /// Tests that a temporal join on a pk-prefix (join key is a strict prefix of the right table's
     /// pk) correctly merges rows committed in epoch1 with rows staged/committed during epoch2, and
     /// produces the right results when the left side arrives in epoch3.
     ///
-    /// Right table: (key INT, seq INT, val INT), pk = (key, seq). The regular variant uses a
-    /// singleton table; the broadcast variant uses a distributed table with all vnodes replicated.
+    /// Right table: (key INT, seq INT, val INT), pk = (key, seq), SINGLETON distribution.
     /// Join condition: `left.left_key` = right.key  (pk prefix: join uses only the first pk column).
     ///
     /// Pre-commit at epoch1: (1,1,100), (1,2,200), (2,1,300)
@@ -931,248 +928,17 @@ mod tests {
     /// Epoch3:  left side sends (`left_key=1`, `left_val=111`) and (`left_key=3`, `left_val=333`).
     ///
     /// Expected join output in epoch3:
-    ///   (1, 111, 1, 1, 100)  — key=1 row matched from epoch1 data
-    ///   (1, 111, 1, 2, 200)  — key=1 row matched from the same lookup entry
-    ///   (3, 333, 3, 1, 400)  — key=3 row matched from epoch2 data
+    ///   (1, 111, 1, 1, 100)  — key=1 row matched from epoch1 data (cache miss → state store read)
+    ///   (1, 111, 1, 2, 200)  — key=1 row matched from epoch1 data (same cache entry)
+    ///   (3, 333, 3, 1, 400)  — key=3 row matched from epoch2 data (cache miss → state store read)
     #[tokio::test]
-    async fn test_temporal_join_pk_prefix_staging_merge_cached() {
-        Box::pin(run_temporal_join_pk_prefix_staging_merge(false)).await;
-    }
-
-    #[tokio::test]
-    async fn test_broadcast_temporal_join_pk_prefix_staging_merge_cached() {
-        Box::pin(run_temporal_join_pk_prefix_staging_merge(true)).await;
-    }
-
-    /// A broadcast temporal join must retract the right row that matched at insert time, even if
-    /// the lookup table has since changed. The lookup replica and left-owned memo table also use
-    /// deliberately different vnode counts here.
-    #[tokio::test]
-    async fn test_broadcast_temporal_join_retracts_memoized_row() {
-        let test_env = prepare_hummock_test_env().await;
-        let right_table_id = TableId::new(1);
-        let memo_table_id = TableId::new(2);
-
-        // Lookup table: (lookup_id, dim_value), distributed across 16 vnodes.
-        let mut right_catalog = gen_pbtable_with_dist_key(
-            right_table_id,
-            vec![
-                ColumnDesc::unnamed(ColumnId::new(0), DataType::Int32),
-                ColumnDesc::unnamed(ColumnId::new(1), DataType::Int32),
-            ],
-            vec![OrderType::ascending()],
-            vec![0],
-            1,
-            vec![0],
-        );
-        right_catalog.maybe_vnode_count = Some(16);
-        test_env.register_table(right_catalog.clone()).await;
-        let right_table = StateTableBuilder::<_, BasicSerde, true, _>::new(
-            &right_catalog,
-            test_env.storage.clone(),
-            Some(Arc::new(Bitmap::ones(16))),
-        )
-        .with_op_consistency_level(StateTableOpConsistencyLevel::Inconsistent)
-        .with_output_column_ids(vec![ColumnId::new(0), ColumnId::new(1)])
-        .forbid_preload_all_rows()
-        .build()
-        .await;
-
-        // Memo row: (right_lookup_id, dim_value, left_lookup_id, left_id). Its prefix remains
-        // `left_lookup_id + left_id`, while its distribution key refers to the `left_id` copy.
-        let mut memo_catalog = gen_pbtable_with_dist_key(
-            memo_table_id,
-            vec![
-                ColumnDesc::unnamed(ColumnId::new(0), DataType::Int32),
-                ColumnDesc::unnamed(ColumnId::new(1), DataType::Int32),
-                ColumnDesc::unnamed(ColumnId::new(2), DataType::Int32),
-                ColumnDesc::unnamed(ColumnId::new(3), DataType::Int32),
-            ],
-            vec![
-                OrderType::ascending(),
-                OrderType::ascending(),
-                OrderType::ascending(),
-            ],
-            vec![2, 3, 0],
-            2,
-            vec![3],
-        );
-        memo_catalog.maybe_vnode_count = Some(8);
-        test_env.register_table(memo_catalog.clone()).await;
-        let memo_table = StateTableBuilder::new(
-            &memo_catalog,
-            test_env.storage.clone(),
-            Some(Arc::new(Bitmap::ones(8))),
-        )
-        .forbid_preload_all_rows()
-        .build()
-        .await;
-
-        // Keep ownership of the memo rows used after the update. The lookup table has a different
-        // vnode count, so incorrectly applying this bitmap to the replica would fail immediately.
-        let mut updated_memo_vnodes = BitmapBuilder::zeroed(8);
-        for left_id in [100, 101] {
-            let vnode = memo_table.compute_vnode_by_pk(OwnedRow::new(vec![
-                Some(1i32.into()),
-                Some(left_id.into()),
-                Some(1i32.into()),
-            ]));
-            updated_memo_vnodes.set(vnode.to_index(), true);
-        }
-        let updated_memo_vnodes = Arc::new(updated_memo_vnodes.finish());
-
-        // Left: (left_id, lookup_id, payload), distributed and keyed by `left_id`.
-        let left_schema = Schema::new(vec![
-            Field::unnamed(DataType::Int32),
-            Field::unnamed(DataType::Int32),
-            Field::unnamed(DataType::Int32),
-        ]);
-        let (mut left_tx, left_source) = MockSource::channel();
-        let left_executor = left_source.into_executor(left_schema, vec![0]);
-
-        let right_schema = Schema::new(vec![
-            Field::unnamed(DataType::Int32),
-            Field::unnamed(DataType::Int32),
-        ]);
-        let (mut right_tx, right_source) = MockSource::channel();
-        let right_executor = right_source.into_executor(right_schema, vec![0]);
-
-        let output_schema = Schema::new(vec![
-            Field::unnamed(DataType::Int32),
-            Field::unnamed(DataType::Int32),
-            Field::unnamed(DataType::Int32),
-            Field::unnamed(DataType::Int32),
-            Field::unnamed(DataType::Int32),
-        ]);
-        let info = ExecutorInfo::for_test(
-            output_schema,
-            vec![0],
-            "BroadcastTemporalJoinRetractTest".to_owned(),
-            0,
-        );
-
-        let executor = TemporalJoinExecutor::<
-            Key32,
-            HummockStorage,
-            BasicSerde,
-            { JoinType::Inner },
-            false,
-        >::new(
-            ActorContext::for_test(0),
-            info,
-            left_executor,
-            right_executor,
-            right_table,
-            vec![1], // left lookup key
-            vec![0], // right lookup key
-            vec![false],
-            None,
-            vec![0, 1, 2, 3, 4],
-            vec![0], // right stream key
-            Arc::new(AtomicU64::new(0)),
-            Arc::new(StreamingMetrics::unused()),
-            1024,
-            vec![DataType::Int32],
-            Some(memo_table),
-            true,
-        );
-        let mut stream = Box::new(executor).execute();
-
-        test_env.storage.start_epoch(
-            test_epoch(1),
-            HashSet::from_iter([right_table_id, memo_table_id]),
-        );
-        left_tx.push_barrier(test_epoch(1), false);
-        right_tx.push_barrier(test_epoch(1), false);
-        stream.expect_barrier().await;
-
-        // Publish dimension v1.
-        right_tx.push_chunk(StreamChunk::from_pretty(
-            " i  i
-             + 1 10",
-        ));
-        test_env.storage.start_epoch(
-            test_epoch(2),
-            HashSet::from_iter([right_table_id, memo_table_id]),
-        );
-        left_tx.push_barrier(test_epoch(2), false);
-        right_tx.push_barrier(test_epoch(2), false);
-        stream.expect_barrier().await;
-
-        // The left row joins v1, which is persisted in memo state under `left_id = 100`.
-        left_tx.push_chunk(StreamChunk::from_pretty(
-            " i   i i
-             + 100 1 7",
-        ));
-        assert_eq!(
-            stream.expect_chunk().await,
-            StreamChunk::from_pretty(
-                " i   i i i  i
-                 + 100 1 7 1 10",
-            )
-        );
-        test_env.storage.start_epoch(
-            test_epoch(3),
-            HashSet::from_iter([right_table_id, memo_table_id]),
-        );
-        left_tx.push_barrier(test_epoch(3), false);
-        right_tx.push_barrier(test_epoch(3), false);
-        stream.expect_barrier().await;
-
-        // Replace dimension v1 with v2 after the left row was joined.
-        right_tx.push_chunk(StreamChunk::from_pretty(
-            "  i  i
-             U- 1 10
-             U+ 1 20",
-        ));
-        test_env.storage.start_epoch(
-            test_epoch(4),
-            HashSet::from_iter([right_table_id, memo_table_id]),
-        );
-        let barrier = Barrier::new_test_barrier(test_epoch(4)).with_mutation(Mutation::Update(
-            UpdateMutation {
-                vnode_bitmaps: HashMap::from([(ActorId::new(0), updated_memo_vnodes)]),
-                ..Default::default()
-            },
-        ));
-        left_tx.send_barrier(barrier.clone());
-        right_tx.send_barrier(barrier);
-        stream.expect_barrier().await;
-        // Applying the memo vnode update waits for this committed epoch after the barrier yield.
-        test_env.commit_epoch(test_epoch(3)).await;
-
-        // Deleting the old left row must retract v1, while a new row sees v2.
-        left_tx.push_chunk(StreamChunk::from_pretty(
-            " i   i i
-             - 100 1 7
-             + 101 1 8",
-        ));
-        assert_eq!(
-            stream.expect_chunk().await,
-            StreamChunk::from_pretty(
-                " i   i i i  i
-                 - 100 1 7 1 10
-                 + 101 1 8 1 20",
-            )
-        );
-
-        test_env.storage.start_epoch(
-            test_epoch(5),
-            HashSet::from_iter([right_table_id, memo_table_id]),
-        );
-        left_tx.push_barrier(test_epoch(5), true);
-        right_tx.push_barrier(test_epoch(5), true);
-        stream.expect_barrier().await;
-    }
-
-    async fn run_temporal_join_pk_prefix_staging_merge(is_broadcast: bool) {
+    async fn test_temporal_join_pk_prefix_staging_merge() {
         let test_env = prepare_hummock_test_env().await;
         let table_id = TableId::new(1);
 
         // Right table schema: (key INT col_id=1, seq INT col_id=2, val INT col_id=3)
-        // pk = (key idx=0, seq idx=1), read_prefix_len_hint = 2 (= full pk length).
-        // The broadcast variant uses a distributed catalog and owns every lookup vnode; the
-        // regular variant preserves the original singleton coverage.
+        // pk = (key idx=0, seq idx=1), SINGLETON distribution (empty distribution_key),
+        // read_prefix_len_hint = 2 (= full pk length).
         let right_col_descs = vec![
             ColumnDesc::unnamed(ColumnId::new(1), DataType::Int32),
             ColumnDesc::unnamed(ColumnId::new(2), DataType::Int32),
@@ -1180,24 +946,7 @@ mod tests {
         ];
         let order_types = vec![OrderType::ascending(), OrderType::ascending()];
         let pk_indices = vec![0usize, 1];
-        let vnode_count = 16;
-        let (pbtable, lookup_vnodes) = if is_broadcast {
-            let mut table = gen_pbtable_with_dist_key(
-                table_id,
-                right_col_descs,
-                order_types,
-                pk_indices,
-                2,
-                vec![0],
-            );
-            table.maybe_vnode_count = Some(vnode_count as _);
-            (table, Some(Arc::new(Bitmap::ones(vnode_count))))
-        } else {
-            (
-                gen_pbtable(table_id, right_col_descs, order_types, pk_indices, 2),
-                None,
-            )
-        };
+        let pbtable = gen_pbtable(table_id, right_col_descs, order_types, pk_indices, 2);
 
         test_env.register_table(pbtable.clone()).await;
 
@@ -1206,7 +955,7 @@ mod tests {
             let mut setup_table = StateTable::<HummockStorage>::from_table_catalog_inconsistent_op(
                 &pbtable,
                 test_env.storage.clone(),
-                lookup_vnodes.clone(),
+                None,
             )
             .await;
             test_env
@@ -1247,17 +996,13 @@ mod tests {
         let right_table = StateTableBuilder::<_, BasicSerde, true, _>::new(
             &pbtable,
             test_env.storage.clone(),
-            lookup_vnodes,
+            None,
         )
         .with_op_consistency_level(StateTableOpConsistencyLevel::Inconsistent)
         .with_output_column_ids(output_column_ids)
         .forbid_preload_all_rows()
         .build()
         .await;
-        let key3_vnode = is_broadcast.then(|| {
-            right_table
-                .compute_vnode_by_pk(OwnedRow::new(vec![Some(3i32.into()), Some(1i32.into())]))
-        });
 
         // Left source: (left_key INT, left_val INT), stream_key = [0].
         let left_schema = Schema::new(vec![
@@ -1320,7 +1065,7 @@ mod tests {
             1024,
             join_key_data_types,
             None, // no memo table (append-only inner join)
-            is_broadcast,
+            false,
         );
 
         let mut stream = Box::new(executor).execute();
@@ -1332,7 +1077,7 @@ mod tests {
 
         // Epoch2: right side inserts (3, 1, 400); left side is quiet.
         // The epoch2→epoch3 barrier will trigger write_chunk + commit for the right table,
-        // making (3,1,400) visible in the replicated state table at epoch3.
+        // making (3,1,400) visible as committed epoch2 data.
         right_tx.push_chunk(StreamChunk::from_pretty(
             " i i   i
             + 3 1 400",
@@ -1341,22 +1086,8 @@ mod tests {
         test_env
             .storage
             .start_epoch(test_epoch(3), HashSet::from_iter([table_id]));
-        let mut barrier = Barrier::with_prev_epoch_for_test(test_epoch(3), test_epoch(2));
-        if let Some(key3_vnode) = key3_vnode {
-            let mut updated_vnodes = BitmapBuilder::zeroed(vnode_count);
-            for vnode in 0..vnode_count {
-                updated_vnodes.set(vnode, vnode != key3_vnode.to_index());
-            }
-            barrier = barrier.with_mutation(Mutation::Update(UpdateMutation {
-                vnode_bitmaps: HashMap::from([(
-                    ActorId::new(0),
-                    Arc::new(updated_vnodes.finish()),
-                )]),
-                ..Default::default()
-            }));
-        }
-        left_tx.send_barrier(barrier.clone());
-        right_tx.send_barrier(barrier);
+        left_tx.push_barrier_with_prev_epoch_for_test(test_epoch(3), test_epoch(2), false);
+        right_tx.push_barrier_with_prev_epoch_for_test(test_epoch(3), test_epoch(2), false);
         stream.expect_barrier().await;
 
         // Start epoch4 before the stop barrier that commits epoch3 data.
@@ -1365,8 +1096,8 @@ mod tests {
             .start_epoch(test_epoch(4), HashSet::from_iter([table_id]));
 
         // Epoch3: left side sends two rows.
-        //   key=1 → state store read → finds (1,1,100) and (1,2,200) from epoch1.
-        //   key=3 → state store read → finds (3,1,400) from epoch2.
+        //   key=1 → cache miss → state store read → finds (1,1,100) and (1,2,200) from epoch1.
+        //   key=3 → cache miss → state store read → finds (3,1,400) from epoch2.
         left_tx.push_chunk(StreamChunk::from_pretty(
             " i   i
             + 1 111

--- a/src/stream/src/executor/temporal_join.rs
+++ b/src/stream/src/executor/temporal_join.rs
@@ -108,7 +108,7 @@ impl JoinEntry {
 struct TemporalSide<K: HashKey, S: StateStore, SD: ValueRowSerde> {
     source: ReplicatedStateTable<S, SD>,
     table_stream_key_indices: Vec<usize>,
-    cache: Option<ManagedLruCache<K, JoinEntry>>,
+    cache: ManagedLruCache<K, JoinEntry>,
     join_key_data_types: Vec<DataType>,
 }
 
@@ -124,13 +124,7 @@ impl<K: HashKey, S: StateStore, SD: ValueRowSerde> TemporalSide<K, S, SD> {
         for key in keys {
             metrics.temporal_join_total_query_cache_count.inc();
 
-            if self
-                .cache
-                .as_mut()
-                .expect("lookup cache should be enabled")
-                .get(key)
-                .is_none()
-            {
+            if self.cache.get(key).is_none() {
                 metrics.temporal_join_cache_miss_count.inc();
 
                 futs.push(async {
@@ -166,73 +160,14 @@ impl<K: HashKey, S: StateStore, SD: ValueRowSerde> TemporalSide<K, S, SD> {
         #[for_await]
         for res in stream::iter(futs).buffered(16) {
             let (key, entry) = res?;
-            self.cache
-                .as_mut()
-                .expect("lookup cache should be enabled")
-                .put(key, entry);
+            self.cache.put(key, entry);
         }
 
         Ok(())
     }
 
-    /// Fetch records directly from storage without retaining them in an operator cache.
-    async fn fetch_keys_uncached(
-        &self,
-        keys: impl Iterator<Item = &K>,
-        metrics: &TemporalJoinMetrics,
-    ) -> StreamExecutorResult<HashMap<K, JoinEntry>> {
-        let mut unique_keys = HashMap::new();
-        for key in keys {
-            metrics.temporal_join_total_query_cache_count.inc();
-            if let Entry::Vacant(entry) = unique_keys.entry(key.clone()) {
-                metrics.temporal_join_cache_miss_count.inc();
-                entry.insert(());
-            }
-        }
-
-        let mut futs = Vec::with_capacity(unique_keys.len());
-        for key in unique_keys.into_keys() {
-            futs.push(async {
-                let pk_prefix = key.deserialize(&self.join_key_data_types)?;
-                let iter = self
-                    .source
-                    .iter_with_prefix(
-                        &pk_prefix,
-                        &(Bound::<OwnedRow>::Unbounded, Bound::<OwnedRow>::Unbounded),
-                        PrefetchOptions::default(),
-                    )
-                    .await?;
-
-                let mut entry = JoinEntry::default();
-                pin_mut!(iter);
-                while let Some(row) = iter.next().await {
-                    let row: OwnedRow = row?;
-                    entry.insert(
-                        row.as_ref()
-                            .project(&self.table_stream_key_indices)
-                            .into_owned_row(),
-                        row,
-                    );
-                }
-                Ok((key, entry)) as StreamExecutorResult<_>
-            });
-        }
-
-        let mut entries = HashMap::with_capacity(futs.len());
-        #[for_await]
-        for res in stream::iter(futs).buffered(16) {
-            let (key, entry) = res?;
-            entries.insert(key, entry);
-        }
-        Ok(entries)
-    }
-
     fn force_peek(&self, key: &K) -> &JoinEntry {
-        self.cache
-            .as_ref()
-            .expect("lookup cache should be enabled")
-            .peek(key)
-            .expect("key should exist")
+        self.cache.peek(key).expect("key should exist")
     }
 
     fn update(
@@ -247,13 +182,9 @@ impl<K: HashKey, S: StateStore, SD: ValueRowSerde> TemporalSide<K, S, SD> {
                 let Some((op, row)) = r else {
                     continue;
                 };
-                if self
-                    .cache
-                    .as_ref()
-                    .is_some_and(|cache| cache.contains(&key))
-                {
+                if self.cache.contains(&key) {
                     // Update cache
-                    let mut entry = self.cache.as_mut().unwrap().get_mut(&key).unwrap();
+                    let mut entry = self.cache.get_mut(&key).unwrap();
                     let stream_key = row.project(right_stream_key_indices).into_owned_row();
                     match op {
                         Op::Insert | Op::UpdateInsert => {
@@ -555,18 +486,9 @@ pub(super) mod phase1 {
                     None
                 }
             });
-        let uncached_entries = if right_table.cache.is_some() {
-            right_table
-                .fetch_or_promote_keys(to_fetch_keys, metrics)
-                .await?;
-            None
-        } else {
-            Some(
-                right_table
-                    .fetch_keys_uncached(to_fetch_keys, metrics)
-                    .await?,
-            )
-        };
+        right_table
+            .fetch_or_promote_keys(to_fetch_keys, metrics)
+            .await?;
 
         for (r, key) in chunk.rows_with_holes().zip_eq_debug(keys.into_iter()) {
             let Some((op, left_row)) = r else {
@@ -578,13 +500,7 @@ pub(super) mod phase1 {
             if APPEND_ONLY {
                 // Append-only temporal join
                 if key.null_bitmap().is_subset(null_matched)
-                    && let join_entry = if let Some(entries) = &uncached_entries {
-                        entries
-                            .get(&key)
-                            .expect("join key should have been fetched")
-                    } else {
-                        right_table.force_peek(&key)
-                    }
+                    && let join_entry = right_table.force_peek(&key)
                     && !join_entry.is_empty()
                 {
                     matched = true;
@@ -598,9 +514,9 @@ pub(super) mod phase1 {
                 }
             } else {
                 // Non-append-only temporal join
-                // The memo table persists each matched right row followed by a prefix identifying
-                // the left row. Regular temporal joins use `join_key + left_stream_key`; broadcast
-                // temporal joins use `left_stream_key`, which also owns the memo state.
+                // The memo table persists each matched right row followed by
+                // `join_key + left_stream_key`. For broadcast temporal joins, its distribution key
+                // refers to the `left_stream_key` portion, so the memo state follows the left side.
                 //
                 // Write pattern:
                 //   for each left input row (with insert op), persist every matched right row.
@@ -616,13 +532,7 @@ pub(super) mod phase1 {
                 match op {
                     Op::Insert | Op::UpdateInsert => {
                         if key.null_bitmap().is_subset(null_matched)
-                            && let join_entry = if let Some(entries) = &uncached_entries {
-                                entries
-                                    .get(&key)
-                                    .expect("join key should have been fetched")
-                            } else {
-                                right_table.force_peek(&key)
-                            }
+                            && let join_entry = right_table.force_peek(&key)
                             && !join_entry.is_empty()
                         {
                             matched = true;
@@ -723,11 +633,9 @@ impl<
         memo_table: Option<StateTable<S>>,
         is_broadcast: bool,
     ) -> Self {
-        let cache = (!is_broadcast).then(|| {
-            let metrics_info =
-                MetricsInfo::new(metrics.clone(), table.table_id(), ctx.id, "temporal join");
-            ManagedLruCache::unbounded(watermark_sequence, metrics_info)
-        });
+        let metrics_info =
+            MetricsInfo::new(metrics.clone(), table.table_id(), ctx.id, "temporal join");
+        let cache = ManagedLruCache::unbounded(watermark_sequence, metrics_info);
 
         let metrics = metrics.new_temporal_join_metrics(table.table_id(), ctx.id, ctx.fragment_id);
 
@@ -768,19 +676,12 @@ impl<
 
         let left_stream_key_indices = self.left.stream_key().to_vec();
         let right_stream_key_indices = self.right.stream_key().to_vec();
-        let memo_table_lookup_prefix = if self.is_broadcast {
-            // Broadcast preserves the left input distribution. Its stream key uniquely identifies
-            // the left row and contains the distribution key, so the memo state follows the left
-            // actor's vnode ownership.
-            left_stream_key_indices
-        } else {
-            // Keep the legacy layout for regular temporal joins and restored plans.
-            self.left_join_keys
-                .iter()
-                .cloned()
-                .chain(left_stream_key_indices)
-                .collect_vec()
-        };
+        let memo_table_lookup_prefix = self
+            .left_join_keys
+            .iter()
+            .cloned()
+            .chain(left_stream_key_indices)
+            .collect_vec();
 
         let null_matched = K::Bitmap::from_bool_vec(self.null_safe);
 
@@ -808,14 +709,10 @@ impl<
 
         #[for_await]
         for msg in input {
-            if let Some(cache) = self.right_table.cache.as_mut() {
-                cache.evict();
-                self.metrics
-                    .temporal_join_cached_entry_count
-                    .set(cache.len() as i64);
-            } else {
-                self.metrics.temporal_join_cached_entry_count.set(0);
-            }
+            self.right_table.cache.evict();
+            self.metrics
+                .temporal_join_cached_entry_count
+                .set(self.right_table.cache.len() as i64);
             match msg? {
                 InternalMessage::WaterMark(watermark) => {
                     let output_watermark_col_idx = *left_to_output.get(&watermark.col_idx).unwrap();
@@ -966,9 +863,8 @@ impl<
                     if let Some((_, true)) = right_post_commit
                         .post_yield_barrier(right_update_vnode_bitmap)
                         .await?
-                        && let Some(cache) = self.right_table.cache.as_mut()
                     {
-                        cache.clear();
+                        self.right_table.cache.clear();
                     }
                     if let Some(memo_post_commit) = memo_post_commit {
                         memo_post_commit
@@ -1043,7 +939,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_broadcast_temporal_join_pk_prefix_staging_merge_uncached() {
+    async fn test_broadcast_temporal_join_pk_prefix_staging_merge_cached() {
         Box::pin(run_temporal_join_pk_prefix_staging_merge(true)).await;
     }
 
@@ -1078,19 +974,24 @@ mod tests {
         .build()
         .await;
 
-        // Memo row: (lookup_id, dim_value, left_id). Its prefix and distribution key are the
-        // broadcast join's left stream key (`left_id`), across 8 vnodes.
+        // Memo row: (right_lookup_id, dim_value, left_lookup_id, left_id). Its prefix remains
+        // `left_lookup_id + left_id`, while its distribution key refers to the `left_id` copy.
         let mut memo_catalog = gen_pbtable_with_dist_key(
             TableId::new(2),
             vec![
                 ColumnDesc::unnamed(ColumnId::new(0), DataType::Int32),
                 ColumnDesc::unnamed(ColumnId::new(1), DataType::Int32),
                 ColumnDesc::unnamed(ColumnId::new(2), DataType::Int32),
+                ColumnDesc::unnamed(ColumnId::new(3), DataType::Int32),
             ],
-            vec![OrderType::ascending(), OrderType::ascending()],
-            vec![2, 0],
-            1,
-            vec![2],
+            vec![
+                OrderType::ascending(),
+                OrderType::ascending(),
+                OrderType::ascending(),
+            ],
+            vec![2, 3, 0],
+            2,
+            vec![3],
         );
         memo_catalog.maybe_vnode_count = Some(8);
         let memo_table =

--- a/src/stream/src/from_proto/temporal_join.rs
+++ b/src/stream/src/from_proto/temporal_join.rs
@@ -161,13 +161,9 @@ impl ExecutorBuilder for TemporalJoinExecutorBuilder {
             let memo_table = node.get_memo_table();
             let memo_table = match memo_table {
                 Ok(memo_table) => {
-                    let vnodes = Arc::new(
-                        params
-                            .vnode_bitmap
-                            .expect("vnodes not set for temporal join"),
-                    );
+                    let vnodes = params.vnode_bitmap.clone().map(Arc::new);
                     Some(
-                        StateTableBuilder::new(memo_table, store.clone(), Some(vnodes.clone()))
+                        StateTableBuilder::new(memo_table, store.clone(), vnodes)
                             .enable_preload_all_rows_by_config(&params.config)
                             .build()
                             .await,

--- a/src/stream/src/from_proto/temporal_join.rs
+++ b/src/stream/src/from_proto/temporal_join.rs
@@ -159,10 +159,6 @@ impl ExecutorBuilder for TemporalJoinExecutorBuilder {
                 .collect_vec();
 
             let memo_table = node.get_memo_table();
-            assert!(
-                !is_broadcast || memo_table.is_err(),
-                "broadcast temporal join must be append-only"
-            );
             let memo_table = match memo_table {
                 Ok(memo_table) => {
                     let vnodes = Arc::new(

--- a/src/stream/src/from_proto/temporal_join.rs
+++ b/src/stream/src/from_proto/temporal_join.rs
@@ -14,8 +14,9 @@
 
 use std::sync::Arc;
 
+use risingwave_common::bitmap::Bitmap;
 use risingwave_common::catalog::ColumnId;
-use risingwave_common::hash::{HashKey, HashKeyDispatcher};
+use risingwave_common::hash::{HashKey, HashKeyDispatcher, VnodeCountCompat};
 use risingwave_common::types::DataType;
 use risingwave_common::util::value_encoding::BasicSerde;
 use risingwave_common::util::value_encoding::column_aware_row_encoding::ColumnAwareSerde;
@@ -76,9 +77,18 @@ impl ExecutorBuilder for TemporalJoinExecutorBuilder {
             .iter()
             .map(|&x| ColumnId::new(table_desc.columns[x].column_id))
             .collect_vec();
-        let vnodes = params.vnode_bitmap.clone().map(Arc::new);
+        let is_broadcast = node.is_broadcast;
+        let vnodes = if is_broadcast {
+            Some(Arc::new(Bitmap::ones(table_desc.vnode_count())))
+        } else {
+            params.vnode_bitmap.clone().map(Arc::new)
+        };
 
         if node.get_is_nested_loop() {
+            assert!(
+                !is_broadcast,
+                "nested-loop temporal join cannot be broadcast"
+            );
             macro_rules! build_nested_loop {
                 ($SD:ident) => {{
                     let right_table =
@@ -149,6 +159,10 @@ impl ExecutorBuilder for TemporalJoinExecutorBuilder {
                 .collect_vec();
 
             let memo_table = node.get_memo_table();
+            assert!(
+                !is_broadcast || memo_table.is_err(),
+                "broadcast temporal join must be append-only"
+            );
             let memo_table = match memo_table {
                 Ok(memo_table) => {
                     let vnodes = Arc::new(
@@ -201,6 +215,7 @@ impl ExecutorBuilder for TemporalJoinExecutorBuilder {
                         join_key_data_types,
                         memo_table,
                         append_only,
+                        is_broadcast,
                     };
 
                     Ok((params.info, dispatcher_args.dispatch()?).into())
@@ -234,6 +249,7 @@ struct TemporalJoinExecutorDispatcherArgs<S: StateStore, SD: ValueRowSerde> {
     join_key_data_types: Vec<DataType>,
     memo_table: Option<StateTable<S>>,
     append_only: bool,
+    is_broadcast: bool,
 }
 
 impl<S: StateStore, SD: ValueRowSerde> HashKeyDispatcher
@@ -268,6 +284,7 @@ impl<S: StateStore, SD: ValueRowSerde> HashKeyDispatcher
                     self.chunk_size,
                     self.join_key_data_types,
                     self.memo_table,
+                    self.is_broadcast,
                 )))
             };
         }


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

This PR adds an opt-in broadcast variant of process-time temporal joins to avoid hot-key bottlenecks on the stream side.

```sql
SELECT ...
FROM events
BROADCAST LEFT JOIN dimensions FOR SYSTEM_TIME AS OF PROCTIME()
ON events.key = dimensions.key;
```

For a regular temporal join, RisingWave reshuffles the left input by the lookup table's distribution key and colocates the join fragment with that table. A low-cardinality or skewed lookup key can therefore send nearly all events to one actor. Broadcast temporal join instead:

- preserves the left input distribution;
- broadcasts lookup-table changes to every temporal-join actor;
- builds the lookup-side `ReplicatedStateTable` with the table's full vnode bitmap;
- reuses the existing managed per-actor lookup cache over replicated storage;
- keeps the full lookup vnode bitmap across actor rescheduling; and
- lets Meta schedule the join fragment independently of the lookup table's vnode count.

The replica only retains local uncommitted changes and does not upload them, so this avoids the persistent N-times dimension-state amplification of manual salting. The lookup cache stores only the actor's on-demand hot set and remains managed by the existing cache eviction policy. The network and replicated-delta cost is proportional to lookup-side change rate and join parallelism, so the behavior is opt-in.

Replicated immutable memtables are retained once per join actor until the source table's committed epoch catches up. They currently bypass the regular write and shared-buffer memory limiters. Operators should therefore keep lookup-side update rates moderate and monitor the node-level `state_store_replicated_imm_size` metric. #26951 tracks a checkpoint-safe memory budget or sharing mechanism.

Retractable left inputs use a separate, left-owned memo table to preserve temporal retraction semantics. The existing protobuf `left_key` remains the lookup join key, and both regular and broadcast temporal joins use the legacy `join_key + left_stream_key` memo prefix. A broadcast memo table maps the left distribution key specifically to its copy in the `left_stream_key` part of that prefix, so it follows the join actor's vnode ownership and normal rescaling. No additional protobuf field is needed.

Current scope:

- append-only and retractable left inputs are supported;
- inner and left outer equality joins are supported; and
- the existing temporal-join lookup prefix and distribution-key validation still applies.

`BROADCAST` remains a contextual word, so ordinary identifiers, quoted aliases, and identifier formatting are unchanged. There is one inherent syntax ambiguity: an existing bare table alias named `broadcast` immediately before `INNER JOIN`, `JOIN`, or `LEFT JOIN` is now interpreted as the modifier. Such queries can preserve the alias with `AS broadcast` or `"broadcast"`.

Closes #26928.

## Checklist

- [x] I have written necessary rustdoc comments.
- [x] I have added necessary e2e tests and planner tests.
- [x] I have added test labels as necessary.
- [ ] I have added fuzzing tests or opened an issue to track them.
- [x] My PR contains breaking changes.
- [ ] My PR changes performance-critical code, so I will run (micro) benchmarks and present the results.
- [ ] I have checked the Release Timeline and Currently Supported Versions to determine which release branches I need to cherry-pick this PR into.

## Tests

- `cargo check -p risingwave_frontend -p risingwave_meta -p risingwave_stream -p risingwave_storage`
- `cargo clippy -p risingwave_frontend -p risingwave_stream -p risingwave_storage --all-targets --all-features --locked -- -D warnings`
- `./risedev run-planner-test temporal_join`
- `./risedev slt ./e2e_test/streaming/temporal_join/append_only/broadcast.slt`
- `./risedev slt ./e2e_test/streaming/temporal_join/non_append_only/broadcast.slt`
- `cargo fmt --all -- --check`
- `git diff --check`

The non-append-only E2E covers matched and unmatched historical retractions after lookup-side changes, a left distribution-key update across actors, different lookup/memo vnode counts, singleton retractable input, and scale-in/scale-out.

## Documentation

- [x] My PR needs documentation updates.

<details>
<summary><b>Release note</b></summary>

RisingWave now supports opt-in broadcast process-time temporal joins with `BROADCAST [LEFT] JOIN ... FOR SYSTEM_TIME AS OF PROCTIME()`. This preserves the stream-side distribution and can avoid actor hot spots when lookup keys have low cardinality or heavy skew. Equality-based inner and left outer joins support both append-only and retractable stream inputs.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for broadcast temporal joins using `BROADCAST ... JOIN` and `BROADCAST ... LEFT JOIN`.
  - Broadcast temporal joins now support non-append-only left inputs, including updates, retractions, and distribution changes.
  - Added handling for broadcast temporal-join plans and replicated lookup processing.

- **Bug Fixes**
  - Improved parsing so `BROADCAST` remains valid as a regular identifier where appropriate.
  - Added clear errors for unsupported non-equality broadcast temporal joins and unsupported process-time broadcast contexts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
