### PR TITLE
chore(deps): update rtrb to 0.3.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14594,9 +14594,9 @@ dependencies = [
 
 [[package]]
 name = "rtrb"
-version = "0.3.1"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3f94e84c073f3b85d4012b44722fa8842b9986d741590d4f2636ad0a5b14143"
+checksum = "fae8ee26b0371a29a77d2b2d6b3ae13aa81def6f9bf1b1b92a32d279a5e709b7"
 
 [[package]]
 name = "rumqttc"


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

Update the locked transitive dependency `rtrb` from 0.3.1 to 0.3.5, the patched release recommended for the existing 0.3 series by RUSTSEC-2026-0274.

`rtrb` is pulled in by `fastrace` 0.7.17, whose `^0.3` requirement accepts this patch release. This is a lockfile-only update; no source, manifest, or feature changes are needed.

Current `fastrace` source uses `Consumer::pop`, not the advisory's affected `ReadChunk::commit` or `commit_all` path, so this PR is preventive dependency hygiene and clears the authoritative audit finding without claiming a demonstrated RisingWave exploit path.

Validation:

- `cargo update -p rtrb@0.3.1 --precise 0.3.5`
- `cargo tree -i rtrb@0.3.5 --locked -e features`
- `cargo metadata --format-version 1 --no-deps --locked`
- `cargo audit --file Cargo.lock`: `RUSTSEC-2026-0274` and `rtrb` are no longer reported; 24 unrelated existing advisories remain
- `git diff --check`

`cargo check -p risingwave_rt --locked` was attempted, but this Windows host does not provide the required MSVC `link.exe`; compilation and tests remain for CI.

Closes #26905

## Checklist

- [x] I have written necessary rustdoc comments (none are needed for this lockfile-only update).
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary.
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them.
- [ ] <!-- OPTIONAL --> My PR contains breaking changes.
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results.
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into.

## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates.

<details>
<summary><b>Release note</b></summary>

</details>