### PR TITLE
fix(source): reject zero rate limit for CDC source creation

### DIFF
--- a/e2e_test/source_inline/cdc/source_rate_limit_zero.slt
+++ b/e2e_test/source_inline/cdc/source_rate_limit_zero.slt
@@ -1,0 +1,30 @@
+# MySQL and SQL Server CDC sources must read an initial offset before creation finishes,
+# so they cannot start with source_rate_limit set to 0.
+
+statement error source_rate_limit.*cannot be 0.*mysql-cdc.*initial CDC offset
+create source mysql_explicit_zero with (
+  connector = 'mysql-cdc',
+  source_rate_limit = '0'
+) format plain encode json;
+
+statement error source_rate_limit.*cannot be 0.*sqlserver-cdc.*initial CDC offset
+create source sqlserver_explicit_zero with (
+  connector = 'sqlserver-cdc',
+  source_rate_limit = '0'
+) format plain encode json;
+
+statement ok
+set source_rate_limit to 0;
+
+statement error source_rate_limit.*cannot be 0.*mysql-cdc.*initial CDC offset
+create source mysql_session_zero with (
+  connector = 'mysql-cdc'
+) format plain encode json;
+
+statement error source_rate_limit.*cannot be 0.*sqlserver-cdc.*initial CDC offset
+create source sqlserver_session_zero with (
+  connector = 'sqlserver-cdc'
+) format plain encode json;
+
+statement ok
+set source_rate_limit to default;

--- a/src/frontend/src/handler/create_source.rs
+++ b/src/frontend/src/handler/create_source.rs
@@ -809,6 +809,13 @@ pub fn bind_connector_props(
     Ok((with_properties, refresh_mode))
 }
 
+fn must_wait_cdc_offset_before_report(with_properties: &WithOptions) -> bool {
+    matches!(
+        with_properties.get_connector().as_deref(),
+        Some(MYSQL_CDC_CONNECTOR) | Some(SQL_SERVER_CDC_CONNECTOR)
+    )
+}
+
 /// When the schema can be inferred from external system (like schema registry),
 /// how to handle the regular columns (i.e., non-generated) defined in SQL?
 pub enum SqlColumnStrategy {
@@ -1182,6 +1189,15 @@ pub async fn handle_create_source(
         )));
     }
 
+    if overwrite_options.source_rate_limit == Some(0)
+        && must_wait_cdc_offset_before_report(&handler_args.with_options)
+    {
+        let connector = handler_args.with_options.get_connector().unwrap();
+        return Err(RwError::from(ErrorCode::InvalidParameterValue(format!(
+            "`source_rate_limit` cannot be 0 when creating a `{connector}` source because source creation must wait for the initial CDC offset."
+        ))));
+    }
+
     let format_encode = stmt.format_encode.into_v2_with_warning();
     let (with_properties, refresh_mode) =
         bind_connector_props(&handler_args, &format_encode, true)?;
@@ -1528,6 +1544,73 @@ pub mod tests {
             ]
         "#]]
         .assert_debug_eq(&columns);
+    }
+
+    #[tokio::test]
+    async fn test_reject_zero_source_rate_limit_when_cdc_must_wait_for_offset() {
+        let frontend = LocalFrontend::new(Default::default()).await;
+        let session = frontend.session_ref();
+
+        for (source_name, connector) in [
+            ("mysql_explicit_zero", "mysql-cdc"),
+            ("sqlserver_explicit_zero", "sqlserver-cdc"),
+        ] {
+            let err = frontend
+                .run_sql_with_session(
+                    session.clone(),
+                    format!(
+                        "CREATE SOURCE {source_name} WITH (connector = '{connector}', source_rate_limit = '0') FORMAT PLAIN ENCODE JSON"
+                    ),
+                )
+                .await
+                .unwrap_err();
+            let message = err.to_string();
+            assert!(
+                message.contains("source creation must wait for the initial CDC offset"),
+                "{message}"
+            );
+        }
+
+        frontend
+            .run_sql_with_session(session.clone(), "SET source_rate_limit TO 0;")
+            .await
+            .unwrap();
+
+        for (source_name, connector) in [
+            ("mysql_session_zero", "mysql-cdc"),
+            ("sqlserver_session_zero", "sqlserver-cdc"),
+        ] {
+            let err = frontend
+                .run_sql_with_session(
+                    session.clone(),
+                    format!(
+                        "CREATE SOURCE {source_name} WITH (connector = '{connector}') FORMAT PLAIN ENCODE JSON"
+                    ),
+                )
+                .await
+                .unwrap_err();
+            assert!(
+                err.to_string()
+                    .contains("source creation must wait for the initial CDC offset"),
+                "{err}"
+            );
+        }
+
+        frontend
+            .run_sql_with_session(
+                session.clone(),
+                "CREATE SOURCE mysql_positive_override WITH (connector = 'mysql-cdc', source_rate_limit = '1') FORMAT PLAIN ENCODE JSON",
+            )
+            .await
+            .unwrap();
+
+        frontend
+            .run_sql_with_session(
+                session,
+                "CREATE SOURCE postgres_zero WITH (connector = 'postgres-cdc') FORMAT PLAIN ENCODE JSON",
+            )
+            .await
+            .unwrap();
     }
 
     #[tokio::test]


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

MySQL CDC and SQL Server CDC source creation must receive an initial CDC offset before the DDL can finish. Starting either source with an effective `source_rate_limit` of 0 pauses the source before that offset can be read, leaving the DDL hung.

This PR rejects that configuration in the frontend before connector setup or streaming-job creation. The validation covers both an explicit WITH option and a session-level rate limit. Other CDC connectors and rate-limit changes on existing sources are unchanged.

close https://github.com/risingwavelabs/risingwave/issues/26942
close https://github.com/risingwavelabs/risingwave/issues/26939

## Tests

- `cargo clippy -p risingwave_frontend --all-targets -- -D warnings`
- `cargo test -p risingwave_frontend handler::create_source::tests -- --nocapture`
- `sqllogictest ... e2e_test/source_inline/cdc/source_rate_limit_zero.slt`
- `cargo fmt --all -- --check`
- `python3 e2e_test/check_slt_coverage.py -d`

## Checklist

- [x] I have written necessary rustdoc comments.
- [x] I have added necessary unit tests and integration tests.
- [x] I have added test labels as necessary.
- [ ] I have added fuzzing tests or opened an issue to track them.
- [ ] My PR contains breaking changes.
- [ ] My PR changes performance-critical code, so I will run (micro) benchmarks and present the results.
- [ ] I have checked the Release Timeline and Currently Supported Versions to determine which release branches I need to cherry-pick this PR into.

## Documentation

- [x] My PR needs documentation updates.

<details>
<summary><b>Release note</b></summary>

Creating a MySQL CDC or SQL Server CDC source with an effective `source_rate_limit` of 0 now returns an error instead of waiting indefinitely for the source's initial CDC offset.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented MySQL CDC and SQL Server CDC sources from being created with a zero rate limit when an initial CDC offset is required.
  * Preserved support for positive MySQL CDC rate limits and zero rate limits for PostgreSQL CDC sources.

* **Tests**
  * Added validation coverage for explicit and session-configured zero rate limits across supported CDC connectors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->