### PR TITLE
feat: support database-scoped RECOVER

### DIFF
--- a/proto/meta.proto
+++ b/proto/meta.proto
@@ -380,7 +380,9 @@ message ApplyThrottleResponse {
   common.Status status = 1;
 }
 
-message RecoverRequest {}
+message RecoverRequest {
+  optional uint32 database_id = 1;
+}
 
 message RecoverResponse {}
 

--- a/src/frontend/src/handler/mod.rs
+++ b/src/frontend/src/handler/mod.rs
@@ -696,7 +696,9 @@ pub async fn handle(
         Statement::DeleteMetaSnapshots { snapshot_ids } => {
             delete_meta_snapshot::handle_delete_meta_snapshots(handler_args, snapshot_ids).await
         }
-        Statement::Recover => recover::handle_recover(handler_args).await,
+        Statement::Recover { database_name } => {
+            recover::handle_recover(handler_args, database_name).await
+        }
         Statement::SetVariable {
             local: _,
             variable,

--- a/src/frontend/src/handler/recover.rs
+++ b/src/frontend/src/handler/recover.rs
@@ -13,13 +13,19 @@
 // limitations under the License.
 
 use pgwire::pg_response::{PgResponse, StatementType};
+use risingwave_sqlparser::ast::ObjectName;
 
 use super::RwPgResponse;
+use crate::binder::Binder;
+use crate::catalog::DatabaseId;
 use crate::error::{ErrorCode, Result};
 use crate::handler::HandlerArgs;
 use crate::session::SessionImpl;
 
-pub(super) async fn handle_recover(handler_args: HandlerArgs) -> Result<RwPgResponse> {
+pub(super) async fn handle_recover(
+    handler_args: HandlerArgs,
+    database_name: Option<ObjectName>,
+) -> Result<RwPgResponse> {
     // Only permit recovery for super users.
     if !handler_args.session.is_super_user() {
         return Err(ErrorCode::PermissionDenied(
@@ -27,12 +33,29 @@ pub(super) async fn handle_recover(handler_args: HandlerArgs) -> Result<RwPgResp
         )
         .into());
     }
-    do_recover(&handler_args.session).await?;
+    let database_id = if let Some(database_name) = database_name {
+        let database_name = Binder::resolve_database_name(database_name)?;
+        Some(
+            handler_args
+                .session
+                .env()
+                .catalog_reader()
+                .read_guard()
+                .get_database_by_name(&database_name)?
+                .id(),
+        )
+    } else {
+        None
+    };
+    do_recover(&handler_args.session, database_id).await?;
     Ok(PgResponse::empty_result(StatementType::RECOVER))
 }
 
-pub(crate) async fn do_recover(session: &SessionImpl) -> Result<()> {
+pub(crate) async fn do_recover(
+    session: &SessionImpl,
+    database_id: Option<DatabaseId>,
+) -> Result<()> {
     let client = session.env().meta_client();
-    client.recover().await?;
+    client.recover(database_id).await?;
     Ok(())
 }

--- a/src/frontend/src/meta_client.rs
+++ b/src/frontend/src/meta_client.rs
@@ -67,7 +67,7 @@ pub trait FrontendMetaClient: Send + Sync {
     async fn get_backup_job_status(&self, job_id: u64) -> Result<(BackupJobStatus, String)>;
     async fn delete_meta_snapshot(&self, snapshot_ids: &[u64]) -> Result<()>;
 
-    async fn recover(&self) -> Result<()>;
+    async fn recover(&self, database_id: Option<DatabaseId>) -> Result<()>;
 
     async fn cancel_creating_jobs(&self, jobs: PbJobs) -> Result<Vec<u32>>;
 
@@ -272,8 +272,8 @@ impl FrontendMetaClient for FrontendMetaClientImpl {
         self.0.delete_meta_snapshot(snapshot_ids).await
     }
 
-    async fn recover(&self) -> Result<()> {
-        self.0.recover().await
+    async fn recover(&self, database_id: Option<DatabaseId>) -> Result<()> {
+        self.0.recover(database_id).await
     }
 
     async fn cancel_creating_jobs(&self, infos: PbJobs) -> Result<Vec<u32>> {

--- a/src/frontend/src/test_utils.rs
+++ b/src/frontend/src/test_utils.rs
@@ -1349,7 +1349,7 @@ impl FrontendMetaClient for MockFrontendMetaClient {
         unimplemented!()
     }
 
-    async fn recover(&self) -> RpcResult<()> {
+    async fn recover(&self, _database_id: Option<DatabaseId>) -> RpcResult<()> {
         unimplemented!()
     }
 

--- a/src/meta/service/src/stream_service.rs
+++ b/src/meta/service/src/stream_service.rs
@@ -16,6 +16,7 @@ use std::collections::{HashMap, HashSet};
 
 use chrono::DateTime;
 use itertools::Itertools;
+use risingwave_common::catalog::DatabaseId;
 use risingwave_common::id::JobId;
 use risingwave_common::secret::LocalSecretManager;
 use risingwave_common::util::stream_graph_visitor::visit_stream_node_mut;
@@ -590,9 +591,10 @@ impl StreamManagerService for StreamServiceImpl {
 
     async fn recover(
         &self,
-        _request: Request<RecoverRequest>,
+        request: Request<RecoverRequest>,
     ) -> Result<Response<RecoverResponse>, Status> {
-        self.barrier_manager.adhoc_recovery().await?;
+        let database_id = request.into_inner().database_id.map(DatabaseId::new);
+        self.barrier_manager.adhoc_recovery(database_id).await?;
         Ok(Response::new(RecoverResponse {}))
     }
 

--- a/src/meta/src/barrier/checkpoint/control.rs
+++ b/src/meta/src/barrier/checkpoint/control.rs
@@ -225,6 +225,10 @@ impl CheckpointControl {
         })
     }
 
+    pub(crate) fn contains_database(&self, database_id: DatabaseId) -> bool {
+        self.databases.contains_key(&database_id)
+    }
+
     pub(crate) fn database_info(&self, database_id: DatabaseId) -> Option<&InflightDatabaseInfo> {
         self.databases
             .get(&database_id)

--- a/src/meta/src/barrier/checkpoint/recovery.rs
+++ b/src/meta/src/barrier/checkpoint/recovery.rs
@@ -327,6 +327,19 @@ impl DatabaseStatusAction<'_, EnterReset> {
 }
 
 impl CheckpointControl {
+    pub(crate) fn on_adhoc_recovery(
+        &mut self,
+        database_id: DatabaseId,
+    ) -> Option<DatabaseStatusAction<'_, EnterReset>> {
+        match self.databases.get(&database_id).expect("should exist") {
+            DatabaseCheckpointControlStatus::Running(_) => {
+                Some(self.new_database_status_action(database_id, EnterReset))
+            }
+            // An overlapping request should wait for the ongoing recovery instead of restarting it.
+            DatabaseCheckpointControlStatus::Recovering(_) => None,
+        }
+    }
+
     pub(crate) fn on_report_failure(
         &mut self,
         database_id: DatabaseId,

--- a/src/meta/src/barrier/checkpoint/recovery.rs
+++ b/src/meta/src/barrier/checkpoint/recovery.rs
@@ -331,6 +331,8 @@ impl CheckpointControl {
         &mut self,
         database_id: DatabaseId,
     ) -> Option<DatabaseStatusAction<'_, EnterReset>> {
+        // The barrier worker calls this only after `contains_database` succeeds. This lookup runs
+        // before the recovery path can suspend, so no barrier event can remove it in between.
         match self.databases.get(&database_id).expect("should exist") {
             DatabaseCheckpointControlStatus::Running(_) => {
                 Some(self.new_database_status_action(database_id, EnterReset))

--- a/src/meta/src/barrier/manager.rs
+++ b/src/meta/src/barrier/manager.rs
@@ -124,10 +124,13 @@ impl GlobalBarrierManager {
         rx.await.context("failed to receive get ddl progress")?
     }
 
-    pub async fn adhoc_recovery(&self) -> MetaResult<()> {
+    pub async fn adhoc_recovery(&self, database_id: Option<DatabaseId>) -> MetaResult<()> {
         let (tx, rx) = oneshot::channel();
         self.request_tx
-            .send(BarrierManagerRequest::AdhocRecovery(tx))
+            .send(BarrierManagerRequest::AdhocRecovery {
+                database_id,
+                sender: tx,
+            })
             .context("failed to send adhoc recovery request")?;
         rx.await.context("failed to wait adhoc recovery")?;
         Ok(())

--- a/src/meta/src/barrier/mod.rs
+++ b/src/meta/src/barrier/mod.rs
@@ -133,7 +133,10 @@ pub(crate) enum BarrierManagerRequest {
     GetBackfillProgress(Sender<MetaResult<HashMap<JobId, BackfillProgress>>>),
     GetFragmentBackfillProgress(Sender<MetaResult<Vec<FragmentBackfillProgress>>>),
     GetCdcProgress(Sender<MetaResult<HashMap<JobId, CdcProgress>>>),
-    AdhocRecovery(Sender<()>),
+    AdhocRecovery {
+        database_id: Option<DatabaseId>,
+        sender: Sender<()>,
+    },
     UpdateDatabaseBarrier(UpdateDatabaseBarrierRequest),
 }
 

--- a/src/meta/src/barrier/worker.rs
+++ b/src/meta/src/barrier/worker.rs
@@ -97,6 +97,9 @@ pub(super) struct GlobalBarrierWorker<C> {
 
     checkpoint_control: CheckpointControl,
 
+    /// Callers waiting for an explicitly requested database recovery to finish.
+    database_recovery_waiters: HashMap<DatabaseId, Vec<Sender<()>>>,
+
     /// Command that has been collected but is still completing.
     /// The join handle of the completing future is stored.
     completing_task: CompletingTask,
@@ -171,6 +174,7 @@ impl<C: GlobalBarrierWorkerContext> GlobalBarrierWorker<C> {
             context,
             env,
             checkpoint_control,
+            database_recovery_waiters: HashMap::new(),
             completing_task: CompletingTask::None,
             request_rx,
             active_streaming_nodes,
@@ -536,10 +540,47 @@ impl<C: GlobalBarrierWorkerContext> GlobalBarrierWorker<C> {
                                 }
                             }
                             // Handle adhoc recovery triggered by user.
-                            BarrierManagerRequest::AdhocRecovery(sender) => {
-                                self.adhoc_recovery().await;
-                                if sender.send(()).is_err() {
-                                    warn!("failed to notify finish of adhoc recovery");
+                            BarrierManagerRequest::AdhocRecovery {
+                                database_id,
+                                sender,
+                            } => {
+                                if let Some(database_id) = database_id {
+                                    if self.checkpoint_control.contains_database(database_id) {
+                                        self.database_recovery_waiters
+                                            .entry(database_id)
+                                            .or_default()
+                                            .push(sender);
+                                        if let Err(err) = self.adhoc_database_recovery(database_id).await {
+                                            self.failure_recovery(err).await;
+                                        }
+                                    } else {
+                                        // A database without streaming jobs has no checkpoint
+                                        // control to recover. Still abort any concurrent creation
+                                        // before marking its scheduler ready again.
+                                        self.context.abort_and_mark_blocked(
+                                            Some(database_id),
+                                            RecoveryReason::Adhoc,
+                                        );
+                                        self.context
+                                            .notify_creating_job_failed(
+                                                Some(database_id),
+                                                format!(
+                                                    "adhoc recovery triggered for database {}",
+                                                    database_id
+                                                ),
+                                            )
+                                            .await;
+                                        self.context
+                                            .mark_ready(MarkReadyOptions::Database(database_id));
+                                        if sender.send(()).is_err() {
+                                            warn!(%database_id, "failed to notify finish of adhoc database recovery");
+                                        }
+                                    }
+                                } else {
+                                    self.adhoc_recovery().await;
+                                    if sender.send(()).is_err() {
+                                        warn!("failed to notify finish of adhoc recovery");
+                                    }
                                 }
                             }
                             BarrierManagerRequest::UpdateDatabaseBarrier( UpdateDatabaseBarrierRequest {
@@ -675,6 +716,7 @@ impl<C: GlobalBarrierWorkerContext> GlobalBarrierWorker<C> {
                                             .await?;
                                         // Mark ready only after the refill runtime state is refreshed.
                                         self.context.mark_ready(MarkReadyOptions::Database(database_id));
+                                        self.notify_database_recovery_waiters(database_id);
                                     }
                                     Err(e) => {
                                         entering_initializing.fail_reload_runtime_info(e);
@@ -689,6 +731,7 @@ impl<C: GlobalBarrierWorkerContext> GlobalBarrierWorker<C> {
                                     .await?;
                                 self.context
                                     .mark_ready(MarkReadyOptions::Database(database_id));
+                                self.notify_database_recovery_waiters(database_id);
                             }
                             CheckpointControlEvent::BatchRefreshTrigger { database_id, job_id } => {
                                 self.handle_batch_refresh_trigger(database_id, job_id).await?;
@@ -989,6 +1032,59 @@ impl<C: GlobalBarrierWorkerContext> GlobalBarrierWorker<C> {
             .instrument(span)
             .await;
     }
+
+    async fn adhoc_database_recovery(&mut self, database_id: DatabaseId) -> MetaResult<()> {
+        let Some(entering_recovery) = self
+            .checkpoint_control
+            .on_report_failure(database_id, &mut self.partial_graph_manager)
+        else {
+            // A recovery is already in progress. The caller has been registered
+            // above and will be notified when that recovery finishes.
+            return Ok(());
+        };
+
+        self.context
+            .abort_and_mark_blocked(Some(database_id), RecoveryReason::Adhoc);
+        self.context
+            .notify_creating_job_failed(
+                Some(database_id),
+                format!("adhoc recovery triggered for database {}", database_id),
+            )
+            .await;
+        let output = self.completing_task.wait_completing_task().await?;
+        entering_recovery.enter(output, &mut self.partial_graph_manager);
+        Ok(())
+    }
+
+    fn notify_database_recovery_waiters(&mut self, database_id: DatabaseId) {
+        for sender in self
+            .database_recovery_waiters
+            .remove(&database_id)
+            .unwrap_or_default()
+        {
+            if sender.send(()).is_err() {
+                warn!(%database_id, "failed to notify finish of adhoc database recovery");
+            }
+        }
+    }
+
+    fn notify_finished_database_recovery_waiters(&mut self) {
+        let recovering_databases = self
+            .checkpoint_control
+            .recovering_databases()
+            .collect::<HashSet<_>>();
+        for (database_id, senders) in std::mem::take(&mut self.database_recovery_waiters) {
+            if recovering_databases.contains(&database_id) {
+                self.database_recovery_waiters.insert(database_id, senders);
+            } else {
+                for sender in senders {
+                    if sender.send(()).is_err() {
+                        warn!(%database_id, "failed to notify finish of adhoc database recovery");
+                    }
+                }
+            }
+        }
+    }
 }
 
 impl<C> GlobalBarrierWorker<C> {
@@ -1092,6 +1188,7 @@ impl<C: GlobalBarrierWorkerContext> GlobalBarrierWorker<C> {
         self.context.mark_ready(MarkReadyOptions::Global {
             blocked_databases: self.checkpoint_control.recovering_databases().collect(),
         });
+        self.notify_finished_database_recovery_waiters();
     }
 
     #[await_tree::instrument("recovery({recovery_reason})")]
@@ -1374,8 +1471,11 @@ impl<C: GlobalBarrierWorkerContext> GlobalBarrierWorker<C> {
                         BarrierManagerRequest::GetCdcProgress(tx) => {
                             let _ = tx.send(Err(anyhow!("cluster under recovery[{}]", recovery_reason).into()));
                         }
-                        BarrierManagerRequest::AdhocRecovery(tx) => {
-                            recover_txs.push(tx);
+                        BarrierManagerRequest::AdhocRecovery {
+                            database_id,
+                            sender,
+                        } => {
+                            recover_txs.push((database_id, sender));
                         }
                         BarrierManagerRequest::UpdateDatabaseBarrier(request) => {
                             update_barrier_requests.push(request);
@@ -1411,8 +1511,15 @@ impl<C: GlobalBarrierWorkerContext> GlobalBarrierWorker<C> {
             let _ = sender.send(());
         }
 
-        for tx in recover_txs {
-            let _ = tx.send(());
+        for (database_id, sender) in recover_txs {
+            if let Some(database_id) = database_id {
+                self.database_recovery_waiters
+                    .entry(database_id)
+                    .or_default()
+                    .push(sender);
+            } else {
+                let _ = sender.send(());
+            }
         }
 
         let recovering_databases = self

--- a/src/meta/src/barrier/worker.rs
+++ b/src/meta/src/barrier/worker.rs
@@ -1034,10 +1034,7 @@ impl<C: GlobalBarrierWorkerContext> GlobalBarrierWorker<C> {
     }
 
     async fn adhoc_database_recovery(&mut self, database_id: DatabaseId) -> MetaResult<()> {
-        let Some(entering_recovery) = self
-            .checkpoint_control
-            .on_report_failure(database_id, &mut self.partial_graph_manager)
-        else {
+        let Some(entering_recovery) = self.checkpoint_control.on_adhoc_recovery(database_id) else {
             // A recovery is already in progress. The caller has been registered
             // above and will be notified when that recovery finishes.
             return Ok(());

--- a/src/rpc_client/src/meta_client.rs
+++ b/src/rpc_client/src/meta_client.rs
@@ -1205,8 +1205,10 @@ impl MetaClient {
             .ok_or_else(|| anyhow!("wait version not set"))?)
     }
 
-    pub async fn recover(&self) -> Result<()> {
-        let request = RecoverRequest {};
+    pub async fn recover(&self, database_id: Option<DatabaseId>) -> Result<()> {
+        let request = RecoverRequest {
+            database_id: database_id.map(|id| id.as_raw_id()),
+        };
         self.inner.recover(request).await?;
         Ok(())
     }

--- a/src/sqlparser/src/ast/mod.rs
+++ b/src/sqlparser/src/ast/mod.rs
@@ -1721,8 +1721,10 @@ pub enum Statement {
     Wait(WaitTarget),
     /// Trigger meta backup.
     Backup,
-    /// Trigger stream job recover
-    Recover,
+    /// Trigger streaming job recovery globally or for a database.
+    Recover {
+        database_name: Option<ObjectName>,
+    },
     /// `USE <db_name>`
     ///
     /// Note: this is a RisingWave specific statement and used to switch the current database.
@@ -2527,8 +2529,11 @@ impl Statement {
                 write!(f, "KILL '{}'", worker_process_id)?;
                 Ok(())
             }
-            Statement::Recover => {
+            Statement::Recover { database_name } => {
                 write!(f, "RECOVER")?;
+                if let Some(database_name) = database_name {
+                    write!(f, " {}", database_name)?;
+                }
                 Ok(())
             }
             Statement::Use { db_name } => {

--- a/src/sqlparser/src/parser.rs
+++ b/src/sqlparser/src/parser.rs
@@ -348,7 +348,11 @@ impl Parser<'_> {
                 Keyword::FLUSH => Ok(Statement::Flush),
                 Keyword::WAIT => Ok(self.parse_wait()?),
                 Keyword::BACKUP => Ok(Statement::Backup),
-                Keyword::RECOVER => Ok(Statement::Recover),
+                Keyword::RECOVER => Ok(Statement::Recover {
+                    database_name: matches!(self.peek_token().token, Token::Word(_))
+                        .then(|| self.parse_object_name())
+                        .transpose()?,
+                }),
                 Keyword::USE => Ok(self.parse_use()?),
                 Keyword::VACUUM => Ok(self.parse_vacuum()?),
                 _ => self.expected_at(checkpoint, "statement"),

--- a/src/sqlparser/tests/sqlparser_common.rs
+++ b/src/sqlparser/tests/sqlparser_common.rs
@@ -27,6 +27,28 @@ use risingwave_sqlparser::parser::ParserError;
 use risingwave_sqlparser::test_utils::*;
 
 #[test]
+fn parse_recover() {
+    assert_matches!(
+        verified_stmt("RECOVER"),
+        Statement::Recover {
+            database_name: None
+        }
+    );
+    assert_matches!(
+        verified_stmt("RECOVER my_database"),
+        Statement::Recover {
+            database_name: Some(name)
+        } if name.to_string() == "my_database"
+    );
+    assert_matches!(
+        verified_stmt("RECOVER \"Database.Name\""),
+        Statement::Recover {
+            database_name: Some(name)
+        } if name.to_string() == "\"Database.Name\""
+    );
+}
+
+#[test]
 fn parse_insert_values() {
     let row = vec![
         Expr::Value(number("1")),

--- a/src/tests/simulation/tests/integration_tests/scale/isolation.rs
+++ b/src/tests/simulation/tests/integration_tests/scale/isolation.rs
@@ -40,6 +40,44 @@ async fn assert_no_expected_global_recovery(session: &mut Session) -> Result<()>
 const MAX_HEARTBEAT_INTERVAL_SEC: u64 = 10;
 
 #[tokio::test]
+async fn test_adhoc_database_recovery() -> Result<()> {
+    let (_cluster, mut session) = prepare_isolation_env().await?;
+
+    session.run("use group1").await?;
+    session.run("create table t1 (v int)").await?;
+    session.run("use group2").await?;
+    session.run("create table t2 (v int)").await?;
+
+    let database_mapping = database_id_mapping(&mut session).await?;
+    let group1_database_id = database_mapping["group1"];
+    let group2_database_id = database_mapping["group2"];
+    let global_events_before = global_recovery_events(&mut session).await?;
+
+    session.run("recover group1").await?;
+
+    let mut database_events = database_recovery_events(&mut session).await?;
+    assert_eq!(
+        database_events.remove(&group1_database_id),
+        Some(vec![
+            DATABASE_RECOVERY_START.to_owned(),
+            DATABASE_RECOVERY_SUCCESS.to_owned(),
+        ])
+    );
+    assert!(!database_events.contains_key(&group2_database_id));
+    assert_eq!(
+        global_recovery_events(&mut session).await?,
+        global_events_before
+    );
+
+    session.run("use group1").await?;
+    session.run("insert into t1 values (1)").await?;
+    session.run("use group2").await?;
+    session.run("insert into t2 values (2)").await?;
+
+    Ok(())
+}
+
+#[tokio::test]
 async fn test_isolation_simple_two_databases() -> Result<()> {
     let (cluster, mut session) = prepare_isolation_env().await?;
 

--- a/src/utils/pgwire/src/pg_response.rs
+++ b/src/utils/pgwire/src/pg_response.rs
@@ -339,7 +339,7 @@ impl StatementType {
             Statement::Wait(_) => Ok(StatementType::WAIT),
             Statement::Backup => Ok(StatementType::BACKUP),
             Statement::DeleteMetaSnapshots { .. } => Ok(StatementType::DELETE_META_SNAPSHOTS),
-            Statement::Recover => Ok(StatementType::RECOVER),
+            Statement::Recover { .. } => Ok(StatementType::RECOVER),
             Statement::Use { .. } => Ok(StatementType::USE),
             Statement::Vacuum { .. } => Ok(StatementType::VACUUM),
             _ => Err("unsupported statement type".to_owned()),


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

Adds `RECOVER <database>` to recover one database while preserving bare `RECOVER` as global recovery.
The optional database ID is propagated through the frontend and meta RPC layers, and the barrier worker coordinates per-database recovery completion, including concurrent and overlapping recovery requests.

## Checklist

- [x] I have written necessary rustdoc comments.
- [x] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [x] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/dev/src/ci.md#ci-labels-guide -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [x] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

`RECOVER <database>` can now recover a single database without triggering global recovery; bare `RECOVER` retains its existing global behavior.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for recovering a specific database with `RECOVER <database_name>`.
  * Preserved global recovery through `RECOVER` without a database name.
  * Database-specific recovery now coordinates independently and avoids disrupting recovery already in progress.

* **Bug Fixes**
  * Improved recovery handling for databases without active streaming jobs.
  * Confirmed targeted recovery leaves other databases unaffected and writable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->