### PR TITLE
fix(ctl): flush CPU profile output before exit

### DIFF
--- a/src/ctl/src/cmd_impl/profile.rs
+++ b/src/ctl/src/cmd_impl/profile.rs
@@ -83,6 +83,7 @@ pub async fn cpu_profile(
                 Ok(ProfilingResponse { result }) => {
                     let mut file = File::create(dir_path_ref.join(svg_file_name)).await?;
                     file.write_all(&result).await?;
+                    file.flush().await?;
                 }
                 Err(err) => {
                     tracing::error!(


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What changed and what is your intention?

Flush the generated CPU-profile SVG before risectl returns, ensuring Tokio completes pending background filesystem writes before runtime shutdown. This prevents large profiles from being truncated and producing malformed SVG files. Validated with cargo fmt --all -- --check and cargo check -p risingwave_ctl.

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] I have added necessary unit tests and integration tests.
- [ ] I have added test labels as necessary.
- [ ] I have added fuzzing tests or opened an issue to track them.
- [ ] My PR contains breaking changes.
- [ ] My PR changes performance-critical code, so I will run benchmarks and present the results.
- [ ] I have checked the release timeline and supported versions for required cherry-picks.

## Documentation

- [ ] My PR needs documentation updates.

<details>
<summary><b>Release note</b></summary>

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * CPU profiling now flushes newly generated SVG files before the profiling task completes, improving file availability and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->