### PR TITLE
ci(pubsub): update expired emulator image

### DIFF
--- a/ci/docker-compose.yml
+++ b/ci/docker-compose.yml
@@ -184,7 +184,7 @@ services:
       retries: 5
 
   pubsub-emulator:
-    image: gcr.io/google.com/cloudsdktool/google-cloud-cli:475.0.0-emulators
+    image: gcr.io/google.com/cloudsdktool/google-cloud-cli:583.0.0-emulators
     command: >
       gcloud beta emulators pubsub start --project=demo --host-port=0.0.0.0:8900
     ports:


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

The Google Cloud CLI registry enforces a one-year retention window. The pinned `475.0.0-emulators` image has been removed upstream, so Docker Compose can no longer start its dependencies. This is currently failing nine jobs in each main-cron run, including source, sink, Pub/Sub, backfill, and Delta Lake tests:

- https://buildkite.com/risingwavelabs/main-cron/builds/9922
- https://buildkite.com/risingwavelabs/main-cron/builds/9930
- https://buildkite.com/risingwavelabs/main-cron/builds/9931

Update the Pub/Sub emulator image to the current versioned `583.0.0-emulators` tag. Its OCI image index is available for both linux/amd64 and linux/arm64.

Upstream retention policy: https://github.com/GoogleCloudPlatform/cloud-sdk-docker#package-retention-policy

## Checklist

- [x] I have written necessary rustdoc comments.
- [x] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [x] <!-- OPTIONAL --> I have added necessary test labels as necessary.
- [x] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them.
- [x] <!-- OPTIONAL --> My PR contains breaking changes.
- [x] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run benchmarks.
- [x] <!-- OPTIONAL --> I have checked the release timeline and supported versions.

## Testing

- `BUILD_ENV_VERSION=validation docker compose -f ci/docker-compose.yml config --quiet`
- Verified the registry manifest for `583.0.0-emulators`; it is an OCI index containing linux/amd64 and linux/arm64 images.

## Documentation

- [x] <!-- OPTIONAL --> My PR needs documentation updates.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Pub/Sub emulator environment to use a newer Google Cloud CLI image version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->