### PR TITLE
fix(connector): ack Pulsar messages for every split (#26892)

### DIFF
--- a/src/connector/src/source/mod.rs
+++ b/src/connector/src/source/mod.rs
@@ -60,6 +60,7 @@ pub mod pulsar;
 pub mod utils;
 
 mod util;
+use std::collections::HashMap;
 use std::future::IntoFuture;
 use std::time::Duration;
 
@@ -187,14 +188,24 @@ impl WaitCheckpointTask {
                 }
             }
             WaitCheckpointTask::AckPulsarMessage(ack_array) => {
-                if let Some((ack_channel_id, to_cumulative_ack)) = ack_array.last() {
-                    let Some(encode_message_id_data) = to_cumulative_ack
+                let mut latest_ack_by_channel = HashMap::new();
+                for (ack_channel_id, to_cumulative_ack) in ack_array {
+                    let encode_message_id_data = to_cumulative_ack
                         .as_bytea()
                         .iter()
-                        .last()
                         .flatten()
-                        .map(|x| x.to_owned())
-                    else {
+                        .last()
+                        .map(|message_id| message_id.to_owned());
+
+                    if let Some(encode_message_id_data) = encode_message_id_data {
+                        latest_ack_by_channel.insert(ack_channel_id, Some(encode_message_id_data));
+                    } else {
+                        latest_ack_by_channel.entry(ack_channel_id).or_insert(None);
+                    }
+                }
+
+                for (ack_channel_id, encode_message_id_data) in latest_ack_by_channel {
+                    let Some(encode_message_id_data) = encode_message_id_data else {
                         GLOBAL_SOURCE_METRICS.inc_connector_ack_failure_count(
                             source_name,
                             "pulsar",
@@ -204,12 +215,12 @@ impl WaitCheckpointTask {
                             source_id = source_id_label,
                             source_name,
                             ack_channel_id,
-                            "skip Pulsar ack because the checkpoint ack batch has no message id",
+                            "skip Pulsar ack because the checkpoint ack batches have no message id",
                         );
-                        return;
+                        continue;
                     };
 
-                    let Some(ack_tx) = PULSAR_ACK_CHANNEL.lock().get(ack_channel_id).cloned()
+                    let Some(ack_tx) = PULSAR_ACK_CHANNEL.lock().get(&ack_channel_id).cloned()
                     else {
                         GLOBAL_SOURCE_METRICS.inc_connector_ack_failure_count(
                             source_name,
@@ -222,7 +233,7 @@ impl WaitCheckpointTask {
                             ack_channel_id,
                             "skip Pulsar ack because the ack channel is missing",
                         );
-                        return;
+                        continue;
                     };
 
                     if let Err(e) = ack_tx.send(encode_message_id_data) {
@@ -424,9 +435,10 @@ pub fn build_pulsar_ack_channel_id(
 
 #[cfg(test)]
 mod tests {
-    use risingwave_pb::id::{ActorId, SourceId};
+    use risingwave_common::array::{Array, BytesArray};
+    use tokio::sync::mpsc::error::TryRecvError;
 
-    use super::{SplitId, build_pulsar_ack_channel_id};
+    use super::*;
 
     #[test]
     fn test_pulsar_ack_channel_id_is_actor_scoped() {
@@ -437,5 +449,56 @@ mod tests {
         let second = build_pulsar_ack_channel_id(source_id, &split_id, ActorId::new(12));
 
         assert_ne!(first, second);
+    }
+
+    fn message_ids<const N: usize>(values: [Option<&[u8]>; N]) -> ArrayRef {
+        BytesArray::from_iter(values).into_ref()
+    }
+
+    #[tokio::test]
+    async fn test_ack_pulsar_message_for_each_split() {
+        let split_0_channel = "test-pulsar-ack-multiple-splits-0".to_owned();
+        let split_1_channel = "test-pulsar-ack-multiple-splits-1".to_owned();
+        let empty_split_channel = "test-pulsar-ack-multiple-splits-empty".to_owned();
+        let (split_0_tx, mut split_0_rx) = tokio::sync::mpsc::unbounded_channel();
+        let (split_1_tx, mut split_1_rx) = tokio::sync::mpsc::unbounded_channel();
+        let (empty_split_tx, mut empty_split_rx) = tokio::sync::mpsc::unbounded_channel();
+
+        PULSAR_ACK_CHANNEL
+            .lock()
+            .insert(split_0_channel.clone(), split_0_tx);
+        PULSAR_ACK_CHANNEL
+            .lock()
+            .insert(split_1_channel.clone(), split_1_tx);
+        PULSAR_ACK_CHANNEL
+            .lock()
+            .insert(empty_split_channel.clone(), empty_split_tx);
+
+        WaitCheckpointTask::AckPulsarMessage(vec![
+            (split_0_channel.clone(), message_ids([Some(b"split-0-old")])),
+            (
+                split_1_channel.clone(),
+                message_ids([Some(b"split-1-latest"), None]),
+            ),
+            (
+                split_0_channel.clone(),
+                message_ids([Some(b"split-0-latest")]),
+            ),
+            (split_0_channel.clone(), message_ids([None])),
+            (empty_split_channel.clone(), message_ids([None, None])),
+        ])
+        .run(SourceId::new(26891), "test_pulsar_source")
+        .await;
+
+        assert_eq!(split_0_rx.try_recv().unwrap(), b"split-0-latest");
+        assert_eq!(split_0_rx.try_recv(), Err(TryRecvError::Empty));
+        assert_eq!(split_1_rx.try_recv().unwrap(), b"split-1-latest");
+        assert_eq!(split_1_rx.try_recv(), Err(TryRecvError::Empty));
+        assert_eq!(empty_split_rx.try_recv(), Err(TryRecvError::Empty));
+
+        let mut ack_channels = PULSAR_ACK_CHANNEL.lock();
+        ack_channels.remove(&split_0_channel);
+        ack_channels.remove(&split_1_channel);
+        ack_channels.remove(&empty_split_channel);
     }
 }

--- a/src/stream/src/executor/source/source_executor.rs
+++ b/src/stream/src/executor/source/source_executor.rs
@@ -1018,19 +1018,27 @@ impl<S: StateStore> SourceExecutor<S> {
 
                     if let Some(task_builder) = &mut wait_checkpoint_task_builder {
                         if let Some(pulsar_message_id_idx) = pulsar_message_id_idx {
-                            let pulsar_message_id_col = chunk.column_at(pulsar_message_id_idx);
-                            task_builder.update_task_on_chunk(
-                                self.actor_ctx.id,
-                                source_id,
-                                &latest_state,
-                                pulsar_message_id_col.clone(),
-                            );
+                            if chunk.capacity() > 0 {
+                                // Each Pulsar chunk comes from one split, so all rows have the same
+                                // split ID.
+                                let (_, row, _) = chunk.row_at(0);
+                                let split_id = SplitId::from(
+                                    row.datum_at(split_idx).unwrap().into_utf8().to_owned(),
+                                );
+                                let pulsar_message_id_col = chunk.column_at(pulsar_message_id_idx);
+                                task_builder.update_task_on_chunk(
+                                    self.actor_ctx.id,
+                                    source_id,
+                                    Some(&split_id),
+                                    pulsar_message_id_col.clone(),
+                                );
+                            }
                         } else {
                             let offset_col = chunk.column_at(offset_idx);
                             task_builder.update_task_on_chunk(
                                 self.actor_ctx.id,
                                 source_id,
-                                &latest_state,
+                                None,
                                 offset_col.clone(),
                             );
                         }
@@ -1120,7 +1128,7 @@ impl WaitCheckpointTaskBuilder {
         &mut self,
         actor_id: ActorId,
         source_id: SourceId,
-        latest_state: &HashMap<SplitId, SplitImpl>,
+        pulsar_split_id: Option<&SplitId>,
         offset_col: ArrayRef,
     ) {
         match &mut self.building_task {
@@ -1131,8 +1139,7 @@ impl WaitCheckpointTaskBuilder {
                 arrays.push(offset_col);
             }
             WaitCheckpointTask::AckPulsarMessage(arrays) => {
-                // each pulsar chunk will only contain one split
-                let split_id = latest_state.keys().next().unwrap();
+                let split_id = pulsar_split_id.expect("Pulsar chunk must have a split ID");
                 let pulsar_ack_channel_id =
                     build_pulsar_ack_channel_id(source_id, split_id, actor_id);
                 arrays.push((pulsar_ack_channel_id, offset_col));
@@ -1275,6 +1282,7 @@ impl<S: StateStore> WaitCheckpointWorker<S> {
 #[cfg(test)]
 mod tests {
     use maplit::{btreemap, convert_args, hashmap};
+    use risingwave_common::array::{Array, BytesArray};
     use risingwave_common::catalog::{ColumnId, Field};
     use risingwave_common::id::SourceId;
     use risingwave_common::system_param::local_manager::LocalSystemParamsManager;
@@ -1294,6 +1302,59 @@ mod tests {
     use crate::task::LocalBarrierManager;
 
     const MOCK_SOURCE_NAME: &str = "mock_source";
+
+    fn message_ids<const N: usize>(values: [Option<&[u8]>; N]) -> ArrayRef {
+        BytesArray::from_iter(values).into_ref()
+    }
+
+    #[test]
+    fn test_build_pulsar_ack_task_for_interleaved_splits() {
+        let (wait_checkpoint_tx, _wait_checkpoint_rx) = unbounded_channel();
+        let mut builder = WaitCheckpointTaskBuilder {
+            wait_checkpoint_tx,
+            building_task: WaitCheckpointTask::AckPulsarMessage(vec![]),
+        };
+        let actor_id = ActorId::new(11);
+        let source_id = SourceId::new(7);
+        let split_a = SplitId::from("persistent://public/default/topic-a");
+        let split_b = SplitId::from("persistent://public/default/topic-b");
+
+        builder.update_task_on_chunk(
+            actor_id,
+            source_id,
+            Some(&split_a),
+            message_ids([Some(b"a-0")]),
+        );
+        builder.update_task_on_chunk(
+            actor_id,
+            source_id,
+            Some(&split_b),
+            message_ids([Some(b"b-0")]),
+        );
+        builder.update_task_on_chunk(
+            actor_id,
+            source_id,
+            Some(&split_a),
+            message_ids([Some(b"a-1")]),
+        );
+
+        let WaitCheckpointTask::AckPulsarMessage(ack_arrays) = builder.building_task else {
+            unreachable!();
+        };
+        let channel_ids = ack_arrays
+            .into_iter()
+            .map(|(channel_id, _)| channel_id)
+            .collect_vec();
+
+        assert_eq!(
+            channel_ids,
+            vec![
+                build_pulsar_ack_channel_id(source_id, &split_a, actor_id),
+                build_pulsar_ack_channel_id(source_id, &split_b, actor_id),
+                build_pulsar_ack_channel_id(source_id, &split_a, actor_id),
+            ]
+        );
+    }
 
     #[tokio::test]
     async fn test_source_executor() {


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

Backports #26892 to `release-3.1`. It records the split ID from each Pulsar chunk and keeps the latest message ID per ACK channel so checkpoints acknowledge every split.

- Closes #26954

## Checklist

- [ ] I have written necessary rustdoc comments.
- [x] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [x] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/dev/src/ci.md#ci-labels-guide -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [x] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->

## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Pulsar checkpoint acknowledgments to process all message batches and retain the latest position for each channel.
  - Checkpoint processing now continues when messages or channel information are missing, rather than stopping prematurely.
  - Fixed checkpoint tracking for interleaved data from multiple splits, ensuring acknowledgments are assigned to the correct channel.
  - Improved handling of empty messages and verified acknowledgment behavior across multiple splits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->