### PR TITLE
fix(stream): recover parallel CDC snapshot readers after errors

### DIFF
--- a/src/common/src/array/data_chunk.rs
+++ b/src/common/src/array/data_chunk.rs
@@ -145,6 +145,11 @@ impl DataChunk {
         self.visibility.count_ones()
     }
 
+    /// Returns whether this chunk contains at least one visible row.
+    pub fn has_visible_rows(&self) -> bool {
+        self.visibility.any()
+    }
+
     // Compute the required permits of this chunk for rate limiting.
     pub fn rate_limit_permits(&self) -> u64 {
         self.cardinality() as _

--- a/src/compute/tests/cdc_tests.rs
+++ b/src/compute/tests/cdc_tests.rs
@@ -718,29 +718,7 @@ async fn test_parallelized_cdc_backfill() {
         materialize.next().await.unwrap().unwrap(),
         Message::Chunk(_)
     ));
-    send_and_poll_barrier(&mut curr_epoch, &mut tx, &mut materialize).await;
-    assert_mv(
-        DataChunk::from_pretty(
-            "I F
-            1 11.00
-            2 22.00
-            5 1.0005
-            6 1.0006
-            8 1.0008",
-        )
-        .into(),
-        &table_schema,
-        memory_state_store.clone(),
-        materialize_table_id,
-    )
-    .await;
-
-    // The backfill executor should process first WAL buffered previously.
-    assert!(matches!(
-        materialize.next().await.unwrap().unwrap(),
-        Message::Chunk(_)
-    ));
-    send_and_poll_barrier(&mut curr_epoch, &mut tx, &mut materialize).await;
+    send_and_poll_chunk_then_barrier(&mut curr_epoch, &mut tx, &mut materialize).await;
     assert_mv(
         DataChunk::from_pretty(
             "I F
@@ -996,33 +974,7 @@ async fn test_parallelized_cdc_backfill_reschedule() {
         materialize.next().await.unwrap().unwrap(),
         Message::Chunk(_)
     ));
-    send_and_poll_barrier(&mut curr_epoch, &mut tx, &mut materialize).await;
-    // Rows in the active split stay buffered until that split is closed.
-    assert_mv(
-        DataChunk::from_pretty(
-            "I F
-            1 10.01
-            2 22.22
-            3 3.03
-            4 4.04
-            5 5.05
-            6 10.08
-            8 1.0008
-            400 400.1",
-        )
-        .into(),
-        &table_schema,
-        memory_state_store.clone(),
-        materialize_table_id,
-    )
-    .await;
-
-    assert!(matches!(
-        materialize.next().await.unwrap().unwrap(),
-        Message::Chunk(_)
-    ));
-    send_and_poll_barrier(&mut curr_epoch, &mut tx, &mut materialize).await;
-    // The buffered rows for split 2 have been consumed.
+    send_and_poll_chunk_then_barrier(&mut curr_epoch, &mut tx, &mut materialize).await;
     assert_mv(
         DataChunk::from_pretty(
             "I F
@@ -1052,6 +1004,26 @@ async fn send_and_poll_barrier(
 ) {
     curr_epoch.inc_epoch();
     tx.push_barrier(*curr_epoch, false);
+    assert!(matches!(
+        materialize.next().await.unwrap().unwrap(),
+        Message::Barrier(Barrier {
+            epoch,
+            ..
+        }) if epoch.curr == *curr_epoch
+    ));
+}
+
+async fn send_and_poll_chunk_then_barrier(
+    curr_epoch: &mut u64,
+    tx: &mut MessageSender,
+    materialize: &mut BoxedMessageStream,
+) {
+    curr_epoch.inc_epoch();
+    tx.push_barrier(*curr_epoch, false);
+    assert!(matches!(
+        materialize.next().await.unwrap().unwrap(),
+        Message::Chunk(_)
+    ));
     assert!(matches!(
         materialize.next().await.unwrap().unwrap(),
         Message::Barrier(Barrier {

--- a/src/connector/src/source/cdc/external/mock_external_table.rs
+++ b/src/connector/src/source/cdc/external/mock_external_table.rs
@@ -12,12 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::cmp::Ordering as CmpOrdering;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
 use futures::stream::BoxStream;
 use futures_async_stream::try_stream;
 use risingwave_common::catalog::Field;
-use risingwave_common::row::OwnedRow;
+use risingwave_common::row::{OwnedRow, Row};
 use risingwave_common::types::{DataType, ScalarImpl};
 use risingwave_common::util::sort_util::{OrderType, cmp_datum};
 
@@ -34,6 +35,7 @@ pub struct MockExternalTableReader {
     snapshot_errors_remaining: AtomicUsize,
     cdc_offset_idx: AtomicUsize,
     parallel_backfill_snapshots: Vec<OwnedRow>,
+    parallel_backfill_pk_indices: Vec<usize>,
 }
 
 impl MockExternalTableReader {
@@ -89,6 +91,7 @@ impl MockExternalTableReader {
             snapshot_cnt: AtomicUsize::new(0),
             snapshot_errors_remaining: AtomicUsize::new(0),
             parallel_backfill_snapshots,
+            parallel_backfill_pk_indices: vec![0],
             cdc_offset_idx: AtomicUsize::new(0),
         }
     }
@@ -172,16 +175,48 @@ impl MockExternalTableReader {
     }
 
     #[try_stream(boxed, ok = OwnedRow, error = ConnectorError)]
-    async fn split_snapshot_read_inner(&self, left: OwnedRow, right: OwnedRow) {
+    async fn split_snapshot_read_inner(
+        &self,
+        start_pk: Option<OwnedRow>,
+        left: Option<OwnedRow>,
+        right: Option<OwnedRow>,
+    ) {
         self.take_snapshot_error()?;
-        for row in &self.parallel_backfill_snapshots {
-            if (left[0].is_none()
-                || cmp_datum(&row[0], &left[0], OrderType::ascending_nulls_first()).is_ge())
-                && (right[0].is_none()
-                    || cmp_datum(&row[0], &right[0], OrderType::ascending_nulls_first()).is_lt())
-            {
-                yield row.clone();
-            }
+        let compare_pk = |row: &OwnedRow, cursor: &OwnedRow| {
+            self.parallel_backfill_pk_indices
+                .iter()
+                .zip(cursor.iter())
+                .find_map(|(&idx, cursor_datum)| {
+                    let ordering =
+                        cmp_datum(&row[idx], cursor_datum, OrderType::ascending_nulls_first());
+                    (ordering != CmpOrdering::Equal).then_some(ordering)
+                })
+                .unwrap_or(CmpOrdering::Equal)
+        };
+        let mut rows = self
+            .parallel_backfill_snapshots
+            .iter()
+            .filter(|row| {
+                left.as_ref().is_none_or(|left| {
+                    cmp_datum(&row[0], &left[0], OrderType::ascending_nulls_first()).is_ge()
+                }) && right.as_ref().is_none_or(|right| {
+                    cmp_datum(&row[0], &right[0], OrderType::ascending_nulls_first()).is_lt()
+                }) && start_pk
+                    .as_ref()
+                    .is_none_or(|cursor| compare_pk(row, cursor).is_gt())
+            })
+            .collect::<Vec<_>>();
+        rows.sort_by(|left, right| {
+            let right_pk = OwnedRow::new(
+                self.parallel_backfill_pk_indices
+                    .iter()
+                    .map(|&idx| right[idx].clone())
+                    .collect(),
+            );
+            compare_pk(left, &right_pk)
+        });
+        for row in rows {
+            yield row.clone();
         }
     }
 }
@@ -219,12 +254,14 @@ impl ExternalTableReader for MockExternalTableReader {
     fn split_snapshot_read(
         &self,
         _table_name: SchemaTableName,
-        left: OwnedRow,
-        right: OwnedRow,
+        start_pk: Option<OwnedRow>,
+        _primary_keys: Vec<String>,
+        left: Option<OwnedRow>,
+        right: Option<OwnedRow>,
         split_columns: Vec<Field>,
     ) -> BoxStream<'_, ConnectorResult<OwnedRow>> {
         assert_eq!(split_columns.len(), 1);
         assert_eq!(split_columns[0].data_type, DataType::Int64);
-        self.split_snapshot_read_inner(left, right)
+        self.split_snapshot_read_inner(start_pk, left, right)
     }
 }

--- a/src/connector/src/source/cdc/external/mock_external_table.rs
+++ b/src/connector/src/source/cdc/external/mock_external_table.rs
@@ -20,6 +20,7 @@ use futures_async_stream::try_stream;
 use risingwave_common::catalog::Field;
 use risingwave_common::row::{OwnedRow, Row};
 use risingwave_common::types::{DataType, ScalarImpl};
+use risingwave_common::util::iter_util::ZipEqFast;
 use risingwave_common::util::sort_util::{OrderType, cmp_datum};
 
 use crate::error::{ConnectorError, ConnectorResult};
@@ -187,7 +188,7 @@ impl MockExternalTableReader {
             self.parallel_backfill_pk_indices
                 .iter()
                 .map(|&idx| row.datum_at(idx))
-                .zip(cursor.iter())
+                .zip_eq_fast(cursor.iter())
                 .find_map(|(row_datum, cursor_datum)| {
                     let ordering =
                         cmp_datum(row_datum, cursor_datum, OrderType::ascending_nulls_first());

--- a/src/connector/src/source/cdc/external/mock_external_table.rs
+++ b/src/connector/src/source/cdc/external/mock_external_table.rs
@@ -182,17 +182,21 @@ impl MockExternalTableReader {
         right: Option<OwnedRow>,
     ) {
         self.take_snapshot_error()?;
+
         let compare_pk = |row: &OwnedRow, cursor: &OwnedRow| {
             self.parallel_backfill_pk_indices
                 .iter()
+                .map(|&idx| row.datum_at(idx))
                 .zip(cursor.iter())
-                .find_map(|(&idx, cursor_datum)| {
+                .find_map(|(row_datum, cursor_datum)| {
                     let ordering =
-                        cmp_datum(&row[idx], cursor_datum, OrderType::ascending_nulls_first());
+                        cmp_datum(row_datum, cursor_datum, OrderType::ascending_nulls_first());
+
                     (ordering != CmpOrdering::Equal).then_some(ordering)
                 })
                 .unwrap_or(CmpOrdering::Equal)
         };
+
         let mut rows = self
             .parallel_backfill_snapshots
             .iter()
@@ -206,15 +210,22 @@ impl MockExternalTableReader {
                     .is_none_or(|cursor| compare_pk(row, cursor).is_gt())
             })
             .collect::<Vec<_>>();
+
         rows.sort_by(|left, right| {
-            let right_pk = OwnedRow::new(
-                self.parallel_backfill_pk_indices
-                    .iter()
-                    .map(|&idx| right[idx].clone())
-                    .collect(),
-            );
-            compare_pk(left, &right_pk)
+            self.parallel_backfill_pk_indices
+                .iter()
+                .find_map(|&idx| {
+                    let ordering = cmp_datum(
+                        left.datum_at(idx),
+                        right.datum_at(idx),
+                        OrderType::ascending_nulls_first(),
+                    );
+
+                    (ordering != CmpOrdering::Equal).then_some(ordering)
+                })
+                .unwrap_or(CmpOrdering::Equal)
         });
+
         for row in rows {
             yield row.clone();
         }

--- a/src/connector/src/source/cdc/external/mod.rs
+++ b/src/connector/src/source/cdc/external/mod.rs
@@ -265,8 +265,10 @@ pub trait ExternalTableReader: Sized {
     fn split_snapshot_read(
         &self,
         table_name: SchemaTableName,
-        left: OwnedRow,
-        right: OwnedRow,
+        start_pk: Option<OwnedRow>,
+        primary_keys: Vec<String>,
+        left: Option<OwnedRow>,
+        right: Option<OwnedRow>,
         split_columns: Vec<Field>,
     ) -> BoxStream<'_, ConnectorResult<OwnedRow>>;
 }
@@ -383,11 +385,20 @@ impl ExternalTableReader for ExternalTableReaderImpl {
     fn split_snapshot_read(
         &self,
         table_name: SchemaTableName,
-        left: OwnedRow,
-        right: OwnedRow,
+        start_pk: Option<OwnedRow>,
+        primary_keys: Vec<String>,
+        left: Option<OwnedRow>,
+        right: Option<OwnedRow>,
         split_columns: Vec<Field>,
     ) -> BoxStream<'_, ConnectorResult<OwnedRow>> {
-        self.split_snapshot_read_inner(table_name, left, right, split_columns)
+        self.split_snapshot_read_inner(
+            table_name,
+            start_pk,
+            primary_keys,
+            left,
+            right,
+            split_columns,
+        )
     }
 }
 
@@ -471,23 +482,45 @@ impl ExternalTableReaderImpl {
     async fn split_snapshot_read_inner(
         &self,
         table_name: SchemaTableName,
-        left: OwnedRow,
-        right: OwnedRow,
+        start_pk: Option<OwnedRow>,
+        primary_keys: Vec<String>,
+        left: Option<OwnedRow>,
+        right: Option<OwnedRow>,
         split_columns: Vec<Field>,
     ) {
         let stream = match self {
-            ExternalTableReaderImpl::MySql(mysql) => {
-                mysql.split_snapshot_read(table_name, left, right, split_columns)
-            }
-            ExternalTableReaderImpl::Postgres(postgres) => {
-                postgres.split_snapshot_read(table_name, left, right, split_columns)
-            }
-            ExternalTableReaderImpl::SqlServer(sql_server) => {
-                sql_server.split_snapshot_read(table_name, left, right, split_columns)
-            }
-            ExternalTableReaderImpl::Mock(mock) => {
-                mock.split_snapshot_read(table_name, left, right, split_columns)
-            }
+            ExternalTableReaderImpl::MySql(mysql) => mysql.split_snapshot_read(
+                table_name,
+                start_pk,
+                primary_keys,
+                left,
+                right,
+                split_columns,
+            ),
+            ExternalTableReaderImpl::Postgres(postgres) => postgres.split_snapshot_read(
+                table_name,
+                start_pk,
+                primary_keys,
+                left,
+                right,
+                split_columns,
+            ),
+            ExternalTableReaderImpl::SqlServer(sql_server) => sql_server.split_snapshot_read(
+                table_name,
+                start_pk,
+                primary_keys,
+                left,
+                right,
+                split_columns,
+            ),
+            ExternalTableReaderImpl::Mock(mock) => mock.split_snapshot_read(
+                table_name,
+                start_pk,
+                primary_keys,
+                left,
+                right,
+                split_columns,
+            ),
         };
 
         pin_mut!(stream);

--- a/src/connector/src/source/cdc/external/mysql.rs
+++ b/src/connector/src/source/cdc/external/mysql.rs
@@ -515,8 +515,10 @@ impl ExternalTableReader for MySqlExternalTableReader {
     fn split_snapshot_read(
         &self,
         _table_name: SchemaTableName,
-        _left: OwnedRow,
-        _right: OwnedRow,
+        _start_pk: Option<OwnedRow>,
+        _primary_keys: Vec<String>,
+        _left: Option<OwnedRow>,
+        _right: Option<OwnedRow>,
         _split_columns: Vec<Field>,
     ) -> BoxStream<'_, ConnectorResult<OwnedRow>> {
         todo!("implement MySQL CDC parallelized backfill")

--- a/src/connector/src/source/cdc/external/postgres.rs
+++ b/src/connector/src/source/cdc/external/postgres.rs
@@ -221,12 +221,21 @@ impl ExternalTableReader for PostgresExternalTableReader {
     fn split_snapshot_read(
         &self,
         table_name: SchemaTableName,
-        left: OwnedRow,
-        right: OwnedRow,
+        start_pk: Option<OwnedRow>,
+        primary_keys: Vec<String>,
+        left: Option<OwnedRow>,
+        right: Option<OwnedRow>,
         split_columns: Vec<Field>,
     ) -> BoxStream<'_, ConnectorResult<OwnedRow>> {
         assert_eq!(table_name, self.schema_table_name);
-        self.split_snapshot_read_inner(table_name, left, right, split_columns)
+        self.split_snapshot_read_inner(
+            table_name,
+            start_pk,
+            primary_keys,
+            left,
+            right,
+            split_columns,
+        )
     }
 }
 
@@ -608,63 +617,106 @@ impl PostgresExternalTableReader {
     async fn split_snapshot_read_inner(
         &self,
         table_name: SchemaTableName,
-        left: OwnedRow,
-        right: OwnedRow,
+        start_pk: Option<OwnedRow>,
+        primary_keys: Vec<String>,
+        left: Option<OwnedRow>,
+        right: Option<OwnedRow>,
         split_columns: Vec<Field>,
     ) {
+        // Build and execute the split snapshot query in two phases. Conceptually, the complete
+        // SQL is (`[...]` marks an optional clause):
+        //
+        // SELECT <selected_columns>
+        // FROM <upstream_table>
+        // WHERE <split_filter>
+        // [AND (<primary_key_columns>) > (<resume_pk_params>)]
+        // ORDER BY <primary_key_columns>
+        //
+        // `<split_filter>` is exactly one of:
+        // - `1 = 1` when both bounds are absent;
+        // - `(<split_columns>) < (<right_bound_params>)` for the first split;
+        // - `(<split_columns>) >= (<left_bound_params>)` for the last split;
+        // - `(<split_columns>) >= (<left_bound_params>) AND
+        //    (<split_columns>) < (<right_bound_params>)` for a middle split.
+        //
+        // First prepare this template with PostgreSQL's positional placeholders (`$1`, `$2`,
+        // ...), then bind values in placeholder order:
+        // [left_bound_values..., right_bound_values..., resume_pk_values...].
+
         assert_eq!(
             split_columns.len(),
             1,
             "multiple split columns is not supported yet"
         );
-        assert_eq!(left.len(), 1, "multiple split columns is not supported yet");
-        assert_eq!(
-            right.len(),
-            1,
+        assert!(
+            left.as_ref().is_none_or(|left| left.len() == 1),
             "multiple split columns is not supported yet"
         );
-        let is_first_split = left[0].is_none();
-        let is_last_split = right[0].is_none();
+        assert!(
+            right.as_ref().is_none_or(|right| right.len() == 1),
+            "multiple split columns is not supported yet"
+        );
+        let is_first_split = left.is_none();
+        let is_last_split = right.is_none();
         let split_column_names = split_columns.iter().map(|c| c.name.clone()).collect_vec();
         let client = self.client.lock().await;
         client.execute("set time zone '+00:00'", &[]).await?;
         // prepare the scan statement, since we may need to convert the RW data type to postgres data type
         // e.g. varchar to uuid
         let prepared_scan_stmt = {
+            let split_filter =
+                Self::split_filter_expression(&split_column_names, is_first_split, is_last_split);
+            let split_param_count =
+                (!is_first_split as usize + !is_last_split as usize) * split_columns.len();
+            let resume_filter = start_pk.is_some().then(|| {
+                let columns = primary_keys
+                    .iter()
+                    .map(|column| Self::quote_column(column))
+                    .join(", ");
+                let params = (1..=primary_keys.len())
+                    .map(|idx| format!("${}", split_param_count + idx))
+                    .join(", ");
+
+                format!("({columns}) > ({params})")
+            });
+
+            let filter = match resume_filter {
+                Some(resume_filter) => format!("({split_filter}) AND ({resume_filter})"),
+                None => split_filter,
+            };
+            let order_key = Self::get_order_key(&primary_keys);
             let scan_sql = format!(
-                "SELECT {} FROM {} WHERE {}",
+                "SELECT {} FROM {} WHERE {} ORDER BY {}",
                 self.field_names,
                 Self::get_normalized_table_name(&table_name),
-                Self::split_filter_expression(&split_column_names, is_first_split, is_last_split),
+                filter,
+                order_key,
             );
+
             client.prepare(&scan_sql).await?
         };
 
-        let mut params: Vec<Option<ScalarAdapter>> = vec![];
-        if !is_first_split {
-            let left_params: Vec<Option<ScalarAdapter>> = left
-                .iter()
-                .zip_eq_fast(prepared_scan_stmt.params().iter().take(left.len()))
-                .map(|(datum, ty)| {
-                    datum
-                        .map(|scalar| ScalarAdapter::from_scalar(scalar, ty))
-                        .transpose()
-                })
-                .try_collect()?;
-            params.extend(left_params);
-        }
-        if !is_last_split {
-            let right_params: Vec<Option<ScalarAdapter>> = right
-                .iter()
-                .zip_eq_fast(prepared_scan_stmt.params().iter().skip(params.len()))
-                .map(|(datum, ty)| {
-                    datum
-                        .map(|scalar| ScalarAdapter::from_scalar(scalar, ty))
-                        .transpose()
-                })
-                .try_collect()?;
-            params.extend(right_params);
-        }
+        let param_values = [left.as_ref(), right.as_ref(), start_pk.as_ref()]
+            .into_iter()
+            .flatten()
+            .flat_map(|row| row.iter())
+            .collect_vec();
+
+        assert_eq!(
+            param_values.len(),
+            prepared_scan_stmt.params().len(),
+            "split snapshot query parameter count must match its bound value count",
+        );
+
+        let params: Vec<Option<ScalarAdapter>> = param_values
+            .into_iter()
+            .zip_eq_fast(prepared_scan_stmt.params())
+            .map(|(datum, ty)| {
+                datum
+                    .map(|scalar| ScalarAdapter::from_scalar(scalar, ty))
+                    .transpose()
+            })
+            .try_collect()?;
 
         let stream = client.query_raw(&prepared_scan_stmt, &params).await?;
         let row_stream = stream.map(|row| {

--- a/src/connector/src/source/cdc/external/sql_server.rs
+++ b/src/connector/src/source/cdc/external/sql_server.rs
@@ -289,8 +289,10 @@ impl ExternalTableReader for SqlServerExternalTableReader {
     fn split_snapshot_read(
         &self,
         _table_name: SchemaTableName,
-        _left: OwnedRow,
-        _right: OwnedRow,
+        _start_pk: Option<OwnedRow>,
+        _primary_keys: Vec<String>,
+        _left: Option<OwnedRow>,
+        _right: Option<OwnedRow>,
         _split_columns: Vec<Field>,
     ) -> BoxStream<'_, ConnectorResult<OwnedRow>> {
         todo!("implement SqlServer CDC parallelized backfill")

--- a/src/frontend/src/optimizer/plan_node/stream_cdc_table_scan.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_cdc_table_scan.rs
@@ -70,7 +70,7 @@ impl StreamCdcTableScan {
     /// schema: | `split_id` | `pk...` | `backfill_finished` | `row_count` | `cdc_offset` |
     ///
     /// For parallelized cdc backfill:
-    /// schema: | `split_id` | `pk...` | `backfill_finished` | `row_count` | `cdc_offset_low` | `cdc_offset_high` |
+    /// schema: | `split_id` | `backfill_finished` | `row_count` | `cdc_offset_low` | `cdc_offset_high` | `pk...` |
     pub fn build_backfill_state_catalog(
         &self,
         state: &mut BuildFragmentGraphState,
@@ -78,14 +78,23 @@ impl StreamCdcTableScan {
     ) -> TableCatalog {
         if is_parallelized_backfill {
             let mut catalog_builder = TableCatalogBuilder::default();
+            let upstream_schema = &self.core.get_table_columns();
             // Use `split_id` as primary key in state table.
             catalog_builder.add_column(&Field::with_name(DataType::Int64, "split_id"));
             catalog_builder.add_order_column(0, OrderType::ascending());
+
             catalog_builder.add_column(&Field::with_name(DataType::Boolean, "backfill_finished"));
             // `row_count` column, the number of rows read from snapshot
             catalog_builder.add_column(&Field::with_name(DataType::Int64, "row_count"));
             catalog_builder.add_column(&Field::with_name(DataType::Jsonb, "cdc_offset_low"));
             catalog_builder.add_column(&Field::with_name(DataType::Jsonb, "cdc_offset_high"));
+
+            // pk columns
+            for col_order in self.core.primary_key() {
+                let col = &upstream_schema[col_order.column_index];
+                catalog_builder.add_column(&Field::from(col));
+            }
+
             catalog_builder
                 .build(vec![], 1)
                 .with_id(state.gen_table_id_wrapped())

--- a/src/stream/src/executor/backfill/cdc/cdc_backfill.rs
+++ b/src/stream/src/executor/backfill/cdc/cdc_backfill.rs
@@ -36,7 +36,6 @@ use risingwave_connector::source::cdc::external::{
     CdcOffset, ExternalCdcTableType, ExternalTableReaderImpl,
 };
 use risingwave_connector::source::{SourceColumnDesc, SourceContext, SourceCtrlOpts};
-use risingwave_pb::common::ThrottleType;
 use rw_futures_util::pausable;
 use thiserror_ext::AsReport;
 use tracing::Instrument;
@@ -378,7 +377,6 @@ impl<S: StateStore> CdcBackfillExecutor<S> {
             // After init the state table and forward the initial barrier to downstream,
             // we now try to create the table reader with retry.
             // If backfill hasn't finished, we can ignore upstream cdc events before we create the table reader.
-            let mut table_reader: Option<ExternalTableReaderImpl> = None;
             let external_table = self.external_table.clone();
             let actor_id = self.actor_ctx.id;
             let fragment_id = self.actor_ctx.fragment_id;
@@ -387,41 +385,36 @@ impl<S: StateStore> CdcBackfillExecutor<S> {
                 actor_id,
                 fragment_id,
             ));
-            loop {
-                if let Some(msg) =
-                    build_reader_and_poll_upstream(&mut upstream, &mut table_reader, &mut future)
-                        .await?
-                {
-                    if let Some(msg) = mapping_message(msg, &self.output_indices) {
-                        match msg {
-                            Message::Barrier(barrier) => {
-                                // commit state to bump the epoch of state table
-                                state_impl.commit_state(barrier.epoch).await?;
-                                yield Message::Barrier(barrier);
-                            }
-                            Message::Chunk(_) => {
-                                // ignore chunk if we need backfill, since we can read the data from the snapshot
-                            }
-                            Message::Watermark(_) => {
-                                // ignore watermark
+            let table_reader = loop {
+                match build_reader_and_poll_upstream(&mut upstream, &mut future).await? {
+                    Either::Left(msg) => {
+                        if let Some(msg) = mapping_message(msg, &self.output_indices) {
+                            match msg {
+                                Message::Barrier(barrier) => {
+                                    // commit state to bump the epoch of state table
+                                    state_impl.commit_state(barrier.epoch).await?;
+                                    yield Message::Barrier(barrier);
+                                }
+                                Message::Chunk(_) => {
+                                    // ignore chunk if we need backfill, since we can read the data from the snapshot
+                                }
+                                Message::Watermark(_) => {
+                                    // ignore watermark
+                                }
                             }
                         }
                     }
-                } else {
-                    assert!(table_reader.is_some(), "table reader must created");
-                    tracing::info!(
-                        %table_id,
-                        upstream_table_name,
-                        "table reader created successfully"
-                    );
-                    break;
+                    Either::Right(table_reader) => break table_reader,
                 }
-            }
-
-            let mut upstream_table_reader = UpstreamTableReader::new(
-                self.external_table.clone(),
-                table_reader.expect("table reader must created"),
+            };
+            tracing::info!(
+                %table_id,
+                upstream_table_name,
+                "table reader created successfully"
             );
+
+            let mut upstream_table_reader =
+                UpstreamTableReader::new(self.external_table.clone(), table_reader);
 
             if last_binlog_offset.is_none() {
                 // Limit concurrent CDC connections globally to 10 using a semaphore.
@@ -524,119 +517,111 @@ impl<S: StateStore> CdcBackfillExecutor<S> {
                         upstream_table_name,
                         "rebuilding CDC table reader after snapshot read failure"
                     );
-                    let mut table_reader = None;
                     let mut future = Box::pin(create_table_reader_with_retry(
                         self.external_table.clone(),
                         self.actor_ctx.id,
                         self.actor_ctx.fragment_id,
                     ));
 
-                    loop {
-                        let Some(msg) = build_reader_and_poll_upstream(
-                            &mut upstream,
-                            &mut table_reader,
-                            &mut future,
-                        )
-                        .await?
-                        else {
-                            break;
-                        };
-
-                        match msg {
-                            Message::Barrier(barrier) => {
-                                if let Some(mutation) = barrier.mutation.as_deref() {
-                                    use crate::executor::Mutation;
-                                    match mutation {
-                                        Mutation::Pause => {
-                                            is_snapshot_paused = true;
-                                        }
-                                        Mutation::Resume => {
-                                            is_snapshot_paused = false;
-                                        }
-                                        Mutation::Throttle(some) => {
-                                            if let Some(entry) =
-                                                some.get(&self.actor_ctx.fragment_id)
-                                                && entry.throttle_type() == ThrottleType::Backfill
-                                            {
-                                                self.rate_limit_rps = entry.rate_limit;
+                    let table_reader = loop {
+                        match build_reader_and_poll_upstream(&mut upstream, &mut future).await? {
+                            Either::Left(msg) => match msg {
+                                Message::Barrier(barrier) => {
+                                    if let Some(mutation) = barrier.mutation.as_deref() {
+                                        use crate::executor::Mutation;
+                                        match mutation {
+                                            Mutation::Pause => {
+                                                is_snapshot_paused = true;
                                             }
+                                            Mutation::Resume => {
+                                                is_snapshot_paused = false;
+                                            }
+                                            Mutation::Throttle(_) => {
+                                                if let Some(entry) = mutation
+                                                    .backfill_throttle_config(
+                                                        self.actor_ctx.fragment_id,
+                                                    )
+                                                {
+                                                    self.rate_limit_rps = entry.rate_limit;
+                                                }
+                                            }
+                                            mutation if mutation.is_stop(self.actor_ctx.id) => {
+                                                tracing::info!(
+                                                    %table_id,
+                                                    upstream_table_name,
+                                                    "CdcBackfill has been dropped due to config change"
+                                                );
+                                                yield Message::Barrier(barrier);
+                                                break 'backfill_loop;
+                                            }
+                                            _ => (),
                                         }
-                                        mutation if mutation.is_stop(self.actor_ctx.id) => {
-                                            tracing::info!(
-                                                %table_id,
-                                                upstream_table_name,
-                                                "CdcBackfill has been dropped due to config change"
-                                            );
-                                            yield Message::Barrier(barrier);
-                                            break 'backfill_loop;
-                                        }
-                                        _ => (),
                                     }
-                                }
 
-                                let (
-                                    emitted_upstream_chunks,
-                                    upstream_processed_row_count,
-                                    consumed_binlog_offset,
-                                ) = Self::consume_upstream_chunk_buffer(
-                                    &offset_parse_func,
-                                    &mut upstream_chunk_buffer,
-                                    current_pk_pos.as_ref(),
-                                    PkCompareInfo {
-                                        indices: &pk_indices,
-                                        order: &pk_order,
-                                        needs_unsigned_i64_compare: &pk_needs_unsigned_i64_compare,
-                                    },
-                                    &last_binlog_offset,
-                                    &self.output_indices,
-                                )?;
-                                if let Some(consumed_binlog_offset) = consumed_binlog_offset {
-                                    last_binlog_offset = Some(consumed_binlog_offset);
-                                }
-                                for chunk in emitted_upstream_chunks {
-                                    yield Message::Chunk(chunk);
-                                }
+                                    let (
+                                        emitted_upstream_chunks,
+                                        upstream_processed_row_count,
+                                        consumed_binlog_offset,
+                                    ) = Self::consume_upstream_chunk_buffer(
+                                        &offset_parse_func,
+                                        &mut upstream_chunk_buffer,
+                                        current_pk_pos.as_ref(),
+                                        PkCompareInfo {
+                                            indices: &pk_indices,
+                                            order: &pk_order,
+                                            needs_unsigned_i64_compare:
+                                                &pk_needs_unsigned_i64_compare,
+                                        },
+                                        &last_binlog_offset,
+                                        &self.output_indices,
+                                    )?;
+                                    if let Some(consumed_binlog_offset) = consumed_binlog_offset {
+                                        last_binlog_offset = Some(consumed_binlog_offset);
+                                    }
+                                    for chunk in emitted_upstream_chunks {
+                                        yield Message::Chunk(chunk);
+                                    }
 
-                                Self::report_metrics(
-                                    &self.metrics,
-                                    0,
-                                    upstream_processed_row_count,
-                                );
-                                state_impl
-                                    .mutate_state(
-                                        current_pk_pos.clone(),
-                                        last_binlog_offset.clone(),
-                                        total_snapshot_row_count,
-                                        false,
-                                    )
-                                    .await?;
-                                state_impl.commit_state(barrier.epoch).await?;
-                                yield Message::Barrier(barrier);
-                            }
-                            Message::Chunk(chunk) => {
-                                if chunk.cardinality() == 0 {
-                                    continue;
+                                    Self::report_metrics(
+                                        &self.metrics,
+                                        0,
+                                        upstream_processed_row_count,
+                                    );
+                                    state_impl
+                                        .mutate_state(
+                                            current_pk_pos.clone(),
+                                            last_binlog_offset.clone(),
+                                            total_snapshot_row_count,
+                                            false,
+                                        )
+                                        .await?;
+                                    state_impl.commit_state(barrier.epoch).await?;
+                                    yield Message::Barrier(barrier);
                                 }
-                                let chunk_binlog_offset =
-                                    get_cdc_chunk_last_offset(&offset_parse_func, &chunk)?;
-                                if let Some(last_binlog_offset) = last_binlog_offset.as_ref()
-                                    && let Some(chunk_offset) = chunk_binlog_offset
-                                    && chunk_offset < *last_binlog_offset
-                                {
-                                    continue;
+                                Message::Chunk(chunk) => {
+                                    if chunk.cardinality() == 0 {
+                                        continue;
+                                    }
+                                    let chunk_binlog_offset =
+                                        get_cdc_chunk_last_offset(&offset_parse_func, &chunk)?;
+                                    if let (Some(last_binlog_offset), Some(chunk_offset)) =
+                                        (last_binlog_offset.as_ref(), chunk_binlog_offset)
+                                        && chunk_offset < *last_binlog_offset
+                                    {
+                                        continue;
+                                    }
+                                    upstream_chunk_buffer.push(chunk.compact_vis());
                                 }
-                                upstream_chunk_buffer.push(chunk.compact_vis());
-                            }
-                            Message::Watermark(_) => {
-                                // Ignore watermark while the snapshot reader is unavailable.
-                            }
+                                Message::Watermark(_) => {
+                                    // Ignore watermark while the snapshot reader is unavailable.
+                                }
+                            },
+                            Either::Right(table_reader) => break table_reader,
                         }
-                    }
+                    };
 
-                    upstream_table_reader = UpstreamTableReader::new(
-                        self.external_table.clone(),
-                        table_reader.expect("table reader must be created"),
-                    );
+                    upstream_table_reader =
+                        UpstreamTableReader::new(self.external_table.clone(), table_reader);
                     pk_needs_unsigned_i64_compare = upstream_table_reader
                         .reader
                         .pk_column_unsigned_i64_compare_flags(&pk_names)?;
@@ -706,11 +691,11 @@ impl<S: StateStore> CdcBackfillExecutor<S> {
                                                 is_snapshot_paused = false;
                                                 snapshot_valve.resume();
                                             }
-                                            Mutation::Throttle(some) => {
-                                                if let Some(entry) =
-                                                    some.get(&self.actor_ctx.fragment_id)
-                                                    && entry.throttle_type()
-                                                        == ThrottleType::Backfill
+                                            Mutation::Throttle(_) => {
+                                                if let Some(entry) = mutation
+                                                    .backfill_throttle_config(
+                                                        self.actor_ctx.fragment_id,
+                                                    )
                                                     && entry.rate_limit != self.rate_limit_rps
                                                 {
                                                     // If self.rate_limit_rps is 0, the snapshot stream does not establish a snapshot_read.
@@ -1110,20 +1095,19 @@ impl<S: StateStore> CdcBackfillExecutor<S> {
 
 pub(crate) async fn build_reader_and_poll_upstream(
     upstream: &mut (impl Stream<Item = StreamExecutorResult<Message>> + Unpin),
-    table_reader: &mut Option<ExternalTableReaderImpl>,
     future: &mut Pin<Box<impl Future<Output = ExternalTableReaderImpl>>>,
-) -> StreamExecutorResult<Option<Message>> {
-    if table_reader.is_some() {
-        return Ok(None);
-    }
+) -> StreamExecutorResult<Either<Message, ExternalTableReaderImpl>> {
     tokio::select! {
         biased;
         reader = &mut *future => {
-            *table_reader = Some(reader);
-            Ok(None)
+            Ok(Either::Right(reader))
         }
         msg = upstream.next() => {
-            msg.transpose()
+            msg.transpose()?
+                .map(Either::Left)
+                .ok_or_else(|| anyhow::anyhow!(
+                    "upstream closed while creating CDC table reader"
+                ).into())
         }
     }
 }

--- a/src/stream/src/executor/backfill/cdc/cdc_backfill.rs
+++ b/src/stream/src/executor/backfill/cdc/cdc_backfill.rs
@@ -431,11 +431,7 @@ impl<S: StateStore> CdcBackfillExecutor<S> {
             // Whether each pk column needs unsigned `i64` comparison. Frontend up-casts narrower
             // unsigned integers, while unsigned float/double/decimal keep their native comparison
             // semantics; only `BIGINT UNSIGNED` can overflow into a negative `i64` in RisingWave.
-            let schema = self.external_table.schema();
-            let pk_names: Vec<String> = pk_indices
-                .iter()
-                .map(|&i| schema.fields[i].name.clone())
-                .collect();
+            let pk_names = self.external_table.pk_names();
             let mut pk_needs_unsigned_i64_compare = upstream_table_reader
                 .reader
                 .pk_column_unsigned_i64_compare_flags(&pk_names)?;

--- a/src/stream/src/executor/backfill/cdc/cdc_backill_v2.rs
+++ b/src/stream/src/executor/backfill/cdc/cdc_backill_v2.rs
@@ -650,7 +650,14 @@ impl<S: StateStore> ParallelizedCdcBackfillExecutor<S> {
 
                         match attempt_state {
                             SnapshotAttemptState::Failed => {
-                                upstream_table_reader.disconnect().await?;
+                                if let Err(error) = upstream_table_reader.disconnect().await {
+                                    tracing::warn!(
+                                        error = %error.as_report(),
+                                        %table_id,
+                                        upstream_table_name,
+                                        "failed to disconnect CDC snapshot reader; continuing with rebuild"
+                                    );
+                                }
 
                                 let mut future = Box::pin(create_table_reader_with_retry(
                                     self.external_table.clone(),

--- a/src/stream/src/executor/backfill/cdc/cdc_backill_v2.rs
+++ b/src/stream/src/executor/backfill/cdc/cdc_backill_v2.rs
@@ -24,11 +24,8 @@ use risingwave_common::row::RowDeserializer;
 use risingwave_common::util::iter_util::ZipEqFast;
 use risingwave_common::util::sort_util::{OrderType, cmp_datum};
 use risingwave_connector::source::cdc::CdcScanOptions;
-use risingwave_connector::source::cdc::external::{
-    CdcOffset, ExternalCdcTableType, ExternalTableReaderImpl,
-};
+use risingwave_connector::source::cdc::external::{CdcOffset, ExternalCdcTableType};
 use risingwave_connector::source::{CdcTableSnapshotSplit, CdcTableSnapshotSplitRaw};
-use risingwave_pb::common::ThrottleType;
 use rw_futures_util::pausable;
 
 use crate::executor::backfill::cdc::cdc_backfill::{
@@ -258,7 +255,6 @@ impl<S: StateStore> ParallelizedCdcBackfillExecutor<S> {
             // Once all splits are complete, the executor only forwards the table-filtered CDC
             // stream and must not depend on the upstream snapshot table still existing.
             let upstream_table_reader = if next_split_idx < actor_snapshot_splits.len() {
-                let mut table_reader: Option<ExternalTableReaderImpl> = None;
                 let external_table = self.external_table.clone();
                 let actor_id = self.actor_ctx.id;
                 let fragment_id = self.actor_ctx.fragment_id;
@@ -267,55 +263,49 @@ impl<S: StateStore> ParallelizedCdcBackfillExecutor<S> {
                     actor_id,
                     fragment_id,
                 ));
-                loop {
-                    if let Some(msg) = build_reader_and_poll_upstream(
-                        &mut upstream,
-                        &mut table_reader,
-                        &mut future,
-                    )
-                    .await?
-                    {
-                        if let Some(msg) = mapping_message(msg, &self.output_indices) {
-                            match msg {
-                                Message::Barrier(barrier) => {
-                                    state_impl.commit_state(barrier.epoch).await?;
-                                    if is_reset_barrier(&barrier, self.actor_ctx.id) {
-                                        next_reset_barrier = Some(barrier);
-                                        continue 'with_cdc_table_snapshot_splits;
+                let table_reader = loop {
+                    match build_reader_and_poll_upstream(&mut upstream, &mut future).await? {
+                        Either::Left(msg) => {
+                            if let Some(msg) = mapping_message(msg, &self.output_indices) {
+                                match msg {
+                                    Message::Barrier(barrier) => {
+                                        state_impl.commit_state(barrier.epoch).await?;
+                                        if is_reset_barrier(&barrier, self.actor_ctx.id) {
+                                            next_reset_barrier = Some(barrier);
+                                            continue 'with_cdc_table_snapshot_splits;
+                                        }
+                                        yield Message::Barrier(barrier);
                                     }
-                                    yield Message::Barrier(barrier);
-                                }
-                                Message::Chunk(chunk) => {
-                                    if chunk.cardinality() == 0 {
-                                        continue;
+                                    Message::Chunk(chunk) => {
+                                        if chunk.cardinality() == 0 {
+                                            continue;
+                                        }
+                                        if let Some(filtered_chunk) = filter_stream_chunk(
+                                            chunk,
+                                            &current_actor_bounds,
+                                            snapshot_split_column_index,
+                                        ) && filtered_chunk.cardinality() > 0
+                                        {
+                                            yield Message::Chunk(filtered_chunk);
+                                        }
                                     }
-                                    if let Some(filtered_chunk) = filter_stream_chunk(
-                                        chunk,
-                                        &current_actor_bounds,
-                                        snapshot_split_column_index,
-                                    ) && filtered_chunk.cardinality() > 0
-                                    {
-                                        yield Message::Chunk(filtered_chunk);
+                                    Message::Watermark(_) => {
+                                        // Ignore watermark, like the `CdcBackfillExecutor`.
                                     }
-                                }
-                                Message::Watermark(_) => {
-                                    // Ignore watermark, like the `CdcBackfillExecutor`.
                                 }
                             }
                         }
-                    } else {
-                        assert!(table_reader.is_some(), "table reader must be created");
-                        tracing::info!(
-                            %table_id,
-                            upstream_table_name,
-                            "table reader created successfully"
-                        );
-                        break;
+                        Either::Right(table_reader) => break table_reader,
                     }
-                }
+                };
+                tracing::info!(
+                    %table_id,
+                    upstream_table_name,
+                    "table reader created successfully"
+                );
                 Some(UpstreamTableReader::new(
                     self.external_table.clone(),
-                    table_reader.expect("table reader must be created"),
+                    table_reader,
                 ))
             } else {
                 None
@@ -402,14 +392,14 @@ impl<S: StateStore> ParallelizedCdcBackfillExecutor<S> {
                                                 is_snapshot_paused = false;
                                                 snapshot_valve.resume();
                                             }
-                                            Mutation::Throttle(some) => {
+                                            Mutation::Throttle(_) => {
                                                 // TODO(zw): optimization: improve throttle.
                                                 // 1. Handle rate limit 0. Currently, to resume the process, the actor must be rebuilt.
                                                 // 2. Apply new rate limit immediately.
-                                                if let Some(entry) =
-                                                    some.get(&self.actor_ctx.fragment_id)
-                                                    && entry.throttle_type()
-                                                        == ThrottleType::Backfill
+                                                if let Some(entry) = mutation
+                                                    .backfill_throttle_config(
+                                                        self.actor_ctx.fragment_id,
+                                                    )
                                                     && entry.rate_limit != self.rate_limit_rps
                                                 {
                                                     // The new rate limit will take effect since next split.

--- a/src/stream/src/executor/backfill/cdc/cdc_backill_v2.rs
+++ b/src/stream/src/executor/backfill/cdc/cdc_backill_v2.rs
@@ -37,7 +37,7 @@ use crate::executor::backfill::cdc::cdc_backfill::{
 use crate::executor::backfill::cdc::state_v2::ParallelizedCdcBackfillState;
 use crate::executor::backfill::cdc::upstream_table::external::ExternalStorageTable;
 use crate::executor::backfill::cdc::upstream_table::snapshot::{
-    SplitSnapshotReadArgs, UpstreamTableRead, UpstreamTableReader,
+    SplitSnapshotReadArgs, SplitSnapshotReadArgsInput, UpstreamTableRead, UpstreamTableReader,
 };
 use crate::executor::backfill::utils::{
     cmp_pk_unsigned_aware, get_cdc_chunk_last_offset, get_new_pos, mapping_chunk, mapping_message,
@@ -407,16 +407,14 @@ impl<S: StateStore> ParallelizedCdcBackfillExecutor<S> {
                             split_cdc_offset_low =
                                 upstream_table_reader.current_cdc_offset().await?;
                         }
-                        if let Some(ref cdc_offset) = split_cdc_offset_low {
-                            if actor_cdc_offset_low
+                        if let Some(ref cdc_offset) = split_cdc_offset_low
+                            && actor_cdc_offset_low
                                 .as_ref()
                                 .is_none_or(|cur| cur > cdc_offset)
-                            {
-                                actor_cdc_offset_low = split_cdc_offset_low.clone();
-                            }
+                        {
+                            actor_cdc_offset_low = split_cdc_offset_low.clone();
                         }
 
-                        // why needed?
                         // Apply changes to the already snapshotted prefix before starting the new
                         // query. Changes after the cursor are reflected by that query instead.
                         let (emitted_chunks, _) = partition_current_split_buffer(
@@ -433,19 +431,24 @@ impl<S: StateStore> ParallelizedCdcBackfillExecutor<S> {
 
                         let attempt_state = {
                             let left_upstream = upstream.by_ref().map(Either::Left);
-                            let read_args = SplitSnapshotReadArgs::new(
-                                current_pk_pos.clone(),
-                                pk_names.clone(),
-                                (!is_leftmost_bound(&split.left_bound_inclusive))
+                            let read_args =
+                                SplitSnapshotReadArgs::new(SplitSnapshotReadArgsInput {
+                                    current_pos: current_pk_pos.clone(),
+                                    primary_keys: pk_names.clone(),
+                                    left_bound_inclusive: (!is_leftmost_bound(
+                                        &split.left_bound_inclusive,
+                                    ))
                                     .then(|| split.left_bound_inclusive.clone()),
-                                (!is_rightmost_bound(&split.right_bound_exclusive))
+                                    right_bound_exclusive: (!is_rightmost_bound(
+                                        &split.right_bound_exclusive,
+                                    ))
                                     .then(|| split.right_bound_exclusive.clone()),
-                                cdc_table_snapshot_split_column.clone(),
-                                self.rate_limit_rps,
-                                additional_columns.clone(),
-                                schema_table_name.clone(),
-                                external_database_name.clone(),
-                            );
+                                    split_columns: cdc_table_snapshot_split_column.clone(),
+                                    rate_limit_rps: self.rate_limit_rps,
+                                    additional_columns: additional_columns.clone(),
+                                    schema_table_name: schema_table_name.clone(),
+                                    database_name: external_database_name.clone(),
+                                });
                             let right_snapshot = pin!(
                                 upstream_table_reader
                                     .snapshot_read_table_split(read_args)

--- a/src/stream/src/executor/backfill/cdc/cdc_backill_v2.rs
+++ b/src/stream/src/executor/backfill/cdc/cdc_backill_v2.rs
@@ -233,45 +233,49 @@ impl<S: StateStore> ParallelizedCdcBackfillExecutor<S> {
             let mut actor_cdc_offset_high: Option<CdcOffset> = None;
             let mut actor_cdc_offset_low: Option<CdcOffset> = None;
             // Find next split that need backfill.
-            let mut next_split_idx = actor_snapshot_splits.len();
+            let mut next_unfinished_split = None;
             'restore_split_state: for (idx, split) in actor_snapshot_splits.iter().enumerate() {
                 let state = state_impl.restore_state(split.split_id).await?;
+
                 if !state.is_finished {
-                    next_split_idx = idx;
+                    next_unfinished_split = Some((idx, state));
                     break 'restore_split_state;
                 }
+
                 extends_current_actor_bound(&mut current_actor_bounds, split);
-                if let Some(ref cdc_offset) = state.cdc_offset_low {
-                    if let Some(ref cur) = actor_cdc_offset_low {
-                        if *cur > *cdc_offset {
-                            actor_cdc_offset_low = state.cdc_offset_low.clone();
-                        }
-                    } else {
-                        actor_cdc_offset_low = state.cdc_offset_low.clone();
-                    }
+
+                if let Some(cdc_offset) = state.cdc_offset_low
+                    && actor_cdc_offset_low
+                        .as_ref()
+                        .is_none_or(|current| current > &cdc_offset)
+                {
+                    actor_cdc_offset_low = Some(cdc_offset);
                 }
-                if let Some(ref cdc_offset) = state.cdc_offset_high {
-                    if let Some(ref cur) = actor_cdc_offset_high {
-                        if *cur < *cdc_offset {
-                            actor_cdc_offset_high = state.cdc_offset_high.clone();
-                        }
-                    } else {
-                        actor_cdc_offset_high = state.cdc_offset_high.clone();
-                    }
+
+                if let Some(cdc_offset) = state.cdc_offset_high
+                    && actor_cdc_offset_high
+                        .as_ref()
+                        .is_none_or(|current| current < &cdc_offset)
+                {
+                    actor_cdc_offset_high = Some(cdc_offset);
                 }
             }
-            for split in actor_snapshot_splits.iter().skip(next_split_idx) {
-                // Initialize state so that overall progress can be measured.
-                state_impl.init_state_if_absent(split.split_id).await?;
+
+            let mut should_report_actor_backfill_progress = None;
+
+            if let Some((next_split_idx, _)) = next_unfinished_split.as_ref() {
+                for split in actor_snapshot_splits.iter().skip(*next_split_idx) {
+                    // Initialize state so that overall progress can be measured.
+                    state_impl.init_state_if_absent(split.split_id).await?;
+                }
+
+                if *next_split_idx > 0 {
+                    should_report_actor_backfill_progress = Some((
+                        actor_snapshot_splits[0].split_id,
+                        actor_snapshot_splits[*next_split_idx - 1].split_id,
+                    ));
+                }
             }
-            let mut should_report_actor_backfill_progress = if next_split_idx > 0 {
-                Some((
-                    actor_snapshot_splits[0].split_id,
-                    actor_snapshot_splits[next_split_idx - 1].split_id,
-                ))
-            } else {
-                None
-            };
 
             let offset_parse_func = self.external_table.table_type().get_cdc_offset_parser()?;
             let mut pk_needs_unsigned_i64_compare = vec![false; pk_indices.len()];
@@ -279,7 +283,7 @@ impl<S: StateStore> ParallelizedCdcBackfillExecutor<S> {
             // A reader is only needed while at least one assigned snapshot split is unfinished.
             // Once all splits are complete, the executor only forwards the table-filtered CDC
             // stream and must not depend on the upstream snapshot table still existing.
-            if next_split_idx < actor_snapshot_splits.len() {
+            if let Some((next_split_idx, next_split_state)) = next_unfinished_split {
                 let external_table = self.external_table.clone();
                 let actor_id = self.actor_ctx.id;
                 let fragment_id = self.actor_ctx.fragment_id;
@@ -289,12 +293,45 @@ impl<S: StateStore> ParallelizedCdcBackfillExecutor<S> {
                     fragment_id,
                 ));
 
+                let next_split = &actor_snapshot_splits[next_split_idx];
+                let finished_split_bounds = current_actor_bounds.clone();
+                let current_split_bounds = Some((
+                    next_split.left_bound_inclusive.clone(),
+                    next_split.right_bound_exclusive.clone(),
+                ));
+
                 let table_reader = loop {
                     match build_reader_and_poll_upstream(&mut upstream, &mut future).await? {
                         Either::Left(msg) => {
                             if let Some(msg) = mapping_message(msg, &self.output_indices) {
                                 match msg {
                                     Message::Barrier(barrier) => {
+                                        // The replacement snapshot will reread rows after the
+                                        // restored cursor. Rows at or before it must be emitted
+                                        // before the barrier commits that cursor.
+                                        let (emitted_chunks, _retained_chunks) =
+                                            partition_current_split_buffer(
+                                                std::mem::take(&mut upstream_chunk_buffer),
+                                                next_split_state.current_pk_pos.as_ref(),
+                                                &pk_in_output_indices,
+                                                &pk_order,
+                                                &pk_needs_unsigned_i64_compare,
+                                            );
+
+                                        for chunk in emitted_chunks {
+                                            yield Message::Chunk(chunk);
+                                        }
+
+                                        state_impl
+                                            .mutate_state(
+                                                next_split.split_id,
+                                                next_split_state.current_pk_pos.clone(),
+                                                false,
+                                                next_split_state.row_count as u64,
+                                                next_split_state.cdc_offset_low.clone(),
+                                                None,
+                                            )
+                                            .await?;
                                         state_impl.commit_state(barrier.epoch).await?;
 
                                         if is_reset_barrier(&barrier, self.actor_ctx.id) {
@@ -304,8 +341,22 @@ impl<S: StateStore> ParallelizedCdcBackfillExecutor<S> {
                                             yield Message::Barrier(barrier)
                                         }
                                     }
-                                    Message::Chunk(_) => {
-                                        // ignore chunk if we need backfill, since we can read the data from the snapshot
+                                    Message::Chunk(chunk) => {
+                                        let (finished_chunk, current_chunk) =
+                                            split_finished_and_current_chunk(
+                                                chunk,
+                                                &finished_split_bounds,
+                                                &current_split_bounds,
+                                                snapshot_split_column_in_output_index,
+                                            );
+
+                                        if let Some(finished_chunk) = finished_chunk {
+                                            yield Message::Chunk(finished_chunk);
+                                        }
+
+                                        if let Some(current_chunk) = current_chunk {
+                                            upstream_chunk_buffer.push(current_chunk);
+                                        }
                                     }
                                     Message::Watermark(_) => {
                                         // Ignore watermark, like the `CdcBackfillExecutor`.

--- a/src/stream/src/executor/backfill/cdc/cdc_backill_v2.rs
+++ b/src/stream/src/executor/backfill/cdc/cdc_backill_v2.rs
@@ -1159,13 +1159,168 @@ fn assert_consecutive_splits(actor_snapshot_splits: &[CdcTableSnapshotSplit]) {
 
 #[cfg(test)]
 mod tests {
-    use risingwave_common::array::StreamChunk;
-    use risingwave_common::row::OwnedRow;
-    use risingwave_common::types::ScalarImpl;
+    use std::collections::BTreeMap;
+    use std::sync::Arc;
+    use std::time::Duration;
 
-    use crate::executor::backfill::cdc::cdc_backill_v2::{
-        filter_stream_chunk, split_finished_and_current_chunk,
+    use futures::StreamExt;
+    use risingwave_common::array::StreamChunk;
+    use risingwave_common::catalog::{ColumnDesc, ColumnId, Field, Schema, TableId};
+    use risingwave_common::row::{OwnedRow, Row};
+    use risingwave_common::types::{DataType, ScalarImpl};
+    use risingwave_common::util::epoch::{EpochExt, test_epoch};
+    use risingwave_common::util::sort_util::OrderType;
+    use risingwave_connector::source::CdcTableSnapshotSplitRaw;
+    use risingwave_connector::source::cdc::external::{
+        ExternalCdcTableType, ExternalTableConfig, SchemaTableName,
     };
+    use risingwave_connector::source::cdc::{
+        CdcScanOptions, CdcTableSnapshotSplitAssignmentWithGeneration,
+    };
+    use risingwave_storage::memory::MemoryStateStore;
+
+    use super::*;
+    use crate::common::table::state_table::StateTable;
+    use crate::common::table::test_utils::gen_pbtable;
+    use crate::executor::monitor::StreamingMetrics;
+    use crate::executor::test_utils::MockSource;
+    use crate::executor::{AddMutation, Execute, Mutation};
+
+    #[tokio::test]
+    async fn test_rebuilds_reader_after_snapshot_error() {
+        let (mut tx, source) = MockSource::channel();
+        let source = source.into_executor(
+            Schema::new(vec![
+                Field::unnamed(DataType::Jsonb),
+                Field::unnamed(DataType::Varchar),
+            ]),
+            vec![0],
+        );
+        let table_schema = Schema::new(vec![
+            Field::with_name(DataType::Int64, "id"),
+            Field::with_name(DataType::Float64, "price"),
+        ]);
+        let external_table = ExternalStorageTable::new(
+            TableId::new(1234),
+            SchemaTableName {
+                schema_name: "public".to_owned(),
+                table_name: "mock_table".to_owned(),
+            },
+            "mydb".to_owned(),
+            ExternalTableConfig::default(),
+            ExternalCdcTableType::Mock,
+            table_schema,
+            vec![OrderType::ascending()],
+            vec![0],
+        )
+        .with_mock_snapshot_errors([1, 0]);
+        let external_table_for_assertion = external_table.clone();
+
+        let state_schema = Schema::new(vec![
+            Field::with_name(DataType::Int64, "split_id"),
+            Field::with_name(DataType::Boolean, "backfill_finished"),
+            Field::with_name(DataType::Int64, "row_count"),
+            Field::with_name(DataType::Jsonb, "cdc_offset_low"),
+            Field::with_name(DataType::Jsonb, "cdc_offset_high"),
+            Field::with_name(DataType::Int64, "id"),
+        ]);
+        let column_descs = state_schema
+            .fields
+            .iter()
+            .enumerate()
+            .map(|(idx, field)| {
+                ColumnDesc::unnamed(ColumnId::new(idx as i32), field.data_type.clone())
+            })
+            .collect();
+        let state_table = StateTable::from_table_catalog(
+            &gen_pbtable(
+                TableId::new(0x42),
+                column_descs,
+                vec![OrderType::ascending()],
+                vec![0],
+                0,
+            ),
+            MemoryStateStore::new(),
+            None,
+        )
+        .await;
+
+        let actor_id = 0x1a.into();
+        let mut executor = ParallelizedCdcBackfillExecutor::new(
+            ActorContext::for_test(actor_id),
+            external_table,
+            source,
+            vec![0, 1],
+            vec![
+                ColumnDesc::named("id", ColumnId::new(1), DataType::Int64),
+                ColumnDesc::named("price", ColumnId::new(2), DataType::Float64),
+            ],
+            Arc::new(StreamingMetrics::unused()),
+            state_table,
+            Some(4),
+            CdcScanOptions {
+                backfill_parallelism: 1,
+                backfill_num_rows_per_split: 100,
+                ..Default::default()
+            },
+            BTreeMap::new(),
+            None,
+        )
+        .boxed()
+        .execute();
+
+        let mut curr_epoch = test_epoch(1);
+        let snapshot_splits = [(
+            actor_id,
+            (
+                vec![CdcTableSnapshotSplitRaw {
+                    split_id: 1,
+                    left_bound_inclusive: OwnedRow::new(vec![Some(ScalarImpl::Int64(1))])
+                        .value_serialize(),
+                    right_bound_exclusive: OwnedRow::new(vec![Some(ScalarImpl::Int64(10))])
+                        .value_serialize(),
+                }],
+                10,
+            ),
+        )]
+        .into_iter()
+        .collect();
+        tx.send_barrier(
+            Barrier::new_test_barrier(curr_epoch).with_mutation(Mutation::Add(AddMutation {
+                actor_cdc_table_snapshot_splits: CdcTableSnapshotSplitAssignmentWithGeneration {
+                    splits: snapshot_splits,
+                },
+                ..Default::default()
+            })),
+        );
+        assert!(matches!(
+            executor.next().await.unwrap().unwrap(),
+            Message::Barrier(Barrier { epoch, .. }) if epoch.curr == curr_epoch
+        ));
+
+        // Drive the injected failure. No error or data should escape while the executor waits
+        // for a barrier at which it can safely checkpoint and replace the reader.
+        assert!(
+            tokio::time::timeout(Duration::from_millis(50), executor.next())
+                .await
+                .is_err()
+        );
+        assert_eq!(external_table_for_assertion.mock_reader_create_count(), 1);
+
+        curr_epoch.inc_epoch();
+        tx.push_barrier(curr_epoch, false);
+        assert!(matches!(
+            executor.next().await.unwrap().unwrap(),
+            Message::Barrier(Barrier { epoch, .. }) if epoch.curr == curr_epoch
+        ));
+
+        // Polling after the barrier reconstructs the reader and resumes the same split.
+        assert!(matches!(
+            executor.next().await.unwrap().unwrap(),
+            Message::Chunk(_)
+        ));
+        assert_eq!(external_table_for_assertion.mock_reader_create_count(), 2);
+    }
 
     #[test]
     fn test_filter_stream_chunk() {

--- a/src/stream/src/executor/backfill/cdc/cdc_backill_v2.rs
+++ b/src/stream/src/executor/backfill/cdc/cdc_backill_v2.rs
@@ -234,12 +234,13 @@ impl<S: StateStore> ParallelizedCdcBackfillExecutor<S> {
             let mut actor_cdc_offset_low: Option<CdcOffset> = None;
             // Find next split that need backfill.
             let mut next_unfinished_split = None;
-            'restore_split_state: for (idx, split) in actor_snapshot_splits.iter().enumerate() {
+
+            for (idx, split) in actor_snapshot_splits.iter().enumerate() {
                 let state = state_impl.restore_state(split.split_id).await?;
 
                 if !state.is_finished {
                     next_unfinished_split = Some((idx, state));
-                    break 'restore_split_state;
+                    break;
                 }
 
                 extends_current_actor_bound(&mut current_actor_bounds, split);
@@ -656,7 +657,7 @@ impl<S: StateStore> ParallelizedCdcBackfillExecutor<S> {
                                     self.actor_ctx.id,
                                     self.actor_ctx.fragment_id,
                                 ));
-                                let table_reader = 'rebuild_reader: loop {
+                                let table_reader = loop {
                                     match build_reader_and_poll_upstream(&mut upstream, &mut future)
                                         .await?
                                     {
@@ -765,7 +766,7 @@ impl<S: StateStore> ParallelizedCdcBackfillExecutor<S> {
                                             }
                                         }
                                         Either::Right(table_reader) => {
-                                            break 'rebuild_reader table_reader;
+                                            break table_reader;
                                         }
                                     }
                                 };
@@ -841,7 +842,7 @@ impl<S: StateStore> ParallelizedCdcBackfillExecutor<S> {
             // we can forward messages directly to the downstream,
             // as backfill is finished.
             #[for_await]
-            'forward_upstream: for msg in &mut upstream {
+            for msg in &mut upstream {
                 let msg = msg?;
                 match msg {
                     Message::Barrier(barrier) => {
@@ -886,7 +887,7 @@ impl<S: StateStore> ParallelizedCdcBackfillExecutor<S> {
                     }
                     Message::Chunk(chunk) => {
                         if actor_snapshot_splits.is_empty() || !chunk.has_visible_rows() {
-                            continue 'forward_upstream;
+                            continue;
                         }
 
                         let chunk_cdc_offset =
@@ -1052,13 +1053,13 @@ fn filter_stream_chunk(
     }
     let mut new_bitmap = BitmapBuilder::with_capacity(chunk.capacity());
     let (ops, columns, visibility) = chunk.into_inner();
-    'filter_rows: for (row_split_key, v) in columns[snapshot_split_column_index]
+    for (row_split_key, v) in columns[snapshot_split_column_index]
         .iter()
         .zip_eq_fast(visibility.iter())
     {
         if !v {
             new_bitmap.append(false);
-            continue 'filter_rows;
+            continue;
         }
         let mut is_in_range = true;
         if !is_leftmost_bound {

--- a/src/stream/src/executor/backfill/cdc/cdc_backill_v2.rs
+++ b/src/stream/src/executor/backfill/cdc/cdc_backill_v2.rs
@@ -18,15 +18,17 @@ use either::Either;
 use futures::stream;
 use futures::stream::select_with_strategy;
 use itertools::Itertools;
+use risingwave_common::array::Op;
 use risingwave_common::bitmap::BitmapBuilder;
 use risingwave_common::catalog::{ColumnDesc, Field};
-use risingwave_common::row::RowDeserializer;
+use risingwave_common::row::{RowDeserializer, RowExt};
 use risingwave_common::util::iter_util::ZipEqFast;
 use risingwave_common::util::sort_util::{OrderType, cmp_datum};
 use risingwave_connector::source::cdc::CdcScanOptions;
 use risingwave_connector::source::cdc::external::{CdcOffset, ExternalCdcTableType};
 use risingwave_connector::source::{CdcTableSnapshotSplit, CdcTableSnapshotSplitRaw};
 use rw_futures_util::pausable;
+use thiserror_ext::AsReport;
 
 use crate::executor::backfill::cdc::cdc_backfill::{
     build_reader_and_poll_upstream, create_table_reader_with_retry,
@@ -37,7 +39,9 @@ use crate::executor::backfill::cdc::upstream_table::external::ExternalStorageTab
 use crate::executor::backfill::cdc::upstream_table::snapshot::{
     SplitSnapshotReadArgs, UpstreamTableRead, UpstreamTableReader,
 };
-use crate::executor::backfill::utils::{get_cdc_chunk_last_offset, mapping_chunk, mapping_message};
+use crate::executor::backfill::utils::{
+    cmp_pk_unsigned_aware, get_cdc_chunk_last_offset, get_new_pos, mapping_chunk, mapping_message,
+};
 use crate::executor::prelude::*;
 use crate::task::cdc_progress::CdcProgressReporter;
 pub struct ParallelizedCdcBackfillExecutor<S: StateStore> {
@@ -65,6 +69,12 @@ pub struct ParallelizedCdcBackfillExecutor<S: StateStore> {
     properties: BTreeMap<String, String>,
 
     progress: Option<CdcProgressReporter>,
+}
+
+enum SnapshotAttemptState {
+    Reading,
+    Failed,
+    Finished(CdcOffset),
 }
 
 impl<S: StateStore> ParallelizedCdcBackfillExecutor<S> {
@@ -101,6 +111,17 @@ impl<S: StateStore> ParallelizedCdcBackfillExecutor<S> {
         assert!(!self.options.disable_backfill);
         // The indices to primary key columns
         let pk_indices = self.external_table.pk_indices().to_vec();
+        let pk_order = self.external_table.pk_order_types().to_vec();
+        let pk_in_output_indices = pk_indices
+            .iter()
+            .map(|pk_idx| {
+                self.output_indices
+                    .iter()
+                    .position(|output_idx| output_idx == pk_idx)
+                    .expect("primary key column must be present in CDC backfill output")
+            })
+            .collect_vec();
+        let pk_names = self.external_table.pk_names();
         let table_id = self.external_table.table_id();
         let upstream_table_name = self.external_table.qualified_table_name();
         let schema_table_name = self.external_table.schema_table_name().clone();
@@ -118,6 +139,11 @@ impl<S: StateStore> ParallelizedCdcBackfillExecutor<S> {
         );
         let snapshot_split_column_index =
             pk_indices[self.options.backfill_split_pk_column_index as usize];
+        let snapshot_split_column_in_output_index = self
+            .output_indices
+            .iter()
+            .position(|&idx| idx == snapshot_split_column_index)
+            .expect("snapshot split column must be present in CDC backfill output");
         let cdc_table_snapshot_split_column =
             vec![self.external_table.schema().fields[snapshot_split_column_index].clone()];
 
@@ -146,7 +172,7 @@ impl<S: StateStore> ParallelizedCdcBackfillExecutor<S> {
         .boxed();
         let mut next_reset_barrier = Some(first_barrier);
         let mut is_reset = false;
-        let mut state_impl = ParallelizedCdcBackfillState::new(self.state_table);
+        let mut state_impl = ParallelizedCdcBackfillState::new(self.state_table, pk_indices.len());
         // The buffered chunks have already been mapped.
         let mut upstream_chunk_buffer: Vec<StreamChunk> = vec![];
 
@@ -208,11 +234,11 @@ impl<S: StateStore> ParallelizedCdcBackfillExecutor<S> {
             let mut actor_cdc_offset_low: Option<CdcOffset> = None;
             // Find next split that need backfill.
             let mut next_split_idx = actor_snapshot_splits.len();
-            for (idx, split) in actor_snapshot_splits.iter().enumerate() {
+            'restore_split_state: for (idx, split) in actor_snapshot_splits.iter().enumerate() {
                 let state = state_impl.restore_state(split.split_id).await?;
                 if !state.is_finished {
                     next_split_idx = idx;
-                    break;
+                    break 'restore_split_state;
                 }
                 extends_current_actor_bound(&mut current_actor_bounds, split);
                 if let Some(ref cdc_offset) = state.cdc_offset_low {
@@ -236,9 +262,7 @@ impl<S: StateStore> ParallelizedCdcBackfillExecutor<S> {
             }
             for split in actor_snapshot_splits.iter().skip(next_split_idx) {
                 // Initialize state so that overall progress can be measured.
-                state_impl
-                    .mutate_state(split.split_id, false, 0, None, None)
-                    .await?;
+                state_impl.init_state_if_absent(split.split_id).await?;
             }
             let mut should_report_actor_backfill_progress = if next_split_idx > 0 {
                 Some((
@@ -250,11 +274,12 @@ impl<S: StateStore> ParallelizedCdcBackfillExecutor<S> {
             };
 
             let offset_parse_func = self.external_table.table_type().get_cdc_offset_parser()?;
+            let mut pk_needs_unsigned_i64_compare = vec![false; pk_indices.len()];
 
             // A reader is only needed while at least one assigned snapshot split is unfinished.
             // Once all splits are complete, the executor only forwards the table-filtered CDC
             // stream and must not depend on the upstream snapshot table still existing.
-            let upstream_table_reader = if next_split_idx < actor_snapshot_splits.len() {
+            if next_split_idx < actor_snapshot_splits.len() {
                 let external_table = self.external_table.clone();
                 let actor_id = self.actor_ctx.id;
                 let fragment_id = self.actor_ctx.fragment_id;
@@ -263,6 +288,7 @@ impl<S: StateStore> ParallelizedCdcBackfillExecutor<S> {
                     actor_id,
                     fragment_id,
                 ));
+
                 let table_reader = loop {
                     match build_reader_and_poll_upstream(&mut upstream, &mut future).await? {
                         Either::Left(msg) => {
@@ -270,24 +296,16 @@ impl<S: StateStore> ParallelizedCdcBackfillExecutor<S> {
                                 match msg {
                                     Message::Barrier(barrier) => {
                                         state_impl.commit_state(barrier.epoch).await?;
+
                                         if is_reset_barrier(&barrier, self.actor_ctx.id) {
                                             next_reset_barrier = Some(barrier);
                                             continue 'with_cdc_table_snapshot_splits;
+                                        } else {
+                                            yield Message::Barrier(barrier)
                                         }
-                                        yield Message::Barrier(barrier);
                                     }
-                                    Message::Chunk(chunk) => {
-                                        if chunk.cardinality() == 0 {
-                                            continue;
-                                        }
-                                        if let Some(filtered_chunk) = filter_stream_chunk(
-                                            chunk,
-                                            &current_actor_bounds,
-                                            snapshot_split_column_index,
-                                        ) && filtered_chunk.cardinality() > 0
-                                        {
-                                            yield Message::Chunk(filtered_chunk);
-                                        }
+                                    Message::Chunk(_) => {
+                                        // ignore chunk if we need backfill, since we can read the data from the snapshot
                                     }
                                     Message::Watermark(_) => {
                                         // Ignore watermark, like the `CdcBackfillExecutor`.
@@ -298,265 +316,467 @@ impl<S: StateStore> ParallelizedCdcBackfillExecutor<S> {
                         Either::Right(table_reader) => break table_reader,
                     }
                 };
+                pk_needs_unsigned_i64_compare =
+                    table_reader.pk_column_unsigned_i64_compare_flags(&pk_names)?;
+
                 tracing::info!(
                     %table_id,
                     upstream_table_name,
                     "table reader created successfully"
                 );
-                Some(UpstreamTableReader::new(
-                    self.external_table.clone(),
-                    table_reader,
-                ))
-            } else {
-                None
-            };
 
-            // Backfill snapshot splits sequentially.
-            for split in actor_snapshot_splits.iter().skip(next_split_idx) {
-                let upstream_table_reader = upstream_table_reader
-                    .as_ref()
-                    .expect("unfinished snapshot split must have a table reader");
-                tracing::info!(
-                    %table_id,
-                    upstream_table_name,
-                    ?split,
-                    is_snapshot_paused,
-                    "start cdc backfill split"
-                );
-                let finished_split_bounds = current_actor_bounds.clone();
-                let current_split_bounds = Some((
-                    split.left_bound_inclusive.clone(),
-                    split.right_bound_exclusive.clone(),
-                ));
-                extends_current_actor_bound(&mut current_actor_bounds, split);
+                let mut upstream_table_reader =
+                    UpstreamTableReader::new(self.external_table.clone(), table_reader);
 
-                let split_cdc_offset_low = {
-                    // Limit concurrent CDC connections globally to 10 using a semaphore.
-                    static CDC_CONN_SEMAPHORE: tokio::sync::Semaphore =
-                        tokio::sync::Semaphore::const_new(10);
+                // Backfill snapshot splits sequentially.
+                for split in actor_snapshot_splits.iter().skip(next_split_idx) {
+                    tracing::info!(
+                        %table_id,
+                        upstream_table_name,
+                        ?split,
+                        is_snapshot_paused,
+                        "start cdc backfill split"
+                    );
+                    let finished_split_bounds = current_actor_bounds.clone();
+                    let current_split_bounds = Some((
+                        split.left_bound_inclusive.clone(),
+                        split.right_bound_exclusive.clone(),
+                    ));
+                    let restored_state = state_impl.restore_state(split.split_id).await?;
+                    let mut current_pk_pos = restored_state.current_pk_pos;
+                    let mut row_count = restored_state.row_count as u64;
+                    let mut split_cdc_offset_low = restored_state.cdc_offset_low;
 
-                    let _permit = CDC_CONN_SEMAPHORE.acquire().await.unwrap();
-                    upstream_table_reader.current_cdc_offset().await?
-                };
-                if let Some(ref cdc_offset) = split_cdc_offset_low {
-                    if let Some(ref cur) = actor_cdc_offset_low {
-                        if *cur > *cdc_offset {
-                            actor_cdc_offset_low = split_cdc_offset_low.clone();
+                    'backfill_loop: loop {
+                        if split_cdc_offset_low.is_none() {
+                            static CDC_CONN_SEMAPHORE: tokio::sync::Semaphore =
+                                tokio::sync::Semaphore::const_new(10);
+                            let _permit = CDC_CONN_SEMAPHORE.acquire().await.unwrap();
+                            split_cdc_offset_low =
+                                upstream_table_reader.current_cdc_offset().await?;
                         }
-                    } else {
-                        actor_cdc_offset_low = split_cdc_offset_low.clone();
-                    }
-                }
-                let mut split_cdc_offset_high = None;
+                        if let Some(ref cdc_offset) = split_cdc_offset_low {
+                            if actor_cdc_offset_low
+                                .as_ref()
+                                .is_none_or(|cur| cur > cdc_offset)
+                            {
+                                actor_cdc_offset_low = split_cdc_offset_low.clone();
+                            }
+                        }
 
-                let left_upstream = upstream.by_ref().map(Either::Left);
-                let read_args = SplitSnapshotReadArgs::new(
-                    split.left_bound_inclusive.clone(),
-                    split.right_bound_exclusive.clone(),
-                    cdc_table_snapshot_split_column.clone(),
-                    self.rate_limit_rps,
-                    additional_columns.clone(),
-                    schema_table_name.clone(),
-                    external_database_name.clone(),
-                );
-                let right_snapshot = pin!(
-                    upstream_table_reader
-                        .snapshot_read_table_split(read_args)
-                        .map(Either::Right)
-                );
-                let (right_snapshot, snapshot_valve) = pausable(right_snapshot);
-                if is_snapshot_paused {
-                    snapshot_valve.pause();
-                }
-                let mut backfill_stream =
-                    select_with_strategy(left_upstream, right_snapshot, |_: &mut ()| {
-                        stream::PollNext::Left
-                    });
-                let mut row_count: u64 = 0;
-                #[for_await]
-                for either in &mut backfill_stream {
-                    match either {
-                        // Upstream
-                        Either::Left(msg) => {
-                            match msg? {
-                                Message::Barrier(barrier) => {
-                                    state_impl.commit_state(barrier.epoch).await?;
-                                    if let Some(mutation) = barrier.mutation.as_deref() {
-                                        use crate::executor::Mutation;
-                                        match mutation {
-                                            Mutation::Pause => {
-                                                is_snapshot_paused = true;
-                                                snapshot_valve.pause();
+                        // why needed?
+                        // Apply changes to the already snapshotted prefix before starting the new
+                        // query. Changes after the cursor are reflected by that query instead.
+                        let (emitted_chunks, _) = partition_current_split_buffer(
+                            std::mem::take(&mut upstream_chunk_buffer),
+                            current_pk_pos.as_ref(),
+                            &pk_in_output_indices,
+                            &pk_order,
+                            &pk_needs_unsigned_i64_compare,
+                        );
+
+                        for chunk in emitted_chunks {
+                            yield Message::Chunk(chunk);
+                        }
+
+                        let attempt_state = {
+                            let left_upstream = upstream.by_ref().map(Either::Left);
+                            let read_args = SplitSnapshotReadArgs::new(
+                                current_pk_pos.clone(),
+                                pk_names.clone(),
+                                (!is_leftmost_bound(&split.left_bound_inclusive))
+                                    .then(|| split.left_bound_inclusive.clone()),
+                                (!is_rightmost_bound(&split.right_bound_exclusive))
+                                    .then(|| split.right_bound_exclusive.clone()),
+                                cdc_table_snapshot_split_column.clone(),
+                                self.rate_limit_rps,
+                                additional_columns.clone(),
+                                schema_table_name.clone(),
+                                external_database_name.clone(),
+                            );
+                            let right_snapshot = pin!(
+                                upstream_table_reader
+                                    .snapshot_read_table_split(read_args)
+                                    .map(Either::Right)
+                            );
+                            let (right_snapshot, snapshot_valve) = pausable(right_snapshot);
+                            if is_snapshot_paused {
+                                snapshot_valve.pause();
+                            }
+                            let mut backfill_stream = select_with_strategy(
+                                left_upstream,
+                                right_snapshot,
+                                |_: &mut ()| stream::PollNext::Left,
+                            );
+                            let mut attempt_state = SnapshotAttemptState::Reading;
+
+                            #[for_await]
+                            'backfill_stream: for either in &mut backfill_stream {
+                                match either {
+                                    Either::Left(upstream_message) => match upstream_message? {
+                                        Message::Barrier(barrier) => {
+                                            // emit chunks where the PK has advanced past before persisting PK state,
+                                            // or else if we crash after the barrier, past events before PK will be lost
+                                            let (emitted_chunks, retained_chunks) =
+                                                partition_current_split_buffer(
+                                                    std::mem::take(&mut upstream_chunk_buffer),
+                                                    current_pk_pos.as_ref(),
+                                                    &pk_in_output_indices,
+                                                    &pk_order,
+                                                    &pk_needs_unsigned_i64_compare,
+                                                );
+
+                                            upstream_chunk_buffer = retained_chunks;
+
+                                            for chunk in emitted_chunks {
+                                                yield Message::Chunk(chunk);
                                             }
-                                            Mutation::Resume => {
-                                                is_snapshot_paused = false;
-                                                snapshot_valve.resume();
-                                            }
-                                            Mutation::Throttle(_) => {
-                                                // TODO(zw): optimization: improve throttle.
-                                                // 1. Handle rate limit 0. Currently, to resume the process, the actor must be rebuilt.
-                                                // 2. Apply new rate limit immediately.
-                                                if let Some(entry) = mutation
-                                                    .backfill_throttle_config(
-                                                        self.actor_ctx.fragment_id,
-                                                    )
-                                                    && entry.rate_limit != self.rate_limit_rps
-                                                {
-                                                    // The new rate limit will take effect since next split.
-                                                    self.rate_limit_rps = entry.rate_limit;
+
+                                            state_impl
+                                                .mutate_state(
+                                                    split.split_id,
+                                                    current_pk_pos.clone(),
+                                                    false,
+                                                    row_count,
+                                                    split_cdc_offset_low.clone(),
+                                                    None,
+                                                )
+                                                .await?;
+                                            state_impl.commit_state(barrier.epoch).await?;
+
+                                            if let Some(mutation) = barrier.mutation.as_deref() {
+                                                use crate::executor::Mutation;
+                                                match mutation {
+                                                    Mutation::Pause => {
+                                                        is_snapshot_paused = true;
+                                                        snapshot_valve.pause();
+                                                    }
+                                                    Mutation::Resume => {
+                                                        is_snapshot_paused = false;
+                                                        snapshot_valve.resume();
+                                                    }
+                                                    Mutation::Throttle(_) => {
+                                                        if let Some(entry) = mutation
+                                                            .backfill_throttle_config(
+                                                                self.actor_ctx.fragment_id,
+                                                            )
+                                                        {
+                                                            self.rate_limit_rps = entry.rate_limit;
+                                                        }
+                                                    }
+                                                    mutation
+                                                        if mutation.is_stop(self.actor_ctx.id) =>
+                                                    {
+                                                        tracing::info!(
+                                                            %table_id,
+                                                            upstream_table_name,
+                                                            "CdcBackfill has been dropped due to config change"
+                                                        );
+
+                                                        yield Message::Barrier(barrier);
+
+                                                        let () = futures::future::pending().await;
+                                                        unreachable!();
+                                                    }
+                                                    _ => (),
                                                 }
                                             }
-                                            mutation if mutation.is_stop(self.actor_ctx.id) => {
+
+                                            if is_reset_barrier(&barrier, self.actor_ctx.id) {
+                                                upstream_chunk_buffer.clear();
+                                                next_reset_barrier = Some(barrier);
+                                                // restart to apply new split state
+                                                continue 'with_cdc_table_snapshot_splits;
+                                            }
+
+                                            if let (Some(split_range), Some(progress)) = (
+                                                should_report_actor_backfill_progress.take(),
+                                                self.progress.as_ref(),
+                                            ) {
+                                                progress.update(
+                                                    self.actor_ctx.fragment_id,
+                                                    self.actor_ctx.id,
+                                                    barrier.epoch,
+                                                    generation.expect("should have set generation when having progress to report"),
+                                                    split_range,
+                                                );
+                                            }
+
+                                            yield Message::Barrier(barrier);
+
+                                            if matches!(attempt_state, SnapshotAttemptState::Failed)
+                                            {
+                                                break 'backfill_stream;
+                                            }
+                                        }
+                                        Message::Chunk(chunk) => {
+                                            if !chunk.has_visible_rows() {
+                                                continue 'backfill_stream;
+                                            }
+
+                                            // emit chunks belonging to past splits which are processed
+                                            let chunk = mapping_chunk(chunk, &self.output_indices);
+                                            let (finished_chunk, current_chunk) =
+                                                split_finished_and_current_chunk(
+                                                    chunk,
+                                                    &finished_split_bounds,
+                                                    &current_split_bounds,
+                                                    snapshot_split_column_in_output_index,
+                                                );
+
+                                            if let Some(finished_chunk) = finished_chunk {
+                                                yield Message::Chunk(finished_chunk);
+                                            }
+
+                                            if let Some(current_chunk) = current_chunk {
+                                                upstream_chunk_buffer.push(current_chunk);
+                                            }
+                                        }
+                                        Message::Watermark(_) => {
+                                            // ignore watermark during backfill
+                                        }
+                                    },
+                                    Either::Right(snapshot) => {
+                                        // if snapshot already failed, continue polling upstream until barrier arrives to reconstruct reader
+                                        if !matches!(attempt_state, SnapshotAttemptState::Reading) {
+                                            continue 'backfill_stream;
+                                        }
+
+                                        match snapshot {
+                                            Ok(None) => {
                                                 tracing::info!(
                                                     %table_id,
-                                                    upstream_table_name,
-                                                    "CdcBackfill has been dropped due to config change"
+                                                    split_id = split.split_id,
+                                                    "snapshot read stream ends"
                                                 );
+
                                                 for chunk in upstream_chunk_buffer.drain(..) {
                                                     yield Message::Chunk(chunk);
                                                 }
-                                                yield Message::Barrier(barrier);
-                                                let () = futures::future::pending().await;
-                                                unreachable!();
+
+                                                static CDC_CONN_SEMAPHORE: tokio::sync::Semaphore =
+                                                    tokio::sync::Semaphore::const_new(10);
+                                                let _permit =
+                                                    CDC_CONN_SEMAPHORE.acquire().await.unwrap();
+                                                let high = upstream_table_reader
+                                                .current_cdc_offset()
+                                                .await?
+                                                .expect(
+                                                    "CDC offset must be available after snapshot completion",
+                                                );
+                                                attempt_state =
+                                                    SnapshotAttemptState::Finished(high);
+
+                                                break 'backfill_stream;
                                             }
-                                            _ => (),
+                                            Ok(Some(chunk)) => {
+                                                current_pk_pos =
+                                                    Some(get_new_pos(&chunk, &pk_indices));
+                                                row_count = row_count
+                                                    .saturating_add(chunk.cardinality() as u64);
+
+                                                yield Message::Chunk(mapping_chunk(
+                                                    chunk,
+                                                    &self.output_indices,
+                                                ));
+                                            }
+                                            Err(error) => {
+                                                attempt_state = SnapshotAttemptState::Failed;
+                                                tracing::warn!(
+                                                    error = %error.as_report(),
+                                                    %table_id,
+                                                    upstream_table_name,
+                                                    "failed to read CDC snapshot; rebuilding reader after a barrier"
+                                                );
+                                            }
                                         }
                                     }
-                                    if is_reset_barrier(&barrier, self.actor_ctx.id) {
-                                        next_reset_barrier = Some(barrier);
-                                        for chunk in upstream_chunk_buffer.drain(..) {
-                                            yield Message::Chunk(chunk);
-                                        }
-                                        continue 'with_cdc_table_snapshot_splits;
-                                    }
-                                    if let Some(split_range) =
-                                        should_report_actor_backfill_progress.take()
-                                        && let Some(ref progress) = self.progress
-                                    {
-                                        progress.update(
-                                            self.actor_ctx.fragment_id,
-                                            self.actor_ctx.id,
-                                            barrier.epoch,
-                                            generation.expect("should have set generation when having progress to report"),
-                                            split_range,
-                                        );
-                                    }
-                                    // emit barrier and continue to consume the backfill stream
-                                    yield Message::Barrier(barrier);
-                                }
-                                Message::Chunk(chunk) => {
-                                    // skip empty upstream chunk
-                                    if chunk.cardinality() == 0 {
-                                        continue;
-                                    }
-
-                                    // TODO(zw): re-enable
-                                    // let chunk_cdc_offset =
-                                    //     get_cdc_chunk_last_offset(&offset_parse_func, &chunk)?;
-                                    // if *self.external_table.table_type()
-                                    //     == ExternalCdcTableType::Postgres
-                                    //     && let Some(cur) = actor_cdc_offset_low.as_ref()
-                                    //     && let Some(chunk_offset) = chunk_cdc_offset
-                                    //     && chunk_offset < *cur
-                                    // {
-                                    //     continue;
-                                    // }
-
-                                    let chunk = mapping_chunk(chunk, &self.output_indices);
-                                    let (finished_chunk, current_chunk) =
-                                        split_finished_and_current_chunk(
-                                            chunk,
-                                            &finished_split_bounds,
-                                            &current_split_bounds,
-                                            snapshot_split_column_index,
-                                        );
-                                    if let Some(finished_chunk) = finished_chunk
-                                        && finished_chunk.cardinality() > 0
-                                    {
-                                        yield Message::Chunk(finished_chunk);
-                                    }
-                                    if let Some(filtered_chunk) = current_chunk
-                                        && filtered_chunk.cardinality() > 0
-                                    {
-                                        // Buffer only rows that overlap the split currently being backfilled.
-                                        upstream_chunk_buffer.push(filtered_chunk);
-                                    }
-                                }
-                                Message::Watermark(_) => {
-                                    // Ignore watermark during backfill, like the `CdcBackfillExecutor`.
                                 }
                             }
-                        }
-                        // Snapshot read
-                        Either::Right(msg) => {
-                            match msg? {
-                                None => {
-                                    tracing::info!(
-                                        %table_id,
-                                        split_id = split.split_id,
-                                        "snapshot read stream ends"
-                                    );
-                                    for chunk in upstream_chunk_buffer.drain(..) {
-                                        yield Message::Chunk(chunk);
-                                    }
+                            attempt_state
+                        };
 
-                                    split_cdc_offset_high = {
-                                        // Limit concurrent CDC connections globally to 10 using a semaphore.
-                                        static CDC_CONN_SEMAPHORE: tokio::sync::Semaphore =
-                                            tokio::sync::Semaphore::const_new(10);
+                        match attempt_state {
+                            SnapshotAttemptState::Failed => {
+                                upstream_table_reader.disconnect().await?;
 
-                                        let _permit = CDC_CONN_SEMAPHORE.acquire().await.unwrap();
-                                        upstream_table_reader.current_cdc_offset().await?
-                                    };
-                                    if let Some(ref cdc_offset) = split_cdc_offset_high {
-                                        if let Some(ref cur) = actor_cdc_offset_high {
-                                            if *cur < *cdc_offset {
-                                                actor_cdc_offset_high =
-                                                    split_cdc_offset_high.clone();
+                                let mut future = Box::pin(create_table_reader_with_retry(
+                                    self.external_table.clone(),
+                                    self.actor_ctx.id,
+                                    self.actor_ctx.fragment_id,
+                                ));
+                                let table_reader = 'rebuild_reader: loop {
+                                    match build_reader_and_poll_upstream(&mut upstream, &mut future)
+                                        .await?
+                                    {
+                                        Either::Left(msg) => {
+                                            if let Some(msg) =
+                                                mapping_message(msg, &self.output_indices)
+                                            {
+                                                match msg {
+                                                    Message::Barrier(barrier) => {
+                                                        // Rows after the cursor will be reread by the
+                                                        // snapshot query started by the new reader.
+                                                        let (emitted_chunks, _retained_chunks) =
+                                                            partition_current_split_buffer(
+                                                                std::mem::take(
+                                                                    &mut upstream_chunk_buffer,
+                                                                ),
+                                                                current_pk_pos.as_ref(),
+                                                                &pk_in_output_indices,
+                                                                &pk_order,
+                                                                &pk_needs_unsigned_i64_compare,
+                                                            );
+                                                        for chunk in emitted_chunks {
+                                                            yield Message::Chunk(chunk);
+                                                        }
+
+                                                        state_impl
+                                                            .mutate_state(
+                                                                split.split_id,
+                                                                current_pk_pos.clone(),
+                                                                false,
+                                                                row_count,
+                                                                split_cdc_offset_low.clone(),
+                                                                None,
+                                                            )
+                                                            .await?;
+                                                        state_impl
+                                                            .commit_state(barrier.epoch)
+                                                            .await?;
+
+                                                        if let Some(mutation) =
+                                                            barrier.mutation.as_deref()
+                                                        {
+                                                            use crate::executor::Mutation;
+                                                            match mutation {
+                                                                Mutation::Pause => {
+                                                                    is_snapshot_paused = true;
+                                                                }
+                                                                Mutation::Resume => {
+                                                                    is_snapshot_paused = false;
+                                                                }
+                                                                Mutation::Throttle(_) => {
+                                                                    if let Some(entry) = mutation
+                                                                        .backfill_throttle_config(
+                                                                            self.actor_ctx
+                                                                                .fragment_id,
+                                                                        )
+                                                                    {
+                                                                        self.rate_limit_rps =
+                                                                            entry.rate_limit;
+                                                                    }
+                                                                }
+                                                                mutation
+                                                                    if mutation.is_stop(
+                                                                        self.actor_ctx.id,
+                                                                    ) =>
+                                                                {
+                                                                    yield Message::Barrier(barrier);
+                                                                    let () =
+                                                                        futures::future::pending()
+                                                                            .await;
+                                                                    unreachable!();
+                                                                }
+                                                                _ => (),
+                                                            }
+                                                        }
+
+                                                        if is_reset_barrier(
+                                                            &barrier,
+                                                            self.actor_ctx.id,
+                                                        ) {
+                                                            next_reset_barrier = Some(barrier);
+                                                            continue 'with_cdc_table_snapshot_splits;
+                                                        }
+
+                                                        yield Message::Barrier(barrier);
+                                                    }
+                                                    Message::Chunk(chunk) => {
+                                                        let (finished_chunk, current_chunk) =
+                                                        split_finished_and_current_chunk(
+                                                            chunk,
+                                                            &finished_split_bounds,
+                                                            &current_split_bounds,
+                                                            snapshot_split_column_in_output_index,
+                                                        );
+                                                        if let Some(finished_chunk) = finished_chunk
+                                                        {
+                                                            yield Message::Chunk(finished_chunk);
+                                                        }
+                                                        if let Some(current_chunk) = current_chunk {
+                                                            upstream_chunk_buffer
+                                                                .push(current_chunk);
+                                                        }
+                                                    }
+                                                    Message::Watermark(_) => {}
+                                                }
                                             }
-                                        } else {
-                                            actor_cdc_offset_high = split_cdc_offset_high.clone();
+                                        }
+                                        Either::Right(table_reader) => {
+                                            break 'rebuild_reader table_reader;
                                         }
                                     }
-                                    // Next split.
-                                    break;
+                                };
+
+                                pk_needs_unsigned_i64_compare =
+                                    table_reader.pk_column_unsigned_i64_compare_flags(&pk_names)?;
+                                upstream_table_reader = UpstreamTableReader::new(
+                                    self.external_table.clone(),
+                                    table_reader,
+                                );
+
+                                tracing::info!(
+                                    %table_id,
+                                    upstream_table_name,
+                                    "CDC table reader rebuilt successfully"
+                                );
+
+                                continue 'backfill_loop;
+                            }
+                            SnapshotAttemptState::Finished(split_cdc_offset_high) => {
+                                if actor_cdc_offset_high
+                                    .as_ref()
+                                    .is_none_or(|cur| cur < &split_cdc_offset_high)
+                                {
+                                    actor_cdc_offset_high = Some(split_cdc_offset_high.clone());
                                 }
-                                Some(chunk) => {
-                                    let chunk_cardinality = chunk.cardinality() as u64;
-                                    row_count = row_count.saturating_add(chunk_cardinality);
-                                    yield Message::Chunk(mapping_chunk(
-                                        chunk,
-                                        &self.output_indices,
-                                    ));
-                                }
+                                state_impl
+                                    .mutate_state(
+                                        split.split_id,
+                                        current_pk_pos.clone(),
+                                        true,
+                                        row_count,
+                                        split_cdc_offset_low.clone(),
+                                        Some(split_cdc_offset_high),
+                                    )
+                                    .await?;
+
+                                break 'backfill_loop;
+                            }
+                            SnapshotAttemptState::Reading => {
+                                unreachable!(
+                                    "backfill stream must not end while the snapshot attempt is still reading"
+                                );
                             }
                         }
                     }
-                }
-                // Mark current split backfill as finished. The state will be persisted by next barrier.
-                state_impl
-                    .mutate_state(
-                        split.split_id,
-                        true,
-                        row_count,
-                        split_cdc_offset_low,
-                        split_cdc_offset_high,
-                    )
-                    .await?;
-                if let Some((_, right_split)) = &mut should_report_actor_backfill_progress {
-                    assert!(
-                        *right_split < split.split_id,
-                        "{} {}",
-                        *right_split,
-                        split.split_id
-                    );
-                    *right_split = split.split_id;
-                } else {
-                    should_report_actor_backfill_progress = Some((split.split_id, split.split_id));
-                }
-            }
 
-            if let Some(upstream_table_reader) = upstream_table_reader {
+                    extends_current_actor_bound(&mut current_actor_bounds, split);
+                    if let Some((_, right_split)) = &mut should_report_actor_backfill_progress {
+                        assert!(
+                            *right_split < split.split_id,
+                            "{} {}",
+                            *right_split,
+                            split.split_id
+                        );
+                        *right_split = split.split_id;
+                    } else {
+                        should_report_actor_backfill_progress =
+                            Some((split.split_id, split.split_id));
+                    }
+                }
+
                 upstream_table_reader.disconnect().await?;
             }
             tracing::info!(
@@ -570,7 +790,7 @@ impl<S: StateStore> ParallelizedCdcBackfillExecutor<S> {
             // we can forward messages directly to the downstream,
             // as backfill is finished.
             #[for_await]
-            for msg in &mut upstream {
+            'forward_upstream: for msg in &mut upstream {
                 let msg = msg?;
                 match msg {
                     Message::Barrier(barrier) => {
@@ -614,11 +834,8 @@ impl<S: StateStore> ParallelizedCdcBackfillExecutor<S> {
                         yield Message::Barrier(barrier);
                     }
                     Message::Chunk(chunk) => {
-                        if actor_snapshot_splits.is_empty() {
-                            continue;
-                        }
-                        if chunk.cardinality() == 0 {
-                            continue;
+                        if actor_snapshot_splits.is_empty() || !chunk.has_visible_rows() {
+                            continue 'forward_upstream;
                         }
 
                         let chunk_cdc_offset =
@@ -650,9 +867,8 @@ impl<S: StateStore> ParallelizedCdcBackfillExecutor<S> {
                         if let Some(filtered_chunk) = filter_stream_chunk(
                             chunk,
                             &current_actor_bounds,
-                            snapshot_split_column_index,
-                        ) && filtered_chunk.cardinality() > 0
-                        {
+                            snapshot_split_column_in_output_index,
+                        ) {
                             yield Message::Chunk(filtered_chunk);
                         }
                     }
@@ -667,6 +883,77 @@ impl<S: StateStore> ParallelizedCdcBackfillExecutor<S> {
     }
 }
 
+/// Partition buffered CDC rows into those already covered by the current snapshot and those
+/// beyond the snapshot cursor.
+///
+/// The buffer has already been filtered to the current split and mapped to the executor's
+/// output schema, so `pk_indices` must refer to positions in that mapped schema.
+fn partition_current_split_buffer(
+    buffered_chunks: Vec<StreamChunk>,
+    current_pk_pos: Option<&OwnedRow>,
+    pk_indices: &[usize],
+    pk_order: &[OrderType],
+    pk_needs_unsigned_i64_compare: &[bool],
+) -> (Vec<StreamChunk>, Vec<StreamChunk>) {
+    let Some(current_pk_pos) = current_pk_pos else {
+        return (vec![], buffered_chunks);
+    };
+
+    let mut emitted_chunks = Vec::with_capacity(buffered_chunks.len());
+    let mut retained_chunks = Vec::with_capacity(buffered_chunks.len());
+
+    for chunk in buffered_chunks {
+        let mut emitted_vis = BitmapBuilder::zeroed(chunk.capacity());
+        let mut retained_vis = BitmapBuilder::zeroed(chunk.capacity());
+
+        for (op, row) in chunk.rows() {
+            let idx = row.index();
+
+            let reached_current_pos = cmp_pk_unsigned_aware(
+                row.project(pk_indices).iter(),
+                current_pk_pos.iter(),
+                pk_order,
+                pk_needs_unsigned_i64_compare,
+            )
+            .is_le();
+
+            match op {
+                Op::Insert | Op::Delete => {
+                    if reached_current_pos {
+                        emitted_vis.set(idx, true);
+                    } else {
+                        retained_vis.set(idx, true);
+                    }
+                }
+                Op::UpdateDelete | Op::UpdateInsert => {
+                    unreachable!("CDC buffered chunks should not contain update pairs")
+                }
+            }
+        }
+
+        for (vis, output) in [
+            (emitted_vis.finish(), &mut emitted_chunks),
+            (retained_vis.finish(), &mut retained_chunks),
+        ] {
+            if vis.any() {
+                let new_chunk = chunk.clone_with_vis(vis).compact_vis();
+                output.push(new_chunk);
+            }
+        }
+    }
+
+    (emitted_chunks, retained_chunks)
+}
+
+/// Split a CDC chunk into rows belonging to already-finished snapshot splits and rows
+/// belonging to the snapshot split currently being processed.
+///
+/// Finished-split rows can be emitted immediately. Current-split rows must be buffered
+/// until the snapshot cursor reaches them. Rows outside both ranges are omitted.
+///
+/// For example, with finished bounds `[0, 100)`, current bounds `[100, 200)`, and CDC rows with
+/// split keys `[50, 120, 180, 250]`, this returns `[50]` as the finished chunk and `[120, 180]`
+/// as the current chunk. The row with split key `250` is omitted.
 fn split_finished_and_current_chunk(
     chunk: StreamChunk,
     finished_split_bounds: &Option<(OwnedRow, OwnedRow)>,
@@ -685,6 +972,12 @@ fn split_finished_and_current_chunk(
     (finished_chunk, current_chunk)
 }
 
+/// Keep rows whose snapshot split-column value falls within `bound`'s half-open range
+/// `[left, right)`, preserving their operations and relative order through a visibility bitmap.
+/// Returns `None` when no bounds are supplied or no visible rows fall within the range.
+///
+/// For example, filtering split keys `[50, 100, 150, 200]` with bounds `[100, 200)` keeps
+/// `[100, 150]`: the left bound is inclusive and the right bound is exclusive.
 fn filter_stream_chunk(
     chunk: StreamChunk,
     bound: &Option<(OwnedRow, OwnedRow)>,
@@ -704,17 +997,17 @@ fn filter_stream_chunk(
     let is_leftmost_bound = is_leftmost_bound(left);
     let is_rightmost_bound = is_rightmost_bound(right);
     if is_leftmost_bound && is_rightmost_bound {
-        return Some(chunk);
+        return chunk.has_visible_rows().then_some(chunk);
     }
     let mut new_bitmap = BitmapBuilder::with_capacity(chunk.capacity());
     let (ops, columns, visibility) = chunk.into_inner();
-    for (row_split_key, v) in columns[snapshot_split_column_index]
+    'filter_rows: for (row_split_key, v) in columns[snapshot_split_column_index]
         .iter()
         .zip_eq_fast(visibility.iter())
     {
         if !v {
             new_bitmap.append(false);
-            continue;
+            continue 'filter_rows;
         }
         let mut is_in_range = true;
         if !is_leftmost_bound {
@@ -738,11 +1031,12 @@ fn filter_stream_chunk(
         }
         new_bitmap.append(is_in_range);
     }
-    Some(StreamChunk::with_visibility(
-        ops,
-        columns,
-        new_bitmap.finish(),
-    ))
+
+    let visibility = new_bitmap.finish();
+
+    visibility
+        .any()
+        .then_some(StreamChunk::with_visibility(ops, columns, visibility))
 }
 
 fn is_leftmost_bound(row: &OwnedRow) -> bool {

--- a/src/stream/src/executor/backfill/cdc/cdc_backill_v2.rs
+++ b/src/stream/src/executor/backfill/cdc/cdc_backill_v2.rs
@@ -34,7 +34,7 @@ use crate::executor::backfill::cdc::cdc_backfill::{
     build_reader_and_poll_upstream, create_table_reader_with_retry,
     get_cdc_json_parse_handling_from_properties, transform_upstream,
 };
-use crate::executor::backfill::cdc::state_v2::ParallelizedCdcBackfillState;
+use crate::executor::backfill::cdc::state_v2::{CdcStateRecord, ParallelizedCdcBackfillState};
 use crate::executor::backfill::cdc::upstream_table::external::ExternalStorageTable;
 use crate::executor::backfill::cdc::upstream_table::snapshot::{
     SplitSnapshotReadArgs, UpstreamTableRead, UpstreamTableReader,
@@ -232,50 +232,45 @@ impl<S: StateStore> ParallelizedCdcBackfillExecutor<S> {
             let mut current_actor_bounds = None;
             let mut actor_cdc_offset_high: Option<CdcOffset> = None;
             let mut actor_cdc_offset_low: Option<CdcOffset> = None;
-            // Find next split that need backfill.
-            let mut next_unfinished_split = None;
+            let mut split_states = Vec::with_capacity(actor_snapshot_splits.len());
 
-            for (idx, split) in actor_snapshot_splits.iter().enumerate() {
+            for split in &actor_snapshot_splits {
                 let state = state_impl.restore_state(split.split_id).await?;
-
-                if !state.is_finished {
-                    next_unfinished_split = Some((idx, state));
-                    break;
-                }
-
                 extends_current_actor_bound(&mut current_actor_bounds, split);
 
-                if let Some(cdc_offset) = state.cdc_offset_low
-                    && actor_cdc_offset_low
-                        .as_ref()
-                        .is_none_or(|current| current > &cdc_offset)
-                {
-                    actor_cdc_offset_low = Some(cdc_offset);
+                if state.is_finished {
+                    if let Some(cdc_offset) = state.cdc_offset_low.as_ref()
+                        && actor_cdc_offset_low
+                            .as_ref()
+                            .is_none_or(|current| current > cdc_offset)
+                    {
+                        actor_cdc_offset_low = Some(cdc_offset.clone());
+                    }
+
+                    if let Some(cdc_offset) = state.cdc_offset_high.as_ref()
+                        && actor_cdc_offset_high
+                            .as_ref()
+                            .is_none_or(|current| current < cdc_offset)
+                    {
+                        actor_cdc_offset_high = Some(cdc_offset.clone());
+                    }
                 }
 
-                if let Some(cdc_offset) = state.cdc_offset_high
-                    && actor_cdc_offset_high
-                        .as_ref()
-                        .is_none_or(|current| current < &cdc_offset)
-                {
-                    actor_cdc_offset_high = Some(cdc_offset);
-                }
+                split_states.push(state);
             }
 
-            let mut should_report_actor_backfill_progress = None;
+            let next_unfinished_split = split_states.iter().position(|state| !state.is_finished);
+            let finished_prefix_len = next_unfinished_split.unwrap_or(actor_snapshot_splits.len());
+            let mut should_report_actor_backfill_progress = (finished_prefix_len > 0).then(|| {
+                (
+                    actor_snapshot_splits[0].split_id,
+                    actor_snapshot_splits[finished_prefix_len - 1].split_id,
+                )
+            });
 
-            if let Some((next_split_idx, _)) = next_unfinished_split.as_ref() {
-                for split in actor_snapshot_splits.iter().skip(*next_split_idx) {
-                    // Initialize state so that overall progress can be measured.
-                    state_impl.init_state_if_absent(split.split_id).await?;
-                }
-
-                if *next_split_idx > 0 {
-                    should_report_actor_backfill_progress = Some((
-                        actor_snapshot_splits[0].split_id,
-                        actor_snapshot_splits[*next_split_idx - 1].split_id,
-                    ));
-                }
+            for split in &actor_snapshot_splits {
+                // Initialize state so that overall progress can be measured.
+                state_impl.init_state_if_absent(split.split_id).await?;
             }
 
             let offset_parse_func = self.external_table.table_type().get_cdc_offset_parser()?;
@@ -284,7 +279,8 @@ impl<S: StateStore> ParallelizedCdcBackfillExecutor<S> {
             // A reader is only needed while at least one assigned snapshot split is unfinished.
             // Once all splits are complete, the executor only forwards the table-filtered CDC
             // stream and must not depend on the upstream snapshot table still existing.
-            if let Some((next_split_idx, next_split_state)) = next_unfinished_split {
+            if let Some(next_split_idx) = next_unfinished_split {
+                let next_split_state = &split_states[next_split_idx];
                 let external_table = self.external_table.clone();
                 let actor_id = self.actor_ctx.id;
                 let fragment_id = self.actor_ctx.fragment_id;
@@ -295,12 +291,6 @@ impl<S: StateStore> ParallelizedCdcBackfillExecutor<S> {
                 ));
 
                 let next_split = &actor_snapshot_splits[next_split_idx];
-                let finished_split_bounds = current_actor_bounds.clone();
-                let current_split_bounds = Some((
-                    next_split.left_bound_inclusive.clone(),
-                    next_split.right_bound_exclusive.clone(),
-                ));
-
                 let table_reader = loop {
                     match build_reader_and_poll_upstream(&mut upstream, &mut future).await? {
                         Either::Left(msg) => {
@@ -343,20 +333,23 @@ impl<S: StateStore> ParallelizedCdcBackfillExecutor<S> {
                                         }
                                     }
                                     Message::Chunk(chunk) => {
-                                        let (finished_chunk, current_chunk) =
-                                            split_finished_and_current_chunk(
-                                                chunk,
-                                                &finished_split_bounds,
-                                                &current_split_bounds,
-                                                snapshot_split_column_in_output_index,
-                                            );
+                                        let (forwarded_chunk, buffered_chunk) = route_cdc_chunk(
+                                            chunk,
+                                            &actor_snapshot_splits,
+                                            &split_states,
+                                            next_split_idx,
+                                            snapshot_split_column_in_output_index,
+                                            &pk_in_output_indices,
+                                            &pk_order,
+                                            &pk_needs_unsigned_i64_compare,
+                                        );
 
-                                        if let Some(finished_chunk) = finished_chunk {
-                                            yield Message::Chunk(finished_chunk);
+                                        if let Some(forwarded_chunk) = forwarded_chunk {
+                                            yield Message::Chunk(forwarded_chunk);
                                         }
 
-                                        if let Some(current_chunk) = current_chunk {
-                                            upstream_chunk_buffer.push(current_chunk);
+                                        if let Some(buffered_chunk) = buffered_chunk {
+                                            upstream_chunk_buffer.push(buffered_chunk);
                                         }
                                     }
                                     Message::Watermark(_) => {
@@ -381,7 +374,20 @@ impl<S: StateStore> ParallelizedCdcBackfillExecutor<S> {
                     UpstreamTableReader::new(self.external_table.clone(), table_reader);
 
                 // Backfill snapshot splits sequentially.
-                for split in actor_snapshot_splits.iter().skip(next_split_idx) {
+                for (split_idx, (split, restored_state)) in actor_snapshot_splits
+                    .iter()
+                    .zip_eq_fast(split_states.iter())
+                    .enumerate()
+                    .skip(next_split_idx)
+                {
+                    if restored_state.is_finished {
+                        extend_backfill_progress(
+                            &mut should_report_actor_backfill_progress,
+                            split.split_id,
+                        );
+
+                        continue;
+                    }
                     tracing::info!(
                         %table_id,
                         upstream_table_name,
@@ -389,15 +395,9 @@ impl<S: StateStore> ParallelizedCdcBackfillExecutor<S> {
                         is_snapshot_paused,
                         "start cdc backfill split"
                     );
-                    let finished_split_bounds = current_actor_bounds.clone();
-                    let current_split_bounds = Some((
-                        split.left_bound_inclusive.clone(),
-                        split.right_bound_exclusive.clone(),
-                    ));
-                    let restored_state = state_impl.restore_state(split.split_id).await?;
-                    let mut current_pk_pos = restored_state.current_pk_pos;
+                    let mut current_pk_pos = restored_state.current_pk_pos.clone();
                     let mut row_count = restored_state.row_count as u64;
-                    let mut split_cdc_offset_low = restored_state.cdc_offset_low;
+                    let mut split_cdc_offset_low = restored_state.cdc_offset_low.clone();
 
                     let split_cdc_offset_high = 'backfill_loop: loop {
                         if split_cdc_offset_low.is_none() {
@@ -586,21 +586,24 @@ impl<S: StateStore> ParallelizedCdcBackfillExecutor<S> {
 
                                             // emit chunks belonging to past splits which are processed
                                             let chunk = mapping_chunk(chunk, &self.output_indices);
-                                            let (finished_chunk, current_chunk) =
-                                                split_finished_and_current_chunk(
-                                                    chunk,
-                                                    &finished_split_bounds,
-                                                    &current_split_bounds,
-                                                    snapshot_split_column_in_output_index,
-                                                );
+                                            let (forwarded_chunk, buffered_chunk) = route_cdc_chunk(
+                                                chunk,
+                                                &actor_snapshot_splits,
+                                                &split_states,
+                                                split_idx,
+                                                snapshot_split_column_in_output_index,
+                                                &pk_in_output_indices,
+                                                &pk_order,
+                                                &pk_needs_unsigned_i64_compare,
+                                            );
 
-                                            if let Some(finished_chunk) = finished_chunk {
-                                                yield Message::Chunk(finished_chunk);
+                                            if let Some(forwarded_chunk) = forwarded_chunk {
+                                                yield Message::Chunk(forwarded_chunk);
                                             }
 
-                                            if let Some(current_chunk) = current_chunk {
+                                            if let Some(buffered_chunk) = buffered_chunk {
                                                 // Buffer only rows that overlap the split currently being backfilled.
-                                                upstream_chunk_buffer.push(current_chunk);
+                                                upstream_chunk_buffer.push(buffered_chunk);
                                             }
                                         }
                                         Message::Watermark(_) => {
@@ -775,20 +778,28 @@ impl<S: StateStore> ParallelizedCdcBackfillExecutor<S> {
                                                         yield Message::Barrier(barrier);
                                                     }
                                                     Message::Chunk(chunk) => {
-                                                        let (finished_chunk, current_chunk) =
-                                                        split_finished_and_current_chunk(
-                                                            chunk,
-                                                            &finished_split_bounds,
-                                                            &current_split_bounds,
-                                                            snapshot_split_column_in_output_index,
-                                                        );
-                                                        if let Some(finished_chunk) = finished_chunk
+                                                        let (forwarded_chunk, buffered_chunk) =
+                                                            route_cdc_chunk(
+                                                                chunk,
+                                                                &actor_snapshot_splits,
+                                                                &split_states,
+                                                                split_idx,
+                                                                snapshot_split_column_in_output_index,
+                                                                &pk_in_output_indices,
+                                                                &pk_order,
+                                                                &pk_needs_unsigned_i64_compare,
+                                                            );
+
+                                                        if let Some(forwarded_chunk) =
+                                                            forwarded_chunk
                                                         {
-                                                            yield Message::Chunk(finished_chunk);
+                                                            yield Message::Chunk(forwarded_chunk);
                                                         }
-                                                        if let Some(current_chunk) = current_chunk {
+
+                                                        if let Some(buffered_chunk) = buffered_chunk
+                                                        {
                                                             upstream_chunk_buffer
-                                                                .push(current_chunk);
+                                                                .push(buffered_chunk);
                                                         }
                                                     }
                                                     Message::Watermark(_) => {}
@@ -843,19 +854,10 @@ impl<S: StateStore> ParallelizedCdcBackfillExecutor<S> {
                         )
                         .await?;
 
-                    extends_current_actor_bound(&mut current_actor_bounds, split);
-                    if let Some((_, right_split)) = &mut should_report_actor_backfill_progress {
-                        assert!(
-                            *right_split < split.split_id,
-                            "{} {}",
-                            *right_split,
-                            split.split_id
-                        );
-                        *right_split = split.split_id;
-                    } else {
-                        should_report_actor_backfill_progress =
-                            Some((split.split_id, split.split_id));
-                    }
+                    extend_backfill_progress(
+                        &mut should_report_actor_backfill_progress,
+                        split.split_id,
+                    );
                 }
 
                 upstream_table_reader.disconnect().await?;
@@ -1026,31 +1028,108 @@ fn partition_current_split_buffer(
     (emitted_chunks, retained_chunks)
 }
 
-/// Split a CDC chunk into rows belonging to already-finished snapshot splits and rows
-/// belonging to the snapshot split currently being processed.
-///
-/// Finished-split rows can be emitted immediately. Current-split rows must be buffered
-/// until the snapshot cursor reaches them. Rows outside both ranges are omitted.
-///
-/// For example, with finished bounds `[0, 100)`, current bounds `[100, 200)`, and CDC rows with
-/// split keys `[50, 120, 180, 250]`, this returns `[50]` as the finished chunk and `[120, 180]`
-/// as the current chunk. The row with split key `250` is omitted.
-fn split_finished_and_current_chunk(
+/// Route CDC using every assigned split's progress. The active split retains its existing
+/// buffering behavior. Other splits forward changes to already-snapshotted rows, while their
+/// unread suffixes are left for a future snapshot. Assignment bounds are sorted and consecutive.
+#[expect(clippy::too_many_arguments)]
+fn route_cdc_chunk(
     chunk: StreamChunk,
-    finished_split_bounds: &Option<(OwnedRow, OwnedRow)>,
-    current_split_bounds: &Option<(OwnedRow, OwnedRow)>,
+    splits: &[CdcTableSnapshotSplit],
+    states: &[CdcStateRecord],
+    current_split_idx: usize,
     snapshot_split_column_index: usize,
+    pk_indices: &[usize],
+    pk_order: &[OrderType],
+    pk_needs_unsigned_i64_compare: &[bool],
 ) -> (Option<StreamChunk>, Option<StreamChunk>) {
-    let finished_chunk = filter_stream_chunk(
-        chunk.clone(),
-        finished_split_bounds,
-        snapshot_split_column_index,
-    )
-    .map(StreamChunk::compact_vis);
-    let current_chunk =
-        filter_stream_chunk(chunk, current_split_bounds, snapshot_split_column_index)
-            .map(StreamChunk::compact_vis);
-    (finished_chunk, current_chunk)
+    let mut forwarded = BitmapBuilder::zeroed(chunk.capacity());
+    let mut buffered = BitmapBuilder::zeroed(chunk.capacity());
+
+    for (_, row) in chunk.rows() {
+        let split_key = row.datum_at(snapshot_split_column_index);
+
+        // binary search to find split containing row
+        // find split where key < right bound
+        let split_idx = splits.partition_point(|split| {
+            !is_rightmost_bound(&split.right_bound_exclusive)
+                && cmp_datum(
+                    split.right_bound_exclusive.datum_at(0),
+                    split_key,
+                    OrderType::ascending_nulls_first(),
+                )
+                .is_le()
+        });
+
+        let Some(split) = splits.get(split_idx) else {
+            // key is outside of assigned split ranges
+            continue;
+        };
+
+        // skip if key < left bound
+        if !is_leftmost_bound(&split.left_bound_inclusive)
+            && cmp_datum(
+                split_key,
+                split.left_bound_inclusive.datum_at(0),
+                OrderType::ascending_nulls_first(),
+            )
+            .is_lt()
+        {
+            continue;
+        }
+
+        // buffer rows in active split
+        if split_idx == current_split_idx {
+            buffered.set(row.index(), true);
+            continue;
+        }
+
+        let state = &states[split_idx];
+        // splits before active split must be finished,
+        // since we start processing from the first unfinished split
+        //
+        // splits after active split can be finished
+        // in some cases of scaling in
+        let is_finished = split_idx < current_split_idx || state.is_finished;
+        let is_before_cursor = state.current_pk_pos.as_ref().is_some_and(|cursor| {
+            cmp_pk_unsigned_aware(
+                row.project(pk_indices).iter(),
+                cursor.iter(),
+                pk_order,
+                pk_needs_unsigned_i64_compare,
+            )
+            .is_le()
+        });
+
+        if is_finished || is_before_cursor {
+            forwarded.set(row.index(), true);
+        }
+
+        // Otherwise leave both bits unset. This row belongs to an unread suffix
+        // of a later split, whose future snapshot will cover it.
+    }
+
+    let forwarded = forwarded.finish();
+    let forwarded_chunk = forwarded
+        .any()
+        .then(|| chunk.clone_with_vis(forwarded).compact_vis());
+
+    let buffered = buffered.finish();
+    let buffered_chunk = buffered
+        .any()
+        .then(|| chunk.clone_with_vis(buffered).compact_vis());
+
+    (forwarded_chunk, buffered_chunk)
+}
+
+// Report only a contiguous completed range as the sequential scan advances,
+// including previously finished splits that it skips.
+fn extend_backfill_progress(progress: &mut Option<(i64, i64)>, split_id: i64) {
+    if let Some((_, right)) = progress {
+        assert!(*right < split_id);
+        *right = split_id;
+    } else {
+        *progress = Some((split_id, split_id));
+    }
 }
 
 /// Keep rows whose snapshot split-column value falls within `bound`'s half-open range
@@ -1120,10 +1199,12 @@ fn filter_stream_chunk(
         .then_some(StreamChunk::with_visibility(ops, columns, visibility))
 }
 
+// has no left bound, e.g. [-inf, N)
 fn is_leftmost_bound(row: &OwnedRow) -> bool {
     row.iter().all(|d| d.is_none())
 }
 
+// has no right bound, e.g. [N, inf)
 fn is_rightmost_bound(row: &OwnedRow) -> bool {
     row.iter().all(|d| d.is_none())
 }
@@ -1443,7 +1524,7 @@ mod tests {
     }
 
     #[test]
-    fn test_split_finished_and_current_chunk() {
+    fn test_route_cdc_chunk() {
         use risingwave_common::array::StreamChunkTestExt;
 
         let chunk = StreamChunk::from_pretty(
@@ -1452,35 +1533,172 @@ mod tests {
              + 6 10
              + 199 40",
         );
-        let finished_split_bounds = Some((
-            OwnedRow::new(vec![Some(ScalarImpl::Int64(1))]),
-            OwnedRow::new(vec![Some(ScalarImpl::Int64(6))]),
-        ));
-        let current_split_bounds = Some((
-            OwnedRow::new(vec![Some(ScalarImpl::Int64(6))]),
-            OwnedRow::new(vec![Some(ScalarImpl::Int64(100))]),
-        ));
+        let splits = [(1_i64, 6_i64), (6, 100)]
+            .into_iter()
+            .enumerate()
+            .map(|(idx, (left, right))| {
+                let bound = |value: i64| OwnedRow::new(vec![Some(value.into())]);
 
-        let (finished_chunk, current_chunk) = split_finished_and_current_chunk(
+                CdcTableSnapshotSplit {
+                    split_id: idx as i64,
+                    left_bound_inclusive: bound(left),
+                    right_bound_exclusive: bound(right),
+                }
+            })
+            .collect_vec();
+        let states = [
+            CdcStateRecord {
+                is_finished: true,
+                ..Default::default()
+            },
+            CdcStateRecord::default(),
+        ];
+
+        let (forwarded_chunk, buffered_chunk) = route_cdc_chunk(
             chunk,
-            &finished_split_bounds,
-            &current_split_bounds,
+            &splits,
+            &states,
+            1,
             0,
+            &[0],
+            &[OrderType::ascending()],
+            &[false],
         );
 
         assert_eq!(
-            finished_chunk.unwrap(),
+            forwarded_chunk.unwrap(),
             StreamChunk::from_pretty(
                 "  I I
                  + 1 11",
             )
         );
         assert_eq!(
-            current_chunk.unwrap(),
+            buffered_chunk.unwrap(),
             StreamChunk::from_pretty(
                 "  I I
                  + 6 10",
             )
+        );
+    }
+
+    #[test]
+    fn test_route_cdc_chunk_with_mixed_split_progress() {
+        use risingwave_common::array::StreamChunkTestExt;
+
+        let bound = |value: i64| OwnedRow::new(vec![Some(value.into())]);
+        let splits = [(1, 100), (100, 200), (200, 300), (300, 400)]
+            .into_iter()
+            .enumerate()
+            .map(|(idx, (left, right))| CdcTableSnapshotSplit {
+                split_id: idx as i64,
+                left_bound_inclusive: bound(left),
+                right_bound_exclusive: bound(right),
+            })
+            .collect_vec();
+
+        // After scale-in:
+        // [finished, active with cursor 150, unfinished with cursor 250, not started]
+        let states = [
+            CdcStateRecord {
+                is_finished: true,
+                ..Default::default()
+            },
+            CdcStateRecord {
+                current_pk_pos: Some(bound(150)),
+                ..Default::default()
+            },
+            CdcStateRecord {
+                current_pk_pos: Some(bound(250)),
+                ..Default::default()
+            },
+            CdcStateRecord::default(),
+        ];
+
+        // splits: [1, 100), [100, 200), [200, 300), [300, 400)
+        // status: finished, active,     unfinished, not started
+        // cursor: None,     150,        250,        N/A
+        //
+        // chunk       expected     split         status         cursor
+        // + 0   0     dropped      before        N/A            N/A
+        // + 1   1     forwarded    [1, 100)      finished       None
+        // + 100 10    buffered     [100, 200)    active         150
+        // - 150 15    buffered     [100, 200)    active         150
+        // + 151 17    buffered     [100, 200)    active         150
+        // + 200 20    forwarded    [200, 300)    unfinished     250
+        // + 251 25    dropped      [200, 300)    unfinished     250
+        // + 300 30    dropped      [300, 400)    not started    None
+        // + 400 40    dropped      after         N/A            N/A
+        let chunk = StreamChunk::from_pretty(
+            "  I I
+             + 0 0
+             + 1 1
+             + 100 10
+             - 150 15
+             + 151 17
+             + 200 20
+             + 251 25
+             + 300 30
+             + 400 40",
+        );
+        let (forwarded_chunk, buffered_chunk) = route_cdc_chunk(
+            chunk,
+            &splits,
+            &states,
+            1,
+            0,
+            &[0],
+            &[OrderType::ascending()],
+            &[false],
+        );
+
+        // Forward the finished split and already-snapshotted rows of the unfinished split.
+        assert_eq!(
+            forwarded_chunk.unwrap(),
+            StreamChunk::from_pretty(
+                "  I I
+             + 1 1
+             + 200 20",
+            )
+        );
+
+        let buffered_chunk = buffered_chunk.unwrap();
+
+        // Routing buffers the entire active split, including rows at/before its cursor.
+        assert_eq!(
+            buffered_chunk,
+            StreamChunk::from_pretty(
+                "  I I
+             + 100 10
+             - 150 15
+             + 151 17",
+            )
+        );
+
+        // At a barrier, rows through the cursor are emitted and only its unread suffix
+        // stays buffered. The row at PK 150 is included in the emitted rows.
+        let (emitted, retained) = partition_current_split_buffer(
+            vec![buffered_chunk],
+            states[1].current_pk_pos.as_ref(),
+            &[0],
+            &[OrderType::ascending()],
+            &[false],
+        );
+
+        assert_eq!(
+            emitted,
+            vec![StreamChunk::from_pretty(
+                "  I I
+             + 100 10
+             - 150 15",
+            )]
+        );
+
+        assert_eq!(
+            retained,
+            vec![StreamChunk::from_pretty(
+                "  I I
+             + 151 17",
+            )]
         );
     }
 }

--- a/src/stream/src/executor/backfill/cdc/cdc_backill_v2.rs
+++ b/src/stream/src/executor/backfill/cdc/cdc_backill_v2.rs
@@ -37,7 +37,7 @@ use crate::executor::backfill::cdc::cdc_backfill::{
 use crate::executor::backfill::cdc::state_v2::ParallelizedCdcBackfillState;
 use crate::executor::backfill::cdc::upstream_table::external::ExternalStorageTable;
 use crate::executor::backfill::cdc::upstream_table::snapshot::{
-    SplitSnapshotReadArgs, SplitSnapshotReadArgsInput, UpstreamTableRead, UpstreamTableReader,
+    SplitSnapshotReadArgs, UpstreamTableRead, UpstreamTableReader,
 };
 use crate::executor::backfill::utils::{
     cmp_pk_unsigned_aware, get_cdc_chunk_last_offset, get_new_pos, mapping_chunk, mapping_message,
@@ -399,7 +399,7 @@ impl<S: StateStore> ParallelizedCdcBackfillExecutor<S> {
                     let mut row_count = restored_state.row_count as u64;
                     let mut split_cdc_offset_low = restored_state.cdc_offset_low;
 
-                    'backfill_loop: loop {
+                    let split_cdc_offset_high = 'backfill_loop: loop {
                         if split_cdc_offset_low.is_none() {
                             static CDC_CONN_SEMAPHORE: tokio::sync::Semaphore =
                                 tokio::sync::Semaphore::const_new(10);
@@ -431,24 +431,23 @@ impl<S: StateStore> ParallelizedCdcBackfillExecutor<S> {
 
                         let attempt_state = {
                             let left_upstream = upstream.by_ref().map(Either::Left);
-                            let read_args =
-                                SplitSnapshotReadArgs::new(SplitSnapshotReadArgsInput {
-                                    current_pos: current_pk_pos.clone(),
-                                    primary_keys: pk_names.clone(),
-                                    left_bound_inclusive: (!is_leftmost_bound(
-                                        &split.left_bound_inclusive,
-                                    ))
-                                    .then(|| split.left_bound_inclusive.clone()),
-                                    right_bound_exclusive: (!is_rightmost_bound(
-                                        &split.right_bound_exclusive,
-                                    ))
-                                    .then(|| split.right_bound_exclusive.clone()),
-                                    split_columns: cdc_table_snapshot_split_column.clone(),
-                                    rate_limit_rps: self.rate_limit_rps,
-                                    additional_columns: additional_columns.clone(),
-                                    schema_table_name: schema_table_name.clone(),
-                                    database_name: external_database_name.clone(),
-                                });
+                            let read_args = SplitSnapshotReadArgs {
+                                current_pos: current_pk_pos.clone(),
+                                primary_keys: pk_names.clone(),
+                                left_bound_inclusive: (!is_leftmost_bound(
+                                    &split.left_bound_inclusive,
+                                ))
+                                .then(|| split.left_bound_inclusive.clone()),
+                                right_bound_exclusive: (!is_rightmost_bound(
+                                    &split.right_bound_exclusive,
+                                ))
+                                .then(|| split.right_bound_exclusive.clone()),
+                                split_columns: cdc_table_snapshot_split_column.clone(),
+                                rate_limit_rps: self.rate_limit_rps,
+                                additional_columns: additional_columns.clone(),
+                                schema_table_name: schema_table_name.clone(),
+                                database_name: external_database_name.clone(),
+                            };
                             let right_snapshot = pin!(
                                 upstream_table_reader
                                     .snapshot_read_table_split(read_args)
@@ -511,11 +510,15 @@ impl<S: StateStore> ParallelizedCdcBackfillExecutor<S> {
                                                         snapshot_valve.resume();
                                                     }
                                                     Mutation::Throttle(_) => {
+                                                        // TODO(zw): optimization: improve throttle.
+                                                        // 1. Handle rate limit 0. Currently, to resume the process, the actor must be rebuilt.
+                                                        // 2. Apply new rate limit immediately.
                                                         if let Some(entry) = mutation
                                                             .backfill_throttle_config(
                                                                 self.actor_ctx.fragment_id,
                                                             )
                                                         {
+                                                            // The new rate limit will take effect since next split.
                                                             self.rate_limit_rps = entry.rate_limit;
                                                         }
                                                     }
@@ -569,6 +572,18 @@ impl<S: StateStore> ParallelizedCdcBackfillExecutor<S> {
                                                 continue 'backfill_stream;
                                             }
 
+                                            // TODO(zw): re-enable
+                                            // let chunk_cdc_offset =
+                                            //     get_cdc_chunk_last_offset(&offset_parse_func, &chunk)?;
+                                            // if *self.external_table.table_type()
+                                            //     == ExternalCdcTableType::Postgres
+                                            //     && let Some(cur) = actor_cdc_offset_low.as_ref()
+                                            //     && let Some(chunk_offset) = chunk_cdc_offset
+                                            //     && chunk_offset < *cur
+                                            // {
+                                            //     continue;
+                                            // }
+
                                             // emit chunks belonging to past splits which are processed
                                             let chunk = mapping_chunk(chunk, &self.output_indices);
                                             let (finished_chunk, current_chunk) =
@@ -584,6 +599,7 @@ impl<S: StateStore> ParallelizedCdcBackfillExecutor<S> {
                                             }
 
                                             if let Some(current_chunk) = current_chunk {
+                                                // Buffer only rows that overlap the split currently being backfilled.
                                                 upstream_chunk_buffer.push(current_chunk);
                                             }
                                         }
@@ -609,6 +625,7 @@ impl<S: StateStore> ParallelizedCdcBackfillExecutor<S> {
                                                     yield Message::Chunk(chunk);
                                                 }
 
+                                                // Limit concurrent CDC connections globally to 10 using a semaphore.
                                                 static CDC_CONN_SEMAPHORE: tokio::sync::Semaphore =
                                                     tokio::sync::Semaphore::const_new(10);
                                                 let _permit =
@@ -652,6 +669,9 @@ impl<S: StateStore> ParallelizedCdcBackfillExecutor<S> {
                         };
 
                         match attempt_state {
+                            SnapshotAttemptState::Finished(split_cdc_offset_high) => {
+                                break 'backfill_loop split_cdc_offset_high;
+                            }
                             SnapshotAttemptState::Failed => {
                                 if let Err(error) = upstream_table_reader.disconnect().await {
                                     tracing::warn!(
@@ -796,33 +816,32 @@ impl<S: StateStore> ParallelizedCdcBackfillExecutor<S> {
 
                                 continue 'backfill_loop;
                             }
-                            SnapshotAttemptState::Finished(split_cdc_offset_high) => {
-                                if actor_cdc_offset_high
-                                    .as_ref()
-                                    .is_none_or(|cur| cur < &split_cdc_offset_high)
-                                {
-                                    actor_cdc_offset_high = Some(split_cdc_offset_high.clone());
-                                }
-                                state_impl
-                                    .mutate_state(
-                                        split.split_id,
-                                        current_pk_pos.clone(),
-                                        true,
-                                        row_count,
-                                        split_cdc_offset_low.clone(),
-                                        Some(split_cdc_offset_high),
-                                    )
-                                    .await?;
-
-                                break 'backfill_loop;
-                            }
                             SnapshotAttemptState::Reading => {
                                 unreachable!(
                                     "backfill stream must not end while the snapshot attempt is still reading"
                                 );
                             }
                         }
+                    };
+
+                    if actor_cdc_offset_high
+                        .as_ref()
+                        .is_none_or(|cur| cur < &split_cdc_offset_high)
+                    {
+                        actor_cdc_offset_high = Some(split_cdc_offset_high.clone());
                     }
+
+                    // Mark current split backfill as finished. The state will be persisted by next barrier.
+                    state_impl
+                        .mutate_state(
+                            split.split_id,
+                            current_pk_pos.clone(),
+                            true,
+                            row_count,
+                            split_cdc_offset_low.clone(),
+                            Some(split_cdc_offset_high),
+                        )
+                        .await?;
 
                     extends_current_actor_bound(&mut current_actor_bounds, split);
                     if let Some((_, right_split)) = &mut should_report_actor_backfill_progress {

--- a/src/stream/src/executor/backfill/cdc/cdc_backill_v2.rs
+++ b/src/stream/src/executor/backfill/cdc/cdc_backill_v2.rs
@@ -1582,6 +1582,60 @@ mod tests {
     }
 
     #[test]
+    fn test_route_cdc_chunk_preserves_deletes_from_later_splits() {
+        use risingwave_common::array::StreamChunkTestExt;
+
+        let bound = |value: i64| OwnedRow::new(vec![Some(value.into())]);
+        let splits = [(100, 200), (200, 300), (300, 400)]
+            .into_iter()
+            .enumerate()
+            .map(|(idx, (left, right))| CdcTableSnapshotSplit {
+                split_id: idx as i64,
+                left_bound_inclusive: bound(left),
+                right_bound_exclusive: bound(right),
+            })
+            .collect_vec();
+        let states = [
+            CdcStateRecord {
+                current_pk_pos: Some(bound(150)),
+                ..Default::default()
+            },
+            CdcStateRecord {
+                is_finished: true,
+                ..Default::default()
+            },
+            CdcStateRecord {
+                current_pk_pos: Some(bound(350)),
+                ..Default::default()
+            },
+        ];
+
+        // Both rows were emitted before scale-in. Their deletes must be forwarded
+        // while the earlier split is active; later snapshots cannot remove them.
+        // chunk       expected     split         status         cursor
+        // - 220 22    forwarded    [200, 300)    finished       None
+        // - 320 32    forwarded    [300, 400)    unfinished     350
+        let deletes = StreamChunk::from_pretty(
+            "  I I
+             - 220 22
+             - 320 32",
+        );
+        let (forwarded_chunk, buffered_chunk) = route_cdc_chunk(
+            deletes.clone(),
+            &splits,
+            &states,
+            0,
+            0,
+            &[0],
+            &[OrderType::ascending()],
+            &[false],
+        );
+
+        assert_eq!(forwarded_chunk, Some(deletes));
+        assert!(buffered_chunk.is_none());
+    }
+
+    #[test]
     fn test_route_cdc_chunk_with_mixed_split_progress() {
         use risingwave_common::array::StreamChunkTestExt;
 

--- a/src/stream/src/executor/backfill/cdc/state_v2.rs
+++ b/src/stream/src/executor/backfill/cdc/state_v2.rs
@@ -12,8 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::ops::Range;
+
 use anyhow::anyhow;
 use risingwave_common::row;
+use risingwave_common::row::OwnedRow;
 use risingwave_common::types::{JsonbVal, ScalarImpl};
 use risingwave_common::util::epoch::EpochPair;
 use risingwave_connector::source::cdc::external::CdcOffset;
@@ -24,29 +27,108 @@ use crate::executor::StreamExecutorResult;
 
 #[derive(Debug, Default)]
 pub struct CdcStateRecord {
+    pub current_pk_pos: Option<OwnedRow>,
     pub is_finished: bool,
-    #[expect(dead_code)]
     pub row_count: i64,
     pub cdc_offset_low: Option<CdcOffset>,
     pub cdc_offset_high: Option<CdcOffset>,
 }
 
-/// state schema: | `split_id` | `backfill_finished` | `row_count` | `cdc_offset_low` | `cdc_offset_high` |
-/// legacy state schema: | `split_id` | `backfill_finished` | `row_count` |
+/// V1 state schema: | `split_id` | `backfill_finished` | `row_count` |
+/// V2 state schema: | `split_id` | `backfill_finished` | `row_count` | `cdc_offset_low` | `cdc_offset_high` |
+/// V3 state schema: | `split_id` | `backfill_finished` | `row_count` | `cdc_offset_low` | `cdc_offset_high` | `pk...` |
 pub struct ParallelizedCdcBackfillState<S: StateStore> {
     state_table: StateTable<S>,
-    state_len: usize,
-    is_legacy_state: bool,
+    layout: ParallelizedCdcBackfillStateLayout,
+}
+
+#[derive(Debug, Clone, Copy)]
+enum ParallelizedCdcBackfillStateLayout {
+    Legacy,
+    WithCdcOffsets,
+    WithSnapshotCursor { pk_len: usize },
+}
+
+struct StateFieldIndices {
+    finished: usize,
+    row_count: usize,
+    cdc_offset_low: Option<usize>,
+    cdc_offset_high: Option<usize>,
+    snapshot_cursor: Option<Range<usize>>,
+}
+
+impl StateFieldIndices {
+    const fn new(
+        finished: usize,
+        row_count: usize,
+        cdc_offset_low: Option<usize>,
+        cdc_offset_high: Option<usize>,
+        snapshot_cursor: Option<Range<usize>>,
+    ) -> Self {
+        Self {
+            finished,
+            row_count,
+            cdc_offset_low,
+            cdc_offset_high,
+            snapshot_cursor,
+        }
+    }
+}
+
+impl ParallelizedCdcBackfillStateLayout {
+    fn from_state_len(state_len: usize, pk_len: usize) -> Self {
+        match state_len {
+            3 => Self::Legacy,
+            5 => Self::WithCdcOffsets,
+            state_len if state_len == pk_len + 5 => Self::WithSnapshotCursor { pk_len },
+            _ => panic!("unsupported parallel CDC backfill state length: {state_len}"),
+        }
+    }
+
+    fn state_len(self) -> usize {
+        match self {
+            Self::Legacy => 3,
+            Self::WithCdcOffsets => 5,
+            Self::WithSnapshotCursor { pk_len } => pk_len + 5,
+        }
+    }
+
+    fn field_indices(self) -> StateFieldIndices {
+        const FINISHED: usize = 1;
+        const ROW_COUNT: usize = 2;
+        const CDC_OFFSET_LOW: usize = 3;
+        const CDC_OFFSET_HIGH: usize = 4;
+        const SNAPSHOT_CURSOR_START: usize = 5;
+
+        match self {
+            Self::Legacy => StateFieldIndices::new(FINISHED, ROW_COUNT, None, None, None),
+            Self::WithCdcOffsets => StateFieldIndices::new(
+                FINISHED,
+                ROW_COUNT,
+                Some(CDC_OFFSET_LOW),
+                Some(CDC_OFFSET_HIGH),
+                None,
+            ),
+            Self::WithSnapshotCursor { pk_len } => StateFieldIndices::new(
+                FINISHED,
+                ROW_COUNT,
+                Some(CDC_OFFSET_LOW),
+                Some(CDC_OFFSET_HIGH),
+                Some(SNAPSHOT_CURSOR_START..SNAPSHOT_CURSOR_START + pk_len),
+            ),
+        }
+    }
 }
 
 impl<S: StateStore> ParallelizedCdcBackfillState<S> {
-    pub fn new(state_table: StateTable<S>) -> Self {
-        let is_legacy_state = state_table.get_data_types().len() == 3;
-        let state_len = if is_legacy_state { 3 } else { 5 };
+    pub fn new(state_table: StateTable<S>, pk_len: usize) -> Self {
+        let layout = ParallelizedCdcBackfillStateLayout::from_state_len(
+            state_table.get_data_types().len(),
+            pk_len,
+        );
         Self {
             state_table,
-            state_len,
-            is_legacy_state,
+            layout,
         }
     }
 
@@ -65,35 +147,51 @@ impl<S: StateStore> ParallelizedCdcBackfillState<S> {
             Some(row) => {
                 tracing::info!("restored cdc backfill state: {:?}", row);
                 let state = row.into_inner().into_vec();
-                let is_finished = match state[1] {
-                    Some(ScalarImpl::Bool(val)) => val,
-                    _ => return Err(anyhow!("invalid backfill state: backfill_finished").into()),
-                };
-                let row_count = match state[2] {
-                    Some(ScalarImpl::Int64(val)) => val,
-                    _ => return Err(anyhow!("invalid backfill state: row_count").into()),
-                };
-                let (cdc_offset_low, cdc_offset_high) = if !self.is_legacy_state {
-                    let cdc_offset_low = match state[3] {
-                        Some(ScalarImpl::Jsonb(ref jsonb)) => {
-                            serde_json::from_value(jsonb.clone().take()).unwrap()
-                        }
-                        None => None,
-                        _ => return Err(anyhow!("invalid backfill state: cdc_offset_low").into()),
-                    };
-                    let cdc_offset_high = match state[4] {
-                        Some(ScalarImpl::Jsonb(ref jsonb)) => {
-                            serde_json::from_value(jsonb.clone().take()).unwrap()
-                        }
-                        None => None,
-                        _ => return Err(anyhow!("invalid backfill state: cdc_offset_high").into()),
-                    };
-                    (cdc_offset_low, cdc_offset_high)
+                let field_indices = self.layout.field_indices();
+                let current_pk_pos = if let Some(snapshot_cursor) = field_indices.snapshot_cursor {
+                    let pk = state[snapshot_cursor].to_vec();
+
+                    // snapshot cursor can only be all None or all Some
+                    if pk.iter().all(Option::is_none) {
+                        None
+                    } else if pk.iter().all(Option::is_some) {
+                        Some(OwnedRow::new(pk))
+                    } else {
+                        return Err(anyhow!(
+                            "invalid backfill state: partially null snapshot cursor"
+                        )
+                        .into());
+                    }
                 } else {
-                    (None, None)
+                    None
                 };
+                let Some(ScalarImpl::Bool(is_finished)) = state[field_indices.finished] else {
+                    return Err(anyhow!("invalid backfill state: backfill_finished").into());
+                };
+                let Some(ScalarImpl::Int64(row_count)) = state[field_indices.row_count] else {
+                    return Err(anyhow!("invalid backfill state: row_count").into());
+                };
+                let parse_offset = |idx: Option<usize>,
+                                    field_name: &str|
+                 -> StreamExecutorResult<Option<CdcOffset>> {
+                    let Some(idx) = idx else {
+                        return Ok(None);
+                    };
+
+                    match state[idx] {
+                        Some(ScalarImpl::Jsonb(ref jsonb)) => {
+                            Ok(serde_json::from_value(jsonb.clone().take()).unwrap())
+                        }
+                        None => Ok(None),
+                        _ => Err(anyhow!("invalid backfill state: {field_name}").into()),
+                    }
+                };
+                let cdc_offset_low = parse_offset(field_indices.cdc_offset_low, "cdc_offset_low")?;
+                let cdc_offset_high =
+                    parse_offset(field_indices.cdc_offset_high, "cdc_offset_high")?;
 
                 Ok(CdcStateRecord {
+                    current_pk_pos,
                     is_finished,
                     row_count,
                     cdc_offset_low,
@@ -108,24 +206,39 @@ impl<S: StateStore> ParallelizedCdcBackfillState<S> {
     pub async fn mutate_state(
         &mut self,
         split_id: i64,
+        current_pk_pos: Option<OwnedRow>,
         is_finished: bool,
         row_count: u64,
         cdc_offset_low: Option<CdcOffset>,
         cdc_offset_high: Option<CdcOffset>,
     ) -> StreamExecutorResult<()> {
-        // schema: | `split_id` | `backfill_finished` | `row_count` | `cdc_offset_low` | `cdc_offset_high` |
-        let mut state = vec![None; self.state_len];
+        // schema: | `split_id` | `backfill_finished` | `row_count` | `cdc_offset_low` | `cdc_offset_high` | `pk...` |
+        let mut state = vec![None; self.layout.state_len()];
         let split_id = Some(ScalarImpl::from(split_id));
         state[0].clone_from(&split_id);
-        state[1] = Some(is_finished.into());
-        state[2] = Some((row_count as i64).into());
-        if !self.is_legacy_state {
-            state[3] = cdc_offset_low.map(|cdc_offset| {
-                let json = serde_json::to_value(cdc_offset).unwrap();
+        let field_indices = self.layout.field_indices();
+
+        if let (Some(snapshot_cursor), Some(current_pk_pos)) =
+            (field_indices.snapshot_cursor, current_pk_pos)
+        {
+            state[snapshot_cursor].clone_from_slice(current_pk_pos.as_inner());
+        }
+
+        state[field_indices.finished] = Some(is_finished.into());
+        state[field_indices.row_count] = Some((row_count as i64).into());
+
+        if let (Some(low_idx), Some(high_idx)) =
+            (field_indices.cdc_offset_low, field_indices.cdc_offset_high)
+        {
+            state[low_idx] = cdc_offset_low.map(|cdc_offset| {
+                let json = serde_json::to_value(cdc_offset)
+                    .expect("CDC low offset must be serializable as JSON");
                 ScalarImpl::Jsonb(JsonbVal::from(json))
             });
-            state[4] = cdc_offset_high.map(|cdc_offset| {
-                let json = serde_json::to_value(cdc_offset).unwrap();
+
+            state[high_idx] = cdc_offset_high.map(|cdc_offset| {
+                let json = serde_json::to_value(cdc_offset)
+                    .expect("CDC high offset must be serializable as JSON");
                 ScalarImpl::Jsonb(JsonbVal::from(json))
             });
         }
@@ -141,6 +254,29 @@ impl<S: StateStore> ParallelizedCdcBackfillState<S> {
         Ok(())
     }
 
+    pub async fn init_state_if_absent(&mut self, split_id: i64) -> StreamExecutorResult<()> {
+        let key = Some(ScalarImpl::from(split_id));
+
+        if self
+            .state_table
+            .get_row(row::once(key.clone()))
+            .await?
+            .is_none()
+        {
+            let state_len = self.layout.state_len();
+            let mut state = vec![None; state_len];
+
+            state[0] = key;
+            let field_indices = self.layout.field_indices();
+            state[field_indices.finished] = Some(false.into());
+            state[field_indices.row_count] = Some(0_i64.into());
+
+            self.state_table.insert(state.as_slice());
+        }
+
+        Ok(())
+    }
+
     /// Persist the state to storage
     pub async fn commit_state(&mut self, new_epoch: EpochPair) -> StreamExecutorResult<()> {
         self.state_table
@@ -149,6 +285,6 @@ impl<S: StateStore> ParallelizedCdcBackfillState<S> {
     }
 
     pub fn is_legacy_state(&self) -> bool {
-        self.is_legacy_state
+        matches!(self.layout, ParallelizedCdcBackfillStateLayout::Legacy)
     }
 }

--- a/src/stream/src/executor/backfill/cdc/upstream_table/external.rs
+++ b/src/stream/src/executor/backfill/cdc/upstream_table/external.rs
@@ -142,6 +142,13 @@ impl ExternalStorageTable {
         &self.pk_indices
     }
 
+    pub fn pk_names(&self) -> Vec<String> {
+        self.pk_indices
+            .iter()
+            .map(|&idx| self.schema.fields[idx].name.clone())
+            .collect()
+    }
+
     pub fn schema_table_name(&self) -> SchemaTableName {
         SchemaTableName {
             schema_name: self.schema_name.clone(),

--- a/src/stream/src/executor/backfill/cdc/upstream_table/snapshot.rs
+++ b/src/stream/src/executor/backfill/cdc/upstream_table/snapshot.rs
@@ -16,7 +16,6 @@ use std::future::Future;
 
 use futures::{Stream, pin_mut};
 use futures_async_stream::try_stream;
-use itertools::Itertools;
 use risingwave_common::array::StreamChunk;
 use risingwave_common::catalog::{ColumnDesc, Field};
 use risingwave_common::row::OwnedRow;
@@ -84,8 +83,10 @@ impl SnapshotReadArgs {
 
 #[derive(Debug, Clone)]
 pub struct SplitSnapshotReadArgs {
-    pub left_bound_inclusive: OwnedRow,
-    pub right_bound_exclusive: OwnedRow,
+    pub current_pos: Option<OwnedRow>,
+    pub primary_keys: Vec<String>,
+    pub left_bound_inclusive: Option<OwnedRow>,
+    pub right_bound_exclusive: Option<OwnedRow>,
     pub split_columns: Vec<Field>,
     pub rate_limit_rps: Option<u32>,
     pub additional_columns: Vec<ColumnDesc>,
@@ -95,8 +96,10 @@ pub struct SplitSnapshotReadArgs {
 
 impl SplitSnapshotReadArgs {
     pub fn new(
-        left_bound_inclusive: OwnedRow,
-        right_bound_exclusive: OwnedRow,
+        current_pos: Option<OwnedRow>,
+        primary_keys: Vec<String>,
+        left_bound_inclusive: Option<OwnedRow>,
+        right_bound_exclusive: Option<OwnedRow>,
         split_columns: Vec<Field>,
         rate_limit_rps: Option<u32>,
         additional_columns: Vec<ColumnDesc>,
@@ -104,6 +107,8 @@ impl SplitSnapshotReadArgs {
         database_name: String,
     ) -> Self {
         Self {
+            current_pos,
+            primary_keys,
             left_bound_inclusive,
             right_bound_exclusive,
             split_columns,
@@ -176,15 +181,7 @@ fn with_additional_columns(
 impl UpstreamTableRead for UpstreamTableReader<ExternalStorageTable> {
     #[try_stream(ok = Option<StreamChunk>, error = StreamExecutorError)]
     async fn snapshot_read_full_table(&self, args: SnapshotReadArgs, batch_size: u32) {
-        let primary_keys = self
-            .table
-            .pk_indices()
-            .iter()
-            .map(|idx| {
-                let f = &self.table.schema().fields[*idx];
-                f.name.clone()
-            })
-            .collect_vec();
+        let primary_keys = self.table.pk_names();
 
         // prepare rate limiter
         if args.rate_limit_rps == Some(0) {
@@ -302,6 +299,8 @@ impl UpstreamTableRead for UpstreamTableReader<ExternalStorageTable> {
 
         let row_stream = self.reader.split_snapshot_read(
             self.table.schema_table_name(),
+            read_args.current_pos.clone(),
+            read_args.primary_keys.clone(),
             read_args.left_bound_inclusive.clone(),
             read_args.right_bound_exclusive.clone(),
             read_args.split_columns.clone(),

--- a/src/stream/src/executor/backfill/cdc/upstream_table/snapshot.rs
+++ b/src/stream/src/executor/backfill/cdc/upstream_table/snapshot.rs
@@ -94,18 +94,31 @@ pub struct SplitSnapshotReadArgs {
     pub database_name: String,
 }
 
+pub struct SplitSnapshotReadArgsInput {
+    pub current_pos: Option<OwnedRow>,
+    pub primary_keys: Vec<String>,
+    pub left_bound_inclusive: Option<OwnedRow>,
+    pub right_bound_exclusive: Option<OwnedRow>,
+    pub split_columns: Vec<Field>,
+    pub rate_limit_rps: Option<u32>,
+    pub additional_columns: Vec<ColumnDesc>,
+    pub schema_table_name: SchemaTableName,
+    pub database_name: String,
+}
+
 impl SplitSnapshotReadArgs {
-    pub fn new(
-        current_pos: Option<OwnedRow>,
-        primary_keys: Vec<String>,
-        left_bound_inclusive: Option<OwnedRow>,
-        right_bound_exclusive: Option<OwnedRow>,
-        split_columns: Vec<Field>,
-        rate_limit_rps: Option<u32>,
-        additional_columns: Vec<ColumnDesc>,
-        schema_table_name: SchemaTableName,
-        database_name: String,
-    ) -> Self {
+    pub fn new(input: SplitSnapshotReadArgsInput) -> Self {
+        let SplitSnapshotReadArgsInput {
+            current_pos,
+            primary_keys,
+            left_bound_inclusive,
+            right_bound_exclusive,
+            split_columns,
+            rate_limit_rps,
+            additional_columns,
+            schema_table_name,
+            database_name,
+        } = input;
         Self {
             current_pos,
             primary_keys,

--- a/src/stream/src/executor/backfill/cdc/upstream_table/snapshot.rs
+++ b/src/stream/src/executor/backfill/cdc/upstream_table/snapshot.rs
@@ -94,45 +94,6 @@ pub struct SplitSnapshotReadArgs {
     pub database_name: String,
 }
 
-pub struct SplitSnapshotReadArgsInput {
-    pub current_pos: Option<OwnedRow>,
-    pub primary_keys: Vec<String>,
-    pub left_bound_inclusive: Option<OwnedRow>,
-    pub right_bound_exclusive: Option<OwnedRow>,
-    pub split_columns: Vec<Field>,
-    pub rate_limit_rps: Option<u32>,
-    pub additional_columns: Vec<ColumnDesc>,
-    pub schema_table_name: SchemaTableName,
-    pub database_name: String,
-}
-
-impl SplitSnapshotReadArgs {
-    pub fn new(input: SplitSnapshotReadArgsInput) -> Self {
-        let SplitSnapshotReadArgsInput {
-            current_pos,
-            primary_keys,
-            left_bound_inclusive,
-            right_bound_exclusive,
-            split_columns,
-            rate_limit_rps,
-            additional_columns,
-            schema_table_name,
-            database_name,
-        } = input;
-        Self {
-            current_pos,
-            primary_keys,
-            left_bound_inclusive,
-            right_bound_exclusive,
-            split_columns,
-            rate_limit_rps,
-            additional_columns,
-            schema_table_name,
-            database_name,
-        }
-    }
-}
-
 /// A wrapper of upstream table for snapshot read
 /// because we need to customize the snapshot read for managed upstream table (e.g. mv, index)
 /// and external upstream table.

--- a/src/stream/src/executor/mod.rs
+++ b/src/stream/src/executor/mod.rs
@@ -757,16 +757,6 @@ impl<M: PartialEq> PartialEq for BarrierInner<M> {
 }
 
 impl Mutation {
-    /// Return the backfill throttle configuration for `fragment_id`.
-    pub fn backfill_throttle_config(&self, fragment_id: FragmentId) -> Option<&ThrottleConfig> {
-        let Mutation::Throttle(fragment_throttles) = self else {
-            return None;
-        };
-        fragment_throttles
-            .get(&fragment_id)
-            .filter(|config| config.throttle_type() == ThrottleType::Backfill)
-    }
-
     /// Get all actors to be stopped (dropped) by this mutation.
     pub fn all_stop_actors(&self) -> Option<&HashSet<ActorId>> {
         match self {
@@ -781,6 +771,17 @@ impl Mutation {
     pub fn is_stop(&self, actor_id: ActorId) -> bool {
         self.all_stop_actors()
             .is_some_and(|actors| actors.contains(&actor_id))
+    }
+
+    /// Return the backfill throttle configuration for `fragment_id`.
+    pub fn backfill_throttle_config(&self, fragment_id: FragmentId) -> Option<&ThrottleConfig> {
+        if let Mutation::Throttle(fragment_throttles) = self {
+            fragment_throttles
+                .get(&fragment_id)
+                .filter(|config| config.throttle_type() == ThrottleType::Backfill)
+        } else {
+            None
+        }
     }
 
     /// Return true if the mutation is stop.

--- a/src/stream/src/executor/mod.rs
+++ b/src/stream/src/executor/mod.rs
@@ -43,6 +43,7 @@ use risingwave_common::util::value_encoding::{DatumFromProtoExt, DatumToProtoExt
 use risingwave_common_estimate_size::EstimateSize;
 use risingwave_connector::source::SplitImpl;
 use risingwave_expr::expr::NonStrictExpression;
+use risingwave_pb::common::ThrottleType;
 use risingwave_pb::data::PbEpoch;
 use risingwave_pb::expr::PbInputRef;
 use risingwave_pb::stream_plan::add_mutation::PbNewUpstreamSink;
@@ -756,6 +757,16 @@ impl<M: PartialEq> PartialEq for BarrierInner<M> {
 }
 
 impl Mutation {
+    /// Return the backfill throttle configuration for `fragment_id`.
+    pub fn backfill_throttle_config(&self, fragment_id: FragmentId) -> Option<&ThrottleConfig> {
+        let Mutation::Throttle(fragment_throttles) = self else {
+            return None;
+        };
+        fragment_throttles
+            .get(&fragment_id)
+            .filter(|config| config.throttle_type() == ThrottleType::Backfill)
+    }
+
     /// Get all actors to be stopped (dropped) by this mutation.
     pub fn all_stop_actors(&self) -> Option<&HashSet<ActorId>> {
         match self {


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

fixes #27022 and #27027 

## What's changed and what's your intention?

Fix CDC snapshot backfill recovery by rebuilding failed external table readers and resuming parallel snapshot reads from a persisted, per-split primary-key cursor.

### Core changes

- Introduce primary-key cursor state for parallel CDC backfill:
  - append the upstream PK columns after `cdc_offset_low` and `cdc_offset_high` in the backfill state table;
  - persist `current_pk_pos` independently for each snapshot split;
  - restore the cursor together with the split's row count and CDC offsets;
  - initialize state rows for all assigned splits so progress includes splits that have not started yet.

- Resume PostgreSQL split snapshot reads from the persisted cursor:
  - pass `current_pos` and the ordered PK column names through `split_snapshot_read`;
  - add `(<pk columns>) > (<cursor values>)` to the split predicate when resuming;
  - add `ORDER BY <pk columns>` so cursor advancement is deterministic;
  - represent open-ended first and last split bounds with `Option<OwnedRow>` instead of sentinel rows.

- Rebuild readers after snapshot-read failures:
  - represent a split attempt as `Reading`, `Failed`, or `Finished(CdcOffset)`;
  - stop the failed attempt, disconnect its reader, and wait for a barrier before checkpointing recovery state;
  - recreate the external reader with retry and restart the same split from `current_pk_pos`;
  - keep polling upstream barriers and CDC chunks while reader creation is retrying;
  - skip reader creation entirely after every assigned snapshot split has finished, so normal CDC forwarding no longer depends on the snapshot table still existing.

- Preserve CDC data while a reader is unavailable:
  - separate CDC rows belonging to completed splits from rows belonging to the active split;
  - partition active-split rows at `current_pk_pos` using the upstream PK ordering and unsigned-MySQL comparison rules;
  - emit rows at or before the checkpointed cursor before committing the recovery barrier;
  - let the resumed snapshot reread rows after the cursor;
  - continue processing pause, resume, throttle, stop, and reset mutations during reader reconstruction.

### Refactors

- Extract `create_table_reader_with_retry` as the shared infinite-retry path for constructing an external table reader.
- Refactor `build_reader_and_poll_upstream` to return `Either<Message, ExternalTableReaderImpl>`:
  - `Either::Left` contains an upstream message;
  - `Either::Right` contains the completed reader.

  This removes the mutable reader output argument and the nested `Option<Message>` return type.

- Group the split snapshot parameters into `SplitSnapshotReadArgs` and `SplitSnapshotReadArgsInput`.
- Add `ExternalStorageTable::pk_names` to derive primary-key names in schema order.
- Add `Mutation::backfill_throttle_config` to centralize fragment and throttle-type filtering.
- Add `DataChunk::has_visible_rows` and use visibility-aware filtering for buffered CDC chunks.
- Simplify the parallel-backfill loop labels and split-attempt cleanup paths.
- Extend the mock external reader with configurable snapshot failures and deterministic composite-PK comparisons.

### State compatibility

The state reader continues to accept the existing layouts:

- V1: `split_id`, completion flag, and row count;
- V2: V1 plus low and high CDC offsets;
- V3: V2 plus the per-split primary-key cursor.

Legacy layouts restore without a cursor, while newly created state tables use V3.

### Tests

- Add executor coverage that injects a snapshot failure, rebuilds the reader, and resumes the same split.
- Update parallel CDC compute tests for cursor-aware buffering and barrier behavior.
- Extend the mock reader to cover failed and resumed snapshot attempts.

### TODO: explicit state schema versioning

The backfill state currently infers its layout from its total number of columns. This is not sufficient once the fixed portion of the schema changes because the number of primary-key cursor columns is variable.

For example, V3 has five fixed fields followed by the PK cursor, so a V3 state table for a two-column primary key has seven columns. If a future V4 adds one fixed field, a V4 table for a single-column primary key would also have seven columns. Column count alone cannot distinguish those layouts, and a decoder can interpret the same position as either the new fixed field or part of the PK cursor.

Follow up by storing an explicit schema version and selecting the field layout and migration path from that version instead of inferring it from the table width.

## Checklist

- [x] I have written necessary rustdoc comments.
- [x] I have added necessary unit tests and integration tests.
- [x] I have added test labels as necessary.
- [ ] I have added fuzzing tests or opened an issue to track them.
- [ ] My PR contains breaking changes.
- [ ] My PR changes performance-critical code, so I will run (micro) benchmarks and present the results.
- [ ] I have checked the Release Timeline and Currently Supported Versions to determine which release branches I need to cherry-pick this PR into.

## Documentation

- [ ] My PR needs documentation updates.
