### PR TITLE
feat(connector): set application name for Postgres clients

### DIFF
--- a/src/batch/executors/src/executor/postgres_query.rs
+++ b/src/batch/executors/src/executor/postgres_query.rs
@@ -123,7 +123,7 @@ impl PostgresQueryExecutor {
     async fn do_execute(self: Box<Self>) {
         tracing::debug!("postgres_query_executor: started");
 
-        let client = create_pg_client(&self.config, None).await?;
+        let client = create_pg_client(&self.config, None, None).await?;
 
         let params: &[&str] = &[];
         let row_stream = client

--- a/src/connector/src/connector_common/postgres.rs
+++ b/src/connector/src/connector_common/postgres.rs
@@ -167,7 +167,7 @@ pub async fn create_pg_client_from_properties(
     tcp_keepalive: Option<TcpKeepaliveConfig>,
 ) -> ConnectorResult<PgClient> {
     let config = pg_connection_config_from_properties(props)?;
-    create_pg_client(&config, tcp_keepalive)
+    create_pg_client(&config, tcp_keepalive, None)
         .await
         .map_err(Into::into)
 }
@@ -564,6 +564,7 @@ impl std::str::FromStr for SslMode {
 pub async fn create_pg_client(
     config: &PgConnectionConfig,
     tcp_keepalive: Option<TcpKeepaliveConfig>,
+    application_name: Option<&str>,
 ) -> anyhow::Result<PgClient> {
     let mut pg_config = tokio_postgres::Config::new();
     pg_config
@@ -572,6 +573,9 @@ pub async fn create_pg_client(
         .host(&config.host)
         .port(config.port)
         .dbname(&config.database);
+    if let Some(application_name) = application_name {
+        pg_config.application_name(application_name);
+    }
 
     // Configure TCP keepalive if provided
     if let Some(keepalive) = tcp_keepalive {

--- a/src/connector/src/sink/postgres.rs
+++ b/src/connector/src/sink/postgres.rs
@@ -117,7 +117,12 @@ fn tcp_keepalive_from_config(config: &PostgresConfig) -> Option<TcpKeepaliveConf
 
 async fn ensure_no_foreign_key(config: &PostgresConfig) -> Result<()> {
     let pg_conn = config.pg_connection_config();
-    let client = create_pg_client(&pg_conn, tcp_keepalive_from_config(config)).await?;
+    let client = create_pg_client(
+        &pg_conn,
+        tcp_keepalive_from_config(config),
+        Some("risingwave-postgres-sink-validator"),
+    )
+    .await?;
 
     ensure_no_foreign_key_with_client(&client, &config.schema, &config.table).await
 }
@@ -329,12 +334,13 @@ impl Sink for PostgresSink {
         Ok(())
     }
 
-    async fn new_log_sinker(&self, _writer_param: SinkWriterParam) -> Result<Self::LogSinker> {
+    async fn new_log_sinker(&self, writer_param: SinkWriterParam) -> Result<Self::LogSinker> {
         PostgresSinkWriter::new(
             self.config.clone(),
             self.schema.clone(),
             self.pk_indices.clone(),
             self.is_append_only,
+            &writer_param,
         )
         .await
     }
@@ -470,11 +476,16 @@ impl PostgresSinkWriter {
         schema: Schema,
         pk_indices: Vec<usize>,
         is_append_only: bool,
+        writer_param: &SinkWriterParam,
     ) -> Result<Self> {
         let tcp_keepalive = tcp_keepalive_from_config(&config);
 
         let pg_conn = config.pg_connection_config();
-        let client = create_pg_client(&pg_conn, tcp_keepalive).await?;
+        let application_name = format!(
+            "risingwave-postgres-sink-{}-{}",
+            writer_param.sink_id, writer_param.actor_id
+        );
+        let client = create_pg_client(&pg_conn, tcp_keepalive, Some(&application_name)).await?;
 
         ensure_no_foreign_key_with_client(&client, &config.schema, &config.table).await?;
 

--- a/src/connector/src/source/cdc/enumerator/mod.rs
+++ b/src/connector/src/source/cdc/enumerator/mod.rs
@@ -244,7 +244,8 @@ impl<T: CdcSourceTypeTrait> DebeziumSplitEnumerator<T> {
             .ok_or_else(|| anyhow::anyhow!("missing `slot.name` in CDC properties"))?;
 
         // No TCP keepalive for CDC enumerator
-        let client = create_pg_client(&pg_conn, None)
+        let application_name = format!("risingwave-postgres-source-enumerator-{}", self.source_id);
+        let client = create_pg_client(&pg_conn, None, Some(&application_name))
             .await
             .context("failed to create the PostgreSQL client")?;
 

--- a/src/connector/src/source/cdc/external/mod.rs
+++ b/src/connector/src/source/cdc/external/mod.rs
@@ -87,14 +87,21 @@ impl ExternalCdcTableType {
         schema: Schema,
         pk_indices: Vec<usize>,
         schema_table_name: SchemaTableName,
+        table_id: u32,
     ) -> ConnectorResult<ExternalTableReaderImpl> {
         match self {
             Self::MySql => Ok(ExternalTableReaderImpl::MySql(
                 MySqlExternalTableReader::new(config, schema, pk_indices).await?,
             )),
             Self::Postgres => Ok(ExternalTableReaderImpl::Postgres(
-                PostgresExternalTableReader::new(config, schema, pk_indices, schema_table_name)
-                    .await?,
+                PostgresExternalTableReader::new(
+                    config,
+                    schema,
+                    pk_indices,
+                    schema_table_name,
+                    table_id,
+                )
+                .await?,
             )),
             Self::SqlServer => Ok(ExternalTableReaderImpl::SqlServer(
                 SqlServerExternalTableReader::new(config, schema, pk_indices).await?,

--- a/src/connector/src/source/cdc/external/postgres.rs
+++ b/src/connector/src/source/cdc/external/postgres.rs
@@ -236,6 +236,7 @@ impl PostgresExternalTableReader {
         rw_schema: Schema,
         pk_indices: Vec<usize>,
         schema_table_name: SchemaTableName,
+        table_id: u32,
     ) -> ConnectorResult<Self> {
         tracing::info!(
             ?rw_schema,
@@ -243,7 +244,16 @@ impl PostgresExternalTableReader {
             "create postgres external table reader"
         );
         // No TCP keepalive for CDC source
-        let client = create_pg_client(&config.pg_connection_config()?, None).await?;
+        let application_name = format!(
+            "risingwave-postgres-source-reader-{}-{}.{}",
+            table_id, schema_table_name.schema_name, schema_table_name.table_name
+        );
+        let client = create_pg_client(
+            &config.pg_connection_config()?,
+            None,
+            Some(&application_name),
+        )
+        .await?;
 
         // Discover user-defined composite columns and arrays of composites.
         // tokio-postgres cannot decode composite values natively, so for these
@@ -1241,6 +1251,7 @@ mod tests {
             rw_schema,
             vec![0, 1],
             schema_table_name.clone(),
+            233,
         )
         .await
         .unwrap();

--- a/src/frontend/src/expr/table_function.rs
+++ b/src/frontend/src/expr/table_function.rs
@@ -331,7 +331,7 @@ impl TableFunction {
                         ssl_mode,
                         ssl_root_cert,
                     };
-                    let client = create_pg_client(&pg_conn, None).await?;
+                    let client = create_pg_client(&pg_conn, None, None).await?;
 
                     let statement = client.prepare(evaled_args[5].as_str()).await?;
 

--- a/src/meta/src/stream/cdc.rs
+++ b/src/meta/src/stream/cdc.rs
@@ -94,6 +94,7 @@ pub(crate) async fn try_init_parallel_cdc_table_snapshot_splits(
             table_schema,
             table_pk_indices,
             schema_table_name,
+            table_id.as_raw_id(),
         )
         .await?;
     let stream = reader.get_parallel_cdc_splits(split_options);

--- a/src/stream/src/executor/backfill/cdc/upstream_table/external.rs
+++ b/src/stream/src/executor/backfill/cdc/upstream_table/external.rs
@@ -125,6 +125,7 @@ impl ExternalStorageTable {
                     schema_name: self.schema_name.clone(),
                     table_name: self.table_name.clone(),
                 },
+                self.table_id.as_raw_id(),
             )
             .await
     }


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

This splits out the Postgres `application_name` part requested in https://github.com/risingwavelabs/risingwave/pull/23096#issuecomment-5561777106.

The Rust Postgres client helper now accepts an optional application name and sets it on `tokio_postgres::Config`. Runtime Postgres source/sink clients pass visible names for:

- Postgres sink writer connections
- Postgres sink validation connections
- Postgres CDC source enumerator connections
- Postgres CDC source snapshot reader connections

No UpdateDelete/Postgres sink write semantics from #23096 are included here.

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] I have added necessary unit tests and integration tests.
- [ ] I have added test labels as necessary.
- [ ] I have added fuzzing tests or opened an issue to track them.
- [ ] My PR contains breaking changes.
- [ ] My PR changes performance-critical code, so I will run (micro) benchmarks and present the results.

## Documentation

- [ ] My PR needs documentation updates.

## Verification

- `cargo fmt`
- `cargo check -p risingwave_connector -p risingwave_meta -p risingwave_stream`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - PostgreSQL connections created by CDC sources, external table readers, and sinks now include descriptive application names.
  - Connection labels identify the related source, sink, table, or processing component for easier database-side monitoring.
  - PostgreSQL connection setup now supports optional application names across query and connector workflows.

- **Bug Fixes**
  - PostgreSQL sink writers now retain the required sink context when establishing connections, ensuring connection labeling is applied consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->