### PR TITLE
fix(connector): statically link curl for Kafka OIDC

### DIFF
--- a/src/connector/Cargo.toml
+++ b/src/connector/Cargo.toml
@@ -139,7 +139,10 @@ rdkafka = { workspace = true, features = [
     "ssl",
     "gssapi",
     "zstd",
+    # Keep both: `curl` enables librdkafka's OIDC client, while `curl-static`
+    # avoids adding a system libcurl dependency to release binaries.
     "curl",
+    "curl-static",
 ] }
 redis = { workspace = true, features = [
     "aio",


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

Statically link libcurl when enabling librdkafka's CURL support for Kafka OIDC authentication.

### Context

#25499 enabled rdkafka's `curl` feature so librdkafka can use its built-in OIDC client to fetch and refresh OAuth tokens. This is required for `sasl.oauthbearer.method=oidc`, but the `curl` feature alone lets `curl-sys` use the system shared libcurl.

The next scheduled [main-cron build #9952](https://buildkite.com/risingwavelabs/main-cron/builds/9952#01a07e51-542f-4b80-b16c-b3183362dcb4) compiled successfully and then failed the release link check:

```text
libcurl.so.4 => /lib/x86_64-linux-gnu/libcurl.so.4
libssl.so.3 => /lib/x86_64-linux-gnu/libssl.so.3
libssl should not be dynamically linked
```

RisingWave release binaries intentionally avoid a runtime dependency on the system OpenSSL (see #18569). A dynamically linked libcurl also makes libcurl and its transitive shared-library dependencies mandatory when the RisingWave process starts, even when Kafka OIDC is not used. That weakens the portability of the release artifact and can cause startup failures on hosts without compatible library versions.

### Fix

Keep both rdkafka features enabled:

- `curl` enables librdkafka's CURL/OIDC code path (`WITH_CURL=1`).
- `curl-static` enables `curl-sys/static-curl`, builds libcurl from the bundled source, and links `libcurl.a`.

Both features are necessary with the current rust-rdkafka feature wiring: `curl-static` selects the static library but does not by itself set rdkafka-sys's `curl` feature. The existing release build configuration continues to link OpenSSL statically.

This preserves Kafka OIDC support without adding a system libcurl/libssl requirement to the RisingWave binary.

### Verification

- `cargo tree --locked -e features -p risingwave_connector -i curl-sys`
  - confirms `madsim-rdkafka/curl`, `madsim-rdkafka/curl-static`, `rdkafka-sys/curl`, `rdkafka-sys/curl-static`, and `curl-sys/static-curl` are enabled together.
- `cargo check --locked -p risingwave_connector`
- `OPENSSL_STATIC=1 OPENSSL_LIB_DIR=/usr/lib/x86_64-linux-gnu OPENSSL_INCLUDE_DIR=/usr/include cargo check --locked -p risingwave_connector`
  - confirms the main-cron-style static OpenSSL configuration builds successfully.
- Native build output confirms `static=curl`, `static=ssl`, and `static=crypto`; the targeted main-cron release build is requested through PR labels to exercise the final `ldd` guard.

## Checklist

- [x] Added an inline comment explaining why both rdkafka features are required.
- [x] Added targeted main-cron labels for the release link check.

This PR has no breaking changes and does not change performance-critical runtime code.

## Documentation

No documentation update is required.

<details>
<summary><b>Release note</b></summary>

Not applicable. This restores the intended release linkage without changing the Kafka OIDC configuration or user-facing behavior.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Release binaries no longer require a system-installed libcurl dependency.
  * OIDC authentication support remains available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->