### PR TITLE
feat(meta): reuse Iceberg compaction pre-commit

### DIFF
--- a/src/connector/src/sink/iceberg/commit.rs
+++ b/src/connector/src/sink/iceberg/commit.rs
@@ -684,6 +684,7 @@ impl IcebergSinkCommitter {
             self.table.identifier(),
             expect_schema_id,
             expect_partition_spec_id,
+            None,
         )
         .await
         .map_err(SinkError::Iceberg)?;
@@ -729,6 +730,7 @@ impl IcebergSinkCommitter {
             table_ident.clone(),
             expect_schema_id,
             expect_partition_spec_id,
+            None,
             self.commit_retry_num as usize,
             retry_log_context,
             |table| {

--- a/src/connector/src/sink/iceberg/commit_retry.rs
+++ b/src/connector/src/sink/iceberg/commit_retry.rs
@@ -22,6 +22,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use anyhow::{Result, anyhow, bail};
+use iceberg::spec::FormatVersion;
 use iceberg::table::Table;
 use iceberg::{Catalog, TableIdent};
 use risingwave_common::util::retry::exponential_backoff;
@@ -76,7 +77,7 @@ impl CommitRetryLogContext {
 
 /// Distinguishes retriable from non-retriable errors inside [`run_with_retry`].
 pub enum CommitError {
-    /// `reload_table` failed (table not found, schema mismatch, partition
+    /// `reload_table` failed (table not found, schema mismatch, partition or requested format
     /// evolution). Non-retriable — the call site's invariants no longer hold.
     ReloadTable(anyhow::Error),
     /// `Transaction::commit` (or its `apply`) failed. Retriable — likely a
@@ -86,18 +87,29 @@ pub enum CommitError {
 
 /// Reload the iceberg table from the catalog and assert that its current
 /// `schema_id` and `default_partition_spec_id` still match the values the
-/// caller computed against. Schema or partition evolution mid-commit is
+/// caller computed against. Schema, partition, or requested format evolution mid-commit is
 /// surfaced as a non-retriable error by the call sites.
 pub async fn reload_table(
     catalog: &dyn Catalog,
     table_ident: &TableIdent,
     schema_id: i32,
     partition_spec_id: i32,
+    format_version: Option<FormatVersion>,
 ) -> Result<Table> {
     let table = catalog
         .load_table(table_ident)
         .await
         .map_err(|e| anyhow!(e).context("reload iceberg table"))?;
+    validate_table_metadata(&table, schema_id, partition_spec_id, format_version)?;
+    Ok(table)
+}
+
+fn validate_table_metadata(
+    table: &Table,
+    schema_id: i32,
+    partition_spec_id: i32,
+    format_version: Option<FormatVersion>,
+) -> Result<()> {
     if table.metadata().current_schema_id() != schema_id {
         bail!(
             "iceberg sink: schema evolution not supported; expect schema id {}, got {}",
@@ -112,12 +124,21 @@ pub async fn reload_table(
             table.metadata().default_partition_spec_id(),
         );
     }
-    Ok(table)
+    if let Some(format_version) = format_version
+        && table.metadata().format_version() != format_version
+    {
+        bail!(
+            "iceberg sink: format evolution not supported; expect format version {}, got {}",
+            format_version,
+            table.metadata().format_version(),
+        );
+    }
+    Ok(())
 }
 
 /// Run a commit-action against the given iceberg table with retry.
 /// 1. Calls `reload_table` before each commit attempt to get the latest metadata
-/// 2. If `reload_table` fails (table not exists/schema/partition mismatch), stops retrying immediately
+/// 2. If `reload_table` fails (table not exists/schema/partition/requested format mismatch), stops retrying immediately
 /// 3. If commit fails, retries with backoff up to `retry_num` times.
 ///
 /// Strategy: exponential backoff 10ms→60s with jitter, up to `retry_num` retries.
@@ -126,6 +147,7 @@ pub async fn run_with_retry<F, Fut, Out>(
     table_ident: TableIdent,
     schema_id: i32,
     partition_spec_id: i32,
+    format_version: Option<FormatVersion>,
     retry_num: usize,
     log_context: CommitRetryLogContext,
     commit_action: F,
@@ -146,10 +168,15 @@ where
             let table_ident = table_ident.clone();
             let commit_action = &commit_action;
             async move {
-                let table =
-                    reload_table(catalog.as_ref(), &table_ident, schema_id, partition_spec_id)
-                        .await
-                        .map_err(CommitError::ReloadTable)?;
+                let table = reload_table(
+                    catalog.as_ref(),
+                    &table_ident,
+                    schema_id,
+                    partition_spec_id,
+                    format_version,
+                )
+                .await
+                .map_err(CommitError::ReloadTable)?;
                 commit_action(table).await
             }
         },

--- a/src/connector/src/sink/iceberg/position_delete.rs
+++ b/src/connector/src/sink/iceberg/position_delete.rs
@@ -15,6 +15,7 @@
 //! Shared iceberg position-delete (Puffin deletion vector) helpers.
 
 use std::collections::HashMap;
+use std::fmt::Display;
 use std::sync::Arc;
 
 use anyhow::{Context, Result, anyhow, bail};
@@ -23,7 +24,9 @@ use iceberg::arrow::schema_to_arrow_schema;
 use iceberg::delete_vector::DeleteVector;
 use iceberg::io::FileIO;
 use iceberg::puffin::{CompressionCodec, PuffinReader, PuffinWriter};
-use iceberg::spec::{DataContentType, DataFile, DataFileBuilder, DataFileFormat, PartitionKey};
+use iceberg::spec::{
+    DataContentType, DataFile, DataFileBuilder, DataFileFormat, FormatVersion, PartitionKey,
+};
 use iceberg::table::Table;
 use iceberg::writer::base_writer::position_delete_file_writer::POSITION_DELETE_SCHEMA;
 use iceberg::writer::file_writer::location_generator::{
@@ -41,6 +44,94 @@ use risingwave_common::array::arrow::arrow_schema_iceberg::SchemaRef as ArrowSch
 
 use crate::sink::iceberg::{IcebergConfig, PARQUET_CREATED_BY};
 use crate::source::iceberg::parquet_file_handler::ParquetFileReader;
+
+/// File-name generators shared by all Iceberg position-delete writers.
+///
+/// All writers use the same prefix and format-specific suffix pattern. The identity is the only
+/// caller-specific part and prevents concurrent actors/epochs from generating the same path.
+#[derive(Clone, Debug)]
+pub struct PositionDeleteFileNameGenerators {
+    pub puffin: DefaultFileNameGenerator,
+    pub parquet: DefaultFileNameGenerator,
+}
+
+impl PositionDeleteFileNameGenerators {
+    pub fn new(identity: impl Display) -> Self {
+        let prefix = "position-delete".to_owned();
+        let unique_suffix = identity.to_string();
+        Self {
+            puffin: DefaultFileNameGenerator::new(
+                prefix.clone(),
+                Some(unique_suffix.clone()),
+                DataFileFormat::Puffin,
+            ),
+            parquet: DefaultFileNameGenerator::new(
+                prefix,
+                Some(unique_suffix),
+                DataFileFormat::Parquet,
+            ),
+        }
+    }
+
+    pub fn for_format(&self, format: DataFileFormat) -> anyhow::Result<&DefaultFileNameGenerator> {
+        match format {
+            DataFileFormat::Puffin => Ok(&self.puffin),
+            DataFileFormat::Parquet => Ok(&self.parquet),
+            other => anyhow::bail!(
+                "unsupported position-delete output format {:?}; expected Puffin or Parquet",
+                other
+            ),
+        }
+    }
+}
+
+/// Write one file-scoped position-delete artifact using the table's configured on-disk format.
+///
+/// All callers share this dispatch so Puffin deletion vectors and V2 Parquet position deletes use
+/// identical file-name and partition-path handling.
+pub async fn write_position_delete_file(
+    table: &Table,
+    config: &IcebergConfig,
+    location_generator: &DefaultLocationGenerator,
+    file_name_generators: &PositionDeleteFileNameGenerators,
+    format_version: FormatVersion,
+    data_file_path: String,
+    delete_vector: &DeleteVector,
+    partition_key: Option<&PartitionKey>,
+) -> Result<DataFile> {
+    let format = if format_version >= FormatVersion::V3 {
+        DataFileFormat::Puffin
+    } else {
+        DataFileFormat::Parquet
+    };
+    let file_name_generator = file_name_generators.for_format(format)?;
+    match format {
+        DataFileFormat::Puffin => {
+            write_dv_puffin_file(
+                table,
+                location_generator,
+                file_name_generator,
+                data_file_path,
+                delete_vector,
+                partition_key,
+            )
+            .await
+        }
+        DataFileFormat::Parquet => {
+            write_parquet_position_delete_file(
+                table,
+                location_generator,
+                file_name_generator,
+                config,
+                data_file_path,
+                delete_vector,
+                partition_key,
+            )
+            .await
+        }
+        _ => unreachable!("position-delete format is selected above"),
+    }
+}
 
 /// Puffin blob property for deletion vector cardinality.
 const DELETION_VECTOR_PROPERTY_CARDINALITY: &str = "cardinality";

--- a/src/meta/src/barrier/command.rs
+++ b/src/meta/src/barrier/command.rs
@@ -917,8 +917,8 @@ impl Command {
                 .expect("non-duplicate");
         }
         info.truncate_tables.extend(truncate_tables);
-        task.iceberg_pk_index_sink_metadata
-            .extend(iceberg_pk_index_sink_metadata);
+        task.iceberg_pk_index_pre_commit_metadata
+            .extend(iceberg_pk_index_sink_metadata.into_iter().map(Into::into));
     }
 }
 

--- a/src/meta/src/barrier/complete_task.rs
+++ b/src/meta/src/barrier/complete_task.rs
@@ -25,7 +25,7 @@ use risingwave_common::util::deployment::Deployment;
 use risingwave_pb::hummock::HummockVersionStats;
 use risingwave_pb::id::{DatabaseId, PartialGraphId};
 use risingwave_pb::stream_service::barrier_complete_response::{
-    PbIcebergPkIndexSinkMetadata, PbListFinishedSource, PbLoadFinishedSource,
+    PbListFinishedSource, PbLoadFinishedSource,
 };
 use tokio::task::JoinHandle;
 
@@ -38,6 +38,7 @@ use crate::barrier::rpc::from_partial_graph_id;
 use crate::barrier::schedule::PeriodicBarriers;
 use crate::hummock::CommitEpochInfo;
 use crate::manager::MetaSrvEnv;
+use crate::manager::iceberg_pk_index_sink::IcebergPkIndexPreCommitMetadata;
 use crate::rpc::metrics::GLOBAL_META_METRICS;
 use crate::{MetaError, MetaResult};
 
@@ -71,8 +72,9 @@ pub(super) struct CompleteBarrierTask {
     pub(super) load_finished_source_ids: Vec<PbLoadFinishedSource>,
     /// Table IDs that have finished materialize refresh and need completion signaling
     pub(super) refresh_finished_table_job_ids: Vec<JobId>,
-    /// Iceberg pk-index sink reports collected during this barrier
-    pub(super) iceberg_pk_index_sink_metadata: Vec<PbIcebergPkIndexSinkMetadata>,
+    /// Iceberg pk-index sink reports and optional compaction overwrite metadata collected during
+    /// this barrier. They are grouped per sink into one pre-commit before Hummock commits.
+    pub(super) iceberg_pk_index_pre_commit_metadata: Vec<IcebergPkIndexPreCommitMetadata>,
 }
 
 impl CompleteBarrierTask {
@@ -106,15 +108,18 @@ impl CompleteBarrierTask {
                 .barrier_wait_commit_latency
                 .start_timer();
 
-            // Iceberg pk-index sink metadata reports are handled in three steps around hummock `commit_epoch`:
-            //   1. pre_commit: persist pending rows under `pending_sink_state` (no iceberg I/O).
+            // Iceberg pk-index sink metadata is handled in four steps around Hummock `commit_epoch`:
+            //   1. pre_commit: merge ordinary reports with optional compaction metadata and persist
+            //      one pending row per sink under `pending_sink_state`.
             //   2. commit_epoch: advance hummock.
             //   3. commit: drive iceberg overwrite_files for queued epochs.
             //   4. advance_committed_epochs: advance the per-partial-graph committed epoch cursor.
             let mut iceberg_pk_index_commit_sink_ids = Vec::new();
-            if !self.iceberg_pk_index_sink_metadata.is_empty() {
+            if !self.iceberg_pk_index_pre_commit_metadata.is_empty() {
                 let res = context
-                    .pre_commit_iceberg_pk_index_sink_metadata(self.iceberg_pk_index_sink_metadata)
+                    .pre_commit_iceberg_pk_index_sink_metadata(
+                        self.iceberg_pk_index_pre_commit_metadata,
+                    )
                     .await?;
                 iceberg_pk_index_commit_sink_ids = res;
             }

--- a/src/meta/src/barrier/context/context_impl.rs
+++ b/src/meta/src/barrier/context/context_impl.rs
@@ -29,7 +29,7 @@ use risingwave_pb::id::SourceId;
 use risingwave_pb::meta::PbTableRefillRuntimeConfig;
 use risingwave_pb::meta::subscribe_response::{Info, Operation};
 use risingwave_pb::stream_service::barrier_complete_response::{
-    PbIcebergPkIndexSinkMetadata, PbListFinishedSource, PbLoadFinishedSource,
+    PbListFinishedSource, PbLoadFinishedSource,
 };
 use risingwave_rpc_client::StreamingControlHandle;
 use thiserror_ext::AsReport;
@@ -49,6 +49,9 @@ use crate::barrier::{
 };
 use crate::hummock::CommitEpochInfo;
 use crate::manager::LocalNotification;
+use crate::manager::iceberg_pk_index_sink::{
+    IcebergPkIndexPreCommitMetadata, group_pre_commit_metadata,
+};
 use crate::model::FragmentDownstreamRelation;
 use crate::serving::{fetch_serving_infos, sync_serving_table_vnode_mappings_to_hummock};
 use crate::stream::{SourceChange, cleanup_dropped_streaming_jobs};
@@ -440,34 +443,30 @@ impl GlobalBarrierWorkerContext for GlobalBarrierWorkerContextImpl {
     #[await_tree::instrument]
     async fn pre_commit_iceberg_pk_index_sink_metadata(
         &self,
-        reports: Vec<PbIcebergPkIndexSinkMetadata>,
+        metadata: Vec<IcebergPkIndexPreCommitMetadata>,
     ) -> MetaResult<Vec<SinkId>> {
-        let grouped = group_reports_by_sink(reports)?;
-        let success_ids: Vec<SinkId> = grouped.keys().cloned().collect();
+        let inputs = group_pre_commit_metadata(metadata)?;
         let futs = FuturesUnordered::new();
-        for (sink_id, (prev_epoch, reports)) in grouped {
-            if reports.is_empty() {
-                continue;
-            }
+        for input in inputs {
             let manager = &self.iceberg_pk_index_sink_manager;
             futs.push(async move {
-                (
-                    sink_id,
-                    manager.pre_commit_epoch(sink_id, prev_epoch, reports).await,
-                )
+                let sink_id = input.sink_id;
+                (sink_id, manager.pre_commit(input).await)
             });
         }
 
         // Drain all futures regardless of individual failures, so that no coordinator is left with
         // state inconsistent vs. the caller's view.
         let results: Vec<(SinkId, anyhow::Result<()>)> = futs.collect().await;
-        let errs: Vec<(SinkId, anyhow::Error)> = results
-            .into_iter()
-            .filter_map(|(id, r)| r.err().map(|e| (id, e)))
-            .collect();
-        if errs.is_empty() {
+        let has_err = results.iter().any(|(_, result)| result.is_err());
+        if !has_err {
+            let success_ids = results.into_iter().map(|(id, _)| id).collect();
             Ok(success_ids)
         } else {
+            let errs = results
+                .into_iter()
+                .filter_map(|(id, result)| result.err().map(|error| (id, error)))
+                .collect();
             Err(aggregate_sink_errors("pre-commit", errs).into())
         }
     }
@@ -485,11 +484,10 @@ impl GlobalBarrierWorkerContext for GlobalBarrierWorkerContextImpl {
             .into_iter()
             .filter_map(|(id, r)| r.err().map(|e| (id, e)))
             .collect();
-        if errs.is_empty() {
-            Ok(())
-        } else {
-            Err(aggregate_sink_errors("commit", errs).into())
+        if !errs.is_empty() {
+            return Err(aggregate_sink_errors("commit", errs).into());
         }
+        Ok(())
     }
 
     fn advance_iceberg_pk_index_sink_committed_epochs(
@@ -522,28 +520,6 @@ fn aggregate_sink_errors(
         sink_ids.join(", "),
         details.join("; ")
     ))
-}
-
-fn group_reports_by_sink(
-    reports: Vec<PbIcebergPkIndexSinkMetadata>,
-) -> MetaResult<HashMap<SinkId, (u64, Vec<PbIcebergPkIndexSinkMetadata>)>> {
-    let mut grouped: HashMap<SinkId, (u64, Vec<PbIcebergPkIndexSinkMetadata>)> = HashMap::new();
-    for r in reports {
-        let sink_id = r.sink_id;
-        let prev_epoch = r.prev_epoch;
-        let entry = grouped.entry(sink_id).or_insert((prev_epoch, Vec::new()));
-        if entry.0 != prev_epoch {
-            return Err(anyhow::anyhow!(
-                "iceberg v3 sink {} reports disagree on prev_epoch: {} vs {}",
-                sink_id,
-                entry.0,
-                prev_epoch
-            )
-            .into());
-        }
-        entry.1.push(r);
-    }
-    Ok(grouped)
 }
 
 impl GlobalBarrierWorkerContextImpl {

--- a/src/meta/src/barrier/context/mod.rs
+++ b/src/meta/src/barrier/context/mod.rs
@@ -25,8 +25,7 @@ use risingwave_meta_model::SinkId;
 use risingwave_pb::common::WorkerNode;
 use risingwave_pb::hummock::HummockVersionStats;
 use risingwave_pb::stream_service::barrier_complete_response::{
-    IcebergPkIndexSinkMetadata as PbIcebergPkIndexSinkMetadata, PbListFinishedSource,
-    PbLoadFinishedSource,
+    PbListFinishedSource, PbLoadFinishedSource,
 };
 use risingwave_rpc_client::StreamingControlHandle;
 
@@ -42,7 +41,9 @@ use crate::barrier::{
 };
 use crate::hummock::{CommitEpochInfo, HummockManagerRef};
 use crate::manager::iceberg_compaction::IcebergCompactionManagerRef;
-use crate::manager::iceberg_pk_index_sink::IcebergPkIndexSinkManager;
+use crate::manager::iceberg_pk_index_sink::{
+    IcebergPkIndexPreCommitMetadata, IcebergPkIndexSinkManager,
+};
 use crate::manager::sink_coordination::SinkCoordinatorManager;
 use crate::manager::{MetaSrvEnv, MetadataManager};
 use crate::serving::ServingVnodeMappingRef;
@@ -167,7 +168,7 @@ pub(super) trait GlobalBarrierWorkerContext: Send + Sync + 'static {
 
     fn pre_commit_iceberg_pk_index_sink_metadata(
         &self,
-        reports: Vec<PbIcebergPkIndexSinkMetadata>,
+        metadata: Vec<IcebergPkIndexPreCommitMetadata>,
     ) -> impl Future<Output = MetaResult<Vec<SinkId>>> + Send + '_;
 
     fn commit_iceberg_pk_index_sink_metadata(

--- a/src/meta/src/barrier/schedule.rs
+++ b/src/meta/src/barrier/schedule.rs
@@ -915,8 +915,8 @@ mod tests {
 
         async fn pre_commit_iceberg_pk_index_sink_metadata(
             &self,
-            _reports: Vec<
-                risingwave_pb::stream_service::barrier_complete_response::IcebergPkIndexSinkMetadata,
+            _metadata: Vec<
+                crate::manager::iceberg_pk_index_sink::IcebergPkIndexPreCommitMetadata,
             >,
         ) -> MetaResult<Vec<risingwave_meta_model::SinkId>> {
             unimplemented!()

--- a/src/meta/src/barrier/schedule.rs
+++ b/src/meta/src/barrier/schedule.rs
@@ -915,9 +915,7 @@ mod tests {
 
         async fn pre_commit_iceberg_pk_index_sink_metadata(
             &self,
-            _metadata: Vec<
-                crate::manager::iceberg_pk_index_sink::IcebergPkIndexPreCommitMetadata,
-            >,
+            _metadata: Vec<crate::manager::iceberg_pk_index_sink::IcebergPkIndexPreCommitMetadata>,
         ) -> MetaResult<Vec<risingwave_meta_model::SinkId>> {
             unimplemented!()
         }

--- a/src/meta/src/barrier/tests/worker_crash_no_early_commit.rs
+++ b/src/meta/src/barrier/tests/worker_crash_no_early_commit.rs
@@ -177,8 +177,8 @@ impl GlobalBarrierWorkerContext for MockBarrierWorkerContext {
 
     async fn pre_commit_iceberg_pk_index_sink_metadata(
         &self,
-        _reports: Vec<
-            risingwave_pb::stream_service::barrier_complete_response::IcebergPkIndexSinkMetadata,
+        _metadata: Vec<
+            crate::manager::iceberg_pk_index_sink::IcebergPkIndexPreCommitMetadata,
         >,
     ) -> MetaResult<Vec<SinkId>> {
         unimplemented!()

--- a/src/meta/src/barrier/tests/worker_crash_no_early_commit.rs
+++ b/src/meta/src/barrier/tests/worker_crash_no_early_commit.rs
@@ -177,9 +177,7 @@ impl GlobalBarrierWorkerContext for MockBarrierWorkerContext {
 
     async fn pre_commit_iceberg_pk_index_sink_metadata(
         &self,
-        _metadata: Vec<
-            crate::manager::iceberg_pk_index_sink::IcebergPkIndexPreCommitMetadata,
-        >,
+        _metadata: Vec<crate::manager::iceberg_pk_index_sink::IcebergPkIndexPreCommitMetadata>,
     ) -> MetaResult<Vec<SinkId>> {
         unimplemented!()
     }

--- a/src/meta/src/barrier/utils.rs
+++ b/src/meta/src/barrier/utils.rs
@@ -190,8 +190,8 @@ pub(super) fn collect_independent_job_commit_epoch_info(
                 .expect("non-duplicate");
         }
     };
-    task.iceberg_pk_index_sink_metadata
-        .extend(iceberg_pk_index_sink_metadata);
+    task.iceberg_pk_index_pre_commit_metadata
+        .extend(iceberg_pk_index_sink_metadata.into_iter().map(Into::into));
 }
 
 pub(super) type NodeToCollect = HashSet<WorkerId>;

--- a/src/meta/src/manager/iceberg_pk_index_sink/coordinator.rs
+++ b/src/meta/src/manager/iceberg_pk_index_sink/coordinator.rs
@@ -25,8 +25,9 @@
 //!
 //! The two phases dispatched from `complete_barrier`:
 //!
-//! 1. `pre_commit` — aggregate the reports, generate a `snapshot_id`, persist the merged file list under
-//!    `pending_sink_state`, return. No iceberg I/O.
+//! 1. `pre_commit` — reload the table, aggregate the reports, generate a `snapshot_id`, and persist
+//!    the merged file list under `pending_sink_state`. Combined compaction pre-commit may also coalesce
+//!    duplicate position-delete artifacts through Iceberg file I/O.
 //! 2. `commit` — run an iceberg `overwrite_files` transaction (keyed on the pre-generated `snapshot_id`
 //!    for idempotency), then mark the row Committed and prune the prior epoch's row.
 //!
@@ -34,21 +35,30 @@
 //! meta-recovery path drops the coordinator, re-registers it (re-running `init`), and retries from the
 //! persisted `pending_sink_state` rows.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
+use std::hash::{Hash, Hasher};
 use std::sync::Arc;
 use std::time::Duration;
 
 use anyhow::{Context, Result, anyhow, bail};
 use iceberg::Catalog;
-use iceberg::spec::{DataFile, ManifestContentType, SerializedDataFile};
+use iceberg::delete_vector::DeleteVector;
+use iceberg::spec::{
+    DataContentType, DataFile, DataFileFormat, FormatVersion, ManifestContentType, PartitionKey,
+    SerializedDataFile,
+};
 use iceberg::table::Table;
 use iceberg::transaction::{ApplyTransactionAction, FastAppendAction, Transaction};
+use iceberg::writer::file_writer::location_generator::{
+    DefaultLocationGenerator, FileNameGenerator, LocationGenerator,
+};
 use prost::Message;
 use risingwave_connector::sink::catalog::SinkId;
 use risingwave_connector::sink::iceberg::commit_retry::{self, CommitError, CommitRetryLogContext};
 use risingwave_connector::sink::iceberg::{
-    IcebergCommitResult, IcebergConfig, IcebergPositionDeleteCommitResult, commit_branch,
-    resolve_partition_type,
+    IcebergCommitResult, IcebergConfig, IcebergPositionDeleteCommitResult,
+    PositionDeleteFileNameGenerators, commit_branch, read_position_deletes_from_file,
+    resolve_partition_type, serialize_data_files_default_spec, write_position_delete_file,
 };
 use risingwave_meta_model::pending_sink_state::SinkState;
 use risingwave_pb::connector_service::PbIcebergPkIndexPreCommitState;
@@ -58,7 +68,9 @@ use sea_orm::DatabaseConnection;
 use serde::{Deserialize, Serialize};
 use thiserror_ext::AsReport;
 use tokio::time::timeout;
+use twox_hash::XxHash64;
 
+use super::CompactionOverwrite;
 use crate::manager::exactly_once_util::{
     clean_aborted_records, commit_and_prune_epoch, list_sink_states_ordered_by_epoch,
     persist_pre_commit_metadata,
@@ -90,6 +102,7 @@ pub struct IcebergPkIndexSinkCoordinator {
     db: DatabaseConnection,
     catalog: Arc<dyn Catalog>,
     table: Table,
+    iceberg_config: IcebergConfig,
     target_branch: String,
     retry_num: usize,
     /// The epoch pre-committed but not yet committed, carried from `pre_commit` to the next `commit`.
@@ -127,14 +140,16 @@ impl IcebergPkIndexSinkCoordinator {
 
         let target_branch =
             commit_branch(iceberg_config.r#type.as_str(), iceberg_config.write_mode);
+        let retry_num = iceberg_config.commit_retry_num as usize;
 
         let mut coordinator = Self {
             sink_id,
             db,
             catalog,
             table,
+            iceberg_config,
             target_branch,
-            retry_num: iceberg_config.commit_retry_num as usize,
+            retry_num,
             waiting_commit: None,
             prev_committed_epoch,
         };
@@ -154,18 +169,155 @@ impl IcebergPkIndexSinkCoordinator {
         &mut self,
         prev_epoch: u64,
         reports: Vec<PbIcebergPkIndexSinkMetadata>,
+        compaction: Option<CompactionOverwrite>,
     ) -> Result<()> {
-        if reports.iter().all(|r| r.metadata.is_none()) {
-            return Ok(());
-        }
+        self.reload_table_for_pre_commit().await?;
+        let current_schema_id = self.table.metadata().current_schema_id();
+        let current_partition_spec_id = self.table.metadata().default_partition_spec_id();
+        let current_format_version = self.table.metadata().format_version();
+        let (ordinary_reports, resolver_reports): (Vec<_>, Vec<_>) =
+            reports.into_iter().partition(|report| {
+                PbIcebergPkIndexSinkRole::try_from(report.role)
+                    != Ok(PbIcebergPkIndexSinkRole::CompactionResolver)
+            });
+        let ordinary_aggregate = aggregate_ordinary_reports(
+            &ordinary_reports,
+            current_schema_id,
+            current_partition_spec_id,
+            current_format_version,
+        )?;
 
-        let merged = aggregate_reports(&reports)?;
-        if merged.data_files.is_empty() && merged.delete_files.is_empty() {
+        let Some(compaction) = compaction else {
+            if !resolver_reports.is_empty() {
+                bail!("compaction resolver reports require compaction pre-commit metadata");
+            }
+            let Some(merged) = ordinary_aggregate else {
+                return Ok(());
+            };
+            if merged.data_files.is_empty() && merged.delete_files.is_empty() {
+                bail!(
+                    "pk-index sink epoch {} has no data files to commit",
+                    prev_epoch
+                );
+            }
+            return self.stage_pre_commit(prev_epoch, merged).await;
+        };
+        let CompactionOverwrite {
+            sink_id,
+            epoch,
+            schema_id: output_schema_id,
+            partition_spec_id: output_partition_spec_id,
+            output_files,
+            input_file_paths,
+            read_snapshot_id,
+        } = compaction;
+        debug_assert_eq!(sink_id, self.sink_id);
+        if epoch != prev_epoch {
             bail!(
-                "pk-index sink epoch {} has no data files to commit",
+                "pk-index sink {} compaction epoch {} does not match pre-commit epoch {}",
+                self.sink_id,
+                epoch,
                 prev_epoch
             );
         }
+        validate_aggregate_ids(
+            "compactor output",
+            output_schema_id,
+            output_partition_spec_id,
+            current_schema_id,
+            current_partition_spec_id,
+        )?;
+        let resolver_delete_aggregate =
+            decode_compaction_resolver_delete_reports(resolver_reports)?;
+        let overwrite_files = self
+            .resolve_compaction_overwrite_files(&input_file_paths)
+            .await
+            .with_context(|| {
+                format!(
+                    "resolve pk-index compaction inputs at read snapshot {}",
+                    read_snapshot_id
+                )
+            })?;
+        let partition_spec = self
+            .table
+            .metadata()
+            .partition_spec_by_id(output_partition_spec_id)
+            .context("find compactor output partition spec")?;
+        let output_schema = self
+            .table
+            .metadata()
+            .schema_by_id(output_schema_id)
+            .context("find compactor output schema")?;
+        let partition_type = partition_spec.partition_type(output_schema)?;
+        let output_data_files = output_files
+            .iter()
+            .cloned()
+            .map(|file| file.try_into(output_partition_spec_id, &partition_type, output_schema))
+            .try_collect::<Vec<DataFile>>()?;
+        let merged = combine_compaction_aggregate(
+            current_schema_id,
+            current_partition_spec_id,
+            current_format_version,
+            ordinary_aggregate,
+            output_files,
+            resolver_delete_aggregate,
+            overwrite_files,
+        )?;
+        let mut added_delete_files = merged
+            .delete_files
+            .iter()
+            .cloned()
+            .map(|file| {
+                file.try_into(
+                    current_partition_spec_id,
+                    &partition_type,
+                    self.table.metadata().current_schema(),
+                )
+            })
+            .try_collect::<Vec<DataFile>>()?;
+        // TODO(pk-index-compaction): Remove
+        // `coalesce_position_delete_files` once the resolver attach/detach protocol
+        // guarantees that foreground sink writes cannot author position-delete
+        // artifacts for compaction output data files in the compaction commit epoch.
+        // Until then, resolver masking deletes and PositionDeleteMerger deletes may
+        // reference the same output file, so Meta must union their positions and
+        // persist exactly one replacement artifact.
+        let discarded_paths = coalesce_position_delete_files(
+            &self.table,
+            &self.iceberg_config,
+            prev_epoch,
+            &output_data_files,
+            &mut added_delete_files,
+        )
+        .await?;
+        let serialized_delete_files =
+            serialize_data_files_default_spec(&self.table, added_delete_files)?;
+        let merged = IcebergPkIndexSinkAggResult {
+            delete_files: serialized_delete_files,
+            ..merged
+        };
+        self.stage_pre_commit(prev_epoch, merged).await?;
+        self.cleanup_discarded_uncommitted_paths(prev_epoch, discarded_paths)
+            .await;
+        Ok(())
+    }
+
+    async fn reload_table_for_pre_commit(&mut self) -> Result<()> {
+        self.table = self
+            .catalog
+            .load_table(self.table.identifier())
+            .await
+            .map_err(|error| {
+                anyhow!(error).context("reload iceberg table before pk-index pre-commit")
+            })?;
+        Ok(())
+    }
+
+    async fn stage_pre_commit(
+        &mut self,
+        prev_epoch: u64,
+        merged: IcebergPkIndexSinkAggResult,
+    ) -> Result<()> {
         let (merged, materialized_add_files) = self.backfill_delete_file_partitions(merged).await?;
         let merged = Arc::new(merged);
 
@@ -180,6 +332,78 @@ impl IcebergPkIndexSinkCoordinator {
             materialized_add_files,
         });
         Ok(())
+    }
+
+    async fn cleanup_discarded_uncommitted_paths(&self, epoch: u64, paths: Vec<String>) {
+        for path in paths {
+            if let Err(error) = self.table.file_io().delete(&path).await {
+                tracing::warn!(
+                    error = %error.as_report(),
+                    sink_id = %self.sink_id,
+                    epoch,
+                    path,
+                    "failed to clean redundant uncommitted pk-index position-delete artifact",
+                );
+            }
+        }
+    }
+
+    async fn resolve_compaction_overwrite_files(
+        &self,
+        input_file_paths: &[String],
+    ) -> Result<Vec<SerializedDataFile>> {
+        let input_paths: HashSet<&str> = input_file_paths.iter().map(String::as_str).collect();
+        let mut required_live_data = input_paths.clone();
+        let mut removed: HashMap<String, DataFile> = HashMap::new();
+
+        if let Some(snapshot) = self.table.metadata().snapshot_for_ref(&self.target_branch) {
+            let manifest_list = self
+                .table
+                .object_cache()
+                .get_manifest_list(snapshot, &self.table.metadata_ref())
+                .await
+                .context("load manifest list for compaction pre-commit")?;
+            for manifest_file in manifest_list.entries() {
+                let manifest = manifest_file
+                    .load_manifest(self.table.file_io())
+                    .await
+                    .context("load manifest for compaction pre-commit")?;
+                for entry in manifest.entries() {
+                    let data_file = entry.data_file();
+                    let path = data_file.file_path();
+                    let is_delete = matches!(
+                        data_file.content_type(),
+                        DataContentType::PositionDeletes | DataContentType::EqualityDeletes
+                    );
+                    if is_delete && input_paths.contains(path) {
+                        required_live_data.remove(path);
+                    }
+                    if !entry.is_alive() {
+                        continue;
+                    }
+                    if input_paths.contains(path) {
+                        required_live_data.remove(path);
+                        removed.insert(path.to_owned(), data_file.clone());
+                    }
+                    if data_file.content_type() == DataContentType::PositionDeletes
+                        && let Some(referenced) = data_file.referenced_data_file()
+                        && input_paths.contains(referenced.as_str())
+                    {
+                        removed.insert(path.to_owned(), data_file.clone());
+                    }
+                }
+            }
+        }
+
+        if !required_live_data.is_empty() {
+            bail!(
+                "pk-index compaction overwrite: {} input data files are no longer live on branch {}",
+                required_live_data.len(),
+                self.target_branch
+            );
+        }
+        serialize_data_files_default_spec(&self.table, removed.into_values().collect())
+            .map_err(Into::into)
     }
 
     pub async fn commit(&mut self) -> Result<()> {
@@ -293,6 +517,7 @@ impl IcebergPkIndexSinkCoordinator {
         let merged = IcebergPkIndexSinkAggResult {
             schema_id: merged.schema_id,
             partition_spec_id: merged.partition_spec_id,
+            format_version: merged.format_version,
             data_files: merged.data_files,
             delete_files: serialized_delete_files,
             overwrite_files: merged.overwrite_files,
@@ -460,6 +685,9 @@ async fn commit_one_epoch(
         table_ident.clone(),
         merged.schema_id,
         merged.partition_spec_id,
+        // Recovered legacy rows predate format persistence. Their files were authored before this
+        // invariant existed, so retain the previous schema/spec-only commit validation for them.
+        merged.format_version,
         retry_num,
         CommitRetryLogContext::new(
             "iceberg_v3_sink_coordinator",
@@ -549,14 +777,265 @@ async fn commit_one_epoch(
 struct IcebergPkIndexSinkAggResult {
     schema_id: i32,
     partition_spec_id: i32,
+    #[serde(default)]
+    format_version: Option<FormatVersion>,
     data_files: Vec<SerializedDataFile>,
     delete_files: Vec<SerializedDataFile>,
     overwrite_files: Vec<SerializedDataFile>,
 }
 
+impl std::fmt::Debug for IcebergPkIndexSinkAggResult {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("IcebergPkIndexSinkAggResult")
+            .field("schema_id", &self.schema_id)
+            .field("partition_spec_id", &self.partition_spec_id)
+            .field("format_version", &self.format_version)
+            .field("data_files", &self.data_files.len())
+            .field("delete_files", &self.delete_files.len())
+            .field("overwrite_files", &self.overwrite_files.len())
+            .finish()
+    }
+}
+
+struct CompactionResolverDeleteAggregate {
+    schema_id: i32,
+    partition_spec_id: i32,
+    delete_files: Vec<SerializedDataFile>,
+}
+
+// TODO(pk-index-compaction): Remove
+// `coalesce_position_delete_files` once the resolver attach/detach protocol
+// guarantees that foreground sink writes cannot author position-delete
+// artifacts for compaction output data files in the compaction commit epoch.
+// Until then, resolver masking deletes and PositionDeleteMerger deletes may
+// reference the same output file, so Meta must union their positions and
+// persist exactly one replacement artifact.
+async fn coalesce_position_delete_files(
+    table: &Table,
+    config: &IcebergConfig,
+    epoch: u64,
+    compaction_output_files: &[DataFile],
+    added_delete_files: &mut Vec<DataFile>,
+) -> Result<Vec<String>> {
+    let mut outputs = HashMap::with_capacity(compaction_output_files.len());
+    let mut reserved_paths =
+        HashSet::with_capacity(compaction_output_files.len() + added_delete_files.len());
+    for output in compaction_output_files {
+        if outputs.insert(output.file_path(), output).is_some()
+            || !reserved_paths.insert(output.file_path().to_owned())
+        {
+            bail!("duplicate compaction output path {}", output.file_path());
+        }
+    }
+    let mut groups: HashMap<String, Vec<usize>> = HashMap::new();
+
+    for delete_file in added_delete_files.iter() {
+        if !reserved_paths.insert(delete_file.file_path().to_owned()) {
+            bail!(
+                "duplicate or overlapping compaction file path {}",
+                delete_file.file_path()
+            );
+        }
+    }
+
+    for (index, delete_file) in added_delete_files.iter().enumerate() {
+        if delete_file.content_type() != DataContentType::PositionDeletes {
+            continue;
+        }
+        let referenced_path = delete_file.referenced_data_file().ok_or_else(|| {
+            anyhow!(
+                "position-delete artifact {} missing referenced_data_file",
+                delete_file.file_path()
+            )
+        })?;
+        if !outputs.contains_key(referenced_path.as_str()) {
+            continue;
+        }
+        groups.entry(referenced_path).or_default().push(index);
+    }
+
+    let format = if table.metadata().format_version() >= FormatVersion::V3 {
+        DataFileFormat::Puffin
+    } else {
+        DataFileFormat::Parquet
+    };
+    let location_generator = DefaultLocationGenerator::new(table.metadata())?;
+    let partition_spec = table.metadata().default_partition_spec();
+    let schema = table.metadata().current_schema();
+    let mut replacement_plans = groups
+        .into_iter()
+        .filter(|(_, indices)| indices.len() > 1)
+        .collect::<Vec<_>>();
+    replacement_plans.sort_unstable_by(|(left, _), (right, _)| left.cmp(right));
+    let replacement_plans = replacement_plans
+        .into_iter()
+        .map(|(referenced_path, indices)| {
+            let output = outputs[referenced_path.as_str()];
+            let partition_key = PartitionKey::new(
+                partition_spec.as_ref().clone(),
+                schema.clone(),
+                output.partition().clone(),
+            );
+            let mut hasher = XxHash64::with_seed(0);
+            referenced_path.hash(&mut hasher);
+            let identity = format!("{}-{:016x}", epoch, hasher.finish());
+            let preview_generator = PositionDeleteFileNameGenerators::new(&identity);
+            let replacement_location = location_generator.generate_location(
+                Some(&partition_key),
+                &preview_generator.for_format(format)?.generate_file_name(),
+            );
+            if !reserved_paths.insert(replacement_location.clone()) {
+                bail!(
+                    "generated compaction position-delete replacement path {} collides with another compaction file",
+                    replacement_location
+                );
+            }
+            Ok((
+                referenced_path,
+                indices,
+                partition_key,
+                identity,
+                replacement_location,
+            ))
+        })
+        .try_collect::<Vec<_>>()?;
+    let mut replacements = Vec::with_capacity(replacement_plans.len());
+    let mut replaced_indices = vec![false; added_delete_files.len()];
+    let mut discarded_paths = Vec::new();
+
+    for (referenced_path, indices, partition_key, identity, replacement_location) in
+        replacement_plans
+    {
+        let mut delete_vector = DeleteVector::default();
+        for index in &indices {
+            let source = &added_delete_files[*index];
+            let positions = read_position_deletes_from_file(table.file_io(), source)
+                .await
+                .with_context(|| {
+                    format!(
+                        "read compaction output position deletes from {}",
+                        source.file_path()
+                    )
+                })?;
+            delete_vector.extend(positions.iter());
+            discarded_paths.push(source.file_path().to_owned());
+            replaced_indices[*index] = true;
+        }
+
+        table
+            .file_io()
+            .delete(&replacement_location)
+            .await
+            .with_context(|| {
+                format!(
+                    "delete prior uncommitted compaction position-delete replacement {replacement_location}"
+                )
+            })?;
+        let file_name_generators = PositionDeleteFileNameGenerators::new(identity);
+        let replacement = write_position_delete_file(
+            table,
+            config,
+            &location_generator,
+            &file_name_generators,
+            table.metadata().format_version(),
+            referenced_path.clone(),
+            &delete_vector,
+            Some(&partition_key),
+        )
+        .await?;
+        replacements.push(replacement);
+    }
+
+    if replaced_indices.iter().any(|replaced| *replaced) {
+        *added_delete_files = added_delete_files
+            .drain(..)
+            .enumerate()
+            .filter_map(|(index, file)| (!replaced_indices[index]).then_some(file))
+            .chain(replacements)
+            .collect();
+    }
+    Ok(discarded_paths)
+}
+
+fn validate_aggregate_ids(
+    source: &str,
+    schema_id: i32,
+    partition_spec_id: i32,
+    current_schema_id: i32,
+    current_partition_spec_id: i32,
+) -> Result<()> {
+    if schema_id != current_schema_id {
+        bail!(
+            "pk-index sink {source} use schema_id {schema_id}, but table current schema_id is {current_schema_id}"
+        );
+    }
+    if partition_spec_id != current_partition_spec_id {
+        bail!(
+            "pk-index sink {source} use partition_spec_id {partition_spec_id}, but table default partition_spec_id is {current_partition_spec_id}"
+        );
+    }
+    Ok(())
+}
+
+fn aggregate_ordinary_reports(
+    reports: &[PbIcebergPkIndexSinkMetadata],
+    current_schema_id: i32,
+    current_partition_spec_id: i32,
+    format_version: FormatVersion,
+) -> Result<Option<IcebergPkIndexSinkAggResult>> {
+    let mut aggregate = aggregate_reports(reports)?;
+    if let Some(aggregate) = &mut aggregate {
+        validate_aggregate_ids(
+            "ordinary reports",
+            aggregate.schema_id,
+            aggregate.partition_spec_id,
+            current_schema_id,
+            current_partition_spec_id,
+        )?;
+        aggregate.format_version = Some(format_version);
+    }
+    Ok(aggregate)
+}
+
+fn combine_compaction_aggregate(
+    current_schema_id: i32,
+    current_partition_spec_id: i32,
+    current_format_version: FormatVersion,
+    ordinary: Option<IcebergPkIndexSinkAggResult>,
+    output_files: Vec<SerializedDataFile>,
+    resolver: Option<CompactionResolverDeleteAggregate>,
+    overwrite_files: Vec<SerializedDataFile>,
+) -> Result<IcebergPkIndexSinkAggResult> {
+    if let Some(resolver) = &resolver {
+        validate_aggregate_ids(
+            "compaction resolver reports",
+            resolver.schema_id,
+            resolver.partition_spec_id,
+            current_schema_id,
+            current_partition_spec_id,
+        )?;
+    }
+
+    let mut merged = ordinary.unwrap_or(IcebergPkIndexSinkAggResult {
+        schema_id: current_schema_id,
+        partition_spec_id: current_partition_spec_id,
+        format_version: None,
+        data_files: vec![],
+        delete_files: vec![],
+        overwrite_files: vec![],
+    });
+    merged.format_version = Some(current_format_version);
+    merged.data_files.extend(output_files);
+    if let Some(resolver) = resolver {
+        merged.delete_files.extend(resolver.delete_files);
+    }
+    merged.overwrite_files.extend(overwrite_files);
+    Ok(merged)
+}
+
 fn aggregate_reports(
     reports: &[PbIcebergPkIndexSinkMetadata],
-) -> Result<IcebergPkIndexSinkAggResult> {
+) -> Result<Option<IcebergPkIndexSinkAggResult>> {
     let mut shared_schema_id: Option<i32> = None;
     let mut shared_partition_spec_id: Option<i32> = None;
 
@@ -564,20 +1043,21 @@ fn aggregate_reports(
     let mut delete_files: Vec<SerializedDataFile> = Vec::new();
     let mut overwrite_files: Vec<SerializedDataFile> = Vec::new();
 
-    if reports.is_empty() {
-        bail!("no reports to aggregate for iceberg pk-index sink coordinator");
-    }
-
     for r in reports {
-        let Some(meta) = &r.metadata else {
-            bail!("iceberg pk-index sink report missing metadata in aggregate_reports");
-        };
-
-        // Validate role: explicitly-Unspecified is a wire-format bug.
         let role = PbIcebergPkIndexSinkRole::try_from(r.role)
             .ok()
             .filter(|r| !matches!(r, PbIcebergPkIndexSinkRole::Unspecified))
             .ok_or_else(|| anyhow!("iceberg pk-index sink report has invalid role: {}", r.role))?;
+        let Some(meta) = &r.metadata else {
+            match role {
+                PbIcebergPkIndexSinkRole::Writer
+                | PbIcebergPkIndexSinkRole::PositionDeleteMerger => continue,
+                PbIcebergPkIndexSinkRole::CompactionResolver => {
+                    bail!("compaction resolver reports require compaction pre-commit metadata");
+                }
+                PbIcebergPkIndexSinkRole::Unspecified => unreachable!(),
+            }
+        };
 
         match role {
             PbIcebergPkIndexSinkRole::Writer => {
@@ -591,10 +1071,7 @@ fn aggregate_reports(
                 data_files.extend(commit_result.data_files);
             }
             PbIcebergPkIndexSinkRole::PositionDeleteMerger => {
-                let commit_result =
-                    IcebergPositionDeleteCommitResult::try_from(meta).map_err(|e| {
-                        anyhow!(e).context("decode pk-index sink position-delete merger metadata")
-                    })?;
+                let commit_result = IcebergPositionDeleteCommitResult::try_from(meta)?;
                 align_report_id(
                     commit_result.schema_id,
                     commit_result.partition_spec_id,
@@ -604,17 +1081,73 @@ fn aggregate_reports(
                 delete_files.extend(commit_result.delete_files);
                 overwrite_files.extend(commit_result.overwrite_files);
             }
-            _ => unreachable!(),
+            PbIcebergPkIndexSinkRole::CompactionResolver => {
+                bail!("compaction resolver reports require compaction pre-commit metadata");
+            }
+            PbIcebergPkIndexSinkRole::Unspecified => {
+                bail!("iceberg pk-index sink report has unspecified role");
+            }
         }
     }
 
-    Ok(IcebergPkIndexSinkAggResult {
-        schema_id: shared_schema_id.unwrap(),
-        partition_spec_id: shared_partition_spec_id.unwrap(),
+    let (Some(schema_id), Some(partition_spec_id)) = (shared_schema_id, shared_partition_spec_id)
+    else {
+        return Ok(None);
+    };
+    Ok(Some(IcebergPkIndexSinkAggResult {
+        schema_id,
+        partition_spec_id,
+        // Filled from the coordinator's current table after report ID validation.
+        format_version: None,
         data_files,
         delete_files,
         overwrite_files,
-    })
+    }))
+}
+
+fn decode_compaction_resolver_delete_reports(
+    reports: impl IntoIterator<Item = PbIcebergPkIndexSinkMetadata>,
+) -> Result<Option<CompactionResolverDeleteAggregate>> {
+    let mut shared_schema_id = None;
+    let mut shared_partition_spec_id = None;
+    let mut delete_files = Vec::new();
+    let mut has_report = false;
+    for report in reports {
+        if PbIcebergPkIndexSinkRole::try_from(report.role)
+            != Ok(PbIcebergPkIndexSinkRole::CompactionResolver)
+        {
+            bail!(
+                "compaction resolver reported unexpected sink role {}",
+                report.role
+            );
+        }
+        let metadata = report
+            .metadata
+            .as_ref()
+            .context("compaction resolver delete report missing metadata")?;
+        let result = IcebergPositionDeleteCommitResult::try_from(metadata)
+            .map_err(|error| anyhow!(error).context("decode compaction resolver delete report"))?;
+        if !result.overwrite_files.is_empty() {
+            bail!("compaction resolver delete report should not contain overwrite_files");
+        }
+        has_report = true;
+        align_report_id(
+            result.schema_id,
+            result.partition_spec_id,
+            &mut shared_schema_id,
+            &mut shared_partition_spec_id,
+        )?;
+        delete_files.extend(result.delete_files);
+    }
+    if !has_report {
+        return Ok(None);
+    }
+    Ok(Some(CompactionResolverDeleteAggregate {
+        schema_id: shared_schema_id.expect("resolver report aligned schema id"),
+        partition_spec_id: shared_partition_spec_id
+            .expect("resolver report aligned partition spec id"),
+        delete_files,
+    }))
 }
 
 fn align_report_id(
@@ -665,3 +1198,7 @@ fn decode_pre_commit_state(blob: &[u8]) -> Result<(Arc<IcebergPkIndexSinkAggResu
     let agg_result = Arc::new(serde_json::from_slice(&state.agg_result)?);
     Ok((agg_result, state.snapshot_id))
 }
+
+#[cfg(all(test, not(madsim)))]
+#[path = "coordinator_test.rs"]
+mod tests;

--- a/src/meta/src/manager/iceberg_pk_index_sink/coordinator_test.rs
+++ b/src/meta/src/manager/iceberg_pk_index_sink/coordinator_test.rs
@@ -1,0 +1,964 @@
+// Copyright 2026 RisingWave Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::BTreeMap;
+use std::sync::Mutex;
+
+use async_trait::async_trait;
+use iceberg::delete_vector::DeleteVector;
+use iceberg::io::FileIO;
+use iceberg::spec::{
+    DataFileBuilder, DataFileFormat, FormatVersion, Literal, NestedField, PrimitiveType, Schema,
+    SortOrder, Struct, TableMetadataBuilder, Transform, Type, UnboundPartitionField,
+    UnboundPartitionSpec,
+};
+use iceberg::writer::file_writer::location_generator::{
+    DefaultFileNameGenerator, DefaultLocationGenerator,
+};
+use iceberg::{
+    Catalog, Namespace, NamespaceIdent, Runtime, TableCommit, TableCreation, TableIdent,
+};
+use risingwave_connector::sink::iceberg::{
+    read_position_deletes_from_file, write_dv_puffin_file, write_parquet_position_delete_file,
+};
+use risingwave_pb::connector_service::SinkMetadata;
+use tempfile::TempDir;
+
+use super::*;
+
+fn report(
+    role: PbIcebergPkIndexSinkRole,
+    metadata: Option<SinkMetadata>,
+) -> PbIcebergPkIndexSinkMetadata {
+    PbIcebergPkIndexSinkMetadata {
+        role: role as i32,
+        metadata,
+        ..Default::default()
+    }
+}
+
+fn serialized_file(path: &str) -> SerializedDataFile {
+    serde_json::from_value(serde_json::json!({
+        "content": 0,
+        "file_path": path,
+        "file_format": "PARQUET",
+        "partition": {},
+        "record_count": 1,
+        "file_size_in_bytes": 1
+    }))
+    .unwrap()
+}
+
+fn writer_metadata(
+    schema_id: i32,
+    partition_spec_id: i32,
+    data_files: Vec<SerializedDataFile>,
+) -> SinkMetadata {
+    SinkMetadata::try_from(&IcebergCommitResult {
+        schema_id,
+        partition_spec_id,
+        data_files,
+    })
+    .unwrap()
+}
+
+fn merger_metadata(
+    schema_id: i32,
+    partition_spec_id: i32,
+    delete_files: Vec<SerializedDataFile>,
+    overwrite_files: Vec<SerializedDataFile>,
+) -> SinkMetadata {
+    SinkMetadata::try_from(&IcebergPositionDeleteCommitResult {
+        schema_id,
+        partition_spec_id,
+        delete_files,
+        overwrite_files,
+    })
+    .unwrap()
+}
+
+fn coalesce_test_config() -> IcebergConfig {
+    IcebergConfig::from_btreemap(BTreeMap::from([
+        ("connector".to_owned(), "iceberg".to_owned()),
+        ("type".to_owned(), "upsert".to_owned()),
+        ("primary_key".to_owned(), "id".to_owned()),
+        ("warehouse.path".to_owned(), "memory://coalesce".to_owned()),
+        ("catalog.type".to_owned(), "storage".to_owned()),
+        ("database.name".to_owned(), "db".to_owned()),
+        ("table.name".to_owned(), "table".to_owned()),
+    ]))
+    .unwrap()
+}
+
+fn coalesce_test_table(temp_dir: &TempDir, format_version: FormatVersion) -> Result<Table> {
+    coalesce_test_table_with_partitioning(temp_dir, format_version, false)
+}
+
+fn coalesce_test_table_with_partitioning(
+    temp_dir: &TempDir,
+    format_version: FormatVersion,
+    partitioned: bool,
+) -> Result<Table> {
+    let location = format!("file://{}", temp_dir.path().display());
+    coalesce_test_table_at_location(&location, format_version, partitioned)
+}
+
+fn coalesce_test_table_at_location(
+    location: &str,
+    format_version: FormatVersion,
+    partitioned: bool,
+) -> Result<Table> {
+    let location = location.to_owned();
+    let schema = Schema::builder()
+        .with_schema_id(0)
+        .with_fields(vec![
+            NestedField::required(1, "id", Type::Primitive(PrimitiveType::Long)).into(),
+        ])
+        .build()?;
+    let partition_spec = if partitioned {
+        UnboundPartitionSpec::builder()
+            .with_spec_id(1)
+            .add_partition_fields(vec![UnboundPartitionField {
+                source_id: 1,
+                field_id: Some(1000),
+                name: "id".to_owned(),
+                transform: Transform::Identity,
+            }])?
+            .build()
+    } else {
+        UnboundPartitionSpec::builder().build()
+    };
+    let metadata = TableMetadataBuilder::new(
+        schema,
+        partition_spec,
+        SortOrder::unsorted_order(),
+        location,
+        format_version,
+        HashMap::new(),
+    )?
+    .build()?
+    .metadata;
+    Ok(Table::builder()
+        .identifier(TableIdent::new(
+            NamespaceIdent::new("db".to_owned()),
+            "table".to_owned(),
+        ))
+        .file_io(FileIO::new_with_fs())
+        .runtime(Runtime::try_current()?)
+        .metadata(metadata)
+        .build()?)
+}
+
+fn output_data_file(table: &Table, name: &str) -> Result<DataFile> {
+    output_data_file_with_partition(table, name, Struct::empty())
+}
+
+fn output_data_file_with_partition(
+    table: &Table,
+    name: &str,
+    partition: Struct,
+) -> Result<DataFile> {
+    Ok(DataFileBuilder::default()
+        .content(DataContentType::Data)
+        .file_path(format!(
+            "{}/data/{name}.parquet",
+            table.metadata().location()
+        ))
+        .file_format(DataFileFormat::Parquet)
+        .partition(partition)
+        .partition_spec_id(table.metadata().default_partition_spec_id())
+        .record_count(10)
+        .file_size_in_bytes(1)
+        .build()?)
+}
+
+async fn write_test_position_delete(
+    table: &Table,
+    config: &IcebergConfig,
+    prefix: &str,
+    referenced_path: &str,
+    positions: impl IntoIterator<Item = u64>,
+) -> Result<DataFile> {
+    write_test_position_delete_with_partition(
+        table,
+        config,
+        prefix,
+        referenced_path,
+        positions,
+        None,
+    )
+    .await
+}
+
+async fn write_test_position_delete_with_partition(
+    table: &Table,
+    config: &IcebergConfig,
+    prefix: &str,
+    referenced_path: &str,
+    positions: impl IntoIterator<Item = u64>,
+    partition_key: Option<&PartitionKey>,
+) -> Result<DataFile> {
+    let format = if table.metadata().format_version() >= FormatVersion::V3 {
+        DataFileFormat::Puffin
+    } else {
+        DataFileFormat::Parquet
+    };
+    let location_generator = DefaultLocationGenerator::new(table.metadata())?;
+    let file_name_generator = DefaultFileNameGenerator::new(prefix.to_owned(), None, format);
+    let delete_vector = DeleteVector::from_iter(positions);
+    if format == DataFileFormat::Puffin {
+        write_dv_puffin_file(
+            table,
+            &location_generator,
+            &file_name_generator,
+            referenced_path.to_owned(),
+            &delete_vector,
+            partition_key,
+        )
+        .await
+    } else {
+        write_parquet_position_delete_file(
+            table,
+            &location_generator,
+            &file_name_generator,
+            config,
+            referenced_path.to_owned(),
+            &delete_vector,
+            partition_key,
+        )
+        .await
+    }
+}
+
+#[derive(Debug)]
+struct ReloadingTestCatalog {
+    table: Mutex<Table>,
+}
+
+impl ReloadingTestCatalog {
+    fn new(table: Table) -> Self {
+        Self {
+            table: Mutex::new(table),
+        }
+    }
+
+    fn set_table(&self, table: Table) {
+        *self.table.lock().unwrap() = table;
+    }
+}
+
+#[async_trait]
+impl Catalog for ReloadingTestCatalog {
+    async fn load_table(&self, _table: &TableIdent) -> iceberg::Result<Table> {
+        Ok(self.table.lock().unwrap().clone())
+    }
+
+    async fn list_namespaces(
+        &self,
+        _parent: Option<&NamespaceIdent>,
+    ) -> iceberg::Result<Vec<NamespaceIdent>> {
+        unreachable!("test only loads a table")
+    }
+
+    async fn create_namespace(
+        &self,
+        _namespace: &NamespaceIdent,
+        _properties: HashMap<String, String>,
+    ) -> iceberg::Result<Namespace> {
+        unreachable!("test only loads a table")
+    }
+
+    async fn get_namespace(&self, _namespace: &NamespaceIdent) -> iceberg::Result<Namespace> {
+        unreachable!("test only loads a table")
+    }
+
+    async fn namespace_exists(&self, _namespace: &NamespaceIdent) -> iceberg::Result<bool> {
+        unreachable!("test only loads a table")
+    }
+
+    async fn update_namespace(
+        &self,
+        _namespace: &NamespaceIdent,
+        _properties: HashMap<String, String>,
+    ) -> iceberg::Result<()> {
+        unreachable!("test only loads a table")
+    }
+
+    async fn drop_namespace(&self, _namespace: &NamespaceIdent) -> iceberg::Result<()> {
+        unreachable!("test only loads a table")
+    }
+
+    async fn list_tables(&self, _namespace: &NamespaceIdent) -> iceberg::Result<Vec<TableIdent>> {
+        unreachable!("test only loads a table")
+    }
+
+    async fn create_table(
+        &self,
+        _namespace: &NamespaceIdent,
+        _creation: TableCreation,
+    ) -> iceberg::Result<Table> {
+        unreachable!("test only loads a table")
+    }
+
+    async fn drop_table(&self, _table: &TableIdent) -> iceberg::Result<()> {
+        unreachable!("test only loads a table")
+    }
+
+    async fn purge_table(&self, _table: &TableIdent) -> iceberg::Result<()> {
+        unreachable!("test only loads a table")
+    }
+
+    async fn table_exists(&self, _table: &TableIdent) -> iceberg::Result<bool> {
+        unreachable!("test only loads a table")
+    }
+
+    async fn rename_table(&self, _src: &TableIdent, _dest: &TableIdent) -> iceberg::Result<()> {
+        unreachable!("test only loads a table")
+    }
+
+    async fn register_table(
+        &self,
+        _table: &TableIdent,
+        _metadata_location: String,
+    ) -> iceberg::Result<Table> {
+        unreachable!("test only loads a table")
+    }
+
+    async fn update_table(&self, _commit: TableCommit) -> iceberg::Result<Table> {
+        unreachable!("test only loads a table")
+    }
+}
+
+fn test_coordinator(
+    table: Table,
+    catalog: Arc<dyn Catalog>,
+    config: IcebergConfig,
+    db: DatabaseConnection,
+) -> IcebergPkIndexSinkCoordinator {
+    IcebergPkIndexSinkCoordinator {
+        sink_id: SinkId::new(42),
+        db,
+        catalog,
+        table,
+        iceberg_config: config,
+        target_branch: "main".to_owned(),
+        retry_num: 0,
+        waiting_commit: None,
+        prev_committed_epoch: None,
+    }
+}
+
+#[tokio::test]
+async fn reload_table_for_pre_commit_observes_v2_to_v3_upgrade() -> Result<()> {
+    let temp_dir = tempfile::tempdir()?;
+    let location = format!("file://{}", temp_dir.path().display());
+    let stale_v2 = coalesce_test_table_at_location(&location, FormatVersion::V2, false)?;
+    let current_v3 = coalesce_test_table_at_location(&location, FormatVersion::V3, false)?;
+    let catalog = Arc::new(ReloadingTestCatalog::new(stale_v2.clone()));
+    let mut coordinator = test_coordinator(
+        stale_v2,
+        catalog.clone(),
+        coalesce_test_config(),
+        DatabaseConnection::Disconnected,
+    );
+
+    catalog.set_table(current_v3);
+    coordinator.reload_table_for_pre_commit().await?;
+
+    assert_eq!(
+        coordinator.table.metadata().format_version(),
+        FormatVersion::V3
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn compactor_output_ids_are_validated_before_physical_rewrite() -> Result<()> {
+    let temp_dir = tempfile::tempdir()?;
+    let table = coalesce_test_table(&temp_dir, FormatVersion::V3)?;
+    let catalog = Arc::new(ReloadingTestCatalog::new(table.clone()));
+    let mut coordinator = test_coordinator(
+        table,
+        catalog,
+        coalesce_test_config(),
+        DatabaseConnection::Disconnected,
+    );
+
+    let error = coordinator
+        .pre_commit(
+            1,
+            vec![],
+            Some(CompactionOverwrite {
+                sink_id: SinkId::new(42),
+                epoch: 1,
+                schema_id: 99,
+                partition_spec_id: 0,
+                output_files: vec![],
+                input_file_paths: vec![],
+                read_snapshot_id: 1,
+            }),
+        )
+        .await
+        .expect_err("compactor schema mismatch should fail");
+
+    assert!(error.to_string().contains("compactor output"));
+    assert!(coordinator.waiting_commit.is_none());
+    Ok(())
+}
+
+#[tokio::test]
+async fn coalesce_position_delete_files_unions_v2_and_v3_artifacts() -> Result<()> {
+    for format_version in [FormatVersion::V2, FormatVersion::V3] {
+        let temp_dir = tempfile::tempdir()?;
+        let table = coalesce_test_table(&temp_dir, format_version)?;
+        let config = coalesce_test_config();
+        let output = output_data_file(&table, "output")?;
+        let resolver =
+            write_test_position_delete(&table, &config, "resolver", output.file_path(), [1, 3])
+                .await?;
+        let merger =
+            write_test_position_delete(&table, &config, "merger", output.file_path(), [3, 5])
+                .await?;
+        let source_paths = HashSet::from([
+            resolver.file_path().to_owned(),
+            merger.file_path().to_owned(),
+        ]);
+        let mut added_delete_files = vec![resolver, merger];
+
+        let result = coalesce_position_delete_files(
+            &table,
+            &config,
+            99,
+            std::slice::from_ref(&output),
+            &mut added_delete_files,
+        )
+        .await?;
+
+        assert_eq!(added_delete_files.len(), 1);
+        let replacement = &added_delete_files[0];
+        assert_eq!(
+            replacement.referenced_data_file().as_deref(),
+            Some(output.file_path())
+        );
+        assert_eq!(replacement.partition(), output.partition());
+        assert_eq!(
+            read_position_deletes_from_file(table.file_io(), replacement).await?,
+            DeleteVector::from([1, 3, 5])
+        );
+        assert_eq!(HashSet::from_iter(result), source_paths);
+    }
+    Ok(())
+}
+
+#[tokio::test]
+async fn coalesce_position_delete_files_preserves_singleton_and_unrelated() -> Result<()> {
+    for format_version in [FormatVersion::V2, FormatVersion::V3] {
+        let temp_dir = tempfile::tempdir()?;
+        let table = coalesce_test_table(&temp_dir, format_version)?;
+        let config = coalesce_test_config();
+        let output = output_data_file(&table, "output")?;
+        let singleton =
+            write_test_position_delete(&table, &config, "singleton", output.file_path(), [7])
+                .await?;
+        let unrelated = write_test_position_delete(
+            &table,
+            &config,
+            "unrelated",
+            "file:///unrelated-data.parquet",
+            [9],
+        )
+        .await?;
+        let expected_paths = vec![
+            singleton.file_path().to_owned(),
+            unrelated.file_path().to_owned(),
+        ];
+        let mut delete_files = vec![singleton, unrelated];
+
+        let result =
+            coalesce_position_delete_files(&table, &config, 99, &[output], &mut delete_files)
+                .await?;
+
+        assert!(result.is_empty());
+        assert_eq!(
+            delete_files
+                .iter()
+                .map(|file| file.file_path())
+                .collect::<Vec<_>>(),
+            expected_paths
+        );
+    }
+    Ok(())
+}
+
+#[tokio::test]
+async fn coalesce_position_delete_files_groups_multiple_outputs() -> Result<()> {
+    let temp_dir = tempfile::tempdir()?;
+    let table = coalesce_test_table(&temp_dir, FormatVersion::V3)?;
+    let config = coalesce_test_config();
+    let outputs = vec![
+        output_data_file(&table, "output-a")?,
+        output_data_file(&table, "output-b")?,
+    ];
+    let mut delete_files = Vec::new();
+    for (prefix, output, positions) in [
+        ("a1", &outputs[0], [1, 3]),
+        ("a2", &outputs[0], [3, 5]),
+        ("b1", &outputs[1], [2, 4]),
+        ("b2", &outputs[1], [4, 6]),
+    ] {
+        delete_files.push(
+            write_test_position_delete(&table, &config, prefix, output.file_path(), positions)
+                .await?,
+        );
+    }
+
+    let result =
+        coalesce_position_delete_files(&table, &config, 99, &outputs, &mut delete_files).await?;
+
+    assert_eq!(result.len(), 4);
+    assert_eq!(delete_files.len(), 2);
+    for (output, expected) in [
+        (&outputs[0], DeleteVector::from([1, 3, 5])),
+        (&outputs[1], DeleteVector::from([2, 4, 6])),
+    ] {
+        let replacement = delete_files
+            .iter()
+            .find(|file| file.referenced_data_file().as_deref() == Some(output.file_path()))
+            .expect("each output should have one replacement");
+        assert_eq!(
+            read_position_deletes_from_file(table.file_io(), replacement).await?,
+            expected
+        );
+    }
+    Ok(())
+}
+
+#[tokio::test]
+async fn coalesce_position_delete_files_preserves_partition() -> Result<()> {
+    for format_version in [FormatVersion::V2, FormatVersion::V3] {
+        let temp_dir = tempfile::tempdir()?;
+        let table = coalesce_test_table_with_partitioning(&temp_dir, format_version, true)?;
+        let config = coalesce_test_config();
+        let partition = Struct::from_iter([Some(Literal::long(11))]);
+        let output = output_data_file_with_partition(&table, "output", partition.clone())?;
+        let partition_key = PartitionKey::new(
+            table.metadata().default_partition_spec().as_ref().clone(),
+            table.metadata().current_schema().clone(),
+            partition.clone(),
+        );
+        let mut delete_files = vec![
+            write_test_position_delete_with_partition(
+                &table,
+                &config,
+                "resolver",
+                output.file_path(),
+                [1],
+                Some(&partition_key),
+            )
+            .await?,
+            write_test_position_delete_with_partition(
+                &table,
+                &config,
+                "merger",
+                output.file_path(),
+                [2],
+                Some(&partition_key),
+            )
+            .await?,
+        ];
+
+        coalesce_position_delete_files(&table, &config, 99, &[output], &mut delete_files).await?;
+
+        assert_eq!(delete_files[0].partition(), &partition);
+        assert_eq!(
+            delete_files[0].partition_spec_id(),
+            table.metadata().default_partition_spec_id()
+        );
+    }
+    Ok(())
+}
+
+#[tokio::test]
+async fn coalesce_position_delete_files_retries_same_path_without_deleting_sources() -> Result<()> {
+    for format_version in [FormatVersion::V2, FormatVersion::V3] {
+        let temp_dir = tempfile::tempdir()?;
+        let table = coalesce_test_table(&temp_dir, format_version)?;
+        let config = coalesce_test_config();
+        let output = output_data_file(&table, "output")?;
+        let sources = vec![
+            write_test_position_delete(&table, &config, "resolver", output.file_path(), [1, 3])
+                .await?,
+            write_test_position_delete(&table, &config, "merger", output.file_path(), [3, 5])
+                .await?,
+        ];
+        let source_paths = sources
+            .iter()
+            .map(|file| file.file_path().to_owned())
+            .collect::<Vec<_>>();
+        let mut first_attempt = sources.clone();
+        coalesce_position_delete_files(
+            &table,
+            &config,
+            99,
+            std::slice::from_ref(&output),
+            &mut first_attempt,
+        )
+        .await?;
+        let first_path = first_attempt[0].file_path().to_owned();
+        let mut second_attempt = sources;
+        coalesce_position_delete_files(&table, &config, 99, &[output], &mut second_attempt).await?;
+
+        assert_eq!(second_attempt[0].file_path(), first_path);
+        for path in source_paths {
+            assert!(table.file_io().exists(path).await?);
+        }
+    }
+    Ok(())
+}
+
+#[tokio::test]
+async fn coalesce_position_delete_files_rejects_replacement_path_collision_before_io() -> Result<()>
+{
+    for format_version in [FormatVersion::V2, FormatVersion::V3] {
+        let temp_dir = tempfile::tempdir()?;
+        let table = coalesce_test_table(&temp_dir, format_version)?;
+        let config = coalesce_test_config();
+        let output = output_data_file(&table, "output")?;
+        let sources = vec![
+            write_test_position_delete(&table, &config, "resolver", output.file_path(), [1])
+                .await?,
+            write_test_position_delete(&table, &config, "merger", output.file_path(), [2]).await?,
+        ];
+        let mut first_attempt = sources.clone();
+        coalesce_position_delete_files(
+            &table,
+            &config,
+            99,
+            std::slice::from_ref(&output),
+            &mut first_attempt,
+        )
+        .await?;
+        let replacement = &first_attempt[0];
+        let replacement_path = replacement.file_path().to_owned();
+        let retained_with_replacement_path = DataFileBuilder::default()
+            .content(DataContentType::PositionDeletes)
+            .file_path(replacement_path.clone())
+            .file_format(replacement.file_format())
+            .partition(replacement.partition().clone())
+            .partition_spec_id(replacement.partition_spec_id())
+            .record_count(1)
+            .file_size_in_bytes(1)
+            .referenced_data_file(Some("file:///unrelated-data.parquet".to_owned()))
+            .build()?;
+        let mut second_attempt = sources;
+        second_attempt.push(retained_with_replacement_path);
+
+        let error =
+            coalesce_position_delete_files(&table, &config, 99, &[output], &mut second_attempt)
+                .await
+                .expect_err("replacement path collision should fail");
+
+        assert!(error.to_string().contains("replacement path"));
+        assert!(table.file_io().exists(replacement_path).await?);
+    }
+    Ok(())
+}
+
+#[tokio::test]
+async fn coalesce_position_delete_files_rejects_invalid_artifacts() -> Result<()> {
+    for format_version in [FormatVersion::V2, FormatVersion::V3] {
+        let temp_dir = tempfile::tempdir()?;
+        let table = coalesce_test_table(&temp_dir, format_version)?;
+        let config = coalesce_test_config();
+        let output = output_data_file(&table, "output")?;
+        let source =
+            write_test_position_delete(&table, &config, "duplicate", output.file_path(), [1])
+                .await?;
+        let mut delete_files = vec![source.clone(), source];
+        let error = coalesce_position_delete_files(
+            &table,
+            &config,
+            99,
+            std::slice::from_ref(&output),
+            &mut delete_files,
+        )
+        .await
+        .expect_err("duplicate path should fail");
+        assert!(error.to_string().contains("duplicate"));
+
+        let selected =
+            write_test_position_delete(&table, &config, "selected", output.file_path(), [1])
+                .await?;
+        let second_selected =
+            write_test_position_delete(&table, &config, "second-selected", output.file_path(), [2])
+                .await?;
+        let retained_with_same_path = DataFileBuilder::default()
+            .content(DataContentType::PositionDeletes)
+            .file_path(selected.file_path().to_owned())
+            .file_format(selected.file_format())
+            .partition(selected.partition().clone())
+            .partition_spec_id(selected.partition_spec_id())
+            .record_count(1)
+            .file_size_in_bytes(1)
+            .referenced_data_file(Some("file:///unrelated-data.parquet".to_owned()))
+            .build()?;
+        let mut delete_files = vec![selected, second_selected, retained_with_same_path];
+        let error =
+            coalesce_position_delete_files(&table, &config, 99, &[output], &mut delete_files)
+                .await
+                .expect_err("selected and retained duplicate path should fail");
+        assert!(error.to_string().contains("duplicate"));
+    }
+    Ok(())
+}
+
+#[tokio::test]
+async fn coalesce_position_delete_files_rejects_missing_reference() -> Result<()> {
+    for format_version in [FormatVersion::V2, FormatVersion::V3] {
+        let temp_dir = tempfile::tempdir()?;
+        let table = coalesce_test_table(&temp_dir, format_version)?;
+        let config = coalesce_test_config();
+        let output = output_data_file(&table, "output")?;
+        let mut delete_files = vec![
+            DataFileBuilder::default()
+                .content(DataContentType::PositionDeletes)
+                .file_path(format!(
+                    "{}/data/missing-reference.parquet",
+                    table.metadata().location()
+                ))
+                .file_format(DataFileFormat::Parquet)
+                .partition(Struct::empty())
+                .partition_spec_id(table.metadata().default_partition_spec_id())
+                .record_count(1)
+                .file_size_in_bytes(1)
+                .build()?,
+        ];
+
+        let result =
+            coalesce_position_delete_files(&table, &config, 99, &[output], &mut delete_files).await;
+
+        let error = result.expect_err("missing reference should fail");
+        assert!(error.to_string().contains("missing referenced_data_file"));
+    }
+    Ok(())
+}
+
+#[test]
+fn pre_commit_state_round_trip_preserves_format_version() -> Result<()> {
+    let input = IcebergPkIndexSinkAggResult {
+        schema_id: 3,
+        partition_spec_id: 4,
+        format_version: Some(FormatVersion::V3),
+        data_files: vec![serialized_file("data")],
+        delete_files: vec![serialized_file("delete")],
+        overwrite_files: vec![serialized_file("overwrite")],
+    };
+
+    let blob = encode_pre_commit_state(&input, 99)?;
+    let (decoded, snapshot_id) = decode_pre_commit_state(&blob)?;
+
+    assert_eq!(snapshot_id, 99);
+    assert_eq!(decoded.format_version, Some(FormatVersion::V3));
+    assert_eq!(decoded.schema_id, 3);
+    assert_eq!(decoded.partition_spec_id, 4);
+    assert_eq!(decoded.data_files.len(), 1);
+    assert_eq!(decoded.delete_files.len(), 1);
+    assert_eq!(decoded.overwrite_files.len(), 1);
+    Ok(())
+}
+
+#[test]
+fn pre_commit_state_decodes_legacy_state_without_format_version() -> Result<()> {
+    let legacy_aggregate = serde_json::json!({
+        "schema_id": 3,
+        "partition_spec_id": 4,
+        "data_files": [],
+        "delete_files": [],
+        "overwrite_files": []
+    });
+    let blob = PbIcebergPkIndexPreCommitState {
+        agg_result: serde_json::to_vec(&legacy_aggregate)?,
+        snapshot_id: 99,
+    }
+    .encode_to_vec();
+
+    let (decoded, snapshot_id) = decode_pre_commit_state(&blob)?;
+
+    assert_eq!(snapshot_id, 99);
+    assert_eq!(decoded.format_version, None);
+    Ok(())
+}
+
+#[test]
+fn ordinary_aggregate_accepts_table_ids() {
+    let aggregate = aggregate_ordinary_reports(
+        &[
+            report(
+                PbIcebergPkIndexSinkRole::Writer,
+                Some(writer_metadata(
+                    3,
+                    4,
+                    vec![serialized_file("ordinary-data")],
+                )),
+            ),
+            report(
+                PbIcebergPkIndexSinkRole::PositionDeleteMerger,
+                Some(merger_metadata(3, 4, vec![], vec![])),
+            ),
+        ],
+        3,
+        4,
+        FormatVersion::V3,
+    )
+    .unwrap()
+    .expect("ordinary metadata should produce an aggregate");
+
+    assert_eq!(aggregate.schema_id, 3);
+    assert_eq!(aggregate.partition_spec_id, 4);
+}
+
+#[test]
+fn ordinary_aggregate_rejects_schema_id_different_from_table() {
+    let error = aggregate_ordinary_reports(
+        &[report(
+            PbIcebergPkIndexSinkRole::Writer,
+            Some(writer_metadata(2, 4, vec![serialized_file("data")])),
+        )],
+        3,
+        4,
+        FormatVersion::V3,
+    )
+    .expect_err("schema mismatch should fail");
+    assert!(error.to_string().contains("schema_id 2"));
+}
+
+#[test]
+fn ordinary_aggregate_rejects_partition_spec_id_different_from_table() {
+    let error = aggregate_ordinary_reports(
+        &[report(
+            PbIcebergPkIndexSinkRole::Writer,
+            Some(writer_metadata(3, 5, vec![serialized_file("data")])),
+        )],
+        3,
+        4,
+        FormatVersion::V3,
+    )
+    .expect_err("partition spec mismatch should fail");
+    assert!(error.to_string().contains("partition_spec_id 5"));
+}
+
+#[test]
+fn ordinary_aggregate_all_empty_is_noop_without_ids() {
+    let aggregate = aggregate_ordinary_reports(
+        &[
+            report(PbIcebergPkIndexSinkRole::Writer, None),
+            report(PbIcebergPkIndexSinkRole::PositionDeleteMerger, None),
+        ],
+        3,
+        4,
+        FormatVersion::V3,
+    )
+    .unwrap();
+    assert!(aggregate.is_none());
+}
+
+#[test]
+fn combine_compaction_aggregate_merges_every_input() {
+    let ordinary = aggregate_reports(&[
+        report(
+            PbIcebergPkIndexSinkRole::Writer,
+            Some(
+                SinkMetadata::try_from(&IcebergCommitResult {
+                    schema_id: 3,
+                    partition_spec_id: 4,
+                    data_files: vec![serialized_file("ordinary-data")],
+                })
+                .unwrap(),
+            ),
+        ),
+        report(
+            PbIcebergPkIndexSinkRole::PositionDeleteMerger,
+            Some(merger_metadata(
+                3,
+                4,
+                vec![serialized_file("ordinary-delete")],
+                vec![serialized_file("ordinary-overwrite")],
+            )),
+        ),
+    ])
+    .unwrap();
+    let resolver = decode_compaction_resolver_delete_reports([report(
+        PbIcebergPkIndexSinkRole::CompactionResolver,
+        Some(merger_metadata(
+            3,
+            4,
+            vec![serialized_file("resolver-delete")],
+            vec![],
+        )),
+    )])
+    .unwrap();
+
+    let merged = combine_compaction_aggregate(
+        3,
+        4,
+        FormatVersion::V3,
+        ordinary,
+        vec![serialized_file("compactor-output")],
+        resolver,
+        vec![serialized_file("resolved-overwrite")],
+    )
+    .unwrap();
+
+    assert_eq!(merged.schema_id, 3);
+    assert_eq!(merged.partition_spec_id, 4);
+    assert_eq!(merged.data_files.len(), 2);
+    assert_eq!(merged.delete_files.len(), 2);
+    assert_eq!(merged.overwrite_files.len(), 2);
+}
+
+#[test]
+fn combine_compaction_aggregate_rejects_resolver_ids_different_from_table() {
+    let resolver = decode_compaction_resolver_delete_reports([report(
+        PbIcebergPkIndexSinkRole::CompactionResolver,
+        Some(merger_metadata(3, 5, vec![], vec![])),
+    )])
+    .unwrap();
+    let error =
+        combine_compaction_aggregate(3, 4, FormatVersion::V3, None, vec![], resolver, vec![])
+            .expect_err("partition spec mismatch should fail");
+    assert!(error.to_string().contains("partition_spec_id 5"));
+}
+
+#[test]
+fn aggregate_reports_ignores_empty_ordinary_metadata() {
+    let merger_metadata = SinkMetadata::try_from(&IcebergPositionDeleteCommitResult {
+        schema_id: 3,
+        partition_spec_id: 4,
+        delete_files: vec![],
+        overwrite_files: vec![],
+    })
+    .unwrap();
+    let merged = aggregate_reports(&[
+        report(PbIcebergPkIndexSinkRole::Writer, None),
+        report(
+            PbIcebergPkIndexSinkRole::PositionDeleteMerger,
+            Some(merger_metadata),
+        ),
+    ])
+    .unwrap()
+    .expect("merger metadata should produce an aggregate");
+
+    assert_eq!(merged.schema_id, 3);
+    assert_eq!(merged.partition_spec_id, 4);
+}

--- a/src/meta/src/manager/iceberg_pk_index_sink/manager.rs
+++ b/src/meta/src/manager/iceberg_pk_index_sink/manager.rs
@@ -20,11 +20,11 @@ use parking_lot::RwLock;
 use risingwave_common::id::PartialGraphId;
 use risingwave_connector::sink::catalog::SinkId;
 use risingwave_connector::sink::iceberg::IcebergConfig;
-use risingwave_pb::stream_service::barrier_complete_response::IcebergPkIndexSinkMetadata as PbIcebergPkIndexSinkMetadata;
 use sea_orm::DatabaseConnection;
 use tokio::sync::Mutex;
 use tracing::warn;
 
+use super::IcebergPkIndexPreCommitMetadata;
 use super::committed_epoch::PartialGraphCommittedEpochs;
 use super::coordinator::IcebergPkIndexSinkCoordinator;
 
@@ -98,19 +98,17 @@ impl IcebergPkIndexSinkManager {
         Ok(())
     }
 
-    /// Pre-commit phase for one epoch: persist the merged report under `pending_sink_state` (no iceberg IO).
-    /// The barrier-complete path awaits this BEFORE issuing hummock `commit_epoch`.
-    pub async fn pre_commit_epoch(
+    /// Pre-commit one epoch, with an optional compaction overwrite folded into the same pending row.
+    /// The barrier-complete path awaits this before issuing Hummock `commit_epoch`.
+    pub(crate) async fn pre_commit(
         &self,
-        sink_id: SinkId,
-        prev_epoch: u64,
-        reports: Vec<PbIcebergPkIndexSinkMetadata>,
+        input: IcebergPkIndexPreCommitMetadata,
     ) -> anyhow::Result<()> {
-        let coordinator = self.coordinator(sink_id)?;
+        let coordinator = self.coordinator(input.sink_id)?;
         coordinator
             .lock()
             .await
-            .pre_commit(prev_epoch, reports)
+            .pre_commit(input.prev_epoch, input.reports, input.compaction)
             .await
     }
 

--- a/src/meta/src/manager/iceberg_pk_index_sink/mod.rs
+++ b/src/meta/src/manager/iceberg_pk_index_sink/mod.rs
@@ -24,14 +24,103 @@ mod committed_epoch;
 mod coordinator;
 mod manager;
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashMap};
 
 use anyhow::anyhow;
+use iceberg::spec::SerializedDataFile;
 pub use manager::IcebergPkIndexSinkManager;
 use risingwave_common::secret::LocalSecretManager;
+use risingwave_connector::sink::catalog::SinkId;
 use risingwave_connector::sink::iceberg::{ENABLE_PK_INDEX, IcebergConfig};
 use risingwave_connector::source::UPSTREAM_SOURCE_KEY;
 use risingwave_pb::catalog::PbSink;
+use risingwave_pb::stream_service::barrier_complete_response::IcebergPkIndexSinkMetadata as PbIcebergPkIndexSinkMetadata;
+
+#[derive(educe::Educe)]
+#[educe(Debug)]
+pub(crate) struct CompactionOverwrite {
+    pub sink_id: SinkId,
+    pub epoch: u64,
+    pub schema_id: i32,
+    pub partition_spec_id: i32,
+    #[educe(Debug(ignore))]
+    pub output_files: Vec<SerializedDataFile>,
+    pub input_file_paths: Vec<String>,
+    pub read_snapshot_id: i64,
+}
+
+/// Metadata collected for one sink/epoch before the Hummock checkpoint is committed.
+/// Ordinary reports and the optional compaction overwrite share one transport shape so the
+/// barrier path does not need separate metadata variants.
+#[derive(Debug)]
+pub(crate) struct IcebergPkIndexPreCommitMetadata {
+    pub sink_id: SinkId,
+    pub prev_epoch: u64,
+    pub reports: Vec<PbIcebergPkIndexSinkMetadata>,
+    pub compaction: Option<CompactionOverwrite>,
+}
+
+impl From<PbIcebergPkIndexSinkMetadata> for IcebergPkIndexPreCommitMetadata {
+    fn from(report: PbIcebergPkIndexSinkMetadata) -> Self {
+        Self {
+            sink_id: report.sink_id,
+            prev_epoch: report.prev_epoch,
+            reports: vec![report],
+            compaction: None,
+        }
+    }
+}
+
+impl From<CompactionOverwrite> for IcebergPkIndexPreCommitMetadata {
+    fn from(overwrite: CompactionOverwrite) -> Self {
+        Self {
+            sink_id: overwrite.sink_id,
+            prev_epoch: overwrite.epoch,
+            reports: vec![],
+            compaction: Some(overwrite),
+        }
+    }
+}
+
+pub(crate) fn group_pre_commit_metadata(
+    metadata: Vec<IcebergPkIndexPreCommitMetadata>,
+) -> anyhow::Result<Vec<IcebergPkIndexPreCommitMetadata>> {
+    let mut grouped = HashMap::<SinkId, IcebergPkIndexPreCommitMetadata>::new();
+    for metadata in metadata {
+        let IcebergPkIndexPreCommitMetadata {
+            sink_id,
+            prev_epoch,
+            reports,
+            compaction,
+        } = metadata;
+        let input = grouped
+            .entry(sink_id)
+            .or_insert_with(|| IcebergPkIndexPreCommitMetadata {
+                sink_id,
+                prev_epoch,
+                reports: Vec::new(),
+                compaction: None,
+            });
+        if input.prev_epoch != prev_epoch {
+            anyhow::bail!(
+                "iceberg v3 sink {} pre-commit metadata disagrees on prev_epoch: {} vs {}",
+                sink_id,
+                input.prev_epoch,
+                prev_epoch
+            );
+        }
+        input.reports.extend(reports);
+        if let Some(overwrite) = compaction
+            && input.compaction.replace(overwrite).is_some()
+        {
+            anyhow::bail!(
+                "iceberg v3 sink {} has multiple compaction overwrites in one barrier",
+                sink_id
+            );
+        }
+    }
+    Ok(grouped.into_values().collect())
+}
 
 /// Returns true if the given sink properties identify a Iceberg pk-index sink
 /// (i.e. an iceberg sink with `enable_pk_index = 'true'`).
@@ -58,4 +147,86 @@ pub fn build_iceberg_config(pb_sink: &PbSink) -> anyhow::Result<IcebergConfig> {
         .map_err(|e| anyhow!(e).context("fill secrets for iceberg"))?;
     IcebergConfig::from_btreemap(with_secrets)
         .map_err(|e| anyhow!(e).context("parse iceberg config"))
+}
+
+#[cfg(test)]
+mod tests {
+    use risingwave_pb::stream_service::PbIcebergPkIndexSinkRole;
+
+    use super::*;
+
+    fn report(
+        sink_id: u32,
+        prev_epoch: u64,
+        role: PbIcebergPkIndexSinkRole,
+    ) -> PbIcebergPkIndexSinkMetadata {
+        PbIcebergPkIndexSinkMetadata {
+            sink_id: SinkId::new(sink_id),
+            prev_epoch,
+            role: role as i32,
+            ..Default::default()
+        }
+    }
+
+    fn overwrite(sink_id: u32, epoch: u64) -> CompactionOverwrite {
+        CompactionOverwrite {
+            sink_id: SinkId::new(sink_id),
+            epoch,
+            schema_id: 3,
+            partition_spec_id: 4,
+            output_files: vec![],
+            input_file_paths: vec![],
+            read_snapshot_id: 1,
+        }
+    }
+
+    #[test]
+    fn group_pre_commit_metadata_combines_reports_and_compaction() {
+        let inputs = group_pre_commit_metadata(vec![
+            report(7, 60, PbIcebergPkIndexSinkRole::Writer).into(),
+            overwrite(7, 60).into(),
+            report(7, 60, PbIcebergPkIndexSinkRole::PositionDeleteMerger).into(),
+        ])
+        .unwrap();
+
+        assert_eq!(inputs.len(), 1);
+        let input = &inputs[0];
+        assert_eq!(input.sink_id, SinkId::new(7));
+        assert_eq!(input.prev_epoch, 60);
+        assert_eq!(input.reports.len(), 2);
+        let overwrite = input.compaction.as_ref().unwrap();
+        assert_eq!(overwrite.schema_id, 3);
+        assert_eq!(overwrite.partition_spec_id, 4);
+    }
+
+    #[test]
+    fn group_pre_commit_metadata_preserves_ordinary_only_sink() {
+        let inputs =
+            group_pre_commit_metadata(vec![report(8, 61, PbIcebergPkIndexSinkRole::Writer).into()])
+                .unwrap();
+
+        assert_eq!(inputs.len(), 1);
+        assert_eq!(inputs[0].sink_id, SinkId::new(8));
+        assert_eq!(inputs[0].prev_epoch, 61);
+        assert_eq!(inputs[0].reports.len(), 1);
+        assert!(inputs[0].compaction.is_none());
+    }
+
+    #[test]
+    fn group_pre_commit_metadata_rejects_duplicate_compaction() {
+        let error =
+            group_pre_commit_metadata(vec![overwrite(7, 60).into(), overwrite(7, 60).into()])
+                .unwrap_err();
+        assert!(error.to_string().contains("multiple compaction overwrites"));
+    }
+
+    #[test]
+    fn group_pre_commit_metadata_rejects_epoch_mismatch() {
+        let error = group_pre_commit_metadata(vec![
+            report(7, 59, PbIcebergPkIndexSinkRole::Writer).into(),
+            overwrite(7, 60).into(),
+        ])
+        .unwrap_err();
+        assert!(error.to_string().contains("disagrees on prev_epoch"));
+    }
 }


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

This PR is stacked on #26975.

The coordinator and pre-commit foundation in this branch is checked out from and adapted to this stack from #26566 by @silver-ymz. The independent-job and global-barrier-worker orchestration in later PRs is implemented separately rather than copied from that PR.

This PR extracts and reuses the Iceberg PK-index coordinator's pre-commit machinery for compaction results:

- Share the manifest and position-delete rewrite path with normal Iceberg commit handling.
- Carry compaction overwrite information through barrier post-collection and completion.
- Keep commit retry behavior in the existing Iceberg coordinator framework.
- Add coordinator coverage for the extracted compaction pre-commit behavior.

This is the reusable commit-side foundation; the global barrier worker does not yet coordinate compaction in this layer.

Stack-head verification: `cargo clippy --all-targets --all-features`.

## Checklist

- [x] I have written necessary rustdoc comments.
- [x] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [x] <!-- OPTIONAL --> I have added test labels as necessary.
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them.
- [ ] <!-- OPTIONAL --> My PR contains breaking changes.
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results.
- [ ] <!-- OPTIONAL --> I have checked the Release Timeline and Currently Supported Versions to determine which release branches I need to cherry-pick this PR into.

## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates.

<details>
<summary><b>Release note</b></summary>

Not applicable. This is internal Iceberg commit-path reuse.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for Iceberg format V3 position-delete files using Puffin, while retaining Parquet support for earlier formats.
  - Added Iceberg primary-key index compaction handling, including merging and replacing position-delete files.
  - Commit metadata now records Iceberg commit epochs and snapshot sequence information.

- **Bug Fixes**
  - Prevented retries from proceeding when Iceberg table format metadata changes unexpectedly.
  - Improved validation of schema, partition, and epoch consistency during index commits.
  - Improved handling of position-delete files during compaction and table format upgrades.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->