### PR TITLE
feat(meta): apply Iceberg V3 compaction with barriers

### DIFF
--- a/src/meta/src/barrier/checkpoint/control.rs
+++ b/src/meta/src/barrier/checkpoint/control.rs
@@ -171,7 +171,7 @@ impl CheckpointControl {
         &mut self,
         periodic_barriers: &mut PeriodicBarriers,
         partial_graph_manager: &mut PartialGraphManager,
-    ) -> Option<CompleteBarrierTask> {
+    ) -> MetaResult<Option<CompleteBarrierTask>> {
         let mut task = None;
         for database in self.databases.values_mut() {
             let Some(database) = database.running_state_mut() else {
@@ -182,9 +182,9 @@ impl CheckpointControl {
                 partial_graph_manager,
                 &mut task,
                 &self.hummock_version_stats,
-            );
+            )?;
         }
-        task
+        Ok(task)
     }
 
     pub(crate) fn barrier_collected(
@@ -335,7 +335,8 @@ impl CheckpointControl {
                     | Command::LoadFinish { .. }
                     | Command::ResetSource { .. }
                     | Command::ResumeBackfill { .. }
-                    | Command::InjectSourceOffsets { .. } => {
+                    | Command::InjectSourceOffsets { .. }
+                    | Command::ApplyIcebergPkIndexCompaction { .. } => {
                         if cfg!(debug_assertions) {
                             panic!(
                                 "new database graph info can only be created for normal creating streaming job, but get command: {} {:?}",
@@ -994,7 +995,7 @@ impl DatabaseCheckpointControl {
         partial_graph_manager: &mut PartialGraphManager,
         task: &mut Option<CompleteBarrierTask>,
         hummock_version_stats: &HummockVersionStats,
-    ) {
+    ) -> MetaResult<()> {
         // `Vec::new` is a const fn, and do not have memory allocation, and therefore is lightweight enough
         let mut independent_jobs_task = vec![];
         let mut finished_jobs = Vec::new();
@@ -1016,7 +1017,7 @@ impl DatabaseCheckpointControl {
                             finished_jobs.push((*job_id, epoch, resps));
                             continue;
                         };
-                        independent_jobs_task.push((*job_id, epoch, resps, info));
+                        independent_jobs_task.push((*job_id, epoch, resps, info, None));
                     }
                 }
                 IndependentCheckpointJob::BatchRefresh(batch_refresh_job) => {
@@ -1028,12 +1029,12 @@ impl DatabaseCheckpointControl {
                             let task = task.get_or_insert_default();
                             task.finished_jobs.push(tracking_job);
                         }
-                        independent_jobs_task.push((*job_id, epoch, resps, info));
+                        independent_jobs_task.push((*job_id, epoch, resps, info, None));
                     }
                 }
                 IndependentCheckpointJob::IcebergV3(iceberg_job) => {
-                    if let Some((epoch, resps, info, is_finish_epoch)) = iceberg_job
-                        .start_completing(partial_graph_manager, min_upstream_inflight_barrier)
+                    if let Some((epoch, resps, info, is_finish_epoch, compaction)) = iceberg_job
+                        .start_completing(partial_graph_manager, min_upstream_inflight_barrier)?
                     {
                         assert!(!is_finish_epoch, "Iceberg V3 jobs remain independent");
                         independent_jobs_task.push((
@@ -1041,6 +1042,7 @@ impl DatabaseCheckpointControl {
                             epoch,
                             resps.into_values().collect_vec(),
                             info,
+                            compaction,
                         ));
                     }
                 }
@@ -1140,13 +1142,18 @@ impl DatabaseCheckpointControl {
         }
         if !independent_jobs_task.is_empty() {
             let task = task.get_or_insert_default();
-            for (job_id, epoch, resps, info) in independent_jobs_task {
+            for (job_id, epoch, resps, info, compaction) in independent_jobs_task {
                 collect_independent_job_commit_epoch_info(task, epoch, resps, &info);
+                if let Some(compaction) = compaction {
+                    task.iceberg_pk_index_pre_commit_metadata
+                        .push(compaction.into());
+                }
                 task.epoch_infos
                     .try_insert(to_partial_graph_id(self.database_id, Some(job_id)), info)
                     .expect("non duplicate");
             }
         }
+        Ok(())
     }
 
     fn ack_completed(

--- a/src/meta/src/barrier/checkpoint/independent_job/iceberg_v3_job/mod.rs
+++ b/src/meta/src/barrier/checkpoint/independent_job/iceberg_v3_job/mod.rs
@@ -21,19 +21,23 @@ use std::ops::Bound::{Excluded, Unbounded};
 use std::sync::atomic::AtomicU32;
 
 use risingwave_common::catalog::TableId;
-use risingwave_common::id::JobId;
+use risingwave_common::id::{JobId, SinkId};
 use risingwave_common::metrics::{LabelGuardedHistogram, LabelGuardedIntGauge};
-use risingwave_common::util::epoch::EpochPair;
+use risingwave_common::util::epoch::{Epoch, EpochPair};
 use risingwave_common::util::stream_graph_visitor::visit_stream_node_cont;
 use risingwave_meta_model::{WorkerId, streaming_job};
 use risingwave_pb::common::WorkerNode;
 use risingwave_pb::ddl_service::PbBackfillType;
 use risingwave_pb::hummock::HummockVersionStats;
-use risingwave_pb::id::{ActorId, FragmentId};
+use risingwave_pb::id::{ActorId, FragmentId, IcebergCompactionTaskId};
 use risingwave_pb::stream_plan::barrier_mutation::Mutation;
+use risingwave_pb::stream_plan::iceberg_pk_index_compaction_context::{Phase, ResolverTaskInput};
+use risingwave_pb::stream_plan::{IcebergPkIndexCompactionContext, UpdateMutation};
 use risingwave_pb::stream_service::BarrierCompleteResponse;
 
-use self::render::{RenderedResolver, partition_resolver};
+use self::render::{
+    IcebergV3StaticActors, RenderedResolver, build_static_actors, partition_resolver,
+};
 use super::{
     BatchRefreshRenderResult, CreatingStreamingJobControl, IndependentCheckpointJob,
     IndependentCheckpointJobControl, IndependentCheckpointJobStatus, IndependentJobControl,
@@ -42,19 +46,21 @@ use super::{
 };
 use crate::MetaResult;
 use crate::barrier::command::{
-    PostCollectCommand, ThrottleConfigMap, UpstreamTableLogEpochs, extract_throttle_config,
+    IcebergPkIndexCompactionOverwrite, PostCollectCommand, ThrottleConfigMap,
+    UpstreamTableLogEpochs, extract_throttle_config,
 };
 use crate::barrier::context::CreateIndependentStreamingJobCommandInfo;
 use crate::barrier::info::BarrierInfo;
-use crate::barrier::notifier::NotifierStarter;
+use crate::barrier::notifier::{CollectionNotifier, NotifierStarter};
 use crate::barrier::partial_graph::{
     CollectedBarrier, PartialGraphBarrierInfo, PartialGraphManager, PartialGraphRecoverer,
     PartialGraphStat,
 };
 use crate::barrier::rpc::to_partial_graph_id;
-use crate::barrier::{BackfillProgress, BarrierKind, FragmentBackfillProgress};
+use crate::barrier::{BackfillProgress, BarrierKind, FragmentBackfillProgress, TracedEpoch};
 use crate::controller::fragment::InflightFragmentInfo;
 use crate::controller::scale::LoadedFragment;
+use crate::manager::iceberg_pk_index_sink::CompactionOverwrite;
 use crate::model::FragmentDownstreamRelation;
 use crate::rpc::metrics::GLOBAL_META_METRICS;
 use crate::stream::ExtendedFragmentBackfillOrder;
@@ -115,6 +121,19 @@ enum IcebergV3InputPhase {
 #[derive(Debug)]
 enum IcebergV3JobStatus {
     Running(IcebergV3InputPhase),
+    Compacting {
+        input_phase: IcebergV3InputPhase,
+        apply: CompactionApply,
+    },
+}
+
+#[derive(Debug)]
+struct CompactionApply {
+    task_id: IcebergCompactionTaskId,
+    overwrite: Option<CompactionOverwrite>,
+    begin_barrier: BarrierInfo,
+    end_barrier: BarrierInfo,
+    notifier: CollectionNotifier,
 }
 
 #[derive(Debug)]
@@ -122,6 +141,7 @@ pub(crate) struct IcebergV3RenderResult {
     active: BatchRefreshRenderResult,
     active_downstreams: FragmentDownstreamRelation,
     resolver: RenderedResolver,
+    static_actors: IcebergV3StaticActors,
 }
 
 impl IcebergV3RenderResult {
@@ -150,10 +170,8 @@ pub(crate) struct IcebergV3JobCheckpointControl {
     node_actors: HashMap<WorkerId, HashSet<ActorId>>,
     max_pending_barrier_num: usize,
     upstream_lag: risingwave_common::metrics::LabelGuardedIntGauge,
-    /// Active graph relations retained for switching the normal input partition during compaction.
-    #[allow(dead_code)]
-    active_downstreams: FragmentDownstreamRelation,
     resolver: RenderedResolver,
+    actors: IcebergV3StaticActors,
 }
 
 impl IcebergV3JobCheckpointControl {
@@ -176,6 +194,8 @@ impl IcebergV3JobCheckpointControl {
             database_resource_group,
             streaming_job_model,
         )?;
+        let static_actors =
+            build_static_actors(&rendered, downstreams, partial_graph_id, worker_nodes)?;
         let mut active_downstreams = downstreams.clone();
         let (active, resolver) = partition_resolver(rendered, &mut active_downstreams)?;
         let active = active.build_job_info(&active_downstreams, partial_graph_id, worker_nodes);
@@ -183,6 +203,7 @@ impl IcebergV3JobCheckpointControl {
             active,
             active_downstreams,
             resolver,
+            static_actors,
         })
     }
 
@@ -193,6 +214,7 @@ impl IcebergV3JobCheckpointControl {
         snapshot_backfill_upstream_tables: HashSet<TableId>,
         snapshot_epoch: u64,
         version_stat: &HummockVersionStats,
+        term_id: &str,
         partial_graph_manager: &mut PartialGraphManager,
         render_result: IcebergV3RenderResult,
     ) -> MetaResult<&'a mut Self> {
@@ -208,8 +230,9 @@ impl IcebergV3JobCheckpointControl {
                     node_actors,
                     actors_to_create,
                 },
-            active_downstreams,
+            active_downstreams: _,
             resolver,
+            static_actors,
         } = render_result;
         let (snapshot, initial_barrier_info) =
             SnapshotPhaseControl::for_new_job(snapshot_epoch, &fragment_infos, &info, version_stat);
@@ -247,12 +270,13 @@ impl IcebergV3JobCheckpointControl {
                 .with_guarded_label_values(&[&format!("{}", job_id)]),
             node_actors,
             max_pending_barrier_num,
-            active_downstreams,
             resolver,
+            actors: static_actors,
         };
 
         let mut graph_adder = partial_graph_manager.add_partial_graph(
             partial_graph_id,
+            term_id,
             IcebergV3BarrierStats::new(job_id, snapshot_epoch),
         );
         if let Err(error) = add_initial_partial_graph(
@@ -357,6 +381,7 @@ impl IcebergV3JobCheckpointControl {
         backfill_order: ExtendedFragmentBackfillOrder,
         version_stat: &HummockVersionStats,
         initial_mutation: Mutation,
+        term_id: &str,
         partial_graph_recoverer: &mut PartialGraphRecoverer<'_>,
         render_result: IcebergV3RenderResult,
     ) -> MetaResult<Self> {
@@ -373,8 +398,9 @@ impl IcebergV3JobCheckpointControl {
                     node_actors,
                     actors_to_create,
                 },
-            active_downstreams,
+            active_downstreams: _,
             resolver,
+            static_actors,
         } = render_result;
 
         let (status, first_barrier_info) = if committed_epoch < snapshot_epoch {
@@ -400,6 +426,7 @@ impl IcebergV3JobCheckpointControl {
 
         partial_graph_recoverer.recover_graph(
             partial_graph_id,
+            term_id,
             initial_mutation,
             &first_barrier_info,
             &node_actors,
@@ -419,8 +446,8 @@ impl IcebergV3JobCheckpointControl {
             upstream_lag: GLOBAL_META_METRICS
                 .snapshot_backfill_lag
                 .with_guarded_label_values(&[&format!("{}", job_id)]),
-            active_downstreams,
             resolver,
+            actors: static_actors,
         })
     }
 
@@ -445,6 +472,27 @@ impl IcebergV3JobCheckpointControl {
                 })
             }
             IcebergV3JobStatus::Running(IcebergV3InputPhase::LogStore { .. }) => None,
+            IcebergV3JobStatus::Compacting {
+                input_phase: IcebergV3InputPhase::Snapshot { snapshot, .. },
+                ..
+            } => {
+                let progress = if snapshot.create_mview_tracker.is_finished() {
+                    "Snapshot finished".to_owned()
+                } else {
+                    format!(
+                        "Snapshot [{}]",
+                        snapshot.create_mview_tracker.gen_backfill_progress()
+                    )
+                };
+                Some(BackfillProgress {
+                    progress,
+                    backfill_type: PbBackfillType::SnapshotBackfill,
+                })
+            }
+            IcebergV3JobStatus::Compacting {
+                input_phase: IcebergV3InputPhase::LogStore { .. },
+                ..
+            } => None,
         }
     }
 
@@ -454,6 +502,16 @@ impl IcebergV3JobCheckpointControl {
                 .create_mview_tracker
                 .collect_fragment_progress(&self.fragment_infos, true),
             IcebergV3JobStatus::Running(IcebergV3InputPhase::LogStore { .. }) => vec![],
+            IcebergV3JobStatus::Compacting {
+                input_phase: IcebergV3InputPhase::Snapshot { snapshot, .. },
+                ..
+            } => snapshot
+                .create_mview_tracker
+                .collect_fragment_progress(&self.fragment_infos, true),
+            IcebergV3JobStatus::Compacting {
+                input_phase: IcebergV3InputPhase::LogStore { .. },
+                ..
+            } => vec![],
         }
     }
 
@@ -474,27 +532,27 @@ impl IcebergV3JobCheckpointControl {
             Option<&mut NotifierStarter>,
         )>,
     ) -> MetaResult<()> {
-        let (mut mutation, mut notifier) = mutation
-            .map(|(mutation, notifier)| (Some(mutation), notifier))
-            .unwrap_or_default();
-        let progress_epoch = self
-            .control
-            .max_committed_epoch
-            .map_or(self.control.info.snapshot_epoch, |committed_epoch| {
-                max(committed_epoch, self.control.info.snapshot_epoch)
-            });
-        self.upstream_lag.set(
-            barrier_info
-                .prev_epoch
-                .value()
-                .0
-                .saturating_sub(progress_epoch) as _,
-        );
-        let available = self.max_pending_barrier_num.saturating_sub(
-            partial_graph_manager.pending_barrier_num(self.control.info.partial_graph_id),
-        );
         match &mut self.status {
             IcebergV3JobStatus::Running(input_phase) => {
+                let (mut mutation, mut notifier) = mutation
+                    .map(|(mutation, notifier)| (Some(mutation), notifier))
+                    .unwrap_or_default();
+                let progress_epoch = self
+                    .control
+                    .max_committed_epoch
+                    .map_or(self.control.info.snapshot_epoch, |committed_epoch| {
+                        max(committed_epoch, self.control.info.snapshot_epoch)
+                    });
+                self.upstream_lag.set(
+                    barrier_info
+                        .prev_epoch
+                        .value()
+                        .0
+                        .saturating_sub(progress_epoch) as _,
+                );
+                let available = self.max_pending_barrier_num.saturating_sub(
+                    partial_graph_manager.pending_barrier_num(self.control.info.partial_graph_id),
+                );
                 let barriers_to_inject = match input_phase {
                     IcebergV3InputPhase::Snapshot {
                         snapshot,
@@ -538,6 +596,21 @@ impl IcebergV3JobCheckpointControl {
                     )?;
                 }
             }
+            IcebergV3JobStatus::Compacting { input_phase, .. } => {
+                assert!(
+                    mutation.is_none(),
+                    "active Iceberg compaction must not receive a second mutation"
+                );
+                match input_phase {
+                    IcebergV3InputPhase::Snapshot {
+                        pending_upstream_barriers,
+                        ..
+                    }
+                    | IcebergV3InputPhase::LogStore {
+                        pending_upstream_barriers,
+                    } => pending_upstream_barriers.push_back(barrier_info.clone()),
+                }
+            }
         }
         Ok(())
     }
@@ -546,61 +619,301 @@ impl IcebergV3JobCheckpointControl {
         &mut self,
         throttle_config: &mut ThrottleConfigMap,
     ) -> Option<risingwave_pb::stream_plan::barrier_mutation::Mutation> {
-        extract_throttle_config(throttle_config, |fragment_id, stream_node| {
-            if let Some(fragment_info) = self.fragment_infos.get_mut(&fragment_id) {
-                fragment_info.nodes = stream_node.clone();
-                true
-            } else {
-                false
+        match &mut self.status {
+            IcebergV3JobStatus::Running(_) => {
+                let mutation =
+                    extract_throttle_config(throttle_config, |fragment_id, stream_node| {
+                        if let Some(fragment_info) = self.fragment_infos.get_mut(&fragment_id) {
+                            fragment_info.nodes = stream_node.clone();
+                            true
+                        } else {
+                            false
+                        }
+                    });
+                if mutation.is_some() {
+                    self.actors.refresh_build_plans(&self.fragment_infos);
+                }
+                mutation
             }
-        })
+            IcebergV3JobStatus::Compacting { .. } => None,
+        }
     }
 
     pub(crate) fn collect(&mut self, collected_barrier: CollectedBarrier<'_>) -> bool {
         match &mut self.status {
-            IcebergV3JobStatus::Running(input_phase) => {
-                let progress = collected_barrier
-                    .resps
-                    .values()
-                    .flat_map(|response| &response.create_mview_progress);
-                if let IcebergV3InputPhase::Snapshot {
+            IcebergV3JobStatus::Running(input_phase) => match input_phase {
+                IcebergV3InputPhase::Snapshot {
                     snapshot,
                     pending_upstream_barriers,
-                } = input_phase
-                    && snapshot.apply_progress(progress)
-                {
-                    pending_upstream_barriers.push_front(snapshot.finish_snapshot_barrier());
-                    *input_phase = IcebergV3InputPhase::LogStore {
-                        pending_upstream_barriers: take(pending_upstream_barriers),
-                    };
+                } => {
+                    let progress = collected_barrier
+                        .resps
+                        .values()
+                        .flat_map(|response| &response.create_mview_progress);
+                    if snapshot.apply_progress(progress) {
+                        pending_upstream_barriers.push_front(snapshot.finish_snapshot_barrier());
+                        *input_phase = IcebergV3InputPhase::LogStore {
+                            pending_upstream_barriers: take(pending_upstream_barriers),
+                        };
+                    }
                 }
-            }
+                IcebergV3InputPhase::LogStore { .. } => {}
+            },
+            IcebergV3JobStatus::Compacting { input_phase, .. } => match input_phase {
+                IcebergV3InputPhase::Snapshot {
+                    snapshot,
+                    pending_upstream_barriers,
+                } => {
+                    let progress = collected_barrier
+                        .resps
+                        .values()
+                        .flat_map(|response| &response.create_mview_progress);
+                    if snapshot.apply_progress(progress) {
+                        pending_upstream_barriers.push_front(snapshot.finish_snapshot_barrier());
+                        *input_phase = IcebergV3InputPhase::LogStore {
+                            pending_upstream_barriers: take(pending_upstream_barriers),
+                        };
+                    }
+                }
+                IcebergV3InputPhase::LogStore { .. } => {}
+            },
         }
         // Ordinary snapshot jobs force a checkpoint to merge into the database graph. Iceberg V3
         // remains independent after catch-up, so its normal checkpoint cadence is sufficient.
         false
     }
 
+    pub(crate) fn start_apply_compaction(
+        &mut self,
+        partial_graph_manager: &mut PartialGraphManager,
+        upstream_barrier: &BarrierInfo,
+        task_id: IcebergCompactionTaskId,
+        overwrite: IcebergPkIndexCompactionOverwrite,
+        notifier: &mut NotifierStarter,
+    ) -> MetaResult<()> {
+        let output_data_file_paths = output_file_paths(&overwrite.output_result.data_files)?;
+        let (begin_barrier, end_barrier) = self.next_compaction_barriers(upstream_barrier)?;
+        let sink_id = SinkId::new(self.control.info.job_id.as_raw_id());
+        let resolver_task_input = ResolverTaskInput {
+            output_data_file_paths,
+            input_data_file_paths: overwrite.input_file_paths.clone(),
+            read_snapshot_id: overwrite.read_snapshot_id,
+        };
+        let compaction_overwrite = CompactionOverwrite {
+            sink_id,
+            epoch: end_barrier.prev_epoch(),
+            schema_id: overwrite.output_result.schema_id,
+            partition_spec_id: overwrite.output_result.partition_spec_id,
+            output_files: overwrite.output_result.data_files,
+            input_file_paths: overwrite.input_file_paths,
+            read_snapshot_id: overwrite.read_snapshot_id,
+        };
+        let mutation = combine_updates(
+            &self.actors.normal_input.detach_mutation,
+            &self.actors.resolver.attach_mutation,
+            IcebergPkIndexCompactionContext {
+                sink_id,
+                task_id,
+                phase: Phase::Begin as i32,
+                resolver_task_input: Some(resolver_task_input),
+            },
+        );
+        let node_actors = merge_node_actors([&self.node_actors, &self.actors.resolver.node_actors]);
+        partial_graph_manager.inject_barrier(
+            self.control.info.partial_graph_id,
+            Some(mutation),
+            &node_actors,
+            self.control.info.state_table_ids.iter().copied(),
+            node_actors.keys().copied(),
+            Some(self.actors.resolver.actors_to_create.clone()),
+            PartialGraphBarrierInfo::new(
+                PostCollectCommand::barrier(),
+                begin_barrier.clone(),
+                None,
+                self.control.info.state_table_ids.clone(),
+            ),
+        )?;
+
+        let input_phase = match std::mem::replace(
+            &mut self.status,
+            IcebergV3JobStatus::Running(IcebergV3InputPhase::LogStore {
+                pending_upstream_barriers: VecDeque::new(),
+            }),
+        ) {
+            IcebergV3JobStatus::Running(input_phase) => input_phase,
+            IcebergV3JobStatus::Compacting { .. } => {
+                unreachable!("compacting status was rejected before barrier injection")
+            }
+        };
+        self.status = IcebergV3JobStatus::Compacting {
+            input_phase,
+            apply: CompactionApply {
+                task_id,
+                overwrite: Some(compaction_overwrite),
+                begin_barrier,
+                end_barrier,
+                notifier: notifier.add_notify(),
+            },
+        };
+        Ok(())
+    }
+
+    fn next_compaction_barriers(
+        &mut self,
+        upstream_barrier: &BarrierInfo,
+    ) -> MetaResult<(BarrierInfo, BarrierInfo)> {
+        match &mut self.status {
+            IcebergV3JobStatus::Running(input_phase) => match input_phase {
+                IcebergV3InputPhase::Snapshot {
+                    snapshot,
+                    pending_upstream_barriers,
+                } => {
+                    pending_upstream_barriers.push_back(upstream_barrier.clone());
+                    let begin = snapshot.next_fake_barrier(&BarrierKind::Checkpoint(vec![]));
+                    let end = snapshot.next_fake_barrier(&BarrierKind::Checkpoint(vec![]));
+                    Ok((begin, end))
+                }
+                IcebergV3InputPhase::LogStore { .. } => {
+                    let BarrierKind::Checkpoint(checkpoint_epochs) = &upstream_barrier.kind else {
+                        return Err(anyhow::anyhow!(
+                            "Iceberg pk-index compaction requires a checkpoint command barrier"
+                        )
+                        .into());
+                    };
+                    let prev_epoch = upstream_barrier.prev_epoch.value();
+                    let curr_epoch = upstream_barrier.curr_epoch.value();
+                    let synthetic = Epoch(prev_epoch.0 + 1);
+                    if synthetic >= curr_epoch {
+                        return Err(anyhow::anyhow!(
+                            "cannot allocate synthetic compaction epoch between {} and {}",
+                            prev_epoch.0,
+                            curr_epoch.0
+                        )
+                        .into());
+                    }
+                    Ok((
+                        BarrierInfo {
+                            prev_epoch: TracedEpoch::new(prev_epoch),
+                            curr_epoch: TracedEpoch::new(synthetic),
+                            kind: BarrierKind::Checkpoint(checkpoint_epochs.clone()),
+                        },
+                        BarrierInfo {
+                            prev_epoch: TracedEpoch::new(synthetic),
+                            curr_epoch: TracedEpoch::new(curr_epoch),
+                            kind: BarrierKind::Checkpoint(vec![synthetic.0]),
+                        },
+                    ))
+                }
+            },
+            IcebergV3JobStatus::Compacting { .. } => Err(anyhow::anyhow!(
+                "Iceberg V3 job {} is already applying compaction",
+                self.control.info.job_id
+            )
+            .into()),
+        }
+    }
+
+    fn inject_end_compaction_barrier(
+        &self,
+        partial_graph_manager: &mut PartialGraphManager,
+    ) -> MetaResult<()> {
+        match &self.status {
+            IcebergV3JobStatus::Running(_) => {
+                unreachable!("end compaction barrier requested while running")
+            }
+            IcebergV3JobStatus::Compacting { apply, .. } => {
+                let sink_id = SinkId::new(self.control.info.job_id.as_raw_id());
+                let mutation = combine_updates(
+                    &self.actors.resolver.detach_mutation,
+                    &self.actors.normal_input.attach_mutation,
+                    IcebergPkIndexCompactionContext {
+                        sink_id,
+                        task_id: apply.task_id,
+                        phase: Phase::End as i32,
+                        resolver_task_input: None,
+                    },
+                );
+                let node_actors = merge_node_actors([
+                    &self.actors.long_running_node_actors,
+                    &self.actors.resolver.node_actors,
+                    &self.actors.normal_input.node_actors,
+                ]);
+                partial_graph_manager.inject_barrier(
+                    self.control.info.partial_graph_id,
+                    Some(mutation),
+                    &node_actors,
+                    self.control.info.state_table_ids.iter().copied(),
+                    node_actors.keys().copied(),
+                    Some(self.actors.normal_input.actors_to_create.clone()),
+                    PartialGraphBarrierInfo::new(
+                        PostCollectCommand::barrier(),
+                        apply.end_barrier.clone(),
+                        None,
+                        self.control.info.state_table_ids.clone(),
+                    ),
+                )
+            }
+        }
+    }
+
+    #[expect(clippy::type_complexity)]
     pub(crate) fn start_completing(
         &mut self,
         partial_graph_manager: &mut PartialGraphManager,
         min_upstream_inflight_barrier: Option<u64>,
-    ) -> Option<(
-        u64,
-        HashMap<WorkerId, BarrierCompleteResponse>,
-        PartialGraphBarrierInfo,
-        bool,
-    )> {
+    ) -> MetaResult<
+        Option<(
+            u64,
+            HashMap<WorkerId, BarrierCompleteResponse>,
+            PartialGraphBarrierInfo,
+            bool,
+            Option<CompactionOverwrite>,
+        )>,
+    > {
         let epoch_end_bound = min_upstream_inflight_barrier
             .map(Excluded)
             .unwrap_or(Unbounded);
-        partial_graph_manager
-            .start_completing(
-                self.control.info.partial_graph_id,
-                epoch_end_bound,
-                |_non_checkpoint_epoch, _, _| {},
-            )
-            .map(|(epoch, responses, info)| (epoch, responses, info, false))
+        let Some((epoch, responses, info)) = partial_graph_manager.start_completing(
+            self.control.info.partial_graph_id,
+            epoch_end_bound,
+            |_non_checkpoint_epoch, _, _| {},
+        ) else {
+            return Ok(None);
+        };
+
+        let inject_end = matches!(
+            &self.status,
+            IcebergV3JobStatus::Compacting { apply, .. }
+                if epoch == apply.begin_barrier.prev_epoch()
+        );
+        if inject_end {
+            self.inject_end_compaction_barrier(partial_graph_manager)?;
+        }
+        let overwrite = match &mut self.status {
+            IcebergV3JobStatus::Running(_) => None,
+            IcebergV3JobStatus::Compacting { apply, .. }
+                if epoch < apply.begin_barrier.prev_epoch()
+                    || epoch == apply.begin_barrier.prev_epoch() =>
+            {
+                None
+            }
+            IcebergV3JobStatus::Compacting { apply, .. }
+                if epoch == apply.end_barrier.prev_epoch() =>
+            {
+                Some(
+                    apply
+                        .overwrite
+                        .take()
+                        .expect("compaction overwrite must be committed exactly once"),
+                )
+            }
+            IcebergV3JobStatus::Compacting { apply, .. } => unreachable!(
+                "unexpected collected epoch {epoch} while applying compaction between {} and {}",
+                apply.begin_barrier.prev_epoch(),
+                apply.end_barrier.prev_epoch(),
+            ),
+        };
+        Ok(Some((epoch, responses, info, false, overwrite)))
     }
 
     pub(crate) fn ack_completed(
@@ -614,8 +927,95 @@ impl IcebergV3JobCheckpointControl {
                     .ack_completed(self.control.info.partial_graph_id, completed_epoch);
                 self.control.ack_completed(completed_epoch);
             }
+            IcebergV3JobStatus::Compacting { apply, .. }
+                if completed_epoch <= apply.begin_barrier.prev_epoch() =>
+            {
+                partial_graph_manager
+                    .ack_completed(self.control.info.partial_graph_id, completed_epoch);
+                self.control.ack_completed(completed_epoch);
+            }
+            IcebergV3JobStatus::Compacting { apply, .. }
+                if completed_epoch == apply.end_barrier.prev_epoch() =>
+            {
+                partial_graph_manager
+                    .ack_completed(self.control.info.partial_graph_id, completed_epoch);
+                self.control.ack_completed(completed_epoch);
+                let IcebergV3JobStatus::Compacting { input_phase, apply } = std::mem::replace(
+                    &mut self.status,
+                    IcebergV3JobStatus::Running(IcebergV3InputPhase::LogStore {
+                        pending_upstream_barriers: VecDeque::new(),
+                    }),
+                ) else {
+                    unreachable!()
+                };
+                self.status = IcebergV3JobStatus::Running(input_phase);
+                apply.notifier.notify_collected();
+            }
+            IcebergV3JobStatus::Compacting { apply, .. } => unreachable!(
+                "unexpected completed epoch {completed_epoch} while applying compaction between {} and {}",
+                apply.begin_barrier.prev_epoch(),
+                apply.end_barrier.prev_epoch(),
+            ),
         }
     }
+}
+
+fn merge_node_actors<'a>(
+    maps: impl IntoIterator<Item = &'a HashMap<WorkerId, HashSet<ActorId>>>,
+) -> HashMap<WorkerId, HashSet<ActorId>> {
+    let mut result: HashMap<WorkerId, HashSet<ActorId>> = HashMap::new();
+    for map in maps {
+        for (worker_id, actors) in map {
+            result
+                .entry(*worker_id)
+                .or_default()
+                .extend(actors.iter().copied());
+        }
+    }
+    result
+}
+
+fn combine_updates(
+    first: &Mutation,
+    second: &Mutation,
+    compaction: IcebergPkIndexCompactionContext,
+) -> Mutation {
+    let mut result = UpdateMutation::default();
+    for mutation in [first, second] {
+        let Mutation::Update(update) = mutation else {
+            unreachable!("static topology activations are update mutations")
+        };
+        result
+            .dispatcher_update
+            .extend(update.dispatcher_update.clone());
+        result.merge_update.extend(update.merge_update.clone());
+        result
+            .actor_vnode_bitmap_update
+            .extend(update.actor_vnode_bitmap_update.clone());
+        result.dropped_actors.extend(update.dropped_actors.clone());
+        result.actor_splits.extend(update.actor_splits.clone());
+        result
+            .actor_new_dispatchers
+            .extend(update.actor_new_dispatchers.clone());
+    }
+    result.iceberg_pk_index_compaction = Some(compaction);
+    Mutation::Update(result)
+}
+
+fn output_file_paths(files: &[iceberg::spec::SerializedDataFile]) -> MetaResult<Vec<String>> {
+    files
+        .iter()
+        .map(|file| {
+            let value = serde_json::to_value(file).map_err(anyhow::Error::from)?;
+            value
+                .get("file_path")
+                .and_then(|path| path.as_str())
+                .map(str::to_owned)
+                .ok_or_else(|| {
+                    anyhow::anyhow!("compaction output file is missing file_path").into()
+                })
+        })
+        .collect()
 }
 
 pub(crate) fn is_iceberg_v3_fragment_nodes<'a>(

--- a/src/meta/src/barrier/checkpoint/independent_job/iceberg_v3_job/render.rs
+++ b/src/meta/src/barrier/checkpoint/independent_job/iceberg_v3_job/render.rs
@@ -12,26 +12,313 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::collections::{HashMap, HashSet};
+
 use risingwave_common::util::stream_graph_visitor::visit_stream_node_cont;
-use risingwave_pb::stream_plan::PbStreamNode;
+use risingwave_meta_model::WorkerId;
+use risingwave_pb::common::WorkerNode;
+use risingwave_pb::id::{ActorId, FragmentId, PartialGraphId};
+use risingwave_pb::stream_plan::barrier_mutation::Mutation;
 use risingwave_pb::stream_plan::stream_node::NodeBody;
+use risingwave_pb::stream_plan::update_mutation::MergeUpdate;
+use risingwave_pb::stream_plan::{PbStreamNode, UpdateMutation};
 
 use super::super::RenderedIndependentJobActors;
 use crate::MetaResult;
+use crate::barrier::edge_builder::{EdgeBuilderFragmentInfo, FragmentEdgeBuilder};
 use crate::controller::fragment::InflightFragmentInfo;
-use crate::model::{DownstreamFragmentRelation, FragmentDownstreamRelation, StreamActor};
+use crate::model::{FragmentDownstreamRelation, StreamJobActorsToCreate};
+
+#[derive(Debug)]
+pub(super) struct ResolverActivation {
+    pub node_actors: HashMap<WorkerId, HashSet<ActorId>>,
+    pub actors_to_create: StreamJobActorsToCreate,
+    pub attach_mutation: Mutation,
+    pub detach_mutation: Mutation,
+}
+
+#[derive(Debug)]
+pub(super) struct NormalInputActivation {
+    pub node_actors: HashMap<WorkerId, HashSet<ActorId>>,
+    pub actors_to_create: StreamJobActorsToCreate,
+    pub attach_mutation: Mutation,
+    pub detach_mutation: Mutation,
+}
+
+#[derive(Debug)]
+pub(super) struct IcebergV3StaticActors {
+    pub normal_input: NormalInputActivation,
+    pub resolver: ResolverActivation,
+    pub long_running_node_actors: HashMap<WorkerId, HashSet<ActorId>>,
+}
+
+impl IcebergV3StaticActors {
+    pub fn refresh_build_plans(
+        &mut self,
+        fragment_infos: &HashMap<FragmentId, InflightFragmentInfo>,
+    ) {
+        for fragments in self.normal_input.actors_to_create.values_mut() {
+            for (fragment_id, (node, ..)) in fragments {
+                *node = fragment_infos[fragment_id].nodes.clone();
+            }
+        }
+    }
+}
 
 /// The resolver fragment is rendered and placed with the whole Iceberg graph, but remains
 /// disconnected until a compaction command activates it.
 #[derive(Debug)]
 pub(super) struct RenderedResolver {
     pub fragment_info: InflightFragmentInfo,
-    /// Pre-rendered actor definitions retained for the compaction activation path.
-    #[allow(dead_code)]
-    pub stream_actors: Vec<StreamActor>,
-    /// The disconnected resolver-to-writer edge retained for compaction activation.
-    #[allow(dead_code)]
-    pub downstream_relation: DownstreamFragmentRelation,
+}
+
+pub(super) fn build_static_actors(
+    rendered: &RenderedIndependentJobActors,
+    downstreams: &FragmentDownstreamRelation,
+    partial_graph_id: PartialGraphId,
+    worker_nodes: &HashMap<WorkerId, WorkerNode>,
+) -> MetaResult<IcebergV3StaticActors> {
+    let fragment_infos = &rendered.fragment_infos;
+    let writer_fragment = fragment_infos
+        .values()
+        .find(|fragment| find_writer_node(&fragment.nodes).is_some())
+        .ok_or_else(|| anyhow::anyhow!("Iceberg V3 graph has no pk-index writer"))?;
+    let writer_node = find_writer_node(&writer_fragment.nodes)
+        .expect("writer fragment was selected by its writer node");
+    let [normal_input, resolver_input] = writer_node.input.as_slice() else {
+        return Err(anyhow::anyhow!("Iceberg writer must have exactly two inputs").into());
+    };
+    let Some(NodeBody::Merge(normal_merge)) = normal_input.node_body.as_ref() else {
+        return Err(anyhow::anyhow!("Iceberg writer normal input must be a Merge node").into());
+    };
+    let Some(NodeBody::Merge(resolver_merge)) = resolver_input.node_body.as_ref() else {
+        return Err(anyhow::anyhow!("Iceberg writer resolver input must be a Merge node").into());
+    };
+    let normal_fragment_id = normal_merge.upstream_fragment_id;
+    let resolver_fragment_id = resolver_merge.upstream_fragment_id;
+    let resolver_fragment = fragment_infos.get(&resolver_fragment_id).ok_or_else(|| {
+        anyhow::anyhow!(
+            "Iceberg writer resolver fragment {} was not rendered",
+            resolver_fragment_id
+        )
+    })?;
+    if !contains_resolver(&resolver_fragment.nodes) {
+        return Err(anyhow::anyhow!(
+            "Iceberg writer resolver input fragment {} has no resolver node",
+            resolver_fragment_id
+        )
+        .into());
+    }
+
+    let mut long_running = HashSet::from([writer_fragment.fragment_id]);
+    let mut pending = vec![writer_fragment.fragment_id];
+    while let Some(fragment_id) = pending.pop() {
+        for downstream in downstreams.get(&fragment_id).into_iter().flatten() {
+            if long_running.insert(downstream.downstream_fragment_id) {
+                pending.push(downstream.downstream_fragment_id);
+            }
+        }
+    }
+    let normal_fragment_ids: HashSet<_> = fragment_infos
+        .keys()
+        .filter(|fragment_id| {
+            !long_running.contains(*fragment_id) && **fragment_id != resolver_fragment_id
+        })
+        .copied()
+        .collect();
+    if !normal_fragment_ids.contains(&normal_fragment_id) {
+        return Err(anyhow::anyhow!(
+            "normal input fragment {} was classified as long-running",
+            normal_fragment_id
+        )
+        .into());
+    }
+
+    let resolver = build_activation(
+        resolver_fragment_id,
+        HashSet::from([resolver_fragment_id]),
+        writer_fragment,
+        rendered,
+        downstreams,
+        partial_graph_id,
+        worker_nodes,
+    )?;
+    let normal_input = build_activation(
+        normal_fragment_id,
+        normal_fragment_ids,
+        writer_fragment,
+        rendered,
+        downstreams,
+        partial_graph_id,
+        worker_nodes,
+    )?;
+    let long_running_node_actors = InflightFragmentInfo::actor_ids_to_collect(
+        fragment_infos
+            .values()
+            .filter(|fragment| long_running.contains(&fragment.fragment_id)),
+    );
+
+    Ok(IcebergV3StaticActors {
+        normal_input: NormalInputActivation {
+            node_actors: normal_input.node_actors,
+            actors_to_create: normal_input.actors_to_create,
+            attach_mutation: normal_input.attach_mutation,
+            detach_mutation: normal_input.detach_mutation,
+        },
+        resolver: ResolverActivation {
+            node_actors: resolver.node_actors,
+            actors_to_create: resolver.actors_to_create,
+            attach_mutation: resolver.attach_mutation,
+            detach_mutation: resolver.detach_mutation,
+        },
+        long_running_node_actors,
+    })
+}
+
+struct Activation {
+    node_actors: HashMap<WorkerId, HashSet<ActorId>>,
+    actors_to_create: StreamJobActorsToCreate,
+    attach_mutation: Mutation,
+    detach_mutation: Mutation,
+}
+
+fn build_activation(
+    edge_fragment_id: FragmentId,
+    fragment_ids: HashSet<FragmentId>,
+    writer_fragment: &InflightFragmentInfo,
+    rendered: &RenderedIndependentJobActors,
+    downstreams: &FragmentDownstreamRelation,
+    partial_graph_id: PartialGraphId,
+    worker_nodes: &HashMap<WorkerId, WorkerNode>,
+) -> MetaResult<Activation> {
+    let fragment_infos = &rendered.fragment_infos;
+    let relation = downstreams
+        .get(&edge_fragment_id)
+        .into_iter()
+        .flatten()
+        .find(|relation| relation.downstream_fragment_id == writer_fragment.fragment_id)
+        .ok_or_else(|| {
+            anyhow::anyhow!(
+                "fragment {} has no edge to writer fragment {}",
+                edge_fragment_id,
+                writer_fragment.fragment_id
+            )
+        })?;
+    let mut builder = FragmentEdgeBuilder::new(
+        fragment_ids
+            .iter()
+            .copied()
+            .chain([writer_fragment.fragment_id])
+            .map(|fragment_id| {
+                let fragment = &fragment_infos[&fragment_id];
+                (
+                    fragment_id,
+                    EdgeBuilderFragmentInfo::from_inflight_with_worker_nodes(
+                        fragment,
+                        partial_graph_id,
+                        worker_nodes,
+                    ),
+                )
+            }),
+    );
+    for fragment_id in &fragment_ids {
+        for relation in downstreams.get(fragment_id).into_iter().flatten() {
+            if fragment_ids.contains(&relation.downstream_fragment_id) {
+                builder.add_edge(*fragment_id, relation);
+            }
+        }
+    }
+    builder.add_edge(edge_fragment_id, relation);
+    let mut edges = builder.build();
+    let actors_to_create = edges.collect_actors_to_create(fragment_ids.iter().map(|fragment_id| {
+        let fragment = &fragment_infos[fragment_id];
+        (
+            fragment.fragment_id,
+            &fragment.nodes,
+            fragment.actors.iter().map(|(actor_id, actor)| {
+                let stream_actor = rendered.stream_actors[&fragment.fragment_id]
+                    .iter()
+                    .find(|stream_actor| stream_actor.actor_id == *actor_id)
+                    .expect("rendered actor should exist");
+                (stream_actor, actor.worker_id)
+            }),
+            vec![],
+        )
+    }));
+    let mut attach_merge_updates = Vec::with_capacity(writer_fragment.actors.len());
+    for actor_id in writer_fragment.actors.keys().copied() {
+        let (mut upstreams, dispatchers) =
+            edges.take_actor_edges(writer_fragment.fragment_id, actor_id);
+        if !dispatchers.is_empty() {
+            return Err(anyhow::anyhow!(
+                "Iceberg writer actor {} unexpectedly has phase dispatchers: {:?}",
+                actor_id,
+                dispatchers
+            )
+            .into());
+        }
+        let added_upstream_actors = upstreams.remove(&edge_fragment_id).ok_or_else(|| {
+            anyhow::anyhow!(
+                "Iceberg writer actor {} has no upstream actors from fragment {}",
+                actor_id,
+                edge_fragment_id
+            )
+        })?;
+        if !upstreams.is_empty() {
+            return Err(anyhow::anyhow!(
+                "Iceberg writer actor {} has unexpected phase upstreams: {:?}",
+                actor_id,
+                upstreams.keys().collect::<Vec<_>>()
+            )
+            .into());
+        }
+        attach_merge_updates.push(MergeUpdate {
+            actor_id,
+            upstream_fragment_id: edge_fragment_id,
+            new_upstream_fragment_id: None,
+            added_upstream_actors: added_upstream_actors.into_values().collect(),
+            removed_upstream_actor_id: vec![],
+        });
+    }
+    if !edges.is_empty() {
+        return Err(anyhow::anyhow!("unconsumed Iceberg phase edges: {:?}", edges).into());
+    }
+    let attach_mutation = Mutation::Update(UpdateMutation {
+        merge_update: attach_merge_updates.clone(),
+        ..Default::default()
+    });
+    let detach_mutation = Mutation::Update(UpdateMutation {
+        merge_update: attach_merge_updates
+            .into_iter()
+            .map(|update| MergeUpdate {
+                actor_id: update.actor_id,
+                upstream_fragment_id: edge_fragment_id,
+                new_upstream_fragment_id: None,
+                added_upstream_actors: vec![],
+                removed_upstream_actor_id: update
+                    .added_upstream_actors
+                    .into_iter()
+                    .map(|actor| actor.actor_id)
+                    .collect(),
+            })
+            .collect(),
+        dropped_actors: fragment_ids
+            .iter()
+            .flat_map(|fragment_id| fragment_infos[fragment_id].actors.keys().copied())
+            .collect(),
+        ..Default::default()
+    });
+    let node_actors = InflightFragmentInfo::actor_ids_to_collect(
+        fragment_ids
+            .iter()
+            .map(|fragment_id| &fragment_infos[fragment_id]),
+    );
+    Ok(Activation {
+        node_actors,
+        actors_to_create,
+        attach_mutation,
+        detach_mutation,
+    })
 }
 
 /// Split the dormant resolver from an Iceberg graph after actor placement and before edge
@@ -73,7 +360,7 @@ pub(super) fn partition_resolver(
         )
         .into());
     }
-    let resolver_actors = rendered
+    rendered
         .stream_actors
         .remove(&resolver_fragment_id)
         .ok_or_else(|| {
@@ -83,7 +370,7 @@ pub(super) fn partition_resolver(
             )
         })?;
 
-    let downstream_relation = {
+    {
         let relations = downstreams.get_mut(&resolver_fragment_id).ok_or_else(|| {
             anyhow::anyhow!(
                 "resolver fragment {} has no downstream relation",
@@ -126,8 +413,6 @@ pub(super) fn partition_resolver(
         rendered,
         RenderedResolver {
             fragment_info: resolver_fragment,
-            stream_actors: resolver_actors,
-            downstream_relation,
         },
     ))
 }

--- a/src/meta/src/barrier/checkpoint/state.rs
+++ b/src/meta/src/barrier/checkpoint/state.rs
@@ -41,7 +41,7 @@ use crate::barrier::cdc_progress::CdcTableBackfillTracker;
 use crate::barrier::checkpoint::independent_job::IcebergV3JobCheckpointControl;
 use crate::barrier::checkpoint::{
     BatchRefreshJobCheckpointControl, BatchRefreshLogicalFragments, CreatingStreamingJobControl,
-    DatabaseCheckpointControl, IndependentCheckpointJob,
+    DatabaseCheckpointControl, IndependentCheckpointJob, IndependentCheckpointJobControl,
 };
 use crate::barrier::command::{
     CreateStreamingJobCommandInfo, PostCollectCommand, ReschedulePlan, ThrottleConfigMap,
@@ -527,6 +527,7 @@ impl DatabaseCheckpointControl {
 
         let mut notify_database_graph = command.is_some();
         let mut throttle_config: Option<ThrottleConfigMap> = None;
+        let mut skip_forward_to_iceberg_job = None;
 
         // Each variant handles its own pre-apply, edge building, mutation generation,
         // collect base info, and post-apply. The match produces values consumed by the
@@ -755,6 +756,7 @@ impl DatabaseCheckpointControl {
                     .copied()
                     .collect();
 
+                let term_id = self.term_id.as_str();
                 let Entry::Vacant(entry) = self.independent_checkpoint_job_controls.entry(job_id)
                 else {
                     panic!("duplicated creating Iceberg V3 job {job_id}");
@@ -772,6 +774,7 @@ impl DatabaseCheckpointControl {
                     snapshot_backfill_upstream_tables,
                     snapshot_epoch,
                     hummock_version_stats,
+                    term_id,
                     partial_graph_manager,
                     render_result,
                 )?;
@@ -1629,6 +1632,40 @@ impl DatabaseCheckpointControl {
                 ));
                 self.apply_simple_command(mutation, "InjectSourceOffsets")
             }
+
+            Some(Command::ApplyIcebergPkIndexCompaction {
+                sink_id,
+                task_id,
+                overwrite,
+            }) => {
+                let job_id = sink_id.as_job_id();
+                let job = self
+                    .independent_checkpoint_job_controls
+                    .get_mut(&job_id)
+                    .and_then(IndependentCheckpointJobControl::running_mut)
+                    .ok_or_else(|| {
+                        anyhow::anyhow!(
+                            "Iceberg V3 independent job for sink {} is not running",
+                            sink_id
+                        )
+                    })?;
+                let IndependentCheckpointJob::IcebergV3(job) = job else {
+                    return Err(anyhow::anyhow!(
+                        "sink {} is not controlled as an Iceberg V3 independent job",
+                        sink_id
+                    )
+                    .into());
+                };
+                job.start_apply_compaction(
+                    partial_graph_manager,
+                    &barrier_info,
+                    task_id,
+                    overwrite,
+                    notifier.as_mut().expect("command has a notifier"),
+                )?;
+                skip_forward_to_iceberg_job = Some(job_id);
+                self.apply_simple_command(None, "ApplyIcebergPkIndexCompaction")
+            }
         };
 
         let mut finished_snapshot_backfill_jobs = HashSet::new();
@@ -1914,6 +1951,9 @@ impl DatabaseCheckpointControl {
             if finished_snapshot_backfill_jobs.contains(job_id)
                 && matches!(job, IndependentCheckpointJob::CreatingStreamingJob(_))
             {
+                continue;
+            }
+            if skip_forward_to_iceberg_job == Some(*job_id) {
                 continue;
             }
             let throttle_mutation = throttle_config.as_mut().and_then(|config| {

--- a/src/meta/src/barrier/command.rs
+++ b/src/meta/src/barrier/command.rs
@@ -21,6 +21,7 @@ use risingwave_common::catalog::{DatabaseId, TableId};
 use risingwave_common::hash::{ActorMapping, VnodeCountCompat};
 use risingwave_common::id::{JobId, SinkId, SourceId};
 use risingwave_common::must_match;
+use risingwave_connector::sink::iceberg::IcebergCommitResult;
 use risingwave_connector::source::{CdcTableSnapshotSplitRaw, SplitImpl};
 use risingwave_hummock_sdk::change_log::build_table_change_log_delta;
 use risingwave_hummock_sdk::vector_index::VectorIndexDelta;
@@ -592,6 +593,22 @@ pub enum Command {
         /// Split ID -> offset (JSON-encoded based on connector type)
         split_offsets: HashMap<String, String>,
     },
+
+    /// Apply a completed Iceberg data-file compaction to the pk-index sink graph.
+    ApplyIcebergPkIndexCompaction {
+        sink_id: SinkId,
+        task_id: risingwave_pb::id::IcebergCompactionTaskId,
+        overwrite: IcebergPkIndexCompactionOverwrite,
+    },
+}
+
+#[derive(Clone, educe::Educe)]
+#[educe(Debug)]
+pub struct IcebergPkIndexCompactionOverwrite {
+    #[educe(Debug(ignore))]
+    pub output_result: IcebergCommitResult,
+    pub input_file_paths: Vec<String>,
+    pub read_snapshot_id: i64,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -689,6 +706,12 @@ impl std::fmt::Display for Command {
                 "InjectSourceOffsets: {} ({} splits)",
                 source_id,
                 split_offsets.len()
+            ),
+            Command::ApplyIcebergPkIndexCompaction {
+                sink_id, task_id, ..
+            } => write!(
+                f,
+                "ApplyIcebergPkIndexCompaction: sink={sink_id} task={task_id}"
             ),
         }
     }

--- a/src/meta/src/barrier/complete_task.rs
+++ b/src/meta/src/barrier/complete_task.rs
@@ -266,33 +266,40 @@ impl CompletingTask {
     ) -> impl Future<Output = MetaResult<BarrierCompleteOutput>> + 'a {
         // If there is no completing barrier, try to start completing the earliest barrier if
         // it has been collected.
-        if let CompletingTask::None = self
-            && let Some(task) = checkpoint_control
+        let mut start_error = None;
+        if let CompletingTask::None = self {
+            match checkpoint_control
                 .next_complete_barrier_task(periodic_barriers, partial_graph_manager)
-        {
             {
-                let epochs_to_ack = task.epochs_to_ack();
-                let context = context.clone();
-                let await_tree_reg = env.await_tree_reg().clone();
-                let env = env.clone();
+                Ok(Some(task)) => {
+                    let epochs_to_ack = task.epochs_to_ack();
+                    let context = context.clone();
+                    let await_tree_reg = env.await_tree_reg().clone();
+                    let env = env.clone();
 
-                let fut = async move { task.complete_barrier(&*context, env).await };
-                let fut = await_tree_reg
-                    .register_derived_root("Barrier Completion Task")
-                    .instrument(fut);
-                let join_handle = tokio::spawn(fut);
+                    let fut = async move { task.complete_barrier(&*context, env).await };
+                    let fut = await_tree_reg
+                        .register_derived_root("Barrier Completion Task")
+                        .instrument(fut);
+                    let join_handle = tokio::spawn(fut);
 
-                *self = CompletingTask::Completing {
-                    epochs_to_ack,
-                    join_handle,
-                };
+                    *self = CompletingTask::Completing {
+                        epochs_to_ack,
+                        join_handle,
+                    };
+                }
+                Ok(None) => {}
+                Err(error) => start_error = Some(error),
             }
         }
 
         async move {
+            if let Some(error) = start_error {
+                return Err(error);
+            }
             if !matches!(self, CompletingTask::Completing { .. }) {
                 return pending().await;
-            };
+            }
             self.next_completed_barrier_inner().await
         }
     }

--- a/src/meta/src/barrier/edge_builder.rs
+++ b/src/meta/src/barrier/edge_builder.rs
@@ -19,8 +19,8 @@ use risingwave_meta_model::WorkerId;
 use risingwave_meta_model::fragment::DistributionType;
 use risingwave_pb::common::{ActorInfo, HostAddress, WorkerNode};
 use risingwave_pb::id::{PartialGraphId, SubscriberId};
-use risingwave_pb::stream_plan::StreamNode;
 use risingwave_pb::stream_plan::update_mutation::MergeUpdate;
+use risingwave_pb::stream_plan::{Dispatcher as PbDispatcher, StreamNode};
 use tracing::warn;
 
 use crate::barrier::rpc::ControlStreamManager;
@@ -143,6 +143,24 @@ impl FragmentEdgeBuildResult {
         &self.actor_new_no_shuffle
     }
 
+    pub(super) fn take_actor_edges(
+        &mut self,
+        fragment_id: FragmentId,
+        actor_id: ActorId,
+    ) -> (ActorUpstreams, Vec<PbDispatcher>) {
+        let upstreams = self
+            .upstreams
+            .get_mut(&fragment_id)
+            .and_then(|upstreams| upstreams.remove(&actor_id))
+            .unwrap_or_default();
+        let dispatchers = self
+            .dispatchers
+            .get_mut(&fragment_id)
+            .and_then(|dispatchers| dispatchers.remove(&actor_id))
+            .unwrap_or_default();
+        (upstreams, dispatchers)
+    }
+
     pub(super) fn collect_actors_to_create(
         &mut self,
         actors: impl Iterator<
@@ -158,16 +176,7 @@ impl FragmentEdgeBuildResult {
         for (fragment_id, node, actors, subscriber_ids) in actors {
             let subscriber_ids: HashSet<_> = subscriber_ids.into_iter().collect();
             for (actor, worker_id) in actors {
-                let upstreams = self
-                    .upstreams
-                    .get_mut(&fragment_id)
-                    .and_then(|upstreams| upstreams.remove(&actor.actor_id))
-                    .unwrap_or_default();
-                let dispatchers = self
-                    .dispatchers
-                    .get_mut(&fragment_id)
-                    .and_then(|upstreams| upstreams.remove(&actor.actor_id))
-                    .unwrap_or_default();
+                let (upstreams, dispatchers) = self.take_actor_edges(fragment_id, actor.actor_id);
                 actors_to_create
                     .entry(worker_id)
                     .or_default()
@@ -181,9 +190,9 @@ impl FragmentEdgeBuildResult {
     }
 
     pub(super) fn is_empty(&self) -> bool {
-        self.merge_updates
+        self.upstreams
             .values()
-            .all(|updates| updates.is_empty())
+            .all(|upstreams| upstreams.is_empty())
             && self.dispatchers.values().all(|dispatchers| {
                 dispatchers
                     .values()

--- a/src/meta/src/barrier/rpc.rs
+++ b/src/meta/src/barrier/rpc.rs
@@ -1223,6 +1223,7 @@ impl PartialGraphRecoverer<'_> {
                 job_backfill_orders,
                 hummock_version_stats,
                 mutation,
+                &term_id,
                 self,
                 render_result,
             )?;


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

This PR is stacked on #26981.

This PR adds global-barrier-worker coordination for applying Iceberg V3 PK-index compaction:

- Add the apply-compaction barrier command and explicit `Running` / `Compacting` job states.
- Insert a fake epoch between two upstream barriers to switch from input actors to resolver actors and then back without rerendering.
- Cache actor placement and edge activation plans so compaction does not perform asynchronous metadata restoration during runtime.
- Buffer upstream barriers while compaction is active and reject a concurrent apply-compaction request.
- Route compaction overwrite information through normal barrier completion and Iceberg commit handling before returning to `Running`.

No scheduler or external caller issues the new command in this layer; it defines and implements the global barrier worker boundary.

Stack-head verification: `cargo clippy --all-targets --all-features`.

## Checklist

- [x] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [x] <!-- OPTIONAL --> I have added test labels as necessary.
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them.
- [ ] <!-- OPTIONAL --> My PR contains breaking changes.
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results.
- [ ] <!-- OPTIONAL --> I have checked the Release Timeline and Currently Supported Versions to determine which release branches I need to cherry-pick this PR into.

## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates.

<details>
<summary><b>Release note</b></summary>

Not applicable. Iceberg V3 compaction triggering is not exposed yet.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for applying Iceberg primary-key index compaction results to sink processing.
  * Compaction now coordinates data-file updates and checkpoint barriers for consistent results.
  * Improved Iceberg V3 job handling during compaction and ongoing processing.

* **Bug Fixes**
  * Errors encountered while completing checkpoints are now surfaced instead of potentially leaving operations waiting indefinitely.
  * Corrected actor-edge collection and empty-state detection during stream updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->