### PR TITLE
fix(iceberg): merge COW overwrite manifests on release-3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6859,7 +6859,7 @@ dependencies = [
 [[package]]
 name = "iceberg"
 version = "0.8.0"
-source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=64a440f15f9d152aa35931fe9b4be066fa40e770#64a440f15f9d152aa35931fe9b4be066fa40e770"
+source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=fc973389f93cb4a0c6be8962ca3ebc7bc9bae8a0#fc973389f93cb4a0c6be8962ca3ebc7bc9bae8a0"
 dependencies = [
  "anyhow",
  "apache-avro 0.21.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -6918,7 +6918,7 @@ dependencies = [
 [[package]]
 name = "iceberg-catalog-glue"
 version = "0.8.0"
-source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=64a440f15f9d152aa35931fe9b4be066fa40e770#64a440f15f9d152aa35931fe9b4be066fa40e770"
+source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=fc973389f93cb4a0c6be8962ca3ebc7bc9bae8a0#fc973389f93cb4a0c6be8962ca3ebc7bc9bae8a0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6933,7 +6933,7 @@ dependencies = [
 [[package]]
 name = "iceberg-catalog-rest"
 version = "0.8.0"
-source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=64a440f15f9d152aa35931fe9b4be066fa40e770#64a440f15f9d152aa35931fe9b4be066fa40e770"
+source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=fc973389f93cb4a0c6be8962ca3ebc7bc9bae8a0#fc973389f93cb4a0c6be8962ca3ebc7bc9bae8a0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -6955,7 +6955,7 @@ dependencies = [
 [[package]]
 name = "iceberg-compaction-core"
 version = "0.1.0"
-source = "git+https://github.com/nimtable/iceberg-compaction.git?rev=dfc7ee949a2c414536b7a5ae5923a4ddb858c014#dfc7ee949a2c414536b7a5ae5923a4ddb858c014"
+source = "git+https://github.com/nimtable/iceberg-compaction.git?rev=4aad595b7285b2a43e988d70a194208b6056f296#4aad595b7285b2a43e988d70a194208b6056f296"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -6984,7 +6984,7 @@ dependencies = [
 [[package]]
 name = "iceberg-datafusion"
 version = "0.8.0"
-source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=64a440f15f9d152aa35931fe9b4be066fa40e770#64a440f15f9d152aa35931fe9b4be066fa40e770"
+source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=fc973389f93cb4a0c6be8962ca3ebc7bc9bae8a0#fc973389f93cb4a0c6be8962ca3ebc7bc9bae8a0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6859,7 +6859,7 @@ dependencies = [
 [[package]]
 name = "iceberg"
 version = "0.8.0"
-source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=515177b5317886f01cbbe54f235519430e72e219#515177b5317886f01cbbe54f235519430e72e219"
+source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=64a440f15f9d152aa35931fe9b4be066fa40e770#64a440f15f9d152aa35931fe9b4be066fa40e770"
 dependencies = [
  "anyhow",
  "apache-avro 0.21.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -6918,7 +6918,7 @@ dependencies = [
 [[package]]
 name = "iceberg-catalog-glue"
 version = "0.8.0"
-source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=515177b5317886f01cbbe54f235519430e72e219#515177b5317886f01cbbe54f235519430e72e219"
+source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=64a440f15f9d152aa35931fe9b4be066fa40e770#64a440f15f9d152aa35931fe9b4be066fa40e770"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6933,7 +6933,7 @@ dependencies = [
 [[package]]
 name = "iceberg-catalog-rest"
 version = "0.8.0"
-source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=515177b5317886f01cbbe54f235519430e72e219#515177b5317886f01cbbe54f235519430e72e219"
+source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=64a440f15f9d152aa35931fe9b4be066fa40e770#64a440f15f9d152aa35931fe9b4be066fa40e770"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -6955,7 +6955,7 @@ dependencies = [
 [[package]]
 name = "iceberg-compaction-core"
 version = "0.1.0"
-source = "git+https://github.com/nimtable/iceberg-compaction.git?rev=68199414368e094af21cd54191c69f2560409288#68199414368e094af21cd54191c69f2560409288"
+source = "git+https://github.com/nimtable/iceberg-compaction.git?rev=dfc7ee949a2c414536b7a5ae5923a4ddb858c014#dfc7ee949a2c414536b7a5ae5923a4ddb858c014"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -6984,7 +6984,7 @@ dependencies = [
 [[package]]
 name = "iceberg-datafusion"
 version = "0.8.0"
-source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=515177b5317886f01cbbe54f235519430e72e219#515177b5317886f01cbbe54f235519430e72e219"
+source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=64a440f15f9d152aa35931fe9b4be066fa40e770#64a440f15f9d152aa35931fe9b4be066fa40e770"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -161,14 +161,14 @@ hashbrown0_15 = { package = "hashbrown", version = "0.15", features = [
 ] }
 hytra = "0.1"
 # branch dev_rebase_main_20260303
-iceberg = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "64a440f15f9d152aa35931fe9b4be066fa40e770", features = [
+iceberg = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "fc973389f93cb4a0c6be8962ca3ebc7bc9bae8a0", features = [
     "storage-s3",
     "storage-gcs",
     "storage-azblob",
     "storage-azdls",
 ] }
-iceberg-catalog-glue = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "64a440f15f9d152aa35931fe9b4be066fa40e770" }
-iceberg-catalog-rest = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "64a440f15f9d152aa35931fe9b4be066fa40e770" }
+iceberg-catalog-glue = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "fc973389f93cb4a0c6be8962ca3ebc7bc9bae8a0" }
+iceberg-catalog-rest = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "fc973389f93cb4a0c6be8962ca3ebc7bc9bae8a0" }
 
 adbc_core = { version = "0.23" }
 adbc_snowflake = { version = "0.23", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -161,14 +161,14 @@ hashbrown0_15 = { package = "hashbrown", version = "0.15", features = [
 ] }
 hytra = "0.1"
 # branch dev_rebase_main_20260303
-iceberg = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "515177b5317886f01cbbe54f235519430e72e219", features = [
+iceberg = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "64a440f15f9d152aa35931fe9b4be066fa40e770", features = [
     "storage-s3",
     "storage-gcs",
     "storage-azblob",
     "storage-azdls",
 ] }
-iceberg-catalog-glue = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "515177b5317886f01cbbe54f235519430e72e219" }
-iceberg-catalog-rest = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "515177b5317886f01cbbe54f235519430e72e219" }
+iceberg-catalog-glue = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "64a440f15f9d152aa35931fe9b4be066fa40e770" }
+iceberg-catalog-rest = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "64a440f15f9d152aa35931fe9b4be066fa40e770" }
 
 adbc_core = { version = "0.23" }
 adbc_snowflake = { version = "0.23", default-features = false }

--- a/src/storage/Cargo.toml
+++ b/src/storage/Cargo.toml
@@ -33,7 +33,7 @@ futures = { version = "0.3", default-features = false, features = ["alloc"] }
 futures-async-stream = { workspace = true }
 hex = "0.4"
 iceberg = { workspace = true }
-iceberg-compaction-core = { git = "https://github.com/nimtable/iceberg-compaction.git", rev = "dfc7ee949a2c414536b7a5ae5923a4ddb858c014" }
+iceberg-compaction-core = { git = "https://github.com/nimtable/iceberg-compaction.git", rev = "4aad595b7285b2a43e988d70a194208b6056f296" }
 itertools = { workspace = true }
 libc = "0.2"
 lz4 = "1.28.0"

--- a/src/storage/Cargo.toml
+++ b/src/storage/Cargo.toml
@@ -33,7 +33,7 @@ futures = { version = "0.3", default-features = false, features = ["alloc"] }
 futures-async-stream = { workspace = true }
 hex = "0.4"
 iceberg = { workspace = true }
-iceberg-compaction-core = { git = "https://github.com/nimtable/iceberg-compaction.git", rev = "68199414368e094af21cd54191c69f2560409288" }
+iceberg-compaction-core = { git = "https://github.com/nimtable/iceberg-compaction.git", rev = "dfc7ee949a2c414536b7a5ae5923a4ddb858c014" }
 itertools = { workspace = true }
 libc = "0.2"
 lz4 = "1.28.0"


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

COW publication to Iceberg main retains old deletion-only manifests, so metadata can keep growing while the live file set stays small. Update the release-3.0 dependency pins to prune these manifests and merge manifests within the existing overwrite commit.

[iceberg-rust#233](https://github.com/risingwavelabs/iceberg-rust/pull/233) contains the implementation: **15 additions / 6 deletions, no test changes**. Overwrite enables merging by default uniformly across format versions, with the existing 8 MiB / 100-manifest policy and explicit snapshot-property overrides. It also preserves each merge bin's partition spec after partition evolution. No V3-specific handling is included.

Pins: Iceberg `fc973389f93cb4a0c6be8962ca3ebc7bc9bae8a0`; [compaction#188](https://github.com/nimtable/iceberg-compaction/pull/188) `4aad595b7285b2a43e988d70a194208b6056f296` aligns its Iceberg dependencies. These patches are based on the existing release-3.0 pins; there are no unrelated dependency upgrades. Maintenance adds no extra snapshot or data-file rewrite.

Validation:

- All **74 existing transaction tests** passed; the test module is unchanged from the base revision.
- Iceberg Clippy (warnings denied), formatting and diff checks passed.
- Compaction `RUSTUP_TOOLCHAIN=nightly-2025-10-10 make check` passed.
- RW `CXXFLAGS='-include cerrno' cargo +nightly-2025-10-10 check -p risingwave_storage --lib --locked` passed. The local C++ flag supplies a missing header in FAISS; no source workaround is included.
- Retain `ci/run-e2e-iceberg-tests` alongside default PR CI. The updated head requires a fresh CI result.

## Checklist

- [x] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests. (No new tests in this patch; existing tests were run.)
- [x] <!-- OPTIONAL --> I have added test labels as necessary.
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them.
- [ ] <!-- OPTIONAL --> My PR contains breaking changes.
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run benchmarks and present the results.
- [x] <!-- OPTIONAL --> I have checked which release branches I need to cherry-pick this PR into. (Requested release-3.0 fix.)

## Documentation

- [x] <!-- OPTIONAL --> My PR needs documentation updates. (Maintenance behavior; no new configuration option.)

<details>
<summary><b>Release note</b></summary>

Reduce manifest accumulation and metadata I/O for Iceberg copy-on-write sinks by pruning obsolete manifests and merging small data manifests during publication to main.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated underlying catalog and storage components to newer revisions.
  - Maintained existing support for S3, Google Cloud Storage, Azure Blob Storage, and Azure Data Lake Storage.
  - No user-facing configuration, workflow, or functionality changes were introduced.
  - Existing behavior and feature availability remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->