### PR TITLE
fix(iceberg): merge manifests during COW overwrite

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7774,7 +7774,7 @@ dependencies = [
 [[package]]
 name = "iceberg"
 version = "0.10.0"
-source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=cd6e1e6acbfb2e41c9af5b6faedaca5eb83f361c#cd6e1e6acbfb2e41c9af5b6faedaca5eb83f361c"
+source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=54d7ddc4565254fb284d0199edd0f8d331d0e3f9#54d7ddc4565254fb284d0199edd0f8d331d0e3f9"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -7833,7 +7833,7 @@ dependencies = [
 [[package]]
 name = "iceberg-catalog-glue"
 version = "0.10.0"
-source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=cd6e1e6acbfb2e41c9af5b6faedaca5eb83f361c#cd6e1e6acbfb2e41c9af5b6faedaca5eb83f361c"
+source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=54d7ddc4565254fb284d0199edd0f8d331d0e3f9#54d7ddc4565254fb284d0199edd0f8d331d0e3f9"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7848,7 +7848,7 @@ dependencies = [
 [[package]]
 name = "iceberg-catalog-rest"
 version = "0.10.0"
-source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=cd6e1e6acbfb2e41c9af5b6faedaca5eb83f361c#cd6e1e6acbfb2e41c9af5b6faedaca5eb83f361c"
+source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=54d7ddc4565254fb284d0199edd0f8d331d0e3f9#54d7ddc4565254fb284d0199edd0f8d331d0e3f9"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -7869,7 +7869,7 @@ dependencies = [
 [[package]]
 name = "iceberg-compaction-core"
 version = "0.1.0"
-source = "git+https://github.com/nimtable/iceberg-compaction.git?rev=58a4c3c274111b7eeaada0a6f15314ddcf537279#58a4c3c274111b7eeaada0a6f15314ddcf537279"
+source = "git+https://github.com/nimtable/iceberg-compaction.git?rev=eddb0e959dfccca448edc32867438115b92f312b#eddb0e959dfccca448edc32867438115b92f312b"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -7898,7 +7898,7 @@ dependencies = [
 [[package]]
 name = "iceberg-datafusion"
 version = "0.10.0"
-source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=cd6e1e6acbfb2e41c9af5b6faedaca5eb83f361c#cd6e1e6acbfb2e41c9af5b6faedaca5eb83f361c"
+source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=54d7ddc4565254fb284d0199edd0f8d331d0e3f9#54d7ddc4565254fb284d0199edd0f8d331d0e3f9"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7914,7 +7914,7 @@ dependencies = [
 [[package]]
 name = "iceberg-storage-opendal"
 version = "0.10.0"
-source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=cd6e1e6acbfb2e41c9af5b6faedaca5eb83f361c#cd6e1e6acbfb2e41c9af5b6faedaca5eb83f361c"
+source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=54d7ddc4565254fb284d0199edd0f8d331d0e3f9#54d7ddc4565254fb284d0199edd0f8d331d0e3f9"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -176,10 +176,10 @@ hashbrown0_16 = { package = "hashbrown", version = "0.16.1", features = [
 ] }
 hytra = "0.1"
 # branch dev_rebase_main_20260807
-iceberg = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "cd6e1e6acbfb2e41c9af5b6faedaca5eb83f361c" }
-iceberg-catalog-glue = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "cd6e1e6acbfb2e41c9af5b6faedaca5eb83f361c" }
-iceberg-catalog-rest = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "cd6e1e6acbfb2e41c9af5b6faedaca5eb83f361c" }
-iceberg-storage-opendal = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "cd6e1e6acbfb2e41c9af5b6faedaca5eb83f361c", features = [
+iceberg = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "54d7ddc4565254fb284d0199edd0f8d331d0e3f9" }
+iceberg-catalog-glue = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "54d7ddc4565254fb284d0199edd0f8d331d0e3f9" }
+iceberg-catalog-rest = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "54d7ddc4565254fb284d0199edd0f8d331d0e3f9" }
+iceberg-storage-opendal = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "54d7ddc4565254fb284d0199edd0f8d331d0e3f9", features = [
     "opendal-azblob",
     "opendal-azdls",
     "opendal-fs",

--- a/src/storage/Cargo.toml
+++ b/src/storage/Cargo.toml
@@ -34,7 +34,7 @@ futures = { version = "0.3", default-features = false, features = ["alloc"] }
 futures-async-stream = { workspace = true }
 hex = "0.4"
 iceberg = { workspace = true }
-iceberg-compaction-core = { git = "https://github.com/nimtable/iceberg-compaction.git", rev = "58a4c3c274111b7eeaada0a6f15314ddcf537279" }
+iceberg-compaction-core = { git = "https://github.com/nimtable/iceberg-compaction.git", rev = "eddb0e959dfccca448edc32867438115b92f312b" }
 itertools = { workspace = true }
 libc = "0.2"
 lz4 = "1.28.0"


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

Forward-port #26990 to RisingWave main. COW publication should prune obsolete deletion-only manifests and merge small data manifests during the existing overwrite commit, preventing metadata growth while the live file set stays small.

Update the pinned dependencies to [iceberg-rust#234](https://github.com/risingwavelabs/iceberg-rust/pull/234), commit `54d7ddc4565254fb284d0199edd0f8d331d0e3f9`, and a [compaction pin-alignment commit](https://github.com/nimtable/iceberg-compaction/compare/58a4c3c274111b7eeaada0a6f15314ddcf537279...eddb0e959dfccca448edc32867438115b92f312b). Both are based on the exact dependencies already used by RisingWave main; no unrelated upstream dependency changes are pulled in. The lockfile changes only these two Git revisions and resolves a single Iceberg source.

Main's Iceberg dependency line no longer contains the old inline merge implementation, so the dependency patch adapts it into one private snapshot-producer helper. It retains the 8 MiB target / 100-manifest first-bin threshold, groups by partition spec, preserves original entry sequences and the current commit's added/deleted entries, and honors explicit property overrides. It adds no extra snapshot or data-file rewrite. No tests or V3-specific handling are added.

Validation:

- 141 existing Iceberg transaction tests pass; the affected test modules are unchanged.
- Iceberg Clippy with warnings denied and workspace formatting pass.
- Compaction `RUSTUP_TOOLCHAIN=nightly-2026-03-05 make check` passes.
- RW `CXXFLAGS='-include cerrno' cargo +nightly-2026-06-21 check -p risingwave_storage --lib --locked` passes. The local C++ flag supplies a missing FAISS header and is not part of the source change.
- RW formatting, locked metadata resolution and diff checks pass.
- External in-memory smoke validation: start with 100 manifests and execute three partial overwrites; each yields one manifest with exactly 100 expected live files and the current deletion, preserving original sequences, historical manifest readability and exactly one snapshot per operation. The smoke program is not part of any PR.
- Request Iceberg e2e coverage alongside default PR CI.

## Checklist

- [x] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests. (No new tests; existing tests and external smoke validation pass.)
- [x] <!-- OPTIONAL --> I have added test labels as necessary.
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them.
- [ ] <!-- OPTIONAL --> My PR contains breaking changes.
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run benchmarks and present the results.
- [x] <!-- OPTIONAL --> I have checked which release branches need this fix. (release-3.0 counterpart: #26990.)

## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. (Internal manifest maintenance; no supported user interface or operational workflow changes.)

<details>
<summary><b>Release note</b></summary>

Reduce Iceberg copy-on-write manifest accumulation and metadata overhead during publication.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated underlying table-format and storage components to newer revisions.
  - Included the latest available improvements and compatibility updates from these components.
  - Added an internal performance benchmark for storage-related operations.
  - No user-facing configuration or feature changes were introduced.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->