### PR TITLE
fix(storage): honor logical SST key ranges in iterators

### DIFF
--- a/src/storage/src/hummock/iterator/backward_concat.rs
+++ b/src/storage/src/hummock/iterator/backward_concat.rs
@@ -23,6 +23,8 @@ pub type BackwardConcatIterator = ConcatIteratorInner<BackwardSstableIterator>;
 mod tests {
     use std::sync::Arc;
 
+    use bytes::Bytes;
+
     use super::*;
     use crate::hummock::iterator::HummockIterator;
     use crate::hummock::iterator::test_utils::{
@@ -88,6 +90,43 @@ mod tests {
             val.into_user_value().unwrap(),
             iterator_test_value_of(TEST_KEYS_COUNT * 3 - 1).as_slice()
         );
+    }
+
+    #[tokio::test]
+    async fn test_backward_concat_logical_ssts_sharing_one_object() {
+        let sstable_store = mock_sstable_store().await;
+        let physical_sst = gen_iterator_test_sstable_info(
+            0,
+            default_builder_opt_for_test(),
+            |x| x,
+            sstable_store.clone(),
+            TEST_KEYS_COUNT,
+        )
+        .await;
+        let split_key = Bytes::from(iterator_test_key_of(TEST_KEYS_COUNT / 2).encode());
+
+        let mut left = physical_sst.get_inner();
+        left.sst_id = 100.into();
+        left.key_range.right = split_key.clone();
+        left.key_range.right_exclusive = true;
+        let mut right = physical_sst.get_inner();
+        right.sst_id = 101.into();
+        right.key_range.left = split_key;
+
+        let mut iter = BackwardConcatIterator::new(
+            vec![right.into(), left.into()],
+            sstable_store,
+            Arc::new(SstableIteratorReadOptions::default()),
+        );
+        iter.rewind().await.unwrap();
+
+        let mut index = TEST_KEYS_COUNT;
+        while iter.is_valid() {
+            index -= 1;
+            assert_eq!(iter.key(), iterator_test_key_of(index).to_ref());
+            iter.next().await.unwrap();
+        }
+        assert_eq!(index, 0);
     }
 
     #[tokio::test]

--- a/src/storage/src/hummock/iterator/forward_concat.rs
+++ b/src/storage/src/hummock/iterator/forward_concat.rs
@@ -22,6 +22,7 @@ pub type ConcatIterator = ConcatIteratorInner<SstableIterator>;
 mod tests {
     use std::sync::Arc;
 
+    use bytes::Bytes;
     #[cfg(feature = "failpoints")]
     use foyer::Hint;
 
@@ -96,6 +97,43 @@ mod tests {
             val.into_user_value().unwrap(),
             iterator_test_value_of(0).as_slice()
         );
+    }
+
+    #[tokio::test]
+    async fn test_concat_logical_ssts_sharing_one_object() {
+        let sstable_store = mock_sstable_store().await;
+        let physical_sst = gen_iterator_test_sstable_info(
+            0,
+            default_builder_opt_for_test(),
+            |x| x,
+            sstable_store.clone(),
+            TEST_KEYS_COUNT,
+        )
+        .await;
+        let split_key = Bytes::from(iterator_test_key_of(TEST_KEYS_COUNT / 2).encode());
+
+        let mut left = physical_sst.get_inner();
+        left.sst_id = 100.into();
+        left.key_range.right = split_key.clone();
+        left.key_range.right_exclusive = true;
+        let mut right = physical_sst.get_inner();
+        right.sst_id = 101.into();
+        right.key_range.left = split_key;
+
+        let mut iter = ConcatIterator::new(
+            vec![left.into(), right.into()],
+            sstable_store,
+            Arc::new(SstableIteratorReadOptions::default()),
+        );
+        iter.rewind().await.unwrap();
+
+        let mut index = 0;
+        while iter.is_valid() {
+            assert_eq!(iter.key(), iterator_test_key_of(index).to_ref());
+            index += 1;
+            iter.next().await.unwrap();
+        }
+        assert_eq!(index, TEST_KEYS_COUNT);
     }
 
     #[tokio::test]

--- a/src/storage/src/hummock/sstable/backward_sstable_iterator.rs
+++ b/src/storage/src/hummock/sstable/backward_sstable_iterator.rs
@@ -17,6 +17,7 @@ use std::sync::Arc;
 
 use foyer::Hint;
 use risingwave_hummock_sdk::key::FullKey;
+use risingwave_hummock_sdk::key_range::KeyRange;
 use risingwave_hummock_sdk::sstable_info::SstableInfo;
 
 use crate::hummock::iterator::{Backward, HummockIterator, ValueMeta};
@@ -44,6 +45,7 @@ pub struct BackwardSstableIterator {
 
     // used for checking if the block is valid, filter out the block that is not in the table-id range
     read_block_meta_range: (usize, usize),
+    key_range: KeyRange,
 }
 
 impl BackwardSstableIterator {
@@ -133,7 +135,12 @@ impl BackwardSstableIterator {
             sstable_store,
             stats: StoreLocalStatistic::default(),
             read_block_meta_range: (start_idx, end_idx),
+            key_range: sstable_info_ref.key_range.clone(),
         }
+    }
+
+    fn block_iter_is_valid(&self) -> bool {
+        self.block_iter.as_ref().is_some_and(|iter| iter.is_valid())
     }
 
     /// Seeks to a block, and then seeks to the key if `seek_key` is given.
@@ -194,17 +201,28 @@ impl HummockIterator for BackwardSstableIterator {
     }
 
     fn is_valid(&self) -> bool {
-        self.block_iter.as_ref().is_some_and(|i| i.is_valid())
+        self.block_iter_is_valid() && super::full_key_in_range(&self.key_range, self.key())
     }
 
     /// Instead of setting idx to 0th block, a `BackwardSstableIterator` rewinds to the last block
     /// in the sstable.
     async fn rewind(&mut self) -> HummockResult<()> {
-        self.seek_idx(self.read_block_meta_range.1 as isize, None)
-            .await
+        if self.key_range.right.is_empty() {
+            self.seek_idx(self.read_block_meta_range.1 as isize, None)
+                .await
+        } else {
+            let right = self.key_range.right.clone();
+            self.seek(FullKey::decode(&right)).await
+        }
     }
 
     async fn seek<'a>(&'a mut self, key: FullKey<&'a [u8]>) -> HummockResult<()> {
+        let right = self.key_range.right.clone();
+        let key = if !right.is_empty() && FullKey::decode(&right).lt(&key) {
+            FullKey::decode(&right)
+        } else {
+            key
+        };
         let block_idx = self
             .sst
             .meta
@@ -220,9 +238,17 @@ impl HummockIterator for BackwardSstableIterator {
         let block_idx = block_idx as isize;
 
         self.seek_idx(block_idx, Some(key)).await?;
-        if !self.is_valid() {
+        if !self.block_iter_is_valid() {
             // Seek to prev block
             self.seek_idx(block_idx - 1, None).await?;
+        }
+
+        if self.block_iter_is_valid()
+            && !right.is_empty()
+            && self.key_range.right_exclusive
+            && self.key() == FullKey::decode(&right)
+        {
+            self.next().await?;
         }
 
         Ok(())

--- a/src/storage/src/hummock/sstable/forward_sstable_iterator.rs
+++ b/src/storage/src/hummock/sstable/forward_sstable_iterator.rs
@@ -17,6 +17,7 @@ use std::sync::Arc;
 
 use await_tree::{InstrumentAwait, SpanExt};
 use risingwave_hummock_sdk::key::FullKey;
+use risingwave_hummock_sdk::key_range::KeyRange;
 use risingwave_hummock_sdk::sstable_info::SstableInfo;
 use sync_point::sync_point;
 use thiserror_ext::AsReport;
@@ -60,6 +61,7 @@ pub struct SstableIterator {
     // precisely inside the boundary block.
     block_start_idx_inclusive: usize,
     block_end_idx_exclusive: usize,
+    key_range: KeyRange,
 }
 
 impl SstableIterator {
@@ -172,7 +174,12 @@ impl SstableIterator {
             preload_retry_times: 0,
             block_start_idx_inclusive,
             block_end_idx_exclusive,
+            key_range: sstable_info_ref.key_range.clone(),
         }
+    }
+
+    fn block_iter_is_valid(&self) -> bool {
+        self.block_iter.as_ref().is_some_and(|iter| iter.is_valid())
     }
 
     fn init_block_prefetch_range(&mut self, start_idx: usize) {
@@ -358,7 +365,7 @@ impl HummockIterator for SstableIterator {
     }
 
     fn is_valid(&self) -> bool {
-        self.block_iter.as_ref().is_some_and(|i| i.is_valid())
+        self.block_iter_is_valid() && super::full_key_in_range(&self.key_range, self.key())
     }
 
     async fn rewind(&mut self) -> HummockResult<()> {
@@ -366,10 +373,14 @@ impl HummockIterator for SstableIterator {
             self.block_iter = None;
             return Ok(());
         }
-        self.init_block_prefetch_range(self.block_start_idx_inclusive);
-        // seek_idx will update the current block iter state
-        self.seek_idx(self.block_start_idx_inclusive, None).await?;
-        Ok(())
+        if self.key_range.left.is_empty() {
+            self.init_block_prefetch_range(self.block_start_idx_inclusive);
+            // seek_idx will update the current block iter state
+            self.seek_idx(self.block_start_idx_inclusive, None).await
+        } else {
+            let left = self.key_range.left.clone();
+            self.seek(FullKey::decode(&left)).await
+        }
     }
 
     async fn seek<'a>(&'a mut self, key: FullKey<&'a [u8]>) -> HummockResult<()> {
@@ -377,11 +388,17 @@ impl HummockIterator for SstableIterator {
             self.block_iter = None;
             return Ok(());
         }
+        let left = self.key_range.left.clone();
+        let key = if !left.is_empty() && FullKey::decode(&left).gt(&key) {
+            FullKey::decode(&left)
+        } else {
+            key
+        };
         let block_idx = self.calculate_block_idx_by_key(key);
         self.init_block_prefetch_range(block_idx);
 
         self.seek_idx(block_idx, Some(key)).await?;
-        if !self.is_valid() {
+        if !self.block_iter_is_valid() {
             // seek to next block
             sync_point!("SSTABLE_ITERATOR::SEEK::BEFORE_NEXT_BLOCK");
             self.seek_idx(block_idx + 1, None).await?;

--- a/src/storage/src/hummock/sstable/mod.rs
+++ b/src/storage/src/hummock/sstable/mod.rs
@@ -43,6 +43,7 @@ use tracing::warn;
 mod backward_sstable_iterator;
 pub use backward_sstable_iterator::*;
 use risingwave_hummock_sdk::key::{FullKey, KeyPayloadType, UserKey, UserKeyRangeRef};
+use risingwave_hummock_sdk::key_range::KeyRange;
 use risingwave_hummock_sdk::{HummockEpoch, HummockSstableObjectId};
 
 mod filter;
@@ -63,6 +64,17 @@ use crate::store::ReadOptions;
 const MAGIC: u32 = 0x5785ab73;
 const OLD_VERSION: u32 = 1;
 const VERSION: u32 = 2;
+
+fn full_key_in_range(key_range: &KeyRange, key: FullKey<&[u8]>) -> bool {
+    let after_left = key_range.left.is_empty() || FullKey::decode(&key_range.left).le(&key);
+    let before_right = key_range.right.is_empty()
+        || if key_range.right_exclusive {
+            key.lt(&FullKey::decode(&key_range.right))
+        } else {
+            key.le(&FullKey::decode(&key_range.right))
+        };
+    after_left && before_right
+}
 
 /// Assume that watermark1 is 5, watermark2 is 7, watermark3 is 11, delete ranges
 /// `{ [0, wmk1) in epoch1, [wmk1, wmk2) in epoch2, [wmk2, wmk3) in epoch3 }`


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

This is stack 1/3 for commit-time vnode-partitioned L0 SSTs.

- Make forward and backward SST iterators stop at the logical `SstableInfo.key_range` instead of reading through the full physical object range.
- Apply the same logical bounds when concat iterators seek across adjacent SST metadata entries.
- Add forward and backward regression tests where two logical SSTs share one object but expose disjoint key ranges.

This is a correctness prerequisite for metadata-only SST splitting: one physical object may be represented by multiple logical SST entries, and each entry must remain confined to its own range.

## Checklist

- [x] I have written necessary rustdoc comments.
- [x] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [x] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/dev/src/ci.md#ci-labels-guide -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

Not applicable. This is an internal storage correctness change.

</details>
