### PR TITLE
feat(storage): partition single-table L0 at commit epoch

### DIFF
--- a/src/meta/src/hummock/manager/commit_epoch.rs
+++ b/src/meta/src/hummock/manager/commit_epoch.rs
@@ -15,10 +15,12 @@
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::sync::Arc;
 
+use bytes::Bytes;
 use itertools::Itertools;
 use risingwave_common::bail;
 use risingwave_common::catalog::TableId;
 use risingwave_common::config::meta::default::compaction_config;
+use risingwave_common::hash::VnodeCountCompat;
 use risingwave_common::system_param::reader::SystemParamsRead;
 use risingwave_hummock_sdk::change_log::EpochNewChangeLog;
 use risingwave_hummock_sdk::compaction_group::group_split::split_sst_with_table_ids;
@@ -29,8 +31,9 @@ use risingwave_hummock_sdk::table_stats::{
 use risingwave_hummock_sdk::table_watermark::TableWatermarks;
 use risingwave_hummock_sdk::vector_index::VectorIndexDelta;
 use risingwave_hummock_sdk::version::HummockVersionStateTableInfo;
+use risingwave_hummock_sdk::vnode_partition::build_vnode_partition_boundary_keys;
 use risingwave_hummock_sdk::{
-    CompactionGroupId, HummockContextId, HummockSstableObjectId, LocalSstableInfo,
+    CompactionGroupId, HummockContextId, HummockSstableId, HummockSstableObjectId, LocalSstableInfo,
 };
 use risingwave_pb::hummock::{CompactionConfig, compact_task};
 use sea_orm::TransactionTrait;
@@ -38,7 +41,7 @@ use sea_orm::TransactionTrait;
 use crate::hummock::error::{Error, Result};
 use crate::hummock::manager::compaction_group_manager::CompactionGroupManager;
 use crate::hummock::manager::transaction::{
-    HummockVersionStatsTransaction, HummockVersionTransaction,
+    CommitSubLevel, HummockVersionStatsTransaction, HummockVersionTransaction,
 };
 use crate::hummock::manager::versioning::Versioning;
 use crate::hummock::metrics_utils::{
@@ -49,8 +52,19 @@ use crate::hummock::sequence::{next_compaction_group_id, next_sstable_id};
 use crate::hummock::time_travel::should_mark_next_time_travel_version_snapshot;
 use crate::hummock::{HummockManager, commit_multi_var_with_provided_txn};
 
+mod commit_epoch_vnode_partition;
+
+use commit_epoch_vnode_partition::{
+    build_nonoverlapping_layers, chunk_nonoverlapping_layer_by_size, count_boundaries_in_key_range,
+    split_sst_by_boundary_keys,
+};
+
 pub struct NewTableFragmentInfo {
     pub table_ids: HashSet<TableId>,
+}
+
+struct VnodeEligibility {
+    boundary_keys: Vec<Bytes>,
 }
 
 #[derive(Default)]
@@ -209,8 +223,14 @@ impl HummockManager {
             }
         }
 
-        let group_id_to_sub_levels =
-            rewrite_commit_sstables_to_sub_level(commit_sstables, &group_id_to_config);
+        let group_id_to_sub_levels = self
+            .rewrite_commit_sstables_to_sub_level(
+                commit_sstables,
+                &group_id_to_config,
+                state_table_info,
+                &new_table_ids,
+            )
+            .await?;
 
         // build group_id to truncate tables
         let mut group_id_to_truncate_tables: HashMap<CompactionGroupId, HashSet<TableId>> =
@@ -501,6 +521,194 @@ impl HummockManager {
 
         Ok(commit_sstables)
     }
+
+    async fn rewrite_commit_sstables_to_sub_level(
+        &self,
+        commit_sstables: BTreeMap<CompactionGroupId, Vec<SstableInfo>>,
+        group_id_to_config: &HashMap<CompactionGroupId, Arc<CompactionConfig>>,
+        state_table_info: &HummockVersionStateTableInfo,
+        new_table_ids: &HashMap<TableId, CompactionGroupId>,
+    ) -> Result<BTreeMap<CompactionGroupId, Vec<CommitSubLevel>>> {
+        struct VnodeSplitPlan {
+            group_id: CompactionGroupId,
+            boundary_keys: Vec<Bytes>,
+            inserted_ssts: Vec<SstableInfo>,
+            sub_level_size_limit: u64,
+            split_count: u64,
+            vnode_partition_count: u32,
+        }
+
+        let mut result = BTreeMap::new();
+        let mut vnode_plans: Vec<VnodeSplitPlan> = vec![];
+        let mut total_new_sst_id_needed: u64 = 0;
+
+        for (group_id, inserted_ssts) in commit_sstables {
+            let config = group_id_to_config
+                .get(&group_id)
+                .expect("compaction group should exist");
+            let sub_level_size_limit = config
+                .max_overlapping_level_size
+                .unwrap_or(compaction_config::max_overlapping_level_size());
+
+            if inserted_ssts.is_empty() {
+                result.insert(group_id, vec![]);
+                continue;
+            }
+
+            let Some(VnodeEligibility { boundary_keys, .. }) = self
+                .vnode_partition_eligibility(
+                    group_id,
+                    &inserted_ssts,
+                    state_table_info,
+                    new_table_ids,
+                    config,
+                )
+                .await
+            else {
+                result.insert(
+                    group_id,
+                    rewrite_commit_sstables_to_sub_level_by_size(
+                        inserted_ssts,
+                        sub_level_size_limit,
+                    ),
+                );
+                continue;
+            };
+
+            let vnode_partition_count = config.split_weight_by_vnode;
+            let mut split_count = 0u64;
+            for sst in &inserted_ssts {
+                split_count += count_boundaries_in_key_range(&sst.key_range, &boundary_keys) as u64;
+            }
+
+            total_new_sst_id_needed += split_count * 2;
+            vnode_plans.push(VnodeSplitPlan {
+                group_id,
+                boundary_keys,
+                inserted_ssts,
+                sub_level_size_limit,
+                split_count,
+                vnode_partition_count,
+            });
+        }
+
+        let mut new_sst_id: HummockSstableId = if total_new_sst_id_needed > 0 {
+            next_sstable_id(&self.env, total_new_sst_id_needed).await?
+        } else {
+            0.into()
+        };
+
+        for plan in vnode_plans {
+            let mut fragments: Vec<SstableInfo> =
+                Vec::with_capacity(plan.inserted_ssts.len() + plan.split_count as usize);
+
+            for sst in plan.inserted_ssts {
+                fragments.extend(split_sst_by_boundary_keys(
+                    sst,
+                    &plan.boundary_keys,
+                    &mut new_sst_id,
+                ));
+            }
+
+            let layers = build_nonoverlapping_layers(fragments);
+
+            let mut sub_levels = vec![];
+            for layer in layers {
+                let chunks = chunk_nonoverlapping_layer_by_size(layer, plan.sub_level_size_limit);
+                sub_levels.extend(chunks.into_iter().map(|ssts| CommitSubLevel {
+                    ssts,
+                    vnode_partition_count: plan.vnode_partition_count,
+                }));
+            }
+
+            result.insert(plan.group_id, sub_levels);
+        }
+
+        Ok(result)
+    }
+
+    async fn vnode_partition_eligibility(
+        &self,
+        group_id: CompactionGroupId,
+        inserted_ssts: &[SstableInfo],
+        state_table_info: &HummockVersionStateTableInfo,
+        new_table_ids: &HashMap<TableId, CompactionGroupId>,
+        config: &CompactionConfig,
+    ) -> Option<VnodeEligibility> {
+        let partition_count = config.split_weight_by_vnode as usize;
+        let mut member_table_ids = state_table_info
+            .compaction_group_member_table_ids(group_id)
+            .iter()
+            .copied()
+            .chain(new_table_ids.iter().filter_map(|(table_id, new_group_id)| {
+                (*new_group_id == group_id).then_some(*table_id)
+            }));
+        let table_id = member_table_ids.next()?;
+        if member_table_ids.next().is_some() {
+            return None;
+        }
+
+        if partition_count <= 1
+            || !inserted_ssts.iter().all(|sst| {
+                sst.table_ids.len() == 1
+                    && sst.table_ids[0] == table_id
+                    && !sst.key_range.inf_key_range()
+                    && !sst.key_range.left.is_empty()
+                    && !sst.key_range.right.is_empty()
+            })
+        {
+            return None;
+        }
+
+        let vnode_count = if let Some(vnode_count) =
+            self.table_id_to_vnode_count.read().get(&table_id).copied()
+        {
+            vnode_count
+        } else {
+            let table = match self
+                .metadata_manager
+                .get_table_catalog_by_ids(&[table_id])
+                .await
+            {
+                Ok(mut tables) => tables.pop(),
+                Err(e) => {
+                    tracing::warn!(
+                        error = %e,
+                        %group_id,
+                        %table_id,
+                        "failed to get table catalog for vnode split in commit_epoch, fallback to overlapping",
+                    );
+                    None
+                }
+            }?;
+            if table.maybe_vnode_count == Some(0) {
+                return None;
+            }
+            let vnode_count = table.vnode_count();
+            self.table_id_to_vnode_count
+                .write()
+                .insert(table_id, vnode_count);
+            vnode_count
+        };
+        if partition_count > vnode_count {
+            tracing::warn!(
+                %group_id,
+                %table_id,
+                vnode_count,
+                partition_count,
+                "partition_count > vnode_count in commit_epoch, fallback to overlapping",
+            );
+            return None;
+        }
+
+        Some(VnodeEligibility {
+            boundary_keys: build_vnode_partition_boundary_keys(
+                table_id,
+                vnode_count,
+                partition_count,
+            ),
+        })
+    }
 }
 
 fn on_handle_add_new_table(
@@ -524,48 +732,37 @@ fn on_handle_add_new_table(
     Ok(())
 }
 
-/// Rewrite the commit sstables to sub-levels based on the compaction group config.
-/// The type of `compaction_group_manager_txn` is too complex to be used in the function signature. So we use `HashMap` instead.
-fn rewrite_commit_sstables_to_sub_level(
-    commit_sstables: BTreeMap<CompactionGroupId, Vec<SstableInfo>>,
-    group_id_to_config: &HashMap<CompactionGroupId, Arc<CompactionConfig>>,
-) -> BTreeMap<CompactionGroupId, Vec<Vec<SstableInfo>>> {
-    let mut overlapping_sstables: BTreeMap<CompactionGroupId, Vec<Vec<SstableInfo>>> =
-        BTreeMap::new();
-    for (group_id, inserted_table_infos) in commit_sstables {
-        let config = group_id_to_config
-            .get(&group_id)
-            .expect("compaction group should exist");
+fn rewrite_commit_sstables_to_sub_level_by_size(
+    inserted_ssts: Vec<SstableInfo>,
+    sub_level_size_limit: u64,
+) -> Vec<CommitSubLevel> {
+    let mut accumulated_size = 0;
+    let mut ssts = vec![];
+    let mut sub_levels = vec![];
 
-        let mut accumulated_size = 0;
-        let mut ssts = vec![];
-        let sub_level_size_limit = config
-            .max_overlapping_level_size
-            .unwrap_or(compaction_config::max_overlapping_level_size());
-
-        let level = overlapping_sstables.entry(group_id).or_default();
-
-        for sst in inserted_table_infos {
-            accumulated_size += sst.sst_size;
-            ssts.push(sst);
-            if accumulated_size > sub_level_size_limit {
-                level.push(ssts);
-
-                // reset the accumulated size and ssts
-                accumulated_size = 0;
-                ssts = vec![];
-            }
+    for sst in inserted_ssts {
+        accumulated_size += sst.sst_size;
+        ssts.push(sst);
+        if accumulated_size > sub_level_size_limit {
+            sub_levels.push(ssts);
+            accumulated_size = 0;
+            ssts = vec![];
         }
-
-        if !ssts.is_empty() {
-            level.push(ssts);
-        }
-
-        // The uploader organizes the ssts in decreasing epoch order, so the level needs to be reversed to ensure that the latest epoch is at the top.
-        level.reverse();
     }
 
-    overlapping_sstables
+    if !ssts.is_empty() {
+        sub_levels.push(ssts);
+    }
+
+    // The uploader organizes the ssts in decreasing epoch order, so the level needs to be reversed to ensure that the latest epoch is at the top.
+    sub_levels.reverse();
+    sub_levels
+        .into_iter()
+        .map(|ssts| CommitSubLevel {
+            ssts,
+            vnode_partition_count: 0,
+        })
+        .collect()
 }
 
 fn is_ordered_subset<T: PartialEq>(vec_1: &Vec<T>, vec_2: &Vec<T>) -> bool {

--- a/src/meta/src/hummock/manager/commit_epoch/commit_epoch_vnode_partition.rs
+++ b/src/meta/src/hummock/manager/commit_epoch/commit_epoch_vnode_partition.rs
@@ -1,0 +1,462 @@
+use bytes::Bytes;
+use risingwave_hummock_sdk::compaction_group::group_split::split_sst_at_vnode_boundary;
+use risingwave_hummock_sdk::key_range::{KeyRange, KeyRangeCommon};
+use risingwave_hummock_sdk::sstable_info::SstableInfo;
+use risingwave_hummock_sdk::{HummockSstableId, KeyComparator};
+
+fn boundary_in_key_range(boundary: &[u8], key_range: &KeyRange) -> bool {
+    if key_range.left.is_empty() || key_range.right.is_empty() {
+        return false;
+    }
+
+    // Require boundary > left to avoid generating empty left range.
+    if !KeyComparator::compare_encoded_full_key(boundary, &key_range.left).is_gt() {
+        return false;
+    }
+
+    // Require boundary < right. `boundary == right` doesn't indicate cross-partition and would
+    // create a tiny tail range.
+    KeyComparator::compare_encoded_full_key(boundary, &key_range.right).is_lt()
+}
+
+pub fn count_boundaries_in_key_range(key_range: &KeyRange, boundary_keys: &[Bytes]) -> usize {
+    boundary_keys
+        .iter()
+        .filter(|b| boundary_in_key_range(b.as_ref(), key_range))
+        .count()
+}
+
+pub fn split_sst_by_boundary_keys(
+    sst: SstableInfo,
+    boundary_keys: &[Bytes],
+    new_sst_id: &mut HummockSstableId,
+) -> Vec<SstableInfo> {
+    let key_range = &sst.key_range;
+    let split_points: Vec<_> = boundary_keys
+        .iter()
+        .filter(|b| boundary_in_key_range(b.as_ref(), key_range))
+        .cloned()
+        .collect();
+
+    if split_points.is_empty() {
+        return vec![sst];
+    }
+
+    let piece_count = split_points.len() + 1;
+    let sizes = allocate_sstable_split_sizes(sst.sst_size, piece_count);
+    debug_assert_eq!(sizes.len(), piece_count);
+
+    let mut pieces = Vec::with_capacity(piece_count);
+    let mut remaining = sst;
+    for (idx, split_key) in split_points.into_iter().enumerate() {
+        let right_size = sizes[idx + 1..].iter().sum();
+        let (left, right) =
+            split_sst_at_vnode_boundary(remaining, new_sst_id, split_key, sizes[idx], right_size);
+        pieces.push(left.expect("vnode boundary must leave a non-empty left SST"));
+        remaining = right.expect("vnode boundary must leave a non-empty right SST");
+    }
+    pieces.push(remaining);
+
+    pieces
+}
+
+fn allocate_sstable_split_sizes(total: u64, parts: usize) -> Vec<u64> {
+    if parts == 0 {
+        return vec![];
+    }
+    let base = total / parts as u64;
+    let remainder = (total % parts as u64) as usize;
+    (0..parts)
+        .map(|i| std::cmp::max(1, base + if i < remainder { 1 } else { 0 }))
+        .collect()
+}
+
+/// Build layers from SSTs in uploader order (newest first), returning oldest first for commit.
+/// Overlapping older SSTs must be below every overlapping newer SST. Place each SST at the
+/// shallowest depth satisfying that constraint; disjoint SSTs can still share a layer.
+pub fn build_nonoverlapping_layers(ssts: Vec<SstableInfo>) -> Vec<Vec<SstableInfo>> {
+    // Layer indices are read depths here: newer layers have smaller indices.
+    let mut layers: Vec<Vec<SstableInfo>> = vec![];
+
+    for sst in ssts {
+        let target_layer_idx = layers
+            .iter()
+            .rposition(|layer| {
+                layer
+                    .iter()
+                    .any(|newer| newer.key_range.sstable_overlap(&sst.key_range))
+            })
+            .map_or(0, |idx| idx + 1);
+        if target_layer_idx == layers.len() {
+            layers.push(vec![]);
+        }
+        layers[target_layer_idx].push(sst);
+    }
+
+    for layer in &mut layers {
+        layer.sort_by(|a, b| a.key_range.cmp(&b.key_range));
+    }
+
+    debug_assert!(
+        layers
+            .iter()
+            .all(|layer| risingwave_hummock_sdk::can_concat(layer))
+    );
+    // Hummock stores L0 sub-levels oldest first and reads them in reverse order.
+    layers.reverse();
+    layers
+}
+
+pub fn chunk_nonoverlapping_layer_by_size(
+    layer: Vec<SstableInfo>,
+    sub_level_size_limit: u64,
+) -> Vec<Vec<SstableInfo>> {
+    let mut out = vec![];
+    let mut current = vec![];
+    let mut accumulated_size = 0u64;
+
+    for sst in layer {
+        accumulated_size += sst.sst_size;
+        current.push(sst);
+        if accumulated_size > sub_level_size_limit {
+            out.push(current);
+            current = vec![];
+            accumulated_size = 0;
+        }
+    }
+    if !current.is_empty() {
+        out.push(current);
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use risingwave_common::catalog::TableId;
+    use risingwave_common::hash::VirtualNode;
+    use risingwave_common::util::epoch::test_epoch;
+    use risingwave_hummock_sdk::key::{FullKey, TableKey};
+    use risingwave_hummock_sdk::sstable_info::SstableInfoInner;
+    use risingwave_hummock_sdk::vnode_partition::build_vnode_partition_boundary_keys;
+
+    use super::*;
+
+    fn fk(table_id: TableId, vnode: usize) -> Bytes {
+        FullKey::new(
+            table_id,
+            TableKey(VirtualNode::from_index(vnode).to_be_bytes().to_vec()),
+            u64::MAX,
+        )
+        .encode()
+        .into()
+    }
+
+    #[test]
+    fn test_build_vnode_partition_boundary_keys() {
+        let table_id = TableId::new(1);
+        let keys = build_vnode_partition_boundary_keys(table_id, 256, 8);
+        assert_eq!(keys.len(), 7);
+        assert_eq!(keys[0], fk(table_id, 32));
+        assert_eq!(keys[6], fk(table_id, 224));
+    }
+
+    #[test]
+    fn test_count_boundaries_in_key_range() {
+        let table_id = TableId::new(1);
+        let keys = build_vnode_partition_boundary_keys(table_id, 256, 8);
+        let kr = KeyRange {
+            left: fk(table_id, 0),
+            right: fk(table_id, 64),
+            right_exclusive: true,
+        };
+        assert_eq!(count_boundaries_in_key_range(&kr, &keys), 1);
+    }
+
+    #[test]
+    fn test_split_sst_by_boundary_keys() {
+        let table_id = TableId::new(1);
+        let keys = build_vnode_partition_boundary_keys(table_id, 256, 8);
+        let sst: SstableInfo = SstableInfoInner {
+            object_id: 1.into(),
+            sst_id: 10.into(),
+            key_range: KeyRange {
+                left: fk(table_id, 0),
+                right: fk(table_id, 64),
+                right_exclusive: true,
+            },
+            file_size: 10,
+            table_ids: vec![table_id],
+            meta_offset: 0,
+            stale_key_count: 0,
+            total_key_count: 0,
+            min_epoch: 1,
+            max_epoch: 1,
+            uncompressed_file_size: 10,
+            range_tombstone_count: 0,
+            filter_type: Default::default(),
+            filter_layout: Default::default(),
+            vnode_statistics: None,
+            sst_size: 10,
+        }
+        .into();
+
+        let mut new_sst_id: HummockSstableId = 100u64.into();
+        let pieces = split_sst_by_boundary_keys(sst, &keys, &mut new_sst_id);
+        assert_eq!(pieces.len(), 2);
+        let sst_id_100: HummockSstableId = 100u64.into();
+        let sst_id_101: HummockSstableId = 101u64.into();
+        let sst_id_102: HummockSstableId = 102u64.into();
+        assert_eq!(pieces[0].sst_id, sst_id_101);
+        assert_eq!(pieces[0].key_range.left, fk(table_id, 0));
+        assert_eq!(pieces[0].key_range.right, fk(table_id, 32));
+        assert!(pieces[0].key_range.right_exclusive);
+        assert_eq!(pieces[1].sst_id, sst_id_100);
+        assert_eq!(pieces[1].key_range.left, fk(table_id, 32));
+        assert_eq!(pieces[1].key_range.right, fk(table_id, 64));
+        assert!(pieces[1].key_range.right_exclusive);
+        assert_eq!(pieces[0].table_ids, vec![table_id]);
+        assert_eq!(pieces[1].table_ids, vec![table_id]);
+        assert_eq!(new_sst_id, sst_id_102);
+    }
+
+    #[test]
+    fn test_build_nonoverlapping_layers() {
+        let table_id = TableId::new(1);
+        let make_sst = |sst_id: u64, left_v: usize, right_v: usize| {
+            SstableInfoInner {
+                object_id: sst_id.into(),
+                sst_id: sst_id.into(),
+                key_range: KeyRange {
+                    left: fk(table_id, left_v),
+                    right: fk(table_id, right_v),
+                    right_exclusive: true,
+                },
+                file_size: 10,
+                table_ids: vec![table_id],
+                meta_offset: 0,
+                stale_key_count: 0,
+                total_key_count: 0,
+                min_epoch: 1,
+                max_epoch: 1,
+                uncompressed_file_size: 10,
+                range_tombstone_count: 0,
+                filter_type: Default::default(),
+                filter_layout: Default::default(),
+                vnode_statistics: None,
+                sst_size: 10,
+            }
+            .into()
+        };
+
+        let ssts = vec![
+            make_sst(1, 0, 64),
+            make_sst(2, 32, 96),
+            make_sst(3, 96, 128),
+        ];
+        let layers = build_nonoverlapping_layers(ssts);
+        assert_eq!(layers.len(), 2);
+        for layer in layers {
+            assert!(risingwave_hummock_sdk::can_concat(&layer));
+        }
+    }
+
+    fn ordered_sst(id: u64, left: usize, right: usize, epoch: u64) -> SstableInfo {
+        let epoch = test_epoch(epoch);
+        let table_id = TableId::new(1);
+        let key = |vnode| {
+            FullKey::new(
+                table_id,
+                TableKey(VirtualNode::from_index(vnode).to_be_bytes().to_vec()),
+                epoch,
+            )
+            .encode()
+            .into()
+        };
+        SstableInfoInner {
+            object_id: id.into(),
+            sst_id: id.into(),
+            key_range: KeyRange::new(key(left), key(right)),
+            table_ids: vec![table_id],
+            min_epoch: epoch,
+            max_epoch: epoch,
+            sst_size: 10,
+            ..Default::default()
+        }
+        .into()
+    }
+
+    fn layer_ids(layers: &[Vec<SstableInfo>]) -> Vec<Vec<HummockSstableId>> {
+        layers
+            .iter()
+            .map(|layer| layer.iter().map(|sst| sst.sst_id).collect())
+            .collect()
+    }
+
+    #[test]
+    fn test_disjoint_newer_sst_does_not_reorder_overlapping_versions() {
+        // Newest first: C is disjoint from both A and B, but A and B overlap.
+        // Sorting layers by max_epoch used to put {A, C} ahead of the newer B.
+        let c = ordered_sst(3, 40, 50, 30);
+        let b = ordered_sst(2, 10, 30, 20);
+        let a = ordered_sst(1, 0, 20, 10);
+        let layers = build_nonoverlapping_layers(vec![c.clone(), b.clone(), a.clone()]);
+        assert_eq!(
+            layer_ids(&layers),
+            vec![vec![a.sst_id], vec![b.sst_id, c.sst_id]]
+        );
+
+        // Model a point present in both A and B at different snapshots. Hummock reads layers
+        // newest first and returns the first visible version, rather than merging point results.
+        let point = KeyRange::new(fk(TableId::new(1), 15), fk(TableId::new(1), 15));
+        for (read_epoch, expected) in [(9, None), (10, Some(10)), (20, Some(20)), (30, Some(20))] {
+            let first_visible = layers
+                .iter()
+                .rev()
+                .flatten()
+                .find(|sst| {
+                    sst.max_epoch <= test_epoch(read_epoch) && sst.key_range.sstable_overlap(&point)
+                })
+                .map(|sst| sst.max_epoch);
+            assert_eq!(first_visible, expected.map(test_epoch));
+        }
+    }
+
+    #[test]
+    fn test_do_not_fill_a_gap_above_an_overlapping_newer_sst() {
+        let newest = ordered_sst(3, 0, 1, 30);
+        let middle = ordered_sst(2, 0, 3, 20);
+        let oldest = ordered_sst(1, 2, 3, 10);
+        // The oldest SST fits beside `newest`, but must stay below `middle`.
+        let layers =
+            build_nonoverlapping_layers(vec![newest.clone(), middle.clone(), oldest.clone()]);
+        assert_eq!(
+            layer_ids(&layers),
+            vec![
+                vec![oldest.sst_id],
+                vec![middle.sst_id],
+                vec![newest.sst_id]
+            ]
+        );
+    }
+
+    #[test]
+    fn test_same_user_key_at_different_epochs_cannot_share_a_layer() {
+        let newest = ordered_sst(2, 15, 15, 20);
+        let oldest = ordered_sst(1, 15, 15, 10);
+        assert!(!newest.key_range.full_key_overlap(&oldest.key_range));
+        assert!(newest.key_range.sstable_overlap(&oldest.key_range));
+        let layers = build_nonoverlapping_layers(vec![newest.clone(), oldest.clone()]);
+        assert_eq!(
+            layer_ids(&layers),
+            vec![vec![oldest.sst_id], vec![newest.sst_id]]
+        );
+    }
+
+    #[test]
+    fn test_split_and_chunk_preserve_overlapping_sst_order() {
+        let table_id = TableId::new(1);
+        let boundaries = build_vnode_partition_boundary_keys(table_id, 256, 8);
+        let newest = ordered_sst(2, 0, 64, 20);
+        let oldest = ordered_sst(1, 0, 64, 10);
+        let mut next_id = 100.into();
+        let fragments = [newest.clone(), oldest.clone()]
+            .into_iter()
+            .flat_map(|sst| split_sst_by_boundary_keys(sst, &boundaries, &mut next_id))
+            .collect();
+        let layers = build_nonoverlapping_layers(fragments);
+        assert_eq!(layers.len(), 2);
+        assert!(
+            layers
+                .iter()
+                .all(|layer| risingwave_hummock_sdk::can_concat(layer))
+        );
+        // Adjacent pieces with exclusive right bounds can share a layer, despite different
+        // epochs in their encoded boundary keys. Chunking must not interleave old/new layers.
+        assert!(
+            layers[0]
+                .iter()
+                .all(|sst| sst.object_id == oldest.object_id)
+        );
+        assert!(
+            layers[1]
+                .iter()
+                .all(|sst| sst.object_id == newest.object_id)
+        );
+        let chunks: Vec<_> = layers
+            .into_iter()
+            .flat_map(|layer| chunk_nonoverlapping_layer_by_size(layer, 1))
+            .collect();
+        for vnode in [0, 31, 32, 63, 64] {
+            let point = KeyRange::new(fk(table_id, vnode), fk(table_id, vnode));
+            let matches: Vec<_> = chunks
+                .iter()
+                .rev()
+                .flatten()
+                .filter(|sst| sst.key_range.sstable_overlap(&point))
+                .map(|sst| sst.object_id)
+                .collect();
+            assert_eq!(matches, vec![newest.object_id, oldest.object_id]);
+        }
+    }
+
+    #[test]
+    fn test_exhaustive_layer_order_and_minimum_depth() {
+        // Enumerate ordered sequences of four closed intervals, including repeated intervals,
+        // nested ranges, touching endpoints, and disjoint ranges. Equal epochs deliberately
+        // ensure the uploader's order, not an epoch sort, is the source of precedence.
+        let ranges: Vec<_> = (0..3)
+            .flat_map(|left| (left..3).map(move |right| (left, right)))
+            .collect();
+        for mut encoding in 0..ranges.len().pow(4) {
+            let mut ssts = vec![];
+            for id in 0..4 {
+                let (left, right) = ranges[encoding % ranges.len()];
+                encoding /= ranges.len();
+                ssts.push(ordered_sst(id, left, right, 10));
+            }
+            let layers = build_nonoverlapping_layers(ssts.clone());
+            assert!(
+                layers
+                    .iter()
+                    .all(|layer| risingwave_hummock_sdk::can_concat(layer))
+            );
+            assert_eq!(layers.iter().map(Vec::len).sum::<usize>(), ssts.len());
+            let depths: Vec<_> = ssts
+                .iter()
+                .map(|sst| {
+                    layers
+                        .iter()
+                        .rev()
+                        .position(|layer| layer.iter().any(|s| s.sst_id == sst.sst_id))
+                        .unwrap()
+                })
+                .collect();
+            for (older_idx, older) in ssts.iter().enumerate() {
+                for (newer_idx, newer) in ssts[..older_idx].iter().enumerate() {
+                    if newer.key_range.sstable_overlap(&older.key_range) {
+                        assert!(depths[newer_idx] < depths[older_idx]);
+                    }
+                }
+            }
+            // A chain of overlapping SSTs ordered by age is a lower bound on layer count.
+            // Enumerate all subsequences independently of the placement algorithm.
+            let minimum_layers = (1u32..1 << ssts.len())
+                .filter_map(|mask| {
+                    let chain: Vec<_> = ssts
+                        .iter()
+                        .enumerate()
+                        .filter(|(idx, _)| mask & (1 << idx) != 0)
+                        .map(|(_, sst)| sst)
+                        .collect();
+                    chain
+                        .windows(2)
+                        .all(|pair| pair[0].key_range.sstable_overlap(&pair[1].key_range))
+                        .then_some(chain.len())
+                })
+                .max()
+                .unwrap();
+            assert_eq!(layers.len(), minimum_layers);
+        }
+        assert!(build_nonoverlapping_layers(vec![]).is_empty());
+    }
+}

--- a/src/meta/src/hummock/manager/compaction/compaction_group_manager.rs
+++ b/src/meta/src/hummock/manager/compaction/compaction_group_manager.rs
@@ -327,7 +327,7 @@ impl HummockManager {
         }
         let mut group_changes: HashMap<CompactionGroupId, UnregisterGroupChange> = HashMap::new();
         // Remove member tables
-        for table_id in table_ids.into_iter().unique() {
+        for table_id in table_ids.iter().copied().unique() {
             let version = new_version_delta.latest_version();
             let Some(info) = version.state_table_info.info().get(&table_id) else {
                 continue;
@@ -394,6 +394,11 @@ impl HummockManager {
             version.latest_version(),
         )));
         commit_multi_var!(self.meta_store_ref(), version, compaction_groups_txn)?;
+
+        let mut vnode_count_cache = self.table_id_to_vnode_count.write();
+        for table_id in table_ids {
+            vnode_count_cache.remove(&table_id);
+        }
 
         // No need to handle DeltaType::GroupDestroy during time travel.
         Ok(())

--- a/src/meta/src/hummock/manager/mod.rs
+++ b/src/meta/src/hummock/manager/mod.rs
@@ -194,6 +194,9 @@ pub struct HummockManager {
     /// In-memory cache of prefetched compaction task ids to reduce per-task DB round-trips.
     prefetched_compaction_task_ids: PrefetchedSequence,
     table_id_to_table_option: parking_lot::RwLock<HashMap<TableId, TableOption>>,
+    /// Table vnode counts are immutable after creation. Cache them for commit-time splitting and
+    /// transient partition-aware L0 scoring without persisting derived compaction state.
+    table_id_to_vnode_count: parking_lot::RwLock<HashMap<TableId, usize>>,
 }
 
 pub type HummockManagerRef = Arc<HummockManager>;
@@ -388,6 +391,7 @@ impl HummockManager {
             gc_manager,
             prefetched_compaction_task_ids: PrefetchedSequence::new(),
             table_id_to_table_option: RwLock::new(HashMap::new()),
+            table_id_to_vnode_count: RwLock::new(HashMap::new()),
         };
         let instance = Arc::new(instance);
         let version_stat_metrics = instance.metrics.clone();

--- a/src/meta/src/hummock/manager/transaction.rs
+++ b/src/meta/src/hummock/manager/transaction.rs
@@ -23,7 +23,9 @@ use risingwave_hummock_sdk::compaction_group::StaticCompactionGroupId;
 use risingwave_hummock_sdk::sstable_info::SstableInfo;
 use risingwave_hummock_sdk::table_watermark::TableWatermarks;
 use risingwave_hummock_sdk::vector_index::VectorIndexDelta;
-use risingwave_hummock_sdk::version::{GroupDelta, HummockVersion, HummockVersionDelta};
+use risingwave_hummock_sdk::version::{
+    GroupDelta, HummockVersion, HummockVersionDelta, IntraLevelDelta,
+};
 use risingwave_hummock_sdk::{
     CompactionGroupId, FrontendHummockVersionDelta, HummockSstableId, HummockVersionId,
 };
@@ -78,6 +80,28 @@ pub(super) struct HummockVersionTransaction<'a> {
     )>,
     disable_apply_to_txn: bool,
     opts: &'a MetaOpts,
+}
+
+pub(super) struct CommitSubLevel {
+    pub ssts: Vec<SstableInfo>,
+    pub vnode_partition_count: u32,
+}
+
+impl CommitSubLevel {
+    fn into_group_delta(self, l0_sub_level_id: u64) -> GroupDelta {
+        if self.vnode_partition_count == 0 {
+            GroupDelta::NewL0SubLevel(self.ssts)
+        } else {
+            GroupDelta::IntraLevel(IntraLevelDelta::new(
+                0,
+                l0_sub_level_id,
+                HashSet::new(),
+                self.ssts,
+                self.vnode_partition_count,
+                0,
+            ))
+        }
+    }
 }
 
 impl<'a> HummockVersionTransaction<'a> {
@@ -165,7 +189,7 @@ impl<'a> HummockVersionTransaction<'a> {
         &mut self,
         tables_to_commit: &HashMap<TableId, u64>,
         new_compaction_groups: Vec<CompactionGroup>,
-        group_id_to_sub_levels: BTreeMap<CompactionGroupId, Vec<Vec<SstableInfo>>>,
+        group_id_to_sub_levels: BTreeMap<CompactionGroupId, Vec<CommitSubLevel>>,
         new_table_ids: &HashMap<TableId, CompactionGroupId>,
         new_table_watermarks: HashMap<TableId, TableWatermarks>,
         change_log_delta: HashMap<TableId, EpochNewChangeLog>,
@@ -198,14 +222,27 @@ impl<'a> HummockVersionTransaction<'a> {
 
         // Append SSTs to a new version.
         for (compaction_group_id, sub_levels) in group_id_to_sub_levels {
+            let next_l0_sub_level_id = new_version_delta
+                .latest_version()
+                .levels
+                .get(&compaction_group_id)
+                .and_then(|levels| {
+                    levels
+                        .l0
+                        .sub_levels
+                        .last()
+                        .map(|level| level.sub_level_id + 1)
+                })
+                .unwrap_or(1);
+
             let group_deltas = &mut new_version_delta
                 .group_deltas
                 .entry(compaction_group_id)
                 .or_default()
                 .group_deltas;
 
-            for sub_level in sub_levels {
-                group_deltas.push(GroupDelta::NewL0SubLevel(sub_level));
+            for (offset, sub_level) in sub_levels.into_iter().enumerate() {
+                group_deltas.push(sub_level.into_group_delta(next_l0_sub_level_id + offset as u64));
             }
         }
 
@@ -495,6 +532,29 @@ mod tests {
             non_checkpoint_epochs: vec![],
             checkpoint_epoch,
         }
+    }
+
+    #[test]
+    fn test_commit_sub_level_delta_type() {
+        assert!(matches!(
+            CommitSubLevel {
+                ssts: vec![],
+                vnode_partition_count: 0,
+            }
+            .into_group_delta(7),
+            GroupDelta::NewL0SubLevel(_)
+        ));
+
+        let GroupDelta::IntraLevel(delta) = (CommitSubLevel {
+            ssts: vec![],
+            vnode_partition_count: 4,
+        })
+        .into_group_delta(7) else {
+            panic!("partitioned commit must use an intra-level delta");
+        };
+        assert_eq!(delta.level_idx, 0);
+        assert_eq!(delta.l0_sub_level_id, 7);
+        assert_eq!(delta.vnode_partition_count, 4);
     }
 
     #[test]

--- a/src/storage/hummock_sdk/src/compaction_group/hummock_version_ext.rs
+++ b/src/storage/hummock_sdk/src/compaction_group/hummock_version_ext.rs
@@ -603,6 +603,7 @@ impl HummockVersionCommon<SstableInfo> {
                                 level_idx,
                                 l0_sub_level_id,
                                 inserted_table_infos,
+                                vnode_partition_count,
                                 ..
                             } = level_delta;
                             {
@@ -611,13 +612,25 @@ impl HummockVersionCommon<SstableInfo> {
                                     "we should only add to L0 when we commit an epoch."
                                 );
                                 if !inserted_table_infos.is_empty() {
+                                    let level_type = if *vnode_partition_count > 0
+                                        && can_concat(inserted_table_infos)
+                                    {
+                                        PbLevelType::Nonoverlapping
+                                    } else {
+                                        PbLevelType::Overlapping
+                                    };
                                     insert_new_sub_level(
                                         &mut levels.l0,
                                         *l0_sub_level_id,
-                                        PbLevelType::Overlapping,
+                                        level_type,
                                         inserted_table_infos.clone(),
                                         None,
                                     );
+                                    if *vnode_partition_count > 0
+                                        && let Some(level) = levels.l0.sub_levels.last_mut()
+                                    {
+                                        level.vnode_partition_count = *vnode_partition_count;
+                                    }
                                 }
                             }
                         } else {

--- a/src/storage/hummock_sdk/src/compaction_group/mod.rs
+++ b/src/storage/hummock_sdk/src/compaction_group/mod.rs
@@ -41,8 +41,10 @@ pub mod StaticCompactionGroupId {
 
 /// The split will follow the following rules:
 /// 1. Ssts with `split_key` will be split into two separate ssts and their `key_range` will be changed `sst_1`: [`sst.key_range.right`, `split_key`) `sst_2`: [`split_key`, `sst.key_range.right`].
-/// 2. Currently only `vnode` 0 and `vnode` max is supported.
-/// 3. Due to the above rule, `vnode` max will be rewritten as `table_id` + 1, vnode 0
+/// 2. Compaction-group membership can only be split at table boundaries (`vnode` 0 or max).
+/// 3. A single-table SST can additionally be split at an internal vnode boundary while remaining
+///    in the same compaction group.
+/// 4. For compaction-group splits, `vnode` max will be rewritten as `table_id` + 1, vnode 0.
 pub mod group_split {
     use std::cmp::Ordering;
     use std::collections::BTreeSet;
@@ -136,6 +138,62 @@ pub mod group_split {
         left_size: u64,
         right_size: u64,
     ) -> (Option<SstableInfo>, Option<SstableInfo>) {
+        let (table_ids_l, table_ids_r) =
+            split_table_ids_with_split_key(&origin_sst_info.table_ids, split_key.clone());
+        split_sst_inner(
+            origin_sst_info,
+            new_sst_id,
+            split_key,
+            left_size,
+            right_size,
+            table_ids_l,
+            table_ids_r,
+        )
+    }
+
+    /// Split a single-table SST at an internal vnode boundary without changing group membership.
+    /// The table id remains present in both logical SSTs because both ranges belong to the same
+    /// state table and compaction group.
+    pub fn split_sst_at_vnode_boundary(
+        origin_sst_info: SstableInfo,
+        new_sst_id: &mut HummockSstableId,
+        split_key: Bytes,
+        left_size: u64,
+        right_size: u64,
+    ) -> (Option<SstableInfo>, Option<SstableInfo>) {
+        let split_user_key = FullKey::decode(&split_key).user_key;
+        assert_ne!(
+            0,
+            split_user_key.get_vnode_id(),
+            "vnode partition boundary must be inside a table"
+        );
+        assert_eq!(
+            origin_sst_info.table_ids.as_slice(),
+            &[split_user_key.table_id],
+            "vnode partition splitting only supports a single-table SST"
+        );
+
+        let table_ids = origin_sst_info.table_ids.clone();
+        split_sst_inner(
+            origin_sst_info,
+            new_sst_id,
+            split_key,
+            left_size,
+            right_size,
+            table_ids.clone(),
+            table_ids,
+        )
+    }
+
+    fn split_sst_inner(
+        origin_sst_info: SstableInfo,
+        new_sst_id: &mut HummockSstableId,
+        split_key: Bytes,
+        left_size: u64,
+        right_size: u64,
+        table_ids_l: Vec<TableId>,
+        table_ids_r: Vec<TableId>,
+    ) -> (Option<SstableInfo>, Option<SstableInfo>) {
         let mut origin_sst_info = origin_sst_info.get_inner();
         let mut branch_table_info = origin_sst_info.clone();
         branch_table_info.sst_id = *new_sst_id;
@@ -152,16 +210,13 @@ pub mod group_split {
             };
 
             let r = KeyRange {
-                left: split_key.clone(),
+                left: split_key,
                 right: key_range.right.clone(),
                 right_exclusive: key_range.right_exclusive,
             };
 
             (l, r)
         };
-        let (table_ids_l, table_ids_r) =
-            split_table_ids_with_split_key(&origin_sst_info.table_ids, split_key);
-
         // rebuild the key_range and size and sstable file size
         {
             // origin_sst_info

--- a/src/storage/hummock_sdk/src/lib.rs
+++ b/src/storage/hummock_sdk/src/lib.rs
@@ -48,6 +48,7 @@ pub mod version;
 pub use frontend_version::{FrontendHummockVersion, FrontendHummockVersionDelta};
 mod frontend_version;
 pub mod vector_index;
+pub mod vnode_partition;
 
 pub use compact::*;
 use risingwave_common::catalog::TableId;

--- a/src/storage/hummock_sdk/src/vnode_partition.rs
+++ b/src/storage/hummock_sdk/src/vnode_partition.rs
@@ -1,0 +1,65 @@
+// Copyright 2026 RisingWave Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use bytes::Bytes;
+use risingwave_common::catalog::TableId;
+use risingwave_common::hash::VirtualNode;
+
+use crate::key::{FullKey, TableKey};
+
+pub fn build_vnode_partition_boundary_keys(
+    table_id: TableId,
+    vnode_count: usize,
+    partition_count: usize,
+) -> Vec<Bytes> {
+    debug_assert!(partition_count > 0);
+    debug_assert!(partition_count <= vnode_count);
+
+    if partition_count <= 1 {
+        return vec![];
+    }
+
+    // Keep the same partitioning rule with `MultiBuilder`:
+    // - First `partition_count - remainder` partitions have `basic` vnodes.
+    // - Last `remainder` partitions have `basic + 1` vnodes.
+    let basic = vnode_count / partition_count;
+    let remainder = vnode_count % partition_count;
+    let small_partitions = partition_count - remainder;
+
+    let mut boundary_keys = Vec::with_capacity(partition_count.saturating_sub(1));
+    let mut start = 0usize;
+    for idx in 0..partition_count {
+        let size = if idx < small_partitions {
+            basic
+        } else {
+            basic + 1
+        };
+        if idx > 0 {
+            boundary_keys.push(vnode_boundary_full_key(table_id, start));
+        }
+        start += size;
+    }
+    debug_assert_eq!(start, vnode_count);
+    boundary_keys
+}
+
+pub fn vnode_boundary_full_key(table_id: TableId, vnode: usize) -> Bytes {
+    FullKey::new(
+        table_id,
+        TableKey(VirtualNode::from_index(vnode).to_be_bytes().to_vec()),
+        u64::MAX,
+    )
+    .encode()
+    .into()
+}

--- a/src/storage/src/hummock/iterator/backward_concat.rs
+++ b/src/storage/src/hummock/iterator/backward_concat.rs
@@ -23,6 +23,8 @@ pub type BackwardConcatIterator = ConcatIteratorInner<BackwardSstableIterator>;
 mod tests {
     use std::sync::Arc;
 
+    use bytes::Bytes;
+
     use super::*;
     use crate::hummock::iterator::HummockIterator;
     use crate::hummock::iterator::test_utils::{
@@ -88,6 +90,43 @@ mod tests {
             val.into_user_value().unwrap(),
             iterator_test_value_of(TEST_KEYS_COUNT * 3 - 1).as_slice()
         );
+    }
+
+    #[tokio::test]
+    async fn test_backward_concat_logical_ssts_sharing_one_object() {
+        let sstable_store = mock_sstable_store().await;
+        let physical_sst = gen_iterator_test_sstable_info(
+            0,
+            default_builder_opt_for_test(),
+            |x| x,
+            sstable_store.clone(),
+            TEST_KEYS_COUNT,
+        )
+        .await;
+        let split_key = Bytes::from(iterator_test_key_of(TEST_KEYS_COUNT / 2).encode());
+
+        let mut left = physical_sst.get_inner();
+        left.sst_id = 100.into();
+        left.key_range.right = split_key.clone();
+        left.key_range.right_exclusive = true;
+        let mut right = physical_sst.get_inner();
+        right.sst_id = 101.into();
+        right.key_range.left = split_key;
+
+        let mut iter = BackwardConcatIterator::new(
+            vec![right.into(), left.into()],
+            sstable_store,
+            Arc::new(SstableIteratorReadOptions::default()),
+        );
+        iter.rewind().await.unwrap();
+
+        let mut index = TEST_KEYS_COUNT;
+        while iter.is_valid() {
+            index -= 1;
+            assert_eq!(iter.key(), iterator_test_key_of(index).to_ref());
+            iter.next().await.unwrap();
+        }
+        assert_eq!(index, 0);
     }
 
     #[tokio::test]

--- a/src/storage/src/hummock/iterator/forward_concat.rs
+++ b/src/storage/src/hummock/iterator/forward_concat.rs
@@ -22,6 +22,7 @@ pub type ConcatIterator = ConcatIteratorInner<SstableIterator>;
 mod tests {
     use std::sync::Arc;
 
+    use bytes::Bytes;
     #[cfg(feature = "failpoints")]
     use foyer::Hint;
 
@@ -96,6 +97,43 @@ mod tests {
             val.into_user_value().unwrap(),
             iterator_test_value_of(0).as_slice()
         );
+    }
+
+    #[tokio::test]
+    async fn test_concat_logical_ssts_sharing_one_object() {
+        let sstable_store = mock_sstable_store().await;
+        let physical_sst = gen_iterator_test_sstable_info(
+            0,
+            default_builder_opt_for_test(),
+            |x| x,
+            sstable_store.clone(),
+            TEST_KEYS_COUNT,
+        )
+        .await;
+        let split_key = Bytes::from(iterator_test_key_of(TEST_KEYS_COUNT / 2).encode());
+
+        let mut left = physical_sst.get_inner();
+        left.sst_id = 100.into();
+        left.key_range.right = split_key.clone();
+        left.key_range.right_exclusive = true;
+        let mut right = physical_sst.get_inner();
+        right.sst_id = 101.into();
+        right.key_range.left = split_key;
+
+        let mut iter = ConcatIterator::new(
+            vec![left.into(), right.into()],
+            sstable_store,
+            Arc::new(SstableIteratorReadOptions::default()),
+        );
+        iter.rewind().await.unwrap();
+
+        let mut index = 0;
+        while iter.is_valid() {
+            assert_eq!(iter.key(), iterator_test_key_of(index).to_ref());
+            index += 1;
+            iter.next().await.unwrap();
+        }
+        assert_eq!(index, TEST_KEYS_COUNT);
     }
 
     #[tokio::test]

--- a/src/storage/src/hummock/sstable/backward_sstable_iterator.rs
+++ b/src/storage/src/hummock/sstable/backward_sstable_iterator.rs
@@ -17,6 +17,7 @@ use std::sync::Arc;
 
 use foyer::Hint;
 use risingwave_hummock_sdk::key::FullKey;
+use risingwave_hummock_sdk::key_range::KeyRange;
 use risingwave_hummock_sdk::sstable_info::SstableInfo;
 
 use crate::hummock::iterator::{Backward, HummockIterator, ValueMeta};
@@ -44,6 +45,7 @@ pub struct BackwardSstableIterator {
 
     // used for checking if the block is valid, filter out the block that is not in the table-id range
     read_block_meta_range: (usize, usize),
+    key_range: KeyRange,
 }
 
 impl BackwardSstableIterator {
@@ -133,7 +135,12 @@ impl BackwardSstableIterator {
             sstable_store,
             stats: StoreLocalStatistic::default(),
             read_block_meta_range: (start_idx, end_idx),
+            key_range: sstable_info_ref.key_range.clone(),
         }
+    }
+
+    fn block_iter_is_valid(&self) -> bool {
+        self.block_iter.as_ref().is_some_and(|iter| iter.is_valid())
     }
 
     /// Seeks to a block, and then seeks to the key if `seek_key` is given.
@@ -194,17 +201,28 @@ impl HummockIterator for BackwardSstableIterator {
     }
 
     fn is_valid(&self) -> bool {
-        self.block_iter.as_ref().is_some_and(|i| i.is_valid())
+        self.block_iter_is_valid() && super::full_key_in_range(&self.key_range, self.key())
     }
 
     /// Instead of setting idx to 0th block, a `BackwardSstableIterator` rewinds to the last block
     /// in the sstable.
     async fn rewind(&mut self) -> HummockResult<()> {
-        self.seek_idx(self.read_block_meta_range.1 as isize, None)
-            .await
+        if self.key_range.right.is_empty() {
+            self.seek_idx(self.read_block_meta_range.1 as isize, None)
+                .await
+        } else {
+            let right = self.key_range.right.clone();
+            self.seek(FullKey::decode(&right)).await
+        }
     }
 
     async fn seek<'a>(&'a mut self, key: FullKey<&'a [u8]>) -> HummockResult<()> {
+        let right = self.key_range.right.clone();
+        let key = if !right.is_empty() && FullKey::decode(&right).lt(&key) {
+            FullKey::decode(&right)
+        } else {
+            key
+        };
         let block_idx = self
             .sst
             .meta
@@ -220,9 +238,17 @@ impl HummockIterator for BackwardSstableIterator {
         let block_idx = block_idx as isize;
 
         self.seek_idx(block_idx, Some(key)).await?;
-        if !self.is_valid() {
+        if !self.block_iter_is_valid() {
             // Seek to prev block
             self.seek_idx(block_idx - 1, None).await?;
+        }
+
+        if self.block_iter_is_valid()
+            && !right.is_empty()
+            && self.key_range.right_exclusive
+            && self.key() == FullKey::decode(&right)
+        {
+            self.next().await?;
         }
 
         Ok(())

--- a/src/storage/src/hummock/sstable/forward_sstable_iterator.rs
+++ b/src/storage/src/hummock/sstable/forward_sstable_iterator.rs
@@ -17,6 +17,7 @@ use std::sync::Arc;
 
 use await_tree::{InstrumentAwait, SpanExt};
 use risingwave_hummock_sdk::key::FullKey;
+use risingwave_hummock_sdk::key_range::KeyRange;
 use risingwave_hummock_sdk::sstable_info::SstableInfo;
 use sync_point::sync_point;
 use thiserror_ext::AsReport;
@@ -60,6 +61,7 @@ pub struct SstableIterator {
     // precisely inside the boundary block.
     block_start_idx_inclusive: usize,
     block_end_idx_exclusive: usize,
+    key_range: KeyRange,
 }
 
 impl SstableIterator {
@@ -172,7 +174,12 @@ impl SstableIterator {
             preload_retry_times: 0,
             block_start_idx_inclusive,
             block_end_idx_exclusive,
+            key_range: sstable_info_ref.key_range.clone(),
         }
+    }
+
+    fn block_iter_is_valid(&self) -> bool {
+        self.block_iter.as_ref().is_some_and(|iter| iter.is_valid())
     }
 
     fn init_block_prefetch_range(&mut self, start_idx: usize) {
@@ -358,7 +365,7 @@ impl HummockIterator for SstableIterator {
     }
 
     fn is_valid(&self) -> bool {
-        self.block_iter.as_ref().is_some_and(|i| i.is_valid())
+        self.block_iter_is_valid() && super::full_key_in_range(&self.key_range, self.key())
     }
 
     async fn rewind(&mut self) -> HummockResult<()> {
@@ -366,10 +373,14 @@ impl HummockIterator for SstableIterator {
             self.block_iter = None;
             return Ok(());
         }
-        self.init_block_prefetch_range(self.block_start_idx_inclusive);
-        // seek_idx will update the current block iter state
-        self.seek_idx(self.block_start_idx_inclusive, None).await?;
-        Ok(())
+        if self.key_range.left.is_empty() {
+            self.init_block_prefetch_range(self.block_start_idx_inclusive);
+            // seek_idx will update the current block iter state
+            self.seek_idx(self.block_start_idx_inclusive, None).await
+        } else {
+            let left = self.key_range.left.clone();
+            self.seek(FullKey::decode(&left)).await
+        }
     }
 
     async fn seek<'a>(&'a mut self, key: FullKey<&'a [u8]>) -> HummockResult<()> {
@@ -377,11 +388,17 @@ impl HummockIterator for SstableIterator {
             self.block_iter = None;
             return Ok(());
         }
+        let left = self.key_range.left.clone();
+        let key = if !left.is_empty() && FullKey::decode(&left).gt(&key) {
+            FullKey::decode(&left)
+        } else {
+            key
+        };
         let block_idx = self.calculate_block_idx_by_key(key);
         self.init_block_prefetch_range(block_idx);
 
         self.seek_idx(block_idx, Some(key)).await?;
-        if !self.is_valid() {
+        if !self.block_iter_is_valid() {
             // seek to next block
             sync_point!("SSTABLE_ITERATOR::SEEK::BEFORE_NEXT_BLOCK");
             self.seek_idx(block_idx + 1, None).await?;

--- a/src/storage/src/hummock/sstable/mod.rs
+++ b/src/storage/src/hummock/sstable/mod.rs
@@ -43,6 +43,7 @@ use tracing::warn;
 mod backward_sstable_iterator;
 pub use backward_sstable_iterator::*;
 use risingwave_hummock_sdk::key::{FullKey, KeyPayloadType, UserKey, UserKeyRangeRef};
+use risingwave_hummock_sdk::key_range::KeyRange;
 use risingwave_hummock_sdk::{HummockEpoch, HummockSstableObjectId};
 
 mod filter;
@@ -63,6 +64,17 @@ use crate::store::ReadOptions;
 const MAGIC: u32 = 0x5785ab73;
 const OLD_VERSION: u32 = 1;
 const VERSION: u32 = 2;
+
+fn full_key_in_range(key_range: &KeyRange, key: FullKey<&[u8]>) -> bool {
+    let after_left = key_range.left.is_empty() || FullKey::decode(&key_range.left).le(&key);
+    let before_right = key_range.right.is_empty()
+        || if key_range.right_exclusive {
+            key.lt(&FullKey::decode(&key_range.right))
+        } else {
+            key.le(&FullKey::decode(&key_range.right))
+        };
+    after_left && before_right
+}
 
 /// Assume that watermark1 is 5, watermark2 is 7, watermark3 is 11, delete ranges
 /// `{ [0, wmk1) in epoch1, [wmk1, wmk2) in epoch2, [wmk2, wmk3) in epoch3 }`


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

This is stack 2/3 and depends on #26993. Until the parent PR is merged, GitHub shows the parent commit in this PR's `main`-based diff.

- For a compaction group containing exactly one table, derive fixed vnode partition boundaries from the table vnode count and `split_weight_by_vnode`.
- At commit epoch, split SST metadata at those vnode boundaries and arrange overlapping uploader output into the minimum number of non-overlapping L0 sub-levels that preserves epoch ordering.
- Add a dedicated SDK split operation for an internal vnode boundary. Both logical SST halves retain the same table id and stay in the same compaction group.
- Publish partitioned commit output through an intra-level version delta so the resulting L0 sub-level records its non-overlapping layout and partition count.
- Keep the old `NewL0SubLevel` path for ineligible and non-single-table compaction groups.

This PR deliberately does not split one table across multiple compaction groups. The version state still owns exactly one compaction group id per table, so an internal-vnode compaction-group split would not be representable correctly.

## Checklist

- [x] I have written necessary rustdoc comments.
- [x] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [x] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/dev/src/ci.md#ci-labels-guide -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

Not applicable. This is an internal Hummock layout experiment.

</details>
