### PR TITLE
refactor(storage): pick single-table L0 compaction by vnode partition

### DIFF
--- a/src/meta/src/hummock/compaction/mod.rs
+++ b/src/meta/src/hummock/compaction/mod.rs
@@ -17,6 +17,7 @@
 pub mod compaction_config;
 pub(crate) mod in_progress_compaction;
 mod overlap_strategy;
+pub(crate) mod vnode_partition;
 use risingwave_common::catalog::{TableId, TableOption};
 use risingwave_hummock_sdk::compact_task::CompactTask;
 use risingwave_hummock_sdk::level::Levels;
@@ -39,7 +40,7 @@ use risingwave_pb::hummock::compaction_config::CompactionMode;
 use risingwave_pb::hummock::{CompactionConfig, PbSstableFilterLayout, PbSstableFilterType};
 pub use selector::{CompactionSelector, CompactionSelectorContext};
 
-use self::selector::{EmergencySelector, LocalSelectorStatistic};
+use self::selector::{EmergencySelector, LocalSelectorStatistic, SingleTableCompactionGroup};
 use super::GroupStateValidator;
 use crate::MetaOpts;
 use crate::hummock::compaction::in_progress_compaction::InProgressCompactionView;
@@ -104,6 +105,7 @@ impl CompactStatus {
         &mut self,
         levels: &Levels,
         member_table_ids: &BTreeSet<TableId>,
+        single_table_compaction_group: Option<SingleTableCompactionGroup>,
         task_id: HummockCompactionTaskId,
         group: &CompactionGroup,
         stats: &mut LocalSelectorStatistic,
@@ -118,6 +120,7 @@ impl CompactStatus {
             group,
             levels,
             member_table_ids,
+            single_table_compaction_group,
             level_handlers: &mut self.level_handlers,
             selector_stats: stats,
             table_id_to_options,
@@ -144,6 +147,7 @@ impl CompactStatus {
                         group,
                         levels,
                         member_table_ids,
+                        single_table_compaction_group,
                         level_handlers: &mut self.level_handlers,
                         selector_stats: stats,
                         table_id_to_options,

--- a/src/meta/src/hummock/compaction/picker/base_level_compaction_picker.rs
+++ b/src/meta/src/hummock/compaction/picker/base_level_compaction_picker.rs
@@ -22,7 +22,7 @@ use risingwave_pb::hummock::{CompactionConfig, LevelType};
 
 use super::non_overlap_sub_level_picker::NonOverlapSubLevelPicker;
 use super::{
-    CompactionInput, CompactionPicker, CompactionTaskValidator, LocalPickerStatistic,
+    CompactionInput, CompactionPicker, CompactionTaskValidator, L0PickerMode, LocalPickerStatistic,
     ValidationRuleType,
 };
 use crate::hummock::compaction::picker::TrivialMovePicker;
@@ -35,6 +35,7 @@ std::thread_local! {
 
 pub struct LevelCompactionPicker {
     target_level: usize,
+    mode: L0PickerMode,
     config: Arc<CompactionConfig>,
     compaction_task_validator: Arc<CompactionTaskValidator>,
     developer_config: Arc<CompactionDeveloperConfig>,
@@ -100,6 +101,7 @@ impl LevelCompactionPicker {
     ) -> LevelCompactionPicker {
         LevelCompactionPicker {
             target_level,
+            mode: L0PickerMode::Legacy,
             compaction_task_validator: Arc::new(CompactionTaskValidator::new(config.clone())),
             config,
             developer_config,
@@ -112,8 +114,25 @@ impl LevelCompactionPicker {
         compaction_task_validator: Arc<CompactionTaskValidator>,
         developer_config: Arc<CompactionDeveloperConfig>,
     ) -> LevelCompactionPicker {
+        Self::new_with_mode(
+            target_level,
+            config,
+            compaction_task_validator,
+            developer_config,
+            L0PickerMode::Legacy,
+        )
+    }
+
+    pub(crate) fn new_with_mode(
+        target_level: usize,
+        config: Arc<CompactionConfig>,
+        compaction_task_validator: Arc<CompactionTaskValidator>,
+        developer_config: Arc<CompactionDeveloperConfig>,
+        mode: L0PickerMode,
+    ) -> LevelCompactionPicker {
         LevelCompactionPicker {
             target_level,
+            mode,
             config,
             compaction_task_validator,
             developer_config,
@@ -136,8 +155,9 @@ impl LevelCompactionPicker {
             0,
             self.target_level,
             overlap_strategy.clone(),
-            if self.compaction_task_validator.is_enable() {
-                // tips: Older versions of the compaction group will be upgraded without this configuration, we leave it with its default behaviour and enable it manually when needed.
+            if self.mode.is_single_table_partition() {
+                0
+            } else if self.compaction_task_validator.is_enable() {
                 self.config.sst_allowed_trivial_move_min_size.unwrap_or(0)
             } else {
                 0
@@ -166,6 +186,7 @@ impl LevelCompactionPicker {
     ) -> Option<CompactionInput> {
         let overlap_strategy = create_overlap_strategy(self.config.compaction_mode());
         let min_compaction_bytes = self.config.sub_level_max_compaction_bytes;
+        let min_expected_level_count = self.mode.min_l0_level_count();
         let non_overlap_sub_level_picker = NonOverlapSubLevelPicker::new(
             min_compaction_bytes,
             // divide by 2 because we need to select files of base level and it need use the other
@@ -174,7 +195,7 @@ impl LevelCompactionPicker {
                 self.config.max_bytes_for_level_base,
                 self.config.max_compaction_bytes / 2,
             ),
-            1,
+            min_expected_level_count,
             // The maximum number of sub_level compact level per task
             self.config.level0_max_compact_file_number,
             overlap_strategy.clone(),
@@ -187,18 +208,32 @@ impl LevelCompactionPicker {
                 .unwrap_or(compaction_config::enable_optimize_l0_interval_selection()),
         );
 
-        let mut max_vnode_partition_idx = 0;
-        for (idx, level) in l0.sub_levels.iter().enumerate() {
-            if level.vnode_partition_count < vnode_partition_count {
-                break;
+        let candidate_levels = if self.mode.is_single_table_partition() {
+            // The partition view has already removed unrelated vnode ranges. It may contain
+            // levels with different legacy partition markers, but must never cross an overlapping
+            // sub-level.
+            let non_overlapping_count = l0
+                .sub_levels
+                .iter()
+                .take_while(|level| level.level_type == LevelType::Nonoverlapping)
+                .count();
+            if non_overlapping_count == 0 {
+                return None;
             }
-            max_vnode_partition_idx = idx;
-        }
+            &l0.sub_levels[..non_overlapping_count]
+        } else {
+            let mut max_vnode_partition_idx = 0;
+            for (idx, level) in l0.sub_levels.iter().enumerate() {
+                if level.vnode_partition_count < vnode_partition_count {
+                    break;
+                }
+                max_vnode_partition_idx = idx;
+            }
+            &l0.sub_levels[..=max_vnode_partition_idx]
+        };
 
-        let candidate_l0_plans = non_overlap_sub_level_picker.pick_l0_multi_non_overlap_level(
-            &l0.sub_levels[..=max_vnode_partition_idx],
-            &level_handlers[0],
-        );
+        let candidate_l0_plans = non_overlap_sub_level_picker
+            .pick_l0_multi_non_overlap_level(candidate_levels, &level_handlers[0]);
         if candidate_l0_plans.is_empty() {
             stats.skip_by_pending_files += 1;
             return None;
@@ -208,6 +243,16 @@ impl LevelCompactionPicker {
         let mut input_levels = vec![];
 
         for input in candidate_l0_plans {
+            // Partition admission already checks the configured L0 depth. Keep the same check at
+            // the task boundary as a defense against a key-range candidate that spans fewer
+            // sub-levels than the partition-level view suggested.
+            if self.mode.is_single_table_partition()
+                && input.sstable_infos.len() < min_expected_level_count
+            {
+                stats.skip_by_count_limit += 1;
+                continue;
+            }
+
             let l0_select_tables = input
                 .sstable_infos
                 .iter()
@@ -305,6 +350,7 @@ impl LevelCompactionPicker {
 
 #[cfg(test)]
 pub mod tests {
+    use risingwave_common::util::iter_util::ZipEqFast;
 
     use super::*;
     use crate::hummock::compaction::compaction_config::CompactionConfigBuilder;
@@ -319,6 +365,87 @@ pub mod tests {
                 .build(),
         );
         LevelCompactionPicker::new(1, config, Arc::new(CompactionDeveloperConfig::default()))
+    }
+
+    #[test]
+    fn test_small_trivial_moves_ignore_legacy_min_size_and_count_all_files() {
+        let config = Arc::new(CompactionConfig {
+            split_weight_by_vnode: 8,
+            ..CompactionConfigBuilder::new()
+                .sst_allowed_trivial_move_min_size(Some(u64::MAX))
+                .sst_allowed_trivial_move_max_count(Some(10))
+                .build()
+        });
+        let mut picker = LevelCompactionPicker::new_with_mode(
+            1,
+            config,
+            Arc::new(CompactionTaskValidator::unused()),
+            Arc::new(CompactionDeveloperConfig::default()),
+            L0PickerMode::SingleTablePartition {
+                min_l0_level_count: 1,
+            },
+        );
+        let levels = Levels {
+            l0: generate_l0_nonoverlapping_multi_sublevels(vec![vec![
+                generate_table(1, 1, 0, 10, 1),
+                generate_table(2, 1, 20, 30, 1),
+            ]]),
+            levels: vec![generate_level(1, vec![])],
+            ..Default::default()
+        };
+        let mut handlers = vec![LevelHandler::new(0), LevelHandler::new(1)];
+        let ret = picker
+            .pick_compaction(&levels, &handlers, &mut LocalPickerStatistic::default())
+            .unwrap();
+        assert_eq!(ret.input_levels[0].table_infos.len(), 2);
+        assert!(ret.input_levels[1].table_infos.is_empty());
+        assert_eq!(ret.total_file_count, 1);
+        ret.add_pending_task(1, &mut handlers);
+        assert!(
+            picker
+                .pick_compaction(&levels, &handlers, &mut LocalPickerStatistic::default())
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn test_to_base_ignores_partition_markers_but_stops_at_overlapping_level() {
+        let config = Arc::new(CompactionConfig {
+            split_weight_by_vnode: 8,
+            ..CompactionConfigBuilder::new().build()
+        });
+        let mut picker = LevelCompactionPicker::new_with_mode(
+            1,
+            config,
+            Arc::new(CompactionTaskValidator::unused()),
+            Arc::new(CompactionDeveloperConfig::default()),
+            L0PickerMode::SingleTablePartition {
+                min_l0_level_count: 1,
+            },
+        );
+        let mut levels = Levels {
+            l0: generate_l0_nonoverlapping_sublevels(
+                (1..=3).map(|id| generate_table(id, 1, 0, 10, id)).collect(),
+            ),
+            levels: vec![generate_level(1, vec![generate_table(10, 1, 0, 10, 0)])],
+            ..Default::default()
+        };
+        for (level, count) in levels.l0.sub_levels.iter_mut().zip_eq_fast([0, 4, 16]) {
+            level.vnode_partition_count = count;
+        }
+        let handlers = vec![LevelHandler::new(0), LevelHandler::new(1)];
+        let ret = picker
+            .pick_compaction(&levels, &handlers, &mut LocalPickerStatistic::default())
+            .unwrap();
+        assert_eq!(ret.input_levels.len(), 4);
+        assert_eq!(ret.input_levels.last().unwrap().table_infos[0].sst_id, 10);
+
+        levels.l0.sub_levels[1].level_type = LevelType::Overlapping;
+        let ret = picker
+            .pick_compaction(&levels, &handlers, &mut LocalPickerStatistic::default())
+            .unwrap();
+        assert_eq!(ret.input_levels.len(), 2);
+        assert_eq!(ret.input_levels[0].table_infos[0].sst_id, 1);
     }
 
     #[test]
@@ -611,7 +738,6 @@ pub mod tests {
             Arc::new(config),
             Arc::new(CompactionDeveloperConfig::default()),
         );
-
         let mut levels = Levels {
             levels: vec![Level {
                 level_idx: 1,
@@ -639,11 +765,114 @@ pub mod tests {
         );
 
         let mut levels_handler = vec![LevelHandler::new(0), LevelHandler::new(1)];
-        let mut local_stats = LocalPickerStatistic::default();
         levels_handler[0].add_pending_task(1, 4, &levels.l0.sub_levels[0].table_infos);
-        let ret = picker.pick_compaction(&levels, &levels_handler, &mut local_stats);
-        // Skip this compaction because the write amplification is too large.
+        let ret = picker.pick_compaction(
+            &levels,
+            &levels_handler,
+            &mut LocalPickerStatistic::default(),
+        );
         assert!(ret.is_none());
+    }
+
+    #[test]
+    fn test_to_base_does_not_reject_by_write_amplification() {
+        let config: CompactionConfig = CompactionConfigBuilder::new()
+            .level0_tier_compact_file_number(2)
+            .max_compaction_bytes(1000)
+            .sub_level_max_compaction_bytes(150)
+            .max_bytes_for_level_multiplier(1)
+            .level0_sub_level_compact_level_count(2)
+            .build();
+        let mut picker = LevelCompactionPicker::new_with_mode(
+            1,
+            Arc::new(config),
+            Arc::new(CompactionTaskValidator::unused()),
+            Arc::new(CompactionDeveloperConfig::default()),
+            L0PickerMode::SingleTablePartition {
+                min_l0_level_count: 2,
+            },
+        );
+
+        let mut levels = Levels {
+            levels: vec![Level {
+                level_idx: 1,
+                level_type: LevelType::Nonoverlapping,
+                table_infos: vec![
+                    generate_table(1, 1, 100, 399, 2),
+                    generate_table(2, 1, 400, 699, 2),
+                    generate_table(3, 1, 700, 999, 2),
+                ],
+                total_file_size: 900,
+                sub_level_id: 0,
+                uncompressed_file_size: 900,
+                ..Default::default()
+            }],
+            l0: generate_l0_nonoverlapping_sublevels(vec![]),
+            ..Default::default()
+        };
+        push_tables_level0_nonoverlapping(
+            &mut levels,
+            vec![
+                generate_table(4, 1, 100, 180, 2),
+                generate_table(5, 1, 400, 450, 2),
+                generate_table(6, 1, 600, 700, 2),
+            ],
+        );
+        push_tables_level0_nonoverlapping(
+            &mut levels,
+            vec![
+                generate_table(7, 1, 100, 180, 3),
+                generate_table(8, 1, 400, 450, 3),
+                generate_table(9, 1, 600, 700, 3),
+            ],
+        );
+
+        let levels_handler = vec![LevelHandler::new(0), LevelHandler::new(1)];
+        let mut local_stats = LocalPickerStatistic::default();
+        let ret = picker.pick_compaction(&levels, &levels_handler, &mut local_stats);
+        assert!(ret.is_some());
+        assert_eq!(local_stats.skip_by_write_amp_limit, 0);
+    }
+
+    #[test]
+    fn test_to_base_defensively_rejects_too_few_selected_levels() {
+        let config = Arc::new(
+            CompactionConfigBuilder::new()
+                .level0_sub_level_compact_level_count(3)
+                .build(),
+        );
+        let developer_config = Arc::new(CompactionDeveloperConfig {
+            enable_trivial_move: false,
+            ..Default::default()
+        });
+        let validator = Arc::new(CompactionTaskValidator::new(config.clone()));
+        let mut picker = LevelCompactionPicker::new_with_mode(
+            1,
+            config,
+            validator,
+            developer_config,
+            L0PickerMode::SingleTablePartition {
+                min_l0_level_count: 3,
+            },
+        );
+        let levels = Levels {
+            levels: vec![generate_level(1, vec![])],
+            l0: generate_l0_nonoverlapping_sublevels(vec![
+                generate_table(1, 1, 0, 10, 1),
+                generate_table(2, 1, 20, 30, 2),
+                generate_table(3, 1, 40, 50, 3),
+            ]),
+            ..Default::default()
+        };
+        let handlers = vec![LevelHandler::new(0), LevelHandler::new(1)];
+        let mut stats = LocalPickerStatistic::default();
+
+        assert!(
+            picker
+                .pick_compaction(&levels, &handlers, &mut stats)
+                .is_none()
+        );
+        assert!(stats.skip_by_count_limit > 0);
     }
 
     #[test]
@@ -771,15 +1000,16 @@ pub mod tests {
                 .build(),
         );
 
-        // Only include sub-level 0 results will violate MAX_WRITE_AMPLIFICATION.
-        // But stopped by pending sub-level when trying to include more sub-levels.
         let mut picker = LevelCompactionPicker::new(
             1,
             config.clone(),
             Arc::new(CompactionDeveloperConfig::default()),
         );
-        let ret = picker.pick_compaction(&levels, &levels_handler, &mut local_stats);
-        assert!(ret.is_none());
+        assert!(
+            picker
+                .pick_compaction(&levels, &levels_handler, &mut local_stats)
+                .is_none()
+        );
 
         // Free the pending sub-level.
         for pending_task_id in &levels_handler[0].pending_tasks_ids() {

--- a/src/meta/src/hummock/compaction/picker/emergency_compaction_picker.rs
+++ b/src/meta/src/hummock/compaction/picker/emergency_compaction_picker.rs
@@ -114,3 +114,37 @@ impl EmergencyCompactionPicker {
         tier_compaction_picker.pick_compaction(levels, level_handlers, stats)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::hummock::compaction::compaction_config::CompactionConfigBuilder;
+    use crate::hummock::compaction::selector::tests::{
+        generate_l0_nonoverlapping_sublevels, generate_level, generate_table,
+    };
+
+    #[test]
+    fn test_legacy_unpartitioned_levels_use_whole_level_in_emergency() {
+        let config = Arc::new(CompactionConfig {
+            split_weight_by_vnode: 8,
+            ..CompactionConfigBuilder::new().build()
+        });
+        let picker = EmergencyCompactionPicker::new(
+            1,
+            config,
+            Arc::new(CompactionDeveloperConfig::default()),
+        );
+        let levels = Levels {
+            l0: generate_l0_nonoverlapping_sublevels(
+                (1..=3).map(|id| generate_table(id, 1, 0, 10, id)).collect(),
+            ),
+            levels: vec![generate_level(1, vec![])],
+            ..Default::default()
+        };
+        let handlers = vec![LevelHandler::new(0), LevelHandler::new(1)];
+        let ret = picker
+            .pick_compaction(&levels, &handlers, &mut LocalPickerStatistic::default())
+            .unwrap();
+        assert_eq!(ret.target_level, 0);
+    }
+}

--- a/src/meta/src/hummock/compaction/picker/intra_compaction_picker.rs
+++ b/src/meta/src/hummock/compaction/picker/intra_compaction_picker.rs
@@ -19,7 +19,7 @@ use risingwave_hummock_sdk::level::{InputLevel, Levels, OverlappingLevel};
 use risingwave_pb::hummock::{CompactionConfig, LevelType};
 
 use super::{
-    CompactionInput, CompactionPicker, CompactionTaskValidator, LocalPickerStatistic,
+    CompactionInput, CompactionPicker, CompactionTaskValidator, L0PickerMode, LocalPickerStatistic,
     ValidationRuleType,
 };
 use crate::hummock::compaction::picker::{NonOverlapSubLevelPicker, TrivialMovePicker};
@@ -31,6 +31,7 @@ pub struct IntraCompactionPicker {
     compaction_task_validator: Arc<CompactionTaskValidator>,
 
     developer_config: Arc<CompactionDeveloperConfig>,
+    mode: L0PickerMode,
 }
 
 impl CompactionPicker for IntraCompactionPicker {
@@ -49,31 +50,24 @@ impl CompactionPicker for IntraCompactionPicker {
             return Some(ret);
         }
 
-        let vnode_partition_count = self.config.split_weight_by_vnode;
-
-        if let Some(ret) =
-            self.pick_whole_level(l0, &level_handlers[0], vnode_partition_count, stats)
+        if !self.mode.is_single_table_partition()
+            && let Some(ret) = self.pick_whole_level(
+                l0,
+                &level_handlers[0],
+                self.config.split_weight_by_vnode,
+                stats,
+            )
         {
             if ret.input_levels.len() < 2 {
-                tracing::error!(
-                    ?ret,
-                    vnode_partition_count,
-                    "pick_whole_level failed to pick enough levels"
-                );
+                tracing::error!(?ret, "pick_whole_level failed to pick enough levels");
                 return None;
             }
-
             return Some(ret);
         }
 
-        if let Some(ret) = self.pick_l0_intra(l0, &level_handlers[0], vnode_partition_count, stats)
-        {
+        if let Some(ret) = self.pick_l0_intra(l0, &level_handlers[0], stats) {
             if ret.input_levels.len() < 2 {
-                tracing::error!(
-                    ?ret,
-                    vnode_partition_count,
-                    "pick_l0_intra failed to pick enough levels"
-                );
+                tracing::error!(?ret, "pick_l0_intra failed to pick enough levels");
                 return None;
             }
 
@@ -94,6 +88,7 @@ impl IntraCompactionPicker {
             compaction_task_validator: Arc::new(CompactionTaskValidator::new(config.clone())),
             config,
             developer_config,
+            mode: L0PickerMode::Legacy,
         }
     }
 
@@ -102,11 +97,26 @@ impl IntraCompactionPicker {
         compaction_task_validator: Arc<CompactionTaskValidator>,
         developer_config: Arc<CompactionDeveloperConfig>,
     ) -> IntraCompactionPicker {
+        Self::new_with_mode(
+            config,
+            compaction_task_validator,
+            developer_config,
+            L0PickerMode::Legacy,
+        )
+    }
+
+    pub(crate) fn new_with_mode(
+        config: Arc<CompactionConfig>,
+        compaction_task_validator: Arc<CompactionTaskValidator>,
+        developer_config: Arc<CompactionDeveloperConfig>,
+        mode: L0PickerMode,
+    ) -> IntraCompactionPicker {
         assert!(config.level0_sub_level_compact_level_count > 1);
         IntraCompactionPicker {
             config,
             compaction_task_validator,
             developer_config,
+            mode,
         }
     }
 
@@ -117,29 +127,29 @@ impl IntraCompactionPicker {
         partition_count: u32,
         stats: &mut LocalPickerStatistic,
     ) -> Option<CompactionInput> {
-        let picker = WholeLevelCompactionPicker::new(
-            self.config.clone(),
-            self.compaction_task_validator.clone(),
-        );
-        picker.pick_whole_level(l0, level_handler, partition_count, stats)
+        WholeLevelCompactionPicker::new(self.config.clone(), self.compaction_task_validator.clone())
+            .pick_whole_level(l0, level_handler, partition_count, stats)
     }
 
     fn pick_l0_intra(
         &self,
         l0: &OverlappingLevel,
         level_handler: &LevelHandler,
-        vnode_partition_count: u32,
         stats: &mut LocalPickerStatistic,
     ) -> Option<CompactionInput> {
         let overlap_strategy = create_overlap_strategy(self.config.compaction_mode());
-        let mut max_vnode_partition_idx = 0;
-        for (idx, level) in l0.sub_levels.iter().enumerate() {
-            if level.vnode_partition_count < vnode_partition_count {
-                break;
+        let legacy_max_partition_idx = if self.mode.is_single_table_partition() {
+            None
+        } else {
+            let mut max_idx = 0;
+            for (idx, level) in l0.sub_levels.iter().enumerate() {
+                if level.vnode_partition_count < self.config.split_weight_by_vnode {
+                    break;
+                }
+                max_idx = idx;
             }
-            max_vnode_partition_idx = idx;
-        }
-
+            Some(max_idx)
+        };
         for (idx, level) in l0.sub_levels.iter().enumerate() {
             if level.level_type != LevelType::Nonoverlapping
                 || level.total_file_size > self.config.sub_level_max_compaction_bytes
@@ -147,7 +157,7 @@ impl IntraCompactionPicker {
                 continue;
             }
 
-            if idx > max_vnode_partition_idx {
+            if legacy_max_partition_idx.is_some_and(|max_idx| idx > max_idx) {
                 break;
             }
 
@@ -176,10 +186,19 @@ impl IntraCompactionPicker {
                     .unwrap_or(compaction_config::enable_optimize_l0_interval_selection()),
             );
 
-            let candidate_l0_plans = non_overlap_sub_level_picker.pick_l0_multi_non_overlap_level(
-                &l0.sub_levels[idx..=max_vnode_partition_idx],
-                level_handler,
-            );
+            let candidate_levels = if let Some(max_idx) = legacy_max_partition_idx {
+                &l0.sub_levels[idx..=max_idx]
+            } else {
+                // Do not cross an overlapping sub-level that still needs Tier compaction.
+                let candidate_levels = &l0.sub_levels[idx..];
+                let non_overlapping_count = candidate_levels
+                    .iter()
+                    .take_while(|level| level.level_type == LevelType::Nonoverlapping)
+                    .count();
+                &candidate_levels[..non_overlapping_count]
+            };
+            let candidate_l0_plans = non_overlap_sub_level_picker
+                .pick_l0_multi_non_overlap_level(candidate_levels, level_handler);
 
             if candidate_l0_plans.is_empty() {
                 continue;
@@ -258,8 +277,9 @@ impl IntraCompactionPicker {
                 continue;
             }
 
-            if l0.sub_levels[idx + 1].vnode_partition_count
-                != l0.sub_levels[idx].vnode_partition_count
+            if !self.mode.is_single_table_partition()
+                && l0.sub_levels[idx + 1].vnode_partition_count
+                    != l0.sub_levels[idx].vnode_partition_count
             {
                 continue;
             }
@@ -356,11 +376,9 @@ impl WholeLevelCompactionPicker {
             let max_compaction_bytes = std::cmp::max(
                 self.config.max_bytes_for_level_base,
                 self.config.sub_level_max_compaction_bytes
-                    * (self.config.level0_sub_level_compact_level_count as u64),
+                    * self.config.level0_sub_level_compact_level_count as u64,
             );
-
             let mut select_input_size = 0;
-
             let mut select_level_inputs = vec![];
             let mut total_file_count = 0;
             let mut wait_enough = false;
@@ -380,7 +398,6 @@ impl WholeLevelCompactionPicker {
 
                 select_input_size += next_level.total_file_size;
                 total_file_count += next_level.table_infos.len() as u64;
-
                 select_level_inputs.push(InputLevel {
                     level_idx: 0,
                     level_type: next_level.level_type,
@@ -414,13 +431,13 @@ impl WholeLevelCompactionPicker {
                 }
             }
         }
-
         None
     }
 }
 
 #[cfg(test)]
 pub mod tests {
+    use risingwave_common::util::iter_util::ZipEqFast;
     use risingwave_hummock_sdk::level::Level;
 
     use super::*;
@@ -738,12 +755,7 @@ pub mod tests {
             );
             let mut local_stats = LocalPickerStatistic::default();
             let ret = picker
-                .pick_l0_intra(
-                    &levels.l0,
-                    &levels_handler[0],
-                    levels.l0.sub_levels[0].vnode_partition_count,
-                    &mut local_stats,
-                )
+                .pick_l0_intra(&levels.l0, &levels_handler[0], &mut local_stats)
                 .unwrap();
 
             // Ensure we can pick a candidate and the returned size/count matches the tables chosen.
@@ -854,7 +866,7 @@ pub mod tests {
             let base = epoch * 100;
             let mut ssts = vec![];
             for i in 1..50 {
-                let left = (i as usize) * 100;
+                let left = i as usize * 100;
                 let right = left + 100;
                 ssts.push(generate_table(base + i, 1, left, right, epoch));
             }
@@ -869,6 +881,59 @@ pub mod tests {
             .pick_whole_level(&l0, &level_handler, 4, &mut LocalPickerStatistic::default())
             .unwrap();
         assert_eq!(ret.input_levels.len(), 2);
+    }
+
+    #[test]
+    fn test_partition_intra_ignores_markers_but_stops_at_overlapping_level() {
+        let config = Arc::new(CompactionConfig {
+            split_weight_by_vnode: 8,
+            ..CompactionConfigBuilder::new()
+                .level0_sub_level_compact_level_count(3)
+                .sub_level_max_compaction_bytes(1000)
+                .build()
+        });
+        let mut l0 = generate_l0_nonoverlapping_multi_sublevels(
+            (1..=3)
+                .map(|epoch| {
+                    vec![
+                        generate_table(epoch * 2, 1, 0, 10, epoch),
+                        generate_table(epoch * 2 + 1, 1, 100, 110, epoch),
+                    ]
+                })
+                .collect(),
+        );
+        for (level, count) in l0.sub_levels.iter_mut().zip_eq_fast([0, 2, 4]) {
+            level.vnode_partition_count = count;
+        }
+        let picker = IntraCompactionPicker::new_with_mode(
+            config,
+            Arc::new(CompactionTaskValidator::unused()),
+            Arc::new(CompactionDeveloperConfig::default()),
+            L0PickerMode::SingleTablePartition {
+                min_l0_level_count: 1,
+            },
+        );
+        let level_handler = LevelHandler::new(0);
+        let ret = picker
+            .pick_l0_intra(&l0, &level_handler, &mut LocalPickerStatistic::default())
+            .unwrap();
+        assert_eq!(ret.input_levels.len(), 3);
+        assert!(
+            ret.input_levels
+                .iter()
+                .all(|level| level.table_infos.len() == 1)
+        );
+        assert_eq!(ret.target_sub_level_id, l0.sub_levels[0].sub_level_id);
+        assert_eq!(ret.vnode_partition_count, 0);
+        assert!(!ret.skip_target_range_conflict_check);
+
+        // An overlapping sub-level cannot be bypassed.
+        l0.sub_levels[1].level_type = LevelType::Overlapping;
+        assert!(
+            picker
+                .pick_l0_intra(&l0, &level_handler, &mut LocalPickerStatistic::default())
+                .is_none()
+        );
     }
 
     #[test]

--- a/src/meta/src/hummock/compaction/picker/mod.rs
+++ b/src/meta/src/hummock/compaction/picker/mod.rs
@@ -46,6 +46,30 @@ pub use vnode_watermark_picker::VnodeWatermarkCompactionPicker;
 
 use crate::hummock::level_handler::LevelHandler;
 
+#[derive(Clone, Copy, Debug, Default)]
+pub(crate) enum L0PickerMode {
+    #[default]
+    Legacy,
+    SingleTablePartition {
+        min_l0_level_count: usize,
+    },
+}
+
+impl L0PickerMode {
+    pub(crate) fn is_single_table_partition(self) -> bool {
+        matches!(self, Self::SingleTablePartition { .. })
+    }
+
+    pub(crate) fn min_l0_level_count(self) -> usize {
+        match self {
+            Self::Legacy => 1,
+            Self::SingleTablePartition { min_l0_level_count } => {
+                std::cmp::max(1, min_l0_level_count)
+            }
+        }
+    }
+}
+
 #[derive(Default, Debug)]
 pub struct LocalPickerStatistic {
     pub skip_by_write_amp_limit: u64,

--- a/src/meta/src/hummock/compaction/selector/level_selector.rs
+++ b/src/meta/src/hummock/compaction/selector/level_selector.rs
@@ -20,17 +20,18 @@
 use std::sync::Arc;
 
 use risingwave_hummock_sdk::HummockCompactionTaskId;
-use risingwave_hummock_sdk::level::Levels;
+use risingwave_hummock_sdk::level::{Levels, OverlappingLevel};
 use risingwave_pb::hummock::compact_task::PbTaskType;
 use risingwave_pb::hummock::{CompactionConfig, LevelType};
 
+use super::single_table_compaction::{SingleTableCompactionGroup, SingleTableL0PickerType};
 use super::{
     CompactionSelector, LevelCompactionPicker, TierCompactionPicker, create_compaction_task,
 };
 use crate::hummock::compaction::overlap_strategy::OverlapStrategy;
 use crate::hummock::compaction::picker::{
-    CompactionPicker, CompactionTaskValidator, IntraCompactionPicker, LocalPickerStatistic,
-    MinOverlappingPicker,
+    CompactionPicker, CompactionTaskValidator, IntraCompactionPicker, L0PickerMode,
+    LocalPickerStatistic, MinOverlappingPicker,
 };
 use crate::hummock::compaction::selector::CompactionSelectorContext;
 use crate::hummock::compaction::{
@@ -60,12 +61,57 @@ impl std::fmt::Display for PickerType {
     }
 }
 
+impl PickerType {
+    fn sort_rank(&self) -> u8 {
+        match self {
+            PickerType::Tier => 0,
+            PickerType::ToBase => 1,
+            PickerType::Intra => 2,
+            PickerType::BottomLevel => 3,
+        }
+    }
+}
+
 #[derive(Default, Debug)]
 pub struct PickerInfo {
     pub score: u64,
     pub select_level: usize,
     pub target_level: usize,
     pub picker_type: PickerType,
+    input: PickerInput,
+}
+
+#[derive(Default, Debug)]
+enum PickerInput {
+    #[default]
+    Global,
+    SingleTablePartition {
+        partition_score: u64,
+        l0: Arc<OverlappingLevel>,
+        min_l0_level_count: usize,
+    },
+}
+
+impl PickerInput {
+    fn partition_score(&self) -> u64 {
+        match self {
+            Self::Global => 0,
+            Self::SingleTablePartition {
+                partition_score, ..
+            } => *partition_score,
+        }
+    }
+
+    fn picker_mode(&self) -> L0PickerMode {
+        match self {
+            Self::Global => L0PickerMode::Legacy,
+            Self::SingleTablePartition {
+                min_l0_level_count, ..
+            } => L0PickerMode::SingleTablePartition {
+                min_l0_level_count: *min_l0_level_count,
+            },
+        }
+    }
 }
 
 #[derive(Default, Debug)]
@@ -109,17 +155,32 @@ impl DynamicLevelSelectorCore {
         overlap_strategy: Arc<dyn OverlapStrategy>,
         compaction_task_validator: Arc<CompactionTaskValidator>,
     ) -> Box<dyn CompactionPicker> {
+        let picker_mode = picker_info.input.picker_mode();
+        let compaction_task_validator = if picker_mode.is_single_table_partition() {
+            Arc::new(CompactionTaskValidator::unused())
+        } else {
+            compaction_task_validator
+        };
         match picker_info.picker_type {
             PickerType::Tier => Box::new(TierCompactionPicker::new_with_validator(
                 self.config.clone(),
                 compaction_task_validator,
             )),
-            PickerType::ToBase => Box::new(LevelCompactionPicker::new_with_validator(
+            PickerType::ToBase => Box::new(LevelCompactionPicker::new_with_mode(
                 picker_info.target_level,
                 self.config.clone(),
                 compaction_task_validator,
                 self.developer_config.clone(),
+                picker_mode,
             )),
+            PickerType::Intra if picker_mode.is_single_table_partition() => {
+                Box::new(IntraCompactionPicker::new_with_mode(
+                    self.config.clone(),
+                    compaction_task_validator,
+                    self.developer_config.clone(),
+                    picker_mode,
+                ))
+            }
             PickerType::Intra => Box::new(IntraCompactionPicker::new_with_validator(
                 self.config.clone(),
                 compaction_task_validator,
@@ -204,6 +265,15 @@ impl DynamicLevelSelectorCore {
         levels: &Levels,
         handlers: &[LevelHandler],
     ) -> SelectContext {
+        self.get_priority_levels_with_single_table_strategy(levels, handlers, None)
+    }
+
+    fn get_priority_levels_with_single_table_strategy(
+        &self,
+        levels: &Levels,
+        handlers: &[LevelHandler],
+        single_table_compaction_group: Option<SingleTableCompactionGroup>,
+    ) -> SelectContext {
         let mut ctx = self.calculate_level_base_size(levels);
 
         let l0_file_count = levels
@@ -255,64 +325,34 @@ impl DynamicLevelSelectorCore {
                     select_level: 0,
                     target_level: 0,
                     picker_type: PickerType::Tier,
+                    input: PickerInput::Global,
                 })
             }
 
-            // The read query at the non-overlapping level only selects ssts that match the query
-            // range at each level, so the number of levels is the most important factor affecting
-            // the read performance. At the same time, the size factor is also added to the score
-            // calculation rule to avoid unbalanced compact task due to large size.
-            let total_size = levels
-                .l0
-                .sub_levels
-                .iter()
-                .filter(|level| {
-                    level.vnode_partition_count == self.config.split_weight_by_vnode
-                        && level.level_type == LevelType::Nonoverlapping
-                })
-                .map(|level| level.total_file_size)
-                .sum::<u64>()
-                .saturating_sub(handlers[0].pending_output_file_size(ctx.base_level as u32));
-            let base_level_size = levels.get_level(ctx.base_level).total_file_size;
-            let base_level_sst_count = levels.get_level(ctx.base_level).table_infos.len() as u64;
-
-            // size limit
-            let non_overlapping_size_score = total_size * SCORE_BASE
-                / std::cmp::max(self.config.max_bytes_for_level_base, base_level_size);
-            // level count limit
-            let non_overlapping_level_count = levels
-                .l0
-                .sub_levels
-                .iter()
-                .filter(|level| level.level_type == LevelType::Nonoverlapping)
-                .count() as u64;
-            let non_overlapping_level_score = non_overlapping_level_count * SCORE_BASE
-                / std::cmp::max(
-                    base_level_sst_count / 16,
-                    self.config.level0_sub_level_compact_level_count as u64,
-                );
-
-            let non_overlapping_score =
-                std::cmp::max(non_overlapping_size_score, non_overlapping_level_score);
-
-            // Reduce the level num of l0 non-overlapping sub_level
-            if non_overlapping_size_score > SCORE_BASE {
-                ctx.score_levels.push(PickerInfo {
-                    score: non_overlapping_score + 1,
-                    select_level: 0,
-                    target_level: ctx.base_level,
-                    picker_type: PickerType::ToBase,
-                });
-            }
-
-            if non_overlapping_level_score > SCORE_BASE {
-                // FIXME: more accurate score calculation algorithm will be introduced (#11903)
-                ctx.score_levels.push(PickerInfo {
-                    score: non_overlapping_score,
-                    select_level: 0,
-                    target_level: 0,
-                    picker_type: PickerType::Intra,
-                });
+            let single_table_candidates = single_table_compaction_group.and_then(|group| {
+                group.build_l0_candidates(&self.config, &levels.l0, &handlers[0])
+            });
+            if let Some(candidates) = single_table_candidates {
+                ctx.score_levels
+                    .extend(candidates.into_iter().map(|candidate| PickerInfo {
+                        score: candidate.score,
+                        select_level: 0,
+                        target_level: match candidate.picker_type {
+                            SingleTableL0PickerType::ToBase => ctx.base_level,
+                            SingleTableL0PickerType::Intra => 0,
+                        },
+                        picker_type: match candidate.picker_type {
+                            SingleTableL0PickerType::ToBase => PickerType::ToBase,
+                            SingleTableL0PickerType::Intra => PickerType::Intra,
+                        },
+                        input: PickerInput::SingleTablePartition {
+                            partition_score: candidate.partition_score,
+                            l0: candidate.l0,
+                            min_l0_level_count: candidate.min_l0_level_count,
+                        },
+                    }));
+            } else {
+                self.add_legacy_l0_candidates(levels, handlers, &mut ctx);
             }
         }
 
@@ -335,6 +375,7 @@ impl DynamicLevelSelectorCore {
                     select_level: level_idx,
                     target_level: level_idx + 1,
                     picker_type: PickerType::BottomLevel,
+                    input: PickerInput::Global,
                 }
             });
         }
@@ -344,8 +385,67 @@ impl DynamicLevelSelectorCore {
             b.score
                 .cmp(&a.score)
                 .then_with(|| a.target_level.cmp(&b.target_level))
+                .then_with(|| a.picker_type.sort_rank().cmp(&b.picker_type.sort_rank()))
+                .then_with(|| b.input.partition_score().cmp(&a.input.partition_score()))
         });
         ctx
+    }
+
+    fn add_legacy_l0_candidates(
+        &self,
+        levels: &Levels,
+        handlers: &[LevelHandler],
+        ctx: &mut SelectContext,
+    ) {
+        // Keep this path equivalent to the original dynamic-level selector. It is used by every
+        // non-single-table compaction group and while a single-table group still contains SSTs
+        // that cannot be represented by the fixed vnode partition layout.
+        let total_size = levels
+            .l0
+            .sub_levels
+            .iter()
+            .filter(|level| {
+                level.vnode_partition_count == self.config.split_weight_by_vnode
+                    && level.level_type == LevelType::Nonoverlapping
+            })
+            .map(|level| level.total_file_size)
+            .sum::<u64>()
+            .saturating_sub(handlers[0].pending_output_file_size(ctx.base_level as u32));
+        let base_level_size = levels.get_level(ctx.base_level).total_file_size;
+        let base_level_sst_count = levels.get_level(ctx.base_level).table_infos.len() as u64;
+        let size_score = total_size * SCORE_BASE
+            / std::cmp::max(self.config.max_bytes_for_level_base, base_level_size);
+        let non_overlapping_level_count = levels
+            .l0
+            .sub_levels
+            .iter()
+            .filter(|level| level.level_type == LevelType::Nonoverlapping)
+            .count() as u64;
+        let level_score = non_overlapping_level_count * SCORE_BASE
+            / std::cmp::max(
+                base_level_sst_count / 16,
+                self.config.level0_sub_level_compact_level_count as u64,
+            );
+        let score = std::cmp::max(size_score, level_score);
+
+        if size_score > SCORE_BASE {
+            ctx.score_levels.push(PickerInfo {
+                score: score + 1,
+                select_level: 0,
+                target_level: ctx.base_level,
+                picker_type: PickerType::ToBase,
+                input: PickerInput::Global,
+            });
+        }
+        if level_score > SCORE_BASE {
+            ctx.score_levels.push(PickerInfo {
+                score,
+                select_level: 0,
+                target_level: 0,
+                picker_type: PickerType::Intra,
+                input: PickerInput::Global,
+            });
+        }
     }
 
     /// `compact_pending_bytes_needed` calculates the number of compact bytes needed to balance the
@@ -435,6 +535,7 @@ impl CompactionSelector for DynamicLevelSelector {
             selector_stats,
             developer_config,
             in_progress_compactions,
+            single_table_compaction_group,
             ..
         } = context;
         let dynamic_level_core = DynamicLevelSelectorCore::new(
@@ -443,7 +544,11 @@ impl CompactionSelector for DynamicLevelSelector {
         );
         let overlap_strategy =
             create_overlap_strategy(compaction_group.compaction_config.compaction_mode());
-        let ctx = dynamic_level_core.get_priority_levels(levels, level_handlers);
+        let ctx = dynamic_level_core.get_priority_levels_with_single_table_strategy(
+            levels,
+            level_handlers,
+            single_table_compaction_group,
+        );
         // TODO: Determine which rule to enable by write limit
         let compaction_task_validator = Arc::new(CompactionTaskValidator::new(
             compaction_group.compaction_config.clone(),
@@ -457,9 +562,20 @@ impl CompactionSelector for DynamicLevelSelector {
                 overlap_strategy.clone(),
                 compaction_task_validator.clone(),
             );
+            let single_table_levels;
+            let picker_levels = match &picker_info.input {
+                PickerInput::Global => levels,
+                PickerInput::SingleTablePartition { l0, .. } => {
+                    single_table_levels = Levels {
+                        l0: l0.as_ref().clone(),
+                        ..levels.clone()
+                    };
+                    &single_table_levels
+                }
+            };
 
             let mut stats = LocalPickerStatistic::default();
-            if let Some(ret) = picker.pick_compaction(levels, level_handlers, &mut stats) {
+            if let Some(ret) = picker.pick_compaction(picker_levels, level_handlers, &mut stats) {
                 if !ret.skip_target_range_conflict_check
                     && in_progress_compactions.has_conflict_with_input(&ret)
                 {
@@ -509,8 +625,8 @@ pub mod tests {
     use risingwave_hummock_sdk::compact_task::{CompactTask, CompactTaskAssignment};
     use risingwave_hummock_sdk::level::{InputLevel, Levels};
     use risingwave_hummock_sdk::version::HummockVersionStateTableInfo;
-    use risingwave_pb::hummock::LevelType;
     use risingwave_pb::hummock::compaction_config::CompactionMode;
+    use risingwave_pb::hummock::{CompactionConfig, LevelType};
 
     use crate::hummock::compaction::compaction_config::CompactionConfigBuilder;
     use crate::hummock::compaction::in_progress_compaction::InProgressCompactionView;
@@ -520,7 +636,7 @@ pub mod tests {
     };
     use crate::hummock::compaction::selector::{
         CompactionSelector, CompactionSelectorContext, DynamicLevelSelector,
-        DynamicLevelSelectorCore, LocalSelectorStatistic,
+        DynamicLevelSelectorCore, LocalSelectorStatistic, SingleTableCompactionGroup,
     };
     use crate::hummock::compaction::{CompactionDeveloperConfig, CompactionTask};
     use crate::hummock::level_handler::LevelHandler;
@@ -535,6 +651,7 @@ pub mod tests {
         level_handlers: &mut [LevelHandler],
         selector_stats: &mut LocalSelectorStatistic,
         in_progress_compactions: &InProgressCompactionView,
+        single_table_compaction_group: Option<SingleTableCompactionGroup>,
     ) -> Option<CompactionTask> {
         selector.pick_compaction(
             task_id,
@@ -542,6 +659,7 @@ pub mod tests {
                 group,
                 levels,
                 member_table_ids: &BTreeSet::new(),
+                single_table_compaction_group,
                 level_handlers,
                 selector_stats,
                 table_id_to_options: &HashMap::default(),
@@ -551,6 +669,60 @@ pub mod tests {
                 in_progress_compactions,
             },
         )
+    }
+
+    #[test]
+    fn test_legacy_depth_pressure_uses_intra_without_size_pressure() {
+        let config = CompactionConfig {
+            split_weight_by_vnode: 8,
+            ..CompactionConfigBuilder::new()
+                .max_level(1)
+                .max_bytes_for_level_base(1024)
+                .level0_sub_level_compact_level_count(3)
+                .sst_allowed_trivial_move_min_size(Some(u64::MAX))
+                .build()
+        };
+        let group = CompactionGroup::new(1, config.clone());
+        let levels = Levels {
+            levels: vec![generate_level(1, vec![])],
+            l0: generate_l0_nonoverlapping_sublevels(
+                (1..=4).map(|id| generate_table(id, 1, 0, 10, id)).collect(),
+            ),
+            ..Default::default()
+        };
+        assert!(levels.l0.total_file_size < config.max_bytes_for_level_base);
+        let mut handlers = vec![LevelHandler::new(0), LevelHandler::new(1)];
+        let core = DynamicLevelSelectorCore::new(
+            Arc::new(config),
+            Arc::new(CompactionDeveloperConfig::default()),
+        );
+        let priorities = core.get_priority_levels(&levels, &handlers);
+        assert!(
+            !priorities
+                .score_levels
+                .iter()
+                .any(|p| matches!(p.picker_type, super::PickerType::ToBase))
+        );
+        assert!(
+            priorities
+                .score_levels
+                .iter()
+                .any(|p| matches!(p.picker_type, super::PickerType::Intra))
+        );
+        let mut selector = DynamicLevelSelector::default();
+        let task = pick_compaction_with_in_progress(
+            &mut selector,
+            1,
+            &group,
+            &levels,
+            &mut handlers,
+            &mut LocalSelectorStatistic::default(),
+            &InProgressCompactionView::default(),
+            None,
+        )
+        .unwrap();
+        assert_eq!(task.input.target_level, 0);
+        assert_compaction_task(&task, &handlers);
     }
 
     #[test]
@@ -834,6 +1006,7 @@ pub mod tests {
             &mut levels_handlers,
             &mut local_stats,
             &empty_in_progress,
+            None,
         )
         .unwrap();
         assert_eq!(compaction.input.target_level, 4);
@@ -857,6 +1030,7 @@ pub mod tests {
                 &mut levels_handlers,
                 &mut local_stats,
                 &in_progress,
+                None,
             )
             .is_none()
         );

--- a/src/meta/src/hummock/compaction/selector/mod.rs
+++ b/src/meta/src/hummock/compaction/selector/mod.rs
@@ -20,6 +20,7 @@
 mod emergency_selector;
 pub(crate) mod level_selector;
 mod manual_selector;
+mod single_table_compaction;
 mod space_reclaim_selector;
 mod tombstone_compaction_selector;
 mod ttl_selector;
@@ -37,6 +38,7 @@ use risingwave_hummock_sdk::table_watermark::TableWatermarks;
 use risingwave_hummock_sdk::version::HummockVersionStateTableInfo;
 use risingwave_hummock_sdk::{CompactionGroupId, HummockCompactionTaskId};
 use risingwave_pb::hummock::compact_task;
+pub use single_table_compaction::SingleTableCompactionGroup;
 pub use space_reclaim_selector::SpaceReclaimCompactionSelector;
 pub use tombstone_compaction_selector::TombstoneCompactionSelector;
 pub use ttl_selector::TtlCompactionSelector;
@@ -56,6 +58,7 @@ pub struct CompactionSelectorContext<'a> {
     pub group: &'a CompactionGroup,
     pub levels: &'a Levels,
     pub member_table_ids: &'a BTreeSet<TableId>,
+    pub single_table_compaction_group: Option<SingleTableCompactionGroup>,
     pub level_handlers: &'a mut [LevelHandler],
     pub selector_stats: &'a mut LocalSelectorStatistic,
     pub table_id_to_options: &'a HashMap<TableId, TableOption>,

--- a/src/meta/src/hummock/compaction/selector/single_table_compaction.rs
+++ b/src/meta/src/hummock/compaction/selector/single_table_compaction.rs
@@ -1,0 +1,367 @@
+// Copyright 2026 RisingWave Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+
+use risingwave_common::catalog::TableId;
+use risingwave_hummock_sdk::level::OverlappingLevel;
+use risingwave_pb::hummock::CompactionConfig;
+
+use super::level_selector::SCORE_BASE;
+use crate::hummock::compaction::vnode_partition::L0VnodePartitionView;
+use crate::hummock::level_handler::LevelHandler;
+
+/// The immutable table metadata required by the partition-aware L0 strategy.
+///
+/// The manager only constructs this value for a compaction group containing exactly one table.
+/// Keeping it as a distinct type prevents the generic selector from inferring single-table
+/// eligibility from partial inputs.
+#[derive(Clone, Copy, Debug)]
+pub struct SingleTableCompactionGroup {
+    table_id: TableId,
+    vnode_count: usize,
+}
+
+impl SingleTableCompactionGroup {
+    pub(crate) fn new(table_id: TableId, vnode_count: usize) -> Self {
+        Self {
+            table_id,
+            vnode_count,
+        }
+    }
+
+    /// Build partition-local candidates from the current L0 and pending state.
+    ///
+    /// `None` means that the current L0 cannot be represented by the fixed vnode layout and the
+    /// caller must use the legacy global L0 strategy. `Some([])` means the partition strategy is
+    /// active but no partition has reached the configured depth threshold.
+    pub(super) fn build_l0_candidates(
+        self,
+        config: &CompactionConfig,
+        l0: &OverlappingLevel,
+        l0_handler: &LevelHandler,
+    ) -> Option<Vec<SingleTableL0Candidate>> {
+        let partition_view = L0VnodePartitionView::build(
+            self.table_id,
+            self.vnode_count,
+            config.split_weight_by_vnode as usize,
+            l0,
+            l0_handler,
+        )?;
+        let min_l0_level_count = config.level0_sub_level_compact_level_count as usize;
+        let partitions = partition_view
+            .into_partitions(min_l0_level_count as u64, SCORE_BASE)
+            .filter(|(score, partition_l0)| {
+                *score > SCORE_BASE && !partition_l0.sub_levels.is_empty()
+            })
+            .map(|(score, partition_l0)| SingleTableL0Partition {
+                score,
+                l0: Arc::new(partition_l0),
+            })
+            .collect::<Vec<_>>();
+
+        let Some(global_l0_score) = partitions.iter().map(|partition| partition.score).max() else {
+            return Some(vec![]);
+        };
+
+        let mut candidates = Vec::with_capacity(partitions.len() * 2);
+        for partition in &partitions {
+            candidates.push(SingleTableL0Candidate {
+                score: global_l0_score.saturating_add(1),
+                partition_score: partition.score,
+                picker_type: SingleTableL0PickerType::ToBase,
+                l0: partition.l0.clone(),
+                min_l0_level_count,
+            });
+        }
+        for partition in partitions {
+            candidates.push(SingleTableL0Candidate {
+                score: global_l0_score,
+                partition_score: partition.score,
+                picker_type: SingleTableL0PickerType::Intra,
+                l0: partition.l0,
+                min_l0_level_count: 1,
+            });
+        }
+        Some(candidates)
+    }
+}
+
+struct SingleTableL0Partition {
+    score: u64,
+    l0: Arc<OverlappingLevel>,
+}
+
+#[derive(Clone, Copy, Debug)]
+pub(super) enum SingleTableL0PickerType {
+    ToBase,
+    Intra,
+}
+
+#[derive(Debug)]
+pub(super) struct SingleTableL0Candidate {
+    pub(super) score: u64,
+    pub(super) partition_score: u64,
+    pub(super) picker_type: SingleTableL0PickerType,
+    pub(super) l0: Arc<OverlappingLevel>,
+    pub(super) min_l0_level_count: usize,
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::{BTreeSet, HashMap};
+    use std::sync::Arc;
+
+    use bytes::Bytes;
+    use itertools::Itertools;
+    use risingwave_common::hash::VirtualNode;
+    use risingwave_hummock_sdk::HummockCompactionTaskId;
+    use risingwave_hummock_sdk::key::{FullKey, TableKey};
+    use risingwave_hummock_sdk::key_range::KeyRange;
+    use risingwave_hummock_sdk::level::{Levels, OverlappingLevel};
+    use risingwave_hummock_sdk::sstable_info::SstableInfo;
+    use risingwave_hummock_sdk::version::HummockVersionStateTableInfo;
+    use risingwave_pb::hummock::CompactionConfig;
+
+    use super::*;
+    use crate::hummock::compaction::compaction_config::CompactionConfigBuilder;
+    use crate::hummock::compaction::in_progress_compaction::InProgressCompactionView;
+    use crate::hummock::compaction::selector::level_selector::DynamicLevelSelector;
+    use crate::hummock::compaction::selector::tests::{
+        generate_l0_nonoverlapping_multi_sublevels, generate_l0_nonoverlapping_sublevels,
+        generate_level, generate_table,
+    };
+    use crate::hummock::compaction::selector::{
+        CompactionSelector, CompactionSelectorContext, LocalSelectorStatistic,
+    };
+    use crate::hummock::compaction::{CompactionDeveloperConfig, CompactionTask};
+    use crate::hummock::level_handler::LevelHandler;
+    use crate::hummock::model::CompactionGroup;
+
+    fn vnode_key(vnode: usize) -> Bytes {
+        FullKey::new(
+            TableId::new(1),
+            TableKey(VirtualNode::from_index(vnode).to_be_bytes().to_vec()),
+            u64::MAX,
+        )
+        .encode()
+        .into()
+    }
+
+    fn vnode_sst(id: u64, left_vnode: usize, right_vnode: usize) -> SstableInfo {
+        let mut sst = generate_table(id, 1, 0, 1, id);
+        let mut inner = sst.get_inner();
+        inner.key_range = KeyRange {
+            left: vnode_key(left_vnode),
+            right: vnode_key(right_vnode),
+            right_exclusive: true,
+        };
+        sst.set_inner(inner);
+        sst
+    }
+
+    fn two_partition_l0(first_depth: usize, second_depth: usize) -> OverlappingLevel {
+        generate_l0_nonoverlapping_multi_sublevels(
+            (0..std::cmp::max(first_depth, second_depth))
+                .map(|level| {
+                    let mut ssts = vec![];
+                    if level < first_depth {
+                        ssts.push(vnode_sst(level as u64 + 1, 0, 32));
+                    }
+                    if level < second_depth {
+                        ssts.push(vnode_sst(level as u64 + 101, 32, 64));
+                    }
+                    ssts
+                })
+                .collect(),
+        )
+    }
+
+    fn pick_compaction(
+        task_id: HummockCompactionTaskId,
+        group: &CompactionGroup,
+        levels: &Levels,
+        level_handlers: &mut [LevelHandler],
+        in_progress_compactions: &InProgressCompactionView,
+    ) -> Option<CompactionTask> {
+        DynamicLevelSelector::default().pick_compaction(
+            task_id,
+            CompactionSelectorContext {
+                group,
+                levels,
+                member_table_ids: &BTreeSet::from([TableId::new(1)]),
+                single_table_compaction_group: Some(SingleTableCompactionGroup::new(
+                    TableId::new(1),
+                    256,
+                )),
+                level_handlers,
+                selector_stats: &mut LocalSelectorStatistic::default(),
+                table_id_to_options: &HashMap::default(),
+                developer_config: Arc::new(CompactionDeveloperConfig::default()),
+                table_watermarks: &HashMap::default(),
+                state_table_info: &HummockVersionStateTableInfo::empty(),
+                in_progress_compactions,
+            },
+        )
+    }
+
+    #[test]
+    fn local_depth_does_not_sum_across_partitions() {
+        let config = CompactionConfig {
+            split_weight_by_vnode: 8,
+            ..CompactionConfigBuilder::new()
+                .level0_sub_level_compact_level_count(3)
+                .build()
+        };
+        let l0 = generate_l0_nonoverlapping_sublevels(
+            (0..8)
+                .map(|partition| {
+                    vnode_sst(partition as u64 + 1, partition * 32, (partition + 1) * 32)
+                })
+                .collect(),
+        );
+        let candidates = SingleTableCompactionGroup::new(TableId::new(1), 256)
+            .build_l0_candidates(&config, &l0, &LevelHandler::new(0))
+            .unwrap();
+        assert!(candidates.is_empty());
+    }
+
+    #[test]
+    fn pending_partition_does_not_block_another_partition() {
+        let config = CompactionConfig {
+            split_weight_by_vnode: 8,
+            ..CompactionConfigBuilder::new()
+                .max_level(1)
+                .max_bytes_for_level_base(1024)
+                .level0_sub_level_compact_level_count(2)
+                .build()
+        };
+        let group = CompactionGroup::new(1, config);
+        let levels = Levels {
+            levels: vec![generate_level(1, vec![])],
+            l0: generate_l0_nonoverlapping_multi_sublevels(
+                (1..=3)
+                    .map(|id| vec![vnode_sst(id, 0, 32), vnode_sst(id + 100, 32, 64)])
+                    .collect(),
+            ),
+            ..Default::default()
+        };
+        let mut handlers = vec![LevelHandler::new(0), LevelHandler::new(1)];
+        handlers[0].add_pending_task(
+            100,
+            0,
+            levels
+                .l0
+                .sub_levels
+                .iter()
+                .map(|level| &level.table_infos[0]),
+        );
+
+        let task = pick_compaction(
+            1,
+            &group,
+            &levels,
+            &mut handlers,
+            &InProgressCompactionView::default(),
+        )
+        .unwrap();
+        let selected_l0_ids = task
+            .input
+            .input_levels
+            .iter()
+            .filter(|level| level.level_idx == 0)
+            .flat_map(|level| level.table_infos.iter())
+            .map(|sst| sst.sst_id.as_raw_id())
+            .collect_vec();
+        assert!(!selected_l0_ids.is_empty());
+        assert!(selected_l0_ids.iter().all(|sst_id| *sst_id > 100));
+    }
+
+    #[test]
+    fn to_base_prefers_the_deeper_partition() {
+        let config = CompactionConfig {
+            split_weight_by_vnode: 8,
+            ..CompactionConfigBuilder::new()
+                .max_level(1)
+                .max_bytes_for_level_base(1024)
+                .level0_sub_level_compact_level_count(2)
+                .build()
+        };
+        let group = CompactionGroup::new(1, config);
+        let levels = Levels {
+            levels: vec![generate_level(1, vec![])],
+            l0: two_partition_l0(4, 2),
+            ..Default::default()
+        };
+        let mut handlers = vec![LevelHandler::new(0), LevelHandler::new(1)];
+
+        let task = pick_compaction(
+            1,
+            &group,
+            &levels,
+            &mut handlers,
+            &InProgressCompactionView::default(),
+        )
+        .unwrap();
+        assert_eq!(task.input.target_level, 1);
+        assert!(
+            task.input
+                .input_levels
+                .iter()
+                .filter(|level| level.level_idx == 0)
+                .flat_map(|level| level.table_infos.iter())
+                .all(|sst| sst.sst_id.as_raw_id() < 100)
+        );
+    }
+
+    #[test]
+    fn intra_is_used_only_after_partition_to_base_is_blocked() {
+        let config = CompactionConfig {
+            split_weight_by_vnode: 8,
+            ..CompactionConfigBuilder::new()
+                .max_level(1)
+                .max_bytes_for_level_base(1024)
+                .level0_sub_level_compact_level_count(2)
+                .build()
+        };
+        let group = CompactionGroup::new(1, config);
+        let levels = Levels {
+            levels: vec![generate_level(
+                1,
+                vec![vnode_sst(1000, 0, 32), vnode_sst(1001, 32, 64)],
+            )],
+            l0: two_partition_l0(4, 2),
+            ..Default::default()
+        };
+        let mut handlers = vec![LevelHandler::new(0), LevelHandler::new(1)];
+        handlers[1].add_pending_task(100, 1, &levels.levels[0].table_infos);
+
+        let task = pick_compaction(
+            1,
+            &group,
+            &levels,
+            &mut handlers,
+            &InProgressCompactionView::default(),
+        )
+        .unwrap();
+        assert_eq!(task.input.target_level, 0);
+        assert!(
+            task.input
+                .input_levels
+                .iter()
+                .flat_map(|level| level.table_infos.iter())
+                .all(|sst| sst.sst_id.as_raw_id() < 100)
+        );
+    }
+}

--- a/src/meta/src/hummock/compaction/vnode_partition.rs
+++ b/src/meta/src/hummock/compaction/vnode_partition.rs
@@ -1,0 +1,286 @@
+// Copyright 2026 RisingWave Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use risingwave_common::catalog::TableId;
+use risingwave_hummock_sdk::key_range::{KeyRange, KeyRangeCommon};
+use risingwave_hummock_sdk::level::{Level, OverlappingLevel};
+use risingwave_hummock_sdk::vnode_partition::{
+    build_vnode_partition_boundary_keys, vnode_boundary_full_key,
+};
+use risingwave_pb::hummock::LevelType;
+
+use crate::hummock::level_handler::LevelHandler;
+
+#[derive(Debug)]
+struct VnodePartition {
+    depth: u64,
+    l0: OverlappingLevel,
+}
+
+/// A transient, fixed vnode-partition view of runnable L0 stack depth.
+///
+/// Partition boundaries come from table metadata and compaction-group config, while depth is
+/// rebuilt from the current version and pending-file state for every selection. Empty vnode ranges
+/// therefore remain stable partitions with zero pressure.
+#[derive(Debug)]
+pub(crate) struct L0VnodePartitionView {
+    partitions: Vec<VnodePartition>,
+}
+
+impl L0VnodePartitionView {
+    pub(crate) fn build(
+        table_id: TableId,
+        vnode_count: usize,
+        partition_count: usize,
+        l0: &OverlappingLevel,
+        l0_handler: &LevelHandler,
+    ) -> Option<Self> {
+        if partition_count <= 1 || partition_count > vnode_count {
+            return None;
+        }
+
+        let partition_ranges = build_partition_ranges(table_id, vnode_count, partition_count);
+        let mut partition_levels = (0..partition_count)
+            .map(|_| {
+                l0.sub_levels
+                    .iter()
+                    .map(|level| Level {
+                        level_idx: level.level_idx,
+                        level_type: level.level_type,
+                        table_infos: vec![],
+                        total_file_size: 0,
+                        sub_level_id: level.sub_level_id,
+                        uncompressed_file_size: 0,
+                        vnode_partition_count: 0,
+                    })
+                    .collect::<Vec<_>>()
+            })
+            .collect::<Vec<_>>();
+
+        for (level_index, level) in l0.sub_levels.iter().enumerate() {
+            for sst in &level.table_infos {
+                if sst.table_ids.as_slice() != [table_id]
+                    || sst.key_range.left.is_empty()
+                    || sst.key_range.right.is_empty()
+                {
+                    return None;
+                }
+                let mut matching_partitions = partition_ranges
+                    .iter()
+                    .enumerate()
+                    .filter(|(_, range)| range.sstable_overlap(&sst.key_range));
+                let (partition_index, _) = matching_partitions.next()?;
+
+                // A filtered L0 view is safe only when every SST belongs to exactly one fixed
+                // partition. Old or unaligned SSTs fall back to the unpartitioned selector until
+                // compaction replaces them.
+                if matching_partitions.next().is_some() {
+                    return None;
+                }
+
+                let partition_level = &mut partition_levels[partition_index][level_index];
+                partition_level.table_infos.push(sst.clone());
+                partition_level.total_file_size += sst.sst_size;
+                partition_level.uncompressed_file_size += sst.uncompressed_file_size;
+            }
+        }
+
+        let partitions = partition_levels
+            .into_iter()
+            .map(|sub_levels| {
+                // Empty sub-levels only contain SSTs from other disjoint vnode partitions. Drop
+                // them so the existing picker sees the same ordered L0 stack for this partition
+                // without being blocked by unrelated levels.
+                let sub_levels = sub_levels
+                    .into_iter()
+                    .filter(|level| !level.table_infos.is_empty())
+                    .collect::<Vec<_>>();
+                let depth = sub_levels
+                    .iter()
+                    .filter(|level| {
+                        level.level_type == LevelType::Nonoverlapping
+                            && level
+                                .table_infos
+                                .iter()
+                                .any(|sst| !l0_handler.is_pending_compact(&sst.sst_id))
+                    })
+                    .count() as u64;
+                let total_file_size = sub_levels.iter().map(|level| level.total_file_size).sum();
+                let uncompressed_file_size = sub_levels
+                    .iter()
+                    .map(|level| level.uncompressed_file_size)
+                    .sum();
+
+                VnodePartition {
+                    depth,
+                    l0: OverlappingLevel {
+                        sub_levels,
+                        total_file_size,
+                        uncompressed_file_size,
+                    },
+                }
+            })
+            .collect();
+
+        Some(Self { partitions })
+    }
+
+    pub(crate) fn into_partitions(
+        self,
+        min_level_count: u64,
+        score_base: u64,
+    ) -> impl Iterator<Item = (u64, OverlappingLevel)> {
+        let threshold = std::cmp::max(1, min_level_count);
+        self.partitions
+            .into_iter()
+            .map(move |partition| (partition.depth * score_base / threshold, partition.l0))
+    }
+
+    #[cfg(test)]
+    fn depths(&self) -> Vec<u64> {
+        self.partitions
+            .iter()
+            .map(|partition| partition.depth)
+            .collect()
+    }
+}
+
+fn build_partition_ranges(
+    table_id: TableId,
+    vnode_count: usize,
+    partition_count: usize,
+) -> Vec<KeyRange> {
+    let mut starts = Vec::with_capacity(partition_count);
+    starts.push(vnode_boundary_full_key(table_id, 0));
+    starts.extend(build_vnode_partition_boundary_keys(
+        table_id,
+        vnode_count,
+        partition_count,
+    ));
+
+    starts
+        .iter()
+        .enumerate()
+        .map(|(idx, left)| KeyRange {
+            left: left.clone(),
+            right: starts.get(idx + 1).cloned().unwrap_or_default(),
+            right_exclusive: true,
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use risingwave_hummock_sdk::level::Level;
+    use risingwave_hummock_sdk::sstable_info::{SstableInfo, SstableInfoInner};
+
+    use super::*;
+
+    fn sst(id: u64, left_vnode: usize, right_vnode: usize) -> SstableInfo {
+        let table_id = TableId::new(1);
+        SstableInfoInner {
+            object_id: id.into(),
+            sst_id: id.into(),
+            key_range: KeyRange {
+                left: vnode_boundary_full_key(table_id, left_vnode),
+                right: vnode_boundary_full_key(table_id, right_vnode),
+                right_exclusive: true,
+            },
+            table_ids: vec![table_id],
+            sst_size: 1,
+            ..Default::default()
+        }
+        .into()
+    }
+
+    fn l0(levels: Vec<Vec<SstableInfo>>) -> OverlappingLevel {
+        OverlappingLevel {
+            sub_levels: levels
+                .into_iter()
+                .enumerate()
+                .map(|(idx, table_infos)| Level {
+                    level_idx: 0,
+                    level_type: LevelType::Nonoverlapping,
+                    table_infos,
+                    sub_level_id: idx as u64,
+                    ..Default::default()
+                })
+                .collect(),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn sparse_writes_do_not_change_partition_layout() {
+        let l0 = l0((1..=4).map(|id| vec![sst(id, 0, 16)]).collect());
+        let view = L0VnodePartitionView::build(TableId::new(1), 256, 8, &l0, &LevelHandler::new(0))
+            .unwrap();
+
+        assert_eq!(view.depths(), vec![4, 0, 0, 0, 0, 0, 0, 0]);
+    }
+
+    #[test]
+    fn depth_counts_non_empty_sub_levels_in_the_partition() {
+        let l0 = l0(vec![vec![sst(1, 0, 4)], vec![sst(2, 8, 12)]]);
+        let view = L0VnodePartitionView::build(TableId::new(1), 256, 8, &l0, &LevelHandler::new(0))
+            .unwrap();
+
+        assert_eq!(view.depths()[0], 2);
+    }
+
+    #[test]
+    fn pending_ssts_are_removed_from_runnable_depth() {
+        let l0 = l0((1..=4).map(|id| vec![sst(id, 0, 16)]).collect());
+        let mut handler = LevelHandler::new(0);
+        handler.add_pending_task(10, 1, &l0.sub_levels[0].table_infos);
+        let view = L0VnodePartitionView::build(TableId::new(1), 256, 8, &l0, &handler).unwrap();
+
+        assert_eq!(view.depths()[0], 3);
+    }
+
+    #[test]
+    fn unrelated_sub_levels_are_removed_from_the_partition_view() {
+        let mut l0 = l0(vec![
+            vec![sst(1, 0, 16)],
+            vec![sst(2, 32, 48)],
+            vec![sst(3, 0, 16)],
+        ]);
+        l0.sub_levels[1].level_type = LevelType::Overlapping;
+        let view = L0VnodePartitionView::build(TableId::new(1), 256, 8, &l0, &LevelHandler::new(0))
+            .unwrap();
+
+        assert_eq!(view.partitions[0].l0.sub_levels.len(), 2);
+        assert!(
+            view.partitions[0]
+                .l0
+                .sub_levels
+                .iter()
+                .all(|level| level.level_type == LevelType::Nonoverlapping)
+        );
+        assert_eq!(view.partitions[1].l0.sub_levels.len(), 1);
+        assert_eq!(
+            view.partitions[1].l0.sub_levels[0].level_type,
+            LevelType::Overlapping
+        );
+    }
+
+    #[test]
+    fn unaligned_sst_disables_the_partition_view() {
+        let l0 = l0(vec![vec![sst(1, 0, 64)]]);
+        assert!(
+            L0VnodePartitionView::build(TableId::new(1), 256, 8, &l0, &LevelHandler::new(0),)
+                .is_none()
+        );
+    }
+}

--- a/src/meta/src/hummock/manager/commit_epoch.rs
+++ b/src/meta/src/hummock/manager/commit_epoch.rs
@@ -15,10 +15,12 @@
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::sync::Arc;
 
+use bytes::Bytes;
 use itertools::Itertools;
 use risingwave_common::bail;
 use risingwave_common::catalog::TableId;
 use risingwave_common::config::meta::default::compaction_config;
+use risingwave_common::hash::VnodeCountCompat;
 use risingwave_common::system_param::reader::SystemParamsRead;
 use risingwave_hummock_sdk::change_log::EpochNewChangeLog;
 use risingwave_hummock_sdk::compaction_group::group_split::split_sst_with_table_ids;
@@ -29,8 +31,9 @@ use risingwave_hummock_sdk::table_stats::{
 use risingwave_hummock_sdk::table_watermark::TableWatermarks;
 use risingwave_hummock_sdk::vector_index::VectorIndexDelta;
 use risingwave_hummock_sdk::version::HummockVersionStateTableInfo;
+use risingwave_hummock_sdk::vnode_partition::build_vnode_partition_boundary_keys;
 use risingwave_hummock_sdk::{
-    CompactionGroupId, HummockContextId, HummockSstableObjectId, LocalSstableInfo,
+    CompactionGroupId, HummockContextId, HummockSstableId, HummockSstableObjectId, LocalSstableInfo,
 };
 use risingwave_pb::hummock::{CompactionConfig, compact_task};
 use sea_orm::TransactionTrait;
@@ -38,7 +41,7 @@ use sea_orm::TransactionTrait;
 use crate::hummock::error::{Error, Result};
 use crate::hummock::manager::compaction_group_manager::CompactionGroupManager;
 use crate::hummock::manager::transaction::{
-    HummockVersionStatsTransaction, HummockVersionTransaction,
+    CommitSubLevel, HummockVersionStatsTransaction, HummockVersionTransaction,
 };
 use crate::hummock::manager::versioning::Versioning;
 use crate::hummock::metrics_utils::{
@@ -49,8 +52,19 @@ use crate::hummock::sequence::{next_compaction_group_id, next_sstable_id};
 use crate::hummock::time_travel::should_mark_next_time_travel_version_snapshot;
 use crate::hummock::{HummockManager, commit_multi_var_with_provided_txn};
 
+mod commit_epoch_vnode_partition;
+
+use commit_epoch_vnode_partition::{
+    build_nonoverlapping_layers, chunk_nonoverlapping_layer_by_size, count_boundaries_in_key_range,
+    split_sst_by_boundary_keys,
+};
+
 pub struct NewTableFragmentInfo {
     pub table_ids: HashSet<TableId>,
+}
+
+struct VnodeEligibility {
+    boundary_keys: Vec<Bytes>,
 }
 
 #[derive(Default)]
@@ -209,8 +223,14 @@ impl HummockManager {
             }
         }
 
-        let group_id_to_sub_levels =
-            rewrite_commit_sstables_to_sub_level(commit_sstables, &group_id_to_config);
+        let group_id_to_sub_levels = self
+            .rewrite_commit_sstables_to_sub_level(
+                commit_sstables,
+                &group_id_to_config,
+                state_table_info,
+                &new_table_ids,
+            )
+            .await?;
 
         // build group_id to truncate tables
         let mut group_id_to_truncate_tables: HashMap<CompactionGroupId, HashSet<TableId>> =
@@ -501,6 +521,194 @@ impl HummockManager {
 
         Ok(commit_sstables)
     }
+
+    async fn rewrite_commit_sstables_to_sub_level(
+        &self,
+        commit_sstables: BTreeMap<CompactionGroupId, Vec<SstableInfo>>,
+        group_id_to_config: &HashMap<CompactionGroupId, Arc<CompactionConfig>>,
+        state_table_info: &HummockVersionStateTableInfo,
+        new_table_ids: &HashMap<TableId, CompactionGroupId>,
+    ) -> Result<BTreeMap<CompactionGroupId, Vec<CommitSubLevel>>> {
+        struct VnodeSplitPlan {
+            group_id: CompactionGroupId,
+            boundary_keys: Vec<Bytes>,
+            inserted_ssts: Vec<SstableInfo>,
+            sub_level_size_limit: u64,
+            split_count: u64,
+            vnode_partition_count: u32,
+        }
+
+        let mut result = BTreeMap::new();
+        let mut vnode_plans: Vec<VnodeSplitPlan> = vec![];
+        let mut total_new_sst_id_needed: u64 = 0;
+
+        for (group_id, inserted_ssts) in commit_sstables {
+            let config = group_id_to_config
+                .get(&group_id)
+                .expect("compaction group should exist");
+            let sub_level_size_limit = config
+                .max_overlapping_level_size
+                .unwrap_or(compaction_config::max_overlapping_level_size());
+
+            if inserted_ssts.is_empty() {
+                result.insert(group_id, vec![]);
+                continue;
+            }
+
+            let Some(VnodeEligibility { boundary_keys, .. }) = self
+                .vnode_partition_eligibility(
+                    group_id,
+                    &inserted_ssts,
+                    state_table_info,
+                    new_table_ids,
+                    config,
+                )
+                .await
+            else {
+                result.insert(
+                    group_id,
+                    rewrite_commit_sstables_to_sub_level_by_size(
+                        inserted_ssts,
+                        sub_level_size_limit,
+                    ),
+                );
+                continue;
+            };
+
+            let vnode_partition_count = config.split_weight_by_vnode;
+            let mut split_count = 0u64;
+            for sst in &inserted_ssts {
+                split_count += count_boundaries_in_key_range(&sst.key_range, &boundary_keys) as u64;
+            }
+
+            total_new_sst_id_needed += split_count * 2;
+            vnode_plans.push(VnodeSplitPlan {
+                group_id,
+                boundary_keys,
+                inserted_ssts,
+                sub_level_size_limit,
+                split_count,
+                vnode_partition_count,
+            });
+        }
+
+        let mut new_sst_id: HummockSstableId = if total_new_sst_id_needed > 0 {
+            next_sstable_id(&self.env, total_new_sst_id_needed).await?
+        } else {
+            0.into()
+        };
+
+        for plan in vnode_plans {
+            let mut fragments: Vec<SstableInfo> =
+                Vec::with_capacity(plan.inserted_ssts.len() + plan.split_count as usize);
+
+            for sst in plan.inserted_ssts {
+                fragments.extend(split_sst_by_boundary_keys(
+                    sst,
+                    &plan.boundary_keys,
+                    &mut new_sst_id,
+                ));
+            }
+
+            let layers = build_nonoverlapping_layers(fragments);
+
+            let mut sub_levels = vec![];
+            for layer in layers {
+                let chunks = chunk_nonoverlapping_layer_by_size(layer, plan.sub_level_size_limit);
+                sub_levels.extend(chunks.into_iter().map(|ssts| CommitSubLevel {
+                    ssts,
+                    vnode_partition_count: plan.vnode_partition_count,
+                }));
+            }
+
+            result.insert(plan.group_id, sub_levels);
+        }
+
+        Ok(result)
+    }
+
+    async fn vnode_partition_eligibility(
+        &self,
+        group_id: CompactionGroupId,
+        inserted_ssts: &[SstableInfo],
+        state_table_info: &HummockVersionStateTableInfo,
+        new_table_ids: &HashMap<TableId, CompactionGroupId>,
+        config: &CompactionConfig,
+    ) -> Option<VnodeEligibility> {
+        let partition_count = config.split_weight_by_vnode as usize;
+        let mut member_table_ids = state_table_info
+            .compaction_group_member_table_ids(group_id)
+            .iter()
+            .copied()
+            .chain(new_table_ids.iter().filter_map(|(table_id, new_group_id)| {
+                (*new_group_id == group_id).then_some(*table_id)
+            }));
+        let table_id = member_table_ids.next()?;
+        if member_table_ids.next().is_some() {
+            return None;
+        }
+
+        if partition_count <= 1
+            || !inserted_ssts.iter().all(|sst| {
+                sst.table_ids.len() == 1
+                    && sst.table_ids[0] == table_id
+                    && !sst.key_range.inf_key_range()
+                    && !sst.key_range.left.is_empty()
+                    && !sst.key_range.right.is_empty()
+            })
+        {
+            return None;
+        }
+
+        let vnode_count = if let Some(vnode_count) =
+            self.table_id_to_vnode_count.read().get(&table_id).copied()
+        {
+            vnode_count
+        } else {
+            let table = match self
+                .metadata_manager
+                .get_table_catalog_by_ids(&[table_id])
+                .await
+            {
+                Ok(mut tables) => tables.pop(),
+                Err(e) => {
+                    tracing::warn!(
+                        error = %e,
+                        %group_id,
+                        %table_id,
+                        "failed to get table catalog for vnode split in commit_epoch, fallback to overlapping",
+                    );
+                    None
+                }
+            }?;
+            if table.maybe_vnode_count == Some(0) {
+                return None;
+            }
+            let vnode_count = table.vnode_count();
+            self.table_id_to_vnode_count
+                .write()
+                .insert(table_id, vnode_count);
+            vnode_count
+        };
+        if partition_count > vnode_count {
+            tracing::warn!(
+                %group_id,
+                %table_id,
+                vnode_count,
+                partition_count,
+                "partition_count > vnode_count in commit_epoch, fallback to overlapping",
+            );
+            return None;
+        }
+
+        Some(VnodeEligibility {
+            boundary_keys: build_vnode_partition_boundary_keys(
+                table_id,
+                vnode_count,
+                partition_count,
+            ),
+        })
+    }
 }
 
 fn on_handle_add_new_table(
@@ -524,48 +732,37 @@ fn on_handle_add_new_table(
     Ok(())
 }
 
-/// Rewrite the commit sstables to sub-levels based on the compaction group config.
-/// The type of `compaction_group_manager_txn` is too complex to be used in the function signature. So we use `HashMap` instead.
-fn rewrite_commit_sstables_to_sub_level(
-    commit_sstables: BTreeMap<CompactionGroupId, Vec<SstableInfo>>,
-    group_id_to_config: &HashMap<CompactionGroupId, Arc<CompactionConfig>>,
-) -> BTreeMap<CompactionGroupId, Vec<Vec<SstableInfo>>> {
-    let mut overlapping_sstables: BTreeMap<CompactionGroupId, Vec<Vec<SstableInfo>>> =
-        BTreeMap::new();
-    for (group_id, inserted_table_infos) in commit_sstables {
-        let config = group_id_to_config
-            .get(&group_id)
-            .expect("compaction group should exist");
+fn rewrite_commit_sstables_to_sub_level_by_size(
+    inserted_ssts: Vec<SstableInfo>,
+    sub_level_size_limit: u64,
+) -> Vec<CommitSubLevel> {
+    let mut accumulated_size = 0;
+    let mut ssts = vec![];
+    let mut sub_levels = vec![];
 
-        let mut accumulated_size = 0;
-        let mut ssts = vec![];
-        let sub_level_size_limit = config
-            .max_overlapping_level_size
-            .unwrap_or(compaction_config::max_overlapping_level_size());
-
-        let level = overlapping_sstables.entry(group_id).or_default();
-
-        for sst in inserted_table_infos {
-            accumulated_size += sst.sst_size;
-            ssts.push(sst);
-            if accumulated_size > sub_level_size_limit {
-                level.push(ssts);
-
-                // reset the accumulated size and ssts
-                accumulated_size = 0;
-                ssts = vec![];
-            }
+    for sst in inserted_ssts {
+        accumulated_size += sst.sst_size;
+        ssts.push(sst);
+        if accumulated_size > sub_level_size_limit {
+            sub_levels.push(ssts);
+            accumulated_size = 0;
+            ssts = vec![];
         }
-
-        if !ssts.is_empty() {
-            level.push(ssts);
-        }
-
-        // The uploader organizes the ssts in decreasing epoch order, so the level needs to be reversed to ensure that the latest epoch is at the top.
-        level.reverse();
     }
 
-    overlapping_sstables
+    if !ssts.is_empty() {
+        sub_levels.push(ssts);
+    }
+
+    // The uploader organizes the ssts in decreasing epoch order, so the level needs to be reversed to ensure that the latest epoch is at the top.
+    sub_levels.reverse();
+    sub_levels
+        .into_iter()
+        .map(|ssts| CommitSubLevel {
+            ssts,
+            vnode_partition_count: 0,
+        })
+        .collect()
 }
 
 fn is_ordered_subset<T: PartialEq>(vec_1: &Vec<T>, vec_2: &Vec<T>) -> bool {

--- a/src/meta/src/hummock/manager/commit_epoch/commit_epoch_vnode_partition.rs
+++ b/src/meta/src/hummock/manager/commit_epoch/commit_epoch_vnode_partition.rs
@@ -1,0 +1,462 @@
+use bytes::Bytes;
+use risingwave_hummock_sdk::compaction_group::group_split::split_sst_at_vnode_boundary;
+use risingwave_hummock_sdk::key_range::{KeyRange, KeyRangeCommon};
+use risingwave_hummock_sdk::sstable_info::SstableInfo;
+use risingwave_hummock_sdk::{HummockSstableId, KeyComparator};
+
+fn boundary_in_key_range(boundary: &[u8], key_range: &KeyRange) -> bool {
+    if key_range.left.is_empty() || key_range.right.is_empty() {
+        return false;
+    }
+
+    // Require boundary > left to avoid generating empty left range.
+    if !KeyComparator::compare_encoded_full_key(boundary, &key_range.left).is_gt() {
+        return false;
+    }
+
+    // Require boundary < right. `boundary == right` doesn't indicate cross-partition and would
+    // create a tiny tail range.
+    KeyComparator::compare_encoded_full_key(boundary, &key_range.right).is_lt()
+}
+
+pub fn count_boundaries_in_key_range(key_range: &KeyRange, boundary_keys: &[Bytes]) -> usize {
+    boundary_keys
+        .iter()
+        .filter(|b| boundary_in_key_range(b.as_ref(), key_range))
+        .count()
+}
+
+pub fn split_sst_by_boundary_keys(
+    sst: SstableInfo,
+    boundary_keys: &[Bytes],
+    new_sst_id: &mut HummockSstableId,
+) -> Vec<SstableInfo> {
+    let key_range = &sst.key_range;
+    let split_points: Vec<_> = boundary_keys
+        .iter()
+        .filter(|b| boundary_in_key_range(b.as_ref(), key_range))
+        .cloned()
+        .collect();
+
+    if split_points.is_empty() {
+        return vec![sst];
+    }
+
+    let piece_count = split_points.len() + 1;
+    let sizes = allocate_sstable_split_sizes(sst.sst_size, piece_count);
+    debug_assert_eq!(sizes.len(), piece_count);
+
+    let mut pieces = Vec::with_capacity(piece_count);
+    let mut remaining = sst;
+    for (idx, split_key) in split_points.into_iter().enumerate() {
+        let right_size = sizes[idx + 1..].iter().sum();
+        let (left, right) =
+            split_sst_at_vnode_boundary(remaining, new_sst_id, split_key, sizes[idx], right_size);
+        pieces.push(left.expect("vnode boundary must leave a non-empty left SST"));
+        remaining = right.expect("vnode boundary must leave a non-empty right SST");
+    }
+    pieces.push(remaining);
+
+    pieces
+}
+
+fn allocate_sstable_split_sizes(total: u64, parts: usize) -> Vec<u64> {
+    if parts == 0 {
+        return vec![];
+    }
+    let base = total / parts as u64;
+    let remainder = (total % parts as u64) as usize;
+    (0..parts)
+        .map(|i| std::cmp::max(1, base + if i < remainder { 1 } else { 0 }))
+        .collect()
+}
+
+/// Build layers from SSTs in uploader order (newest first), returning oldest first for commit.
+/// Overlapping older SSTs must be below every overlapping newer SST. Place each SST at the
+/// shallowest depth satisfying that constraint; disjoint SSTs can still share a layer.
+pub fn build_nonoverlapping_layers(ssts: Vec<SstableInfo>) -> Vec<Vec<SstableInfo>> {
+    // Layer indices are read depths here: newer layers have smaller indices.
+    let mut layers: Vec<Vec<SstableInfo>> = vec![];
+
+    for sst in ssts {
+        let target_layer_idx = layers
+            .iter()
+            .rposition(|layer| {
+                layer
+                    .iter()
+                    .any(|newer| newer.key_range.sstable_overlap(&sst.key_range))
+            })
+            .map_or(0, |idx| idx + 1);
+        if target_layer_idx == layers.len() {
+            layers.push(vec![]);
+        }
+        layers[target_layer_idx].push(sst);
+    }
+
+    for layer in &mut layers {
+        layer.sort_by(|a, b| a.key_range.cmp(&b.key_range));
+    }
+
+    debug_assert!(
+        layers
+            .iter()
+            .all(|layer| risingwave_hummock_sdk::can_concat(layer))
+    );
+    // Hummock stores L0 sub-levels oldest first and reads them in reverse order.
+    layers.reverse();
+    layers
+}
+
+pub fn chunk_nonoverlapping_layer_by_size(
+    layer: Vec<SstableInfo>,
+    sub_level_size_limit: u64,
+) -> Vec<Vec<SstableInfo>> {
+    let mut out = vec![];
+    let mut current = vec![];
+    let mut accumulated_size = 0u64;
+
+    for sst in layer {
+        accumulated_size += sst.sst_size;
+        current.push(sst);
+        if accumulated_size > sub_level_size_limit {
+            out.push(current);
+            current = vec![];
+            accumulated_size = 0;
+        }
+    }
+    if !current.is_empty() {
+        out.push(current);
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use risingwave_common::catalog::TableId;
+    use risingwave_common::hash::VirtualNode;
+    use risingwave_common::util::epoch::test_epoch;
+    use risingwave_hummock_sdk::key::{FullKey, TableKey};
+    use risingwave_hummock_sdk::sstable_info::SstableInfoInner;
+    use risingwave_hummock_sdk::vnode_partition::build_vnode_partition_boundary_keys;
+
+    use super::*;
+
+    fn fk(table_id: TableId, vnode: usize) -> Bytes {
+        FullKey::new(
+            table_id,
+            TableKey(VirtualNode::from_index(vnode).to_be_bytes().to_vec()),
+            u64::MAX,
+        )
+        .encode()
+        .into()
+    }
+
+    #[test]
+    fn test_build_vnode_partition_boundary_keys() {
+        let table_id = TableId::new(1);
+        let keys = build_vnode_partition_boundary_keys(table_id, 256, 8);
+        assert_eq!(keys.len(), 7);
+        assert_eq!(keys[0], fk(table_id, 32));
+        assert_eq!(keys[6], fk(table_id, 224));
+    }
+
+    #[test]
+    fn test_count_boundaries_in_key_range() {
+        let table_id = TableId::new(1);
+        let keys = build_vnode_partition_boundary_keys(table_id, 256, 8);
+        let kr = KeyRange {
+            left: fk(table_id, 0),
+            right: fk(table_id, 64),
+            right_exclusive: true,
+        };
+        assert_eq!(count_boundaries_in_key_range(&kr, &keys), 1);
+    }
+
+    #[test]
+    fn test_split_sst_by_boundary_keys() {
+        let table_id = TableId::new(1);
+        let keys = build_vnode_partition_boundary_keys(table_id, 256, 8);
+        let sst: SstableInfo = SstableInfoInner {
+            object_id: 1.into(),
+            sst_id: 10.into(),
+            key_range: KeyRange {
+                left: fk(table_id, 0),
+                right: fk(table_id, 64),
+                right_exclusive: true,
+            },
+            file_size: 10,
+            table_ids: vec![table_id],
+            meta_offset: 0,
+            stale_key_count: 0,
+            total_key_count: 0,
+            min_epoch: 1,
+            max_epoch: 1,
+            uncompressed_file_size: 10,
+            range_tombstone_count: 0,
+            filter_type: Default::default(),
+            filter_layout: Default::default(),
+            vnode_statistics: None,
+            sst_size: 10,
+        }
+        .into();
+
+        let mut new_sst_id: HummockSstableId = 100u64.into();
+        let pieces = split_sst_by_boundary_keys(sst, &keys, &mut new_sst_id);
+        assert_eq!(pieces.len(), 2);
+        let sst_id_100: HummockSstableId = 100u64.into();
+        let sst_id_101: HummockSstableId = 101u64.into();
+        let sst_id_102: HummockSstableId = 102u64.into();
+        assert_eq!(pieces[0].sst_id, sst_id_101);
+        assert_eq!(pieces[0].key_range.left, fk(table_id, 0));
+        assert_eq!(pieces[0].key_range.right, fk(table_id, 32));
+        assert!(pieces[0].key_range.right_exclusive);
+        assert_eq!(pieces[1].sst_id, sst_id_100);
+        assert_eq!(pieces[1].key_range.left, fk(table_id, 32));
+        assert_eq!(pieces[1].key_range.right, fk(table_id, 64));
+        assert!(pieces[1].key_range.right_exclusive);
+        assert_eq!(pieces[0].table_ids, vec![table_id]);
+        assert_eq!(pieces[1].table_ids, vec![table_id]);
+        assert_eq!(new_sst_id, sst_id_102);
+    }
+
+    #[test]
+    fn test_build_nonoverlapping_layers() {
+        let table_id = TableId::new(1);
+        let make_sst = |sst_id: u64, left_v: usize, right_v: usize| {
+            SstableInfoInner {
+                object_id: sst_id.into(),
+                sst_id: sst_id.into(),
+                key_range: KeyRange {
+                    left: fk(table_id, left_v),
+                    right: fk(table_id, right_v),
+                    right_exclusive: true,
+                },
+                file_size: 10,
+                table_ids: vec![table_id],
+                meta_offset: 0,
+                stale_key_count: 0,
+                total_key_count: 0,
+                min_epoch: 1,
+                max_epoch: 1,
+                uncompressed_file_size: 10,
+                range_tombstone_count: 0,
+                filter_type: Default::default(),
+                filter_layout: Default::default(),
+                vnode_statistics: None,
+                sst_size: 10,
+            }
+            .into()
+        };
+
+        let ssts = vec![
+            make_sst(1, 0, 64),
+            make_sst(2, 32, 96),
+            make_sst(3, 96, 128),
+        ];
+        let layers = build_nonoverlapping_layers(ssts);
+        assert_eq!(layers.len(), 2);
+        for layer in layers {
+            assert!(risingwave_hummock_sdk::can_concat(&layer));
+        }
+    }
+
+    fn ordered_sst(id: u64, left: usize, right: usize, epoch: u64) -> SstableInfo {
+        let epoch = test_epoch(epoch);
+        let table_id = TableId::new(1);
+        let key = |vnode| {
+            FullKey::new(
+                table_id,
+                TableKey(VirtualNode::from_index(vnode).to_be_bytes().to_vec()),
+                epoch,
+            )
+            .encode()
+            .into()
+        };
+        SstableInfoInner {
+            object_id: id.into(),
+            sst_id: id.into(),
+            key_range: KeyRange::new(key(left), key(right)),
+            table_ids: vec![table_id],
+            min_epoch: epoch,
+            max_epoch: epoch,
+            sst_size: 10,
+            ..Default::default()
+        }
+        .into()
+    }
+
+    fn layer_ids(layers: &[Vec<SstableInfo>]) -> Vec<Vec<HummockSstableId>> {
+        layers
+            .iter()
+            .map(|layer| layer.iter().map(|sst| sst.sst_id).collect())
+            .collect()
+    }
+
+    #[test]
+    fn test_disjoint_newer_sst_does_not_reorder_overlapping_versions() {
+        // Newest first: C is disjoint from both A and B, but A and B overlap.
+        // Sorting layers by max_epoch used to put {A, C} ahead of the newer B.
+        let c = ordered_sst(3, 40, 50, 30);
+        let b = ordered_sst(2, 10, 30, 20);
+        let a = ordered_sst(1, 0, 20, 10);
+        let layers = build_nonoverlapping_layers(vec![c.clone(), b.clone(), a.clone()]);
+        assert_eq!(
+            layer_ids(&layers),
+            vec![vec![a.sst_id], vec![b.sst_id, c.sst_id]]
+        );
+
+        // Model a point present in both A and B at different snapshots. Hummock reads layers
+        // newest first and returns the first visible version, rather than merging point results.
+        let point = KeyRange::new(fk(TableId::new(1), 15), fk(TableId::new(1), 15));
+        for (read_epoch, expected) in [(9, None), (10, Some(10)), (20, Some(20)), (30, Some(20))] {
+            let first_visible = layers
+                .iter()
+                .rev()
+                .flatten()
+                .find(|sst| {
+                    sst.max_epoch <= test_epoch(read_epoch) && sst.key_range.sstable_overlap(&point)
+                })
+                .map(|sst| sst.max_epoch);
+            assert_eq!(first_visible, expected.map(test_epoch));
+        }
+    }
+
+    #[test]
+    fn test_do_not_fill_a_gap_above_an_overlapping_newer_sst() {
+        let newest = ordered_sst(3, 0, 1, 30);
+        let middle = ordered_sst(2, 0, 3, 20);
+        let oldest = ordered_sst(1, 2, 3, 10);
+        // The oldest SST fits beside `newest`, but must stay below `middle`.
+        let layers =
+            build_nonoverlapping_layers(vec![newest.clone(), middle.clone(), oldest.clone()]);
+        assert_eq!(
+            layer_ids(&layers),
+            vec![
+                vec![oldest.sst_id],
+                vec![middle.sst_id],
+                vec![newest.sst_id]
+            ]
+        );
+    }
+
+    #[test]
+    fn test_same_user_key_at_different_epochs_cannot_share_a_layer() {
+        let newest = ordered_sst(2, 15, 15, 20);
+        let oldest = ordered_sst(1, 15, 15, 10);
+        assert!(!newest.key_range.full_key_overlap(&oldest.key_range));
+        assert!(newest.key_range.sstable_overlap(&oldest.key_range));
+        let layers = build_nonoverlapping_layers(vec![newest.clone(), oldest.clone()]);
+        assert_eq!(
+            layer_ids(&layers),
+            vec![vec![oldest.sst_id], vec![newest.sst_id]]
+        );
+    }
+
+    #[test]
+    fn test_split_and_chunk_preserve_overlapping_sst_order() {
+        let table_id = TableId::new(1);
+        let boundaries = build_vnode_partition_boundary_keys(table_id, 256, 8);
+        let newest = ordered_sst(2, 0, 64, 20);
+        let oldest = ordered_sst(1, 0, 64, 10);
+        let mut next_id = 100.into();
+        let fragments = [newest.clone(), oldest.clone()]
+            .into_iter()
+            .flat_map(|sst| split_sst_by_boundary_keys(sst, &boundaries, &mut next_id))
+            .collect();
+        let layers = build_nonoverlapping_layers(fragments);
+        assert_eq!(layers.len(), 2);
+        assert!(
+            layers
+                .iter()
+                .all(|layer| risingwave_hummock_sdk::can_concat(layer))
+        );
+        // Adjacent pieces with exclusive right bounds can share a layer, despite different
+        // epochs in their encoded boundary keys. Chunking must not interleave old/new layers.
+        assert!(
+            layers[0]
+                .iter()
+                .all(|sst| sst.object_id == oldest.object_id)
+        );
+        assert!(
+            layers[1]
+                .iter()
+                .all(|sst| sst.object_id == newest.object_id)
+        );
+        let chunks: Vec<_> = layers
+            .into_iter()
+            .flat_map(|layer| chunk_nonoverlapping_layer_by_size(layer, 1))
+            .collect();
+        for vnode in [0, 31, 32, 63, 64] {
+            let point = KeyRange::new(fk(table_id, vnode), fk(table_id, vnode));
+            let matches: Vec<_> = chunks
+                .iter()
+                .rev()
+                .flatten()
+                .filter(|sst| sst.key_range.sstable_overlap(&point))
+                .map(|sst| sst.object_id)
+                .collect();
+            assert_eq!(matches, vec![newest.object_id, oldest.object_id]);
+        }
+    }
+
+    #[test]
+    fn test_exhaustive_layer_order_and_minimum_depth() {
+        // Enumerate ordered sequences of four closed intervals, including repeated intervals,
+        // nested ranges, touching endpoints, and disjoint ranges. Equal epochs deliberately
+        // ensure the uploader's order, not an epoch sort, is the source of precedence.
+        let ranges: Vec<_> = (0..3)
+            .flat_map(|left| (left..3).map(move |right| (left, right)))
+            .collect();
+        for mut encoding in 0..ranges.len().pow(4) {
+            let mut ssts = vec![];
+            for id in 0..4 {
+                let (left, right) = ranges[encoding % ranges.len()];
+                encoding /= ranges.len();
+                ssts.push(ordered_sst(id, left, right, 10));
+            }
+            let layers = build_nonoverlapping_layers(ssts.clone());
+            assert!(
+                layers
+                    .iter()
+                    .all(|layer| risingwave_hummock_sdk::can_concat(layer))
+            );
+            assert_eq!(layers.iter().map(Vec::len).sum::<usize>(), ssts.len());
+            let depths: Vec<_> = ssts
+                .iter()
+                .map(|sst| {
+                    layers
+                        .iter()
+                        .rev()
+                        .position(|layer| layer.iter().any(|s| s.sst_id == sst.sst_id))
+                        .unwrap()
+                })
+                .collect();
+            for (older_idx, older) in ssts.iter().enumerate() {
+                for (newer_idx, newer) in ssts[..older_idx].iter().enumerate() {
+                    if newer.key_range.sstable_overlap(&older.key_range) {
+                        assert!(depths[newer_idx] < depths[older_idx]);
+                    }
+                }
+            }
+            // A chain of overlapping SSTs ordered by age is a lower bound on layer count.
+            // Enumerate all subsequences independently of the placement algorithm.
+            let minimum_layers = (1u32..1 << ssts.len())
+                .filter_map(|mask| {
+                    let chain: Vec<_> = ssts
+                        .iter()
+                        .enumerate()
+                        .filter(|(idx, _)| mask & (1 << idx) != 0)
+                        .map(|(_, sst)| sst)
+                        .collect();
+                    chain
+                        .windows(2)
+                        .all(|pair| pair[0].key_range.sstable_overlap(&pair[1].key_range))
+                        .then_some(chain.len())
+                })
+                .max()
+                .unwrap();
+            assert_eq!(layers.len(), minimum_layers);
+        }
+        assert!(build_nonoverlapping_layers(vec![]).is_empty());
+    }
+}

--- a/src/meta/src/hummock/manager/compaction/compaction_group_manager.rs
+++ b/src/meta/src/hummock/manager/compaction/compaction_group_manager.rs
@@ -327,7 +327,7 @@ impl HummockManager {
         }
         let mut group_changes: HashMap<CompactionGroupId, UnregisterGroupChange> = HashMap::new();
         // Remove member tables
-        for table_id in table_ids.into_iter().unique() {
+        for table_id in table_ids.iter().copied().unique() {
             let version = new_version_delta.latest_version();
             let Some(info) = version.state_table_info.info().get(&table_id) else {
                 continue;
@@ -394,6 +394,11 @@ impl HummockManager {
             version.latest_version(),
         )));
         commit_multi_var!(self.meta_store_ref(), version, compaction_groups_txn)?;
+
+        let mut vnode_count_cache = self.table_id_to_vnode_count.write();
+        for table_id in table_ids {
+            vnode_count_cache.remove(&table_id);
+        }
 
         // No need to handle DeltaType::GroupDestroy during time travel.
         Ok(())

--- a/src/meta/src/hummock/manager/compaction/mod.rs
+++ b/src/meta/src/hummock/manager/compaction/mod.rs
@@ -29,6 +29,7 @@ use rand::rng as thread_rng;
 use rand::seq::SliceRandom;
 use risingwave_common::catalog::TableId;
 use risingwave_common::config::meta::default::compaction_config;
+use risingwave_common::hash::VnodeCountCompat;
 use risingwave_common::util::epoch::Epoch;
 use risingwave_hummock_sdk::compact_task::{CompactTask, CompactTaskAssignment, ReportTask};
 use risingwave_hummock_sdk::compaction_group::StateTableId;
@@ -62,8 +63,8 @@ use crate::hummock::compaction::in_progress_compaction::InProgressCompactionView
 use crate::hummock::compaction::selector::level_selector::PickerInfo;
 use crate::hummock::compaction::selector::{
     DynamicLevelSelector, DynamicLevelSelectorCore, LocalSelectorStatistic, ManualCompactionOption,
-    ManualCompactionSelector, SpaceReclaimCompactionSelector, TombstoneCompactionSelector,
-    TtlCompactionSelector, VnodeWatermarkCompactionSelector,
+    ManualCompactionSelector, SingleTableCompactionGroup, SpaceReclaimCompactionSelector,
+    TombstoneCompactionSelector, TtlCompactionSelector, VnodeWatermarkCompactionSelector,
 };
 use crate::hummock::compaction::{
     CompactStatus, CompactionDeveloperConfig, CompactionSelector,
@@ -345,6 +346,83 @@ impl HummockManager {
             .await
     }
 
+    async fn prefetch_compaction_table_vnode_counts(
+        &self,
+        compaction_groups: &[CompactionGroupId],
+    ) {
+        let single_table_groups = {
+            let versioning = self
+                .versioning
+                .read_with_process_name("prefetch_compaction_table_vnode_counts")
+                .await;
+            compaction_groups
+                .iter()
+                .filter_map(|group_id| {
+                    let members = versioning
+                        .current_version
+                        .state_table_info
+                        .compaction_group_member_table_ids(*group_id);
+                    (members.len() == 1)
+                        .then(|| (*group_id, *members.iter().next().expect("len==1")))
+                })
+                .collect_vec()
+        };
+
+        let missing_groups = {
+            let cache = self.table_id_to_vnode_count.read();
+            single_table_groups
+                .into_iter()
+                .filter(|(_, table_id)| !cache.contains_key(table_id))
+                .collect_vec()
+        };
+        if missing_groups.is_empty() {
+            return;
+        }
+
+        let missing_table_ids = {
+            let config_manager = self
+                .compaction_group_manager
+                .read_with_process_name("prefetch_compaction_table_vnode_counts")
+                .await;
+            missing_groups
+                .into_iter()
+                .filter_map(|(group_id, table_id)| {
+                    config_manager
+                        .try_get_compaction_group_config(group_id)
+                        .is_some_and(|group| group.compaction_config.split_weight_by_vnode > 1)
+                        .then_some(table_id)
+                })
+                .collect_vec()
+        };
+        if missing_table_ids.is_empty() {
+            return;
+        }
+
+        match self
+            .metadata_manager
+            .get_table_catalog_by_ids(&missing_table_ids)
+            .await
+        {
+            Ok(tables) => {
+                let mut cache = self.table_id_to_vnode_count.write();
+                for table in tables {
+                    // A creating table may still carry the catalog placeholder `Some(0)`.
+                    if table.maybe_vnode_count == Some(0) {
+                        continue;
+                    }
+                    cache.insert(table.id, table.vnode_count());
+                }
+            }
+            Err(error) => {
+                warn!(
+                    error = %error.as_report(),
+                    ?missing_table_ids,
+                    "Failed to prefetch table vnode counts for compaction",
+                );
+            }
+        }
+    }
+
     pub async fn get_compact_tasks_impl(
         &self,
         compaction_groups: Vec<CompactionGroupId>,
@@ -352,6 +430,13 @@ impl HummockManager {
         selector: &mut dyn CompactionSelector,
     ) -> Result<(Vec<CompactTask>, Vec<CompactionGroupId>)> {
         let deterministic_mode = self.env.opts.compaction_deterministic_test;
+
+        // Do catalog I/O before taking the compaction/versioning write locks. Membership is
+        // revalidated below before a cached vnode count is passed to the selector.
+        if selector.task_type() == TaskType::Dynamic {
+            self.prefetch_compaction_table_vnode_counts(&compaction_groups)
+                .await;
+        }
 
         let mut compaction_guard = self
             .compaction
@@ -479,6 +564,18 @@ impl HummockManager {
                 compact_task_assignment.tree_ref().values(),
                 compaction_group_id,
             );
+            let single_table_compaction_group =
+                if group_config.compaction_config.split_weight_by_vnode > 1
+                    && let [table_id] = member_table_ids.as_slice()
+                {
+                    self.table_id_to_vnode_count
+                        .read()
+                        .get(table_id)
+                        .copied()
+                        .map(|vnode_count| SingleTableCompactionGroup::new(*table_id, vnode_count))
+                } else {
+                    None
+                };
 
             while let Some(picked_task) = compact_status.get_compact_task(
                 version
@@ -488,6 +585,7 @@ impl HummockManager {
                     .latest_version()
                     .state_table_info
                     .compaction_group_member_table_ids(compaction_group_id),
+                single_table_compaction_group,
                 task_id as HummockCompactionTaskId,
                 &group_config,
                 &mut stats,

--- a/src/meta/src/hummock/manager/mod.rs
+++ b/src/meta/src/hummock/manager/mod.rs
@@ -194,6 +194,9 @@ pub struct HummockManager {
     /// In-memory cache of prefetched compaction task ids to reduce per-task DB round-trips.
     prefetched_compaction_task_ids: PrefetchedSequence,
     table_id_to_table_option: parking_lot::RwLock<HashMap<TableId, TableOption>>,
+    /// Table vnode counts are immutable after creation. Cache them for commit-time splitting and
+    /// transient partition-aware L0 scoring without persisting derived compaction state.
+    table_id_to_vnode_count: parking_lot::RwLock<HashMap<TableId, usize>>,
 }
 
 pub type HummockManagerRef = Arc<HummockManager>;
@@ -388,6 +391,7 @@ impl HummockManager {
             gc_manager,
             prefetched_compaction_task_ids: PrefetchedSequence::new(),
             table_id_to_table_option: RwLock::new(HashMap::new()),
+            table_id_to_vnode_count: RwLock::new(HashMap::new()),
         };
         let instance = Arc::new(instance);
         let version_stat_metrics = instance.metrics.clone();

--- a/src/meta/src/hummock/manager/tests.rs
+++ b/src/meta/src/hummock/manager/tests.rs
@@ -3222,6 +3222,15 @@ async fn test_old_version_dropped_table_sst_does_not_make_new_compaction_fail() 
         .sum();
     group.l0.sub_levels = dirty_l0_sub_levels;
 
+    // Keep this as a physical compaction test after small L0 SSTs become eligible for trivial
+    // move. An overlapping base SST prevents Meta from consuming every L0 SST as metadata-only
+    // moves before the test can inspect a compactor task.
+    let base_sst = gen_sstable_info(14, vec![live_table_id.as_raw_id()], test_epoch(1));
+    let base_level = group.levels.last_mut().unwrap();
+    base_level.total_file_size = base_sst.sst_size;
+    base_level.uncompressed_file_size = base_sst.uncompressed_file_size;
+    base_level.table_infos = vec![base_sst];
+
     // Simulate the upgrade path:
     // 1. an old version wrote SST metadata containing table ids [live, dropped];
     // 2. the old version dropped one table, but the checkpoint still had stale SST table ids;

--- a/src/meta/src/hummock/manager/transaction.rs
+++ b/src/meta/src/hummock/manager/transaction.rs
@@ -23,7 +23,9 @@ use risingwave_hummock_sdk::compaction_group::StaticCompactionGroupId;
 use risingwave_hummock_sdk::sstable_info::SstableInfo;
 use risingwave_hummock_sdk::table_watermark::TableWatermarks;
 use risingwave_hummock_sdk::vector_index::VectorIndexDelta;
-use risingwave_hummock_sdk::version::{GroupDelta, HummockVersion, HummockVersionDelta};
+use risingwave_hummock_sdk::version::{
+    GroupDelta, HummockVersion, HummockVersionDelta, IntraLevelDelta,
+};
 use risingwave_hummock_sdk::{
     CompactionGroupId, FrontendHummockVersionDelta, HummockSstableId, HummockVersionId,
 };
@@ -78,6 +80,28 @@ pub(super) struct HummockVersionTransaction<'a> {
     )>,
     disable_apply_to_txn: bool,
     opts: &'a MetaOpts,
+}
+
+pub(super) struct CommitSubLevel {
+    pub ssts: Vec<SstableInfo>,
+    pub vnode_partition_count: u32,
+}
+
+impl CommitSubLevel {
+    fn into_group_delta(self, l0_sub_level_id: u64) -> GroupDelta {
+        if self.vnode_partition_count == 0 {
+            GroupDelta::NewL0SubLevel(self.ssts)
+        } else {
+            GroupDelta::IntraLevel(IntraLevelDelta::new(
+                0,
+                l0_sub_level_id,
+                HashSet::new(),
+                self.ssts,
+                self.vnode_partition_count,
+                0,
+            ))
+        }
+    }
 }
 
 impl<'a> HummockVersionTransaction<'a> {
@@ -165,7 +189,7 @@ impl<'a> HummockVersionTransaction<'a> {
         &mut self,
         tables_to_commit: &HashMap<TableId, u64>,
         new_compaction_groups: Vec<CompactionGroup>,
-        group_id_to_sub_levels: BTreeMap<CompactionGroupId, Vec<Vec<SstableInfo>>>,
+        group_id_to_sub_levels: BTreeMap<CompactionGroupId, Vec<CommitSubLevel>>,
         new_table_ids: &HashMap<TableId, CompactionGroupId>,
         new_table_watermarks: HashMap<TableId, TableWatermarks>,
         change_log_delta: HashMap<TableId, EpochNewChangeLog>,
@@ -198,14 +222,27 @@ impl<'a> HummockVersionTransaction<'a> {
 
         // Append SSTs to a new version.
         for (compaction_group_id, sub_levels) in group_id_to_sub_levels {
+            let next_l0_sub_level_id = new_version_delta
+                .latest_version()
+                .levels
+                .get(&compaction_group_id)
+                .and_then(|levels| {
+                    levels
+                        .l0
+                        .sub_levels
+                        .last()
+                        .map(|level| level.sub_level_id + 1)
+                })
+                .unwrap_or(1);
+
             let group_deltas = &mut new_version_delta
                 .group_deltas
                 .entry(compaction_group_id)
                 .or_default()
                 .group_deltas;
 
-            for sub_level in sub_levels {
-                group_deltas.push(GroupDelta::NewL0SubLevel(sub_level));
+            for (offset, sub_level) in sub_levels.into_iter().enumerate() {
+                group_deltas.push(sub_level.into_group_delta(next_l0_sub_level_id + offset as u64));
             }
         }
 
@@ -495,6 +532,29 @@ mod tests {
             non_checkpoint_epochs: vec![],
             checkpoint_epoch,
         }
+    }
+
+    #[test]
+    fn test_commit_sub_level_delta_type() {
+        assert!(matches!(
+            CommitSubLevel {
+                ssts: vec![],
+                vnode_partition_count: 0,
+            }
+            .into_group_delta(7),
+            GroupDelta::NewL0SubLevel(_)
+        ));
+
+        let GroupDelta::IntraLevel(delta) = (CommitSubLevel {
+            ssts: vec![],
+            vnode_partition_count: 4,
+        })
+        .into_group_delta(7) else {
+            panic!("partitioned commit must use an intra-level delta");
+        };
+        assert_eq!(delta.level_idx, 0);
+        assert_eq!(delta.l0_sub_level_id, 7);
+        assert_eq!(delta.vnode_partition_count, 4);
     }
 
     #[test]

--- a/src/meta/src/hummock/test_utils.rs
+++ b/src/meta/src/hummock/test_utils.rs
@@ -424,6 +424,7 @@ pub fn compaction_selector_context<'a>(
         group,
         levels,
         member_table_ids,
+        single_table_compaction_group: None,
         level_handlers,
         selector_stats,
         table_id_to_options,

--- a/src/storage/hummock_sdk/src/compaction_group/hummock_version_ext.rs
+++ b/src/storage/hummock_sdk/src/compaction_group/hummock_version_ext.rs
@@ -603,6 +603,7 @@ impl HummockVersionCommon<SstableInfo> {
                                 level_idx,
                                 l0_sub_level_id,
                                 inserted_table_infos,
+                                vnode_partition_count,
                                 ..
                             } = level_delta;
                             {
@@ -611,13 +612,25 @@ impl HummockVersionCommon<SstableInfo> {
                                     "we should only add to L0 when we commit an epoch."
                                 );
                                 if !inserted_table_infos.is_empty() {
+                                    let level_type = if *vnode_partition_count > 0
+                                        && can_concat(inserted_table_infos)
+                                    {
+                                        PbLevelType::Nonoverlapping
+                                    } else {
+                                        PbLevelType::Overlapping
+                                    };
                                     insert_new_sub_level(
                                         &mut levels.l0,
                                         *l0_sub_level_id,
-                                        PbLevelType::Overlapping,
+                                        level_type,
                                         inserted_table_infos.clone(),
                                         None,
                                     );
+                                    if *vnode_partition_count > 0
+                                        && let Some(level) = levels.l0.sub_levels.last_mut()
+                                    {
+                                        level.vnode_partition_count = *vnode_partition_count;
+                                    }
                                 }
                             }
                         } else {

--- a/src/storage/hummock_sdk/src/compaction_group/mod.rs
+++ b/src/storage/hummock_sdk/src/compaction_group/mod.rs
@@ -41,8 +41,10 @@ pub mod StaticCompactionGroupId {
 
 /// The split will follow the following rules:
 /// 1. Ssts with `split_key` will be split into two separate ssts and their `key_range` will be changed `sst_1`: [`sst.key_range.right`, `split_key`) `sst_2`: [`split_key`, `sst.key_range.right`].
-/// 2. Currently only `vnode` 0 and `vnode` max is supported.
-/// 3. Due to the above rule, `vnode` max will be rewritten as `table_id` + 1, vnode 0
+/// 2. Compaction-group membership can only be split at table boundaries (`vnode` 0 or max).
+/// 3. A single-table SST can additionally be split at an internal vnode boundary while remaining
+///    in the same compaction group.
+/// 4. For compaction-group splits, `vnode` max will be rewritten as `table_id` + 1, vnode 0.
 pub mod group_split {
     use std::cmp::Ordering;
     use std::collections::BTreeSet;
@@ -136,6 +138,62 @@ pub mod group_split {
         left_size: u64,
         right_size: u64,
     ) -> (Option<SstableInfo>, Option<SstableInfo>) {
+        let (table_ids_l, table_ids_r) =
+            split_table_ids_with_split_key(&origin_sst_info.table_ids, split_key.clone());
+        split_sst_inner(
+            origin_sst_info,
+            new_sst_id,
+            split_key,
+            left_size,
+            right_size,
+            table_ids_l,
+            table_ids_r,
+        )
+    }
+
+    /// Split a single-table SST at an internal vnode boundary without changing group membership.
+    /// The table id remains present in both logical SSTs because both ranges belong to the same
+    /// state table and compaction group.
+    pub fn split_sst_at_vnode_boundary(
+        origin_sst_info: SstableInfo,
+        new_sst_id: &mut HummockSstableId,
+        split_key: Bytes,
+        left_size: u64,
+        right_size: u64,
+    ) -> (Option<SstableInfo>, Option<SstableInfo>) {
+        let split_user_key = FullKey::decode(&split_key).user_key;
+        assert_ne!(
+            0,
+            split_user_key.get_vnode_id(),
+            "vnode partition boundary must be inside a table"
+        );
+        assert_eq!(
+            origin_sst_info.table_ids.as_slice(),
+            &[split_user_key.table_id],
+            "vnode partition splitting only supports a single-table SST"
+        );
+
+        let table_ids = origin_sst_info.table_ids.clone();
+        split_sst_inner(
+            origin_sst_info,
+            new_sst_id,
+            split_key,
+            left_size,
+            right_size,
+            table_ids.clone(),
+            table_ids,
+        )
+    }
+
+    fn split_sst_inner(
+        origin_sst_info: SstableInfo,
+        new_sst_id: &mut HummockSstableId,
+        split_key: Bytes,
+        left_size: u64,
+        right_size: u64,
+        table_ids_l: Vec<TableId>,
+        table_ids_r: Vec<TableId>,
+    ) -> (Option<SstableInfo>, Option<SstableInfo>) {
         let mut origin_sst_info = origin_sst_info.get_inner();
         let mut branch_table_info = origin_sst_info.clone();
         branch_table_info.sst_id = *new_sst_id;
@@ -152,16 +210,13 @@ pub mod group_split {
             };
 
             let r = KeyRange {
-                left: split_key.clone(),
+                left: split_key,
                 right: key_range.right.clone(),
                 right_exclusive: key_range.right_exclusive,
             };
 
             (l, r)
         };
-        let (table_ids_l, table_ids_r) =
-            split_table_ids_with_split_key(&origin_sst_info.table_ids, split_key);
-
         // rebuild the key_range and size and sstable file size
         {
             // origin_sst_info

--- a/src/storage/hummock_sdk/src/lib.rs
+++ b/src/storage/hummock_sdk/src/lib.rs
@@ -48,6 +48,7 @@ pub mod version;
 pub use frontend_version::{FrontendHummockVersion, FrontendHummockVersionDelta};
 mod frontend_version;
 pub mod vector_index;
+pub mod vnode_partition;
 
 pub use compact::*;
 use risingwave_common::catalog::TableId;

--- a/src/storage/hummock_sdk/src/vnode_partition.rs
+++ b/src/storage/hummock_sdk/src/vnode_partition.rs
@@ -1,0 +1,65 @@
+// Copyright 2026 RisingWave Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use bytes::Bytes;
+use risingwave_common::catalog::TableId;
+use risingwave_common::hash::VirtualNode;
+
+use crate::key::{FullKey, TableKey};
+
+pub fn build_vnode_partition_boundary_keys(
+    table_id: TableId,
+    vnode_count: usize,
+    partition_count: usize,
+) -> Vec<Bytes> {
+    debug_assert!(partition_count > 0);
+    debug_assert!(partition_count <= vnode_count);
+
+    if partition_count <= 1 {
+        return vec![];
+    }
+
+    // Keep the same partitioning rule with `MultiBuilder`:
+    // - First `partition_count - remainder` partitions have `basic` vnodes.
+    // - Last `remainder` partitions have `basic + 1` vnodes.
+    let basic = vnode_count / partition_count;
+    let remainder = vnode_count % partition_count;
+    let small_partitions = partition_count - remainder;
+
+    let mut boundary_keys = Vec::with_capacity(partition_count.saturating_sub(1));
+    let mut start = 0usize;
+    for idx in 0..partition_count {
+        let size = if idx < small_partitions {
+            basic
+        } else {
+            basic + 1
+        };
+        if idx > 0 {
+            boundary_keys.push(vnode_boundary_full_key(table_id, start));
+        }
+        start += size;
+    }
+    debug_assert_eq!(start, vnode_count);
+    boundary_keys
+}
+
+pub fn vnode_boundary_full_key(table_id: TableId, vnode: usize) -> Bytes {
+    FullKey::new(
+        table_id,
+        TableKey(VirtualNode::from_index(vnode).to_be_bytes().to_vec()),
+        u64::MAX,
+    )
+    .encode()
+    .into()
+}

--- a/src/storage/src/hummock/iterator/backward_concat.rs
+++ b/src/storage/src/hummock/iterator/backward_concat.rs
@@ -23,6 +23,8 @@ pub type BackwardConcatIterator = ConcatIteratorInner<BackwardSstableIterator>;
 mod tests {
     use std::sync::Arc;
 
+    use bytes::Bytes;
+
     use super::*;
     use crate::hummock::iterator::HummockIterator;
     use crate::hummock::iterator::test_utils::{
@@ -88,6 +90,43 @@ mod tests {
             val.into_user_value().unwrap(),
             iterator_test_value_of(TEST_KEYS_COUNT * 3 - 1).as_slice()
         );
+    }
+
+    #[tokio::test]
+    async fn test_backward_concat_logical_ssts_sharing_one_object() {
+        let sstable_store = mock_sstable_store().await;
+        let physical_sst = gen_iterator_test_sstable_info(
+            0,
+            default_builder_opt_for_test(),
+            |x| x,
+            sstable_store.clone(),
+            TEST_KEYS_COUNT,
+        )
+        .await;
+        let split_key = Bytes::from(iterator_test_key_of(TEST_KEYS_COUNT / 2).encode());
+
+        let mut left = physical_sst.get_inner();
+        left.sst_id = 100.into();
+        left.key_range.right = split_key.clone();
+        left.key_range.right_exclusive = true;
+        let mut right = physical_sst.get_inner();
+        right.sst_id = 101.into();
+        right.key_range.left = split_key;
+
+        let mut iter = BackwardConcatIterator::new(
+            vec![right.into(), left.into()],
+            sstable_store,
+            Arc::new(SstableIteratorReadOptions::default()),
+        );
+        iter.rewind().await.unwrap();
+
+        let mut index = TEST_KEYS_COUNT;
+        while iter.is_valid() {
+            index -= 1;
+            assert_eq!(iter.key(), iterator_test_key_of(index).to_ref());
+            iter.next().await.unwrap();
+        }
+        assert_eq!(index, 0);
     }
 
     #[tokio::test]

--- a/src/storage/src/hummock/iterator/forward_concat.rs
+++ b/src/storage/src/hummock/iterator/forward_concat.rs
@@ -22,6 +22,7 @@ pub type ConcatIterator = ConcatIteratorInner<SstableIterator>;
 mod tests {
     use std::sync::Arc;
 
+    use bytes::Bytes;
     #[cfg(feature = "failpoints")]
     use foyer::Hint;
 
@@ -96,6 +97,43 @@ mod tests {
             val.into_user_value().unwrap(),
             iterator_test_value_of(0).as_slice()
         );
+    }
+
+    #[tokio::test]
+    async fn test_concat_logical_ssts_sharing_one_object() {
+        let sstable_store = mock_sstable_store().await;
+        let physical_sst = gen_iterator_test_sstable_info(
+            0,
+            default_builder_opt_for_test(),
+            |x| x,
+            sstable_store.clone(),
+            TEST_KEYS_COUNT,
+        )
+        .await;
+        let split_key = Bytes::from(iterator_test_key_of(TEST_KEYS_COUNT / 2).encode());
+
+        let mut left = physical_sst.get_inner();
+        left.sst_id = 100.into();
+        left.key_range.right = split_key.clone();
+        left.key_range.right_exclusive = true;
+        let mut right = physical_sst.get_inner();
+        right.sst_id = 101.into();
+        right.key_range.left = split_key;
+
+        let mut iter = ConcatIterator::new(
+            vec![left.into(), right.into()],
+            sstable_store,
+            Arc::new(SstableIteratorReadOptions::default()),
+        );
+        iter.rewind().await.unwrap();
+
+        let mut index = 0;
+        while iter.is_valid() {
+            assert_eq!(iter.key(), iterator_test_key_of(index).to_ref());
+            index += 1;
+            iter.next().await.unwrap();
+        }
+        assert_eq!(index, TEST_KEYS_COUNT);
     }
 
     #[tokio::test]

--- a/src/storage/src/hummock/sstable/backward_sstable_iterator.rs
+++ b/src/storage/src/hummock/sstable/backward_sstable_iterator.rs
@@ -17,6 +17,7 @@ use std::sync::Arc;
 
 use foyer::Hint;
 use risingwave_hummock_sdk::key::FullKey;
+use risingwave_hummock_sdk::key_range::KeyRange;
 use risingwave_hummock_sdk::sstable_info::SstableInfo;
 
 use crate::hummock::iterator::{Backward, HummockIterator, ValueMeta};
@@ -44,6 +45,7 @@ pub struct BackwardSstableIterator {
 
     // used for checking if the block is valid, filter out the block that is not in the table-id range
     read_block_meta_range: (usize, usize),
+    key_range: KeyRange,
 }
 
 impl BackwardSstableIterator {
@@ -133,7 +135,12 @@ impl BackwardSstableIterator {
             sstable_store,
             stats: StoreLocalStatistic::default(),
             read_block_meta_range: (start_idx, end_idx),
+            key_range: sstable_info_ref.key_range.clone(),
         }
+    }
+
+    fn block_iter_is_valid(&self) -> bool {
+        self.block_iter.as_ref().is_some_and(|iter| iter.is_valid())
     }
 
     /// Seeks to a block, and then seeks to the key if `seek_key` is given.
@@ -194,17 +201,28 @@ impl HummockIterator for BackwardSstableIterator {
     }
 
     fn is_valid(&self) -> bool {
-        self.block_iter.as_ref().is_some_and(|i| i.is_valid())
+        self.block_iter_is_valid() && super::full_key_in_range(&self.key_range, self.key())
     }
 
     /// Instead of setting idx to 0th block, a `BackwardSstableIterator` rewinds to the last block
     /// in the sstable.
     async fn rewind(&mut self) -> HummockResult<()> {
-        self.seek_idx(self.read_block_meta_range.1 as isize, None)
-            .await
+        if self.key_range.right.is_empty() {
+            self.seek_idx(self.read_block_meta_range.1 as isize, None)
+                .await
+        } else {
+            let right = self.key_range.right.clone();
+            self.seek(FullKey::decode(&right)).await
+        }
     }
 
     async fn seek<'a>(&'a mut self, key: FullKey<&'a [u8]>) -> HummockResult<()> {
+        let right = self.key_range.right.clone();
+        let key = if !right.is_empty() && FullKey::decode(&right).lt(&key) {
+            FullKey::decode(&right)
+        } else {
+            key
+        };
         let block_idx = self
             .sst
             .meta
@@ -220,9 +238,17 @@ impl HummockIterator for BackwardSstableIterator {
         let block_idx = block_idx as isize;
 
         self.seek_idx(block_idx, Some(key)).await?;
-        if !self.is_valid() {
+        if !self.block_iter_is_valid() {
             // Seek to prev block
             self.seek_idx(block_idx - 1, None).await?;
+        }
+
+        if self.block_iter_is_valid()
+            && !right.is_empty()
+            && self.key_range.right_exclusive
+            && self.key() == FullKey::decode(&right)
+        {
+            self.next().await?;
         }
 
         Ok(())

--- a/src/storage/src/hummock/sstable/forward_sstable_iterator.rs
+++ b/src/storage/src/hummock/sstable/forward_sstable_iterator.rs
@@ -17,6 +17,7 @@ use std::sync::Arc;
 
 use await_tree::{InstrumentAwait, SpanExt};
 use risingwave_hummock_sdk::key::FullKey;
+use risingwave_hummock_sdk::key_range::KeyRange;
 use risingwave_hummock_sdk::sstable_info::SstableInfo;
 use sync_point::sync_point;
 use thiserror_ext::AsReport;
@@ -60,6 +61,7 @@ pub struct SstableIterator {
     // precisely inside the boundary block.
     block_start_idx_inclusive: usize,
     block_end_idx_exclusive: usize,
+    key_range: KeyRange,
 }
 
 impl SstableIterator {
@@ -172,7 +174,12 @@ impl SstableIterator {
             preload_retry_times: 0,
             block_start_idx_inclusive,
             block_end_idx_exclusive,
+            key_range: sstable_info_ref.key_range.clone(),
         }
+    }
+
+    fn block_iter_is_valid(&self) -> bool {
+        self.block_iter.as_ref().is_some_and(|iter| iter.is_valid())
     }
 
     fn init_block_prefetch_range(&mut self, start_idx: usize) {
@@ -358,7 +365,7 @@ impl HummockIterator for SstableIterator {
     }
 
     fn is_valid(&self) -> bool {
-        self.block_iter.as_ref().is_some_and(|i| i.is_valid())
+        self.block_iter_is_valid() && super::full_key_in_range(&self.key_range, self.key())
     }
 
     async fn rewind(&mut self) -> HummockResult<()> {
@@ -366,10 +373,14 @@ impl HummockIterator for SstableIterator {
             self.block_iter = None;
             return Ok(());
         }
-        self.init_block_prefetch_range(self.block_start_idx_inclusive);
-        // seek_idx will update the current block iter state
-        self.seek_idx(self.block_start_idx_inclusive, None).await?;
-        Ok(())
+        if self.key_range.left.is_empty() {
+            self.init_block_prefetch_range(self.block_start_idx_inclusive);
+            // seek_idx will update the current block iter state
+            self.seek_idx(self.block_start_idx_inclusive, None).await
+        } else {
+            let left = self.key_range.left.clone();
+            self.seek(FullKey::decode(&left)).await
+        }
     }
 
     async fn seek<'a>(&'a mut self, key: FullKey<&'a [u8]>) -> HummockResult<()> {
@@ -377,11 +388,17 @@ impl HummockIterator for SstableIterator {
             self.block_iter = None;
             return Ok(());
         }
+        let left = self.key_range.left.clone();
+        let key = if !left.is_empty() && FullKey::decode(&left).gt(&key) {
+            FullKey::decode(&left)
+        } else {
+            key
+        };
         let block_idx = self.calculate_block_idx_by_key(key);
         self.init_block_prefetch_range(block_idx);
 
         self.seek_idx(block_idx, Some(key)).await?;
-        if !self.is_valid() {
+        if !self.block_iter_is_valid() {
             // seek to next block
             sync_point!("SSTABLE_ITERATOR::SEEK::BEFORE_NEXT_BLOCK");
             self.seek_idx(block_idx + 1, None).await?;

--- a/src/storage/src/hummock/sstable/mod.rs
+++ b/src/storage/src/hummock/sstable/mod.rs
@@ -43,6 +43,7 @@ use tracing::warn;
 mod backward_sstable_iterator;
 pub use backward_sstable_iterator::*;
 use risingwave_hummock_sdk::key::{FullKey, KeyPayloadType, UserKey, UserKeyRangeRef};
+use risingwave_hummock_sdk::key_range::KeyRange;
 use risingwave_hummock_sdk::{HummockEpoch, HummockSstableObjectId};
 
 mod filter;
@@ -63,6 +64,17 @@ use crate::store::ReadOptions;
 const MAGIC: u32 = 0x5785ab73;
 const OLD_VERSION: u32 = 1;
 const VERSION: u32 = 2;
+
+fn full_key_in_range(key_range: &KeyRange, key: FullKey<&[u8]>) -> bool {
+    let after_left = key_range.left.is_empty() || FullKey::decode(&key_range.left).le(&key);
+    let before_right = key_range.right.is_empty()
+        || if key_range.right_exclusive {
+            key.lt(&FullKey::decode(&key_range.right))
+        } else {
+            key.le(&FullKey::decode(&key_range.right))
+        };
+    after_left && before_right
+}
 
 /// Assume that watermark1 is 5, watermark2 is 7, watermark3 is 11, delete ranges
 /// `{ [0, wmk1) in epoch1, [wmk1, wmk2) in epoch2, [wmk2, wmk3) in epoch3 }`


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

This is stack 3/3 and depends on #26994, which in turn depends on #26993. Until the parent PRs are merged, GitHub shows their commits in this PR's `main`-based diff.

- Enable the new strategy only for a compaction group containing exactly one table with `split_weight_by_vnode > 1` and a known table vnode count.
- Rebuild a transient fixed-partition L0 view from the current version and pending-file state for every selection. Sparse or unwritten vnode ranges remain stable empty partitions.
- Score runnable pressure as partition-local non-overlapping L0 depth divided by `level0_sub_level_compact_level_count`.
- Try ToBase for eligible partitions in descending local pressure order. Only after all eligible ToBase candidates are blocked does selection fall back to partition-local Intra compaction.
- Remove the write-amplification validator and small-file trivial-move minimum from the new single-table path. Candidate admission is controlled by the depth threshold; the picker retains a defensive minimum-level check.
- Fall back to the existing global selector when an old or unaligned SST cannot be represented by the fixed vnode layout. Non-single-table compaction groups continue to use the existing picker path.

This makes the single-table policy deterministic: reaching the partition depth threshold admits the partition, ToBase gets the first opportunity, and Intra is a fallback rather than an independently gated competing path.

## Checklist

- [x] I have written necessary rustdoc comments.
- [x] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [x] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/dev/src/ci.md#ci-labels-guide -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

Not applicable. This draft tracks an internal Hummock compaction-policy experiment.

</details>
